### PR TITLE
Iron 0.21 — fuzz target: replay_roundtrip

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,6 +19,9 @@ name: Fuzz
 #   * `fuzz_codegen_wasip2`     — source → wasip2 core + component → component-model validate.
 #   * `fuzz_verify_runner`      — source → run_verify_for_items_vm.
 #   * `fuzz_parity_vm_vs_wasm_gc` — VM ↔ wasm-gc in-process differential.
+#   * `fuzz_replay_roundtrip`   — VM record → replay roundtrip; asserts
+#     replay reproduces the recording's stdout + return value + full
+#     trace consumption.
 #
 # Linux-only by deliberate choice. AFL++ on macOS hosted runners
 # hits frequent CPU-scaling and persistent-mode quirks that burn CI
@@ -108,6 +111,9 @@ jobs:
             corpus: corpus/parser
             dict: dicts/aver.dict
           - target: fuzz_codegen_wasip2
+            corpus: corpus/parser
+            dict: dicts/aver.dict
+          - target: fuzz_replay_roundtrip
             corpus: corpus/parser
             dict: dicts/aver.dict
     steps:

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -80,6 +80,13 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "fuzz_replay_roundtrip"
+path = "fuzz_targets/replay_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
 [profile.release]
 debug = 1
 overflow-checks = true

--- a/fuzz/fuzz_targets/replay_roundtrip.rs
+++ b/fuzz/fuzz_targets/replay_roundtrip.rs
@@ -1,0 +1,189 @@
+// Coverage-guided fuzz target: source → VM record → VM replay
+// roundtrip.
+//
+// Different surface from `fuzz_replay_codec`. That target hammers
+// the JSON serialisation / deserialisation of a `SessionRecording`.
+// This one checks the *semantic* invariant the recorder + replayer
+// are supposed to maintain: replay of a recording must reproduce
+// the original run bit-for-bit.
+//
+// Pipeline per AFL exec:
+//   1. lex / parse / typecheck / pipeline (zero-error gate)
+//   2. compile + VM run with `start_recording()`, capture stdout +
+//      decoded entry-fn return value + effect trace.
+//   3. fresh compile + VM run with `start_replay(effects)`,
+//      capture stdout + decoded return value.
+//   4. assert stdout identical, output identical, replay consumed
+//      the entire trace (`ensure_replay_consumed` Ok).
+//
+// Bug class this surfaces:
+//   - recorder dropping events / under-counting (replay runs out of
+//     trace mid-execution)
+//   - replayer mis-decoding effect args (return-value mismatch even
+//     when the original ran cleanly)
+//   - non-determinism in the VM itself that the recorder can't
+//     bridge (real bug; recording shape should fail loudly, not
+//     silently produce wrong output on replay)
+//
+// In-process throughput pattern from `parity_vm_vs_wasm_gc`:
+// `aver::services::console::capture_output` redirects stdout
+// per-thread so we read what the program "printed" without
+// touching the real fd.
+
+#[path = "common.rs"]
+mod common;
+
+use aver::ast::TopLevel;
+use aver::ir::{PipelineConfig, TypecheckMode};
+use aver::replay::JsonValue;
+use std::panic::AssertUnwindSafe;
+
+const MAX_INPUT_SIZE: usize = 4 * 1024;
+
+/// Decoded outcome of one VM run. Mirror of the parity target's
+/// `BackendOutcome` shape — same comparison currency (stdout
+/// bytes + `JsonValue` output) so a future "record on backend A,
+/// replay on backend B" target can reuse it.
+struct RunOutcome {
+    stdout: Vec<u8>,
+    value: JsonValue,
+    /// Recorded effect trace — populated only on the record run.
+    /// The replay run takes this as input and the comparison
+    /// asserts `ensure_replay_consumed`.
+    recorded_effects: Option<Vec<aver::replay::EffectRecord>>,
+}
+
+fn main() {
+    afl::fuzz_nohook!(|data: &[u8]| {
+        if data.len() > MAX_INPUT_SIZE {
+            return;
+        }
+        let c = common::counters();
+        c.record_exec();
+        let Ok(source) = std::str::from_utf8(data) else {
+            return;
+        };
+
+        let mut lexer = aver::lexer::Lexer::new(source);
+        let Ok(tokens) = lexer.tokenize() else { return };
+        c.record_lex_ok();
+        let mut parser = aver::parser::Parser::new(tokens);
+        let Ok(mut items) = parser.parse() else { return };
+        let (nodes, depth) = common::ast_metrics(&items);
+        c.record_parse_ok(nodes, depth);
+        let errors = aver::types::checker::run_type_check(&items);
+        if !errors.is_empty() {
+            return;
+        }
+        c.record_typecheck_clean();
+
+        let _ = aver::ir::pipeline::run(
+            &mut items,
+            PipelineConfig {
+                typecheck: Some(TypecheckMode::Full { base_dir: None }),
+                ..Default::default()
+            },
+        );
+
+        // First run: record. Captures the canonical (stdout,
+        // value, trace) triple the replay must reproduce.
+        let Some(record) = run_vm(&items, RecordMode::Record) else {
+            return;
+        };
+        let trace = match record.recorded_effects.as_ref() {
+            Some(t) => t.clone(),
+            None => return,
+        };
+
+        // Second run: replay against the recorded trace. Same
+        // program, fresh VM, recorder swapped for replayer.
+        let Some(replay) = run_vm(&items, RecordMode::Replay(trace)) else {
+            // Replay refused / panicked under catch_unwind. Real
+            // bug class — record produced a trace the replay
+            // can't consume.
+            eprintln!(
+                "replay_roundtrip: record succeeded but replay refused on the recorded trace"
+            );
+            std::process::abort();
+        };
+
+        if record.stdout != replay.stdout {
+            let r = String::from_utf8_lossy(&record.stdout);
+            let p = String::from_utf8_lossy(&replay.stdout);
+            eprintln!(
+                "replay_roundtrip: stdout divergence\n--- record ---\n{r}\n--- replay ---\n{p}"
+            );
+            std::process::abort();
+        }
+        if record.value != replay.value {
+            eprintln!(
+                "replay_roundtrip: output value divergence\n--- record: {:?}\n--- replay: {:?}",
+                record.value, replay.value
+            );
+            std::process::abort();
+        }
+    });
+    common::counters().flush();
+}
+
+enum RecordMode {
+    Record,
+    Replay(Vec<aver::replay::EffectRecord>),
+}
+
+fn run_vm(items: &[TopLevel], mode: RecordMode) -> Option<RunOutcome> {
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let mut arena = aver::nan_value::Arena::new();
+        aver::vm::register_service_types(&mut arena);
+        let (code, globals) =
+            aver::vm::compile_program_with_modules(items, &mut arena, None, "", None).ok()?;
+        let mut machine = aver::vm::VM::new(code, globals, arena);
+        machine.set_cli_args(Vec::new());
+        let want_record = match &mode {
+            RecordMode::Record => {
+                machine.start_recording();
+                true
+            }
+            RecordMode::Replay(trace) => {
+                // `validate_args = true` so a replay that supplies
+                // mismatched effect args fails loudly instead of
+                // silently consuming the wrong slot.
+                machine.start_replay(trace.clone(), true);
+                false
+            }
+        };
+        let (run_res, stdout, _stderr) =
+            aver::services::console::capture_output(|| machine.run());
+        let nv = run_res.ok()?;
+        if let RecordMode::Replay(_) = &mode {
+            // `ensure_replay_consumed` is the load-bearing assertion
+            // here: a recording that under-runs (program reads N
+            // events on record, M < N on replay) silently passes
+            // the stdout/value check if both runs stop at the same
+            // point but diverged earlier in the trace. The recorder
+            // is supposed to capture every effect the program
+            // touched; if replay leaves trailing events, the
+            // semantic invariant is broken.
+            machine.ensure_replay_consumed().ok()?;
+        }
+        let value = <aver::nan_value::NanValue as aver::nan_value::NanValueConvert>::to_value(
+            nv,
+            &machine.arena,
+        );
+        let json = aver::replay::value_to_json(&value).ok()?;
+        let recorded_effects = if want_record {
+            Some(machine.recorded_effects().to_vec())
+        } else {
+            None
+        };
+        Some(RunOutcome {
+            stdout,
+            value: json,
+            recorded_effects,
+        })
+    }));
+    match result {
+        Ok(outcome) => outcome,
+        Err(_) => None,
+    }
+}


### PR DESCRIPTION
## Summary

Sister to \`fuzz_replay_codec\`. That one chases JSON serialisation; this one checks the **semantic invariant**: replay of a recording must reproduce the original VM run bit-for-bit (stdout + decoded \`JsonValue\` output + full trace consumption).

## Pipeline

1. lex / parse / typecheck / pipeline (zero-error gate)
2. compile + VM run with \`start_recording()\` → \`(stdout, value, trace)\`
3. fresh compile + VM run with \`start_replay(trace, validate_args=true)\` → \`(stdout, value)\`
4. assert stdout + value identical AND \`ensure_replay_consumed()\` is \`Ok\` (a recording that captures N events but replay consumes M < N would silently pass the equality check if both runs stop at the same expression but diverged earlier in the trace)

## Bug classes this surfaces

- recorder dropping events (under-counting)
- replayer mis-decoding effect args (return mismatch even when original ran cleanly)
- VM non-determinism the recorder can't bridge

## Wiring

- \`fuzz/fuzz_targets/replay_roundtrip.rs\` — new target
- \`fuzz/Cargo.toml\` — new \`[[bin]]\` (reuses the existing feature set, no new deps)
- \`.github/workflows/fuzz.yml\` — matrix gains \`fuzz_replay_roundtrip\` (corpus/parser + aver.dict)
- header doc lists the 8th target

## Test plan

- [x] \`cargo afl build --release --bin fuzz_replay_roundtrip\` succeeds (no warnings)
- [ ] CI green on this PR
- [ ] Next nightly: \`Fuzz nightly (fuzz_replay_roundtrip)\` runs with 30-min budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)