### PR TITLE
ci: move WASM release build + Bench Gate off PR-time CI to main-only jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,37 @@ jobs:
           PROPTEST_CASES: '2000'
         run: cargo test -p aver-lang --features wasm
 
+  wasm_release_build:
+    # Post-merge release-build verification under `--features wasm`.
+    # PR-time CI runs `cargo test --features wasm` (debug profile) in
+    # the `wasm` job above — that catches every logic regression. The
+    # release build only matters when the artifact actually ships
+    # (post-merge to `main`), and dragging it onto PR-time CI added
+    # 3–5 min of wait without ever surfacing a release-only bug in
+    # practice. If a release-mode regression slips in, a hot follow-up
+    # PR fixes it from main; PR review unblocks immediately.
+    name: WASM release build (main)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [check, wasm]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Build (wasm release)
         run: cargo build -p aver-lang --features wasm --release
 
   bench:
+    # Post-merge bench gate. PR-time CI doesn't run this — perf
+    # regressions get caught when they hit `main`, then a follow-up
+    # PR reverts or fixes them. Trade chosen deliberately: PR review
+    # unblocks 3–5 min faster, and the fix-forward latency for a perf
+    # regression on a pre-1.0 compiler is acceptable. Locally,
+    # contributors can still run `aver bench bench/scenarios/
+    # --target=vm` against their branch before opening a PR if they
+    # touched a perf-sensitive path.
     name: Bench Gate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
> User-frustration reduction. PR-time CI was waiting on two steps that only matter post-merge:
>
> 1. `Build (wasm release)` — 3–5 min release-profile build of `--features wasm`. Debug profile (`cargo test --features wasm`) catches every logic regression in practice; release-only bugs are rare and survivable as fix-forward.
> 2. `Bench Gate` — release build of `aver` + bench scenario sweep. Perf gating is more valuable on `main` than pre-merge for a pre-1.0 compiler; if a perf regression slips in, a follow-up PR fixes it.

## What this PR does

- Extracts `Build (wasm release)` from the `wasm` job into a new `wasm_release_build` job.
- Gates both `wasm_release_build` and `bench` on `github.event_name == 'push' && github.ref == 'refs/heads/main'`.
- Adds inline doc comments explaining the trade-off at each `if:` gate.

## What PR-time CI still covers

- `Check & Test` — debug, full workspace.
- `WASM` job — `cargo clippy --features wasm` + `cargo test --features wasm` (debug profile catches every logic regression).

## What main-only CI adds

- `WASM release build (main)` — release-profile build of `aver-lang --features wasm` as the artifact-shape gate.
- `Bench Gate` — release build + bench sweep against committed baselines.

## Wall-clock impact

Roughly 6–10 min off PR-time wall clock when bench + wasm release build aren't blocking. The Check & Test job usually dominates, so this is a meaningful trim.

## Fix-forward latency

If a release-mode or perf regression slips into `main`, a hot follow-up PR fixes it. PR review unblocks for everyone else immediately. For a pre-1.0 compiler with no SLA on `main` stability, this is the right trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)