### PR TITLE
Iron 0.21 Hardcore Fuzz — Phase 0: per-target metrics

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -170,6 +170,27 @@ jobs:
             -x ${{ matrix.dict }} \
             -- target/release/${{ matrix.target }}
 
+      - name: Iron Phase 0 metrics
+        # Each fuzz target writes accumulator stats to
+        # `/tmp/aver_fuzz_metrics_<target>.txt` every 10k execs.
+        # The file persists between AFL persistent-mode iterations
+        # and gets a final snapshot just before the harness exits.
+        # CI surfaces it so we can chart parse-success rate, AST
+        # shape distribution, and depth high-water marks
+        # independently from AFL's bitmap coverage. Phase 1 (custom
+        # AFL mutator) will compare its own pre/post numbers
+        # against this baseline.
+        if: always()
+        run: |
+          metrics_file="/tmp/aver_fuzz_metrics_${{ matrix.target }}.txt"
+          echo "::group::Iron Phase 0 fuzz metrics — ${{ matrix.target }}"
+          if [ -f "$metrics_file" ]; then
+            cat "$metrics_file"
+          else
+            echo "no metrics snapshot (target ran < 10k execs)"
+          fi
+          echo "::endgroup::"
+
       - name: Fail on crash
         # AFL writes one file per distinct crash under
         # `out/<target>/<id>/crashes/`. Anything other than the
@@ -376,6 +397,23 @@ jobs:
             -o out/${{ matrix.target }} \
             -x ${{ matrix.dict }} \
             -- target/release/${{ matrix.target }}
+
+      - name: Iron Phase 0 metrics
+        # Same metrics surface as pr-smoke — see the comment there.
+        # On a 30-min nightly the snapshot is far more interesting
+        # than on a 180-s smoke: parse_ok / typecheck_clean rates
+        # tell us whether the target is exploring deep pipeline
+        # paths or stuck rejecting at the lexer.
+        if: always()
+        run: |
+          metrics_file="/tmp/aver_fuzz_metrics_${{ matrix.target }}.txt"
+          echo "::group::Iron Phase 0 fuzz metrics — ${{ matrix.target }}"
+          if [ -f "$metrics_file" ]; then
+            cat "$metrics_file"
+          else
+            echo "no metrics snapshot (target ran < 10k execs)"
+          fi
+          echo "::endgroup::"
 
       - name: Summarise findings
         working-directory: fuzz

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -15,6 +15,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,16 +83,31 @@ name = "aver-lang"
 version = "0.20.0"
 dependencies = [
  "aver-memory",
+ "aver-rt",
+ "clap",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
+ "toml",
  "url",
 ]
 
 [[package]]
 name = "aver-memory"
 version = "0.2.8"
+dependencies = [
+ "aver-rt",
+]
+
+[[package]]
+name = "aver-rt"
+version = "0.4.7"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "rand",
+]
 
 [[package]]
 name = "bitflags"
@@ -51,10 +116,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "displaydoc"
@@ -105,6 +222,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,7 +267,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -269,10 +424,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -317,10 +490,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
@@ -329,6 +514,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -361,9 +555,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rustc_version"
@@ -386,6 +615,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -437,6 +672,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +697,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -477,7 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -514,6 +770,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +841,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +862,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -608,6 +956,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -737,6 +1094,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -78,6 +78,14 @@ impl Counters {
         }
     }
 
+    /// Force a snapshot write regardless of flush interval. Call
+    /// from the fuzz target's `main` after `afl::fuzz!` returns so
+    /// the final state survives even when AFL terminates the loop
+    /// mid-budget at the `-V` deadline.
+    pub fn flush(&self) {
+        self.flush_to_disk();
+    }
+
     pub fn record_lex_ok(&self) {
         self.lex_ok.fetch_add(1, Ordering::Relaxed);
     }
@@ -113,9 +121,12 @@ impl Counters {
 }
 
 /// How often to snapshot to disk. Tuned so the I/O cost is
-/// negligible vs the fuzz throughput (10k execs takes ~1 s in
-/// persistent mode, so once per second of fuzzing is the budget).
-const FLUSH_INTERVAL: u64 = 10_000;
+/// negligible vs the fuzz throughput (1k execs takes ~100ms in
+/// persistent mode, so ten flushes per second of fuzzing is the
+/// budget — cheap, and short PR-smoke runs (180 s) reach the
+/// first flush in well under a second even on the slow
+/// typecheck target).
+const FLUSH_INTERVAL: u64 = 1_000;
 
 /// Count AST nodes by walking every `TopLevel` and its expression
 /// subtree iteratively. We care about the order of magnitude, not
@@ -231,15 +242,12 @@ fn expr_metrics(root: &aver::ast::Spanned<aver::ast::Expr>, base_depth: u64) -> 
 }
 
 /// Global counters per fuzz binary. Each target initialises its
-/// own `Counters` via `Counters::new("fuzz_<target>")` and reaches
-/// for it through `counters()`.
+/// own `Counters` via `Counters::new(env!("CARGO_BIN_NAME"))` and
+/// reaches for it through `counters()`. Using the cargo-injected
+/// bin name (compile-time) instead of a runtime env var means the
+/// AFL forkserver child processes don't need any env plumbing —
+/// the binary's identity is baked in at link time.
 pub fn counters() -> &'static Counters {
     static COUNTERS: OnceLock<Counters> = OnceLock::new();
-    COUNTERS.get_or_init(|| {
-        let target = std::env::var("AVER_FUZZ_TARGET_NAME")
-            .ok()
-            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
-            .unwrap_or("fuzz_unknown");
-        Counters::new(target)
-    })
+    COUNTERS.get_or_init(|| Counters::new(env!("CARGO_BIN_NAME")))
 }

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -1,0 +1,245 @@
+// Iron 0.21 "Hardcore Fuzz" — Phase 0: shared metrics module for
+// fuzz targets. AFL gives us `execs_done`, `corpus_count`, and
+// `bitmap_cvg` via its own `fuzzer_stats` file, but those tell us
+// nothing about *where in the pipeline* each input ended up.
+//
+// For the upcoming `aver-fuzz-mutator` work we need to know:
+//
+//   - how many inputs actually parse as Aver source
+//   - how many additionally type-check
+//   - what AST shape (node count, max depth) the accepted inputs have
+//
+// Without these baselines we can't tell whether Phase 1 (custom
+// mutator) shifts inputs deeper into the pipeline — coverage alone
+// is ambiguous because a random-byte fuzzer that finds 50% bitmap
+// coverage on the lexer rejection paths looks superficially similar
+// to a structured fuzzer that finds 50% coverage on the typecheck
+// happy paths.
+//
+// All counters are `AtomicU64` so the persistent-mode AFL harness
+// can update them from a single thread without lock contention.
+// `flush_to_disk` writes a snapshot to `/tmp/aver_fuzz_metrics_<target>.txt`
+// every `FLUSH_INTERVAL` executions; CI reads the file at the end
+// of the fuzz step and uploads it alongside the queue artifact.
+
+// Each fuzz binary picks the subset of this module it needs —
+// `parse_bytes` ignores `record_typecheck_clean`, `replay_codec`
+// ignores the AST walkers. Suppress the per-binary dead-code
+// warnings rather than scatter `#[allow]` on every helper.
+#![allow(dead_code)]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+pub struct Counters {
+    pub target: &'static str,
+    /// Total `afl::fuzz!` callback invocations. Mirrors AFL's own
+    /// `execs_done` but tracked here so we don't have to scrape
+    /// AFL's stats file.
+    pub execs: AtomicU64,
+    /// Inputs that survived `Lexer::tokenize`. Indicates the
+    /// fraction of fuzz attempts that produced a valid token
+    /// stream — the floor below which a structure-aware mutator
+    /// cannot be useful.
+    pub lex_ok: AtomicU64,
+    /// Inputs whose token stream also parsed as `Vec<TopLevel>`.
+    /// The headline metric for "is this input even Aver?".
+    pub parse_ok: AtomicU64,
+    /// Inputs that typechecked without producing errors. Only
+    /// updated by targets that actually run the typechecker; stays
+    /// 0 for `parse_bytes` / `replay_codec`.
+    pub typecheck_clean: AtomicU64,
+    /// Running sum of AST node counts for parsed inputs. Divide
+    /// by `parse_ok` for the average; combined with
+    /// `max_ast_depth` gives a sense of "how chunky are the
+    /// programs the fuzzer is exploring".
+    pub ast_node_sum: AtomicU64,
+    /// High-water mark for AST depth across the campaign.
+    pub max_ast_depth: AtomicU64,
+}
+
+impl Counters {
+    pub const fn new(target: &'static str) -> Self {
+        Self {
+            target,
+            execs: AtomicU64::new(0),
+            lex_ok: AtomicU64::new(0),
+            parse_ok: AtomicU64::new(0),
+            typecheck_clean: AtomicU64::new(0),
+            ast_node_sum: AtomicU64::new(0),
+            max_ast_depth: AtomicU64::new(0),
+        }
+    }
+
+    pub fn record_exec(&self) {
+        let n = self.execs.fetch_add(1, Ordering::Relaxed) + 1;
+        if n.is_multiple_of(FLUSH_INTERVAL) {
+            self.flush_to_disk();
+        }
+    }
+
+    pub fn record_lex_ok(&self) {
+        self.lex_ok.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_parse_ok(&self, ast_nodes: u64, depth: u64) {
+        self.parse_ok.fetch_add(1, Ordering::Relaxed);
+        self.ast_node_sum.fetch_add(ast_nodes, Ordering::Relaxed);
+        self.max_ast_depth.fetch_max(depth, Ordering::Relaxed);
+    }
+
+    pub fn record_typecheck_clean(&self) {
+        self.typecheck_clean.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn flush_to_disk(&self) {
+        let path = format!("/tmp/aver_fuzz_metrics_{}.txt", self.target);
+        // Snapshot the counters into a deterministic table. Ignore
+        // I/O errors — metrics are observational, not load-bearing,
+        // and a fuzz worker that can't write to `/tmp` has bigger
+        // problems than missing telemetry.
+        let snapshot = format!(
+            "target={target}\nexecs={execs}\nlex_ok={lex_ok}\nparse_ok={parse_ok}\ntypecheck_clean={typecheck_clean}\nast_node_sum={ast_node_sum}\nmax_ast_depth={max_ast_depth}\n",
+            target = self.target,
+            execs = self.execs.load(Ordering::Relaxed),
+            lex_ok = self.lex_ok.load(Ordering::Relaxed),
+            parse_ok = self.parse_ok.load(Ordering::Relaxed),
+            typecheck_clean = self.typecheck_clean.load(Ordering::Relaxed),
+            ast_node_sum = self.ast_node_sum.load(Ordering::Relaxed),
+            max_ast_depth = self.max_ast_depth.load(Ordering::Relaxed),
+        );
+        let _ = std::fs::write(&path, snapshot);
+    }
+}
+
+/// How often to snapshot to disk. Tuned so the I/O cost is
+/// negligible vs the fuzz throughput (10k execs takes ~1 s in
+/// persistent mode, so once per second of fuzzing is the budget).
+const FLUSH_INTERVAL: u64 = 10_000;
+
+/// Count AST nodes by walking every `TopLevel` and its expression
+/// subtree iteratively. We care about the order of magnitude, not
+/// exact bookkeeping — Box/Spanned wrappers don't count.
+pub fn ast_metrics(items: &[aver::ast::TopLevel]) -> (u64, u64) {
+    let mut total: u64 = items.len() as u64;
+    let mut max_depth: u64 = 1;
+    for item in items {
+        if let aver::ast::TopLevel::FnDef(f) = item {
+            for stmt in f.body.stmts() {
+                let expr = match stmt {
+                    aver::ast::Stmt::Expr(e) => e,
+                    aver::ast::Stmt::Binding(_, _, e) => e,
+                };
+                let (n, d) = expr_metrics(expr, 1);
+                total = total.saturating_add(n);
+                if d > max_depth {
+                    max_depth = d;
+                }
+            }
+        }
+    }
+    (total, max_depth)
+}
+
+/// Iterative-with-stack expression walker. Avoids self-recursion
+/// for the same reason `dotted_name` got rewritten this morning —
+/// a fuzz harness should never reproduce the bug it's hunting.
+fn expr_metrics(root: &aver::ast::Spanned<aver::ast::Expr>, base_depth: u64) -> (u64, u64) {
+    use aver::ast::Expr;
+    let mut total: u64 = 0;
+    let mut max_depth: u64 = base_depth;
+    let mut stack: Vec<(&aver::ast::Spanned<Expr>, u64)> = vec![(root, base_depth)];
+    while let Some((node, d)) = stack.pop() {
+        total = total.saturating_add(1);
+        if d > max_depth {
+            max_depth = d;
+        }
+        // Cap total walk to avoid runaway cost on adversarial AST
+        // shapes — the fuzz harness must stay fast.
+        if total > 100_000 {
+            break;
+        }
+        match &node.node {
+            Expr::BinOp(_, a, b) => {
+                stack.push((a, d + 1));
+                stack.push((b, d + 1));
+            }
+            Expr::Neg(inner) => stack.push((inner, d + 1)),
+            Expr::Attr(inner, _) => stack.push((inner, d + 1)),
+            Expr::FnCall(callee, args) => {
+                stack.push((callee, d + 1));
+                for a in args {
+                    stack.push((a, d + 1));
+                }
+            }
+            Expr::Constructor(_, payload) => {
+                if let Some(arg) = payload {
+                    stack.push((arg, d + 1));
+                }
+            }
+            Expr::Match { subject, arms } => {
+                stack.push((subject, d + 1));
+                for arm in arms {
+                    stack.push((&arm.body, d + 1));
+                }
+            }
+            Expr::List(items) | Expr::Tuple(items) => {
+                for item in items {
+                    stack.push((item, d + 1));
+                }
+            }
+            Expr::IndependentProduct(items, _) => {
+                for item in items {
+                    stack.push((item, d + 1));
+                }
+            }
+            Expr::MapLiteral(entries) => {
+                for (k, v) in entries {
+                    stack.push((k, d + 1));
+                    stack.push((v, d + 1));
+                }
+            }
+            Expr::ErrorProp(inner) => stack.push((inner, d + 1)),
+            Expr::RecordCreate { fields, .. } => {
+                for (_, v) in fields {
+                    stack.push((v, d + 1));
+                }
+            }
+            Expr::RecordUpdate { base, updates, .. } => {
+                stack.push((base, d + 1));
+                for (_, v) in updates {
+                    stack.push((v, d + 1));
+                }
+            }
+            Expr::TailCall(boxed) => {
+                for a in &boxed.args {
+                    stack.push((a, d + 1));
+                }
+            }
+            Expr::InterpolatedStr(parts) => {
+                for part in parts {
+                    if let aver::ast::StrPart::Parsed(expr) = part {
+                        stack.push((expr, d + 1));
+                    }
+                }
+            }
+            // Leaves: Ident, Literal, etc. — nothing to push.
+            _ => {}
+        }
+    }
+    (total, max_depth)
+}
+
+/// Global counters per fuzz binary. Each target initialises its
+/// own `Counters` via `Counters::new("fuzz_<target>")` and reaches
+/// for it through `counters()`.
+pub fn counters() -> &'static Counters {
+    static COUNTERS: OnceLock<Counters> = OnceLock::new();
+    COUNTERS.get_or_init(|| {
+        let target = std::env::var("AVER_FUZZ_TARGET_NAME")
+            .ok()
+            .map(|s| Box::leak(s.into_boxed_str()) as &'static str)
+            .unwrap_or("fuzz_unknown");
+        Counters::new(target)
+    })
+}

--- a/fuzz/fuzz_targets/parse_bytes.rs
+++ b/fuzz/fuzz_targets/parse_bytes.rs
@@ -10,15 +10,29 @@
 // AFL finds get minimized by `afl-tmin` and committed as
 // `tests/regressions/parser/<hash>.av`, which `cargo test --test
 // parser_regressions` re-runs on every PR to prevent regressions.
+//
+// Iron 0.21 Hardcore Fuzz Phase 0: emits per-campaign metrics to
+// `/tmp/aver_fuzz_metrics_fuzz_parse_bytes.txt`. CI uploads the file
+// alongside the AFL queue artifact so we can chart parse-success
+// rate, ast-shape distribution, and depth high-water marks
+// independently from AFL's bitmap coverage.
+
+#[path = "common.rs"]
+mod common;
 
 fn main() {
     afl::fuzz!(|data: &[u8]| {
+        let c = common::counters();
+        c.record_exec();
         let Ok(source) = std::str::from_utf8(data) else {
             return;
         };
         let mut lexer = aver::lexer::Lexer::new(source);
         let Ok(tokens) = lexer.tokenize() else { return };
+        c.record_lex_ok();
         let mut parser = aver::parser::Parser::new(tokens);
-        let _ = parser.parse();
+        let Ok(items) = parser.parse() else { return };
+        let (nodes, depth) = common::ast_metrics(&items);
+        c.record_parse_ok(nodes, depth);
     });
 }

--- a/fuzz/fuzz_targets/parse_bytes.rs
+++ b/fuzz/fuzz_targets/parse_bytes.rs
@@ -35,4 +35,8 @@ fn main() {
         let (nodes, depth) = common::ast_metrics(&items);
         c.record_parse_ok(nodes, depth);
     });
+    // Final snapshot — interval flush may not fire if AFL terminates
+    // the persistent loop mid-budget. CI reads this file after the
+    // fuzz step.
+    common::counters().flush();
 }

--- a/fuzz/fuzz_targets/replay_codec.rs
+++ b/fuzz/fuzz_targets/replay_codec.rs
@@ -54,4 +54,5 @@ fn main() {
         // generator side.
         let _ = aver::replay::json::value_to_json(&value);
     });
+    common::counters().flush();
 }

--- a/fuzz/fuzz_targets/replay_codec.rs
+++ b/fuzz/fuzz_targets/replay_codec.rs
@@ -22,18 +22,32 @@
 // Round-trips that survive `json_to_value` get a second pass through
 // `value_to_json` to exercise the encoder's own panic surface (the
 // non-finite-float and unsupported-variant guards live there).
+//
+// Iron 0.21 Hardcore Fuzz Phase 0: metrics surface to
+// `/tmp/aver_fuzz_metrics_fuzz_replay_codec.txt`. The `lex_ok` counter
+// re-purposes for "parse_json succeeded" — same semantic role
+// (input passes the first parser layer). `parse_ok` is "json_to_value
+// succeeded". `ast_node_sum` / `max_ast_depth` stay zero here
+// because we don't construct a `Vec<TopLevel>` for replay JSON.
+
+#[path = "common.rs"]
+mod common;
 
 fn main() {
     afl::fuzz!(|data: &[u8]| {
+        let c = common::counters();
+        c.record_exec();
         let Ok(source) = std::str::from_utf8(data) else {
             return;
         };
         let Ok(json) = aver::replay::json::parse_json(source) else {
             return;
         };
+        c.record_lex_ok();
         let Ok(value) = aver::replay::json::json_to_value(&json) else {
             return;
         };
+        c.record_parse_ok(0, 0);
         // Re-encode to exercise the encoder's variant arms with a
         // value tree that *survived* a real decode. Tightens the
         // round-trip invariant the B3 proptest already locks for the

--- a/fuzz/fuzz_targets/typecheck_program.rs
+++ b/fuzz/fuzz_targets/typecheck_program.rs
@@ -61,4 +61,5 @@ fn main() {
         // suppresses cascading from.
         aver::resolver::resolve_program(&mut items);
     });
+    common::counters().flush();
 }

--- a/fuzz/fuzz_targets/typecheck_program.rs
+++ b/fuzz/fuzz_targets/typecheck_program.rs
@@ -21,21 +21,39 @@
 // Steps 3 and 4 are gated on the prior step producing an `Ok` — we
 // don't want to count "parser said no" as a typecheck panic, and we
 // don't want to count "typecheck wrote errors" as a resolver panic.
+//
+// Iron 0.21 Hardcore Fuzz Phase 0: metrics surface to
+// `/tmp/aver_fuzz_metrics_fuzz_typecheck_program.txt`. The `typecheck_clean`
+// counter is the headline metric this target adds over `parse_bytes`
+// — once Phase 1 lands the custom mutator, the ratio
+// `typecheck_clean / parse_ok` is the direct measure of whether
+// structured mutations push inputs deeper into the pipeline.
+
+#[path = "common.rs"]
+mod common;
 
 fn main() {
     afl::fuzz!(|data: &[u8]| {
+        let c = common::counters();
+        c.record_exec();
         let Ok(source) = std::str::from_utf8(data) else {
             return;
         };
         let mut lexer = aver::lexer::Lexer::new(source);
         let Ok(tokens) = lexer.tokenize() else { return };
+        c.record_lex_ok();
         let mut parser = aver::parser::Parser::new(tokens);
         let Ok(mut items) = parser.parse() else { return };
+        let (nodes, depth) = common::ast_metrics(&items);
+        c.record_parse_ok(nodes, depth);
         // run_type_check returns a Vec<TypeError> for valid frontend
         // inputs that have real type problems — that's not a panic and
         // not a fuzz finding. We only care that the function returns
         // cleanly without unwinding.
-        let _ = aver::types::checker::run_type_check(&items);
+        let errors = aver::types::checker::run_type_check(&items);
+        if errors.is_empty() {
+            c.record_typecheck_clean();
+        }
         // The resolver mutates its input — feed it the same `items`
         // afterwards. If typecheck wrote `Spanned::ty` annotations,
         // resolve sees them; if not, resolve falls through the


### PR DESCRIPTION
## Summary
Foundation for the Iron 0.21 "Hardcore Fuzz Edition" expansion. Adds atomic-counter metrics to the three existing fuzz targets so subsequent phases (custom mutator, new codegen / differential / verify targets) can measure whether they actually push inputs deeper into the pipeline — bitmap coverage alone is ambiguous.

## What lands

- `fuzz/fuzz_targets/common.rs` — shared `Counters` struct with `execs / lex_ok / parse_ok / typecheck_clean / ast_node_sum / max_ast_depth` atomic counters, iterative AST walker (stack-bounded by construction).
- Three existing fuzz targets call `record_*` per fuzz iteration.
- Counters snapshot to `/tmp/aver_fuzz_metrics_<target>.txt` every 10 000 execs.
- New `Iron Phase 0 metrics` CI step on both pr-smoke and nightly — `cat`s the snapshot inside a `::group::` collapsible.

## Why per-target metrics matter

Without them "did Phase 1 mutator help?" collapses to reading AFL's bitmap coverage. Bitmap coverage on `parse_bytes` counts edges hit by lexer rejection paths the same as edges hit by typecheck happy paths. The shift custom mutators promise (more inputs flowing into deeper pipeline stages) is invisible to that signal. The four ratios this PR surfaces (`lex_ok / execs`, `parse_ok / lex_ok`, `typecheck_clean / parse_ok`, `max_ast_depth`) are the headline measurement Phase 1+ iterates against.

## Test plan
- [x] `cargo afl build --release` — all three fuzz binaries link with the new common module
- [x] `cargo test --lib`, `cargo fmt --check`, `cargo clippy ... -- -D warnings`
- [x] Workflow YAML syntactically valid (push trigger should fire fuzz smoke jobs)

## Next
- Phase 1: `aver-fuzz-mutator` cdylib (custom AFL mutator, class A mutations)
- New targets: fuzz_codegen_wasm_gc, fuzz_differential_vm_vs_wasm_gc, fuzz_verify_solver, fuzz_replay_full

🤖 Generated with [Claude Code](https://claude.com/claude-code)