### PR TITLE
ir: typed identity keys (FnKey/TypeKey/LawKey) — bridge to a compiler-wide resolved IR

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -835,18 +835,26 @@ pub fn find_fn_contract_scoped<'a>(
     if let Some(prefix) = scope
         && !name_is_already_qualified
     {
-        let scoped = format!("{}.{}", prefix, bare);
-        if let Some(c) = ctx.proof_ir.fn_contracts.get(&scoped) {
+        let scoped_key = crate::ir::FnKey::in_module(prefix.to_string(), bare);
+        if let Some(c) = ctx.proof_ir.fn_contracts.get(&scoped_key) {
             return Some(c);
         }
     }
-    if let Some(c) = ctx.proof_ir.fn_contracts.get(name) {
+    // Direct `name`-as-given lookup: build entry key for bare,
+    // module key for already-qualified.
+    let direct_key =
+        if name_is_already_qualified && let Some((prefix, bare_part)) = name.rsplit_once('.') {
+            crate::ir::FnKey::in_module(prefix.to_string(), bare_part)
+        } else {
+            crate::ir::FnKey::entry(name)
+        };
+    if let Some(c) = ctx.proof_ir.fn_contracts.get(&direct_key) {
         return Some(c);
     }
     for m in &ctx.modules {
         for fd in &m.fn_defs {
             if fd.name == bare {
-                let canonical = format!("{}.{}", m.prefix, bare);
+                let canonical = crate::ir::FnKey::in_module(m.prefix.clone(), bare);
                 if let Some(c) = ctx.proof_ir.fn_contracts.get(&canonical) {
                     return Some(c);
                 }
@@ -868,15 +876,84 @@ pub fn fn_contract_exists_scoped(ctx: &CodegenContext, name: &str, scope: Option
     find_fn_contract_scoped(ctx, name, scope).is_some()
 }
 
+/// Round-7: build a [`crate::ir::FnKey`] from a borrowed `&FnDef`.
+/// The owning module is resolved by pointer-comparison against
+/// `ctx.modules[*].fn_defs` (entry items / synthesized variants /
+/// `extra_fn_defs` fall through to `FnKey::entry`). This is the
+/// single resolver consumers should reach for from emit code with
+/// a `&FnDef` in hand — produces the typed key the IR maps store
+/// instead of leaving the bare-name collision risk in place.
+pub fn fn_key_for_decl(ctx: &CodegenContext, fd: &FnDef) -> crate::ir::FnKey {
+    match fn_owning_scope_for(ctx, fd) {
+        Some(prefix) => crate::ir::FnKey::in_module(prefix.to_string(), fd.name.clone()),
+        None => crate::ir::FnKey::entry(fd.name.clone()),
+    }
+}
+
+/// Round-7: build a [`crate::ir::TypeKey`] from a borrowed
+/// `&TypeDef`. Same shape as [`fn_key_for_decl`] — pointer-eq
+/// against `ctx.modules[*].type_defs` resolves the owning module.
+pub fn type_key_for_decl(ctx: &CodegenContext, td: &TypeDef) -> crate::ir::TypeKey {
+    for m in &ctx.modules {
+        for t in &m.type_defs {
+            if std::ptr::eq(t, td) {
+                return crate::ir::TypeKey::in_module(m.prefix.clone(), type_def_name(td));
+            }
+        }
+    }
+    crate::ir::TypeKey::entry(type_def_name(td))
+}
+
+/// Round-7: resolve a (possibly bare) type name from the AST into
+/// a [`crate::ir::TypeKey`]. `scope` is the emit-time current scope
+/// (`Some(prefix)` inside a per-module emit loop, `None` for
+/// entry). Bare names prefer the current scope, then entry, then
+/// fall back to module-walk first match — mirroring
+/// [`find_refined_type_scoped`]'s resolution order.
+pub fn type_key_for_name(
+    ctx: &CodegenContext,
+    name: &str,
+    scope: Option<&str>,
+) -> crate::ir::TypeKey {
+    let bare = name.rsplit('.').next().unwrap_or(name);
+    let name_is_qualified = name.contains('.');
+    if let Some(prefix) = scope
+        && !name_is_qualified
+    {
+        for m in &ctx.modules {
+            if m.prefix == prefix && m.type_defs.iter().any(|td| type_def_name(td) == bare) {
+                return crate::ir::TypeKey::in_module(prefix.to_string(), bare);
+            }
+        }
+    }
+    // Entry-declared types win the bare lookup when no scope is
+    // active (or when scope's module doesn't own the name).
+    if !name_is_qualified && ctx.type_defs.iter().any(|td| type_def_name(td) == bare) {
+        return crate::ir::TypeKey::entry(bare);
+    }
+    if name_is_qualified
+        && let Some((prefix, bare_part)) = name.rsplit_once('.')
+        && ctx.modules.iter().any(|m| m.prefix == prefix)
+    {
+        return crate::ir::TypeKey::in_module(prefix.to_string(), bare_part);
+    }
+    for m in &ctx.modules {
+        if m.type_defs.iter().any(|td| type_def_name(td) == bare) {
+            return crate::ir::TypeKey::in_module(m.prefix.clone(), bare);
+        }
+    }
+    // Unresolved — fall back to entry key with the original text.
+    // Callers using this typically end up with a miss in the IR
+    // map, which is the same outcome as the pre-FnKey
+    // `find_refined_type` returning `None`.
+    crate::ir::TypeKey::entry(name)
+}
+
 /// Round-6: resolve a `&FnDef`'s owning scope by pointer comparison
-/// against `ctx.modules[*].fn_defs`. The bare-keyed `fn_owning_scope`
-/// helper collides when two modules export same-named fns (last
-/// insert wins), so emit-time callers that hold a borrowed `&FnDef`
-/// from one module's `fn_defs` couldn't use it to canonically
-/// resolve their own scope. Pointer-eq sidesteps the bare-name
-/// collision — `&CountdownA.fn_defs[0]` and `&CountdownB.fn_defs[0]`
-/// are *distinct* addresses even with `fd.name = "countdown"` in
-/// both.
+/// against `ctx.modules[*].fn_defs`. Pointer-eq sidesteps the
+/// bare-name collision — `&CountdownA.fn_defs[0]` and
+/// `&CountdownB.fn_defs[0]` are *distinct* addresses even with
+/// `fd.name = "countdown"` in both.
 ///
 /// Returns `None` when the `fd` is not in any dep module — entry
 /// items, synthesized buffered variants, and `extra_fn_defs` all
@@ -959,20 +1036,26 @@ pub fn find_refined_type_with_key_scoped<'a>(
     if let Some(prefix) = scope
         && !name_is_already_qualified
     {
-        let scoped = format!("{}.{}", prefix, bare);
-        if let Some(decl) = ctx.proof_ir.refined_types.get(&scoped) {
-            return Some((scoped, decl));
+        let scoped_key = crate::ir::TypeKey::in_module(prefix.to_string(), bare);
+        if let Some(decl) = ctx.proof_ir.refined_types.get(&scoped_key) {
+            return Some((scoped_key.canonical(), decl));
         }
     }
-    if let Some(decl) = ctx.proof_ir.refined_types.get(name) {
-        return Some((name.to_string(), decl));
+    let direct_key =
+        if name_is_already_qualified && let Some((prefix, bare_part)) = name.rsplit_once('.') {
+            crate::ir::TypeKey::in_module(prefix.to_string(), bare_part)
+        } else {
+            crate::ir::TypeKey::entry(name)
+        };
+    if let Some(decl) = ctx.proof_ir.refined_types.get(&direct_key) {
+        return Some((direct_key.canonical(), decl));
     }
     for m in &ctx.modules {
         for td in &m.type_defs {
             if type_def_name(td) == bare {
-                let canonical = format!("{}.{}", m.prefix, bare);
-                if let Some(decl) = ctx.proof_ir.refined_types.get(&canonical) {
-                    return Some((canonical, decl));
+                let canonical_key = crate::ir::TypeKey::in_module(m.prefix.clone(), bare);
+                if let Some(decl) = ctx.proof_ir.refined_types.get(&canonical_key) {
+                    return Some((canonical_key.canonical(), decl));
                 }
             }
         }
@@ -984,7 +1067,10 @@ pub fn find_refined_type_with_key_scoped<'a>(
 /// in-flight `refined_types` map plus dep-module list — used inside
 /// `proof_lower` where there is no `CodegenContext` yet.
 pub fn resolve_refined_type_in<'a>(
-    refined_types: &'a std::collections::HashMap<String, crate::ir::proof_ir::RefinedTypeDecl>,
+    refined_types: &'a std::collections::HashMap<
+        crate::ir::TypeKey,
+        crate::ir::proof_ir::RefinedTypeDecl,
+    >,
     modules: &[crate::codegen::ModuleInfo],
     name: &str,
 ) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
@@ -992,24 +1078,33 @@ pub fn resolve_refined_type_in<'a>(
 }
 
 /// Same as [`resolve_refined_type_in`] but returns the canonical
-/// key paired with the decl — used by IR-internal callers (the
-/// proof-lower side `walk_for_refinement_carrier`) so they
-/// thread the same canonical identifier through their boolean
-/// `.is_some()` checks today and any future load-bearing
-/// downstream use without re-introducing bare-name heuristics.
+/// `TypeKey` paired with the decl — used by IR-internal callers
+/// (the proof-lower side `walk_for_refinement_carrier`) so they
+/// thread the canonical identity through downstream comparisons
+/// without re-introducing bare-name heuristics.
 pub fn resolve_refined_type_in_with_key<'a>(
-    refined_types: &'a std::collections::HashMap<String, crate::ir::proof_ir::RefinedTypeDecl>,
+    refined_types: &'a std::collections::HashMap<
+        crate::ir::TypeKey,
+        crate::ir::proof_ir::RefinedTypeDecl,
+    >,
     modules: &[crate::codegen::ModuleInfo],
     name: &str,
-) -> Option<(String, &'a crate::ir::proof_ir::RefinedTypeDecl)> {
-    if let Some(decl) = refined_types.get(name) {
-        return Some((name.to_string(), decl));
-    }
+) -> Option<(crate::ir::TypeKey, &'a crate::ir::proof_ir::RefinedTypeDecl)> {
     let bare = name.rsplit('.').next().unwrap_or(name);
+    let name_is_already_qualified = name.contains('.');
+    let direct_key =
+        if name_is_already_qualified && let Some((prefix, bare_part)) = name.rsplit_once('.') {
+            crate::ir::TypeKey::in_module(prefix.to_string(), bare_part)
+        } else {
+            crate::ir::TypeKey::entry(name)
+        };
+    if let Some(decl) = refined_types.get(&direct_key) {
+        return Some((direct_key, decl));
+    }
     for m in modules {
         for td in &m.type_defs {
             if type_def_name(td) == bare {
-                let canonical = format!("{}.{}", m.prefix, bare);
+                let canonical = crate::ir::TypeKey::in_module(m.prefix.clone(), bare);
                 if let Some(decl) = refined_types.get(&canonical) {
                     return Some((canonical, decl));
                 }
@@ -2296,9 +2391,15 @@ mod tests {
             },
             witness: Some(witness.to_string()),
         };
-        let mut refined_types: HashMap<String, RefinedTypeDecl> = HashMap::new();
-        refined_types.insert("A.Natural".to_string(), make_decl("a", 0));
-        refined_types.insert("B.Natural".to_string(), make_decl("b", 10));
+        let mut refined_types: HashMap<crate::ir::TypeKey, RefinedTypeDecl> = HashMap::new();
+        refined_types.insert(
+            crate::ir::TypeKey::in_module("A", "Natural"),
+            make_decl("a", 0),
+        );
+        refined_types.insert(
+            crate::ir::TypeKey::in_module("B", "Natural"),
+            make_decl("b", 10),
+        );
 
         // Fully-qualified lookups hit the exact slot.
         let a = resolve_refined_type_in(&refined_types, &modules, "A.Natural")
@@ -2388,12 +2489,14 @@ mod tests {
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
         };
-        ctx.proof_ir
-            .refined_types
-            .insert("Natural".to_string(), make_decl("entry_n", "0"));
-        ctx.proof_ir
-            .refined_types
-            .insert("Mod.Natural".to_string(), make_decl("mod_n", "10"));
+        ctx.proof_ir.refined_types.insert(
+            crate::ir::TypeKey::entry("Natural"),
+            make_decl("entry_n", "0"),
+        );
+        ctx.proof_ir.refined_types.insert(
+            crate::ir::TypeKey::in_module("Mod", "Natural"),
+            make_decl("mod_n", "10"),
+        );
 
         let from_module = find_refined_type_scoped(&ctx, "Natural", Some("Mod"))
             .expect("Mod-scoped Natural lookup");

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -111,6 +111,12 @@ fn transpile_unified(ctx: &CodegenContext) -> ProjectOutput {
         crate::call_graph::ordered_fn_components(&mutual_fns_all, &ctx.module_prefixes);
 
     let mut fuel_per_scope: HashMap<String, Vec<String>> = HashMap::new();
+    // Round-7 follow-up: these three sets still key by bare fn name.
+    // Verify laws are entry-only per current model, so cross-module
+    // same-bare-name collision can't actually arise here today — but
+    // when laws-in-modules lands, migrate these to `HashSet<FnKey>`
+    // alongside `transitive_opaque_closure` and `emit_law_samples`
+    // signatures. Tracked as deferred from the FnKey/TypeKey PR.
     let mut fuel_emitted: HashSet<String> = HashSet::new();
     let mut native_emitted: HashSet<String> = HashSet::new();
     let mut axiom_fn_names: HashSet<String> = HashSet::new();

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -255,8 +255,8 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             continue;
         }
         let canonical_key = match module_prefix {
-            Some(prefix) => format!("{}.{}", prefix, name),
-            None => name.clone(),
+            Some(prefix) => crate::ir::TypeKey::in_module(prefix.to_string(), name),
+            None => crate::ir::TypeKey::entry(name),
         };
         if ir.refined_types.contains_key(&canonical_key) {
             // Same canonical key already populated — possible if a
@@ -347,10 +347,10 @@ fn populate_fn_contracts_for_scope(
     plans: &HashMap<String, RecursionPlan>,
 ) {
     let scoped_fns: Vec<&FnDef> = inputs.pure_fns_in_scope(scope);
-    let qualify = |bare: &str| -> String {
+    let qualify = |bare: &str| -> crate::ir::FnKey {
         match scope {
-            Some(prefix) => format!("{}.{}", prefix, bare),
-            None => bare.to_string(),
+            Some(prefix) => crate::ir::FnKey::in_module(prefix.to_string(), bare),
+            None => crate::ir::FnKey::entry(bare),
         }
     };
 
@@ -359,8 +359,7 @@ fn populate_fn_contracts_for_scope(
             continue;
         };
         // `fn_name` stays bare (used as `source_name` in each insert);
-        // `canonical_key` is the map key (`Module.fn` for module-scope,
-        // bare for entry-scope).
+        // `canonical_key` is the typed map key.
         let canonical_key = qualify(fn_name);
 
         // IntCountdown — fuel-encoded countdown on a single Int param.
@@ -680,7 +679,7 @@ fn classify_law_strategy(
     law: &crate::ast::VerifyLaw,
     fn_name: &str,
     inputs: &ProofLowerInputs,
-    refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
+    refined_types: &std::collections::HashMap<crate::ir::TypeKey, crate::ir::RefinedTypeDecl>,
 ) -> crate::ir::ProofStrategy {
     use crate::ir::ProofStrategy;
 
@@ -838,7 +837,7 @@ fn detect_simp_omega_unfold(
     law: &crate::ast::VerifyLaw,
     fn_name: &str,
     inputs: &ProofLowerInputs,
-    refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
+    refined_types: &std::collections::HashMap<crate::ir::TypeKey, crate::ir::RefinedTypeDecl>,
 ) -> Option<SimpOmegaPlan> {
     use std::collections::BTreeSet;
 
@@ -963,7 +962,7 @@ fn refinement_lift_for_given_ir(
     given_name: &str,
     lhs: &Spanned<crate::ast::Expr>,
     rhs: &Spanned<crate::ast::Expr>,
-    refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
+    refined_types: &std::collections::HashMap<crate::ir::TypeKey, crate::ir::RefinedTypeDecl>,
     dep_modules: &[crate::codegen::ModuleInfo],
 ) -> Option<String> {
     let mut result: Option<String> = None;
@@ -975,7 +974,7 @@ fn refinement_lift_for_given_ir(
 fn walk_for_refinement_carrier(
     expr: &Spanned<crate::ast::Expr>,
     given_name: &str,
-    refined_types: &std::collections::HashMap<String, crate::ir::RefinedTypeDecl>,
+    refined_types: &std::collections::HashMap<crate::ir::TypeKey, crate::ir::RefinedTypeDecl>,
     dep_modules: &[crate::codegen::ModuleInfo],
     result: &mut Option<String>,
 ) {
@@ -1007,7 +1006,7 @@ fn walk_for_refinement_carrier(
                 // the returned identifier inherits the same
                 // canonical guarantee `find_refined_type_with_key`
                 // gives the backend side.
-                *result = Some(canonical_key);
+                *result = Some(canonical_key.canonical());
                 return;
             }
             // Even non-matching RecordCreate may contain nested

--- a/src/ir/identity.rs
+++ b/src/ir/identity.rs
@@ -1,0 +1,157 @@
+//! Identity keys for named declarations.
+//!
+//! Aver source can declare the same bare name in two modules
+//! (`A.foo` and `B.foo` are distinct fns; `A.Natural` and
+//! `B.Natural` are distinct types). The typechecker keeps these
+//! straight at its boundary (`fn_sigs` is keyed by canonical
+//! `Module.name`), but downstream consumers — proof IR, backends,
+//! the VM bytecode lowerer — historically threaded bare `String`s
+//! around and re-derived identity from `fd.name` at every lookup.
+//! That produced a steady drip of "two same-bare-name fns get the
+//! wrong contract / refinement / strategy" bugs (review rounds 1-6
+//! of the proof-export audit).
+//!
+//! `FnKey` / `TypeKey` / `LawKey` are the typed replacements.
+//! Identity is resolved **once** at the IR boundary (today: the
+//! `proof_lower` stage); from there backends consume the key
+//! directly. The compiler refuses to compare a key to a bare
+//! `String`, so the bug class can no longer be expressed.
+//!
+//! These types live in `crate::ir` rather than `crate::ir::proof_ir`
+//! because identity-across-module-boundary is a general IR concern,
+//! not a proof-specific one. The proof flow is the first consumer;
+//! future cross-module identity sites (VM call-site resolution,
+//! Rust codegen multi-module module-fn lookups) will use the same
+//! types.
+
+/// Canonical identity for a user-defined function across the IR
+/// boundary. `scope = None` is the entry file; `scope = Some(prefix)`
+/// names a dep module (`"ModuleA"`, `"Models.User"`, …). `name`
+/// is the bare source name. Two modules each declaring a `foo`
+/// produce distinct `FnKey { scope: Some("A"), name: "foo" }` and
+/// `FnKey { scope: Some("B"), name: "foo" }` keys.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct FnKey {
+    pub scope: Option<String>,
+    pub name: String,
+}
+
+impl FnKey {
+    /// Entry-scope (None) constructor.
+    pub fn entry(name: impl Into<String>) -> Self {
+        Self {
+            scope: None,
+            name: name.into(),
+        }
+    }
+
+    /// Module-scope constructor.
+    pub fn in_module(prefix: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            scope: Some(prefix.into()),
+            name: name.into(),
+        }
+    }
+
+    /// Canonical text form: `Module.name` for module-scoped fns,
+    /// bare `name` for entry. Use this only when crossing an
+    /// interop boundary (Lean qualified imports, Dafny
+    /// `Aver_Module.fn` references) — internal IR / backend logic
+    /// should keep operating on the typed key.
+    pub fn canonical(&self) -> String {
+        match &self.scope {
+            Some(prefix) => format!("{}.{}", prefix, self.name),
+            None => self.name.clone(),
+        }
+    }
+
+    /// Scope as a borrowed `&str` for callers that just need to
+    /// branch on entry vs module without taking ownership.
+    pub fn scope_str(&self) -> Option<&str> {
+        self.scope.as_deref()
+    }
+}
+
+/// Canonical identity for a user-defined type — same shape and
+/// reasoning as [`FnKey`]. Refined records, sum types, and opaque
+/// records all live in the IR keyed by `TypeKey` so a bare AST
+/// reference (`Expr::RecordCreate { type_name: "Natural" }`) is
+/// resolved once at the IR boundary against the caller's owning
+/// scope, never re-resolved per emit site.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct TypeKey {
+    pub scope: Option<String>,
+    pub name: String,
+}
+
+impl TypeKey {
+    pub fn entry(name: impl Into<String>) -> Self {
+        Self {
+            scope: None,
+            name: name.into(),
+        }
+    }
+
+    pub fn in_module(prefix: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            scope: Some(prefix.into()),
+            name: name.into(),
+        }
+    }
+
+    pub fn canonical(&self) -> String {
+        match &self.scope {
+            Some(prefix) => format!("{}.{}", prefix, self.name),
+            None => self.name.clone(),
+        }
+    }
+
+    pub fn scope_str(&self) -> Option<&str> {
+        self.scope.as_deref()
+    }
+}
+
+/// Canonical identity for a verify-law theorem. Targets a fn by
+/// [`FnKey`]; the `law_name` is local to that fn (Aver's
+/// `verify <fn> law <law_name>` syntax — names only collide within
+/// one fn's verify block).
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct LawKey {
+    pub fn_key: FnKey,
+    pub law_name: String,
+}
+
+impl LawKey {
+    pub fn new(fn_key: FnKey, law_name: impl Into<String>) -> Self {
+        Self {
+            fn_key,
+            law_name: law_name.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fn_key_canonical_distinguishes_entry_from_module() {
+        let entry = FnKey::entry("foo");
+        let in_a = FnKey::in_module("A", "foo");
+        let in_b = FnKey::in_module("B", "foo");
+        assert_eq!(entry.canonical(), "foo");
+        assert_eq!(in_a.canonical(), "A.foo");
+        assert_eq!(in_b.canonical(), "B.foo");
+        // The Hash + Eq contract distinguishes them — that's the
+        // entire point of the type.
+        assert_ne!(entry, in_a);
+        assert_ne!(in_a, in_b);
+    }
+
+    #[test]
+    fn nested_module_prefix_round_trips_through_canonical() {
+        let key = FnKey::in_module("Models.User", "freshId");
+        assert_eq!(key.canonical(), "Models.User.freshId");
+        assert_eq!(key.scope_str(), Some("Models.User"));
+    }
+}

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -6,6 +6,7 @@ mod buffer_build;
 mod calls;
 pub mod dump;
 pub mod escape;
+pub mod identity;
 mod interp_lower;
 pub mod last_use;
 mod leaf;
@@ -16,6 +17,7 @@ pub mod proof_ir;
 pub mod vars;
 
 pub use analyze::{AnalysisResult, BodyShape, FnAnalysis, NeutralAllocPolicy, analyze};
+pub use identity::{FnKey, LawKey, TypeKey};
 pub use pipeline::{
     FnCountChange, NonTailEntry, PassDiagnostic, PassReport, PipelineConfig, PipelineResult,
     PipelineStage, TypecheckMode,

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -23,6 +23,15 @@ use std::collections::HashMap;
 
 use crate::ast::Spanned;
 
+// Identity keys for named declarations crossing module boundaries
+// (`FnKey`, `TypeKey`, `LawKey`) live in `crate::ir::identity` —
+// they're general identity primitives, not proof-specific. Today's
+// proof flow is where the bare-string bug class first surfaced
+// (reviewer rounds 5/6), but other backends with multi-module emit
+// (VM, Rust codegen, WASM) will reach for the same types when they
+// hit the same bug class. Re-exported here for ergonomics.
+pub use crate::ir::identity::{FnKey, LawKey, TypeKey};
+
 /// Output of the `proof_lower` pipeline stage. Every decision the
 /// proof backends will make is materialised here; backends become
 /// pure renderers.
@@ -33,15 +42,18 @@ use crate::ast::Spanned;
 /// untyped AST path, same as runtime backends (VM, Rust, WASM).
 #[derive(Debug, Clone, Default)]
 pub struct ProofIR {
-    /// Every refinement-lifted user type, keyed by canonical type
-    /// name (`Module.Natural` or bare `Natural` when no enclosing
-    /// module). Includes types declared in the entry items and in
-    /// dependent modules — the lowerer normalises both into the
-    /// same map so backends don't have to walk two corpora.
-    pub refined_types: HashMap<String, RefinedTypeDecl>,
+    /// Every refinement-lifted user type, keyed by [`TypeKey`].
+    /// Two modules with same-bare-name refined records (`A.Natural`
+    /// and `B.Natural`) get distinct keys so their predicates never
+    /// merge. Includes types declared in the entry items and in
+    /// dependent modules.
+    pub refined_types: HashMap<TypeKey, RefinedTypeDecl>,
     /// Per-pure-fn contract describing what proof artifact the fn
     /// lowers to (native / fuel / structural / linear recurrence).
-    pub fn_contracts: HashMap<String, FnContract>,
+    /// Keyed by [`FnKey`] so two modules with same-bare-name fns
+    /// (`A.foo` IntCountdown + `B.foo` ListStructural) hold their
+    /// own contracts without collision.
+    pub fn_contracts: HashMap<FnKey, FnContract>,
     /// Per-verify-law theorem decomposed into quantifiers, premises,
     /// and claim with all wrapper-strip / val-projection / drop-vs-
     /// keep decisions baked in, plus the pinned proof strategy.

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -266,7 +266,7 @@ fn fib_tr_native_contract_matches_legacy_recursion_plan() {
     let contract = ctx
         .proof_ir
         .fn_contracts
-        .get("fibTR")
+        .get(&aver::ir::FnKey::entry("fibTR"))
         .unwrap_or_else(|| panic!("fibTR has no FnContract in ProofIR"));
     let RecursionContract::Native {
         precondition,
@@ -382,7 +382,7 @@ fn exposed_int_countdown_lowers_to_fuel_contract() {
     let contract = ctx
         .proof_ir
         .fn_contracts
-        .get("exposed_count")
+        .get(&aver::ir::FnKey::entry("exposed_count"))
         .expect("exposed_count has no FnContract in ProofIR");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
@@ -446,7 +446,7 @@ fn int_ascending_lowers_to_bound_fuel_contract() {
     let contract = ctx
         .proof_ir
         .fn_contracts
-        .get("climb")
+        .get(&aver::ir::FnKey::entry("climb"))
         .expect("climb has no FnContract");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
@@ -508,7 +508,7 @@ fn list_structural_lowers_to_seq_len_fuel_contract() {
     let contract = ctx
         .proof_ir
         .fn_contracts
-        .get("len")
+        .get(&aver::ir::FnKey::entry("len"))
         .expect("len has no FnContract");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
@@ -561,7 +561,7 @@ fn sizeof_structural_lowers_to_sizeof_fuel_contract() {
     let contract = ctx
         .proof_ir
         .fn_contracts
-        .get("count")
+        .get(&aver::ir::FnKey::entry("count"))
         .expect("count has no FnContract");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
@@ -601,7 +601,7 @@ fn string_pos_advance_lowers_to_string_pos_fuel_contract() {
     let contract = ctx
         .proof_ir
         .fn_contracts
-        .get("walk")
+        .get(&aver::ir::FnKey::entry("walk"))
         .expect("walk has no FnContract");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
@@ -666,7 +666,7 @@ fn mutual_int_countdown_lowers_to_lex_fuel_contract() {
         let contract = ctx
             .proof_ir
             .fn_contracts
-            .get(fn_name)
+            .get(&aver::ir::FnKey::entry(fn_name))
             .unwrap_or_else(|| panic!("{} has no FnContract", fn_name));
         let RecursionContract::Fuel { fuel_metric } = contract
             .recursion
@@ -715,7 +715,7 @@ fn linear_recurrence_lowers_to_dedicated_contract() {
     let contract = ctx
         .proof_ir
         .fn_contracts
-        .get("fib")
+        .get(&aver::ir::FnKey::entry("fib"))
         .expect("fib has no FnContract");
     assert!(
         matches!(


### PR DESCRIPTION
## Summary

Six rounds of reviewer audit kept finding variations of the same class: backends had `HashMap<String, T>` and `HashSet<String>` keyed by bare fn / type names, then re-derived identity from `fd.name` / `td.name` / `vb.fn_name` at every lookup. Each round patched one site; the next round found another. The underlying type system permitted the bug — comparing a bare name to a canonical key was a normal `String::eq` call away.

## The bridge

Typed identity primitives in `crate::ir::identity`:

```rust
pub struct FnKey   { pub scope: Option<String>, pub name: String }
pub struct TypeKey { pub scope: Option<String>, pub name: String }
pub struct LawKey  { pub fn_key: FnKey, pub law_name: String }
```

These are **general compiler primitives**, not proof-specific. Identity-across-module-boundary is the same problem in any pass that operates on multi-module input; the proof flow is where today's bugs surface most loudly because it has the most cross-module HashMaps.

## Applied today

- `ProofIR.fn_contracts: HashMap<FnKey, FnContract>`
- `ProofIR.refined_types: HashMap<TypeKey, RefinedTypeDecl>`
- `populate_fn_contracts_for_scope` builds canonical keys at the IR boundary — no bare-name lookups downstream.
- `find_fn_contract_scoped` / `find_refined_type_with_key_scoped` / `resolve_refined_type_in*` consume typed keys internally; external API still takes `&str` for ergonomics, but each callsite resolves to the right typed key once.
- Single resolvers from emit code: `fn_key_for_decl(ctx, fd)`, `type_key_for_decl(ctx, td)`, `type_key_for_name(ctx, name, scope)`.

## Deferred to follow-up

- `LawTheorem.fn_name: String` stays bare — verify laws are entry-only per current model, no cross-module collision today.
- Dafny `fuel_emitted` / `native_emitted` / `axiom_fn_names` `HashSet<String>` stay bare for the same reason. TODO comment in `dafny/mod.rs` points at the migration path when laws-in-modules lands.
- Constructor identity (`CtorKey`), wider AST migration to resolved `FnId` / `TypeId` (the semantic-IR layer the reviewer outlined) — separate future work.

## This is the bridge, not the destination

The destination per reviewer's plan: parser-emits-strings → module/name resolution → resolved IR with stable IDs → every downstream pass (typechecker, proof lowering, codegen, opaque checks, recursion analysis) consumes IDs. Today's PR makes the bridge typed enough that the bug class can no longer be expressed in the IR maps that already crossed the boundary; follow-ups extend the same discipline outward.

## Test plan

- [x] `cargo test`: 1513 passing (was 1511), no regressions.
- [x] All existing cross-module tests (refined-predicates, same-shape-fn_contracts, differentiated-shapes) pass against the typed maps.
- [x] `cargo fmt --all -- --check` clean.
- [x] Unit test in `ir::identity` pinning canonical-key roundtrip and entry-vs-module distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)