### PR TITLE
types/checker: reject duplicate type defs + duplicate variant/field names

### DIFF
--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -133,9 +133,47 @@ impl TypeChecker {
             TypeDef::Sum {
                 name: type_name,
                 variants,
-                ..
+                line,
             } => {
                 let canonical_type = canonical_name(module_name, type_name);
+                // Iron-followup: duplicate type defs in the same module
+                // used to silently overwrite via `HashMap::insert`,
+                // leaving the VM symbol table half-populated with the
+                // first variant set and trying to register the second.
+                // `fuzz_verify_runner` crash id:000001 minimised to a
+                // `type Tree ... \n type Tree he canonical Lea` shape
+                // that panicked at `vm/compiler/mod.rs:531 ctor id`
+                // because the arena's variant list belonged to the
+                // first decl but the symbol path used the second.
+                // Reject the duplicate at typecheck so the VM never
+                // sees the inconsistency.
+                if self.fn_sigs.contains_key(&canonical_type) {
+                    self.error_at_line(
+                        *line,
+                        format!("Type '{}' is already defined in this module", type_name),
+                    );
+                    return;
+                }
+                // Iron-followup: same module-level rule applies inside
+                // a single type: two variants with the same name make
+                // the VM symbol table register one ctor key under two
+                // distinct (variant_id, ctor_id) pairs, which the
+                // intern assertion catches as a panic
+                // (`vm/symbol.rs:205` — `fuzz_verify_runner` crash
+                // id:000000). Reject the duplicate at typecheck.
+                let mut seen_variants: std::collections::HashSet<&str> =
+                    std::collections::HashSet::new();
+                for variant in variants {
+                    if !seen_variants.insert(variant.name.as_str()) {
+                        self.error_at_line(
+                            *line,
+                            format!(
+                                "Type '{}': variant '{}' is declared more than once",
+                                type_name, variant.name
+                            ),
+                        );
+                    }
+                }
                 let variant_names: Vec<String> = variants.iter().map(|v| v.name.clone()).collect();
                 // Register variant names for exhaustiveness under both
                 // the canonical and bare keys — exhaustiveness reads
@@ -194,9 +232,37 @@ impl TypeChecker {
             TypeDef::Product {
                 name: type_name,
                 fields,
-                ..
+                line,
             } => {
                 let canonical_type = canonical_name(module_name, type_name);
+                // Same duplicate-type rule as the Sum arm — a record
+                // re-declared in the same module would silently
+                // overwrite the first via `HashMap::insert` and leave
+                // downstream consumers (codegen, VM compiler, refinement
+                // detector) reading whichever copy won the race.
+                if self.fn_sigs.contains_key(&canonical_type) {
+                    self.error_at_line(
+                        *line,
+                        format!("Type '{}' is already defined in this module", type_name),
+                    );
+                    return;
+                }
+                // Duplicate field names in a record — same hazard the
+                // Sum-variant check guards against, just on the
+                // product side.
+                let mut seen_fields: std::collections::HashSet<&str> =
+                    std::collections::HashSet::new();
+                for (fname, _) in fields {
+                    if !seen_fields.insert(fname.as_str()) {
+                        self.error_at_line(
+                            *line,
+                            format!(
+                                "Type '{}': field '{}' is declared more than once",
+                                type_name, fname
+                            ),
+                        );
+                    }
+                }
                 // Record constructors are handled via Expr::RecordCreate
                 // — fn_sigs entry exists so `Ident("TypeName")` resolves
                 // to `Type::Named(bare)` (Iron — A3: source-faithful).

--- a/tests/regressions/verify_runner/duplicate_type_def_panic_at_ctor_id.av
+++ b/tests/regressions/verify_runner/duplicate_type_def_panic_at_ctor_id.av
@@ -1,0 +1,22 @@
+module M
+    intent =
+        "Minimal repro for fuzz_verify_runner crash id:000001."
+        "A second `type T` declaration overwrote the first via"
+        "HashMap::insert in the typechecker's signature table; the"
+        "VM compiler then asked the arena for a ctor id that"
+        "belonged to the first declaration's variant list and"
+        "panicked at vm/compiler/mod.rs:531 with `ctor id`."
+        "Typechecker now rejects duplicate type names so the second"
+        "declaration never reaches codegen."
+
+type T
+    A
+
+type T
+    A
+
+verify dummy
+    1 => 1
+
+fn dummy() -> Int
+    1

--- a/tests/regressions/verify_runner/duplicate_variants_panic_at_symbol_intern.av
+++ b/tests/regressions/verify_runner/duplicate_variants_panic_at_symbol_intern.av
@@ -1,0 +1,19 @@
+module M
+    intent =
+        "Minimal repro for fuzz_verify_runner crash id:000000."
+        "Two variants with the same name in a single sum type made"
+        "the VM symbol table intern the same ctor key under two"
+        "distinct (variant_id, ctor_id) pairs and panic at"
+        "vm/symbol.rs:205 with `assertion left == right failed`."
+        "Typechecker now rejects duplicate variant names so the VM"
+        "never sees the inconsistency."
+
+type T
+    A
+    A
+
+verify dummy
+    1 => 1
+
+fn dummy() -> Int
+    1


### PR DESCRIPTION
## Summary

`fuzz_verify_runner` saved two real crashes on its first post-fix nightly (PR #88 unblocked the queue exploration that had been silently aborting since 2026-05-21):

- **`vm/symbol.rs:205` panic** — single type with two variants of the same name; VM symbol table tried to intern the same ctor key under two distinct `(variant_id, ctor_id)` pairs.
- **`vm/compiler/mod.rs:531 "ctor id"` panic** — two `type T` declarations in the same module; second overwrote the first via `HashMap::insert` in the typechecker's signature table, then the VM compiler asked the arena for a ctor id that belonged to the first declaration's variant list.

Both shapes typechecked cleanly pre-fix — Iron 0.21's duplicate checks covered fn names but not type defs, variant names, or record field names. This PR adds the symmetric checks in `register_type_def_sigs`.

## Test plan

- [x] Both fuzz crash inputs (`/tmp/crash0.av`, `/tmp/crash1.av`) now produce typecheck errors instead of panics
- [x] Minimized regression fixtures landed under `tests/regressions/verify_runner/` — existing `verify_runner_regressions_do_not_hang` gate catches them
- [x] 615 lib tests pass
- [x] No existing example regresses (refinement, formal, data — all build clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)