### PR TITLE
Iron — A5: typed key for record_field_types

### DIFF
--- a/src/types/checker/builtins.rs
+++ b/src/types/checker/builtins.rs
@@ -23,10 +23,8 @@ impl TypeChecker {
             ("headers", header_map()),
         ];
         for (field, ty) in net_resp_fields {
-            self.record_field_types.insert(
-                crate::visibility::member_key("HttpResponse", field),
-                ty.clone(),
-            );
+            self.record_field_types
+                .insert(RecordFieldKey::new("HttpResponse", *field), ty.clone());
         }
         let net_req_fields: &[(&str, Type)] = &[
             ("method", Type::Str),
@@ -36,10 +34,8 @@ impl TypeChecker {
             ("headers", header_map()),
         ];
         for (field, ty) in net_req_fields {
-            self.record_field_types.insert(
-                crate::visibility::member_key("HttpRequest", field),
-                ty.clone(),
-            );
+            self.record_field_types
+                .insert(RecordFieldKey::new("HttpRequest", *field), ty.clone());
         }
         let effect_arg_var = || Type::Var("EffectArg".to_string());
         // `printable_var` retired in 0.16: Console.print/error/warn now
@@ -63,7 +59,7 @@ impl TypeChecker {
         ];
         for (field, ty) in effect_event_fields {
             self.record_field_types.insert(
-                crate::visibility::member_key(crate::types::effect_event::TYPE_NAME, field),
+                RecordFieldKey::new(crate::types::effect_event::TYPE_NAME, *field),
                 ty.clone(),
             );
         }
@@ -77,17 +73,15 @@ impl TypeChecker {
         )];
         for (field, ty) in trace_fields {
             self.record_field_types.insert(
-                crate::visibility::member_key(crate::types::trace::TYPE_NAME, field),
+                RecordFieldKey::new(crate::types::trace::TYPE_NAME, *field),
                 ty.clone(),
             );
         }
         let tcp_conn_fields: &[(&str, Type)] =
             &[("id", Type::Str), ("host", Type::Str), ("port", Type::Int)];
         for (field, ty) in tcp_conn_fields {
-            self.record_field_types.insert(
-                crate::visibility::member_key("Tcp.Connection", field),
-                ty.clone(),
-            );
+            self.record_field_types
+                .insert(RecordFieldKey::new("Tcp.Connection", *field), ty.clone());
         }
         // Phase 4.7+ fix #11 — `Tcp.Connection` is opaque. It's a
         // stateful handle to a pool slot: `id` is internal, `host`
@@ -426,10 +420,8 @@ impl TypeChecker {
             let terminal_size_fields: &[(&str, Type)] =
                 &[("width", Type::Int), ("height", Type::Int)];
             for (field, ty) in terminal_size_fields {
-                self.record_field_types.insert(
-                    crate::visibility::member_key("Terminal.Size", field),
-                    ty.clone(),
-                );
+                self.record_field_types
+                    .insert(RecordFieldKey::new("Terminal.Size", *field), ty.clone());
             }
         }
 

--- a/src/types/checker/infer/expr.rs
+++ b/src/types/checker/infer/expr.rs
@@ -1105,21 +1105,12 @@ impl TypeChecker {
                             ));
                             return Type::Invalid;
                         }
-                        let key = crate::visibility::member_key(type_name, field);
-                        if let Some(field_ty) = self.find_record_field_type(&key) {
+                        if let Some(field_ty) = self.find_record_field_type(type_name, field) {
                             field_ty.clone()
+                        } else if self.has_record_schema(type_name) {
+                            self.error(format!("Record '{}' has no field '{}'", type_name, field));
+                            Type::Invalid
                         } else {
-                            let schema_prefix = format!("{}.", type_name);
-                            let has_known_schema = self
-                                .record_field_types
-                                .keys()
-                                .any(|k| k.starts_with(&schema_prefix));
-                            if has_known_schema {
-                                self.error(format!(
-                                    "Record '{}' has no field '{}'",
-                                    type_name, field
-                                ));
-                            }
                             Type::Invalid
                         }
                     }

--- a/src/types/checker/infer/records.rs
+++ b/src/types/checker/infer/records.rs
@@ -25,22 +25,10 @@ impl TypeChecker {
             return Type::Named(canonical_type);
         }
 
-        // Iron — A3: `record_field_types` is dual-keyed under both the
-        // canonical "Module.Type.field" and the bare alias
-        // "Type.field". Strip the prefix and accept only keys that
-        // produce a single-segment field name; otherwise the
-        // canonical entry "Module.Type.field" matches the bare
-        // prefix "Type." and the leftover "Module.field"-shaped
-        // remainder leaks in as a phantom required field.
-        let schema_prefix = format!("{}.", type_name);
-        let mut expected = HashMap::new();
-        for (key, ty) in &self.record_field_types {
-            if let Some(field_name) = key.strip_prefix(&schema_prefix)
-                && !field_name.contains('.')
-            {
-                expected.insert(field_name.to_string(), ty.clone());
-            }
-        }
+        // Iron — A5: `fields_for_type` canonicalises `type_name`
+        // through `sig_aliases` so an unqualified reference picks
+        // up the canonical `"Module.Type"` entries and back.
+        let expected: HashMap<String, Type> = self.fields_for_type(type_name).into_iter().collect();
 
         let mut seen = HashSet::new();
         for (field_name, expr) in fields {
@@ -131,19 +119,9 @@ impl TypeChecker {
             ));
         }
 
-        // Same dual-key filter as `infer_record_create_expr`: keep
-        // only entries whose prefix-strip leaves a single segment so
-        // the canonical "Module.Type.field" entry doesn't pollute the
-        // map when `type_name` matches the module name.
-        let schema_prefix = format!("{}.", type_name);
-        let mut expected_fields = HashMap::new();
-        for (key, ty) in &self.record_field_types {
-            if let Some(field_name) = key.strip_prefix(&schema_prefix)
-                && !field_name.contains('.')
-            {
-                expected_fields.insert(field_name.to_string(), ty.clone());
-            }
-        }
+        // Iron — A5: same canonicalised lookup as construction.
+        let expected_fields: HashMap<String, Type> =
+            self.fields_for_type(type_name).into_iter().collect();
 
         for (field_name, expr) in updates {
             // Bidirectional: same propagation as RecordCreate so generic

--- a/src/types/checker/memo.rs
+++ b/src/types/checker/memo.rs
@@ -155,29 +155,23 @@ impl TypeChecker {
 
     /// Check whether a named user-defined type has only memo-safe fields.
     pub(super) fn named_type_memo_safe(&self, name: &str, visiting: &mut HashSet<String>) -> bool {
-        // Check record fields: keys are "TypeName.fieldName". Filter
-        // for single-segment remainders so the dual-keyed
-        // "Module.Type.field" canonical entries don't double-count
-        // (Iron — A3).
-        let prefix = format!("{}.", name);
-        let mut found_fields = false;
-        for (key, field_ty) in &self.record_field_types {
-            if let Some(rest) = key.strip_prefix(&prefix)
-                && !rest.contains('.')
-            {
-                found_fields = true;
-                if !self.is_memo_safe(field_ty, visiting) {
+        // Iron — A5: `fields_for_type` resolves `name` through
+        // `sig_aliases` and returns one `(field_name, field_type)`
+        // per declared field; no dual-key arithmetic.
+        let fields = self.fields_for_type(name);
+        if !fields.is_empty() {
+            for (_, field_ty) in fields {
+                if !self.is_memo_safe(&field_ty, visiting) {
                     return false;
                 }
             }
-        }
-        if found_fields {
             return true;
         }
 
         // Check sum type variants: constructors are registered in fn_sigs
         // as "TypeName.VariantName" with param types, or in value_members
         // for zero-arg constructors.
+        let prefix = format!("{}.", name);
         let mut found_variants = false;
         for (key, sig) in &self.fn_sigs {
             if key.starts_with(&prefix) && key.len() > prefix.len() {

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -225,13 +225,42 @@ struct FnSig {
     effects: Vec<String>,
 }
 
+/// Iron — A5: typed key for `record_field_types`. Pre-A5 the map
+/// was keyed by `"TypeName.fieldName"` stringifications, which
+/// forced every reader to `strip_prefix(format!("{type}."))` and
+/// then re-check that the remainder didn't itself contain a dot
+/// (because the post-A3 dual-keying mirrored each entry under both
+/// the canonical `"Module.Type.field"` form and the bare alias
+/// `"Type.field"` — and the canonical form spuriously matched the
+/// `"Module."` prefix-strip when the read came from a module
+/// looking up its own fields). The struct key separates the two
+/// dimensions, so the canonical resolution happens once at
+/// insert/lookup (via `sig_aliases`) and iteration filters on
+/// `key.type_name == canonical` with no string-shape gymnastics.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RecordFieldKey {
+    pub(crate) type_name: String,
+    pub(crate) field_name: String,
+}
+
+impl RecordFieldKey {
+    pub(crate) fn new(type_name: impl Into<String>, field_name: impl Into<String>) -> Self {
+        Self {
+            type_name: type_name.into(),
+            field_name: field_name.into(),
+        }
+    }
+}
+
 struct TypeChecker {
     fn_sigs: HashMap<String, FnSig>,
     value_members: HashMap<String, Type>,
-    /// Field types for record types: "TypeName.fieldName" → Type.
+    /// Field types for record types, keyed by `(type_name, field_name)`.
     /// Populated for both user-defined `record` types and built-in records
-    /// (HttpResponse, Header). Enables checked dot-access on Named types.
-    record_field_types: HashMap<String, Type>,
+    /// (HttpResponse, Header). Single entry per (canonical type name, field);
+    /// lookup canonicalises `type_name` through `sig_aliases` at read time.
+    /// Enables checked dot-access on Named types.
+    record_field_types: HashMap<RecordFieldKey, Type>,
     /// Unqualified → qualified aliases for cross-module lookups.
     /// E.g. "Shape.Circle" → "Data.Shape.Circle".
     sig_aliases: HashMap<String, String>,
@@ -328,12 +357,53 @@ impl TypeChecker {
         })
     }
 
-    fn find_record_field_type(&self, key: &str) -> Option<&Type> {
-        self.record_field_types.get(key).or_else(|| {
-            self.sig_aliases
-                .get(key)
-                .and_then(|c| self.record_field_types.get(c))
-        })
+    fn find_record_field_type(&self, type_name: &str, field_name: &str) -> Option<&Type> {
+        // Iron — A5: lookup canonicalises the type-name dimension via
+        // `sig_aliases` before hashing. We only need to do that for
+        // the type-name part — field names are intra-type and stay
+        // verbatim.
+        let direct = RecordFieldKey::new(type_name, field_name);
+        if let Some(ty) = self.record_field_types.get(&direct) {
+            return Some(ty);
+        }
+        if let Some(canonical_type) = self.sig_aliases.get(type_name) {
+            let canonical = RecordFieldKey::new(canonical_type, field_name);
+            return self.record_field_types.get(&canonical);
+        }
+        None
+    }
+
+    /// Iron — A5: list every `(field_name, field_type)` pair declared
+    /// for `type_name`. Resolves `type_name` through `sig_aliases`
+    /// so a bare reference in source matches a canonical entry; the
+    /// reverse direction (canonical reference hitting a bare entry)
+    /// is a no-op because A3 normalises stored keys to canonical
+    /// form whenever a module alias exists.
+    fn fields_for_type(&self, type_name: &str) -> Vec<(String, Type)> {
+        let canonical = self
+            .sig_aliases
+            .get(type_name)
+            .map(String::as_str)
+            .unwrap_or(type_name);
+        self.record_field_types
+            .iter()
+            .filter(|(k, _)| k.type_name == canonical || k.type_name == type_name)
+            .map(|(k, v)| (k.field_name.clone(), v.clone()))
+            .collect()
+    }
+
+    /// Iron — A5: `true` if any field has been registered for
+    /// `type_name`. Drops the pre-A5 `record_field_types.keys().any(|k|
+    /// k.starts_with(&format!("{}.", type_name)))` substring probe.
+    fn has_record_schema(&self, type_name: &str) -> bool {
+        let canonical = self
+            .sig_aliases
+            .get(type_name)
+            .map(String::as_str)
+            .unwrap_or(type_name);
+        self.record_field_types
+            .keys()
+            .any(|k| k.type_name == canonical || k.type_name == type_name)
     }
 
     // -- Helpers -----------------------------------------------------------

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -217,19 +217,27 @@ impl TypeChecker {
                     self.fn_sigs.insert(type_name.clone(), prod_sig);
                 }
                 // Register per-field types so dot-access is checked.
-                // Dual-keyed (canonical + bare) so the `Type.field`
-                // prefix-strip pass in `infer/records.rs` sees the
-                // bare keys while `find_record_field` lookups still
-                // chase the canonical via `sig_aliases`.
+                // Iron — A5: single entry under the canonical
+                // `(Module.Type, field)` key. Bare-name lookups
+                // canonicalise via `sig_aliases`; no more mirror
+                // entry under `(Type, field)`. The bare→canonical
+                // alias is still recorded so other code paths
+                // (`find_value_member`, `find_fn_sig`) can resolve
+                // bare references.
                 for (field_name, ty_str) in fields {
                     let field_ty = parse_type_str_strict(ty_str).unwrap_or(Type::Invalid);
-                    let alias_key = crate::visibility::member_key(type_name, field_name);
-                    let canonical_key = canonical_name(module_name, &alias_key);
+                    let canonical_type = if module_name != type_name {
+                        canonical_name(module_name, type_name)
+                    } else {
+                        type_name.clone()
+                    };
                     self.record_field_types
-                        .insert(canonical_key.clone(), field_ty.clone());
-                    if canonical_key != alias_key {
-                        self.sig_aliases.insert(alias_key.clone(), canonical_key);
-                        self.record_field_types.insert(alias_key, field_ty);
+                        .insert(RecordFieldKey::new(&canonical_type, field_name), field_ty);
+                    if canonical_type != *type_name {
+                        let alias_key = crate::visibility::member_key(type_name, field_name);
+                        let canonical_key =
+                            crate::visibility::member_key(&canonical_type, field_name);
+                        self.sig_aliases.insert(alias_key, canonical_key);
                     }
                 }
             }
@@ -399,13 +407,16 @@ impl TypeChecker {
                 }
                 SymbolKind::RecordField { field_type, .. } => {
                     let field_ty = parse_type_str_strict(field_type).unwrap_or(Type::Invalid);
-                    self.record_field_types
-                        .insert(entry.canonical_name.clone(), field_ty.clone());
-                    // Mirror to the bare alias key so the
-                    // `Type.field` prefix-strip pass in
-                    // `infer/records.rs` reaches imported records too.
-                    if let Some(alias) = &entry.alias {
-                        self.record_field_types.insert(alias.clone(), field_ty);
+                    // Iron — A5: canonical_name is
+                    // "Module.Type.field"; split off the trailing
+                    // field name and keep the rest as the typed-key
+                    // `type_name`. Bare alias still goes into
+                    // `sig_aliases` so a source reference of `Type`
+                    // canonicalises to `Module.Type` at lookup.
+                    let canonical = &entry.canonical_name;
+                    if let Some((canonical_type, field_name)) = canonical.rsplit_once('.') {
+                        self.record_field_types
+                            .insert(RecordFieldKey::new(canonical_type, field_name), field_ty);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- `record_field_types` swaps `HashMap<String, Type>` (keyed by stringified `\"Type.field\"`) for `HashMap<RecordFieldKey, Type>` where the struct separates `type_name` from `field_name`.
- Canonical resolution moves to insert/lookup time (single `sig_aliases` step on the type-name dimension), eliminating the post-A3 dual-keying and the `strip_prefix + !rest.contains('.')` filter that the record-create / record-update / memo-safety scans needed to skip phantom entries.
- Two new helpers on `TypeChecker`: `fields_for_type` (list all `(field_name, type)` pairs for a type) and `has_record_schema` (probe before emitting an `unknown field` diagnostic).

## Test plan
- [x] `cargo test --all-features --tests` — all suites green
- [x] `cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings && cargo clippy -p aver-lang --lib --bin aver -- -D warnings`
- [x] `cargo clippy -p aver-lang --lib --bin aver --features wasm -- -D warnings`
- [x] `cargo fmt --all -- --check`

No user-facing behaviour change → no CHANGELOG entry (per project policy on internal refactors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)