### PR TITLE
Iron — B1: typed NEG opcodes complete the typed-arith pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 - **Duplicate function name is now a type error.** Defining the same `fn` name twice in a module surfaces "Function 'X' is already defined in this module" at the duplicate's source line. Pre-Iron, the second definition silently dropped the first — a typo could swap your function's body without any signal.
 - **Polymorphic recursion that would need `T := F<...T...>` is rejected.** Shapes like `fn nest(v: A) -> Unit; nest([v])` (where the recursive call would need `A` to equal `List<A>`) now surface as a normal type-incompatibility error instead of silently typechecking with a circular binding.
 
+### Improved
+- **Unary minus skips runtime tag-dispatch on the VM.** Two new typed opcodes (`NEG_INT` / `NEG_FLOAT`) replace the generic `NEG`'s `is_int / is_float` branch when the operand's source type resolves to `Int` or `Float`. Continues the typed-arith pipeline established in 0.17.2 (`ADD_INT`, `MUL_FLOAT`, …) — `-x` in tight numeric loops now dispatches in the same shape as `+`, `*`, `/`. As a side effect `-0.0` on a `Float`-typed operand round-trips its sign bit through the VM the same way it does on every other backend, because the typed dispatch operates on the float bit pattern instead of decoding through a generic path.
+
 ### Fixed
 - **Replay can load `Vector` values.** `aver run --record` emitted a `$vector` marker for `Value::Vector`, but `aver replay` had no matching decode arm — any recording with a Vector value failed to load with `unknown replay marker '$vector'`.
 - **Replay can load `Map`s with a single string key.** A 1-entry string-keyed `Map` encoded as `{"key": value}` collided with the marker-wrap shape; replay tried to interpret `key` as an unknown marker. The decoder now only treats `$`-prefixed keys as markers, so plain string keys flow through as map entries.

--- a/src/vm/compiler/expr.rs
+++ b/src/vm/compiler/expr.rs
@@ -64,7 +64,18 @@ impl<'a> FnCompiler<'a> {
             }
             Expr::Neg(inner) => {
                 self.compile_expr(inner)?;
-                self.emit_op(crate::vm::opcode::NEG);
+                // Iron — B1: pick a typed NEG when the operand's
+                // `Spanned::ty()` resolves to a numeric primitive.
+                // Skips the `is_int / is_float` branch in `NEG` and
+                // (for Float) preserves `-0.0` because the typed
+                // dispatch operates on the float bit pattern, not on
+                // `0 - x` desugar.
+                let op = match inner.ty() {
+                    Some(crate::ast::Type::Int) => crate::vm::opcode::NEG_INT,
+                    Some(crate::ast::Type::Float) => crate::vm::opcode::NEG_FLOAT,
+                    _ => crate::vm::opcode::NEG,
+                };
+                self.emit_op(op);
                 Ok(())
             }
             Expr::FnCall(fn_expr, args) => self.compile_call(fn_expr, args),

--- a/src/vm/execute/dispatch.rs
+++ b/src/vm/execute/dispatch.rs
@@ -289,6 +289,15 @@ impl VM {
                         return Err(VmError::type_err("cannot negate non-numeric"));
                     }
                 }
+                NEG_INT => {
+                    let a = self.stack.pop().ok_or(VmError::StackUnderflow)?;
+                    let r = a.as_int(&self.arena).wrapping_neg();
+                    self.stack.push(NanValue::new_int(r, &mut self.arena));
+                }
+                NEG_FLOAT => {
+                    let a = self.stack.pop().ok_or(VmError::StackUnderflow)?;
+                    self.stack.push(NanValue::new_float(-a.as_float()));
+                }
                 NOT => {
                     let a = self.stack.pop().ok_or(VmError::StackUnderflow)?;
                     self.stack.push(NanValue::new_bool(!a.as_bool()));

--- a/src/vm/opcode.rs
+++ b/src/vm/opcode.rs
@@ -90,6 +90,19 @@ pub const MUL_FLOAT: u8 = 0x1C;
 /// the spec, no runtime check.
 pub const DIV_FLOAT: u8 = 0x1D;
 
+/// Typed unary `-` on an `Int` operand. Pops one value, decodes
+/// via `as_int` (inline), negates with `wrapping_neg`, re-boxes
+/// through `NanValue::new_int`. Skips the `is_int / is_float`
+/// branch in `NEG`. Emitted when `inner.ty()` resolves to
+/// `Type::Int`.
+pub const NEG_INT: u8 = 0x1E;
+/// Typed unary `-` on a `Float` operand. Same shape as `NEG_INT`
+/// but on the float side: raw `f64::from_bits`, IEEE 754 negation
+/// (sign-bit flip), push as `NanValue::new_float`. Skips the
+/// `NEG` tag-dispatch chain and preserves `-0.0` because the
+/// negation runs on the float bit pattern, not on `0 - x` desugar.
+pub const NEG_FLOAT: u8 = 0x1F;
+
 // -- Comparison --------------------------------------------------------------
 
 /// Pop b, pop a, push a == b.
@@ -403,6 +416,8 @@ pub fn opcode_name(op: u8) -> &'static str {
         DIV => "DIV",
         MOD => "MOD",
         NEG => "NEG",
+        NEG_INT => "NEG_INT",
+        NEG_FLOAT => "NEG_FLOAT",
         NOT => "NOT",
         EQ => "EQ",
         EQ_INT => "EQ_INT",
@@ -493,6 +508,8 @@ pub fn opcode_operand_width(op: u8, code: &[u8], ip: usize) -> usize {
         | DIV
         | MOD
         | NEG
+        | NEG_INT
+        | NEG_FLOAT
         | NOT
         | EQ
         | EQ_INT


### PR DESCRIPTION
## Summary
- Two new typed opcodes: `NEG_INT` (0x1E) and `NEG_FLOAT` (0x1F). Skip the `is_int / is_float` branch in the generic `NEG` dispatch — same shape as the 0.17.2 typed-arith sweep.
- `Expr::Neg` compilation picks the typed variant when the inner expression's `Spanned::ty()` resolves to `Int` / `Float`, falls back to `NEG` otherwise.
- Side effect: `-0.0` on a `Float`-typed operand round-trips its sign bit through the VM the same way every other backend already does, because the typed dispatch operates on the float bit pattern.

Note: full local-monomorfizacja (typed `LOAD_LOCAL_INT` etc. hooked into a dual-stack representation) is deferred to 0.22+. With the current NaN-boxed `Vec<NanValue>` stack a typed `LOAD_LOCAL_INT` would not skip any tag check that the consumer (`ADD_INT`, …) doesn't already inline — there's no quick win without restructuring the stack representation.

## Test plan
- [x] `cargo test --all-features --tests` — all suites green (606 lib + integration)
- [x] `cargo run --bin aver -- run /tmp/neg_test.av` — `-42` and `-3.14` print as expected
- [x] `cargo clippy -p aver-lang --lib --bin aver -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)