### PR TITLE
refinement: cross-module lift fix (Lean + Dafny) + sample fuel completeness

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -46,18 +46,33 @@ pub fn refinement_info_for<'a>(
     type_name: &str,
     ctx: &'a CodegenContext,
 ) -> Option<RefinementInfo<'a>> {
-    let (carrier_field, carrier_type) = ctx.items.iter().find_map(|item| match item {
-        TopLevel::TypeDef(TypeDef::Product { name, fields, .. })
-            if name == type_name && fields.len() == 1 =>
-        {
-            let (fname, ftype) = &fields[0];
-            Some((fname.as_str(), ftype.as_str()))
-        }
+    // Refinement records may live in the entry file (`ctx.items`) or
+    // in a dependent module (`ctx.modules[i].type_defs`). Same for
+    // the smart constructor. Walk both so cross-module compilations
+    // (`aver proof natural_app.av` depending on a `Natural` module)
+    // produce the same lifted shape as the standalone module file.
+    let entry_typedefs = ctx.items.iter().filter_map(|item| match item {
+        TopLevel::TypeDef(td) => Some(td),
         _ => None,
-    })?;
+    });
+    let module_typedefs = ctx.modules.iter().flat_map(|m| m.type_defs.iter());
+    let (carrier_field, carrier_type) =
+        entry_typedefs
+            .chain(module_typedefs)
+            .find_map(|td| match td {
+                TypeDef::Product { name, fields, .. } if name == type_name && fields.len() == 1 => {
+                    let (fname, ftype) = &fields[0];
+                    Some((fname.as_str(), ftype.as_str()))
+                }
+                _ => None,
+            })?;
 
-    for item in &ctx.items {
-        let TopLevel::FnDef(fd) = item else { continue };
+    let entry_fns = ctx.items.iter().filter_map(|item| match item {
+        TopLevel::FnDef(fd) => Some(fd),
+        _ => None,
+    });
+    let module_fns = ctx.modules.iter().flat_map(|m| m.fn_defs.iter());
+    for fd in entry_fns.chain(module_fns) {
         if !fd.return_type.starts_with("Result<") {
             continue;
         }
@@ -226,9 +241,15 @@ fn search_refinement_wrapper<'a>(
                 // Need a stable reference into ctx for the returned
                 // &str. `refinement_info_for` returns refs into ctx
                 // already, but we want the *type name* itself; the
-                // name lives in the TypeDef in ctx.items.
-                for item in &ctx.items {
-                    if let TopLevel::TypeDef(TypeDef::Product { name, .. }) = item
+                // name may live in `ctx.items` (standalone build) or
+                // in a dependent module's `type_defs` (cross-module).
+                let entry_tds = ctx.items.iter().filter_map(|i| match i {
+                    TopLevel::TypeDef(td) => Some(td),
+                    _ => None,
+                });
+                let module_tds = ctx.modules.iter().flat_map(|m| m.type_defs.iter());
+                for td in entry_tds.chain(module_tds) {
+                    if let TypeDef::Product { name, .. } = td
                         && name == type_name
                     {
                         *result = Some(name.as_str());

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -574,6 +574,22 @@ fn collect_called_fns(expr: &Spanned<Expr>, out: &mut std::collections::BTreeSet
                 collect_called_fns(e, out);
             }
         }
+        Expr::TailCall(tc) => {
+            let TailCallData { target, args, .. } = tc.as_ref();
+            if !target.contains('.') {
+                out.insert(target.clone());
+            }
+            for a in args {
+                collect_called_fns(a, out);
+            }
+        }
+        Expr::Tuple(elems) | Expr::IndependentProduct(elems, _) => {
+            for e in elems {
+                collect_called_fns(e, out);
+            }
+        }
+        Expr::Attr(obj, _) => collect_called_fns(obj, out),
+        Expr::Neg(inner) => collect_called_fns(inner, out),
         _ => {}
     }
 }
@@ -751,25 +767,39 @@ pub fn emit_law_samples(
             let mut callees = std::collections::BTreeSet::new();
             collect_called_fns(lhs_rw, &mut callees);
             collect_called_fns(rhs_rw, &mut callees);
-            let mut transitive = std::collections::BTreeSet::new();
-            for f in &callees {
-                if let Some(fd) = ctx
-                    .items
-                    .iter()
-                    .filter_map(|i| {
-                        if let TopLevel::FnDef(fd) = i {
-                            Some(fd)
-                        } else {
-                            None
+            // Full transitive closure — 1-level was missing deep
+            // SCC members (addLeft → addStep → addDigits → ...).
+            // Without them, fuel attrs only land on direct callees
+            // and Z3 leaves the rest sealed by their wrappers'
+            // metric, which is enough for `add(0, X)` (recursion
+            // bottoms out immediately) but not for `(X, Y)` with
+            // multi-digit operands.
+            let mut changed = true;
+            while changed {
+                changed = false;
+                let snapshot: Vec<String> = callees.iter().cloned().collect();
+                for f in &snapshot {
+                    if let Some(fd) = ctx
+                        .items
+                        .iter()
+                        .filter_map(|i| {
+                            if let TopLevel::FnDef(fd) = i {
+                                Some(fd)
+                            } else {
+                                None
+                            }
+                        })
+                        .chain(ctx.modules.iter().flat_map(|m| m.fn_defs.iter()))
+                        .find(|fd| &fd.name == f)
+                    {
+                        let before = callees.len();
+                        collect_called_fns_in_body(&fd.body, &mut callees);
+                        if callees.len() != before {
+                            changed = true;
                         }
-                    })
-                    .chain(ctx.modules.iter().flat_map(|m| m.fn_defs.iter()))
-                    .find(|fd| &fd.name == f)
-                {
-                    collect_called_fns_in_body(&fd.body, &mut transitive);
+                    }
                 }
             }
-            callees.extend(transitive);
             let mut fuel_targets: Vec<String> = Vec::new();
             for f in &callees {
                 if !known.contains(f) {
@@ -1055,11 +1085,11 @@ pub fn emit_verify_law(
     // ensures can't be proved from Dafny's side. Match Lean's
     // `sorry` fallback by emitting `assume` over the ensures —
     // users get the same "this lemma is accepted on trust" signal.
+    // (Bounded-∀ form via per-pair sample lemma dispatch was
+    // tried — works for small pairs but Z3 still can't close
+    // samples with large literals like 10⁹ even at fuel 500; see
+    // issue #81 for the follow-up.)
     if law_refs_opaque_fn(&law.lhs, opaque_fns) || law_refs_opaque_fn(&law.rhs, opaque_fns) {
-        // `{:axiom}` on the assume silences Dafny's
-        // "assume statement has no {:axiom} annotation" warning, since
-        // we're explicitly treating this as an axiom on trust (same
-        // shape as Lean's `sorry`).
         lines.push(format!("  assume {{:axiom}} {} == {};", lhs, rhs));
         lines.push("}\n".to_string());
         return lines.join("\n");


### PR DESCRIPTION
## Summary

Two coupled fixes from #81. Bounded-∀ universal (Part 2 of #81) was attempted in this PR and reverted — kept the genuine improvements, see issue for findings.

### Cross-module refinement lift (Lean + Dafny)

`refinement_info_for` in `src/codegen/common.rs` walked only `ctx.items`, never `ctx.modules`. The same `Natural` record emitted differently depending on entry point:

| Entry | Before | After |
|---|---|---|
| `aver proof natural.av` (standalone) | lifted ✓ | lifted ✓ |
| `aver proof natural_app.av --module-root examples` (cross-module) | fallback ✗ | lifted ✓ |

Now both `ctx.items` and `ctx.modules[i].{type_defs, fn_defs}` are searched. Affects both backends (shared helper). Lifted shape is now invariant under entry-point choice.

### Sample-lemma fuel attr completeness (Dafny)

`collect_called_fns` in `src/codegen/dafny/toplevel.rs` was missing `Expr::TailCall`, `Expr::Attr`, `Expr::Tuple`, `Expr::IndependentProduct`, `Expr::Neg`. TCO-transformed tail calls (`Cons -> addLeft(...)` → `Expr::TailCall`) were invisible to the walker, so sample-lemma fuel attrs only covered the directly-called fns. BigInt's `add_commutative__sample_1` had `{:fuel add, addDigits, fromInt}` but no `addLeft`/`addStep`/`addCarryTo` — only worked because `a == 0` samples bottom out before hitting those. Also turned 1-level transitive into fixed-point closure.

### Universal bounded-∀ — open

Attempted full-cross-product sample lemmas + bounded `requires a == k1 || ...` + case-split body dispatching to per-pair lemmas (Lean-parity with `rcases` + `native_decide`). Z3 can't close samples like `add(fromInt(10⁹), fromInt(X))` — fuel 100 → 500 unchanged, because `digitsOf(10⁹) = [0, 1]` produces a 2-digit decomposition and the mutual recursion through `addLeft`/`addStep` can't be symbolically driven to a ground term. Reverted; tracked in #81 with three concrete real fix paths (native decreases-tuple / explicit unfolding hints / domain-size gating).

## Test plan
- [x] Cross-module Lean: `examples/refinement/natural_app.av` emits `abbrev Natural := { n : Int // (n >= 0) }` (was `structure`), `lake build` passes
- [x] Cross-module Dafny: same example emits `type Natural = n: int | (n >= 0) witness 0` (was `datatype`), `dafny verify` passes (6 verified, 0 errors)
- [x] Standalone refinement examples unchanged: natural 16/0, positive 9/0, int_range 9/0, nonneg_float 6/0, bigint 23/0, email 0/0
- [x] `cargo test --release --lib --features wasm` — 630/630

🤖 Generated with [Claude Code](https://claude.com/claude-code)