### PR TITLE
codegen: consolidate bare-name → FnId boundary conversions (#138 phase C close)

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -2548,7 +2548,6 @@ mod tests {
             extra_fn_defs: Vec::new(),
             mutual_tco_members: HashSet::new(),
             recursive_fns: HashSet::new(),
-            fn_analyses: HashMap::new(),
             buffer_build_sinks: HashMap::new(),
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -196,7 +196,6 @@ mod tests {
             extra_fn_defs: Vec::new(),
             mutual_tco_members: HashSet::new(),
             recursive_fns: HashSet::new(),
-            fn_analyses: HashMap::new(),
             buffer_build_sinks: HashMap::new(),
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1553,7 +1553,6 @@ mod tests {
             extra_fn_defs: Vec::new(),
             mutual_tco_members: HashSet::<crate::ir::FnId>::new(),
             recursive_fns: HashSet::<crate::ir::FnId>::new(),
-            fn_analyses: HashMap::new(),
             buffer_build_sinks: HashMap::new(),
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -16,6 +16,7 @@ pub mod proof_lower;
 pub mod recursion;
 #[cfg(feature = "runtime")]
 pub mod rust;
+pub mod scc;
 #[cfg(feature = "wasip2")]
 pub mod wasip2;
 #[cfg(feature = "wasm-compile")]
@@ -94,11 +95,6 @@ pub struct CodegenContext {
     /// `mutual_tco_members`. Used by codegen sites that previously
     /// called `call_graph::find_recursive_fns` ad-hoc.
     pub recursive_fns: HashSet<crate::ir::FnId>,
-    /// Per-fn analysis facts unioned from entry + every dep module's
-    /// `AnalysisResult.fn_analyses`. WASM emitter / VM compiler /
-    /// future inliner read `allocates`, `thin_kind`, `body_shape`,
-    /// `local_count`, etc. from here instead of recomputing.
-    pub fn_analyses: HashMap<String, crate::ir::FnAnalysis>,
     /// Buffer-build sink fns (`List.prepend`/`reverse` builders consumed
     /// by `String.join`). The Rust backend emits a `<fn>__buffered`
     /// variant alongside each entry; the WASM backend rewrites bodies
@@ -189,42 +185,32 @@ pub fn build_context(
 
     let module_prefixes: HashSet<String> = modules.iter().map(|m| m.prefix.clone()).collect();
 
-    // Symbol table threaded in from the caller (pipeline or stripped
-    // test driver). Used here to convert the per-scope bare-name sets
-    // unioned below into FnId-keyed sets.
-
-    // Helper: bare fn name → entry-scope FnId. Used for entry-source
-    // analysis facts (per-module facts use `(prefix, name)` below).
-    let entry_fn_id = |name: &str| -> Option<crate::ir::FnId> {
-        symbol_table.fn_id_of(&crate::ir::FnKey::entry(name))
-    };
-    let module_fn_id = |prefix: &str, name: &str| -> Option<crate::ir::FnId> {
-        symbol_table.fn_id_of(&crate::ir::FnKey::in_module(prefix.to_string(), name))
-    };
-
-    // Mutual-TCO membership unions per-module sets from the analyze stage
-    // (entry's `entry_analysis` + each dep module's `module.analysis`).
-    // Aver's module DAG invariant guarantees SCCs never span modules, so
-    // a per-module union is the correct global view — see
-    // `project_aver_module_dag` memory and `src/ir/analyze.rs` doc.
-    //
-    // Falls back to ad-hoc `tailcall_scc_components` per module when the
-    // analysis isn't supplied (callers that haven't migrated to the
-    // pipeline). The fallback path will go away once every entry point
-    // runs the canonical pipeline.
+    // Mutual-TCO membership unions per-scope sets from the analyze
+    // stage (entry's `entry_analysis` + each dep module's
+    // `module.analysis`); falls back to recomputing per-scope via
+    // `call_graph::tailcall_scc_components` when no analysis ran.
+    // Aver's module DAG invariant guarantees SCCs never span
+    // modules — per-scope union is the correct global view (see
+    // `project_aver_module_dag` memory + `src/ir/analyze.rs`). The
+    // FnId resolution happens inside the `scc` wrappers below.
     let mut mutual_tco_members: HashSet<crate::ir::FnId> = HashSet::new();
     match entry_analysis {
-        Some(a) => {
-            mutual_tco_members.extend(a.mutual_tco_members.iter().filter_map(|n| entry_fn_id(n)))
-        }
+        Some(a) => mutual_tco_members.extend(scc::analysis_set_to_fn_ids(
+            &a.mutual_tco_members,
+            &symbol_table,
+            None,
+        )),
         None => {
+            // No entry analysis: compute the per-scope SCC set inline
+            // via `call_graph` and project to FnIds. Same effect as
+            // running the analyze stage's mutual-TCO discovery.
             let entry_fns: Vec<&FnDef> = fn_defs.iter().filter(|fd| fd.name != "main").collect();
             for group in crate::call_graph::tailcall_scc_components(&entry_fns) {
                 if group.len() < 2 {
                     continue;
                 }
                 for fd in group {
-                    if let Some(id) = entry_fn_id(&fd.name) {
+                    if let Some(id) = symbol_table.fn_id_of(&crate::ir::FnKey::entry(&fd.name)) {
                         mutual_tco_members.insert(id);
                     }
                 }
@@ -233,11 +219,11 @@ pub fn build_context(
     }
     for module in &modules {
         match module.analysis.as_ref() {
-            Some(a) => mutual_tco_members.extend(
-                a.mutual_tco_members
-                    .iter()
-                    .filter_map(|n| module_fn_id(&module.prefix, n)),
-            ),
+            Some(a) => mutual_tco_members.extend(scc::analysis_set_to_fn_ids(
+                &a.mutual_tco_members,
+                &symbol_table,
+                Some(&module.prefix),
+            )),
             None => {
                 let mod_fns: Vec<&FnDef> = module.fn_defs.iter().collect();
                 for group in crate::call_graph::tailcall_scc_components(&mod_fns) {
@@ -245,7 +231,10 @@ pub fn build_context(
                         continue;
                     }
                     for fd in group {
-                        if let Some(id) = module_fn_id(&module.prefix, &fd.name) {
+                        if let Some(id) = symbol_table.fn_id_of(&crate::ir::FnKey::in_module(
+                            module.prefix.clone(),
+                            &fd.name,
+                        )) {
                             mutual_tco_members.insert(id);
                         }
                     }
@@ -254,59 +243,44 @@ pub fn build_context(
         }
     }
 
-    // Per-fn analysis dictionary — union of entry's `fn_analyses` plus
-    // each dep module's. Codegen reads `allocates`, `thin_kind`, etc.
-    // from here instead of recomputing.
-    let mut fn_analyses: HashMap<String, crate::ir::FnAnalysis> = HashMap::new();
-    if let Some(a) = entry_analysis {
-        for (name, fa) in &a.fn_analyses {
-            fn_analyses.insert(name.clone(), fa.clone());
-        }
-    }
-    for module in &modules {
-        if let Some(a) = module.analysis.as_ref() {
-            for (name, fa) in &a.fn_analyses {
-                fn_analyses
-                    .entry(name.clone())
-                    .or_insert_with(|| fa.clone());
-            }
-        }
-    }
-
-    // `recursive_fns` follows the same shape as `mutual_tco_members` —
-    // per-module sets unioned (Aver's module DAG keeps cross-module
-    // recursion from existing). Falls back to ad-hoc `find_recursive_fns`
-    // when a module's analysis is missing. Keyed by opaque `FnId` for
-    // the same disambiguation guarantee as `mutual_tco_members`.
+    // `recursive_fns` follows the same shape — per-scope union with
+    // analyze-stage fallback. Keyed by opaque `FnId` so entry +
+    // dep-module same-bare-name fns stay distinct.
     let mut recursive_fns: HashSet<crate::ir::FnId> = HashSet::new();
     match entry_analysis {
-        Some(a) => recursive_fns.extend(a.recursive_fns.iter().filter_map(|n| entry_fn_id(n))),
-        None => {
-            recursive_fns.extend(
-                crate::call_graph::find_recursive_fns(&items)
-                    .iter()
-                    .filter_map(|n| entry_fn_id(n)),
-            );
-        }
+        Some(a) => recursive_fns.extend(scc::analysis_set_to_fn_ids(
+            &a.recursive_fns,
+            &symbol_table,
+            None,
+        )),
+        None => recursive_fns.extend(scc::bare_names_to_fn_ids(
+            crate::call_graph::find_recursive_fns(&items)
+                .iter()
+                .map(String::as_str),
+            &symbol_table,
+            None,
+        )),
     }
     for module in &modules {
         match module.analysis.as_ref() {
-            Some(a) => recursive_fns.extend(
-                a.recursive_fns
-                    .iter()
-                    .filter_map(|n| module_fn_id(&module.prefix, n)),
-            ),
+            Some(a) => recursive_fns.extend(scc::analysis_set_to_fn_ids(
+                &a.recursive_fns,
+                &symbol_table,
+                Some(&module.prefix),
+            )),
             None => {
                 let mod_items: Vec<TopLevel> = module
                     .fn_defs
                     .iter()
                     .map(|fd| TopLevel::FnDef(fd.clone()))
                     .collect();
-                recursive_fns.extend(
+                recursive_fns.extend(scc::bare_names_to_fn_ids(
                     crate::call_graph::find_recursive_fns(&mod_items)
                         .iter()
-                        .filter_map(|n| module_fn_id(&module.prefix, n)),
-                );
+                        .map(String::as_str),
+                    &symbol_table,
+                    Some(&module.prefix),
+                ));
             }
         }
     }
@@ -453,7 +427,6 @@ pub fn build_context(
         extra_fn_defs: Vec::new(),
         mutual_tco_members,
         recursive_fns,
-        fn_analyses,
         buffer_build_sinks,
         buffer_fusion_sites,
         synthesized_buffered_fns,
@@ -530,22 +503,26 @@ impl CodegenContext {
         }
         self.mutual_tco_members = mutual_tco_members;
 
-        let mut recursive_fns: HashSet<crate::ir::FnId> =
+        let mut recursive_fns: HashSet<crate::ir::FnId> = scc::bare_names_to_fn_ids(
             crate::call_graph::find_recursive_fns(&self.items)
                 .iter()
-                .filter_map(|n| entry_fn_id(n))
-                .collect();
+                .map(String::as_str),
+            &symbol_table,
+            None,
+        );
         for module in &self.modules {
             let mod_items: Vec<TopLevel> = module
                 .fn_defs
                 .iter()
                 .map(|fd| TopLevel::FnDef(fd.clone()))
                 .collect();
-            recursive_fns.extend(
+            recursive_fns.extend(scc::bare_names_to_fn_ids(
                 crate::call_graph::find_recursive_fns(&mod_items)
                     .iter()
-                    .filter_map(|n| module_fn_id(&module.prefix, n)),
-            );
+                    .map(String::as_str),
+                &symbol_table,
+                Some(&module.prefix),
+            ));
         }
         self.recursive_fns = recursive_fns;
 

--- a/src/codegen/recursion/detect.rs
+++ b/src/codegen/recursion/detect.rs
@@ -1535,21 +1535,15 @@ fn walk_caller_collect_callsite_guards(
 /// (`tests/proof_ir_diff.rs`) cross-checks ProofIR against the
 /// legacy classifier output — that test is itself slated for
 /// rationalisation once the migration is fully bedded down.
-pub fn analyze_plans(
-    inputs: &ProofLowerInputs,
-) -> (HashMap<String, RecursionPlan>, Vec<ProofModeIssue>) {
-    analyze_plans_in_scope(inputs, None, true)
-}
-
-/// Scope-aware variant. `scope = None` runs against entry only,
+/// Scope-aware classifier. `scope = None` runs against entry only,
 /// `Some(prefix)` against one dep module. Aver's module DAG
 /// invariant rules out cross-module recursion SCCs, so per-scope
 /// classification is the canonical view and avoids two
 /// same-bare-name fns from different modules colliding in the
-/// SCC analyser's `HashMap<name, _>`. The `global_view` flag is
-/// the legacy entry point: it keeps the old "chain all fns,
-/// classify globally" behaviour for callers that don't yet know
-/// about scopes.
+/// SCC analyser's `HashMap<name, _>`. The `global_view` flag keeps
+/// the legacy "chain all fns, classify globally" behaviour for
+/// `tests/proof_ir_diff.rs` cross-check tests; production callers
+/// always pass `global_view = false` and walk scopes themselves.
 pub fn analyze_plans_in_scope(
     inputs: &ProofLowerInputs,
     scope: Option<&str>,

--- a/src/codegen/recursion/mod.rs
+++ b/src/codegen/recursion/mod.rs
@@ -17,7 +17,7 @@ use std::collections::HashSet;
 use crate::ast::{Expr, FnBody, MatchArm, Spanned, Stmt, StrPart, TailCallData};
 use crate::codegen::common::expr_to_dotted_name;
 
-pub use detect::{analyze_plans, analyze_plans_in_scope};
+pub use detect::analyze_plans_in_scope;
 
 /// Classification for a single recursive fn (or a whole mutual-recursion
 /// SCC, in which case every fn in the SCC gets its own plan from the

--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -1030,7 +1030,6 @@ mod tests {
             extra_fn_defs: Vec::new(),
             mutual_tco_members: HashSet::new(),
             recursive_fns: HashSet::new(),
-            fn_analyses: HashMap::new(),
             buffer_build_sinks: HashMap::new(),
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -2791,7 +2791,6 @@ mod tests {
             extra_fn_defs: Vec::new(),
             mutual_tco_members: HashSet::new(),
             recursive_fns: HashSet::new(),
-            fn_analyses: HashMap::new(),
             buffer_build_sinks: HashMap::new(),
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),

--- a/src/codegen/scc.rs
+++ b/src/codegen/scc.rs
@@ -1,0 +1,60 @@
+//! Bare-name → `FnId` projection helpers for codegen boundary code.
+//!
+//! `call_graph` is **scope-local by design** — every public fn operates on
+//! a single scope (entry module OR one dep module), returns bare-name
+//! results, and Aver's module DAG invariant keeps cross-module SCCs
+//! impossible so the bare-name keying is correct within a scope (see
+//! `project_aver_module_dag` memory).
+//!
+//! Codegen, however, needs `FnId` identity once it joins per-scope
+//! results into a global view (`CodegenContext.recursive_fns` /
+//! `mutual_tco_members` are FnId-keyed after #145 phase C). The
+//! conversion is mechanical — pick `FnKey::entry` or `FnKey::in_module`
+//! based on scope and look the ID up — but writing it inline in every
+//! place that consumes a per-scope bare-name set turned `build_context`
+//! / `refresh_facts` / `pipeline.rs` proof setup into ~120 lines of
+//! near-identical `filter_map` blocks. These two helpers collapse the
+//! pattern.
+
+use std::collections::HashSet;
+
+use crate::ir::{FnId, FnKey, SymbolTable};
+
+/// Project a sequence of bare fn names (as `&str`) to `FnId`s through
+/// the symbol table. `scope = None` resolves names against the entry
+/// scope; `Some(prefix)` resolves against the dep module with that
+/// prefix. Names that don't resolve (built-ins, synthetic helpers
+/// the table excludes) are dropped silently — same semantics every
+/// per-scope union loop already had.
+pub fn bare_names_to_fn_ids<'a>(
+    names: impl IntoIterator<Item = &'a str>,
+    symbols: &SymbolTable,
+    scope: Option<&str>,
+) -> HashSet<FnId> {
+    names
+        .into_iter()
+        .filter_map(|n| symbols.fn_id_of(&fn_key_in_scope(scope, n)))
+        .collect()
+}
+
+/// Same shape as [`bare_names_to_fn_ids`] but accepts an iterator over
+/// `&String` (which is what `HashSet<String>` / `Vec<String>` from
+/// `AnalysisResult.recursive_fns` / `mutual_tco_members` yields). Avoids
+/// `.iter().map(String::as_str)` ceremony at every call site.
+pub fn analysis_set_to_fn_ids<'a, I>(
+    names: I,
+    symbols: &SymbolTable,
+    scope: Option<&str>,
+) -> HashSet<FnId>
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    bare_names_to_fn_ids(names.into_iter().map(String::as_str), symbols, scope)
+}
+
+fn fn_key_in_scope(scope: Option<&str>, name: &str) -> FnKey {
+    match scope {
+        Some(prefix) => FnKey::in_module(prefix.to_string(), name),
+        None => FnKey::entry(name),
+    }
+}

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -584,17 +584,19 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
         let recursive_fns_owned: std::collections::HashSet<crate::ir::FnId> = {
             let mut set = std::collections::HashSet::new();
             if let Some(a) = result.analysis.as_ref() {
-                set.extend(
-                    a.recursive_fns
-                        .iter()
-                        .filter_map(|n| symbols.fn_id_of(&crate::ir::FnKey::entry(n))),
-                );
+                set.extend(crate::codegen::scc::analysis_set_to_fn_ids(
+                    &a.recursive_fns,
+                    symbols,
+                    None,
+                ));
             }
             for m in cfg.dep_modules {
                 if let Some(a) = m.analysis.as_ref() {
-                    set.extend(a.recursive_fns.iter().filter_map(|n| {
-                        symbols.fn_id_of(&crate::ir::FnKey::in_module(m.prefix.clone(), n))
-                    }));
+                    set.extend(crate::codegen::scc::analysis_set_to_fn_ids(
+                        &a.recursive_fns,
+                        symbols,
+                        Some(&m.prefix),
+                    ));
                 }
             }
             set

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4935,7 +4935,6 @@ mod tests {
             extra_fn_defs: Vec::new(),
             mutual_tco_members: HashSet::new(),
             recursive_fns: HashSet::new(),
-            fn_analyses: HashMap::new(),
             buffer_build_sinks: HashMap::new(),
             buffer_fusion_sites: Vec::new(),
             synthesized_buffered_fns: Vec::new(),

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -19,7 +19,7 @@
 use aver::ast::{Spanned, TopLevel, TypeDef};
 use aver::codegen::CodegenContext;
 use aver::codegen::common::refinement_info_for;
-use aver::codegen::recursion::{RecursionPlan, analyze_plans};
+use aver::codegen::recursion::{RecursionPlan, analyze_plans_in_scope};
 use aver::ir::proof_ir::{
     DecreaseProof, FuelMetric, Measure, PreservationProof, QuantifierType, RecursionContract,
 };
@@ -320,7 +320,7 @@ fn fib_tr_native_contract_matches_legacy_recursion_plan() {
     let src = include_str!("../examples/data/fibonacci.av");
     let ctx = build_ctx(src);
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
-    let (plans, _) = analyze_plans(&inputs);
+    let (plans, _) = analyze_plans_in_scope(&inputs, None, true);
 
     let RecursionPlan::IntCountdownGuarded {
         param_index,
@@ -435,7 +435,7 @@ fn exposed_int_countdown_lowers_to_fuel_contract() {
          \x20       _ -> exposed_count(n - 1)\n";
     let ctx = build_ctx(src);
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
-    let (plans, _) = analyze_plans(&inputs);
+    let (plans, _) = analyze_plans_in_scope(&inputs, None, true);
 
     let RecursionPlan::IntCountdown {
         param_index: legacy_idx,
@@ -495,7 +495,7 @@ fn int_ascending_lowers_to_bound_fuel_contract() {
          \x20       false -> climb(n + 1)\n";
     let ctx = build_ctx(src);
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
-    let (plans, _) = analyze_plans(&inputs);
+    let (plans, _) = analyze_plans_in_scope(&inputs, None, true);
 
     let RecursionPlan::IntAscending {
         param_index: legacy_idx,
@@ -554,7 +554,7 @@ fn list_structural_lowers_to_seq_len_fuel_contract() {
          \x20       [_, ..rest] -> 1 + len(rest)\n";
     let ctx = build_ctx(src);
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
-    let (plans, _) = analyze_plans(&inputs);
+    let (plans, _) = analyze_plans_in_scope(&inputs, None, true);
 
     let RecursionPlan::ListStructural {
         param_index: legacy_idx,
@@ -609,7 +609,7 @@ fn sizeof_structural_lowers_to_sizeof_fuel_contract() {
          \x20       Tree.Node(l, r) -> count(l) + count(r)\n";
     let ctx = build_ctx(src);
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
-    let (plans, _) = analyze_plans(&inputs);
+    let (plans, _) = analyze_plans_in_scope(&inputs, None, true);
 
     assert!(
         matches!(plans.get("count"), Some(RecursionPlan::SizeOfStructural)),
@@ -645,7 +645,7 @@ fn string_pos_advance_lowers_to_string_pos_fuel_contract() {
          \x20       true -> walk(s, pos + 1)\n";
     let ctx = build_ctx(src);
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
-    let (plans, _) = analyze_plans(&inputs);
+    let (plans, _) = analyze_plans_in_scope(&inputs, None, true);
 
     assert!(
         matches!(plans.get("walk"), Some(RecursionPlan::StringPosAdvance)),
@@ -704,7 +704,7 @@ fn mutual_int_countdown_lowers_to_lex_fuel_contract() {
          \x20       _ -> even(n - 1)\n";
     let ctx = build_ctx(src);
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
-    let (plans, _) = analyze_plans(&inputs);
+    let (plans, _) = analyze_plans_in_scope(&inputs, None, true);
 
     for fn_name in ["even", "odd"] {
         assert!(
@@ -752,7 +752,7 @@ fn linear_recurrence_lowers_to_dedicated_contract() {
          \x20           _ -> fib(n - 1) + fib(n - 2)\n";
     let ctx = build_ctx(src);
     let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
-    let (plans, _) = analyze_plans(&inputs);
+    let (plans, _) = analyze_plans_in_scope(&inputs, None, true);
 
     assert!(
         matches!(plans.get("fib"), Some(RecursionPlan::LinearRecurrence2)),


### PR DESCRIPTION
## Summary

Two follow-ups to PR #145 closing out Phase C:

1. **Delete dead field \`CodegenContext.fn_analyses\`** — written by \`build_context\` and \`refresh_facts\`, never read by any consumer. The comment promised future use ("WASM emitter / VM compiler / future inliner read from here") but consumers always reached for \`module.analysis.fn_analyses\` directly. ~40 lines removed across producer + 4 synthetic-ctx stubs.

2. **\`crate::codegen::scc\` helpers — one source-of-truth for bare-name → FnId conversion.** Phase C left ~120 lines of \`.filter_map(|n| symbol_table.fn_id_of(&FnKey::entry(n)))\` blocks scattered across \`build_context\` / \`refresh_facts\` / \`pipeline::run\` proof setup. Two helpers (\`bare_names_to_fn_ids\` for \`&str\` iters, \`analysis_set_to_fn_ids\` for \`&String\` iters) collapse the pattern.

3. **Remove \`recursion::analyze_plans()\` legacy global wrapper.** Only \`tests/proof_ir_diff.rs\` called it — migrated to \`analyze_plans_in_scope(inputs, None, true)\` explicitly.

## Why not full Poziom 3 (FnId in \`call_graph\` public API)

\`call_graph\` is consumed by **tco / typechecker / analyze** stages that run **BEFORE** SymbolTable is built. A full FnId migration would require reordering the whole pipeline (BuildSymbols before TCO) plus plumbing \`&SymbolTable\` through TCO / typechecker / analyze sigs — gigantic surface-area touch for zero bug-fix value (per-scope bare-name is already DAG-safe). The \`scc::*\` helpers give codegen post-SymbolTable consumers the typed boundary they wanted without touching the front-end.

## Net effect

Gross: +147 / -120 = +27 line delta (mostly \`scc.rs\` introduction). Net effect: **4 inline \`filter_map\` blocks → 1-line helper calls**, and the helper is the only place the entry-vs-Module scope routing lives.

## Test plan

- [x] cargo build --lib + --bin aver
- [x] cargo test (1521 passed; \`explain_passes_spec\` pre-existing concurrent-tempfile flake as in prior PRs)
- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)