### PR TITLE
codegen/wasm_gc: dedicated __rt_println_to_lm helper for wasip2 Console.*

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -382,6 +382,14 @@ pub(super) struct Wasip2Lowering {
     /// Aver `(ref null $string)` to LM[0..len]. `Some(...)` when
     /// any string-marshalling effect (i.e., `Console.*`) is wired.
     pub(super) str_to_lm_fn_idx: Option<u32>,
+    /// `__rt_println_to_lm` helper wasm fn idx. Same shape as
+    /// `str_to_lm_fn_idx` but also writes `'\n'` at LM[len] before
+    /// returning `len + 1`. Allocated alongside the JS-bridge
+    /// helpers when any string-marshalling effect is wired; used
+    /// only by `Console.print` / `Console.error` / `Console.warn`
+    /// on `--target wasip2` to honour the VM and AverBridge
+    /// `Console.* == println!` semantic at the bridge layer.
+    pub(super) println_to_lm_fn_idx: Option<u32>,
 
     // ── Phase 1.4: Time.unixMs / Random.{int, float} ───────────
     /// `wasi:clocks/wall-clock.now` imported wasm fn idx.

--- a/src/codegen/wasm_gc/body/builtins_wasip2.rs
+++ b/src/codegen/wasm_gc/body/builtins_wasip2.rs
@@ -110,14 +110,23 @@ pub(super) fn emit_console_print_wasip2(
     func.instruction(&Instruction::GlobalSet(handle_global));
     func.instruction(&Instruction::End);
 
-    // Step 2: marshal s → LM[0..len], stash len.
-    let str_to_lm = lowering.str_to_lm_fn_idx.ok_or_else(|| {
+    // Step 2: marshal s + trailing '\n' through the println_to_lm
+    // helper. Single Call writes the string bytes to LM[0..len],
+    // appends `'\n'` at LM[len], and returns `len + 1`. VM and
+    // wasm-gc AverBridge both treat `Console.print(s)` as
+    // `println!(s)` (see `services::console::write_stdout` /
+    // `write_stderr_*`); having a dedicated println helper keeps
+    // that semantic at the bridge level instead of patching the
+    // length post-hoc at every call site, and lets the chunked
+    // write below stay shape-identical with Disk.* / Http.* (the
+    // non-newline consumers of plain `__rt_string_to_lm`).
+    let println_to_lm = lowering.println_to_lm_fn_idx.ok_or_else(|| {
         WasmGcError::Validation(
-            "Console.* on wasip2: __rt_string_to_lm fn idx missing — bridge not allocated".into(),
+            "Console.* on wasip2: __rt_println_to_lm fn idx missing — bridge not allocated".into(),
         )
     })?;
     emit_expr(func, &args[0], slots, ctx)?;
-    func.instruction(&Instruction::Call(str_to_lm));
+    func.instruction(&Instruction::Call(println_to_lm));
     func.instruction(&Instruction::LocalSet(len_local));
 
     // Step 3: defensive memory.grow(1) so retptr+12 stays in-bounds

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -851,6 +851,10 @@ pub(super) fn emit_module_with(
             grow_type: idx.grow_type,
             from_lm_fn: next_fn(),
             to_lm_fn: next_fn(),
+            // `println_to_lm` reuses `to_lm_type` — same `(s: ref
+            // string) -> i32` shape. The body writes `'\n'` at
+            // LM[len] before returning `len + 1`.
+            println_to_lm_fn: next_fn(),
             pages_fn: next_fn(),
             grow_fn: next_fn(),
         })
@@ -1695,6 +1699,9 @@ pub(super) fn emit_module_with(
     if let Some(b) = &bridge {
         funcs.function(b.from_lm_type);
         funcs.function(b.to_lm_type);
+        // println_to_lm reuses the to_lm wasm type (same
+        // `(s: ref string) -> i32` signature).
+        funcs.function(b.to_lm_type);
         funcs.function(b.pages_type);
         funcs.function(b.grow_type);
     }
@@ -2019,6 +2026,7 @@ pub(super) fn emit_module_with(
                 stdout_handle_global: wasip2_globals.as_ref().and_then(|g| g.stdout_handle),
                 stderr_handle_global: wasip2_globals.as_ref().and_then(|g| g.stderr_handle),
                 str_to_lm_fn_idx: bridge.as_ref().map(|b| b.to_lm_fn),
+                println_to_lm_fn_idx: bridge.as_ref().map(|b| b.println_to_lm_fn),
                 clocks_now_fn_idx: wasip2_imports
                     .lookup_wasm_fn_idx(Wasip2ImportSlot::ClocksWallClockNow),
                 random_u64_fn_idx: wasip2_imports
@@ -6322,6 +6330,7 @@ struct BridgeIndices {
     grow_type: u32,
     from_lm_fn: u32,
     to_lm_fn: u32,
+    println_to_lm_fn: u32,
     pages_fn: u32,
     grow_fn: u32,
 }
@@ -6481,6 +6490,88 @@ fn emit_bridge_bodies(codes: &mut CodeSection, registry: &TypeRegistry) -> Resul
     "#
     );
     codes.function(&wat_helper::compile_wat_helper(&to_lm_wat)?);
+
+    // println_to_lm(s) → i32 (= s.len + 1). Same shape as `to_lm`
+    // plus a `'\n'` (0x0A) byte at LM[len] before returning. Used
+    // by `Console.print` / `Console.error` / `Console.warn` on
+    // `--target wasip2` so the `Console.* == println!` semantic
+    // VM and AverBridge ship lives at the bridge layer instead of
+    // every call site appending the newline by hand. Body is a
+    // textual edit of `to_lm` with the trailing `local.get $len`
+    // swapped for "store '\n' at LM[len]; return len + 1".
+    let println_to_lm_wat = format!(
+        r#"
+        (module
+          {padding}
+          (type $string (array (mut i8)))
+          (memory 1)
+          (func (export "helper") (param $s (ref null $string)) (result i32)
+            (local $len i32)
+            (local $i i32)
+            (local $needed i32)
+            (local $current i32)
+            local.get $s
+            array.len
+            local.set $len
+
+            ;; needed = (len + 1 + 65535) >> 16
+            local.get $len
+            i32.const 1
+            i32.add
+            i32.const 65535
+            i32.add
+            i32.const 16
+            i32.shr_u
+            local.set $needed
+
+            memory.size
+            local.set $current
+
+            local.get $needed
+            local.get $current
+            i32.gt_u
+            (if
+              (then
+                local.get $needed
+                local.get $current
+                i32.sub
+                memory.grow
+                drop))
+
+            i32.const 0
+            local.set $i
+            (block $break
+              (loop $next
+                local.get $i
+                local.get $len
+                i32.ge_u
+                br_if $break
+
+                local.get $i
+                local.get $s
+                local.get $i
+                array.get_u $string
+                i32.store8
+
+                local.get $i
+                i32.const 1
+                i32.add
+                local.set $i
+                br $next))
+
+            ;; LM[len] = '\n' (0x0A)
+            local.get $len
+            i32.const 10
+            i32.store8
+
+            ;; return len + 1
+            local.get $len
+            i32.const 1
+            i32.add)
+        )
+    "#
+    );
+    codes.function(&wat_helper::compile_wat_helper(&println_to_lm_wat)?);
 
     // pages() -> i32 (= memory.size). Trivially small; wasm-encoder.
     let mut pages = wasm_encoder::Function::new([]);

--- a/tests/wasip2_stress.rs
+++ b/tests/wasip2_stress.rs
@@ -36,7 +36,7 @@
 
 #![cfg(feature = "wasip2")]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -50,13 +50,13 @@ fn tempdir(prefix: &str) -> PathBuf {
     dir
 }
 
-fn write_fixture(dir: &PathBuf, name: &str, source: &str) -> PathBuf {
+fn write_fixture(dir: &Path, name: &str, source: &str) -> PathBuf {
     let path = dir.join(name);
     std::fs::write(&path, source).expect("write fixture");
     path
 }
 
-fn run_wasip2(dir: &PathBuf, fixture: &PathBuf, args: &[&str]) -> std::process::Output {
+fn run_wasip2(dir: &Path, fixture: &Path, args: &[&str]) -> std::process::Output {
     let aver_bin = env!("CARGO_BIN_EXE_aver");
     let mut cmd = Command::new(aver_bin);
     cmd.current_dir(dir).arg("run").arg("--wasip2").arg(fixture);
@@ -162,7 +162,7 @@ fn main() -> Unit
         Result.Err(_) -> Console.print("cleanup err")
 "#;
     let fixture = write_fixture(&dir, "large.av", src);
-    let payload: String = std::iter::repeat('x').take(50_000).collect();
+    let payload = "x".repeat(50_000);
     let out = run_wasip2(&dir, &fixture, &[&payload]);
     assert_ok(&out, "large.av");
     let s = stdout(&out);
@@ -198,18 +198,25 @@ fn main() -> Unit
     // 5000 bytes — over the 4096-byte single-call cap. Pre-fix
     // this trapped with "Buffer too large for blocking-write-
     // and-flush". Post-fix the chunked-write loop walks it in
-    // 4096-byte slices.
-    let payload: String = std::iter::repeat('y').take(5_000).collect();
+    // 4096-byte slices. The `+ 1` covers the trailing newline
+    // the `__rt_println_to_lm` bridge helper appends so the
+    // wasip2 `Console.print` matches VM / AverBridge's `println!`
+    // semantic (see PR #204).
+    let payload = "y".repeat(5_000);
     let out = run_wasip2(&dir, &fixture, &[&payload]);
     assert_ok(&out, "print.av");
     let s = stdout(&out);
     assert_eq!(
         s.len(),
-        5_000,
-        "expected exactly 5000 bytes printed, got {} bytes",
+        5_001,
+        "expected exactly 5001 bytes printed (5000 'y' + '\\n'), got {} bytes",
         s.len()
     );
-    assert!(s.chars().all(|c| c == 'y'), "expected all y's");
+    assert!(s.ends_with('\n'), "expected trailing newline");
+    assert!(
+        s[..5_000].chars().all(|c| c == 'y'),
+        "expected first 5000 bytes to all be 'y'"
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }
 


### PR DESCRIPTION
## Summary

\`Console.print\` / \`Console.error\` / \`Console.warn\` on \`--target wasip2\` previously wrote only the string bytes to the wasip2 output stream. VM and wasm-gc AverBridge both treat these as \`println!\` (see \`services::console::write_stdout\` and matching \`write_stderr_*\`), so successive \`Console.print(\"a\"); Console.print(\"b\")\` calls came out as \`a\\nb\\n\` on VM / wasm-gc and \`ab\` on wasip2 — every line jammed together.

The \`parity_vm_vs_wasm_gc\` fuzz target would surface this on any input that called \`Console.print\` more than once.

## Fix

Add a dedicated \`__rt_println_to_lm\` bridge helper alongside the existing \`__rt_string_to_lm\`. Same \`(s: ref string) -> i32\` signature (reuses the to_lm wasm type slot); the body copies the string bytes, writes a \`'\\n'\` (0x0A) at LM[len], grows memory by \`(len + 1 + 65535) >> 16\` pages instead of \`(len + 65535) >> 16\`, and returns \`len + 1\`.

\`Console.print\` / \`error\` / \`warn\` swap their \`Call __rt_string_to_lm\` for \`Call __rt_println_to_lm\` at the emit site — single Call replaces the str-copy + manual-newline-patch shape, keeping the \`println!\` semantic at the bridge layer instead of every call site recomputing it.

Other consumers of \`__rt_string_to_lm\` (Disk.writeText / Http marshalling) stay on the no-newline helper unchanged.

## Why a separate helper instead of inline newline-write at call site

Architectural cleanliness: \`Console.* == println!\` is a semantic the bridge owns, not a length-patching convention every call site recomputes. The 4 inline ops (store '\\n', bump len by 1) per Console.* call had the visual feel of post-hoc patching. Pulling them into a named bridge helper:

- Centralises the println semantic for future Console.* variants
- Saves bytes when programs print a lot (1 Call per site vs 4 inline ops)
- Keeps the chunked-write loop shape-identical with Disk.* / Http.* (the non-newline consumers)

## Test plan

- [x] Manual 3-way VM / wasm-gc / wasip2 parity (stdout sha256) on \`hello\`, \`calculator\`, \`fibonacci\`, \`quicksort\`, \`rle\`, \`natural\`, \`bigint\` — all bit-identical (was: 4 examples diverged on wasip2 with no newlines between lines).
- [x] \`tests/wasip2_stress.rs::large_console_print\` updated to expect 5001 bytes (5000 payload + trailing '\\n').
- [x] \`cargo test\` clean
- [x] \`cargo test --features wasm,wasip2\` clean
- [x] \`cargo clippy --features wasm,wasip2 -p aver-lang --lib --bin aver --tests -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)