### PR TITLE
ProofIR: pin SimpOmegaUnfold law strategy (Step 28)

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -130,6 +130,10 @@ pub fn emit_verify_law_forall_auto_proof(
                 };
                 Some(vec![step])
             }
+            // SimpOmegaUnfold runs at its position in the chain
+            // (below spec_equivalence + maps) — falls through here
+            // and emits in the dedicated arm further down.
+            ProofStrategy::SimpOmegaUnfold { .. } => None,
             _ => None,
         };
         if let Some(lines) = proof_lines {
@@ -185,6 +189,30 @@ pub fn emit_verify_law_forall_auto_proof(
             )
         })
         .or_else(|| {
+            // IR-pinned SimpOmegaUnfold takes precedence over the
+            // legacy detection here — the lowerer already ran the
+            // same shape check and captured `unfold_fns`,
+            // `wrapper_return`, `smart_guard`. When the IR didn't
+            // pin (BackendDispatch), fall through to the legacy
+            // detector below.
+            if let Some(crate::ir::ProofStrategy::SimpOmegaUnfold {
+                ref unfold_fns,
+                wrapper_return,
+                ref smart_guard,
+            }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+            {
+                return Some(AutoProof {
+                    support_lines: Vec::new(),
+                    proof_lines: emit_simp_omega_from_ir(
+                        unfold_fns,
+                        wrapper_return,
+                        smart_guard.as_ref(),
+                        &proof_intro_names,
+                        ctx,
+                    ),
+                    replaces_theorem: false,
+                });
+            }
             emit_simp_omega_law(vb, law, ctx, &proof_intro_names).map(|proof_lines| AutoProof {
                 support_lines: Vec::new(),
                 proof_lines,
@@ -205,6 +233,58 @@ pub fn emit_verify_law_forall_auto_proof(
 /// Works when the function is a non-recursive match on Int args
 /// (e.g. `computeScore(0, level) => 0`). `simp` unfolds the function,
 /// `omega` closes the linear arithmetic goal.
+/// Render the simp+omega tactic from IR-pinned data. Mirrors the
+/// emit body of the legacy `emit_simp_omega_law` (kept as fallback
+/// for `BackendDispatch`) but sources `unfold_fns` / `wrapper_
+/// return` / `smart_guard` from `ProofIR.law_theorems[*].strategy`.
+fn emit_simp_omega_from_ir(
+    unfold_fns: &[String],
+    wrapper_return: bool,
+    smart_guard: Option<&crate::ir::SmartGuard>,
+    intro_names: &[String],
+    ctx: &CodegenContext,
+) -> Vec<String> {
+    let lean_names: Vec<String> = unfold_fns.iter().map(|n| aver_name_to_lean(n)).collect();
+    if wrapper_return {
+        let by_cases_clauses: Vec<String> = intro_names
+            .iter()
+            .map(|n| {
+                let predicate = match smart_guard {
+                    Some(g) => {
+                        let substituted = crate::codegen::common::substitute_ident_in_expr(
+                            &g.predicate,
+                            &g.param,
+                            n,
+                        );
+                        emit_expr(&substituted, ctx)
+                    }
+                    None => format!("{n} ≥ 0"),
+                };
+                format!("by_cases h_{n} : {predicate}")
+            })
+            .collect();
+        let by_cases_chain = by_cases_clauses.join(" <;> ");
+        let simp_hyps: Vec<String> = intro_names
+            .iter()
+            .map(|n| format!("h_{n}"))
+            .chain(["Int.add_comm".to_string(), "Int.mul_comm".to_string()])
+            .collect();
+        let simp_args = simp_hyps.join(", ");
+        intro_then(
+            intro_names,
+            vec![
+                format!("unfold {}", lean_names.join(" ")),
+                format!("{by_cases_chain} <;> simp [{simp_args}]"),
+            ],
+        )
+    } else {
+        intro_then(
+            intro_names,
+            vec![format!("simp only [{}] <;> omega", lean_names.join(", "))],
+        )
+    }
+}
+
 fn emit_simp_omega_law(
     vb: &VerifyBlock,
     law: &VerifyLaw,

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -614,7 +614,284 @@ fn classify_law_strategy(
     if let Some(inner_fn) = detect_wrapper_unary_equivalence(law, fn_name, inputs) {
         return ProofStrategy::WrapperUnaryEquivalence { inner_fn };
     }
+    // `simp + omega` over an unfolded fn chain — generic catch-all
+    // for Int laws whose two sides reduce to flat arithmetic once
+    // every reachable fn is unfolded. Runs last so the more-
+    // specific wrapper strategies pin their shapes first.
+    if let Some(plan) = detect_simp_omega_unfold(law, fn_name, inputs) {
+        return ProofStrategy::SimpOmegaUnfold {
+            unfold_fns: plan.unfold_fns,
+            wrapper_return: plan.wrapper_return,
+            smart_guard: plan.smart_guard,
+        };
+    }
     ProofStrategy::BackendDispatch
+}
+
+/// Internal scratch for the simp+omega detector. Carries the
+/// same fields as the IR variant but lives outside the IR enum so
+/// callers can build it incrementally before pinning.
+struct SimpOmegaPlan {
+    unfold_fns: Vec<String>,
+    wrapper_return: bool,
+    smart_guard: Option<crate::ir::SmartGuard>,
+}
+
+fn detect_simp_omega_unfold(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<SimpOmegaPlan> {
+    use std::collections::BTreeSet;
+
+    // Outer fn must take only Int params — `simp + omega` works on
+    // linear arithmetic, not on opaque wrapper types.
+    let outer_fd = inputs.find_fn_def_by_call_name(fn_name)?;
+    if outer_fd.params.iter().any(|(_, t)| t != "Int") {
+        return None;
+    }
+    // All law givens Int.
+    if law.givens.is_empty() || law.givens.iter().any(|g| g.type_name != "Int") {
+        return None;
+    }
+
+    // Seed the unfold set from the law's two sides + the outer fn.
+    let mut fn_names: BTreeSet<String> = BTreeSet::new();
+    collect_fn_calls_expr(&law.lhs, &mut fn_names);
+    collect_fn_calls_expr(&law.rhs, &mut fn_names);
+    fn_names.insert(fn_name.to_string());
+
+    // Transitive expansion through entry+dep fn bodies. Each round
+    // can only add fns reachable from the new set; converges in
+    // O(items). Without this, cross-module refinement smart
+    // constructors (`Modules.Natural.Natural.fromInt`) wouldn't be
+    // in the unfold list and the goal would carry opaque
+    // match-on-Result branches simp/omega can't close.
+    loop {
+        let before = fn_names.len();
+        let snapshot: Vec<String> = fn_names.iter().cloned().collect();
+        for fd in iter_all_fn_defs(inputs) {
+            if !snapshot.contains(&fd.name) {
+                continue;
+            }
+            for stmt in fd.body.stmts() {
+                match stmt {
+                    crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => {
+                        collect_fn_calls_expr(e, &mut fn_names);
+                    }
+                }
+            }
+        }
+        if fn_names.len() == before {
+            break;
+        }
+    }
+
+    // Self-recursion rejection — `unfold fn` only does one step, so
+    // a recursive body leaves a stale `fn` in the goal that simp
+    // can't close. Check against the narrow self-only set; calling
+    // a peer fn in the unfold list is fine.
+    let mut wrapper_return = false;
+    for fd in iter_all_fn_defs(inputs) {
+        if !fn_names.contains(&fd.name) {
+            continue;
+        }
+        let mut self_only: BTreeSet<String> = BTreeSet::new();
+        self_only.insert(fd.name.clone());
+        if body_calls_any_of_inputs(&fd.body, &self_only) {
+            return None;
+        }
+        // Int-only check only for the outer law fn — cross-module
+        // callees may take refined types.
+        if fd.name == fn_name && fd.params.iter().any(|(_, t)| t != "Int") {
+            return None;
+        }
+        let ret = fd.return_type.as_str();
+        if ret != "Int" && ret != "Float" {
+            wrapper_return = true;
+        }
+    }
+
+    // Top-level law fn first in the unfold list — Lean needs to see
+    // it in the goal before transitively-reached callees, otherwise
+    // `unfold` fails outright at the outermost call layer.
+    let mut ordered: Vec<String> = Vec::new();
+    if fn_names.contains(fn_name) {
+        ordered.push(fn_name.to_string());
+    }
+    for n in &fn_names {
+        if n != fn_name {
+            ordered.push(n.clone());
+        }
+    }
+
+    let smart_guard = extract_smart_constructor_guard(&fn_names, inputs);
+
+    Some(SimpOmegaPlan {
+        unfold_fns: ordered,
+        wrapper_return,
+        smart_guard,
+    })
+}
+
+fn iter_all_fn_defs<'a>(inputs: &'a ProofLowerInputs<'a>) -> impl Iterator<Item = &'a FnDef> {
+    inputs
+        .entry_items
+        .iter()
+        .filter_map(|item| match item {
+            TopLevel::FnDef(fd) => Some(fd),
+            _ => None,
+        })
+        .chain(inputs.dep_modules.iter().flat_map(|m| m.fn_defs.iter()))
+}
+
+fn body_calls_any_of_inputs(
+    body: &crate::ast::FnBody,
+    names: &std::collections::BTreeSet<String>,
+) -> bool {
+    let mut called = std::collections::BTreeSet::new();
+    for stmt in body.stmts() {
+        match stmt {
+            crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => {
+                collect_fn_calls_expr(e, &mut called);
+            }
+        }
+    }
+    called.iter().any(|c| names.contains(c))
+}
+
+fn collect_fn_calls_expr(
+    expr: &Spanned<crate::ast::Expr>,
+    out: &mut std::collections::BTreeSet<String>,
+) {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::FnCall(f, args) => {
+            if let Some(name) = expr_to_dotted_name(&f.node) {
+                // Skip uppercase namespace handles (`List.len`,
+                // `Option.Some`) — those are built-in namespaces,
+                // not user fns the auto-proof can unfold. The leaf
+                // segment's case discriminates user fns from
+                // namespace types (cross-module user calls survive
+                // because the leaf fn name starts lower-case).
+                let last = name.rsplit('.').next().unwrap_or(&name);
+                if last.chars().next().is_some_and(|c| c.is_lowercase()) {
+                    out.insert(name);
+                }
+            }
+            for arg in args {
+                collect_fn_calls_expr(arg, out);
+            }
+        }
+        Expr::BinOp(_, l, r) => {
+            collect_fn_calls_expr(l, out);
+            collect_fn_calls_expr(r, out);
+        }
+        Expr::Attr(obj, _) => collect_fn_calls_expr(obj, out),
+        Expr::Match { subject, arms, .. } => {
+            collect_fn_calls_expr(subject, out);
+            for arm in arms {
+                collect_fn_calls_expr(&arm.body, out);
+            }
+        }
+        Expr::TailCall(boxed) => {
+            out.insert(boxed.target.clone());
+            for arg in &boxed.args {
+                collect_fn_calls_expr(arg, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Find a single-param smart constructor in the unfold set whose
+/// body is the canonical `match <bool-subj> { true → Ok; false →
+/// Err }` shape. Returns the param name + bool subject of the
+/// first match.
+fn extract_smart_constructor_guard(
+    fn_names: &std::collections::BTreeSet<String>,
+    inputs: &ProofLowerInputs,
+) -> Option<crate::ir::SmartGuard> {
+    use crate::ast::{Expr, MatchArm, Pattern, Stmt};
+    for fd in iter_all_fn_defs(inputs) {
+        if !fn_names.contains(&fd.name) {
+            continue;
+        }
+        if !fd.return_type.starts_with("Result<") {
+            continue;
+        }
+        if fd.params.len() != 1 {
+            continue;
+        }
+        let (param_name, param_type) = &fd.params[0];
+        if param_type != "Int" {
+            continue;
+        }
+        let stmts = fd.body.stmts();
+        if stmts.len() != 1 {
+            continue;
+        }
+        let Stmt::Expr(body_expr) = &stmts[0] else {
+            continue;
+        };
+        let Expr::Match { subject, arms } = &body_expr.node else {
+            continue;
+        };
+        if !arms_match_bool_ok_err(arms) {
+            continue;
+        }
+        return Some(crate::ir::SmartGuard {
+            param: param_name.clone(),
+            predicate: (**subject).clone(),
+        });
+        // Reference the type to satisfy the MatchArm import.
+        #[allow(unreachable_code)]
+        {
+            let _: Option<&MatchArm> = None;
+            let _: Option<&Pattern> = None;
+        }
+    }
+    None
+}
+
+fn arms_match_bool_ok_err(arms: &[crate::ast::MatchArm]) -> bool {
+    use crate::ast::{Expr, Literal, Pattern};
+    if arms.len() != 2 {
+        return false;
+    }
+    let starts_with_ctor = |expr: &Spanned<Expr>, name: &str| -> bool {
+        match &expr.node {
+            Expr::Constructor(n, _) => n == name,
+            Expr::FnCall(callee, _) => {
+                if let Expr::Attr(obj, field) = &callee.node
+                    && let Expr::Ident(ns) = &obj.node
+                {
+                    format!("{ns}.{field}") == name
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    };
+    let mut saw_true_ok = false;
+    let mut saw_false_err = false;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::Literal(Literal::Bool(true)) => {
+                if starts_with_ctor(&arm.body, "Result.Ok") {
+                    saw_true_ok = true;
+                }
+            }
+            Pattern::Literal(Literal::Bool(false)) => {
+                if starts_with_ctor(&arm.body, "Result.Err") {
+                    saw_false_err = true;
+                }
+            }
+            _ => return false,
+        }
+    }
+    saw_true_ok && saw_false_err
 }
 
 /// Return `Some(op)` iff `fn_name` resolves to a 2-arg Int wrapper

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -23,7 +23,7 @@ pub use pipeline::{
 pub use proof_ir::{
     DecreaseProof, FnContract, FuelMetric, LawTheorem, Measure, NativeIntCountdownBody, Predicate,
     PreservationProof, ProofIR, ProofStrategy, Quantifier, QuantifierType, RecursionContract,
-    RefinedTypeDecl, UnclassifiedFn,
+    RefinedTypeDecl, SmartGuard, UnclassifiedFn,
 };
 
 pub use alloc_info::{

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -72,6 +72,18 @@ pub struct UnclassifiedFn {
     pub message: String,
 }
 
+/// Refinement smart-constructor guard a `SimpOmegaUnfold` strategy
+/// found in the law's fn unfold chain. `param` is the smart
+/// constructor's input parameter name; `predicate` is the Bool
+/// subject of its `match true/false → Ok/Err` body. Backends emit
+/// `by_cases h_<v> : <substituted predicate>` for each law-given by
+/// rewriting `param` to `<v>` inside the predicate.
+#[derive(Debug, Clone)]
+pub struct SmartGuard {
+    pub param: String,
+    pub predicate: Spanned<crate::ast::Expr>,
+}
+
 /// A refinement-lifted user type — opaque record with a single
 /// carrier field, paired with a validating smart constructor. The
 /// presence of this decl in `ProofIR.refined_types` is the
@@ -366,6 +378,37 @@ pub enum ProofStrategy {
         /// Source-level name of the inner binary wrapper the unary
         /// fn equals (the law's "other side" calls this).
         inner_fn: String,
+    },
+    /// `simp + omega` over an unfolded fn chain — the generic
+    /// catch-all for Int laws whose lhs/rhs reduce to flat linear
+    /// arithmetic once every reachable fn is unfolded. Triggers when
+    /// every given is `Int` and the transitive fn-call closure of
+    /// the law's two sides is non-recursive. The backend emits a
+    /// `simp only [<unfold_fns>] <;> omega` chain, optionally
+    /// wrapped in `by_cases` when a refinement smart constructor
+    /// sits in the chain (its guard goes on top so omega doesn't
+    /// face an `Except.ok` / `Except.err` split).
+    SimpOmegaUnfold {
+        /// Ordered fn unfold list. Top-level law fn comes first —
+        /// Lean's `unfold` resolves left-to-right and the call
+        /// layer the tactic peels at each step must match the goal
+        /// shape.
+        unfold_fns: Vec<String>,
+        /// `true` when at least one fn in `unfold_fns` returns a
+        /// wrapper (Result, Option, …). Drives the by_cases branch
+        /// in the emit — `omega` is a linear-arithmetic decision
+        /// procedure that can't close constructor-equality goals,
+        /// so the wrapper case splits on the smart-constructor
+        /// guard predicate first.
+        wrapper_return: bool,
+        /// Smart-constructor guard pulled from the first refinement
+        /// `fromX(p: Int) -> Result<X, _>` in the unfold chain.
+        /// `Some` when one was found; `None` falls back to the
+        /// conservative `(n ≥ 0)` predicate on the wrapper-return
+        /// path. The pair carries the smart constructor's parameter
+        /// name (so the law-quantified var can be substituted in)
+        /// and the Bool subject of the constructor's `match`.
+        smart_guard: Option<SmartGuard>,
     },
     /// Structural induction on a recursive ADT parameter.
     Induction { param: String },

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -975,3 +975,40 @@ fn wrapper_unary_equivalence_pinned_with_inner_fn_name() {
     };
     assert_eq!(inner_fn, "add");
 }
+
+#[test]
+fn simp_omega_unfold_pinned_on_sub_anti_comm_via_zero() {
+    // `sub(a, b) => 0 - sub(b, a)` doesn't fit
+    // WrapperSubAntiCommutative (that requires `Neg(call)` form);
+    // falls through to SimpOmegaUnfold. The IR captures the
+    // unfold list (just `sub` — non-recursive) plus
+    // `wrapper_return: false` (sub returns Int).
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn sub(a: Int, b: Int) -> Int\n\
+         \x20   a - b\n\
+         \n\
+         verify sub law antiCommutative\n\
+         \x20   given a: Int = -2..2\n\
+         \x20   given b: Int = -2..2\n\
+         \x20   sub(a, b) => 0 - sub(b, a)\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "sub" && t.law_name == "antiCommutative")
+        .expect("sub::antiCommutative law theorem missing");
+    let aver::ir::ProofStrategy::SimpOmegaUnfold {
+        ref unfold_fns,
+        wrapper_return,
+        ref smart_guard,
+    } = theorem.strategy
+    else {
+        panic!("expected SimpOmegaUnfold, got: {:?}", theorem.strategy);
+    };
+    assert!(unfold_fns.contains(&"sub".to_string()));
+    assert!(!wrapper_return, "sub returns Int, not a wrapper");
+    assert!(smart_guard.is_none(), "no refinement in chain");
+}


### PR DESCRIPTION
## Summary

Migrate the simp+omega-with-unfold-chain strategy from backend ad-hoc detection into the lowerer. The IR now carries the full plan (`unfold_fns`, `wrapper_return`, `smart_guard`) so the backend reads the decision instead of re-running the transitive fn-call walk + refinement guard scan.

New IR types:
- `ProofStrategy::SimpOmegaUnfold { unfold_fns, wrapper_return, smart_guard }`
- `SmartGuard { param, predicate }` — backend-neutral refinement guard pair

## Chain order preserved

The IR-pinned SimpOmegaUnfold runs at the *same position* in `law_auto`'s strategy chain as the legacy `emit_simp_omega_law` — after `induction → Reflexive/Wrapper* → spec_equivalence → maps`. Moving it to the top would steal shapes the spec/maps paths own. The legacy `emit_simp_omega_law` stays as fallback for `BackendDispatch` cases the lowerer hasn't classified yet.

## Coverage

```
$ aver compile --emit-ir-after=law_lower examples/formal/law_auto.av | grep -v BackendDispatch
- add::associative          (WrapperAssociative)
- add::commutative          (WrapperCommutative)
- add::commutativeSwapSides (WrapperCommutative)
- add::identityZero         (WrapperIdentity)
- add::identityZeroLeft     (WrapperIdentity)
- addOne::identityViaAdd    (WrapperUnaryEquivalence)
- id::reflexive             (Reflexive)
- mul::associative          (WrapperAssociative)
- mul::commutative          (WrapperCommutative)
- mul::identityOne          (WrapperIdentity)
- mul::identityOneLeft      (WrapperIdentity)
- sub::antiCommutative      (SimpOmegaUnfold { unfold_fns: ["sub"], … })   ← Step 28
- sub::rightIdentity        (WrapperSubRightIdentity)
```

13/15 law_auto.av laws now pinned. The remaining 2 (`incCount::existingKeyIncrements`, `incCount::keyPresent`) are map-update laws — Step 29 handles those.

## Architecture

Producer (`proof_lower::detect_simp_omega_unfold`):
- Validates outer fn (Int params) + all law givens Int.
- Transitively expands the unfold set through entry+dep fn bodies.
- Rejects self-recursive members (single-step unfold problem).
- Detects wrapper return via `FnDef.return_type` string — sidesteps the legacy detector's `ctx.fn_sigs` dependency on full `CodegenContext`.
- ~250 lines of ported detection helpers as private to proof_lower.

Consumer (`lean::law_auto::emit_simp_omega_from_ir`):
- Mirrors the legacy emit body shape but sources `unfold_fns` / `wrapper_return` / `smart_guard` from the IR.
- `wrapper_return` → `unfold <fns>` + by_cases per law-given + `simp [<hyps>, Int.add_comm, Int.mul_comm]`.
- `!wrapper_return` → `simp only [<fns>] <;> omega`.

## Test plan

- [x] `cargo test --lib` (615 pass)
- [x] `cargo test --test proof_ir_diff` (21 pass — new test `simp_omega_unfold_pinned_on_sub_anti_comm_via_zero` asserts the IR carries `unfold_fns: ["sub"]`, `wrapper_return: false`)
- [x] `cargo test --test proof_spec` (35 pass — emit byte-identical: `simp only [sub] <;> omega` for the smoke case)
- [x] `cargo test --test explain_passes_spec` (5 pass)

## Follow-up

- Step 29: map laws (`emit_direct_map_set_law`, `emit_map_update_law`, `emit_map_increment_tracked_count_law`)
- Step 30: structural `Induction { param }`
- Step 31: `emit_guarded_domain_law`
- Step 32: retire `BackendDispatch` once every theorem has a pinned strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)