### PR TITLE
codegen/lean: bare-name fn lookups → identity-keyed view path — #170 Phase 5 (PR E1)

### DIFF
--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1679,13 +1679,13 @@ fn emit_verify_trace_block_proofs(
         let lhs_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
             &fn_call,
             &synthetic_law,
-            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+            |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
             mode.clone(),
         );
         let rhs_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
             right,
             &synthetic_law,
-            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+            |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
             mode,
         );
 
@@ -1771,13 +1771,13 @@ fn emit_verify_law_block(
     let law_lhs = crate::codegen::common::rewrite_effectful_calls_in_law(
         &law.lhs,
         law,
-        |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+        |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
         crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
     );
     let law_rhs = crate::codegen::common::rewrite_effectful_calls_in_law(
         &law.rhs,
         law,
-        |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+        |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
         crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
     );
     // Refinement quantifier lift: when a given Int variable shows up
@@ -1824,7 +1824,7 @@ fn emit_verify_law_block(
         let oracle_projected = crate::codegen::common::rewrite_effectful_calls_in_law(
             expr,
             law,
-            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+            |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
             crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
         );
         // Refinement lift: bare references to lifted-given idents
@@ -2032,13 +2032,13 @@ fn emit_verify_law_block(
                 let left_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
                     left,
                     law,
-                    |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+                    |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
                     mode.clone(),
                 );
                 let right_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
                     right,
                     law,
-                    |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+                    |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
                     mode,
                 );
                 let left_str = emit_expr_legacy(&left_rw, ctx, None);
@@ -2101,13 +2101,13 @@ fn emit_verify_law_block(
         let left_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
             left,
             law,
-            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+            |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
             mode.clone(),
         );
         let right_rw = crate::codegen::common::rewrite_effectful_calls_in_law(
             right,
             law,
-            |n| ctx.fn_defs.iter().find(|fd| fd.name == n),
+            |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
             mode,
         );
         let left_str = emit_expr_legacy(&left_rw, ctx, None);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -633,6 +633,45 @@ impl CodegenContext {
     pub fn active_module_scope(&self) -> Option<String> {
         self.current_module_scope.borrow().clone()
     }
+
+    /// Identity-keyed lookup from a bare fn name + scope to the
+    /// matching `&FnDef` in `fn_defs` / `modules[i].fn_defs`. Resolves
+    /// the name through the symbol table to an `FnId` first, then
+    /// recovers the AST `FnDef` via `fn_id_for_decl` pointer-eq scope
+    /// matching — so two same-bare-name fns across modules can't
+    /// cross-resolve.
+    ///
+    /// **Epic #170 Phase 5 helper.** Replaces the
+    /// `ctx.fn_defs.iter().find(|fd| fd.name == name)` pattern that
+    /// proof-mode law / verify rewriters used pre-migration. Backends
+    /// that still need a `&FnDef` (rather than the resolved twin —
+    /// e.g. `rewrite_effectful_calls_in_law` consumes AST shape)
+    /// reach this method instead of walking by bare name.
+    ///
+    /// Returns `None` when the symbol table doesn't know the name
+    /// under the given scope, or when the resolved `FnId` doesn't
+    /// match any `&FnDef` in that scope (synthetic FnDefs added
+    /// post-pipeline fall through here — callers can fallback to a
+    /// bare-name walk over `extra_fn_defs` etc. when that matters).
+    pub fn fn_def_by_name(&self, name: &str, scope: Option<&str>) -> Option<&FnDef> {
+        use crate::ir::FnKey;
+        let key = match scope {
+            Some(prefix) => FnKey::in_module(prefix.to_string(), name),
+            None => FnKey::entry(name),
+        };
+        let fn_id = self.symbol_table.fn_id_of(&key)?;
+        let matches = |fd: &&FnDef| crate::codegen::common::fn_id_for_decl(self, fd) == Some(fn_id);
+        match scope {
+            None => self.fn_defs.iter().find(matches),
+            Some(prefix) => self
+                .modules
+                .iter()
+                .find(|m| m.prefix == prefix)?
+                .fn_defs
+                .iter()
+                .find(matches),
+        }
+    }
 }
 
 impl CodegenContext {


### PR DESCRIPTION
> First Lean migration step in Phase 5. Swaps 9 sites of `ctx.fn_defs.iter().find(|fd| fd.name == n)` to an identity-keyed helper that goes through the symbol table.

## What this PR adds

### `CodegenContext::fn_def_by_name(name, scope)` helper

Identity-keyed lookup from a bare fn name + scope to the matching `&FnDef`:
1. Build a scope-aware `FnKey` (`entry(name)` or `in_module(prefix, name)`)
2. Resolve to `FnId` via `symbol_table.fn_id_of`
3. Recover the `&FnDef` from `fn_defs` / `modules[i].fn_defs` via `fn_id_for_decl` pointer-eq scope matching

Two same-bare-name fns across modules can't cross-resolve. Returns `None` for synthetic post-pipeline FnDefs that don't live in the symbol table (callers can fall back to bare-name walks over `extra_fn_defs` etc.).

### Lean toplevel migration

9 callsites in `lean/toplevel.rs` (proof / verify law rewriter closures) swapped:
```diff
-|n| ctx.fn_defs.iter().find(|fd| fd.name == n)
+|n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref())
```

All sites feed `rewrite_effectful_calls_in_law` / oracle injection — entry-only by current grammar, but the helper honours `active_module_scope` when future module-scoped laws ship.

## What this PR doesn't do

- `emit_expr_legacy` calls in `lean/toplevel.rs` hot path stay (~30 sites) — PR E2 follow-up.
- Dafny analogous swap (7 sites) — PR F1.
- `verify_law.rs` `HashMap<String, &FnDef>` typed identity — PR F2.

## Tests

- [x] 1655 tests pass; 2 known flaky in batch (`tco_pass_exposes_typed_fields` / `proof_dafny_verifies_json_when_dafny_is_available`), both green in isolation
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Proof artifacts byte-identical (md5 diff = 0 lines) across 13 baseline fixtures

## Epic #170 progress

- [x] Phase 1-4 (#171, #172, #173, #174)
- [x] **Phase 5 PR E1: Lean toplevel bare-name lookups** ← this PR
- [ ] Phase 5 PR E2: Lean `emit_expr_legacy` hot path drop
- [ ] Phase 5 PR F1: Dafny analogous bare-name swap
- [ ] Phase 5 PR F2: `verify_law.rs` typed identity
- [ ] Phase 6: wasm-gc / wasip2 public API on view
- [ ] Phase 7: proof_lower decision A
- [ ] Phase 8: guardrails test

🤖 Generated with [Claude Code](https://claude.com/claude-code)