### PR TITLE
Iron stage 2: proof export CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,43 @@ jobs:
           name: bench-results
           path: bench-results.ndjson
           retention-days: 30
+
+  proof:
+    # Iron — C4: proof-export CI gate. `tests/proof_spec.rs` already
+    # carries 7 Lake-build smoke tests that emit Lean from real Aver
+    # examples and run `lake build` on the output. Locally they skip
+    # cleanly when `lake` isn't on PATH; on CI we install Lean (via
+    # elan, the Lean toolchain manager) so the tests exercise the
+    # real proof build pipeline and a regression in proof codegen
+    # surfaces as a red CI gate instead of silent green.
+    name: Proof Export
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Lean (via elan)
+        # `--default-toolchain none` skips the auto-install of a
+        # Lean release; each Aver-emitted proof project carries its
+        # own `lean-toolchain` file, so elan fetches the matching
+        # version the first time `lake build` runs in a project dir.
+        # Quieter + faster than pre-installing a fixed Lean version
+        # that may drift from what the emitted lean-toolchain pins.
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Verify `lake` reachable
+        run: lake --version
+
+      - name: Run proof-export smoke tests
+        # Restricting to the proof_spec target keeps this job short
+        # (no overlap with the lib / wasm / bench jobs). The tests
+        # invoke `aver proof <example> --target lean`, then `lake
+        # build` against the emitted directory; a Lean-side compile
+        # error in any of the 7 fixtures fails the job.
+        run: cargo test -p aver-lang --test proof_spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,15 +118,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install Lean (via elan)
-        # `--default-toolchain none` skips the auto-install of a
-        # Lean release; each Aver-emitted proof project carries its
-        # own `lean-toolchain` file, so elan fetches the matching
-        # version the first time `lake build` runs in a project dir.
-        # Quieter + faster than pre-installing a fixed Lean version
-        # that may drift from what the emitted lean-toolchain pins.
+        # Elan with a real default toolchain — `--default-toolchain none`
+        # leaves `lake` as a wrapper that errors on every call because
+        # it has no toolchain to delegate to (works for a project dir
+        # with its own `lean-toolchain` file, broken for the upfront
+        # `lake --version` sanity check). Pinning `stable` makes the
+        # bare-PATH lake binary executable; emitted proof projects with
+        # a different `lean-toolchain` still trigger elan to fetch the
+        # matching version on first `lake build`.
         run: |
           curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --default-toolchain none
+            | sh -s -- -y --default-toolchain stable
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Verify `lake` reachable

--- a/docs/iron-plan.md
+++ b/docs/iron-plan.md
@@ -33,7 +33,7 @@ Tagline draft: *Iron in the frame — the type checker stops lying to itself abo
 | C1  | Parser + lexer crash-resistance via `proptest` (bytes-in)  | todo   | ~80 LOC   | low      | —   |
 | C2  | `proptest` matcher invariants + Type AST generators        | done   | ~150 LOC  | low      | #28 |
 | C3  | Cross-backend differential property tests                  | todo   | ~200 LOC  | medium   | —   |
-| C4  | Proof export CI gate (`lake build`, `dafny verify`)        | todo   | CI yaml   | low      | —   |
+| C4  | Proof export CI gate (`lake build` via elan)               | done   | CI yaml   | low      | stage 2 |
 
 Note: `cargo-fuzz` revisited and rejected for now. The crate requires nightly Rust (libfuzzer-sys uses `-Z` flags); Aver's CI is stable-Rust throughout (`dtolnay/rust-toolchain@stable`). Adding a nightly toolchain to CI just for fuzz targets is a real cost. `proptest` covers the same surface for structured inputs (matcher invariants, cross-backend differential) and reaches into crash-resistance via `prop::collection::vec(any::<u8>(), 0..N)` strategies — bytes-in, lexer/parser must not panic. If we later need true coverage-guided fuzzing (corpus evolution, mutation-based), the right path is a separate fuzz workflow on a dedicated nightly job, not pulling nightly into the main CI gate.
 


### PR DESCRIPTION
Second Iron stage. Single small win for this slice — bigger items (A1 unary minus, A3 Type::Named canonical) staged separately so each PR stays scoped and the patch-vs-minor decision can wait until cumulative Iron surface is visible.

(Branch name carries a stale \"-neg\" suffix from when stage 2 was planned around unary minus; refocused after A1 was assessed as too cross-cutting for autonomous overnight work.)

## What's in this stage

- **C4 — proof export CI gate.** New \`Proof Export\` job in \`.github/workflows/ci.yml\` installs Lean (via elan, the Lean toolchain manager) and runs the existing \`tests/proof_spec.rs\` smoke suite. The suite has 7 fixtures that emit Lean from real Aver examples (\`law_auto\`, \`fibonacci\`, \`rle\`, \`quicksort\`, \`json\`, \`grok_s_language\`, \`pure_question_bang\`) and run \`lake build\` against the emitted project. Pre-Iron those tests skipped cleanly when \`lake\` was missing from PATH; on CI they now exercise the real proof build and a regression in proof codegen surfaces as red CI instead of silent green.

  elan installed with \`--default-toolchain none\` — each emitted proof project carries its own \`lean-toolchain\` file, so elan fetches the right Lean version the first time \`lake build\` runs in that project dir.

  Dafny verification gate not in this PR. Dafny install is more involved (.NET dep); lake covers the more commonly-used Lean half. Adding a Dafny step later is mechanical — the \`dafny verify\` smoke tests in \`proof_spec.rs\` already have the same skip-when-missing shape.

## What's NOT in this stage

Carried forward to subsequent Iron stages (see \`docs/iron-plan.md\`):

- A1 — unary minus → \`Expr::Neg\` (the big cross-backend refactor; needs its own dedicated session with self-host parity in the same PR)
- A3 — \`Type::Named\` canonical matching via SymbolRegistry
- A4 — \`Type::Invalid\` cascade audit
- A5 — \`record_field_types\` string keys → struct
- B1, B2, B3 — VM perf + symbol Result + replay determinism property tests
- C3 — cross-backend differential proptest

## Test plan

- [x] \`cargo test -p aver-lang --test proof_spec\` — 35 passed locally (lake installed)
- [ ] CI: Proof Export job installs elan, runs the same 35 tests with lake actually exercising them