### PR TITLE
codegen/rust: bridge fn_sigs sites → typed-HIR — #180 Phase 7 PR 1/n

### DIFF
--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -815,7 +815,9 @@ fn borrow_mask_from_fn_def(
 
 /// Look up whether the callee's i-th parameter is borrowed (`&T`).
 /// Returns a Vec of booleans, one per parameter, indicating borrow status.
-/// Uses fn_sigs first, falls back to FnDef type annotations from the AST.
+/// Uses the resolved-program view for typed param types; falls back to
+/// `FnDef` AST annotations when the callee isn't in the view (only TCO
+/// status reads from the AST `FnDef`).
 /// TCO functions (self or mutual) never use borrow-by-default.
 fn callee_borrow_mask(name: &str, arg_count: usize, ctx: &CodegenContext) -> Vec<bool> {
     // First, try to find the FnDef to check for TCO (which overrides everything)
@@ -824,30 +826,27 @@ fn callee_borrow_mask(name: &str, arg_count: usize, ctx: &CodegenContext) -> Vec
         return borrow_mask_from_fn_def(fd, arg_count, ctx);
     }
 
-    // No FnDef found, try fn_sigs (type-checker resolved types)
+    // No FnDef found — read param types from the resolved-program
+    // view. The qualified lookup hits cross-module callsites that
+    // arrive as bare dotted names; the bare-name fallback covers
+    // entry-scope synthesised wrappers.
     let lookup_name = if let Some((prefix, bare)) = resolve_module_call(name, ctx) {
         crate::visibility::qualified_name(prefix, bare)
     } else {
         name.to_string()
     };
-
-    // temporary-migration-bridge: `ctx.fn_sigs` borrow-decision
-    // fallback for callees that haven't been threaded through
-    // the resolved-program view (cross-module callsites where
-    // only the dotted source name is in scope). Slated for
-    // removal with Phase 7 of #180.
-    if let Some((param_types, _, _)) = ctx
-        .fn_sigs
-        .get(&lookup_name)
-        .or_else(|| ctx.fn_sigs.get(name))
-    {
-        // Without FnDef we can't check TCO status, but self-TCO functions
-        // always resolve via find_fn_def_by_name above, so this path is safe
-        // for borrow-by-default on all non-scalar types including Named.
-        return param_types
+    let resolved = crate::codegen::common::fn_id_for_dotted_name(ctx, &lookup_name)
+        .or_else(|| crate::codegen::common::fn_id_for_dotted_name(ctx, name))
+        .and_then(|id| ctx.resolved_program.fn_by_id(id));
+    if let Some(rfd) = resolved {
+        // Self-TCO functions always resolve via `find_fn_def_by_name`
+        // above, so this path is safe for borrow-by-default on all
+        // non-scalar types including Named.
+        return rfd
+            .params
             .iter()
             .take(arg_count)
-            .map(should_borrow_param)
+            .map(|(_, ty)| should_borrow_param(ty))
             .collect();
     }
 
@@ -1709,39 +1708,25 @@ fn emit_list_arm_body(arm: &ResolvedMatchArm, ctx: &CodegenContext, body: String
     }
 }
 
-// temporary-migration-bridge: constructor-boxed-positions
-// detection still consults `ctx.fn_sigs` because constructors
-// are registered under dotted source names (`"Type.Variant"`)
-// and the cross-module suffix fallback hasn't been threaded
-// through the resolved-program view yet. Identity comparison
-// for the param-vs-return Named ref already prefers `TypeId`
-// via `Type::named_id()` further down (PR #189).
+/// Recursive-position detection for a record/variant constructor:
+/// returns the indices of constructor fields whose declared type is
+/// the constructor's owning type itself (the boxed-positions a
+/// `Tree.Node(left: Tree, value: Int, right: Tree)` lowers under in
+/// the Rust backend via `Arc::new(...)` to keep the type sized).
+///
+/// #180 Phase 7: routes through `find_ctor_owning_type` (which walks
+/// `ctx.symbol_table` + `ctx.items` / `ctx.modules`) instead of the
+/// legacy `ctx.fn_sigs` keyed by dotted source name. Identity-safe
+/// across cross-module same-bare-name twins via `TypeId` equality.
 pub(super) fn constructor_boxed_positions(name: &str, ctx: &CodegenContext) -> HashSet<usize> {
-    let sig = ctx.fn_sigs.get(name).or_else(|| {
-        // Cross-module constructors: "Type.Variant" may be registered as
-        // "Module.Type.Variant" in fn_sigs. Search by suffix.
-        let suffix = format!(".{}", name);
-        ctx.fn_sigs
-            .iter()
-            .find(|(k, _)| k.ends_with(&suffix))
-            .map(|(_, v)| v)
-    });
     let mut out = HashSet::new();
-    let Some((params, ret, _)) = sig else {
+    let Some(decl) = find_ctor_owning_type(name, ctx) else {
         return out;
     };
-    let Some(ret_name) = ret.named_name() else {
-        return out;
-    };
-    let ret_id = ret.named_id();
-    // Epic #180 Phase 6 — prefer `TypeId` equality when both
-    // sides carry a stamp, fall back to `name` for `id: None`
-    // refs (synthetic / unresolved ctor sigs). Identity-safe
-    // across cross-module same-bare-name twins.
-    for (idx, param) in params.iter().enumerate() {
-        let matches = match (ret_id, param.named_id()) {
+    for (idx, field_ty) in decl.field_types.iter().enumerate() {
+        let matches = match (decl.owning_type_id, field_ty.named_id()) {
             (Some(r), Some(p)) => r == p,
-            _ => param.named_name() == Some(ret_name),
+            _ => field_ty.named_name() == decl.owning_type_name.as_deref(),
         };
         if matches {
             out.insert(idx);
@@ -1750,33 +1735,131 @@ pub(super) fn constructor_boxed_positions(name: &str, ctx: &CodegenContext) -> H
     out
 }
 
+/// Constructor declaration view — the constructor's field types +
+/// the canonical identity of the type the constructor belongs to.
+/// Built by walking `TypeDef`s in `ctx.items` and dep modules.
+struct CtorDecl {
+    /// Parsed field types in declaration order. Carry stamped
+    /// `Type::Named.id` when the field references a known nominal
+    /// type post-resolver — `parse_type_str` reads them off the
+    /// source annotation, and `Type::named_id()` reflects whatever
+    /// the type-string resolver populated.
+    field_types: Vec<crate::types::Type>,
+    /// Owning type's `TypeId` (when registered in the symbol
+    /// table) — preferred identity primitive for recursive-field
+    /// detection.
+    owning_type_id: Option<crate::ir::TypeId>,
+    /// Owning type's canonical name — fallback identity when
+    /// `owning_type_id` isn't stamped (synthetic typedefs, refs not
+    /// indexed by the table).
+    owning_type_name: Option<String>,
+}
+
+fn find_ctor_owning_type(name: &str, ctx: &CodegenContext) -> Option<CtorDecl> {
+    use crate::ast::{TopLevel, TypeDef};
+
+    let consider =
+        |type_name: &str, ctor_name: &str, fields: Vec<crate::types::Type>| -> CtorDecl {
+            let owning_type_id = ctx
+                .symbol_table
+                .type_id_of(&crate::ir::TypeKey::entry(type_name))
+                .or_else(|| {
+                    // The bare lookup didn't hit — try as `Module.Name`
+                    // for module-scoped types whose key carries an
+                    // explicit prefix.
+                    type_name.rsplit_once('.').and_then(|(prefix, bare)| {
+                        ctx.symbol_table
+                            .type_id_of(&crate::ir::TypeKey::in_module(prefix.to_string(), bare))
+                    })
+                });
+            let _ = ctor_name;
+            CtorDecl {
+                field_types: fields,
+                owning_type_id,
+                owning_type_name: Some(type_name.to_string()),
+            }
+        };
+
+    // Constructor name shapes the source may produce:
+    //   - `Shape.Circle` (entry sum type)
+    //   - `MyModule.Shape.Circle` (module sum type — dotted parent)
+    //   - `Box` (entry product / single-ctor type)
+    //   - `MyModule.Box` (module product)
+    //
+    // Walk every typedef across entry + dep modules and match either
+    // the bare-name product form or the `parent.variant` sum form.
+    let walk_one = |td: &TypeDef, scope: Option<&str>| -> Option<CtorDecl> {
+        match td {
+            TypeDef::Sum {
+                name: parent,
+                variants,
+                ..
+            } => {
+                let parent_full = match scope {
+                    Some(prefix) => format!("{prefix}.{parent}"),
+                    None => parent.clone(),
+                };
+                for v in variants {
+                    let bare_form = format!("{parent}.{}", v.name);
+                    let full_form = format!("{parent_full}.{}", v.name);
+                    if name == bare_form || name == full_form {
+                        let fields = v
+                            .fields
+                            .iter()
+                            .map(|t| crate::types::parse_type_str(t))
+                            .collect();
+                        return Some(consider(&parent_full, &v.name, fields));
+                    }
+                }
+                None
+            }
+            TypeDef::Product {
+                name: parent,
+                fields,
+                ..
+            } => {
+                let parent_full = match scope {
+                    Some(prefix) => format!("{prefix}.{parent}"),
+                    None => parent.clone(),
+                };
+                if name == parent || name == parent_full {
+                    let fts = fields
+                        .iter()
+                        .map(|(_, t)| crate::types::parse_type_str(t))
+                        .collect();
+                    return Some(consider(&parent_full, parent, fts));
+                }
+                None
+            }
+        }
+    };
+
+    for item in &ctx.items {
+        if let TopLevel::TypeDef(td) = item
+            && let Some(decl) = walk_one(td, None)
+        {
+            return Some(decl);
+        }
+    }
+    for m in &ctx.modules {
+        for td in &m.type_defs {
+            if let Some(decl) = walk_one(td, Some(&m.prefix)) {
+                return Some(decl);
+            }
+        }
+    }
+    None
+}
+
 pub(super) fn constructor_boxed_bindings(
     name: &str,
     bindings: &[String],
     ctx: &CodegenContext,
 ) -> Vec<String> {
-    let mut sig_name = None;
-    if ctx.fn_sigs.contains_key(name) {
-        sig_name = Some(name.to_string());
-    } else {
-        // Cross-module constructors: bare or dotted name may be registered
-        // with a module prefix in fn_sigs. Search by suffix.
-        let suffix = format!(".{}", name);
-        let mut matches = ctx
-            .fn_sigs
-            .keys()
-            .filter(|k| k.ends_with(&suffix))
-            .cloned()
-            .collect::<Vec<_>>();
-        matches.sort();
-        if matches.len() == 1 {
-            sig_name = matches.into_iter().next();
-        }
-    }
-    let Some(sig_name) = sig_name else {
-        return Vec::new();
-    };
-    let boxed = constructor_boxed_positions(&sig_name, ctx);
+    // `constructor_boxed_positions` walks `TypeDef`s directly post-#180
+    // Phase 7, so the dotted-vs-bare ambiguity is resolved by the type
+    // walker rather than by canonicalising the constructor name here.
+    let boxed = constructor_boxed_positions(name, ctx);
     bindings
         .iter()
         .enumerate()

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -372,17 +372,23 @@ fn type_can_derive_hash_eq(td: &TypeDef, ctx: &CodegenContext) -> bool {
     rust_hash_eq_safe_named(&key, ctx, &mut visiting)
 }
 
-// temporary-migration-bridge: `ctx.fn_sigs` side channel is
-// slated for removal in Phase 7 of #180 (projection from
-// `ResolvedProgramView` + typed `.ty()`). This memo-eligibility
-// check is identity-safe today because `fd.name` is unambiguous
-// in the entry scope where memo wrappers are synthesised.
+/// Memo-eligibility predicate: a fn supports the Rust memoization
+/// wrapper only if every one of its declared param types is hash+eq
+/// safe in the Rust lowering. Reads param types directly from the
+/// `ResolvedFnDef` (typed-HIR canonical source) — #180 Phase 7's
+/// projection of `ctx.fn_sigs` onto the resolved view. Memo wrappers
+/// are synthesised in the entry scope, so the `&FnDef` is unambiguous;
+/// `fn_id_for_decl` resolves it through the symbol-table-keyed view.
 fn fn_supports_rust_memo(fd: &FnDef, ctx: &CodegenContext) -> bool {
-    ctx.fn_sigs.get(&fd.name).is_some_and(|(params, _, _)| {
-        params.iter().all(|param| {
-            let mut visiting = HashSet::new();
-            rust_hash_eq_safe_type(param, ctx, &mut visiting)
-        })
+    let Some(fn_id) = crate::codegen::common::fn_id_for_decl(ctx, fd) else {
+        return false;
+    };
+    let Some(rfd) = ctx.resolved_program.fn_by_id(fn_id) else {
+        return false;
+    };
+    rfd.params.iter().all(|(_, param)| {
+        let mut visiting = HashSet::new();
+        rust_hash_eq_safe_type(param, ctx, &mut visiting)
     })
 }
 
@@ -562,29 +568,22 @@ fn emit_product_type(
     out.trim_end().to_string()
 }
 
-/// Collect local_types from function signature or annotations.
+/// Collect local_types from function signature.
 ///
-/// temporary-migration-bridge: `ctx.fn_sigs` side channel is
-/// slated for removal in Phase 7 of #180. Synthetic / mid-
-/// rewrite fns the resolved-view path doesn't index fall back
-/// here; the typed `collect_fn_local_types_from_resolved` is
-/// the preferred entry point for resolved fn defs.
+/// #180 Phase 7: routes through the `ResolvedProgramView` (already-
+/// parsed typed params) when the fn resolves through the symbol
+/// table. Synthetic / mid-rewrite fns the resolved-view path doesn't
+/// index fall back to `parse_type_str` on the AST annotations.
 fn collect_fn_local_types(fd: &FnDef, ctx: &CodegenContext) -> HashMap<String, Type> {
-    let mut local_types = HashMap::new();
-    if let Some((param_types, _, _)) = ctx.fn_sigs.get(&fd.name) {
-        for (i, (name, _)) in fd.params.iter().enumerate() {
-            if let Some(ty) = param_types.get(i) {
-                local_types.insert(name.clone(), ty.clone());
-            }
-        }
-    } else {
-        // Fallback: parse type annotations directly
-        for (name, type_ann) in &fd.params {
-            let ty = crate::types::parse_type_str(type_ann);
-            local_types.insert(name.clone(), ty);
-        }
+    let resolved = crate::codegen::common::fn_id_for_decl(ctx, fd)
+        .and_then(|id| ctx.resolved_program.fn_by_id(id));
+    if let Some(rfd) = resolved {
+        return collect_fn_local_types_from_resolved(rfd);
     }
-    local_types
+    fd.params
+        .iter()
+        .map(|(name, type_ann)| (name.clone(), crate::types::parse_type_str(type_ann)))
+        .collect()
 }
 
 /// Collect local_types directly from a `ResolvedFnDef`'s already-
@@ -1232,26 +1231,35 @@ fn passthrough_param_names(
         .collect()
 }
 
-// temporary-migration-bridge: `ctx.fn_sigs` lookup for the
-// effects slot. Slated for removal in Phase 7 of #180 (effects
-// projected from `ResolvedFnDef.effects`). Today's bare-name
-// lookup is consistent with the entry-scope assumption the
-// memo wrapper synthesis already makes.
-fn lookup_call_effects<'a>(name: &str, ctx: &'a CodegenContext) -> Option<&'a Vec<String>> {
-    if let Some((_, _, effects)) = ctx.fn_sigs.get(name) {
-        return Some(effects);
+/// Resolve the declared effect list of a callee by source-level
+/// name. #180 Phase 7: routes through the `ResolvedProgramView` —
+/// `fn_id_for_dotted_name` handles the bare/dotted split, then the
+/// fn's resolved effects are read off `ResolvedFnDef.effects`. The
+/// suffix fallback survives for callsites that haven't been threaded
+/// through a `FnKey` yet (entry-scope synthesised wrappers calling
+/// dep fns by bare name).
+///
+/// Returns `Some([])` for known pure fns, `Some([Console.print, …])`
+/// for declared effects, or `None` when the name doesn't resolve.
+fn lookup_call_effects(name: &str, ctx: &CodegenContext) -> Option<Vec<String>> {
+    if let Some(fn_id) = crate::codegen::common::fn_id_for_dotted_name(ctx, name)
+        && let Some(rfd) = ctx.resolved_program.fn_by_id(fn_id)
+    {
+        return Some(rfd.effects.iter().map(|e| e.node.clone()).collect());
     }
-
+    // Suffix fallback: a bare name (or one without an exact key)
+    // matches against module-scoped fns sharing the bare suffix.
+    // Returns a unique match only — ambiguity (two modules with the
+    // same bare fn) keeps the legacy behaviour of returning `None`.
     let bare = name.rsplit('.').next().unwrap_or(name);
-    let suffix = format!(".{}", bare);
-    let mut matches = ctx
-        .fn_sigs
-        .iter()
-        .filter_map(|(candidate, (_, _, effects))| {
-            (candidate == name || candidate == bare || candidate.ends_with(&suffix))
-                .then_some(effects)
-        })
-        .collect::<Vec<_>>();
+    let mut matches: Vec<Vec<String>> = Vec::new();
+    for m in &ctx.resolved_program.modules {
+        for rfd in &m.fn_defs {
+            if rfd.name == bare {
+                matches.push(rfd.effects.iter().map(|e| e.node.clone()).collect());
+            }
+        }
+    }
     if matches.len() == 1 {
         matches.pop()
     } else {
@@ -3416,14 +3424,12 @@ mod tests {
 
         let mut ctx = empty_ctx();
         ctx.fn_defs = vec![helper_tag.clone(), helper_score.clone(), fd.clone()];
-        ctx.fn_sigs
-            .insert("tag".to_string(), (vec![Type::Int], Type::Int, vec![]));
-        ctx.fn_sigs
-            .insert("score".to_string(), (vec![Type::Int], Type::Int, vec![]));
-        ctx.fn_sigs.insert(
-            "sumAreas".to_string(),
-            (vec![Type::Int, Type::Int, Type::Int], Type::Int, vec![]),
-        );
+        ctx.items = vec![
+            TopLevel::FnDef(helper_tag.clone()),
+            TopLevel::FnDef(helper_score.clone()),
+            TopLevel::FnDef(fd.clone()),
+        ];
+        ctx.refresh_facts();
 
         let emitted = {
             let r = ctx.resolve_fn_def(&fd, None);
@@ -3525,11 +3531,11 @@ mod tests {
         };
 
         let mut ctx = empty_ctx();
-        ctx.type_defs.push(td);
-        ctx.fn_sigs.insert(
-            "member".to_string(),
-            (vec![Type::named("Tree")], Type::Bool, vec![]),
-        );
+        ctx.type_defs.push(td.clone());
+        ctx.items.push(TopLevel::TypeDef(td));
+        ctx.items.push(TopLevel::FnDef(fd.clone()));
+        ctx.fn_defs.push(fd.clone());
+        ctx.refresh_facts();
 
         let emitted = {
             let r = ctx.resolve_fn_def(&fd, None);


### PR DESCRIPTION
## Summary

Migrates the five `temporary-migration-bridge` tagged `ctx.fn_sigs.get(...)` callsites in the Rust codegen to the typed-HIR projection: `ctx.resolved_program.fn_by_id(...)` for fn lookups, a fresh `find_ctor_owning_type` walk over `ctx.items` / `ctx.modules` typedefs for constructor sigs. After this PR the banned `ctx.fn_sigs.get(` pattern in `tests/identity_guardrails.rs` has zero violations.

Phase 7 of #180's epic-level goal is to drop `ctx.fn_sigs` entirely. That requires migrating ~100 more reads across Lean `law_auto` specs, `verify_law` module, and `rust/toplevel` internal sites — deferred to follow-up PRs (Phase 7 PR 2/n). The bridge-tagged sites are the smallest closed scope and the only ones currently banned by `identity_guardrails`.

## Sites migrated

- `fn_supports_rust_memo(fd)` — reads param types off `ResolvedFnDef.params` via `fn_id_for_decl(ctx, fd)`.
- `collect_fn_local_types(fd)` — same path; synthesised / mid-rewrite fallback parses AST annotations as before.
- `lookup_call_effects(name)` — resolves the `FnId` via `fn_id_for_dotted_name`, reads `ResolvedFnDef.effects`. Returns owned `Vec<String>`. Suffix fallback walks `ctx.resolved_program.modules`.
- `callee_borrow_mask(name)` — same FnId resolution for both the qualified-name + bare-name attempts.
- `constructor_boxed_positions(name)` — new `find_ctor_owning_type` walks `ctx.items` / `ctx.modules` typedefs directly. `constructor_boxed_bindings` simplified — no fn_sigs suffix scan.

## Test plan

- [x] `cargo test` clean
- [x] `cargo test --features wasm` clean
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `tests/identity_guardrails.rs::no_banned_identity_patterns_without_category_comment` passes — banned `ctx.fn_sigs.get(` pattern has 0 violations
- [x] Two synthesised-ctx unit tests (`memoized_named_param_clones_cache_key_before_body`, `optimized_tco_hoists_invariant_pure_call_chain_over_passthrough_param`) updated to call `ctx.refresh_facts()` after populating items + fn_defs (the production-flow shape, replacing direct fn_sigs.insert)

## What's left for Phase 7's full close (follow-ups)

- Lean `law_auto` specs read `ctx.fn_sigs` (linear_int, simp_normalized, linear_recurrence2, etc.) — needs `canonical_spec_ref` rework
- `verify_law` module passes `fn_sigs` as a parameter through ~20 functions — migrate to a `&CodegenContext` shape
- `ctx.fn_sigs` storage + population (`tc_result.fn_sigs.clone()` + SymbolRegistry + intrinsic injection + synthesised `__buffered` injection) stays in place until the above land
- After full drop: extend `identity_guardrails` to ban any `fn_sigs` field access (not just `ctx.fn_sigs.get(`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)