### PR TITLE
Iron 0.21 — fuzz corpus: edge-case seeds

### DIFF
--- a/fuzz/corpus/parser/bare_namespace.av
+++ b/fuzz/corpus/parser/bare_namespace.av
@@ -1,0 +1,25 @@
+module BareNamespace
+    intent =
+        "Mention every namespace by bare name in a position where typecheck"
+        "may or may not accept it — Vector / List / Option / Map / Result."
+        "Iron 0.21 fuzz_codegen_wasm_gc nightly produced three aver_type_of"
+        "panics on this exact shape (typecheck pass without Spanned::ty stamp)."
+    effects []
+
+fn shapes() -> List<Int>
+    ? "Plain List literal returning the expected type."
+    [1, 2, 3]
+
+fn options() -> Option<Int>
+    ? "Some constructor with primitive payload."
+    Option.Some(42)
+
+fn results() -> Result<Int, String>
+    ? "Ok constructor with primitive payload."
+    Result.Ok(7)
+
+fn main() -> Int
+    ! []
+    match Option.Some(1)
+        Option.Some(n) -> n
+        Option.None -> 0

--- a/fuzz/corpus/parser/deep_match.av
+++ b/fuzz/corpus/parser/deep_match.av
@@ -1,0 +1,24 @@
+module DeepMatch
+    intent =
+        "Match arms with nested constructors + literal + binding patterns."
+        "Exercises pattern compilation depth + exhaustiveness checker shapes."
+    effects []
+
+type Tree
+    Leaf
+    Node(Tree, Int, Tree)
+
+fn sumTree(t: Tree) -> Int
+    ? "Recursive tree sum — nested match destructures both subtrees."
+    match t
+        Tree.Leaf -> 0
+        Tree.Node(left, value, right) -> sumTree(left) + value + sumTree(right)
+
+verify sumTree
+    sumTree(Tree.Leaf) => 0
+    sumTree(Tree.Node(Tree.Leaf, 5, Tree.Leaf)) => 5
+    sumTree(Tree.Node(Tree.Node(Tree.Leaf, 1, Tree.Leaf), 2, Tree.Node(Tree.Leaf, 3, Tree.Leaf))) => 6
+
+fn main() -> Int
+    ! []
+    sumTree(Tree.Node(Tree.Leaf, 7, Tree.Leaf))

--- a/fuzz/corpus/parser/effects_empty.av
+++ b/fuzz/corpus/parser/effects_empty.av
@@ -1,0 +1,20 @@
+module EffectsEmpty
+    intent =
+        "Explicit `effects []` declaration. Iron 0.21 parity nightly found a"
+        "real VM↔wasm-gc divergence on a program with `effects []` plus a"
+        "verify block (`List literal: cannot resolve list instantiation`)."
+        "Seed targets the transition the `toggle-effects` mutator cycles."
+    effects []
+
+fn pure(x: Int) -> Int
+    ? "Pure function — no effects, no IO."
+    x * 2
+
+verify pure
+    pure(0)   => 0
+    pure(1)   => 2
+    pure(-3)  => -6
+
+fn main() -> Int
+    ! []
+    pure(21)

--- a/fuzz/corpus/parser/map_vector_literals.av
+++ b/fuzz/corpus/parser/map_vector_literals.av
@@ -1,0 +1,23 @@
+module MapVectorLiterals
+    intent =
+        "Map + Vector + List literals in expression positions. Exercises"
+        "the per-instantiation codegen registry (Map<K,V> / Vector<T> /"
+        "List<T>) — recurring source of `List literal: cannot resolve"
+        "list instantiation` shapes in parity nightlies."
+    effects []
+
+fn counts() -> Map<String, Int>
+    ? "Map literal with String keys and Int values."
+    {"alpha" => 1, "beta" => 2, "gamma" => 3}
+
+fn sequence() -> List<Int>
+    ? "Plain List literal."
+    [10, 20, 30]
+
+fn buckets() -> Vector<Int>
+    ? "Vector built from a List literal."
+    Vector.fromList([1, 2, 3, 4])
+
+fn main() -> Int
+    ! []
+    List.len(sequence())

--- a/fuzz/corpus/parser/recursive_with_base.av
+++ b/fuzz/corpus/parser/recursive_with_base.av
@@ -1,0 +1,23 @@
+module RecursiveWithBase
+    intent =
+        "Tail-recursive fn with an explicit base case — the shape AFL nightly"
+        "mutated into the verify_runner hangs (drop the base, the recursion"
+        "becomes an infinite TCO loop). Seeds the neighbourhood so mutator"
+        "byte-havoc + targeted strategies have a starting point that already"
+        "exercises the step-limit boundary."
+    effects []
+
+fn countDown(n: Int) -> Int
+    ? "Counts down to zero. Real terminating recursion."
+    match n
+        0 -> 0
+        _ -> countDown(n - 1)
+
+verify countDown
+    countDown(0)   => 0
+    countDown(1)   => 0
+    countDown(10)  => 0
+
+fn main() -> Int
+    ! []
+    countDown(5)

--- a/fuzz/corpus/parser/result_unit.av
+++ b/fuzz/corpus/parser/result_unit.av
@@ -1,0 +1,24 @@
+module ResultUnit
+    intent =
+        "Result<Unit, X> — the shape that tripped emit_inner_eq_dispatch in"
+        "wasm-gc codegen (Iron 0.21 PR #53 fix). Carrier eq path needs the"
+        "Unit dummy-i32-slot handling; seeds make sure the corpus mutates"
+        "around the boundary."
+    effects []
+
+fn ensurePositive(n: Int) -> Result<Unit, String>
+    ? "Returns Ok(Unit) when n > 0, Err with reason otherwise."
+    match n > 0
+        true  -> Result.Ok(Unit)
+        false -> Result.Err("non-positive")
+
+verify ensurePositive
+    ensurePositive(1)  => Result.Ok(Unit)
+    ensurePositive(0)  => Result.Err("non-positive")
+    ensurePositive(-5) => Result.Err("non-positive")
+
+fn main() -> Int
+    ! []
+    match ensurePositive(3)
+        Result.Ok(_)  -> 0
+        Result.Err(_) -> 1

--- a/fuzz/corpus/parser/tuple_destructure.av
+++ b/fuzz/corpus/parser/tuple_destructure.av
@@ -1,0 +1,19 @@
+module TupleDestructure
+    intent =
+        "Tuple construction + destructure in match. Tuple<A, B> carrier"
+        "type goes through the same eq_helpers path as Option / Result."
+    effects []
+
+fn swap(t: Tuple<Int, String>) -> Tuple<String, Int>
+    ? "Swaps a 2-tuple's elements."
+    match t
+        (i, s) -> (s, i)
+
+verify swap
+    swap((1, "one")) => ("one", 1)
+    swap((42, "answer")) => ("answer", 42)
+
+fn main() -> Int
+    ! []
+    match swap((7, "hello"))
+        (_, n) -> n

--- a/fuzz/corpus/parser/verify_law_given.av
+++ b/fuzz/corpus/parser/verify_law_given.av
@@ -1,0 +1,23 @@
+module VerifyLawGiven
+    intent =
+        "verify <fn> law with given + when clause — the shape verify_runner's"
+        "law expansion path exercises (collect_combinations cartesian)."
+        "Seeds the corpus so the AST mutator can byte-havoc the law boundary."
+    effects []
+
+fn double(x: Int) -> Int
+    ? "Doubles its argument."
+    x * 2
+
+verify double law doubleIsAddSelf
+    given x: Int = [0, 1, 7, (-3), 100]
+    double(x) => (x + x)
+
+verify double law doubleNonNegativeWhenInputNonNegative
+    given x: Int = [0, 2, 4, 100]
+    when (x >= 0)
+    (double(x) >= 0) => true
+
+fn main() -> Int
+    ! []
+    double(21)


### PR DESCRIPTION
## Summary

Adds 8 hand-curated seeds to \`fuzz/corpus/parser/\`. Each targets a shape AFL nightly already touched or that the targeted-mutation strategies (PR #58) cycle around.

- \`recursive_with_base.av\` — tail-recursive fn with base case; un-broken neighbourhood of the verify_runner hang shapes
- \`bare_namespace.av\` — \`Vector/List/Option/Map/Result\` in expr position; PR #45's 3 codegen panics shape
- \`deep_match.av\` — recursive type + nested constructor/binding match arms
- \`result_unit.av\` — \`Result<Unit, X>\`; PR #53 fixed \`emit_inner_eq_dispatch\` for this
- \`effects_empty.av\` — explicit \`effects []\`; the \`toggle-effects\` mutator boundary
- \`verify_law_given.av\` — \`verify <fn> law\` + \`given\` + \`when\`; law-expansion cartesian
- \`map_vector_literals.av\` — Map + Vector + List literals; \"List literal: cannot resolve list instantiation\" parity divergence source
- \`tuple_destructure.av\` — Tuple construction + destructure; same eq_helpers path as Option/Result

All 8 verified typecheck-clean via \`aver check\`. AFL's queue seeding script picks them up automatically.

## Out of scope

\`afl-cmin\` integration — Linux-only tool, needs a workflow pre-step to dedupe corpus by coverage. Edge seeds were the higher-value half of #33; cmin is a tracked follow-up.

## Test plan

- [x] \`aver check\` on each new seed — 8/8 typecheck-clean
- [ ] CI green (only docs+yaml-touching is the lack-of-yaml-touching; should be 3 min)
- [ ] Next nightly: AFL queue grows from the new seeds; check counters \`parse_ok\` / \`typecheck_clean\` ratios

🤖 Generated with [Claude Code](https://claude.com/claude-code)