### PR TITLE
codegen/program_view: document Typed HIR boundary — #180 close

### DIFF
--- a/src/codegen/program_view.rs
+++ b/src/codegen/program_view.rs
@@ -8,6 +8,66 @@
 //! metadata (spans, diagnostics, syntax-discovery), not as the
 //! authoritative backend input.
 //!
+//! # Current Typed HIR boundary (post epic #180)
+//!
+//! Aver's **Typed HIR** is a query layer, not a duplicate IR enum. Its
+//! two structural primitives — what backends mean when they reach for
+//! "the typed program" — are:
+//!
+//! 1. [`ResolvedProgramView`] (this struct). The canonical post-name-
+//!    resolution program: every `FnDef` projected through
+//!    [`crate::ir::hir::ResolvedFnDef`] with typed
+//!    `params: Vec<(String, Type)>` and `return_type: Type`, indexed
+//!    by opaque [`crate::ir::FnId`]. Backends ask
+//!    "what does this fn look like?" through `fn_by_id` or
+//!    `entry_fns()` / `module_fns(prefix)` and get typed answers.
+//! 2. Stamped [`crate::ast::Spanned`]`<`[`crate::ir::hir::ResolvedExpr`]`>`.
+//!    Every reachable body expression in a well-typed program has
+//!    `.ty().is_some()` after the typechecker stamps and the
+//!    resolver propagates. Backends read inferred types per node
+//!    without re-running inference.
+//!
+//! Together they answer "what name does this refer to?" (resolved
+//! HIR via `FnId` / `TypeId` / `CtorId`) and "what type does this
+//! expression have?" (typed slot via `Spanned::ty()`).
+//!
+//! Conscious exceptions still walking `ast::*` directly (each
+//! documented at the call site):
+//!
+//! - **`verify_law` helper walkers** ([`crate::verify_law`]). The
+//!   helper-law / contextual-helper hint walkers operate on
+//!   entry-only AST `FnDef`s through [`crate::verify_law::EntryFnIndex`].
+//!   The parser invariant (`verify <name>` only accepts a single
+//!   `Ident`) keeps the identity-safe contract; migration to FnId
+//!   keying is gated on module-scoped verify shipping.
+//! - **Lean / Dafny proof + law spec emitters**. Several recognisers
+//!   (`emit_*_spec_equivalence_law`, `direct_call` AST shape match)
+//!   keep walking `Spanned<Expr>` source-shape because the proof IR
+//!   is keyed on syntactic surfaces the user wrote, not the resolver-
+//!   canonicalised form. `emit_expr_legacy` is the explicit adapter.
+//! - **wasm-gc post-link view** ([`crate::codegen::wasm_gc::view`]).
+//!   The wasm-gc backend collapses N modules into one emit unit via
+//!   `flatten_multimodule`, then rebuilds its own
+//!   [`crate::ir::SymbolTable`] + resolver pass over the flattened
+//!   slice. The post-link namespace is the identity layer in that
+//!   backend; the documented `backend-link-stage` category covers it.
+//!
+//! Trigger-driven follow-up (NOT scoped to #180):
+//!
+//! - **MIR / Core IR**. Per-expression effects, SSA / CFG / explicit
+//!   ownership / effect tracking per instruction belong to a separate
+//!   epic. Typed HIR is the substrate they lower from; build the IR
+//!   when an inliner / monomorphiser / cross-scope optimiser needs it.
+//! - **`TypedProgramView` wrapper**. Combining `resolved_program`'s
+//!   `FnId` index with the typed expression slot into one query
+//!   surface (`view.fn_by_id(id).body_expr_type(span)` or similar)
+//!   would tighten the contract but adds no semantic value today —
+//!   wait for a real consumer.
+//! - **Module-scoped verify → FnId keyed `verify_law`**. The
+//!   `EntryFnIndex` newtype is the tripwire that forces the
+//!   contributor to address keying when the parser starts accepting
+//!   dotted verify targets.
+//!
 //! ## Construction
 //!
 //! Built once at the codegen boundary:


### PR DESCRIPTION
## Summary

Doc-only PR. Adds a module-level doc block on `codegen/program_view.rs` that names what backends mean by "Typed HIR" after epic #180:

1. `ResolvedProgramView` — the canonical post-name-resolution program with typed `params` / `return_type` and `FnId` indexing.
2. Stamped `Spanned<ResolvedExpr>` — every reachable body expression carries `.ty()` after typecheck.

Together they answer "what does this name refer to?" and "what type does this expression have?" without backends re-running resolution or inference.

## Conscious exceptions documented at the doc surface

- `verify_law` entry-only AST walkers (via `EntryFnIndex` — gated on module-scoped verify trigger)
- Lean / Dafny proof + law spec emitters using `emit_expr_legacy` for syntactic shape matching
- wasm-gc post-link view (`backend-link-stage` category)

Each exception is already tagged at its call site with one of the allowed `identity_guardrails` categories.

## Trigger-driven follow-ups explicitly NOT scoped to #180

- MIR / Core IR (per-expression effects, SSA, ownership tracking)
- Unified `TypedProgramView` wrapper combining FnId + typed expr-slot queries
- Module-scoped verify → FnId-keyed `verify_law` rewrite gated on parser changes

## Test plan

- [x] No code paths touched — doc only
- [x] `cargo build` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `tests/identity_guardrails.rs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)