### PR TITLE
verify_law: doc FnSigMap parallel-scope cleanup — #180 close

### DIFF
--- a/src/verify_law.rs
+++ b/src/verify_law.rs
@@ -8,6 +8,32 @@ use crate::types::Type;
 
 pub mod expand;
 
+/// `name → (params, return_type, effects)` map carrying the fn / ctor
+/// signatures the verify-law helpers query when classifying a law's
+/// callees.
+///
+/// # Parallel-scope cleanup deferred after epic #180 close
+///
+/// Epic #180 Phase 7 dropped `CodegenContext.fn_sigs` as a stored side
+/// channel (PRs #193, #194) — codegen consumers now reach into the
+/// `ResolvedProgramView` directly or materialise the map on demand via
+/// [`crate::codegen::CodegenContext::fn_sigs_projection`]. The
+/// `FnSigMap` type alias survives because the 18 verify-law functions
+/// below still take it as a parameter; callers build it on demand and
+/// pass it through. The shape is semantically identical to what
+/// `ctx.fn_sigs` carried pre-Phase-7, so the rewrite is interface
+/// tightening (introduce a small `FnSigOracle` trait, or pass
+/// `&CodegenContext` directly so the verify_law helpers project on
+/// access) and not a soundness change. Tracked as parallel-scope
+/// cleanup — not blocking on any user-visible behavior, run-loop
+/// driven when an LSP / inliner / monomorph trigger lands.
+///
+/// Similarly, [`crate::types::checker::TypeCheckResult::fn_sigs`]
+/// stays exposed by the typechecker; it's the upstream source of
+/// truth that diagnostics + the codegen projection both consume.
+/// Removing the field would force the typechecker to expose a
+/// different shape (probably an iterator over typed fn sigs); same
+/// trigger-driven scope.
 pub type FnSigMap = HashMap<String, (Vec<Type>, Type, Vec<String>)>;
 
 /// Bare-name → `&FnDef` index for the **entry module only**.


### PR DESCRIPTION
## Summary

Documents the two residual scope items left after epic #180 Phase 7 closed:

1. `verify_law::FnSigMap` survives as a parameter type on 18 helper functions. Callers materialise it on demand via `ctx.fn_sigs_projection()`. Tightening the interface (introduce a `FnSigOracle` trait, or pass `&CodegenContext` directly) is interface change, not soundness or behavior change.
2. `tc_result.fn_sigs` (the typechecker's own API surface) stays exposed — upstream source of truth for diagnostics + the codegen projection.

The doc comment on the `FnSigMap` type alias names both items, points back to PRs #193 / #194, and frames the cleanup as trigger-driven (LSP rename / inliner / monomorph). A future contributor reaching this surface sees the history + the rationale instead of re-deriving it.

With this merged, every item in epic #180's "Definition of done" list (#1–6) is satisfied. The epic can be closed.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `tests/identity_guardrails.rs` passes (doc-only change, no banned-pattern regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)