### PR TITLE
codegen/wasm_gc: WasmGcLinkedView as backend-link stage — #147 phase E PR 9.3b

### DIFF
--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -54,6 +54,7 @@ mod module;
 mod tests;
 mod types;
 mod types_discovery;
+mod view;
 mod wasip2_helpers;
 mod wasip2_http;
 mod wasip2_http_server;

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -96,51 +96,6 @@ use crate::types::Type as AverType;
 
 use crate::ast::{FnDef, TopLevel, TypeDef};
 
-/// Resolved-HIR view of the wasm-gc backend's post-flatten compile
-/// unit. The pipeline-built `CodegenContext.resolved_fn_defs` is keyed
-/// against pre-flatten items (cross-module names like `Fractal.render`
-/// still reference their owning module); `flatten_multimodule` runs
-/// AFTER pipeline and rewrites those into single-module flat names
-/// (`Fractal_render`), so a fresh resolver pass against the flattened
-/// items is the source of truth this backend uses.
-///
-/// Naming the invariant in a helper is deliberate — calling code in
-/// `emit_module_with` reads `view.resolved_fn_defs` and the rebuild
-/// stays local to this backend. PR 9.3 (Phase E roadmap, #147) decides
-/// whether `flatten` moves into the pipeline so a shared
-/// `CodegenContext` covers wasm-gc too, or whether this backend keeps a
-/// formal post-flatten codegen view.
-struct FlattenedResolvedView {
-    symbol_table: crate::ir::SymbolTable,
-    resolved_fn_defs: Vec<crate::ir::hir::ResolvedFnDef>,
-}
-
-fn build_flattened_resolved_view(
-    items: &[TopLevel],
-    fn_defs: &[&FnDef],
-) -> Result<FlattenedResolvedView, WasmGcError> {
-    // Wasm-gc emits a single flattened module — `dep_modules` is empty
-    // by construction; `flatten_multimodule` has already merged dep
-    // fns into `items` with prefixed names.
-    let symbol_table = crate::ir::SymbolTable::build(items, &[]);
-    let resolve_ctx = crate::ir::hir::ResolveCtx::new(&symbol_table);
-    let resolved_fn_defs: Vec<crate::ir::hir::ResolvedFnDef> = fn_defs
-        .iter()
-        .filter_map(|fd| crate::ir::hir::resolve_fn_def_external(&resolve_ctx, fd))
-        .collect();
-    if resolved_fn_defs.len() != fn_defs.len() {
-        return Err(WasmGcError::Validation(format!(
-            "wasm-gc resolver dropped {} of {} fn defs — typecheck must run before codegen",
-            fn_defs.len() - resolved_fn_defs.len(),
-            fn_defs.len()
-        )));
-    }
-    Ok(FlattenedResolvedView {
-        symbol_table,
-        resolved_fn_defs,
-    })
-}
-
 pub(super) fn emit_module_with(
     items: &[TopLevel],
     handler_name: Option<&str>,
@@ -154,10 +109,9 @@ pub(super) fn emit_module_with(
         })
         .collect();
 
-    let FlattenedResolvedView {
-        symbol_table,
-        resolved_fn_defs,
-    } = build_flattened_resolved_view(items, &fn_defs)?;
+    let view = super::view::WasmGcLinkedView::build(items, &fn_defs)?;
+    let symbol_table = view.symbol_table;
+    let resolved_fn_defs = view.resolved_fn_defs;
 
     let registry =
         TypeRegistry::build_with_handler(items, &resolved_fn_defs, handler_name.is_some());

--- a/src/codegen/wasm_gc/view.rs
+++ b/src/codegen/wasm_gc/view.rs
@@ -1,0 +1,124 @@
+//! Wasm-gc backend-link view — the resolved-HIR slice the rest of
+//! this backend reads.
+//!
+//! ## Why this exists as a named view, not a transitional hack
+//!
+//! The pipeline (`parse → tco → typecheck → resolve → CodegenContext`)
+//! is module-aware: `CodegenContext.resolved_fn_defs` holds the
+//! entry's fns and `resolved_module_fn_defs` holds each dep's fns
+//! separately, both keyed against the pre-flatten `SymbolTable`.
+//! That structure is correct for backends that emit per-module
+//! artifacts (Rust → one Rust crate per Aver module, VM → per-
+//! module bytecode, Lean → namespaces, Dafny → modules).
+//!
+//! The wasm-gc backend emits a single .wasm file by design — that's
+//! a *linking* decision, not a semantic one. The pipeline shouldn't
+//! know about it. So this backend runs its own legal link stage:
+//! [`flatten_multimodule`] (in `crate::codegen::wasm_gc::flatten`)
+//! merges dep fns into the entry's items with module-prefixed names
+//! (`Fractal.render` → `Fractal_render`), then this view runs a
+//! fresh resolver pass against the flattened items.
+//!
+//! Calling this a "link" stage names what it actually is: the
+//! backend collapses N modules into 1 emit unit, and identity
+//! lookups in the post-link world use [`WasmGcLinkedView`] as the
+//! canonical resolver substrate. Mirrors how a native linker has
+//! its own symbol view distinct from the per-translation-unit views
+//! the compiler produced.
+//!
+//! ## Invariant
+//!
+//! - **Input:** post-typecheck, post-resolve, post-flatten items
+//!   slice. Every reachable `FnDef` has been monomorphised and
+//!   prefixed.
+//! - **Output:** [`WasmGcLinkedView`] holding the flattened-scope
+//!   [`SymbolTable`] plus one [`ResolvedFnDef`] per source `FnDef`,
+//!   indexable by stable [`FnId`].
+//!
+//! ## Why FnId lookup, not bare name
+//!
+//! Pre-PR-9.3a the codegen `CodegenContext::resolve_fn_def` flat-
+//! searched resolved tables by `rfd.name == fd.name`. Post-flatten
+//! that happens to work in wasm-gc because every name is prefixed.
+//! [`fn_def_by_id`] keys by `FnId` instead so the pattern doesn't
+//! depend on flatten's name-uniqueness side effect — the link stage
+//! still rewrites names, but the identity layer stays robust.
+//!
+//! [`flatten_multimodule`]: super::flatten::flatten_multimodule
+//! [`SymbolTable`]: crate::ir::SymbolTable
+//! [`ResolvedFnDef`]: crate::ir::hir::ResolvedFnDef
+//! [`FnId`]: crate::ir::FnId
+
+use std::collections::HashMap;
+
+use crate::ast::{FnDef, TopLevel};
+use crate::ir::FnId;
+use crate::ir::SymbolTable;
+use crate::ir::hir::{ResolvedFnDef, resolve_fn_def_external};
+
+use super::WasmGcError;
+
+/// Resolved-HIR view of the wasm-gc backend's post-link compile
+/// unit. See module doc for the invariant.
+pub(super) struct WasmGcLinkedView {
+    /// Resolver SymbolTable built against the flattened items. Use
+    /// `fn_id_of(&FnKey)` against this table to translate a source
+    /// name to a stable identity.
+    pub(super) symbol_table: SymbolTable,
+    /// Resolved fn defs, one per source `FnDef` in the flattened
+    /// compile unit. Source-position order matches `module.rs`'s
+    /// wasm fn idx allocation, so positional indexing
+    /// (`resolved_fn_defs[i]`) lines up with the `i`-th
+    /// `&FnDef` the caller iterates.
+    pub(super) resolved_fn_defs: Vec<ResolvedFnDef>,
+    /// `FnId → resolved_fn_defs index` for O(1) lookup by stable
+    /// identity. Built once during [`Self::build`]; mirrors the
+    /// FnKey/FnId-keyed pattern in
+    /// [`crate::codegen::CodegenContext::resolve_fn_def`] (PR 9.3a).
+    fn_id_to_idx: HashMap<FnId, usize>,
+}
+
+impl WasmGcLinkedView {
+    /// Build the view from post-flatten items + the `&FnDef` list
+    /// the caller already extracted from them.
+    ///
+    /// Wasm-gc emits a single flattened module — `dep_modules` is
+    /// empty by construction in [`SymbolTable::build`]; the
+    /// flattened items carry every dep fn under prefixed names.
+    pub(super) fn build(items: &[TopLevel], fn_defs: &[&FnDef]) -> Result<Self, WasmGcError> {
+        let symbol_table = SymbolTable::build(items, &[]);
+        let resolve_ctx = crate::ir::hir::ResolveCtx::new(&symbol_table);
+        let resolved_fn_defs: Vec<ResolvedFnDef> = fn_defs
+            .iter()
+            .filter_map(|fd| resolve_fn_def_external(&resolve_ctx, fd))
+            .collect();
+        if resolved_fn_defs.len() != fn_defs.len() {
+            return Err(WasmGcError::Validation(format!(
+                "wasm-gc resolver dropped {} of {} fn defs — typecheck must run before codegen",
+                fn_defs.len() - resolved_fn_defs.len(),
+                fn_defs.len()
+            )));
+        }
+        let fn_id_to_idx: HashMap<FnId, usize> = resolved_fn_defs
+            .iter()
+            .enumerate()
+            .map(|(i, rfd)| (rfd.fn_id, i))
+            .collect();
+        Ok(Self {
+            symbol_table,
+            resolved_fn_defs,
+            fn_id_to_idx,
+        })
+    }
+
+    /// Stable identity lookup — preferred over the linear
+    /// `resolved_fn_defs.iter().find(|rfd| rfd.name == ...)` shape.
+    /// Returns `None` for FnIds the resolver pass didn't lift,
+    /// which today only happens on typecheck-rejected programs.
+    #[allow(dead_code)]
+    pub(super) fn fn_def_by_id(&self, fn_id: FnId) -> Option<&ResolvedFnDef> {
+        self.fn_id_to_idx
+            .get(&fn_id)
+            .map(|&i| &self.resolved_fn_defs[i])
+    }
+}


### PR DESCRIPTION
## Summary

PR 9.2 (#160) stashed the post-flatten resolver rebuild in a private `FlattenedResolvedView` struct inside `module.rs`, with a doc-comment marking it as a transitional view pending PR 9.3. **This PR makes the view first-class.**

The wasm-gc backend emits a single .wasm file by design — that's a *linking* decision, not a semantic one. The pipeline (`parse → tco → typecheck → resolve → CodegenContext`) stays module-aware and correct for backends that emit per-module artifacts (Rust crate / VM bytecode / Lean namespace / Dafny module). Wasm-gc runs its own legal link stage (`flatten_multimodule` merges deps with prefixed names) and `WasmGcLinkedView` is the resolved-HIR substrate the rest of the backend reads in the post-link world. Same shape as a native linker holding its own symbol view distinct from per-translation-unit views the compiler produced.

Issue: #147 phase E PR 9.3b.

## What changed

- **New `src/codegen/wasm_gc/view.rs`** — `WasmGcLinkedView` with `symbol_table` + `resolved_fn_defs` + `fn_id_to_idx` (`HashMap<FnId, usize>` for O(1) stable-identity lookup). Module doc names the invariant: input is post-typecheck/resolve/flatten items; output is the FnId-indexable resolver substrate. Mirrors the FnKey/FnId-keyed pattern from PR 9.3a (#161).
- **`WasmGcLinkedView::build(items, &[&FnDef])`** — replaces the inline `build_flattened_resolved_view` helper that lived in `module.rs`. Same Phase-E-invariant check (drop count → typecheck must run first).
- **`WasmGcLinkedView::fn_def_by_id(FnId) -> Option<&ResolvedFnDef>`** — preferred over the linear `resolved_fn_defs.iter().find(|rfd| rfd.name == ...)` shape. Allowed-dead today; callers migrate to it incrementally.
- **`module.rs`** — drops the private `FlattenedResolvedView` / `build_flattened_resolved_view` definitions; `emit_module_with` reaches into `super::view::WasmGcLinkedView::build(items, &fn_defs)?` and destructures `symbol_table` + `resolved_fn_defs` out as before.

Net: **+128 / −49** across 3 files (new `view.rs` + 2 small edits).

## Phase E roadmap (#147)

- ✅ PR 9.0.1 — `body/infer.rs` IR-agnostic readers
- ✅ PR 9 — shared `ctx.resolve_{fn_def,expr,stmt,pattern}` helpers
- ✅ PR 9.1 (#159) — `body/emit.rs` + slots + builtins consume `ResolvedExpr`
- ✅ PR 9.2 (#160) — `types_discovery` + `types` + `module` orchestration walkers
- ✅ PR 9.3a (#161) — `CodegenContext::resolve_fn_def` keys by FnKey/FnId
- ✅ PR 9.3b — `WasmGcLinkedView` backend-link stage (this PR)

After this PR every wasm-gc walker / emitter consumes `ResolvedExpr` identity directly; the post-link resolver-view rebuild is a named backend concept, not a transitional hack. **PR 10 / 11 / 12 (Lean / Dafny / self-host migration) can land next.**

## Test plan

- [x] `cargo build --features wasm`
- [x] `cargo test --features wasm --no-fail-fast` — **1649 passed, 0 failed**.
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Byte-identical wasm output for every snapshot fixture (all 12 baseline md5s match; `life.wasm` 10508 bytes — md5 flaky pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)