### PR TITLE
codegen/lean: emit pipeline consumes ResolvedExpr — #147 phase E PR 10

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -1766,6 +1766,15 @@ pub(crate) fn is_unit_expr_spanned(expr: &crate::ast::Spanned<crate::ast::Expr>)
     is_unit_expr(&expr.node)
 }
 
+/// Resolved-form mirror of [`is_unit_expr`]. Same Phase-E shape
+/// (`ResolvedExpr::Literal(Unit)`); used by migrated backends.
+pub(crate) fn is_unit_expr_resolved(expr: &crate::ir::hir::ResolvedExpr) -> bool {
+    matches!(
+        expr,
+        crate::ir::hir::ResolvedExpr::Literal(crate::ast::Literal::Unit)
+    )
+}
+
 /// Escape an Aver identifier if it collides with a target language reserved word.
 ///
 /// `affix` is appended as a suffix (e.g. `"_"` for Dafny, `"'"` for Lean).
@@ -2260,7 +2269,7 @@ pub(crate) fn route_pure_components_per_scope<F, G>(
 ) -> PerScopeSections
 where
     F: Fn(&FnDef) -> bool,
-    G: FnMut(&[&FnDef]) -> Vec<String>,
+    G: FnMut(&[&FnDef], &str) -> Vec<String>,
 {
     let mut by_scope: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
@@ -2270,9 +2279,9 @@ where
          scope: String,
          by_scope: &mut std::collections::HashMap<String, Vec<String>>| {
             let comps = crate::call_graph::ordered_fn_components(&fns, &ctx.module_prefixes);
-            let bucket = by_scope.entry(scope).or_default();
+            let bucket = by_scope.entry(scope.clone()).or_default();
             for comp in comps {
-                bucket.extend(emit(&comp));
+                bucket.extend(emit(&comp, scope.as_str()));
             }
         };
 
@@ -2555,6 +2564,7 @@ mod tests {
             symbol_table,
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
+            current_module_scope: std::cell::RefCell::new(None),
         };
         ctx.proof_ir
             .refined_types

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -190,7 +190,7 @@ fn transpile_unified(ctx: &CodegenContext) -> ProjectOutput {
     let mut pure_per_scope = crate::codegen::common::route_pure_components_per_scope(
         ctx,
         |fd| fd.effects.is_empty() && fd.name != "main",
-        |comp| {
+        |comp, _scope| {
             comp.iter()
                 .map(|fd| emit_pure_or_axiom(fd))
                 .filter(|s| !s.is_empty())

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -2,21 +2,22 @@
 ///
 /// Only pure namespaces are mapped. Effectful services (Console, Disk, Http, etc.)
 /// are skipped by the Lean transpiler — those functions won't appear in output.
-use crate::ast::{Expr, Spanned};
+use crate::ast::Spanned;
 use crate::codegen::CodegenContext;
 use crate::codegen::builtins::{Builtin, recognize_builtin};
+use crate::ir::hir::ResolvedExpr;
 
 /// Try to emit a builtin call as Lean 4 code.
 /// Returns `None` if the name is not a pure builtin.
 pub fn emit_builtin_call(
     name: &str,
-    args: &[Spanned<Expr>],
+    args: &[Spanned<ResolvedExpr>],
     ctx: &CodegenContext,
 ) -> Option<String> {
-    use crate::codegen::common::is_unit_expr;
+    use crate::codegen::common::is_unit_expr_resolved;
 
     // Map<T, Unit> set operations: intercept before generic builtin path
-    if name == "Map.set" && args.len() == 3 && is_unit_expr(&args[2].node) {
+    if name == "Map.set" && args.len() == 3 && is_unit_expr_resolved(&args[2].node) {
         let m = p(&super::expr::emit_expr(&args[0], ctx));
         let k = p(&super::expr::emit_expr(&args[1], ctx));
         return Some(format!("AverSet.add {} {}", m, k));
@@ -154,9 +155,9 @@ pub fn emit_builtin_call(
     Some(result)
 }
 
-fn emit_list_length_subject(arg: &Spanned<Expr>, ctx: &CodegenContext) -> String {
+fn emit_list_length_subject(arg: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
     match &arg.node {
-        Expr::List(items) if items.is_empty() => "(([] : List Unit))".to_string(),
+        ResolvedExpr::List(items) if items.is_empty() => "(([] : List Unit))".to_string(),
         _ => p(&super::expr::emit_expr(arg, ctx)),
     }
 }
@@ -173,8 +174,9 @@ fn p(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{Expr, Literal, Spanned};
+    use crate::ast::{Literal, Spanned};
     use crate::codegen::CodegenContext;
+    use crate::ir::hir::ResolvedCallee;
     use std::collections::{HashMap, HashSet};
 
     fn empty_ctx() -> CodegenContext {
@@ -203,20 +205,18 @@ mod tests {
             symbol_table: crate::ir::SymbolTable::default(),
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
+            current_module_scope: std::cell::RefCell::new(None),
         }
     }
 
     #[test]
     fn option_with_default_wraps_getd_expression_in_parentheses() {
         let ctx = empty_ctx();
-        let option_expr = Spanned::bare(Expr::FnCall(
-            Box::new(Spanned::bare(Expr::Attr(
-                Box::new(Spanned::bare(Expr::Ident("Char".to_string()))),
-                "fromCode".to_string(),
-            ))),
-            vec![Spanned::bare(Expr::Literal(Literal::Int(8)))],
+        let option_expr = Spanned::bare(ResolvedExpr::Call(
+            ResolvedCallee::Builtin("Char.fromCode".to_string()),
+            vec![Spanned::bare(ResolvedExpr::Literal(Literal::Int(8)))],
         ));
-        let default_expr = Spanned::bare(Expr::Literal(Literal::Str("".to_string())));
+        let default_expr = Spanned::bare(ResolvedExpr::Literal(Literal::Str("".to_string())));
 
         let emitted = emit_builtin_call("Option.withDefault", &[option_expr, default_expr], &ctx)
             .expect("Option.withDefault should be emitted");
@@ -227,8 +227,9 @@ mod tests {
     #[test]
     fn list_len_annotates_empty_list_in_theorem_friendly_form() {
         let ctx = empty_ctx();
-        let emitted = emit_builtin_call("List.len", &[Spanned::bare(Expr::List(vec![]))], &ctx)
-            .expect("List.len should be emitted");
+        let emitted =
+            emit_builtin_call("List.len", &[Spanned::bare(ResolvedExpr::List(vec![]))], &ctx)
+                .expect("List.len should be emitted");
 
         assert_eq!(emitted, "(([] : List Unit)).length");
     }

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -2,28 +2,32 @@
 use super::builtins;
 use super::pattern::emit_pattern;
 use super::shared::to_lower_first;
-use crate::ast::*;
+use crate::ast::{BinOp, Literal, Spanned};
 use crate::codegen::CodegenContext;
-use crate::codegen::common::{expr_to_dotted_name, is_user_type, resolve_module_call};
+use crate::codegen::common::{is_user_type, resolve_module_call};
+use crate::ir::hir::{
+    BuiltinCtor, ResolvedCallee, ResolvedCtor, ResolvedExpr, ResolvedMatchArm, ResolvedPattern,
+    ResolvedStmt, ResolvedStrPart,
+};
 
 /// Emit a Lean 4 expression from an Aver Expr.
-pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
+pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
     match &expr.node {
-        Expr::Literal(lit) => emit_literal(lit),
+        ResolvedExpr::Literal(lit) => emit_literal(lit),
         // Synthetic ident injected by the proof-mode recursion lowerer
         // (`recursion::rewrite_native_guarded_calls`) to mark a position
         // where Lean needs an `(by omega)` proof obligation for the
-        // recursive-call precondition. Stays a plain Aver `Expr::Ident`
+        // recursive-call precondition. Stays a plain Aver `ResolvedExpr::Ident`
         // through the AST so Dafny's emit path (which doesn't inject this
         // sentinel) and the type checker (already done before codegen)
         // never see it.
-        Expr::Ident(name) | Expr::Resolved { name, .. }
+        ResolvedExpr::Ident(name) | ResolvedExpr::Resolved { name, .. }
             if name == crate::codegen::recursion::OMEGA_PROOF_SENTINEL =>
         {
             "(by omega)".to_string()
         }
-        Expr::Ident(name) | Expr::Resolved { name, .. } => aver_name_to_lean(name),
-        Expr::Attr(obj, field) => {
+        ResolvedExpr::Ident(name) | ResolvedExpr::Resolved { name, .. } => aver_name_to_lean(name),
+        ResolvedExpr::Attr(obj, field) => {
             // Refinement-via-opaque records emit as Lean `Subtype`,
             // so the carrier field projects through `.val` instead
             // of the source-named `.carrier_field`. Detect by the
@@ -36,14 +40,17 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
                 && field == &decl.carrier_field
             {
                 let obj_str = emit_expr(obj, ctx);
-                let needs_parens = !matches!(&obj.node, Expr::Ident(_) | Expr::Resolved { .. });
+                let needs_parens = !matches!(
+                    &obj.node,
+                    ResolvedExpr::Ident(_) | ResolvedExpr::Resolved { .. }
+                );
                 return if needs_parens {
                     format!("({obj_str}).val")
                 } else {
                     format!("{obj_str}.val")
                 };
             }
-            if let Expr::Ident(type_name) = &obj.node {
+            if let ResolvedExpr::Ident(type_name) = &obj.node {
                 // Option.None → none
                 if type_name == "Option" && field == "None" {
                     return "none".to_string();
@@ -61,7 +68,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
                 }
             }
             // Check module-qualified reference
-            if let Some(full_dotted) = expr_to_dotted_name(&expr.node)
+            if let Some(full_dotted) = crate::ir::hir::resolved_to_dotted(&expr.node)
                 && let Some((prefix, bare)) = resolve_module_call(&full_dotted, ctx)
             {
                 if let Some(dot_pos) = bare.find('.') {
@@ -78,16 +85,17 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
                 return bare_lean;
             }
             let obj_str = emit_expr(obj, ctx);
-            let needs_parens = !matches!(&obj.node, Expr::Ident(_) | Expr::Attr(_, _));
+            let needs_parens =
+                !matches!(&obj.node, ResolvedExpr::Ident(_) | ResolvedExpr::Attr(_, _));
             if needs_parens {
                 format!("({}).{}", obj_str, aver_name_to_lean(field))
             } else {
                 format!("{}.{}", obj_str, aver_name_to_lean(field))
             }
         }
-        Expr::FnCall(fn_expr, args) => emit_fn_call(fn_expr, args, ctx),
-        Expr::Neg(inner) => format!("(-{})", emit_expr(inner, ctx)),
-        Expr::BinOp(op, left, right) => {
+        ResolvedExpr::Call(callee, args) => emit_fn_call(callee, args, ctx),
+        ResolvedExpr::Neg(inner) => format!("(-{})", emit_expr(inner, ctx)),
+        ResolvedExpr::BinOp(op, left, right) => {
             let l = emit_expr(left, ctx);
             let r = emit_expr(right, ctx);
             let op_str = match op {
@@ -104,15 +112,15 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             };
             format!("({} {} {})", l, op_str, r)
         }
-        Expr::Match { subject, arms } => emit_match(subject, arms, expr.line, ctx),
-        Expr::Constructor(name, arg) => emit_constructor(name, arg, ctx),
-        Expr::ErrorProp(inner) => {
+        ResolvedExpr::Match { subject, arms } => emit_match(subject, arms, expr.line, ctx),
+        ResolvedExpr::Ctor(ctor, args) => emit_constructor(ctor, args, ctx),
+        ResolvedExpr::ErrorProp(inner) => {
             // ? operator — unwrap Except using withDefault
             let inner_str = emit_expr(inner, ctx);
             format!("(({}).withDefault default)", inner_str)
         }
-        Expr::InterpolatedStr(parts) => emit_interpolated_str(parts, ctx),
-        Expr::List(elements) => {
+        ResolvedExpr::InterpolatedStr(parts) => emit_interpolated_str(parts, ctx),
+        ResolvedExpr::List(elements) => {
             if elements.is_empty() {
                 "[]".to_string()
             } else {
@@ -120,19 +128,19 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
                 format!("[{}]", parts.join(", "))
             }
         }
-        Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+        ResolvedExpr::Tuple(items) | ResolvedExpr::IndependentProduct(items, _) => {
             // Oracle v1: passed through as a tuple; `?!` semantic fold
             // is deferred (coordinates with the outer `Result.Ok(...)`
             // wrapper the typechecker forces).
             let parts: Vec<String> = items.iter().map(|e| emit_expr(e, ctx)).collect();
             format!("({})", parts.join(", "))
         }
-        Expr::MapLiteral(entries) => {
+        ResolvedExpr::MapLiteral(entries) => {
             if entries.is_empty() {
                 "[]".to_string()
             } else if entries
                 .iter()
-                .all(|(_, v)| crate::codegen::common::is_unit_expr(&v.node))
+                .all(|(_, v)| crate::codegen::common::is_unit_expr_resolved(&v.node))
             {
                 // Map<T, Unit> literal → set literal
                 let parts: Vec<String> = entries.iter().map(|(k, _)| emit_expr(k, ctx)).collect();
@@ -145,7 +153,9 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
                 format!("[{}]", parts.join(", "))
             }
         }
-        Expr::RecordCreate { type_name, fields } => {
+        ResolvedExpr::RecordCreate {
+            type_name, fields, ..
+        } => {
             // Refinement-via-opaque types emit as Lean `Subtype`,
             // so construction is `⟨value, proof⟩`. The proof
             // obligation is whatever predicate the smart
@@ -190,10 +200,11 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             let lean_type_name = type_name.replace('.', "_");
             format!("{{ {} : {} }}", parts.join(", "), lean_type_name)
         }
-        Expr::RecordUpdate {
+        ResolvedExpr::RecordUpdate {
             type_name: _,
             base,
             updates,
+            ..
         } => {
             let base_str = emit_expr(base, ctx);
             let parts: Vec<String> = updates
@@ -204,30 +215,33 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
                 .collect();
             format!("{{ {} with {} }}", base_str, parts.join(", "))
         }
-        Expr::TailCall(boxed) => {
-            // TailCall is an internal optimization — emit as regular call
-            let TailCallData { target, args, .. } = boxed.as_ref();
+        ResolvedExpr::TailCall { target, args } => {
+            // TailCall is an internal optimization — emit as regular call.
+            // Resolve FnId → canonical name via the symbol table, then
+            // strip the module prefix because Lean's emit doesn't
+            // qualify intra-module recursive calls.
+            let target_name = ctx.symbol_table.fn_entry(*target).key.name.clone();
             let parts: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
             if parts.is_empty() {
-                aver_name_to_lean(target)
+                aver_name_to_lean(&target_name)
             } else {
-                format!("{} {}", aver_name_to_lean(target), parts.join(" "))
+                format!("{} {}", aver_name_to_lean(&target_name), parts.join(" "))
             }
         }
     }
 }
 
 /// Emit an expression wrapped in parens if it's a compound expression.
-fn emit_expr_atom(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
+fn emit_expr_atom(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
     let s = emit_expr(expr, ctx);
     match &expr.node {
-        Expr::Literal(Literal::Int(i)) if *i < 0 => format!("({})", s),
-        Expr::Literal(Literal::Float(f)) if *f < 0.0 => format!("({})", s),
-        Expr::Literal(_)
-        | Expr::Ident(_)
-        | Expr::List(_)
-        | Expr::Tuple(_)
-        | Expr::IndependentProduct(_, _) => s,
+        ResolvedExpr::Literal(Literal::Int(i)) if *i < 0 => format!("({})", s),
+        ResolvedExpr::Literal(Literal::Float(f)) if *f < 0.0 => format!("({})", s),
+        ResolvedExpr::Literal(_)
+        | ResolvedExpr::Ident(_)
+        | ResolvedExpr::List(_)
+        | ResolvedExpr::Tuple(_)
+        | ResolvedExpr::IndependentProduct(_, _) => s,
         _ => {
             if s.starts_with('(')
                 || s.starts_with('[')
@@ -264,126 +278,137 @@ fn escape_lean_string(s: &str) -> String {
     crate::codegen::common::escape_string_literal(s)
 }
 
-fn emit_fn_call(fn_expr: &Spanned<Expr>, args: &[Spanned<Expr>], ctx: &CodegenContext) -> String {
-    let fn_name = expr_to_dotted_name(&fn_expr.node);
-
-    if let Some(name) = &fn_name {
-        // Check builtin
-        if let Some(lean_code) = builtins::emit_builtin_call(name, args, ctx) {
-            return lean_code;
-        }
-
-        // Oracle v1: BranchPath constructors render through the structure
-        // definitions in LEAN_PRELUDE_BRANCH_PATH.
-        let arg_strs_owned: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
-        match name.as_str() {
-            "BranchPath.child" if arg_strs_owned.len() == 2 => {
-                return format!(
-                    "BranchPath.child {} {}",
-                    arg_strs_owned[0], arg_strs_owned[1]
-                );
+fn emit_fn_call(
+    callee: &ResolvedCallee,
+    args: &[Spanned<ResolvedExpr>],
+    ctx: &CodegenContext,
+) -> String {
+    // Resolved-form classification — preserves the pre-Phase-E
+    // dispatch order: builtin special-cases, Oracle BranchPath
+    // hand-shapes, module-qualified, then plain ident.
+    match callee {
+        ResolvedCallee::Builtin(name) => {
+            if let Some(lean_code) = builtins::emit_builtin_call(name, args, ctx) {
+                return lean_code;
             }
-            "BranchPath.parse" if arg_strs_owned.len() == 1 => {
-                return format!("BranchPath.parse {}", arg_strs_owned[0]);
-            }
-            _ => {}
-        }
-
-        // Module-qualified call
-        if let Some((prefix, bare)) = resolve_module_call(name, ctx) {
-            if let Some(dot_pos) = bare.find('.') {
-                let type_name = &bare[..dot_pos];
-                let variant_name = &bare[dot_pos + 1..];
-                if is_user_type(type_name, ctx) {
-                    let arg_strs: Vec<String> =
-                        args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
+            // Oracle v1: BranchPath ctors render through structure
+            // definitions in LEAN_PRELUDE_BRANCH_PATH.
+            let arg_strs_owned: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
+            match name.as_str() {
+                "BranchPath.child" if arg_strs_owned.len() == 2 => {
                     return format!(
-                        "{}.{} {}",
-                        type_name,
-                        to_lower_first(variant_name),
-                        arg_strs.join(" ")
+                        "BranchPath.child {} {}",
+                        arg_strs_owned[0], arg_strs_owned[1]
                     );
                 }
+                "BranchPath.parse" if arg_strs_owned.len() == 1 => {
+                    return format!("BranchPath.parse {}", arg_strs_owned[0]);
+                }
+                _ => {}
             }
-            let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
-            let qualified = if !ctx.modules.is_empty() {
-                format!("{}.{}", prefix, aver_name_to_lean(bare))
+            // Generic builtin fallback: render dotted with each arg
+            // as a Lean atom.
+            if arg_strs_owned.is_empty() {
+                aver_name_to_lean(name)
             } else {
-                aver_name_to_lean(bare)
+                format!("{} {}", aver_name_to_lean(name), arg_strs_owned.join(" "))
+            }
+        }
+        ResolvedCallee::Intrinsic(intr) => {
+            // Compiler-synthesised `__buf_*` / `__to_str` intrinsics
+            // don't reach the Lean backend in practice (Lean emit
+            // doesn't see post-interp-lower buffer shapes), but the
+            // resolver carries them through; render as bare-name
+            // call so the diagnostic stays traceable.
+            let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
+            if arg_strs.is_empty() {
+                intr.name().to_string()
+            } else {
+                format!("{} {}", intr.name(), arg_strs.join(" "))
+            }
+        }
+        ResolvedCallee::Fn(fn_id) => {
+            let entry = ctx.symbol_table.fn_entry(*fn_id);
+            let bare = entry.key.name.as_str();
+            let module_prefix = entry.key.scope_str();
+            let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
+            let func = match module_prefix {
+                Some(prefix) if !ctx.modules.is_empty() => {
+                    format!("{}.{}", prefix, aver_name_to_lean(bare))
+                }
+                _ => aver_name_to_lean(bare),
             };
             if arg_strs.is_empty() {
-                return qualified;
-            }
-            return format!("{} {}", qualified, arg_strs.join(" "));
-        }
-
-        // User-defined type constructor: Shape.Circle(r)
-        if let Some(dot_pos) = name.find('.') {
-            let type_name = &name[..dot_pos];
-            let variant_name = &name[dot_pos + 1..];
-            if is_user_type(type_name, ctx) {
-                let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
-                if arg_strs.is_empty() {
-                    return format!("{}.{}", type_name, to_lower_first(variant_name));
-                }
-                return format!(
-                    "{}.{} {}",
-                    type_name,
-                    to_lower_first(variant_name),
-                    arg_strs.join(" ")
-                );
+                func
+            } else {
+                format!("{} {}", func, arg_strs.join(" "))
             }
         }
-    }
-
-    // Regular function call — curried application
-    let func = emit_expr(fn_expr, ctx);
-    let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
-    if arg_strs.is_empty() {
-        func
-    } else {
-        format!("{} {}", func, arg_strs.join(" "))
-    }
-}
-
-fn emit_constructor(name: &str, arg: &Option<Box<Spanned<Expr>>>, ctx: &CodegenContext) -> String {
-    // Accept both bare and qualified forms — parser / lifter may
-    // produce either. Aver's `Result.Ok(x)` and `Ok(x)` are the same
-    // wrapper semantically; same for Option.
-    match name {
-        "Ok" | "Result.Ok" => {
-            let inner = arg
-                .as_ref()
-                .map(|a| emit_expr_atom(a, ctx))
-                .unwrap_or_else(|| "()".to_string());
-            format!("Except.ok {}", inner)
+        ResolvedCallee::LocalSlot { name, .. } => {
+            // First-class fn value bound to a local — curry application.
+            let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
+            let func = aver_name_to_lean(name);
+            if arg_strs.is_empty() {
+                func
+            } else {
+                format!("{} {}", func, arg_strs.join(" "))
+            }
         }
-        "Err" | "Result.Err" => {
-            let inner = arg
-                .as_ref()
-                .map(|a| emit_expr_atom(a, ctx))
-                .unwrap_or_else(|| "()".to_string());
-            format!("Except.error {}", inner)
-        }
-        "Some" | "Option.Some" => {
-            let inner = arg
-                .as_ref()
-                .map(|a| emit_expr_atom(a, ctx))
-                .unwrap_or_else(|| "()".to_string());
-            format!("some {}", inner)
-        }
-        "None" | "Option.None" => "none".to_string(),
-        _ => {
-            let inner = arg
-                .as_ref()
-                .map(|a| emit_expr_atom(a, ctx))
-                .unwrap_or_else(|| "()".to_string());
-            format!("{} {}", name, inner)
+        ResolvedCallee::Unresolved { callee: inner } => {
+            // Typecheck-rejected callee — render the source-faithful
+            // expression as a curry'd call so the surrounding Lean
+            // proof still typechecks (verify driver surfaces the
+            // missing target separately).
+            let func = emit_expr(inner, ctx);
+            let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
+            if arg_strs.is_empty() {
+                func
+            } else {
+                format!("{} {}", func, arg_strs.join(" "))
+            }
         }
     }
 }
 
-fn emit_interpolated_str(parts: &[StrPart], ctx: &CodegenContext) -> String {
+fn emit_constructor(
+    ctor: &ResolvedCtor,
+    args: &[Spanned<ResolvedExpr>],
+    ctx: &CodegenContext,
+) -> String {
+    let inner_str = || -> String {
+        args.first()
+            .map(|a| emit_expr_atom(a, ctx))
+            .unwrap_or_else(|| "()".to_string())
+    };
+    match ctor {
+        ResolvedCtor::Builtin(BuiltinCtor::ResultOk) => format!("Except.ok {}", inner_str()),
+        ResolvedCtor::Builtin(BuiltinCtor::ResultErr) => {
+            format!("Except.error {}", inner_str())
+        }
+        ResolvedCtor::Builtin(BuiltinCtor::OptionSome) => format!("some {}", inner_str()),
+        ResolvedCtor::Builtin(BuiltinCtor::OptionNone) => "none".to_string(),
+        ResolvedCtor::User { type_id, name, .. } => {
+            // User ctor: `Type.variant` in Lean. Lean convention is
+            // lowercase variant names; type stays as written.
+            let type_name = ctx.symbol_table.type_entry(*type_id).key.name.clone();
+            let variant = to_lower_first(name);
+            let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
+            if arg_strs.is_empty() {
+                format!("{}.{}", type_name, variant)
+            } else {
+                format!("{}.{} {}", type_name, variant, arg_strs.join(" "))
+            }
+        }
+        ResolvedCtor::Unresolved { name } => {
+            // Typecheck-rejected ctor — surface the source name as a
+            // call expression so the surrounding emit still produces
+            // a parseable Lean term.
+            format!("{} {}", name, inner_str())
+        }
+    }
+}
+
+fn emit_interpolated_str(parts: &[ResolvedStrPart], ctx: &CodegenContext) -> String {
     if parts.is_empty() {
         return "\"\"".to_string();
     }
@@ -392,10 +417,10 @@ fn emit_interpolated_str(parts: &[StrPart], ctx: &CodegenContext) -> String {
     result.push_str("s!\"");
     for part in parts {
         match part {
-            StrPart::Literal(s) => {
+            ResolvedStrPart::Literal(s) => {
                 result.push_str(&escape_lean_string(s));
             }
-            StrPart::Parsed(expr) => {
+            ResolvedStrPart::Parsed(expr) => {
                 result.push('{');
                 result.push_str(&emit_expr(expr, ctx));
                 result.push('}');
@@ -407,8 +432,8 @@ fn emit_interpolated_str(parts: &[StrPart], ctx: &CodegenContext) -> String {
 }
 
 fn emit_match(
-    subject: &Spanned<Expr>,
-    arms: &[MatchArm],
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
     line: usize,
     ctx: &CodegenContext,
 ) -> String {
@@ -468,7 +493,7 @@ fn emit_match(
     // preserving wrapper-return emit untouched.
     let needs_eq_binder = matches!(
         &subject.node,
-        Expr::Ident(_) | Expr::Resolved { .. } | Expr::Attr(_, _)
+        ResolvedExpr::Ident(_) | ResolvedExpr::Resolved { .. } | ResolvedExpr::Attr(_, _)
     );
     if needs_eq_binder {
         let eq_name = format!("h_{}", line);
@@ -484,22 +509,21 @@ fn emit_match(
 /// surrounding `if`'s predicate as a hypothesis. Used to decide
 /// when the enclosing Bool match should emit dependent-`if h :
 /// cond then …`.
-fn true_body_uses_refinement_subtype(expr: &Spanned<Expr>, ctx: &CodegenContext) -> bool {
+fn true_body_uses_refinement_subtype(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> bool {
     match &expr.node {
-        Expr::RecordCreate { type_name, .. } => {
+        ResolvedExpr::RecordCreate { type_name, .. } => {
             crate::codegen::common::find_refined_type(ctx, type_name)
                 .map(|decl| decl.carrier_type == "Int")
                 .unwrap_or(false)
         }
-        Expr::FnCall(callee, args) => {
-            true_body_uses_refinement_subtype(callee, ctx)
-                || args
-                    .iter()
-                    .any(|a| true_body_uses_refinement_subtype(a, ctx))
-        }
-        Expr::Constructor(_, Some(arg)) => true_body_uses_refinement_subtype(arg, ctx),
-        Expr::Attr(o, _) => true_body_uses_refinement_subtype(o, ctx),
-        Expr::Match { arms, .. } => arms
+        ResolvedExpr::Call(_, args) => args
+            .iter()
+            .any(|a| true_body_uses_refinement_subtype(a, ctx)),
+        ResolvedExpr::Ctor(_, args) => args
+            .iter()
+            .any(|a| true_body_uses_refinement_subtype(a, ctx)),
+        ResolvedExpr::Attr(o, _) => true_body_uses_refinement_subtype(o, ctx),
+        ResolvedExpr::Match { arms, .. } => arms
             .iter()
             .any(|arm| true_body_uses_refinement_subtype(&arm.body, ctx)),
         _ => false,
@@ -507,7 +531,9 @@ fn true_body_uses_refinement_subtype(expr: &Spanned<Expr>, ctx: &CodegenContext)
 }
 
 /// If all arms are `true -> expr` and `false -> expr`, return (true_body, false_body).
-fn extract_bool_arms(arms: &[MatchArm]) -> Option<(&Spanned<Expr>, &Spanned<Expr>)> {
+fn extract_bool_arms(
+    arms: &[ResolvedMatchArm],
+) -> Option<(&Spanned<ResolvedExpr>, &Spanned<ResolvedExpr>)> {
     if arms.len() != 2 {
         return None;
     }
@@ -515,8 +541,8 @@ fn extract_bool_arms(arms: &[MatchArm]) -> Option<(&Spanned<Expr>, &Spanned<Expr
     let mut false_body = None;
     for arm in arms {
         match &arm.pattern {
-            Pattern::Literal(Literal::Bool(true)) => true_body = Some(arm.body.as_ref()),
-            Pattern::Literal(Literal::Bool(false)) => false_body = Some(arm.body.as_ref()),
+            ResolvedPattern::Literal(Literal::Bool(true)) => true_body = Some(arm.body.as_ref()),
+            ResolvedPattern::Literal(Literal::Bool(false)) => false_body = Some(arm.body.as_ref()),
             _ => return None,
         }
     }
@@ -524,15 +550,65 @@ fn extract_bool_arms(arms: &[MatchArm]) -> Option<(&Spanned<Expr>, &Spanned<Expr
 }
 
 /// Emit a statement as Lean 4 code.
-pub fn emit_stmt(stmt: &Stmt, ctx: &CodegenContext) -> String {
+pub fn emit_stmt(stmt: &ResolvedStmt, ctx: &CodegenContext) -> String {
     match stmt {
-        Stmt::Binding(name, type_ann, expr) => {
-            let val = emit_expr(expr, ctx);
-            let _ = type_ann;
+        ResolvedStmt::Binding {
+            name,
+            ty_ann: _,
+            value,
+        } => {
+            let val = emit_expr(value, ctx);
             format!("let {} := {}", aver_name_to_lean(name), val)
         }
-        Stmt::Expr(expr) => emit_expr(expr, ctx),
+        ResolvedStmt::Expr(expr) => emit_expr(expr, ctx),
     }
+}
+
+/// Source-shape adapter for callers that still hold a raw
+/// `Spanned<crate::ast::Expr>` (TCO / mutual-TCO bodies, law_auto
+/// proof generation, recursion fuel emit, the various AST walks in
+/// `toplevel.rs`). Resolves the expression on demand against the
+/// codegen context's symbol table — `scope` carries the owning
+/// module prefix when known (`None` for entry-scope code), same
+/// shape as PR 9.4's `EmitCtx::current_module_scope` in rust
+/// codegen. The migrated `emit_expr` core stays
+/// `ResolvedExpr`-only.
+pub fn emit_expr_legacy(
+    expr: &crate::ast::Spanned<crate::ast::Expr>,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> String {
+    let active = ctx.active_module_scope();
+    let effective = scope.or(active.as_deref());
+    let resolved = ctx.resolve_expr(expr, effective);
+    emit_expr(&resolved, ctx)
+}
+
+/// Source-shape adapter for [`emit_stmt`]. See [`emit_expr_legacy`] for
+/// the scope-fallback rule.
+pub fn emit_stmt_legacy(
+    stmt: &crate::ast::Stmt,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> String {
+    let active = ctx.active_module_scope();
+    let effective = scope.or(active.as_deref());
+    let resolved = ctx.resolve_stmt(stmt, effective);
+    emit_stmt(&resolved, ctx)
+}
+
+/// Source-shape adapter for [`emit_pattern`]. See [`emit_expr_legacy`]
+/// for the scope-fallback rule.
+#[allow(dead_code)]
+pub fn emit_pattern_legacy(
+    pat: &crate::ast::Pattern,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> String {
+    let active = ctx.active_module_scope();
+    let effective = scope.or(active.as_deref());
+    let resolved = ctx.resolve_pattern(pat, effective);
+    super::pattern::emit_pattern(&resolved)
 }
 
 /// Convert an Aver identifier to a valid Lean 4 identifier.

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -8,7 +8,7 @@ mod shared;
 mod spec;
 
 use super::VerifyEmitMode;
-use super::expr::{aver_name_to_lean, emit_expr};
+use super::expr::{aver_name_to_lean, emit_expr_legacy};
 use crate::ast::{VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 use crate::verify_law::{collect_missing_helper_law_hints, missing_helper_law_message};
@@ -182,8 +182,8 @@ pub fn emit_verify_law_forall_auto_proof(
                 vec![
                     format!(
                         "change {} = {}",
-                        emit_expr(unfolded_impl, ctx),
-                        emit_expr(unfolded_spec, ctx)
+                        emit_expr_legacy(unfolded_impl, ctx, None),
+                        emit_expr_legacy(unfolded_spec, ctx, None)
                     ),
                     "omega".to_string(),
                 ],
@@ -273,7 +273,7 @@ pub fn emit_verify_law_forall_auto_proof(
                     _ => unreachable!(),
                 };
                 let atom_arg = |e: &crate::ast::Spanned<crate::ast::Expr>| {
-                    let rendered = emit_expr(e, ctx);
+                    let rendered = emit_expr_legacy(e, ctx, None);
                     if rendered.contains(' ') && !rendered.starts_with('(') {
                         format!("({rendered})")
                     } else {
@@ -316,7 +316,7 @@ pub fn emit_verify_law_forall_auto_proof(
                 let extras_lean: Vec<String> =
                     extra_unfolds.iter().map(|n| aver_name_to_lean(n)).collect();
                 let atom_render = |e: &crate::ast::Spanned<crate::ast::Expr>| {
-                    let rendered = emit_expr(e, ctx);
+                    let rendered = emit_expr_legacy(e, ctx, None);
                     if rendered.contains(' ') && !rendered.starts_with('(') {
                         format!("({rendered})")
                     } else {
@@ -373,7 +373,7 @@ pub fn emit_verify_law_forall_auto_proof(
             {
                 let outer_lean = aver_name_to_lean(outer_fn);
                 let atom_render = |e: &crate::ast::Spanned<crate::ast::Expr>| {
-                    let rendered = emit_expr(e, ctx);
+                    let rendered = emit_expr_legacy(e, ctx, None);
                     if rendered.contains(' ') && !rendered.starts_with('(') {
                         format!("({rendered})")
                     } else {
@@ -488,7 +488,7 @@ fn emit_simp_omega_from_ir(
                             &g.param,
                             n,
                         );
-                        emit_expr(&substituted, ctx)
+                        emit_expr_legacy(&substituted, ctx, None)
                     }
                     None => format!("{n} ≥ 0"),
                 };

--- a/src/codegen/lean/law_auto/spec/linear_int.rs
+++ b/src/codegen/lean/law_auto/spec/linear_int.rs
@@ -4,7 +4,7 @@ use crate::ast::{BinOp, Expr, Spanned, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 use crate::verify_law::canonical_spec_ref;
 
-use super::super::super::expr::emit_expr;
+use super::super::super::expr::emit_expr_legacy;
 use super::super::shared::{body_terminal_expr, callee_matches_name, find_fn_def, substitute_expr};
 use super::super::{AutoProof, intro_then};
 
@@ -85,8 +85,8 @@ pub(super) fn emit_linear_int_omega_spec_equivalence_law(
                 vec![
                     format!(
                         "change {} = {}",
-                        emit_expr(&unfolded_impl, ctx),
-                        emit_expr(&unfolded_spec, ctx)
+                        emit_expr_legacy(&unfolded_impl, ctx, None),
+                        emit_expr_legacy(&unfolded_spec, ctx, None)
                     ),
                     "omega".to_string(),
                 ],

--- a/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
+++ b/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
@@ -7,7 +7,7 @@ use crate::codegen::lean::recurrence::{
 };
 use crate::verify_law::canonical_spec_ref;
 
-use super::super::super::expr::{aver_name_to_lean, emit_expr};
+use super::super::super::expr::{aver_name_to_lean, emit_expr_legacy};
 use super::super::shared::find_fn_def;
 use super::super::{AutoProof, indent_lines};
 
@@ -22,9 +22,12 @@ pub(in super::super) fn emit_second_order_linear_recurrence_spec_equivalence_law
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     let impl_shape = detect_tailrec_int_linear_pair_wrapper(impl_fd)?;
     let spec_shape = detect_second_order_int_linear_recurrence(spec_fd)?;
-    if emit_expr(&impl_shape.negative_branch, ctx) != emit_expr(&spec_shape.negative_branch, ctx)
-        || emit_expr(&impl_shape.seed_prev, ctx) != emit_expr(&spec_shape.base0, ctx)
-        || emit_expr(&impl_shape.seed_curr, ctx) != emit_expr(&spec_shape.base1, ctx)
+    if emit_expr_legacy(&impl_shape.negative_branch, ctx, None)
+        != emit_expr_legacy(&spec_shape.negative_branch, ctx, None)
+        || emit_expr_legacy(&impl_shape.seed_prev, ctx, None)
+            != emit_expr_legacy(&spec_shape.base0, ctx, None)
+        || emit_expr_legacy(&impl_shape.seed_curr, ctx, None)
+            != emit_expr_legacy(&spec_shape.base1, ctx, None)
     {
         return None;
     }
@@ -45,8 +48,8 @@ pub(in super::super) fn emit_second_order_linear_recurrence_spec_equivalence_law
     let shift_theorem = format!("{theorem_base}__worker_nat_shift");
     let helper_nat_theorem = format!("{theorem_base}__helper_nat");
     let helper_seed_theorem = format!("{theorem_base}__helper_seed");
-    let base0 = emit_expr(&spec_shape.base0, ctx);
-    let base1 = emit_expr(&spec_shape.base1, ctx);
+    let base0 = emit_expr_legacy(&spec_shape.base0, ctx, None);
+    let base1 = emit_expr_legacy(&spec_shape.base1, ctx, None);
     let worker_step = render_affine_pair_expr(spec_shape.recurrence, "a", "b");
 
     let mut support_lines = Vec::new();

--- a/src/codegen/lean/law_auto/spec/mod.rs
+++ b/src/codegen/lean/law_auto/spec/mod.rs
@@ -8,7 +8,7 @@ use crate::ast::{Expr, Spanned, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 use crate::verify_law::canonical_spec_ref;
 
-use super::super::expr::emit_expr;
+use super::super::expr::emit_expr_legacy;
 use super::shared::{body_terminal_expr, callee_matches_name, find_fn_def, law_simp_defs};
 use super::{AutoProof, intro_then};
 
@@ -164,7 +164,8 @@ pub(super) fn emit_spec_function_equivalence_law(
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     let impl_body = body_terminal_expr(impl_fd.body.as_ref())?;
     let spec_body = body_terminal_expr(spec_fd.body.as_ref())?;
-    let bodies_match_exactly = emit_expr(impl_body, ctx) == emit_expr(spec_body, ctx);
+    let bodies_match_exactly =
+        emit_expr_legacy(impl_body, ctx, None) == emit_expr_legacy(spec_body, ctx, None);
 
     let try_side = |impl_side: &Spanned<Expr>, spec_side: &Spanned<Expr>| -> Option<AutoProof> {
         let Expr::FnCall(impl_callee, impl_args) = &impl_side.node else {

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1227,49 +1227,52 @@ fn transpile_unified(
     let pure_per_scope = crate::codegen::common::route_pure_components_per_scope(
         ctx,
         toplevel::is_pure_fn,
-        |comp| {
-            let mut out: Vec<String> = Vec::new();
-            if comp.len() > 1 {
-                let code = match emit_mode {
-                    LeanEmitMode::Proof => {
-                        let all_supported = comp
-                            .iter()
-                            .all(|fd| crate::codegen::common::fn_contract_exists_for_fn(ctx, fd));
-                        if all_supported {
-                            toplevel::emit_mutual_group_proof(comp, ctx)
-                        } else {
-                            toplevel::emit_mutual_group(comp, ctx)
+        |comp, scope| {
+            let scope_opt = if scope.is_empty() { None } else { Some(scope) };
+            ctx.with_module_scope(scope_opt, || {
+                let mut out: Vec<String> = Vec::new();
+                if comp.len() > 1 {
+                    let code = match emit_mode {
+                        LeanEmitMode::Proof => {
+                            let all_supported = comp.iter().all(|fd| {
+                                crate::codegen::common::fn_contract_exists_for_fn(ctx, fd)
+                            });
+                            if all_supported {
+                                toplevel::emit_mutual_group_proof(comp, ctx)
+                            } else {
+                                toplevel::emit_mutual_group(comp, ctx)
+                            }
                         }
-                    }
-                    LeanEmitMode::Standard => toplevel::emit_mutual_group(comp, ctx),
-                };
-                out.push(code);
-                out.push(String::new());
-            } else if let Some(fd) = comp.first() {
-                let emitted = match emit_mode {
-                    LeanEmitMode::Proof => {
-                        let is_recursive = recursive_names.contains(&fd.name);
-                        // ProofIR's `fn_contracts` holds an entry only for
-                        // recursive fns the ContractLower stage could
-                        // classify. Recursive fns without a contract land
-                        // in `unclassified_fns` and fall through to the
-                        // partial/non-recursive emit.
-                        if is_recursive
-                            && !crate::codegen::common::fn_contract_exists_for_fn(ctx, fd)
-                        {
-                            toplevel::emit_fn_def(fd, &recursive_names, ctx)
-                        } else {
-                            toplevel::emit_fn_def_proof(fd, ctx)
-                        }
-                    }
-                    LeanEmitMode::Standard => toplevel::emit_fn_def(fd, &recursive_fns, ctx),
-                };
-                if let Some(code) = emitted {
+                        LeanEmitMode::Standard => toplevel::emit_mutual_group(comp, ctx),
+                    };
                     out.push(code);
                     out.push(String::new());
+                } else if let Some(fd) = comp.first() {
+                    let emitted = match emit_mode {
+                        LeanEmitMode::Proof => {
+                            let is_recursive = recursive_names.contains(&fd.name);
+                            // ProofIR's `fn_contracts` holds an entry only for
+                            // recursive fns the ContractLower stage could
+                            // classify. Recursive fns without a contract land
+                            // in `unclassified_fns` and fall through to the
+                            // partial/non-recursive emit.
+                            if is_recursive
+                                && !crate::codegen::common::fn_contract_exists_for_fn(ctx, fd)
+                            {
+                                toplevel::emit_fn_def(fd, &recursive_names, ctx)
+                            } else {
+                                toplevel::emit_fn_def_proof(fd, ctx)
+                            }
+                        }
+                        LeanEmitMode::Standard => toplevel::emit_fn_def(fd, &recursive_fns, ctx),
+                    };
+                    if let Some(code) = emitted {
+                        out.push(code);
+                        out.push(String::new());
+                    }
                 }
-            }
-            out
+                out
+            })
         },
     );
 
@@ -1308,24 +1311,27 @@ fn transpile_unified(
 
     for module in &ctx.modules {
         let mut body_sections: Vec<String> = Vec::new();
-        for td in &module.type_defs {
-            body_sections.push(toplevel::emit_type_def_in_scope(
-                td,
-                ctx,
-                Some(module.prefix.as_str()),
-            ));
-            if toplevel::is_recursive_type_def(td) {
-                body_sections.push(toplevel::emit_recursive_decidable_eq(
-                    toplevel::type_def_name(td),
+        ctx.with_module_scope(Some(module.prefix.as_str()), || {
+            for td in &module.type_defs {
+                body_sections.push(toplevel::emit_type_def_in_scope(
+                    td,
+                    ctx,
+                    Some(module.prefix.as_str()),
                 ));
-                if matches!(emit_mode, LeanEmitMode::Proof)
-                    && let Some(measure) = toplevel::emit_recursive_measure(td, &recursive_types)
-                {
-                    body_sections.push(measure);
+                if toplevel::is_recursive_type_def(td) {
+                    body_sections.push(toplevel::emit_recursive_decidable_eq(
+                        toplevel::type_def_name(td),
+                    ));
+                    if matches!(emit_mode, LeanEmitMode::Proof)
+                        && let Some(measure) =
+                            toplevel::emit_recursive_measure(td, &recursive_types)
+                    {
+                        body_sections.push(measure);
+                    }
                 }
+                body_sections.push(String::new());
             }
-            body_sections.push(String::new());
-        }
+        });
         if let Some(scope_sections) = pure_per_scope.by_scope.get(&module.prefix) {
             body_sections.extend(scope_sections.clone());
         }
@@ -1560,6 +1566,7 @@ mod tests {
             symbol_table: crate::ir::SymbolTable::default(),
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
+            current_module_scope: std::cell::RefCell::new(None),
         }
     }
 

--- a/src/codegen/lean/pattern.rs
+++ b/src/codegen/lean/pattern.rs
@@ -1,26 +1,27 @@
 /// Aver patterns → Lean 4 pattern strings.
 use super::shared::to_lower_first;
-use crate::ast::*;
+use crate::ast::Literal;
+use crate::ir::hir::{BuiltinCtor, ResolvedCtor, ResolvedPattern};
 
-/// Emit a Lean 4 pattern from an Aver Pattern.
-pub fn emit_pattern(pat: &Pattern) -> String {
+/// Emit a Lean 4 pattern from a resolved Aver Pattern.
+pub fn emit_pattern(pat: &ResolvedPattern) -> String {
     match pat {
-        Pattern::Wildcard => "_".to_string(),
-        Pattern::Literal(lit) => emit_literal_pattern(lit),
-        Pattern::Ident(name) => super::expr::aver_name_to_lean(name),
-        Pattern::EmptyList => "[]".to_string(),
-        Pattern::Cons(head, tail) => {
+        ResolvedPattern::Wildcard => "_".to_string(),
+        ResolvedPattern::Literal(lit) => emit_literal_pattern(lit),
+        ResolvedPattern::Ident(name) => super::expr::aver_name_to_lean(name),
+        ResolvedPattern::EmptyList => "[]".to_string(),
+        ResolvedPattern::Cons(head, tail) => {
             format!(
                 "{} :: {}",
                 super::expr::aver_name_to_lean(head),
                 super::expr::aver_name_to_lean(tail)
             )
         }
-        Pattern::Tuple(pats) => {
+        ResolvedPattern::Tuple(pats) => {
             let parts: Vec<String> = pats.iter().map(emit_pattern).collect();
             format!("({})", parts.join(", "))
         }
-        Pattern::Constructor(name, bindings) => emit_constructor_pattern(name, bindings),
+        ResolvedPattern::Ctor(ctor, bindings) => emit_ctor_pattern(ctor, bindings),
     }
 }
 
@@ -34,9 +35,9 @@ fn emit_literal_pattern(lit: &Literal) -> String {
     }
 }
 
-fn emit_constructor_pattern(name: &str, bindings: &[String]) -> String {
-    match name {
-        "Result.Ok" => {
+fn emit_ctor_pattern(ctor: &ResolvedCtor, bindings: &[String]) -> String {
+    match ctor {
+        ResolvedCtor::Builtin(BuiltinCtor::ResultOk) => {
             if bindings.is_empty() {
                 ".ok".to_string()
             } else {
@@ -47,7 +48,7 @@ fn emit_constructor_pattern(name: &str, bindings: &[String]) -> String {
                 format!(".ok {}", parts.join(" "))
             }
         }
-        "Result.Err" => {
+        ResolvedCtor::Builtin(BuiltinCtor::ResultErr) => {
             if bindings.is_empty() {
                 ".error".to_string()
             } else {
@@ -58,7 +59,7 @@ fn emit_constructor_pattern(name: &str, bindings: &[String]) -> String {
                 format!(".error {}", parts.join(" "))
             }
         }
-        "Option.Some" => {
+        ResolvedCtor::Builtin(BuiltinCtor::OptionSome) => {
             if bindings.is_empty() {
                 ".some".to_string()
             } else {
@@ -69,24 +70,31 @@ fn emit_constructor_pattern(name: &str, bindings: &[String]) -> String {
                 format!(".some {}", parts.join(" "))
             }
         }
-        "Option.None" => ".none".to_string(),
-        _ => {
-            // Source syntax only produces qualified constructors here.
-            // Keep the bare-name fallback for manually-constructed ASTs in tests.
-            if let Some(dot_pos) = name.find('.') {
-                let variant = &name[dot_pos + 1..];
-                // Lean convention: lowercase constructor names
-                let lean_variant = to_lower_first(variant);
-                if bindings.is_empty() {
-                    format!(".{}", lean_variant)
-                } else {
-                    let parts: Vec<String> = bindings
-                        .iter()
-                        .map(|b| super::expr::aver_name_to_lean(b))
-                        .collect();
-                    format!(".{} {}", lean_variant, parts.join(" "))
-                }
-            } else if bindings.is_empty() {
+        ResolvedCtor::Builtin(BuiltinCtor::OptionNone) => ".none".to_string(),
+        ResolvedCtor::User { name, .. } => {
+            // Lean convention: lowercase constructor names. The
+            // `name` field of `ResolvedCtor::User` is the bare
+            // variant name (e.g. `"Point"` for `Shape.Point`); the
+            // owning type's emit context already namespaces the
+            // ctor at the call site, so no qualified-name handling
+            // is needed here.
+            let lean_variant = to_lower_first(name);
+            if bindings.is_empty() {
+                format!(".{}", lean_variant)
+            } else {
+                let parts: Vec<String> = bindings
+                    .iter()
+                    .map(|b| super::expr::aver_name_to_lean(b))
+                    .collect();
+                format!(".{} {}", lean_variant, parts.join(" "))
+            }
+        }
+        ResolvedCtor::Unresolved { name } => {
+            // Typecheck-rejected program reached the renderer.
+            // Surface the source name in a Lean-shaped placeholder so
+            // the user-facing error from the typecheck stage stays
+            // the load-bearing diagnostic.
+            if bindings.is_empty() {
                 format!("⟨⟩ /- {} -/", name)
             } else {
                 let parts: Vec<String> = bindings

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1,7 +1,7 @@
 /// Top-level Aver items → Lean 4 items (defs, inductives, structures, examples).
 use std::collections::{HashMap, HashSet};
 
-use super::expr::{aver_name_to_lean, emit_expr, emit_stmt};
+use super::expr::{aver_name_to_lean, emit_expr_legacy, emit_stmt_legacy};
 use super::law_auto::{emit_verify_law_forall_auto_proof, emit_verify_law_support_theorems};
 use super::recurrence::{
     detect_second_order_int_linear_recurrence, recurrence_nat_helper_name, render_affine_pair_expr,
@@ -107,7 +107,7 @@ fn emit_product_type(
     {
         let carrier_ty = type_annotation_to_lean(&decl.carrier_type);
         let param = aver_name_to_lean(&decl.predicate_param);
-        let predicate = super::expr::emit_expr(&decl.invariant.expr, ctx);
+        let predicate = super::expr::emit_expr_legacy(&decl.invariant.expr, ctx, None);
         return format!("abbrev {name} := {{ {param} : {carrier_ty} // {predicate} }}");
     }
 
@@ -576,15 +576,15 @@ fn emit_nat_linear_recurrence_fn(
         emit_doc_comment(&fd.desc),
         vec![
             format!("private def {} : Nat -> {}", nat_helper_name, ret_type),
-            format!("  | 0 => {}", emit_expr(&shape.base0, ctx)),
-            format!("  | 1 => {}", emit_expr(&shape.base1, ctx)),
+            format!("  | 0 => {}", emit_expr_legacy(&shape.base0, ctx, None)),
+            format!("  | 1 => {}", emit_expr_legacy(&shape.base1, ctx, None)),
             format!("  | n + 2 => {}", nat_step),
             String::new(),
             format!("def {} ({} : Int) : {} :=", fn_name, lean_param, ret_type),
             format!(
                 "  if {} < 0 then {} else {} {}.toNat",
                 lean_param,
-                emit_expr(&shape.negative_branch, ctx),
+                emit_expr_legacy(&shape.negative_branch, ctx, None),
                 nat_helper_name,
                 lean_param
             ),
@@ -714,7 +714,7 @@ fn emit_native_guarded_int_countdown_fn(
     } else {
         precondition
             .iter()
-            .map(|p| format!("({})", emit_expr(p, ctx)))
+            .map(|p| format!("({})", emit_expr_legacy(p, ctx, None)))
             .collect::<Vec<_>>()
             .join(" ∧ ")
     };
@@ -736,8 +736,8 @@ fn emit_native_guarded_int_countdown_fn(
         &fd.name,
         &aux_name,
     );
-    let base_str = emit_expr(base_arm_body, ctx);
-    let rec_str = emit_expr(&rewritten_wc, ctx);
+    let base_str = emit_expr_legacy(base_arm_body, ctx, None);
+    let rec_str = emit_expr_legacy(&rewritten_wc, ctx, None);
     let arg_names = emit_fn_param_names(&fd.params);
 
     let mut lines = Vec::new();
@@ -1482,28 +1482,28 @@ fn emit_do_stmt(stmt: &Stmt, ctx: &CodegenContext, is_last: bool) -> String {
             format!(
                 "  let {} <- {}",
                 aver_name_to_lean(name),
-                emit_expr(inner, ctx)
+                emit_expr_legacy(inner, ctx, None)
             )
         }
         Stmt::Binding(name, _, expr) => format!(
             "  let {} := {}",
             aver_name_to_lean(name),
-            emit_expr(expr, ctx)
+            emit_expr_legacy(expr, ctx, None)
         ),
         Stmt::Expr(expr) if matches!(&expr.node, Expr::ErrorProp(_)) && is_last => {
             let Expr::ErrorProp(inner) = &expr.node else {
                 unreachable!()
             };
-            format!("  {}", emit_expr(inner, ctx))
+            format!("  {}", emit_expr_legacy(inner, ctx, None))
         }
         Stmt::Expr(expr) if matches!(&expr.node, Expr::ErrorProp(_)) => {
             let Expr::ErrorProp(inner) = &expr.node else {
                 unreachable!()
             };
-            format!("  let _ <- {}", emit_expr(inner, ctx))
+            format!("  let _ <- {}", emit_expr_legacy(inner, ctx, None))
         }
-        Stmt::Expr(expr) if is_last => format!("  {}", emit_expr(expr, ctx)),
-        Stmt::Expr(expr) => format!("  let _ := {}", emit_expr(expr, ctx)),
+        Stmt::Expr(expr) if is_last => format!("  {}", emit_expr_legacy(expr, ctx, None)),
+        Stmt::Expr(expr) => format!("  let _ := {}", emit_expr_legacy(expr, ctx, None)),
     }
 }
 
@@ -1514,13 +1514,13 @@ fn emit_fn_body(body: &FnBody, ctx: &CodegenContext) -> String {
         let is_last = i == stmts.len() - 1;
         match stmt {
             Stmt::Binding(_, _, _) => {
-                lines.push(format!("  {}", emit_stmt(stmt, ctx)));
+                lines.push(format!("  {}", emit_stmt_legacy(stmt, ctx, None)));
             }
             Stmt::Expr(expr) => {
                 if is_last {
-                    lines.push(format!("  {}", emit_expr(expr, ctx)));
+                    lines.push(format!("  {}", emit_expr_legacy(expr, ctx, None)));
                 } else {
-                    lines.push(format!("  let _ := {}", emit_expr(expr, ctx)));
+                    lines.push(format!("  let _ := {}", emit_expr_legacy(expr, ctx, None)));
                 }
             }
         }
@@ -1573,8 +1573,8 @@ pub fn emit_verify_block(
 
     let mut lines = Vec::new();
     for (idx, (left, right)) in vb.cases.iter().enumerate() {
-        let left_str = emit_expr(left, ctx);
-        let right_str = emit_expr(right, ctx);
+        let left_str = emit_expr_legacy(left, ctx, None);
+        let right_str = emit_expr_legacy(right, ctx, None);
         match verify_mode {
             VerifyEmitMode::NativeDecide => {
                 lines.push(format!(
@@ -1652,7 +1652,7 @@ fn emit_verify_trace_block_proofs(
         };
 
         let Some(fn_call) = result_fn_call else {
-            let lhs_summary = emit_expr(left, ctx);
+            let lhs_summary = emit_expr_legacy(left, ctx, None);
             lines.push(format!(
                 "-- verify {} trace case {}/{}: `{}` is runtime-only (see docs/oracle.md)",
                 vb.fn_name,
@@ -1680,8 +1680,8 @@ fn emit_verify_trace_block_proofs(
             mode,
         );
 
-        let lhs_str = emit_expr(&lhs_rw, ctx);
-        let rhs_str = emit_expr(&rhs_rw, ctx);
+        let lhs_str = emit_expr_legacy(&lhs_rw, ctx, None);
+        let rhs_str = emit_expr_legacy(&rhs_rw, ctx, None);
 
         match verify_mode {
             VerifyEmitMode::NativeDecide => {
@@ -1804,8 +1804,8 @@ fn emit_verify_law_block(
     } else {
         crate::codegen::common::strip_refinement_wrappers(&law_rhs, &lifted_vars, ctx)
     };
-    let lhs_template = emit_expr(&law_lhs, ctx);
-    let rhs_template = emit_expr(&law_rhs, ctx);
+    let lhs_template = emit_expr_legacy(&law_lhs, ctx, None);
+    let rhs_template = emit_expr_legacy(&law_rhs, ctx, None);
     // The `when` clause references the same oracle bindings the law
     // body does, so it needs the same subtype projection. Without this
     // a `when rng(root, 0, 1, 6) >= 1` clause would emit `rng ...`
@@ -1826,7 +1826,7 @@ fn emit_verify_law_block(
         // `LE Natural` / `OfNat Natural 10` in Lean.
         let val_projected =
             crate::codegen::common::project_lifted_idents_to_val(&oracle_projected, &lifted_vars);
-        emit_expr(&val_projected, ctx)
+        emit_expr_legacy(&val_projected, ctx, None)
     });
     let quant_params = law
         .givens
@@ -1885,7 +1885,10 @@ fn emit_verify_law_block(
         ));
     }
     if let Some(when_expr) = &law.when {
-        lines.push(format!("-- when {}", emit_expr(when_expr, ctx)));
+        lines.push(format!(
+            "-- when {}",
+            emit_expr_legacy(when_expr, ctx, None)
+        ));
     }
     // Issue #128: singleton-domain givens + RHS that references no
     // given + IR didn't pin a strategy that closes the constant-RHS
@@ -2029,12 +2032,12 @@ fn emit_verify_law_block(
                     |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
                     mode,
                 );
-                let left_str = emit_expr(&left_rw, ctx);
-                let right_str = emit_expr(&right_rw, ctx);
+                let left_str = emit_expr_legacy(&left_rw, ctx, None);
+                let right_str = emit_expr_legacy(&right_rw, ctx, None);
                 if let Some(guard) = law.sample_guards.get(idx) {
                     format!(
                         "({} = true -> {} = {})",
-                        emit_expr(guard, ctx),
+                        emit_expr_legacy(guard, ctx, None),
                         left_str,
                         right_str
                     )
@@ -2098,12 +2101,12 @@ fn emit_verify_law_block(
             |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
             mode,
         );
-        let left_str = emit_expr(&left_rw, ctx);
-        let right_str = emit_expr(&right_rw, ctx);
+        let left_str = emit_expr_legacy(&left_rw, ctx, None);
+        let right_str = emit_expr_legacy(&right_rw, ctx, None);
         let sample_prop = if let Some(guard) = law.sample_guards.get(idx) {
             format!(
                 "{} = true -> {} = {}",
-                emit_expr(guard, ctx),
+                emit_expr_legacy(guard, ctx, None),
                 left_str,
                 right_str
             )
@@ -2189,7 +2192,7 @@ fn law_given_domain_to_lean(domain: &VerifyGivenDomain, ctx: &CodegenContext) ->
             "[{}]",
             values
                 .iter()
-                .map(|v| emit_expr(v, ctx))
+                .map(|v| emit_expr_legacy(v, ctx, None))
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
@@ -2210,10 +2213,10 @@ fn law_given_domain_prop(given: &VerifyGiven, ctx: &CodegenContext) -> String {
     let values = law_given_domain_values(&given.domain);
     match values.as_slice() {
         [] => "False".to_string(),
-        [value] => format!("{given_name} = {}", emit_expr(value, ctx)),
+        [value] => format!("{given_name} = {}", emit_expr_legacy(value, ctx, None)),
         _ => values
             .iter()
-            .map(|value| format!("{given_name} = {}", emit_expr(value, ctx)))
+            .map(|value| format!("{given_name} = {}", emit_expr_legacy(value, ctx, None)))
             .collect::<Vec<_>>()
             .join(" ∨ "),
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -184,6 +184,14 @@ pub struct CodegenContext {
     /// are skipped from this list — codegen falls back to
     /// `fn_defs` in those cases.
     pub resolved_fn_defs: Vec<crate::ir::hir::ResolvedFnDef>,
+    /// Module scope currently active for name resolution. Set by a
+    /// backend dispatcher before emitting a dep-module's fns so that
+    /// legacy resolve-on-demand adapters (e.g. Lean's
+    /// `emit_expr_legacy`) thread the right scope into
+    /// `resolve_expr` / `resolve_stmt` instead of defaulting to entry.
+    /// Empty by default. Set with [`Self::with_module_scope`] in a
+    /// scoped manner.
+    pub current_module_scope: std::cell::RefCell<Option<String>>,
     /// Per-dep resolved fn defs, parallel to `modules`. Each
     /// entry in `resolved_module_fn_defs[i]` corresponds to
     /// `modules[i].fn_defs` in source order — same skip-on-missing
@@ -530,6 +538,7 @@ pub fn build_context(
         symbol_table,
         resolved_fn_defs,
         resolved_module_fn_defs,
+        current_module_scope: std::cell::RefCell::new(None),
     };
     // ProofIR no longer populated here. Pipeline owns the lowerings
     // (`PipelineStage::RefinementLower`, `PipelineStage::ContractLower`);
@@ -541,6 +550,25 @@ pub fn build_context(
     // stays `default()` here for those callers until they explicitly
     // refresh.
     ctx
+}
+
+impl CodegenContext {
+    /// Set `current_module_scope` for the duration of `f`. Backends
+    /// wrap their per-module emit calls with this so legacy
+    /// resolve-on-demand adapters see the correct prefix.
+    pub fn with_module_scope<R>(&self, scope: Option<&str>, f: impl FnOnce() -> R) -> R {
+        let prev = self.current_module_scope.replace(scope.map(|s| s.to_string()));
+        let out = f();
+        *self.current_module_scope.borrow_mut() = prev;
+        out
+    }
+
+    /// Snapshot of the active module scope. Cloned so callers may
+    /// pass `as_deref()` into resolver/emitter APIs without holding
+    /// the `RefCell` borrow.
+    pub fn active_module_scope(&self) -> Option<String> {
+        self.current_module_scope.borrow().clone()
+    }
 }
 
 impl CodegenContext {

--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -1043,6 +1043,7 @@ mod tests {
             symbol_table: crate::ir::SymbolTable::default(),
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
+            current_module_scope: std::cell::RefCell::new(None),
         }
     }
 

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -3035,6 +3035,7 @@ mod tests {
             symbol_table: crate::ir::SymbolTable::default(),
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
+            current_module_scope: std::cell::RefCell::new(None),
         }
     }
 

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4988,6 +4988,7 @@ mod tests {
             symbol_table: aver::ir::SymbolTable::default(),
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
+            current_module_scope: std::cell::RefCell::new(None),
         }
     }
 


### PR DESCRIPTION
## Summary
- Migrates the Lean rendering layer (`expr.rs`, `pattern.rs`, `builtins.rs`, `toplevel.rs`, `law_auto[/spec/*]`) from raw `ast::Expr`/`Pattern` to the resolved IR — `ResolvedExpr` + `ResolvedCallee` + `ResolvedCtor` + `ResolvedPattern`. `emit_expr` dispatches calls and constructors via the symbol table instead of parsing dotted names from strings.
- Adds module-scope plumbing on `CodegenContext` (`current_module_scope: RefCell<Option<String>>` + `with_module_scope` / `active_module_scope`). The Lean dispatcher wraps `route_pure_components_per_scope` emits so legacy resolve-on-demand adapters (`emit_{expr,stmt,pattern}_legacy`) fall back to the active scope when `None` is passed — closes the same cross-module bug class PR 9.4 fixed in Rust codegen.
- `route_pure_components_per_scope` closure signature extended to `(comp, scope)`; Dafny's call updated to ignore the second arg (its rendering layer migrates in PR 11).

## Test plan
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` clean
- [x] `cargo test --features wasm --no-fail-fast` — 1653 passed, 0 failed
- [x] Lean+Dafny proof artifacts byte-identical (md5) on all six baseline fixtures: calculator, hostile_order_axis, lambda, shapes, temperature, user_record

🤖 Generated with [Claude Code](https://claude.com/claude-code)