### PR TITLE
tests: identity-guardrails extension for Type::Named id-awareness — #180 Phase 8

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -131,6 +131,11 @@ fn type_to_dafny(ty: &Type) -> String {
         // the dependent module; already-qualified user types
         // (`Level.Room`) need the module-segment prefixed with `Aver_`
         // so the qualifier matches the renamed Dafny module.
+        //
+        // display-only: rendering the Dafny type identifier string.
+        // `name` IS the right surface here. Identity-sensitive
+        // routing already happens upstream via
+        // `backend_named_type_key`; this arm only emits text.
         Type::Named { name, .. } => {
             if crate::codegen::builtin_records::find(name).is_some() {
                 name.replace('.', "_")

--- a/src/codegen/lean/types.rs
+++ b/src/codegen/lean/types.rs
@@ -42,6 +42,10 @@ pub fn type_to_lean(ty: &Type) -> String {
                  This indicates unresolved typing leaked into codegen."
             )
         }
+        // display-only: rendering the Lean type identifier string
+        // — `name` IS the right surface, `id` carries no display
+        // information. Identity-sensitive routing happens at the
+        // call layer (see `backend_named_type_key`).
         Type::Named { name, .. } => {
             if name.contains('.') {
                 name.replace('.', "_")

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -118,8 +118,8 @@ impl ModuleInfo {
 /// wasm-gc) to iterate the view directly. New code in backends
 /// should default to the view. AST consumption requires a clear
 /// category in a code comment: `diagnostic-only`,
-/// `syntax-discovery-only`, `backend-link-stage`, or
-/// `temporary-migration-bridge`.
+/// `syntax-discovery-only`, `backend-link-stage`, `display-only`,
+/// or `temporary-migration-bridge`.
 pub struct CodegenContext {
     /// All top-level items (post-TCO transform, post-typecheck).
     ///

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -3218,6 +3218,11 @@ fn smart_ctor_matches(
     let crate::types::Type::Result(ok, _) = parsed else {
         return false;
     };
+    // syntax-discovery-only: pulls the inner Named's `name` out
+    // of the raw `parse_type_str` parse to feed into the
+    // symbol-table resolution below. The identity decision is
+    // the `TypeId` comparison built from that name plus scope;
+    // the bare `name` is just an intermediate handle.
     let crate::types::Type::Named { name: n, .. } = &*ok else {
         return false;
     };

--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -831,6 +831,11 @@ fn callee_borrow_mask(name: &str, arg_count: usize, ctx: &CodegenContext) -> Vec
         name.to_string()
     };
 
+    // temporary-migration-bridge: `ctx.fn_sigs` borrow-decision
+    // fallback for callees that haven't been threaded through
+    // the resolved-program view (cross-module callsites where
+    // only the dotted source name is in scope). Slated for
+    // removal with Phase 7 of #180.
     if let Some((param_types, _, _)) = ctx
         .fn_sigs
         .get(&lookup_name)
@@ -1704,6 +1709,13 @@ fn emit_list_arm_body(arm: &ResolvedMatchArm, ctx: &CodegenContext, body: String
     }
 }
 
+// temporary-migration-bridge: constructor-boxed-positions
+// detection still consults `ctx.fn_sigs` because constructors
+// are registered under dotted source names (`"Type.Variant"`)
+// and the cross-module suffix fallback hasn't been threaded
+// through the resolved-program view yet. Identity comparison
+// for the param-vs-return Named ref already prefers `TypeId`
+// via `Type::named_id()` further down (PR #189).
 pub(super) fn constructor_boxed_positions(name: &str, ctx: &CodegenContext) -> HashSet<usize> {
     let sig = ctx.fn_sigs.get(name).or_else(|| {
         // Cross-module constructors: "Type.Variant" may be registered as

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -656,6 +656,13 @@ fn needs_named_type(ctx: &CodegenContext, wanted: &str) -> bool {
     })
 }
 
+// syntax-discovery-only: walks ALL fn signatures asking "does
+// any param / return type contain a Named ref with this exact
+// bare-string name?" Callers pass builtin record names
+// (`"HttpResponse"`, `"Tcp.Connection"`, `"Terminal.Size"`)
+// whose typed registration carries no `id` — those refs are
+// matched by the name surface they were declared with. The
+// query is a discovery walk, not an identity decision.
 fn type_contains_named(ty: &Type, wanted: &str) -> bool {
     match ty {
         Type::Named { name, .. } => name == wanted,

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -372,6 +372,11 @@ fn type_can_derive_hash_eq(td: &TypeDef, ctx: &CodegenContext) -> bool {
     rust_hash_eq_safe_named(&key, ctx, &mut visiting)
 }
 
+// temporary-migration-bridge: `ctx.fn_sigs` side channel is
+// slated for removal in Phase 7 of #180 (projection from
+// `ResolvedProgramView` + typed `.ty()`). This memo-eligibility
+// check is identity-safe today because `fd.name` is unambiguous
+// in the entry scope where memo wrappers are synthesised.
 fn fn_supports_rust_memo(fd: &FnDef, ctx: &CodegenContext) -> bool {
     ctx.fn_sigs.get(&fd.name).is_some_and(|(params, _, _)| {
         params.iter().all(|param| {
@@ -558,6 +563,12 @@ fn emit_product_type(
 }
 
 /// Collect local_types from function signature or annotations.
+///
+/// temporary-migration-bridge: `ctx.fn_sigs` side channel is
+/// slated for removal in Phase 7 of #180. Synthetic / mid-
+/// rewrite fns the resolved-view path doesn't index fall back
+/// here; the typed `collect_fn_local_types_from_resolved` is
+/// the preferred entry point for resolved fn defs.
 fn collect_fn_local_types(fd: &FnDef, ctx: &CodegenContext) -> HashMap<String, Type> {
     let mut local_types = HashMap::new();
     if let Some((param_types, _, _)) = ctx.fn_sigs.get(&fd.name) {
@@ -1221,6 +1232,11 @@ fn passthrough_param_names(
         .collect()
 }
 
+// temporary-migration-bridge: `ctx.fn_sigs` lookup for the
+// effects slot. Slated for removal in Phase 7 of #180 (effects
+// projected from `ResolvedFnDef.effects`). Today's bare-name
+// lookup is consistent with the entry-scope assumption the
+// memo wrapper synthesis already makes.
 fn lookup_call_effects<'a>(name: &str, ctx: &'a CodegenContext) -> Option<&'a Vec<String>> {
     if let Some((_, _, effects)) = ctx.fn_sigs.get(name) {
         return Some(effects);

--- a/src/codegen/rust/types.rs
+++ b/src/codegen/rust/types.rs
@@ -36,6 +36,10 @@ pub fn type_to_rust(ty: &Type) -> String {
                  This indicates unresolved typing leaked into codegen."
             )
         }
+        // display-only: rendering the Rust type identifier string
+        // — `name` IS the right surface, `id` carries no display
+        // information. Identity-sensitive routing happens at the
+        // call layer (see `backend_named_type_key`).
         Type::Named { name, .. } => {
             // Dotted names like Tcp.Connection → not supported in transpilation
             if name.contains('.') {

--- a/src/codegen/wasm_gc/body/emit.rs
+++ b/src/codegen/wasm_gc/body/emit.rs
@@ -614,6 +614,13 @@ pub(super) fn emit_expr(
 fn sum_or_record_eq_fn(operand: &Spanned<ResolvedExpr>, ctx: &EmitCtx<'_>) -> Option<u32> {
     let ty = operand.ty()?;
     match ty {
+        // temporary-migration-bridge: wasm-gc `TypeRegistry`
+        // (record_fields / variants / newtype_underlying) is still
+        // string-keyed by bare `TypeDef.name`. `flatten_multimodule`
+        // strips module prefixes from field types, so the registry
+        // and this lookup operate in the post-strip namespace where
+        // bare-name keying is consistent. Canonical-key migration
+        // is its own scope (paired flatten changes required).
         crate::types::Type::Named { name, .. } => {
             // Newtypes already lower to their underlying primitive —
             // no helper needed (the default i64/f64 eq handles them).

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -4479,6 +4479,12 @@ fn register_nominal_in_type(
 ) {
     let canonical: String = t.display().chars().filter(|c| !c.is_whitespace()).collect();
     match t {
+        // temporary-migration-bridge: wasm-gc `TypeRegistry` is
+        // still string-keyed by bare `TypeDef.name` (flatten strips
+        // module prefixes from field types). Canonical-key
+        // migration for wasm-gc is a separate scope; until then
+        // bare-name keying is consistent within the registry's
+        // post-flatten namespace.
         AverType::Named { name, .. } => {
             if type_registry.record_fields.contains_key(name) {
                 eq_helpers.register_transitive(name, EqKind::Record, type_registry);
@@ -4580,6 +4586,11 @@ fn discover_builtins_in_expr(
             // Sum/record `==`/`!=` need a per-type `__eq_<TypeName>`
             // helper — register on discovery so the slot is allocated
             // before emit runs the BinOp dispatch.
+            //
+            // temporary-migration-bridge: wasm-gc `TypeRegistry`
+            // still string-keyed; see the canonical-key migration
+            // note on `register_nominal_in_type`. Bare-name lookup
+            // is consistent within the post-flatten namespace.
             use crate::ast::BinOp as Op;
             if matches!(op, Op::Eq | Op::Neq)
                 && let Some(t) = l.ty()

--- a/tests/identity_guardrails.rs
+++ b/tests/identity_guardrails.rs
@@ -1,15 +1,21 @@
 //! Identity-keying guardrails for the codegen layer.
 //!
-//! Epic #170 Phase 8 — the final acceptance gate. This test scans
-//! the codebase for the patterns the epic eliminated and fails the
-//! build if any of them reappear without an explicit
-//! "this is OK because …" comment.
+//! Epic #170 Phase 8 + Epic #180 Phase 8 — the acceptance gate
+//! for typed-identity hygiene. This test scans the codebase for
+//! the patterns past epics eliminated and fails the build if any
+//! of them reappear without an explicit "this is OK because …"
+//! comment.
 //!
 //! ## Rationale
 //!
-//! Phases 1–7 of #170 moved every identity-sensitive lookup off
-//! bare-string keying to typed IDs (`FnId` / `TypeId` / `CtorId`).
-//! The patterns below were the smell-shapes the audit found —
+//! Epic #170 moved every identity-sensitive *function* lookup off
+//! bare-string keying to typed IDs (`FnId` / `CtorId`). Epic
+//! #180 extended the same discipline to *types*: `TypeId` for
+//! nominal identity, `Spanned<ResolvedExpr>.ty()` for the typed
+//! query layer, and helpers like `backend_named_type_key` for
+//! registry routing.
+//!
+//! The patterns below were the smell-shapes those audits found —
 //! removing them once isn't enough, because a contributor unaware
 //! of the epic could re-introduce them in a future PR. The test
 //! enforces "you can do this, but you must say WHY out loud in a
@@ -34,6 +40,11 @@
 //!   `flatten_multimodule`). The link stage's namespace is the
 //!   identity layer; bare-name lookups against it are safe by the
 //!   stage's own invariant.
+//! - `display-only` — pattern matches a `Type::Named { name, .. }`
+//!   only to render the name into a backend output string (e.g.
+//!   Lean / Dafny / Rust type-name emission, where `name` IS the
+//!   right surface and `id` carries no display information). Use
+//!   for renderers, never for routing / lookup decisions.
 //! - `temporary-migration-bridge` — pattern is acknowledged as
 //!   debt with a known follow-up scope. New code MUST NOT add this
 //!   category; existing tagged sites stay until their migration
@@ -78,6 +89,7 @@ const ALLOWED_CATEGORIES: &[&str] = &[
     "diagnostic-only",
     "syntax-discovery-only",
     "backend-link-stage",
+    "display-only",
     "temporary-migration-bridge",
 ];
 
@@ -105,6 +117,22 @@ const BANNED_PATTERNS: &[BannedPattern] = &[
     BannedPattern {
         needle: ".rsplit('.').next() == Some(",
         label: "suffix match on dotted name — accepts Foo.target as 'target'",
+    },
+    // Epic #180 Phase 8 — typed-HIR / Type::Named id-awareness.
+    BannedPattern {
+        needle: "::Named { name",
+        label: "Type::Named { name, .. } — destructure ignores `id`. Use \
+                backend_named_type_key(ctx, ty) / find_refined_type_for_named, \
+                or pattern-match `Type::Named { id, name }` and prefer id when \
+                stamped. Display renderers / syntax-discovery walks tag with \
+                the matching category",
+    },
+    BannedPattern {
+        needle: "ctx.fn_sigs.get(",
+        label: "ctx.fn_sigs.get(name) — string-keyed fn signature side channel. \
+                Prefer ctx.resolve_fn_def(fd, scope) for ResolvedFnDef.params / \
+                return_type, or the resolved-program view. fn_sigs is slated \
+                for removal in Phase 7 of #180",
     },
 ];
 


### PR DESCRIPTION
## Summary

Extends \`tests/identity_guardrails.rs\` with two new banned patterns and one new escape category. Pins the typed-HIR identity invariants Epic #180 has been building so a future contributor can't silently regress them.

## New banned patterns

- \`::Named { name\` — flags any \`Type::Named { name, .. }\` / \`AverType::Named { name, .. }\` destructure that ignores the \`id\` field. Migration path: \`backend_named_type_key(ctx, ty)\` / \`find_refined_type_for_named\` for nominal identity decisions, or \`Type::Named { id, name }\` with id-first comparison for callers that need both fields.
- \`ctx.fn_sigs.get(\` — flags string-keyed fn signature side-channel reads. Prefer \`ctx.resolve_fn_def(fd, scope)\` for the typed \`ResolvedFnDef\` surface; \`ctx.fn_sigs\` itself is slated for removal as Phase 7 of #180.

## New escape category

- \`display-only\` — pattern matches \`Type::Named { name, .. }\` only to render the name into a backend output string (Lean / Dafny / Rust type-name emitters). The \`name\` IS the right surface here, \`id\` carries no display information. Distinct from \`syntax-discovery-only\` (which describes shape-recognition walks, not text emission).

## Tagged existing sites

| Category | Sites |
|---|---|
| \`display-only\` | \`lean/types.rs::type_to_lean\`, \`dafny/toplevel.rs::type_to_dafny\`, \`rust/types.rs::type_to_rust\` |
| \`syntax-discovery-only\` | \`rust/mod.rs::type_contains_named\` (builtin-name walk), \`proof_lower::smart_ctor_matches\` (intermediate handle, identity decision is TypeId compare) |
| \`temporary-migration-bridge\` (wasm-gc registry) | \`module.rs::register_nominal_in_type\`, \`module.rs::body-collector BinOp arm\`, \`body/emit.rs::sum_or_record_eq_fn\` — wasm-gc TypeRegistry still string-keyed by bare \`TypeDef.name\` after \`flatten_multimodule\` strips module prefixes; canonical-key migration for wasm-gc is its own scope |
| \`temporary-migration-bridge\` (fn_sigs) | five sites in \`rust/toplevel.rs\` + \`rust/expr.rs\` — memo support check, local_types collection, call-effects lookup, borrow-decision fallback, constructor-boxed-positions detection. All carry the Phase 7 removal pointer |

## Tests

- [x] \`cargo test\` — 1583 tests pass, 0 failed (same total as prior merged work; this PR adds no new fixtures)
- [x] \`cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --test identity_guardrails\` — both guardrail tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)