### PR TITLE
Iron 0.21 — wasm-gc Console.print routes through services::console capture

### DIFF
--- a/src/runtime/wasm_gc/imports/lm.rs
+++ b/src/runtime/wasm_gc/imports/lm.rs
@@ -44,22 +44,25 @@ pub(crate) fn host_print(
             Val::I32(n) => n,
             _ => 0,
         };
-        if len > 0 {
+        let text: String = if len > 0 {
             let mut buf = vec![0u8; len as usize];
             let _ = memory.read(&caller, 0, &mut buf);
-            let text = String::from_utf8_lossy(&buf);
-            if to_stdout {
-                println!("{}", text);
-            } else {
-                eprintln!("{}", text);
-            }
+            String::from_utf8_lossy(&buf).into_owned()
         } else {
-            // Empty string still emits a newline in VM semantics.
-            if to_stdout {
-                println!();
-            } else {
-                eprintln!();
-            }
+            // Empty string still emits a newline in VM semantics —
+            // `write_stdout` appends the newline itself.
+            String::new()
+        };
+        // Route through `aver::services::console` instead of direct
+        // `println!` / `eprintln!` so the in-process parity fuzz
+        // target's `capture_output` thread-local sees wasm-gc writes
+        // too (the VM already routes here). Direct stdio bypassed
+        // the buffer, hiding semantic divergence behind a "wasm-gc
+        // stdout looks empty when captured" symptom.
+        if to_stdout {
+            crate::services::console::write_stdout_str(&text);
+        } else {
+            crate::services::console::write_stderr_plain_str(&text);
         }
     }
     Ok(())

--- a/src/services/console.rs
+++ b/src/services/console.rs
@@ -54,6 +54,21 @@ where
     (result, out, err)
 }
 
+/// Capture-aware `println!`-equivalent — embedders that bypass the
+/// `Console.print` builtin (currently the wasm-gc backend's import
+/// handler in `runtime::wasm_gc::imports::lm`) should call this
+/// instead of raw `println!` so the thread-local `capture_output`
+/// buffer sees their writes too.
+pub fn write_stdout_str(s: &str) {
+    write_stdout(s);
+}
+
+/// Capture-aware `eprintln!`-equivalent. Same rationale as
+/// `write_stdout_str`.
+pub fn write_stderr_plain_str(s: &str) {
+    write_stderr_plain(s);
+}
+
 fn write_stdout(s: &str) {
     CAPTURE.with(|c| {
         if let Some((out, _)) = c.borrow_mut().as_mut() {

--- a/tests/wasm_gc_capture_output.rs
+++ b/tests/wasm_gc_capture_output.rs
@@ -61,10 +61,14 @@ fn wasm_gc_console_print_writes_to_capture_buffer() {
     });
 
     if let Err(e) = &run_res {
-        panic!("wasm-gc run_in_process should succeed on hello-world, got: {}", e);
+        panic!(
+            "wasm-gc run_in_process should succeed on hello-world, got: {}",
+            e
+        );
     }
     assert_eq!(
-        stdout, b"hello, world\n",
+        stdout,
+        b"hello, world\n",
         "wasm-gc Console.print must populate the capture_output stdout buffer; got {:?}",
         String::from_utf8_lossy(&stdout)
     );

--- a/tests/wasm_gc_capture_output.rs
+++ b/tests/wasm_gc_capture_output.rs
@@ -1,0 +1,76 @@
+//! Regression: wasm-gc `Console.print` must route through
+//! `aver::services::console::capture_output`, not raw `println!`.
+//!
+//! Nightly fuzz `parity_vm_vs_wasm_gc` reported 3 crashes that
+//! looked like real semantic divergence:
+//!
+//!   vm   : Some(("hello,...\n", Null))
+//!   wasm : Some(("", Null))            ← empty buffer!
+//!
+//! Root cause: the wasm-gc backend's `Console.print` import handler
+//! (`runtime::wasm_gc::imports::lm::host_print`) used direct
+//! `println!` / `eprintln!`, bypassing the per-thread capture
+//! buffer the parity target installs via `capture_output`. The VM
+//! routes through `services::console`, so it captured correctly;
+//! the asymmetry presented as "wasm-gc produced no output" which
+//! is a phantom semantic divergence — both backends *did* print
+//! the same bytes, the in-process harness just couldn't see the
+//! wasm-gc side.
+//!
+//! This test pins the invariant: a trivial Console.print program
+//! must yield identical captured stdout from VM and wasm-gc.
+
+#![cfg(feature = "wasm")]
+
+use aver::ir::{PipelineConfig, TypecheckMode};
+
+const HELLO_SRC: &str = r#"module M
+    intent =
+        "capture regression"
+    effects [Console]
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("hello, world")
+"#;
+
+#[test]
+fn wasm_gc_console_print_writes_to_capture_buffer() {
+    let mut lexer = aver::lexer::Lexer::new(HELLO_SRC);
+    let tokens = lexer.tokenize().expect("lex");
+    let mut parser = aver::parser::Parser::new(tokens);
+    let mut items = parser.parse().expect("parse");
+    let _ = aver::ir::pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+
+    let (run_res, stdout, stderr) = aver::services::console::capture_output(|| {
+        aver::runtime::wasm_gc::run_in_process(
+            &items,
+            None,
+            aver::runtime::wasm_gc::RunConfig {
+                program_args: Vec::new(),
+                entry_info: None,
+                mode: aver::runtime::wasm_gc::EffectMode::Normal,
+            },
+        )
+    });
+
+    if let Err(e) = &run_res {
+        panic!("wasm-gc run_in_process should succeed on hello-world, got: {}", e);
+    }
+    assert_eq!(
+        stdout, b"hello, world\n",
+        "wasm-gc Console.print must populate the capture_output stdout buffer; got {:?}",
+        String::from_utf8_lossy(&stdout)
+    );
+    assert!(
+        stderr.is_empty(),
+        "stderr should be empty for a pure Console.print program; got {:?}",
+        String::from_utf8_lossy(&stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- wasm-gc backend's \`Console.print\` host import handler (\`runtime/wasm_gc/imports/lm::host_print\`) used direct \`println!\` / \`eprintln!\`, bypassing the per-thread \`CAPTURE\` buffer in \`services::console\`.
- Fix: new public \`services::console::write_stdout_str\` / \`write_stderr_plain_str\` thin wrappers around existing private writers. Both honour \`CAPTURE\` when set, fall through to \`println!\` / \`eprintln!\` when not — so non-capture behaviour is byte-identical.
- Regression test \`wasm_gc_capture_output.rs\` pins that \`Console.print(\"hello, world\")\` lands in the capture buffer as \`b\"hello, world\\n\"\`.

## Bug class

Iron 0.21 nightly 26109363108 (after in-process parity landed) reported 3 \`parity_vm_vs_wasm_gc\` crashes that looked like real semantic divergence:

\`\`\`
vm   : Some((\"hello,...\\n\", Null))
wasm : Some((\"\", Null))            ← empty capture
*** STDOUT DIVERGE ***
\`\`\`

Subprocess \`aver run\` showed identical stdout on both backends — the bytes were being printed, just to fd 1 directly. The in-process parity target then panicked on a phantom divergence.

Real bug class: **in-process parity infrastructure**, not a backend semantic bug. With this fix the in-process fuzz target should report 0 crashes on the same shape.

## Test plan

- [x] \`cargo test --release --features wasm --test wasm_gc_capture_output\` — 1 passed
- [ ] Existing tests still pass (lib + integration)
- [ ] CI green on the next push
- [ ] Next nightly: \`fuzz_parity_vm_vs_wasm_gc\` finishes with 0 crashes (currently 3 from this exact shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)