### PR TITLE
proof_lower+lean: Step 34 — pin MapKeyTrackedIncrement law strategy

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -292,6 +292,42 @@ pub fn emit_verify_law_forall_auto_proof(
             })
         })
         .or_else(|| {
+            // IR-pinned `MapKeyTrackedIncrement` — the lowerer
+            // validated the outer fn's "tracked counter" body
+            // template (Some(n) -> n + 1, None -> 1) and matched the
+            // law against the `Option.withDefault`-defaulted shape.
+            // Backend renders the 2-line `simp [outer] ; cases h :
+            // AverMap.get m k <;> simp [AverMap.get_set_self, h]`
+            // tactic.
+            if let Some(crate::ir::ProofStrategy::MapKeyTrackedIncrement {
+                ref outer_fn,
+                ref map_arg,
+                ref key_arg,
+            }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+            {
+                let outer_lean = aver_name_to_lean(outer_fn);
+                let atom_render = |e: &crate::ast::Spanned<crate::ast::Expr>| {
+                    let rendered = emit_expr(e, ctx);
+                    if rendered.contains(' ') && !rendered.starts_with('(') {
+                        format!("({rendered})")
+                    } else {
+                        rendered
+                    }
+                };
+                let lines = vec![
+                    format!("simp [{}]", outer_lean),
+                    format!(
+                        "cases h : AverMap.get {} {} <;> simp [AverMap.get_set_self, h]",
+                        atom_render(map_arg),
+                        atom_render(key_arg),
+                    ),
+                ];
+                return Some(AutoProof {
+                    support_lines: Vec::new(),
+                    proof_lines: intro_then(&proof_intro_names, lines),
+                    replaces_theorem: false,
+                });
+            }
             maps::emit_map_increment_tracked_count_law(vb, law, ctx, &proof_intro_names).map(
                 |proof_lines| AutoProof {
                     support_lines: Vec::new(),

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -1450,9 +1450,9 @@ fn defaulted_map_get(
     Some((&get_args[0], &get_args[1], default))
 }
 
-fn option_with_default_args<'a>(
-    expr: &'a Spanned<crate::ast::Expr>,
-) -> Option<(&'a Spanned<crate::ast::Expr>, &'a Spanned<crate::ast::Expr>)> {
+fn option_with_default_args(
+    expr: &Spanned<crate::ast::Expr>,
+) -> Option<(&Spanned<crate::ast::Expr>, &Spanned<crate::ast::Expr>)> {
     let args = call_named_args(expr, "Option.withDefault")?;
     (args.len() == 2).then_some((&args[0], &args[1]))
 }

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -635,6 +635,16 @@ fn classify_law_strategy(
     if let Some((axiom, args)) = detect_map_set_axiom(law) {
         return ProofStrategy::LibraryAxiom { axiom, args };
     }
+    // Tracked-counter increment: specialised body template + `+ 1`
+    // rhs. Checked before the more general MapUpdatePostcondition so
+    // the tighter strategy wins for this shape.
+    if let Some(inc) = detect_map_key_tracked_increment(law, fn_name, inputs) {
+        return ProofStrategy::MapKeyTrackedIncrement {
+            outer_fn: inc.outer_fn,
+            map_arg: inc.map_arg,
+            key_arg: inc.key_arg,
+        };
+    }
     // Post-condition of an inline-defined map-update fn — case-split
     // over `Map.get m k` and apply the `Map.set` axioms.
     if let Some(post) = detect_map_update_postcondition(law, fn_name, inputs) {
@@ -1279,6 +1289,177 @@ fn is_map_set_of_params(
     args.len() == 3
         && matches_ident_expr(&args[0], map_param)
         && matches_ident_expr(&args[1], key_param)
+}
+
+struct MapKeyTrackedIncrementPlan {
+    outer_fn: String,
+    map_arg: Spanned<crate::ast::Expr>,
+    key_arg: Spanned<crate::ast::Expr>,
+}
+
+/// Detect the canonical tracked-counter increment law:
+/// `Option.withDefault(Map.get(outer(m, k), k), 0) ==
+/// Option.withDefault(Map.get(m, k), 0) + 1`, where `outer` follows
+/// the increment-by-one body template (see
+/// [`outer_fn_map_increment_shape`]).
+fn detect_map_key_tracked_increment(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<MapKeyTrackedIncrementPlan> {
+    use crate::ast::{BinOp, Expr};
+
+    outer_fn_map_increment_shape(fn_name, inputs)?;
+
+    let side = |after: &Spanned<crate::ast::Expr>,
+                rhs: &Spanned<crate::ast::Expr>|
+     -> Option<MapKeyTrackedIncrementPlan> {
+        let (map_arg, key_arg, default_arg) = defaulted_map_get_after_fn_call(after, fn_name)?;
+        if !is_int_lit(default_arg, 0) {
+            return None;
+        }
+        let Expr::BinOp(BinOp::Add, base, one) = &rhs.node else {
+            return None;
+        };
+        if !is_int_lit(one, 1) {
+            return None;
+        }
+        let (base_map, base_key, base_default) = defaulted_map_get(base)?;
+        if map_arg.node != base_map.node
+            || key_arg.node != base_key.node
+            || default_arg.node != base_default.node
+        {
+            return None;
+        }
+        Some(MapKeyTrackedIncrementPlan {
+            outer_fn: fn_name.to_string(),
+            map_arg: map_arg.clone(),
+            key_arg: key_arg.clone(),
+        })
+    };
+    side(&law.lhs, &law.rhs).or_else(|| side(&law.rhs, &law.lhs))
+}
+
+/// Validate `outer(m, k)` follows the canonical tracked-counter
+/// increment body:
+///
+/// ```text
+/// let v = Map.get m k
+/// match v {
+///   Some(n) -> Map.set m k (n + 1)
+///   None    -> Map.set m k 1
+/// }
+/// ```
+fn outer_fn_map_increment_shape(fn_name: &str, inputs: &ProofLowerInputs) -> Option<()> {
+    use crate::ast::{BinOp, Expr, Pattern, Stmt};
+
+    let fd = inputs.find_fn_def_by_call_name(fn_name)?;
+    if fd.params.len() != 2 {
+        return None;
+    }
+    let map_param = fd.params[0].0.as_str();
+    let key_param = fd.params[1].0.as_str();
+    let stmts = fd.body.stmts();
+    if stmts.len() != 2 {
+        return None;
+    }
+    let Stmt::Binding(current, _, bound_expr) = &stmts[0] else {
+        return None;
+    };
+    if !is_map_get_of_params(bound_expr, map_param, key_param) {
+        return None;
+    }
+    let Stmt::Expr(last_expr) = &stmts[1] else {
+        return None;
+    };
+    let Expr::Match { subject, arms, .. } = &last_expr.node else {
+        return None;
+    };
+    if !matches_ident_expr(subject, current) || arms.len() != 2 {
+        return None;
+    }
+
+    let some_arm = arms.iter().find_map(|arm| match &arm.pattern {
+        Pattern::Constructor(name, vars) if name == "Option.Some" && vars.len() == 1 => {
+            Some((vars[0].as_str(), arm.body.as_ref()))
+        }
+        _ => None,
+    })?;
+    let none_arm = arms.iter().find_map(|arm| match &arm.pattern {
+        Pattern::Constructor(name, vars) if name == "Option.None" && vars.is_empty() => {
+            Some(arm.body.as_ref())
+        }
+        _ => None,
+    })?;
+
+    let (some_bound, some_body) = some_arm;
+    let some_set = call_named_args(some_body, "Map.set")?;
+    let none_set = call_named_args(none_arm, "Map.set")?;
+    if some_set.len() != 3 || none_set.len() != 3 {
+        return None;
+    }
+    if !matches_ident_expr(&some_set[0], map_param)
+        || !matches_ident_expr(&some_set[1], key_param)
+        || !matches_ident_expr(&none_set[0], map_param)
+        || !matches_ident_expr(&none_set[1], key_param)
+    {
+        return None;
+    }
+    let Expr::BinOp(BinOp::Add, add_left, add_right) = &some_set[2].node else {
+        return None;
+    };
+    if !matches_ident_expr(add_left, some_bound) || !is_int_lit(add_right, 1) {
+        return None;
+    }
+    if !is_int_lit(&none_set[2], 1) {
+        return None;
+    }
+    Some(())
+}
+
+/// `Option.withDefault(Map.get(outer(m, k), k), d)` — extract (m, k,
+/// d) when the outer call matches `fn_name` and the lookup uses the
+/// same key as the outer call's key arg.
+fn defaulted_map_get_after_fn_call<'a>(
+    expr: &'a Spanned<crate::ast::Expr>,
+    fn_name: &str,
+) -> Option<(
+    &'a Spanned<crate::ast::Expr>,
+    &'a Spanned<crate::ast::Expr>,
+    &'a Spanned<crate::ast::Expr>,
+)> {
+    let (inner, default) = option_with_default_args(expr)?;
+    let (map_arg, key_arg) = map_get_after_fn_call(inner, fn_name)?;
+    Some((map_arg, key_arg, default))
+}
+
+/// `Option.withDefault(Map.get(m, k), d)` — extract (m, k, d) for the
+/// bare lookup form (no surrounding outer call).
+fn defaulted_map_get(
+    expr: &Spanned<crate::ast::Expr>,
+) -> Option<(
+    &Spanned<crate::ast::Expr>,
+    &Spanned<crate::ast::Expr>,
+    &Spanned<crate::ast::Expr>,
+)> {
+    let (inner, default) = option_with_default_args(expr)?;
+    let get_args = call_named_args(inner, "Map.get")?;
+    if get_args.len() != 2 {
+        return None;
+    }
+    Some((&get_args[0], &get_args[1], default))
+}
+
+fn option_with_default_args<'a>(
+    expr: &'a Spanned<crate::ast::Expr>,
+) -> Option<(&'a Spanned<crate::ast::Expr>, &'a Spanned<crate::ast::Expr>)> {
+    let args = call_named_args(expr, "Option.withDefault")?;
+    (args.len() == 2).then_some((&args[0], &args[1]))
+}
+
+fn is_int_lit(expr: &Spanned<crate::ast::Expr>, n: i64) -> bool {
+    use crate::ast::{Expr, Literal};
+    matches!(&expr.node, Expr::Literal(Literal::Int(m)) if *m == n)
 }
 
 /// `Map.has(outer(m, k), k)` — pick out the (m, k) from the inner

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -465,6 +465,32 @@ pub enum ProofStrategy {
         /// backends translate to their lemma vocabulary.
         extra_unfolds: Vec<String>,
     },
+    /// Counter-increment specialisation of [`MapUpdatePostcondition`].
+    /// The outer fn `outer(m, k)` is the canonical "tracked counter"
+    /// shape:
+    ///
+    /// ```text
+    /// let v = Map.get m k
+    /// match v {
+    ///   Some(n) -> Map.set m k (n + 1)
+    ///   None    -> Map.set m k 1
+    /// }
+    /// ```
+    ///
+    /// The law states the algebraic content:
+    /// `Option.withDefault(Map.get(outer(m, k), k), 0) ==
+    /// Option.withDefault(Map.get(m, k), 0) + 1` — get-or-default
+    /// after the increment equals the prior get-or-default plus 1.
+    /// Tighter than [`MapUpdatePostcondition`] because both the body
+    /// template AND the rhs `+ 1` shape are pinned.
+    MapKeyTrackedIncrement {
+        /// Source name of the outer increment fn.
+        outer_fn: String,
+        /// The map argument as it appears at the law's call site.
+        map_arg: Spanned<crate::ast::Expr>,
+        /// The key argument as it appears at the law's call site.
+        key_arg: Spanned<crate::ast::Expr>,
+    },
     /// Bounded universal: case-split over the declared `given`
     /// domain, dispatch each case to a per-sample lemma.
     BoundedUniversal,

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1231,3 +1231,40 @@ fn map_update_postcondition_pinned_get_after_with_helper_unfolds() {
         "GetAfter should carry the helper-fn unfold set (outer fn excluded)"
     );
 }
+
+#[test]
+fn map_key_tracked_increment_pinned_on_defaulted_get_plus_one() {
+    // `Option.withDefault(Map.get(incCount(m, k), k), 0) ==
+    // Option.withDefault(Map.get(m, k), 0) + 1` — the canonical
+    // tracked-counter increment law. Outer fn body is the specific
+    // `Some(n) -> n + 1 / None -> 1` template. Step 34 pins
+    // `MapKeyTrackedIncrement { outer_fn: "incCount", … }`.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn incCount(counts: Map<String, Int>, word: String) -> Map<String, Int>\n\
+         \x20   current = Map.get(counts, word)\n\
+         \x20   match current\n\
+         \x20       Option.Some(n) -> Map.set(counts, word, n + 1)\n\
+         \x20       Option.None -> Map.set(counts, word, 1)\n\
+         \n\
+         verify incCount law trackedCountStepsByOne\n\
+         \x20   given counts: Map<String, Int> = [{}]\n\
+         \x20   given word: String = [\"a\"]\n\
+         \x20   Option.withDefault(Map.get(incCount(counts, word), word), 0) => Option.withDefault(Map.get(counts, word), 0) + 1\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "incCount" && t.law_name == "trackedCountStepsByOne")
+        .expect("incCount::trackedCountStepsByOne law theorem missing");
+    let aver::ir::ProofStrategy::MapKeyTrackedIncrement { ref outer_fn, .. } = theorem.strategy
+    else {
+        panic!(
+            "expected MapKeyTrackedIncrement, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(outer_fn, "incCount");
+}


### PR DESCRIPTION
## Summary

- New IR variant `ProofStrategy::MapKeyTrackedIncrement { outer_fn, map_arg, key_arg }` captures the canonical tracked-counter increment law: `Option.withDefault(Map.get(outer(m, k), k), 0) == Option.withDefault(Map.get(m, k), 0) + 1`, where `outer` follows the `Some(n) -> n + 1 / None -> 1` body template. Tighter than `MapUpdatePostcondition` because both body shape AND rhs `+ 1` are pinned.
- Detector runs before `MapUpdatePostcondition` so the tighter strategy wins. Lean consumer renders the same 2-line tactic as before; byte-identical emit on `examples/data/map.av::incCount::trackedCountStepsByOne`.
- Legacy `maps::emit_map_increment_tracked_count_law` stays as a fallback alongside `MapUpdatePostcondition` — both retired in Step 35.

## Test plan

- [x] `cargo test --test proof_ir_diff` — 27 passed (one new diff test)
- [x] `cargo test --test proof_spec` — 35 passed; Lean build of `map.av` validates the emit
- [x] `cargo test --lib` — 615 passed
- [x] `cargo fmt --all --check`, `cargo clippy --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)