### PR TITLE
proof_lower+lean: Step 41 — pin LinearRecurrence2SpecEquivalence in IR

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -232,6 +232,26 @@ pub fn emit_verify_law_forall_auto_proof(
         });
     }
 
+    // IR-pinned `LinearRecurrence2SpecEquivalence` — lowerer
+    // validated impl as tail-rec wrapper, spec as direct second-order
+    // recurrence, helper as their shared affine worker. Dispatches
+    // to the existing emit which renders the Nat-helper + shift
+    // lemma + helper-seed bridge (heavy ~50-line support_lines stay
+    // in the legacy module). The IR pin makes the algebraic decision
+    // observable in `proof_ir.law_theorems` and provides the integration
+    // point for a future Dafny consumer (issue #116).
+    if matches!(
+        law_strategy_for(ctx, &vb.fn_name, &law.name),
+        Some(crate::ir::ProofStrategy::LinearRecurrence2SpecEquivalence { .. })
+    ) && let Some(proof) = spec::emit_second_order_linear_recurrence_spec_equivalence_law(
+        vb,
+        law,
+        ctx,
+        &proof_intro_names,
+    ) {
+        return Some(proof);
+    }
+
     spec::emit_spec_function_equivalence_law(vb, law, ctx, &proof_intro_names)
         .or_else(|| {
             // IR-pinned Map library axiom (has_set_self / get_set_self).

--- a/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
+++ b/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
@@ -11,7 +11,7 @@ use super::super::super::expr::{aver_name_to_lean, emit_expr};
 use super::super::shared::find_fn_def;
 use super::super::{AutoProof, indent_lines};
 
-pub(super) fn emit_second_order_linear_recurrence_spec_equivalence_law(
+pub(in super::super) fn emit_second_order_linear_recurrence_spec_equivalence_law(
     vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,

--- a/src/codegen/lean/law_auto/spec/mod.rs
+++ b/src/codegen/lean/law_auto/spec/mod.rs
@@ -2,6 +2,8 @@ mod linear_int;
 mod linear_recurrence2;
 mod simp_normalized;
 
+pub(super) use linear_recurrence2::emit_second_order_linear_recurrence_spec_equivalence_law;
+
 use crate::ast::{Expr, Spanned, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 use crate::verify_law::canonical_spec_ref;

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -684,6 +684,22 @@ fn classify_law_strategy(
             spec_fn,
         };
     }
+    // Second-order linear recurrence (fib / fibSpec shape). Detector
+    // validates impl as tail-rec wrapper, spec as direct second-order
+    // recurrence, helper as their shared affine worker — all three
+    // shapes pinned in `lean::recurrence`. Backends consume the
+    // (impl_fn, spec_fn, helper_fn) names from IR; the proof template
+    // differs per target (Lean Nat-helper + induction; Dafny still
+    // pending — issue #116).
+    if let Some((spec_fn, helper_fn)) =
+        detect_linear_recurrence2_spec_equivalence(law, fn_name, inputs)
+    {
+        return ProofStrategy::LinearRecurrence2SpecEquivalence {
+            impl_fn: fn_name.to_string(),
+            spec_fn,
+            helper_fn,
+        };
+    }
     // Linear arithmetic over an unfold chain — generic catch-all.
     // Named for the semantic, not the backend tactic.
     if let Some(plan) = detect_simp_omega_unfold(law, fn_name, inputs, refined_types) {
@@ -1639,6 +1655,79 @@ fn detect_effectful_spec_equivalence(
         Some(r_name)
     };
     try_side(&rewritten_lhs, &rewritten_rhs).or_else(|| try_side(&rewritten_rhs, &rewritten_lhs))
+}
+
+/// Detect second-order linear recurrence spec equivalence (fib /
+/// fibSpec pattern). impl_fn is a tail-rec wrapper dispatching on
+/// `n < 0` and calling a 3-arg helper with seed pair; spec_fn is a
+/// direct recurrence with `match n { 0 / 1 / _ }` arms. The shared
+/// affine recurrence must match between the helper's worker and the
+/// spec's `_` arm. Returns `(spec_fn_name, helper_fn_name)` on
+/// match. Detection lives behind the `lean::recurrence::detect_*`
+/// helpers because their AST patterns were specced there originally;
+/// the data they extract is backend-neutral.
+fn detect_linear_recurrence2_spec_equivalence(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<(String, String)> {
+    use crate::codegen::lean::recurrence::{
+        detect_second_order_int_linear_recurrence, detect_tailrec_int_linear_pair_worker,
+        detect_tailrec_int_linear_pair_wrapper,
+    };
+
+    let spec_fn_name = &law.name;
+    if spec_fn_name == fn_name {
+        return None;
+    }
+    if !law_references_fn(&law.lhs, spec_fn_name) && !law_references_fn(&law.rhs, spec_fn_name) {
+        return None;
+    }
+
+    let impl_fd = inputs.find_fn_def_by_call_name(fn_name)?;
+    let spec_fd = inputs.find_fn_def_by_call_name(spec_fn_name)?;
+    let impl_shape = detect_tailrec_int_linear_pair_wrapper(impl_fd)?;
+    let spec_shape = detect_second_order_int_linear_recurrence(spec_fd)?;
+
+    // AST-strict cross-check: negative branch + seed values must
+    // match across impl wrapper and spec direct recurrence.
+    if impl_shape.negative_branch.node != spec_shape.negative_branch.node
+        || impl_shape.seed_prev.node != spec_shape.base0.node
+        || impl_shape.seed_curr.node != spec_shape.base1.node
+    {
+        return None;
+    }
+
+    let helper_fd = inputs.find_fn_def_by_call_name(&impl_shape.helper_fn_name)?;
+    let helper_shape = detect_tailrec_int_linear_pair_worker(helper_fd)?;
+    if helper_shape.recurrence != spec_shape.recurrence {
+        return None;
+    }
+
+    Some((spec_fn_name.clone(), impl_shape.helper_fn_name))
+}
+
+fn law_references_fn(expr: &Spanned<crate::ast::Expr>, target: &str) -> bool {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::FnCall(callee, args) => {
+            let name = match &callee.node {
+                Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.as_str()),
+                _ => None,
+            };
+            if name == Some(target) {
+                return true;
+            }
+            args.iter().any(|a| law_references_fn(a, target))
+        }
+        Expr::BinOp(_, l, r) => law_references_fn(l, target) || law_references_fn(r, target),
+        Expr::Attr(base, _) => law_references_fn(base, target),
+        Expr::Match { subject, arms } => {
+            law_references_fn(subject, target)
+                || arms.iter().any(|arm| law_references_fn(&arm.body, target))
+        }
+        _ => false,
+    }
 }
 
 /// Validate the outer fn's body matches the "inspect get, set in

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -544,6 +544,24 @@ pub enum ProofStrategy {
         /// Source name of the spec fn (the other side of the law).
         spec_fn: String,
     },
+    /// Second-order linear recurrence spec equivalence — impl is a
+    /// tail-recursive Int linear-pair wrapper (e.g. `fib` dispatching
+    /// on `n < 0` and calling a 3-arg `fibTR(n, 0, 1)` helper) and
+    /// spec is a direct second-order recurrence (`match n { 0 -> b0;
+    /// 1 -> b1; _ -> recurrence(spec(n-1), spec(n-2)) }`). The
+    /// impl's helper implements the same affine recurrence as the
+    /// spec's `_` arm. Both Lean and Dafny render via a Nat-keyed
+    /// helper + shift lemma + helper-seed bridge; the algebraic
+    /// content (a fixed-point of the recurrence) is the same in both
+    /// targets but the syntactic proof template differs per backend.
+    LinearRecurrence2SpecEquivalence {
+        /// Source name of the impl (tail-recursive wrapper) fn.
+        impl_fn: String,
+        /// Source name of the spec (direct recurrence) fn.
+        spec_fn: String,
+        /// Source name of the worker fn called by `impl_fn`.
+        helper_fn: String,
+    },
     /// Bounded universal: case-split over the declared `given`
     /// domain, dispatch each case to a per-sample lemma.
     BoundedUniversal,


### PR DESCRIPTION
## Summary

Both Lean and Dafny will eventually emit support theorems for the second-order linear recurrence spec-equivalence shape (fib / fibSpec). PR #113 made the Lean side work in production. With Lean working, the shape detection should live in the IR substrate — same pattern as Steps 24-40 — so future backends consume the algebraic decision without re-detecting.

- New `ProofStrategy::LinearRecurrence2SpecEquivalence { impl_fn, spec_fn, helper_fn }`.
- Detector in `proof_lower` validates impl/spec/helper shapes via the existing `lean::recurrence::detect_*` helpers (acknowledged cross-module dep; the data extracted is backend-neutral, the helper location is the Lean module historically).
- Lean consumer reads the IR pin and dispatches to existing emit. Visible in `aver compile --emit-ir-after law_lower`:
  ```
  fib::fibSpec (LinearRecurrence2SpecEquivalence { impl_fn: \"fib\", spec_fn: \"fibSpec\", helper_fn: \"fibTR\" }, ...)
  ```
- Dafny consumer **unchanged**. The current IH-body emit fires on `fib::fibSpec` but Z3 can't close the postcondition (tail-rec accumulator vs direct recurrence). Issue #116 stays open with the new context that PR #113's Lean template needs a Dafny analogue (Nat helper + shift lemma + helper-seed bridge). The IR pin provides the integration point for that work.

## Test plan

- [x] `cargo test --lib` — 615 passed
- [x] `cargo test --test proof_spec` — 39 passed (incl. dafny verify on the 4 clean examples)
- [x] `cargo test --test proof_ir_diff` — 31 passed
- [x] `cargo fmt --all --check`, `cargo clippy --lib`
- [x] Verified IR pin fires on `fib::fibSpec` via `--emit-ir-after law_lower`

🤖 Generated with [Claude Code](https://claude.com/claude-code)