### PR TITLE
proof_lower+ir: refresh module docs after Steps 24-40 migration

### DIFF
--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -1,26 +1,22 @@
 //! Build `ProofIR` from a `CodegenContext`.
 //!
-//! The lowering producer side of the Step 1 / Step 2 split: types
-//! live in `src/ir/proof_ir.rs`, the function that fills them in
-//! from a typechecked + analysed codegen context lives here. Output
-//! lands in `CodegenContext.proof_ir`; both proof backends read
-//! from the same field, so any classifier-side decision flows
-//! consistently to Lean and Dafny without each backend re-running
-//! shape detection.
+//! The lowering producer: types live in `src/ir/proof_ir.rs`, this
+//! file fills them in from a typechecked + analysed codegen
+//! context. Output lands in `CodegenContext.proof_ir`; both proof
+//! backends read from the same field, so any classifier-side
+//! decision flows consistently to Lean and Dafny without each
+//! backend re-running shape detection.
 //!
-//! **Step 2 scope**: this commit only populates
-//! `ProofIR.refined_types` — refinement-via-opaque records lifted
-//! to subtype on Lean / subset type on Dafny. `fn_contracts` and
-//! `law_theorems` are intentionally left empty; backends still go
-//! through the legacy `codegen::recursion::RecursionPlan` and the
-//! ad-hoc law-lowering path in `lean::toplevel`. Step 3 onwards
-//! migrates backends to read from ProofIR one feature at a time.
+//! Populates three IR sections: `refined_types` (refinement-via-
+//! opaque records → Lean Subtype / Dafny subset type),
+//! `fn_contracts` (per-pure-fn recursion shape: native /
+//! sized-fuel / linear recurrence), and `law_theorems` (per-verify-
+//! law strategy + quantifier decomposition + claim shape, with
+//! Oracle-Lift'd impl-spec calls for effectful equivalence).
 //!
-//! A diff test (`tests/proof_ir_diff.rs`) asserts the new producer
-//! agrees with the legacy `refinement_info_for` + Dafny
-//! `refinement_witness_for` walk on every flagship refinement
-//! example — once the test is stable the legacy walkers become dead
-//! code in their consumers (Step 3 / Step 4 deletes them).
+//! `tests/proof_ir_diff.rs` pins the producer's output for each
+//! canonical source pattern — divergence between the classifier and
+//! the IR populator surfaces there.
 
 use std::collections::HashSet;
 
@@ -59,10 +55,10 @@ pub struct ProofLowerInputs<'a> {
 }
 
 impl<'a> ProofLowerInputs<'a> {
-    /// Build a view from a fully-assembled `CodegenContext`. Used by
-    /// `refresh_facts` (test helper) and by the migration-window
-    /// `build_context` path before Step 7e moves lowering into the
-    /// pipeline. Reads only the fields the lowerer actually needs.
+    /// Build a view from a fully-assembled `CodegenContext` — used
+    /// by `refresh_facts` (test helper) and by any caller that
+    /// already owns a built context. Reads only the fields the
+    /// lowerer actually needs.
     pub fn from_ctx(ctx: &'a CodegenContext) -> Self {
         Self {
             entry_items: &ctx.items,
@@ -156,10 +152,10 @@ impl<'a> ProofLowerInputs<'a> {
     }
 }
 
-/// Run both proof-export lowerings in one shot — convenience for
-/// callers that want a fully-populated ProofIR. The pipeline uses
-/// `populate_refined_types` and `populate_fn_contracts` directly
-/// because the two are independent stages there (Step 7h split).
+/// Run every proof-export lowering in one shot — convenience for
+/// callers that want a fully-populated ProofIR. The pipeline calls
+/// the three `populate_*` fns directly so it can run them as
+/// independent stages and short-circuit on typecheck failure.
 pub fn lower(inputs: &ProofLowerInputs) -> ProofIR {
     let mut ir = ProofIR::default();
     populate_refined_types(inputs, &mut ir);
@@ -227,23 +223,17 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
     }
 }
 
-/// Walk `analyze_plans(ctx)` and populate `ProofIR.fn_contracts`.
+/// Walk `analyze_plans(inputs)` and populate `ProofIR.fn_contracts`.
 ///
-/// **Step 5 scope**: only `IntCountdownGuarded` plans translate to
-/// a `FnContract`. It's the most proof-heavy variant — caller-
-/// derived precondition + preservation + decrease — so it sets the
-/// pattern for the rest. All other `RecursionPlan` variants (Fuel-
-/// emitted shapes, `LinearRecurrence2`, `Mutual*`) are skipped here
-/// and continue going through the legacy `RecursionPlan` path
-/// directly on the consumer side. Subsequent Steps add one variant
-/// per commit, with their own diff tests.
-///
-/// The lowering is intentionally a **translation pass** over the
-/// existing classifier output, not a re-implementation: backends
-/// keep reading `RecursionPlan` during the migration window, the
-/// diff test (`tests/proof_ir_diff.rs`) asserts both sides agree on
-/// the fibTR flagship, and once every variant is covered we delete
-/// the consumer-side `RecursionPlan` reads in a later Step.
+/// Translation pass over the classifier output (`RecursionPlan`) —
+/// no re-implementation. The diff test (`tests/proof_ir_diff.rs`)
+/// pins what each `RecursionPlan` variant lowers to so divergence
+/// between the classifier and the IR populator surfaces there.
+/// Coverage today: `IntCountdownGuarded`, `LinearRecurrence2`,
+/// `Sized*` (length / sizeOf / string-pos / int-ascending). Fuel-
+/// only and Mutual* plans don't materialise as `FnContract` (their
+/// recursion shape doesn't need IR-level pre-decisions; backends
+/// emit fuel scaffolding inline).
 pub fn populate_fn_contracts(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
     let (plans, issues) = analyze_plans(inputs);
     ir.unclassified_fns
@@ -499,13 +489,18 @@ pub fn populate_fn_contracts(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
 /// Walk every verify block, lift `VerifyKind::Law` entries into
 /// `ProofIR.law_theorems`.
 ///
-/// **Step 23 scope**: extract the law's shape — quantifiers from
-/// `givens`, premises from `when` (when non-empty), the claim from
-/// `lhs == rhs`. Strategy stays `ProofStrategy::BackendDispatch`; the
-/// backend's existing ad-hoc chain (rfl / induction / arithmetic
-/// wrapper / spec equiv / map laws / simp+omega / guarded domain)
-/// still decides which proof tactic emits. Subsequent Steps move
-/// concrete strategy decisions into the lowerer, one shape at a time.
+/// Extracts the law's shape (quantifiers from `givens`, premises
+/// from `when`, claim from `lhs == rhs`) and pins a `ProofStrategy`
+/// via [`classify_law_strategy`]. Covered strategies: Reflexive,
+/// Commutative / Associative / IdentityElement / AntiCommutative /
+/// UnaryEqualsBinary (arithmetic wrappers), Induction (recursive
+/// ADTs), LibraryAxiom (Map set/get), MapUpdatePostcondition,
+/// MapKeyTrackedIncrement, SpecEquivalence{,SimpNormalized},
+/// LinearIntSpecEquivalence, EffectfulSpecEquivalence (with Oracle
+/// Lift), LinearArithmetic (catch-all over an unfold chain).
+/// Unmatched shapes pin `BackendDispatch` and fall through to the
+/// backend's residual chain (linear_recurrence2 emit + sampled /
+/// guarded-domain fallback).
 pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
     use crate::ast::{TopLevel, VerifyKind};
     use crate::ir::{LawTheorem, Predicate, Quantifier, QuantifierType};
@@ -2111,10 +2106,10 @@ fn has_indirect_rec_variants(variants: &[crate::ast::TypeVariant], type_name: &s
 }
 
 /// Return `Some(op)` iff `fn_name` resolves to a 2-arg Int wrapper
-/// `fn f(p1: Int, p2: Int) -> Int :- p1 <op> p2`. The op family is
-/// restricted to those with commutative/associative lemmas
-/// (`Add`, `Mul`); other binary wrappers (e.g. `Sub`) lower through
-/// the backend chain (Step 26+ pins sub anti-commutative).
+/// `fn f(p1: Int, p2: Int) -> Int :- p1 <op> p2`. The op family
+/// covers `Add` / `Mul` (commutative + associative lemmas) and
+/// `Sub` (anti-commutative + right-identity); other ops fall back
+/// to `BackendDispatch`.
 fn wrapper_binop(fn_name: &str, inputs: &ProofLowerInputs) -> Option<crate::ast::BinOp> {
     use crate::ast::{BinOp, Expr};
 

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -7,22 +7,17 @@
 //! in the `proof_lower` pipeline stage; both backends see the same
 //! decision and either render it consistently or fail consistently.
 //!
-//! The architectural goal: replace the ad-hoc "guess and emit"
-//! pattern that grew across `src/codegen/{common,recursion,lean,
-//! dafny}` during 0.22.0 with a single typed model. Each variant
-//! that says "emit native" or "lift to subtype" carries inside its
-//! payload everything the backend needs and everything the
-//! classifier proved — the type system makes it impossible to
-//! produce a "native" decision without also producing the side-
-//! conditions that justify it.
+//! Replaces the ad-hoc "guess and emit" pattern that grew across
+//! `src/codegen/{common,recursion,lean,dafny}` during 0.22.0 with a
+//! single typed model. Each variant that says "emit native" or
+//! "lift to subtype" carries inside its payload everything the
+//! backend needs and everything the classifier proved — the type
+//! system makes it impossible to produce a "native" decision
+//! without also producing the side-conditions that justify it.
 //!
-//! **Status**: skeleton. Step 1 (this file) defines the types. Step
-//! 2 wires `proof_lower` to populate `ProofIR.refined_types` for
-//! refinement-via-opaque records; backends still go through the old
-//! `codegen::common::refinement_info_for` path and tests verify
-//! both paths produce equivalent decisions. Steps 3+ migrate one
-//! backend at a time, then extend coverage to recursion contracts
-//! and law theorems.
+//! Coverage today: `refined_types` (refinement-via-opaque records),
+//! `fn_contracts` (per-pure-fn recursion shape), `law_theorems`
+//! (per-verify-law strategy + quantifier + claim decomposition).
 
 use std::collections::HashMap;
 
@@ -45,13 +40,11 @@ pub struct ProofIR {
     /// same map so backends don't have to walk two corpora.
     pub refined_types: HashMap<String, RefinedTypeDecl>,
     /// Per-pure-fn contract describing what proof artifact the fn
-    /// lowers to. Currently a stub (empty); Step 5+ populates it
-    /// when migrating the `RecursionPlan` machinery.
+    /// lowers to (native / fuel / structural / linear recurrence).
     pub fn_contracts: HashMap<String, FnContract>,
     /// Per-verify-law theorem decomposed into quantifiers, premises,
     /// and claim with all wrapper-strip / val-projection / drop-vs-
-    /// keep decisions baked in. Currently empty; populated when
-    /// migrating the law emit path.
+    /// keep decisions baked in, plus the pinned proof strategy.
     pub law_theorems: Vec<LawTheorem>,
     /// Recursive pure fns whose shape fell outside every recognised
     /// pattern. Surfaced as diagnostics ("recursive function 'foo'
@@ -138,8 +131,8 @@ pub struct RefinedTypeDecl {
     pub witness: Option<String>,
 }
 
-/// Per-pure-fn proof contract. Placeholder shape — Step 5+ fills
-/// this in with recursion plan migration.
+/// Per-pure-fn proof contract — what recursion shape (if any) the
+/// lowerer pinned for emit.
 #[derive(Debug, Clone)]
 pub struct FnContract {
     pub source_name: String,
@@ -183,9 +176,8 @@ pub enum RecursionContract {
         /// Conjunction of precondition clauses, kept as a vector so
         /// backends can render one `requires` per clause (Dafny) or
         /// fold into a single `&&` chain (Lean). Empty means "no
-        /// caller-derived precondition" — the lowerer leaves the
-        /// fibTR-style default (`param ≥ 0`) synthesis to the
-        /// backend for now; Step 6+ moves that into the lowerer.
+        /// caller-derived precondition" — the backend synthesises a
+        /// fibTR-style default (`param ≥ 0`) at emit time.
         precondition: Vec<Predicate>,
         /// Symbolic measure (e.g. `natAbs(n)`). Backends render per
         /// target language (`Int.natAbs n` on Lean, `n` with a
@@ -558,13 +550,13 @@ pub enum ProofStrategy {
     /// No automated strategy — emit with `sorry` (Lean) / `assume
     /// {:axiom}` (Dafny). User fills in manually.
     Sorry,
-    /// Lowerer has not pinned a strategy yet; the backend's
-    /// existing `or_else` chain decides. Placeholder during the
-    /// Step 23+ migration — every law theorem starts here, and
-    /// subsequent Steps move concrete strategies (Reflexive,
-    /// Induction, …) into the lowerer one shape at a time. The
-    /// backend treats `BackendDispatch` as "fall through to ad-hoc
-    /// strategy chain", same behaviour as pre-migration.
+    /// Lowerer has not pinned a strategy for this law; the backend's
+    /// `or_else` chain decides. Today reached by linear-recurrence-
+    /// spec equivalence (Lean-specific, ~50-line support theorems
+    /// stay in the backend) and the sampled / guarded-domain
+    /// fallback. The backend treats `BackendDispatch` as "fall
+    /// through to ad-hoc strategy chain"; pinned variants above
+    /// short-circuit to a known emit.
     BackendDispatch,
 }
 


### PR DESCRIPTION
## Summary

- Strips stale \"Step N scope\" / \"migration window\" / \"Subsequent Steps move ...\" references from `proof_lower.rs` and `proof_ir.rs`. Migration covered by those markers is complete (we're at Step 40+); docs now describe current state.
- Notable rewrites: `proof_lower.rs` module header (lists the three populated IR sections), `populate_fn_contracts` doc (names actual covered RecursionPlan variants), `populate_law_theorems` doc (enumerates the 13 pinned ProofStrategy variants), `BackendDispatch` variant doc (describes what actually falls through today).
- Docs-only — no code changes.

## Test plan

- [x] `cargo test --lib` — 615 passed
- [x] `cargo test --test proof_ir_diff` — 31 passed
- [x] `cargo test --test proof_spec` — 35 passed
- [x] `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)