### PR TITLE
codegen/dafny + tests: list-induction hints + dafny verify smoke tests

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1278,6 +1278,43 @@ pub fn emit_verify_law(
             }
             lines.push("  }".to_string());
         }
+    } else if let Some(list_given_idx) = law
+        .givens
+        .iter()
+        .position(|g| g.type_name.starts_with("List<"))
+    {
+        // Inductive hint for `List<T>`-parameterised laws — case-split
+        // on `[] / [head, ..tail]` and recurse on the tail. Fires when
+        // any fn called from either side (top-level OR nested) is
+        // directly recursive — broader than the Int-given branch
+        // which only inspects the top-level fn, because `List<T>` laws
+        // often wrap the recursive fn under a Map / Option helper
+        // (e.g. `Map.has(countWords(words), word)` — countWords is
+        // recursive but `Map.has` is the top fn).
+        let mut called: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        collect_called_fns(&law.lhs, &mut called);
+        collect_called_fns(&law.rhs, &mut called);
+        let any_recursive = called.iter().any(|f| is_directly_recursive(f, ctx));
+        if any_recursive {
+            let list_param = aver_name_to_dafny(&law.givens[list_given_idx].name);
+            let lemma_name = format!("{}_{}", fn_name, law_name);
+            let other_args: Vec<String> = law
+                .givens
+                .iter()
+                .enumerate()
+                .map(|(i, g)| {
+                    if i == list_given_idx {
+                        format!("{}[1..]", list_param)
+                    } else {
+                        aver_name_to_dafny(&g.name)
+                    }
+                })
+                .collect();
+            lines.push(format!("  if |{}| == 0 {{", list_param));
+            lines.push("  } else {".to_string());
+            lines.push(format!("    {}({});", lemma_name, other_args.join(", ")));
+            lines.push("  }".to_string());
+        }
     }
 
     lines.push("}\n".to_string());

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -59,6 +59,66 @@ fn assert_proof_builds(example_path: &str, prefix: &str) {
     let _ = std::fs::remove_dir_all(&output_dir);
 }
 
+/// `dafny verify` smoke test. Mirrors `assert_proof_builds` but runs
+/// the Dafny backend through the full verifier (not just the parser /
+/// compile front-end). `lake build` accepts `sorry`-bearing proofs;
+/// `dafny verify` actually closes the goal. Three examples currently
+/// verify cleanly through both backends and pin the IR-migrated
+/// strategy coverage (Steps 24-40 of the proof-IR migration); the
+/// remaining flagship examples (`fibonacci`, `rle`, `quicksort`,
+/// `json`) carry pre-IR-migration Dafny gaps tracked in issue #114.
+fn assert_dafny_verifies(example_path: &str, prefix: &str) {
+    if Command::new("dafny").arg("--version").output().is_err() {
+        eprintln!("skipping dafny verify smoke test: `dafny` not available");
+        return;
+    }
+
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let output_dir = temp_output_dir(prefix);
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+
+    let proof = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg(example_path)
+        .arg("--backend")
+        .arg("dafny")
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("expected `aver proof --backend dafny` to run");
+    assert!(
+        proof.status.success(),
+        "`aver proof --backend dafny` failed:\n{}",
+        format_output(&proof)
+    );
+
+    let dfy = std::fs::read_dir(&output_dir)
+        .expect("read output_dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.extension().is_some_and(|x| x == "dfy")
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n != "common.dfy")
+        })
+        .expect("expected a non-`common.dfy` Dafny file in output");
+    let verify = Command::new("dafny")
+        .current_dir(&output_dir)
+        .arg("verify")
+        .arg(&dfy)
+        .output()
+        .expect("expected `dafny verify` to run");
+    assert!(
+        verify.status.success(),
+        "`dafny verify` failed:\n{}",
+        format_output(&verify)
+    );
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
 #[test]
 fn proof_export_builds_law_auto_when_lake_is_available() {
     assert_proof_builds("examples/formal/law_auto.av", "aver-proof-smoke");
@@ -1675,4 +1735,27 @@ fn proof_accepts_complete_independence_mode() {
         stderr
     );
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn proof_dafny_verifies_law_auto_when_dafny_is_available() {
+    assert_dafny_verifies("examples/formal/law_auto.av", "aver-dafny-law-auto");
+}
+
+#[test]
+fn proof_dafny_verifies_spec_laws_when_dafny_is_available() {
+    assert_dafny_verifies("examples/formal/spec_laws.av", "aver-dafny-spec-laws");
+}
+
+#[test]
+fn proof_dafny_verifies_oracle_independent_products_when_dafny_is_available() {
+    assert_dafny_verifies(
+        "examples/formal/oracle_independent_products.av",
+        "aver-dafny-oracle-products",
+    );
+}
+
+#[test]
+fn proof_dafny_verifies_map_when_dafny_is_available() {
+    assert_dafny_verifies("examples/data/map.av", "aver-dafny-map");
 }


### PR DESCRIPTION
## Summary

Two changes that fit together — the test infrastructure exposes a real Dafny verification gap, the codegen fix closes one of the gaps, and both land together so the test allowlist isn't created with a known-failing entry that doesn't immediately get fixed.

**Codegen — list-induction hints for `List<T>`-parameterised laws** (`src/codegen/dafny/toplevel.rs`):
- Previously the inductive-hint branch only fired for laws with a single Int given. Laws with a `List<T>` given fell through to an empty lemma body — Dafny couldn't close the cons case without an inductive hypothesis.
- New branch case-splits on `|xs| == 0` and recurses on `xs[1..]`. Detection inspects every fn called anywhere in the law tree, since `List<T>` laws often wrap the recursive fn under `Map.*` / `Option.*` helpers.
- `examples/data/map.av` Dafny verify: 2 errors → 0.

**Tests — `assert_dafny_verifies` smoke helper** (`tests/proof_spec.rs`):
- Mirrors `assert_proof_builds` but invokes `dafny verify` (the verifier, not the compile front-end). `lake build` accepts `sorry`; `dafny verify` actually closes the goal — issue #114 catalogued examples where the gap was hidden because we never ran `dafny verify` in tests.
- Four examples gate through the new helper today: `law_auto.av`, `spec_laws.av`, `oracle_independent_products.av`, `map.av`. The remaining flagship examples carry pre-IR-migration Dafny gaps (tracked in #114) and stay outside the smoke set until those fixes land.

## Test plan

- [x] `cargo test --test proof_spec` — 39 passed (4 new dafny verify tests)
- [x] `cargo test --lib` — 615 passed
- [x] `cargo test --test proof_ir_diff` — 31 passed
- [x] `cargo fmt --all --check`, `cargo clippy --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)