### PR TITLE
codegen: id-aware refined-type lookup for typed Named refs — #180 Phase 6

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -952,6 +952,49 @@ pub fn find_refined_type<'a>(
     find_refined_type_with_key_scoped(ctx, name, None).map(|(_, d)| d)
 }
 
+/// Direct `TypeId` lookup against `ProofIR.refined_types`.
+///
+/// Epic #180 Phase 6 — preferred entry point for callers holding a
+/// typed `Type::Named { id: Some(_), .. }` reference (the
+/// typechecker / resolver canonicalises Named refs with `id` when
+/// the name binds to a declared type). Skips the
+/// name → `TypeKey` → `TypeId` chain that
+/// [`find_refined_type_with_key_scoped`] walks for bare-string
+/// callers — and is identity-safe across cross-module same-bare-
+/// name twins, since `TypeId` carries the module disambiguation.
+///
+/// Returns `None` for builtins / unresolved refs whose `id` was
+/// never stamped; callers should fall back to the name-based path
+/// in that case (see [`find_refined_type_for_named`] for the
+/// combined helper).
+pub fn find_refined_type_by_id(
+    ctx: &CodegenContext,
+    type_id: crate::ir::TypeId,
+) -> Option<&crate::ir::proof_ir::RefinedTypeDecl> {
+    ctx.proof_ir.refined_types.get(&type_id)
+}
+
+/// Refined-type lookup for a `Type::Named` ref. Prefers the
+/// id-direct path when `id: Some(_)` is stamped, falls back to the
+/// name-keyed resolution chain otherwise (builtins, unresolved
+/// refs).
+///
+/// Epic #180 Phase 6 — preferred over hand-rolled
+/// `Type::Named { name, .. }` destructure + `find_refined_type`
+/// at sites that consume `Spanned<ResolvedExpr>.ty()`.
+pub fn find_refined_type_for_named<'a>(
+    ctx: &'a CodegenContext,
+    named: &crate::types::Type,
+) -> Option<&'a crate::ir::proof_ir::RefinedTypeDecl> {
+    let crate::types::Type::Named { id, name } = named else {
+        return None;
+    };
+    match id {
+        Some(type_id) => find_refined_type_by_id(ctx, *type_id),
+        None => find_refined_type(ctx, name),
+    }
+}
+
 /// Scope-aware fn-contract resolver. `scope = Some(prefix)` directs
 /// bare-name lookups to that module's slot before falling back to
 /// entry / module-walk. Mirror of `find_refined_type_scoped` for fn

--- a/src/codegen/dafny/expr.rs
+++ b/src/codegen/dafny/expr.rs
@@ -119,8 +119,8 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
             // Refinement-via-opaque records emit as Dafny subset types,
             // so projecting the carrier field is the identity (the
             // value *is* the underlying `int`).
-            if let Some(crate::types::Type::Named { name: t_name, .. }) = obj.ty()
-                && let Some(decl) = crate::codegen::common::find_refined_type(ctx, t_name)
+            if let Some(ty) = obj.ty()
+                && let Some(decl) = crate::codegen::common::find_refined_type_for_named(ctx, ty)
                 && decl.carrier_type == "Int"
                 && field == &decl.carrier_field
             {

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -34,8 +34,8 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
             // typechecker stamp on the host expression, then look
             // up the lifted-type decision the lowerer already made
             // in `ctx.proof_ir.refined_types`.
-            if let Some(crate::types::Type::Named { name: t_name, .. }) = obj.ty()
-                && let Some(decl) = crate::codegen::common::find_refined_type(ctx, t_name)
+            if let Some(ty) = obj.ty()
+                && let Some(decl) = crate::codegen::common::find_refined_type_for_named(ctx, ty)
                 && decl.carrier_type == "Int"
                 && field == &decl.carrier_field
             {


### PR DESCRIPTION
## Summary

First slice of epic #180 Phase 6 (\`Type::Named { id }\` matching across backends). Refined-type detection in expr emit now prefers the canonical \`TypeId\` carried on \`Spanned<ResolvedExpr>.ty()\` over a bare-string lookup chain.

## What this PR adds

Two helpers in \`codegen::common\`:

- \`find_refined_type_by_id(ctx, type_id)\` — direct lookup against \`ProofIR.refined_types: HashMap<TypeId, _>\`. Identity-safe across cross-module same-bare-name twins by construction.
- \`find_refined_type_for_named(ctx, named)\` — accepts any \`&Type::Named\`, dispatches to the id-direct path when \`id\` is stamped (canonical case), falls back to the name-keyed resolution chain for \`id: None\` (builtins / unresolved refs).

Migrates two refinement-detection sites — \`lean::expr::emit_expr\` and \`dafny::expr::emit_expr\` attr-projection arms — from hand-rolled \`Type::Named { name, .. }\` destructure + \`find_refined_type(ctx, name)\` to the combined helper.

## Phase 6 audit

| Category | Sites | Status |
|---|---|---|
| **Refinement-detection** (id-direct viable today) | 2 | ✅ this PR |
| **DISPLAY** — type-name rendering at output boundary | 3 | doc-tag pass deferred to Phase 8 guardrail PR |
| **REGISTRY** — wasm-gc / dafny / rust eq-hash / type-default / newtype-underlying string-keyed maps | ~10 | real cascade, separate PR (mirrors #170 Phase 7 \`FnId\` migration, but for \`TypeId\`) |
| **smart_ctor_matches** in \`proof_lower.rs\` — parses \`fd.return_type\` raw string | 1 | needs \`ResolvedFnDef.return_type\` threading; separate slice |

## Tests

- [x] \`cargo test\` — 1579 lib + integration tests pass, 0 failed
- [x] \`cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)