### PR TITLE
codegen/proof: refined_types + LawTheorem on opaque IDs (#138 phase E2+E3)

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -1026,22 +1026,36 @@ pub fn find_refined_type_scoped<'a>(
 
 /// Round-4 central canonical resolver. Both `find_refined_type` and
 /// `find_refined_type_scoped` reduce to this. Returns the exact
-/// `(canonical_key, &decl)` pair stored in `ProofIR.refined_types`
-/// so downstream code can re-key safely (no string heuristics).
+/// `(canonical_name, &decl)` pair stored in `ProofIR.refined_types`
+/// so downstream code can re-key safely (no string heuristics). The
+/// canonical name is the string form of the `TypeKey` the IR resolved
+/// the decl from (e.g. `AAA.Natural`) — even though the map itself is
+/// keyed by opaque `TypeId` after phase E2, consumers expect a
+/// human-readable identifier here for diagnostics and `defmt`-style
+/// canonical comparison.
+///
+/// Without `ctx.symbol_table` (synthetic legacy ctxs), returns
+/// `None` — the FnId/TypeId migration makes the table mandatory for
+/// proof IR lookup in production paths.
 pub fn find_refined_type_with_key_scoped<'a>(
     ctx: &'a CodegenContext,
     name: &str,
     scope: Option<&str>,
 ) -> Option<(String, &'a crate::ir::proof_ir::RefinedTypeDecl)> {
+    let symbols = ctx.symbol_table.as_ref()?;
     let bare = name.rsplit('.').next().unwrap_or(name);
     let name_is_already_qualified = name.contains('.');
+    let try_key =
+        |key: crate::ir::TypeKey| -> Option<(String, &'a crate::ir::proof_ir::RefinedTypeDecl)> {
+            let id = symbols.type_id_of(&key)?;
+            let decl = ctx.proof_ir.refined_types.get(&id)?;
+            Some((key.canonical(), decl))
+        };
     if let Some(prefix) = scope
         && !name_is_already_qualified
+        && let Some(hit) = try_key(crate::ir::TypeKey::in_module(prefix.to_string(), bare))
     {
-        let scoped_key = crate::ir::TypeKey::in_module(prefix.to_string(), bare);
-        if let Some(decl) = ctx.proof_ir.refined_types.get(&scoped_key) {
-            return Some((scoped_key.canonical(), decl));
-        }
+        return Some(hit);
     }
     let direct_key =
         if name_is_already_qualified && let Some((prefix, bare_part)) = name.rsplit_once('.') {
@@ -1049,16 +1063,15 @@ pub fn find_refined_type_with_key_scoped<'a>(
         } else {
             crate::ir::TypeKey::entry(name)
         };
-    if let Some(decl) = ctx.proof_ir.refined_types.get(&direct_key) {
-        return Some((direct_key.canonical(), decl));
+    if let Some(hit) = try_key(direct_key) {
+        return Some(hit);
     }
     for m in &ctx.modules {
         for td in &m.type_defs {
-            if type_def_name(td) == bare {
-                let canonical_key = crate::ir::TypeKey::in_module(m.prefix.clone(), bare);
-                if let Some(decl) = ctx.proof_ir.refined_types.get(&canonical_key) {
-                    return Some((canonical_key.canonical(), decl));
-                }
+            if type_def_name(td) == bare
+                && let Some(hit) = try_key(crate::ir::TypeKey::in_module(m.prefix.clone(), bare))
+            {
+                return Some(hit);
             }
         }
     }
@@ -1067,31 +1080,35 @@ pub fn find_refined_type_with_key_scoped<'a>(
 
 /// Same resolution shape as [`find_refined_type`] but driven by the
 /// in-flight `refined_types` map plus dep-module list — used inside
-/// `proof_lower` where there is no `CodegenContext` yet.
+/// `proof_lower` where there is no `CodegenContext` yet. Resolves
+/// `name` → `TypeKey` → opaque `TypeId` through the supplied symbol
+/// table, then looks up the decl by id.
 pub fn resolve_refined_type_in<'a>(
     refined_types: &'a std::collections::HashMap<
-        crate::ir::TypeKey,
+        crate::ir::TypeId,
         crate::ir::proof_ir::RefinedTypeDecl,
     >,
+    symbols: &crate::ir::SymbolTable,
     modules: &[crate::codegen::ModuleInfo],
     name: &str,
 ) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
-    resolve_refined_type_in_with_key(refined_types, modules, name).map(|(_, d)| d)
+    resolve_refined_type_in_with_key(refined_types, symbols, modules, name).map(|(_, d)| d)
 }
 
 /// Same as [`resolve_refined_type_in`] but returns the canonical
-/// `TypeKey` paired with the decl — used by IR-internal callers
+/// `TypeId` paired with the decl — used by IR-internal callers
 /// (the proof-lower side `walk_for_refinement_carrier`) so they
-/// thread the canonical identity through downstream comparisons
+/// thread the opaque identity through downstream comparisons
 /// without re-introducing bare-name heuristics.
 pub fn resolve_refined_type_in_with_key<'a>(
     refined_types: &'a std::collections::HashMap<
-        crate::ir::TypeKey,
+        crate::ir::TypeId,
         crate::ir::proof_ir::RefinedTypeDecl,
     >,
+    symbols: &crate::ir::SymbolTable,
     modules: &[crate::codegen::ModuleInfo],
     name: &str,
-) -> Option<(crate::ir::TypeKey, &'a crate::ir::proof_ir::RefinedTypeDecl)> {
+) -> Option<(crate::ir::TypeId, &'a crate::ir::proof_ir::RefinedTypeDecl)> {
     let bare = name.rsplit('.').next().unwrap_or(name);
     let name_is_already_qualified = name.contains('.');
     let direct_key =
@@ -1100,15 +1117,19 @@ pub fn resolve_refined_type_in_with_key<'a>(
         } else {
             crate::ir::TypeKey::entry(name)
         };
-    if let Some(decl) = refined_types.get(&direct_key) {
-        return Some((direct_key, decl));
+    if let Some(id) = symbols.type_id_of(&direct_key)
+        && let Some(decl) = refined_types.get(&id)
+    {
+        return Some((id, decl));
     }
     for m in modules {
         for td in &m.type_defs {
             if type_def_name(td) == bare {
                 let canonical = crate::ir::TypeKey::in_module(m.prefix.clone(), bare);
-                if let Some(decl) = refined_types.get(&canonical) {
-                    return Some((canonical, decl));
+                if let Some(id) = symbols.type_id_of(&canonical)
+                    && let Some(decl) = refined_types.get(&id)
+                {
+                    return Some((id, decl));
                 }
             }
         }
@@ -2393,22 +2414,24 @@ mod tests {
             },
             witness: Some(witness.to_string()),
         };
-        let mut refined_types: HashMap<crate::ir::TypeKey, RefinedTypeDecl> = HashMap::new();
-        refined_types.insert(
-            crate::ir::TypeKey::in_module("A", "Natural"),
-            make_decl("a", 0),
-        );
-        refined_types.insert(
-            crate::ir::TypeKey::in_module("B", "Natural"),
-            make_decl("b", 10),
-        );
+        let symbols = crate::ir::SymbolTable::build(&[], &modules);
+        let a_id = symbols
+            .type_id_of(&crate::ir::TypeKey::in_module("A", "Natural"))
+            .expect("A.Natural TypeId");
+        let b_id = symbols
+            .type_id_of(&crate::ir::TypeKey::in_module("B", "Natural"))
+            .expect("B.Natural TypeId");
+
+        let mut refined_types: HashMap<crate::ir::TypeId, RefinedTypeDecl> = HashMap::new();
+        refined_types.insert(a_id, make_decl("a", 0));
+        refined_types.insert(b_id, make_decl("b", 10));
 
         // Fully-qualified lookups hit the exact slot.
-        let a = resolve_refined_type_in(&refined_types, &modules, "A.Natural")
+        let a = resolve_refined_type_in(&refined_types, &symbols, &modules, "A.Natural")
             .expect("A.Natural canonical lookup");
         assert_eq!(a.predicate_param, "a");
         assert_eq!(a.witness.as_deref(), Some("0"));
-        let b = resolve_refined_type_in(&refined_types, &modules, "B.Natural")
+        let b = resolve_refined_type_in(&refined_types, &symbols, &modules, "B.Natural")
             .expect("B.Natural canonical lookup");
         assert_eq!(b.predicate_param, "b");
         assert_eq!(b.witness.as_deref(), Some("10"));
@@ -2416,7 +2439,7 @@ mod tests {
         // Bare lookup finds *something* (module-walk first match) —
         // the typechecker prevents mixed usage upstream, so the
         // observed ordering is the order modules walk.
-        let bare = resolve_refined_type_in(&refined_types, &modules, "Natural")
+        let bare = resolve_refined_type_in(&refined_types, &symbols, &modules, "Natural")
             .expect("bare Natural resolves via module walk");
         assert!(
             bare.predicate_param == "a" || bare.predicate_param == "b",
@@ -2425,7 +2448,7 @@ mod tests {
 
         // No-module-owner lookup misses — i.e. a bare name that
         // wasn't declared in any module is None, not "first in map".
-        assert!(resolve_refined_type_in(&refined_types, &modules, "Unrelated").is_none());
+        assert!(resolve_refined_type_in(&refined_types, &symbols, &modules, "Unrelated").is_none());
     }
 
     #[test]
@@ -2437,11 +2460,16 @@ mod tests {
         // The pre-fix order tried direct `refined_types.get(name)`
         // first, which matched entry's bare-keyed slot and the
         // scope-prefix lookup never ran.
-        use crate::ast::TypeDef;
+        use crate::ast::{TopLevel, TypeDef};
         use crate::codegen::{CodegenContext, ModuleInfo};
         use crate::ir::proof_ir::{Predicate, QuantifierType, RefinedTypeDecl};
         use std::collections::{HashMap, HashSet};
 
+        let entry_natural = TypeDef::Product {
+            name: "Natural".to_string(),
+            fields: vec![("value".to_string(), "Int".to_string())],
+            line: 1,
+        };
         let module = ModuleInfo {
             prefix: "Mod".to_string(),
             depends: Vec::new(),
@@ -2466,15 +2494,25 @@ mod tests {
             witness: Some(witness.to_string()),
         };
 
+        let items = vec![TopLevel::TypeDef(entry_natural)];
+        let modules = vec![module];
+        let symbol_table = crate::ir::SymbolTable::build(&items, &modules);
+        let entry_id = symbol_table
+            .type_id_of(&crate::ir::TypeKey::entry("Natural"))
+            .expect("entry Natural id");
+        let mod_id = symbol_table
+            .type_id_of(&crate::ir::TypeKey::in_module("Mod", "Natural"))
+            .expect("Mod.Natural id");
+
         let mut ctx = CodegenContext {
-            items: Vec::new(),
+            items,
             fn_sigs: HashMap::new(),
             memo_fns: HashSet::new(),
             memo_safe_types: HashSet::new(),
             type_defs: Vec::new(),
             fn_defs: Vec::new(),
             project_name: "scope-test".to_string(),
-            modules: vec![module],
+            modules,
             module_prefixes: HashSet::new(),
             #[cfg(feature = "runtime")]
             policy: None,
@@ -2490,16 +2528,14 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
-            symbol_table: None,
+            symbol_table: Some(symbol_table),
         };
-        ctx.proof_ir.refined_types.insert(
-            crate::ir::TypeKey::entry("Natural"),
-            make_decl("entry_n", "0"),
-        );
-        ctx.proof_ir.refined_types.insert(
-            crate::ir::TypeKey::in_module("Mod", "Natural"),
-            make_decl("mod_n", "10"),
-        );
+        ctx.proof_ir
+            .refined_types
+            .insert(entry_id, make_decl("entry_n", "0"));
+        ctx.proof_ir
+            .refined_types
+            .insert(mod_id, make_decl("mod_n", "10"));
 
         let from_module = find_refined_type_scoped(&ctx, "Natural", Some("Mod"))
             .expect("Mod-scoped Natural lookup");

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1281,12 +1281,17 @@ pub fn emit_verify_law(
     // BackendDispatch / Sorry don't close constant-RHS shapes;
     // anything else (Reflexive, Associative, MapUpdatePostcondition,
     // …) does and stays. Mirror of the Lean gate.
-    let vb_fn_key = crate::ir::FnKey::entry(&vb.fn_name);
-    let ir_strategy_closes_const_rhs = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == vb_fn_key && t.law_name == law.name)
+    let vb_fn_id = ctx
+        .symbol_table
+        .as_ref()
+        .and_then(|s| s.fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name)));
+    let ir_strategy_closes_const_rhs = vb_fn_id
+        .and_then(|fn_id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        })
         .is_some_and(|t| {
             !matches!(
                 t.strategy,
@@ -1331,11 +1336,13 @@ pub fn emit_verify_law(
         impl_fn,
         spec_fn,
         helper_fn,
-    }) = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == crate::ir::FnKey::entry(&vb.fn_name) && t.law_name == law.name)
+    }) = vb_fn_id
+        .and_then(|fn_id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        })
         .map(|t| t.strategy.clone())
     {
         return emit_linear_recurrence2_support_stack(

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -30,11 +30,14 @@ fn law_strategy_for(
     fn_name: &str,
     law_name: &str,
 ) -> Option<crate::ir::ProofStrategy> {
-    let key = crate::ir::FnKey::entry(fn_name);
+    let fn_id = ctx
+        .symbol_table
+        .as_ref()?
+        .fn_id_of(&crate::ir::FnKey::entry(fn_name))?;
     ctx.proof_ir
         .law_theorems
         .iter()
-        .find(|t| t.fn_key == key && t.law_name == law_name)
+        .find(|t| t.fn_id == fn_id && t.law_name == law_name)
         .map(|t| t.strategy.clone())
 }
 

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -2158,6 +2158,23 @@ verify square law squareSpec
     #[test]
     fn transpile_auto_proves_reflexive_law_with_rfl() {
         let mut ctx = empty_ctx();
+        // After the phase-E3 migration LawTheorem.fn_id is resolved
+        // through the symbol table at populate time, so the law's
+        // target fn must exist as a FnDef in `ctx.items`. Pre-fix
+        // the verify block alone was enough (FnKey was constructed
+        // from the bare name without checking).
+        let id_law = FnDef {
+            name: "idLaw".to_string(),
+            line: 1,
+            params: vec![("x".to_string(), "Int".to_string())],
+            return_type: "Int".to_string(),
+            effects: vec![],
+            desc: None,
+            body: Rc::new(FnBody::from_expr(sb(Expr::Ident("x".to_string())))),
+            resolution: None,
+        };
+        ctx.fn_defs.push(id_law.clone());
+        ctx.items.push(TopLevel::FnDef(id_law));
         ctx.items.push(TopLevel::Verify(VerifyBlock {
             fn_name: "idLaw".to_string(),
             line: 1,
@@ -2609,6 +2626,21 @@ verify square law squareSpec
     #[test]
     fn transpile_auto_proves_direct_map_set_laws() {
         let mut ctx = empty_ctx();
+
+        // Stub FnDef for the verify target — see analogous note in
+        // `transpile_auto_proves_reflexive_law_with_rfl`.
+        let map_fn = FnDef {
+            name: "map".to_string(),
+            line: 1,
+            params: vec![],
+            return_type: "Int".to_string(),
+            effects: vec![],
+            desc: None,
+            body: Rc::new(FnBody::from_expr(sb(Expr::Literal(Literal::Int(0))))),
+            resolution: None,
+        };
+        ctx.fn_defs.push(map_fn.clone());
+        ctx.items.push(TopLevel::FnDef(map_fn));
 
         let map_set = |m: Spanned<Expr>, k: Spanned<Expr>, v: Spanned<Expr>| {
             sb(Expr::FnCall(

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1896,12 +1896,16 @@ fn emit_verify_law_block(
     // constant-RHS shapes (Reflexive, Commutative, Associative,
     // MapUpdatePostcondition, …) stay in the keep-set; Induction
     // / BackendDispatch / Sorry don't.
-    let vb_fn_key = crate::ir::FnKey::entry(&vb.fn_name);
     let ir_strategy_closes_const_rhs = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == vb_fn_key && t.law_name == law.name)
+        .symbol_table
+        .as_ref()
+        .and_then(|s| s.fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name)))
+        .and_then(|fn_id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        })
         .is_some_and(|t| {
             !matches!(
                 t.strategy,

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -234,18 +234,25 @@ pub fn lower(inputs: &ProofLowerInputs) -> ProofIR {
 /// (Lean → Subtype, Dafny → subset type) render these directly.
 pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
     // Walk entry items first, then dep modules. The map is keyed by
-    // *canonical* name: bare for entry types, `Module.Name` for
-    // module-owned types. Bare keying was insufficient — the
-    // typechecker explicitly permits two modules to expose
-    // distinct types of the same bare name (`A.Shape` vs
-    // `B.Shape`; see `tests/typechecker_spec::cross_module_same_named_
-    // types_do_not_merge`). If a project depends on two modules
-    // each declaring a refined `Natural` with different predicates,
-    // bare keying picked whichever one walked first and silently
-    // applied its predicate at every call site referring to the
-    // other. Canonical keying gives each declaration its own slot;
-    // [`find_refined_type`] does the lookup-side resolution from
-    // bare references back through `ctx.modules`.
+    // opaque `TypeId` resolved through the symbol table — same
+    // collision-safe shape as `fn_contracts: HashMap<FnId, _>`. The
+    // typechecker explicitly permits two modules to expose distinct
+    // types of the same bare name (`A.Shape` vs `B.Shape`; see
+    // `tests/typechecker_spec::cross_module_same_named_types_do_not_
+    // merge`); opaque IDs make their predicates impossible to merge
+    // by construction. Producer resolves `TypeKey -> TypeId` once
+    // here; consumers (`find_refined_type_scoped`) resolve through
+    // the same symbol table at lookup time.
+    //
+    // BuildSymbols auto-enables alongside RefinementLower in the
+    // pipeline, so reaching this point without `inputs.symbol_table`
+    // is a wiring bug. Synthetic-ctx callers (test helpers) must
+    // build the symbol table before invoking `lower` — `refresh_facts`
+    // and the lean/dafny test `populate_proof_ir` helpers already do.
+    let symbols = inputs
+        .symbol_table
+        .expect("populate_refined_types requires SymbolTable (run BuildSymbols first)");
+
     let entry_typedefs = inputs.entry_items.iter().filter_map(|item| match item {
         TopLevel::TypeDef(td) => Some((None::<&str>, td)),
         _ => None,
@@ -263,15 +270,22 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
         if fields.len() != 1 {
             continue;
         }
-        let canonical_key = match module_prefix {
+        let type_key = match module_prefix {
             Some(prefix) => crate::ir::TypeKey::in_module(prefix.to_string(), name),
             None => crate::ir::TypeKey::entry(name),
         };
+        let Some(canonical_key) = symbols.type_id_of(&type_key) else {
+            // Type isn't in the symbol table — built-ins (Result.Ok
+            // etc.) are excluded by construction; for user types
+            // this is a wiring bug surfaced via the symbol-table
+            // builder, so just skip.
+            continue;
+        };
         if ir.refined_types.contains_key(&canonical_key) {
-            // Same canonical key already populated — possible if a
-            // module is walked twice through dep aliasing. Skip so
-            // we don't overwrite a verified-witness entry with a
-            // predicate-eval fallback witness.
+            // Same TypeId already populated — possible if a module
+            // is walked twice through dep aliasing. Skip so we don't
+            // overwrite a verified-witness entry with a predicate-
+            // eval fallback witness.
             continue;
         }
         // Scope the smart-constructor lookup to the same module the
@@ -633,6 +647,10 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
     use crate::ast::{TopLevel, VerifyKind};
     use crate::ir::{LawTheorem, Predicate, Quantifier, QuantifierType};
 
+    let symbols = inputs
+        .symbol_table
+        .expect("populate_law_theorems requires SymbolTable (run BuildSymbols first)");
+
     let entry_verifies = inputs.entry_items.iter().filter_map(|item| match item {
         TopLevel::Verify(vb) => Some(vb),
         _ => None,
@@ -667,11 +685,18 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
 
         let strategy = classify_law_strategy(law, &vb.fn_name, inputs, &ir.refined_types);
 
+        // Verify laws are entry-only per current model — see
+        // `LawTheorem.fn_id` doc. The bare `vb.fn_name` resolves
+        // through the symbol table to an entry-scope `FnId`; when
+        // the fn isn't in the symbol table (verify block targeting
+        // a fn that doesn't exist), skip the law silently — the
+        // typechecker / verify-driver surfaces the missing target
+        // elsewhere.
+        let Some(fn_id) = symbols.fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name)) else {
+            continue;
+        };
         ir.law_theorems.push(LawTheorem {
-            // Verify laws are entry-only per current model — see
-            // `LawTheorem.fn_key` doc. The bare `vb.fn_name` from
-            // the source AST becomes an entry-scope `FnKey`.
-            fn_key: crate::ir::FnKey::entry(vb.fn_name.clone()),
+            fn_id,
             law_name: law.name.clone(),
             quantifiers,
             premises,
@@ -704,7 +729,7 @@ fn classify_law_strategy(
     law: &crate::ast::VerifyLaw,
     fn_name: &str,
     inputs: &ProofLowerInputs,
-    refined_types: &std::collections::HashMap<crate::ir::TypeKey, crate::ir::RefinedTypeDecl>,
+    refined_types: &std::collections::HashMap<crate::ir::TypeId, crate::ir::RefinedTypeDecl>,
 ) -> crate::ir::ProofStrategy {
     use crate::ir::ProofStrategy;
 
@@ -862,7 +887,7 @@ fn detect_simp_omega_unfold(
     law: &crate::ast::VerifyLaw,
     fn_name: &str,
     inputs: &ProofLowerInputs,
-    refined_types: &std::collections::HashMap<crate::ir::TypeKey, crate::ir::RefinedTypeDecl>,
+    refined_types: &std::collections::HashMap<crate::ir::TypeId, crate::ir::RefinedTypeDecl>,
 ) -> Option<SimpOmegaPlan> {
     use std::collections::BTreeSet;
 
@@ -877,12 +902,16 @@ fn detect_simp_omega_unfold(
     // Natural, b: Natural)`) and unfold through the smart
     // constructor to Int arithmetic. Skip the outer-Int rejection
     // for lifted laws.
+    let symbols = inputs
+        .symbol_table
+        .expect("detect_simp_omega_unfold requires SymbolTable");
     let lifted = law.givens.iter().any(|g| {
         refinement_lift_for_given_ir(
             &g.name,
             &law.lhs,
             &law.rhs,
             refined_types,
+            symbols,
             inputs.dep_modules,
         )
         .is_some()
@@ -987,19 +1016,35 @@ fn refinement_lift_for_given_ir(
     given_name: &str,
     lhs: &Spanned<crate::ast::Expr>,
     rhs: &Spanned<crate::ast::Expr>,
-    refined_types: &std::collections::HashMap<crate::ir::TypeKey, crate::ir::RefinedTypeDecl>,
+    refined_types: &std::collections::HashMap<crate::ir::TypeId, crate::ir::RefinedTypeDecl>,
+    symbols: &crate::ir::SymbolTable,
     dep_modules: &[crate::codegen::ModuleInfo],
 ) -> Option<String> {
     let mut result: Option<String> = None;
-    walk_for_refinement_carrier(lhs, given_name, refined_types, dep_modules, &mut result);
-    walk_for_refinement_carrier(rhs, given_name, refined_types, dep_modules, &mut result);
+    walk_for_refinement_carrier(
+        lhs,
+        given_name,
+        refined_types,
+        symbols,
+        dep_modules,
+        &mut result,
+    );
+    walk_for_refinement_carrier(
+        rhs,
+        given_name,
+        refined_types,
+        symbols,
+        dep_modules,
+        &mut result,
+    );
     result
 }
 
 fn walk_for_refinement_carrier(
     expr: &Spanned<crate::ast::Expr>,
     given_name: &str,
-    refined_types: &std::collections::HashMap<crate::ir::TypeKey, crate::ir::RefinedTypeDecl>,
+    refined_types: &std::collections::HashMap<crate::ir::TypeId, crate::ir::RefinedTypeDecl>,
+    symbols: &crate::ir::SymbolTable,
     dep_modules: &[crate::codegen::ModuleInfo],
     result: &mut Option<String>,
 ) {
@@ -1015,55 +1060,87 @@ fn walk_for_refinement_carrier(
                 Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == given_name
             );
             if matches_var
-                && let Some((canonical_key, _decl)) =
+                && let Some((type_id, _decl)) =
                     crate::codegen::common::resolve_refined_type_in_with_key(
                         refined_types,
+                        symbols,
                         dep_modules,
                         type_name,
                     )
             {
-                // Return the canonical key the IR populator stored
-                // the slot under (e.g. `AAA.Natural`), not
-                // `decl.name` which is bare per `RefinedTypeDecl`'s
-                // doc. Today the only consumer reads `.is_some()`
-                // (see `detect_simp_omega_unfold`), so this is a
-                // hygiene fix — but any future load-bearing use of
-                // the returned identifier inherits the same
-                // canonical guarantee `find_refined_type_with_key`
-                // gives the backend side.
-                *result = Some(canonical_key.canonical());
+                // Stringify the canonical name via the symbol table's
+                // type entry. The only consumer today reads `.is_some()`
+                // (see `detect_simp_omega_unfold`), but recovering a
+                // human-readable id keeps the diagnostic path honest.
+                *result = Some(symbols.type_entry(type_id).key.canonical());
                 return;
             }
             // Even non-matching RecordCreate may contain nested
             // refinement carriers (e.g. `Foo(value = Bar(value = a))`).
             for (_, v) in fields {
-                walk_for_refinement_carrier(v, given_name, refined_types, dep_modules, result);
+                walk_for_refinement_carrier(
+                    v,
+                    given_name,
+                    refined_types,
+                    symbols,
+                    dep_modules,
+                    result,
+                );
             }
         }
         Expr::FnCall(callee, args) => {
-            walk_for_refinement_carrier(callee, given_name, refined_types, dep_modules, result);
+            walk_for_refinement_carrier(
+                callee,
+                given_name,
+                refined_types,
+                symbols,
+                dep_modules,
+                result,
+            );
             for a in args {
-                walk_for_refinement_carrier(a, given_name, refined_types, dep_modules, result);
+                walk_for_refinement_carrier(
+                    a,
+                    given_name,
+                    refined_types,
+                    symbols,
+                    dep_modules,
+                    result,
+                );
             }
         }
         Expr::BinOp(_, l, r) => {
-            walk_for_refinement_carrier(l, given_name, refined_types, dep_modules, result);
-            walk_for_refinement_carrier(r, given_name, refined_types, dep_modules, result);
+            walk_for_refinement_carrier(l, given_name, refined_types, symbols, dep_modules, result);
+            walk_for_refinement_carrier(r, given_name, refined_types, symbols, dep_modules, result);
         }
         Expr::Match { subject, arms, .. } => {
-            walk_for_refinement_carrier(subject, given_name, refined_types, dep_modules, result);
+            walk_for_refinement_carrier(
+                subject,
+                given_name,
+                refined_types,
+                symbols,
+                dep_modules,
+                result,
+            );
             for arm in arms {
                 walk_for_refinement_carrier(
                     &arm.body,
                     given_name,
                     refined_types,
+                    symbols,
                     dep_modules,
                     result,
                 );
             }
         }
         Expr::Attr(obj, _) => {
-            walk_for_refinement_carrier(obj, given_name, refined_types, dep_modules, result);
+            walk_for_refinement_carrier(
+                obj,
+                given_name,
+                refined_types,
+                symbols,
+                dep_modules,
+                result,
+            );
         }
         _ => {}
     }

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -43,12 +43,14 @@ pub use crate::ir::symbol_table::{CtorId, FnId, ModuleId, TypeId};
 /// untyped AST path, same as runtime backends (VM, Rust, WASM).
 #[derive(Debug, Clone, Default)]
 pub struct ProofIR {
-    /// Every refinement-lifted user type, keyed by [`TypeKey`].
-    /// Two modules with same-bare-name refined records (`A.Natural`
-    /// and `B.Natural`) get distinct keys so their predicates never
-    /// merge. Includes types declared in the entry items and in
-    /// dependent modules.
-    pub refined_types: HashMap<TypeKey, RefinedTypeDecl>,
+    /// Every refinement-lifted user type, keyed by opaque [`TypeId`]
+    /// from the symbol table. Same-bare-name refined records in two
+    /// modules (`A.Natural` vs `B.Natural`) get distinct IDs, so
+    /// their predicates never merge. Includes types declared in the
+    /// entry items and in dependent modules; name resolution happens
+    /// once in `populate_refined_types`, consumers look up directly
+    /// by id through `ctx.symbol_table`.
+    pub refined_types: HashMap<TypeId, RefinedTypeDecl>,
     /// Per-pure-fn contract describing what proof artifact the fn
     /// lowers to (native / fuel / structural / linear recurrence).
     /// Keyed by opaque [`FnId`] from the symbol table — name
@@ -296,13 +298,14 @@ pub enum DecreaseProof {
 /// already baked into the fields below; backends render directly.
 #[derive(Debug, Clone)]
 pub struct LawTheorem {
-    /// Round-7+: typed identity for the fn this law targets. Verify
-    /// laws are entry-only per the current model, so the key's
-    /// scope is effectively always `None` today — keying via
-    /// [`FnKey`] is the discipline marker, ready for laws in dep
-    /// modules once that feature lands. Callsites compare against
-    /// the typed key, not a bare string.
-    pub fn_key: FnKey,
+    /// Opaque identity of the fn this law targets, resolved through
+    /// `SymbolTable` at populate time (phase E3). Verify laws are
+    /// entry-only per the current model, so this is effectively
+    /// always an entry-scope `FnId` today; once laws-in-modules
+    /// lands the same `FnId` will distinguish two same-bare-name
+    /// recursive fns across modules without any per-callsite scope
+    /// plumbing.
+    pub fn_id: FnId,
     pub law_name: String,
     pub quantifiers: Vec<Quantifier>,
     /// Premises in order. Already includes `when` if it carries

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -3169,7 +3169,10 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
     // selected stage populated) instead of the (unchanged) items list.
     if proof_target {
         match pipeline_result.proof_ir {
-            Some(ir) => print!("{}", render_proof_ir_dump(&ir)),
+            Some(ir) => print!(
+                "{}",
+                render_proof_ir_dump(&ir, pipeline_result.symbol_table.as_ref())
+            ),
             None => {
                 eprintln!(
                     "{}",
@@ -3214,7 +3217,7 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
 /// exporter (Lean / Dafny) would consume. Useful for debugging
 /// "why did this fn get Fuel vs Native?", "what precondition did
 /// the lowerer derive?", "did this type lift to a subtype?".
-fn render_proof_ir_dump(ir: &aver::ir::ProofIR) -> String {
+fn render_proof_ir_dump(ir: &aver::ir::ProofIR, symbols: Option<&aver::ir::SymbolTable>) -> String {
     use aver::ir::{Measure, RecursionContract};
     use std::fmt::Write as _;
     let mut out = String::new();
@@ -3284,14 +3287,21 @@ fn render_proof_ir_dump(ir: &aver::ir::ProofIR) -> String {
     writeln!(out).unwrap();
     writeln!(out, "## law_theorems ({})", ir.law_theorems.len()).unwrap();
     let mut laws: Vec<_> = ir.law_theorems.iter().collect();
-    laws.sort_by(|a, b| {
-        (a.fn_key.canonical(), &a.law_name).cmp(&(b.fn_key.canonical(), &b.law_name))
-    });
+    // Render the fn identity through the symbol table so the dump
+    // stays human-readable after the FnKey → FnId migration. When
+    // there is no symbol table (best-effort path), fall back to
+    // the raw FnId for sort-stability.
+    let fn_label = |fn_id: aver::ir::FnId| -> String {
+        symbols
+            .map(|s| s.fn_entry(fn_id).key.canonical())
+            .unwrap_or_else(|| format!("FnId({:?})", fn_id))
+    };
+    laws.sort_by(|a, b| (fn_label(a.fn_id), &a.law_name).cmp(&(fn_label(b.fn_id), &b.law_name)));
     for theorem in laws {
         writeln!(
             out,
             "- {}::{} ({:?}, {} quantifier(s), {} premise(s))",
-            theorem.fn_key.canonical(),
+            fn_label(theorem.fn_id),
             theorem.law_name,
             theorem.strategy,
             theorem.quantifiers.len(),

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -85,6 +85,24 @@ fn fn_contract<'a>(
     ctx.proof_ir.fn_contracts.get(&id)
 }
 
+/// Find a `LawTheorem` by entry-scope fn name + law name. Mirror of
+/// `fn_contract` for the FnKey → FnId migration: tests resolve the
+/// fn identity through the symbol table, then match by opaque id.
+fn law_theorem<'a>(
+    ctx: &'a CodegenContext,
+    fn_name: &str,
+    law_name: &str,
+) -> Option<&'a aver::ir::proof_ir::LawTheorem> {
+    let fn_id = ctx
+        .symbol_table
+        .as_ref()?
+        .fn_id_of(&aver::ir::FnKey::entry(fn_name))?;
+    ctx.proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_id == fn_id && t.law_name == law_name)
+}
+
 fn legacy_decision(ctx: &CodegenContext, type_name: &str) -> Option<LegacyDecl> {
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
     let info = refinement_info_for(type_name, &inputs)?;
@@ -778,11 +796,7 @@ fn law_lower_populates_theorems_from_verify_law_blocks() {
          \x20   add(a, b) => add(b, a)\n";
     let ctx = build_ctx(src);
 
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("add") && t.law_name == "commutative")
+    let theorem = law_theorem(&ctx, "add", "commutative")
         .expect("add::commutative law theorem missing from ProofIR");
 
     assert_eq!(theorem.quantifiers.len(), 2, "expected 2 quantifiers");
@@ -828,11 +842,7 @@ fn reflexive_law_pinned_when_lhs_equals_rhs() {
          \x20   given x: Int = -2..2\n\
          \x20   x => x\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("id") && t.law_name == "reflexive")
+    let theorem = law_theorem(&ctx, "id", "reflexive")
         .expect("id::reflexive law theorem missing from ProofIR");
     assert!(
         matches!(theorem.strategy, aver::ir::ProofStrategy::Reflexive),
@@ -857,12 +867,8 @@ fn wrapper_associative_pinned_on_three_int_givens_assoc_shape() {
          \x20   given c: Int = -1..1\n\
          \x20   add(add(a, b), c) => add(a, add(b, c))\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("add") && t.law_name == "associative")
-        .expect("add::associative law theorem missing");
+    let theorem =
+        law_theorem(&ctx, "add", "associative").expect("add::associative law theorem missing");
     assert!(
         matches!(
             theorem.strategy,
@@ -890,12 +896,8 @@ fn wrapper_identity_pinned_on_add_with_zero_rhs() {
          \x20   given a: Int = -3..3\n\
          \x20   add(a, 0) => a\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("add") && t.law_name == "identityZero")
-        .expect("add::identityZero law theorem missing");
+    let theorem =
+        law_theorem(&ctx, "add", "identityZero").expect("add::identityZero law theorem missing");
     assert!(
         matches!(
             theorem.strategy,
@@ -923,12 +925,8 @@ fn wrapper_sub_right_identity_pinned_on_sub_with_zero_rhs() {
          \x20   given a: Int = -3..3\n\
          \x20   sub(a, 0) => a\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("sub") && t.law_name == "rightIdentity")
-        .expect("sub::rightIdentity law theorem missing");
+    let theorem =
+        law_theorem(&ctx, "sub", "rightIdentity").expect("sub::rightIdentity law theorem missing");
     assert!(
         matches!(
             theorem.strategy,
@@ -957,11 +955,7 @@ fn wrapper_sub_anti_commutative_pinned_with_neg_direction() {
          \x20   given b: Int = -2..2\n\
          \x20   sub(a, b) => -sub(b, a)\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("sub") && t.law_name == "antiCommutative")
+    let theorem = law_theorem(&ctx, "sub", "antiCommutative")
         .expect("sub::antiCommutative law theorem missing");
     assert!(
         matches!(
@@ -996,11 +990,7 @@ fn wrapper_unary_equivalence_pinned_with_inner_fn_name() {
          \x20   given a: Int = -2..2\n\
          \x20   addOne(a) => add(a, 1)\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("addOne") && t.law_name == "identityViaAdd")
+    let theorem = law_theorem(&ctx, "addOne", "identityViaAdd")
         .expect("addOne::identityViaAdd law theorem missing");
     let aver::ir::ProofStrategy::UnaryEqualsBinary { ref inner_fn } = theorem.strategy else {
         panic!("expected UnaryEqualsBinary, got: {:?}", theorem.strategy);
@@ -1026,11 +1016,7 @@ fn simp_omega_unfold_pinned_on_sub_anti_comm_via_zero() {
          \x20   given b: Int = -2..2\n\
          \x20   sub(a, b) => 0 - sub(b, a)\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("sub") && t.law_name == "antiCommutative")
+    let theorem = law_theorem(&ctx, "sub", "antiCommutative")
         .expect("sub::antiCommutative law theorem missing");
     let aver::ir::ProofStrategy::LinearArithmetic {
         ref unfold_fns,
@@ -1077,12 +1063,8 @@ fn linear_arithmetic_pinned_with_lifted_for_refinement_law() {
          \x20   when b >= 0\n\
          \x20   add(Natural(value = a), Natural(value = b)) => add(Natural(value = b), Natural(value = a))\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("add") && t.law_name == "commutative")
-        .expect("add::commutative law theorem missing");
+    let theorem =
+        law_theorem(&ctx, "add", "commutative").expect("add::commutative law theorem missing");
     let aver::ir::ProofStrategy::LinearArithmetic {
         wrapper_return,
         lifted,
@@ -1119,12 +1101,7 @@ fn induction_pinned_on_recursive_adt_given() {
          \x20   given t: Tree = [Tree.Leaf]\n\
          \x20   id(t) => t\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("id") && t.law_name == "identity")
-        .expect("id::identity law theorem missing");
+    let theorem = law_theorem(&ctx, "id", "identity").expect("id::identity law theorem missing");
     let aver::ir::ProofStrategy::Induction { ref param } = theorem.strategy else {
         panic!(
             "expected Induction {{ param }}, got: {:?}",
@@ -1151,12 +1128,8 @@ fn library_axiom_pinned_on_map_has_set_self() {
          \x20   given v: Int = [1]\n\
          \x20   Map.has(Map.set(m, k, v), k) => true\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("touch") && t.law_name == "hasAfterSet")
-        .expect("touch::hasAfterSet law theorem missing");
+    let theorem =
+        law_theorem(&ctx, "touch", "hasAfterSet").expect("touch::hasAfterSet law theorem missing");
     let aver::ir::ProofStrategy::LibraryAxiom {
         ref axiom,
         ref args,
@@ -1188,11 +1161,7 @@ fn map_update_postcondition_pinned_has_after() {
          \x20   given word: String = [\"a\"]\n\
          \x20   Map.has(incCount(counts, word), word) => true\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("incCount") && t.law_name == "keyPresent")
+    let theorem = law_theorem(&ctx, "incCount", "keyPresent")
         .expect("incCount::keyPresent law theorem missing");
     let aver::ir::ProofStrategy::MapUpdatePostcondition {
         ref outer_fn,
@@ -1235,13 +1204,7 @@ fn map_update_postcondition_pinned_get_after_with_helper_unfolds() {
          \x20   given counts: Map<String, Int> = [{\"a\" => 1}]\n\
          \x20   Map.get(incCount(counts, \"a\"), \"a\") => Option.Some(addOne(Option.withDefault(Map.get(counts, \"a\"), 0)))\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| {
-            t.fn_key == aver::ir::FnKey::entry("incCount") && t.law_name == "existingKeyIncrements"
-        })
+    let theorem = law_theorem(&ctx, "incCount", "existingKeyIncrements")
         .expect("incCount::existingKeyIncrements law theorem missing");
     let aver::ir::ProofStrategy::MapUpdatePostcondition {
         ref outer_fn,
@@ -1285,13 +1248,7 @@ fn map_key_tracked_increment_pinned_on_defaulted_get_plus_one() {
          \x20   given word: String = [\"a\"]\n\
          \x20   Option.withDefault(Map.get(incCount(counts, word), word), 0) => Option.withDefault(Map.get(counts, word), 0) + 1\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| {
-            t.fn_key == aver::ir::FnKey::entry("incCount") && t.law_name == "trackedCountStepsByOne"
-        })
+    let theorem = law_theorem(&ctx, "incCount", "trackedCountStepsByOne")
         .expect("incCount::trackedCountStepsByOne law theorem missing");
     let aver::ir::ProofStrategy::MapKeyTrackedIncrement { ref outer_fn, .. } = theorem.strategy
     else {
@@ -1325,12 +1282,8 @@ fn spec_equivalence_pinned_on_identical_body_impl_spec_pair() {
          \x20   given x: Int = [0]\n\
          \x20   absVal(x) => absValSpec(x)\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("absVal") && t.law_name == "absValSpec")
-        .expect("absVal::absValSpec law theorem missing");
+    let theorem =
+        law_theorem(&ctx, "absVal", "absValSpec").expect("absVal::absValSpec law theorem missing");
     let aver::ir::ProofStrategy::SpecEquivalence { ref extra_unfolds } = theorem.strategy else {
         panic!("expected SpecEquivalence, got: {:?}", theorem.strategy);
     };
@@ -1367,11 +1320,7 @@ fn effectful_spec_equivalence_pinned_post_oracle_lift() {
          \x20   given rnd: Random.int = [counterStub]\n\
          \x20   pickPair() => pairSpec(BranchPath.Root, rnd)\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("pickPair") && t.law_name == "branchPathLaw")
+    let theorem = law_theorem(&ctx, "pickPair", "branchPathLaw")
         .expect("pickPair::branchPathLaw law theorem missing");
     let aver::ir::ProofStrategy::EffectfulSpecEquivalence {
         ref impl_fn,
@@ -1407,12 +1356,8 @@ fn simp_normalized_spec_equivalence_pinned_on_arithmetic_identity_gap() {
          \x20   given x: Int = [0]\n\
          \x20   square(x) => squareSpec(x)\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("square") && t.law_name == "squareSpec")
-        .expect("square::squareSpec law theorem missing");
+    let theorem =
+        law_theorem(&ctx, "square", "squareSpec").expect("square::squareSpec law theorem missing");
     let aver::ir::ProofStrategy::SpecEquivalenceSimpNormalized { ref extra_unfolds } =
         theorem.strategy
     else {
@@ -1451,12 +1396,8 @@ fn linear_int_spec_equivalence_pinned_on_commutative_addition() {
          \x20   given n: Int = [0]\n\
          \x20   addOne(n) => addOneSpec(n)\n";
     let ctx = build_ctx(src);
-    let theorem = ctx
-        .proof_ir
-        .law_theorems
-        .iter()
-        .find(|t| t.fn_key == aver::ir::FnKey::entry("addOne") && t.law_name == "addOneSpec")
-        .expect("addOne::addOneSpec law theorem missing");
+    let theorem =
+        law_theorem(&ctx, "addOne", "addOneSpec").expect("addOne::addOneSpec law theorem missing");
     let aver::ir::ProofStrategy::LinearIntSpecEquivalence {
         ref unfolded_impl,
         ref unfolded_spec,


### PR DESCRIPTION
## Summary

Completes phase-E proof-codegen migration started in #142. Both remaining ProofIR maps switch to opaque IDs resolved through SymbolTable:

- \`ProofIR.refined_types: HashMap<TypeKey, _>\` → \`HashMap<TypeId, _>\`
- \`LawTheorem.fn_key: FnKey\` → \`LawTheorem.fn_id: FnId\`

Same shape as #142's \`fn_contracts\` migration — producer resolves identity once at the IR boundary, consumers mirror the resolution at lookup time, BuildSymbols auto-enables when proof stages run.

## What changed

- **Producer side** (\`populate_refined_types\`, \`populate_law_theorems\`): resolve through symbols, panic if symbol_table missing (hard invariant from #142). Verify laws are entry-only per current model — populate skips silently if target fn isn't a FnDef.
- **Consumer side**: \`find_refined_type_*\` in \`common.rs\` resolves through symbol_table; \`law_strategy_for\` (lean/law_auto), \`vb_fn_id\` branches (lean/dafny toplevel) mirror the same flow.
- **In-flight resolver** \`resolve_refined_type_in*\` (used by proof_lower's own walk) takes \`&SymbolTable\` parameter — same lookup shape, opaque ids underneath.
- **render_proof_ir_dump** in main/commands gets \`&SymbolTable\` so the diagnostic dump can stringify opaque IDs.
- **Synthetic-AST tests**: two tests previously verified a fn that didn't exist as a FnDef; now they push a stub (the migration treats "verify target must be a real fn" as the invariant it always was).
- **tests/proof_ir_diff**: 18 LawTheorem lookups bulk-rewritten to a \`law_theorem(&ctx, fn, law)\` helper, mirroring \`fn_contract(...)\` from #142.

## Net effect

After this PR \`FnKey\` and \`TypeKey\` survive only as transient builder types inside the IR boundary. The public ProofIR + LawTheorem surface is fully opaque-id; cross-module same-bare-name collisions are impossible by construction.

## Follow-ups (issue #138)

- Dafny bare-name HashSets (\`fuel_emitted\` / \`native_emitted\` / \`axiom_fn_names\`) — comment-flagged for laws-in-modules
- Rust / WASM / VM backend bare-string sites (separate PRs)

## Test plan

- [x] cargo build + cargo test (628 lib + integration suites green; one pre-existing flake in \`explain_passes_spec\` from concurrent tempfile naming)
- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)