### PR TITLE
ProofIR: pin WrapperUnaryEquivalence law strategy (Step 27)

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -105,6 +105,17 @@ pub fn emit_verify_law_forall_auto_proof(
                 // extra lemmas.
                 Some(vec![format!("simp [{}]", fn_lean)])
             }
+            ProofStrategy::WrapperUnaryEquivalence { ref inner_fn } => {
+                // `outer(a) = inner(a, K)` (or `inner(K, a)`) over
+                // the same op. Lean's `simp [outer, inner]`
+                // collapses both wrappers to the underlying op
+                // expression on both sides.
+                Some(vec![format!(
+                    "simp [{}, {}]",
+                    fn_lean,
+                    aver_name_to_lean(inner_fn)
+                )])
+            }
             ProofStrategy::WrapperSubAntiCommutative { neg_on_rhs } => {
                 // `Int.neg_sub b a : -(b - a) = a - b`. When the
                 // negation sits on the rhs of the user's law we

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -580,29 +580,39 @@ fn classify_law_strategy(
     if law.lhs == law.rhs {
         return ProofStrategy::Reflexive;
     }
-    let Some(op) = wrapper_binop(fn_name, inputs) else {
-        return ProofStrategy::BackendDispatch;
-    };
-    if detect_wrapper_commutative(law, fn_name, op) {
-        return ProofStrategy::WrapperCommutative { op };
-    }
-    if detect_wrapper_associative(law, fn_name, op) {
-        return ProofStrategy::WrapperAssociative { op };
-    }
-    if detect_wrapper_identity(law, fn_name, op) {
-        return ProofStrategy::WrapperIdentity { op };
-    }
-    // Sub-specific shapes (right identity + anti-commutative). The
-    // Add/Mul wrappers can't fit these — Sub's negation behaviour
-    // is structurally different, and Mul has no anti-commutative
-    // law (commutative). Gated on `op == Sub`.
-    if matches!(op, crate::ast::BinOp::Sub) {
-        if detect_wrapper_sub_right_identity(law, fn_name) {
-            return ProofStrategy::WrapperSubRightIdentity;
+    // Binary-wrapper-shaped laws first. `wrapper_binop` returns
+    // `None` for non-binary fns — unary wrappers (Step 27 below)
+    // are tried after this block falls through.
+    if let Some(op) = wrapper_binop(fn_name, inputs) {
+        if detect_wrapper_commutative(law, fn_name, op) {
+            return ProofStrategy::WrapperCommutative { op };
         }
-        if let Some(neg_on_rhs) = detect_wrapper_sub_anti_commutative(law, fn_name) {
-            return ProofStrategy::WrapperSubAntiCommutative { neg_on_rhs };
+        if detect_wrapper_associative(law, fn_name, op) {
+            return ProofStrategy::WrapperAssociative { op };
         }
+        if detect_wrapper_identity(law, fn_name, op) {
+            return ProofStrategy::WrapperIdentity { op };
+        }
+        // Sub-specific shapes (right identity + anti-commutative).
+        // Add/Mul wrappers can't fit these — Sub's negation
+        // behaviour is structurally different, and Mul has no
+        // anti-commutative law (commutative).
+        if matches!(op, crate::ast::BinOp::Sub) {
+            if detect_wrapper_sub_right_identity(law, fn_name) {
+                return ProofStrategy::WrapperSubRightIdentity;
+            }
+            if let Some(neg_on_rhs) = detect_wrapper_sub_anti_commutative(law, fn_name) {
+                return ProofStrategy::WrapperSubAntiCommutative { neg_on_rhs };
+            }
+        }
+    }
+    // Unary↔binary wrapper equivalence — `fn_name` is the OUTER
+    // (unary) wrapper, the law's other side calls an inner binary
+    // wrapper with the unary's constant baked in. Independent of
+    // the binary-wrapper branch above (a unary `addOne(a) = a + 1`
+    // fails `wrapper_binop` because it has only one param).
+    if let Some(inner_fn) = detect_wrapper_unary_equivalence(law, fn_name, inputs) {
+        return ProofStrategy::WrapperUnaryEquivalence { inner_fn };
     }
     ProofStrategy::BackendDispatch
 }
@@ -663,6 +673,127 @@ fn detect_wrapper_associative(
     let nested = |side| matches_assoc_nested(side, fn_name, a, b, c);
     let flat = |side| matches_assoc_flat(side, fn_name, a, b, c);
     (nested(&law.lhs) && flat(&law.rhs)) || (nested(&law.rhs) && flat(&law.lhs))
+}
+
+/// Detect a unary↔binary wrapper equivalence shape:
+/// outer side: `outer(g)` where `fn outer(p) -> p <op> K`
+/// other side: `inner(g, K)` or `inner(K, g)` where `fn inner(a, b) -> a <op> b`
+/// Both sides must agree on op + constant + var-position.
+/// Returns the inner fn's source name, or `None` if no match.
+fn detect_wrapper_unary_equivalence(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<String> {
+    if law.givens.len() != 1 || law.givens[0].type_name != "Int" {
+        return None;
+    }
+    let unary = unary_int_wrapper(fn_name, inputs)?;
+    let g = &law.givens[0].name;
+
+    let try_side = |call_side: &Spanned<crate::ast::Expr>,
+                    other_side: &Spanned<crate::ast::Expr>|
+     -> Option<String> {
+        if !matches_unary_call(call_side, fn_name, g) {
+            return None;
+        }
+        let (callee_name, var_first, lit) = binary_call_var_const(other_side, g)?;
+        if lit != unary.constant || var_first != unary.var_first {
+            return None;
+        }
+        let inner_op = wrapper_binop(&callee_name, inputs)?;
+        if inner_op != unary.op {
+            return None;
+        }
+        Some(callee_name)
+    };
+    try_side(&law.lhs, &law.rhs).or_else(|| try_side(&law.rhs, &law.lhs))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct UnaryIntWrapper {
+    op: crate::ast::BinOp,
+    constant: i64,
+    var_first: bool,
+}
+
+/// Resolve `fn outer(p: Int) -> Int :- p <op> K` or `K <op> p`.
+/// Returns the op + literal + which side carries the param.
+fn unary_int_wrapper(fn_name: &str, inputs: &ProofLowerInputs) -> Option<UnaryIntWrapper> {
+    use crate::ast::{Expr, Literal};
+
+    let fd = inputs.find_fn_def_by_call_name(fn_name)?;
+    if fd.params.len() != 1 || fd.return_type != "Int" {
+        return None;
+    }
+    let (param, param_ty) = &fd.params[0];
+    if param_ty != "Int" {
+        return None;
+    }
+    let expr = body_terminal_expr(fd.body.as_ref())?;
+    let Expr::BinOp(op, left, right) = &expr.node else {
+        return None;
+    };
+    let lit_of = |e: &Spanned<Expr>| -> Option<i64> {
+        match &e.node {
+            Expr::Literal(Literal::Int(n)) => Some(*n),
+            _ => None,
+        }
+    };
+    if matches_ident_expr(left, param) {
+        let n = lit_of(right)?;
+        return Some(UnaryIntWrapper {
+            op: *op,
+            constant: n,
+            var_first: true,
+        });
+    }
+    if matches_ident_expr(right, param) {
+        let n = lit_of(left)?;
+        return Some(UnaryIntWrapper {
+            op: *op,
+            constant: n,
+            var_first: false,
+        });
+    }
+    None
+}
+
+fn matches_unary_call(expr: &Spanned<crate::ast::Expr>, fn_name: &str, arg: &str) -> bool {
+    use crate::ast::Expr;
+    let Expr::FnCall(callee, args) = &expr.node else {
+        return false;
+    };
+    args.len() == 1 && callee_matches_name(callee, fn_name) && matches_ident_expr(&args[0], arg)
+}
+
+/// `inner(var, K)` or `inner(K, var)` shape. Returns
+/// `(callee_name, var_first, K)` on match.
+fn binary_call_var_const(
+    expr: &Spanned<crate::ast::Expr>,
+    var_name: &str,
+) -> Option<(String, bool, i64)> {
+    use crate::ast::{Expr, Literal};
+    let Expr::FnCall(callee, args) = &expr.node else {
+        return None;
+    };
+    if args.len() != 2 {
+        return None;
+    }
+    let callee_name = expr_to_dotted_name(&callee.node)?;
+    match (&args[0].node, &args[1].node) {
+        (Expr::Ident(v) | Expr::Resolved { name: v, .. }, Expr::Literal(Literal::Int(n)))
+            if v == var_name =>
+        {
+            Some((callee_name, true, *n))
+        }
+        (Expr::Literal(Literal::Int(n)), Expr::Ident(v) | Expr::Resolved { name: v, .. })
+            if v == var_name =>
+        {
+            Some((callee_name, false, *n))
+        }
+        _ => None,
+    }
 }
 
 fn detect_wrapper_sub_right_identity(law: &crate::ast::VerifyLaw, fn_name: &str) -> bool {

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -356,6 +356,17 @@ pub enum ProofStrategy {
         /// swapped form `-sub(b, a) => sub(a, b)`.
         neg_on_rhs: bool,
     },
+    /// Equivalence between a unary wrapper and a binary wrapper
+    /// over the same op, e.g. `fn addOne(a) -> a + 1` plus
+    /// `verify addOne law identityViaAdd ... addOne(a) => add(a, 1)`.
+    /// The IR captures the inner binary fn name so the backend
+    /// renders `simp [<outer>, <inner>]` without re-scanning the
+    /// AST for the equivalent.
+    WrapperUnaryEquivalence {
+        /// Source-level name of the inner binary wrapper the unary
+        /// fn equals (the law's "other side" calls this).
+        inner_fn: String,
+    },
     /// Structural induction on a recursive ADT parameter.
     Induction { param: String },
     /// Bounded universal: case-split over the declared `given`

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -940,3 +940,38 @@ fn wrapper_sub_anti_commutative_pinned_with_neg_direction() {
         theorem.strategy,
     );
 }
+
+#[test]
+fn wrapper_unary_equivalence_pinned_with_inner_fn_name() {
+    // `addOne(a) => add(a, 1)` over `fn addOne(a) -> a + 1` and
+    // `fn add(a, b) -> a + b` — Step 27 pins
+    // `WrapperUnaryEquivalence { inner_fn: "add" }`. The inner fn
+    // name lives in the IR so the backend renders
+    // `simp [addOne, add]` without rescanning.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn add(a: Int, b: Int) -> Int\n\
+         \x20   a + b\n\
+         \n\
+         fn addOne(a: Int) -> Int\n\
+         \x20   a + 1\n\
+         \n\
+         verify addOne law identityViaAdd\n\
+         \x20   given a: Int = -2..2\n\
+         \x20   addOne(a) => add(a, 1)\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "addOne" && t.law_name == "identityViaAdd")
+        .expect("addOne::identityViaAdd law theorem missing");
+    let aver::ir::ProofStrategy::WrapperUnaryEquivalence { ref inner_fn } = theorem.strategy else {
+        panic!(
+            "expected WrapperUnaryEquivalence, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(inner_fn, "add");
+}


### PR DESCRIPTION
## Summary

`outer(a) => inner(a, K)` (or `inner(K, a)`) where `fn outer(p) -> p <op> K` and `fn inner(a, b) -> a <op> b` (same op) pins as `WrapperUnaryEquivalence { inner_fn }`. The inner fn name lives in the IR; Lean renders `simp [<outer>, <inner>]` directly.

Dispatch restructure: `classify_law_strategy`'s binary-wrapper branch becomes a gated lookup (`if let Some(op) = wrapper_binop(...)`). When fn_name fails that check (unary outer wrappers have one param), the binary block falls through and the unary-equivalence branch runs independently. Preserves existing behaviour — binary shapes still pin first, unary equivalence is the next-priority match.

## Coverage

```
$ aver compile --emit-ir-after=law_lower examples/formal/law_auto.av | grep -v BackendDispatch | grep "^-"
- add::associative          (WrapperAssociative)
- add::commutative          (WrapperCommutative)
- add::commutativeSwapSides (WrapperCommutative)
- add::identityZero         (WrapperIdentity)
- add::identityZeroLeft     (WrapperIdentity)
- addOne::identityViaAdd    (WrapperUnaryEquivalence { inner_fn: "add" })   ← Step 27
- id::reflexive             (Reflexive)
- mul::associative          (WrapperAssociative)
- mul::commutative          (WrapperCommutative)
- mul::identityOne          (WrapperIdentity)
- mul::identityOneLeft      (WrapperIdentity)
- sub::rightIdentity        (WrapperSubRightIdentity)
```

12/15 law_auto.av laws now pinned. Remaining 3 (incCount map laws + sub anti-commutative via `0 - sub` form) on `BackendDispatch`.

## Test plan

- [x] `cargo test --lib` (615 pass)
- [x] `cargo test --test proof_ir_diff` (20 pass — new test asserts `inner_fn: "add"`)
- [x] `cargo test --test proof_spec` (35 pass — `addOne::identityViaAdd` emits `simp [addOne, add]` identical to pre-migration)
- [x] `cargo test --test explain_passes_spec` (5 pass)

## Follow-up

- Step 28+: `Induction { param }`, map laws (direct_set / update / increment_tracked_count), simp+omega, guarded domain
- Step N+: retire `BackendDispatch` once every theorem has a pinned strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)