### PR TITLE
tests/proof_spec: extend coverage to 11 more examples (post-IR audit)

### DIFF
--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -1824,3 +1824,76 @@ fn proof_dafny_verifies_oracle_independent_products_when_dafny_is_available() {
 fn proof_dafny_verifies_map_when_dafny_is_available() {
     assert_dafny_verifies("examples/data/map.av", "aver-dafny-map");
 }
+
+// --- expanded coverage (post-IR-migration audit, 0.22.0) ---
+
+#[test]
+fn proof_export_builds_clock_as_data_when_lake_is_available() {
+    assert_proof_builds("examples/formal/clock_as_data.av", "aver-proof-clock");
+}
+
+#[test]
+fn proof_dafny_verifies_clock_as_data_when_dafny_is_available() {
+    assert_dafny_verifies("examples/formal/clock_as_data.av", "aver-dafny-clock");
+}
+
+#[test]
+fn proof_export_builds_file_store_pure_core_when_lake_is_available() {
+    assert_proof_builds(
+        "examples/formal/file_store_pure_core.av",
+        "aver-proof-file-store-pure",
+    );
+}
+
+#[test]
+fn proof_dafny_verifies_file_store_pure_core_when_dafny_is_available() {
+    assert_dafny_verifies(
+        "examples/formal/file_store_pure_core.av",
+        "aver-dafny-file-store-pure",
+    );
+}
+
+#[test]
+fn proof_export_builds_oracle_trace_when_lake_is_available() {
+    assert_proof_builds("examples/formal/oracle_trace.av", "aver-proof-oracle-trace");
+}
+
+#[test]
+fn proof_dafny_verifies_oracle_trace_when_dafny_is_available() {
+    assert_dafny_verifies("examples/formal/oracle_trace.av", "aver-dafny-oracle-trace");
+}
+
+#[test]
+fn proof_export_builds_terminal_size_snapshot_when_lake_is_available() {
+    assert_proof_builds(
+        "examples/formal/terminal_size_snapshot.av",
+        "aver-proof-terminal-size",
+    );
+}
+
+#[test]
+fn proof_dafny_verifies_terminal_size_snapshot_when_dafny_is_available() {
+    assert_dafny_verifies(
+        "examples/formal/terminal_size_snapshot.av",
+        "aver-dafny-terminal-size",
+    );
+}
+
+#[test]
+fn proof_export_builds_trust_check_when_lake_is_available() {
+    assert_proof_builds("examples/formal/trust_check.av", "aver-proof-trust-check");
+}
+
+#[test]
+fn proof_dafny_verifies_trust_check_when_dafny_is_available() {
+    assert_dafny_verifies("examples/formal/trust_check.av", "aver-dafny-trust-check");
+}
+
+#[test]
+fn proof_export_builds_date_when_lake_is_available() {
+    // Lean-only — Dafny side has `parseIntSlice(s, from, to)` whose
+    // `s[from..to]` slice can't be range-proved without a `requires`
+    // clause we don't auto-emit yet. Real-example gap tracked
+    // alongside the umbrella Dafny issue.
+    assert_proof_builds("examples/data/date.av", "aver-proof-date");
+}


### PR DESCRIPTION
## Summary

Audit beyond the original 9 proof_spec examples found:

- **5 examples** clean on both backends (Lean + Dafny verify): `clock_as_data`, `file_store_pure_core`, `oracle_trace`, `terminal_size_snapshot`, `trust_check`. Each gets paired tests.
- **1 example** Lean-only clean (Dafny has `parseIntSlice` slice-bounds gap): `data/date`.
- **4 examples** skipped — Lake build errors (Lean emit gaps, separate from sorry/dafny issues), tracked in #123: `hostile_order_axis`, `file_store_shell`, `red_black_tree`, `randomness_paradox`.

`proof_spec` test count: 39 → **50**.

## Test plan

- [x] `cargo test --test proof_spec` — 50 passed
- [x] `cargo test --lib` — 615 passed
- [x] `cargo test --test proof_ir_diff` — 31 passed
- [x] `cargo fmt --all --check`, `cargo clippy --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)