### PR TITLE
codegen: canonical-key central resolver + sound witness + dafny-verify in tests (review round 4)

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -269,13 +269,13 @@ fn is_ok_constructor_with_identity(
 /// constructor predicate has to be discharged from `a`'s `when`
 /// clause inside the theorem type — which is exactly what the
 /// previous heuristic-laden auto-proof had to work around.
-pub fn refinement_lift_for_given<'a>(
+pub fn refinement_lift_for_given(
     given_name: &str,
     given_type: &str,
     lhs: &Spanned<Expr>,
     rhs: &Spanned<Expr>,
-    ctx: &'a CodegenContext,
-) -> Option<&'a str> {
+    ctx: &CodegenContext,
+) -> Option<String> {
     // Float carriers don't get lifted: `Int.add_comm` exists and is
     // universally provable in Lean's `Int` model, but `Float.add_
     // comm` doesn't hold across IEEE 754 — `NaN ≠ NaN` blows up
@@ -286,18 +286,25 @@ pub fn refinement_lift_for_given<'a>(
     if given_type == "Float" {
         return None;
     }
-    let mut result: Option<&'a str> = None;
+    // Round-4 finding 2: return the *canonical key* the IR uses
+    // (e.g. `AAA.Natural` for module-owned, bare `Natural` for
+    // entry), not the bare `TypeDef.name`. Downstream
+    // `strip_refinement_wrappers` / `when_is_redundant` / backend
+    // emit all key off this same identifier, so two modules with
+    // distinct refined `Natural` records can no longer merge under
+    // a single bare name.
+    let mut result: Option<String> = None;
     search_refinement_wrapper(lhs, given_name, given_type, ctx, &mut result);
     search_refinement_wrapper(rhs, given_name, given_type, ctx, &mut result);
     result
 }
 
-fn search_refinement_wrapper<'a>(
+fn search_refinement_wrapper(
     expr: &Spanned<Expr>,
     given_name: &str,
     given_type: &str,
-    ctx: &'a CodegenContext,
-    result: &mut Option<&'a str>,
+    ctx: &CodegenContext,
+    result: &mut Option<String>,
 ) {
     if result.is_some() {
         return;
@@ -309,37 +316,12 @@ fn search_refinement_wrapper<'a>(
                 &fvalue.node,
                 Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == given_name
             );
-            // Round-3 finding 3: route through the canonical IR
-            // decision instead of re-walking entry + every module
-            // via `refinement_info_for`. The unscoped re-walk
-            // returned whichever refined record walked first when
-            // two modules carried the same bare name, then the
-            // returned `name` was used downstream as if it identified
-            // a unique decl. `find_refined_type` resolves against
-            // `proof_ir.refined_types` which `populate_refined_types`
-            // already keyed by canonical `Module.Name`.
             if matches_var
-                && let Some(decl) = find_refined_type(ctx, type_name)
+                && let Some((canonical_key, decl)) = find_refined_type_with_key(ctx, type_name)
                 && decl.carrier_type == given_type
             {
-                // Need a stable reference into ctx for the returned
-                // &str. `refinement_info_for` returns refs into ctx
-                // already, but we want the *type name* itself; the
-                // name may live in `ctx.items` (standalone build) or
-                // in a dependent module's `type_defs` (cross-module).
-                let entry_tds = ctx.items.iter().filter_map(|i| match i {
-                    TopLevel::TypeDef(td) => Some(td),
-                    _ => None,
-                });
-                let module_tds = ctx.modules.iter().flat_map(|m| m.type_defs.iter());
-                for td in entry_tds.chain(module_tds) {
-                    if let TypeDef::Product { name, .. } = td
-                        && name == type_name
-                    {
-                        *result = Some(name.as_str());
-                        return;
-                    }
-                }
+                *result = Some(canonical_key);
+                return;
             }
             for (_, v) in fields {
                 search_refinement_wrapper(v, given_name, given_type, ctx, result);
@@ -463,6 +445,7 @@ fn project_lifted_ident_leaf(
 pub fn strip_refinement_wrappers(
     expr: &Spanned<Expr>,
     lifted_vars: &std::collections::HashMap<String, String>,
+    ctx: &CodegenContext,
 ) -> Spanned<Expr> {
     let new_node = match &expr.node {
         Expr::RecordCreate { type_name, fields } if fields.len() == 1 => {
@@ -471,15 +454,22 @@ pub fn strip_refinement_wrappers(
                 Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.clone()),
                 _ => None,
             };
+            // Round-4 finding 2: `lifted_vars[name]` holds the
+            // *canonical key* (`AAA.Natural` for module-owned, bare
+            // for entry). Canonicalise the AST's `type_name` against
+            // the same resolver so a bare `Natural` written inside a
+            // dep module strips against `AAA.Natural`, not the
+            // unrelated entry-bare slot of the same name.
+            let canonical_for_ast = find_refined_type_with_key(ctx, type_name).map(|(k, _)| k);
             if let Some(name) = var_name
                 && let Some(refined) = lifted_vars.get(&name)
-                && refined == type_name
+                && canonical_for_ast.as_deref() == Some(refined.as_str())
             {
                 return Spanned::new(Expr::Ident(name), expr.line);
             }
             let new_fields: Vec<(String, Spanned<Expr>)> = fields
                 .iter()
-                .map(|(n, v)| (n.clone(), strip_refinement_wrappers(v, lifted_vars)))
+                .map(|(n, v)| (n.clone(), strip_refinement_wrappers(v, lifted_vars, ctx)))
                 .collect();
             Expr::RecordCreate {
                 type_name: type_name.clone(),
@@ -487,22 +477,24 @@ pub fn strip_refinement_wrappers(
             }
         }
         Expr::FnCall(callee, args) => Expr::FnCall(
-            Box::new(strip_refinement_wrappers(callee, lifted_vars)),
+            Box::new(strip_refinement_wrappers(callee, lifted_vars, ctx)),
             args.iter()
-                .map(|a| strip_refinement_wrappers(a, lifted_vars))
+                .map(|a| strip_refinement_wrappers(a, lifted_vars, ctx))
                 .collect(),
         ),
         Expr::BinOp(op, l, r) => Expr::BinOp(
             *op,
-            Box::new(strip_refinement_wrappers(l, lifted_vars)),
-            Box::new(strip_refinement_wrappers(r, lifted_vars)),
+            Box::new(strip_refinement_wrappers(l, lifted_vars, ctx)),
+            Box::new(strip_refinement_wrappers(r, lifted_vars, ctx)),
         ),
         Expr::Attr(o, f) => Expr::Attr(
-            Box::new(strip_refinement_wrappers(o, lifted_vars)),
+            Box::new(strip_refinement_wrappers(o, lifted_vars, ctx)),
             f.clone(),
         ),
-        Expr::Neg(i) => Expr::Neg(Box::new(strip_refinement_wrappers(i, lifted_vars))),
-        Expr::ErrorProp(i) => Expr::ErrorProp(Box::new(strip_refinement_wrappers(i, lifted_vars))),
+        Expr::Neg(i) => Expr::Neg(Box::new(strip_refinement_wrappers(i, lifted_vars, ctx))),
+        Expr::ErrorProp(i) => {
+            Expr::ErrorProp(Box::new(strip_refinement_wrappers(i, lifted_vars, ctx)))
+        }
         _ => expr.node.clone(),
     };
     Spanned::new(new_node, expr.line)
@@ -813,7 +805,18 @@ pub fn find_refined_type<'a>(
     ctx: &'a CodegenContext,
     name: &str,
 ) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
-    find_refined_type_scoped(ctx, name, None)
+    find_refined_type_with_key_scoped(ctx, name, None).map(|(_, d)| d)
+}
+
+/// Canonical-key-aware resolver — returns `(canonical_key, decl)`
+/// so consumers thread one stable identifier through refinement
+/// lift / strip-wrappers / when-redundancy / backend emit instead
+/// of recomputing identity from bare AST names.
+pub fn find_refined_type_with_key<'a>(
+    ctx: &'a CodegenContext,
+    name: &str,
+) -> Option<(String, &'a crate::ir::proof_ir::RefinedTypeDecl)> {
+    find_refined_type_with_key_scoped(ctx, name, None)
 }
 
 /// Module-scope-aware variant of [`find_refined_type`]. When the
@@ -838,6 +841,18 @@ pub fn find_refined_type_scoped<'a>(
     name: &str,
     scope: Option<&str>,
 ) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
+    find_refined_type_with_key_scoped(ctx, name, scope).map(|(_, d)| d)
+}
+
+/// Round-4 central canonical resolver. Both `find_refined_type` and
+/// `find_refined_type_scoped` reduce to this. Returns the exact
+/// `(canonical_key, &decl)` pair stored in `ProofIR.refined_types`
+/// so downstream code can re-key safely (no string heuristics).
+pub fn find_refined_type_with_key_scoped<'a>(
+    ctx: &'a CodegenContext,
+    name: &str,
+    scope: Option<&str>,
+) -> Option<(String, &'a crate::ir::proof_ir::RefinedTypeDecl)> {
     let bare = name.rsplit('.').next().unwrap_or(name);
     let name_is_already_qualified = name.contains('.');
     if let Some(prefix) = scope
@@ -845,18 +860,18 @@ pub fn find_refined_type_scoped<'a>(
     {
         let scoped = format!("{}.{}", prefix, bare);
         if let Some(decl) = ctx.proof_ir.refined_types.get(&scoped) {
-            return Some(decl);
+            return Some((scoped, decl));
         }
     }
     if let Some(decl) = ctx.proof_ir.refined_types.get(name) {
-        return Some(decl);
+        return Some((name.to_string(), decl));
     }
     for m in &ctx.modules {
         for td in &m.type_defs {
             if type_def_name(td) == bare {
                 let canonical = format!("{}.{}", m.prefix, bare);
                 if let Some(decl) = ctx.proof_ir.refined_types.get(&canonical) {
-                    return Some(decl);
+                    return Some((canonical, decl));
                 }
             }
         }

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1366,7 +1366,18 @@ pub fn emit_verify_law(
         .iter()
         .map(|g| {
             if let Some(refined) = lifted_vars.get(&g.name) {
-                return format!("{}: {}", aver_name_to_dafny(&g.name), refined);
+                // `refined` is a canonical key — bare for entry
+                // types, `Module.Name` for module-owned. Translate
+                // the module prefix to Dafny's `Aver_Module.Name`
+                // form so the lemma signature picks up the actual
+                // module-emitted subset type.
+                let display = match refined.rsplit_once('.') {
+                    Some((prefix, bare)) => {
+                        format!("{}.{}", super::dafny_module_name(prefix), bare)
+                    }
+                    None => refined.clone(),
+                };
+                return format!("{}: {}", aver_name_to_dafny(&g.name), display);
             }
             // Oracle v1: if the given's "type" is a classified effect
             // reference (`Random.int`, `Http.get`, etc.), the param is
@@ -1411,8 +1422,8 @@ pub fn emit_verify_law(
         (law_lhs, law_rhs)
     } else {
         (
-            crate::codegen::common::strip_refinement_wrappers(&law_lhs, &lifted_vars),
-            crate::codegen::common::strip_refinement_wrappers(&law_rhs, &lifted_vars),
+            crate::codegen::common::strip_refinement_wrappers(&law_lhs, &lifted_vars, ctx),
+            crate::codegen::common::strip_refinement_wrappers(&law_rhs, &lifted_vars, ctx),
         )
     };
 

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1797,12 +1797,12 @@ fn emit_verify_law_block(
     let law_lhs = if lifted_vars.is_empty() {
         law_lhs
     } else {
-        crate::codegen::common::strip_refinement_wrappers(&law_lhs, &lifted_vars)
+        crate::codegen::common::strip_refinement_wrappers(&law_lhs, &lifted_vars, ctx)
     };
     let law_rhs = if lifted_vars.is_empty() {
         law_rhs
     } else {
-        crate::codegen::common::strip_refinement_wrappers(&law_rhs, &lifted_vars)
+        crate::codegen::common::strip_refinement_wrappers(&law_rhs, &lifted_vars, ctx)
     };
     let lhs_template = emit_expr(&law_lhs, ctx);
     let rhs_template = emit_expr(&law_rhs, ctx);

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -231,6 +231,17 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             expr: info.predicate.clone(),
         };
         let witness = pick_witness(name, inputs, info.predicate, info.param_name, module_prefix);
+        // Round-4 finding 1: a `None` witness means we couldn't
+        // exhibit any inhabitant satisfying the predicate. Inserting
+        // the slot anyway makes Dafny silently fall back to
+        // `witness 0` even when the predicate excludes 0 — producing
+        // an unsound subset type. Skip the lift entirely: the
+        // backend will emit a plain `datatype` instead, which is
+        // honest about the missing invariant. The pure-fn / law
+        // paths still typecheck against the plain record.
+        let Some(witness) = witness else {
+            continue;
+        };
         ir.refined_types.insert(
             canonical_key,
             RefinedTypeDecl {
@@ -239,7 +250,7 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
                 carrier_field: info.carrier_field.to_string(),
                 predicate_param: info.param_name.to_string(),
                 invariant,
-                witness,
+                witness: Some(witness),
             },
         );
     }
@@ -2743,16 +2754,34 @@ fn pick_witness(
             }
         }
     }
-    // Predicate-evaluation fallback. Sweep small magnitudes first
-    // (covers `n >= 0`, `n > 0`, `n != 0`) then climb in powers of
-    // ten to catch shapes like `n >= 10`, `n >= 100`, …; the latter
-    // are common refinement invariants (Positive-with-floor,
-    // ID-format bounds). Cap at 10^6 — below the i64 wrap-around
-    // cliff so eval stays exact, above any realistic refinement
-    // floor. Without the wider sweep, Dafny's `witness 0` fallback
-    // silently violates the predicate and the verify run fails on
-    // the type definition itself.
-    for candidate in [0i64, 1, -1, 10, 100, 1_000, 10_000, 100_000, 1_000_000] {
+    // Predicate-evaluation. Two-stage: first sweep candidates
+    // *extracted from the predicate AST itself* (any `Literal::Int`
+    // reachable through `BinOp` / `FnCall` chains, plus the
+    // neighbours `K`, `K-1`, `K+1` so `n == 5` / `n > 5` / `n < 5`
+    // all land their witness). Then fall back to a fixed magnitude
+    // sweep for shapes that don't mention concrete numbers
+    // (`n != 0`, `Bool.and(n >= 0, n <= max())`, …). Returning
+    // `None` here is intentional and `populate_refined_types`
+    // skips the slot — the alternative was Dafny silently emitting
+    // `witness 0` against a predicate the witness didn't satisfy.
+    let mut tried = std::collections::HashSet::<i64>::new();
+    let mut candidates: Vec<i64> = Vec::new();
+    let mut from_ast: Vec<i64> = Vec::new();
+    collect_int_literals(predicate, &mut from_ast);
+    for k in from_ast {
+        for delta in &[0_i64, 1, -1] {
+            if let Some(c) = k.checked_add(*delta) {
+                candidates.push(c);
+            }
+        }
+    }
+    candidates.extend_from_slice(&[
+        0, 1, -1, 2, -2, 10, -10, 100, 1_000, 10_000, 100_000, 1_000_000,
+    ]);
+    for candidate in candidates {
+        if !tried.insert(candidate) {
+            continue;
+        }
         if eval_int_bool_predicate(predicate, param_name, candidate) == Some(true) {
             return Some(candidate.to_string());
         }
@@ -2760,10 +2789,50 @@ fn pick_witness(
     None
 }
 
+fn collect_int_literals(expr: &Spanned<Expr>, out: &mut Vec<i64>) {
+    match &expr.node {
+        Expr::Literal(Literal::Int(n)) => out.push(*n),
+        Expr::Neg(inner) => {
+            if let Expr::Literal(Literal::Int(n)) = &inner.node {
+                out.push(-n);
+            } else {
+                collect_int_literals(inner, out);
+            }
+        }
+        Expr::BinOp(_, l, r) => {
+            collect_int_literals(l, out);
+            collect_int_literals(r, out);
+        }
+        Expr::FnCall(callee, args) => {
+            collect_int_literals(callee, out);
+            for a in args {
+                collect_int_literals(a, out);
+            }
+        }
+        Expr::Match { subject, arms } => {
+            collect_int_literals(subject, out);
+            for arm in arms {
+                collect_int_literals(&arm.body, out);
+            }
+        }
+        Expr::Attr(o, _) | Expr::ErrorProp(o) => collect_int_literals(o, out),
+        _ => {}
+    }
+}
+
 fn smart_ctor_matches(fd: &FnDef, type_name: &str) -> bool {
-    fd.return_type.starts_with("Result<")
-        && fd.return_type[7..].starts_with(type_name)
-        && fd.params.len() == 1
+    // Parse the return type instead of `starts_with`-matching its
+    // textual form — `Result<Nat, E>` would otherwise also match a
+    // type_name of `Natural` or any other `Nat*` prefix because the
+    // raw text starts with the same characters.
+    if fd.params.len() != 1 {
+        return false;
+    }
+    let parsed = crate::types::parse_type_str(&fd.return_type);
+    matches!(
+        parsed,
+        crate::types::Type::Result(ok, _) if matches!(&*ok, crate::types::Type::Named(n) if n == type_name)
+    )
 }
 
 fn is_result_ok(expr: &Expr) -> bool {

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -2153,6 +2153,27 @@ fn proof_export_cross_module_refined_types_keep_distinct_predicates() {
          got line:\n{bbb_witness_line}"
     );
 
+    // Round-4 finding 3: text checks aren't enough — the witness
+    // must actually satisfy the predicate or Dafny rejects the
+    // subset type at verify time. Run `dafny verify` on the
+    // generated project to catch unsound witnesses going forward.
+    // Skipped silently when dafny isn't on PATH (matches the
+    // pattern used by `assert_dafny_verifies`).
+    if Command::new("dafny").arg("--version").output().is_ok() {
+        let verify = Command::new("dafny")
+            .current_dir(&dafny_out)
+            .arg("verify")
+            .arg("Entry.dfy")
+            .output()
+            .expect("dafny verify");
+        assert!(
+            verify.status.success(),
+            "`dafny verify` rejected the cross-module refinement output \
+             — most likely a witness violates its predicate:\n{}",
+            format_output(&verify)
+        );
+    }
+
     let _ = std::fs::remove_dir_all(&root);
 }
 


### PR DESCRIPTION
## Summary

User question on the round-3 PR was \"jak to mozliwe\" — how does each round of review keep finding more. Diagnosis: previous PRs patched specific sites reactively but left the **identity model** of refined types as a tangle of bare-name string heuristics. Round-4 fixes that structurally.

### F1 — sound witness or no refinement

`pick_witness` now:
- Scopes the smart-constructor walk to the type's owning module (from round 3).
- Extracts candidate Int literals from the predicate AST itself plus their `±1` neighbours, so `n == 5`, `n >= 5`, `n > 5`, `Bool.and(n >= 0, n <= 9)` all land a witness their predicate accepts.
- Falls back to the prior magnitude sweep `[0, 1, -1, 2, -2, 10, ..., 1_000_000]` for predicates without literal numbers.

`populate_refined_types` SKIPS the slot entirely when `pick_witness` returns `None` — the backend then emits a plain `datatype` instead of an unsound subset type. Better an honest plain record than Dafny silently emitting `witness 0` against a predicate that excludes 0.

`smart_ctor_matches` parses `Result<X, E>` instead of `starts_with`-matching, so `Result<Nat, E>` no longer accidentally matches `type_name = \"Natural\"`.

### F2 — central `(canonical_key, &decl)` resolver

New `find_refined_type_with_key(ctx, name) -> Option<(String, &decl)>` returns the exact key `ProofIR.refined_types` stored the slot under. Everywhere downstream now threads canonical key instead of re-deriving identity from a bare name:

- `refinement_lift_for_given` returns the canonical key (was `&TypeDef.name`, bare).
- `strip_refinement_wrappers` re-canonicalises the AST `type_name` through the same resolver before comparing against `lifted_vars[given]`.
- `when_is_redundant_with_refinement_lifts` already reads decl from `find_refined_type` directly (canonical-key safe).
- Dafny lemma params translate `Module.Name` canonical keys to `Aver_Module.Name` so the generated lemma matches the actually-emitted subset type.

### F3 — cross-module test runs `dafny verify`

Previous round's text-match check would only catch the exact `>= 10 → witness 0` regression. The new test invokes `dafny verify` on the generated project so any future change producing an unsatisfiable subset type fails the test on the actual proof obligation, not a string heuristic.

## Test plan

- [x] Existing 1509 `cargo test` passing; one pre-existing flake at ~10% rate in `tests/explain_passes_spec` (race in nanos-based tempfile naming, shared across main and this branch).
- [x] `proof_export_cross_module_refined_types_keep_distinct_predicates` now invokes `dafny verify` on the AAA/BBB fixture.
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)