### PR TITLE
codegen/proof: migrate fn_contracts to FnId-keyed (#138 phase E1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ harness = false
 [[bench]]
 name = "comparison_bench"
 harness = false
+required-features = ["wasm"]
 
 [profile.release]
 lto = true

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -830,34 +830,41 @@ pub fn find_fn_contract_scoped<'a>(
     name: &str,
     scope: Option<&str>,
 ) -> Option<&'a crate::ir::proof_ir::FnContract> {
+    // Round-7: `ProofIR.fn_contracts` is keyed by opaque `FnId`
+    // after the phase-E migration. Resolve `name` → `FnKey` →
+    // `FnId` through the symbol table, then look up the contract.
+    // Without a symbol table (legacy callers that haven't enabled
+    // `run_build_symbols`) this returns `None`, which the
+    // downstream emit path treats the same as "no contract" — the
+    // table is part of every production build flow.
+    let symbols = ctx.symbol_table.as_ref()?;
     let bare = name.rsplit('.').next().unwrap_or(name);
     let name_is_already_qualified = name.contains('.');
+    let try_key = |key: crate::ir::FnKey| -> Option<&'a crate::ir::proof_ir::FnContract> {
+        let id = symbols.fn_id_of(&key)?;
+        ctx.proof_ir.fn_contracts.get(&id)
+    };
     if let Some(prefix) = scope
         && !name_is_already_qualified
+        && let Some(c) = try_key(crate::ir::FnKey::in_module(prefix.to_string(), bare))
     {
-        let scoped_key = crate::ir::FnKey::in_module(prefix.to_string(), bare);
-        if let Some(c) = ctx.proof_ir.fn_contracts.get(&scoped_key) {
-            return Some(c);
-        }
+        return Some(c);
     }
-    // Direct `name`-as-given lookup: build entry key for bare,
-    // module key for already-qualified.
     let direct_key =
         if name_is_already_qualified && let Some((prefix, bare_part)) = name.rsplit_once('.') {
             crate::ir::FnKey::in_module(prefix.to_string(), bare_part)
         } else {
             crate::ir::FnKey::entry(name)
         };
-    if let Some(c) = ctx.proof_ir.fn_contracts.get(&direct_key) {
+    if let Some(c) = try_key(direct_key) {
         return Some(c);
     }
     for m in &ctx.modules {
         for fd in &m.fn_defs {
-            if fd.name == bare {
-                let canonical = crate::ir::FnKey::in_module(m.prefix.clone(), bare);
-                if let Some(c) = ctx.proof_ir.fn_contracts.get(&canonical) {
-                    return Some(c);
-                }
+            if fd.name == bare
+                && let Some(c) = try_key(crate::ir::FnKey::in_module(m.prefix.clone(), bare))
+            {
+                return Some(c);
             }
         }
     }
@@ -978,7 +985,15 @@ pub fn find_fn_contract_for_fn<'a>(
     ctx: &'a CodegenContext,
     fd: &FnDef,
 ) -> Option<&'a crate::ir::proof_ir::FnContract> {
-    find_fn_contract_scoped(ctx, &fd.name, fn_owning_scope_for(ctx, fd))
+    // Direct path: resolve the `&FnDef` to a `FnKey` via pointer-eq
+    // scope detection, then look up the `FnId` in the symbol table
+    // and the contract by ID. Cleaner than the bare-name resolver
+    // chain because the source `&FnDef` already identifies its
+    // owning module unambiguously.
+    let symbols = ctx.symbol_table.as_ref()?;
+    let fn_key = fn_key_for_decl(ctx, fd);
+    let fn_id = symbols.fn_id_of(&fn_key)?;
+    ctx.proof_ir.fn_contracts.get(&fn_id)
 }
 
 /// Membership check counterpart of [`find_fn_contract_for_fn`].

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -808,23 +808,17 @@ pub fn find_refined_type<'a>(
     find_refined_type_with_key_scoped(ctx, name, None).map(|(_, d)| d)
 }
 
-/// Round-5: `ir.fn_contracts` is now keyed by canonical name
-/// (`Module.fn` for module-owned fns, bare for entry). Callsites
-/// holding a bare fn name resolve to the right slot through this
-/// resolver.
-pub fn find_fn_contract<'a>(
-    ctx: &'a CodegenContext,
-    name: &str,
-) -> Option<&'a crate::ir::proof_ir::FnContract> {
-    find_fn_contract_scoped(ctx, name, None)
-}
-
-/// Scope-aware variant. `scope = Some(prefix)` directs bare-name
-/// lookups to that module's slot before falling back to entry /
-/// module-walk. Mirror of `find_refined_type_scoped` for fn
+/// Scope-aware fn-contract resolver. `scope = Some(prefix)` directs
+/// bare-name lookups to that module's slot before falling back to
+/// entry / module-walk. Mirror of `find_refined_type_scoped` for fn
 /// contracts — without it, two modules with same-bare-name
 /// recursive fns silently merge under whichever module-walk hit
 /// first.
+///
+/// Prefer `find_fn_contract_for_fn` whenever you have a `&FnDef` in
+/// hand: it resolves identity by pointer-eq against
+/// `ctx.modules[*].fn_defs` and avoids the bare-name footgun this
+/// scoped lookup still inherits from string-based call sites.
 pub fn find_fn_contract_scoped<'a>(
     ctx: &'a CodegenContext,
     name: &str,
@@ -869,13 +863,6 @@ pub fn find_fn_contract_scoped<'a>(
         }
     }
     None
-}
-
-/// Membership check counterpart of [`find_fn_contract`]. Used by
-/// the SCC routing in `transpile_unified` to decide whether a fn
-/// has a contract pinned without borrowing the decl.
-pub fn fn_contract_exists(ctx: &CodegenContext, name: &str) -> bool {
-    find_fn_contract(ctx, name).is_some()
 }
 
 /// Scoped membership check.

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -695,7 +695,10 @@ mod tests {
                 run_refinement_lower: true,
                 run_contract_lower: true,
                 run_law_lower: true,
-                run_build_symbols: false,
+                // BuildSymbols is needed for fn_contracts lookup
+                // (keyed by opaque FnId resolved through the symbol
+                // table since the FnKey → FnId migration).
+                run_build_symbols: true,
                 dep_modules: &[],
                 alloc_policy: None,
                 call_ctx: None,
@@ -720,6 +723,7 @@ mod tests {
         if let Some(ir) = proof_ir {
             ctx.proof_ir = ir;
         }
+        ctx.symbol_table = pipeline_result.symbol_table;
         ctx
     }
 

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1571,7 +1571,10 @@ mod tests {
                 run_refinement_lower: true,
                 run_contract_lower: true,
                 run_law_lower: true,
-                run_build_symbols: false,
+                // BuildSymbols is needed for fn_contracts lookup
+                // (keyed by opaque FnId resolved through the symbol
+                // table since the FnKey → FnId migration).
+                run_build_symbols: true,
                 dep_modules: &[],
                 alloc_policy: None,
                 call_ctx: None,
@@ -1596,6 +1599,7 @@ mod tests {
         if let Some(ir) = proof_ir {
             ctx.proof_ir = ir;
         }
+        ctx.symbol_table = pipeline_result.symbol_table;
         ctx
     }
 

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1515,6 +1515,11 @@ mod tests {
     /// IR-pinned law strategies rely on this being populated so the
     /// backend's IR-pin lookups can fire.
     fn populate_proof_ir(ctx: &mut CodegenContext) {
+        // Mirror the production order: BuildSymbols → proof_lower. The
+        // populate side asserts the symbol table is present (it's a
+        // hard prerequisite for FnId-keyed fn_contracts), so synthetic-
+        // ctx tests have to build it the same way `refresh_facts` does.
+        ctx.symbol_table = Some(crate::ir::SymbolTable::build(&ctx.items, &ctx.modules));
         let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
         ctx.proof_ir = crate::codegen::proof_lower::lower(&inputs);
     }

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -879,8 +879,8 @@ fn emit_fuelized_sizeof_fn(fd: &FnDef, ctx: &CodegenContext) -> String {
 /// Read the rank component of a `Fuel { Lex { .., rank } }` contract.
 /// Returns `None` when the fn has no contract or the contract isn't
 /// a Lex shape (non-mutual variant or non-recursive).
-fn contract_lex_rank(ctx: &CodegenContext, fn_name: &str) -> Option<usize> {
-    contract_lex_params_rank(ctx, fn_name).map(|(_, rank)| rank)
+fn contract_lex_rank(ctx: &CodegenContext, fd: &FnDef) -> Option<usize> {
+    contract_lex_params_rank(ctx, fd).map(|(_, rank)| rank)
 }
 
 /// Read both the params Vec and rank of a `Fuel { Lex { params, rank } }`
@@ -892,9 +892,9 @@ fn contract_lex_rank(ctx: &CodegenContext, fn_name: &str) -> Option<usize> {
 /// - `MutualSizeOfRanked`: `params.is_empty()`
 fn contract_lex_params_rank<'a>(
     ctx: &'a CodegenContext,
-    fn_name: &str,
+    fd: &FnDef,
 ) -> Option<(&'a [String], usize)> {
-    let contract = crate::codegen::common::find_fn_contract(ctx, fn_name)?;
+    let contract = crate::codegen::common::find_fn_contract_for_fn(ctx, fd)?;
     let crate::ir::RecursionContract::Fuel {
         fuel_metric: crate::ir::FuelMetric::Lex { params, rank },
     } = contract.recursion.as_ref()?
@@ -908,7 +908,7 @@ fn emit_fuelized_mutual_string_pos_group(fns: &[&FnDef], ctx: &CodegenContext) -
     let targets: HashSet<String> = fns.iter().map(|fd| fd.name.clone()).collect();
     let max_rank = fns
         .iter()
-        .filter_map(|fd| contract_lex_rank(ctx, &fd.name))
+        .filter_map(|fd| contract_lex_rank(ctx, fd))
         .max()
         .unwrap_or(1);
 
@@ -1059,7 +1059,7 @@ fn emit_native_mutual_sizeof_group(fns: &[&FnDef], ctx: &CodegenContext) -> Opti
         // MutualSizeOfRanked carries `params: vec![]` + rank>=1; any
         // other Lex shape (single-param mutual int-countdown, two-
         // param string-pos) fails this group's pre-conditions.
-        match contract_lex_params_rank(ctx, &fd.name) {
+        match contract_lex_params_rank(ctx, fd) {
             Some(([], rank)) => {
                 ranks.insert(fd.name.clone(), rank);
             }
@@ -1126,7 +1126,7 @@ fn emit_fuelized_mutual_sizeof_group(fns: &[&FnDef], ctx: &CodegenContext) -> St
         .collect();
     let rank_budget = fns
         .iter()
-        .filter_map(|fd| contract_lex_rank(ctx, &fd.name))
+        .filter_map(|fd| contract_lex_rank(ctx, fd))
         .max()
         .unwrap_or(1)
         + 1;
@@ -2300,7 +2300,7 @@ pub fn emit_mutual_group_proof(fns: &[&FnDef], ctx: &CodegenContext) -> String {
     //   `[]` rank >=1 → MutualSizeOfRanked
     let all_int_countdown = fns.iter().all(|fd| {
         matches!(
-            contract_lex_params_rank(ctx, &fd.name),
+            contract_lex_params_rank(ctx, fd),
             Some((params, 0)) if params.len() == 1
         )
     });
@@ -2310,7 +2310,7 @@ pub fn emit_mutual_group_proof(fns: &[&FnDef], ctx: &CodegenContext) -> String {
 
     let all_string_pos = fns.iter().all(|fd| {
         matches!(
-            contract_lex_params_rank(ctx, &fd.name),
+            contract_lex_params_rank(ctx, fd),
             Some((params, _)) if params.len() == 2
         )
     });
@@ -2320,7 +2320,7 @@ pub fn emit_mutual_group_proof(fns: &[&FnDef], ctx: &CodegenContext) -> String {
 
     let all_sizeof = fns.iter().all(|fd| {
         matches!(
-            contract_lex_params_rank(ctx, &fd.name),
+            contract_lex_params_rank(ctx, fd),
             Some((params, _)) if params.is_empty()
         )
     });
@@ -2352,7 +2352,7 @@ pub fn emit_mutual_group_proof(fns: &[&FnDef], ctx: &CodegenContext) -> String {
         for line in body.lines() {
             lines.push(format!("  {}", line));
         }
-        match contract_lex_params_rank(ctx, &fd.name) {
+        match contract_lex_params_rank(ctx, fd) {
             Some((params, 0)) if params.len() == 1 => {
                 // MutualIntCountdown — every member counts down the
                 // shared first-Int param. (The IR's param name is

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -473,6 +473,13 @@ impl CodegenContext {
         }
         self.recursive_fns = recursive_fns;
 
+        // Symbol table must be rebuilt before proof_lower runs so the
+        // populate side can resolve `FnKey` → opaque `FnId` for the
+        // (now FnId-keyed) `fn_contracts` map. Synthetic-ctx test
+        // paths reach this codepath through `refresh_facts`, so this
+        // is the only place those flows get a symbol table.
+        self.symbol_table = Some(crate::ir::SymbolTable::build(&self.items, &self.modules));
+
         // ProofIR's `fn_contracts` / `refined_types` are derived from
         // the just-recomputed item set + the recursion classifier, so
         // they must stay in step with the rest of the facts. Test

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -363,13 +363,17 @@ fn populate_fn_contracts_for_scope(
         }
     };
     // Round-7 phase E: contracts key by opaque `FnId` resolved
-    // once via the symbol table. When the table isn't wired up
-    // (legacy synthetic-IR test paths), skip populating contracts
-    // entirely — backends without a symbol table have no way to
-    // look them up anyway.
-    let Some(symbols) = inputs.symbol_table else {
-        return;
-    };
+    // once via the symbol table. The pipeline auto-enables
+    // BuildSymbols whenever ContractLower runs, so reaching this
+    // point without `inputs.symbol_table` is a wiring bug — callers
+    // who build a `ProofLowerInputs` by hand (synthetic-ctx tests)
+    // are responsible for setting `symbol_table` before calling
+    // populate. We panic instead of silently skipping so the
+    // wiring bug surfaces at the producer rather than as missing
+    // contracts in downstream emit output.
+    let symbols = inputs
+        .symbol_table
+        .expect("populate_fn_contracts requires SymbolTable (run BuildSymbols first)");
 
     for (fn_name, plan) in plans {
         let Some(fd) = scoped_fns.iter().find(|fd| fd.name == *fn_name) else {

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -52,6 +52,14 @@ pub struct ProofLowerInputs<'a> {
     /// Recursive fn names from the `analyze` pipeline stage. Used by
     /// `analyze_plans` to short-circuit non-recursive fns.
     pub recursive_fns: &'a HashSet<String>,
+    /// Resolved-identity table (#138 phase E). When `Some`, the
+    /// populate-side resolves `FnKey` / `TypeKey` to `FnId` /
+    /// `TypeId` once at the IR boundary and keys `ProofIR.fn_contracts`
+    /// / `ProofIR.refined_types` / `LawTheorem.fn_id` by the opaque
+    /// IDs. Callers that haven't wired in the symbol-table stage
+    /// pass `None` and fall through to legacy key-typed maps
+    /// (transitional during phase E migration).
+    pub symbol_table: Option<&'a crate::ir::SymbolTable>,
 }
 
 impl<'a> ProofLowerInputs<'a> {
@@ -65,6 +73,7 @@ impl<'a> ProofLowerInputs<'a> {
             dep_modules: &ctx.modules,
             module_prefixes: &ctx.module_prefixes,
             recursive_fns: &ctx.recursive_fns,
+            symbol_table: ctx.symbol_table.as_ref(),
         }
     }
 
@@ -353,14 +362,23 @@ fn populate_fn_contracts_for_scope(
             None => crate::ir::FnKey::entry(bare),
         }
     };
+    // Round-7 phase E: contracts key by opaque `FnId` resolved
+    // once via the symbol table. When the table isn't wired up
+    // (legacy synthetic-IR test paths), skip populating contracts
+    // entirely — backends without a symbol table have no way to
+    // look them up anyway.
+    let Some(symbols) = inputs.symbol_table else {
+        return;
+    };
 
     for (fn_name, plan) in plans {
         let Some(fd) = scoped_fns.iter().find(|fd| fd.name == *fn_name) else {
             continue;
         };
-        // `fn_name` stays bare (used as `source_name` in each insert);
-        // `canonical_key` is the typed map key.
-        let canonical_key = qualify(fn_name);
+        let fn_key = qualify(fn_name);
+        let Some(canonical_key) = symbols.fn_id_of(&fn_key) else {
+            continue;
+        };
 
         // IntCountdown — fuel-encoded countdown on a single Int param.
         // Distinct from IntCountdownGuarded: external callers may pass
@@ -370,7 +388,7 @@ fn populate_fn_contracts_for_scope(
         if let RecursionPlan::IntCountdown { param_index } = plan {
             if let Some((param_name, _)) = fd.params.get(*param_index) {
                 ir.fn_contracts.insert(
-                    canonical_key.clone(),
+                    canonical_key,
                     FnContract {
                         source_name: fn_name.clone(),
                         recursion: Some(RecursionContract::Fuel {
@@ -391,7 +409,7 @@ fn populate_fn_contracts_for_scope(
         if let RecursionPlan::IntAscending { param_index, bound } = plan {
             if let Some((param_name, _)) = fd.params.get(*param_index) {
                 ir.fn_contracts.insert(
-                    canonical_key.clone(),
+                    canonical_key,
                     FnContract {
                         source_name: fn_name.clone(),
                         recursion: Some(RecursionContract::Fuel {
@@ -415,7 +433,7 @@ fn populate_fn_contracts_for_scope(
         if let RecursionPlan::ListStructural { param_index } = plan {
             if let Some((param_name, _)) = fd.params.get(*param_index) {
                 ir.fn_contracts.insert(
-                    canonical_key.clone(),
+                    canonical_key,
                     FnContract {
                         source_name: fn_name.clone(),
                         recursion: Some(RecursionContract::Fuel {
@@ -435,7 +453,7 @@ fn populate_fn_contracts_for_scope(
         // whole frame — so the IR variant carries no param name.
         if matches!(plan, RecursionPlan::SizeOfStructural) {
             ir.fn_contracts.insert(
-                canonical_key.clone(),
+                canonical_key,
                 FnContract {
                     source_name: fn_name.clone(),
                     recursion: Some(RecursionContract::Fuel {
@@ -454,7 +472,7 @@ fn populate_fn_contracts_for_scope(
                 (fd.params.first(), fd.params.get(1))
             {
                 ir.fn_contracts.insert(
-                    canonical_key.clone(),
+                    canonical_key,
                     FnContract {
                         source_name: fn_name.clone(),
                         recursion: Some(RecursionContract::Fuel {
@@ -491,7 +509,7 @@ fn populate_fn_contracts_for_scope(
                     .map(|(n, _)| vec![n.clone()])
                     .unwrap_or_default();
                 ir.fn_contracts.insert(
-                    canonical_key.clone(),
+                    canonical_key,
                     FnContract {
                         source_name: fn_name.clone(),
                         recursion: Some(RecursionContract::Fuel {
@@ -504,7 +522,7 @@ fn populate_fn_contracts_for_scope(
             RecursionPlan::MutualStringPosAdvance { rank } => {
                 let params = fd.params.iter().take(2).map(|(n, _)| n.clone()).collect();
                 ir.fn_contracts.insert(
-                    canonical_key.clone(),
+                    canonical_key,
                     FnContract {
                         source_name: fn_name.clone(),
                         recursion: Some(RecursionContract::Fuel {
@@ -519,7 +537,7 @@ fn populate_fn_contracts_for_scope(
             }
             RecursionPlan::MutualSizeOfRanked { rank } => {
                 ir.fn_contracts.insert(
-                    canonical_key.clone(),
+                    canonical_key,
                     FnContract {
                         source_name: fn_name.clone(),
                         recursion: Some(RecursionContract::Fuel {
@@ -534,7 +552,7 @@ fn populate_fn_contracts_for_scope(
             }
             RecursionPlan::LinearRecurrence2 => {
                 ir.fn_contracts.insert(
-                    canonical_key.clone(),
+                    canonical_key,
                     FnContract {
                         source_name: fn_name.clone(),
                         recursion: Some(RecursionContract::LinearRecurrence2),
@@ -571,7 +589,7 @@ fn populate_fn_contracts_for_scope(
             .collect();
 
         ir.fn_contracts.insert(
-            canonical_key.clone(),
+            canonical_key,
             FnContract {
                 source_name: fn_name.clone(),
                 recursion: Some(RecursionContract::Native {

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -526,6 +526,19 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
     // RefinementLower writes `refined_types`, ContractLower writes
     // `fn_contracts`, LawLower writes `law_theorems`. Each is
     // independently opt-in.
+    // BuildSymbols runs BEFORE proof stages so `populate_*` resolve
+    // `FnKey`/`TypeKey` to `FnId`/`TypeId` once at the IR boundary
+    // and key `ProofIR.fn_contracts` / `ProofIR.refined_types` /
+    // `LawTheorem.fn_id` by the opaque IDs (#138 phase E).
+    if cfg.run_build_symbols {
+        let symbol_table = crate::ir::SymbolTable::build(items, cfg.dep_modules);
+        result
+            .pass_diagnostics
+            .push(diag_for_build_symbols(&symbol_table));
+        result.symbol_table = Some(symbol_table);
+        fire(&mut cfg, PipelineStage::BuildSymbols, items);
+    }
+
     if cfg.run_refinement_lower || cfg.run_contract_lower || cfg.run_law_lower {
         // Round-5: union entry's analyze with each dep module's
         // `analysis.recursive_fns`. Without this, multi-module proof
@@ -556,6 +569,7 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
             dep_modules: cfg.dep_modules,
             module_prefixes: &module_prefixes,
             recursive_fns: &recursive_fns_owned,
+            symbol_table: result.symbol_table.as_ref(),
         };
         let mut ir = result.proof_ir.take().unwrap_or_default();
         if cfg.run_refinement_lower {
@@ -574,15 +588,6 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
             fire(&mut cfg, PipelineStage::LawLower, items);
         }
         result.proof_ir = Some(ir);
-    }
-
-    if cfg.run_build_symbols {
-        let symbol_table = crate::ir::SymbolTable::build(items, cfg.dep_modules);
-        result
-            .pass_diagnostics
-            .push(diag_for_build_symbols(&symbol_table));
-        result.symbol_table = Some(symbol_table);
-        fire(&mut cfg, PipelineStage::BuildSymbols, items);
     }
 
     result

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -530,7 +530,17 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
     // `FnKey`/`TypeKey` to `FnId`/`TypeId` once at the IR boundary
     // and key `ProofIR.fn_contracts` / `ProofIR.refined_types` /
     // `LawTheorem.fn_id` by the opaque IDs (#138 phase E).
-    if cfg.run_build_symbols {
+    //
+    // Proof stages have a hard dependency on the symbol table —
+    // since fn_contracts is keyed by `FnId`, populate cannot run
+    // without resolved identity. Auto-enable here so callers can't
+    // accidentally turn on `run_contract_lower` / `run_law_lower`
+    // without symbols and silently produce an empty proof IR.
+    let needs_symbols = cfg.run_build_symbols
+        || cfg.run_refinement_lower
+        || cfg.run_contract_lower
+        || cfg.run_law_lower;
+    if needs_symbols {
         let symbol_table = crate::ir::SymbolTable::build(items, cfg.dep_modules);
         result
             .pass_diagnostics

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -31,6 +31,7 @@ use crate::ast::Spanned;
 // (VM, Rust codegen, WASM) will reach for the same types when they
 // hit the same bug class. Re-exported here for ergonomics.
 pub use crate::ir::identity::{FnKey, LawKey, TypeKey};
+pub use crate::ir::symbol_table::{CtorId, FnId, ModuleId, TypeId};
 
 /// Output of the `proof_lower` pipeline stage. Every decision the
 /// proof backends will make is materialised here; backends become
@@ -50,10 +51,13 @@ pub struct ProofIR {
     pub refined_types: HashMap<TypeKey, RefinedTypeDecl>,
     /// Per-pure-fn contract describing what proof artifact the fn
     /// lowers to (native / fuel / structural / linear recurrence).
-    /// Keyed by [`FnKey`] so two modules with same-bare-name fns
-    /// (`A.foo` IntCountdown + `B.foo` ListStructural) hold their
-    /// own contracts without collision.
-    pub fn_contracts: HashMap<FnKey, FnContract>,
+    /// Keyed by opaque [`FnId`] from the symbol table — name
+    /// resolution happens once in `populate_fn_contracts`;
+    /// consumers thereafter use `ctx.symbol_table` to resolve
+    /// `&FnDef → FnId` and look up directly. Cross-module
+    /// same-bare-name fns get distinct IDs, so the lookup is
+    /// unambiguous without per-call-site scope plumbing.
+    pub fn_contracts: HashMap<FnId, FnContract>,
     /// Per-verify-law theorem decomposed into quantifiers, premises,
     /// and claim with all wrapper-strip / val-projection / drop-vs-
     /// keep decisions baked in, plus the pinned proof strategy.

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -301,6 +301,12 @@ fn build_ctx(
     if let Some(ir) = proof_ir {
         ctx.proof_ir = ir;
     }
+    // BuildSymbols auto-runs when any proof stage is on (see
+    // `ir::pipeline::run`), so the symbol table is populated for the
+    // proof path. Plumb it through so backend lookups
+    // (`find_fn_contract_for_fn`, etc.) resolve through opaque IDs
+    // instead of returning `None` and dropping recursion contracts.
+    ctx.symbol_table = pipeline_result.symbol_table;
     Ok(ctx)
 }
 

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -352,14 +352,36 @@ fn build_project_ctx(
     let root_depends = module_depends(&entry_items);
     let loaded = load_module_tree_from_map(&root_depends, files)?;
 
+    // Build the dep-module list BEFORE pipeline::run so the pipeline
+    // sees the full program. `SymbolTable::build` walks dep_modules
+    // to assign `FnId`s to module-owned fns; `populate_fn_contracts`
+    // then resolves `FnKey { scope: Some("Module"), name }` against
+    // those ids. Skipping this step left the multi-file proof path
+    // with an entry-only symbol table and module fns silently missing
+    // from `proof_ir.fn_contracts`.
+    let modules: Vec<codegen::ModuleInfo> = loaded
+        .iter()
+        .cloned()
+        .map(|m| loaded_to_module_info(m, apply_traversal_lowering))
+        .collect();
+
     // Multi-file pipeline. `apply_traversal_lowering` mirrors the CLI
-    // proof-vs-runtime distinction at this API boundary.
+    // proof-vs-runtime distinction at this API boundary: proof export
+    // wants source-level IR (no traversal lowering) AND the proof
+    // stages populated. BuildSymbols auto-enables alongside proof
+    // stages so the FnId-keyed `fn_contracts` / `refined_types` maps
+    // are reachable downstream.
+    let proof_target = !apply_traversal_lowering;
     let pipeline_result = crate::ir::pipeline::run(
         &mut entry_items,
         PipelineConfig {
             typecheck: Some(TypecheckMode::WithLoaded(&loaded)),
             run_interp_lower: apply_traversal_lowering,
             run_buffer_build: apply_traversal_lowering,
+            run_refinement_lower: proof_target,
+            run_contract_lower: proof_target,
+            run_law_lower: proof_target,
+            dep_modules: &modules,
             ..Default::default()
         },
     );
@@ -368,19 +390,20 @@ fn build_project_ctx(
         return Err(format_tc_errors(&tc_result.errors));
     }
 
-    let modules: Vec<codegen::ModuleInfo> = loaded
-        .into_iter()
-        .map(|m| loaded_to_module_info(m, apply_traversal_lowering))
-        .collect();
-
-    Ok(codegen::build_context(
+    let proof_ir = pipeline_result.proof_ir;
+    let mut ctx = codegen::build_context(
         entry_items,
         &tc_result,
         pipeline_result.analysis.as_ref(),
         HashSet::new(),
         "playground".to_string(),
         modules,
-    ))
+    );
+    if let Some(ir) = proof_ir {
+        ctx.proof_ir = ir;
+    }
+    ctx.symbol_table = pipeline_result.symbol_table;
+    Ok(ctx)
 }
 
 /// Multi-file Aver project → Lean 4 project files.
@@ -1055,6 +1078,68 @@ mod tests {
             .expect("multi-file Dafny export should succeed");
         assert!(!out.is_empty(), "Dafny project export should produce files");
         assert!(out.iter().any(|(k, _)| k.ends_with(".dfy")));
+    }
+
+    #[test]
+    fn proof_project_path_populates_fnid_keyed_proof_ir() {
+        // Regression for the PR #142 follow-up: `build_project_ctx`
+        // used to skip proof stages + drop the symbol table, so
+        // `proof_*_files_project` exported multi-file proofs with
+        // an empty ProofIR. Existing project tests only assert
+        // files are produced; this one asserts the FnId-keyed proof
+        // layer actually landed for a recursive fn in a dep module.
+        let mut files: HashMap<String, String> = HashMap::new();
+        files.insert(
+            "helper.av".to_string(),
+            r#"module Helper
+    intent = "countdown"
+    depends []
+
+fn down(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> down(n - 1)
+"#
+            .to_string(),
+        );
+        files.insert(
+            "main.av".to_string(),
+            r#"module Main
+    intent = "use helper"
+    depends [Helper]
+
+fn main() -> Int
+    Helper.down(3)
+"#
+            .to_string(),
+        );
+
+        let ctx = super::build_project_ctx(&files, "main.av", false)
+            .expect("multi-file proof ctx should build");
+
+        // The fix proper: symbol table is plumbed onto the multi-file
+        // proof ctx (regression for the previous "build_context without
+        // proof_ir / symbol_table" gap).
+        let symbols = ctx
+            .symbol_table
+            .as_ref()
+            .expect("symbol_table must be plumbed onto multi-file proof ctx");
+        let helper_down_id = symbols
+            .fn_id_of(&crate::ir::FnKey::in_module("Helper".to_string(), "down"))
+            .expect("SymbolTable must carry FnId for Helper.down");
+
+        // Producer side: the FnId-keyed `fn_contracts` map must
+        // hold the recursion contract for the dep-module fn.
+        // Pre-fix this was empty because the pipeline ran without
+        // `dep_modules` and `populate_fn_contracts` had nothing
+        // to classify outside the entry scope.
+        assert!(
+            ctx.proof_ir.fn_contracts.contains_key(&helper_down_id),
+            "fn_contracts should hold an entry for Helper.down (FnId={:?}); \
+             got {} entries instead",
+            helper_down_id,
+            ctx.proof_ir.fn_contracts.len()
+        );
     }
 
     #[test]

--- a/src/self_host/main.rs
+++ b/src/self_host/main.rs
@@ -25,6 +25,7 @@ pub use replay_support::*;
 
 mod self_host_support;
 
+#[allow(clippy::needless_return, unused_braces)]
 pub mod aver_generated;
 
 fn main() {

--- a/src/vm/symbol.rs
+++ b/src/vm/symbol.rs
@@ -448,8 +448,12 @@ mod tests {
         let some = table
             .intern_wrapper("Option.Some", 2)
             .expect("intern Option.Some");
-        table.add_namespace_member("Option", "Some", VmSymbolTable::symbol_ref(some));
-        table.add_namespace_member("Option", "None", NanValue::NONE);
+        table
+            .add_namespace_member("Option", "Some", VmSymbolTable::symbol_ref(some))
+            .expect("add Option.Some member");
+        table
+            .add_namespace_member("Option", "None", NanValue::NONE)
+            .expect("add Option.None member");
 
         let some_member = table.find("Some").unwrap();
         let none_member = table.find("None").unwrap();

--- a/tests/explain_passes_spec.rs
+++ b/tests/explain_passes_spec.rs
@@ -84,6 +84,7 @@ fn main() -> Int
             "analyze",
             "escape",
             "last_use",
+            "build_symbols",
             "refinement_lower",
             "contract_lower",
             "law_lower",

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -72,6 +72,19 @@ fn build_ctx(src: &str) -> CodegenContext {
     ctx
 }
 
+/// Resolve a top-level fn's `FnContract` by bare name. After the
+/// FnKey → FnId migration the contracts map is keyed by opaque
+/// `FnId`, so tests resolve the identity through the symbol table
+/// the same way backends do.
+fn fn_contract<'a>(
+    ctx: &'a CodegenContext,
+    name: &str,
+) -> Option<&'a aver::ir::proof_ir::FnContract> {
+    let key = aver::ir::FnKey::entry(name);
+    let id = ctx.symbol_table.as_ref()?.fn_id_of(&key)?;
+    ctx.proof_ir.fn_contracts.get(&id)
+}
+
 fn legacy_decision(ctx: &CodegenContext, type_name: &str) -> Option<LegacyDecl> {
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
     let info = refinement_info_for(type_name, &inputs)?;
@@ -309,11 +322,8 @@ fn fib_tr_native_contract_matches_legacy_recursion_plan() {
         );
     };
 
-    let contract = ctx
-        .proof_ir
-        .fn_contracts
-        .get(&aver::ir::FnKey::entry("fibTR"))
-        .unwrap_or_else(|| panic!("fibTR has no FnContract in ProofIR"));
+    let contract =
+        fn_contract(&ctx, "fibTR").unwrap_or_else(|| panic!("fibTR has no FnContract in ProofIR"));
     let RecursionContract::Native {
         precondition,
         measure,
@@ -425,11 +435,8 @@ fn exposed_int_countdown_lowers_to_fuel_contract() {
         );
     };
 
-    let contract = ctx
-        .proof_ir
-        .fn_contracts
-        .get(&aver::ir::FnKey::entry("exposed_count"))
-        .expect("exposed_count has no FnContract in ProofIR");
+    let contract =
+        fn_contract(&ctx, "exposed_count").expect("exposed_count has no FnContract in ProofIR");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
         .as_ref()
@@ -489,11 +496,7 @@ fn int_ascending_lowers_to_bound_fuel_contract() {
         );
     };
 
-    let contract = ctx
-        .proof_ir
-        .fn_contracts
-        .get(&aver::ir::FnKey::entry("climb"))
-        .expect("climb has no FnContract");
+    let contract = fn_contract(&ctx, "climb").expect("climb has no FnContract");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
         .as_ref()
@@ -551,11 +554,7 @@ fn list_structural_lowers_to_seq_len_fuel_contract() {
         );
     };
 
-    let contract = ctx
-        .proof_ir
-        .fn_contracts
-        .get(&aver::ir::FnKey::entry("len"))
-        .expect("len has no FnContract");
+    let contract = fn_contract(&ctx, "len").expect("len has no FnContract");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
         .as_ref()
@@ -604,11 +603,7 @@ fn sizeof_structural_lowers_to_sizeof_fuel_contract() {
         plans.get("count")
     );
 
-    let contract = ctx
-        .proof_ir
-        .fn_contracts
-        .get(&aver::ir::FnKey::entry("count"))
-        .expect("count has no FnContract");
+    let contract = fn_contract(&ctx, "count").expect("count has no FnContract");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
         .as_ref()
@@ -644,11 +639,7 @@ fn string_pos_advance_lowers_to_string_pos_fuel_contract() {
         plans.get("walk")
     );
 
-    let contract = ctx
-        .proof_ir
-        .fn_contracts
-        .get(&aver::ir::FnKey::entry("walk"))
-        .expect("walk has no FnContract");
+    let contract = fn_contract(&ctx, "walk").expect("walk has no FnContract");
     let RecursionContract::Fuel { fuel_metric } = contract
         .recursion
         .as_ref()
@@ -709,11 +700,8 @@ fn mutual_int_countdown_lowers_to_lex_fuel_contract() {
             plans.get(fn_name),
         );
 
-        let contract = ctx
-            .proof_ir
-            .fn_contracts
-            .get(&aver::ir::FnKey::entry(fn_name))
-            .unwrap_or_else(|| panic!("{} has no FnContract", fn_name));
+        let contract =
+            fn_contract(&ctx, fn_name).unwrap_or_else(|| panic!("{} has no FnContract", fn_name));
         let RecursionContract::Fuel { fuel_metric } = contract
             .recursion
             .as_ref()
@@ -758,11 +746,7 @@ fn linear_recurrence_lowers_to_dedicated_contract() {
         plans.get("fib"),
     );
 
-    let contract = ctx
-        .proof_ir
-        .fn_contracts
-        .get(&aver::ir::FnKey::entry("fib"))
-        .expect("fib has no FnContract");
+    let contract = fn_contract(&ctx, "fib").expect("fib has no FnContract");
     assert!(
         matches!(
             contract.recursion,

--- a/tests/replay_proptest.rs
+++ b/tests/replay_proptest.rs
@@ -1,3 +1,9 @@
+// `HashMap<Value, Value>` keys are intentionally Value: Value carries
+// interior-mutability slots (Arc<RefCell<_>>) only for variant payloads
+// that the generator skips, so the maps tested here are well-behaved
+// despite clippy's conservative `mutable_key_type` check.
+#![allow(clippy::mutable_key_type)]
+
 //! Property tests for the replay JSON codec (Iron — B3).
 //!
 //! Every replay-safe `Value` must round-trip through the replay JSON


### PR DESCRIPTION
## Summary

Issue #138 phase E1: ProofIR.fn_contracts switches from bare-name / FnKey hybrid to opaque `FnId`, resolved once at the producer boundary through `SymbolTable`. Removes the recurring cross-module bare-name collision class — backends now look up contracts by the canonical id the producer assigned, not by re-deriving identity at each lookup site.

## What changed

- Pipeline runs `BuildSymbols` before the proof stages (`ContractLower`, `LawLower`) so populate has a symbol table.
- `ProofIR.fn_contracts: HashMap<FnKey, FnContract>` → `HashMap<FnId, FnContract>`.
- `populate_fn_contracts_for_scope` resolves canonical FnKey → FnId at insert; skips fns that don't resolve.
- `find_fn_contract_scoped` / `find_fn_contract_for_fn` in `codegen/common.rs` mirror that resolution flow at lookup time.
- Test helpers in `lean/mod.rs`, `dafny/mod.rs`, `tests/proof_ir_diff.rs` flip `run_build_symbols: true` and plumb `symbol_table` into `ctx.symbol_table`.
- Synthetic-ctx path in `CodegenContext::refresh_facts` rebuilds `SymbolTable::build` before re-running `proof_lower::lower`, so the empty-ctx unit tests keep working without per-test changes.

## Follow-ups (tracked in #138)

- TypeKey → TypeId for `refined_types`
- LawTheorem.fn_key → FnId
- Bare-name HashSets in `dafny/mod.rs` (`fuel_emitted`, `native_emitted`, `axiom_fn_names`) once laws-in-modules lands
- Rust/WASM/VM backends — analogous bare-string sites in their call_graph + fn_sigs maps

## Drive-by

`cargo clippy --all-targets` was failing on main on a handful of pre-existing pre-`--lib --bin aver` (CI scope) issues — fixed so local sweep stays clean:
- `vm/symbol.rs` test had unused `Result` on `add_namespace_member`
- `benches/comparison_bench` declared `use wasmtime` unconditionally; bench now needs `--features wasm` to compile
- generated `self_host/aver_generated` triggers `unused_braces` + `needless_return` — `#[allow(...)]` on the module declaration
- `replay_proptest` `HashMap<Value, Value>` trips `mutable_key_type` (intentionally — payloads with interior mutability are filtered out by the generator); module-level allow added

## Test plan

- [x] cargo build + cargo test (1521 passed; 0 failed)
- [x] cargo fmt --check
- [x] CI-style clippy (--lib --bin aver, with and without --features wasm)
- [x] cargo clippy --all-targets -- -D warnings (now also clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)