### PR TITLE
codegen/wasm-gc: formal post-link view doc + cross-module regression — #170 Phase 6

### DIFF
--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -125,6 +125,29 @@ impl std::error::Error for WasmGcError {}
 /// `__rt_*` JS bridge + `_start` export. This is the path used by
 /// `--target wasm-gc` (browsers, Workers, embedded wasmtime via
 /// `aver run --wasm-gc`).
+///
+/// # Epic #170 Phase 6 contract — input shape
+///
+/// **Input is post-pipeline AST `&[TopLevel]`, not
+/// `&ResolvedProgramView`**, and this is intentional. The wasm-gc
+/// backend runs its own [`backend-link-stage`](self::view): a
+/// `flatten_multimodule` pass collapses dep modules into the entry
+/// items with module-prefixed names (`Fractal.render` →
+/// `Fractal_render`), then [`WasmGcLinkedView`] runs a fresh resolver
+/// pass against the flattened slice. The pre-link `ResolvedProgramView`
+/// from the pipeline keyed against the pre-flatten `SymbolTable`
+/// doesn't match the post-link namespace, so this backend builds
+/// its own post-link view internally rather than consuming the
+/// shared one.
+///
+/// **What this means for identity safety**: post-flatten lookups
+/// inside the backend go through `WasmGcLinkedView::fn_def_by_id`
+/// (opaque `FnId`), not bare-name walks over the flattened items.
+/// Cross-module same-bare-name fns get distinct `FnId`s by virtue
+/// of the prefix-mangle, and the link view's resolver pass
+/// canonicalises them.
+///
+/// [`WasmGcLinkedView`]: self::view::WasmGcLinkedView
 pub fn compile_to_wasm_gc(
     items: &[TopLevel],
     _analysis: Option<&AnalysisResult>,

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -122,6 +122,125 @@ fn default_val(ty: &wasmtime::ValType) -> wasmtime::Val {
     }
 }
 
+/// Multi-module compile: parses entry + dep sources, runs the
+/// pipeline with `WithLoaded`, flattens dep fns into the entry
+/// namespace, runs the post-link resolver pass, and emits wasm
+/// bytes. Mirrors the playground's multi-file path so tests can
+/// exercise cross-module identity through the wasm-gc backend's
+/// `flatten_multimodule` + `WasmGcLinkedView` (epic #170 Phase 6).
+fn compile_multi_module_bytes(entry_src: &str, dep_sources: &[(&str, &str)]) -> Vec<u8> {
+    let mut entry_items = parse_source(entry_src).unwrap_or_else(|e| {
+        panic!("entry parse failed: {e}\n--- entry ---\n{entry_src}");
+    });
+    let loaded: Vec<aver::source::LoadedModule> = dep_sources
+        .iter()
+        .map(|(prefix, src)| aver::source::LoadedModule {
+            dep_name: prefix.to_string(),
+            items: parse_source(src).unwrap_or_else(|e| {
+                panic!("dep '{prefix}' parse failed: {e}\n--- dep ---\n{src}");
+            }),
+            path: std::path::PathBuf::from(format!("{prefix}.av")),
+        })
+        .collect();
+
+    let neutral_policy = aver::ir::NeutralAllocPolicy;
+    let result = pipeline::run(
+        &mut entry_items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::WithLoaded(&loaded)),
+            alloc_policy: Some(&neutral_policy),
+            run_interp_lower: false,
+            run_buffer_build: false,
+            ..Default::default()
+        },
+    );
+    if let Some(tc) = &result.typecheck
+        && !tc.errors.is_empty()
+    {
+        panic!("typecheck failed: {:?}", tc.errors);
+    }
+    let modules: Vec<aver::codegen::ModuleInfo> = loaded
+        .into_iter()
+        .map(|m| aver::codegen::ModuleInfo::from_loaded(&m))
+        .collect();
+    aver::codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
+    aver::ir::pipeline::resolve(&mut entry_items);
+    compile_to_wasm_gc(&entry_items, result.analysis.as_ref()).unwrap_or_else(|e| {
+        panic!("wasm-gc multi-module compile failed: {e:?}");
+    })
+}
+
+fn run_int_multi(entry_src: &str, dep_sources: &[(&str, &str)]) -> i64 {
+    let bytes = compile_multi_module_bytes(entry_src, dep_sources);
+    let mut config = wasmtime::Config::new();
+    config.wasm_gc(true);
+    config.wasm_tail_call(true);
+    config.wasm_function_references(true);
+    config.wasm_reference_types(true);
+    config.wasm_multi_value(true);
+    config.wasm_bulk_memory(true);
+    config.cranelift_opt_level(wasmtime::OptLevel::Speed);
+    config.max_wasm_stack(8 * 1024 * 1024);
+    config.async_stack_size(12 * 1024 * 1024);
+    let engine = wasmtime::Engine::new(&config).expect("wasmtime engine");
+    let module = wasmtime::Module::new(&engine, &bytes)
+        .unwrap_or_else(|e| panic!("wasmtime rejected wasm-gc bytes: {e}"));
+    let mut store = wasmtime::Store::new(&engine, ());
+    let mut linker = wasmtime::Linker::new(&engine);
+    stub_imports(&module, &engine, &mut linker);
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .unwrap_or_else(|e| panic!("instantiate failed: {e}"));
+    let main = instance
+        .get_typed_func::<(), i64>(&mut store, "main")
+        .unwrap_or_else(|e| panic!("main: () -> Int export missing: {e}"));
+    main.call(&mut store, ())
+        .unwrap_or_else(|e| panic!("main trapped: {e}"))
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Cross-module identity (epic #170 Phase 6)
+// ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn cross_module_same_bare_name_fns_resolve_via_flatten_and_link_view() {
+    // Two same-bare `helper(n: Int) -> Int` fns — one in entry, one
+    // in dep module `Worker`. Different bodies (+1 vs +100). The
+    // wasm-gc backend's `flatten_multimodule` mangles dep fn names
+    // (`Worker.helper` → `Worker_helper`), then `WasmGcLinkedView`
+    // re-resolves against the flattened namespace and indexes by
+    // `FnId`. If either step regressed to bare-name keying, the two
+    // fns would collide on `helper` and main's `1 + 100 = 101`
+    // result would shift (e.g. to `1 + 1 = 2` if entry's body
+    // shadowed Worker's, or `100 + 100 = 200` the other way).
+    let entry_src = r#"
+module Entry
+    intent = "cross-module same-bare-name regression"
+    depends [Worker]
+
+fn helper(n: Int) -> Int
+    n + 1
+
+fn main() -> Int
+    helper(0) + Worker.helper(0)
+"#;
+    let dep_src = r#"
+module Worker
+    intent = "Worker module with same-bare 'helper'"
+    exposes [helper]
+    depends []
+
+fn helper(n: Int) -> Int
+    n + 100
+"#;
+    let result = run_int_multi(entry_src, &[("Worker", dep_src)]);
+    assert_eq!(
+        result, 101,
+        "expected Entry.helper(0) + Worker.helper(0) = 1 + 100 = 101; \
+         a divergence here means flatten / link-view crossed wires"
+    );
+}
+
 // ────────────────────────────────────────────────────────────────────
 // List<T>
 // ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
> Closes Phase 6 of the HIR-as-canonical-backend-input epic for the wasm-gc backend.

## Why doc + test, not signature change

Phase 6 audit asked for `compile_to_wasm_gc(view: &ResolvedProgramView)`. After investigation: wasm-gc's AST input is **intentional**, not migration debt. The backend runs its own `flatten_multimodule` link stage that produces a different namespace than the pre-link pipeline view (dep fns get module-prefixed names like `Worker.helper` → `Worker_helper`). The pre-link `ResolvedProgramView` from the pipeline can't be reused — it's keyed against the wrong `SymbolTable`. So the AST input is the correct API; the post-link identity layer is `WasmGcLinkedView` (already formalized in `view.rs` module doc since PR 9.3b).

## What this PR adds

### Public API doc invariant on `compile_to_wasm_gc`
Names the AST input as intentional (not a migration debt) and points contributors to `WasmGcLinkedView` for the post-link identity layer. Explains what cross-module same-bare-name safety means in this backend (prefix-mangle + post-link resolver pass + FnId lookups).

### Cross-module same-bare-name regression test
`cross_module_same_bare_name_fns_resolve_via_flatten_and_link_view`: two `helper(n: Int) -> Int` fns (entry + dep module `Worker`) with different bodies. `main = helper(0) + Worker.helper(0)` returns `1 + 100 = 101`. A regression in flatten or link-view keying would collapse the two onto one body and shift the result.

### Test helpers
`compile_multi_module_bytes` + `run_int_multi` — first multi-module fixture in the wasm-gc test suite. Follows the playground's `compile_project_to_wasm` flow.

## Tests

- [x] 1658 tests pass, 0 failed
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Epic #170 progress

- [x] Phase 1-4 (#171, #172, #173, #174)
- [x] Phase 5 PR E1 (#175), F1 (#176), F2 (#177)
- [x] **Phase 6: wasm-gc post-link view formal + regression** ← this PR
- [ ] Phase 5 PR E2: Lean `emit_expr_legacy` hot path drop
- [ ] Phase 7: proof_lower decision A (matcher API)
- [ ] Phase 8: guardrails test

🤖 Generated with [Claude Code](https://claude.com/claude-code)