### PR TITLE
ProofIR: pin WrapperSubRightIdentity + AntiCommutative (Step 26)

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -99,6 +99,26 @@ pub fn emit_verify_law_forall_auto_proof(
                 // unfolds.
                 Some(vec![format!("simp [{}]", fn_lean)])
             }
+            ProofStrategy::WrapperSubRightIdentity => {
+                // `sub(a, 0) => a` unfolds the wrapper; Lean's
+                // `simp [sub]` reduces `a - 0` to `a` without
+                // extra lemmas.
+                Some(vec![format!("simp [{}]", fn_lean)])
+            }
+            ProofStrategy::WrapperSubAntiCommutative { neg_on_rhs } => {
+                // `Int.neg_sub b a : -(b - a) = a - b`. When the
+                // negation sits on the rhs of the user's law we
+                // need `.symm` to align directions; when it's on
+                // the lhs the law statement already matches.
+                let a = aver_name_to_lean(&law.givens[0].name);
+                let b = aver_name_to_lean(&law.givens[1].name);
+                let step = if neg_on_rhs {
+                    format!("simpa [{}] using (Int.neg_sub {} {}).symm", fn_lean, b, a)
+                } else {
+                    format!("simpa [{}] using (Int.neg_sub {} {})", fn_lean, b, a)
+                };
+                Some(vec![step])
+            }
             _ => None,
         };
         if let Some(lines) = proof_lines {

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -592,6 +592,18 @@ fn classify_law_strategy(
     if detect_wrapper_identity(law, fn_name, op) {
         return ProofStrategy::WrapperIdentity { op };
     }
+    // Sub-specific shapes (right identity + anti-commutative). The
+    // Add/Mul wrappers can't fit these — Sub's negation behaviour
+    // is structurally different, and Mul has no anti-commutative
+    // law (commutative). Gated on `op == Sub`.
+    if matches!(op, crate::ast::BinOp::Sub) {
+        if detect_wrapper_sub_right_identity(law, fn_name) {
+            return ProofStrategy::WrapperSubRightIdentity;
+        }
+        if let Some(neg_on_rhs) = detect_wrapper_sub_anti_commutative(law, fn_name) {
+            return ProofStrategy::WrapperSubAntiCommutative { neg_on_rhs };
+        }
+    }
     ProofStrategy::BackendDispatch
 }
 
@@ -619,7 +631,7 @@ fn wrapper_binop(fn_name: &str, inputs: &ProofLowerInputs) -> Option<crate::ast:
     if !matches_ident_expr(left, p1) || !matches_ident_expr(right, p2) {
         return None;
     }
-    matches!(op, BinOp::Add | BinOp::Mul).then_some(*op)
+    matches!(op, BinOp::Add | BinOp::Mul | BinOp::Sub).then_some(*op)
 }
 
 fn detect_wrapper_commutative(
@@ -651,6 +663,38 @@ fn detect_wrapper_associative(
     let nested = |side| matches_assoc_nested(side, fn_name, a, b, c);
     let flat = |side| matches_assoc_flat(side, fn_name, a, b, c);
     (nested(&law.lhs) && flat(&law.rhs)) || (nested(&law.rhs) && flat(&law.lhs))
+}
+
+fn detect_wrapper_sub_right_identity(law: &crate::ast::VerifyLaw, fn_name: &str) -> bool {
+    if law.givens.len() != 1 || law.givens[0].type_name != "Int" {
+        return false;
+    }
+    let g = &law.givens[0].name;
+    matches_sub_right_identity_side(&law.lhs, &law.rhs, fn_name, g)
+        || matches_sub_right_identity_side(&law.rhs, &law.lhs, fn_name, g)
+}
+
+/// Detect `sub(a, b) => -sub(b, a)` or the swapped arrangement.
+/// Returns `Some(neg_on_rhs)` — `true` when the negation is on the
+/// rhs (canonical direction); `false` when swapped (call on rhs,
+/// negation on lhs). `None` when the shape doesn't fit.
+fn detect_wrapper_sub_anti_commutative(law: &crate::ast::VerifyLaw, fn_name: &str) -> Option<bool> {
+    if law.givens.len() != 2 || law.givens.iter().any(|g| g.type_name != "Int") {
+        return None;
+    }
+    let a = &law.givens[0].name;
+    let b = &law.givens[1].name;
+    if matches_binary_call(&law.lhs, fn_name, a, b)
+        && matches_neg_binary_call(&law.rhs, fn_name, b, a)
+    {
+        return Some(true);
+    }
+    if matches_binary_call(&law.rhs, fn_name, a, b)
+        && matches_neg_binary_call(&law.lhs, fn_name, b, a)
+    {
+        return Some(false);
+    }
+    None
 }
 
 fn detect_wrapper_identity(
@@ -750,6 +794,36 @@ fn matches_assoc_flat(
         return false;
     };
     matches_ident_expr(x, a) && matches_ident_expr(y, b) && matches_ident_expr(z, c)
+}
+
+fn matches_sub_right_identity_side(
+    call_side: &Spanned<crate::ast::Expr>,
+    ident_side: &Spanned<crate::ast::Expr>,
+    fn_name: &str,
+    given_name: &str,
+) -> bool {
+    use crate::ast::{Expr, Literal};
+    if !matches_ident_expr(ident_side, given_name) {
+        return false;
+    }
+    let Some((x, y)) = call2_args(call_side, fn_name) else {
+        return false;
+    };
+    matches_ident_expr(x, given_name)
+        && matches!(&y.node, Expr::Literal(Literal::Int(n)) if *n == 0)
+}
+
+fn matches_neg_binary_call(
+    expr: &Spanned<crate::ast::Expr>,
+    fn_name: &str,
+    a: &str,
+    b: &str,
+) -> bool {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::Neg(inner) => matches_binary_call(inner, fn_name, a, b),
+        _ => false,
+    }
 }
 
 fn matches_identity_side(

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -341,6 +341,21 @@ pub enum ProofStrategy {
     /// `wrapper(a, 1) => a` for `Mul`). The identity literal is
     /// determined by `op` — backends compute it directly.
     WrapperIdentity { op: crate::ast::BinOp },
+    /// Right-identity over a 2-arg Sub wrapper: `sub(a, 0) => a`.
+    /// Sub-specific because subtraction's identity is one-sided —
+    /// the symmetric `0 - a` is `-a`, not `a`, so it doesn't fit
+    /// `WrapperIdentity`.
+    WrapperSubRightIdentity,
+    /// Anti-commutative law over a 2-arg Sub wrapper:
+    /// `sub(a, b) => -sub(b, a)` or the swapped arrangement.
+    /// `neg_on_rhs` records which side carries the negation —
+    /// drives the `.symm` flip on backends that prove via
+    /// `Int.neg_sub`.
+    WrapperSubAntiCommutative {
+        /// `true` for `sub(a, b) => -sub(b, a)`, `false` for the
+        /// swapped form `-sub(b, a) => sub(a, b)`.
+        neg_on_rhs: bool,
+    },
     /// Structural induction on a recursive ADT parameter.
     Induction { param: String },
     /// Bounded universal: case-split over the declared `given`

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -877,3 +877,66 @@ fn wrapper_identity_pinned_on_add_with_zero_rhs() {
         theorem.strategy,
     );
 }
+
+#[test]
+fn wrapper_sub_right_identity_pinned_on_sub_with_zero_rhs() {
+    // `sub(a, 0) => a` over `fn sub(a, b) -> a - b` — Step 26 pins
+    // `WrapperSubRightIdentity`. Sub-specific because subtraction's
+    // identity is one-sided.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn sub(a: Int, b: Int) -> Int\n\
+         \x20   a - b\n\
+         \n\
+         verify sub law rightIdentity\n\
+         \x20   given a: Int = -3..3\n\
+         \x20   sub(a, 0) => a\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "sub" && t.law_name == "rightIdentity")
+        .expect("sub::rightIdentity law theorem missing");
+    assert!(
+        matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::WrapperSubRightIdentity
+        ),
+        "expected WrapperSubRightIdentity, got: {:?}",
+        theorem.strategy,
+    );
+}
+
+#[test]
+fn wrapper_sub_anti_commutative_pinned_with_neg_direction() {
+    // `sub(a, b) => -sub(b, a)` over `fn sub(a, b) -> a - b` —
+    // `WrapperSubAntiCommutative { neg_on_rhs: true }`. The IR's
+    // direction flag drives `.symm` selection on the Lean side.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn sub(a: Int, b: Int) -> Int\n\
+         \x20   a - b\n\
+         \n\
+         verify sub law antiCommutative\n\
+         \x20   given a: Int = -2..2\n\
+         \x20   given b: Int = -2..2\n\
+         \x20   sub(a, b) => -sub(b, a)\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "sub" && t.law_name == "antiCommutative")
+        .expect("sub::antiCommutative law theorem missing");
+    assert!(
+        matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::WrapperSubAntiCommutative { neg_on_rhs: true }
+        ),
+        "expected WrapperSubAntiCommutative {{ neg_on_rhs: true }}, got: {:?}",
+        theorem.strategy,
+    );
+}


### PR DESCRIPTION
## Summary

Two Sub-specific law strategies migrate from backend ad-hoc detection into the lowerer:

- `WrapperSubRightIdentity` — `sub(a, 0) => a` over a 2-arg Int wrapper around `BinOp::Sub`. One given, no payload — shape fully determines the Lean tactic (`simp [<fn>]`).
- `WrapperSubAntiCommutative { neg_on_rhs }` — `sub(a,b) => -sub(b,a)` or the swapped arrangement. The bool records which side carries the `Neg` wrap; drives `.symm` selection on Lean side.

`wrapper_binop` extended to accept `BinOp::Sub` (was Add/Mul only). Sub-specific shapes activate only when `op == Sub`; Add/Mul-only commutative/associative/identity arms stay gated to those ops.

## Coverage

```
$ aver compile --emit-ir-after=law_lower examples/formal/law_auto.av | grep -v BackendDispatch
## law_theorems (15)
- add::associative          (WrapperAssociative)
- add::commutative          (WrapperCommutative)
- add::commutativeSwapSides (WrapperCommutative)
- add::identityZero         (WrapperIdentity)
- add::identityZeroLeft     (WrapperIdentity)
- id::reflexive             (Reflexive)
- mul::associative          (WrapperAssociative)
- mul::commutative          (WrapperCommutative)
- mul::identityOne          (WrapperIdentity)
- mul::identityOneLeft      (WrapperIdentity)
- sub::rightIdentity        (WrapperSubRightIdentity)   ← Step 26
```

11/15 law_auto.av laws now pinned. The remaining `sub::antiCommutative` uses `0 - sub(b, a)` syntax (not `-sub(b, a)`), falling through to `simp+omega` — Step 28+ pins that distinct shape.

## Test plan

- [x] `cargo test --lib` (615 pass)
- [x] `cargo test --test proof_ir_diff` (19 pass — 2 new tests: right-identity pin, anti-commutative with neg_on_rhs flag)
- [x] `cargo test --test proof_spec` (35 pass — `sub::rightIdentity` emits `simp [sub]` identical to pre-migration)
- [x] `cargo test --test explain_passes_spec` (5 pass)

## Follow-up

- Step 27: `WrapperUnaryEquivalence` (`addOne(a) => add(a, 1)` shape)
- Step 28+: `Induction { param }`, map laws, simp+omega, guarded domain
- Step N+: retire `BackendDispatch` once every theorem has a pinned strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)