### PR TITLE
Iron 0.21 — wasm-gc match: first wildcard wins (was last)

### DIFF
--- a/src/codegen/wasm_gc/body/emit.rs
+++ b/src/codegen/wasm_gc/body/emit.rs
@@ -3069,7 +3069,20 @@ pub(super) fn emit_match(
     for arm in arms {
         match &arm.pattern {
             Pattern::Literal(Literal::Int(n)) => typed_arms.push((*n, &arm.body)),
-            Pattern::Wildcard => wildcard_body = Some(&arm.body),
+            // First wildcard wins. Aver match semantics is
+            // first-applicable-arm; a plain `wildcard_body =
+            // Some(...)` here let *later* wildcards overwrite the
+            // earlier one, so a program with several `_ -> ...`
+            // arms produced bytecode that ran the *last* wildcard
+            // — diverging from VM which honours source order. Iron
+            // 0.21 nightly's `int-boundary` mutator strategy hit
+            // exactly this against the new `recursive_with_base.av`
+            // seed: VM returned the terminal arm's value, wasm-gc
+            // applied the trailing `(-countDown((n-1)))` arm and
+            // produced the negated value.
+            Pattern::Wildcard => {
+                wildcard_body.get_or_insert(&arm.body);
+            }
             _ => {
                 return Err(WasmGcError::Unimplemented(
                     "phase 4 — Int match supports only Int literal patterns + wildcard",

--- a/tests/regressions/parser/match_duplicate_wildcards.av
+++ b/tests/regressions/parser/match_duplicate_wildcards.av
@@ -1,12 +1,6 @@
 module M
 fn countDown(n: Int) -> Int
-    ? "Multiple `_ -> ...` arms — Aver match is first-arm-wins, but the"
-    ? "wasm-gc Int-match emitter used to overwrite `wildcard_body` on"
-    ? "every Wildcard pattern, so the *last* arm ran instead. Iron 0.21"
-    ? "nightly's `int-boundary` mutator strategy hit this against the"
-    ? "recursive_with_base.av seed: VM returned the terminal arm's"
-    ? "value, wasm-gc applied the trailing `(-countDown((n-1)))` arm"
-    ? "and produced the negated value at every recursive level."
+    ? "Multiple `_ -> ...` arms — Aver match is first-arm-wins, but the wasm-gc Int-match emitter used to overwrite `wildcard_body` on every Wildcard pattern, so the last arm ran instead. Iron 0.21 nightly's int-boundary mutator hit this against recursive_with_base.av."
     match (-(-(-n)))
         0 -> 1
         0 -> 0

--- a/tests/regressions/parser/match_duplicate_wildcards.av
+++ b/tests/regressions/parser/match_duplicate_wildcards.av
@@ -1,0 +1,24 @@
+module M
+fn countDown(n: Int) -> Int
+    ? "Multiple `_ -> ...` arms — Aver match is first-arm-wins, but the"
+    ? "wasm-gc Int-match emitter used to overwrite `wildcard_body` on"
+    ? "every Wildcard pattern, so the *last* arm ran instead. Iron 0.21"
+    ? "nightly's `int-boundary` mutator strategy hit this against the"
+    ? "recursive_with_base.av seed: VM returned the terminal arm's"
+    ? "value, wasm-gc applied the trailing `(-countDown((n-1)))` arm"
+    ? "and produced the negated value at every recursive level."
+    match (-(-(-n)))
+        0 -> 1
+        0 -> 0
+        0 -> 0
+        _ -> countDown((n - 1))
+        _ -> countDown((n - 1))
+        _ -> countDown((n - 1))
+        _ -> (-countDown((n - 1)))
+
+verify countDown
+    countDown(0) => 1
+    countDown(5) => 1
+
+fn main() -> Int
+    countDown(5)


### PR DESCRIPTION
## Summary

Iron 0.21 first scheduled nightly (run 26146387313, 2026-05-20) hit **18 parity_vm_vs_wasm_gc crashes** from one seed (\`recursive_with_base.av\`, added in #62) mutated with \`int-boundary\` strategy (#58). Strategy attribution (#50) named the mutator in 17/18 crash filenames.

Divergent shape:

\`\`\`
match (-(-(-n)))
    0 -> 1
    0 -> 0
    0 -> 0
    _ -> countDown((n - 1))            # VM ran this
    _ -> countDown((n - 1))
    _ -> countDown((n - 1))
    _ -> (-countDown((n - 1)))         # wasm-gc ran this
\`\`\`

VM returned 1, wasm-gc returned -1. Boundary-int mutations followed the same pattern (VM = terminal arm's value, wasm-gc = its negation).

## Root cause

\`src/codegen/wasm_gc/body/emit.rs:3072\` collecting the Int-match wildcard:

\`\`\`rust
Pattern::Wildcard => wildcard_body = Some(&arm.body)
\`\`\`

Plain \`=\` overwrote the slot on every Wildcard arm — programs with multiple \`_ -> ...\` shipped bytecode running the **last** one. Aver match semantics is first-applicable-arm (VM honours source order).

## Fix

\`wildcard_body.get_or_insert(&arm.body)\` — first wildcard wins. Mirrors the pattern other emit_*_match arms already use (Option, Result, List, Tuple — all \`if X.is_none()\` gates).

## Regression

\`tests/regressions/parser/match_duplicate_wildcards.av\` pins the minimal repro shape so a future refactor can't re-introduce it.

## Test plan

- [x] In-process parity check on 3 sampled crash files — VM + wasm-gc identical after fix
- [x] \`cargo test --features wasm --lib\` — 627 passed
- [ ] CI green
- [ ] Next nightly: \`fuzz_parity_vm_vs_wasm_gc\` should report 0 crashes from this shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)