### PR TITLE
codegen/wasm_gc: body/infer.rs readers IR-agnostic — #147 phase E PR 9.0.1

### DIFF
--- a/src/codegen/wasm_gc/body/infer.rs
+++ b/src/codegen/wasm_gc/body/infer.rs
@@ -15,7 +15,7 @@
 
 use wasm_encoder::ValType;
 
-use crate::ast::{Expr, MatchArm, Pattern, Spanned};
+use crate::ast::{MatchArm, Pattern, Spanned};
 use crate::types::Type;
 
 use super::super::WasmGcError;
@@ -50,15 +50,59 @@ pub(super) fn arm_is_result_pattern(arm: &MatchArm) -> bool {
     false
 }
 
+/// Resolved-form mirror of [`arm_is_option_pattern`] for emitters that
+/// have already migrated to walk [`crate::ir::hir::ResolvedMatchArm`].
+/// The pattern shape comparison happens against
+/// [`crate::ir::hir::ResolvedCtor::Builtin`] variants instead of the
+/// source-shape dotted name. Allowed dead until the wasm-gc match
+/// emitters migrate in the follow-up PRs of #147 phase E.
+#[allow(dead_code)]
+pub(super) fn arm_is_option_pattern_resolved(
+    arm: &crate::ir::hir::ResolvedMatchArm,
+) -> bool {
+    use crate::ir::hir::{BuiltinCtor, ResolvedCtor, ResolvedPattern};
+    matches!(
+        &arm.pattern,
+        ResolvedPattern::Ctor(
+            ResolvedCtor::Builtin(BuiltinCtor::OptionSome | BuiltinCtor::OptionNone),
+            _,
+        )
+    )
+}
+
+/// Resolved-form mirror of [`arm_is_result_pattern`]. Allowed dead
+/// until the wasm-gc match emitters migrate in the follow-up PRs of
+/// #147 phase E.
+#[allow(dead_code)]
+pub(super) fn arm_is_result_pattern_resolved(
+    arm: &crate::ir::hir::ResolvedMatchArm,
+) -> bool {
+    use crate::ir::hir::{BuiltinCtor, ResolvedCtor, ResolvedPattern};
+    matches!(
+        &arm.pattern,
+        ResolvedPattern::Ctor(
+            ResolvedCtor::Builtin(BuiltinCtor::ResultOk | BuiltinCtor::ResultErr),
+            _,
+        )
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Typed-AST accessors
 // ---------------------------------------------------------------------------
 
-/// Inferred Aver type for a `Spanned<Expr>`. Panics if the type checker
-/// did not stamp this node — that is a pipeline bug, not a recoverable
-/// codegen condition (see module doc).
+/// Inferred Aver type for a typed `Spanned<T>`. Panics if the type
+/// checker did not stamp this node — that is a pipeline bug, not a
+/// recoverable codegen condition (see module doc).
+///
+/// Generic over the wrapped node type so the readers work uniformly
+/// against both `Spanned<crate::ast::Expr>` (source-shape, used by
+/// the pre-PR-9.x dispatch sites that haven't migrated yet) and
+/// `Spanned<crate::ir::hir::ResolvedExpr>` (resolved, used by the
+/// migrated emitters). `Spanned::ty()` is generic over `T` already,
+/// so the readers don't care which IR shape the node carries.
 #[track_caller]
-pub(super) fn aver_type_of(expr: &Spanned<Expr>) -> &Type {
+pub(super) fn aver_type_of<T: std::fmt::Debug>(expr: &Spanned<T>) -> &Type {
     expr.ty().unwrap_or_else(|| {
         panic!(
             "wasm-gc emit: expression has no type — typecheck must run before codegen \
@@ -73,15 +117,15 @@ pub(super) fn aver_type_of(expr: &Spanned<Expr>) -> &Type {
 /// (`record_field_type`, `aver_to_wasm`, registry canonical lookups),
 /// so a single `display()` per call site keeps the diff small.
 #[track_caller]
-pub(super) fn aver_type_str_of(expr: &Spanned<Expr>) -> String {
+pub(super) fn aver_type_str_of<T: std::fmt::Debug>(expr: &Spanned<T>) -> String {
     aver_type_of(expr).display()
 }
 
-/// WASM machine type for a `Spanned<Expr>`. Same panic contract as
-/// `aver_type_of`; `Ok(None)` for Unit (no value pushed).
+/// WASM machine type for a typed `Spanned<T>`. Same panic contract
+/// as `aver_type_of`; `Ok(None)` for Unit (no value pushed).
 #[track_caller]
-pub(super) fn wasm_type_of(
-    expr: &Spanned<Expr>,
+pub(super) fn wasm_type_of<T: std::fmt::Debug>(
+    expr: &Spanned<T>,
     registry: &TypeRegistry,
 ) -> Result<Option<ValType>, WasmGcError> {
     aver_to_wasm(&aver_type_str_of(expr), Some(registry))
@@ -91,8 +135,8 @@ pub(super) fn wasm_type_of(
 /// form used by wasm-gc registries. Generic constructors must already be
 /// resolved by the type checker before codegen reaches this reader.
 #[track_caller]
-pub(super) fn aver_type_canonical(
-    expr: &Spanned<Expr>,
+pub(super) fn aver_type_canonical<T: std::fmt::Debug>(
+    expr: &Spanned<T>,
     _return_type: &str,
     _registry: &TypeRegistry,
 ) -> String {

--- a/src/codegen/wasm_gc/body/infer.rs
+++ b/src/codegen/wasm_gc/body/infer.rs
@@ -57,9 +57,7 @@ pub(super) fn arm_is_result_pattern(arm: &MatchArm) -> bool {
 /// source-shape dotted name. Allowed dead until the wasm-gc match
 /// emitters migrate in the follow-up PRs of #147 phase E.
 #[allow(dead_code)]
-pub(super) fn arm_is_option_pattern_resolved(
-    arm: &crate::ir::hir::ResolvedMatchArm,
-) -> bool {
+pub(super) fn arm_is_option_pattern_resolved(arm: &crate::ir::hir::ResolvedMatchArm) -> bool {
     use crate::ir::hir::{BuiltinCtor, ResolvedCtor, ResolvedPattern};
     matches!(
         &arm.pattern,
@@ -74,9 +72,7 @@ pub(super) fn arm_is_option_pattern_resolved(
 /// until the wasm-gc match emitters migrate in the follow-up PRs of
 /// #147 phase E.
 #[allow(dead_code)]
-pub(super) fn arm_is_result_pattern_resolved(
-    arm: &crate::ir::hir::ResolvedMatchArm,
-) -> bool {
+pub(super) fn arm_is_result_pattern_resolved(arm: &crate::ir::hir::ResolvedMatchArm) -> bool {
     use crate::ir::hir::{BuiltinCtor, ResolvedCtor, ResolvedPattern};
     matches!(
         &arm.pattern,


### PR DESCRIPTION
## Summary

Smaller foothold landing before the body/emit.rs migration (PR 9.1). The infer.rs type readers become generic over the wrapped node type, so the wasm-gc backend's existing source-shape emitters and the future resolved-shape emitters share the same readers without any cascade.

## Changes

- `aver_type_of`, `aver_type_str_of`, `wasm_type_of`, `aver_type_canonical` now take `&Spanned<T: Debug>` instead of `&Spanned<Expr>` specifically. `Spanned::ty()` is already generic over `T`, so the readers just thread the type through. The only requirement is `Debug` for the panic message.
- New `arm_is_option_pattern_resolved` / `arm_is_result_pattern_resolved` — resolved-form mirrors of the existing arm predicates. Dispatch on `ResolvedCtor::Builtin(BuiltinCtor::Option*/Result*)` directly instead of walking the source-shape dotted-name string. Allowed-dead until the wasm-gc match emitters migrate in PR 9.1.

## No behaviour change

Every current caller still passes `Spanned<Expr>` and gets the same type info back. Foundation for the larger body/emit.rs migration in the next PR.

## Test results

- `cargo test --features wasm --no-fail-fast`: **1649 tests pass**, 0 failures.
- `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `aver compile examples/core/order_total.av --target wasm-gc` md5 `61e45b325279e17e1b0d8dce3fde43f9` (byte-identical).

## Test plan

- [x] `cargo build --features wasm`
- [x] `cargo test --features wasm --no-fail-fast` (1649 passed)
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `aver compile examples/core/order_total.av --target wasm-gc` byte-identical (md5 `61e45b325279e17e1b0d8dce3fde43f9`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)