### PR TITLE
ProofIR: lift refinement_auto_proof bypass into IR strategy (Step 30)

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -192,15 +192,28 @@ pub fn emit_verify_law_forall_auto_proof(
                 ref unfold_fns,
                 wrapper_return,
                 ref smart_guard,
+                lifted,
             }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
             {
+                // Lifted laws use base intro names — the Subtype
+                // lift incorporates the `when` premise into the
+                // theorem's quantifier types, so the user-side
+                // hypotheses (`h_a`, `h_b`, `h_when`) aren't
+                // available in the proof goal. Non-lifted paths
+                // keep premise expansion for by_cases hypotheses.
+                let chosen_intro: &[String] = if lifted {
+                    &intro_names
+                } else {
+                    &proof_intro_names
+                };
                 return Some(AutoProof {
                     support_lines: Vec::new(),
                     proof_lines: emit_simp_omega_from_ir(
                         unfold_fns,
                         wrapper_return,
                         smart_guard.as_ref(),
-                        &proof_intro_names,
+                        lifted,
+                        chosen_intro,
                         ctx,
                     ),
                     replaces_theorem: false,
@@ -234,11 +247,26 @@ fn emit_simp_omega_from_ir(
     unfold_fns: &[String],
     wrapper_return: bool,
     smart_guard: Option<&crate::ir::SmartGuard>,
+    lifted: bool,
     intro_names: &[String],
     ctx: &CodegenContext,
 ) -> Vec<String> {
     let lean_names: Vec<String> = unfold_fns.iter().map(|n| aver_name_to_lean(n)).collect();
-    if wrapper_return {
+    if lifted && wrapper_return {
+        // Subtype/subset lift carries the smart-constructor
+        // invariant in the type — the law-quantified vars are
+        // already `Natural` (etc.) in the theorem statement, so
+        // by_cases case-split is unnecessary. Plain unfold + simp
+        // with arithmetic lemmas closes via Lean's built-in
+        // commutativity normalisation.
+        intro_then(
+            intro_names,
+            vec![
+                format!("unfold {}", lean_names.join(" ")),
+                "simp [Int.add_comm, Int.mul_comm]".to_string(),
+            ],
+        )
+    } else if wrapper_return {
         let by_cases_clauses: Vec<String> = intro_names
             .iter()
             .map(|n| {

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1879,77 +1879,14 @@ fn emit_verify_law_block(
             rhs: law_rhs.clone(),
             sample_guards: law.sample_guards.clone(),
         };
-        // Refinement-lifted theorem (∀ a b : Natural, …) closes
-        // through a trivial unfold + `Int.add_comm` / `Int.mul_comm`
-        // rewrite — the Subtype invariant is in the type, so no
-        // by_cases or `simp [hyp]` machinery is needed. Emit
-        // directly here, skipping the auto_proof chain whose
-        // wrapper-return tactic was the last consumer of the
-        // by_cases heuristic.
-        let refinement_auto_proof = if !lifted_vars.is_empty()
-            && matches!(verify_mode, VerifyEmitMode::NativeDecide)
-        {
-            let intro_names: Vec<String> = law
-                .givens
-                .iter()
-                .map(|g| aver_name_to_lean(&g.name))
-                .collect();
-            let mut fn_names = std::collections::BTreeSet::new();
-            collect_user_fn_calls(&law_lhs, &mut fn_names);
-            collect_user_fn_calls(&law_rhs, &mut fn_names);
-            fn_names.insert(vb.fn_name.clone());
-            // Transitively expand so the unfold list reaches every
-            // user fn the law's body walks through (same expansion
-            // strategy as `emit_simp_omega_law` in `law_auto.rs`).
-            loop {
-                let before = fn_names.len();
-                let snapshot: Vec<String> = fn_names.iter().cloned().collect();
-                for item in &ctx.items {
-                    if let crate::ast::TopLevel::FnDef(fd) = item
-                        && snapshot.contains(&fd.name)
-                    {
-                        for stmt in fd.body.stmts() {
-                            let (crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e)) =
-                                stmt;
-                            collect_user_fn_calls(e, &mut fn_names);
-                        }
-                    }
-                }
-                if fn_names.len() == before {
-                    break;
-                }
-            }
-            // Top-level law fn first so `unfold` sees it in the
-            // goal before transitively-reached callees.
-            let mut ordered: Vec<String> = Vec::new();
-            if fn_names.contains(&vb.fn_name) {
-                ordered.push(vb.fn_name.clone());
-            }
-            for n in &fn_names {
-                if n != &vb.fn_name {
-                    ordered.push(n.clone());
-                }
-            }
-            let lean_names: Vec<String> = ordered.iter().map(|n| aver_name_to_lean(n)).collect();
-            let intro_clause = if intro_names.is_empty() {
-                String::new()
-            } else {
-                format!("  intro {}\n", intro_names.join(" "))
-            };
-            let proof_body = format!(
-                "{intro_clause}  unfold {}\n  simp [Int.add_comm, Int.mul_comm]",
-                lean_names.join(" ")
-            );
-            Some(proof_body)
-        } else {
-            None
-        };
-        if let Some(proof_body) = refinement_auto_proof {
-            lines.push(format!(
-                "theorem {} : ∀ {}, {} := by\n{}",
-                theorem_base, quant_params, theorem_prop, proof_body
-            ));
-        } else if let Some(auto_proof) = emit_verify_law_forall_auto_proof(
+        // (Removed: refinement_auto_proof — Aver-specific bypass.
+        // Refinement-lifted laws now flow through law_auto via the
+        // IR-pinned `ProofStrategy::LinearArithmetic { lifted: true }`.
+        // The lowerer detects the `Refined(value = given)` carrier
+        // shape and pins the strategy; emit_simp_omega_from_ir
+        // skips by_cases when lifted=true. Step 30 retired this
+        // separate code path so all laws go through one dispatch.)
+        if let Some(auto_proof) = emit_verify_law_forall_auto_proof(
             vb,
             &law_for_auto_proof,
             ctx,
@@ -2361,49 +2298,4 @@ pub fn emit_mutual_group_proof(fns: &[&FnDef], ctx: &CodegenContext) -> String {
 
     lines.push("end".to_string());
     lines.join("\n")
-}
-
-/// Collect user-defined fn names referenced anywhere in `expr`,
-/// following the same last-segment-lowercase filter
-/// `law_auto::collect_fn_calls` uses (skip built-in namespace
-/// handles like `List.len`, keep cross-module `Modules.X.Y.fn`
-/// because their leaf segment starts lower-case).
-fn collect_user_fn_calls(expr: &Spanned<Expr>, out: &mut std::collections::BTreeSet<String>) {
-    match &expr.node {
-        Expr::FnCall(callee, args) => {
-            if let Some(name) = crate::codegen::common::expr_to_dotted_name(&callee.node) {
-                let last = name.rsplit('.').next().unwrap_or(&name);
-                if last.chars().next().is_some_and(|c| c.is_lowercase()) {
-                    out.insert(name);
-                }
-            }
-            for a in args {
-                collect_user_fn_calls(a, out);
-            }
-        }
-        Expr::BinOp(_, l, r) => {
-            collect_user_fn_calls(l, out);
-            collect_user_fn_calls(r, out);
-        }
-        Expr::Attr(o, _) => collect_user_fn_calls(o, out),
-        Expr::Neg(i) | Expr::ErrorProp(i) => collect_user_fn_calls(i, out),
-        Expr::Match { subject, arms } => {
-            collect_user_fn_calls(subject, out);
-            for arm in arms {
-                collect_user_fn_calls(&arm.body, out);
-            }
-        }
-        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
-            for it in items {
-                collect_user_fn_calls(it, out);
-            }
-        }
-        Expr::RecordCreate { fields, .. } => {
-            for (_, v) in fields {
-                collect_user_fn_calls(v, out);
-            }
-        }
-        Expr::Constructor(_, Some(arg)) => collect_user_fn_calls(arg, out),
-        _ => {}
-    }
 }

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -542,7 +542,7 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             None => Vec::new(),
         };
 
-        let strategy = classify_law_strategy(law, &vb.fn_name, inputs);
+        let strategy = classify_law_strategy(law, &vb.fn_name, inputs, &ir.refined_types);
 
         ir.law_theorems.push(LawTheorem {
             fn_name: vb.fn_name.clone(),
@@ -578,6 +578,7 @@ fn classify_law_strategy(
     law: &crate::ast::VerifyLaw,
     fn_name: &str,
     inputs: &ProofLowerInputs,
+    refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
 ) -> crate::ir::ProofStrategy {
     use crate::ir::ProofStrategy;
 
@@ -620,11 +621,12 @@ fn classify_law_strategy(
     }
     // Linear arithmetic over an unfold chain — generic catch-all.
     // Named for the semantic, not the backend tactic.
-    if let Some(plan) = detect_simp_omega_unfold(law, fn_name, inputs) {
+    if let Some(plan) = detect_simp_omega_unfold(law, fn_name, inputs, refined_types) {
         return ProofStrategy::LinearArithmetic {
             unfold_fns: plan.unfold_fns,
             wrapper_return: plan.wrapper_return,
             smart_guard: plan.smart_guard,
+            lifted: plan.lifted,
         };
     }
     ProofStrategy::BackendDispatch
@@ -637,23 +639,36 @@ struct SimpOmegaPlan {
     unfold_fns: Vec<String>,
     wrapper_return: bool,
     smart_guard: Option<crate::ir::SmartGuard>,
+    /// `true` when at least one law given is used as a refinement
+    /// carrier in the law body (e.g. `given a: Int` used as
+    /// `Natural(value = a)`). Subtype/subset lift carries the
+    /// invariant in the type, so wrapper case-split is unnecessary.
+    lifted: bool,
 }
 
 fn detect_simp_omega_unfold(
     law: &crate::ast::VerifyLaw,
     fn_name: &str,
     inputs: &ProofLowerInputs,
+    refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
 ) -> Option<SimpOmegaPlan> {
     use std::collections::BTreeSet;
 
-    // Outer fn must take only Int params — `simp + omega` works on
-    // linear arithmetic, not on opaque wrapper types.
     let outer_fd = inputs.find_fn_def_by_call_name(fn_name)?;
-    if outer_fd.params.iter().any(|(_, t)| t != "Int") {
-        return None;
-    }
     // All law givens Int.
     if law.givens.is_empty() || law.givens.iter().any(|g| g.type_name != "Int") {
+        return None;
+    }
+    // Detect refinement lifts — when any given is used as a
+    // `Refined(value = given)` carrier in the law body, the outer
+    // fn may legitimately take the refined type (`fn add(a:
+    // Natural, b: Natural)`) and unfold through the smart
+    // constructor to Int arithmetic. Skip the outer-Int rejection
+    // for lifted laws.
+    let lifted = law.givens.iter().any(|g| {
+        refinement_lift_for_given_ir(&g.name, &law.lhs, &law.rhs, refined_types).is_some()
+    });
+    if !lifted && outer_fd.params.iter().any(|(_, t)| t != "Int") {
         return None;
     }
 
@@ -703,9 +718,10 @@ fn detect_simp_omega_unfold(
         if body_calls_any_of_inputs(&fd.body, &self_only) {
             return None;
         }
-        // Int-only check only for the outer law fn — cross-module
-        // callees may take refined types.
-        if fd.name == fn_name && fd.params.iter().any(|(_, t)| t != "Int") {
+        // Int-only check for the outer law fn — but skip when the
+        // law is refinement-lifted (outer fn takes the refined
+        // type, body unfolds through the smart constructor).
+        if fd.name == fn_name && !lifted && fd.params.iter().any(|(_, t)| t != "Int") {
             return None;
         }
         let ret = fd.return_type.as_str();
@@ -733,7 +749,81 @@ fn detect_simp_omega_unfold(
         unfold_fns: ordered,
         wrapper_return,
         smart_guard,
+        lifted,
     })
+}
+
+/// Backend-neutral analogue of `codegen::common::refinement_lift_
+/// for_given`. Walks `lhs` / `rhs` looking for a `RecordCreate {
+/// type_name, fields: [(_, Ident(given))] }` shape where `type_
+/// name` is a refined type whose carrier matches the given's
+/// declared type. Returns the refined type name on first match.
+///
+/// The legacy version (common.rs) takes `&CodegenContext` and
+/// borrows the type name from `ctx.items`. The lowerer reads
+/// `refined_types` directly off the in-progress `ProofIR`
+/// (populated by `populate_refined_types`, which runs before
+/// `populate_law_theorems` in `lower(...)`).
+fn refinement_lift_for_given_ir(
+    given_name: &str,
+    lhs: &Spanned<crate::ast::Expr>,
+    rhs: &Spanned<crate::ast::Expr>,
+    refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
+) -> Option<String> {
+    let mut result: Option<String> = None;
+    walk_for_refinement_carrier(lhs, given_name, refined_types, &mut result);
+    walk_for_refinement_carrier(rhs, given_name, refined_types, &mut result);
+    result
+}
+
+fn walk_for_refinement_carrier(
+    expr: &Spanned<crate::ast::Expr>,
+    given_name: &str,
+    refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
+    result: &mut Option<String>,
+) {
+    use crate::ast::Expr;
+    if result.is_some() {
+        return;
+    }
+    match &expr.node {
+        Expr::RecordCreate { type_name, fields } if fields.len() == 1 => {
+            let (_, fvalue) = &fields[0];
+            let matches_var = matches!(
+                &fvalue.node,
+                Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == given_name
+            );
+            if matches_var && let Some(decl) = refined_types.get(type_name) {
+                *result = Some(decl.name.clone());
+                return;
+            }
+            // Even non-matching RecordCreate may contain nested
+            // refinement carriers (e.g. `Foo(value = Bar(value = a))`).
+            for (_, v) in fields {
+                walk_for_refinement_carrier(v, given_name, refined_types, result);
+            }
+        }
+        Expr::FnCall(callee, args) => {
+            walk_for_refinement_carrier(callee, given_name, refined_types, result);
+            for a in args {
+                walk_for_refinement_carrier(a, given_name, refined_types, result);
+            }
+        }
+        Expr::BinOp(_, l, r) => {
+            walk_for_refinement_carrier(l, given_name, refined_types, result);
+            walk_for_refinement_carrier(r, given_name, refined_types, result);
+        }
+        Expr::Match { subject, arms, .. } => {
+            walk_for_refinement_carrier(subject, given_name, refined_types, result);
+            for arm in arms {
+                walk_for_refinement_carrier(&arm.body, given_name, refined_types, result);
+            }
+        }
+        Expr::Attr(obj, _) => {
+            walk_for_refinement_carrier(obj, given_name, refined_types, result);
+        }
+        _ => {}
+    }
 }
 
 fn iter_all_fn_defs<'a>(inputs: &'a ProofLowerInputs<'a>) -> impl Iterator<Item = &'a FnDef> {

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -409,6 +409,14 @@ pub enum ProofStrategy {
         /// conservative `(n ≥ 0)` default when `wrapper_return`
         /// forces case-splitting.
         smart_guard: Option<SmartGuard>,
+        /// `true` when at least one law given is lifted to a
+        /// refinement type (`given a: Int` used as `Refined(value
+        /// = a)` in the law body). The Subtype/subset lift carries
+        /// the invariant in the type, so the by_cases case-split
+        /// that `wrapper_return` would otherwise force is
+        /// unnecessary — backends emit a plain unfold + simp
+        /// against arithmetic lemmas.
+        lifted: bool,
     },
     /// Structural induction on a recursive ADT parameter.
     Induction { param: String },

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -3103,7 +3103,15 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
     let captured = std::cell::RefCell::new(None::<Vec<aver::ast::TopLevel>>);
     let target = target_stage.unwrap();
     let neutral_policy = aver::ir::NeutralAllocPolicy;
-    let run_refinement_lower = target == PipelineStage::RefinementLower;
+    // Law lowering reads `proof_ir.refined_types` to detect
+    // refinement-lifted shapes — RefinementLower is a transitive
+    // dependency when targeting LawLower. Without it the lifted
+    // detection always returns false and the diagnostic
+    // misrepresents the law's actual classification.
+    let run_refinement_lower = matches!(
+        target,
+        PipelineStage::RefinementLower | PipelineStage::LawLower
+    );
     let run_contract_lower = target == PipelineStage::ContractLower;
     let run_law_lower = target == PipelineStage::LawLower;
     let proof_target = run_refinement_lower || run_contract_lower || run_law_lower;

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1006,11 +1006,64 @@ fn simp_omega_unfold_pinned_on_sub_anti_comm_via_zero() {
         ref unfold_fns,
         wrapper_return,
         ref smart_guard,
+        lifted,
     } = theorem.strategy
     else {
         panic!("expected LinearArithmetic, got: {:?}", theorem.strategy);
     };
     assert!(unfold_fns.contains(&"sub".to_string()));
     assert!(!wrapper_return, "sub returns Int, not a wrapper");
+    assert!(!lifted, "no refinement lift in plain Int law");
     assert!(smart_guard.is_none(), "no refinement in chain");
+}
+
+#[test]
+fn linear_arithmetic_pinned_with_lifted_for_refinement_law() {
+    // Refinement-lifted law: givens are Int but used as
+    // `Natural(value = a)` carriers in the law body. The outer fn
+    // takes Natural params; the legacy backend bypassed the
+    // strategy chain via `refinement_auto_proof` in toplevel.rs.
+    // Step 30 routes these through `LinearArithmetic { lifted:
+    // true }` — backend skips by_cases (Subtype carries the
+    // invariant) and emits the unfold + simp tactic directly.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         record Natural\n\
+         \x20   value: Int\n\
+         \n\
+         fn fromInt(n: Int) -> Result<Natural, String>\n\
+         \x20   match n >= 0\n\
+         \x20       true -> Result.Ok(Natural(value = n))\n\
+         \x20       false -> Result.Err(\"negative\")\n\
+         \n\
+         fn add(a: Natural, b: Natural) -> Result<Natural, String>\n\
+         \x20   fromInt(a.value + b.value)\n\
+         \n\
+         verify add law commutative\n\
+         \x20   given a: Int = [0, 1, 7]\n\
+         \x20   given b: Int = [0, 1, 7]\n\
+         \x20   when a >= 0\n\
+         \x20   when b >= 0\n\
+         \x20   add(Natural(value = a), Natural(value = b)) => add(Natural(value = b), Natural(value = a))\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "add" && t.law_name == "commutative")
+        .expect("add::commutative law theorem missing");
+    let aver::ir::ProofStrategy::LinearArithmetic {
+        wrapper_return,
+        lifted,
+        ..
+    } = theorem.strategy
+    else {
+        panic!(
+            "expected LinearArithmetic for refinement-lifted law, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert!(wrapper_return, "add returns Result, wrapper");
+    assert!(lifted, "givens used as Natural carriers — lifted=true");
 }


### PR DESCRIPTION
## Summary

The `refinement_auto_proof` block in `lean/toplevel.rs:1889-1947` was a code-specific bypass: refinement-lifted laws (givens used as `Refined(value = a)` carriers) skipped the law_auto strategy chain and emitted directly. After Steps 24-28 the IR pinned strategies for most laws — but refinement-lifted ones ended up `BackendDispatch` in the IR while the actual emit came from a separate code path. **Fidelity gap**: IR metadata diverged from emit decision.

This PR closes the gap. Refinement-lifted laws now flow through the same IR-pinned dispatch as everything else.

## Changes

1. **`LinearArithmetic` gains `lifted: bool`** — `true` when any law given is used as a refinement carrier in the law body.

2. **`proof_lower::detect_simp_omega_unfold`** now reads `proof_ir.refined_types` (populated by `RefinementLower`) to detect refinement lifts. When lifted, accepts non-Int outer fn params — refinement outer fns like `fn add(a: Natural, b: Natural)` are legitimate; the body unfolds through the smart constructor to Int arithmetic.

3. **`lean::law_auto::emit_simp_omega_from_ir`** honours `lifted`: when both `lifted` and `wrapper_return` hold, emits `unfold <fns>; simp [Int.add_comm, Int.mul_comm]` directly — no by_cases, because the Subtype lift carries the smart-constructor invariant in the type.

4. **`refinement_auto_proof` and `collect_user_fn_calls`** deleted from `lean/toplevel.rs`. All laws now go through `emit_verify_law_forall_auto_proof`.

5. **`cmd_emit_ir_after`**: `RefinementLower` is now a transitive dependency of `LawLower`. Without it the lifted detector reads an empty `proof_ir.refined_types` and always returns `lifted: false` — the diagnostic CLI misrepresented the actual classification. Now mirrors production where all three proof stages run together.

## Smoke

```
$ aver compile --emit-ir-after=law_lower examples/refinement/natural/natural.av | grep "^- "
- Natural : { n : Int // <predicate> } witness 0
- add::commutative (LinearArithmetic { unfold_fns: ["add", "fromInt"],
    wrapper_return: true, smart_guard: Some(SmartGuard { ... }),
    lifted: true }, 2 quantifier(s), 1 premise(s))
- mul::commutative (LinearArithmetic { ..., lifted: true }, ...)
```

Lean emit byte-identical to pre-Step-30:
```
theorem add_law_commutative : ∀ (a : Natural) (b : Natural), add a b = add b a := by
  intro a b
  unfold add fromInt
  simp [Int.add_comm, Int.mul_comm]
```

## Test plan

- [x] `cargo test --lib` (615 pass)
- [x] `cargo test --test proof_ir_diff` (22 pass — new test `linear_arithmetic_pinned_with_lifted_for_refinement_law` asserts `lifted: true` for refinement-lifted laws)
- [x] `cargo test --test proof_spec` (35 pass — natural.av Lean emit unchanged)
- [x] `cargo test --test explain_passes_spec` (5 pass)

## Architecture

The user's "to ma być wszystko ogólne, masz generalizować" critique applied directly to `refinement_auto_proof` — an Aver-specific code-path bypass that grew before ProofIR existed. With ProofIR in place + `LinearArithmetic { lifted }` carrying the decision, the bypass has no reason to exist; the lowerer pins the strategy, the backend renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)