### PR TITLE
codegen/wasm_gc: canonical-key registry routing — #180 Phase 6 PR 3

### DIFF
--- a/src/codegen/wasm_gc/body/emit.rs
+++ b/src/codegen/wasm_gc/body/emit.rs
@@ -614,31 +614,31 @@ pub(super) fn emit_expr(
 fn sum_or_record_eq_fn(operand: &Spanned<ResolvedExpr>, ctx: &EmitCtx<'_>) -> Option<u32> {
     let ty = operand.ty()?;
     match ty {
-        // temporary-migration-bridge: wasm-gc `TypeRegistry` keys
-        // dep types by bare `TypeDef.name` for non-colliding bare
-        // names (the common case post #180 Phase 6 PR 3) and by
-        // canonical `Prefix.Name` for cross-module same-bare-name
-        // collisions. The bare-name lookup below hits the registry
-        // for the non-colliding path; collision-case eq dispatch is
-        // a follow-up (would need a typed key resolved against the
-        // post-flatten symbol table).
-        crate::types::Type::Named { name, .. } => {
+        // Resolve the registry key through the post-flatten symbol
+        // table: non-colliding dep types map to their bare
+        // `TypeDef.name`; cross-module same-bare-name collisions map
+        // to their renamed canonical `Prefix.Name` (#180 Phase 6 PR 3).
+        crate::types::Type::Named { id, name } => {
+            let key: String = match id {
+                Some(type_id) => ctx.symbol_table.type_entry(*type_id).key.canonical(),
+                None => name.clone(),
+            };
             // Newtypes already lower to their underlying primitive —
             // no helper needed (the default i64/f64 eq handles them).
-            if ctx.registry.newtype_underlying(name).is_some() {
+            if ctx.registry.newtype_underlying(&key).is_some() {
                 return None;
             }
-            let is_record = ctx.registry.record_fields.contains_key(name);
+            let is_record = ctx.registry.record_fields.contains_key(&key);
             let is_sum = ctx
                 .registry
                 .variants
                 .values()
                 .flat_map(|v| v.iter())
-                .any(|v| &v.parent == name);
+                .any(|v| v.parent == key);
             if !is_record && !is_sum {
                 return None;
             }
-            ctx.fn_map.eq_helpers.get(name).copied()
+            ctx.fn_map.eq_helpers.get(&key).copied()
         }
         // Generic carriers — `Option<X>`, `Result<X,Y>`, `Tuple<…>`
         // have per-instantiation `__eq_<canonical>` helpers since

--- a/src/codegen/wasm_gc/body/emit.rs
+++ b/src/codegen/wasm_gc/body/emit.rs
@@ -614,13 +614,14 @@ pub(super) fn emit_expr(
 fn sum_or_record_eq_fn(operand: &Spanned<ResolvedExpr>, ctx: &EmitCtx<'_>) -> Option<u32> {
     let ty = operand.ty()?;
     match ty {
-        // temporary-migration-bridge: wasm-gc `TypeRegistry`
-        // (record_fields / variants / newtype_underlying) is still
-        // string-keyed by bare `TypeDef.name`. `flatten_multimodule`
-        // strips module prefixes from field types, so the registry
-        // and this lookup operate in the post-strip namespace where
-        // bare-name keying is consistent. Canonical-key migration
-        // is its own scope (paired flatten changes required).
+        // temporary-migration-bridge: wasm-gc `TypeRegistry` keys
+        // dep types by bare `TypeDef.name` for non-colliding bare
+        // names (the common case post #180 Phase 6 PR 3) and by
+        // canonical `Prefix.Name` for cross-module same-bare-name
+        // collisions. The bare-name lookup below hits the registry
+        // for the non-colliding path; collision-case eq dispatch is
+        // a follow-up (would need a typed key resolved against the
+        // post-flatten symbol table).
         crate::types::Type::Named { name, .. } => {
             // Newtypes already lower to their underlying primitive —
             // no helper needed (the default i64/f64 eq handles them).

--- a/src/codegen/wasm_gc/flatten.rs
+++ b/src/codegen/wasm_gc/flatten.rs
@@ -2,20 +2,44 @@
 //!
 //! The wasm-gc backend emits one standalone module today. Dependent Aver
 //! modules are therefore inlined into the entry module by prefixing function
-//! names with their module path and rewriting cross-module calls to those flat
-//! function names. Type definitions stay bare because the wasm-gc type
-//! registry is local to the final flattened module.
+//! names with their module path and rewriting cross-module calls to those
+//! flat function names.
+//!
+//! Type identity follows two rules:
+//!
+//! - **Non-colliding types** (a bare name declared by exactly one dep
+//!   module): the dep `TypeDef.name` stays bare. Entry-side qualified
+//!   references like `record Wrapper { status: TmpReviewB.Status }` get
+//!   their module prefix stripped to the bare form, matching the registry's
+//!   bare key. Stamped expression types from the pre-flatten typechecker
+//!   also use bare names and resolve correctly.
+//! - **Colliding types** (same bare name declared by two or more dep
+//!   modules — see #180 Phase 6 PR 3): dep `TypeDef.name` gets renamed to
+//!   the canonical `"Prefix.Name"` form (`Left.Box`, `Right.Box`) so the
+//!   wasm-gc `TypeRegistry` keys them into distinct slots. Dep-internal
+//!   bare references to the colliding own type (in `TypeDef` field types,
+//!   `FnDef` signatures, body `Constructor` / `RecordCreate` / `RecordUpdate`
+//!   / pattern heads, let-binding annotations) get rewritten to canonical
+//!   so the post-flatten resolver + registry agree. Entry-side qualified
+//!   references stay verbatim (no strip) for the same reason.
+//!
+//! Treating collision as the trigger keeps the migration narrow: the legacy
+//! strip path and bare-name lookups continue to work for every existing
+//! single-declarer dep type, and only the genuinely-ambiguous slot pair gets
+//! the canonical-key routing.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use crate::ast::{Expr, FnBody, Spanned, Stmt, TopLevel, TypeDef};
+use crate::ast::{Expr, FnBody, Pattern, Spanned, Stmt, TopLevel, TypeDef};
 use crate::codegen::ModuleInfo;
+use crate::codegen::common::type_def_name;
 
 /// Walks each loaded `ModuleInfo`, prefixes every fn name with
 /// `{module_prefix}_`, rewrites bare same-module call sites to use the
-/// prefixed name, then appends the dep's `TypeDef`s and `FnDef`s onto the
-/// entry items. Cross-module callsites in the entry are rewritten from
-/// `Attr(Ident("Fractal"), "render")` to `Ident("Fractal_render")`.
+/// prefixed name, strips non-colliding module-qualified type refs to their
+/// bare form, canonicalises colliding own-type refs to `Prefix.Name`, then
+/// appends the dep's renamed `TypeDef`s + prefixed `FnDef`s onto the entry
+/// items.
 ///
 /// Component Model is a future separate mode; this single-binary path is the
 /// bench-friendly and playground-friendly default.
@@ -25,6 +49,25 @@ pub fn flatten_multimodule(items: &mut Vec<TopLevel>, dep_modules: &[ModuleInfo]
     }
 
     let prefixes: HashSet<String> = dep_modules.iter().map(|m| m.prefix.clone()).collect();
+
+    // Bare-name → owning dep prefix(es) across all dep modules. A bare
+    // name that appears in two+ dep entries is "colliding"; the wasm-gc
+    // `TypeRegistry` keys those canonically (`Left.Box` / `Right.Box`)
+    // so the two slots don't merge under one bare key.
+    let mut bare_owners: HashMap<String, Vec<String>> = HashMap::new();
+    for dep in dep_modules {
+        for td in &dep.type_defs {
+            bare_owners
+                .entry(type_def_name(td).to_string())
+                .or_default()
+                .push(dep.prefix.clone());
+        }
+    }
+    let colliding_bare_names: HashSet<String> = bare_owners
+        .iter()
+        .filter(|(_, owners)| owners.len() > 1)
+        .map(|(bare, _)| bare.clone())
+        .collect();
 
     let qualified_type_names: HashSet<String> = dep_modules
         .iter()
@@ -38,16 +81,20 @@ pub fn flatten_multimodule(items: &mut Vec<TopLevel>, dep_modules: &[ModuleInfo]
         })
         .collect();
 
+    let empty_own_colliding: HashSet<String> = HashSet::new();
     let empty_set: HashSet<String> = HashSet::new();
+
     for item in items.iter_mut() {
         match item {
             TopLevel::FnDef(fd) => {
-                rewrite_fn_signature(fd, &qualified_type_names);
+                rewrite_fn_signature(fd, &qualified_type_names, &colliding_bare_names);
                 let body_arc = std::sync::Arc::make_mut(&mut fd.body);
                 let FnBody::Block(stmts) = body_arc;
-                rewrite_stmts(stmts, &prefixes, None, &empty_set);
+                rewrite_stmts(stmts, &prefixes, None, &empty_set, &empty_own_colliding, "");
             }
-            TopLevel::TypeDef(td) => rewrite_type_def(td, &qualified_type_names),
+            TopLevel::TypeDef(td) => {
+                rewrite_type_def(td, &qualified_type_names, &colliding_bare_names);
+            }
             _ => {}
         }
     }
@@ -55,18 +102,47 @@ pub fn flatten_multimodule(items: &mut Vec<TopLevel>, dep_modules: &[ModuleInfo]
     for dep in dep_modules {
         let same_module_fns: HashSet<String> =
             dep.fn_defs.iter().map(|fd| fd.name.clone()).collect();
+        // Own colliding type names — the canonicalisation passes use
+        // this set to rewrite dep-internal bare refs to `Prefix.Name`
+        // (only colliding ones need the rewrite; non-colliding bare
+        // names continue to resolve against the registry's bare key).
+        let own_colliding: HashSet<String> = dep
+            .type_defs
+            .iter()
+            .filter_map(|td| {
+                let bare = type_def_name(td).to_string();
+                if colliding_bare_names.contains(&bare) {
+                    Some(bare)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         for td in &dep.type_defs {
             let mut new_td = td.clone();
-            rewrite_type_def(&mut new_td, &qualified_type_names);
+            rewrite_type_def(&mut new_td, &qualified_type_names, &colliding_bare_names);
+            // Rename the typedef itself to `Prefix.Name` if it collides
+            // with another dep's bare name.
+            rename_typedef_if_colliding(&mut new_td, &dep.prefix, &colliding_bare_names);
             items.push(TopLevel::TypeDef(new_td));
         }
+
         for fd in &dep.fn_defs {
             let mut new_fd = fd.clone();
-            rewrite_fn_signature(&mut new_fd, &qualified_type_names);
+            rewrite_fn_signature(&mut new_fd, &qualified_type_names, &colliding_bare_names);
+            canonicalise_fn_signature_for_own_colliding(&mut new_fd, &dep.prefix, &own_colliding);
 
             let body_arc = std::sync::Arc::make_mut(&mut new_fd.body);
             let FnBody::Block(stmts) = body_arc;
-            rewrite_stmts(stmts, &prefixes, Some(&dep.prefix), &same_module_fns);
+            rewrite_stmts(
+                stmts,
+                &prefixes,
+                Some(&dep.prefix),
+                &same_module_fns,
+                &own_colliding,
+                &dep.prefix,
+            );
 
             new_fd.name = prefixed(&dep.prefix, &fd.name);
             items.push(TopLevel::FnDef(new_fd));
@@ -78,38 +154,132 @@ fn prefixed(prefix: &str, name: &str) -> String {
     format!("{}_{}", prefix.replace('.', "_"), name)
 }
 
-fn rewrite_fn_signature(fd: &mut crate::ast::FnDef, qualified_type_names: &HashSet<String>) {
+fn rewrite_fn_signature(
+    fd: &mut crate::ast::FnDef,
+    qualified_type_names: &HashSet<String>,
+    colliding_bare_names: &HashSet<String>,
+) {
     for (_, ty) in fd.params.iter_mut() {
-        *ty = strip_module_prefixes(ty, qualified_type_names);
+        *ty = strip_non_colliding_prefixes(ty, qualified_type_names, colliding_bare_names);
     }
-    fd.return_type = strip_module_prefixes(&fd.return_type, qualified_type_names);
+    fd.return_type =
+        strip_non_colliding_prefixes(&fd.return_type, qualified_type_names, colliding_bare_names);
 }
 
-fn rewrite_type_def(td: &mut TypeDef, qualified_type_names: &HashSet<String>) {
+fn rewrite_type_def(
+    td: &mut TypeDef,
+    qualified_type_names: &HashSet<String>,
+    colliding_bare_names: &HashSet<String>,
+) {
     match td {
         TypeDef::Sum { variants, .. } => {
             for variant in variants {
                 for ty in variant.fields.iter_mut() {
-                    *ty = strip_module_prefixes(ty, qualified_type_names);
+                    *ty = strip_non_colliding_prefixes(
+                        ty,
+                        qualified_type_names,
+                        colliding_bare_names,
+                    );
                 }
             }
         }
         TypeDef::Product { fields, .. } => {
             for (_, ty) in fields.iter_mut() {
-                *ty = strip_module_prefixes(ty, qualified_type_names);
+                *ty = strip_non_colliding_prefixes(ty, qualified_type_names, colliding_bare_names);
             }
         }
     }
 }
 
-fn strip_module_prefixes(type_str: &str, qualified_type_names: &HashSet<String>) -> String {
+fn rename_typedef_if_colliding(
+    td: &mut TypeDef,
+    dep_prefix: &str,
+    colliding_bare_names: &HashSet<String>,
+) {
+    match td {
+        TypeDef::Sum { name, .. } | TypeDef::Product { name, .. } => {
+            if colliding_bare_names.contains(name.as_str()) {
+                *name = format!("{dep_prefix}.{name}");
+            }
+        }
+    }
+}
+
+fn canonicalise_fn_signature_for_own_colliding(
+    fd: &mut crate::ast::FnDef,
+    dep_prefix: &str,
+    own_colliding: &HashSet<String>,
+) {
+    if own_colliding.is_empty() {
+        return;
+    }
+    for (_, ty) in fd.params.iter_mut() {
+        *ty = canonicalise_own_colliding(ty, dep_prefix, own_colliding);
+    }
+    fd.return_type = canonicalise_own_colliding(&fd.return_type, dep_prefix, own_colliding);
+}
+
+/// Strip module prefixes from qualified type references in `type_str`,
+/// but leave colliding refs canonical. `Vector<TmpReviewB.Status>` becomes
+/// `Vector<Status>`; `Vector<Left.Box>` stays as `Vector<Left.Box>` so
+/// downstream `TypeRegistry` lookups land on the right slot.
+fn strip_non_colliding_prefixes(
+    type_str: &str,
+    qualified_type_names: &HashSet<String>,
+    colliding_bare_names: &HashSet<String>,
+) -> String {
     if qualified_type_names.is_empty() {
         return type_str.to_string();
     }
     let mut out = type_str.to_string();
     for qualified in qualified_type_names {
-        if let Some((_, bare)) = qualified.rsplit_once('.') {
-            out = replace_qualified_type(&out, qualified, bare);
+        let Some((_, bare)) = qualified.rsplit_once('.') else {
+            continue;
+        };
+        if colliding_bare_names.contains(bare) {
+            // Two+ deps declare this bare name — keep the qualified form
+            // so the wasm-gc registry can disambiguate by canonical key.
+            continue;
+        }
+        out = replace_qualified_type(&out, qualified, bare);
+    }
+    out
+}
+
+/// Rewrite bare own-type references in `type_str` to `Prefix.Name` when
+/// the bare name is in `own_colliding`. Run after the strip pass so the
+/// two transforms compose cleanly.
+fn canonicalise_own_colliding(
+    type_str: &str,
+    dep_prefix: &str,
+    own_colliding: &HashSet<String>,
+) -> String {
+    if own_colliding.is_empty() {
+        return type_str.to_string();
+    }
+    let mut out = String::with_capacity(type_str.len());
+    let bytes = type_str.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b.is_ascii_alphabetic() || b == b'_' {
+            let start = i;
+            while i < bytes.len()
+                && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_' || bytes[i] == b'.')
+            {
+                i += 1;
+            }
+            let token = &type_str[start..i];
+            if !token.contains('.') && own_colliding.contains(token) {
+                out.push_str(dep_prefix);
+                out.push('.');
+                out.push_str(token);
+            } else {
+                out.push_str(token);
+            }
+        } else {
+            out.push(b as char);
+            i += 1;
         }
     }
     out
@@ -162,6 +332,8 @@ fn rewrite_expr(
     prefixes: &HashSet<String>,
     same_module_prefix: Option<&str>,
     same_module_fns: &HashSet<String>,
+    own_colliding: &HashSet<String>,
+    dep_prefix: &str,
 ) {
     match expr {
         Expr::FnCall(callee, args) => {
@@ -190,9 +362,18 @@ fn rewrite_expr(
                 prefixes,
                 same_module_prefix,
                 same_module_fns,
+                own_colliding,
+                dep_prefix,
             );
             for arg in args.iter_mut() {
-                rewrite_expr(&mut arg.node, prefixes, same_module_prefix, same_module_fns);
+                rewrite_expr(
+                    &mut arg.node,
+                    prefixes,
+                    same_module_prefix,
+                    same_module_fns,
+                    own_colliding,
+                    dep_prefix,
+                );
             }
         }
         Expr::TailCall(boxed) => {
@@ -202,7 +383,14 @@ fn rewrite_expr(
                 boxed.target = prefixed(prefix, &boxed.target);
             }
             for arg in boxed.args.iter_mut() {
-                rewrite_expr(&mut arg.node, prefixes, same_module_prefix, same_module_fns);
+                rewrite_expr(
+                    &mut arg.node,
+                    prefixes,
+                    same_module_prefix,
+                    same_module_fns,
+                    own_colliding,
+                    dep_prefix,
+                );
             }
         }
         Expr::BinOp(_, left, right) => {
@@ -211,12 +399,16 @@ fn rewrite_expr(
                 prefixes,
                 same_module_prefix,
                 same_module_fns,
+                own_colliding,
+                dep_prefix,
             );
             rewrite_expr(
                 &mut right.node,
                 prefixes,
                 same_module_prefix,
                 same_module_fns,
+                own_colliding,
+                dep_prefix,
             );
         }
         Expr::Neg(inner) => {
@@ -225,6 +417,8 @@ fn rewrite_expr(
                 prefixes,
                 same_module_prefix,
                 same_module_fns,
+                own_colliding,
+                dep_prefix,
             );
         }
         Expr::Match { subject, arms } => {
@@ -233,53 +427,94 @@ fn rewrite_expr(
                 prefixes,
                 same_module_prefix,
                 same_module_fns,
+                own_colliding,
+                dep_prefix,
             );
             for arm in arms.iter_mut() {
+                if !dep_prefix.is_empty() {
+                    canonicalise_pattern(&mut arm.pattern, dep_prefix, own_colliding);
+                }
                 rewrite_expr(
                     &mut arm.body.node,
                     prefixes,
                     same_module_prefix,
                     same_module_fns,
+                    own_colliding,
+                    dep_prefix,
                 );
             }
         }
         Expr::Attr(_, _) => {
+            // Cross-module call shape (`Worker.helper`) first — produces
+            // an `Ident("Worker_helper")` for FnCall callees. Doing the
+            // own-colliding canonicalisation before this would let the
+            // canonicalised form be mis-matched as a cross-module access
+            // and unrewritten back to bare.
             let rewrite = attr_chain_to_dotted(expr)
                 .and_then(|dotted| rewrite_dotted_module_ref(&dotted, prefixes));
             if let Some(new_node) = rewrite {
                 *expr = new_node;
                 return;
             }
+            if !dep_prefix.is_empty() {
+                canonicalise_attr_head_for_own_colliding(expr, dep_prefix, own_colliding);
+            }
             if let Expr::Attr(obj, _) = expr {
-                rewrite_expr(&mut obj.node, prefixes, same_module_prefix, same_module_fns);
+                rewrite_expr(
+                    &mut obj.node,
+                    prefixes,
+                    same_module_prefix,
+                    same_module_fns,
+                    own_colliding,
+                    dep_prefix,
+                );
             }
         }
-        Expr::Constructor(_, payload) => {
+        Expr::Constructor(name, payload) => {
+            if !dep_prefix.is_empty() {
+                canonicalise_constructor_name(name, dep_prefix, own_colliding);
+            }
             if let Some(payload) = payload.as_deref_mut() {
                 rewrite_expr(
                     &mut payload.node,
                     prefixes,
                     same_module_prefix,
                     same_module_fns,
+                    own_colliding,
+                    dep_prefix,
                 );
             }
         }
-        Expr::RecordCreate { fields, .. } => {
+        Expr::RecordCreate { type_name, fields } => {
+            if !dep_prefix.is_empty() {
+                canonicalise_bare_type_name(type_name, dep_prefix, own_colliding);
+            }
             for (_, expr) in fields.iter_mut() {
                 rewrite_expr(
                     &mut expr.node,
                     prefixes,
                     same_module_prefix,
                     same_module_fns,
+                    own_colliding,
+                    dep_prefix,
                 );
             }
         }
-        Expr::RecordUpdate { base, updates, .. } => {
+        Expr::RecordUpdate {
+            type_name,
+            base,
+            updates,
+        } => {
+            if !dep_prefix.is_empty() {
+                canonicalise_bare_type_name(type_name, dep_prefix, own_colliding);
+            }
             rewrite_expr(
                 &mut base.node,
                 prefixes,
                 same_module_prefix,
                 same_module_fns,
+                own_colliding,
+                dep_prefix,
             );
             for (_, expr) in updates.iter_mut() {
                 rewrite_expr(
@@ -287,6 +522,8 @@ fn rewrite_expr(
                     prefixes,
                     same_module_prefix,
                     same_module_fns,
+                    own_colliding,
+                    dep_prefix,
                 );
             }
         }
@@ -297,17 +534,28 @@ fn rewrite_expr(
                     prefixes,
                     same_module_prefix,
                     same_module_fns,
+                    own_colliding,
+                    dep_prefix,
                 );
             }
         }
         Expr::MapLiteral(entries) => {
             for (key, value) in entries.iter_mut() {
-                rewrite_expr(&mut key.node, prefixes, same_module_prefix, same_module_fns);
+                rewrite_expr(
+                    &mut key.node,
+                    prefixes,
+                    same_module_prefix,
+                    same_module_fns,
+                    own_colliding,
+                    dep_prefix,
+                );
                 rewrite_expr(
                     &mut value.node,
                     prefixes,
                     same_module_prefix,
                     same_module_fns,
+                    own_colliding,
+                    dep_prefix,
                 );
             }
         }
@@ -317,6 +565,8 @@ fn rewrite_expr(
                 prefixes,
                 same_module_prefix,
                 same_module_fns,
+                own_colliding,
+                dep_prefix,
             );
         }
         Expr::InterpolatedStr(parts) => {
@@ -327,11 +577,65 @@ fn rewrite_expr(
                         prefixes,
                         same_module_prefix,
                         same_module_fns,
+                        own_colliding,
+                        dep_prefix,
                     );
                 }
             }
         }
         _ => {}
+    }
+}
+
+fn canonicalise_bare_type_name(
+    type_name: &mut String,
+    dep_prefix: &str,
+    own_colliding: &HashSet<String>,
+) {
+    if !type_name.contains('.') && own_colliding.contains(type_name.as_str()) {
+        *type_name = format!("{dep_prefix}.{type_name}");
+    }
+}
+
+fn canonicalise_constructor_name(
+    name: &mut String,
+    dep_prefix: &str,
+    own_colliding: &HashSet<String>,
+) {
+    let head = name.split('.').next().unwrap_or(name);
+    if own_colliding.contains(head) {
+        let rest = &name[head.len()..];
+        *name = format!("{dep_prefix}.{head}{rest}");
+    }
+}
+
+fn canonicalise_attr_head_for_own_colliding(
+    expr: &mut Expr,
+    dep_prefix: &str,
+    own_colliding: &HashSet<String>,
+) {
+    fn walk(e: &mut Expr, dep_prefix: &str, own_colliding: &HashSet<String>, depth: u32) {
+        if depth > 32 {
+            return;
+        }
+        match e {
+            Expr::Attr(inner, _) => walk(&mut inner.node, dep_prefix, own_colliding, depth + 1),
+            Expr::Ident(name) if !name.contains('.') && own_colliding.contains(name.as_str()) => {
+                *name = format!("{dep_prefix}.{name}");
+            }
+            _ => {}
+        }
+    }
+    walk(expr, dep_prefix, own_colliding, 0);
+}
+
+fn canonicalise_pattern(pat: &mut Pattern, dep_prefix: &str, own_colliding: &HashSet<String>) {
+    if let Pattern::Constructor(name, _bindings) = pat {
+        let head = name.split('.').next().unwrap_or(name);
+        if own_colliding.contains(head) {
+            let rest = &name[head.len()..];
+            *name = format!("{dep_prefix}.{head}{rest}");
+        }
     }
 }
 
@@ -368,15 +672,34 @@ fn rewrite_stmts(
     prefixes: &HashSet<String>,
     same_module_prefix: Option<&str>,
     same_module_fns: &HashSet<String>,
+    own_colliding: &HashSet<String>,
+    dep_prefix: &str,
 ) {
     for stmt in stmts.iter_mut() {
         match stmt {
-            Stmt::Binding(_, _, expr) | Stmt::Expr(expr) => {
+            Stmt::Binding(_, type_ann, expr) => {
+                if !dep_prefix.is_empty()
+                    && let Some(ty) = type_ann.as_mut()
+                {
+                    *ty = canonicalise_own_colliding(ty, dep_prefix, own_colliding);
+                }
                 rewrite_expr(
                     &mut expr.node,
                     prefixes,
                     same_module_prefix,
                     same_module_fns,
+                    own_colliding,
+                    dep_prefix,
+                );
+            }
+            Stmt::Expr(expr) => {
+                rewrite_expr(
+                    &mut expr.node,
+                    prefixes,
+                    same_module_prefix,
+                    same_module_fns,
+                    own_colliding,
+                    dep_prefix,
                 );
             }
         }

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -4479,12 +4479,14 @@ fn register_nominal_in_type(
 ) {
     let canonical: String = t.display().chars().filter(|c| !c.is_whitespace()).collect();
     match t {
-        // temporary-migration-bridge: wasm-gc `TypeRegistry` is
-        // still string-keyed by bare `TypeDef.name` (flatten strips
-        // module prefixes from field types). Canonical-key
-        // migration for wasm-gc is a separate scope; until then
-        // bare-name keying is consistent within the registry's
-        // post-flatten namespace.
+        // temporary-migration-bridge: wasm-gc `TypeRegistry` keys
+        // dep types by bare `TypeDef.name` for non-colliding bare
+        // names (the common case post #180 Phase 6 PR 3) and by
+        // canonical `Prefix.Name` for cross-module same-bare-name
+        // collisions. The bare-name lookup below hits the registry
+        // for the non-colliding path; eq-helper registration on the
+        // collision path is a follow-up (would need a typed key
+        // resolved against the post-flatten symbol table).
         AverType::Named { name, .. } => {
             if type_registry.record_fields.contains_key(name) {
                 eq_helpers.register_transitive(name, EqKind::Record, type_registry);
@@ -4587,10 +4589,12 @@ fn discover_builtins_in_expr(
             // helper — register on discovery so the slot is allocated
             // before emit runs the BinOp dispatch.
             //
-            // temporary-migration-bridge: wasm-gc `TypeRegistry`
-            // still string-keyed; see the canonical-key migration
-            // note on `register_nominal_in_type`. Bare-name lookup
-            // is consistent within the post-flatten namespace.
+            // temporary-migration-bridge: same shape as the comment
+            // on `register_nominal_in_type` — bare-name lookup hits
+            // the registry for non-colliding dep types post #180
+            // Phase 6 PR 3; collision-case eq-helpers route through
+            // canonical `Prefix.Name` keys and need a typed lookup
+            // (follow-up scope).
             use crate::ast::BinOp as Op;
             if matches!(op, Op::Eq | Op::Neq)
                 && let Some(t) = l.ty()

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -140,6 +140,7 @@ pub(super) fn emit_module_with(
             &mut effect_registry,
             &mut eq_helpers_registry,
             &registry,
+            &symbol_table,
         );
     }
     // Sweep nominal element types of every registered List / Vector
@@ -4443,10 +4444,18 @@ fn discover_builtins_in_fn(
     effects: &mut EffectRegistry,
     eq_helpers: &mut EqHelperRegistry,
     type_registry: &TypeRegistry,
+    symbol_table: &crate::ir::SymbolTable,
 ) {
     let crate::ir::hir::ResolvedFnBody::Block(stmts) = fd.body.as_ref();
     for stmt in stmts {
-        discover_builtins_in_stmt(stmt, builtins, effects, eq_helpers, type_registry);
+        discover_builtins_in_stmt(
+            stmt,
+            builtins,
+            effects,
+            eq_helpers,
+            type_registry,
+            symbol_table,
+        );
     }
 }
 
@@ -4456,12 +4465,46 @@ fn discover_builtins_in_stmt(
     effects: &mut EffectRegistry,
     eq_helpers: &mut EqHelperRegistry,
     type_registry: &TypeRegistry,
+    symbol_table: &crate::ir::SymbolTable,
 ) {
     match stmt {
         crate::ir::hir::ResolvedStmt::Binding { value: e, .. }
-        | crate::ir::hir::ResolvedStmt::Expr(e) => {
-            discover_builtins_in_expr(&e.node, builtins, effects, eq_helpers, type_registry)
-        }
+        | crate::ir::hir::ResolvedStmt::Expr(e) => discover_builtins_in_expr(
+            &e.node,
+            builtins,
+            effects,
+            eq_helpers,
+            type_registry,
+            symbol_table,
+        ),
+    }
+}
+
+/// Recursively walks `t` and registers every nominal record/sum it
+/// reaches in `eq_helpers`. Needed for `==` on collection types
+/// whose element/key/value type is nominal — `List<Tree>`,
+/// `Map<Color, Tree>`, `Option<Box>`, etc. Without this, the
+/// helper-body emit (`emit_list_eq`, `emit_record_eq_inline`,
+/// `emit_eq_record`) would dispatch by `Call(__eq_<Tree>)` against
+/// an unregistered slot.
+/// Canonical wasm-gc `TypeRegistry` key for a `Type::Named` reference.
+///
+/// Resolves the bare/canonical name of a nominal type by routing through
+/// the post-flatten `SymbolTable` when the typechecker stamped a `TypeId`.
+/// Returns the registry key shape `TypeRegistry::build_with_handler`
+/// inserts under: bare for non-colliding dep types (where the wasm-gc
+/// link stage keeps the `TypeDef.name` as written) and canonical
+/// `Prefix.Name` for the cross-module same-bare-name collision case
+/// (where #180 Phase 6 PR 3's `flatten_multimodule` renamed the dep
+/// `TypeDef.name`). Falls back to `name` for builtins / unresolved refs
+/// whose `id` is `None`.
+fn named_type_registry_key(symbol_table: &crate::ir::SymbolTable, ty: &AverType) -> Option<String> {
+    match ty {
+        AverType::Named {
+            id: Some(type_id), ..
+        } => Some(symbol_table.type_entry(*type_id).key.canonical()),
+        AverType::Named { id: None, name } => Some(name.clone()),
+        _ => None,
     }
 }
 
@@ -4476,50 +4519,46 @@ fn register_nominal_in_type(
     t: &AverType,
     eq_helpers: &mut EqHelperRegistry,
     type_registry: &super::types::TypeRegistry,
+    symbol_table: &crate::ir::SymbolTable,
 ) {
     let canonical: String = t.display().chars().filter(|c| !c.is_whitespace()).collect();
     match t {
-        // temporary-migration-bridge: wasm-gc `TypeRegistry` keys
-        // dep types by bare `TypeDef.name` for non-colliding bare
-        // names (the common case post #180 Phase 6 PR 3) and by
-        // canonical `Prefix.Name` for cross-module same-bare-name
-        // collisions. The bare-name lookup below hits the registry
-        // for the non-colliding path; eq-helper registration on the
-        // collision path is a follow-up (would need a typed key
-        // resolved against the post-flatten symbol table).
-        AverType::Named { name, .. } => {
-            if type_registry.record_fields.contains_key(name) {
-                eq_helpers.register_transitive(name, EqKind::Record, type_registry);
+        AverType::Named { .. } => {
+            let Some(key) = named_type_registry_key(symbol_table, t) else {
+                return;
+            };
+            if type_registry.record_fields.contains_key(&key) {
+                eq_helpers.register_transitive(&key, EqKind::Record, type_registry);
             } else if type_registry
                 .variants
                 .values()
                 .flat_map(|v| v.iter())
-                .any(|v| &v.parent == name)
+                .any(|v| v.parent == key)
             {
-                eq_helpers.register_transitive(name, EqKind::Sum, type_registry);
+                eq_helpers.register_transitive(&key, EqKind::Sum, type_registry);
             }
         }
         AverType::Option(inner) => {
             eq_helpers.register_transitive(&canonical, EqKind::OptionEq, type_registry);
-            register_nominal_in_type(inner, eq_helpers, type_registry);
+            register_nominal_in_type(inner, eq_helpers, type_registry, symbol_table);
         }
         AverType::Result(ok, err) => {
             eq_helpers.register_transitive(&canonical, EqKind::ResultEq, type_registry);
-            register_nominal_in_type(ok, eq_helpers, type_registry);
-            register_nominal_in_type(err, eq_helpers, type_registry);
+            register_nominal_in_type(ok, eq_helpers, type_registry, symbol_table);
+            register_nominal_in_type(err, eq_helpers, type_registry, symbol_table);
         }
         AverType::Tuple(items) => {
             eq_helpers.register_transitive(&canonical, EqKind::TupleEq, type_registry);
             for item in items {
-                register_nominal_in_type(item, eq_helpers, type_registry);
+                register_nominal_in_type(item, eq_helpers, type_registry, symbol_table);
             }
         }
         AverType::List(inner) | AverType::Vector(inner) => {
-            register_nominal_in_type(inner, eq_helpers, type_registry);
+            register_nominal_in_type(inner, eq_helpers, type_registry, symbol_table);
         }
         AverType::Map(k, v) => {
-            register_nominal_in_type(k, eq_helpers, type_registry);
-            register_nominal_in_type(v, eq_helpers, type_registry);
+            register_nominal_in_type(k, eq_helpers, type_registry, symbol_table);
+            register_nominal_in_type(v, eq_helpers, type_registry, symbol_table);
         }
         _ => {}
     }
@@ -4531,6 +4570,7 @@ fn discover_builtins_in_expr(
     effects: &mut EffectRegistry,
     eq_helpers: &mut EqHelperRegistry,
     type_registry: &TypeRegistry,
+    symbol_table: &crate::ir::SymbolTable,
 ) {
     use crate::ir::hir::{ResolvedCallee, ResolvedExpr, ResolvedStrPart};
     match expr {
@@ -4563,7 +4603,14 @@ fn discover_builtins_in_expr(
                 }
             }
             for arg in args {
-                discover_builtins_in_expr(&arg.node, builtins, effects, eq_helpers, type_registry);
+                discover_builtins_in_expr(
+                    &arg.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
             }
         }
         ResolvedExpr::BinOp(op, l, r) => {
@@ -4587,28 +4634,26 @@ fn discover_builtins_in_expr(
             }
             // Sum/record `==`/`!=` need a per-type `__eq_<TypeName>`
             // helper — register on discovery so the slot is allocated
-            // before emit runs the BinOp dispatch.
-            //
-            // temporary-migration-bridge: same shape as the comment
-            // on `register_nominal_in_type` — bare-name lookup hits
-            // the registry for non-colliding dep types post #180
-            // Phase 6 PR 3; collision-case eq-helpers route through
-            // canonical `Prefix.Name` keys and need a typed lookup
-            // (follow-up scope).
+            // before emit runs the BinOp dispatch. Use the typed-key
+            // resolver so non-colliding dep types resolve to their
+            // registry-bare key and the cross-module same-bare-name
+            // collision case (#180 Phase 6 PR 3) resolves to the
+            // renamed canonical `Prefix.Name` key.
             use crate::ast::BinOp as Op;
             if matches!(op, Op::Eq | Op::Neq)
                 && let Some(t) = l.ty()
-                && let AverType::Named { name, .. } = t
+                && matches!(t, AverType::Named { .. })
+                && let Some(key) = named_type_registry_key(symbol_table, t)
             {
-                if type_registry.record_fields.contains_key(name) {
-                    eq_helpers.register_transitive(name, EqKind::Record, type_registry);
+                if type_registry.record_fields.contains_key(&key) {
+                    eq_helpers.register_transitive(&key, EqKind::Record, type_registry);
                 } else if type_registry
                     .variants
                     .values()
                     .flat_map(|v| v.iter())
-                    .any(|v| &v.parent == name)
+                    .any(|v| v.parent == key)
                 {
-                    eq_helpers.register_transitive(name, EqKind::Sum, type_registry);
+                    eq_helpers.register_transitive(&key, EqKind::Sum, type_registry);
                 }
             }
             // List / Vector / Map / Option / Result / Tuple `==` —
@@ -4619,16 +4664,44 @@ fn discover_builtins_in_expr(
             if matches!(op, Op::Eq | Op::Neq)
                 && let Some(t) = l.ty()
             {
-                register_nominal_in_type(t, eq_helpers, type_registry);
+                register_nominal_in_type(t, eq_helpers, type_registry, symbol_table);
             }
-            discover_builtins_in_expr(&l.node, builtins, effects, eq_helpers, type_registry);
-            discover_builtins_in_expr(&r.node, builtins, effects, eq_helpers, type_registry);
+            discover_builtins_in_expr(
+                &l.node,
+                builtins,
+                effects,
+                eq_helpers,
+                type_registry,
+                symbol_table,
+            );
+            discover_builtins_in_expr(
+                &r.node,
+                builtins,
+                effects,
+                eq_helpers,
+                type_registry,
+                symbol_table,
+            );
         }
         ResolvedExpr::Neg(inner) => {
-            discover_builtins_in_expr(&inner.node, builtins, effects, eq_helpers, type_registry);
+            discover_builtins_in_expr(
+                &inner.node,
+                builtins,
+                effects,
+                eq_helpers,
+                type_registry,
+                symbol_table,
+            );
         }
         ResolvedExpr::Match { subject, arms } => {
-            discover_builtins_in_expr(&subject.node, builtins, effects, eq_helpers, type_registry);
+            discover_builtins_in_expr(
+                &subject.node,
+                builtins,
+                effects,
+                eq_helpers,
+                type_registry,
+                symbol_table,
+            );
             // String-subject match (`match path { "/" -> ... }`)
             // needs `StringEq` to compare each non-default arm's
             // literal against the subject. Register it eagerly when
@@ -4648,34 +4721,80 @@ fn discover_builtins_in_expr(
                     effects,
                     eq_helpers,
                     type_registry,
+                    symbol_table,
                 );
             }
         }
         ResolvedExpr::TailCall { args, .. } => {
             for arg in args {
-                discover_builtins_in_expr(&arg.node, builtins, effects, eq_helpers, type_registry);
+                discover_builtins_in_expr(
+                    &arg.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
             }
         }
-        ResolvedExpr::Attr(obj, _) => {
-            discover_builtins_in_expr(&obj.node, builtins, effects, eq_helpers, type_registry)
-        }
-        ResolvedExpr::ErrorProp(inner) => {
-            discover_builtins_in_expr(&inner.node, builtins, effects, eq_helpers, type_registry)
-        }
+        ResolvedExpr::Attr(obj, _) => discover_builtins_in_expr(
+            &obj.node,
+            builtins,
+            effects,
+            eq_helpers,
+            type_registry,
+            symbol_table,
+        ),
+        ResolvedExpr::ErrorProp(inner) => discover_builtins_in_expr(
+            &inner.node,
+            builtins,
+            effects,
+            eq_helpers,
+            type_registry,
+            symbol_table,
+        ),
         ResolvedExpr::Ctor(_, args) => {
             for a in args {
-                discover_builtins_in_expr(&a.node, builtins, effects, eq_helpers, type_registry);
+                discover_builtins_in_expr(
+                    &a.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
             }
         }
         ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, e) in fields {
-                discover_builtins_in_expr(&e.node, builtins, effects, eq_helpers, type_registry);
+                discover_builtins_in_expr(
+                    &e.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
             }
         }
         ResolvedExpr::RecordUpdate { base, updates, .. } => {
-            discover_builtins_in_expr(&base.node, builtins, effects, eq_helpers, type_registry);
+            discover_builtins_in_expr(
+                &base.node,
+                builtins,
+                effects,
+                eq_helpers,
+                type_registry,
+                symbol_table,
+            );
             for (_, e) in updates {
-                discover_builtins_in_expr(&e.node, builtins, effects, eq_helpers, type_registry);
+                discover_builtins_in_expr(
+                    &e.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
             }
         }
         // `InterpolatedStr` lowers to `array.new_fixed` + the variadic
@@ -4702,18 +4821,33 @@ fn discover_builtins_in_expr(
                         effects,
                         eq_helpers,
                         type_registry,
+                        symbol_table,
                     );
                 }
             }
         }
         ResolvedExpr::List(items) => {
             for item in items {
-                discover_builtins_in_expr(&item.node, builtins, effects, eq_helpers, type_registry);
+                discover_builtins_in_expr(
+                    &item.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
             }
         }
         ResolvedExpr::Tuple(items) => {
             for item in items {
-                discover_builtins_in_expr(&item.node, builtins, effects, eq_helpers, type_registry);
+                discover_builtins_in_expr(
+                    &item.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
             }
         }
         ResolvedExpr::IndependentProduct(items, _) => {
@@ -4729,13 +4863,34 @@ fn discover_builtins_in_expr(
             effects.register(EffectName::RecordSetBranch);
             effects.register(EffectName::RecordExitGroup);
             for item in items {
-                discover_builtins_in_expr(&item.node, builtins, effects, eq_helpers, type_registry);
+                discover_builtins_in_expr(
+                    &item.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
             }
         }
         ResolvedExpr::MapLiteral(entries) => {
             for (k, v) in entries {
-                discover_builtins_in_expr(&k.node, builtins, effects, eq_helpers, type_registry);
-                discover_builtins_in_expr(&v.node, builtins, effects, eq_helpers, type_registry);
+                discover_builtins_in_expr(
+                    &k.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
+                discover_builtins_in_expr(
+                    &v.node,
+                    builtins,
+                    effects,
+                    eq_helpers,
+                    type_registry,
+                    symbol_table,
+                );
             }
         }
         _ => {}

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -312,6 +312,58 @@ record Box
     );
 }
 
+// Cross-module same-bare-name `==`/`!=` dispatch — exercises the
+// canonical-key routing through `named_type_registry_key` at the three
+// `temporary-migration-bridge` eq-helper sites (`register_nominal_in_
+// type`, the `BinOp Eq/Neq` arm of `discover_builtins_in_expr`,
+// `sum_or_record_eq_fn`). Pre-#180-Phase-6-PR-3 these resolved the
+// per-type `__eq_<Box>` slot by the bare `Type::Named.name` of the
+// operand's stamped type — fine for non-colliding dep types, but in
+// the collision case the registry had renamed `Left.Box` / `Right.Box`
+// canonical entries and the bare lookup would miss, leaving the eq
+// helper unregistered and the BinOp emit unable to dispatch.
+#[test]
+fn cross_module_same_bare_name_records_dispatch_eq_via_canonical_key() {
+    let entry_src = r#"
+module Entry
+    intent = "cross-module same-bare-name == dispatch"
+    depends [Left, Right]
+
+fn main() -> Int
+    a = Left.Box(value = 7)
+    b = Left.Box(value = 7)
+    c = Right.Box(value = 7)
+    d = Right.Box(value = 9)
+    match Bool.and(a == b, c != d)
+        true -> 1
+        false -> 0
+"#;
+    let left_src = r#"
+module Left
+    intent = "left container"
+    exposes [Box]
+    depends []
+
+record Box
+    value: Int
+"#;
+    let right_src = r#"
+module Right
+    intent = "right container"
+    exposes [Box]
+    depends []
+
+record Box
+    value: Int
+"#;
+    let result = run_int_multi(entry_src, &[("Left", left_src), ("Right", right_src)]);
+    assert_eq!(
+        result, 1,
+        "expected Left.Box eq + Right.Box neq to dispatch through canonical \
+         per-type __eq_<X> helpers post #180 Phase 6 PR 3 — got {result}"
+    );
+}
+
 // ────────────────────────────────────────────────────────────────────
 // List<T>
 // ────────────────────────────────────────────────────────────────────

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -241,6 +241,77 @@ fn helper(n: Int) -> Int
     );
 }
 
+// Cross-module same-bare-name `TypeDef` regression for wasm-gc
+// — known-failing pin, `#[ignore]`'d until the canonical-key
+// migration lands.
+//
+// Epic #180 Phase 6 PR A (#189) migrated Dafny + Rust registries
+// to canonical keys (`Left.Box` vs `Right.Box`). wasm-gc's
+// `TypeRegistry` plus the `flatten_multimodule` field-type
+// stripping pass are interconnected: changing one without the
+// other breaks the wider lookup chain (record field types →
+// record_type_idx → struct emission, constructor name normalise
+// → variant routing, etc.). A complete migration touches
+// `flatten`, `TypeRegistry::build_with_handler`, and every
+// downstream walk that lookups TypeDef.name — meaningfully
+// bigger scope than fits a single PR alongside the Phase 6
+// follow-ups.
+//
+// Pinned here as a RED test so the regression has a name and
+// the canonical-key migration has a clear acceptance gate.
+// Three `temporary-migration-bridge` tagged sites in
+// `wasm_gc/{module,body/emit}.rs` (PR #191) are the entry
+// points that flip together with the registry storage.
+#[test]
+fn cross_module_same_bare_name_types_resolve_to_distinct_records() {
+    // Two dep modules each declare `record Box { value: Int }`
+    // — same bare name, different field schemas. Entry creates
+    // one of each and reads `.value`. Pre-migration,
+    // `flatten_multimodule` strips module prefixes from field
+    // types, both `Box` records land under the bare-name `Box`
+    // slot in `TypeRegistry`, and the second
+    // `record_fields.insert` wins → record-create / projection
+    // picks the wrong field schema (or, more commonly, validation
+    // fails before that point).
+    //
+    // Post-migration, wasm-gc `TypeRegistry` would key by
+    // canonical name (`Left.Box` vs `Right.Box`), so the two
+    // records occupy distinct slots. Expected `5 + 10 = 15`.
+    let entry_src = r#"
+module Entry
+    intent = "cross-module same-bare-name TYPE regression"
+    depends [Left, Right]
+
+fn main() -> Int
+    Left.Box(value = 5).value + Right.Box(value = 10).value
+"#;
+    let left_src = r#"
+module Left
+    intent = "left container"
+    exposes [Box]
+    depends []
+
+record Box
+    value: Int
+"#;
+    let right_src = r#"
+module Right
+    intent = "right container"
+    exposes [Box]
+    depends []
+
+record Box
+    value: Int
+"#;
+    let result = run_int_multi(entry_src, &[("Left", left_src), ("Right", right_src)]);
+    assert_eq!(
+        result, 15,
+        "expected Left.Box(5).value + Right.Box(10).value = 15; \
+         a divergence here means cross-module TypeDef bare names \
+         collided in the wasm-gc registry"
+    );
+}
+
 // ────────────────────────────────────────────────────────────────────
 // List<T>
 // ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Closes the cross-module same-bare-name `TypeDef` regression in the wasm-gc backend (the RED `cross_module_same_bare_name_types_resolve_to_distinct_records` pin in `tests/wasm_gc_spec.rs` is now green).
- `flatten_multimodule` is now collision-aware: same bare name declared by two+ dep modules → dep `TypeDef.name` gets renamed to `Prefix.Name` and dep-internal bare references to that own type are canonicalised in the same form. Single-declarer dep types keep the legacy bare-name flow.
- Builds on the Dafny + Rust canonical-key migration shape from #189; the three `temporary-migration-bridge` tagged eq-helper sites from #191 get refreshed comments noting the residual collision+eq follow-up.

## What changes

`src/codegen/wasm_gc/flatten.rs` (the bulk of the diff) gains:
- A pre-pass over `dep_modules` building `bare_owners: HashMap<bare → Vec<prefix>>` and the derived `colliding_bare_names` set.
- A modified strip pass (`strip_non_colliding_prefixes`) — qualified refs whose bare half is in the collision set keep their `Prefix.Name` form; non-colliding qualified refs strip to bare exactly like before.
- A canonicalise pass (`canonicalise_own_colliding` for type strings, plus body walkers for `Constructor`, `RecordCreate`, `RecordUpdate`, `Pattern::Constructor` heads, `Attr` chain heads, let-binding annotations).
- A rename step for colliding dep `TypeDef.name` itself (`Box` → `Left.Box`).

`src/codegen/wasm_gc/module.rs` + `body/emit.rs`: the three `temporary-migration-bridge` comments are rewritten to describe the new state — bare-name lookups are correct for non-colliding dep types post-PR; the collision+eq case is documented as a narrower follow-up.

`tests/wasm_gc_spec.rs`: the `cross_module_same_bare_name_types_resolve_to_distinct_records` pin loses its `#[ignore]`.

## Test plan

- [x] `cross_module_same_bare_name_types_resolve_to_distinct_records` passes (RED → GREEN).
- [x] `playground::compiles_multi_file_wasm_gc_with_imported_type_in_record_field` still passes.
- [x] `playground::compiles_multi_file_rogue_from_virtual_fs` still passes.
- [x] `cargo test` clean.
- [x] `cargo test --features wasm` clean.
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] All seven wasm-gc games (snake/life/wumpus/tetris/checkers/doom/rogue) compile via `aver compile --target=wasm-gc … -o /tmp/<name>.wasm` and produce validating bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)