### PR TITLE
ir: wire SymbolTable into pipeline + CodegenContext (#138 phase E follow-up)

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -2488,6 +2488,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
+            symbol_table: None,
         };
         ctx.proof_ir.refined_types.insert(
             crate::ir::TypeKey::entry("Natural"),

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -695,6 +695,7 @@ mod tests {
                 run_refinement_lower: true,
                 run_contract_lower: true,
                 run_law_lower: true,
+                run_build_symbols: false,
                 dep_modules: &[],
                 alloc_policy: None,
                 call_ctx: None,

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -201,6 +201,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
+            symbol_table: None,
         }
     }
 

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1543,6 +1543,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
+            symbol_table: None,
         }
     }
 
@@ -1570,6 +1571,7 @@ mod tests {
                 run_refinement_lower: true,
                 run_contract_lower: true,
                 run_law_lower: true,
+                run_build_symbols: false,
                 dep_modules: &[],
                 alloc_policy: None,
                 call_ctx: None,

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -121,6 +121,13 @@ pub struct CodegenContext {
     /// `refinement_info_for` for now. Step 3+ migrates backends.
     #[cfg(feature = "runtime")]
     pub proof_ir: crate::ir::ProofIR,
+    /// Resolved-identity table (#138 phase E). `Some` when the
+    /// pipeline's `run_build_symbols` was on. No consumer reads
+    /// it through this field yet — production callers populate
+    /// it so downstream migration PRs (proof IR maps keyed by
+    /// `FnId`, backend `FnId → name` mangling) can wire in
+    /// without re-running name resolution per emit site.
+    pub symbol_table: Option<crate::ir::SymbolTable>,
 }
 
 /// Output files from a codegen backend.
@@ -404,6 +411,7 @@ pub fn build_context(
         synthesized_buffered_fns,
         #[cfg(feature = "runtime")]
         proof_ir: crate::ir::ProofIR::default(),
+        symbol_table: None,
     };
     // ProofIR no longer populated here. Pipeline owns the lowerings
     // (`PipelineStage::RefinementLower`, `PipelineStage::ContractLower`);

--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -1035,6 +1035,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
+            symbol_table: None,
         }
     }
 

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -2796,6 +2796,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
+            symbol_table: None,
         }
     }
 

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -63,6 +63,14 @@ pub enum PipelineStage {
     /// `ProofStrategy::BackendDispatch` and the consumer's ad-hoc
     /// chain still decides.
     LawLower,
+    /// Build the resolved-identity table (`SymbolTable`) — opaque
+    /// `FnId` / `TypeId` / `CtorId` / `ModuleId` for every named
+    /// declaration. Phase E of #138; populates
+    /// `PipelineResult.symbol_table`. No consumer reads it from
+    /// the pipeline output yet, but downstream migration PRs
+    /// (proof IR maps keyed by `FnId`, backend mangling by
+    /// `FnId → name`) all depend on this stage running.
+    BuildSymbols,
 }
 
 impl PipelineStage {
@@ -79,6 +87,7 @@ impl PipelineStage {
             Self::RefinementLower => "refinement_lower",
             Self::ContractLower => "contract_lower",
             Self::LawLower => "law_lower",
+            Self::BuildSymbols => "build_symbols",
         }
     }
 }
@@ -150,6 +159,13 @@ pub struct PipelineConfig<'a> {
     /// exporters always enable it alongside refinement_lower and
     /// contract_lower.
     pub run_law_lower: bool,
+    /// Whether to run the symbol-table build pass (#138 phase E).
+    /// Populates `PipelineResult.symbol_table` with opaque IDs for
+    /// every named declaration. Cheap to run unconditionally —
+    /// pure traversal of entry items + dep modules, no analysis.
+    /// Independent of every other stage; future consumers (proof
+    /// IR maps keyed by `FnId`, resolved AST emit) require it on.
+    pub run_build_symbols: bool,
     /// Pre-loaded dependent modules. Carried alongside items so the
     /// proof-lower pass can walk both the entry and dep type/fn defs
     /// (refinement records live in either; cross-module recursion is
@@ -188,6 +204,7 @@ impl<'a> Default for PipelineConfig<'a> {
             run_refinement_lower: false,
             run_contract_lower: false,
             run_law_lower: false,
+            run_build_symbols: false,
             dep_modules: &[],
             alloc_policy: None,
             call_ctx: None,
@@ -273,6 +290,17 @@ pub enum PassReport {
         /// with quantifiers + premises + claim.
         law_theorems: usize,
     },
+    BuildSymbols {
+        /// Modules in the table (always ≥ 1 — entry scope counts).
+        modules: usize,
+        /// Total fn declarations across entry + dep modules.
+        fns: usize,
+        /// Total type declarations across entry + dep modules.
+        types: usize,
+        /// Total constructors (record + sum variants) across all
+        /// type declarations.
+        ctors: usize,
+    },
 }
 
 /// Per-fn counter delta — used by `Tco` and `InterpLower` reports to
@@ -321,6 +349,13 @@ pub struct PipelineResult {
     /// populated by the stages that ran (an opt-in to only
     /// RefinementLower leaves `fn_contracts` empty, vice versa).
     pub proof_ir: Option<crate::ir::ProofIR>,
+    /// Resolved-identity table — opaque `FnId` / `TypeId` /
+    /// `CtorId` / `ModuleId` for every named declaration in the
+    /// program (#138 phase E). `Some` when `run_build_symbols`
+    /// was on. No consumer reads it through this field yet;
+    /// downstream migration PRs (proof IR maps keyed by `FnId`,
+    /// backend mangling) will start once the wire-up is in place.
+    pub symbol_table: Option<crate::ir::SymbolTable>,
     /// Per-stage diagnostic records — one per pass that actually ran.
     /// Drives `aver compile --explain-passes`; consumed by the future
     /// CI failable-invariant checks.
@@ -541,6 +576,15 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
         result.proof_ir = Some(ir);
     }
 
+    if cfg.run_build_symbols {
+        let symbol_table = crate::ir::SymbolTable::build(items, cfg.dep_modules);
+        result
+            .pass_diagnostics
+            .push(diag_for_build_symbols(&symbol_table));
+        result.symbol_table = Some(symbol_table);
+        fire(&mut cfg, PipelineStage::BuildSymbols, items);
+    }
+
     result
 }
 
@@ -729,6 +773,18 @@ fn diag_for_law_lower(ir: &crate::ir::ProofIR) -> PassDiagnostic {
         stage: PipelineStage::LawLower,
         report: PassReport::LawLower {
             law_theorems: ir.law_theorems.len(),
+        },
+    }
+}
+
+fn diag_for_build_symbols(table: &crate::ir::SymbolTable) -> PassDiagnostic {
+    PassDiagnostic {
+        stage: PipelineStage::BuildSymbols,
+        report: PassReport::BuildSymbols {
+            modules: table.modules.len(),
+            fns: table.fns.len(),
+            types: table.types.len(),
+            ctors: table.ctors.len(),
         },
     }
 }

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -2486,6 +2486,13 @@ fn build_codegen_context(
             run_refinement_lower,
             run_contract_lower,
             run_law_lower,
+            // #138 phase E wire-up — build the symbol table for
+            // every codegen context. Cheap, no consumers yet but
+            // downstream PRs migrate proof IR maps to `FnId` and
+            // need the table populated. Production callers always
+            // get it; ad-hoc `pipeline::run` callers (tests,
+            // playground) opt in via `PipelineConfig`.
+            run_build_symbols: true,
             dep_modules: &modules,
             ..Default::default()
         },
@@ -2535,6 +2542,7 @@ fn build_codegen_context(
     // pipeline; pull it across before assembly so build_context doesn't
     // redundantly recompute it.
     let prebuilt_proof_ir = pipeline_result.proof_ir;
+    let prebuilt_symbol_table = pipeline_result.symbol_table;
     let mut ctx = codegen::build_context(
         items,
         &tc_result,
@@ -2549,6 +2557,7 @@ fn build_codegen_context(
     }
     #[cfg(not(feature = "runtime"))]
     let _ = prebuilt_proof_ir;
+    ctx.symbol_table = prebuilt_symbol_table;
     ctx.policy = policy;
     ctx.emit_replay_runtime = use_scoped_runtime;
     ctx.runtime_policy_from_env = use_runtime_policy;
@@ -3500,6 +3509,17 @@ fn render_pass_diagnostics(diags: &[aver::ir::pipeline::PassDiagnostic]) -> Stri
                     "{label} {law_theorems} verify-law theorem(s) lowered\n"
                 ));
             }
+            PassReport::BuildSymbols {
+                modules,
+                fns,
+                types,
+                ctors,
+            } => {
+                out.push_str(&format!(
+                    "{label} symbol table: {modules} module(s), {fns} fn(s), \
+                     {types} type(s), {ctors} ctor(s)\n"
+                ));
+            }
         }
         out.push('\n');
     }
@@ -3662,6 +3682,16 @@ fn render_pass_diagnostics_json(diags: &[aver::ir::pipeline::PassDiagnostic]) ->
             }
             PassReport::LawLower { law_theorems } => {
                 out.push_str(&format!("{{\"law_theorems\":{}}}", law_theorems));
+            }
+            PassReport::BuildSymbols {
+                modules,
+                fns,
+                types,
+                ctors,
+            } => {
+                out.push_str(&format!(
+                    "{{\"modules\":{modules},\"fns\":{fns},\"types\":{types},\"ctors\":{ctors}}}"
+                ));
             }
         }
         out.push('}');
@@ -4782,6 +4812,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: aver::ir::ProofIR::default(),
+            symbol_table: None,
         }
     }
 

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -44,6 +44,10 @@ fn build_ctx(src: &str) -> CodegenContext {
             run_refinement_lower: true,
             run_contract_lower: true,
             run_law_lower: true,
+            // Build the symbol table alongside proof IR so downstream
+            // tests that touch `ctx.symbol_table` see the populated
+            // form. Cheap traversal — no analysis.
+            run_build_symbols: true,
             dep_modules: &[],
             alloc_policy: None,
             call_ctx: None,
@@ -64,6 +68,7 @@ fn build_ctx(src: &str) -> CodegenContext {
     if let Some(ir) = proof_ir {
         ctx.proof_ir = ir;
     }
+    ctx.symbol_table = pipeline_result.symbol_table;
     ctx
 }
 
@@ -143,6 +148,47 @@ fn assert_equiv(src: &str, type_names: &[&str]) {
 fn natural_refinement_decision_matches_legacy() {
     let src = include_str!("../examples/refinement/natural/natural.av");
     assert_equiv(src, &["Natural"]);
+}
+
+#[test]
+fn pipeline_populates_symbol_table_when_build_symbols_is_on() {
+    // #138 phase E wire-up: when the pipeline runs with
+    // `run_build_symbols = true`, the result carries a populated
+    // `SymbolTable` and `build_codegen_context` plumbs it into
+    // `ctx.symbol_table`. No downstream consumer reads it yet —
+    // this test is the contract that the table exists.
+    let src = include_str!("../examples/refinement/natural/natural.av");
+    let ctx = build_ctx(src);
+    let symbols = ctx
+        .symbol_table
+        .as_ref()
+        .expect("ctx.symbol_table must be Some after run_build_symbols");
+
+    // Natural.av declares the `Natural` record + the `fromInt` /
+    // `toInt` / `add` / `mul` fns. Look up via `TypeKey` /
+    // `FnKey` directly — exercises the resolver path the
+    // migration PRs will rely on.
+    let nat_id = symbols
+        .type_id_of(&aver::ir::TypeKey::entry("Natural"))
+        .expect("Natural type id");
+    let entry = symbols.type_entry(nat_id);
+    assert_eq!(entry.key.name, "Natural");
+    assert!(entry.is_product, "Natural is a record (product)");
+
+    let from_int = symbols
+        .fn_id_of(&aver::ir::FnKey::entry("fromInt"))
+        .expect("fromInt fn id");
+    assert_eq!(symbols.fn_entry(from_int).key.name, "fromInt");
+
+    // Result.Ok / Result.Err / Option.Some / Option.None are
+    // built-ins, NOT user-declared, so they must NOT appear here.
+    // (Future: built-in ctors get their own well-known IDs; for
+    // now their absence is the contract.)
+    assert!(
+        symbols
+            .type_id_of(&aver::ir::TypeKey::entry("Result"))
+            .is_none()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

PR #140 landed the `SymbolTable` foundation but left it dead code — no caller invoked `SymbolTable::build`. This PR wires it into the compiler pipeline.

## Changed

- `PipelineStage::BuildSymbols` + `PipelineConfig.run_build_symbols` + `PipelineResult.symbol_table: Option<SymbolTable>`. New stage runs after proof lowering (independent of every other stage, cheap traversal).
- `PassReport::BuildSymbols { modules, fns, types, ctors }` surfaces table stats through `--explain-passes`.
- `CodegenContext.symbol_table: Option<SymbolTable>` carries the pipeline output into emit code.
- `build_codegen_context` enables `run_build_symbols: true` for every production codegen path. Cheap, no consumers yet, but downstream migration PRs (proof IR maps keyed by `FnId`, backend mangling) read it from here.

**No consumer reads `ctx.symbol_table` yet** — this PR is the wire-up only. The first read site lands in the next PR (proof IR maps migrating `HashMap<FnKey, _>` → `HashMap<FnId, _>`).

## Test

- New `pipeline_populates_symbol_table_when_build_symbols_is_on` integration test: takes `examples/refinement/natural/natural.av` through the proof-mode pipeline, asserts `ctx.symbol_table` is `Some` and resolves the source-declared `Natural` / `fromInt`, while built-in `Result` does NOT appear.
- `cargo test`: all passing, no regressions.
- `cargo fmt --all -- --check` clean, clippy clean (CI-style invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)