### PR TITLE
ProofIR: pin LibraryAxiom strategy for Map.has/get_set_self (Step 32)

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -179,6 +179,44 @@ pub fn emit_verify_law_forall_auto_proof(
         })
         .or_else(|| spec::emit_spec_function_equivalence_law(vb, law, ctx, &proof_intro_names))
         .or_else(|| {
+            // IR-pinned Map library axiom (has_set_self / get_set_self).
+            // The lowerer detected the canonical shape and captured the
+            // (m, k, v) args; backend just renders the Lean simpa.
+            if let Some(crate::ir::ProofStrategy::LibraryAxiom {
+                ref axiom,
+                ref args,
+            }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+                && matches!(axiom.as_str(), "Map.has_set_self" | "Map.get_set_self")
+                && args.len() == 3
+            {
+                let lemma = match axiom.as_str() {
+                    "Map.has_set_self" => "AverMap.has_set_self",
+                    "Map.get_set_self" => "AverMap.get_set_self",
+                    _ => unreachable!(),
+                };
+                let atom_arg = |e: &crate::ast::Spanned<crate::ast::Expr>| {
+                    let rendered = emit_expr(e, ctx);
+                    if rendered.contains(' ') && !rendered.starts_with('(') {
+                        format!("({rendered})")
+                    } else {
+                        rendered
+                    }
+                };
+                return Some(AutoProof {
+                    support_lines: Vec::new(),
+                    proof_lines: intro_then(
+                        &proof_intro_names,
+                        vec![format!(
+                            "simpa using {} {} {} {}",
+                            lemma,
+                            atom_arg(&args[0]),
+                            atom_arg(&args[1]),
+                            atom_arg(&args[2]),
+                        )],
+                    ),
+                    replaces_theorem: false,
+                });
+            }
             maps::emit_direct_map_set_law(law, ctx, &proof_intro_names).map(|proof_lines| {
                 AutoProof {
                     support_lines: Vec::new(),

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -630,6 +630,11 @@ fn classify_law_strategy(
     if let Some(inner_fn) = detect_wrapper_unary_equivalence(law, fn_name, inputs) {
         return ProofStrategy::UnaryEqualsBinary { inner_fn };
     }
+    // Library axiom instances — Map.has-after-set, Map.get-after-set.
+    // Specific shape, single-line `simpa using axiom` emit on Lean.
+    if let Some((axiom, args)) = detect_map_set_axiom(law) {
+        return ProofStrategy::LibraryAxiom { axiom, args };
+    }
     // Linear arithmetic over an unfold chain — generic catch-all.
     // Named for the semantic, not the backend tactic.
     if let Some(plan) = detect_simp_omega_unfold(law, fn_name, inputs, refined_types) {
@@ -995,6 +1000,116 @@ fn arms_match_bool_ok_err(arms: &[crate::ast::MatchArm]) -> bool {
         }
     }
     saw_true_ok && saw_false_err
+}
+
+/// Detect a Map library axiom instance:
+///   `Map.has(Map.set(m, k, v), k) => true`        → `Map.has_set_self`
+///   `Map.get(Map.set(m, k, v), k) => Option.Some(v)` → `Map.get_set_self`
+/// Returns `(axiom_name, [m, k, v])` on match, either side
+/// orientation. Both axioms use the same `[m, k, v]` arg order.
+fn detect_map_set_axiom(
+    law: &crate::ast::VerifyLaw,
+) -> Option<(String, Vec<Spanned<crate::ast::Expr>>)> {
+    // `Map.has(Map.set(m, k, v), k) => true`
+    let has_side = |side: &Spanned<crate::ast::Expr>,
+                    other: &Spanned<crate::ast::Expr>|
+     -> Option<(String, Vec<Spanned<crate::ast::Expr>>)> {
+        let (m, k, v) = map_has_set_parts(side)?;
+        if !is_bool_true(other) {
+            return None;
+        }
+        Some((
+            "Map.has_set_self".to_string(),
+            vec![m.clone(), k.clone(), v.clone()],
+        ))
+    };
+    if let Some(found) = has_side(&law.lhs, &law.rhs).or_else(|| has_side(&law.rhs, &law.lhs)) {
+        return Some(found);
+    }
+
+    // `Map.get(Map.set(m, k, v), k) => Option.Some(v)`
+    let get_side = |side: &Spanned<crate::ast::Expr>,
+                    other: &Spanned<crate::ast::Expr>|
+     -> Option<(String, Vec<Spanned<crate::ast::Expr>>)> {
+        let (m, k, v) = map_get_set_parts(side)?;
+        let some_v = option_some_arg(other)?;
+        if &some_v.node != &v.node {
+            return None;
+        }
+        Some((
+            "Map.get_set_self".to_string(),
+            vec![m.clone(), k.clone(), v.clone()],
+        ))
+    };
+    get_side(&law.lhs, &law.rhs).or_else(|| get_side(&law.rhs, &law.lhs))
+}
+
+fn map_has_set_parts(
+    expr: &Spanned<crate::ast::Expr>,
+) -> Option<(
+    &Spanned<crate::ast::Expr>,
+    &Spanned<crate::ast::Expr>,
+    &Spanned<crate::ast::Expr>,
+)> {
+    let has_args = call_named_args(expr, "Map.has")?;
+    if has_args.len() != 2 {
+        return None;
+    }
+    let set_args = call_named_args(&has_args[0], "Map.set")?;
+    if set_args.len() != 3 {
+        return None;
+    }
+    if set_args[1].node != has_args[1].node {
+        return None;
+    }
+    Some((&set_args[0], &set_args[1], &set_args[2]))
+}
+
+fn map_get_set_parts(
+    expr: &Spanned<crate::ast::Expr>,
+) -> Option<(
+    &Spanned<crate::ast::Expr>,
+    &Spanned<crate::ast::Expr>,
+    &Spanned<crate::ast::Expr>,
+)> {
+    let get_args = call_named_args(expr, "Map.get")?;
+    if get_args.len() != 2 {
+        return None;
+    }
+    let set_args = call_named_args(&get_args[0], "Map.set")?;
+    if set_args.len() != 3 {
+        return None;
+    }
+    if set_args[1].node != get_args[1].node {
+        return None;
+    }
+    Some((&set_args[0], &set_args[1], &set_args[2]))
+}
+
+fn option_some_arg(expr: &Spanned<crate::ast::Expr>) -> Option<&Spanned<crate::ast::Expr>> {
+    let args = call_named_args(expr, "Option.Some")?;
+    (args.len() == 1).then_some(&args[0])
+}
+
+fn call_named_args<'a>(
+    expr: &'a Spanned<crate::ast::Expr>,
+    full_name: &str,
+) -> Option<&'a [Spanned<crate::ast::Expr>]> {
+    use crate::ast::Expr;
+    let Expr::FnCall(callee, args) = &expr.node else {
+        return None;
+    };
+    let callee_name = expr_to_dotted_name(&callee.node)?;
+    if callee_name == full_name {
+        Some(args.as_slice())
+    } else {
+        None
+    }
+}
+
+fn is_bool_true(expr: &Spanned<crate::ast::Expr>) -> bool {
+    use crate::ast::{Expr, Literal};
+    matches!(&expr.node, Expr::Literal(Literal::Bool(true)))
 }
 
 /// Detect a `given` that binds a recursive sum-typed ADT — the

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -1033,7 +1033,7 @@ fn detect_map_set_axiom(
      -> Option<(String, Vec<Spanned<crate::ast::Expr>>)> {
         let (m, k, v) = map_get_set_parts(side)?;
         let some_v = option_some_arg(other)?;
-        if &some_v.node != &v.node {
+        if some_v.node != v.node {
             return None;
         }
         Some((

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -420,6 +420,23 @@ pub enum ProofStrategy {
     },
     /// Structural induction on a recursive ADT parameter.
     Induction { param: String },
+    /// Library axiom instance — the law instantiates a named
+    /// data-structure axiom (e.g. AverMap's `has_set_self` or
+    /// `get_set_self`). Backends map the axiom name to their
+    /// lemma vocabulary (Lean: `AverMap.has_set_self`; Dafny:
+    /// its own set/lookup axioms; Z3: built-in array theory).
+    /// Args carry the call-site expressions the axiom applies to.
+    LibraryAxiom {
+        /// Canonical axiom name. Recognised values today:
+        /// `"Map.has_set_self"`, `"Map.get_set_self"`. Open string
+        /// so future axioms (List, Set, Array, …) extend without
+        /// enum churn.
+        axiom: String,
+        /// Arguments in the order the axiom expects. For Map
+        /// axioms: `[m, k, v]` (the map, key, value the axiom
+        /// reasons about).
+        args: Vec<Spanned<crate::ast::Expr>>,
+    },
     /// Bounded universal: case-split over the declared `given`
     /// domain, dispatch each case to a per-sample lemma.
     BoundedUniversal,

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1103,3 +1103,37 @@ fn induction_pinned_on_recursive_adt_given() {
     };
     assert_eq!(param, "t");
 }
+
+#[test]
+fn library_axiom_pinned_on_map_has_set_self() {
+    // `Map.has(Map.set(m, k, v), k) => true` — canonical
+    // has-after-set axiom. Step 32 pins
+    // `LibraryAxiom { axiom: "Map.has_set_self", args: [m, k, v] }`.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn touch(m: Map<String, Int>, k: String, v: Int) -> Map<String, Int>\n\
+         \x20   Map.set(m, k, v)\n\
+         \n\
+         verify touch law hasAfterSet\n\
+         \x20   given m: Map<String, Int> = [{}]\n\
+         \x20   given k: String = [\"x\"]\n\
+         \x20   given v: Int = [1]\n\
+         \x20   Map.has(Map.set(m, k, v), k) => true\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "touch" && t.law_name == "hasAfterSet")
+        .expect("touch::hasAfterSet law theorem missing");
+    let aver::ir::ProofStrategy::LibraryAxiom {
+        ref axiom,
+        ref args,
+    } = theorem.strategy
+    else {
+        panic!("expected LibraryAxiom, got: {:?}", theorem.strategy);
+    };
+    assert_eq!(axiom, "Map.has_set_self");
+    assert_eq!(args.len(), 3, "args should be [m, k, v]");
+}


### PR DESCRIPTION
## Summary

New `ProofStrategy::LibraryAxiom { axiom: String, args: Vec<Spanned<Expr>> }` variant — captures laws that instantiate a named data-structure axiom. Step 32 populates it for the two AverMap canonical shapes handled by `emit_direct_map_set_law`:

| Source pattern | Axiom name |
|---|---|
| `Map.has(Map.set(m, k, v), k) => true` | `Map.has_set_self` |
| `Map.get(Map.set(m, k, v), k) => Option.Some(v)` | `Map.get_set_self` |

`args` carry `[m, k, v]` from the call site. Backend renders `simpa using AverMap.<axiom> <m> <k> <v>`. Lean-specific lemma name lookup stays in the backend; the IR carries the canonical axiom name only — Dafny / Z3 / future backends map to their own axiom vocabularies.

`axiom: String` keeps the variant open for future axioms (List append, Set membership, …) without enum churn.

## Architecture

Producer (`proof_lower::detect_map_set_axiom`):
- Pattern-matches `Map.has` / `Map.get` over `Map.set(m, k, v)` with the matching key arg on both sides
- Either lhs/rhs orientation accepted
- Returns `(axiom_name, [m, k, v])` on first match

Helpers ported as private to proof_lower (~60 lines): `call_named_args`, `map_has_set_parts`, `map_get_set_parts`, `option_some_arg`, `is_bool_true`. Same layer-preservation rule as earlier Steps.

Consumer (`lean::law_auto`):
- IR-pinned LibraryAxiom for the two recognised Map axioms emits `simpa using <lemma> <m> <k> <v>` directly
- Falls through to legacy `emit_direct_map_set_law` for laws the lowerer didn't classify

## Test plan

- [x] `cargo test --lib` (615 pass)
- [x] `cargo test --test proof_ir_diff` (24 pass — new test `library_axiom_pinned_on_map_has_set_self`)
- [x] `cargo test --test proof_spec` (35 pass)
- [x] `cargo test --test explain_passes_spec` (5 pass)

## Follow-up

- Step 33: `emit_map_update_law` (incCount::keyPresent — multi-line `cases h : AverMap.get ...` tactic)
- Step 34: `emit_map_increment_tracked_count_law` (incCount::existingKeyIncrements — complex multi-step)
- Step 35: retire `BackendDispatch` once every shape pins through the IR

🤖 Generated with [Claude Code](https://claude.com/claude-code)