### PR TITLE
codegen: scope-aware witness picker + lookup ordering + canonical-IR routing (review round 3)

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -309,10 +309,18 @@ fn search_refinement_wrapper<'a>(
                 &fvalue.node,
                 Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == given_name
             );
-            let inputs_local = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
+            // Round-3 finding 3: route through the canonical IR
+            // decision instead of re-walking entry + every module
+            // via `refinement_info_for`. The unscoped re-walk
+            // returned whichever refined record walked first when
+            // two modules carried the same bare name, then the
+            // returned `name` was used downstream as if it identified
+            // a unique decl. `find_refined_type` resolves against
+            // `proof_ir.refined_types` which `populate_refined_types`
+            // already keyed by canonical `Module.Name`.
             if matches_var
-                && let Some(info) = refinement_info_for(type_name, &inputs_local)
-                && info.carrier_type == given_type
+                && let Some(decl) = find_refined_type(ctx, type_name)
+                && decl.carrier_type == given_type
             {
                 // Need a stable reference into ctx for the returned
                 // &str. `refinement_info_for` returns refs into ctx
@@ -720,13 +728,22 @@ pub fn when_is_redundant_with_refinement_lifts(
     // walk) would length-mismatch and keep the now-redundant
     // premise. Same flatten on both sides keeps natural / positive
     // / int_range behavior identical to pre-fix.
-    let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
+    // Round-3 finding 3: same canonical-IR routing as
+    // `search_refinement_wrapper`. The legacy `refinement_info_for`
+    // walks every module looking for a same-bare-name record, so
+    // two modules with distinct predicates would share whichever
+    // walked first. `find_refined_type` reads from
+    // `proof_ir.refined_types` keyed by canonical `Module.Name`.
     let mut lifted_predicates: Vec<Spanned<Expr>> = Vec::new();
     for (given_name, refined_type) in lifted_vars {
-        let Some(info) = refinement_info_for(refined_type, &inputs) else {
+        let Some(decl) = find_refined_type(ctx, refined_type) else {
             return false;
         };
-        let substituted = substitute_ident_in_expr(info.predicate, info.param_name, given_name);
+        let substituted = substitute_ident_in_expr(
+            &decl.invariant.expr,
+            decl.predicate_param.as_str(),
+            given_name,
+        );
         lifted_predicates.extend(flatten_bool_and_conjuncts(&substituted));
     }
     if when_conjuncts.len() != lifted_predicates.len() {
@@ -808,24 +825,31 @@ pub fn find_refined_type<'a>(
 /// inside module B's emit pick up `B.Natural`, not whichever module
 /// happened to populate first.
 ///
-/// Resolution order:
-///   1. Direct lookup (covers exact-canonical hits + bare-entry).
-///   2. If `scope = Some(prefix)`, try `prefix.bare`.
+/// Resolution order (revised after review round 3):
+///   1. If `scope = Some(prefix)` AND `name` is bare, try
+///      `prefix.bare` FIRST — without this an entry-level
+///      refined record with the same bare name would shadow the
+///      module's own slot from inside that module's emit pass.
+///   2. Direct lookup of `name` as written (covers exact-canonical
+///      hits + bare-entry from entry-scope callers).
 ///   3. Walk modules to find owners and try each canonical key.
 pub fn find_refined_type_scoped<'a>(
     ctx: &'a CodegenContext,
     name: &str,
     scope: Option<&str>,
 ) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
-    if let Some(decl) = ctx.proof_ir.refined_types.get(name) {
-        return Some(decl);
-    }
     let bare = name.rsplit('.').next().unwrap_or(name);
-    if let Some(prefix) = scope {
+    let name_is_already_qualified = name.contains('.');
+    if let Some(prefix) = scope
+        && !name_is_already_qualified
+    {
         let scoped = format!("{}.{}", prefix, bare);
         if let Some(decl) = ctx.proof_ir.refined_types.get(&scoped) {
             return Some(decl);
         }
+    }
+    if let Some(decl) = ctx.proof_ir.refined_types.get(name) {
+        return Some(decl);
     }
     for m in &ctx.modules {
         for td in &m.type_defs {
@@ -2177,5 +2201,89 @@ mod tests {
         // No-module-owner lookup misses — i.e. a bare name that
         // wasn't declared in any module is None, not "first in map".
         assert!(resolve_refined_type_in(&refined_types, &modules, "Unrelated").is_none());
+    }
+
+    #[test]
+    fn find_refined_type_scoped_prefers_current_module_over_entry_collision() {
+        // Review finding 2 (round 3): when entry AND a dep module
+        // both declare a refined record of the same bare name, the
+        // module's emit pass (passing `scope = Some(prefix)` and a
+        // bare reference) must resolve to its OWN slot, not entry's.
+        // The pre-fix order tried direct `refined_types.get(name)`
+        // first, which matched entry's bare-keyed slot and the
+        // scope-prefix lookup never ran.
+        use crate::ast::TypeDef;
+        use crate::codegen::{CodegenContext, ModuleInfo};
+        use crate::ir::proof_ir::{Predicate, QuantifierType, RefinedTypeDecl};
+        use std::collections::{HashMap, HashSet};
+
+        let module = ModuleInfo {
+            prefix: "Mod".to_string(),
+            depends: Vec::new(),
+            type_defs: vec![TypeDef::Product {
+                name: "Natural".to_string(),
+                fields: vec![("value".to_string(), "Int".to_string())],
+                line: 1,
+            }],
+            fn_defs: Vec::new(),
+            analysis: None,
+        };
+
+        let make_decl = |param: &str, witness: &str| RefinedTypeDecl {
+            name: "Natural".to_string(),
+            carrier_type: "Int".to_string(),
+            carrier_field: "value".to_string(),
+            predicate_param: param.to_string(),
+            invariant: Predicate {
+                free_vars: vec![(param.to_string(), QuantifierType::Plain("Int".to_string()))],
+                expr: sb(Expr::Literal(Literal::Bool(true))),
+            },
+            witness: Some(witness.to_string()),
+        };
+
+        let mut ctx = CodegenContext {
+            items: Vec::new(),
+            fn_sigs: HashMap::new(),
+            memo_fns: HashSet::new(),
+            memo_safe_types: HashSet::new(),
+            type_defs: Vec::new(),
+            fn_defs: Vec::new(),
+            project_name: "scope-test".to_string(),
+            modules: vec![module],
+            module_prefixes: HashSet::new(),
+            #[cfg(feature = "runtime")]
+            policy: None,
+            emit_replay_runtime: false,
+            runtime_policy_from_env: false,
+            guest_entry: None,
+            emit_self_host_support: false,
+            extra_fn_defs: Vec::new(),
+            mutual_tco_members: HashSet::new(),
+            recursive_fns: HashSet::new(),
+            fn_analyses: HashMap::new(),
+            buffer_build_sinks: HashMap::new(),
+            buffer_fusion_sites: Vec::new(),
+            synthesized_buffered_fns: Vec::new(),
+            proof_ir: crate::ir::ProofIR::default(),
+        };
+        ctx.proof_ir
+            .refined_types
+            .insert("Natural".to_string(), make_decl("entry_n", "0"));
+        ctx.proof_ir
+            .refined_types
+            .insert("Mod.Natural".to_string(), make_decl("mod_n", "10"));
+
+        let from_module = find_refined_type_scoped(&ctx, "Natural", Some("Mod"))
+            .expect("Mod-scoped Natural lookup");
+        assert_eq!(
+            from_module.predicate_param, "mod_n",
+            "scope=Some(\"Mod\") + bare `Natural` must resolve to Mod.Natural, \
+             not entry's bare-keyed slot"
+        );
+
+        // Entry scope still resolves to entry's slot.
+        let from_entry =
+            find_refined_type_scoped(&ctx, "Natural", None).expect("entry Natural lookup");
+        assert_eq!(from_entry.predicate_param, "entry_n");
     }
 }

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -230,7 +230,7 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             )],
             expr: info.predicate.clone(),
         };
-        let witness = pick_witness(name, inputs, info.predicate, info.param_name);
+        let witness = pick_witness(name, inputs, info.predicate, info.param_name, module_prefix);
         ir.refined_types.insert(
             canonical_key,
             RefinedTypeDecl {
@@ -2685,47 +2685,85 @@ fn pick_witness(
     inputs: &ProofLowerInputs,
     predicate: &Spanned<Expr>,
     param_name: &str,
+    scope: Option<&str>,
 ) -> Option<String> {
-    let smart_ctor_name = inputs.entry_items.iter().find_map(|item| match item {
-        TopLevel::FnDef(fd)
-            if fd.return_type.starts_with("Result<")
-                && fd.return_type[7..].starts_with(type_name)
-                && fd.params.len() == 1 =>
-        {
-            Some(fd.name.clone())
-        }
-        _ => None,
-    });
+    // Smart-constructor + verify-block walk, scoped to the same
+    // module the type lives in. Refinement-via-opaque keeps record
+    // and constructor in the same module (the carrier field is
+    // opaque from outside), so this mirrors that constraint. Without
+    // the scope a module-B `Natural` with predicate `n >= 10` would
+    // pick up entry's `fromInt(0)` verify case, silently breaking
+    // the witness invariant.
+    let smart_ctor_name: Option<String> = match scope {
+        None => inputs.entry_items.iter().find_map(|item| match item {
+            TopLevel::FnDef(fd) if smart_ctor_matches(fd, type_name) => Some(fd.name.clone()),
+            _ => None,
+        }),
+        Some(prefix) => inputs
+            .dep_modules
+            .iter()
+            .find(|m| m.prefix == prefix)
+            .and_then(|m| {
+                m.fn_defs
+                    .iter()
+                    .find(|fd| smart_ctor_matches(fd, type_name))
+                    .map(|fd| fd.name.clone())
+            }),
+    };
     if let Some(smart_ctor_name) = smart_ctor_name {
-        for item in inputs.entry_items {
-            let TopLevel::Verify(vb) = item else {
-                continue;
-            };
-            if vb.fn_name != smart_ctor_name {
-                continue;
-            }
-            for (lhs, rhs) in &vb.cases {
-                if !is_result_ok(&rhs.node) {
-                    continue;
-                }
-                let Expr::FnCall(_, args) = &lhs.node else {
+        // Verify blocks live on `inputs.entry_items` only — `ModuleInfo`
+        // doesn't surface verify cases. Scoped verify-block walk would
+        // need a separate plumb that's not in `ProofLowerInputs` today.
+        // Restrict the verify-sample fast path to entry scope; module
+        // scopes fall through to the predicate-evaluation fallback,
+        // which now sweeps a wider range so non-trivial predicates
+        // (`n >= 10`) still get a real witness.
+        if scope.is_none() {
+            for item in inputs.entry_items {
+                let TopLevel::Verify(vb) = item else {
                     continue;
                 };
-                if args.len() != 1 {
+                if vb.fn_name != smart_ctor_name {
                     continue;
                 }
-                if let Some(lit) = literal_int_value(&args[0]) {
-                    return Some(lit);
+                for (lhs, rhs) in &vb.cases {
+                    if !is_result_ok(&rhs.node) {
+                        continue;
+                    }
+                    let Expr::FnCall(_, args) = &lhs.node else {
+                        continue;
+                    };
+                    if args.len() != 1 {
+                        continue;
+                    }
+                    if let Some(lit) = literal_int_value(&args[0]) {
+                        return Some(lit);
+                    }
                 }
             }
         }
     }
-    for candidate in [0i64, 1, -1] {
+    // Predicate-evaluation fallback. Sweep small magnitudes first
+    // (covers `n >= 0`, `n > 0`, `n != 0`) then climb in powers of
+    // ten to catch shapes like `n >= 10`, `n >= 100`, …; the latter
+    // are common refinement invariants (Positive-with-floor,
+    // ID-format bounds). Cap at 10^6 — below the i64 wrap-around
+    // cliff so eval stays exact, above any realistic refinement
+    // floor. Without the wider sweep, Dafny's `witness 0` fallback
+    // silently violates the predicate and the verify run fails on
+    // the type definition itself.
+    for candidate in [0i64, 1, -1, 10, 100, 1_000, 10_000, 100_000, 1_000_000] {
         if eval_int_bool_predicate(predicate, param_name, candidate) == Some(true) {
             return Some(candidate.to_string());
         }
     }
     None
+}
+
+fn smart_ctor_matches(fd: &FnDef, type_name: &str) -> bool {
+    fd.return_type.starts_with("Result<")
+        && fd.return_type[7..].starts_with(type_name)
+        && fd.params.len() == 1
 }
 
 fn is_result_ok(expr: &Expr) -> bool {

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -2109,6 +2109,50 @@ fn proof_export_cross_module_refined_types_keep_distinct_predicates() {
         "BBB.lean leaked AAA's predicate; got:\n{bbb_lean}"
     );
 
+    // Round-3 finding 1: the prior round only checked Lean. `pick_
+    // witness` was un-scoped and tried only `[0, 1, -1]` candidates,
+    // so `BBB.Natural`'s `n >= 10` got `witness = None` and Dafny
+    // silently fell back to `witness 0` — which violates the
+    // predicate. The scoped picker now (a) scopes the smart-ctor
+    // walk to the same module and (b) sweeps higher candidates.
+    let dafny_out = root.join("out-dafny");
+    let dafny_proof = Command::new(aver_bin)
+        .current_dir(&root)
+        .arg("proof")
+        .arg("entry.av")
+        .arg("--backend")
+        .arg("dafny")
+        .arg("-o")
+        .arg(&dafny_out)
+        .output()
+        .expect("aver proof --backend dafny");
+    assert!(
+        dafny_proof.status.success(),
+        "`aver proof --backend dafny` failed:\n{}",
+        format_output(&dafny_proof)
+    );
+
+    let aaa_dfy = std::fs::read_to_string(dafny_out.join("AAA.dfy")).expect("read AAA.dfy");
+    let bbb_dfy = std::fs::read_to_string(dafny_out.join("BBB.dfy")).expect("read BBB.dfy");
+
+    assert!(
+        aaa_dfy.contains("type Natural") && aaa_dfy.contains("n >= 0"),
+        "AAA.dfy must declare `type Natural` with `n >= 0`; got:\n{aaa_dfy}"
+    );
+    assert!(
+        bbb_dfy.contains("type Natural") && bbb_dfy.contains("n >= 10"),
+        "BBB.dfy must declare `type Natural` with `n >= 10`; got:\n{bbb_dfy}"
+    );
+    let bbb_witness_line = bbb_dfy
+        .lines()
+        .find(|l| l.contains("type Natural"))
+        .expect("BBB.dfy must declare `type Natural`");
+    assert!(
+        !bbb_witness_line.contains("witness 0"),
+        "BBB.Natural with `n >= 10` must NOT fall back to `witness 0`; \
+         got line:\n{bbb_witness_line}"
+    );
+
     let _ = std::fs::remove_dir_all(&root);
 }
 


### PR DESCRIPTION
## Summary

Three review findings from round 3, all in the same theme: proof-lower's canonical-naming boundary still leaked at three corners after #130 / #131 / #132.

- **F1 — `pick_witness` was un-scoped.** It walked `inputs.entry_items` for the smart constructor regardless of which module the type lived in, then only tried `[0, 1, -1]` as predicate-eval candidates. For `BBB.Natural` with `n >= 10` this produced `witness = None`; the Dafny emitter then fell back to `witness 0`, silently violating the predicate. Now scoped to the same module the record lives in (matches the `exposes opaque` constraint), with the candidate sweep climbing `[0, 1, -1, 10, 100, …, 1_000_000]` so realistic refinement floors land a real witness.

- **F2 — `find_refined_type_scoped` had the wrong lookup order.** Direct `refined_types.get(name)` ran before the scope-prefix lookup, so when entry and a dep module both declared a refined record of the same bare name, the module's emit pass would resolve to entry's slot. Order reversed: `scope.bare` runs first for bare names.

- **F3 — Two `refinement_info_for(...)`-via-full-walk holdouts.** `search_refinement_wrapper` and `when_is_redundant_with_refinement_lifts` both now route through `find_refined_type(ctx, name)` — i.e. they read the canonical IR decision `populate_refined_types` baked in instead of re-walking entry + every module. Removes the "first match wins" surface entirely from proof-semantics paths.

## Test plan

- [x] `cross_module_refined_types_keep_distinct_predicates` extended: asserts Dafny output (was Lean-only) and `BBB.Natural` (`n >= 10`) gets a witness ≠ 0 (manual check: emits `witness 10`).
- [x] New `find_refined_type_scoped_prefers_current_module_over_entry_collision` unit test pins the lookup-order fix.
- [x] `cargo test`: 1509 passing (was 1508), no regressions.
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)