### PR TITLE
Iron stage 3: replay codec property tests + two found-and-fixed bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 - **Duplicate function name is now a type error.** Defining the same `fn` name twice in a module surfaces "Function 'X' is already defined in this module" at the duplicate's source line. Pre-Iron, the second definition silently dropped the first — a typo could swap your function's body without any signal.
 - **Polymorphic recursion that would need `T := F<...T...>` is rejected.** Shapes like `fn nest(v: A) -> Unit; nest([v])` (where the recursive call would need `A` to equal `List<A>`) now surface as a normal type-incompatibility error instead of silently typechecking with a circular binding.
 
+### Fixed
+- **Replay can load `Vector` values.** `aver run --record` emitted a `$vector` marker for `Value::Vector`, but `aver replay` had no matching decode arm — any recording with a Vector value failed to load with `unknown replay marker '$vector'`.
+- **Replay can load `Map`s with a single string key.** A 1-entry string-keyed `Map` encoded as `{"key": value}` collided with the marker-wrap shape; replay tried to interpret `key` as an unknown marker. The decoder now only treats `$`-prefixed keys as markers, so plain string keys flow through as map entries.
+
 ## 0.20.0 "Pulse" — 2026-05-18
 
 > _The same Aver source that opened HTTP both ways in 0.19 now opens raw TCP — connect, send, receive, ping. One pool, one handle shape, every backend the same._

--- a/src/replay/json.rs
+++ b/src/replay/json.rs
@@ -218,7 +218,22 @@ fn marker_single_key(obj: &BTreeMap<String, JsonValue>) -> Option<(&str, &JsonVa
     if obj.len() != 1 {
         return None;
     }
-    obj.iter().next().map(|(k, v)| (k.as_str(), v))
+    // Iron — B3: only treat a single-key object as a marker wrap when
+    // the key starts with `$`. All real markers (`$ok`, `$err`,
+    // `$some`, `$none`, `$tuple`, `$map`, `$record`, `$variant`,
+    // `$vector`) use that sigil. A user-level `Map` with a single
+    // string key (e.g. `{"a" → 0}`) also encodes as a single-key
+    // JSON object — without the `$`-gate, the decoder was treating
+    // every 1-entry string-keyed map as an attempted-but-unknown
+    // marker wrap and erroring `unknown replay marker 'a'`. Found
+    // by `tests/replay_proptest.rs`.
+    obj.iter().next().and_then(|(k, v)| {
+        if k.starts_with('$') {
+            Some((k.as_str(), v))
+        } else {
+            None
+        }
+    })
 }
 
 fn decode_marker(marker: &str, payload: &JsonValue) -> Result<Value, String> {
@@ -231,8 +246,24 @@ fn decode_marker(marker: &str, payload: &JsonValue) -> Result<Value, String> {
         "$map" => decode_map(payload),
         "$record" => decode_record(payload),
         "$variant" => decode_variant(payload),
+        "$vector" => decode_vector(payload),
         _ => Err(format!("unknown replay marker '{}'", marker)),
     }
+}
+
+/// Iron — B3: `value_to_json` emits `wrap_marker("$vector", JsonValue::Array(...))`
+/// for `Value::Vector`, but pre-Iron `decode_marker` had no
+/// matching arm — encoding produced JSON the decoder rejected
+/// with "unknown replay marker '$vector'". Any replay recording
+/// that captured a Vector value failed to load back. Found by
+/// the replay-codec roundtrip property test (`tests/replay_proptest.rs`).
+fn decode_vector(payload: &JsonValue) -> Result<Value, String> {
+    let items = parse_array(payload, "$vector")?;
+    let mut out = Vec::with_capacity(items.len());
+    for item in items {
+        out.push(json_to_value(item)?);
+    }
+    Ok(Value::Vector(aver_rt::AverVector::from_vec(out)))
 }
 
 fn decode_tuple(payload: &JsonValue) -> Result<Value, String> {

--- a/tests/replay_proptest.rs
+++ b/tests/replay_proptest.rs
@@ -1,0 +1,242 @@
+//! Property tests for the replay JSON codec (Iron — B3).
+//!
+//! Every replay-safe `Value` must round-trip through the replay JSON
+//! encoder + decoder without information loss. The codec is the
+//! contract between `aver run --record` (writes JSON, emits trace) and
+//! `aver replay --check` (reads JSON, fakes effects, asserts results
+//! match) — if encode→decode loses a bit, replay determinism is no
+//! longer the invariant the system advertises.
+//!
+//! The hand-picked tests in `tests/wasm_gc_record_replay_spec.rs` cover
+//! the end-to-end pipeline (compile → run → record → replay) on a
+//! fixed set of programs; these property tests probe the codec itself
+//! across the full set of replay-safe `Value` shapes the generator
+//! produces. The two layers are complementary — end-to-end finds bugs
+//! in the recording state machine + host shim, the property tests
+//! find bugs in the JSON serialisation primitives that the rest sits
+//! on.
+//!
+//! Out of scope by design:
+//!   - `Value::Fn` / `Value::Builtin` / `Value::Namespace` — these
+//!     return `Err` from `value_to_json` and the generator skips
+//!     them. Per-fn closures aren't replayable across runs anyway
+//!     (they reference compiled bytecode positions).
+//!   - Non-finite floats (NaN / ±inf) — `value_to_json` rejects them
+//!     explicitly; the generator stays in the finite range.
+
+use aver::replay::json::{json_to_value, value_to_json};
+use aver::value::{Value, list_from_vec, list_to_vec};
+use proptest::prelude::*;
+use std::collections::HashMap;
+use std::sync::Arc as Rc;
+
+/// Normalise `Value::Record` field order alphabetically by name —
+/// recursively, so nested records inside lists / tuples / maps /
+/// other records also get normalised. The codec round-trip
+/// produces alphabetically-sorted record fields (canonical-JSON
+/// design choice) but the source can be in any order; this helper
+/// lets the property test compare both sides on the same footing
+/// without changing `Value::PartialEq`'s semantics (positional
+/// slice equality, which other call sites depend on).
+fn normalize_record_field_order(value: Value) -> Value {
+    match value {
+        Value::Record { type_name, fields } => {
+            let mut owned: Vec<(String, Value)> = fields
+                .iter()
+                .map(|(n, v)| (n.clone(), normalize_record_field_order(v.clone())))
+                .collect();
+            owned.sort_by(|a, b| a.0.cmp(&b.0));
+            Value::Record {
+                type_name,
+                fields: Rc::from(owned),
+            }
+        }
+        Value::Ok(inner) => Value::Ok(Box::new(normalize_record_field_order(*inner))),
+        Value::Err(inner) => Value::Err(Box::new(normalize_record_field_order(*inner))),
+        Value::Some(inner) => Value::Some(Box::new(normalize_record_field_order(*inner))),
+        Value::Tuple(items) => Value::Tuple(
+            items
+                .into_iter()
+                .map(normalize_record_field_order)
+                .collect(),
+        ),
+        Value::List(_) => {
+            // `list_to_vec` walks the cons cells; normalise each
+            // element then rebuild via `list_from_vec`.
+            let items = list_to_vec(&value).expect("list_to_vec on Value::List always succeeds");
+            list_from_vec(
+                items
+                    .into_iter()
+                    .map(normalize_record_field_order)
+                    .collect(),
+            )
+        }
+        Value::Vector(vec) => Value::Vector(aver_rt::AverVector::from_vec(
+            vec.iter()
+                .cloned()
+                .map(normalize_record_field_order)
+                .collect(),
+        )),
+        Value::Map(m) => {
+            let mut out = HashMap::with_capacity(m.len());
+            for (k, v) in m {
+                out.insert(
+                    normalize_record_field_order(k),
+                    normalize_record_field_order(v),
+                );
+            }
+            Value::Map(out)
+        }
+        Value::Variant {
+            type_name,
+            variant,
+            fields,
+        } => Value::Variant {
+            type_name,
+            variant,
+            fields: Rc::from(
+                fields
+                    .iter()
+                    .cloned()
+                    .map(normalize_record_field_order)
+                    .collect::<Vec<_>>(),
+            ),
+        },
+        other => other,
+    }
+}
+
+/// Generator for `Value`s that the replay codec advertises as
+/// round-trippable. Recursive, depth- and breadth-capped so a single
+/// property case stays bounded.
+fn arb_replay_safe_value() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        any::<i64>().prop_map(Value::Int),
+        // Stay in the finite range — `value_to_json` rejects NaN/inf.
+        prop::num::f64::POSITIVE
+            .prop_filter("finite only", |f| f.is_finite())
+            .prop_map(Value::Float),
+        prop::num::f64::NEGATIVE
+            .prop_filter("finite only", |f| f.is_finite())
+            .prop_map(Value::Float),
+        Just(Value::Float(0.0)),
+        ".{0,20}".prop_map(Value::Str),
+        any::<bool>().prop_map(Value::Bool),
+        Just(Value::Unit),
+        Just(Value::None),
+    ];
+
+    leaf.prop_recursive(4, 32, 4, |inner| {
+        // Each branch is `.boxed()` to a common `BoxedStrategy<Value>`
+        // so `prop_oneof!` has a single concrete type to dispatch on.
+        // Without the box, each branch's inferred Strategy type leaks
+        // a different closure generic, blocking the dispatch.
+        prop_oneof![
+            inner.clone().prop_map(|v| Value::Ok(Box::new(v))).boxed(),
+            inner.clone().prop_map(|v| Value::Err(Box::new(v))).boxed(),
+            inner.clone().prop_map(|v| Value::Some(Box::new(v))).boxed(),
+            prop::collection::vec(inner.clone(), 0..4)
+                .prop_map(list_from_vec)
+                .boxed(),
+            prop::collection::vec(inner.clone(), 0..4)
+                .prop_map(Value::Tuple)
+                .boxed(),
+            prop::collection::vec(inner.clone(), 0..4)
+                .prop_map(|v| Value::Vector(aver_rt::AverVector::from_vec(v)))
+                .boxed(),
+            // Maps with String keys only — the codec routes
+            // string-keyed maps to a JSON Object and other shapes to
+            // a `$map` array of pairs. Both paths should round-trip,
+            // but the string-key shape is the common case in user
+            // code so the generator prioritises it.
+            prop::collection::vec(("[a-z]{1,6}".prop_map(Value::Str), inner.clone()), 0..4,)
+                .prop_map(|pairs| {
+                    let mut m = HashMap::new();
+                    for (k, v) in pairs {
+                        m.insert(k, v);
+                    }
+                    Value::Map(m)
+                })
+                .boxed(),
+            // Record — type_name + field list. Field names are
+            // identifier-shaped, field values recurse.
+            (
+                "[A-Z][a-z]{0,4}",
+                prop::collection::vec(("[a-z]{1,4}", inner.clone()), 1..3),
+            )
+                .prop_map(|(type_name, fields)| Value::Record {
+                    type_name: type_name.to_string(),
+                    fields: Rc::from(
+                        fields
+                            .into_iter()
+                            .map(|(n, v)| (n.to_string(), v))
+                            .collect::<Vec<_>>(),
+                    ),
+                })
+                .boxed(),
+            // Variant — fully-qualified constructor + positional
+            // fields.
+            (
+                "[A-Z][a-z]{0,4}",
+                "[A-Z][a-z]{0,4}",
+                prop::collection::vec(inner.clone(), 0..3),
+            )
+                .prop_map(|(type_name, variant, fields)| Value::Variant {
+                    type_name: type_name.to_string(),
+                    variant: variant.to_string(),
+                    fields: Rc::from(fields),
+                })
+                .boxed(),
+        ]
+    })
+}
+
+proptest! {
+    /// Replay codec round-trip — for every replay-safe `Value`, the
+    /// sequence `value_to_json(v).and_then(json_to_value)` must
+    /// return a value that compares equal to the original up to
+    /// `Record`-field reordering. The codec uses BTreeMap when
+    /// emitting record/map JSON so the wire form is canonical
+    /// (same record → same bytes regardless of source field order),
+    /// which means the decoded `Value::Record` ends up with fields
+    /// in alphabetical order even if the input had them in source
+    /// order. We accept that — canonical JSON is a deliberate
+    /// design choice the recording/replay diff workflow depends
+    /// on — and compare after normalising both sides.
+    ///
+    /// What this property still catches strictly: any *value-level*
+    /// loss in the codec. Integers, floats (bit-equal via
+    /// `to_bits` in `PartialEq`), strings, list/tuple/vector
+    /// contents, variant constructor + field positions, Map
+    /// contents, etc. all must round-trip exactly.
+    ///
+    /// Iron — B3 found-and-fixed:
+    ///   - `Value::Vector` encoded with marker `$vector` but the
+    ///     decoder had no matching arm; any replay JSON containing
+    ///     a Vector failed to load. Fixed in `decode_marker`.
+    #[test]
+    fn replay_codec_round_trips_every_safe_value(value in arb_replay_safe_value()) {
+        let json = value_to_json(&value).map_err(|e| TestCaseError::fail(format!(
+            "value_to_json failed on replay-safe value: {e}"
+        )))?;
+        let decoded = json_to_value(&json).map_err(|e| TestCaseError::fail(format!(
+            "json_to_value failed on encoded JSON: {e}"
+        )))?;
+        let lhs = normalize_record_field_order(decoded);
+        let rhs = normalize_record_field_order(value);
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Encoding determinism — encoding the same value twice produces
+    /// the same JSON. Catches any implicit dependency on RNG, hash
+    /// iteration order, or mutable internal state in the codec.
+    /// This is the property that lets a recorded JSON file be a
+    /// deterministic fingerprint of the value, regardless of which
+    /// run produced it.
+    #[test]
+    fn replay_encoding_is_deterministic(value in arb_replay_safe_value()) {
+        let j1 = value_to_json(&value);
+        let j2 = value_to_json(&value);
+        prop_assert_eq!(j1, j2);
+    }
+}


### PR DESCRIPTION
Third Iron stage. Builds on stage 2 (PR #29 — proof export CI gate) and stage 1 (PR #28 — type checker invariants). \`docs/iron-plan.md\` tracks the full track.

## What's in this stage

- **B3 — replay codec property tests** (\`tests/replay_proptest.rs\`). Two property tests sweep every replay-safe \`Value\` shape through \`value_to_json → json_to_value\` and assert round-trip identity (up to canonical Record field reordering — the codec normalises to alphabetical order for stable wire output, the test mirrors that normalisation before comparing). Second property asserts encoding determinism: same value → same JSON across runs.

  Generator (\`arb_replay_safe_value\`) covers every variant the codec advertises as round-trippable: Int / Float (finite only — codec rejects NaN/inf) / Str / Bool / Unit / Ok / Err / Some / None / List / Tuple / Vector / Map (string-keyed shape) / Record / Variant. Fn / Builtin / Namespace are out of scope by the codec's own contract.

- **Two found-and-fixed codec bugs** surfaced by the first proptest sweep:

  1. **\`$vector\` marker encoded but never decoded** (\`src/replay/json.rs\`). \`value_to_json\` emitted \`wrap_marker(\"$vector\", JsonValue::Array(...))\` for \`Value::Vector\`; \`decode_marker\` had no matching arm. Any replay JSON carrying a Vector failed with \`unknown replay marker '$vector'\`. Added \`decode_vector\`. **Pre-Iron impact:** any program recording a Vector value could not be replayed at all.

  2. **Single-key string-keyed \`Map\` ambiguous with marker wrap** (\`src/replay/json.rs\`). \`Map<String, V>\` encodes directly as a JSON Object (no marker), so \`{\"a\": 0}\` produced JSON identical in shape to a marker-wrapped value. The decoder's \`marker_single_key\` interpreted every 1-key Object as a marker candidate; \`{\"a\": 0}\` came out as \`unknown replay marker 'a'\`. Fixed by gating the marker check on \`key.starts_with('$')\`. **Pre-Iron impact:** any recording with a 1-entry string-keyed map (commonest map shape in real programs) failed to replay.

  Both fixes are covered by the property test going forward — the bug shapes can't regress without a fresh proptest counter-example.

- **CHANGELOG entries** for the two user-facing fixes (under \`## 0.21.0 \"Iron\" (unreleased)\` § Fixed).

## What's NOT in this stage

Tracked in \`docs/iron-plan.md\`:

- A1 — unary minus → \`Expr::Neg\` (still pending; cross-backend refactor + self-host parity; needs dedicated session)
- A3 — \`Type::Named\` canonical matching via SymbolRegistry
- A4 — \`Type::Invalid\` cascade audit
- A5 — \`record_field_types\` string keys → struct
- B1 — VM typed opcodes (perf track)
- B2 — VM symbol panics → \`Result\` (38 caller sites, large)
- C3 — cross-backend differential proptest

## Test plan

- [x] \`cargo test -p aver-lang --test replay_proptest\` — 2 properties × 256 cases each
- [x] \`cargo test -p aver-lang --lib\` — 606 passed
- [x] \`cargo test -p aver-lang --features wasm,wasip2 --tests\` — 25/25 suites green (incl. new replay_proptest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)