### PR TITLE
ProofIR: pin Reflexive law strategy (Step 24)

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -24,6 +24,21 @@ pub struct AutoProof {
     pub replaces_theorem: bool,
 }
 
+/// Look up the strategy `proof_lower::populate_law_theorems` pinned
+/// on `(fn_name, law_name)`. Returns `None` when no contract was
+/// lowered (LawLower disabled or the verify block wasn't a Law).
+fn law_strategy_for(
+    ctx: &CodegenContext,
+    fn_name: &str,
+    law_name: &str,
+) -> Option<crate::ir::ProofStrategy> {
+    ctx.proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == fn_name && t.law_name == law_name)
+        .map(|t| t.strategy.clone())
+}
+
 pub fn emit_verify_law_forall_auto_proof(
     vb: &VerifyBlock,
     law: &VerifyLaw,
@@ -57,7 +72,17 @@ pub fn emit_verify_law_forall_auto_proof(
         return Some(proof);
     }
 
-    if law.lhs == law.rhs {
+    // Reflexive strategy — `lhs.node` ≡ `rhs.node` (`x => x`,
+    // `add(b, a) => add(b, a)`). The lowerer pinned this on
+    // `ProofIR.law_theorems[*].strategy = Reflexive`; backend
+    // honours that decision instead of running the syntactic
+    // equality check ad-hoc. Falls through to the strategy chain
+    // when the contract isn't Reflexive (BackendDispatch or any
+    // future variant).
+    if matches!(
+        law_strategy_for(ctx, &vb.fn_name, &law.name),
+        Some(crate::ir::ProofStrategy::Reflexive)
+    ) {
         return Some(AutoProof {
             support_lines: Vec::new(),
             proof_lines: intro_then(&proof_intro_names, vec!["rfl".to_string()]),

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -2158,6 +2158,11 @@ verify square law squareSpec
             trace: false,
             cases_givens: vec![],
         }));
+        // Synthetic-AST test bypasses the parser + pipeline, so the
+        // LawLower stage hasn't run. refresh_facts populates
+        // ProofIR.law_theorems with Reflexive on `x => x` — backend's
+        // Step-24 reader checks the IR to emit rfl.
+        ctx.refresh_facts();
         let out = transpile(&mut ctx);
         let lean = out
             .files

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -522,6 +522,21 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             None => Vec::new(),
         };
 
+        // Pin `Reflexive` when the claim's two sides are
+        // syntactically identical (e.g. `x => x`, `add(b, a) =>
+        // add(b, a)`). Backends emit `rfl` for this case — no
+        // simp, no induction, no strategy chain walk. PartialEq on
+        // Spanned<Expr> compares the wrapped node + line, so two
+        // distinct source positions of the same identifier won't
+        // collide here; this is `lhs.node` structural equality
+        // through the derived PartialEq. Future steps will pin
+        // SimpOverLemmas / Induction / etc. on the remaining shapes.
+        let strategy = if law.lhs == law.rhs {
+            ProofStrategy::Reflexive
+        } else {
+            ProofStrategy::BackendDispatch
+        };
+
         ir.law_theorems.push(LawTheorem {
             fn_name: vb.fn_name.clone(),
             law_name: law.name.clone(),
@@ -529,7 +544,7 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             premises,
             claim_lhs: law.lhs.clone(),
             claim_rhs: law.rhs.clone(),
-            strategy: ProofStrategy::BackendDispatch,
+            strategy,
         });
     }
 }

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -767,9 +767,42 @@ fn law_lower_populates_theorems_from_verify_law_blocks() {
         "no `when` clause → no premises, got: {:?}",
         theorem.premises
     );
+    // `add(a, b) => add(b, a)` — distinct LHS/RHS, falls through
+    // to BackendDispatch (Step 24+ pins Reflexive only when sides
+    // are syntactically identical; SimpOverLemmas, Induction, etc.
+    // come later).
     assert!(
         matches!(theorem.strategy, aver::ir::ProofStrategy::BackendDispatch),
-        "Step 23 always emits BackendDispatch, got: {:?}",
+        "commutative falls through to BackendDispatch, got: {:?}",
+        theorem.strategy,
+    );
+}
+
+#[test]
+fn reflexive_law_pinned_when_lhs_equals_rhs() {
+    // `x => x` is the canonical Reflexive shape. After Step 24
+    // proof_lower pins `ProofStrategy::Reflexive`, and Lean's
+    // law_auto reads from there instead of running the syntactic
+    // equality check ad-hoc.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn id(a: Int) -> Int\n\
+         \x20   a\n\
+         \n\
+         verify id law reflexive\n\
+         \x20   given x: Int = -2..2\n\
+         \x20   x => x\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "id" && t.law_name == "reflexive")
+        .expect("id::reflexive law theorem missing from ProofIR");
+    assert!(
+        matches!(theorem.strategy, aver::ir::ProofStrategy::Reflexive),
+        "x => x must pin Reflexive, got: {:?}",
         theorem.strategy,
     );
 }


### PR DESCRIPTION
## Summary

First concrete `ProofStrategy` migration on top of the Step-23 LawLower framework. `proof_lower::populate_law_theorems` now pins `ProofStrategy::Reflexive` when `law.lhs == law.rhs` (syntactic equality); Lean's `law_auto::emit_verify_law_forall_auto_proof` reads the IR-pinned strategy instead of running the AST equality check ad-hoc.

Behaviour preserved — same `rfl` emit for the same shapes. The migration is "source of the decision shifts from the backend to the lowerer"; backend's strategy chain order (induction first → reflexive → arithmetic → …) unchanged.

## Test plan

- [x] `cargo test --lib` (615 pass)
- [x] `cargo test --test proof_ir_diff` (15 pass — new `reflexive_law_pinned_when_lhs_equals_rhs` asserts the producer pins Reflexive on `x => x`; the existing commutative test still asserts BackendDispatch)
- [x] `cargo test --test proof_spec` (35 pass — end-to-end Lean/Dafny build)
- [x] `cargo test --test explain_passes_spec` (5 pass)
- [x] Synthetic-AST unit test `transpile_auto_proves_reflexive_law_with_rfl` updated to call `ctx.refresh_facts()` — synthetic ctx bypasses the pipeline, refresh_facts is the bridge for those

## Follow-up

Subsequent Steps pin more strategies one at a time:
- Step 25: `SimpOverLemmas(...)` for commutative/associative/identity arithmetic wrapper laws
- Step 26: `Induction { param }` for structural recursion on recursive ADTs
- Step 27: spec function equivalence, map laws
- Step 28: simp+omega, guarded domain
- Step N+: retire `BackendDispatch` once every theorem has a pinned strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)