### PR TITLE
fuzz: cap mutator output growth + disable CMPLOG

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -62,6 +62,16 @@ env:
   AFL_NO_UI: '1'
   AFL_FAST_CAL: '1'
   AFL_CMPLOG_ONLY_NEW: '1'
+  # CMPLOG forkserver allocates its own SysV shared memory segments
+  # per calibration. With the type-driven AST mutator landed, queue
+  # growth jumped ~5× — the first CI run saw three targets abort with
+  # `shmget() failed` after ~12 min, never producing a `crashes saved`
+  # entry (the failure was systemic, not a real find). Disabling
+  # CMPLOG keeps the standard forkserver coverage path and trades the
+  # cmp-instrumentation guidance for a stable run. If a future fuzz
+  # finding hinges on CMPLOG-found magic constants, re-enable it
+  # together with a tighter `-q` queue cap.
+  AFL_NO_CMPLOG: '1'
   # Ubuntu's `/proc/sys/kernel/core_pattern` points at the apport pipe
   # (`|/usr/share/apport/...`), which AFL refuses to run against — it
   # would mis-classify crashes as timeouts. We don't have passwordless

--- a/fuzz/mutator/src/mutations.rs
+++ b/fuzz/mutator/src/mutations.rs
@@ -827,12 +827,27 @@ fn replace_fn_body<R: Rng>(rng: &mut R, items: &mut [TopLevel]) -> bool {
     }
 }
 
+/// Maximum total `TopLevel` count after `inject-fn` will keep
+/// pushing. AFL chains custom mutators across the queue, so a seed
+/// that already grew to N items can come back through the mutator
+/// hundreds of times in one campaign. Without a ceiling, programs
+/// stack into the thousands of fns, every additional fn touches new
+/// edges in resolver / typecheck / codegen, and AFL's queue grows
+/// faster than the host can calibrate. 32 is the empirical knee:
+/// large enough to exercise cross-fn shapes the seed corpus doesn't
+/// reach, small enough that the queue + shm budget stays within
+/// hosted-runner limits.
+const MAX_TOPLEVEL_AFTER_INJECT: usize = 32;
+
 /// Synthesize a fresh pure fn and append it to the program. Uses
 /// the type-driven generator to build a body matching the random
 /// signature, so the new fn typechecks by construction. Append
 /// rather than insert so the `module` declaration (which must be
 /// the first top-level) keeps its position.
 fn inject_fn<R: Rng>(rng: &mut R, items: &mut Vec<TopLevel>) -> bool {
+    if items.len() >= MAX_TOPLEVEL_AFTER_INJECT {
+        return false;
+    }
     let existing_names: Vec<String> = items
         .iter()
         .filter_map(|i| {

--- a/fuzz/mutator/src/typed_gen.rs
+++ b/fuzz/mutator/src/typed_gen.rs
@@ -25,10 +25,15 @@ use rand::seq::IndexedRandom;
 
 /// Maximum nesting depth for generated expressions. At this depth we
 /// stop recurring through fn calls / constructors and fall back to
-/// the cheapest base case (literal or in-scope local). Five is enough
-/// to thread a Result around two fn calls or build a 3-deep tuple,
-/// which covers the shapes the existing corpus stresses.
-const MAX_DEPTH: u32 = 5;
+/// the cheapest base case (literal or in-scope local). Three keeps
+/// the generated AST small enough that AFL's coverage map churns at
+/// a sustainable rate — the first CI nightly with this mutator wired
+/// in hit `shmget()` exhaustion on three targets because a depth-5
+/// generator produced so many unique well-typed shapes that AFL ran
+/// out of shared-memory segments calibrating them. Three still
+/// covers the shapes the existing corpus stresses (Result around a
+/// fn call, 2-deep tuple, 1-level record).
+const MAX_DEPTH: u32 = 3;
 
 /// Subset of Aver's `Type` enum that we need for generation. We
 /// re-derive it from source-level annotations rather than reusing


### PR DESCRIPTION
## Summary
First CI nightly with the type-driven AST mutator wired in saw three targets (codegen_wasip2, verify_runner, parity_vm_vs_wasm_gc) abort with \`shmget() failed\` after ~12 min, **0 crashes saved** — systemic, not real finds. Well-typed mutator output flooded AFL's queue (~5300 entries in 30s on parity) and the host ran out of SysV shared-memory segments calibrating new inputs.

Three independent knobs:

- \`typed_gen::MAX_DEPTH\` 5 → 3. Smaller generated ASTs, sustainable churn rate.
- \`inject-fn\` guard: \`items.len() >= 32 → false\`. Without it, repeated mutator chains stack synthesized fns into the thousands per program.
- \`fuzz.yml\` adds \`AFL_NO_CMPLOG=1\`. CMPLOG runs a second forkserver with its own shm allocations per calibration; doubles shm pressure for marginal added coverage on Aver source.

Hashmap-iteration-driven \"instability detected during calibration\" warnings are pre-existing aver-lang behavior under fuzz instrumentation — left alone (we don't change runtime semantics to please the fuzzer).

## Test plan
- [x] \`cargo test --release --test mutations\` — 21/21 passed
- [x] \`cargo build --release --features wasm\` from repo root
- [ ] Trigger nightly post-merge and verify all 8 targets reach the 30-min mark

🤖 Generated with [Claude Code](https://claude.com/claude-code)