### PR TITLE
lean/proof: emit Int-carrier refinement records as Subtype + lift theorem quantification

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -170,6 +170,165 @@ fn is_ok_constructor_with_identity(
     }
 }
 
+/// Walk `lhs`/`rhs` looking for `RecordCreate { type_name: X, fields:
+/// [(_, Ident(given_name))] }` where `X` is a refinement record whose
+/// carrier matches `given_type`. Returns the refined type name when
+/// found, so callers can lift `given_name`'s quantifier from the
+/// carrier type to the refined type. Without this, theorems would
+/// emit `∀ (a : Int), … RecordCreate(a) …` where the smart-
+/// constructor predicate has to be discharged from `a`'s `when`
+/// clause inside the theorem type — which is exactly what the
+/// previous heuristic-laden auto-proof had to work around.
+pub fn refinement_lift_for_given<'a>(
+    given_name: &str,
+    given_type: &str,
+    lhs: &Spanned<Expr>,
+    rhs: &Spanned<Expr>,
+    ctx: &'a CodegenContext,
+) -> Option<&'a str> {
+    // Float carriers don't get lifted: `Int.add_comm` exists and is
+    // universally provable in Lean's `Int` model, but `Float.add_
+    // comm` doesn't hold across IEEE 754 — `NaN ≠ NaN` blows up
+    // the universal claim. Sample-form assertions (concrete Float
+    // values, no NaN in the declared `given` domain) still pass
+    // through the older auto-proof shape; we only lift when the
+    // underlying arithmetic has a true universal law.
+    if given_type == "Float" {
+        return None;
+    }
+    let mut result: Option<&'a str> = None;
+    search_refinement_wrapper(lhs, given_name, given_type, ctx, &mut result);
+    search_refinement_wrapper(rhs, given_name, given_type, ctx, &mut result);
+    result
+}
+
+fn search_refinement_wrapper<'a>(
+    expr: &Spanned<Expr>,
+    given_name: &str,
+    given_type: &str,
+    ctx: &'a CodegenContext,
+    result: &mut Option<&'a str>,
+) {
+    if result.is_some() {
+        return;
+    }
+    match &expr.node {
+        Expr::RecordCreate { type_name, fields } if fields.len() == 1 => {
+            let (_, fvalue) = &fields[0];
+            let matches_var = matches!(
+                &fvalue.node,
+                Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == given_name
+            );
+            if matches_var
+                && let Some(info) = refinement_info_for(type_name, ctx)
+                && info.carrier_type == given_type
+            {
+                // Need a stable reference into ctx for the returned
+                // &str. `refinement_info_for` returns refs into ctx
+                // already, but we want the *type name* itself; the
+                // name lives in the TypeDef in ctx.items.
+                for item in &ctx.items {
+                    if let TopLevel::TypeDef(TypeDef::Product { name, .. }) = item
+                        && name == type_name
+                    {
+                        *result = Some(name.as_str());
+                        return;
+                    }
+                }
+            }
+            for (_, v) in fields {
+                search_refinement_wrapper(v, given_name, given_type, ctx, result);
+            }
+        }
+        Expr::FnCall(callee, args) => {
+            search_refinement_wrapper(callee, given_name, given_type, ctx, result);
+            for a in args {
+                search_refinement_wrapper(a, given_name, given_type, ctx, result);
+            }
+        }
+        Expr::BinOp(_, l, r) => {
+            search_refinement_wrapper(l, given_name, given_type, ctx, result);
+            search_refinement_wrapper(r, given_name, given_type, ctx, result);
+        }
+        Expr::Attr(o, _) => search_refinement_wrapper(o, given_name, given_type, ctx, result),
+        Expr::Neg(i) | Expr::ErrorProp(i) => {
+            search_refinement_wrapper(i, given_name, given_type, ctx, result);
+        }
+        Expr::Match { subject, arms } => {
+            search_refinement_wrapper(subject, given_name, given_type, ctx, result);
+            for arm in arms {
+                search_refinement_wrapper(&arm.body, given_name, given_type, ctx, result);
+            }
+        }
+        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+            for it in items {
+                search_refinement_wrapper(it, given_name, given_type, ctx, result);
+            }
+        }
+        Expr::Constructor(_, Some(arg)) => {
+            search_refinement_wrapper(arg, given_name, given_type, ctx, result);
+        }
+        _ => {}
+    }
+}
+
+/// Strip `RecordCreate { type_name: X, fields: [(_, Ident(g))] }` →
+/// `Ident(g)` when `g` is in `lifted_vars` and `X` is the refined
+/// type those vars were lifted to. Used after `refinement_lift_for_
+/// given` decides the lift: theorem body talks about `g : Natural`
+/// directly, so the `Natural(value = g)` wrapper that aver source
+/// wrote becomes redundant noise.
+pub fn strip_refinement_wrappers(
+    expr: &Spanned<Expr>,
+    lifted_vars: &std::collections::HashMap<String, String>,
+    ctx: &CodegenContext,
+) -> Spanned<Expr> {
+    let new_node = match &expr.node {
+        Expr::RecordCreate { type_name, fields } if fields.len() == 1 => {
+            let (_, fvalue) = &fields[0];
+            let var_name = match &fvalue.node {
+                Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.clone()),
+                _ => None,
+            };
+            if let Some(name) = var_name
+                && let Some(refined) = lifted_vars.get(&name)
+                && refined == type_name
+            {
+                return Spanned::new(Expr::Ident(name), expr.line);
+            }
+            let new_fields: Vec<(String, Spanned<Expr>)> = fields
+                .iter()
+                .map(|(n, v)| (n.clone(), strip_refinement_wrappers(v, lifted_vars, ctx)))
+                .collect();
+            Expr::RecordCreate {
+                type_name: type_name.clone(),
+                fields: new_fields,
+            }
+        }
+        Expr::FnCall(callee, args) => Expr::FnCall(
+            Box::new(strip_refinement_wrappers(callee, lifted_vars, ctx)),
+            args.iter()
+                .map(|a| strip_refinement_wrappers(a, lifted_vars, ctx))
+                .collect(),
+        ),
+        Expr::BinOp(op, l, r) => Expr::BinOp(
+            *op,
+            Box::new(strip_refinement_wrappers(l, lifted_vars, ctx)),
+            Box::new(strip_refinement_wrappers(r, lifted_vars, ctx)),
+        ),
+        Expr::Attr(o, f) => Expr::Attr(
+            Box::new(strip_refinement_wrappers(o, lifted_vars, ctx)),
+            f.clone(),
+        ),
+        Expr::Neg(i) => Expr::Neg(Box::new(strip_refinement_wrappers(i, lifted_vars, ctx))),
+        Expr::ErrorProp(i) => {
+            Expr::ErrorProp(Box::new(strip_refinement_wrappers(i, lifted_vars, ctx)))
+        }
+        _ => expr.node.clone(),
+    };
+    Spanned::new(new_node, expr.line)
+}
+
 fn is_err_constructor(expr: &Spanned<Expr>) -> bool {
     match &expr.node {
         Expr::Constructor(name, Some(_)) => name == "Result.Err",

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -281,7 +281,6 @@ fn search_refinement_wrapper<'a>(
 pub fn strip_refinement_wrappers(
     expr: &Spanned<Expr>,
     lifted_vars: &std::collections::HashMap<String, String>,
-    ctx: &CodegenContext,
 ) -> Spanned<Expr> {
     let new_node = match &expr.node {
         Expr::RecordCreate { type_name, fields } if fields.len() == 1 => {
@@ -298,7 +297,7 @@ pub fn strip_refinement_wrappers(
             }
             let new_fields: Vec<(String, Spanned<Expr>)> = fields
                 .iter()
-                .map(|(n, v)| (n.clone(), strip_refinement_wrappers(v, lifted_vars, ctx)))
+                .map(|(n, v)| (n.clone(), strip_refinement_wrappers(v, lifted_vars)))
                 .collect();
             Expr::RecordCreate {
                 type_name: type_name.clone(),
@@ -306,24 +305,22 @@ pub fn strip_refinement_wrappers(
             }
         }
         Expr::FnCall(callee, args) => Expr::FnCall(
-            Box::new(strip_refinement_wrappers(callee, lifted_vars, ctx)),
+            Box::new(strip_refinement_wrappers(callee, lifted_vars)),
             args.iter()
-                .map(|a| strip_refinement_wrappers(a, lifted_vars, ctx))
+                .map(|a| strip_refinement_wrappers(a, lifted_vars))
                 .collect(),
         ),
         Expr::BinOp(op, l, r) => Expr::BinOp(
             *op,
-            Box::new(strip_refinement_wrappers(l, lifted_vars, ctx)),
-            Box::new(strip_refinement_wrappers(r, lifted_vars, ctx)),
+            Box::new(strip_refinement_wrappers(l, lifted_vars)),
+            Box::new(strip_refinement_wrappers(r, lifted_vars)),
         ),
         Expr::Attr(o, f) => Expr::Attr(
-            Box::new(strip_refinement_wrappers(o, lifted_vars, ctx)),
+            Box::new(strip_refinement_wrappers(o, lifted_vars)),
             f.clone(),
         ),
-        Expr::Neg(i) => Expr::Neg(Box::new(strip_refinement_wrappers(i, lifted_vars, ctx))),
-        Expr::ErrorProp(i) => {
-            Expr::ErrorProp(Box::new(strip_refinement_wrappers(i, lifted_vars, ctx)))
-        }
+        Expr::Neg(i) => Expr::Neg(Box::new(strip_refinement_wrappers(i, lifted_vars))),
+        Expr::ErrorProp(i) => Expr::ErrorProp(Box::new(strip_refinement_wrappers(i, lifted_vars))),
         _ => expr.node.clone(),
     };
     Spanned::new(new_node, expr.line)

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -12,6 +12,23 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
         Expr::Literal(lit) => emit_literal(lit),
         Expr::Ident(name) | Expr::Resolved { name, .. } => aver_name_to_lean(name),
         Expr::Attr(obj, field) => {
+            // Refinement-via-opaque records emit as Lean `Subtype`,
+            // so the carrier field projects through `.val` instead
+            // of the source-named `.carrier_field`. Detect by the
+            // typechecker stamp on the host expression.
+            if let Some(crate::types::Type::Named(t_name)) = obj.ty()
+                && let Some(info) = crate::codegen::common::refinement_info_for(t_name, ctx)
+                && info.carrier_type == "Int"
+                && field == info.carrier_field
+            {
+                let obj_str = emit_expr(obj, ctx);
+                let needs_parens = !matches!(&obj.node, Expr::Ident(_) | Expr::Resolved { .. });
+                return if needs_parens {
+                    format!("({obj_str}).val")
+                } else {
+                    format!("{obj_str}.val")
+                };
+            }
             if let Expr::Ident(type_name) = &obj.node {
                 // Option.None → none
                 if type_name == "Option" && field == "None" {
@@ -115,6 +132,38 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             }
         }
         Expr::RecordCreate { type_name, fields } => {
+            // Refinement-via-opaque types emit as Lean `Subtype`,
+            // so construction is `⟨value, proof⟩`. The proof
+            // obligation is whatever predicate the smart
+            // constructor branches on; we emit `by omega` because:
+            //   * for `if h : pred then ⟨v, _⟩ else …` shapes the
+            //     dependent-if binding `h` is in scope and omega
+            //     picks it up automatically.
+            //   * for literal sample positions (`⟨7, _⟩` in a
+            //     theorem about `7 ≥ 0`) omega closes by constant
+            //     evaluation.
+            //   * for law-quantified positions where the law's
+            //     `when` clause guarantees the predicate, the
+            //     quant-lifter (toplevel.rs) emits the refined
+            //     type directly so RecordCreate never appears
+            //     against a free Int — only against concrete
+            //     samples and intro-bound values.
+            // Refinement records emit as Subtype only when the
+            // carrier is `Int` (see emit_product_type for the
+            // matching guard). Float-carrier records keep the
+            // structure shape and a plain `{ value := … }` record
+            // literal, so this fast-path is gated on the carrier
+            // matching.
+            if let Some(info) = crate::codegen::common::refinement_info_for(type_name, ctx)
+                && info.carrier_type == "Int"
+                && fields.len() == 1
+            {
+                let (_, value_expr) = &fields[0];
+                let value_str = emit_expr(value_expr, ctx);
+                return format!(
+                    "⟨{value_str}, by first | omega | decide | (simp_all; omega) | assumption⟩"
+                );
+            }
             let parts: Vec<String> = fields
                 .iter()
                 .map(|(name, expr)| {
@@ -354,7 +403,16 @@ fn emit_match(
         let cond = emit_expr(subject, ctx);
         let t = emit_expr(true_body, ctx);
         let f = emit_expr(false_body, ctx);
-        let _ = line;
+        // Dependent `if h : cond then T else F` ONLY when the true
+        // branch contains a refinement-Subtype constructor — those
+        // need the predicate as a hypothesis in scope to discharge
+        // their `by omega` proof obligation. Plain `if` everywhere
+        // else keeps spec-equivalence and other auto-provers (which
+        // pattern-match on the plain `if`-shape) working.
+        if true_body_uses_refinement_subtype(true_body, ctx) {
+            let hyp = format!("h_{line}");
+            return format!("if {hyp} : {cond} then {t}\n  else {f}");
+        }
         return format!("if {cond} then {t}\n  else {f}");
     }
     let subj = emit_expr(subject, ctx);
@@ -390,6 +448,34 @@ fn emit_match(
     // tolerant of any future re-introduction of named binders.
     let _ = line;
     format!("match {} with\n{}", subj, arm_strs.join("\n"))
+}
+
+/// True iff `expr` (recursively) contains a `RecordCreate` whose
+/// type is an Int-carrier refinement record — i.e. one we'll emit
+/// as a Lean Subtype constructor `⟨val, by omega⟩` that needs the
+/// surrounding `if`'s predicate as a hypothesis. Used to decide
+/// when the enclosing Bool match should emit dependent-`if h :
+/// cond then …`.
+fn true_body_uses_refinement_subtype(expr: &Spanned<Expr>, ctx: &CodegenContext) -> bool {
+    match &expr.node {
+        Expr::RecordCreate { type_name, .. } => {
+            crate::codegen::common::refinement_info_for(type_name, ctx)
+                .map(|info| info.carrier_type == "Int")
+                .unwrap_or(false)
+        }
+        Expr::FnCall(callee, args) => {
+            true_body_uses_refinement_subtype(callee, ctx)
+                || args
+                    .iter()
+                    .any(|a| true_body_uses_refinement_subtype(a, ctx))
+        }
+        Expr::Constructor(_, Some(arg)) => true_body_uses_refinement_subtype(arg, ctx),
+        Expr::Attr(o, _) => true_body_uses_refinement_subtype(o, ctx),
+        Expr::Match { arms, .. } => arms
+            .iter()
+            .any(|arm| true_body_uses_refinement_subtype(&arm.body, ctx)),
+        _ => false,
+    }
 }
 
 /// If all arms are `true -> expr` and `false -> expr`, return (true_body, false_body).

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1461,12 +1461,12 @@ fn emit_verify_law_block(
     let law_lhs = if lifted_vars.is_empty() {
         law_lhs
     } else {
-        crate::codegen::common::strip_refinement_wrappers(&law_lhs, &lifted_vars, ctx)
+        crate::codegen::common::strip_refinement_wrappers(&law_lhs, &lifted_vars)
     };
     let law_rhs = if lifted_vars.is_empty() {
         law_rhs
     } else {
-        crate::codegen::common::strip_refinement_wrappers(&law_rhs, &lifted_vars, ctx)
+        crate::codegen::common::strip_refinement_wrappers(&law_rhs, &lifted_vars)
     };
     let lhs_template = emit_expr(&law_lhs, ctx);
     let rhs_template = emit_expr(&law_rhs, ctx);
@@ -1603,11 +1603,9 @@ fn emit_verify_law_block(
                         && snapshot.contains(&fd.name)
                     {
                         for stmt in fd.body.stmts() {
-                            if let crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) =
-                                stmt
-                            {
-                                collect_user_fn_calls(e, &mut fn_names);
-                            }
+                            let (crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e)) =
+                                stmt;
+                            collect_user_fn_calls(e, &mut fn_names);
                         }
                     }
                 }

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -79,17 +79,23 @@ fn emit_sum_type(name: &str, variants: &[TypeVariant]) -> String {
 }
 
 fn emit_product_type(name: &str, fields: &[(String, String)], ctx: &CodegenContext) -> String {
-    // Refinement detection lives in `refinement_info_for` (common.rs)
-    // — kept around as foundation for a future Subtype-based refactor
-    // that would eliminate the by_cases / unfold / simp heuristic in
-    // `law_auto.rs`. Not wired here yet: switching from `structure
-    // X { value : T }` to `abbrev X := { v : T // P v }` breaks the
-    // currently-generated theorem statements (they quantify over the
-    // carrier `Int` and construct `Natural(value = a)` inside the
-    // type, which under Subtype needs an in-type proof `(a : Int)
-    // → ... → ⟨a, proof⟩` that the law emitter doesn't know how to
-    // produce yet). Real refactor is a separate design task.
-    let _ = ctx;
+    // Refinement-via-opaque records emit as Lean `Subtype` only
+    // when the carrier is `Int`. Float-carrier records (NonNegFloat,
+    // Discount, …) stay as plain `structure`, because Lean's `Float`
+    // model doesn't admit universal arithmetic laws (IEEE 754: `NaN
+    // ≠ NaN`, `+` not commutative across infinities), so the lift
+    // would just produce uniwersalne theorems we can't prove. The
+    // existing sample-based path covers them: domain values come
+    // from `given a: Float = […]`, and proofs are sample-by-sample
+    // via native_decide.
+    if let Some(info) = crate::codegen::common::refinement_info_for(name, ctx)
+        && info.carrier_type == "Int"
+    {
+        let carrier_ty = type_annotation_to_lean(info.carrier_type);
+        let param = aver_name_to_lean(info.param_name);
+        let predicate = super::expr::emit_expr(info.predicate, ctx);
+        return format!("abbrev {name} := {{ {param} : {carrier_ty} // {predicate} }}");
+    }
 
     let mut lines = Vec::new();
     let is_recursive = is_recursive_product(name, fields);
@@ -1429,6 +1435,39 @@ fn emit_verify_law_block(
         ctx,
         crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
     );
+    // Refinement quantifier lift: when a given Int variable shows up
+    // in the law body wrapped in a refinement-record constructor
+    // (`Natural(value = a)`, `Positive(value = a)`, …), lift the
+    // quantifier from the carrier type to the refined type so the
+    // theorem statement reads `∀ (a : Natural), …` instead of
+    // `∀ (a : Int), … Natural(value = a) …`. Strip the wrapper
+    // constructor in the body templates so they read as
+    // `add a b`, not `add (Natural(value = a)) (Natural(value = b))`.
+    // The smart-constructor predicate ceases to be a per-case proof
+    // obligation — it's already carried by the type.
+    let mut lifted_vars: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    for given in &law.givens {
+        if let Some(refined) = crate::codegen::common::refinement_lift_for_given(
+            &given.name,
+            &given.type_name,
+            &law_lhs,
+            &law_rhs,
+            ctx,
+        ) {
+            lifted_vars.insert(given.name.clone(), refined.to_string());
+        }
+    }
+    let law_lhs = if lifted_vars.is_empty() {
+        law_lhs
+    } else {
+        crate::codegen::common::strip_refinement_wrappers(&law_lhs, &lifted_vars, ctx)
+    };
+    let law_rhs = if lifted_vars.is_empty() {
+        law_rhs
+    } else {
+        crate::codegen::common::strip_refinement_wrappers(&law_rhs, &lifted_vars, ctx)
+    };
     let lhs_template = emit_expr(&law_lhs, ctx);
     let rhs_template = emit_expr(&law_rhs, ctx);
     // The `when` clause references the same oracle bindings the law
@@ -1458,7 +1497,13 @@ fn emit_verify_law_block(
             // `∀ rng : BranchPath → Int → ... → Int`. Other effect
             // kinds (Output, unclassified) keep the plain function
             // signature.
-            let type_text = if let Some(subtype) = bounded_oracle_subtype_for(&given.type_name) {
+            // Refinement lift: quant param `a` lifts from `Int` to
+            // the wrapping refinement record (`Natural`, `Positive`,
+            // …) when the law body used `Natural(value = a)` etc.
+            // See `refinement_lift_for_given` for the detection.
+            let type_text = if let Some(refined) = lifted_vars.get(&given.name) {
+                refined.clone()
+            } else if let Some(subtype) = bounded_oracle_subtype_for(&given.type_name) {
                 subtype.to_string()
             } else {
                 match crate::types::checker::effect_classification::oracle_signature(
@@ -1511,6 +1556,7 @@ fn emit_verify_law_block(
             &lhs_template,
             &rhs_template,
             when_template.as_deref(),
+            &lifted_vars,
         );
         // Oracle v1: the auto-proof matchers compare law.lhs / law.rhs
         // ASTs. For effectful laws the theorem statement has been
@@ -1527,7 +1573,79 @@ fn emit_verify_law_block(
             rhs: law_rhs.clone(),
             sample_guards: law.sample_guards.clone(),
         };
-        if let Some(auto_proof) = emit_verify_law_forall_auto_proof(
+        // Refinement-lifted theorem (∀ a b : Natural, …) closes
+        // through a trivial unfold + `Int.add_comm` / `Int.mul_comm`
+        // rewrite — the Subtype invariant is in the type, so no
+        // by_cases or `simp [hyp]` machinery is needed. Emit
+        // directly here, skipping the auto_proof chain whose
+        // wrapper-return tactic was the last consumer of the
+        // by_cases heuristic.
+        let refinement_auto_proof = if !lifted_vars.is_empty()
+            && matches!(verify_mode, VerifyEmitMode::NativeDecide)
+        {
+            let intro_names: Vec<String> = law
+                .givens
+                .iter()
+                .map(|g| aver_name_to_lean(&g.name))
+                .collect();
+            let mut fn_names = std::collections::BTreeSet::new();
+            collect_user_fn_calls(&law_lhs, &mut fn_names);
+            collect_user_fn_calls(&law_rhs, &mut fn_names);
+            fn_names.insert(vb.fn_name.clone());
+            // Transitively expand so the unfold list reaches every
+            // user fn the law's body walks through (same expansion
+            // strategy as `emit_simp_omega_law` in `law_auto.rs`).
+            loop {
+                let before = fn_names.len();
+                let snapshot: Vec<String> = fn_names.iter().cloned().collect();
+                for item in &ctx.items {
+                    if let crate::ast::TopLevel::FnDef(fd) = item
+                        && snapshot.contains(&fd.name)
+                    {
+                        for stmt in fd.body.stmts() {
+                            if let crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) =
+                                stmt
+                            {
+                                collect_user_fn_calls(e, &mut fn_names);
+                            }
+                        }
+                    }
+                }
+                if fn_names.len() == before {
+                    break;
+                }
+            }
+            // Top-level law fn first so `unfold` sees it in the
+            // goal before transitively-reached callees.
+            let mut ordered: Vec<String> = Vec::new();
+            if fn_names.contains(&vb.fn_name) {
+                ordered.push(vb.fn_name.clone());
+            }
+            for n in &fn_names {
+                if n != &vb.fn_name {
+                    ordered.push(n.clone());
+                }
+            }
+            let lean_names: Vec<String> = ordered.iter().map(|n| aver_name_to_lean(n)).collect();
+            let intro_clause = if intro_names.is_empty() {
+                String::new()
+            } else {
+                format!("  intro {}\n", intro_names.join(" "))
+            };
+            let proof_body = format!(
+                "{intro_clause}  unfold {}\n  simp [Int.add_comm, Int.mul_comm]",
+                lean_names.join(" ")
+            );
+            Some(proof_body)
+        } else {
+            None
+        };
+        if let Some(proof_body) = refinement_auto_proof {
+            lines.push(format!(
+                "theorem {} : ∀ {}, {} := by\n{}",
+                theorem_base, quant_params, theorem_prop, proof_body
+            ));
+        } else if let Some(auto_proof) = emit_verify_law_forall_auto_proof(
             vb,
             &law_for_auto_proof,
             ctx,
@@ -1556,7 +1674,16 @@ fn emit_verify_law_block(
         }
     }
 
-    if !vb.cases.is_empty() {
+    // Skip checked_domain emission for refinement-lifted laws: the
+    // universal theorem already quantifies over the refined type
+    // (`∀ a b : Natural`), which strictly entails any
+    // sample-domain conjunction over the same body. Keeping
+    // checked_domain would emit a 25+ conjunct of `add ⟨v, by …⟩`
+    // calls that Lean has to run `native_decide` against, which
+    // for compound predicates (`Bool.and(n ≥ 0, n ≤ 100)`) blows
+    // through `maxHeartbeats`. The per-case `sample_N` theorems
+    // below still get emitted as a granular cross-check.
+    if !vb.cases.is_empty() && lifted_vars.is_empty() {
         let domain_theorem_name = format!("{}_checked_domain", theorem_base);
         let domain_prop = vb
             .cases
@@ -1680,16 +1807,29 @@ fn law_theorem_prop(
     lhs_template: &str,
     rhs_template: &str,
     when_template: Option<&str>,
+    lifted_vars: &std::collections::HashMap<String, String>,
 ) -> String {
     let mut premises = Vec::new();
     if law.when.is_some() {
-        premises.extend(
-            law.givens
-                .iter()
-                .map(|given| law_given_domain_prop(given, ctx)),
-        );
+        // Lifted vars are quantified over the refinement record
+        // (`a : Natural`), not the carrier `Int`, so the
+        // disjunctive domain premise (`a = 0 ∨ a = 1 ∨ …`) is
+        // type-mismatched (Lean sees `0 : Int` against
+        // `a : Natural`) and the `when a ≥ 0` premise is trivially
+        // entailed by the type's invariant. Skip both for lifted
+        // givens — the universal claim over the refined type is
+        // strictly stronger than a domain-restricted one.
+        premises.extend(law.givens.iter().filter_map(|given| {
+            if lifted_vars.contains_key(&given.name) {
+                None
+            } else {
+                Some(law_given_domain_prop(given, ctx))
+            }
+        }));
     }
-    if let Some(when_expr) = when_template {
+    if let Some(when_expr) = when_template
+        && !law.givens.iter().all(|g| lifted_vars.contains_key(&g.name))
+    {
         premises.push(format!("{when_expr} = true"));
     }
     let conclusion = format!("{lhs_template} = {rhs_template}");
@@ -1896,4 +2036,49 @@ pub fn emit_mutual_group_proof(
 
     lines.push("end".to_string());
     lines.join("\n")
+}
+
+/// Collect user-defined fn names referenced anywhere in `expr`,
+/// following the same last-segment-lowercase filter
+/// `law_auto::collect_fn_calls` uses (skip built-in namespace
+/// handles like `List.len`, keep cross-module `Modules.X.Y.fn`
+/// because their leaf segment starts lower-case).
+fn collect_user_fn_calls(expr: &Spanned<Expr>, out: &mut std::collections::BTreeSet<String>) {
+    match &expr.node {
+        Expr::FnCall(callee, args) => {
+            if let Some(name) = crate::codegen::common::expr_to_dotted_name(&callee.node) {
+                let last = name.rsplit('.').next().unwrap_or(&name);
+                if last.chars().next().is_some_and(|c| c.is_lowercase()) {
+                    out.insert(name);
+                }
+            }
+            for a in args {
+                collect_user_fn_calls(a, out);
+            }
+        }
+        Expr::BinOp(_, l, r) => {
+            collect_user_fn_calls(l, out);
+            collect_user_fn_calls(r, out);
+        }
+        Expr::Attr(o, _) => collect_user_fn_calls(o, out),
+        Expr::Neg(i) | Expr::ErrorProp(i) => collect_user_fn_calls(i, out),
+        Expr::Match { subject, arms } => {
+            collect_user_fn_calls(subject, out);
+            for arm in arms {
+                collect_user_fn_calls(&arm.body, out);
+            }
+        }
+        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+            for it in items {
+                collect_user_fn_calls(it, out);
+            }
+        }
+        Expr::RecordCreate { fields, .. } => {
+            for (_, v) in fields {
+                collect_user_fn_calls(v, out);
+            }
+        }
+        Expr::Constructor(_, Some(arg)) => collect_user_fn_calls(arg, out),
+        _ => {}
+    }
 }


### PR DESCRIPTION
Closes #75.

Replaces ad-hoc \`by_cases\`/\`unfold\`/\`simp\` heuristic in \`law_auto.rs\` with proper dependent-type emission. POC manually verified; this PR wires it through the generator.

## Universal proofs went from ~25-line by_cases to 3-line tactic

Before:
\`\`\`lean
theorem add_law_commutative : ∀ (a : Int) (b : Int), a = 0 ∨ a = 1 ∨ … ->
  b = 0 ∨ … -> ((a >= 0) && (b >= 0)) = true ->
  add (Natural(value := a)) … = … := by
  intro a b
  intro h_a h_b
  rcases h_a with h_a_case | h_a_rest
  · cases h_a_case
    rcases h_b with h_b_case | …
    ··· { 25 more cases }
\`\`\`

After:
\`\`\`lean
abbrev Natural := { n : Int // n >= 0 }
theorem add_law_commutative : ∀ (a : Natural) (b : Natural), add a b = add b a := by
  intro a b
  unfold add fromInt
  simp [Int.add_comm, Int.mul_comm]
\`\`\`

## Mechanism (7 coupled changes)

1. **emit_product_type**: refinement record → \`abbrev X := { v : Int // P v }\` (Int carriers only — Float keeps structure shape because IEEE 754 doesn't admit universal arithmetic laws)
2. **RecordCreate emit**: Int-refined → \`⟨val, by first | omega | decide | (simp_all; omega) | assumption⟩\`
3. **Attr emit**: \`.carrier_field\` on refined → \`.val\` (Subtype projection)
4. **emit_match Bool**: dependent \`if h : cond then T else F\` when true-branch contains a refined RecordCreate; plain \`if\` otherwise (spec-equivalence prover and other matchers stay unaffected)
5. **Quantifier lift** (toplevel.rs): \`given a: Int\` + body \`Natural(value = a)\` → \`∀ (a : Natural), …\`; wrapper stripped from lhs/rhs; \`given\` disjunction + \`when\` premise skipped (refined type carries the invariant)
6. **Universal proof shape**: refinement-lifted laws short-circuit auto_proof chain, emit \`intro; unfold all; simp [Int.add_comm, Int.mul_comm]\`
7. **checked_domain emission**: skipped for refinement-lifted laws (universal entails samples; 25-conjunct of compound-predicate Subtypes blew \`maxHeartbeats\`)

Two new helpers in \`common.rs\`: \`refinement_lift_for_given\` (detect wrapper-pattern in body) and \`strip_refinement_wrappers\` (rewrite to bare ident).

## Test plan
- [x] \`cargo build --release --features wasm\` from repo root
- [x] \`cargo test --release --lib codegen::lean::tests --features wasm\` — 58/58 ok (including \`transpile_auto_proves_guarded_canonical_spec_law_in_auto_mode\` which would have broken under unconditional dependent-if)
- [x] \`lake build\` succeeds on all six refinement examples: Natural, Positive, IntRange (compound \`Bool.and\` predicate), NonNegFloat (Float carrier — stays plain structure path), BigInt (recursive carrier), natural_app (cross-module)
- [x] \`cargo fmt\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)