### PR TITLE
codegen/dafny: emit pipeline consumes ResolvedExpr — #147 phase E PR 11

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -1756,17 +1756,7 @@ pub(crate) fn is_set_annotation(ann: &str) -> bool {
     is_set_type(&parse_type_annotation(ann))
 }
 
-/// Check if an expression is a compile-time Unit literal.
-pub(crate) fn is_unit_expr(expr: &crate::ast::Expr) -> bool {
-    matches!(expr, crate::ast::Expr::Literal(crate::ast::Literal::Unit))
-}
-
-/// Check if a spanned expression is a compile-time Unit literal.
-pub(crate) fn is_unit_expr_spanned(expr: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
-    is_unit_expr(&expr.node)
-}
-
-/// Resolved-form mirror of [`is_unit_expr`]. Same Phase-E shape
+/// Resolved-form mirror of the historical AST helper. Same Phase-E shape
 /// (`ResolvedExpr::Literal(Unit)`); used by migrated backends.
 pub(crate) fn is_unit_expr_resolved(expr: &crate::ir::hir::ResolvedExpr) -> bool {
     matches!(

--- a/src/codegen/dafny/expr.rs
+++ b/src/codegen/dafny/expr.rs
@@ -1,7 +1,11 @@
 /// Aver expressions → Dafny expression strings.
-use crate::ast::*;
+use crate::ast::{BinOp, Literal, Spanned};
 use crate::codegen::CodegenContext;
-use crate::codegen::common::{expr_to_dotted_name, is_user_type, resolve_module_call};
+use crate::codegen::common::{is_user_type, resolve_module_call};
+use crate::ir::hir::{
+    BuiltinCtor, ResolvedCallee, ResolvedCtor, ResolvedExpr, ResolvedMatchArm, ResolvedPattern,
+    ResolvedStrPart,
+};
 
 /// Dafny reserved words.
 const DAFNY_RESERVED: &[&str] = &[
@@ -106,12 +110,12 @@ pub fn aver_name_to_dafny(name: &str) -> String {
     crate::codegen::common::escape_reserved_word(&normalized, DAFNY_RESERVED, "_")
 }
 
-/// Emit a Dafny expression from an Aver Spanned<Expr>.
-pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
+/// Emit a Dafny expression from a resolved Aver expression.
+pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
     match &expr.node {
-        Expr::Literal(lit) => emit_literal(lit),
-        Expr::Ident(name) | Expr::Resolved { name, .. } => aver_name_to_dafny(name),
-        Expr::Attr(obj, field) => {
+        ResolvedExpr::Literal(lit) => emit_literal(lit),
+        ResolvedExpr::Ident(name) | ResolvedExpr::Resolved { name, .. } => aver_name_to_dafny(name),
+        ResolvedExpr::Attr(obj, field) => {
             // Refinement-via-opaque records emit as Dafny subset types,
             // so projecting the carrier field is the identity (the
             // value *is* the underlying `int`).
@@ -122,7 +126,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             {
                 return emit_expr(obj, ctx);
             }
-            if let Expr::Ident(type_name) = &obj.node {
+            if let ResolvedExpr::Ident(type_name) = &obj.node {
                 if type_name == "Option" && field == "None" {
                     return "Option.None".to_string();
                 }
@@ -136,7 +140,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             // `is_user_type` because Aver allows `module Enemy` to coexist
             // with `record Enemy`. If the head is a known module prefix,
             // route through the renamed Dafny module (`Aver_Enemy.fn`).
-            if let Some(full_dotted) = expr_to_dotted_name_spanned(expr)
+            if let Some(full_dotted) = crate::ir::hir::resolved_to_dotted(&expr.node)
                 && let Some((prefix, bare)) = resolve_module_call(&full_dotted, ctx)
             {
                 if let Some(dot_pos) = bare.find('.') {
@@ -152,7 +156,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
                 }
                 return bare_dafny;
             }
-            if let Expr::Ident(type_name) = &obj.node
+            if let ResolvedExpr::Ident(type_name) = &obj.node
                 && is_user_type(type_name, ctx)
             {
                 return format!("{}.{}", type_name, field);
@@ -160,14 +164,14 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             let obj_str = emit_expr(obj, ctx);
             format!("{}.{}", obj_str, aver_name_to_dafny(field))
         }
-        Expr::FnCall(fn_expr, args) => emit_fn_call(fn_expr, args, ctx),
-        Expr::Neg(inner) => {
+        ResolvedExpr::Call(callee, args) => emit_fn_call(callee, args, ctx),
+        ResolvedExpr::Neg(inner) => {
             // Dafny accepts `(-x)` uniformly for `int` and `real`,
             // unlike `0 - x` which fails when `x` is real (the literal
             // `0` is int and Dafny rejects mixed-type arithmetic).
             format!("(-{})", emit_expr(inner, ctx))
         }
-        Expr::BinOp(op, left, right) => {
+        ResolvedExpr::BinOp(op, left, right) => {
             let l = emit_expr(left, ctx);
             let r = emit_expr(right, ctx);
             // Float `/` lowers via `FloatDiv` so Aver's IEEE-754
@@ -194,22 +198,22 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             };
             format!("({} {} {})", l, op_str, r)
         }
-        Expr::Match { subject, arms, .. } => emit_match(subject, arms, ctx),
-        Expr::Constructor(name, arg) => emit_constructor(name, arg.as_deref(), ctx),
-        Expr::ErrorProp(_) => {
+        ResolvedExpr::Match { subject, arms } => emit_match(subject, arms, ctx),
+        ResolvedExpr::Ctor(ctor, args) => emit_constructor(ctor, args, ctx),
+        ResolvedExpr::ErrorProp(_) => {
             // ? operator requires early-return semantics (Err propagation).
             // Dafny pure functions cannot express this; functions using ? are
-            // skipped at the top-level emission stage.  If we get here, emit
+            // skipped at the top-level emission stage. If we get here, emit
             // a marker that makes the generated Dafny obviously wrong rather
             // than silently modelling a different program.
             "/* ERROR: ? operator not supported in Dafny pure functions */".to_string()
         }
-        Expr::InterpolatedStr(parts) => emit_interpolated_str(parts, ctx),
-        Expr::List(elems) => {
+        ResolvedExpr::InterpolatedStr(parts) => emit_interpolated_str(parts, ctx),
+        ResolvedExpr::List(elems) => {
             let items: Vec<String> = elems.iter().map(|e| emit_expr(e, ctx)).collect();
             format!("[{}]", items.join(", "))
         }
-        Expr::Tuple(elems) | Expr::IndependentProduct(elems, _) => {
+        ResolvedExpr::Tuple(elems) | ResolvedExpr::IndependentProduct(elems, _) => {
             // Oracle v1: plain `!` lifts to a Dafny tuple — schedule
             // invariance is a compiler-level claim, no extra machinery at
             // the expression site. `?!` also passes through the tuple form
@@ -222,12 +226,12 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             let items: Vec<String> = elems.iter().map(|e| emit_expr(e, ctx)).collect();
             format!("({})", items.join(", "))
         }
-        Expr::MapLiteral(entries) => {
+        ResolvedExpr::MapLiteral(entries) => {
             if entries.is_empty() {
                 "map[]".to_string()
             } else if entries
                 .iter()
-                .all(|(_, v)| crate::codegen::common::is_unit_expr_spanned(v))
+                .all(|(_, v)| crate::codegen::common::is_unit_expr_resolved(&v.node))
             {
                 // Map<T, Unit> literal → set literal
                 let items: Vec<String> = entries.iter().map(|(k, _)| emit_expr(k, ctx)).collect();
@@ -240,7 +244,9 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
                 format!("map[{}]", items.join(", "))
             }
         }
-        Expr::RecordCreate { type_name, fields } => {
+        ResolvedExpr::RecordCreate {
+            type_name, fields, ..
+        } => {
             // Int-carrier refinement records emit as a subset type
             // (`type X = n: int | P n`), so `X(value := k)` collapses
             // to just `k` — the value already inhabits the subset.
@@ -265,7 +271,7 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
             let dafny_type_name = type_name.replace('.', "_");
             format!("{}({})", dafny_type_name, field_strs.join(", "))
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
             let base_str = emit_expr(base, ctx);
             let update_strs: Vec<String> = updates
                 .iter()
@@ -275,19 +281,13 @@ pub fn emit_expr(expr: &Spanned<Expr>, ctx: &CodegenContext) -> String {
                 .collect();
             format!("{}.({})", base_str, update_strs.join(", "))
         }
-        Expr::TailCall(inner) => {
-            let TailCallData {
-                target: name, args, ..
-            } = inner.as_ref();
+        ResolvedExpr::TailCall { target, args } => {
+            let entry = ctx.symbol_table.fn_entry(*target);
+            let name = entry.key.name.as_str();
             let arg_strs: Vec<String> = args.iter().map(|a| emit_expr(a, ctx)).collect();
             format!("{}({})", aver_name_to_dafny(name), arg_strs.join(", "))
         }
     }
-}
-
-/// Helper to extract dotted name from a Spanned<Expr>.
-fn expr_to_dotted_name_spanned(expr: &Spanned<Expr>) -> Option<String> {
-    expr_to_dotted_name(&expr.node)
 }
 
 fn emit_literal(lit: &Literal) -> String {
@@ -312,48 +312,78 @@ fn emit_literal(lit: &Literal) -> String {
     }
 }
 
-fn emit_fn_call(fn_expr: &Spanned<Expr>, args: &[Spanned<Expr>], ctx: &CodegenContext) -> String {
+fn emit_fn_call(
+    callee: &ResolvedCallee,
+    args: &[Spanned<ResolvedExpr>],
+    ctx: &CodegenContext,
+) -> String {
     use crate::codegen::builtins::recognize_builtin;
-    use crate::codegen::common::is_unit_expr_spanned;
+    use crate::codegen::common::is_unit_expr_resolved;
 
-    let dotted = expr_to_dotted_name_spanned(fn_expr);
-
-    // Map<T, Unit> set operations: intercept before generic builtin path
-    if let Some(name) = dotted.as_deref()
-        && name == "Map.set"
-        && args.len() == 3
-        && is_unit_expr_spanned(&args[2])
-    {
-        let m = emit_expr(&args[0], ctx);
-        let k = emit_expr(&args[1], ctx);
-        return format!("({} + {{{}}})", m, k);
-    }
-
-    if let Some(builtin) = dotted.as_deref().and_then(recognize_builtin) {
-        let a: Vec<String> = args.iter().map(|e| emit_expr(e, ctx)).collect();
-        return emit_dafny_builtin(builtin, &a);
-    }
-
-    // Oracle v1: BranchPath.* constructor calls map onto the underscore-
-    // named prelude functions (Dafny's dotted notation collides with
-    // record-member access on the BranchPath datatype).
-    if let Some(name) = dotted.as_deref() {
-        let a: Vec<String> = args.iter().map(|e| emit_expr(e, ctx)).collect();
-        match name {
-            "BranchPath.child" if a.len() == 2 => {
-                return format!("BranchPath_child({}, {})", a[0], a[1]);
+    match callee {
+        ResolvedCallee::Builtin(name) => {
+            // Map<T, Unit> set operations: intercept before generic builtin path
+            if name == "Map.set" && args.len() == 3 && is_unit_expr_resolved(&args[2].node) {
+                let m = emit_expr(&args[0], ctx);
+                let k = emit_expr(&args[1], ctx);
+                return format!("({} + {{{}}})", m, k);
             }
-            "BranchPath.parse" if a.len() == 1 => {
-                return format!("BranchPath_parse({})", a[0]);
+            if let Some(builtin) = recognize_builtin(name) {
+                let a: Vec<String> = args.iter().map(|e| emit_expr(e, ctx)).collect();
+                return emit_dafny_builtin(builtin, &a);
             }
-            _ => {}
+            // Oracle v1: BranchPath.* constructor calls map onto the
+            // underscore-named prelude functions (Dafny's dotted
+            // notation collides with record-member access on the
+            // BranchPath datatype).
+            let a: Vec<String> = args.iter().map(|e| emit_expr(e, ctx)).collect();
+            match name.as_str() {
+                "BranchPath.child" if a.len() == 2 => {
+                    return format!("BranchPath_child({}, {})", a[0], a[1]);
+                }
+                "BranchPath.parse" if a.len() == 1 => {
+                    return format!("BranchPath_parse({})", a[0]);
+                }
+                _ => {}
+            }
+            // Generic builtin fallback — render as dotted call.
+            format!("{}({})", aver_name_to_dafny(name), a.join(", "))
+        }
+        ResolvedCallee::Intrinsic(intr) => {
+            // Compiler-synthesised `__buf_*` / `__to_str` intrinsics
+            // don't reach the Dafny backend in practice (Dafny emit
+            // doesn't see post-interp-lower buffer shapes), but the
+            // resolver carries them through; render as bare-name call.
+            let a: Vec<String> = args.iter().map(|e| emit_expr(e, ctx)).collect();
+            format!("{}({})", intr.name(), a.join(", "))
+        }
+        ResolvedCallee::Fn(fn_id) => {
+            let entry = ctx.symbol_table.fn_entry(*fn_id);
+            let bare = entry.key.name.as_str();
+            let module_prefix = entry.key.scope_str();
+            let arg_strs: Vec<String> = args.iter().map(|a| emit_expr(a, ctx)).collect();
+            let func = match module_prefix {
+                Some(prefix) if !ctx.modules.is_empty() => {
+                    format!("{}.{}", super::dafny_module_name(prefix), aver_name_to_dafny(bare))
+                }
+                _ => aver_name_to_dafny(bare),
+            };
+            format!("{}({})", func, arg_strs.join(", "))
+        }
+        ResolvedCallee::LocalSlot { name, .. } => {
+            let arg_strs: Vec<String> = args.iter().map(|a| emit_expr(a, ctx)).collect();
+            format!("{}({})", aver_name_to_dafny(name), arg_strs.join(", "))
+        }
+        ResolvedCallee::Unresolved { callee: inner } => {
+            // Typecheck-rejected callee — render the source-faithful
+            // expression as a regular call so the surrounding Dafny
+            // module still parses (verify driver surfaces the missing
+            // target separately).
+            let func = emit_expr(inner, ctx);
+            let arg_strs: Vec<String> = args.iter().map(|a| emit_expr(a, ctx)).collect();
+            format!("{}({})", func, arg_strs.join(", "))
         }
     }
-
-    // Not a recognized builtin — generic function call
-    let fn_name = emit_expr(fn_expr, ctx);
-    let arg_strs: Vec<String> = args.iter().map(|e| emit_expr(e, ctx)).collect();
-    format!("{}({})", fn_name, arg_strs.join(", "))
 }
 
 fn emit_dafny_builtin(b: crate::codegen::builtins::Builtin, a: &[String]) -> String {
@@ -480,7 +510,11 @@ fn emit_dafny_builtin(b: crate::codegen::builtins::Builtin, a: &[String]) -> Str
     }
 }
 
-fn emit_match(subject: &Spanned<Expr>, arms: &[MatchArm], ctx: &CodegenContext) -> String {
+fn emit_match(
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
+    ctx: &CodegenContext,
+) -> String {
     // Check if this is a list-pattern match (EmptyList / Cons arms)
     if has_list_patterns(arms) {
         return emit_list_match(subject, arms, ctx);
@@ -512,39 +546,43 @@ fn emit_match(subject: &Spanned<Expr>, arms: &[MatchArm], ctx: &CodegenContext) 
 
 /// Should we emit this match as an if-then-else chain?
 /// Yes for matches on scalar values (int, bool, string literals) and wildcards.
-fn should_emit_as_if_chain(arms: &[MatchArm]) -> bool {
+fn should_emit_as_if_chain(arms: &[ResolvedMatchArm]) -> bool {
     arms.iter().all(|arm| {
         matches!(
             arm.pattern,
-            Pattern::Literal(_) | Pattern::Wildcard | Pattern::Ident(_)
+            ResolvedPattern::Literal(_) | ResolvedPattern::Wildcard | ResolvedPattern::Ident(_)
         )
     })
 }
 
 /// Check if arms form a bool match: `true -> ..., false -> ...` (in either order).
-fn is_bool_match(arms: &[MatchArm]) -> bool {
+fn is_bool_match(arms: &[ResolvedMatchArm]) -> bool {
     if arms.len() != 2 {
         return false;
     }
     let has_true = arms
         .iter()
-        .any(|a| matches!(&a.pattern, Pattern::Literal(Literal::Bool(true))));
+        .any(|a| matches!(&a.pattern, ResolvedPattern::Literal(Literal::Bool(true))));
     let has_false = arms
         .iter()
-        .any(|a| matches!(&a.pattern, Pattern::Literal(Literal::Bool(false))));
+        .any(|a| matches!(&a.pattern, ResolvedPattern::Literal(Literal::Bool(false))));
     has_true && has_false
 }
 
 /// Emit a bool match as `if subject then true_body else false_body`.
-fn emit_bool_match(subject: &Spanned<Expr>, arms: &[MatchArm], ctx: &CodegenContext) -> String {
+fn emit_bool_match(
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
+    ctx: &CodegenContext,
+) -> String {
     let subj = emit_expr(subject, ctx);
     let true_arm = arms
         .iter()
-        .find(|a| matches!(&a.pattern, Pattern::Literal(Literal::Bool(true))))
+        .find(|a| matches!(&a.pattern, ResolvedPattern::Literal(Literal::Bool(true))))
         .unwrap();
     let false_arm = arms
         .iter()
-        .find(|a| matches!(&a.pattern, Pattern::Literal(Literal::Bool(false))))
+        .find(|a| matches!(&a.pattern, ResolvedPattern::Literal(Literal::Bool(false))))
         .unwrap();
     let true_body = emit_expr(&true_arm.body, ctx);
     let false_body = emit_expr(&false_arm.body, ctx);
@@ -552,12 +590,21 @@ fn emit_bool_match(subject: &Spanned<Expr>, arms: &[MatchArm], ctx: &CodegenCont
 }
 
 /// Emit a match as a Dafny if-then-else chain.
-fn emit_if_chain(subject: &Spanned<Expr>, arms: &[MatchArm], ctx: &CodegenContext) -> String {
+fn emit_if_chain(
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
+    ctx: &CodegenContext,
+) -> String {
     let subj = emit_expr(subject, ctx);
     emit_if_chain_inner(&subj, arms, 0, ctx)
 }
 
-fn emit_if_chain_inner(subj: &str, arms: &[MatchArm], idx: usize, ctx: &CodegenContext) -> String {
+fn emit_if_chain_inner(
+    subj: &str,
+    arms: &[ResolvedMatchArm],
+    idx: usize,
+    ctx: &CodegenContext,
+) -> String {
     if idx >= arms.len() {
         return "/* unreachable */".to_string();
     }
@@ -566,14 +613,14 @@ fn emit_if_chain_inner(subj: &str, arms: &[MatchArm], idx: usize, ctx: &CodegenC
     let body = emit_expr(&arm.body, ctx);
 
     match &arm.pattern {
-        Pattern::Wildcard | Pattern::Ident(_) => {
-            if let Pattern::Ident(name) = &arm.pattern {
+        ResolvedPattern::Wildcard | ResolvedPattern::Ident(_) => {
+            if let ResolvedPattern::Ident(name) = &arm.pattern {
                 format!("(var {} := {}; {})", aver_name_to_dafny(name), subj, body)
             } else {
                 body
             }
         }
-        Pattern::Literal(lit) => {
+        ResolvedPattern::Literal(lit) => {
             let rest = emit_if_chain_inner(subj, arms, idx + 1, ctx);
 
             let lit_str = emit_literal(lit);
@@ -587,25 +634,29 @@ fn emit_if_chain_inner(subj: &str, arms: &[MatchArm], idx: usize, ctx: &CodegenC
 }
 
 /// Check if any arm uses list patterns (EmptyList or Cons).
-fn has_list_patterns(arms: &[MatchArm]) -> bool {
+fn has_list_patterns(arms: &[ResolvedMatchArm]) -> bool {
     arms.iter()
-        .any(|arm| matches!(arm.pattern, Pattern::EmptyList | Pattern::Cons(_, _)))
+        .any(|arm| matches!(arm.pattern, ResolvedPattern::EmptyList | ResolvedPattern::Cons(_, _)))
 }
 
 /// Emit a match on a list (seq) as if-then-else with seq operations.
-fn emit_list_match(subject: &Spanned<Expr>, arms: &[MatchArm], ctx: &CodegenContext) -> String {
+fn emit_list_match(
+    subject: &Spanned<ResolvedExpr>,
+    arms: &[ResolvedMatchArm],
+    ctx: &CodegenContext,
+) -> String {
     let subj = emit_expr(subject, ctx);
 
     // Find empty-list arm and cons arm
     let empty_arm = arms
         .iter()
-        .find(|a| matches!(a.pattern, Pattern::EmptyList));
+        .find(|a| matches!(a.pattern, ResolvedPattern::EmptyList));
     let cons_arm = arms
         .iter()
-        .find(|a| matches!(a.pattern, Pattern::Cons(_, _)));
+        .find(|a| matches!(a.pattern, ResolvedPattern::Cons(_, _)));
     let wildcard_arm = arms
         .iter()
-        .find(|a| matches!(a.pattern, Pattern::Wildcard | Pattern::Ident(_)));
+        .find(|a| matches!(a.pattern, ResolvedPattern::Wildcard | ResolvedPattern::Ident(_)));
 
     let empty_body = if let Some(arm) = empty_arm {
         emit_expr(&arm.body, ctx)
@@ -616,7 +667,7 @@ fn emit_list_match(subject: &Spanned<Expr>, arms: &[MatchArm], ctx: &CodegenCont
     };
 
     let cons_body = if let Some(arm) = cons_arm {
-        if let Pattern::Cons(head, tail) = &arm.pattern {
+        if let ResolvedPattern::Cons(head, tail) = &arm.pattern {
             let head_name = aver_name_to_dafny(head);
             let tail_name = aver_name_to_dafny(tail);
             let body = emit_expr(&arm.body, ctx);
@@ -639,76 +690,118 @@ fn emit_list_match(subject: &Spanned<Expr>, arms: &[MatchArm], ctx: &CodegenCont
     )
 }
 
-fn emit_pattern(pattern: &Pattern) -> String {
+pub(crate) fn emit_pattern(pattern: &ResolvedPattern) -> String {
     match pattern {
-        Pattern::Wildcard => "_".to_string(),
-        Pattern::Literal(lit) => emit_literal(lit),
-        Pattern::Ident(name) => aver_name_to_dafny(name),
-        Pattern::EmptyList => "Nil".to_string(),
-        Pattern::Cons(head, tail) => {
+        ResolvedPattern::Wildcard => "_".to_string(),
+        ResolvedPattern::Literal(lit) => emit_literal(lit),
+        ResolvedPattern::Ident(name) => aver_name_to_dafny(name),
+        ResolvedPattern::EmptyList => "Nil".to_string(),
+        ResolvedPattern::Cons(head, tail) => {
             format!(
                 "Cons({}, {})",
                 aver_name_to_dafny(head),
                 aver_name_to_dafny(tail)
             )
         }
-        Pattern::Tuple(pats) => {
+        ResolvedPattern::Tuple(pats) => {
             let subs: Vec<String> = pats.iter().map(emit_pattern).collect();
             format!("({})", subs.join(", "))
         }
-        Pattern::Constructor(name, bindings) => {
-            let variant = if let Some(dot_pos) = name.rfind('.') {
-                &name[dot_pos + 1..]
-            } else {
-                name.as_str()
-            };
-            if bindings.is_empty() {
-                variant.to_string()
-            } else {
-                let subs: Vec<String> = bindings.iter().map(|b| aver_name_to_dafny(b)).collect();
-                format!("{}({})", variant, subs.join(", "))
-            }
-        }
+        ResolvedPattern::Ctor(ctor, bindings) => emit_ctor_pattern(ctor, bindings),
     }
 }
 
-fn emit_constructor(name: &str, arg: Option<&Spanned<Expr>>, ctx: &CodegenContext) -> String {
+fn emit_ctor_pattern(ctor: &ResolvedCtor, bindings: &[String]) -> String {
+    let variant = match ctor {
+        ResolvedCtor::Builtin(BuiltinCtor::ResultOk) => "Ok".to_string(),
+        ResolvedCtor::Builtin(BuiltinCtor::ResultErr) => "Err".to_string(),
+        ResolvedCtor::Builtin(BuiltinCtor::OptionSome) => "Some".to_string(),
+        ResolvedCtor::Builtin(BuiltinCtor::OptionNone) => "None".to_string(),
+        ResolvedCtor::User { name, .. } => {
+            if let Some(dot_pos) = name.rfind('.') {
+                name[dot_pos + 1..].to_string()
+            } else {
+                name.clone()
+            }
+        }
+        ResolvedCtor::Unresolved { name } => {
+            if let Some(dot_pos) = name.rfind('.') {
+                name[dot_pos + 1..].to_string()
+            } else {
+                name.clone()
+            }
+        }
+    };
+    if bindings.is_empty() {
+        variant
+    } else {
+        let subs: Vec<String> = bindings.iter().map(|b| aver_name_to_dafny(b)).collect();
+        format!("{}({})", variant, subs.join(", "))
+    }
+}
+
+fn emit_constructor(
+    ctor: &ResolvedCtor,
+    args: &[Spanned<ResolvedExpr>],
+    ctx: &CodegenContext,
+) -> String {
     // In Dafny expression context, qualify constructors to avoid
     // ambiguity. User-defined types and the built-in `Result` /
     // `Option` are kept fully qualified — the latter because user code
     // can declare its own `enum ParseResult { Ok, Err }` with the same
     // variant names, and Dafny needs the discriminator to pick the
     // right datatype.
-    let qualified = if let Some(dot_pos) = name.rfind('.') {
-        let type_name = &name[..dot_pos];
-        let variant = &name[dot_pos + 1..];
-        if is_user_type(type_name, ctx) || type_name == "Result" || type_name == "Option" {
-            format!("{}.{}", type_name, variant)
-        } else {
-            variant.to_string()
+    let qualified = match ctor {
+        ResolvedCtor::Builtin(BuiltinCtor::ResultOk) => "Result.Ok".to_string(),
+        ResolvedCtor::Builtin(BuiltinCtor::ResultErr) => "Result.Err".to_string(),
+        ResolvedCtor::Builtin(BuiltinCtor::OptionSome) => "Option.Some".to_string(),
+        ResolvedCtor::Builtin(BuiltinCtor::OptionNone) => return "Option.None".to_string(),
+        ResolvedCtor::User { type_id, name, .. } => {
+            let type_entry = ctx.symbol_table.type_entry(*type_id);
+            let type_name = type_entry.key.name.as_str();
+            let variant = if let Some(dot_pos) = name.rfind('.') {
+                &name[dot_pos + 1..]
+            } else {
+                name.as_str()
+            };
+            if is_user_type(type_name, ctx) {
+                format!("{}.{}", type_name, variant)
+            } else {
+                variant.to_string()
+            }
         }
-    } else {
-        name.to_string()
+        ResolvedCtor::Unresolved { name } => {
+            let (type_name, variant) = if let Some(dot_pos) = name.rfind('.') {
+                (&name[..dot_pos], &name[dot_pos + 1..])
+            } else {
+                ("", name.as_str())
+            };
+            if is_user_type(type_name, ctx) || type_name == "Result" || type_name == "Option" {
+                format!("{}.{}", type_name, variant)
+            } else {
+                variant.to_string()
+            }
+        }
     };
-    if let Some(a) = arg {
-        let arg_str = emit_expr(a, ctx);
-        format!("{}({})", qualified, arg_str)
-    } else {
+    if args.is_empty() {
         qualified
+    } else {
+        let arg_strs: Vec<String> = args.iter().map(|a| emit_expr(a, ctx)).collect();
+        format!("{}({})", qualified, arg_strs.join(", "))
     }
 }
 
-fn emit_interpolated_str(parts: &[StrPart], ctx: &CodegenContext) -> String {
+fn emit_interpolated_str(parts: &[ResolvedStrPart], ctx: &CodegenContext) -> String {
     let mut pieces = Vec::new();
     for part in parts {
         match part {
-            StrPart::Literal(s) => {
+            ResolvedStrPart::Literal(s) => {
                 pieces.push(format!(
                     "\"{}\"",
                     crate::codegen::common::escape_string_literal_unicode(s)
                 ));
             }
-            StrPart::Parsed(expr) => {
+            ResolvedStrPart::Parsed(expr) => {
                 pieces.push(format!("ToString({})", emit_expr(expr, ctx)));
             }
         }
@@ -718,4 +811,34 @@ fn emit_interpolated_str(parts: &[StrPart], ctx: &CodegenContext) -> String {
     } else {
         pieces.join(" + ")
     }
+}
+
+/// Source-shape adapter for callers that still hold a raw
+/// `Spanned<crate::ast::Expr>`. Resolves the expression on demand
+/// against the codegen context's symbol table; `scope` carries the
+/// owning module prefix when known, with `ctx.active_module_scope()`
+/// as the fallback when callers pass `None`.
+pub fn emit_expr_legacy(
+    expr: &crate::ast::Spanned<crate::ast::Expr>,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> String {
+    let active = ctx.active_module_scope();
+    let effective = scope.or(active.as_deref());
+    let resolved = ctx.resolve_expr(expr, effective);
+    emit_expr(&resolved, ctx)
+}
+
+/// Source-shape adapter for [`emit_pattern`]. See [`emit_expr_legacy`]
+/// for the scope-fallback rule.
+#[allow(dead_code)]
+pub fn emit_pattern_legacy(
+    pat: &crate::ast::Pattern,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> String {
+    let active = ctx.active_module_scope();
+    let effective = scope.or(active.as_deref());
+    let resolved = ctx.resolve_pattern(pat, effective);
+    emit_pattern(&resolved)
 }

--- a/src/codegen/dafny/expr.rs
+++ b/src/codegen/dafny/expr.rs
@@ -364,7 +364,11 @@ fn emit_fn_call(
             let arg_strs: Vec<String> = args.iter().map(|a| emit_expr(a, ctx)).collect();
             let func = match module_prefix {
                 Some(prefix) if !ctx.modules.is_empty() => {
-                    format!("{}.{}", super::dafny_module_name(prefix), aver_name_to_dafny(bare))
+                    format!(
+                        "{}.{}",
+                        super::dafny_module_name(prefix),
+                        aver_name_to_dafny(bare)
+                    )
                 }
                 _ => aver_name_to_dafny(bare),
             };
@@ -635,8 +639,12 @@ fn emit_if_chain_inner(
 
 /// Check if any arm uses list patterns (EmptyList or Cons).
 fn has_list_patterns(arms: &[ResolvedMatchArm]) -> bool {
-    arms.iter()
-        .any(|arm| matches!(arm.pattern, ResolvedPattern::EmptyList | ResolvedPattern::Cons(_, _)))
+    arms.iter().any(|arm| {
+        matches!(
+            arm.pattern,
+            ResolvedPattern::EmptyList | ResolvedPattern::Cons(_, _)
+        )
+    })
 }
 
 /// Emit a match on a list (seq) as if-then-else with seq operations.
@@ -654,9 +662,12 @@ fn emit_list_match(
     let cons_arm = arms
         .iter()
         .find(|a| matches!(a.pattern, ResolvedPattern::Cons(_, _)));
-    let wildcard_arm = arms
-        .iter()
-        .find(|a| matches!(a.pattern, ResolvedPattern::Wildcard | ResolvedPattern::Ident(_)));
+    let wildcard_arm = arms.iter().find(|a| {
+        matches!(
+            a.pattern,
+            ResolvedPattern::Wildcard | ResolvedPattern::Ident(_)
+        )
+    });
 
     let empty_body = if let Some(arm) = empty_arm {
         emit_expr(&arm.body, ctx)

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -135,27 +135,41 @@ fn transpile_unified(ctx: &CodegenContext) -> ProjectOutput {
             .and_then(|fd| crate::codegen::common::fn_owning_scope_for(ctx, fd))
             .map(|s| s.to_string())
             .unwrap_or_default();
-        // Try native `decreases` tuple first — when every member has a
-        // sizeOf-measurable parameter and a classifier rank, the SCC
-        // emits as plain mutual functions and proofs over concrete
-        // values no longer hit the fuel-encoding's symbolic-unfolding
-        // ceiling (BigInt's 10⁹ pairs close as real samples instead of
-        // needing the literal-magnitude cutoff). Falls back to fuel
-        // when the SCC has a non-sizeOf member.
-        if let Some(code) = fuel::emit_mutual_native_decreases_group(&scc_fns, ctx) {
-            fuel_per_scope.entry(scope).or_default().push(code);
-            insert_fn_ids(&mut native_emitted, &scc_fns);
+        // Mutual SCC emit resolves fn bodies through `emit_fn_body` →
+        // `emit_expr_legacy`, which falls back to
+        // `ctx.active_module_scope()` when no explicit scope is passed.
+        // Wrap the fuel/native dispatch in `with_module_scope` so a
+        // module-owned mutual group doesn't resolve as if it were
+        // entry-scope (same shape as the pure-fn path in
+        // `route_pure_components_per_scope` below).
+        let scope_opt = if scope.is_empty() {
+            None
         } else {
-            match fuel::emit_mutual_fuel_group(&scc_fns, ctx) {
-                Some(code) => {
-                    fuel_per_scope.entry(scope).or_default().push(code);
-                    insert_fn_ids(&mut fuel_emitted, &scc_fns);
-                }
-                None => {
-                    insert_fn_ids(&mut axiom_fn_ids, &scc_fns);
+            Some(scope.as_str())
+        };
+        ctx.with_module_scope(scope_opt, || {
+            // Try native `decreases` tuple first — when every member has a
+            // sizeOf-measurable parameter and a classifier rank, the SCC
+            // emits as plain mutual functions and proofs over concrete
+            // values no longer hit the fuel-encoding's symbolic-unfolding
+            // ceiling (BigInt's 10⁹ pairs close as real samples instead of
+            // needing the literal-magnitude cutoff). Falls back to fuel
+            // when the SCC has a non-sizeOf member.
+            if let Some(code) = fuel::emit_mutual_native_decreases_group(&scc_fns, ctx) {
+                fuel_per_scope.entry(scope.clone()).or_default().push(code);
+                insert_fn_ids(&mut native_emitted, &scc_fns);
+            } else {
+                match fuel::emit_mutual_fuel_group(&scc_fns, ctx) {
+                    Some(code) => {
+                        fuel_per_scope.entry(scope.clone()).or_default().push(code);
+                        insert_fn_ids(&mut fuel_emitted, &scc_fns);
+                    }
+                    None => {
+                        insert_fn_ids(&mut axiom_fn_ids, &scc_fns);
+                    }
                 }
             }
-        }
+        });
     }
 
     let needs_axiom_for_error_prop = |fd: &FnDef| -> bool {

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -190,11 +190,14 @@ fn transpile_unified(ctx: &CodegenContext) -> ProjectOutput {
     let mut pure_per_scope = crate::codegen::common::route_pure_components_per_scope(
         ctx,
         |fd| fd.effects.is_empty() && fd.name != "main",
-        |comp, _scope| {
-            comp.iter()
-                .map(|fd| emit_pure_or_axiom(fd))
-                .filter(|s| !s.is_empty())
-                .collect()
+        |comp, scope| {
+            let scope_opt = if scope.is_empty() { None } else { Some(scope) };
+            ctx.with_module_scope(scope_opt, || {
+                comp.iter()
+                    .map(|fd| emit_pure_or_axiom(fd))
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
         },
     );
 
@@ -204,13 +207,15 @@ fn transpile_unified(ctx: &CodegenContext) -> ProjectOutput {
     // ---- Per-module files (collected into the shared module tree) ----
     for module in &ctx.modules {
         let mut sections: Vec<String> = Vec::new();
-        for td in &module.type_defs {
-            if let Some(code) =
-                toplevel::emit_type_def_in_scope(td, ctx, Some(module.prefix.as_str()))
-            {
-                sections.push(code);
+        ctx.with_module_scope(Some(module.prefix.as_str()), || {
+            for td in &module.type_defs {
+                if let Some(code) =
+                    toplevel::emit_type_def_in_scope(td, ctx, Some(module.prefix.as_str()))
+                {
+                    sections.push(code);
+                }
             }
-        }
+        });
         sections.extend(pure_per_scope.take(&module.prefix));
         if let Some(fuel) = fuel_per_scope.get(&module.prefix) {
             sections.extend(fuel.clone());

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1602,7 +1602,8 @@ pub fn emit_verify_law(
                 let guard = bindings
                     .iter()
                     .map(|(n, v)| {
-                        let val = literal_int_value(v).unwrap_or_else(|| emit_expr_legacy(v, ctx, None));
+                        let val =
+                            literal_int_value(v).unwrap_or_else(|| emit_expr_legacy(v, ctx, None));
                         format!("{} == {}", aver_name_to_dafny(n), val)
                     })
                     .collect::<Vec<_>>()

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -4,7 +4,7 @@ use crate::codegen::CodegenContext;
 use crate::codegen::common::parse_type_annotation;
 use crate::types::Type;
 
-use super::expr::{aver_name_to_dafny, emit_expr};
+use super::expr::{aver_name_to_dafny, emit_expr_legacy};
 
 /// Emit a Dafny type from an Aver type annotation string.
 /// Ghost-predicate names emitted by `oracle_subtypes::dafny_subtype_predicates`
@@ -155,7 +155,7 @@ pub fn emit_type_def_in_scope(
             if let Some(decl) = crate::codegen::common::find_refined_type_scoped(ctx, name, scope)
                 && decl.carrier_type == "Int"
             {
-                let predicate = super::expr::emit_expr(&decl.invariant.expr, ctx);
+                let predicate = super::expr::emit_expr_legacy(&decl.invariant.expr, ctx, None);
                 let bind = aver_name_to_dafny(&decl.predicate_param);
                 let witness = decl.witness.clone().unwrap_or_else(|| "0".to_string());
                 return Some(format!(
@@ -284,7 +284,7 @@ fn emit_block_as_expr(stmts: &[Stmt], ctx: &CodegenContext) -> String {
     if stmts.len() == 1
         && let Stmt::Expr(expr) = &stmts[0]
     {
-        return emit_expr(expr, ctx);
+        return emit_expr_legacy(expr, ctx, None);
     }
 
     // For blocks with bindings, collect them and emit the last expression
@@ -294,7 +294,7 @@ fn emit_block_as_expr(stmts: &[Stmt], ctx: &CodegenContext) -> String {
     for (i, stmt) in stmts.iter().enumerate() {
         match stmt {
             Stmt::Binding(name, type_ann, expr) => {
-                let mut val = emit_expr(expr, ctx);
+                let mut val = emit_expr_legacy(expr, ctx, None);
                 // Map<T, Unit> binding initialized with Map.empty → set literal
                 if let Some(ann) = type_ann
                     && crate::codegen::common::is_set_annotation(ann)
@@ -306,7 +306,7 @@ fn emit_block_as_expr(stmts: &[Stmt], ctx: &CodegenContext) -> String {
             }
             Stmt::Expr(expr) => {
                 if i == stmts.len() - 1 {
-                    final_expr = Some(emit_expr(expr, ctx));
+                    final_expr = Some(emit_expr_legacy(expr, ctx, None));
                 }
             }
         }
@@ -999,8 +999,8 @@ pub fn emit_law_samples(
             )
             .collect();
         for (idx, (lhs_rw, rhs_rw)) in rewritten.iter().enumerate() {
-            let l = emit_expr(lhs_rw, ctx);
-            let r = emit_expr(rhs_rw, ctx);
+            let l = emit_expr_legacy(lhs_rw, ctx, None);
+            let r = emit_expr_legacy(rhs_rw, ctx, None);
             let mut callees = std::collections::BTreeSet::new();
             collect_called_fns(lhs_rw, &mut callees);
             collect_called_fns(rhs_rw, &mut callees);
@@ -1094,8 +1094,8 @@ pub fn emit_law_samples(
             fn_name, law_name, suffix
         ));
         for (lhs_rw, rhs_rw) in &rewritten {
-            let l = emit_expr(lhs_rw, ctx);
-            let r = emit_expr(rhs_rw, ctx);
+            let l = emit_expr_legacy(lhs_rw, ctx, None);
+            let r = emit_expr_legacy(rhs_rw, ctx, None);
             // `{:split_here}` tells Dafny to check the preceding assert as
             // its own VC — without it, Z3 accumulates hypothesis state
             // across all samples in the method and occasionally times out
@@ -1459,8 +1459,8 @@ pub fn emit_verify_law(
         )
     };
 
-    let lhs = emit_expr(&law_lhs, ctx);
-    let rhs = emit_expr(&law_rhs, ctx);
+    let lhs = emit_expr_legacy(&law_lhs, ctx, None);
+    let rhs = emit_expr_legacy(&law_rhs, ctx, None);
 
     let mut lines = Vec::new();
     // Collect all functions used in the law for fuel annotations
@@ -1535,7 +1535,7 @@ pub fn emit_verify_law(
             ctx,
         );
         if !when_redundant {
-            let when_str = emit_expr(when_expr, ctx);
+            let when_str = emit_expr_legacy(when_expr, ctx, None);
             lines.push(format!("  requires {}", when_str));
         }
     }
@@ -1602,7 +1602,7 @@ pub fn emit_verify_law(
                 let guard = bindings
                     .iter()
                     .map(|(n, v)| {
-                        let val = literal_int_value(v).unwrap_or_else(|| emit_expr(v, ctx));
+                        let val = literal_int_value(v).unwrap_or_else(|| emit_expr_legacy(v, ctx, None));
                         format!("{} == {}", aver_name_to_dafny(n), val)
                     })
                     .collect::<Vec<_>>()

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -227,9 +227,12 @@ mod tests {
     #[test]
     fn list_len_annotates_empty_list_in_theorem_friendly_form() {
         let ctx = empty_ctx();
-        let emitted =
-            emit_builtin_call("List.len", &[Spanned::bare(ResolvedExpr::List(vec![]))], &ctx)
-                .expect("List.len should be emitted");
+        let emitted = emit_builtin_call(
+            "List.len",
+            &[Spanned::bare(ResolvedExpr::List(vec![]))],
+            &ctx,
+        )
+        .expect("List.len should be emitted");
 
         assert_eq!(emitted, "(([] : List Unit)).length");
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -557,7 +557,9 @@ impl CodegenContext {
     /// wrap their per-module emit calls with this so legacy
     /// resolve-on-demand adapters see the correct prefix.
     pub fn with_module_scope<R>(&self, scope: Option<&str>, f: impl FnOnce() -> R) -> R {
-        let prev = self.current_module_scope.replace(scope.map(|s| s.to_string()));
+        let prev = self
+            .current_module_scope
+            .replace(scope.map(|s| s.to_string()));
         let out = f();
         *self.current_module_scope.borrow_mut() = prev;
         out

--- a/src/self_host/main.rs
+++ b/src/self_host/main.rs
@@ -25,6 +25,13 @@ pub use replay_support::*;
 
 mod self_host_support;
 
+// Generated Rust from `aver compile self_hosted/main.av --target rust`.
+// The macro expansion of `aver_list_match!` always wraps each arm body
+// in `{ ... }`, even when the body is already a block-like return — so
+// `unused_braces` lights up across every file in the tree. It's a
+// template artifact, not actionable at the source level, so silence it
+// locally to keep `cargo clippy --all-targets -- -D warnings` clean.
+#[allow(unused_braces)]
 pub mod aver_generated;
 
 fn main() {


### PR DESCRIPTION
> Stacked on #165 (PR 10) — merge that first.

## Summary
- Migrates the Dafny rendering layer (`expr.rs`) from raw `ast::Expr`/`Pattern` to the resolved IR. `emit_expr` walks `ResolvedExpr`; `emit_fn_call` dispatches on `ResolvedCallee::{Builtin, Fn, LocalSlot, Unresolved, Intrinsic}` via the symbol table; `emit_constructor` walks `ResolvedCtor::{Builtin, User}` with full arg lists. `Fn(fn_id)` lookups route dep-module fns through `super::dafny_module_name(prefix)`.
- Fixes a latent emit regression: the old `emit_constructor` took `arg: Option<&Spanned<Expr>>` because the AST historically encoded multi-arg constructors via `FnCall(Attr(Type, Variant), [a,b])`. The resolver lifts every form into `ResolvedCtor`, so the Dafny emitter now renders every arg — `ParseResult.Ok(json, pos)` against a `(Json, int)` datatype no longer collapses to single-arg `ParseResult.Ok(json)`. Caught by `proof_dafny_verifies_json_when_dafny_is_available`.
- Source-shape adapters `emit_{expr,pattern}_legacy` resolve on demand for the remaining `Spanned<ast::Expr>` callers (refinement-type invariants, law theorems, mutual fuel groups). The per-module dispatcher in `transpile_unified` wraps emit calls with `ctx.with_module_scope(...)` so legacy callers passing `None` fall back to the active scope — same plumbing PR 10 introduced for Lean.
- `is_unit_expr` / `is_unit_expr_spanned` (AST helpers in `common.rs`) deleted — `is_unit_expr_resolved` is the only consumer after both backends migrated.

## Test plan
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` clean
- [x] `cargo test --features wasm --no-fail-fast` — 1653 passed, 0 failed (initial run caught the JSON ParseResult bug; second pass green)
- [x] Lean+Dafny proof artifacts byte-identical (md5) on nine baseline fixtures: calculator, fibonacci, hostile_order_axis, json, lambda, quicksort, shapes, temperature, user_record

🤖 Generated with [Claude Code](https://claude.com/claude-code)