### PR TITLE
Iron 0.21 — wasm-gc: handle Unit inner in carrier eq dispatch

### DIFF
--- a/src/codegen/wasm_gc/body/eq_helpers.rs
+++ b/src/codegen/wasm_gc/body/eq_helpers.rs
@@ -719,6 +719,20 @@ fn emit_inner_eq_dispatch(
         "Bool" => {
             f.instruction(&Instruction::I32Eq);
         }
+        "Unit" => {
+            // `Unit` has no wasm representation, but the surrounding
+            // `Result<Unit, X>` / `Tuple<Unit, X>` struct uses a
+            // dummy `i32` slot (see module.rs:4150, "Unit on either
+            // side has no wasm value; we use a dummy `i32` slot").
+            // The caller did two `struct.get` and pushed two dummy
+            // i32s; comparing them with `I32Eq` always yields 1
+            // since any two Unit values are equal by definition.
+            // `Option<Unit>` never reaches this path — Option's
+            // struct emitter rejects Unit element earlier
+            // ("Option element type `Unit` has no wasm
+            // representation").
+            f.instruction(&Instruction::I32Eq);
+        }
         "Float" => {
             f.instruction(&Instruction::F64Eq);
         }

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -46,17 +46,10 @@ fn single_file_examples() -> Vec<PathBuf> {
 ///   * `examples/formal/oracle_independent_products.av` — uses a
 ///     `BranchPath` carrier the wasm-gc backend doesn't yet dispatch.
 ///     Tracked under the wasm-gc verify limitations doc.
-///   * `examples/apps/status_board.av` — uses `Result<Unit, String>`
-///     which trips the carrier-eq path: `emit_inner_eq_dispatch`
-///     has no `"Unit"` arm and the surrounding `StructGet` assumes
-///     the inner field pushes a value. Real codegen bug, tracked
-///     under its own ticket — this suite is the regression net, not
-///     the fix.
 fn is_skipped(path: &Path) -> bool {
     let s = path.to_string_lossy();
     s.contains("/examples/diagnostics/")
         || s.ends_with("/examples/formal/oracle_independent_products.av")
-        || s.ends_with("/examples/apps/status_board.av")
 }
 
 fn walk(dir: &Path, out: &mut Vec<PathBuf>) {


### PR DESCRIPTION
## Summary

\`emit_inner_eq_dispatch\` (eq_helpers.rs) only knew \`Int\`, \`Bool\`, \`Float\`, \`String\`, and registered helper types. \`Result<Unit, X>\` / \`Tuple<Unit, X>\` tripped \"carrier eq inner type \`Unit\` has no eq dispatch\".

Fix: add a \`\"Unit\"\` arm emitting \`I32Eq\`. The Result struct uses a dummy \`i32\` slot for the Unit-typed side (\`module.rs:4150\`); the caller pushed two dummy \`i32 0\`s via \`struct.get\`, comparing them with \`I32Eq\` always yields 1 — correct semantics, any two Unit values are equal.

\`Option<Unit>\` doesn't reach this path because Option's struct emitter rejects Unit element earlier (\"Option element type \`Unit\` has no wasm representation\").

## Surface

Flagged by \`tests/wasm_gc_codegen_regression.rs\` on first run; \`examples/apps/status_board.av\` uses \`Result<Unit, String>\` (\`animateProbeLoop\` body). Skipped in the regression suite as a TODO; this PR unskips it.

## Test plan

- [x] \`cargo test --release --features wasm-compile --test wasm_gc_codegen_regression\` — 37/37 single-file examples compile + validate (was 36/37)
- [x] \`cargo test --release --features wasm --lib\` — 627 passed
- [ ] CI green on the next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)