### PR TITLE
proof_lower+lean: Step 38 — Oracle Lift + pin EffectfulSpecEquivalence

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -1134,12 +1134,15 @@ pub(crate) enum OracleInjectionMode<'a> {
 /// Backend-agnostic — operates on AST + `CodegenContext`. Both the
 /// Dafny and Lean backends call this before emitting the law body so
 /// the law statement matches the lifted fn shape emitted alongside.
-pub(crate) fn rewrite_effectful_calls_in_law(
+pub(crate) fn rewrite_effectful_calls_in_law<'fd, F>(
     expr: &crate::ast::Spanned<Expr>,
     law: &crate::ast::VerifyLaw,
-    ctx: &CodegenContext,
+    find_fn_def: F,
     mode: OracleInjectionMode,
-) -> crate::ast::Spanned<Expr> {
+) -> crate::ast::Spanned<Expr>
+where
+    F: Fn(&str) -> Option<&'fd crate::ast::FnDef> + Copy,
+{
     use crate::ast::{Spanned, VerifyGivenDomain};
 
     let injection_by_effect: std::collections::HashMap<String, Spanned<Expr>> = law
@@ -1172,7 +1175,7 @@ pub(crate) fn rewrite_effectful_calls_in_law(
             Some((g.type_name.clone(), arg_expr))
         })
         .collect();
-    let rewritten = rewrite_effectful_call(expr, &injection_by_effect, ctx);
+    let rewritten = rewrite_effectful_call(expr, &injection_by_effect, find_fn_def);
 
     // For `LemmaBindingProjected`, oracle bindings live as subtypes
     // (`RandomIntInBounds` etc.); direct calls `rng(path, n, min, max)`
@@ -1272,11 +1275,14 @@ fn project_oracle_direct_calls(
     Spanned::new(new_node, line)
 }
 
-fn rewrite_effectful_call(
+fn rewrite_effectful_call<'fd, F>(
     expr: &crate::ast::Spanned<Expr>,
     injection_by_effect: &std::collections::HashMap<String, crate::ast::Spanned<Expr>>,
-    ctx: &CodegenContext,
-) -> crate::ast::Spanned<Expr> {
+    find_fn_def: F,
+) -> crate::ast::Spanned<Expr>
+where
+    F: Fn(&str) -> Option<&'fd crate::ast::FnDef> + Copy,
+{
     use crate::ast::Spanned;
     use crate::types::checker::effect_classification::{EffectDimension, classify};
 
@@ -1284,10 +1290,13 @@ fn rewrite_effectful_call(
         Expr::FnCall(callee, args) => {
             let rewritten_args: Vec<Spanned<Expr>> = args
                 .iter()
-                .map(|a| rewrite_effectful_call(a, injection_by_effect, ctx))
+                .map(|a| rewrite_effectful_call(a, injection_by_effect, find_fn_def))
                 .collect();
-            let rewritten_callee =
-                Box::new(rewrite_effectful_call(callee, injection_by_effect, ctx));
+            let rewritten_callee = Box::new(rewrite_effectful_call(
+                callee,
+                injection_by_effect,
+                find_fn_def,
+            ));
 
             let callee_name = match &callee.node {
                 Expr::Ident(name) => Some(name.clone()),
@@ -1296,7 +1305,7 @@ fn rewrite_effectful_call(
             };
 
             if let Some(name) = callee_name
-                && let Some(fd) = ctx.fn_defs.iter().find(|fd| fd.name == name)
+                && let Some(fd) = find_fn_def(&name)
                 && !fd.effects.is_empty()
                 && fd
                     .effects
@@ -1347,8 +1356,8 @@ fn rewrite_effectful_call(
         Expr::BinOp(op, l, r) => Spanned::new(
             Expr::BinOp(
                 *op,
-                Box::new(rewrite_effectful_call(l, injection_by_effect, ctx)),
-                Box::new(rewrite_effectful_call(r, injection_by_effect, ctx)),
+                Box::new(rewrite_effectful_call(l, injection_by_effect, find_fn_def)),
+                Box::new(rewrite_effectful_call(r, injection_by_effect, find_fn_def)),
             ),
             expr.line,
         ),
@@ -1356,7 +1365,7 @@ fn rewrite_effectful_call(
             Expr::Tuple(
                 items
                     .iter()
-                    .map(|i| rewrite_effectful_call(i, injection_by_effect, ctx))
+                    .map(|i| rewrite_effectful_call(i, injection_by_effect, find_fn_def))
                     .collect(),
             ),
             expr.line,

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -696,8 +696,18 @@ pub fn emit_law_samples(
         let case_bindings = vb.case_givens.first().map(|v| v.as_slice()).unwrap_or(&[]);
         let mode = OracleInjectionMode::SampleCaseBinding(case_bindings);
         (
-            rewrite_effectful_calls_in_law(lhs, law, ctx, mode.clone()),
-            rewrite_effectful_calls_in_law(rhs, law, ctx, mode),
+            rewrite_effectful_calls_in_law(
+                lhs,
+                law,
+                |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+                mode.clone(),
+            ),
+            rewrite_effectful_calls_in_law(
+                rhs,
+                law,
+                |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+                mode,
+            ),
         )
     });
     let any_opaque = first_rewrite
@@ -748,8 +758,18 @@ pub fn emit_law_samples(
         .map(|(idx, (lhs, rhs))| {
             let case_bindings = vb.case_givens.get(idx).map(|v| v.as_slice()).unwrap_or(&[]);
             let mode = OracleInjectionMode::SampleCaseBinding(case_bindings);
-            let lhs_rw = rewrite_effectful_calls_in_law(lhs, law, ctx, mode.clone());
-            let rhs_rw = rewrite_effectful_calls_in_law(rhs, law, ctx, mode);
+            let lhs_rw = rewrite_effectful_calls_in_law(
+                lhs,
+                law,
+                |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+                mode.clone(),
+            );
+            let rhs_rw = rewrite_effectful_calls_in_law(
+                rhs,
+                law,
+                |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+                mode,
+            );
             (lhs_rw, rhs_rw)
         })
         .collect();
@@ -1033,10 +1053,18 @@ pub fn emit_verify_law(
     // lifted `pickOne` takes `(path, rnd_Random_int, <orig_args>)`.
     // Inject `BranchPath.root()` + the matching given identifier for
     // each classified non-output effect in the callee's signature.
-    let law_lhs =
-        rewrite_effectful_calls_in_law(&law.lhs, law, ctx, OracleInjectionMode::LemmaBinding);
-    let law_rhs =
-        rewrite_effectful_calls_in_law(&law.rhs, law, ctx, OracleInjectionMode::LemmaBinding);
+    let law_lhs = rewrite_effectful_calls_in_law(
+        &law.lhs,
+        law,
+        |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+        OracleInjectionMode::LemmaBinding,
+    );
+    let law_rhs = rewrite_effectful_calls_in_law(
+        &law.rhs,
+        law,
+        |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+        OracleInjectionMode::LemmaBinding,
+    );
 
     // Refinement-lift wrapper stripping: when a given was promoted to
     // a refined type, the source-written `X(value = a)` constructor

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -149,7 +149,7 @@ pub fn emit_verify_law_forall_auto_proof(
     // spec fns have syntactically-identical bodies; backend closes
     // via `simpa [<unfolds>]` (impl + spec + transitively-reached
     // helpers). Falls through to the legacy spec dispatch when IR
-    // didn't pin (other 4 sub-shapes are still backend-driven).
+    // didn't pin (other spec sub-shapes are still backend-driven).
     if let Some(crate::ir::ProofStrategy::SpecEquivalence { ref extra_unfolds }) =
         law_strategy_for(ctx, &vb.fn_name, &law.name)
     {
@@ -159,6 +159,29 @@ pub fn emit_verify_law_forall_auto_proof(
             proof_lines: intro_then(
                 &proof_intro_names,
                 vec![format!("simpa [{}]", lean_names.join(", "))],
+            ),
+            replaces_theorem: false,
+        });
+    }
+
+    // IR-pinned `EffectfulSpecEquivalence` — Oracle Lift normalised
+    // both sides; lowerer matched the canonical `impl(args) ==
+    // spec(args)` shape post-rewrite. Backend emits `simp [impl,
+    // spec]`; both definitions unfold to the same oracle call.
+    if let Some(crate::ir::ProofStrategy::EffectfulSpecEquivalence {
+        ref impl_fn,
+        ref spec_fn,
+    }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+    {
+        return Some(AutoProof {
+            support_lines: Vec::new(),
+            proof_lines: intro_then(
+                &proof_intro_names,
+                vec![format!(
+                    "simp [{}, {}]",
+                    aver_name_to_lean(impl_fn),
+                    aver_name_to_lean(spec_fn)
+                )],
             ),
             replaces_theorem: false,
         });

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1656,13 +1656,13 @@ fn emit_verify_trace_block_proofs(
         let lhs_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
             &fn_call,
             &synthetic_law,
-            ctx,
+            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
             mode.clone(),
         );
         let rhs_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
             right,
             &synthetic_law,
-            ctx,
+            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
             mode,
         );
 
@@ -1724,13 +1724,13 @@ fn emit_verify_law_block(
     let law_lhs = crate::codegen::common::rewrite_effectful_calls_in_law(
         &law.lhs,
         law,
-        ctx,
+        |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
         crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
     );
     let law_rhs = crate::codegen::common::rewrite_effectful_calls_in_law(
         &law.rhs,
         law,
-        ctx,
+        |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
         crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
     );
     // Refinement quantifier lift: when a given Int variable shows up
@@ -1777,7 +1777,7 @@ fn emit_verify_law_block(
         let oracle_projected = crate::codegen::common::rewrite_effectful_calls_in_law(
             expr,
             law,
-            ctx,
+            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
             crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
         );
         // Refinement lift: bare references to lifted-given idents
@@ -1942,11 +1942,15 @@ fn emit_verify_law_block(
                 let left_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
                     left,
                     law,
-                    ctx,
+                    |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
                     mode.clone(),
                 );
-                let right_rw =
-                    crate::codegen::common::rewrite_effectful_calls_in_law(right, law, ctx, mode);
+                let right_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
+                    right,
+                    law,
+                    |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+                    mode,
+                );
                 let left_str = emit_expr(&left_rw, ctx);
                 let right_str = emit_expr(&right_rw, ctx);
                 if let Some(guard) = law.sample_guards.get(idx) {
@@ -2004,10 +2008,18 @@ fn emit_verify_law_block(
         // `impl(…, a) = spec(…, b)` pairs.
         let case_bindings = vb.case_givens.get(idx).map(|v| v.as_slice()).unwrap_or(&[]);
         let mode = crate::codegen::common::OracleInjectionMode::SampleCaseBinding(case_bindings);
-        let left_rw =
-            crate::codegen::common::rewrite_effectful_calls_in_law(left, law, ctx, mode.clone());
-        let right_rw =
-            crate::codegen::common::rewrite_effectful_calls_in_law(right, law, ctx, mode);
+        let left_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
+            left,
+            law,
+            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+            mode.clone(),
+        );
+        let right_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
+            right,
+            law,
+            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+            mode,
+        );
         let left_str = emit_expr(&left_rw, ctx);
         let right_str = emit_expr(&right_rw, ctx);
         let sample_prop = if let Some(guard) = law.sample_guards.get(idx) {

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -661,6 +661,17 @@ fn classify_law_strategy(
     if let Some(extra_unfolds) = detect_spec_equivalence(law, fn_name, inputs) {
         return ProofStrategy::SpecEquivalence { extra_unfolds };
     }
+    // Effectful counterpart — Oracle Lift normalises both sides
+    // (oracle args injected into impl call) and the lowerer matches
+    // the canonical `impl(args) == spec(args)` shape on the
+    // rewritten form. Fires on real oracle-spec laws like
+    // `pickPair() => pairSpec(BranchPath.Root, rnd)`.
+    if let Some(spec_fn) = detect_effectful_spec_equivalence(law, fn_name, inputs) {
+        return ProofStrategy::EffectfulSpecEquivalence {
+            impl_fn: fn_name.to_string(),
+            spec_fn,
+        };
+    }
     // Linear arithmetic over an unfold chain — generic catch-all.
     // Named for the semantic, not the backend tactic.
     if let Some(plan) = detect_simp_omega_unfold(law, fn_name, inputs, refined_types) {
@@ -1302,6 +1313,83 @@ fn detect_spec_equivalence(
         }
     }
     Some(names.into_iter().collect())
+}
+
+/// Detect functional equivalence between an effectful impl fn and
+/// a spec fn (different name). Runs Oracle Lift over both sides of
+/// the law first — injecting `BranchPath.Root` and oracle givens
+/// into every classified effectful call site — then matches the
+/// canonical `impl(args) == spec(args)` direct-call shape with
+/// identical argument lists on the rewritten form. Returns the
+/// spec fn name on match.
+///
+/// Body-match is not required here (and would fail — impl and spec
+/// bodies usually differ syntactically; Oracle Lift normalises them
+/// to a common oracle call only after backend-side `simp` unfolds).
+fn detect_effectful_spec_equivalence(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<String> {
+    use crate::ast::Expr;
+
+    let impl_fd = inputs.find_fn_def_by_call_name(fn_name)?;
+    if impl_fd.effects.is_empty() {
+        return None;
+    }
+    if !impl_fd
+        .effects
+        .iter()
+        .all(|e| crate::types::checker::effect_classification::is_classified(&e.node))
+    {
+        return None;
+    }
+
+    let find_fn = |name: &str| -> Option<&crate::ast::FnDef> {
+        inputs
+            .entry_items
+            .iter()
+            .filter_map(|item| match item {
+                TopLevel::FnDef(fd) => Some(fd),
+                _ => None,
+            })
+            .find(|fd| fd.name == name)
+    };
+    let rewritten_lhs = crate::codegen::common::rewrite_effectful_calls_in_law(
+        &law.lhs,
+        law,
+        find_fn,
+        crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
+    );
+    let rewritten_rhs = crate::codegen::common::rewrite_effectful_calls_in_law(
+        &law.rhs,
+        law,
+        find_fn,
+        crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
+    );
+
+    let direct_call =
+        |expr: &Spanned<crate::ast::Expr>| -> Option<(String, Vec<Spanned<crate::ast::Expr>>)> {
+            let Expr::FnCall(callee, args) = &expr.node else {
+                return None;
+            };
+            let name = match &callee.node {
+                Expr::Ident(n) | Expr::Resolved { name: n, .. } => n.clone(),
+                _ => return None,
+            };
+            Some((name, args.clone()))
+        };
+    let try_side = |impl_side: &Spanned<crate::ast::Expr>,
+                    spec_side: &Spanned<crate::ast::Expr>|
+     -> Option<String> {
+        let (l_name, l_args) = direct_call(impl_side)?;
+        let (r_name, r_args) = direct_call(spec_side)?;
+        if l_args != r_args || l_name == r_name || l_name != fn_name {
+            return None;
+        }
+        Some(r_name)
+    };
+    try_side(&rewritten_lhs, &rewritten_rhs).or_else(|| try_side(&rewritten_rhs, &rewritten_lhs))
 }
 
 /// Validate the outer fn's body matches the "inspect get, set in

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -506,6 +506,22 @@ pub enum ProofStrategy {
         /// names; backends translate to their lemma vocabulary.
         extra_unfolds: Vec<String>,
     },
+    /// Functional equivalence between an effectful impl fn and a
+    /// spec fn. Same "claim states `impl(args) == spec(args)`"
+    /// content as [`SpecEquivalence`], but the law's source-level
+    /// shape is non-canonical (impl call usually omits oracle args
+    /// the spec call carries explicitly). The lowerer runs an
+    /// Oracle Lift over both sides — injecting oracle args from
+    /// `given oracle: Random.int = ...` into every classified
+    /// effectful call site — and matches the canonical shape on the
+    /// rewritten form. Backends emit `simp [impl, spec]`; both
+    /// definitions unfold to the same oracle call after lifting.
+    EffectfulSpecEquivalence {
+        /// Source name of the impl fn (= `vb.fn_name`).
+        impl_fn: String,
+        /// Source name of the spec fn (the other side of the law).
+        spec_fn: String,
+    },
     /// Bounded universal: case-split over the declared `given`
     /// domain, dispatch each case to a per-sample lemma.
     BoundedUniversal,

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1306,3 +1306,49 @@ fn spec_equivalence_pinned_on_identical_body_impl_spec_pair() {
         "extra_unfolds should be the impl + spec pair (sorted)"
     );
 }
+
+#[test]
+fn effectful_spec_equivalence_pinned_post_oracle_lift() {
+    // Effectful impl + spec via Random.int oracle. Source-level law
+    // shape `pickPair() => pairSpec(BranchPath.Root, rnd)` has
+    // mismatched arg counts (impl 0, spec 2) — non-canonical.
+    // Step 38's Oracle Lift in the detector injects
+    // `(BranchPath.Root, rnd)` into the impl call, both sides
+    // become `pickPair(BranchPath.Root, rnd) == pairSpec(...)` with
+    // identical args, and the canonical-shape match succeeds.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn counterStub(path: BranchPath, n: Int, min: Int, max: Int) -> Int\n\
+         \x20   n\n\
+         \n\
+         fn pairSpec(path: BranchPath, rnd: Fn(BranchPath, Int, Int, Int) -> Int) -> Tuple<Int, Int>\n\
+         \x20   (rnd(BranchPath.child(path, 0), 0, 1, 6), rnd(BranchPath.child(path, 1), 0, 7, 12))\n\
+         \n\
+         fn pickPair() -> Tuple<Int, Int>\n\
+         \x20   ! [Random.int]\n\
+         \x20   (Random.int(1, 6), Random.int(7, 12))!\n\
+         \n\
+         verify pickPair law branchPathLaw\n\
+         \x20   given rnd: Random.int = [counterStub]\n\
+         \x20   pickPair() => pairSpec(BranchPath.Root, rnd)\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "pickPair" && t.law_name == "branchPathLaw")
+        .expect("pickPair::branchPathLaw law theorem missing");
+    let aver::ir::ProofStrategy::EffectfulSpecEquivalence {
+        ref impl_fn,
+        ref spec_fn,
+    } = theorem.strategy
+    else {
+        panic!(
+            "expected EffectfulSpecEquivalence, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(impl_fn, "pickPair");
+    assert_eq!(spec_fn, "pairSpec");
+}


### PR DESCRIPTION
## Summary

- Refactors `codegen::common::rewrite_effectful_calls_in_law` to take a `find_fn_def: F` closure instead of `&CodegenContext` — `proof_lower` can now run the same Oracle Lift from its own `ProofLowerInputs` view. Lean + Dafny callers pass `|n| ctx.fn_defs.iter().find(...)`; no behaviour change.
- New IR variant `ProofStrategy::EffectfulSpecEquivalence { impl_fn, spec_fn }`. The detector runs Oracle Lift over both sides of the law (injecting `BranchPath.Root` + oracle givens into every classified effectful call site) and matches the canonical `impl(args) == spec(args)` shape on the rewritten form. Fires on real oracle-spec laws (`pickPair() => pairSpec(BranchPath.Root, rnd)` — source shape non-canonical, post-lift canonical).
- Lean consumer emits `simp [impl, spec]` — byte-identical to legacy emit on `examples/formal/oracle_independent_products.av::pickPair::branchPathLaw`. Verified by inspection.
- Falls through to the legacy `spec::emit_spec_function_equivalence_law` chain when IR doesn't pin (3 sub-shapes still backend-driven: simp_normalized, linear_int, linear_recurrence2).

## Test plan

- [x] `cargo test --test proof_ir_diff` — 29 passed (one new diff test asserts pin on source-level non-canonical pickPair/pairSpec shape)
- [x] `cargo test --test proof_spec` — 35 passed (incl. `oracle_independent_products.av` Lean build)
- [x] `cargo test --lib` — 615 passed
- [x] `cargo test --tests` — full integration sweep clean
- [x] `cargo fmt --all --check`, `cargo clippy --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)