### PR TITLE
ci(proof): bump Dafny 4.9.0 → 4.11.0

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -68,7 +68,14 @@ jobs:
         # the job.
         uses: dafny-lang/setup-dafny-action@v1.9.1
         with:
-          dafny-version: 4.9.0
+          # 4.11.0: 4.9.0 leaves 2 quicksort postconditions un-
+          # discharged on top of the 5-budget (left: 7, right: 5)
+          # and drifts on rle in the same direction; 4.11.0's SMT
+          # encoding closes both within budget on the same source.
+          # Bumping in lockstep with the macOS Homebrew Dafny used
+          # by local contributors keeps `cargo test --test
+          # proof_spec` behaviour identical between dev + CI.
+          dafny-version: 4.11.0
 
       - name: Verify `dafny` reachable
         run: dafny --version


### PR DESCRIPTION
## Summary

The nightly proof gate failed on \`proof_dafny_verifies_quicksort_when_dafny_is_available\` (left: 7 errors, right: 5 budget) and \`proof_dafny_verifies_rle_when_dafny_is_available\`. Same source, same \`aver proof --backend dafny\` output, same budgets — the gap is the Dafny version: CI was pinned to 4.9.0, and locally on macOS the same tests pass with Homebrew's 4.11.0.

4.11.0's SMT encoding discharges the postconditions 4.9.0 leaves open on both fixtures, putting the observed errors inside the existing budgets. Bumping the action input lines CI up with the dev-local toolchain so \`cargo test --test proof_spec\` produces the same result on both sides.

## Reproduction

- CI nightly 2026-05-27, 2026-05-28 + the manual workflow_dispatch run today: both proof tests fail at the budget boundary.
- Local macOS 4.11.0: \`cargo test --features wasm --test proof_spec\` runs 61/61 clean.

## What's not in this PR

No source or test changes — the budgets in \`tests/proof_spec.rs\` already account for the obligations Dafny can't auto-close on the flagship corpus (\`fibonacci\`, \`rle\`, \`quicksort\`, \`date\`, \`json\`). Bumping the verifier doesn't change those gates, it just makes CI agree with local on which errors fall under them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)