### PR TITLE
proof_lower+lean: Step 40 — pin LinearIntSpecEquivalence strategy

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -164,6 +164,31 @@ pub fn emit_verify_law_forall_auto_proof(
         });
     }
 
+    // IR-pinned `LinearIntSpecEquivalence` — Step 40: lowerer
+    // validated substituted bodies are pure linear arithmetic over
+    // Int givens. Backend emits `change <impl> = <spec> ; omega`.
+    if let Some(crate::ir::ProofStrategy::LinearIntSpecEquivalence {
+        ref unfolded_impl,
+        ref unfolded_spec,
+    }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+    {
+        return Some(AutoProof {
+            support_lines: Vec::new(),
+            proof_lines: intro_then(
+                &proof_intro_names,
+                vec![
+                    format!(
+                        "change {} = {}",
+                        emit_expr(unfolded_impl, ctx),
+                        emit_expr(unfolded_spec, ctx)
+                    ),
+                    "omega".to_string(),
+                ],
+            ),
+            replaces_theorem: false,
+        });
+    }
+
     // IR-pinned `SpecEquivalenceSimpNormalized` — Step 39 broaden:
     // impl and spec bodies aren't syntactically identical but
     // normalize to the same expression under arg substitution +

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -668,6 +668,16 @@ fn classify_law_strategy(
     if let Some(extra_unfolds) = detect_simp_normalized_spec_equivalence(law, fn_name, inputs) {
         return ProofStrategy::SpecEquivalenceSimpNormalized { extra_unfolds };
     }
+    // Linear-Int spec equivalence — substituted bodies are pure
+    // linear arithmetic over Int givens; decided by `omega` / LIA.
+    if let Some((unfolded_impl, unfolded_spec)) =
+        detect_linear_int_spec_equivalence(law, fn_name, inputs)
+    {
+        return ProofStrategy::LinearIntSpecEquivalence {
+            unfolded_impl,
+            unfolded_spec,
+        };
+    }
     // Effectful counterpart — Oracle Lift normalises both sides
     // (oracle args injected into impl call) and the lowerer matches
     // the canonical `impl(args) == spec(args)` shape on the
@@ -1452,6 +1462,111 @@ fn detect_simp_normalized_spec_equivalence(
         }
     }
     Some(names.into_iter().collect())
+}
+
+/// Detect "linear Int" spec equivalence: same canonical impl/spec
+/// call shape as the other spec detectors, all givens are `Int`,
+/// both impl and spec return `Int`, and the substituted bodies are
+/// purely linear arithmetic expressions over the law-quantified
+/// givens (only `Int` literals, given idents, `Add`, `Sub`). On
+/// match returns the two substituted bodies — backends rewrite to
+/// `change <impl> = <spec>` and close via their linear-arithmetic
+/// decision procedure (`omega` on Lean, Z3 LIA on Dafny).
+fn detect_linear_int_spec_equivalence(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<(Spanned<crate::ast::Expr>, Spanned<crate::ast::Expr>)> {
+    use crate::ast::Expr;
+    use std::collections::HashSet;
+
+    if law.givens.is_empty() || !law.givens.iter().all(|g| g.type_name == "Int") {
+        return None;
+    }
+    let spec_fn_name = &law.name;
+    if spec_fn_name == fn_name {
+        return None;
+    }
+    let spec_fd = inputs.find_fn_def_by_call_name(spec_fn_name)?;
+    if !spec_fd.effects.is_empty() || spec_fd.name == "main" {
+        return None;
+    }
+    let impl_fd = inputs.find_fn_def_by_call_name(fn_name)?;
+    if impl_fd.return_type != "Int" || spec_fd.return_type != "Int" {
+        return None;
+    }
+
+    let direct_call =
+        |expr: &Spanned<crate::ast::Expr>| -> Option<(String, Vec<Spanned<crate::ast::Expr>>)> {
+            let Expr::FnCall(callee, args) = &expr.node else {
+                return None;
+            };
+            let name = match &callee.node {
+                Expr::Ident(n) | Expr::Resolved { name: n, .. } => n.clone(),
+                _ => return None,
+            };
+            Some((name, args.clone()))
+        };
+    let canonical_shape_args = |lhs: &Spanned<crate::ast::Expr>,
+                                rhs: &Spanned<crate::ast::Expr>|
+     -> Option<Vec<Spanned<crate::ast::Expr>>> {
+        let (l_name, l_args) = direct_call(lhs)?;
+        let (r_name, r_args) = direct_call(rhs)?;
+        if l_name != fn_name || r_name != *spec_fn_name || l_args != r_args {
+            return None;
+        }
+        if l_args.len() != impl_fd.params.len() || r_args.len() != spec_fd.params.len() {
+            return None;
+        }
+        Some(l_args)
+    };
+    let call_args = canonical_shape_args(&law.lhs, &law.rhs)
+        .or_else(|| canonical_shape_args(&law.rhs, &law.lhs))?;
+
+    let impl_body = body_terminal_expr(impl_fd.body.as_ref())?;
+    let spec_body = body_terminal_expr(spec_fd.body.as_ref())?;
+    let impl_subst: std::collections::HashMap<String, Spanned<crate::ast::Expr>> = impl_fd
+        .params
+        .iter()
+        .zip(call_args.iter())
+        .map(|((n, _), arg)| (n.clone(), arg.clone()))
+        .collect();
+    let spec_subst: std::collections::HashMap<String, Spanned<crate::ast::Expr>> = spec_fd
+        .params
+        .iter()
+        .zip(call_args.iter())
+        .map(|((n, _), arg)| (n.clone(), arg.clone()))
+        .collect();
+    let unfolded_impl =
+        crate::ast_rewrite::rewrite_idents_scoped(impl_body, |name| impl_subst.get(name).cloned());
+    let unfolded_spec =
+        crate::ast_rewrite::rewrite_idents_scoped(spec_body, |name| spec_subst.get(name).cloned());
+
+    let allowed_idents: HashSet<&str> = law.givens.iter().map(|g| g.name.as_str()).collect();
+    if !is_linear_int_expr(&unfolded_impl, &allowed_idents)
+        || !is_linear_int_expr(&unfolded_spec, &allowed_idents)
+    {
+        return None;
+    }
+    Some((unfolded_impl, unfolded_spec))
+}
+
+/// Check whether `expr` is purely linear arithmetic over `allowed_
+/// idents`: only `Int` literals, allowed idents, and `Add`/`Sub`
+/// BinOps. Mirrors legacy `spec::linear_int::is_linear_int_expr`.
+fn is_linear_int_expr(
+    expr: &Spanned<crate::ast::Expr>,
+    allowed_idents: &std::collections::HashSet<&str>,
+) -> bool {
+    use crate::ast::{BinOp, Expr, Literal};
+    match &expr.node {
+        Expr::Literal(Literal::Int(_)) => true,
+        Expr::Ident(name) | Expr::Resolved { name, .. } => allowed_idents.contains(name.as_str()),
+        Expr::BinOp(BinOp::Add | BinOp::Sub, left, right) => {
+            is_linear_int_expr(left, allowed_idents) && is_linear_int_expr(right, allowed_idents)
+        }
+        _ => false,
+    }
 }
 
 /// Detect functional equivalence between an effectful impl fn and

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -518,6 +518,24 @@ pub enum ProofStrategy {
         /// transitively-reached helpers from law sides.
         extra_unfolds: Vec<String>,
     },
+    /// Linear-Int spec equivalence — impl and spec bodies are both
+    /// linear arithmetic expressions over Int givens (only
+    /// `Literal::Int`, given idents, `Add`, `Sub`) after arg
+    /// substitution. Bodies may differ syntactically but the
+    /// equivalence is decidable by a linear-arithmetic solver
+    /// (Presburger / `omega` / Z3 LIA). Backends emit a `change
+    /// <impl_unfolded> = <spec_unfolded>` rewrite then close via
+    /// their decision procedure; the IR carries the substituted
+    /// expressions so the backend can render them via its own
+    /// `emit_expr`.
+    LinearIntSpecEquivalence {
+        /// Impl body with formal params substituted by call-site
+        /// args. Linear-arithmetic-only after substitution.
+        unfolded_impl: Spanned<crate::ast::Expr>,
+        /// Spec body with formal params substituted by call-site
+        /// args. Linear-arithmetic-only after substitution.
+        unfolded_spec: Spanned<crate::ast::Expr>,
+    },
     /// Functional equivalence between an effectful impl fn and a
     /// spec fn. Same "claim states `impl(args) == spec(args)`"
     /// content as [`SpecEquivalence`], but the law's source-level

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1393,3 +1393,56 @@ fn simp_normalized_spec_equivalence_pinned_on_arithmetic_identity_gap() {
         "extra_unfolds should be the impl + spec pair (sorted)"
     );
 }
+
+#[test]
+fn linear_int_spec_equivalence_pinned_on_commutative_addition() {
+    // `addOne(n) = n + 1` vs `addOneSpec(n) = 1 + n`. Bodies differ
+    // (operand order), substitute n into both → `n + 1` and `1 + n`
+    // — pure linear-int arithmetic over the given `n`. Step 40 pins
+    // `LinearIntSpecEquivalence { unfolded_impl, unfolded_spec }`.
+    // Distinct from `SpecEquivalenceSimpNormalized` because the
+    // `simplify_identity_expr` pass doesn't rewrite `1 + n` to
+    // `n + 1` (no commutativity normalisation), so the body-match
+    // check there fails and falls through to this detector.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn addOne(n: Int) -> Int\n\
+         \x20   n + 1\n\
+         \n\
+         fn addOneSpec(n: Int) -> Int\n\
+         \x20   1 + n\n\
+         \n\
+         verify addOne law addOneSpec\n\
+         \x20   given n: Int = [0]\n\
+         \x20   addOne(n) => addOneSpec(n)\n";
+    let ctx = build_ctx(src);
+    let theorem = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_name == "addOne" && t.law_name == "addOneSpec")
+        .expect("addOne::addOneSpec law theorem missing");
+    let aver::ir::ProofStrategy::LinearIntSpecEquivalence {
+        ref unfolded_impl,
+        ref unfolded_spec,
+    } = theorem.strategy
+    else {
+        panic!(
+            "expected LinearIntSpecEquivalence, got: {:?}",
+            theorem.strategy
+        );
+    };
+    // Asserting full Spanned AST equality is brittle (carries
+    // OnceLock type cells); just check the shape stripped to Debug.
+    let impl_repr = format!("{:?}", unfolded_impl.node);
+    let spec_repr = format!("{:?}", unfolded_spec.node);
+    assert!(
+        impl_repr.contains("Ident(\"n\")") && impl_repr.contains("Int(1)"),
+        "unfolded_impl should reference n and literal 1, got: {impl_repr}"
+    );
+    assert!(
+        spec_repr.contains("Ident(\"n\")") && spec_repr.contains("Int(1)"),
+        "unfolded_spec should reference n and literal 1, got: {spec_repr}"
+    );
+}


### PR DESCRIPTION
## Summary

- New IR variant `ProofStrategy::LinearIntSpecEquivalence { unfolded_impl, unfolded_spec }` carries substituted bodies as `Spanned<Expr>` so backends render them via their own `emit_expr`. Detector requires canonical impl/spec call shape, all Int givens/returns, and substituted bodies that satisfy `is_linear_int_expr` (only Int literals, given idents, Add/Sub).
- Lean consumer emits `change <impl> = <spec> ; omega` — byte-identical to legacy `spec::linear_int::emit_linear_int_omega_spec_equivalence_law`. Verified on `addOne(n) = n + 1` vs `addOneSpec(n) = 1 + n`.
- Dafny: no consumer change — empty lemma body + fuel attrs let Z3 close linear-Int equivalences. Verified.
- Runs after `SpecEquivalence{,SimpNormalized}` so the tighter pins win when both would match.

## Test plan

- [x] `cargo test --test proof_ir_diff` — 31 passed (one new diff test)
- [x] `cargo test --test proof_spec` — 35 passed
- [x] `cargo test --lib` — 615 passed
- [x] `cargo fmt --all --check`, `cargo clippy --lib`
- [x] Verified IR pin + Lean emit byte-identical + Dafny verifies on synthetic example

🤖 Generated with [Claude Code](https://claude.com/claude-code)