### PR TITLE
codegen/wasm_gc: bump String.fromFloat shortest-roundtrip cap 15 → 17

### DIFF
--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -1679,7 +1679,20 @@ fn emit_string_from_float(registry: &TypeRegistry) -> Result<Function, WasmGcErr
                 ;; end_pos = 21
                 i32.const 21 local.set $end_pos)
               (else
-                ;; Find shortest N (1..15).
+                ;; Find shortest N (1..17). 17 is the maximum number
+                ;; of fractional digits any IEEE 754 f64 value
+                ;; needs for a round-trip-unique representation —
+                ;; matches Rust's `f64::to_string` shortest-
+                ;; roundtrip (Ryu/Grisu). Bumped from 15 in PR #203
+                ;; because the prior cap diverged from VM / Rust /
+                ;; wasip2 output by one digit on values in the
+                ;; [0.1, 10) range, e.g. golden-ratio `Float.fromInt
+                ;; (fib(n + 1)) / Float.fromInt(fib(n))` from
+                ;; `examples/data/fibonacci.av` printed
+                ;; `1.618181818181818` on wasm-gc vs
+                ;; `1.6181818181818182` on VM. For values outside
+                ;; that range the overflow guard below fires first,
+                ;; so the cap is effectively unreachable.
                 f64.const 1 local.set $pow
                 i32.const 0 local.set $n
 
@@ -1693,7 +1706,7 @@ fn emit_string_from_float(registry: &TypeRegistry) -> Result<Function, WasmGcErr
                     ;; `(((-0.5772) * (-61.8024)) * (-877.8128))` ≈
                     ;; -31313.64 the loop converges late enough that
                     ;; `abs_val * 10^N` crosses 2^63 (~9.22e18) before
-                    ;; N hits the 15-digit cap below, and the next
+                    ;; N hits the 17-digit cap below, and the next
                     ;; `trunc_f64_s` traps with "wasm trap: integer
                     ;; overflow". Bail out of the loop with the
                     ;; current $scaled / $pow / $n when the next
@@ -1726,7 +1739,7 @@ fn emit_string_from_float(registry: &TypeRegistry) -> Result<Function, WasmGcErr
                     br_if $ndone
 
                     local.get $n
-                    i32.const 15
+                    i32.const 17
                     i32.ge_s
                     br_if $ndone
 

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -241,6 +241,36 @@ fn helper(n: Int) -> Int
     );
 }
 
+// `String.fromFloat` shortest-roundtrip on a 17-significant-digit
+// f64 — pins the WAT helper's frac-digit cap at 17 (was 15 pre-#203,
+// which truncated `1.6181818181818182` to `1.618181818181818` and
+// surfaced as a VM↔wasm-gc parity divergence on every Aver source
+// that printed a Float of ≥16 fractional digits — e.g. the
+// `goldenApprox(n) = Float.fromInt(fib(n + 1)) / Float.fromInt(fib(n))`
+// line in `examples/data/fibonacci.av`).
+//
+// Rust's `f64::to_string` rounds the golden-ratio approximation
+// to exactly `"1.6181818181818182"` (18 chars). The helper now
+// matches.
+#[test]
+fn string_from_float_emits_17_digit_shortest_roundtrip() {
+    assert_eq!(
+        run_int(
+            r#"module Tmp
+    intent = "String.fromFloat shortest-roundtrip"
+    depends []
+
+fn main() -> Int
+    String.len(String.fromFloat(1.6181818181818182))
+"#
+        ),
+        18,
+        "expected 18-char `1.6181818181818182` shortest-roundtrip; \
+         a shorter result means the WAT helper's frac-digit cap \
+         regressed below 17",
+    );
+}
+
 // Cross-module same-bare-name `TypeDef` regression for wasm-gc
 // — known-failing pin, `#[ignore]`'d until the canonical-key
 // migration lands.


### PR DESCRIPTION
## Summary

The WAT helper for \`String.fromFloat\` capped the shortest-roundtrip loop at N=15 fractional digits to guarantee \`i64.trunc_f64_s\` couldn't trap on \`abs_val * 10^N\` (which crosses 2^63 ≈ 9.22e18 for values in the 10²+ range). That worked, but it also cut precision one digit short on values in the [0.1, 10) range where the multiplication doesn't overflow — \`1.6181818181818182\` came out as \`1.618181818181818\` (1 fewer digit than Rust's \`f64::to_string\`).

This diverged from VM and wasip2 (both use Rust's shortest-roundtrip) and surfaced as a VM↔wasm-gc parity mismatch on every Aver source that printed a Float of ≥16 fractional digits — e.g. \`goldenApprox(n) = Float.fromInt(fib(n + 1)) / Float.fromInt(fib(n))\` in \`examples/data/fibonacci.av\`. The \`parity_vm_vs_wasm_gc\` fuzz target would surface it as a stdout divergence on any input exercising \`String.fromFloat\`.

## Fix

Bumping the cap to 17 (the IEEE 754 f64 max sig-digit needed for round-trip uniqueness) closes the gap without touching the overflow guard above the cap, which still bails one iteration before \`abs_val * 10^N >= 2^63\` and prevents the trap on large magnitudes. For values outside [0.1, 10) the overflow guard fires first, so the cap is effectively unreachable in those ranges.

## Regression

New test \`string_from_float_emits_17_digit_shortest_roundtrip\` in \`tests/wasm_gc_spec.rs\` pins \`String.len(String.fromFloat(1.6181818181818182)) == 18\` so the cap can't quietly regress to 15 again.

## Test plan

- [x] \`cargo test\` clean
- [x] \`cargo test --features wasm\` clean
- [x] \`cargo clippy --features wasm -p aver-lang --lib --bin aver --tests -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] Manual VM↔wasm-gc parity (stdout sha256) on \`fibonacci\`, \`calculator\`, \`quicksort\`, \`rle\`, \`natural\`, \`bigint\` all bit-identical (was 4 divergences on the float-printing sources, all 6 now match)

## Separately noted

VM↔wasip2 parity reveals a different pre-existing issue: \`Console.print\` on wasip2 omits the trailing newline that VM and wasm-gc both append, so wasip2 stdout is everything-jammed-together. Not from this PR's code path; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)