### PR TITLE
main: aver compile --emit-ir-after=name_resolve — #147 phase E PR 5

### DIFF
--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -428,14 +428,15 @@ pub(super) enum Commands {
         optimize: Option<WasmOptMode>,
         /// Print the IR after the named pipeline stage and exit before codegen.
         /// One of: `tco`, `typecheck`, `interp_lower`, `buffer_build`, `resolve`,
-        /// `last_use`, `analyze`, `escape`, `build_symbols`, `refinement_lower`,
-        /// `contract_lower`, `law_lower`. Use `--emit-ir-after=resolve` to see
-        /// the final IR that goes into codegen. Pass `parse` to see the AST as
-        /// the parser produced it, before any pass runs. For side-artifact
-        /// stages (`build_symbols` dumps the SymbolTable, `refinement_lower` /
-        /// `contract_lower` / `law_lower` dump the ProofIR sections each
-        /// populates) the dump shows the produced artifact, not the
-        /// (unchanged) items list.
+        /// `last_use`, `analyze`, `escape`, `build_symbols`, `name_resolve`,
+        /// `refinement_lower`, `contract_lower`, `law_lower`. Use
+        /// `--emit-ir-after=resolve` to see the final IR that goes into codegen.
+        /// Pass `parse` to see the AST as the parser produced it, before any
+        /// pass runs. For side-artifact stages (`build_symbols` dumps the
+        /// SymbolTable; `name_resolve` dumps the resolved HIR with FnId/CtorId/
+        /// TypeId markers; `refinement_lower` / `contract_lower` / `law_lower`
+        /// dump the ProofIR sections each populates) the dump shows the
+        /// produced artifact, not the (unchanged) items list.
         #[arg(long, value_name = "PASS")]
         emit_ir_after: Option<String>,
         /// Run the full pipeline and print a per-pass diagnostic report

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -3067,6 +3067,7 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
         "analyze" => Some(PipelineStage::Analyze),
         "escape" => Some(PipelineStage::Escape),
         "build_symbols" => Some(PipelineStage::BuildSymbols),
+        "name_resolve" => Some(PipelineStage::NameResolve),
         "refinement_lower" => Some(PipelineStage::RefinementLower),
         "contract_lower" => Some(PipelineStage::ContractLower),
         "law_lower" => Some(PipelineStage::LawLower),
@@ -3075,7 +3076,7 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
                 "{}",
                 format!(
                     "unknown --emit-ir-after stage '{}'; expected one of: \
-                     parse, tco, typecheck, interp_lower, buffer_build, resolve, last_use, analyze, escape, build_symbols, refinement_lower, contract_lower, law_lower",
+                     parse, tco, typecheck, interp_lower, buffer_build, resolve, last_use, analyze, escape, build_symbols, name_resolve, refinement_lower, contract_lower, law_lower",
                     other
                 )
                 .red()
@@ -3149,6 +3150,7 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
             run_refinement_lower,
             run_contract_lower,
             run_law_lower,
+            run_name_resolve: target == PipelineStage::NameResolve,
             dep_modules: &dep_modules,
             on_after_pass: Some(Box::new(|stage, items_after| {
                 if stage == target {
@@ -3197,6 +3199,29 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
             "{}",
             render_symbol_table_dump(&pipeline_result.symbol_table)
         );
+        return;
+    }
+
+    // `name_resolve` — render the resolved HIR (Phase E PR 5 of #147).
+    // The resolved AST lives in `pipeline_result.resolved_items`, not
+    // in the item slice, because the pass is a producer rather than
+    // an in-place rewrite. `dump_resolved_program` surfaces opaque
+    // `FnId` / `CtorId` / `TypeId` markers so the migration is
+    // visually verifiable from the CLI.
+    if target == PipelineStage::NameResolve {
+        match pipeline_result.resolved_items {
+            Some(items) => {
+                print!("{}", aver::ir::hir::dump_resolved_program(&items));
+            }
+            None => {
+                eprintln!(
+                    "{}",
+                    "stage 'name_resolve' did not run (likely skipped after typecheck errors)"
+                        .red(),
+                );
+                process::exit(1);
+            }
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary

Fifth PR of the Phase E stack from RFC #147. Wires the resolved HIR dump (PR #152) into the CLI so users can inspect the Phase E output from `aver compile`. Completes the deferred CLI work from PR 4's \"What's NOT here\" section. **Zero risk: pure plumbing, no pipeline behaviour change.**

Stacks on #152 (merged on main).

## What lands

- `cmd_emit_ir_after` recognises `name_resolve` as a stage name.
- Sets `PipelineConfig::run_name_resolve: true` when the target is `NameResolve` so the pass actually fires.
- After `pipeline::run` returns, when the target is `NameResolve` the CLI renders `pipeline_result.resolved_items` via `aver::ir::hir::dump_resolved_program` and prints it. Mirrors the side-artifact rendering path that `build_symbols` / `refinement_lower` etc. already use.
- `--help` text on the `emit-ir-after` flag lists `name_resolve` alongside the other stages.

## Smoke test

`aver compile examples/core/order_total.av --emit-ir-after=name_resolve` now prints (excerpt):

```
fn <fn:0>mkDiscount(percent: Float) -> Result<Discount, String>
    match (<slot:0:percent> < 0)
      | true -> Result.Err(\"Discount cannot be negative\")
      | false -> ...
        | false -> Result.Ok(<type:1>Discount(percent = <slot:0:percent>))
```

— every name that the resolver classified carries its opaque identity in the dump, exactly the visual signal future backend migration PRs will use to verify their input.

## What's NOT here

- **Backend migration**: still next. PR 4 (dump tooling) + PR 5 (CLI wiring) together give us a full inspection loop before any backend changes touch real codegen.

## Verified

- ✅ `cargo build --features wasm` clean.
- ✅ `cargo test --features wasm` — 1648 passed, 0 failed.
- ✅ `cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings` clean.
- ✅ `cargo clippy -p aver-lang --lib --bin aver -- -D warnings` clean.
- ✅ `cargo fmt --all -- --check` clean.
- ✅ `aver compile examples/core/order_total.av --target wasm-gc` byte-identical to main (md5 `61e45b325279e17e1b0d8dce3fde43f9`).

## Test plan

- [ ] Run `aver compile examples/core/order_total.av --emit-ir-after=name_resolve` locally — verify the dump renders with FnId/CtorId/TypeId markers.
- [ ] Skim `src/main/commands.rs:cmd_emit_ir_after` — confirm the new branch mirrors the existing side-artifact stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)