### PR TITLE
codegen: drop ctx.fn_sigs storage — #180 Phase 7 PR 2/n

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -2782,7 +2782,6 @@ mod tests {
 
         let mut ctx = CodegenContext {
             items,
-            fn_sigs: HashMap::new(),
             memo_fns: HashSet::new(),
             memo_safe_types: HashSet::new(),
             type_defs: Vec::new(),

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -182,7 +182,6 @@ mod tests {
     fn empty_ctx() -> CodegenContext {
         CodegenContext {
             items: vec![],
-            fn_sigs: HashMap::new(),
             memo_fns: HashSet::new(),
             memo_safe_types: HashSet::new(),
             type_defs: vec![],

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -523,7 +523,7 @@ pub fn emit_verify_law_support_theorems(
     ctx: &CodegenContext,
     _theorem_base: &str,
 ) -> Vec<String> {
-    collect_missing_helper_law_hints(&ctx.items, &ctx.fn_sigs)
+    collect_missing_helper_law_hints(&ctx.items, &ctx.fn_sigs_projection())
         .into_iter()
         .find(|hint| hint.line == vb.line && hint.fn_name == vb.fn_name)
         .map(|hint| {

--- a/src/codegen/lean/law_auto/spec/linear_int.rs
+++ b/src/codegen/lean/law_auto/spec/linear_int.rs
@@ -29,7 +29,7 @@ pub(super) fn emit_linear_int_omega_spec_equivalence_law(
         return None;
     }
 
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs)?;
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs_projection())?;
     let impl_fd = find_fn_def(ctx, &vb.fn_name)?;
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     if impl_fd.return_type != "Int" || spec_fd.return_type != "Int" {

--- a/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
+++ b/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
@@ -17,7 +17,7 @@ pub(in super::super) fn emit_second_order_linear_recurrence_spec_equivalence_law
     ctx: &CodegenContext,
     _intro_names: &[String],
 ) -> Option<AutoProof> {
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs)?;
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs_projection())?;
     let impl_fd = find_fn_def(ctx, &vb.fn_name)?;
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     let impl_shape = detect_tailrec_int_linear_pair_wrapper(impl_fd)?;

--- a/src/codegen/lean/law_auto/spec/mod.rs
+++ b/src/codegen/lean/law_auto/spec/mod.rs
@@ -159,7 +159,7 @@ pub(super) fn emit_spec_function_equivalence_law(
         return Some(proof);
     }
 
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs)?;
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs_projection())?;
     let impl_fd = find_fn_def(ctx, &vb.fn_name)?;
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     let impl_body = body_terminal_expr(impl_fd.body.as_ref())?;

--- a/src/codegen/lean/law_auto/spec/simp_normalized.rs
+++ b/src/codegen/lean/law_auto/spec/simp_normalized.rs
@@ -135,7 +135,7 @@ pub(super) fn emit_simp_normalized_spec_equivalence_law(
     ctx: &CodegenContext,
     intro_names: &[String],
 ) -> Option<AutoProof> {
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs)?;
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs_projection())?;
     let impl_fd = find_fn_def(ctx, &vb.fn_name)?;
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     let impl_body = body_terminal_expr(impl_fd.body.as_ref())?;

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1557,7 +1557,6 @@ mod tests {
     fn empty_ctx() -> CodegenContext {
         CodegenContext {
             items: vec![],
-            fn_sigs: HashMap::new(),
             memo_fns: HashSet::new(),
             memo_safe_types: HashSet::new(),
             type_defs: vec![],

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1809,8 +1809,9 @@ fn emit_verify_law_block(
     // runtime-only marker — matches the cases-form trace block
     // behavior in `emit_verify_trace_block_proofs`. The `aver verify`
     // runtime path still exercises the law under the given stubs.
+    let fn_sigs = ctx.fn_sigs_projection();
     if crate::codegen::common::law_lhs_has_trace_projection(&law.lhs) {
-        let header = match canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs) {
+        let header = match canonical_spec_ref(&vb.fn_name, law, &fn_sigs) {
             Some(spec_ref) => format!(
                 "-- verify law {}.spec {}: trace-projection LHS is runtime-only (see docs/oracle.md)",
                 fn_name, spec_ref.spec_fn_name,
@@ -1822,7 +1823,7 @@ fn emit_verify_law_block(
         };
         return (header, case_index_start + vb.cases.len());
     }
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs);
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &fn_sigs);
     let theorem_base = match &spec_ref {
         Some(spec_ref) => format!(
             "{}_eq_{}",

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -127,8 +127,6 @@ pub struct CodegenContext {
     /// discovery access. Backends iterating fn bodies should reach
     /// `resolved_program.entry_fns()` instead.
     pub items: Vec<TopLevel>,
-    /// Function signatures: name → (param_types, return_type, effects).
-    pub fn_sigs: HashMap<String, (Vec<crate::types::Type>, crate::types::Type, Vec<String>)>,
     /// Functions eligible for auto-memoization.
     pub memo_fns: HashSet<String>,
     /// Set of type names whose values are memo-safe.
@@ -428,49 +426,6 @@ pub fn build_context(
         }
     }
 
-    // Start with checker's fn_sigs (exposed API), then add signatures for
-    // ALL module functions (including private helpers) via SymbolRegistry.
-    // Codegen emits full module implementations, so it needs signatures for
-    // intra-module calls that the checker intentionally omits.
-    let mut fn_sigs = tc_result.fn_sigs.clone();
-    {
-        let pairs: Vec<(String, Vec<TopLevel>)> = modules
-            .iter()
-            .map(|m| {
-                let items: Vec<TopLevel> = m
-                    .fn_defs
-                    .iter()
-                    .map(|fd| TopLevel::FnDef(fd.clone()))
-                    .chain(m.type_defs.iter().map(|td| TopLevel::TypeDef(td.clone())))
-                    .collect();
-                (m.prefix.clone(), items)
-            })
-            .collect();
-        let registry = crate::visibility::SymbolRegistry::from_modules_all(&pairs);
-        for entry in &registry.entries {
-            if fn_sigs.contains_key(&entry.canonical_name) {
-                continue;
-            }
-            if let crate::visibility::SymbolKind::Function {
-                params,
-                return_type,
-                effects,
-                ..
-            } = &entry.kind
-            {
-                let parsed_params: Vec<crate::types::Type> = params
-                    .iter()
-                    .map(|(_, ty_str)| crate::types::parse_type_str(ty_str))
-                    .collect();
-                let ret = crate::types::parse_type_str(return_type);
-                fn_sigs.insert(
-                    entry.canonical_name.clone(),
-                    (parsed_params, ret, effects.clone()),
-                );
-            }
-        }
-    }
-
     // Detection layer for buffer-build sinks + fusion sites. The
     // ACTUAL rewrite + synthesis must happen BEFORE the resolver
     // pass (callers run it via `ir::run_buffer_build_pass` between
@@ -499,57 +454,6 @@ pub fn build_context(
         .filter(|fd| fd.name.ends_with("__buffered"))
         .cloned()
         .collect();
-    // 0.15 Traversal — register signatures for the four buffer-build
-    // internal intrinsics. Without these in fn_sigs, downstream
-    // `infer_aver_type` on `__buf_append(...)` etc. returns None and
-    // `expr_is_heap_ptr` falls through to false — meaning TCO
-    // compaction doesn't retain the buffer pointer across GC, the
-    // buffer object gets relocated by collect_end, and the next
-    // iteration reads through the stale pointer producing
-    // `memory access out of bounds` traps. Buffer parses to
-    // Type::Named("Buffer") which is_heap_type accepts.
-    {
-        let buffer_ty = || crate::types::Type::named("Buffer");
-        let str_ty = || crate::types::Type::Str;
-        let int_ty = || crate::types::Type::Int;
-        let intrinsic_sigs: &[(&str, Vec<crate::types::Type>, crate::types::Type)] = &[
-            ("__buf_new", vec![int_ty()], buffer_ty()),
-            ("__buf_append", vec![buffer_ty(), str_ty()], buffer_ty()),
-            (
-                "__buf_append_sep_unless_first",
-                vec![buffer_ty(), str_ty()],
-                buffer_ty(),
-            ),
-            ("__buf_finalize", vec![buffer_ty()], str_ty()),
-        ];
-        for (name, params, ret) in intrinsic_sigs {
-            fn_sigs.insert(name.to_string(), (params.clone(), ret.clone(), vec![]));
-        }
-    }
-
-    // Inject signatures for synthesized variants into fn_sigs so the
-    // WASM emitter's type-section pass produces correct param/return
-    // wasm types (the fallback path emits `all-i64` which breaks
-    // validation when a body calls intrinsics with i32 buffer ptrs).
-    for fd in synthesized_buffered_fns.iter() {
-        if fn_sigs.contains_key(&fd.name) {
-            continue;
-        }
-        let param_types: Vec<crate::types::Type> = fd
-            .params
-            .iter()
-            .map(|(_, ty_str)| crate::types::parse_type_str(ty_str))
-            .collect();
-        let ret = crate::types::parse_type_str(&fd.return_type);
-        fn_sigs.insert(
-            fd.name.clone(),
-            (
-                param_types,
-                ret,
-                fd.effects.iter().map(|e| e.node.clone()).collect(),
-            ),
-        );
-    }
 
     // Epic #170 Phase 1: build the canonical `ResolvedProgramView`
     // once, from the pipeline's already-resolved entry items + the
@@ -574,7 +478,6 @@ pub fn build_context(
 
     let ctx = CodegenContext {
         items,
-        fn_sigs,
         memo_fns,
         memo_safe_types: tc_result.memo_safe_types.clone(),
         type_defs,
@@ -978,5 +881,138 @@ impl CodegenContext {
             unreachable!()
         };
         arms.into_iter().next().unwrap().pattern
+    }
+}
+
+fn fn_sigs_projection_typedef(
+    out: &mut crate::verify_law::FnSigMap,
+    td: &crate::ast::TypeDef,
+    scope: Option<&str>,
+) {
+    match td {
+        crate::ast::TypeDef::Sum {
+            name: parent,
+            variants,
+            ..
+        } => {
+            let parent_full = match scope {
+                Some(prefix) => format!("{prefix}.{parent}"),
+                None => parent.clone(),
+            };
+            for v in variants {
+                let key = format!("{parent_full}.{}", v.name);
+                let fields = v
+                    .fields
+                    .iter()
+                    .map(|t| crate::types::parse_type_str(t))
+                    .collect();
+                let ret = crate::types::Type::named(parent_full.clone());
+                out.entry(key).or_insert((fields, ret, Vec::new()));
+            }
+        }
+        crate::ast::TypeDef::Product {
+            name: parent,
+            fields,
+            ..
+        } => {
+            let parent_full = match scope {
+                Some(prefix) => format!("{prefix}.{parent}"),
+                None => parent.clone(),
+            };
+            let fts = fields
+                .iter()
+                .map(|(_, t)| crate::types::parse_type_str(t))
+                .collect();
+            let ret = crate::types::Type::named(parent_full.clone());
+            out.entry(parent_full).or_insert((fts, ret, Vec::new()));
+        }
+    }
+}
+
+impl CodegenContext {
+    /// Build a fresh `(params, ret, effects)` map projected from
+    /// `resolved_program` + the codegen ctx's auxiliary inputs.
+    ///
+    /// Epic #180 Phase 7 PR 2 — replaces the dropped `ctx.fn_sigs`
+    /// side channel for consumers (`verify_law` helper-law walkers,
+    /// the Lean `canonical_spec_ref` checks, builtin-record discovery
+    /// `needs_named_type`) that still take a bare `&FnSigMap` and
+    /// want a unified query surface. Each call walks `resolved_
+    /// program.entry_fns()` + every module's resolved fn defs plus
+    /// the synthesised `__buf_*` intrinsics and `__buffered` variants
+    /// the codegen pipeline registered side-band. Bare-name keys
+    /// (entry fns) and dotted canonical keys (`Module.fn`,
+    /// `Module.Type.Variant`) appear in the same map — matching the
+    /// shape the legacy storage carried, so consumer code stays
+    /// keyed by source-level name.
+    ///
+    /// Callers materialise the map on demand; there is no
+    /// invalidation contract because the underlying `resolved_
+    /// program` is rebuilt deterministically from the same inputs
+    /// each time. The cost is one HashMap allocation + a walk of
+    /// every resolved fn def — small relative to the codegen pass
+    /// it appears in.
+    pub fn fn_sigs_projection(&self) -> crate::verify_law::FnSigMap {
+        use crate::verify_law::FnSigMap;
+        let mut out: FnSigMap = FnSigMap::new();
+
+        // Entry-scope resolved fns — keyed by their bare name.
+        for rfd in self.resolved_program.entry_fns() {
+            let params: Vec<crate::types::Type> =
+                rfd.params.iter().map(|(_, t)| t.clone()).collect();
+            let effects: Vec<String> = rfd.effects.iter().map(|e| e.node.clone()).collect();
+            out.entry(rfd.name.clone())
+                .or_insert((params, rfd.return_type.clone(), effects));
+        }
+        // Module-scoped resolved fns — keyed by `Module.fn`. Mirrors
+        // how the legacy fn_sigs population used the SymbolRegistry's
+        // canonical_name field (qualified for module-owned, bare for
+        // entry).
+        for m in &self.resolved_program.modules {
+            for rfd in &m.fn_defs {
+                let key = format!("{}.{}", m.prefix, rfd.name);
+                let params: Vec<crate::types::Type> =
+                    rfd.params.iter().map(|(_, t)| t.clone()).collect();
+                let effects: Vec<String> = rfd.effects.iter().map(|e| e.node.clone()).collect();
+                out.entry(key)
+                    .or_insert((params, rfd.return_type.clone(), effects));
+            }
+        }
+
+        // Constructor sigs: every variant + product typedef across
+        // entry items and dep modules registers a callable with
+        // (field_types, owning_type, no effects). The typechecker
+        // exposed these through `tc_result.fn_sigs`; project them
+        // here from the same TypeDef shapes so consumers keyed on
+        // constructor names (e.g. `Shape.Circle`) keep matching.
+        for item in &self.items {
+            if let TopLevel::TypeDef(td) = item {
+                fn_sigs_projection_typedef(&mut out, td, None);
+            }
+        }
+        for m in &self.modules {
+            for td in &m.type_defs {
+                fn_sigs_projection_typedef(&mut out, td, Some(&m.prefix));
+            }
+        }
+
+        // Synthesised `__buf_*` intrinsics — wired up in codegen
+        // setup (see the pre-Phase-7 fn_sigs population block) so
+        // downstream traversal-fusion emit can resolve their types.
+        // Mirror the same shapes here so any consumer that previously
+        // saw them in `ctx.fn_sigs` still finds them post-drop.
+        let buf = || crate::types::Type::named("Buffer");
+        let int = || crate::types::Type::Int;
+        let s = || crate::types::Type::Str;
+        out.entry("__buf_new".into())
+            .or_insert((vec![int()], buf(), vec![]));
+        out.entry("__buf_append".into())
+            .or_insert((vec![buf(), s()], buf(), vec![]));
+        out.entry("__buf_append_sep_unless_first".into())
+            .or_insert((vec![buf(), s()], buf(), vec![]));
+        out.entry("__buf_finalize".into())
+            .or_insert((vec![buf()], s(), vec![]));
+
+        out
     }
 }

--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -1020,7 +1020,6 @@ mod tests {
     fn empty_ctx() -> CodegenContext {
         CodegenContext {
             items: vec![],
-            fn_sigs: HashMap::new(),
             memo_fns: HashSet::new(),
             memo_safe_types: HashSet::new(),
             type_defs: vec![],

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -651,8 +651,25 @@ fn is_shared_runtime_type(td: &TypeDef) -> bool {
 }
 
 fn needs_named_type(ctx: &CodegenContext, wanted: &str) -> bool {
-    ctx.fn_sigs.values().any(|(params, ret, _effects)| {
-        params.iter().any(|p| type_contains_named(p, wanted)) || type_contains_named(ret, wanted)
+    // Walks resolved fn defs (entry + every dep module). The wasm-gc
+    // counterpart `items_reference_name` uses the same shape — a
+    // substring scan over signature surface — so the discovery
+    // semantics stay identical post #180 Phase 7 fn_sigs drop.
+    let scan = |params: &[(String, Type)], ret: &Type| -> bool {
+        params.iter().any(|(_, p)| type_contains_named(p, wanted))
+            || type_contains_named(ret, wanted)
+    };
+    if ctx
+        .resolved_program
+        .entry_fns()
+        .any(|rfd| scan(&rfd.params, &rfd.return_type))
+    {
+        return true;
+    }
+    ctx.resolved_program.modules.iter().any(|m| {
+        m.fn_defs
+            .iter()
+            .any(|rfd| scan(&rfd.params, &rfd.return_type))
     })
 }
 

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -3100,17 +3100,16 @@ pub fn emit_verify_blocks(verify_blocks: &[&VerifyBlock], ctx: &CodegenContext) 
 mod tests {
     use super::*;
     use crate::ast::{
-        BinOp, Expr, FnBody, FnDef, Literal, MatchArm, Pattern, Spanned, TypeDef, TypeVariant,
+        BinOp, Expr, FnBody, FnDef, Literal, MatchArm, Pattern, Spanned, TopLevel, TypeDef,
+        TypeVariant,
     };
     use crate::codegen::CodegenContext;
-    use crate::types::Type;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashSet;
     use std::sync::Arc as Rc;
 
     fn empty_ctx() -> CodegenContext {
         CodegenContext {
             items: vec![],
-            fn_sigs: HashMap::new(),
             memo_fns: HashSet::new(),
             memo_safe_types: HashSet::new(),
             type_defs: vec![],
@@ -3479,8 +3478,9 @@ mod tests {
             resolution: None,
         };
         let mut ctx = empty_ctx();
-        ctx.fn_sigs
-            .insert("f".to_string(), (vec![Type::Float], Type::Float, vec![]));
+        ctx.items.push(TopLevel::FnDef(fd.clone()));
+        ctx.fn_defs.push(fd.clone());
+        ctx.refresh_facts();
 
         let emitted = {
             let r = ctx.resolve_fn_def(&fd, None);
@@ -3776,15 +3776,25 @@ mod tests {
             resolution: None,
         };
 
+        let first = FnDef {
+            name: "first".to_string(),
+            line: 1,
+            params: vec![
+                ("a".to_string(), "Int".to_string()),
+                ("b".to_string(), "Int".to_string()),
+            ],
+            return_type: "Int".to_string(),
+            effects: vec![],
+            desc: None,
+            body: Rc::new(FnBody::from_expr(Spanned::bare(Expr::Ident(
+                "a".to_string(),
+            )))),
+            resolution: None,
+        };
         let mut semantic_ctx = empty_ctx();
-        semantic_ctx.fn_sigs.insert(
-            "swap".to_string(),
-            (vec![Type::Int, Type::Int], Type::Int, vec![]),
-        );
-        semantic_ctx.fn_sigs.insert(
-            "first".to_string(),
-            (vec![Type::Int, Type::Int], Type::Int, vec![]),
-        );
+        semantic_ctx.items = vec![TopLevel::FnDef(first.clone()), TopLevel::FnDef(fd.clone())];
+        semantic_ctx.fn_defs = vec![first, fd.clone()];
+        semantic_ctx.refresh_facts();
         let semantic = {
             let r = semantic_ctx.resolve_fn_def(&fd, None);
             emit_public_fn_def(&fd, r.as_ref(), false, &semantic_ctx, None)
@@ -3830,14 +3840,9 @@ mod tests {
         };
 
         let mut semantic_ctx = empty_ctx();
-        semantic_ctx.fn_sigs.insert(
-            "cellAt".to_string(),
-            (
-                vec![Type::Vector(Box::new(Type::Int)), Type::Int],
-                Type::Int,
-                vec![],
-            ),
-        );
+        semantic_ctx.items = vec![TopLevel::FnDef(fd.clone())];
+        semantic_ctx.fn_defs = vec![fd.clone()];
+        semantic_ctx.refresh_facts();
         let semantic = {
             let r = semantic_ctx.resolve_fn_def(&fd, None);
             emit_public_fn_def(&fd, r.as_ref(), false, &semantic_ctx, None)
@@ -3902,14 +3907,9 @@ mod tests {
         };
 
         let mut semantic_ctx = empty_ctx();
-        semantic_ctx.fn_sigs.insert(
-            "cellAtPlusOne".to_string(),
-            (
-                vec![Type::Vector(Box::new(Type::Int)), Type::Int],
-                Type::Int,
-                vec![],
-            ),
-        );
+        semantic_ctx.items = vec![TopLevel::FnDef(fd.clone())];
+        semantic_ctx.fn_defs = vec![fd.clone()];
+        semantic_ctx.refresh_facts();
         let semantic = {
             let r = semantic_ctx.resolve_fn_def(&fd, None);
             emit_public_fn_def(&fd, r.as_ref(), false, &semantic_ctx, None)

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4678,7 +4678,8 @@ fn cmd_proof_lean(
             format!("warning[{}:1]: {}", issue.line, issue.message).yellow()
         );
     }
-    let missing_helper_hints = collect_missing_helper_law_hints(&ctx.items, &ctx.fn_sigs);
+    let missing_helper_hints =
+        collect_missing_helper_law_hints(&ctx.items, &ctx.fn_sigs_projection());
     for hint in missing_helper_hints {
         eprintln!(
             "{}",
@@ -4690,7 +4691,8 @@ fn cmd_proof_lean(
             .yellow()
         );
     }
-    let contextual_helper_hints = collect_contextual_helper_law_hints(&ctx.items, &ctx.fn_sigs);
+    let contextual_helper_hints =
+        collect_contextual_helper_law_hints(&ctx.items, &ctx.fn_sigs_projection());
     for hint in contextual_helper_hints {
         eprintln!(
             "{}",
@@ -4966,7 +4968,6 @@ mod tests {
     fn empty_codegen_ctx() -> CodegenContext {
         CodegenContext {
             items: vec![],
-            fn_sigs: HashMap::new(),
             memo_fns: HashSet::new(),
             memo_safe_types: HashSet::new(),
             type_defs: vec![],

--- a/tests/identity_guardrails.rs
+++ b/tests/identity_guardrails.rs
@@ -128,11 +128,12 @@ const BANNED_PATTERNS: &[BannedPattern] = &[
                 the matching category",
     },
     BannedPattern {
-        needle: "ctx.fn_sigs.get(",
-        label: "ctx.fn_sigs.get(name) — string-keyed fn signature side channel. \
-                Prefer ctx.resolve_fn_def(fd, scope) for ResolvedFnDef.params / \
-                return_type, or the resolved-program view. fn_sigs is slated \
-                for removal in Phase 7 of #180",
+        needle: "ctx.fn_sigs.",
+        label: "ctx.fn_sigs.* — string-keyed fn signature side channel removed \
+                in Phase 7 of #180. Prefer ctx.resolve_fn_def(fd, scope) for \
+                ResolvedFnDef.params / return_type, ctx.resolved_program for \
+                the resolved-program view, or ctx.fn_sigs_projection() for a \
+                fresh fn-sig map (verify_law / law_auto consumers)",
     },
 ];
 


### PR DESCRIPTION
## Summary

Closes the structural goal of #180 Phase 7: `ctx.fn_sigs` is gone as a stored side channel. Consumers that still need a `(params, ret, effects)` map keyed by source-level name reach for `ctx.fn_sigs_projection()`, which materialises the map on demand from `resolved_program` + the `TypeDef`s on `ctx.items` / `ctx.modules` + the synthesised `__buf_*` intrinsics.

Follow-up to #193 (Phase 7 PR 1/n) which cleared the five bridge-tagged callsites in the Rust codegen.

## Migrated callsites

- **Seven Lean `law_auto` callers** in `lean/toplevel.rs` + `lean/law_auto.rs` + `lean/law_auto/spec/{linear_int, linear_recurrence2, simp_normalized, mod}.rs` — switch from `&ctx.fn_sigs` to `&ctx.fn_sigs_projection()`.
- **`rust/mod.rs::needs_named_type`** walks `resolved_program` directly for its substring-scan-on-signatures discovery.
- **`main/commands.rs`** verify CLI helpers use the projection.

## Population removed

The ~100-line block in `codegen/mod.rs` that built `fn_sigs` from `tc_result.fn_sigs.clone()` + `SymbolRegistry` walks + intrinsic injection + synthesised `__buffered` variants is deleted. Every read of those entries now goes through `fn_sigs_projection`.

## Test setups

Unit tests in `rust/toplevel.rs` that synthesised a `CodegenContext` by poking `ctx.fn_sigs.insert(...)` directly (memo eligibility, optimised forward / leaf / binding-block wrappers, float-param non-memo) now push the `FnDef` into `ctx.items` + `ctx.fn_defs` and call `ctx.refresh_facts()` — the same shape `build_context` uses in production.

## Guardrail tightened

`tests/identity_guardrails.rs` banned needle: `ctx.fn_sigs.get(` → `ctx.fn_sigs.` (field-access prefix). Catches any `ctx.fn_sigs.{get,values,iter,...}` regression while letting the new `ctx.fn_sigs_projection(` method name pass cleanly.

## What's left for full epic #180 close

- `verify_law` module still takes `&FnSigMap` as a parameter through 18 functions — that's an internal API refactor (introduce a small trait or just take `&CodegenContext`) that's parallel scope to the storage drop. Callers already build the `FnSigMap` on demand via projection; the rewrite tightens the interface but doesn't change semantics.
- `tc_result.fn_sigs` (the typechecker's own API) stays exposed — it's the upstream source of truth for diagnostics + the projection.
- After the `verify_law` rewrite lands, the `FnSigMap` type alias itself can move from `verify_law` into a codegen-internal module, and `parse_type_str` calls inside `fn_sigs_projection_typedef` can route through the resolved-view's typed `field_types` (currently parses AST source strings).

## Test plan

- [x] `cargo test` clean
- [x] `cargo test --features wasm` clean
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `tests/identity_guardrails.rs` passes with tightened banned needle

🤖 Generated with [Claude Code](https://claude.com/claude-code)