### PR TITLE
examples + proof/lean: Natural refinement-via-opaque + Lean synth-budget fix

### DIFF
--- a/examples/modules/int_range/int_range.av
+++ b/examples/modules/int_range/int_range.av
@@ -1,0 +1,51 @@
+module IntRange
+    exposes [fromInt, toInt, add]
+    exposes opaque [IntRange]
+    intent =
+        "Refinement-via-opaque, range-bounded variant. Smart"
+        "constructor gates on a compound predicate `Bool.and(n >="
+        "0, n <= 100)` (Aver has no && operator). Exercises the"
+        "auto-proof generator's predicate extraction on a compound"
+        "guard: the by_cases clause should read"
+        "`by_cases h_a : Bool.and(a >= 0, a <= 100)`. The `add` law"
+        "doesn't try closure (sum of two range-ints may exceed"
+        "100) — it claims commutativity, which holds regardless."
+    effects []
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    ? "Smart constructor — admits only ints in 0..=100."
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("IntRange must be in 0..=100")
+
+verify fromInt
+    fromInt(0)   => Result.Ok(IntRange(value = 0))
+    fromInt(50)  => Result.Ok(IntRange(value = 50))
+    fromInt(100) => Result.Ok(IntRange(value = 100))
+    fromInt(-1)  => Result.Err("IntRange must be in 0..=100")
+    fromInt(101) => Result.Err("IntRange must be in 0..=100")
+
+fn toInt(n: IntRange) -> Int
+    ? "Unwrap into the underlying Int. Always in 0..=100."
+    n.value
+
+verify toInt
+    toInt(IntRange(value = 50)) => 50
+
+fn add(a: IntRange, b: IntRange) -> Result<IntRange, String>
+    ? "Sum of two IntRange values — may overflow the upper bound, so the result is Result-bound; fromInt re-validates."
+    fromInt(a.value + b.value)
+
+verify add
+    add(IntRange(value = 10), IntRange(value = 20)) => Result.Ok(IntRange(value = 30))
+    add(IntRange(value = 60), IntRange(value = 50)) => Result.Err("IntRange must be in 0..=100")
+
+verify add law commutative
+    given a: Int = [0, 1, 50, 99, 100]
+    given b: Int = [0, 1, 50, 99, 100]
+    when Bool.and(a >= 0, a <= 100)
+    when Bool.and(b >= 0, b <= 100)
+    add(IntRange(value = a), IntRange(value = b)) => add(IntRange(value = b), IntRange(value = a))

--- a/examples/modules/natural/natural.av
+++ b/examples/modules/natural/natural.av
@@ -1,0 +1,76 @@
+module Natural
+    exposes [fromInt, toInt, add, mul]
+    exposes opaque [Natural]
+    intent =
+        "Refinement-via-opaque, sound-proof variant. Aver has no"
+        "refinement types and no value-level contracts; instead, an"
+        "opaque record with a validating constructor pins the `Int"
+        ">= 0` invariant inside the defining module."
+        ""
+        "All arithmetic operations return Result<Nat, String> and"
+        "route through fromInt internally. This loses the 'closed"
+        "under +' shorthand (the caller has to thread the Result"
+        "through every call site) but gains soundness against Aver"
+        "Int's i64 wrap-around: `add(Natural(value = i64::MAX),"
+        "Natural(value = 1))` returns Err, not a silent overflow that"
+        "produces a Nat with value < 0. A naive `add(a, b) ="
+        "Natural(value = a.value + b.value)` is fully provable for"
+        "unbounded ints in Lean / Dafny / Z3 but wrong on the Aver"
+        "runtime — the gap between a mathematical proof and the"
+        "VM's actual semantics. This variant closes that gap."
+    effects []
+
+record Natural
+    value: Int
+
+fn fromInt(n: Int) -> Result<Natural, String>
+    ? "Smart constructor — admits only non-negative ints into Nat."
+    match n >= 0
+        true  -> Result.Ok(Natural(value = n))
+        false -> Result.Err("Nat must be non-negative")
+
+verify fromInt
+    fromInt(0)   => Result.Ok(Natural(value = 0))
+    fromInt(7)   => Result.Ok(Natural(value = 7))
+    fromInt(-1)  => Result.Err("Nat must be non-negative")
+    fromInt(-99) => Result.Err("Nat must be non-negative")
+
+fn toInt(n: Natural) -> Int
+    ? "Unwrap a Nat back into its underlying Int. Always non-negative."
+    n.value
+
+verify toInt
+    toInt(Natural(value = 0)) => 0
+    toInt(Natural(value = 5)) => 5
+
+fn add(a: Natural, b: Natural) -> Result<Natural, String>
+    ? "Sum of two Nats — overflow-safe. Routes the raw Int sum"
+      "through fromInt so wrap-around (i64::MAX + 1 = i64::MIN)"
+      "surfaces as Err instead of a Nat with value < 0."
+    fromInt(a.value + b.value)
+
+verify add
+    add(Natural(value = 0), Natural(value = 5)) => Result.Ok(Natural(value = 5))
+    add(Natural(value = 3), Natural(value = 4)) => Result.Ok(Natural(value = 7))
+
+verify add law commutative
+    given a: Int = [0, 1, 7, 100]
+    given b: Int = [0, 1, 7, 100]
+    when a >= 0
+    when b >= 0
+    add(Natural(value = a), Natural(value = b)) => add(Natural(value = b), Natural(value = a))
+
+fn mul(a: Natural, b: Natural) -> Result<Natural, String>
+    ? "Product of two Nats — overflow-safe via fromInt."
+    fromInt(a.value * b.value)
+
+verify mul
+    mul(Natural(value = 0), Natural(value = 5)) => Result.Ok(Natural(value = 0))
+    mul(Natural(value = 2), Natural(value = 3)) => Result.Ok(Natural(value = 6))
+
+verify mul law commutative
+    given a: Int = [0, 1, 7, 12]
+    given b: Int = [0, 1, 7, 12]
+    when a >= 0
+    when b >= 0
+    mul(Natural(value = a), Natural(value = b)) => mul(Natural(value = b), Natural(value = a))

--- a/examples/modules/natural/proof/SafeSumCommutative.lean
+++ b/examples/modules/natural/proof/SafeSumCommutative.lean
@@ -1,0 +1,56 @@
+-- Manual companion proof for `verify safeSum law commutative` in
+-- examples/modules/natural_app.av.
+--
+-- `aver proof --backend lean` exports the law as a `sorry` placeholder
+-- because the generator's auto-proof path (simp + omega) doesn't close
+-- a wrapper-equality goal like `Except.ok x = Except.ok y`. This file
+-- discharges the universal claim by hand. Drop it next to the
+-- generated `NaturalApp.lean` (or splice the body into the corresponding
+-- `theorem safeSum_law_commutative` statement) to turn the sorry into a
+-- real proof.
+--
+-- Build:
+--   aver proof examples/modules/natural_app.av --module-root examples \
+--     --backend lean --output out --name AverApp
+--   # then splice / patch this proof into out/NaturalApp.lean
+--   cd out && lake build
+
+import AverCommon
+import Modules.Natural.Natural
+
+open Modules.Natural.Natural
+
+-- safeSum is the consumer-side function from natural_app.av; its
+-- signature has to match the generated one byte-for-byte for the
+-- proof to discharge the sorry.
+def safeSum (a : Int) (b : Int) : Except String Int :=
+  match Modules.Natural.Natural.fromInt a with
+  | .error msg => Except.error msg
+  | .ok na => match Modules.Natural.Natural.fromInt b with
+      | .error msg => Except.error msg
+      | .ok nb => match Modules.Natural.Natural.add na nb with
+          | .error msg => Except.error msg
+          | .ok sum => Except.ok (Modules.Natural.Natural.toInt sum)
+
+/-- safeSum is commutative for all Int (unbounded in the proof model).
+    Three observations make this tractable:
+      1. fromInt only branches on `n ≥ 0`, so the result depends solely
+         on the sign — same predicate on both sides.
+      2. add(Nat(a), Nat(b)) just feeds (a + b) back through fromInt,
+         and Int.add_comm closes the arithmetic obligation on the
+         only path that reaches `Except.ok`.
+      3. Every error path produces the same constant message, so the
+         four "at least one negative" arms are syntactically equal. -/
+theorem safeSum_commutative : ∀ (a b : Int), safeSum a b = safeSum b a := by
+  intro a b
+  unfold safeSum
+  unfold Modules.Natural.Natural.fromInt
+  unfold Modules.Natural.Natural.add
+  unfold Modules.Natural.Natural.toInt
+  by_cases ha : a ≥ 0
+  · by_cases hb : b ≥ 0
+    · simp [ha, hb, Int.add_comm]
+    · simp [ha, hb]
+  · by_cases hb : b ≥ 0
+    · simp [ha, hb]
+    · simp [ha, hb]

--- a/examples/modules/natural_app.av
+++ b/examples/modules/natural_app.av
@@ -1,0 +1,40 @@
+module NaturalApp
+    depends [Modules.Natural.Natural]
+    exposes [safeSum]
+    intent =
+        "Consumer side of the Natural refinement-via-opaque example."
+        "Demonstrates that external callers reach Natural only through"
+        "the exposed API (fromInt, add, toInt) — direct Natural(value"
+        "= ...) construction would be rejected by the typechecker"
+        "because Natural is declared `exposes opaque`."
+    effects [Console.print]
+
+fn safeSum(a: Int, b: Int) -> Result<Int, String>
+    ? "Validate both inputs through the smart constructor, add the two Naturals, unwrap to Int. Either side being negative — or the sum overflowing i64 — surfaces as Err."
+    match Modules.Natural.Natural.fromInt(a)
+        Result.Err(msg) -> Result.Err(msg)
+        Result.Ok(na) -> match Modules.Natural.Natural.fromInt(b)
+            Result.Err(msg) -> Result.Err(msg)
+            Result.Ok(nb) -> match Modules.Natural.Natural.add(na, nb)
+                Result.Err(msg) -> Result.Err(msg)
+                Result.Ok(sum) -> Result.Ok(Modules.Natural.Natural.toInt(sum))
+
+verify safeSum
+    safeSum(3, 4)   => Result.Ok(7)
+    safeSum(0, 0)   => Result.Ok(0)
+    safeSum(-1, 5)  => Result.Err("Nat must be non-negative")
+    safeSum(5, -1)  => Result.Err("Nat must be non-negative")
+
+fn render(r: Result<Int, String>) -> String
+    ? "Render Result<Int, String> for display."
+    match r
+        Result.Ok(n)    -> "sum = {n}"
+        Result.Err(msg) -> "error: {msg}"
+
+verify render
+    render(Result.Ok(7)) => "sum = 7"
+    render(Result.Err("Nat must be non-negative")) => "error: Nat must be non-negative"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(render(safeSum(3, 4)))

--- a/examples/modules/natural_app.av
+++ b/examples/modules/natural_app.av
@@ -25,6 +25,11 @@ verify safeSum
     safeSum(-1, 5)  => Result.Err("Nat must be non-negative")
     safeSum(5, -1)  => Result.Err("Nat must be non-negative")
 
+verify safeSum law commutative
+    given a: Int = [-1, 0, 1, 7, 100]
+    given b: Int = [-1, 0, 1, 7, 100]
+    safeSum(a, b) => safeSum(b, a)
+
 fn render(r: Result<Int, String>) -> String
     ? "Render Result<Int, String> for display."
     match r

--- a/examples/modules/nonneg_float/nonneg_float.av
+++ b/examples/modules/nonneg_float/nonneg_float.av
@@ -1,0 +1,49 @@
+module NonNegFloat
+    exposes [fromFloat, toFloat, add]
+    exposes opaque [NonNegFloat]
+    intent =
+        "Refinement-via-opaque on Float. Same shape as Natural"
+        "but the carrier is Float instead of Int. Tests whether"
+        "the auto-proof path extends naturally to Float-typed"
+        "givens. Caveat IEEE 754: `-0.0 >= 0.0` is `true` and"
+        "`NaN >= 0.0` is `false`, so the smart constructor admits"
+        "negative zero and rejects NaN — `aver verify --hostile`"
+        "explores both boundaries."
+    effects []
+
+record NonNegFloat
+    value: Float
+
+fn fromFloat(x: Float) -> Result<NonNegFloat, String>
+    ? "Smart constructor — admits non-negative floats."
+    match x >= 0.0
+        true  -> Result.Ok(NonNegFloat(value = x))
+        false -> Result.Err("NonNegFloat must be >= 0.0")
+
+verify fromFloat
+    fromFloat(0.0)   => Result.Ok(NonNegFloat(value = 0.0))
+    fromFloat(1.5)   => Result.Ok(NonNegFloat(value = 1.5))
+    fromFloat(-1.5)  => Result.Err("NonNegFloat must be >= 0.0")
+
+fn toFloat(n: NonNegFloat) -> Float
+    ? "Unwrap a NonNegFloat into its underlying Float."
+    n.value
+
+verify toFloat
+    toFloat(NonNegFloat(value = 0.0)) => 0.0
+    toFloat(NonNegFloat(value = 2.5)) => 2.5
+
+fn add(a: NonNegFloat, b: NonNegFloat) -> Result<NonNegFloat, String>
+    ? "Sum of two non-negative floats. fromFloat re-validates because Float `+` can produce NaN (Inf + (-Inf)) or Inf — the predicate `x >= 0.0` filters both consistently."
+    fromFloat(a.value + b.value)
+
+verify add
+    add(NonNegFloat(value = 0.0), NonNegFloat(value = 1.5)) => Result.Ok(NonNegFloat(value = 1.5))
+    add(NonNegFloat(value = 2.0), NonNegFloat(value = 3.0)) => Result.Ok(NonNegFloat(value = 5.0))
+
+verify add law commutative
+    given a: Float = [0.0, 1.0, 2.5, 100.0]
+    given b: Float = [0.0, 1.0, 2.5, 100.0]
+    when a >= 0.0
+    when b >= 0.0
+    add(NonNegFloat(value = a), NonNegFloat(value = b)) => add(NonNegFloat(value = b), NonNegFloat(value = a))

--- a/examples/modules/positive/positive.av
+++ b/examples/modules/positive/positive.av
@@ -1,0 +1,49 @@
+module Positive
+    exposes [fromInt, toInt, mul]
+    exposes opaque [Positive]
+    intent =
+        "Refinement-via-opaque, strictly-positive variant. Same"
+        "shape as Natural but the smart constructor gates on"
+        "`n > 0` instead of `n >= 0`. Exercises the auto-proof"
+        "generator's predicate extraction: the by_cases clause it"
+        "emits should read `by_cases h_a : a > 0`, copied straight"
+        "from this fn's body, not a Nat-style `≥ 0`."
+    effects []
+
+record Positive
+    value: Int
+
+fn fromInt(n: Int) -> Result<Positive, String>
+    ? "Smart constructor — admits only strictly-positive ints."
+    match n > 0
+        true  -> Result.Ok(Positive(value = n))
+        false -> Result.Err("Positive must be > 0")
+
+verify fromInt
+    fromInt(1)  => Result.Ok(Positive(value = 1))
+    fromInt(7)  => Result.Ok(Positive(value = 7))
+    fromInt(0)  => Result.Err("Positive must be > 0")
+    fromInt(-1) => Result.Err("Positive must be > 0")
+
+fn toInt(n: Positive) -> Int
+    ? "Unwrap a Positive into its underlying Int. Always > 0."
+    n.value
+
+verify toInt
+    toInt(Positive(value = 1)) => 1
+    toInt(Positive(value = 5)) => 5
+
+fn mul(a: Positive, b: Positive) -> Result<Positive, String>
+    ? "Product of two Positives — overflow-safe via fromInt."
+    fromInt(a.value * b.value)
+
+verify mul
+    mul(Positive(value = 2), Positive(value = 3)) => Result.Ok(Positive(value = 6))
+    mul(Positive(value = 1), Positive(value = 7)) => Result.Ok(Positive(value = 7))
+
+verify mul law commutative
+    given a: Int = [1, 2, 7, 12]
+    given b: Int = [1, 2, 7, 12]
+    when a > 0
+    when b > 0
+    mul(Positive(value = a), Positive(value = b)) => mul(Positive(value = b), Positive(value = a))

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aver-lang"
-version = "0.20.0"
+version = "0.21.1"
 dependencies = [
  "aver-memory",
  "aver-rt",

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -147,7 +147,10 @@ fn is_ok_constructor_with_identity(
         return false;
     }
     let (t, fields) = match ctor_arg_node {
-        Expr::RecordCreate { type_name: t, fields } => (t.as_str(), fields),
+        Expr::RecordCreate {
+            type_name: t,
+            fields,
+        } => (t.as_str(), fields),
         _ => return false,
     };
     if t != type_name || fields.len() != 1 {

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -1,11 +1,184 @@
 use std::collections::HashSet;
 
 use crate::ast::{
-    Expr, FnBody, FnDef, Spanned, Stmt, StrPart, TailCallData, TopLevel, TypeDef, TypeVariant,
-    VerifyBlock, VerifyGivenDomain, VerifyKind,
+    Expr, FnBody, FnDef, Literal, MatchArm, Pattern, Spanned, Stmt, StrPart, TailCallData,
+    TopLevel, TypeDef, TypeVariant, VerifyBlock, VerifyGivenDomain, VerifyKind,
 };
 use crate::codegen::CodegenContext;
 use crate::types::Type;
+
+/// A "refinement record" is the canonical `refinement-via-opaque`
+/// pattern: a single-field `record X { carrier: T }` paired with a
+/// validating smart constructor
+///   `fn fromX(p: T) -> Result<X, _>` body = `match <pred-in-p> with`
+///   `    true  -> Result.Ok(X(carrier = p))`
+///   `    false -> Result.Err("...")`
+///
+/// Detecting this shape lets backends emit the type as a true
+/// dependent / subset type (`def X := { n : T // P n }` in Lean,
+/// `type X = n: T | P n` in Dafny) instead of a flat product, which
+/// in turn collapses universal-law proofs into one-liners
+/// (`rw [Int.add_comm]`) by carrying the invariant inside the type
+/// rather than threading it through ad-hoc tactic plumbing.
+#[derive(Debug, Clone)]
+pub struct RefinementInfo<'a> {
+    /// Carrier-type annotation as written in the record field
+    /// (`"Int"`, `"Float"`, …). Backends emit this as the
+    /// subset's underlying type.
+    pub carrier_type: &'a str,
+    /// Carrier-field name (e.g. `"value"`). Lean projects through
+    /// `.val` on a Subtype, so users of the carrier field have to
+    /// rewrite `n.value → n.val` when the host type is refined.
+    pub carrier_field: &'a str,
+    /// Name of the smart constructor's input parameter (`"n"` in
+    /// `fromInt(n: Int) → Result<X, _>`). Used when substituting
+    /// the law's quantified variable into the predicate.
+    pub param_name: &'a str,
+    /// AST node for the bool predicate the smart constructor
+    /// branches on — the body's `Match { subject = <here>, ... }`.
+    pub predicate: &'a Spanned<Expr>,
+}
+
+/// Inspect `ctx` for a refinement-via-opaque record by `type_name`.
+/// Returns `Some(info)` iff there's exactly one matching smart
+/// constructor and the record has a single carrier field.
+pub fn refinement_info_for<'a>(
+    type_name: &str,
+    ctx: &'a CodegenContext,
+) -> Option<RefinementInfo<'a>> {
+    let (carrier_field, carrier_type) = ctx.items.iter().find_map(|item| match item {
+        TopLevel::TypeDef(TypeDef::Product { name, fields, .. })
+            if name == type_name && fields.len() == 1 =>
+        {
+            let (fname, ftype) = &fields[0];
+            Some((fname.as_str(), ftype.as_str()))
+        }
+        _ => None,
+    })?;
+
+    for item in &ctx.items {
+        let TopLevel::FnDef(fd) = item else { continue };
+        if !fd.return_type.starts_with("Result<") {
+            continue;
+        }
+        if !fd.return_type[7..].starts_with(type_name) {
+            continue;
+        }
+        if fd.params.len() != 1 {
+            continue;
+        }
+        let (param_name, _) = &fd.params[0];
+        let stmts = fd.body.stmts();
+        if stmts.len() != 1 {
+            continue;
+        }
+        let Stmt::Expr(body_expr) = &stmts[0] else {
+            continue;
+        };
+        let Expr::Match { subject, arms } = &body_expr.node else {
+            continue;
+        };
+        if !is_bool_ok_err_match(arms, type_name, carrier_field, param_name) {
+            continue;
+        }
+        return Some(RefinementInfo {
+            carrier_type,
+            carrier_field,
+            param_name,
+            predicate: subject,
+        });
+    }
+    None
+}
+
+/// True iff a two-arm bool match is the canonical refinement shape:
+/// `true -> Result.Ok(<TypeName>(<carrier_field> = <param>))` and
+/// `false -> Result.Err(_)`. Required so we don't mis-classify a
+/// random `match … -> Result.Ok(...) | -> Result.Err(...)` (e.g. an
+/// effectful pipeline) as a smart constructor.
+fn is_bool_ok_err_match(
+    arms: &[MatchArm],
+    type_name: &str,
+    carrier_field: &str,
+    param_name: &str,
+) -> bool {
+    if arms.len() != 2 {
+        return false;
+    }
+    let mut true_ok = false;
+    let mut false_err = false;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::Literal(Literal::Bool(true)) => {
+                if is_ok_constructor_with_identity(&arm.body, type_name, carrier_field, param_name)
+                {
+                    true_ok = true;
+                }
+            }
+            Pattern::Literal(Literal::Bool(false)) => {
+                if is_err_constructor(&arm.body) {
+                    false_err = true;
+                }
+            }
+            _ => return false,
+        }
+    }
+    true_ok && false_err
+}
+
+fn is_ok_constructor_with_identity(
+    expr: &Spanned<Expr>,
+    type_name: &str,
+    carrier_field: &str,
+    param_name: &str,
+) -> bool {
+    // Result.Ok(<TypeName>(<carrier_field> = <param>))
+    let (ctor_name, ctor_arg_node) = match &expr.node {
+        Expr::Constructor(name, Some(arg)) => (name.clone(), &arg.node),
+        Expr::FnCall(callee, args) if args.len() == 1 => {
+            let Some(name) = expr_to_dotted_name(&callee.node) else {
+                return false;
+            };
+            (name, &args[0].node)
+        }
+        _ => return false,
+    };
+    if ctor_name != "Result.Ok" {
+        return false;
+    }
+    let (t, fields) = match ctor_arg_node {
+        Expr::RecordCreate { type_name: t, fields } => (t.as_str(), fields),
+        _ => return false,
+    };
+    if t != type_name || fields.len() != 1 {
+        return false;
+    }
+    let (fname, fvalue) = &fields[0];
+    if fname != carrier_field {
+        return false;
+    }
+    // Post-resolver bodies have `Expr::Resolved` instead of
+    // `Expr::Ident` for fn-param references; accept both shapes so
+    // detection works regardless of which stage of the pipeline we
+    // run in.
+    match &fvalue.node {
+        Expr::Ident(name) | Expr::Resolved { name, .. } => name == param_name,
+        _ => false,
+    }
+}
+
+fn is_err_constructor(expr: &Spanned<Expr>) -> bool {
+    match &expr.node {
+        Expr::Constructor(name, Some(_)) => name == "Result.Err",
+        Expr::FnCall(callee, args) if args.len() == 1 => {
+            matches!(
+                expr_to_dotted_name(&callee.node),
+                Some(name) if name == "Result.Err"
+            )
+        }
+        _ => false,
+    }
+}
 
 // Backend-neutral predicates on AST items — all three codegen backends
 // (Lean, Dafny, Rust) want the same view of "is this pure?",

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -354,9 +354,9 @@ fn emit_match(
         let cond = emit_expr(subject, ctx);
         let t = emit_expr(true_body, ctx);
         let f = emit_expr(false_body, ctx);
-        return format!("if {} then {}\n  else {}", cond, t, f);
+        let _ = line;
+        return format!("if {cond} then {t}\n  else {f}");
     }
-
     let subj = emit_expr(subject, ctx);
     let mut arm_strs = Vec::new();
     for arm in arms {

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -358,7 +358,6 @@ fn emit_match(
     }
 
     let subj = emit_expr(subject, ctx);
-    let eq_name = format!("h_{}", line);
     let mut arm_strs = Vec::new();
     for arm in arms {
         let pat = emit_pattern(&arm.pattern);
@@ -377,7 +376,20 @@ fn emit_match(
             arm_strs.push(format!("  | {} => {}", pat, body));
         }
     }
-    format!("match {} : {} with\n{}", eq_name, subj, arm_strs.join("\n"))
+    // Plain `match … with` (no `h_NN :` named hypothesis). The named
+    // form was historically defensive — equation-style proofs could
+    // refer to `h_NN` for hypothesis-driven reasoning — but the
+    // generated output never actually uses those bindings, and the
+    // shape blocks `simp` from reducing if-inside-match inside the
+    // auto-proof tactic for wrapper-return cross-module laws. The
+    // unused-variable linter was warning on them in every Lean
+    // export. Drop them so `simp [hyp]` + `by_cases` actually closes
+    // the resulting goal. Three fuel-helper emitters still call
+    // `strip_match_eq_binders`; with this change that strip is a
+    // no-op, but leaving the call in place keeps the older paths
+    // tolerant of any future re-introduction of named binders.
+    let _ = line;
+    format!("match {} with\n{}", subj, arm_strs.join("\n"))
 }
 
 /// If all arms are `true -> expr` and `false -> expr`, return (true_body, false_body).

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -10,8 +10,8 @@ mod shared;
 mod spec;
 
 use super::VerifyEmitMode;
-use super::expr::aver_name_to_lean;
-use crate::ast::{Expr, Spanned, VerifyBlock, VerifyLaw};
+use super::expr::{aver_name_to_lean, emit_expr};
+use crate::ast::{Expr, Pattern, Literal, Spanned, Stmt, VerifyBlock, VerifyLaw, MatchArm};
 use crate::codegen::CodegenContext;
 use crate::verify_law::{collect_missing_helper_law_hints, missing_helper_law_message};
 use sampled::emit_guarded_domain_law;
@@ -233,6 +233,26 @@ fn emit_simp_omega_law(
     let lean_names: Vec<String> = ordered.iter().map(|n| aver_name_to_lean(n)).collect();
     let simp_list = lean_names.join(", ");
 
+    // Pull the actual guard predicate out of whatever smart
+    // constructor the fn_names walk reaches. The canonical shape is
+    //   fn fromX(p: Int) -> Result<NamedY, _>
+    //       match <bool-expr-in-p>
+    //           true  -> Result.Ok(NamedY(...))
+    //           false -> Result.Err("...")
+    // — i.e. a refinement-via-opaque smart constructor. We grab the
+    // `<bool-expr-in-p>` subject and the param name, so when we
+    // build the `by_cases` clauses below we can substitute the
+    // law-quantified variable for the smart-constructor's
+    // parameter and emit the *actual* guard:
+    //   Nat       → `by_cases h_a : a ≥ 0`
+    //   Positive  → `by_cases h_a : a > 0`
+    //   Discount  → `by_cases h_a : (a ≥ 0) && (a ≤ 100)`
+    // Falls back to the conservative `a ≥ 0` (the Nat shape) when
+    // we can't find a matching smart constructor; lake will error
+    // loudly if the pick is wrong, prompting a manual companion
+    // proof rather than silently issuing `sorry`.
+    let smart_guard = extract_smart_constructor_guard(&fn_names, ctx);
+
     if wrapper_return {
         // `simp + omega` can't close `Except.ok x = Except.ok y` —
         // omega is a linear-arithmetic decision procedure on Int,
@@ -259,7 +279,16 @@ fn emit_simp_omega_law(
         // Natural example actually discharges here now.
         let by_cases_clauses: Vec<String> = intro_names
             .iter()
-            .map(|n| format!("by_cases h_{n} : {n} ≥ 0"))
+            .map(|n| {
+                let predicate = match &smart_guard {
+                    Some((param, subject)) => {
+                        let substituted = substitute_ident_in_expr(subject, param, n);
+                        emit_expr(&substituted, ctx)
+                    }
+                    None => format!("{n} ≥ 0"),
+                };
+                format!("by_cases h_{n} : {predicate}")
+            })
             .collect();
         let by_cases_chain = by_cases_clauses.join(" <;> ");
         let simp_hyps: Vec<String> = intro_names
@@ -381,4 +410,140 @@ pub(super) fn indent_lines(lines: Vec<String>, spaces: usize) -> Vec<String> {
         .into_iter()
         .map(|line| format!("{pad}{line}"))
         .collect()
+}
+
+/// Find a single-param smart constructor in `fn_names` whose body
+/// is the canonical refinement-via-opaque shape:
+///   match <subject:Bool>
+///       true  -> Result.Ok(...)
+///       false -> Result.Err(...)
+/// Returns `(param_name, subject_expr)` of the first match. Used
+/// by the wrapper-return auto-proof path so by_cases emits the
+/// real guard from the source, not a hard-coded `≥ 0`.
+fn extract_smart_constructor_guard(
+    fn_names: &std::collections::BTreeSet<String>,
+    ctx: &CodegenContext,
+) -> Option<(String, Spanned<Expr>)> {
+    for item in &ctx.items {
+        let crate::ast::TopLevel::FnDef(fd) = item else {
+            continue;
+        };
+        if !fn_names.contains(&fd.name) {
+            continue;
+        }
+        if !fd.return_type.starts_with("Result<") {
+            continue;
+        }
+        if fd.params.len() != 1 {
+            continue;
+        }
+        let (param_name, param_type) = &fd.params[0];
+        if param_type != "Int" {
+            continue;
+        }
+        let stmts = fd.body.stmts();
+        if stmts.len() != 1 {
+            continue;
+        }
+        let Stmt::Expr(body_expr) = &stmts[0] else {
+            continue;
+        };
+        let Expr::Match { subject, arms } = &body_expr.node else {
+            continue;
+        };
+        if arms.len() != 2 {
+            continue;
+        }
+        if !arms_are_bool_ok_err(arms) {
+            continue;
+        }
+        return Some((param_name.clone(), (**subject).clone()));
+    }
+    None
+}
+
+/// True iff the two arms together look like a smart-constructor
+/// branch on Bool: one arm has `Pattern::Literal(Bool(true))` and
+/// produces an `Result.Ok(...)`, the other `Bool(false)` →
+/// `Result.Err(...)`.
+fn arms_are_bool_ok_err(arms: &[MatchArm]) -> bool {
+    if arms.len() != 2 {
+        return false;
+    }
+    let mut saw_true_ok = false;
+    let mut saw_false_err = false;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::Literal(Literal::Bool(true)) => {
+                if body_starts_with_constructor(&arm.body, "Result.Ok") {
+                    saw_true_ok = true;
+                }
+            }
+            Pattern::Literal(Literal::Bool(false)) => {
+                if body_starts_with_constructor(&arm.body, "Result.Err") {
+                    saw_false_err = true;
+                }
+            }
+            _ => return false,
+        }
+    }
+    saw_true_ok && saw_false_err
+}
+
+/// Whether a Spanned<Expr> is a call to the named constructor
+/// (`Result.Ok` / `Result.Err`). Handles both AST shapes the
+/// parser can produce — `Expr::Constructor(name, ...)` and the
+/// `Expr::FnCall(Expr::Attr(Expr::Ident(ns), name), ...)` form.
+fn body_starts_with_constructor(expr: &Spanned<Expr>, full_name: &str) -> bool {
+    match &expr.node {
+        Expr::Constructor(name, _) => name == full_name,
+        Expr::FnCall(callee, _) => {
+            if let Expr::Attr(obj, field) = &callee.node
+                && let Expr::Ident(ns) = &obj.node
+            {
+                let dotted = format!("{ns}.{field}");
+                dotted == full_name
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Recursively substitute every `Expr::Ident(from)` with
+/// `Expr::Ident(to)` inside `expr`. Used by the wrapper-return
+/// auto-proof to rewrite a smart constructor's guard subject in
+/// terms of the law-quantified variable: a smart constructor that
+/// takes `n` and gates on `n ≥ 0` becomes `a ≥ 0` when the law
+/// quantifies over `a`.
+fn substitute_ident_in_expr(expr: &Spanned<Expr>, from: &str, to: &str) -> Spanned<Expr> {
+    let new_node = match &expr.node {
+        Expr::Ident(name) => Expr::Ident(if name == from {
+            to.to_string()
+        } else {
+            name.clone()
+        }),
+        Expr::BinOp(op, l, r) => Expr::BinOp(
+            *op,
+            Box::new(substitute_ident_in_expr(l, from, to)),
+            Box::new(substitute_ident_in_expr(r, from, to)),
+        ),
+        Expr::Neg(inner) => Expr::Neg(Box::new(substitute_ident_in_expr(inner, from, to))),
+        Expr::Attr(inner, field) => Expr::Attr(
+            Box::new(substitute_ident_in_expr(inner, from, to)),
+            field.clone(),
+        ),
+        Expr::FnCall(callee, args) => Expr::FnCall(
+            Box::new(substitute_ident_in_expr(callee, from, to)),
+            args.iter()
+                .map(|a| substitute_ident_in_expr(a, from, to))
+                .collect(),
+        ),
+        Expr::ErrorProp(inner) => {
+            Expr::ErrorProp(Box::new(substitute_ident_in_expr(inner, from, to)))
+        }
+        _ => expr.node.clone(),
+    };
+    Spanned::new(new_node, expr.line)
 }

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -11,7 +11,7 @@ mod spec;
 
 use super::VerifyEmitMode;
 use super::expr::{aver_name_to_lean, emit_expr};
-use crate::ast::{Expr, Pattern, Literal, Spanned, Stmt, VerifyBlock, VerifyLaw, MatchArm};
+use crate::ast::{Expr, Literal, MatchArm, Pattern, Spanned, Stmt, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 use crate::verify_law::{collect_missing_helper_law_hints, missing_helper_law_message};
 use sampled::emit_guarded_domain_law;

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -144,46 +144,143 @@ fn emit_simp_omega_law(
     collect_fn_calls(&law.lhs, &mut fn_names);
     collect_fn_calls(&law.rhs, &mut fn_names);
     fn_names.insert(vb.fn_name.clone());
+    // Transitively expand: include functions called from the body
+    // of every fn we've already collected. Without this, a law on
+    // `safeSum(a, b) => safeSum(b, a)` collects only `safeSum`
+    // itself — but the unfold tactic needs every function that
+    // appears under it (including cross-module callees like
+    // `Modules.Natural.Natural.fromInt`) so the resulting goal is
+    // free of opaque match-on-Except branches that `simp` can't
+    // close. Bounded iteration: each round can only add what's
+    // reachable from the new set, so it converges in O(items).
+    loop {
+        let before = fn_names.len();
+        let snapshot: Vec<String> = fn_names.iter().cloned().collect();
+        for item in &ctx.items {
+            if let crate::ast::TopLevel::FnDef(fd) = item
+                && snapshot.contains(&fd.name)
+            {
+                for stmt in fd.body.stmts() {
+                    match stmt {
+                        crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => {
+                            collect_fn_calls(e, &mut fn_names);
+                        }
+                    }
+                }
+            }
+        }
+        if fn_names.len() == before {
+            break;
+        }
+    }
     // Only proceed if all referenced functions exist in ctx, are non-recursive,
     // and have only Int parameters. simp+omega works on flat match-on-Int bodies.
     if fn_names.iter().any(|n| !ctx.fn_sigs.contains_key(n)) {
         return None;
     }
+    let mut wrapper_return = false;
     for item in &ctx.items {
         if let crate::ast::TopLevel::FnDef(fd) = item
             && fn_names.contains(&fd.name)
         {
-            // Reject recursive functions.
-            if body_calls_any_of(&fd.body, &fn_names) {
+            // Reject self-recursive functions: `unfold fn` only does
+            // one step, so a self-recursive body leaves another call
+            // to `fn` in the goal that simp can't close. Narrow check
+            // — we used to reject anything in `fn_names`, but after
+            // we extended `fn_names` with transitive callees the
+            // narrow form (`{fd.name}`) is what we actually want;
+            // calling a *different* fn that's also in the unfold
+            // list is fine because the next unfold pass strips it.
+            let mut self_only = std::collections::BTreeSet::new();
+            self_only.insert(fd.name.clone());
+            if body_calls_any_of(&fd.body, &self_only) {
                 return None;
             }
-            // Reject functions with non-Int parameters.
-            if fd.params.iter().any(|(_, t)| t != "Int") {
+            // The Int-parameter constraint only applies to the
+            // top-level law function. Cross-module callees may take
+            // refined types like `Natural`.
+            if fd.name == vb.fn_name && fd.params.iter().any(|(_, t)| t != "Int") {
                 return None;
             }
-            // Reject wrapped return types (Result, Option, List,
-            // Tuple, …). `simp [fn] <;> omega` unfolds the body but
-            // omega only closes linear-arithmetic goals on Int; a
-            // wrapper-equality goal like `Except.ok x = Except.ok y`
-            // leaves a constructor mismatch omega can't see. Without
-            // this guard, generator emits an auto-proof that
-            // typechecks against the body but lake fails with
-            // `omega could not prove the goal` — exactly the failure
-            // the sound-proof Natural example triggered, where
-            // `safeSum` returns `Result<Int, String>` and walks
-            // through `Modules.Natural.Natural.add`'s `Except`.
-            // Plain `Int` / `Float` returns stay on the omega path.
             if fd.return_type != "Int" && fd.return_type != "Float" {
-                return None;
+                wrapper_return = true;
             }
         }
     }
-    let lean_names: Vec<String> = fn_names.iter().map(|n| aver_name_to_lean(n)).collect();
+    // Inspect cross-module callees via `ctx.fn_sigs` (they aren't in
+    // `ctx.items`). Mark wrapper_return when their result type is a
+    // wrapper (Result, Option, …).
+    for name in &fn_names {
+        if let Some((_params, ret, _effects)) = ctx.fn_sigs.get(name) {
+            if !matches!(ret, crate::types::Type::Int | crate::types::Type::Float) {
+                wrapper_return = true;
+            }
+        }
+    }
+
+    // Top-level law fn first in the unfold list — Lean needs to see
+    // it in the goal before transitively-reached callees, otherwise
+    // `unfold Modules.X.Y.foo` fails outright at `safeSum a b = …`.
+    let mut ordered: Vec<String> = Vec::new();
+    if fn_names.contains(&vb.fn_name) {
+        ordered.push(vb.fn_name.clone());
+    }
+    for n in &fn_names {
+        if n != &vb.fn_name {
+            ordered.push(n.clone());
+        }
+    }
+    let lean_names: Vec<String> = ordered.iter().map(|n| aver_name_to_lean(n)).collect();
     let simp_list = lean_names.join(", ");
-    Some(intro_then(
-        intro_names,
-        vec![format!("simp only [{}] <;> omega", simp_list)],
-    ))
+
+    if wrapper_return {
+        // `simp + omega` can't close `Except.ok x = Except.ok y` —
+        // omega is a linear-arithmetic decision procedure on Int,
+        // blind to constructor-equality on a wrapper. The tactic
+        // below was verified by hand on the sound-proof Natural
+        // example (`examples/modules/natural_app.av`):
+        //   1. `unfold` every user fn the law touches, top-level
+        //      first so the goal exposes the call layer Lean's
+        //      `unfold` operates on at each step.
+        //   2. For each Int parameter, branch on `p ≥ 0` (the only
+        //      predicate that fromInt-style smart constructors use
+        //      to decide ok/err).
+        //   3. `simp` with all introduced hypotheses + `Int.add_
+        //      comm` + `Int.mul_comm` closes the resulting case
+        //      grid. The arithmetic lemmas are conservative
+        //      defaults — `simp` ignores them when the goal
+        //      doesn't mention `+`/`*`.
+        // Conservative shape: if a smart constructor uses a
+        // different predicate (`x > 0`, `x ≤ 100`, …) the
+        // `by_cases` pick is wrong and lake fails with a real
+        // `unsolved goals` error, prompting a manual companion
+        // proof. Strictly better than the silent `sorry` we used
+        // to emit — `safeSum.commutative` in the sound-proof
+        // Natural example actually discharges here now.
+        let by_cases_clauses: Vec<String> = intro_names
+            .iter()
+            .map(|n| format!("by_cases h_{n} : {n} ≥ 0"))
+            .collect();
+        let by_cases_chain = by_cases_clauses.join(" <;> ");
+        let simp_hyps: Vec<String> = intro_names
+            .iter()
+            .map(|n| format!("h_{n}"))
+            .chain(["Int.add_comm".to_string(), "Int.mul_comm".to_string()])
+            .collect();
+        let simp_args = simp_hyps.join(", ");
+        Some(intro_then(
+            intro_names,
+            vec![
+                format!("unfold {}", lean_names.join(" ")),
+                format!("{by_cases_chain} <;> simp [{simp_args}]"),
+            ],
+        ))
+    } else {
+        Some(intro_then(
+            intro_names,
+            vec![format!("simp only [{}] <;> omega", simp_list)],
+        ))
+    }
 }
 
 fn body_calls_any_of(
@@ -204,10 +301,18 @@ fn body_calls_any_of(
 fn collect_fn_calls(expr: &Spanned<Expr>, out: &mut std::collections::BTreeSet<String>) {
     match &expr.node {
         Expr::FnCall(f, args) => {
-            if let Some(name) = crate::codegen::common::expr_to_dotted_name(&f.node)
-                && (!name.contains('.') || name.chars().next().is_some_and(|c| c.is_lowercase()))
-            {
-                out.insert(name);
+            if let Some(name) = crate::codegen::common::expr_to_dotted_name(&f.node) {
+                // Skip top-level uppercase namespace handles like
+                // `List.len` / `Option.Some` — those are built-in
+                // namespaces, not user functions the auto-proof
+                // can unfold. Cross-module user calls
+                // (`Modules.X.Y.fn`) survive because the leaf
+                // function name `fn` starts lower-case even when the
+                // dotted prefix starts uppercase.
+                let last = name.rsplit('.').next().unwrap_or(&name);
+                if last.chars().next().is_some_and(|c| c.is_lowercase()) {
+                    out.insert(name);
+                }
             }
             for arg in args {
                 collect_fn_calls(arg, out);

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -211,10 +211,10 @@ fn emit_simp_omega_law(
     // `ctx.items`). Mark wrapper_return when their result type is a
     // wrapper (Result, Option, …).
     for name in &fn_names {
-        if let Some((_params, ret, _effects)) = ctx.fn_sigs.get(name) {
-            if !matches!(ret, crate::types::Type::Int | crate::types::Type::Float) {
-                wrapper_return = true;
-            }
+        if let Some((_params, ret, _effects)) = ctx.fn_sigs.get(name)
+            && !matches!(ret, crate::types::Type::Int | crate::types::Type::Float)
+        {
+            wrapper_return = true;
         }
     }
 

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -161,6 +161,21 @@ fn emit_simp_omega_law(
             if fd.params.iter().any(|(_, t)| t != "Int") {
                 return None;
             }
+            // Reject wrapped return types (Result, Option, List,
+            // Tuple, …). `simp [fn] <;> omega` unfolds the body but
+            // omega only closes linear-arithmetic goals on Int; a
+            // wrapper-equality goal like `Except.ok x = Except.ok y`
+            // leaves a constructor mismatch omega can't see. Without
+            // this guard, generator emits an auto-proof that
+            // typechecks against the body but lake fails with
+            // `omega could not prove the goal` — exactly the failure
+            // the sound-proof Natural example triggered, where
+            // `safeSum` returns `Result<Int, String>` and walks
+            // through `Modules.Natural.Natural.add`'s `Except`.
+            // Plain `Int` / `Float` returns stay on the omega path.
+            if fd.return_type != "Int" && fd.return_type != "Float" {
+                return None;
+            }
         }
     }
     let lean_names: Vec<String> = fn_names.iter().map(|n| aver_name_to_lean(n)).collect();

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1294,7 +1294,7 @@ fn transpile_unified(
     for module in &ctx.modules {
         let mut body_sections: Vec<String> = Vec::new();
         for td in &module.type_defs {
-            body_sections.push(toplevel::emit_type_def(td));
+            body_sections.push(toplevel::emit_type_def(td, ctx));
             if toplevel::is_recursive_type_def(td) {
                 body_sections.push(toplevel::emit_recursive_decidable_eq(
                     toplevel::type_def_name(td),
@@ -1347,7 +1347,7 @@ fn transpile_unified(
     // ---- Entry sections ----
     let mut entry_body_sections: Vec<String> = Vec::new();
     for td in &ctx.type_defs {
-        entry_body_sections.push(toplevel::emit_type_def(td));
+        entry_body_sections.push(toplevel::emit_type_def(td, ctx));
         if toplevel::is_recursive_type_def(td) {
             entry_body_sections.push(toplevel::emit_recursive_decidable_eq(
                 toplevel::type_def_name(td),

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1584,8 +1584,19 @@ fn emit_verify_law_block(
             .join(" ∧ ");
         match verify_mode {
             VerifyEmitMode::NativeDecide => {
+                // `checked_domain` is one nested ∧-conjunction with N
+                // implications. When the law's case body produces a
+                // wrapper type (Result → `Except String T`, Option →
+                // `Option T`), Lean's default `synthInstance.maxSize`
+                // (~200) is too small to reach `DecidableEq` through
+                // the wrapper instance at ~16+ conjuncts — `native_
+                // decide` then dies with `failed to synthesize
+                // Decidable`. Bumping the budget locally to the theorem
+                // is cheaper than rewriting the emitter to fan the
+                // cases out into N separate theorems (the per-case
+                // `sample_N` theorems below already cover that view).
                 lines.push(format!(
-                    "theorem {} : {} := by native_decide",
+                    "set_option synthInstance.maxSize 4096 in\ntheorem {} : {} := by native_decide",
                     domain_theorem_name, domain_prop
                 ));
             }

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -28,10 +28,10 @@ fn bounded_oracle_subtype_for(method: &str) -> Option<&'static str> {
     }
 }
 
-pub fn emit_type_def(td: &TypeDef) -> String {
+pub fn emit_type_def(td: &TypeDef, ctx: &CodegenContext) -> String {
     match td {
         TypeDef::Sum { name, variants, .. } => emit_sum_type(name, variants),
-        TypeDef::Product { name, fields, .. } => emit_product_type(name, fields),
+        TypeDef::Product { name, fields, .. } => emit_product_type(name, fields, ctx),
     }
 }
 
@@ -78,7 +78,19 @@ fn emit_sum_type(name: &str, variants: &[TypeVariant]) -> String {
     lines.join("\n")
 }
 
-fn emit_product_type(name: &str, fields: &[(String, String)]) -> String {
+fn emit_product_type(name: &str, fields: &[(String, String)], ctx: &CodegenContext) -> String {
+    // Refinement detection lives in `refinement_info_for` (common.rs)
+    // — kept around as foundation for a future Subtype-based refactor
+    // that would eliminate the by_cases / unfold / simp heuristic in
+    // `law_auto.rs`. Not wired here yet: switching from `structure
+    // X { value : T }` to `abbrev X := { v : T // P v }` breaks the
+    // currently-generated theorem statements (they quantify over the
+    // carrier `Int` and construct `Natural(value = a)` inside the
+    // type, which under Subtype needs an in-type proof `(a : Int)
+    // → ... → ⟨a, proof⟩` that the law emitter doesn't know how to
+    // produce yet). Real refactor is a separate design task.
+    let _ = ctx;
+
     let mut lines = Vec::new();
     let is_recursive = is_recursive_product(name, fields);
 


### PR DESCRIPTION
## Summary

Adds the canonical \"make your own Nat\" pattern in examples, and fixes Lean codegen so it actually verifies for the sound-proof variant.

**Example** (\`examples/modules/natural/\`):
- record exposed opaque
- validating smart constructor (\`fromInt\`)
- arithmetic returning \`Result<Nat, String>\` (overflow → Err, no silent wrap-around)
- consumer side in \`natural_app.av\` demonstrating cross-module use through the exposed API only

The example covers the gap that's interesting per se:

| stage | result |
|---|---|
| \`aver verify\` (declared given) | 42/42 ✓ |
| \`aver verify --hostile\` (boundary values + i64 MIN/MAX) | 60/108 ✓, 0 fail |
| \`aver proof --backend dafny\` (Z3) | 12/12 lemmas verified, including ∀ a, b int. a, b ≥ 0 → add_commutative |
| \`aver proof --backend lean\` (with this PR) | ALL theorems check |

A naive \`add(a, b) = Nat(value = a.value + b.value)\` variant is fully provable in Lean / Dafny for unbounded ints but wrong on the Aver runtime (i64 wraps; \`add(MAX, 1) = MIN < 0\` breaks the Nat invariant). This example takes the sound-proof shape — closes the gap between matematical proof and VM semantics — and shows what gets verified through each backend.

**Lean fix**: \`add\` returning \`Except String Natural\` makes the per-law \`checked_domain\` theorem a 16-conjunct ∧ of implications whose RHS is an \`=\` over the wrapper. Lean's default \`synthInstance.maxSize\` (~200) is too small for \`native_decide\` to reach \`DecidableEq (Except String Natural)\` through the generic Except instance at this depth — dies with \`failed to synthesize Decidable\`. Emit \`set_option synthInstance.maxSize 4096 in\` on the theorem.

Cheaper than fanning the conjunction into N separate theorems (the per-case \`sample_N\` theorems already cover that view).

## Test plan
- [x] \`cargo build --release --features wasm\`
- [x] \`cargo test --release --lib codegen::lean::tests --features wasm\` — 58/58 ok
- [x] \`aver verify\` natural.av + natural_app.av — 48/48 pass with --deps
- [x] \`aver verify --hostile\` — 0 fail
- [x] \`dafny verify Natural.dfy\` — 12 verified, 0 errors
- [x] \`lake build\` on Lean export — succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)