### PR TITLE
codegen: canonical-key registry routing for nominal types — #180 Phase 6

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -952,6 +952,67 @@ pub fn find_refined_type<'a>(
     find_refined_type_with_key_scoped(ctx, name, None).map(|(_, d)| d)
 }
 
+/// Canonical backend key for a nominal `Type::Named` reference.
+///
+/// Epic #180 Phase 6 — preferred entry point for backend
+/// registries (record-field maps, eq-helper registration,
+/// type-default chasing, newtype underlying lookups) that
+/// previously extracted `name` directly out of
+/// `Type::Named { name, .. }`. The raw `name` field is
+/// source-faithful (so a bare `Shape` reference inside module
+/// `A` stays as `"Shape"` even when the declaration is
+/// canonically `A.Shape`). Registry routing keyed on raw `name`
+/// silently collides two modules' same-bare-name types under
+/// one slot — keying by the canonical form is identity-safe by
+/// construction.
+///
+/// Resolution order:
+///
+/// 1. `id: Some(type_id)` (the canonical case post-typecheck) →
+///    `symbol_table.type_entry(id).key.canonical()`.
+/// 2. `id: None` (builtins / unresolved refs that never went
+///    through `canonicalise_type`) → fall back to the source-
+///    faithful `name`. The resolver stamps `id: Some(_)`
+///    whenever the name binds to a declared type, so `id: None`
+///    survives only for refs the symbol table doesn't know.
+/// 3. Non-`Named` types (compound shapes like `List<X>`,
+///    `Result<A, B>`, tuples, maps) → `None`. Backend layout
+///    registries key compound types by a canonical compound
+///    string (`format!("List<{}>", inner)`) the caller builds
+///    itself; this helper covers only the nominal case.
+pub fn backend_named_type_key(ctx: &CodegenContext, ty: &crate::types::Type) -> Option<String> {
+    let crate::types::Type::Named { id, name } = ty else {
+        return None;
+    };
+    if let Some(type_id) = id {
+        return Some(ctx.symbol_table.type_entry(*type_id).key.canonical());
+    }
+    Some(name.clone())
+}
+
+/// Canonical backend key for a [`TypeDef`] declaration.
+///
+/// Epic #180 Phase 6 — paired with [`backend_named_type_key`] at
+/// the registry-storage side. Backend registries insert
+/// `TypeDef`s under the canonical key (`"Shape"` for entry,
+/// `"A.Shape"` for module-owned) so cross-module same-bare-name
+/// types occupy distinct slots and the
+/// `backend_named_type_key`-derived lookup at the expression
+/// side hits the right declaration.
+///
+/// Falls back to the bare `type_def_name(td)` when the symbol
+/// table doesn't index this `TypeDef` (synthetic / builtin
+/// inserts) — registry insertion paths accept both during the
+/// migration window.
+pub fn backend_type_def_key(ctx: &CodegenContext, td: &crate::ast::TypeDef) -> String {
+    let key = type_key_for_decl(ctx, td);
+    if ctx.symbol_table.type_id_of(&key).is_some() {
+        key.canonical()
+    } else {
+        type_def_name(td).to_string()
+    }
+}
+
 /// Direct `TypeId` lookup against `ProofIR.refined_types`.
 ///
 /// Epic #180 Phase 6 — preferred entry point for callers holding a

--- a/src/codegen/dafny/fuel.rs
+++ b/src/codegen/dafny/fuel.rs
@@ -351,7 +351,10 @@ fn type_default(ty: &Type, ctx: &CodegenContext, visiting: &mut HashSet<String>)
                 .collect::<Option<_>>()?;
             format!("({})", parts.join(", "))
         }
-        Type::Named { name, .. } => named_type_default(name, ctx, visiting)?,
+        Type::Named { .. } => {
+            let key = crate::codegen::common::backend_named_type_key(ctx, ty)?;
+            named_type_default(&key, ctx, visiting)?
+        }
         Type::Fn(_, _, _) | Type::Var(_) | Type::Invalid => return None,
     })
 }
@@ -375,7 +378,26 @@ fn named_type_default(
     result
 }
 
+/// Locate a `TypeDef` by canonical or bare name.
+///
+/// Epic #180 Phase 6 — accepts dotted canonical keys
+/// (`"A.Shape"` for module-owned types) routed to the matching
+/// module's `type_defs` list, so cross-module same-bare-name
+/// types resolve to the correct declaration instead of the
+/// first-match-wins bare lookup. Bare keys (entry-scope types,
+/// builtins) still resolve via the entry → module-walk fallback
+/// chain.
 fn find_type_def<'a>(ctx: &'a CodegenContext, target: &str) -> Option<&'a TypeDef> {
+    if let Some((prefix, bare)) = target.rsplit_once('.') {
+        for m in &ctx.modules {
+            if m.prefix == prefix {
+                return m
+                    .type_defs
+                    .iter()
+                    .find(|td| crate::codegen::common::type_def_name(td) == bare);
+            }
+        }
+    }
     ctx.type_defs
         .iter()
         .chain(ctx.modules.iter().flat_map(|m| m.type_defs.iter()))

--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -1053,22 +1053,37 @@ fn attr_result_is_copy(
         }
         _ => None,
     };
-    let record_name = match obj_type {
-        Some(Type::Named { name, .. }) => name.as_str(),
-        _ => return false,
+    let Some(named_ty) = obj_type.filter(|t| matches!(t, Type::Named { .. })) else {
+        return false;
     };
-    // Find record definition and look up field type.
-    for td in ctx
+    let Some(record_key) = crate::codegen::common::backend_named_type_key(ctx, named_ty) else {
+        return false;
+    };
+    // Find record definition and look up field type. Iterate
+    // through `(module_prefix, td)` pairs so canonical-key
+    // matching (`"A.Shape"`) routes to the right module's
+    // TypeDef list instead of first-bare-match-wins.
+    let candidates = ctx
         .type_defs
         .iter()
-        .chain(ctx.modules.iter().flat_map(|m| m.type_defs.iter()))
-    {
-        if let TypeDef::Product { name, fields, .. } = td
-            && name == record_name
-            && let Some((_, type_ann)) = fields.iter().find(|(n, _)| n == field)
-        {
-            let ty = types::parse_type_str(type_ann);
-            return super::emit_ctx::is_copy_type(&ty);
+        .map(|td| (None, td))
+        .chain(ctx.modules.iter().flat_map(|m| {
+            m.type_defs
+                .iter()
+                .map(move |td| (Some(m.prefix.as_str()), td))
+        }));
+    for (scope, td) in candidates {
+        if let TypeDef::Product { name, fields, .. } = td {
+            let canonical = match scope {
+                Some(prefix) => format!("{}.{}", prefix, name),
+                None => name.clone(),
+            };
+            if canonical == record_key
+                && let Some((_, type_ann)) = fields.iter().find(|(n, _)| n == field)
+            {
+                let ty = types::parse_type_str(type_ann);
+                return super::emit_ctx::is_copy_type(&ty);
+            }
         }
     }
     false
@@ -1703,15 +1718,20 @@ pub(super) fn constructor_boxed_positions(name: &str, ctx: &CodegenContext) -> H
     let Some((params, ret, _)) = sig else {
         return out;
     };
-    let Type::Named { name: ret_name, .. } = ret else {
+    let Some(ret_name) = ret.named_name() else {
         return out;
     };
+    let ret_id = ret.named_id();
+    // Epic #180 Phase 6 — prefer `TypeId` equality when both
+    // sides carry a stamp, fall back to `name` for `id: None`
+    // refs (synthetic / unresolved ctor sigs). Identity-safe
+    // across cross-module same-bare-name twins.
     for (idx, param) in params.iter().enumerate() {
-        if let Type::Named {
-            name: param_name, ..
-        } = param
-            && param_name == ret_name
-        {
+        let matches = match (ret_id, param.named_id()) {
+            (Some(r), Some(p)) => r == p,
+            _ => param.named_name() == Some(ret_name),
+        };
+        if matches {
             out.insert(idx);
         }
     }

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -285,7 +285,22 @@ fn emit_type_def_with_visibility(td: &TypeDef, public: bool, ctx: &CodegenContex
 
 use crate::codegen::common::type_def_name;
 
+/// Locate a `TypeDef` by canonical or bare name.
+///
+/// Epic #180 Phase 6 — accepts dotted canonical keys
+/// (`"A.Shape"` for module-owned types) routed to the matching
+/// module's `type_defs` list, so cross-module same-bare-name
+/// types resolve to the correct declaration instead of the
+/// first-match-wins bare lookup. Bare keys still resolve via
+/// the entry → module-walk fallback chain.
 fn find_type_def<'a>(name: &str, ctx: &'a CodegenContext) -> Option<&'a TypeDef> {
+    if let Some((prefix, bare)) = name.rsplit_once('.') {
+        for module in &ctx.modules {
+            if module.prefix == prefix {
+                return module.type_defs.iter().find(|td| type_def_name(td) == bare);
+            }
+        }
+    }
     ctx.type_defs
         .iter()
         .find(|td| type_def_name(td) == name)
@@ -316,7 +331,12 @@ fn rust_hash_eq_safe_type(
             .iter()
             .all(|item| rust_hash_eq_safe_type(item, ctx, visiting)),
         Type::Map(_, _) | Type::Fn(_, _, _) | Type::Var(_) | Type::Invalid => false,
-        Type::Named { name, .. } => rust_hash_eq_safe_named(name, ctx, visiting),
+        Type::Named { .. } => {
+            let Some(key) = crate::codegen::common::backend_named_type_key(ctx, ty) else {
+                return false;
+            };
+            rust_hash_eq_safe_named(&key, ctx, visiting)
+        }
     }
 }
 
@@ -348,7 +368,8 @@ fn rust_hash_eq_safe_named(
 
 fn type_can_derive_hash_eq(td: &TypeDef, ctx: &CodegenContext) -> bool {
     let mut visiting = HashSet::new();
-    rust_hash_eq_safe_named(type_def_name(td), ctx, &mut visiting)
+    let key = crate::codegen::common::backend_type_def_key(ctx, td);
+    rust_hash_eq_safe_named(&key, ctx, &mut visiting)
 }
 
 fn fn_supports_rust_memo(fd: &FnDef, ctx: &CodegenContext) -> bool {

--- a/tests/cross_module_type_keys.rs
+++ b/tests/cross_module_type_keys.rs
@@ -1,0 +1,187 @@
+//! Cross-module same-bare-name `TypeDef` regression.
+//!
+//! Epic #180 Phase 6 — pins the canonical-key behavior of
+//! `backend_named_type_key` / `backend_type_def_key`. Two dep
+//! modules each declare a `Shape` sum with different variants;
+//! the helpers must hand each declaration a distinct canonical
+//! key (`"Round.Shape"`, `"Sharp.Shape"`) so backend registry
+//! lookups route to the right TypeDef instead of
+//! first-match-wins.
+
+use aver::ast::TypeDef;
+use aver::codegen::common::{backend_named_type_key, backend_type_def_key};
+use aver::codegen::{ModuleInfo, build_context};
+use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
+use aver::source::{LoadedModule, parse_source};
+use aver::types::Type;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+const ENTRY_SRC: &str = r#"module Entry
+    intent = "cross-module same-bare-name type regression"
+    depends [Round, Sharp]
+
+fn main() -> Int
+    1
+"#;
+
+const ROUND_SRC: &str = r#"module Round
+    intent = "round shapes"
+    exposes [Shape]
+    depends []
+
+type Shape
+    Circle(Int)
+    Disc
+"#;
+
+const SHARP_SRC: &str = r#"module Sharp
+    intent = "sharp shapes"
+    exposes [Shape]
+    depends []
+
+type Shape
+    Triangle
+    Square(Int)
+"#;
+
+fn build_three_module_ctx() -> aver::codegen::CodegenContext {
+    let mut entry_items = parse_source(ENTRY_SRC).expect("entry parse");
+    let loaded: Vec<LoadedModule> = vec![
+        LoadedModule {
+            dep_name: "Round".to_string(),
+            items: parse_source(ROUND_SRC).expect("Round parse"),
+            path: PathBuf::from("Round.av"),
+        },
+        LoadedModule {
+            dep_name: "Sharp".to_string(),
+            items: parse_source(SHARP_SRC).expect("Sharp parse"),
+            path: PathBuf::from("Sharp.av"),
+        },
+    ];
+    let modules: Vec<ModuleInfo> = loaded.iter().map(ModuleInfo::from_loaded).collect();
+    let result = pipeline::run(
+        &mut entry_items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::WithLoaded(&loaded)),
+            run_build_symbols: true,
+            dep_modules: &modules,
+            ..Default::default()
+        },
+    );
+    let tc = result.typecheck.as_ref().expect("typecheck");
+    assert!(
+        tc.errors.is_empty(),
+        "multi-module fixture should typecheck: {:?}",
+        tc.errors
+    );
+    build_context(
+        entry_items.clone(),
+        tc,
+        result.analysis.as_ref(),
+        HashSet::new(),
+        "test".to_string(),
+        modules,
+        result.symbol_table,
+        result.resolved_items,
+    )
+}
+
+#[test]
+fn backend_type_def_key_distinguishes_cross_module_same_bare_name() {
+    let ctx = build_three_module_ctx();
+
+    let round_shape = ctx
+        .modules
+        .iter()
+        .find(|m| m.prefix == "Round")
+        .and_then(|m| {
+            m.type_defs
+                .iter()
+                .find(|td| matches!(td, TypeDef::Sum { name, .. } if name == "Shape"))
+        })
+        .expect("Round.Shape exists");
+    let sharp_shape = ctx
+        .modules
+        .iter()
+        .find(|m| m.prefix == "Sharp")
+        .and_then(|m| {
+            m.type_defs
+                .iter()
+                .find(|td| matches!(td, TypeDef::Sum { name, .. } if name == "Shape"))
+        })
+        .expect("Sharp.Shape exists");
+
+    let round_key = backend_type_def_key(&ctx, round_shape);
+    let sharp_key = backend_type_def_key(&ctx, sharp_shape);
+
+    assert_eq!(
+        round_key, "Round.Shape",
+        "Round.Shape should get its module-qualified canonical key, got {round_key:?}"
+    );
+    assert_eq!(
+        sharp_key, "Sharp.Shape",
+        "Sharp.Shape should get its module-qualified canonical key, got {sharp_key:?}"
+    );
+    assert_ne!(
+        round_key, sharp_key,
+        "cross-module dups must produce distinct registry keys"
+    );
+}
+
+#[test]
+fn backend_named_type_key_routes_id_stamped_named_to_canonical() {
+    let ctx = build_three_module_ctx();
+
+    let round_id = ctx
+        .symbol_table
+        .type_id_of(&aver::ir::TypeKey::in_module("Round", "Shape"))
+        .expect("Round.Shape TypeId");
+    let sharp_id = ctx
+        .symbol_table
+        .type_id_of(&aver::ir::TypeKey::in_module("Sharp", "Shape"))
+        .expect("Sharp.Shape TypeId");
+
+    let round_named = Type::Named {
+        id: Some(round_id),
+        name: "Shape".to_string(),
+    };
+    let sharp_named = Type::Named {
+        id: Some(sharp_id),
+        name: "Shape".to_string(),
+    };
+    let round_key = backend_named_type_key(&ctx, &round_named).expect("Named is Some");
+    let sharp_key = backend_named_type_key(&ctx, &sharp_named).expect("Named is Some");
+
+    assert_eq!(round_key, "Round.Shape");
+    assert_eq!(sharp_key, "Sharp.Shape");
+    assert_ne!(round_key, sharp_key);
+}
+
+#[test]
+fn backend_named_type_key_falls_back_to_name_for_unresolved_refs() {
+    let ctx = build_three_module_ctx();
+    let unresolved = Type::Named {
+        id: None,
+        name: "Unknown".to_string(),
+    };
+    let key = backend_named_type_key(&ctx, &unresolved).expect("Named is Some");
+    assert_eq!(
+        key, "Unknown",
+        "id: None should fall back to the source-faithful name"
+    );
+}
+
+#[test]
+fn backend_named_type_key_returns_none_for_compound_types() {
+    let ctx = build_three_module_ctx();
+
+    let list_of_int = Type::List(Box::new(Type::Int));
+    assert!(
+        backend_named_type_key(&ctx, &list_of_int).is_none(),
+        "compound types have no canonical Named key"
+    );
+
+    let result_int_str = Type::Result(Box::new(Type::Int), Box::new(Type::Str));
+    assert!(backend_named_type_key(&ctx, &result_int_str).is_none());
+}


### PR DESCRIPTION
## Summary

Cross-module same-bare-name TypeDefs (e.g. \`Round.Shape\` and \`Sharp.Shape\` both bare \`Shape\`) used to collide in backend registry lookups — \`find_type_def(\"Shape\", ctx)\` matched the first-walked entry, masking the wrong declaration's fields. This PR routes those lookups by canonical key (\`\"Round.Shape\"\` vs \`\"Sharp.Shape\"\`) so each ref hits its correct declaration.

## Design — B+ from peer review

Backend type registries stay string-keyed (they often carry compound/layout keys like \`List<A.Shape>\` that have no \`TypeId\`). What changes is that the string IS the canonical backend type key — derived id-first for nominal types, never the raw source-faithful bare name.

Two helpers in \`codegen::common\`:

- \`backend_named_type_key(ctx, ty: &Type)\` — for the call-side. \`id: Some(_)\` → canonical via \`symbol_table.type_entry(id).key.canonical()\`. \`id: None\` → source-faithful \`name\` (builtins, unresolved). Compound types → \`None\` (caller builds compound strings).
- \`backend_type_def_key(ctx, td: &TypeDef)\` — symmetric storage-side helper. Pairs with the call-side so canonical lookups hit canonical inserts.

## Migrated

| Site | Migration |
|---|---|
| Dafny \`type_default\` Named arm | Helper-routed lookup |
| Dafny \`find_type_def\` | Accepts dotted canonical keys |
| Rust \`rust_hash_eq_safe_type\` Named arm | Helper-routed |
| Rust \`type_can_derive_hash_eq\` | \`backend_type_def_key\` for recursive entry |
| Rust \`find_type_def\` | Accepts dotted canonical keys |
| Rust \`record_is_copy\` | Helper + scope-aware TypeDef iteration |
| Rust \`constructor_boxed_positions\` | \`TypeId\` equality via \`Type::named_id()\` |

## Test

\`tests/cross_module_type_keys.rs\` — 4 pins on a 3-module fixture (entry + \`Round\` + \`Sharp\`, each dep declaring \`type Shape\` with different variants):

- \`backend_type_def_key_distinguishes_cross_module_same_bare_name\` — round_key == \"Round.Shape\", sharp_key == \"Sharp.Shape\", round_key != sharp_key
- \`backend_named_type_key_routes_id_stamped_named_to_canonical\` — same routing on \`Type::Named { id: Some(_), name: \"Shape\" }\` refs
- \`backend_named_type_key_falls_back_to_name_for_unresolved_refs\` — id: None preserves source name
- \`backend_named_type_key_returns_none_for_compound_types\` — \`List<Int>\` / \`Result<Int, String>\` → None

## Deferred to follow-up

- **wasm-gc registry** — \`TypeRegistry::build_with_handler\` ingests \`TypeDef.name\` (bare) and \`flatten_multimodule\` strips module prefixes from field types. Canonical keying needs a paired flatten change; separate scope.
- **\`smart_ctor_matches\` in \`proof_lower\`** — parses \`fd.return_type\` raw, produces id-less Named. Needs \`ResolvedFnDef.return_type\` threading; separate slice.
- **\`type_contains_named\` in \`rust/mod.rs\`** — callers pass builtin names (no \`id\`); the name comparison is syntax-discovery, not identity. Tag candidate for Phase 8.
- **DISPLAY-only Named matches** (3 sites in lean/rust/dafny type renderers) — \`name\` is the right surface for output strings. Tag pass joins Phase 8.

## Tests

- [x] \`cargo test\` — 1583 tests pass, 0 failed (1579 + 4 new cross-module pins)
- [x] \`cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)