### PR TITLE
proof_lower+lean: Step 33 — pin MapUpdatePostcondition law strategy

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -226,6 +226,63 @@ pub fn emit_verify_law_forall_auto_proof(
             })
         })
         .or_else(|| {
+            // IR-pinned `MapUpdatePostcondition` — the lowerer
+            // validated the outer fn's "inspect get, set in every
+            // arm" body shape and captured the law's (map, key)
+            // args + the helper-fn unfold set. Backend renders the
+            // 2-line `simp [outer (, extras)] ; cases h : AverMap.get
+            // m k <;> simp [AverMap.<axiom> (, extras)]` tactic.
+            if let Some(crate::ir::ProofStrategy::MapUpdatePostcondition {
+                ref outer_fn,
+                kind,
+                ref map_arg,
+                ref key_arg,
+                ref extra_unfolds,
+            }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+            {
+                let outer_lean = aver_name_to_lean(outer_fn);
+                let extras_lean: Vec<String> =
+                    extra_unfolds.iter().map(|n| aver_name_to_lean(n)).collect();
+                let atom_render = |e: &crate::ast::Spanned<crate::ast::Expr>| {
+                    let rendered = emit_expr(e, ctx);
+                    if rendered.contains(' ') && !rendered.starts_with('(') {
+                        format!("({rendered})")
+                    } else {
+                        rendered
+                    }
+                };
+                let (axiom_lemma, prefix_extras): (&str, Vec<String>) = match kind {
+                    crate::ir::MapUpdatePostconditionKind::HasAfter => {
+                        ("AverMap.has_set_self", Vec::new())
+                    }
+                    crate::ir::MapUpdatePostconditionKind::GetAfter => {
+                        ("AverMap.get_set_self", extras_lean.clone())
+                    }
+                };
+                let simp_first: String = {
+                    let mut items = vec![outer_lean.clone()];
+                    items.extend(prefix_extras);
+                    format!("simp [{}]", items.join(", "))
+                };
+                let simp_second: String = {
+                    let mut items = vec![axiom_lemma.to_string()];
+                    if matches!(kind, crate::ir::MapUpdatePostconditionKind::GetAfter) {
+                        items.push(outer_lean.clone());
+                        items.extend(extras_lean.iter().cloned());
+                    }
+                    format!(
+                        "cases h : AverMap.get {} {} <;> simp [{}]",
+                        atom_render(map_arg),
+                        atom_render(key_arg),
+                        items.join(", ")
+                    )
+                };
+                return Some(AutoProof {
+                    support_lines: Vec::new(),
+                    proof_lines: intro_then(&proof_intro_names, vec![simp_first, simp_second]),
+                    replaces_theorem: false,
+                });
+            }
             maps::emit_map_update_law(vb, law, ctx, &proof_intro_names).map(|proof_lines| {
                 AutoProof {
                     support_lines: Vec::new(),

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -1066,9 +1066,8 @@ struct MapUpdatePostconditionPlan {
 }
 
 /// Detect a post-condition law on an inline map-update fn `outer(m,
-/// k)`. Two shapes:
-///   - `Map.has(outer(m, k), k) == true`             (`HasAfter`)
-///   - `Map.get(outer(m, k), k) == Option.Some(...)` (`GetAfter`)
+/// k)`. Two shapes: `Map.has(outer(m, k), k) == true` (`HasAfter`),
+/// or `Map.get(outer(m, k), k) == Option.Some(...)` (`GetAfter`).
 /// Both require `outer`'s body to follow the "inspect get, set in
 /// every arm" template (see `outer_fn_map_update_shape`).
 fn detect_map_update_postcondition(

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -635,6 +635,17 @@ fn classify_law_strategy(
     if let Some((axiom, args)) = detect_map_set_axiom(law) {
         return ProofStrategy::LibraryAxiom { axiom, args };
     }
+    // Post-condition of an inline-defined map-update fn — case-split
+    // over `Map.get m k` and apply the `Map.set` axioms.
+    if let Some(post) = detect_map_update_postcondition(law, fn_name, inputs) {
+        return ProofStrategy::MapUpdatePostcondition {
+            outer_fn: post.outer_fn,
+            kind: post.kind,
+            map_arg: post.map_arg,
+            key_arg: post.key_arg,
+            extra_unfolds: post.extra_unfolds,
+        };
+    }
     // Linear arithmetic over an unfold chain — generic catch-all.
     // Named for the semantic, not the backend tactic.
     if let Some(plan) = detect_simp_omega_unfold(law, fn_name, inputs, refined_types) {
@@ -1042,6 +1053,280 @@ fn detect_map_set_axiom(
         ))
     };
     get_side(&law.lhs, &law.rhs).or_else(|| get_side(&law.rhs, &law.lhs))
+}
+
+/// Internal scratch carrier — mirrors the IR variant but lives in
+/// the lowerer so callers can build incrementally.
+struct MapUpdatePostconditionPlan {
+    outer_fn: String,
+    kind: crate::ir::MapUpdatePostconditionKind,
+    map_arg: Spanned<crate::ast::Expr>,
+    key_arg: Spanned<crate::ast::Expr>,
+    extra_unfolds: Vec<String>,
+}
+
+/// Detect a post-condition law on an inline map-update fn `outer(m,
+/// k)`. Two shapes:
+///   - `Map.has(outer(m, k), k) == true`             (`HasAfter`)
+///   - `Map.get(outer(m, k), k) == Option.Some(...)` (`GetAfter`)
+/// Both require `outer`'s body to follow the "inspect get, set in
+/// every arm" template (see `outer_fn_map_update_shape`).
+fn detect_map_update_postcondition(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<MapUpdatePostconditionPlan> {
+    use crate::ir::MapUpdatePostconditionKind;
+
+    outer_fn_map_update_shape(fn_name, inputs)?;
+
+    let has_side = |side: &Spanned<crate::ast::Expr>,
+                    other: &Spanned<crate::ast::Expr>|
+     -> Option<MapUpdatePostconditionPlan> {
+        if !is_bool_true(other) {
+            return None;
+        }
+        let (map_arg, key_arg) = map_has_after_fn_call(side, fn_name)?;
+        Some(MapUpdatePostconditionPlan {
+            outer_fn: fn_name.to_string(),
+            kind: MapUpdatePostconditionKind::HasAfter,
+            map_arg: map_arg.clone(),
+            key_arg: key_arg.clone(),
+            extra_unfolds: Vec::new(),
+        })
+    };
+    if let Some(plan) = has_side(&law.lhs, &law.rhs).or_else(|| has_side(&law.rhs, &law.lhs)) {
+        return Some(plan);
+    }
+
+    let get_side = |side: &Spanned<crate::ast::Expr>,
+                    other: &Spanned<crate::ast::Expr>|
+     -> Option<MapUpdatePostconditionPlan> {
+        option_some_arg(other)?;
+        let (map_arg, key_arg) = map_get_after_fn_call(side, fn_name)?;
+        let extra_unfolds = law_helper_unfolds(law, fn_name, inputs);
+        Some(MapUpdatePostconditionPlan {
+            outer_fn: fn_name.to_string(),
+            kind: MapUpdatePostconditionKind::GetAfter,
+            map_arg: map_arg.clone(),
+            key_arg: key_arg.clone(),
+            extra_unfolds,
+        })
+    };
+    get_side(&law.lhs, &law.rhs).or_else(|| get_side(&law.rhs, &law.lhs))
+}
+
+/// Collect user helper-fn source names referenced from the law's
+/// lhs/rhs/when, expanded transitively through pure (effect-free,
+/// non-main) fn bodies. The outer fn is excluded — it's carried in
+/// the IR variant separately. Filters out stdlib / namespace calls
+/// (`Map.get`, `Option.withDefault`, …) by requiring each name to
+/// resolve to a user fn def. Sorted for deterministic emit.
+fn law_helper_unfolds(
+    law: &crate::ast::VerifyLaw,
+    outer_fn: &str,
+    inputs: &ProofLowerInputs,
+) -> Vec<String> {
+    use std::collections::BTreeSet;
+
+    let resolve_user_fn = |name: &str| -> Option<&FnDef> {
+        let fd = inputs.find_fn_def_by_call_name(name)?;
+        if !fd.effects.is_empty() || fd.name == "main" {
+            return None;
+        }
+        Some(fd)
+    };
+
+    // Seed from law sides, immediately filtering to user-fn names.
+    let mut raw: BTreeSet<String> = BTreeSet::new();
+    collect_fn_calls_expr(&law.lhs, &mut raw);
+    collect_fn_calls_expr(&law.rhs, &mut raw);
+    if let Some(when_expr) = &law.when {
+        collect_fn_calls_expr(when_expr, &mut raw);
+    }
+    let mut names: BTreeSet<String> = raw
+        .into_iter()
+        .filter_map(|n| resolve_user_fn(&n).map(|fd| fd.name.clone()))
+        .collect();
+
+    // Transitive expansion through pure user fn bodies.
+    loop {
+        let before = names.len();
+        let snapshot: Vec<String> = names.iter().cloned().collect();
+        for name in snapshot {
+            let Some(fd) = resolve_user_fn(&name) else {
+                continue;
+            };
+            let mut called: BTreeSet<String> = BTreeSet::new();
+            for stmt in fd.body.stmts() {
+                match stmt {
+                    crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => {
+                        collect_fn_calls_expr(e, &mut called);
+                    }
+                }
+            }
+            for c in called {
+                if let Some(callee_fd) = resolve_user_fn(&c) {
+                    names.insert(callee_fd.name.clone());
+                }
+            }
+        }
+        if names.len() == before {
+            break;
+        }
+    }
+    names.remove(outer_fn);
+    names.into_iter().collect()
+}
+
+/// Validate the outer fn's body matches the "inspect get, set in
+/// every arm" template:
+///
+/// ```text
+/// fn outer(m: Map<K, V>, k: K) -> Map<K, V>
+///   [v = Map.get(m, k);]?
+///   match (v | Map.get(m, k)) {
+///     _ -> Map.set(m, k, _)
+///     _ -> Map.set(m, k, _)
+///     ...
+///   }
+/// ```
+///
+/// Returns `Some(())` on match. The map/key params are positional —
+/// position 0 is the map, position 1 is the key.
+fn outer_fn_map_update_shape(fn_name: &str, inputs: &ProofLowerInputs) -> Option<()> {
+    let fd = inputs.find_fn_def_by_call_name(fn_name)?;
+    if fd.params.len() != 2 {
+        return None;
+    }
+    let map_param = fd.params[0].0.as_str();
+    let key_param = fd.params[1].0.as_str();
+    map_update_body_matches(fd.body.stmts(), map_param, key_param).then_some(())
+}
+
+fn map_update_body_matches(stmts: &[crate::ast::Stmt], map_param: &str, key_param: &str) -> bool {
+    use crate::ast::Stmt;
+    if stmts.len() < 2 {
+        // Even the no-let variant requires the match to be the last
+        // stmt — but a single-stmt body is too short to be this shape.
+        return matches!(stmts.first(), Some(Stmt::Expr(e)) if map_update_match_expr(e, map_param, key_param, None));
+    }
+    let Some(last) = stmts.last() else {
+        return false;
+    };
+    let mut bound_name: Option<&str> = None;
+    for stmt in &stmts[..stmts.len() - 1] {
+        match stmt {
+            Stmt::Binding(name, _, expr) => {
+                if !is_map_get_of_params(expr, map_param, key_param) {
+                    return false;
+                }
+                bound_name = Some(name);
+            }
+            Stmt::Expr(_) => return false,
+        }
+    }
+    match last {
+        Stmt::Expr(expr) => map_update_match_expr(expr, map_param, key_param, bound_name),
+        Stmt::Binding(_, _, _) => false,
+    }
+}
+
+fn map_update_match_expr(
+    expr: &Spanned<crate::ast::Expr>,
+    map_param: &str,
+    key_param: &str,
+    bound_name: Option<&str>,
+) -> bool {
+    use crate::ast::Expr;
+    let Expr::Match { subject, arms } = &expr.node else {
+        return false;
+    };
+    if arms.len() < 2 {
+        return false;
+    }
+    let subject_ok = match bound_name {
+        Some(name) => matches_ident_expr(subject, name),
+        None => is_map_get_of_params(subject, map_param, key_param),
+    };
+    if !subject_ok {
+        return false;
+    }
+    arms.iter()
+        .all(|arm| is_map_set_of_params(&arm.body, map_param, key_param))
+}
+
+fn is_map_get_of_params(
+    expr: &Spanned<crate::ast::Expr>,
+    map_param: &str,
+    key_param: &str,
+) -> bool {
+    let Some(args) = call_named_args(expr, "Map.get") else {
+        return false;
+    };
+    args.len() == 2
+        && matches_ident_expr(&args[0], map_param)
+        && matches_ident_expr(&args[1], key_param)
+}
+
+fn is_map_set_of_params(
+    expr: &Spanned<crate::ast::Expr>,
+    map_param: &str,
+    key_param: &str,
+) -> bool {
+    let Some(args) = call_named_args(expr, "Map.set") else {
+        return false;
+    };
+    args.len() == 3
+        && matches_ident_expr(&args[0], map_param)
+        && matches_ident_expr(&args[1], key_param)
+}
+
+/// `Map.has(outer(m, k), k)` — pick out the (m, k) from the inner
+/// outer-fn call when the two key positions agree. Returns `None`
+/// when the outer call doesn't match `fn_name` or shape is off.
+fn map_has_after_fn_call<'a>(
+    expr: &'a Spanned<crate::ast::Expr>,
+    fn_name: &str,
+) -> Option<(&'a Spanned<crate::ast::Expr>, &'a Spanned<crate::ast::Expr>)> {
+    use crate::ast::Expr;
+    let has_args = call_named_args(expr, "Map.has")?;
+    if has_args.len() != 2 {
+        return None;
+    }
+    let Expr::FnCall(callee, fn_args) = &has_args[0].node else {
+        return None;
+    };
+    if fn_args.len() != 2
+        || !callee_matches_name(callee, fn_name)
+        || fn_args[1].node != has_args[1].node
+    {
+        return None;
+    }
+    Some((&fn_args[0], &fn_args[1]))
+}
+
+/// `Map.get(outer(m, k), k)` — pick out the (m, k) from the inner
+/// outer-fn call when the two key positions agree.
+fn map_get_after_fn_call<'a>(
+    expr: &'a Spanned<crate::ast::Expr>,
+    fn_name: &str,
+) -> Option<(&'a Spanned<crate::ast::Expr>, &'a Spanned<crate::ast::Expr>)> {
+    use crate::ast::Expr;
+    let get_args = call_named_args(expr, "Map.get")?;
+    if get_args.len() != 2 {
+        return None;
+    }
+    let Expr::FnCall(callee, fn_args) = &get_args[0].node else {
+        return None;
+    };
+    if fn_args.len() != 2
+        || !callee_matches_name(callee, fn_name)
+        || fn_args[1].node != get_args[1].node
+    {
+        return None;
+    }
+    Some((&fn_args[0], &fn_args[1]))
 }
 
 fn map_has_set_parts(

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -21,9 +21,9 @@ pub use pipeline::{
     PipelineStage, TypecheckMode,
 };
 pub use proof_ir::{
-    DecreaseProof, FnContract, FuelMetric, LawTheorem, Measure, NativeIntCountdownBody, Predicate,
-    PreservationProof, ProofIR, ProofStrategy, Quantifier, QuantifierType, RecursionContract,
-    RefinedTypeDecl, SmartGuard, UnclassifiedFn,
+    DecreaseProof, FnContract, FuelMetric, LawTheorem, MapUpdatePostconditionKind, Measure,
+    NativeIntCountdownBody, Predicate, PreservationProof, ProofIR, ProofStrategy, Quantifier,
+    QuantifierType, RecursionContract, RefinedTypeDecl, SmartGuard, UnclassifiedFn,
 };
 
 pub use alloc_info::{

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -437,6 +437,34 @@ pub enum ProofStrategy {
         /// reasons about).
         args: Vec<Spanned<crate::ast::Expr>>,
     },
+    /// Post-condition of an inline-defined map-update fn. The outer
+    /// fn `outer(m, k)` has body shape `let v = Map.get m k; match v
+    /// { Some(_) -> Map.set m k _; None -> Map.set m k _ }` — i.e. it
+    /// inspects the existing value and writes some new value at key
+    /// `k` in every arm. The law asserts a post-condition on that
+    /// update:
+    ///   - `Map.has(outer(m, k), k) == true`              (`HasAfter`)
+    ///   - `Map.get(outer(m, k), k) == Option.Some(...)`  (`GetAfter`)
+    /// Backends emit a 2-step proof: unfold the outer fn, case-split
+    /// on `Map.get m k` (the same value `outer` inspected), apply the
+    /// `Map.set`-axioms on each branch. Named after the law's
+    /// algebraic content, not the Lean tactic.
+    MapUpdatePostcondition {
+        /// Source name of the outer update fn.
+        outer_fn: String,
+        /// Which post-condition the law asserts.
+        kind: MapUpdatePostconditionKind,
+        /// The map argument as it appears at the law's call site.
+        map_arg: Spanned<crate::ast::Expr>,
+        /// The key argument as it appears at the law's call site.
+        key_arg: Spanned<crate::ast::Expr>,
+        /// Additional helper-fn source names to unfold on top of
+        /// `outer_fn` — only used for `GetAfter`, where the rhs's
+        /// `Option.Some(...)` typically wraps the prior value via a
+        /// pure user helper (e.g. `addOne(...)`). Source names;
+        /// backends translate to their lemma vocabulary.
+        extra_unfolds: Vec<String>,
+    },
     /// Bounded universal: case-split over the declared `given`
     /// domain, dispatch each case to a per-sample lemma.
     BoundedUniversal,
@@ -451,6 +479,15 @@ pub enum ProofStrategy {
     /// backend treats `BackendDispatch` as "fall through to ad-hoc
     /// strategy chain", same behaviour as pre-migration.
     BackendDispatch,
+}
+
+/// Discriminator for [`ProofStrategy::MapUpdatePostcondition`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MapUpdatePostconditionKind {
+    /// Law shape: `Map.has(outer(m, k), k) == true`.
+    HasAfter,
+    /// Law shape: `Map.get(outer(m, k), k) == Option.Some(...)`.
+    GetAfter,
 }
 
 /// A bool predicate with explicit free-variable context. Stays in

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -442,9 +442,9 @@ pub enum ProofStrategy {
     /// { Some(_) -> Map.set m k _; None -> Map.set m k _ }` — i.e. it
     /// inspects the existing value and writes some new value at key
     /// `k` in every arm. The law asserts a post-condition on that
-    /// update:
-    ///   - `Map.has(outer(m, k), k) == true`              (`HasAfter`)
-    ///   - `Map.get(outer(m, k), k) == Option.Some(...)`  (`GetAfter`)
+    /// update — `Map.has(outer(m, k), k) == true` (`HasAfter`), or
+    /// `Map.get(outer(m, k), k) == Option.Some(...)` (`GetAfter`).
+    ///
     /// Backends emit a 2-step proof: unfold the outer fn, case-split
     /// on `Map.get m k` (the same value `outer` inspected), apply the
     /// `Map.set`-axioms on each branch. Named after the law's

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1137,3 +1137,97 @@ fn library_axiom_pinned_on_map_has_set_self() {
     assert_eq!(axiom, "Map.has_set_self");
     assert_eq!(args.len(), 3, "args should be [m, k, v]");
 }
+
+#[test]
+fn map_update_postcondition_pinned_has_after() {
+    // `Map.has(incCount(counts, word), word) => true` — `incCount`'s
+    // body inspects `Map.get(counts, word)` and `Map.set`s on every
+    // arm. Step 33 pins `MapUpdatePostcondition { kind: HasAfter,
+    // outer_fn: "incCount", … }`.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn incCount(counts: Map<String, Int>, word: String) -> Map<String, Int>\n\
+         \x20   current = Map.get(counts, word)\n\
+         \x20   match current\n\
+         \x20       Option.Some(n) -> Map.set(counts, word, n + 1)\n\
+         \x20       Option.None -> Map.set(counts, word, 1)\n\
+         \n\
+         verify incCount law keyPresent\n\
+         \x20   given counts: Map<String, Int> = [{}]\n\
+         \x20   given word: String = [\"a\"]\n\
+         \x20   Map.has(incCount(counts, word), word) => true\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "incCount" && t.law_name == "keyPresent")
+        .expect("incCount::keyPresent law theorem missing");
+    let aver::ir::ProofStrategy::MapUpdatePostcondition {
+        ref outer_fn,
+        kind,
+        ref extra_unfolds,
+        ..
+    } = theorem.strategy
+    else {
+        panic!(
+            "expected MapUpdatePostcondition, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(outer_fn, "incCount");
+    assert_eq!(kind, aver::ir::MapUpdatePostconditionKind::HasAfter);
+    assert!(
+        extra_unfolds.is_empty(),
+        "HasAfter shouldn't carry helper unfolds, got: {extra_unfolds:?}"
+    );
+}
+
+#[test]
+fn map_update_postcondition_pinned_get_after_with_helper_unfolds() {
+    // `Map.get(incCount(counts, "a"), "a") => Option.Some(addOne(...))`
+    // — same `incCount` body shape, GetAfter variant pulls helper
+    // fns (`addOne`) into the IR's `extra_unfolds` set.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn addOne(n: Int) -> Int\n\
+         \x20   n + 1\n\
+         \n\
+         fn incCount(counts: Map<String, Int>, word: String) -> Map<String, Int>\n\
+         \x20   current = Map.get(counts, word)\n\
+         \x20   match current\n\
+         \x20       Option.Some(n) -> Map.set(counts, word, n + 1)\n\
+         \x20       Option.None -> Map.set(counts, word, 1)\n\
+         \n\
+         verify incCount law existingKeyIncrements\n\
+         \x20   given counts: Map<String, Int> = [{\"a\" => 1}]\n\
+         \x20   Map.get(incCount(counts, \"a\"), \"a\") => Option.Some(addOne(Option.withDefault(Map.get(counts, \"a\"), 0)))\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "incCount" && t.law_name == "existingKeyIncrements")
+        .expect("incCount::existingKeyIncrements law theorem missing");
+    let aver::ir::ProofStrategy::MapUpdatePostcondition {
+        ref outer_fn,
+        kind,
+        ref extra_unfolds,
+        ..
+    } = theorem.strategy
+    else {
+        panic!(
+            "expected MapUpdatePostcondition, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(outer_fn, "incCount");
+    assert_eq!(kind, aver::ir::MapUpdatePostconditionKind::GetAfter);
+    assert_eq!(
+        extra_unfolds,
+        &vec!["addOne".to_string()],
+        "GetAfter should carry the helper-fn unfold set (outer fn excluded)"
+    );
+}


### PR DESCRIPTION
## Summary

- New IR variant `ProofStrategy::MapUpdatePostcondition { outer_fn, kind, map_arg, key_arg, extra_unfolds }` captures the "post-condition of an inline map-update fn" shape: `Map.has(outer(m, k), k) == true` (`HasAfter`) and `Map.get(outer(m, k), k) == Option.Some(...)` (`GetAfter`). Lowerer validates the outer fn's "inspect get, set in every arm" body and gathers user-fn unfolds; Lean consumer renders the same 2-line tactic as before.
- `examples/formal/law_auto.av` coverage: 13/15 → 14/15 pinned strategies (`incCount::keyPresent` + `existingKeyIncrements` now pin through IR). Byte-identical Lean emit.
- Legacy `maps::emit_map_update_law` stays as a safety-net fallback for shapes the IR doesn't pin — retired alongside `BackendDispatch` in Step 35.

## Test plan

- [x] `cargo test --test proof_ir_diff` — 26 passed (24 prior + 2 new diff tests)
- [x] `cargo test --test proof_spec` — 35 passed; Lean build of `law_auto.av` validates the emit
- [x] `cargo test --tests` — full integration sweep clean
- [x] `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)