### PR TITLE
codegen/wasm_gc: body/emit.rs + slots + builtins consume ResolvedExpr — #147 phase E PR 9.1

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -29,8 +29,10 @@ use wasm_encoder::{Function, Instruction, ValType};
 use super::WasmGcError;
 use super::types::TypeRegistry;
 
-use crate::ast::{FnBody, FnDef, Stmt};
 use crate::ir::CallLowerCtx;
+use crate::ir::SymbolTable;
+use crate::ir::hir::{ResolvedExpr, ResolvedFnBody, ResolvedFnDef, ResolvedStmt};
+use crate::types::Type;
 
 mod builtins;
 mod builtins_wasip2;
@@ -156,26 +158,33 @@ pub(super) struct FnEntry {
 #[allow(clippy::too_many_arguments)]
 pub(super) fn emit_fn_body(
     func: &mut Function,
-    fd: &FnDef,
+    rfd: &ResolvedFnDef,
     fn_map: &FnMap,
     self_wasm_idx: u32,
     registry: &TypeRegistry,
+    symbol_table: &SymbolTable,
     effect_idx_lookup: &HashMap<String, u32>,
     caller_fn_collector: &std::cell::RefCell<CallerFnCollector>,
     wasip2_lowering: Option<&Wasip2Lowering>,
 ) -> Result<Vec<ValType>, WasmGcError> {
-    let slots = SlotTable::build_for_fn(fd, registry, fn_map)?;
-    let FnBody::Block(stmts) = fd.body.as_ref();
+    let slots = SlotTable::build_for_fn(rfd, registry, fn_map)?;
+    let ResolvedFnBody::Block(stmts) = rfd.body.as_ref();
     let last_idx = stmts.len().saturating_sub(1);
+
+    // Source-shape canonical of the enclosing fn's return type. Many
+    // emit helpers (Option.None hint, ErrorProp enclosing fixup, list
+    // empty literal fallback) want the string form once; compute it
+    // here so the per-emit-site reads stay a cheap `&str`.
+    let return_type_str = rfd.return_type.display();
 
     // Precollect every `let`-bound name so `CallLowerCtx::is_local_value`
     // can recognise locals without a parallel type table — the wasm-gc
     // backend's IR shape recognition (`classify_leaf_op` /
     // `classify_call_plan`) only needs the name, not the type.
     let mut binding_names: HashSet<String> = HashSet::new();
-    fn collect_names(stmts: &[Stmt], out: &mut HashSet<String>) {
+    fn collect_names(stmts: &[ResolvedStmt], out: &mut HashSet<String>) {
         for s in stmts {
-            if let Stmt::Binding(name, _, _) = s {
+            if let ResolvedStmt::Binding { name, .. } = s {
                 out.insert(name.clone());
             }
         }
@@ -185,11 +194,12 @@ pub(super) fn emit_fn_body(
     let ctx = EmitCtx {
         fn_map,
         self_wasm_idx,
-        self_fn_name: fd.name.as_str(),
-        return_type: fd.return_type.as_str(),
+        self_fn_name: rfd.name.as_str(),
+        return_type: &return_type_str,
         registry,
-        resolution: fd.resolution.as_ref(),
-        params: &fd.params,
+        symbol_table,
+        resolution: rfd.resolution.as_ref(),
+        params: &rfd.params,
         binding_names: &binding_names,
         effect_idx_lookup,
         caller_fn_collector,
@@ -199,9 +209,9 @@ pub(super) fn emit_fn_body(
     for (i, stmt) in stmts.iter().enumerate() {
         let is_last = i == last_idx;
         match stmt {
-            Stmt::Binding(name, _annot, expr) => {
-                emit_expr(func, expr, &slots, &ctx)?;
-                let produces_value = aver_type_str_of(expr).trim() != "Unit";
+            ResolvedStmt::Binding { name, value, .. } => {
+                emit_expr(func, value, &slots, &ctx)?;
+                let produces_value = aver_type_str_of(value).trim() != "Unit";
                 if name == "_" {
                     // `_ = expr` — sequence-only binding. Drop the
                     // value (if any) and move on; the resolver
@@ -223,7 +233,7 @@ pub(super) fn emit_fn_body(
                     func.instruction(&Instruction::LocalSet(slot));
                 }
             }
-            Stmt::Expr(spanned) => {
+            ResolvedStmt::Expr(spanned) => {
                 emit_expr(func, spanned, &slots, &ctx)?;
                 // Whether the expression leaves a value on the stack
                 // is decided structurally (typecheck stamps `Unit` on
@@ -237,12 +247,12 @@ pub(super) fn emit_fn_body(
                     func.instruction(&Instruction::Drop);
                 }
                 if is_last {
-                    if fd.return_type.trim() == "Unit" && produces_value {
+                    if return_type_str.trim() == "Unit" && produces_value {
                         func.instruction(&Instruction::Drop);
-                    } else if fd.return_type.trim() != "Unit" && !produces_value {
+                    } else if return_type_str.trim() != "Unit" && !produces_value {
                         return Err(WasmGcError::Validation(format!(
                             "fn `{}` returns {} but trailing expression yields no value",
-                            fd.name, fd.return_type
+                            rfd.name, return_type_str
                         )));
                     }
                 }
@@ -251,7 +261,7 @@ pub(super) fn emit_fn_body(
     }
     func.instruction(&Instruction::End);
 
-    Ok(slots.extra_locals(count_value_params(&fd.params)))
+    Ok(slots.extra_locals(count_value_params(&rfd.params)))
 }
 
 /// Lazy-populated registry of caller_fn names actually emitted by the
@@ -290,16 +300,23 @@ pub(super) struct EmitCtx<'a> {
     pub(super) self_fn_name: &'a str,
     pub(super) return_type: &'a str,
     pub(super) registry: &'a TypeRegistry,
+    /// Shared resolver symbol table — used by emit-site dispatch to
+    /// turn a `ResolvedCallee::Fn(FnId)` / `ResolvedCtor::User { type_id, .. }`
+    /// back into the canonical name the wasm fn-map / variant registry
+    /// is keyed by. Phase E PR 9.1 threaded this in so the migration
+    /// could read identity off the resolved AST directly instead of
+    /// re-deriving from source strings.
+    pub(super) symbol_table: &'a SymbolTable,
     /// Resolver's local-name → slot map for the current fn. `None`
     /// when the fn was emitted without `resolution` populated (the
     /// pipeline always populates it for production paths; tests may
     /// pre-resolve manually).
     pub(super) resolution: Option<&'a crate::ast::FnResolution>,
-    /// Param name → declared aver type. Used by `CallLowerCtx` for
+    /// Param name → resolved aver type. Used by `CallLowerCtx` for
     /// local-name recognition; the typed-AST refactor (Step 3) made
     /// the *type* portion redundant for emit, but the param list is
     /// still the source of truth for "is this name a param?".
-    pub(super) params: &'a [(String, String)],
+    pub(super) params: &'a [(String, Type)],
     /// Set of `let`-bound local names (no type information attached —
     /// types come from `Spanned::ty()` at the use site). Powers
     /// `CallLowerCtx::is_local_value` for the shared IR-level shape
@@ -565,9 +582,9 @@ impl<'a> EmitCtx<'a> {
     /// and `Map.set` (picks the `set_in_place` helper). Anonymous
     /// expressions land here as a transient stack value with no
     /// binding to alias against, which counts as uniquely owned.
-    pub(super) fn arg_uniquely_owned(&self, arg: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
+    pub(super) fn arg_uniquely_owned(&self, arg: &crate::ast::Spanned<ResolvedExpr>) -> bool {
         match &arg.node {
-            crate::ast::Expr::Resolved { slot, last_use, .. } => {
+            ResolvedExpr::Resolved { slot, last_use, .. } => {
                 last_use.0 && !self.is_aliased_slot(*slot)
             }
             _ => true,

--- a/src/codegen/wasm_gc/body/builtins.rs
+++ b/src/codegen/wasm_gc/body/builtins.rs
@@ -5,8 +5,8 @@
 
 use wasm_encoder::{Function, Instruction, ValType};
 
-use crate::ast::{Expr, Spanned};
-use crate::ir::{LeafOp, classify_leaf_op};
+use crate::ast::Spanned;
+use crate::ir::hir::{ResolvedCallee, ResolvedExpr, ResolvedStrPart};
 
 use super::super::WasmGcError;
 use super::super::types::{TypeRegistry, aver_to_wasm};
@@ -37,7 +37,7 @@ pub(super) fn emit_dotted_builtin(
     func: &mut Function,
     parent: &str,
     method: &str,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -665,7 +665,7 @@ pub(super) fn emit_args_get_inline(
 pub(super) fn emit_map_kv_call(
     func: &mut Function,
     method: &str,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -749,7 +749,7 @@ pub(super) fn emit_map_kv_call(
 /// signatures so any reachable instantiation registers).
 pub(super) fn emit_vector_new(
     func: &mut Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -798,7 +798,7 @@ pub(super) fn emit_vector_new(
 /// today it surfaces as Unimplemented.
 pub(super) fn emit_option_with_default(
     func: &mut Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -816,31 +816,37 @@ pub(super) fn emit_option_with_default(
     // `IntModOrDefaultLiteral`) lights up across every backend
     // automatically. The classifier is re-run on the parent call
     // because `Option.withDefault` is the shape's outer shell.
-    let outer_call = Expr::FnCall(
-        Box::new(Spanned::new(
-            Expr::Attr(
-                Box::new(Spanned::new(Expr::Ident("Option".into()), 0)),
-                "withDefault".into(),
-            ),
-            0,
-        )),
+    use crate::ir::hir::classify::{ResolvedLeafOp, classify_leaf_op_resolved};
+    let outer_call = ResolvedExpr::Call(
+        ResolvedCallee::Builtin("Option.withDefault".into()),
         args.to_vec(),
     );
-    if let Some(leaf) = classify_leaf_op(&outer_call, ctx) {
+    let is_user_type = |name: &str| {
+        ctx.registry.records.contains_key(name)
+            || ctx.registry.variants.contains_key(name)
+            || ctx
+                .registry
+                .variants
+                .values()
+                .flat_map(|vs| vs.iter())
+                .any(|info| info.parent == name)
+    };
+    if let Some(leaf) = classify_leaf_op_resolved(&outer_call, &is_user_type) {
         match leaf {
-            LeafOp::VectorSetOrDefaultSameVector {
+            ResolvedLeafOp::VectorSetOrDefaultSameVector {
                 vector,
                 index,
                 value,
             } => {
                 return emit_vector_set_or_default(func, vector, index, value, slots, ctx);
             }
-            LeafOp::VectorGetOrDefaultLiteral {
+            ResolvedLeafOp::VectorGetOrDefaultLiteral {
                 vector,
                 index,
                 default_literal,
             } => {
-                let default_spanned = Spanned::new(Expr::Literal(default_literal.clone()), 0);
+                let default_spanned =
+                    Spanned::new(ResolvedExpr::Literal(default_literal.clone()), 0);
                 return emit_vector_get_or_default(
                     func,
                     vector,
@@ -857,11 +863,8 @@ pub(super) fn emit_option_with_default(
     // `Option.withDefault(Map.get(m, k), default)` — Map fusion isn't
     // in `LeafOp` (legacy backends use runtime helpers and don't need
     // a per-shape leaf), so handle it locally.
-    if let Expr::FnCall(inner_callee, inner_args) = &opt_arg.node
-        && let Expr::Attr(parent, member) = &inner_callee.node
-        && let Expr::Ident(p) = &parent.node
-        && p == "Map"
-        && member == "get"
+    if let ResolvedExpr::Call(ResolvedCallee::Builtin(name), inner_args) = &opt_arg.node
+        && name == "Map.get"
         && inner_args.len() == 2
     {
         return emit_map_get_or_default(
@@ -889,7 +892,7 @@ pub(super) fn emit_option_with_default(
 /// hitting it route through pattern match instead).
 pub(super) fn emit_result_with_default(
     func: &mut Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -908,11 +911,8 @@ pub(super) fn emit_result_with_default(
     // expect a struct ref where there's only an i64 on the stack.
     // Emit the safe form here: if `b == 0` push `default`, else push
     // `__int_mod_euclid(a, b)`.
-    if let Expr::FnCall(callee, inner_args) = &res_arg.node
-        && let Expr::Attr(parent, member) = &callee.node
-        && let Expr::Ident(p) = &parent.node
-        && p == "Int"
-        && member == "mod"
+    if let ResolvedExpr::Call(ResolvedCallee::Builtin(name), inner_args) = &res_arg.node
+        && name == "Int.mod"
         && inner_args.len() == 2
     {
         let block_ty = wasm_encoder::BlockType::Result(ValType::I64);
@@ -996,8 +996,8 @@ pub(super) fn emit_result_with_default(
 /// inferred Option<T>, E from the err argument's type.
 pub(super) fn emit_option_to_result(
     func: &mut Function,
-    opt_arg: &Spanned<Expr>,
-    err_arg: &Spanned<Expr>,
+    opt_arg: &Spanned<ResolvedExpr>,
+    err_arg: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1074,8 +1074,8 @@ pub(super) fn emit_option_to_result(
 
 pub(super) fn emit_option_with_default_boxed(
     func: &mut Function,
-    opt_arg: &Spanned<Expr>,
-    default_arg: &Spanned<Expr>,
+    opt_arg: &Spanned<ResolvedExpr>,
+    default_arg: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1134,9 +1134,9 @@ pub(super) fn emit_option_with_default_boxed(
 /// allocates on the hot lookup path.
 pub(super) fn emit_map_get_or_default(
     func: &mut Function,
-    map: &Spanned<Expr>,
-    key: &Spanned<Expr>,
-    default: &Spanned<Expr>,
+    map: &Spanned<ResolvedExpr>,
+    key: &Spanned<ResolvedExpr>,
+    default: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1168,9 +1168,9 @@ pub(super) fn emit_map_get_or_default(
 /// calls `Vector.set` on.
 pub(super) fn emit_vector_set_or_default(
     func: &mut Function,
-    vector: &Spanned<Expr>,
-    index: &Spanned<Expr>,
-    value: &Spanned<Expr>,
+    vector: &Spanned<ResolvedExpr>,
+    index: &Spanned<ResolvedExpr>,
+    value: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1279,11 +1279,10 @@ pub(super) fn emit_vector_set_or_default(
 /// once it lands (interleave separators, then call this helper).
 pub(super) fn emit_interpolated_str(
     func: &mut Function,
-    parts: &[crate::ast::StrPart],
+    parts: &[ResolvedStrPart],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
-    use crate::ast::StrPart;
     let string_type_idx = ctx
         .registry
         .string_array_type_idx
@@ -1313,7 +1312,7 @@ pub(super) fn emit_interpolated_str(
         ))?;
     for part in parts {
         match part {
-            StrPart::Literal(s) => {
+            ResolvedStrPart::Literal(s) => {
                 let bytes = s.as_bytes();
                 let seg_idx =
                     ctx.registry
@@ -1328,7 +1327,7 @@ pub(super) fn emit_interpolated_str(
                     array_data_index: seg_idx,
                 });
             }
-            StrPart::Parsed(inner) => {
+            ResolvedStrPart::Parsed(inner) => {
                 let aver_ty = aver_type_str_of(inner);
                 emit_expr(func, inner, slots, ctx)?;
                 match aver_ty.trim() {
@@ -1386,9 +1385,9 @@ pub(super) fn emit_interpolated_str(
 /// type is the vector's element type (Aver guarantees `default` agrees).
 pub(super) fn emit_vector_get_or_default(
     func: &mut Function,
-    vector: &Spanned<Expr>,
-    index: &Spanned<Expr>,
-    default: &Spanned<Expr>,
+    vector: &Spanned<ResolvedExpr>,
+    index: &Spanned<ResolvedExpr>,
+    default: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1440,7 +1439,7 @@ pub(super) fn emit_vector_get_or_default(
 /// canonical comes from `infer_aver_type(list)`.
 pub(super) fn emit_list_op_call(
     func: &mut Function,
-    list_arg: &Spanned<Expr>,
+    list_arg: &Spanned<ResolvedExpr>,
     op: &str,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -1474,8 +1473,8 @@ pub(super) fn emit_list_op_call(
 /// and the call surfaces a clear error.
 pub(super) fn emit_list_op_call_2(
     func: &mut Function,
-    list_arg: &Spanned<Expr>,
-    second_arg: &Spanned<Expr>,
+    list_arg: &Spanned<ResolvedExpr>,
+    second_arg: &Spanned<ResolvedExpr>,
     op: &str,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -1513,7 +1512,7 @@ pub(super) fn emit_list_op_call_2(
 /// list's element type (must be `Tuple<K, V>`).
 pub(super) fn emit_map_from_list_call(
     func: &mut Function,
-    list_arg: &Spanned<Expr>,
+    list_arg: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1542,8 +1541,8 @@ pub(super) fn emit_map_from_list_call(
 /// element types.
 pub(super) fn emit_list_zip_call(
     func: &mut Function,
-    la: &Spanned<Expr>,
-    lb: &Spanned<Expr>,
+    la: &Spanned<ResolvedExpr>,
+    lb: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1572,7 +1571,7 @@ pub(super) fn emit_list_zip_call(
 /// registered for the matching `List<T>` canonical.
 pub(super) fn emit_vec_from_list_call(
     func: &mut Function,
-    list_arg: &Spanned<Expr>,
+    list_arg: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1596,7 +1595,7 @@ pub(super) fn emit_vec_from_list_call(
 /// build the list canonical from it.
 pub(super) fn emit_vec_to_list_call(
     func: &mut Function,
-    vec_arg: &Spanned<Expr>,
+    vec_arg: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1627,8 +1626,8 @@ pub(super) fn emit_vec_to_list_call(
 /// `Option.withDefault(Vector.get(...), default)` shape).
 pub(super) fn emit_vector_get_boxed(
     func: &mut Function,
-    vector: &Spanned<Expr>,
-    index: &Spanned<Expr>,
+    vector: &Spanned<ResolvedExpr>,
+    index: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1701,9 +1700,9 @@ pub(super) fn emit_vector_get_boxed(
 /// argument that forced the copy.)
 pub(super) fn emit_vector_set_boxed(
     func: &mut Function,
-    vector: &Spanned<Expr>,
-    index: &Spanned<Expr>,
-    value: &Spanned<Expr>,
+    vector: &Spanned<ResolvedExpr>,
+    index: &Spanned<ResolvedExpr>,
+    value: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {

--- a/src/codegen/wasm_gc/body/builtins_wasip2.rs
+++ b/src/codegen/wasm_gc/body/builtins_wasip2.rs
@@ -11,7 +11,8 @@
 
 use wasm_encoder::Instruction;
 
-use crate::ast::{Expr, Spanned};
+use crate::ast::Spanned;
+use crate::ir::hir::ResolvedExpr;
 
 use super::super::WasmGcError;
 use super::emit::emit_expr;
@@ -39,7 +40,7 @@ use super::{EmitCtx, SlotTable};
 pub(super) fn emit_console_print_wasip2(
     func: &mut wasm_encoder::Function,
     method: &str,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -238,7 +239,7 @@ pub(super) fn emit_args_get_wasip2(
 /// > itself so call sites don't need to.
 pub(super) fn emit_env_get_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -322,7 +323,7 @@ pub(super) fn emit_env_get_wasip2(
 /// emitted on wasip2 with imports, so the page-1 LM is available.
 pub(super) fn emit_time_unix_ms_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
     let lowering = ctx.wasip2_lowering.ok_or_else(|| {
@@ -377,7 +378,7 @@ pub(super) fn emit_time_unix_ms_wasip2(
 /// to be reused immediately afterwards.
 pub(super) fn emit_time_now_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
     let lowering = ctx.wasip2_lowering.ok_or_else(|| {
@@ -434,7 +435,7 @@ pub(super) fn emit_time_now_wasip2(
 /// instruction: `Call $__rt_console_read_line`.
 pub(super) fn emit_console_read_line_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
     let lowering = ctx.wasip2_lowering.ok_or_else(|| {
@@ -467,7 +468,7 @@ pub(super) fn emit_console_read_line_wasip2(
 /// implementation detail.
 pub(super) fn emit_time_sleep_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -497,7 +498,7 @@ pub(super) fn emit_time_sleep_wasip2(
 /// `false` on no-preopens / Err / wasi-error; `true` on Ok.
 pub(super) fn emit_disk_exists_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -527,7 +528,7 @@ pub(super) fn emit_disk_exists_wasip2(
 /// light `__rt_tcp_ping` wrapper.
 pub(super) fn emit_tcp_ping_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -556,7 +557,7 @@ pub(super) fn emit_tcp_ping_wasip2(
 /// helper.
 pub(super) fn emit_tcp_send_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -583,7 +584,7 @@ pub(super) fn emit_tcp_send_wasip2(
 /// on `--target wasip2`. Pushes conn and calls the helper.
 pub(super) fn emit_tcp_read_line_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -609,7 +610,7 @@ pub(super) fn emit_tcp_read_line_wasip2(
 /// `__rt_tcp_write_line` helper.
 pub(super) fn emit_tcp_write_line_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -638,7 +639,7 @@ pub(super) fn emit_tcp_write_line_wasip2(
 /// ref onto the stack and calls the `__rt_tcp_close` helper.
 pub(super) fn emit_tcp_close_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -669,7 +670,7 @@ pub(super) fn emit_tcp_close_wasip2(
 /// Phase 4.2.2+ — this dispatcher stays put.
 pub(super) fn emit_tcp_connect_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -698,7 +699,7 @@ pub(super) fn emit_tcp_connect_wasip2(
 
 pub(super) fn emit_disk_read_text_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -733,7 +734,7 @@ pub(super) fn emit_disk_read_text_wasip2(
 /// shape via `aver/random_int`).
 pub(super) fn emit_random_int_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -793,7 +794,7 @@ pub(super) fn emit_random_int_wasip2(
 /// bits with no exponent bits set.
 pub(super) fn emit_random_float_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
     let lowering = ctx.wasip2_lowering.ok_or_else(|| {
@@ -829,7 +830,7 @@ pub(super) fn emit_random_float_wasip2(
 /// blocking-write-and-flush + per-call resource drops.
 pub(super) fn emit_disk_write_text_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -860,7 +861,7 @@ pub(super) fn emit_disk_write_text_wasip2(
 /// `__rt_disk_delete` (single wasi `unlink-file-at` underneath).
 pub(super) fn emit_disk_delete_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -886,7 +887,7 @@ pub(super) fn emit_disk_delete_wasip2(
 /// Phase 1.5.4 — `Disk.deleteDir(path) -> Result<Unit, String>`.
 pub(super) fn emit_disk_delete_dir_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -912,7 +913,7 @@ pub(super) fn emit_disk_delete_dir_wasip2(
 /// Phase 1.5.4 — `Disk.makeDir(path) -> Result<Unit, String>`.
 pub(super) fn emit_disk_make_dir_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -939,7 +940,7 @@ pub(super) fn emit_disk_make_dir_wasip2(
 /// emitter as `__rt_disk_write_text` flipped to append mode.
 pub(super) fn emit_disk_append_text_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -969,7 +970,7 @@ pub(super) fn emit_disk_append_text_wasip2(
 /// read-directory + entry-iteration loop + drops.
 pub(super) fn emit_disk_list_dir_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1006,7 +1007,7 @@ fn emit_http_simple_method_wasip2(
     method_name: &str,
     method_tag: i32,
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1066,7 +1067,7 @@ fn emit_http_body_method_wasip2(
     method_name: &str,
     method_tag: i32,
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1095,7 +1096,7 @@ fn emit_http_body_method_wasip2(
 
 pub(super) fn emit_http_get_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1104,7 +1105,7 @@ pub(super) fn emit_http_get_wasip2(
 
 pub(super) fn emit_http_head_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1113,7 +1114,7 @@ pub(super) fn emit_http_head_wasip2(
 
 pub(super) fn emit_http_delete_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1122,7 +1123,7 @@ pub(super) fn emit_http_delete_wasip2(
 
 pub(super) fn emit_http_post_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1131,7 +1132,7 @@ pub(super) fn emit_http_post_wasip2(
 
 pub(super) fn emit_http_put_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1140,7 +1141,7 @@ pub(super) fn emit_http_put_wasip2(
 
 pub(super) fn emit_http_patch_wasip2(
     func: &mut wasm_encoder::Function,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {

--- a/src/codegen/wasm_gc/body/emit.rs
+++ b/src/codegen/wasm_gc/body/emit.rs
@@ -3,16 +3,49 @@
 
 use wasm_encoder::{Function, Instruction, ValType};
 
-use crate::ast::{BinOp, Expr, Literal, MatchArm, Pattern, Spanned};
+use crate::ast::{BinOp, Literal, Spanned};
+use crate::ir::hir::{
+    BuiltinCtor, ResolvedCallee, ResolvedCtor, ResolvedExpr, ResolvedMatchArm, ResolvedPattern,
+};
 
 use super::super::WasmGcError;
 use super::super::types::{TypeRegistry, aver_to_wasm};
 use super::builtins::{emit_dotted_builtin, emit_interpolated_str};
 use super::infer::{
-    arm_is_option_pattern, arm_is_result_pattern, aver_type_canonical, aver_type_str_of,
-    wasm_type_of,
+    arm_is_option_pattern_resolved, arm_is_result_pattern_resolved, aver_type_canonical,
+    aver_type_str_of, wasm_type_of,
 };
 use super::{EmitCtx, SlotTable};
+
+/// Source-level dotted name for a [`ResolvedCtor`]. Reconstructs the
+/// `"Result.Ok"` / `"Option.None"` / `"Module.User.Circle"` form that
+/// the registry / dispatch logic was keyed on pre-PR-9.1. User ctors
+/// resolve their parent type via the [`SymbolTable`] threaded into
+/// [`EmitCtx`].
+pub(super) fn ctor_dotted_name(ctor: &ResolvedCtor, ctx: &EmitCtx<'_>) -> String {
+    match ctor {
+        ResolvedCtor::Builtin(BuiltinCtor::ResultOk) => "Result.Ok".to_string(),
+        ResolvedCtor::Builtin(BuiltinCtor::ResultErr) => "Result.Err".to_string(),
+        ResolvedCtor::Builtin(BuiltinCtor::OptionSome) => "Option.Some".to_string(),
+        ResolvedCtor::Builtin(BuiltinCtor::OptionNone) => "Option.None".to_string(),
+        ResolvedCtor::User { type_id, name, .. } => {
+            let parent = ctx.symbol_table.type_entry(*type_id).key.name.clone();
+            format!("{parent}.{name}")
+        }
+        ResolvedCtor::Unresolved { name } => name.clone(),
+    }
+}
+
+/// True iff `expr` is the literal `Option.None` constructor reference
+/// — handles both call form (`Option.None`) and the bare-attr / bare-
+/// ident shape now lowered through [`ResolvedExpr::Ctor`] with zero
+/// args.
+fn is_option_none_expr(expr: &ResolvedExpr) -> bool {
+    matches!(
+        expr,
+        ResolvedExpr::Ctor(ResolvedCtor::Builtin(BuiltinCtor::OptionNone), args) if args.is_empty()
+    )
+}
 
 /// Emit a "default value" of the given Aver primitive / ref type onto
 /// the wasm stack. Used by `Option.None` constructor to satisfy
@@ -89,7 +122,7 @@ pub(super) fn emit_default_value(
 /// emitted from a match arm.
 pub(super) fn emit_option_constructor(
     func: &mut Function,
-    payload: Option<&Spanned<Expr>>,
+    payload: Option<&Spanned<ResolvedExpr>>,
     t_aver_hint: Option<&str>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -142,22 +175,22 @@ pub(super) fn emit_option_constructor(
 /// function pushes one value (or zero for `Unit`) for every call.
 pub(super) fn emit_expr(
     func: &mut Function,
-    expr: &Spanned<Expr>,
+    expr: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
     match &expr.node {
-        Expr::Literal(Literal::Int(n)) => {
+        ResolvedExpr::Literal(Literal::Int(n)) => {
             func.instruction(&Instruction::I64Const(*n));
         }
-        Expr::Literal(Literal::Float(f)) => {
+        ResolvedExpr::Literal(Literal::Float(f)) => {
             func.instruction(&Instruction::F64Const((*f).into()));
         }
-        Expr::Literal(Literal::Bool(b)) => {
+        ResolvedExpr::Literal(Literal::Bool(b)) => {
             func.instruction(&Instruction::I32Const(if *b { 1 } else { 0 }));
         }
-        Expr::Literal(Literal::Unit) => {}
-        Expr::Literal(Literal::Str(s)) => {
+        ResolvedExpr::Literal(Literal::Unit) => {}
+        ResolvedExpr::Literal(Literal::Str(s)) => {
             // String literal → passive data segment; emit
             // `array.new_data $string $seg` with offset=0, size=len.
             let bytes = s.as_bytes();
@@ -180,19 +213,19 @@ pub(super) fn emit_expr(
                 array_data_index: seg_idx,
             });
         }
-        Expr::InterpolatedStr(parts) => {
+        ResolvedExpr::InterpolatedStr(parts) => {
             emit_interpolated_str(func, parts, slots, ctx)?;
         }
-        Expr::List(items) => {
+        ResolvedExpr::List(items) => {
             emit_list_literal(func, expr, items, slots, ctx)?;
         }
-        Expr::MapLiteral(entries) => {
+        ResolvedExpr::MapLiteral(entries) => {
             emit_map_literal(func, entries, slots, ctx)?;
         }
-        Expr::Tuple(items) => {
+        ResolvedExpr::Tuple(items) => {
             emit_tuple_literal(func, items, slots, ctx)?;
         }
-        Expr::IndependentProduct(items, unwrap) => {
+        ResolvedExpr::IndependentProduct(items, unwrap) => {
             // wasm-gc has no parallelism (no `std::thread::scope`
             // analogue), so both `(a, b, c)!` and `(a, b, c)?!` lower
             // as sequential evaluation. `!` (unwrap=false) is just a
@@ -218,15 +251,15 @@ pub(super) fn emit_expr(
             }
             emit_group_call(func, ctx, "__record_exit_group");
         }
-        Expr::Ident(_) => {
+        ResolvedExpr::Ident(_) => {
             return Err(WasmGcError::Unimplemented(
                 "bare Ident reached emitter (resolver should have produced Resolved)",
             ));
         }
-        Expr::Resolved { slot, .. } => {
+        ResolvedExpr::Resolved { slot, .. } => {
             func.instruction(&Instruction::LocalGet(*slot as u32));
         }
-        Expr::BinOp(op, l, r) => {
+        ResolvedExpr::BinOp(op, l, r) => {
             // Read operand types from typed AST. Aver's type checker
             // has already proven both operands have the same type, so
             // peeking at the LHS suffices.
@@ -353,7 +386,7 @@ pub(super) fn emit_expr(
                 func.instruction(&inst);
             }
         }
-        Expr::Neg(inner) => {
+        ResolvedExpr::Neg(inner) => {
             // Numeric unary minus. Float uses `f64.neg` which preserves
             // the IEEE sign bit (so `-0.0` survives the round trip);
             // Int has no dedicated instruction and lowers to
@@ -369,148 +402,117 @@ pub(super) fn emit_expr(
                 func.instruction(&Instruction::I64Sub);
             }
         }
-        Expr::FnCall(callee, args) => {
-            // `Type.Variant(args)` parses as `FnCall(Attr(_, name),
-            // args)` — route to struct.new when `name` is a known
-            // variant, otherwise check for a dotted builtin, otherwise
-            // a real fn call.
-            if let Expr::Attr(parent, member) = &callee.node {
-                // Built-in Option constructors come through here as
-                // `Option.Some(v)` / `Option.None`. Catch them before
-                // user-variant lookup because Option isn't a TypeDef.
-                // Other `Option.<method>` calls (`withDefault`, etc.)
-                // fall through to the dotted-builtin dispatch below.
-                if let Expr::Ident(p) = &parent.node
-                    && p == "Option"
-                    && (member == "Some" || member == "None")
-                {
-                    return match member.as_str() {
-                        "Some" if args.len() == 1 => {
-                            emit_option_constructor(func, Some(&args[0]), None, slots, ctx)
+        ResolvedExpr::Call(callee, args) => {
+            match callee {
+                ResolvedCallee::Builtin(name) => {
+                    // `List.prepend(head, tail)` — direct Cons cell.
+                    if name == "List.prepend" && args.len() == 2 {
+                        return emit_list_prepend(func, &args[0], &args[1], slots, ctx);
+                    }
+                    // `List.empty()` — null ref of the surrounding
+                    // list type.
+                    if name == "List.empty" && args.is_empty() {
+                        return emit_list_empty(func, ctx);
+                    }
+                    // Generic `Parent.member(args)` dotted-builtin
+                    // dispatch (Console.* / Float.* / Map.* / Vector.*
+                    // / wasip2 effects / etc.). Split the canonical
+                    // string back into `parent` + `method` for the
+                    // existing dispatch shape — the resolver pass
+                    // joined them into a single name.
+                    let (parent, member) = name.rsplit_once('.').ok_or_else(|| {
+                        WasmGcError::Validation(format!(
+                            "ResolvedCallee::Builtin `{name}` is not in `Parent.method` form"
+                        ))
+                    })?;
+                    return emit_dotted_builtin(func, parent, member, args, slots, ctx);
+                }
+                ResolvedCallee::Intrinsic(intr) => {
+                    // Compiler-synthesised `__buf_*` / `__to_str`
+                    // intrinsics. Route them through the same dotted-
+                    // builtin dispatch as registered builtins —
+                    // pre-Phase-E these reached the emitter as
+                    // `Expr::FnCall(Ident("__buf_*"), args)` and fell
+                    // into the `ctx.fn_map.builtins` lookup branch in
+                    // `emit_dotted_builtin`. The intrinsic carries its
+                    // canonical name; the dispatch keys by that.
+                    let name = intr.name();
+                    // The dotted-builtin dispatcher splits on the
+                    // final `.`; synthesised intrinsics are bare
+                    // (`__buf_new`), so route them through the
+                    // registered-builtin fast path by passing an
+                    // empty parent. `emit_dotted_builtin` looks up
+                    // `fn_map.builtins.get(&dotted)` first — for that
+                    // we need the raw intrinsic name. Take the path
+                    // directly here instead of asking the dispatcher.
+                    if let Some(&wasm_idx) = ctx.fn_map.builtins.get(name) {
+                        for arg in args {
+                            emit_expr(func, arg, slots, ctx)?;
                         }
-                        "None" => {
-                            // Read T from the typed AST first; use the
-                            // Type::Invalid-recovery reader so post-
-                            // error gradual-typing branches still
-                            // resolve to a concrete Option<T>.
-                            let stamped_canonical =
-                                aver_type_canonical(expr, ctx.return_type, ctx.registry);
-                            let hint: String = if let Some(inner) = stamped_canonical
-                                .strip_prefix("Option<")
-                                .and_then(|s| s.strip_suffix('>'))
-                            {
-                                inner.to_string()
-                            } else {
-                                ctx.return_type.to_string()
-                            };
-                            emit_option_constructor(func, None, Some(&hint), slots, ctx)
-                        }
-                        _ => Err(WasmGcError::Validation(format!(
-                            "Option.{member} with {} args is not a valid constructor",
-                            args.len()
-                        ))),
-                    };
+                        func.instruction(&Instruction::Call(wasm_idx));
+                        return Ok(());
+                    }
+                    return Err(WasmGcError::Validation(format!(
+                        "intrinsic `{name}` not registered in fn_map.builtins"
+                    )));
                 }
-                if let Expr::Ident(p) = &parent.node
-                    && p == "Result"
-                    && (member == "Ok" || member == "Err")
-                {
-                    return emit_result_constructor(func, member, args.first(), slots, ctx);
+                ResolvedCallee::Fn(id) => {
+                    let name = ctx.symbol_table.fn_entry(*id).key.name.clone();
+                    let entry = ctx.fn_map.by_name.get(&name);
+                    if entry.is_none() && ctx.self_local_slot(&name).is_some() {
+                        // Local slot of a `Fn(...) -> _` value — wasm-
+                        // gc doesn't emit higher-order calls. Same
+                        // semantics as pre-Phase-E.
+                        func.instruction(&Instruction::Unreachable);
+                        return Ok(());
+                    }
+                    for arg in args {
+                        emit_expr(func, arg, slots, ctx)?;
+                    }
+                    let entry = entry.ok_or(WasmGcError::Validation(format!(
+                        "call to unknown fn `{name}`"
+                    )))?;
+                    func.instruction(&Instruction::Call(entry.wasm_idx));
                 }
-                // `List.prepend(head, tail)` — direct Cons cell.
-                if let Expr::Ident(p) = &parent.node
-                    && p == "List"
-                    && member == "prepend"
-                    && args.len() == 2
-                {
-                    return emit_list_prepend(func, &args[0], &args[1], slots, ctx);
+                ResolvedCallee::LocalSlot { .. } => {
+                    // First-class fn value bound to a local — wasm-gc
+                    // is validation-polymorphic via `Unreachable`.
+                    // Verify-only fns reach this; bare `_start` never
+                    // executes the trap.
+                    func.instruction(&Instruction::Unreachable);
+                    return Ok(());
                 }
-                // `List.empty()` — null ref of the surrounding list type.
-                if let Expr::Ident(p) = &parent.node
-                    && p == "List"
-                    && member == "empty"
-                    && args.is_empty()
-                {
-                    return emit_list_empty(func, ctx);
-                }
-                // `Foo.Bar(args...)` — sum-type variant constructor.
-                // Disambiguate by parent so two sumtypes sharing a
-                // bare variant name (e.g. `Query.ProviderSummary` vs
-                // `QueryOutput.ProviderSummary`) pick up their own
-                // concrete struct idx.
-                let parent_ident = match &parent.node {
-                    Expr::Ident(n) => Some(n.as_str()),
-                    Expr::Resolved { name, .. } => Some(name.as_str()),
-                    _ => None,
-                };
-                let info = parent_ident
-                    .and_then(|p| ctx.registry.variant_in(p, member))
-                    .or_else(|| ctx.registry.variant(member))
-                    .cloned();
-                if let Some(info) = info {
-                    return emit_constructor_with_args(func, &info, args, slots, ctx);
-                }
-                // Builtins: `Type.method(args...)` shape. We support
-                // a curated set today (the ones bench scenarios use);
-                // anything else surfaces as Unimplemented.
-                if let Some(parent_name) = parent_ident {
-                    return emit_dotted_builtin(func, parent_name, member, args, slots, ctx);
+                ResolvedCallee::Unresolved { callee: inner } => {
+                    return Err(WasmGcError::Validation(format!(
+                        "unresolved callee reached wasm-gc emit: {:?}",
+                        inner.node
+                    )));
                 }
             }
-            let name = match &callee.node {
-                Expr::Ident(n) => n.as_str(),
-                Expr::Resolved { name, .. } => name.as_str(),
-                _ => {
-                    return Err(WasmGcError::Unimplemented(
-                        "phase 3b — exotic callee shape (chained Attr, lambda, etc.)",
-                    ));
-                }
-            };
-            // Resolve before evaluating args — if `name` is a local
-            // (binding/param of a `Fn(...) -> _` shape, only ever
-            // reachable through verify-only fns) the wasm-gc backend
-            // doesn't emit a higher-order call. Emit `unreachable`,
-            // which wasm validation treats as polymorphic — the
-            // surrounding block's result type can be anything. Body is
-            // dead from a `_start` perspective so the trap never fires.
-            let entry = ctx.fn_map.by_name.get(name);
-            if entry.is_none() && ctx.self_local_slot(name).is_some() {
-                func.instruction(&Instruction::Unreachable);
-                return Ok(());
-            }
-            for arg in args {
-                emit_expr(func, arg, slots, ctx)?;
-            }
-            let entry = entry.ok_or(WasmGcError::Validation(format!(
-                "call to unknown fn `{name}`"
-            )))?;
-            func.instruction(&Instruction::Call(entry.wasm_idx));
         }
-        Expr::Match { subject, arms } => emit_match(func, subject, arms, slots, ctx)?,
-        Expr::TailCall(boxed) => emit_tail_call(func, &boxed.target, &boxed.args, slots, ctx)?,
-        Expr::RecordCreate { type_name, fields } => {
-            emit_record_create(func, type_name, fields, slots, ctx)?
+        ResolvedExpr::Match { subject, arms } => emit_match(func, subject, arms, slots, ctx)?,
+        ResolvedExpr::TailCall { target, args } => {
+            let target_name = ctx.symbol_table.fn_entry(*target).key.name.clone();
+            emit_tail_call(func, &target_name, args, slots, ctx)?
         }
-        Expr::RecordUpdate {
+        ResolvedExpr::RecordCreate {
+            type_name, fields, ..
+        } => emit_record_create(func, type_name, fields, slots, ctx)?,
+        ResolvedExpr::RecordUpdate {
             type_name,
             base,
             updates,
+            ..
         } => emit_record_update(func, type_name, base, updates, slots, ctx)?,
-        Expr::Attr(obj, field) => {
+        ResolvedExpr::Attr(obj, field) => {
             // `Option.None` lands here as a bare attribute reference
             // (parser doesn't synthesise a FnCall for nullary
-            // constructors). Catch it before falling into struct field
-            // access, which would never resolve.
-            if let Expr::Ident(p) = &obj.node
+            // constructors, and the resolver passes Attr through
+            // structurally without re-classifying nullary built-ins).
+            if let ResolvedExpr::Ident(p) = &obj.node
                 && p == "Option"
                 && field == "None"
             {
-                // Read T from the typed AST: type checker stamps every
-                // `Option.None` with the inferred Option<T>. Use the
-                // Type::Invalid-recovery canonical reader so post-error
-                // gradual-typing branches still resolve to a concrete
-                // instantiation (single-instantiation fallback or
-                // enclosing-fn return-type carry-through).
                 let stamped_canonical = aver_type_canonical(expr, ctx.return_type, ctx.registry);
                 let hint: String = if let Some(inner) = stamped_canonical
                     .strip_prefix("Option<")
@@ -521,32 +523,69 @@ pub(super) fn emit_expr(
                     ctx.return_type.to_string()
                 };
                 emit_option_constructor(func, None, Some(&hint), slots, ctx)?;
-            } else if let Expr::Ident(parent) = &obj.node
+            } else if let ResolvedExpr::Ident(parent) = &obj.node
                 && let Some(info) = ctx.registry.variant_in(parent, field).cloned()
                 && info.fields.is_empty()
             {
                 // `Tag.Red` etc. — Attr access on a user-defined sum
-                // type's name resolves to a nullary variant constructor.
-                // The FnCall path already does this for `Tag.Red()`;
-                // mirror it for the bare-attr form so the variant can
-                // be used in any value position (Map K, fn arg, return
-                // expr) without a trailing `()`.
+                // type's name resolves to a nullary variant
+                // constructor. The Ctor arm already does this for
+                // `Tag.Red()`; mirror it for the bare-attr form.
                 emit_constructor_with_args(func, &info, &[], slots, ctx)?;
             } else {
                 emit_attr_get(func, obj, field, slots, ctx)?;
             }
         }
-        Expr::Constructor(name, payload) => {
-            emit_constructor(func, expr, name, payload.as_deref(), slots, ctx)?
-        }
-        Expr::ErrorProp(inner) => emit_error_prop(func, inner, slots, ctx)?,
-        #[allow(unreachable_patterns)]
-        other => {
-            eprintln!("UNIMPL EMIT shape={:?}", other);
-            return Err(WasmGcError::Unimplemented(
-                "expression shape outside phase 2/3/4",
-            ));
-        }
+        ResolvedExpr::Ctor(ctor, args) => match ctor {
+            ResolvedCtor::Builtin(BuiltinCtor::OptionSome) => {
+                if args.len() != 1 {
+                    return Err(WasmGcError::Validation(format!(
+                        "Option.Some constructor requires 1 arg, got {}",
+                        args.len()
+                    )));
+                }
+                emit_option_constructor(func, Some(&args[0]), None, slots, ctx)?;
+            }
+            ResolvedCtor::Builtin(BuiltinCtor::OptionNone) => {
+                // Read T from the typed AST first; use the Type::
+                // Invalid-recovery reader so post-error gradual-typing
+                // branches still resolve to a concrete Option<T>.
+                let stamped_canonical = aver_type_canonical(expr, ctx.return_type, ctx.registry);
+                let hint: String = if let Some(inner) = stamped_canonical
+                    .strip_prefix("Option<")
+                    .and_then(|s| s.strip_suffix('>'))
+                {
+                    inner.to_string()
+                } else {
+                    ctx.return_type.to_string()
+                };
+                emit_option_constructor(func, None, Some(&hint), slots, ctx)?;
+            }
+            ResolvedCtor::Builtin(BuiltinCtor::ResultOk) => {
+                emit_result_constructor(func, "Ok", args.first(), slots, ctx)?;
+            }
+            ResolvedCtor::Builtin(BuiltinCtor::ResultErr) => {
+                emit_result_constructor(func, "Err", args.first(), slots, ctx)?;
+            }
+            ResolvedCtor::User { type_id, name, .. } => {
+                let parent = ctx.symbol_table.type_entry(*type_id).key.name.clone();
+                let info = ctx
+                    .registry
+                    .variant_in(&parent, name)
+                    .or_else(|| ctx.registry.variant(name))
+                    .cloned()
+                    .ok_or(WasmGcError::Validation(format!(
+                        "unknown variant `{parent}.{name}` in constructor"
+                    )))?;
+                emit_constructor_with_args(func, &info, args, slots, ctx)?;
+            }
+            ResolvedCtor::Unresolved { name } => {
+                return Err(WasmGcError::Validation(format!(
+                    "unresolved ctor `{name}` reached wasm-gc emit"
+                )));
+            }
+        },
+        ResolvedExpr::ErrorProp(inner) => emit_error_prop(func, inner, slots, ctx)?,
     }
     Ok(())
 }
@@ -568,7 +607,7 @@ pub(super) fn emit_expr(
 /// reachable site, so a miss surfaces as `None` and the call falls
 /// through to the default arm where wasm validation will catch the
 /// type mismatch.
-fn sum_or_record_eq_fn(operand: &Spanned<Expr>, ctx: &EmitCtx<'_>) -> Option<u32> {
+fn sum_or_record_eq_fn(operand: &Spanned<ResolvedExpr>, ctx: &EmitCtx<'_>) -> Option<u32> {
     let ty = operand.ty()?;
     match ty {
         crate::types::Type::Named { name, .. } => {
@@ -640,12 +679,15 @@ fn sum_or_record_eq_fn(operand: &Spanned<Expr>, ctx: &EmitCtx<'_>) -> Option<u32
     }
 }
 
-fn nullary_variant_idx(expr: &Spanned<Expr>, ctx: &EmitCtx<'_>) -> Option<u32> {
+fn nullary_variant_idx(expr: &Spanned<ResolvedExpr>, ctx: &EmitCtx<'_>) -> Option<u32> {
     match &expr.node {
-        Expr::Attr(obj, field) => {
+        // Bare `Tag.Red` form (resolver doesn't lift bare attr access
+        // to Ctor — only `Tag.Red()` parses as FnCall, only
+        // `Constructor("...", None)` reaches the Ctor arm).
+        ResolvedExpr::Attr(obj, field) => {
             let parent = match &obj.node {
-                Expr::Ident(p) => p.as_str(),
-                Expr::Resolved { name, .. } => name.as_str(),
+                ResolvedExpr::Ident(p) => p.as_str(),
+                ResolvedExpr::Resolved { name, .. } => name.as_str(),
                 _ => return None,
             };
             let info = ctx.registry.variant(field)?;
@@ -655,26 +697,15 @@ fn nullary_variant_idx(expr: &Spanned<Expr>, ctx: &EmitCtx<'_>) -> Option<u32> {
                 None
             }
         }
-        Expr::FnCall(callee, args) if args.is_empty() => {
-            if let Expr::Attr(obj, field) = &callee.node {
-                let parent = match &obj.node {
-                    Expr::Ident(p) => p.as_str(),
-                    Expr::Resolved { name, .. } => name.as_str(),
-                    _ => return None,
-                };
-                let info = ctx.registry.variant(field)?;
-                if info.parent == parent && info.fields.is_empty() {
-                    Some(info.type_idx)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        }
-        Expr::Constructor(name, payload) if payload.is_none() => {
-            let bare = name.rsplit('.').next().unwrap_or(name);
-            let info = ctx.registry.variant(bare)?;
+        // Resolved `Tag.Red(args)` calls — the resolver lifts the
+        // FnCall(Attr) shape into Ctor when the dotted name resolves
+        // to a user ctor. Match the nullary case here.
+        ResolvedExpr::Ctor(ResolvedCtor::User { type_id, name, .. }, args) if args.is_empty() => {
+            let parent_name = ctx.symbol_table.type_entry(*type_id).key.name.clone();
+            let info = ctx
+                .registry
+                .variant_in(&parent_name, name)
+                .or_else(|| ctx.registry.variant(name))?;
             if info.fields.is_empty() {
                 Some(info.type_idx)
             } else {
@@ -691,8 +722,8 @@ fn nullary_variant_idx(expr: &Spanned<Expr>, ctx: &EmitCtx<'_>) -> Option<u32> {
 /// surface; same O(total_len) bytes copied.
 pub(super) fn emit_string_concat2(
     func: &mut Function,
-    lhs: &Spanned<Expr>,
-    rhs: &Spanned<Expr>,
+    lhs: &Spanned<ResolvedExpr>,
+    rhs: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -728,8 +759,8 @@ pub(super) fn emit_string_concat2(
 /// optionally invert with `i32.eqz` for `!=`.
 pub(super) fn emit_string_eq(
     func: &mut Function,
-    lhs: &Spanned<Expr>,
-    rhs: &Spanned<Expr>,
+    lhs: &Spanned<ResolvedExpr>,
+    rhs: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
     invert: bool,
@@ -770,7 +801,7 @@ pub(super) fn emit_string_eq(
 /// `expr_needs_scratch` predicate is updated to cover this case).
 pub(super) fn emit_error_prop(
     func: &mut Function,
-    inner: &Spanned<Expr>,
+    inner: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -885,7 +916,7 @@ pub(super) fn emit_error_prop(
 pub(super) fn emit_record_create(
     func: &mut Function,
     type_name: &str,
-    fields: &[(String, Spanned<Expr>)],
+    fields: &[(String, Spanned<ResolvedExpr>)],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -942,7 +973,7 @@ pub(super) fn emit_record_create(
         // would otherwise default to `ctx.return_type` or the first
         // registered list canonical — both wrong when the field's
         // declared type is e.g. `List<List<Point>>`.
-        if let Expr::List(items) = &provided.1.node
+        if let ResolvedExpr::List(items) = &provided.1.node
             && items.is_empty()
         {
             let canonical: String = decl_ty.chars().filter(|c| !c.is_whitespace()).collect();
@@ -957,23 +988,6 @@ pub(super) fn emit_record_create(
     }
     func.instruction(&Instruction::StructNew(type_idx));
     Ok(())
-}
-
-/// True iff `expr` is the literal `Option.None` constructor reference
-/// (either as `Expr::Attr(Ident("Option"), "None")` or as a
-/// `Constructor("Option.None", None)` after pipeline rewrites).
-fn is_option_none_expr(expr: &Expr) -> bool {
-    match expr {
-        Expr::Attr(obj, field) => {
-            field == "None" && matches!(&obj.node, Expr::Ident(name) if name == "Option")
-        }
-        Expr::Constructor(name, payload) => {
-            payload.is_none()
-                && (name == "Option.None"
-                    || name.rsplit('.').next() == Some("None") && name.starts_with("Option"))
-        }
-        _ => false,
-    }
 }
 
 /// Lower `RecordUpdate { type_name, base, updates }` to a fresh
@@ -992,8 +1006,8 @@ fn is_option_none_expr(expr: &Expr) -> bool {
 pub(super) fn emit_record_update(
     func: &mut Function,
     type_name: &str,
-    base: &Spanned<Expr>,
-    updates: &[(String, Spanned<Expr>)],
+    base: &Spanned<ResolvedExpr>,
+    updates: &[(String, Spanned<ResolvedExpr>)],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1027,7 +1041,7 @@ pub(super) fn emit_record_update(
                 emit_option_constructor(func, None, Some(inner.trim()), slots, ctx)?;
                 continue;
             }
-            if let Expr::List(items) = &override_expr.node
+            if let ResolvedExpr::List(items) = &override_expr.node
                 && items.is_empty()
             {
                 let canonical: String = decl_ty.chars().filter(|c| !c.is_whitespace()).collect();
@@ -1064,7 +1078,7 @@ pub(super) fn emit_record_update(
 /// backend just reads the stamp.
 pub(super) fn emit_attr_get(
     func: &mut Function,
-    obj: &Spanned<Expr>,
+    obj: &Spanned<ResolvedExpr>,
     field: &str,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -1115,7 +1129,7 @@ pub(super) fn emit_attr_get(
 pub(super) fn emit_result_constructor(
     func: &mut Function,
     variant: &str,
-    payload: Option<&Spanned<Expr>>,
+    payload: Option<&Spanned<ResolvedExpr>>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1190,8 +1204,8 @@ pub(super) fn emit_result_constructor(
 /// `List.prepend(head, tail)` → `struct.new $list_T head tail`.
 pub(super) fn emit_list_prepend(
     func: &mut Function,
-    head: &Spanned<Expr>,
-    tail: &Spanned<Expr>,
+    head: &Spanned<ResolvedExpr>,
+    tail: &Spanned<ResolvedExpr>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1255,7 +1269,7 @@ pub(super) fn emit_list_empty(func: &mut Function, ctx: &EmitCtx<'_>) -> Result<
 /// `E`. We rely on those invariants here.
 pub(super) fn emit_independent_product_unwrap(
     func: &mut Function,
-    items: &[Spanned<Expr>],
+    items: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1428,7 +1442,7 @@ fn emit_branch_marker(func: &mut Function, ctx: &EmitCtx<'_>, branch_idx: u32) {
 /// `enter_group` / `exit_group` are emitted by the caller arm.
 fn emit_tuple_literal_with_branch_markers(
     func: &mut Function,
-    items: &[Spanned<Expr>],
+    items: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1459,7 +1473,7 @@ fn emit_tuple_literal_with_branch_markers(
 
 pub(super) fn emit_tuple_literal(
     func: &mut Function,
-    items: &[Spanned<Expr>],
+    items: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1491,7 +1505,7 @@ pub(super) fn emit_tuple_literal(
 
 pub(super) fn emit_map_literal(
     func: &mut Function,
-    entries: &[(Spanned<Expr>, Spanned<Expr>)],
+    entries: &[(Spanned<ResolvedExpr>, Spanned<ResolvedExpr>)],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1534,8 +1548,8 @@ pub(super) fn emit_map_literal(
 
 pub(super) fn emit_list_literal(
     func: &mut Function,
-    outer: &Spanned<Expr>,
-    items: &[Spanned<Expr>],
+    outer: &Spanned<ResolvedExpr>,
+    items: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -1557,7 +1571,7 @@ pub(super) fn emit_list_literal(
             // the enclosing fn's return type when it parses as
             // `List<T>` and the first item lacks its own resolvable
             // type — this gives the correct T for both shapes.
-            let needs_hint = matches!(&first.node, Expr::List(xs) if xs.is_empty())
+            let needs_hint = matches!(&first.node, ResolvedExpr::List(xs) if xs.is_empty())
                 || is_option_none_expr(&first.node);
             let elem_ty = if needs_hint {
                 let ret: String = ctx
@@ -1641,7 +1655,7 @@ pub(super) fn emit_list_literal(
             continue;
         }
         if let Some(elem) = elem_ty.as_deref()
-            && let Expr::List(xs) = &item.node
+            && let ResolvedExpr::List(xs) = &item.node
             && xs.is_empty()
             && let Some(list_idx) = ctx.registry.list_type_idx(elem)
         {
@@ -1666,13 +1680,13 @@ pub(super) fn emit_list_literal(
 /// corresponding ident binding. `_` skips the bind.
 pub(super) fn emit_tuple_match(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    arm: &MatchArm,
+    subject: &Spanned<ResolvedExpr>,
+    arm: &ResolvedMatchArm,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
     let pat_items = match &arm.pattern {
-        Pattern::Tuple(items) => items.as_slice(),
+        ResolvedPattern::Tuple(items) => items.as_slice(),
         _ => {
             return Err(WasmGcError::Validation(
                 "emit_tuple_match called on non-Tuple pattern".into(),
@@ -1699,7 +1713,7 @@ pub(super) fn emit_tuple_match(
     // tuple destructure currently only supports flat `Pattern::Ident`
     // items (multi-binding nested tuples land elsewhere).
     for (field_idx, (pat, &slot)) in pat_items.iter().zip(arm_slots.iter()).enumerate() {
-        if matches!(pat, Pattern::Ident(_)) && slot != u16::MAX {
+        if matches!(pat, ResolvedPattern::Ident(_)) && slot != u16::MAX {
             func.instruction(&Instruction::LocalGet(scratch));
             func.instruction(&Instruction::RefCastNonNull(
                 wasm_encoder::HeapType::Concrete(tuple_idx),
@@ -1732,8 +1746,8 @@ pub(super) fn emit_tuple_match(
 /// than silently mis-emitting.
 pub(super) fn emit_tuple_constructor_match(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    arms: &[MatchArm],
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
     block_ty: wasm_encoder::BlockType,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -1778,7 +1792,7 @@ fn emit_tuple_constructor_arm_cascade(
     scratch: u32,
     tuple_idx: u32,
     elems: &[String],
-    arms: &[MatchArm],
+    arms: &[ResolvedMatchArm],
     block_ty: wasm_encoder::BlockType,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -1793,8 +1807,8 @@ fn emit_tuple_constructor_arm_cascade(
     }
     let arm = &arms[0];
     match &arm.pattern {
-        Pattern::Wildcard => emit_expr(func, &arm.body, slots, ctx),
-        Pattern::Ident(_) => {
+        ResolvedPattern::Wildcard => emit_expr(func, &arm.body, slots, ctx),
+        ResolvedPattern::Ident(_) => {
             if let Some(arm_slots) = arm.binding_slots.get()
                 && let Some(&slot) = arm_slots.first()
                 && slot != u16::MAX
@@ -1804,7 +1818,7 @@ fn emit_tuple_constructor_arm_cascade(
             }
             emit_expr(func, &arm.body, slots, ctx)
         }
-        Pattern::Tuple(items) => {
+        ResolvedPattern::Tuple(items) => {
             if items.len() != elems.len() {
                 return Err(WasmGcError::Validation(format!(
                     "tuple match arm has {} sub-patterns, subject is a {}-tuple",
@@ -1818,8 +1832,9 @@ fn emit_tuple_constructor_arm_cascade(
             // when no constructor tests are present.
             let mut tests_emitted = 0u32;
             for (i, pat) in items.iter().enumerate() {
-                if let Pattern::Constructor(name, _) = pat {
-                    let bare = name.rsplit('.').next().unwrap_or(name);
+                if let ResolvedPattern::Ctor(ctor, _) = pat {
+                    let name = ctor_dotted_name(ctor, ctx);
+                    let bare = name.rsplit('.').next().unwrap_or(&name);
                     let elem_canonical: String =
                         elems[i].chars().filter(|c| !c.is_whitespace()).collect();
                     let res_idx = ctx.registry.result_type_idx(&elem_canonical).ok_or(
@@ -1876,7 +1891,7 @@ fn emit_tuple_constructor_arm_cascade(
             let mut slot_idx = 0;
             for (i, pat) in items.iter().enumerate() {
                 match pat {
-                    Pattern::Ident(_) => {
+                    ResolvedPattern::Ident(_) => {
                         let slot = arm_slots[slot_idx];
                         slot_idx += 1;
                         if slot != u16::MAX {
@@ -1891,8 +1906,9 @@ fn emit_tuple_constructor_arm_cascade(
                             func.instruction(&Instruction::LocalSet(slot as u32));
                         }
                     }
-                    Pattern::Constructor(name, bindings) => {
-                        let bare = name.rsplit('.').next().unwrap_or(name);
+                    ResolvedPattern::Ctor(ctor, bindings) => {
+                        let name = ctor_dotted_name(ctor, ctx);
+                        let bare = name.rsplit('.').next().unwrap_or(&name);
                         let elem_canonical: String =
                             elems[i].chars().filter(|c| !c.is_whitespace()).collect();
                         let res_idx_opt = ctx.registry.result_type_idx(&elem_canonical);
@@ -1958,8 +1974,8 @@ fn emit_tuple_constructor_arm_cascade(
 /// the head and tail. Subject must be a registered `List<T>`.
 pub(super) fn emit_list_match(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    arms: &[MatchArm],
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
     block_ty: wasm_encoder::BlockType,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -1976,13 +1992,13 @@ pub(super) fn emit_list_match(
             "List match: subject type `{subject_ty}` is not a registered List<T>"
         )))?;
 
-    let mut empty_arm: Option<&MatchArm> = None;
-    let mut cons_arm: Option<&MatchArm> = None;
+    let mut empty_arm: Option<&ResolvedMatchArm> = None;
+    let mut cons_arm: Option<&ResolvedMatchArm> = None;
     for arm in arms {
         match &arm.pattern {
-            Pattern::EmptyList => empty_arm = Some(arm),
-            Pattern::Cons(_, _) => cons_arm = Some(arm),
-            Pattern::Wildcard => {
+            ResolvedPattern::EmptyList => empty_arm = Some(arm),
+            ResolvedPattern::Cons(_, _) => cons_arm = Some(arm),
+            ResolvedPattern::Wildcard => {
                 if empty_arm.is_none() {
                     empty_arm = Some(arm);
                 } else if cons_arm.is_none() {
@@ -2007,7 +2023,7 @@ pub(super) fn emit_list_match(
     func.instruction(&Instruction::If(block_ty));
     emit_expr(func, &empty_arm.body, slots, ctx)?;
     func.instruction(&Instruction::Else);
-    if let Pattern::Cons(_head_name, _tail_name) = &cons_arm.pattern {
+    if let ResolvedPattern::Cons(_head_name, _tail_name) = &cons_arm.pattern {
         let arm_slots = cons_arm.binding_slots.get().ok_or(WasmGcError::Validation(
             "Cons match arm reached emit without resolver-allocated binding_slots".into(),
         ))?;
@@ -2046,8 +2062,8 @@ pub(super) fn emit_list_match(
 /// field 2 (E).
 pub(super) fn emit_result_match(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    arms: &[MatchArm],
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
     block_ty: wasm_encoder::BlockType,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -2064,19 +2080,16 @@ pub(super) fn emit_result_match(
             "Result match: subject type `{subject_ty}` is not a registered Result<T,E>"
         )))?;
 
-    let mut ok_arm: Option<&MatchArm> = None;
-    let mut err_arm: Option<&MatchArm> = None;
+    let mut ok_arm: Option<&ResolvedMatchArm> = None;
+    let mut err_arm: Option<&ResolvedMatchArm> = None;
     for arm in arms {
         match &arm.pattern {
-            Pattern::Constructor(name, _) => {
-                let bare = name.rsplit('.').next().unwrap_or(name);
-                if bare == "Ok" {
-                    ok_arm = Some(arm);
-                } else if bare == "Err" {
-                    err_arm = Some(arm);
-                }
-            }
-            Pattern::Wildcard => {
+            ResolvedPattern::Ctor(ctor, _) => match ctor {
+                ResolvedCtor::Builtin(BuiltinCtor::ResultOk) => ok_arm = Some(arm),
+                ResolvedCtor::Builtin(BuiltinCtor::ResultErr) => err_arm = Some(arm),
+                _ => {}
+            },
+            ResolvedPattern::Wildcard => {
                 if err_arm.is_none() {
                     err_arm = Some(arm);
                 } else if ok_arm.is_none() {
@@ -2107,7 +2120,7 @@ pub(super) fn emit_result_match(
     func.instruction(&Instruction::I32Const(1));
     func.instruction(&Instruction::I32Eq);
     func.instruction(&Instruction::If(block_ty));
-    if let Pattern::Constructor(_, _) = &ok_arm.pattern
+    if let ResolvedPattern::Ctor(_, _) = &ok_arm.pattern
         && let Some(arm_slots) = ok_arm.binding_slots.get()
         && let Some(&slot) = arm_slots.first()
         && slot != u16::MAX
@@ -2124,7 +2137,7 @@ pub(super) fn emit_result_match(
     }
     emit_expr(func, &ok_arm.body, slots, ctx)?;
     func.instruction(&Instruction::Else);
-    if let Pattern::Constructor(_, _) = &err_arm.pattern
+    if let ResolvedPattern::Ctor(_, _) = &err_arm.pattern
         && let Some(arm_slots) = err_arm.binding_slots.get()
         && let Some(&slot) = arm_slots.first()
         && slot != u16::MAX
@@ -2152,9 +2165,9 @@ pub(super) fn emit_result_match(
 /// the wasm stack.
 pub(super) fn emit_map_get_match_fused(
     func: &mut Function,
-    map: &Spanned<Expr>,
-    key: &Spanned<Expr>,
-    arms: &[MatchArm],
+    map: &Spanned<ResolvedExpr>,
+    key: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
     block_ty: wasm_encoder::BlockType,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -2170,19 +2183,16 @@ pub(super) fn emit_map_get_match_fused(
         )))?;
 
     // Locate the Some / None arms (wildcard counts as None catch-all).
-    let mut some_arm: Option<&MatchArm> = None;
-    let mut none_arm: Option<&MatchArm> = None;
+    let mut some_arm: Option<&ResolvedMatchArm> = None;
+    let mut none_arm: Option<&ResolvedMatchArm> = None;
     for arm in arms {
         match &arm.pattern {
-            Pattern::Constructor(name, _) => {
-                let bare = name.rsplit('.').next().unwrap_or(name);
-                if bare == "Some" {
-                    some_arm = Some(arm);
-                } else if bare == "None" {
-                    none_arm = Some(arm);
-                }
-            }
-            Pattern::Wildcard => {
+            ResolvedPattern::Ctor(ctor, _) => match ctor {
+                ResolvedCtor::Builtin(BuiltinCtor::OptionSome) => some_arm = Some(arm),
+                ResolvedCtor::Builtin(BuiltinCtor::OptionNone) => none_arm = Some(arm),
+                _ => {}
+            },
+            ResolvedPattern::Wildcard => {
                 if none_arm.is_none() {
                     none_arm = Some(arm);
                 } else if some_arm.is_none() {
@@ -2206,7 +2216,7 @@ pub(super) fn emit_map_get_match_fused(
     // binding slot (if any); the value is harmlessly dead in the
     // None branch (we always pop, regardless of which arm fires —
     // wasm requires a balanced stack across the branch boundary).
-    if let Pattern::Constructor(_, _) = &some_arm.pattern
+    if let ResolvedPattern::Ctor(_, _) = &some_arm.pattern
         && let Some(arm_slots) = some_arm.binding_slots.get()
         && let Some(&slot) = arm_slots.first()
         && slot != u16::MAX
@@ -2236,8 +2246,8 @@ pub(super) fn emit_map_get_match_fused(
 ///    `struct.get $option_T 1`; None arm emits its body directly.
 pub(super) fn emit_option_match(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    arms: &[MatchArm],
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
     block_ty: wasm_encoder::BlockType,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -2259,19 +2269,16 @@ pub(super) fn emit_option_match(
 
     // Locate Some / None arms. Wildcard arm acts as the None
     // catch-all — same convention the variant dispatcher uses.
-    let mut some_arm: Option<&MatchArm> = None;
-    let mut none_arm: Option<&MatchArm> = None;
+    let mut some_arm: Option<&ResolvedMatchArm> = None;
+    let mut none_arm: Option<&ResolvedMatchArm> = None;
     for arm in arms {
         match &arm.pattern {
-            Pattern::Constructor(name, _) => {
-                let bare = name.rsplit('.').next().unwrap_or(name);
-                if bare == "Some" {
-                    some_arm = Some(arm);
-                } else if bare == "None" {
-                    none_arm = Some(arm);
-                }
-            }
-            Pattern::Wildcard => {
+            ResolvedPattern::Ctor(ctor, _) => match ctor {
+                ResolvedCtor::Builtin(BuiltinCtor::OptionSome) => some_arm = Some(arm),
+                ResolvedCtor::Builtin(BuiltinCtor::OptionNone) => none_arm = Some(arm),
+                _ => {}
+            },
+            ResolvedPattern::Wildcard => {
                 if none_arm.is_none() {
                     none_arm = Some(arm);
                 } else if some_arm.is_none() {
@@ -2306,7 +2313,7 @@ pub(super) fn emit_option_match(
 
     // Some branch: extract value into the bound slot (if any), then
     // emit body.
-    if let Pattern::Constructor(_, _) = &some_arm.pattern
+    if let ResolvedPattern::Ctor(_, _) = &some_arm.pattern
         && let Some(arm_slots) = some_arm.binding_slots.get()
         && let Some(&slot) = arm_slots.first()
         && slot != u16::MAX
@@ -2344,8 +2351,8 @@ pub(super) fn emit_option_match(
 /// catch-all is the final else.
 pub(super) fn emit_string_match(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    arms: &[MatchArm],
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
     block_ty: wasm_encoder::BlockType,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -2384,10 +2391,10 @@ pub(super) fn emit_string_match(
     // Split arms: literal-string arms first (in source order), then
     // a single default (wildcard or non-literal pattern). The type
     // checker already proved exhaustivity.
-    let mut literal_arms: Vec<(&str, &MatchArm)> = Vec::new();
-    let mut default_arm: Option<&MatchArm> = None;
+    let mut literal_arms: Vec<(&str, &ResolvedMatchArm)> = Vec::new();
+    let mut default_arm: Option<&ResolvedMatchArm> = None;
     for arm in arms {
-        if let Pattern::Literal(Literal::Str(s)) = &arm.pattern {
+        if let ResolvedPattern::Literal(Literal::Str(s)) = &arm.pattern {
             literal_arms.push((s.as_str(), arm));
         } else if default_arm.is_none() {
             default_arm = Some(arm);
@@ -2479,8 +2486,8 @@ pub(super) fn emit_string_literal_bytes(
 
 pub(super) fn emit_variant_dispatch(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    arms: &[MatchArm],
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
     block_ty: wasm_encoder::BlockType,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -2498,7 +2505,7 @@ pub(super) fn emit_variant_dispatch(
 
 pub(super) fn emit_variant_arm_cascade(
     func: &mut Function,
-    arms: &[MatchArm],
+    arms: &[ResolvedMatchArm],
     block_ty: wasm_encoder::BlockType,
     subject_scratch: u32,
     slots: &SlotTable,
@@ -2523,8 +2530,9 @@ pub(super) fn emit_variant_arm_cascade(
     // emit its body. Else recurse on the rest.
     let arm = &arms[0];
     match &arm.pattern {
-        Pattern::Constructor(name, _) => {
-            let bare = name.rsplit('.').next().unwrap_or(name);
+        ResolvedPattern::Ctor(ctor, _) => {
+            let name = ctor_dotted_name(ctor, ctx);
+            let bare = name.rsplit('.').next().unwrap_or(&name);
             let parent_hint = name.rsplit_once('.').map(|(p, _)| p);
             // Prefer the parent-disambiguated lookup so two sumtypes
             // sharing a bare variant name (e.g. `Query.ProviderSummary`
@@ -2547,7 +2555,7 @@ pub(super) fn emit_variant_arm_cascade(
             emit_variant_arm_cascade(func, &arms[1..], block_ty, subject_scratch, slots, ctx)?;
             func.instruction(&Instruction::End);
         }
-        Pattern::Wildcard => {
+        ResolvedPattern::Wildcard => {
             // Wildcard before the end — just emit it (rest unreachable).
             return emit_arm_body(func, arm, subject_scratch, slots, ctx);
         }
@@ -2565,13 +2573,14 @@ pub(super) fn emit_variant_arm_cascade(
 /// pattern decides what to extract.
 pub(super) fn emit_arm_body(
     func: &mut Function,
-    arm: &MatchArm,
+    arm: &ResolvedMatchArm,
     subject_scratch: u32,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
-    if let Pattern::Constructor(name, bindings) = &arm.pattern {
-        let bare = name.rsplit('.').next().unwrap_or(name);
+    if let ResolvedPattern::Ctor(ctor, bindings) = &arm.pattern {
+        let name = ctor_dotted_name(ctor, ctx);
+        let bare = name.rsplit('.').next().unwrap_or(&name);
         let parent_hint = name.rsplit_once('.').map(|(p, _)| p);
         let info = parent_hint
             .and_then(|p| ctx.registry.variant_in(p, bare))
@@ -2633,19 +2642,20 @@ pub(super) fn emit_arm_body(
 /// lands in phase 3b.
 pub(super) fn emit_single_variant_match(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    arm: &MatchArm,
+    subject: &Spanned<ResolvedExpr>,
+    arm: &ResolvedMatchArm,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
     let (constructor, bindings) = match &arm.pattern {
-        Pattern::Constructor(c, b) => (c.as_str(), b.as_slice()),
+        ResolvedPattern::Ctor(c, b) => (ctor_dotted_name(c, ctx), b.as_slice()),
         _ => {
             return Err(WasmGcError::Validation(
                 "emit_single_variant_match called on non-Constructor pattern".into(),
             ));
         }
     };
+    let constructor = constructor.as_str();
     let body = arm.body.as_ref();
     let arm_slots = arm.binding_slots.get().ok_or(WasmGcError::Validation(
         "single-arm match reached emit without resolver-allocated binding_slots".into(),
@@ -2772,7 +2782,7 @@ pub(super) fn emit_single_variant_match(
 pub(super) fn emit_constructor_with_args(
     func: &mut Function,
     info: &super::super::types::VariantInfo,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -2795,81 +2805,6 @@ pub(super) fn emit_constructor_with_args(
     Ok(())
 }
 
-/// Lower `Constructor(name, Some(payload))` or nullary `Constructor(name, None)`
-/// to `struct.new $variant_type_idx`. Variants are positional (no field
-/// names), so payload values are pushed in source order before
-/// `struct.new`.
-pub(super) fn emit_constructor(
-    func: &mut Function,
-    outer: &Spanned<Expr>,
-    name: &str,
-    payload: Option<&Spanned<Expr>>,
-    slots: &SlotTable,
-    ctx: &EmitCtx<'_>,
-) -> Result<(), WasmGcError> {
-    // Built-in `Option` constructors don't go through `TypeRegistry`'s
-    // variant table (Option isn't a TypeDef). Route them to the
-    // dedicated emitter that picks the right monomorphised slot.
-    let bare = name.rsplit('.').next().unwrap_or(name);
-    if name == "Option.Some" || (bare == "Some" && name.starts_with("Option")) {
-        return emit_option_constructor(func, payload, None, slots, ctx);
-    }
-    if name == "Option.None" || (bare == "None" && name.starts_with("Option")) {
-        // Read T off the typed outer expr (Option<T> stamped by the
-        // type checker), with the Type::Invalid-recovery reader so
-        // post-error gradual-typing branches still resolve.
-        let stamped_canonical = aver_type_canonical(outer, ctx.return_type, ctx.registry);
-        let hint: String = if let Some(inner) = stamped_canonical
-            .strip_prefix("Option<")
-            .and_then(|s| s.strip_suffix('>'))
-        {
-            inner.to_string()
-        } else {
-            ctx.return_type.to_string()
-        };
-        return emit_option_constructor(func, None, Some(&hint), slots, ctx);
-    }
-    if name == "Result.Ok" || (bare == "Ok" && name.starts_with("Result")) {
-        return emit_result_constructor(func, "Ok", payload, slots, ctx);
-    }
-    if name == "Result.Err" || (bare == "Err" && name.starts_with("Result")) {
-        return emit_result_constructor(func, "Err", payload, slots, ctx);
-    }
-    // Constructor names can be dotted (`Foo.Bar`) or bare (`Bar`).
-    // Prefer the parent-disambiguated lookup when the dotted form is
-    // available so two sumtypes sharing a bare variant name don't
-    // collide.
-    let bare = name.rsplit('.').next().unwrap_or(name);
-    let parent_hint = name.rsplit_once('.').map(|(p, _)| p);
-    let info = parent_hint
-        .and_then(|p| ctx.registry.variant_in(p, bare))
-        .or_else(|| ctx.registry.variant(bare))
-        .ok_or(WasmGcError::Validation(format!(
-            "unknown variant constructor `{name}`"
-        )))?;
-    // Aver's AST treats single-payload constructors as `Some(expr)` —
-    // multi-field variants come through as `Some(Tuple(...))`. Phase
-    // 3a only handles the single-payload case directly; tuple-payload
-    // variants need phase 3b (Tuple lowering) to come online.
-    let payload_count = info.fields.len();
-    if payload_count == 0 {
-        // Nullary constructor — empty struct.
-        func.instruction(&Instruction::StructNew(info.type_idx));
-        return Ok(());
-    }
-    if payload_count > 1 {
-        return Err(WasmGcError::Unimplemented(
-            "phase 3b — multi-field variant constructors (need Tuple lowering)",
-        ));
-    }
-    let payload = payload.ok_or(WasmGcError::Validation(format!(
-        "variant `{name}` expects 1 payload but got 0"
-    )))?;
-    emit_expr(func, payload, slots, ctx)?;
-    func.instruction(&Instruction::StructNew(info.type_idx));
-    Ok(())
-}
-
 /// Lower `match subject { arm0; arm1; ...; default }` into a cascade
 /// of `if`/`else` blocks. Phase-4 shape:
 /// - subject must be `Int` or `Bool`,
@@ -2883,8 +2818,8 @@ pub(super) fn emit_constructor(
 /// Bool subjects (single `if` over the boolean).
 pub(super) fn emit_match(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    arms: &[MatchArm],
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
@@ -2913,13 +2848,13 @@ pub(super) fn emit_match(
         }
         // Find which arm is `true` and which is `false`. Wildcard
         // counts as the "other" branch.
-        let mut true_body: Option<&Spanned<Expr>> = None;
-        let mut false_body: Option<&Spanned<Expr>> = None;
+        let mut true_body: Option<&Spanned<ResolvedExpr>> = None;
+        let mut false_body: Option<&Spanned<ResolvedExpr>> = None;
         for arm in arms {
             match &arm.pattern {
-                Pattern::Literal(Literal::Bool(true)) => true_body = Some(&arm.body),
-                Pattern::Literal(Literal::Bool(false)) => false_body = Some(&arm.body),
-                Pattern::Wildcard => {
+                ResolvedPattern::Literal(Literal::Bool(true)) => true_body = Some(&arm.body),
+                ResolvedPattern::Literal(Literal::Bool(false)) => false_body = Some(&arm.body),
+                ResolvedPattern::Wildcard => {
                     if true_body.is_none() {
                         true_body = Some(&arm.body);
                     } else {
@@ -2951,15 +2886,17 @@ pub(super) fn emit_match(
     // List match — `[] -> ...; [head, ..tail] -> ...`. Subject is
     // `(ref null $list_T)`; empty = ref.is_null, cons = struct.get
     // head/tail.
-    if arms
-        .iter()
-        .any(|a| matches!(&a.pattern, Pattern::EmptyList | Pattern::Cons(_, _)))
-    {
+    if arms.iter().any(|a| {
+        matches!(
+            &a.pattern,
+            ResolvedPattern::EmptyList | ResolvedPattern::Cons(_, _)
+        )
+    }) {
         return emit_list_match(func, subject, arms, block_ty, slots, ctx);
     }
 
     // Built-in `Result<T, E>` match — tag-based, two payload fields.
-    if arms.iter().any(arm_is_result_pattern) {
+    if arms.iter().any(arm_is_result_pattern_resolved) {
         return emit_result_match(func, subject, arms, block_ty, slots, ctx);
     }
 
@@ -2967,16 +2904,13 @@ pub(super) fn emit_match(
     // first field. Detected up-front because Option isn't in the
     // user-variant table and the subject is always a (ref null
     // $option_T).
-    if arms.iter().any(arm_is_option_pattern) {
+    if arms.iter().any(arm_is_option_pattern_resolved) {
         // Fused shape: `match Map.get(m, k) { Option.Some(v) -> ...;
         // Option.None -> ... }` lowers via the per-(K,V) get_pair
         // helper — multi-result `(found, value)` return — without
         // ever allocating an Option<V>.
-        if let Expr::FnCall(callee, fn_args) = &subject.node
-            && let Expr::Attr(parent, member) = &callee.node
-            && let Expr::Ident(p) = &parent.node
-            && p == "Map"
-            && member == "get"
+        if let ResolvedExpr::Call(ResolvedCallee::Builtin(name), fn_args) = &subject.node
+            && name == "Map.get"
             && fn_args.len() == 2
         {
             return emit_map_get_match_fused(
@@ -2996,7 +2930,7 @@ pub(super) fn emit_match(
     // `(ref null $tuple_A_B_..._N)`; struct.get its fields into
     // bindings. Variadic arity (any N >= 2).
     if arms.len() == 1
-        && let Pattern::Tuple(items) = &arms[0].pattern
+        && let ResolvedPattern::Tuple(items) = &arms[0].pattern
         && items.len() >= 2
     {
         return emit_tuple_match(func, subject, &arms[0], slots, ctx);
@@ -3007,12 +2941,12 @@ pub(super) fn emit_match(
     // tests AND'd into one verdict; bindings extract from the
     // per-element variant struct on the matching branch.
     if arms.iter().any(|a| {
-        matches!(&a.pattern, Pattern::Tuple(items)
-            if items.iter().any(|i| matches!(i, Pattern::Constructor(_, _))))
+        matches!(&a.pattern, ResolvedPattern::Tuple(items)
+            if items.iter().any(|i| matches!(i, ResolvedPattern::Ctor(_, _))))
     }) && arms.last().is_some_and(|a| {
         matches!(
             &a.pattern,
-            Pattern::Wildcard | Pattern::Ident(_) | Pattern::Tuple(_)
+            ResolvedPattern::Wildcard | ResolvedPattern::Ident(_) | ResolvedPattern::Tuple(_)
         )
     }) {
         return emit_tuple_constructor_match(func, subject, arms, block_ty, slots, ctx);
@@ -3022,7 +2956,7 @@ pub(super) fn emit_match(
     // Common in newtype-style sum types; cast + extract directly without
     // a dispatch test.
     if arms.len() == 1
-        && let Pattern::Constructor(_, _) = &arms[0].pattern
+        && let ResolvedPattern::Ctor(_, _) = &arms[0].pattern
     {
         return emit_single_variant_match(func, subject, &arms[0], slots, ctx);
     }
@@ -3031,7 +2965,7 @@ pub(super) fn emit_match(
     // cascade against the variant struct types.
     let has_constructor_arm = arms
         .iter()
-        .any(|a| matches!(a.pattern, Pattern::Constructor(_, _)));
+        .any(|a| matches!(a.pattern, ResolvedPattern::Ctor(_, _)));
     if has_constructor_arm {
         return emit_variant_dispatch(func, subject, arms, block_ty, slots, ctx);
     }
@@ -3064,11 +2998,11 @@ pub(super) fn emit_match(
     //
     // This keeps phase 4 contained — phase 5 cleanup can switch to a
     // proper temp-local once we add a per-fn local-allocator.
-    let mut wildcard_body: Option<&Spanned<Expr>> = None;
-    let mut typed_arms: Vec<(i64, &Spanned<Expr>)> = Vec::new();
+    let mut wildcard_body: Option<&Spanned<ResolvedExpr>> = None;
+    let mut typed_arms: Vec<(i64, &Spanned<ResolvedExpr>)> = Vec::new();
     for arm in arms {
         match &arm.pattern {
-            Pattern::Literal(Literal::Int(n)) => typed_arms.push((*n, &arm.body)),
+            ResolvedPattern::Literal(Literal::Int(n)) => typed_arms.push((*n, &arm.body)),
             // First wildcard wins. Aver match semantics is
             // first-applicable-arm; a plain `wildcard_body =
             // Some(...)` here let *later* wildcards overwrite the
@@ -3080,7 +3014,7 @@ pub(super) fn emit_match(
             // seed: VM returned the terminal arm's value, wasm-gc
             // applied the trailing `(-countDown((n-1)))` arm and
             // produced the negated value.
-            Pattern::Wildcard => {
+            ResolvedPattern::Wildcard => {
                 wildcard_body.get_or_insert(&arm.body);
             }
             _ => {
@@ -3100,9 +3034,9 @@ pub(super) fn emit_match(
 
 pub(super) fn emit_int_match_cascade(
     func: &mut Function,
-    subject: &Spanned<Expr>,
-    typed_arms: &[(i64, &Spanned<Expr>)],
-    wildcard: &Spanned<Expr>,
+    subject: &Spanned<ResolvedExpr>,
+    typed_arms: &[(i64, &Spanned<ResolvedExpr>)],
+    wildcard: &Spanned<ResolvedExpr>,
     block_ty: wasm_encoder::BlockType,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
@@ -3140,7 +3074,7 @@ pub(super) fn emit_int_match_cascade(
 pub(super) fn emit_tail_call(
     func: &mut Function,
     target: &str,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {

--- a/src/codegen/wasm_gc/body/infer.rs
+++ b/src/codegen/wasm_gc/body/infer.rs
@@ -15,7 +15,7 @@
 
 use wasm_encoder::ValType;
 
-use crate::ast::{MatchArm, Pattern, Spanned};
+use crate::ast::Spanned;
 use crate::types::Type;
 
 use super::super::WasmGcError;
@@ -25,38 +25,13 @@ use super::super::types::{TypeRegistry, aver_to_wasm};
 // Match-arm shape predicates (schema-level — no type inference involved)
 // ---------------------------------------------------------------------------
 
-/// True when a match arm matches against `Option.Some(_)` or
+/// True when a match arm matches against `Option.Some(_)` /
 /// `Option.None`. Used to opt the surrounding match into the
 /// dedicated tag-based dispatch path (instead of the generic
-/// `ref.test` cascade for user variants).
-pub(super) fn arm_is_option_pattern(arm: &MatchArm) -> bool {
-    if let Pattern::Constructor(name, _) = &arm.pattern {
-        let bare = name.rsplit('.').next().unwrap_or(name);
-        return name == "Option.Some"
-            || name == "Option.None"
-            || ((bare == "Some" || bare == "None") && name.starts_with("Option"));
-    }
-    false
-}
-
-/// True when a match arm targets `Result.Ok(_)` or `Result.Err(_)`.
-pub(super) fn arm_is_result_pattern(arm: &MatchArm) -> bool {
-    if let Pattern::Constructor(name, _) = &arm.pattern {
-        let bare = name.rsplit('.').next().unwrap_or(name);
-        return name == "Result.Ok"
-            || name == "Result.Err"
-            || ((bare == "Ok" || bare == "Err") && name.starts_with("Result"));
-    }
-    false
-}
-
-/// Resolved-form mirror of [`arm_is_option_pattern`] for emitters that
-/// have already migrated to walk [`crate::ir::hir::ResolvedMatchArm`].
-/// The pattern shape comparison happens against
-/// [`crate::ir::hir::ResolvedCtor::Builtin`] variants instead of the
-/// source-shape dotted name. Allowed dead until the wasm-gc match
-/// emitters migrate in the follow-up PRs of #147 phase E.
-#[allow(dead_code)]
+/// `ref.test` cascade for user variants). Reads identity off
+/// [`crate::ir::hir::ResolvedCtor::Builtin`] — post Phase E PR 9.1
+/// every reachable arm carries the typed ctor, so the pre-resolve
+/// source-shape variant is gone.
 pub(super) fn arm_is_option_pattern_resolved(arm: &crate::ir::hir::ResolvedMatchArm) -> bool {
     use crate::ir::hir::{BuiltinCtor, ResolvedCtor, ResolvedPattern};
     matches!(
@@ -68,10 +43,9 @@ pub(super) fn arm_is_option_pattern_resolved(arm: &crate::ir::hir::ResolvedMatch
     )
 }
 
-/// Resolved-form mirror of [`arm_is_result_pattern`]. Allowed dead
-/// until the wasm-gc match emitters migrate in the follow-up PRs of
-/// #147 phase E.
-#[allow(dead_code)]
+/// True when a match arm matches against `Result.Ok(_)` /
+/// `Result.Err(_)`. Same Phase E shape as
+/// [`arm_is_option_pattern_resolved`].
 pub(super) fn arm_is_result_pattern_resolved(arm: &crate::ir::hir::ResolvedMatchArm) -> bool {
     use crate::ir::hir::{BuiltinCtor, ResolvedCtor, ResolvedPattern};
     matches!(

--- a/src/codegen/wasm_gc/body/slots.rs
+++ b/src/codegen/wasm_gc/body/slots.rs
@@ -10,12 +10,19 @@ use std::collections::{HashMap, HashSet};
 
 use wasm_encoder::ValType;
 
-use crate::ast::{Expr, FnBody, FnDef, Literal, Pattern, Spanned, Stmt};
+use crate::ast::{Literal, Spanned};
+use crate::ir::hir::{
+    ResolvedCallee, ResolvedExpr, ResolvedFnBody, ResolvedFnDef, ResolvedPattern, ResolvedStmt,
+    ResolvedStrPart,
+};
+use crate::types::Type;
 
 use super::super::WasmGcError;
 use super::super::types::{TypeRegistry, aver_to_wasm};
 use super::FnMap;
-use super::infer::{arm_is_option_pattern, arm_is_result_pattern, aver_type_str_of};
+use super::infer::{
+    arm_is_option_pattern_resolved, arm_is_result_pattern_resolved, aver_type_str_of,
+};
 
 /// Per-fn slot table — one entry per local (param or binding) in
 /// resolver-allocation order. Slot N maps to `wasm local N`.
@@ -99,7 +106,7 @@ impl SlotTable {
     /// AST (`Spanned::ty()`), builds a dense `Vec<ValType>` indexed by
     /// slot number.
     pub(super) fn build_for_fn(
-        fd: &FnDef,
+        fd: &ResolvedFnDef,
         registry: &TypeRegistry,
         _fn_map: &FnMap,
     ) -> Result<Self, WasmGcError> {
@@ -137,7 +144,7 @@ impl SlotTable {
             // body that touches anything beyond the parameters will
             // surface the gap as a wasm validation error.
             for (_, ty) in &fd.params {
-                let v = aver_to_wasm(ty, Some(registry))
+                let v = aver_to_wasm(&ty.display(), Some(registry))
                     .unwrap_or(None)
                     .unwrap_or(ValType::I32);
                 by_slot.push(v);
@@ -293,314 +300,198 @@ impl SlotTable {
 /// True if the body reaches an `Args.get()` call (no args). The inline
 /// expansion needs four scratch slots; they're only worth reserving
 /// when actually used.
-pub(super) fn fn_needs_args_get_scratch(fd: &FnDef) -> bool {
-    let FnBody::Block(stmts) = fd.body.as_ref();
+pub(super) fn fn_needs_args_get_scratch(fd: &ResolvedFnDef) -> bool {
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     stmts.iter().any(stmt_reaches_args_get_no_args)
 }
 
-fn stmt_reaches_args_get_no_args(stmt: &Stmt) -> bool {
+fn stmt_reaches_args_get_no_args(stmt: &ResolvedStmt) -> bool {
     match stmt {
-        Stmt::Binding(_, _, e) | Stmt::Expr(e) => expr_reaches_args_get_no_args(&e.node),
+        ResolvedStmt::Binding { value, .. } | ResolvedStmt::Expr(value) => {
+            expr_reaches_args_get_no_args(&value.node)
+        }
     }
 }
 
-fn expr_reaches_args_get_no_args(expr: &Expr) -> bool {
+/// Shared walker over a [`ResolvedExpr`] that returns `true` when any
+/// reachable [`ResolvedExpr::Call`] matches the predicate. Builtin
+/// callees are recognised by their `ResolvedCallee::Builtin(name)`
+/// canonical string; user fns / intrinsics never match the
+/// short-circuit predicate (they don't expose Args/Console/Env/Random
+/// builtins). Replaces the four near-identical walkers from the
+/// pre-Phase-E shape.
+fn expr_reaches_builtin_call<F>(expr: &ResolvedExpr, matches: &F) -> bool
+where
+    F: Fn(&str, &[Spanned<ResolvedExpr>]) -> bool,
+{
     match expr {
-        Expr::FnCall(callee, args) => {
-            if args.is_empty()
-                && let Expr::Attr(parent, member) = &callee.node
-                && let Expr::Ident(p) = &parent.node
-                && p == "Args"
-                && member == "get"
+        ResolvedExpr::Call(callee, args) => {
+            if let ResolvedCallee::Builtin(name) = callee
+                && matches(name.as_str(), args)
             {
                 return true;
             }
-            expr_reaches_args_get_no_args(&callee.node)
-                || args.iter().any(|a| expr_reaches_args_get_no_args(&a.node))
+            args.iter()
+                .any(|a| expr_reaches_builtin_call(&a.node, matches))
         }
-        Expr::BinOp(_, l, r) => {
-            expr_reaches_args_get_no_args(&l.node) || expr_reaches_args_get_no_args(&r.node)
+        ResolvedExpr::BinOp(_, l, r) => {
+            expr_reaches_builtin_call(&l.node, matches)
+                || expr_reaches_builtin_call(&r.node, matches)
         }
-        Expr::Neg(inner) => expr_reaches_args_get_no_args(&inner.node),
-        Expr::Match { subject, arms } => {
-            expr_reaches_args_get_no_args(&subject.node)
+        ResolvedExpr::Neg(inner) => expr_reaches_builtin_call(&inner.node, matches),
+        ResolvedExpr::Match { subject, arms } => {
+            expr_reaches_builtin_call(&subject.node, matches)
                 || arms
                     .iter()
-                    .any(|a| expr_reaches_args_get_no_args(&a.body.node))
+                    .any(|a| expr_reaches_builtin_call(&a.body.node, matches))
         }
-        Expr::TailCall(boxed) => boxed
-            .args
+        ResolvedExpr::TailCall { args, .. } => args
             .iter()
-            .any(|a| expr_reaches_args_get_no_args(&a.node)),
-        Expr::Attr(obj, _) => expr_reaches_args_get_no_args(&obj.node),
-        Expr::ErrorProp(inner) => expr_reaches_args_get_no_args(&inner.node),
-        Expr::Constructor(_, payload) => payload
-            .as_deref()
-            .is_some_and(|p| expr_reaches_args_get_no_args(&p.node)),
-        Expr::RecordCreate { fields, .. } => fields
+            .any(|a| expr_reaches_builtin_call(&a.node, matches)),
+        ResolvedExpr::Attr(obj, _) => expr_reaches_builtin_call(&obj.node, matches),
+        ResolvedExpr::ErrorProp(inner) => expr_reaches_builtin_call(&inner.node, matches),
+        ResolvedExpr::Ctor(_, args) => args
             .iter()
-            .any(|(_, e)| expr_reaches_args_get_no_args(&e.node)),
-        Expr::RecordUpdate { base, updates, .. } => {
-            expr_reaches_args_get_no_args(&base.node)
+            .any(|a| expr_reaches_builtin_call(&a.node, matches)),
+        ResolvedExpr::RecordCreate { fields, .. } => fields
+            .iter()
+            .any(|(_, e)| expr_reaches_builtin_call(&e.node, matches)),
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
+            expr_reaches_builtin_call(&base.node, matches)
                 || updates
                     .iter()
-                    .any(|(_, e)| expr_reaches_args_get_no_args(&e.node))
+                    .any(|(_, e)| expr_reaches_builtin_call(&e.node, matches))
         }
-        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
-            items.iter().any(|e| expr_reaches_args_get_no_args(&e.node))
-        }
-        Expr::MapLiteral(entries) => entries.iter().any(|(k, v)| {
-            expr_reaches_args_get_no_args(&k.node) || expr_reaches_args_get_no_args(&v.node)
+        ResolvedExpr::List(items)
+        | ResolvedExpr::Tuple(items)
+        | ResolvedExpr::IndependentProduct(items, _) => items
+            .iter()
+            .any(|e| expr_reaches_builtin_call(&e.node, matches)),
+        ResolvedExpr::MapLiteral(entries) => entries.iter().any(|(k, v)| {
+            expr_reaches_builtin_call(&k.node, matches)
+                || expr_reaches_builtin_call(&v.node, matches)
         }),
-        Expr::InterpolatedStr(parts) => parts.iter().any(|p| {
-            if let crate::ast::StrPart::Parsed(inner) = p {
-                expr_reaches_args_get_no_args(&inner.node)
+        ResolvedExpr::InterpolatedStr(parts) => parts.iter().any(|p| {
+            if let ResolvedStrPart::Parsed(inner) = p {
+                expr_reaches_builtin_call(&inner.node, matches)
             } else {
                 false
             }
         }),
         _ => false,
     }
+}
+
+fn expr_reaches_args_get_no_args(expr: &ResolvedExpr) -> bool {
+    expr_reaches_builtin_call(expr, &|name, args| name == "Args.get" && args.is_empty())
 }
 
 /// True if the body reaches at least one `Console.print` /
 /// `Console.error` / `Console.warn` call. Used to gate the i32 scratch
 /// slot that the wasip2 call-site lowering uses to cache the
 /// `__rt_string_to_lm` byte-length return for the retptr computation.
-pub(super) fn fn_needs_console_print_wasip2_scratch(fd: &FnDef) -> bool {
-    let FnBody::Block(stmts) = fd.body.as_ref();
+pub(super) fn fn_needs_console_print_wasip2_scratch(fd: &ResolvedFnDef) -> bool {
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     stmts.iter().any(stmt_reaches_console_print)
 }
 
-fn stmt_reaches_console_print(stmt: &Stmt) -> bool {
+fn stmt_reaches_console_print(stmt: &ResolvedStmt) -> bool {
     match stmt {
-        Stmt::Binding(_, _, e) | Stmt::Expr(e) => expr_reaches_console_print(&e.node),
+        ResolvedStmt::Binding { value, .. } | ResolvedStmt::Expr(value) => {
+            expr_reaches_console_print(&value.node)
+        }
     }
 }
 
-fn expr_reaches_console_print(expr: &Expr) -> bool {
-    match expr {
-        Expr::FnCall(callee, args) => {
-            if let Expr::Attr(parent, member) = &callee.node
-                && let Expr::Ident(p) = &parent.node
-                && p == "Console"
-                && matches!(member.as_str(), "print" | "error" | "warn")
-            {
-                return true;
-            }
-            expr_reaches_console_print(&callee.node)
-                || args.iter().any(|a| expr_reaches_console_print(&a.node))
-        }
-        Expr::BinOp(_, l, r) => {
-            expr_reaches_console_print(&l.node) || expr_reaches_console_print(&r.node)
-        }
-        Expr::Neg(inner) => expr_reaches_console_print(&inner.node),
-        Expr::Match { subject, arms } => {
-            expr_reaches_console_print(&subject.node)
-                || arms
-                    .iter()
-                    .any(|a| expr_reaches_console_print(&a.body.node))
-        }
-        Expr::TailCall(boxed) => boxed
-            .args
-            .iter()
-            .any(|a| expr_reaches_console_print(&a.node)),
-        Expr::Attr(obj, _) => expr_reaches_console_print(&obj.node),
-        Expr::ErrorProp(inner) => expr_reaches_console_print(&inner.node),
-        Expr::Constructor(_, payload) => payload
-            .as_deref()
-            .is_some_and(|p| expr_reaches_console_print(&p.node)),
-        Expr::RecordCreate { fields, .. } => fields
-            .iter()
-            .any(|(_, e)| expr_reaches_console_print(&e.node)),
-        Expr::RecordUpdate { base, updates, .. } => {
-            expr_reaches_console_print(&base.node)
-                || updates
-                    .iter()
-                    .any(|(_, e)| expr_reaches_console_print(&e.node))
-        }
-        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
-            items.iter().any(|e| expr_reaches_console_print(&e.node))
-        }
-        Expr::MapLiteral(entries) => entries.iter().any(|(k, v)| {
-            expr_reaches_console_print(&k.node) || expr_reaches_console_print(&v.node)
-        }),
-        Expr::InterpolatedStr(parts) => parts.iter().any(|p| {
-            if let crate::ast::StrPart::Parsed(inner) = p {
-                expr_reaches_console_print(&inner.node)
-            } else {
-                false
-            }
-        }),
-        _ => false,
-    }
+fn expr_reaches_console_print(expr: &ResolvedExpr) -> bool {
+    expr_reaches_builtin_call(expr, &|name, _| {
+        matches!(name, "Console.print" | "Console.error" | "Console.warn")
+    })
 }
 
 /// True if the body reaches at least one `Env.get(name)` call.
 /// Used to gate the wasip2 `[retptr, key_len]` scratch pair.
-pub(super) fn fn_needs_env_get_wasip2_scratch(fd: &FnDef) -> bool {
-    let FnBody::Block(stmts) = fd.body.as_ref();
+pub(super) fn fn_needs_env_get_wasip2_scratch(fd: &ResolvedFnDef) -> bool {
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     stmts.iter().any(stmt_reaches_env_get)
 }
 
-fn stmt_reaches_env_get(stmt: &Stmt) -> bool {
+fn stmt_reaches_env_get(stmt: &ResolvedStmt) -> bool {
     match stmt {
-        Stmt::Binding(_, _, e) | Stmt::Expr(e) => expr_reaches_env_get(&e.node),
+        ResolvedStmt::Binding { value, .. } | ResolvedStmt::Expr(value) => {
+            expr_reaches_env_get(&value.node)
+        }
     }
 }
 
-fn expr_reaches_env_get(expr: &Expr) -> bool {
-    match expr {
-        Expr::FnCall(callee, args) => {
-            if let Expr::Attr(parent, member) = &callee.node
-                && let Expr::Ident(p) = &parent.node
-                && p == "Env"
-                && member == "get"
-            {
-                return true;
-            }
-            expr_reaches_env_get(&callee.node) || args.iter().any(|a| expr_reaches_env_get(&a.node))
-        }
-        Expr::BinOp(_, l, r) => expr_reaches_env_get(&l.node) || expr_reaches_env_get(&r.node),
-        Expr::Neg(inner) => expr_reaches_env_get(&inner.node),
-        Expr::Match { subject, arms } => {
-            expr_reaches_env_get(&subject.node)
-                || arms.iter().any(|a| expr_reaches_env_get(&a.body.node))
-        }
-        Expr::TailCall(boxed) => boxed.args.iter().any(|a| expr_reaches_env_get(&a.node)),
-        Expr::Attr(obj, _) => expr_reaches_env_get(&obj.node),
-        Expr::ErrorProp(inner) => expr_reaches_env_get(&inner.node),
-        Expr::Constructor(_, payload) => payload
-            .as_deref()
-            .is_some_and(|p| expr_reaches_env_get(&p.node)),
-        Expr::RecordCreate { fields, .. } => {
-            fields.iter().any(|(_, e)| expr_reaches_env_get(&e.node))
-        }
-        Expr::RecordUpdate { base, updates, .. } => {
-            expr_reaches_env_get(&base.node)
-                || updates.iter().any(|(_, e)| expr_reaches_env_get(&e.node))
-        }
-        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
-            items.iter().any(|e| expr_reaches_env_get(&e.node))
-        }
-        Expr::MapLiteral(entries) => entries
-            .iter()
-            .any(|(k, v)| expr_reaches_env_get(&k.node) || expr_reaches_env_get(&v.node)),
-        Expr::InterpolatedStr(parts) => parts.iter().any(|p| {
-            if let crate::ast::StrPart::Parsed(inner) = p {
-                expr_reaches_env_get(&inner.node)
-            } else {
-                false
-            }
-        }),
-        _ => false,
-    }
+fn expr_reaches_env_get(expr: &ResolvedExpr) -> bool {
+    expr_reaches_builtin_call(expr, &|name, _| name == "Env.get")
 }
 
 /// True if the body reaches at least one `Random.int(min, max)` call.
 /// Gates the wasip2 i64 scratch slot that stashes `min` once so the
 /// call-site lowering doesn't double-evaluate it.
-pub(super) fn fn_needs_random_int_wasip2_scratch(fd: &FnDef) -> bool {
-    let FnBody::Block(stmts) = fd.body.as_ref();
+pub(super) fn fn_needs_random_int_wasip2_scratch(fd: &ResolvedFnDef) -> bool {
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     stmts.iter().any(stmt_reaches_random_int)
 }
 
-fn stmt_reaches_random_int(stmt: &Stmt) -> bool {
+fn stmt_reaches_random_int(stmt: &ResolvedStmt) -> bool {
     match stmt {
-        Stmt::Binding(_, _, e) | Stmt::Expr(e) => expr_reaches_random_int(&e.node),
+        ResolvedStmt::Binding { value, .. } | ResolvedStmt::Expr(value) => {
+            expr_reaches_random_int(&value.node)
+        }
     }
 }
 
-fn expr_reaches_random_int(expr: &Expr) -> bool {
-    match expr {
-        Expr::FnCall(callee, args) => {
-            if let Expr::Attr(parent, member) = &callee.node
-                && let Expr::Ident(p) = &parent.node
-                && p == "Random"
-                && member == "int"
-            {
-                return true;
-            }
-            expr_reaches_random_int(&callee.node)
-                || args.iter().any(|a| expr_reaches_random_int(&a.node))
-        }
-        Expr::BinOp(_, l, r) => {
-            expr_reaches_random_int(&l.node) || expr_reaches_random_int(&r.node)
-        }
-        Expr::Neg(inner) => expr_reaches_random_int(&inner.node),
-        Expr::Match { subject, arms } => {
-            expr_reaches_random_int(&subject.node)
-                || arms.iter().any(|a| expr_reaches_random_int(&a.body.node))
-        }
-        Expr::TailCall(boxed) => boxed.args.iter().any(|a| expr_reaches_random_int(&a.node)),
-        Expr::Attr(obj, _) => expr_reaches_random_int(&obj.node),
-        Expr::ErrorProp(inner) => expr_reaches_random_int(&inner.node),
-        Expr::Constructor(_, payload) => payload
-            .as_deref()
-            .is_some_and(|p| expr_reaches_random_int(&p.node)),
-        Expr::RecordCreate { fields, .. } => {
-            fields.iter().any(|(_, e)| expr_reaches_random_int(&e.node))
-        }
-        Expr::RecordUpdate { base, updates, .. } => {
-            expr_reaches_random_int(&base.node)
-                || updates
-                    .iter()
-                    .any(|(_, e)| expr_reaches_random_int(&e.node))
-        }
-        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
-            items.iter().any(|e| expr_reaches_random_int(&e.node))
-        }
-        Expr::MapLiteral(entries) => entries
-            .iter()
-            .any(|(k, v)| expr_reaches_random_int(&k.node) || expr_reaches_random_int(&v.node)),
-        Expr::InterpolatedStr(parts) => parts.iter().any(|p| {
-            if let crate::ast::StrPart::Parsed(inner) = p {
-                expr_reaches_random_int(&inner.node)
-            } else {
-                false
-            }
-        }),
-        _ => false,
-    }
+fn expr_reaches_random_int(expr: &ResolvedExpr) -> bool {
+    expr_reaches_builtin_call(expr, &|name, _| name == "Random.int")
 }
 
 /// True if the body has at least one multi-arm `match` whose arms are
 /// `Pattern::Constructor` against a non-newtype variant. Single-arm
 /// matches and newtype matches don't need a scratch (the cast is
 /// elided), so we only allocate when really necessary.
-pub(super) fn fn_needs_subject_scratch(fd: &FnDef, registry: &TypeRegistry) -> bool {
-    let FnBody::Block(stmts) = fd.body.as_ref();
+pub(super) fn fn_needs_subject_scratch(fd: &ResolvedFnDef, registry: &TypeRegistry) -> bool {
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     stmts.iter().any(|s| stmt_needs_scratch(s, registry))
 }
 
-pub(super) fn stmt_needs_scratch(stmt: &Stmt, registry: &TypeRegistry) -> bool {
+pub(super) fn stmt_needs_scratch(stmt: &ResolvedStmt, registry: &TypeRegistry) -> bool {
     match stmt {
-        Stmt::Binding(_, _, e) | Stmt::Expr(e) => expr_needs_scratch(&e.node, registry),
+        ResolvedStmt::Binding { value, .. } | ResolvedStmt::Expr(value) => {
+            expr_needs_scratch(&value.node, registry)
+        }
     }
 }
 
 #[allow(clippy::only_used_in_recursion)]
-pub(super) fn expr_needs_scratch(expr: &Expr, registry: &TypeRegistry) -> bool {
+pub(super) fn expr_needs_scratch(expr: &ResolvedExpr, registry: &TypeRegistry) -> bool {
     match expr {
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::Match { subject, arms } => {
             if expr_needs_scratch(&subject.node, registry) {
                 return true;
             }
             // Built-in Option dispatch needs a scratch (subject ref is
             // read multiple times: tag check, value extraction).
-            if arms.iter().any(arm_is_option_pattern) {
+            if arms.iter().any(arm_is_option_pattern_resolved) {
                 return true;
             }
-            if arms.iter().any(arm_is_result_pattern) {
+            if arms.iter().any(arm_is_result_pattern_resolved) {
+                return true;
+            }
+            if arms.iter().any(|a| {
+                matches!(
+                    &a.pattern,
+                    ResolvedPattern::EmptyList | ResolvedPattern::Cons(_, _)
+                )
+            }) {
                 return true;
             }
             if arms
                 .iter()
-                .any(|a| matches!(&a.pattern, Pattern::EmptyList | Pattern::Cons(_, _)))
+                .any(|a| matches!(&a.pattern, ResolvedPattern::Tuple(_)))
             {
-                return true;
-            }
-            if arms.iter().any(|a| matches!(&a.pattern, Pattern::Tuple(_))) {
                 return true;
             }
             // String-subject match (`match s { "literal" -> ... }`)
@@ -608,7 +499,7 @@ pub(super) fn expr_needs_scratch(expr: &Expr, registry: &TypeRegistry) -> bool {
             // each literal — needs a scratch slot.
             if arms
                 .iter()
-                .any(|a| matches!(&a.pattern, Pattern::Literal(Literal::Str(_))))
+                .any(|a| matches!(&a.pattern, ResolvedPattern::Literal(Literal::Str(_))))
             {
                 return true;
             }
@@ -625,64 +516,48 @@ pub(super) fn expr_needs_scratch(expr: &Expr, registry: &TypeRegistry) -> bool {
             // "no scratch reserved".
             if arms
                 .iter()
-                .any(|a| matches!(a.pattern, Pattern::Constructor(_, _)))
+                .any(|a| matches!(&a.pattern, ResolvedPattern::Ctor(_, _)))
             {
                 return true;
             }
             arms.iter()
                 .any(|a| expr_needs_scratch(&a.body.node, registry))
         }
-        Expr::BinOp(_, l, r) => {
+        ResolvedExpr::BinOp(_, l, r) => {
             expr_needs_scratch(&l.node, registry) || expr_needs_scratch(&r.node, registry)
         }
-        Expr::Neg(inner) => expr_needs_scratch(&inner.node, registry),
-        Expr::FnCall(callee, args) => {
-            // `Option.withDefault(opt, default)` falls back to the
-            // boxed path when the inner shape isn't a fused
-            // Vector/Map. The boxed emitter stashes the Option in the
-            // scratch slot for tag inspection. Conservatively reserve
-            // scratch for any Option.withDefault call — the cost of
-            // an unused scratch local is one wasm value, the cost of
-            // missing it is a validation crash.
-            if let Expr::Attr(parent, member) = &callee.node
-                && let Expr::Ident(p) = &parent.node
-                && ((p == "Option" || p == "Result") && member == "withDefault")
+        ResolvedExpr::Neg(inner) => expr_needs_scratch(&inner.node, registry),
+        ResolvedExpr::Call(callee, args) => {
+            // `Option.withDefault(opt, default)` / `Result.withDefault`
+            // / `Option.toResult` — conservatively reserve scratch; the
+            // boxed emitters stash the Option/Result for tag inspection.
+            if let ResolvedCallee::Builtin(name) = callee
+                && matches!(
+                    name.as_str(),
+                    "Option.withDefault" | "Result.withDefault" | "Option.toResult"
+                )
             {
                 return true;
             }
-            // `Option.toResult(opt, err)` inspects the Option's tag
-            // and re-uses the value field on the Some arm — same
-            // scratch-slot story as withDefault.
-            if let Expr::Attr(parent, member) = &callee.node
-                && let Expr::Ident(p) = &parent.node
-                && p == "Option"
-                && member == "toResult"
-            {
-                return true;
-            }
-            expr_needs_scratch(&callee.node, registry)
-                || args.iter().any(|a| expr_needs_scratch(&a.node, registry))
+            args.iter().any(|a| expr_needs_scratch(&a.node, registry))
         }
-        Expr::TailCall(boxed) => boxed
-            .args
-            .iter()
-            .any(|a| expr_needs_scratch(&a.node, registry)),
-        Expr::Attr(obj, _) => expr_needs_scratch(&obj.node, registry),
+        ResolvedExpr::TailCall { args, .. } => {
+            args.iter().any(|a| expr_needs_scratch(&a.node, registry))
+        }
+        ResolvedExpr::Attr(obj, _) => expr_needs_scratch(&obj.node, registry),
         // `subject?` stashes the Result in scratch, reads tag, and
         // either unwraps field 1 or returns the whole subject.
-        Expr::ErrorProp(_) => true,
-        Expr::Constructor(_, payload) => payload
-            .as_deref()
-            .is_some_and(|p| expr_needs_scratch(&p.node, registry)),
-        Expr::RecordCreate { fields, .. } => fields
+        ResolvedExpr::ErrorProp(_) => true,
+        ResolvedExpr::Ctor(_, args) => args.iter().any(|a| expr_needs_scratch(&a.node, registry)),
+        ResolvedExpr::RecordCreate { fields, .. } => fields
             .iter()
             .any(|(_, e)| expr_needs_scratch(&e.node, registry)),
         // List literal with elements uses the scratch slot for the
         // running tail during the right-fold; empty literal lowers to
         // a single ref.null and doesn't need it.
-        Expr::List(items) if !items.is_empty() => true,
-        Expr::List(items) => items.iter().any(|e| expr_needs_scratch(&e.node, registry)),
-        Expr::MapLiteral(entries) => entries.iter().any(|(k, v)| {
+        ResolvedExpr::List(items) if !items.is_empty() => true,
+        ResolvedExpr::List(items) => items.iter().any(|e| expr_needs_scratch(&e.node, registry)),
+        ResolvedExpr::MapLiteral(entries) => entries.iter().any(|(k, v)| {
             expr_needs_scratch(&k.node, registry) || expr_needs_scratch(&v.node, registry)
         }),
         // `(...)?!` (unwrap=true) stashes each element's Result in the
@@ -691,16 +566,32 @@ pub(super) fn expr_needs_scratch(expr: &Expr, registry: &TypeRegistry) -> bool {
         // just one per element. Bare `(...)!` (unwrap=false) doesn't
         // need scratch — elements are emitted positionally into the
         // tuple struct.
-        Expr::IndependentProduct(items, unwrap) => {
+        ResolvedExpr::IndependentProduct(items, unwrap) => {
             *unwrap || items.iter().any(|e| expr_needs_scratch(&e.node, registry))
         }
-        Expr::Tuple(items) => items.iter().any(|e| expr_needs_scratch(&e.node, registry)),
+        ResolvedExpr::Tuple(items) => items.iter().any(|e| expr_needs_scratch(&e.node, registry)),
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
+            expr_needs_scratch(&base.node, registry)
+                || updates
+                    .iter()
+                    .any(|(_, e)| expr_needs_scratch(&e.node, registry))
+        }
+        ResolvedExpr::InterpolatedStr(parts) => parts.iter().any(|p| {
+            if let ResolvedStrPart::Parsed(inner) = p {
+                expr_needs_scratch(&inner.node, registry)
+            } else {
+                false
+            }
+        }),
         _ => false,
     }
 }
 
-pub(super) fn count_value_params(params: &[(String, String)]) -> usize {
-    params.iter().filter(|(_, ty)| ty.trim() != "Unit").count()
+pub(super) fn count_value_params(params: &[(String, Type)]) -> usize {
+    params
+        .iter()
+        .filter(|(_, ty)| ty.display().trim() != "Unit")
+        .count()
 }
 
 /// Walks the fn body collecting whitespace-stripped `Vector<T>`
@@ -708,23 +599,23 @@ pub(super) fn count_value_params(params: &[(String, String)]) -> usize {
 /// has a `Vector<T>` type stamp. Drives the per-fn allocation of
 /// scratch locals consumed by the clone-on-write emit in
 /// `emit_vector_set_or_default` / `emit_vector_set_boxed`.
-fn collect_vector_set_canonicals(fd: &FnDef, out: &mut HashSet<String>) {
-    let FnBody::Block(stmts) = fd.body.as_ref();
+fn collect_vector_set_canonicals(fd: &ResolvedFnDef, out: &mut HashSet<String>) {
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     for stmt in stmts {
         match stmt {
-            Stmt::Binding(_, _, e) | Stmt::Expr(e) => walk_expr_for_vector_set(e, out),
+            ResolvedStmt::Binding { value, .. } | ResolvedStmt::Expr(value) => {
+                walk_expr_for_vector_set(value, out)
+            }
         }
     }
 }
 
-fn walk_expr_for_vector_set(expr: &Spanned<Expr>, out: &mut HashSet<String>) {
+fn walk_expr_for_vector_set(expr: &Spanned<ResolvedExpr>, out: &mut HashSet<String>) {
     match &expr.node {
-        Expr::FnCall(callee, args) => {
+        ResolvedExpr::Call(callee, args) => {
             // Direct `Vector.set(v, i, x)`.
-            if let Expr::Attr(parent, member) = &callee.node
-                && let Expr::Ident(p) = &parent.node
-                && p == "Vector"
-                && member == "set"
+            if let ResolvedCallee::Builtin(name) = callee
+                && name == "Vector.set"
                 && args.len() == 3
             {
                 let vec_aver = aver_type_str_of(&args[0]);
@@ -733,59 +624,60 @@ fn walk_expr_for_vector_set(expr: &Spanned<Expr>, out: &mut HashSet<String>) {
                     out.insert(canonical);
                 }
             }
-            walk_expr_for_vector_set(callee, out);
             for a in args {
                 walk_expr_for_vector_set(a, out);
             }
         }
-        Expr::BinOp(_, l, r) => {
+        ResolvedExpr::BinOp(_, l, r) => {
             walk_expr_for_vector_set(l, out);
             walk_expr_for_vector_set(r, out);
         }
-        Expr::Neg(inner) => walk_expr_for_vector_set(inner, out),
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::Neg(inner) => walk_expr_for_vector_set(inner, out),
+        ResolvedExpr::Match { subject, arms } => {
             walk_expr_for_vector_set(subject, out);
             for arm in arms {
                 walk_expr_for_vector_set(&arm.body, out);
             }
         }
-        Expr::TailCall(boxed) => {
-            for a in &boxed.args {
+        ResolvedExpr::TailCall { args, .. } => {
+            for a in args {
                 walk_expr_for_vector_set(a, out);
             }
         }
-        Expr::Attr(obj, _) => walk_expr_for_vector_set(obj, out),
-        Expr::ErrorProp(inner) => walk_expr_for_vector_set(inner, out),
-        Expr::Constructor(_, payload) => {
-            if let Some(p) = payload.as_deref() {
-                walk_expr_for_vector_set(p, out);
+        ResolvedExpr::Attr(obj, _) => walk_expr_for_vector_set(obj, out),
+        ResolvedExpr::ErrorProp(inner) => walk_expr_for_vector_set(inner, out),
+        ResolvedExpr::Ctor(_, args) => {
+            for a in args {
+                walk_expr_for_vector_set(a, out);
             }
         }
-        Expr::RecordCreate { fields, .. } => {
+        ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, e) in fields {
                 walk_expr_for_vector_set(e, out);
             }
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             walk_expr_for_vector_set(base, out);
             for (_, e) in updates {
                 walk_expr_for_vector_set(e, out);
             }
         }
-        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+        ResolvedExpr::List(items)
+        | ResolvedExpr::Tuple(items)
+        | ResolvedExpr::IndependentProduct(items, _) => {
             for e in items {
                 walk_expr_for_vector_set(e, out);
             }
         }
-        Expr::MapLiteral(entries) => {
+        ResolvedExpr::MapLiteral(entries) => {
             for (k, v) in entries {
                 walk_expr_for_vector_set(k, out);
                 walk_expr_for_vector_set(v, out);
             }
         }
-        Expr::InterpolatedStr(parts) => {
+        ResolvedExpr::InterpolatedStr(parts) => {
             for p in parts {
-                if let crate::ast::StrPart::Parsed(inner) = p {
+                if let ResolvedStrPart::Parsed(inner) = p {
                     walk_expr_for_vector_set(inner, out);
                 }
             }

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -119,6 +119,27 @@ pub(super) fn emit_module_with(
         })
         .collect();
 
+    // Phase E PR 9.1 — build the resolver `SymbolTable` once and lift
+    // every `FnDef` to its resolved-HIR shape so `emit_fn_body` (and
+    // the dispatch sites it threads into) can read identity off
+    // `ResolvedExpr` / `ResolvedCallee` / `ResolvedCtor` directly.
+    // Wasm-gc emits a single flattened module — `dep_modules` is
+    // empty by construction; flatten.rs has already merged dep fns
+    // into `items`.
+    let symbol_table = crate::ir::SymbolTable::build(items, &[]);
+    let resolve_ctx = crate::ir::hir::ResolveCtx::new(&symbol_table);
+    let resolved_fn_defs: Vec<crate::ir::hir::ResolvedFnDef> = fn_defs
+        .iter()
+        .filter_map(|fd| crate::ir::hir::resolve_fn_def_external(&resolve_ctx, fd))
+        .collect();
+    if resolved_fn_defs.len() != fn_defs.len() {
+        return Err(WasmGcError::Validation(format!(
+            "wasm-gc resolver dropped {} of {} fn defs — typecheck must run before codegen",
+            fn_defs.len() - resolved_fn_defs.len(),
+            fn_defs.len()
+        )));
+    }
+
     // Discover used pure-builtins. Walk every fn body looking for
     // `FnCall` whose callee is `Attr(_, "method")` and the dotted
     // form is a known builtin. Discovery happens before slot
@@ -2255,15 +2276,16 @@ pub(super) fn emit_module_with(
     // emit later in the code section calls `register` again with the
     // same names; the collector is idempotent so the idx assignment
     // matches what the call sites observed during this probe.
-    for (i, fd) in fn_defs.iter().enumerate() {
+    for (i, _fd) in fn_defs.iter().enumerate() {
         let self_wasm_idx = import_count + 1 + (i as u32);
         let mut probe = Function::new([]);
         let _ = emit_fn_body(
             &mut probe,
-            fd,
+            &resolved_fn_defs[i],
             &fn_map,
             self_wasm_idx,
             &registry,
+            &symbol_table,
             &effect_idx_lookup,
             &caller_fn_collector,
             wasip2_lowering.as_ref(),
@@ -2476,17 +2498,18 @@ pub(super) fn emit_module_with(
         codes.function(&start);
     }
 
-    for (i, fd) in fn_defs.iter().enumerate() {
+    for (i, _fd) in fn_defs.iter().enumerate() {
         let self_wasm_idx = import_count + 1 + (i as u32);
         // Dry run: discover extra locals by emitting into a throwaway
         // fn. Cheaper than threading a separate pre-pass.
         let mut probe = Function::new([]);
         let extra_locals_dry = emit_fn_body(
             &mut probe,
-            fd,
+            &resolved_fn_defs[i],
             &fn_map,
             self_wasm_idx,
             &registry,
+            &symbol_table,
             &effect_idx_lookup,
             &caller_fn_collector,
             wasip2_lowering.as_ref(),
@@ -2496,10 +2519,11 @@ pub(super) fn emit_module_with(
         let mut func = Function::new(local_groups);
         let _ = emit_fn_body(
             &mut func,
-            fd,
+            &resolved_fn_defs[i],
             &fn_map,
             self_wasm_idx,
             &registry,
+            &symbol_table,
             &effect_idx_lookup,
             &caller_fn_collector,
             wasip2_lowering.as_ref(),


### PR DESCRIPTION
## Summary

Mirror of the Rust codegen migration (#156) for the wasm-gc body subfiles. After this PR the entire `body/` module reads identity off `ResolvedExpr` / `ResolvedCallee` / `ResolvedCtor` instead of re-parsing `Expr::Attr(Ident(\"Option\"), \"Some\")` shape recognitions per emit site.

Issue: #147 phase E PR 9.1.

## What changed

- **`body.rs::emit_fn_body`** now takes `&ResolvedFnDef` + `&SymbolTable`. `EmitCtx` gains a `symbol_table` field so `Call(Fn(id), args)` / `Ctor(User { type_id, .. }, args)` can resolve to the canonical name the registry is keyed by. Statement walk consumes `ResolvedStmt`; binding-name collector reads `ResolvedStmt::Binding { name, .. }`. `EmitCtx::params` switches from `&[(String, String)]` to `&[(String, Type)]`.
- **`body/emit.rs`** — the hand-coded `Expr::FnCall(Attr(Ident(\"Foo\"), member), ...)` dispatch tree collapses to a clean three-way split on `ResolvedCallee` (Builtin / Fn / Intrinsic / LocalSlot / Unresolved) and `ResolvedCtor` (Builtin variants / User / Unresolved). The parent-disambiguated variant lookup, `List.prepend` / `List.empty` fast paths, Option/Result builtin constructors, and the dotted-builtin fallback are all preserved — the dispatch is just smaller. Match emitters (Option, Result, list, tuple-of-constructors, variant cascade, single-arm variant) consume `&[ResolvedMatchArm]` with `ResolvedPattern::Ctor(ctor, bindings)` arms. Pattern dotted-name reconstruction lives in one helper, `ctor_dotted_name`. `nullary_variant_idx` collapses to the resolved \`Attr\` (bare attribute) + zero-arg `Ctor(User, [])` shapes the resolver produces. Dead `emit_constructor` (old `Expr::Constructor` lowering) removed.
- **`body/slots.rs`** — four near-identical Args.get / Console.\* / Env.get / Random.int scratch walkers fold into one `expr_reaches_builtin_call` predicate keyed by the resolved builtin canonical. `expr_needs_scratch` recognises `ResolvedExpr::Call(Builtin(\"Option.withDefault\"|\"Result.withDefault\"|\"Option.toResult\"), ..)` instead of the source-shape `Expr::Attr` walk. `collect_vector_set_canonicals` recognises `Vector.set` the same way. `count_value_params` takes `&[(String, Type)]`. `SlotTable::build_for_fn` consumes `&ResolvedFnDef`.
- **`body/builtins.rs` + `body/builtins_wasip2.rs`** — entry signatures switch to `&[Spanned<ResolvedExpr>]`. The synthetic-call shape that `emit_option_with_default` built to feed `classify_leaf_op` now builds a `ResolvedExpr::Call(Builtin(\"Option.withDefault\"), args)` and dispatches through `classify_leaf_op_resolved`. Map.get fusion and Int.mod fusion arms recognise `Call(Builtin(\"Map.get\"|\"Int.mod\"), ..)`. `emit_interpolated_str` consumes `&[ResolvedStrPart]`.
- **`body/infer.rs`** — pre-resolve `arm_is_option_pattern` / `arm_is_result_pattern` predicates removed; the `_resolved` variants graduate from `#[allow(dead_code)]` to live.
- **`module.rs`** — 3 `emit_fn_body` callsites pass `&resolved_fn_defs[i]` + `&symbol_table`. `SymbolTable::build` + per-fn `resolve_fn_def_external` happens once at the top of `emit_module_with`; aborts with a clear validation error if any fn drops out of the resolver. Wasm-gc emits a single flattened module — `dep_modules` is empty by construction; `flatten.rs` has already merged dep fns into `items`.

Out of scope (deferred to PR 9.2 per #147 plan):
- `module.rs` orchestration outside the 3 callsites — fn signature emission still reads `fd.params` source-shape.
- `types_discovery.rs` / `types.rs` / `flatten.rs` — program-level walkers that register types/fns before emit.

Net: **−159 lines** across 7 files (−860 / +701).

## Removed `Expr::` shape recognitions

- `Expr::FnCall(Attr(Ident(\"Option\"), \"Some\"|\"None\"), args)` → `ResolvedCtor::Builtin(OptionSome|OptionNone)`.
- `Expr::FnCall(Attr(Ident(\"Result\"), \"Ok\"|\"Err\"), args)` → `ResolvedCtor::Builtin(ResultOk|ResultErr)`.
- `Expr::FnCall(Attr(Ident(parent), member), args)` with registry hit → `ResolvedCtor::User { type_id, name, .. }`.
- `Expr::FnCall(Attr(Ident(parent), member), args)` fallback → `ResolvedCallee::Builtin(\"parent.member\")` + dispatch via `rsplit_once('.')`.
- `Expr::FnCall(Ident(name), args)` → `ResolvedCallee::Fn(FnId)` / `LocalSlot` (verify-only fns), name read via `symbol_table.fn_entry(id).key`.
- `Expr::TailCall(boxed)` with `boxed.target: String` → `ResolvedExpr::TailCall { target: FnId, args }`; canonical name via the symbol table.
- `Pattern::Constructor(name: String, bindings)` → `ResolvedPattern::Ctor(ctor: ResolvedCtor, bindings)`; the bare-name lookup uses `ctor_dotted_name` once at the dispatch site.
- `is_option_none_expr` collapses to `matches!(expr, ResolvedExpr::Ctor(ResolvedCtor::Builtin(BuiltinCtor::OptionNone), args) if args.is_empty())`.
- Four `expr_reaches_*` walkers in `slots.rs` fold into one builtin-name-keyed predicate.

## Test plan

- [x] `cargo build --features wasm`
- [x] `cargo test --features wasm --no-fail-fast` — **1649 passed, 0 failed**.
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Byte-identical wasm output for every snapshot fixture:
  - `order_total` md5 `61e45b325279e17e1b0d8dce3fde43f9` ✓
  - `calculator` md5 `2dee891f87c1ad875f35d5b772c92a6a` ✓
  - `lists` md5 `e270694ac4a201e9e8001a73c2193b6a` ✓
  - `shapes` md5 `fe7f2c96ad7471643006c4571ece5df0` ✓
  - `user_record` md5 `5d9948577bf0d99a8f7729357c778259` ✓
  - `temperature` md5 `e04e85be65d1b87b5b7e8bb7be120bc4` ✓
  - `lambda` md5 `290c8bc2b2469f75c8362973ca35238c` ✓
  - `hello` md5 `3011e815fd3bd061ee04b157e17345a9` ✓
  - `effects_explicit` md5 `18c2ce31339d45927bed5bac4543c821` ✓
  - `independent_fanout` md5 `4c8feea2d327008c806fb8e5e6b133bd` ✓
  - `snake` md5 `370631b754e9418076c600b849c68aca` ✓
  - `wumpus` md5 `535fae7b7d02c3156e7f1706d930aaef` ✓
  - `life` 10508 bytes (size-stable; md5 flaky across builds per pre-existing HashMap iteration order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)