### PR TITLE
codegen: module-scope-aware naming consistency across proof export (review round 2)

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -42,37 +42,112 @@ pub struct RefinementInfo<'a> {
 /// Inspect inputs for a refinement-via-opaque record by `type_name`.
 /// Returns `Some(info)` iff there's exactly one matching smart
 /// constructor and the record has a single carrier field.
+///
+/// Defaults to "any scope" — walks entry + every dep module's
+/// type_defs and fn_defs to find the record + smart constructor.
+/// Use [`refinement_info_for_in_scope`] when two modules declare a
+/// refined record of the same bare name (`A.Natural` vs `B.Natural`)
+/// and you need each scope's *own* predicate; the unscoped form
+/// returns whichever record walked first.
 pub fn refinement_info_for<'a>(
     type_name: &str,
     inputs: &crate::codegen::proof_lower::ProofLowerInputs<'a>,
 ) -> Option<RefinementInfo<'a>> {
-    // Refinement records may live in the entry file or in a
-    // dependent module. Same for the smart constructor. Walk both
-    // so cross-module compilations (`aver proof natural_app.av`
-    // depending on a `Natural` module) produce the same lifted
-    // shape as the standalone module file.
-    let entry_typedefs = inputs.entry_items.iter().filter_map(|item| match item {
-        TopLevel::TypeDef(td) => Some(td),
-        _ => None,
-    });
-    let module_typedefs = inputs.dep_modules.iter().flat_map(|m| m.type_defs.iter());
-    let (carrier_field, carrier_type) =
-        entry_typedefs
-            .chain(module_typedefs)
-            .find_map(|td| match td {
-                TypeDef::Product { name, fields, .. } if name == type_name && fields.len() == 1 => {
-                    let (fname, ftype) = &fields[0];
-                    Some((fname.as_str(), ftype.as_str()))
-                }
-                _ => None,
-            })?;
+    refinement_info_for_walk(type_name, inputs, None)
+}
 
-    let entry_fns = inputs.entry_items.iter().filter_map(|item| match item {
-        TopLevel::FnDef(fd) => Some(fd),
+/// Module-scoped variant of [`refinement_info_for`]. `scope =
+/// None` means "look in entry items only"; `scope = Some(prefix)`
+/// means "look in the dep module whose `prefix` matches".
+///
+/// Refinement-via-opaque is a single-module pattern: the record is
+/// declared `exposes opaque [X]` and the smart constructor lives in
+/// the same module (the carrier field isn't reachable from outside,
+/// so the constructor can't reside elsewhere). Scoping the search
+/// to one module gives each scope its own predicate, which is what
+/// `populate_refined_types` needs so canonical `A.Natural` and
+/// `B.Natural` slots don't share a predicate from whichever module
+/// happened to walk first.
+pub fn refinement_info_for_in_scope<'a>(
+    type_name: &str,
+    inputs: &crate::codegen::proof_lower::ProofLowerInputs<'a>,
+    scope: Option<&str>,
+) -> Option<RefinementInfo<'a>> {
+    refinement_info_for_walk(type_name, inputs, Some(scope))
+}
+
+fn refinement_info_for_walk<'a>(
+    type_name: &str,
+    inputs: &crate::codegen::proof_lower::ProofLowerInputs<'a>,
+    // Outer Option: None = "any scope" (legacy); Some(inner) =
+    // module-scoped. Inner Option: None = entry, Some(prefix) =
+    // module by prefix.
+    scope_filter: Option<Option<&str>>,
+) -> Option<RefinementInfo<'a>> {
+    let entry_only = matches!(scope_filter, Some(None));
+    let module_only_prefix = match scope_filter {
+        Some(Some(p)) => Some(p),
         _ => None,
-    });
-    let module_fns = inputs.dep_modules.iter().flat_map(|m| m.fn_defs.iter());
-    for fd in entry_fns.chain(module_fns) {
+    };
+    let allow_entry = scope_filter.is_none() || entry_only;
+    let entry_typedefs: Vec<&'a TypeDef> = if allow_entry {
+        inputs
+            .entry_items
+            .iter()
+            .filter_map(|item| match item {
+                TopLevel::TypeDef(td) => Some(td),
+                _ => None,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let module_typedefs: Vec<&'a TypeDef> = inputs
+        .dep_modules
+        .iter()
+        .filter(|m| match (scope_filter, module_only_prefix) {
+            (None, _) => true,
+            (Some(None), _) => false,
+            (Some(Some(_)), Some(p)) => m.prefix == p,
+            _ => false,
+        })
+        .flat_map(|m| m.type_defs.iter())
+        .collect();
+    let (carrier_field, carrier_type) = entry_typedefs
+        .into_iter()
+        .chain(module_typedefs)
+        .find_map(|td| match td {
+            TypeDef::Product { name, fields, .. } if name == type_name && fields.len() == 1 => {
+                let (fname, ftype) = &fields[0];
+                Some((fname.as_str(), ftype.as_str()))
+            }
+            _ => None,
+        })?;
+
+    let entry_fns: Vec<&'a FnDef> = if allow_entry {
+        inputs
+            .entry_items
+            .iter()
+            .filter_map(|item| match item {
+                TopLevel::FnDef(fd) => Some(fd),
+                _ => None,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let module_fns: Vec<&'a FnDef> = inputs
+        .dep_modules
+        .iter()
+        .filter(|m| match (scope_filter, module_only_prefix) {
+            (None, _) => true,
+            (Some(None), _) => false,
+            (Some(Some(_)), Some(p)) => m.prefix == p,
+            _ => false,
+        })
+        .flat_map(|m| m.fn_defs.iter())
+        .collect();
+    for fd in entry_fns.into_iter().chain(module_fns) {
         if !fd.return_type.starts_with("Result<") {
             continue;
         }
@@ -721,7 +796,48 @@ pub fn find_refined_type<'a>(
     ctx: &'a CodegenContext,
     name: &str,
 ) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
-    resolve_refined_type_in(&ctx.proof_ir.refined_types, &ctx.modules, name)
+    find_refined_type_scoped(ctx, name, None)
+}
+
+/// Module-scope-aware variant of [`find_refined_type`]. When the
+/// caller knows which module's emit-pass is in flight (`scope =
+/// Some(module.prefix)`), the resolver tries `Module.Name` *before*
+/// falling back to module-walk ordering. Two modules with same-bare
+/// refined records (`A.Natural` + `B.Natural`, distinct predicates)
+/// then resolve to the *current scope*'s entry — bare references
+/// inside module B's emit pick up `B.Natural`, not whichever module
+/// happened to populate first.
+///
+/// Resolution order:
+///   1. Direct lookup (covers exact-canonical hits + bare-entry).
+///   2. If `scope = Some(prefix)`, try `prefix.bare`.
+///   3. Walk modules to find owners and try each canonical key.
+pub fn find_refined_type_scoped<'a>(
+    ctx: &'a CodegenContext,
+    name: &str,
+    scope: Option<&str>,
+) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
+    if let Some(decl) = ctx.proof_ir.refined_types.get(name) {
+        return Some(decl);
+    }
+    let bare = name.rsplit('.').next().unwrap_or(name);
+    if let Some(prefix) = scope {
+        let scoped = format!("{}.{}", prefix, bare);
+        if let Some(decl) = ctx.proof_ir.refined_types.get(&scoped) {
+            return Some(decl);
+        }
+    }
+    for m in &ctx.modules {
+        for td in &m.type_defs {
+            if type_def_name(td) == bare {
+                let canonical = format!("{}.{}", m.prefix, bare);
+                if let Some(decl) = ctx.proof_ir.refined_types.get(&canonical) {
+                    return Some(decl);
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Same resolution shape as [`find_refined_type`] but driven by the
@@ -811,12 +927,19 @@ fn expr_calls_named(expr: &Spanned<Expr>, names: &HashSet<String>) -> bool {
         Expr::FnCall(callee, args) => {
             // Resolve the callee through the same path other emitters use —
             // covers bare (`size`), dotted (`Dep.toSorted`), and resolved
-            // module-qualified (`Models.User.size`) shapes. Without this,
-            // a law calling `Dep.toSorted(xs)` slipped past the gate and
-            // emitted a non-closing `induction t with …` against a
-            // fuel-bounded helper.
+            // module-qualified shapes. The unclassified set is populated
+            // from the recursion classifier's diagnostics, which today
+            // emit the local `fd.name` (bare) regardless of which module
+            // the fn lives in (see `recursion::detect`'s issue messages).
+            // Match BOTH the resolved canonical name and its bare suffix
+            // so `Dep.toSorted(xs)` lands on the gate when the set holds
+            // just `toSorted` — and so a future migration to qualified
+            // diagnostic names keeps working.
             let direct = expr_to_dotted_name(&callee.node)
-                .map(|n| names.contains(n.as_str()))
+                .map(|n| {
+                    let bare = n.rsplit('.').next().unwrap_or(n.as_str());
+                    names.contains(n.as_str()) || names.contains(bare)
+                })
                 .unwrap_or(false);
             direct
                 || expr_calls_named(callee, names)
@@ -960,7 +1083,11 @@ fn expr_has_trace_field(expr: &Spanned<Expr>) -> bool {
     }
 }
 
-const TRACE_API_METHODS: &[&str] = &["event", "group", "branch", "length", "contains"];
+/// Oracle's trace-buffer API surface. Every method that
+/// `infer_trace_method` in the typechecker recognises as a
+/// trace-only call. Keep in sync with
+/// `src/types/checker/infer/expr.rs::infer_trace_method`.
+const TRACE_API_METHODS: &[&str] = &["event", "group", "branch", "length", "contains", "count"];
 
 fn expr_has_trace_api_call(expr: &Spanned<Expr>) -> bool {
     match &expr.node {
@@ -1900,11 +2027,16 @@ mod tests {
 
     #[test]
     fn law_calls_unclassified_fn_detects_dotted_callee() {
-        // Review finding 1: a law calling `Dep.toSorted(xs)` (where
-        // `toSorted` is on the unclassified list) used to slip past
-        // the gate because `expr_calls_named` only matched bare
-        // `Expr::Ident` callees. With `expr_to_dotted_name`-based
-        // resolution the dotted form is detected too.
+        // Review finding 1 (round 2): the recursion classifier emits
+        // `UnclassifiedFn` messages keyed by bare `fd.name`, so the
+        // unclassified set the gate consults holds BARE names even
+        // for fns living in a dep module. A law calling
+        // `Dep.toSorted(xs)` against a bare-`toSorted` unclassified
+        // set has to match on the bare suffix too — otherwise the
+        // gate doesn't fire and the backend emits a non-closing
+        // `induction t with …`. Also accepts a fully-qualified entry
+        // for forward compat with a future classifier that emits
+        // canonical names.
         let lhs = sb(Expr::FnCall(
             bsb(Expr::Attr(
                 bsb(Expr::Ident("Dep".to_string())),
@@ -1915,15 +2047,26 @@ mod tests {
         let rhs = sb(Expr::Ident("xs".to_string()));
         let law = law_with(lhs, rhs);
 
-        let mut unclassified = HashSet::new();
-        unclassified.insert("Dep.toSorted".to_string());
-        assert!(law_calls_unclassified_fn(&law, &unclassified));
+        // Forward-compat: a fully-qualified entry matches a dotted
+        // callee directly.
+        let mut canonical = HashSet::new();
+        canonical.insert("Dep.toSorted".to_string());
+        assert!(law_calls_unclassified_fn(&law, &canonical));
 
-        // Same lhs, but the unclassified set names only the bare
-        // form — confirms the dotted name resolved through.
+        // Real production shape today: classifier emits bare names;
+        // the gate must still catch the dotted callsite.
         let mut bare_only = HashSet::new();
         bare_only.insert("toSorted".to_string());
-        assert!(!law_calls_unclassified_fn(&law, &bare_only));
+        assert!(
+            law_calls_unclassified_fn(&law, &bare_only),
+            "bare unclassified name must catch a dotted callsite via suffix match"
+        );
+
+        // Negative control: an unrelated bare name in the set does
+        // not match the dotted callsite.
+        let mut unrelated = HashSet::new();
+        unrelated.insert("somethingElse".to_string());
+        assert!(!law_calls_unclassified_fn(&law, &unrelated));
     }
 
     #[test]

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -195,7 +195,9 @@ fn transpile_unified(ctx: &CodegenContext) -> ProjectOutput {
     for module in &ctx.modules {
         let mut sections: Vec<String> = Vec::new();
         for td in &module.type_defs {
-            if let Some(code) = toplevel::emit_type_def(td, ctx) {
+            if let Some(code) =
+                toplevel::emit_type_def_in_scope(td, ctx, Some(module.prefix.as_str()))
+            {
                 sections.push(code);
             }
         }

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -112,6 +112,18 @@ fn literal_int_value(expr: &Spanned<Expr>) -> Option<String> {
 /// poorly automated, and multi-field needs a `predicate` over the
 /// product which the smart-constructor pattern doesn't supply.
 pub fn emit_type_def(td: &TypeDef, ctx: &CodegenContext) -> Option<String> {
+    emit_type_def_in_scope(td, ctx, None)
+}
+
+/// Module-scoped emit: `scope` carries the prefix of the module
+/// whose typedefs we're rendering (or `None` for entry items).
+/// Drives [`find_refined_type_scoped`] so a refined record with a
+/// bare name resolves to the current module's slot.
+pub fn emit_type_def_in_scope(
+    td: &TypeDef,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> Option<String> {
     match td {
         TypeDef::Sum { name, variants, .. } => {
             let variant_strs: Vec<String> = variants
@@ -140,7 +152,7 @@ pub fn emit_type_def(td: &TypeDef, ctx: &CodegenContext) -> Option<String> {
             ))
         }
         TypeDef::Product { name, fields, .. } => {
-            if let Some(decl) = crate::codegen::common::find_refined_type(ctx, name)
+            if let Some(decl) = crate::codegen::common::find_refined_type_scoped(ctx, name, scope)
                 && decl.carrier_type == "Int"
             {
                 let predicate = super::expr::emit_expr(&decl.invariant.expr, ctx);

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -486,12 +486,11 @@ fn emit_match(
 /// cond then …`.
 fn true_body_uses_refinement_subtype(expr: &Spanned<Expr>, ctx: &CodegenContext) -> bool {
     match &expr.node {
-        Expr::RecordCreate { type_name, .. } => ctx
-            .proof_ir
-            .refined_types
-            .get(type_name)
-            .map(|decl| decl.carrier_type == "Int")
-            .unwrap_or(false),
+        Expr::RecordCreate { type_name, .. } => {
+            crate::codegen::common::find_refined_type(ctx, type_name)
+                .map(|decl| decl.carrier_type == "Int")
+                .unwrap_or(false)
+        }
         Expr::FnCall(callee, args) => {
             true_body_uses_refinement_subtype(callee, ctx)
                 || args

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1297,7 +1297,11 @@ fn transpile_unified(
     for module in &ctx.modules {
         let mut body_sections: Vec<String> = Vec::new();
         for td in &module.type_defs {
-            body_sections.push(toplevel::emit_type_def(td, ctx));
+            body_sections.push(toplevel::emit_type_def_in_scope(
+                td,
+                ctx,
+                Some(module.prefix.as_str()),
+            ));
             if toplevel::is_recursive_type_def(td) {
                 body_sections.push(toplevel::emit_recursive_decidable_eq(
                     toplevel::type_def_name(td),

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -29,9 +29,18 @@ fn bounded_oracle_subtype_for(method: &str) -> Option<&'static str> {
 }
 
 pub fn emit_type_def(td: &TypeDef, ctx: &CodegenContext) -> String {
+    emit_type_def_in_scope(td, ctx, None)
+}
+
+/// Module-scoped emit: `scope` carries the prefix of the module
+/// whose typedefs we're currently rendering (or `None` for entry
+/// items). Drives [`find_refined_type_scoped`] so a refined record
+/// with a bare name resolves to the current module's canonical
+/// entry instead of whichever module populated first.
+pub fn emit_type_def_in_scope(td: &TypeDef, ctx: &CodegenContext, scope: Option<&str>) -> String {
     match td {
         TypeDef::Sum { name, variants, .. } => emit_sum_type(name, variants),
-        TypeDef::Product { name, fields, .. } => emit_product_type(name, fields, ctx),
+        TypeDef::Product { name, fields, .. } => emit_product_type(name, fields, ctx, scope),
     }
 }
 
@@ -78,7 +87,12 @@ fn emit_sum_type(name: &str, variants: &[TypeVariant]) -> String {
     lines.join("\n")
 }
 
-fn emit_product_type(name: &str, fields: &[(String, String)], ctx: &CodegenContext) -> String {
+fn emit_product_type(
+    name: &str,
+    fields: &[(String, String)],
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> String {
     // Refinement-via-opaque records emit as Lean `Subtype` only
     // when the carrier is `Int`. Float-carrier records (NonNegFloat,
     // Discount, …) stay as plain `structure`, because Lean's `Float`
@@ -88,7 +102,7 @@ fn emit_product_type(name: &str, fields: &[(String, String)], ctx: &CodegenConte
     // existing sample-based path covers them: domain values come
     // from `given a: Float = […]`, and proofs are sample-by-sample
     // via native_decide.
-    if let Some(decl) = crate::codegen::common::find_refined_type(ctx, name)
+    if let Some(decl) = crate::codegen::common::find_refined_type_scoped(ctx, name, scope)
         && decl.carrier_type == "Int"
     {
         let carrier_ty = type_annotation_to_lean(&decl.carrier_type);

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -21,7 +21,7 @@
 use std::collections::HashSet;
 
 use crate::ast::{Expr, FnDef, Literal, Spanned, TopLevel, TypeDef};
-use crate::codegen::common::{expr_to_dotted_name, refinement_info_for};
+use crate::codegen::common::expr_to_dotted_name;
 use crate::codegen::recursion::{RecursionPlan, analyze_plans};
 use crate::codegen::{CodegenContext, ModuleInfo};
 use crate::ir::proof_ir::{
@@ -211,7 +211,16 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             // predicate-eval fallback witness.
             continue;
         }
-        let Some(info) = refinement_info_for(name, inputs) else {
+        // Scope the smart-constructor lookup to the same module the
+        // record lives in. Refinement-via-opaque keeps the record
+        // opaque (`exposes opaque [X]`); a smart constructor in any
+        // other module couldn't reach the carrier field anyway.
+        // Without the scope, two modules each declaring a `Natural`
+        // with different predicates would both pick up whichever
+        // smart constructor walked first.
+        let Some(info) =
+            crate::codegen::common::refinement_info_for_in_scope(name, inputs, module_prefix)
+        else {
             continue;
         };
         let invariant = Predicate {

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -2004,6 +2004,115 @@ fn proof_dafny_verifies_date_when_dafny_is_available() {
 }
 
 #[test]
+fn proof_export_cross_module_refined_types_keep_distinct_predicates() {
+    // Review findings 2 + 3 (round 2): two modules each declaring a
+    // refined `Natural` (different predicates) must each carry its
+    // own predicate into the Lean / Dafny export. Pre-fix
+    // `populate_refined_types` keyed `refined_types` by bare name
+    // and called the unscoped `refinement_info_for` — both `A` and
+    // `B` ended up sharing whichever predicate walked first. The
+    // canonical-key + scoped-info path gives each module its own
+    // slot; `find_refined_type_scoped` then resolves bare lookups
+    // inside each module's emit pass to the local entry.
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let root = temp_output_dir("aver-proof-cross-module-refined");
+    std::fs::create_dir_all(&root).expect("create root");
+
+    std::fs::write(
+        root.join("AAA.av"),
+        "module AAA\n\
+         \x20   exposes [fromInt]\n\
+         \x20   exposes opaque [Natural]\n\
+         \x20   intent = \"Module AAA's Natural — non-negative.\"\n\
+         \x20   effects []\n\
+         \n\
+         record Natural\n\
+         \x20   value: Int\n\
+         \n\
+         fn fromInt(n: Int) -> Result<Natural, String>\n\
+         \x20   ? \"Smart constructor — non-negative.\"\n\
+         \x20   match n >= 0\n\
+         \x20       true  -> Result.Ok(Natural(value = n))\n\
+         \x20       false -> Result.Err(\"AAA: must be non-negative\")\n",
+    )
+    .expect("write AAA.av");
+
+    std::fs::write(
+        root.join("BBB.av"),
+        "module BBB\n\
+         \x20   exposes [fromInt]\n\
+         \x20   exposes opaque [Natural]\n\
+         \x20   intent = \"Module BBB's Natural — at least 10.\"\n\
+         \x20   effects []\n\
+         \n\
+         record Natural\n\
+         \x20   value: Int\n\
+         \n\
+         fn fromInt(n: Int) -> Result<Natural, String>\n\
+         \x20   ? \"Smart constructor — at least 10.\"\n\
+         \x20   match n >= 10\n\
+         \x20       true  -> Result.Ok(Natural(value = n))\n\
+         \x20       false -> Result.Err(\"BBB: must be >= 10\")\n",
+    )
+    .expect("write BBB.av");
+
+    std::fs::write(
+        root.join("entry.av"),
+        "module Entry\n\
+         \x20   depends [AAA, BBB]\n\
+         \x20   intent = \"Touches both Naturals so both surface in the proof IR.\"\n\
+         \n\
+         fn main() -> Int\n\
+         \x20   0\n",
+    )
+    .expect("write entry.av");
+
+    let out_dir = root.join("out");
+    let proof = Command::new(aver_bin)
+        .current_dir(&root)
+        .arg("proof")
+        .arg("entry.av")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("aver proof");
+    assert!(
+        proof.status.success(),
+        "`aver proof` failed:\n{}",
+        format_output(&proof)
+    );
+
+    let aaa_lean = std::fs::read_to_string(out_dir.join("AAA.lean")).expect("read AAA.lean");
+    let bbb_lean = std::fs::read_to_string(out_dir.join("BBB.lean")).expect("read BBB.lean");
+
+    // AAA's Natural carries `>= 0`; BBB's carries `>= 10`. Each
+    // module's emit pass must resolve its own predicate, not the
+    // other's. Before the scope fix, populate kept only the first
+    // walked predicate under bare key `Natural` and both modules
+    // emitted the same subtype.
+    assert!(
+        aaa_lean.contains("abbrev Natural") && aaa_lean.contains(">= 0"),
+        "AAA.lean must abbrev Natural with `>= 0`; got:\n{aaa_lean}"
+    );
+    assert!(
+        bbb_lean.contains("abbrev Natural") && bbb_lean.contains(">= 10"),
+        "BBB.lean must abbrev Natural with `>= 10`; got:\n{bbb_lean}"
+    );
+    // Defense in depth: AAA's emit must not carry BBB's predicate
+    // or vice versa.
+    assert!(
+        !aaa_lean.contains(">= 10"),
+        "AAA.lean leaked BBB's predicate; got:\n{aaa_lean}"
+    );
+    assert!(
+        !bbb_lean.contains("n >= 0 "),
+        "BBB.lean leaked AAA's predicate; got:\n{bbb_lean}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn proof_export_lake_builds_red_black_tree_after_singleton_and_fuel_gates() {
     // Issue #128: red_black_tree.av carried 44 lake errors after the
     // #123 path-shadow / `.val` fixes. The diagnosis in the issue


### PR DESCRIPTION
## Summary

Five review findings from the post-#130/#131 round — all clustered around proof-lower's canonical-naming boundary still leaking bare references at population *and* lookup sides.

- **F1**: `expr_calls_named` matched the unclassified-fn set only against the dotted callee form, but the recursion classifier emits its `UnclassifiedFn` diagnostics using bare `fd.name` regardless of which module the fn lives in. `Dep.toSorted(xs)` against a bare-`toSorted` set then slipped past the gate. Matches both canonical and bare suffix now. The earlier `bare_only` test (which pinned the broken behaviour) is flipped to assert the fix.

- **F2**: `populate_refined_types` keyed `ProofIR.refined_types` by canonical `Module.Name` (per #131) but still queried info via the unscoped `refinement_info_for(name, inputs)`. Two modules each declaring a refined `Natural` with different predicates both inherited whichever walked first. New `refinement_info_for_in_scope(name, inputs, scope)` filters typedefs + smart-constructor walks to the same module — mirroring Aver's `exposes opaque` constraint that record + constructor live together.

- **F3**: `find_refined_type(ctx, name)` was scope-agnostic, so module B's emit pass resolved bare `Natural` to whichever entry walked first. New `find_refined_type_scoped(ctx, name, scope)` tries `prefix.bare` before module-walk fallback. `emit_type_def_in_scope` plumbs the current module's prefix from the per-module loops in both backends.

- **F4**: `TRACE_API_METHODS` was missing `count`, which the typechecker supports on `Trace`. `fn().trace.count(...)` slipped past the gate.

- **F5**: One remaining `ctx.proof_ir.refined_types.get(type_name)` in `lean::expr::true_body_uses_refinement_subtype` — routed through `find_refined_type` so dependent-`if h : pred` emits correctly for module-owned refined records.

## Test plan

- [x] New `proof_export_cross_module_refined_types_keep_distinct_predicates` — file-based fixture with two modules each declaring `Natural` (different predicates), asserts neither leaks the other's predicate into its emitted `.lean`.
- [x] `law_calls_unclassified_fn_detects_dotted_callee` flipped to assert bare-suffix-match catches dotted callsites.
- [x] `cargo test`: 1508 passing (was 1507), no regressions.
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)