### PR TITLE
codegen/wasm_gc: FnMap keyed by FnId, not bare name — #147 phase E PR 9.3c

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -46,9 +46,18 @@ use emit::emit_expr;
 use infer::aver_type_str_of;
 use slots::{SlotTable, count_value_params};
 
-/// Maps fn name → wasm fn index + return type. Built once per module.
+/// Maps fn identity → wasm fn index + return type. Built once per
+/// module in `module::emit_module_with`. PR 9.3c keyed dispatch by
+/// stable [`crate::ir::FnId`] (mirror of the FnKey-based
+/// `CodegenContext::resolve_fn_def` from PR 9.3a); pre-9.3c this
+/// field was `by_name: HashMap<String, FnEntry>`, which happened to
+/// work post-flatten only because every dep fn carried a module
+/// prefix in its name.
 pub(super) struct FnMap {
-    pub(super) by_name: std::collections::HashMap<String, FnEntry>,
+    /// FnId → wasm fn entry. `Call(Fn(id))` and the
+    /// `ResolvedExpr::TailCall { target }` dispatch read this
+    /// directly.
+    pub(super) by_id: std::collections::HashMap<crate::ir::FnId, FnEntry>,
     /// Dotted builtin name → wasm fn index. Populated by
     /// `module::emit_module` from the `BuiltinRegistry` so call
     /// sites can `call $builtin_idx` for `String.fromInt` etc.
@@ -137,6 +146,7 @@ impl FnMap {
     }
 }
 
+#[derive(Clone)]
 pub(super) struct FnEntry {
     pub(super) wasm_idx: u32,
     /// Kept for symmetry with the other backends' fn-table entries —

--- a/src/codegen/wasm_gc/body/emit.rs
+++ b/src/codegen/wasm_gc/body/emit.rs
@@ -457,21 +457,28 @@ pub(super) fn emit_expr(
                     )));
                 }
                 ResolvedCallee::Fn(id) => {
-                    let name = ctx.symbol_table.fn_entry(*id).key.name.clone();
-                    let entry = ctx.fn_map.by_name.get(&name);
-                    if entry.is_none() && ctx.self_local_slot(&name).is_some() {
-                        // Local slot of a `Fn(...) -> _` value — wasm-
-                        // gc doesn't emit higher-order calls. Same
-                        // semantics as pre-Phase-E.
-                        func.instruction(&Instruction::Unreachable);
-                        return Ok(());
+                    let entry = ctx.fn_map.by_id.get(id);
+                    if entry.is_none() {
+                        // Resolved fn id with no wasm fn idx — either
+                        // a `Fn(...) -> _` value parked in a local
+                        // slot (verify-only fns) or a typecheck-
+                        // rejected program that still reached emit.
+                        // Wasm-gc doesn't emit higher-order calls;
+                        // `unreachable` keeps validation polymorphic.
+                        let name = ctx.symbol_table.fn_entry(*id).key.name.clone();
+                        if ctx.self_local_slot(&name).is_some() {
+                            func.instruction(&Instruction::Unreachable);
+                            return Ok(());
+                        }
+                        return Err(WasmGcError::Validation(format!(
+                            "call to unknown fn `{name}` (FnId {:?})",
+                            id
+                        )));
                     }
+                    let entry = entry.expect("just checked");
                     for arg in args {
                         emit_expr(func, arg, slots, ctx)?;
                     }
-                    let entry = entry.ok_or(WasmGcError::Validation(format!(
-                        "call to unknown fn `{name}`"
-                    )))?;
                     func.instruction(&Instruction::Call(entry.wasm_idx));
                 }
                 ResolvedCallee::LocalSlot { .. } => {
@@ -491,10 +498,7 @@ pub(super) fn emit_expr(
             }
         }
         ResolvedExpr::Match { subject, arms } => emit_match(func, subject, arms, slots, ctx)?,
-        ResolvedExpr::TailCall { target, args } => {
-            let target_name = ctx.symbol_table.fn_entry(*target).key.name.clone();
-            emit_tail_call(func, &target_name, args, slots, ctx)?
-        }
+        ResolvedExpr::TailCall { target, args } => emit_tail_call(func, *target, args, slots, ctx)?,
         ResolvedExpr::RecordCreate {
             type_name, fields, ..
         } => emit_record_create(func, type_name, fields, slots, ctx)?,
@@ -3073,18 +3077,18 @@ pub(super) fn emit_int_match_cascade(
 /// `Unimplemented` so the user sees a clear bump line.
 pub(super) fn emit_tail_call(
     func: &mut Function,
-    target: &str,
+    target: crate::ir::FnId,
     args: &[Spanned<ResolvedExpr>],
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
-    let entry = ctx
-        .fn_map
-        .by_name
-        .get(target)
-        .ok_or(WasmGcError::Validation(format!(
-            "tail call to unknown fn `{target}`"
-        )))?;
+    let entry = ctx.fn_map.by_id.get(&target).ok_or_else(|| {
+        let name = ctx.symbol_table.fn_entry(target).key.canonical();
+        WasmGcError::Validation(format!(
+            "tail call to unknown fn `{name}` (FnId {:?})",
+            target
+        ))
+    })?;
     for arg in args {
         emit_expr(func, arg, slots, ctx)?;
     }
@@ -3094,7 +3098,11 @@ pub(super) fn emit_tail_call(
     // Deep recursion will trash the stack with this on; only flip it
     // for shallow scenarios.
     let no_tail_call = std::env::var_os("AVER_WASM_GC_NO_TAIL_CALL").is_some();
-    let target_idx = if target == ctx.self_fn_name {
+    // Self-tail-call check via wasm fn idx — by_id lookup already
+    // yielded the entry, so `entry.wasm_idx == ctx.self_wasm_idx`
+    // iff `target` names the current fn. Skips the pre-PR-9.3c
+    // `target_name == ctx.self_fn_name` string compare.
+    let target_idx = if entry.wasm_idx == ctx.self_wasm_idx {
         ctx.self_wasm_idx
     } else {
         entry.wasm_idx

--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -7,38 +7,50 @@
 //! Status: Phase 1 — module scaffold. `compile_to_wasm_gc` returns a
 //! placeholder error until a hello-world emitter lands in `module.rs`.
 //!
-//! ## Phase E (resolved AST) migration plan
+//! ## Phase E (resolved AST) migration — shipped
 //!
 //! Issue #147 phase E migrates every backend from consuming
 //! `crate::ast::Expr` / `FnBody` / `Pattern` to consuming the
-//! resolved-HIR shapes in `crate::ir::hir`. The wasm-gc backend is
-//! migrated across three PRs because it's the largest backend
-//! (~36k lines, 8 files actively walking `Expr`):
+//! resolved-HIR shapes in `crate::ir::hir`. The wasm-gc backend
+//! shipped across five PRs:
 //!
-//! - **PR 9** (foundation) — shared `CodegenContext::resolve_fn_def` /
-//!   `resolve_expr` / `resolve_stmt` / `resolve_pattern` methods
-//!   promoted from `rust/toplevel.rs`. No wasm-gc behaviour change;
-//!   gives the follow-up PRs a one-line lookup boundary.
-//! - **PR 9.1** — `body/emit.rs` (3.1k) migrates to take
-//!   `&Spanned<ResolvedExpr>`; cascades through `emit_list_literal`,
-//!   `emit_map_literal`, `emit_constructor`, `emit_match`,
-//!   `emit_tail_call`, etc. The remaining body subfiles
-//!   (`body/{slots, builtins, builtins_wasip2, infer, eq_helpers,
-//!   hash_helpers}.rs`) migrate alongside since they share the
-//!   `Spanned<Expr>` borrows.
-//! - **PR 9.2** — `module.rs` orchestration (6.3k),
-//!   `types_discovery.rs` / `types.rs` / `flatten.rs` (program-level
-//!   walkers that register types / fns before emit). After this PR
-//!   the wasm-gc backend reads `ctx.resolved_fn_defs` /
-//!   `resolved_module_fn_defs` exclusively; the `&FnDef` borrows in
-//!   `module.rs` survive only as the source-shape metadata that the
-//!   resolver doesn't reproduce (e.g. param annotation source
-//!   strings used by the WIT signature emitter).
+//! - **PR 9.0.1** — `body/infer.rs` type readers generic over
+//!   `Spanned<T: Debug>` so they work uniformly against
+//!   `Spanned<Expr>` and `Spanned<ResolvedExpr>`.
+//! - **PR 9** (foundation) — shared `CodegenContext::resolve_fn_def`
+//!   / `resolve_expr` / `resolve_stmt` / `resolve_pattern` methods.
+//!   Behaviour-neutral one-line lookup boundary for follow-ups.
+//! - **PR 9.1** — `body/emit.rs` (+ `body/{slots, builtins,
+//!   builtins_wasip2}.rs`) take `&Spanned<ResolvedExpr>`. The
+//!   `Expr::FnCall(Attr(Ident("X"), member), args)` recognition
+//!   tree collapses to `ResolvedCallee` / `ResolvedCtor` dispatch.
+//! - **PR 9.2** — `types_discovery.rs` / `types.rs` / `module.rs`
+//!   program-level walkers consume `&ResolvedFnDef` /
+//!   `&Spanned<ResolvedExpr>`. After this PR every walker /
+//!   emitter reads identity off the resolved HIR; the source-shape
+//!   `&FnDef` borrows survive only for signature metadata
+//!   (`fd.return_type` / `fd.params` as source strings, kept
+//!   verbatim for WIT signature emission and param-annotation
+//!   passthrough).
+//! - **PR 9.3a** — `CodegenContext::resolve_fn_def` keys lookup by
+//!   `FnKey`/`FnId` via `SymbolTable::fn_id_of`, not bare name.
+//!   Closes the bare-name-flat-search smell that worked only
+//!   because `flatten_multimodule` prefixes dep fn names.
+//! - **PR 9.3b** — [`view::WasmGcLinkedView`] promotes the post-
+//!   flatten resolver rebuild to a first-class backend-link stage.
+//!   The pipeline stays module-aware; wasm-gc owns its single-
+//!   module link view as a legal codegen concept, not a transitional
+//!   hack. `fn_def_by_id(FnId)` mirrors the FnId-keyed pattern
+//!   from PR 9.3a.
+//! - **PR 9.3c** — [`body::FnMap`] keyed by `FnId` only (was
+//!   `by_name: HashMap<String, FnEntry>` pre-9.3c). `Call(Fn(id))`
+//!   and `ResolvedExpr::TailCall { target }` dispatch through
+//!   `fn_map.by_id.get(&id)` so call lowering matches the FnId-
+//!   keyed identity layer end to end.
 //!
 //! The byte-identical gate for every wasm-gc snapshot
 //! (`order_total.wasm` md5 `61e45b325279e17e1b0d8dce3fde43f9`, the
-//! game suite, the wasip2 stress fixtures) holds across each PR — no
-//! generated wasm shifts until the migration is fully through.
+//! game suite, the wasip2 stress fixtures) held across each PR.
 
 use crate::ast::TopLevel;
 use crate::ir::AnalysisResult;

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -2062,16 +2062,24 @@ pub(super) fn emit_module_with(
     // wired in the post-emit phase further down. Globals + their
     // start-fn init are gone.)
 
-    // Build the fn-name → wasm-fn-idx map. With K imports:
+    // Build the FnId → wasm-fn-idx map. With K imports:
     //   imports at idx 0..K
     //   _start at K
     //   user fn i at K+1+i
     //   builtin at K+1+N+m (assigned by builtin_registry already)
+    //
+    // `resolved_fn_defs` is position-aligned with `fn_defs`
+    // (`WasmGcLinkedView::build` errors if the resolver drops any
+    // fn), so `resolved_fn_defs[i].fn_id` is the FnId for
+    // `fn_defs[i]`. PR 9.3c switched this map from name-keyed to
+    // FnId-keyed — mirror of the FnKey/FnId dispatch shape in
+    // `CodegenContext::resolve_fn_def` (PR 9.3a).
     let start_wasm_idx = import_count;
-    let mut by_name: HashMap<String, FnEntry> = HashMap::new();
+    let mut by_id: HashMap<crate::ir::FnId, FnEntry> = HashMap::new();
     for (i, fd) in fn_defs.iter().enumerate() {
-        by_name.insert(
-            fd.name.clone(),
+        let rfd = &resolved_fn_defs[i];
+        by_id.insert(
+            rfd.fn_id,
             FnEntry {
                 wasm_idx: import_count + 1 + (i as u32),
                 return_type: fd.return_type.clone(),
@@ -2145,7 +2153,7 @@ pub(super) fn emit_module_with(
         }
     }
     let fn_map = FnMap {
-        by_name,
+        by_id,
         builtins: builtin_idx_lookup,
         effects: effect_idx_lookup.clone(),
         map_helpers: map_helpers_lookup,


### PR DESCRIPTION
## Summary

PR 9.3a (#161) made `CodegenContext::resolve_fn_def` key by `FnKey/FnId` via `SymbolTable::fn_id_of` instead of bare-name flat search. PR 9.3b (#162) promoted the post-flatten resolver rebuild to a first-class `WasmGcLinkedView`. **This PR closes the last name-keyed dispatch site in wasm-gc**: `FnMap.by_name` → `FnMap.by_id`.

Pre-9.3c the call lowering path in `body/emit.rs` did `FnId → name → fn_map.by_name.get(&name)` — the projection through string worked only because `flatten_multimodule` prefixes every dep fn name. Now `Call(Fn(id))` and `TailCall { target }` read `fn_map.by_id.get(&id)` directly.

Issue: #147 phase E PR 9.3c.

## What changed

- **`body.rs`** — `FnMap.by_name: HashMap<String, FnEntry>` dropped; replaced by `FnMap.by_id: HashMap<FnId, FnEntry>`. `FnEntry` gains `derive(Clone)`. Doc-comment explains the FnId-keyed dispatch is the mirror of `CodegenContext::resolve_fn_def`'s FnKey-keyed lookup from PR 9.3a.
- **`module.rs`** — fn-map construction loop iterates `(i, fd)` and reads `resolved_fn_defs[i].fn_id` to key the entry (position-aligned by `WasmGcLinkedView::build`'s invariant).
- **`body/emit.rs::emit_expr`** `Call(Fn(id))` arm — reads `ctx.fn_map.by_id.get(id)` first. Falls back to `ctx.self_local_slot(name)` only when by_id misses (`Fn(...) -> _` values parked in local slots, verify-only paths). Name lookup via `symbol_table.fn_entry(*id).key.name` happens only on the miss path, for the diagnostic message and the slot check.
- **`body/emit.rs::emit_tail_call`** — signature switches from `target: &str` to `target: crate::ir::FnId`. The `ResolvedExpr::TailCall { target, args }` dispatch passes the FnId directly. Self-tail-call check compares `entry.wasm_idx == ctx.self_wasm_idx` (replaces the pre-9.3c `target_name == ctx.self_fn_name` string compare).
- **`mod.rs`** — module-level doc-comment rewritten to reflect the shipped Phase E sequence (PR 9.0.1 → 9 → 9.1 → 9.2 → 9.3a → 9.3b → 9.3c) instead of the pre-merge "PR 9.2" plan. Mentions `WasmGcLinkedView` and `FnMap.by_id` explicitly.

Net: **+90 / −55** across 4 files.

## Why this closes the smell

The reviewer flagged it post-9.3b:
> W wasm-gc call lowering nadal jest projekcja FnId -> name -> fn_map.by_name. W flattened world to pewnie działa, ale turbo-solid wersja to FnMap keyed by FnId.

After this PR: every dispatch in wasm-gc reads identity off `FnId` end-to-end. Call lowering, tail-call, resolver lookup, view's `fn_def_by_id` — same key throughout.

## Test plan

- [x] `cargo build --features wasm`
- [x] `cargo test --features wasm --no-fail-fast` — **1649 passed, 0 failed**.
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Byte-identical wasm output for every snapshot fixture (all 12 baseline md5s match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)