### PR TITLE
types/checker: typed identity (Type::Named<TypeId>, fn_sigs by FnId) — #147 phase B

### DIFF
--- a/aver-lsp/src/hover.rs
+++ b/aver-lsp/src/hover.rs
@@ -349,7 +349,7 @@ fn is_memo_safe_type(ty: &Type, safe_named: &std::collections::HashSet<String>) 
         Type::Tuple(items) => items.iter().all(|item| is_memo_safe_type(item, safe_named)),
         Type::List(_) | Type::Vector(_) | Type::Map(_, _) | Type::Fn(_, _, _) => false,
         Type::Result(_, _) | Type::Option(_) => false,
-        Type::Named(name) => safe_named.contains(name),
+        Type::Named { name, .. } => safe_named.contains(name),
         // Unresolved generics + recovery types — never memoise; treat
         // as opaque conservatively.
         Type::Var(_) | Type::Invalid => false,

--- a/examples/services/redis.av
+++ b/examples/services/redis.av
@@ -3,7 +3,7 @@ module Redis
         "Minimal Redis client over raw TCP using the RESP protocol."
         "Demonstrates persistent Tcp connections: connect once, issue multiple"
         "commands on the same socket, close explicitly."
-    exposes [connect, disconnect, ping, set, get, del]
+    exposes [connect, disconnect, ping, set, get, del, RedisConfig]
     depends []
     effects [Console, Tcp]
 

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -133,17 +133,17 @@ impl Type {
                 // distinct `TypeId`, must stay incompatible).
                 (Some(a), Some(b)) => a == b,
                 // Exactly one side carries a `TypeId`: the typechecker
-                // already classified that side, the other side is a
-                // raw stamp (parser output / builtin / in-flight
-                // recovery). Phase B post-review tightens this branch:
-                // the pre-phase-B suffix fallback would have happily
-                // matched `Named { Some(A_Shape), "A.Shape" }` against
-                // `Named { None, "Shape" }`, re-introducing the
-                // cross-module collapse the typed identity is meant to
-                // prevent. Require strict-name equality so a Some-id
-                // side never matches a string that could canonicalise
-                // to a different ID.
-                (Some(_), None) | (None, Some(_)) => name_a == name_b,
+                // already classified that side; the other side
+                // attempted resolution and came up empty. Always
+                // reject — silent name fallback here was the round-6
+                // entry-fallback bug, where a dep module's
+                // unresolved bare `Shape` silently bound to the
+                // entry module's own `Shape`. Builtins like
+                // `HttpResponse` never set `id` on either side, so
+                // they exercise the `(None, None)` branch below;
+                // genuine cross-module typed/raw mixes hit this
+                // branch and must fail.
+                (Some(_), None) | (None, Some(_)) => false,
                 // Both sides unresolved (raw stamps, builtin records,
                 // tests). Keep the historical suffix relation as a
                 // best-effort match — there's no typed identity to

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -132,12 +132,23 @@ impl Type {
                 // names happen to coincide (cross-module `Shape` —
                 // distinct `TypeId`, must stay incompatible).
                 (Some(a), Some(b)) => a == b,
-                // At least one side is unresolved (builtin record, in-
-                // flight stamp, parser output not yet through the
-                // checker's resolve pass). Fall back to the source-name
-                // suffix relation that has been the compatibility
-                // contract since before opaque IDs existed.
-                _ => {
+                // Exactly one side carries a `TypeId`: the typechecker
+                // already classified that side, the other side is a
+                // raw stamp (parser output / builtin / in-flight
+                // recovery). Phase B post-review tightens this branch:
+                // the pre-phase-B suffix fallback would have happily
+                // matched `Named { Some(A_Shape), "A.Shape" }` against
+                // `Named { None, "Shape" }`, re-introducing the
+                // cross-module collapse the typed identity is meant to
+                // prevent. Require strict-name equality so a Some-id
+                // side never matches a string that could canonicalise
+                // to a different ID.
+                (Some(_), None) | (None, Some(_)) => name_a == name_b,
+                // Both sides unresolved (raw stamps, builtin records,
+                // tests). Keep the historical suffix relation as a
+                // best-effort match — there's no typed identity to
+                // disagree with on either side.
+                (None, None) => {
                     name_a == name_b
                         || name_a.ends_with(&format!(".{}", name_b))
                         || name_b.ends_with(&format!(".{}", name_a))

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -1,9 +1,11 @@
-/// Aver static type representation.
-///
-/// Lives under `crate::ast` so that `Spanned<T>` can carry an optional
-/// `Type` annotation without forming a cycle through `crate::types`
-/// (which depends on `crate::ast`). The original `crate::types::Type`
-/// is re-exported from here for backward compatibility.
+//! Aver static type representation.
+//!
+//! Lives under `crate::ast` so that `Spanned<T>` can carry an optional
+//! `Type` annotation without forming a cycle through `crate::types`
+//! (which depends on `crate::ast`). The original `crate::types::Type`
+//! is re-exported from here for backward compatibility.
+
+use crate::ir::TypeId;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
@@ -21,10 +23,64 @@ pub enum Type {
     Fn(Vec<Type>, Box<Type>, Vec<String>),
     Var(String), // named type variable in polymorphic builtin signatures (instantiated at call site)
     Invalid, // checker recovery after an earlier error; matches anything in `.compatible` to suppress cascading diagnostics
-    Named(String), // user-defined type: Shape, User, etc.
+    /// User-defined or builtin named type. The `id` is `Some` once the
+    /// typechecker has resolved the reference against the program's
+    /// [`crate::ir::SymbolTable`] (#138 phase B). The `id` is `None` for
+    /// transient parser output (before typecheck has run), for builtin
+    /// record types (`HttpResponse`, `Header`, `Tcp.Connection`,
+    /// `Buffer`, …) that aren't registered in the user-program symbol
+    /// table, and for stamps the checker couldn't resolve.
+    ///
+    /// Identity:
+    /// - two `Named` with both `id = Some` compare by `id` (typed
+    ///   identity — cross-module same-bare-name types stay distinct);
+    /// - otherwise fall back to source-faithful name comparison, with
+    ///   the historical suffix tolerance for `Bare` vs `Module.Bare`.
+    Named {
+        id: Option<TypeId>,
+        name: String,
+    },
 }
 
 impl Type {
+    /// Build a `Type::Named` whose identity has not been resolved
+    /// against a `SymbolTable` (parser output, builtins, in-flight
+    /// stamps). Equivalent to `Named { id: None, name: name.into() }`.
+    pub fn named(name: impl Into<String>) -> Self {
+        Self::Named {
+            id: None,
+            name: name.into(),
+        }
+    }
+
+    /// Build a `Type::Named` resolved against the program's
+    /// `SymbolTable`. Caller is responsible for ensuring `name` is the
+    /// canonical form (`symbol_table.type_entry(id).key.canonical()`).
+    pub fn named_resolved(id: TypeId, name: impl Into<String>) -> Self {
+        Self::Named {
+            id: Some(id),
+            name: name.into(),
+        }
+    }
+
+    /// Source-faithful name of a `Named` (`"Shape"` / `"A.Shape"` /
+    /// `"HttpResponse"`); `None` for any non-`Named` variant.
+    pub fn named_name(&self) -> Option<&str> {
+        match self {
+            Type::Named { name, .. } => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Resolved `TypeId` of a `Named`, if any. `None` for unresolved
+    /// references and for any non-`Named` variant.
+    pub fn named_id(&self) -> Option<TypeId> {
+        match self {
+            Type::Named { id, .. } => *id,
+            _ => None,
+        }
+    }
+
     /// `a.compatible(b)` — can a value of type `self` be used where `other` is expected?
     /// Two concrete types must be equal (structurally) to be compatible. Type variables
     /// are resolved by the type checker at call sites, not by this raw relation.
@@ -60,9 +116,33 @@ impl Type {
                             .any(|expected| crate::effects::effect_satisfies(expected, actual))
                     })
             }
-            (Type::Named(a), Type::Named(b)) => {
-                a == b || a.ends_with(&format!(".{}", b)) || b.ends_with(&format!(".{}", a))
-            }
+            (
+                Type::Named {
+                    id: id_a,
+                    name: name_a,
+                },
+                Type::Named {
+                    id: id_b,
+                    name: name_b,
+                },
+            ) => match (id_a, id_b) {
+                // Both sides resolved against the symbol table: typed
+                // identity is the load-bearing comparison. Two distinct
+                // `TypeId`s never compare equal even when their source
+                // names happen to coincide (cross-module `Shape` —
+                // distinct `TypeId`, must stay incompatible).
+                (Some(a), Some(b)) => a == b,
+                // At least one side is unresolved (builtin record, in-
+                // flight stamp, parser output not yet through the
+                // checker's resolve pass). Fall back to the source-name
+                // suffix relation that has been the compatibility
+                // contract since before opaque IDs existed.
+                _ => {
+                    name_a == name_b
+                        || name_a.ends_with(&format!(".{}", name_b))
+                        || name_b.ends_with(&format!(".{}", name_a))
+                }
+            },
             _ => false,
         }
     }
@@ -102,7 +182,7 @@ impl Type {
             }
             Type::Var(name) => name.clone(),
             Type::Invalid => "Invalid".to_string(),
-            Type::Named(n) => n.clone(),
+            Type::Named { name, .. } => name.clone(),
         }
     }
 }

--- a/src/checker/coverage.rs
+++ b/src/checker/coverage.rs
@@ -214,7 +214,9 @@ pub fn collect_verify_coverage_warnings_in(
                 });
             }
 
-            if let Type::Named(type_name) = ret_ty
+            if let Type::Named {
+                name: type_name, ..
+            } = ret_ty
                 && let Some(constructors) = local_sum_type_constructors(items, &type_name)
             {
                 let mut covered = BTreeSet::new();

--- a/src/codegen/builtin_records.rs
+++ b/src/codegen/builtin_records.rs
@@ -50,7 +50,7 @@ impl BuiltinType {
             BuiltinType::Str => Type::Str,
             BuiltinType::Bool => Type::Bool,
             BuiltinType::Float => Type::Float,
-            BuiltinType::ListOf(name) => Type::List(Box::new(Type::Named((*name).to_string()))),
+            BuiltinType::ListOf(name) => Type::List(Box::new(Type::named(*name))),
             BuiltinType::MapStrListStr => Type::Map(
                 Box::new(Type::Str),
                 Box::new(Type::List(Box::new(Type::Str))),

--- a/src/codegen/dafny/expr.rs
+++ b/src/codegen/dafny/expr.rs
@@ -115,7 +115,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             // Refinement-via-opaque records emit as Dafny subset types,
             // so projecting the carrier field is the identity (the
             // value *is* the underlying `int`).
-            if let Some(crate::types::Type::Named(t_name)) = obj.ty()
+            if let Some(crate::types::Type::Named { name: t_name, .. }) = obj.ty()
                 && let Some(decl) = crate::codegen::common::find_refined_type(ctx, t_name)
                 && decl.carrier_type == "Int"
                 && field == &decl.carrier_field

--- a/src/codegen/dafny/fuel.rs
+++ b/src/codegen/dafny/fuel.rs
@@ -351,7 +351,7 @@ fn type_default(ty: &Type, ctx: &CodegenContext, visiting: &mut HashSet<String>)
                 .collect::<Option<_>>()?;
             format!("({})", parts.join(", "))
         }
-        Type::Named(name) => named_type_default(name, ctx, visiting)?,
+        Type::Named { name, .. } => named_type_default(name, ctx, visiting)?,
         Type::Fn(_, _, _) | Type::Var(_) | Type::Invalid => return None,
     })
 }

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -71,7 +71,7 @@ fn type_to_dafny(ty: &Type) -> String {
         // the dependent module; already-qualified user types
         // (`Level.Room`) need the module-segment prefixed with `Aver_`
         // so the qualifier matches the renamed Dafny module.
-        Type::Named(name) => {
+        Type::Named { name, .. } => {
             if crate::codegen::builtin_records::find(name).is_some() {
                 name.replace('.', "_")
             } else if let Some(dot) = name.rfind('.') {

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -30,7 +30,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             // typechecker stamp on the host expression, then look
             // up the lifted-type decision the lowerer already made
             // in `ctx.proof_ir.refined_types`.
-            if let Some(crate::types::Type::Named(t_name)) = obj.ty()
+            if let Some(crate::types::Type::Named { name: t_name, .. }) = obj.ty()
                 && let Some(decl) = crate::codegen::common::find_refined_type(ctx, t_name)
                 && decl.carrier_type == "Int"
                 && field == &decl.carrier_field

--- a/src/codegen/lean/types.rs
+++ b/src/codegen/lean/types.rs
@@ -42,7 +42,7 @@ pub fn type_to_lean(ty: &Type) -> String {
                  This indicates unresolved typing leaked into codegen."
             )
         }
-        Type::Named(name) => {
+        Type::Named { name, .. } => {
             if name.contains('.') {
                 name.replace('.', "_")
             } else {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -366,7 +366,7 @@ pub fn build_context(
     // `memory access out of bounds` traps. Buffer parses to
     // Type::Named("Buffer") which is_heap_type accepts.
     {
-        let buffer_ty = || crate::types::Type::Named("Buffer".to_string());
+        let buffer_ty = || crate::types::Type::named("Buffer");
         let str_ty = || crate::types::Type::Str;
         let int_ty = || crate::types::Type::Int;
         let intrinsic_sigs: &[(&str, Vec<crate::types::Type>, crate::types::Type)] = &[

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -3026,7 +3026,7 @@ fn smart_ctor_matches(fd: &FnDef, type_name: &str) -> bool {
     let parsed = crate::types::parse_type_str(&fd.return_type);
     matches!(
         parsed,
-        crate::types::Type::Result(ok, _) if matches!(&*ok, crate::types::Type::Named(n) if n == type_name)
+        crate::types::Type::Result(ok, _) if matches!(&*ok, crate::types::Type::Named { name: n, .. } if n == type_name)
     )
 }
 

--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -1081,7 +1081,7 @@ mod tests {
             ))]),
         ];
         let mut local_types = HashMap::new();
-        local_types.insert("config".to_string(), Type::Named("DbConfig".to_string()));
+        local_types.insert("config".to_string(), Type::named("DbConfig"));
         local_types.insert("sql".to_string(), Type::Str);
 
         let emitted = emit_builtin_call(

--- a/src/codegen/rust/emit_ctx.rs
+++ b/src/codegen/rust/emit_ctx.rs
@@ -145,7 +145,7 @@ pub fn should_borrow_param(ty: &Type) -> bool {
             | Type::Result(_, _)
             | Type::Option(_)
             | Type::Tuple(_)
-            | Type::Named(_)
+            | Type::Named { .. }
     )
 }
 
@@ -161,6 +161,6 @@ mod tests {
         assert!(is_copy_type(&Type::Unit));
         assert!(!is_copy_type(&Type::Str));
         assert!(!is_copy_type(&Type::List(Box::new(Type::Int))));
-        assert!(!is_copy_type(&Type::Named("Foo".to_string())));
+        assert!(!is_copy_type(&Type::named("Foo")));
     }
 }

--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -1102,7 +1102,7 @@ fn attr_result_is_copy(obj: &Expr, field: &str, ctx: &CodegenContext, ectx: &Emi
         _ => None,
     };
     let record_name = match obj_type {
-        Some(Type::Named(name)) => name.as_str(),
+        Some(Type::Named { name, .. }) => name.as_str(),
         _ => return false,
     };
     // Find record definition and look up field type.
@@ -1751,11 +1751,13 @@ pub(super) fn constructor_boxed_positions(name: &str, ctx: &CodegenContext) -> H
     let Some((params, ret, _)) = sig else {
         return out;
     };
-    let Type::Named(ret_name) = ret else {
+    let Type::Named { name: ret_name, .. } = ret else {
         return out;
     };
     for (idx, param) in params.iter().enumerate() {
-        if let Type::Named(param_name) = param
+        if let Type::Named {
+            name: param_name, ..
+        } = param
             && param_name == ret_name
         {
             out.insert(idx);

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -585,7 +585,7 @@ fn needs_named_type(ctx: &CodegenContext, wanted: &str) -> bool {
 
 fn type_contains_named(ty: &Type, wanted: &str) -> bool {
     match ty {
-        Type::Named(name) => name == wanted,
+        Type::Named { name, .. } => name == wanted,
         Type::Result(ok, err) => {
             type_contains_named(ok, wanted) || type_contains_named(err, wanted)
         }

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -104,7 +104,7 @@ fn rust_hash_eq_safe_type(
             .iter()
             .all(|item| rust_hash_eq_safe_type(item, ctx, visiting)),
         Type::Map(_, _) | Type::Fn(_, _, _) | Type::Var(_) | Type::Invalid => false,
-        Type::Named(name) => rust_hash_eq_safe_named(name, ctx, visiting),
+        Type::Named { name, .. } => rust_hash_eq_safe_named(name, ctx, visiting),
     }
 }
 
@@ -3191,7 +3191,7 @@ mod tests {
         ctx.type_defs.push(td);
         ctx.fn_sigs.insert(
             "member".to_string(),
-            (vec![Type::Named("Tree".to_string())], Type::Bool, vec![]),
+            (vec![Type::named("Tree")], Type::Bool, vec![]),
         );
 
         let emitted = emit_public_fn_def(&fd, true, &ctx);

--- a/src/codegen/rust/types.rs
+++ b/src/codegen/rust/types.rs
@@ -36,7 +36,7 @@ pub fn type_to_rust(ty: &Type) -> String {
                  This indicates unresolved typing leaked into codegen."
             )
         }
-        Type::Named(name) => {
+        Type::Named { name, .. } => {
             // Dotted names like Tcp.Connection → not supported in transpilation
             if name.contains('.') {
                 name.replace('.', "_")

--- a/src/codegen/wasm_gc/body/emit.rs
+++ b/src/codegen/wasm_gc/body/emit.rs
@@ -571,7 +571,7 @@ pub(super) fn emit_expr(
 fn sum_or_record_eq_fn(operand: &Spanned<Expr>, ctx: &EmitCtx<'_>) -> Option<u32> {
     let ty = operand.ty()?;
     match ty {
-        crate::types::Type::Named(name) => {
+        crate::types::Type::Named { name, .. } => {
             // Newtypes already lower to their underlying primitive —
             // no helper needed (the default i64/f64 eq handles them).
             if ctx.registry.newtype_underlying(name).is_some() {

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -4462,7 +4462,7 @@ fn register_nominal_in_type(
 ) {
     let canonical: String = t.display().chars().filter(|c| !c.is_whitespace()).collect();
     match t {
-        AverType::Named(name) => {
+        AverType::Named { name, .. } => {
             if type_registry.record_fields.contains_key(name) {
                 eq_helpers.register_transitive(name, EqKind::Record, type_registry);
             } else if type_registry
@@ -4570,7 +4570,7 @@ fn discover_builtins_in_expr(
             use crate::ast::BinOp as Op;
             if matches!(op, Op::Eq | Op::Neq)
                 && let Some(t) = l.ty()
-                && let AverType::Named(name) = t
+                && let AverType::Named { name, .. } = t
             {
                 if type_registry.record_fields.contains_key(name) {
                     eq_helpers.register_transitive(name, EqKind::Record, type_registry);

--- a/src/diagnostics/context.rs
+++ b/src/diagnostics/context.rs
@@ -563,7 +563,7 @@ pub fn is_memo_safe_type(ty: &crate::types::Type, safe_named: &HashSet<String>) 
         | Type::Invalid
         | Type::Var(_) => false,
         Type::Result(_, _) | Type::Option(_) => false,
-        Type::Named(name) => safe_named.contains(name),
+        Type::Named { name, .. } => safe_named.contains(name),
     }
 }
 
@@ -735,7 +735,7 @@ fn return_type_category(
         crate::types::Type::Option(_) => Some("option"),
         crate::types::Type::Bool => Some("bool"),
         crate::types::Type::List(_) => Some("list"),
-        crate::types::Type::Named(_) => Some("named"),
+        crate::types::Type::Named { .. } => Some("named"),
         _ => None,
     }
 }

--- a/src/ir/buffer_build.rs
+++ b/src/ir/buffer_build.rs
@@ -621,7 +621,7 @@ fn intrinsic_call(line: usize, name: &str, args: Vec<Spanned<Expr>>) -> Spanned<
 /// returns the (possibly-grown) owned buffer.
 fn buffer_intrinsic_call(line: usize, name: &str, args: Vec<Spanned<Expr>>) -> Spanned<Expr> {
     let call = intrinsic_call(line, name, args);
-    call.set_ty(crate::types::Type::Named("Buffer".to_string()));
+    call.set_ty(crate::types::Type::named("Buffer"));
     call
 }
 
@@ -996,7 +996,7 @@ fn build_buffered_variant(fd: &FnDef, shape: &BufferBuildShape) -> Option<FnDef>
     // returning the possibly-grown buffer. The outer intrinsic appends
     // the user's element. The result is what gets passed as the
     // buffered variant's `__buf` arg in the recursive call.
-    let buffer_ty = crate::types::Type::Named("Buffer".to_string());
+    let buffer_ty = crate::types::Type::named("Buffer");
     let buf_ident = || sp_at_typed(line, Expr::Ident(buf_name.to_string()), buffer_ty.clone());
     let sep_ident = || {
         sp_at_typed(
@@ -1094,7 +1094,7 @@ fn build_buffered_variant(fd: &FnDef, shape: &BufferBuildShape) -> Option<FnDef>
             subject: subject_orig.clone(),
             arms: new_arms,
         },
-        crate::types::Type::Named("Buffer".to_string()),
+        crate::types::Type::named("Buffer"),
     );
 
     let new_body = FnBody::Block(vec![Stmt::Expr(new_match)]);

--- a/src/ir/identity.rs
+++ b/src/ir/identity.rs
@@ -24,6 +24,52 @@
 //! Rust codegen multi-module module-fn lookups) will use the same
 //! types.
 
+// ---------------------------------------------------------------------------
+// Opaque IDs
+// ---------------------------------------------------------------------------
+//
+// These live here, not in `symbol_table`, so that `crate::ast::Type` can
+// carry a `TypeId` field without `ast` having to depend on `crate::ir`'s
+// AST-bearing modules. `identity` has no upward deps (only `std`), which
+// keeps the dependency layering clean: `ast` → `ir::identity` →
+// `ir::symbol_table` (consumes ast) → everything else.
+
+/// Opaque, stable identity for a function declaration. Indices are
+/// assigned by [`crate::ir::SymbolTable::build`] in deterministic order
+/// (modules in dep order, then entry; fns in source order within each
+/// scope). Two builds against the same input produce the same IDs.
+///
+/// `FnId` is `Copy` and 4 bytes wide — cheap to thread through
+/// resolved AST and IR nodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct FnId(pub u32);
+
+/// Opaque, stable identity for a type declaration (record or sum).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct TypeId(pub u32);
+
+/// Opaque, stable identity for a constructor (a single variant of a
+/// sum type, or a single record's nominal constructor — record types
+/// still have exactly one "constructor" in the symbol table sense so
+/// pattern emit + value construction route through one shape).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct CtorId(pub u32);
+
+/// Opaque, stable identity for a module. `ModuleId(0)` is reserved
+/// for the entry scope (matching `FnKey::scope == None`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct ModuleId(pub u32);
+
+impl ModuleId {
+    /// The entry scope — top-level items not declared inside any dep
+    /// module. Always assigned `ModuleId(0)`.
+    pub const ENTRY: ModuleId = ModuleId(0);
+
+    pub fn is_entry(self) -> bool {
+        self == Self::ENTRY
+    }
+}
+
 /// Canonical identity for a user-defined function across the IR
 /// boundary. `scope = None` is the entry file; `scope = Some(prefix)`
 /// names a dep module (`"ModuleA"`, `"Models.User"`, …). `name`

--- a/src/ir/interp_lower.rs
+++ b/src/ir/interp_lower.rs
@@ -152,7 +152,7 @@ fn build_buffer_pipeline(line: usize, parts: &[StrPart]) -> Spanned<Expr> {
     // populated by the synthesiser itself for downstream backends (Rust
     // codegen reads `expr.ty()` to gate hoists on owned-mutable
     // `Buffer`s, see `src/codegen/rust/toplevel.rs`).
-    let buffer_ty = Type::Named("Buffer".to_string());
+    let buffer_ty = Type::named("Buffer");
     let mut buf = intrinsic_call(
         line,
         "__buf_new",

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -18,7 +18,7 @@ pub mod symbol_table;
 pub mod vars;
 
 pub use analyze::{AnalysisResult, BodyShape, FnAnalysis, NeutralAllocPolicy, analyze};
-pub use identity::{FnKey, LawKey, TypeKey};
+pub use identity::{CtorId, FnId, FnKey, LawKey, ModuleId, TypeId, TypeKey};
 pub use pipeline::{
     FnCountChange, NonTailEntry, PassDiagnostic, PassReport, PipelineConfig, PipelineResult,
     PipelineStage, TypecheckMode,
@@ -28,9 +28,7 @@ pub use proof_ir::{
     NativeIntCountdownBody, Predicate, PreservationProof, ProofIR, ProofStrategy, Quantifier,
     QuantifierType, RecursionContract, RefinedTypeDecl, SmartGuard, UnclassifiedFn,
 };
-pub use symbol_table::{
-    CtorEntry, CtorId, FnEntry, FnId, ModuleEntry, ModuleId, SymbolTable, TypeEntry, TypeId,
-};
+pub use symbol_table::{CtorEntry, FnEntry, ModuleEntry, SymbolTable, TypeEntry};
 
 pub use alloc_info::{
     AllocPolicy, compute_alloc_info, count_alloc_sites_in_fn, count_alloc_sites_in_program,

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -30,8 +30,7 @@ use crate::ast::Spanned;
 // (reviewer rounds 5/6), but other backends with multi-module emit
 // (VM, Rust codegen, WASM) will reach for the same types when they
 // hit the same bug class. Re-exported here for ergonomics.
-pub use crate::ir::identity::{FnKey, LawKey, TypeKey};
-pub use crate::ir::symbol_table::{CtorId, FnId, ModuleId, TypeId};
+pub use crate::ir::identity::{CtorId, FnId, FnKey, LawKey, ModuleId, TypeId, TypeKey};
 
 /// Output of the `proof_lower` pipeline stage. Every decision the
 /// proof backends will make is materialised here; backends become

--- a/src/ir/symbol_table.rs
+++ b/src/ir/symbol_table.rs
@@ -40,45 +40,7 @@ use std::collections::HashMap;
 
 use crate::ast::{FnDef, TopLevel, TypeDef, TypeVariant};
 use crate::codegen::ModuleInfo;
-use crate::ir::identity::{FnKey, TypeKey};
-
-/// Opaque, stable identity for a function declaration. Indices
-/// are assigned by [`SymbolTable::build`] in deterministic order
-/// (modules in dep order, then entry; fns in source order within
-/// each scope). Two builds against the same input produce the
-/// same IDs.
-///
-/// `FnId` is `Copy` and 4 bytes wide — cheap to thread through
-/// resolved AST and IR nodes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct FnId(pub u32);
-
-/// Opaque, stable identity for a type declaration (record or sum).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct TypeId(pub u32);
-
-/// Opaque, stable identity for a constructor (a single variant of
-/// a sum type, or a single record's nominal constructor — record
-/// types still have exactly one "constructor" in the symbol table
-/// sense so pattern emit + value construction route through one
-/// shape).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct CtorId(pub u32);
-
-/// Opaque, stable identity for a module. `ModuleId(0)` is reserved
-/// for the entry scope (matching `FnKey::scope == None`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct ModuleId(pub u32);
-
-impl ModuleId {
-    /// The entry scope — top-level items not declared inside any
-    /// dep module. Always assigned `ModuleId(0)`.
-    pub const ENTRY: ModuleId = ModuleId(0);
-
-    pub fn is_entry(self) -> bool {
-        self == Self::ENTRY
-    }
-}
+use crate::ir::identity::{CtorId, FnId, FnKey, ModuleId, TypeId, TypeKey};
 
 /// One entry in the function table. The `key` field is the public
 /// canonical handle; `module` is the owning scope; `index_in_module`

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -483,11 +483,11 @@ fn validate_self_host_guest_entry_contract(ctx: &codegen::CodegenContext) -> Res
         .ok_or_else(|| format!("guest entry '{entry_name}' was not found"))?;
 
     let has_prog = fd.params.iter().any(|(name, type_ann)| {
-        name == "prog" && parse_type_str(type_ann) == Type::Named("Program".to_string())
+        name == "prog" && parse_type_str(type_ann) == Type::named("Program")
     });
     let has_module_fns = fd.params.iter().any(|(name, type_ann)| {
         name == "moduleFns"
-            && parse_type_str(type_ann) == Type::List(Box::new(Type::Named("FnDef".to_string())))
+            && parse_type_str(type_ann) == Type::List(Box::new(Type::named("FnDef")))
     });
 
     if has_prog && has_module_fns {
@@ -507,7 +507,7 @@ fn mark_type_uses(
     used_by_target: &mut HashMap<String, HashSet<String>>,
 ) {
     match ty {
-        Type::Named(name) => {
+        Type::Named { name, .. } => {
             let parts = name
                 .split('.')
                 .map(|part| part.to_string())

--- a/src/main/context_cmd.rs
+++ b/src/main/context_cmd.rs
@@ -270,7 +270,7 @@ fn build_module_depths(contexts: &[FileContext]) -> Vec<usize> {
 
 fn collect_named_type_refs(ty: &Type, out: &mut Vec<String>) {
     match ty {
-        Type::Named(name) => out.push(name.clone()),
+        Type::Named { name, .. } => out.push(name.clone()),
         Type::Result(ok, err) | Type::Map(ok, err) => {
             collect_named_type_refs(ok, out);
             collect_named_type_refs(err, out);

--- a/src/main/format_cmd.rs
+++ b/src/main/format_cmd.rs
@@ -375,7 +375,7 @@ fn format_type_for_source(ty: &Type) -> String {
         }
         Type::Var(name) => name.clone(),
         Type::Invalid => "Invalid".to_string(),
-        Type::Named(name) => name.clone(),
+        Type::Named { name, .. } => name.clone(),
     }
 }
 

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -1115,10 +1115,7 @@ fn main() -> Int
         // The fix proper: symbol table is plumbed onto the multi-file
         // proof ctx (regression for the previous "build_context without
         // proof_ir / symbol_table" gap).
-        let symbols = ctx
-            .symbol_table
-            .as_ref()
-            .expect("symbol_table must be plumbed onto multi-file proof ctx");
+        let symbols = &ctx.symbol_table;
         let helper_down_id = symbols
             .fn_id_of(&crate::ir::FnKey::in_module("Helper".to_string(), "down"))
             .expect("SymbolTable must carry FnId for Helper.down");

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -321,7 +321,7 @@ impl<'a> ResolverState<'a> {
             Pattern::Constructor(name, bindings) => {
                 let bare = name.rsplit('.').next().unwrap_or(name);
                 let parent_hint: Option<String> = match (subject_ty, name.split_once('.')) {
-                    (Some(Type::Named(parent)), _) => Some(parent.clone()),
+                    (Some(Type::Named { name: parent, .. }), _) => Some(parent.clone()),
                     (_, Some((parent, _))) => Some(parent.to_string()),
                     _ => self
                         .type_info

--- a/src/types/checker/builtins.rs
+++ b/src/types/checker/builtins.rs
@@ -67,9 +67,7 @@ impl TypeChecker {
         // Oracle v1: Trace = { events: List<EffectEvent> }.
         let trace_fields: &[(&str, Type)] = &[(
             "events",
-            Type::List(Box::new(Type::Named(
-                crate::types::effect_event::TYPE_NAME.to_string(),
-            ))),
+            Type::List(Box::new(Type::named(crate::types::effect_event::TYPE_NAME))),
         )];
         for (field, ty) in trace_fields {
             self.record_field_types.insert(
@@ -93,12 +91,7 @@ impl TypeChecker {
         // backend-by-backend runtime guards.
         self.opaque_types.insert("Tcp.Connection".to_string());
 
-        let net_ret = || {
-            Type::Result(
-                Box::new(Type::Named("HttpResponse".to_string())),
-                Box::new(Type::Str),
-            )
-        };
+        let net_ret = || Type::Result(Box::new(Type::named("HttpResponse")), Box::new(Type::Str));
         let disk_unit = || Type::Result(Box::new(Type::Unit), Box::new(Type::Str));
         let disk_str = || Type::Result(Box::new(Type::Str), Box::new(Type::Str));
         let disk_list = || {
@@ -150,15 +143,15 @@ impl TypeChecker {
         };
         let http_handler = || {
             Type::Fn(
-                vec![Type::Named("HttpRequest".to_string())],
-                Box::new(Type::Named("HttpResponse".to_string())),
+                vec![Type::named("HttpRequest")],
+                Box::new(Type::named("HttpResponse")),
                 server_handler_effects(),
             )
         };
         let http_handler_with_context = || {
             Type::Fn(
-                vec![context_var(), Type::Named("HttpRequest".to_string())],
-                Box::new(Type::Named("HttpResponse".to_string())),
+                vec![context_var(), Type::named("HttpRequest")],
+                Box::new(Type::named("HttpResponse")),
                 server_handler_effects(),
             )
         };
@@ -303,27 +296,24 @@ impl TypeChecker {
             (
                 "Tcp.connect",
                 &[Type::Str, Type::Int],
-                Type::Result(
-                    Box::new(Type::Named("Tcp.Connection".to_string())),
-                    Box::new(Type::Str),
-                ),
+                Type::Result(Box::new(Type::named("Tcp.Connection")), Box::new(Type::Str)),
                 &["Tcp.connect"],
             ),
             (
                 "Tcp.writeLine",
-                &[Type::Named("Tcp.Connection".to_string()), Type::Str],
+                &[Type::named("Tcp.Connection"), Type::Str],
                 Type::Result(Box::new(Type::Unit), Box::new(Type::Str)),
                 &["Tcp.writeLine"],
             ),
             (
                 "Tcp.readLine",
-                &[Type::Named("Tcp.Connection".to_string())],
+                &[Type::named("Tcp.Connection")],
                 Type::Result(Box::new(Type::Str), Box::new(Type::Str)),
                 &["Tcp.readLine"],
             ),
             (
                 "Tcp.close",
-                &[Type::Named("Tcp.Connection".to_string())],
+                &[Type::named("Tcp.Connection")],
                 Type::Result(Box::new(Type::Unit), Box::new(Type::Str)),
                 &["Tcp.close"],
             ),
@@ -395,7 +385,7 @@ impl TypeChecker {
                 (
                     "Terminal.size",
                     &[],
-                    Type::Named("Terminal.Size".to_string()),
+                    Type::named("Terminal.Size"),
                     &["Terminal.size"],
                 ),
                 (
@@ -638,7 +628,7 @@ impl TypeChecker {
         // BranchPath — opaque builtin used by Oracle-proof specs for
         // generative-effect oracles (`(BranchPath, Int, args...) -> T`).
         // Three constructors, no other public surface.
-        let branch_path_ty = || Type::Named(crate::types::branch_path::TYPE_NAME.to_string());
+        let branch_path_ty = || Type::named(crate::types::branch_path::TYPE_NAME.to_string());
         // `BranchPath.Root` is a nullary value (like `Option.None`) —
         // PascalCase, no parens. `.child` / `.parse` are methods.
         self.value_members

--- a/src/types/checker/effect_classification.rs
+++ b/src/types/checker/effect_classification.rs
@@ -99,20 +99,18 @@ impl RuntimeType {
                 Box::new(Type::List(Box::new(Type::Str))),
                 Box::new(Type::Str),
             ),
-            RuntimeType::HttpResponseResult => Type::Result(
-                Box::new(Type::Named("HttpResponse".to_string())),
-                Box::new(Type::Str),
-            ),
+            RuntimeType::HttpResponseResult => {
+                Type::Result(Box::new(Type::named("HttpResponse")), Box::new(Type::Str))
+            }
             RuntimeType::MapStrListStr => Type::Map(
                 Box::new(Type::Str),
                 Box::new(Type::List(Box::new(Type::Str))),
             ),
-            RuntimeType::TerminalSize => Type::Named("Terminal.Size".to_string()),
-            RuntimeType::TcpConnection => Type::Named("Tcp.Connection".to_string()),
-            RuntimeType::ResultTcpConnectionStr => Type::Result(
-                Box::new(Type::Named("Tcp.Connection".to_string())),
-                Box::new(Type::Str),
-            ),
+            RuntimeType::TerminalSize => Type::named("Terminal.Size"),
+            RuntimeType::TcpConnection => Type::named("Tcp.Connection"),
+            RuntimeType::ResultTcpConnectionStr => {
+                Type::Result(Box::new(Type::named("Tcp.Connection")), Box::new(Type::Str))
+            }
         }
     }
 }
@@ -463,7 +461,7 @@ pub fn oracle_signature(method: &str) -> Option<Type> {
             ))
         }
         EffectDimension::Generative | EffectDimension::GenerativeOutput => {
-            let mut params = vec![Type::Named(branch_path::TYPE_NAME.to_string()), Type::Int];
+            let mut params = vec![Type::named(branch_path::TYPE_NAME.to_string()), Type::Int];
             params.extend(c.runtime_params.iter().copied().map(runtime_type));
             Some(Type::Fn(
                 params,
@@ -539,7 +537,7 @@ mod tests {
         match sig {
             Type::Fn(params, ret, _) => {
                 assert_eq!(params.len(), 4);
-                assert!(matches!(params[0], Type::Named(ref n) if n == "BranchPath"));
+                assert!(matches!(params[0], Type::Named { name: ref n, .. } if n == "BranchPath"));
                 assert_eq!(params[1], Type::Int);
                 assert_eq!(params[2], Type::Int);
                 assert_eq!(params[3], Type::Int);
@@ -556,7 +554,7 @@ mod tests {
         match sig {
             Type::Fn(params, ret, _) => {
                 assert_eq!(params.len(), 2);
-                assert!(matches!(params[0], Type::Named(ref n) if n == "BranchPath"));
+                assert!(matches!(params[0], Type::Named { name: ref n, .. } if n == "BranchPath"));
                 assert_eq!(params[1], Type::Int);
                 assert_eq!(*ret, Type::Float);
             }
@@ -597,12 +595,14 @@ mod tests {
         match sig {
             Type::Fn(params, ret, _) => {
                 assert_eq!(params.len(), 3);
-                assert!(matches!(params[0], Type::Named(ref n) if n == "BranchPath"));
+                assert!(matches!(params[0], Type::Named { name: ref n, .. } if n == "BranchPath"));
                 assert_eq!(params[1], Type::Int);
                 assert_eq!(params[2], Type::Str);
                 match *ret {
                     Type::Result(ok, err) => {
-                        assert!(matches!(*ok, Type::Named(ref n) if n == "HttpResponse"));
+                        assert!(
+                            matches!(*ok, Type::Named { name: ref n, .. } if n == "HttpResponse")
+                        );
                         assert_eq!(*err, Type::Str);
                     }
                     other => panic!("expected Result, got {:?}", other),
@@ -619,7 +619,7 @@ mod tests {
         match sig {
             Type::Fn(params, ret, _) => {
                 assert_eq!(params.len(), 2);
-                assert!(matches!(params[0], Type::Named(ref n) if n == "BranchPath"));
+                assert!(matches!(params[0], Type::Named { name: ref n, .. } if n == "BranchPath"));
                 assert_eq!(params[1], Type::Int);
                 assert_eq!(*ret, Type::Result(Box::new(Type::Str), Box::new(Type::Str)));
             }
@@ -634,7 +634,7 @@ mod tests {
         match sig {
             Type::Fn(params, ret, _) => {
                 assert_eq!(params.len(), 3);
-                assert!(matches!(params[0], Type::Named(ref n) if n == "BranchPath"));
+                assert!(matches!(params[0], Type::Named { name: ref n, .. } if n == "BranchPath"));
                 assert_eq!(params[1], Type::Int);
                 assert_eq!(params[2], Type::Str);
                 assert_eq!(
@@ -656,7 +656,7 @@ mod tests {
         match sig {
             Type::Fn(params, ret, _) => {
                 assert_eq!(params.len(), 4);
-                assert!(matches!(params[0], Type::Named(ref n) if n == "BranchPath"));
+                assert!(matches!(params[0], Type::Named { name: ref n, .. } if n == "BranchPath"));
                 assert_eq!(params[1], Type::Int);
                 assert_eq!(params[2], Type::Str);
                 assert_eq!(params[3], Type::Int);
@@ -676,7 +676,7 @@ mod tests {
         match sig {
             Type::Fn(params, ret, _) => {
                 assert_eq!(params.len(), 4);
-                assert!(matches!(params[0], Type::Named(ref n) if n == "BranchPath"));
+                assert!(matches!(params[0], Type::Named { name: ref n, .. } if n == "BranchPath"));
                 assert_eq!(params[1], Type::Int);
                 assert_eq!(params[2], Type::Str);
                 assert_eq!(params[3], Type::Str);
@@ -747,7 +747,7 @@ mod tests {
         match sig {
             Type::Fn(params, ret, _) => {
                 assert_eq!(params.len(), 6);
-                assert!(matches!(params[0], Type::Named(ref n) if n == "BranchPath"));
+                assert!(matches!(params[0], Type::Named { name: ref n, .. } if n == "BranchPath"));
                 assert_eq!(params[1], Type::Int);
                 assert_eq!(params[2], Type::Str);
                 assert_eq!(params[3], Type::Str);
@@ -764,7 +764,9 @@ mod tests {
                 }
                 match *ret {
                     Type::Result(ok, err) => {
-                        assert!(matches!(*ok, Type::Named(ref n) if n == "HttpResponse"));
+                        assert!(
+                            matches!(*ok, Type::Named { name: ref n, .. } if n == "HttpResponse")
+                        );
                         assert_eq!(*err, Type::Str);
                     }
                     other => panic!("expected Result, got {:?}", other),
@@ -818,7 +820,7 @@ mod tests {
         match sig {
             Type::Fn(params, ret, effects) => {
                 assert!(params.is_empty());
-                assert_eq!(*ret, Type::Named("Terminal.Size".to_string()));
+                assert_eq!(*ret, Type::named("Terminal.Size"));
                 assert!(effects.is_empty());
             }
             other => panic!("expected Fn, got {:?}", other),

--- a/src/types/checker/effect_lifting.rs
+++ b/src/types/checker/effect_lifting.rs
@@ -840,7 +840,7 @@ pub fn type_to_annotation(ty: &Type) -> String {
         Type::Str => "String".to_string(),
         Type::Bool => "Bool".to_string(),
         Type::Unit => "Unit".to_string(),
-        Type::Named(n) => n.clone(),
+        Type::Named { name: n, .. } => n.clone(),
         Type::Option(inner) => format!("Option<{}>", type_to_annotation(inner)),
         Type::Result(ok, err) => format!(
             "Result<{}, {}>",

--- a/src/types/checker/exhaustiveness.rs
+++ b/src/types/checker/exhaustiveness.rs
@@ -78,7 +78,7 @@ impl TypeChecker {
             Type::Map(_, _) | Type::Fn(_, _, _) | Type::Unit | Type::Var(_) => {
                 return;
             }
-            Type::Named(name) if !self.type_variants.contains_key(name) => return, // records
+            Type::Named { name, .. } if !self.has_variants_for(name) => return, // records
             _ => {}
         }
 
@@ -137,7 +137,7 @@ impl TypeChecker {
 
         // Track how deeply we've expanded each Named type to prevent
         // exponential branching on recursive sum types.
-        let named_key = if let Type::Named(name) = head_ty {
+        let named_key = if let Type::Named { name, .. } = head_ty {
             let d = type_depth.entry(name.clone()).or_insert(0);
             *d += 1;
             if *d > RECURSIVE_TYPE_MAX_DEPTH {
@@ -251,8 +251,8 @@ impl TypeChecker {
                 arg_types: items.clone(),
             }]),
             Type::Vector(_) => None, // Vector is not exhaustively matchable
-            Type::Named(name) => {
-                let variants = self.type_variants.get(name)?;
+            Type::Named { name, .. } => {
+                let variants = self.variants_for(name)?;
                 let mut out = Vec::new();
                 for variant in variants {
                     out.push(CtorSpec {

--- a/src/types/checker/flow.rs
+++ b/src/types/checker/flow.rs
@@ -206,6 +206,12 @@ impl TypeChecker {
                             let ty = if let Some(ann_src) = type_ann {
                                 match crate::types::parse_type_str_strict(ann_src) {
                                     Ok(annotated) => {
+                                        let annotated = self.canonicalize_named(annotated);
+                                        self.report_ambiguous_named(
+                                            &annotated,
+                                            expr.line,
+                                            &format!("Binding '{}' annotation", name),
+                                        );
                                         if !self.compatible(&inferred, &annotated) {
                                             self.error(format!(
                                                 "Binding '{}': expression has type {}, annotation says {}",
@@ -601,7 +607,8 @@ impl TypeChecker {
                         // annotation rather than stamping `Unknown`.
                         let parsed_ann = type_ann
                             .as_ref()
-                            .and_then(|src| crate::types::parse_type_str_strict(src).ok());
+                            .and_then(|src| crate::types::parse_type_str_strict(src).ok())
+                            .map(|ty| self.canonicalize_named(ty));
                         let inferred = self.infer_type_with_expected(expr, parsed_ann.as_ref());
                         // Mirror the top-level rejection above — fn refs
                         // aren't supported as local bindings, period. See
@@ -615,6 +622,12 @@ impl TypeChecker {
                         let ty = if let Some(ann_src) = type_ann {
                             match crate::types::parse_type_str_strict(ann_src) {
                                 Ok(annotated) => {
+                                    let annotated = self.canonicalize_named(annotated);
+                                    self.report_ambiguous_named(
+                                        &annotated,
+                                        expr.line,
+                                        &format!("Binding '{}' annotation", name),
+                                    );
                                     if !self.compatible(&inferred, &annotated) {
                                         self.error(format!(
                                             "Binding '{}': expression has type {}, annotation says {}",

--- a/src/types/checker/flow.rs
+++ b/src/types/checker/flow.rs
@@ -267,8 +267,7 @@ impl TypeChecker {
                 // Oracle v1: classify the verified function's effects to
                 // decide whether this verify block is in the proof subset.
                 let fn_effects: Vec<String> = self
-                    .fn_sigs
-                    .get(&vb.fn_name)
+                    .find_fn_sig(&vb.fn_name)
                     .map(|sig| sig.effects.clone())
                     .unwrap_or_default();
                 let classified_effects: Vec<String> = fn_effects
@@ -479,8 +478,7 @@ impl TypeChecker {
                 // Inherit effects from the tested function so verify blocks
                 // can call effectful functions without declaring effects.
                 let inherited_effects: Vec<String> = self
-                    .fn_sigs
-                    .get(&vb.fn_name)
+                    .find_fn_sig(&vb.fn_name)
                     .map(|sig| sig.effects.clone())
                     .unwrap_or_default();
                 let caller = format!("<verify:{}>", vb.fn_name);

--- a/src/types/checker/hostile_values.rs
+++ b/src/types/checker/hostile_values.rs
@@ -65,7 +65,7 @@ pub fn boundary_values(ty: &Type) -> Vec<Literal> {
         // Named (user records / sum types) and Unknown: no literal
         // representation available without checking the project's type
         // table. Caller should leave these alone.
-        Type::Named(_) | Type::Var(_) | Type::Invalid => Vec::new(),
+        Type::Named { .. } | Type::Var(_) | Type::Invalid => Vec::new(),
     }
 }
 
@@ -144,7 +144,7 @@ pub fn boundary_exprs(ty: &Type) -> Vec<Spanned<Expr>> {
         // syntax for boundary inputs), Fn / Named / Unknown require
         // user-defined witnesses that hostile mode cannot invent.
         Type::Map(_, _) | Type::Vector(_) | Type::Fn(_, _, _) => Vec::new(),
-        Type::Named(_) | Type::Var(_) | Type::Invalid => Vec::new(),
+        Type::Named { .. } | Type::Var(_) | Type::Invalid => Vec::new(),
     }
 }
 
@@ -235,7 +235,7 @@ mod tests {
     fn named_and_unknown_return_empty() {
         // No literal representation — domain expansion should not invent
         // values for user-defined types in 0.13.
-        assert!(boundary_values(&Type::Named("Shape".to_string())).is_empty());
+        assert!(boundary_values(&Type::named("Shape")).is_empty());
         assert!(boundary_values(&Type::Invalid).is_empty());
     }
 
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn boundary_exprs_named_returns_empty() {
-        assert!(boundary_exprs(&Type::Named("MyShape".to_string())).is_empty());
+        assert!(boundary_exprs(&Type::named("MyShape")).is_empty());
     }
 
     #[test]

--- a/src/types/checker/infer/expr.rs
+++ b/src/types/checker/infer/expr.rs
@@ -986,8 +986,12 @@ impl TypeChecker {
                             &arm.body,
                             arm_expected_ref,
                         );
-                        // Only report mismatch when both types are concrete
-                        if !first_ty.compatible(&arm_ty)
+                        // Only report mismatch when both types are concrete.
+                        // Phase B: route through `self.compatible` so the
+                        // symbol table resolves either side's bare ↔
+                        // canonical reference instead of the raw
+                        // `Type::compatible`'s suffix fallback.
+                        if !self.compatible(&first_ty, &arm_ty)
                             && !matches!(first_ty, Type::Invalid)
                             && !matches!(arm_ty, Type::Invalid)
                         {

--- a/src/types/checker/infer/expr.rs
+++ b/src/types/checker/infer/expr.rs
@@ -175,12 +175,18 @@ impl TypeChecker {
     /// inference logic lives in `infer_type_inner`; this wrapper exists only
     /// to keep the `set_ty` step in one place.
     pub(in super::super) fn infer_type(&mut self, expr: &Spanned<Expr>) -> Type {
-        // Iron — A3: leave Spanned.ty stamps in whatever form the
-        // source wrote (bare or qualified) so downstream discovery
-        // walkers (wasm-gc TypeRegistry, codegen helpers) keep seeing
-        // the source-faithful shape. The matcher itself resolves
-        // bare ↔ canonical via `sig_aliases` at comparison time.
-        let t = self.infer_type_inner(expr);
+        // Phase B: every stamp goes through `canonicalize_named` so
+        // `Type::Named` always carries a `TypeId` whenever the
+        // current checker can resolve it. The pre-phase-B matcher
+        // re-resolved unresolved sides itself; round-6 caught that
+        // route as the path for the entry-fallback leak (an
+        // unresolved `Shape` in a dep sig silently bound to the
+        // entry's `Shape`). Canonicalising once at the stamp site
+        // means the matcher can rely on `id` being the
+        // load-bearing signal and reject mixed `(Some, None)`
+        // outright.
+        let raw = self.infer_type_inner(expr);
+        let t = self.canonicalize_named(raw);
         expr.set_ty(t.clone());
         t
     }

--- a/src/types/checker/infer/expr.rs
+++ b/src/types/checker/infer/expr.rs
@@ -124,7 +124,7 @@ fn display_type_for_expected(ty: &Type) -> String {
                 )
             }
         }
-        Type::Named(name) => name.clone(),
+        Type::Named { name, .. } => name.clone(),
     }
 }
 
@@ -137,7 +137,7 @@ fn display_type_for_expected(ty: &Type) -> String {
 fn type_is_fully_concrete(ty: &Type) -> bool {
     match ty {
         Type::Var(_) | Type::Invalid => false,
-        Type::Int | Type::Float | Type::Str | Type::Bool | Type::Unit | Type::Named(_) => true,
+        Type::Int | Type::Float | Type::Str | Type::Bool | Type::Unit | Type::Named { .. } => true,
         Type::Option(inner) | Type::List(inner) | Type::Vector(inner) => {
             type_is_fully_concrete(inner)
         }
@@ -1118,12 +1118,12 @@ impl TypeChecker {
                     if field == "result" {
                         return self.infer_type(obj);
                     }
-                    return Type::Named("Trace".to_string());
+                    return Type::named("Trace");
                 }
                 let obj_ty = self.infer_type(obj);
                 // Oracle v1: `.contains` / `.length` / `.event` accessors
                 // on a Trace value. Return types match the plan's API.
-                if matches!(&obj_ty, Type::Named(n) if n == "Trace") {
+                if matches!(&obj_ty, Type::Named { name: n, .. } if n == "Trace") {
                     match field.as_str() {
                         "length" => {
                             return Type::Fn(vec![], Box::new(Type::Int), vec![]);
@@ -1151,9 +1151,7 @@ impl TypeChecker {
                         "event" => {
                             return Type::Fn(
                                 vec![Type::Int],
-                                Box::new(Type::Option(Box::new(Type::Named(
-                                    "EffectEvent".to_string(),
-                                )))),
+                                Box::new(Type::Option(Box::new(Type::named("EffectEvent")))),
                                 vec![],
                             );
                         }
@@ -1165,7 +1163,7 @@ impl TypeChecker {
                         "group" => {
                             return Type::Fn(
                                 vec![Type::Int],
-                                Box::new(Type::Named("Trace".to_string())),
+                                Box::new(Type::named("Trace")),
                                 vec![],
                             );
                         }
@@ -1177,7 +1175,7 @@ impl TypeChecker {
                         "branch" => {
                             return Type::Fn(
                                 vec![Type::Int],
-                                Box::new(Type::Named("Trace".to_string())),
+                                Box::new(Type::named("Trace")),
                                 vec![],
                             );
                         }
@@ -1185,16 +1183,15 @@ impl TypeChecker {
                     }
                 }
                 match obj_ty {
-                    Type::Named(ref type_name) => {
-                        // Iron — A3: `opaque_types` keys are canonical
+                    Type::Named {
+                        name: ref type_name,
+                        ..
+                    } => {
+                        // Phase B: `opaque_types` keys are canonical
                         // "Module.Type"; resolve the bare reference
-                        // through `sig_aliases` before checking.
-                        let canon = self
-                            .sig_aliases
-                            .get(type_name)
-                            .map(String::as_str)
-                            .unwrap_or(type_name);
-                        if !self.self_host_mode && self.opaque_types.contains(canon) {
+                        // through the symbol table before checking.
+                        let canon = self.canonical_type_name(type_name);
+                        if !self.self_host_mode && self.opaque_types.contains(&canon) {
                             self.error(format!(
                                 "Cannot access field '{}' of opaque type '{}'",
                                 field, type_name

--- a/src/types/checker/infer/list_calls.rs
+++ b/src/types/checker/infer/list_calls.rs
@@ -85,7 +85,10 @@ impl TypeChecker {
                 let out_ty = match (&left_ty, &right_ty) {
                     (Type::Var(_), _) => right_ty,
                     (_, Type::Var(_)) => left_ty,
-                    _ if left_ty.compatible(&right_ty) => left_ty,
+                    // Phase B: route through `self.compatible` so the
+                    // symbol table resolves bare ↔ canonical instead of
+                    // the raw `Type::compatible`'s suffix fallback.
+                    _ if self.compatible(&left_ty, &right_ty) => left_ty,
                     _ => {
                         self.error(format!(
                             "Arguments of '{}': list element types differ: {} vs {}",

--- a/src/types/checker/infer/patterns.rs
+++ b/src/types/checker/infer/patterns.rs
@@ -65,7 +65,9 @@ impl TypeChecker {
                 "None" if arity == 0 => return Vec::new(),
                 _ => {}
             },
-            Type::Named(_type_name) => {
+            Type::Named {
+                name: _type_name, ..
+            } => {
                 let qualified = if ctor_name.contains('.') {
                     ctor_name.to_string()
                 } else {
@@ -111,12 +113,8 @@ impl TypeChecker {
                 // `sig_aliases` because `opaque_types` is keyed by the
                 // canonical `Module.Type` form.
                 let type_prefix = name.split('.').next().unwrap_or(name);
-                let canon_prefix = self
-                    .sig_aliases
-                    .get(type_prefix)
-                    .map(String::as_str)
-                    .unwrap_or(type_prefix);
-                if !self.self_host_mode && self.opaque_types.contains(canon_prefix) {
+                let canon_prefix = self.canonical_type_name(type_prefix);
+                if !self.self_host_mode && self.opaque_types.contains(&canon_prefix) {
                     self.error(format!(
                         "Cannot pattern match on opaque type '{}'",
                         type_prefix

--- a/src/types/checker/infer/records.rs
+++ b/src/types/checker/infer/records.rs
@@ -18,7 +18,7 @@ impl TypeChecker {
                 "Cannot construct opaque type '{}' — use its module's constructor function",
                 type_name
             ));
-            return Type::named(canonical_type);
+            return self.canonicalize_named(Type::named(canonical_type));
         }
 
         // Iron — A5: `fields_for_type` canonicalises `type_name`
@@ -79,7 +79,10 @@ impl TypeChecker {
                 }
             }
         }
-        Type::named(type_name.to_string())
+        // Phase B: stamp with the symbol-table TypeId so downstream
+        // backends see the typed identity (peer-review #148: record
+        // create/update returned `Type::named(...)` with `id: None`).
+        self.canonicalize_named(Type::named(type_name.to_string()))
     }
 
     pub(in super::super) fn infer_record_update_expr(
@@ -96,7 +99,7 @@ impl TypeChecker {
                 "Cannot update opaque type '{}' — use its module's API",
                 type_name
             ));
-            return Type::named(type_name.to_string());
+            return self.canonicalize_named(Type::named(type_name.to_string()));
         }
         let base_ty = self.infer_type(base);
         // Canonicalize the user-written type name so the matcher sees
@@ -144,6 +147,9 @@ impl TypeChecker {
             }
         }
 
-        Type::named(type_name.to_string())
+        // Phase B: stamp with the symbol-table TypeId so downstream
+        // backends see the typed identity (peer-review #148: record
+        // create/update returned `Type::named(...)` with `id: None`).
+        self.canonicalize_named(Type::named(type_name.to_string()))
     }
 }

--- a/src/types/checker/infer/records.rs
+++ b/src/types/checker/infer/records.rs
@@ -12,17 +12,13 @@ impl TypeChecker {
         // opaque type by its bare name (`Discount` from
         // `Pricing.Discount`) is caught the same way the fully
         // qualified form would be.
-        let canonical_type = self
-            .sig_aliases
-            .get(type_name)
-            .cloned()
-            .unwrap_or_else(|| type_name.to_string());
+        let canonical_type = self.canonical_type_name(type_name);
         if !self.self_host_mode && self.opaque_types.contains(canonical_type.as_str()) {
             self.error(format!(
                 "Cannot construct opaque type '{}' — use its module's constructor function",
                 type_name
             ));
-            return Type::Named(canonical_type);
+            return Type::named(canonical_type);
         }
 
         // Iron — A5: `fields_for_type` canonicalises `type_name`
@@ -83,7 +79,7 @@ impl TypeChecker {
                 }
             }
         }
-        Type::Named(type_name.to_string())
+        Type::named(type_name.to_string())
     }
 
     pub(in super::super) fn infer_record_update_expr(
@@ -94,22 +90,18 @@ impl TypeChecker {
     ) -> Type {
         // Iron — A3: same canonical resolution as construction so the
         // bare-named reference to an imported opaque type is caught.
-        let canon = self
-            .sig_aliases
-            .get(type_name)
-            .map(String::as_str)
-            .unwrap_or(type_name);
-        if !self.self_host_mode && self.opaque_types.contains(canon) {
+        let canon = self.canonical_type_name(type_name);
+        if !self.self_host_mode && self.opaque_types.contains(&canon) {
             self.error(format!(
                 "Cannot update opaque type '{}' — use its module's API",
                 type_name
             ));
-            return Type::Named(type_name.to_string());
+            return Type::named(type_name.to_string());
         }
         let base_ty = self.infer_type(base);
         // Canonicalize the user-written type name so the matcher sees
         // the same form `infer_type` stamps onto the base expression.
-        let expected_ty = self.canonicalize_named(Type::Named(type_name.to_string()));
+        let expected_ty = self.canonicalize_named(Type::named(type_name.to_string()));
         if !self.compatible(&base_ty, &expected_ty) {
             self.error(format!(
                 "{}.update: base has type {}, expected {}",
@@ -152,6 +144,6 @@ impl TypeChecker {
             }
         }
 
-        Type::Named(type_name.to_string())
+        Type::named(type_name.to_string())
     }
 }

--- a/src/types/checker/memo.rs
+++ b/src/types/checker/memo.rs
@@ -2,13 +2,13 @@ use super::*;
 
 impl TypeChecker {
     pub(super) fn check(&mut self, items: &[TopLevel], base_dir: Option<&str>) {
-        // Iron — A3: load + integrate dependency modules FIRST so the
-        // alias map is populated before `build_signatures`
-        // canonicalises local fn / type annotations. Without this, a
-        // bare reference to an imported type in a local signature
-        // stays as `Type::Named("Discount")` instead of resolving to
-        // `Type::Named("Pricing.Discount.Discount")`, and the strict
-        // matcher then rejects every call site of that function.
+        // Phase B: track the entry module's prefix so bare-name
+        // resolution in `resolve_fn_id` / `resolve_type_id` knows
+        // which scope to try first.
+        self.current_module_prefix = Self::module_decl(items).map(|m| m.name.clone());
+        // Load + integrate dependency modules FIRST so the alias
+        // maps are populated before `build_signatures` resolves local
+        // fn / type annotations.
         let mut loaded_modules: Vec<crate::source::LoadedModule> = Vec::new();
         if let Some(base) = base_dir
             && let Some(module) = Self::module_decl(items)
@@ -40,10 +40,12 @@ impl TypeChecker {
         items: &[TopLevel],
         loaded: &[crate::source::LoadedModule],
     ) {
-        // Iron — A3: dependency aliases come in before local
-        // signatures so `build_signatures`'s canonicalization sees
-        // imported types (e.g. `Tile` resolves to `Types.Tile` when
-        // `Types` is in `depends`).
+        // Phase B: track the entry module's prefix (see `check`).
+        self.current_module_prefix = Self::module_decl(items).map(|m| m.name.clone());
+        // Dependency aliases come in before local signatures so
+        // `build_signatures`'s resolution sees imported types
+        // (e.g. `Tile` resolves to `Types.Tile` when `Types` is in
+        // `depends`).
         self.integrate_loaded_modules(loaded);
         self.build_signatures(items);
         self.check_loaded_module_bodies(loaded);
@@ -78,22 +80,27 @@ impl TypeChecker {
     /// surfaces alongside any error in `main.av`.
     fn check_loaded_module_bodies(&mut self, modules: &[crate::source::LoadedModule]) {
         for (idx, module) in modules.iter().enumerate() {
-            let mut sub = TypeChecker::new();
-            // Propagate self-host opaque bypass into the dep module sub-
-            // checker. `domain/builtins.av` round-trips `Tcp.Connection`
-            // through the replay `Val` shape; without this, the sub-checker
-            // re-enforces opacity even when the parent compile was kicked
-            // off with `--with-self-host-support`.
+            // Phase B: clone the parent's `SymbolTable` into the sub-
+            // checker so every module shares the same opaque
+            // identity space. The dep module's own declarations are
+            // already registered in the table (the parent built it
+            // from `entry_items + dep_modules`).
+            let mut sub = TypeChecker::new_with_symbols(self.symbol_table.clone());
             sub.self_host_mode = self.self_host_mode;
-            // Iron — A3: pull in dependency aliases BEFORE building
-            // local signatures. build_signatures canonicalizes every
-            // type annotation by walking `sig_aliases`; without the
-            // imported types in there first, a bare reference like
-            // `Tile` (imported from `Types`) stays as
-            // `Type::Named("Tile")` instead of being rewritten to
-            // `Type::Named("Types.Tile")`, and the strict matcher
-            // then rejects the call site that passes the canonical
-            // form.
+            // Phase B: the dep module's prefix in the symbol table is
+            // its `dep_name` (the path the entry's `depends` clause
+            // wrote, e.g. `Pricing.Discount`), not the interior
+            // `module X` declaration inside the file. Use the
+            // `dep_name` so `resolve_fn_id` finds `mkDiscount` ->
+            // `FnKey::in_module(dep_name, "mkDiscount")` for own-module
+            // bodies in the sub-checker.
+            sub.current_module_prefix = Some(module.dep_name.clone());
+            // Pull in dependency aliases BEFORE building local
+            // signatures. `build_signatures` canonicalises every
+            // type annotation through the symbol table; without the
+            // imported types in the alias map first, a bare
+            // reference like `Tile` (imported from `Types`) wouldn't
+            // resolve.
             let others: Vec<_> = modules
                 .iter()
                 .enumerate()
@@ -141,7 +148,7 @@ impl TypeChecker {
             | Type::Invalid
             | Type::Var(_) => false,
             Type::Result(_, _) | Type::Option(_) => false,
-            Type::Named(name) => {
+            Type::Named { name, .. } => {
                 // Prevent infinite recursion for cyclic type defs
                 if !visiting.insert(name.clone()) {
                     return true;
@@ -168,12 +175,14 @@ impl TypeChecker {
             return true;
         }
 
-        // Check sum type variants: constructors are registered in fn_sigs
-        // as "TypeName.VariantName" with param types, or in value_members
-        // for zero-arg constructors.
+        // Check sum type variants: constructors are registered as
+        // "TypeName.VariantName" with param types, or in value_members
+        // for zero-arg constructors. Phase B: constructors live in
+        // `extra_sigs`, never in the FnId-keyed `fn_sigs`, but
+        // `all_fn_sigs` flattens both halves for the prefix scan.
         let prefix = format!("{}.", name);
         let mut found_variants = false;
-        for (key, sig) in &self.fn_sigs {
+        for (key, sig) in self.all_fn_sigs() {
             if key.starts_with(&prefix) && key.len() > prefix.len() {
                 found_variants = true;
                 for param in &sig.params {
@@ -206,7 +215,7 @@ impl TypeChecker {
                     TypeDef::Sum { name, .. } | TypeDef::Product { name, .. } => name,
                 };
                 let mut visiting = HashSet::new();
-                if self.is_memo_safe(&Type::Named(name.clone()), &mut visiting) {
+                if self.is_memo_safe(&Type::named(name.clone()), &mut visiting) {
                     safe.insert(name.clone());
                 }
             }

--- a/src/types/checker/memo.rs
+++ b/src/types/checker/memo.rs
@@ -53,6 +53,17 @@ impl TypeChecker {
     }
 
     fn integrate_loaded_modules(&mut self, modules: &[crate::source::LoadedModule]) {
+        // Phase B (peer review round 6): track each dep module's own
+        // `depends` list so the per-owner type resolver
+        // (`canonicalize_named_in_module`) can walk it instead of
+        // falling back to the importer's context or to whichever
+        // siblings happen to be in the entry's loaded tree.
+        for m in modules {
+            if let Some(module_decl) = TypeChecker::module_decl(&m.items) {
+                self.module_depends
+                    .insert(m.dep_name.clone(), module_decl.depends.clone());
+            }
+        }
         let pairs: Vec<_> = modules
             .iter()
             .map(|m| (m.dep_name.clone(), m.items.clone()))
@@ -79,7 +90,7 @@ impl TypeChecker {
     /// back into the parent so a real type bug in `combat.av` still
     /// surfaces alongside any error in `main.av`.
     fn check_loaded_module_bodies(&mut self, modules: &[crate::source::LoadedModule]) {
-        for (idx, module) in modules.iter().enumerate() {
+        for module in modules {
             // Phase B: clone the parent's `SymbolTable` into the sub-
             // checker so every module shares the same opaque
             // identity space. The dep module's own declarations are
@@ -95,19 +106,25 @@ impl TypeChecker {
             // `FnKey::in_module(dep_name, "mkDiscount")` for own-module
             // bodies in the sub-checker.
             sub.current_module_prefix = Some(module.dep_name.clone());
-            // Pull in dependency aliases BEFORE building local
-            // signatures. `build_signatures` canonicalises every
-            // type annotation through the symbol table; without the
-            // imported types in the alias map first, a bare
-            // reference like `Tile` (imported from `Types`) wouldn't
-            // resolve.
-            let others: Vec<_> = modules
+            // Phase B (peer review round 6): the sub-checker for
+            // module `B` must see `B`'s *own* depends — not every
+            // sibling the entry happened to load. The pre-fix sent
+            // `modules - self`, which let an unrelated sibling `C`
+            // (also a dep of the entry) leak into `B`'s resolver
+            // context and silently shadow types `B` genuinely
+            // depends on. Filter `modules` by the dep names listed
+            // in `B`'s own `depends [...]` declaration so the only
+            // bare-name aliases the sub-checker sees come from
+            // modules `B` itself imported.
+            let own_depends: Vec<String> = TypeChecker::module_decl(&module.items)
+                .map(|m| m.depends.clone())
+                .unwrap_or_default();
+            let visible_to_sub: Vec<_> = modules
                 .iter()
-                .enumerate()
-                .filter(|(i, _)| *i != idx)
-                .map(|(_, m)| m.clone())
+                .filter(|m| own_depends.iter().any(|d| d == &m.dep_name))
+                .cloned()
                 .collect();
-            sub.integrate_loaded_modules(&others);
+            sub.integrate_loaded_modules(&visible_to_sub);
             sub.build_signatures(&module.items);
             sub.check_top_level_stmts(&module.items);
             sub.check_verify_blocks(&module.items);

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -14,6 +14,7 @@ use super::{Type, parse_type_str_strict};
 use crate::ast::{
     BinOp, Expr, FnDef, Literal, Module, Pattern, Spanned, Stmt, TailCallData, TopLevel, TypeDef,
 };
+use crate::ir::{FnId, FnKey, SymbolTable, TypeId, TypeKey};
 
 mod builtins;
 pub mod effect_classification;
@@ -73,9 +74,67 @@ pub fn run_type_check_with_base(items: &[TopLevel], base_dir: Option<&str>) -> V
 }
 
 pub fn run_type_check_full(items: &[TopLevel], base_dir: Option<&str>) -> TypeCheckResult {
-    let mut checker = TypeChecker::new();
+    let mut checker = TypeChecker::new_with_symbols(build_symbols_for_items(items, base_dir));
     checker.check(items, base_dir);
     finalize_check_result(checker, items)
+}
+
+/// Build the `SymbolTable` for a typecheck entry point. Mirrors the
+/// dep-resolution path inside [`TypeChecker::check`] so the table
+/// covers both entry items and any modules the entry file depends on.
+/// Filesystem errors are silently dropped here — the checker rebuilds
+/// its own diagnostics during the actual check, so duplicating them at
+/// the symbol-table layer would only produce noise.
+fn build_symbols_for_items(items: &[TopLevel], base_dir: Option<&str>) -> SymbolTable {
+    let dep_modules = base_dir
+        .and_then(|base| {
+            TypeChecker::module_decl(items).and_then(|m| {
+                crate::source::load_module_tree(&m.depends, base)
+                    .ok()
+                    .map(|loaded| symbols_dep_modules_from_loaded(&loaded))
+            })
+        })
+        .unwrap_or_default();
+    SymbolTable::build(items, &dep_modules)
+}
+
+/// Pre-loaded variant of [`build_symbols_for_items`] for the
+/// `WithLoaded` typecheck driver (playground virtual FS).
+fn build_symbols_with_loaded(
+    items: &[TopLevel],
+    loaded: &[crate::source::LoadedModule],
+) -> SymbolTable {
+    let dep_modules = symbols_dep_modules_from_loaded(loaded);
+    SymbolTable::build(items, &dep_modules)
+}
+
+fn symbols_dep_modules_from_loaded(
+    loaded: &[crate::source::LoadedModule],
+) -> Vec<crate::codegen::ModuleInfo> {
+    loaded
+        .iter()
+        .map(|m| crate::codegen::ModuleInfo {
+            prefix: m.dep_name.clone(),
+            depends: Vec::new(),
+            type_defs: m
+                .items
+                .iter()
+                .filter_map(|i| match i {
+                    TopLevel::TypeDef(td) => Some(td.clone()),
+                    _ => None,
+                })
+                .collect(),
+            fn_defs: m
+                .items
+                .iter()
+                .filter_map(|i| match i {
+                    TopLevel::FnDef(fd) => Some(fd.clone()),
+                    _ => None,
+                })
+                .collect(),
+            analysis: None,
+        })
+        .collect()
 }
 
 /// Variant of [`run_type_check_full`] that uses pre-loaded dependency
@@ -86,7 +145,7 @@ pub fn run_type_check_with_loaded(
     items: &[TopLevel],
     loaded: &[crate::source::LoadedModule],
 ) -> TypeCheckResult {
-    let mut checker = TypeChecker::new();
+    let mut checker = TypeChecker::new_with_symbols(build_symbols_with_loaded(items, loaded));
     checker.check_with_loaded(items, loaded);
     finalize_check_result(checker, items)
 }
@@ -102,7 +161,7 @@ pub fn run_type_check_full_self_host(
     items: &[TopLevel],
     base_dir: Option<&str>,
 ) -> TypeCheckResult {
-    let mut checker = TypeChecker::new();
+    let mut checker = TypeChecker::new_with_symbols(build_symbols_for_items(items, base_dir));
     checker.self_host_mode = true;
     checker.check(items, base_dir);
     finalize_check_result(checker, items)
@@ -114,36 +173,48 @@ pub fn run_type_check_with_loaded_self_host(
     items: &[TopLevel],
     loaded: &[crate::source::LoadedModule],
 ) -> TypeCheckResult {
-    let mut checker = TypeChecker::new();
+    let mut checker = TypeChecker::new_with_symbols(build_symbols_with_loaded(items, loaded));
     checker.self_host_mode = true;
     checker.check_with_loaded(items, loaded);
     finalize_check_result(checker, items)
 }
 
 fn finalize_check_result(mut checker: TypeChecker, items: &[TopLevel]) -> TypeCheckResult {
-    // Internal `fn_sigs` is keyed by canonical "Module.name" (Iron — A3).
-    // The exported map preserves both forms so external consumers
-    // (`verify_effects`, Lean / Dafny codegen, the CLI summary) can
-    // continue to look entries up by the bare name the user wrote.
-    let mut fn_sigs: HashMap<String, (Vec<Type>, Type, Vec<String>)> = checker
-        .fn_sigs
-        .iter()
-        .map(|(k, v)| {
-            (
-                k.clone(),
-                (v.params.clone(), v.ret.clone(), v.effects.clone()),
-            )
-        })
-        .collect();
-    for (alias, canonical) in &checker.sig_aliases {
-        if !fn_sigs.contains_key(alias)
-            && let Some(sig) = checker.fn_sigs.get(canonical)
-        {
-            fn_sigs.insert(
-                alias.clone(),
-                (sig.params.clone(), sig.ret.clone(), sig.effects.clone()),
-            );
+    // Phase B: build the exported string-keyed map by flattening both
+    // halves of the internal split (`fn_sigs` keyed by `FnId`,
+    // `extra_sigs` keyed by canonical string). External consumers
+    // (`verify_effects`, Lean / Dafny codegen, the CLI summary,
+    // `diagnostics::context::callgraph`) continue to look entries up by
+    // bare or canonical name. For entry-scope fns inside an
+    // `module X` declaration we mirror the entry under both
+    // `"X.name"` (TypeChecker canonical) and the bare name; for
+    // module-scoped fns we keep the symbol table's canonical plus a
+    // bare alias mirror.
+    let entry_prefix = checker.current_module_prefix.clone();
+    let mut fn_sigs: HashMap<String, (Vec<Type>, Type, Vec<String>)> = HashMap::new();
+    for (id, sig) in &checker.fn_sigs {
+        let entry = checker.symbol_table.fn_entry(*id);
+        let canonical = if entry.module.is_entry() {
+            match entry_prefix.as_deref() {
+                Some(prefix) => crate::visibility::qualified_name(prefix, &entry.key.name),
+                None => entry.key.name.clone(),
+            }
+        } else {
+            entry.key.canonical()
+        };
+        let triple = (sig.params.clone(), sig.ret.clone(), sig.effects.clone());
+        fn_sigs.insert(canonical.clone(), triple.clone());
+        // Mirror bare alias so existing bare-name external callers
+        // keep resolving regardless of whether the canonical carries
+        // a module prefix.
+        if entry.key.name != canonical {
+            fn_sigs.entry(entry.key.name.clone()).or_insert(triple);
         }
+    }
+    for (k, sig) in &checker.extra_sigs {
+        fn_sigs
+            .entry(k.clone())
+            .or_insert_with(|| (sig.params.clone(), sig.ret.clone(), sig.effects.clone()));
     }
 
     let memo_safe_types = checker.compute_memo_safe_types(items);
@@ -254,20 +325,60 @@ impl RecordFieldKey {
 }
 
 struct TypeChecker {
-    fn_sigs: HashMap<String, FnSig>,
+    /// Resolved-identity table — phase B (#138). Populated by
+    /// [`TypeChecker::new_with_symbols`] from the program's `entry_items
+    /// + dep_modules` before any signature registration. Carries opaque
+    /// `FnId` / `TypeId` for every user-defined fn and type. The
+    /// checker resolves bare-name references through it instead of the
+    /// pre-phase-B `sig_aliases` string→string map.
+    symbol_table: SymbolTable,
+    /// User-defined function signatures, keyed by the opaque `FnId`
+    /// from `symbol_table`. Phase B (#138) migrated this away from
+    /// `HashMap<String, FnSig>` so that two modules each declaring `foo`
+    /// can't silently collide through bare-name keying.
+    ///
+    /// Built-in fn signatures (namespace methods like `Int.add`,
+    /// `Console.print`) and user constructors (variants of sum types,
+    /// product type constructors keyed by `"Module.Type.Variant"`)
+    /// don't have `FnId`s in the program symbol table — those live in
+    /// `extra_sigs` keyed by canonical string. `find_fn_sig` chains
+    /// the two for a unified bare-name → signature lookup.
+    fn_sigs: HashMap<FnId, FnSig>,
+    /// Builtin fn signatures + constructor signatures keyed by
+    /// canonical string. The non-`FnId` half of the split — entries
+    /// here either come from `register_builtins` (namespace methods)
+    /// or `register_type_def_sigs` (sum-type variant constructors,
+    /// product type "callable name" entries). Lookups against this
+    /// map use the canonical key directly; bare→canonical resolution
+    /// goes through `symbol_table.type_id_of` for type-derived keys.
+    extra_sigs: HashMap<String, FnSig>,
+    /// Bare → `FnId` aliases for cross-module imports. Populated
+    /// during `integrate_registry` from visibility-exposed aliases
+    /// (and during `build_signatures` for the current module's own
+    /// fns). The typed replacement for the pre-phase-B
+    /// `sig_aliases: HashMap<String, String>`: same bare-name routing
+    /// role, but the value side now carries opaque identity instead
+    /// of a string that needed re-resolution downstream.
+    bare_fn_aliases: HashMap<String, FnId>,
+    /// Bare → `TypeId` aliases. Same role as `bare_fn_aliases`
+    /// for the type-name dimension; consumed by `resolve_type_id`
+    /// and `canonical_type_name`.
+    bare_type_aliases: HashMap<String, TypeId>,
     value_members: HashMap<String, Type>,
     /// Field types for record types, keyed by `(type_name, field_name)`.
     /// Populated for both user-defined `record` types and built-in records
     /// (HttpResponse, Header). Single entry per (canonical type name, field);
-    /// lookup canonicalises `type_name` through `sig_aliases` at read time.
+    /// lookup canonicalises `type_name` through `SymbolTable` at read time.
     /// Enables checked dot-access on Named types.
     record_field_types: HashMap<RecordFieldKey, Type>,
-    /// Unqualified → qualified aliases for cross-module lookups.
-    /// E.g. "Shape.Circle" → "Data.Shape.Circle".
-    sig_aliases: HashMap<String, String>,
     /// Variant names for sum types: "Shape" → ["Circle", "Rect", "Point"].
     /// Pre-populated for Result and Option; extended by user-defined sum types.
     type_variants: HashMap<String, Vec<String>>,
+    /// Module prefix of the items currently being checked. `None`
+    /// while checking entry-scope items. Per-module sub-checkers
+    /// (`check_loaded_module_bodies`) set this to the dep module's
+    /// prefix so bare-name resolution finds the local type/fn first.
+    current_module_prefix: Option<String>,
     /// Top-level bindings visible from function bodies.
     globals: HashMap<String, Type>,
     /// Local bindings in the current function/scope.
@@ -309,7 +420,7 @@ struct TypeChecker {
 }
 
 impl TypeChecker {
-    fn new() -> Self {
+    fn new_with_symbols(symbol_table: SymbolTable) -> Self {
         let mut type_variants = HashMap::new();
         type_variants.insert(
             "Result".to_string(),
@@ -321,11 +432,15 @@ impl TypeChecker {
         );
 
         let mut tc = TypeChecker {
+            symbol_table,
             fn_sigs: HashMap::new(),
+            extra_sigs: HashMap::new(),
+            bare_fn_aliases: HashMap::new(),
+            bare_type_aliases: HashMap::new(),
             value_members: HashMap::new(),
             record_field_types: HashMap::new(),
-            sig_aliases: HashMap::new(),
             type_variants,
+            current_module_prefix: None,
             globals: HashMap::new(),
             locals: HashMap::new(),
             errors: Vec::new(),
@@ -342,69 +457,244 @@ impl TypeChecker {
         tc
     }
 
-    // -- Alias-aware lookups ------------------------------------------------
+    // -- Identity resolution (phase B) -------------------------------------
+
+    /// Resolve a source-faithful function reference (`"foo"`,
+    /// `"Module.foo"`, `"Tcp.send"`) to a `FnId` via the symbol table.
+    /// Tries, in order: literal-as-qualified (split `"Module.foo"`
+    /// into `(Module, foo)`), current-module-scoped bare name, then
+    /// entry-scope bare name, then the typed bare-alias map.
+    ///
+    /// Misses for builtin namespace methods and constructors — those
+    /// don't live in the program symbol table; callers fall back to
+    /// the `extra_sigs` string-keyed half.
+    pub(crate) fn resolve_fn_id(&self, name: &str) -> Option<FnId> {
+        if let Some((prefix, n)) = name.rsplit_once('.') {
+            if let Some(id) = self.symbol_table.fn_id_of(&FnKey::in_module(prefix, n)) {
+                return Some(id);
+            }
+            // Entry items that declare `module Rogue` still live
+            // under `FnKey::entry` in the symbol table — only
+            // dep modules occupy real module scopes. Fall back to
+            // entry-scope lookup when the qualified prefix matches
+            // the current scope's declared module name.
+            if self.current_module_prefix.as_deref() == Some(prefix)
+                && let Some(id) = self.symbol_table.fn_id_of(&FnKey::entry(n))
+            {
+                return Some(id);
+            }
+        }
+        if let Some(prefix) = self.current_module_prefix.as_deref()
+            && let Some(id) = self.symbol_table.fn_id_of(&FnKey::in_module(prefix, name))
+        {
+            return Some(id);
+        }
+        if let Some(id) = self.symbol_table.fn_id_of(&FnKey::entry(name)) {
+            return Some(id);
+        }
+        // Cross-module bare-name imports — `bare_fn_aliases` is the
+        // typed replacement for the pre-phase-B `sig_aliases` map.
+        // Populated by `integrate_registry` from visibility-exposed
+        // aliases (and by `build_signatures` for the current module's
+        // own fns), so a bare reference to an imported fn picks up
+        // its `FnId` here even when the symbol-table key would need a
+        // scope hint to find it.
+        self.bare_fn_aliases.get(name).copied()
+    }
+
+    /// Type-side equivalent of [`Self::resolve_fn_id`].
+    pub(crate) fn resolve_type_id(&self, name: &str) -> Option<TypeId> {
+        if let Some((prefix, n)) = name.rsplit_once('.') {
+            if let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n)) {
+                return Some(id);
+            }
+            if self.current_module_prefix.as_deref() == Some(prefix)
+                && let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(n))
+            {
+                return Some(id);
+            }
+        }
+        if let Some(prefix) = self.current_module_prefix.as_deref()
+            && let Some(id) = self
+                .symbol_table
+                .type_id_of(&TypeKey::in_module(prefix, name))
+        {
+            return Some(id);
+        }
+        if let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(name)) {
+            return Some(id);
+        }
+        self.bare_type_aliases.get(name).copied()
+    }
+
+    /// Canonical name (`"Module.Type"` or bare entry name) for a
+    /// source-faithful type reference. Resolves through the symbol
+    /// table; falls back to the input string for references the table
+    /// doesn't know about (builtins, opaque host types, in-flight
+    /// recovery from earlier errors).
+    ///
+    /// For entry-scope types in a checker that's currently processing
+    /// items with a `module X` declaration, the returned name includes
+    /// the `X.` prefix even though the symbol table itself stores
+    /// entry items without one. This preserves the pre-phase-B
+    /// canonical view the typechecker's internal maps
+    /// (`type_variants`, `record_field_types`, …) are keyed against.
+    pub(crate) fn canonical_type_name(&self, name: &str) -> String {
+        match self.resolve_type_id(name) {
+            Some(id) => {
+                let entry = self.symbol_table.type_entry(id);
+                if entry.module.is_entry()
+                    && let Some(prefix) = self.current_module_prefix.as_deref()
+                {
+                    crate::visibility::qualified_name(prefix, &entry.key.name)
+                } else {
+                    entry.key.canonical()
+                }
+            }
+            None => name.to_string(),
+        }
+    }
+
+    // -- Unified lookups ---------------------------------------------------
 
     fn find_fn_sig(&self, key: &str) -> Option<&FnSig> {
-        self.fn_sigs
-            .get(key)
-            .or_else(|| self.sig_aliases.get(key).and_then(|c| self.fn_sigs.get(c)))
+        // Phase B: user fns live in `fn_sigs` keyed by `FnId`; everything
+        // else (builtins + sum-type variant constructors) stays in
+        // `extra_sigs`. Direct hit on `extra_sigs` covers references that
+        // came in already-canonicalised; `resolve_fn_id` chains the
+        // symbol-table lookups for bare/qualified user-fn references.
+        if let Some(id) = self.resolve_fn_id(key)
+            && let Some(sig) = self.fn_sigs.get(&id)
+        {
+            return Some(sig);
+        }
+        if let Some(sig) = self.extra_sigs.get(key) {
+            return Some(sig);
+        }
+        // Try canonicalised form for type-derived keys
+        // (`"Module.Type.Variant"`).
+        let canonical = self.canonical_extra_key(key);
+        if canonical != key {
+            return self.extra_sigs.get(&canonical);
+        }
+        None
+    }
+
+    /// Take a bare-or-qualified key that may name a constructor or a
+    /// per-type member (`"Shape.Circle"`, `"Status.Open"`) and resolve
+    /// the leading type segment through `canonical_type_name`. Uses
+    /// the typechecker view of canonical names (which include the
+    /// entry module's prefix), matching what `register_type_def_sigs`
+    /// inserts into `extra_sigs`.
+    fn canonical_extra_key(&self, key: &str) -> String {
+        if let Some((head, tail)) = key.split_once('.') {
+            let canonical_type = self.canonical_type_name(head);
+            if canonical_type != head {
+                return format!("{}.{}", canonical_type, tail);
+            }
+        }
+        key.to_string()
     }
 
     fn find_value_member(&self, key: &str) -> Option<&Type> {
-        self.value_members.get(key).or_else(|| {
-            self.sig_aliases
-                .get(key)
-                .and_then(|c| self.value_members.get(c))
-        })
+        if let Some(v) = self.value_members.get(key) {
+            return Some(v);
+        }
+        let canonical = self.canonical_extra_key(key);
+        if canonical != key {
+            return self.value_members.get(&canonical);
+        }
+        None
     }
 
     fn find_record_field_type(&self, type_name: &str, field_name: &str) -> Option<&Type> {
-        // Iron — A5: lookup canonicalises the type-name dimension via
-        // `sig_aliases` before hashing. We only need to do that for
-        // the type-name part — field names are intra-type and stay
-        // verbatim.
         let direct = RecordFieldKey::new(type_name, field_name);
         if let Some(ty) = self.record_field_types.get(&direct) {
             return Some(ty);
         }
-        if let Some(canonical_type) = self.sig_aliases.get(type_name) {
+        let canonical_type = self.canonical_type_name(type_name);
+        if canonical_type != type_name {
             let canonical = RecordFieldKey::new(canonical_type, field_name);
             return self.record_field_types.get(&canonical);
         }
         None
     }
 
-    /// Iron — A5: list every `(field_name, field_type)` pair declared
-    /// for `type_name`. Resolves `type_name` through `sig_aliases`
-    /// so a bare reference in source matches a canonical entry; the
-    /// reverse direction (canonical reference hitting a bare entry)
-    /// is a no-op because A3 normalises stored keys to canonical
-    /// form whenever a module alias exists.
     fn fields_for_type(&self, type_name: &str) -> Vec<(String, Type)> {
-        let canonical = self
-            .sig_aliases
-            .get(type_name)
-            .map(String::as_str)
-            .unwrap_or(type_name);
+        let canonical = self.canonical_type_name(type_name);
+        let canonical_ref: &str = canonical.as_str();
         self.record_field_types
             .iter()
-            .filter(|(k, _)| k.type_name == canonical || k.type_name == type_name)
+            .filter(|(k, _)| k.type_name == canonical_ref || k.type_name == type_name)
             .map(|(k, v)| (k.field_name.clone(), v.clone()))
             .collect()
     }
 
-    /// Iron — A5: `true` if any field has been registered for
-    /// `type_name`. Drops the pre-A5 `record_field_types.keys().any(|k|
-    /// k.starts_with(&format!("{}.", type_name)))` substring probe.
     fn has_record_schema(&self, type_name: &str) -> bool {
-        let canonical = self
-            .sig_aliases
-            .get(type_name)
-            .map(String::as_str)
-            .unwrap_or(type_name);
+        let canonical = self.canonical_type_name(type_name);
+        let canonical_ref: &str = canonical.as_str();
         self.record_field_types
             .keys()
-            .any(|k| k.type_name == canonical || k.type_name == type_name)
+            .any(|k| k.type_name == canonical_ref || k.type_name == type_name)
+    }
+
+    /// Look up the variant list for a named sum type. Resolves
+    /// `name` through `canonical_type_name` so bare references find
+    /// the canonical "Module.Type" entry registered by
+    /// `register_type_def_sigs` / `integrate_registry`.
+    pub(crate) fn variants_for(&self, name: &str) -> Option<&Vec<String>> {
+        if let Some(v) = self.type_variants.get(name) {
+            return Some(v);
+        }
+        let canonical = self.canonical_type_name(name);
+        if canonical != name {
+            return self.type_variants.get(&canonical);
+        }
+        None
+    }
+
+    pub(crate) fn has_variants_for(&self, name: &str) -> bool {
+        self.variants_for(name).is_some()
+    }
+
+    /// Iterate every fn signature regardless of which storage half
+    /// holds it. Used by the namespace-prefix check and by
+    /// `finalize_check_result` to flatten for external export.
+    fn all_fn_sigs(&self) -> impl Iterator<Item = (String, &FnSig)> + '_ {
+        let from_user = self.fn_sigs.iter().map(|(id, sig)| {
+            let name = self.symbol_table.fn_entry(*id).key.canonical();
+            (name, sig)
+        });
+        let from_extra = self.extra_sigs.iter().map(|(k, sig)| (k.clone(), sig));
+        from_user.chain(from_extra)
+    }
+
+    fn fn_sig_contains_canonical(&self, canonical: &str) -> bool {
+        if let Some(id) = self.resolve_fn_id(canonical)
+            && self.fn_sigs.contains_key(&id)
+        {
+            return true;
+        }
+        if self.extra_sigs.contains_key(canonical) {
+            return true;
+        }
+        let canonical_form = self.canonical_extra_key(canonical);
+        canonical_form != canonical && self.extra_sigs.contains_key(&canonical_form)
+    }
+
+    /// Insert a fn signature under its canonical form. Routes to the
+    /// `FnId`-keyed user map when the name resolves through the
+    /// symbol table (i.e. it names a user fn declared in `items` or a
+    /// dep module); otherwise it lands in the `extra_sigs` half.
+    fn insert_fn_sig(&mut self, canonical: &str, sig: FnSig) {
+        match self.resolve_fn_id(canonical) {
+            Some(id) => {
+                self.fn_sigs.insert(id, sig);
+            }
+            None => {
+                self.extra_sigs.insert(canonical.to_string(), sig);
+            }
+        }
     }
 
     // -- Helpers -----------------------------------------------------------
@@ -436,7 +726,13 @@ impl TypeChecker {
     }
 
     fn insert_sig(&mut self, name: &str, params: &[Type], ret: Type, effects: &[&str]) {
-        self.fn_sigs.insert(
+        // Builtins (Int.add, Console.print, …) are not part of the
+        // user-program symbol table, so they always land in
+        // `extra_sigs`. The `insert_fn_sig` router would normally
+        // resolve user fns into `fn_sigs` — but no `register_builtins`
+        // caller could ever name a user fn, so we short-circuit here
+        // to avoid pointless symbol-table probes.
+        self.extra_sigs.insert(
             name.to_string(),
             FnSig {
                 params: params.to_vec(),
@@ -472,45 +768,45 @@ impl TypeChecker {
             .cloned()
     }
 
-    /// Iron — A3: `&self`-bearing constraint check. Resolves bare
-    /// Named types through `sig_aliases` so source-faithful Spanned
-    /// stamps (often bare inside a module) match against
-    /// canonicalised fn signatures (always "Module.Type").
+    /// Phase B: `&self`-bearing constraint check. Resolves bare named
+    /// types against the `SymbolTable` (carried on `self`) so
+    /// source-faithful Spanned stamps still match against canonical fn
+    /// signatures. Replaces the pre-phase-B `sig_aliases` string→string
+    /// alias map with typed `TypeId` resolution.
     pub(super) fn compatible(&self, actual: &Type, expected: &Type) -> bool {
         let mut subst = HashMap::new();
-        Self::match_expected_type_inner(actual, expected, &mut subst, &self.sig_aliases)
+        Self::match_expected_type_inner(actual, expected, &mut subst, Some(self))
     }
 
-    /// Static-form matcher (no alias resolution). Tests use this
-    /// directly; production code should reach for `compatible`
+    /// Static-form matcher (no symbol-table resolution). Tests use
+    /// this directly; production code should reach for `compatible`
     /// instead.
     pub(super) fn match_expected_type(
         actual: &Type,
         expected: &Type,
         subst: &mut HashMap<String, Type>,
     ) -> bool {
-        Self::match_expected_type_inner(actual, expected, subst, &HashMap::new())
+        Self::match_expected_type_inner(actual, expected, subst, None)
     }
 
-    /// Iron — A3: `&self` matcher that lets the caller carry a
-    /// substitution (poly fn arg inference). The pure `compatible`
-    /// helper above hides `subst` for the common "no Type::Var
-    /// involved" callers; this method exposes it for the FnCall arg
-    /// loop in `infer/expr.rs`.
+    /// `&self` matcher that lets the caller carry a substitution
+    /// (poly fn arg inference). The pure `compatible` helper above
+    /// hides `subst` for the common "no `Type::Var` involved" callers;
+    /// this method exposes it for the FnCall arg loop in `infer/expr.rs`.
     pub(super) fn match_with(
         &self,
         actual: &Type,
         expected: &Type,
         subst: &mut HashMap<String, Type>,
     ) -> bool {
-        Self::match_expected_type_inner(actual, expected, subst, &self.sig_aliases)
+        Self::match_expected_type_inner(actual, expected, subst, Some(self))
     }
 
     fn match_expected_type_inner(
         actual: &Type,
         expected: &Type,
         subst: &mut HashMap<String, Type>,
-        aliases: &HashMap<String, String>,
+        checker: Option<&TypeChecker>,
     ) -> bool {
         // Iron — A4: `Type::Invalid` is the checker's "we already
         // reported an error here, don't compound it" sentinel.
@@ -533,61 +829,73 @@ impl TypeChecker {
             Type::Str => matches!(actual, Type::Str),
             Type::Bool => matches!(actual, Type::Bool),
             Type::Unit => matches!(actual, Type::Unit),
-            Type::Named(expected_name) => match actual {
-                // Iron — A3: bare ↔ canonical resolves through
-                // `sig_aliases`. After A3, fn / record / variant
-                // signatures live under their "Module.Type" key and
-                // mirror a bare-name alias in `sig_aliases`; source
-                // expressions stamp Spanned.ty in whatever form the
-                // user wrote. Resolve both sides to the canonical
-                // form first, then compare strictly. Two distinct
-                // modules both exposing "Shape" still produce
-                // ambiguous aliases at registration time — that's
-                // surfaced upfront elsewhere; here we only need to
-                // know that whatever bare form survives in
-                // `sig_aliases` IS the unique canonical.
-                Type::Named(actual_name) => {
-                    let exp_canon = aliases
-                        .get(expected_name)
-                        .map(String::as_str)
-                        .unwrap_or(expected_name);
-                    let act_canon = aliases
-                        .get(actual_name)
-                        .map(String::as_str)
-                        .unwrap_or(actual_name);
-                    act_canon == exp_canon
+            Type::Named {
+                id: expected_id,
+                name: expected_name,
+            } => match actual {
+                // Phase B: typed-identity comparison. When both sides
+                // carry a `TypeId` (resolved against the symbol table)
+                // we compare IDs directly — two unrelated modules
+                // declaring `Shape` get distinct `TypeId`s by
+                // construction and so stay incompatible. When the
+                // checker is available we resolve either side's bare
+                // string through `resolve_type_id` to bring it into
+                // the typed identity domain; without the checker (or
+                // for references that don't resolve, like builtin
+                // `HttpResponse`) we fall back to canonical-name
+                // equality.
+                Type::Named {
+                    id: actual_id,
+                    name: actual_name,
+                } => {
+                    let exp_id = expected_id
+                        .or_else(|| checker.and_then(|c| c.resolve_type_id(expected_name)));
+                    let act_id =
+                        actual_id.or_else(|| checker.and_then(|c| c.resolve_type_id(actual_name)));
+                    match (exp_id, act_id) {
+                        (Some(e), Some(a)) => e == a,
+                        _ => {
+                            let exp = checker
+                                .map(|c| c.canonical_type_name(expected_name))
+                                .unwrap_or_else(|| expected_name.clone());
+                            let act = checker
+                                .map(|c| c.canonical_type_name(actual_name))
+                                .unwrap_or_else(|| actual_name.clone());
+                            exp == act
+                        }
+                    }
                 }
                 _ => false,
             },
             Type::Option(expected_inner) => match actual {
                 Type::Option(actual_inner) => {
-                    Self::match_expected_type_inner(actual_inner, expected_inner, subst, aliases)
+                    Self::match_expected_type_inner(actual_inner, expected_inner, subst, checker)
                 }
                 _ => false,
             },
             Type::List(expected_inner) => match actual {
                 Type::List(actual_inner) => {
-                    Self::match_expected_type_inner(actual_inner, expected_inner, subst, aliases)
+                    Self::match_expected_type_inner(actual_inner, expected_inner, subst, checker)
                 }
                 _ => false,
             },
             Type::Vector(expected_inner) => match actual {
                 Type::Vector(actual_inner) => {
-                    Self::match_expected_type_inner(actual_inner, expected_inner, subst, aliases)
+                    Self::match_expected_type_inner(actual_inner, expected_inner, subst, checker)
                 }
                 _ => false,
             },
             Type::Result(expected_ok, expected_err) => match actual {
                 Type::Result(actual_ok, actual_err) => {
-                    Self::match_expected_type_inner(actual_ok, expected_ok, subst, aliases)
-                        && Self::match_expected_type_inner(actual_err, expected_err, subst, aliases)
+                    Self::match_expected_type_inner(actual_ok, expected_ok, subst, checker)
+                        && Self::match_expected_type_inner(actual_err, expected_err, subst, checker)
                 }
                 _ => false,
             },
             Type::Map(expected_k, expected_v) => match actual {
                 Type::Map(actual_k, actual_v) => {
-                    Self::match_expected_type_inner(actual_k, expected_k, subst, aliases)
-                        && Self::match_expected_type_inner(actual_v, expected_v, subst, aliases)
+                    Self::match_expected_type_inner(actual_k, expected_k, subst, checker)
+                        && Self::match_expected_type_inner(actual_v, expected_v, subst, checker)
                 }
                 _ => false,
             },
@@ -599,7 +907,7 @@ impl TypeChecker {
                                 actual_item,
                                 expected_item,
                                 subst,
-                                aliases,
+                                checker,
                             )
                         },
                     )
@@ -616,10 +924,10 @@ impl TypeChecker {
                                 actual_param,
                                 expected_param,
                                 subst,
-                                aliases,
+                                checker,
                             )
                         },
-                    ) && Self::match_expected_type_inner(actual_ret, expected_ret, subst, aliases)
+                    ) && Self::match_expected_type_inner(actual_ret, expected_ret, subst, checker)
                         && actual_effects.iter().all(|actual| {
                             expected_effects
                                 .iter()
@@ -679,7 +987,7 @@ impl TypeChecker {
             | Type::Bool
             | Type::Unit
             | Type::Invalid
-            | Type::Named(_) => false,
+            | Type::Named { .. } => false,
             Type::Option(inner) | Type::List(inner) | Type::Vector(inner) => {
                 Self::type_contains_var(inner, name)
             }
@@ -729,7 +1037,7 @@ impl TypeChecker {
             | Type::Bool
             | Type::Unit
             | Type::Invalid
-            | Type::Named(_) => ty.clone(),
+            | Type::Named { .. } => ty.clone(),
         }
     }
 }

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -382,13 +382,16 @@ impl RecordFieldKey {
 
 /// Bare-name resolution result. Tracks ambiguity explicitly so
 /// `resolve_fn_id` / `resolve_type_id` can refuse the look-up when
-/// two distinct identities surface the same source name (without that
-/// distinction the bare alias would be last-write-wins — peer review
-/// flagged this on PR #148).
+/// two distinct identities surface the same source name. The
+/// `Ambiguous` variant carries the actual candidate IDs (only those
+/// that made it through visibility, since that's the population
+/// path) so diagnostics can suggest exactly the names the user can
+/// actually pick from — never a private dep type that happens to
+/// share the bare name.
 #[derive(Debug, Clone)]
 enum Resolution<T> {
     Single(T),
-    Ambiguous,
+    Ambiguous(Vec<T>),
 }
 
 impl<T: Copy + PartialEq> Resolution<T> {
@@ -399,15 +402,22 @@ impl<T: Copy + PartialEq> Resolution<T> {
     fn merge(&mut self, candidate: T) {
         match self {
             Resolution::Single(existing) if *existing == candidate => {}
-            Resolution::Single(_) => *self = Resolution::Ambiguous,
-            Resolution::Ambiguous => {}
+            Resolution::Single(existing) => {
+                let prior = *existing;
+                *self = Resolution::Ambiguous(vec![prior, candidate]);
+            }
+            Resolution::Ambiguous(seen) => {
+                if !seen.contains(&candidate) {
+                    seen.push(candidate);
+                }
+            }
         }
     }
 
     fn unambiguous(&self) -> Option<T> {
         match self {
             Resolution::Single(v) => Some(*v),
-            Resolution::Ambiguous => None,
+            Resolution::Ambiguous(_) => None,
         }
     }
 }
@@ -611,25 +621,23 @@ impl TypeChecker {
     pub(crate) fn type_name_is_ambiguous(&self, name: &str) -> bool {
         matches!(
             self.bare_type_aliases.get(name),
-            Some(Resolution::Ambiguous)
+            Some(Resolution::Ambiguous(_))
         )
     }
 
-    /// List the canonical names of every type sharing `bare`. Used
-    /// to produce a helpful "use `A.Foo` or `B.Foo`" diagnostic when
-    /// an ambiguous bare reference surfaces in source. Returns an
-    /// empty list when the name isn't ambiguous (the caller doesn't
-    /// emit a diagnostic in that case).
+    /// List the canonical names of every type that the bare alias map
+    /// recorded as a candidate for `bare`. The `Resolution::Ambiguous`
+    /// variant carries the actual conflicting `TypeId`s populated
+    /// through visibility-exposed aliases — never scans the full
+    /// `symbol_table.types`, so a private (non-exposed) dep type that
+    /// happens to share a bare name never appears in the diagnostic.
     pub(crate) fn ambiguous_type_candidates(&self, bare: &str) -> Vec<String> {
-        if !self.type_name_is_ambiguous(bare) {
+        let Some(Resolution::Ambiguous(ids)) = self.bare_type_aliases.get(bare) else {
             return Vec::new();
-        }
-        let mut out: Vec<String> = self
-            .symbol_table
-            .types
+        };
+        let mut out: Vec<String> = ids
             .iter()
-            .filter(|e| e.key.name == bare)
-            .map(|e| e.key.canonical())
+            .map(|id| self.symbol_table.type_entry(*id).key.canonical())
             .collect();
         out.sort();
         out

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -204,18 +204,32 @@ fn finalize_check_result(mut checker: TypeChecker, items: &[TopLevel]) -> TypeCh
         checker.fn_sigs.iter().map(|(id, sig)| (*id, sig)).collect();
     ordered_user.sort_by_key(|(id, _)| id.0);
 
-    let mut bare_owners: HashMap<String, FnId> = HashMap::new();
-    let mut bare_ambiguous: HashSet<String> = HashSet::new();
+    // Tally bare-name owners. Phase B (peer review round 2): an
+    // entry-scope fn shadows any dep-module fn sharing the same bare
+    // name — source-level `doit()` inside `Main` unambiguously means
+    // `Main.doit`, even when a dep also exposes `doit`. We therefore
+    // suppress the bare alias only for dep-dep ambiguity (multiple
+    // dep modules share a bare name *and* the entry doesn't define
+    // one). When the entry owns the bare name, the bare alias points
+    // at the entry FnId; dep fns stay reachable only by qualified
+    // name.
+    let mut bare_entry_owner: HashMap<String, FnId> = HashMap::new();
+    let mut bare_dep_owners: HashMap<String, FnId> = HashMap::new();
+    let mut bare_dep_ambiguous: HashSet<String> = HashSet::new();
     for (id, _) in &ordered_user {
         let entry = checker.symbol_table.fn_entry(*id);
         let bare = entry.key.name.as_str();
-        match bare_owners.get(bare) {
+        if entry.module.is_entry() {
+            bare_entry_owner.insert(bare.to_string(), *id);
+            continue;
+        }
+        match bare_dep_owners.get(bare) {
             None => {
-                bare_owners.insert(bare.to_string(), *id);
+                bare_dep_owners.insert(bare.to_string(), *id);
             }
             Some(prior) if prior == id => {}
             Some(_) => {
-                bare_ambiguous.insert(bare.to_string());
+                bare_dep_ambiguous.insert(bare.to_string());
             }
         }
     }
@@ -232,10 +246,24 @@ fn finalize_check_result(mut checker: TypeChecker, items: &[TopLevel]) -> TypeCh
         };
         let triple = (sig.params.clone(), sig.ret.clone(), sig.effects.clone());
         fn_sigs.insert(canonical.clone(), triple.clone());
-        // Bare alias only when there's no conflict between distinct
-        // modules' fns sharing the same bare name. The canonical key
-        // is always present so consumers can fall back to it.
-        if entry.key.name != canonical && !bare_ambiguous.contains(&entry.key.name) {
+        // Bare alias rules:
+        //  - entry-scope owner always wins (shadows any dep with the
+        //    same bare name);
+        //  - dep-scope fn gets the bare alias only when (a) the entry
+        //    doesn't own it and (b) no other dep module conflicts.
+        if entry.key.name == canonical {
+            continue;
+        }
+        let is_entry_owner = bare_entry_owner.get(&entry.key.name) == Some(id);
+        let mut emit_bare = false;
+        if entry.module.is_entry() {
+            emit_bare = is_entry_owner;
+        } else if !bare_entry_owner.contains_key(&entry.key.name)
+            && !bare_dep_ambiguous.contains(&entry.key.name)
+        {
+            emit_bare = true;
+        }
+        if emit_bare {
             fn_sigs.entry(entry.key.name.clone()).or_insert(triple);
         }
     }
@@ -570,6 +598,21 @@ impl TypeChecker {
         self.bare_fn_aliases
             .get(name)
             .and_then(Resolution::unambiguous)
+    }
+
+    /// `true` when the bare alias map has recorded multiple distinct
+    /// `TypeId`s for `name` (cross-module same-bare-name import).
+    /// Distinct from "name doesn't resolve at all" — used by the
+    /// matcher to decide whether a mixed (Some, None) typed/raw
+    /// comparison should fall back to name equality (only when the
+    /// `None` side is genuinely a builtin / external name, not when
+    /// it's ambiguous bare reference whose typed identity we
+    /// deliberately suppressed).
+    pub(crate) fn type_name_is_ambiguous(&self, name: &str) -> bool {
+        matches!(
+            self.bare_type_aliases.get(name),
+            Some(Resolution::Ambiguous)
+        )
     }
 
     /// Register a bare → `FnId` alias, marking it `Ambiguous` if a
@@ -943,9 +986,42 @@ impl TypeChecker {
                         .or_else(|| checker.and_then(|c| c.resolve_type_id(expected_name)));
                     let act_id =
                         actual_id.or_else(|| checker.and_then(|c| c.resolve_type_id(actual_name)));
+                    // Phase B (peer review round 2): the typed-identity
+                    // comparison must reject mixed (Some, None) cases
+                    // for user-defined types — otherwise an ambiguous
+                    // bare reference (`Shape` when both `A.Shape` and
+                    // `B.Shape` are exposed) silently matches against
+                    // any specific `A.Shape` / `B.Shape` via the
+                    // string fallback below. Distinguish "ambiguous
+                    // bare reference, identity deliberately
+                    // suppressed" from "builtin name that has no
+                    // typed identity by design (`HttpResponse`,
+                    // `Buffer`, …)" by asking the checker whether the
+                    // unresolved side's name is recorded as
+                    // ambiguous; reject in that case, allow name
+                    // fallback otherwise.
                     match (exp_id, act_id) {
                         (Some(e), Some(a)) => e == a,
-                        _ => {
+                        (Some(_), None) | (None, Some(_)) => {
+                            let unresolved = if exp_id.is_none() {
+                                expected_name
+                            } else {
+                                actual_name
+                            };
+                            if checker.is_some_and(|c| c.type_name_is_ambiguous(unresolved)) {
+                                return false;
+                            }
+                            // Builtin / external name: allow strict
+                            // name equality so two stamps of the same
+                            // builtin (`HttpResponse` vs
+                            // `HttpResponse`) still match. No suffix
+                            // fallback — that would let
+                            // `"A.Shape"` swallow a bare `"Shape"`
+                            // and re-introduce the cross-module
+                            // collapse.
+                            expected_name == actual_name
+                        }
+                        (None, None) => {
                             let exp = checker
                                 .map(|c| c.canonical_type_name(expected_name))
                                 .unwrap_or_else(|| expected_name.clone());

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -615,6 +615,101 @@ impl TypeChecker {
         )
     }
 
+    /// List the canonical names of every type sharing `bare`. Used
+    /// to produce a helpful "use `A.Foo` or `B.Foo`" diagnostic when
+    /// an ambiguous bare reference surfaces in source. Returns an
+    /// empty list when the name isn't ambiguous (the caller doesn't
+    /// emit a diagnostic in that case).
+    pub(crate) fn ambiguous_type_candidates(&self, bare: &str) -> Vec<String> {
+        if !self.type_name_is_ambiguous(bare) {
+            return Vec::new();
+        }
+        let mut out: Vec<String> = self
+            .symbol_table
+            .types
+            .iter()
+            .filter(|e| e.key.name == bare)
+            .map(|e| e.key.canonical())
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// Walk `ty` and emit one diagnostic per distinct ambiguous bare
+    /// name reachable from it. Called from the signature-registration
+    /// boundary (`build_signatures`, `register_type_def_sigs`) so the
+    /// user gets a clean "Ambiguous type name 'Foo'; use `A.Foo` or
+    /// `B.Foo`" message instead of the downstream `expected Foo, got
+    /// Foo` cascade the matcher otherwise produces.
+    pub(super) fn report_ambiguous_named(&mut self, ty: &Type, line: usize, source_ctx: &str) {
+        let mut seen: HashSet<String> = HashSet::new();
+        self.collect_ambiguous_into(ty, &mut seen);
+        for name in seen {
+            let candidates = self.ambiguous_type_candidates(&name);
+            if candidates.is_empty() {
+                continue;
+            }
+            let suggestion = match candidates.as_slice() {
+                [a] => a.clone(),
+                [a, b] => format!("`{}` or `{}`", a, b),
+                more => {
+                    let last = more.last().expect("non-empty");
+                    let head = &more[..more.len() - 1];
+                    let joined = head
+                        .iter()
+                        .map(|c| format!("`{}`", c))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("{}, or `{}`", joined, last)
+                }
+            };
+            self.error_at_line(
+                line,
+                format!(
+                    "{source_ctx}: Ambiguous type name '{name}'; use {suggestion} to disambiguate"
+                ),
+            );
+        }
+    }
+
+    fn collect_ambiguous_into(&self, ty: &Type, out: &mut HashSet<String>) {
+        match ty {
+            Type::Named { id: None, name } if self.type_name_is_ambiguous(name) => {
+                out.insert(name.clone());
+            }
+            Type::Named { .. }
+            | Type::Int
+            | Type::Float
+            | Type::Str
+            | Type::Bool
+            | Type::Unit
+            | Type::Var(_)
+            | Type::Invalid => {}
+            Type::Option(inner) | Type::List(inner) | Type::Vector(inner) => {
+                self.collect_ambiguous_into(inner, out);
+            }
+            Type::Result(ok, err) => {
+                self.collect_ambiguous_into(ok, out);
+                self.collect_ambiguous_into(err, out);
+            }
+            Type::Map(k, v) => {
+                self.collect_ambiguous_into(k, out);
+                self.collect_ambiguous_into(v, out);
+            }
+            Type::Tuple(items) => {
+                for item in items {
+                    self.collect_ambiguous_into(item, out);
+                }
+            }
+            Type::Fn(params, ret, _) => {
+                for p in params {
+                    self.collect_ambiguous_into(p, out);
+                }
+                self.collect_ambiguous_into(ret, out);
+            }
+        }
+    }
+
     /// Register a bare → `FnId` alias, marking it `Ambiguous` if a
     /// different identity is already registered under the same bare
     /// name. Duplicate registration of the same identity (e.g. an

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -180,19 +180,47 @@ pub fn run_type_check_with_loaded_self_host(
 }
 
 fn finalize_check_result(mut checker: TypeChecker, items: &[TopLevel]) -> TypeCheckResult {
-    // Phase B: build the exported string-keyed map by flattening both
-    // halves of the internal split (`fn_sigs` keyed by `FnId`,
-    // `extra_sigs` keyed by canonical string). External consumers
-    // (`verify_effects`, Lean / Dafny codegen, the CLI summary,
-    // `diagnostics::context::callgraph`) continue to look entries up by
-    // bare or canonical name. For entry-scope fns inside an
-    // `module X` declaration we mirror the entry under both
-    // `"X.name"` (TypeChecker canonical) and the bare name; for
-    // module-scoped fns we keep the symbol table's canonical plus a
-    // bare alias mirror.
+    // Phase B (post peer-review #148): flatten the internal split
+    // (`fn_sigs` keyed by `FnId`, `extra_sigs` keyed by canonical
+    // string) into the exported `HashMap<String, _>` external
+    // consumers expect. The old bare-alias mirror was last-write-wins
+    // across modules: when two distinct dep modules each exposed `foo`,
+    // one would silently win the global `"foo"` slot and Rust codegen's
+    // `ctx.fn_sigs.get(&fd.name)` could pick up the wrong signature.
+    //
+    // Now bare aliases land only when unambiguous. Each canonical key
+    // is always present; bare-name keys land only when no other fn in
+    // the program shares that bare name. Consumers that previously
+    // relied on a non-deterministic global "foo" entry will see a miss
+    // and surface a clear "qualify the reference" error instead of
+    // mismatched parameters.
     let entry_prefix = checker.current_module_prefix.clone();
     let mut fn_sigs: HashMap<String, (Vec<Type>, Type, Vec<String>)> = HashMap::new();
-    for (id, sig) in &checker.fn_sigs {
+
+    // Iterate in `FnId` order for deterministic output (HashMap
+    // iteration order would otherwise leak non-determinism into the
+    // exported map and downstream diagnostics).
+    let mut ordered_user: Vec<(FnId, &FnSig)> =
+        checker.fn_sigs.iter().map(|(id, sig)| (*id, sig)).collect();
+    ordered_user.sort_by_key(|(id, _)| id.0);
+
+    let mut bare_owners: HashMap<String, FnId> = HashMap::new();
+    let mut bare_ambiguous: HashSet<String> = HashSet::new();
+    for (id, _) in &ordered_user {
+        let entry = checker.symbol_table.fn_entry(*id);
+        let bare = entry.key.name.as_str();
+        match bare_owners.get(bare) {
+            None => {
+                bare_owners.insert(bare.to_string(), *id);
+            }
+            Some(prior) if prior == id => {}
+            Some(_) => {
+                bare_ambiguous.insert(bare.to_string());
+            }
+        }
+    }
+
+    for (id, sig) in &ordered_user {
         let entry = checker.symbol_table.fn_entry(*id);
         let canonical = if entry.module.is_entry() {
             match entry_prefix.as_deref() {
@@ -204,10 +232,10 @@ fn finalize_check_result(mut checker: TypeChecker, items: &[TopLevel]) -> TypeCh
         };
         let triple = (sig.params.clone(), sig.ret.clone(), sig.effects.clone());
         fn_sigs.insert(canonical.clone(), triple.clone());
-        // Mirror bare alias so existing bare-name external callers
-        // keep resolving regardless of whether the canonical carries
-        // a module prefix.
-        if entry.key.name != canonical {
+        // Bare alias only when there's no conflict between distinct
+        // modules' fns sharing the same bare name. The canonical key
+        // is always present so consumers can fall back to it.
+        if entry.key.name != canonical && !bare_ambiguous.contains(&entry.key.name) {
             fn_sigs.entry(entry.key.name.clone()).or_insert(triple);
         }
     }
@@ -324,6 +352,38 @@ impl RecordFieldKey {
     }
 }
 
+/// Bare-name resolution result. Tracks ambiguity explicitly so
+/// `resolve_fn_id` / `resolve_type_id` can refuse the look-up when
+/// two distinct identities surface the same source name (without that
+/// distinction the bare alias would be last-write-wins — peer review
+/// flagged this on PR #148).
+#[derive(Debug, Clone)]
+enum Resolution<T> {
+    Single(T),
+    Ambiguous,
+}
+
+impl<T: Copy + PartialEq> Resolution<T> {
+    /// Merge another candidate identity into an alias entry. Two
+    /// distinct identities for the same bare name produce
+    /// `Ambiguous`; a duplicate registration of the same identity is
+    /// a no-op (same module re-traversed by another path).
+    fn merge(&mut self, candidate: T) {
+        match self {
+            Resolution::Single(existing) if *existing == candidate => {}
+            Resolution::Single(_) => *self = Resolution::Ambiguous,
+            Resolution::Ambiguous => {}
+        }
+    }
+
+    fn unambiguous(&self) -> Option<T> {
+        match self {
+            Resolution::Single(v) => Some(*v),
+            Resolution::Ambiguous => None,
+        }
+    }
+}
+
 struct TypeChecker {
     /// Resolved-identity table — phase B (#138). Populated by
     /// [`TypeChecker::new_with_symbols`] from the program's `entry_items
@@ -359,11 +419,19 @@ struct TypeChecker {
     /// `sig_aliases: HashMap<String, String>`: same bare-name routing
     /// role, but the value side now carries opaque identity instead
     /// of a string that needed re-resolution downstream.
-    bare_fn_aliases: HashMap<String, FnId>,
+    ///
+    /// When two distinct modules each expose the same bare name
+    /// (`Pricing.percent` *and* `Math.percent` both surface a bare
+    /// `percent`), the entry switches to [`Resolution::Ambiguous`]
+    /// and `resolve_fn_id` refuses to silently pick one — the user
+    /// must qualify the reference. Avoids the
+    /// "global bare alias last-wins" bug class peer review #148
+    /// flagged.
+    bare_fn_aliases: HashMap<String, Resolution<FnId>>,
     /// Bare → `TypeId` aliases. Same role as `bare_fn_aliases`
     /// for the type-name dimension; consumed by `resolve_type_id`
     /// and `canonical_type_name`.
-    bare_type_aliases: HashMap<String, TypeId>,
+    bare_type_aliases: HashMap<String, Resolution<TypeId>>,
     value_members: HashMap<String, Type>,
     /// Field types for record types, keyed by `(type_name, field_name)`.
     /// Populated for both user-defined `record` types and built-in records
@@ -496,10 +564,31 @@ impl TypeChecker {
         // typed replacement for the pre-phase-B `sig_aliases` map.
         // Populated by `integrate_registry` from visibility-exposed
         // aliases (and by `build_signatures` for the current module's
-        // own fns), so a bare reference to an imported fn picks up
-        // its `FnId` here even when the symbol-table key would need a
-        // scope hint to find it.
-        self.bare_fn_aliases.get(name).copied()
+        // own fns). Returns `None` when two distinct modules surface
+        // the same bare name so the caller can refuse the look-up
+        // instead of last-write-wins.
+        self.bare_fn_aliases
+            .get(name)
+            .and_then(Resolution::unambiguous)
+    }
+
+    /// Register a bare → `FnId` alias, marking it `Ambiguous` if a
+    /// different identity is already registered under the same bare
+    /// name. Duplicate registration of the same identity (e.g. an
+    /// item walked twice by `integrate_registry` + `build_signatures`)
+    /// is a no-op.
+    pub(super) fn merge_bare_fn_alias(&mut self, alias: String, id: FnId) {
+        self.bare_fn_aliases
+            .entry(alias)
+            .and_modify(|r| r.merge(id))
+            .or_insert(Resolution::Single(id));
+    }
+
+    pub(super) fn merge_bare_type_alias(&mut self, alias: String, id: TypeId) {
+        self.bare_type_aliases
+            .entry(alias)
+            .and_modify(|r| r.merge(id))
+            .or_insert(Resolution::Single(id));
     }
 
     /// Type-side equivalent of [`Self::resolve_fn_id`].
@@ -524,7 +613,9 @@ impl TypeChecker {
         if let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(name)) {
             return Some(id);
         }
-        self.bare_type_aliases.get(name).copied()
+        self.bare_type_aliases
+            .get(name)
+            .and_then(Resolution::unambiguous)
     }
 
     /// Canonical name (`"Module.Type"` or bare entry name) for a

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -488,6 +488,16 @@ struct TypeChecker {
     /// flagged on `fn takes(s: C.Shape)` references against a `C`
     /// whose `exposes` list didn't include `Shape`.
     visible_type_ids: HashSet<TypeId>,
+    /// Per-module `depends` list, keyed by the dep module's
+    /// `dep_name`. Populated by `integrate_loaded_modules` so the
+    /// per-owner type resolver (`canonicalize_named_in_module`) can
+    /// walk an owner module's *own* depends when canonicalising its
+    /// exported signatures — not the entry module's or arbitrary
+    /// loaded siblings'. Round-6 peer review caught the leak: B
+    /// depends on A; Main depends on B, C; B's bare `Shape` was
+    /// resolving against `[A, C]` (Main's loaded tree) instead of
+    /// `[A]` (B's own depends), and `Shape` came back ambiguous.
+    module_depends: HashMap<String, Vec<String>>,
     value_members: HashMap<String, Type>,
     /// Field types for record types, keyed by `(type_name, field_name)`.
     /// Populated for both user-defined `record` types and built-in records
@@ -563,6 +573,7 @@ impl TypeChecker {
             bare_type_aliases: HashMap::new(),
             visible_fn_ids: HashSet::new(),
             visible_type_ids: HashSet::new(),
+            module_depends: HashMap::new(),
             value_members: HashMap::new(),
             record_field_types: HashMap::new(),
             type_variants,
@@ -1234,10 +1245,21 @@ impl TypeChecker {
                     id: actual_id,
                     name: actual_name,
                 } => {
-                    let exp_id = expected_id
-                        .or_else(|| checker.and_then(|c| c.resolve_type_id(expected_name)));
-                    let act_id =
-                        actual_id.or_else(|| checker.and_then(|c| c.resolve_type_id(actual_name)));
+                    // Peer review round 6: do NOT auto-resolve an
+                    // unresolved side in the matcher's
+                    // (importer-context) symbol table. Upstream
+                    // signature/binding boundaries
+                    // (`canonicalize_named`,
+                    // `canonicalize_named_in_module`) are
+                    // responsible for stamping `id` in the correct
+                    // owner context. If a `Type::Named` reaches the
+                    // matcher with `id = None`, that's a deliberate
+                    // unresolved state — either a genuine builtin
+                    // (HttpResponse) or a resolution gap the matcher
+                    // must surface, not silently paper over by
+                    // re-resolving in the wrong scope.
+                    let exp_id = *expected_id;
+                    let act_id = *actual_id;
                     // Phase B (peer review round 2): the typed-identity
                     // comparison must reject mixed (Some, None) cases
                     // for user-defined types — otherwise an ambiguous
@@ -1254,25 +1276,15 @@ impl TypeChecker {
                     // fallback otherwise.
                     match (exp_id, act_id) {
                         (Some(e), Some(a)) => e == a,
-                        (Some(_), None) | (None, Some(_)) => {
-                            let unresolved = if exp_id.is_none() {
-                                expected_name
-                            } else {
-                                actual_name
-                            };
-                            if checker.is_some_and(|c| c.type_name_is_ambiguous(unresolved)) {
-                                return false;
-                            }
-                            // Builtin / external name: allow strict
-                            // name equality so two stamps of the same
-                            // builtin (`HttpResponse` vs
-                            // `HttpResponse`) still match. No suffix
-                            // fallback — that would let
-                            // `"A.Shape"` swallow a bare `"Shape"`
-                            // and re-introduce the cross-module
-                            // collapse.
-                            expected_name == actual_name
-                        }
+                        // Peer review round 6 entry-fallback bug:
+                        // a dep module's unresolved bare `Shape` was
+                        // silently binding to the entry module's
+                        // `Shape` via name equality here. Reject all
+                        // mixed (Some, None) cases. Builtins always
+                        // exercise (None, None) below; user-source
+                        // typed/raw mixes are by definition a
+                        // resolution gap and must surface.
+                        (Some(_), None) | (None, Some(_)) => false,
                         (None, None) => {
                             let exp = checker
                                 .map(|c| c.canonical_type_name(expected_name))

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -470,6 +470,24 @@ struct TypeChecker {
     /// for the type-name dimension; consumed by `resolve_type_id`
     /// and `canonical_type_name`.
     bare_type_aliases: HashMap<String, Resolution<TypeId>>,
+    /// `FnId`s the current checker may legitimately resolve to.
+    /// Populated from `build_signatures` (the current module's own
+    /// fns — always visible from within the module) and from
+    /// `integrate_registry` (visibility-exposed entries from each
+    /// dep module — already filtered against the `exposes` contract
+    /// by `crate::visibility::SymbolRegistry::from_modules`).
+    ///
+    /// `resolve_fn_id` consults this set so a qualified
+    /// `C.helper()` reference fails when `helper` isn't exposed even
+    /// though the symbol table — which carries every fn from every
+    /// dep module regardless of visibility — has its `FnId`.
+    visible_fn_ids: HashSet<FnId>,
+    /// `TypeId`s the current checker may legitimately resolve to.
+    /// Same role as `visible_fn_ids` for the type-name dimension —
+    /// closes the qualified-private-import leak peer review round 4
+    /// flagged on `fn takes(s: C.Shape)` references against a `C`
+    /// whose `exposes` list didn't include `Shape`.
+    visible_type_ids: HashSet<TypeId>,
     value_members: HashMap<String, Type>,
     /// Field types for record types, keyed by `(type_name, field_name)`.
     /// Populated for both user-defined `record` types and built-in records
@@ -543,6 +561,8 @@ impl TypeChecker {
             extra_sigs: HashMap::new(),
             bare_fn_aliases: HashMap::new(),
             bare_type_aliases: HashMap::new(),
+            visible_fn_ids: HashSet::new(),
+            visible_type_ids: HashSet::new(),
             value_members: HashMap::new(),
             record_field_types: HashMap::new(),
             type_variants,
@@ -575,36 +595,38 @@ impl TypeChecker {
     /// don't live in the program symbol table; callers fall back to
     /// the `extra_sigs` string-keyed half.
     pub(crate) fn resolve_fn_id(&self, name: &str) -> Option<FnId> {
+        // Phase B (peer review round 4): every `SymbolTable`
+        // resolution path filters through `visible_fn_ids` so a
+        // qualified `C.helper()` reference can't reach into a dep
+        // module's private fn just because the symbol table
+        // unconditionally stores every dep entry. Bare-name lookup
+        // already went through `bare_fn_aliases`, which is itself
+        // populated only from visibility-exposed entries — that
+        // branch stays as-is.
         if let Some((prefix, n)) = name.rsplit_once('.') {
-            if let Some(id) = self.symbol_table.fn_id_of(&FnKey::in_module(prefix, n)) {
+            if let Some(id) = self.symbol_table.fn_id_of(&FnKey::in_module(prefix, n))
+                && self.visible_fn_ids.contains(&id)
+            {
                 return Some(id);
             }
-            // Entry items that declare `module Rogue` still live
-            // under `FnKey::entry` in the symbol table — only
-            // dep modules occupy real module scopes. Fall back to
-            // entry-scope lookup when the qualified prefix matches
-            // the current scope's declared module name.
             if self.current_module_prefix.as_deref() == Some(prefix)
                 && let Some(id) = self.symbol_table.fn_id_of(&FnKey::entry(n))
+                && self.visible_fn_ids.contains(&id)
             {
                 return Some(id);
             }
         }
         if let Some(prefix) = self.current_module_prefix.as_deref()
             && let Some(id) = self.symbol_table.fn_id_of(&FnKey::in_module(prefix, name))
+            && self.visible_fn_ids.contains(&id)
         {
             return Some(id);
         }
-        if let Some(id) = self.symbol_table.fn_id_of(&FnKey::entry(name)) {
+        if let Some(id) = self.symbol_table.fn_id_of(&FnKey::entry(name))
+            && self.visible_fn_ids.contains(&id)
+        {
             return Some(id);
         }
-        // Cross-module bare-name imports — `bare_fn_aliases` is the
-        // typed replacement for the pre-phase-B `sig_aliases` map.
-        // Populated by `integrate_registry` from visibility-exposed
-        // aliases (and by `build_signatures` for the current module's
-        // own fns). Returns `None` when two distinct modules surface
-        // the same bare name so the caller can refuse the look-up
-        // instead of last-write-wins.
         self.bare_fn_aliases
             .get(name)
             .and_then(Resolution::unambiguous)
@@ -643,16 +665,25 @@ impl TypeChecker {
         out
     }
 
-    /// Walk `ty` and emit one diagnostic per distinct ambiguous bare
-    /// name reachable from it. Called from the signature-registration
-    /// boundary (`build_signatures`, `register_type_def_sigs`) so the
-    /// user gets a clean "Ambiguous type name 'Foo'; use `A.Foo` or
-    /// `B.Foo`" message instead of the downstream `expected Foo, got
-    /// Foo` cascade the matcher otherwise produces.
+    /// Walk `ty` and emit diagnostics for every distinct unresolved
+    /// reason the typechecker deliberately blocked resolution.
+    /// Called from the signature-registration boundary
+    /// (`build_signatures`, `register_type_def_sigs`, flow's binding
+    /// annotations) so the user gets a clean explanation instead of
+    /// downstream `expected X, got X` cascades. Two reasons are
+    /// surfaced:
+    ///
+    ///   - Ambiguous bare reference: `Foo` matches multiple
+    ///     visibility-exposed `TypeId`s. Diagnostic suggests the
+    ///     qualified forms.
+    ///   - Private qualified import: `Module.Foo` exists in the
+    ///     symbol table but isn't on `Module`'s `exposes` list.
+    ///     Diagnostic names the dep + asks for the export.
     pub(super) fn report_ambiguous_named(&mut self, ty: &Type, line: usize, source_ctx: &str) {
-        let mut seen: HashSet<String> = HashSet::new();
-        self.collect_ambiguous_into(ty, &mut seen);
-        for name in seen {
+        let mut seen_ambig: HashSet<String> = HashSet::new();
+        let mut seen_private: HashSet<String> = HashSet::new();
+        self.collect_unresolved_into(ty, &mut seen_ambig, &mut seen_private);
+        for name in seen_ambig {
             let candidates = self.ambiguous_type_candidates(&name);
             if candidates.is_empty() {
                 continue;
@@ -678,12 +709,33 @@ impl TypeChecker {
                 ),
             );
         }
+        for qualified in seen_private {
+            let (module, type_name) = qualified
+                .rsplit_once('.')
+                .map(|(m, t)| (m.to_string(), t.to_string()))
+                .expect("private qualified name always has a `.`");
+            self.error_at_line(
+                line,
+                format!(
+                    "{source_ctx}: Type '{qualified}' is not exposed by module '{module}' — add '{type_name}' to its `exposes` list to import it",
+                ),
+            );
+        }
     }
 
-    fn collect_ambiguous_into(&self, ty: &Type, out: &mut HashSet<String>) {
+    fn collect_unresolved_into(
+        &self,
+        ty: &Type,
+        ambig: &mut HashSet<String>,
+        private: &mut HashSet<String>,
+    ) {
         match ty {
-            Type::Named { id: None, name } if self.type_name_is_ambiguous(name) => {
-                out.insert(name.clone());
+            Type::Named { id: None, name } => {
+                if self.type_name_is_ambiguous(name) {
+                    ambig.insert(name.clone());
+                } else if self.type_name_is_private_import(name) {
+                    private.insert(name.clone());
+                }
             }
             Type::Named { .. }
             | Type::Int
@@ -694,26 +746,26 @@ impl TypeChecker {
             | Type::Var(_)
             | Type::Invalid => {}
             Type::Option(inner) | Type::List(inner) | Type::Vector(inner) => {
-                self.collect_ambiguous_into(inner, out);
+                self.collect_unresolved_into(inner, ambig, private);
             }
             Type::Result(ok, err) => {
-                self.collect_ambiguous_into(ok, out);
-                self.collect_ambiguous_into(err, out);
+                self.collect_unresolved_into(ok, ambig, private);
+                self.collect_unresolved_into(err, ambig, private);
             }
             Type::Map(k, v) => {
-                self.collect_ambiguous_into(k, out);
-                self.collect_ambiguous_into(v, out);
+                self.collect_unresolved_into(k, ambig, private);
+                self.collect_unresolved_into(v, ambig, private);
             }
             Type::Tuple(items) => {
                 for item in items {
-                    self.collect_ambiguous_into(item, out);
+                    self.collect_unresolved_into(item, ambig, private);
                 }
             }
             Type::Fn(params, ret, _) => {
                 for p in params {
-                    self.collect_ambiguous_into(p, out);
+                    self.collect_unresolved_into(p, ambig, private);
                 }
-                self.collect_ambiguous_into(ret, out);
+                self.collect_unresolved_into(ret, ambig, private);
             }
         }
     }
@@ -737,14 +789,21 @@ impl TypeChecker {
             .or_insert(Resolution::Single(id));
     }
 
-    /// Type-side equivalent of [`Self::resolve_fn_id`].
+    /// Type-side equivalent of [`Self::resolve_fn_id`]. Same
+    /// visibility gating: `SymbolTable` look-ups are filtered through
+    /// `visible_type_ids` so a qualified `C.Shape` reference can't
+    /// resolve to a private (non-exposed) type even though the symbol
+    /// table holds every dep type unconditionally.
     pub(crate) fn resolve_type_id(&self, name: &str) -> Option<TypeId> {
         if let Some((prefix, n)) = name.rsplit_once('.') {
-            if let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n)) {
+            if let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n))
+                && self.visible_type_ids.contains(&id)
+            {
                 return Some(id);
             }
             if self.current_module_prefix.as_deref() == Some(prefix)
                 && let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(n))
+                && self.visible_type_ids.contains(&id)
             {
                 return Some(id);
             }
@@ -753,15 +812,41 @@ impl TypeChecker {
             && let Some(id) = self
                 .symbol_table
                 .type_id_of(&TypeKey::in_module(prefix, name))
+            && self.visible_type_ids.contains(&id)
         {
             return Some(id);
         }
-        if let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(name)) {
+        if let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(name))
+            && self.visible_type_ids.contains(&id)
+        {
             return Some(id);
         }
         self.bare_type_aliases
             .get(name)
             .and_then(Resolution::unambiguous)
+    }
+
+    /// `true` when `name` (qualified `Module.Type` form) resolves to
+    /// an existing `TypeId` in the symbol table but the typechecker
+    /// hasn't registered that ID as visible to the current scope.
+    /// Distinguishes "type doesn't exist anywhere" (silently miss →
+    /// downstream "unknown type" error) from "type exists but its
+    /// dep module doesn't expose it" (explicit private-import
+    /// diagnostic emitted by `report_named_visibility_errors`).
+    pub(crate) fn type_name_is_private_import(&self, name: &str) -> bool {
+        let Some((prefix, n)) = name.rsplit_once('.') else {
+            return false;
+        };
+        if self.current_module_prefix.as_deref() == Some(prefix) {
+            // Self-references like `Main.foo` inside `Main` always
+            // resolve through the entry-scope alias; never a privacy
+            // failure.
+            return false;
+        }
+        let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n)) else {
+            return false;
+        };
+        !self.visible_type_ids.contains(&id)
     }
 
     /// Canonical name (`"Module.Type"` or bare entry name) for a
@@ -923,15 +1008,79 @@ impl TypeChecker {
     /// `FnId`-keyed user map when the name resolves through the
     /// symbol table (i.e. it names a user fn declared in `items` or a
     /// dep module); otherwise it lands in the `extra_sigs` half.
+    ///
+    /// Also marks the `FnId` as visible to the current scope — every
+    /// fn the checker's own `build_signatures` / `integrate_registry`
+    /// path inserts is by definition reachable from here (own module
+    /// items or visibility-exposed dep entries). The visibility
+    /// gating in `resolve_fn_id` then refuses look-ups against any
+    /// `FnId` that landed in the symbol table but not in this set —
+    /// a qualified `C.helper()` reference whose `helper` isn't on
+    /// `C`'s `exposes` list never gets inserted here and so never
+    /// resolves.
     fn insert_fn_sig(&mut self, canonical: &str, sig: FnSig) {
-        match self.resolve_fn_id(canonical) {
+        match self.fn_id_for_canonical(canonical) {
             Some(id) => {
                 self.fn_sigs.insert(id, sig);
+                self.visible_fn_ids.insert(id);
             }
             None => {
                 self.extra_sigs.insert(canonical.to_string(), sig);
             }
         }
+    }
+
+    /// `resolve_fn_id` minus the visibility filter — used by
+    /// `insert_fn_sig` (where the very point of the insert is to
+    /// register visibility) and by other boundary points that build
+    /// the visible set itself. Production look-ups must go through
+    /// `resolve_fn_id`.
+    fn fn_id_for_canonical(&self, name: &str) -> Option<FnId> {
+        if let Some((prefix, n)) = name.rsplit_once('.') {
+            if let Some(id) = self.symbol_table.fn_id_of(&FnKey::in_module(prefix, n)) {
+                return Some(id);
+            }
+            if self.current_module_prefix.as_deref() == Some(prefix)
+                && let Some(id) = self.symbol_table.fn_id_of(&FnKey::entry(n))
+            {
+                return Some(id);
+            }
+        }
+        if let Some(prefix) = self.current_module_prefix.as_deref()
+            && let Some(id) = self.symbol_table.fn_id_of(&FnKey::in_module(prefix, name))
+        {
+            return Some(id);
+        }
+        self.symbol_table.fn_id_of(&FnKey::entry(name))
+    }
+
+    /// Type-side equivalent of [`Self::fn_id_for_canonical`].
+    fn type_id_for_canonical(&self, name: &str) -> Option<TypeId> {
+        if let Some((prefix, n)) = name.rsplit_once('.') {
+            if let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n)) {
+                return Some(id);
+            }
+            if self.current_module_prefix.as_deref() == Some(prefix)
+                && let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(n))
+            {
+                return Some(id);
+            }
+        }
+        if let Some(prefix) = self.current_module_prefix.as_deref()
+            && let Some(id) = self
+                .symbol_table
+                .type_id_of(&TypeKey::in_module(prefix, name))
+        {
+            return Some(id);
+        }
+        self.symbol_table.type_id_of(&TypeKey::entry(name))
+    }
+
+    /// Mark a `TypeId` as visible to the current scope. Called from
+    /// `register_type_def_sigs` (own module types) and
+    /// `integrate_registry` (visibility-exposed dep types).
+    fn mark_type_visible(&mut self, id: TypeId) {
+        self.visible_type_ids.insert(id);
     }
 
     // -- Helpers -----------------------------------------------------------

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -152,6 +152,89 @@ impl TypeChecker {
     /// canonical form resolved through the symbol table. Leaves the
     /// structure intact otherwise — `Type::Var`, primitives,
     /// `Type::List<Bare>` (recurse into inner), etc.
+    /// Owner-aware variant of `canonicalize_named`. Bare `Type::Named`
+    /// references inside `ty` resolve against `owner_module`'s scope
+    /// in the symbol table, ignoring the importer's
+    /// `current_module_prefix` / `bare_type_aliases`. Used by
+    /// `integrate_registry` when integrating a dep module's exported
+    /// signatures: a bare `Shape` in B's `fn make() -> Shape` must
+    /// always stamp as `B.Shape`, regardless of what `Shape` means in
+    /// the importing module.
+    ///
+    /// Resolves through `symbol_table.type_id_of` directly — bypasses
+    /// the visibility filter. Owners always see their own types, and
+    /// the resulting `TypeId` is the soundness anchor downstream
+    /// matcher checks rely on. The importer's visibility is a
+    /// separate concern enforced when the user-source side references
+    /// the type by name.
+    pub(super) fn canonicalize_named_in_module(&self, ty: Type, owner_module: &str) -> Type {
+        match ty {
+            Type::Named { id, name } => {
+                let resolved = if let Some((prefix, n)) = name.rsplit_once('.') {
+                    // Already qualified: trust the explicit prefix.
+                    self.symbol_table
+                        .type_id_of(&TypeKey::in_module(prefix, n))
+                        .or_else(|| {
+                            // Owner referencing its own type via the
+                            // full `Module.Type` form: SymbolTable
+                            // stores entry items under `TypeKey::entry`
+                            // for the parent build path, so probe
+                            // entry too when the explicit prefix
+                            // matches `owner_module`.
+                            if prefix == owner_module {
+                                self.symbol_table.type_id_of(&TypeKey::entry(n))
+                            } else {
+                                None
+                            }
+                        })
+                } else {
+                    self.symbol_table
+                        .type_id_of(&TypeKey::in_module(owner_module, &name))
+                        .or_else(|| self.symbol_table.type_id_of(&TypeKey::entry(&name)))
+                };
+                match resolved {
+                    Some(resolved_id) => Type::Named {
+                        id: Some(resolved_id),
+                        name,
+                    },
+                    None => Type::Named { id, name },
+                }
+            }
+            Type::List(inner) => Type::List(Box::new(
+                self.canonicalize_named_in_module(*inner, owner_module),
+            )),
+            Type::Vector(inner) => Type::Vector(Box::new(
+                self.canonicalize_named_in_module(*inner, owner_module),
+            )),
+            Type::Option(inner) => Type::Option(Box::new(
+                self.canonicalize_named_in_module(*inner, owner_module),
+            )),
+            Type::Result(ok, err) => Type::Result(
+                Box::new(self.canonicalize_named_in_module(*ok, owner_module)),
+                Box::new(self.canonicalize_named_in_module(*err, owner_module)),
+            ),
+            Type::Map(k, v) => Type::Map(
+                Box::new(self.canonicalize_named_in_module(*k, owner_module)),
+                Box::new(self.canonicalize_named_in_module(*v, owner_module)),
+            ),
+            Type::Tuple(items) => Type::Tuple(
+                items
+                    .into_iter()
+                    .map(|t| self.canonicalize_named_in_module(t, owner_module))
+                    .collect(),
+            ),
+            Type::Fn(params, ret, effects) => Type::Fn(
+                params
+                    .into_iter()
+                    .map(|t| self.canonicalize_named_in_module(t, owner_module))
+                    .collect(),
+                Box::new(self.canonicalize_named_in_module(*ret, owner_module)),
+                effects,
+            ),
+            other => other,
+        }
+    }
+
     pub(super) fn canonicalize_named(&self, ty: Type) -> Type {
         // Phase B: keep the `name` field source-faithful (matches
         // pre-phase-B `Type::Named(bare)` behaviour — backend codegen
@@ -515,16 +598,20 @@ impl TypeChecker {
                                 entry.module, fn_name, unknown, param_name
                             )
                         })?;
-                        parsed_params.push(self.canonicalize_named(ty));
+                        // Phase B (peer review round 5): canonicalise
+                        // dep module sigs in the OWNER's scope so a
+                        // bare `Shape` in B's `fn make() -> Shape`
+                        // stamps as B.Shape regardless of what `Shape`
+                        // means in the importing module.
+                        parsed_params.push(self.canonicalize_named_in_module(ty, &entry.module));
                     }
-                    let ret = self.canonicalize_named(parse_type_str_strict(return_type).map_err(
-                        |unknown| {
-                            format!(
-                                "Module '{}', function '{}': unknown return type '{}'",
-                                entry.module, fn_name, unknown
-                            )
-                        },
-                    )?);
+                    let ret_raw = parse_type_str_strict(return_type).map_err(|unknown| {
+                        format!(
+                            "Module '{}', function '{}': unknown return type '{}'",
+                            entry.module, fn_name, unknown
+                        )
+                    })?;
+                    let ret = self.canonicalize_named_in_module(ret_raw, &entry.module);
                     self.insert_fn_sig(
                         &entry.canonical_name,
                         FnSig {
@@ -568,8 +655,9 @@ impl TypeChecker {
                     let params: Vec<Type> = field_types
                         .iter()
                         .map(|f| {
-                            self.canonicalize_named(
+                            self.canonicalize_named_in_module(
                                 parse_type_str_strict(f).unwrap_or(Type::Invalid),
+                                &entry.module,
                             )
                         })
                         .collect();
@@ -590,8 +678,9 @@ impl TypeChecker {
                     }
                 }
                 SymbolKind::RecordField { field_type, .. } => {
-                    let field_ty = self.canonicalize_named(
+                    let field_ty = self.canonicalize_named_in_module(
                         parse_type_str_strict(field_type).unwrap_or(Type::Invalid),
+                        &entry.module,
                     );
                     let canonical = &entry.canonical_name;
                     if let Some((canonical_type, field_name)) = canonical.rsplit_once('.') {

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -97,7 +97,7 @@ impl TypeChecker {
                 if canonical != f.name
                     && let Some(id) = self.resolve_fn_id(&canonical)
                 {
-                    self.bare_fn_aliases.insert(f.name.clone(), id);
+                    self.merge_bare_fn_alias(f.name.clone(), id);
                 }
             }
         }
@@ -256,7 +256,7 @@ impl TypeChecker {
                 if canonical_type != *type_name
                     && let Some(id) = self.resolve_type_id(&canonical_type)
                 {
-                    self.bare_type_aliases.insert(type_name.clone(), id);
+                    self.merge_bare_type_alias(type_name.clone(), id);
                 }
                 // Register each constructor with a qualified key.
                 for variant in variants {
@@ -342,7 +342,7 @@ impl TypeChecker {
                 if canonical_type != *type_name
                     && let Some(id) = self.resolve_type_id(&canonical_type)
                 {
-                    self.bare_type_aliases.insert(type_name.clone(), id);
+                    self.merge_bare_type_alias(type_name.clone(), id);
                 }
                 // Register per-field types so dot-access is checked.
                 // Phase B: single entry under canonical `(Module.Type,
@@ -433,7 +433,7 @@ impl TypeChecker {
                         .symbol_table
                         .fn_id_of(&FnKey::in_module(entry.module.clone(), fn_name.clone()))
                     {
-                        self.bare_fn_aliases.insert(alias.to_string(), id);
+                        self.merge_bare_fn_alias(alias.to_string(), id);
                     }
                 }
                 SymbolKind::OpaqueType { name }
@@ -443,7 +443,7 @@ impl TypeChecker {
                         .symbol_table
                         .type_id_of(&TypeKey::in_module(entry.module.clone(), name.clone()))
                     {
-                        self.bare_type_aliases.insert(alias.to_string(), id);
+                        self.merge_bare_type_alias(alias.to_string(), id);
                     }
                 }
                 SymbolKind::Constructor { .. } | SymbolKind::RecordField { .. } => {

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -153,53 +153,41 @@ impl TypeChecker {
     /// structure intact otherwise — `Type::Var`, primitives,
     /// `Type::List<Bare>` (recurse into inner), etc.
     /// Owner-aware variant of `canonicalize_named`. Bare `Type::Named`
-    /// references inside `ty` resolve against `owner_module`'s scope
-    /// in the symbol table, ignoring the importer's
-    /// `current_module_prefix` / `bare_type_aliases`. Used by
-    /// `integrate_registry` when integrating a dep module's exported
-    /// signatures: a bare `Shape` in B's `fn make() -> Shape` must
-    /// always stamp as `B.Shape`, regardless of what `Shape` means in
-    /// the importing module.
+    /// references inside `ty` resolve in `owner_module`'s **own
+    /// resolver context**: the owner's own types plus the
+    /// visibility-exposed types from each module the owner itself
+    /// declares in its `depends [...]`. The contrast with
+    /// `canonicalize_named` (the importer-context variant) is the
+    /// whole point — peer review round 6 caught the regression where
+    /// B's exported `fn pass(s: Shape) -> Shape` (with `Shape`
+    /// meaning A.Shape per B's depends [A]) silently resolved against
+    /// the importer's bare alias map, which was ambiguous between A
+    /// and an unrelated sibling C the entry happened to also depend
+    /// on. Routing the resolution through B's own depends shuts
+    /// siblings out.
     ///
-    /// Resolves through `symbol_table.type_id_of` directly — bypasses
-    /// the visibility filter. Owners always see their own types, and
-    /// the resulting `TypeId` is the soundness anchor downstream
-    /// matcher checks rely on. The importer's visibility is a
-    /// separate concern enforced when the user-source side references
-    /// the type by name.
+    /// Three resolution cases, in order:
+    ///
+    /// 1. Qualified form (`Module.Type`): trust the prefix, but the
+    ///    referenced type must be exposed by the named module unless
+    ///    the owner is the named module itself.
+    /// 2. Bare in owner's own scope.
+    /// 3. Bare in any of owner's own `depends [...]` — exposed
+    ///    types only.
+    ///
+    /// No entry-scope fallback for dep modules: a bare reference in
+    /// a dep that doesn't resolve via the above stays unresolved
+    /// rather than silently binding to an unrelated `Shape` in the
+    /// entry module.
     pub(super) fn canonicalize_named_in_module(&self, ty: Type, owner_module: &str) -> Type {
         match ty {
-            Type::Named { id, name } => {
-                let resolved = if let Some((prefix, n)) = name.rsplit_once('.') {
-                    // Already qualified: trust the explicit prefix.
-                    self.symbol_table
-                        .type_id_of(&TypeKey::in_module(prefix, n))
-                        .or_else(|| {
-                            // Owner referencing its own type via the
-                            // full `Module.Type` form: SymbolTable
-                            // stores entry items under `TypeKey::entry`
-                            // for the parent build path, so probe
-                            // entry too when the explicit prefix
-                            // matches `owner_module`.
-                            if prefix == owner_module {
-                                self.symbol_table.type_id_of(&TypeKey::entry(n))
-                            } else {
-                                None
-                            }
-                        })
-                } else {
-                    self.symbol_table
-                        .type_id_of(&TypeKey::in_module(owner_module, &name))
-                        .or_else(|| self.symbol_table.type_id_of(&TypeKey::entry(&name)))
-                };
-                match resolved {
-                    Some(resolved_id) => Type::Named {
-                        id: Some(resolved_id),
-                        name,
-                    },
-                    None => Type::Named { id, name },
-                }
-            }
+            Type::Named { id, name } => match self.resolve_in_owner_context(&name, owner_module) {
+                Some(resolved_id) => Type::Named {
+                    id: Some(resolved_id),
+                    name,
+                },
+                None => Type::Named { id, name },
+            },
             Type::List(inner) => Type::List(Box::new(
                 self.canonicalize_named_in_module(*inner, owner_module),
             )),
@@ -233,6 +221,61 @@ impl TypeChecker {
             ),
             other => other,
         }
+    }
+
+    /// Resolve a single type name in `owner_module`'s context. See
+    /// `canonicalize_named_in_module` for the three-case ordering.
+    fn resolve_in_owner_context(&self, name: &str, owner_module: &str) -> Option<TypeId> {
+        if let Some((prefix, n)) = name.rsplit_once('.') {
+            // Qualified form: trust the prefix, but enforce
+            // visibility unless the owner is the named module.
+            let id = self
+                .symbol_table
+                .type_id_of(&TypeKey::in_module(prefix, n))?;
+            if prefix == owner_module || self.is_type_exposed_by(prefix, n) {
+                return Some(id);
+            }
+            return None;
+        }
+        // Bare in owner's own scope.
+        if let Some(id) = self
+            .symbol_table
+            .type_id_of(&TypeKey::in_module(owner_module, name))
+        {
+            return Some(id);
+        }
+        // Bare in any of owner's own depends — visibility-exposed
+        // only. No fallback to entry: bare references in a dep that
+        // can't be satisfied by its own scope or its own depends
+        // stay unresolved.
+        if let Some(deps) = self.module_depends.get(owner_module) {
+            for dep in deps {
+                if let Some(id) = self
+                    .symbol_table
+                    .type_id_of(&TypeKey::in_module(dep.as_str(), name))
+                    && self.is_type_exposed_by(dep, name)
+                {
+                    return Some(id);
+                }
+            }
+        }
+        None
+    }
+
+    /// `true` when `module` exposes a type named `type_name` to its
+    /// importers — i.e. the type is in `module`'s `exposes [...]`
+    /// list (or admitted by the underscore default rule).
+    /// The exposure source of truth is `visible_type_ids`, populated
+    /// from `visibility::SymbolRegistry::from_modules` entries. If
+    /// the type's `TypeId` is in that set, it was visibility-exposed.
+    fn is_type_exposed_by(&self, module: &str, type_name: &str) -> bool {
+        let Some(id) = self
+            .symbol_table
+            .type_id_of(&TypeKey::in_module(module, type_name))
+        else {
+            return false;
+        };
+        self.visible_type_ids.contains(&id)
     }
 
     pub(super) fn canonicalize_named(&self, ty: Type) -> Type {

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -54,7 +54,15 @@ impl TypeChecker {
                 let mut params = Vec::new();
                 for (param_name, ty_str) in &f.params {
                     match parse_type_str_strict(ty_str) {
-                        Ok(ty) => params.push(self.canonicalize_named(ty)),
+                        Ok(ty) => {
+                            let canon = self.canonicalize_named(ty);
+                            self.report_ambiguous_named(
+                                &canon,
+                                f.line,
+                                &format!("Function '{}', parameter '{}'", f.name, param_name),
+                            );
+                            params.push(canon);
+                        }
                         Err(unknown) => {
                             self.error(format!(
                                 "Function '{}': unknown type '{}' for parameter '{}'",
@@ -65,7 +73,15 @@ impl TypeChecker {
                     }
                 }
                 let ret = match parse_type_str_strict(&f.return_type) {
-                    Ok(ty) => self.canonicalize_named(ty),
+                    Ok(ty) => {
+                        let canon = self.canonicalize_named(ty);
+                        self.report_ambiguous_named(
+                            &canon,
+                            f.line,
+                            &format!("Function '{}' return type", f.name),
+                        );
+                        canon
+                    }
                     Err(unknown) => {
                         self.error(format!(
                             "Function '{}': unknown return type '{}'",
@@ -264,9 +280,15 @@ impl TypeChecker {
                         .fields
                         .iter()
                         .map(|f| {
-                            self.canonicalize_named(
+                            let canon = self.canonicalize_named(
                                 parse_type_str_strict(f).unwrap_or(Type::Invalid),
-                            )
+                            );
+                            self.report_ambiguous_named(
+                                &canon,
+                                *line,
+                                &format!("Type '{}', variant '{}'", type_name, variant.name),
+                            );
+                            canon
                         })
                         .collect();
                     let alias_key = crate::visibility::member_key(type_name, &variant.name);
@@ -353,6 +375,11 @@ impl TypeChecker {
                 for (field_name, ty_str) in fields {
                     let field_ty = self
                         .canonicalize_named(parse_type_str_strict(ty_str).unwrap_or(Type::Invalid));
+                    self.report_ambiguous_named(
+                        &field_ty,
+                        *line,
+                        &format!("Type '{}', field '{}'", type_name, field_name),
+                    );
                     let canonical_type = if module_name != type_name {
                         canonical_name(module_name, type_name)
                     } else {

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -109,9 +109,12 @@ impl TypeChecker {
                 // Bare alias so source-faithful references inside this
                 // module's own bodies (`foo()`) still resolve to its
                 // FnId when the canonical name carries the module
-                // prefix (`A.foo`).
+                // prefix (`A.foo`). Use `fn_id_for_canonical` (no
+                // visibility filter) — the fn IS visible to its own
+                // module, and `insert_fn_sig` above already added it
+                // to `visible_fn_ids`.
                 if canonical != f.name
-                    && let Some(id) = self.resolve_fn_id(&canonical)
+                    && let Some(id) = self.fn_id_for_canonical(&canonical)
                 {
                     self.merge_bare_fn_alias(f.name.clone(), id);
                 }
@@ -266,13 +269,18 @@ impl TypeChecker {
                     effects: vec![],
                 };
                 self.insert_fn_sig(&canonical_type, type_sig);
-                // Bare alias for the type name so bodies inside the
-                // same module can reference `Shape` and have it
-                // resolve to its TypeId.
-                if canonical_type != *type_name
-                    && let Some(id) = self.resolve_type_id(&canonical_type)
-                {
-                    self.merge_bare_type_alias(type_name.clone(), id);
+                // Mark the type itself visible to the current scope —
+                // own-module types are always visible to their own
+                // module. `type_id_for_canonical` bypasses the
+                // visibility filter so we can register it.
+                if let Some(id) = self.type_id_for_canonical(&canonical_type) {
+                    self.mark_type_visible(id);
+                    // Bare alias for the type name so bodies inside the
+                    // same module can reference `Shape` and have it
+                    // resolve to its TypeId.
+                    if canonical_type != *type_name {
+                        self.merge_bare_type_alias(type_name.clone(), id);
+                    }
                 }
                 // Register each constructor with a qualified key.
                 for variant in variants {
@@ -361,10 +369,11 @@ impl TypeChecker {
                     effects: vec![],
                 };
                 self.insert_fn_sig(&canonical_type, prod_sig);
-                if canonical_type != *type_name
-                    && let Some(id) = self.resolve_type_id(&canonical_type)
-                {
-                    self.merge_bare_type_alias(type_name.clone(), id);
+                if let Some(id) = self.type_id_for_canonical(&canonical_type) {
+                    self.mark_type_visible(id);
+                    if canonical_type != *type_name {
+                        self.merge_bare_type_alias(type_name.clone(), id);
+                    }
                 }
                 // Register per-field types so dot-access is checked.
                 // Phase B: single entry under canonical `(Module.Type,
@@ -444,23 +453,26 @@ impl TypeChecker {
     ) -> Result<(), String> {
         use crate::visibility::SymbolKind;
 
-        // First pass: populate the bare → typed-id alias maps from
-        // every entry that carries a visibility-exposed alias. Phase B
-        // moves bare-name resolution off `sig_aliases` (string→string)
-        // and onto these typed bridges. Done up front so the second
-        // pass — which calls `insert_fn_sig` and `resolved_named_type`
-        // — can already resolve type references via the aliases.
+        // First pass: populate the bare → typed-id alias maps AND the
+        // visibility sets from every registry entry. The registry
+        // itself is already filtered to exposed-only items by
+        // `SymbolRegistry::from_modules`, so every `FnId` / `TypeId`
+        // we see here is by definition visible to the current
+        // checker. The visibility gating in `resolve_*_id` then
+        // refuses look-ups against any ID that the symbol table has
+        // but this pass never touched — closing the
+        // qualified-private-import leak (peer review round 4).
         for entry in &registry.entries {
-            let Some(alias) = entry.alias.as_deref() else {
-                continue;
-            };
             match &entry.kind {
                 SymbolKind::Function { name: fn_name, .. } => {
                     if let Some(id) = self
                         .symbol_table
                         .fn_id_of(&FnKey::in_module(entry.module.clone(), fn_name.clone()))
                     {
-                        self.merge_bare_fn_alias(alias.to_string(), id);
+                        self.visible_fn_ids.insert(id);
+                        if let Some(alias) = entry.alias.as_deref() {
+                            self.merge_bare_fn_alias(alias.to_string(), id);
+                        }
                     }
                 }
                 SymbolKind::OpaqueType { name }
@@ -470,7 +482,10 @@ impl TypeChecker {
                         .symbol_table
                         .type_id_of(&TypeKey::in_module(entry.module.clone(), name.clone()))
                     {
-                        self.merge_bare_type_alias(alias.to_string(), id);
+                        self.visible_type_ids.insert(id);
+                        if let Some(alias) = entry.alias.as_deref() {
+                            self.merge_bare_type_alias(alias.to_string(), id);
+                        }
                     }
                 }
                 SymbolKind::Constructor { .. } | SymbolKind::RecordField { .. } => {

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -181,13 +181,25 @@ impl TypeChecker {
     /// entry module.
     pub(super) fn canonicalize_named_in_module(&self, ty: Type, owner_module: &str) -> Type {
         match ty {
-            Type::Named { id, name } => match self.resolve_in_owner_context(&name, owner_module) {
-                Some(resolved_id) => Type::Named {
-                    id: Some(resolved_id),
-                    name,
-                },
-                None => Type::Named { id, name },
+            // Peer review round 7: `Some(id)` is sacred even in the
+            // owner-context canonicaliser. Never overwrite an
+            // existing typed-identity stamp.
+            Type::Named {
+                id: Some(existing),
+                name,
+            } => Type::Named {
+                id: Some(existing),
+                name,
             },
+            Type::Named { id: None, name } => {
+                match self.resolve_in_owner_context(&name, owner_module) {
+                    Some(resolved_id) => Type::Named {
+                        id: Some(resolved_id),
+                        name,
+                    },
+                    None => Type::Named { id: None, name },
+                }
+            }
             Type::List(inner) => Type::List(Box::new(
                 self.canonicalize_named_in_module(*inner, owner_module),
             )),
@@ -286,13 +298,27 @@ impl TypeChecker {
         // `id` field carries the typed identity; the matcher uses it
         // when both sides have `Some` and falls back to source-name
         // matching otherwise.
+        //
+        // Peer review round 7: once a stamp carries `Some(id)`, no
+        // later context may overwrite it. Pre-fix the canonicaliser
+        // re-stamped any `Some` value by `resolve_type_id(name)` in
+        // the current scope, which let an importer's bare alias for
+        // `Shape` re-bind a properly-stamped `C.Shape` value to
+        // `A.Shape`. `Some(_)` is sacred; only fill in `id: None`.
         match ty {
-            Type::Named { id, name } => match self.resolve_type_id(&name) {
+            Type::Named {
+                id: Some(existing),
+                name,
+            } => Type::Named {
+                id: Some(existing),
+                name,
+            },
+            Type::Named { id: None, name } => match self.resolve_type_id(&name) {
                 Some(resolved_id) => Type::Named {
                     id: Some(resolved_id),
                     name,
                 },
-                None => Type::Named { id, name },
+                None => Type::Named { id: None, name },
             },
             Type::List(inner) => Type::List(Box::new(self.canonicalize_named(*inner))),
             Type::Vector(inner) => Type::Vector(Box::new(self.canonicalize_named(*inner))),

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -33,8 +33,16 @@ impl TypeChecker {
         // a later-in-source type with a bare `Type::Named`, and the
         // strict matcher would then reject otherwise-correct
         // programs.
-        let module_name = Self::module_decl(items)
-            .map(|m| m.name.clone())
+        // Phase B: prefer `current_module_prefix` (set by the
+        // sub-checker driver to the dep module's `dep_name`) so the
+        // canonical name aligns with the symbol table's `FnKey`. Fall
+        // back to the interior `module X` declaration only at entry
+        // scope where the symbol table doesn't use a module prefix
+        // for items at all (entry items live under `FnKey::entry`).
+        let module_name = self
+            .current_module_prefix
+            .clone()
+            .or_else(|| Self::module_decl(items).map(|m| m.name.clone()))
             .unwrap_or_default();
         for item in items {
             if let TopLevel::TypeDef(td) = item {
@@ -46,7 +54,7 @@ impl TypeChecker {
                 let mut params = Vec::new();
                 for (param_name, ty_str) in &f.params {
                     match parse_type_str_strict(ty_str) {
-                        Ok(ty) => params.push(ty),
+                        Ok(ty) => params.push(self.canonicalize_named(ty)),
                         Err(unknown) => {
                             self.error(format!(
                                 "Function '{}': unknown type '{}' for parameter '{}'",
@@ -57,7 +65,7 @@ impl TypeChecker {
                     }
                 }
                 let ret = match parse_type_str_strict(&f.return_type) {
-                    Ok(ty) => ty,
+                    Ok(ty) => self.canonicalize_named(ty),
                     Err(unknown) => {
                         self.error(format!(
                             "Function '{}': unknown return type '{}'",
@@ -68,7 +76,7 @@ impl TypeChecker {
                 };
                 let canonical = canonical_name(&module_name, &f.name);
                 // Iron — A2: refuse silent shadowing.
-                if self.fn_sigs.contains_key(&canonical) {
+                if self.fn_sig_contains_canonical(&canonical) {
                     self.error_at_line(
                         f.line,
                         format!("Function '{}' is already defined in this module", f.name),
@@ -79,25 +87,68 @@ impl TypeChecker {
                     ret,
                     effects: f.effects.iter().map(|e| e.node.clone()).collect(),
                 };
-                self.fn_sigs.insert(canonical.clone(), sig.clone());
-                if canonical != f.name {
-                    self.sig_aliases.insert(f.name.clone(), canonical);
-                    self.fn_sigs.insert(f.name.clone(), sig);
+                // Phase B: routing handled by `insert_fn_sig` — user
+                // fns land in the `FnId`-keyed `fn_sigs`.
+                self.insert_fn_sig(&canonical, sig);
+                // Bare alias so source-faithful references inside this
+                // module's own bodies (`foo()`) still resolve to its
+                // FnId when the canonical name carries the module
+                // prefix (`A.foo`).
+                if canonical != f.name
+                    && let Some(id) = self.resolve_fn_id(&canonical)
+                {
+                    self.bare_fn_aliases.insert(f.name.clone(), id);
                 }
             }
         }
     }
 
-    /// Iron — A3: rewrite every `Type::Named(bare)` reachable from
-    /// `ty` to `Type::Named(canonical)` when `bare` has a registered
-    /// alias. Leaves the structure intact otherwise — `Type::Var`,
-    /// primitives, `Type::List<Bare>` (recurse into inner), etc.
+    /// Build a `Type::Named` for `type_name` declared inside
+    /// `module_name`. Keeps the `name` field source-faithful (bare
+    /// `type_name`, matching pre-phase-B's stamping convention) and
+    /// populates `id` from the symbol table. Entry items declaring
+    /// `module X` live under `TypeKey::entry` in the symbol table,
+    /// so we probe entry scope as a fallback when the module-scoped
+    /// lookup misses.
+    pub(super) fn resolved_named_type(&self, type_name: &str, module_name: &str) -> Type {
+        let id = if module_name.is_empty() {
+            self.symbol_table
+                .type_id_of(&crate::ir::TypeKey::entry(type_name))
+        } else {
+            self.symbol_table
+                .type_id_of(&crate::ir::TypeKey::in_module(module_name, type_name))
+                .or_else(|| {
+                    self.symbol_table
+                        .type_id_of(&crate::ir::TypeKey::entry(type_name))
+                })
+        };
+        Type::Named {
+            id,
+            name: type_name.to_string(),
+        }
+    }
+
+    /// Phase B: rewrite every `Type::Named { id: None, name: bare }`
+    /// reachable from `ty` so that `id` and `name` reflect the
+    /// canonical form resolved through the symbol table. Leaves the
+    /// structure intact otherwise — `Type::Var`, primitives,
+    /// `Type::List<Bare>` (recurse into inner), etc.
     pub(super) fn canonicalize_named(&self, ty: Type) -> Type {
+        // Phase B: keep the `name` field source-faithful (matches
+        // pre-phase-B `Type::Named(bare)` behaviour — backend codegen
+        // that does string-equality lookups against its own type
+        // registry needs to keep seeing what the user wrote). The
+        // `id` field carries the typed identity; the matcher uses it
+        // when both sides have `Some` and falls back to source-name
+        // matching otherwise.
         match ty {
-            Type::Named(name) => {
-                let resolved = self.sig_aliases.get(&name).cloned().unwrap_or(name);
-                Type::Named(resolved)
-            }
+            Type::Named { id, name } => match self.resolve_type_id(&name) {
+                Some(resolved_id) => Type::Named {
+                    id: Some(resolved_id),
+                    name,
+                },
+                None => Type::Named { id, name },
+            },
             Type::List(inner) => Type::List(Box::new(self.canonicalize_named(*inner))),
             Type::Vector(inner) => Type::Vector(Box::new(self.canonicalize_named(*inner))),
             Type::Option(inner) => Type::Option(Box::new(self.canonicalize_named(*inner))),
@@ -147,7 +198,7 @@ impl TypeChecker {
                 // first decl but the symbol path used the second.
                 // Reject the duplicate at typecheck so the VM never
                 // sees the inconsistency.
-                if self.fn_sigs.contains_key(&canonical_type) {
+                if self.fn_sig_contains_canonical(&canonical_type) {
                     self.error_at_line(
                         *line,
                         format!("Type '{}' is already defined in this module", type_name),
@@ -185,47 +236,55 @@ impl TypeChecker {
                 if canonical_type != *type_name {
                     self.type_variants.insert(type_name.clone(), variant_names);
                 }
-                // Iron — A3: fn_sigs values stay source-faithful
-                // (`Type::Named(bare)`) so downstream discovery /
-                // codegen walkers see what the user wrote; the
-                // `sig_aliases` map carries bare → canonical for the
-                // matcher to resolve at comparison time.
+                // Phase B: type-as-callable goes through the unified
+                // `insert_fn_sig` router. User types land in `fn_sigs`
+                // keyed by `FnId` only if the type also names a
+                // function — they generally don't, so this falls
+                // through to `extra_sigs`. The bare-alias mirror that
+                // pre-phase-B `sig_aliases` carried is subsumed by
+                // `canonical_extra_key` doing the symbol-table type
+                // resolution on lookup.
                 let type_sig = FnSig {
                     params: vec![],
-                    ret: Type::Named(type_name.clone()),
+                    ret: self.resolved_named_type(type_name, module_name),
                     effects: vec![],
                 };
-                self.fn_sigs
-                    .insert(canonical_type.clone(), type_sig.clone());
-                if canonical_type != *type_name {
-                    self.sig_aliases
-                        .insert(type_name.clone(), canonical_type.clone());
-                    self.fn_sigs.insert(type_name.clone(), type_sig);
+                self.insert_fn_sig(&canonical_type, type_sig);
+                // Bare alias for the type name so bodies inside the
+                // same module can reference `Shape` and have it
+                // resolve to its TypeId.
+                if canonical_type != *type_name
+                    && let Some(id) = self.resolve_type_id(&canonical_type)
+                {
+                    self.bare_type_aliases.insert(type_name.clone(), id);
                 }
                 // Register each constructor with a qualified key.
                 for variant in variants {
                     let params: Vec<Type> = variant
                         .fields
                         .iter()
-                        .map(|f| parse_type_str_strict(f).unwrap_or(Type::Invalid))
+                        .map(|f| {
+                            self.canonicalize_named(
+                                parse_type_str_strict(f).unwrap_or(Type::Invalid),
+                            )
+                        })
                         .collect();
                     let alias_key = crate::visibility::member_key(type_name, &variant.name);
                     let canonical_key = canonical_name(module_name, &alias_key);
                     if params.is_empty() {
-                        self.value_members
-                            .insert(canonical_key.clone(), Type::Named(type_name.clone()));
-                    } else {
-                        self.fn_sigs.insert(
+                        self.value_members.insert(
                             canonical_key.clone(),
+                            self.resolved_named_type(type_name, module_name),
+                        );
+                    } else {
+                        self.insert_fn_sig(
+                            &canonical_key,
                             FnSig {
                                 params,
-                                ret: Type::Named(type_name.clone()),
+                                ret: self.resolved_named_type(type_name, module_name),
                                 effects: vec![],
                             },
                         );
-                    }
-                    if canonical_key != alias_key {
-                        self.sig_aliases.insert(alias_key, canonical_key);
                     }
                 }
             }
@@ -240,7 +299,7 @@ impl TypeChecker {
                 // overwrite the first via `HashMap::insert` and leave
                 // downstream consumers (codegen, VM compiler, refinement
                 // detector) reading whichever copy won the race.
-                if self.fn_sigs.contains_key(&canonical_type) {
+                if self.fn_sig_contains_canonical(&canonical_type) {
                     self.error_at_line(
                         *line,
                         format!("Type '{}' is already defined in this module", type_name),
@@ -263,35 +322,37 @@ impl TypeChecker {
                         );
                     }
                 }
-                // Record constructors are handled via Expr::RecordCreate
-                // — fn_sigs entry exists so `Ident("TypeName")` resolves
-                // to `Type::Named(bare)` (Iron — A3: source-faithful).
+                // Record constructors flow through `Expr::RecordCreate`.
+                // The fn_sigs-like entry lets `Ident("TypeName")` resolve
+                // to a `Type::Named`-shaped callable for diagnostic use.
                 let params: Vec<Type> = fields
                     .iter()
-                    .map(|(_, ty_str)| parse_type_str_strict(ty_str).unwrap_or(Type::Invalid))
+                    .map(|(_, ty_str)| {
+                        self.canonicalize_named(
+                            parse_type_str_strict(ty_str).unwrap_or(Type::Invalid),
+                        )
+                    })
                     .collect();
                 let prod_sig = FnSig {
                     params,
-                    ret: Type::Named(type_name.clone()),
+                    ret: self.resolved_named_type(type_name, module_name),
                     effects: vec![],
                 };
-                self.fn_sigs
-                    .insert(canonical_type.clone(), prod_sig.clone());
-                if canonical_type != *type_name {
-                    self.sig_aliases
-                        .insert(type_name.clone(), canonical_type.clone());
-                    self.fn_sigs.insert(type_name.clone(), prod_sig);
+                self.insert_fn_sig(&canonical_type, prod_sig);
+                if canonical_type != *type_name
+                    && let Some(id) = self.resolve_type_id(&canonical_type)
+                {
+                    self.bare_type_aliases.insert(type_name.clone(), id);
                 }
                 // Register per-field types so dot-access is checked.
-                // Iron — A5: single entry under the canonical
-                // `(Module.Type, field)` key. Bare-name lookups
-                // canonicalise via `sig_aliases`; no more mirror
-                // entry under `(Type, field)`. The bare→canonical
-                // alias is still recorded so other code paths
-                // (`find_value_member`, `find_fn_sig`) can resolve
-                // bare references.
+                // Phase B: single entry under canonical `(Module.Type,
+                // field)` — the bare-alias mirror that pre-phase-B
+                // `sig_aliases` carried is subsumed by
+                // `canonical_type_name` resolving through the symbol
+                // table on lookup.
                 for (field_name, ty_str) in fields {
-                    let field_ty = parse_type_str_strict(ty_str).unwrap_or(Type::Invalid);
+                    let field_ty = self
+                        .canonicalize_named(parse_type_str_strict(ty_str).unwrap_or(Type::Invalid));
                     let canonical_type = if module_name != type_name {
                         canonical_name(module_name, type_name)
                     } else {
@@ -299,12 +360,6 @@ impl TypeChecker {
                     };
                     self.record_field_types
                         .insert(RecordFieldKey::new(&canonical_type, field_name), field_ty);
-                    if canonical_type != *type_name {
-                        let alias_key = crate::visibility::member_key(type_name, field_name);
-                        let canonical_key =
-                            crate::visibility::member_key(&canonical_type, field_name);
-                        self.sig_aliases.insert(alias_key, canonical_key);
-                    }
                 }
             }
         }
@@ -339,53 +394,70 @@ impl TypeChecker {
 
     pub(super) fn has_namespace_prefix(&self, key: &str) -> bool {
         let prefix = format!("{}.", key);
-        self.fn_sigs.keys().any(|k| k.starts_with(&prefix))
+        self.all_fn_sigs().any(|(k, _)| k.starts_with(&prefix))
             || self.value_members.keys().any(|k| k.starts_with(&prefix))
     }
 
-    /// Populate checker maps from the shared SymbolRegistry.
-    /// The registry is the canonical source — checker derives its maps from it.
+    /// Populate checker maps from the shared SymbolRegistry. The
+    /// registry is the canonical source — checker derives its maps
+    /// from it.
+    ///
+    /// Phase B: registry entries are stored under their canonical
+    /// name (`"Module.Type"`, `"Module.fn"`, `"Module.Type.field"`).
+    /// The bare → canonical alias map that pre-phase-B code
+    /// maintained (`sig_aliases`) is gone; instead, lookups
+    /// canonicalise through the `SymbolTable` (`resolve_type_id` /
+    /// `resolve_fn_id`) at read time. Per-fn / per-type duplicate
+    /// mirror entries are gone too — `insert_fn_sig` routes user fns
+    /// into `fn_sigs` (FnId-keyed) and leaves builtins/constructors
+    /// in `extra_sigs` (string-keyed).
     pub(super) fn integrate_registry(
         &mut self,
         registry: &crate::visibility::SymbolRegistry,
     ) -> Result<(), String> {
         use crate::visibility::SymbolKind;
 
-        // Iron — A3: aliases first. `canonicalize_named` walks
-        // `sig_aliases` to rewrite bare references in fn/variant
-        // type annotations, and entries come from the registry in
-        // (function, type, constructor) order — without this pre-
-        // pass, a function whose param type names a type defined
-        // later in the same module's entry list would canonicalize
-        // to the bare name and the strict matcher would then reject
-        // any call site that uses the canonical form.
+        // First pass: populate the bare → typed-id alias maps from
+        // every entry that carries a visibility-exposed alias. Phase B
+        // moves bare-name resolution off `sig_aliases` (string→string)
+        // and onto these typed bridges. Done up front so the second
+        // pass — which calls `insert_fn_sig` and `resolved_named_type`
+        // — can already resolve type references via the aliases.
         for entry in &registry.entries {
-            if let Some(alias) = &entry.alias
-                && matches!(
-                    entry.kind,
-                    SymbolKind::OpaqueType { .. }
-                        | SymbolKind::SumType { .. }
-                        | SymbolKind::ProductType { .. }
-                )
-            {
-                self.sig_aliases
-                    .insert(alias.clone(), entry.canonical_name.clone());
+            let Some(alias) = entry.alias.as_deref() else {
+                continue;
+            };
+            match &entry.kind {
+                SymbolKind::Function { name: fn_name, .. } => {
+                    if let Some(id) = self
+                        .symbol_table
+                        .fn_id_of(&FnKey::in_module(entry.module.clone(), fn_name.clone()))
+                    {
+                        self.bare_fn_aliases.insert(alias.to_string(), id);
+                    }
+                }
+                SymbolKind::OpaqueType { name }
+                | SymbolKind::SumType { name, .. }
+                | SymbolKind::ProductType { name, .. } => {
+                    if let Some(id) = self
+                        .symbol_table
+                        .type_id_of(&TypeKey::in_module(entry.module.clone(), name.clone()))
+                    {
+                        self.bare_type_aliases.insert(alias.to_string(), id);
+                    }
+                }
+                SymbolKind::Constructor { .. } | SymbolKind::RecordField { .. } => {
+                    // Constructors / record fields aren't part of
+                    // SymbolTable's fn/type id space — they're keyed
+                    // by `CtorId` under their owning type. Their bare
+                    // aliases stay routed through the canonical
+                    // string keys in `extra_sigs` (handled by
+                    // `find_fn_sig` falling back on direct lookup).
+                }
             }
         }
 
         for entry in &registry.entries {
-            if let Some(alias) = &entry.alias
-                && !matches!(
-                    entry.kind,
-                    SymbolKind::OpaqueType { .. }
-                        | SymbolKind::SumType { .. }
-                        | SymbolKind::ProductType { .. }
-                )
-            {
-                self.sig_aliases
-                    .insert(alias.clone(), entry.canonical_name.clone());
-            }
-
             match &entry.kind {
                 SymbolKind::Function {
                     name: fn_name,
@@ -401,16 +473,18 @@ impl TypeChecker {
                                 entry.module, fn_name, unknown, param_name
                             )
                         })?;
-                        parsed_params.push(ty);
+                        parsed_params.push(self.canonicalize_named(ty));
                     }
-                    let ret = parse_type_str_strict(return_type).map_err(|unknown| {
-                        format!(
-                            "Module '{}', function '{}': unknown return type '{}'",
-                            entry.module, fn_name, unknown
-                        )
-                    })?;
-                    self.fn_sigs.insert(
-                        entry.canonical_name.clone(),
+                    let ret = self.canonicalize_named(parse_type_str_strict(return_type).map_err(
+                        |unknown| {
+                            format!(
+                                "Module '{}', function '{}': unknown return type '{}'",
+                                entry.module, fn_name, unknown
+                            )
+                        },
+                    )?);
+                    self.insert_fn_sig(
+                        &entry.canonical_name,
                         FnSig {
                             params: parsed_params,
                             ret,
@@ -419,15 +493,12 @@ impl TypeChecker {
                     );
                 }
                 SymbolKind::OpaqueType { name } => {
-                    // Iron — A3: fn_sigs values stay source-faithful
-                    // (bare `Type::Named(name)`); the bare alias is in
-                    // `sig_aliases` for matcher resolution.
                     let canonical = entry.canonical_name.clone();
-                    self.fn_sigs.insert(
-                        canonical.clone(),
+                    self.insert_fn_sig(
+                        &canonical,
                         FnSig {
                             params: vec![],
-                            ret: Type::Named(name.clone()),
+                            ret: self.resolved_named_type(name, &entry.module),
                             effects: vec![],
                         },
                     );
@@ -438,12 +509,11 @@ impl TypeChecker {
                     self.type_variants.insert(canonical, variants.clone());
                 }
                 SymbolKind::ProductType { name, .. } => {
-                    let canonical = entry.canonical_name.clone();
-                    self.fn_sigs.insert(
-                        canonical,
+                    self.insert_fn_sig(
+                        &entry.canonical_name,
                         FnSig {
                             params: vec![],
-                            ret: Type::Named(name.clone()),
+                            ret: self.resolved_named_type(name, &entry.module),
                             effects: vec![],
                         },
                     );
@@ -455,30 +525,32 @@ impl TypeChecker {
                 } => {
                     let params: Vec<Type> = field_types
                         .iter()
-                        .map(|f| parse_type_str_strict(f).unwrap_or(Type::Invalid))
+                        .map(|f| {
+                            self.canonicalize_named(
+                                parse_type_str_strict(f).unwrap_or(Type::Invalid),
+                            )
+                        })
                         .collect();
                     if params.is_empty() {
-                        self.value_members
-                            .insert(entry.canonical_name.clone(), Type::Named(type_name.clone()));
-                    } else {
-                        self.fn_sigs.insert(
+                        self.value_members.insert(
                             entry.canonical_name.clone(),
+                            self.resolved_named_type(type_name, &entry.module),
+                        );
+                    } else {
+                        self.insert_fn_sig(
+                            &entry.canonical_name,
                             FnSig {
                                 params,
-                                ret: Type::Named(type_name.clone()),
+                                ret: self.resolved_named_type(type_name, &entry.module),
                                 effects: vec![],
                             },
                         );
                     }
                 }
                 SymbolKind::RecordField { field_type, .. } => {
-                    let field_ty = parse_type_str_strict(field_type).unwrap_or(Type::Invalid);
-                    // Iron — A5: canonical_name is
-                    // "Module.Type.field"; split off the trailing
-                    // field name and keep the rest as the typed-key
-                    // `type_name`. Bare alias still goes into
-                    // `sig_aliases` so a source reference of `Type`
-                    // canonicalises to `Module.Type` at lookup.
+                    let field_ty = self.canonicalize_named(
+                        parse_type_str_strict(field_type).unwrap_or(Type::Invalid),
+                    );
                     let canonical = &entry.canonical_name;
                     if let Some((canonical_type, field_name)) = canonical.rsplit_once('.') {
                         self.record_field_types

--- a/src/types/checker/tests.rs
+++ b/src/types/checker/tests.rs
@@ -673,7 +673,7 @@ mod proptest_strategies {
             Just(Type::Bool),
             Just(Type::Unit),
             Just(Type::Invalid),
-            "[A-Z][a-zA-Z]{0,4}".prop_map(Type::Named),
+            "[A-Z][a-zA-Z]{0,4}".prop_map(Type::named),
             "[A-Z]".prop_map(Type::Var),
         ];
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -108,7 +108,7 @@ pub fn parse_type_str_strict(s: &str) -> Result<Type, String> {
                 && s.chars()
                     .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
             {
-                return Ok(Type::Named(s.to_string()));
+                return Ok(Type::named(s));
             }
 
             Err(s.to_string())
@@ -179,7 +179,7 @@ pub fn parse_type_str(s: &str) -> Type {
                     .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
                 && s != "Any"
             {
-                return Type::Named(s.to_string());
+                return Type::named(s);
             }
             // Invalid — internal recovery fallback
             Type::Invalid
@@ -427,7 +427,7 @@ mod tests {
         // Capitalized identifiers are now parsed as user-defined Named types
         assert_eq!(
             parse_type_str("SomeUnknownType"),
-            Type::Named("SomeUnknownType".to_string())
+            Type::named("SomeUnknownType")
         );
         // Lowercase non-keyword identifiers and empty strings become invalid recovery.
         assert_eq!(parse_type_str(""), Type::Invalid);
@@ -527,18 +527,15 @@ mod tests {
         // Capitalized identifiers are accepted as user-defined Named types
         assert_eq!(
             parse_type_str_strict("Result<MyError, String>").unwrap(),
-            Type::Result(
-                Box::new(Type::Named("MyError".to_string())),
-                Box::new(Type::Str)
-            )
+            Type::Result(Box::new(Type::named("MyError")), Box::new(Type::Str))
         );
         assert_eq!(
             parse_type_str_strict("Option<Shape>").unwrap(),
-            Type::Option(Box::new(Type::Named("Shape".to_string())))
+            Type::Option(Box::new(Type::named("Shape")))
         );
         assert_eq!(
             parse_type_str_strict("List<User>").unwrap(),
-            Type::List(Box::new(Type::Named("User".to_string())))
+            Type::List(Box::new(Type::named("User")))
         );
         // Lowercase unknown types still fail
         assert!(parse_type_str_strict("integ").is_err());
@@ -548,18 +545,15 @@ mod tests {
     fn test_dotted_named_type() {
         assert_eq!(
             parse_type_str("Tcp.Connection"),
-            Type::Named("Tcp.Connection".to_string())
+            Type::named("Tcp.Connection")
         );
         assert_eq!(
             parse_type_str_strict("Tcp.Connection").unwrap(),
-            Type::Named("Tcp.Connection".to_string())
+            Type::named("Tcp.Connection")
         );
         assert_eq!(
             parse_type_str_strict("Result<Tcp.Connection, String>").unwrap(),
-            Type::Result(
-                Box::new(Type::Named("Tcp.Connection".to_string())),
-                Box::new(Type::Str)
-            )
+            Type::Result(Box::new(Type::named("Tcp.Connection")), Box::new(Type::Str))
         );
     }
 

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -858,16 +858,16 @@ fn error_record_creation_field_type_mismatch() {
 fn named_types_are_compatible_with_same_name() {
     // Two Named("Shape") values should be compatible
     use aver::types::Type;
-    let a = Type::Named("Shape".to_string());
-    let b = Type::Named("Shape".to_string());
+    let a = Type::named("Shape");
+    let b = Type::named("Shape");
     assert!(a.compatible(&b));
 }
 
 #[test]
 fn named_types_are_incompatible_with_different_names() {
     use aver::types::Type;
-    let a = Type::Named("Shape".to_string());
-    let b = Type::Named("User".to_string());
+    let a = Type::named("Shape");
+    let b = Type::named("User");
     assert!(!a.compatible(&b));
 }
 
@@ -878,7 +878,7 @@ fn named_type_is_compatible_with_invalid_recovery() {
     // into a cascade of `expected X, got Invalid` diagnostics. Pre-A4
     // this test asserted the opposite direction.
     use aver::types::Type;
-    let named = Type::Named("Shape".to_string());
+    let named = Type::named("Shape");
     assert!(named.compatible(&Type::Invalid));
     assert!(Type::Invalid.compatible(&named));
 }

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2725,6 +2725,69 @@ fn callsWithB() -> Float
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// Phase B (#138, peer review round 7): `canonicalize_named` must
+/// treat an existing `Some(TypeId)` as sacred. Pre-fix, the
+/// canonicaliser overwrote any `id` by whatever `resolve_type_id`
+/// returned in the *current* checker context — so a value coming
+/// back from `C.make()` correctly stamped with `Some(C.Shape)`
+/// would get re-stamped to `Some(A.Shape)` when `infer_type` re-
+/// canonicalised it in the importer's context (A's `Shape` is the
+/// only visible bare alias). Soundness collapsed: `A.consume(C.make())`
+/// silently typechecked.
+///
+/// Fix: canonicaliser only fills in `id: None`. Once a stamp has
+/// `id: Some(_)`, no later context can override it.
+#[test]
+fn canonicalize_named_does_not_overwrite_existing_typeid() {
+    let root = temp_module_root("canonicalize_preserves_id");
+    std::fs::write(
+        root.join("A.av"),
+        r#"module A
+    exposes [Shape, consume]
+    intent = "Public A.Shape + consumer."
+
+type Shape
+    Circle(Float)
+
+fn consume(s: Shape) -> Float
+    match s
+        Shape.Circle(r) -> r
+"#,
+    )
+    .expect("write A.av failed");
+    std::fs::write(
+        root.join("C.av"),
+        r#"module C
+    exposes [make]
+    intent = "Private C.Shape (only `make` exposed)."
+
+type Shape
+    Hexagon(Float)
+
+fn make() -> Shape
+    Shape.Hexagon(1.0)
+"#,
+    )
+    .expect("write C.av failed");
+
+    let src = r#"module Main
+    depends [A, C]
+    intent = "Tries to feed C.make() into A.consume — distinct types, must reject."
+
+fn caller() -> Float
+    A.consume(C.make())
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("Argument 1 of 'A.consume'")
+                || e.contains("Argument 1 of 'consume'")),
+        "expected an argument-type mismatch on `A.consume(C.make())` (A.Shape != C.Shape); got: {errs:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// Phase B (#138, peer review round 6): an exported `fn` in module
 /// B that references a type by bare name must resolve in B's own
 /// resolver context — B's own types + B's actual `depends` transitive

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2696,10 +2696,30 @@ fn callsWithB() -> Float
     // names. Without that refusal the old name-equality fallback
     // would let both calls go through and silently agree on
     // whichever `Shape` happened to win the global alias slot.
-    let mismatches: Vec<&String> = errs.iter().filter(|e| e.contains("takesShape")).collect();
+    // Both call sites are equally unsound (one passes A.Shape, the
+    // other B.Shape against an ambiguous bare param), so both must
+    // surface. Asserting exact count catches an asymmetric regression
+    // where one side gets rejected because the bare alias secretly
+    // resolved to the other module's identity.
+    let call_mismatches: Vec<&String> = errs
+        .iter()
+        .filter(|e| e.contains("Argument 1 of 'takesShape'"))
+        .collect();
+    assert_eq!(
+        call_mismatches.len(),
+        2,
+        "expected exactly 2 argument-mismatch diagnostics on `takesShape(...)` calls when `Shape` is ambiguous, got: {errs:?}"
+    );
+    // Explicit ambiguity diagnostic on the param annotation itself —
+    // surfaces the underlying cause instead of just two
+    // type-mismatch errors that read `expected Shape, got Shape`.
     assert!(
-        !mismatches.is_empty(),
-        "expected at least one diagnostic on a `takesShape(...)` call when `Shape` is ambiguous, got: {errs:?}"
+        errs.iter().any(|e| {
+            e.contains("Ambiguous type name 'Shape'")
+                && e.contains("A.Shape")
+                && e.contains("B.Shape")
+        }),
+        "expected an 'Ambiguous type name Shape; use A.Shape or B.Shape' diagnostic, got: {errs:?}"
     );
 
     let _ = std::fs::remove_dir_all(&root);

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2725,6 +2725,136 @@ fn callsWithB() -> Float
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// Phase B (#138, peer review round 3 nit #1): the ambiguity
+/// diagnostic must NOT list a private (non-exposed) candidate even
+/// when it shares the bare name. `Resolution::Ambiguous(Vec<TypeId>)`
+/// carries the candidate IDs populated through visibility-exposed
+/// aliases — types that aren't exposed never reach the alias map, so
+/// `ambiguous_type_candidates` returns only the names the user can
+/// actually pick from.
+#[test]
+fn ambiguity_diagnostic_omits_private_dep_candidates() {
+    let root = temp_module_root("ambiguity_private_excluded");
+    std::fs::write(
+        root.join("A.av"),
+        r#"module A
+    exposes [Shape]
+    intent = "Public A.Shape."
+
+type Shape
+    Circle(Float)
+"#,
+    )
+    .expect("write A.av failed");
+    std::fs::write(
+        root.join("B.av"),
+        r#"module B
+    exposes [Shape]
+    intent = "Public B.Shape."
+
+type Shape
+    Triangle(Float)
+"#,
+    )
+    .expect("write B.av failed");
+    // C declares a `Shape` but does NOT expose it. (Non-empty
+    // `exposes [helper]` triggers the explicit-list rule, so `Shape`
+    // — absent from the list — stays private.) Pre-fix
+    // `ambiguous_type_candidates` would have scanned the full
+    // SymbolTable and listed `C.Shape` alongside `A.Shape` / `B.Shape`
+    // in the user-facing diagnostic, even though the user can't
+    // actually reference `C.Shape` from `Main`.
+    std::fs::write(
+        root.join("C.av"),
+        r#"module C
+    exposes [helper]
+    intent = "Private C.Shape (Shape NOT in exposes list)."
+
+type Shape
+    Hexagon(Float)
+
+fn helper() -> Int
+    0
+"#,
+    )
+    .expect("write C.av failed");
+
+    let src = r#"module Main
+    depends [A, B, C]
+    intent = "Bare Shape with one private dep candidate."
+
+fn takesShape(s: Shape) -> Float
+    0.0
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    let ambig = errs
+        .iter()
+        .find(|e| e.contains("Ambiguous type name 'Shape'"))
+        .expect("expected an ambiguity diagnostic");
+    assert!(ambig.contains("A.Shape"), "missing A.Shape: {ambig}");
+    assert!(ambig.contains("B.Shape"), "missing B.Shape: {ambig}");
+    assert!(
+        !ambig.contains("C.Shape"),
+        "private C.Shape leaked into diagnostic: {ambig}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Phase B (#138, peer review round 3 nit #2): the explicit
+/// ambiguity diagnostic now also fires on local binding annotations
+/// (`x: Shape = ...`), not just function param / return / record
+/// field positions. Without this hook the matcher still rejects the
+/// program — but the user got "expected Shape, got Shape" instead of
+/// the actionable "Ambiguous type name; use A.Shape or B.Shape".
+#[test]
+fn ambiguous_bare_name_in_binding_annotation_surfaces_explicit_diagnostic() {
+    let root = temp_module_root("ambiguous_binding_ann");
+    std::fs::write(
+        root.join("A.av"),
+        r#"module A
+    exposes [Shape]
+    intent = "A.Shape."
+
+type Shape
+    Circle(Float)
+"#,
+    )
+    .expect("write A.av failed");
+    std::fs::write(
+        root.join("B.av"),
+        r#"module B
+    exposes [Shape]
+    intent = "B.Shape."
+
+type Shape
+    Triangle(Float)
+"#,
+    )
+    .expect("write B.av failed");
+
+    let src = r#"module Main
+    depends [A, B]
+    intent = "Bare Shape annotation in a binding."
+
+fn pick() -> Float
+    s: Shape = A.Shape.Circle(1.0)
+    0.0
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        errs.iter().any(|e| {
+            e.contains("Binding 's' annotation")
+                && e.contains("Ambiguous type name 'Shape'")
+                && e.contains("A.Shape")
+                && e.contains("B.Shape")
+        }),
+        "expected an ambiguity diagnostic on the binding annotation, got: {errs:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// Phase B (#138, peer review #148): the exported `TypeCheckResult.fn_sigs`
 /// map must not silently bind a bare-name fn entry when two distinct
 /// dep modules both expose the same bare name. Rust codegen and

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2725,6 +2725,53 @@ fn callsWithB() -> Float
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// Phase B (#138, peer review round 4 F1): a qualified
+/// `C.Shape` reference must NOT resolve when `C` doesn't expose
+/// `Shape`. Pre-fix `resolve_type_id` consulted the symbol table
+/// directly, which carries every dep type regardless of the
+/// `exposes` contract, so the qualified import bypassed visibility.
+/// Now `resolve_type_id` filters through `visible_type_ids`
+/// (populated only from `SymbolRegistry::from_modules` and own-
+/// module declarations); the qualified private import either fails
+/// to resolve, or — when picked up at a signature boundary — the
+/// explicit "private import" diagnostic surfaces.
+#[test]
+fn qualified_private_dep_type_does_not_resolve() {
+    let root = temp_module_root("qualified_private_import");
+    std::fs::write(
+        root.join("C.av"),
+        r#"module C
+    exposes [helper]
+    intent = "C.Shape declared but NOT exposed."
+
+type Shape
+    Hexagon(Float)
+
+fn helper() -> Int
+    0
+"#,
+    )
+    .expect("write C.av failed");
+
+    let src = r#"module Main
+    depends [C]
+    intent = "Tries to import C.Shape directly."
+
+fn takesPrivate(s: C.Shape) -> Float
+    0.0
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        errs.iter().any(|e| {
+            (e.contains("private") || e.contains("not exposed") || e.contains("not visible"))
+                && e.contains("C.Shape")
+        }),
+        "expected a 'C.Shape is private / not exposed' diagnostic on `s: C.Shape`, got: {errs:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// Phase B (#138, peer review round 3 nit #1): the ambiguity
 /// diagnostic must NOT list a private (non-exposed) candidate even
 /// when it shares the bare name. `Resolution::Ambiguous(Vec<TypeId>)`

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2725,6 +2725,130 @@ fn callsWithB() -> Float
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// Phase B (#138, peer review round 6): an exported `fn` in module
+/// B that references a type by bare name must resolve in B's own
+/// resolver context — B's own types + B's actual `depends` transitive
+/// exports — NOT against arbitrary siblings the entry module happens
+/// to also pull in.
+///
+/// Repro: B depends on A and re-uses `A.Shape` as bare `Shape` in
+/// its own signature. Main depends on B and C (C exposes an
+/// unrelated `Shape`). Pre-fix, when Main's checker canonicalised
+/// B's exported sig, the bare `Shape` resolved against the
+/// importer's bare alias map — which was ambiguous between
+/// `A.Shape` and `C.Shape` — and the typed-id never got populated.
+/// `takeA(B.pass(A.make()))` then failed with the cross-module
+/// collapse. Fix: per-owner resolver knows B's own `depends [A]`,
+/// resolves `Shape` to `A.Shape`, ignoring siblings.
+#[test]
+fn dep_module_resolver_uses_owner_depends_not_importer_siblings() {
+    let root = temp_module_root("owner_depends_resolver");
+    std::fs::write(
+        root.join("A.av"),
+        r#"module A
+    exposes [Shape, make]
+    intent = "A.Shape + factory."
+
+type Shape
+    Circle(Float)
+
+fn make() -> Shape
+    Shape.Circle(1.0)
+"#,
+    )
+    .expect("write A.av failed");
+    std::fs::write(
+        root.join("B.av"),
+        r#"module B
+    depends [A]
+    exposes [pass]
+    intent = "Re-exports an A.Shape passthrough; uses bare `Shape`."
+
+fn pass(s: Shape) -> Shape
+    s
+"#,
+    )
+    .expect("write B.av failed");
+    std::fs::write(
+        root.join("C.av"),
+        r#"module C
+    exposes [Shape]
+    intent = "Unrelated sibling Shape that must NOT leak into B's scope."
+
+type Shape
+    Triangle(Float)
+"#,
+    )
+    .expect("write C.av failed");
+
+    let src = r#"module Main
+    depends [B, C]
+    intent = "Plumbs A.make through B.pass; C is just an unrelated sibling."
+
+fn takeA(s: A.Shape) -> Float
+    match s
+        A.Shape.Circle(r) -> r
+
+fn caller() -> Float
+    takeA(B.pass(A.make()))
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        errs.is_empty(),
+        "expected B's bare `Shape` to resolve to A.Shape via B's own depends; got: {errs:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Phase B (#138, peer review round 6 part 2): a dep module B's
+/// bare `Shape` must NOT fall back to a `Shape` declared in the
+/// entry module. Entry-scope types don't belong to dep modules'
+/// resolver contexts. `B.id(s: Shape)` with no `Shape` in B's scope
+/// (and Main defining one) should fail to resolve, not silently bind
+/// B's parameter to Main's type.
+#[test]
+fn dep_module_resolver_does_not_fall_back_to_entry_types() {
+    let root = temp_module_root("dep_resolver_no_entry_fallback");
+    std::fs::write(
+        root.join("B.av"),
+        r#"module B
+    exposes [id]
+    intent = "Has no `Shape`; uses bare `Shape` in its signature."
+
+fn id(s: Shape) -> Shape
+    s
+"#,
+    )
+    .expect("write B.av failed");
+
+    let src = r#"module Main
+    depends [B]
+    intent = "Defines its own Shape; B must NOT pick it up."
+
+type Shape
+    Circle(Float)
+
+fn caller() -> Float
+    match B.id(Shape.Circle(1.0))
+        Shape.Circle(r) -> r
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    // B's signature contains an unresolved `Shape` — B has neither
+    // its own nor any dep providing one. The pre-fix entry-fallback
+    // let this silently bind to Main's `Shape`, smuggling Main's
+    // type into B's signature. Either B's sig fails to typecheck
+    // (B can't resolve `Shape`) or Main's call surfaces the
+    // identity mismatch; both are acceptable, but a quiet `✓ types`
+    // is the regression we're guarding against.
+    assert!(
+        !errs.is_empty(),
+        "expected B's `s: Shape` to fail to silently bind to Main.Shape via entry-fallback; got no errors"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// Phase B (#138, peer review round 5 F1): the type stamp on
 /// a dep module's exported fn signature must resolve in the dep's
 /// own scope, not the importer's. Pre-fix

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2675,25 +2675,31 @@ type Shape
     depends [A, B]
     intent = "Bare reference to Shape must be ambiguous."
 
-fn takesAShape(s: A.Shape) -> Float
+fn takesShape(s: Shape) -> Float
     0.0
 
+fn callsWithA() -> Float
+    takesShape(A.Shape.Circle(1.0))
+
 fn callsWithB() -> Float
-    takesAShape(B.Shape.Triangle(3.0))
+    takesShape(B.Shape.Triangle(2.0))
 "#;
     let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
-    // Bare `Shape` resolves to neither: the param expects `A.Shape`
-    // (qualified), the caller passes a `B.Shape.Triangle` — typed
-    // identity must reject the call regardless of whether the bare
-    // `Shape` alias map remembers one side or the other. Pre-phase-B
-    // soundness already relied on the matcher rejecting this; what
-    // peer review #148 added on top: the bare alias map must not
-    // silently bind one side, so `Shape` referenced bare anywhere in
-    // Main also fails to resolve.
+    // The param annotation `s: Shape` cannot resolve — both
+    // `A.Shape` and `B.Shape` are exposed, so the bare alias is
+    // `Ambiguous` and `resolve_type_id` deliberately refuses it.
+    // Each call site then surfaces a typed-identity mismatch: the
+    // caller's `A.Shape.Circle(...)` / `B.Shape.Triangle(...)` stamps
+    // a `Type::Named { id: Some(_), name: "Shape" }` value, the
+    // param is `Type::Named { id: None, name: "Shape" }`, and the
+    // matcher refuses the mixed-id case for ambiguous-by-design
+    // names. Without that refusal the old name-equality fallback
+    // would let both calls go through and silently agree on
+    // whichever `Shape` happened to win the global alias slot.
+    let mismatches: Vec<&String> = errs.iter().filter(|e| e.contains("takesShape")).collect();
     assert!(
-        errs.iter()
-            .any(|e| e.contains("Argument 1 of 'takesAShape'") && e.contains("expected A.Shape")),
-        "expected A.Shape vs B.Shape mismatch at the call site, got: {errs:?}"
+        !mismatches.is_empty(),
+        "expected at least one diagnostic on a `takesShape(...)` call when `Shape` is ambiguous, got: {errs:?}"
     );
 
     let _ = std::fs::remove_dir_all(&root);
@@ -2767,6 +2773,73 @@ fn caller() -> Int
     assert!(
         !result.fn_sigs.contains_key("doit"),
         "bare `doit` must not appear when two dep modules both expose it; keys: {:?}",
+        result.fn_sigs.keys().collect::<Vec<_>>()
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Phase B (#138, peer review round 2): when the entry module and a
+/// dep module both declare `doit`, source-level `doit()` inside the
+/// entry unambiguously means the entry's own fn. The exported
+/// `TypeCheckResult.fn_sigs` bare alias must therefore point at the
+/// entry fn rather than being suppressed as "ambiguous" — consumers
+/// (`verify_effects`, `diagnostics::context::callgraph`, intent
+/// checks) still look the entry's bodies up by `&fd.name` and need
+/// the local signature.
+#[test]
+fn entry_local_fn_shadows_dep_module_bare_alias() {
+    use aver::source::parse_source;
+
+    let root = temp_module_root("entry_shadows_dep_fn");
+    std::fs::write(
+        root.join("Helper.av"),
+        r#"module Helper
+    exposes [doit]
+    intent = "Dep `doit` returning a String."
+
+fn doit(n: Int) -> String
+    "from-helper"
+"#,
+    )
+    .expect("write Helper.av failed");
+
+    let src = r#"module Main
+    depends [Helper]
+    intent = "Local `doit` shadowing the imported one."
+
+fn doit(n: Int) -> Int
+    n
+
+fn caller() -> Int
+    doit(7)
+"#;
+    let items = parse_source(src).expect("parse failed");
+    let mut items = items;
+    aver::tco::transform_program(&mut items);
+    let result = aver::types::checker::run_type_check_full(&items, root.to_str());
+
+    // No errors — `doit(7)` resolves to the entry's own fn.
+    assert!(
+        result.errors.is_empty(),
+        "expected entry-local `doit` to resolve cleanly, got: {:?}",
+        result.errors
+    );
+    // Bare alias points at the entry's signature (returns `Int`),
+    // not at Helper's (returns `String`).
+    let (_, bare_ret, _) = result
+        .fn_sigs
+        .get("doit")
+        .expect("expected bare `doit` alias to be present (entry shadowing)");
+    assert!(
+        matches!(bare_ret, aver::ast::Type::Int),
+        "bare `doit` ret must be the entry fn's `Int`, not Helper.doit's `String`; got {:?}",
+        bare_ret
+    );
+    // Canonical Helper.doit is still reachable for callers that want it.
+    assert!(
+        result.fn_sigs.contains_key("Helper.doit"),
+        "expected canonical Helper.doit, got keys: {:?}",
         result.fn_sigs.keys().collect::<Vec<_>>()
     );
 

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2725,6 +2725,125 @@ fn callsWithB() -> Float
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// Phase B (#138, peer review round 5 F1): the type stamp on
+/// a dep module's exported fn signature must resolve in the dep's
+/// own scope, not the importer's. Pre-fix
+/// `integrate_registry` called the regular `canonicalize_named`,
+/// which uses the importer's `current_module_prefix` + bare alias
+/// map — so `B.make() -> Shape` (where `Shape` is B's own type) lost
+/// its `TypeId` whenever `Shape` was ambiguous or unresolvable in
+/// `Main`. The user-visible failure was
+/// `expected B.Shape, got Shape` on every cross-module call.
+#[test]
+fn dep_module_exported_sig_resolves_in_owner_scope() {
+    let root = temp_module_root("owner_aware_canonicalize");
+    std::fs::write(
+        root.join("A.av"),
+        r#"module A
+    exposes [Shape]
+    intent = "A.Shape."
+
+type Shape
+    Circle(Float)
+"#,
+    )
+    .expect("write A.av failed");
+    std::fs::write(
+        root.join("B.av"),
+        r#"module B
+    exposes [Shape, make]
+    intent = "B.Shape + factory."
+
+type Shape
+    Triangle(Float)
+
+fn make() -> Shape
+    Shape.Triangle(2.0)
+"#,
+    )
+    .expect("write B.av failed");
+
+    let src = r#"module Main
+    depends [A, B]
+    intent = "Forwards B.make() into a B.Shape consumer."
+
+fn takeB(s: B.Shape) -> Float
+    match s
+        B.Shape.Triangle(r) -> r
+
+fn caller() -> Float
+    takeB(B.make())
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        errs.is_empty(),
+        "expected `takeB(B.make())` to typecheck cleanly when B.make's return is B.Shape; got: {errs:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Phase B (#138, peer review round 5 F1, soundness counterpart):
+/// even when both dep modules hide their own `Shape` from `exposes`,
+/// the typechecker must still distinguish `C.Shape` from `D.Shape`
+/// at the matcher boundary so `D.consume(C.make())` is rejected.
+/// Pre-fix the registry-side canonicalisation left both signatures'
+/// `Shape` references unresolved (`id: None`), the matcher's
+/// `(None, None)` branch compared by name, and the call silently
+/// passed. With owner-aware canonicalisation each side carries its
+/// own real `TypeId` (still treated as opaque to the importer
+/// because neither type is exposed) and the matcher rejects.
+#[test]
+fn private_exported_sig_types_do_not_collapse_across_modules() {
+    let root = temp_module_root("private_exported_sigs_distinct");
+    std::fs::write(
+        root.join("C.av"),
+        r#"module C
+    exposes [make]
+    intent = "C's Shape is private but appears in exported make."
+
+type Shape
+    Hexagon(Float)
+
+fn make() -> Shape
+    Shape.Hexagon(1.0)
+"#,
+    )
+    .expect("write C.av failed");
+    std::fs::write(
+        root.join("D.av"),
+        r#"module D
+    exposes [consume]
+    intent = "D's Shape is private but appears in exported consume."
+
+type Shape
+    Circle(Float)
+
+fn consume(s: Shape) -> Float
+    match s
+        Shape.Circle(r) -> r
+"#,
+    )
+    .expect("write D.av failed");
+
+    let src = r#"module Main
+    depends [C, D]
+    intent = "Tries to feed C.make() into D.consume — distinct private types."
+
+fn main() -> Float
+    D.consume(C.make())
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("Argument 1 of 'D.consume'")
+                || e.contains("Argument 1 of 'consume'")),
+        "expected an argument-type mismatch on `D.consume(C.make())` (C.Shape != D.Shape); got: {errs:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// Phase B (#138, peer review round 4 F1): a qualified
 /// `C.Shape` reference must NOT resolve when `C` doesn't expose
 /// `Shape`. Pre-fix `resolve_type_id` consulted the symbol table

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2638,6 +2638,141 @@ fn pick() -> Int
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// Phase B (#138, peer review #148): when two dep modules each
+/// expose the same bare type name (`A.Shape` *and* `B.Shape` both
+/// exposed as `Shape`), the bare alias resolution must NOT silently
+/// pick one. The pre-review code last-write-won an arbitrary
+/// `TypeId`; that's the same bug class typed identity is supposed to
+/// eliminate. Verify the bare reference is rejected so callers are
+/// forced to qualify.
+#[test]
+fn cross_module_same_bare_type_name_bare_reference_is_ambiguous() {
+    let root = temp_module_root("bare_ambiguous_type");
+    std::fs::write(
+        root.join("A.av"),
+        r#"module A
+    exposes [Shape]
+    intent = "Module A's Shape."
+
+type Shape
+    Circle(Float)
+"#,
+    )
+    .expect("write A.av failed");
+    std::fs::write(
+        root.join("B.av"),
+        r#"module B
+    exposes [Shape]
+    intent = "Module B's Shape."
+
+type Shape
+    Triangle(Float)
+"#,
+    )
+    .expect("write B.av failed");
+
+    let src = r#"module Main
+    depends [A, B]
+    intent = "Bare reference to Shape must be ambiguous."
+
+fn takesAShape(s: A.Shape) -> Float
+    0.0
+
+fn callsWithB() -> Float
+    takesAShape(B.Shape.Triangle(3.0))
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    // Bare `Shape` resolves to neither: the param expects `A.Shape`
+    // (qualified), the caller passes a `B.Shape.Triangle` — typed
+    // identity must reject the call regardless of whether the bare
+    // `Shape` alias map remembers one side or the other. Pre-phase-B
+    // soundness already relied on the matcher rejecting this; what
+    // peer review #148 added on top: the bare alias map must not
+    // silently bind one side, so `Shape` referenced bare anywhere in
+    // Main also fails to resolve.
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("Argument 1 of 'takesAShape'") && e.contains("expected A.Shape")),
+        "expected A.Shape vs B.Shape mismatch at the call site, got: {errs:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Phase B (#138, peer review #148): the exported `TypeCheckResult.fn_sigs`
+/// map must not silently bind a bare-name fn entry when two distinct
+/// dep modules both expose the same bare name. Rust codegen and
+/// other downstream consumers historically did
+/// `ctx.fn_sigs.get(&fd.name)` against a `HashMap<String, _>` whose
+/// global bare alias was last-write-wins — a real bug class where a
+/// `foo` lookup could pick up the wrong module's parameter list.
+/// After this PR the bare-name entry exists only when unambiguous;
+/// the canonical `"Module.foo"` key is always present.
+#[test]
+fn cross_module_same_bare_fn_name_drops_bare_alias_in_exported_map() {
+    use aver::source::parse_source;
+    use aver::types::checker::run_type_check_with_base;
+
+    let root = temp_module_root("bare_ambiguous_fn");
+    std::fs::write(
+        root.join("A.av"),
+        r#"module A
+    exposes [doit]
+    intent = "Module A's doit."
+
+fn doit(a: Int) -> Int
+    a
+"#,
+    )
+    .expect("write A.av failed");
+    std::fs::write(
+        root.join("B.av"),
+        r#"module B
+    exposes [doit]
+    intent = "Module B's doit (different param)."
+
+fn doit(b: String) -> Int
+    0
+"#,
+    )
+    .expect("write B.av failed");
+
+    let src = r#"module Main
+    depends [A, B]
+    intent = "Two `doit` fns, only the qualified form may resolve."
+
+fn caller() -> Int
+    A.doit(1)
+"#;
+    let items = parse_source(src).expect("parse failed");
+    let mut items = items;
+    aver::tco::transform_program(&mut items);
+    let _ = run_type_check_with_base(&items, root.to_str());
+    let result = aver::types::checker::run_type_check_full(&items, root.to_str());
+
+    // Both qualified canonicals are present.
+    assert!(
+        result.fn_sigs.contains_key("A.doit"),
+        "expected canonical A.doit, got keys: {:?}",
+        result.fn_sigs.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        result.fn_sigs.contains_key("B.doit"),
+        "expected canonical B.doit, got keys: {:?}",
+        result.fn_sigs.keys().collect::<Vec<_>>()
+    );
+    // The bare-name alias is suppressed because A.doit and B.doit
+    // disagree — last-write-wins would have left whichever module
+    // happened to iterate second silently winning the `doit` slot.
+    assert!(
+        !result.fn_sigs.contains_key("doit"),
+        "bare `doit` must not appear when two dep modules both expose it; keys: {:?}",
+        result.fn_sigs.keys().collect::<Vec<_>>()
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// Iron — A4: a single source error (here: an unknown function
 /// call) must not fan out through downstream `compatible` checks
 /// and produce a cascade of "expected X, got Invalid" diagnostics.


### PR DESCRIPTION
## Summary

Phase B of #147: the typechecker now carries opaque identity through the same `SymbolTable` layer the proof IR and backends already consume (#141–#146). Cross-module same-bare-name user types stay distinct by `TypeId` at the matcher boundary instead of relying on `sig_aliases` string→string canonicalisation.

Single atomic PR — design choices documented inline so the review can stay in one session.

## Design

Picked a single-variant approach rather than `Type::Unresolved` + `Type::Named`:

```rust
pub enum Type {
    …
    Named { id: Option<TypeId>, name: String },
}
```

- `id` is the load-bearing identity. Two `Named` with both `Some` compare by `id == id` (typed identity — cross-module `Shape` types stay distinct by construction).
- `name` stays **source-faithful** (what the user wrote: `"Shape"` or `"A.Shape"`), so downstream string-equality consumers — Rust codegen's boxing detection (`param_name == ret_name`), wasm-gc dispatch tables — keep seeing the pre-phase-B form. The matcher falls back to source-name comparison when either side's `id` is `None` (builtins like `HttpResponse` / `Header` / `Tcp.Connection`, in-flight stamps that didn't resolve).

The dual-variant `Unresolved` design was attempted earlier in the session but produced an explosion of pattern-match touch points across 38 files without a real soundness improvement over the `Option<TypeId>` field; ~127 mechanical sweeps were already painful, dual variants would have ~doubled the diff. Compiler eats complexity, not surface area.

### Storage split

`TypeChecker.fn_sigs: HashMap<String, FnSig>` is gone. In its place:

- `fn_sigs: HashMap<FnId, FnSig>` — **user-defined** functions only (one entry per `FnId` in the program symbol table).
- `extra_sigs: HashMap<String, FnSig>` — builtin namespace methods (`Int.add`, `Console.print`) and sum-type variant constructors keyed by canonical `"Module.Type.Variant"`. These don't have `FnId`s in `SymbolTable` because they're not part of the user-program identity space.

`find_fn_sig` / `insert_fn_sig` / `all_fn_sigs` chain the two halves so existing bare-name callsites (and the exported `TypeCheckResult.fn_sigs` string-keyed map) keep working.

### sig_aliases dropped

`sig_aliases: HashMap<String, String>` is gone. Replaced by typed bridges:

- `bare_fn_aliases: HashMap<String, FnId>`
- `bare_type_aliases: HashMap<String, TypeId>`

Populated from visibility-exposed aliases in `integrate_registry` (and from `build_signatures` for the current module's own fns). `resolve_fn_id` / `resolve_type_id` chain: literal-as-qualified → current-module-scoped → entry-scope → typed bare alias.

### Pipeline ordering

`SymbolTable::build` now runs **before** typecheck in `build_symbols_for_items` / `build_symbols_with_loaded`. The table is threaded into the checker via `TypeChecker::new_with_symbols`. The existing `pipeline::run` build of the table after typecheck stays — `result.symbol_table` is unchanged for backward compat, just built deterministically against the same inputs.

### Opaque ID types relocated

`FnId` / `TypeId` / `CtorId` / `ModuleId` moved from `ir::symbol_table` to `ir::identity` so `ast::Type` can carry a `TypeId` field without forming a cycle through `ir::symbol_table` (which depends on `ast`). Re-exports preserve every existing import path.

## Verified

- ✅ `cargo build --features wasm` — clean.
- ✅ `cargo test --features wasm` — **1608 passed, 0 failed, 7 ignored**.
- ✅ `cargo clippy --all-targets --features wasm -- -D warnings` — clean.
- ✅ `cargo fmt --check` — clean.
- ✅ Regression test `cross_module_same_named_types_do_not_merge` passes.
- ✅ `aver compile examples/core/order_total.av --target wasm-gc` produces **byte-identical output** to pre-change (md5 `61e45b325279e17e1b0d8dce3fde43f9`).
- ✅ `aver check` on `examples/games/snake.av` and `examples/games/rogue/main.av` succeeds.

## Test plan

- [ ] Skim the patch (~940 +/-494, 45 files; bulk is mechanical `Type::Named(n)` → `Type::Named { name: n, .. }` and `Type::Named("X".to_string())` → `Type::named("X")`)
- [ ] Spot-check `src/types/checker/mod.rs` — new `resolve_fn_id`/`resolve_type_id`/`canonical_type_name` helpers + storage split rationale
- [ ] Spot-check `src/types/checker/modules.rs` — `build_signatures` / `register_type_def_sigs` / `integrate_registry` route through `insert_fn_sig`, populate typed aliases, `canonicalize_named` sets `id` without rewriting `name`
- [ ] Verify locally: `cargo test --features wasm` and `aver compile examples/core/order_total.av --target wasm-gc`
- [ ] Confirm follow-up scope (constructors → `CtorId`, type-name maps → typed keys) belongs to a separate PR

## Deferred (not blocking phase B)

- Constructors still live in `extra_sigs` keyed by canonical string. They have `CtorEntry`s in `SymbolTable` already but aren't keyed by `CtorId` in the checker yet — migrating that is its own pass.
- `record_field_types`, `type_variants`, `value_members`, `opaque_types` stay string-keyed using canonical-form keys with on-the-fly resolution through `canonical_type_name`. Migrating each to `TypeId`-keyed is mechanical but heavy and out of phase B's stated scope.
- `pipeline::run` still rebuilds the symbol table after typecheck for `result.symbol_table`. Either remove the duplicate build or have typecheck stash its table into `result` — small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)