### PR TITLE
ProofIR: rename Wrapper* strategies to algebraic property names

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -82,45 +82,38 @@ pub fn emit_verify_law_forall_auto_proof(
         let fn_lean = aver_name_to_lean(&vb.fn_name);
         let proof_lines = match strategy {
             ProofStrategy::Reflexive => Some(vec!["rfl".to_string()]),
-            ProofStrategy::WrapperCommutative { op } => match op {
+            ProofStrategy::Commutative { op } => match op {
                 BinOp::Add => Some(vec![format!("simp [{}, Int.add_comm]", fn_lean)]),
                 BinOp::Mul => Some(vec![format!("simp [{}, Int.mul_comm]", fn_lean)]),
                 _ => None,
             },
-            ProofStrategy::WrapperAssociative { op } => match op {
+            ProofStrategy::Associative { op } => match op {
                 BinOp::Add => Some(vec![format!("simp [{}, Int.add_assoc]", fn_lean)]),
                 BinOp::Mul => Some(vec![format!("simp [{}, Int.mul_assoc]", fn_lean)]),
                 _ => None,
             },
-            ProofStrategy::WrapperIdentity { .. } => {
+            ProofStrategy::IdentityElement { .. } => {
                 // Add → `simp [fn]` collapses `a + 0` / `0 + a`;
-                // Mul → same against `a * 1` / `1 * a`. The IR's
-                // op tag is implicit in the wrapper fn body Lean
-                // unfolds.
+                // Mul → same against `a * 1` / `1 * a`; Sub →
+                // `simp [fn]` reduces `a - 0` to `a` (one-sided —
+                // detector enforces shape). Op-agnostic emit:
+                // unfold the wrapper and simp closes via Lean's
+                // built-in identity lemmas.
                 Some(vec![format!("simp [{}]", fn_lean)])
             }
-            ProofStrategy::WrapperSubRightIdentity => {
-                // `sub(a, 0) => a` unfolds the wrapper; Lean's
-                // `simp [sub]` reduces `a - 0` to `a` without
-                // extra lemmas.
-                Some(vec![format!("simp [{}]", fn_lean)])
-            }
-            ProofStrategy::WrapperUnaryEquivalence { ref inner_fn } => {
-                // `outer(a) = inner(a, K)` (or `inner(K, a)`) over
-                // the same op. Lean's `simp [outer, inner]`
-                // collapses both wrappers to the underlying op
-                // expression on both sides.
+            ProofStrategy::UnaryEqualsBinary { ref inner_fn } => {
+                // `outer(a) = inner(a, K)` (or `inner(K, a)`) —
+                // simp unfolds both fns to the same underlying op
+                // expression on each side.
                 Some(vec![format!(
                     "simp [{}, {}]",
                     fn_lean,
                     aver_name_to_lean(inner_fn)
                 )])
             }
-            ProofStrategy::WrapperSubAntiCommutative { neg_on_rhs } => {
-                // `Int.neg_sub b a : -(b - a) = a - b`. When the
-                // negation sits on the rhs of the user's law we
-                // need `.symm` to align directions; when it's on
-                // the lhs the law statement already matches.
+            ProofStrategy::AntiCommutative { neg_on_rhs, .. } => {
+                // `Int.neg_sub b a : -(b - a) = a - b`. `.symm` flip
+                // when the user's law puts the negation on rhs.
                 let a = aver_name_to_lean(&law.givens[0].name);
                 let b = aver_name_to_lean(&law.givens[1].name);
                 let step = if neg_on_rhs {
@@ -130,10 +123,10 @@ pub fn emit_verify_law_forall_auto_proof(
                 };
                 Some(vec![step])
             }
-            // SimpOmegaUnfold runs at its position in the chain
+            // LinearArithmetic runs at its position in the chain
             // (below spec_equivalence + maps) — falls through here
             // and emits in the dedicated arm further down.
-            ProofStrategy::SimpOmegaUnfold { .. } => None,
+            ProofStrategy::LinearArithmetic { .. } => None,
             _ => None,
         };
         if let Some(lines) = proof_lines {
@@ -195,7 +188,7 @@ pub fn emit_verify_law_forall_auto_proof(
             // `wrapper_return`, `smart_guard`. When the IR didn't
             // pin (BackendDispatch), fall through to the legacy
             // detector below.
-            if let Some(crate::ir::ProofStrategy::SimpOmegaUnfold {
+            if let Some(crate::ir::ProofStrategy::LinearArithmetic {
                 ref unfold_fns,
                 wrapper_return,
                 ref smart_guard,

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -558,18 +558,22 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
 
 /// Pick the strategy `LawLower` should pin on a `(fn, law)` pair.
 ///
-/// Decision order (later steps fold in more shapes):
-/// 1. `Reflexive` — `law.lhs == law.rhs` syntactically.
-/// 2. `WrapperCommutative { op }` — 2-arg Int wrapper whose body
-///    is `BinOp::Add` / `BinOp::Mul` (commutator-lemma-bearing
-///    ops), claim matches `f(a,b) = f(b,a)`.
-/// 3. `WrapperAssociative { op }` — same wrapper shape, 3 givens,
-///    claim matches `f(f(a,b),c) = f(a,f(b,c))`.
-/// 4. `WrapperIdentity { op }` — 1 given, claim matches
-///    `f(a, identity_of(op)) = a` (`0` for Add, `1` for Mul).
-/// 5. `BackendDispatch` — fall through to the backend chain
-///    (sub variants, unary-equivalence, induction, simp+omega,
-///    etc. — Step 26+ pins more).
+/// Decision order — specific algebraic properties first, then
+/// generic linear-arithmetic catch-all, then `BackendDispatch`:
+/// 1. `Reflexive` — `law.lhs ≡ law.rhs` syntactically.
+/// 2. `Commutative { op }` — fn body is `a <op> b`, claim is
+///    `f(a, b) = f(b, a)` (op restricted to commutative ones).
+/// 3. `Associative { op }` — same body, 3 givens, assoc claim.
+/// 4. `IdentityElement { op }` — `f(a, e) = a` (or `f(e, a) = a`),
+///    where `e` is the op's identity. Covers Add/Mul both-sided
+///    plus Sub right-sided.
+/// 5. `AntiCommutative { op: Sub, neg_on_rhs }` — `f(a, b) =
+///    -f(b, a)` form. Sub-only (Mul has no anti-commutative law).
+/// 6. `UnaryEqualsBinary { inner_fn }` — outer fn is unary, claim
+///    binds it to the inner binary fn at a constant.
+/// 7. `LinearArithmetic { unfold_fns, ... }` — catch-all when the
+///    law reduces to linear arith after unfolding the call chain.
+/// 8. `BackendDispatch` — backend's ad-hoc chain decides.
 fn classify_law_strategy(
     law: &crate::ast::VerifyLaw,
     fn_name: &str,
@@ -581,45 +585,43 @@ fn classify_law_strategy(
         return ProofStrategy::Reflexive;
     }
     // Binary-wrapper-shaped laws first. `wrapper_binop` returns
-    // `None` for non-binary fns — unary wrappers (Step 27 below)
-    // are tried after this block falls through.
+    // `None` for non-binary fns — unary wrappers are tried after
+    // this block falls through.
     if let Some(op) = wrapper_binop(fn_name, inputs) {
         if detect_wrapper_commutative(law, fn_name, op) {
-            return ProofStrategy::WrapperCommutative { op };
+            return ProofStrategy::Commutative { op };
         }
         if detect_wrapper_associative(law, fn_name, op) {
-            return ProofStrategy::WrapperAssociative { op };
+            return ProofStrategy::Associative { op };
         }
         if detect_wrapper_identity(law, fn_name, op) {
-            return ProofStrategy::WrapperIdentity { op };
+            return ProofStrategy::IdentityElement { op };
         }
-        // Sub-specific shapes (right identity + anti-commutative).
-        // Add/Mul wrappers can't fit these — Sub's negation
-        // behaviour is structurally different, and Mul has no
-        // anti-commutative law (commutative).
-        if matches!(op, crate::ast::BinOp::Sub) {
-            if detect_wrapper_sub_right_identity(law, fn_name) {
-                return ProofStrategy::WrapperSubRightIdentity;
-            }
-            if let Some(neg_on_rhs) = detect_wrapper_sub_anti_commutative(law, fn_name) {
-                return ProofStrategy::WrapperSubAntiCommutative { neg_on_rhs };
-            }
+        // Sub right-identity collapses into IdentityElement —
+        // same emit (`simp [fn]`), different lhs/rhs shape. The
+        // detector validates the right-side `f(a, 0) = a` form
+        // (`f(0, a) = -a` doesn't equal `a`, so Sub is one-sided).
+        if matches!(op, crate::ast::BinOp::Sub) && detect_wrapper_sub_right_identity(law, fn_name) {
+            return ProofStrategy::IdentityElement { op };
+        }
+        // Anti-commutative is Sub-specific (Add/Mul are
+        // commutative, no anti-commutativity). The op tag keeps
+        // it parameterised even though only Sub currently fires.
+        if matches!(op, crate::ast::BinOp::Sub)
+            && let Some(neg_on_rhs) = detect_wrapper_sub_anti_commutative(law, fn_name)
+        {
+            return ProofStrategy::AntiCommutative { op, neg_on_rhs };
         }
     }
-    // Unary↔binary wrapper equivalence — `fn_name` is the OUTER
-    // (unary) wrapper, the law's other side calls an inner binary
-    // wrapper with the unary's constant baked in. Independent of
-    // the binary-wrapper branch above (a unary `addOne(a) = a + 1`
-    // fails `wrapper_binop` because it has only one param).
+    // Unary fn equal to binary fn at a constant — `fn_name` is the
+    // unary outer; the binary fn name is captured for backends.
     if let Some(inner_fn) = detect_wrapper_unary_equivalence(law, fn_name, inputs) {
-        return ProofStrategy::WrapperUnaryEquivalence { inner_fn };
+        return ProofStrategy::UnaryEqualsBinary { inner_fn };
     }
-    // `simp + omega` over an unfolded fn chain — generic catch-all
-    // for Int laws whose two sides reduce to flat arithmetic once
-    // every reachable fn is unfolded. Runs last so the more-
-    // specific wrapper strategies pin their shapes first.
+    // Linear arithmetic over an unfold chain — generic catch-all.
+    // Named for the semantic, not the backend tactic.
     if let Some(plan) = detect_simp_omega_unfold(law, fn_name, inputs) {
-        return ProofStrategy::SimpOmegaUnfold {
+        return ProofStrategy::LinearArithmetic {
             unfold_fns: plan.unfold_fns,
             wrapper_return: plan.wrapper_return,
             smart_guard: plan.smart_guard,

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -329,85 +329,85 @@ pub enum QuantifierType {
     OracleSubtype(String),
 }
 
-/// Auto-proof strategy the lowerer chose for the universal theorem.
-/// Backends translate to their tactic vocabulary (Lean: `simp;
-/// omega`, Dafny: empty body, etc.).
+/// Algebraic / proof-theoretic shape of a verify-law theorem.
+///
+/// **Naming rule**: variants describe **what the law says**, not
+/// **how a backend proves it**. The IR is target-agnostic — Lean
+/// maps `Commutative { op: Add }` to `simp [fn, Int.add_comm]`,
+/// Dafny maps the same variant to its own lemma vocabulary, a Z3
+/// backend could ship a different tactic again. Tactic names
+/// (`SimpOverLemmas`, `simp+omega`) do not appear in variant names;
+/// `LinearArithmetic` is named for the semantic, not the tactic.
 #[derive(Debug, Clone)]
 pub enum ProofStrategy {
-    /// `rfl` / definitional equality.
+    /// `rfl` / definitional equality — `lhs ≡ rhs` syntactically.
     Reflexive,
     /// `simp` chain over named lemmas (e.g. `[Int.add_comm,
-    /// Int.mul_comm]`).
+    /// Int.mul_comm]`). Legacy draft variant; not yet emitted by
+    /// the lowerer — kept for future use when a strategy wants to
+    /// hand the backend a specific lemma list.
     SimpOverLemmas(Vec<String>),
-    /// Commutative law over a 2-arg Int-Int wrapper:
-    /// `wrapper(a, b) => wrapper(b, a)`. Backend renders as
-    /// `simp [<wrapper_name>, <op-comm-lemma>]` where the lemma
-    /// is derived from `op` (`Add → Int.add_comm`, `Mul → Int.
-    /// mul_comm`). Op stays in IR so backends pick their own
-    /// lemma vocabulary (Dafny would use a different incantation).
-    WrapperCommutative { op: crate::ast::BinOp },
-    /// Associative law over the same shape:
-    /// `wrapper(wrapper(a,b),c) => wrapper(a,wrapper(b,c))`.
-    WrapperAssociative { op: crate::ast::BinOp },
-    /// Identity-element law (`wrapper(a, 0) => a` for `Add`,
-    /// `wrapper(a, 1) => a` for `Mul`). The identity literal is
-    /// determined by `op` — backends compute it directly.
-    WrapperIdentity { op: crate::ast::BinOp },
-    /// Right-identity over a 2-arg Sub wrapper: `sub(a, 0) => a`.
-    /// Sub-specific because subtraction's identity is one-sided —
-    /// the symmetric `0 - a` is `-a`, not `a`, so it doesn't fit
-    /// `WrapperIdentity`.
-    WrapperSubRightIdentity,
-    /// Anti-commutative law over a 2-arg Sub wrapper:
-    /// `sub(a, b) => -sub(b, a)` or the swapped arrangement.
-    /// `neg_on_rhs` records which side carries the negation —
-    /// drives the `.symm` flip on backends that prove via
-    /// `Int.neg_sub`.
-    WrapperSubAntiCommutative {
-        /// `true` for `sub(a, b) => -sub(b, a)`, `false` for the
-        /// swapped form `-sub(b, a) => sub(a, b)`.
+    /// `∀ a b, f(a, b) = f(b, a)` — commutativity of the law's fn,
+    /// whose body reduces to `a <op> b`. The `op` tag lets backends
+    /// pick their own lemma vocabulary (Lean: `Int.add_comm`,
+    /// Dafny: built-in arithmetic axioms).
+    Commutative { op: crate::ast::BinOp },
+    /// `∀ a b c, f(f(a,b),c) = f(a,f(b,c))` — associativity of `f`.
+    Associative { op: crate::ast::BinOp },
+    /// `∀ a, f(a, e) = a` (or the swapped `f(e, a) = a`) — the
+    /// identity-element law for the underlying op (`e` = `0` for
+    /// Add / Sub, `1` for Mul). Backends emit `simp [fn]` (the
+    /// wrapper's body unfolds to the identity equation, which simp
+    /// closes); the variant doesn't need a `side` field because
+    /// the emit is symmetric — Sub is naturally one-sided (only
+    /// right-identity), Add/Mul accept either side. The lowerer
+    /// guarantees the law's actual shape matches the op's identity
+    /// behaviour before pinning.
+    IdentityElement { op: crate::ast::BinOp },
+    /// `∀ a b, f(a, b) = -f(b, a)` (or the swapped negation).
+    /// `neg_on_rhs` records which side carries the `-` wrap so
+    /// backends with directional lemmas (Lean's `Int.neg_sub b a :
+    /// -(b - a) = a - b`) can flip via `.symm` correctly.
+    AntiCommutative {
+        op: crate::ast::BinOp,
+        /// `true` for `f(a, b) = -f(b, a)` (negation on rhs);
+        /// `false` for the swapped arrangement.
         neg_on_rhs: bool,
     },
-    /// Equivalence between a unary wrapper and a binary wrapper
-    /// over the same op, e.g. `fn addOne(a) -> a + 1` plus
-    /// `verify addOne law identityViaAdd ... addOne(a) => add(a, 1)`.
-    /// The IR captures the inner binary fn name so the backend
-    /// renders `simp [<outer>, <inner>]` without re-scanning the
-    /// AST for the equivalent.
-    WrapperUnaryEquivalence {
-        /// Source-level name of the inner binary wrapper the unary
-        /// fn equals (the law's "other side" calls this).
+    /// `∀ a, g(a) = f(a, c)` or `f(c, a)` — the unary fn `g` is
+    /// the binary fn `f` with one argument bound to constant `c`.
+    /// Backends unfold both fns to expose the underlying op; the
+    /// IR carries `inner_fn` (the binary's source name) so the
+    /// unfold list is unambiguous.
+    UnaryEqualsBinary {
+        /// Source-level name of the binary fn the unary one equals.
         inner_fn: String,
     },
-    /// `simp + omega` over an unfolded fn chain — the generic
-    /// catch-all for Int laws whose lhs/rhs reduce to flat linear
-    /// arithmetic once every reachable fn is unfolded. Triggers when
-    /// every given is `Int` and the transitive fn-call closure of
-    /// the law's two sides is non-recursive. The backend emits a
-    /// `simp only [<unfold_fns>] <;> omega` chain, optionally
-    /// wrapped in `by_cases` when a refinement smart constructor
-    /// sits in the chain (its guard goes on top so omega doesn't
-    /// face an `Except.ok` / `Except.err` split).
-    SimpOmegaUnfold {
-        /// Ordered fn unfold list. Top-level law fn comes first —
-        /// Lean's `unfold` resolves left-to-right and the call
-        /// layer the tactic peels at each step must match the goal
-        /// shape.
+    /// "Linear arithmetic over an unfold chain" — the law's two
+    /// sides reduce to a flat linear equation on Int once every
+    /// reachable user fn is unfolded. Generic catch-all for Int
+    /// laws that don't fit a named algebraic property. The IR
+    /// captures the unfold list + wrapper-return signal +
+    /// refinement smart-constructor guard; backends translate to
+    /// their decision procedure (Lean: `simp + omega`, Dafny: Z3
+    /// linear int prover). Named for the **semantic** ("linear
+    /// arithmetic"), not the Lean tactic.
+    LinearArithmetic {
+        /// Ordered fn unfold list. Top-level law fn first — Lean's
+        /// `unfold` resolves left-to-right and the call layer the
+        /// tactic peels at each step must match the goal shape.
         unfold_fns: Vec<String>,
         /// `true` when at least one fn in `unfold_fns` returns a
-        /// wrapper (Result, Option, …). Drives the by_cases branch
-        /// in the emit — `omega` is a linear-arithmetic decision
-        /// procedure that can't close constructor-equality goals,
-        /// so the wrapper case splits on the smart-constructor
-        /// guard predicate first.
+        /// wrapper (Result, Option, …). Drives extra case-split
+        /// machinery in the emit — pure linear-arithmetic provers
+        /// can't close constructor-equality goals, so the wrapper
+        /// case splits on the smart-constructor guard first.
         wrapper_return: bool,
-        /// Smart-constructor guard pulled from the first refinement
+        /// Smart-constructor guard pulled from a refinement
         /// `fromX(p: Int) -> Result<X, _>` in the unfold chain.
-        /// `Some` when one was found; `None` falls back to the
-        /// conservative `(n ≥ 0)` predicate on the wrapper-return
-        /// path. The pair carries the smart constructor's parameter
-        /// name (so the law-quantified var can be substituted in)
-        /// and the Bool subject of the constructor's `match`.
+        /// `Some` when one was found; `None` falls back to a
+        /// conservative `(n ≥ 0)` default when `wrapper_return`
+        /// forces case-splitting.
         smart_guard: Option<SmartGuard>,
     },
     /// Structural induction on a recursive ADT parameter.

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -768,12 +768,12 @@ fn law_lower_populates_theorems_from_verify_law_blocks() {
         theorem.premises
     );
     // `add(a, b) => add(b, a)` — Step 25 pins
-    // `WrapperCommutative { op: Add }` for this shape (2-arg Int
+    // `Commutative { op: Add }` for this shape (2-arg Int
     // wrapper around `BinOp::Add`).
     assert!(
         matches!(
             theorem.strategy,
-            aver::ir::ProofStrategy::WrapperCommutative {
+            aver::ir::ProofStrategy::Commutative {
                 op: aver::ast::BinOp::Add
             }
         ),
@@ -814,7 +814,7 @@ fn reflexive_law_pinned_when_lhs_equals_rhs() {
 #[test]
 fn wrapper_associative_pinned_on_three_int_givens_assoc_shape() {
     // `add(add(a,b),c) => add(a,add(b,c))` over `fn add(a,b) -> a+b`
-    // — Step 25 pins `WrapperAssociative { op: Add }`.
+    // — Step 25 pins `Associative { op: Add }`.
     let src = "module M\n\
          \x20   intent = \"t\"\n\
          \n\
@@ -836,7 +836,7 @@ fn wrapper_associative_pinned_on_three_int_givens_assoc_shape() {
     assert!(
         matches!(
             theorem.strategy,
-            aver::ir::ProofStrategy::WrapperAssociative {
+            aver::ir::ProofStrategy::Associative {
                 op: aver::ast::BinOp::Add
             }
         ),
@@ -848,7 +848,7 @@ fn wrapper_associative_pinned_on_three_int_givens_assoc_shape() {
 #[test]
 fn wrapper_identity_pinned_on_add_with_zero_rhs() {
     // `add(a, 0) => a` over `fn add(a,b) -> a+b` — pins
-    // `WrapperIdentity { op: Add }`. The identity literal is
+    // `IdentityElement { op: Add }`. The identity literal is
     // implicit (`0` for Add; `1` for Mul).
     let src = "module M\n\
          \x20   intent = \"t\"\n\
@@ -869,7 +869,7 @@ fn wrapper_identity_pinned_on_add_with_zero_rhs() {
     assert!(
         matches!(
             theorem.strategy,
-            aver::ir::ProofStrategy::WrapperIdentity {
+            aver::ir::ProofStrategy::IdentityElement {
                 op: aver::ast::BinOp::Add
             }
         ),
@@ -881,7 +881,7 @@ fn wrapper_identity_pinned_on_add_with_zero_rhs() {
 #[test]
 fn wrapper_sub_right_identity_pinned_on_sub_with_zero_rhs() {
     // `sub(a, 0) => a` over `fn sub(a, b) -> a - b` — Step 26 pins
-    // `WrapperSubRightIdentity`. Sub-specific because subtraction's
+    // `IdentityElement { op: aver::ast::BinOp::Sub }`. Sub-specific because subtraction's
     // identity is one-sided.
     let src = "module M\n\
          \x20   intent = \"t\"\n\
@@ -902,9 +902,11 @@ fn wrapper_sub_right_identity_pinned_on_sub_with_zero_rhs() {
     assert!(
         matches!(
             theorem.strategy,
-            aver::ir::ProofStrategy::WrapperSubRightIdentity
+            aver::ir::ProofStrategy::IdentityElement {
+                op: aver::ast::BinOp::Sub
+            }
         ),
-        "expected WrapperSubRightIdentity, got: {:?}",
+        "expected IdentityElement {{ op: Sub }}, got: {:?}",
         theorem.strategy,
     );
 }
@@ -912,7 +914,7 @@ fn wrapper_sub_right_identity_pinned_on_sub_with_zero_rhs() {
 #[test]
 fn wrapper_sub_anti_commutative_pinned_with_neg_direction() {
     // `sub(a, b) => -sub(b, a)` over `fn sub(a, b) -> a - b` —
-    // `WrapperSubAntiCommutative { neg_on_rhs: true }`. The IR's
+    // `AntiCommutative { op: aver::ast::BinOp::Sub, neg_on_rhs: true }`. The IR's
     // direction flag drives `.symm` selection on the Lean side.
     let src = "module M\n\
          \x20   intent = \"t\"\n\
@@ -934,7 +936,10 @@ fn wrapper_sub_anti_commutative_pinned_with_neg_direction() {
     assert!(
         matches!(
             theorem.strategy,
-            aver::ir::ProofStrategy::WrapperSubAntiCommutative { neg_on_rhs: true }
+            aver::ir::ProofStrategy::AntiCommutative {
+                op: aver::ast::BinOp::Sub,
+                neg_on_rhs: true
+            }
         ),
         "expected WrapperSubAntiCommutative {{ neg_on_rhs: true }}, got: {:?}",
         theorem.strategy,
@@ -945,7 +950,7 @@ fn wrapper_sub_anti_commutative_pinned_with_neg_direction() {
 fn wrapper_unary_equivalence_pinned_with_inner_fn_name() {
     // `addOne(a) => add(a, 1)` over `fn addOne(a) -> a + 1` and
     // `fn add(a, b) -> a + b` — Step 27 pins
-    // `WrapperUnaryEquivalence { inner_fn: "add" }`. The inner fn
+    // `UnaryEqualsBinary { inner_fn: "add" }`. The inner fn
     // name lives in the IR so the backend renders
     // `simp [addOne, add]` without rescanning.
     let src = "module M\n\
@@ -967,11 +972,8 @@ fn wrapper_unary_equivalence_pinned_with_inner_fn_name() {
         .iter()
         .find(|t| t.fn_name == "addOne" && t.law_name == "identityViaAdd")
         .expect("addOne::identityViaAdd law theorem missing");
-    let aver::ir::ProofStrategy::WrapperUnaryEquivalence { ref inner_fn } = theorem.strategy else {
-        panic!(
-            "expected WrapperUnaryEquivalence, got: {:?}",
-            theorem.strategy
-        );
+    let aver::ir::ProofStrategy::UnaryEqualsBinary { ref inner_fn } = theorem.strategy else {
+        panic!("expected UnaryEqualsBinary, got: {:?}", theorem.strategy);
     };
     assert_eq!(inner_fn, "add");
 }
@@ -980,7 +982,7 @@ fn wrapper_unary_equivalence_pinned_with_inner_fn_name() {
 fn simp_omega_unfold_pinned_on_sub_anti_comm_via_zero() {
     // `sub(a, b) => 0 - sub(b, a)` doesn't fit
     // WrapperSubAntiCommutative (that requires `Neg(call)` form);
-    // falls through to SimpOmegaUnfold. The IR captures the
+    // falls through to LinearArithmetic. The IR captures the
     // unfold list (just `sub` — non-recursive) plus
     // `wrapper_return: false` (sub returns Int).
     let src = "module M\n\
@@ -1000,13 +1002,13 @@ fn simp_omega_unfold_pinned_on_sub_anti_comm_via_zero() {
         .iter()
         .find(|t| t.fn_name == "sub" && t.law_name == "antiCommutative")
         .expect("sub::antiCommutative law theorem missing");
-    let aver::ir::ProofStrategy::SimpOmegaUnfold {
+    let aver::ir::ProofStrategy::LinearArithmetic {
         ref unfold_fns,
         wrapper_return,
         ref smart_guard,
     } = theorem.strategy
     else {
-        panic!("expected SimpOmegaUnfold, got: {:?}", theorem.strategy);
+        panic!("expected LinearArithmetic, got: {:?}", theorem.strategy);
     };
     assert!(unfold_fns.contains(&"sub".to_string()));
     assert!(!wrapper_return, "sub returns Int, not a wrapper");


### PR DESCRIPTION
## Summary

`ProofStrategy` variant names had a `Wrapper*` prefix tied to the Aver source pattern (the law's outer fn was a wrapper around a primitive op). That's incidental — the IR is supposed to describe **what the law says**, not the surface form. Backend renaming + future spellings of the same algebraic law shouldn't carry a misnomer in the IR.

## Renames

| Before | After |
|---|---|
| `WrapperCommutative { op }` | `Commutative { op }` |
| `WrapperAssociative { op }` | `Associative { op }` |
| `WrapperIdentity { op }` | `IdentityElement { op }` |
| `WrapperSubRightIdentity` | folded into `IdentityElement { op: Sub }` |
| `WrapperSubAntiCommutative { neg_on_rhs }` | `AntiCommutative { op, neg_on_rhs }` |
| `WrapperUnaryEquivalence { inner_fn }` | `UnaryEqualsBinary { inner_fn }` |
| `SimpOmegaUnfold { ... }` | `LinearArithmetic { ... }` |

`WrapperSubRightIdentity` folds into `IdentityElement { op: Sub }` because both variants emit identically (`simp [fn]`); the detector enforces Sub's one-sided shape (`f(a, 0) = a` only) before pinning. `AntiCommutative` gains an `op` field for parameterisation even though only `Sub` currently fires — keeps the variant open for future generalisations.

`SimpOmegaUnfold` rename is the most semantically meaningful — it was named for the **Lean tactic** (simp + omega), but Dafny's equivalent uses Z3, and a future Z3-direct backend would use yet another. The IR now describes the **semantic** ("this law is linear arithmetic over an unfold chain") and backends translate to their own decision procedure.

## Docs

`ProofStrategy` enum-level docstring now spells out the naming rule:

> **Naming rule**: variants describe **what the law says**, not **how a backend proves it**. The IR is target-agnostic — Lean maps `Commutative { op: Add }` to `simp [fn, Int.add_comm]`, Dafny maps the same variant to its own lemma vocabulary, a Z3 backend could ship a different tactic again. Tactic names do not appear in variant names.

## Test plan

- [x] `cargo test --lib` (615 pass)
- [x] `cargo test --test proof_ir_diff` (21 pass — variant names updated in assertions)
- [x] `cargo test --test proof_spec` (35 pass — Lean emit byte-identical to pre-rename)
- [x] `cargo test --test explain_passes_spec` (5 pass)
- [x] Smoke: `aver compile --emit-ir-after=law_lower examples/formal/law_auto.av` produces the renamed variant names

## Follow-up

Step 30: lift the `refinement_auto_proof` bypass in `lean/toplevel.rs:1889` into the law_auto chain so refinement-lifted laws flow through the same IR-pinned dispatch as everything else (instead of an Aver-specific code path that bypasses ProofIR). After that, the lowerer's strategy decisions become source-of-truth for every law, including refinement ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)