### PR TITLE
codegen: canonicalise refined_types keying for cross-module disambiguation

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -693,6 +693,62 @@ pub fn is_pure_fn(fd: &FnDef) -> bool {
 
 /// Issue #128: do all of a law's givens carry a singleton domain?
 ///
+/// Resolve a (possibly bare) type name to its [`RefinedTypeDecl`]
+/// in `ctx.proof_ir.refined_types`. The IR is keyed by canonical
+/// name (bare for entry types, `Module.Name` for module types);
+/// callers see whatever the AST node carried (`Expr::RecordCreate
+/// { type_name: "Natural" }` is bare, `obj.ty()` on a stamped
+/// expression can be either).
+///
+/// Resolution order:
+///   1. Direct lookup (covers exact-canonical hits and bare entry
+///      types).
+///   2. If no direct hit, walk `ctx.modules` for a type def with
+///      this bare name and try `Module.Name` keys until one
+///      resolves.
+///
+/// Returns `None` if no match — consistent with the previous
+/// `HashMap::get` semantics. Two modules declaring the same bare
+/// name (`A.Natural` + `B.Natural` with distinct predicates) each
+/// get their own canonical slot now; a direct-canonical-key lookup
+/// disambiguates correctly, and a bare-name lookup resolves to the
+/// first module that owns the name (typechecker's
+/// `cross_module_same_named_types_do_not_merge` rejects mixed
+/// usage upstream, so the order-dependence is observed only when a
+/// project carries one such refined type as actually-used and the
+/// other as dead-code in deps).
+pub fn find_refined_type<'a>(
+    ctx: &'a CodegenContext,
+    name: &str,
+) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
+    resolve_refined_type_in(&ctx.proof_ir.refined_types, &ctx.modules, name)
+}
+
+/// Same resolution shape as [`find_refined_type`] but driven by the
+/// in-flight `refined_types` map plus dep-module list — used inside
+/// `proof_lower` where there is no `CodegenContext` yet.
+pub fn resolve_refined_type_in<'a>(
+    refined_types: &'a std::collections::HashMap<String, crate::ir::proof_ir::RefinedTypeDecl>,
+    modules: &[crate::codegen::ModuleInfo],
+    name: &str,
+) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
+    if let Some(decl) = refined_types.get(name) {
+        return Some(decl);
+    }
+    let bare = name.rsplit('.').next().unwrap_or(name);
+    for m in modules {
+        for td in &m.type_defs {
+            if type_def_name(td) == bare {
+                let canonical = format!("{}.{}", m.prefix, bare);
+                if let Some(decl) = refined_types.get(&canonical) {
+                    return Some(decl);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// A `verify fn law … given a: T = [v]` with one value per given binds
 /// the law to a single concrete point. Combined with
 /// [`law_rhs_is_independent_of_givens`] this is the "sample-only"
@@ -1903,5 +1959,80 @@ mod tests {
             law_lhs_has_trace_projection(&runtime_trace_lhs),
             "Oracle `.trace.event(0)` projection must trigger the gate"
         );
+    }
+
+    #[test]
+    fn resolve_refined_type_disambiguates_cross_module_same_bare_name() {
+        // Review finding 3: two modules each declaring a refined
+        // `Natural` (different predicates) used to silently collide
+        // under bare keying — `populate_refined_types` skipped the
+        // second one via `contains_key`, and the backend lookup
+        // returned whichever predicate landed first. With canonical
+        // keying (`A.Natural` / `B.Natural`) the slots are separate;
+        // a fully-qualified lookup matches exactly, a bare lookup
+        // resolves through module-walk ordering.
+        use crate::ast::{TypeDef, TypeVariant};
+        use crate::codegen::ModuleInfo;
+        use crate::ir::proof_ir::{Predicate, QuantifierType, RefinedTypeDecl};
+        use std::collections::HashMap;
+        let _ = TypeVariant {
+            name: String::new(),
+            fields: Vec::new(),
+        }; // make sure TypeVariant import resolves under all features
+
+        let make_module = |prefix: &str| ModuleInfo {
+            prefix: prefix.to_string(),
+            depends: Vec::new(),
+            type_defs: vec![TypeDef::Product {
+                name: "Natural".to_string(),
+                fields: vec![("value".to_string(), "Int".to_string())],
+                line: 1,
+            }],
+            fn_defs: Vec::new(),
+            analysis: None,
+        };
+        let modules = vec![make_module("A"), make_module("B")];
+
+        let make_decl = |predicate_param: &str, witness: i64| RefinedTypeDecl {
+            name: "Natural".to_string(),
+            carrier_type: "Int".to_string(),
+            carrier_field: "value".to_string(),
+            predicate_param: predicate_param.to_string(),
+            invariant: Predicate {
+                free_vars: vec![(
+                    predicate_param.to_string(),
+                    QuantifierType::Plain("Int".to_string()),
+                )],
+                expr: sb(Expr::Literal(Literal::Bool(true))),
+            },
+            witness: Some(witness.to_string()),
+        };
+        let mut refined_types: HashMap<String, RefinedTypeDecl> = HashMap::new();
+        refined_types.insert("A.Natural".to_string(), make_decl("a", 0));
+        refined_types.insert("B.Natural".to_string(), make_decl("b", 10));
+
+        // Fully-qualified lookups hit the exact slot.
+        let a = resolve_refined_type_in(&refined_types, &modules, "A.Natural")
+            .expect("A.Natural canonical lookup");
+        assert_eq!(a.predicate_param, "a");
+        assert_eq!(a.witness.as_deref(), Some("0"));
+        let b = resolve_refined_type_in(&refined_types, &modules, "B.Natural")
+            .expect("B.Natural canonical lookup");
+        assert_eq!(b.predicate_param, "b");
+        assert_eq!(b.witness.as_deref(), Some("10"));
+
+        // Bare lookup finds *something* (module-walk first match) —
+        // the typechecker prevents mixed usage upstream, so the
+        // observed ordering is the order modules walk.
+        let bare = resolve_refined_type_in(&refined_types, &modules, "Natural")
+            .expect("bare Natural resolves via module walk");
+        assert!(
+            bare.predicate_param == "a" || bare.predicate_param == "b",
+            "bare Natural must resolve to one of the canonical decls"
+        );
+
+        // No-module-owner lookup misses — i.e. a bare name that
+        // wasn't declared in any module is None, not "first in map".
+        assert!(resolve_refined_type_in(&refined_types, &modules, "Unrelated").is_none());
     }
 }

--- a/src/codegen/dafny/expr.rs
+++ b/src/codegen/dafny/expr.rs
@@ -116,7 +116,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             // so projecting the carrier field is the identity (the
             // value *is* the underlying `int`).
             if let Some(crate::types::Type::Named(t_name)) = obj.ty()
-                && let Some(decl) = ctx.proof_ir.refined_types.get(t_name)
+                && let Some(decl) = crate::codegen::common::find_refined_type(ctx, t_name)
                 && decl.carrier_type == "Int"
                 && field == &decl.carrier_field
             {
@@ -246,7 +246,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             // to just `k` — the value already inhabits the subset.
             // Dafny narrowing (via `if pred then ... else ...`) is
             // what closes the refinement obligation at the call site.
-            if let Some(decl) = ctx.proof_ir.refined_types.get(type_name)
+            if let Some(decl) = crate::codegen::common::find_refined_type(ctx, type_name)
                 && decl.carrier_type == "Int"
                 && fields.len() == 1
             {

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -140,7 +140,7 @@ pub fn emit_type_def(td: &TypeDef, ctx: &CodegenContext) -> Option<String> {
             ))
         }
         TypeDef::Product { name, fields, .. } => {
-            if let Some(decl) = ctx.proof_ir.refined_types.get(name)
+            if let Some(decl) = crate::codegen::common::find_refined_type(ctx, name)
                 && decl.carrier_type == "Int"
             {
                 let predicate = super::expr::emit_expr(&decl.invariant.expr, ctx);

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -31,7 +31,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             // up the lifted-type decision the lowerer already made
             // in `ctx.proof_ir.refined_types`.
             if let Some(crate::types::Type::Named(t_name)) = obj.ty()
-                && let Some(decl) = ctx.proof_ir.refined_types.get(t_name)
+                && let Some(decl) = crate::codegen::common::find_refined_type(ctx, t_name)
                 && decl.carrier_type == "Int"
                 && field == &decl.carrier_field
             {
@@ -168,7 +168,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             // structure shape and a plain `{ value := … }` record
             // literal, so this fast-path is gated on the carrier
             // matching.
-            if let Some(decl) = ctx.proof_ir.refined_types.get(type_name)
+            if let Some(decl) = crate::codegen::common::find_refined_type(ctx, type_name)
                 && decl.carrier_type == "Int"
                 && fields.len() == 1
             {

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -88,7 +88,7 @@ fn emit_product_type(name: &str, fields: &[(String, String)], ctx: &CodegenConte
     // existing sample-based path covers them: domain values come
     // from `given a: Float = […]`, and proofs are sample-by-sample
     // via native_decide.
-    if let Some(decl) = ctx.proof_ir.refined_types.get(name)
+    if let Some(decl) = crate::codegen::common::find_refined_type(ctx, name)
         && decl.carrier_type == "Int"
     {
         let carrier_ty = type_annotation_to_lean(&decl.carrier_type);

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -170,32 +170,45 @@ pub fn lower(inputs: &ProofLowerInputs) -> ProofIR {
 /// `RefinedTypeDecl` entries into `ir.refined_types`. Backends
 /// (Lean → Subtype, Dafny → subset type) render these directly.
 pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
-    // Walk entry items first, then dep modules. Both feed into the
-    // same map keyed by bare type name — consumers (Lean / Dafny
-    // emit paths) always query by bare name because that's what
-    // they see in the AST nodes (`Expr::RecordCreate { type_name:
-    // "Natural", ... }`, `TypeDef::Product { name: "Natural", ... }`).
-    // Aver's module DAG invariant + typechecker's duplicate-type
-    // rejection (PR #89) make name collisions a compile error, so
-    // bare-name keying is safe.
+    // Walk entry items first, then dep modules. The map is keyed by
+    // *canonical* name: bare for entry types, `Module.Name` for
+    // module-owned types. Bare keying was insufficient — the
+    // typechecker explicitly permits two modules to expose
+    // distinct types of the same bare name (`A.Shape` vs
+    // `B.Shape`; see `tests/typechecker_spec::cross_module_same_named_
+    // types_do_not_merge`). If a project depends on two modules
+    // each declaring a refined `Natural` with different predicates,
+    // bare keying picked whichever one walked first and silently
+    // applied its predicate at every call site referring to the
+    // other. Canonical keying gives each declaration its own slot;
+    // [`find_refined_type`] does the lookup-side resolution from
+    // bare references back through `ctx.modules`.
     let entry_typedefs = inputs.entry_items.iter().filter_map(|item| match item {
-        TopLevel::TypeDef(td) => Some(td),
+        TopLevel::TypeDef(td) => Some((None::<&str>, td)),
         _ => None,
     });
-    let module_typedefs = inputs.dep_modules.iter().flat_map(|m| m.type_defs.iter());
+    let module_typedefs = inputs.dep_modules.iter().flat_map(|m| {
+        m.type_defs
+            .iter()
+            .map(move |td| (Some(m.prefix.as_str()), td))
+    });
 
-    for td in entry_typedefs.chain(module_typedefs) {
+    for (module_prefix, td) in entry_typedefs.chain(module_typedefs) {
         let TypeDef::Product { name, fields, .. } = td else {
             continue;
         };
         if fields.len() != 1 {
             continue;
         }
-        if ir.refined_types.contains_key(name) {
-            // Already classified via another path (typically the
-            // entry walk picked it up first); skip the dep-module
-            // duplicate so we don't overwrite a verified-witness
-            // entry with a predicate-eval fallback witness.
+        let canonical_key = match module_prefix {
+            Some(prefix) => format!("{}.{}", prefix, name),
+            None => name.clone(),
+        };
+        if ir.refined_types.contains_key(&canonical_key) {
+            // Same canonical key already populated — possible if a
+            // module is walked twice through dep aliasing. Skip so
+            // we don't overwrite a verified-witness entry with a
+            // predicate-eval fallback witness.
             continue;
         }
         let Some(info) = refinement_info_for(name, inputs) else {
@@ -210,7 +223,7 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
         };
         let witness = pick_witness(name, inputs, info.predicate, info.param_name);
         ir.refined_types.insert(
-            name.clone(),
+            canonical_key,
             RefinedTypeDecl {
                 name: name.clone(),
                 carrier_type: info.carrier_type.to_string(),
@@ -747,7 +760,14 @@ fn detect_simp_omega_unfold(
     // constructor to Int arithmetic. Skip the outer-Int rejection
     // for lifted laws.
     let lifted = law.givens.iter().any(|g| {
-        refinement_lift_for_given_ir(&g.name, &law.lhs, &law.rhs, refined_types).is_some()
+        refinement_lift_for_given_ir(
+            &g.name,
+            &law.lhs,
+            &law.rhs,
+            refined_types,
+            inputs.dep_modules,
+        )
+        .is_some()
     });
     if !lifted && outer_fd.params.iter().any(|(_, t)| t != "Int") {
         return None;
@@ -850,10 +870,11 @@ fn refinement_lift_for_given_ir(
     lhs: &Spanned<crate::ast::Expr>,
     rhs: &Spanned<crate::ast::Expr>,
     refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
+    dep_modules: &[crate::codegen::ModuleInfo],
 ) -> Option<String> {
     let mut result: Option<String> = None;
-    walk_for_refinement_carrier(lhs, given_name, refined_types, &mut result);
-    walk_for_refinement_carrier(rhs, given_name, refined_types, &mut result);
+    walk_for_refinement_carrier(lhs, given_name, refined_types, dep_modules, &mut result);
+    walk_for_refinement_carrier(rhs, given_name, refined_types, dep_modules, &mut result);
     result
 }
 
@@ -861,6 +882,7 @@ fn walk_for_refinement_carrier(
     expr: &Spanned<crate::ast::Expr>,
     given_name: &str,
     refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
+    dep_modules: &[crate::codegen::ModuleInfo],
     result: &mut Option<String>,
 ) {
     use crate::ast::Expr;
@@ -874,34 +896,46 @@ fn walk_for_refinement_carrier(
                 &fvalue.node,
                 Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == given_name
             );
-            if matches_var && let Some(decl) = refined_types.get(type_name) {
+            if matches_var
+                && let Some(decl) = crate::codegen::common::resolve_refined_type_in(
+                    refined_types,
+                    dep_modules,
+                    type_name,
+                )
+            {
                 *result = Some(decl.name.clone());
                 return;
             }
             // Even non-matching RecordCreate may contain nested
             // refinement carriers (e.g. `Foo(value = Bar(value = a))`).
             for (_, v) in fields {
-                walk_for_refinement_carrier(v, given_name, refined_types, result);
+                walk_for_refinement_carrier(v, given_name, refined_types, dep_modules, result);
             }
         }
         Expr::FnCall(callee, args) => {
-            walk_for_refinement_carrier(callee, given_name, refined_types, result);
+            walk_for_refinement_carrier(callee, given_name, refined_types, dep_modules, result);
             for a in args {
-                walk_for_refinement_carrier(a, given_name, refined_types, result);
+                walk_for_refinement_carrier(a, given_name, refined_types, dep_modules, result);
             }
         }
         Expr::BinOp(_, l, r) => {
-            walk_for_refinement_carrier(l, given_name, refined_types, result);
-            walk_for_refinement_carrier(r, given_name, refined_types, result);
+            walk_for_refinement_carrier(l, given_name, refined_types, dep_modules, result);
+            walk_for_refinement_carrier(r, given_name, refined_types, dep_modules, result);
         }
         Expr::Match { subject, arms, .. } => {
-            walk_for_refinement_carrier(subject, given_name, refined_types, result);
+            walk_for_refinement_carrier(subject, given_name, refined_types, dep_modules, result);
             for arm in arms {
-                walk_for_refinement_carrier(&arm.body, given_name, refined_types, result);
+                walk_for_refinement_carrier(
+                    &arm.body,
+                    given_name,
+                    refined_types,
+                    dep_modules,
+                    result,
+                );
             }
         }
         Expr::Attr(obj, _) => {
-            walk_for_refinement_carrier(obj, given_name, refined_types, result);
+            walk_for_refinement_carrier(obj, given_name, refined_types, dep_modules, result);
         }
         _ => {}
     }


### PR DESCRIPTION
## Summary

Review finding 3: `populate_refined_types` keyed `ProofIR.refined_types` by bare type name, but the typechecker explicitly permits two modules to expose distinct types of the same bare name (see `tests/typechecker_spec::cross_module_same_named_types_do_not_merge`). If a project depends on two modules each declaring a refined `Natural` with different predicates, bare keying picked whichever walked first and silently applied its predicate at every callsite referring to the *other*.

The `RefinedTypeDecl` doc already promised canonical "Module.Type" keys — this PR makes the implementation match.

## What changed

- `populate_refined_types` keys entries by canonical name: bare for entry types, `Module.Name` for module-owned types. The `name` field on `RefinedTypeDecl` stays bare per its existing contract (backends emit the source name; canonical form is the map key).
- `find_refined_type(ctx, name)` / `resolve_refined_type_in(map, modules, name)` are the new lookup paths: direct canonical hit wins, then module-walk resolves bare → `Module.Name`. Six backend sites (Lean / Dafny `expr.rs` + `toplevel.rs`) switched over plus the in-flight `walk_for_refinement_carrier` recursion.
- `walk_for_refinement_carrier` / `refinement_lift_for_given_ir` thread `dep_modules` through so the IR populator resolves the same way the backends do.

## Test plan

- [x] New unit test `resolve_refined_type_disambiguates_cross_module_same_bare_name` — both `A.Natural` and `B.Natural` resolve to their own decl by canonical name; bare lookup falls through to module-walk; unrelated names miss cleanly.
- [x] `cargo test`: 1507 passing (was 1506), no regressions.
- [x] `cargo fmt --all -- --check` clean.

## Out of scope

Finding 2 (IR-as-source-of-truth refactor — backends still ad-hoc decide wrapper-strip / `.val` / drop-vs-keep) is a wider architectural pass and stays separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)