### PR TITLE
ci(fuzz): pin cargo-afl to 0.18.1 — 0.18.2 panics on install

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -163,14 +163,21 @@ jobs:
         # ensures the AFL llvm passes are compiled — a half-baked
         # cache restore can leave the binary present but the
         # instrumentation source missing.
+        #
+        # Version pin: 0.18.2 (released 2026-05-11) panics on
+        # `config --build` with `could not copy directory
+        # cargo-afl-common-0.18.2/AFLplusplus` — every nightly fuzz
+        # run since 2026-05-27 failed with this panic at install
+        # time, never executing any fuzz target. Pin to the last
+        # known-good version until upstream ships a fix.
         run: |
           if ! command -v cargo-afl >/dev/null; then
-            cargo install cargo-afl --locked
+            cargo install cargo-afl --version 0.18.1 --locked
           fi
           cargo afl --version
           if ! cargo afl config --build --force; then
             echo "cargo-afl source missing — force-reinstalling"
-            cargo install cargo-afl --locked --force
+            cargo install cargo-afl --version 0.18.1 --locked --force
             cargo afl config --build --force
           fi
 


### PR DESCRIPTION
## Summary

Every nightly fuzz run since 2026-05-27 failed at install time with

\`\`\`
thread 'main' panicked at cargo-afl-0.18.2/src/main.rs:144:34:
called Result::unwrap() on an Err value: could not copy
directory cargo-afl-common-0.18.2/AFLplusplus
\`\`\`

\`cargo-afl\` 0.18.2 (released 2026-05-11) tries to copy the bundled AFLplusplus subtree from the crates.io tarball during \`cargo afl config --build\` and panics on the missing directory — the tarball ships a stripped subtree, the copy step assumes the full clone.

Pin both install steps to 0.18.1 (released 2026-04-19, last known-good) until upstream ships a fix. Removes the regression on the nightly fuzz lane without touching the AFL targets themselves.

## Note on recent nightly failures

The 2026-05-27 and 2026-05-28 nightly fuzz failures recorded in the Fuzz workflow are this \`cargo-afl\` regression at install time, **not Aver-side bugs** — every fuzz target's actual execution never ran (\"no metrics snapshot — target ran < 10k execs\" / \`out/<target>/default\` missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)