### PR TITLE
verify_law: FnSigOracle trait + drop fn_sigs_projection — #180 close

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -523,7 +523,7 @@ pub fn emit_verify_law_support_theorems(
     ctx: &CodegenContext,
     _theorem_base: &str,
 ) -> Vec<String> {
-    collect_missing_helper_law_hints(&ctx.items, &ctx.fn_sigs_projection())
+    collect_missing_helper_law_hints(&ctx.items, ctx)
         .into_iter()
         .find(|hint| hint.line == vb.line && hint.fn_name == vb.fn_name)
         .map(|hint| {

--- a/src/codegen/lean/law_auto/spec/linear_int.rs
+++ b/src/codegen/lean/law_auto/spec/linear_int.rs
@@ -29,7 +29,7 @@ pub(super) fn emit_linear_int_omega_spec_equivalence_law(
         return None;
     }
 
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs_projection())?;
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, ctx)?;
     let impl_fd = find_fn_def(ctx, &vb.fn_name)?;
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     if impl_fd.return_type != "Int" || spec_fd.return_type != "Int" {

--- a/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
+++ b/src/codegen/lean/law_auto/spec/linear_recurrence2.rs
@@ -17,7 +17,7 @@ pub(in super::super) fn emit_second_order_linear_recurrence_spec_equivalence_law
     ctx: &CodegenContext,
     _intro_names: &[String],
 ) -> Option<AutoProof> {
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs_projection())?;
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, ctx)?;
     let impl_fd = find_fn_def(ctx, &vb.fn_name)?;
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     let impl_shape = detect_tailrec_int_linear_pair_wrapper(impl_fd)?;

--- a/src/codegen/lean/law_auto/spec/mod.rs
+++ b/src/codegen/lean/law_auto/spec/mod.rs
@@ -159,7 +159,7 @@ pub(super) fn emit_spec_function_equivalence_law(
         return Some(proof);
     }
 
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs_projection())?;
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, ctx)?;
     let impl_fd = find_fn_def(ctx, &vb.fn_name)?;
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     let impl_body = body_terminal_expr(impl_fd.body.as_ref())?;

--- a/src/codegen/lean/law_auto/spec/simp_normalized.rs
+++ b/src/codegen/lean/law_auto/spec/simp_normalized.rs
@@ -135,7 +135,7 @@ pub(super) fn emit_simp_normalized_spec_equivalence_law(
     ctx: &CodegenContext,
     intro_names: &[String],
 ) -> Option<AutoProof> {
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &ctx.fn_sigs_projection())?;
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, ctx)?;
     let impl_fd = find_fn_def(ctx, &vb.fn_name)?;
     let spec_fd = find_fn_def(ctx, &spec_ref.spec_fn_name)?;
     let impl_body = body_terminal_expr(impl_fd.body.as_ref())?;

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1809,9 +1809,8 @@ fn emit_verify_law_block(
     // runtime-only marker — matches the cases-form trace block
     // behavior in `emit_verify_trace_block_proofs`. The `aver verify`
     // runtime path still exercises the law under the given stubs.
-    let fn_sigs = ctx.fn_sigs_projection();
     if crate::codegen::common::law_lhs_has_trace_projection(&law.lhs) {
-        let header = match canonical_spec_ref(&vb.fn_name, law, &fn_sigs) {
+        let header = match canonical_spec_ref(&vb.fn_name, law, ctx) {
             Some(spec_ref) => format!(
                 "-- verify law {}.spec {}: trace-projection LHS is runtime-only (see docs/oracle.md)",
                 fn_name, spec_ref.spec_fn_name,
@@ -1823,7 +1822,7 @@ fn emit_verify_law_block(
         };
         return (header, case_index_start + vb.cases.len());
     }
-    let spec_ref = canonical_spec_ref(&vb.fn_name, law, &fn_sigs);
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, ctx);
     let theorem_base = match &spec_ref {
         Some(spec_ref) => format!(
             "{}_eq_{}",

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -884,135 +884,105 @@ impl CodegenContext {
     }
 }
 
-fn fn_sigs_projection_typedef(
-    out: &mut crate::verify_law::FnSigMap,
-    td: &crate::ast::TypeDef,
-    scope: Option<&str>,
-) {
-    match td {
-        crate::ast::TypeDef::Sum {
-            name: parent,
-            variants,
-            ..
-        } => {
-            let parent_full = match scope {
-                Some(prefix) => format!("{prefix}.{parent}"),
-                None => parent.clone(),
-            };
-            for v in variants {
-                let key = format!("{parent_full}.{}", v.name);
-                let fields = v
-                    .fields
-                    .iter()
-                    .map(|t| crate::types::parse_type_str(t))
-                    .collect();
-                let ret = crate::types::Type::named(parent_full.clone());
-                out.entry(key).or_insert((fields, ret, Vec::new()));
+/// Per-key projection of the legacy `fn_sigs` map: routes a source-
+/// level name through `resolved_program` first (entry + every dep
+/// module's resolved fns), then walks `TypeDef`s for constructor sigs,
+/// then handles the synthesised `__buf_*` intrinsics. Lets a
+/// `CodegenContext` answer `FnSigOracle::fn_sig` without materialising
+/// the whole `FnSigMap` up front — the verify-law helpers query
+/// individual names, so per-key resolution is cheaper than per-call
+/// rebuild.
+fn codegen_ctx_fn_sig(ctx: &CodegenContext, name: &str) -> Option<crate::verify_law::FnSigInfo> {
+    use crate::verify_law::FnSigInfo;
+
+    if let Some(fn_id) = crate::codegen::common::fn_id_for_dotted_name(ctx, name)
+        && let Some(rfd) = ctx.resolved_program.fn_by_id(fn_id)
+    {
+        return Some(FnSigInfo {
+            return_type: rfd.return_type.clone(),
+            is_pure: rfd.effects.is_empty(),
+        });
+    }
+
+    // Constructor lookup: `Type.Variant` (entry sum), `Module.Type.
+    // Variant` (module sum), `Box` (entry product), `Module.Box`
+    // (module product). Walks the same `TypeDef` surfaces the
+    // legacy fn_sigs population did via SymbolRegistry.
+    let walk = |td: &crate::ast::TypeDef, scope: Option<&str>| -> Option<FnSigInfo> {
+        match td {
+            crate::ast::TypeDef::Sum {
+                name: parent,
+                variants,
+                ..
+            } => {
+                let parent_full = match scope {
+                    Some(prefix) => format!("{prefix}.{parent}"),
+                    None => parent.clone(),
+                };
+                for v in variants {
+                    let bare = format!("{parent}.{}", v.name);
+                    let full = format!("{parent_full}.{}", v.name);
+                    if name == bare || name == full {
+                        return Some(FnSigInfo {
+                            return_type: crate::types::Type::named(parent_full.clone()),
+                            is_pure: true,
+                        });
+                    }
+                }
+                None
+            }
+            crate::ast::TypeDef::Product { name: parent, .. } => {
+                let parent_full = match scope {
+                    Some(prefix) => format!("{prefix}.{parent}"),
+                    None => parent.clone(),
+                };
+                if name == parent || name == parent_full {
+                    return Some(FnSigInfo {
+                        return_type: crate::types::Type::named(parent_full),
+                        is_pure: true,
+                    });
+                }
+                None
             }
         }
-        crate::ast::TypeDef::Product {
-            name: parent,
-            fields,
-            ..
-        } => {
-            let parent_full = match scope {
-                Some(prefix) => format!("{prefix}.{parent}"),
-                None => parent.clone(),
-            };
-            let fts = fields
-                .iter()
-                .map(|(_, t)| crate::types::parse_type_str(t))
-                .collect();
-            let ret = crate::types::Type::named(parent_full.clone());
-            out.entry(parent_full).or_insert((fts, ret, Vec::new()));
+    };
+    for item in &ctx.items {
+        if let TopLevel::TypeDef(td) = item
+            && let Some(info) = walk(td, None)
+        {
+            return Some(info);
         }
+    }
+    for m in &ctx.modules {
+        for td in &m.type_defs {
+            if let Some(info) = walk(td, Some(&m.prefix)) {
+                return Some(info);
+            }
+        }
+    }
+
+    // Synthesised `__buf_*` intrinsics — the deforestation pipeline
+    // emits these as opaque callables; verify-law walkers may surface
+    // a reference if a user's law body sketches the buffer pipeline.
+    match name {
+        "__buf_new" => Some(FnSigInfo {
+            return_type: crate::types::Type::named("Buffer"),
+            is_pure: true,
+        }),
+        "__buf_append" | "__buf_append_sep_unless_first" => Some(FnSigInfo {
+            return_type: crate::types::Type::named("Buffer"),
+            is_pure: true,
+        }),
+        "__buf_finalize" => Some(FnSigInfo {
+            return_type: crate::types::Type::Str,
+            is_pure: true,
+        }),
+        _ => None,
     }
 }
 
-impl CodegenContext {
-    /// Build a fresh `(params, ret, effects)` map projected from
-    /// `resolved_program` + the codegen ctx's auxiliary inputs.
-    ///
-    /// Epic #180 Phase 7 PR 2 — replaces the dropped `ctx.fn_sigs`
-    /// side channel for consumers (`verify_law` helper-law walkers,
-    /// the Lean `canonical_spec_ref` checks, builtin-record discovery
-    /// `needs_named_type`) that still take a bare `&FnSigMap` and
-    /// want a unified query surface. Each call walks `resolved_
-    /// program.entry_fns()` + every module's resolved fn defs plus
-    /// the synthesised `__buf_*` intrinsics and `__buffered` variants
-    /// the codegen pipeline registered side-band. Bare-name keys
-    /// (entry fns) and dotted canonical keys (`Module.fn`,
-    /// `Module.Type.Variant`) appear in the same map — matching the
-    /// shape the legacy storage carried, so consumer code stays
-    /// keyed by source-level name.
-    ///
-    /// Callers materialise the map on demand; there is no
-    /// invalidation contract because the underlying `resolved_
-    /// program` is rebuilt deterministically from the same inputs
-    /// each time. The cost is one HashMap allocation + a walk of
-    /// every resolved fn def — small relative to the codegen pass
-    /// it appears in.
-    pub fn fn_sigs_projection(&self) -> crate::verify_law::FnSigMap {
-        use crate::verify_law::FnSigMap;
-        let mut out: FnSigMap = FnSigMap::new();
-
-        // Entry-scope resolved fns — keyed by their bare name.
-        for rfd in self.resolved_program.entry_fns() {
-            let params: Vec<crate::types::Type> =
-                rfd.params.iter().map(|(_, t)| t.clone()).collect();
-            let effects: Vec<String> = rfd.effects.iter().map(|e| e.node.clone()).collect();
-            out.entry(rfd.name.clone())
-                .or_insert((params, rfd.return_type.clone(), effects));
-        }
-        // Module-scoped resolved fns — keyed by `Module.fn`. Mirrors
-        // how the legacy fn_sigs population used the SymbolRegistry's
-        // canonical_name field (qualified for module-owned, bare for
-        // entry).
-        for m in &self.resolved_program.modules {
-            for rfd in &m.fn_defs {
-                let key = format!("{}.{}", m.prefix, rfd.name);
-                let params: Vec<crate::types::Type> =
-                    rfd.params.iter().map(|(_, t)| t.clone()).collect();
-                let effects: Vec<String> = rfd.effects.iter().map(|e| e.node.clone()).collect();
-                out.entry(key)
-                    .or_insert((params, rfd.return_type.clone(), effects));
-            }
-        }
-
-        // Constructor sigs: every variant + product typedef across
-        // entry items and dep modules registers a callable with
-        // (field_types, owning_type, no effects). The typechecker
-        // exposed these through `tc_result.fn_sigs`; project them
-        // here from the same TypeDef shapes so consumers keyed on
-        // constructor names (e.g. `Shape.Circle`) keep matching.
-        for item in &self.items {
-            if let TopLevel::TypeDef(td) = item {
-                fn_sigs_projection_typedef(&mut out, td, None);
-            }
-        }
-        for m in &self.modules {
-            for td in &m.type_defs {
-                fn_sigs_projection_typedef(&mut out, td, Some(&m.prefix));
-            }
-        }
-
-        // Synthesised `__buf_*` intrinsics — wired up in codegen
-        // setup (see the pre-Phase-7 fn_sigs population block) so
-        // downstream traversal-fusion emit can resolve their types.
-        // Mirror the same shapes here so any consumer that previously
-        // saw them in `ctx.fn_sigs` still finds them post-drop.
-        let buf = || crate::types::Type::named("Buffer");
-        let int = || crate::types::Type::Int;
-        let s = || crate::types::Type::Str;
-        out.entry("__buf_new".into())
-            .or_insert((vec![int()], buf(), vec![]));
-        out.entry("__buf_append".into())
-            .or_insert((vec![buf(), s()], buf(), vec![]));
-        out.entry("__buf_append_sep_unless_first".into())
-            .or_insert((vec![buf(), s()], buf(), vec![]));
-        out.entry("__buf_finalize".into())
-            .or_insert((vec![buf()], s(), vec![]));
-
-        out
+impl crate::verify_law::FnSigOracle for CodegenContext {
+    fn fn_sig(&self, name: &str) -> Option<crate::verify_law::FnSigInfo> {
+        codegen_ctx_fn_sig(self, name)
     }
 }

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4678,8 +4678,7 @@ fn cmd_proof_lean(
             format!("warning[{}:1]: {}", issue.line, issue.message).yellow()
         );
     }
-    let missing_helper_hints =
-        collect_missing_helper_law_hints(&ctx.items, &ctx.fn_sigs_projection());
+    let missing_helper_hints = collect_missing_helper_law_hints(&ctx.items, ctx);
     for hint in missing_helper_hints {
         eprintln!(
             "{}",
@@ -4691,8 +4690,7 @@ fn cmd_proof_lean(
             .yellow()
         );
     }
-    let contextual_helper_hints =
-        collect_contextual_helper_law_hints(&ctx.items, &ctx.fn_sigs_projection());
+    let contextual_helper_hints = collect_contextual_helper_law_hints(&ctx.items, ctx);
     for hint in contextual_helper_hints {
         eprintln!(
             "{}",

--- a/src/verify_law.rs
+++ b/src/verify_law.rs
@@ -8,33 +8,49 @@ use crate::types::Type;
 
 pub mod expand;
 
-/// `name → (params, return_type, effects)` map carrying the fn / ctor
-/// signatures the verify-law helpers query when classifying a law's
-/// callees.
+/// Legacy `name → (params, return_type, effects)` map carrying the fn /
+/// ctor signatures the verify-law helpers query.
 ///
-/// # Parallel-scope cleanup deferred after epic #180 close
-///
-/// Epic #180 Phase 7 dropped `CodegenContext.fn_sigs` as a stored side
-/// channel (PRs #193, #194) — codegen consumers now reach into the
-/// `ResolvedProgramView` directly or materialise the map on demand via
-/// [`crate::codegen::CodegenContext::fn_sigs_projection`]. The
-/// `FnSigMap` type alias survives because the 18 verify-law functions
-/// below still take it as a parameter; callers build it on demand and
-/// pass it through. The shape is semantically identical to what
-/// `ctx.fn_sigs` carried pre-Phase-7, so the rewrite is interface
-/// tightening (introduce a small `FnSigOracle` trait, or pass
-/// `&CodegenContext` directly so the verify_law helpers project on
-/// access) and not a soundness change. Tracked as parallel-scope
-/// cleanup — not blocking on any user-visible behavior, run-loop
-/// driven when an LSP / inliner / monomorph trigger lands.
-///
-/// Similarly, [`crate::types::checker::TypeCheckResult::fn_sigs`]
-/// stays exposed by the typechecker; it's the upstream source of
-/// truth that diagnostics + the codegen projection both consume.
-/// Removing the field would force the typechecker to expose a
-/// different shape (probably an iterator over typed fn sigs); same
-/// trigger-driven scope.
+/// Kept as a type alias for callers (mostly tests) that still build the
+/// map literally; production code reaches the verify-law surface
+/// through [`FnSigOracle`] now, which `FnSigMap` also implements. Epic
+/// #180 Phase 7 closed the side-channel storage path — see PRs #193 /
+/// #194 / this PR's history.
 pub type FnSigMap = HashMap<String, (Vec<Type>, Type, Vec<String>)>;
+
+/// What every verify-law helper needs to know about a fn or ctor
+/// reachable from a `verify ... law ...` block: its return type and
+/// whether it has any declared effects (purity). Cheap to derive at
+/// the call site — either from the legacy [`FnSigMap`] or directly
+/// from a [`CodegenContext`]'s resolved view.
+#[derive(Debug, Clone)]
+pub struct FnSigInfo {
+    pub return_type: Type,
+    pub is_pure: bool,
+}
+
+/// Look up a fn / ctor signature by source-level name.
+///
+/// Epic #180 Phase 7 closing refactor: verify-law helpers used to take
+/// `&FnSigMap` directly, which forced every caller to materialise the
+/// map on demand. Switching to a trait lets a
+/// [`crate::codegen::CodegenContext`] pass itself as the oracle — the
+/// resolved-program view answers per-key queries without rebuilding
+/// the map up front. `FnSigMap` keeps its `impl FnSigOracle` for
+/// backward compat with tests that prefer to build a literal sig map.
+pub trait FnSigOracle {
+    fn fn_sig(&self, name: &str) -> Option<FnSigInfo>;
+}
+
+impl FnSigOracle for FnSigMap {
+    fn fn_sig(&self, name: &str) -> Option<FnSigInfo> {
+        let (_, return_type, effects) = self.get(name)?;
+        Some(FnSigInfo {
+            return_type: return_type.clone(),
+            is_pure: effects.is_empty(),
+        })
+    }
+}
 
 /// Bare-name → `&FnDef` index for the **entry module only**.
 ///
@@ -119,22 +135,22 @@ pub struct ContextualHelperLawHint {
     pub missing_helpers: Vec<String>,
 }
 
-pub fn named_law_function(law: &VerifyLaw, fn_sigs: &FnSigMap) -> Option<NamedLawFunction> {
-    let (_, _, effects) = fn_sigs.get(&law.name)?;
+pub fn named_law_function(law: &VerifyLaw, fn_sigs: &dyn FnSigOracle) -> Option<NamedLawFunction> {
+    let info = fn_sigs.fn_sig(&law.name)?;
     Some(NamedLawFunction {
         name: law.name.clone(),
-        is_pure: effects.is_empty(),
+        is_pure: info.is_pure,
     })
 }
 
-pub fn declared_spec_ref(law: &VerifyLaw, fn_sigs: &FnSigMap) -> Option<VerifyLawSpecRef> {
+pub fn declared_spec_ref(law: &VerifyLaw, fn_sigs: &dyn FnSigOracle) -> Option<VerifyLawSpecRef> {
     let named = named_law_function(law, fn_sigs)?;
     named.is_pure.then_some(VerifyLawSpecRef {
         spec_fn_name: named.name,
     })
 }
 
-pub fn law_spec_ref(law: &VerifyLaw, fn_sigs: &FnSigMap) -> Option<VerifyLawSpecRef> {
+pub fn law_spec_ref(law: &VerifyLaw, fn_sigs: &dyn FnSigOracle) -> Option<VerifyLawSpecRef> {
     let spec = declared_spec_ref(law, fn_sigs)?;
     law_calls_function(law, &spec.spec_fn_name).then_some(spec)
 }
@@ -142,7 +158,7 @@ pub fn law_spec_ref(law: &VerifyLaw, fn_sigs: &FnSigMap) -> Option<VerifyLawSpec
 pub fn canonical_spec_ref(
     fn_name: &str,
     law: &VerifyLaw,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Option<VerifyLawSpecRef> {
     let spec = law_spec_ref(law, fn_sigs)?;
     canonical_spec_shape(fn_name, law, &spec.spec_fn_name).then_some(spec)
@@ -168,7 +184,7 @@ pub fn canonical_spec_shape(fn_name: &str, law: &VerifyLaw, spec_fn_name: &str) 
 
 pub fn collect_missing_helper_law_hints(
     items: &[TopLevel],
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Vec<MissingHelperLawHint> {
     let fn_defs = EntryFnIndex::from_entry_items(items);
     let verified_law_functions = items
@@ -214,7 +230,7 @@ pub fn missing_helper_law_message(hint: &MissingHelperLawHint) -> String {
 
 pub fn collect_contextual_helper_law_hints(
     items: &[TopLevel],
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Vec<ContextualHelperLawHint> {
     let fn_defs = EntryFnIndex::from_entry_items(items);
     let contextual_law_targets = items
@@ -264,7 +280,7 @@ fn missing_helper_law_hint_for_block(
     law: &VerifyLaw,
     fn_defs: &EntryFnIndex<'_>,
     verified_law_functions: &HashSet<String>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Option<MissingHelperLawHint> {
     if law.when.is_none() || law.givens.len() != 1 {
         return None;
@@ -301,7 +317,7 @@ fn contextual_helper_law_hint_for_block(
     law: &VerifyLaw,
     fn_defs: &EntryFnIndex<'_>,
     contextual_law_targets: &HashSet<String>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Option<ContextualHelperLawHint> {
     let parser_name = contextual_roundtrip_parser_name(law, fn_defs, fn_sigs)?;
     let root_parser_name = wrapper_dispatch_root(&parser_name, fn_defs, fn_sigs)
@@ -330,7 +346,7 @@ fn contextual_helper_law_hint_for_block(
 fn direct_pure_user_calls_in_law(
     law: &VerifyLaw,
     fn_defs: &EntryFnIndex<'_>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
     collect_direct_pure_user_calls(&law.lhs, fn_defs, fn_sigs, &mut out);
@@ -341,7 +357,7 @@ fn direct_pure_user_calls_in_law(
 fn top_level_direct_pure_call_in_law(
     law: &VerifyLaw,
     fn_defs: &EntryFnIndex<'_>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Option<String> {
     direct_pure_user_call_name(&law.lhs, fn_defs, fn_sigs)
         .or_else(|| direct_pure_user_call_name(&law.rhs, fn_defs, fn_sigs))
@@ -350,7 +366,7 @@ fn top_level_direct_pure_call_in_law(
 fn contextual_roundtrip_parser_name(
     law: &VerifyLaw,
     fn_defs: &EntryFnIndex<'_>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Option<String> {
     let given = law.givens.first()?;
     detect_roundtrip_layers(law, &given.name, fn_defs, fn_sigs).map(|(parser_name, _)| parser_name)
@@ -359,7 +375,7 @@ fn contextual_roundtrip_parser_name(
 fn frontier_helper_calls(
     root_name: &str,
     fn_defs: &EntryFnIndex<'_>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> BTreeSet<String> {
     let mut current =
         wrapper_dispatch_root(root_name, fn_defs, fn_sigs).unwrap_or_else(|| root_name.to_string());
@@ -386,7 +402,7 @@ fn frontier_helper_calls(
 fn wrapper_dispatch_root(
     fn_name: &str,
     fn_defs: &EntryFnIndex<'_>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Option<String> {
     let fd = fn_defs.get(fn_name)?;
     let tail = fd.body.tail_expr()?;
@@ -400,9 +416,9 @@ fn wrapper_dispatch_root(
 fn direct_pure_fn_callees_matching_return(
     fn_name: &str,
     fn_defs: &EntryFnIndex<'_>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> BTreeSet<String> {
-    let Some((_, return_type, _)) = fn_sigs.get(fn_name) else {
+    let Some(caller_info) = fn_sigs.fn_sig(fn_name) else {
         return BTreeSet::new();
     };
     let Some(fd) = fn_defs.get(fn_name) else {
@@ -421,8 +437,8 @@ fn direct_pure_fn_callees_matching_return(
         .into_iter()
         .filter(|callee| {
             callee != fn_name
-                && fn_sigs.get(callee).is_some_and(|(_, callee_ret, effects)| {
-                    effects.is_empty() && callee_ret == return_type
+                && fn_sigs.fn_sig(callee).is_some_and(|callee_info| {
+                    callee_info.is_pure && callee_info.return_type == caller_info.return_type
                 })
         })
         .collect()
@@ -431,7 +447,7 @@ fn direct_pure_fn_callees_matching_return(
 fn collect_direct_pure_user_calls(
     expr: &Spanned<Expr>,
     fn_defs: &EntryFnIndex<'_>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
     out: &mut BTreeSet<String>,
 ) {
     match &expr.node {
@@ -491,9 +507,7 @@ fn collect_direct_pure_user_calls(
         Expr::TailCall(boxed) => {
             let TailCallData { target, args, .. } = boxed.as_ref();
             if fn_defs.contains_key(target)
-                && fn_sigs
-                    .get(target)
-                    .is_some_and(|(_, _, effects)| effects.is_empty())
+                && fn_sigs.fn_sig(target).is_some_and(|info| info.is_pure)
             {
                 out.insert(target.clone());
             }
@@ -508,7 +522,7 @@ fn collect_direct_pure_user_calls(
 fn direct_pure_user_call_name(
     expr: &Spanned<Expr>,
     fn_defs: &EntryFnIndex<'_>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Option<String> {
     let Expr::FnCall(callee, _) = &expr.node else {
         return None;
@@ -518,8 +532,8 @@ fn direct_pure_user_call_name(
         return None;
     }
     fn_sigs
-        .get(&name)
-        .is_some_and(|(_, _, effects)| effects.is_empty())
+        .fn_sig(&name)
+        .is_some_and(|info| info.is_pure)
         .then_some(name)
 }
 
@@ -540,7 +554,7 @@ fn detect_roundtrip_layers(
     law: &VerifyLaw,
     given_name: &str,
     fn_defs: &EntryFnIndex<'_>,
-    fn_sigs: &FnSigMap,
+    fn_sigs: &dyn FnSigOracle,
 ) -> Option<(String, String)> {
     if law.givens.len() != 1 {
         return None;
@@ -550,7 +564,7 @@ fn detect_roundtrip_layers(
         expr: &Spanned<Expr>,
         given_name: &str,
         fn_defs: &EntryFnIndex<'_>,
-        fn_sigs: &FnSigMap,
+        fn_sigs: &dyn FnSigOracle,
     ) -> Option<(String, String)> {
         let Expr::FnCall(parser_callee, parser_args) = &expr.node else {
             return None;
@@ -586,14 +600,14 @@ fn detect_roundtrip_layers(
             return None;
         }
         if !fn_sigs
-            .get(&parser_name)
-            .is_some_and(|(_, _, effects)| effects.is_empty())
+            .fn_sig(&parser_name)
+            .is_some_and(|info| info.is_pure)
         {
             return None;
         }
         if !fn_sigs
-            .get(&serializer_name)
-            .is_some_and(|(_, _, effects)| effects.is_empty())
+            .fn_sig(&serializer_name)
+            .is_some_and(|info| info.is_pure)
         {
             return None;
         }

--- a/tests/identity_guardrails.rs
+++ b/tests/identity_guardrails.rs
@@ -128,12 +128,12 @@ const BANNED_PATTERNS: &[BannedPattern] = &[
                 the matching category",
     },
     BannedPattern {
-        needle: "ctx.fn_sigs.",
-        label: "ctx.fn_sigs.* — string-keyed fn signature side channel removed \
+        needle: "ctx.fn_sigs",
+        label: "ctx.fn_sigs* — string-keyed fn signature side channel removed \
                 in Phase 7 of #180. Prefer ctx.resolve_fn_def(fd, scope) for \
                 ResolvedFnDef.params / return_type, ctx.resolved_program for \
-                the resolved-program view, or ctx.fn_sigs_projection() for a \
-                fresh fn-sig map (verify_law / law_auto consumers)",
+                the resolved-program view, or pass ctx directly to verify_law \
+                helpers (ctx impls FnSigOracle)",
     },
 ];
 


### PR DESCRIPTION
## Summary

Tightens the verify-law API surface so callers don't have to materialise a whole `FnSigMap` on demand. Verify-law helpers used to take `&FnSigMap`, which forced every Lean / CLI caller to call `ctx.fn_sigs_projection()` right before passing the result in. The map allocation was wasteful for helpers that only query 1-2 names per invocation.

This closes the parallel-scope cleanup item noted in PR #195's doc comment on `FnSigMap`. Epic #180 now has zero open structural items.

## New shape

- `FnSigOracle` trait (in `verify_law`) with a single method `fn_sig(name) -> Option<FnSigInfo>`. `FnSigInfo` carries the `return_type` + an `is_pure` flag — the only two things verify-law's three internal read sites actually consume.
- `impl FnSigOracle for FnSigMap` keeps the legacy API working (tests still build a literal `FnSigMap` and pass it).
- `impl FnSigOracle for CodegenContext` (in `codegen/mod.rs`) routes per-key queries through `resolved_program` first (entry + dep module fns), then walks `TypeDef`s for constructor sigs, then handles the synthesised `__buf_*` intrinsics.

## Sites migrated

- 18 verify-law helper signatures flip from `&FnSigMap` to `&dyn FnSigOracle`.
- Three internal read sites destructure `FnSigInfo` instead of the legacy `(_, return_type, effects)` tuple.
- 7 Lean `law_auto` callsites + 2 `main/commands.rs` CLI helpers pass `ctx` directly.

## Dropped

- `CodegenContext::fn_sigs_projection()` + the helper `fn_sigs_projection_typedef` are removed — no callers left.

`tests/identity_guardrails.rs` banned-pattern label refreshed: pass `ctx` directly to verify_law helpers via the `FnSigOracle` impl rather than the (now removed) projection method.

## Test plan

- [x] `cargo test` clean
- [x] `cargo test --features wasm` clean (modulo pre-existing flakiness in `wasm_gc_record_replay_spec` when run in parallel — same tests pass in isolation, unrelated to this PR's code paths)
- [x] `cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `tests/identity_guardrails.rs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)