### PR TITLE
fuzz: update replay_roundtrip + parity targets to new VM API

### DIFF
--- a/fuzz/fuzz_targets/parity_vm_vs_wasm_gc.rs
+++ b/fuzz/fuzz_targets/parity_vm_vs_wasm_gc.rs
@@ -94,7 +94,7 @@ fn main() {
         );
         let analysis = pipeline.analysis.as_ref();
 
-        let vm_outcome = run_vm(&items, analysis);
+        let vm_outcome = run_vm(&pipeline.resolved_items, &pipeline.symbol_table, analysis);
         let wasm_outcome = run_wasm_gc(&items, analysis);
 
         match (vm_outcome, wasm_outcome) {
@@ -125,12 +125,16 @@ fn main() {
 /// Compile `items` against the VM, run `main`, capture stdout +
 /// return value. `None` on any compile / runtime / panic failure;
 /// `Some(outcome)` when the run completed cleanly.
-fn run_vm(items: &[TopLevel], analysis: Option<&aver::ir::AnalysisResult>) -> Option<BackendOutcome> {
+fn run_vm(
+    items: &[aver::ir::hir::ResolvedTopLevel],
+    symbols: &aver::ir::SymbolTable,
+    analysis: Option<&aver::ir::AnalysisResult>,
+) -> Option<BackendOutcome> {
     let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
         let mut arena = aver::nan_value::Arena::new();
         aver::vm::register_service_types(&mut arena);
         let (code, globals) =
-            aver::vm::compile_program_with_modules(items, &mut arena, None, "", analysis)
+            aver::vm::compile_program_with_modules(items, symbols, &mut arena, None, "", analysis)
                 .ok()?;
         let mut machine = aver::vm::VM::new(code, globals, arena);
         machine.set_cli_args(Vec::new());

--- a/fuzz/fuzz_targets/replay_roundtrip.rs
+++ b/fuzz/fuzz_targets/replay_roundtrip.rs
@@ -33,8 +33,8 @@
 #[path = "common.rs"]
 mod common;
 
-use aver::ast::TopLevel;
-use aver::ir::{PipelineConfig, TypecheckMode};
+use aver::ir::hir::ResolvedTopLevel;
+use aver::ir::{PipelineConfig, SymbolTable, TypecheckMode};
 use aver::replay::JsonValue;
 use std::panic::AssertUnwindSafe;
 
@@ -77,7 +77,7 @@ fn main() {
         }
         c.record_typecheck_clean();
 
-        let _ = aver::ir::pipeline::run(
+        let pipeline_result = aver::ir::pipeline::run(
             &mut items,
             PipelineConfig {
                 typecheck: Some(TypecheckMode::Full { base_dir: None }),
@@ -87,7 +87,11 @@ fn main() {
 
         // First run: record. Captures the canonical (stdout,
         // value, trace) triple the replay must reproduce.
-        let Some(record) = run_vm(&items, RecordMode::Record) else {
+        let Some(record) = run_vm(
+            &pipeline_result.resolved_items,
+            &pipeline_result.symbol_table,
+            RecordMode::Record,
+        ) else {
             return;
         };
         let trace = match record.recorded_effects.as_ref() {
@@ -97,7 +101,11 @@ fn main() {
 
         // Second run: replay against the recorded trace. Same
         // program, fresh VM, recorder swapped for replayer.
-        let Some(replay) = run_vm(&items, RecordMode::Replay(trace)) else {
+        let Some(replay) = run_vm(
+            &pipeline_result.resolved_items,
+            &pipeline_result.symbol_table,
+            RecordMode::Replay(trace),
+        ) else {
             // Replay refused / panicked under catch_unwind. Real
             // bug class — record produced a trace the replay
             // can't consume.
@@ -131,12 +139,17 @@ enum RecordMode {
     Replay(Vec<aver::replay::EffectRecord>),
 }
 
-fn run_vm(items: &[TopLevel], mode: RecordMode) -> Option<RunOutcome> {
+fn run_vm(
+    items: &[ResolvedTopLevel],
+    symbols: &SymbolTable,
+    mode: RecordMode,
+) -> Option<RunOutcome> {
     let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
         let mut arena = aver::nan_value::Arena::new();
         aver::vm::register_service_types(&mut arena);
         let (code, globals) =
-            aver::vm::compile_program_with_modules(items, &mut arena, None, "", None).ok()?;
+            aver::vm::compile_program_with_modules(items, symbols, &mut arena, None, "", None)
+                .ok()?;
         let mut machine = aver::vm::VM::new(code, globals, arena);
         machine.set_cli_args(Vec::new());
         let want_record = match &mode {


### PR DESCRIPTION
## Summary

\`aver::vm::compile_program_with_modules\` grew a second \`&SymbolTable\` parameter and switched its \`items\` parameter from \`&[TopLevel]\` to \`&[ResolvedTopLevel]\` in PR #155 (#147 Phase E PR 7), but the fuzz targets never followed. The two affected targets have failed to compile on every nightly fuzz run since then with E0061 (\"function takes 6 arguments but 5 arguments were supplied\") — recorded as generic build failures with \`No out/<target>/default — fuzz step likely never ran\`.

The other six fuzz targets compile and run fine, so the failure pattern stayed invisible in the run summary until someone read the per-job logs.

## What changed

Both targets:

- Keep the \`pipeline::run\` result instead of \`let _ = ...\`'s it,
- Read \`resolved_items\` + \`symbol_table\` off the pipeline output,
- Pass both to \`compile_program_with_modules\`.

\`parity_vm_vs_wasm_gc\` keeps the wasm-gc side on \`&[TopLevel]\` because \`aver::runtime::wasm_gc::run_in_process\` still takes the source-shape AST (the wasm-gc backend runs its own resolver pass internally — see \`WasmGcLinkedView\`).

No fuzz-target logic change beyond the signature fix; the record→replay invariant + VM↔wasm-gc parity checks are unchanged.

## Test plan

- [x] \`cd fuzz && cargo check --bins\` clean
- [x] All 8 fuzz target binaries link
- [ ] Next nightly Fuzz workflow goes 8/8 green (paired with PR #199's cargo-afl pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)