### PR TITLE
codegen: CodegenContext.recursive_fns + mutual_tco_members on FnId (#138 phase C start)

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -831,7 +831,7 @@ pub fn find_fn_contract_scoped<'a>(
     // `run_build_symbols`) this returns `None`, which the
     // downstream emit path treats the same as "no contract" — the
     // table is part of every production build flow.
-    let symbols = ctx.symbol_table.as_ref()?;
+    let symbols = &ctx.symbol_table;
     let bare = name.rsplit('.').next().unwrap_or(name);
     let name_is_already_qualified = name.contains('.');
     let try_key = |key: crate::ir::FnKey| -> Option<&'a crate::ir::proof_ir::FnContract> {
@@ -977,7 +977,7 @@ pub fn find_fn_contract_for_fn<'a>(
     // and the contract by ID. Cleaner than the bare-name resolver
     // chain because the source `&FnDef` already identifies its
     // owning module unambiguously.
-    let symbols = ctx.symbol_table.as_ref()?;
+    let symbols = &ctx.symbol_table;
     let fn_key = fn_key_for_decl(ctx, fd);
     let fn_id = symbols.fn_id_of(&fn_key)?;
     ctx.proof_ir.fn_contracts.get(&fn_id)
@@ -990,14 +990,12 @@ pub fn fn_contract_exists_for_fn(ctx: &CodegenContext, fd: &FnDef) -> bool {
 
 /// Resolve `&FnDef` to the opaque [`crate::ir::FnId`] from the
 /// symbol table. Pointer-eq scope detection routes module-owned
-/// fns through their canonical `Module.fn` key. Returns `None`
-/// when there's no symbol table (legacy synthetic-ctx paths) or
-/// when the fn isn't registered (built-ins / synthesized variants
-/// the table excludes by design).
+/// fns through their canonical `Module.fn` key. Returns `None` when
+/// the fn isn't registered (built-ins / synthesized variants the
+/// table excludes by design).
 pub fn fn_id_for_decl(ctx: &CodegenContext, fd: &FnDef) -> Option<crate::ir::FnId> {
-    let symbols = ctx.symbol_table.as_ref()?;
     let fn_key = fn_key_for_decl(ctx, fd);
-    symbols.fn_id_of(&fn_key)
+    ctx.symbol_table.fn_id_of(&fn_key)
 }
 
 /// Resolve a dotted source-level name (`fn`, `Module.fn`) to the
@@ -1006,13 +1004,12 @@ pub fn fn_id_for_decl(ctx: &CodegenContext, fd: &FnDef) -> Option<crate::ir::FnI
 /// — keeps the FnKey resolution in one place instead of letting
 /// each walker re-derive identity from bare strings.
 pub fn fn_id_for_dotted_name(ctx: &CodegenContext, dotted: &str) -> Option<crate::ir::FnId> {
-    let symbols = ctx.symbol_table.as_ref()?;
     let key = if let Some((prefix, bare)) = dotted.rsplit_once('.') {
         crate::ir::FnKey::in_module(prefix.to_string(), bare)
     } else {
         crate::ir::FnKey::entry(dotted)
     };
-    symbols.fn_id_of(&key)
+    ctx.symbol_table.fn_id_of(&key)
 }
 
 /// Canonical-key-aware resolver — returns `(canonical_key, decl)`
@@ -1061,15 +1058,16 @@ pub fn find_refined_type_scoped<'a>(
 /// human-readable identifier here for diagnostics and `defmt`-style
 /// canonical comparison.
 ///
-/// Without `ctx.symbol_table` (synthetic legacy ctxs), returns
-/// `None` — the FnId/TypeId migration makes the table mandatory for
-/// proof IR lookup in production paths.
+/// `ctx.symbol_table` is always populated after phase E (pipeline
+/// builds it unconditionally); the lookup returns `None` only when
+/// the requested type isn't registered (built-ins / non-existent
+/// names) or when the type has no `RefinedTypeDecl` slot.
 pub fn find_refined_type_with_key_scoped<'a>(
     ctx: &'a CodegenContext,
     name: &str,
     scope: Option<&str>,
 ) -> Option<(String, &'a crate::ir::proof_ir::RefinedTypeDecl)> {
-    let symbols = ctx.symbol_table.as_ref()?;
+    let symbols = &ctx.symbol_table;
     let bare = name.rsplit('.').next().unwrap_or(name);
     let name_is_already_qualified = name.contains('.');
     let try_key =
@@ -2555,7 +2553,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
-            symbol_table: Some(symbol_table),
+            symbol_table,
         };
         ctx.proof_ir
             .refined_types

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -719,11 +719,11 @@ mod tests {
             HashSet::new(),
             project_name.to_string(),
             vec![],
+            pipeline_result.symbol_table,
         );
         if let Some(ir) = proof_ir {
             ctx.proof_ir = ir;
         }
-        ctx.symbol_table = pipeline_result.symbol_table;
         ctx
     }
 

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1308,8 +1308,7 @@ pub fn emit_verify_law(
     // …) does and stays. Mirror of the Lean gate.
     let vb_fn_id = ctx
         .symbol_table
-        .as_ref()
-        .and_then(|s| s.fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name)));
+        .fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name));
     let ir_strategy_closes_const_rhs = vb_fn_id
         .and_then(|fn_id| {
             ctx.proof_ir

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -201,7 +201,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
-            symbol_table: None,
+            symbol_table: crate::ir::SymbolTable::default(),
         }
     }
 

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -32,7 +32,6 @@ fn law_strategy_for(
 ) -> Option<crate::ir::ProofStrategy> {
     let fn_id = ctx
         .symbol_table
-        .as_ref()?
         .fn_id_of(&crate::ir::FnKey::entry(fn_name))?;
     ctx.proof_ir
         .law_theorems

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -754,19 +754,20 @@ pub(crate) fn recursive_type_names(ctx: &CodegenContext) -> HashSet<String> {
 }
 
 pub(crate) fn recursive_pure_fn_names(ctx: &CodegenContext) -> HashSet<String> {
-    let pure_names: HashSet<String> = pure_fns(ctx)
+    // `ctx.recursive_fns` is the single source of truth — populated
+    // by `build_context` from analyze in production, by
+    // `refresh_facts()` (called from each `transpile*` entry point)
+    // in test stubs. After phase C it's keyed by opaque `FnId`;
+    // project pure-fn ids back through the symbol table and surface
+    // bare names for Lean's downstream scope-local classifiers.
+    let symbols = &ctx.symbol_table;
+    let pure_ids: HashSet<crate::ir::FnId> = pure_fns(ctx)
         .into_iter()
-        .map(|fd| fd.name.clone())
+        .filter_map(|fd| crate::codegen::common::fn_id_for_decl(ctx, fd))
         .collect();
-    // `ctx.recursive_fns` is the single source of truth — populated by
-    // `build_context` from analyze in production, by `refresh_facts()`
-    // (called from each `transpile*` entry point) in test stubs. Aver's
-    // module DAG keeps cross-module recursion impossible, so the union
-    // of per-module sets is the correct global view.
     ctx.recursive_fns
-        .iter()
-        .filter(|name| pure_names.contains(name.as_str()))
-        .cloned()
+        .intersection(&pure_ids)
+        .map(|id| symbols.fn_entry(*id).key.name.clone())
         .collect()
 }
 
@@ -1206,7 +1207,16 @@ fn transpile_unified(
 ) -> ProjectOutput {
     // Read recursion fact from `ctx.recursive_fns` — populated upstream
     // by `refresh_facts()` (test stubs) or `build_context` (production).
-    let recursive_fns: HashSet<String> = ctx.recursive_fns.clone();
+    // After phase C the set is keyed by `FnId`; project back to bare
+    // names for scope-local `emit_fn_def` consumers via the symbol
+    // table (the DAG invariant keeps bare-name unambiguous within a
+    // single scope). The proof-mode auto-prove path also needs the
+    // same bare-name projection.
+    let recursive_fns: HashSet<String> = ctx
+        .recursive_fns
+        .iter()
+        .map(|id| ctx.symbol_table.fn_entry(*id).key.name.clone())
+        .collect();
     let recursive_names = recursive_pure_fn_names(ctx);
     let recursive_types = recursive_type_names(ctx);
 
@@ -1519,7 +1529,7 @@ mod tests {
         // populate side asserts the symbol table is present (it's a
         // hard prerequisite for FnId-keyed fn_contracts), so synthetic-
         // ctx tests have to build it the same way `refresh_facts` does.
-        ctx.symbol_table = Some(crate::ir::SymbolTable::build(&ctx.items, &ctx.modules));
+        ctx.symbol_table = crate::ir::SymbolTable::build(&ctx.items, &ctx.modules);
         let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
         ctx.proof_ir = crate::codegen::proof_lower::lower(&inputs);
     }
@@ -1541,14 +1551,14 @@ mod tests {
             guest_entry: None,
             emit_self_host_support: false,
             extra_fn_defs: Vec::new(),
-            mutual_tco_members: HashSet::new(),
-            recursive_fns: HashSet::new(),
+            mutual_tco_members: HashSet::<crate::ir::FnId>::new(),
+            recursive_fns: HashSet::<crate::ir::FnId>::new(),
             fn_analyses: HashMap::new(),
             buffer_build_sinks: HashMap::new(),
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
-            symbol_table: None,
+            symbol_table: crate::ir::SymbolTable::default(),
         }
     }
 
@@ -1600,11 +1610,11 @@ mod tests {
             HashSet::new(),
             project_name.to_string(),
             vec![],
+            pipeline_result.symbol_table,
         );
         if let Some(ir) = proof_ir {
             ctx.proof_ir = ir;
         }
-        ctx.symbol_table = pipeline_result.symbol_table;
         ctx
     }
 

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1898,8 +1898,7 @@ fn emit_verify_law_block(
     // / BackendDispatch / Sorry don't.
     let ir_strategy_closes_const_rhs = ctx
         .symbol_table
-        .as_ref()
-        .and_then(|s| s.fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name)))
+        .fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name))
         .and_then(|fn_id| {
             ctx.proof_ir
                 .law_theorems

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -80,15 +80,20 @@ pub struct CodegenContext {
     /// Set temporarily by the Rust backend when emitting a dependent module so that
     /// `find_fn_def_by_name` can resolve same-module calls.
     pub extra_fn_defs: Vec<FnDef>,
-    /// Functions that are part of a mutual-TCO SCC group (emitted as trampoline + wrappers).
-    /// Functions NOT in this set but with TailCalls are emitted as plain self-TCO loops.
-    pub mutual_tco_members: HashSet<String>,
-    /// Functions that call themselves directly or transitively. Set-form
-    /// union of `entry_analysis.recursive_fns` plus each module's
-    /// `analysis.recursive_fns`. Used by codegen sites that previously
-    /// called `call_graph::find_recursive_fns` ad-hoc (Lean recursion
-    /// planning, type checker flow, etc.).
-    pub recursive_fns: HashSet<String>,
+    /// Functions that are part of a mutual-TCO SCC group (emitted as
+    /// trampoline + wrappers). Functions NOT in this set but with
+    /// TailCalls are emitted as plain self-TCO loops. Keyed by opaque
+    /// [`crate::ir::FnId`] from the symbol table — entry-module fns
+    /// and dep-module fns with the same bare name can't accidentally
+    /// merge under bare-name keying.
+    pub mutual_tco_members: HashSet<crate::ir::FnId>,
+    /// Functions that call themselves directly or transitively. Set-
+    /// form union of `entry_analysis.recursive_fns` plus each
+    /// module's `analysis.recursive_fns`. Keyed by opaque
+    /// [`crate::ir::FnId`] — same disambiguation guarantee as
+    /// `mutual_tco_members`. Used by codegen sites that previously
+    /// called `call_graph::find_recursive_fns` ad-hoc.
+    pub recursive_fns: HashSet<crate::ir::FnId>,
     /// Per-fn analysis facts unioned from entry + every dep module's
     /// `AnalysisResult.fn_analyses`. WASM emitter / VM compiler /
     /// future inliner read `allocates`, `thin_kind`, `body_shape`,
@@ -121,13 +126,12 @@ pub struct CodegenContext {
     /// `refinement_info_for` for now. Step 3+ migrates backends.
     #[cfg(feature = "runtime")]
     pub proof_ir: crate::ir::ProofIR,
-    /// Resolved-identity table (#138 phase E). `Some` when the
-    /// pipeline's `run_build_symbols` was on. No consumer reads
-    /// it through this field yet — production callers populate
-    /// it so downstream migration PRs (proof IR maps keyed by
-    /// `FnId`, backend `FnId → name` mangling) can wire in
-    /// without re-running name resolution per emit site.
-    pub symbol_table: Option<crate::ir::SymbolTable>,
+    /// Resolved-identity table (#138 phase E). Always populated:
+    /// `pipeline::run` builds it unconditionally and threads it
+    /// through `build_context`. Consumers (proof IR lookups,
+    /// backend FnId/TypeId resolution) read it directly — no
+    /// `Option` wrapper to unwrap at each callsite.
+    pub symbol_table: crate::ir::SymbolTable,
 }
 
 /// Output files from a codegen backend.
@@ -145,6 +149,13 @@ pub struct ProjectOutput {
 /// codegen unions the per-module sets to build a global view (sound
 /// under Aver's module DAG invariant — no cross-module SCCs possible,
 /// see `src/ir/analyze.rs` doc).
+///
+/// `symbol_table` is the resolved-identity layer built by the
+/// pipeline (`pipeline_result.symbol_table`). Always required:
+/// `pipeline::run` builds it unconditionally so every caller has
+/// one available. The ad-hoc test helpers that drive a stripped
+/// pipeline build their own via `SymbolTable::build(&items,
+/// &modules)` and pass it here.
 pub fn build_context(
     items: Vec<TopLevel>,
     tc_result: &TypeCheckResult,
@@ -152,6 +163,7 @@ pub fn build_context(
     memo_fns: HashSet<String>,
     project_name: String,
     modules: Vec<ModuleInfo>,
+    symbol_table: crate::ir::SymbolTable,
 ) -> CodegenContext {
     let type_defs: Vec<TypeDef> = items
         .iter()
@@ -177,6 +189,19 @@ pub fn build_context(
 
     let module_prefixes: HashSet<String> = modules.iter().map(|m| m.prefix.clone()).collect();
 
+    // Symbol table threaded in from the caller (pipeline or stripped
+    // test driver). Used here to convert the per-scope bare-name sets
+    // unioned below into FnId-keyed sets.
+
+    // Helper: bare fn name → entry-scope FnId. Used for entry-source
+    // analysis facts (per-module facts use `(prefix, name)` below).
+    let entry_fn_id = |name: &str| -> Option<crate::ir::FnId> {
+        symbol_table.fn_id_of(&crate::ir::FnKey::entry(name))
+    };
+    let module_fn_id = |prefix: &str, name: &str| -> Option<crate::ir::FnId> {
+        symbol_table.fn_id_of(&crate::ir::FnKey::in_module(prefix.to_string(), name))
+    };
+
     // Mutual-TCO membership unions per-module sets from the analyze stage
     // (entry's `entry_analysis` + each dep module's `module.analysis`).
     // Aver's module DAG invariant guarantees SCCs never span modules, so
@@ -187,9 +212,11 @@ pub fn build_context(
     // analysis isn't supplied (callers that haven't migrated to the
     // pipeline). The fallback path will go away once every entry point
     // runs the canonical pipeline.
-    let mut mutual_tco_members: HashSet<String> = HashSet::new();
+    let mut mutual_tco_members: HashSet<crate::ir::FnId> = HashSet::new();
     match entry_analysis {
-        Some(a) => mutual_tco_members.extend(a.mutual_tco_members.iter().cloned()),
+        Some(a) => {
+            mutual_tco_members.extend(a.mutual_tco_members.iter().filter_map(|n| entry_fn_id(n)))
+        }
         None => {
             let entry_fns: Vec<&FnDef> = fn_defs.iter().filter(|fd| fd.name != "main").collect();
             for group in crate::call_graph::tailcall_scc_components(&entry_fns) {
@@ -197,14 +224,20 @@ pub fn build_context(
                     continue;
                 }
                 for fd in group {
-                    mutual_tco_members.insert(fd.name.clone());
+                    if let Some(id) = entry_fn_id(&fd.name) {
+                        mutual_tco_members.insert(id);
+                    }
                 }
             }
         }
     }
     for module in &modules {
         match module.analysis.as_ref() {
-            Some(a) => mutual_tco_members.extend(a.mutual_tco_members.iter().cloned()),
+            Some(a) => mutual_tco_members.extend(
+                a.mutual_tco_members
+                    .iter()
+                    .filter_map(|n| module_fn_id(&module.prefix, n)),
+            ),
             None => {
                 let mod_fns: Vec<&FnDef> = module.fn_defs.iter().collect();
                 for group in crate::call_graph::tailcall_scc_components(&mod_fns) {
@@ -212,7 +245,9 @@ pub fn build_context(
                         continue;
                     }
                     for fd in group {
-                        mutual_tco_members.insert(fd.name.clone());
+                        if let Some(id) = module_fn_id(&module.prefix, &fd.name) {
+                            mutual_tco_members.insert(id);
+                        }
                     }
                 }
             }
@@ -241,24 +276,37 @@ pub fn build_context(
     // `recursive_fns` follows the same shape as `mutual_tco_members` —
     // per-module sets unioned (Aver's module DAG keeps cross-module
     // recursion from existing). Falls back to ad-hoc `find_recursive_fns`
-    // when a module's analysis is missing.
-    let mut recursive_fns: HashSet<String> = HashSet::new();
+    // when a module's analysis is missing. Keyed by opaque `FnId` for
+    // the same disambiguation guarantee as `mutual_tco_members`.
+    let mut recursive_fns: HashSet<crate::ir::FnId> = HashSet::new();
     match entry_analysis {
-        Some(a) => recursive_fns.extend(a.recursive_fns.iter().cloned()),
+        Some(a) => recursive_fns.extend(a.recursive_fns.iter().filter_map(|n| entry_fn_id(n))),
         None => {
-            recursive_fns.extend(crate::call_graph::find_recursive_fns(&items));
+            recursive_fns.extend(
+                crate::call_graph::find_recursive_fns(&items)
+                    .iter()
+                    .filter_map(|n| entry_fn_id(n)),
+            );
         }
     }
     for module in &modules {
         match module.analysis.as_ref() {
-            Some(a) => recursive_fns.extend(a.recursive_fns.iter().cloned()),
+            Some(a) => recursive_fns.extend(
+                a.recursive_fns
+                    .iter()
+                    .filter_map(|n| module_fn_id(&module.prefix, n)),
+            ),
             None => {
                 let mod_items: Vec<TopLevel> = module
                     .fn_defs
                     .iter()
                     .map(|fd| TopLevel::FnDef(fd.clone()))
                     .collect();
-                recursive_fns.extend(crate::call_graph::find_recursive_fns(&mod_items));
+                recursive_fns.extend(
+                    crate::call_graph::find_recursive_fns(&mod_items)
+                        .iter()
+                        .filter_map(|n| module_fn_id(&module.prefix, n)),
+                );
             }
         }
     }
@@ -411,7 +459,12 @@ pub fn build_context(
         synthesized_buffered_fns,
         #[cfg(feature = "runtime")]
         proof_ir: crate::ir::ProofIR::default(),
-        symbol_table: None,
+        // Symbol table threaded through from the pipeline (or
+        // built locally in fallback). The FnId-keyed `recursive_
+        // fns` / `mutual_tco_members` above used it; backends
+        // (proof_lower / Lean / Rust / Dafny) read it directly off
+        // ctx for opaque-ID lookups.
+        symbol_table,
     };
     // ProofIR no longer populated here. Pipeline owns the lowerings
     // (`PipelineStage::RefinementLower`, `PipelineStage::ContractLower`);
@@ -437,16 +490,29 @@ impl CodegenContext {
     /// Calling `refresh_facts` on a production-built ctx is redundant
     /// work that produces the same answer — leave it off the hot path.
     pub fn refresh_facts(&mut self) {
+        // Synthetic-ctx path must own its symbol table too — FnId-
+        // keyed sets below resolve through it, same shape as the
+        // production `build_context` flow.
+        let symbol_table = crate::ir::SymbolTable::build(&self.items, &self.modules);
+        let entry_fn_id = |name: &str| -> Option<crate::ir::FnId> {
+            symbol_table.fn_id_of(&crate::ir::FnKey::entry(name))
+        };
+        let module_fn_id = |prefix: &str, name: &str| -> Option<crate::ir::FnId> {
+            symbol_table.fn_id_of(&crate::ir::FnKey::in_module(prefix.to_string(), name))
+        };
+
         let entry_fn_refs: Vec<&FnDef> =
             self.fn_defs.iter().filter(|fd| fd.name != "main").collect();
 
-        let mut mutual_tco_members: HashSet<String> = HashSet::new();
+        let mut mutual_tco_members: HashSet<crate::ir::FnId> = HashSet::new();
         for group in crate::call_graph::tailcall_scc_components(&entry_fn_refs) {
             if group.len() < 2 {
                 continue;
             }
             for fd in group {
-                mutual_tco_members.insert(fd.name.clone());
+                if let Some(id) = entry_fn_id(&fd.name) {
+                    mutual_tco_members.insert(id);
+                }
             }
         }
         for module in &self.modules {
@@ -456,29 +522,37 @@ impl CodegenContext {
                     continue;
                 }
                 for fd in group {
-                    mutual_tco_members.insert(fd.name.clone());
+                    if let Some(id) = module_fn_id(&module.prefix, &fd.name) {
+                        mutual_tco_members.insert(id);
+                    }
                 }
             }
         }
         self.mutual_tco_members = mutual_tco_members;
 
-        let mut recursive_fns: HashSet<String> = crate::call_graph::find_recursive_fns(&self.items);
+        let mut recursive_fns: HashSet<crate::ir::FnId> =
+            crate::call_graph::find_recursive_fns(&self.items)
+                .iter()
+                .filter_map(|n| entry_fn_id(n))
+                .collect();
         for module in &self.modules {
             let mod_items: Vec<TopLevel> = module
                 .fn_defs
                 .iter()
                 .map(|fd| TopLevel::FnDef(fd.clone()))
                 .collect();
-            recursive_fns.extend(crate::call_graph::find_recursive_fns(&mod_items));
+            recursive_fns.extend(
+                crate::call_graph::find_recursive_fns(&mod_items)
+                    .iter()
+                    .filter_map(|n| module_fn_id(&module.prefix, n)),
+            );
         }
         self.recursive_fns = recursive_fns;
 
-        // Symbol table must be rebuilt before proof_lower runs so the
-        // populate side can resolve `FnKey` → opaque `FnId` for the
-        // (now FnId-keyed) `fn_contracts` map. Synthetic-ctx test
-        // paths reach this codepath through `refresh_facts`, so this
-        // is the only place those flows get a symbol table.
-        self.symbol_table = Some(crate::ir::SymbolTable::build(&self.items, &self.modules));
+        // Reuse the symbol table built at the top of this function
+        // for proof_lower below — it already resolved every FnId we
+        // need for `recursive_fns` / `mutual_tco_members`.
+        self.symbol_table = symbol_table;
 
         // ProofIR's `fn_contracts` / `refined_types` are derived from
         // the just-recomputed item set + the recursion classifier, so

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -49,9 +49,13 @@ pub struct ProofLowerInputs<'a> {
     pub dep_modules: &'a [ModuleInfo],
     /// Set of dep module prefix strings (e.g. `"Models.User"`).
     pub module_prefixes: &'a HashSet<String>,
-    /// Recursive fn names from the `analyze` pipeline stage. Used by
-    /// `analyze_plans` to short-circuit non-recursive fns.
-    pub recursive_fns: &'a HashSet<String>,
+    /// Recursive fn ids from the `analyze` pipeline stage. Keyed
+    /// by opaque [`crate::ir::FnId`] so entry+module same-bare-name
+    /// fns don't merge. Per-scope helpers below project back to
+    /// `HashSet<String>` for consumers that operate on a single
+    /// scope (the DAG invariant keeps bare-name unambiguous within
+    /// a scope).
+    pub recursive_fns: &'a HashSet<crate::ir::FnId>,
     /// Resolved-identity table (#138 phase E). When `Some`, the
     /// populate-side resolves `FnKey` / `TypeKey` to `FnId` /
     /// `TypeId` once at the IR boundary and keys `ProofIR.fn_contracts`
@@ -59,7 +63,7 @@ pub struct ProofLowerInputs<'a> {
     /// IDs. Callers that haven't wired in the symbol-table stage
     /// pass `None` and fall through to legacy key-typed maps
     /// (transitional during phase E migration).
-    pub symbol_table: Option<&'a crate::ir::SymbolTable>,
+    pub symbol_table: &'a crate::ir::SymbolTable,
 }
 
 impl<'a> ProofLowerInputs<'a> {
@@ -73,7 +77,7 @@ impl<'a> ProofLowerInputs<'a> {
             dep_modules: &ctx.modules,
             module_prefixes: &ctx.module_prefixes,
             recursive_fns: &ctx.recursive_fns,
-            symbol_table: ctx.symbol_table.as_ref(),
+            symbol_table: &ctx.symbol_table,
         }
     }
 
@@ -98,18 +102,31 @@ impl<'a> ProofLowerInputs<'a> {
             .collect()
     }
 
-    /// Recursive pure fn names. Filters `recursive_fns` (populated by
-    /// the analyze pipeline stage) by pure-ness.
+    /// Recursive pure fn names. Filters `recursive_fns` by pure-ness.
+    /// Returns bare names (pure_fns view is the whole program here,
+    /// so any FnId in `recursive_fns` that maps back to a pure fn
+    /// gets its bare name surfaced for downstream classifiers).
     pub fn recursive_pure_fn_names(&self) -> HashSet<String> {
-        let pure_names: HashSet<String> = self
+        let symbols = self.symbol_table;
+        let pure_ids: HashSet<crate::ir::FnId> = self
             .pure_fns()
             .into_iter()
-            .map(|fd| fd.name.clone())
+            .filter_map(|fd| {
+                let scope = self
+                    .dep_modules
+                    .iter()
+                    .find(|m| m.fn_defs.iter().any(|d| std::ptr::eq(d, fd)))
+                    .map(|m| m.prefix.as_str());
+                let key = match scope {
+                    Some(prefix) => crate::ir::FnKey::in_module(prefix.to_string(), &fd.name),
+                    None => crate::ir::FnKey::entry(&fd.name),
+                };
+                symbols.fn_id_of(&key)
+            })
             .collect();
         self.recursive_fns
-            .iter()
-            .filter(|name| pure_names.contains(name.as_str()))
-            .cloned()
+            .intersection(&pure_ids)
+            .map(|id| symbols.fn_entry(*id).key.name.clone())
             .collect()
     }
 
@@ -141,19 +158,27 @@ impl<'a> ProofLowerInputs<'a> {
         }
     }
 
-    /// Recursive pure fn names restricted to a single scope. The
-    /// global `recursive_fns` set is filtered by membership in that
-    /// scope's `pure_fns_in_scope`.
+    /// Recursive pure fn names restricted to a single scope. Filters
+    /// the FnId-keyed `recursive_fns` to the ones whose canonical
+    /// scope matches `scope`, then projects back to bare names for
+    /// scope-local consumers (DAG invariant keeps bare-name
+    /// unambiguous within a single scope).
     pub fn recursive_pure_fn_names_in_scope(&self, scope: Option<&str>) -> HashSet<String> {
-        let pure_names: HashSet<String> = self
+        let symbols = self.symbol_table;
+        let pure_ids: HashSet<crate::ir::FnId> = self
             .pure_fns_in_scope(scope)
             .into_iter()
-            .map(|fd| fd.name.clone())
+            .filter_map(|fd| {
+                let key = match scope {
+                    Some(prefix) => crate::ir::FnKey::in_module(prefix.to_string(), &fd.name),
+                    None => crate::ir::FnKey::entry(&fd.name),
+                };
+                symbols.fn_id_of(&key)
+            })
             .collect();
         self.recursive_fns
-            .iter()
-            .filter(|name| pure_names.contains(name.as_str()))
-            .cloned()
+            .intersection(&pure_ids)
+            .map(|id| symbols.fn_entry(*id).key.name.clone())
             .collect()
     }
 
@@ -244,14 +269,11 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
     // here; consumers (`find_refined_type_scoped`) resolve through
     // the same symbol table at lookup time.
     //
-    // BuildSymbols auto-enables alongside RefinementLower in the
-    // pipeline, so reaching this point without `inputs.symbol_table`
-    // is a wiring bug. Synthetic-ctx callers (test helpers) must
-    // build the symbol table before invoking `lower` — `refresh_facts`
-    // and the lean/dafny test `populate_proof_ir` helpers already do.
-    let symbols = inputs
-        .symbol_table
-        .expect("populate_refined_types requires SymbolTable (run BuildSymbols first)");
+    // SymbolTable is always present (`ProofLowerInputs.symbol_table`
+    // is `&SymbolTable`, not `Option<&_>` — the pipeline builds it
+    // unconditionally). Synthetic-ctx callers (test helpers) thread
+    // their own through `from_ctx` / direct construction.
+    let symbols = inputs.symbol_table;
 
     let entry_typedefs = inputs.entry_items.iter().filter_map(|item| match item {
         TopLevel::TypeDef(td) => Some((None::<&str>, td)),
@@ -376,18 +398,10 @@ fn populate_fn_contracts_for_scope(
             None => crate::ir::FnKey::entry(bare),
         }
     };
-    // Round-7 phase E: contracts key by opaque `FnId` resolved
-    // once via the symbol table. The pipeline auto-enables
-    // BuildSymbols whenever ContractLower runs, so reaching this
-    // point without `inputs.symbol_table` is a wiring bug — callers
-    // who build a `ProofLowerInputs` by hand (synthetic-ctx tests)
-    // are responsible for setting `symbol_table` before calling
-    // populate. We panic instead of silently skipping so the
-    // wiring bug surfaces at the producer rather than as missing
-    // contracts in downstream emit output.
-    let symbols = inputs
-        .symbol_table
-        .expect("populate_fn_contracts requires SymbolTable (run BuildSymbols first)");
+    // Contracts key by opaque `FnId`; SymbolTable is always present
+    // (pipeline builds it unconditionally, `ProofLowerInputs.symbol_
+    // table: &SymbolTable`).
+    let symbols = inputs.symbol_table;
 
     for (fn_name, plan) in plans {
         let Some(fd) = scoped_fns.iter().find(|fd| fd.name == *fn_name) else {
@@ -647,9 +661,7 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
     use crate::ast::{TopLevel, VerifyKind};
     use crate::ir::{LawTheorem, Predicate, Quantifier, QuantifierType};
 
-    let symbols = inputs
-        .symbol_table
-        .expect("populate_law_theorems requires SymbolTable (run BuildSymbols first)");
+    let symbols = inputs.symbol_table;
 
     let entry_verifies = inputs.entry_items.iter().filter_map(|item| match item {
         TopLevel::Verify(vb) => Some(vb),
@@ -902,9 +914,7 @@ fn detect_simp_omega_unfold(
     // Natural, b: Natural)`) and unfold through the smart
     // constructor to Int arithmetic. Skip the outer-Int rejection
     // for lifted laws.
-    let symbols = inputs
-        .symbol_table
-        .expect("detect_simp_omega_unfold requires SymbolTable");
+    let symbols = inputs.symbol_table;
     let lifted = law.givens.iter().any(|g| {
         refinement_lift_for_given_ir(
             &g.name,

--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -1035,7 +1035,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
-            symbol_table: None,
+            symbol_table: crate::ir::SymbolTable::default(),
         }
     }
 

--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -857,10 +857,9 @@ fn borrow_mask_from_fn_def(fd: &FnDef, arg_count: usize, ctx: &CodegenContext) -
     // Memo functions always use borrow-by-default (memo wrapper takes &T),
     // even if the body has self-tail-calls.
     let is_memo = ctx.memo_fns.contains(&fd.name);
-    if !is_memo
-        && !ctx.mutual_tco_members.contains(&fd.name)
-        && super::toplevel::body_has_self_tailcall(&fd.body, &fd.name)
-    {
+    let is_mutual_tco = crate::codegen::common::fn_id_for_decl(ctx, fd)
+        .is_some_and(|id| ctx.mutual_tco_members.contains(&id));
+    if !is_memo && !is_mutual_tco && super::toplevel::body_has_self_tailcall(&fd.body, &fd.name) {
         return vec![false; arg_count];
     }
     fd.params

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -454,7 +454,9 @@ fn entry_module_sections(
     }
 
     for fd in &ctx.fn_defs {
-        if fd.name == "main" || ctx.mutual_tco_members.contains(&fd.name) {
+        let is_mutual = crate::codegen::common::fn_id_for_decl(ctx, fd)
+            .is_some_and(|id| ctx.mutual_tco_members.contains(&id));
+        if fd.name == "main" || is_mutual {
             continue;
         }
         let is_memo = ctx.memo_fns.contains(&fd.name);
@@ -483,13 +485,29 @@ fn module_sections(module: &crate::codegen::ModuleInfo, ctx: &CodegenContext) ->
 
     // Same shape as the entry path: groups (with indices) come from
     // `find_mutual_tco_groups`, set-form membership reads from
-    // `module.analysis.mutual_tco_members` when the analyze stage ran.
+    // `module.analysis.mutual_tco_members` (bare names, scope-local
+    // per module, DAG invariant keeps them unambiguous) when the
+    // analyze stage ran. Fall back to projecting `ctx.mutual_tco_members`
+    // (FnId set) back to bare names for this module's scope.
     let fn_refs: Vec<&FnDef> = module.fn_defs.iter().collect();
     let mutual_groups = toplevel::find_mutual_tco_groups(&fn_refs);
-    let module_mutual: &HashSet<String> = match module.analysis.as_ref() {
-        Some(a) => &a.mutual_tco_members,
-        None => &ctx.mutual_tco_members,
+    let module_mutual_owned: HashSet<String> = match module.analysis.as_ref() {
+        Some(a) => a.mutual_tco_members.clone(),
+        None => ctx
+            .mutual_tco_members
+            .iter()
+            .filter_map(|id| {
+                let entry = ctx.symbol_table.fn_entry(*id);
+                entry
+                    .key
+                    .scope
+                    .as_deref()
+                    .filter(|s| *s == module.prefix)
+                    .map(|_| entry.key.name.clone())
+            })
+            .collect(),
     };
+    let module_mutual = &module_mutual_owned;
 
     for (group_id, group_indices) in mutual_groups.iter().enumerate() {
         let group_fns: Vec<&FnDef> = group_indices.iter().map(|&idx| fn_refs[idx]).collect();
@@ -610,6 +628,10 @@ mod tests {
             "source should typecheck without errors: {:?}",
             tc.errors
         );
+        // No pipeline analyze stage run here — supply a locally-built
+        // SymbolTable so build_context can populate its FnId-keyed
+        // sets. Cheap traversal, no analysis.
+        let symbol_table = crate::ir::SymbolTable::build(&items, &[]);
         build_context(
             items,
             &tc,
@@ -617,6 +639,7 @@ mod tests {
             HashSet::new(),
             project_name.to_string(),
             vec![],
+            symbol_table,
         )
     }
 

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -2796,7 +2796,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: crate::ir::ProofIR::default(),
-            symbol_table: None,
+            symbol_table: crate::ir::SymbolTable::default(),
         }
     }
 

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -351,11 +351,14 @@ pub struct PipelineResult {
     pub proof_ir: Option<crate::ir::ProofIR>,
     /// Resolved-identity table — opaque `FnId` / `TypeId` /
     /// `CtorId` / `ModuleId` for every named declaration in the
-    /// program (#138 phase E). `Some` when `run_build_symbols`
-    /// was on. No consumer reads it through this field yet;
-    /// downstream migration PRs (proof IR maps keyed by `FnId`,
-    /// backend mangling) will start once the wire-up is in place.
-    pub symbol_table: Option<crate::ir::SymbolTable>,
+    /// program (#138 phase E). Always populated: the pipeline
+    /// builds it unconditionally at the head of `run` (it's the
+    /// universal foundation for proof IR + backend identity).
+    /// `run_build_symbols` in `PipelineConfig` controls whether
+    /// the BuildSymbols stage fires its `on_after_pass` hook for
+    /// `--emit-ir-after=build_symbols`; the table itself is built
+    /// regardless.
+    pub symbol_table: crate::ir::SymbolTable,
     /// Per-stage diagnostic records — one per pass that actually ran.
     /// Drives `aver compile --explain-passes`; consumed by the future
     /// CI failable-invariant checks.
@@ -521,32 +524,21 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
         crate::ir::alias::annotate_program_alias_slots(items);
     }
 
-    // Proof-export lowerings come last — they share an output sink
-    // (`result.proof_ir`) but populate disjoint fields:
-    // RefinementLower writes `refined_types`, ContractLower writes
-    // `fn_contracts`, LawLower writes `law_theorems`. Each is
-    // independently opt-in.
-    // BuildSymbols runs BEFORE proof stages so `populate_*` resolve
-    // `FnKey`/`TypeKey` to `FnId`/`TypeId` once at the IR boundary
-    // and key `ProofIR.fn_contracts` / `ProofIR.refined_types` /
-    // `LawTheorem.fn_id` by the opaque IDs (#138 phase E).
-    //
-    // Proof stages have a hard dependency on the symbol table —
-    // since fn_contracts is keyed by `FnId`, populate cannot run
-    // without resolved identity. Auto-enable here so callers can't
-    // accidentally turn on `run_contract_lower` / `run_law_lower`
-    // without symbols and silently produce an empty proof IR.
-    let needs_symbols = cfg.run_build_symbols
-        || cfg.run_refinement_lower
-        || cfg.run_contract_lower
-        || cfg.run_law_lower;
-    if needs_symbols {
+    // Resolved-identity table is the universal foundation for proof
+    // IR + every backend's name lookup, so it's built unconditionally.
+    // `run_build_symbols` in PipelineConfig controls only whether the
+    // BuildSymbols stage fires its `on_after_pass` hook (for
+    // `--emit-ir-after=build_symbols`); the table itself lands in
+    // `result.symbol_table` regardless.
+    {
         let symbol_table = crate::ir::SymbolTable::build(items, cfg.dep_modules);
         result
             .pass_diagnostics
             .push(diag_for_build_symbols(&symbol_table));
-        result.symbol_table = Some(symbol_table);
-        fire(&mut cfg, PipelineStage::BuildSymbols, items);
+        result.symbol_table = symbol_table;
+        if cfg.run_build_symbols {
+            fire(&mut cfg, PipelineStage::BuildSymbols, items);
+        }
     }
 
     if cfg.run_refinement_lower || cfg.run_contract_lower || cfg.run_law_lower {
@@ -559,15 +551,26 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
         // rules out cross-module recursion SCCs, so unioning the
         // per-scope `recursive_fns` sets matches the build-time
         // `ctx.recursive_fns` view in `codegen::build_context`.
-        let recursive_fns_owned: std::collections::HashSet<String> = {
-            let mut set: std::collections::HashSet<String> = result
-                .analysis
-                .as_ref()
-                .map(|a| a.recursive_fns.iter().cloned().collect())
-                .unwrap_or_default();
+        // Project per-scope bare-name sets to opaque FnIds through the
+        // (already-built) symbol table — same flow `build_context`
+        // uses to populate `ctx.recursive_fns`. Without a symbol
+        // table the producer side of proof_lower can't run anyway
+        // (populate panics by design), so default to empty.
+        let symbols = &result.symbol_table;
+        let recursive_fns_owned: std::collections::HashSet<crate::ir::FnId> = {
+            let mut set = std::collections::HashSet::new();
+            if let Some(a) = result.analysis.as_ref() {
+                set.extend(
+                    a.recursive_fns
+                        .iter()
+                        .filter_map(|n| symbols.fn_id_of(&crate::ir::FnKey::entry(n))),
+                );
+            }
             for m in cfg.dep_modules {
                 if let Some(a) = m.analysis.as_ref() {
-                    set.extend(a.recursive_fns.iter().cloned());
+                    set.extend(a.recursive_fns.iter().filter_map(|n| {
+                        symbols.fn_id_of(&crate::ir::FnKey::in_module(m.prefix.clone(), n))
+                    }));
                 }
             }
             set
@@ -579,7 +582,7 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
             dep_modules: cfg.dep_modules,
             module_prefixes: &module_prefixes,
             recursive_fns: &recursive_fns_owned,
-            symbol_table: result.symbol_table.as_ref(),
+            symbol_table: symbols,
         };
         let mut ir = result.proof_ir.take().unwrap_or_default();
         if cfg.run_refinement_lower {
@@ -1138,6 +1141,10 @@ fn factorial(n: Int, acc: Int) -> Int
                 PipelineStage::Analyze,
                 PipelineStage::Escape,
                 PipelineStage::LastUse,
+                // Symbol table is built unconditionally (universal
+                // foundation for proof IR + backend identity); the
+                // diagnostic always lands in `pass_diagnostics`.
+                PipelineStage::BuildSymbols,
             ]
         );
 

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -291,8 +291,6 @@ pub enum PassReport {
         law_theorems: usize,
     },
     BuildSymbols {
-        /// Modules in the table (always ≥ 1 — entry scope counts).
-        modules: usize,
         /// Total fn declarations across entry + dep modules.
         fns: usize,
         /// Total type declarations across entry + dep modules.
@@ -300,7 +298,33 @@ pub enum PassReport {
         /// Total constructors (record + sum variants) across all
         /// type declarations.
         ctors: usize,
+        /// Per-module breakdown (entry first, then deps in walk
+        /// order). Shows where each fn/type lives — useful for
+        /// "is this big project actually multi-module?" sanity
+        /// checks at a glance.
+        modules: Vec<BuildSymbolsModule>,
+        /// Number of bare fn names that occur in 2+ different
+        /// scopes (e.g. entry + Module, or Module.A + Module.B).
+        /// Under bare-name keying these would have silently
+        /// merged; opaque `FnId` keeps them distinct. Zero would
+        /// mean phase E migration had no practical effect on
+        /// *this* project — non-zero is the proof it did.
+        fn_name_collisions: usize,
+        /// Same for type names.
+        type_name_collisions: usize,
     },
+}
+
+/// Per-module entry in `PassReport::BuildSymbols`. `prefix` is the
+/// dotted module name (`"Models.User"`); the entry scope is
+/// represented by an empty string so JSON consumers can sort/group
+/// uniformly.
+#[derive(Debug, Clone)]
+pub struct BuildSymbolsModule {
+    pub prefix: String,
+    pub fns: usize,
+    pub types: usize,
+    pub ctors: usize,
 }
 
 /// Per-fn counter delta — used by `Tco` and `InterpLower` reports to
@@ -796,13 +820,53 @@ fn diag_for_law_lower(ir: &crate::ir::ProofIR) -> PassDiagnostic {
 }
 
 fn diag_for_build_symbols(table: &crate::ir::SymbolTable) -> PassDiagnostic {
+    // Per-module breakdown: walk every fn/type/ctor, bucket by its
+    // owning module, count. Single pass, O(fns + types + ctors).
+    let mut per_module: Vec<BuildSymbolsModule> = table
+        .modules
+        .iter()
+        .map(|m| BuildSymbolsModule {
+            prefix: m.prefix.clone().unwrap_or_default(),
+            fns: 0,
+            types: 0,
+            ctors: 0,
+        })
+        .collect();
+    for fe in &table.fns {
+        per_module[fe.module.0 as usize].fns += 1;
+    }
+    for te in &table.types {
+        per_module[te.module.0 as usize].types += 1;
+    }
+    for ce in &table.ctors {
+        let owning_module = table.types[ce.owning_type.0 as usize].module;
+        per_module[owning_module.0 as usize].ctors += 1;
+    }
+
+    // Bare-name collision count: a fn/type with the same `key.name`
+    // appearing in 2+ different scopes. Under bare-name keying these
+    // would silently merge; under opaque IDs each gets its own slot.
+    use std::collections::HashMap;
+    let mut fn_buckets: HashMap<&str, usize> = HashMap::new();
+    for fe in &table.fns {
+        *fn_buckets.entry(fe.key.name.as_str()).or_default() += 1;
+    }
+    let fn_name_collisions = fn_buckets.values().filter(|c| **c >= 2).count();
+    let mut type_buckets: HashMap<&str, usize> = HashMap::new();
+    for te in &table.types {
+        *type_buckets.entry(te.key.name.as_str()).or_default() += 1;
+    }
+    let type_name_collisions = type_buckets.values().filter(|c| **c >= 2).count();
+
     PassDiagnostic {
         stage: PipelineStage::BuildSymbols,
         report: PassReport::BuildSymbols {
-            modules: table.modules.len(),
             fns: table.fns.len(),
             types: table.types.len(),
             ctors: table.ctors.len(),
+            modules: per_module,
+            fn_name_collisions,
+            type_name_collisions,
         },
     }
 }

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -427,10 +427,15 @@ pub(super) enum Commands {
         #[arg(long, value_enum)]
         optimize: Option<WasmOptMode>,
         /// Print the IR after the named pipeline stage and exit before codegen.
-        /// One of: `tco`, `typecheck`, `interp_lower`, `buffer_build`, `resolve`.
-        /// Use `--emit-ir-after=resolve` to see the final IR that goes into
-        /// codegen. Pass `parse` to see the AST as the parser produced it,
-        /// before any pass runs.
+        /// One of: `tco`, `typecheck`, `interp_lower`, `buffer_build`, `resolve`,
+        /// `last_use`, `analyze`, `escape`, `build_symbols`, `refinement_lower`,
+        /// `contract_lower`, `law_lower`. Use `--emit-ir-after=resolve` to see
+        /// the final IR that goes into codegen. Pass `parse` to see the AST as
+        /// the parser produced it, before any pass runs. For side-artifact
+        /// stages (`build_symbols` dumps the SymbolTable, `refinement_lower` /
+        /// `contract_lower` / `law_lower` dump the ProofIR sections each
+        /// populates) the dump shows the produced artifact, not the
+        /// (unchanged) items list.
         #[arg(long, value_name = "PASS")]
         emit_ir_after: Option<String>,
         /// Run the full pipeline and print a per-pass diagnostic report

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -3065,6 +3065,7 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
         "last_use" => Some(PipelineStage::LastUse),
         "analyze" => Some(PipelineStage::Analyze),
         "escape" => Some(PipelineStage::Escape),
+        "build_symbols" => Some(PipelineStage::BuildSymbols),
         "refinement_lower" => Some(PipelineStage::RefinementLower),
         "contract_lower" => Some(PipelineStage::ContractLower),
         "law_lower" => Some(PipelineStage::LawLower),
@@ -3073,7 +3074,7 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
                 "{}",
                 format!(
                     "unknown --emit-ir-after stage '{}'; expected one of: \
-                     parse, tco, typecheck, interp_lower, buffer_build, resolve, last_use, analyze, escape, refinement_lower, contract_lower, law_lower",
+                     parse, tco, typecheck, interp_lower, buffer_build, resolve, last_use, analyze, escape, build_symbols, refinement_lower, contract_lower, law_lower",
                     other
                 )
                 .red()
@@ -3184,6 +3185,17 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
                 process::exit(1);
             }
         }
+        return;
+    }
+
+    // `build_symbols` is the same shape — side-artifact (the symbol
+    // table), not item rewrite. Dump the resolved-identity layer so
+    // users can inspect FnKey → FnId / TypeKey → TypeId mappings.
+    if target == PipelineStage::BuildSymbols {
+        print!(
+            "{}",
+            render_symbol_table_dump(&pipeline_result.symbol_table)
+        );
         return;
     }
 
@@ -3311,6 +3323,67 @@ fn render_proof_ir_dump(ir: &aver::ir::ProofIR, symbols: &aver::ir::SymbolTable)
             theorem.strategy,
             theorem.quantifiers.len(),
             theorem.premises.len(),
+        )
+        .unwrap();
+    }
+    out
+}
+
+/// Backend-neutral textual dump of the resolved-identity layer.
+/// Drives `aver compile FILE --emit-ir-after=build_symbols` — same
+/// shape as `render_proof_ir_dump`, just for the SymbolTable
+/// side-artifact instead of ProofIR. Lists every module / fn /
+/// type / ctor with its opaque ID so debug sessions can verify
+/// "what FnId did `Module.foo` resolve to?" without grep'ing.
+fn render_symbol_table_dump(symbols: &aver::ir::SymbolTable) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    writeln!(out, "# SymbolTable").unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "## modules ({})", symbols.modules.len()).unwrap();
+    for (idx, m) in symbols.modules.iter().enumerate() {
+        let prefix = m.prefix.as_deref().unwrap_or("<entry>");
+        writeln!(out, "- ModuleId({}) = {}", idx, prefix).unwrap();
+    }
+    writeln!(out).unwrap();
+    writeln!(out, "## fns ({})", symbols.fns.len()).unwrap();
+    for (idx, fe) in symbols.fns.iter().enumerate() {
+        writeln!(
+            out,
+            "- FnId({}) = {} (in ModuleId({}), source index {})",
+            idx,
+            fe.key.canonical(),
+            fe.module.0,
+            fe.index_in_module,
+        )
+        .unwrap();
+    }
+    writeln!(out).unwrap();
+    writeln!(out, "## types ({})", symbols.types.len()).unwrap();
+    for (idx, te) in symbols.types.iter().enumerate() {
+        let shape = if te.is_product { "record" } else { "sum" };
+        writeln!(
+            out,
+            "- TypeId({}) = {} ({}, {} ctor(s), in ModuleId({}))",
+            idx,
+            te.key.canonical(),
+            shape,
+            te.variants.len().max(if te.is_product { 1 } else { 0 }),
+            te.module.0,
+        )
+        .unwrap();
+    }
+    writeln!(out).unwrap();
+    writeln!(out, "## ctors ({})", symbols.ctors.len()).unwrap();
+    for (idx, ce) in symbols.ctors.iter().enumerate() {
+        let owning = &symbols.types[ce.owning_type.0 as usize];
+        writeln!(
+            out,
+            "- CtorId({}) = {}.{} (of TypeId({}))",
+            idx,
+            owning.key.canonical(),
+            ce.name,
+            ce.owning_type.0,
         )
         .unwrap();
     }
@@ -3525,15 +3598,35 @@ fn render_pass_diagnostics(diags: &[aver::ir::pipeline::PassDiagnostic]) -> Stri
                 ));
             }
             PassReport::BuildSymbols {
-                modules,
                 fns,
                 types,
                 ctors,
+                modules,
+                fn_name_collisions,
+                type_name_collisions,
             } => {
                 out.push_str(&format!(
-                    "{label} symbol table: {modules} module(s), {fns} fn(s), \
-                     {types} type(s), {ctors} ctor(s)\n"
+                    "{label} symbol table: {} module(s), {fns} fn(s), \
+                     {types} type(s), {ctors} ctor(s)\n",
+                    modules.len()
                 ));
+                if *fn_name_collisions > 0 || *type_name_collisions > 0 {
+                    out.push_str(&format!(
+                        "  • bare-name collisions resolved by opaque ID: \
+                         {fn_name_collisions} fn name(s), {type_name_collisions} type name(s)\n"
+                    ));
+                }
+                for m in modules {
+                    let scope = if m.prefix.is_empty() {
+                        "<entry>"
+                    } else {
+                        m.prefix.as_str()
+                    };
+                    out.push_str(&format!(
+                        "  • {scope}: {} fn(s), {} type(s), {} ctor(s)\n",
+                        m.fns, m.types, m.ctors
+                    ));
+                }
             }
         }
         out.push('\n');
@@ -3699,14 +3792,34 @@ fn render_pass_diagnostics_json(diags: &[aver::ir::pipeline::PassDiagnostic]) ->
                 out.push_str(&format!("{{\"law_theorems\":{}}}", law_theorems));
             }
             PassReport::BuildSymbols {
-                modules,
                 fns,
                 types,
                 ctors,
+                modules,
+                fn_name_collisions,
+                type_name_collisions,
             } => {
                 out.push_str(&format!(
-                    "{{\"modules\":{modules},\"fns\":{fns},\"types\":{types},\"ctors\":{ctors}}}"
+                    "{{\"fns\":{fns},\"types\":{types},\"ctors\":{ctors},\
+                     \"fn_name_collisions\":{fn_name_collisions},\
+                     \"type_name_collisions\":{type_name_collisions},\
+                     \"modules\":["
                 ));
+                let mut first = true;
+                for m in modules {
+                    if !first {
+                        out.push(',');
+                    }
+                    first = false;
+                    out.push_str(&format!(
+                        "{{\"prefix\":{},\"fns\":{},\"types\":{},\"ctors\":{}}}",
+                        json_escape(&m.prefix),
+                        m.fns,
+                        m.types,
+                        m.ctors
+                    ));
+                }
+                out.push_str("]}");
             }
         }
         out.push('}');

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -2542,7 +2542,6 @@ fn build_codegen_context(
     // pipeline; pull it across before assembly so build_context doesn't
     // redundantly recompute it.
     let prebuilt_proof_ir = pipeline_result.proof_ir;
-    let prebuilt_symbol_table = pipeline_result.symbol_table;
     let mut ctx = codegen::build_context(
         items,
         &tc_result,
@@ -2550,6 +2549,7 @@ fn build_codegen_context(
         memo_fns,
         name,
         modules,
+        pipeline_result.symbol_table,
     );
     #[cfg(feature = "runtime")]
     if let Some(ir) = prebuilt_proof_ir {
@@ -2557,7 +2557,6 @@ fn build_codegen_context(
     }
     #[cfg(not(feature = "runtime"))]
     let _ = prebuilt_proof_ir;
-    ctx.symbol_table = prebuilt_symbol_table;
     ctx.policy = policy;
     ctx.emit_replay_runtime = use_scoped_runtime;
     ctx.runtime_policy_from_env = use_runtime_policy;
@@ -3171,7 +3170,7 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
         match pipeline_result.proof_ir {
             Some(ir) => print!(
                 "{}",
-                render_proof_ir_dump(&ir, pipeline_result.symbol_table.as_ref())
+                render_proof_ir_dump(&ir, &pipeline_result.symbol_table)
             ),
             None => {
                 eprintln!(
@@ -3217,7 +3216,7 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
 /// exporter (Lean / Dafny) would consume. Useful for debugging
 /// "why did this fn get Fuel vs Native?", "what precondition did
 /// the lowerer derive?", "did this type lift to a subtype?".
-fn render_proof_ir_dump(ir: &aver::ir::ProofIR, symbols: Option<&aver::ir::SymbolTable>) -> String {
+fn render_proof_ir_dump(ir: &aver::ir::ProofIR, symbols: &aver::ir::SymbolTable) -> String {
     use aver::ir::{Measure, RecursionContract};
     use std::fmt::Write as _;
     let mut out = String::new();
@@ -3226,15 +3225,9 @@ fn render_proof_ir_dump(ir: &aver::ir::ProofIR, symbols: Option<&aver::ir::Symbo
     writeln!(out, "## refined_types ({})", ir.refined_types.len()).unwrap();
     // After phase E2 the map is keyed by opaque `TypeId`; render the
     // canonical `Module.Name` form via the symbol table so two
-    // module-owned `Natural`s disambiguate in the dump. Without a
-    // symbol table (best-effort path), fall back to the bare
-    // `decl.name` — the dump is diagnostic, not load-bearing for
-    // any consumer.
-    let type_label = |type_id: aver::ir::TypeId| -> String {
-        symbols
-            .map(|s| s.type_entry(type_id).key.canonical())
-            .unwrap_or_else(|| format!("TypeId({:?})", type_id))
-    };
+    // module-owned `Natural`s disambiguate in the dump.
+    let type_label =
+        |type_id: aver::ir::TypeId| -> String { symbols.type_entry(type_id).key.canonical() };
     let mut refined: Vec<(aver::ir::TypeId, &aver::ir::proof_ir::RefinedTypeDecl)> = ir
         .refined_types
         .iter()
@@ -3306,14 +3299,8 @@ fn render_proof_ir_dump(ir: &aver::ir::ProofIR, symbols: Option<&aver::ir::Symbo
     writeln!(out, "## law_theorems ({})", ir.law_theorems.len()).unwrap();
     let mut laws: Vec<_> = ir.law_theorems.iter().collect();
     // Render the fn identity through the symbol table so the dump
-    // stays human-readable after the FnKey → FnId migration. When
-    // there is no symbol table (best-effort path), fall back to
-    // the raw FnId for sort-stability.
-    let fn_label = |fn_id: aver::ir::FnId| -> String {
-        symbols
-            .map(|s| s.fn_entry(fn_id).key.canonical())
-            .unwrap_or_else(|| format!("FnId({:?})", fn_id))
-    };
+    // stays human-readable after the FnKey → FnId migration.
+    let fn_label = |fn_id: aver::ir::FnId| -> String { symbols.fn_entry(fn_id).key.canonical() };
     laws.sort_by(|a, b| (fn_label(a.fn_id), &a.law_name).cmp(&(fn_label(b.fn_id), &b.law_name)));
     for theorem in laws {
         writeln!(
@@ -4840,7 +4827,7 @@ mod tests {
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),
             proof_ir: aver::ir::ProofIR::default(),
-            symbol_table: None,
+            symbol_table: aver::ir::SymbolTable::default(),
         }
     }
 

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -297,16 +297,11 @@ fn build_ctx(
         HashSet::new(),
         "playground".to_string(),
         vec![],
+        pipeline_result.symbol_table,
     );
     if let Some(ir) = proof_ir {
         ctx.proof_ir = ir;
     }
-    // BuildSymbols auto-runs when any proof stage is on (see
-    // `ir::pipeline::run`), so the symbol table is populated for the
-    // proof path. Plumb it through so backend lookups
-    // (`find_fn_contract_for_fn`, etc.) resolve through opaque IDs
-    // instead of returning `None` and dropping recursion contracts.
-    ctx.symbol_table = pipeline_result.symbol_table;
     Ok(ctx)
 }
 
@@ -398,11 +393,11 @@ fn build_project_ctx(
         HashSet::new(),
         "playground".to_string(),
         modules,
+        pipeline_result.symbol_table,
     );
     if let Some(ir) = proof_ir {
         ctx.proof_ir = ir;
     }
-    ctx.symbol_table = pipeline_result.symbol_table;
     Ok(ctx)
 }
 

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -64,11 +64,11 @@ fn build_ctx(src: &str) -> CodegenContext {
         HashSet::new(),
         "diff".to_string(),
         vec![],
+        pipeline_result.symbol_table,
     );
     if let Some(ir) = proof_ir {
         ctx.proof_ir = ir;
     }
-    ctx.symbol_table = pipeline_result.symbol_table;
     ctx
 }
 
@@ -81,7 +81,7 @@ fn fn_contract<'a>(
     name: &str,
 ) -> Option<&'a aver::ir::proof_ir::FnContract> {
     let key = aver::ir::FnKey::entry(name);
-    let id = ctx.symbol_table.as_ref()?.fn_id_of(&key)?;
+    let id = ctx.symbol_table.fn_id_of(&key)?;
     ctx.proof_ir.fn_contracts.get(&id)
 }
 
@@ -95,7 +95,6 @@ fn law_theorem<'a>(
 ) -> Option<&'a aver::ir::proof_ir::LawTheorem> {
     let fn_id = ctx
         .symbol_table
-        .as_ref()?
         .fn_id_of(&aver::ir::FnKey::entry(fn_name))?;
     ctx.proof_ir
         .law_theorems
@@ -190,10 +189,7 @@ fn pipeline_populates_symbol_table_when_build_symbols_is_on() {
     // this test is the contract that the table exists.
     let src = include_str!("../examples/refinement/natural/natural.av");
     let ctx = build_ctx(src);
-    let symbols = ctx
-        .symbol_table
-        .as_ref()
-        .expect("ctx.symbol_table must be Some after run_build_symbols");
+    let symbols = &ctx.symbol_table;
 
     // Natural.av declares the `Natural` record + the `fromInt` /
     // `toInt` / `add` / `mul` fns. Look up via `TypeKey` /


### PR DESCRIPTION
## Summary

First step of phase C from issue #138 — the two \`HashSet<String>\` sets in \`CodegenContext\` (\`recursive_fns\` + \`mutual_tco_members\`) switch to opaque \`FnId\`. Bare-name keying silently mergowało entry's \`foo\` i dep module's \`foo\` w jeden globalny set; po PR-ach #142–#144 (proof codegen FnId migration) mamy już \`SymbolTable\` dostępny up-front, więc ten sam wzorzec przenosi się na pozostałe ctx-level identity maps.

## What changed

- \`CodegenContext.recursive_fns: HashSet<FnId>\`
- \`CodegenContext.mutual_tco_members: HashSet<FnId>\`
- \`ProofLowerInputs.recursive_fns: &HashSet<FnId>\` — per-scope helpery (\`recursive_pure_fn_names_in_scope\`) projektują back na bare strings przez \`SymbolTable.fn_entry(id).key.name\` dla scope-local consumers (\`analyze_plans\`); DAG invariant gwarantuje bare-name unambiguity w pojedynczym scope.
- **Producenci**:
  - \`build_context\` buduje \`SymbolTable\` up-front, plumbuje na \`ctx.symbol_table\`, konwertuje per-module bare-name sety → FnId. Konsekwentnie: dla każdej dep-module analysis bare-name w jej scope zaadresowany przez \`fn_key_in_module(prefix, name)\`.
  - \`refresh_facts\` (synthetic-ctx test path) — jeden SymbolTable na początku, reuse'owany dla proof_lower poniżej (zamiast budować dwukrotnie).
  - \`pipeline::run\` proof-stages path projektuje analysis bare-name sety → FnId przez \`result.symbol_table\` przed dostarczeniem do \`ProofLowerInputs.recursive_fns\`.
- **Consumenci** (scope-local — bare-name OK by DAG invariant):
  - Lean: \`recursive_pure_fn_names(ctx)\` projektuje FnId → bare przez symbol table; \`transpile_unified\` builds scope-local \`HashSet<String>\` z \`ctx.recursive_fns\` dla \`emit_fn_def\`.
  - Rust: \`is_mutual_tco\` checks via \`fn_id_for_decl + contains\`. Module emit path projektuje \`ctx.mutual_tco_members\` → bare per-module scope dla \`module_mutual.contains(&fd.name)\` fallback.

## Net effect

Phase C item \"recursive_fns / mutual_tco_members\" zamknięte. \`CodegenContext.fn_analyses: HashMap<String, FnAnalysis>\` zostaje na osobny mały PR (oddzielny consumer set). Rust \`fn_sigs\` (22 callsity) + WASM/VM backendy + typechecker Phase B zostają tracked w #138.

## Test plan

- [x] cargo build --lib + --bin aver
- [x] cargo test (1521 passed; \`explain_passes_spec\` flake jest pre-existing race w concurrent tempfile naming — izolowany run pass)
- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)