### PR TITLE
codegen/rust: emit_fn_def reads param types from ResolvedFnDef — #180 Phase 3

### DIFF
--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -555,16 +555,48 @@ fn collect_fn_local_types(fd: &FnDef, ctx: &CodegenContext) -> HashMap<String, T
     local_types
 }
 
+/// Collect local_types directly from a `ResolvedFnDef`'s already-
+/// parsed `params: Vec<(String, Type)>`. **Epic #180 Phase 3**: this
+/// is the typed-HIR path — no `ctx.fn_sigs.get(...)` side-channel,
+/// no `parse_type_str(string)` recompute. The resolved view's
+/// params are the canonical source of truth post-typecheck.
+fn collect_fn_local_types_from_resolved(
+    resolved: &crate::ir::hir::ResolvedFnDef,
+) -> HashMap<String, Type> {
+    resolved
+        .params
+        .iter()
+        .map(|(name, ty)| (name.clone(), ty.clone()))
+        .collect()
+}
+
 /// Build an EmitCtx for a function from its parameter types in fn_sigs.
 /// Uses borrow-by-default: non-Copy, non-Str params are tracked as borrowed.
 fn build_fn_ectx(fd: &FnDef, ctx: &CodegenContext, scope: Option<&str>) -> EmitCtx {
     EmitCtx::for_fn(collect_fn_local_types(fd, ctx)).with_scope(scope)
 }
 
+/// Typed-HIR variant of [`build_fn_ectx`]. Reads param types from the
+/// `ResolvedFnDef` directly — epic #180 Phase 3 migration path.
+fn build_fn_ectx_from_resolved(
+    resolved: &crate::ir::hir::ResolvedFnDef,
+    scope: Option<&str>,
+) -> EmitCtx {
+    EmitCtx::for_fn(collect_fn_local_types_from_resolved(resolved)).with_scope(scope)
+}
+
 /// Build an EmitCtx for a function WITHOUT borrow-by-default.
 /// Used for TCO and memo functions where params need to be owned/mutable.
 fn build_fn_ectx_no_borrow(fd: &FnDef, ctx: &CodegenContext, scope: Option<&str>) -> EmitCtx {
     EmitCtx::for_fn_no_borrow(collect_fn_local_types(fd, ctx)).with_scope(scope)
+}
+
+/// Typed-HIR variant of [`build_fn_ectx_no_borrow`].
+fn build_fn_ectx_no_borrow_from_resolved(
+    resolved: &crate::ir::hir::ResolvedFnDef,
+    scope: Option<&str>,
+) -> EmitCtx {
+    EmitCtx::for_fn_no_borrow(collect_fn_local_types_from_resolved(resolved)).with_scope(scope)
 }
 
 /// Emit a Rust function from an Aver FnDef.
@@ -642,10 +674,14 @@ fn emit_fn_def_with_visibility(
     // TCO functions need owned/mutable params, no borrow-by-default.
     // Memo functions always use borrow-by-default (memo wrapper takes &T).
     // Normal functions use borrow-by-default for non-Copy, non-Str params.
+    // **Epic #180 Phase 3**: read param types directly from the
+    // `ResolvedFnDef` (typed-HIR canonical source) instead of the
+    // legacy `ctx.fn_sigs.get(name)` + `parse_type_str(string)`
+    // side-channel chain.
     let ectx = if has_tco && !use_memo {
-        build_fn_ectx_no_borrow(fd, ctx, scope)
+        build_fn_ectx_no_borrow_from_resolved(resolved_fd, scope)
     } else {
-        build_fn_ectx(fd, ctx, scope)
+        build_fn_ectx_from_resolved(resolved_fd, scope)
     };
 
     let guest_args_name = if is_guest_entry {


### PR DESCRIPTION
> First vertical slice of epic #180. `emit_fn_def_with_visibility` now builds its `EmitCtx` local_types directly from `resolved_fd.params: Vec<(String, Type)>` — the typechecker stamped the resolved fn def's params with canonical types, so there's no reason to re-derive them through the `ctx.fn_sigs` / `parse_type_str` side-channel chain.

## What this PR does

Adds typed-HIR variants of the `EmitCtx` builders:
- `collect_fn_local_types_from_resolved` — reads `resolved.params` directly
- `build_fn_ectx_from_resolved` / `build_fn_ectx_no_borrow_from_resolved` — wrappers

`emit_fn_def_with_visibility` already had `resolved_fd: &ResolvedFnDef` in scope (from epic #170 PR D #174), so the migration is a 4-line swap.

## What this PR doesn't do

The legacy AST-shape builders stay for `toplevel.rs:2937` (main fn ectx) and the test fixtures at `:3085`. Those don't have a `ResolvedFnDef` in scope; migrating them needs threading the resolved view through `emit_public_main` and the test helpers — follow-up phases catch them as we migrate more sites onto `.ty()`.

## Tests

- [x] 1667 tests pass, 0 failed (1660 + 7 stamp-invariant fixtures from PR #184)
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Rust codegen output byte-identical against main on `examples/core/calculator.av` (md5 `cd7fcd9b42466dbcd9df9f777f1758d1` on both sides)

## Epic #180 progress

- [x] Phase 1: audit + acceptance (#180 body)
- [x] Phase 2: stamp invariant gate (#184)
- [x] **Phase 3: Rust codegen first slice** ← this PR
- [ ] Phase 4: Lean codegen on `.ty()`
- [ ] Phase 5: Dafny codegen on `.ty()`
- [ ] Phase 6: `Type::Named { id }` matching
- [ ] Phase 7: `fn_sigs` projection from typed view
- [ ] Phase 8: guardrails extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)