### PR TITLE
codegen: cross-module bare-type lookup + scope-aware resolve helpers — #147 phase E PR 9.4 (self-host regen fix)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -729,7 +729,7 @@ impl CodegenContext {
         let lifted = resolve_fn_def_external(&rctx, fd).unwrap_or_else(|| {
             let stmts: Vec<ResolvedStmt> = match fd.body.as_ref() {
                 crate::ast::FnBody::Block(stmts) => {
-                    stmts.iter().map(|s| self.resolve_stmt(s)).collect()
+                    stmts.iter().map(|s| self.resolve_stmt(s, scope)).collect()
                 }
             };
             ResolvedFnDef {
@@ -751,23 +751,43 @@ impl CodegenContext {
         Cow::Owned(lifted)
     }
 
+    /// Entry module's name from `items` (the `module X` declaration's
+    /// X). `None` for ad-hoc test programs without a module decl.
+    fn entry_module_name(&self) -> Option<String> {
+        self.items.iter().find_map(|i| match i {
+            TopLevel::Module(m) => Some(m.name.clone()),
+            _ => None,
+        })
+    }
+
     /// Resolve a source-shape `Spanned<Expr>` on demand using the
     /// entry's resolver context. Used by emit helpers that still walk
     /// `Expr` (TCO hoisting, mutual TCO, verify blocks, follow-up
     /// backends pre-migration) and need to feed the resolved shape
     /// into the migrated emitter. The returned `Spanned<ResolvedExpr>`
     /// carries the same line + type stamp as the input.
+    ///
+    /// `scope` is the owning module prefix when the caller knows
+    /// which dep module the expression lives in, `None` for entry-
+    /// scope code. Required for cross-module name resolution — e.g.,
+    /// a call site in module `A` referring to `Val.ValOk` declared
+    /// in module `B` only resolves to `ResolvedCtor::User` when the
+    /// resolver's `current_module` matches the call site's owning
+    /// scope. Pre-PR-9.4 the helper used the *entry* module name
+    /// uniformly, which broke cross-module ctor / fn classification
+    /// for the legacy emit paths (mutual TCO trampolines, TCO hoist
+    /// — they walked dep-module fn bodies but the resolver context
+    /// said "you're in the entry module"; the self-host regen
+    /// surfaced the gap when same-name shadowing across modules was
+    /// no longer an option).
     pub fn resolve_expr(
         &self,
         expr: &crate::ast::Spanned<crate::ast::Expr>,
+        scope: Option<&str>,
     ) -> crate::ast::Spanned<crate::ir::hir::ResolvedExpr> {
         use crate::ir::hir::{ResolveCtx, ResolvedStmt};
-        let module_name = self.items.iter().find_map(|i| match i {
-            TopLevel::Module(m) => Some(m.name.clone()),
-            _ => None,
-        });
         let mut rctx = ResolveCtx::new(&self.symbol_table);
-        rctx.current_module = module_name;
+        rctx.current_module = scope.map(String::from).or_else(|| self.entry_module_name());
         let stmt = crate::ast::Stmt::Expr(expr.clone());
         match crate::ir::hir::resolve::resolve_stmt_external(&rctx, &stmt) {
             ResolvedStmt::Expr(s) => s,
@@ -777,14 +797,14 @@ impl CodegenContext {
 
     /// Same as [`Self::resolve_expr`] but for whole statements
     /// (`Binding(name, ty_ann, expr)` or `Expr(expr)`).
-    pub fn resolve_stmt(&self, stmt: &crate::ast::Stmt) -> crate::ir::hir::ResolvedStmt {
+    pub fn resolve_stmt(
+        &self,
+        stmt: &crate::ast::Stmt,
+        scope: Option<&str>,
+    ) -> crate::ir::hir::ResolvedStmt {
         use crate::ir::hir::ResolveCtx;
-        let module_name = self.items.iter().find_map(|i| match i {
-            TopLevel::Module(m) => Some(m.name.clone()),
-            _ => None,
-        });
         let mut rctx = ResolveCtx::new(&self.symbol_table);
-        rctx.current_module = module_name;
+        rctx.current_module = scope.map(String::from).or_else(|| self.entry_module_name());
         crate::ir::hir::resolve::resolve_stmt_external(&rctx, stmt)
     }
 
@@ -793,15 +813,15 @@ impl CodegenContext {
     /// it through `resolve_stmt_external`, since the resolver doesn't
     /// expose a standalone pattern lifter — same workaround
     /// `rust/toplevel.rs` used pre-PR-9.
-    pub fn resolve_pattern(&self, pat: &crate::ast::Pattern) -> crate::ir::hir::ResolvedPattern {
+    pub fn resolve_pattern(
+        &self,
+        pat: &crate::ast::Pattern,
+        scope: Option<&str>,
+    ) -> crate::ir::hir::ResolvedPattern {
         use crate::ast::{Expr, Literal, MatchArm, Spanned, Stmt};
         use crate::ir::hir::{ResolveCtx, ResolvedExpr, ResolvedStmt};
-        let module_name = self.items.iter().find_map(|i| match i {
-            TopLevel::Module(m) => Some(m.name.clone()),
-            _ => None,
-        });
         let mut rctx = ResolveCtx::new(&self.symbol_table);
-        rctx.current_module = module_name;
+        rctx.current_module = scope.map(String::from).or_else(|| self.entry_module_name());
         let synthetic_arm = MatchArm {
             pattern: pat.clone(),
             body: Box::new(Spanned::bare(Expr::Literal(Literal::Unit))),

--- a/src/codegen/rust/emit_ctx.rs
+++ b/src/codegen/rust/emit_ctx.rs
@@ -17,6 +17,17 @@ pub struct EmitCtx {
     pub rc_wrapped: HashSet<String>,
     /// Parameters emitted as `&T` borrows (borrow-by-default for non-Copy, non-Str params).
     pub borrowed_params: HashSet<String>,
+    /// Owning module prefix for the function whose body this context
+    /// is emitting (`Some("Domain.Eval.Core")` inside a dep module's
+    /// fn body, `None` for entry-scope fns). Threaded into
+    /// `ctx.resolve_expr` / `ctx.resolve_stmt` / `ctx.resolve_pattern`
+    /// from the on-demand legacy emit helpers so cross-module ctor /
+    /// fn classification uses the right resolver `current_module`
+    /// instead of falling back to the entry's. Pre-PR-9.4 the legacy
+    /// helpers used the entry-module name uniformly, which silently
+    /// mis-resolved cross-module `Type.Variant(...)` calls inside
+    /// trampoline arms (self-host regen exposure).
+    pub current_module_scope: Option<String>,
 }
 
 impl EmitCtx {
@@ -26,6 +37,7 @@ impl EmitCtx {
             local_types: HashMap::new(),
             rc_wrapped: HashSet::new(),
             borrowed_params: HashSet::new(),
+            current_module_scope: None,
         }
     }
 
@@ -41,6 +53,7 @@ impl EmitCtx {
             local_types: param_types,
             rc_wrapped: HashSet::new(),
             borrowed_params,
+            current_module_scope: None,
         }
     }
 
@@ -50,7 +63,16 @@ impl EmitCtx {
             local_types: param_types,
             rc_wrapped: HashSet::new(),
             borrowed_params: HashSet::new(),
+            current_module_scope: None,
         }
+    }
+
+    /// Stamp the owning module prefix onto a context — chains
+    /// fluently after `for_fn` / `for_fn_no_borrow`. `None` for
+    /// entry-scope fns keeps the field default.
+    pub fn with_scope(mut self, scope: Option<&str>) -> Self {
+        self.current_module_scope = scope.map(String::from);
+        self
     }
 
     /// Is this variable a Copy type in Rust (i64, f64, bool, ())?
@@ -74,6 +96,7 @@ impl EmitCtx {
             local_types: self.local_types.clone(),
             rc_wrapped: rc,
             borrowed_params: self.borrowed_params.clone(),
+            current_module_scope: self.current_module_scope.clone(),
         }
     }
 }

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -449,6 +449,7 @@ fn entry_module_sections(
             group_id + 1,
             &group_fns,
             ctx,
+            None,
             "pub ",
         ));
     }
@@ -515,6 +516,7 @@ fn module_sections(module: &crate::codegen::ModuleInfo, ctx: &CodegenContext) ->
             group_id + 1,
             &group_fns,
             ctx,
+            Some(&module.prefix),
             "pub ",
         ));
     }

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -14,10 +14,18 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
 // Resolved-form lookup helpers live as methods on [`CodegenContext`]
-// since Phase E PR 9: `ctx.resolve_fn_def(fd)`, `ctx.resolve_expr(spanned)`,
-// `ctx.resolve_stmt(stmt)`, `ctx.resolve_pattern(pat)` — shared with
-// wasm-gc / Lean / Dafny / self-host backends as they migrate. See
-// `src/codegen/mod.rs`.
+// since Phase E PR 9: `ctx.resolve_fn_def(fd, scope)`,
+// `ctx.resolve_expr(spanned, scope)`, `ctx.resolve_stmt(stmt, scope)`,
+// `ctx.resolve_pattern(pat, scope)` — shared with wasm-gc / Lean /
+// Dafny / self-host backends as they migrate. The `scope` parameter
+// (Phase E PR 9.3a / 9.4) carries the owning module prefix when the
+// caller knows which dep module the source-shape AST lives in, so
+// cross-module ctor / fn classification uses the right resolver
+// `current_module` instead of the entry's. The local `emit_*_legacy`
+// helpers below read `scope` off `EmitCtx::current_module_scope`
+// (stamped via `EmitCtx::with_scope` at fn-emit time) so the
+// threading stays implicit through 20+ on-demand call sites.
+// See `src/codegen/mod.rs`.
 
 /// Source-shape variant of [`emit_expr`] for emitters that still hold
 /// a pre-resolve [`Expr`] borrow (TCO hoisting / loop, mutual-TCO
@@ -27,14 +35,14 @@ use std::fmt::Write as _;
 /// call — cheap for the small subtrees these helpers walk.
 fn emit_expr_legacy(expr: &Expr, ctx: &CodegenContext, ectx: &EmitCtx) -> String {
     let spanned = Spanned::bare(expr.clone());
-    let resolved = ctx.resolve_expr(&spanned);
+    let resolved = ctx.resolve_expr(&spanned, ectx.current_module_scope.as_deref());
     emit_expr(&resolved.node, ctx, ectx)
 }
 
 /// `clone_arg`/`borrow_arg` analogue that takes a source-shape `&Expr`.
 fn clone_arg_legacy(expr: &Expr, ctx: &CodegenContext, ectx: &EmitCtx) -> String {
     let spanned = Spanned::bare(expr.clone());
-    let resolved = ctx.resolve_expr(&spanned);
+    let resolved = ctx.resolve_expr(&spanned, ectx.current_module_scope.as_deref());
     clone_arg(&resolved.node, ctx, ectx)
 }
 
@@ -86,13 +94,18 @@ fn classify_body_expr_plan_source<'a>(
 /// through [`CodegenContext::resolve_stmt`] and calls the migrated
 /// emit.
 fn emit_stmt_legacy(stmt: &Stmt, ctx: &CodegenContext, ectx: &EmitCtx) -> String {
-    let resolved = ctx.resolve_stmt(stmt);
+    let resolved = ctx.resolve_stmt(stmt, ectx.current_module_scope.as_deref());
     emit_stmt(&resolved, ctx, ectx)
 }
 
 /// Source-shape variant of [`super::pattern::emit_pattern`].
-fn emit_pattern_legacy(pat: &Pattern, string_context: bool, ctx: &CodegenContext) -> String {
-    let resolved = ctx.resolve_pattern(pat);
+fn emit_pattern_legacy(
+    pat: &Pattern,
+    string_context: bool,
+    ctx: &CodegenContext,
+    ectx: &EmitCtx,
+) -> String {
+    let resolved = ctx.resolve_pattern(pat, ectx.current_module_scope.as_deref());
     super::pattern::emit_pattern(&resolved, string_context, ctx)
 }
 
@@ -113,11 +126,16 @@ fn has_list_patterns_legacy(arms: &[MatchArm]) -> bool {
 /// past `Expr` shape (TCO loop emit, mutual-TCO trampoline arms) but
 /// need to feed `&[ResolvedMatchArm]` to the migrated dispatch /
 /// list-match / pattern emit helpers.
-fn resolve_match_arms_on_demand(arms: &[MatchArm], ctx: &CodegenContext) -> Vec<ResolvedMatchArm> {
+fn resolve_match_arms_on_demand(
+    arms: &[MatchArm],
+    ctx: &CodegenContext,
+    ectx: &EmitCtx,
+) -> Vec<ResolvedMatchArm> {
+    let scope = ectx.current_module_scope.as_deref();
     arms.iter()
         .map(|arm| {
-            let pattern = ctx.resolve_pattern(&arm.pattern);
-            let body = Box::new(ctx.resolve_expr(&arm.body));
+            let pattern = ctx.resolve_pattern(&arm.pattern, scope);
+            let body = Box::new(ctx.resolve_expr(&arm.body, scope));
             let binding_slots = std::sync::OnceLock::new();
             if let Some(slots) = arm.binding_slots.get() {
                 let _ = binding_slots.set(slots.clone());
@@ -138,7 +156,7 @@ fn classify_dispatch_plan_for_rust_legacy(
     ctx: &CodegenContext,
     ectx: &EmitCtx,
 ) -> Option<crate::ir::MatchDispatchPlan> {
-    let resolved = resolve_match_arms_on_demand(arms, ctx);
+    let resolved = resolve_match_arms_on_demand(arms, ctx, ectx);
     classify_dispatch_plan_for_rust(&resolved, ctx, ectx)
 }
 
@@ -149,12 +167,13 @@ fn emit_list_match_legacy<F>(
     list_shape: Option<crate::ir::ListMatchShape>,
     allow_fast_macro: bool,
     ctx: &CodegenContext,
+    ectx: &EmitCtx,
     body_for_arm: F,
 ) -> String
 where
     F: Fn(&MatchArm) -> String,
 {
-    let resolved = resolve_match_arms_on_demand(arms, ctx);
+    let resolved = resolve_match_arms_on_demand(arms, ctx, ectx);
     super::expr::emit_list_match(
         subject,
         &resolved,
@@ -185,12 +204,13 @@ fn emit_dispatch_table_match_legacy<F>(
     arms: &[MatchArm],
     shape: &crate::ir::DispatchTableShape,
     ctx: &CodegenContext,
+    ectx: &EmitCtx,
     body_for_arm: F,
 ) -> String
 where
     F: Fn(&MatchArm) -> String,
 {
-    let resolved = resolve_match_arms_on_demand(arms, ctx);
+    let resolved = resolve_match_arms_on_demand(arms, ctx, ectx);
     super::expr::emit_dispatch_table_match(subject, &resolved, shape, |rarm| {
         let idx = resolved
             .iter()
@@ -537,14 +557,14 @@ fn collect_fn_local_types(fd: &FnDef, ctx: &CodegenContext) -> HashMap<String, T
 
 /// Build an EmitCtx for a function from its parameter types in fn_sigs.
 /// Uses borrow-by-default: non-Copy, non-Str params are tracked as borrowed.
-fn build_fn_ectx(fd: &FnDef, ctx: &CodegenContext) -> EmitCtx {
-    EmitCtx::for_fn(collect_fn_local_types(fd, ctx))
+fn build_fn_ectx(fd: &FnDef, ctx: &CodegenContext, scope: Option<&str>) -> EmitCtx {
+    EmitCtx::for_fn(collect_fn_local_types(fd, ctx)).with_scope(scope)
 }
 
 /// Build an EmitCtx for a function WITHOUT borrow-by-default.
 /// Used for TCO and memo functions where params need to be owned/mutable.
-fn build_fn_ectx_no_borrow(fd: &FnDef, ctx: &CodegenContext) -> EmitCtx {
-    EmitCtx::for_fn_no_borrow(collect_fn_local_types(fd, ctx))
+fn build_fn_ectx_no_borrow(fd: &FnDef, ctx: &CodegenContext, scope: Option<&str>) -> EmitCtx {
+    EmitCtx::for_fn_no_borrow(collect_fn_local_types(fd, ctx)).with_scope(scope)
 }
 
 /// Emit a Rust function from an Aver FnDef.
@@ -604,9 +624,9 @@ fn emit_fn_def_with_visibility(
     // Memo functions always use borrow-by-default (memo wrapper takes &T).
     // Normal functions use borrow-by-default for non-Copy, non-Str params.
     let ectx = if has_tco && !use_memo {
-        build_fn_ectx_no_borrow(fd, ctx)
+        build_fn_ectx_no_borrow(fd, ctx, scope)
     } else {
-        build_fn_ectx(fd, ctx)
+        build_fn_ectx(fd, ctx, scope)
     };
 
     let guest_args_name = if is_guest_entry {
@@ -2179,7 +2199,7 @@ fn emit_tco_expr(
 
             let needs_as_str = has_string_literal_patterns_legacy(arms);
             if has_list_patterns_legacy(arms) {
-                return emit_list_match_legacy(subj, arms, None, true, ctx, |arm| {
+                return emit_list_match_legacy(subj, arms, None, true, ctx, ectx, |arm| {
                     emit_tco_expr(
                         &arm.body.node,
                         self_name,
@@ -2194,7 +2214,7 @@ fn emit_tco_expr(
             }
 
             if let Some(crate::ir::MatchDispatchPlan::Table(shape)) = dispatch_plan.as_ref() {
-                return emit_dispatch_table_match_legacy(subj, arms, shape, ctx, |arm| {
+                return emit_dispatch_table_match_legacy(subj, arms, shape, ctx, ectx, |arm| {
                     emit_tco_expr(
                         &arm.body.node,
                         self_name,
@@ -2216,7 +2236,7 @@ fn emit_tco_expr(
 
             let mut arm_strs = Vec::new();
             for arm in arms {
-                let pat = emit_pattern_legacy(&arm.pattern, needs_as_str, ctx);
+                let pat = emit_pattern_legacy(&arm.pattern, needs_as_str, ctx, ectx);
                 let body = emit_tco_expr(
                     &arm.body.node,
                     self_name,
@@ -2317,6 +2337,7 @@ pub fn emit_mutual_tco_block(
     group_id: usize,
     group_fns: &[&FnDef],
     ctx: &CodegenContext,
+    scope: Option<&str>,
     visibility: &str,
 ) -> String {
     let enum_name = format!("__MutualTco{}", group_id);
@@ -2408,7 +2429,7 @@ pub fn emit_mutual_tco_block(
         tramp_lines.push(format!("            {} => {{", binding));
 
         // Trampoline params are `mut T`, no borrow-by-default
-        let ectx = build_fn_ectx_no_borrow(fd, ctx);
+        let ectx = build_fn_ectx_no_borrow(fd, ctx, scope);
         let ectx = if rc_names.is_empty() {
             ectx
         } else {
@@ -2598,7 +2619,7 @@ fn emit_trampoline_expr(
 
             // List match
             if has_list_patterns_legacy(arms) {
-                return emit_list_match_legacy(subj, arms, None, true, ctx, |arm| {
+                return emit_list_match_legacy(subj, arms, None, true, ctx, ectx, |arm| {
                     emit_trampoline_expr(
                         &arm.body.node,
                         enum_name,
@@ -2611,7 +2632,7 @@ fn emit_trampoline_expr(
             }
 
             if let Some(crate::ir::MatchDispatchPlan::Table(shape)) = dispatch_plan.as_ref() {
-                return emit_dispatch_table_match_legacy(subj, arms, shape, ctx, |arm| {
+                return emit_dispatch_table_match_legacy(subj, arms, shape, ctx, ectx, |arm| {
                     emit_trampoline_expr(
                         &arm.body.node,
                         enum_name,
@@ -2632,7 +2653,7 @@ fn emit_trampoline_expr(
 
             let mut arm_strs = Vec::new();
             for arm in arms {
-                let pat = emit_pattern_legacy(&arm.pattern, needs_as_str, ctx);
+                let pat = emit_pattern_legacy(&arm.pattern, needs_as_str, ctx, ectx);
                 let body = emit_trampoline_expr(
                     &arm.body.node,
                     enum_name,
@@ -2896,7 +2917,7 @@ fn emit_main_with_visibility(
 
     // Main function body
     if let Some(fd) = main_fn {
-        let main_ectx = build_fn_ectx(fd, ctx);
+        let main_ectx = build_fn_ectx(fd, ctx, None);
         let stmts = fd.body.stmts();
         for (i, stmt) in stmts.iter().enumerate() {
             let is_last = i == stmts.len() - 1;
@@ -3042,7 +3063,7 @@ mod tests {
             "repeatSum",
             vec![("xs", "List<Int>"), ("remaining", "Int"), ("sink", "Int")],
         );
-        let ectx = build_fn_ectx(&fd, &ctx);
+        let ectx = build_fn_ectx(&fd, &ctx, None);
         let expr = Expr::TailCall(Box::new(TailCallData::new(
             "repeatSum".to_string(),
             vec![
@@ -3095,7 +3116,7 @@ mod tests {
                 ("sink", "Int"),
             ],
         );
-        let ectx = build_fn_ectx(&fd, &ctx);
+        let ectx = build_fn_ectx(&fd, &ctx, None);
         let expr = Expr::TailCall(Box::new(TailCallData::new(
             "repeatAppend".to_string(),
             vec![
@@ -3148,7 +3169,7 @@ mod tests {
     fn self_tco_does_not_rewrite_same_arity_mutual_tailcall() {
         let ctx = empty_ctx();
         let fd = list_param_fn("validSymbolNames", vec![("e", "Sexpr")]);
-        let ectx = build_fn_ectx(&fd, &ctx);
+        let ectx = build_fn_ectx(&fd, &ctx, None);
         let expr = Expr::TailCall(Box::new(TailCallData::new(
             "validSymbolList".to_string(),
             vec![Spanned::bare(Expr::Ident("e".to_string()))],
@@ -3177,7 +3198,7 @@ mod tests {
             "sumAreas",
             vec![("n", "Int"), ("acc", "Int"), ("pick", "Int")],
         );
-        let ectx = build_fn_ectx(&fd, &ctx);
+        let ectx = build_fn_ectx(&fd, &ctx, None);
         let expr = Expr::TailCall(Box::new(TailCallData::new(
             "sumAreas".to_string(),
             vec![
@@ -3498,7 +3519,7 @@ mod tests {
         assert_eq!(groups[0], vec![0, 1]);
 
         let ctx = empty_ctx();
-        let block = emit_mutual_tco_block(1, &fn_defs, &ctx, "pub ");
+        let block = emit_mutual_tco_block(1, &fn_defs, &ctx, None, "pub ");
 
         // Enum with variants for both functions
         assert!(block.contains("enum __MutualTco1"));
@@ -3553,7 +3574,7 @@ mod tests {
         assert_eq!(groups[0], vec![0, 1, 2]);
 
         let ctx = empty_ctx();
-        let block = emit_mutual_tco_block(1, &fn_defs, &ctx, "pub ");
+        let block = emit_mutual_tco_block(1, &fn_defs, &ctx, None, "pub ");
         assert!(block.contains("StateA(i64)"));
         assert!(block.contains("StateB(i64)"));
         assert!(block.contains("StateC(i64)"));

--- a/src/ir/hir/resolve.rs
+++ b/src/ir/hir/resolve.rs
@@ -107,6 +107,20 @@ impl<'a> ResolveCtx<'a> {
     }
 
     /// Type-side equivalent of [`Self::resolve_fn_id`].
+    ///
+    /// Resolution order (first match wins):
+    /// 1. `prefix.name` matches `TypeKey::in_module(prefix, name)`.
+    /// 2. `prefix.name` with `prefix == current_module` matches the
+    ///    entry-scope `TypeKey::entry(name)` (Aver lets a
+    ///    self-referencing module spell its own type with the
+    ///    qualified form).
+    /// 3. Bare `name` in `current_module` (`TypeKey::in_module(current, name)`).
+    /// 4. Bare `name` in entry scope (`TypeKey::entry(name)`).
+    /// 5. Bare `name` searched across every scope via
+    ///    [`crate::ir::SymbolTable::type_id_by_bare_name`] — handles
+    ///    the cross-module case where module `A` references type
+    ///    `Val` declared in module `B` without qualification. Returns
+    ///    `None` when ambiguous (caller must qualify).
     pub fn resolve_type_id(&self, name: &str) -> Option<TypeId> {
         if let Some((prefix, n)) = name.rsplit_once('.') {
             if let Some(id) = self.symbols.type_id_of(&TypeKey::in_module(prefix, n)) {
@@ -123,7 +137,16 @@ impl<'a> ResolveCtx<'a> {
         {
             return Some(id);
         }
-        self.symbols.type_id_of(&TypeKey::entry(name))
+        if let Some(id) = self.symbols.type_id_of(&TypeKey::entry(name)) {
+            return Some(id);
+        }
+        // Cross-module bare-name fallback. Phase-E ctor resolution
+        // for `Val.ValOk(x)` written from a module that doesn't host
+        // `Val` (e.g. `Domain.Eval.Core` referencing
+        // `Domain.Value.Val`). `type_id_by_bare_name` returns `None`
+        // on ambiguity, so two scopes that share a type name still
+        // need a qualified reference.
+        self.symbols.type_id_by_bare_name(name)
     }
 
     /// Resolve a `"Type.Variant"` constructor reference to a

--- a/src/ir/symbol_table.rs
+++ b/src/ir/symbol_table.rs
@@ -232,6 +232,36 @@ impl SymbolTable {
         self.type_index.get(key).copied()
     }
 
+    /// Resolve a *bare* type name (no module prefix) against every
+    /// scope in the table — entry first, then each dep module — and
+    /// return the unique match. Returns `None` when the name doesn't
+    /// resolve OR when two or more scopes legitimately share it
+    /// (ambiguous reference; caller must qualify).
+    ///
+    /// Phase-E cross-module ctor resolution: an Aver expression like
+    /// `Val.ValOk(x)` written from a module that doesn't host the
+    /// `Val` type still needs to resolve to the right `TypeId` so the
+    /// resolver can lift the call to `ResolvedCtor::User`. Pre-PR-8
+    /// the rust codegen worked around the gap by matching ctors by
+    /// raw string after the resolver had moved on; PR 8 made the
+    /// resolved-form classification authoritative, which exposed
+    /// this missing lookup. Adding it here keeps identity logic on
+    /// the symbol table where the rest of identity resolution lives.
+    pub fn type_id_by_bare_name(&self, name: &str) -> Option<TypeId> {
+        let mut found: Option<TypeId> = None;
+        for (key, id) in &self.type_index {
+            if key.name == name {
+                if found.is_some() {
+                    // Ambiguous bare reference across scopes; the
+                    // caller must qualify with a module prefix.
+                    return None;
+                }
+                found = Some(*id);
+            }
+        }
+        found
+    }
+
     /// Resolve a constructor by (owning type, variant name).
     pub fn ctor_id_of(&self, owning_type: TypeId, variant: &str) -> Option<CtorId> {
         self.ctor_index
@@ -482,5 +512,72 @@ mod tests {
         let entry_fn = table.fn_id_of(&FnKey::entry("entry_fn")).unwrap();
         assert_eq!(table.fn_entry(entry_fn).module, ModuleId::ENTRY);
         assert_eq!(table.module_entry(ModuleId::ENTRY).prefix, None);
+    }
+
+    #[test]
+    fn type_id_by_bare_name_resolves_unique_cross_module_type() {
+        // Phase-E PR 9.4: a callsite in module `A` referring to type
+        // `Val` declared in module `B` (no qualifier in source) gets
+        // the right `TypeId` via this fallback. The rule is: "bare
+        // type name from any scope resolves iff exactly one scope
+        // declares it".
+        let mod_a = module("A", vec![], vec![sum("Color", &["Red", "Blue"], 1)]);
+        let mod_b = module("B", vec![], vec![product("Val", 1)]);
+        let table = SymbolTable::build(&[], &[mod_a, mod_b]);
+        table.assert_consistent();
+
+        let val_id = table.type_id_by_bare_name("Val");
+        let qualified = table.type_id_of(&TypeKey::in_module("B", "Val"));
+        assert_eq!(val_id, qualified, "bare `Val` resolves to B.Val");
+        assert!(val_id.is_some());
+
+        let color_id = table.type_id_by_bare_name("Color");
+        assert_eq!(
+            color_id,
+            table.type_id_of(&TypeKey::in_module("A", "Color"))
+        );
+    }
+
+    #[test]
+    fn type_id_by_bare_name_returns_none_on_ambiguity() {
+        // Two modules each declaring a type called `T` — bare
+        // reference is ambiguous, caller must qualify. The cross-
+        // module ctor-classification path falls back to
+        // `Unresolved` here, which the typechecker then flags as a
+        // user-facing error (or the caller already qualified, in
+        // which case the higher-priority `TypeKey::in_module`
+        // lookup succeeded before this method ran).
+        let mod_a = module("A", vec![], vec![product("T", 1)]);
+        let mod_b = module("B", vec![], vec![product("T", 1)]);
+        let table = SymbolTable::build(&[], &[mod_a, mod_b]);
+        table.assert_consistent();
+
+        assert_eq!(table.type_id_by_bare_name("T"), None);
+
+        // Qualified lookups still resolve.
+        assert!(table.type_id_of(&TypeKey::in_module("A", "T")).is_some());
+        assert!(table.type_id_of(&TypeKey::in_module("B", "T")).is_some());
+    }
+
+    #[test]
+    fn type_id_by_bare_name_finds_entry_scope_type() {
+        // Bare lookup also reaches the entry scope when only the
+        // entry declares the type — same uniqueness rule.
+        let entry_type = product("Cfg", 1);
+        let mod_a = module("A", vec![], vec![sum("Other", &["X"], 1)]);
+        let table = SymbolTable::build(&[TopLevel::TypeDef(entry_type)], &[mod_a]);
+        table.assert_consistent();
+
+        let cfg = table.type_id_by_bare_name("Cfg");
+        assert_eq!(cfg, table.type_id_of(&TypeKey::entry("Cfg")));
+        assert!(cfg.is_some());
+    }
+
+    #[test]
+    fn type_id_by_bare_name_missing_name_is_none() {
+        let mod_a = module("A", vec![], vec![product("X", 1)]);
+        let table = SymbolTable::build(&[], &[mod_a]);
+        table.assert_consistent();
+        assert_eq!(table.type_id_by_bare_name("NotATypeAnywhere"), None);
     }
 }

--- a/src/self_host/aver_generated/domain/ast/mod.rs
+++ b/src/self_host/aver_generated/domain/ast/mod.rs
@@ -2922,18 +2922,19 @@ pub fn ctorNameToTag(name: AverStr) -> i64 {
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Result.Ok" {
-            tagResultOk()
+            crate::aver_generated::domain::ast::tagResultOk()
         } else {
             if &*__dispatch_subject == "Result.Err" {
-                tagResultErr()
+                crate::aver_generated::domain::ast::tagResultErr()
             } else {
                 if &*__dispatch_subject == "Option.Some" {
-                    tagOptionSome()
+                    crate::aver_generated::domain::ast::tagOptionSome()
                 } else {
                     if &*__dispatch_subject == "Option.None" {
-                        tagOptionNone()
+                        crate::aver_generated::domain::ast::tagOptionNone()
                     } else {
-                        (tagUserBase() + &userCtorTagOffset(name))
+                        (crate::aver_generated::domain::ast::tagUserBase()
+                            + &crate::aver_generated::domain::ast::userCtorTagOffset(name))
                     }
                 }
             }
@@ -2945,7 +2946,7 @@ pub fn ctorNameToTag(name: AverStr) -> i64 {
 #[inline(always)]
 pub fn userCtorTagOffset(name: AverStr) -> i64 {
     crate::cancel_checkpoint();
-    userCtorTagOffsetLoop(name, 0i64, 0i64)
+    crate::aver_generated::domain::ast::userCtorTagOffsetLoop(name, 0i64, 0i64)
 }
 
 /// Walk the constructor name and accumulate a bounded rolling hash.
@@ -2960,8 +2961,10 @@ pub fn userCtorTagOffsetLoop(mut name: AverStr, mut pos: i64, mut acc: i64) -> i
             match (name.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(ch) => {
                     let __tmp1 = (pos + 1i64);
-                    let __tmp2 =
-                        userCtorTagStep(acc, (ch.chars().next().map(|c| c as i64).unwrap_or(0i64)));
+                    let __tmp2 = crate::aver_generated::domain::ast::userCtorTagStep(
+                        acc,
+                        (ch.chars().next().map(|c| c as i64).unwrap_or(0i64)),
+                    );
                     pos = __tmp1;
                     acc = __tmp2;
                     continue;
@@ -2977,7 +2980,7 @@ pub fn userCtorTagStep(acc: i64, code: i64) -> i64 {
     crate::cancel_checkpoint();
     let next = ((acc * 131i64) + code);
     {
-        let __b = userTagSpan();
+        let __b = crate::aver_generated::domain::ast::userTagSpan();
         if __b == 0i64 {
             0i64
         } else {

--- a/src/self_host/aver_generated/domain/builtins/helpers/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/helpers/mod.rs
@@ -54,7 +54,7 @@ pub fn twoArgs(args: &aver_rt::AverList<Val>) -> Result<(Val, Val), AverStr> {
 pub fn expectList(v: &Val) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValList(items) => Ok(items),
+        crate::aver_generated::domain::value::Val::ValList(items) => Ok(items),
         _ => Err(AverStr::from("expected list argument")),
     }
 }
@@ -63,7 +63,7 @@ pub fn expectList(v: &Val) -> Result<aver_rt::AverList<Val>, AverStr> {
 pub fn expectInt(v: &Val) -> Result<i64, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValInt(n) => Ok(n),
+        crate::aver_generated::domain::value::Val::ValInt(n) => Ok(n),
         _ => Err(AverStr::from("expected int argument")),
     }
 }
@@ -72,7 +72,7 @@ pub fn expectInt(v: &Val) -> Result<i64, AverStr> {
 pub fn expectStr(v: &Val) -> Result<AverStr, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValStr(s) => Ok(s),
+        crate::aver_generated::domain::value::Val::ValStr(s) => Ok(s),
         _ => Err(AverStr::from("expected string argument")),
     }
 }

--- a/src/self_host/aver_generated/domain/builtins/list/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/list/mod.rs
@@ -12,34 +12,36 @@ pub fn call(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "List.prepend" {
-            builtinListPrepend(args)
+            crate::aver_generated::domain::builtins::list::builtinListPrepend(args)
         } else {
             if &*__dispatch_subject == "List.len" {
-                builtinListLen(args)
+                crate::aver_generated::domain::builtins::list::builtinListLen(args)
             } else {
                 if &*__dispatch_subject == "List.take" {
-                    builtinListTake(args)
+                    crate::aver_generated::domain::builtins::list::builtinListTake(args)
                 } else {
                     if &*__dispatch_subject == "List.drop" {
-                        builtinListDrop(args)
+                        crate::aver_generated::domain::builtins::list::builtinListDrop(args)
                     } else {
                         if &*__dispatch_subject == "List.reverse" {
-                            builtinListReverse(args)
+                            crate::aver_generated::domain::builtins::list::builtinListReverse(args)
                         } else {
                             if &*__dispatch_subject == "List.concat" {
-                                builtinListConcat(args)
+                                crate::aver_generated::domain::builtins::list::builtinListConcat(
+                                    args,
+                                )
                             } else {
                                 if &*__dispatch_subject == "List.contains" {
-                                    builtinListContains(args)
+                                    crate::aver_generated::domain::builtins::list::builtinListContains(args)
                                 } else {
                                     if &*__dispatch_subject == "List.zip" {
-                                        builtinListZip(args)
+                                        crate::aver_generated::domain::builtins::list::builtinListZip(args)
                                     } else {
                                         if &*__dispatch_subject == "List.head" {
-                                            builtinListHead(args)
+                                            crate::aver_generated::domain::builtins::list::builtinListHead(args)
                                         } else {
                                             if &*__dispatch_subject == "List.tail" {
-                                                builtinListTail(args)
+                                                crate::aver_generated::domain::builtins::list::builtinListTail(args)
                                             } else {
                                                 Err(aver_rt::AverStr::from({
                                                     let mut __b = {
@@ -76,7 +78,7 @@ pub fn builtinListPrepend(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (v, lstV) = pair;
-        builtinListPrependInner(&v, &lstV)
+        crate::aver_generated::domain::builtins::list::builtinListPrependInner(&v, &lstV)
     }
 }
 
@@ -84,7 +86,9 @@ pub fn builtinListPrepend(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
 pub fn builtinListPrependInner(v: &Val, lstV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
-    Ok(Val::ValList(aver_rt::AverList::prepend(v.clone(), &items)))
+    Ok(crate::aver_generated::domain::value::Val::ValList(
+        aver_rt::AverList::prepend(v.clone(), &items),
+    ))
 }
 
 /// List.len(list) -> length as Int.
@@ -92,7 +96,9 @@ pub fn builtinListLen(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
-    Ok(Val::ValInt((items.len() as i64)))
+    Ok(crate::aver_generated::domain::value::Val::ValInt(
+        (items.len() as i64),
+    ))
 }
 
 /// List.take(list, n) -> first n elements.
@@ -101,7 +107,7 @@ pub fn builtinListTake(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (lstV, nV) = pair;
-        builtinListTakeInner(&lstV, &nV)
+        crate::aver_generated::domain::builtins::list::builtinListTakeInner(&lstV, &nV)
     }
 }
 
@@ -110,7 +116,9 @@ pub fn builtinListTakeInner(lstV: &Val, nV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
     let count = crate::aver_generated::domain::builtins::helpers::expectInt(nV)?;
-    Ok(Val::ValList(listTake(&items, count)))
+    Ok(crate::aver_generated::domain::value::Val::ValList(
+        crate::aver_generated::domain::builtins::list::listTake(&items, count),
+    ))
 }
 
 /// Keep the first count elements; negative counts produce empty lists.
@@ -118,7 +126,7 @@ pub fn builtinListTakeInner(lstV: &Val, nV: &Val) -> Result<Val, AverStr> {
 pub fn listTake(items: &aver_rt::AverList<Val>, count: i64) -> aver_rt::AverList<Val> {
     crate::cancel_checkpoint();
     if (count > 0i64) {
-        aver_list_match!(items.clone(), [] => aver_rt::AverList::empty(), [item, rest] => aver_rt::AverList::prepend(item, &listTake(&rest, (count - 1i64))))
+        aver_list_match!(items.clone(), [] => aver_rt::AverList::empty(), [item, rest] => aver_rt::AverList::prepend(item, &crate::aver_generated::domain::builtins::list::listTake(&rest, (count - 1i64))))
     } else {
         aver_rt::AverList::empty()
     }
@@ -130,7 +138,7 @@ pub fn builtinListDrop(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (lstV, nV) = pair;
-        builtinListDropInner(&lstV, &nV)
+        crate::aver_generated::domain::builtins::list::builtinListDropInner(&lstV, &nV)
     }
 }
 
@@ -139,7 +147,9 @@ pub fn builtinListDropInner(lstV: &Val, nV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
     let count = crate::aver_generated::domain::builtins::helpers::expectInt(nV)?;
-    Ok(Val::ValList(listDrop(items, count)))
+    Ok(crate::aver_generated::domain::value::Val::ValList(
+        crate::aver_generated::domain::builtins::list::listDrop(items, count),
+    ))
 }
 
 /// Skip the first count elements; negative counts leave the list unchanged.
@@ -165,7 +175,9 @@ pub fn builtinListReverse(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
-    Ok(Val::ValList(items.reverse()))
+    Ok(crate::aver_generated::domain::value::Val::ValList(
+        items.reverse(),
+    ))
 }
 
 /// List.concat(a, b) -> concatenated list.
@@ -174,7 +186,7 @@ pub fn builtinListConcat(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
-        builtinListConcatInner(&aV, &bV)
+        crate::aver_generated::domain::builtins::list::builtinListConcatInner(&aV, &bV)
     }
 }
 
@@ -183,7 +195,9 @@ pub fn builtinListConcatInner(aV: &Val, bV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let aItems = crate::aver_generated::domain::builtins::helpers::expectList(aV)?;
     let bItems = crate::aver_generated::domain::builtins::helpers::expectList(bV)?;
-    Ok(Val::ValList(aver_rt::AverList::concat(&aItems, &bItems)))
+    Ok(crate::aver_generated::domain::value::Val::ValList(
+        aver_rt::AverList::concat(&aItems, &bItems),
+    ))
 }
 
 /// List.contains(list, value) -> Bool.
@@ -192,7 +206,7 @@ pub fn builtinListContains(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (lstV, needle) = pair;
-        builtinListContainsInner(&lstV, &needle)
+        crate::aver_generated::domain::builtins::list::builtinListContainsInner(&lstV, &needle)
     }
 }
 
@@ -200,7 +214,9 @@ pub fn builtinListContains(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
 pub fn builtinListContainsInner(lstV: &Val, needle: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
-    Ok(Val::ValBool(listContainsVal(items, needle.clone())))
+    Ok(crate::aver_generated::domain::value::Val::ValBool(
+        crate::aver_generated::domain::builtins::list::listContainsVal(items, needle.clone()),
+    ))
 }
 
 /// Check if a value is in a list by repr comparison.
@@ -221,7 +237,7 @@ pub fn builtinListZip(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
-        builtinListZipInner(&aV, &bV)
+        crate::aver_generated::domain::builtins::list::builtinListZipInner(&aV, &bV)
     }
 }
 
@@ -230,14 +246,20 @@ pub fn builtinListZipInner(aV: &Val, bV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let aItems = crate::aver_generated::domain::builtins::helpers::expectList(aV)?;
     let bItems = crate::aver_generated::domain::builtins::helpers::expectList(bV)?;
-    Ok(Val::ValList(zipLists(&aItems, &bItems)))
+    Ok(crate::aver_generated::domain::value::Val::ValList(
+        crate::aver_generated::domain::builtins::list::zipLists(&aItems, &bItems),
+    ))
 }
 
 /// Zip two lists into list of ValTuple.
 #[inline(always)]
 pub fn zipLists(a: &aver_rt::AverList<Val>, b: &aver_rt::AverList<Val>) -> aver_rt::AverList<Val> {
     crate::cancel_checkpoint();
-    zipListsAcc(a.clone(), b.clone(), aver_rt::AverList::empty())
+    crate::aver_generated::domain::builtins::list::zipListsAcc(
+        a.clone(),
+        b.clone(),
+        aver_rt::AverList::empty(),
+    )
 }
 
 /// Accumulate zipped pairs in reverse, then reverse at end.
@@ -251,7 +273,7 @@ pub fn zipListsAcc(
         crate::cancel_checkpoint();
         let reversed = acc.reverse();
         return aver_list_match!(a, [] => reversed, [x, xs] => { aver_list_match!(b, [] => reversed, [y, ys] => { {
-            let __tmp2 = aver_rt::AverList::prepend(Val::ValTuple(aver_rt::AverList::from_vec(vec![x, y])), &acc);
+            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValTuple(aver_rt::AverList::from_vec(vec![x, y])), &acc);
             a = xs;
             b = ys;
             acc = __tmp2;
@@ -265,7 +287,7 @@ pub fn builtinListHead(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
-    aver_list_match!(items, [] => Ok(Val::ValNone.clone()), [h, rest] => Ok(Val::ValSome(std::sync::Arc::new(h))))
+    aver_list_match!(items, [] => Ok(Val::ValNone.clone()), [h, rest] => Ok(crate::aver_generated::domain::value::Val::ValSome(std::sync::Arc::new(h))))
 }
 
 /// List.tail(list) -> Option of rest.
@@ -273,5 +295,5 @@ pub fn builtinListTail(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
-    aver_list_match!(items, [] => Ok(Val::ValNone.clone()), [h, rest] => Ok(Val::ValSome(std::sync::Arc::new(Val::ValList(rest)))))
+    aver_list_match!(items, [] => Ok(Val::ValNone.clone()), [h, rest] => Ok(crate::aver_generated::domain::value::Val::ValSome(std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValList(rest)))))
 }

--- a/src/self_host/aver_generated/domain/builtins/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/mod.rs
@@ -31,7 +31,7 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverMap<Aver
             __MutualTco1::TuplesToMap(mut items, mut acc) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(items, [] => { return acc }, [item, rest] => match item {
-                Val::ValTuple(parts) => __MutualTco1::TuplesToMapOne(parts, rest, acc),
+                crate::aver_generated::domain::value::Val::ValTuple(parts) => __MutualTco1::TuplesToMapOne(parts, rest, acc),
                 _ => __MutualTco1::TuplesToMap(rest, acc)
                 })
             }
@@ -67,13 +67,13 @@ pub fn tuplesToMapOne(
 /// Dispatch qualified builtin calls to sub-module implementations.
 pub fn callBuiltin(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match callBuiltinFast(name.clone(), args) {
+    match crate::aver_generated::domain::builtins::callBuiltinFast(name.clone(), args) {
         Some(result) => result,
         None => {
             if name.starts_with("List.") {
                 crate::aver_generated::domain::builtins::list::call(name, args)
             } else {
-                callBuiltinAfterList(name, args)
+                crate::aver_generated::domain::builtins::callBuiltinAfterList(name, args)
             }
         }
     }
@@ -89,22 +89,28 @@ pub fn callBuiltinFast(
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Map.set" {
-            Some(builtinMapSet(args))
+            Some(crate::aver_generated::domain::builtins::builtinMapSet(args))
         } else {
             if &*__dispatch_subject == "Map.get" {
-                Some(builtinMapGet(args))
+                Some(crate::aver_generated::domain::builtins::builtinMapGet(args))
             } else {
                 if &*__dispatch_subject == "Map.has" {
-                    Some(builtinMapHas(args))
+                    Some(crate::aver_generated::domain::builtins::builtinMapHas(args))
                 } else {
                     if &*__dispatch_subject == "Map.fromList" {
-                        Some(builtinMapFromList(args))
+                        Some(crate::aver_generated::domain::builtins::builtinMapFromList(
+                            args,
+                        ))
                     } else {
                         if &*__dispatch_subject == "Map.entries" {
-                            Some(builtinMapEntries(args))
+                            Some(crate::aver_generated::domain::builtins::builtinMapEntries(
+                                args,
+                            ))
                         } else {
                             if &*__dispatch_subject == "Map.remove" {
-                                Some(builtinMapRemove(args))
+                                Some(crate::aver_generated::domain::builtins::builtinMapRemove(
+                                    args,
+                                ))
                             } else {
                                 if &*__dispatch_subject == "Vector.new" {
                                     Some(crate::aver_generated::domain::builtins::vector::call(
@@ -184,22 +190,22 @@ pub fn callBuiltinByIdValues(id: i64, args: &aver_rt::AverList<Val>) -> Result<V
     {
         let __dispatch_subject = id;
         if __dispatch_subject == 1i64 {
-            builtinMapSet(args)
+            crate::aver_generated::domain::builtins::builtinMapSet(args)
         } else {
             if __dispatch_subject == 2i64 {
-                builtinMapGet(args)
+                crate::aver_generated::domain::builtins::builtinMapGet(args)
             } else {
                 if __dispatch_subject == 3i64 {
-                    builtinMapHas(args)
+                    crate::aver_generated::domain::builtins::builtinMapHas(args)
                 } else {
                     if __dispatch_subject == 4i64 {
-                        builtinMapFromList(args)
+                        crate::aver_generated::domain::builtins::builtinMapFromList(args)
                     } else {
                         if __dispatch_subject == 5i64 {
-                            builtinMapEntries(args)
+                            crate::aver_generated::domain::builtins::builtinMapEntries(args)
                         } else {
                             if __dispatch_subject == 6i64 {
-                                builtinMapRemove(args)
+                                crate::aver_generated::domain::builtins::builtinMapRemove(args)
                             } else {
                                 if __dispatch_subject == 7i64 {
                                     crate::aver_generated::domain::builtins::vector::call(
@@ -287,7 +293,7 @@ pub fn callBuiltinAfterList(name: AverStr, args: &aver_rt::AverList<Val>) -> Res
                 if name.starts_with("Float.") {
                     crate::aver_generated::domain::builtins::primitives::callFloat(name, args)
                 } else {
-                    callBuiltinOther(name, args)
+                    crate::aver_generated::domain::builtins::callBuiltinOther(name, args)
                 }
             }
         }
@@ -306,64 +312,66 @@ pub fn callBuiltinOther(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<
                 crate::aver_generated::domain::builtins::primitives::callChar(name, args)
             } else {
                 if &*__dispatch_subject == "Console.print" {
-                    builtinConsolePrint(args)
+                    crate::aver_generated::domain::builtins::builtinConsolePrint(args)
                 } else {
                     if &*__dispatch_subject == "Console.readLine" {
-                        builtinConsoleReadLine(args)
+                        crate::aver_generated::domain::builtins::builtinConsoleReadLine(args)
                     } else {
                         if &*__dispatch_subject == "Console.error" {
-                            builtinConsoleError(args)
+                            crate::aver_generated::domain::builtins::builtinConsoleError(args)
                         } else {
                             if &*__dispatch_subject == "Console.warn" {
-                                builtinConsoleWarn(args)
+                                crate::aver_generated::domain::builtins::builtinConsoleWarn(args)
                             } else {
                                 if &*__dispatch_subject == "Disk.readText" {
-                                    builtinDiskReadText(args)
+                                    crate::aver_generated::domain::builtins::builtinDiskReadText(
+                                        args,
+                                    )
                                 } else {
                                     if &*__dispatch_subject == "Disk.writeText" {
-                                        builtinDiskWriteText(args)
+                                        crate::aver_generated::domain::builtins::builtinDiskWriteText(args)
                                     } else {
                                         if &*__dispatch_subject == "Disk.exists" {
-                                            builtinDiskExists(args)
+                                            crate::aver_generated::domain::builtins::builtinDiskExists(args)
                                         } else {
                                             if &*__dispatch_subject == "Disk.listDir" {
-                                                builtinDiskListDir(args)
+                                                crate::aver_generated::domain::builtins::builtinDiskListDir(args)
                                             } else {
                                                 if &*__dispatch_subject == "Disk.appendText" {
-                                                    builtinDiskAppendText(args)
+                                                    crate::aver_generated::domain::builtins::builtinDiskAppendText(args)
                                                 } else {
                                                     if &*__dispatch_subject == "Disk.delete" {
-                                                        builtinDiskDelete(args)
+                                                        crate::aver_generated::domain::builtins::builtinDiskDelete(args)
                                                     } else {
                                                         if &*__dispatch_subject == "Disk.deleteDir"
                                                         {
-                                                            builtinDiskDeleteDir(args)
+                                                            crate::aver_generated::domain::builtins::builtinDiskDeleteDir(args)
                                                         } else {
                                                             if &*__dispatch_subject
                                                                 == "Disk.makeDir"
                                                             {
-                                                                builtinDiskMakeDir(args)
+                                                                crate::aver_generated::domain::builtins::builtinDiskMakeDir(args)
                                                             } else {
                                                                 if &*__dispatch_subject == "Env.get"
                                                                 {
-                                                                    builtinEnvGet(args)
+                                                                    crate::aver_generated::domain::builtins::builtinEnvGet(args)
                                                                 } else {
                                                                     if &*__dispatch_subject
                                                                         == "Env.set"
                                                                     {
-                                                                        builtinEnvSet(args)
+                                                                        crate::aver_generated::domain::builtins::builtinEnvSet(args)
                                                                     } else {
                                                                         if &*__dispatch_subject
                                                                             == "Args.get"
                                                                         {
-                                                                            builtinArgsGet(args)
+                                                                            crate::aver_generated::domain::builtins::builtinArgsGet(args)
                                                                         } else {
                                                                             if &*__dispatch_subject
                                                                                 == "Result.Ok"
                                                                             {
                                                                                 crate::aver_generated::domain::builtins::wrappers::call(name, args)
                                                                             } else {
-                                                                                if &*__dispatch_subject == "Result.Err" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Result.withDefault" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.Some" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.None" { Ok(Val::ValNone.clone()) } else { if &*__dispatch_subject == "Option.withDefault" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.toResult" { crate::aver_generated::domain::builtins::wrappers::callOptionToResult(args) } else { if &*__dispatch_subject == "Bool.or" { builtinBoolOr(args) } else { if &*__dispatch_subject == "Bool.and" { builtinBoolAnd(args) } else { if &*__dispatch_subject == "Bool.not" { builtinBoolNot(args) } else { if &*__dispatch_subject == "Map.set" { builtinMapSet(args) } else { if &*__dispatch_subject == "Map.get" { builtinMapGet(args) } else { if &*__dispatch_subject == "Map.has" { builtinMapHas(args) } else { if &*__dispatch_subject == "Map.entries" { builtinMapEntries(args) } else { if &*__dispatch_subject == "Map.keys" { builtinMapKeys(args) } else { if &*__dispatch_subject == "Map.values" { builtinMapValues(args) } else { if &*__dispatch_subject == "Map.fromList" { builtinMapFromList(args) } else { if &*__dispatch_subject == "Map.size" { builtinMapSize(args) } else { if &*__dispatch_subject == "Map.len" { builtinMapSize(args) } else { if &*__dispatch_subject == "Map.remove" { builtinMapRemove(args) } else { callBuiltinServices(name, args) } } } } } } } } } } } } } } } } } } }
+                                                                                if &*__dispatch_subject == "Result.Err" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Result.withDefault" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.Some" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.None" { Ok(Val::ValNone.clone()) } else { if &*__dispatch_subject == "Option.withDefault" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.toResult" { crate::aver_generated::domain::builtins::wrappers::callOptionToResult(args) } else { if &*__dispatch_subject == "Bool.or" { crate::aver_generated::domain::builtins::builtinBoolOr(args) } else { if &*__dispatch_subject == "Bool.and" { crate::aver_generated::domain::builtins::builtinBoolAnd(args) } else { if &*__dispatch_subject == "Bool.not" { crate::aver_generated::domain::builtins::builtinBoolNot(args) } else { if &*__dispatch_subject == "Map.set" { crate::aver_generated::domain::builtins::builtinMapSet(args) } else { if &*__dispatch_subject == "Map.get" { crate::aver_generated::domain::builtins::builtinMapGet(args) } else { if &*__dispatch_subject == "Map.has" { crate::aver_generated::domain::builtins::builtinMapHas(args) } else { if &*__dispatch_subject == "Map.entries" { crate::aver_generated::domain::builtins::builtinMapEntries(args) } else { if &*__dispatch_subject == "Map.keys" { crate::aver_generated::domain::builtins::builtinMapKeys(args) } else { if &*__dispatch_subject == "Map.values" { crate::aver_generated::domain::builtins::builtinMapValues(args) } else { if &*__dispatch_subject == "Map.fromList" { crate::aver_generated::domain::builtins::builtinMapFromList(args) } else { if &*__dispatch_subject == "Map.size" { crate::aver_generated::domain::builtins::builtinMapSize(args) } else { if &*__dispatch_subject == "Map.len" { crate::aver_generated::domain::builtins::builtinMapSize(args) } else { if &*__dispatch_subject == "Map.remove" { crate::aver_generated::domain::builtins::builtinMapRemove(args) } else { crate::aver_generated::domain::builtins::callBuiltinServices(name, args) } } } } } } } } } } } } } } } } } } }
                                                                             }
                                                                         }
                                                                     }
@@ -442,8 +450,12 @@ pub fn builtinConsoleReadLine(args: &aver_rt::AverList<Val>) -> Result<Val, Aver
             (aver_rt::read_line()).into_aver()
         })
     } {
-        Ok(line) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValStr(line)))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(line) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(line)),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -461,8 +473,12 @@ pub fn builtinDiskReadText(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
             || (aver_rt::read_text(&__effect_arg0)).into_aver(),
         )
     } {
-        Ok(content) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValStr(content)))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(content) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(content)),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -473,10 +489,9 @@ pub fn builtinArgsGet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
         crate::cancel_checkpoint();
         aver_replay::invoke_effect("Args.get", vec![], || aver_replay::current_cli_args())
     };
-    Ok(Val::ValList(stringsToVals(
-        rawArgs,
-        aver_rt::AverList::empty(),
-    )))
+    Ok(crate::aver_generated::domain::value::Val::ValList(
+        crate::aver_generated::domain::builtins::stringsToVals(rawArgs, aver_rt::AverList::empty()),
+    ))
 }
 
 /// Env.get(key) -> Option<String>.
@@ -493,7 +508,9 @@ pub fn builtinEnvGet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
             || (aver_rt::env_get(&__effect_arg0)).into_aver(),
         )
     } {
-        Some(value) => Ok(Val::ValSome(std::sync::Arc::new(Val::ValStr(value)))),
+        Some(value) => Ok(crate::aver_generated::domain::value::Val::ValSome(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(value)),
+        )),
         None => Ok(Val::ValNone.clone()),
     }
 }
@@ -504,7 +521,7 @@ pub fn builtinEnvSet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (keyV, valueV) = pair;
-        builtinEnvSetInner(&keyV, &valueV)
+        crate::aver_generated::domain::builtins::builtinEnvSetInner(&keyV, &valueV)
     }
 }
 
@@ -538,7 +555,7 @@ pub fn stringsToVals(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(strs, [] => acc.reverse(), [s, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(Val::ValStr(s), &acc);
+            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValStr(s), &acc);
             strs = rest;
             acc = __tmp1;
             continue;
@@ -551,14 +568,19 @@ pub fn builtinMapEntries(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValMap(m) => Ok(Val::ValList(mapEntriesToTuples(
-            {
-                let mut es: Vec<_> = m.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                es.sort_by(|a, b| a.0.cmp(&b.0));
-                aver_rt::AverList::from_vec(es)
-            },
-            aver_rt::AverList::empty(),
-        ))),
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
+            Ok(crate::aver_generated::domain::value::Val::ValList(
+                crate::aver_generated::domain::builtins::mapEntriesToTuples(
+                    {
+                        let mut es: Vec<_> =
+                            m.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                        es.sort_by(|a, b| a.0.cmp(&b.0));
+                        aver_rt::AverList::from_vec(es)
+                    },
+                    aver_rt::AverList::empty(),
+                ),
+            ))
+        }
         _ => Err(AverStr::from("Map.entries requires a Map")),
     }
 }
@@ -573,7 +595,7 @@ pub fn mapEntriesToTuples(
         crate::cancel_checkpoint();
         return aver_list_match!(entries, [] => acc.reverse(), [pair, rest] => { match pair {
             (k, v) => {
-            let __tmp1 = aver_rt::AverList::prepend(Val::ValTuple(aver_rt::AverList::from_vec(vec![Val::ValStr(k), v])), &acc);
+            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValTuple(aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::value::Val::ValStr(k), v])), &acc);
             entries = rest;
             acc = __tmp1;
             continue;
@@ -587,14 +609,18 @@ pub fn builtinMapKeys(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValMap(m) => Ok(Val::ValList(stringsToVals(
-            {
-                let mut ks: Vec<_> = m.keys().cloned().collect();
-                ks.sort();
-                aver_rt::AverList::from_vec(ks)
-            },
-            aver_rt::AverList::empty(),
-        ))),
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
+            Ok(crate::aver_generated::domain::value::Val::ValList(
+                crate::aver_generated::domain::builtins::stringsToVals(
+                    {
+                        let mut ks: Vec<_> = m.keys().cloned().collect();
+                        ks.sort();
+                        aver_rt::AverList::from_vec(ks)
+                    },
+                    aver_rt::AverList::empty(),
+                ),
+            ))
+        }
         _ => Err(AverStr::from("Map.keys requires a Map")),
     }
 }
@@ -604,9 +630,11 @@ pub fn builtinMapValues(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValMap(m) => Ok(Val::ValList(aver_rt::AverList::from_vec(
-            m.values().cloned().collect::<Vec<_>>(),
-        ))),
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
+            Ok(crate::aver_generated::domain::value::Val::ValList(
+                aver_rt::AverList::from_vec(m.values().cloned().collect::<Vec<_>>()),
+            ))
+        }
         _ => Err(AverStr::from("Map.values requires a Map")),
     }
 }
@@ -616,7 +644,9 @@ pub fn builtinMapFromList(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
-    Ok(Val::ValMap(tuplesToMap(&items, &HashMap::new())))
+    Ok(crate::aver_generated::domain::value::Val::ValMap(
+        crate::aver_generated::domain::builtins::tuplesToMap(&items, &HashMap::new()),
+    ))
 }
 
 /// Map.size(map) -> Int.
@@ -624,7 +654,9 @@ pub fn builtinMapSize(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValMap(m) => Ok(Val::ValInt((m.len() as i64))),
+        crate::aver_generated::domain::value::Val::ValMap(m) => Ok(
+            crate::aver_generated::domain::value::Val::ValInt((m.len() as i64)),
+        ),
         _ => Err(AverStr::from("Map.size requires a Map")),
     }
 }
@@ -635,7 +667,7 @@ pub fn builtinMapRemove(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (mapV, keyV) = pair;
-        builtinMapRemoveInner(&mapV, &keyV)
+        crate::aver_generated::domain::builtins::builtinMapRemoveInner(&mapV, &keyV)
     }
 }
 
@@ -643,9 +675,11 @@ pub fn builtinMapRemove(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
 pub fn builtinMapRemoveInner(mapV: &Val, keyV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
-        Val::ValMap(m) => Ok(Val::ValMap(
-            m.remove_owned(&crate::aver_generated::domain::value::mapKeyRepr(keyV)),
-        )),
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
+            Ok(crate::aver_generated::domain::value::Val::ValMap(
+                m.remove_owned(&crate::aver_generated::domain::value::mapKeyRepr(keyV)),
+            ))
+        }
         _ => Err(AverStr::from("Map.remove requires a Map")),
     }
 }
@@ -656,72 +690,85 @@ pub fn callBuiltinServices(name: AverStr, args: &aver_rt::AverList<Val>) -> Resu
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Random.int" {
-            builtinRandomInt(args)
+            crate::aver_generated::domain::builtins::builtinRandomInt(args)
         } else {
             if &*__dispatch_subject == "Time.now" {
-                builtinTimeNow(args)
+                crate::aver_generated::domain::builtins::builtinTimeNow(args)
             } else {
                 if &*__dispatch_subject == "Time.sleep" {
-                    builtinTimeSleep(args)
+                    crate::aver_generated::domain::builtins::builtinTimeSleep(args)
                 } else {
                     if &*__dispatch_subject == "Time.unixMs" {
-                        builtinTimeUnixMs(args)
+                        crate::aver_generated::domain::builtins::builtinTimeUnixMs(args)
                     } else {
                         if &*__dispatch_subject == "Http.get" {
-                            builtinHttpSimple(args, AverStr::from("get"))
+                            crate::aver_generated::domain::builtins::builtinHttpSimple(
+                                args,
+                                AverStr::from("get"),
+                            )
                         } else {
                             if &*__dispatch_subject == "Http.head" {
-                                builtinHttpSimple(args, AverStr::from("head"))
+                                crate::aver_generated::domain::builtins::builtinHttpSimple(
+                                    args,
+                                    AverStr::from("head"),
+                                )
                             } else {
                                 if &*__dispatch_subject == "Http.delete" {
-                                    builtinHttpSimple(args, AverStr::from("delete"))
+                                    crate::aver_generated::domain::builtins::builtinHttpSimple(
+                                        args,
+                                        AverStr::from("delete"),
+                                    )
                                 } else {
                                     if &*__dispatch_subject == "Http.post" {
-                                        builtinHttpBody(args, AverStr::from("post"))
+                                        crate::aver_generated::domain::builtins::builtinHttpBody(
+                                            args,
+                                            AverStr::from("post"),
+                                        )
                                     } else {
                                         if &*__dispatch_subject == "Http.put" {
-                                            builtinHttpBody(args, AverStr::from("put"))
+                                            crate::aver_generated::domain::builtins::builtinHttpBody(
+                                                args,
+                                                AverStr::from("put"),
+                                            )
                                         } else {
                                             if &*__dispatch_subject == "Http.patch" {
-                                                builtinHttpBody(args, AverStr::from("patch"))
+                                                crate::aver_generated::domain::builtins::builtinHttpBody(args, AverStr::from("patch"))
                                             } else {
                                                 if &*__dispatch_subject == "HttpServer.listen" {
-                                                    builtinHttpServerListen(args)
+                                                    crate::aver_generated::domain::builtins::builtinHttpServerListen(args)
                                                 } else {
                                                     if &*__dispatch_subject
                                                         == "HttpServer.listenWith"
                                                     {
-                                                        builtinHttpServerListenWith(args)
+                                                        crate::aver_generated::domain::builtins::builtinHttpServerListenWith(args)
                                                     } else {
                                                         if &*__dispatch_subject == "Tcp.send" {
-                                                            builtinTcpSend(args)
+                                                            crate::aver_generated::domain::builtins::builtinTcpSend(args)
                                                         } else {
                                                             if &*__dispatch_subject == "Tcp.ping" {
-                                                                builtinTcpPing(args)
+                                                                crate::aver_generated::domain::builtins::builtinTcpPing(args)
                                                             } else {
                                                                 if &*__dispatch_subject
                                                                     == "Tcp.connect"
                                                                 {
-                                                                    builtinTcpConnect(args)
+                                                                    crate::aver_generated::domain::builtins::builtinTcpConnect(args)
                                                                 } else {
                                                                     if &*__dispatch_subject
                                                                         == "Tcp.writeLine"
                                                                     {
-                                                                        builtinTcpWriteLine(args)
+                                                                        crate::aver_generated::domain::builtins::builtinTcpWriteLine(args)
                                                                     } else {
                                                                         if &*__dispatch_subject
                                                                             == "Tcp.readLine"
                                                                         {
-                                                                            builtinTcpReadLine(args)
+                                                                            crate::aver_generated::domain::builtins::builtinTcpReadLine(args)
                                                                         } else {
                                                                             if &*__dispatch_subject
                                                                                 == "Tcp.close"
                                                                             {
-                                                                                builtinTcpClose(
-                                                                                    args,
-                                                                                )
+                                                                                crate::aver_generated::domain::builtins::builtinTcpClose(args)
                                                                             } else {
-                                                                                if &*__dispatch_subject == "Terminal.clear" { builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.flush" { builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.enableRawMode" { builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.disableRawMode" { builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.hideCursor" { builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.showCursor" { builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.resetColor" { builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.readKey" { builtinTerminalReadKey(args) } else { if &*__dispatch_subject == "Terminal.size" { builtinTerminalSize(args) } else { if &*__dispatch_subject == "Terminal.print" { builtinTerminalPrint(args) } else { if &*__dispatch_subject == "Terminal.setColor" { builtinTerminalSetColor(args) } else { if &*__dispatch_subject == "Terminal.moveTo" { builtinTerminalMoveTo(args) } else { tryVariantConstructor(name, args) } } } } } } } } } } } }
+                                                                                if &*__dispatch_subject == "Terminal.clear" { crate::aver_generated::domain::builtins::builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.flush" { crate::aver_generated::domain::builtins::builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.enableRawMode" { crate::aver_generated::domain::builtins::builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.disableRawMode" { crate::aver_generated::domain::builtins::builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.hideCursor" { crate::aver_generated::domain::builtins::builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.showCursor" { crate::aver_generated::domain::builtins::builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.resetColor" { crate::aver_generated::domain::builtins::builtinTerminalNoArg(name, args) } else { if &*__dispatch_subject == "Terminal.readKey" { crate::aver_generated::domain::builtins::builtinTerminalReadKey(args) } else { if &*__dispatch_subject == "Terminal.size" { crate::aver_generated::domain::builtins::builtinTerminalSize(args) } else { if &*__dispatch_subject == "Terminal.print" { crate::aver_generated::domain::builtins::builtinTerminalPrint(args) } else { if &*__dispatch_subject == "Terminal.setColor" { crate::aver_generated::domain::builtins::builtinTerminalSetColor(args) } else { if &*__dispatch_subject == "Terminal.moveTo" { crate::aver_generated::domain::builtins::builtinTerminalMoveTo(args) } else { crate::aver_generated::domain::builtins::tryVariantConstructor(name, args) } } } } } } } } } } } }
                                                                             }
                                                                         }
                                                                     }
@@ -744,7 +791,6 @@ pub fn callBuiltinServices(name: AverStr, args: &aver_rt::AverList<Val>) -> Resu
 }
 
 /// Fail explicitly for host services that still need callback/runtime bridging in the self-host.
-#[inline(always)]
 pub fn builtinUnsupportedHostService(name: AverStr) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     Err(aver_rt::AverStr::from({
@@ -766,7 +812,7 @@ pub fn builtinHttpServerListen(args: &aver_rt::AverList<Val>) -> Result<Val, Ave
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (portV, handlerV) = pair;
-        builtinHttpServerListenInner(&portV, &handlerV)
+        crate::aver_generated::domain::builtins::builtinHttpServerListenInner(&portV, &handlerV)
     }
 }
 
@@ -806,7 +852,7 @@ pub fn builtinHttpServerListenWith(args: &aver_rt::AverList<Val>) -> Result<Val,
                         if let Some((handlerV, ignored)) =
                             aver_rt::list_uncons_cloned(&__list_subject)
                         {
-                            builtinHttpServerListenWithInner(&portV, &contextV, &handlerV)
+                            crate::aver_generated::domain::builtins::builtinHttpServerListenWithInner(&portV, &contextV, &handlerV)
                         } else {
                             Err(AverStr::from("HttpServer.listenWith takes 3 arguments"))
                         }
@@ -861,7 +907,7 @@ pub fn builtinRandomInt(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (minV, maxV) = pair;
-        builtinRandomIntInner(&minV, &maxV)
+        crate::aver_generated::domain::builtins::builtinRandomIntInner(&minV, &maxV)
     }
 }
 
@@ -870,7 +916,7 @@ pub fn builtinRandomIntInner(minV: &Val, maxV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let minN = crate::aver_generated::domain::builtins::helpers::expectInt(minV)?;
     let maxN = crate::aver_generated::domain::builtins::helpers::expectInt(maxV)?;
-    Ok(Val::ValInt({
+    Ok(crate::aver_generated::domain::value::Val::ValInt({
         let __effect_arg0 = minN;
         let __effect_arg1 = maxN;
         crate::cancel_checkpoint();
@@ -905,7 +951,7 @@ pub fn builtinTimeSleep(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
 /// Time.unixMs() -> Int.
 pub fn builtinTimeUnixMs(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    Ok(Val::ValInt({
+    Ok(crate::aver_generated::domain::value::Val::ValInt({
         crate::cancel_checkpoint();
         aver_replay::invoke_effect("Time.unixMs", vec![], || aver_rt::time_unix_ms())
     }))
@@ -917,25 +963,25 @@ pub fn builtinTerminalNoArg(name: AverStr, args: &aver_rt::AverList<Val>) -> Res
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Terminal.clear" {
-            termClear()
+            crate::aver_generated::domain::builtins::termClear()
         } else {
             if &*__dispatch_subject == "Terminal.flush" {
-                termFlush()
+                crate::aver_generated::domain::builtins::termFlush()
             } else {
                 if &*__dispatch_subject == "Terminal.enableRawMode" {
-                    termEnableRawMode()
+                    crate::aver_generated::domain::builtins::termEnableRawMode()
                 } else {
                     if &*__dispatch_subject == "Terminal.disableRawMode" {
-                        termDisableRawMode()
+                        crate::aver_generated::domain::builtins::termDisableRawMode()
                     } else {
                         if &*__dispatch_subject == "Terminal.hideCursor" {
-                            termHideCursor()
+                            crate::aver_generated::domain::builtins::termHideCursor()
                         } else {
                             if &*__dispatch_subject == "Terminal.showCursor" {
-                                termShowCursor()
+                                crate::aver_generated::domain::builtins::termShowCursor()
                             } else {
                                 if &*__dispatch_subject == "Terminal.resetColor" {
-                                    termResetColor()
+                                    crate::aver_generated::domain::builtins::termResetColor()
                                 } else {
                                     Err(aver_rt::AverStr::from({
                                         let mut __b = {
@@ -1054,7 +1100,9 @@ pub fn builtinTerminalReadKey(args: &aver_rt::AverList<Val>) -> Result<Val, Aver
             (aver_rt::terminal_read_key()).into_aver()
         })
     } {
-        Some(k) => Ok(Val::ValSome(std::sync::Arc::new(Val::ValStr(k)))),
+        Some(k) => Ok(crate::aver_generated::domain::value::Val::ValSome(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(k)),
+        )),
         None => Ok(Val::ValNone.clone()),
     }
 }
@@ -1072,11 +1120,17 @@ pub fn builtinTerminalSize(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
             }
         })
     };
-    Ok(Val::ValRecord(
+    Ok(crate::aver_generated::domain::value::Val::ValRecord(
         AverStr::from("TerminalSize"),
         aver_rt::AverList::from_vec(vec![
-            (AverStr::from("width"), Val::ValInt(sz.width.clone())),
-            (AverStr::from("height"), Val::ValInt(sz.height.clone())),
+            (
+                AverStr::from("width"),
+                crate::aver_generated::domain::value::Val::ValInt(sz.width.clone()),
+            ),
+            (
+                AverStr::from("height"),
+                crate::aver_generated::domain::value::Val::ValInt(sz.height.clone()),
+            ),
         ]),
     ))
 }
@@ -1086,8 +1140,12 @@ pub fn builtinTerminalPrint(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v.clone() {
-        Val::ValStr(s) => termPrintStr(s),
-        _ => termPrintStr(crate::aver_generated::domain::value::valRepr(&v)),
+        crate::aver_generated::domain::value::Val::ValStr(s) => {
+            crate::aver_generated::domain::builtins::termPrintStr(s)
+        }
+        _ => crate::aver_generated::domain::builtins::termPrintStr(
+            crate::aver_generated::domain::value::valRepr(&v),
+        ),
     }
 }
 
@@ -1132,7 +1190,7 @@ pub fn builtinTerminalMoveTo(args: &aver_rt::AverList<Val>) -> Result<Val, AverS
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (xV, yV) = pair;
-        builtinTerminalMoveToInner(&xV, &yV)
+        crate::aver_generated::domain::builtins::builtinTerminalMoveToInner(&xV, &yV)
     }
 }
 
@@ -1163,7 +1221,7 @@ pub fn builtinDiskWriteText(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (pathV, contentV) = pair;
-        builtinDiskWriteTextInner(&pathV, &contentV)
+        crate::aver_generated::domain::builtins::builtinDiskWriteTextInner(&pathV, &contentV)
     }
 }
 
@@ -1185,8 +1243,12 @@ pub fn builtinDiskWriteTextInner(pathV: &Val, contentV: &Val) -> Result<Val, Ave
             || (aver_rt::write_text(&__effect_arg0, &__effect_arg1)).into_aver(),
         )
     } {
-        Ok(_) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValUnit.clone()))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(Val::ValUnit.clone()),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -1196,7 +1258,7 @@ pub fn builtinDiskAppendText(args: &aver_rt::AverList<Val>) -> Result<Val, AverS
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (pathV, contentV) = pair;
-        builtinDiskAppendTextInner(&pathV, &contentV)
+        crate::aver_generated::domain::builtins::builtinDiskAppendTextInner(&pathV, &contentV)
     }
 }
 
@@ -1218,8 +1280,12 @@ pub fn builtinDiskAppendTextInner(pathV: &Val, contentV: &Val) -> Result<Val, Av
             || (aver_rt::append_text(&__effect_arg0, &__effect_arg1)).into_aver(),
         )
     } {
-        Ok(_) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValUnit.clone()))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(Val::ValUnit.clone()),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -1237,8 +1303,12 @@ pub fn builtinDiskDelete(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
             || (aver_rt::delete_file(&__effect_arg0)).into_aver(),
         )
     } {
-        Ok(_) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValUnit.clone()))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(Val::ValUnit.clone()),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -1256,8 +1326,12 @@ pub fn builtinDiskDeleteDir(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
             || (aver_rt::delete_dir(&__effect_arg0)).into_aver(),
         )
     } {
-        Ok(_) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValUnit.clone()))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(Val::ValUnit.clone()),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -1275,8 +1349,12 @@ pub fn builtinDiskMakeDir(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
             || (aver_rt::make_dir(&__effect_arg0)).into_aver(),
         )
     } {
-        Ok(_) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValUnit.clone()))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(Val::ValUnit.clone()),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -1285,7 +1363,7 @@ pub fn builtinDiskExists(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let path = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
-    Ok(Val::ValBool({
+    Ok(crate::aver_generated::domain::value::Val::ValBool({
         let __effect_arg0 = path;
         crate::cancel_checkpoint();
         aver_replay::invoke_effect(
@@ -1310,10 +1388,17 @@ pub fn builtinDiskListDir(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
             || (aver_rt::list_dir(&__effect_arg0)).into_aver(),
         )
     } {
-        Ok(entries) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValList(
-            stringsToVals(entries, aver_rt::AverList::empty()),
-        )))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(entries) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValList(
+                crate::aver_generated::domain::builtins::stringsToVals(
+                    entries,
+                    aver_rt::AverList::empty(),
+                ),
+            )),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -1321,8 +1406,8 @@ pub fn builtinDiskListDir(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
 #[inline(always)]
 pub fn tryVariantConstructor(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match splitDotted(name.clone()) {
-        Some(_) => Ok(Val::ValVariant(
+    match crate::aver_generated::domain::builtins::splitDotted(name.clone()) {
+        Some(_) => Ok(crate::aver_generated::domain::value::Val::ValVariant(
             crate::aver_generated::domain::ast::ctorNameToTag(name.clone()),
             name,
             args.clone(),
@@ -1343,7 +1428,11 @@ pub fn tryVariantConstructor(name: AverStr, args: &aver_rt::AverList<Val>) -> Re
 #[inline(always)]
 pub fn splitDotted(name: AverStr) -> Option<(AverStr, AverStr)> {
     crate::cancel_checkpoint();
-    splitDottedLoop(name.clone(), 0i64, (name.chars().count() as i64))
+    crate::aver_generated::domain::builtins::splitDottedLoop(
+        name.clone(),
+        0i64,
+        (name.chars().count() as i64),
+    )
 }
 
 /// Find first dot and split.
@@ -1385,7 +1474,7 @@ pub fn builtinBoolOr(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
-        builtinBoolOrInner(&aV, &bV)
+        crate::aver_generated::domain::builtins::builtinBoolOrInner(&aV, &bV)
     }
 }
 
@@ -1393,12 +1482,12 @@ pub fn builtinBoolOr(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
 pub fn builtinBoolOrInner(aV: &Val, bV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match aV.clone() {
-        Val::ValBool(a) => match bV.clone() {
-            Val::ValBool(b) => {
+        crate::aver_generated::domain::value::Val::ValBool(a) => match bV.clone() {
+            crate::aver_generated::domain::value::Val::ValBool(b) => {
                 if a {
-                    Ok(Val::ValBool(true))
+                    Ok(crate::aver_generated::domain::value::Val::ValBool(true))
                 } else {
-                    Ok(Val::ValBool(b))
+                    Ok(crate::aver_generated::domain::value::Val::ValBool(b))
                 }
             }
             _ => Err(AverStr::from("Bool.or requires Bool arguments")),
@@ -1413,7 +1502,7 @@ pub fn builtinBoolAnd(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
-        builtinBoolAndInner(&aV, &bV)
+        crate::aver_generated::domain::builtins::builtinBoolAndInner(&aV, &bV)
     }
 }
 
@@ -1421,12 +1510,12 @@ pub fn builtinBoolAnd(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
 pub fn builtinBoolAndInner(aV: &Val, bV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match aV.clone() {
-        Val::ValBool(a) => match bV.clone() {
-            Val::ValBool(b) => {
+        crate::aver_generated::domain::value::Val::ValBool(a) => match bV.clone() {
+            crate::aver_generated::domain::value::Val::ValBool(b) => {
                 if a {
-                    Ok(Val::ValBool(b))
+                    Ok(crate::aver_generated::domain::value::Val::ValBool(b))
                 } else {
-                    Ok(Val::ValBool(false))
+                    Ok(crate::aver_generated::domain::value::Val::ValBool(false))
                 }
             }
             _ => Err(AverStr::from("Bool.and requires Bool arguments")),
@@ -1440,11 +1529,11 @@ pub fn builtinBoolNot(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValBool(b) => {
+        crate::aver_generated::domain::value::Val::ValBool(b) => {
             if b {
-                Ok(Val::ValBool(false))
+                Ok(crate::aver_generated::domain::value::Val::ValBool(false))
             } else {
-                Ok(Val::ValBool(true))
+                Ok(crate::aver_generated::domain::value::Val::ValBool(true))
             }
         }
         _ => Err(AverStr::from("Bool.not requires Bool argument")),
@@ -1463,7 +1552,9 @@ pub fn builtinMapSet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
                     {
                         let __list_subject = r2;
                         if let Some((valV, r3)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                            builtinMapSetInner(&mapV, &keyV, &valV)
+                            crate::aver_generated::domain::builtins::builtinMapSetInner(
+                                &mapV, &keyV, &valV,
+                            )
                         } else {
                             Err(AverStr::from("Map.set takes 3 arguments"))
                         }
@@ -1482,10 +1573,12 @@ pub fn builtinMapSet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
 pub fn builtinMapSetInner(mapV: &Val, keyV: &Val, valV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
-        Val::ValMap(m) => Ok(Val::ValMap(m.insert_owned(
-            crate::aver_generated::domain::value::mapKeyRepr(keyV),
-            valV.clone(),
-        ))),
+        crate::aver_generated::domain::value::Val::ValMap(m) => Ok(
+            crate::aver_generated::domain::value::Val::ValMap(m.insert_owned(
+                crate::aver_generated::domain::value::mapKeyRepr(keyV),
+                valV.clone(),
+            )),
+        ),
         _ => Err(AverStr::from("Map.set requires a Map")),
     }
 }
@@ -1496,7 +1589,7 @@ pub fn builtinMapGet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (mapV, keyV) = pair;
-        builtinMapGetInner(&mapV, &keyV)
+        crate::aver_generated::domain::builtins::builtinMapGetInner(&mapV, &keyV)
     }
 }
 
@@ -1504,12 +1597,14 @@ pub fn builtinMapGet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
 pub fn builtinMapGetInner(mapV: &Val, keyV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
-        Val::ValMap(m) => {
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
             match m
                 .get(&crate::aver_generated::domain::value::mapKeyRepr(keyV))
                 .cloned()
             {
-                Some(v) => Ok(Val::ValSome(std::sync::Arc::new(v))),
+                Some(v) => Ok(crate::aver_generated::domain::value::Val::ValSome(
+                    std::sync::Arc::new(v),
+                )),
                 None => Ok(Val::ValNone.clone()),
             }
         }
@@ -1523,7 +1618,7 @@ pub fn builtinMapHas(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (mapV, keyV) = pair;
-        builtinMapHasInner(&mapV, &keyV)
+        crate::aver_generated::domain::builtins::builtinMapHasInner(&mapV, &keyV)
     }
 }
 
@@ -1531,9 +1626,11 @@ pub fn builtinMapHas(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
 pub fn builtinMapHasInner(mapV: &Val, keyV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
-        Val::ValMap(m) => Ok(Val::ValBool(
-            m.contains_key(&crate::aver_generated::domain::value::mapKeyRepr(keyV)),
-        )),
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
+            Ok(crate::aver_generated::domain::value::Val::ValBool(
+                m.contains_key(&crate::aver_generated::domain::value::mapKeyRepr(keyV)),
+            ))
+        }
         _ => Err(AverStr::from("Map.has requires a Map")),
     }
 }
@@ -1541,7 +1638,7 @@ pub fn builtinMapHasInner(mapV: &Val, keyV: &Val) -> Result<Val, AverStr> {
 /// Time.now() -> ISO timestamp string.
 pub fn builtinTimeNow(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    Ok(Val::ValStr({
+    Ok(crate::aver_generated::domain::value::Val::ValStr({
         crate::cancel_checkpoint();
         aver_replay::invoke_effect("Time.now", vec![], || (aver_rt::time_now()).into_aver())
     }))
@@ -1555,36 +1652,42 @@ pub fn builtinHttpSimple(args: &aver_rt::AverList<Val>, method: AverStr) -> Resu
     {
         let __dispatch_subject = method;
         if &*__dispatch_subject == "get" {
-            Ok(httpResponseToVal(&{
-                let __effect_arg0 = url;
-                crate::cancel_checkpoint();
-                aver_replay::invoke_effect(
-                    "Http.get",
-                    vec![aver_replay::ReplayValue::to_replay_json(&__effect_arg0)],
-                    || (aver_rt::http::get(&__effect_arg0)).into_aver(),
-                )
-            }))
+            Ok(crate::aver_generated::domain::builtins::httpResponseToVal(
+                &{
+                    let __effect_arg0 = url;
+                    crate::cancel_checkpoint();
+                    aver_replay::invoke_effect(
+                        "Http.get",
+                        vec![aver_replay::ReplayValue::to_replay_json(&__effect_arg0)],
+                        || (aver_rt::http::get(&__effect_arg0)).into_aver(),
+                    )
+                },
+            ))
         } else {
             if &*__dispatch_subject == "head" {
-                Ok(httpResponseToVal(&{
-                    let __effect_arg0 = url;
-                    crate::cancel_checkpoint();
-                    aver_replay::invoke_effect(
-                        "Http.head",
-                        vec![aver_replay::ReplayValue::to_replay_json(&__effect_arg0)],
-                        || (aver_rt::http::head(&__effect_arg0)).into_aver(),
-                    )
-                }))
+                Ok(crate::aver_generated::domain::builtins::httpResponseToVal(
+                    &{
+                        let __effect_arg0 = url;
+                        crate::cancel_checkpoint();
+                        aver_replay::invoke_effect(
+                            "Http.head",
+                            vec![aver_replay::ReplayValue::to_replay_json(&__effect_arg0)],
+                            || (aver_rt::http::head(&__effect_arg0)).into_aver(),
+                        )
+                    },
+                ))
             } else {
-                Ok(httpResponseToVal(&{
-                    let __effect_arg0 = url;
-                    crate::cancel_checkpoint();
-                    aver_replay::invoke_effect(
-                        "Http.delete",
-                        vec![aver_replay::ReplayValue::to_replay_json(&__effect_arg0)],
-                        || (aver_rt::http::delete(&__effect_arg0)).into_aver(),
-                    )
-                }))
+                Ok(crate::aver_generated::domain::builtins::httpResponseToVal(
+                    &{
+                        let __effect_arg0 = url;
+                        crate::cancel_checkpoint();
+                        aver_replay::invoke_effect(
+                            "Http.delete",
+                            vec![aver_replay::ReplayValue::to_replay_json(&__effect_arg0)],
+                            || (aver_rt::http::delete(&__effect_arg0)).into_aver(),
+                        )
+                    },
+                ))
             }
         }
     }
@@ -1607,7 +1710,9 @@ pub fn builtinHttpBody(args: &aver_rt::AverList<Val>, method: AverStr) -> Result
                                 if let Some((hdrsV, r4)) =
                                     aver_rt::list_uncons_cloned(&__list_subject)
                                 {
-                                    builtinHttpBodyInner(&urlV, &bodyV, &ctV, &hdrsV, method)
+                                    crate::aver_generated::domain::builtins::builtinHttpBodyInner(
+                                        &urlV, &bodyV, &ctV, &hdrsV, method,
+                                    )
                                 } else {
                                     Err(AverStr::from("Http method takes 4 arguments"))
                                 }
@@ -1641,84 +1746,90 @@ pub fn builtinHttpBodyInner(
     {
         let __dispatch_subject = method;
         if &*__dispatch_subject == "post" {
-            Ok(httpResponseToVal(&{
-                let __effect_arg0 = url;
-                let __effect_arg1 = body;
-                let __effect_arg2 = ct;
-                let __effect_arg3 = HashMap::new();
-                crate::cancel_checkpoint();
-                aver_replay::invoke_effect(
-                    "Http.post",
-                    vec![
-                        aver_replay::ReplayValue::to_replay_json(&__effect_arg0),
-                        aver_replay::ReplayValue::to_replay_json(&__effect_arg1),
-                        aver_replay::ReplayValue::to_replay_json(&__effect_arg2),
-                        aver_replay::ReplayValue::to_replay_json(&__effect_arg3),
-                    ],
-                    || {
-                        (aver_rt::http::post(
-                            &__effect_arg0,
-                            &__effect_arg1,
-                            &__effect_arg2,
-                            &__effect_arg3,
-                        ))
-                        .into_aver()
-                    },
-                )
-            }))
+            Ok(crate::aver_generated::domain::builtins::httpResponseToVal(
+                &{
+                    let __effect_arg0 = url;
+                    let __effect_arg1 = body;
+                    let __effect_arg2 = ct;
+                    let __effect_arg3 = HashMap::new();
+                    crate::cancel_checkpoint();
+                    aver_replay::invoke_effect(
+                        "Http.post",
+                        vec![
+                            aver_replay::ReplayValue::to_replay_json(&__effect_arg0),
+                            aver_replay::ReplayValue::to_replay_json(&__effect_arg1),
+                            aver_replay::ReplayValue::to_replay_json(&__effect_arg2),
+                            aver_replay::ReplayValue::to_replay_json(&__effect_arg3),
+                        ],
+                        || {
+                            (aver_rt::http::post(
+                                &__effect_arg0,
+                                &__effect_arg1,
+                                &__effect_arg2,
+                                &__effect_arg3,
+                            ))
+                            .into_aver()
+                        },
+                    )
+                },
+            ))
         } else {
             if &*__dispatch_subject == "put" {
-                Ok(httpResponseToVal(&{
-                    let __effect_arg0 = url;
-                    let __effect_arg1 = body;
-                    let __effect_arg2 = ct;
-                    let __effect_arg3 = HashMap::new();
-                    crate::cancel_checkpoint();
-                    aver_replay::invoke_effect(
-                        "Http.put",
-                        vec![
-                            aver_replay::ReplayValue::to_replay_json(&__effect_arg0),
-                            aver_replay::ReplayValue::to_replay_json(&__effect_arg1),
-                            aver_replay::ReplayValue::to_replay_json(&__effect_arg2),
-                            aver_replay::ReplayValue::to_replay_json(&__effect_arg3),
-                        ],
-                        || {
-                            (aver_rt::http::put(
-                                &__effect_arg0,
-                                &__effect_arg1,
-                                &__effect_arg2,
-                                &__effect_arg3,
-                            ))
-                            .into_aver()
-                        },
-                    )
-                }))
+                Ok(crate::aver_generated::domain::builtins::httpResponseToVal(
+                    &{
+                        let __effect_arg0 = url;
+                        let __effect_arg1 = body;
+                        let __effect_arg2 = ct;
+                        let __effect_arg3 = HashMap::new();
+                        crate::cancel_checkpoint();
+                        aver_replay::invoke_effect(
+                            "Http.put",
+                            vec![
+                                aver_replay::ReplayValue::to_replay_json(&__effect_arg0),
+                                aver_replay::ReplayValue::to_replay_json(&__effect_arg1),
+                                aver_replay::ReplayValue::to_replay_json(&__effect_arg2),
+                                aver_replay::ReplayValue::to_replay_json(&__effect_arg3),
+                            ],
+                            || {
+                                (aver_rt::http::put(
+                                    &__effect_arg0,
+                                    &__effect_arg1,
+                                    &__effect_arg2,
+                                    &__effect_arg3,
+                                ))
+                                .into_aver()
+                            },
+                        )
+                    },
+                ))
             } else {
-                Ok(httpResponseToVal(&{
-                    let __effect_arg0 = url;
-                    let __effect_arg1 = body;
-                    let __effect_arg2 = ct;
-                    let __effect_arg3 = HashMap::new();
-                    crate::cancel_checkpoint();
-                    aver_replay::invoke_effect(
-                        "Http.patch",
-                        vec![
-                            aver_replay::ReplayValue::to_replay_json(&__effect_arg0),
-                            aver_replay::ReplayValue::to_replay_json(&__effect_arg1),
-                            aver_replay::ReplayValue::to_replay_json(&__effect_arg2),
-                            aver_replay::ReplayValue::to_replay_json(&__effect_arg3),
-                        ],
-                        || {
-                            (aver_rt::http::patch(
-                                &__effect_arg0,
-                                &__effect_arg1,
-                                &__effect_arg2,
-                                &__effect_arg3,
-                            ))
-                            .into_aver()
-                        },
-                    )
-                }))
+                Ok(crate::aver_generated::domain::builtins::httpResponseToVal(
+                    &{
+                        let __effect_arg0 = url;
+                        let __effect_arg1 = body;
+                        let __effect_arg2 = ct;
+                        let __effect_arg3 = HashMap::new();
+                        crate::cancel_checkpoint();
+                        aver_replay::invoke_effect(
+                            "Http.patch",
+                            vec![
+                                aver_replay::ReplayValue::to_replay_json(&__effect_arg0),
+                                aver_replay::ReplayValue::to_replay_json(&__effect_arg1),
+                                aver_replay::ReplayValue::to_replay_json(&__effect_arg2),
+                                aver_replay::ReplayValue::to_replay_json(&__effect_arg3),
+                            ],
+                            || {
+                                (aver_rt::http::patch(
+                                    &__effect_arg0,
+                                    &__effect_arg1,
+                                    &__effect_arg2,
+                                    &__effect_arg3,
+                                ))
+                                .into_aver()
+                            },
+                        )
+                    },
+                ))
             }
         }
     }
@@ -1729,31 +1840,45 @@ pub fn builtinHttpBodyInner(
 pub fn httpResponseToVal(result: &Result<HttpResponse, AverStr>) -> Val {
     crate::cancel_checkpoint();
     match result.clone() {
-        Ok(resp) => Val::ValOk(std::sync::Arc::new(Val::ValRecord(
-            AverStr::from("HttpResponse"),
-            aver_rt::AverList::from_vec(vec![
-                (AverStr::from("status"), Val::ValInt(resp.status.clone())),
-                (AverStr::from("body"), Val::ValStr(resp.body.clone())),
-                (AverStr::from("headers"), headersToVal(&resp.headers)),
-            ]),
-        ))),
-        Err(e) => Val::ValErr(std::sync::Arc::new(Val::ValStr(e))),
+        Ok(resp) => crate::aver_generated::domain::value::Val::ValOk(std::sync::Arc::new(
+            crate::aver_generated::domain::value::Val::ValRecord(
+                AverStr::from("HttpResponse"),
+                aver_rt::AverList::from_vec(vec![
+                    (
+                        AverStr::from("status"),
+                        crate::aver_generated::domain::value::Val::ValInt(resp.status.clone()),
+                    ),
+                    (
+                        AverStr::from("body"),
+                        crate::aver_generated::domain::value::Val::ValStr(resp.body.clone()),
+                    ),
+                    (
+                        AverStr::from("headers"),
+                        crate::aver_generated::domain::builtins::headersToVal(&resp.headers),
+                    ),
+                ]),
+            ),
+        )),
+        Err(e) => crate::aver_generated::domain::value::Val::ValErr(std::sync::Arc::new(
+            crate::aver_generated::domain::value::Val::ValStr(e),
+        )),
     }
 }
 
 /// Convert host headers Map<String, List<String>> to a Val.ValMap whose values are Val.ValList of Val.ValStr.
-#[inline(always)]
 pub fn headersToVal(headers: &aver_rt::AverMap<AverStr, aver_rt::AverList<AverStr>>) -> Val {
     crate::cancel_checkpoint();
-    Val::ValMap(headersToValMap(
-        headers.clone(),
-        {
-            let mut ks: Vec<_> = headers.keys().cloned().collect();
-            ks.sort();
-            aver_rt::AverList::from_vec(ks)
-        },
-        HashMap::new(),
-    ))
+    crate::aver_generated::domain::value::Val::ValMap(
+        crate::aver_generated::domain::builtins::headersToValMap(
+            headers.clone(),
+            {
+                let mut ks: Vec<_> = headers.keys().cloned().collect();
+                ks.sort();
+                aver_rt::AverList::from_vec(ks)
+            },
+            HashMap::new(),
+        ),
+    )
 }
 
 /// Walk header keys, converting each value list to a Val.ValList.
@@ -1766,12 +1891,12 @@ pub fn headersToValMap(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(names, [] => acc, [name, rest] => { match headers.get(&name).cloned() { Some(values) => { {
-            let __tmp2 = acc.insert_owned(name, Val::ValList(stringsToValStrs(values, aver_rt::AverList::empty())));
+            let __tmp2 = acc.insert_owned(name, crate::aver_generated::domain::value::Val::ValList(crate::aver_generated::domain::builtins::stringsToValStrs(values, aver_rt::AverList::empty())));
             names = rest;
             acc = __tmp2;
             continue;
         } }, None => { {
-            let __tmp2 = acc.insert_owned(name, Val::ValList(aver_rt::AverList::empty()));
+            let __tmp2 = acc.insert_owned(name, crate::aver_generated::domain::value::Val::ValList(aver_rt::AverList::empty()));
             names = rest;
             acc = __tmp2;
             continue;
@@ -1788,7 +1913,7 @@ pub fn stringsToValStrs(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(values, [] => acc.reverse(), [v, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(Val::ValStr(v), &acc);
+            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValStr(v), &acc);
             values = rest;
             acc = __tmp1;
             continue;
@@ -1808,7 +1933,9 @@ pub fn builtinTcpSend(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
                     {
                         let __list_subject = r2;
                         if let Some((msgV, r3)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                            builtinTcpSendInner(&hostV, &portV, &msgV)
+                            crate::aver_generated::domain::builtins::builtinTcpSendInner(
+                                &hostV, &portV, &msgV,
+                            )
                         } else {
                             Err(AverStr::from("Tcp.send takes 3 arguments"))
                         }
@@ -1844,8 +1971,12 @@ pub fn builtinTcpSendInner(hostV: &Val, portV: &Val, msgV: &Val) -> Result<Val, 
             || (aver_rt::tcp::send(&__effect_arg0, __effect_arg1, &__effect_arg2)).into_aver(),
         )
     } {
-        Ok(resp) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValStr(resp)))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(resp) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(resp)),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -1855,7 +1986,7 @@ pub fn builtinTcpPing(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (hostV, portV) = pair;
-        builtinTcpPingInner(&hostV, &portV)
+        crate::aver_generated::domain::builtins::builtinTcpPingInner(&hostV, &portV)
     }
 }
 
@@ -1877,8 +2008,12 @@ pub fn builtinTcpPingInner(hostV: &Val, portV: &Val) -> Result<Val, AverStr> {
             || (aver_rt::tcp::ping(&__effect_arg0, __effect_arg1)).into_aver(),
         )
     } {
-        Ok(_) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValUnit.clone()))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(Val::ValUnit.clone()),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -1888,7 +2023,7 @@ pub fn builtinTcpConnect(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (hostV, portV) = pair;
-        builtinTcpConnectInner(&hostV, &portV)
+        crate::aver_generated::domain::builtins::builtinTcpConnectInner(&hostV, &portV)
     }
 }
 
@@ -1910,21 +2045,33 @@ pub fn builtinTcpConnectInner(hostV: &Val, portV: &Val) -> Result<Val, AverStr> 
             || (aver_rt::tcp::connect(&__effect_arg0, __effect_arg1)).into_aver(),
         )
     } {
-        Ok(conn) => Ok(Val::ValOk(std::sync::Arc::new(tcpConnToVal(&conn)))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(conn) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::builtins::tcpConnToVal(&conn)),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
 /// Convert host Tcp.Connection record to Val.
-#[inline(always)]
 pub fn tcpConnToVal(conn: &Tcp_Connection) -> Val {
     crate::cancel_checkpoint();
-    Val::ValRecord(
+    crate::aver_generated::domain::value::Val::ValRecord(
         AverStr::from("Tcp.Connection"),
         aver_rt::AverList::from_vec(vec![
-            (AverStr::from("id"), Val::ValStr(conn.id.clone())),
-            (AverStr::from("host"), Val::ValStr(conn.host.clone())),
-            (AverStr::from("port"), Val::ValInt(conn.port.clone())),
+            (
+                AverStr::from("id"),
+                crate::aver_generated::domain::value::Val::ValStr(conn.id.clone()),
+            ),
+            (
+                AverStr::from("host"),
+                crate::aver_generated::domain::value::Val::ValStr(conn.host.clone()),
+            ),
+            (
+                AverStr::from("port"),
+                crate::aver_generated::domain::value::Val::ValInt(conn.port.clone()),
+            ),
         ]),
     )
 }
@@ -1933,7 +2080,9 @@ pub fn tcpConnToVal(conn: &Tcp_Connection) -> Val {
 pub fn valToTcpConn(v: &Val) -> Result<Tcp_Connection, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValRecord(_, fields) => valToTcpConnFields(&fields),
+        crate::aver_generated::domain::value::Val::ValRecord(_, fields) => {
+            crate::aver_generated::domain::builtins::valToTcpConnFields(&fields)
+        }
         _ => Err(AverStr::from("expected Tcp.Connection record")),
     }
 }
@@ -1943,13 +2092,22 @@ pub fn valToTcpConnFields(
     fields: &aver_rt::AverList<(AverStr, Val)>,
 ) -> Result<Tcp_Connection, AverStr> {
     crate::cancel_checkpoint();
-    let idVal = lookupFieldVal(fields.clone(), AverStr::from("id"));
-    let hostVal = lookupFieldVal(fields.clone(), AverStr::from("host"));
-    let portVal = lookupFieldVal(fields.clone(), AverStr::from("port"));
+    let idVal = crate::aver_generated::domain::builtins::lookupFieldVal(
+        fields.clone(),
+        AverStr::from("id"),
+    );
+    let hostVal = crate::aver_generated::domain::builtins::lookupFieldVal(
+        fields.clone(),
+        AverStr::from("host"),
+    );
+    let portVal = crate::aver_generated::domain::builtins::lookupFieldVal(
+        fields.clone(),
+        AverStr::from("port"),
+    );
     match idVal {
-        Val::ValStr(id) => match hostVal {
-            Val::ValStr(host) => match portVal {
-                Val::ValInt(port) => Ok(Tcp_Connection {
+        crate::aver_generated::domain::value::Val::ValStr(id) => match hostVal {
+            crate::aver_generated::domain::value::Val::ValStr(host) => match portVal {
+                crate::aver_generated::domain::value::Val::ValInt(port) => Ok(Tcp_Connection {
                     id: id,
                     host: host,
                     port: port,
@@ -1982,14 +2140,14 @@ pub fn builtinTcpWriteLine(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (connV, lineV) = pair;
-        builtinTcpWriteLineInner(&connV, &lineV)
+        crate::aver_generated::domain::builtins::builtinTcpWriteLineInner(&connV, &lineV)
     }
 }
 
 /// Inner Tcp.writeLine.
 pub fn builtinTcpWriteLineInner(connV: &Val, lineV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let tc = valToTcpConn(connV)?;
+    let tc = crate::aver_generated::domain::builtins::valToTcpConn(connV)?;
     let line = crate::aver_generated::domain::builtins::helpers::expectStr(lineV)?;
     match {
         let __effect_arg0 = tc;
@@ -2004,8 +2162,12 @@ pub fn builtinTcpWriteLineInner(connV: &Val, lineV: &Val) -> Result<Val, AverStr
             || (aver_rt::tcp::write_line(&__effect_arg0, &__effect_arg1)).into_aver(),
         )
     } {
-        Ok(_) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValUnit.clone()))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(Val::ValUnit.clone()),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -2013,7 +2175,7 @@ pub fn builtinTcpWriteLineInner(connV: &Val, lineV: &Val) -> Result<Val, AverStr
 pub fn builtinTcpReadLine(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let tc = valToTcpConn(&v)?;
+    let tc = crate::aver_generated::domain::builtins::valToTcpConn(&v)?;
     match {
         let __effect_arg0 = tc;
         crate::cancel_checkpoint();
@@ -2023,8 +2185,12 @@ pub fn builtinTcpReadLine(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
             || (aver_rt::tcp::read_line(&__effect_arg0)).into_aver(),
         )
     } {
-        Ok(line) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValStr(line)))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(line) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(line)),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -2032,7 +2198,7 @@ pub fn builtinTcpReadLine(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
 pub fn builtinTcpClose(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let tc = valToTcpConn(&v)?;
+    let tc = crate::aver_generated::domain::builtins::valToTcpConn(&v)?;
     match {
         let __effect_arg0 = tc;
         crate::cancel_checkpoint();
@@ -2042,8 +2208,12 @@ pub fn builtinTcpClose(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
             || (aver_rt::tcp::close(&__effect_arg0)).into_aver(),
         )
     } {
-        Ok(_) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValUnit.clone()))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(Val::ValUnit.clone()),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 

--- a/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
@@ -12,25 +12,27 @@ pub fn callInt(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, Aver
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "String.fromInt" {
-            builtinIntToString(args)
+            crate::aver_generated::domain::builtins::primitives::builtinIntToString(args)
         } else {
             if &*__dispatch_subject == "Float.fromInt" {
-                builtinIntToFloat(args)
+                crate::aver_generated::domain::builtins::primitives::builtinIntToFloat(args)
             } else {
                 if &*__dispatch_subject == "Int.fromString" {
-                    builtinIntFromString(args)
+                    crate::aver_generated::domain::builtins::primitives::builtinIntFromString(args)
                 } else {
                     if &*__dispatch_subject == "Int.abs" {
-                        builtinIntAbs(args)
+                        crate::aver_generated::domain::builtins::primitives::builtinIntAbs(args)
                     } else {
                         if &*__dispatch_subject == "Int.mod" {
-                            builtinIntMod(args)
+                            crate::aver_generated::domain::builtins::primitives::builtinIntMod(args)
                         } else {
                             if &*__dispatch_subject == "Int.max" {
-                                builtinIntMax(args)
+                                crate::aver_generated::domain::builtins::primitives::builtinIntMax(
+                                    args,
+                                )
                             } else {
                                 if &*__dispatch_subject == "Int.min" {
-                                    builtinIntMin(args)
+                                    crate::aver_generated::domain::builtins::primitives::builtinIntMin(args)
                                 } else {
                                     Err(aver_rt::AverStr::from({
                                         let mut __b = {
@@ -60,7 +62,7 @@ pub fn builtinIntMax(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
-        builtinIntMaxInner(&aV, &bV)
+        crate::aver_generated::domain::builtins::primitives::builtinIntMaxInner(&aV, &bV)
     }
 }
 
@@ -70,9 +72,9 @@ pub fn builtinIntMaxInner(aV: &Val, bV: &Val) -> Result<Val, AverStr> {
     let a = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
     let b = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
     if (a > b) {
-        Ok(Val::ValInt(a))
+        Ok(crate::aver_generated::domain::value::Val::ValInt(a))
     } else {
-        Ok(Val::ValInt(b))
+        Ok(crate::aver_generated::domain::value::Val::ValInt(b))
     }
 }
 
@@ -82,7 +84,7 @@ pub fn builtinIntMin(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
-        builtinIntMinInner(&aV, &bV)
+        crate::aver_generated::domain::builtins::primitives::builtinIntMinInner(&aV, &bV)
     }
 }
 
@@ -92,9 +94,9 @@ pub fn builtinIntMinInner(aV: &Val, bV: &Val) -> Result<Val, AverStr> {
     let a = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
     let b = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
     if (a < b) {
-        Ok(Val::ValInt(a))
+        Ok(crate::aver_generated::domain::value::Val::ValInt(a))
     } else {
-        Ok(Val::ValInt(b))
+        Ok(crate::aver_generated::domain::value::Val::ValInt(b))
     }
 }
 
@@ -105,65 +107,65 @@ pub fn callString(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, A
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "String.len" {
-            builtinStringLen(args)
+            crate::aver_generated::domain::builtins::primitives::builtinStringLen(args)
         } else {
             if &*__dispatch_subject == "String.charAt" {
-                builtinStringCharAt(args)
+                crate::aver_generated::domain::builtins::primitives::builtinStringCharAt(args)
             } else {
                 if &*__dispatch_subject == "String.chars" {
-                    builtinStringChars(args)
+                    crate::aver_generated::domain::builtins::primitives::builtinStringChars(args)
                 } else {
                     if &*__dispatch_subject == "String.join" {
-                        builtinStringJoin(args)
+                        crate::aver_generated::domain::builtins::primitives::builtinStringJoin(args)
                     } else {
                         if &*__dispatch_subject == "String.slice" {
-                            builtinStringSlice(args)
+                            crate::aver_generated::domain::builtins::primitives::builtinStringSlice(
+                                args,
+                            )
                         } else {
                             if &*__dispatch_subject == "String.fromBool" {
-                                builtinStringFromBool(args)
+                                crate::aver_generated::domain::builtins::primitives::builtinStringFromBool(args)
                             } else {
                                 if &*__dispatch_subject == "String.fromInt" {
-                                    builtinStringFromInt(args)
+                                    crate::aver_generated::domain::builtins::primitives::builtinStringFromInt(args)
                                 } else {
                                     if &*__dispatch_subject == "String.fromFloat" {
-                                        builtinStringFromFloat(args)
+                                        crate::aver_generated::domain::builtins::primitives::builtinStringFromFloat(args)
                                     } else {
                                         if &*__dispatch_subject == "String.contains" {
-                                            builtinStringContains(args)
+                                            crate::aver_generated::domain::builtins::primitives::builtinStringContains(args)
                                         } else {
                                             if &*__dispatch_subject == "String.startsWith" {
-                                                builtinStringStartsWith(args)
+                                                crate::aver_generated::domain::builtins::primitives::builtinStringStartsWith(args)
                                             } else {
                                                 if &*__dispatch_subject == "String.toLower" {
-                                                    builtinStringToLower(args)
+                                                    crate::aver_generated::domain::builtins::primitives::builtinStringToLower(args)
                                                 } else {
                                                     if &*__dispatch_subject == "String.toUpper" {
-                                                        builtinStringToUpper(args)
+                                                        crate::aver_generated::domain::builtins::primitives::builtinStringToUpper(args)
                                                     } else {
                                                         if &*__dispatch_subject == "String.trim" {
-                                                            builtinStringTrim(args)
+                                                            crate::aver_generated::domain::builtins::primitives::builtinStringTrim(args)
                                                         } else {
                                                             if &*__dispatch_subject
                                                                 == "String.endsWith"
                                                             {
-                                                                builtinStringEndsWith(args)
+                                                                crate::aver_generated::domain::builtins::primitives::builtinStringEndsWith(args)
                                                             } else {
                                                                 if &*__dispatch_subject
                                                                     == "String.split"
                                                                 {
-                                                                    builtinStringSplit(args)
+                                                                    crate::aver_generated::domain::builtins::primitives::builtinStringSplit(args)
                                                                 } else {
                                                                     if &*__dispatch_subject
                                                                         == "String.repeat"
                                                                     {
-                                                                        builtinStringRepeat(args)
+                                                                        crate::aver_generated::domain::builtins::primitives::builtinStringRepeat(args)
                                                                     } else {
                                                                         if &*__dispatch_subject
                                                                             == "String.replace"
                                                                         {
-                                                                            builtinStringReplaceAll(
-                                                                                args,
-                                                                            )
+                                                                            crate::aver_generated::domain::builtins::primitives::builtinStringReplaceAll(args)
                                                                         } else {
                                                                             Err(aver_rt::AverStr::from({ let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((40i64) as usize); __b.push_str(&AverStr::from("unknown string builtin: ")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(name)))); __b }))
                                                                         }
@@ -193,10 +195,10 @@ pub fn callChar(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, Ave
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Char.fromCode" {
-            builtinCharFromCode(args)
+            crate::aver_generated::domain::builtins::primitives::builtinCharFromCode(args)
         } else {
             if &*__dispatch_subject == "Char.toCode" {
-                builtinCharToCode(args)
+                crate::aver_generated::domain::builtins::primitives::builtinCharToCode(args)
             } else {
                 Err(aver_rt::AverStr::from({
                     let mut __b = {
@@ -217,7 +219,9 @@ pub fn builtinIntToFloat(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
-    Ok(Val::ValFloat(n as f64))
+    Ok(crate::aver_generated::domain::value::Val::ValFloat(
+        n as f64,
+    ))
 }
 
 /// String.fromInt(n) -> string representation.
@@ -225,7 +229,9 @@ pub fn builtinIntToString(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
-    Ok(Val::ValStr((n.to_string()).into_aver()))
+    Ok(crate::aver_generated::domain::value::Val::ValStr(
+        (n.to_string()).into_aver(),
+    ))
 }
 
 /// Int.abs(n) -> absolute value.
@@ -233,7 +239,7 @@ pub fn builtinIntAbs(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
-    Ok(Val::ValInt(n.abs()))
+    Ok(crate::aver_generated::domain::value::Val::ValInt(n.abs()))
 }
 
 /// Int.mod(a, b) -> a mod b as Result.
@@ -242,7 +248,7 @@ pub fn builtinIntMod(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
-        builtinIntModInner(&aV, &bV)
+        crate::aver_generated::domain::builtins::primitives::builtinIntModInner(&aV, &bV)
     }
 }
 
@@ -252,18 +258,22 @@ pub fn builtinIntModInner(aV: &Val, bV: &Val) -> Result<Val, AverStr> {
     let a = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
     let b = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
     if (b == 0i64) {
-        Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(
-            AverStr::from("modulo by zero"),
-        ))))
+        Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(
+                AverStr::from("modulo by zero"),
+            )),
+        ))
     } else {
-        Ok(Val::ValOk(std::sync::Arc::new(Val::ValInt({
-            let __b = b;
-            if __b == 0i64 {
-                0i64
-            } else {
-                (a).rem_euclid(__b)
-            }
-        }))))
+        Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValInt({
+                let __b = b;
+                if __b == 0i64 {
+                    0i64
+                } else {
+                    (a).rem_euclid(__b)
+                }
+            })),
+        ))
     }
 }
 
@@ -272,7 +282,9 @@ pub fn builtinStringLen(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
-    Ok(Val::ValInt((s.chars().count() as i64)))
+    Ok(crate::aver_generated::domain::value::Val::ValInt(
+        (s.chars().count() as i64),
+    ))
 }
 
 /// String.charAt(s, index) -> single character string or error.
@@ -281,7 +293,7 @@ pub fn builtinStringCharAt(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, idxV) = pair;
-        builtinStringCharAtInner(&sV, &idxV)
+        crate::aver_generated::domain::builtins::primitives::builtinStringCharAtInner(&sV, &idxV)
     }
 }
 
@@ -291,7 +303,9 @@ pub fn builtinStringCharAtInner(sV: &Val, idxV: &Val) -> Result<Val, AverStr> {
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
     let idx = crate::aver_generated::domain::builtins::helpers::expectInt(idxV)?;
     match (s.chars().nth(idx as usize).map(|c| c.to_string())).into_aver() {
-        Some(c) => Ok(Val::ValSome(std::sync::Arc::new(Val::ValStr(c)))),
+        Some(c) => Ok(crate::aver_generated::domain::value::Val::ValSome(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(c)),
+        )),
         None => Ok(Val::ValNone.clone()),
     }
 }
@@ -302,7 +316,7 @@ pub fn builtinStringJoin(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (lstV, sepV) = pair;
-        builtinStringJoinInner(&lstV, &sepV)
+        crate::aver_generated::domain::builtins::primitives::builtinStringJoinInner(&lstV, &sepV)
     }
 }
 
@@ -311,8 +325,13 @@ pub fn builtinStringJoinInner(lstV: &Val, sepV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
     let sep = crate::aver_generated::domain::builtins::helpers::expectStr(sepV)?;
-    let strs = extractStrings(items, aver_rt::AverList::empty())?;
-    Ok(Val::ValStr((aver_rt::string_join(&strs, &sep)).into_aver()))
+    let strs = crate::aver_generated::domain::builtins::primitives::extractStrings(
+        items,
+        aver_rt::AverList::empty(),
+    )?;
+    Ok(crate::aver_generated::domain::value::Val::ValStr(
+        (aver_rt::string_join(&strs, &sep)).into_aver(),
+    ))
 }
 
 /// Convert list of ValStr to list of String.
@@ -324,7 +343,7 @@ pub fn extractStrings(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(items, [] => Ok(acc.reverse()), [v, rest] => { match v {
-            Val::ValStr(s) => {
+            crate::aver_generated::domain::value::Val::ValStr(s) => {
             let __tmp1 = aver_rt::AverList::prepend(s, &acc);
             items = rest;
             acc = __tmp1;
@@ -350,7 +369,7 @@ pub fn builtinStringSlice(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
                             {
                                 let __list_subject = rest3;
                                 if __list_subject.is_empty() {
-                                    builtinStringSliceInner(&sV, &startV, &endV)
+                                    crate::aver_generated::domain::builtins::primitives::builtinStringSliceInner(&sV, &startV, &endV)
                                 } else {
                                     Err(AverStr::from("String.slice takes 3 arguments"))
                                 }
@@ -375,7 +394,7 @@ pub fn builtinStringSliceInner(sV: &Val, startV: &Val, endV: &Val) -> Result<Val
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
     let start = crate::aver_generated::domain::builtins::helpers::expectInt(startV)?;
     let end = crate::aver_generated::domain::builtins::helpers::expectInt(endV)?;
-    Ok(Val::ValStr(
+    Ok(crate::aver_generated::domain::value::Val::ValStr(
         (aver_rt::string_slice(&s, start, end)).into_aver(),
     ))
 }
@@ -385,7 +404,9 @@ pub fn builtinStringFromBool(args: &aver_rt::AverList<Val>) -> Result<Val, AverS
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValBool(b) => Ok(Val::ValStr((b.to_string()).into_aver())),
+        crate::aver_generated::domain::value::Val::ValBool(b) => Ok(
+            crate::aver_generated::domain::value::Val::ValStr((b.to_string()).into_aver()),
+        ),
         _ => Err(AverStr::from("String.fromBool requires Bool")),
     }
 }
@@ -395,7 +416,9 @@ pub fn builtinStringFromInt(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
-    Ok(Val::ValStr((n.to_string()).into_aver()))
+    Ok(crate::aver_generated::domain::value::Val::ValStr(
+        (n.to_string()).into_aver(),
+    ))
 }
 
 /// String.fromFloat(f) -> string.
@@ -403,7 +426,9 @@ pub fn builtinStringFromFloat(args: &aver_rt::AverList<Val>) -> Result<Val, Aver
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValFloat(f) => Ok(Val::ValStr((f.to_string()).into_aver())),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
+            crate::aver_generated::domain::value::Val::ValStr((f.to_string()).into_aver()),
+        ),
         _ => Err(AverStr::from("String.fromFloat requires Float")),
     }
 }
@@ -414,7 +439,7 @@ pub fn builtinStringContains(args: &aver_rt::AverList<Val>) -> Result<Val, AverS
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (hV, nV) = pair;
-        builtinStringContainsInner(&hV, &nV)
+        crate::aver_generated::domain::builtins::primitives::builtinStringContainsInner(&hV, &nV)
     }
 }
 
@@ -423,7 +448,9 @@ pub fn builtinStringContainsInner(hV: &Val, nV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let h = crate::aver_generated::domain::builtins::helpers::expectStr(hV)?;
     let n = crate::aver_generated::domain::builtins::helpers::expectStr(nV)?;
-    Ok(Val::ValBool(h.contains(&*n)))
+    Ok(crate::aver_generated::domain::value::Val::ValBool(
+        h.contains(&*n),
+    ))
 }
 
 /// String.startsWith(s, prefix) -> Bool.
@@ -432,7 +459,7 @@ pub fn builtinStringStartsWith(args: &aver_rt::AverList<Val>) -> Result<Val, Ave
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, pV) = pair;
-        builtinStringStartsWithInner(&sV, &pV)
+        crate::aver_generated::domain::builtins::primitives::builtinStringStartsWithInner(&sV, &pV)
     }
 }
 
@@ -441,7 +468,9 @@ pub fn builtinStringStartsWithInner(sV: &Val, pV: &Val) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
     let p = crate::aver_generated::domain::builtins::helpers::expectStr(pV)?;
-    Ok(Val::ValBool(s.starts_with(&*p)))
+    Ok(crate::aver_generated::domain::value::Val::ValBool(
+        s.starts_with(&*p),
+    ))
 }
 
 /// String.toLower(s) -> lowercase string.
@@ -449,7 +478,9 @@ pub fn builtinStringToLower(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
-    Ok(Val::ValStr((s.to_lowercase()).into_aver()))
+    Ok(crate::aver_generated::domain::value::Val::ValStr(
+        (s.to_lowercase()).into_aver(),
+    ))
 }
 
 /// Char.fromCode(n) -> single character string.
@@ -458,7 +489,9 @@ pub fn builtinCharFromCode(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
     match (char::from_u32(n as u32).map(|c| c.to_string())).into_aver() {
-        Some(c) => Ok(Val::ValSome(std::sync::Arc::new(Val::ValStr(c)))),
+        Some(c) => Ok(crate::aver_generated::domain::value::Val::ValSome(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(c)),
+        )),
         None => Ok(Val::ValNone.clone()),
     }
 }
@@ -468,7 +501,7 @@ pub fn builtinCharToCode(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
-    Ok(Val::ValInt(
+    Ok(crate::aver_generated::domain::value::Val::ValInt(
         (s.chars().next().map(|c| c as i64).unwrap_or(0i64)),
     ))
 }
@@ -479,8 +512,12 @@ pub fn builtinIntFromString(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match (s.parse::<i64>().map_err(|e| e.to_string())).into_aver() {
-        Ok(n) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValInt(n)))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(n) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValInt(n)),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -489,12 +526,14 @@ pub fn builtinStringChars(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
-    Ok(Val::ValList(stringToCharList(
-        s.clone(),
-        0i64,
-        (s.chars().count() as i64),
-        aver_rt::AverList::empty(),
-    )))
+    Ok(crate::aver_generated::domain::value::Val::ValList(
+        crate::aver_generated::domain::builtins::primitives::stringToCharList(
+            s.clone(),
+            0i64,
+            (s.chars().count() as i64),
+            aver_rt::AverList::empty(),
+        ),
+    ))
 }
 
 /// Split string into list of ValStr chars.
@@ -514,7 +553,10 @@ pub fn stringToCharList(
             match (s.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
                     let __tmp1 = (pos + 1i64);
-                    let __tmp3 = aver_rt::AverList::prepend(Val::ValStr(c), &acc);
+                    let __tmp3 = aver_rt::AverList::prepend(
+                        crate::aver_generated::domain::value::Val::ValStr(c),
+                        &acc,
+                    );
                     pos = __tmp1;
                     acc = __tmp3;
                     continue;
@@ -532,52 +574,56 @@ pub fn callFloat(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, Av
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "String.fromFloat" {
-            builtinFloatToString(args)
+            crate::aver_generated::domain::builtins::primitives::builtinFloatToString(args)
         } else {
             if &*__dispatch_subject == "Float.fromInt" {
-                builtinFloatFromInt(args)
+                crate::aver_generated::domain::builtins::primitives::builtinFloatFromInt(args)
             } else {
                 if &*__dispatch_subject == "Float.round" {
-                    builtinFloatRound(args)
+                    crate::aver_generated::domain::builtins::primitives::builtinFloatRound(args)
                 } else {
                     if &*__dispatch_subject == "Float.fromString" {
-                        builtinFloatFromString(args)
+                        crate::aver_generated::domain::builtins::primitives::builtinFloatFromString(
+                            args,
+                        )
                     } else {
                         if &*__dispatch_subject == "Float.abs" {
-                            builtinFloatAbs(args)
+                            crate::aver_generated::domain::builtins::primitives::builtinFloatAbs(
+                                args,
+                            )
                         } else {
                             if &*__dispatch_subject == "Float.floor" {
-                                builtinFloatFloor(args)
+                                crate::aver_generated::domain::builtins::primitives::builtinFloatFloor(args)
                             } else {
                                 if &*__dispatch_subject == "Float.ceil" {
-                                    builtinFloatCeil(args)
+                                    crate::aver_generated::domain::builtins::primitives::builtinFloatCeil(args)
                                 } else {
                                     if &*__dispatch_subject == "Float.min" {
-                                        builtinFloatMin(args)
+                                        crate::aver_generated::domain::builtins::primitives::builtinFloatMin(args)
                                     } else {
                                         if &*__dispatch_subject == "Float.max" {
-                                            builtinFloatMax(args)
+                                            crate::aver_generated::domain::builtins::primitives::builtinFloatMax(args)
                                         } else {
                                             if &*__dispatch_subject == "Float.sin" {
-                                                builtinFloatSin(args)
+                                                crate::aver_generated::domain::builtins::primitives::builtinFloatSin(args)
                                             } else {
                                                 if &*__dispatch_subject == "Float.cos" {
-                                                    builtinFloatCos(args)
+                                                    crate::aver_generated::domain::builtins::primitives::builtinFloatCos(args)
                                                 } else {
                                                     if &*__dispatch_subject == "Float.sqrt" {
-                                                        builtinFloatSqrt(args)
+                                                        crate::aver_generated::domain::builtins::primitives::builtinFloatSqrt(args)
                                                     } else {
                                                         if &*__dispatch_subject == "Float.pow" {
-                                                            builtinFloatPow(args)
+                                                            crate::aver_generated::domain::builtins::primitives::builtinFloatPow(args)
                                                         } else {
                                                             if &*__dispatch_subject == "Float.atan2"
                                                             {
-                                                                builtinFloatAtan2(args)
+                                                                crate::aver_generated::domain::builtins::primitives::builtinFloatAtan2(args)
                                                             } else {
                                                                 if &*__dispatch_subject
                                                                     == "Float.pi"
                                                                 {
-                                                                    builtinFloatPi(args)
+                                                                    crate::aver_generated::domain::builtins::primitives::builtinFloatPi(args)
                                                                 } else {
                                                                     Err(aver_rt::AverStr::from({
                                                                         let mut __b = {
@@ -612,8 +658,12 @@ pub fn builtinFloatFromString(args: &aver_rt::AverList<Val>) -> Result<Val, Aver
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match (s.parse::<f64>().map_err(|e| e.to_string())).into_aver() {
-        Ok(f) => Ok(Val::ValOk(std::sync::Arc::new(Val::ValFloat(f)))),
-        Err(e) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(e)))),
+        Ok(f) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValFloat(f)),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
     }
 }
 
@@ -622,7 +672,9 @@ pub fn builtinFloatFromInt(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
-    Ok(Val::ValFloat(n as f64))
+    Ok(crate::aver_generated::domain::value::Val::ValFloat(
+        n as f64,
+    ))
 }
 
 /// Float.round(f) -> Int.
@@ -630,7 +682,9 @@ pub fn builtinFloatRound(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValFloat(f) => Ok(Val::ValInt(f.round() as i64)),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
+            crate::aver_generated::domain::value::Val::ValInt(f.round() as i64),
+        ),
         _ => Err(AverStr::from("Float.round requires Float")),
     }
 }
@@ -640,7 +694,9 @@ pub fn builtinFloatToString(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValFloat(f) => Ok(Val::ValStr((f.to_string()).into_aver())),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
+            crate::aver_generated::domain::value::Val::ValStr((f.to_string()).into_aver()),
+        ),
         _ => Err(AverStr::from("String.fromFloat requires Float")),
     }
 }
@@ -650,7 +706,9 @@ pub fn builtinFloatAbs(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValFloat(f) => Ok(Val::ValFloat(f.abs())),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => {
+            Ok(crate::aver_generated::domain::value::Val::ValFloat(f.abs()))
+        }
         _ => Err(AverStr::from("Float.abs requires Float")),
     }
 }
@@ -660,7 +718,9 @@ pub fn builtinFloatFloor(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValFloat(f) => Ok(Val::ValInt(f.floor() as i64)),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
+            crate::aver_generated::domain::value::Val::ValInt(f.floor() as i64),
+        ),
         _ => Err(AverStr::from("Float.floor requires Float")),
     }
 }
@@ -670,7 +730,9 @@ pub fn builtinFloatCeil(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValFloat(f) => Ok(Val::ValInt(f.ceil() as i64)),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
+            crate::aver_generated::domain::value::Val::ValInt(f.ceil() as i64),
+        ),
         _ => Err(AverStr::from("Float.ceil requires Float")),
     }
 }
@@ -680,7 +742,12 @@ pub fn builtinFloatMin(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
-        (Val::ValFloat(a), Val::ValFloat(b)) => Ok(Val::ValFloat(a.min(b))),
+        (
+            crate::aver_generated::domain::value::Val::ValFloat(a),
+            crate::aver_generated::domain::value::Val::ValFloat(b),
+        ) => Ok(crate::aver_generated::domain::value::Val::ValFloat(
+            a.min(b),
+        )),
         _ => Err(AverStr::from("Float.min requires two Floats")),
     }
 }
@@ -690,7 +757,12 @@ pub fn builtinFloatMax(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
-        (Val::ValFloat(a), Val::ValFloat(b)) => Ok(Val::ValFloat(a.max(b))),
+        (
+            crate::aver_generated::domain::value::Val::ValFloat(a),
+            crate::aver_generated::domain::value::Val::ValFloat(b),
+        ) => Ok(crate::aver_generated::domain::value::Val::ValFloat(
+            a.max(b),
+        )),
         _ => Err(AverStr::from("Float.max requires two Floats")),
     }
 }
@@ -700,7 +772,9 @@ pub fn builtinFloatSin(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValFloat(f) => Ok(Val::ValFloat(f.sin())),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => {
+            Ok(crate::aver_generated::domain::value::Val::ValFloat(f.sin()))
+        }
         _ => Err(AverStr::from("Float.sin requires Float")),
     }
 }
@@ -710,7 +784,9 @@ pub fn builtinFloatCos(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValFloat(f) => Ok(Val::ValFloat(f.cos())),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => {
+            Ok(crate::aver_generated::domain::value::Val::ValFloat(f.cos()))
+        }
         _ => Err(AverStr::from("Float.cos requires Float")),
     }
 }
@@ -720,7 +796,9 @@ pub fn builtinFloatSqrt(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValFloat(f) => Ok(Val::ValFloat(f.sqrt())),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
+            crate::aver_generated::domain::value::Val::ValFloat(f.sqrt()),
+        ),
         _ => Err(AverStr::from("Float.sqrt requires Float")),
     }
 }
@@ -730,7 +808,12 @@ pub fn builtinFloatPow(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
-        (Val::ValFloat(a), Val::ValFloat(b)) => Ok(Val::ValFloat(a.powf(b))),
+        (
+            crate::aver_generated::domain::value::Val::ValFloat(a),
+            crate::aver_generated::domain::value::Val::ValFloat(b),
+        ) => Ok(crate::aver_generated::domain::value::Val::ValFloat(
+            a.powf(b),
+        )),
         _ => Err(AverStr::from("Float.pow requires two Floats")),
     }
 }
@@ -740,7 +823,12 @@ pub fn builtinFloatAtan2(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
-        (Val::ValFloat(a), Val::ValFloat(b)) => Ok(Val::ValFloat(a.atan2(b))),
+        (
+            crate::aver_generated::domain::value::Val::ValFloat(a),
+            crate::aver_generated::domain::value::Val::ValFloat(b),
+        ) => Ok(crate::aver_generated::domain::value::Val::ValFloat(
+            a.atan2(b),
+        )),
         _ => Err(AverStr::from("Float.atan2 requires two Floats")),
     }
 }
@@ -751,7 +839,9 @@ pub fn builtinFloatPi(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     {
         let __list_subject = args;
         if __list_subject.is_empty() {
-            Ok(Val::ValFloat(std::f64::consts::PI))
+            Ok(crate::aver_generated::domain::value::Val::ValFloat(
+                std::f64::consts::PI,
+            ))
         } else {
             Err(AverStr::from("Float.pi takes 0 arguments"))
         }
@@ -763,7 +853,9 @@ pub fn builtinStringToUpper(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
-    Ok(Val::ValStr((s.to_uppercase()).into_aver()))
+    Ok(crate::aver_generated::domain::value::Val::ValStr(
+        (s.to_uppercase()).into_aver(),
+    ))
 }
 
 /// String.trim(s) -> trimmed string.
@@ -771,7 +863,9 @@ pub fn builtinStringTrim(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
-    Ok(Val::ValStr((s.trim().to_string()).into_aver()))
+    Ok(crate::aver_generated::domain::value::Val::ValStr(
+        (s.trim().to_string()).into_aver(),
+    ))
 }
 
 /// String.endsWith(s, suffix) -> Bool.
@@ -780,7 +874,7 @@ pub fn builtinStringEndsWith(args: &aver_rt::AverList<Val>) -> Result<Val, AverS
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, pV) = pair;
-        builtinStringEndsWithInner(&sV, &pV)
+        crate::aver_generated::domain::builtins::primitives::builtinStringEndsWithInner(&sV, &pV)
     }
 }
 
@@ -789,7 +883,9 @@ pub fn builtinStringEndsWithInner(sV: &Val, pV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
     let p = crate::aver_generated::domain::builtins::helpers::expectStr(pV)?;
-    Ok(Val::ValBool(s.ends_with(&*p)))
+    Ok(crate::aver_generated::domain::value::Val::ValBool(
+        s.ends_with(&*p),
+    ))
 }
 
 /// String.split(s, sep) -> List<String>.
@@ -798,7 +894,7 @@ pub fn builtinStringSplit(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, sepV) = pair;
-        builtinStringSplitInner(&sV, &sepV)
+        crate::aver_generated::domain::builtins::primitives::builtinStringSplitInner(&sV, &sepV)
     }
 }
 
@@ -810,10 +906,12 @@ pub fn builtinStringSplitInner(sV: &Val, sepV: &Val) -> Result<Val, AverStr> {
     let parts =
         (aver_rt::AverList::from_vec(s.split(&*sep).map(|s| s.to_string()).collect::<Vec<_>>()))
             .into_aver();
-    Ok(Val::ValList(strPartsToVals(
-        parts,
-        aver_rt::AverList::empty(),
-    )))
+    Ok(crate::aver_generated::domain::value::Val::ValList(
+        crate::aver_generated::domain::builtins::primitives::strPartsToVals(
+            parts,
+            aver_rt::AverList::empty(),
+        ),
+    ))
 }
 
 /// Convert string list to ValStr list.
@@ -825,7 +923,7 @@ pub fn strPartsToVals(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(parts, [] => acc.reverse(), [s, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(Val::ValStr(s), &acc);
+            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValStr(s), &acc);
             parts = rest;
             acc = __tmp1;
             continue;
@@ -839,7 +937,7 @@ pub fn builtinStringRepeat(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, nV) = pair;
-        builtinStringRepeatInner(&sV, &nV)
+        crate::aver_generated::domain::builtins::primitives::builtinStringRepeatInner(&sV, &nV)
     }
 }
 
@@ -848,7 +946,9 @@ pub fn builtinStringRepeatInner(sV: &Val, nV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
     let n = crate::aver_generated::domain::builtins::helpers::expectInt(nV)?;
-    Ok(Val::ValStr(repeatStr(s, n, AverStr::from(""))))
+    Ok(crate::aver_generated::domain::value::Val::ValStr(
+        crate::aver_generated::domain::builtins::primitives::repeatStr(s, n, AverStr::from("")),
+    ))
 }
 
 /// Repeat string n times.
@@ -877,7 +977,7 @@ pub fn repeatStr(mut s: AverStr, mut n: i64, mut acc: AverStr) -> AverStr {
 pub fn builtinStringReplaceAll(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     if ((args.len() as i64) == 3i64) {
-        builtinStringReplaceAllExtract(args)
+        crate::aver_generated::domain::builtins::primitives::builtinStringReplaceAllExtract(args)
     } else {
         Err(AverStr::from("String.replace takes 3 arguments"))
     }
@@ -887,7 +987,7 @@ pub fn builtinStringReplaceAll(args: &aver_rt::AverList<Val>) -> Result<Val, Ave
 #[inline(always)]
 pub fn builtinStringReplaceAllExtract(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    aver_list_match!(args.clone(), [] => Err(AverStr::from("String.replace takes 3 arguments")), [sV, r1] => aver_list_match!(r1, [] => Err(AverStr::from("String.replace takes 3 arguments")), [fromV, r2] => aver_list_match!(r2, [] => Err(AverStr::from("String.replace takes 3 arguments")), [toV, r3] => builtinStringReplaceAllDo(&sV, &fromV, &toV))))
+    aver_list_match!(args.clone(), [] => Err(AverStr::from("String.replace takes 3 arguments")), [sV, r1] => aver_list_match!(r1, [] => Err(AverStr::from("String.replace takes 3 arguments")), [fromV, r2] => aver_list_match!(r2, [] => Err(AverStr::from("String.replace takes 3 arguments")), [toV, r3] => crate::aver_generated::domain::builtins::primitives::builtinStringReplaceAllDo(&sV, &fromV, &toV))))
 }
 
 /// Inner impl of String.replace.
@@ -896,5 +996,7 @@ pub fn builtinStringReplaceAllDo(sV: &Val, fromV: &Val, toV: &Val) -> Result<Val
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
     let from = crate::aver_generated::domain::builtins::helpers::expectStr(fromV)?;
     let to = crate::aver_generated::domain::builtins::helpers::expectStr(toV)?;
-    Ok(Val::ValStr((s.replace(&*from, &*to)).into_aver()))
+    Ok(crate::aver_generated::domain::value::Val::ValStr(
+        (s.replace(&*from, &*to)).into_aver(),
+    ))
 }

--- a/src/self_host/aver_generated/domain/builtins/vector/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/vector/mod.rs
@@ -12,22 +12,26 @@ pub fn call(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Vector.new" {
-            builtinVectorNew(args)
+            crate::aver_generated::domain::builtins::vector::builtinVectorNew(args)
         } else {
             if &*__dispatch_subject == "Vector.get" {
-                builtinVectorGet(args)
+                crate::aver_generated::domain::builtins::vector::builtinVectorGet(args)
             } else {
                 if &*__dispatch_subject == "Vector.set" {
-                    builtinVectorSet(args)
+                    crate::aver_generated::domain::builtins::vector::builtinVectorSet(args)
                 } else {
                     if &*__dispatch_subject == "Vector.len" {
-                        builtinVectorLen(args)
+                        crate::aver_generated::domain::builtins::vector::builtinVectorLen(args)
                     } else {
                         if &*__dispatch_subject == "Vector.fromList" {
-                            builtinVectorFromList(args)
+                            crate::aver_generated::domain::builtins::vector::builtinVectorFromList(
+                                args,
+                            )
                         } else {
                             if &*__dispatch_subject == "List.fromVector" {
-                                builtinVectorToList(args)
+                                crate::aver_generated::domain::builtins::vector::builtinVectorToList(
+                                    args,
+                                )
                             } else {
                                 Err(aver_rt::AverStr::from({
                                     let mut __b = {
@@ -55,10 +59,11 @@ pub fn builtinVectorNew(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
-        (Val::ValInt(size), defaultVal) => Ok(Val::ValVector(aver_rt::AverVector::new(
-            size as usize,
-            defaultVal,
-        ))),
+        (crate::aver_generated::domain::value::Val::ValInt(size), defaultVal) => {
+            Ok(crate::aver_generated::domain::value::Val::ValVector(
+                aver_rt::AverVector::new(size as usize, defaultVal),
+            ))
+        }
         _ => Err(AverStr::from("Vector.new: first arg must be Int")),
     }
 }
@@ -68,8 +73,13 @@ pub fn builtinVectorGet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
-        (Val::ValVector(vec), Val::ValInt(idx)) => match vec.get(idx as usize).cloned() {
-            Some(v) => Ok(Val::ValSome(std::sync::Arc::new(v))),
+        (
+            crate::aver_generated::domain::value::Val::ValVector(vec),
+            crate::aver_generated::domain::value::Val::ValInt(idx),
+        ) => match vec.get(idx as usize).cloned() {
+            Some(v) => Ok(crate::aver_generated::domain::value::Val::ValSome(
+                std::sync::Arc::new(v),
+            )),
             None => Ok(Val::ValNone.clone()),
         },
         _ => Err(AverStr::from("Vector.get: expected (Vector, Int)")),
@@ -89,7 +99,9 @@ pub fn builtinVectorSet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
                         let __list_subject = rest2;
                         if let Some((valV, ignored)) = aver_rt::list_uncons_cloned(&__list_subject)
                         {
-                            builtinVectorSetInner(&vecV, &idxV, &valV)
+                            crate::aver_generated::domain::builtins::vector::builtinVectorSetInner(
+                                &vecV, &idxV, &valV,
+                            )
                         } else {
                             Err(AverStr::from("Vector.set: expected 3 args"))
                         }
@@ -108,20 +120,22 @@ pub fn builtinVectorSet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
 pub fn builtinVectorSetInner(vecV: &Val, idxV: &Val, valV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match vecV.clone() {
-        Val::ValVector(vec) => match idxV.clone() {
-            Val::ValInt(idx) => {
-                if (idx < 0i64) {
-                    Ok(Val::ValNone.clone())
-                } else {
-                    if (idx < (vec.len() as i64)) {
-                        builtinVectorSetInBounds(&vec, idx, valV)
-                    } else {
+        crate::aver_generated::domain::value::Val::ValVector(vec) => {
+            match idxV.clone() {
+                crate::aver_generated::domain::value::Val::ValInt(idx) => {
+                    if (idx < 0i64) {
                         Ok(Val::ValNone.clone())
+                    } else {
+                        if (idx < (vec.len() as i64)) {
+                            crate::aver_generated::domain::builtins::vector::builtinVectorSetInBounds(&vec, idx, valV)
+                        } else {
+                            Ok(Val::ValNone.clone())
+                        }
                     }
                 }
+                _ => Err(AverStr::from("Vector.set: second arg must be Int")),
             }
-            _ => Err(AverStr::from("Vector.set: second arg must be Int")),
-        },
+        }
         _ => Err(AverStr::from("Vector.set: first arg must be Vector")),
     }
 }
@@ -135,7 +149,9 @@ pub fn builtinVectorSetInBounds(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match vec.clone().set_owned(idx as usize, valV.clone()) {
-        Some(newVec) => Ok(Val::ValSome(std::sync::Arc::new(Val::ValVector(newVec)))),
+        Some(newVec) => Ok(crate::aver_generated::domain::value::Val::ValSome(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValVector(newVec)),
+        )),
         None => Err(AverStr::from("Vector.set: index out of bounds")),
     }
 }
@@ -145,7 +161,9 @@ pub fn builtinVectorLen(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValVector(vec) => Ok(Val::ValInt((vec.len() as i64))),
+        crate::aver_generated::domain::value::Val::ValVector(vec) => Ok(
+            crate::aver_generated::domain::value::Val::ValInt((vec.len() as i64)),
+        ),
         _ => Err(AverStr::from("Vector.len: expected Vector")),
     }
 }
@@ -155,9 +173,11 @@ pub fn builtinVectorFromList(args: &aver_rt::AverList<Val>) -> Result<Val, AverS
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValList(items) => Ok(Val::ValVector(aver_rt::AverVector::from_vec(
-            items.to_vec(),
-        ))),
+        crate::aver_generated::domain::value::Val::ValList(items) => {
+            Ok(crate::aver_generated::domain::value::Val::ValVector(
+                aver_rt::AverVector::from_vec(items.to_vec()),
+            ))
+        }
         _ => Err(AverStr::from("Vector.fromList: expected List")),
     }
 }
@@ -167,7 +187,9 @@ pub fn builtinVectorToList(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
-        Val::ValVector(vec) => Ok(Val::ValList(vec.to_list())),
+        crate::aver_generated::domain::value::Val::ValVector(vec) => Ok(
+            crate::aver_generated::domain::value::Val::ValList(vec.to_list()),
+        ),
         _ => Err(AverStr::from("List.fromVector: expected Vector")),
     }
 }

--- a/src/self_host/aver_generated/domain/builtins/wrappers/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/wrappers/mod.rs
@@ -12,19 +12,21 @@ pub fn call(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Result.Ok" {
-            builtinResultOk(args)
+            crate::aver_generated::domain::builtins::wrappers::builtinResultOk(args)
         } else {
             if &*__dispatch_subject == "Result.Err" {
-                builtinResultErr(args)
+                crate::aver_generated::domain::builtins::wrappers::builtinResultErr(args)
             } else {
                 if &*__dispatch_subject == "Result.withDefault" {
-                    builtinResultWithDefault(args)
+                    crate::aver_generated::domain::builtins::wrappers::builtinResultWithDefault(
+                        args,
+                    )
                 } else {
                     if &*__dispatch_subject == "Option.Some" {
-                        builtinOptionSome(args)
+                        crate::aver_generated::domain::builtins::wrappers::builtinOptionSome(args)
                     } else {
                         if &*__dispatch_subject == "Option.withDefault" {
-                            builtinOptionWithDefault(args)
+                            crate::aver_generated::domain::builtins::wrappers::builtinOptionWithDefault(args)
                         } else {
                             Err(aver_rt::AverStr::from({
                                 let mut __b = {
@@ -49,14 +51,18 @@ pub fn call(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
 pub fn builtinResultOk(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    Ok(Val::ValOk(std::sync::Arc::new(v)))
+    Ok(crate::aver_generated::domain::value::Val::ValOk(
+        std::sync::Arc::new(v),
+    ))
 }
 
 /// Result.Err(value) -> wrapped Err value.
 pub fn builtinResultErr(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    Ok(Val::ValErr(std::sync::Arc::new(v)))
+    Ok(crate::aver_generated::domain::value::Val::ValErr(
+        std::sync::Arc::new(v),
+    ))
 }
 
 /// Result.withDefault(result, default) -> unwrap Ok or return default.
@@ -66,11 +72,11 @@ pub fn builtinResultWithDefault(args: &aver_rt::AverList<Val>) -> Result<Val, Av
     {
         let (resV, defV) = pair;
         match resV {
-            Val::ValOk(inner) => {
+            crate::aver_generated::domain::value::Val::ValOk(inner) => {
                 let inner = (*inner).clone();
                 Ok(inner)
             }
-            Val::ValErr(_) => Ok(defV),
+            crate::aver_generated::domain::value::Val::ValErr(_) => Ok(defV),
             _ => Err(AverStr::from("Result.withDefault requires Result value")),
         }
     }
@@ -80,7 +86,9 @@ pub fn builtinResultWithDefault(args: &aver_rt::AverList<Val>) -> Result<Val, Av
 pub fn builtinOptionSome(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    Ok(Val::ValSome(std::sync::Arc::new(v)))
+    Ok(crate::aver_generated::domain::value::Val::ValSome(
+        std::sync::Arc::new(v),
+    ))
 }
 
 /// Option.withDefault(option, default) -> unwrap Some or return default.
@@ -90,11 +98,11 @@ pub fn builtinOptionWithDefault(args: &aver_rt::AverList<Val>) -> Result<Val, Av
     {
         let (optV, defV) = pair;
         match optV {
-            Val::ValSome(inner) => {
+            crate::aver_generated::domain::value::Val::ValSome(inner) => {
                 let inner = (*inner).clone();
                 Ok(inner)
             }
-            Val::ValNone => Ok(defV),
+            crate::aver_generated::domain::value::Val::ValNone => Ok(defV),
             _ => Err(AverStr::from("Option.withDefault requires Option value")),
         }
     }
@@ -107,11 +115,15 @@ pub fn callOptionToResult(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
     {
         let (optV, errV) = pair;
         match optV {
-            Val::ValSome(inner) => {
+            crate::aver_generated::domain::value::Val::ValSome(inner) => {
                 let inner = (*inner).clone();
-                Ok(Val::ValOk(std::sync::Arc::new(inner)))
+                Ok(crate::aver_generated::domain::value::Val::ValOk(
+                    std::sync::Arc::new(inner),
+                ))
             }
-            Val::ValNone => Ok(Val::ValErr(std::sync::Arc::new(errV))),
+            crate::aver_generated::domain::value::Val::ValNone => Ok(
+                crate::aver_generated::domain::value::Val::ValErr(std::sync::Arc::new(errV)),
+            ),
             _ => Err(AverStr::from("Option.toResult requires Option value")),
         }
     }

--- a/src/self_host/aver_generated/domain/eval/common/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/common/mod.rs
@@ -14,9 +14,11 @@ use crate::*;
 pub fn evalVarFallback(name: AverStr, fns: &FnStore) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::store::lookupFnOption(fns, name.clone()) {
-        Some(fd) => Ok(Val::ValFnRef(fd.name.clone())),
+        Some(fd) => Ok(crate::aver_generated::domain::value::Val::ValFnRef(
+            fd.name.clone(),
+        )),
         None => match crate::aver_generated::domain::builtins::splitDotted(name.clone()) {
-            Some(_) => Ok(Val::ValVariant(
+            Some(_) => Ok(crate::aver_generated::domain::value::Val::ValVariant(
                 crate::aver_generated::domain::ast::ctorNameToTag(name.clone()),
                 name,
                 aver_rt::AverList::empty(),
@@ -43,14 +45,14 @@ pub fn propagationPrefix() -> AverStr {
 /// Mark a language-level Result.Err so function boundaries can convert it back into a value.
 pub fn wrapPropagatedError(msg: AverStr) -> AverStr {
     crate::cancel_checkpoint();
-    (propagationPrefix() + &msg)
+    (crate::aver_generated::domain::eval::common::propagationPrefix() + &msg)
 }
 
 /// Return the propagated payload when the evaluator error is an internal ? marker.
 #[inline(always)]
 pub fn unwrapPropagatedError(err: AverStr) -> Option<AverStr> {
     crate::cancel_checkpoint();
-    let prefix = propagationPrefix();
+    let prefix = crate::aver_generated::domain::eval::common::propagationPrefix();
     if err.starts_with(&*prefix) {
         Some(
             (aver_rt::string_slice(
@@ -71,10 +73,14 @@ pub fn normalizeFnReturn(result: &Result<Val, AverStr>) -> Result<Val, AverStr> 
     crate::cancel_checkpoint();
     match result.clone() {
         Ok(v) => Ok(v),
-        Err(err) => match unwrapPropagatedError(err.clone()) {
-            Some(msg) => Ok(Val::ValErr(std::sync::Arc::new(Val::ValStr(msg)))),
-            None => Err(err),
-        },
+        Err(err) => {
+            match crate::aver_generated::domain::eval::common::unwrapPropagatedError(err.clone()) {
+                Some(msg) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+                    std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(msg)),
+                )),
+                None => Err(err),
+            }
+        }
     }
 }
 

--- a/src/self_host/aver_generated/domain/eval/core/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/core/mod.rs
@@ -153,7 +153,7 @@ fn __mutual_tco_trampoline_1(
                 mut acc,
             ) => {
                 crate::cancel_checkpoint();
-                aver_list_match!(exprs, [] => { return Ok(acc) }, [e, restExprs] => { match evalExpr(&e, &env, &fns) { Err(err) => { return Err(err) }, Ok(v) => { __MutualTco1::EvalArgsMapToNamedEnvBind(restExprs, params, env, fns, acc, v) } } })
+                aver_list_match!(exprs, [] => { return Ok(acc) }, [e, restExprs] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { return Err(err) }, Ok(v) => { __MutualTco1::EvalArgsMapToNamedEnvBind(restExprs, params, env, fns, acc, v) } } })
             }
             __MutualTco1::EvalArgsMapToNamedEnvBind(
                 mut restExprs,
@@ -241,7 +241,7 @@ fn __mutual_tco_trampoline_2(
                 mut acc,
             ) => {
                 crate::cancel_checkpoint();
-                aver_list_match!(exprs, [] => { return Ok(acc) }, [e, restExprs] => { match evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { return Err(err) }, Ok(v) => { __MutualTco2::EvalArgsSlotToNamedEnvBind(restExprs, params, env, slotMap, fns, acc, v) } } })
+                aver_list_match!(exprs, [] => { return Ok(acc) }, [e, restExprs] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { return Err(err) }, Ok(v) => { __MutualTco2::EvalArgsSlotToNamedEnvBind(restExprs, params, env, slotMap, fns, acc, v) } } })
             }
             __MutualTco2::EvalArgsSlotToNamedEnvBind(
                 mut restExprs,
@@ -374,7 +374,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
         __state = match __state {
             __MutualTco3::EvalExpr(mut expr, mut env, mut fns) => {
                 crate::cancel_checkpoint();
-                match evalImmediateNamedExpr(&expr) {
+                match crate::aver_generated::domain::eval::core::evalImmediateNamedExpr(&expr) {
                     Some(v) => return Ok(v),
                     None => __MutualTco3::EvalExprBasic(expr, env, fns),
                 }
@@ -382,20 +382,28 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
             __MutualTco3::EvalExprBasic(mut expr, mut env, mut fns) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
+                    crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
+                        cond,
+                        thenExpr,
+                        elseExpr,
+                    ) => {
                         let cond = (*cond).clone();
                         let thenExpr = (*thenExpr).clone();
                         let elseExpr = (*elseExpr).clone();
                         __MutualTco3::EvalBoolBranch(cond, thenExpr, elseExpr, env, fns)
                     }
-                    Expr::ExprVar(name) => return evalVar(name, &env, &fns),
-                    Expr::ExprSlot(_) => {
+                    crate::aver_generated::domain::ast::Expr::ExprVar(name) => {
+                        return crate::aver_generated::domain::eval::core::evalVar(
+                            name, &env, &fns,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprSlot(_) => {
                         return Err(AverStr::from("ExprSlot in map-based eval path"));
                     }
-                    Expr::ExprBinopSlotInt(_, _, _) => {
+                    crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(_, _, _) => {
                         return Err(AverStr::from("ExprBinopSlotInt in map-based eval path"));
                     }
-                    Expr::ExprBinopSlots(_, _, _) => {
+                    crate::aver_generated::domain::ast::Expr::ExprBinopSlots(_, _, _) => {
                         return Err(AverStr::from("ExprBinopSlots in map-based eval path"));
                     }
                     _ => __MutualTco3::EvalExprInternal(expr, env, fns),
@@ -404,16 +412,20 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
             __MutualTco3::EvalExprInternal(mut expr, mut env, mut fns) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprCmpSlotInt(_, _, _) => {
+                    crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(_, _, _) => {
                         return Err(AverStr::from("ExprCmpSlotInt in map-based eval path"));
                     }
-                    Expr::ExprCmpSlots(_, _, _) => {
+                    crate::aver_generated::domain::ast::Expr::ExprCmpSlots(_, _, _) => {
                         return Err(AverStr::from("ExprCmpSlots in map-based eval path"));
                     }
-                    Expr::ExprVectorGetOrInt(vecExpr, idxExpr, defaultValue) => {
+                    crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+                        vecExpr,
+                        idxExpr,
+                        defaultValue,
+                    ) => {
                         let vecExpr = (*vecExpr).clone();
                         let idxExpr = (*idxExpr).clone();
-                        return evalVectorGetOrIntExpr(
+                        return crate::aver_generated::domain::eval::core::evalVectorGetOrIntExpr(
                             &vecExpr,
                             &idxExpr,
                             defaultValue,
@@ -421,44 +433,92 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &fns,
                         );
                     }
-                    Expr::ExprIntModOrInt(a, b, defaultValue) => {
+                    crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(
+                        a,
+                        b,
+                        defaultValue,
+                    ) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalIntModOrIntExpr(&a, &b, defaultValue, &env, &fns);
+                        return crate::aver_generated::domain::eval::core::evalIntModOrIntExpr(
+                            &a,
+                            &b,
+                            defaultValue,
+                            &env,
+                            &fns,
+                        );
                     }
-                    Expr::ExprAdd(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprAdd(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalBinop(&a, &b, &env, &fns, &BinOp::OpAdd);
+                        return crate::aver_generated::domain::eval::core::evalBinop(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &BinOp::OpAdd,
+                        );
                     }
-                    Expr::ExprSub(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalBinop(&a, &b, &env, &fns, &BinOp::OpSub);
+                        return crate::aver_generated::domain::eval::core::evalBinop(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &BinOp::OpSub,
+                        );
                     }
-                    Expr::ExprMul(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalBinop(&a, &b, &env, &fns, &BinOp::OpMul);
+                        return crate::aver_generated::domain::eval::core::evalBinop(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &BinOp::OpMul,
+                        );
                     }
-                    Expr::ExprDiv(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalBinop(&a, &b, &env, &fns, &BinOp::OpDiv);
+                        return crate::aver_generated::domain::eval::core::evalBinop(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &BinOp::OpDiv,
+                        );
                     }
-                    Expr::ExprNeg(inner) => {
+                    crate::aver_generated::domain::ast::Expr::ExprNeg(inner) => {
                         let inner = (*inner).clone();
-                        return evalNeg(&inner, &env, &fns);
+                        return crate::aver_generated::domain::eval::core::evalNeg(
+                            &inner, &env, &fns,
+                        );
                     }
-                    Expr::ExprEq(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprEq(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmp(&a, &b, &env, &fns, &CmpOp::CmpEq);
+                        return crate::aver_generated::domain::eval::core::evalCmp(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &CmpOp::CmpEq,
+                        );
                     }
-                    Expr::ExprNeq(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmp(&a, &b, &env, &fns, &CmpOp::CmpNeq);
+                        return crate::aver_generated::domain::eval::core::evalCmp(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &CmpOp::CmpNeq,
+                        );
                     }
                     _ => __MutualTco3::EvalExprAggregate(expr, env, fns),
                 }
@@ -466,62 +526,118 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
             __MutualTco3::EvalExprAggregate(mut expr, mut env, mut fns) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprLt(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmp(&a, &b, &env, &fns, &CmpOp::CmpLt);
+                        return crate::aver_generated::domain::eval::core::evalCmp(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &CmpOp::CmpLt,
+                        );
                     }
-                    Expr::ExprGt(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmp(&a, &b, &env, &fns, &CmpOp::CmpGt);
+                        return crate::aver_generated::domain::eval::core::evalCmp(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &CmpOp::CmpGt,
+                        );
                     }
-                    Expr::ExprLte(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmp(&a, &b, &env, &fns, &CmpOp::CmpLte);
+                        return crate::aver_generated::domain::eval::core::evalCmp(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &CmpOp::CmpLte,
+                        );
                     }
-                    Expr::ExprGte(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmp(&a, &b, &env, &fns, &CmpOp::CmpGte);
+                        return crate::aver_generated::domain::eval::core::evalCmp(
+                            &a,
+                            &b,
+                            &env,
+                            &fns,
+                            &CmpOp::CmpGte,
+                        );
                     }
-                    Expr::ExprConcat(parts) => return evalConcatExpr(&parts, &env, &fns),
-                    Expr::ExprTuple(exprs) => return evalTupleExpr(&exprs, &env, &fns),
-                    Expr::ExprList(exprs) => return evalListExpr(&exprs, &env, &fns),
-                    Expr::ExprRecord(name, fieldExprs) => {
-                        return evalRecordExpr(name, &fieldExprs, &env, &fns);
+                    crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
+                        return crate::aver_generated::domain::eval::core::evalConcatExpr(
+                            &parts, &env, &fns,
+                        );
                     }
-                    Expr::ExprFieldAccess(obj, field) => {
+                    crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
+                        return crate::aver_generated::domain::eval::core::evalTupleExpr(
+                            &exprs, &env, &fns,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
+                        return crate::aver_generated::domain::eval::core::evalListExpr(
+                            &exprs, &env, &fns,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprRecord(name, fieldExprs) => {
+                        return crate::aver_generated::domain::eval::core::evalRecordExpr(
+                            name,
+                            &fieldExprs,
+                            &env,
+                            &fns,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprFieldAccess(obj, field) => {
                         let obj = (*obj).clone();
-                        return evalFieldAccess(&obj, field, &env, &fns);
+                        return crate::aver_generated::domain::eval::core::evalFieldAccess(
+                            &obj, field, &env, &fns,
+                        );
                     }
-                    Expr::ExprCall(name, argExprs) => return evalCall(name, &argExprs, &env, &fns),
+                    crate::aver_generated::domain::ast::Expr::ExprCall(name, argExprs) => {
+                        return crate::aver_generated::domain::eval::core::evalCall(
+                            name, &argExprs, &env, &fns,
+                        );
+                    }
                     _ => __MutualTco3::EvalExprCalls(expr, env, fns),
                 }
             }
             __MutualTco3::EvalExprCalls(mut expr, mut env, mut fns) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprCallDirect(fnId, argExprs) => {
-                        return evalCallDirect(fnId, &argExprs, &env, &fns);
+                    crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, argExprs) => {
+                        return crate::aver_generated::domain::eval::core::evalCallDirect(
+                            fnId, &argExprs, &env, &fns,
+                        );
                     }
-                    Expr::ExprCallBuiltin(name, argExprs) => {
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, argExprs) => {
                         __MutualTco3::EvalCallBuiltinMaybeSpecial(name, argExprs, env, fns)
                     }
-                    Expr::ExprCallBuiltinId(id, argExprs) => {
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, argExprs) => {
                         __MutualTco3::EvalCallBuiltinById(id, argExprs, env, fns)
                     }
-                    Expr::ExprMatch(scrutinee, arms) => {
+                    crate::aver_generated::domain::ast::Expr::ExprMatch(scrutinee, arms) => {
                         let scrutinee = (*scrutinee).clone();
                         __MutualTco3::EvalMatchExpr(scrutinee, arms, env, fns)
                     }
-                    Expr::ExprPropagate(inner) => {
+                    crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => {
                         let inner = (*inner).clone();
-                        return evalPropagate(&inner, &env, &fns);
+                        return crate::aver_generated::domain::eval::core::evalPropagate(
+                            &inner, &env, &fns,
+                        );
                     }
-                    Expr::ExprIndependentProduct(exprs, unwrap) => {
-                        return evalIndependentProduct(&exprs, unwrap, &env, &fns);
+                    crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
+                        exprs,
+                        unwrap,
+                    ) => {
+                        return crate::aver_generated::domain::eval::core::evalIndependentProduct(
+                            &exprs, unwrap, &env, &fns,
+                        );
                     }
                     _ => {
                         return Err(aver_rt::AverStr::from({
@@ -544,9 +660,9 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let condV = evalExpr(&cond, &env, &fns)?;
+                let condV = crate::aver_generated::domain::eval::core::evalExpr(&cond, &env, &fns)?;
                 match condV.clone() {
-                    Val::ValBool(flag) => {
+                    crate::aver_generated::domain::value::Val::ValBool(flag) => {
                         if flag {
                             __MutualTco3::EvalExpr(thenExpr, env, fns)
                         } else {
@@ -562,7 +678,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
             }
             __MutualTco3::EvalMatchExpr(mut scrutinee, mut arms, mut env, mut fns) => {
                 crate::cancel_checkpoint();
-                match evalExpr(&scrutinee, &env, &fns) {
+                match crate::aver_generated::domain::eval::core::evalExpr(&scrutinee, &env, &fns) {
                     Ok(v) => __MutualTco3::EvalMatch(v, arms, env, fns),
                     Err(e) => return Err(e),
                 }
@@ -571,7 +687,9 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                 crate::cancel_checkpoint();
                 match id {
                     15i64 => __MutualTco3::EvalOptionWithDefaultExpr(argExprs, env, fns),
-                    _ => match evalArgs(&argExprs, &env, &fns) {
+                    _ => match crate::aver_generated::domain::eval::core::evalArgs(
+                        &argExprs, &env, &fns,
+                    ) {
                         Err(e) => return Err(e),
                         Ok(args) => {
                             return crate::aver_generated::domain::builtins::callBuiltinByIdValues(
@@ -587,7 +705,11 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                     "Option.withDefault" => {
                         __MutualTco3::EvalOptionWithDefaultExpr(argExprs, env, fns)
                     }
-                    _ => return evalCallBuiltin(name, &argExprs, &env, &fns),
+                    _ => {
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltin(
+                            name, &argExprs, &env, &fns,
+                        );
+                    }
                 }
             }
             __MutualTco3::EvalOptionWithDefaultExpr(mut argExprs, mut env, mut fns) => {
@@ -607,7 +729,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                                     fns,
                                 )
                             } else {
-                                return evalCallBuiltin(
+                                return crate::aver_generated::domain::eval::core::evalCallBuiltin(
                                     AverStr::from("Option.withDefault"),
                                     &argExprs,
                                     &env,
@@ -616,7 +738,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             }
                         }
                     } else {
-                        return evalCallBuiltin(
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltin(
                             AverStr::from("Option.withDefault"),
                             &argExprs,
                             &env,
@@ -633,7 +755,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
             ) => {
                 crate::cancel_checkpoint();
                 match optionExpr.clone() {
-                    Expr::ExprCallBuiltin(name, vecArgs) => {
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, vecArgs) => {
                         let __dispatch_subject = name;
                         if &*__dispatch_subject == "Vector.set" {
                             __MutualTco3::EvalVectorSetWithDefaultExpr(
@@ -651,7 +773,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                                     fns,
                                 )
                             } else {
-                                return evalCallBuiltin(
+                                return crate::aver_generated::domain::eval::core::evalCallBuiltin(
                                     AverStr::from("Option.withDefault"),
                                     &aver_rt::AverList::from_vec(vec![optionExpr, defaultExpr]),
                                     &env,
@@ -661,7 +783,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                         }
                     }
                     _ => {
-                        return evalCallBuiltin(
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltin(
                             AverStr::from("Option.withDefault"),
                             &aver_rt::AverList::from_vec(vec![optionExpr, defaultExpr]),
                             &env,
@@ -699,25 +821,17 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                                             fns,
                                         )
                                     } else {
-                                        return evalCallBuiltin(
-                                            AverStr::from("Option.withDefault"),
-                                            &aver_rt::AverList::from_vec(vec![
-                                                Expr::ExprCallBuiltin(
-                                                    AverStr::from("Vector.set"),
-                                                    vecArgs,
-                                                ),
-                                                defaultExpr,
-                                            ]),
-                                            &env,
-                                            &fns,
-                                        );
+                                        return crate::aver_generated::domain::eval::core::evalCallBuiltin(AverStr::from("Option.withDefault"), &aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(AverStr::from("Vector.set"), vecArgs), defaultExpr]), &env, &fns);
                                     }
                                 }
                             } else {
-                                return evalCallBuiltin(
+                                return crate::aver_generated::domain::eval::core::evalCallBuiltin(
                                     AverStr::from("Option.withDefault"),
                                     &aver_rt::AverList::from_vec(vec![
-                                        Expr::ExprCallBuiltin(AverStr::from("Vector.set"), vecArgs),
+                                        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                                            AverStr::from("Vector.set"),
+                                            vecArgs,
+                                        ),
                                         defaultExpr,
                                     ]),
                                     &env,
@@ -726,10 +840,13 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             }
                         }
                     } else {
-                        return evalCallBuiltin(
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltin(
                             AverStr::from("Option.withDefault"),
                             &aver_rt::AverList::from_vec(vec![
-                                Expr::ExprCallBuiltin(AverStr::from("Vector.set"), vecArgs),
+                                crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                                    AverStr::from("Vector.set"),
+                                    vecArgs,
+                                ),
                                 defaultExpr,
                             ]),
                             &env,
@@ -747,9 +864,12 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let vecV = evalExpr(&vecExpr, &env, &fns)?;
-                let idxV = evalExpr(&idxExpr, &env, &fns)?;
-                let valueV = evalExpr(&valueExpr, &env, &fns)?;
+                let vecV =
+                    crate::aver_generated::domain::eval::core::evalExpr(&vecExpr, &env, &fns)?;
+                let idxV =
+                    crate::aver_generated::domain::eval::core::evalExpr(&idxExpr, &env, &fns)?;
+                let valueV =
+                    crate::aver_generated::domain::eval::core::evalExpr(&valueExpr, &env, &fns)?;
                 __MutualTco3::EvalVectorSetWithDefaultExprResult(
                     vecV,
                     idxV,
@@ -801,10 +921,13 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                                     fns,
                                 )
                             } else {
-                                return evalCallBuiltin(
+                                return crate::aver_generated::domain::eval::core::evalCallBuiltin(
                                     AverStr::from("Option.withDefault"),
                                     &aver_rt::AverList::from_vec(vec![
-                                        Expr::ExprCallBuiltin(AverStr::from("Vector.get"), vecArgs),
+                                        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                                            AverStr::from("Vector.get"),
+                                            vecArgs,
+                                        ),
                                         defaultExpr,
                                     ]),
                                     &env,
@@ -813,10 +936,13 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             }
                         }
                     } else {
-                        return evalCallBuiltin(
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltin(
                             AverStr::from("Option.withDefault"),
                             &aver_rt::AverList::from_vec(vec![
-                                Expr::ExprCallBuiltin(AverStr::from("Vector.get"), vecArgs),
+                                crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                                    AverStr::from("Vector.get"),
+                                    vecArgs,
+                                ),
                                 defaultExpr,
                             ]),
                             &env,
@@ -833,8 +959,10 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let vecV = evalExpr(&vecExpr, &env, &fns)?;
-                let idxV = evalExpr(&idxExpr, &env, &fns)?;
+                let vecV =
+                    crate::aver_generated::domain::eval::core::evalExpr(&vecExpr, &env, &fns)?;
+                let idxV =
+                    crate::aver_generated::domain::eval::core::evalExpr(&idxExpr, &env, &fns)?;
                 __MutualTco3::EvalVectorGetWithDefaultExprResult(vecV, idxV, defaultExpr, env, fns)
             }
             __MutualTco3::EvalVectorGetWithDefaultExprResult(
@@ -1271,7 +1399,8 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
         __state = match __state {
             __MutualTco4::EvalExprSlot(mut expr, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
-                match evalImmediateSlotExpr(&expr, &env) {
+                match crate::aver_generated::domain::eval::core::evalImmediateSlotExpr(&expr, &env)
+                {
                     Some(result) => return result,
                     None => __MutualTco4::EvalExprSlotBasic(expr, env, slotMap, fns),
                 }
@@ -1279,7 +1408,11 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
             __MutualTco4::EvalExprSlotBasic(mut expr, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
+                    crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
+                        cond,
+                        thenExpr,
+                        elseExpr,
+                    ) => {
                         let cond = (*cond).clone();
                         let thenExpr = (*thenExpr).clone();
                         let elseExpr = (*elseExpr).clone();
@@ -1287,15 +1420,23 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             cond, thenExpr, elseExpr, env, slotMap, fns,
                         )
                     }
-                    Expr::ExprVar(name) => return evalVarSlot(name, &fns),
-                    Expr::ExprBinopSlotInt(op, slot, rhs) => {
-                        return evalBinopSlotInt(&op, slot, rhs, &env);
+                    crate::aver_generated::domain::ast::Expr::ExprVar(name) => {
+                        return crate::aver_generated::domain::eval::core::evalVarSlot(name, &fns);
                     }
-                    Expr::ExprBinopSlots(op, lhs, rhs) => {
-                        return evalBinopSlots(&op, lhs, rhs, &env);
+                    crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(op, slot, rhs) => {
+                        return crate::aver_generated::domain::eval::core::evalBinopSlotInt(
+                            &op, slot, rhs, &env,
+                        );
                     }
-                    Expr::ExprCmpSlotInt(op, slot, rhs) => {
-                        return evalCmpSlotInt(&op, slot, rhs, &env);
+                    crate::aver_generated::domain::ast::Expr::ExprBinopSlots(op, lhs, rhs) => {
+                        return crate::aver_generated::domain::eval::core::evalBinopSlots(
+                            &op, lhs, rhs, &env,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(op, slot, rhs) => {
+                        return crate::aver_generated::domain::eval::core::evalCmpSlotInt(
+                            &op, slot, rhs, &env,
+                        );
                     }
                     _ => __MutualTco4::EvalExprSlotInternal(expr, env, slotMap, fns),
                 }
@@ -1303,57 +1444,113 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
             __MutualTco4::EvalExprSlotInternal(mut expr, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprCmpSlots(op, lhs, rhs) => return evalCmpSlots(&op, lhs, rhs, &env),
-                    Expr::ExprVectorGetOrInt(vecExpr, idxExpr, defaultValue) => {
+                    crate::aver_generated::domain::ast::Expr::ExprCmpSlots(op, lhs, rhs) => {
+                        return crate::aver_generated::domain::eval::core::evalCmpSlots(
+                            &op, lhs, rhs, &env,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+                        vecExpr,
+                        idxExpr,
+                        defaultValue,
+                    ) => {
                         let vecExpr = (*vecExpr).clone();
                         let idxExpr = (*idxExpr).clone();
-                        return evalVectorGetOrIntExprSlot(
-                            &vecExpr,
-                            &idxExpr,
+                        return crate::aver_generated::domain::eval::core::evalVectorGetOrIntExprSlot(&vecExpr, &idxExpr, defaultValue, &env, &slotMap, &fns);
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(
+                        a,
+                        b,
+                        defaultValue,
+                    ) => {
+                        let a = (*a).clone();
+                        let b = (*b).clone();
+                        return crate::aver_generated::domain::eval::core::evalIntModOrIntExprSlot(
+                            &a,
+                            &b,
                             defaultValue,
                             &env,
                             &slotMap,
                             &fns,
                         );
                     }
-                    Expr::ExprIntModOrInt(a, b, defaultValue) => {
+                    crate::aver_generated::domain::ast::Expr::ExprAdd(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalIntModOrIntExprSlot(&a, &b, defaultValue, &env, &slotMap, &fns);
+                        return crate::aver_generated::domain::eval::core::evalBinopSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &BinOp::OpAdd,
+                        );
                     }
-                    Expr::ExprAdd(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalBinopSlot(&a, &b, &env, &slotMap, &fns, &BinOp::OpAdd);
+                        return crate::aver_generated::domain::eval::core::evalBinopSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &BinOp::OpSub,
+                        );
                     }
-                    Expr::ExprSub(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalBinopSlot(&a, &b, &env, &slotMap, &fns, &BinOp::OpSub);
+                        return crate::aver_generated::domain::eval::core::evalBinopSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &BinOp::OpMul,
+                        );
                     }
-                    Expr::ExprMul(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalBinopSlot(&a, &b, &env, &slotMap, &fns, &BinOp::OpMul);
+                        return crate::aver_generated::domain::eval::core::evalBinopSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &BinOp::OpDiv,
+                        );
                     }
-                    Expr::ExprDiv(a, b) => {
-                        let a = (*a).clone();
-                        let b = (*b).clone();
-                        return evalBinopSlot(&a, &b, &env, &slotMap, &fns, &BinOp::OpDiv);
-                    }
-                    Expr::ExprNeg(inner) => {
+                    crate::aver_generated::domain::ast::Expr::ExprNeg(inner) => {
                         let inner = (*inner).clone();
-                        return evalNegSlot(&inner, &env, &slotMap, &fns);
+                        return crate::aver_generated::domain::eval::core::evalNegSlot(
+                            &inner, &env, &slotMap, &fns,
+                        );
                     }
-                    Expr::ExprEq(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprEq(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmpSlot(&a, &b, &env, &slotMap, &fns, &CmpOp::CmpEq);
+                        return crate::aver_generated::domain::eval::core::evalCmpSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &CmpOp::CmpEq,
+                        );
                     }
-                    Expr::ExprNeq(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmpSlot(&a, &b, &env, &slotMap, &fns, &CmpOp::CmpNeq);
+                        return crate::aver_generated::domain::eval::core::evalCmpSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &CmpOp::CmpNeq,
+                        );
                     }
                     _ => __MutualTco4::EvalExprSlotAggregate(expr, env, slotMap, fns),
                 }
@@ -1361,38 +1558,88 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
             __MutualTco4::EvalExprSlotAggregate(mut expr, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprLt(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmpSlot(&a, &b, &env, &slotMap, &fns, &CmpOp::CmpLt);
+                        return crate::aver_generated::domain::eval::core::evalCmpSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &CmpOp::CmpLt,
+                        );
                     }
-                    Expr::ExprGt(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmpSlot(&a, &b, &env, &slotMap, &fns, &CmpOp::CmpGt);
+                        return crate::aver_generated::domain::eval::core::evalCmpSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &CmpOp::CmpGt,
+                        );
                     }
-                    Expr::ExprLte(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmpSlot(&a, &b, &env, &slotMap, &fns, &CmpOp::CmpLte);
+                        return crate::aver_generated::domain::eval::core::evalCmpSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &CmpOp::CmpLte,
+                        );
                     }
-                    Expr::ExprGte(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        return evalCmpSlot(&a, &b, &env, &slotMap, &fns, &CmpOp::CmpGte);
+                        return crate::aver_generated::domain::eval::core::evalCmpSlot(
+                            &a,
+                            &b,
+                            &env,
+                            &slotMap,
+                            &fns,
+                            &CmpOp::CmpGte,
+                        );
                     }
-                    Expr::ExprConcat(parts) => return evalConcatSlot(&parts, &env, &slotMap, &fns),
-                    Expr::ExprTuple(exprs) => return evalTupleSlot(&exprs, &env, &slotMap, &fns),
-                    Expr::ExprList(exprs) => return evalListSlot(&exprs, &env, &slotMap, &fns),
-                    Expr::ExprRecord(name, fieldExprs) => {
-                        return evalRecordSlot(name, &fieldExprs, &env, &slotMap, &fns);
+                    crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
+                        return crate::aver_generated::domain::eval::core::evalConcatSlot(
+                            &parts, &env, &slotMap, &fns,
+                        );
                     }
-                    Expr::ExprFieldAccess(obj, field) => {
+                    crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
+                        return crate::aver_generated::domain::eval::core::evalTupleSlot(
+                            &exprs, &env, &slotMap, &fns,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
+                        return crate::aver_generated::domain::eval::core::evalListSlot(
+                            &exprs, &env, &slotMap, &fns,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprRecord(name, fieldExprs) => {
+                        return crate::aver_generated::domain::eval::core::evalRecordSlot(
+                            name,
+                            &fieldExprs,
+                            &env,
+                            &slotMap,
+                            &fns,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprFieldAccess(obj, field) => {
                         let obj = (*obj).clone();
-                        return evalFieldAccessSlot(&obj, field, &env, &slotMap, &fns);
+                        return crate::aver_generated::domain::eval::core::evalFieldAccessSlot(
+                            &obj, field, &env, &slotMap, &fns,
+                        );
                     }
-                    Expr::ExprCall(name, argExprs) => {
-                        return evalCallSlot(name, &argExprs, &env, &slotMap, &fns);
+                    crate::aver_generated::domain::ast::Expr::ExprCall(name, argExprs) => {
+                        return crate::aver_generated::domain::eval::core::evalCallSlot(
+                            name, &argExprs, &env, &slotMap, &fns,
+                        );
                     }
                     _ => __MutualTco4::EvalExprSlotCalls(expr, env, slotMap, fns),
                 }
@@ -1400,39 +1647,13 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
             __MutualTco4::EvalExprSlotCalls(mut expr, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprCallDirect(fnId, argExprs) => {
-                        return evalCallDirectSlot(fnId, &argExprs, &env, &slotMap, &fns);
-                    }
-                    Expr::ExprCallBuiltin(name, argExprs) => {
-                        __MutualTco4::EvalCallBuiltinSlotMaybeSpecial(
-                            name, argExprs, env, slotMap, fns,
-                        )
-                    }
-                    Expr::ExprCallBuiltinId(id, argExprs) => {
-                        __MutualTco4::EvalCallBuiltinByIdSlot(id, argExprs, env, slotMap, fns)
-                    }
-                    Expr::ExprMatch(scrutinee, arms) => {
-                        let scrutinee = (*scrutinee).clone();
-                        __MutualTco4::EvalMatchExprSlot(scrutinee, arms, env, slotMap, fns)
-                    }
-                    Expr::ExprPropagate(inner) => {
-                        let inner = (*inner).clone();
-                        return evalPropagateSlot(&inner, &env, &slotMap, &fns);
-                    }
-                    Expr::ExprIndependentProduct(exprs, unwrap) => {
-                        return evalIndependentProductSlot(&exprs, unwrap, &env, &slotMap, &fns);
-                    }
-                    _ => {
-                        return Err(aver_rt::AverStr::from({
-                            let mut __b = {
-                                let mut __b = aver_rt::Buffer::with_capacity((45i64) as usize);
-                                __b.push_str(&AverStr::from("unsupported slot expression: "));
-                                __b
-                            };
-                            __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(expr))));
-                            __b
-                        }));
-                    }
+                crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, argExprs) => return crate::aver_generated::domain::eval::core::evalCallDirectSlot(fnId, &argExprs, &env, &slotMap, &fns),
+                crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, argExprs) => __MutualTco4::EvalCallBuiltinSlotMaybeSpecial(name, argExprs, env, slotMap, fns),
+                crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, argExprs) => __MutualTco4::EvalCallBuiltinByIdSlot(id, argExprs, env, slotMap, fns),
+                crate::aver_generated::domain::ast::Expr::ExprMatch(scrutinee, arms) => { let scrutinee = (*scrutinee).clone(); __MutualTco4::EvalMatchExprSlot(scrutinee, arms, env, slotMap, fns) },
+                crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => { let inner = (*inner).clone(); return crate::aver_generated::domain::eval::core::evalPropagateSlot(&inner, &env, &slotMap, &fns) },
+                crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => return crate::aver_generated::domain::eval::core::evalIndependentProductSlot(&exprs, unwrap, &env, &slotMap, &fns),
+                _ => return Err(aver_rt::AverStr::from({ let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((45i64) as usize); __b.push_str(&AverStr::from("unsupported slot expression: ")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(expr)))); __b }))
                 }
             }
             __MutualTco4::EvalBoolBranchSlot(
@@ -1444,9 +1665,11 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let condV = evalExprSlot(&cond, &env, &slotMap, &fns)?;
+                let condV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &cond, &env, &slotMap, &fns,
+                )?;
                 match condV.clone() {
-                    Val::ValBool(flag) => {
+                    crate::aver_generated::domain::value::Val::ValBool(flag) => {
                         if flag {
                             __MutualTco4::EvalExprSlot(thenExpr, env, slotMap, fns)
                         } else {
@@ -1472,7 +1695,9 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                     15i64 => {
                         __MutualTco4::EvalOptionWithDefaultExprSlot(argExprs, env, slotMap, fns)
                     }
-                    _ => match evalArgsSlot(&argExprs, &env, &slotMap, &fns) {
+                    _ => match crate::aver_generated::domain::eval::core::evalArgsSlot(
+                        &argExprs, &env, &slotMap, &fns,
+                    ) {
                         Err(e) => return Err(e),
                         Ok(args) => {
                             return crate::aver_generated::domain::builtins::callBuiltinByIdValues(
@@ -1494,7 +1719,11 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                     "Option.withDefault" => {
                         __MutualTco4::EvalOptionWithDefaultExprSlot(argExprs, env, slotMap, fns)
                     }
-                    _ => return evalCallBuiltinSlot(name, &argExprs, &env, &slotMap, &fns),
+                    _ => {
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(
+                            name, &argExprs, &env, &slotMap, &fns,
+                        );
+                    }
                 }
             }
             __MutualTco4::EvalOptionWithDefaultExprSlot(
@@ -1520,17 +1749,11 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                                     fns,
                                 )
                             } else {
-                                return evalCallBuiltinSlot(
-                                    AverStr::from("Option.withDefault"),
-                                    &argExprs,
-                                    &env,
-                                    &slotMap,
-                                    &fns,
-                                );
+                                return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(AverStr::from("Option.withDefault"), &argExprs, &env, &slotMap, &fns);
                             }
                         }
                     } else {
-                        return evalCallBuiltinSlot(
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(
                             AverStr::from("Option.withDefault"),
                             &argExprs,
                             &env,
@@ -1549,7 +1772,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
             ) => {
                 crate::cancel_checkpoint();
                 match optionExpr.clone() {
-                    Expr::ExprCallBuiltin(name, vecArgs) => {
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, vecArgs) => {
                         let __dispatch_subject = name;
                         if &*__dispatch_subject == "Vector.set" {
                             __MutualTco4::EvalVectorSetWithDefaultExprSlot(
@@ -1569,18 +1792,12 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                                     fns,
                                 )
                             } else {
-                                return evalCallBuiltinSlot(
-                                    AverStr::from("Option.withDefault"),
-                                    &aver_rt::AverList::from_vec(vec![optionExpr, defaultExpr]),
-                                    &env,
-                                    &slotMap,
-                                    &fns,
-                                );
+                                return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(AverStr::from("Option.withDefault"), &aver_rt::AverList::from_vec(vec![optionExpr, defaultExpr]), &env, &slotMap, &fns);
                             }
                         }
                     }
                     _ => {
-                        return evalCallBuiltinSlot(
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(
                             AverStr::from("Option.withDefault"),
                             &aver_rt::AverList::from_vec(vec![optionExpr, defaultExpr]),
                             &env,
@@ -1621,39 +1838,21 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                                             fns,
                                         )
                                     } else {
-                                        return evalCallBuiltinSlot(
-                                            AverStr::from("Option.withDefault"),
-                                            &aver_rt::AverList::from_vec(vec![
-                                                Expr::ExprCallBuiltin(
-                                                    AverStr::from("Vector.set"),
-                                                    vecArgs,
-                                                ),
-                                                defaultExpr,
-                                            ]),
-                                            &env,
-                                            &slotMap,
-                                            &fns,
-                                        );
+                                        return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(AverStr::from("Option.withDefault"), &aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(AverStr::from("Vector.set"), vecArgs), defaultExpr]), &env, &slotMap, &fns);
                                     }
                                 }
                             } else {
-                                return evalCallBuiltinSlot(
-                                    AverStr::from("Option.withDefault"),
-                                    &aver_rt::AverList::from_vec(vec![
-                                        Expr::ExprCallBuiltin(AverStr::from("Vector.set"), vecArgs),
-                                        defaultExpr,
-                                    ]),
-                                    &env,
-                                    &slotMap,
-                                    &fns,
-                                );
+                                return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(AverStr::from("Option.withDefault"), &aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(AverStr::from("Vector.set"), vecArgs), defaultExpr]), &env, &slotMap, &fns);
                             }
                         }
                     } else {
-                        return evalCallBuiltinSlot(
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(
                             AverStr::from("Option.withDefault"),
                             &aver_rt::AverList::from_vec(vec![
-                                Expr::ExprCallBuiltin(AverStr::from("Vector.set"), vecArgs),
+                                crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                                    AverStr::from("Vector.set"),
+                                    vecArgs,
+                                ),
                                 defaultExpr,
                             ]),
                             &env,
@@ -1673,9 +1872,15 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let vecV = evalExprSlot(&vecExpr, &env, &slotMap, &fns)?;
-                let idxV = evalExprSlot(&idxExpr, &env, &slotMap, &fns)?;
-                let valueV = evalExprSlot(&valueExpr, &env, &slotMap, &fns)?;
+                let vecV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &vecExpr, &env, &slotMap, &fns,
+                )?;
+                let idxV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &idxExpr, &env, &slotMap, &fns,
+                )?;
+                let valueV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &valueExpr, &env, &slotMap, &fns,
+                )?;
                 __MutualTco4::EvalVectorSetWithDefaultExprSlotResult(
                     vecV,
                     idxV,
@@ -1731,23 +1936,17 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                                     fns,
                                 )
                             } else {
-                                return evalCallBuiltinSlot(
-                                    AverStr::from("Option.withDefault"),
-                                    &aver_rt::AverList::from_vec(vec![
-                                        Expr::ExprCallBuiltin(AverStr::from("Vector.get"), vecArgs),
-                                        defaultExpr,
-                                    ]),
-                                    &env,
-                                    &slotMap,
-                                    &fns,
-                                );
+                                return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(AverStr::from("Option.withDefault"), &aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(AverStr::from("Vector.get"), vecArgs), defaultExpr]), &env, &slotMap, &fns);
                             }
                         }
                     } else {
-                        return evalCallBuiltinSlot(
+                        return crate::aver_generated::domain::eval::core::evalCallBuiltinSlot(
                             AverStr::from("Option.withDefault"),
                             &aver_rt::AverList::from_vec(vec![
-                                Expr::ExprCallBuiltin(AverStr::from("Vector.get"), vecArgs),
+                                crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                                    AverStr::from("Vector.get"),
+                                    vecArgs,
+                                ),
                                 defaultExpr,
                             ]),
                             &env,
@@ -1766,8 +1965,12 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let vecV = evalExprSlot(&vecExpr, &env, &slotMap, &fns)?;
-                let idxV = evalExprSlot(&idxExpr, &env, &slotMap, &fns)?;
+                let vecV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &vecExpr, &env, &slotMap, &fns,
+                )?;
+                let idxV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &idxExpr, &env, &slotMap, &fns,
+                )?;
                 __MutualTco4::EvalVectorGetWithDefaultExprSlotResult(
                     vecV,
                     idxV,
@@ -1804,12 +2007,14 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let v = evalExprSlot(&scrutinee, &env, &slotMap, &fns)?;
+                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &scrutinee, &env, &slotMap, &fns,
+                )?;
                 __MutualTco4::EvalMatchSlot(v, arms, env, slotMap, fns)
             }
             __MutualTco4::EvalMatchSlot(mut v, mut arms, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
-                aver_list_match!(arms, [] => { return Err(AverStr::from("no matching arm")) }, [arm, rest] => match crate::aver_generated::domain::match_mod::matchPattern(&arm.pattern, &v) { Ok(bindings) => { __MutualTco4::EvalExprSlot(arm.body.clone(), mergeBindingsSlot(&bindings, &arm.bindingSlots, &env), slotMap, fns) }, Err(_) => { __MutualTco4::EvalMatchSlot(v, rest, env, slotMap, fns) } })
+                aver_list_match!(arms, [] => { return Err(AverStr::from("no matching arm")) }, [arm, rest] => match crate::aver_generated::domain::match_mod::matchPattern(&arm.pattern, &v) { Ok(bindings) => { __MutualTco4::EvalExprSlot(arm.body.clone(), crate::aver_generated::domain::eval::core::mergeBindingsSlot(&bindings, &arm.bindingSlots, &env), slotMap, fns) }, Err(_) => { __MutualTco4::EvalMatchSlot(v, rest, env, slotMap, fns) } })
             }
         };
     }
@@ -2168,7 +2373,9 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> Result<Val, AverStr> 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let v = evalExprSlot(&e, &env, &slotMap, &fns)?;
+                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &e, &env, &slotMap, &fns,
+                )?;
                 let nextEnv = crate::aver_generated::domain::eval::slots::setSlot(&env, slot, &v);
                 {
                     let __list_subject = rest.clone();
@@ -2181,7 +2388,9 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> Result<Val, AverStr> 
             }
             __MutualTco5::EvalStmtExprSlotNext(mut e, mut rest, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
-                let v = evalExprSlot(&e, &env, &slotMap, &fns)?;
+                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &e, &env, &slotMap, &fns,
+                )?;
                 {
                     let __list_subject = rest.clone();
                     if __list_subject.is_empty() {
@@ -2200,7 +2409,9 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> Result<Val, AverStr> 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let v = evalExprSlot(&e, &env, &slotMap, &fns)?;
+                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &e, &env, &slotMap, &fns,
+                )?;
                 {
                     let __list_subject = rest.clone();
                     if __list_subject.is_empty() {
@@ -2213,9 +2424,9 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> Result<Val, AverStr> 
             __MutualTco5::EvalStmtsSlot(mut stmts, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(stmts, [] => { return Ok(Val::ValUnit.clone()) }, [stmt, rest] => match stmt {
-                Stmt::StmtBindSlot(slot, e) => __MutualTco5::EvalStmtBindSlotNext(slot, e, rest, env, slotMap, fns),
-                Stmt::StmtExpr(e) => __MutualTco5::EvalStmtExprSlotNext(e, rest, env, slotMap, fns),
-                Stmt::StmtBind(name, e) => __MutualTco5::EvalStmtBindFallbackSlotNext(name, e, rest, env, slotMap, fns)
+                crate::aver_generated::domain::ast::Stmt::StmtBindSlot(slot, e) => __MutualTco5::EvalStmtBindSlotNext(slot, e, rest, env, slotMap, fns),
+                crate::aver_generated::domain::ast::Stmt::StmtExpr(e) => __MutualTco5::EvalStmtExprSlotNext(e, rest, env, slotMap, fns),
+                crate::aver_generated::domain::ast::Stmt::StmtBind(name, e) => __MutualTco5::EvalStmtBindFallbackSlotNext(name, e, rest, env, slotMap, fns)
                 })
             }
         };
@@ -2344,7 +2555,7 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<SlotTailStep, 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                aver_list_match!(stmts, [] => { return Ok(SlotTailStep::SlotTailDone(Val::ValUnit.clone())) }, [stmt, rest] => { { let __list_subject = rest.clone(); if __list_subject.is_empty() { return evalTailStmtSlot(selfId, &stmt, slotCount, &env, &slotMap, &fns) } else { __MutualTco6::EvalStmtsSlotTailNext(selfId, stmt, rest, slotCount, env, slotMap, fns) } } })
+                aver_list_match!(stmts, [] => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(Val::ValUnit.clone())) }, [stmt, rest] => { { let __list_subject = rest.clone(); if __list_subject.is_empty() { return crate::aver_generated::domain::eval::core::evalTailStmtSlot(selfId, &stmt, slotCount, &env, &slotMap, &fns) } else { __MutualTco6::EvalStmtsSlotTailNext(selfId, stmt, rest, slotCount, env, slotMap, fns) } } })
             }
             __MutualTco6::EvalStmtsSlotTailNext(
                 mut selfId,
@@ -2357,15 +2568,21 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<SlotTailStep, 
             ) => {
                 crate::cancel_checkpoint();
                 match stmt {
-                    Stmt::StmtBindSlot(slot, e) => __MutualTco6::EvalStmtsSlotTailBind(
-                        selfId, slot, e, rest, slotCount, env, slotMap, fns,
-                    ),
-                    Stmt::StmtExpr(e) => __MutualTco6::EvalStmtsSlotTailExpr(
-                        selfId, e, rest, slotCount, env, slotMap, fns,
-                    ),
-                    Stmt::StmtBind(_, e) => __MutualTco6::EvalStmtsSlotTailExpr(
-                        selfId, e, rest, slotCount, env, slotMap, fns,
-                    ),
+                    crate::aver_generated::domain::ast::Stmt::StmtBindSlot(slot, e) => {
+                        __MutualTco6::EvalStmtsSlotTailBind(
+                            selfId, slot, e, rest, slotCount, env, slotMap, fns,
+                        )
+                    }
+                    crate::aver_generated::domain::ast::Stmt::StmtExpr(e) => {
+                        __MutualTco6::EvalStmtsSlotTailExpr(
+                            selfId, e, rest, slotCount, env, slotMap, fns,
+                        )
+                    }
+                    crate::aver_generated::domain::ast::Stmt::StmtBind(_, e) => {
+                        __MutualTco6::EvalStmtsSlotTailExpr(
+                            selfId, e, rest, slotCount, env, slotMap, fns,
+                        )
+                    }
                 }
             }
             __MutualTco6::EvalStmtsSlotTailBind(
@@ -2379,7 +2596,9 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<SlotTailStep, 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let v = evalExprSlot(&e, &env, &slotMap, &fns)?;
+                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &e, &env, &slotMap, &fns,
+                )?;
                 __MutualTco6::EvalStmtsSlotTail(
                     selfId,
                     rest,
@@ -2399,7 +2618,9 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<SlotTailStep, 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let _ = evalExprSlot(&e, &env, &slotMap, &fns)?;
+                let _ = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &e, &env, &slotMap, &fns,
+                )?;
                 __MutualTco6::EvalStmtsSlotTail(selfId, rest, slotCount, env, slotMap, fns)
             }
         };
@@ -2543,27 +2764,18 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<SlotTailStep, 
             ) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprCallDirect(fnId, argExprs) => {
+                    crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, argExprs) => {
                         if (fnId == selfId) {
-                            match evalArgsSlotToSlotEnv(
-                                argExprs,
-                                env,
-                                slotMap,
-                                fns,
-                                aver_rt::AverVector::new(slotCount as usize, Val::ValUnit.clone()),
-                                0i64,
-                            ) {
-                                Ok(nextEnv) => return Ok(SlotTailStep::SlotTailRecurEnv(nextEnv)),
-                                Err(e) => return Err(e),
-                            }
+                            match crate::aver_generated::domain::eval::core::evalArgsSlotToSlotEnv(argExprs, env, slotMap, fns, aver_rt::AverVector::new(slotCount as usize, Val::ValUnit.clone()), 0i64) { Ok(nextEnv) => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailRecurEnv(nextEnv)) }, Err(e) => { return Err(e) } }
                         } else {
-                            match evalCallDirectSlot(fnId, &argExprs, &env, &slotMap, &fns) {
-                                Ok(v) => return Ok(SlotTailStep::SlotTailDone(v)),
-                                Err(e) => return Err(e),
-                            }
+                            match crate::aver_generated::domain::eval::core::evalCallDirectSlot(fnId, &argExprs, &env, &slotMap, &fns) { Ok(v) => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v)) }, Err(e) => { return Err(e) } }
                         }
                     }
-                    Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
+                    crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
+                        cond,
+                        thenExpr,
+                        elseExpr,
+                    ) => {
                         let cond = (*cond).clone();
                         let thenExpr = (*thenExpr).clone();
                         let elseExpr = (*elseExpr).clone();
@@ -2571,14 +2783,20 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<SlotTailStep, 
                             selfId, cond, thenExpr, elseExpr, slotCount, env, slotMap, fns,
                         )
                     }
-                    Expr::ExprMatch(scrutinee, arms) => {
+                    crate::aver_generated::domain::ast::Expr::ExprMatch(scrutinee, arms) => {
                         let scrutinee = (*scrutinee).clone();
                         __MutualTco7::EvalTailMatchExprSlot(
                             selfId, scrutinee, arms, slotCount, env, slotMap, fns,
                         )
                     }
-                    _ => match evalExprSlot(&expr, &env, &slotMap, &fns) {
-                        Ok(v) => return Ok(SlotTailStep::SlotTailDone(v)),
+                    _ => match crate::aver_generated::domain::eval::core::evalExprSlot(
+                        &expr, &env, &slotMap, &fns,
+                    ) {
+                        Ok(v) => return Ok(
+                            crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(
+                                v,
+                            ),
+                        ),
                         Err(e) => return Err(e),
                     },
                 }
@@ -2594,9 +2812,11 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<SlotTailStep, 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let condV = evalExprSlot(&cond, &env, &slotMap, &fns)?;
+                let condV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &cond, &env, &slotMap, &fns,
+                )?;
                 match condV.clone() {
-                    Val::ValBool(flag) => {
+                    crate::aver_generated::domain::value::Val::ValBool(flag) => {
                         if flag {
                             __MutualTco7::EvalTailExprSlot(
                                 selfId, thenExpr, slotCount, env, slotMap, fns,
@@ -2624,7 +2844,9 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<SlotTailStep, 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let v = evalExprSlot(&scrutinee, &env, &slotMap, &fns)?;
+                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                    &scrutinee, &env, &slotMap, &fns,
+                )?;
                 __MutualTco7::EvalTailMatchSlot(selfId, v, arms, slotCount, env, slotMap, fns)
             }
             __MutualTco7::EvalTailMatchSlot(
@@ -2637,7 +2859,7 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<SlotTailStep, 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                aver_list_match!(arms, [] => { return Err(AverStr::from("no matching arm")) }, [arm, rest] => match crate::aver_generated::domain::match_mod::matchPattern(&arm.pattern, &v) { Ok(bindings) => { __MutualTco7::EvalTailExprSlot(selfId, arm.body.clone(), slotCount, mergeBindingsSlot(&bindings, &arm.bindingSlots, &env), slotMap, fns) }, Err(_) => { __MutualTco7::EvalTailMatchSlot(selfId, v, rest, slotCount, env, slotMap, fns) } })
+                aver_list_match!(arms, [] => { return Err(AverStr::from("no matching arm")) }, [arm, rest] => match crate::aver_generated::domain::match_mod::matchPattern(&arm.pattern, &v) { Ok(bindings) => { __MutualTco7::EvalTailExprSlot(selfId, arm.body.clone(), slotCount, crate::aver_generated::domain::eval::core::mergeBindingsSlot(&bindings, &arm.bindingSlots, &env), slotMap, fns) }, Err(_) => { __MutualTco7::EvalTailMatchSlot(selfId, v, rest, slotCount, env, slotMap, fns) } })
             }
         };
     }
@@ -2807,10 +3029,18 @@ pub fn mergeOneBindingSlot(
 pub fn evalImmediateNamedExpr(expr: &Expr) -> Option<Val> {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprInt(n) => Some(Val::ValInt(n)),
-        Expr::ExprFloat(f) => Some(Val::ValFloat(f)),
-        Expr::ExprStr(s) => Some(Val::ValStr(s)),
-        Expr::ExprBool(b) => Some(Val::ValBool(b)),
+        crate::aver_generated::domain::ast::Expr::ExprInt(n) => {
+            Some(crate::aver_generated::domain::value::Val::ValInt(n))
+        }
+        crate::aver_generated::domain::ast::Expr::ExprFloat(f) => {
+            Some(crate::aver_generated::domain::value::Val::ValFloat(f))
+        }
+        crate::aver_generated::domain::ast::Expr::ExprStr(s) => {
+            Some(crate::aver_generated::domain::value::Val::ValStr(s))
+        }
+        crate::aver_generated::domain::ast::Expr::ExprBool(b) => {
+            Some(crate::aver_generated::domain::value::Val::ValBool(b))
+        }
         _ => None,
     }
 }
@@ -2851,8 +3081,8 @@ pub fn evalVectorGetOrIntExpr(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let vecV = evalExpr(vecExpr, env, fns)?;
-    let idxV = evalExpr(idxExpr, env, fns)?;
+    let vecV = crate::aver_generated::domain::eval::core::evalExpr(vecExpr, env, fns)?;
+    let idxV = crate::aver_generated::domain::eval::core::evalExpr(idxExpr, env, fns)?;
     crate::aver_generated::domain::eval::ops::evalVectorGetOrIntVals(&vecV, &idxV, defaultValue)
 }
 
@@ -2865,8 +3095,8 @@ pub fn evalIntModOrIntExpr(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let aV = evalExpr(a, env, fns)?;
-    let bV = evalExpr(b, env, fns)?;
+    let aV = crate::aver_generated::domain::eval::core::evalExpr(a, env, fns)?;
+    let bV = crate::aver_generated::domain::eval::core::evalExpr(b, env, fns)?;
     crate::aver_generated::domain::eval::ops::evalIntModOrIntVals(&aV, &bV, defaultValue)
 }
 
@@ -2877,16 +3107,16 @@ pub fn evalPropagate(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = evalExpr(inner, env, fns)?;
+    let v = crate::aver_generated::domain::eval::core::evalExpr(inner, env, fns)?;
     match v {
-        Val::ValOk(x) => {
+        crate::aver_generated::domain::value::Val::ValOk(x) => {
             let x = (*x).clone();
             Ok(x)
         }
-        Val::ValErr(e) => {
+        crate::aver_generated::domain::value::Val::ValErr(e) => {
             let e = (*e).clone();
             match e {
-                Val::ValStr(msg) => {
+                crate::aver_generated::domain::value::Val::ValStr(msg) => {
                     Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(msg))
                 }
                 _ => Err(
@@ -2908,11 +3138,14 @@ pub fn evalIndependentProduct(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = evalIndependentItems(exprs, env, fns)?;
+    let items = crate::aver_generated::domain::eval::core::evalIndependentItems(exprs, env, fns)?;
     if unwrap {
-        unwrapProductResults(items, aver_rt::AverList::empty())
+        crate::aver_generated::domain::eval::core::unwrapProductResults(
+            items,
+            aver_rt::AverList::empty(),
+        )
     } else {
-        Ok(Val::ValTuple(items))
+        Ok(crate::aver_generated::domain::value::Val::ValTuple(items))
     }
 }
 
@@ -2923,7 +3156,7 @@ pub fn evalIndependentItems(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
-    aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [a, rest] => { aver_list_match!(rest, [] => match evalExpr(&a, env, fns) { Ok(va) => { Ok(aver_rt::AverList::from_vec(vec![va])) }, Err(e) => { Err(e) } }, [b, rest2] => { { let __list_subject = rest2; if __list_subject.is_empty() { { let (va, vb) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = evalExpr(&a, env, fns); crate::aver_replay::set_effect_branch(1); let _r1 = evalExpr(&b, env, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = evalExpr(&a, env, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = evalExpr(&b, env, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(aver_rt::AverList::from_vec(vec![va, vb])) } } else { { let (leftExprs, rightExprs) = splitIndependentExprs(exprs.clone(), aver_rt::AverList::empty(), aver_rt::AverList::empty(), true); { let (leftVals, rightVals) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = evalIndependentItems(&leftExprs, env, fns); crate::aver_replay::set_effect_branch(1); let _r1 = evalIndependentItems(&rightExprs, env, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = evalIndependentItems(&leftExprs, env, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = evalIndependentItems(&rightExprs, env, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(interleaveIndependentVals(leftVals, rightVals, true, aver_rt::AverList::empty())) } } } } }) })
+    aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [a, rest] => { aver_list_match!(rest, [] => match crate::aver_generated::domain::eval::core::evalExpr(&a, env, fns) { Ok(va) => { Ok(aver_rt::AverList::from_vec(vec![va])) }, Err(e) => { Err(e) } }, [b, rest2] => { { let __list_subject = rest2; if __list_subject.is_empty() { { let (va, vb) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalExpr(&a, env, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalExpr(&b, env, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExpr(&a, env, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExpr(&b, env, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(aver_rt::AverList::from_vec(vec![va, vb])) } } else { { let (leftExprs, rightExprs) = crate::aver_generated::domain::eval::core::splitIndependentExprs(exprs.clone(), aver_rt::AverList::empty(), aver_rt::AverList::empty(), true); { let (leftVals, rightVals) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalIndependentItems(&leftExprs, env, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalIndependentItems(&rightExprs, env, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItems(&leftExprs, env, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItems(&rightExprs, env, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(crate::aver_generated::domain::eval::core::interleaveIndependentVals(leftVals, rightVals, true, aver_rt::AverList::empty())) } } } } }) })
 }
 
 /// Split a product into alternating branches so recursive ?! can cover all items.
@@ -2963,7 +3196,7 @@ pub fn interleaveIndependentVals(
     loop {
         crate::cancel_checkpoint();
         return if takeLeft {
-            aver_list_match!(left, [] => finishIndependentVals(right, acc), [v, rest] => { {
+            aver_list_match!(left, [] => crate::aver_generated::domain::eval::core::finishIndependentVals(right, acc), [v, rest] => { {
             let __tmp3 = aver_rt::AverList::prepend(v, &acc);
             left = rest;
             takeLeft = false;
@@ -2971,7 +3204,7 @@ pub fn interleaveIndependentVals(
             continue;
         } })
         } else {
-            aver_list_match!(right, [] => finishIndependentVals(left, acc), [v, rest] => { {
+            aver_list_match!(right, [] => crate::aver_generated::domain::eval::core::finishIndependentVals(left, acc), [v, rest] => { {
             let __tmp3 = aver_rt::AverList::prepend(v, &acc);
             right = rest;
             takeLeft = true;
@@ -3007,15 +3240,15 @@ pub fn unwrapProductResults(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(items, [] => Ok(Val::ValTuple(acc.reverse())), [v, rest] => { match v {
-            Val::ValOk(x) => { let x = (*x).clone(); {
+        return aver_list_match!(items, [] => Ok(crate::aver_generated::domain::value::Val::ValTuple(acc.reverse())), [v, rest] => { match v {
+            crate::aver_generated::domain::value::Val::ValOk(x) => { let x = (*x).clone(); {
             let __tmp1 = aver_rt::AverList::prepend(x, &acc);
             items = rest;
             acc = __tmp1;
             continue;
         } },
-            Val::ValErr(e) => { let e = (*e).clone(); match e {
-            Val::ValStr(msg) => Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(msg)),
+            crate::aver_generated::domain::value::Val::ValErr(e) => { let e = (*e).clone(); match e {
+            crate::aver_generated::domain::value::Val::ValStr(msg) => Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(msg)),
             _ => Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(AverStr::from("propagated error")))
         } },
             _ => Err(AverStr::from("?! operator requires all elements to be Result values"))
@@ -3032,7 +3265,7 @@ pub fn evalBinopRight(
     op: &BinOp,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match evalExpr(b, env, fns) {
+    match crate::aver_generated::domain::eval::core::evalExpr(b, env, fns) {
         Err(e) => Err(e),
         Ok(vb) => crate::aver_generated::domain::eval::ops::evalBinopVals(va, &vb, op),
     }
@@ -3047,9 +3280,9 @@ pub fn evalBinop(
     op: &BinOp,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match evalExpr(a, env, fns) {
+    match crate::aver_generated::domain::eval::core::evalExpr(a, env, fns) {
         Err(e) => Err(e),
-        Ok(va) => evalBinopRight(&va, b, env, fns, op),
+        Ok(va) => crate::aver_generated::domain::eval::core::evalBinopRight(&va, b, env, fns, op),
     }
 }
 
@@ -3060,7 +3293,7 @@ pub fn evalNeg(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match evalExpr(inner, env, fns) {
+    match crate::aver_generated::domain::eval::core::evalExpr(inner, env, fns) {
         Err(e) => Err(e),
         Ok(v) => crate::aver_generated::domain::eval::ops::evalNegVals(&v),
     }
@@ -3075,7 +3308,7 @@ pub fn evalCmpRight(
     op: &CmpOp,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match evalExpr(b, env, fns) {
+    match crate::aver_generated::domain::eval::core::evalExpr(b, env, fns) {
         Err(e) => Err(e),
         Ok(vb) => crate::aver_generated::domain::eval::ops::evalCmpVals(va, &vb, op),
     }
@@ -3090,9 +3323,9 @@ pub fn evalCmp(
     op: &CmpOp,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match evalExpr(a, env, fns) {
+    match crate::aver_generated::domain::eval::core::evalExpr(a, env, fns) {
         Err(e) => Err(e),
-        Ok(va) => evalCmpRight(&va, b, env, fns, op),
+        Ok(va) => crate::aver_generated::domain::eval::core::evalCmpRight(&va, b, env, fns, op),
     }
 }
 
@@ -3103,7 +3336,12 @@ pub fn evalConcatExpr(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    evalConcatParts(parts.clone(), env.clone(), fns.clone(), AverStr::from(""))
+    crate::aver_generated::domain::eval::core::evalConcatParts(
+        parts.clone(),
+        env.clone(),
+        fns.clone(),
+        AverStr::from(""),
+    )
 }
 
 /// Concatenate interpolation parts. Self-recursive for codegen TCO.
@@ -3115,7 +3353,7 @@ pub fn evalConcatParts(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(parts, [] => Ok(Val::ValStr(acc)), [p, rest] => { match evalExpr(&p, &env, &fns) { Err(e) => { Err(e) }, Ok(v) => { {
+        return aver_list_match!(parts, [] => Ok(crate::aver_generated::domain::value::Val::ValStr(acc)), [p, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&p, &env, &fns) { Err(e) => { Err(e) }, Ok(v) => { {
             let __tmp3 = (acc + &crate::aver_generated::domain::value::valRepr(&v));
             parts = rest;
             acc = __tmp3;
@@ -3131,8 +3369,8 @@ pub fn evalTupleExpr(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = evalListItems(exprs, env, fns)?;
-    Ok(Val::ValTuple(items))
+    let items = crate::aver_generated::domain::eval::core::evalListItems(exprs, env, fns)?;
+    Ok(crate::aver_generated::domain::value::Val::ValTuple(items))
 }
 
 /// Evaluate record constructor.
@@ -3143,8 +3381,10 @@ pub fn evalRecordExpr(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let fields = evalRecordFields(fieldExprs, env, fns)?;
-    Ok(Val::ValRecord(name, fields))
+    let fields = crate::aver_generated::domain::eval::core::evalRecordFields(fieldExprs, env, fns)?;
+    Ok(crate::aver_generated::domain::value::Val::ValRecord(
+        name, fields,
+    ))
 }
 
 /// Evaluate record field expressions.
@@ -3154,7 +3394,7 @@ pub fn evalRecordFields(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
-    aver_list_match!(fieldExprs.clone(), [] => Ok(aver_rt::AverList::empty()), [pair, rest] => { { let (fname, expr) = pair; evalRecordFieldOne(fname, &expr, &rest, env, fns) } })
+    aver_list_match!(fieldExprs.clone(), [] => Ok(aver_rt::AverList::empty()), [pair, rest] => { { let (fname, expr) = pair; crate::aver_generated::domain::eval::core::evalRecordFieldOne(fname, &expr, &rest, env, fns) } })
 }
 
 /// Evaluate one record field and continue.
@@ -3166,8 +3406,8 @@ pub fn evalRecordFieldOne(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
-    let v = evalExpr(expr, env, fns)?;
-    let restFields = evalRecordFields(rest, env, fns)?;
+    let v = crate::aver_generated::domain::eval::core::evalExpr(expr, env, fns)?;
+    let restFields = crate::aver_generated::domain::eval::core::evalRecordFields(rest, env, fns)?;
     Ok(aver_rt::AverList::prepend((fname, v), &restFields))
 }
 
@@ -3179,9 +3419,9 @@ pub fn evalFieldAccess(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = evalExpr(obj, env, fns)?;
+    let v = crate::aver_generated::domain::eval::core::evalExpr(obj, env, fns)?;
     match v {
-        Val::ValRecord(_, fields) => {
+        crate::aver_generated::domain::value::Val::ValRecord(_, fields) => {
             crate::aver_generated::domain::eval::common::lookupField(fields, field)
         }
         _ => Err(AverStr::from("field access on non-record")),
@@ -3195,8 +3435,8 @@ pub fn evalListExpr(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match evalListItems(exprs, env, fns) {
-        Ok(items) => Ok(Val::ValList(items)),
+    match crate::aver_generated::domain::eval::core::evalListItems(exprs, env, fns) {
+        Ok(items) => Ok(crate::aver_generated::domain::value::Val::ValList(items)),
         Err(e) => Err(e),
     }
 }
@@ -3208,7 +3448,7 @@ pub fn evalListItems(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
-    evalListItemsRev(
+    crate::aver_generated::domain::eval::core::evalListItemsRev(
         exprs.clone(),
         env.clone(),
         fns.clone(),
@@ -3225,7 +3465,7 @@ pub fn evalListItemsRev(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match evalExpr(&e, &env, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
+        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
             let __tmp3 = aver_rt::AverList::prepend(v, &acc);
             exprs = rest;
             acc = __tmp3;
@@ -3241,7 +3481,7 @@ pub fn evalArgs(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
-    evalArgsRev(
+    crate::aver_generated::domain::eval::core::evalArgsRev(
         exprs.clone(),
         env.clone(),
         fns.clone(),
@@ -3258,7 +3498,7 @@ pub fn evalArgsRev(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match evalExpr(&e, &env, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
+        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
             let __tmp3 = aver_rt::AverList::prepend(v, &acc);
             exprs = rest;
             acc = __tmp3;
@@ -3277,7 +3517,7 @@ pub fn callWithArgs(
     if crate::aver_generated::domain::eval::records::isRecordUpdate(name.clone(), args) {
         crate::aver_generated::domain::eval::records::doRecordUpdate(args)
     } else {
-        callWithArgsNormal(args, name, fns)
+        crate::aver_generated::domain::eval::core::callWithArgsNormal(args, name, fns)
     }
 }
 
@@ -3289,7 +3529,7 @@ pub fn callWithArgsNormal(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::store::lookupFnOption(fns, name.clone()) {
-        Some(fd) => callResolved(&fd, args, fns),
+        Some(fd) => crate::aver_generated::domain::eval::core::callResolved(&fd, args, fns),
         None => crate::aver_generated::domain::builtins::callBuiltin(name, args),
     }
 }
@@ -3302,7 +3542,7 @@ pub fn callResolved(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let fnId = crate::aver_generated::domain::eval::store::lookupFnId(fns, fd.name.clone())?;
-    callResolvedById(fnId, fd, args, fns)
+    crate::aver_generated::domain::eval::core::callResolvedById(fnId, fd, args, fns)
 }
 
 /// Call a function with a known store id: slot-based if resolved, map-based otherwise.
@@ -3314,14 +3554,14 @@ pub fn callResolvedById(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     if (fd.slotCount > 0i64) {
-        evalResolvedSlotFn(
+        crate::aver_generated::domain::eval::core::evalResolvedSlotFn(
             fnId,
             fd,
             &crate::aver_generated::domain::eval::slots::buildSlotEnv(args, fd.slotCount),
             fns,
         )
     } else {
-        evalResolvedNamedFn(
+        crate::aver_generated::domain::eval::core::evalResolvedNamedFn(
             fd,
             &crate::aver_generated::domain::eval::store::zipArgs(
                 fd.params.clone(),
@@ -3342,9 +3582,14 @@ pub fn evalResolvedSlotFn(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     if fd.tailLoop {
-        evalResolvedSlotLoop(fnId, fd.clone(), calleeEnv.clone(), fns.clone())
+        crate::aver_generated::domain::eval::core::evalResolvedSlotLoop(
+            fnId,
+            fd.clone(),
+            calleeEnv.clone(),
+            fns.clone(),
+        )
     } else {
-        evalResolvedSlotDirect(fd, calleeEnv, fns)
+        crate::aver_generated::domain::eval::core::evalResolvedSlotDirect(fd, calleeEnv, fns)
     }
 }
 
@@ -3357,12 +3602,14 @@ pub fn evalResolvedSlotLoop(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        let step = evalResolvedSlotStep(fnId, &fd, &calleeEnv, &fns)?;
+        let step = crate::aver_generated::domain::eval::core::evalResolvedSlotStep(
+            fnId, &fd, &calleeEnv, &fns,
+        )?;
         return match step {
-            SlotTailStep::SlotTailDone(v) => {
+            crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v) => {
                 crate::aver_generated::domain::eval::common::normalizeFnReturn(&Ok(v))
             }
-            SlotTailStep::SlotTailRecurEnv(nextEnv) => {
+            crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailRecurEnv(nextEnv) => {
                 calleeEnv = nextEnv;
                 continue;
             }
@@ -3378,41 +3625,70 @@ pub fn evalResolvedSlotDirect(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let result = match fd.fastPath.clone() {
-        FnFastPath::FastLeaf(leaf) => {
+        crate::aver_generated::domain::ast::FnFastPath::FastLeaf(leaf) => {
             crate::aver_generated::domain::eval::fast::runFastLeafSlot(&leaf, calleeEnv)
         }
-        FnFastPath::FastForwardCall(targetId, slotArgs) => {
-            fastForwardCall(calleeEnv, targetId, &slotArgs, fns)
-        }
-        FnFastPath::FastBoolSlotBranch(slot, thenLeaf, elseLeaf) => {
-            crate::aver_generated::domain::eval::fast::fastBoolSlotBranch(
-                calleeEnv, slot, &thenLeaf, &elseLeaf,
+        crate::aver_generated::domain::ast::FnFastPath::FastForwardCall(targetId, slotArgs) => {
+            crate::aver_generated::domain::eval::core::fastForwardCall(
+                calleeEnv, targetId, &slotArgs, fns,
             )
         }
-        FnFastPath::FastEqIntBranch(slot, expected, thenLeaf, elseLeaf) => {
-            crate::aver_generated::domain::eval::fast::fastEqIntBranch(
-                calleeEnv, slot, expected, &thenLeaf, &elseLeaf,
+        crate::aver_generated::domain::ast::FnFastPath::FastBoolSlotBranch(
+            slot,
+            thenLeaf,
+            elseLeaf,
+        ) => crate::aver_generated::domain::eval::fast::fastBoolSlotBranch(
+            calleeEnv, slot, &thenLeaf, &elseLeaf,
+        ),
+        crate::aver_generated::domain::ast::FnFastPath::FastEqIntBranch(
+            slot,
+            expected,
+            thenLeaf,
+            elseLeaf,
+        ) => crate::aver_generated::domain::eval::fast::fastEqIntBranch(
+            calleeEnv, slot, expected, &thenLeaf, &elseLeaf,
+        ),
+        crate::aver_generated::domain::ast::FnFastPath::FastEqStringBranch(
+            slot,
+            expected,
+            thenLeaf,
+            elseLeaf,
+        ) => crate::aver_generated::domain::eval::fast::fastEqStringBranch(
+            calleeEnv, slot, expected, &thenLeaf, &elseLeaf,
+        ),
+        crate::aver_generated::domain::ast::FnFastPath::FastLtIntSlotsBranch(
+            lhsSlot,
+            rhsSlot,
+            thenLeaf,
+            elseLeaf,
+        ) => crate::aver_generated::domain::eval::fast::fastLtIntSlotsBranch(
+            calleeEnv, lhsSlot, rhsSlot, &thenLeaf, &elseLeaf,
+        ),
+        crate::aver_generated::domain::ast::FnFastPath::FastListSlotBranch(
+            slot,
+            emptyLeaf,
+            headSlot,
+            tailSlot,
+            consLeaf,
+        ) => crate::aver_generated::domain::eval::fast::fastListSlotBranch(
+            calleeEnv, slot, &emptyLeaf, headSlot, tailSlot, &consLeaf,
+        ),
+        crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr => {
+            crate::aver_generated::domain::eval::core::evalResolvedSingleExprSlot(
+                &fd.body,
+                calleeEnv,
+                &fd.slotMap,
+                fns,
             )
         }
-        FnFastPath::FastEqStringBranch(slot, expected, thenLeaf, elseLeaf) => {
-            crate::aver_generated::domain::eval::fast::fastEqStringBranch(
-                calleeEnv, slot, expected, &thenLeaf, &elseLeaf,
+        crate::aver_generated::domain::ast::FnFastPath::FastNone => {
+            crate::aver_generated::domain::eval::core::evalStmtsSlot(
+                &fd.body,
+                calleeEnv,
+                &fd.slotMap,
+                fns,
             )
         }
-        FnFastPath::FastLtIntSlotsBranch(lhsSlot, rhsSlot, thenLeaf, elseLeaf) => {
-            crate::aver_generated::domain::eval::fast::fastLtIntSlotsBranch(
-                calleeEnv, lhsSlot, rhsSlot, &thenLeaf, &elseLeaf,
-            )
-        }
-        FnFastPath::FastListSlotBranch(slot, emptyLeaf, headSlot, tailSlot, consLeaf) => {
-            crate::aver_generated::domain::eval::fast::fastListSlotBranch(
-                calleeEnv, slot, &emptyLeaf, headSlot, tailSlot, &consLeaf,
-            )
-        }
-        FnFastPath::FastSingleExpr => {
-            evalResolvedSingleExprSlot(&fd.body, calleeEnv, &fd.slotMap, fns)
-        }
-        FnFastPath::FastNone => evalStmtsSlot(&fd.body, calleeEnv, &fd.slotMap, fns),
     };
     crate::aver_generated::domain::eval::common::normalizeFnReturn(&result)
 }
@@ -3426,68 +3702,118 @@ pub fn evalResolvedSlotStep(
 ) -> Result<SlotTailStep, AverStr> {
     crate::cancel_checkpoint();
     match fd.fastPath.clone() {
-        FnFastPath::FastLeaf(leaf) => {
+        crate::aver_generated::domain::ast::FnFastPath::FastLeaf(leaf) => {
             match crate::aver_generated::domain::eval::fast::runFastLeafSlot(&leaf, calleeEnv) {
-                Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+                Ok(v) => {
+                    Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v))
+                }
                 Err(e) => Err(e),
             }
         }
-        FnFastPath::FastForwardCall(targetId, slotArgs) => {
-            match fastForwardCall(calleeEnv, targetId, &slotArgs, fns) {
-                Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+        crate::aver_generated::domain::ast::FnFastPath::FastForwardCall(targetId, slotArgs) => {
+            match crate::aver_generated::domain::eval::core::fastForwardCall(
+                calleeEnv, targetId, &slotArgs, fns,
+            ) {
+                Ok(v) => {
+                    Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v))
+                }
                 Err(e) => Err(e),
             }
         }
-        FnFastPath::FastBoolSlotBranch(slot, thenLeaf, elseLeaf) => {
+        crate::aver_generated::domain::ast::FnFastPath::FastBoolSlotBranch(
+            slot,
+            thenLeaf,
+            elseLeaf,
+        ) => {
             match crate::aver_generated::domain::eval::fast::fastBoolSlotBranch(
                 calleeEnv, slot, &thenLeaf, &elseLeaf,
             ) {
-                Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+                Ok(v) => {
+                    Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v))
+                }
                 Err(e) => Err(e),
             }
         }
-        FnFastPath::FastEqIntBranch(slot, expected, thenLeaf, elseLeaf) => {
+        crate::aver_generated::domain::ast::FnFastPath::FastEqIntBranch(
+            slot,
+            expected,
+            thenLeaf,
+            elseLeaf,
+        ) => {
             match crate::aver_generated::domain::eval::fast::fastEqIntBranch(
                 calleeEnv, slot, expected, &thenLeaf, &elseLeaf,
             ) {
-                Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+                Ok(v) => {
+                    Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v))
+                }
                 Err(e) => Err(e),
             }
         }
-        FnFastPath::FastEqStringBranch(slot, expected, thenLeaf, elseLeaf) => {
+        crate::aver_generated::domain::ast::FnFastPath::FastEqStringBranch(
+            slot,
+            expected,
+            thenLeaf,
+            elseLeaf,
+        ) => {
             match crate::aver_generated::domain::eval::fast::fastEqStringBranch(
                 calleeEnv, slot, expected, &thenLeaf, &elseLeaf,
             ) {
-                Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+                Ok(v) => {
+                    Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v))
+                }
                 Err(e) => Err(e),
             }
         }
-        FnFastPath::FastLtIntSlotsBranch(lhsSlot, rhsSlot, thenLeaf, elseLeaf) => {
+        crate::aver_generated::domain::ast::FnFastPath::FastLtIntSlotsBranch(
+            lhsSlot,
+            rhsSlot,
+            thenLeaf,
+            elseLeaf,
+        ) => {
             match crate::aver_generated::domain::eval::fast::fastLtIntSlotsBranch(
                 calleeEnv, lhsSlot, rhsSlot, &thenLeaf, &elseLeaf,
             ) {
-                Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+                Ok(v) => {
+                    Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v))
+                }
                 Err(e) => Err(e),
             }
         }
-        FnFastPath::FastListSlotBranch(slot, emptyLeaf, headSlot, tailSlot, consLeaf) => {
+        crate::aver_generated::domain::ast::FnFastPath::FastListSlotBranch(
+            slot,
+            emptyLeaf,
+            headSlot,
+            tailSlot,
+            consLeaf,
+        ) => {
             match crate::aver_generated::domain::eval::fast::fastListSlotBranch(
                 calleeEnv, slot, &emptyLeaf, headSlot, tailSlot, &consLeaf,
             ) {
-                Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+                Ok(v) => {
+                    Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v))
+                }
                 Err(e) => Err(e),
             }
         }
-        FnFastPath::FastSingleExpr => evalResolvedSingleExprSlotTail(
-            fnId,
-            &fd.body,
-            fd.slotCount,
-            &fd.slotMap,
-            calleeEnv,
-            fns,
-        ),
-        FnFastPath::FastNone => {
-            evalStmtsSlotTail(fnId, &fd.body, fd.slotCount, calleeEnv, &fd.slotMap, fns)
+        crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr => {
+            crate::aver_generated::domain::eval::core::evalResolvedSingleExprSlotTail(
+                fnId,
+                &fd.body,
+                fd.slotCount,
+                &fd.slotMap,
+                calleeEnv,
+                fns,
+            )
+        }
+        crate::aver_generated::domain::ast::FnFastPath::FastNone => {
+            crate::aver_generated::domain::eval::core::evalStmtsSlotTail(
+                fnId,
+                &fd.body,
+                fd.slotCount,
+                calleeEnv,
+                &fd.slotMap,
+                fns,
+            )
         }
     }
 }
@@ -3500,10 +3826,26 @@ pub fn evalResolvedNamedFn(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let result = match fd.fastPath.clone() {
-        FnFastPath::FastLeaf(leaf) => runFastLeafNamed(&leaf, &fd.body, calleeEnv, fns),
-        FnFastPath::FastSingleExpr => evalResolvedSingleExprNamed(&fd.body, calleeEnv, fns),
-        FnFastPath::FastNone => evalStmts(fd.body.clone(), calleeEnv.clone(), fns.clone()),
-        _ => evalResolvedSingleExprNamed(&fd.body, calleeEnv, fns),
+        crate::aver_generated::domain::ast::FnFastPath::FastLeaf(leaf) => {
+            crate::aver_generated::domain::eval::core::runFastLeafNamed(
+                &leaf, &fd.body, calleeEnv, fns,
+            )
+        }
+        crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr => {
+            crate::aver_generated::domain::eval::core::evalResolvedSingleExprNamed(
+                &fd.body, calleeEnv, fns,
+            )
+        }
+        crate::aver_generated::domain::ast::FnFastPath::FastNone => {
+            crate::aver_generated::domain::eval::core::evalStmts(
+                fd.body.clone(),
+                calleeEnv.clone(),
+                fns.clone(),
+            )
+        }
+        _ => crate::aver_generated::domain::eval::core::evalResolvedSingleExprNamed(
+            &fd.body, calleeEnv, fns,
+        ),
     };
     crate::aver_generated::domain::eval::common::normalizeFnReturn(&result)
 }
@@ -3520,12 +3862,16 @@ pub fn evalResolvedSingleExprSlot(
         let __list_subject = body.clone();
         if let Some((stmt, rest)) = aver_rt::list_uncons_cloned(&__list_subject) {
             if (rest == aver_rt::AverList::empty()) {
-                evalResolvedSingleStmtSlot(&stmt, calleeEnv, slotMap, fns)
+                crate::aver_generated::domain::eval::core::evalResolvedSingleStmtSlot(
+                    &stmt, calleeEnv, slotMap, fns,
+                )
             } else {
-                evalStmtsSlot(body, calleeEnv, slotMap, fns)
+                crate::aver_generated::domain::eval::core::evalStmtsSlot(
+                    body, calleeEnv, slotMap, fns,
+                )
             }
         } else {
-            evalStmtsSlot(body, calleeEnv, slotMap, fns)
+            crate::aver_generated::domain::eval::core::evalStmtsSlot(body, calleeEnv, slotMap, fns)
         }
     }
 }
@@ -3544,16 +3890,26 @@ pub fn evalResolvedSingleExprSlotTail(
         let __list_subject = body.clone();
         if let Some((stmt, rest)) = aver_rt::list_uncons_cloned(&__list_subject) {
             if (rest == aver_rt::AverList::empty()) {
-                evalTailStmtSlot(selfId, &stmt, slotCount, calleeEnv, slotMap, fns)
+                crate::aver_generated::domain::eval::core::evalTailStmtSlot(
+                    selfId, &stmt, slotCount, calleeEnv, slotMap, fns,
+                )
             } else {
-                match evalStmtsSlot(body, calleeEnv, slotMap, fns) {
-                    Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+                match crate::aver_generated::domain::eval::core::evalStmtsSlot(
+                    body, calleeEnv, slotMap, fns,
+                ) {
+                    Ok(v) => Ok(
+                        crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v),
+                    ),
                     Err(e) => Err(e),
                 }
             }
         } else {
-            match evalStmtsSlot(body, calleeEnv, slotMap, fns) {
-                Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+            match crate::aver_generated::domain::eval::core::evalStmtsSlot(
+                body, calleeEnv, slotMap, fns,
+            ) {
+                Ok(v) => {
+                    Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v))
+                }
                 Err(e) => Err(e),
             }
         }
@@ -3571,15 +3927,21 @@ pub fn evalTailStmtSlot(
 ) -> Result<SlotTailStep, AverStr> {
     crate::cancel_checkpoint();
     match stmt.clone() {
-        Stmt::StmtExpr(expr) => evalTailExprSlot(selfId, &expr, slotCount, env, slotMap, fns),
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::eval::core::evalTailExprSlot(
+                selfId, &expr, slotCount, env, slotMap, fns,
+            )
+        }
         _ => {
-            match evalStmtsSlot(
+            match crate::aver_generated::domain::eval::core::evalStmtsSlot(
                 &aver_rt::AverList::from_vec(vec![stmt.clone()]),
                 env,
                 slotMap,
                 fns,
             ) {
-                Ok(v) => Ok(SlotTailStep::SlotTailDone(v)),
+                Ok(v) => {
+                    Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v))
+                }
                 Err(e) => Err(e),
             }
         }
@@ -3595,8 +3957,10 @@ pub fn evalResolvedSingleStmtSlot(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match stmt.clone() {
-        Stmt::StmtExpr(expr) => evalExprSlot(&expr, calleeEnv, slotMap, fns),
-        _ => evalStmtsSlot(
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::eval::core::evalExprSlot(&expr, calleeEnv, slotMap, fns)
+        }
+        _ => crate::aver_generated::domain::eval::core::evalStmtsSlot(
             &aver_rt::AverList::from_vec(vec![stmt.clone()]),
             calleeEnv,
             slotMap,
@@ -3616,12 +3980,22 @@ pub fn evalResolvedSingleExprNamed(
         let __list_subject = body.clone();
         if let Some((stmt, rest)) = aver_rt::list_uncons_cloned(&__list_subject) {
             if (rest == aver_rt::AverList::empty()) {
-                evalResolvedSingleStmtNamed(&stmt, calleeEnv, fns)
+                crate::aver_generated::domain::eval::core::evalResolvedSingleStmtNamed(
+                    &stmt, calleeEnv, fns,
+                )
             } else {
-                evalStmts(body.clone(), calleeEnv.clone(), fns.clone())
+                crate::aver_generated::domain::eval::core::evalStmts(
+                    body.clone(),
+                    calleeEnv.clone(),
+                    fns.clone(),
+                )
             }
         } else {
-            evalStmts(body.clone(), calleeEnv.clone(), fns.clone())
+            crate::aver_generated::domain::eval::core::evalStmts(
+                body.clone(),
+                calleeEnv.clone(),
+                fns.clone(),
+            )
         }
     }
 }
@@ -3634,8 +4008,10 @@ pub fn evalResolvedSingleStmtNamed(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match stmt.clone() {
-        Stmt::StmtExpr(expr) => evalExpr(&expr, calleeEnv, fns),
-        _ => evalStmts(
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::eval::core::evalExpr(&expr, calleeEnv, fns)
+        }
+        _ => crate::aver_generated::domain::eval::core::evalStmts(
             aver_rt::AverList::from_vec(vec![stmt.clone()]),
             calleeEnv.clone(),
             fns.clone(),
@@ -3652,11 +4028,21 @@ pub fn runFastLeafNamed(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match leaf.clone() {
-        FastLeaf::LeafConstInt(n) => Ok(Val::ValInt(n)),
-        FastLeaf::LeafConstFloat(f) => Ok(Val::ValFloat(f)),
-        FastLeaf::LeafConstStr(s) => Ok(Val::ValStr(s)),
-        FastLeaf::LeafConstBool(b) => Ok(Val::ValBool(b)),
-        _ => evalResolvedSingleExprNamed(body, calleeEnv, fns),
+        crate::aver_generated::domain::ast::FastLeaf::LeafConstInt(n) => {
+            Ok(crate::aver_generated::domain::value::Val::ValInt(n))
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafConstFloat(f) => {
+            Ok(crate::aver_generated::domain::value::Val::ValFloat(f))
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafConstStr(s) => {
+            Ok(crate::aver_generated::domain::value::Val::ValStr(s))
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafConstBool(b) => {
+            Ok(crate::aver_generated::domain::value::Val::ValBool(b))
+        }
+        _ => crate::aver_generated::domain::eval::core::evalResolvedSingleExprNamed(
+            body, calleeEnv, fns,
+        ),
     }
 }
 
@@ -3668,13 +4054,13 @@ pub fn fastForwardCall(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let args = collectFastForwardArgs(
+    let args = crate::aver_generated::domain::eval::core::collectFastForwardArgs(
         slotArgs.clone(),
         calleeEnv.clone(),
         aver_rt::AverList::empty(),
     )?;
     let fd = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId)?;
-    callResolvedById(fnId, &fd, &args, fns)
+    crate::aver_generated::domain::eval::core::callResolvedById(fnId, &fd, &args, fns)
 }
 
 /// Collect forwarded slot arguments in call order.
@@ -3703,9 +4089,9 @@ pub fn evalCall(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match evalArgs(argExprs, env, fns) {
+    match crate::aver_generated::domain::eval::core::evalArgs(argExprs, env, fns) {
         Err(e) => Err(e),
-        Ok(args) => callWithArgs(&args, name, fns),
+        Ok(args) => crate::aver_generated::domain::eval::core::callWithArgs(&args, name, fns),
     }
 }
 
@@ -3719,9 +4105,11 @@ pub fn evalCallDirect(
     crate::cancel_checkpoint();
     let fd = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId)?;
     if (fd.slotCount > 0i64) {
-        evalCallDirectMapToSlot(fnId, &fd, argExprs, env, fns)
+        crate::aver_generated::domain::eval::core::evalCallDirectMapToSlot(
+            fnId, &fd, argExprs, env, fns,
+        )
     } else {
-        evalCallDirectMapToNamed(&fd, argExprs, env, fns)
+        crate::aver_generated::domain::eval::core::evalCallDirectMapToNamed(&fd, argExprs, env, fns)
     }
 }
 
@@ -3734,14 +4122,14 @@ pub fn evalCallDirectMapToSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let calleeEnv = evalArgsMapToSlotEnv(
+    let calleeEnv = crate::aver_generated::domain::eval::core::evalArgsMapToSlotEnv(
         argExprs.clone(),
         env.clone(),
         fns.clone(),
         aver_rt::AverVector::new(fd.slotCount as usize, Val::ValUnit.clone()),
         0i64,
     )?;
-    evalResolvedSlotFn(fnId, fd, &calleeEnv, fns)
+    crate::aver_generated::domain::eval::core::evalResolvedSlotFn(fnId, fd, &calleeEnv, fns)
 }
 
 /// Call resolved function by evaluating args directly into the callee named env.
@@ -3752,8 +4140,14 @@ pub fn evalCallDirectMapToNamed(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let calleeEnv = evalArgsMapToNamedEnv(argExprs, &fd.params, env, fns, &HashMap::new())?;
-    evalResolvedNamedFn(fd, &calleeEnv, fns)
+    let calleeEnv = crate::aver_generated::domain::eval::core::evalArgsMapToNamedEnv(
+        argExprs,
+        &fd.params,
+        env,
+        fns,
+        &HashMap::new(),
+    )?;
+    crate::aver_generated::domain::eval::core::evalResolvedNamedFn(fd, &calleeEnv, fns)
 }
 
 /// Call a builtin directly, skipping fns lookup.
@@ -3764,7 +4158,7 @@ pub fn evalCallBuiltin(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match evalArgs(argExprs, env, fns) {
+    match crate::aver_generated::domain::eval::core::evalArgs(argExprs, env, fns) {
         Err(e) => Err(e),
         Ok(args) => crate::aver_generated::domain::builtins::callBuiltin(name, &args),
     }
@@ -3777,7 +4171,7 @@ pub fn evalStmtExpr(
     fns: &FnStore,
 ) -> Result<(Val, aver_rt::AverMap<AverStr, Val>), AverStr> {
     crate::cancel_checkpoint();
-    match evalExpr(e, env, fns) {
+    match crate::aver_generated::domain::eval::core::evalExpr(e, env, fns) {
         Ok(v) => Ok((v, env.clone())),
         Err(e) => Err(e.clone()),
     }
@@ -3791,7 +4185,7 @@ pub fn evalStmtBind(
     fns: &FnStore,
 ) -> Result<(Val, aver_rt::AverMap<AverStr, Val>), AverStr> {
     crate::cancel_checkpoint();
-    match evalExpr(e, env, fns) {
+    match crate::aver_generated::domain::eval::core::evalExpr(e, env, fns) {
         Ok(v) => Ok((v.clone(), env.clone().insert_owned(name, v))),
         Err(e) => Err(e.clone()),
     }
@@ -3805,9 +4199,15 @@ pub fn evalStmt(
 ) -> Result<(Val, aver_rt::AverMap<AverStr, Val>), AverStr> {
     crate::cancel_checkpoint();
     match stmt.clone() {
-        Stmt::StmtExpr(e) => evalStmtExpr(&e, env, fns),
-        Stmt::StmtBind(name, e) => evalStmtBind(name, &e, env, fns),
-        Stmt::StmtBindSlot(_, e) => evalStmtExpr(&e, env, fns),
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(e) => {
+            crate::aver_generated::domain::eval::core::evalStmtExpr(&e, env, fns)
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtBind(name, e) => {
+            crate::aver_generated::domain::eval::core::evalStmtBind(name, &e, env, fns)
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(_, e) => {
+            crate::aver_generated::domain::eval::core::evalStmtExpr(&e, env, fns)
+        }
     }
 }
 
@@ -3819,7 +4219,7 @@ pub fn evalStmts(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(stmts, [] => Ok(Val::ValUnit.clone()), [s, rest] => { match evalStmt(&s, &env, &fns) { Err(e) => { Err(e) }, Ok(pair) => { match pair {
+        return aver_list_match!(stmts, [] => Ok(Val::ValUnit.clone()), [s, rest] => { match crate::aver_generated::domain::eval::core::evalStmt(&s, &env, &fns) { Err(e) => { Err(e) }, Ok(pair) => { match pair {
             (v, newEnv) => { let __list_subject = rest.clone(); if __list_subject.is_empty() { Ok(v) } else { {
             stmts = rest;
             env = newEnv;
@@ -3833,8 +4233,12 @@ pub fn evalStmts(
 pub fn evalProgram(prog: &Program) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let fnsStore = crate::aver_generated::domain::eval::store::fnsToStore(&prog.fns);
-    let v = evalStmts(prog.stmts.clone(), HashMap::new(), fnsStore.clone())?;
-    maybeCallMain(&fnsStore, &v)
+    let v = crate::aver_generated::domain::eval::core::evalStmts(
+        prog.stmts.clone(),
+        HashMap::new(),
+        fnsStore.clone(),
+    )?;
+    crate::aver_generated::domain::eval::core::maybeCallMain(&fnsStore, &v)
 }
 
 /// Evaluate a program with additional functions from loaded modules.
@@ -3846,15 +4250,23 @@ pub fn evalProgramWithFns(
     let allFns = crate::aver_generated::domain::eval::store::fnsToStore(
         &aver_rt::AverList::concat(&extraFns.clone(), &prog.fns.clone()),
     );
-    let v = evalStmts(prog.stmts.clone(), HashMap::new(), allFns.clone())?;
-    maybeCallMain(&allFns, &v)
+    let v = crate::aver_generated::domain::eval::core::evalStmts(
+        prog.stmts.clone(),
+        HashMap::new(),
+        allFns.clone(),
+    )?;
+    crate::aver_generated::domain::eval::core::maybeCallMain(&allFns, &v)
 }
 
 /// If a main() function exists, call it. Otherwise return fallback value.
 pub fn maybeCallMain(fns: &FnStore, fallback: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::store::lookupFnOption(fns, AverStr::from("main")) {
-        Some(fd) => callResolved(&fd, &aver_rt::AverList::empty(), fns),
+        Some(fd) => crate::aver_generated::domain::eval::core::callResolved(
+            &fd,
+            &aver_rt::AverList::empty(),
+            fns,
+        ),
         None => Ok(fallback.clone()),
     }
 }
@@ -3866,13 +4278,21 @@ pub fn evalImmediateSlotExpr(
 ) -> Option<Result<Val, AverStr>> {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprSlot(slot) => Some(crate::aver_generated::domain::eval::slots::lookupSlot(
-            env, slot,
-        )),
-        Expr::ExprInt(n) => Some(Ok(Val::ValInt(n))),
-        Expr::ExprFloat(f) => Some(Ok(Val::ValFloat(f))),
-        Expr::ExprStr(s) => Some(Ok(Val::ValStr(s))),
-        Expr::ExprBool(b) => Some(Ok(Val::ValBool(b))),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => Some(
+            crate::aver_generated::domain::eval::slots::lookupSlot(env, slot),
+        ),
+        crate::aver_generated::domain::ast::Expr::ExprInt(n) => {
+            Some(Ok(crate::aver_generated::domain::value::Val::ValInt(n)))
+        }
+        crate::aver_generated::domain::ast::Expr::ExprFloat(f) => {
+            Some(Ok(crate::aver_generated::domain::value::Val::ValFloat(f)))
+        }
+        crate::aver_generated::domain::ast::Expr::ExprStr(s) => {
+            Some(Ok(crate::aver_generated::domain::value::Val::ValStr(s)))
+        }
+        crate::aver_generated::domain::ast::Expr::ExprBool(b) => {
+            Some(Ok(crate::aver_generated::domain::value::Val::ValBool(b)))
+        }
         _ => None,
     }
 }
@@ -3904,7 +4324,11 @@ pub fn evalBinopSlotInt(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let left = crate::aver_generated::domain::eval::slots::lookupSlot(env, slot)?;
-    crate::aver_generated::domain::eval::ops::evalBinopVals(&left, &Val::ValInt(rhs), op)
+    crate::aver_generated::domain::eval::ops::evalBinopVals(
+        &left,
+        &crate::aver_generated::domain::value::Val::ValInt(rhs),
+        op,
+    )
 }
 
 /// Evaluate a specialized slot-vs-slot arithmetic expression.
@@ -3929,7 +4353,11 @@ pub fn evalCmpSlotInt(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let left = crate::aver_generated::domain::eval::slots::lookupSlot(env, slot)?;
-    crate::aver_generated::domain::eval::ops::evalCmpVals(&left, &Val::ValInt(rhs), op)
+    crate::aver_generated::domain::eval::ops::evalCmpVals(
+        &left,
+        &crate::aver_generated::domain::value::Val::ValInt(rhs),
+        op,
+    )
 }
 
 /// Evaluate a specialized slot-vs-slot comparison.
@@ -3955,8 +4383,8 @@ pub fn evalVectorGetOrIntExprSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let vecV = evalExprSlot(vecExpr, env, slotMap, fns)?;
-    let idxV = evalExprSlot(idxExpr, env, slotMap, fns)?;
+    let vecV = crate::aver_generated::domain::eval::core::evalExprSlot(vecExpr, env, slotMap, fns)?;
+    let idxV = crate::aver_generated::domain::eval::core::evalExprSlot(idxExpr, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalVectorGetOrIntVals(&vecV, &idxV, defaultValue)
 }
 
@@ -3970,8 +4398,8 @@ pub fn evalIntModOrIntExprSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let aV = evalExprSlot(a, env, slotMap, fns)?;
-    let bV = evalExprSlot(b, env, slotMap, fns)?;
+    let aV = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
+    let bV = crate::aver_generated::domain::eval::core::evalExprSlot(b, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalIntModOrIntVals(&aV, &bV, defaultValue)
 }
 
@@ -3985,8 +4413,8 @@ pub fn evalBinopSlot(
     op: &BinOp,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let va = evalExprSlot(a, env, slotMap, fns)?;
-    let vb = evalExprSlot(b, env, slotMap, fns)?;
+    let va = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
+    let vb = crate::aver_generated::domain::eval::core::evalExprSlot(b, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalBinopVals(&va, &vb, op)
 }
 
@@ -3998,7 +4426,7 @@ pub fn evalNegSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = evalExprSlot(inner, env, slotMap, fns)?;
+    let v = crate::aver_generated::domain::eval::core::evalExprSlot(inner, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalNegVals(&v)
 }
 
@@ -4012,8 +4440,8 @@ pub fn evalCmpSlot(
     op: &CmpOp,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let va = evalExprSlot(a, env, slotMap, fns)?;
-    let vb = evalExprSlot(b, env, slotMap, fns)?;
+    let va = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
+    let vb = crate::aver_generated::domain::eval::core::evalExprSlot(b, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalCmpVals(&va, &vb, op)
 }
 
@@ -4025,7 +4453,7 @@ pub fn evalConcatSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    evalConcatPartsSlot(
+    crate::aver_generated::domain::eval::core::evalConcatPartsSlot(
         parts.clone(),
         env.clone(),
         slotMap.clone(),
@@ -4044,7 +4472,7 @@ pub fn evalConcatPartsSlot(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(parts, [] => Ok(Val::ValStr(acc)), [p, rest] => { match evalExprSlot(&p, &env, &slotMap, &fns) { Err(e) => { Err(e) }, Ok(v) => { {
+        return aver_list_match!(parts, [] => Ok(crate::aver_generated::domain::value::Val::ValStr(acc)), [p, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&p, &env, &slotMap, &fns) { Err(e) => { Err(e) }, Ok(v) => { {
             let __tmp4 = (acc + &crate::aver_generated::domain::value::valRepr(&v));
             parts = rest;
             acc = __tmp4;
@@ -4061,8 +4489,9 @@ pub fn evalTupleSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = evalListItemsSlot(exprs, env, slotMap, fns)?;
-    Ok(Val::ValTuple(items))
+    let items =
+        crate::aver_generated::domain::eval::core::evalListItemsSlot(exprs, env, slotMap, fns)?;
+    Ok(crate::aver_generated::domain::value::Val::ValTuple(items))
 }
 
 /// List literal in slot path.
@@ -4073,8 +4502,9 @@ pub fn evalListSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = evalListItemsSlot(exprs, env, slotMap, fns)?;
-    Ok(Val::ValList(items))
+    let items =
+        crate::aver_generated::domain::eval::core::evalListItemsSlot(exprs, env, slotMap, fns)?;
+    Ok(crate::aver_generated::domain::value::Val::ValList(items))
 }
 
 /// Evaluate list of expressions in slot path.
@@ -4085,7 +4515,7 @@ pub fn evalListItemsSlot(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
-    evalListItemsSlotRev(
+    crate::aver_generated::domain::eval::core::evalListItemsSlotRev(
         exprs.clone(),
         env.clone(),
         slotMap.clone(),
@@ -4104,7 +4534,7 @@ pub fn evalListItemsSlotRev(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
+        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
             let __tmp4 = aver_rt::AverList::prepend(v, &acc);
             exprs = rest;
             acc = __tmp4;
@@ -4122,8 +4552,12 @@ pub fn evalRecordSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let fields = evalRecordFieldsSlot(fieldExprs, env, slotMap, fns)?;
-    Ok(Val::ValRecord(name, fields))
+    let fields = crate::aver_generated::domain::eval::core::evalRecordFieldsSlot(
+        fieldExprs, env, slotMap, fns,
+    )?;
+    Ok(crate::aver_generated::domain::value::Val::ValRecord(
+        name, fields,
+    ))
 }
 
 /// Evaluate record fields in slot path.
@@ -4134,7 +4568,7 @@ pub fn evalRecordFieldsSlot(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
-    aver_list_match!(fieldExprs.clone(), [] => Ok(aver_rt::AverList::empty()), [pair, rest] => { { let (fname, expr) = pair; evalRecordFieldOneSlot(fname, &expr, &rest, env, slotMap, fns) } })
+    aver_list_match!(fieldExprs.clone(), [] => Ok(aver_rt::AverList::empty()), [pair, rest] => { { let (fname, expr) = pair; crate::aver_generated::domain::eval::core::evalRecordFieldOneSlot(fname, &expr, &rest, env, slotMap, fns) } })
 }
 
 /// Evaluate one record field in slot path.
@@ -4147,8 +4581,9 @@ pub fn evalRecordFieldOneSlot(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
-    let v = evalExprSlot(expr, env, slotMap, fns)?;
-    let restFields = evalRecordFieldsSlot(rest, env, slotMap, fns)?;
+    let v = crate::aver_generated::domain::eval::core::evalExprSlot(expr, env, slotMap, fns)?;
+    let restFields =
+        crate::aver_generated::domain::eval::core::evalRecordFieldsSlot(rest, env, slotMap, fns)?;
     Ok(aver_rt::AverList::prepend((fname, v), &restFields))
 }
 
@@ -4161,9 +4596,9 @@ pub fn evalFieldAccessSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = evalExprSlot(obj, env, slotMap, fns)?;
+    let v = crate::aver_generated::domain::eval::core::evalExprSlot(obj, env, slotMap, fns)?;
     match v {
-        Val::ValRecord(_, fields) => {
+        crate::aver_generated::domain::value::Val::ValRecord(_, fields) => {
             crate::aver_generated::domain::eval::common::lookupField(fields, field)
         }
         _ => Err(AverStr::from("field access on non-record")),
@@ -4179,8 +4614,9 @@ pub fn evalCallSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let args = evalArgsSlot(argExprs, env, slotMap, fns)?;
-    callWithArgs(&args, name, fns)
+    let args =
+        crate::aver_generated::domain::eval::core::evalArgsSlot(argExprs, env, slotMap, fns)?;
+    crate::aver_generated::domain::eval::core::callWithArgs(&args, name, fns)
 }
 
 /// Call a pre-resolved function directly from slot mode using the function store.
@@ -4194,9 +4630,13 @@ pub fn evalCallDirectSlot(
     crate::cancel_checkpoint();
     let fd = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId)?;
     if (fd.slotCount > 0i64) {
-        evalCallDirectSlotToSlot(fnId, &fd, argExprs, env, slotMap, fns)
+        crate::aver_generated::domain::eval::core::evalCallDirectSlotToSlot(
+            fnId, &fd, argExprs, env, slotMap, fns,
+        )
     } else {
-        evalCallDirectSlotToNamed(&fd, argExprs, env, slotMap, fns)
+        crate::aver_generated::domain::eval::core::evalCallDirectSlotToNamed(
+            &fd, argExprs, env, slotMap, fns,
+        )
     }
 }
 
@@ -4210,7 +4650,7 @@ pub fn evalCallDirectSlotToSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let calleeEnv = evalArgsSlotToSlotEnv(
+    let calleeEnv = crate::aver_generated::domain::eval::core::evalArgsSlotToSlotEnv(
         argExprs.clone(),
         env.clone(),
         slotMap.clone(),
@@ -4218,7 +4658,7 @@ pub fn evalCallDirectSlotToSlot(
         aver_rt::AverVector::new(fd.slotCount as usize, Val::ValUnit.clone()),
         0i64,
     )?;
-    evalResolvedSlotFn(fnId, fd, &calleeEnv, fns)
+    crate::aver_generated::domain::eval::core::evalResolvedSlotFn(fnId, fd, &calleeEnv, fns)
 }
 
 /// Call resolved function by evaluating args directly into a named env from slot caller state.
@@ -4230,9 +4670,15 @@ pub fn evalCallDirectSlotToNamed(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let calleeEnv =
-        evalArgsSlotToNamedEnv(argExprs, &fd.params, env, slotMap, fns, &HashMap::new())?;
-    evalResolvedNamedFn(fd, &calleeEnv, fns)
+    let calleeEnv = crate::aver_generated::domain::eval::core::evalArgsSlotToNamedEnv(
+        argExprs,
+        &fd.params,
+        env,
+        slotMap,
+        fns,
+        &HashMap::new(),
+    )?;
+    crate::aver_generated::domain::eval::core::evalResolvedNamedFn(fd, &calleeEnv, fns)
 }
 
 /// Call a builtin directly, skipping fns lookup (slot-based path).
@@ -4244,8 +4690,9 @@ pub fn evalCallBuiltinSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let args = evalArgsSlot(argExprs, env, slotMap, fns)?;
-    crate::aver_generated::domain::builtins::callBuiltin(name.clone(), &args)
+    let args =
+        crate::aver_generated::domain::eval::core::evalArgsSlot(argExprs, env, slotMap, fns)?;
+    crate::aver_generated::domain::builtins::callBuiltin(name, &args)
 }
 
 /// Evaluate argument expressions in slot path.
@@ -4256,7 +4703,7 @@ pub fn evalArgsSlot(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
-    aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [e0, rest] => { aver_list_match!(rest, [] => evalArgsSlot1(&e0, env, slotMap, fns), [e1, rest2] => { aver_list_match!(rest2, [] => evalArgsSlot2(&e0, &e1, env, slotMap, fns), [e2, rest3] => { { let __list_subject = rest3; if __list_subject.is_empty() { evalArgsSlot3(&e0, &e1, &e2, env, slotMap, fns) } else { evalArgsSlotRev(exprs.clone(), env.clone(), slotMap.clone(), fns.clone(), aver_rt::AverList::empty()) } } }) }) })
+    aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [e0, rest] => { aver_list_match!(rest, [] => crate::aver_generated::domain::eval::core::evalArgsSlot1(&e0, env, slotMap, fns), [e1, rest2] => { aver_list_match!(rest2, [] => crate::aver_generated::domain::eval::core::evalArgsSlot2(&e0, &e1, env, slotMap, fns), [e2, rest3] => { { let __list_subject = rest3; if __list_subject.is_empty() { crate::aver_generated::domain::eval::core::evalArgsSlot3(&e0, &e1, &e2, env, slotMap, fns) } else { crate::aver_generated::domain::eval::core::evalArgsSlotRev(exprs.clone(), env.clone(), slotMap.clone(), fns.clone(), aver_rt::AverList::empty()) } } }) }) })
 }
 
 /// Fast path for one slot-path argument.
@@ -4267,7 +4714,7 @@ pub fn evalArgsSlot1(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
-    let v0 = evalExprSlot(e0, env, slotMap, fns)?;
+    let v0 = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
     Ok(aver_rt::AverList::from_vec(vec![v0]))
 }
 
@@ -4280,8 +4727,8 @@ pub fn evalArgsSlot2(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
-    let v0 = evalExprSlot(e0, env, slotMap, fns)?;
-    let v1 = evalExprSlot(e1, env, slotMap, fns)?;
+    let v0 = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
+    let v1 = crate::aver_generated::domain::eval::core::evalExprSlot(e1, env, slotMap, fns)?;
     Ok(aver_rt::AverList::from_vec(vec![v0, v1]))
 }
 
@@ -4295,9 +4742,9 @@ pub fn evalArgsSlot3(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
-    let v0 = evalExprSlot(e0, env, slotMap, fns)?;
-    let v1 = evalExprSlot(e1, env, slotMap, fns)?;
-    let v2 = evalExprSlot(e2, env, slotMap, fns)?;
+    let v0 = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
+    let v1 = crate::aver_generated::domain::eval::core::evalExprSlot(e1, env, slotMap, fns)?;
+    let v2 = crate::aver_generated::domain::eval::core::evalExprSlot(e2, env, slotMap, fns)?;
     Ok(aver_rt::AverList::from_vec(vec![v0, v1, v2]))
 }
 
@@ -4311,7 +4758,7 @@ pub fn evalArgsSlotRev(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
+        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
             let __tmp4 = aver_rt::AverList::prepend(v, &acc);
             exprs = rest;
             acc = __tmp4;
@@ -4330,7 +4777,7 @@ pub fn evalArgsMapToSlotEnv(
 ) -> Result<aver_rt::AverVector<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc), [e, rest] => { match evalExpr(&e, &env, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
+        return aver_list_match!(exprs, [] => Ok(acc), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
             let __tmp3 = crate::aver_generated::domain::eval::slots::setSlot(&acc, idx, &v);
             let __tmp4 = (idx + 1i64);
             exprs = rest;
@@ -4352,7 +4799,7 @@ pub fn evalArgsSlotToSlotEnv(
 ) -> Result<aver_rt::AverVector<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc), [e, rest] => { match evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
+        return aver_list_match!(exprs, [] => Ok(acc), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
             let __tmp4 = crate::aver_generated::domain::eval::slots::setSlot(&acc, idx, &v);
             let __tmp5 = (idx + 1i64);
             exprs = rest;
@@ -4371,16 +4818,16 @@ pub fn evalPropagateSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = evalExprSlot(inner, env, slotMap, fns)?;
+    let v = crate::aver_generated::domain::eval::core::evalExprSlot(inner, env, slotMap, fns)?;
     match v {
-        Val::ValOk(x) => {
+        crate::aver_generated::domain::value::Val::ValOk(x) => {
             let x = (*x).clone();
             Ok(x)
         }
-        Val::ValErr(e) => {
+        crate::aver_generated::domain::value::Val::ValErr(e) => {
             let e = (*e).clone();
             match e {
-                Val::ValStr(msg) => {
+                crate::aver_generated::domain::value::Val::ValStr(msg) => {
                     Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(msg))
                 }
                 _ => Err(
@@ -4403,11 +4850,16 @@ pub fn evalIndependentProductSlot(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = evalIndependentItemsSlot(exprs, env, slotMap, fns)?;
+    let items = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(
+        exprs, env, slotMap, fns,
+    )?;
     if unwrap {
-        unwrapProductResults(items, aver_rt::AverList::empty())
+        crate::aver_generated::domain::eval::core::unwrapProductResults(
+            items,
+            aver_rt::AverList::empty(),
+        )
     } else {
-        Ok(Val::ValTuple(items))
+        Ok(crate::aver_generated::domain::value::Val::ValTuple(items))
     }
 }
 
@@ -4419,5 +4871,5 @@ pub fn evalIndependentItemsSlot(
     fns: &FnStore,
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
-    aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [a, rest] => { aver_list_match!(rest, [] => match evalExprSlot(&a, env, slotMap, fns) { Ok(va) => { Ok(aver_rt::AverList::from_vec(vec![va])) }, Err(e) => { Err(e) } }, [b, rest2] => { { let __list_subject = rest2; if __list_subject.is_empty() { { let (va, vb) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = evalExprSlot(&a, env, slotMap, fns); crate::aver_replay::set_effect_branch(1); let _r1 = evalExprSlot(&b, env, slotMap, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = evalExprSlot(&a, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = evalExprSlot(&b, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(aver_rt::AverList::from_vec(vec![va, vb])) } } else { { let (leftExprs, rightExprs) = splitIndependentExprs(exprs.clone(), aver_rt::AverList::empty(), aver_rt::AverList::empty(), true); { let (leftVals, rightVals) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = evalIndependentItemsSlot(&leftExprs, env, slotMap, fns); crate::aver_replay::set_effect_branch(1); let _r1 = evalIndependentItemsSlot(&rightExprs, env, slotMap, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = evalIndependentItemsSlot(&leftExprs, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = evalIndependentItemsSlot(&rightExprs, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(interleaveIndependentVals(leftVals, rightVals, true, aver_rt::AverList::empty())) } } } } }) })
+    aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [a, rest] => { aver_list_match!(rest, [] => match crate::aver_generated::domain::eval::core::evalExprSlot(&a, env, slotMap, fns) { Ok(va) => { Ok(aver_rt::AverList::from_vec(vec![va])) }, Err(e) => { Err(e) } }, [b, rest2] => { { let __list_subject = rest2; if __list_subject.is_empty() { { let (va, vb) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalExprSlot(&a, env, slotMap, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalExprSlot(&b, env, slotMap, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExprSlot(&a, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExprSlot(&b, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(aver_rt::AverList::from_vec(vec![va, vb])) } } else { { let (leftExprs, rightExprs) = crate::aver_generated::domain::eval::core::splitIndependentExprs(exprs.clone(), aver_rt::AverList::empty(), aver_rt::AverList::empty(), true); { let (leftVals, rightVals) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&leftExprs, env, slotMap, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&rightExprs, env, slotMap, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&leftExprs, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&rightExprs, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(crate::aver_generated::domain::eval::core::interleaveIndependentVals(leftVals, rightVals, true, aver_rt::AverList::empty())) } } } } }) })
 }

--- a/src/self_host/aver_generated/domain/eval/fast/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/fast/mod.rs
@@ -18,27 +18,62 @@ pub fn runFastLeafSlot(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match leaf.clone() {
-        FastLeaf::LeafConstInt(n) => Ok(Val::ValInt(n)),
-        FastLeaf::LeafConstFloat(f) => Ok(Val::ValFloat(f)),
-        FastLeaf::LeafConstStr(s) => Ok(Val::ValStr(s)),
-        FastLeaf::LeafConstBool(b) => Ok(Val::ValBool(b)),
-        FastLeaf::LeafSlot(slot) => {
+        crate::aver_generated::domain::ast::FastLeaf::LeafConstInt(n) => {
+            Ok(crate::aver_generated::domain::value::Val::ValInt(n))
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafConstFloat(f) => {
+            Ok(crate::aver_generated::domain::value::Val::ValFloat(f))
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafConstStr(s) => {
+            Ok(crate::aver_generated::domain::value::Val::ValStr(s))
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafConstBool(b) => {
+            Ok(crate::aver_generated::domain::value::Val::ValBool(b))
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafSlot(slot) => {
             crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)
         }
-        FastLeaf::LeafFieldAccess(slot, field) => fastFieldAccessSlot(calleeEnv, slot, field),
-        FastLeaf::LeafMapGet(mapSlot, keySlot) => fastMapGetSlot(calleeEnv, mapSlot, keySlot),
-        FastLeaf::LeafMapSet(mapSlot, keySlot, valueSlot) => {
-            fastMapSetSlot(calleeEnv, mapSlot, keySlot, valueSlot)
+        crate::aver_generated::domain::ast::FastLeaf::LeafFieldAccess(slot, field) => {
+            crate::aver_generated::domain::eval::fast::fastFieldAccessSlot(calleeEnv, slot, field)
         }
-        FastLeaf::LeafMapHas(mapSlot, keySlot) => fastMapHasSlot(calleeEnv, mapSlot, keySlot),
-        FastLeaf::LeafMapRemove(mapSlot, keySlot) => fastMapRemoveSlot(calleeEnv, mapSlot, keySlot),
-        FastLeaf::LeafVectorNew(sizeSlot, fill) => fastVectorNewSlot(calleeEnv, sizeSlot, fill),
-        FastLeaf::LeafVectorLen(vecSlot) => fastVectorLenSlot(calleeEnv, vecSlot),
-        FastLeaf::LeafVectorGetOrInt(vecSlot, idxSlot, defaultValue) => {
-            fastVectorGetOrIntSlot(calleeEnv, vecSlot, idxSlot, defaultValue)
+        crate::aver_generated::domain::ast::FastLeaf::LeafMapGet(mapSlot, keySlot) => {
+            crate::aver_generated::domain::eval::fast::fastMapGetSlot(calleeEnv, mapSlot, keySlot)
         }
-        FastLeaf::LeafBinopSlots(op, slotA, slotB) => fastBinopSlots(calleeEnv, &op, slotA, slotB),
-        FastLeaf::LeafCmpSlots(op, slotA, slotB) => fastCmpSlots(calleeEnv, &op, slotA, slotB),
+        crate::aver_generated::domain::ast::FastLeaf::LeafMapSet(mapSlot, keySlot, valueSlot) => {
+            crate::aver_generated::domain::eval::fast::fastMapSetSlot(
+                calleeEnv, mapSlot, keySlot, valueSlot,
+            )
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafMapHas(mapSlot, keySlot) => {
+            crate::aver_generated::domain::eval::fast::fastMapHasSlot(calleeEnv, mapSlot, keySlot)
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafMapRemove(mapSlot, keySlot) => {
+            crate::aver_generated::domain::eval::fast::fastMapRemoveSlot(
+                calleeEnv, mapSlot, keySlot,
+            )
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafVectorNew(sizeSlot, fill) => {
+            crate::aver_generated::domain::eval::fast::fastVectorNewSlot(calleeEnv, sizeSlot, fill)
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafVectorLen(vecSlot) => {
+            crate::aver_generated::domain::eval::fast::fastVectorLenSlot(calleeEnv, vecSlot)
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafVectorGetOrInt(
+            vecSlot,
+            idxSlot,
+            defaultValue,
+        ) => crate::aver_generated::domain::eval::fast::fastVectorGetOrIntSlot(
+            calleeEnv,
+            vecSlot,
+            idxSlot,
+            defaultValue,
+        ),
+        crate::aver_generated::domain::ast::FastLeaf::LeafBinopSlots(op, slotA, slotB) => {
+            crate::aver_generated::domain::eval::fast::fastBinopSlots(calleeEnv, &op, slotA, slotB)
+        }
+        crate::aver_generated::domain::ast::FastLeaf::LeafCmpSlots(op, slotA, slotB) => {
+            crate::aver_generated::domain::eval::fast::fastCmpSlots(calleeEnv, &op, slotA, slotB)
+        }
     }
 }
 
@@ -52,7 +87,11 @@ pub fn fastBoolSlotBranch(
     crate::cancel_checkpoint();
     let slotV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match slotV {
-        Val::ValBool(cond) => selectFastLeaf(cond, thenLeaf, elseLeaf, calleeEnv),
+        crate::aver_generated::domain::value::Val::ValBool(cond) => {
+            crate::aver_generated::domain::eval::fast::selectFastLeaf(
+                cond, thenLeaf, elseLeaf, calleeEnv,
+            )
+        }
         _ => Err(AverStr::from("fast bool branch expects Bool slot")),
     }
 }
@@ -68,7 +107,14 @@ pub fn fastEqIntBranch(
     crate::cancel_checkpoint();
     let slotV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match slotV {
-        Val::ValInt(actual) => selectFastLeaf((actual == expected), thenLeaf, elseLeaf, calleeEnv),
+        crate::aver_generated::domain::value::Val::ValInt(actual) => {
+            crate::aver_generated::domain::eval::fast::selectFastLeaf(
+                (actual == expected),
+                thenLeaf,
+                elseLeaf,
+                calleeEnv,
+            )
+        }
         _ => Err(AverStr::from("fast int branch expects Int slot")),
     }
 }
@@ -84,7 +130,14 @@ pub fn fastEqStringBranch(
     crate::cancel_checkpoint();
     let slotV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match slotV {
-        Val::ValStr(actual) => selectFastLeaf((actual == expected), thenLeaf, elseLeaf, calleeEnv),
+        crate::aver_generated::domain::value::Val::ValStr(actual) => {
+            crate::aver_generated::domain::eval::fast::selectFastLeaf(
+                (actual == expected),
+                thenLeaf,
+                elseLeaf,
+                calleeEnv,
+            )
+        }
         _ => Err(AverStr::from("fast string branch expects String slot")),
     }
 }
@@ -101,8 +154,15 @@ pub fn fastLtIntSlotsBranch(
     let lhsV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, lhsSlot)?;
     let rhsV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, rhsSlot)?;
     match lhsV {
-        Val::ValInt(lhs) => match rhsV {
-            Val::ValInt(rhs) => selectFastLeaf((lhs < rhs), thenLeaf, elseLeaf, calleeEnv),
+        crate::aver_generated::domain::value::Val::ValInt(lhs) => match rhsV {
+            crate::aver_generated::domain::value::Val::ValInt(rhs) => {
+                crate::aver_generated::domain::eval::fast::selectFastLeaf(
+                    (lhs < rhs),
+                    thenLeaf,
+                    elseLeaf,
+                    calleeEnv,
+                )
+            }
             _ => Err(AverStr::from("fast lt branch expects Int rhs slot")),
         },
         _ => Err(AverStr::from("fast lt branch expects Int lhs slot")),
@@ -119,9 +179,9 @@ pub fn selectFastLeaf(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     if cond {
-        runFastLeafSlot(thenLeaf, calleeEnv)
+        crate::aver_generated::domain::eval::fast::runFastLeafSlot(thenLeaf, calleeEnv)
     } else {
-        runFastLeafSlot(elseLeaf, calleeEnv)
+        crate::aver_generated::domain::eval::fast::runFastLeafSlot(elseLeaf, calleeEnv)
     }
 }
 
@@ -137,8 +197,10 @@ pub fn fastListSlotBranch(
     crate::cancel_checkpoint();
     let listV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match listV {
-        Val::ValList(items) => {
-            fastListSlotBranchItems(&items, calleeEnv, emptyLeaf, headSlot, tailSlot, consLeaf)
+        crate::aver_generated::domain::value::Val::ValList(items) => {
+            crate::aver_generated::domain::eval::fast::fastListSlotBranchItems(
+                &items, calleeEnv, emptyLeaf, headSlot, tailSlot, consLeaf,
+            )
         }
         _ => Err(AverStr::from("no matching arm")),
     }
@@ -155,7 +217,7 @@ pub fn fastListSlotBranchItems(
     consLeaf: &FastLeaf,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    aver_list_match!(items.clone(), [] => runFastLeafSlot(emptyLeaf, calleeEnv), [head, tail] => runFastLeafSlot(consLeaf, &crate::aver_generated::domain::eval::slots::setSlot(&crate::aver_generated::domain::eval::slots::setSlot(calleeEnv, headSlot, &head), tailSlot, &Val::ValList(tail))))
+    aver_list_match!(items.clone(), [] => crate::aver_generated::domain::eval::fast::runFastLeafSlot(emptyLeaf, calleeEnv), [head, tail] => crate::aver_generated::domain::eval::fast::runFastLeafSlot(consLeaf, &crate::aver_generated::domain::eval::slots::setSlot(&crate::aver_generated::domain::eval::slots::setSlot(calleeEnv, headSlot, &head), tailSlot, &crate::aver_generated::domain::value::Val::ValList(tail))))
 }
 
 /// Read a record field directly from a resolved slot.
@@ -167,7 +229,7 @@ pub fn fastFieldAccessSlot(
     crate::cancel_checkpoint();
     let recordV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match recordV {
-        Val::ValRecord(_, fields) => {
+        crate::aver_generated::domain::value::Val::ValRecord(_, fields) => {
             crate::aver_generated::domain::eval::common::lookupField(fields, field)
         }
         _ => Err(AverStr::from("field access on non-record")),
@@ -183,19 +245,21 @@ pub fn fastMapGetSlot(
     crate::cancel_checkpoint();
     let mapV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
     let keyV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
-    fastMapGetSlotInner(&mapV, &keyV)
+    crate::aver_generated::domain::eval::fast::fastMapGetSlotInner(&mapV, &keyV)
 }
 
 /// Look up a key in a ValMap without going through builtin dispatch.
 pub fn fastMapGetSlotInner(mapV: &Val, keyV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
-        Val::ValMap(m) => {
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
             match m
                 .get(&crate::aver_generated::domain::value::mapKeyRepr(keyV))
                 .cloned()
             {
-                Some(v) => Ok(Val::ValSome(std::sync::Arc::new(v))),
+                Some(v) => Ok(crate::aver_generated::domain::value::Val::ValSome(
+                    std::sync::Arc::new(v),
+                )),
                 None => Ok(Val::ValNone.clone()),
             }
         }
@@ -214,17 +278,19 @@ pub fn fastMapSetSlot(
     let mapV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
     let keyV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
     let valueV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, valueSlot)?;
-    fastMapSetSlotInner(&mapV, &keyV, &valueV)
+    crate::aver_generated::domain::eval::fast::fastMapSetSlotInner(&mapV, &keyV, &valueV)
 }
 
 /// Set a key in a ValMap without going through builtin dispatch.
 pub fn fastMapSetSlotInner(mapV: &Val, keyV: &Val, valueV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
-        Val::ValMap(m) => Ok(Val::ValMap(m.insert_owned(
-            crate::aver_generated::domain::value::mapKeyRepr(keyV),
-            valueV.clone(),
-        ))),
+        crate::aver_generated::domain::value::Val::ValMap(m) => Ok(
+            crate::aver_generated::domain::value::Val::ValMap(m.insert_owned(
+                crate::aver_generated::domain::value::mapKeyRepr(keyV),
+                valueV.clone(),
+            )),
+        ),
         _ => Err(AverStr::from("Map.set requires a Map")),
     }
 }
@@ -237,17 +303,19 @@ pub fn fastVectorNewSlot(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let sizeV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, sizeSlot)?;
-    fastVectorNewSlotInner(&sizeV, fill)
+    crate::aver_generated::domain::eval::fast::fastVectorNewSlotInner(&sizeV, fill)
 }
 
 /// Allocate a vector when the wrapper shape is known in advance.
 pub fn fastVectorNewSlotInner(sizeV: &Val, fill: i64) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match sizeV.clone() {
-        Val::ValInt(size) => Ok(Val::ValVector(aver_rt::AverVector::new(
-            size as usize,
-            Val::ValInt(fill),
-        ))),
+        crate::aver_generated::domain::value::Val::ValInt(size) => Ok(
+            crate::aver_generated::domain::value::Val::ValVector(aver_rt::AverVector::new(
+                size as usize,
+                crate::aver_generated::domain::value::Val::ValInt(fill),
+            )),
+        ),
         _ => Err(AverStr::from("Vector.new size must be Int")),
     }
 }
@@ -262,7 +330,11 @@ pub fn fastVectorGetOrIntSlot(
     crate::cancel_checkpoint();
     let vecV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, vecSlot)?;
     let idxV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, idxSlot)?;
-    fastVectorGetOrIntSlotInner(&vecV, &idxV, defaultValue)
+    crate::aver_generated::domain::eval::fast::fastVectorGetOrIntSlotInner(
+        &vecV,
+        &idxV,
+        defaultValue,
+    )
 }
 
 /// Read a vector cell with an integer default without going through builtin dispatch.
@@ -273,11 +345,15 @@ pub fn fastVectorGetOrIntSlotInner(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match vecV.clone() {
-        Val::ValVector(vec) => match idxV.clone() {
-            Val::ValInt(idx) => match vec.get(idx as usize).cloned() {
-                Some(v) => Ok(v),
-                None => Ok(Val::ValInt(defaultValue)),
-            },
+        crate::aver_generated::domain::value::Val::ValVector(vec) => match idxV.clone() {
+            crate::aver_generated::domain::value::Val::ValInt(idx) => {
+                match vec.get(idx as usize).cloned() {
+                    Some(v) => Ok(v),
+                    None => Ok(crate::aver_generated::domain::value::Val::ValInt(
+                        defaultValue,
+                    )),
+                }
+            }
             _ => Err(AverStr::from("Vector.get index must be Int")),
         },
         _ => Err(AverStr::from("Vector.get expects a Vector")),
@@ -294,9 +370,11 @@ pub fn fastMapHasSlot(
     let mapV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
     let keyV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
     match mapV {
-        Val::ValMap(m) => Ok(Val::ValBool(
-            m.contains_key(&crate::aver_generated::domain::value::mapKeyRepr(&keyV)),
-        )),
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
+            Ok(crate::aver_generated::domain::value::Val::ValBool(
+                m.contains_key(&crate::aver_generated::domain::value::mapKeyRepr(&keyV)),
+            ))
+        }
         _ => Err(AverStr::from("Map.has requires a Map")),
     }
 }
@@ -311,9 +389,11 @@ pub fn fastMapRemoveSlot(
     let mapV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
     let keyV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
     match mapV {
-        Val::ValMap(m) => Ok(Val::ValMap(
-            m.remove_owned(&crate::aver_generated::domain::value::mapKeyRepr(&keyV)),
-        )),
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
+            Ok(crate::aver_generated::domain::value::Val::ValMap(
+                m.remove_owned(&crate::aver_generated::domain::value::mapKeyRepr(&keyV)),
+            ))
+        }
         _ => Err(AverStr::from("Map.remove requires a Map")),
     }
 }
@@ -326,7 +406,9 @@ pub fn fastVectorLenSlot(
     crate::cancel_checkpoint();
     let vecV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, vecSlot)?;
     match vecV {
-        Val::ValVector(vec) => Ok(Val::ValInt((vec.len() as i64))),
+        crate::aver_generated::domain::value::Val::ValVector(vec) => Ok(
+            crate::aver_generated::domain::value::Val::ValInt((vec.len() as i64)),
+        ),
         _ => Err(AverStr::from("Vector.len expects a Vector")),
     }
 }

--- a/src/self_host/aver_generated/domain/eval/ops/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/ops/mod.rs
@@ -9,14 +9,20 @@ use crate::*;
 pub fn applyBinop(x: i64, y: i64, op: &BinOp) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match op {
-        BinOp::OpAdd => Ok(Val::ValInt((x + y))),
-        BinOp::OpSub => Ok(Val::ValInt((x - y))),
-        BinOp::OpMul => Ok(Val::ValInt((x * y))),
-        BinOp::OpDiv => {
+        crate::aver_generated::domain::ast::BinOp::OpAdd => {
+            Ok(crate::aver_generated::domain::value::Val::ValInt((x + y)))
+        }
+        crate::aver_generated::domain::ast::BinOp::OpSub => {
+            Ok(crate::aver_generated::domain::value::Val::ValInt((x - y)))
+        }
+        crate::aver_generated::domain::ast::BinOp::OpMul => {
+            Ok(crate::aver_generated::domain::value::Val::ValInt((x * y)))
+        }
+        crate::aver_generated::domain::ast::BinOp::OpDiv => {
             if (y == 0i64) {
                 Err(AverStr::from("division by zero"))
             } else {
-                Ok(Val::ValInt((x / y)))
+                Ok(crate::aver_generated::domain::value::Val::ValInt((x / y)))
             }
         }
     }
@@ -26,14 +32,20 @@ pub fn applyBinop(x: i64, y: i64, op: &BinOp) -> Result<Val, AverStr> {
 pub fn applyBinopFloat(x: f64, y: f64, op: &BinOp) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match op {
-        BinOp::OpAdd => Ok(Val::ValFloat((x + y))),
-        BinOp::OpSub => Ok(Val::ValFloat((x - y))),
-        BinOp::OpMul => Ok(Val::ValFloat((x * y))),
-        BinOp::OpDiv => {
+        crate::aver_generated::domain::ast::BinOp::OpAdd => {
+            Ok(crate::aver_generated::domain::value::Val::ValFloat((x + y)))
+        }
+        crate::aver_generated::domain::ast::BinOp::OpSub => {
+            Ok(crate::aver_generated::domain::value::Val::ValFloat((x - y)))
+        }
+        crate::aver_generated::domain::ast::BinOp::OpMul => {
+            Ok(crate::aver_generated::domain::value::Val::ValFloat((x * y)))
+        }
+        crate::aver_generated::domain::ast::BinOp::OpDiv => {
             if (y == 0.0f64) {
                 Err(AverStr::from("float division by zero"))
             } else {
-                Ok(Val::ValFloat((x / y)))
+                Ok(crate::aver_generated::domain::value::Val::ValFloat((x / y)))
             }
         }
     }
@@ -43,12 +55,24 @@ pub fn applyBinopFloat(x: f64, y: f64, op: &BinOp) -> Result<Val, AverStr> {
 pub fn applyCmp(x: i64, y: i64, op: &CmpOp) -> Val {
     crate::cancel_checkpoint();
     match op {
-        CmpOp::CmpEq => Val::ValBool((x == y)),
-        CmpOp::CmpNeq => Val::ValBool((x != y)),
-        CmpOp::CmpLt => Val::ValBool((x < y)),
-        CmpOp::CmpGt => Val::ValBool((x > y)),
-        CmpOp::CmpLte => Val::ValBool((x <= y)),
-        CmpOp::CmpGte => Val::ValBool((x >= y)),
+        crate::aver_generated::domain::ast::CmpOp::CmpEq => {
+            crate::aver_generated::domain::value::Val::ValBool((x == y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpNeq => {
+            crate::aver_generated::domain::value::Val::ValBool((x != y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLt => {
+            crate::aver_generated::domain::value::Val::ValBool((x < y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGt => {
+            crate::aver_generated::domain::value::Val::ValBool((x > y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLte => {
+            crate::aver_generated::domain::value::Val::ValBool((x <= y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGte => {
+            crate::aver_generated::domain::value::Val::ValBool((x >= y))
+        }
     }
 }
 
@@ -56,12 +80,24 @@ pub fn applyCmp(x: i64, y: i64, op: &CmpOp) -> Val {
 pub fn applyCmpFloat(x: f64, y: f64, op: &CmpOp) -> Val {
     crate::cancel_checkpoint();
     match op {
-        CmpOp::CmpEq => Val::ValBool((x == y)),
-        CmpOp::CmpNeq => Val::ValBool((x != y)),
-        CmpOp::CmpLt => Val::ValBool((x < y)),
-        CmpOp::CmpGt => Val::ValBool((x > y)),
-        CmpOp::CmpLte => Val::ValBool((x <= y)),
-        CmpOp::CmpGte => Val::ValBool((x >= y)),
+        crate::aver_generated::domain::ast::CmpOp::CmpEq => {
+            crate::aver_generated::domain::value::Val::ValBool((x == y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpNeq => {
+            crate::aver_generated::domain::value::Val::ValBool((x != y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLt => {
+            crate::aver_generated::domain::value::Val::ValBool((x < y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGt => {
+            crate::aver_generated::domain::value::Val::ValBool((x > y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLte => {
+            crate::aver_generated::domain::value::Val::ValBool((x <= y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGte => {
+            crate::aver_generated::domain::value::Val::ValBool((x >= y))
+        }
     }
 }
 
@@ -69,12 +105,29 @@ pub fn applyCmpFloat(x: f64, y: f64, op: &CmpOp) -> Val {
 pub fn evalBinopVals(va: &Val, vb: &Val, op: &BinOp) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match (va.clone(), vb.clone()) {
-        (Val::ValInt(x), Val::ValInt(y)) => applyBinop(x, y, op),
-        (Val::ValFloat(x), Val::ValFloat(y)) => applyBinopFloat(x, y, op),
-        (Val::ValInt(x), Val::ValFloat(y)) => applyBinopFloat(x as f64, y, op),
-        (Val::ValFloat(x), Val::ValInt(y)) => applyBinopFloat(x, y as f64, op),
-        (Val::ValStr(x), Val::ValStr(y)) => match op {
-            BinOp::OpAdd => Ok(Val::ValStr((x + &y))),
+        (
+            crate::aver_generated::domain::value::Val::ValInt(x),
+            crate::aver_generated::domain::value::Val::ValInt(y),
+        ) => crate::aver_generated::domain::eval::ops::applyBinop(x, y, op),
+        (
+            crate::aver_generated::domain::value::Val::ValFloat(x),
+            crate::aver_generated::domain::value::Val::ValFloat(y),
+        ) => crate::aver_generated::domain::eval::ops::applyBinopFloat(x, y, op),
+        (
+            crate::aver_generated::domain::value::Val::ValInt(x),
+            crate::aver_generated::domain::value::Val::ValFloat(y),
+        ) => crate::aver_generated::domain::eval::ops::applyBinopFloat(x as f64, y, op),
+        (
+            crate::aver_generated::domain::value::Val::ValFloat(x),
+            crate::aver_generated::domain::value::Val::ValInt(y),
+        ) => crate::aver_generated::domain::eval::ops::applyBinopFloat(x, y as f64, op),
+        (
+            crate::aver_generated::domain::value::Val::ValStr(x),
+            crate::aver_generated::domain::value::Val::ValStr(y),
+        ) => match op {
+            crate::aver_generated::domain::ast::BinOp::OpAdd => {
+                Ok(crate::aver_generated::domain::value::Val::ValStr((x + &y)))
+            }
             _ => Err(AverStr::from("strings only support +")),
         },
         _ => Err(AverStr::from("binop type mismatch")),
@@ -85,8 +138,12 @@ pub fn evalBinopVals(va: &Val, vb: &Val, op: &BinOp) -> Result<Val, AverStr> {
 pub fn evalNegVals(v: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValInt(n) => Ok(Val::ValInt((0i64 - n))),
-        Val::ValFloat(f) => Ok(Val::ValFloat((0.0f64 - f))),
+        crate::aver_generated::domain::value::Val::ValInt(n) => Ok(
+            crate::aver_generated::domain::value::Val::ValInt((0i64 - n)),
+        ),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
+            crate::aver_generated::domain::value::Val::ValFloat((0.0f64 - f)),
+        ),
         _ => Err(AverStr::from("unary '-' requires Int or Float")),
     }
 }
@@ -95,13 +152,39 @@ pub fn evalNegVals(v: &Val) -> Result<Val, AverStr> {
 pub fn evalCmpVals(va: &Val, vb: &Val, op: &CmpOp) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match (va.clone(), vb.clone()) {
-        (Val::ValInt(x), Val::ValInt(y)) => Ok(applyCmp(x, y, op)),
-        (Val::ValFloat(x), Val::ValFloat(y)) => Ok(applyCmpFloat(x, y, op)),
-        (Val::ValInt(x), Val::ValFloat(y)) => Ok(applyCmpFloat(x as f64, y, op)),
-        (Val::ValFloat(x), Val::ValInt(y)) => Ok(applyCmpFloat(x, y as f64, op)),
-        (Val::ValStr(x), Val::ValStr(y)) => Ok(applyStrCmp(x, y, op)),
-        (Val::ValBool(x), Val::ValBool(y)) => applyBoolCmp(x, y, op),
-        (a, b) => evalCmpRepr(&a, &b, op),
+        (
+            crate::aver_generated::domain::value::Val::ValInt(x),
+            crate::aver_generated::domain::value::Val::ValInt(y),
+        ) => Ok(crate::aver_generated::domain::eval::ops::applyCmp(x, y, op)),
+        (
+            crate::aver_generated::domain::value::Val::ValFloat(x),
+            crate::aver_generated::domain::value::Val::ValFloat(y),
+        ) => Ok(crate::aver_generated::domain::eval::ops::applyCmpFloat(
+            x, y, op,
+        )),
+        (
+            crate::aver_generated::domain::value::Val::ValInt(x),
+            crate::aver_generated::domain::value::Val::ValFloat(y),
+        ) => Ok(crate::aver_generated::domain::eval::ops::applyCmpFloat(
+            x as f64, y, op,
+        )),
+        (
+            crate::aver_generated::domain::value::Val::ValFloat(x),
+            crate::aver_generated::domain::value::Val::ValInt(y),
+        ) => Ok(crate::aver_generated::domain::eval::ops::applyCmpFloat(
+            x, y as f64, op,
+        )),
+        (
+            crate::aver_generated::domain::value::Val::ValStr(x),
+            crate::aver_generated::domain::value::Val::ValStr(y),
+        ) => Ok(crate::aver_generated::domain::eval::ops::applyStrCmp(
+            x, y, op,
+        )),
+        (
+            crate::aver_generated::domain::value::Val::ValBool(x),
+            crate::aver_generated::domain::value::Val::ValBool(y),
+        ) => crate::aver_generated::domain::eval::ops::applyBoolCmp(x, y, op),
+        (a, b) => crate::aver_generated::domain::eval::ops::evalCmpRepr(&a, &b, op),
     }
 }
 
@@ -109,12 +192,24 @@ pub fn evalCmpVals(va: &Val, vb: &Val, op: &CmpOp) -> Result<Val, AverStr> {
 pub fn applyStrCmp(x: AverStr, y: AverStr, op: &CmpOp) -> Val {
     crate::cancel_checkpoint();
     match op {
-        CmpOp::CmpEq => Val::ValBool((x == y)),
-        CmpOp::CmpNeq => Val::ValBool((x != y)),
-        CmpOp::CmpLt => Val::ValBool((x < y)),
-        CmpOp::CmpGt => Val::ValBool((x > y)),
-        CmpOp::CmpLte => Val::ValBool((x <= y)),
-        CmpOp::CmpGte => Val::ValBool((x >= y)),
+        crate::aver_generated::domain::ast::CmpOp::CmpEq => {
+            crate::aver_generated::domain::value::Val::ValBool((x == y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpNeq => {
+            crate::aver_generated::domain::value::Val::ValBool((x != y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLt => {
+            crate::aver_generated::domain::value::Val::ValBool((x < y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGt => {
+            crate::aver_generated::domain::value::Val::ValBool((x > y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLte => {
+            crate::aver_generated::domain::value::Val::ValBool((x <= y))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGte => {
+            crate::aver_generated::domain::value::Val::ValBool((x >= y))
+        }
     }
 }
 
@@ -122,8 +217,12 @@ pub fn applyStrCmp(x: AverStr, y: AverStr, op: &CmpOp) -> Val {
 pub fn applyBoolCmp(x: bool, y: bool, op: &CmpOp) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match op {
-        CmpOp::CmpEq => Ok(Val::ValBool((x == y))),
-        CmpOp::CmpNeq => Ok(Val::ValBool((x != y))),
+        crate::aver_generated::domain::ast::CmpOp::CmpEq => {
+            Ok(crate::aver_generated::domain::value::Val::ValBool((x == y)))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpNeq => {
+            Ok(crate::aver_generated::domain::value::Val::ValBool((x != y)))
+        }
         _ => Err(AverStr::from("bools only support == and !=")),
     }
 }
@@ -132,14 +231,18 @@ pub fn applyBoolCmp(x: bool, y: bool, op: &CmpOp) -> Result<Val, AverStr> {
 pub fn evalCmpRepr(va: &Val, vb: &Val, op: &CmpOp) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match op {
-        CmpOp::CmpEq => Ok(Val::ValBool(
-            (crate::aver_generated::domain::value::valRepr(va)
-                == crate::aver_generated::domain::value::valRepr(vb)),
-        )),
-        CmpOp::CmpNeq => Ok(Val::ValBool(
-            (crate::aver_generated::domain::value::valRepr(va)
-                != crate::aver_generated::domain::value::valRepr(vb)),
-        )),
+        crate::aver_generated::domain::ast::CmpOp::CmpEq => {
+            Ok(crate::aver_generated::domain::value::Val::ValBool(
+                (crate::aver_generated::domain::value::valRepr(va)
+                    == crate::aver_generated::domain::value::valRepr(vb)),
+            ))
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpNeq => {
+            Ok(crate::aver_generated::domain::value::Val::ValBool(
+                (crate::aver_generated::domain::value::valRepr(va)
+                    != crate::aver_generated::domain::value::valRepr(vb)),
+            ))
+        }
         _ => Err(aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = {
@@ -151,7 +254,7 @@ pub fn evalCmpRepr(va: &Val, vb: &Val, op: &CmpOp) -> Result<Val, AverStr> {
                                 __b
                             };
                             __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(
-                                &(cmpOpName(op)),
+                                &(crate::aver_generated::domain::eval::ops::cmpOpName(op)),
                             )));
                             __b
                         };
@@ -178,12 +281,12 @@ pub fn evalCmpRepr(va: &Val, vb: &Val, op: &CmpOp) -> Result<Val, AverStr> {
 pub fn cmpOpName(op: &CmpOp) -> AverStr {
     crate::cancel_checkpoint();
     match op {
-        CmpOp::CmpEq => AverStr::from("=="),
-        CmpOp::CmpNeq => AverStr::from("!="),
-        CmpOp::CmpLt => AverStr::from("<"),
-        CmpOp::CmpGt => AverStr::from(">"),
-        CmpOp::CmpLte => AverStr::from("<="),
-        CmpOp::CmpGte => AverStr::from(">="),
+        crate::aver_generated::domain::ast::CmpOp::CmpEq => AverStr::from("=="),
+        crate::aver_generated::domain::ast::CmpOp::CmpNeq => AverStr::from("!="),
+        crate::aver_generated::domain::ast::CmpOp::CmpLt => AverStr::from("<"),
+        crate::aver_generated::domain::ast::CmpOp::CmpGt => AverStr::from(">"),
+        crate::aver_generated::domain::ast::CmpOp::CmpLte => AverStr::from("<="),
+        crate::aver_generated::domain::ast::CmpOp::CmpGte => AverStr::from(">="),
     }
 }
 
@@ -191,10 +294,12 @@ pub fn cmpOpName(op: &CmpOp) -> AverStr {
 #[inline(always)]
 pub fn evalVectorGetOrIntVals(vecV: &Val, idxV: &Val, defaultValue: i64) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    match evalVectorGetMaybeDefault(vecV, idxV) {
+    match crate::aver_generated::domain::eval::ops::evalVectorGetMaybeDefault(vecV, idxV) {
         Ok(maybeV) => match maybeV {
             Some(v) => Ok(v),
-            None => Ok(Val::ValInt(defaultValue)),
+            None => Ok(crate::aver_generated::domain::value::Val::ValInt(
+                defaultValue,
+            )),
         },
         Err(err) => Err(err),
     }
@@ -204,12 +309,14 @@ pub fn evalVectorGetOrIntVals(vecV: &Val, idxV: &Val, defaultValue: i64) -> Resu
 pub fn evalIntModOrIntVals(aV: &Val, bV: &Val, defaultValue: i64) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match aV.clone() {
-        Val::ValInt(a) => match bV.clone() {
-            Val::ValInt(b) => {
+        crate::aver_generated::domain::value::Val::ValInt(a) => match bV.clone() {
+            crate::aver_generated::domain::value::Val::ValInt(b) => {
                 if (b == 0i64) {
-                    Ok(Val::ValInt(defaultValue))
+                    Ok(crate::aver_generated::domain::value::Val::ValInt(
+                        defaultValue,
+                    ))
                 } else {
-                    Ok(Val::ValInt(
+                    Ok(crate::aver_generated::domain::value::Val::ValInt(
                         (if (b) == 0i64 {
                             Err("Int.mod: divisor must not be zero".to_string())
                         } else {
@@ -234,21 +341,23 @@ pub fn evalVectorSetMaybeDefault(
 ) -> Result<Option<Val>, AverStr> {
     crate::cancel_checkpoint();
     match vecV.clone() {
-        Val::ValVector(vec) => match idxV.clone() {
-            Val::ValInt(idx) => {
+        crate::aver_generated::domain::value::Val::ValVector(vec) => match idxV.clone() {
+            crate::aver_generated::domain::value::Val::ValInt(idx) => {
                 if (idx < 0i64) {
                     Ok(None)
                 } else {
                     if (idx < (vec.len() as i64)) {
-                        Ok(Some(Val::ValVector({
-                            let __vec = vec.clone();
-                            let __idx = idx as usize;
-                            if __idx < __vec.len() {
-                                __vec.set_unchecked(__idx, valueV.clone())
-                            } else {
-                                __vec
-                            }
-                        })))
+                        Ok(Some(crate::aver_generated::domain::value::Val::ValVector(
+                            {
+                                let __vec = vec.clone();
+                                let __idx = idx as usize;
+                                if __idx < __vec.len() {
+                                    __vec.set_unchecked(__idx, valueV.clone())
+                                } else {
+                                    __vec
+                                }
+                            },
+                        )))
                     } else {
                         Ok(None)
                     }
@@ -264,11 +373,13 @@ pub fn evalVectorSetMaybeDefault(
 pub fn evalVectorGetMaybeDefault(vecV: &Val, idxV: &Val) -> Result<Option<Val>, AverStr> {
     crate::cancel_checkpoint();
     match vecV.clone() {
-        Val::ValVector(vec) => match idxV.clone() {
-            Val::ValInt(idx) => match vec.get(idx as usize).cloned() {
-                Some(v) => Ok(Some(v)),
-                None => Ok(None),
-            },
+        crate::aver_generated::domain::value::Val::ValVector(vec) => match idxV.clone() {
+            crate::aver_generated::domain::value::Val::ValInt(idx) => {
+                match vec.get(idx as usize).cloned() {
+                    Some(v) => Ok(Some(v)),
+                    None => Ok(None),
+                }
+            }
             _ => Err(AverStr::from("Vector.get: expected (Vector, Int)")),
         },
         _ => Err(AverStr::from("Vector.get: expected (Vector, Int)")),

--- a/src/self_host/aver_generated/domain/eval/records/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/records/mod.rs
@@ -30,10 +30,16 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverList<(Av
             }
             __MutualTco1::MergeOneField(mut k, mut v, mut rest, mut overrides, mut acc) => {
                 crate::cancel_checkpoint();
-                match findOverride(k.clone(), overrides.clone()) {
+                match crate::aver_generated::domain::eval::records::findOverride(
+                    k.clone(),
+                    overrides.clone(),
+                ) {
                     Some(newV) => __MutualTco1::MergeRecordFieldsAcc(
                         rest,
-                        removeOverride(k.clone(), &overrides),
+                        crate::aver_generated::domain::eval::records::removeOverride(
+                            k.clone(),
+                            &overrides,
+                        ),
                         aver_rt::AverList::prepend((k, newV), &acc),
                     ),
                     None => __MutualTco1::MergeRecordFieldsAcc(
@@ -82,7 +88,7 @@ pub fn mergeOneField(
 pub fn isRecordUpdate(name: AverStr, args: &aver_rt::AverList<Val>) -> bool {
     crate::cancel_checkpoint();
     if name.contains(".update") {
-        hasNamedRecord(args)
+        crate::aver_generated::domain::eval::records::hasNamedRecord(args)
     } else {
         false
     }
@@ -93,7 +99,7 @@ pub fn isRecordUpdate(name: AverStr, args: &aver_rt::AverList<Val>) -> bool {
 pub fn hasNamedRecord(args: &aver_rt::AverList<Val>) -> bool {
     crate::cancel_checkpoint();
     if ((args.len() as i64) == 2i64) {
-        isNamedSentinel(args)
+        crate::aver_generated::domain::eval::records::isNamedSentinel(args)
     } else {
         false
     }
@@ -106,7 +112,7 @@ pub fn isNamedSentinel(args: &aver_rt::AverList<Val>) -> bool {
     {
         let __list_subject = args.clone();
         if let Some((_, rest)) = aver_rt::list_uncons_cloned(&__list_subject) {
-            isNamedSentinelInner(&rest)
+            crate::aver_generated::domain::eval::records::isNamedSentinelInner(&rest)
         } else {
             if __list_subject.is_empty() {
                 false
@@ -122,7 +128,7 @@ pub fn isNamedSentinel(args: &aver_rt::AverList<Val>) -> bool {
 pub fn isNamedSentinelInner(rest: &aver_rt::AverList<Val>) -> bool {
     crate::cancel_checkpoint();
     aver_list_match!(rest.clone(), [] => false, [v, ignored] => match v {
-        Val::ValRecord(typeName, _) => {
+        crate::aver_generated::domain::value::Val::ValRecord(typeName, _) => {
             (&*typeName == "_named")
         },
         _ => {
@@ -135,7 +141,7 @@ pub fn isNamedSentinelInner(rest: &aver_rt::AverList<Val>) -> bool {
 #[inline(always)]
 pub fn doRecordUpdate(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    aver_list_match!(args.clone(), [] => Err(AverStr::from("record update requires (record, named fields)")), [baseVal, rest] => doRecordUpdateInner(&baseVal, &rest))
+    aver_list_match!(args.clone(), [] => Err(AverStr::from("record update requires (record, named fields)")), [baseVal, rest] => crate::aver_generated::domain::eval::records::doRecordUpdateInner(&baseVal, &rest))
 }
 
 /// Extract named fields from rest and apply update.
@@ -143,8 +149,8 @@ pub fn doRecordUpdate(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
 pub fn doRecordUpdateInner(baseVal: &Val, rest: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(rest.clone(), [] => Err(AverStr::from("record update requires named fields")), [namedVal, ignored] => match namedVal {
-        Val::ValRecord(_, namedFields) => {
-            applyRecordUpdate(baseVal, &namedFields)
+        crate::aver_generated::domain::value::Val::ValRecord(_, namedFields) => {
+            crate::aver_generated::domain::eval::records::applyRecordUpdate(baseVal, &namedFields)
         },
         _ => {
             Err(AverStr::from("record update requires named fields"))
@@ -159,10 +165,15 @@ pub fn applyRecordUpdate(
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match baseVal.clone() {
-        Val::ValRecord(typeName, existingFields) => Ok(Val::ValRecord(
-            typeName,
-            mergeRecordFields(&existingFields, namedFields),
-        )),
+        crate::aver_generated::domain::value::Val::ValRecord(typeName, existingFields) => {
+            Ok(crate::aver_generated::domain::value::Val::ValRecord(
+                typeName,
+                crate::aver_generated::domain::eval::records::mergeRecordFields(
+                    &existingFields,
+                    namedFields,
+                ),
+            ))
+        }
         _ => Err(AverStr::from("update requires a record value")),
     }
 }
@@ -174,7 +185,11 @@ pub fn mergeRecordFields(
     overrides: &aver_rt::AverList<(AverStr, Val)>,
 ) -> aver_rt::AverList<(AverStr, Val)> {
     crate::cancel_checkpoint();
-    mergeRecordFieldsAcc(existing, overrides, &aver_rt::AverList::empty())
+    crate::aver_generated::domain::eval::records::mergeRecordFieldsAcc(
+        existing,
+        overrides,
+        &aver_rt::AverList::empty(),
+    )
 }
 
 /// Find a field value in the overrides list.
@@ -201,7 +216,11 @@ pub fn removeOverride(
     overrides: &aver_rt::AverList<(AverStr, Val)>,
 ) -> aver_rt::AverList<(AverStr, Val)> {
     crate::cancel_checkpoint();
-    removeOverrideAcc(k, overrides.clone(), aver_rt::AverList::empty())
+    crate::aver_generated::domain::eval::records::removeOverrideAcc(
+        k,
+        overrides.clone(),
+        aver_rt::AverList::empty(),
+    )
 }
 
 /// Accumulate non-matching fields, then concat remainder when match found.

--- a/src/self_host/aver_generated/domain/eval/slots/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/slots/mod.rs
@@ -7,7 +7,7 @@ use crate::*;
 #[inline(always)]
 pub fn buildSlotEnv(args: &aver_rt::AverList<Val>, slotCount: i64) -> aver_rt::AverVector<Val> {
     crate::cancel_checkpoint();
-    buildSlotEnvLoop(
+    crate::aver_generated::domain::eval::slots::buildSlotEnvLoop(
         args.clone(),
         aver_rt::AverVector::new(slotCount as usize, Val::ValUnit.clone()),
         0i64,

--- a/src/self_host/aver_generated/domain/eval/store/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/store/mod.rs
@@ -141,7 +141,7 @@ pub fn lookupFnOption(fns: &FnStore, name: AverStr) -> Option<FnDef> {
 #[inline(always)]
 pub fn lookupFn(fns: &FnStore, name: AverStr) -> Result<FnDef, AverStr> {
     crate::cancel_checkpoint();
-    match lookupFnOption(fns, name.clone()) {
+    match crate::aver_generated::domain::eval::store::lookupFnOption(fns, name.clone()) {
         Some(fd) => Ok(fd),
         None => Err((AverStr::from("undefined function: ") + &name)),
     }
@@ -188,7 +188,8 @@ pub fn mergeBindings(
 /// Build a function store with a name->id index and id->FnDef table.
 pub fn fnsToStore(fns: &aver_rt::AverList<FnDef>) -> FnStore {
     crate::cancel_checkpoint();
-    let nameToId = fnsToIdMap(fns.clone(), HashMap::new(), 0i64);
+    let nameToId =
+        crate::aver_generated::domain::eval::store::fnsToIdMap(fns.clone(), HashMap::new(), 0i64);
     FnStore {
         nameToId: nameToId,
         byId: aver_rt::AverVector::from_vec(fns.to_vec()),

--- a/src/self_host/aver_generated/domain/lexer/chars/mod.rs
+++ b/src/self_host/aver_generated/domain/lexer/chars/mod.rs
@@ -79,10 +79,10 @@ pub fn isUpper(c: AverStr) -> bool {
 #[inline(always)]
 pub fn isLetterOrUnderscore(c: AverStr) -> bool {
     crate::cancel_checkpoint();
-    if isLower(c.clone()) {
+    if crate::aver_generated::domain::lexer::chars::isLower(c.clone()) {
         true
     } else {
-        if isUpper(c.clone()) {
+        if crate::aver_generated::domain::lexer::chars::isUpper(c.clone()) {
             true
         } else {
             (&*c == "_")
@@ -95,7 +95,7 @@ pub fn isLetterOrUnderscore(c: AverStr) -> bool {
 pub fn isAlpha(c: AverStr) -> bool {
     crate::cancel_checkpoint();
     if ((c.chars().count() as i64) == 1i64) {
-        isLetterOrUnderscore(c)
+        crate::aver_generated::domain::lexer::chars::isLetterOrUnderscore(c)
     } else {
         false
     }
@@ -105,7 +105,11 @@ pub fn isAlpha(c: AverStr) -> bool {
 #[inline(always)]
 pub fn isAlphaNum(c: AverStr) -> bool {
     crate::cancel_checkpoint();
-    if isAlpha(c.clone()) { true } else { isDigit(c) }
+    if crate::aver_generated::domain::lexer::chars::isAlpha(c.clone()) {
+        true
+    } else {
+        crate::aver_generated::domain::lexer::chars::isDigit(c)
+    }
 }
 
 /// Convert a digit character to its integer value.
@@ -166,10 +170,11 @@ pub fn readNumberLoop(mut src: AverStr, mut pos: i64, mut acc: i64) -> (i64, i64
         return if (pos < (src.chars().count() as i64)) {
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
-                    if isDigit(c.clone()) {
+                    if crate::aver_generated::domain::lexer::chars::isDigit(c.clone()) {
                         {
                             let __tmp1 = (pos + 1i64);
-                            let __tmp2 = ((acc * 10i64) + digitVal(c));
+                            let __tmp2 = ((acc * 10i64)
+                                + crate::aver_generated::domain::lexer::chars::digitVal(c));
                             pos = __tmp1;
                             acc = __tmp2;
                             continue;
@@ -190,14 +195,14 @@ pub fn readNumberLoop(mut src: AverStr, mut pos: i64, mut acc: i64) -> (i64, i64
 #[inline(always)]
 pub fn readNumber(src: AverStr, pos: i64, acc: i64) -> (i64, i64) {
     crate::cancel_checkpoint();
-    readNumberLoop(src.clone(), pos, acc)
+    crate::aver_generated::domain::lexer::chars::readNumberLoop(src, pos, acc)
 }
 
 /// Check if character can continue a dotted identifier (alphanumeric, underscore, or dot).
 #[inline(always)]
 pub fn isIdentCharDotted(c: AverStr) -> bool {
     crate::cancel_checkpoint();
-    if isAlphaNum(c.clone()) {
+    if crate::aver_generated::domain::lexer::chars::isAlphaNum(c.clone()) {
         true
     } else {
         (&*c == ".")
@@ -208,7 +213,7 @@ pub fn isIdentCharDotted(c: AverStr) -> bool {
 #[inline(always)]
 pub fn isIdentCharPlain(c: AverStr) -> bool {
     crate::cancel_checkpoint();
-    isAlphaNum(c.clone())
+    crate::aver_generated::domain::lexer::chars::isAlphaNum(c)
 }
 
 /// Read identifier including dots (for qualified names like List.prepend).
@@ -219,7 +224,7 @@ pub fn readIdentLoopDotted(mut src: AverStr, mut pos: i64, mut acc: AverStr) -> 
         return if (pos < (src.chars().count() as i64)) {
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
-                    if isIdentCharDotted(c.clone()) {
+                    if crate::aver_generated::domain::lexer::chars::isIdentCharDotted(c.clone()) {
                         {
                             let __tmp1 = (pos + 1i64);
                             let __tmp2 = (acc + &c);
@@ -247,7 +252,7 @@ pub fn readIdentLoopPlain(mut src: AverStr, mut pos: i64, mut acc: AverStr) -> (
         return if (pos < (src.chars().count() as i64)) {
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
-                    if isIdentCharPlain(c.clone()) {
+                    if crate::aver_generated::domain::lexer::chars::isIdentCharPlain(c.clone()) {
                         {
                             let __tmp1 = (pos + 1i64);
                             let __tmp2 = (acc + &c);
@@ -272,9 +277,9 @@ pub fn readIdentLoopPlain(mut src: AverStr, mut pos: i64, mut acc: AverStr) -> (
 pub fn readIdent(src: AverStr, pos: i64, acc: AverStr, dotted: bool) -> (AverStr, i64) {
     crate::cancel_checkpoint();
     if dotted {
-        readIdentLoopDotted(src, pos, acc)
+        crate::aver_generated::domain::lexer::chars::readIdentLoopDotted(src, pos, acc)
     } else {
-        readIdentLoopPlain(src, pos, acc)
+        crate::aver_generated::domain::lexer::chars::readIdentLoopPlain(src, pos, acc)
     }
 }
 
@@ -297,30 +302,42 @@ pub fn keywordOrIdent(s: AverStr) -> Token {
                         Token::TkFalse.clone()
                     } else {
                         if &*__dispatch_subject == "module" {
-                            Token::TkIdent(AverStr::from("module"))
+                            crate::aver_generated::domain::token::Token::TkIdent(AverStr::from(
+                                "module",
+                            ))
                         } else {
                             if &*__dispatch_subject == "type" {
-                                Token::TkIdent(AverStr::from("type"))
+                                crate::aver_generated::domain::token::Token::TkIdent(AverStr::from(
+                                    "type",
+                                ))
                             } else {
                                 if &*__dispatch_subject == "record" {
-                                    Token::TkIdent(AverStr::from("record"))
+                                    crate::aver_generated::domain::token::Token::TkIdent(
+                                        AverStr::from("record"),
+                                    )
                                 } else {
                                     if &*__dispatch_subject == "verify" {
-                                        Token::TkIdent(AverStr::from("verify"))
+                                        crate::aver_generated::domain::token::Token::TkIdent(
+                                            AverStr::from("verify"),
+                                        )
                                     } else {
                                         if &*__dispatch_subject == "depends" {
-                                            Token::TkIdent(AverStr::from("depends"))
+                                            crate::aver_generated::domain::token::Token::TkIdent(
+                                                AverStr::from("depends"),
+                                            )
                                         } else {
                                             if &*__dispatch_subject == "exposes" {
-                                                Token::TkIdent(AverStr::from("exposes"))
+                                                crate::aver_generated::domain::token::Token::TkIdent(
+                                                    AverStr::from("exposes"),
+                                                )
                                             } else {
                                                 if &*__dispatch_subject == "intent" {
-                                                    Token::TkIdent(AverStr::from("intent"))
+                                                    crate::aver_generated::domain::token::Token::TkIdent(AverStr::from("intent"))
                                                 } else {
                                                     if &*__dispatch_subject == "decision" {
-                                                        Token::TkIdent(AverStr::from("decision"))
+                                                        crate::aver_generated::domain::token::Token::TkIdent(AverStr::from("decision"))
                                                     } else {
-                                                        Token::TkIdent(s)
+                                                        crate::aver_generated::domain::token::Token::TkIdent(s)
                                                     }
                                                 }
                                             }

--- a/src/self_host/aver_generated/domain/lexer/mod.rs
+++ b/src/self_host/aver_generated/domain/lexer/mod.rs
@@ -71,10 +71,10 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
             __MutualTco2::TokenizeDefault(mut c, mut src, mut pos) => {
                 crate::cancel_checkpoint();
                 if crate::aver_generated::domain::lexer::chars::isDigit(c.clone()) {
-                    return tokenizeDigit(src, pos);
+                    return crate::aver_generated::domain::lexer::tokenizeDigit(src, pos);
                 } else {
                     if crate::aver_generated::domain::lexer::chars::isAlpha(c.clone()) {
-                        return tokenizeAlpha(src, pos);
+                        return crate::aver_generated::domain::lexer::tokenizeAlpha(src, pos);
                     } else {
                         __MutualTco2::TokenizeBraceOrSkip(c, src, pos)
                     }
@@ -83,16 +83,16 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
             __MutualTco2::TokenizeBraceOrSkip(mut c, mut src, mut pos) => {
                 crate::cancel_checkpoint();
                 let nextPos = (pos + 1i64);
-                if (c == openBrace()) {
+                if (c == crate::aver_generated::domain::lexer::openBrace()) {
                     return aver_rt::AverList::prepend(
                         Token::TkLBrace.clone(),
-                        &tokenize(src, nextPos),
+                        &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                     );
                 } else {
-                    if (c == closeBrace()) {
+                    if (c == crate::aver_generated::domain::lexer::closeBrace()) {
                         return aver_rt::AverList::prepend(
                             Token::TkRBrace.clone(),
-                            &tokenize(src, nextPos),
+                            &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                         );
                     } else {
                         __MutualTco2::Tokenize(src, nextPos)
@@ -108,70 +108,68 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
                         __MutualTco2::Tokenize(src, nextPos)
                     } else {
                         if &*__dispatch_subject == "\n" {
-                            return tokenizeNewline(src, nextPos);
+                            return crate::aver_generated::domain::lexer::tokenizeNewline(
+                                src, nextPos,
+                            );
                         } else {
                             if &*__dispatch_subject == "/" {
-                                return tokenizeSlashOrComment(src, pos);
+                                return crate::aver_generated::domain::lexer::tokenizeSlashOrComment(
+                                    src, pos,
+                                );
                             } else {
                                 if &*__dispatch_subject == "+" {
                                     return aver_rt::AverList::prepend(
                                         Token::TkPlus.clone(),
-                                        &tokenize(src, nextPos),
+                                        &crate::aver_generated::domain::lexer::tokenize(
+                                            src, nextPos,
+                                        ),
                                     );
                                 } else {
                                     if &*__dispatch_subject == "*" {
                                         return aver_rt::AverList::prepend(
                                             Token::TkStar.clone(),
-                                            &tokenize(src, nextPos),
+                                            &crate::aver_generated::domain::lexer::tokenize(
+                                                src, nextPos,
+                                            ),
                                         );
                                     } else {
                                         if &*__dispatch_subject == "<" {
-                                            return tokenizeLt(src, pos);
+                                            return crate::aver_generated::domain::lexer::tokenizeLt(
+                                                src, pos,
+                                            );
                                         } else {
                                             if &*__dispatch_subject == ">" {
-                                                return tokenizeGt(src, pos);
+                                                return crate::aver_generated::domain::lexer::tokenizeGt(src, pos);
                                             } else {
                                                 if &*__dispatch_subject == "!" {
-                                                    return tokenizeBang(src, pos);
+                                                    return crate::aver_generated::domain::lexer::tokenizeBang(src, pos);
                                                 } else {
                                                     if &*__dispatch_subject == "?" {
-                                                        return aver_rt::AverList::prepend(
-                                                            Token::TkQuestion.clone(),
-                                                            &tokenize(src, nextPos),
-                                                        );
+                                                        return aver_rt::AverList::prepend(Token::TkQuestion.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                     } else {
                                                         if &*__dispatch_subject == "\"" {
-                                                            return tokenizeString(
-                                                                src,
-                                                                nextPos,
-                                                                AverStr::from(""),
-                                                            );
+                                                            return crate::aver_generated::domain::lexer::tokenizeString(src, nextPos, AverStr::from(""));
                                                         } else {
                                                             if &*__dispatch_subject == "(" {
-                                                                return aver_rt::AverList::prepend(
-                                                                    Token::TkLParen.clone(),
-                                                                    &tokenize(src, nextPos),
-                                                                );
+                                                                return aver_rt::AverList::prepend(Token::TkLParen.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                             } else {
                                                                 if &*__dispatch_subject == ")" {
-                                                                    return aver_rt::AverList::prepend(Token::TkRParen.clone(), &tokenize(src, nextPos));
+                                                                    return aver_rt::AverList::prepend(Token::TkRParen.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                                 } else {
                                                                     if &*__dispatch_subject == "[" {
-                                                                        return aver_rt::AverList::prepend(Token::TkLBracket.clone(), &tokenize(src, nextPos));
+                                                                        return aver_rt::AverList::prepend(Token::TkLBracket.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                                     } else {
                                                                         if &*__dispatch_subject
                                                                             == "]"
                                                                         {
-                                                                            return aver_rt::AverList::prepend(Token::TkRBracket.clone(), &tokenize(src, nextPos));
+                                                                            return aver_rt::AverList::prepend(Token::TkRBracket.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                                         } else {
                                                                             if &*__dispatch_subject
                                                                                 == "."
                                                                             {
-                                                                                return tokenizeDot(
-                                                                                    src, pos,
-                                                                                );
+                                                                                return crate::aver_generated::domain::lexer::tokenizeDot(src, pos);
                                                                             } else {
-                                                                                if &*__dispatch_subject == "," { return aver_rt::AverList::prepend(Token::TkComma.clone(), &tokenize(src, nextPos)) } else { if &*__dispatch_subject == ":" { return aver_rt::AverList::prepend(Token::TkColon.clone(), &tokenize(src, nextPos)) } else { if &*__dispatch_subject == "=" { return tokenizeEq(src, pos) } else { if &*__dispatch_subject == "-" { return tokenizeMinus(src, pos) } else { __MutualTco2::TokenizeDefault(c, src, pos) } } } }
+                                                                                if &*__dispatch_subject == "," { return aver_rt::AverList::prepend(Token::TkComma.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if &*__dispatch_subject == ":" { return aver_rt::AverList::prepend(Token::TkColon.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if &*__dispatch_subject == "=" { return crate::aver_generated::domain::lexer::tokenizeEq(src, pos) } else { if &*__dispatch_subject == "-" { return crate::aver_generated::domain::lexer::tokenizeMinus(src, pos) } else { __MutualTco2::TokenizeDefault(c, src, pos) } } } }
                                                                             }
                                                                         }
                                                                     }
@@ -281,10 +279,14 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
             }
             __MutualTco3::TokenizeInterpExprC(mut src, mut pos, mut c) => {
                 crate::cancel_checkpoint();
-                if (c == closeBrace()) {
+                if (c == crate::aver_generated::domain::lexer::closeBrace()) {
                     return aver_rt::AverList::prepend(
                         Token::TkInterpEnd.clone(),
-                        &tokenizeString(src, (pos + 1i64), AverStr::from("")),
+                        &crate::aver_generated::domain::lexer::tokenizeString(
+                            src,
+                            (pos + 1i64),
+                            AverStr::from(""),
+                        ),
                     );
                 } else {
                     __MutualTco3::TokenizeInterpExprChar(src, pos, c)
@@ -293,7 +295,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
             __MutualTco3::TokenizeInterpExprChar(mut src, mut pos, mut c) => {
                 crate::cancel_checkpoint();
                 if crate::aver_generated::domain::lexer::chars::isDigit(c.clone()) {
-                    return tokenizeInterpDigit(src, pos);
+                    return crate::aver_generated::domain::lexer::tokenizeInterpDigit(src, pos);
                 } else {
                     __MutualTco3::TokenizeInterpNonDigit(src, pos, c)
                 }
@@ -317,63 +319,47 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                         if &*__dispatch_subject == "(" {
                             return aver_rt::AverList::prepend(
                                 Token::TkLParen.clone(),
-                                &tokenizeInterpExpr(src, nextPos),
+                                &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
+                                    src, nextPos,
+                                ),
                             );
                         } else {
                             if &*__dispatch_subject == ")" {
                                 return aver_rt::AverList::prepend(
                                     Token::TkRParen.clone(),
-                                    &tokenizeInterpExpr(src, nextPos),
+                                    &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
+                                        src, nextPos,
+                                    ),
                                 );
                             } else {
                                 if &*__dispatch_subject == "+" {
                                     return aver_rt::AverList::prepend(
                                         Token::TkPlus.clone(),
-                                        &tokenizeInterpExpr(src, nextPos),
+                                        &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
+                                            src, nextPos,
+                                        ),
                                     );
                                 } else {
                                     if &*__dispatch_subject == "-" {
-                                        return aver_rt::AverList::prepend(
-                                            Token::TkMinus.clone(),
-                                            &tokenizeInterpExpr(src, nextPos),
-                                        );
+                                        return aver_rt::AverList::prepend(Token::TkMinus.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                     } else {
                                         if &*__dispatch_subject == "*" {
-                                            return aver_rt::AverList::prepend(
-                                                Token::TkStar.clone(),
-                                                &tokenizeInterpExpr(src, nextPos),
-                                            );
+                                            return aver_rt::AverList::prepend(Token::TkStar.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                         } else {
                                             if &*__dispatch_subject == "," {
-                                                return aver_rt::AverList::prepend(
-                                                    Token::TkComma.clone(),
-                                                    &tokenizeInterpExpr(src, nextPos),
-                                                );
+                                                return aver_rt::AverList::prepend(Token::TkComma.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                             } else {
                                                 if &*__dispatch_subject == "." {
-                                                    return aver_rt::AverList::prepend(
-                                                        Token::TkDot.clone(),
-                                                        &tokenizeInterpExpr(src, nextPos),
-                                                    );
+                                                    return aver_rt::AverList::prepend(Token::TkDot.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                                 } else {
                                                     if &*__dispatch_subject == "[" {
-                                                        return aver_rt::AverList::prepend(
-                                                            Token::TkLBracket.clone(),
-                                                            &tokenizeInterpExpr(src, nextPos),
-                                                        );
+                                                        return aver_rt::AverList::prepend(Token::TkLBracket.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                                     } else {
                                                         if &*__dispatch_subject == "]" {
-                                                            return aver_rt::AverList::prepend(
-                                                                Token::TkRBracket.clone(),
-                                                                &tokenizeInterpExpr(src, nextPos),
-                                                            );
+                                                            return aver_rt::AverList::prepend(Token::TkRBracket.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                                         } else {
                                                             if &*__dispatch_subject == "\"" {
-                                                                return tokenizeInterpString(
-                                                                    src,
-                                                                    nextPos,
-                                                                    AverStr::from(""),
-                                                                );
+                                                                return crate::aver_generated::domain::lexer::tokenizeInterpString(src, nextPos, AverStr::from(""));
                                                             } else {
                                                                 __MutualTco3::TokenizeInterpExpr(
                                                                     src, nextPos,
@@ -406,7 +392,9 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                                     crate::aver_generated::domain::lexer::chars::keywordOrIdent(
                                         word,
                                     ),
-                                    &tokenizeInterpExpr(src, newPos),
+                                    &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
+                                        src, newPos,
+                                    ),
                                 );
                             }
                         }
@@ -471,7 +459,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
                 crate::cancel_checkpoint();
                 if (pos >= (src.chars().count() as i64)) {
                     return aver_rt::AverList::from_vec(vec![
-                        Token::TkStr(acc),
+                        crate::aver_generated::domain::token::Token::TkStr(acc),
                         Token::TkEof.clone(),
                     ]);
                 } else {
@@ -490,7 +478,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
                     }
                     None => {
                         return aver_rt::AverList::from_vec(vec![
-                            Token::TkStr(acc),
+                            crate::aver_generated::domain::token::Token::TkStr(acc),
                             Token::TkEof.clone(),
                         ]);
                     }
@@ -562,7 +550,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
                     }
                     None => {
                         return aver_rt::AverList::from_vec(vec![
-                            Token::TkStr(acc),
+                            crate::aver_generated::domain::token::Token::TkStr(acc),
                             Token::TkEof.clone(),
                         ]);
                     }
@@ -572,8 +560,8 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
                 crate::cancel_checkpoint();
                 if (&*c == "\"") {
                     return aver_rt::AverList::prepend(
-                        Token::TkStr(acc),
-                        &tokenize(src, (pos + 1i64)),
+                        crate::aver_generated::domain::token::Token::TkStr(acc),
+                        &crate::aver_generated::domain::lexer::tokenize(src, (pos + 1i64)),
                     );
                 } else {
                     __MutualTco4::TokenizeStringCharInner(src, pos, acc, c)
@@ -581,10 +569,10 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
             }
             __MutualTco4::TokenizeStringCharInner(mut src, mut pos, mut acc, mut c) => {
                 crate::cancel_checkpoint();
-                if (c == openBrace()) {
+                if (c == crate::aver_generated::domain::lexer::openBrace()) {
                     __MutualTco4::TokenizeStringMaybeEscapedBrace(src, pos, acc)
                 } else {
-                    if (c == closeBrace()) {
+                    if (c == crate::aver_generated::domain::lexer::closeBrace()) {
                         __MutualTco4::TokenizeStringMaybeEscapedClose(src, pos, acc)
                     } else {
                         __MutualTco4::TokenizeString(src, (pos + 1i64), (acc + &c))
@@ -596,22 +584,30 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
                 let nextPos = (pos + 1i64);
                 match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
                     Some(next) => {
-                        if (next == openBrace()) {
-                            __MutualTco4::TokenizeString(src, (pos + 2i64), (acc + &openBrace()))
+                        if (next == crate::aver_generated::domain::lexer::openBrace()) {
+                            __MutualTco4::TokenizeString(
+                                src,
+                                (pos + 2i64),
+                                (acc + &crate::aver_generated::domain::lexer::openBrace()),
+                            )
                         } else {
-                            return tokenizeInterp(src, pos, acc);
+                            return crate::aver_generated::domain::lexer::tokenizeInterp(
+                                src, pos, acc,
+                            );
                         }
                     }
-                    None => return tokenizeInterp(src, pos, acc),
+                    None => {
+                        return crate::aver_generated::domain::lexer::tokenizeInterp(src, pos, acc);
+                    }
                 }
             }
             __MutualTco4::TokenizeStringMaybeEscapedClose(mut src, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 let nextPos = (pos + 1i64);
-                let accBrace = (acc + &closeBrace());
+                let accBrace = (acc + &crate::aver_generated::domain::lexer::closeBrace());
                 match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
                     Some(next) => {
-                        if (next == closeBrace()) {
+                        if (next == crate::aver_generated::domain::lexer::closeBrace()) {
                             __MutualTco4::TokenizeString(src, (pos + 2i64), accBrace)
                         } else {
                             __MutualTco4::TokenizeString(src, nextPos, accBrace)
@@ -683,7 +679,7 @@ pub fn tokenizeDigit(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     {
         let (n, newPos) =
             crate::aver_generated::domain::lexer::chars::readNumber(src.clone(), pos, 0i64);
-        tokenizeAfterInt(src, newPos, n)
+        crate::aver_generated::domain::lexer::tokenizeAfterInt(src, newPos, n)
     }
 }
 
@@ -694,12 +690,18 @@ pub fn tokenizeAfterInt(src: AverStr, pos: i64, n: i64) -> aver_rt::AverList<Tok
     match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
         Some(c) => {
             if (c == AverStr::from(".")) {
-                tokenizeAfterIntDot(src, pos, n)
+                crate::aver_generated::domain::lexer::tokenizeAfterIntDot(src, pos, n)
             } else {
-                aver_rt::AverList::prepend(Token::TkInt(n), &tokenize(src, pos))
+                aver_rt::AverList::prepend(
+                    crate::aver_generated::domain::token::Token::TkInt(n),
+                    &crate::aver_generated::domain::lexer::tokenize(src, pos),
+                )
             }
         }
-        None => aver_rt::AverList::prepend(Token::TkInt(n), &tokenize(src, pos)),
+        None => aver_rt::AverList::prepend(
+            crate::aver_generated::domain::token::Token::TkInt(n),
+            &crate::aver_generated::domain::lexer::tokenize(src, pos),
+        ),
     }
 }
 
@@ -711,12 +713,18 @@ pub fn tokenizeAfterIntDot(src: AverStr, pos: i64, n: i64) -> aver_rt::AverList<
     match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
         Some(d) => {
             if crate::aver_generated::domain::lexer::chars::isDigit(d) {
-                tokenizeFloat(src, nextPos, n)
+                crate::aver_generated::domain::lexer::tokenizeFloat(src, nextPos, n)
             } else {
-                aver_rt::AverList::prepend(Token::TkInt(n), &tokenize(src, pos))
+                aver_rt::AverList::prepend(
+                    crate::aver_generated::domain::token::Token::TkInt(n),
+                    &crate::aver_generated::domain::lexer::tokenize(src, pos),
+                )
             }
         }
-        None => aver_rt::AverList::prepend(Token::TkInt(n), &tokenize(src, pos)),
+        None => aver_rt::AverList::prepend(
+            crate::aver_generated::domain::token::Token::TkInt(n),
+            &crate::aver_generated::domain::lexer::tokenize(src, pos),
+        ),
     }
 }
 
@@ -726,7 +734,13 @@ pub fn tokenizeFloat(src: AverStr, pos: i64, intPart: i64) -> aver_rt::AverList<
     {
         let (decPart, newPos) =
             crate::aver_generated::domain::lexer::chars::readNumber(src.clone(), pos, 0i64);
-        buildFloat(src, newPos.clone(), intPart, decPart, (newPos - pos))
+        crate::aver_generated::domain::lexer::buildFloat(
+            src,
+            newPos.clone(),
+            intPart,
+            decPart,
+            (newPos - pos),
+        )
     }
 }
 
@@ -739,15 +753,19 @@ pub fn buildFloat(
     decDigits: i64,
 ) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
-    let f = (intPart as f64 + (decPart as f64 / pow10(decDigits)));
-    aver_rt::AverList::prepend(Token::TkFloat(f), &tokenize(src, pos))
+    let f = (intPart as f64
+        + (decPart as f64 / crate::aver_generated::domain::lexer::pow10(decDigits)));
+    aver_rt::AverList::prepend(
+        crate::aver_generated::domain::token::Token::TkFloat(f),
+        &crate::aver_generated::domain::lexer::tokenize(src, pos),
+    )
 }
 
 /// Compute 10^n as Float.
 #[inline(always)]
 pub fn pow10(n: i64) -> f64 {
     crate::cancel_checkpoint();
-    pow10Acc(n, 1.0f64)
+    crate::aver_generated::domain::lexer::pow10Acc(n, 1.0f64)
 }
 
 /// Accumulate 10^n as Float.
@@ -774,7 +792,7 @@ pub fn pow10Acc(mut n: i64, mut acc: f64) -> f64 {
 pub fn tokenizeAlpha(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
     match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
-        Some(c) => tokenizeAlphaWith(
+        Some(c) => crate::aver_generated::domain::lexer::tokenizeAlphaWith(
             src,
             pos,
             crate::aver_generated::domain::lexer::chars::isUpper(c),
@@ -795,7 +813,7 @@ pub fn tokenizeAlphaWith(src: AverStr, pos: i64, dotted: bool) -> aver_rt::AverL
         );
         aver_rt::AverList::prepend(
             crate::aver_generated::domain::lexer::chars::keywordOrIdent(word),
-            &tokenize(src, newPos),
+            &crate::aver_generated::domain::lexer::tokenize(src, newPos),
         )
     }
 }
@@ -813,13 +831,22 @@ pub fn tokenizeMinus(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     let nextPos = (pos + 1i64);
     match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
         Some(c) => {
-            if isGreaterThan(c) {
-                aver_rt::AverList::prepend(Token::TkArrow.clone(), &tokenize(src, (pos + 2i64)))
+            if crate::aver_generated::domain::lexer::isGreaterThan(c) {
+                aver_rt::AverList::prepend(
+                    Token::TkArrow.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
+                )
             } else {
-                aver_rt::AverList::prepend(Token::TkMinus.clone(), &tokenize(src, nextPos))
+                aver_rt::AverList::prepend(
+                    Token::TkMinus.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+                )
             }
         }
-        None => aver_rt::AverList::prepend(Token::TkMinus.clone(), &tokenize(src, nextPos)),
+        None => aver_rt::AverList::prepend(
+            Token::TkMinus.clone(),
+            &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+        ),
     }
 }
 
@@ -837,10 +864,10 @@ pub fn openBrace() -> AverStr {
 pub fn tokenizeInterp(src: AverStr, pos: i64, acc: AverStr) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
     aver_rt::AverList::prepend(
-        Token::TkStr(acc),
+        crate::aver_generated::domain::token::Token::TkStr(acc),
         &aver_rt::AverList::prepend(
             Token::TkInterpStart.clone(),
-            &tokenizeInterpExpr(src, (pos + 1i64)),
+            &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, (pos + 1i64)),
         ),
     )
 }
@@ -865,14 +892,17 @@ pub fn tokenizeInterpString(
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
         return if (pos >= (src.chars().count() as i64)) {
-            aver_rt::AverList::prepend(Token::TkStr(acc), &tokenizeInterpExpr(src, pos))
+            aver_rt::AverList::prepend(
+                crate::aver_generated::domain::token::Token::TkStr(acc),
+                &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
+            )
         } else {
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
                     if (&*c == "\"") {
                         aver_rt::AverList::prepend(
-                            Token::TkStr(acc),
-                            &tokenizeInterpExpr(src, nextPos),
+                            crate::aver_generated::domain::token::Token::TkStr(acc),
+                            &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos),
                         )
                     } else {
                         {
@@ -883,9 +913,10 @@ pub fn tokenizeInterpString(
                         }
                     }
                 }
-                None => {
-                    aver_rt::AverList::prepend(Token::TkStr(acc), &tokenizeInterpExpr(src, pos))
-                }
+                None => aver_rt::AverList::prepend(
+                    crate::aver_generated::domain::token::Token::TkStr(acc),
+                    &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
+                ),
             }
         };
     }
@@ -897,7 +928,10 @@ pub fn tokenizeInterpDigit(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     {
         let (n, newPos) =
             crate::aver_generated::domain::lexer::chars::readNumber(src.clone(), pos, 0i64);
-        aver_rt::AverList::prepend(Token::TkInt(n), &tokenizeInterpExpr(src, newPos))
+        aver_rt::AverList::prepend(
+            crate::aver_generated::domain::token::Token::TkInt(n),
+            &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, newPos),
+        )
     }
 }
 
@@ -909,12 +943,18 @@ pub fn tokenizeSlashOrComment(src: AverStr, pos: i64) -> aver_rt::AverList<Token
     match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
         Some(c) => {
             if (c == AverStr::from("/")) {
-                skipLineComment(src, (pos + 2i64))
+                crate::aver_generated::domain::lexer::skipLineComment(src, (pos + 2i64))
             } else {
-                aver_rt::AverList::prepend(Token::TkSlash.clone(), &tokenize(src, nextPos))
+                aver_rt::AverList::prepend(
+                    Token::TkSlash.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+                )
             }
         }
-        None => aver_rt::AverList::prepend(Token::TkSlash.clone(), &tokenize(src, nextPos)),
+        None => aver_rt::AverList::prepend(
+            Token::TkSlash.clone(),
+            &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+        ),
     }
 }
 
@@ -930,7 +970,7 @@ pub fn skipLineComment(mut src: AverStr, mut pos: i64) -> aver_rt::AverList<Toke
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
                     if (&*c == "\n") {
-                        tokenizeNewline(src, nextPos)
+                        crate::aver_generated::domain::lexer::tokenizeNewline(src, nextPos)
                     } else {
                         {
                             pos = nextPos;
@@ -952,12 +992,21 @@ pub fn tokenizeDot(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
         Some(c) => {
             if (c == AverStr::from(".")) {
-                aver_rt::AverList::prepend(Token::TkDotDot.clone(), &tokenize(src, (pos + 2i64)))
+                aver_rt::AverList::prepend(
+                    Token::TkDotDot.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
+                )
             } else {
-                aver_rt::AverList::prepend(Token::TkDot.clone(), &tokenize(src, nextPos))
+                aver_rt::AverList::prepend(
+                    Token::TkDot.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+                )
             }
         }
-        None => aver_rt::AverList::prepend(Token::TkDot.clone(), &tokenize(src, nextPos)),
+        None => aver_rt::AverList::prepend(
+            Token::TkDot.clone(),
+            &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+        ),
     }
 }
 
@@ -969,12 +1018,21 @@ pub fn tokenizeLt(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
         Some(c) => {
             if (c == AverStr::from("=")) {
-                aver_rt::AverList::prepend(Token::TkLte.clone(), &tokenize(src, (pos + 2i64)))
+                aver_rt::AverList::prepend(
+                    Token::TkLte.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
+                )
             } else {
-                aver_rt::AverList::prepend(Token::TkLt.clone(), &tokenize(src, nextPos))
+                aver_rt::AverList::prepend(
+                    Token::TkLt.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+                )
             }
         }
-        None => aver_rt::AverList::prepend(Token::TkLt.clone(), &tokenize(src, nextPos)),
+        None => aver_rt::AverList::prepend(
+            Token::TkLt.clone(),
+            &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+        ),
     }
 }
 
@@ -986,12 +1044,21 @@ pub fn tokenizeGt(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
         Some(c) => {
             if (c == AverStr::from("=")) {
-                aver_rt::AverList::prepend(Token::TkGte.clone(), &tokenize(src, (pos + 2i64)))
+                aver_rt::AverList::prepend(
+                    Token::TkGte.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
+                )
             } else {
-                aver_rt::AverList::prepend(Token::TkGt.clone(), &tokenize(src, nextPos))
+                aver_rt::AverList::prepend(
+                    Token::TkGt.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+                )
             }
         }
-        None => aver_rt::AverList::prepend(Token::TkGt.clone(), &tokenize(src, nextPos)),
+        None => aver_rt::AverList::prepend(
+            Token::TkGt.clone(),
+            &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+        ),
     }
 }
 
@@ -1003,12 +1070,21 @@ pub fn tokenizeBang(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
         Some(c) => {
             if (c == AverStr::from("=")) {
-                aver_rt::AverList::prepend(Token::TkNeq.clone(), &tokenize(src, (pos + 2i64)))
+                aver_rt::AverList::prepend(
+                    Token::TkNeq.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
+                )
             } else {
-                aver_rt::AverList::prepend(Token::TkBang.clone(), &tokenize(src, nextPos))
+                aver_rt::AverList::prepend(
+                    Token::TkBang.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+                )
             }
         }
-        None => aver_rt::AverList::prepend(Token::TkBang.clone(), &tokenize(src, nextPos)),
+        None => aver_rt::AverList::prepend(
+            Token::TkBang.clone(),
+            &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+        ),
     }
 }
 
@@ -1022,30 +1098,42 @@ pub fn tokenizeEq(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
         Some(c) => {
             let __dispatch_subject = c;
             if &*__dispatch_subject == "=" {
-                aver_rt::AverList::prepend(Token::TkEqEq.clone(), &tokenize(src, pos2))
+                aver_rt::AverList::prepend(
+                    Token::TkEqEq.clone(),
+                    &crate::aver_generated::domain::lexer::tokenize(src, pos2),
+                )
             } else {
                 if &*__dispatch_subject == ">" {
-                    aver_rt::AverList::prepend(Token::TkFatArrow.clone(), &tokenize(src, pos2))
+                    aver_rt::AverList::prepend(
+                        Token::TkFatArrow.clone(),
+                        &crate::aver_generated::domain::lexer::tokenize(src, pos2),
+                    )
                 } else {
-                    aver_rt::AverList::prepend(Token::TkEq.clone(), &tokenize(src, nextPos))
+                    aver_rt::AverList::prepend(
+                        Token::TkEq.clone(),
+                        &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+                    )
                 }
             }
         }
-        None => aver_rt::AverList::prepend(Token::TkEq.clone(), &tokenize(src, nextPos)),
+        None => aver_rt::AverList::prepend(
+            Token::TkEq.clone(),
+            &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
+        ),
     }
 }
 
 /// Handle newline: count indent of next line, emit NEWLINE + raw indent marker.
 pub fn tokenizeNewline(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
-    let r = countIndent(src.clone(), pos, 0i64);
+    let r = crate::aver_generated::domain::lexer::countIndent(src.clone(), pos, 0i64);
     {
         let (indent, newPos) = r;
         aver_rt::AverList::prepend(
             Token::TkNewline.clone(),
             &aver_rt::AverList::prepend(
-                Token::TkInt(((0i64 - indent) - 1i64)),
-                &tokenize(src, newPos),
+                crate::aver_generated::domain::token::Token::TkInt(((0i64 - indent) - 1i64)),
+                &crate::aver_generated::domain::lexer::tokenize(src, newPos),
             ),
         )
     }
@@ -1054,8 +1142,11 @@ pub fn tokenizeNewline(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
 /// Tokenize a complete source string with INDENT/DEDENT.
 pub fn lex(src: AverStr) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
-    let raw = tokenize(src, 0i64);
-    let processed = processIndentation(&raw, &aver_rt::AverList::from_vec(vec![0i64]));
+    let raw = crate::aver_generated::domain::lexer::tokenize(src, 0i64);
+    let processed = crate::aver_generated::domain::lexer::processIndentation(
+        &raw,
+        &aver_rt::AverList::from_vec(vec![0i64]),
+    );
     processed
 }
 
@@ -1066,7 +1157,7 @@ pub fn processIndentation(
     stack: &aver_rt::AverList<i64>,
 ) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
-    aver_list_match!(tokens.clone(), [] => emitFinalDedents(stack), [t, rest] => processIndentToken(&t, &rest, stack))
+    aver_list_match!(tokens.clone(), [] => crate::aver_generated::domain::lexer::emitFinalDedents(stack), [t, rest] => crate::aver_generated::domain::lexer::processIndentToken(&t, &rest, stack))
 }
 
 /// Process one token in the indentation pass.
@@ -1077,12 +1168,17 @@ pub fn processIndentToken(
 ) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
     match t {
-        Token::TkNewline => processAfterNewline(rest, stack),
-        Token::TkEof => aver_rt::AverList::concat(
-            &emitFinalDedents(stack),
+        crate::aver_generated::domain::token::Token::TkNewline => {
+            crate::aver_generated::domain::lexer::processAfterNewline(rest, stack)
+        }
+        crate::aver_generated::domain::token::Token::TkEof => aver_rt::AverList::concat(
+            &crate::aver_generated::domain::lexer::emitFinalDedents(stack),
             &aver_rt::AverList::from_vec(vec![Token::TkEof.clone()]),
         ),
-        _ => aver_rt::AverList::prepend(t.clone(), &processIndentation(rest, stack)),
+        _ => aver_rt::AverList::prepend(
+            t.clone(),
+            &crate::aver_generated::domain::lexer::processIndentation(rest, stack),
+        ),
     }
 }
 
@@ -1093,7 +1189,7 @@ pub fn processAfterNewline(
     stack: &aver_rt::AverList<i64>,
 ) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
-    aver_list_match!(tokens.clone(), [] => aver_rt::AverList::prepend(Token::TkNewline.clone(), &emitFinalDedents(stack)), [t, rest] => processAfterNewlineToken(&t, &rest, stack))
+    aver_list_match!(tokens.clone(), [] => aver_rt::AverList::prepend(Token::TkNewline.clone(), &crate::aver_generated::domain::lexer::emitFinalDedents(stack)), [t, rest] => crate::aver_generated::domain::lexer::processAfterNewlineToken(&t, &rest, stack))
 }
 
 /// Check if token after newline is a raw indent marker.
@@ -1104,19 +1200,29 @@ pub fn processAfterNewlineToken(
 ) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
     match t.clone() {
-        Token::TkInt(n) => {
+        crate::aver_generated::domain::token::Token::TkInt(n) => {
             if (n < 0i64) {
-                emitIndentChange(((0i64 - n) - 1i64), rest, stack)
+                crate::aver_generated::domain::lexer::emitIndentChange(
+                    ((0i64 - n) - 1i64),
+                    rest,
+                    stack,
+                )
             } else {
                 aver_rt::AverList::prepend(
                     Token::TkNewline.clone(),
-                    &aver_rt::AverList::prepend(t.clone(), &processIndentation(rest, stack)),
+                    &aver_rt::AverList::prepend(
+                        t.clone(),
+                        &crate::aver_generated::domain::lexer::processIndentation(rest, stack),
+                    ),
                 )
             }
         }
         _ => aver_rt::AverList::prepend(
             Token::TkNewline.clone(),
-            &aver_rt::AverList::prepend(t.clone(), &processIndentation(rest, stack)),
+            &aver_rt::AverList::prepend(
+                t.clone(),
+                &crate::aver_generated::domain::lexer::processIndentation(rest, stack),
+            ),
         ),
     }
 }
@@ -1129,20 +1235,26 @@ pub fn emitIndentChange(
     stack: &aver_rt::AverList<i64>,
 ) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
-    let currentIndent = stackTop(stack);
+    let currentIndent = crate::aver_generated::domain::lexer::stackTop(stack);
     if (indent > currentIndent) {
         aver_rt::AverList::prepend(
             Token::TkNewline.clone(),
             &aver_rt::AverList::prepend(
                 Token::TkIndent.clone(),
-                &processIndentation(rest, &aver_rt::AverList::prepend(indent, &stack.clone())),
+                &crate::aver_generated::domain::lexer::processIndentation(
+                    rest,
+                    &aver_rt::AverList::prepend(indent, &stack.clone()),
+                ),
             ),
         )
     } else {
         if (indent < currentIndent) {
-            emitDedents(indent, rest, stack)
+            crate::aver_generated::domain::lexer::emitDedents(indent, rest, stack)
         } else {
-            aver_rt::AverList::prepend(Token::TkNewline.clone(), &processIndentation(rest, stack))
+            aver_rt::AverList::prepend(
+                Token::TkNewline.clone(),
+                &crate::aver_generated::domain::lexer::processIndentation(rest, stack),
+            )
         }
     }
 }
@@ -1154,7 +1266,7 @@ pub fn emitDedents(
     stack: &aver_rt::AverList<i64>,
 ) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
-    emitDedentsAcc(
+    crate::aver_generated::domain::lexer::emitDedentsAcc(
         targetIndent,
         rest.clone(),
         stack.clone(),
@@ -1173,7 +1285,7 @@ pub fn emitDedentsAcc(
     loop {
         crate::cancel_checkpoint();
         let reversed = acc.reverse();
-        return aver_list_match!(stack.clone(), [] => aver_rt::AverList::concat(&reversed, &processIndentation(&rest, &aver_rt::AverList::from_vec(vec![0i64]))), [top, below] => { if (top <= targetIndent) { aver_rt::AverList::concat(&reversed, &aver_rt::AverList::prepend(Token::TkNewline.clone(), &processIndentation(&rest, &stack))) } else { {
+        return aver_list_match!(stack.clone(), [] => aver_rt::AverList::concat(&reversed, &crate::aver_generated::domain::lexer::processIndentation(&rest, &aver_rt::AverList::from_vec(vec![0i64]))), [top, below] => { if (top <= targetIndent) { aver_rt::AverList::concat(&reversed, &aver_rt::AverList::prepend(Token::TkNewline.clone(), &crate::aver_generated::domain::lexer::processIndentation(&rest, &stack))) } else { {
             let __tmp3 = aver_rt::AverList::prepend(Token::TkDedent.clone(), &acc);
             stack = below;
             acc = __tmp3;
@@ -1186,7 +1298,10 @@ pub fn emitDedentsAcc(
 #[inline(always)]
 pub fn emitFinalDedents(stack: &aver_rt::AverList<i64>) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
-    emitFinalDedentsAcc(stack.clone(), aver_rt::AverList::empty())
+    crate::aver_generated::domain::lexer::emitFinalDedentsAcc(
+        stack.clone(),
+        aver_rt::AverList::empty(),
+    )
 }
 
 /// Accumulate DEDENT tokens for each indent level above 0.

--- a/src/self_host/aver_generated/domain/match_mod/mod.rs
+++ b/src/self_host/aver_generated/domain/match_mod/mod.rs
@@ -38,7 +38,7 @@ fn __mutual_tco_trampoline_1(
                 mut acc,
             ) => {
                 crate::cancel_checkpoint();
-                let bindings = matchPattern(&pat, &item)?;
+                let bindings = crate::aver_generated::domain::match_mod::matchPattern(&pat, &item)?;
                 __MutualTco1::MatchPatTupleItemsAcc(
                     restPats,
                     restItems,
@@ -83,19 +83,39 @@ pub fn matchPatTupleOne(
 pub fn matchPattern(pat: &Pattern, v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match pat.clone() {
-        Pattern::PatWild => Ok(aver_rt::AverList::empty()),
-        Pattern::PatInt(n) => matchPatInt(n, v),
-        Pattern::PatFloat(f) => matchPatFloat(f, v),
-        Pattern::PatBool(b) => matchPatBool(b, v),
-        Pattern::PatStr(s) => matchPatStr(s, v),
-        Pattern::PatEmpty => matchPatEmpty(v),
-        Pattern::PatCons(h, t) => matchPatCons(h, t, v),
-        Pattern::PatConstructor(ctorName, bindings) => matchPatConstructor(ctorName, &bindings, v),
-        Pattern::PatConstructorId(tag, ctorName, bindings) => {
-            matchPatConstructorById(tag, ctorName, &bindings, v)
+        crate::aver_generated::domain::ast::Pattern::PatWild => Ok(aver_rt::AverList::empty()),
+        crate::aver_generated::domain::ast::Pattern::PatInt(n) => {
+            crate::aver_generated::domain::match_mod::matchPatInt(n, v)
         }
-        Pattern::PatTuple(pats) => matchPatTuple(&pats, v),
-        Pattern::PatVar(name) => Ok(aver_rt::AverList::from_vec(vec![(name, v.clone())])),
+        crate::aver_generated::domain::ast::Pattern::PatFloat(f) => {
+            crate::aver_generated::domain::match_mod::matchPatFloat(f, v)
+        }
+        crate::aver_generated::domain::ast::Pattern::PatBool(b) => {
+            crate::aver_generated::domain::match_mod::matchPatBool(b, v)
+        }
+        crate::aver_generated::domain::ast::Pattern::PatStr(s) => {
+            crate::aver_generated::domain::match_mod::matchPatStr(s, v)
+        }
+        crate::aver_generated::domain::ast::Pattern::PatEmpty => {
+            crate::aver_generated::domain::match_mod::matchPatEmpty(v)
+        }
+        crate::aver_generated::domain::ast::Pattern::PatCons(h, t) => {
+            crate::aver_generated::domain::match_mod::matchPatCons(h, t, v)
+        }
+        crate::aver_generated::domain::ast::Pattern::PatConstructor(ctorName, bindings) => {
+            crate::aver_generated::domain::match_mod::matchPatConstructor(ctorName, &bindings, v)
+        }
+        crate::aver_generated::domain::ast::Pattern::PatConstructorId(tag, ctorName, bindings) => {
+            crate::aver_generated::domain::match_mod::matchPatConstructorById(
+                tag, ctorName, &bindings, v,
+            )
+        }
+        crate::aver_generated::domain::ast::Pattern::PatTuple(pats) => {
+            crate::aver_generated::domain::match_mod::matchPatTuple(&pats, v)
+        }
+        crate::aver_generated::domain::ast::Pattern::PatVar(name) => {
+            Ok(aver_rt::AverList::from_vec(vec![(name, v.clone())]))
+        }
     }
 }
 
@@ -103,7 +123,7 @@ pub fn matchPattern(pat: &Pattern, v: &Val) -> Result<aver_rt::AverList<(AverStr
 pub fn matchPatInt(n: i64, v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValInt(m) => {
+        crate::aver_generated::domain::value::Val::ValInt(m) => {
             if (n == m) {
                 Ok(aver_rt::AverList::empty())
             } else {
@@ -118,7 +138,7 @@ pub fn matchPatInt(n: i64, v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)>,
 pub fn matchPatFloat(f: f64, v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValFloat(vf) => {
+        crate::aver_generated::domain::value::Val::ValFloat(vf) => {
             if (f == vf) {
                 Ok(aver_rt::AverList::empty())
             } else {
@@ -133,7 +153,7 @@ pub fn matchPatFloat(f: f64, v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)
 pub fn matchPatBool(b: bool, v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValBool(vb) => {
+        crate::aver_generated::domain::value::Val::ValBool(vb) => {
             if (b == vb) {
                 Ok(aver_rt::AverList::empty())
             } else {
@@ -148,7 +168,7 @@ pub fn matchPatBool(b: bool, v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)
 pub fn matchPatStr(s: AverStr, v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValStr(vs) => {
+        crate::aver_generated::domain::value::Val::ValStr(vs) => {
             if (s == vs) {
                 Ok(aver_rt::AverList::empty())
             } else {
@@ -163,7 +183,7 @@ pub fn matchPatStr(s: AverStr, v: &Val) -> Result<aver_rt::AverList<(AverStr, Va
 pub fn matchPatEmpty(v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValList(items) => {
+        crate::aver_generated::domain::value::Val::ValList(items) => {
             let __list_subject = items;
             if __list_subject.is_empty() {
                 Ok(aver_rt::AverList::empty())
@@ -183,8 +203,8 @@ pub fn matchPatCons(
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValList(items) => {
-            aver_list_match!(items, [] => Err(AverStr::from("no match")), [head, tail] => Ok(aver_rt::AverList::from_vec(vec![(h, head), (t, Val::ValList(tail))])))
+        crate::aver_generated::domain::value::Val::ValList(items) => {
+            aver_list_match!(items, [] => Err(AverStr::from("no match")), [head, tail] => Ok(aver_rt::AverList::from_vec(vec![(h, head), (t, crate::aver_generated::domain::value::Val::ValList(tail))])))
         }
         _ => Err(AverStr::from("no match")),
     }
@@ -201,18 +221,32 @@ pub fn matchPatConstructor(
     {
         let __dispatch_subject = ctorName.clone();
         if &*__dispatch_subject == "Result.Ok" {
-            matchWrapperPat(v, AverStr::from("Ok"), bindings)
+            crate::aver_generated::domain::match_mod::matchWrapperPat(
+                v,
+                AverStr::from("Ok"),
+                bindings,
+            )
         } else {
             if &*__dispatch_subject == "Result.Err" {
-                matchWrapperPat(v, AverStr::from("Err"), bindings)
+                crate::aver_generated::domain::match_mod::matchWrapperPat(
+                    v,
+                    AverStr::from("Err"),
+                    bindings,
+                )
             } else {
                 if &*__dispatch_subject == "Option.Some" {
-                    matchWrapperPat(v, AverStr::from("Some"), bindings)
+                    crate::aver_generated::domain::match_mod::matchWrapperPat(
+                        v,
+                        AverStr::from("Some"),
+                        bindings,
+                    )
                 } else {
                     if &*__dispatch_subject == "Option.None" {
-                        matchNonePat(v)
+                        crate::aver_generated::domain::match_mod::matchNonePat(v)
                     } else {
-                        matchGenericConstructor(ctorName, bindings, v)
+                        crate::aver_generated::domain::match_mod::matchGenericConstructor(
+                            ctorName, bindings, v,
+                        )
                     }
                 }
             }
@@ -227,7 +261,9 @@ pub fn matchPatTuple(
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValTuple(items) => matchPatTupleItems(pats, &items),
+        crate::aver_generated::domain::value::Val::ValTuple(items) => {
+            crate::aver_generated::domain::match_mod::matchPatTupleItems(pats, &items)
+        }
         _ => Err(AverStr::from("no match")),
     }
 }
@@ -238,7 +274,11 @@ pub fn matchPatTupleItems(
     items: &aver_rt::AverList<Val>,
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
-    matchPatTupleItemsAcc(pats, items, &aver_rt::AverList::empty())
+    crate::aver_generated::domain::match_mod::matchPatTupleItemsAcc(
+        pats,
+        items,
+        &aver_rt::AverList::empty(),
+    )
 }
 
 /// Match a generic variant constructor pattern using the full name stored in the value.
@@ -249,8 +289,10 @@ pub fn matchGenericConstructor(
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValVariant(_, fullName, fields) => {
-            matchGenericCtorCheck(ctorName, fullName, bindings, &fields)
+        crate::aver_generated::domain::value::Val::ValVariant(_, fullName, fields) => {
+            crate::aver_generated::domain::match_mod::matchGenericCtorCheck(
+                ctorName, fullName, bindings, &fields,
+            )
         }
         _ => Err(AverStr::from("no match")),
     }
@@ -266,7 +308,9 @@ pub fn matchGenericCtorCheck(
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     if (fullName == ctorName) {
-        Ok(zipBindings(bindings, fields))
+        Ok(crate::aver_generated::domain::match_mod::zipBindings(
+            bindings, fields,
+        ))
     } else {
         Err(AverStr::from("no match"))
     }
@@ -284,18 +328,22 @@ pub fn matchPatConstructorById(
     {
         let __dispatch_subject = tag;
         if __dispatch_subject == 1i64 {
-            matchWrapperPatDirect(v, 1i64, bindings)
+            crate::aver_generated::domain::match_mod::matchWrapperPatDirect(v, 1i64, bindings)
         } else {
             if __dispatch_subject == 2i64 {
-                matchWrapperPatDirect(v, 2i64, bindings)
+                crate::aver_generated::domain::match_mod::matchWrapperPatDirect(v, 2i64, bindings)
             } else {
                 if __dispatch_subject == 3i64 {
-                    matchWrapperPatDirect(v, 3i64, bindings)
+                    crate::aver_generated::domain::match_mod::matchWrapperPatDirect(
+                        v, 3i64, bindings,
+                    )
                 } else {
                     if __dispatch_subject == 4i64 {
-                        matchNonePat(v)
+                        crate::aver_generated::domain::match_mod::matchNonePat(v)
                     } else {
-                        matchGenericCtorById(tag, ctorName, bindings, v)
+                        crate::aver_generated::domain::match_mod::matchGenericCtorById(
+                            tag, ctorName, bindings, v,
+                        )
                     }
                 }
             }
@@ -315,9 +363,9 @@ pub fn matchWrapperPatDirect(
         let __dispatch_subject = tag;
         if __dispatch_subject == 1i64 {
             match v.clone() {
-                Val::ValOk(inner) => {
+                crate::aver_generated::domain::value::Val::ValOk(inner) => {
                     let inner = (*inner).clone();
-                    Ok(zipBindings(
+                    Ok(crate::aver_generated::domain::match_mod::zipBindings(
                         bindings,
                         &aver_rt::AverList::from_vec(vec![inner]),
                     ))
@@ -327,9 +375,9 @@ pub fn matchWrapperPatDirect(
         } else {
             if __dispatch_subject == 2i64 {
                 match v.clone() {
-                    Val::ValErr(inner) => {
+                    crate::aver_generated::domain::value::Val::ValErr(inner) => {
                         let inner = (*inner).clone();
-                        Ok(zipBindings(
+                        Ok(crate::aver_generated::domain::match_mod::zipBindings(
                             bindings,
                             &aver_rt::AverList::from_vec(vec![inner]),
                         ))
@@ -339,9 +387,9 @@ pub fn matchWrapperPatDirect(
             } else {
                 if __dispatch_subject == 3i64 {
                     match v.clone() {
-                        Val::ValSome(inner) => {
+                        crate::aver_generated::domain::value::Val::ValSome(inner) => {
                             let inner = (*inner).clone();
-                            Ok(zipBindings(
+                            Ok(crate::aver_generated::domain::match_mod::zipBindings(
                                 bindings,
                                 &aver_rt::AverList::from_vec(vec![inner]),
                             ))
@@ -365,10 +413,12 @@ pub fn matchGenericCtorById(
 ) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValVariant(vTag, fullName, fields) => {
+        crate::aver_generated::domain::value::Val::ValVariant(vTag, fullName, fields) => {
             if (vTag == tag) {
                 if (fullName == ctorName) {
-                    Ok(zipBindings(bindings, &fields))
+                    Ok(crate::aver_generated::domain::match_mod::zipBindings(
+                        bindings, &fields,
+                    ))
                 } else {
                     Err(AverStr::from("no match"))
                 }
@@ -384,7 +434,7 @@ pub fn matchGenericCtorById(
 pub fn matchNonePat(v: &Val) -> Result<aver_rt::AverList<(AverStr, Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v {
-        Val::ValNone => Ok(aver_rt::AverList::empty()),
+        crate::aver_generated::domain::value::Val::ValNone => Ok(aver_rt::AverList::empty()),
         _ => Err(AverStr::from("no match")),
     }
 }
@@ -401,9 +451,9 @@ pub fn matchWrapperPat(
         let __dispatch_subject = tag;
         if &*__dispatch_subject == "Ok" {
             match v.clone() {
-                Val::ValOk(inner) => {
+                crate::aver_generated::domain::value::Val::ValOk(inner) => {
                     let inner = (*inner).clone();
-                    Ok(zipBindings(
+                    Ok(crate::aver_generated::domain::match_mod::zipBindings(
                         bindings,
                         &aver_rt::AverList::from_vec(vec![inner]),
                     ))
@@ -413,9 +463,9 @@ pub fn matchWrapperPat(
         } else {
             if &*__dispatch_subject == "Err" {
                 match v.clone() {
-                    Val::ValErr(inner) => {
+                    crate::aver_generated::domain::value::Val::ValErr(inner) => {
                         let inner = (*inner).clone();
-                        Ok(zipBindings(
+                        Ok(crate::aver_generated::domain::match_mod::zipBindings(
                             bindings,
                             &aver_rt::AverList::from_vec(vec![inner]),
                         ))
@@ -425,9 +475,9 @@ pub fn matchWrapperPat(
             } else {
                 if &*__dispatch_subject == "Some" {
                     match v.clone() {
-                        Val::ValSome(inner) => {
+                        crate::aver_generated::domain::value::Val::ValSome(inner) => {
                             let inner = (*inner).clone();
-                            Ok(zipBindings(
+                            Ok(crate::aver_generated::domain::match_mod::zipBindings(
                                 bindings,
                                 &aver_rt::AverList::from_vec(vec![inner]),
                             ))
@@ -449,7 +499,11 @@ pub fn zipBindings(
     vals: &aver_rt::AverList<Val>,
 ) -> aver_rt::AverList<(AverStr, Val)> {
     crate::cancel_checkpoint();
-    zipBindingsAcc(names.clone(), vals.clone(), aver_rt::AverList::empty())
+    crate::aver_generated::domain::match_mod::zipBindingsAcc(
+        names.clone(),
+        vals.clone(),
+        aver_rt::AverList::empty(),
+    )
 }
 
 /// Accumulate binding pairs in reverse, then reverse at end.

--- a/src/self_host/aver_generated/domain/parser/expr/mod.rs
+++ b/src/self_host/aver_generated/domain/parser/expr/mod.rs
@@ -21,21 +21,25 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> Result<(Expr, i64), A
                 let nextPos = (pos + 1i64);
                 let t = crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos);
                 match t {
-                    Token::TkPlus => __MutualTco1::ParseAddExprRight(tokens, nextPos, left, 0i64),
-                    Token::TkMinus => __MutualTco1::ParseAddExprRight(tokens, nextPos, left, 1i64),
+                    crate::aver_generated::domain::token::Token::TkPlus => {
+                        __MutualTco1::ParseAddExprRight(tokens, nextPos, left, 0i64)
+                    }
+                    crate::aver_generated::domain::token::Token::TkMinus => {
+                        __MutualTco1::ParseAddExprRight(tokens, nextPos, left, 1i64)
+                    }
                     _ => return Ok((left, pos)),
                 }
             }
             __MutualTco1::ParseAddExprRight(mut tokens, mut pos, mut left, mut op) => {
                 crate::cancel_checkpoint();
-                let r = parseMulExpr(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::expr::parseMulExpr(&tokens, pos)?;
                 match r {
                     (right, pos2) => {
                         if (op == 0i64) {
                             __MutualTco1::ParseAddExprTail(
                                 tokens,
                                 pos2,
-                                Expr::ExprAdd(
+                                crate::aver_generated::domain::ast::Expr::ExprAdd(
                                     std::sync::Arc::new(left),
                                     std::sync::Arc::new(right),
                                 ),
@@ -44,7 +48,7 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> Result<(Expr, i64), A
                             __MutualTco1::ParseAddExprTail(
                                 tokens,
                                 pos2,
-                                Expr::ExprSub(
+                                crate::aver_generated::domain::ast::Expr::ExprSub(
                                     std::sync::Arc::new(left),
                                     std::sync::Arc::new(right),
                                 ),
@@ -119,7 +123,7 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> Result<(Expr, i64), A
         __state = match __state {
             __MutualTco2::ParseCallArgsList(mut tokens, mut pos, mut name, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = parseExpr(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
                 match r {
                     (expr, pos2) => __MutualTco2::ParseCallArgsListTail(
                         tokens,
@@ -131,16 +135,27 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> Result<(Expr, i64), A
             }
             __MutualTco2::ParseCallArgsListTail(mut tokens, mut pos0, mut name, mut args) => {
                 crate::cancel_checkpoint();
-                let pos = skipNl(tokens.clone(), pos0);
+                let pos = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos0);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos.clone()) {
-                    Token::TkComma => __MutualTco2::ParseCallArgsAfterComma(
-                        tokens.clone(),
-                        skipNl(tokens, (pos + 1i64)),
-                        name,
-                        args,
-                    ),
-                    Token::TkRParen => {
-                        return Ok((Expr::ExprCall(name, args.reverse()), (pos + 1i64)));
+                    crate::aver_generated::domain::token::Token::TkComma => {
+                        __MutualTco2::ParseCallArgsAfterComma(
+                            tokens.clone(),
+                            crate::aver_generated::domain::parser::expr::skipNl(
+                                tokens,
+                                (pos + 1i64),
+                            ),
+                            name,
+                            args,
+                        )
+                    }
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Expr::ExprCall(
+                                name,
+                                args.reverse(),
+                            ),
+                            (pos + 1i64),
+                        ));
                     }
                     _ => return Err(AverStr::from("Expected ',' or ')' in argument list")),
                 }
@@ -148,10 +163,16 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> Result<(Expr, i64), A
             __MutualTco2::ParseCallArgsAfterComma(mut tokens, mut pos, mut name, mut args) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkRParen => {
-                        return Ok((Expr::ExprCall(name, args.reverse()), (pos + 1i64)));
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Expr::ExprCall(
+                                name,
+                                args.reverse(),
+                            ),
+                            (pos + 1i64),
+                        ));
                     }
-                    Token::TkIdent(field) => {
+                    crate::aver_generated::domain::token::Token::TkIdent(field) => {
                         __MutualTco2::ParseCallArgsCheckNamed(tokens, pos, name, args, field)
                     }
                     _ => __MutualTco2::ParseCallArgsList(tokens, pos, name, args),
@@ -166,8 +187,8 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> Result<(Expr, i64), A
             ) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, (pos + 1i64)) {
-                    Token::TkEq => {
-                        return parseNamedArgs(
+                    crate::aver_generated::domain::token::Token::TkEq => {
+                        return crate::aver_generated::domain::parser::expr::parseNamedArgs(
                             &tokens,
                             pos,
                             name,
@@ -256,18 +277,25 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<(Expr, i64), A
             __MutualTco3::ParseFieldAccess(mut tokens, mut pos, mut obj) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkIdent(field) => __MutualTco3::ParseFieldAccessTail(
-                        tokens,
-                        (pos + 1i64),
-                        Expr::ExprFieldAccess(std::sync::Arc::new(obj), field),
-                    ),
+                    crate::aver_generated::domain::token::Token::TkIdent(field) => {
+                        __MutualTco3::ParseFieldAccessTail(
+                            tokens,
+                            (pos + 1i64),
+                            crate::aver_generated::domain::ast::Expr::ExprFieldAccess(
+                                std::sync::Arc::new(obj),
+                                field,
+                            ),
+                        )
+                    }
                     _ => return Err(AverStr::from("Expected field name after '.'")),
                 }
             }
             __MutualTco3::ParseFieldAccessTail(mut tokens, mut pos, mut expr) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkDot => __MutualTco3::ParseFieldAccess(tokens, (pos + 1i64), expr),
+                    crate::aver_generated::domain::token::Token::TkDot => {
+                        __MutualTco3::ParseFieldAccess(tokens, (pos + 1i64), expr)
+                    }
                     _ => return Ok((expr, pos)),
                 }
             }
@@ -314,7 +342,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<(Expr, i64), A
         __state = match __state {
             __MutualTco4::ParseInterpParts(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = parseExpr(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
                 match r {
                     (expr, pos2) => __MutualTco4::ParseInterpAfterExpr(
                         tokens,
@@ -326,7 +354,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<(Expr, i64), A
             __MutualTco4::ParseInterpAfterExpr(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkInterpEnd => {
+                    crate::aver_generated::domain::token::Token::TkInterpEnd => {
                         __MutualTco4::ParseInterpContinue(tokens, (pos + 1i64), acc)
                     }
                     _ => return Err(AverStr::from("Expected } in string interpolation")),
@@ -336,22 +364,39 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<(Expr, i64), A
                 crate::cancel_checkpoint();
                 let nextPos = (pos + 1i64);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkStr(s) => __MutualTco4::ParseInterpAfterStr(
-                        tokens,
-                        nextPos,
-                        aver_rt::AverList::prepend(Expr::ExprStr(s), &acc),
-                    ),
-                    Token::TkInterpStart => __MutualTco4::ParseInterpParts(tokens, nextPos, acc),
-                    _ => return Ok((Expr::ExprConcat(acc.reverse()), pos)),
+                    crate::aver_generated::domain::token::Token::TkStr(s) => {
+                        __MutualTco4::ParseInterpAfterStr(
+                            tokens,
+                            nextPos,
+                            aver_rt::AverList::prepend(
+                                crate::aver_generated::domain::ast::Expr::ExprStr(s),
+                                &acc,
+                            ),
+                        )
+                    }
+                    crate::aver_generated::domain::token::Token::TkInterpStart => {
+                        __MutualTco4::ParseInterpParts(tokens, nextPos, acc)
+                    }
+                    _ => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Expr::ExprConcat(acc.reverse()),
+                            pos,
+                        ));
+                    }
                 }
             }
             __MutualTco4::ParseInterpAfterStr(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkInterpStart => {
+                    crate::aver_generated::domain::token::Token::TkInterpStart => {
                         __MutualTco4::ParseInterpParts(tokens, (pos + 1i64), acc)
                     }
-                    _ => return Ok((Expr::ExprConcat(acc.reverse()), pos)),
+                    _ => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Expr::ExprConcat(acc.reverse()),
+                            pos,
+                        ));
+                    }
                 }
             }
         };
@@ -422,7 +467,7 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> Result<(Expr, i64), A
         __state = match __state {
             __MutualTco5::ParseListItems(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = parseExpr(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
                 match r {
                     (expr, pos2) => __MutualTco5::ParseListItemsTail(
                         tokens,
@@ -433,15 +478,23 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> Result<(Expr, i64), A
             }
             __MutualTco5::ParseListItemsTail(mut tokens, mut pos0, mut items) => {
                 crate::cancel_checkpoint();
-                let pos = skipNl(tokens.clone(), pos0);
+                let pos = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos0);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos.clone()) {
-                    Token::TkComma => __MutualTco5::ParseListAfterComma(
-                        tokens.clone(),
-                        skipNl(tokens, (pos + 1i64)),
-                        items,
-                    ),
-                    Token::TkRBracket => {
-                        return Ok((Expr::ExprList(items.reverse()), (pos + 1i64)));
+                    crate::aver_generated::domain::token::Token::TkComma => {
+                        __MutualTco5::ParseListAfterComma(
+                            tokens.clone(),
+                            crate::aver_generated::domain::parser::expr::skipNl(
+                                tokens,
+                                (pos + 1i64),
+                            ),
+                            items,
+                        )
+                    }
+                    crate::aver_generated::domain::token::Token::TkRBracket => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Expr::ExprList(items.reverse()),
+                            (pos + 1i64),
+                        ));
                     }
                     _ => return Err(AverStr::from("Expected ',' or ']' in list literal")),
                 }
@@ -449,7 +502,12 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> Result<(Expr, i64), A
             __MutualTco5::ParseListAfterComma(mut tokens, mut pos, mut items) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkRBracket => return Ok((Expr::ExprList(items), (pos + 1i64))),
+                    crate::aver_generated::domain::token::Token::TkRBracket => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Expr::ExprList(items),
+                            (pos + 1i64),
+                        ));
+                    }
                     _ => __MutualTco5::ParseListItems(tokens, pos, items),
                 }
             }
@@ -508,7 +566,7 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<(Expr, i64), A
         __state = match __state {
             __MutualTco6::ParseMapEntries(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let kr = parseExpr(&tokens, pos)?;
+                let kr = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
                 match kr {
                     (keyExpr, pos2) => __MutualTco6::ParseMapAfterKey(tokens, pos2, acc, keyExpr),
                 }
@@ -520,13 +578,15 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<(Expr, i64), A
                     pos,
                     &Token::TkFatArrow,
                 )?;
-                let vr = parseExpr(&tokens, pos2)?;
+                let vr = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
                 match vr {
                     (valExpr, pos3) => __MutualTco6::ParseMapEntryTail(
                         tokens,
                         pos3,
                         aver_rt::AverList::prepend(
-                            Expr::ExprTuple(aver_rt::AverList::from_vec(vec![keyExpr, valExpr])),
+                            crate::aver_generated::domain::ast::Expr::ExprTuple(
+                                aver_rt::AverList::from_vec(vec![keyExpr, valExpr]),
+                            ),
                             &acc,
                         ),
                     ),
@@ -534,18 +594,27 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<(Expr, i64), A
             }
             __MutualTco6::ParseMapEntryTail(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let pos2 = skipNl(tokens.clone(), pos);
+                let pos2 = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos2.clone()) {
-                    Token::TkComma => __MutualTco6::ParseMapEntries(
-                        tokens.clone(),
-                        skipNl(tokens, (pos2 + 1i64)),
-                        acc,
-                    ),
-                    Token::TkRBrace => {
+                    crate::aver_generated::domain::token::Token::TkComma => {
+                        __MutualTco6::ParseMapEntries(
+                            tokens.clone(),
+                            crate::aver_generated::domain::parser::expr::skipNl(
+                                tokens,
+                                (pos2 + 1i64),
+                            ),
+                            acc,
+                        )
+                    }
+                    crate::aver_generated::domain::token::Token::TkRBrace => {
                         return Ok((
-                            Expr::ExprCall(
+                            crate::aver_generated::domain::ast::Expr::ExprCall(
                                 AverStr::from("Map.fromList"),
-                                aver_rt::AverList::from_vec(vec![Expr::ExprList(acc.reverse())]),
+                                aver_rt::AverList::from_vec(vec![
+                                    crate::aver_generated::domain::ast::Expr::ExprList(
+                                        acc.reverse(),
+                                    ),
+                                ]),
                             ),
                             (pos2 + 1i64),
                         ));
@@ -629,24 +698,30 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<(Expr, i64), A
                 let pos2 =
                     crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos2.clone()) {
-                    Token::TkDedent => {
+                    crate::aver_generated::domain::token::Token::TkDedent => {
                         let __list_subject = acc.clone();
                         if __list_subject.is_empty() {
                             return Err(AverStr::from("Expected at least one match arm"));
                         } else {
                             return Ok((
-                                Expr::ExprMatch(std::sync::Arc::new(subject), acc.reverse()),
+                                crate::aver_generated::domain::ast::Expr::ExprMatch(
+                                    std::sync::Arc::new(subject),
+                                    acc.reverse(),
+                                ),
                                 (pos2 + 1i64),
                             ));
                         }
                     }
-                    Token::TkEof => {
+                    crate::aver_generated::domain::token::Token::TkEof => {
                         let __list_subject = acc.clone();
                         if __list_subject.is_empty() {
                             return Err(AverStr::from("Expected at least one match arm"));
                         } else {
                             return Ok((
-                                Expr::ExprMatch(std::sync::Arc::new(subject), acc.reverse()),
+                                crate::aver_generated::domain::ast::Expr::ExprMatch(
+                                    std::sync::Arc::new(subject),
+                                    acc.reverse(),
+                                ),
                                 pos2,
                             ));
                         }
@@ -668,7 +743,7 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<(Expr, i64), A
                     pos,
                     &Token::TkArrow,
                 )?;
-                let er = parseExpr(&tokens, pos2)?;
+                let er = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
                 match er {
                     (body, pos3) => __MutualTco7::ParseMatchArms(
                         tokens.clone(),
@@ -773,7 +848,10 @@ fn __mutual_tco_trampoline_8(mut __state: __MutualTco8) -> Result<(Expr, i64), A
                             return Err(AverStr::from("Expected at least one match arm"));
                         } else {
                             return Ok((
-                                Expr::ExprMatch(std::sync::Arc::new(subject), acc.reverse()),
+                                crate::aver_generated::domain::ast::Expr::ExprMatch(
+                                    std::sync::Arc::new(subject),
+                                    acc.reverse(),
+                                ),
                                 pos,
                             ));
                         }
@@ -802,7 +880,7 @@ fn __mutual_tco_trampoline_8(mut __state: __MutualTco8) -> Result<(Expr, i64), A
                     pos,
                     &Token::TkArrow,
                 )?;
-                let er = parseExpr(&tokens, pos2)?;
+                let er = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
                 match er {
                     (body, pos3) => __MutualTco8::ParseMatchArmsFlat(
                         tokens.clone(),
@@ -883,21 +961,25 @@ fn __mutual_tco_trampoline_9(mut __state: __MutualTco9) -> Result<(Expr, i64), A
                 crate::cancel_checkpoint();
                 let nextPos = (pos + 1i64);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkStar => __MutualTco9::ParseMulExprRight(tokens, nextPos, left, 0i64),
-                    Token::TkSlash => __MutualTco9::ParseMulExprRight(tokens, nextPos, left, 1i64),
+                    crate::aver_generated::domain::token::Token::TkStar => {
+                        __MutualTco9::ParseMulExprRight(tokens, nextPos, left, 0i64)
+                    }
+                    crate::aver_generated::domain::token::Token::TkSlash => {
+                        __MutualTco9::ParseMulExprRight(tokens, nextPos, left, 1i64)
+                    }
                     _ => return Ok((left, pos)),
                 }
             }
             __MutualTco9::ParseMulExprRight(mut tokens, mut pos, mut left, mut op) => {
                 crate::cancel_checkpoint();
-                let r = parseAtom(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::expr::parseAtom(&tokens, pos)?;
                 match r {
                     (right, pos2) => {
                         if (op == 0i64) {
                             __MutualTco9::ParseMulExprTail(
                                 tokens,
                                 pos2,
-                                Expr::ExprMul(
+                                crate::aver_generated::domain::ast::Expr::ExprMul(
                                     std::sync::Arc::new(left),
                                     std::sync::Arc::new(right),
                                 ),
@@ -906,7 +988,7 @@ fn __mutual_tco_trampoline_9(mut __state: __MutualTco9) -> Result<(Expr, i64), A
                             __MutualTco9::ParseMulExprTail(
                                 tokens,
                                 pos2,
-                                Expr::ExprDiv(
+                                crate::aver_generated::domain::ast::Expr::ExprDiv(
                                     std::sync::Arc::new(left),
                                     std::sync::Arc::new(right),
                                 ),
@@ -985,24 +1067,28 @@ fn __mutual_tco_trampoline_10(mut __state: __MutualTco10) -> Result<(Expr, i64),
             ) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkIdent(field) => __MutualTco10::ParseNamedArgField(
-                        tokens,
-                        (pos + 1i64),
-                        name,
-                        positionalArgs,
-                        namedAcc,
-                        field,
-                    ),
-                    Token::TkRParen => {
+                    crate::aver_generated::domain::token::Token::TkIdent(field) => {
+                        __MutualTco10::ParseNamedArgField(
+                            tokens,
+                            (pos + 1i64),
+                            name,
+                            positionalArgs,
+                            namedAcc,
+                            field,
+                        )
+                    }
+                    crate::aver_generated::domain::token::Token::TkRParen => {
                         return Ok((
-                            Expr::ExprCall(
+                            crate::aver_generated::domain::ast::Expr::ExprCall(
                                 name,
                                 aver_rt::AverList::concat(
                                     &positionalArgs.reverse(),
-                                    &aver_rt::AverList::from_vec(vec![Expr::ExprRecord(
-                                        AverStr::from("_named"),
-                                        namedAcc.reverse(),
-                                    )]),
+                                    &aver_rt::AverList::from_vec(vec![
+                                        crate::aver_generated::domain::ast::Expr::ExprRecord(
+                                            AverStr::from("_named"),
+                                            namedAcc.reverse(),
+                                        ),
+                                    ]),
                                 ),
                             ),
                             (pos + 1i64),
@@ -1029,7 +1115,7 @@ fn __mutual_tco_trampoline_10(mut __state: __MutualTco10) -> Result<(Expr, i64),
                     pos,
                     &Token::TkEq,
                 )?;
-                let r = parseExpr(&tokens, pos2)?;
+                let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
                 match r {
                     (expr, pos3) => __MutualTco10::ParseNamedArgsTail(
                         tokens,
@@ -1048,25 +1134,32 @@ fn __mutual_tco_trampoline_10(mut __state: __MutualTco10) -> Result<(Expr, i64),
                 mut namedAcc,
             ) => {
                 crate::cancel_checkpoint();
-                let pos = skipNl(tokens.clone(), pos0);
+                let pos = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos0);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos.clone()) {
-                    Token::TkComma => __MutualTco10::ParseNamedArgs(
-                        tokens.clone(),
-                        skipNl(tokens, (pos + 1i64)),
-                        name,
-                        positionalArgs,
-                        namedAcc,
-                    ),
-                    Token::TkRParen => {
+                    crate::aver_generated::domain::token::Token::TkComma => {
+                        __MutualTco10::ParseNamedArgs(
+                            tokens.clone(),
+                            crate::aver_generated::domain::parser::expr::skipNl(
+                                tokens,
+                                (pos + 1i64),
+                            ),
+                            name,
+                            positionalArgs,
+                            namedAcc,
+                        )
+                    }
+                    crate::aver_generated::domain::token::Token::TkRParen => {
                         return Ok((
-                            Expr::ExprCall(
+                            crate::aver_generated::domain::ast::Expr::ExprCall(
                                 name,
                                 aver_rt::AverList::concat(
                                     &positionalArgs.reverse(),
-                                    &aver_rt::AverList::from_vec(vec![Expr::ExprRecord(
-                                        AverStr::from("_named"),
-                                        namedAcc.reverse(),
-                                    )]),
+                                    &aver_rt::AverList::from_vec(vec![
+                                        crate::aver_generated::domain::ast::Expr::ExprRecord(
+                                            AverStr::from("_named"),
+                                            namedAcc.reverse(),
+                                        ),
+                                    ]),
                                 ),
                             ),
                             (pos + 1i64),
@@ -1167,7 +1260,7 @@ fn __mutual_tco_trampoline_11(mut __state: __MutualTco11) -> Result<(Expr, i64),
             __MutualTco11::ParseRecordFields(mut tokens, mut pos, mut name, mut acc) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkIdent(field) => {
+                    crate::aver_generated::domain::token::Token::TkIdent(field) => {
                         __MutualTco11::ParseRecordField(tokens, (pos + 1i64), name, acc, field)
                     }
                     _ => return Err(AverStr::from("Expected field name in record constructor")),
@@ -1180,7 +1273,7 @@ fn __mutual_tco_trampoline_11(mut __state: __MutualTco11) -> Result<(Expr, i64),
                     pos,
                     &Token::TkEq,
                 )?;
-                let r = parseExpr(&tokens, pos2)?;
+                let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
                 match r {
                     (expr, pos3) => __MutualTco11::ParseRecordFieldsTail(
                         tokens,
@@ -1192,16 +1285,27 @@ fn __mutual_tco_trampoline_11(mut __state: __MutualTco11) -> Result<(Expr, i64),
             }
             __MutualTco11::ParseRecordFieldsTail(mut tokens, mut pos, mut name, mut fields) => {
                 crate::cancel_checkpoint();
-                let pos2 = skipNl(tokens.clone(), pos);
+                let pos2 = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos2.clone()) {
-                    Token::TkComma => __MutualTco11::ParseRecordAfterComma(
-                        tokens.clone(),
-                        skipNl(tokens, (pos2 + 1i64)),
-                        name,
-                        fields,
-                    ),
-                    Token::TkRParen => {
-                        return Ok((Expr::ExprRecord(name, fields.reverse()), (pos2 + 1i64)));
+                    crate::aver_generated::domain::token::Token::TkComma => {
+                        __MutualTco11::ParseRecordAfterComma(
+                            tokens.clone(),
+                            crate::aver_generated::domain::parser::expr::skipNl(
+                                tokens,
+                                (pos2 + 1i64),
+                            ),
+                            name,
+                            fields,
+                        )
+                    }
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Expr::ExprRecord(
+                                name,
+                                fields.reverse(),
+                            ),
+                            (pos2 + 1i64),
+                        ));
                     }
                     _ => return Err(AverStr::from("Expected ',' or ')' in record constructor")),
                 }
@@ -1209,7 +1313,12 @@ fn __mutual_tco_trampoline_11(mut __state: __MutualTco11) -> Result<(Expr, i64),
             __MutualTco11::ParseRecordAfterComma(mut tokens, mut pos, mut name, mut fields) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkRParen => return Ok((Expr::ExprRecord(name, fields), (pos + 1i64))),
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Expr::ExprRecord(name, fields),
+                            (pos + 1i64),
+                        ));
+                    }
                     _ => __MutualTco11::ParseRecordFields(tokens, pos, name, fields),
                 }
             }
@@ -1291,7 +1400,7 @@ fn __mutual_tco_trampoline_12(mut __state: __MutualTco12) -> Result<(Expr, i64),
         __state = match __state {
             __MutualTco12::ParseTupleRest(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = parseExpr(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
                 match r {
                     (expr, pos2) => __MutualTco12::ParseTupleRestTail(
                         tokens,
@@ -1302,15 +1411,24 @@ fn __mutual_tco_trampoline_12(mut __state: __MutualTco12) -> Result<(Expr, i64),
             }
             __MutualTco12::ParseTupleRestTail(mut tokens, mut pos0, mut items) => {
                 crate::cancel_checkpoint();
-                let pos = skipNl(tokens.clone(), pos0);
+                let pos = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos0);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos.clone()) {
-                    Token::TkComma => __MutualTco12::ParseTupleAfterComma(
-                        tokens.clone(),
-                        skipNl(tokens, (pos + 1i64)),
-                        items,
-                    ),
-                    Token::TkRParen => {
-                        return finishTupleOrProduct(&tokens, (pos + 1i64), &items.reverse());
+                    crate::aver_generated::domain::token::Token::TkComma => {
+                        __MutualTco12::ParseTupleAfterComma(
+                            tokens.clone(),
+                            crate::aver_generated::domain::parser::expr::skipNl(
+                                tokens,
+                                (pos + 1i64),
+                            ),
+                            items,
+                        )
+                    }
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return crate::aver_generated::domain::parser::expr::finishTupleOrProduct(
+                            &tokens,
+                            (pos + 1i64),
+                            &items.reverse(),
+                        );
                     }
                     _ => return Err(AverStr::from("Expected ')' or ',' in tuple")),
                 }
@@ -1318,7 +1436,13 @@ fn __mutual_tco_trampoline_12(mut __state: __MutualTco12) -> Result<(Expr, i64),
             __MutualTco12::ParseTupleAfterComma(mut tokens, mut pos, mut items) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkRParen => return finishTupleOrProduct(&tokens, (pos + 1i64), &items),
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return crate::aver_generated::domain::parser::expr::finishTupleOrProduct(
+                            &tokens,
+                            (pos + 1i64),
+                            &items,
+                        );
+                    }
                     _ => __MutualTco12::ParseTupleRest(tokens, pos, items),
                 }
             }
@@ -1368,10 +1492,10 @@ pub fn parseTupleAfterComma(
 /// Parse an expression: comparison level, then optional ? postfix.
 pub fn parseExpr(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let r = parseCmpExpr(tokens, pos)?;
+    let r = crate::aver_generated::domain::parser::expr::parseCmpExpr(tokens, pos)?;
     {
         let (expr, pos2) = r;
-        Ok(parsePostfixQuestion(tokens, pos2, &expr))
+        Ok(crate::aver_generated::domain::parser::expr::parsePostfixQuestion(tokens, pos2, &expr))
     }
 }
 
@@ -1383,8 +1507,10 @@ pub fn parsePostfixQuestion(
 ) -> (Expr, i64) {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
-        Token::TkQuestion => (
-            Expr::ExprPropagate(std::sync::Arc::new(expr.clone())),
+        crate::aver_generated::domain::token::Token::TkQuestion => (
+            crate::aver_generated::domain::ast::Expr::ExprPropagate(std::sync::Arc::new(
+                expr.clone(),
+            )),
             (pos + 1i64),
         ),
         _ => (expr.clone(), pos),
@@ -1394,10 +1520,10 @@ pub fn parsePostfixQuestion(
 /// Parse comparison: addExpr (('==' | '<' | '>') addExpr)?
 pub fn parseCmpExpr(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let r = parseAddExpr(tokens, pos)?;
+    let r = crate::aver_generated::domain::parser::expr::parseAddExpr(tokens, pos)?;
     {
         let (left, pos2) = r;
-        parseCmpExprTail(tokens, pos2, &left)
+        crate::aver_generated::domain::parser::expr::parseCmpExprTail(tokens, pos2, &left)
     }
 }
 
@@ -1410,12 +1536,36 @@ pub fn parseCmpExprTail(
     crate::cancel_checkpoint();
     let nextPos = (pos + 1i64);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
-        Token::TkEqEq => parseCmpExprRight(tokens, nextPos, left, 0i64),
-        Token::TkNeq => parseCmpExprRight(tokens, nextPos, left, 1i64),
-        Token::TkLt => parseCmpExprRight(tokens, nextPos, left, 2i64),
-        Token::TkGt => parseCmpExprRight(tokens, nextPos, left, 3i64),
-        Token::TkLte => parseCmpExprRight(tokens, nextPos, left, 4i64),
-        Token::TkGte => parseCmpExprRight(tokens, nextPos, left, 5i64),
+        crate::aver_generated::domain::token::Token::TkEqEq => {
+            crate::aver_generated::domain::parser::expr::parseCmpExprRight(
+                tokens, nextPos, left, 0i64,
+            )
+        }
+        crate::aver_generated::domain::token::Token::TkNeq => {
+            crate::aver_generated::domain::parser::expr::parseCmpExprRight(
+                tokens, nextPos, left, 1i64,
+            )
+        }
+        crate::aver_generated::domain::token::Token::TkLt => {
+            crate::aver_generated::domain::parser::expr::parseCmpExprRight(
+                tokens, nextPos, left, 2i64,
+            )
+        }
+        crate::aver_generated::domain::token::Token::TkGt => {
+            crate::aver_generated::domain::parser::expr::parseCmpExprRight(
+                tokens, nextPos, left, 3i64,
+            )
+        }
+        crate::aver_generated::domain::token::Token::TkLte => {
+            crate::aver_generated::domain::parser::expr::parseCmpExprRight(
+                tokens, nextPos, left, 4i64,
+            )
+        }
+        crate::aver_generated::domain::token::Token::TkGte => {
+            crate::aver_generated::domain::parser::expr::parseCmpExprRight(
+                tokens, nextPos, left, 5i64,
+            )
+        }
         _ => Ok((left.clone(), pos)),
     }
 }
@@ -1428,10 +1578,10 @@ pub fn parseCmpExprRight(
     op: i64,
 ) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let r = parseAddExpr(tokens, pos)?;
+    let r = crate::aver_generated::domain::parser::expr::parseAddExpr(tokens, pos)?;
     {
         let (right, pos2) = r;
-        buildCmpExpr(left, &right, pos2, op)
+        crate::aver_generated::domain::parser::expr::buildCmpExpr(left, &right, pos2, op)
     }
 }
 
@@ -1443,7 +1593,7 @@ pub fn buildCmpExpr(left: &Expr, right: &Expr, pos: i64, op: i64) -> Result<(Exp
         let __dispatch_subject = op;
         if __dispatch_subject == 0i64 {
             Ok((
-                Expr::ExprEq(
+                crate::aver_generated::domain::ast::Expr::ExprEq(
                     std::sync::Arc::new(left.clone()),
                     std::sync::Arc::new(right.clone()),
                 ),
@@ -1452,7 +1602,7 @@ pub fn buildCmpExpr(left: &Expr, right: &Expr, pos: i64, op: i64) -> Result<(Exp
         } else {
             if __dispatch_subject == 1i64 {
                 Ok((
-                    Expr::ExprNeq(
+                    crate::aver_generated::domain::ast::Expr::ExprNeq(
                         std::sync::Arc::new(left.clone()),
                         std::sync::Arc::new(right.clone()),
                     ),
@@ -1461,7 +1611,7 @@ pub fn buildCmpExpr(left: &Expr, right: &Expr, pos: i64, op: i64) -> Result<(Exp
             } else {
                 if __dispatch_subject == 2i64 {
                     Ok((
-                        Expr::ExprLt(
+                        crate::aver_generated::domain::ast::Expr::ExprLt(
                             std::sync::Arc::new(left.clone()),
                             std::sync::Arc::new(right.clone()),
                         ),
@@ -1470,7 +1620,7 @@ pub fn buildCmpExpr(left: &Expr, right: &Expr, pos: i64, op: i64) -> Result<(Exp
                 } else {
                     if __dispatch_subject == 3i64 {
                         Ok((
-                            Expr::ExprGt(
+                            crate::aver_generated::domain::ast::Expr::ExprGt(
                                 std::sync::Arc::new(left.clone()),
                                 std::sync::Arc::new(right.clone()),
                             ),
@@ -1479,7 +1629,7 @@ pub fn buildCmpExpr(left: &Expr, right: &Expr, pos: i64, op: i64) -> Result<(Exp
                     } else {
                         if __dispatch_subject == 4i64 {
                             Ok((
-                                Expr::ExprLte(
+                                crate::aver_generated::domain::ast::Expr::ExprLte(
                                     std::sync::Arc::new(left.clone()),
                                     std::sync::Arc::new(right.clone()),
                                 ),
@@ -1488,7 +1638,7 @@ pub fn buildCmpExpr(left: &Expr, right: &Expr, pos: i64, op: i64) -> Result<(Exp
                         } else {
                             if __dispatch_subject == 5i64 {
                                 Ok((
-                                    Expr::ExprGte(
+                                    crate::aver_generated::domain::ast::Expr::ExprGte(
                                         std::sync::Arc::new(left.clone()),
                                         std::sync::Arc::new(right.clone()),
                                     ),
@@ -1508,20 +1658,20 @@ pub fn buildCmpExpr(left: &Expr, right: &Expr, pos: i64, op: i64) -> Result<(Exp
 /// Parse additive: mulExpr (('+' | '-') mulExpr)*
 pub fn parseAddExpr(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let r = parseMulExpr(tokens, pos)?;
+    let r = crate::aver_generated::domain::parser::expr::parseMulExpr(tokens, pos)?;
     {
         let (expr, pos2) = r;
-        parseAddExprTail(tokens, pos2, &expr)
+        crate::aver_generated::domain::parser::expr::parseAddExprTail(tokens, pos2, &expr)
     }
 }
 
 /// Parse multiplicative: atom ('*' atom)*
 pub fn parseMulExpr(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let r = parseAtom(tokens, pos)?;
+    let r = crate::aver_generated::domain::parser::expr::parseAtom(tokens, pos)?;
     {
         let (expr, pos2) = r;
-        parseMulExprTail(tokens, pos2, &expr)
+        crate::aver_generated::domain::parser::expr::parseMulExprTail(tokens, pos2, &expr)
     }
 }
 
@@ -1531,17 +1681,43 @@ pub fn parseAtom(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Expr, i
     let nextPos = (pos + 1i64);
     let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t.clone() {
-        Token::TkMinus => parseNegAtom(tokens, nextPos),
-        Token::TkInt(n) => Ok((Expr::ExprInt(n), nextPos)),
-        Token::TkFloat(f) => Ok((Expr::ExprFloat(f), nextPos)),
-        Token::TkStr(s) => parseStringOrInterp(tokens, nextPos, s),
-        Token::TkTrue => Ok((Expr::ExprBool(true), nextPos)),
-        Token::TkFalse => Ok((Expr::ExprBool(false), nextPos)),
-        Token::TkLBracket => parseListExpr(tokens, nextPos),
-        Token::TkLBrace => parseMapLiteral(tokens, nextPos),
-        Token::TkLParen => parseParenExpr(tokens, nextPos),
-        Token::TkMatch => parseMatchExpr(tokens, nextPos),
-        Token::TkIdent(name) => parseIdentOrCall(tokens, nextPos, name),
+        crate::aver_generated::domain::token::Token::TkMinus => {
+            crate::aver_generated::domain::parser::expr::parseNegAtom(tokens, nextPos)
+        }
+        crate::aver_generated::domain::token::Token::TkInt(n) => Ok((
+            crate::aver_generated::domain::ast::Expr::ExprInt(n),
+            nextPos,
+        )),
+        crate::aver_generated::domain::token::Token::TkFloat(f) => Ok((
+            crate::aver_generated::domain::ast::Expr::ExprFloat(f),
+            nextPos,
+        )),
+        crate::aver_generated::domain::token::Token::TkStr(s) => {
+            crate::aver_generated::domain::parser::expr::parseStringOrInterp(tokens, nextPos, s)
+        }
+        crate::aver_generated::domain::token::Token::TkTrue => Ok((
+            crate::aver_generated::domain::ast::Expr::ExprBool(true),
+            nextPos,
+        )),
+        crate::aver_generated::domain::token::Token::TkFalse => Ok((
+            crate::aver_generated::domain::ast::Expr::ExprBool(false),
+            nextPos,
+        )),
+        crate::aver_generated::domain::token::Token::TkLBracket => {
+            crate::aver_generated::domain::parser::expr::parseListExpr(tokens, nextPos)
+        }
+        crate::aver_generated::domain::token::Token::TkLBrace => {
+            crate::aver_generated::domain::parser::expr::parseMapLiteral(tokens, nextPos)
+        }
+        crate::aver_generated::domain::token::Token::TkLParen => {
+            crate::aver_generated::domain::parser::expr::parseParenExpr(tokens, nextPos)
+        }
+        crate::aver_generated::domain::token::Token::TkMatch => {
+            crate::aver_generated::domain::parser::expr::parseMatchExpr(tokens, nextPos)
+        }
+        crate::aver_generated::domain::token::Token::TkIdent(name) => {
+            crate::aver_generated::domain::parser::expr::parseIdentOrCall(tokens, nextPos, name)
+        }
         _ => Err(aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = aver_rt::Buffer::with_capacity((41i64) as usize);
@@ -1562,26 +1738,35 @@ pub fn parseMapLiteral(
     pos: i64,
 ) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = skipNl(tokens.clone(), pos);
+    let pos2 = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
-        Token::TkRBrace => Ok((
-            Expr::ExprCall(
+        crate::aver_generated::domain::token::Token::TkRBrace => Ok((
+            crate::aver_generated::domain::ast::Expr::ExprCall(
                 AverStr::from("Map.fromList"),
-                aver_rt::AverList::from_vec(vec![Expr::ExprList(aver_rt::AverList::empty())]),
+                aver_rt::AverList::from_vec(vec![
+                    crate::aver_generated::domain::ast::Expr::ExprList(aver_rt::AverList::empty()),
+                ]),
             ),
             (pos2 + 1i64),
         )),
-        _ => parseMapEntries(tokens, pos2, &aver_rt::AverList::empty()),
+        _ => crate::aver_generated::domain::parser::expr::parseMapEntries(
+            tokens,
+            pos2,
+            &aver_rt::AverList::empty(),
+        ),
     }
 }
 
 /// Parse unary minus into the first-class Expr.ExprNeg node.
 pub fn parseNegAtom(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let r = parseAtom(tokens, pos)?;
+    let r = crate::aver_generated::domain::parser::expr::parseAtom(tokens, pos)?;
     {
         let (expr, pos2) = r;
-        Ok((Expr::ExprNeg(std::sync::Arc::new(expr)), pos2))
+        Ok((
+            crate::aver_generated::domain::ast::Expr::ExprNeg(std::sync::Arc::new(expr)),
+            pos2,
+        ))
     }
 }
 
@@ -1593,38 +1778,54 @@ pub fn parseStringOrInterp(
 ) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
-        Token::TkInterpStart => parseInterpParts(
-            tokens,
-            (pos + 1i64),
-            &aver_rt::AverList::from_vec(vec![Expr::ExprStr(prefix)]),
-        ),
-        _ => Ok((Expr::ExprStr(prefix), pos)),
+        crate::aver_generated::domain::token::Token::TkInterpStart => {
+            crate::aver_generated::domain::parser::expr::parseInterpParts(
+                tokens,
+                (pos + 1i64),
+                &aver_rt::AverList::from_vec(vec![
+                    crate::aver_generated::domain::ast::Expr::ExprStr(prefix),
+                ]),
+            )
+        }
+        _ => Ok((
+            crate::aver_generated::domain::ast::Expr::ExprStr(prefix),
+            pos,
+        )),
     }
 }
 
 /// Parse list literal: [expr, expr, ...] or [].
 pub fn parseListExpr(tokens: &aver_rt::AverList<Token>, pos0: i64) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let pos = skipNl(tokens.clone(), pos0);
+    let pos = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos0);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
-        Token::TkRBracket => Ok((Expr::ExprList(aver_rt::AverList::empty()), (pos + 1i64))),
-        _ => parseListItems(tokens, pos, &aver_rt::AverList::empty()),
+        crate::aver_generated::domain::token::Token::TkRBracket => Ok((
+            crate::aver_generated::domain::ast::Expr::ExprList(aver_rt::AverList::empty()),
+            (pos + 1i64),
+        )),
+        _ => crate::aver_generated::domain::parser::expr::parseListItems(
+            tokens,
+            pos,
+            &aver_rt::AverList::empty(),
+        ),
     }
 }
 
 /// Parse parenthesized expression or tuple.
 pub fn parseParenExpr(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let r = parseExpr(tokens, pos)?;
+    let r = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos)?;
     {
         let (expr, pos2) = r;
         match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
-            Token::TkComma => parseTupleRest(
-                tokens,
-                (pos2 + 1i64),
-                &aver_rt::AverList::from_vec(vec![expr]),
-            ),
-            Token::TkRParen => Ok((expr, (pos2 + 1i64))),
+            crate::aver_generated::domain::token::Token::TkComma => {
+                crate::aver_generated::domain::parser::expr::parseTupleRest(
+                    tokens,
+                    (pos2 + 1i64),
+                    &aver_rt::AverList::from_vec(vec![expr]),
+                )
+            }
+            crate::aver_generated::domain::token::Token::TkRParen => Ok((expr, (pos2 + 1i64))),
             _ => Err(AverStr::from("Expected ')' or ',' after expression")),
         }
     }
@@ -1638,25 +1839,40 @@ pub fn finishTupleOrProduct(
 ) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
-        Token::TkQuestion => {
+        crate::aver_generated::domain::token::Token::TkQuestion => {
             match crate::aver_generated::domain::parser_match::tokenAt(tokens, (pos + 1i64)) {
-                Token::TkBang => Ok((
-                    Expr::ExprIndependentProduct(items.clone(), true),
+                crate::aver_generated::domain::token::Token::TkBang => Ok((
+                    crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
+                        items.clone(),
+                        true,
+                    ),
                     (pos + 2i64),
                 )),
-                _ => Ok((Expr::ExprTuple(items.clone()), pos)),
+                _ => Ok((
+                    crate::aver_generated::domain::ast::Expr::ExprTuple(items.clone()),
+                    pos,
+                )),
             }
         }
-        Token::TkBang => {
+        crate::aver_generated::domain::token::Token::TkBang => {
             match crate::aver_generated::domain::parser_match::tokenAt(tokens, (pos + 1i64)) {
-                Token::TkLBracket => Ok((Expr::ExprTuple(items.clone()), pos)),
+                crate::aver_generated::domain::token::Token::TkLBracket => Ok((
+                    crate::aver_generated::domain::ast::Expr::ExprTuple(items.clone()),
+                    pos,
+                )),
                 _ => Ok((
-                    Expr::ExprIndependentProduct(items.clone(), false),
+                    crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
+                        items.clone(),
+                        false,
+                    ),
                     (pos + 1i64),
                 )),
             }
         }
-        _ => Ok((Expr::ExprTuple(items.clone()), pos)),
+        _ => Ok((
+            crate::aver_generated::domain::ast::Expr::ExprTuple(items.clone()),
+            pos,
+        )),
     }
 }
 
@@ -1669,9 +1885,17 @@ pub fn parseIdentOrCall(
     crate::cancel_checkpoint();
     let nextPos = (pos + 1i64);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
-        Token::TkLParen => chainFieldAccess(tokens, nextPos, name),
-        Token::TkDot => parseFieldAccess(tokens, nextPos, &Expr::ExprVar(name)),
-        _ => Ok((Expr::ExprVar(name), pos)),
+        crate::aver_generated::domain::token::Token::TkLParen => {
+            crate::aver_generated::domain::parser::expr::chainFieldAccess(tokens, nextPos, name)
+        }
+        crate::aver_generated::domain::token::Token::TkDot => {
+            crate::aver_generated::domain::parser::expr::parseFieldAccess(
+                tokens,
+                nextPos,
+                &crate::aver_generated::domain::ast::Expr::ExprVar(name),
+            )
+        }
+        _ => Ok((crate::aver_generated::domain::ast::Expr::ExprVar(name), pos)),
     }
 }
 
@@ -1682,10 +1906,10 @@ pub fn chainFieldAccess(
     name: AverStr,
 ) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let r = parseCallOrRecord(tokens, pos, name)?;
+    let r = crate::aver_generated::domain::parser::expr::parseCallOrRecord(tokens, pos, name)?;
     {
         let (expr, pos2) = r;
-        parseFieldAccessTail(tokens, pos2, &expr)
+        crate::aver_generated::domain::parser::expr::parseFieldAccessTail(tokens, pos2, &expr)
     }
 }
 
@@ -1695,15 +1919,15 @@ pub fn skipNl(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> i64 {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
         return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-            Token::TkNewline => {
+            crate::aver_generated::domain::token::Token::TkNewline => {
                 pos = nextPos;
                 continue;
             }
-            Token::TkIndent => {
+            crate::aver_generated::domain::token::Token::TkIndent => {
                 pos = nextPos;
                 continue;
             }
-            Token::TkDedent => {
+            crate::aver_generated::domain::token::Token::TkDedent => {
                 pos = nextPos;
                 continue;
             }
@@ -1719,14 +1943,23 @@ pub fn parseCallOrRecord(
     name: AverStr,
 ) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = skipNl(tokens.clone(), pos);
+    let pos2 = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
-        Token::TkRParen => Ok((
-            Expr::ExprCall(name, aver_rt::AverList::empty()),
+        crate::aver_generated::domain::token::Token::TkRParen => Ok((
+            crate::aver_generated::domain::ast::Expr::ExprCall(name, aver_rt::AverList::empty()),
             (pos2 + 1i64),
         )),
-        Token::TkIdent(first) => parseCallOrRecordLookahead(tokens, pos2, name, first),
-        _ => parseCallArgsList(tokens, pos2, name, &aver_rt::AverList::empty()),
+        crate::aver_generated::domain::token::Token::TkIdent(first) => {
+            crate::aver_generated::domain::parser::expr::parseCallOrRecordLookahead(
+                tokens, pos2, name, first,
+            )
+        }
+        _ => crate::aver_generated::domain::parser::expr::parseCallArgsList(
+            tokens,
+            pos2,
+            name,
+            &aver_rt::AverList::empty(),
+        ),
     }
 }
 
@@ -1739,18 +1972,30 @@ pub fn parseCallOrRecordLookahead(
 ) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, (pos + 1i64)) {
-        Token::TkEq => parseRecordFields(tokens, pos, name, &aver_rt::AverList::empty()),
-        _ => parseCallArgsList(tokens, pos, name, &aver_rt::AverList::empty()),
+        crate::aver_generated::domain::token::Token::TkEq => {
+            crate::aver_generated::domain::parser::expr::parseRecordFields(
+                tokens,
+                pos,
+                name,
+                &aver_rt::AverList::empty(),
+            )
+        }
+        _ => crate::aver_generated::domain::parser::expr::parseCallArgsList(
+            tokens,
+            pos,
+            name,
+            &aver_rt::AverList::empty(),
+        ),
     }
 }
 
 /// Parse: match expr NEWLINE INDENT arms DEDENT. Called after TkMatch is consumed.
 pub fn parseMatchExpr(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Expr, i64), AverStr> {
     crate::cancel_checkpoint();
-    let r = parseExpr(tokens, pos)?;
+    let r = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos)?;
     {
         let (subject, pos2) = r;
-        parseMatchAfterSubject(tokens, pos2, &subject)
+        crate::aver_generated::domain::parser::expr::parseMatchAfterSubject(tokens, pos2, &subject)
     }
 }
 
@@ -1763,9 +2008,19 @@ pub fn parseMatchAfterSubject(
     crate::cancel_checkpoint();
     let pos2 = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
-        Token::TkIndent => {
-            parseMatchArms(tokens, (pos2 + 1i64), subject, &aver_rt::AverList::empty())
+        crate::aver_generated::domain::token::Token::TkIndent => {
+            crate::aver_generated::domain::parser::expr::parseMatchArms(
+                tokens,
+                (pos2 + 1i64),
+                subject,
+                &aver_rt::AverList::empty(),
+            )
         }
-        _ => parseMatchArmsFlat(tokens, pos2, subject, &aver_rt::AverList::empty()),
+        _ => crate::aver_generated::domain::parser::expr::parseMatchArmsFlat(
+            tokens,
+            pos2,
+            subject,
+            &aver_rt::AverList::empty(),
+        ),
     }
 }

--- a/src/self_host/aver_generated/domain/parser/mod.rs
+++ b/src/self_host/aver_generated/domain/parser/mod.rs
@@ -33,7 +33,7 @@ fn __mutual_tco_trampoline_1(
             }
             __MutualTco1::ParseFnBodyOneStmtFlat(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = parseStmt(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::parseStmt(&tokens, pos)?;
                 match r {
                     (stmt, pos2) => __MutualTco1::ParseFnBodyAfterStmtFlat(
                         tokens,
@@ -45,7 +45,7 @@ fn __mutual_tco_trampoline_1(
             __MutualTco1::ParseFnBodyAfterStmtFlat(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                    Token::TkNewline => {
+                    crate::aver_generated::domain::token::Token::TkNewline => {
                         __MutualTco1::ParseFnBodyStmtsFlat(tokens, (pos + 1i64), acc)
                     }
                     _ => return Ok((acc, pos)),
@@ -110,14 +110,16 @@ fn __mutual_tco_trampoline_2(
                 let pos2 =
                     crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos2.clone()) {
-                    Token::TkDedent => return Ok((acc, (pos2 + 1i64))),
-                    Token::TkEof => return Ok((acc, pos2)),
+                    crate::aver_generated::domain::token::Token::TkDedent => {
+                        return Ok((acc, (pos2 + 1i64)));
+                    }
+                    crate::aver_generated::domain::token::Token::TkEof => return Ok((acc, pos2)),
                     _ => __MutualTco2::ParseFnBodyOneStmtIndented(tokens, pos2, acc),
                 }
             }
             __MutualTco2::ParseFnBodyOneStmtIndented(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = parseStmt(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::parseStmt(&tokens, pos)?;
                 match r {
                     (stmt, pos2) => __MutualTco2::ParseFnBodyStmtsIndented(
                         tokens,
@@ -205,17 +207,17 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Program, AverS
                     pos,
                 );
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos2.clone()) {
-                    Token::TkEof => {
+                    crate::aver_generated::domain::token::Token::TkEof => {
                         return Ok(Program {
                             deps: deps,
                             fns: fns.reverse(),
                             stmts: stmts.reverse(),
                         });
                     }
-                    Token::TkFn => {
+                    crate::aver_generated::domain::token::Token::TkFn => {
                         __MutualTco3::ParseProgramFn(tokens, (pos2 + 1i64), deps, fns, stmts)
                     }
-                    Token::TkIdent(kw) => {
+                    crate::aver_generated::domain::token::Token::TkIdent(kw) => {
                         __MutualTco3::ParseProgramKeyword(tokens, pos2, deps, fns, stmts, kw)
                     }
                     _ => __MutualTco3::ParseProgramStmt(tokens, pos2, deps, fns, stmts),
@@ -302,7 +304,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Program, AverS
             }
             __MutualTco3::ParseProgramFn(mut tokens, mut pos, mut deps, mut fns, mut stmts) => {
                 crate::cancel_checkpoint();
-                let r = parseFnDef(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::parseFnDef(&tokens, pos)?;
                 match r {
                     (fd, pos2) => __MutualTco3::ParseProgram(
                         tokens.clone(),
@@ -315,7 +317,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Program, AverS
             }
             __MutualTco3::ParseProgramStmt(mut tokens, mut pos, mut deps, mut fns, mut stmts) => {
                 crate::cancel_checkpoint();
-                let r = parseStmt(&tokens, pos)?;
+                let r = crate::aver_generated::domain::parser::parseStmt(&tokens, pos)?;
                 match r {
                     (st, pos2) => __MutualTco3::ParseProgram(
                         tokens.clone(),
@@ -420,8 +422,10 @@ pub fn parseStmt(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Stmt, i
     crate::cancel_checkpoint();
     let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t {
-        Token::TkIdent(name) => parseStmtAfterIdent(tokens, (pos + 1i64), name),
-        _ => parseStmtExpr(tokens, pos),
+        crate::aver_generated::domain::token::Token::TkIdent(name) => {
+            crate::aver_generated::domain::parser::parseStmtAfterIdent(tokens, (pos + 1i64), name)
+        }
+        _ => crate::aver_generated::domain::parser::parseStmtExpr(tokens, pos),
     }
 }
 
@@ -433,9 +437,17 @@ pub fn parseStmtAfterIdent(
 ) -> Result<(Stmt, i64), AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
-        Token::TkEq => parseBinding(tokens, (pos + 1i64), name),
-        Token::TkColon => parseBinding(tokens, skipTypeAnnotationAndEq(tokens, pos), name),
-        _ => parseStmtExprFrom(tokens, pos, name),
+        crate::aver_generated::domain::token::Token::TkEq => {
+            crate::aver_generated::domain::parser::parseBinding(tokens, (pos + 1i64), name)
+        }
+        crate::aver_generated::domain::token::Token::TkColon => {
+            crate::aver_generated::domain::parser::parseBinding(
+                tokens,
+                crate::aver_generated::domain::parser::skipTypeAnnotationAndEq(tokens, pos),
+                name,
+            )
+        }
+        _ => crate::aver_generated::domain::parser::parseStmtExprFrom(tokens, pos, name),
     }
 }
 
@@ -444,7 +456,7 @@ pub fn skipTypeAnnotationAndEq(tokens: &aver_rt::AverList<Token>, pos: i64) -> i
     crate::cancel_checkpoint();
     let pos2 = crate::aver_generated::domain::parser_match::skipTypeAnnotation(tokens, pos);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
-        Token::TkEq => (pos2 + 1i64),
+        crate::aver_generated::domain::token::Token::TkEq => (pos2 + 1i64),
         _ => pos2,
     }
 }
@@ -460,8 +472,8 @@ pub fn parseBinding(
     {
         let (expr, pos2) = r;
         Ok((
-            Stmt::StmtBind(name, expr),
-            skipTrailingDedent(tokens, pos2, pos),
+            crate::aver_generated::domain::ast::Stmt::StmtBind(name, expr),
+            crate::aver_generated::domain::parser::skipTrailingDedent(tokens, pos2, pos),
         ))
     }
 }
@@ -469,9 +481,14 @@ pub fn parseBinding(
 /// If expression consumed an INDENT (multi-line), skip the trailing DEDENT.
 pub fn skipTrailingDedent(tokens: &aver_rt::AverList<Token>, pos: i64, startPos: i64) -> i64 {
     crate::cancel_checkpoint();
-    match countIndentsInRange(tokens.clone(), startPos, pos, 0i64) {
+    match crate::aver_generated::domain::parser::countIndentsInRange(
+        tokens.clone(),
+        startPos,
+        pos,
+        0i64,
+    ) {
         0i64 => pos,
-        n => skipNDedents(tokens.clone(), pos, n),
+        n => crate::aver_generated::domain::parser::skipNDedents(tokens.clone(), pos, n),
     }
 }
 
@@ -490,13 +507,13 @@ pub fn countIndentsInRange(
             count
         } else {
             match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                Token::TkIndent => {
+                crate::aver_generated::domain::token::Token::TkIndent => {
                     let __tmp3 = (count + 1i64);
                     pos = nextPos;
                     count = __tmp3;
                     continue;
                 }
-                Token::TkDedent => {
+                crate::aver_generated::domain::token::Token::TkDedent => {
                     let __tmp3 = (count - 1i64);
                     pos = nextPos;
                     count = __tmp3;
@@ -521,11 +538,11 @@ pub fn skipNDedents(mut tokens: aver_rt::AverList<Token>, mut pos: i64, mut n: i
             pos
         } else {
             match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                Token::TkNewline => {
+                crate::aver_generated::domain::token::Token::TkNewline => {
                     pos = nextPos;
                     continue;
                 }
-                Token::TkDedent => {
+                crate::aver_generated::domain::token::Token::TkDedent => {
                     let __tmp1 = nextPos;
                     let __tmp2 = (n - 1i64);
                     pos = __tmp1;
@@ -544,7 +561,10 @@ pub fn parseStmtExpr(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(Stm
     let r = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos)?;
     {
         let (expr, pos2) = r;
-        Ok((Stmt::StmtExpr(expr), skipTrailingDedent(tokens, pos2, pos)))
+        Ok((
+            crate::aver_generated::domain::ast::Stmt::StmtExpr(expr),
+            crate::aver_generated::domain::parser::skipTrailingDedent(tokens, pos2, pos),
+        ))
     }
 }
 
@@ -558,7 +578,7 @@ pub fn parseStmtExprFrom(
     let ir = crate::aver_generated::domain::parser::expr::parseIdentOrCall(tokens, pos, name)?;
     {
         let (expr, pos2) = ir;
-        parseStmtExprFromMul(tokens, pos2, &expr)
+        crate::aver_generated::domain::parser::parseStmtExprFromMul(tokens, pos2, &expr)
     }
 }
 
@@ -572,7 +592,7 @@ pub fn parseStmtExprFromMul(
     let mr = crate::aver_generated::domain::parser::expr::parseMulExprTail(tokens, pos, expr)?;
     {
         let (expr2, pos2) = mr;
-        parseStmtExprFromAdd(tokens, pos2, &expr2)
+        crate::aver_generated::domain::parser::parseStmtExprFromAdd(tokens, pos2, &expr2)
     }
 }
 
@@ -586,7 +606,7 @@ pub fn parseStmtExprFromAdd(
     let ar = crate::aver_generated::domain::parser::expr::parseAddExprTail(tokens, pos, expr)?;
     {
         let (expr2, pos2) = ar;
-        parseStmtExprFromCmp(tokens, pos2, &expr2)
+        crate::aver_generated::domain::parser::parseStmtExprFromCmp(tokens, pos2, &expr2)
     }
 }
 
@@ -600,7 +620,9 @@ pub fn parseStmtExprFromCmp(
     let cr = crate::aver_generated::domain::parser::expr::parseCmpExprTail(tokens, pos, expr)?;
     {
         let (expr2, pos2) = cr;
-        Ok(parseStmtExprFromQ(tokens, pos2, &expr2))
+        Ok(crate::aver_generated::domain::parser::parseStmtExprFromQ(
+            tokens, pos2, &expr2,
+        ))
     }
 }
 
@@ -610,7 +632,10 @@ pub fn parseStmtExprFromQ(tokens: &aver_rt::AverList<Token>, pos: i64, expr: &Ex
     let qr = crate::aver_generated::domain::parser::expr::parsePostfixQuestion(tokens, pos, expr);
     {
         let (expr2, pos2) = qr;
-        (Stmt::StmtExpr(expr2), pos2)
+        (
+            crate::aver_generated::domain::ast::Stmt::StmtExpr(expr2),
+            pos2,
+        )
     }
 }
 
@@ -619,7 +644,9 @@ pub fn parseFnDef(tokens: &aver_rt::AverList<Token>, pos: i64) -> Result<(FnDef,
     crate::cancel_checkpoint();
     let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t {
-        Token::TkIdent(name) => parseFnDefParams(tokens, (pos + 1i64), name),
+        crate::aver_generated::domain::token::Token::TkIdent(name) => {
+            crate::aver_generated::domain::parser::parseFnDefParams(tokens, (pos + 1i64), name)
+        }
         _ => Err(AverStr::from("Expected function name after 'fn'")),
     }
 }
@@ -639,7 +666,7 @@ pub fn parseFnDefParams(
     )?;
     {
         let (params, pos3) = pr;
-        parseFnDefBody(tokens, pos3, name, &params)
+        crate::aver_generated::domain::parser::parseFnDefBody(tokens, pos3, name, &params)
     }
 }
 
@@ -654,8 +681,15 @@ pub fn parseFnDefBody(
     let pos2 = crate::aver_generated::domain::parser_match::skipReturnType(tokens, pos);
     let pos3 = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos2);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos3.clone()) {
-        Token::TkIndent => parseFnDefBodyIndented(tokens, (pos3 + 1i64), name, params),
-        _ => parseFnDefBodyFlat(tokens, pos3, name, params),
+        crate::aver_generated::domain::token::Token::TkIndent => {
+            crate::aver_generated::domain::parser::parseFnDefBodyIndented(
+                tokens,
+                (pos3 + 1i64),
+                name,
+                params,
+            )
+        }
+        _ => crate::aver_generated::domain::parser::parseFnDefBodyFlat(tokens, pos3, name, params),
     }
 }
 
@@ -668,7 +702,11 @@ pub fn parseFnDefBodyIndented(
 ) -> Result<(FnDef, i64), AverStr> {
     crate::cancel_checkpoint();
     let pos2 = crate::aver_generated::domain::parser_match::skipDescAndEffects(tokens.clone(), pos);
-    let sr = parseFnBodyStmtsIndented(tokens, pos2, &aver_rt::AverList::empty())?;
+    let sr = crate::aver_generated::domain::parser::parseFnBodyStmtsIndented(
+        tokens,
+        pos2,
+        &aver_rt::AverList::empty(),
+    )?;
     {
         let (stmts, pos3) = sr;
         Ok((
@@ -695,7 +733,11 @@ pub fn parseFnDefBodyFlat(
 ) -> Result<(FnDef, i64), AverStr> {
     crate::cancel_checkpoint();
     let pos2 = crate::aver_generated::domain::parser_match::skipDescAndEffects(tokens.clone(), pos);
-    let sr = parseFnBodyStmtsFlat(tokens, pos2, &aver_rt::AverList::empty())?;
+    let sr = crate::aver_generated::domain::parser::parseFnBodyStmtsFlat(
+        tokens,
+        pos2,
+        &aver_rt::AverList::empty(),
+    )?;
     {
         let (stmts, pos3) = sr;
         Ok((
@@ -717,7 +759,7 @@ pub fn parseFnDefBodyFlat(
 #[inline(always)]
 pub fn parse(tokens: &aver_rt::AverList<Token>) -> Result<Program, AverStr> {
     crate::cancel_checkpoint();
-    parseProgram(
+    crate::aver_generated::domain::parser::parseProgram(
         tokens,
         0i64,
         &aver_rt::AverList::empty(),

--- a/src/self_host/aver_generated/domain/parser_match/mod.rs
+++ b/src/self_host/aver_generated/domain/parser_match/mod.rs
@@ -31,16 +31,24 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> Result<(Pattern, i64)
                 mut acc,
             ) => {
                 crate::cancel_checkpoint();
-                match tokenAt(&tokens, pos) {
-                    Token::TkRParen => {
-                        return Ok((Pattern::PatConstructor(name, acc.reverse()), (pos + 1i64)));
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Pattern::PatConstructor(
+                                name,
+                                acc.reverse(),
+                            ),
+                            (pos + 1i64),
+                        ));
                     }
-                    Token::TkIdent(binding) => __MutualTco1::ParseConstructorPatternTail(
-                        tokens,
-                        (pos + 1i64),
-                        name,
-                        aver_rt::AverList::prepend(binding, &acc),
-                    ),
+                    crate::aver_generated::domain::token::Token::TkIdent(binding) => {
+                        __MutualTco1::ParseConstructorPatternTail(
+                            tokens,
+                            (pos + 1i64),
+                            name,
+                            aver_rt::AverList::prepend(binding, &acc),
+                        )
+                    }
                     _ => {
                         return Err(AverStr::from(
                             "Expected binding or ')' in constructor pattern",
@@ -50,15 +58,23 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> Result<(Pattern, i64)
             }
             __MutualTco1::ParseConstructorPatternTail(mut tokens, mut pos, mut name, mut acc) => {
                 crate::cancel_checkpoint();
-                match tokenAt(&tokens, pos) {
-                    Token::TkComma => __MutualTco1::ParseConstructorPatternBindings(
-                        tokens,
-                        (pos + 1i64),
-                        name,
-                        acc,
-                    ),
-                    Token::TkRParen => {
-                        return Ok((Pattern::PatConstructor(name, acc.reverse()), (pos + 1i64)));
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                    crate::aver_generated::domain::token::Token::TkComma => {
+                        __MutualTco1::ParseConstructorPatternBindings(
+                            tokens,
+                            (pos + 1i64),
+                            name,
+                            acc,
+                        )
+                    }
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Pattern::PatConstructor(
+                                name,
+                                acc.reverse(),
+                            ),
+                            (pos + 1i64),
+                        ));
                     }
                     _ => return Err(AverStr::from("Expected ',' or ')' in constructor pattern")),
                 }
@@ -109,36 +125,22 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> Result<(Pattern, i64)
             __MutualTco2::ParseIdentPatternMaybeConstructor(mut tokens, mut pos, mut name) => {
                 crate::cancel_checkpoint();
                 let nextPos = (pos + 1i64);
-                match tokenAt(&tokens, pos) {
-                    Token::TkDot => __MutualTco2::ParseIdentPatternDotted(tokens, nextPos, name),
-                    Token::TkLParen => {
-                        return parseConstructorPatternBindings(
-                            &tokens,
-                            nextPos,
-                            name,
-                            &aver_rt::AverList::empty(),
-                        );
-                    }
-                    _ => {
-                        if name.contains(".") {
-                            return Ok((
-                                Pattern::PatConstructor(name, aver_rt::AverList::empty()),
-                                pos,
-                            ));
-                        } else {
-                            return Ok((Pattern::PatVar(name), pos));
-                        }
-                    }
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                crate::aver_generated::domain::token::Token::TkDot => __MutualTco2::ParseIdentPatternDotted(tokens, nextPos, name),
+                crate::aver_generated::domain::token::Token::TkLParen => return crate::aver_generated::domain::parser_match::parseConstructorPatternBindings(&tokens, nextPos, name, &aver_rt::AverList::empty()),
+                _ => if name.contains(".") { return Ok((crate::aver_generated::domain::ast::Pattern::PatConstructor(name, aver_rt::AverList::empty()), pos)) } else { return Ok((crate::aver_generated::domain::ast::Pattern::PatVar(name), pos)) }
                 }
             }
             __MutualTco2::ParseIdentPatternDotted(mut tokens, mut pos, mut prefix) => {
                 crate::cancel_checkpoint();
-                match tokenAt(&tokens, pos) {
-                    Token::TkIdent(s) => __MutualTco2::ParseIdentPatternMaybeConstructor(
-                        tokens,
-                        (pos + 1i64),
-                        ((prefix + &AverStr::from(".")) + &s),
-                    ),
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                    crate::aver_generated::domain::token::Token::TkIdent(s) => {
+                        __MutualTco2::ParseIdentPatternMaybeConstructor(
+                            tokens,
+                            (pos + 1i64),
+                            ((prefix + &AverStr::from(".")) + &s),
+                        )
+                    }
                     _ => return Err(AverStr::from("Expected identifier after '.' in pattern")),
                 }
             }
@@ -185,21 +187,32 @@ fn __mutual_tco_trampoline_3(
         __state = match __state {
             __MutualTco3::ParseParamList(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                match tokenAt(&tokens, pos) {
-                    Token::TkRParen => return Ok((acc.reverse(), (pos + 1i64))),
-                    Token::TkIdent(name) => __MutualTco3::ParseParamListTail(
-                        tokens.clone(),
-                        skipTypeAnnotation(&tokens, (pos + 1i64)),
-                        aver_rt::AverList::prepend(name, &acc),
-                    ),
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((acc.reverse(), (pos + 1i64)));
+                    }
+                    crate::aver_generated::domain::token::Token::TkIdent(name) => {
+                        __MutualTco3::ParseParamListTail(
+                            tokens.clone(),
+                            crate::aver_generated::domain::parser_match::skipTypeAnnotation(
+                                &tokens,
+                                (pos + 1i64),
+                            ),
+                            aver_rt::AverList::prepend(name, &acc),
+                        )
+                    }
                     _ => return Err(AverStr::from("Expected parameter name or ')'")),
                 }
             }
             __MutualTco3::ParseParamListTail(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                match tokenAt(&tokens, pos) {
-                    Token::TkRParen => return Ok((acc.reverse(), (pos + 1i64))),
-                    Token::TkComma => __MutualTco3::ParseParamList(tokens, (pos + 1i64), acc),
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((acc.reverse(), (pos + 1i64)));
+                    }
+                    crate::aver_generated::domain::token::Token::TkComma => {
+                        __MutualTco3::ParseParamList(tokens, (pos + 1i64), acc)
+                    }
                     _ => return Err(AverStr::from("Expected ',' or ')' in parameter list")),
                 }
             }
@@ -245,14 +258,19 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<(Pattern, i64)
         __state = match __state {
             __MutualTco4::ParseTuplePatternElements(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                match tokenAt(&tokens, pos) {
-                    Token::TkRParen => return Ok((Pattern::PatTuple(acc.reverse()), (pos + 1i64))),
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Pattern::PatTuple(acc.reverse()),
+                            (pos + 1i64),
+                        ));
+                    }
                     _ => __MutualTco4::ParseTuplePatternElement(tokens, pos, acc),
                 }
             }
             __MutualTco4::ParseTuplePatternElement(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let pr = parsePattern(&tokens, pos)?;
+                let pr = crate::aver_generated::domain::parser_match::parsePattern(&tokens, pos)?;
                 match pr {
                     (pat, pos2) => __MutualTco4::ParseTuplePatternElementTail(
                         tokens,
@@ -263,11 +281,16 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<(Pattern, i64)
             }
             __MutualTco4::ParseTuplePatternElementTail(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                match tokenAt(&tokens, pos) {
-                    Token::TkComma => {
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                    crate::aver_generated::domain::token::Token::TkComma => {
                         __MutualTco4::ParseTuplePatternElements(tokens, (pos + 1i64), acc)
                     }
-                    Token::TkRParen => return Ok((Pattern::PatTuple(acc.reverse()), (pos + 1i64))),
+                    crate::aver_generated::domain::token::Token::TkRParen => {
+                        return Ok((
+                            crate::aver_generated::domain::ast::Pattern::PatTuple(acc.reverse()),
+                            (pos + 1i64),
+                        ));
+                    }
                     _ => return Err(AverStr::from("Expected ',' or ')' in tuple pattern")),
                 }
             }
@@ -326,19 +349,21 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> i64 {
             __MutualTco5::SkipBlockFlat(mut tokens, mut pos) => {
                 crate::cancel_checkpoint();
                 let nextPos = (pos + 1i64);
-                match tokenAt(&tokens, pos) {
-                    Token::TkEof => return pos,
-                    Token::TkNewline => __MutualTco5::SkipBlockFlatAfterNewline(tokens, nextPos),
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                    crate::aver_generated::domain::token::Token::TkEof => return pos,
+                    crate::aver_generated::domain::token::Token::TkNewline => {
+                        __MutualTco5::SkipBlockFlatAfterNewline(tokens, nextPos)
+                    }
                     _ => __MutualTco5::SkipBlockFlat(tokens, nextPos),
                 }
             }
             __MutualTco5::SkipBlockFlatAfterNewline(mut tokens, mut pos) => {
                 crate::cancel_checkpoint();
-                match tokenAt(&tokens, pos) {
-                    Token::TkEof => return pos,
-                    Token::TkNewline => return pos,
-                    Token::TkFn => return pos,
-                    Token::TkIdent(kw) => {
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                    crate::aver_generated::domain::token::Token::TkEof => return pos,
+                    crate::aver_generated::domain::token::Token::TkNewline => return pos,
+                    crate::aver_generated::domain::token::Token::TkFn => return pos,
+                    crate::aver_generated::domain::token::Token::TkIdent(kw) => {
                         let __dispatch_subject = kw;
                         if &*__dispatch_subject == "module" {
                             return pos;
@@ -383,7 +408,7 @@ pub fn skipBlockFlatAfterNewline(tokens: &aver_rt::AverList<Token>, pos: i64) ->
 #[inline(always)]
 pub fn tokenAt(tokens: &aver_rt::AverList<Token>, pos: i64) -> Token {
     crate::cancel_checkpoint();
-    tokenAtWalk(tokens.clone(), pos, 0i64)
+    crate::aver_generated::domain::parser_match::tokenAtWalk(tokens.clone(), pos, 0i64)
 }
 
 /// Walk the list to find token at target index.
@@ -415,8 +440,8 @@ pub fn expect(
     expected: &Token,
 ) -> Result<i64, AverStr> {
     crate::cancel_checkpoint();
-    let t = tokenAt(tokens, pos);
-    if isToken(&t, expected) {
+    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
+    if crate::aver_generated::domain::parser_match::isToken(&t, expected) {
         Ok((pos + 1i64))
     } else {
         Err(aver_rt::AverStr::from({
@@ -447,8 +472,8 @@ pub fn expect(
 pub fn skipNewlines(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
-        return match tokenAt(&tokens, pos) {
-            Token::TkNewline => {
+        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkNewline => {
                 let __tmp1 = (pos + 1i64);
                 pos = __tmp1;
                 continue;
@@ -463,12 +488,12 @@ pub fn skipNewlinesAndDedents(mut tokens: aver_rt::AverList<Token>, mut pos: i64
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match tokenAt(&tokens, pos) {
-            Token::TkNewline => {
+        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkNewline => {
                 pos = nextPos;
                 continue;
             }
-            Token::TkDedent => {
+            crate::aver_generated::domain::token::Token::TkDedent => {
                 pos = nextPos;
                 continue;
             }
@@ -484,16 +509,37 @@ pub fn parsePattern(
 ) -> Result<(Pattern, i64), AverStr> {
     crate::cancel_checkpoint();
     let nextPos = (pos + 1i64);
-    let t = tokenAt(tokens, pos);
+    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t.clone() {
-        Token::TkInt(n) => Ok((Pattern::PatInt(n), nextPos)),
-        Token::TkFloat(f) => Ok((Pattern::PatFloat(f), nextPos)),
-        Token::TkStr(s) => Ok((Pattern::PatStr(s), nextPos)),
-        Token::TkTrue => Ok((Pattern::PatBool(true), nextPos)),
-        Token::TkFalse => Ok((Pattern::PatBool(false), nextPos)),
-        Token::TkLBracket => parseListPattern(tokens, nextPos),
-        Token::TkLParen => parseTuplePattern(tokens, nextPos),
-        Token::TkIdent(s) => parseIdentPattern(tokens, nextPos, s),
+        crate::aver_generated::domain::token::Token::TkInt(n) => Ok((
+            crate::aver_generated::domain::ast::Pattern::PatInt(n),
+            nextPos,
+        )),
+        crate::aver_generated::domain::token::Token::TkFloat(f) => Ok((
+            crate::aver_generated::domain::ast::Pattern::PatFloat(f),
+            nextPos,
+        )),
+        crate::aver_generated::domain::token::Token::TkStr(s) => Ok((
+            crate::aver_generated::domain::ast::Pattern::PatStr(s),
+            nextPos,
+        )),
+        crate::aver_generated::domain::token::Token::TkTrue => Ok((
+            crate::aver_generated::domain::ast::Pattern::PatBool(true),
+            nextPos,
+        )),
+        crate::aver_generated::domain::token::Token::TkFalse => Ok((
+            crate::aver_generated::domain::ast::Pattern::PatBool(false),
+            nextPos,
+        )),
+        crate::aver_generated::domain::token::Token::TkLBracket => {
+            crate::aver_generated::domain::parser_match::parseListPattern(tokens, nextPos)
+        }
+        crate::aver_generated::domain::token::Token::TkLParen => {
+            crate::aver_generated::domain::parser_match::parseTuplePattern(tokens, nextPos)
+        }
+        crate::aver_generated::domain::token::Token::TkIdent(s) => {
+            crate::aver_generated::domain::parser_match::parseIdentPattern(tokens, nextPos, s)
+        }
         _ => Err(aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = aver_rt::Buffer::with_capacity((38i64) as usize);
@@ -519,7 +565,9 @@ pub fn parseIdentPattern(
     if (name == AverStr::from("_")) {
         Ok((Pattern::PatWild.clone(), pos))
     } else {
-        parseIdentPatternMaybeConstructor(tokens, pos, name)
+        crate::aver_generated::domain::parser_match::parseIdentPatternMaybeConstructor(
+            tokens, pos, name,
+        )
     }
 }
 
@@ -529,7 +577,11 @@ pub fn parseTuplePattern(
     pos: i64,
 ) -> Result<(Pattern, i64), AverStr> {
     crate::cancel_checkpoint();
-    parseTuplePatternElements(tokens, pos, &aver_rt::AverList::empty())
+    crate::aver_generated::domain::parser_match::parseTuplePatternElements(
+        tokens,
+        pos,
+        &aver_rt::AverList::empty(),
+    )
 }
 
 /// Parse [] or [h, ..t] list pattern.
@@ -538,9 +590,17 @@ pub fn parseListPattern(
     pos: i64,
 ) -> Result<(Pattern, i64), AverStr> {
     crate::cancel_checkpoint();
-    match tokenAt(tokens, pos) {
-        Token::TkRBracket => Ok((Pattern::PatEmpty.clone(), (pos + 1i64))),
-        Token::TkIdent(head) => parseConsPattern(tokens, (pos + 1i64), head),
+    match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
+        crate::aver_generated::domain::token::Token::TkRBracket => {
+            Ok((Pattern::PatEmpty.clone(), (pos + 1i64)))
+        }
+        crate::aver_generated::domain::token::Token::TkIdent(head) => {
+            crate::aver_generated::domain::parser_match::parseConsPattern(
+                tokens,
+                (pos + 1i64),
+                head,
+            )
+        }
         _ => Err(AverStr::from("Expected identifier or ']' in list pattern")),
     }
 }
@@ -552,13 +612,17 @@ pub fn parseConsPattern(
     head: AverStr,
 ) -> Result<(Pattern, i64), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = expect(tokens, pos, &Token::TkComma)?;
-    let pos3 = expect(tokens, pos2, &Token::TkDotDot)?;
-    let t = tokenAt(tokens, pos3);
+    let pos2 = crate::aver_generated::domain::parser_match::expect(tokens, pos, &Token::TkComma)?;
+    let pos3 = crate::aver_generated::domain::parser_match::expect(tokens, pos2, &Token::TkDotDot)?;
+    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos3.clone());
     match t {
-        Token::TkIdent(tail) => Ok((
-            Pattern::PatCons(head, tail),
-            expect(tokens, (pos3 + 1i64), &Token::TkRBracket)?,
+        crate::aver_generated::domain::token::Token::TkIdent(tail) => Ok((
+            crate::aver_generated::domain::ast::Pattern::PatCons(head, tail),
+            crate::aver_generated::domain::parser_match::expect(
+                tokens,
+                (pos3 + 1i64),
+                &Token::TkRBracket,
+            )?,
         )),
         _ => Err(AverStr::from("Expected tail identifier in cons pattern")),
     }
@@ -567,8 +631,10 @@ pub fn parseConsPattern(
 /// Skip optional : Type annotation.
 pub fn skipTypeAnnotation(tokens: &aver_rt::AverList<Token>, pos: i64) -> i64 {
     crate::cancel_checkpoint();
-    match tokenAt(tokens, pos) {
-        Token::TkColon => skipTypeExpr(tokens, (pos + 1i64)),
+    match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
+        crate::aver_generated::domain::token::Token::TkColon => {
+            crate::aver_generated::domain::parser_match::skipTypeExpr(tokens, (pos + 1i64))
+        }
         _ => pos,
     }
 }
@@ -577,9 +643,17 @@ pub fn skipTypeAnnotation(tokens: &aver_rt::AverList<Token>, pos: i64) -> i64 {
 pub fn skipTypeExpr(tokens: &aver_rt::AverList<Token>, pos: i64) -> i64 {
     crate::cancel_checkpoint();
     let nextPos = (pos + 1i64);
-    match tokenAt(tokens, pos) {
-        Token::TkIdent(_) => skipTypeExprTail(tokens.clone(), nextPos),
-        Token::TkLParen => skipUntilClose(tokens.clone(), nextPos, 1i64),
+    match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
+        crate::aver_generated::domain::token::Token::TkIdent(_) => {
+            crate::aver_generated::domain::parser_match::skipTypeExprTail(tokens.clone(), nextPos)
+        }
+        crate::aver_generated::domain::token::Token::TkLParen => {
+            crate::aver_generated::domain::parser_match::skipUntilClose(
+                tokens.clone(),
+                nextPos,
+                1i64,
+            )
+        }
         _ => pos,
     }
 }
@@ -589,16 +663,20 @@ pub fn skipTypeExprTail(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> i
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match tokenAt(&tokens, pos) {
-            Token::TkLt => skipUntilGt(tokens, nextPos, 1i64),
-            Token::TkDot => match tokenAt(&tokens, nextPos) {
-                Token::TkIdent(_) => {
-                    let __tmp1 = (pos + 2i64);
-                    pos = __tmp1;
-                    continue;
+        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkLt => {
+                crate::aver_generated::domain::parser_match::skipUntilGt(tokens, nextPos, 1i64)
+            }
+            crate::aver_generated::domain::token::Token::TkDot => {
+                match crate::aver_generated::domain::parser_match::tokenAt(&tokens, nextPos) {
+                    crate::aver_generated::domain::token::Token::TkIdent(_) => {
+                        let __tmp1 = (pos + 2i64);
+                        pos = __tmp1;
+                        continue;
+                    }
+                    _ => pos,
                 }
-                _ => pos,
-            },
+            }
             _ => pos,
         };
     }
@@ -613,15 +691,15 @@ pub fn skipUntilGt(mut tokens: aver_rt::AverList<Token>, mut pos: i64, mut depth
         return if (depth == 0i64) {
             pos
         } else {
-            match tokenAt(&tokens, pos) {
-                Token::TkEof => pos,
-                Token::TkLt => {
+            match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                crate::aver_generated::domain::token::Token::TkEof => pos,
+                crate::aver_generated::domain::token::Token::TkLt => {
                     let __tmp2 = (depth + 1i64);
                     pos = nextPos;
                     depth = __tmp2;
                     continue;
                 }
-                Token::TkGt => {
+                crate::aver_generated::domain::token::Token::TkGt => {
                     let __tmp2 = (depth - 1i64);
                     pos = nextPos;
                     depth = __tmp2;
@@ -645,15 +723,15 @@ pub fn skipUntilClose(mut tokens: aver_rt::AverList<Token>, mut pos: i64, mut de
         return if (depth == 0i64) {
             pos
         } else {
-            match tokenAt(&tokens, pos) {
-                Token::TkEof => pos,
-                Token::TkLParen => {
+            match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                crate::aver_generated::domain::token::Token::TkEof => pos,
+                crate::aver_generated::domain::token::Token::TkLParen => {
                     let __tmp2 = (depth + 1i64);
                     pos = nextPos;
                     depth = __tmp2;
                     continue;
                 }
-                Token::TkRParen => {
+                crate::aver_generated::domain::token::Token::TkRParen => {
                     let __tmp2 = (depth - 1i64);
                     pos = nextPos;
                     depth = __tmp2;
@@ -671,8 +749,10 @@ pub fn skipUntilClose(mut tokens: aver_rt::AverList<Token>, mut pos: i64, mut de
 /// Skip optional -> ReturnType annotation.
 pub fn skipReturnType(tokens: &aver_rt::AverList<Token>, pos: i64) -> i64 {
     crate::cancel_checkpoint();
-    match tokenAt(tokens, pos) {
-        Token::TkArrow => skipTypeExpr(tokens, (pos + 1i64)),
+    match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
+        crate::aver_generated::domain::token::Token::TkArrow => {
+            crate::aver_generated::domain::parser_match::skipTypeExpr(tokens, (pos + 1i64))
+        }
         _ => pos,
     }
 }
@@ -682,17 +762,19 @@ pub fn skipDescAndEffects(mut tokens: aver_rt::AverList<Token>, mut pos: i64) ->
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match tokenAt(&tokens, pos) {
-            Token::TkQuestion => {
+        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkQuestion => {
                 let __tmp0 = tokens.clone();
-                let __tmp1 = skipToNextLine(tokens, nextPos);
+                let __tmp1 =
+                    crate::aver_generated::domain::parser_match::skipToNextLine(tokens, nextPos);
                 tokens = __tmp0;
                 pos = __tmp1;
                 continue;
             }
-            Token::TkBang => {
+            crate::aver_generated::domain::token::Token::TkBang => {
                 let __tmp0 = tokens.clone();
-                let __tmp1 = skipEffectsBlock(&tokens, nextPos);
+                let __tmp1 =
+                    crate::aver_generated::domain::parser_match::skipEffectsBlock(&tokens, nextPos);
                 tokens = __tmp0;
                 pos = __tmp1;
                 continue;
@@ -705,9 +787,14 @@ pub fn skipDescAndEffects(mut tokens: aver_rt::AverList<Token>, mut pos: i64) ->
 /// Skip ! [effects] block — may span multiple lines with INDENT/DEDENT.
 pub fn skipEffectsBlock(tokens: &aver_rt::AverList<Token>, pos: i64) -> i64 {
     crate::cancel_checkpoint();
-    match tokenAt(tokens, pos) {
-        Token::TkLBracket => skipUntilRBracket(tokens.clone(), (pos + 1i64)),
-        _ => skipToNextLine(tokens.clone(), pos),
+    match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
+        crate::aver_generated::domain::token::Token::TkLBracket => {
+            crate::aver_generated::domain::parser_match::skipUntilRBracket(
+                tokens.clone(),
+                (pos + 1i64),
+            )
+        }
+        _ => crate::aver_generated::domain::parser_match::skipToNextLine(tokens.clone(), pos),
     }
 }
 
@@ -716,9 +803,11 @@ pub fn skipUntilRBracket(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> 
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match tokenAt(&tokens, pos) {
-            Token::TkEof => pos,
-            Token::TkRBracket => skipNewlines(tokens, nextPos),
+        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkEof => pos,
+            crate::aver_generated::domain::token::Token::TkRBracket => {
+                crate::aver_generated::domain::parser_match::skipNewlines(tokens, nextPos)
+            }
             _ => {
                 pos = nextPos;
                 continue;
@@ -732,9 +821,9 @@ pub fn skipToNextLine(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> i64
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match tokenAt(&tokens, pos) {
-            Token::TkEof => pos,
-            Token::TkNewline => nextPos,
+        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkEof => pos,
+            crate::aver_generated::domain::token::Token::TkNewline => nextPos,
             _ => {
                 pos = nextPos;
                 continue;
@@ -746,11 +835,17 @@ pub fn skipToNextLine(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> i64
 /// Skip tokens until matching DEDENT, or fall back to heuristic for flat streams.
 pub fn skipBlock(tokens: &aver_rt::AverList<Token>, pos: i64) -> i64 {
     crate::cancel_checkpoint();
-    let pos2 = skipNewlines(tokens.clone(), pos);
-    match tokenAt(tokens, pos2.clone()) {
-        Token::TkIndent => skipIndentBlock(tokens.clone(), (pos2 + 1i64), 1i64),
-        Token::TkEof => pos2,
-        _ => skipBlockFlat(tokens, pos2),
+    let pos2 = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);
+    match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
+        crate::aver_generated::domain::token::Token::TkIndent => {
+            crate::aver_generated::domain::parser_match::skipIndentBlock(
+                tokens.clone(),
+                (pos2 + 1i64),
+                1i64,
+            )
+        }
+        crate::aver_generated::domain::token::Token::TkEof => pos2,
+        _ => crate::aver_generated::domain::parser_match::skipBlockFlat(tokens, pos2),
     }
 }
 
@@ -759,15 +854,15 @@ pub fn skipIndentBlock(mut tokens: aver_rt::AverList<Token>, mut pos: i64, mut d
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match tokenAt(&tokens, pos) {
-            Token::TkEof => pos,
-            Token::TkIndent => {
+        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkEof => pos,
+            crate::aver_generated::domain::token::Token::TkIndent => {
                 let __tmp2 = (depth + 1i64);
                 pos = nextPos;
                 depth = __tmp2;
                 continue;
             }
-            Token::TkDedent => {
+            crate::aver_generated::domain::token::Token::TkDedent => {
                 if (depth <= 1i64) {
                     nextPos
                 } else {
@@ -793,8 +888,12 @@ pub fn parseModuleHeader(
     pos: i64,
 ) -> (aver_rt::AverList<AverStr>, i64) {
     crate::cancel_checkpoint();
-    let endPos = skipBlock(tokens, pos);
-    let depList = findDependsInRange(tokens.clone(), pos, endPos);
+    let endPos = crate::aver_generated::domain::parser_match::skipBlock(tokens, pos);
+    let depList = crate::aver_generated::domain::parser_match::findDependsInRange(
+        tokens.clone(),
+        pos,
+        endPos.clone(),
+    );
     (depList, endPos)
 }
 
@@ -811,10 +910,12 @@ pub fn findDependsInRange(
         return if (pos >= endPos) {
             aver_rt::AverList::empty()
         } else {
-            match tokenAt(&tokens, pos) {
-                Token::TkIdent(kw) => {
+            match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                crate::aver_generated::domain::token::Token::TkIdent(kw) => {
                     if (&*kw == "depends") {
-                        findDependsListAt(&tokens, nextPos, endPos)
+                        crate::aver_generated::domain::parser_match::findDependsListAt(
+                            &tokens, nextPos, endPos,
+                        )
                     } else {
                         {
                             pos = nextPos;
@@ -838,13 +939,15 @@ pub fn findDependsListAt(
     endPos: i64,
 ) -> aver_rt::AverList<AverStr> {
     crate::cancel_checkpoint();
-    match tokenAt(tokens, pos) {
-        Token::TkLBracket => collectDependsNames(
-            tokens.clone(),
-            (pos + 1i64),
-            endPos,
-            aver_rt::AverList::empty(),
-        ),
+    match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
+        crate::aver_generated::domain::token::Token::TkLBracket => {
+            crate::aver_generated::domain::parser_match::collectDependsNames(
+                tokens.clone(),
+                (pos + 1i64),
+                endPos,
+                aver_rt::AverList::empty(),
+            )
+        }
         _ => aver_rt::AverList::empty(),
     }
 }
@@ -863,9 +966,9 @@ pub fn collectDependsNames(
         return if (pos >= endPos) {
             acc.reverse()
         } else {
-            match tokenAt(&tokens, pos) {
-                Token::TkRBracket => acc.reverse(),
-                Token::TkIdent(name) => {
+            match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+                crate::aver_generated::domain::token::Token::TkRBracket => acc.reverse(),
+                crate::aver_generated::domain::token::Token::TkIdent(name) => {
                     let __tmp3 = aver_rt::AverList::prepend(name, &acc);
                     pos = nextPos;
                     acc = __tmp3;
@@ -883,12 +986,12 @@ pub fn collectDependsNames(
 /// Check if we've reached the end of a function body (flat mode).
 pub fn isBodyEndFlat(tokens: &aver_rt::AverList<Token>, pos: i64) -> bool {
     crate::cancel_checkpoint();
-    let t = tokenAt(tokens, pos);
+    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t {
-        Token::TkEof => true,
-        Token::TkFn => true,
-        Token::TkNewline => true,
-        Token::TkDedent => true,
+        crate::aver_generated::domain::token::Token::TkEof => true,
+        crate::aver_generated::domain::token::Token::TkFn => true,
+        crate::aver_generated::domain::token::Token::TkNewline => true,
+        crate::aver_generated::domain::token::Token::TkDedent => true,
         _ => false,
     }
 }
@@ -896,16 +999,16 @@ pub fn isBodyEndFlat(tokens: &aver_rt::AverList<Token>, pos: i64) -> bool {
 /// Check if position looks like a match arm start.
 pub fn isArmStart(tokens: &aver_rt::AverList<Token>, pos: i64) -> bool {
     crate::cancel_checkpoint();
-    let t = tokenAt(tokens, pos);
+    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t {
-        Token::TkInt(_) => true,
-        Token::TkFloat(_) => true,
-        Token::TkStr(_) => true,
-        Token::TkTrue => true,
-        Token::TkFalse => true,
-        Token::TkLBracket => true,
-        Token::TkLParen => true,
-        Token::TkIdent(_) => true,
+        crate::aver_generated::domain::token::Token::TkInt(_) => true,
+        crate::aver_generated::domain::token::Token::TkFloat(_) => true,
+        crate::aver_generated::domain::token::Token::TkStr(_) => true,
+        crate::aver_generated::domain::token::Token::TkTrue => true,
+        crate::aver_generated::domain::token::Token::TkFalse => true,
+        crate::aver_generated::domain::token::Token::TkLBracket => true,
+        crate::aver_generated::domain::token::Token::TkLParen => true,
+        crate::aver_generated::domain::token::Token::TkIdent(_) => true,
         _ => false,
     }
 }

--- a/src/self_host/aver_generated/domain/resolver/calls/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/calls/mod.rs
@@ -34,7 +34,7 @@ pub fn resolveCallsInFns(
         crate::cancel_checkpoint();
         return aver_list_match!(fns, [] => acc.reverse(), [f, rest] => { {
             let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(resolveCallsInFn(&f, &fnMap), &acc);
+            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::calls::resolveCallsInFn(&f, &fnMap), &acc);
             fns = rest;
             fnMap = __tmp1;
             acc = __tmp2;
@@ -49,7 +49,11 @@ pub fn resolveCallsInFn(fd: &FnDef, fnMap: &aver_rt::AverMap<AverStr, i64>) -> F
     FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
-        body: resolveCallsInStmts(fd.body.clone(), fnMap.clone(), aver_rt::AverList::empty()),
+        body: crate::aver_generated::domain::resolver::calls::resolveCallsInStmts(
+            fd.body.clone(),
+            fnMap.clone(),
+            aver_rt::AverList::empty(),
+        ),
         slotCount: fd.slotCount,
         slotMap: fd.slotMap.clone(),
         fastPath: fd.fastPath.clone(),
@@ -68,7 +72,7 @@ pub fn resolveCallsInStmts(
         crate::cancel_checkpoint();
         return aver_list_match!(stmts, [] => acc.reverse(), [s, rest] => { {
             let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(resolveCallsInStmt(&s, &fnMap), &acc);
+            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::calls::resolveCallsInStmt(&s, &fnMap), &acc);
             stmts = rest;
             fnMap = __tmp1;
             acc = __tmp2;
@@ -81,11 +85,23 @@ pub fn resolveCallsInStmts(
 pub fn resolveCallsInStmt(s: &Stmt, fnMap: &aver_rt::AverMap<AverStr, i64>) -> Stmt {
     crate::cancel_checkpoint();
     match s.clone() {
-        Stmt::StmtBind(name, expr) => Stmt::StmtBind(name, resolveCallsInExpr(&expr, fnMap)),
-        Stmt::StmtBindSlot(slot, expr) => {
-            Stmt::StmtBindSlot(slot, resolveCallsInExpr(&expr, fnMap))
+        crate::aver_generated::domain::ast::Stmt::StmtBind(name, expr) => {
+            crate::aver_generated::domain::ast::Stmt::StmtBind(
+                name,
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&expr, fnMap),
+            )
         }
-        Stmt::StmtExpr(expr) => Stmt::StmtExpr(resolveCallsInExpr(&expr, fnMap)),
+        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(slot, expr) => {
+            crate::aver_generated::domain::ast::Stmt::StmtBindSlot(
+                slot,
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&expr, fnMap),
+            )
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::ast::Stmt::StmtExpr(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&expr, fnMap),
+            )
+        }
     }
 }
 
@@ -93,38 +109,74 @@ pub fn resolveCallsInStmt(s: &Stmt, fnMap: &aver_rt::AverMap<AverStr, i64>) -> S
 pub fn resolveCallsInExpr(expr: &Expr, fnMap: &aver_rt::AverMap<AverStr, i64>) -> Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
+        crate::aver_generated::domain::ast::Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
             let cond = (*cond).clone();
             let thenExpr = (*thenExpr).clone();
             let elseExpr = (*elseExpr).clone();
-            Expr::ExprBoolBranch(
-                std::sync::Arc::new(resolveCallsInExpr(&cond, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&thenExpr, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&elseExpr, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(
+                        &cond, fnMap,
+                    ),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(
+                        &thenExpr, fnMap,
+                    ),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(
+                        &elseExpr, fnMap,
+                    ),
+                ),
             )
         }
-        Expr::ExprCall(name, args) => resolveOneCall(name, &args, fnMap),
-        Expr::ExprCallDirect(fnId, args) => Expr::ExprCallDirect(
-            fnId,
-            resolveCallsInExprs(args, fnMap.clone(), aver_rt::AverList::empty()),
-        ),
-        Expr::ExprCallBuiltin(name, args) => {
-            match crate::aver_generated::domain::ast::builtinNameToId(name.clone()) {
-                Some(id) => Expr::ExprCallBuiltinId(
-                    id,
-                    resolveCallsInExprs(args, fnMap.clone(), aver_rt::AverList::empty()),
+        crate::aver_generated::domain::ast::Expr::ExprCall(name, args) => {
+            crate::aver_generated::domain::resolver::calls::resolveOneCall(name, &args, fnMap)
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, args) => {
+            crate::aver_generated::domain::ast::Expr::ExprCallDirect(
+                fnId,
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                    args,
+                    fnMap.clone(),
+                    aver_rt::AverList::empty(),
                 ),
-                None => Expr::ExprCallBuiltin(
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, args) => {
+            match crate::aver_generated::domain::ast::builtinNameToId(name.clone()) {
+                Some(id) => crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
+                    id,
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                        args,
+                        fnMap.clone(),
+                        aver_rt::AverList::empty(),
+                    ),
+                ),
+                None => crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                     name,
-                    resolveCallsInExprs(args, fnMap.clone(), aver_rt::AverList::empty()),
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                        args,
+                        fnMap.clone(),
+                        aver_rt::AverList::empty(),
+                    ),
                 ),
             }
         }
-        Expr::ExprCallBuiltinId(id, args) => Expr::ExprCallBuiltinId(
-            id,
-            resolveCallsInExprs(args, fnMap.clone(), aver_rt::AverList::empty()),
-        ),
-        _ => resolveCallsInExprInternal(expr, fnMap),
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, args) => {
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
+                id,
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                    args,
+                    fnMap.clone(),
+                    aver_rt::AverList::empty(),
+                ),
+            )
+        }
+        _ => {
+            crate::aver_generated::domain::resolver::calls::resolveCallsInExprInternal(expr, fnMap)
+        }
     }
 }
 
@@ -132,65 +184,99 @@ pub fn resolveCallsInExpr(expr: &Expr, fnMap: &aver_rt::AverMap<AverStr, i64>) -
 pub fn resolveCallsInExprInternal(expr: &Expr, fnMap: &aver_rt::AverMap<AverStr, i64>) -> Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprBinopSlotInt(_, _, _) => expr.clone(),
-        Expr::ExprBinopSlots(_, _, _) => expr.clone(),
-        Expr::ExprCmpSlotInt(_, _, _) => expr.clone(),
-        Expr::ExprCmpSlots(_, _, _) => expr.clone(),
-        Expr::ExprVectorGetOrInt(vecExpr, idxExpr, defaultValue) => {
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(_, _, _) => expr.clone(),
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlots(_, _, _) => expr.clone(),
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(_, _, _) => expr.clone(),
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlots(_, _, _) => expr.clone(),
+        crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+            vecExpr,
+            idxExpr,
+            defaultValue,
+        ) => {
             let vecExpr = (*vecExpr).clone();
             let idxExpr = (*idxExpr).clone();
-            Expr::ExprVectorGetOrInt(
-                std::sync::Arc::new(resolveCallsInExpr(&vecExpr, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&idxExpr, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(
+                        &vecExpr, fnMap,
+                    ),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(
+                        &idxExpr, fnMap,
+                    ),
+                ),
                 defaultValue,
             )
         }
-        Expr::ExprIntModOrInt(a, b, defaultValue) => {
+        crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(a, b, defaultValue) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprIntModOrInt(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
                 defaultValue,
             )
         }
-        Expr::ExprAdd(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprAdd(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprAdd(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprAdd(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprSub(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprSub(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprSub(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprMul(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprMul(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprMul(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprDiv(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprDiv(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprDiv(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprNeg(inner) => {
+        crate::aver_generated::domain::ast::Expr::ExprNeg(inner) => {
             let inner = (*inner).clone();
-            Expr::ExprNeg(std::sync::Arc::new(resolveCallsInExpr(&inner, fnMap)))
+            crate::aver_generated::domain::ast::Expr::ExprNeg(std::sync::Arc::new(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&inner, fnMap),
+            ))
         }
-        _ => resolveCallsInExprTail(expr, fnMap),
+        _ => crate::aver_generated::domain::resolver::calls::resolveCallsInExprTail(expr, fnMap),
     }
 }
 
@@ -198,91 +284,154 @@ pub fn resolveCallsInExprInternal(expr: &Expr, fnMap: &aver_rt::AverMap<AverStr,
 pub fn resolveCallsInExprTail(expr: &Expr, fnMap: &aver_rt::AverMap<AverStr, i64>) -> Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprEq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprEq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprEq(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprEq(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprNeq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprNeq(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprNeq(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprLt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprLt(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprLt(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprGt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprGt(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprGt(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprLte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprLte(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprLte(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprGte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprGte(
-                std::sync::Arc::new(resolveCallsInExpr(&a, fnMap)),
-                std::sync::Arc::new(resolveCallsInExpr(&b, fnMap)),
+            crate::aver_generated::domain::ast::Expr::ExprGte(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&a, fnMap),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&b, fnMap),
+                ),
             )
         }
-        Expr::ExprMatch(subj, arms) => {
+        crate::aver_generated::domain::ast::Expr::ExprMatch(subj, arms) => {
             let subj = (*subj).clone();
-            Expr::ExprMatch(
-                std::sync::Arc::new(resolveCallsInExpr(&subj, fnMap)),
-                resolveCallsInArms(arms, fnMap.clone(), aver_rt::AverList::empty()),
+            crate::aver_generated::domain::ast::Expr::ExprMatch(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(
+                        &subj, fnMap,
+                    ),
+                ),
+                crate::aver_generated::domain::resolver::calls::resolveCallsInArms(
+                    arms,
+                    fnMap.clone(),
+                    aver_rt::AverList::empty(),
+                ),
             )
         }
-        Expr::ExprPropagate(inner) => {
+        crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => {
             let inner = (*inner).clone();
-            Expr::ExprPropagate(std::sync::Arc::new(resolveCallsInExpr(&inner, fnMap)))
+            crate::aver_generated::domain::ast::Expr::ExprPropagate(std::sync::Arc::new(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&inner, fnMap),
+            ))
         }
-        Expr::ExprConcat(parts) => Expr::ExprConcat(resolveCallsInExprs(
-            parts,
-            fnMap.clone(),
-            aver_rt::AverList::empty(),
-        )),
-        Expr::ExprTuple(exprs) => Expr::ExprTuple(resolveCallsInExprs(
-            exprs,
-            fnMap.clone(),
-            aver_rt::AverList::empty(),
-        )),
-        Expr::ExprIndependentProduct(exprs, unwrap) => Expr::ExprIndependentProduct(
-            resolveCallsInExprs(exprs, fnMap.clone(), aver_rt::AverList::empty()),
-            unwrap,
-        ),
-        Expr::ExprList(exprs) => Expr::ExprList(resolveCallsInExprs(
-            exprs,
-            fnMap.clone(),
-            aver_rt::AverList::empty(),
-        )),
-        Expr::ExprRecord(name, fields) => Expr::ExprRecord(
-            name,
-            resolveCallsInFields(fields, fnMap.clone(), aver_rt::AverList::empty()),
-        ),
-        Expr::ExprFieldAccess(obj, field) => {
+        crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
+            crate::aver_generated::domain::ast::Expr::ExprConcat(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                    parts,
+                    fnMap.clone(),
+                    aver_rt::AverList::empty(),
+                ),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
+            crate::aver_generated::domain::ast::Expr::ExprTuple(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                    exprs,
+                    fnMap.clone(),
+                    aver_rt::AverList::empty(),
+                ),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => {
+            crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                    exprs,
+                    fnMap.clone(),
+                    aver_rt::AverList::empty(),
+                ),
+                unwrap,
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
+            crate::aver_generated::domain::ast::Expr::ExprList(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                    exprs,
+                    fnMap.clone(),
+                    aver_rt::AverList::empty(),
+                ),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprRecord(name, fields) => {
+            crate::aver_generated::domain::ast::Expr::ExprRecord(
+                name,
+                crate::aver_generated::domain::resolver::calls::resolveCallsInFields(
+                    fields,
+                    fnMap.clone(),
+                    aver_rt::AverList::empty(),
+                ),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprFieldAccess(obj, field) => {
             let obj = (*obj).clone();
-            Expr::ExprFieldAccess(std::sync::Arc::new(resolveCallsInExpr(&obj, fnMap)), field)
+            crate::aver_generated::domain::ast::Expr::ExprFieldAccess(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&obj, fnMap),
+                ),
+                field,
+            )
         }
         _ => expr.clone(),
     }
@@ -296,17 +445,21 @@ pub fn resolveOneCall(
     fnMap: &aver_rt::AverMap<AverStr, i64>,
 ) -> Expr {
     crate::cancel_checkpoint();
-    let resolvedArgs = resolveCallsInExprs(args.clone(), fnMap.clone(), aver_rt::AverList::empty());
+    let resolvedArgs = crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+        args.clone(),
+        fnMap.clone(),
+        aver_rt::AverList::empty(),
+    );
     match fnMap.get(&name).cloned() {
-        Some(fnId) => Expr::ExprCallDirect(fnId, resolvedArgs),
+        Some(fnId) => crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, resolvedArgs),
         None => {
             if name.ends_with(".update") {
-                Expr::ExprCall(name, resolvedArgs)
+                crate::aver_generated::domain::ast::Expr::ExprCall(name, resolvedArgs)
             } else {
-                if isBuiltinCallName(name.clone()) {
-                    Expr::ExprCallBuiltin(name, resolvedArgs)
+                if crate::aver_generated::domain::resolver::calls::isBuiltinCallName(name.clone()) {
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, resolvedArgs)
                 } else {
-                    Expr::ExprCall(name, resolvedArgs)
+                    crate::aver_generated::domain::ast::Expr::ExprCall(name, resolvedArgs)
                 }
             }
         }
@@ -317,7 +470,7 @@ pub fn resolveOneCall(
 #[inline(always)]
 pub fn isBuiltinCallName(name: AverStr) -> bool {
     crate::cancel_checkpoint();
-    isBuiltinCallNameFrom(
+    crate::aver_generated::domain::resolver::calls::isBuiltinCallNameFrom(
         name,
         aver_rt::AverList::from_vec(vec![
             AverStr::from("Args.get"),
@@ -475,7 +628,7 @@ pub fn resolveCallsInExprs(
         crate::cancel_checkpoint();
         return aver_list_match!(exprs, [] => acc.reverse(), [e, rest] => { {
             let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(resolveCallsInExpr(&e, &fnMap), &acc);
+            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&e, &fnMap), &acc);
             exprs = rest;
             fnMap = __tmp1;
             acc = __tmp2;
@@ -495,7 +648,7 @@ pub fn resolveCallsInArms(
         crate::cancel_checkpoint();
         return aver_list_match!(arms, [] => acc.reverse(), [arm, rest] => { {
             let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(MatchArm { pattern: arm.pattern.clone(), body: resolveCallsInExpr(&arm.body, &fnMap), bindingSlots: arm.bindingSlots.clone() }, &acc);
+            let __tmp2 = aver_rt::AverList::prepend(MatchArm { pattern: arm.pattern.clone(), body: crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&arm.body, &fnMap), bindingSlots: arm.bindingSlots.clone() }, &acc);
             arms = rest;
             fnMap = __tmp1;
             acc = __tmp2;
@@ -516,7 +669,7 @@ pub fn resolveCallsInFields(
         return aver_list_match!(fields, [] => acc.reverse(), [pair, rest] => { match pair {
             (name, expr) => {
             let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend((name, resolveCallsInExpr(&expr, &fnMap)), &acc);
+            let __tmp2 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&expr, &fnMap)), &acc);
             fields = rest;
             fnMap = __tmp1;
             acc = __tmp2;

--- a/src/self_host/aver_generated/domain/resolver/core/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/core/mod.rs
@@ -17,76 +17,113 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> i64 {
             __MutualTco1::MaxSlotInExpr(mut expr, mut acc) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
+                    crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
+                        cond,
+                        thenExpr,
+                        elseExpr,
+                    ) => {
                         let cond = (*cond).clone();
                         let thenExpr = (*thenExpr).clone();
                         let elseExpr = (*elseExpr).clone();
                         __MutualTco1::MaxSlotInExpr(
                             elseExpr,
-                            maxSlotInExpr(&thenExpr, maxSlotInExpr(&cond, acc)),
+                            crate::aver_generated::domain::resolver::core::maxSlotInExpr(
+                                &thenExpr,
+                                crate::aver_generated::domain::resolver::core::maxSlotInExpr(
+                                    &cond, acc,
+                                ),
+                            ),
                         )
                     }
-                    Expr::ExprSlot(slot) => return maxInt(slot, acc),
-                    Expr::ExprBinopSlotInt(_, slot, _) => return maxInt(slot, acc),
-                    Expr::ExprBinopSlots(_, lhs, rhs) => return maxInt(rhs, maxInt(lhs, acc)),
-                    Expr::ExprCmpSlotInt(_, slot, _) => return maxInt(slot, acc),
-                    Expr::ExprCmpSlots(_, lhs, rhs) => return maxInt(rhs, maxInt(lhs, acc)),
+                    crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+                        return crate::aver_generated::domain::resolver::core::maxInt(slot, acc);
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(_, slot, _) => {
+                        return crate::aver_generated::domain::resolver::core::maxInt(slot, acc);
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprBinopSlots(_, lhs, rhs) => {
+                        return crate::aver_generated::domain::resolver::core::maxInt(
+                            rhs,
+                            crate::aver_generated::domain::resolver::core::maxInt(lhs, acc),
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(_, slot, _) => {
+                        return crate::aver_generated::domain::resolver::core::maxInt(slot, acc);
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprCmpSlots(_, lhs, rhs) => {
+                        return crate::aver_generated::domain::resolver::core::maxInt(
+                            rhs,
+                            crate::aver_generated::domain::resolver::core::maxInt(lhs, acc),
+                        );
+                    }
                     _ => __MutualTco1::MaxSlotInExprComposite(expr, acc),
                 }
             }
             __MutualTco1::MaxSlotInExprComposite(mut expr, mut acc) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                    Expr::ExprVectorGetOrInt(vecExpr, idxExpr, _) => {
+                    crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+                        vecExpr,
+                        idxExpr,
+                        _,
+                    ) => {
                         let vecExpr = (*vecExpr).clone();
                         let idxExpr = (*idxExpr).clone();
-                        __MutualTco1::MaxSlotInExpr(idxExpr, maxSlotInExpr(&vecExpr, acc))
+                        __MutualTco1::MaxSlotInExpr(
+                            idxExpr,
+                            crate::aver_generated::domain::resolver::core::maxSlotInExpr(
+                                &vecExpr, acc,
+                            ),
+                        )
                     }
-                    Expr::ExprIntModOrInt(a, b, _) => {
+                    crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(a, b, _) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
-                        __MutualTco1::MaxSlotInExpr(b, maxSlotInExpr(&a, acc))
+                        __MutualTco1::MaxSlotInExpr(
+                            b,
+                            crate::aver_generated::domain::resolver::core::maxSlotInExpr(&a, acc),
+                        )
                     }
-                    Expr::ExprAdd(a, b) => {
-                        let a = (*a).clone();
-                        let b = (*b).clone();
-                        __MutualTco1::MaxSlotInExprPair(a, b, acc)
-                    }
-                    Expr::ExprSub(a, b) => {
-                        let a = (*a).clone();
-                        let b = (*b).clone();
-                        __MutualTco1::MaxSlotInExprPair(a, b, acc)
-                    }
-                    Expr::ExprMul(a, b) => {
-                        let a = (*a).clone();
-                        let b = (*b).clone();
-                        __MutualTco1::MaxSlotInExprPair(a, b, acc)
-                    }
-                    Expr::ExprDiv(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprAdd(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
                         __MutualTco1::MaxSlotInExprPair(a, b, acc)
                     }
-                    Expr::ExprNeg(inner) => {
+                    crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
+                        let a = (*a).clone();
+                        let b = (*b).clone();
+                        __MutualTco1::MaxSlotInExprPair(a, b, acc)
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
+                        let a = (*a).clone();
+                        let b = (*b).clone();
+                        __MutualTco1::MaxSlotInExprPair(a, b, acc)
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
+                        let a = (*a).clone();
+                        let b = (*b).clone();
+                        __MutualTco1::MaxSlotInExprPair(a, b, acc)
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprNeg(inner) => {
                         let inner = (*inner).clone();
                         __MutualTco1::MaxSlotInExpr(inner, acc)
                     }
-                    Expr::ExprEq(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprEq(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
                         __MutualTco1::MaxSlotInExprPair(a, b, acc)
                     }
-                    Expr::ExprNeq(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
                         __MutualTco1::MaxSlotInExprPair(a, b, acc)
                     }
-                    Expr::ExprLt(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
                         __MutualTco1::MaxSlotInExprPair(a, b, acc)
                     }
-                    Expr::ExprGt(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
                         __MutualTco1::MaxSlotInExprPair(a, b, acc)
@@ -97,34 +134,75 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> i64 {
             __MutualTco1::MaxSlotInExprAggregate(mut expr, mut acc) => {
                 crate::cancel_checkpoint();
                 match expr {
-                    Expr::ExprLte(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
                         __MutualTco1::MaxSlotInExprPair(a, b, acc)
                     }
-                    Expr::ExprGte(a, b) => {
+                    crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
                         let a = (*a).clone();
                         let b = (*b).clone();
                         __MutualTco1::MaxSlotInExprPair(a, b, acc)
                     }
-                    Expr::ExprCall(_, args) => return maxSlotInExprs(args, acc),
-                    Expr::ExprCallDirect(_, args) => return maxSlotInExprs(args, acc),
-                    Expr::ExprCallBuiltin(_, args) => return maxSlotInExprs(args, acc),
-                    Expr::ExprCallBuiltinId(_, args) => return maxSlotInExprs(args, acc),
-                    Expr::ExprMatch(subj, arms) => {
+                    crate::aver_generated::domain::ast::Expr::ExprCall(_, args) => {
+                        return crate::aver_generated::domain::resolver::core::maxSlotInExprs(
+                            args, acc,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprCallDirect(_, args) => {
+                        return crate::aver_generated::domain::resolver::core::maxSlotInExprs(
+                            args, acc,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(_, args) => {
+                        return crate::aver_generated::domain::resolver::core::maxSlotInExprs(
+                            args, acc,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(_, args) => {
+                        return crate::aver_generated::domain::resolver::core::maxSlotInExprs(
+                            args, acc,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprMatch(subj, arms) => {
                         let subj = (*subj).clone();
-                        return maxSlotInArms(arms, maxSlotInExpr(&subj, acc));
+                        return crate::aver_generated::domain::resolver::core::maxSlotInArms(
+                            arms,
+                            crate::aver_generated::domain::resolver::core::maxSlotInExpr(
+                                &subj, acc,
+                            ),
+                        );
                     }
-                    Expr::ExprPropagate(inner) => {
+                    crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => {
                         let inner = (*inner).clone();
                         __MutualTco1::MaxSlotInExpr(inner, acc)
                     }
-                    Expr::ExprConcat(parts) => return maxSlotInExprs(parts, acc),
-                    Expr::ExprTuple(exprs) => return maxSlotInExprs(exprs, acc),
-                    Expr::ExprIndependentProduct(exprs, _) => return maxSlotInExprs(exprs, acc),
-                    Expr::ExprList(exprs) => return maxSlotInExprs(exprs, acc),
-                    Expr::ExprRecord(_, fields) => return maxSlotInFields(fields, acc),
-                    Expr::ExprFieldAccess(obj, _) => {
+                    crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
+                        return crate::aver_generated::domain::resolver::core::maxSlotInExprs(
+                            parts, acc,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
+                        return crate::aver_generated::domain::resolver::core::maxSlotInExprs(
+                            exprs, acc,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, _) => {
+                        return crate::aver_generated::domain::resolver::core::maxSlotInExprs(
+                            exprs, acc,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
+                        return crate::aver_generated::domain::resolver::core::maxSlotInExprs(
+                            exprs, acc,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprRecord(_, fields) => {
+                        return crate::aver_generated::domain::resolver::core::maxSlotInFields(
+                            fields, acc,
+                        );
+                    }
+                    crate::aver_generated::domain::ast::Expr::ExprFieldAccess(obj, _) => {
                         let obj = (*obj).clone();
                         __MutualTco1::MaxSlotInExpr(obj, acc)
                     }
@@ -133,7 +211,10 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> i64 {
             }
             __MutualTco1::MaxSlotInExprPair(mut a, mut b, mut acc) => {
                 crate::cancel_checkpoint();
-                __MutualTco1::MaxSlotInExpr(b, maxSlotInExpr(&a, acc))
+                __MutualTco1::MaxSlotInExpr(
+                    b,
+                    crate::aver_generated::domain::resolver::core::maxSlotInExpr(&a, acc),
+                )
             }
         };
     }
@@ -185,7 +266,7 @@ fn __mutual_tco_trampoline_2(
             }
             __MutualTco2::ResolveOneArm(mut arm, mut rest, mut slots, mut acc) => {
                 crate::cancel_checkpoint();
-                match resolveArm(&arm, &slots) {
+                match crate::aver_generated::domain::resolver::core::resolveArm(&arm, &slots) {
                     (resolvedArm, mergedSlots) => __MutualTco2::ResolveArms(
                         rest,
                         mergedSlots,
@@ -277,28 +358,37 @@ fn __mutual_tco_trampoline_3(
             __MutualTco3::ResolveOneStmt(mut s, mut rest, mut slots, mut next, mut acc) => {
                 crate::cancel_checkpoint();
                 match s.clone() {
-                    Stmt::StmtBind(name, expr) => {
+                    crate::aver_generated::domain::ast::Stmt::StmtBind(name, expr) => {
                         __MutualTco3::ResolveStmtBind(name, expr, rest, slots, next, acc)
                     }
-                    Stmt::StmtExpr(expr) => {
+                    crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
                         __MutualTco3::ResolveStmtExpr(expr, rest, slots, next, acc)
                     }
-                    Stmt::StmtBindSlot(_, _) => __MutualTco3::ResolveStmts(
-                        rest,
-                        slots,
-                        next,
-                        aver_rt::AverList::prepend(s, &acc),
-                    ),
+                    crate::aver_generated::domain::ast::Stmt::StmtBindSlot(_, _) => {
+                        __MutualTco3::ResolveStmts(
+                            rest,
+                            slots,
+                            next,
+                            aver_rt::AverList::prepend(s, &acc),
+                        )
+                    }
                 }
             }
             __MutualTco3::ResolveStmtExpr(mut expr, mut rest, mut slots, mut next, mut acc) => {
                 crate::cancel_checkpoint();
-                match resolveExpr(&expr, &slots) {
+                match crate::aver_generated::domain::resolver::core::resolveExpr(&expr, &slots) {
                     (re, newSlots) => __MutualTco3::ResolveStmts(
                         rest,
                         newSlots.clone(),
-                        maxInt(next, (mapMaxVal(&newSlots) + 1i64)),
-                        aver_rt::AverList::prepend(Stmt::StmtExpr(re), &acc),
+                        crate::aver_generated::domain::resolver::core::maxInt(
+                            next,
+                            (crate::aver_generated::domain::resolver::core::mapMaxVal(&newSlots)
+                                + 1i64),
+                        ),
+                        aver_rt::AverList::prepend(
+                            crate::aver_generated::domain::ast::Stmt::StmtExpr(re),
+                            &acc,
+                        ),
                     ),
                 }
             }
@@ -311,7 +401,7 @@ fn __mutual_tco_trampoline_3(
                 mut acc,
             ) => {
                 crate::cancel_checkpoint();
-                match resolveExpr(&expr, &slots) {
+                match crate::aver_generated::domain::resolver::core::resolveExpr(&expr, &slots) {
                     (newExpr, exprSlots) => __MutualTco3::ResolveStmtBindFinish(
                         name, newExpr, rest, exprSlots, next, acc,
                     ),
@@ -331,7 +421,10 @@ fn __mutual_tco_trampoline_3(
                     rest,
                     newSlots,
                     (next + 1i64),
-                    aver_rt::AverList::prepend(Stmt::StmtBindSlot(next, newExpr), &acc),
+                    aver_rt::AverList::prepend(
+                        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(next, newExpr),
+                        &acc,
+                    ),
                 )
             }
         };
@@ -434,7 +527,7 @@ pub fn resolveFns(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(fns, [] => acc.reverse(), [f, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(resolveFn(&f), &acc);
+            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::core::resolveFn(&f), &acc);
             fns = rest;
             acc = __tmp1;
             continue;
@@ -445,10 +538,14 @@ pub fn resolveFns(
 /// Resolve one function: assign slots to params and locals.
 pub fn resolveFn(fd: &FnDef) -> FnDef {
     crate::cancel_checkpoint();
-    let paramResult = buildParamSlots(fd.params.clone(), HashMap::new(), 0i64);
+    let paramResult = crate::aver_generated::domain::resolver::core::buildParamSlots(
+        fd.params.clone(),
+        HashMap::new(),
+        0i64,
+    );
     {
         let (slotMap, nextSlot) = paramResult;
-        resolveBody(fd, &slotMap, nextSlot)
+        crate::aver_generated::domain::resolver::core::resolveBody(fd, &slotMap, nextSlot)
     }
 }
 
@@ -475,10 +572,20 @@ pub fn buildParamSlots(
 /// Walk body stmts, resolve vars, track new bindings. slotCount = max slot + 1 from body scan.
 pub fn resolveBody(fd: &FnDef, slots: &aver_rt::AverMap<AverStr, i64>, nextSlot: i64) -> FnDef {
     crate::cancel_checkpoint();
-    let resolved = resolveStmts(&fd.body, slots, nextSlot, &aver_rt::AverList::empty());
+    let resolved = crate::aver_generated::domain::resolver::core::resolveStmts(
+        &fd.body,
+        slots,
+        nextSlot,
+        &aver_rt::AverList::empty(),
+    );
     {
         let (newBody, finalSlot, finalSlotMap) = resolved;
-        computeSlotCount(fd, &newBody, finalSlot, &finalSlotMap)
+        crate::aver_generated::domain::resolver::core::computeSlotCount(
+            fd,
+            &newBody,
+            finalSlot,
+            &finalSlotMap,
+        )
     }
 }
 
@@ -490,7 +597,10 @@ pub fn computeSlotCount(
     slotMap: &aver_rt::AverMap<AverStr, i64>,
 ) -> FnDef {
     crate::cancel_checkpoint();
-    let maxFromBody = maxSlotInStmts(body.clone(), (baseSlot - 1i64));
+    let maxFromBody = crate::aver_generated::domain::resolver::core::maxSlotInStmts(
+        body.clone(),
+        (baseSlot - 1i64),
+    );
     FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
@@ -508,7 +618,7 @@ pub fn maxSlotInStmts(mut stmts: aver_rt::AverList<Stmt>, mut acc: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(stmts, [] => acc, [s, rest] => { {
-            let __tmp1 = maxSlotInStmt(&s, acc);
+            let __tmp1 = crate::aver_generated::domain::resolver::core::maxSlotInStmt(&s, acc);
             stmts = rest;
             acc = __tmp1;
             continue;
@@ -520,9 +630,18 @@ pub fn maxSlotInStmts(mut stmts: aver_rt::AverList<Stmt>, mut acc: i64) -> i64 {
 pub fn maxSlotInStmt(s: &Stmt, acc: i64) -> i64 {
     crate::cancel_checkpoint();
     match s.clone() {
-        Stmt::StmtBindSlot(slot, expr) => maxSlotInExpr(&expr, maxInt(slot, acc)),
-        Stmt::StmtExpr(expr) => maxSlotInExpr(&expr, acc),
-        Stmt::StmtBind(_, expr) => maxSlotInExpr(&expr, acc),
+        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(slot, expr) => {
+            crate::aver_generated::domain::resolver::core::maxSlotInExpr(
+                &expr,
+                crate::aver_generated::domain::resolver::core::maxInt(slot, acc),
+            )
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::resolver::core::maxSlotInExpr(&expr, acc)
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtBind(_, expr) => {
+            crate::aver_generated::domain::resolver::core::maxSlotInExpr(&expr, acc)
+        }
     }
 }
 
@@ -532,7 +651,7 @@ pub fn maxSlotInExprs(mut exprs: aver_rt::AverList<Expr>, mut acc: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(exprs, [] => acc, [e, rest] => { {
-            let __tmp1 = maxSlotInExpr(&e, acc);
+            let __tmp1 = crate::aver_generated::domain::resolver::core::maxSlotInExpr(&e, acc);
             exprs = rest;
             acc = __tmp1;
             continue;
@@ -547,7 +666,7 @@ pub fn maxSlotInFields(mut fields: aver_rt::AverList<(AverStr, Expr)>, mut acc: 
         crate::cancel_checkpoint();
         return aver_list_match!(fields, [] => acc, [pair, rest] => { match pair {
             (_, expr) => {
-            let __tmp1 = maxSlotInExpr(&expr, acc);
+            let __tmp1 = crate::aver_generated::domain::resolver::core::maxSlotInExpr(&expr, acc);
             fields = rest;
             acc = __tmp1;
             continue;
@@ -562,7 +681,7 @@ pub fn maxSlotInArms(mut arms: aver_rt::AverList<MatchArm>, mut acc: i64) -> i64
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(arms, [] => acc, [arm, rest] => { {
-            let __tmp1 = maxSlotInExpr(&arm.body, acc);
+            let __tmp1 = crate::aver_generated::domain::resolver::core::maxSlotInExpr(&arm.body, acc);
             arms = rest;
             acc = __tmp1;
             continue;
@@ -584,26 +703,41 @@ pub fn resolveExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
+        crate::aver_generated::domain::ast::Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
             let cond = (*cond).clone();
             let thenExpr = (*thenExpr).clone();
             let elseExpr = (*elseExpr).clone();
             (
-                Expr::ExprBoolBranch(
-                    std::sync::Arc::new(resolveExprSimple(&cond, slots)),
-                    std::sync::Arc::new(resolveExprSimple(&thenExpr, slots)),
-                    std::sync::Arc::new(resolveExprSimple(&elseExpr, slots)),
+                crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
+                    std::sync::Arc::new(
+                        crate::aver_generated::domain::resolver::core::resolveExprSimple(
+                            &cond, slots,
+                        ),
+                    ),
+                    std::sync::Arc::new(
+                        crate::aver_generated::domain::resolver::core::resolveExprSimple(
+                            &thenExpr, slots,
+                        ),
+                    ),
+                    std::sync::Arc::new(
+                        crate::aver_generated::domain::resolver::core::resolveExprSimple(
+                            &elseExpr, slots,
+                        ),
+                    ),
                 ),
                 slots.clone(),
             )
         }
-        Expr::ExprVar(name) => (resolveVar(name, slots), slots.clone()),
-        Expr::ExprInt(_) => (expr.clone(), slots.clone()),
-        Expr::ExprFloat(_) => (expr.clone(), slots.clone()),
-        Expr::ExprStr(_) => (expr.clone(), slots.clone()),
-        Expr::ExprBool(_) => (expr.clone(), slots.clone()),
-        Expr::ExprSlot(_) => (expr.clone(), slots.clone()),
-        _ => resolveExprAfterLeaf(expr, slots),
+        crate::aver_generated::domain::ast::Expr::ExprVar(name) => (
+            crate::aver_generated::domain::resolver::core::resolveVar(name, slots),
+            slots.clone(),
+        ),
+        crate::aver_generated::domain::ast::Expr::ExprInt(_) => (expr.clone(), slots.clone()),
+        crate::aver_generated::domain::ast::Expr::ExprFloat(_) => (expr.clone(), slots.clone()),
+        crate::aver_generated::domain::ast::Expr::ExprStr(_) => (expr.clone(), slots.clone()),
+        crate::aver_generated::domain::ast::Expr::ExprBool(_) => (expr.clone(), slots.clone()),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(_) => (expr.clone(), slots.clone()),
+        _ => crate::aver_generated::domain::resolver::core::resolveExprAfterLeaf(expr, slots),
     }
 }
 
@@ -614,72 +748,128 @@ pub fn resolveExprAfterLeaf(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprBinopSlotInt(_, _, _) => (expr.clone(), slots.clone()),
-        Expr::ExprBinopSlots(_, _, _) => (expr.clone(), slots.clone()),
-        Expr::ExprCmpSlotInt(_, _, _) => (expr.clone(), slots.clone()),
-        Expr::ExprCmpSlots(_, _, _) => (expr.clone(), slots.clone()),
-        Expr::ExprVectorGetOrInt(vecExpr, idxExpr, defaultValue) => {
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(_, _, _) => {
+            (expr.clone(), slots.clone())
+        }
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlots(_, _, _) => {
+            (expr.clone(), slots.clone())
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(_, _, _) => {
+            (expr.clone(), slots.clone())
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlots(_, _, _) => {
+            (expr.clone(), slots.clone())
+        }
+        crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+            vecExpr,
+            idxExpr,
+            defaultValue,
+        ) => {
             let vecExpr = (*vecExpr).clone();
             let idxExpr = (*idxExpr).clone();
             (
-                Expr::ExprVectorGetOrInt(
-                    std::sync::Arc::new(resolveExprSimple(&vecExpr, slots)),
-                    std::sync::Arc::new(resolveExprSimple(&idxExpr, slots)),
+                crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+                    std::sync::Arc::new(
+                        crate::aver_generated::domain::resolver::core::resolveExprSimple(
+                            &vecExpr, slots,
+                        ),
+                    ),
+                    std::sync::Arc::new(
+                        crate::aver_generated::domain::resolver::core::resolveExprSimple(
+                            &idxExpr, slots,
+                        ),
+                    ),
                     defaultValue,
                 ),
                 slots.clone(),
             )
         }
-        Expr::ExprIntModOrInt(a, b, defaultValue) => {
+        crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(a, b, defaultValue) => {
             let a = (*a).clone();
             let b = (*b).clone();
             (
-                Expr::ExprIntModOrInt(
-                    std::sync::Arc::new(resolveExprSimple(&a, slots)),
-                    std::sync::Arc::new(resolveExprSimple(&b, slots)),
+                crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(
+                    std::sync::Arc::new(
+                        crate::aver_generated::domain::resolver::core::resolveExprSimple(&a, slots),
+                    ),
+                    std::sync::Arc::new(
+                        crate::aver_generated::domain::resolver::core::resolveExprSimple(&b, slots),
+                    ),
                     defaultValue,
                 ),
                 slots.clone(),
             )
         }
-        Expr::ExprAdd(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprAdd(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("add"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("add"),
+            )
         }
-        Expr::ExprSub(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("sub"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("sub"),
+            )
         }
-        Expr::ExprMul(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("mul"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("mul"),
+            )
         }
-        Expr::ExprDiv(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("div"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("div"),
+            )
         }
-        Expr::ExprNeg(inner) => {
+        crate::aver_generated::domain::ast::Expr::ExprNeg(inner) => {
             let inner = (*inner).clone();
             (
-                Expr::ExprNeg(std::sync::Arc::new(resolveExprSimple(&inner, slots))),
+                crate::aver_generated::domain::ast::Expr::ExprNeg(std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::core::resolveExprSimple(&inner, slots),
+                )),
                 slots.clone(),
             )
         }
-        Expr::ExprEq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprEq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("eq"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("eq"),
+            )
         }
-        Expr::ExprNeq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("neq"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("neq"),
+            )
         }
-        _ => resolveExprAfterArith(expr, slots),
+        _ => crate::aver_generated::domain::resolver::core::resolveExprAfterArith(expr, slots),
     }
 }
 
@@ -690,59 +880,97 @@ pub fn resolveExprAfterArith(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprLt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("lt"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("lt"),
+            )
         }
-        Expr::ExprGt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("gt"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("gt"),
+            )
         }
-        Expr::ExprLte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("lte"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("lte"),
+            )
         }
-        Expr::ExprGte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            resolveBinExpr(&a, &b, slots, AverStr::from("gte"))
+            crate::aver_generated::domain::resolver::core::resolveBinExpr(
+                &a,
+                &b,
+                slots,
+                AverStr::from("gte"),
+            )
         }
-        Expr::ExprCall(name, args) => resolveCallExpr(name, &args, slots),
-        Expr::ExprCallDirect(fnId, args) => (
-            Expr::ExprCallDirect(
+        crate::aver_generated::domain::ast::Expr::ExprCall(name, args) => {
+            crate::aver_generated::domain::resolver::core::resolveCallExpr(name, &args, slots)
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, args) => (
+            crate::aver_generated::domain::ast::Expr::ExprCallDirect(
                 fnId,
-                resolveExprs(args, slots.clone(), aver_rt::AverList::empty()),
+                crate::aver_generated::domain::resolver::core::resolveExprs(
+                    args,
+                    slots.clone(),
+                    aver_rt::AverList::empty(),
+                ),
             ),
             slots.clone(),
         ),
-        Expr::ExprCallBuiltin(name, args) => (
-            Expr::ExprCallBuiltin(
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, args) => (
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                 name,
-                resolveExprs(args, slots.clone(), aver_rt::AverList::empty()),
+                crate::aver_generated::domain::resolver::core::resolveExprs(
+                    args,
+                    slots.clone(),
+                    aver_rt::AverList::empty(),
+                ),
             ),
             slots.clone(),
         ),
-        Expr::ExprCallBuiltinId(id, args) => (
-            Expr::ExprCallBuiltinId(
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, args) => (
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
                 id,
-                resolveExprs(args, slots.clone(), aver_rt::AverList::empty()),
+                crate::aver_generated::domain::resolver::core::resolveExprs(
+                    args,
+                    slots.clone(),
+                    aver_rt::AverList::empty(),
+                ),
             ),
             slots.clone(),
         ),
-        Expr::ExprMatch(subj, arms) => {
+        crate::aver_generated::domain::ast::Expr::ExprMatch(subj, arms) => {
             let subj = (*subj).clone();
-            resolveMatchExpr(&subj, &arms, slots)
+            crate::aver_generated::domain::resolver::core::resolveMatchExpr(&subj, &arms, slots)
         }
-        Expr::ExprPropagate(inner) => {
+        crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => {
             let inner = (*inner).clone();
-            resolvePropExpr(&inner, slots)
+            crate::aver_generated::domain::resolver::core::resolvePropExpr(&inner, slots)
         }
-        Expr::ExprConcat(parts) => resolveConcatExpr(&parts, slots),
-        Expr::ExprTuple(exprs) => resolveTupleExpr(&exprs, slots),
-        _ => resolveExprAfterAggregate(expr, slots),
+        crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
+            crate::aver_generated::domain::resolver::core::resolveConcatExpr(&parts, slots)
+        }
+        crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
+            crate::aver_generated::domain::resolver::core::resolveTupleExpr(&exprs, slots)
+        }
+        _ => crate::aver_generated::domain::resolver::core::resolveExprAfterAggregate(expr, slots),
     }
 }
 
@@ -753,14 +981,20 @@ pub fn resolveExprAfterAggregate(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprIndependentProduct(exprs, unwrap) => {
-            resolveIndependentProductExpr(&exprs, unwrap, slots)
+        crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => {
+            crate::aver_generated::domain::resolver::core::resolveIndependentProductExpr(
+                &exprs, unwrap, slots,
+            )
         }
-        Expr::ExprList(exprs) => resolveListExpr(&exprs, slots),
-        Expr::ExprRecord(name, fields) => resolveRecordExpr(name, &fields, slots),
-        Expr::ExprFieldAccess(obj, field) => {
+        crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
+            crate::aver_generated::domain::resolver::core::resolveListExpr(&exprs, slots)
+        }
+        crate::aver_generated::domain::ast::Expr::ExprRecord(name, fields) => {
+            crate::aver_generated::domain::resolver::core::resolveRecordExpr(name, &fields, slots)
+        }
+        crate::aver_generated::domain::ast::Expr::ExprFieldAccess(obj, field) => {
             let obj = (*obj).clone();
-            resolveFieldExpr(&obj, field, slots)
+            crate::aver_generated::domain::resolver::core::resolveFieldExpr(&obj, field, slots)
         }
         _ => (expr.clone(), slots.clone()),
     }
@@ -775,49 +1009,67 @@ pub fn resolveBinExpr(
     op: AverStr,
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
-    let ra = resolveExprSimple(a, slots);
-    let rb = resolveExprSimple(b, slots);
+    let ra = crate::aver_generated::domain::resolver::core::resolveExprSimple(a, slots);
+    let rb = crate::aver_generated::domain::resolver::core::resolveExprSimple(b, slots);
     {
         let __dispatch_subject = op;
         if &*__dispatch_subject == "add" {
             (
-                Expr::ExprAdd(std::sync::Arc::new(ra), std::sync::Arc::new(rb)),
+                crate::aver_generated::domain::ast::Expr::ExprAdd(
+                    std::sync::Arc::new(ra),
+                    std::sync::Arc::new(rb),
+                ),
                 slots.clone(),
             )
         } else {
             if &*__dispatch_subject == "sub" {
                 (
-                    Expr::ExprSub(std::sync::Arc::new(ra), std::sync::Arc::new(rb)),
+                    crate::aver_generated::domain::ast::Expr::ExprSub(
+                        std::sync::Arc::new(ra),
+                        std::sync::Arc::new(rb),
+                    ),
                     slots.clone(),
                 )
             } else {
                 if &*__dispatch_subject == "mul" {
                     (
-                        Expr::ExprMul(std::sync::Arc::new(ra), std::sync::Arc::new(rb)),
+                        crate::aver_generated::domain::ast::Expr::ExprMul(
+                            std::sync::Arc::new(ra),
+                            std::sync::Arc::new(rb),
+                        ),
                         slots.clone(),
                     )
                 } else {
                     if &*__dispatch_subject == "div" {
                         (
-                            Expr::ExprDiv(std::sync::Arc::new(ra), std::sync::Arc::new(rb)),
+                            crate::aver_generated::domain::ast::Expr::ExprDiv(
+                                std::sync::Arc::new(ra),
+                                std::sync::Arc::new(rb),
+                            ),
                             slots.clone(),
                         )
                     } else {
                         if &*__dispatch_subject == "eq" {
                             (
-                                Expr::ExprEq(std::sync::Arc::new(ra), std::sync::Arc::new(rb)),
+                                crate::aver_generated::domain::ast::Expr::ExprEq(
+                                    std::sync::Arc::new(ra),
+                                    std::sync::Arc::new(rb),
+                                ),
                                 slots.clone(),
                             )
                         } else {
                             if &*__dispatch_subject == "neq" {
                                 (
-                                    Expr::ExprNeq(std::sync::Arc::new(ra), std::sync::Arc::new(rb)),
+                                    crate::aver_generated::domain::ast::Expr::ExprNeq(
+                                        std::sync::Arc::new(ra),
+                                        std::sync::Arc::new(rb),
+                                    ),
                                     slots.clone(),
                                 )
                             } else {
                                 if &*__dispatch_subject == "lt" {
                                     (
-                                        Expr::ExprLt(
+                                        crate::aver_generated::domain::ast::Expr::ExprLt(
                                             std::sync::Arc::new(ra),
                                             std::sync::Arc::new(rb),
                                         ),
@@ -826,7 +1078,7 @@ pub fn resolveBinExpr(
                                 } else {
                                     if &*__dispatch_subject == "gt" {
                                         (
-                                            Expr::ExprGt(
+                                            crate::aver_generated::domain::ast::Expr::ExprGt(
                                                 std::sync::Arc::new(ra),
                                                 std::sync::Arc::new(rb),
                                             ),
@@ -835,7 +1087,7 @@ pub fn resolveBinExpr(
                                     } else {
                                         if &*__dispatch_subject == "lte" {
                                             (
-                                                Expr::ExprLte(
+                                                crate::aver_generated::domain::ast::Expr::ExprLte(
                                                     std::sync::Arc::new(ra),
                                                     std::sync::Arc::new(rb),
                                                 ),
@@ -843,21 +1095,9 @@ pub fn resolveBinExpr(
                                             )
                                         } else {
                                             if &*__dispatch_subject == "gte" {
-                                                (
-                                                    Expr::ExprGte(
-                                                        std::sync::Arc::new(ra),
-                                                        std::sync::Arc::new(rb),
-                                                    ),
-                                                    slots.clone(),
-                                                )
+                                                (crate::aver_generated::domain::ast::Expr::ExprGte(std::sync::Arc::new(ra), std::sync::Arc::new(rb)), slots.clone())
                                             } else {
-                                                (
-                                                    Expr::ExprAdd(
-                                                        std::sync::Arc::new(ra),
-                                                        std::sync::Arc::new(rb),
-                                                    ),
-                                                    slots.clone(),
-                                                )
+                                                (crate::aver_generated::domain::ast::Expr::ExprAdd(std::sync::Arc::new(ra), std::sync::Arc::new(rb)), slots.clone())
                                             }
                                         }
                                     }
@@ -875,7 +1115,7 @@ pub fn resolveBinExpr(
 pub fn resolveExprSimple(expr: &Expr, slots: &aver_rt::AverMap<AverStr, i64>) -> Expr {
     crate::cancel_checkpoint();
     {
-        let (e, _) = resolveExpr(expr, slots);
+        let (e, _) = crate::aver_generated::domain::resolver::core::resolveExpr(expr, slots);
         e
     }
 }
@@ -888,9 +1128,13 @@ pub fn resolveCallExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     (
-        Expr::ExprCall(
+        crate::aver_generated::domain::ast::Expr::ExprCall(
             name,
-            resolveExprs(args.clone(), slots.clone(), aver_rt::AverList::empty()),
+            crate::aver_generated::domain::resolver::core::resolveExprs(
+                args.clone(),
+                slots.clone(),
+                aver_rt::AverList::empty(),
+            ),
         ),
         slots.clone(),
     )
@@ -903,12 +1147,19 @@ pub fn resolveMatchExpr(
     slots: &aver_rt::AverMap<AverStr, i64>,
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
-    let rs = resolveExprSimple(subj, slots);
-    let armsResult = resolveArms(arms, slots, &aver_rt::AverList::empty());
+    let rs = crate::aver_generated::domain::resolver::core::resolveExprSimple(subj, slots);
+    let armsResult = crate::aver_generated::domain::resolver::core::resolveArms(
+        arms,
+        slots,
+        &aver_rt::AverList::empty(),
+    );
     {
         let (resolvedArms, mergedSlots) = armsResult;
         (
-            Expr::ExprMatch(std::sync::Arc::new(rs), resolvedArms),
+            crate::aver_generated::domain::ast::Expr::ExprMatch(
+                std::sync::Arc::new(rs),
+                resolvedArms,
+            ),
             mergedSlots,
         )
     }
@@ -921,7 +1172,9 @@ pub fn resolvePropExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     (
-        Expr::ExprPropagate(std::sync::Arc::new(resolveExprSimple(inner, slots))),
+        crate::aver_generated::domain::ast::Expr::ExprPropagate(std::sync::Arc::new(
+            crate::aver_generated::domain::resolver::core::resolveExprSimple(inner, slots),
+        )),
         slots.clone(),
     )
 }
@@ -933,11 +1186,13 @@ pub fn resolveConcatExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     (
-        Expr::ExprConcat(resolveExprs(
-            parts.clone(),
-            slots.clone(),
-            aver_rt::AverList::empty(),
-        )),
+        crate::aver_generated::domain::ast::Expr::ExprConcat(
+            crate::aver_generated::domain::resolver::core::resolveExprs(
+                parts.clone(),
+                slots.clone(),
+                aver_rt::AverList::empty(),
+            ),
+        ),
         slots.clone(),
     )
 }
@@ -949,11 +1204,13 @@ pub fn resolveTupleExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     (
-        Expr::ExprTuple(resolveExprs(
-            exprs.clone(),
-            slots.clone(),
-            aver_rt::AverList::empty(),
-        )),
+        crate::aver_generated::domain::ast::Expr::ExprTuple(
+            crate::aver_generated::domain::resolver::core::resolveExprs(
+                exprs.clone(),
+                slots.clone(),
+                aver_rt::AverList::empty(),
+            ),
+        ),
         slots.clone(),
     )
 }
@@ -966,8 +1223,12 @@ pub fn resolveIndependentProductExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     (
-        Expr::ExprIndependentProduct(
-            resolveExprs(exprs.clone(), slots.clone(), aver_rt::AverList::empty()),
+        crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
+            crate::aver_generated::domain::resolver::core::resolveExprs(
+                exprs.clone(),
+                slots.clone(),
+                aver_rt::AverList::empty(),
+            ),
             unwrap,
         ),
         slots.clone(),
@@ -981,11 +1242,13 @@ pub fn resolveListExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     (
-        Expr::ExprList(resolveExprs(
-            exprs.clone(),
-            slots.clone(),
-            aver_rt::AverList::empty(),
-        )),
+        crate::aver_generated::domain::ast::Expr::ExprList(
+            crate::aver_generated::domain::resolver::core::resolveExprs(
+                exprs.clone(),
+                slots.clone(),
+                aver_rt::AverList::empty(),
+            ),
+        ),
         slots.clone(),
     )
 }
@@ -998,9 +1261,13 @@ pub fn resolveRecordExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     (
-        Expr::ExprRecord(
+        crate::aver_generated::domain::ast::Expr::ExprRecord(
             name,
-            resolveFields(fields.clone(), slots.clone(), aver_rt::AverList::empty()),
+            crate::aver_generated::domain::resolver::core::resolveFields(
+                fields.clone(),
+                slots.clone(),
+                aver_rt::AverList::empty(),
+            ),
         ),
         slots.clone(),
     )
@@ -1014,7 +1281,12 @@ pub fn resolveFieldExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     (
-        Expr::ExprFieldAccess(std::sync::Arc::new(resolveExprSimple(obj, slots)), field),
+        crate::aver_generated::domain::ast::Expr::ExprFieldAccess(
+            std::sync::Arc::new(
+                crate::aver_generated::domain::resolver::core::resolveExprSimple(obj, slots),
+            ),
+            field,
+        ),
         slots.clone(),
     )
 }
@@ -1024,8 +1296,8 @@ pub fn resolveFieldExpr(
 pub fn resolveVar(name: AverStr, slots: &aver_rt::AverMap<AverStr, i64>) -> Expr {
     crate::cancel_checkpoint();
     match slots.get(&name).cloned() {
-        Some(slot) => Expr::ExprSlot(slot),
-        None => Expr::ExprVar(name),
+        Some(slot) => crate::aver_generated::domain::ast::Expr::ExprSlot(slot),
+        None => crate::aver_generated::domain::ast::Expr::ExprVar(name),
     }
 }
 
@@ -1040,7 +1312,7 @@ pub fn resolveExprs(
         crate::cancel_checkpoint();
         return aver_list_match!(exprs, [] => acc.reverse(), [e, rest] => { {
             let __tmp1 = slots.clone();
-            let __tmp2 = aver_rt::AverList::prepend(resolveExprSimple(&e, &slots), &acc);
+            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::core::resolveExprSimple(&e, &slots), &acc);
             exprs = rest;
             slots = __tmp1;
             acc = __tmp2;
@@ -1061,7 +1333,7 @@ pub fn resolveFields(
         return aver_list_match!(fields, [] => acc.reverse(), [pair, rest] => { match pair {
             (name, expr) => {
             let __tmp1 = slots.clone();
-            let __tmp2 = aver_rt::AverList::prepend((name, resolveExprSimple(&expr, &slots)), &acc);
+            let __tmp2 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::core::resolveExprSimple(&expr, &slots)), &acc);
             fields = rest;
             slots = __tmp1;
             acc = __tmp2;
@@ -1077,10 +1349,18 @@ pub fn resolveArm(
     slots: &aver_rt::AverMap<AverStr, i64>,
 ) -> (MatchArm, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
-    let armSlotResult = addPatternSlots(&arm.pattern, slots);
+    let armSlotResult =
+        crate::aver_generated::domain::resolver::core::addPatternSlots(&arm.pattern, slots);
     {
         let (newSlots, _) = armSlotResult;
-        resolveArmBody(arm, &newSlots, &patternBindingSlots(&arm.pattern, slots))
+        crate::aver_generated::domain::resolver::core::resolveArmBody(
+            arm,
+            &newSlots,
+            &crate::aver_generated::domain::resolver::core::patternBindingSlots(
+                &arm.pattern,
+                slots,
+            ),
+        )
     }
 }
 
@@ -1092,7 +1372,8 @@ pub fn resolveArmBody(
 ) -> (MatchArm, aver_rt::AverMap<AverStr, i64>) {
     crate::cancel_checkpoint();
     {
-        let (re, finalSlots) = resolveExpr(&arm.body, newSlots);
+        let (re, finalSlots) =
+            crate::aver_generated::domain::resolver::core::resolveExpr(&arm.body, newSlots);
         (
             MatchArm {
                 pattern: arm.pattern.clone(),
@@ -1110,9 +1391,14 @@ pub fn patternBindingSlots(
     slots: &aver_rt::AverMap<AverStr, i64>,
 ) -> aver_rt::AverMap<AverStr, i64> {
     crate::cancel_checkpoint();
-    let nextSlot = (mapMaxVal(slots) + 1i64);
+    let nextSlot = (crate::aver_generated::domain::resolver::core::mapMaxVal(slots) + 1i64);
     {
-        let (bindingSlots, _) = patternBindingSlotsInner(pat, &HashMap::new(), nextSlot);
+        let (bindingSlots, _) =
+            crate::aver_generated::domain::resolver::core::patternBindingSlotsInner(
+                pat,
+                &HashMap::new(),
+                nextSlot,
+            );
         bindingSlots
     }
 }
@@ -1125,15 +1411,38 @@ pub fn patternBindingSlotsInner(
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     crate::cancel_checkpoint();
     match pat.clone() {
-        Pattern::PatVar(name) => (bindingSlots.clone().insert_owned(name, next), (next + 1i64)),
-        Pattern::PatCons(h, t) => patternBindingSlotsCons(h, t, bindingSlots, next),
-        Pattern::PatConstructor(_, bindings) => {
-            patternBindingSlotsConstructor(bindings, bindingSlots.clone(), next)
+        crate::aver_generated::domain::ast::Pattern::PatVar(name) => {
+            (bindingSlots.clone().insert_owned(name, next), (next + 1i64))
         }
-        Pattern::PatConstructorId(_, _, bindings) => {
-            patternBindingSlotsConstructor(bindings, bindingSlots.clone(), next)
+        crate::aver_generated::domain::ast::Pattern::PatCons(h, t) => {
+            crate::aver_generated::domain::resolver::core::patternBindingSlotsCons(
+                h,
+                t,
+                bindingSlots,
+                next,
+            )
         }
-        Pattern::PatTuple(pats) => patternBindingSlotsTuple(pats, bindingSlots.clone(), next),
+        crate::aver_generated::domain::ast::Pattern::PatConstructor(_, bindings) => {
+            crate::aver_generated::domain::resolver::core::patternBindingSlotsConstructor(
+                bindings,
+                bindingSlots.clone(),
+                next,
+            )
+        }
+        crate::aver_generated::domain::ast::Pattern::PatConstructorId(_, _, bindings) => {
+            crate::aver_generated::domain::resolver::core::patternBindingSlotsConstructor(
+                bindings,
+                bindingSlots.clone(),
+                next,
+            )
+        }
+        crate::aver_generated::domain::ast::Pattern::PatTuple(pats) => {
+            crate::aver_generated::domain::resolver::core::patternBindingSlotsTuple(
+                pats,
+                bindingSlots.clone(),
+                next,
+            )
+        }
         _ => (bindingSlots.clone(), next),
     }
 }
@@ -1179,7 +1488,7 @@ pub fn patternBindingSlotsTuple(
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(pats, [] => (bindingSlots, next), [p, rest] => { match patternBindingSlotsInner(&p, &bindingSlots, next) {
+        return aver_list_match!(pats, [] => (bindingSlots, next), [p, rest] => { match crate::aver_generated::domain::resolver::core::patternBindingSlotsInner(&p, &bindingSlots, next) {
             (newBindingSlots, newNext) => {
             pats = rest;
             bindingSlots = newBindingSlots;
@@ -1196,8 +1505,8 @@ pub fn addPatternSlots(
     slots: &aver_rt::AverMap<AverStr, i64>,
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     crate::cancel_checkpoint();
-    let nextSlot = (mapMaxVal(slots) + 1i64);
-    addPatternSlotsInner(pat, slots, nextSlot)
+    let nextSlot = (crate::aver_generated::domain::resolver::core::mapMaxVal(slots) + 1i64);
+    crate::aver_generated::domain::resolver::core::addPatternSlotsInner(pat, slots, nextSlot)
 }
 
 /// Get maximum value in a map, or -1 if empty.
@@ -1205,7 +1514,7 @@ pub fn addPatternSlots(
 pub fn mapMaxVal(m: &aver_rt::AverMap<AverStr, i64>) -> i64 {
     crate::cancel_checkpoint();
     let vals = aver_rt::AverList::from_vec(m.values().cloned().collect::<Vec<_>>());
-    maxInList(vals, (0i64 - 1i64))
+    crate::aver_generated::domain::resolver::core::maxInList(vals, (0i64 - 1i64))
 }
 
 /// Find maximum value in a list.
@@ -1232,13 +1541,33 @@ pub fn addPatternSlotsInner(
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     crate::cancel_checkpoint();
     match pat.clone() {
-        Pattern::PatVar(name) => (slots.clone().insert_owned(name, next), (next + 1i64)),
-        Pattern::PatCons(h, t) => addConsSlots(h, t, slots, next),
-        Pattern::PatConstructor(_, bindings) => addConstructorSlots(bindings, slots.clone(), next),
-        Pattern::PatConstructorId(_, _, bindings) => {
-            addConstructorSlots(bindings, slots.clone(), next)
+        crate::aver_generated::domain::ast::Pattern::PatVar(name) => {
+            (slots.clone().insert_owned(name, next), (next + 1i64))
         }
-        Pattern::PatTuple(pats) => addTuplePatternSlots(pats, slots.clone(), next),
+        crate::aver_generated::domain::ast::Pattern::PatCons(h, t) => {
+            crate::aver_generated::domain::resolver::core::addConsSlots(h, t, slots, next)
+        }
+        crate::aver_generated::domain::ast::Pattern::PatConstructor(_, bindings) => {
+            crate::aver_generated::domain::resolver::core::addConstructorSlots(
+                bindings,
+                slots.clone(),
+                next,
+            )
+        }
+        crate::aver_generated::domain::ast::Pattern::PatConstructorId(_, _, bindings) => {
+            crate::aver_generated::domain::resolver::core::addConstructorSlots(
+                bindings,
+                slots.clone(),
+                next,
+            )
+        }
+        crate::aver_generated::domain::ast::Pattern::PatTuple(pats) => {
+            crate::aver_generated::domain::resolver::core::addTuplePatternSlots(
+                pats,
+                slots.clone(),
+                next,
+            )
+        }
         _ => (slots.clone(), next),
     }
 }
@@ -1284,7 +1613,7 @@ pub fn addTuplePatternSlots(
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(pats, [] => (slots, next), [p, rest] => { match addPatternSlotsInner(&p, &slots, next) {
+        return aver_list_match!(pats, [] => (slots, next), [p, rest] => { match crate::aver_generated::domain::resolver::core::addPatternSlotsInner(&p, &slots, next) {
             (newSlots, newNext) => {
             pats = rest;
             slots = newSlots;

--- a/src/self_host/aver_generated/domain/resolver/fast/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/fast/mod.rs
@@ -14,7 +14,7 @@ pub fn annotateFastFns(
         crate::cancel_checkpoint();
         return aver_list_match!(fns, [] => acc.reverse(), [f, rest] => { {
             let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(annotateFastFn(&f, &fnMap), &acc);
+            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::fast::annotateFastFn(&f, &fnMap), &acc);
             fns = rest;
             fnMap = __tmp1;
             acc = __tmp2;
@@ -33,8 +33,11 @@ pub fn annotateFastFn(fd: &FnDef, fnMap: &aver_rt::AverMap<AverStr, i64>) -> FnD
         body: fd.body.clone(),
         slotCount: fd.slotCount,
         slotMap: fd.slotMap.clone(),
-        fastPath: classifyFastPath(&fd.body),
-        tailLoop: classifyTailLoop(selfId, fd.body.clone()),
+        fastPath: crate::aver_generated::domain::resolver::fast::classifyFastPath(&fd.body),
+        tailLoop: crate::aver_generated::domain::resolver::fast::classifyTailLoop(
+            selfId,
+            fd.body.clone(),
+        ),
     }
 }
 
@@ -43,7 +46,7 @@ pub fn annotateFastFn(fd: &FnDef, fnMap: &aver_rt::AverMap<AverStr, i64>) -> FnD
 pub fn classifyTailLoop(mut selfId: i64, mut body: aver_rt::AverList<Stmt>) -> bool {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(body, [] => false, [stmt, rest] => { { let __list_subject = rest.clone(); if __list_subject.is_empty() { stmtNeedsTailLoop(selfId, &stmt) } else { {
+        return aver_list_match!(body, [] => false, [stmt, rest] => { { let __list_subject = rest.clone(); if __list_subject.is_empty() { crate::aver_generated::domain::resolver::fast::stmtNeedsTailLoop(selfId, &stmt) } else { {
             body = rest;
             continue;
         } } } });
@@ -54,7 +57,9 @@ pub fn classifyTailLoop(mut selfId: i64, mut body: aver_rt::AverList<Stmt>) -> b
 pub fn stmtNeedsTailLoop(selfId: i64, stmt: &Stmt) -> bool {
     crate::cancel_checkpoint();
     match stmt.clone() {
-        Stmt::StmtExpr(expr) => exprNeedsTailLoop(selfId, expr),
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::resolver::fast::exprNeedsTailLoop(selfId, expr)
+        }
         _ => false,
     }
 }
@@ -64,11 +69,13 @@ pub fn exprNeedsTailLoop(mut selfId: i64, mut expr: Expr) -> bool {
     loop {
         crate::cancel_checkpoint();
         return match expr {
-            Expr::ExprCallDirect(fnId, _) => (fnId == selfId),
-            Expr::ExprBoolBranch(_, thenExpr, elseExpr) => {
+            crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, _) => (fnId == selfId),
+            crate::aver_generated::domain::ast::Expr::ExprBoolBranch(_, thenExpr, elseExpr) => {
                 let thenExpr = (*thenExpr).clone();
                 let elseExpr = (*elseExpr).clone();
-                if exprNeedsTailLoop(selfId, thenExpr) {
+                if crate::aver_generated::domain::resolver::fast::exprNeedsTailLoop(
+                    selfId, thenExpr,
+                ) {
                     true
                 } else {
                     {
@@ -77,7 +84,9 @@ pub fn exprNeedsTailLoop(mut selfId: i64, mut expr: Expr) -> bool {
                     }
                 }
             }
-            Expr::ExprMatch(_, arms) => armsNeedTailLoop(selfId, arms),
+            crate::aver_generated::domain::ast::Expr::ExprMatch(_, arms) => {
+                crate::aver_generated::domain::resolver::fast::armsNeedTailLoop(selfId, arms)
+            }
             _ => false,
         };
     }
@@ -88,7 +97,7 @@ pub fn exprNeedsTailLoop(mut selfId: i64, mut expr: Expr) -> bool {
 pub fn armsNeedTailLoop(mut selfId: i64, mut arms: aver_rt::AverList<MatchArm>) -> bool {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(arms, [] => false, [arm, rest] => { if exprNeedsTailLoop(selfId, arm.body.clone()) { true } else { {
+        return aver_list_match!(arms, [] => false, [arm, rest] => { if crate::aver_generated::domain::resolver::fast::exprNeedsTailLoop(selfId, arm.body.clone()) { true } else { {
             arms = rest;
             continue;
         } } });
@@ -102,7 +111,7 @@ pub fn classifyFastPath(body: &aver_rt::AverList<Stmt>) -> FnFastPath {
         let __list_subject = body.clone();
         if let Some((stmt, rest)) = aver_rt::list_uncons_cloned(&__list_subject) {
             if (rest == aver_rt::AverList::empty()) {
-                classifyFastStmt(&stmt)
+                crate::aver_generated::domain::resolver::fast::classifyFastStmt(&stmt)
             } else {
                 FnFastPath::FastNone.clone()
             }
@@ -116,7 +125,9 @@ pub fn classifyFastPath(body: &aver_rt::AverList<Stmt>) -> FnFastPath {
 pub fn classifyFastStmt(stmt: &Stmt) -> FnFastPath {
     crate::cancel_checkpoint();
     match stmt.clone() {
-        Stmt::StmtExpr(expr) => classifyFastExpr(&expr),
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::resolver::fast::classifyFastExpr(&expr)
+        }
         _ => FnFastPath::FastNone.clone(),
     }
 }
@@ -125,13 +136,15 @@ pub fn classifyFastStmt(stmt: &Stmt) -> FnFastPath {
 #[inline(always)]
 pub fn classifyFastExpr(expr: &Expr) -> FnFastPath {
     crate::cancel_checkpoint();
-    match classifyFastLeafExpr(expr) {
-        Some(leaf) => FnFastPath::FastLeaf(leaf),
+    match crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(expr) {
+        Some(leaf) => crate::aver_generated::domain::ast::FnFastPath::FastLeaf(leaf),
         None => match expr.clone() {
-            Expr::ExprCallDirect(fnId, args) => classifyFastForwardCall(fnId, &args),
-            Expr::ExprMatch(scrutinee, arms) => {
+            crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, args) => {
+                crate::aver_generated::domain::resolver::fast::classifyFastForwardCall(fnId, &args)
+            }
+            crate::aver_generated::domain::ast::Expr::ExprMatch(scrutinee, arms) => {
                 let scrutinee = (*scrutinee).clone();
-                classifyFastMatch(&scrutinee, &arms)
+                crate::aver_generated::domain::resolver::fast::classifyFastMatch(&scrutinee, &arms)
             }
             _ => FnFastPath::FastSingleExpr.clone(),
         },
@@ -142,27 +155,47 @@ pub fn classifyFastExpr(expr: &Expr) -> FnFastPath {
 pub fn classifyFastLeafExpr(expr: &Expr) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprInt(n) => Some(FastLeaf::LeafConstInt(n)),
-        Expr::ExprFloat(f) => Some(FastLeaf::LeafConstFloat(f)),
-        Expr::ExprStr(s) => Some(FastLeaf::LeafConstStr(s)),
-        Expr::ExprBool(b) => Some(FastLeaf::LeafConstBool(b)),
-        Expr::ExprSlot(slot) => Some(FastLeaf::LeafSlot(slot)),
-        Expr::ExprFieldAccess(obj, field) => {
+        crate::aver_generated::domain::ast::Expr::ExprInt(n) => Some(
+            crate::aver_generated::domain::ast::FastLeaf::LeafConstInt(n),
+        ),
+        crate::aver_generated::domain::ast::Expr::ExprFloat(f) => {
+            Some(crate::aver_generated::domain::ast::FastLeaf::LeafConstFloat(f))
+        }
+        crate::aver_generated::domain::ast::Expr::ExprStr(s) => Some(
+            crate::aver_generated::domain::ast::FastLeaf::LeafConstStr(s),
+        ),
+        crate::aver_generated::domain::ast::Expr::ExprBool(b) => Some(
+            crate::aver_generated::domain::ast::FastLeaf::LeafConstBool(b),
+        ),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+            Some(crate::aver_generated::domain::ast::FastLeaf::LeafSlot(slot))
+        }
+        crate::aver_generated::domain::ast::Expr::ExprFieldAccess(obj, field) => {
             let obj = (*obj).clone();
-            classifyFastFieldAccess(&obj, field)
+            crate::aver_generated::domain::resolver::fast::classifyFastFieldAccess(&obj, field)
         }
-        Expr::ExprCallBuiltin(name, args) => classifyFastBuiltinLeaf(name, &args),
-        Expr::ExprAdd(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, args) => {
+            crate::aver_generated::domain::resolver::fast::classifyFastBuiltinLeaf(name, &args)
+        }
+        crate::aver_generated::domain::ast::Expr::ExprAdd(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastBinopSlots(&BinOp::OpAdd, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastBinopSlots(
+                &BinOp::OpAdd,
+                &a,
+                &b,
+            )
         }
-        Expr::ExprSub(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastBinopSlots(&BinOp::OpSub, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastBinopSlots(
+                &BinOp::OpSub,
+                &a,
+                &b,
+            )
         }
-        _ => classifyFastLeafExprTail(expr),
+        _ => crate::aver_generated::domain::resolver::fast::classifyFastLeafExprTail(expr),
     }
 }
 
@@ -170,45 +203,77 @@ pub fn classifyFastLeafExpr(expr: &Expr) -> Option<FastLeaf> {
 pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprMul(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastBinopSlots(&BinOp::OpMul, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastBinopSlots(
+                &BinOp::OpMul,
+                &a,
+                &b,
+            )
         }
-        Expr::ExprDiv(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastBinopSlots(&BinOp::OpDiv, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastBinopSlots(
+                &BinOp::OpDiv,
+                &a,
+                &b,
+            )
         }
-        Expr::ExprEq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprEq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastCmpSlots(&CmpOp::CmpEq, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
+                &CmpOp::CmpEq,
+                &a,
+                &b,
+            )
         }
-        Expr::ExprNeq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastCmpSlots(&CmpOp::CmpNeq, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
+                &CmpOp::CmpNeq,
+                &a,
+                &b,
+            )
         }
-        Expr::ExprLt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastCmpSlots(&CmpOp::CmpLt, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
+                &CmpOp::CmpLt,
+                &a,
+                &b,
+            )
         }
-        Expr::ExprGt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastCmpSlots(&CmpOp::CmpGt, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
+                &CmpOp::CmpGt,
+                &a,
+                &b,
+            )
         }
-        Expr::ExprLte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastCmpSlots(&CmpOp::CmpLte, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
+                &CmpOp::CmpLte,
+                &a,
+                &b,
+            )
         }
-        Expr::ExprGte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastCmpSlots(&CmpOp::CmpGte, &a, &b)
+            crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
+                &CmpOp::CmpGte,
+                &a,
+                &b,
+            )
         }
         _ => None,
     }
@@ -218,7 +283,9 @@ pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
 pub fn classifyFastFieldAccess(obj: &Expr, field: AverStr) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match obj.clone() {
-        Expr::ExprSlot(slot) => Some(FastLeaf::LeafFieldAccess(slot, field)),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+            Some(crate::aver_generated::domain::ast::FastLeaf::LeafFieldAccess(slot, field))
+        }
         _ => None,
     }
 }
@@ -227,8 +294,10 @@ pub fn classifyFastFieldAccess(obj: &Expr, field: AverStr) -> Option<FastLeaf> {
 pub fn classifyFastBinopSlots(op: &BinOp, a: &Expr, b: &Expr) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match a.clone() {
-        Expr::ExprSlot(sa) => match b.clone() {
-            Expr::ExprSlot(sb) => Some(FastLeaf::LeafBinopSlots(op.clone(), sa, sb)),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(sa) => match b.clone() {
+            crate::aver_generated::domain::ast::Expr::ExprSlot(sb) => Some(
+                crate::aver_generated::domain::ast::FastLeaf::LeafBinopSlots(op.clone(), sa, sb),
+            ),
             _ => None,
         },
         _ => None,
@@ -239,8 +308,10 @@ pub fn classifyFastBinopSlots(op: &BinOp, a: &Expr, b: &Expr) -> Option<FastLeaf
 pub fn classifyFastCmpSlots(op: &CmpOp, a: &Expr, b: &Expr) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match a.clone() {
-        Expr::ExprSlot(sa) => match b.clone() {
-            Expr::ExprSlot(sb) => Some(FastLeaf::LeafCmpSlots(op.clone(), sa, sb)),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(sa) => match b.clone() {
+            crate::aver_generated::domain::ast::Expr::ExprSlot(sb) => Some(
+                crate::aver_generated::domain::ast::FastLeaf::LeafCmpSlots(op.clone(), sa, sb),
+            ),
             _ => None,
         },
         _ => None,
@@ -254,25 +325,29 @@ pub fn classifyFastBuiltinLeaf(name: AverStr, args: &aver_rt::AverList<Expr>) ->
     {
         let __dispatch_subject = name;
         if &*__dispatch_subject == "Vector.new" {
-            classifyFastVectorNew(args)
+            crate::aver_generated::domain::resolver::fast::classifyFastVectorNew(args)
         } else {
             if &*__dispatch_subject == "Vector.len" {
-                classifyFastVectorLen(args)
+                crate::aver_generated::domain::resolver::fast::classifyFastVectorLen(args)
             } else {
                 if &*__dispatch_subject == "Option.withDefault" {
-                    classifyFastOptionWithDefault(args)
+                    crate::aver_generated::domain::resolver::fast::classifyFastOptionWithDefault(
+                        args,
+                    )
                 } else {
                     if &*__dispatch_subject == "Map.get" {
-                        classifyFastMapGet(args)
+                        crate::aver_generated::domain::resolver::fast::classifyFastMapGet(args)
                     } else {
                         if &*__dispatch_subject == "Map.set" {
-                            classifyFastMapSet(args)
+                            crate::aver_generated::domain::resolver::fast::classifyFastMapSet(args)
                         } else {
                             if &*__dispatch_subject == "Map.has" {
-                                classifyFastMapHas(args)
+                                crate::aver_generated::domain::resolver::fast::classifyFastMapHas(
+                                    args,
+                                )
                             } else {
                                 if &*__dispatch_subject == "Map.remove" {
-                                    classifyFastMapRemove(args)
+                                    crate::aver_generated::domain::resolver::fast::classifyFastMapRemove(args)
                                 } else {
                                     None
                                 }
@@ -294,7 +369,9 @@ pub fn classifyFastMapGet(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf> {
             {
                 let __list_subject = rest;
                 if let Some((keyExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    classifyFastMapGetArgs(&mapExpr, &keyExpr)
+                    crate::aver_generated::domain::resolver::fast::classifyFastMapGetArgs(
+                        &mapExpr, &keyExpr,
+                    )
                 } else {
                     None
                 }
@@ -309,8 +386,10 @@ pub fn classifyFastMapGet(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf> {
 pub fn classifyFastMapGetArgs(mapExpr: &Expr, keyExpr: &Expr) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match mapExpr.clone() {
-        Expr::ExprSlot(mapSlot) => match keyExpr.clone() {
-            Expr::ExprSlot(keySlot) => Some(FastLeaf::LeafMapGet(mapSlot, keySlot)),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(mapSlot) => match keyExpr.clone() {
+            crate::aver_generated::domain::ast::Expr::ExprSlot(keySlot) => Some(
+                crate::aver_generated::domain::ast::FastLeaf::LeafMapGet(mapSlot, keySlot),
+            ),
             _ => None,
         },
         _ => None,
@@ -331,7 +410,9 @@ pub fn classifyFastMapSet(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf> {
                         if let Some((valueExpr, ignored)) =
                             aver_rt::list_uncons_cloned(&__list_subject)
                         {
-                            classifyFastMapSetArgs(&mapExpr, &keyExpr, &valueExpr)
+                            crate::aver_generated::domain::resolver::fast::classifyFastMapSetArgs(
+                                &mapExpr, &keyExpr, &valueExpr,
+                            )
                         } else {
                             None
                         }
@@ -354,13 +435,17 @@ pub fn classifyFastMapSetArgs(
 ) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match mapExpr.clone() {
-        Expr::ExprSlot(mapSlot) => match keyExpr.clone() {
-            Expr::ExprSlot(keySlot) => match valueExpr.clone() {
-                Expr::ExprSlot(valueSlot) => {
-                    Some(FastLeaf::LeafMapSet(mapSlot, keySlot, valueSlot))
+        crate::aver_generated::domain::ast::Expr::ExprSlot(mapSlot) => match keyExpr.clone() {
+            crate::aver_generated::domain::ast::Expr::ExprSlot(keySlot) => {
+                match valueExpr.clone() {
+                    crate::aver_generated::domain::ast::Expr::ExprSlot(valueSlot) => {
+                        Some(crate::aver_generated::domain::ast::FastLeaf::LeafMapSet(
+                            mapSlot, keySlot, valueSlot,
+                        ))
+                    }
+                    _ => None,
                 }
-                _ => None,
-            },
+            }
             _ => None,
         },
         _ => None,
@@ -376,7 +461,9 @@ pub fn classifyFastMapHas(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf> {
             {
                 let __list_subject = rest;
                 if let Some((keyExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    classifyFastMapHasArgs(&mapExpr, &keyExpr)
+                    crate::aver_generated::domain::resolver::fast::classifyFastMapHasArgs(
+                        &mapExpr, &keyExpr,
+                    )
                 } else {
                     None
                 }
@@ -391,8 +478,10 @@ pub fn classifyFastMapHas(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf> {
 pub fn classifyFastMapHasArgs(mapExpr: &Expr, keyExpr: &Expr) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match mapExpr.clone() {
-        Expr::ExprSlot(mapSlot) => match keyExpr.clone() {
-            Expr::ExprSlot(keySlot) => Some(FastLeaf::LeafMapHas(mapSlot, keySlot)),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(mapSlot) => match keyExpr.clone() {
+            crate::aver_generated::domain::ast::Expr::ExprSlot(keySlot) => Some(
+                crate::aver_generated::domain::ast::FastLeaf::LeafMapHas(mapSlot, keySlot),
+            ),
             _ => None,
         },
         _ => None,
@@ -408,7 +497,9 @@ pub fn classifyFastMapRemove(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf>
             {
                 let __list_subject = rest;
                 if let Some((keyExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    classifyFastMapRemoveArgs(&mapExpr, &keyExpr)
+                    crate::aver_generated::domain::resolver::fast::classifyFastMapRemoveArgs(
+                        &mapExpr, &keyExpr,
+                    )
                 } else {
                     None
                 }
@@ -423,8 +514,10 @@ pub fn classifyFastMapRemove(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf>
 pub fn classifyFastMapRemoveArgs(mapExpr: &Expr, keyExpr: &Expr) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match mapExpr.clone() {
-        Expr::ExprSlot(mapSlot) => match keyExpr.clone() {
-            Expr::ExprSlot(keySlot) => Some(FastLeaf::LeafMapRemove(mapSlot, keySlot)),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(mapSlot) => match keyExpr.clone() {
+            crate::aver_generated::domain::ast::Expr::ExprSlot(keySlot) => Some(
+                crate::aver_generated::domain::ast::FastLeaf::LeafMapRemove(mapSlot, keySlot),
+            ),
             _ => None,
         },
         _ => None,
@@ -438,7 +531,9 @@ pub fn classifyFastVectorLen(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf>
         let __list_subject = args.clone();
         if let Some((vecExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
             match vecExpr {
-                Expr::ExprSlot(slot) => Some(FastLeaf::LeafVectorLen(slot)),
+                crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => Some(
+                    crate::aver_generated::domain::ast::FastLeaf::LeafVectorLen(slot),
+                ),
                 _ => None,
             }
         } else {
@@ -456,7 +551,9 @@ pub fn classifyFastVectorNew(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf>
             {
                 let __list_subject = rest;
                 if let Some((fillExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    classifyFastVectorNewArgs(&sizeExpr, &fillExpr)
+                    crate::aver_generated::domain::resolver::fast::classifyFastVectorNewArgs(
+                        &sizeExpr, &fillExpr,
+                    )
                 } else {
                     None
                 }
@@ -471,8 +568,10 @@ pub fn classifyFastVectorNew(args: &aver_rt::AverList<Expr>) -> Option<FastLeaf>
 pub fn classifyFastVectorNewArgs(sizeExpr: &Expr, fillExpr: &Expr) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match sizeExpr.clone() {
-        Expr::ExprSlot(sizeSlot) => match fillExpr.clone() {
-            Expr::ExprInt(fill) => Some(FastLeaf::LeafVectorNew(sizeSlot, fill)),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(sizeSlot) => match fillExpr.clone() {
+            crate::aver_generated::domain::ast::Expr::ExprInt(fill) => Some(
+                crate::aver_generated::domain::ast::FastLeaf::LeafVectorNew(sizeSlot, fill),
+            ),
             _ => None,
         },
         _ => None,
@@ -488,7 +587,10 @@ pub fn classifyFastOptionWithDefault(args: &aver_rt::AverList<Expr>) -> Option<F
             {
                 let __list_subject = rest;
                 if let Some((defaultExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    classifyFastOptionWithDefaultArgs(&optionExpr, &defaultExpr)
+                    crate::aver_generated::domain::resolver::fast::classifyFastOptionWithDefaultArgs(
+                        &optionExpr,
+                        &defaultExpr,
+                    )
                 } else {
                     None
                 }
@@ -506,9 +608,12 @@ pub fn classifyFastOptionWithDefaultArgs(
 ) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match optionExpr.clone() {
-        Expr::ExprCallBuiltin(name, innerArgs) => {
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, innerArgs) => {
             if (name == AverStr::from("Vector.get")) {
-                classifyFastVectorGet(&innerArgs, defaultExpr)
+                crate::aver_generated::domain::resolver::fast::classifyFastVectorGet(
+                    &innerArgs,
+                    defaultExpr,
+                )
             } else {
                 None
             }
@@ -529,7 +634,11 @@ pub fn classifyFastVectorGet(
             {
                 let __list_subject = rest;
                 if let Some((idxExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    classifyFastVectorGetArgs(&vecExpr, &idxExpr, defaultExpr)
+                    crate::aver_generated::domain::resolver::fast::classifyFastVectorGetArgs(
+                        &vecExpr,
+                        &idxExpr,
+                        defaultExpr,
+                    )
                 } else {
                     None
                 }
@@ -548,13 +657,19 @@ pub fn classifyFastVectorGetArgs(
 ) -> Option<FastLeaf> {
     crate::cancel_checkpoint();
     match vecExpr.clone() {
-        Expr::ExprSlot(vecSlot) => match idxExpr.clone() {
-            Expr::ExprSlot(idxSlot) => match defaultExpr.clone() {
-                Expr::ExprInt(defaultValue) => {
-                    Some(FastLeaf::LeafVectorGetOrInt(vecSlot, idxSlot, defaultValue))
+        crate::aver_generated::domain::ast::Expr::ExprSlot(vecSlot) => match idxExpr.clone() {
+            crate::aver_generated::domain::ast::Expr::ExprSlot(idxSlot) => {
+                match defaultExpr.clone() {
+                    crate::aver_generated::domain::ast::Expr::ExprInt(defaultValue) => Some(
+                        crate::aver_generated::domain::ast::FastLeaf::LeafVectorGetOrInt(
+                            vecSlot,
+                            idxSlot,
+                            defaultValue,
+                        ),
+                    ),
+                    _ => None,
                 }
-                _ => None,
-            },
+            }
             _ => None,
         },
         _ => None,
@@ -565,12 +680,16 @@ pub fn classifyFastVectorGetArgs(
 #[inline(always)]
 pub fn classifyFastMatch(scrutinee: &Expr, arms: &aver_rt::AverList<MatchArm>) -> FnFastPath {
     crate::cancel_checkpoint();
-    match classifyBoolArms(arms) {
+    match crate::aver_generated::domain::resolver::fast::classifyBoolArms(arms) {
         Some(pair) => {
             let (thenLeaf, elseLeaf) = pair;
-            classifyFastMatchScrutinee(scrutinee, &thenLeaf, &elseLeaf)
+            crate::aver_generated::domain::resolver::fast::classifyFastMatchScrutinee(
+                scrutinee, &thenLeaf, &elseLeaf,
+            )
         }
-        None => classifyFastListMatch(scrutinee, arms),
+        None => {
+            crate::aver_generated::domain::resolver::fast::classifyFastListMatch(scrutinee, arms)
+        }
     }
 }
 
@@ -578,7 +697,9 @@ pub fn classifyFastMatch(scrutinee: &Expr, arms: &aver_rt::AverList<MatchArm>) -
 pub fn classifyFastListMatch(scrutinee: &Expr, arms: &aver_rt::AverList<MatchArm>) -> FnFastPath {
     crate::cancel_checkpoint();
     match scrutinee.clone() {
-        Expr::ExprSlot(slot) => classifyFastListArms(slot, arms),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+            crate::aver_generated::domain::resolver::fast::classifyFastListArms(slot, arms)
+        }
         _ => FnFastPath::FastSingleExpr.clone(),
     }
 }
@@ -593,7 +714,9 @@ pub fn classifyFastListArms(slot: i64, arms: &aver_rt::AverList<MatchArm>) -> Fn
                 let __list_subject = rest;
                 if let Some((arm2, tail)) = aver_rt::list_uncons_cloned(&__list_subject) {
                     if (tail == aver_rt::AverList::empty()) {
-                        classifyFastListArmPair(slot, &arm1, &arm2)
+                        crate::aver_generated::domain::resolver::fast::classifyFastListArmPair(
+                            slot, &arm1, &arm2,
+                        )
                     } else {
                         FnFastPath::FastSingleExpr.clone()
                     }
@@ -611,11 +734,11 @@ pub fn classifyFastListArms(slot: i64, arms: &aver_rt::AverList<MatchArm>) -> Fn
 #[inline(always)]
 pub fn classifyFastListArmPair(slot: i64, arm1: &MatchArm, arm2: &MatchArm) -> FnFastPath {
     crate::cancel_checkpoint();
-    let leaf1 = classifyFastLeafExpr(&arm1.body);
-    let leaf2 = classifyFastLeafExpr(&arm2.body);
+    let leaf1 = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm1.body);
+    let leaf2 = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm2.body);
     match leaf1 {
         Some(v1) => match leaf2 {
-            Some(v2) => classifyFastListPatterns(
+            Some(v2) => crate::aver_generated::domain::resolver::fast::classifyFastListPatterns(
                 slot,
                 &arm1.pattern,
                 &arm1.bindingSlots,
@@ -642,9 +765,25 @@ pub fn classifyFastListPatterns(
 ) -> FnFastPath {
     crate::cancel_checkpoint();
     match p1.clone() {
-        Pattern::PatEmpty => classifyFastListOther(slot, leaf1, p2, bindingSlots2, leaf2),
-        Pattern::PatCons(head, tail) => {
-            classifyFastListConsFirst(slot, head, tail, bindingSlots1, leaf1, p2, leaf2)
+        crate::aver_generated::domain::ast::Pattern::PatEmpty => {
+            crate::aver_generated::domain::resolver::fast::classifyFastListOther(
+                slot,
+                leaf1,
+                p2,
+                bindingSlots2,
+                leaf2,
+            )
+        }
+        crate::aver_generated::domain::ast::Pattern::PatCons(head, tail) => {
+            crate::aver_generated::domain::resolver::fast::classifyFastListConsFirst(
+                slot,
+                head,
+                tail,
+                bindingSlots1,
+                leaf1,
+                p2,
+                leaf2,
+            )
         }
         _ => FnFastPath::FastSingleExpr.clone(),
     }
@@ -660,8 +799,15 @@ pub fn classifyFastListOther(
 ) -> FnFastPath {
     crate::cancel_checkpoint();
     match other.clone() {
-        Pattern::PatCons(head, tail) => {
-            classifyFastListCons(slot, emptyLeaf, head, tail, bindingSlots, otherLeaf)
+        crate::aver_generated::domain::ast::Pattern::PatCons(head, tail) => {
+            crate::aver_generated::domain::resolver::fast::classifyFastListCons(
+                slot,
+                emptyLeaf,
+                head,
+                tail,
+                bindingSlots,
+                otherLeaf,
+            )
         }
         _ => FnFastPath::FastSingleExpr.clone(),
     }
@@ -679,8 +825,15 @@ pub fn classifyFastListConsFirst(
 ) -> FnFastPath {
     crate::cancel_checkpoint();
     match other {
-        Pattern::PatEmpty => {
-            classifyFastListCons(slot, otherLeaf, head, tail, bindingSlots, consLeaf)
+        crate::aver_generated::domain::ast::Pattern::PatEmpty => {
+            crate::aver_generated::domain::resolver::fast::classifyFastListCons(
+                slot,
+                otherLeaf,
+                head,
+                tail,
+                bindingSlots,
+                consLeaf,
+            )
         }
         _ => FnFastPath::FastSingleExpr.clone(),
     }
@@ -699,7 +852,7 @@ pub fn classifyFastListCons(
     crate::cancel_checkpoint();
     match bindingSlots.get(&head).cloned() {
         Some(headSlot) => match bindingSlots.get(&tail).cloned() {
-            Some(tailSlot) => FnFastPath::FastListSlotBranch(
+            Some(tailSlot) => crate::aver_generated::domain::ast::FnFastPath::FastListSlotBranch(
                 slot,
                 emptyLeaf.clone(),
                 headSlot,
@@ -716,8 +869,13 @@ pub fn classifyFastListCons(
 #[inline(always)]
 pub fn classifyFastForwardCall(fnId: i64, args: &aver_rt::AverList<Expr>) -> FnFastPath {
     crate::cancel_checkpoint();
-    match classifyFastForwardSlots(args.clone(), aver_rt::AverList::empty()) {
-        Some(slotArgs) => FnFastPath::FastForwardCall(fnId, slotArgs),
+    match crate::aver_generated::domain::resolver::fast::classifyFastForwardSlots(
+        args.clone(),
+        aver_rt::AverList::empty(),
+    ) {
+        Some(slotArgs) => {
+            crate::aver_generated::domain::ast::FnFastPath::FastForwardCall(fnId, slotArgs)
+        }
         None => FnFastPath::FastSingleExpr.clone(),
     }
 }
@@ -731,7 +889,7 @@ pub fn classifyFastForwardSlots(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(args, [] => Some(acc.reverse()), [arg, rest] => { match arg {
-            Expr::ExprSlot(slot) => {
+            crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
             let __tmp1 = aver_rt::AverList::prepend(slot, &acc);
             args = rest;
             acc = __tmp1;
@@ -752,7 +910,9 @@ pub fn classifyBoolArms(arms: &aver_rt::AverList<MatchArm>) -> Option<(FastLeaf,
                 let __list_subject = rest;
                 if let Some((arm2, tail)) = aver_rt::list_uncons_cloned(&__list_subject) {
                     if (tail == aver_rt::AverList::empty()) {
-                        classifyBoolArmPair(&arm1, &arm2)
+                        crate::aver_generated::domain::resolver::fast::classifyBoolArmPair(
+                            &arm1, &arm2,
+                        )
                     } else {
                         None
                     }
@@ -770,11 +930,16 @@ pub fn classifyBoolArms(arms: &aver_rt::AverList<MatchArm>) -> Option<(FastLeaf,
 #[inline(always)]
 pub fn classifyBoolArmPair(arm1: &MatchArm, arm2: &MatchArm) -> Option<(FastLeaf, FastLeaf)> {
     crate::cancel_checkpoint();
-    let leaf1 = classifyFastLeafExpr(&arm1.body);
-    let leaf2 = classifyFastLeafExpr(&arm2.body);
+    let leaf1 = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm1.body);
+    let leaf2 = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm2.body);
     match leaf1 {
         Some(v1) => match leaf2 {
-            Some(v2) => classifyBoolArmPatterns(&arm1.pattern, &v1, &arm2.pattern, &v2),
+            Some(v2) => crate::aver_generated::domain::resolver::fast::classifyBoolArmPatterns(
+                &arm1.pattern,
+                &v1,
+                &arm2.pattern,
+                &v2,
+            ),
             None => None,
         },
         None => None,
@@ -790,7 +955,11 @@ pub fn classifyBoolArmPatterns(
 ) -> Option<(FastLeaf, FastLeaf)> {
     crate::cancel_checkpoint();
     match p1.clone() {
-        Pattern::PatBool(b1) => classifyBoolArmPatternsInner(b1, leaf1, p2, leaf2),
+        crate::aver_generated::domain::ast::Pattern::PatBool(b1) => {
+            crate::aver_generated::domain::resolver::fast::classifyBoolArmPatternsInner(
+                b1, leaf1, p2, leaf2,
+            )
+        }
         _ => None,
     }
 }
@@ -804,7 +973,11 @@ pub fn classifyBoolArmPatternsInner(
 ) -> Option<(FastLeaf, FastLeaf)> {
     crate::cancel_checkpoint();
     match p2.clone() {
-        Pattern::PatBool(b2) => classifyBoolArmPatternsPair(b1, leaf1, b2, leaf2),
+        crate::aver_generated::domain::ast::Pattern::PatBool(b2) => {
+            crate::aver_generated::domain::resolver::fast::classifyBoolArmPatternsPair(
+                b1, leaf1, b2, leaf2,
+            )
+        }
         _ => None,
     }
 }
@@ -832,23 +1005,33 @@ pub fn classifyFastMatchScrutinee(
 ) -> FnFastPath {
     crate::cancel_checkpoint();
     match scrutinee.clone() {
-        Expr::ExprSlot(slot) => {
-            FnFastPath::FastBoolSlotBranch(slot, thenLeaf.clone(), elseLeaf.clone())
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+            crate::aver_generated::domain::ast::FnFastPath::FastBoolSlotBranch(
+                slot,
+                thenLeaf.clone(),
+                elseLeaf.clone(),
+            )
         }
-        Expr::ExprEq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprEq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastEqScrutinee(&a, &b, thenLeaf, elseLeaf)
+            crate::aver_generated::domain::resolver::fast::classifyFastEqScrutinee(
+                &a, &b, thenLeaf, elseLeaf,
+            )
         }
-        Expr::ExprLt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastLtScrutinee(&a, &b, thenLeaf, elseLeaf)
+            crate::aver_generated::domain::resolver::fast::classifyFastLtScrutinee(
+                &a, &b, thenLeaf, elseLeaf,
+            )
         }
-        Expr::ExprGt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            classifyFastLtScrutinee(&b, &a, thenLeaf, elseLeaf)
+            crate::aver_generated::domain::resolver::fast::classifyFastLtScrutinee(
+                &b, &a, thenLeaf, elseLeaf,
+            )
         }
         _ => FnFastPath::FastSingleExpr.clone(),
     }
@@ -863,9 +1046,17 @@ pub fn classifyFastEqScrutinee(
 ) -> FnFastPath {
     crate::cancel_checkpoint();
     match a.clone() {
-        Expr::ExprSlot(slot) => classifyFastEqOther(slot, b, thenLeaf, elseLeaf),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+            crate::aver_generated::domain::resolver::fast::classifyFastEqOther(
+                slot, b, thenLeaf, elseLeaf,
+            )
+        }
         _ => match b.clone() {
-            Expr::ExprSlot(slot) => classifyFastEqOther(slot, a, thenLeaf, elseLeaf),
+            crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+                crate::aver_generated::domain::resolver::fast::classifyFastEqOther(
+                    slot, a, thenLeaf, elseLeaf,
+                )
+            }
             _ => FnFastPath::FastSingleExpr.clone(),
         },
     }
@@ -880,11 +1071,21 @@ pub fn classifyFastEqOther(
 ) -> FnFastPath {
     crate::cancel_checkpoint();
     match other.clone() {
-        Expr::ExprInt(n) => {
-            FnFastPath::FastEqIntBranch(slot, n, thenLeaf.clone(), elseLeaf.clone())
+        crate::aver_generated::domain::ast::Expr::ExprInt(n) => {
+            crate::aver_generated::domain::ast::FnFastPath::FastEqIntBranch(
+                slot,
+                n,
+                thenLeaf.clone(),
+                elseLeaf.clone(),
+            )
         }
-        Expr::ExprStr(s) => {
-            FnFastPath::FastEqStringBranch(slot, s, thenLeaf.clone(), elseLeaf.clone())
+        crate::aver_generated::domain::ast::Expr::ExprStr(s) => {
+            crate::aver_generated::domain::ast::FnFastPath::FastEqStringBranch(
+                slot,
+                s,
+                thenLeaf.clone(),
+                elseLeaf.clone(),
+            )
         }
         _ => FnFastPath::FastSingleExpr.clone(),
     }
@@ -899,9 +1100,14 @@ pub fn classifyFastLtScrutinee(
 ) -> FnFastPath {
     crate::cancel_checkpoint();
     match a.clone() {
-        Expr::ExprSlot(lhs) => match b.clone() {
-            Expr::ExprSlot(rhs) => {
-                FnFastPath::FastLtIntSlotsBranch(lhs, rhs, thenLeaf.clone(), elseLeaf.clone())
+        crate::aver_generated::domain::ast::Expr::ExprSlot(lhs) => match b.clone() {
+            crate::aver_generated::domain::ast::Expr::ExprSlot(rhs) => {
+                crate::aver_generated::domain::ast::FnFastPath::FastLtIntSlotsBranch(
+                    lhs,
+                    rhs,
+                    thenLeaf.clone(),
+                    elseLeaf.clone(),
+                )
             }
             _ => FnFastPath::FastSingleExpr.clone(),
         },

--- a/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
@@ -12,7 +12,7 @@ pub fn rewriteInternalFns(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(fns, [] => acc.reverse(), [f, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(rewriteInternalFn(&f), &acc);
+            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewriteInternalFn(&f), &acc);
             fns = rest;
             acc = __tmp1;
             continue;
@@ -26,7 +26,10 @@ pub fn rewriteInternalFn(fd: &FnDef) -> FnDef {
     FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
-        body: rewriteInternalStmts(fd.body.clone(), aver_rt::AverList::empty()),
+        body: crate::aver_generated::domain::resolver::rewrite::rewriteInternalStmts(
+            fd.body.clone(),
+            aver_rt::AverList::empty(),
+        ),
         slotCount: fd.slotCount,
         slotMap: fd.slotMap.clone(),
         fastPath: fd.fastPath.clone(),
@@ -43,7 +46,7 @@ pub fn rewriteInternalStmts(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(stmts, [] => acc.reverse(), [stmt, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(rewriteInternalStmt(&stmt), &acc);
+            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewriteInternalStmt(&stmt), &acc);
             stmts = rest;
             acc = __tmp1;
             continue;
@@ -55,9 +58,23 @@ pub fn rewriteInternalStmts(
 pub fn rewriteInternalStmt(stmt: &Stmt) -> Stmt {
     crate::cancel_checkpoint();
     match stmt.clone() {
-        Stmt::StmtBind(name, expr) => Stmt::StmtBind(name, rewriteInternalExpr(&expr)),
-        Stmt::StmtBindSlot(slot, expr) => Stmt::StmtBindSlot(slot, rewriteInternalExpr(&expr)),
-        Stmt::StmtExpr(expr) => Stmt::StmtExpr(rewriteInternalExpr(&expr)),
+        crate::aver_generated::domain::ast::Stmt::StmtBind(name, expr) => {
+            crate::aver_generated::domain::ast::Stmt::StmtBind(
+                name,
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr),
+            )
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(slot, expr) => {
+            crate::aver_generated::domain::ast::Stmt::StmtBindSlot(
+                slot,
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr),
+            )
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::ast::Stmt::StmtExpr(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr),
+            )
+        }
     }
 }
 
@@ -65,39 +82,61 @@ pub fn rewriteInternalStmt(stmt: &Stmt) -> Stmt {
 pub fn rewriteInternalExpr(expr: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
+        crate::aver_generated::domain::ast::Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
             let cond = (*cond).clone();
             let thenExpr = (*thenExpr).clone();
             let elseExpr = (*elseExpr).clone();
-            Expr::ExprBoolBranch(
-                std::sync::Arc::new(rewriteInternalExpr(&cond)),
-                std::sync::Arc::new(rewriteInternalExpr(&thenExpr)),
-                std::sync::Arc::new(rewriteInternalExpr(&elseExpr)),
+            crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&cond),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(
+                        &thenExpr,
+                    ),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(
+                        &elseExpr,
+                    ),
+                ),
             )
         }
-        Expr::ExprBinopSlotInt(_, _, _) => expr.clone(),
-        Expr::ExprBinopSlots(_, _, _) => expr.clone(),
-        Expr::ExprCmpSlotInt(_, _, _) => expr.clone(),
-        Expr::ExprCmpSlots(_, _, _) => expr.clone(),
-        Expr::ExprVectorGetOrInt(vecExpr, idxExpr, defaultValue) => {
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(_, _, _) => expr.clone(),
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlots(_, _, _) => expr.clone(),
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(_, _, _) => expr.clone(),
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlots(_, _, _) => expr.clone(),
+        crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+            vecExpr,
+            idxExpr,
+            defaultValue,
+        ) => {
             let vecExpr = (*vecExpr).clone();
             let idxExpr = (*idxExpr).clone();
-            Expr::ExprVectorGetOrInt(
-                std::sync::Arc::new(rewriteInternalExpr(&vecExpr)),
-                std::sync::Arc::new(rewriteInternalExpr(&idxExpr)),
+            crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&vecExpr),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&idxExpr),
+                ),
                 defaultValue,
             )
         }
-        Expr::ExprIntModOrInt(a, b, defaultValue) => {
+        crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(a, b, defaultValue) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprIntModOrInt(
-                std::sync::Arc::new(rewriteInternalExpr(&a)),
-                std::sync::Arc::new(rewriteInternalExpr(&b)),
+            crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                ),
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
+                ),
                 defaultValue,
             )
         }
-        _ => rewriteInternalExprAfterLeaf(expr),
+        _ => crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprAfterLeaf(expr),
     }
 }
 
@@ -105,101 +144,103 @@ pub fn rewriteInternalExpr(expr: &Expr) -> Expr {
 pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprAdd(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprAdd(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalBinop(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinop(
                 &BinOp::OpAdd,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        Expr::ExprSub(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalBinop(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinop(
                 &BinOp::OpSub,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        Expr::ExprMul(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalBinop(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinop(
                 &BinOp::OpMul,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        Expr::ExprDiv(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalBinop(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinop(
                 &BinOp::OpDiv,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        Expr::ExprNeg(inner) => {
+        crate::aver_generated::domain::ast::Expr::ExprNeg(inner) => {
             let inner = (*inner).clone();
-            Expr::ExprNeg(std::sync::Arc::new(rewriteInternalExpr(&inner)))
+            crate::aver_generated::domain::ast::Expr::ExprNeg(std::sync::Arc::new(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&inner),
+            ))
         }
-        Expr::ExprEq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprEq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalCmp(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
                 &CmpOp::CmpEq,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        Expr::ExprNeq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalCmp(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
                 &CmpOp::CmpNeq,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        Expr::ExprLt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalCmp(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
                 &CmpOp::CmpLt,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        Expr::ExprGt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalCmp(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
                 &CmpOp::CmpGt,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        Expr::ExprLte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalCmp(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
                 &CmpOp::CmpLte,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        Expr::ExprGte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            rewriteInternalCmp(
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
                 &CmpOp::CmpGte,
-                &rewriteInternalExpr(&a),
-                &rewriteInternalExpr(&b),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
         }
-        _ => rewriteInternalExprAfterArith(expr),
+        _ => crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprAfterArith(expr),
     }
 }
 
@@ -207,50 +248,108 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
 pub fn rewriteInternalExprAfterArith(expr: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprMatch(scrutinee, arms) => {
+        crate::aver_generated::domain::ast::Expr::ExprMatch(scrutinee, arms) => {
             let scrutinee = (*scrutinee).clone();
-            rewriteInternalMatch(
-                &rewriteInternalExpr(&scrutinee),
-                &rewriteInternalArms(arms, aver_rt::AverList::empty()),
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalMatch(
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&scrutinee),
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalArms(
+                    arms,
+                    aver_rt::AverList::empty(),
+                ),
             )
         }
-        Expr::ExprPropagate(inner) => {
+        crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => {
             let inner = (*inner).clone();
-            Expr::ExprPropagate(std::sync::Arc::new(rewriteInternalExpr(&inner)))
+            crate::aver_generated::domain::ast::Expr::ExprPropagate(std::sync::Arc::new(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&inner),
+            ))
         }
-        Expr::ExprConcat(parts) => {
-            Expr::ExprConcat(rewriteInternalExprs(parts, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
+            crate::aver_generated::domain::ast::Expr::ExprConcat(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                    parts,
+                    aver_rt::AverList::empty(),
+                ),
+            )
         }
-        Expr::ExprTuple(exprs) => {
-            Expr::ExprTuple(rewriteInternalExprs(exprs, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
+            crate::aver_generated::domain::ast::Expr::ExprTuple(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                    exprs,
+                    aver_rt::AverList::empty(),
+                ),
+            )
         }
-        Expr::ExprIndependentProduct(exprs, unwrap) => Expr::ExprIndependentProduct(
-            rewriteInternalExprs(exprs, aver_rt::AverList::empty()),
-            unwrap,
-        ),
-        Expr::ExprList(exprs) => {
-            Expr::ExprList(rewriteInternalExprs(exprs, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => {
+            crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                    exprs,
+                    aver_rt::AverList::empty(),
+                ),
+                unwrap,
+            )
         }
-        Expr::ExprRecord(name, fields) => Expr::ExprRecord(
-            name,
-            rewriteInternalFields(fields, aver_rt::AverList::empty()),
-        ),
-        Expr::ExprFieldAccess(obj, field) => {
+        crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
+            crate::aver_generated::domain::ast::Expr::ExprList(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                    exprs,
+                    aver_rt::AverList::empty(),
+                ),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprRecord(name, fields) => {
+            crate::aver_generated::domain::ast::Expr::ExprRecord(
+                name,
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalFields(
+                    fields,
+                    aver_rt::AverList::empty(),
+                ),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprFieldAccess(obj, field) => {
             let obj = (*obj).clone();
-            Expr::ExprFieldAccess(std::sync::Arc::new(rewriteInternalExpr(&obj)), field)
+            crate::aver_generated::domain::ast::Expr::ExprFieldAccess(
+                std::sync::Arc::new(
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&obj),
+                ),
+                field,
+            )
         }
-        Expr::ExprCall(name, args) => {
-            Expr::ExprCall(name, rewriteInternalExprs(args, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Expr::ExprCall(name, args) => {
+            crate::aver_generated::domain::ast::Expr::ExprCall(
+                name,
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                    args,
+                    aver_rt::AverList::empty(),
+                ),
+            )
         }
-        Expr::ExprCallDirect(fnId, args) => {
-            Expr::ExprCallDirect(fnId, rewriteInternalExprs(args, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, args) => {
+            crate::aver_generated::domain::ast::Expr::ExprCallDirect(
+                fnId,
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                    args,
+                    aver_rt::AverList::empty(),
+                ),
+            )
         }
-        Expr::ExprCallBuiltin(name, args) => rewriteInternalBuiltin(
-            name,
-            &rewriteInternalExprs(args, aver_rt::AverList::empty()),
-        ),
-        Expr::ExprCallBuiltinId(id, args) => {
-            Expr::ExprCallBuiltinId(id, rewriteInternalExprs(args, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, args) => {
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalBuiltin(
+                name,
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                    args,
+                    aver_rt::AverList::empty(),
+                ),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, args) => {
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
+                id,
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                    args,
+                    aver_rt::AverList::empty(),
+                ),
+            )
         }
         _ => expr.clone(),
     }
@@ -265,7 +364,7 @@ pub fn rewriteInternalExprs(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(exprs, [] => acc.reverse(), [expr, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(rewriteInternalExpr(&expr), &acc);
+            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr), &acc);
             exprs = rest;
             acc = __tmp1;
             continue;
@@ -283,7 +382,7 @@ pub fn rewriteInternalFields(
         crate::cancel_checkpoint();
         return aver_list_match!(fields, [] => acc.reverse(), [pair, rest] => { match pair {
             (name, expr) => {
-            let __tmp1 = aver_rt::AverList::prepend((name, rewriteInternalExpr(&expr)), &acc);
+            let __tmp1 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr)), &acc);
             fields = rest;
             acc = __tmp1;
             continue;
@@ -301,7 +400,7 @@ pub fn rewriteInternalArms(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(arms, [] => acc.reverse(), [arm, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(MatchArm { pattern: rewritePattern(&arm.pattern), body: rewriteInternalExpr(&arm.body), bindingSlots: arm.bindingSlots.clone() }, &acc);
+            let __tmp1 = aver_rt::AverList::prepend(MatchArm { pattern: crate::aver_generated::domain::resolver::rewrite::rewritePattern(&arm.pattern), body: crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&arm.body), bindingSlots: arm.bindingSlots.clone() }, &acc);
             arms = rest;
             acc = __tmp1;
             continue;
@@ -313,20 +412,26 @@ pub fn rewriteInternalArms(
 pub fn rewritePattern(pat: &Pattern) -> Pattern {
     crate::cancel_checkpoint();
     match pat.clone() {
-        Pattern::PatConstructor(name, bindings) => rewritePatConstructor(name, &bindings),
-        Pattern::PatTuple(pats) => {
-            Pattern::PatTuple(rewritePatterns(pats, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Pattern::PatConstructor(name, bindings) => {
+            crate::aver_generated::domain::resolver::rewrite::rewritePatConstructor(name, &bindings)
+        }
+        crate::aver_generated::domain::ast::Pattern::PatTuple(pats) => {
+            crate::aver_generated::domain::ast::Pattern::PatTuple(
+                crate::aver_generated::domain::resolver::rewrite::rewritePatterns(
+                    pats,
+                    aver_rt::AverList::empty(),
+                ),
+            )
         }
         _ => pat.clone(),
     }
 }
 
 /// Convert PatConstructor to PatConstructorId with stable tag and full constructor name.
-#[inline(always)]
 pub fn rewritePatConstructor(name: AverStr, bindings: &aver_rt::AverList<AverStr>) -> Pattern {
     crate::cancel_checkpoint();
     let tag = crate::aver_generated::domain::ast::ctorNameToTag(name.clone());
-    Pattern::PatConstructorId(tag, name.clone(), bindings.clone())
+    crate::aver_generated::domain::ast::Pattern::PatConstructorId(tag, name, bindings.clone())
 }
 
 /// Rewrite a list of patterns.
@@ -338,7 +443,7 @@ pub fn rewritePatterns(
     loop {
         crate::cancel_checkpoint();
         return aver_list_match!(pats, [] => acc.reverse(), [p, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(rewritePattern(&p), &acc);
+            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewritePattern(&p), &acc);
             pats = rest;
             acc = __tmp1;
             continue;
@@ -350,10 +455,20 @@ pub fn rewritePatterns(
 pub fn rewriteInternalBinop(op: &BinOp, left: &Expr, right: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match left.clone() {
-        Expr::ExprSlot(slot) => rewriteInternalBinopSlotLeft(op, slot, right),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinopSlotLeft(
+                op, slot, right,
+            )
+        }
         _ => match right.clone() {
-            Expr::ExprSlot(slot) => rewriteInternalBinopSlotRight(op, left, slot),
-            _ => rebuildInternalBinop(op, left, right),
+            crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinopSlotRight(
+                    op, left, slot,
+                )
+            }
+            _ => crate::aver_generated::domain::resolver::rewrite::rebuildInternalBinop(
+                op, left, right,
+            ),
         },
     }
 }
@@ -362,9 +477,17 @@ pub fn rewriteInternalBinop(op: &BinOp, left: &Expr, right: &Expr) -> Expr {
 pub fn rewriteInternalBinopSlotLeft(op: &BinOp, slot: i64, right: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match right.clone() {
-        Expr::ExprInt(n) => Expr::ExprBinopSlotInt(op.clone(), slot, n),
-        Expr::ExprSlot(rhs) => Expr::ExprBinopSlots(op.clone(), slot, rhs),
-        _ => rebuildInternalBinop(op, &Expr::ExprSlot(slot), right),
+        crate::aver_generated::domain::ast::Expr::ExprInt(n) => {
+            crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(op.clone(), slot, n)
+        }
+        crate::aver_generated::domain::ast::Expr::ExprSlot(rhs) => {
+            crate::aver_generated::domain::ast::Expr::ExprBinopSlots(op.clone(), slot, rhs)
+        }
+        _ => crate::aver_generated::domain::resolver::rewrite::rebuildInternalBinop(
+            op,
+            &crate::aver_generated::domain::ast::Expr::ExprSlot(slot),
+            right,
+        ),
     }
 }
 
@@ -372,15 +495,25 @@ pub fn rewriteInternalBinopSlotLeft(op: &BinOp, slot: i64, right: &Expr) -> Expr
 pub fn rewriteInternalBinopSlotRight(op: &BinOp, left: &Expr, slot: i64) -> Expr {
     crate::cancel_checkpoint();
     match left.clone() {
-        Expr::ExprSlot(lhs) => Expr::ExprBinopSlots(op.clone(), lhs, slot),
-        Expr::ExprInt(n) => {
-            if binopCanFlip(op) {
-                Expr::ExprBinopSlotInt(op.clone(), slot, n)
+        crate::aver_generated::domain::ast::Expr::ExprSlot(lhs) => {
+            crate::aver_generated::domain::ast::Expr::ExprBinopSlots(op.clone(), lhs, slot)
+        }
+        crate::aver_generated::domain::ast::Expr::ExprInt(n) => {
+            if crate::aver_generated::domain::resolver::rewrite::binopCanFlip(op) {
+                crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(op.clone(), slot, n)
             } else {
-                rebuildInternalBinop(op, left, &Expr::ExprSlot(slot))
+                crate::aver_generated::domain::resolver::rewrite::rebuildInternalBinop(
+                    op,
+                    left,
+                    &crate::aver_generated::domain::ast::Expr::ExprSlot(slot),
+                )
             }
         }
-        _ => rebuildInternalBinop(op, left, &Expr::ExprSlot(slot)),
+        _ => crate::aver_generated::domain::resolver::rewrite::rebuildInternalBinop(
+            op,
+            left,
+            &crate::aver_generated::domain::ast::Expr::ExprSlot(slot),
+        ),
     }
 }
 
@@ -388,22 +521,30 @@ pub fn rewriteInternalBinopSlotRight(op: &BinOp, left: &Expr, slot: i64) -> Expr
 pub fn rebuildInternalBinop(op: &BinOp, left: &Expr, right: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match op {
-        BinOp::OpAdd => Expr::ExprAdd(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
-        BinOp::OpSub => Expr::ExprSub(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
-        BinOp::OpMul => Expr::ExprMul(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
-        BinOp::OpDiv => Expr::ExprDiv(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
+        crate::aver_generated::domain::ast::BinOp::OpAdd => {
+            crate::aver_generated::domain::ast::Expr::ExprAdd(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
+        crate::aver_generated::domain::ast::BinOp::OpSub => {
+            crate::aver_generated::domain::ast::Expr::ExprSub(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
+        crate::aver_generated::domain::ast::BinOp::OpMul => {
+            crate::aver_generated::domain::ast::Expr::ExprMul(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
+        crate::aver_generated::domain::ast::BinOp::OpDiv => {
+            crate::aver_generated::domain::ast::Expr::ExprDiv(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
     }
 }
 
@@ -411,8 +552,8 @@ pub fn rebuildInternalBinop(op: &BinOp, left: &Expr, right: &Expr) -> Expr {
 pub fn binopCanFlip(op: &BinOp) -> bool {
     crate::cancel_checkpoint();
     match op {
-        BinOp::OpAdd => true,
-        BinOp::OpMul => true,
+        crate::aver_generated::domain::ast::BinOp::OpAdd => true,
+        crate::aver_generated::domain::ast::BinOp::OpMul => true,
         _ => false,
     }
 }
@@ -424,12 +565,14 @@ pub fn rewriteInternalBuiltin(name: AverStr, args: &aver_rt::AverList<Expr>) -> 
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Option.withDefault" {
-            rewriteInternalOptionWithDefault(args)
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalOptionWithDefault(args)
         } else {
             if &*__dispatch_subject == "Result.withDefault" {
-                rewriteInternalResultWithDefault(args)
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalResultWithDefault(
+                    args,
+                )
             } else {
-                Expr::ExprCallBuiltin(name, args.clone())
+                crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, args.clone())
             }
         }
     }
@@ -444,13 +587,19 @@ pub fn rewriteInternalOptionWithDefault(args: &aver_rt::AverList<Expr>) -> Expr 
             {
                 let __list_subject = rest;
                 if let Some((defaultExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    rewriteInternalOptionWithDefaultArgs(&optionExpr, &defaultExpr)
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalOptionWithDefaultArgs(&optionExpr, &defaultExpr)
                 } else {
-                    Expr::ExprCallBuiltin(AverStr::from("Option.withDefault"), args.clone())
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                        AverStr::from("Option.withDefault"),
+                        args.clone(),
+                    )
                 }
             }
         } else {
-            Expr::ExprCallBuiltin(AverStr::from("Option.withDefault"), args.clone())
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                AverStr::from("Option.withDefault"),
+                args.clone(),
+            )
         }
     }
 }
@@ -459,23 +608,28 @@ pub fn rewriteInternalOptionWithDefault(args: &aver_rt::AverList<Expr>) -> Expr 
 pub fn rewriteInternalOptionWithDefaultArgs(optionExpr: &Expr, defaultExpr: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match defaultExpr.clone() {
-        Expr::ExprInt(defaultValue) => match optionExpr.clone() {
-            Expr::ExprCallBuiltin(name, innerArgs) => {
-                if (name == AverStr::from("Vector.get")) {
-                    rewriteInternalVectorGetOrInt(&innerArgs, defaultValue)
-                } else {
-                    Expr::ExprCallBuiltin(
-                        AverStr::from("Option.withDefault"),
-                        aver_rt::AverList::from_vec(vec![optionExpr.clone(), defaultExpr.clone()]),
-                    )
+        crate::aver_generated::domain::ast::Expr::ExprInt(defaultValue) => {
+            match optionExpr.clone() {
+                crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, innerArgs) => {
+                    if (name == AverStr::from("Vector.get")) {
+                        crate::aver_generated::domain::resolver::rewrite::rewriteInternalVectorGetOrInt(&innerArgs, defaultValue)
+                    } else {
+                        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                            AverStr::from("Option.withDefault"),
+                            aver_rt::AverList::from_vec(vec![
+                                optionExpr.clone(),
+                                defaultExpr.clone(),
+                            ]),
+                        )
+                    }
                 }
+                _ => crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                    AverStr::from("Option.withDefault"),
+                    aver_rt::AverList::from_vec(vec![optionExpr.clone(), defaultExpr.clone()]),
+                ),
             }
-            _ => Expr::ExprCallBuiltin(
-                AverStr::from("Option.withDefault"),
-                aver_rt::AverList::from_vec(vec![optionExpr.clone(), defaultExpr.clone()]),
-            ),
-        },
-        _ => Expr::ExprCallBuiltin(
+        }
+        _ => crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
             AverStr::from("Option.withDefault"),
             aver_rt::AverList::from_vec(vec![optionExpr.clone(), defaultExpr.clone()]),
         ),
@@ -491,23 +645,29 @@ pub fn rewriteInternalVectorGetOrInt(args: &aver_rt::AverList<Expr>, defaultValu
             {
                 let __list_subject = rest;
                 if let Some((idxExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    rewriteInternalVectorGetOrIntArgs(&vecExpr, &idxExpr, defaultValue)
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalVectorGetOrIntArgs(&vecExpr, &idxExpr, defaultValue)
                 } else {
-                    Expr::ExprCallBuiltin(
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                         AverStr::from("Option.withDefault"),
                         aver_rt::AverList::from_vec(vec![
-                            Expr::ExprCallBuiltin(AverStr::from("Vector.get"), args.clone()),
-                            Expr::ExprInt(defaultValue),
+                            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                                AverStr::from("Vector.get"),
+                                args.clone(),
+                            ),
+                            crate::aver_generated::domain::ast::Expr::ExprInt(defaultValue),
                         ]),
                     )
                 }
             }
         } else {
-            Expr::ExprCallBuiltin(
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                 AverStr::from("Option.withDefault"),
                 aver_rt::AverList::from_vec(vec![
-                    Expr::ExprCallBuiltin(AverStr::from("Vector.get"), args.clone()),
-                    Expr::ExprInt(defaultValue),
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                        AverStr::from("Vector.get"),
+                        args.clone(),
+                    ),
+                    crate::aver_generated::domain::ast::Expr::ExprInt(defaultValue),
                 ]),
             )
         }
@@ -522,28 +682,28 @@ pub fn rewriteInternalVectorGetOrIntArgs(
     defaultValue: i64,
 ) -> Expr {
     crate::cancel_checkpoint();
-    if exprHasSlotShape(vecExpr) {
-        Expr::ExprVectorGetOrInt(
+    if crate::aver_generated::domain::resolver::rewrite::exprHasSlotShape(vecExpr) {
+        crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
             std::sync::Arc::new(vecExpr.clone()),
             std::sync::Arc::new(idxExpr.clone()),
             defaultValue,
         )
     } else {
-        if exprHasSlotShape(idxExpr) {
-            Expr::ExprVectorGetOrInt(
+        if crate::aver_generated::domain::resolver::rewrite::exprHasSlotShape(idxExpr) {
+            crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
                 std::sync::Arc::new(vecExpr.clone()),
                 std::sync::Arc::new(idxExpr.clone()),
                 defaultValue,
             )
         } else {
-            Expr::ExprCallBuiltin(
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                 AverStr::from("Option.withDefault"),
                 aver_rt::AverList::from_vec(vec![
-                    Expr::ExprCallBuiltin(
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                         AverStr::from("Vector.get"),
                         aver_rt::AverList::from_vec(vec![vecExpr.clone(), idxExpr.clone()]),
                     ),
-                    Expr::ExprInt(defaultValue),
+                    crate::aver_generated::domain::ast::Expr::ExprInt(defaultValue),
                 ]),
             )
         }
@@ -559,13 +719,19 @@ pub fn rewriteInternalResultWithDefault(args: &aver_rt::AverList<Expr>) -> Expr 
             {
                 let __list_subject = rest;
                 if let Some((defaultExpr, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    rewriteInternalResultWithDefaultArgs(&resultExpr, &defaultExpr)
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalResultWithDefaultArgs(&resultExpr, &defaultExpr)
                 } else {
-                    Expr::ExprCallBuiltin(AverStr::from("Result.withDefault"), args.clone())
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                        AverStr::from("Result.withDefault"),
+                        args.clone(),
+                    )
                 }
             }
         } else {
-            Expr::ExprCallBuiltin(AverStr::from("Result.withDefault"), args.clone())
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                AverStr::from("Result.withDefault"),
+                args.clone(),
+            )
         }
     }
 }
@@ -574,23 +740,31 @@ pub fn rewriteInternalResultWithDefault(args: &aver_rt::AverList<Expr>) -> Expr 
 pub fn rewriteInternalResultWithDefaultArgs(resultExpr: &Expr, defaultExpr: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match defaultExpr.clone() {
-        Expr::ExprInt(defaultValue) => match resultExpr.clone() {
-            Expr::ExprCallBuiltin(name, innerArgs) => {
-                if (name == AverStr::from("Int.mod")) {
-                    rewriteInternalIntModOrInt(&innerArgs, defaultValue)
-                } else {
-                    Expr::ExprCallBuiltin(
-                        AverStr::from("Result.withDefault"),
-                        aver_rt::AverList::from_vec(vec![resultExpr.clone(), defaultExpr.clone()]),
-                    )
+        crate::aver_generated::domain::ast::Expr::ExprInt(defaultValue) => {
+            match resultExpr.clone() {
+                crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, innerArgs) => {
+                    if (name == AverStr::from("Int.mod")) {
+                        crate::aver_generated::domain::resolver::rewrite::rewriteInternalIntModOrInt(
+                            &innerArgs,
+                            defaultValue,
+                        )
+                    } else {
+                        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                            AverStr::from("Result.withDefault"),
+                            aver_rt::AverList::from_vec(vec![
+                                resultExpr.clone(),
+                                defaultExpr.clone(),
+                            ]),
+                        )
+                    }
                 }
+                _ => crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                    AverStr::from("Result.withDefault"),
+                    aver_rt::AverList::from_vec(vec![resultExpr.clone(), defaultExpr.clone()]),
+                ),
             }
-            _ => Expr::ExprCallBuiltin(
-                AverStr::from("Result.withDefault"),
-                aver_rt::AverList::from_vec(vec![resultExpr.clone(), defaultExpr.clone()]),
-            ),
-        },
-        _ => Expr::ExprCallBuiltin(
+        }
+        _ => crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
             AverStr::from("Result.withDefault"),
             aver_rt::AverList::from_vec(vec![resultExpr.clone(), defaultExpr.clone()]),
         ),
@@ -606,23 +780,33 @@ pub fn rewriteInternalIntModOrInt(args: &aver_rt::AverList<Expr>, defaultValue: 
             {
                 let __list_subject = rest;
                 if let Some((b, ignored)) = aver_rt::list_uncons_cloned(&__list_subject) {
-                    rewriteInternalIntModOrIntArgs(&a, &b, defaultValue)
+                    crate::aver_generated::domain::resolver::rewrite::rewriteInternalIntModOrIntArgs(
+                        &a,
+                        &b,
+                        defaultValue,
+                    )
                 } else {
-                    Expr::ExprCallBuiltin(
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                         AverStr::from("Result.withDefault"),
                         aver_rt::AverList::from_vec(vec![
-                            Expr::ExprCallBuiltin(AverStr::from("Int.mod"), args.clone()),
-                            Expr::ExprInt(defaultValue),
+                            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                                AverStr::from("Int.mod"),
+                                args.clone(),
+                            ),
+                            crate::aver_generated::domain::ast::Expr::ExprInt(defaultValue),
                         ]),
                     )
                 }
             }
         } else {
-            Expr::ExprCallBuiltin(
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                 AverStr::from("Result.withDefault"),
                 aver_rt::AverList::from_vec(vec![
-                    Expr::ExprCallBuiltin(AverStr::from("Int.mod"), args.clone()),
-                    Expr::ExprInt(defaultValue),
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                        AverStr::from("Int.mod"),
+                        args.clone(),
+                    ),
+                    crate::aver_generated::domain::ast::Expr::ExprInt(defaultValue),
                 ]),
             )
         }
@@ -633,28 +817,28 @@ pub fn rewriteInternalIntModOrInt(args: &aver_rt::AverList<Expr>, defaultValue: 
 #[inline(always)]
 pub fn rewriteInternalIntModOrIntArgs(a: &Expr, b: &Expr, defaultValue: i64) -> Expr {
     crate::cancel_checkpoint();
-    if exprHasSlotShape(a) {
-        Expr::ExprIntModOrInt(
+    if crate::aver_generated::domain::resolver::rewrite::exprHasSlotShape(a) {
+        crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(
             std::sync::Arc::new(a.clone()),
             std::sync::Arc::new(b.clone()),
             defaultValue,
         )
     } else {
-        if exprHasSlotShape(b) {
-            Expr::ExprIntModOrInt(
+        if crate::aver_generated::domain::resolver::rewrite::exprHasSlotShape(b) {
+            crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(
                 std::sync::Arc::new(a.clone()),
                 std::sync::Arc::new(b.clone()),
                 defaultValue,
             )
         } else {
-            Expr::ExprCallBuiltin(
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                 AverStr::from("Result.withDefault"),
                 aver_rt::AverList::from_vec(vec![
-                    Expr::ExprCallBuiltin(
+                    crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                         AverStr::from("Int.mod"),
                         aver_rt::AverList::from_vec(vec![a.clone(), b.clone()]),
                     ),
-                    Expr::ExprInt(defaultValue),
+                    crate::aver_generated::domain::ast::Expr::ExprInt(defaultValue),
                 ]),
             )
         }
@@ -665,13 +849,13 @@ pub fn rewriteInternalIntModOrIntArgs(a: &Expr, b: &Expr, defaultValue: i64) -> 
 pub fn exprHasSlotShape(expr: &Expr) -> bool {
     crate::cancel_checkpoint();
     match expr {
-        Expr::ExprSlot(_) => true,
-        Expr::ExprBinopSlotInt(_, _, _) => true,
-        Expr::ExprBinopSlots(_, _, _) => true,
-        Expr::ExprCmpSlotInt(_, _, _) => true,
-        Expr::ExprCmpSlots(_, _, _) => true,
-        Expr::ExprVectorGetOrInt(_, _, _) => true,
-        Expr::ExprIntModOrInt(_, _, _) => true,
+        crate::aver_generated::domain::ast::Expr::ExprSlot(_) => true,
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(_, _, _) => true,
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlots(_, _, _) => true,
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(_, _, _) => true,
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlots(_, _, _) => true,
+        crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(_, _, _) => true,
+        crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(_, _, _) => true,
         _ => false,
     }
 }
@@ -680,10 +864,20 @@ pub fn exprHasSlotShape(expr: &Expr) -> bool {
 pub fn rewriteInternalCmp(op: &CmpOp, left: &Expr, right: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match left.clone() {
-        Expr::ExprSlot(slot) => rewriteInternalCmpSlotLeft(op, slot, right),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+            crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmpSlotLeft(
+                op, slot, right,
+            )
+        }
         _ => match right.clone() {
-            Expr::ExprSlot(slot) => rewriteInternalCmpSlotRight(op, left, slot),
-            _ => rebuildInternalCmp(op, left, right),
+            crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmpSlotRight(
+                    op, left, slot,
+                )
+            }
+            _ => crate::aver_generated::domain::resolver::rewrite::rebuildInternalCmp(
+                op, left, right,
+            ),
         },
     }
 }
@@ -692,9 +886,17 @@ pub fn rewriteInternalCmp(op: &CmpOp, left: &Expr, right: &Expr) -> Expr {
 pub fn rewriteInternalCmpSlotLeft(op: &CmpOp, slot: i64, right: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match right.clone() {
-        Expr::ExprInt(n) => Expr::ExprCmpSlotInt(op.clone(), slot, n),
-        Expr::ExprSlot(rhs) => Expr::ExprCmpSlots(op.clone(), slot, rhs),
-        _ => rebuildInternalCmp(op, &Expr::ExprSlot(slot), right),
+        crate::aver_generated::domain::ast::Expr::ExprInt(n) => {
+            crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(op.clone(), slot, n)
+        }
+        crate::aver_generated::domain::ast::Expr::ExprSlot(rhs) => {
+            crate::aver_generated::domain::ast::Expr::ExprCmpSlots(op.clone(), slot, rhs)
+        }
+        _ => crate::aver_generated::domain::resolver::rewrite::rebuildInternalCmp(
+            op,
+            &crate::aver_generated::domain::ast::Expr::ExprSlot(slot),
+            right,
+        ),
     }
 }
 
@@ -702,9 +904,21 @@ pub fn rewriteInternalCmpSlotLeft(op: &CmpOp, slot: i64, right: &Expr) -> Expr {
 pub fn rewriteInternalCmpSlotRight(op: &CmpOp, left: &Expr, slot: i64) -> Expr {
     crate::cancel_checkpoint();
     match left.clone() {
-        Expr::ExprInt(n) => Expr::ExprCmpSlotInt(flipCmp(op), slot, n),
-        Expr::ExprSlot(lhs) => Expr::ExprCmpSlots(op.clone(), lhs, slot),
-        _ => rebuildInternalCmp(op, left, &Expr::ExprSlot(slot)),
+        crate::aver_generated::domain::ast::Expr::ExprInt(n) => {
+            crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(
+                crate::aver_generated::domain::resolver::rewrite::flipCmp(op),
+                slot,
+                n,
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprSlot(lhs) => {
+            crate::aver_generated::domain::ast::Expr::ExprCmpSlots(op.clone(), lhs, slot)
+        }
+        _ => crate::aver_generated::domain::resolver::rewrite::rebuildInternalCmp(
+            op,
+            left,
+            &crate::aver_generated::domain::ast::Expr::ExprSlot(slot),
+        ),
     }
 }
 
@@ -712,30 +926,42 @@ pub fn rewriteInternalCmpSlotRight(op: &CmpOp, left: &Expr, slot: i64) -> Expr {
 pub fn rebuildInternalCmp(op: &CmpOp, left: &Expr, right: &Expr) -> Expr {
     crate::cancel_checkpoint();
     match op {
-        CmpOp::CmpEq => Expr::ExprEq(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
-        CmpOp::CmpNeq => Expr::ExprNeq(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
-        CmpOp::CmpLt => Expr::ExprLt(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
-        CmpOp::CmpGt => Expr::ExprGt(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
-        CmpOp::CmpLte => Expr::ExprLte(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
-        CmpOp::CmpGte => Expr::ExprGte(
-            std::sync::Arc::new(left.clone()),
-            std::sync::Arc::new(right.clone()),
-        ),
+        crate::aver_generated::domain::ast::CmpOp::CmpEq => {
+            crate::aver_generated::domain::ast::Expr::ExprEq(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpNeq => {
+            crate::aver_generated::domain::ast::Expr::ExprNeq(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLt => {
+            crate::aver_generated::domain::ast::Expr::ExprLt(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGt => {
+            crate::aver_generated::domain::ast::Expr::ExprGt(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLte => {
+            crate::aver_generated::domain::ast::Expr::ExprLte(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGte => {
+            crate::aver_generated::domain::ast::Expr::ExprGte(
+                std::sync::Arc::new(left.clone()),
+                std::sync::Arc::new(right.clone()),
+            )
+        }
     }
 }
 
@@ -743,12 +969,12 @@ pub fn rebuildInternalCmp(op: &CmpOp, left: &Expr, right: &Expr) -> Expr {
 pub fn flipCmp(op: &CmpOp) -> CmpOp {
     crate::cancel_checkpoint();
     match op {
-        CmpOp::CmpEq => CmpOp::CmpEq.clone(),
-        CmpOp::CmpNeq => CmpOp::CmpNeq.clone(),
-        CmpOp::CmpLt => CmpOp::CmpGt.clone(),
-        CmpOp::CmpGt => CmpOp::CmpLt.clone(),
-        CmpOp::CmpLte => CmpOp::CmpGte.clone(),
-        CmpOp::CmpGte => CmpOp::CmpLte.clone(),
+        crate::aver_generated::domain::ast::CmpOp::CmpEq => CmpOp::CmpEq.clone(),
+        crate::aver_generated::domain::ast::CmpOp::CmpNeq => CmpOp::CmpNeq.clone(),
+        crate::aver_generated::domain::ast::CmpOp::CmpLt => CmpOp::CmpGt.clone(),
+        crate::aver_generated::domain::ast::CmpOp::CmpGt => CmpOp::CmpLt.clone(),
+        crate::aver_generated::domain::ast::CmpOp::CmpLte => CmpOp::CmpGte.clone(),
+        crate::aver_generated::domain::ast::CmpOp::CmpGte => CmpOp::CmpLte.clone(),
     }
 }
 
@@ -756,16 +982,19 @@ pub fn flipCmp(op: &CmpOp) -> CmpOp {
 #[inline(always)]
 pub fn rewriteInternalMatch(scrutinee: &Expr, arms: &aver_rt::AverList<MatchArm>) -> Expr {
     crate::cancel_checkpoint();
-    match rewriteBoolMatchArms(arms) {
+    match crate::aver_generated::domain::resolver::rewrite::rewriteBoolMatchArms(arms) {
         Some(pair) => {
             let (thenExpr, elseExpr) = pair;
-            Expr::ExprBoolBranch(
+            crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
                 std::sync::Arc::new(scrutinee.clone()),
                 std::sync::Arc::new(thenExpr),
                 std::sync::Arc::new(elseExpr),
             )
         }
-        None => Expr::ExprMatch(std::sync::Arc::new(scrutinee.clone()), arms.clone()),
+        None => crate::aver_generated::domain::ast::Expr::ExprMatch(
+            std::sync::Arc::new(scrutinee.clone()),
+            arms.clone(),
+        ),
     }
 }
 
@@ -779,7 +1008,9 @@ pub fn rewriteBoolMatchArms(arms: &aver_rt::AverList<MatchArm>) -> Option<(Expr,
                 let __list_subject = rest;
                 if let Some((arm2, tail)) = aver_rt::list_uncons_cloned(&__list_subject) {
                     if (tail == aver_rt::AverList::empty()) {
-                        rewriteBoolMatchArmPair(&arm1, &arm2)
+                        crate::aver_generated::domain::resolver::rewrite::rewriteBoolMatchArmPair(
+                            &arm1, &arm2,
+                        )
                     } else {
                         None
                     }
@@ -797,8 +1028,13 @@ pub fn rewriteBoolMatchArms(arms: &aver_rt::AverList<MatchArm>) -> Option<(Expr,
 pub fn rewriteBoolMatchArmPair(arm1: &MatchArm, arm2: &MatchArm) -> Option<(Expr, Expr)> {
     crate::cancel_checkpoint();
     match arm1.pattern.clone() {
-        Pattern::PatBool(b1) => {
-            rewriteBoolMatchArmPairInner(b1, &arm1.body, &arm2.pattern, &arm2.body)
+        crate::aver_generated::domain::ast::Pattern::PatBool(b1) => {
+            crate::aver_generated::domain::resolver::rewrite::rewriteBoolMatchArmPairInner(
+                b1,
+                &arm1.body,
+                &arm2.pattern,
+                &arm2.body,
+            )
         }
         _ => None,
     }
@@ -813,7 +1049,11 @@ pub fn rewriteBoolMatchArmPairInner(
 ) -> Option<(Expr, Expr)> {
     crate::cancel_checkpoint();
     match p2.clone() {
-        Pattern::PatBool(b2) => rewriteBoolMatchArmPairBools(b1, body1, b2, body2),
+        crate::aver_generated::domain::ast::Pattern::PatBool(b2) => {
+            crate::aver_generated::domain::resolver::rewrite::rewriteBoolMatchArmPairBools(
+                b1, body1, b2, body2,
+            )
+        }
         _ => None,
     }
 }

--- a/src/self_host/aver_generated/domain/token/mod.rs
+++ b/src/self_host/aver_generated/domain/token/mod.rs
@@ -517,7 +517,7 @@ impl aver_replay::ReplayValue for Token {
 pub fn tokenRepr(t: &Token) -> AverStr {
     crate::cancel_checkpoint();
     match t.clone() {
-        Token::TkInt(n) => aver_rt::AverStr::from({
+        crate::aver_generated::domain::token::Token::TkInt(n) => aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = {
                     let mut __b = aver_rt::Buffer::with_capacity((21i64) as usize);
@@ -530,8 +530,8 @@ pub fn tokenRepr(t: &Token) -> AverStr {
             __b.push_str(&AverStr::from(")"));
             __b
         }),
-        Token::TkFloat(f) => AverStr::from("Float"),
-        Token::TkStr(s) => aver_rt::AverStr::from({
+        crate::aver_generated::domain::token::Token::TkFloat(f) => AverStr::from("Float"),
+        crate::aver_generated::domain::token::Token::TkStr(s) => aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = {
                     let mut __b = aver_rt::Buffer::with_capacity((21i64) as usize);
@@ -544,7 +544,7 @@ pub fn tokenRepr(t: &Token) -> AverStr {
             __b.push_str(&AverStr::from(")"));
             __b
         }),
-        Token::TkIdent(s) => aver_rt::AverStr::from({
+        crate::aver_generated::domain::token::Token::TkIdent(s) => aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = {
                     let mut __b = aver_rt::Buffer::with_capacity((23i64) as usize);
@@ -557,40 +557,40 @@ pub fn tokenRepr(t: &Token) -> AverStr {
             __b.push_str(&AverStr::from(")"));
             __b
         }),
-        Token::TkTrue => AverStr::from("True"),
-        Token::TkFalse => AverStr::from("False"),
-        Token::TkPlus => AverStr::from("Plus"),
-        Token::TkMinus => AverStr::from("Minus"),
-        Token::TkStar => AverStr::from("Star"),
-        Token::TkSlash => AverStr::from("Slash"),
-        Token::TkEq => AverStr::from("Eq"),
-        Token::TkEqEq => AverStr::from("EqEq"),
-        Token::TkNeq => AverStr::from("Neq"),
-        Token::TkLt => AverStr::from("Lt"),
-        Token::TkGt => AverStr::from("Gt"),
-        Token::TkLte => AverStr::from("Lte"),
-        Token::TkGte => AverStr::from("Gte"),
-        Token::TkLParen => AverStr::from("LParen"),
-        Token::TkRParen => AverStr::from("RParen"),
-        Token::TkComma => AverStr::from("Comma"),
-        Token::TkArrow => AverStr::from("Arrow"),
-        Token::TkLBracket => AverStr::from("LBracket"),
-        Token::TkRBracket => AverStr::from("RBracket"),
-        Token::TkDot => AverStr::from("Dot"),
-        Token::TkDotDot => AverStr::from("DotDot"),
-        Token::TkQuestion => AverStr::from("Question"),
-        Token::TkNewline => AverStr::from("Newline"),
-        Token::TkInterpStart => AverStr::from("InterpStart"),
-        Token::TkInterpEnd => AverStr::from("InterpEnd"),
-        Token::TkColon => AverStr::from("Colon"),
-        Token::TkBang => AverStr::from("Bang"),
-        Token::TkFatArrow => AverStr::from("FatArrow"),
-        Token::TkIndent => AverStr::from("Indent"),
-        Token::TkDedent => AverStr::from("Dedent"),
-        Token::TkLBrace => AverStr::from("LBrace"),
-        Token::TkRBrace => AverStr::from("RBrace"),
-        Token::TkFn => AverStr::from("Fn"),
-        Token::TkMatch => AverStr::from("Match"),
-        Token::TkEof => AverStr::from("Eof"),
+        crate::aver_generated::domain::token::Token::TkTrue => AverStr::from("True"),
+        crate::aver_generated::domain::token::Token::TkFalse => AverStr::from("False"),
+        crate::aver_generated::domain::token::Token::TkPlus => AverStr::from("Plus"),
+        crate::aver_generated::domain::token::Token::TkMinus => AverStr::from("Minus"),
+        crate::aver_generated::domain::token::Token::TkStar => AverStr::from("Star"),
+        crate::aver_generated::domain::token::Token::TkSlash => AverStr::from("Slash"),
+        crate::aver_generated::domain::token::Token::TkEq => AverStr::from("Eq"),
+        crate::aver_generated::domain::token::Token::TkEqEq => AverStr::from("EqEq"),
+        crate::aver_generated::domain::token::Token::TkNeq => AverStr::from("Neq"),
+        crate::aver_generated::domain::token::Token::TkLt => AverStr::from("Lt"),
+        crate::aver_generated::domain::token::Token::TkGt => AverStr::from("Gt"),
+        crate::aver_generated::domain::token::Token::TkLte => AverStr::from("Lte"),
+        crate::aver_generated::domain::token::Token::TkGte => AverStr::from("Gte"),
+        crate::aver_generated::domain::token::Token::TkLParen => AverStr::from("LParen"),
+        crate::aver_generated::domain::token::Token::TkRParen => AverStr::from("RParen"),
+        crate::aver_generated::domain::token::Token::TkComma => AverStr::from("Comma"),
+        crate::aver_generated::domain::token::Token::TkArrow => AverStr::from("Arrow"),
+        crate::aver_generated::domain::token::Token::TkLBracket => AverStr::from("LBracket"),
+        crate::aver_generated::domain::token::Token::TkRBracket => AverStr::from("RBracket"),
+        crate::aver_generated::domain::token::Token::TkDot => AverStr::from("Dot"),
+        crate::aver_generated::domain::token::Token::TkDotDot => AverStr::from("DotDot"),
+        crate::aver_generated::domain::token::Token::TkQuestion => AverStr::from("Question"),
+        crate::aver_generated::domain::token::Token::TkNewline => AverStr::from("Newline"),
+        crate::aver_generated::domain::token::Token::TkInterpStart => AverStr::from("InterpStart"),
+        crate::aver_generated::domain::token::Token::TkInterpEnd => AverStr::from("InterpEnd"),
+        crate::aver_generated::domain::token::Token::TkColon => AverStr::from("Colon"),
+        crate::aver_generated::domain::token::Token::TkBang => AverStr::from("Bang"),
+        crate::aver_generated::domain::token::Token::TkFatArrow => AverStr::from("FatArrow"),
+        crate::aver_generated::domain::token::Token::TkIndent => AverStr::from("Indent"),
+        crate::aver_generated::domain::token::Token::TkDedent => AverStr::from("Dedent"),
+        crate::aver_generated::domain::token::Token::TkLBrace => AverStr::from("LBrace"),
+        crate::aver_generated::domain::token::Token::TkRBrace => AverStr::from("RBrace"),
+        crate::aver_generated::domain::token::Token::TkFn => AverStr::from("Fn"),
+        crate::aver_generated::domain::token::Token::TkMatch => AverStr::from("Match"),
+        crate::aver_generated::domain::token::Token::TkEof => AverStr::from("Eof"),
     }
 }

--- a/src/self_host/aver_generated/domain/value/mod.rs
+++ b/src/self_host/aver_generated/domain/value/mod.rs
@@ -398,11 +398,11 @@ pub fn valListRepr(
         crate::cancel_checkpoint();
         return aver_list_match!(items, [] => { aver_rt::AverStr::from({ let mut __b = { let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((18i64) as usize); __b.push_str(&AverStr::from("[")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(acc)))); __b }; __b.push_str(&AverStr::from("]")); __b }) }, [v, rest] => { if first { {
             items = rest;
-            acc = valReprInner(&v);
+            acc = crate::aver_generated::domain::value::valReprInner(&v);
             first = false;
             continue;
         } } else { {
-            let __tmp1 = ((acc + &AverStr::from(", ")) + &valReprInner(&v));
+            let __tmp1 = ((acc + &AverStr::from(", ")) + &crate::aver_generated::domain::value::valReprInner(&v));
             items = rest;
             acc = __tmp1;
             first = false;
@@ -415,11 +415,11 @@ pub fn valListRepr(
 pub fn valRepr(v: &Val) -> AverStr {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValInt(n) => (n.to_string()).into_aver(),
-        Val::ValFloat(f) => (f.to_string()).into_aver(),
-        Val::ValStr(s) => s,
-        Val::ValBool(b) => (b.to_string()).into_aver(),
-        Val::ValFnRef(name) => aver_rt::AverStr::from({
+        crate::aver_generated::domain::value::Val::ValInt(n) => (n.to_string()).into_aver(),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => (f.to_string()).into_aver(),
+        crate::aver_generated::domain::value::Val::ValStr(s) => s,
+        crate::aver_generated::domain::value::Val::ValBool(b) => (b.to_string()).into_aver(),
+        crate::aver_generated::domain::value::Val::ValFnRef(name) => aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = {
                     let mut __b = aver_rt::Buffer::with_capacity((21i64) as usize);
@@ -432,11 +432,18 @@ pub fn valRepr(v: &Val) -> AverStr {
             __b.push_str(&AverStr::from(">"));
             __b
         }),
-        Val::ValList(items) => valListRepr(items, AverStr::from(""), true),
-        Val::ValVector(vec) => {
-            (AverStr::from("Vector") + &valListRepr(vec.to_list(), AverStr::from(""), true))
+        crate::aver_generated::domain::value::Val::ValList(items) => {
+            crate::aver_generated::domain::value::valListRepr(items, AverStr::from(""), true)
         }
-        Val::ValOk(inner) => {
+        crate::aver_generated::domain::value::Val::ValVector(vec) => {
+            (AverStr::from("Vector")
+                + &crate::aver_generated::domain::value::valListRepr(
+                    vec.to_list(),
+                    AverStr::from(""),
+                    true,
+                ))
+        }
+        crate::aver_generated::domain::value::Val::ValOk(inner) => {
             let inner = (*inner).clone();
             aver_rt::AverStr::from({
                 let mut __b = {
@@ -446,7 +453,7 @@ pub fn valRepr(v: &Val) -> AverStr {
                         __b
                     };
                     __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(
-                        &(valReprInner(&inner)),
+                        &(crate::aver_generated::domain::value::valReprInner(&inner)),
                     )));
                     __b
                 };
@@ -454,7 +461,7 @@ pub fn valRepr(v: &Val) -> AverStr {
                 __b
             })
         }
-        Val::ValErr(inner) => {
+        crate::aver_generated::domain::value::Val::ValErr(inner) => {
             let inner = (*inner).clone();
             aver_rt::AverStr::from({
                 let mut __b = {
@@ -464,7 +471,7 @@ pub fn valRepr(v: &Val) -> AverStr {
                         __b
                     };
                     __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(
-                        &(valReprInner(&inner)),
+                        &(crate::aver_generated::domain::value::valReprInner(&inner)),
                     )));
                     __b
                 };
@@ -472,7 +479,7 @@ pub fn valRepr(v: &Val) -> AverStr {
                 __b
             })
         }
-        Val::ValTuple(items) => aver_rt::AverStr::from({
+        crate::aver_generated::domain::value::Val::ValTuple(items) => aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = {
                     let mut __b = aver_rt::Buffer::with_capacity((18i64) as usize);
@@ -480,14 +487,18 @@ pub fn valRepr(v: &Val) -> AverStr {
                     __b
                 };
                 __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(
-                    &(valFieldsRepr(items, AverStr::from(""), true)),
+                    &(crate::aver_generated::domain::value::valFieldsRepr(
+                        items,
+                        AverStr::from(""),
+                        true,
+                    )),
                 )));
                 __b
             };
             __b.push_str(&AverStr::from(")"));
             __b
         }),
-        Val::ValSome(inner) => {
+        crate::aver_generated::domain::value::Val::ValSome(inner) => {
             let inner = (*inner).clone();
             aver_rt::AverStr::from({
                 let mut __b = {
@@ -497,7 +508,7 @@ pub fn valRepr(v: &Val) -> AverStr {
                         __b
                     };
                     __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(
-                        &(valReprInner(&inner)),
+                        &(crate::aver_generated::domain::value::valReprInner(&inner)),
                     )));
                     __b
                 };
@@ -505,8 +516,8 @@ pub fn valRepr(v: &Val) -> AverStr {
                 __b
             })
         }
-        Val::ValNone => AverStr::from("Option.None"),
-        Val::ValRecord(name, _) => aver_rt::AverStr::from({
+        crate::aver_generated::domain::value::Val::ValNone => AverStr::from("Option.None"),
+        crate::aver_generated::domain::value::Val::ValRecord(name, _) => aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = aver_rt::Buffer::with_capacity((21i64) as usize);
                 __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(name))));
@@ -515,17 +526,21 @@ pub fn valRepr(v: &Val) -> AverStr {
             __b.push_str(&AverStr::from("(...)"));
             __b
         }),
-        Val::ValMap(m) => valMapRepr(
-            {
-                let mut es: Vec<_> = m.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                es.sort_by(|a, b| a.0.cmp(&b.0));
-                aver_rt::AverList::from_vec(es)
-            },
-            AverStr::from(""),
-            true,
-        ),
-        Val::ValVariant(_, fullName, fields) => valVariantReprTagged(fullName, &fields),
-        Val::ValUnit => AverStr::from("()"),
+        crate::aver_generated::domain::value::Val::ValMap(m) => {
+            crate::aver_generated::domain::value::valMapRepr(
+                {
+                    let mut es: Vec<_> = m.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                    es.sort_by(|a, b| a.0.cmp(&b.0));
+                    aver_rt::AverList::from_vec(es)
+                },
+                AverStr::from(""),
+                true,
+            )
+        }
+        crate::aver_generated::domain::value::Val::ValVariant(_, fullName, fields) => {
+            crate::aver_generated::domain::value::valVariantReprTagged(fullName, &fields)
+        }
+        crate::aver_generated::domain::value::Val::ValUnit => AverStr::from("()"),
     }
 }
 
@@ -533,8 +548,10 @@ pub fn valRepr(v: &Val) -> AverStr {
 pub fn valReprInner(v: &Val) -> AverStr {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValStr(s) => ((AverStr::from("\"") + &s) + &AverStr::from("\"")),
-        Val::ValFnRef(name) => aver_rt::AverStr::from({
+        crate::aver_generated::domain::value::Val::ValStr(s) => {
+            ((AverStr::from("\"") + &s) + &AverStr::from("\""))
+        }
+        crate::aver_generated::domain::value::Val::ValFnRef(name) => aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = {
                     let mut __b = aver_rt::Buffer::with_capacity((21i64) as usize);
@@ -547,7 +564,7 @@ pub fn valReprInner(v: &Val) -> AverStr {
             __b.push_str(&AverStr::from(">"));
             __b
         }),
-        Val::ValTuple(items) => aver_rt::AverStr::from({
+        crate::aver_generated::domain::value::Val::ValTuple(items) => aver_rt::AverStr::from({
             let mut __b = {
                 let mut __b = {
                     let mut __b = aver_rt::Buffer::with_capacity((18i64) as usize);
@@ -555,18 +572,29 @@ pub fn valReprInner(v: &Val) -> AverStr {
                     __b
                 };
                 __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(
-                    &(valFieldsRepr(items, AverStr::from(""), true)),
+                    &(crate::aver_generated::domain::value::valFieldsRepr(
+                        items,
+                        AverStr::from(""),
+                        true,
+                    )),
                 )));
                 __b
             };
             __b.push_str(&AverStr::from(")"));
             __b
         }),
-        Val::ValVector(vec) => {
-            (AverStr::from("Vector") + &valListRepr(vec.to_list(), AverStr::from(""), true))
+        crate::aver_generated::domain::value::Val::ValVector(vec) => {
+            (AverStr::from("Vector")
+                + &crate::aver_generated::domain::value::valListRepr(
+                    vec.to_list(),
+                    AverStr::from(""),
+                    true,
+                ))
         }
-        Val::ValList(items) => valListRepr(items, AverStr::from(""), true),
-        _ => valRepr(v),
+        crate::aver_generated::domain::value::Val::ValList(items) => {
+            crate::aver_generated::domain::value::valListRepr(items, AverStr::from(""), true)
+        }
+        _ => crate::aver_generated::domain::value::valRepr(v),
     }
 }
 
@@ -582,11 +610,11 @@ pub fn valMapRepr(
         return aver_list_match!(entries, [] => { aver_rt::AverStr::from({ let mut __b = { let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((18i64) as usize); __b.push_str(&AverStr::from("{")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(acc)))); __b }; __b.push_str(&AverStr::from("}")); __b }) }, [pair, rest] => { match pair {
             (k, v) => if first { {
             entries = rest;
-            acc = ((quoteString(k) + &AverStr::from(": ")) + &valReprInner(&v));
+            acc = ((crate::aver_generated::domain::value::quoteString(k) + &AverStr::from(": ")) + &crate::aver_generated::domain::value::valReprInner(&v));
             first = false;
             continue;
         } } else { {
-            let __tmp1 = ((((acc + &AverStr::from(", ")) + &quoteString(k)) + &AverStr::from(": ")) + &valReprInner(&v));
+            let __tmp1 = ((((acc + &AverStr::from(", ")) + &crate::aver_generated::domain::value::quoteString(k)) + &AverStr::from(": ")) + &crate::aver_generated::domain::value::valReprInner(&v));
             entries = rest;
             acc = __tmp1;
             first = false;
@@ -600,11 +628,11 @@ pub fn valMapRepr(
 pub fn mapKeyRepr(v: &Val) -> AverStr {
     crate::cancel_checkpoint();
     match v.clone() {
-        Val::ValInt(n) => (n.to_string()).into_aver(),
-        Val::ValFloat(f) => (f.to_string()).into_aver(),
-        Val::ValStr(s) => s,
-        Val::ValBool(b) => (b.to_string()).into_aver(),
-        _ => valRepr(v),
+        crate::aver_generated::domain::value::Val::ValInt(n) => (n.to_string()).into_aver(),
+        crate::aver_generated::domain::value::Val::ValFloat(f) => (f.to_string()).into_aver(),
+        crate::aver_generated::domain::value::Val::ValStr(s) => s,
+        crate::aver_generated::domain::value::Val::ValBool(b) => (b.to_string()).into_aver(),
+        _ => crate::aver_generated::domain::value::valRepr(v),
     }
 }
 
@@ -630,7 +658,11 @@ pub fn valVariantReprTagged(fullName: AverStr, fields: &aver_rt::AverList<Val>) 
                         __b
                     };
                     __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(
-                        &(valFieldsRepr(fields.clone(), AverStr::from(""), true)),
+                        &(crate::aver_generated::domain::value::valFieldsRepr(
+                            fields.clone(),
+                            AverStr::from(""),
+                            true,
+                        )),
                     )));
                     __b
                 };
@@ -652,11 +684,11 @@ pub fn valFieldsRepr(
         crate::cancel_checkpoint();
         return aver_list_match!(items, [] => acc, [v, rest] => { if first { {
             items = rest;
-            acc = valReprInner(&v);
+            acc = crate::aver_generated::domain::value::valReprInner(&v);
             first = false;
             continue;
         } } else { {
-            let __tmp1 = ((acc + &AverStr::from(", ")) + &valReprInner(&v));
+            let __tmp1 = ((acc + &AverStr::from(", ")) + &crate::aver_generated::domain::value::valReprInner(&v));
             items = rest;
             acc = __tmp1;
             first = false;

--- a/src/self_host/aver_generated/entry/mod.rs
+++ b/src/self_host/aver_generated/entry/mod.rs
@@ -176,7 +176,7 @@ pub fn qualifyFnsOne(
 /// Lex, parse, resolve, and evaluate an Aver source string (no module loading).
 pub fn run(source: AverStr) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let tokens = crate::aver_generated::domain::lexer::lex(source.clone());
+    let tokens = crate::aver_generated::domain::lexer::lex(source);
     let prog = crate::aver_generated::domain::parser::parse(&tokens)?;
     let resolved = crate::aver_generated::domain::resolver::resolveProgram(&prog);
     runGuestProgram(
@@ -202,7 +202,7 @@ pub fn prepareProgramWithModules(
     moduleRoot: AverStr,
 ) -> Result<(Program, aver_rt::AverList<FnDef>), AverStr> {
     crate::cancel_checkpoint();
-    let tokens = crate::aver_generated::domain::lexer::lex(source.clone());
+    let tokens = crate::aver_generated::domain::lexer::lex(source);
     let prog = crate::aver_generated::domain::parser::parse(&tokens)?;
     let resolved = crate::aver_generated::domain::resolver::resolveProgram(&prog);
     let r = loadModules(
@@ -392,8 +392,11 @@ pub fn shiftFnIdsInFn(fd: &FnDef, offset: i64) -> FnDef {
 pub fn shiftFnIdsInFastPath(path: &FnFastPath, offset: i64) -> FnFastPath {
     crate::cancel_checkpoint();
     match path.clone() {
-        FnFastPath::FastForwardCall(targetId, slotArgs) => {
-            FnFastPath::FastForwardCall((targetId + offset), slotArgs)
+        crate::aver_generated::domain::ast::FnFastPath::FastForwardCall(targetId, slotArgs) => {
+            crate::aver_generated::domain::ast::FnFastPath::FastForwardCall(
+                (targetId + offset),
+                slotArgs,
+            )
         }
         _ => path.clone(),
     }
@@ -421,9 +424,21 @@ pub fn shiftFnIdsInStmts(
 pub fn shiftFnIdsInStmt(stmt: &Stmt, offset: i64) -> Stmt {
     crate::cancel_checkpoint();
     match stmt.clone() {
-        Stmt::StmtBind(name, expr) => Stmt::StmtBind(name, shiftFnIdsInExpr(&expr, offset)),
-        Stmt::StmtBindSlot(slot, expr) => Stmt::StmtBindSlot(slot, shiftFnIdsInExpr(&expr, offset)),
-        Stmt::StmtExpr(expr) => Stmt::StmtExpr(shiftFnIdsInExpr(&expr, offset)),
+        crate::aver_generated::domain::ast::Stmt::StmtBind(name, expr) => {
+            crate::aver_generated::domain::ast::Stmt::StmtBind(
+                name,
+                shiftFnIdsInExpr(&expr, offset),
+            )
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(slot, expr) => {
+            crate::aver_generated::domain::ast::Stmt::StmtBindSlot(
+                slot,
+                shiftFnIdsInExpr(&expr, offset),
+            )
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::ast::Stmt::StmtExpr(shiftFnIdsInExpr(&expr, offset))
+        }
     }
 }
 
@@ -431,78 +446,82 @@ pub fn shiftFnIdsInStmt(stmt: &Stmt, offset: i64) -> Stmt {
 pub fn shiftFnIdsInExpr(expr: &Expr, offset: i64) -> Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
+        crate::aver_generated::domain::ast::Expr::ExprBoolBranch(cond, thenExpr, elseExpr) => {
             let cond = (*cond).clone();
             let thenExpr = (*thenExpr).clone();
             let elseExpr = (*elseExpr).clone();
-            Expr::ExprBoolBranch(
+            crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
                 std::sync::Arc::new(shiftFnIdsInExpr(&cond, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&thenExpr, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&elseExpr, offset)),
             )
         }
-        Expr::ExprVectorGetOrInt(vecExpr, idxExpr, defaultValue) => {
+        crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
+            vecExpr,
+            idxExpr,
+            defaultValue,
+        ) => {
             let vecExpr = (*vecExpr).clone();
             let idxExpr = (*idxExpr).clone();
-            Expr::ExprVectorGetOrInt(
+            crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
                 std::sync::Arc::new(shiftFnIdsInExpr(&vecExpr, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&idxExpr, offset)),
                 defaultValue,
             )
         }
-        Expr::ExprIntModOrInt(a, b, defaultValue) => {
+        crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(a, b, defaultValue) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprIntModOrInt(
+            crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
                 defaultValue,
             )
         }
-        Expr::ExprAdd(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprAdd(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprAdd(
+            crate::aver_generated::domain::ast::Expr::ExprAdd(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
         }
-        Expr::ExprSub(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprSub(
+            crate::aver_generated::domain::ast::Expr::ExprSub(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
         }
-        Expr::ExprMul(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprMul(
+            crate::aver_generated::domain::ast::Expr::ExprMul(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
         }
-        Expr::ExprDiv(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprDiv(
+            crate::aver_generated::domain::ast::Expr::ExprDiv(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
         }
-        Expr::ExprEq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprEq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprEq(
+            crate::aver_generated::domain::ast::Expr::ExprEq(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
         }
-        Expr::ExprNeq(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprNeq(
+            crate::aver_generated::domain::ast::Expr::ExprNeq(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
@@ -515,51 +534,65 @@ pub fn shiftFnIdsInExpr(expr: &Expr, offset: i64) -> Expr {
 pub fn shiftFnIdsInExprTail(expr: &Expr, offset: i64) -> Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprLt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprLt(
+            crate::aver_generated::domain::ast::Expr::ExprLt(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
         }
-        Expr::ExprGt(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprGt(
+            crate::aver_generated::domain::ast::Expr::ExprGt(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
         }
-        Expr::ExprLte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprLte(
+            crate::aver_generated::domain::ast::Expr::ExprLte(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
         }
-        Expr::ExprGte(a, b) => {
+        crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
             let a = (*a).clone();
             let b = (*b).clone();
-            Expr::ExprGte(
+            crate::aver_generated::domain::ast::Expr::ExprGte(
                 std::sync::Arc::new(shiftFnIdsInExpr(&a, offset)),
                 std::sync::Arc::new(shiftFnIdsInExpr(&b, offset)),
             )
         }
-        Expr::ExprConcat(parts) => {
-            Expr::ExprConcat(shiftFnIdsInExprs(parts, offset, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
+            crate::aver_generated::domain::ast::Expr::ExprConcat(shiftFnIdsInExprs(
+                parts,
+                offset,
+                aver_rt::AverList::empty(),
+            ))
         }
-        Expr::ExprTuple(exprs) => {
-            Expr::ExprTuple(shiftFnIdsInExprs(exprs, offset, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
+            crate::aver_generated::domain::ast::Expr::ExprTuple(shiftFnIdsInExprs(
+                exprs,
+                offset,
+                aver_rt::AverList::empty(),
+            ))
         }
-        Expr::ExprList(exprs) => {
-            Expr::ExprList(shiftFnIdsInExprs(exprs, offset, aver_rt::AverList::empty()))
+        crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
+            crate::aver_generated::domain::ast::Expr::ExprList(shiftFnIdsInExprs(
+                exprs,
+                offset,
+                aver_rt::AverList::empty(),
+            ))
         }
-        Expr::ExprRecord(name, fields) => Expr::ExprRecord(
-            name,
-            shiftFnIdsInFields(fields, offset, aver_rt::AverList::empty()),
-        ),
+        crate::aver_generated::domain::ast::Expr::ExprRecord(name, fields) => {
+            crate::aver_generated::domain::ast::Expr::ExprRecord(
+                name,
+                shiftFnIdsInFields(fields, offset, aver_rt::AverList::empty()),
+            )
+        }
         _ => shiftFnIdsInExprCalls(expr, offset),
     }
 }
@@ -568,41 +601,56 @@ pub fn shiftFnIdsInExprTail(expr: &Expr, offset: i64) -> Expr {
 pub fn shiftFnIdsInExprCalls(expr: &Expr, offset: i64) -> Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
-        Expr::ExprFieldAccess(obj, field) => {
+        crate::aver_generated::domain::ast::Expr::ExprFieldAccess(obj, field) => {
             let obj = (*obj).clone();
-            Expr::ExprFieldAccess(std::sync::Arc::new(shiftFnIdsInExpr(&obj, offset)), field)
+            crate::aver_generated::domain::ast::Expr::ExprFieldAccess(
+                std::sync::Arc::new(shiftFnIdsInExpr(&obj, offset)),
+                field,
+            )
         }
-        Expr::ExprCall(name, args) => Expr::ExprCall(
-            name,
-            shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
-        ),
-        Expr::ExprCallDirect(fnId, args) => Expr::ExprCallDirect(
-            (fnId + offset),
-            shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
-        ),
-        Expr::ExprCallBuiltin(name, args) => Expr::ExprCallBuiltin(
-            name,
-            shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
-        ),
-        Expr::ExprCallBuiltinId(id, args) => Expr::ExprCallBuiltinId(
-            id,
-            shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
-        ),
-        Expr::ExprMatch(scrutinee, arms) => {
+        crate::aver_generated::domain::ast::Expr::ExprCall(name, args) => {
+            crate::aver_generated::domain::ast::Expr::ExprCall(
+                name,
+                shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, args) => {
+            crate::aver_generated::domain::ast::Expr::ExprCallDirect(
+                (fnId + offset),
+                shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, args) => {
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
+                name,
+                shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, args) => {
+            crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
+                id,
+                shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
+            )
+        }
+        crate::aver_generated::domain::ast::Expr::ExprMatch(scrutinee, arms) => {
             let scrutinee = (*scrutinee).clone();
-            Expr::ExprMatch(
+            crate::aver_generated::domain::ast::Expr::ExprMatch(
                 std::sync::Arc::new(shiftFnIdsInExpr(&scrutinee, offset)),
                 shiftFnIdsInArms(arms, offset, aver_rt::AverList::empty()),
             )
         }
-        Expr::ExprPropagate(inner) => {
+        crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => {
             let inner = (*inner).clone();
-            Expr::ExprPropagate(std::sync::Arc::new(shiftFnIdsInExpr(&inner, offset)))
+            crate::aver_generated::domain::ast::Expr::ExprPropagate(std::sync::Arc::new(
+                shiftFnIdsInExpr(&inner, offset),
+            ))
         }
-        Expr::ExprIndependentProduct(exprs, unwrap) => Expr::ExprIndependentProduct(
-            shiftFnIdsInExprs(exprs, offset, aver_rt::AverList::empty()),
-            unwrap,
-        ),
+        crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => {
+            crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
+                shiftFnIdsInExprs(exprs, offset, aver_rt::AverList::empty()),
+                unwrap,
+            )
+        }
         _ => expr.clone(),
     }
 }
@@ -719,7 +767,7 @@ pub fn loadProgramFromFile(
             || (aver_rt::read_text(&__effect_arg0)).into_aver(),
         )
     }?;
-    prepareProgramWithModules(source, moduleRoot.clone())
+    prepareProgramWithModules(source, moduleRoot)
 }
 
 /// Dispatch normalized CLI args: path, module root, then guest args. Carries the user main()'s return Val up so the wrapping replay scope serialises it as recording.output.
@@ -760,7 +808,7 @@ pub fn finishCliRun(localFns: &aver_rt::AverList<FnDef>, result: &Val) -> Result
 pub fn finishCliMainResult(result: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match result.clone() {
-        Val::ValErr(err) => {
+        crate::aver_generated::domain::value::Val::ValErr(err) => {
             let err = (*err).clone();
             Err((AverStr::from("Main returned error: ")
                 + &crate::aver_generated::domain::value::valRepr(&err)))

--- a/src/self_host/main.rs
+++ b/src/self_host/main.rs
@@ -25,7 +25,6 @@ pub use replay_support::*;
 
 mod self_host_support;
 
-#[allow(clippy::needless_return, unused_braces)]
 pub mod aver_generated;
 
 fn main() {


### PR DESCRIPTION
## Summary

PR 8 (#156) migrated Rust codegen from `Expr` to `ResolvedExpr` and made resolved-form classification authoritative. The migration silently broke two paths used by the self-host regen but not exercised by single-module tests. Self-host regen — `aver compile self_hosted/main.av --target rust ...` — produced 342 Rust type errors. **This PR fixes both root causes and regenerates `src/self_host/`** to match the modern Rust codegen output.

Issue: #147 phase E PR 9.4.

## Root causes

### 1. Cross-module ctor classification gap

`ResolveCtx::resolve_type_id(name)` searched only `current_module` + entry scope. A bare type reference from a dep module (`Val.ValOk(x)` in `Domain.Eval.Core` referring to `Val` declared in `Domain.Value`) resolved to `None` → ctor classified as `Unresolved` → rust codegen emitted `Val::ValOk(arg)` without the `Arc::new(...)` wrap the self-referential variant needs.

### 2. Legacy emit helpers had no module-scope context

The on-demand `ctx.resolve_expr(spanned)` / `resolve_stmt(stmt)` / `resolve_pattern(pat)` always passed the *entry* module name as `current_module`. For fns inside dep modules (mutual TCO trampoline arms via `emit_expr_legacy`), the resolver ran with the wrong scope, missing local refs and producing owned-by-default call args instead of borrowed.

## What changed

- **`src/ir/symbol_table.rs`** — new `SymbolTable::type_id_by_bare_name(name)` searches every scope and returns the unique match (`None` on ambiguity). Language rule: a bare type from a dep module resolves iff exactly one scope declares it; ambiguous references still require the qualifier. **Four new unit tests** cover unique cross-module / ambiguity → `None` / entry-scope / missing-name → `None`.
- **`src/ir/hir/resolve.rs`** — `ResolveCtx::resolve_type_id` gains `symbols.type_id_by_bare_name` as the final fallback. Closes the cross-module ctor classification gap.
- **`src/codegen/mod.rs`** — `resolve_expr` / `resolve_stmt` / `resolve_pattern` gain `scope: Option<&str>` (mirror of PR 9.3a's `resolve_fn_def(fd, scope)`). New private `entry_module_name()` helper.
- **`src/codegen/rust/emit_ctx.rs`** — `EmitCtx` gains `current_module_scope: Option<String>` plus `with_scope(scope)` fluent builder. Stamped at fn-emit time so the 20+ legacy on-demand resolver call sites read scope off `ectx.current_module_scope` instead of threading `scope` through every signature.
- **`src/codegen/rust/toplevel.rs`** — `build_fn_ectx` / `build_fn_ectx_no_borrow` take `scope`. `emit_mutual_tco_block` gains `scope`. Module-level doc-comment block updated to reflect the new scope-aware signatures and the `EmitCtx` mechanism.
- **`src/codegen/rust/mod.rs`** — `emit_mutual_tco_block` callsites pass `None` for entry path, `Some(&module.prefix)` for dep-module path.
- **`src/self_host/`** — regenerated. Was last at `1517fd08` (pre-Phase-E); commits between then and this PR (#142 → #163) layered changes the Rust codegen could no longer reproduce. The regen now matches modern Rust codegen output: fully-qualified ctor references (`crate::aver_generated::domain::value::Val::ValOk`), proper `Arc::new` wrapping, borrowed args at mutual TCO call sites.

Net (excluding regenerated `src/self_host/`): **+298 / −85** across 6 files.

## Why this was undetected

Single-module unit tests don't exercise cross-module ctor resolution from a dep-module caller. Self-host (`self_hosted/main.av` with `depends [Domain.Token, Domain.Lexer, Domain.Ast, Domain.Value, Domain.Eval, Domain.Parser, Domain.Resolver]`) is the largest multi-module Aver program in the repo and the only one with self-referential sum types (`Val` enum with `ValOk(Val)`, `ValErr(Val)`, etc.) referenced cross-module. **Adding the bare-name resolution tests + regenerating self-host as part of CI would have caught this.** Follow-up tracking for a `aver compile self_hosted/main.av --target rust` step in CI is worth considering.

## Test plan

- [x] `cargo build` / `cargo build --features wasm` / `cargo build --tests --features wasm` — clean.
- [x] `cargo test --features wasm --no-fail-fast` — **1653 passed, 0 failed** (1649 baseline + 4 new bare-name resolution tests).
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Wasm-gc byte-identical for every snapshot fixture (all 12 baseline md5s match).
- [x] Self-host regen: `aver compile self_hosted/main.av --target rust ...` produces `src/self_host/` that `cargo build`s cleanly (342 errors → 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)