### PR TITLE
proof_lower+lean: Step 37 — pin SpecEquivalence for identical-body impl/spec pairs

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -145,6 +145,25 @@ pub fn emit_verify_law_forall_auto_proof(
         }
     }
 
+    // IR-pinned `SpecEquivalence` — the lowerer validated impl and
+    // spec fns have syntactically-identical bodies; backend closes
+    // via `simpa [<unfolds>]` (impl + spec + transitively-reached
+    // helpers). Falls through to the legacy spec dispatch when IR
+    // didn't pin (other 4 sub-shapes are still backend-driven).
+    if let Some(crate::ir::ProofStrategy::SpecEquivalence { ref extra_unfolds }) =
+        law_strategy_for(ctx, &vb.fn_name, &law.name)
+    {
+        let lean_names: Vec<String> = extra_unfolds.iter().map(|n| aver_name_to_lean(n)).collect();
+        return Some(AutoProof {
+            support_lines: Vec::new(),
+            proof_lines: intro_then(
+                &proof_intro_names,
+                vec![format!("simpa [{}]", lean_names.join(", "))],
+            ),
+            replaces_theorem: false,
+        });
+    }
+
     spec::emit_spec_function_equivalence_law(vb, law, ctx, &proof_intro_names)
         .or_else(|| {
             // IR-pinned Map library axiom (has_set_self / get_set_self).

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -656,6 +656,11 @@ fn classify_law_strategy(
             extra_unfolds: post.extra_unfolds,
         };
     }
+    // Functional equivalence of `vb.fn_name` and a same-named spec
+    // fn whose body is syntactically identical to the impl's.
+    if let Some(extra_unfolds) = detect_spec_equivalence(law, fn_name, inputs) {
+        return ProofStrategy::SpecEquivalence { extra_unfolds };
+    }
     // Linear arithmetic over an unfold chain — generic catch-all.
     // Named for the semantic, not the backend tactic.
     if let Some(plan) = detect_simp_omega_unfold(law, fn_name, inputs, refined_types) {
@@ -1186,6 +1191,117 @@ fn law_helper_unfolds(
     }
     names.remove(outer_fn);
     names.into_iter().collect()
+}
+
+/// Detect functional equivalence of `fn_name` and a same-named spec
+/// fn (`spec_fn_name = law.name`). Requires (a) law.name resolves to
+/// a pure user fn `spec_fd` in `inputs`; (b) law's lhs/rhs are direct
+/// calls — one to `fn_name`, one to `law.name` — with identical
+/// argument lists; (c) `impl_fd` and `spec_fd` bodies are single-
+/// terminal-expression bodies whose AST nodes match exactly.
+///
+/// On match, returns the unfold list: impl + spec + any user
+/// helpers reachable from the law sides. Sorted for deterministic
+/// emit.
+fn detect_spec_equivalence(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<Vec<String>> {
+    use crate::ast::Expr;
+    use std::collections::BTreeSet;
+
+    let spec_fn_name = &law.name;
+    if spec_fn_name == fn_name {
+        return None;
+    }
+    let spec_fd = inputs.find_fn_def_by_call_name(spec_fn_name)?;
+    if !spec_fd.effects.is_empty() || spec_fd.name == "main" {
+        return None;
+    }
+    let impl_fd = inputs.find_fn_def_by_call_name(fn_name)?;
+
+    let direct_call =
+        |expr: &Spanned<crate::ast::Expr>| -> Option<(String, Vec<Spanned<crate::ast::Expr>>)> {
+            let Expr::FnCall(callee, args) = &expr.node else {
+                return None;
+            };
+            let name = match &callee.node {
+                Expr::Ident(n) | Expr::Resolved { name: n, .. } => n.clone(),
+                _ => return None,
+            };
+            Some((name, args.clone()))
+        };
+    let canonical_shape =
+        |lhs: &Spanned<crate::ast::Expr>, rhs: &Spanned<crate::ast::Expr>| -> bool {
+            let Some((l_name, l_args)) = direct_call(lhs) else {
+                return false;
+            };
+            let Some((r_name, r_args)) = direct_call(rhs) else {
+                return false;
+            };
+            l_name == fn_name && r_name == *spec_fn_name && l_args == r_args
+        };
+    if !canonical_shape(&law.lhs, &law.rhs) && !canonical_shape(&law.rhs, &law.lhs) {
+        return None;
+    }
+
+    let impl_body = body_terminal_expr(impl_fd.body.as_ref())?;
+    let spec_body = body_terminal_expr(spec_fd.body.as_ref())?;
+    if impl_body.node != spec_body.node {
+        return None;
+    }
+
+    // Build the unfold set: impl + spec + transitively-reached user
+    // helpers from law sides. Mirrors the legacy `law_simp_defs`
+    // semantic but uses inputs (not CodegenContext).
+    let resolve_user_fn = |name: &str| -> Option<&FnDef> {
+        let fd = inputs.find_fn_def_by_call_name(name)?;
+        if !fd.effects.is_empty() || fd.name == "main" {
+            return None;
+        }
+        Some(fd)
+    };
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    names.insert(fn_name.to_string());
+    names.insert(spec_fn_name.clone());
+    let mut seed: BTreeSet<String> = BTreeSet::new();
+    collect_fn_calls_expr(&law.lhs, &mut seed);
+    collect_fn_calls_expr(&law.rhs, &mut seed);
+    if let Some(when_expr) = &law.when {
+        collect_fn_calls_expr(when_expr, &mut seed);
+    }
+    for n in seed {
+        if let Some(fd) = resolve_user_fn(&n) {
+            names.insert(fd.name.clone());
+        }
+    }
+    loop {
+        let before = names.len();
+        let snapshot: Vec<String> = names.iter().cloned().collect();
+        for name in snapshot {
+            let Some(fd) = resolve_user_fn(&name) else {
+                continue;
+            };
+            let mut called: BTreeSet<String> = BTreeSet::new();
+            for stmt in fd.body.stmts() {
+                match stmt {
+                    crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => {
+                        collect_fn_calls_expr(e, &mut called);
+                    }
+                }
+            }
+            for c in called {
+                if let Some(callee_fd) = resolve_user_fn(&c) {
+                    names.insert(callee_fd.name.clone());
+                }
+            }
+        }
+        if names.len() == before {
+            break;
+        }
+    }
+    Some(names.into_iter().collect())
 }
 
 /// Validate the outer fn's body matches the "inspect get, set in

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -491,6 +491,21 @@ pub enum ProofStrategy {
         /// The key argument as it appears at the law's call site.
         key_arg: Spanned<crate::ast::Expr>,
     },
+    /// Functional equivalence between an impl fn and a (declared)
+    /// spec fn — the law states `impl(args) == spec(args)` and the
+    /// two fn bodies are syntactically identical (after typecheck).
+    /// Backends close the goal by unfolding both fns; their bodies
+    /// reduce to the same term and the equality holds by reflexivity
+    /// modulo simp normalisation. Lean emits `simpa [<unfolds>]`,
+    /// Dafny would reveal both and let Z3 prove the equivalence.
+    /// Named for the algebraic content (functional equivalence),
+    /// not the backend tactic.
+    SpecEquivalence {
+        /// All user fn source names to unfold — impl + spec + any
+        /// transitively-reached helpers from law sides. Source
+        /// names; backends translate to their lemma vocabulary.
+        extra_unfolds: Vec<String>,
+    },
     /// Bounded universal: case-split over the declared `given`
     /// domain, dispatch each case to a per-sample lemma.
     BoundedUniversal,

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1268,3 +1268,41 @@ fn map_key_tracked_increment_pinned_on_defaulted_get_plus_one() {
     };
     assert_eq!(outer_fn, "incCount");
 }
+
+#[test]
+fn spec_equivalence_pinned_on_identical_body_impl_spec_pair() {
+    // `verify absVal law absValSpec` with `absVal(x) => absValSpec(x)`
+    // and identical bodies in both fns. Step 37 pins
+    // `SpecEquivalence { extra_unfolds: [absVal, absValSpec] }`.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn absVal(x: Int) -> Int\n\
+         \x20   match x < 0\n\
+         \x20       true -> 0 - x\n\
+         \x20       false -> x\n\
+         \n\
+         fn absValSpec(x: Int) -> Int\n\
+         \x20   match x < 0\n\
+         \x20       true -> 0 - x\n\
+         \x20       false -> x\n\
+         \n\
+         verify absVal law absValSpec\n\
+         \x20   given x: Int = [0]\n\
+         \x20   absVal(x) => absValSpec(x)\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "absVal" && t.law_name == "absValSpec")
+        .expect("absVal::absValSpec law theorem missing");
+    let aver::ir::ProofStrategy::SpecEquivalence { ref extra_unfolds } = theorem.strategy else {
+        panic!("expected SpecEquivalence, got: {:?}", theorem.strategy);
+    };
+    assert_eq!(
+        extra_unfolds,
+        &vec!["absVal".to_string(), "absValSpec".to_string()],
+        "extra_unfolds should be the impl + spec pair (sorted)"
+    );
+}


### PR DESCRIPTION
## Summary

- First spec-equivalence migration. New IR variant `ProofStrategy::SpecEquivalence { extra_unfolds }` captures the canonical "impl fn and spec fn have syntactically-identical bodies; law states `impl(args) == spec(args)`" shape.
- Detection in `proof_lower::detect_spec_equivalence`: spec_fn name = law.name, both sides direct calls with identical args, impl/spec terminal-expression bodies match AST-node-for-node. `extra_unfolds` set = impl + spec + transitively-reached user helpers.
- Lean consumer emits `simpa [<unfolds>]` — byte-identical to the legacy emit on `examples/formal/spec_laws.av::absVal::absValSpec`.
- Falls through to the legacy `spec::emit_spec_function_equivalence_law` chain when IR doesn't pin (4 other spec sub-shapes migrate later).

## Test plan

- [x] `cargo test --test proof_ir_diff` — 28 passed
- [x] `cargo test --test proof_spec` — 35 passed (incl. `spec_laws.av` Lean build)
- [x] `cargo test --lib` — 615 passed
- [x] `cargo fmt --all --check`, `cargo clippy --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)