### PR TITLE
ir/proof: migrate LawTheorem.fn_name to FnKey (issue #138 phase A.2)

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1281,11 +1281,12 @@ pub fn emit_verify_law(
     // BackendDispatch / Sorry don't close constant-RHS shapes;
     // anything else (Reflexive, Associative, MapUpdatePostcondition,
     // …) does and stays. Mirror of the Lean gate.
+    let vb_fn_key = crate::ir::FnKey::entry(&vb.fn_name);
     let ir_strategy_closes_const_rhs = ctx
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == vb.fn_name && t.law_name == law.name)
+        .find(|t| t.fn_key == vb_fn_key && t.law_name == law.name)
         .is_some_and(|t| {
             !matches!(
                 t.strategy,
@@ -1334,7 +1335,7 @@ pub fn emit_verify_law(
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == vb.fn_name && t.law_name == law.name)
+        .find(|t| t.fn_key == crate::ir::FnKey::entry(&vb.fn_name) && t.law_name == law.name)
         .map(|t| t.strategy.clone())
     {
         return emit_linear_recurrence2_support_stack(

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -30,10 +30,11 @@ fn law_strategy_for(
     fn_name: &str,
     law_name: &str,
 ) -> Option<crate::ir::ProofStrategy> {
+    let key = crate::ir::FnKey::entry(fn_name);
     ctx.proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == fn_name && t.law_name == law_name)
+        .find(|t| t.fn_key == key && t.law_name == law_name)
         .map(|t| t.strategy.clone())
 }
 

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1896,11 +1896,12 @@ fn emit_verify_law_block(
     // constant-RHS shapes (Reflexive, Commutative, Associative,
     // MapUpdatePostcondition, …) stay in the keep-set; Induction
     // / BackendDispatch / Sorry don't.
+    let vb_fn_key = crate::ir::FnKey::entry(&vb.fn_name);
     let ir_strategy_closes_const_rhs = ctx
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == vb.fn_name && t.law_name == law.name)
+        .find(|t| t.fn_key == vb_fn_key && t.law_name == law.name)
         .is_some_and(|t| {
             !matches!(
                 t.strategy,

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -646,7 +646,10 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
         let strategy = classify_law_strategy(law, &vb.fn_name, inputs, &ir.refined_types);
 
         ir.law_theorems.push(LawTheorem {
-            fn_name: vb.fn_name.clone(),
+            // Verify laws are entry-only per current model — see
+            // `LawTheorem.fn_key` doc. The bare `vb.fn_name` from
+            // the source AST becomes an entry-scope `FnKey`.
+            fn_key: crate::ir::FnKey::entry(vb.fn_name.clone()),
             law_name: law.name.clone(),
             quantifiers,
             premises,

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -292,7 +292,13 @@ pub enum DecreaseProof {
 /// already baked into the fields below; backends render directly.
 #[derive(Debug, Clone)]
 pub struct LawTheorem {
-    pub fn_name: String,
+    /// Round-7+: typed identity for the fn this law targets. Verify
+    /// laws are entry-only per the current model, so the key's
+    /// scope is effectively always `None` today — keying via
+    /// [`FnKey`] is the discipline marker, ready for laws in dep
+    /// modules once that feature lands. Callsites compare against
+    /// the typed key, not a bare string.
+    pub fn_key: FnKey,
     pub law_name: String,
     pub quantifiers: Vec<Quantifier>,
     /// Premises in order. Already includes `when` if it carries

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -3275,12 +3275,14 @@ fn render_proof_ir_dump(ir: &aver::ir::ProofIR) -> String {
     writeln!(out).unwrap();
     writeln!(out, "## law_theorems ({})", ir.law_theorems.len()).unwrap();
     let mut laws: Vec<_> = ir.law_theorems.iter().collect();
-    laws.sort_by(|a, b| (&a.fn_name, &a.law_name).cmp(&(&b.fn_name, &b.law_name)));
+    laws.sort_by(|a, b| {
+        (a.fn_key.canonical(), &a.law_name).cmp(&(b.fn_key.canonical(), &b.law_name))
+    });
     for theorem in laws {
         writeln!(
             out,
             "- {}::{} ({:?}, {} quantifier(s), {} premise(s))",
-            theorem.fn_name,
+            theorem.fn_key.canonical(),
             theorem.law_name,
             theorem.strategy,
             theorem.quantifiers.len(),

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -752,7 +752,7 @@ fn law_lower_populates_theorems_from_verify_law_blocks() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "add" && t.law_name == "commutative")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("add") && t.law_name == "commutative")
         .expect("add::commutative law theorem missing from ProofIR");
 
     assert_eq!(theorem.quantifiers.len(), 2, "expected 2 quantifiers");
@@ -802,7 +802,7 @@ fn reflexive_law_pinned_when_lhs_equals_rhs() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "id" && t.law_name == "reflexive")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("id") && t.law_name == "reflexive")
         .expect("id::reflexive law theorem missing from ProofIR");
     assert!(
         matches!(theorem.strategy, aver::ir::ProofStrategy::Reflexive),
@@ -831,7 +831,7 @@ fn wrapper_associative_pinned_on_three_int_givens_assoc_shape() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "add" && t.law_name == "associative")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("add") && t.law_name == "associative")
         .expect("add::associative law theorem missing");
     assert!(
         matches!(
@@ -864,7 +864,7 @@ fn wrapper_identity_pinned_on_add_with_zero_rhs() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "add" && t.law_name == "identityZero")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("add") && t.law_name == "identityZero")
         .expect("add::identityZero law theorem missing");
     assert!(
         matches!(
@@ -897,7 +897,7 @@ fn wrapper_sub_right_identity_pinned_on_sub_with_zero_rhs() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "sub" && t.law_name == "rightIdentity")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("sub") && t.law_name == "rightIdentity")
         .expect("sub::rightIdentity law theorem missing");
     assert!(
         matches!(
@@ -931,7 +931,7 @@ fn wrapper_sub_anti_commutative_pinned_with_neg_direction() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "sub" && t.law_name == "antiCommutative")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("sub") && t.law_name == "antiCommutative")
         .expect("sub::antiCommutative law theorem missing");
     assert!(
         matches!(
@@ -970,7 +970,7 @@ fn wrapper_unary_equivalence_pinned_with_inner_fn_name() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "addOne" && t.law_name == "identityViaAdd")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("addOne") && t.law_name == "identityViaAdd")
         .expect("addOne::identityViaAdd law theorem missing");
     let aver::ir::ProofStrategy::UnaryEqualsBinary { ref inner_fn } = theorem.strategy else {
         panic!("expected UnaryEqualsBinary, got: {:?}", theorem.strategy);
@@ -1000,7 +1000,7 @@ fn simp_omega_unfold_pinned_on_sub_anti_comm_via_zero() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "sub" && t.law_name == "antiCommutative")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("sub") && t.law_name == "antiCommutative")
         .expect("sub::antiCommutative law theorem missing");
     let aver::ir::ProofStrategy::LinearArithmetic {
         ref unfold_fns,
@@ -1051,7 +1051,7 @@ fn linear_arithmetic_pinned_with_lifted_for_refinement_law() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "add" && t.law_name == "commutative")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("add") && t.law_name == "commutative")
         .expect("add::commutative law theorem missing");
     let aver::ir::ProofStrategy::LinearArithmetic {
         wrapper_return,
@@ -1093,7 +1093,7 @@ fn induction_pinned_on_recursive_adt_given() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "id" && t.law_name == "identity")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("id") && t.law_name == "identity")
         .expect("id::identity law theorem missing");
     let aver::ir::ProofStrategy::Induction { ref param } = theorem.strategy else {
         panic!(
@@ -1125,7 +1125,7 @@ fn library_axiom_pinned_on_map_has_set_self() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "touch" && t.law_name == "hasAfterSet")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("touch") && t.law_name == "hasAfterSet")
         .expect("touch::hasAfterSet law theorem missing");
     let aver::ir::ProofStrategy::LibraryAxiom {
         ref axiom,
@@ -1162,7 +1162,7 @@ fn map_update_postcondition_pinned_has_after() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "incCount" && t.law_name == "keyPresent")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("incCount") && t.law_name == "keyPresent")
         .expect("incCount::keyPresent law theorem missing");
     let aver::ir::ProofStrategy::MapUpdatePostcondition {
         ref outer_fn,
@@ -1209,7 +1209,9 @@ fn map_update_postcondition_pinned_get_after_with_helper_unfolds() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "incCount" && t.law_name == "existingKeyIncrements")
+        .find(|t| {
+            t.fn_key == aver::ir::FnKey::entry("incCount") && t.law_name == "existingKeyIncrements"
+        })
         .expect("incCount::existingKeyIncrements law theorem missing");
     let aver::ir::ProofStrategy::MapUpdatePostcondition {
         ref outer_fn,
@@ -1257,7 +1259,9 @@ fn map_key_tracked_increment_pinned_on_defaulted_get_plus_one() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "incCount" && t.law_name == "trackedCountStepsByOne")
+        .find(|t| {
+            t.fn_key == aver::ir::FnKey::entry("incCount") && t.law_name == "trackedCountStepsByOne"
+        })
         .expect("incCount::trackedCountStepsByOne law theorem missing");
     let aver::ir::ProofStrategy::MapKeyTrackedIncrement { ref outer_fn, .. } = theorem.strategy
     else {
@@ -1295,7 +1299,7 @@ fn spec_equivalence_pinned_on_identical_body_impl_spec_pair() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "absVal" && t.law_name == "absValSpec")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("absVal") && t.law_name == "absValSpec")
         .expect("absVal::absValSpec law theorem missing");
     let aver::ir::ProofStrategy::SpecEquivalence { ref extra_unfolds } = theorem.strategy else {
         panic!("expected SpecEquivalence, got: {:?}", theorem.strategy);
@@ -1337,7 +1341,7 @@ fn effectful_spec_equivalence_pinned_post_oracle_lift() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "pickPair" && t.law_name == "branchPathLaw")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("pickPair") && t.law_name == "branchPathLaw")
         .expect("pickPair::branchPathLaw law theorem missing");
     let aver::ir::ProofStrategy::EffectfulSpecEquivalence {
         ref impl_fn,
@@ -1377,7 +1381,7 @@ fn simp_normalized_spec_equivalence_pinned_on_arithmetic_identity_gap() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "square" && t.law_name == "squareSpec")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("square") && t.law_name == "squareSpec")
         .expect("square::squareSpec law theorem missing");
     let aver::ir::ProofStrategy::SpecEquivalenceSimpNormalized { ref extra_unfolds } =
         theorem.strategy
@@ -1421,7 +1425,7 @@ fn linear_int_spec_equivalence_pinned_on_commutative_addition() {
         .proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_name == "addOne" && t.law_name == "addOneSpec")
+        .find(|t| t.fn_key == aver::ir::FnKey::entry("addOne") && t.law_name == "addOneSpec")
         .expect("addOne::addOneSpec law theorem missing");
     let aver::ir::ProofStrategy::LinearIntSpecEquivalence {
         ref unfolded_impl,


### PR DESCRIPTION
## Summary

First incremental cut of the long-term plan tracked in #138 (\"resolved identity layer\"). `LawTheorem.fn_name: String` → `LawTheorem.fn_key: FnKey`. Verify laws are entry-only per current model so the key's scope is always `None` today — keying via `FnKey` is the discipline marker, ready for laws-in-modules without re-touching every comparison site.

## Changed

- `LawTheorem.fn_name: String` → `LawTheorem.fn_key: FnKey`.
- `populate_law_theorems` builds `FnKey::entry(vb.fn_name)` once at the IR boundary.
- 4 lookup sites switched: `lean::law_auto::law_strategy_for`, `lean::toplevel::emit_verify_law_block` (round-3 const-RHS gate), `dafny::toplevel::emit_verify_law` (twin gate + LinearRecurrence2 lookup).
- `--emit-ir-after=law_lower` dump in `main::commands` sorts + prints by `fn_key.canonical()` so the output text shape stays the same.
- `tests/proof_ir_diff` lookups updated (18 sites).

## Out-of-scope (per #138 phase plan)

- **Dafny emit sets** (`fuel_emitted` / `native_emitted` / `axiom_fn_names`). They drive `transitive_opaque_closure` which walks callee bare names from law body; full migration needs the resolved-IR layer (#138 phase E) to map bare callee → FnKey deterministically. Today's TODO comment in `dafny/mod.rs` stays as the marker.
- **`CtorKey`** (phase A.3) — separate PR.

## Test plan

- [x] `cargo test`: 1513 passing (unchanged), no regressions.
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)