### PR TITLE
proof export + hostile: tighten classifiers per code-review feedback

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -366,10 +366,7 @@ fn project_lifted_ident_leaf(
     if lifted_vars.contains_key(target_name) {
         Spanned::new(
             Expr::Attr(
-                Box::new(Spanned::new(
-                    Expr::Ident(target_name.clone()),
-                    expr.line,
-                )),
+                Box::new(Spanned::new(Expr::Ident(target_name.clone()), expr.line)),
                 "val".to_string(),
             ),
             expr.line,

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -299,6 +299,86 @@ fn search_refinement_wrapper<'a>(
 /// given` decides the lift: theorem body talks about `g : Natural`
 /// directly, so the `Natural(value = g)` wrapper that aver source
 /// wrote becomes redundant noise.
+/// Rewrite bare references to refinement-lifted given variables
+/// (`a` → `a.val`) inside scalar / arithmetic contexts so the emitted
+/// Lean expression typechecks against the Subtype carrier.
+///
+/// Background: a `verify ... law` with `given a: Int` whose body
+/// wraps `a` in `Natural(value = a)` lifts the quantifier from
+/// `∀ (a : Int)` to `∀ (a : Natural)`. The law's `when` clause stays
+/// in the user's variable space — `when a >= 10` references the bare
+/// `a`, which in Lean is now the Subtype `Natural := { v : Int //
+/// v ≥ 0 }`, NOT the underlying Int. `a >= 10` then fails to
+/// synthesize an `LE Natural` / `OfNat Natural 10` instance.
+///
+/// Transform projects bare lifted-var Idents to `.val` ONLY inside
+/// `BinOp` comparators and the `Bool.and` / `Bool.or` chains the
+/// parser builds for multi-`when` lines. Lifted-var refs in function
+/// arguments (e.g. `add(a, b)` over `a, b : Natural`) stay bare —
+/// those positions DO expect the Subtype carrier, not the underlying
+/// Int. The two cases mirror `strip_refinement_wrappers`'s
+/// counterpart (stripping `Natural(value = a)` → `a` in
+/// function-arg positions).
+pub fn project_lifted_idents_to_val(
+    expr: &Spanned<Expr>,
+    lifted_vars: &std::collections::HashMap<String, String>,
+) -> Spanned<Expr> {
+    if lifted_vars.is_empty() {
+        return expr.clone();
+    }
+    let new_node = match &expr.node {
+        Expr::BinOp(op, l, r) if is_comparator_binop(*op) => {
+            let l_proj = project_lifted_ident_leaf(l, lifted_vars);
+            let r_proj = project_lifted_ident_leaf(r, lifted_vars);
+            Expr::BinOp(*op, Box::new(l_proj), Box::new(r_proj))
+        }
+        Expr::FnCall(callee, args) => {
+            let name = expr_to_dotted_name(&callee.node);
+            if matches!(name.as_deref(), Some("Bool.and") | Some("Bool.or")) {
+                Expr::FnCall(
+                    callee.clone(),
+                    args.iter()
+                        .map(|a| project_lifted_idents_to_val(a, lifted_vars))
+                        .collect(),
+                )
+            } else {
+                return expr.clone();
+            }
+        }
+        _ => return expr.clone(),
+    };
+    Spanned::new(new_node, expr.line)
+}
+
+fn is_comparator_binop(op: crate::ast::BinOp) -> bool {
+    use crate::ast::BinOp::*;
+    matches!(op, Lt | Gt | Lte | Gte | Eq | Neq)
+}
+
+fn project_lifted_ident_leaf(
+    expr: &Spanned<Expr>,
+    lifted_vars: &std::collections::HashMap<String, String>,
+) -> Spanned<Expr> {
+    let target_name = match &expr.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => n,
+        _ => return expr.clone(),
+    };
+    if lifted_vars.contains_key(target_name) {
+        Spanned::new(
+            Expr::Attr(
+                Box::new(Spanned::new(
+                    Expr::Ident(target_name.clone()),
+                    expr.line,
+                )),
+                "val".to_string(),
+            ),
+            expr.line,
+        )
+    } else {
+        expr.clone()
+    }
+}
+
 pub fn strip_refinement_wrappers(
     expr: &Spanned<Expr>,
     lifted_vars: &std::collections::HashMap<String, String>,

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -86,12 +86,18 @@ fn type_to_dafny(ty: &Type) -> String {
     }
 }
 
-/// Find a literal Int witness for a refinement subset type by inspecting
+/// Find a literal Int witness for a refinement subset type. First tries
 /// the smart constructor's verify block (`fromX(K) => Result.Ok(...)` —
-/// the first such `K` satisfies the predicate by definition). Falls back
-/// to `None` when the verify block is missing or has no Ok case with a
-/// literal argument; the caller substitutes `0` in that case.
+/// the first such `K` satisfies the predicate by definition). Falls
+/// back to evaluating the refinement's bool predicate on small
+/// candidates (`[0, 1, -1]`); the first candidate that satisfies the
+/// predicate is a valid Dafny `witness`. Cross-module refinement
+/// records sit in `ctx.modules[i].fn_defs` whose verify blocks are
+/// not surfaced through `ModuleInfo`, so the predicate-eval fallback
+/// is what keeps `type Positive = n: int | (n > 0) witness 1`
+/// emitting correctly when `Positive` is imported as a dependency.
 fn refinement_witness_for(type_name: &str, ctx: &CodegenContext) -> Option<String> {
+    // Entry-module verify-block scan (preserves existing behaviour).
     let smart_ctor_name = ctx.items.iter().find_map(|item| match item {
         TopLevel::FnDef(fd)
             if fd.return_type.starts_with("Result<")
@@ -101,30 +107,110 @@ fn refinement_witness_for(type_name: &str, ctx: &CodegenContext) -> Option<Strin
             Some(fd.name.clone())
         }
         _ => None,
-    })?;
-    for item in &ctx.items {
-        let TopLevel::Verify(vb) = item else {
-            continue;
-        };
-        if vb.fn_name != smart_ctor_name {
-            continue;
-        }
-        for (lhs, rhs) in &vb.cases {
-            if !is_result_ok(&rhs.node) {
-                continue;
-            }
-            let Expr::FnCall(_, args) = &lhs.node else {
+    });
+    if let Some(smart_ctor_name) = smart_ctor_name {
+        for item in &ctx.items {
+            let TopLevel::Verify(vb) = item else {
                 continue;
             };
-            if args.len() != 1 {
+            if vb.fn_name != smart_ctor_name {
                 continue;
             }
-            if let Some(lit) = literal_int_value(&args[0]) {
-                return Some(lit);
+            for (lhs, rhs) in &vb.cases {
+                if !is_result_ok(&rhs.node) {
+                    continue;
+                }
+                let Expr::FnCall(_, args) = &lhs.node else {
+                    continue;
+                };
+                if args.len() != 1 {
+                    continue;
+                }
+                if let Some(lit) = literal_int_value(&args[0]) {
+                    return Some(lit);
+                }
             }
         }
     }
+    // Predicate-eval fallback. Cross-module refinement records can't
+    // surface their verify blocks via `ModuleInfo`, and even the
+    // entry-module path misses types whose smart constructor has no
+    // verify samples. Walk the refinement's bool predicate AST and
+    // pick the first candidate from `[0, 1, -1]` that satisfies it.
+    let info = crate::codegen::common::refinement_info_for(type_name, ctx)?;
+    for candidate in [0i64, 1, -1] {
+        if eval_int_bool_predicate(info.predicate, info.param_name, candidate) == Some(true) {
+            return Some(candidate.to_string());
+        }
+    }
     None
+}
+
+/// Evaluate a simple Bool predicate AST with `param_name` bound to
+/// `value`. Supports comparator BinOps over int arithmetic, `Bool.and`
+/// / `Bool.or`, and bool literals — covers every refinement predicate
+/// shape that `refinement_info_for` accepts today. Returns `None`
+/// when the predicate uses a shape the evaluator can't reduce (e.g. a
+/// fn call to something other than `Bool.and`/`Bool.or`); witness
+/// emission then falls back to `0`.
+fn eval_int_bool_predicate(
+    expr: &Spanned<Expr>,
+    param_name: &str,
+    value: i64,
+) -> Option<bool> {
+    match &expr.node {
+        Expr::Literal(Literal::Bool(b)) => Some(*b),
+        Expr::BinOp(op, l, r) => {
+            use crate::ast::BinOp::*;
+            let li = eval_int_arith(l, param_name, value)?;
+            let ri = eval_int_arith(r, param_name, value)?;
+            Some(match op {
+                Lt => li < ri,
+                Gt => li > ri,
+                Lte => li <= ri,
+                Gte => li >= ri,
+                Eq => li == ri,
+                Neq => li != ri,
+                _ => return None,
+            })
+        }
+        Expr::FnCall(callee, args) if args.len() == 2 => {
+            let name = crate::codegen::common::expr_to_dotted_name(&callee.node)?;
+            match name.as_str() {
+                "Bool.and" => Some(
+                    eval_int_bool_predicate(&args[0], param_name, value)?
+                        && eval_int_bool_predicate(&args[1], param_name, value)?,
+                ),
+                "Bool.or" => Some(
+                    eval_int_bool_predicate(&args[0], param_name, value)?
+                        || eval_int_bool_predicate(&args[1], param_name, value)?,
+                ),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn eval_int_arith(expr: &Spanned<Expr>, param_name: &str, value: i64) -> Option<i64> {
+    match &expr.node {
+        Expr::Literal(Literal::Int(n)) => Some(*n),
+        Expr::Ident(name) | Expr::Resolved { name, .. } if name == param_name => Some(value),
+        Expr::BinOp(op, l, r) => {
+            use crate::ast::BinOp::*;
+            let li = eval_int_arith(l, param_name, value)?;
+            let ri = eval_int_arith(r, param_name, value)?;
+            match op {
+                Add => Some(li.checked_add(ri)?),
+                Sub => Some(li.checked_sub(ri)?),
+                Mul => Some(li.checked_mul(ri)?),
+                Div => Some(li.checked_div(ri)?),
+                _ => None,
+            }
+        }
+        Expr::Neg(inner) => Some(-eval_int_arith(inner, param_name, value)?),
+        _ => None,
+    }
 }
 
 fn is_result_ok(expr: &Expr) -> bool {

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -153,11 +153,7 @@ fn refinement_witness_for(type_name: &str, ctx: &CodegenContext) -> Option<Strin
 /// when the predicate uses a shape the evaluator can't reduce (e.g. a
 /// fn call to something other than `Bool.and`/`Bool.or`); witness
 /// emission then falls back to `0`.
-fn eval_int_bool_predicate(
-    expr: &Spanned<Expr>,
-    param_name: &str,
-    value: i64,
-) -> Option<bool> {
+fn eval_int_bool_predicate(expr: &Spanned<Expr>, param_name: &str, value: i64) -> Option<bool> {
     match &expr.node {
         Expr::Literal(Literal::Bool(b)) => Some(*b),
         Expr::BinOp(op, l, r) => {

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -3289,14 +3289,23 @@ verify mirror law involutive
         let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
         let lean = generated_lean_file(&out);
         // `when a >= 10` is STRONGER than Natural's `n >= 0` invariant
-        // so the universal theorem must keep it as a premise.
+        // so the universal theorem must keep it as a premise — AND
+        // project `a` to `a.val` because the quantifier is now over
+        // the Subtype carrier, not the underlying Int. The bare-`a`
+        // shape would fail `lake build` with `failed to synthesize LE
+        // Natural / OfNat Natural 10`.
         let universal_theorem = lean
             .lines()
             .find(|l| l.contains("theorem identity_law_selfEq"))
             .unwrap_or_else(|| panic!("expected universal theorem line, got:\n{}", lean));
         assert!(
-            universal_theorem.contains("a >= 10"),
-            "expected `when a >= 10` to stay in universal theorem premise, got:\n{}",
+            universal_theorem.contains("a.val >= 10"),
+            "expected `when a.val >= 10` (projected) in universal theorem premise, got:\n{}",
+            universal_theorem
+        );
+        assert!(
+            !universal_theorem.contains(" a >= 10"),
+            "must NOT emit bare `a >= 10` — Subtype carrier has no `LE Natural` instance, got:\n{}",
             universal_theorem
         );
     }
@@ -3399,14 +3408,18 @@ verify mirror law involutive
     }
 
     #[test]
-    fn proof_mode_caller_with_compound_interval_guard_synthesizes_conjunction() {
-        // Issue 84 generalisation: a single caller wraps the callsite in
-        // nested `match (n > 2) { true -> match (n < 500) { true ->
-        // worker(n) }}` guards. The classifier extracts both predicates
-        // (positive form, in callee's variable space) and the Lean
-        // emitter joins them with `∧` for the aux's precondition. Same
-        // pattern opaque types use for smart-constructor predicates —
-        // single source-of-truth Spanned<Expr> representation.
+    fn proof_mode_non_zero_base_literal_falls_back_to_fuel() {
+        // Conservative guard: native IntCountdownGuarded emit assumes
+        // the aux's default `(h_dom : p ≥ 0)` precondition, under
+        // which only `match p { 0 -> ... }` proves preservation
+        // (wildcard arm gives `p ≠ 0`, with `p ≥ 0` that's `p ≥ 1`,
+        // so `p - 1 ≥ 0`). A non-zero base literal like `match p { 5
+        // -> ... }` would let `p = 0` reach the wildcard arm and
+        // recurse with `p - 1 = -1`, breaking the precondition.
+        // `omega` would rightly reject it at lake build. Compiler
+        // must reject the shape upfront — generalising to arbitrary
+        // literals needs a real preservation check that doesn't
+        // exist yet (follow-up). Falls back to fuel encoding.
         let src = "module Worker\n\
              \x20   intent = \"t\"\n\
              \n\
@@ -3425,38 +3438,15 @@ verify mirror law involutive
         let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
         let lean = generated_lean_file(&out);
         assert!(
-            lean.contains("def worker__aux (n : Int) (h_dom : ((n > 2)) ∧ ((n < 500))) : Int :="),
-            "expected aux with ∧-joined caller-derived predicate, got:\n{}",
-            lean
-        );
-        // Body literal is `3`, not `0`, so the dependent-if splits on
-        // `n = 3`. This aligns with the caller's lower bound (`n > 2`)
-        // — preservation: `(n > 2 ∧ n < 500 ∧ n ≠ 3) → (n - 1 > 2 ∧ n -
-        // 1 < 500)` is exactly the linear-integer claim omega closes
-        // at the recursive callsite.
-        assert!(
-            lean.contains("if h_zero : n = 3 then n"),
-            "expected dependent-if on literal 3 with body-arm value, got:\n{}",
+            !lean.contains("worker__aux"),
+            "must NOT emit native aux when base literal != 0 — preservation isn't provable without a real linear-int check; got:\n{}",
             lean
         );
         assert!(
-            lean.contains("else worker__aux (n - 1) (by omega)"),
-            "expected rec call carrying (by omega), got:\n{}",
+            lean.contains("def worker__fuel"),
+            "expected fuel fallback for non-zero base literal, got:\n{}",
             lean
         );
-        assert!(
-            lean.contains("if h_dom : ((n > 2)) ∧ ((n < 500)) then worker__aux n h_dom"),
-            "expected wrapper dispatching on conjunction, got:\n{}",
-            lean
-        );
-        // Wrapper's else falls back to the body's literal-arm value
-        // (`n` here — the source's `3 -> n` arm).
-        assert!(
-            lean.contains("else n"),
-            "expected wrapper else falling through to base, got:\n{}",
-            lean
-        );
-        assert!(!lean.contains("def worker__fuel"));
     }
 
     #[test]

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1715,13 +1715,21 @@ fn emit_verify_law_block(
     // against a `RandomIntInBounds` parameter and Lean would reject
     // the type mismatch.
     let when_template = law.when.as_ref().map(|expr| {
-        let projected = crate::codegen::common::rewrite_effectful_calls_in_law(
+        let oracle_projected = crate::codegen::common::rewrite_effectful_calls_in_law(
             expr,
             law,
             ctx,
             crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
         );
-        emit_expr(&projected, ctx)
+        // Refinement lift: bare references to lifted-given idents
+        // inside `when`'s comparator BinOps need `.val` projection
+        // because the quantifier is now over the Subtype carrier,
+        // not the underlying Int. Without this `when a >= 10` over
+        // `a : Natural` emits as `a >= 10` and fails to synthesize
+        // `LE Natural` / `OfNat Natural 10` in Lean.
+        let val_projected =
+            crate::codegen::common::project_lifted_idents_to_val(&oracle_projected, &lifted_vars);
+        emit_expr(&val_projected, ctx)
     });
     let quant_params = law
         .givens

--- a/src/codegen/recursion/detect.rs
+++ b/src/codegen/recursion/detect.rs
@@ -447,6 +447,22 @@ pub(crate) fn int_countdown_native_arms(
     let (literal_value, literal_arm_body) = literal_arm?;
     let wildcard_arm_body = wildcard_arm_body?;
 
+    // Lean native emit assumes the default `(h_dom : p ≥ 0)`
+    // precondition; under that, the wildcard arm constraint `p ≠ L`
+    // combined with `p ≥ 0` must imply `p ≥ 1` so the recursive call
+    // `f(p - 1)` lands in-domain. That holds only when `L == 0`. A
+    // shape like `match n { 5 -> base; _ -> f(n - 1) }` would let
+    // `n = 0` reach the wildcard arm, recurse with `n - 1 = -1`, and
+    // break the precondition — `omega` rightly rejects this at lake
+    // build. Generalising to arbitrary literals needs a proper
+    // preservation check over (precondition ∧ arm-constraint ⊢
+    // f-args-in-domain) and a non-default precondition derived from
+    // the caller's guards; until that's in, restrict native emit to
+    // the literal-zero shape and fall back to fuel otherwise.
+    if literal_value != 0 {
+        return None;
+    }
+
     let mut lit_calls = Vec::new();
     collect_calls_from_expr(&literal_arm_body, &mut lit_calls);
     if lit_calls.iter().any(|(n, _)| call_matches(n, &fd.name)) {

--- a/src/diagnostics/vm_verify.rs
+++ b/src/diagnostics/vm_verify.rs
@@ -203,19 +203,126 @@ pub(crate) fn apply_hostile_expansion(
     Ok(())
 }
 
-/// Walk the fn's body looking for any `Expr::IndependentProduct`,
-/// which lowers to the VM `CALL_PAR` opcode. Only laws whose fn
-/// contains one of these have anything to gain from the order-axis
-/// hostile twin — for every other shape, reverse-eval is a no-op
+/// Walk the fn's body and every transitively-reachable callee
+/// looking for any `Expr::IndependentProduct`, which lowers to the
+/// VM `CALL_PAR` opcode. Only laws whose call-graph closure contains
+/// one of these have anything to gain from the order-axis hostile
+/// twin — for every other shape, reverse-eval is a no-op
 /// (sequential evaluation) and the twin would just double cost.
+///
+/// Transitive coverage matters: a wrapper that calls a helper which
+/// itself contains `(a, b)!` is order-sensitive, but the root fn's
+/// own body doesn't show that. Pre-fix this gate ran only against
+/// `block.fn_name`'s body and silently skipped the reverse-eval
+/// twin for those shapes, so hostile mode missed real order bugs in
+/// transitively-called helpers.
 fn fn_body_uses_independent_product(block: &VerifyBlock, items: &[TopLevel]) -> bool {
-    let Some(fn_def) = items.iter().find_map(|i| match i {
-        TopLevel::FnDef(fd) if fd.name == block.fn_name => Some(fd),
-        _ => None,
-    }) else {
-        return false;
-    };
-    fn_body_contains_independent_product(&fn_def.body)
+    let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut stack: Vec<String> = vec![block.fn_name.clone()];
+    while let Some(name) = stack.pop() {
+        if !visited.insert(name.clone()) {
+            continue;
+        }
+        let Some(fn_def) = items.iter().find_map(|i| match i {
+            TopLevel::FnDef(fd) if fd.name == name => Some(fd),
+            _ => None,
+        }) else {
+            continue;
+        };
+        if fn_body_contains_independent_product(&fn_def.body) {
+            return true;
+        }
+        let mut callees = std::collections::HashSet::new();
+        for stmt in fn_def.body.stmts() {
+            match stmt {
+                crate::ast::Stmt::Expr(e) | crate::ast::Stmt::Binding(_, _, e) => {
+                    collect_fn_call_names(&e.node, &mut callees);
+                }
+            }
+        }
+        for callee in callees {
+            if !visited.contains(&callee) {
+                stack.push(callee);
+            }
+        }
+    }
+    false
+}
+
+fn collect_fn_call_names(expr: &Expr, out: &mut std::collections::HashSet<String>) {
+    match expr {
+        Expr::FnCall(callee, args) => {
+            if let Some(name) = crate::codegen::common::expr_to_dotted_name(&callee.node) {
+                // Skip namespace builtins (Console.print, List.reverse, etc.)
+                // — they don't have user-side `(a, b)!` shapes that hostile
+                // would reorder. Same heuristic the dafny collect_called_fns
+                // helper uses.
+                if !name.contains('.') {
+                    out.insert(name);
+                }
+            }
+            collect_fn_call_names(&callee.node, out);
+            for arg in args {
+                collect_fn_call_names(&arg.node, out);
+            }
+        }
+        Expr::TailCall(boxed) => {
+            if !boxed.target.contains('.') {
+                out.insert(boxed.target.clone());
+            }
+            for arg in &boxed.args {
+                collect_fn_call_names(&arg.node, out);
+            }
+        }
+        Expr::Attr(o, _) | Expr::Neg(o) | Expr::ErrorProp(o) => {
+            collect_fn_call_names(&o.node, out);
+        }
+        Expr::BinOp(_, l, r) => {
+            collect_fn_call_names(&l.node, out);
+            collect_fn_call_names(&r.node, out);
+        }
+        Expr::Match { subject, arms } => {
+            collect_fn_call_names(&subject.node, out);
+            for arm in arms {
+                collect_fn_call_names(&arm.body.node, out);
+            }
+        }
+        Expr::Constructor(_, payload) => {
+            if let Some(p) = payload.as_deref() {
+                collect_fn_call_names(&p.node, out);
+            }
+        }
+        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+            for item in items {
+                collect_fn_call_names(&item.node, out);
+            }
+        }
+        Expr::MapLiteral(entries) => {
+            for (k, v) in entries {
+                collect_fn_call_names(&k.node, out);
+                collect_fn_call_names(&v.node, out);
+            }
+        }
+        Expr::RecordCreate { fields, .. } => {
+            for (_, v) in fields {
+                collect_fn_call_names(&v.node, out);
+            }
+        }
+        Expr::RecordUpdate { base, updates, .. } => {
+            collect_fn_call_names(&base.node, out);
+            for (_, v) in updates {
+                collect_fn_call_names(&v.node, out);
+            }
+        }
+        Expr::InterpolatedStr(parts) => {
+            for part in parts {
+                if let crate::ast::StrPart::Parsed(inner) = part {
+                    collect_fn_call_names(&inner.node, out);
+                }
+            }
+        }
+        Expr::Literal(_) | Expr::Ident(_) | Expr::Resolved { .. } => {}
+    }
 }
 
 fn fn_body_contains_independent_product(body: &crate::ast::FnBody) -> bool {


### PR DESCRIPTION
## Summary

Code review surfaced four real holes in the refinement-recovery machinery from 0.22.0. Common thread: "guess and emit" rather than "prove or fallback". Each fix moves the classifier to the conservative side — fuel encoding, explicit premise, runtime check, or better-shaped witness — when the compiler can't actually prove the artifact will hold.

**High**
- **#1 Lean `when` projection.** Stronger `when a >= 10` over `a : Natural` emitted bare `a >= 10` in the universal theorem and lake build failed (`failed to synthesize LE Natural / OfNat Natural 10`). Now projects bare lifted-var refs to `.val` inside comparator BinOps and `Bool.and`/`Bool.or` chains. The pre-existing unit test asserted the broken shape; updated.
- **#2 IntCountdownGuarded literal-0 restriction.** Non-zero base literals like `match n { 5 -> base; _ -> f(n - 1) }` slipped through the detector but `omega` couldn't prove preservation at the recursive call. Restricted to literal-0 only; arbitrary literals need a real preservation check (follow-up).

**Medium**
- **#3 Dafny refinement witness.** Cross-module `Positive` (predicate `n > 0`) fell back to `witness 0` which fails verification. Added predicate-eval fallback that tries `[0, 1, -1]` against the refinement's bool predicate. Cross-module Positive now emits `witness 1` and verifies clean.
- **#4 Hostile reverse-eval transitive coverage.** Only checked root verified fn's body for `IndependentProduct`. Wrappers calling helpers with `(a, b)!` silently skipped the reverse-eval twin. Now walks call-graph transitively.

## Test plan

- [x] 615 lib tests pass (updated tests for #1 and #2; added negative assertion for the bare-`a` shape that broke lake build)
- [x] 35 proof_spec integration tests pass
- [x] Lake build smoke: natural, positive, int_range, fibonacci all clean
- [x] Dafny verify smoke: standalone Positive emits `witness 1`, verifies clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)