### PR TITLE
codegen/lean: fix linear_recurrence2 spec equivalence emit (resolves #111)

### DIFF
--- a/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
+++ b/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
@@ -2,7 +2,7 @@ use crate::ast::{VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 use crate::codegen::lean::recurrence::{
     detect_second_order_int_linear_recurrence, detect_tailrec_int_linear_pair_worker,
-    detect_tailrec_int_linear_pair_wrapper, fuel_helper_name, recurrence_nat_helper_name,
+    detect_tailrec_int_linear_pair_wrapper, native_aux_helper_name, recurrence_nat_helper_name,
     render_affine_pair_expr,
 };
 use crate::verify_law::canonical_spec_ref;
@@ -38,7 +38,7 @@ pub(super) fn emit_second_order_linear_recurrence_spec_equivalence_law(
     let impl_lean = aver_name_to_lean(&vb.fn_name);
     let spec_lean = aver_name_to_lean(&spec_ref.spec_fn_name);
     let helper_lean = aver_name_to_lean(&impl_shape.helper_fn_name);
-    let helper_fuel_lean = fuel_helper_name(&impl_shape.helper_fn_name);
+    let helper_aux_lean = native_aux_helper_name(&impl_shape.helper_fn_name);
     let spec_nat_lean = recurrence_nat_helper_name(&spec_ref.spec_fn_name);
     let worker_nat_lean = recurrence_nat_helper_name(&impl_shape.helper_fn_name);
     let theorem_base = format!("{impl_lean}_eq_{spec_lean}");
@@ -94,18 +94,32 @@ pub(super) fn emit_second_order_linear_recurrence_spec_equivalence_law(
             "| zero =>".to_string(),
             format!(
                 "    simp [{}, {}, {}]",
-                helper_lean, helper_fuel_lean, worker_nat_lean
+                helper_lean, helper_aux_lean, worker_nat_lean
             ),
             "| succ k ih =>".to_string(),
-            "    have hk : Int.ofNat (Nat.succ k) ≠ 0 := by".to_string(),
-            "      simp [Nat.succ_eq_add_one]".to_string(),
-            "      omega".to_string(),
-            "    have hk' : Int.ofNat (Nat.succ k) - 1 = Int.ofNat k := by".to_string(),
-            "      simpa [Nat.succ_eq_add_one]".to_string(),
+            "    have h_nn : (Int.ofNat (k + 1) : Int) >= 0 := by".to_string(),
+            "      show ((k + 1 : Nat) : Int) >= 0; exact_mod_cast Nat.zero_le _".to_string(),
+            "    have hk : ¬ (Int.ofNat (k + 1) : Int) = 0 := by".to_string(),
+            "      show ((k + 1 : Nat) : Int) ≠ 0; exact_mod_cast Nat.succ_ne_zero k".to_string(),
+            "    have hk' : (Int.ofNat (k + 1) : Int) - 1 = Int.ofNat k := by".to_string(),
+            "      show ((k + 1 : Nat) : Int) - 1 = ((k : Nat) : Int); push_cast; omega"
+                .to_string(),
+            "    have h_k_nn : (Int.ofNat k : Int) >= 0 := Int.ofNat_nonneg k".to_string(),
+            "    have h_ih := ih b (a + b)".to_string(),
             format!(
-                "    simpa [{}, {}, {}, hk, hk'] using (ih b (a + b))",
-                helper_lean, helper_fuel_lean, worker_nat_lean
+                "    rw [show {} (Int.ofNat (k + 1)) a b = {} (Int.ofNat (k + 1)) a b h_nn from dif_pos h_nn]",
+                helper_lean, helper_aux_lean
             ),
+            format!(
+                "    rw [show {} (Int.ofNat (k + 1)) a b h_nn = {} (Int.ofNat k) b (a + b) h_k_nn by rw [{}.eq_def]; rw [dif_neg hk]; congr 1]",
+                helper_aux_lean, helper_aux_lean, helper_aux_lean
+            ),
+            format!(
+                "    rw [show {} (Int.ofNat k) b (a + b) h_k_nn = {} (Int.ofNat k) b (a + b) from (dif_pos h_k_nn).symm]",
+                helper_aux_lean, helper_lean
+            ),
+            "    rw [h_ih]".to_string(),
+            "    rfl".to_string(),
         ],
         2,
     ));

--- a/src/codegen/lean/recurrence.rs
+++ b/src/codegen/lean/recurrence.rs
@@ -88,8 +88,11 @@ pub(crate) fn recurrence_nat_helper_name(fn_name: &str) -> String {
     format!("{}__nat", aver_name_to_lean(fn_name))
 }
 
-pub(crate) fn fuel_helper_name(fn_name: &str) -> String {
-    format!("{}__fuel", aver_name_to_lean(fn_name))
+/// Lean-side native-emit aux name. Sized-recursion plans (e.g.
+/// `fibTR`) emit this form — the helper carries the explicit
+/// `(h : p ≥ 0)` precondition arg and recurses on `Int.natAbs n`.
+pub(crate) fn native_aux_helper_name(fn_name: &str) -> String {
+    format!("{}__aux", aver_name_to_lean(fn_name))
 }
 
 pub(crate) fn render_affine_pair_expr(expr: AffinePairExpr, prev2: &str, prev1: &str) -> String {
@@ -130,7 +133,7 @@ pub(crate) fn detect_second_order_int_linear_recurrence(
     else {
         return None;
     };
-    if !matches!(&inner_subject.node, Expr::Ident(name) if name == param_name) {
+    if ident_name(&inner_subject.node) != Some(param_name.as_str()) {
         return None;
     }
 
@@ -167,18 +170,18 @@ pub(crate) fn detect_tailrec_int_linear_pair_worker(
     let Expr::Match { subject, arms, .. } = &body.node else {
         return None;
     };
-    if !matches!(&subject.node, Expr::Ident(name) if name == count_param_name) {
+    if ident_name(&subject.node) != Some(count_param_name.as_str()) {
         return None;
     }
 
     let zero_branch = match_arm_body_for_int(arms, 0)?;
-    if !matches!(&zero_branch.node, Expr::Ident(name) if name == prev_param_name) {
+    if ident_name(&zero_branch.node) != Some(prev_param_name.as_str()) {
         return None;
     }
 
     let recursive_branch = match_arm_body_for_wildcard(arms)?;
     let args: &[Spanned<Expr>] = match &recursive_branch.node {
-        Expr::FnCall(callee, args) if matches!(&callee.node, Expr::Ident(name) if name == &fd.name) => {
+        Expr::FnCall(callee, args) if ident_name(&callee.node) == Some(fd.name.as_str()) => {
             args.as_slice()
         }
         Expr::TailCall(call) if call.target == fd.name => call.args.as_slice(),
@@ -188,7 +191,7 @@ pub(crate) fn detect_tailrec_int_linear_pair_worker(
         return None;
     }
     if !matches_int_sub_positive(&args[0].node, count_param_name, 1)
-        || !matches!(&args[1].node, Expr::Ident(name) if name == curr_param_name.as_str())
+        || ident_name(&args[1].node) != Some(curr_param_name.as_str())
     {
         return None;
     }
@@ -217,20 +220,18 @@ pub(crate) fn detect_tailrec_int_linear_pair_wrapper(
     let Expr::FnCall(callee, args) = nonnegative_branch else {
         return None;
     };
-    let Expr::Ident(helper_fn_name) = &callee.node else {
-        return None;
-    };
+    let helper_fn_name = ident_name(&callee.node)?.to_string();
     let [count_arg, seed_prev, seed_curr] = args.as_slice() else {
         return None;
     };
-    if !matches!(&count_arg.node, Expr::Ident(name) if name == param_name) {
+    if ident_name(&count_arg.node) != Some(param_name.as_str()) {
         return None;
     }
 
     Some(TailrecIntLinearPairWrapperShape {
         param_name: param_name.clone(),
         negative_branch: negative_branch.clone(),
-        helper_fn_name: helper_fn_name.clone(),
+        helper_fn_name,
         seed_prev: seed_prev.clone(),
         seed_curr: seed_curr.clone(),
     })
@@ -246,7 +247,7 @@ fn split_negative_guard<'a>(
     let Expr::BinOp(BinOp::Lt, left, right) = &subject.node else {
         return None;
     };
-    if !matches!(&left.node, Expr::Ident(name) if name == param_name)
+    if ident_name(&left.node) != Some(param_name)
         || !matches!(&right.node, Expr::Literal(Literal::Int(0)))
     {
         return None;
@@ -283,7 +284,7 @@ fn parse_recurrence_affine(expr: &Expr, fn_name: &str, param_name: &str) -> Opti
     match expr {
         Expr::Literal(Literal::Int(value)) => Some(AffinePairExpr::constant(*value)),
         Expr::FnCall(callee, args) => {
-            if !matches!(&callee.node, Expr::Ident(name) if name == fn_name) || args.len() != 1 {
+            if ident_name(&callee.node) != Some(fn_name) || args.len() != 1 {
                 return None;
             }
             let offset = int_sub_positive_offset(&args[0].node, param_name)?;
@@ -325,8 +326,8 @@ fn parse_recurrence_affine(expr: &Expr, fn_name: &str, param_name: &str) -> Opti
 fn parse_affine_expr(expr: &Expr, prev2_name: &str, prev1_name: &str) -> Option<AffinePairExpr> {
     match expr {
         Expr::Literal(Literal::Int(value)) => Some(AffinePairExpr::constant(*value)),
-        Expr::Ident(name) if name == prev2_name => Some(AffinePairExpr::prev2()),
-        Expr::Ident(name) if name == prev1_name => Some(AffinePairExpr::prev1()),
+        e if ident_name(e) == Some(prev2_name) => Some(AffinePairExpr::prev2()),
+        e if ident_name(e) == Some(prev1_name) => Some(AffinePairExpr::prev1()),
         Expr::BinOp(BinOp::Add, left, right) => Some(
             parse_affine_expr(&left.node, prev2_name, prev1_name)?.add(parse_affine_expr(
                 &right.node,
@@ -354,6 +355,14 @@ fn parse_affine_expr(expr: &Expr, prev2_name: &str, prev1_name: &str) -> Option<
     }
 }
 
+/// Bare-ident name regardless of pipeline-resolve state.
+fn ident_name(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Ident(name) | Expr::Resolved { name, .. } => Some(name.as_str()),
+        _ => None,
+    }
+}
+
 fn int_literal(expr: &Expr) -> Option<i64> {
     match expr {
         Expr::Literal(Literal::Int(value)) => Some(*value),
@@ -369,7 +378,7 @@ fn int_sub_positive_offset(expr: &Expr, param_name: &str) -> Option<i64> {
     let Expr::BinOp(BinOp::Sub, left, right) = expr else {
         return None;
     };
-    if !matches!(&left.node, Expr::Ident(name) if name == param_name) {
+    if ident_name(&left.node) != Some(param_name) {
         return None;
     }
     let value = int_literal(&right.node)?;


### PR DESCRIPTION
## Summary

Closes #111. Two latent bugs in the second-order linear recurrence spec-equivalence emit, both invisible until you tried `aver proof examples/data/fibonacci.av` and noticed the `fib::fibSpec` law output `sorry` instead of the full proof.

- **Layer 1 — Resolved-vs-Ident in detectors.** `lean::recurrence::detect_*` matched `Expr::Ident` strictly; production pipelines run `resolve` which rewrites to `Expr::Resolved`. Proof-mode test pipelines kept `Ident`, which is why tests exercised the emit but production never did. New `ident_name` helper handles both; 11 sites patched.
- **Layer 2 — `__fuel` → `__aux` rename + native-emit proof strategy.** Even after Layer 1, support_lines referenced `fibTR__fuel` but sized-recursion plans emit `fibTR__aux`. Renamed the import; dropped now-unused `fuel_helper_name`. Rewriting the helper-nat inductive proof was the hard part — legacy `simpa [fibTR__aux, ...]` blew Lean's max recursion depth on the `Int`-keyed self-call. Replaced with an explicit four-step rewrite chain (unfold `fibTR` via `dif_pos`; one-step `fibTR__aux.eq_def`; fold inner call back into `fibTR` via `(dif_pos _).symm`; apply IH; `rfl`).

`aver proof examples/data/fibonacci.av` now emits the full second-order recurrence proof; Lake accepts it.

## Test plan

- [x] `cargo test --test proof_spec proof_export_builds_fibonacci_when_lake_is_available` — passes (Lake builds full proof, no sorry)
- [x] `cargo test --test proof_spec` — 35 passed
- [x] `cargo test --lib` — 615 passed (includes `fibonacci_example_auto_proves_general_linear_recurrence_spec_law` which still hits the same code path)
- [x] `cargo test --test proof_ir_diff` — 31 passed
- [x] `cargo fmt --all --check`, `cargo clippy --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)