### PR TITLE
codegen: resolve_fn_def by FnKey/FnId, not bare name — #147 phase E PR 9.3a

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -665,6 +665,17 @@ impl CodegenContext {
     /// wrappers, TCO hoist rewrites, test fixtures) which the
     /// resolver hasn't lifted upfront.
     ///
+    /// `scope` is the owning module prefix when `fd` came from a
+    /// dependency module's `module.fn_defs`, `None` when `fd` is part
+    /// of the entry's `ctx.fn_defs`. Lookup keys by
+    /// [`crate::ir::FnKey`] through the [`crate::ir::SymbolTable`] so
+    /// two modules that share a bare fn name (e.g. `Util.format` and
+    /// `Other.format`) resolve to their own [`crate::ir::FnId`]
+    /// without bare-name collisions. Pre-PR-9.3a this matched by
+    /// `rfd.name == fd.name` against a flat search of every resolved
+    /// table — fragile the moment flatten changes (or doesn't run)
+    /// and two scopes share a name.
+    ///
     /// Phase E shared lookup boundary — Rust codegen (PR 8) already
     /// consumes this through `rust::toplevel::resolved_fn_def_for`;
     /// wasm-gc / Lean / Dafny / self-host backends pick it up in
@@ -675,25 +686,46 @@ impl CodegenContext {
     pub fn resolve_fn_def<'a>(
         &'a self,
         fd: &'a FnDef,
+        scope: Option<&str>,
     ) -> std::borrow::Cow<'a, crate::ir::hir::ResolvedFnDef> {
+        use crate::ir::FnKey;
         use crate::ir::hir::{
             ResolveCtx, ResolvedFnBody, ResolvedFnDef, ResolvedStmt, resolve_fn_def_external,
         };
         use std::borrow::Cow;
-        if let Some(rfd) = self.resolved_fn_defs.iter().find(|rfd| rfd.name == fd.name) {
-            return Cow::Borrowed(rfd);
-        }
-        for module in &self.resolved_module_fn_defs {
-            if let Some(rfd) = module.iter().find(|rfd| rfd.name == fd.name) {
+
+        // Resolve identity via the symbol table — entry scope vs
+        // dependency module scope is the caller's stated context.
+        let key = match scope {
+            Some(prefix) => FnKey::in_module(prefix.to_string(), fd.name.clone()),
+            None => FnKey::entry(fd.name.clone()),
+        };
+        if let Some(fn_id) = self.symbol_table.fn_id_of(&key) {
+            // Resolved tables are dense in the order each scope's
+            // `build_context` populated them; the only authoritative
+            // way to find the right slot is `fn_id` equality.
+            if let Some(rfd) = self.resolved_fn_defs.iter().find(|rfd| rfd.fn_id == fn_id) {
                 return Cow::Borrowed(rfd);
             }
+            for module in &self.resolved_module_fn_defs {
+                if let Some(rfd) = module.iter().find(|rfd| rfd.fn_id == fn_id) {
+                    return Cow::Borrowed(rfd);
+                }
+            }
+            // Symbol table knew the key but resolver didn't lift a
+            // resolved entry. Falls through to the synthetic-fallback
+            // path below; in production this shouldn't happen.
         }
+
+        // Synthetic FnDef path — memo wrappers, TCO hoist rewrites,
+        // test fixtures the resolver never saw. Lift on demand
+        // against the entry's resolver context.
         let module_name = self.items.iter().find_map(|i| match i {
             TopLevel::Module(m) => Some(m.name.clone()),
             _ => None,
         });
         let mut rctx = ResolveCtx::new(&self.symbol_table);
-        rctx.current_module = module_name;
+        rctx.current_module = scope.map(String::from).or(module_name);
         let lifted = resolve_fn_def_external(&rctx, fd).unwrap_or_else(|| {
             let stmts: Vec<ResolvedStmt> = match fd.body.as_ref() {
                 crate::ast::FnBody::Block(stmts) => {

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -460,7 +460,7 @@ fn entry_module_sections(
             continue;
         }
         let is_memo = ctx.memo_fns.contains(&fd.name);
-        sections.push(toplevel::emit_public_fn_def(fd, is_memo, ctx));
+        sections.push(toplevel::emit_public_fn_def(fd, is_memo, ctx, None));
     }
 
     if main_fn.is_some() || !top_level_stmts.is_empty() {
@@ -524,7 +524,12 @@ fn module_sections(module: &crate::codegen::ModuleInfo, ctx: &CodegenContext) ->
             continue;
         }
         let is_memo = ctx.memo_fns.contains(&fd.name);
-        sections.push(toplevel::emit_public_fn_def(fd, is_memo, ctx));
+        sections.push(toplevel::emit_public_fn_def(
+            fd,
+            is_memo,
+            ctx,
+            Some(&module.prefix),
+        ));
     }
 
     sections

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -548,19 +548,32 @@ fn build_fn_ectx_no_borrow(fd: &FnDef, ctx: &CodegenContext) -> EmitCtx {
 }
 
 /// Emit a Rust function from an Aver FnDef.
+///
+/// `scope` is the owning module prefix when `fd` came from a
+/// dependency module (`module.fn_defs`), `None` when `fd` is part of
+/// the entry's `ctx.fn_defs`. Threaded into `ctx.resolve_fn_def` so
+/// the resolved lookup keys by `FnKey` instead of bare name — two
+/// modules that share a fn name (`Util.format` vs `Other.format`)
+/// pick up their own `FnId` without collision.
 #[allow(dead_code)]
-pub fn emit_fn_def(fd: &FnDef, is_memo: bool, ctx: &CodegenContext) -> String {
-    emit_fn_def_with_visibility(fd, is_memo, ctx, false)
+pub fn emit_fn_def(fd: &FnDef, is_memo: bool, ctx: &CodegenContext, scope: Option<&str>) -> String {
+    emit_fn_def_with_visibility(fd, is_memo, ctx, scope, false)
 }
 
-pub fn emit_public_fn_def(fd: &FnDef, is_memo: bool, ctx: &CodegenContext) -> String {
-    emit_fn_def_with_visibility(fd, is_memo, ctx, true)
+pub fn emit_public_fn_def(
+    fd: &FnDef,
+    is_memo: bool,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> String {
+    emit_fn_def_with_visibility(fd, is_memo, ctx, scope, true)
 }
 
 fn emit_fn_def_with_visibility(
     fd: &FnDef,
     is_memo: bool,
     ctx: &CodegenContext,
+    scope: Option<&str>,
     public: bool,
 ) -> String {
     let mut lines = Vec::new();
@@ -606,7 +619,7 @@ fn emit_fn_def_with_visibility(
     } else {
         None
     };
-    let resolved_fd_owned = ctx.resolve_fn_def(fd);
+    let resolved_fd_owned = ctx.resolve_fn_def(fd, scope);
     let resolved_fd = resolved_fd_owned.as_ref();
     let optimized_thin_plan = classify_thin_fn_def_for_rust(resolved_fd, ctx, &ectx);
 
@@ -3299,7 +3312,7 @@ mod tests {
             (vec![Type::Int, Type::Int, Type::Int], Type::Int, vec![]),
         );
 
-        let emitted = emit_public_fn_def(&fd, false, &ctx);
+        let emitted = emit_public_fn_def(&fd, false, &ctx, None);
         assert!(emitted.contains("let __aver_inv0 = score(tag(pick));"));
         // Numeric add no longer uses &rhs
         assert!(emitted.contains("let __tmp1 = (acc + __aver_inv0);"));
@@ -3347,7 +3360,7 @@ mod tests {
         ctx.fn_sigs
             .insert("f".to_string(), (vec![Type::Float], Type::Float, vec![]));
 
-        let emitted = emit_public_fn_def(&fd, true, &ctx);
+        let emitted = emit_public_fn_def(&fd, true, &ctx, None);
         assert!(!emitted.contains("thread_local!"));
     }
 
@@ -3399,7 +3412,7 @@ mod tests {
             (vec![Type::named("Tree")], Type::Bool, vec![]),
         );
 
-        let emitted = emit_public_fn_def(&fd, true, &ctx);
+        let emitted = emit_public_fn_def(&fd, true, &ctx, None);
         assert!(emitted.contains("let __memo_key = t.clone();"));
         assert!(emitted.contains("get(&__memo_key)"));
         assert!(emitted.contains("insert(__memo_key, __result.clone())"));
@@ -3644,7 +3657,7 @@ mod tests {
             "first".to_string(),
             (vec![Type::Int, Type::Int], Type::Int, vec![]),
         );
-        let semantic = emit_public_fn_def(&fd, false, &semantic_ctx);
+        let semantic = emit_public_fn_def(&fd, false, &semantic_ctx, None);
         // Both modes now emit #[inline(always)] for thin wrappers
         assert!(semantic.contains("#[inline(always)]"));
         assert!(semantic.contains("pub fn swap(a: i64, b: i64) -> i64"));
@@ -3694,7 +3707,7 @@ mod tests {
                 vec![],
             ),
         );
-        let semantic = emit_public_fn_def(&fd, false, &semantic_ctx);
+        let semantic = emit_public_fn_def(&fd, false, &semantic_ctx, None);
         // Both modes now emit #[inline(always)] for leaf wrappers
         assert!(semantic.contains("#[inline(always)]"));
         // Vector param is now borrowed
@@ -3763,7 +3776,7 @@ mod tests {
                 vec![],
             ),
         );
-        let semantic = emit_public_fn_def(&fd, false, &semantic_ctx);
+        let semantic = emit_public_fn_def(&fd, false, &semantic_ctx, None);
         // Both modes now emit #[inline(always)] for binding-block wrappers
         assert!(semantic.contains("#[inline(always)]"));
         assert!(semantic.contains("let cell = grid.get(idx as usize).cloned().unwrap_or(0i64);"));


### PR DESCRIPTION
## Summary

`CodegenContext::resolve_fn_def(fd)` previously searched `resolved_fn_defs` / `resolved_module_fn_defs` flat by `rfd.name == fd.name`. That works today because every multi-module codegen path flattens dep fns through `flatten_multimodule` with module-prefixed names (`Fractal_render`), so bare names happen to be unique post-flatten. The moment two scopes legitimately share a fn name (or flatten changes), bare-name lookup silently picks the wrong entry.

This PR plumbs the caller's scope context through and keys the lookup by `crate::ir::FnKey` via `SymbolTable::fn_id_of` → `FnId` equality against the resolved tables.

Issue: #147 phase E PR 9.3a.

## What changed

- **`src/codegen/mod.rs::CodegenContext::resolve_fn_def(fd, scope: Option<&str>)`** — builds `FnKey::entry(name)` for `scope = None` (entry fns) or `FnKey::in_module(prefix, name)` for `scope = Some(prefix)` (dep modules). Looks up `fn_id` via `self.symbol_table.fn_id_of(&key)` then searches `resolved_fn_defs` and each `resolved_module_fn_defs` table by `rfd.fn_id == fn_id`. Synthetic-FnDef fallback (memo wrappers, TCO hoist rewrites, test fixtures the resolver never saw) stays — lifts on demand via `resolve_fn_def_external`.
- **`src/codegen/rust/toplevel.rs`** — `emit_fn_def` / `emit_public_fn_def` / `emit_fn_def_with_visibility` gain `scope: Option<&str>`. Threaded down to the single `ctx.resolve_fn_def(fd, scope)` callsite.
- **`src/codegen/rust/mod.rs`** — callers pass `None` for the entry-path loop (`for fd in &ctx.fn_defs`) and `Some(&module.prefix)` for the module-path loop (`for fd in &module.fn_defs`).
- **Test callsites** (in-module + integration test code in `rust/toplevel.rs` test modules) updated to pass `None` — they emit standalone synthetic FnDefs against the entry scope.

Net: +50 / -19 lines across 3 files.

## Why this matters

The reviewer flagged it during PR 9.2 (#160) review:
> Jeśli ten helper ma zostać wspólną ścieżką dla backendów, powinien iść po FnId, ewentualnie po jednoznacznym (module, name), nie po samym stringu nazwy.

Sequencing: 9.3a (this PR — smell fix) → 9.3b (`WasmGcLinkedView` promotion + FnId-keyed mirror). Independent PRs because they touch different backends and live well apart in review.

## Test plan

- [x] `cargo build --features wasm`
- [x] `cargo test --features wasm --no-fail-fast` — **1649 passed, 0 failed**.
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)