### PR TITLE
Iron 0.21 — proof: bump setup-dafny-action to v1.9.1

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -66,7 +66,7 @@ jobs:
         # followed by `dafny verify Prog.dfy` against the emitted
         # project. A Dafny-side proof failure on any fixture fails
         # the job.
-        uses: dafny-lang/setup-dafny-action@v1.7.3
+        uses: dafny-lang/setup-dafny-action@v1.9.1
         with:
           dafny-version: 4.9.0
 


### PR DESCRIPTION
v1.7.3 doesn't exist. Manual nightly trigger on `proof.yml` failed with `Unable to resolve action dafny-lang/setup-dafny-action@v1.7.3`. Bumping to current latest v1.9.1.