### PR TITLE
codegen: ResolvedProgramView + consolidated build_context — #170 Phase 1

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -2703,6 +2703,7 @@ mod tests {
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
         };
         ctx.proof_ir
             .refined_types

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -739,6 +739,7 @@ mod tests {
             project_name.to_string(),
             vec![],
             pipeline_result.symbol_table,
+            pipeline_result.resolved_items,
         );
         if let Some(ir) = proof_ir {
             ctx.proof_ir = ir;

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -206,6 +206,7 @@ mod tests {
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
         }
     }
 

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1581,6 +1581,7 @@ mod tests {
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
         }
     }
 
@@ -1633,6 +1634,7 @@ mod tests {
             project_name.to_string(),
             vec![],
             pipeline_result.symbol_table,
+            pipeline_result.resolved_items,
         );
         if let Some(ir) = proof_ir {
             ctx.proof_ir = ir;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -10,6 +10,7 @@ pub mod common;
 pub mod dafny;
 #[cfg(feature = "runtime")]
 pub mod lean;
+pub mod program_view;
 #[cfg(feature = "runtime")]
 pub mod proof_lower;
 #[cfg(feature = "runtime")]
@@ -201,6 +202,20 @@ pub struct CodegenContext {
     /// `TypeId` namespace, matching the VM compiler's
     /// `integrate_module` shape.
     pub resolved_module_fn_defs: Vec<Vec<crate::ir::hir::ResolvedFnDef>>,
+    /// Canonical resolved-program view of the whole codegen input —
+    /// entry items (post-pipeline `NameResolve`) + per-dep-module
+    /// resolved fn defs + `FnId`-keyed lookup.
+    ///
+    /// **Epic #170 Phase 1 invariant.** `resolved_program` is the
+    /// primary source of truth for backend codegen — `fn_defs`,
+    /// `type_defs`, `items`, `resolved_fn_defs`, and
+    /// `resolved_module_fn_defs` remain available as projection /
+    /// source metadata / migration cache, but consumers should reach
+    /// the view first when an `FnId` / `TypeId` is in hand. Subsequent
+    /// phases (#170 Phase 3+) migrate backends to iterate the view as
+    /// their primary input; this field is the foundation those PRs
+    /// build on.
+    pub resolved_program: crate::codegen::program_view::ResolvedProgramView,
 }
 
 /// Output files from a codegen backend.
@@ -225,6 +240,7 @@ pub struct ProjectOutput {
 /// one available. The ad-hoc test helpers that drive a stripped
 /// pipeline build their own via `SymbolTable::build(&items,
 /// &modules)` and pass it here.
+#[allow(clippy::too_many_arguments)]
 pub fn build_context(
     items: Vec<TopLevel>,
     tc_result: &TypeCheckResult,
@@ -233,6 +249,7 @@ pub fn build_context(
     project_name: String,
     modules: Vec<ModuleInfo>,
     symbol_table: crate::ir::SymbolTable,
+    resolved_items: Vec<crate::ir::hir::ResolvedTopLevel>,
 ) -> CodegenContext {
     let type_defs: Vec<TypeDef> = items
         .iter()
@@ -481,29 +498,25 @@ pub fn build_context(
         );
     }
 
-    // Resolved-HIR lift of every fn def (entry + each dep), against
-    // the entry's symbol table. The Rust backend (#147 phase E PR 8)
-    // consumes these from `ctx.resolved_fn_defs` /
-    // `ctx.resolved_module_fn_defs`; tests + helper paths that build
-    // a ctx piecewise refresh them via `CodegenContext::refresh_facts`.
-    let resolved_fn_defs: Vec<crate::ir::hir::ResolvedFnDef> = {
-        let entry_ctx = crate::ir::hir::ResolveCtx::new(&symbol_table);
-        fn_defs
-            .iter()
-            .filter_map(|fd| crate::ir::hir::resolve_fn_def_external(&entry_ctx, fd))
-            .collect()
-    };
-    let resolved_module_fn_defs: Vec<Vec<crate::ir::hir::ResolvedFnDef>> = modules
+    // Epic #170 Phase 1: build the canonical `ResolvedProgramView`
+    // once, from the pipeline's already-resolved entry items + the
+    // dep modules' AST fn defs. The view does the module-side
+    // resolution (pinning `ResolveCtx.current_module = Some(prefix)`)
+    // — that's the only producer in the codebase. `resolved_fn_defs`
+    // / `resolved_module_fn_defs` then project FROM the view rather
+    // than running an independent second resolve, eliminating the
+    // "two truths" hazard build_context carried since PR 9.
+    let resolved_program = crate::codegen::program_view::ResolvedProgramView::build(
+        resolved_items,
+        &modules,
+        &symbol_table,
+    );
+    let resolved_fn_defs: Vec<crate::ir::hir::ResolvedFnDef> =
+        resolved_program.entry_fns().cloned().collect();
+    let resolved_module_fn_defs: Vec<Vec<crate::ir::hir::ResolvedFnDef>> = resolved_program
+        .modules
         .iter()
-        .map(|module| {
-            let mut module_ctx = crate::ir::hir::ResolveCtx::new(&symbol_table);
-            module_ctx.current_module = Some(module.prefix.clone());
-            module
-                .fn_defs
-                .iter()
-                .filter_map(|fd| crate::ir::hir::resolve_fn_def_external(&module_ctx, fd))
-                .collect()
-        })
+        .map(|m| m.fn_defs.clone())
         .collect();
 
     let ctx = CodegenContext {
@@ -539,6 +552,7 @@ pub fn build_context(
         resolved_fn_defs,
         resolved_module_fn_defs,
         current_module_scope: std::cell::RefCell::new(None),
+        resolved_program,
     };
     // ProofIR no longer populated here. Pipeline owns the lowerings
     // (`PipelineStage::RefinementLower`, `PipelineStage::ContractLower`);
@@ -653,27 +667,26 @@ impl CodegenContext {
         // need for `recursive_fns` / `mutual_tco_members`.
         self.symbol_table = symbol_table;
 
-        // Refresh the resolved-HIR mirror of every fn def so the
-        // backend (#147 phase E PR 8) sees the same shape
-        // `build_context` would have produced from scratch.
-        let entry_resolve_ctx = crate::ir::hir::ResolveCtx::new(&self.symbol_table);
-        self.resolved_fn_defs = self
-            .fn_defs
-            .iter()
-            .filter_map(|fd| crate::ir::hir::resolve_fn_def_external(&entry_resolve_ctx, fd))
-            .collect();
+        // Rebuild the canonical resolved view from the current items
+        // + modules (post-PR-A: this is the single source for resolved
+        // bodies). Entry-side resolved items are produced by
+        // `resolve_program`, then the view runs the per-dep-module
+        // resolve internally and indexes everything by `FnId`. The
+        // `resolved_fn_defs` / `resolved_module_fn_defs` mirrors below
+        // are projections of this view, kept for callsites that still
+        // walk them directly during the #170 backend-migration arc.
+        let entry_resolved_items = crate::ir::hir::resolve_program(&self.symbol_table, &self.items);
+        self.resolved_program = crate::codegen::program_view::ResolvedProgramView::build(
+            entry_resolved_items,
+            &self.modules,
+            &self.symbol_table,
+        );
+        self.resolved_fn_defs = self.resolved_program.entry_fns().cloned().collect();
         self.resolved_module_fn_defs = self
+            .resolved_program
             .modules
             .iter()
-            .map(|module| {
-                let mut module_ctx = crate::ir::hir::ResolveCtx::new(&self.symbol_table);
-                module_ctx.current_module = Some(module.prefix.clone());
-                module
-                    .fn_defs
-                    .iter()
-                    .filter_map(|fd| crate::ir::hir::resolve_fn_def_external(&module_ctx, fd))
-                    .collect()
-            })
+            .map(|m| m.fn_defs.clone())
             .collect();
 
         // ProofIR's `fn_contracts` / `refined_types` are derived from
@@ -731,20 +744,17 @@ impl CodegenContext {
             None => FnKey::entry(fd.name.clone()),
         };
         if let Some(fn_id) = self.symbol_table.fn_id_of(&key) {
-            // Resolved tables are dense in the order each scope's
-            // `build_context` populated them; the only authoritative
-            // way to find the right slot is `fn_id` equality.
-            if let Some(rfd) = self.resolved_fn_defs.iter().find(|rfd| rfd.fn_id == fn_id) {
+            // Canonical lookup goes through the resolved-program view —
+            // its `fn_by_id` index is the single FnId-keyed source for
+            // the resolved body, replacing the dual-walk over
+            // `resolved_fn_defs` + `resolved_module_fn_defs` that
+            // predated #170 Phase 1.
+            if let Some(rfd) = self.resolved_program.fn_by_id(fn_id) {
                 return Cow::Borrowed(rfd);
             }
-            for module in &self.resolved_module_fn_defs {
-                if let Some(rfd) = module.iter().find(|rfd| rfd.fn_id == fn_id) {
-                    return Cow::Borrowed(rfd);
-                }
-            }
-            // Symbol table knew the key but resolver didn't lift a
-            // resolved entry. Falls through to the synthetic-fallback
-            // path below; in production this shouldn't happen.
+            // Symbol table knew the key but the view didn't index it.
+            // Falls through to the synthetic-fallback path below; in
+            // production this shouldn't happen.
         }
 
         // Synthetic FnDef path — memo wrappers, TCO hoist rewrites,

--- a/src/codegen/program_view.rs
+++ b/src/codegen/program_view.rs
@@ -1,0 +1,281 @@
+//! Canonical resolved view of the program for codegen consumers.
+//!
+//! Single source of truth for "what does the program look like, after
+//! name resolution, with module/entry scope preserved". Backends that
+//! used to walk `CodegenContext.{items, fn_defs, type_defs}` (raw
+//! `ast::*`) should iterate this view's resolved fn defs instead. The
+//! AST-shape fields on `CodegenContext` remain available as source
+//! metadata (spans, diagnostics, syntax-discovery), not as the
+//! authoritative backend input.
+//!
+//! ## Construction
+//!
+//! Built once at the codegen boundary:
+//! - **Entry slice** projects from `PipelineResult.resolved_items` —
+//!   the resolver pass populates this unconditionally, so we just
+//!   pick out the `ResolvedTopLevel::FnDef` variants and clone the
+//!   resolved fn defs out of them. No re-resolve.
+//! - **Module slice** resolves each dep module's `&[FnDef]` through
+//!   `resolve_fn_def_external` under a `ResolveCtx` pinned to that
+//!   module's prefix. This is the only producer of resolved module
+//!   bodies — `CodegenContext.resolved_module_fn_defs` is a
+//!   projection / cache of this view, not an independent source.
+//!
+//! ## Lookups
+//!
+//! The view exposes `fn_by_id(FnId)` so callsites that have an opaque
+//! `FnId` in hand (typical for identity-sensitive emit) can recover
+//! the resolved body without round-tripping through bare names.
+//! Iteration is provided per-scope: `entry_fns()` walks the entry
+//! slice; `module_fns(prefix)` walks one dep module's slice.
+//!
+//! Epic #170 Phase 1: this is the foundation every later phase
+//! builds on. Backends migrate to consuming the view as primary
+//! input in subsequent PRs; this PR only consolidates the producer
+//! side without touching backend signatures.
+
+use std::collections::HashMap;
+
+use crate::codegen::ModuleInfo;
+use crate::ir::SymbolTable;
+use crate::ir::hir::{ResolveCtx, ResolvedFnDef, ResolvedTopLevel, resolve_fn_def_external};
+
+/// Resolved-form mirror of one dep module's fn defs, with the
+/// module's prefix preserved so per-scope iteration is cheap and the
+/// view can build an `FnId`-keyed lookup without losing scope.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedModuleFns {
+    /// Module prefix (e.g. `"Models.User"`). Same value as
+    /// `ModuleInfo.prefix` on the AST side.
+    pub prefix: String,
+    /// Resolved fn defs in module source order — position-aligned
+    /// with `ModuleInfo.fn_defs` for the rare consumer that needs
+    /// to pair AST and resolved forms side-by-side.
+    pub fn_defs: Vec<ResolvedFnDef>,
+}
+
+/// Canonical resolved-program view consumed by codegen.
+///
+/// Holds the entry-scope items (post-pipeline, post-NameResolve) plus
+/// each dep module's resolved fn defs, with an `FnId` index so
+/// identity-keyed lookups don't walk linearly.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedProgramView {
+    /// Entry-scope resolved items, exactly as the pipeline produced
+    /// them. Includes `FnDef`, `Module` markers, and `Passthrough`
+    /// variants (verify/decision/typedef nodes that haven't been
+    /// promoted to resolved form yet — see [`ResolvedTopLevel`]).
+    pub entry_items: Vec<ResolvedTopLevel>,
+    /// Per-dep-module resolved fn defs. Order matches the input
+    /// `Vec<ModuleInfo>` so existing position-keyed consumers still
+    /// work during migration.
+    pub modules: Vec<ResolvedModuleFns>,
+    /// `FnId → (scope, ResolvedFnDef index)` index. The opaque
+    /// `FnId` keys (built by `SymbolTable` at pipeline head) are the
+    /// canonical identity primitive — every consumer that has an
+    /// `FnId` in hand should reach this map instead of bare-name
+    /// matching against `entry_items`.
+    fn_index: HashMap<crate::ir::FnId, FnIndexEntry>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FnIndexEntry {
+    /// `None` = entry scope; `Some(i)` = `modules[i]`.
+    module: Option<usize>,
+    /// Position inside the owning slice's `fn_defs`.
+    pos: usize,
+}
+
+impl ResolvedProgramView {
+    /// Build the view from a pipeline-produced entry slice and the
+    /// `Vec<ModuleInfo>` carrying dep modules' AST fn defs. The
+    /// caller has already run `pipeline::run` (or equivalent) and is
+    /// passing through the canonical `resolved_items` — we do not
+    /// re-resolve the entry side. Module fn defs are resolved here
+    /// (the pipeline doesn't walk them), pinning
+    /// `ResolveCtx.current_module` to each module's prefix so a
+    /// dotted reference inside one module's body resolves through
+    /// that module's import set first.
+    pub fn build(
+        entry_items: Vec<ResolvedTopLevel>,
+        modules: &[ModuleInfo],
+        symbol_table: &SymbolTable,
+    ) -> Self {
+        let module_views: Vec<ResolvedModuleFns> = modules
+            .iter()
+            .map(|module| {
+                let mut rctx = ResolveCtx::new(symbol_table);
+                rctx.current_module = Some(module.prefix.clone());
+                let fn_defs = module
+                    .fn_defs
+                    .iter()
+                    .filter_map(|fd| resolve_fn_def_external(&rctx, fd))
+                    .collect();
+                ResolvedModuleFns {
+                    prefix: module.prefix.clone(),
+                    fn_defs,
+                }
+            })
+            .collect();
+
+        let mut fn_index: HashMap<crate::ir::FnId, FnIndexEntry> = HashMap::new();
+        for (pos, item) in entry_items.iter().enumerate() {
+            if let ResolvedTopLevel::FnDef(rfd) = item {
+                fn_index.insert(rfd.fn_id, FnIndexEntry { module: None, pos });
+            }
+        }
+        for (i, m) in module_views.iter().enumerate() {
+            for (pos, rfd) in m.fn_defs.iter().enumerate() {
+                fn_index.insert(
+                    rfd.fn_id,
+                    FnIndexEntry {
+                        module: Some(i),
+                        pos,
+                    },
+                );
+            }
+        }
+
+        Self {
+            entry_items,
+            modules: module_views,
+            fn_index,
+        }
+    }
+
+    /// Resolved entry-scope fn defs in source order — the same set
+    /// `CodegenContext.resolved_fn_defs` projected today, just
+    /// reached through the canonical view.
+    pub fn entry_fns(&self) -> impl Iterator<Item = &ResolvedFnDef> + '_ {
+        self.entry_items.iter().filter_map(|item| match item {
+            ResolvedTopLevel::FnDef(rfd) => Some(rfd),
+            _ => None,
+        })
+    }
+
+    /// Resolved fn defs from one dep module, in source order.
+    /// Returns an empty iterator when no module with that prefix is
+    /// present — callers that need an existence check should use
+    /// [`Self::module`] instead.
+    pub fn module_fns(&self, prefix: &str) -> impl Iterator<Item = &ResolvedFnDef> + '_ {
+        self.modules
+            .iter()
+            .find(|m| m.prefix == prefix)
+            .into_iter()
+            .flat_map(|m| m.fn_defs.iter())
+    }
+
+    /// Whole module slice (prefix + resolved fns) for callsites that
+    /// need the prefix alongside.
+    pub fn module(&self, prefix: &str) -> Option<&ResolvedModuleFns> {
+        self.modules.iter().find(|m| m.prefix == prefix)
+    }
+
+    /// `FnId`-keyed lookup. Returns the resolved fn def regardless
+    /// of scope — identity-sensitive consumers (proof emitter,
+    /// inliner, monomorph) reach this rather than walking entry +
+    /// modules manually.
+    pub fn fn_by_id(&self, id: crate::ir::FnId) -> Option<&ResolvedFnDef> {
+        let entry = *self.fn_index.get(&id)?;
+        match entry.module {
+            None => {
+                let item = self.entry_items.get(entry.pos)?;
+                match item {
+                    ResolvedTopLevel::FnDef(rfd) => Some(rfd),
+                    _ => None,
+                }
+            }
+            Some(i) => self.modules.get(i)?.fn_defs.get(entry.pos),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{FnBody, FnDef, Module, Spanned, TopLevel};
+    use crate::codegen::ModuleInfo;
+    use crate::ir::SymbolTable;
+
+    fn mk_fn(name: &str) -> FnDef {
+        FnDef {
+            name: name.to_string(),
+            line: 1,
+            params: vec![],
+            return_type: "Int".to_string(),
+            effects: vec![],
+            desc: None,
+            body: std::sync::Arc::new(FnBody::Block(vec![crate::ast::Stmt::Expr(Spanned::bare(
+                crate::ast::Expr::Literal(crate::ast::Literal::Int(0)),
+            ))])),
+            resolution: None,
+        }
+    }
+
+    fn mk_module(prefix: &str, fn_names: &[&str]) -> ModuleInfo {
+        ModuleInfo {
+            prefix: prefix.to_string(),
+            depends: vec![],
+            type_defs: vec![],
+            fn_defs: fn_names.iter().map(|n| mk_fn(n)).collect(),
+            analysis: None,
+        }
+    }
+
+    #[test]
+    fn view_indexes_entry_fns_by_fn_id() {
+        let entry_items = vec![TopLevel::FnDef(mk_fn("foo")), TopLevel::FnDef(mk_fn("bar"))];
+        let symbol_table = SymbolTable::build(&entry_items, &[]);
+        let resolved = crate::ir::hir::resolve_program(&symbol_table, &entry_items);
+        let view = ResolvedProgramView::build(resolved, &[], &symbol_table);
+
+        assert_eq!(view.entry_fns().count(), 2);
+        let foo_id = symbol_table
+            .fn_id_of(&crate::ir::FnKey::entry("foo"))
+            .expect("foo entry FnId");
+        let bar_id = symbol_table
+            .fn_id_of(&crate::ir::FnKey::entry("bar"))
+            .expect("bar entry FnId");
+        assert_eq!(view.fn_by_id(foo_id).map(|f| f.name.as_str()), Some("foo"));
+        assert_eq!(view.fn_by_id(bar_id).map(|f| f.name.as_str()), Some("bar"));
+    }
+
+    #[test]
+    fn cross_module_same_bare_name_disambiguates_by_fn_id() {
+        // The whole point of this view: two modules with a `walker`
+        // fn must NOT collide. The `FnId` lookup picks the right
+        // resolved body for each.
+        let entry_items: Vec<TopLevel> = vec![TopLevel::Module(Module {
+            name: "Entry".to_string(),
+            line: 1,
+            depends: vec!["A".to_string(), "B".to_string()],
+            exposes: vec![],
+            exposes_opaque: vec![],
+            exposes_line: None,
+            intent: "Test".to_string(),
+            effects: None,
+            effects_line: None,
+        })];
+        let modules = vec![mk_module("A", &["walker"]), mk_module("B", &["walker"])];
+        let symbol_table = SymbolTable::build(&entry_items, &modules);
+        let resolved = crate::ir::hir::resolve_program(&symbol_table, &entry_items);
+        let view = ResolvedProgramView::build(resolved, &modules, &symbol_table);
+
+        let a_id = symbol_table
+            .fn_id_of(&crate::ir::FnKey::in_module("A".to_string(), "walker"))
+            .expect("A.walker FnId");
+        let b_id = symbol_table
+            .fn_id_of(&crate::ir::FnKey::in_module("B".to_string(), "walker"))
+            .expect("B.walker FnId");
+        assert_ne!(a_id, b_id, "FnIds must be distinct across modules");
+
+        let a_walker = view.fn_by_id(a_id).expect("A.walker present");
+        let b_walker = view.fn_by_id(b_id).expect("B.walker present");
+        assert_eq!(a_walker.name, "walker");
+        assert_eq!(b_walker.name, "walker");
+        assert_eq!(a_walker.fn_id, a_id);
+        assert_eq!(b_walker.fn_id, b_id);
+        assert_eq!(view.module_fns("A").count(), 1);
+        assert_eq!(view.module_fns("B").count(), 1);
+    }
+}

--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -1044,6 +1044,7 @@ mod tests {
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
         }
     }
 

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -639,6 +639,7 @@ mod tests {
         // SymbolTable so build_context can populate its FnId-keyed
         // sets. Cheap traversal, no analysis.
         let symbol_table = crate::ir::SymbolTable::build(&items, &[]);
+        let resolved_items = crate::ir::hir::resolve_program(&symbol_table, &items);
         build_context(
             items,
             &tc,
@@ -647,6 +648,7 @@ mod tests {
             project_name.to_string(),
             vec![],
             symbol_table,
+            resolved_items,
         )
     }
 

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -3036,6 +3036,7 @@ mod tests {
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
         }
     }
 

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -2561,6 +2561,7 @@ fn build_codegen_context(
         name,
         modules,
         pipeline_result.symbol_table,
+        pipeline_result.resolved_items,
     );
     #[cfg(feature = "runtime")]
     if let Some(ir) = prebuilt_proof_ir {
@@ -4989,6 +4990,7 @@ mod tests {
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            resolved_program: aver::codegen::program_view::ResolvedProgramView::default(),
         }
     }
 

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -298,6 +298,7 @@ fn build_ctx(
         "playground".to_string(),
         vec![],
         pipeline_result.symbol_table,
+        pipeline_result.resolved_items,
     );
     if let Some(ir) = proof_ir {
         ctx.proof_ir = ir;
@@ -394,6 +395,7 @@ fn build_project_ctx(
         "playground".to_string(),
         modules,
         pipeline_result.symbol_table,
+        pipeline_result.resolved_items,
     );
     if let Some(ir) = proof_ir {
         ctx.proof_ir = ir;

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -65,6 +65,7 @@ fn build_ctx(src: &str) -> CodegenContext {
         "diff".to_string(),
         vec![],
         pipeline_result.symbol_table,
+        pipeline_result.resolved_items,
     );
     if let Some(ir) = proof_ir {
         ctx.proof_ir = ir;


### PR DESCRIPTION
> Foundation PR for epic #170 ("HIR as canonical backend input"). No backend signatures change — just consolidating the producer side so there's **one source of truth** for resolved fn defs from the pipeline boundary forward.

Closes the duplicate-resolve hazard called out in the epic audit: pre-PR-A, `build_context` re-ran `resolve_fn_def_external` per fn_def even though `pipeline_result.resolved_items` already carried the entry-side resolved form.

## What this PR does

1. **`src/codegen/program_view.rs`** introduces `ResolvedProgramView` — the canonical resolved-form mirror of a codegen input. Carries entry items (post-`NameResolve`), per-dep-module resolved fn defs, and an `FnId`-keyed lookup index.
2. **`build_context`** now takes `resolved_items: Vec<ResolvedTopLevel>` from `PipelineResult.resolved_items` and projects through the view for the entry slice. The duplicate `resolve_fn_def_external` walk over entry `fn_defs` is gone.
3. The view is the **only producer** of resolved dep-module fn defs. `CodegenContext.{resolved_fn_defs, resolved_module_fn_defs}` are kept as compatibility projections from `ctx.resolved_program`, not independent storage.
4. **`CodegenContext::resolve_fn_def`** routes through `resolved_program.fn_by_id(fn_id)` instead of walking the two projection vectors manually.
5. **`refresh_facts`** (test-only ctx rebuilder) rebuilds the view as the single resolved source and projects to the compatibility fields.

## What this PR doesn't do (epic #170 follow-ups)

Per the epic plan: backend entry points (`rust::transpile`, `lean::transpile`, `dafny::transpile`, `wasm_gc::compile_to_wasm_gc`) still take what they took before. Migration to `&ResolvedProgramView` as the primary backend input is incremental, per backend, in subsequent phases. This PR is the foundation; future PRs swap `ctx.fn_defs.iter()` for `ctx.resolved_program.entry_fns()` one backend at a time without breaking API.

## Tests

- [x] 2 new unit tests on the view:
  - `view_indexes_entry_fns_by_fn_id`
  - `cross_module_same_bare_name_disambiguates_by_fn_id` — regression-test stake-in-the-ground for module-owned fns with bare-name twins
- [x] All 1656 tests pass (1653 pre-PR + 2 new view tests + 1 PR #169 carry-over)
- [x] Proof artifacts byte-identical across 13 baseline fixtures (calculator, fibonacci, hostile_order_axis, json, lambda, quicksort, red_black_tree, bigint, natural, natural_app, shapes, temperature, user_record)
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Epic #170 progress

- [x] **Phase 1: ResolvedProgramView + consolidated build_context** ← this PR
- [ ] Phase 2: doc invariant + refresh_facts polish
- [ ] Phase 3: first vertical slice — Rust codegen on `ctx.resolved_program`
- [ ] Phase 4: VM polish + Rust legacy adapter drops
- [ ] Phase 5: Lean + Dafny — `fd.name == n` → `fn_by_id`; verify_law `HashMap<String, &FnDef>` typed
- [ ] Phase 6: wasm-gc / wasip2 public API on view; post-link view formal
- [ ] Phase 7: proof_lower decision A (matcher API + `syntax-discovery-only` tags)
- [ ] Phase 8: guardrails test for banned patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)