### PR TITLE
codegen: shared ctx.resolve_{fn_def,expr,stmt,pattern} — #147 phase E PR 9

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -655,4 +655,137 @@ impl CodegenContext {
         let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(self);
         self.proof_ir = crate::codegen::proof_lower::lower(&inputs);
     }
+
+    /// Look up the resolved-HIR mirror of a source-shape [`FnDef`]
+    /// previously stashed in [`resolved_fn_defs`] /
+    /// [`resolved_module_fn_defs`]. Falls back to a fresh per-call
+    /// resolver lift against the entry's [`crate::ir::SymbolTable`]
+    /// when neither path covers `fd` — this happens for synthetic
+    /// FnDefs inserted between `build_context` and emit (memo
+    /// wrappers, TCO hoist rewrites, test fixtures) which the
+    /// resolver hasn't lifted upfront.
+    ///
+    /// Phase E shared lookup boundary — Rust codegen (PR 8) already
+    /// consumes this through `rust::toplevel::resolved_fn_def_for`;
+    /// wasm-gc / Lean / Dafny / self-host backends pick it up in
+    /// their follow-up PRs.
+    ///
+    /// [`resolved_fn_defs`]: Self::resolved_fn_defs
+    /// [`resolved_module_fn_defs`]: Self::resolved_module_fn_defs
+    pub fn resolve_fn_def<'a>(
+        &'a self,
+        fd: &'a FnDef,
+    ) -> std::borrow::Cow<'a, crate::ir::hir::ResolvedFnDef> {
+        use crate::ir::hir::{
+            ResolveCtx, ResolvedFnBody, ResolvedFnDef, ResolvedStmt, resolve_fn_def_external,
+        };
+        use std::borrow::Cow;
+        if let Some(rfd) = self.resolved_fn_defs.iter().find(|rfd| rfd.name == fd.name) {
+            return Cow::Borrowed(rfd);
+        }
+        for module in &self.resolved_module_fn_defs {
+            if let Some(rfd) = module.iter().find(|rfd| rfd.name == fd.name) {
+                return Cow::Borrowed(rfd);
+            }
+        }
+        let module_name = self.items.iter().find_map(|i| match i {
+            TopLevel::Module(m) => Some(m.name.clone()),
+            _ => None,
+        });
+        let mut rctx = ResolveCtx::new(&self.symbol_table);
+        rctx.current_module = module_name;
+        let lifted = resolve_fn_def_external(&rctx, fd).unwrap_or_else(|| {
+            let stmts: Vec<ResolvedStmt> = match fd.body.as_ref() {
+                crate::ast::FnBody::Block(stmts) => {
+                    stmts.iter().map(|s| self.resolve_stmt(s)).collect()
+                }
+            };
+            ResolvedFnDef {
+                fn_id: crate::ir::FnId(u32::MAX),
+                name: fd.name.clone(),
+                line: fd.line,
+                params: fd
+                    .params
+                    .iter()
+                    .map(|(n, ann)| (n.clone(), crate::types::parse_type_str(ann)))
+                    .collect(),
+                return_type: crate::types::parse_type_str(&fd.return_type),
+                effects: fd.effects.clone(),
+                desc: fd.desc.clone(),
+                body: std::sync::Arc::new(ResolvedFnBody::Block(stmts)),
+                resolution: fd.resolution.clone(),
+            }
+        });
+        Cow::Owned(lifted)
+    }
+
+    /// Resolve a source-shape `Spanned<Expr>` on demand using the
+    /// entry's resolver context. Used by emit helpers that still walk
+    /// `Expr` (TCO hoisting, mutual TCO, verify blocks, follow-up
+    /// backends pre-migration) and need to feed the resolved shape
+    /// into the migrated emitter. The returned `Spanned<ResolvedExpr>`
+    /// carries the same line + type stamp as the input.
+    pub fn resolve_expr(
+        &self,
+        expr: &crate::ast::Spanned<crate::ast::Expr>,
+    ) -> crate::ast::Spanned<crate::ir::hir::ResolvedExpr> {
+        use crate::ir::hir::{ResolveCtx, ResolvedStmt};
+        let module_name = self.items.iter().find_map(|i| match i {
+            TopLevel::Module(m) => Some(m.name.clone()),
+            _ => None,
+        });
+        let mut rctx = ResolveCtx::new(&self.symbol_table);
+        rctx.current_module = module_name;
+        let stmt = crate::ast::Stmt::Expr(expr.clone());
+        match crate::ir::hir::resolve::resolve_stmt_external(&rctx, &stmt) {
+            ResolvedStmt::Expr(s) => s,
+            ResolvedStmt::Binding { value, .. } => value,
+        }
+    }
+
+    /// Same as [`Self::resolve_expr`] but for whole statements
+    /// (`Binding(name, ty_ann, expr)` or `Expr(expr)`).
+    pub fn resolve_stmt(&self, stmt: &crate::ast::Stmt) -> crate::ir::hir::ResolvedStmt {
+        use crate::ir::hir::ResolveCtx;
+        let module_name = self.items.iter().find_map(|i| match i {
+            TopLevel::Module(m) => Some(m.name.clone()),
+            _ => None,
+        });
+        let mut rctx = ResolveCtx::new(&self.symbol_table);
+        rctx.current_module = module_name;
+        crate::ir::hir::resolve::resolve_stmt_external(&rctx, stmt)
+    }
+
+    /// Resolve a source-shape [`crate::ast::Pattern`] to its resolved
+    /// HIR form. Wraps the pattern in a synthetic match arm + drops
+    /// it through `resolve_stmt_external`, since the resolver doesn't
+    /// expose a standalone pattern lifter — same workaround
+    /// `rust/toplevel.rs` used pre-PR-9.
+    pub fn resolve_pattern(&self, pat: &crate::ast::Pattern) -> crate::ir::hir::ResolvedPattern {
+        use crate::ast::{Expr, Literal, MatchArm, Spanned, Stmt};
+        use crate::ir::hir::{ResolveCtx, ResolvedExpr, ResolvedStmt};
+        let module_name = self.items.iter().find_map(|i| match i {
+            TopLevel::Module(m) => Some(m.name.clone()),
+            _ => None,
+        });
+        let mut rctx = ResolveCtx::new(&self.symbol_table);
+        rctx.current_module = module_name;
+        let synthetic_arm = MatchArm {
+            pattern: pat.clone(),
+            body: Box::new(Spanned::bare(Expr::Literal(Literal::Unit))),
+            binding_slots: std::sync::OnceLock::new(),
+        };
+        let stmt = Stmt::Expr(Spanned::bare(Expr::Match {
+            subject: Box::new(Spanned::bare(Expr::Literal(Literal::Unit))),
+            arms: vec![synthetic_arm],
+        }));
+        let resolved_stmt = crate::ir::hir::resolve::resolve_stmt_external(&rctx, &stmt);
+        let ResolvedStmt::Expr(spanned) = resolved_stmt else {
+            unreachable!()
+        };
+        let ResolvedExpr::Match { arms, .. } = spanned.node else {
+            unreachable!()
+        };
+        arms.into_iter().next().unwrap().pattern
+    }
 }

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -6,103 +6,18 @@ use super::expr::{
 use super::types::type_annotation_to_rust;
 use crate::ast::*;
 use crate::codegen::CodegenContext;
-use crate::ir::hir::{
-    ResolveCtx, ResolvedExpr, ResolvedFnBody, ResolvedFnDef, ResolvedMatchArm, ResolvedPattern,
-    ResolvedStmt, resolve_fn_def_external,
-};
+use crate::ir::hir::{ResolvedFnBody, ResolvedMatchArm, ResolvedStmt};
 use crate::ir::{BodyExprPlan, CallPlan, LeafOp, thin_kind_is_parent_thin_candidate};
 use crate::types::{Type, parse_type_str};
 /// Top-level Aver items → Rust items (structs, enums, functions, tests).
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
-/// Look up the resolved-HIR mirror of a source-shape `FnDef` previously
-/// stashed in `ctx.resolved_fn_defs` / `ctx.resolved_module_fn_defs`. If
-/// neither path covers `fd`, fall back to a fresh per-call resolver lift
-/// against the entry's symbol table — this happens for synthetic FnDefs
-/// inserted between `build_context` and emit (e.g. memo wrappers, TCO
-/// hoist rewrites) which the resolver hasn't lifted upfront.
-fn resolved_fn_def_for<'a>(
-    fd: &'a FnDef,
-    ctx: &'a CodegenContext,
-) -> std::borrow::Cow<'a, ResolvedFnDef> {
-    use std::borrow::Cow;
-    if let Some(rfd) = ctx.resolved_fn_defs.iter().find(|rfd| rfd.name == fd.name) {
-        return Cow::Borrowed(rfd);
-    }
-    for module in &ctx.resolved_module_fn_defs {
-        if let Some(rfd) = module.iter().find(|rfd| rfd.name == fd.name) {
-            return Cow::Borrowed(rfd);
-        }
-    }
-    let module_name = ctx.items.iter().find_map(|i| match i {
-        TopLevel::Module(m) => Some(m.name.clone()),
-        _ => None,
-    });
-    let mut rctx = ResolveCtx::new(&ctx.symbol_table);
-    rctx.current_module = module_name;
-    let lifted = resolve_fn_def_external(&rctx, fd).unwrap_or_else(|| {
-        // Symbol-table lookup failed (typical for synthetic test FnDefs
-        // not registered in the program's `SymbolTable`). Synthesize
-        // the resolved fn def by lifting each body statement through
-        // [`resolved_stmt_on_demand`] — same shape the resolver
-        // would have produced if it had seen this fn. `fn_id` is left
-        // as a sentinel since no symbol-table entry maps to it.
-        let stmts: Vec<ResolvedStmt> = match fd.body.as_ref() {
-            FnBody::Block(stmts) => stmts
-                .iter()
-                .map(|s| resolved_stmt_on_demand(s, ctx))
-                .collect(),
-        };
-        ResolvedFnDef {
-            fn_id: crate::ir::FnId(u32::MAX),
-            name: fd.name.clone(),
-            line: fd.line,
-            params: fd
-                .params
-                .iter()
-                .map(|(n, ann)| (n.clone(), crate::types::parse_type_str(ann)))
-                .collect(),
-            return_type: crate::types::parse_type_str(&fd.return_type),
-            effects: fd.effects.clone(),
-            desc: fd.desc.clone(),
-            body: std::sync::Arc::new(ResolvedFnBody::Block(stmts)),
-            resolution: fd.resolution.clone(),
-        }
-    });
-    Cow::Owned(lifted)
-}
-
-/// Resolve a source-shape `Spanned<Expr>` on demand using the entry's
-/// resolver context — used by emit helpers that still walk `Expr` (TCO
-/// hoisting, mutual TCO, verify blocks) and need to feed the resolved
-/// shape into `emit_expr`. The `Spanned<ResolvedExpr>` carries the
-/// same line + type stamp as the input.
-fn resolved_expr_on_demand(expr: &Spanned<Expr>, ctx: &CodegenContext) -> Spanned<ResolvedExpr> {
-    let module_name = ctx.items.iter().find_map(|i| match i {
-        TopLevel::Module(m) => Some(m.name.clone()),
-        _ => None,
-    });
-    let mut rctx = ResolveCtx::new(&ctx.symbol_table);
-    rctx.current_module = module_name;
-    let stmt = Stmt::Expr(expr.clone());
-    match crate::ir::hir::resolve::resolve_stmt_external(&rctx, &stmt) {
-        crate::ir::hir::ResolvedStmt::Expr(s) => s,
-        crate::ir::hir::ResolvedStmt::Binding { value, .. } => value,
-    }
-}
-
-/// Same as [`resolved_expr_on_demand`] but for whole statements
-/// (`Binding(name, ty_ann, expr)` or `Expr(expr)`).
-fn resolved_stmt_on_demand(stmt: &Stmt, ctx: &CodegenContext) -> ResolvedStmt {
-    let module_name = ctx.items.iter().find_map(|i| match i {
-        TopLevel::Module(m) => Some(m.name.clone()),
-        _ => None,
-    });
-    let mut rctx = ResolveCtx::new(&ctx.symbol_table);
-    rctx.current_module = module_name;
-    crate::ir::hir::resolve::resolve_stmt_external(&rctx, stmt)
-}
+// Resolved-form lookup helpers live as methods on [`CodegenContext`]
+// since Phase E PR 9: `ctx.resolve_fn_def(fd)`, `ctx.resolve_expr(spanned)`,
+// `ctx.resolve_stmt(stmt)`, `ctx.resolve_pattern(pat)` — shared with
+// wasm-gc / Lean / Dafny / self-host backends as they migrate. See
+// `src/codegen/mod.rs`.
 
 /// Source-shape variant of [`emit_expr`] for emitters that still hold
 /// a pre-resolve [`Expr`] borrow (TCO hoisting / loop, mutual-TCO
@@ -112,14 +27,14 @@ fn resolved_stmt_on_demand(stmt: &Stmt, ctx: &CodegenContext) -> ResolvedStmt {
 /// call — cheap for the small subtrees these helpers walk.
 fn emit_expr_legacy(expr: &Expr, ctx: &CodegenContext, ectx: &EmitCtx) -> String {
     let spanned = Spanned::bare(expr.clone());
-    let resolved = resolved_expr_on_demand(&spanned, ctx);
+    let resolved = ctx.resolve_expr(&spanned);
     emit_expr(&resolved.node, ctx, ectx)
 }
 
 /// `clone_arg`/`borrow_arg` analogue that takes a source-shape `&Expr`.
 fn clone_arg_legacy(expr: &Expr, ctx: &CodegenContext, ectx: &EmitCtx) -> String {
     let spanned = Spanned::bare(expr.clone());
-    let resolved = resolved_expr_on_demand(&spanned, ctx);
+    let resolved = ctx.resolve_expr(&spanned);
     clone_arg(&resolved.node, ctx, ectx)
 }
 
@@ -168,44 +83,17 @@ fn classify_body_expr_plan_source<'a>(
 /// Source-shape variant of [`super::expr::emit_stmt`] for sites that
 /// still walk pre-resolve [`Stmt`] (memo wrappers, TCO loop emit,
 /// trampoline arms, verify cases, main fn body). Lifts on-demand
-/// through [`resolved_stmt_on_demand`] and calls the migrated emit.
+/// through [`CodegenContext::resolve_stmt`] and calls the migrated
+/// emit.
 fn emit_stmt_legacy(stmt: &Stmt, ctx: &CodegenContext, ectx: &EmitCtx) -> String {
-    let resolved = resolved_stmt_on_demand(stmt, ctx);
+    let resolved = ctx.resolve_stmt(stmt);
     emit_stmt(&resolved, ctx, ectx)
 }
 
 /// Source-shape variant of [`super::pattern::emit_pattern`].
 fn emit_pattern_legacy(pat: &Pattern, string_context: bool, ctx: &CodegenContext) -> String {
-    let resolved = resolved_pattern_on_demand(pat, ctx);
+    let resolved = ctx.resolve_pattern(pat);
     super::pattern::emit_pattern(&resolved, string_context, ctx)
-}
-
-fn resolved_pattern_on_demand(pat: &Pattern, ctx: &CodegenContext) -> ResolvedPattern {
-    let module_name = ctx.items.iter().find_map(|i| match i {
-        TopLevel::Module(m) => Some(m.name.clone()),
-        _ => None,
-    });
-    let mut rctx = ResolveCtx::new(&ctx.symbol_table);
-    rctx.current_module = module_name;
-    // Resolve via a synthetic match arm wrapper: simplest path that
-    // doesn't expose a private resolver helper.
-    let synthetic_arm = MatchArm {
-        pattern: pat.clone(),
-        body: Box::new(Spanned::bare(Expr::Literal(Literal::Unit))),
-        binding_slots: std::sync::OnceLock::new(),
-    };
-    let stmt = Stmt::Expr(Spanned::bare(Expr::Match {
-        subject: Box::new(Spanned::bare(Expr::Literal(Literal::Unit))),
-        arms: vec![synthetic_arm],
-    }));
-    let resolved_stmt = crate::ir::hir::resolve::resolve_stmt_external(&rctx, &stmt);
-    let ResolvedStmt::Expr(spanned) = resolved_stmt else {
-        unreachable!()
-    };
-    let ResolvedExpr::Match { arms, .. } = spanned.node else {
-        unreachable!()
-    };
-    arms.into_iter().next().unwrap().pattern
 }
 
 /// Legacy [`has_string_literal_patterns`] for source-shape MatchArm.
@@ -228,8 +116,8 @@ fn has_list_patterns_legacy(arms: &[MatchArm]) -> bool {
 fn resolve_match_arms_on_demand(arms: &[MatchArm], ctx: &CodegenContext) -> Vec<ResolvedMatchArm> {
     arms.iter()
         .map(|arm| {
-            let pattern = resolved_pattern_on_demand(&arm.pattern, ctx);
-            let body = Box::new(resolved_expr_on_demand(&arm.body, ctx));
+            let pattern = ctx.resolve_pattern(&arm.pattern);
+            let body = Box::new(ctx.resolve_expr(&arm.body));
             let binding_slots = std::sync::OnceLock::new();
             if let Some(slots) = arm.binding_slots.get() {
                 let _ = binding_slots.set(slots.clone());
@@ -718,7 +606,7 @@ fn emit_fn_def_with_visibility(
     } else {
         None
     };
-    let resolved_fd_owned = resolved_fn_def_for(fd, ctx);
+    let resolved_fd_owned = ctx.resolve_fn_def(fd);
     let resolved_fd = resolved_fd_owned.as_ref();
     let optimized_thin_plan = classify_thin_fn_def_for_rust(resolved_fd, ctx, &ectx);
 

--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -6,6 +6,39 @@
 //!
 //! Status: Phase 1 — module scaffold. `compile_to_wasm_gc` returns a
 //! placeholder error until a hello-world emitter lands in `module.rs`.
+//!
+//! ## Phase E (resolved AST) migration plan
+//!
+//! Issue #147 phase E migrates every backend from consuming
+//! `crate::ast::Expr` / `FnBody` / `Pattern` to consuming the
+//! resolved-HIR shapes in `crate::ir::hir`. The wasm-gc backend is
+//! migrated across three PRs because it's the largest backend
+//! (~36k lines, 8 files actively walking `Expr`):
+//!
+//! - **PR 9** (foundation) — shared `CodegenContext::resolve_fn_def` /
+//!   `resolve_expr` / `resolve_stmt` / `resolve_pattern` methods
+//!   promoted from `rust/toplevel.rs`. No wasm-gc behaviour change;
+//!   gives the follow-up PRs a one-line lookup boundary.
+//! - **PR 9.1** — `body/emit.rs` (3.1k) migrates to take
+//!   `&Spanned<ResolvedExpr>`; cascades through `emit_list_literal`,
+//!   `emit_map_literal`, `emit_constructor`, `emit_match`,
+//!   `emit_tail_call`, etc. The remaining body subfiles
+//!   (`body/{slots, builtins, builtins_wasip2, infer, eq_helpers,
+//!   hash_helpers}.rs`) migrate alongside since they share the
+//!   `Spanned<Expr>` borrows.
+//! - **PR 9.2** — `module.rs` orchestration (6.3k),
+//!   `types_discovery.rs` / `types.rs` / `flatten.rs` (program-level
+//!   walkers that register types / fns before emit). After this PR
+//!   the wasm-gc backend reads `ctx.resolved_fn_defs` /
+//!   `resolved_module_fn_defs` exclusively; the `&FnDef` borrows in
+//!   `module.rs` survive only as the source-shape metadata that the
+//!   resolver doesn't reproduce (e.g. param annotation source
+//!   strings used by the WIT signature emitter).
+//!
+//! The byte-identical gate for every wasm-gc snapshot
+//! (`order_total.wasm` md5 `61e45b325279e17e1b0d8dce3fde43f9`, the
+//! game suite, the wasip2 stress fixtures) holds across each PR — no
+//! generated wasm shifts until the migration is fully through.
 
 use crate::ast::TopLevel;
 use crate::ir::AnalysisResult;


### PR DESCRIPTION
## Summary

Foundation for the wasm-gc backend migration (follow-up PRs 9.1 / 9.2). Promotes the resolved-lookup helpers from `src/codegen/rust/toplevel.rs` to `CodegenContext` methods so every backend hits the same one-line boundary when migrating off source-shape `Expr` / `FnBody` / `Pattern`.

Scope-bounded to **foundation only** because the wasm-gc backend is ~3× the size of the Rust backend migrated in PR 8 (36k lines vs ~11k, 8 files actively walking `Expr`). Splitting into 9 / 9.1 / 9.2 keeps each PR atomic, mergeable, and small enough to verify byte-identical against the wasm-gc snapshot suite.

## Changes

- **`CodegenContext::resolve_fn_def(fd)`** — look up the resolved-HIR mirror of a source-shape `FnDef` in `resolved_fn_defs` / `resolved_module_fn_defs` (already populated by `build_context` since PR 8). Falls back to a fresh per-call resolver lift when neither path covers `fd` — same shape as the pre-PR-9 private helper in `rust/toplevel.rs`.
- **`CodegenContext::resolve_expr(spanned)` / `resolve_stmt(stmt)` / `resolve_pattern(pat)`** — on-demand resolver lifts for source-shape borrows. Used by emit helpers that still walk pre-resolve AST (TCO hoisting, mutual TCO, verify cases, etc.).
- **`rust/toplevel.rs`** drops the private `resolved_fn_def_for` / `resolved_expr_on_demand` / `resolved_stmt_on_demand` / `resolved_pattern_on_demand` in favour of the shared methods. Identical semantics, smaller diff for the next migrator.
- **`wasm_gc/mod.rs`** gains a module-level doc comment describing the staged migration plan (PR 9 foundation, PR 9.1 `body/emit.rs`, PR 9.2 `module.rs` / `types_discovery.rs` / `types.rs` / `flatten.rs`).

## No behavioural change

The methods are byte-for-byte equivalent to the removed private helpers; only the access surface moves. The Rust backend's emit path is unaffected.

## Test results

- `cargo test --features wasm --no-fail-fast`: **1649 tests pass**, 0 failures.
- `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings`: clean.
- `cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `aver compile examples/core/order_total.av --target wasm-gc` → md5 `61e45b325279e17e1b0d8dce3fde43f9` (byte-identical).
- All 13 captured wasm-gc snapshots size-identical to pre-PR baselines; 12/13 byte-identical. The 13th (`life.wasm`) is flaky across builds **pre-existing** — type-section ordering depends on `HashMap` iteration — but size is deterministic at 10508 bytes across every run, so it's not a PR-introduced regression.

## What this PR does NOT do

- Doesn't change wasm-gc emit logic. `body/emit.rs`, `body/builtins.rs`, `types_discovery.rs`, etc. all still consume `&Spanned<Expr>` / `&FnBody`. PR 9.1 / 9.2 migrate them.

## Test plan

- [x] `cargo build --features wasm`
- [x] `cargo test --features wasm --no-fail-fast` (1649 passed)
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `aver compile examples/core/order_total.av --target wasm-gc` byte-identical (md5 `61e45b325279e17e1b0d8dce3fde43f9`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)