### PR TITLE
codegen/wasm_gc: types_discovery + types + module orchestration consume ResolvedExpr — #147 phase E PR 9.2

### DIFF
--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -94,38 +94,34 @@ use super::wasip2_helpers::{
 use super::wat_helper;
 use crate::types::Type as AverType;
 
-use crate::ast::{Expr, FnDef, Stmt, TopLevel, TypeDef};
+use crate::ast::{FnDef, TopLevel, TypeDef};
 
-pub(super) fn emit_module_with(
+/// Resolved-HIR view of the wasm-gc backend's post-flatten compile
+/// unit. The pipeline-built `CodegenContext.resolved_fn_defs` is keyed
+/// against pre-flatten items (cross-module names like `Fractal.render`
+/// still reference their owning module); `flatten_multimodule` runs
+/// AFTER pipeline and rewrites those into single-module flat names
+/// (`Fractal_render`), so a fresh resolver pass against the flattened
+/// items is the source of truth this backend uses.
+///
+/// Naming the invariant in a helper is deliberate — calling code in
+/// `emit_module_with` reads `view.resolved_fn_defs` and the rebuild
+/// stays local to this backend. PR 9.3 (Phase E roadmap, #147) decides
+/// whether `flatten` moves into the pipeline so a shared
+/// `CodegenContext` covers wasm-gc too, or whether this backend keeps a
+/// formal post-flatten codegen view.
+struct FlattenedResolvedView {
+    symbol_table: crate::ir::SymbolTable,
+    resolved_fn_defs: Vec<crate::ir::hir::ResolvedFnDef>,
+}
+
+fn build_flattened_resolved_view(
     items: &[TopLevel],
-    handler_name: Option<&str>,
-    target: super::TargetMode,
-) -> Result<Vec<u8>, WasmGcError> {
-    let registry = TypeRegistry::build_with_handler(items, handler_name.is_some());
-
-    // Lazy caller_fn name registry — populated during user-fn body
-    // emit by `emit_caller_fn_idx` call sites. Threaded into every
-    // `emit_fn_body` call via `EmitCtx::caller_fn_collector`. The
-    // post-emit phase reads `collector.names` to materialise the
-    // exported caller-fn name table (`__caller_fn_count` +
-    // `__caller_fn_name`) and the matching passive data segments.
-    let caller_fn_collector = std::cell::RefCell::new(super::body::CallerFnCollector::default());
-
-    let fn_defs: Vec<&FnDef> = items
-        .iter()
-        .filter_map(|it| match it {
-            TopLevel::FnDef(fd) => Some(fd),
-            _ => None,
-        })
-        .collect();
-
-    // Phase E PR 9.1 — build the resolver `SymbolTable` once and lift
-    // every `FnDef` to its resolved-HIR shape so `emit_fn_body` (and
-    // the dispatch sites it threads into) can read identity off
-    // `ResolvedExpr` / `ResolvedCallee` / `ResolvedCtor` directly.
-    // Wasm-gc emits a single flattened module — `dep_modules` is
-    // empty by construction; flatten.rs has already merged dep fns
-    // into `items`.
+    fn_defs: &[&FnDef],
+) -> Result<FlattenedResolvedView, WasmGcError> {
+    // Wasm-gc emits a single flattened module — `dep_modules` is empty
+    // by construction; `flatten_multimodule` has already merged dep
+    // fns into `items` with prefixed names.
     let symbol_table = crate::ir::SymbolTable::build(items, &[]);
     let resolve_ctx = crate::ir::hir::ResolveCtx::new(&symbol_table);
     let resolved_fn_defs: Vec<crate::ir::hir::ResolvedFnDef> = fn_defs
@@ -139,6 +135,40 @@ pub(super) fn emit_module_with(
             fn_defs.len()
         )));
     }
+    Ok(FlattenedResolvedView {
+        symbol_table,
+        resolved_fn_defs,
+    })
+}
+
+pub(super) fn emit_module_with(
+    items: &[TopLevel],
+    handler_name: Option<&str>,
+    target: super::TargetMode,
+) -> Result<Vec<u8>, WasmGcError> {
+    let fn_defs: Vec<&FnDef> = items
+        .iter()
+        .filter_map(|it| match it {
+            TopLevel::FnDef(fd) => Some(fd),
+            _ => None,
+        })
+        .collect();
+
+    let FlattenedResolvedView {
+        symbol_table,
+        resolved_fn_defs,
+    } = build_flattened_resolved_view(items, &fn_defs)?;
+
+    let registry =
+        TypeRegistry::build_with_handler(items, &resolved_fn_defs, handler_name.is_some());
+
+    // Lazy caller_fn name registry — populated during user-fn body
+    // emit by `emit_caller_fn_idx` call sites. Threaded into every
+    // `emit_fn_body` call via `EmitCtx::caller_fn_collector`. The
+    // post-emit phase reads `collector.names` to materialise the
+    // exported caller-fn name table (`__caller_fn_count` +
+    // `__caller_fn_name`) and the matching passive data segments.
+    let caller_fn_collector = std::cell::RefCell::new(super::body::CallerFnCollector::default());
 
     // Discover used pure-builtins. Walk every fn body looking for
     // `FnCall` whose callee is `Attr(_, "method")` and the dotted
@@ -149,7 +179,7 @@ pub(super) fn emit_module_with(
     let mut effect_registry = EffectRegistry::new();
     let mut eq_helpers_registry = EqHelperRegistry::new();
     let mut hash_helpers_registry = HashHelperRegistry::new();
-    for fd in &fn_defs {
+    for fd in &resolved_fn_defs {
         discover_builtins_in_fn(
             fd,
             &mut builtin_registry,
@@ -767,7 +797,7 @@ pub(super) fn emit_module_with(
     // 7) List / Vector.fromList / String.split-join helpers — per-T
     //    instantiation list ops, plus singleton split/join when the
     //    surface code uses them.
-    let needs_split_join = items_use_string_split_join(items);
+    let needs_split_join = fn_defs_use_string_split_join(&resolved_fn_defs);
     let mut list_helpers = super::lists::ListHelperRegistry::default();
     list_helpers.assign_slots(
         &registry.list_order,
@@ -4446,27 +4476,28 @@ fn emit_user_types(
 /// any wasm bytes get emitted, so slot allocation can run with the
 /// full set known.
 fn discover_builtins_in_fn(
-    fd: &FnDef,
+    fd: &crate::ir::hir::ResolvedFnDef,
     builtins: &mut BuiltinRegistry,
     effects: &mut EffectRegistry,
     eq_helpers: &mut EqHelperRegistry,
     type_registry: &TypeRegistry,
 ) {
-    let crate::ast::FnBody::Block(stmts) = fd.body.as_ref();
+    let crate::ir::hir::ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     for stmt in stmts {
         discover_builtins_in_stmt(stmt, builtins, effects, eq_helpers, type_registry);
     }
 }
 
 fn discover_builtins_in_stmt(
-    stmt: &Stmt,
+    stmt: &crate::ir::hir::ResolvedStmt,
     builtins: &mut BuiltinRegistry,
     effects: &mut EffectRegistry,
     eq_helpers: &mut EqHelperRegistry,
     type_registry: &TypeRegistry,
 ) {
     match stmt {
-        Stmt::Binding(_, _, e) | Stmt::Expr(e) => {
+        crate::ir::hir::ResolvedStmt::Binding { value: e, .. }
+        | crate::ir::hir::ResolvedStmt::Expr(e) => {
             discover_builtins_in_expr(&e.node, builtins, effects, eq_helpers, type_registry)
         }
     }
@@ -4525,23 +4556,20 @@ fn register_nominal_in_type(
 }
 
 fn discover_builtins_in_expr(
-    expr: &Expr,
+    expr: &crate::ir::hir::ResolvedExpr,
     builtins: &mut BuiltinRegistry,
     effects: &mut EffectRegistry,
     eq_helpers: &mut EqHelperRegistry,
     type_registry: &TypeRegistry,
 ) {
-    use crate::ast::StrPart;
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr, ResolvedStrPart};
     match expr {
-        Expr::FnCall(callee, args) => {
-            if let Expr::Attr(_parent, member) = &callee.node
-                && let Some(parent_name) = expr_to_dotted_head(&callee.node)
-            {
-                let dotted = format!("{parent_name}.{member}");
-                if let Some(name) = BuiltinName::from_dotted(&dotted) {
+        ResolvedExpr::Call(callee, args) => {
+            if let ResolvedCallee::Builtin(dotted) = callee {
+                if let Some(name) = BuiltinName::from_dotted(dotted) {
                     builtins.register(name);
                 }
-                if let Some(name) = EffectName::from_dotted(&dotted) {
+                if let Some(name) = EffectName::from_dotted(dotted) {
                     effects.register(name);
                 }
                 // `Args.get()` (no args, returns List<String>) lowers
@@ -4564,12 +4592,11 @@ fn discover_builtins_in_expr(
                     builtins.register(BuiltinName::IntModEuclid);
                 }
             }
-            discover_builtins_in_expr(&callee.node, builtins, effects, eq_helpers, type_registry);
             for arg in args {
                 discover_builtins_in_expr(&arg.node, builtins, effects, eq_helpers, type_registry);
             }
         }
-        Expr::BinOp(op, l, r) => {
+        ResolvedExpr::BinOp(op, l, r) => {
             // String `+` lowers to `__wasmgc_concat_n`; String `==`/`!=`
             // lower to `__wasmgc_string_eq`. Both helpers must be
             // registered up front so emit can `Call` them by index.
@@ -4620,10 +4647,10 @@ fn discover_builtins_in_expr(
             discover_builtins_in_expr(&l.node, builtins, effects, eq_helpers, type_registry);
             discover_builtins_in_expr(&r.node, builtins, effects, eq_helpers, type_registry);
         }
-        Expr::Neg(inner) => {
+        ResolvedExpr::Neg(inner) => {
             discover_builtins_in_expr(&inner.node, builtins, effects, eq_helpers, type_registry);
         }
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::Match { subject, arms } => {
             discover_builtins_in_expr(&subject.node, builtins, effects, eq_helpers, type_registry);
             // String-subject match (`match path { "/" -> ... }`)
             // needs `StringEq` to compare each non-default arm's
@@ -4632,7 +4659,7 @@ fn discover_builtins_in_expr(
             if arms.iter().any(|a| {
                 matches!(
                     &a.pattern,
-                    crate::ast::Pattern::Literal(crate::ast::Literal::Str(_))
+                    crate::ir::hir::ResolvedPattern::Literal(crate::ast::Literal::Str(_))
                 )
             }) {
                 builtins.register(BuiltinName::StringEq);
@@ -4647,28 +4674,28 @@ fn discover_builtins_in_expr(
                 );
             }
         }
-        Expr::TailCall(boxed) => {
-            for arg in &boxed.args {
+        ResolvedExpr::TailCall { args, .. } => {
+            for arg in args {
                 discover_builtins_in_expr(&arg.node, builtins, effects, eq_helpers, type_registry);
             }
         }
-        Expr::Attr(obj, _) => {
+        ResolvedExpr::Attr(obj, _) => {
             discover_builtins_in_expr(&obj.node, builtins, effects, eq_helpers, type_registry)
         }
-        Expr::ErrorProp(inner) => {
+        ResolvedExpr::ErrorProp(inner) => {
             discover_builtins_in_expr(&inner.node, builtins, effects, eq_helpers, type_registry)
         }
-        Expr::Constructor(_, payload) => {
-            if let Some(p) = payload.as_deref() {
-                discover_builtins_in_expr(&p.node, builtins, effects, eq_helpers, type_registry);
+        ResolvedExpr::Ctor(_, args) => {
+            for a in args {
+                discover_builtins_in_expr(&a.node, builtins, effects, eq_helpers, type_registry);
             }
         }
-        Expr::RecordCreate { fields, .. } => {
+        ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, e) in fields {
                 discover_builtins_in_expr(&e.node, builtins, effects, eq_helpers, type_registry);
             }
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             discover_builtins_in_expr(&base.node, builtins, effects, eq_helpers, type_registry);
             for (_, e) in updates {
                 discover_builtins_in_expr(&e.node, builtins, effects, eq_helpers, type_registry);
@@ -4680,7 +4707,7 @@ fn discover_builtins_in_expr(
         // part may also need `String.fromInt` (if its type is Int) —
         // we conservatively register that too; unused registrations
         // are stripped by `wasm-opt -Oz`.
-        Expr::InterpolatedStr(parts) => {
+        ResolvedExpr::InterpolatedStr(parts) => {
             // Variadic concat is mandatory; the per-type stringifiers
             // are registered conservatively whenever interpolation
             // exists in the program — unused registrations get DCE'd
@@ -4691,7 +4718,7 @@ fn discover_builtins_in_expr(
             builtins.register(BuiltinName::StringFromFloat);
             builtins.register(BuiltinName::StringFromBool);
             for p in parts {
-                if let StrPart::Parsed(inner) = p {
+                if let ResolvedStrPart::Parsed(inner) = p {
                     discover_builtins_in_expr(
                         &inner.node,
                         builtins,
@@ -4702,17 +4729,17 @@ fn discover_builtins_in_expr(
                 }
             }
         }
-        Expr::List(items) => {
+        ResolvedExpr::List(items) => {
             for item in items {
                 discover_builtins_in_expr(&item.node, builtins, effects, eq_helpers, type_registry);
             }
         }
-        Expr::Tuple(items) => {
+        ResolvedExpr::Tuple(items) => {
             for item in items {
                 discover_builtins_in_expr(&item.node, builtins, effects, eq_helpers, type_registry);
             }
         }
-        Expr::IndependentProduct(items, _) => {
+        ResolvedExpr::IndependentProduct(items, _) => {
             // `?!` and `!` lower as sequential evaluation in wasm-gc,
             // but the recorder still needs the structural-scope
             // markers (`enter_group`, `set_branch`, `exit_group`) so
@@ -4728,7 +4755,7 @@ fn discover_builtins_in_expr(
                 discover_builtins_in_expr(&item.node, builtins, effects, eq_helpers, type_registry);
             }
         }
-        Expr::MapLiteral(entries) => {
+        ResolvedExpr::MapLiteral(entries) => {
             for (k, v) in entries {
                 discover_builtins_in_expr(&k.node, builtins, effects, eq_helpers, type_registry);
                 discover_builtins_in_expr(&v.node, builtins, effects, eq_helpers, type_registry);
@@ -4741,66 +4768,44 @@ fn discover_builtins_in_expr(
 /// True iff any reachable fn body calls `String.split` or `String.join`.
 /// Used to gate registration of the (T=String) split/join helpers in
 /// `lists::ListHelperRegistry::assign_slots`.
-fn items_use_string_split_join(items: &[TopLevel]) -> bool {
-    use crate::ast::{Expr, FnBody, Stmt};
-    fn walk(e: &Expr) -> bool {
+fn fn_defs_use_string_split_join(fn_defs: &[crate::ir::hir::ResolvedFnDef]) -> bool {
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr, ResolvedFnBody, ResolvedStmt};
+    fn walk(e: &ResolvedExpr) -> bool {
         match e {
-            Expr::FnCall(callee, args) => {
-                if let Expr::Attr(_parent, member) = &callee.node
-                    && let Some(p) = expr_to_dotted_head(&callee.node)
-                    && p == "String"
-                    && (member == "split" || member == "join")
+            ResolvedExpr::Call(callee, args) => {
+                if let ResolvedCallee::Builtin(name) = callee
+                    && (name == "String.split" || name == "String.join")
                 {
                     return true;
                 }
-                walk(&callee.node) || args.iter().any(|a| walk(&a.node))
+                args.iter().any(|a| walk(&a.node))
             }
-            Expr::BinOp(_, l, r) => walk(&l.node) || walk(&r.node),
-            Expr::Neg(inner) => walk(&inner.node),
-            Expr::Match { subject, arms } => {
+            ResolvedExpr::BinOp(_, l, r) => walk(&l.node) || walk(&r.node),
+            ResolvedExpr::Neg(inner) => walk(&inner.node),
+            ResolvedExpr::Match { subject, arms } => {
                 walk(&subject.node) || arms.iter().any(|a| walk(&a.body.node))
             }
-            Expr::TailCall(boxed) => boxed.args.iter().any(|a| walk(&a.node)),
-            Expr::Attr(obj, _) => walk(&obj.node),
-            Expr::RecordCreate { fields, .. } => fields.iter().any(|(_, e)| walk(&e.node)),
-            Expr::Constructor(_, payload) => {
-                payload.as_deref().map(|p| walk(&p.node)).unwrap_or(false)
-            }
-            Expr::List(items) => items.iter().any(|x| walk(&x.node)),
-            Expr::InterpolatedStr(_) => false,
+            ResolvedExpr::TailCall { args, .. } => args.iter().any(|a| walk(&a.node)),
+            ResolvedExpr::Attr(obj, _) => walk(&obj.node),
+            ResolvedExpr::RecordCreate { fields, .. } => fields.iter().any(|(_, e)| walk(&e.node)),
+            ResolvedExpr::Ctor(_, args) => args.iter().any(|a| walk(&a.node)),
+            ResolvedExpr::List(items) => items.iter().any(|x| walk(&x.node)),
+            ResolvedExpr::InterpolatedStr(_) => false,
             _ => false,
         }
     }
-    for item in items {
-        if let TopLevel::FnDef(fd) = item {
-            let FnBody::Block(stmts) = fd.body.as_ref();
-            for stmt in stmts {
-                let e = match stmt {
-                    Stmt::Binding(_, _, e) | Stmt::Expr(e) => &e.node,
-                };
-                if walk(e) {
-                    return true;
-                }
+    for fd in fn_defs {
+        let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
+        for stmt in stmts {
+            let e = match stmt {
+                ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => &e.node,
+            };
+            if walk(e) {
+                return true;
             }
         }
     }
     false
-}
-
-/// Extract `Parent` from an `Attr(Parent, _)` callee — the parent is
-/// either an Ident or a Resolved local. Anything else (chained Attr,
-/// fn call result) returns None and the dispatch falls through to a
-/// regular fn call.
-fn expr_to_dotted_head(expr: &Expr) -> Option<&str> {
-    if let Expr::Attr(parent, _) = expr {
-        match &parent.node {
-            Expr::Ident(n) => Some(n.as_str()),
-            Expr::Resolved { name, .. } => Some(name.as_str()),
-            _ => None,
-        }
-    } else {
-        None
-    }
 }
 
 /// `__rt_list_string_cons(head, tail) -> list`. Lets the JS host

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -117,7 +117,7 @@ pub(super) struct TypeRegistry {
     pub(super) string_array_type_idx: Option<u32>,
     /// Per-byte-sequence passive data segment for `String` literals.
     /// Each unique literal in the program lands at one segment idx;
-    /// `Expr::Literal(Literal::Str(_))` lowers to `array.new_data
+    /// `ResolvedExpr::Literal(Literal::Str(_))` lowers to `array.new_data
     /// $string $segment_idx` with offset=0, size=len.
     pub(super) string_literals: Vec<Vec<u8>>,
     pub(super) string_literal_idx: HashMap<Vec<u8>, u32>,
@@ -164,7 +164,11 @@ impl TypeRegistry {
     /// them up). Also intern the `"cf-ipcountry"` string literal so
     /// the synthesised `aver_http_handle` wrapper has a valid data
     /// segment to source it from.
-    pub(super) fn build_with_handler(items: &[TopLevel], _handler_active: bool) -> Self {
+    pub(super) fn build_with_handler(
+        items: &[TopLevel],
+        resolved_fn_defs: &[crate::ir::hir::ResolvedFnDef],
+        _handler_active: bool,
+    ) -> Self {
         // _handler_active is consumed by `items_reference_name`
         // overrides below so the rest of the builder stays
         // unchanged.
@@ -255,13 +259,13 @@ impl TypeRegistry {
         // like `fn main() -> Int { _ = Time.unixMs(); 42 }`.
         let has_fn_defs = items.iter().any(|item| matches!(item, TopLevel::FnDef(_)));
         let needs_string = has_fn_defs
-            || items.iter().any(|item| match item {
-                TopLevel::FnDef(fd) => {
-                    fd.return_type.contains("String")
-                        || fd.params.iter().any(|(_, t)| t.contains("String"))
-                        || fn_body_produces_string(fd)
-                }
-                _ => false,
+            || resolved_fn_defs.iter().any(|fd| {
+                fd.return_type.display().contains("String")
+                    || fd
+                        .params
+                        .iter()
+                        .any(|(_, t)| t.display().contains("String"))
+                    || fn_body_produces_string(fd)
             });
         let string_array_type_idx = if needs_string {
             let idx = next_idx;
@@ -302,29 +306,22 @@ impl TypeRegistry {
         // canonical bench shape today.
         let mut vector_types: HashMap<String, u32> = HashMap::new();
         let mut vector_order: Vec<String> = Vec::new();
-        for item in items {
-            if let TopLevel::FnDef(fd) = item {
+        for fd in resolved_fn_defs {
+            collect_vectors_from_str(
+                &fd.return_type.display(),
+                &mut vector_types,
+                &mut vector_order,
+                &mut next_idx,
+            );
+            for (_, ty) in &fd.params {
                 collect_vectors_from_str(
-                    &fd.return_type,
-                    &mut vector_types,
-                    &mut vector_order,
-                    &mut next_idx,
-                );
-                for (_, ty) in &fd.params {
-                    collect_vectors_from_str(
-                        ty,
-                        &mut vector_types,
-                        &mut vector_order,
-                        &mut next_idx,
-                    );
-                }
-                collect_vectors_from_fn_body(
-                    fd,
+                    &ty.display(),
                     &mut vector_types,
                     &mut vector_order,
                     &mut next_idx,
                 );
             }
+            collect_vectors_from_fn_body(fd, &mut vector_types, &mut vector_order, &mut next_idx);
         }
         // Record field walks — `record { nums: Vector<Int> }` only
         // shows up in the record's field list, not in any fn
@@ -344,66 +341,71 @@ impl TypeRegistry {
         // rec group.
         let mut result_types: HashMap<String, u32> = HashMap::new();
         let mut result_order: Vec<String> = Vec::new();
-        for item in items {
-            if let TopLevel::FnDef(fd) = item {
+        for fd in resolved_fn_defs {
+            collect_results_from_str(
+                &fd.return_type.display(),
+                &mut result_types,
+                &mut result_order,
+                &mut next_idx,
+            );
+            for (_, ty) in &fd.params {
                 collect_results_from_str(
-                    &fd.return_type,
+                    &ty.display(),
                     &mut result_types,
                     &mut result_order,
                     &mut next_idx,
                 );
-                for (_, ty) in &fd.params {
+            }
+            collect_results_from_builtin_uses(
+                fd,
+                &mut result_types,
+                &mut result_order,
+                &mut next_idx,
+            );
+            // Walk binding annotations too — `let r: Result<Box, MyErr> = …`
+            // wouldn't be picked up by the builtin-uses scan (which only
+            // looks at known dotted calls like `Disk.readText`). Without this,
+            // user-typed `Result<custom, custom>` values fail to find their
+            // type slot at construction time.
+            use crate::ir::hir::{ResolvedFnBody, ResolvedStmt};
+            let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
+            for stmt in stmts {
+                if let ResolvedStmt::Binding {
+                    ty_ann: Some(annot),
+                    ..
+                } = stmt
+                {
                     collect_results_from_str(
-                        ty,
+                        &annot.display(),
                         &mut result_types,
                         &mut result_order,
                         &mut next_idx,
                     );
                 }
-                collect_results_from_builtin_uses(
-                    fd,
-                    &mut result_types,
-                    &mut result_order,
-                    &mut next_idx,
-                );
-                // Walk binding annotations too — `let r: Result<Box, MyErr> = …`
-                // wouldn't be picked up by the builtin-uses scan (which only
-                // looks at known dotted calls like `Disk.readText`). Without this,
-                // user-typed `Result<custom, custom>` values fail to find their
-                // type slot at construction time.
-                use crate::ast::{FnBody, Stmt};
-                let FnBody::Block(stmts) = fd.body.as_ref();
-                for stmt in stmts {
-                    if let Stmt::Binding(_, Some(annot), _) = stmt {
-                        collect_results_from_str(
-                            annot,
-                            &mut result_types,
-                            &mut result_order,
-                            &mut next_idx,
-                        );
-                    }
-                }
             }
         }
         let mut list_types: HashMap<String, u32> = HashMap::new();
         let mut list_order: Vec<String> = Vec::new();
-        for item in items {
-            if let TopLevel::FnDef(fd) = item {
+        for fd in resolved_fn_defs {
+            collect_lists_from_str(
+                &fd.return_type.display(),
+                &mut list_types,
+                &mut list_order,
+                &mut next_idx,
+            );
+            for (_, ty) in &fd.params {
                 collect_lists_from_str(
-                    &fd.return_type,
+                    &ty.display(),
                     &mut list_types,
                     &mut list_order,
                     &mut next_idx,
                 );
-                for (_, ty) in &fd.params {
-                    collect_lists_from_str(ty, &mut list_types, &mut list_order, &mut next_idx);
-                }
-                // Body annotations — `nested: List<List<Int>> = [a, b]`
-                // adds `List<List<Int>>` even when no fn signature
-                // mentions it. Mirrors the same body-walk options
-                // and vectors already do.
-                collect_lists_from_fn_body(fd, &mut list_types, &mut list_order, &mut next_idx);
             }
+            // Body annotations — `nested: List<List<Int>> = [a, b]`
+            // adds `List<List<Int>>` even when no fn signature
+            // mentions it. Mirrors the same body-walk options
+            // and vectors already do.
+            collect_lists_from_fn_body(fd, &mut list_types, &mut list_order, &mut next_idx);
         }
         for (_, fields) in record_fields.iter() {
             for (_, ty) in fields {
@@ -452,29 +454,22 @@ impl TypeRegistry {
         // allocate a struct slot per unique `T`.
         let mut option_types: HashMap<String, u32> = HashMap::new();
         let mut option_order: Vec<String> = Vec::new();
-        for item in items {
-            if let TopLevel::FnDef(fd) = item {
+        for fd in resolved_fn_defs {
+            collect_options_from_str(
+                &fd.return_type.display(),
+                &mut option_types,
+                &mut option_order,
+                &mut next_idx,
+            );
+            for (_, ty) in &fd.params {
                 collect_options_from_str(
-                    &fd.return_type,
-                    &mut option_types,
-                    &mut option_order,
-                    &mut next_idx,
-                );
-                for (_, ty) in &fd.params {
-                    collect_options_from_str(
-                        ty,
-                        &mut option_types,
-                        &mut option_order,
-                        &mut next_idx,
-                    );
-                }
-                collect_options_from_fn_body(
-                    fd,
+                    &ty.display(),
                     &mut option_types,
                     &mut option_order,
                     &mut next_idx,
                 );
             }
+            collect_options_from_fn_body(fd, &mut option_types, &mut option_order, &mut next_idx);
         }
         // Record field walk — `record GameState { lastAiResult:
         // Option<AiResult> }` only spells `Option<AiResult>` in the
@@ -528,12 +523,10 @@ impl TypeRegistry {
                 collect_maps_from_str(ty, &mut pending_maps_for_options);
             }
         }
-        for item in items {
-            if let TopLevel::FnDef(fd) = item {
-                collect_maps_from_str(&fd.return_type, &mut pending_maps_for_options);
-                for (_, ty) in &fd.params {
-                    collect_maps_from_str(ty, &mut pending_maps_for_options);
-                }
+        for fd in resolved_fn_defs {
+            collect_maps_from_str(&fd.return_type.display(), &mut pending_maps_for_options);
+            for (_, ty) in &fd.params {
+                collect_maps_from_str(&ty.display(), &mut pending_maps_for_options);
             }
         }
         if handler_active
@@ -573,27 +566,29 @@ impl TypeRegistry {
                 collect_maps_from_str(ty, &mut pending_maps);
             }
         }
-        for item in items {
-            if let TopLevel::FnDef(fd) = item {
-                collect_maps_from_str(&fd.return_type, &mut pending_maps);
-                for (_, ty) in &fd.params {
-                    collect_maps_from_str(ty, &mut pending_maps);
+        for fd in resolved_fn_defs {
+            collect_maps_from_str(&fd.return_type.display(), &mut pending_maps);
+            for (_, ty) in &fd.params {
+                collect_maps_from_str(&ty.display(), &mut pending_maps);
+            }
+            // Walk let-binding annotations too — `let m: Map<Person, Int> =
+            // Map.set(…)` won't show up in fn signatures and the discovery
+            // walker would otherwise miss the canonical entirely. Mirrors
+            // what the Result walker added a few commits back.
+            use crate::ir::hir::{ResolvedFnBody, ResolvedStmt};
+            let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
+            for stmt in stmts {
+                if let ResolvedStmt::Binding {
+                    ty_ann: Some(annot),
+                    ..
+                } = stmt
+                {
+                    collect_maps_from_str(&annot.display(), &mut pending_maps);
                 }
-                // Walk let-binding annotations too — `let m: Map<Person, Int> =
-                // Map.set(…)` won't show up in fn signatures and the discovery
-                // walker would otherwise miss the canonical entirely. Mirrors
-                // what the Result walker added a few commits back.
-                use crate::ast::{FnBody, Stmt};
-                let FnBody::Block(stmts) = fd.body.as_ref();
-                for stmt in stmts {
-                    if let Stmt::Binding(_, Some(annot), _) = stmt {
-                        collect_maps_from_str(annot, &mut pending_maps);
-                    }
-                    let expr = match stmt {
-                        Stmt::Binding(_, _, e) | Stmt::Expr(e) => e,
-                    };
-                    collect_maps_from_expr(expr, &mut pending_maps);
-                }
+                let expr = match stmt {
+                    ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => e,
+                };
+                collect_maps_from_expr(expr, &mut pending_maps);
             }
         }
         // Dedup in encounter order.
@@ -675,23 +670,26 @@ impl TypeRegistry {
         // results/options.
         let mut tuple_types: HashMap<String, u32> = HashMap::new();
         let mut tuple_order: Vec<String> = Vec::new();
-        for item in items {
-            if let TopLevel::FnDef(fd) = item {
+        for fd in resolved_fn_defs {
+            collect_tuples_from_str(
+                &fd.return_type.display(),
+                &mut tuple_types,
+                &mut tuple_order,
+                &mut next_idx,
+            );
+            for (_, ty) in &fd.params {
                 collect_tuples_from_str(
-                    &fd.return_type,
+                    &ty.display(),
                     &mut tuple_types,
                     &mut tuple_order,
                     &mut next_idx,
                 );
-                for (_, ty) in &fd.params {
-                    collect_tuples_from_str(ty, &mut tuple_types, &mut tuple_order, &mut next_idx);
-                }
-                // Walk the body for `Expr::Tuple` literals — the
-                // canonical `Tuple<A,B>` for a `(a, b)` literal is
-                // built from the items' typed-AST element types and
-                // never has to appear in any signature.
-                collect_tuples_from_fn_body(fd, &mut tuple_types, &mut tuple_order, &mut next_idx);
             }
+            // Walk the body for `ResolvedExpr::Tuple` literals — the
+            // canonical `Tuple<A,B>` for a `(a, b)` literal is
+            // built from the items' typed-AST element types and
+            // never has to appear in any signature.
+            collect_tuples_from_fn_body(fd, &mut tuple_types, &mut tuple_order, &mut next_idx);
         }
         // Record fields can carry tuple types too.
         for (_, fields) in record_fields.iter() {
@@ -767,10 +765,8 @@ impl TypeRegistry {
         let mut string_literals: Vec<Vec<u8>> = Vec::new();
         let mut string_literal_idx: HashMap<Vec<u8>, u32> = HashMap::new();
         let _ = handler_active;
-        for item in items {
-            if let TopLevel::FnDef(fd) = item {
-                collect_string_literals_in_fn(fd, &mut string_literals, &mut string_literal_idx);
-            }
+        for fd in resolved_fn_defs {
+            collect_string_literals_in_fn(fd, &mut string_literals, &mut string_literal_idx);
         }
         // Note: caller_fn name registration moved out of `TypeRegistry`
         // — `body::CallerFnCollector` lazy-registers names during
@@ -784,13 +780,7 @@ impl TypeRegistry {
         // its bytes as a passive segment so the emitter has an idx
         // to pull at struct.new time, regardless of whether user
         // source ever spells the literal.
-        let int_mod_used = items.iter().any(|item| {
-            if let TopLevel::FnDef(fd) = item {
-                fn_body_calls_int_mod(fd)
-            } else {
-                false
-            }
-        });
+        let int_mod_used = resolved_fn_defs.iter().any(fn_body_calls_int_mod);
         if int_mod_used {
             let bytes = b"Division by zero".to_vec();
             string_literal_idx.entry(bytes.clone()).or_insert_with(|| {
@@ -1225,29 +1215,22 @@ pub(super) fn parse_map_kv(canonical: &str) -> Option<(&str, &str)> {
 /// via a literal, an interpolation, or a String-producing builtin.
 /// Used by `TypeRegistry::build` to decide whether to allocate the
 /// `(array i8)` slot.
-fn fn_body_produces_string(fd: &crate::ast::FnDef) -> bool {
-    use crate::ast::{FnBody, Stmt};
-    let FnBody::Block(stmts) = fd.body.as_ref();
+fn fn_body_produces_string(fd: &crate::ir::hir::ResolvedFnDef) -> bool {
+    use crate::ir::hir::{ResolvedFnBody, ResolvedStmt};
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     stmts.iter().any(|s| match s {
-        Stmt::Binding(_, _, e) | Stmt::Expr(e) => expr_uses_string(&e.node),
+        ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => expr_uses_string(&e.node),
     })
 }
 
-fn expr_uses_string(expr: &crate::ast::Expr) -> bool {
-    use crate::ast::Expr;
+fn expr_uses_string(expr: &crate::ir::hir::ResolvedExpr) -> bool {
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr};
     match expr {
-        Expr::FnCall(callee, args) => {
-            if let Expr::Attr(parent, member) = &callee.node {
-                let parent_name = match &parent.node {
-                    Expr::Ident(n) => Some(n.as_str()),
-                    Expr::Resolved { name, .. } => Some(name.as_str()),
-                    _ => None,
-                };
-                if let Some(p) = parent_name {
-                    let dotted = format!("{p}.{member}");
-                    if matches!(
-                        dotted.as_str(),
-                        "String.fromInt"
+        ResolvedExpr::Call(callee, args) => {
+            if let ResolvedCallee::Builtin(dotted) = callee
+                && matches!(
+                    dotted.as_str(),
+                    "String.fromInt"
                             | "String.fromFloat"
                             | "String.len"
                             | "String.length"
@@ -1309,29 +1292,28 @@ fn expr_uses_string(expr: &crate::ast::Expr) -> bool {
                             | "Terminal.print"
                             | "Terminal.setColor"
                             | "Terminal.readKey"
-                    ) {
-                        return true;
-                    }
-                }
+                )
+            {
+                return true;
             }
-            expr_uses_string(&callee.node) || args.iter().any(|a| expr_uses_string(&a.node))
+            args.iter().any(|a| expr_uses_string(&a.node))
         }
-        Expr::BinOp(_, l, r) => expr_uses_string(&l.node) || expr_uses_string(&r.node),
-        Expr::Neg(inner) => expr_uses_string(&inner.node),
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::BinOp(_, l, r) => expr_uses_string(&l.node) || expr_uses_string(&r.node),
+        ResolvedExpr::Neg(inner) => expr_uses_string(&inner.node),
+        ResolvedExpr::Match { subject, arms } => {
             expr_uses_string(&subject.node) || arms.iter().any(|a| expr_uses_string(&a.body.node))
         }
-        Expr::TailCall(boxed) => boxed.args.iter().any(|a| expr_uses_string(&a.node)),
-        Expr::Attr(obj, _) => expr_uses_string(&obj.node),
-        Expr::Constructor(_, payload) => payload
-            .as_deref()
-            .is_some_and(|p| expr_uses_string(&p.node)),
-        Expr::RecordCreate { fields, .. } => fields.iter().any(|(_, e)| expr_uses_string(&e.node)),
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::TailCall { args, .. } => args.iter().any(|a| expr_uses_string(&a.node)),
+        ResolvedExpr::Attr(obj, _) => expr_uses_string(&obj.node),
+        ResolvedExpr::Ctor(_, args) => args.iter().any(|a| expr_uses_string(&a.node)),
+        ResolvedExpr::RecordCreate { fields, .. } => {
+            fields.iter().any(|(_, e)| expr_uses_string(&e.node))
+        }
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             expr_uses_string(&base.node) || updates.iter().any(|(_, e)| expr_uses_string(&e.node))
         }
-        Expr::Literal(crate::ast::Literal::Str(_)) => true,
-        Expr::InterpolatedStr(_) => true,
+        ResolvedExpr::Literal(crate::ast::Literal::Str(_)) => true,
+        ResolvedExpr::InterpolatedStr(_) => true,
         _ => false,
     }
 }
@@ -1340,55 +1322,49 @@ fn expr_uses_string(expr: &crate::ast::Expr) -> bool {
 /// table. Both `Literal::Str` and the `Literal` parts of an
 /// `InterpolatedStr` count — each unique byte sequence gets a passive
 /// data segment.
-fn fn_body_calls_int_mod(fd: &crate::ast::FnDef) -> bool {
-    use crate::ast::{Expr, FnBody, Stmt};
-    fn walk(e: &Expr) -> bool {
+fn fn_body_calls_int_mod(fd: &crate::ir::hir::ResolvedFnDef) -> bool {
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr, ResolvedFnBody, ResolvedStmt};
+    fn walk(e: &ResolvedExpr) -> bool {
         match e {
-            Expr::FnCall(callee, args) => {
-                let hit = if let Expr::Attr(parent, member) = &callee.node
-                    && let Expr::Ident(p) = &parent.node
-                {
-                    p == "Int" && member == "mod"
-                } else {
-                    false
-                };
-                hit || walk(&callee.node) || args.iter().any(|a| walk(&a.node))
+            ResolvedExpr::Call(callee, args) => {
+                let hit = matches!(callee, ResolvedCallee::Builtin(name) if name == "Int.mod");
+                hit || args.iter().any(|a| walk(&a.node))
             }
-            Expr::Match { subject, arms } => {
+            ResolvedExpr::Match { subject, arms } => {
                 walk(&subject.node) || arms.iter().any(|a| walk(&a.body.node))
             }
-            Expr::BinOp(_, l, r) => walk(&l.node) || walk(&r.node),
-            Expr::Neg(inner) => walk(&inner.node),
-            Expr::Attr(o, _) => walk(&o.node),
-            Expr::ErrorProp(i) => walk(&i.node),
-            Expr::TailCall(b) => b.args.iter().any(|a| walk(&a.node)),
-            Expr::List(xs) | Expr::Tuple(xs) | Expr::IndependentProduct(xs, _) => {
-                xs.iter().any(|x| walk(&x.node))
-            }
-            Expr::RecordCreate { fields, .. } => fields.iter().any(|(_, e)| walk(&e.node)),
-            Expr::RecordUpdate { base, updates, .. } => {
+            ResolvedExpr::BinOp(_, l, r) => walk(&l.node) || walk(&r.node),
+            ResolvedExpr::Neg(inner) => walk(&inner.node),
+            ResolvedExpr::Attr(o, _) => walk(&o.node),
+            ResolvedExpr::ErrorProp(i) => walk(&i.node),
+            ResolvedExpr::TailCall { args, .. } => args.iter().any(|a| walk(&a.node)),
+            ResolvedExpr::List(xs)
+            | ResolvedExpr::Tuple(xs)
+            | ResolvedExpr::IndependentProduct(xs, _) => xs.iter().any(|x| walk(&x.node)),
+            ResolvedExpr::RecordCreate { fields, .. } => fields.iter().any(|(_, e)| walk(&e.node)),
+            ResolvedExpr::RecordUpdate { base, updates, .. } => {
                 walk(&base.node) || updates.iter().any(|(_, e)| walk(&e.node))
             }
-            Expr::Constructor(_, p) => p.as_deref().is_some_and(|x| walk(&x.node)),
+            ResolvedExpr::Ctor(_, args) => args.iter().any(|a| walk(&a.node)),
             _ => false,
         }
     }
-    let FnBody::Block(stmts) = fd.body.as_ref();
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     stmts.iter().any(|stmt| match stmt {
-        Stmt::Binding(_, _, e) | Stmt::Expr(e) => walk(&e.node),
+        ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => walk(&e.node),
     })
 }
 
 fn collect_string_literals_in_fn(
-    fd: &crate::ast::FnDef,
+    fd: &crate::ir::hir::ResolvedFnDef,
     out: &mut Vec<Vec<u8>>,
     idx: &mut HashMap<Vec<u8>, u32>,
 ) {
-    use crate::ast::{FnBody, Stmt};
-    let FnBody::Block(stmts) = fd.body.as_ref();
+    use crate::ir::hir::{ResolvedFnBody, ResolvedStmt};
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     for stmt in stmts {
         let expr = match stmt {
-            Stmt::Binding(_, _, e) | Stmt::Expr(e) => &e.node,
+            ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => &e.node,
         };
         collect_string_literals_in_expr(expr, out, idx);
     }
@@ -1403,77 +1379,77 @@ fn intern_literal(bytes: Vec<u8>, out: &mut Vec<Vec<u8>>, idx: &mut HashMap<Vec<
 }
 
 fn collect_string_literals_in_expr(
-    expr: &crate::ast::Expr,
+    expr: &crate::ir::hir::ResolvedExpr,
     out: &mut Vec<Vec<u8>>,
     idx: &mut HashMap<Vec<u8>, u32>,
 ) {
-    use crate::ast::{Expr, Literal, StrPart};
+    use crate::ast::Literal;
+    use crate::ir::hir::{ResolvedExpr, ResolvedStrPart};
     match expr {
-        Expr::Literal(Literal::Str(s)) => intern_literal(s.as_bytes().to_vec(), out, idx),
-        Expr::InterpolatedStr(parts) => {
+        ResolvedExpr::Literal(Literal::Str(s)) => intern_literal(s.as_bytes().to_vec(), out, idx),
+        ResolvedExpr::InterpolatedStr(parts) => {
             for p in parts {
                 match p {
-                    StrPart::Literal(s) => intern_literal(s.as_bytes().to_vec(), out, idx),
-                    StrPart::Parsed(inner) => {
+                    ResolvedStrPart::Literal(s) => intern_literal(s.as_bytes().to_vec(), out, idx),
+                    ResolvedStrPart::Parsed(inner) => {
                         collect_string_literals_in_expr(&inner.node, out, idx);
                     }
                 }
             }
         }
-        Expr::FnCall(callee, args) => {
-            collect_string_literals_in_expr(&callee.node, out, idx);
+        ResolvedExpr::Call(_, args) => {
             for a in args {
                 collect_string_literals_in_expr(&a.node, out, idx);
             }
         }
-        Expr::BinOp(_, l, r) => {
+        ResolvedExpr::BinOp(_, l, r) => {
             collect_string_literals_in_expr(&l.node, out, idx);
             collect_string_literals_in_expr(&r.node, out, idx);
         }
-        Expr::Neg(inner) => collect_string_literals_in_expr(&inner.node, out, idx),
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::Neg(inner) => collect_string_literals_in_expr(&inner.node, out, idx),
+        ResolvedExpr::Match { subject, arms } => {
             collect_string_literals_in_expr(&subject.node, out, idx);
             for a in arms {
-                if let crate::ast::Pattern::Literal(Literal::Str(s)) = &a.pattern {
+                if let crate::ir::hir::ResolvedPattern::Literal(Literal::Str(s)) = &a.pattern {
                     intern_literal(s.as_bytes().to_vec(), out, idx);
                 }
                 collect_string_literals_in_expr(&a.body.node, out, idx);
             }
         }
-        Expr::TailCall(boxed) => {
-            for a in &boxed.args {
+        ResolvedExpr::TailCall { args, .. } => {
+            for a in args {
                 collect_string_literals_in_expr(&a.node, out, idx);
             }
         }
-        Expr::Attr(obj, _) => collect_string_literals_in_expr(&obj.node, out, idx),
-        Expr::ErrorProp(inner) => collect_string_literals_in_expr(&inner.node, out, idx),
-        Expr::Constructor(_, payload) => {
-            if let Some(p) = payload.as_deref() {
-                collect_string_literals_in_expr(&p.node, out, idx);
+        ResolvedExpr::Attr(obj, _) => collect_string_literals_in_expr(&obj.node, out, idx),
+        ResolvedExpr::ErrorProp(inner) => collect_string_literals_in_expr(&inner.node, out, idx),
+        ResolvedExpr::Ctor(_, args) => {
+            for a in args {
+                collect_string_literals_in_expr(&a.node, out, idx);
             }
         }
-        Expr::RecordCreate { fields, .. } => {
+        ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, e) in fields {
                 collect_string_literals_in_expr(&e.node, out, idx);
             }
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             collect_string_literals_in_expr(&base.node, out, idx);
             for (_, e) in updates {
                 collect_string_literals_in_expr(&e.node, out, idx);
             }
         }
-        Expr::List(items) => {
+        ResolvedExpr::List(items) => {
             for item in items {
                 collect_string_literals_in_expr(&item.node, out, idx);
             }
         }
-        Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+        ResolvedExpr::Tuple(items) | ResolvedExpr::IndependentProduct(items, _) => {
             for item in items {
                 collect_string_literals_in_expr(&item.node, out, idx);
             }
         }
-        Expr::MapLiteral(entries) => {
+        ResolvedExpr::MapLiteral(entries) => {
             for (k, v) in entries {
                 collect_string_literals_in_expr(&k.node, out, idx);
                 collect_string_literals_in_expr(&v.node, out, idx);
@@ -1846,99 +1822,96 @@ fn effect_implies_builtin_record(effect: &str, record_name: &str) -> bool {
 /// expressions to catch builtin calls like `String.chars` whose
 /// return type (`List<String>`) only appears as a stdlib signature.
 fn collect_lists_from_fn_body(
-    fd: &crate::ast::FnDef,
+    fd: &crate::ir::hir::ResolvedFnDef,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ast::{FnBody, Stmt};
-    let FnBody::Block(stmts) = fd.body.as_ref();
+    use crate::ir::hir::{ResolvedFnBody, ResolvedStmt};
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     for stmt in stmts {
-        if let Stmt::Binding(_, Some(annot), _) = stmt {
-            collect_lists_from_str(annot, out, order, next_idx);
+        if let ResolvedStmt::Binding {
+            ty_ann: Some(annot),
+            ..
+        } = stmt
+        {
+            collect_lists_from_str(&annot.display(), out, order, next_idx);
         }
         let expr = match stmt {
-            Stmt::Binding(_, _, e) | Stmt::Expr(e) => &e.node,
+            ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => &e.node,
         };
         collect_lists_from_expr(expr, out, order, next_idx);
     }
 }
 
 fn collect_lists_from_expr(
-    expr: &crate::ast::Expr,
+    expr: &crate::ir::hir::ResolvedExpr,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ast::Expr;
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr};
     match expr {
-        Expr::FnCall(callee, args) => {
+        ResolvedExpr::Call(callee, args) => {
             // `String.chars(s)` returns `List<String>` — register it
             // eagerly here since the canonical never appears in fn
             // signatures by itself.
-            if let Expr::Attr(parent, member) = &callee.node {
-                let parent_name = match &parent.node {
-                    Expr::Ident(n) => Some(n.as_str()),
-                    Expr::Resolved { name, .. } => Some(name.as_str()),
-                    _ => None,
-                };
-                if let Some(p) = parent_name {
-                    let dotted = format!("{p}.{member}");
-                    if dotted == "String.chars" {
-                        let canonical = "List<String>".to_string();
-                        if !out.contains_key(&canonical) {
-                            out.insert(canonical.clone(), *next_idx);
-                            order.push(canonical);
-                            *next_idx += 1;
-                        }
-                    }
+            if let ResolvedCallee::Builtin(name) = callee
+                && name == "String.chars"
+            {
+                let canonical = "List<String>".to_string();
+                if !out.contains_key(&canonical) {
+                    out.insert(canonical.clone(), *next_idx);
+                    order.push(canonical);
+                    *next_idx += 1;
                 }
             }
-            collect_lists_from_expr(&callee.node, out, order, next_idx);
             for a in args {
                 collect_lists_from_expr(&a.node, out, order, next_idx);
             }
         }
-        Expr::BinOp(_, l, r) => {
+        ResolvedExpr::BinOp(_, l, r) => {
             collect_lists_from_expr(&l.node, out, order, next_idx);
             collect_lists_from_expr(&r.node, out, order, next_idx);
         }
-        Expr::Neg(inner) => collect_lists_from_expr(&inner.node, out, order, next_idx),
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::Neg(inner) => collect_lists_from_expr(&inner.node, out, order, next_idx),
+        ResolvedExpr::Match { subject, arms } => {
             collect_lists_from_expr(&subject.node, out, order, next_idx);
             for arm in arms {
                 collect_lists_from_expr(&arm.body.node, out, order, next_idx);
             }
         }
-        Expr::TailCall(boxed) => {
-            for a in &boxed.args {
+        ResolvedExpr::TailCall { args, .. } => {
+            for a in args {
                 collect_lists_from_expr(&a.node, out, order, next_idx);
             }
         }
-        Expr::Attr(obj, _) => collect_lists_from_expr(&obj.node, out, order, next_idx),
-        Expr::RecordCreate { fields, .. } => {
+        ResolvedExpr::Attr(obj, _) => collect_lists_from_expr(&obj.node, out, order, next_idx),
+        ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, e) in fields {
                 collect_lists_from_expr(&e.node, out, order, next_idx);
             }
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             collect_lists_from_expr(&base.node, out, order, next_idx);
             for (_, e) in updates {
                 collect_lists_from_expr(&e.node, out, order, next_idx);
             }
         }
-        Expr::Constructor(_, payload) => {
-            if let Some(p) = payload.as_deref() {
-                collect_lists_from_expr(&p.node, out, order, next_idx);
+        ResolvedExpr::Ctor(_, args) => {
+            for a in args {
+                collect_lists_from_expr(&a.node, out, order, next_idx);
             }
         }
-        Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+        ResolvedExpr::Tuple(items) | ResolvedExpr::IndependentProduct(items, _) => {
             for it in items {
                 collect_lists_from_expr(&it.node, out, order, next_idx);
             }
         }
-        Expr::ErrorProp(inner) => collect_lists_from_expr(&inner.node, out, order, next_idx),
-        Expr::List(items) => {
+        ResolvedExpr::ErrorProp(inner) => {
+            collect_lists_from_expr(&inner.node, out, order, next_idx)
+        }
+        ResolvedExpr::List(items) => {
             for x in items {
                 collect_lists_from_expr(&x.node, out, order, next_idx);
             }

--- a/src/codegen/wasm_gc/types_discovery.rs
+++ b/src/codegen/wasm_gc/types_discovery.rs
@@ -86,13 +86,18 @@ pub(super) fn collect_vectors_from_str(
 /// targets the curated set the bench scenarios use; broader auto-
 /// discovery would mean reading `types::checker::builtins` directly.
 pub(super) fn collect_results_from_builtin_uses(
-    fd: &crate::ast::FnDef,
+    fd: &crate::ir::hir::ResolvedFnDef,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ast::{Expr, FnBody, Stmt};
-    fn walk(e: &Expr, out: &mut HashMap<String, u32>, order: &mut Vec<String>, next_idx: &mut u32) {
+    use crate::ir::hir::{ResolvedExpr, ResolvedFnBody, ResolvedStmt};
+    fn walk(
+        e: &ResolvedExpr,
+        out: &mut HashMap<String, u32>,
+        order: &mut Vec<String>,
+        next_idx: &mut u32,
+    ) {
         let mut intern = |canonical: &str| {
             if !out.contains_key(canonical) {
                 out.insert(canonical.to_string(), *next_idx);
@@ -101,11 +106,8 @@ pub(super) fn collect_results_from_builtin_uses(
             }
         };
         match e {
-            Expr::FnCall(callee, args) => {
-                if let Expr::Attr(parent, member) = &callee.node
-                    && let Expr::Ident(p) = &parent.node
-                {
-                    let dotted = format!("{}.{}", p, member);
+            ResolvedExpr::Call(callee, args) => {
+                if let crate::ir::hir::ResolvedCallee::Builtin(dotted) = callee {
                     match dotted.as_str() {
                         "Float.fromString" => intern("Result<Float,String>"),
                         "Int.fromString" | "Int.mod" | "Byte.fromHex" => {
@@ -135,46 +137,45 @@ pub(super) fn collect_results_from_builtin_uses(
                         _ => {}
                     }
                 }
-                walk(&callee.node, out, order, next_idx);
                 for a in args {
                     walk(&a.node, out, order, next_idx);
                 }
             }
-            Expr::BinOp(_, l, r) => {
+            ResolvedExpr::BinOp(_, l, r) => {
                 walk(&l.node, out, order, next_idx);
                 walk(&r.node, out, order, next_idx);
             }
-            Expr::Neg(inner) => walk(&inner.node, out, order, next_idx),
-            Expr::Match { subject, arms } => {
+            ResolvedExpr::Neg(inner) => walk(&inner.node, out, order, next_idx),
+            ResolvedExpr::Match { subject, arms } => {
                 walk(&subject.node, out, order, next_idx);
                 for arm in arms {
                     walk(&arm.body.node, out, order, next_idx);
                 }
             }
-            Expr::TailCall(boxed) => {
-                for a in &boxed.args {
+            ResolvedExpr::TailCall { args, .. } => {
+                for a in args {
                     walk(&a.node, out, order, next_idx);
                 }
             }
-            Expr::Attr(obj, _) => walk(&obj.node, out, order, next_idx),
-            Expr::ErrorProp(inner) => walk(&inner.node, out, order, next_idx),
-            Expr::Constructor(_, payload) => {
-                if let Some(p) = payload.as_deref() {
-                    walk(&p.node, out, order, next_idx);
+            ResolvedExpr::Attr(obj, _) => walk(&obj.node, out, order, next_idx),
+            ResolvedExpr::ErrorProp(inner) => walk(&inner.node, out, order, next_idx),
+            ResolvedExpr::Ctor(_, args) => {
+                for a in args {
+                    walk(&a.node, out, order, next_idx);
                 }
             }
-            Expr::RecordCreate { fields, .. } => {
+            ResolvedExpr::RecordCreate { fields, .. } => {
                 for (_, e) in fields {
                     walk(&e.node, out, order, next_idx);
                 }
             }
-            Expr::RecordUpdate { base, updates, .. } => {
+            ResolvedExpr::RecordUpdate { base, updates, .. } => {
                 walk(&base.node, out, order, next_idx);
                 for (_, e) in updates {
                     walk(&e.node, out, order, next_idx);
                 }
             }
-            Expr::List(items) => {
+            ResolvedExpr::List(items) => {
                 for x in items {
                     walk(&x.node, out, order, next_idx);
                 }
@@ -182,10 +183,10 @@ pub(super) fn collect_results_from_builtin_uses(
             _ => {}
         }
     }
-    let FnBody::Block(stmts) = fd.body.as_ref();
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     for stmt in stmts {
         let expr = match stmt {
-            Stmt::Binding(_, _, e) | Stmt::Expr(e) => &e.node,
+            ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => &e.node,
         };
         walk(expr, out, order, next_idx);
     }
@@ -270,49 +271,55 @@ pub(super) fn collect_tuples_from_str(
     }
 }
 
-/// Walk a fn body for `Expr::Tuple` literals — register each unique
+/// Walk a fn body for `ResolvedExpr::Tuple` literals — register each unique
 /// `Tuple<A,B>` derived from the items' stamped types. Mirrors the
 /// body walks already done for `List`/`Option`/`Vector` discovery.
 pub(super) fn collect_tuples_from_fn_body(
-    fd: &crate::ast::FnDef,
+    fd: &crate::ir::hir::ResolvedFnDef,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ast::{FnBody, Stmt};
-    let FnBody::Block(stmts) = fd.body.as_ref();
+    use crate::ir::hir::{ResolvedFnBody, ResolvedStmt};
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     for stmt in stmts {
-        if let Stmt::Binding(_, Some(annot), _) = stmt {
-            collect_tuples_from_str(annot, out, order, next_idx);
+        if let ResolvedStmt::Binding {
+            ty_ann: Some(annot),
+            ..
+        } = stmt
+        {
+            collect_tuples_from_str(&annot.display(), out, order, next_idx);
         }
         let expr = match stmt {
-            Stmt::Binding(_, _, e) | Stmt::Expr(e) => e,
+            ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => e,
         };
         collect_tuples_from_expr(expr, out, order, next_idx);
     }
 }
 
 pub(super) fn collect_tuples_from_expr(
-    expr: &crate::ast::Spanned<crate::ast::Expr>,
+    expr: &crate::ast::Spanned<crate::ir::hir::ResolvedExpr>,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ast::Expr;
+    use crate::ir::hir::ResolvedExpr;
     // Register the canonical for this node first if it's a tuple
     // literal — derived from the items' stamped types so nested
     // `(a, (b, c))` registers both inner and outer canonicals.
-    // `Expr::IndependentProduct` (the `(...)!` form) lowers as a
+    // `ResolvedExpr::IndependentProduct` (the `(...)!` form) lowers as a
     // tuple under wasm-gc and shares the same canonical shape.
     // `(...)?!` (unwrap=true) is a tuple of unwrapped Ok types —
     // strip the Result<_,_> wrapper from each stamped element type
     // before building the canonical.
-    let tuple_items_with_unwrap: Option<(&Vec<crate::ast::Spanned<crate::ast::Expr>>, bool)> =
-        match &expr.node {
-            Expr::Tuple(xs) => Some((xs, false)),
-            Expr::IndependentProduct(xs, unwrap) => Some((xs, *unwrap)),
-            _ => None,
-        };
+    let tuple_items_with_unwrap: Option<(
+        &Vec<crate::ast::Spanned<crate::ir::hir::ResolvedExpr>>,
+        bool,
+    )> = match &expr.node {
+        ResolvedExpr::Tuple(xs) => Some((xs, false)),
+        ResolvedExpr::IndependentProduct(xs, unwrap) => Some((xs, *unwrap)),
+        _ => None,
+    };
     if let Some((items, unwrap)) = tuple_items_with_unwrap
         && items.len() >= 2
     {
@@ -353,57 +360,56 @@ pub(super) fn collect_tuples_from_expr(
     }
     // Recurse into sub-expressions.
     match &expr.node {
-        Expr::FnCall(callee, args) => {
-            collect_tuples_from_expr(callee, out, order, next_idx);
+        ResolvedExpr::Call(_, args) => {
             for a in args {
                 collect_tuples_from_expr(a, out, order, next_idx);
             }
         }
-        Expr::BinOp(_, l, r) => {
+        ResolvedExpr::BinOp(_, l, r) => {
             collect_tuples_from_expr(l, out, order, next_idx);
             collect_tuples_from_expr(r, out, order, next_idx);
         }
-        Expr::Neg(inner) => collect_tuples_from_expr(inner, out, order, next_idx),
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::Neg(inner) => collect_tuples_from_expr(inner, out, order, next_idx),
+        ResolvedExpr::Match { subject, arms } => {
             collect_tuples_from_expr(subject, out, order, next_idx);
             for arm in arms {
                 collect_tuples_from_expr(&arm.body, out, order, next_idx);
             }
         }
-        Expr::TailCall(boxed) => {
-            for a in &boxed.args {
+        ResolvedExpr::TailCall { args, .. } => {
+            for a in args {
                 collect_tuples_from_expr(a, out, order, next_idx);
             }
         }
-        Expr::Attr(obj, _) => collect_tuples_from_expr(obj, out, order, next_idx),
-        Expr::ErrorProp(inner) => collect_tuples_from_expr(inner, out, order, next_idx),
-        Expr::Constructor(_, payload) => {
-            if let Some(p) = payload.as_deref() {
-                collect_tuples_from_expr(p, out, order, next_idx);
+        ResolvedExpr::Attr(obj, _) => collect_tuples_from_expr(obj, out, order, next_idx),
+        ResolvedExpr::ErrorProp(inner) => collect_tuples_from_expr(inner, out, order, next_idx),
+        ResolvedExpr::Ctor(_, args) => {
+            for a in args {
+                collect_tuples_from_expr(a, out, order, next_idx);
             }
         }
-        Expr::RecordCreate { fields, .. } => {
+        ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, e) in fields {
                 collect_tuples_from_expr(e, out, order, next_idx);
             }
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             collect_tuples_from_expr(base, out, order, next_idx);
             for (_, e) in updates {
                 collect_tuples_from_expr(e, out, order, next_idx);
             }
         }
-        Expr::List(items) => {
+        ResolvedExpr::List(items) => {
             for x in items {
                 collect_tuples_from_expr(x, out, order, next_idx);
             }
         }
-        Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+        ResolvedExpr::Tuple(items) | ResolvedExpr::IndependentProduct(items, _) => {
             for x in items {
                 collect_tuples_from_expr(x, out, order, next_idx);
             }
         }
-        Expr::MapLiteral(entries) => {
+        ResolvedExpr::MapLiteral(entries) => {
             for (k, v) in entries {
                 collect_tuples_from_expr(k, out, order, next_idx);
                 collect_tuples_from_expr(v, out, order, next_idx);
@@ -555,102 +561,99 @@ pub(super) fn collect_options_from_str(
 /// `Option<V>` where V is read off `Map<K,V>` — so the body walk is
 /// the primary discovery path.
 pub(super) fn collect_options_from_fn_body(
-    fd: &crate::ast::FnDef,
+    fd: &crate::ir::hir::ResolvedFnDef,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ast::{FnBody, Stmt};
-    let FnBody::Block(stmts) = fd.body.as_ref();
+    use crate::ir::hir::{ResolvedFnBody, ResolvedStmt};
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     for stmt in stmts {
-        if let Stmt::Binding(_, Some(annot), _) = stmt {
-            collect_options_from_str(annot, out, order, next_idx);
+        if let ResolvedStmt::Binding {
+            ty_ann: Some(annot),
+            ..
+        } = stmt
+        {
+            collect_options_from_str(&annot.display(), out, order, next_idx);
         }
         let expr = match stmt {
-            Stmt::Binding(_, _, e) | Stmt::Expr(e) => &e.node,
+            ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => &e.node,
         };
         collect_options_from_expr(expr, out, order, next_idx);
     }
 }
 
 pub(super) fn collect_options_from_expr(
-    expr: &crate::ast::Expr,
+    expr: &crate::ir::hir::ResolvedExpr,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ast::Expr;
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr};
     match expr {
-        Expr::FnCall(callee, args) => {
+        ResolvedExpr::Call(callee, args) => {
             // `String.charAt(s, i)` and `Char.fromCode(code)` both
             // declare `Option<String>` as their return type, but the
             // canonical never appears anywhere else — eager-register
             // it here so the builtin's emit can resolve the slot.
-            if let Expr::Attr(parent, member) = &callee.node {
-                let parent_name = match &parent.node {
-                    Expr::Ident(n) => Some(n.as_str()),
-                    Expr::Resolved { name, .. } => Some(name.as_str()),
-                    _ => None,
-                };
-                if let Some(p) = parent_name {
-                    let dotted = format!("{p}.{member}");
-                    if matches!(
-                        dotted.as_str(),
-                        "String.charAt" | "Char.fromCode" | "Terminal.readKey" | "Env.get"
-                    ) {
-                        let canonical = "Option<String>".to_string();
-                        if !out.contains_key(&canonical) {
-                            out.insert(canonical.clone(), *next_idx);
-                            order.push(canonical);
-                            *next_idx += 1;
-                        }
-                    }
+            if let ResolvedCallee::Builtin(dotted) = callee
+                && matches!(
+                    dotted.as_str(),
+                    "String.charAt" | "Char.fromCode" | "Terminal.readKey" | "Env.get"
+                )
+            {
+                let canonical = "Option<String>".to_string();
+                if !out.contains_key(&canonical) {
+                    out.insert(canonical.clone(), *next_idx);
+                    order.push(canonical);
+                    *next_idx += 1;
                 }
             }
-            collect_options_from_expr(&callee.node, out, order, next_idx);
             for a in args {
                 collect_options_from_expr(&a.node, out, order, next_idx);
             }
         }
-        Expr::BinOp(_, l, r) => {
+        ResolvedExpr::BinOp(_, l, r) => {
             collect_options_from_expr(&l.node, out, order, next_idx);
             collect_options_from_expr(&r.node, out, order, next_idx);
         }
-        Expr::Neg(inner) => collect_options_from_expr(&inner.node, out, order, next_idx),
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::Neg(inner) => collect_options_from_expr(&inner.node, out, order, next_idx),
+        ResolvedExpr::Match { subject, arms } => {
             collect_options_from_expr(&subject.node, out, order, next_idx);
             for arm in arms {
                 collect_options_from_expr(&arm.body.node, out, order, next_idx);
             }
         }
-        Expr::TailCall(boxed) => {
-            for a in &boxed.args {
+        ResolvedExpr::TailCall { args, .. } => {
+            for a in args {
                 collect_options_from_expr(&a.node, out, order, next_idx);
             }
         }
-        Expr::Attr(obj, _) => collect_options_from_expr(&obj.node, out, order, next_idx),
-        Expr::RecordCreate { fields, .. } => {
+        ResolvedExpr::Attr(obj, _) => collect_options_from_expr(&obj.node, out, order, next_idx),
+        ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, e) in fields {
                 collect_options_from_expr(&e.node, out, order, next_idx);
             }
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             collect_options_from_expr(&base.node, out, order, next_idx);
             for (_, e) in updates {
                 collect_options_from_expr(&e.node, out, order, next_idx);
             }
         }
-        Expr::Constructor(_, payload) => {
-            if let Some(p) = payload.as_deref() {
-                collect_options_from_expr(&p.node, out, order, next_idx);
+        ResolvedExpr::Ctor(_, args) => {
+            for a in args {
+                collect_options_from_expr(&a.node, out, order, next_idx);
             }
         }
-        Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+        ResolvedExpr::Tuple(items) | ResolvedExpr::IndependentProduct(items, _) => {
             for it in items {
                 collect_options_from_expr(&it.node, out, order, next_idx);
             }
         }
-        Expr::ErrorProp(inner) => collect_options_from_expr(&inner.node, out, order, next_idx),
+        ResolvedExpr::ErrorProp(inner) => {
+            collect_options_from_expr(&inner.node, out, order, next_idx)
+        }
         _ => {}
     }
 }
@@ -662,33 +665,37 @@ pub(super) fn collect_options_from_expr(
 /// bench spells out `Vector<Int>` in fn signatures so this body walk
 /// is a defensive backstop, not the primary discovery path.
 pub(super) fn collect_vectors_from_fn_body(
-    fd: &crate::ast::FnDef,
+    fd: &crate::ir::hir::ResolvedFnDef,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ast::{FnBody, Stmt};
-    let FnBody::Block(stmts) = fd.body.as_ref();
+    use crate::ir::hir::{ResolvedFnBody, ResolvedStmt};
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     for stmt in stmts {
-        if let Stmt::Binding(_, Some(annot), _) = stmt {
-            collect_vectors_from_str(annot, out, order, next_idx);
+        if let ResolvedStmt::Binding {
+            ty_ann: Some(annot),
+            ..
+        } = stmt
+        {
+            collect_vectors_from_str(&annot.display(), out, order, next_idx);
         }
         let expr = match stmt {
-            Stmt::Binding(_, _, e) | Stmt::Expr(e) => &e.node,
+            ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => &e.node,
         };
         collect_vectors_from_expr(expr, out, order, next_idx);
     }
 }
 
 pub(super) fn collect_vectors_from_expr(
-    expr: &crate::ast::Expr,
+    expr: &crate::ir::hir::ResolvedExpr,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ast::{Expr, StrPart};
+    use crate::ir::hir::{ResolvedExpr, ResolvedStrPart};
     match expr {
-        Expr::FnCall(callee, args) => {
+        ResolvedExpr::Call(callee, args) => {
             // `Vector.new(n, fill)` instantiates `Vector<T>` where `T` is
             // the *type* of the fill arg — and crucially, that may itself
             // be a Vector (`Vector.new(3, inner_vec)` produces
@@ -698,22 +705,19 @@ pub(super) fn collect_vectors_from_expr(
             // no slot, codegen errors with "instantiation `Vector<…>`
             // was not registered". Mirrors the InterpolatedStr / `+`
             // branches that pre-register `Vector<String>` from a stamp.
-            if let Expr::Attr(parent, member) = &callee.node
-                && member == "new"
-                && let Expr::Ident(p) = &parent.node
-                && p == "Vector"
+            if let crate::ir::hir::ResolvedCallee::Builtin(name) = callee
+                && name == "Vector.new"
                 && args.len() == 2
                 && let Some(fill_ty) = args[1].ty()
             {
                 let canonical = format!("Vector<{}>", fill_ty.display());
                 collect_vectors_from_str(&canonical, out, order, next_idx);
             }
-            collect_vectors_from_expr(&callee.node, out, order, next_idx);
             for a in args {
                 collect_vectors_from_expr(&a.node, out, order, next_idx);
             }
         }
-        Expr::BinOp(op, l, r) => {
+        ResolvedExpr::BinOp(op, l, r) => {
             // String `+` lowers to `__wasmgc_concat_n`, which takes a
             // `Vector<String>` (array of String refs). Register that
             // canonical eagerly when we see the operator on String
@@ -726,42 +730,44 @@ pub(super) fn collect_vectors_from_expr(
             collect_vectors_from_expr(&l.node, out, order, next_idx);
             collect_vectors_from_expr(&r.node, out, order, next_idx);
         }
-        Expr::Neg(inner) => collect_vectors_from_expr(&inner.node, out, order, next_idx),
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::Neg(inner) => collect_vectors_from_expr(&inner.node, out, order, next_idx),
+        ResolvedExpr::Match { subject, arms } => {
             collect_vectors_from_expr(&subject.node, out, order, next_idx);
             for arm in arms {
                 collect_vectors_from_expr(&arm.body.node, out, order, next_idx);
             }
         }
-        Expr::TailCall(boxed) => {
-            for a in &boxed.args {
+        ResolvedExpr::TailCall { args, .. } => {
+            for a in args {
                 collect_vectors_from_expr(&a.node, out, order, next_idx);
             }
         }
-        Expr::Attr(obj, _) => collect_vectors_from_expr(&obj.node, out, order, next_idx),
-        Expr::RecordCreate { fields, .. } => {
+        ResolvedExpr::Attr(obj, _) => collect_vectors_from_expr(&obj.node, out, order, next_idx),
+        ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, e) in fields {
                 collect_vectors_from_expr(&e.node, out, order, next_idx);
             }
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             collect_vectors_from_expr(&base.node, out, order, next_idx);
             for (_, e) in updates {
                 collect_vectors_from_expr(&e.node, out, order, next_idx);
             }
         }
-        Expr::Constructor(_, payload) => {
-            if let Some(p) = payload.as_deref() {
-                collect_vectors_from_expr(&p.node, out, order, next_idx);
+        ResolvedExpr::Ctor(_, args) => {
+            for a in args {
+                collect_vectors_from_expr(&a.node, out, order, next_idx);
             }
         }
-        Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+        ResolvedExpr::Tuple(items) | ResolvedExpr::IndependentProduct(items, _) => {
             for it in items {
                 collect_vectors_from_expr(&it.node, out, order, next_idx);
             }
         }
-        Expr::ErrorProp(inner) => collect_vectors_from_expr(&inner.node, out, order, next_idx),
-        Expr::InterpolatedStr(parts) => {
+        ResolvedExpr::ErrorProp(inner) => {
+            collect_vectors_from_expr(&inner.node, out, order, next_idx)
+        }
+        ResolvedExpr::InterpolatedStr(parts) => {
             // Interpolation lowers to an `array.new_fixed (array (ref
             // null $string)) N` + variadic concat. The array type
             // shares a slot with `Vector<String>` (same wasm shape),
@@ -769,7 +775,7 @@ pub(super) fn collect_vectors_from_expr(
             // mentions Vector<String>.
             collect_vectors_from_str("Vector<String>", out, order, next_idx);
             for p in parts {
-                if let StrPart::Parsed(inner) = p {
+                if let ResolvedStrPart::Parsed(inner) = p {
                     collect_vectors_from_expr(&inner.node, out, order, next_idx);
                 }
             }
@@ -826,58 +832,63 @@ pub(super) fn collect_maps_from_str(type_str: &str, out: &mut Vec<String>) {
 /// nested literals / fn args / match arms all get their stamps
 /// harvested.
 pub(super) fn collect_maps_from_expr(
-    expr: &crate::ast::Spanned<crate::ast::Expr>,
+    expr: &crate::ast::Spanned<crate::ir::hir::ResolvedExpr>,
     out: &mut Vec<String>,
 ) {
-    use crate::ast::Expr;
+    use crate::ir::hir::ResolvedExpr;
     if let Some(ty) = expr.ty() {
         let display = ty.display();
         collect_maps_from_str(&display, out);
     }
     match &expr.node {
-        Expr::FnCall(callee, args) => {
-            collect_maps_from_expr(callee, out);
+        ResolvedExpr::Call(_, args) => {
             for a in args {
                 collect_maps_from_expr(a, out);
             }
         }
-        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+        ResolvedExpr::List(items)
+        | ResolvedExpr::Tuple(items)
+        | ResolvedExpr::IndependentProduct(items, _) => {
             for it in items {
                 collect_maps_from_expr(it, out);
             }
         }
-        Expr::MapLiteral(entries) => {
+        ResolvedExpr::MapLiteral(entries) => {
             for (k, v) in entries {
                 collect_maps_from_expr(k, out);
                 collect_maps_from_expr(v, out);
             }
         }
-        Expr::RecordCreate { fields, .. } => {
+        ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, v) in fields {
                 collect_maps_from_expr(v, out);
             }
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             collect_maps_from_expr(base, out);
             for (_, v) in updates {
                 collect_maps_from_expr(v, out);
             }
         }
-        Expr::Constructor(_, Some(arg)) => collect_maps_from_expr(arg, out),
-        Expr::Match { subject, arms } => {
+        ResolvedExpr::Ctor(_, args) => {
+            for a in args {
+                collect_maps_from_expr(a, out);
+            }
+        }
+        ResolvedExpr::Match { subject, arms } => {
             collect_maps_from_expr(subject, out);
             for arm in arms {
                 collect_maps_from_expr(&arm.body, out);
             }
         }
-        Expr::BinOp(_, l, r) => {
+        ResolvedExpr::BinOp(_, l, r) => {
             collect_maps_from_expr(l, out);
             collect_maps_from_expr(r, out);
         }
-        Expr::Neg(inner) => collect_maps_from_expr(inner, out),
-        Expr::Attr(e, _) | Expr::ErrorProp(e) => collect_maps_from_expr(e, out),
-        Expr::TailCall(tc) => {
-            for a in &tc.args {
+        ResolvedExpr::Neg(inner) => collect_maps_from_expr(inner, out),
+        ResolvedExpr::Attr(e, _) | ResolvedExpr::ErrorProp(e) => collect_maps_from_expr(e, out),
+        ResolvedExpr::TailCall { args, .. } => {
+            for a in args {
                 collect_maps_from_expr(a, out);
             }
         }


### PR DESCRIPTION
## Summary

Mirror of PR 9.1 (#159) for the program-level walkers that register types / fns before emit. After this PR the wasm-gc backend reads identity off `ResolvedExpr` / `ResolvedCallee` / `ResolvedCtor` across every walker — type discovery, builtin discovery, scratch-slot recognition, string-literal interning. Local resolver-view rebuild stays in this backend (named helper + TODO for PR 9.3).

Issue: #147 phase E PR 9.2.

## What changed

- **`types_discovery.rs`** — the six `collect_*_from_fn_body` / `collect_*_from_expr` walkers (vectors, options, results, tuples, lists, maps) take `&ResolvedFnDef` / `&Spanned<ResolvedExpr>`. `ResolvedExpr::Call(Builtin(\"Args.get\"|\"String.charAt\"|\"Vector.new\"|\"String.chars\"|...), args)` drives the eager-registration recognitions that pre-Phase-E detected via `Expr::FnCall(Attr(Ident(\"X\"), member), args)`. Binding-annotation walks (`let r: Result<…> = …`) read `ResolvedStmt::Binding { ty_ann: Some(Type), .. }` and pass `&annot.display()` through to the string-keyed registries.
- **`types.rs`** — `TypeRegistry::build_with_handler(items, resolved_fn_defs, handler_active)`: signature gains `&[ResolvedFnDef]` so the six `for fd in resolved_fn_defs` loops walk the resolved-form bodies; the signature-string lookups read `&fd.return_type.display()` / `&ty.display()` instead of the pre-Phase-E `&fd.return_type` / `ty` source strings. `fn_body_produces_string` / `fn_body_calls_int_mod` / `collect_string_literals_in_*` / `collect_lists_from_*` walkers migrate to take `&ResolvedFnDef` / `&ResolvedExpr`; the `Expr::FnCall(Attr(Ident(\"X\"), member), args)` shape-detection chains collapse to `ResolvedCallee::Builtin(name)` match-and-test. The `needs_string` check iterates `resolved_fn_defs`.
- **`module.rs`** — `discover_builtins_in_fn` / `_in_stmt` / `_in_expr` take `&ResolvedFnDef` / `&ResolvedStmt` / `&ResolvedExpr`. The `Expr::FnCall(Attr(Ident(parent), member), args)` recognition collapses to `ResolvedCallee::Builtin(dotted)`. Pattern recognition switches `Pattern::Literal(Str(_))` → `ResolvedPattern::Literal(Str(_))`. `items_use_string_split_join` renamed to `fn_defs_use_string_split_join` and consumes `&[ResolvedFnDef]`. `expr_to_dotted_head` dropped (no remaining consumers).
- **`module.rs`** — `emit_module_with` extracts the post-flatten resolver-view rebuild into a named helper `build_flattened_resolved_view(items, fn_defs) -> FlattenedResolvedView { symbol_table, resolved_fn_defs }`. The helper's doc-comment names the invariant: `flatten_multimodule` runs AFTER the pipeline (cross-module names rewrite to single-module flat names), so the pipeline's pre-flatten `CodegenContext.resolved_fn_defs` doesn't fit; the wasm-gc backend keeps its own post-flatten resolver view as a documented intermediate.

## Out of scope (deferred to PR 9.3 per #147 roadmap)

- The plumbing decision: either move `flatten_multimodule` into the pipeline so a shared `CodegenContext` covers wasm-gc, OR formalise the post-flatten resolver view as a first-class backend concept. Either path is an architectural call separate from the walker migration that lands here.
- `compile_to_wasm_gc(items, _analysis)` entry signature unchanged (the helper hides the rebuild from callers).
- `flatten.rs` stays AST-level — it's a pre-resolver name-rewrite pass on raw `Expr`, not a type-discovery walker.

Net: **−11 lines** across 3 files (−513 / +502).

## Test plan

- [x] `cargo build --features wasm`
- [x] `cargo test --features wasm --no-fail-fast` — **1649 passed, 0 failed**.
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Byte-identical wasm output for every snapshot fixture (all 12 baseline md5s match; `life.wasm` 10508 bytes — md5 flaky pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)