### PR TITLE
vm: guard CALL_KNOWN argc-overflow + fix wildcard `_` param slot allocation

### DIFF
--- a/src/diagnostics/vm_verify.rs
+++ b/src/diagnostics/vm_verify.rs
@@ -698,12 +698,14 @@ pub fn run_verify_for_items_vm_with_mode(
 /// (`fn id(x) -> Int = id(-7)` and friends — byte-havoc dropping the
 /// terminating arm) where Aver's TCO turns infinite recursion into a
 /// goto-loop with no stack growth, so without this cap the VM
-/// dispatch loop never terminates. 10M opcodes is well above what
+/// dispatch loop never terminates. 1M opcodes is 100× above what
 /// real verify cases need (per-case eval is normally <10k steps on
 /// the bench suite) and short enough that an unconverging case bails
-/// in ~50-200ms instead of pinning the host. The cap resets per
-/// `run_named_function`, so cases don't share budget.
-const VERIFY_VM_STEP_LIMIT: u64 = 10_000_000;
+/// in ~5-50ms even on a slow shared CI runner — well under AFL's
+/// default `AFL_HANG_TMOUT=1000ms`, so fuzz-discovered infinite loops
+/// surface as proper `VmError::StepLimit` instead of AFL hangs. The
+/// cap resets per `run_named_function`, so cases don't share budget.
+const VERIFY_VM_STEP_LIMIT: u64 = 1_000_000;
 
 /// Variant for audit / LSP: accept pre-loaded dependency modules
 /// (virtual filesystems) instead of resolving from disk.

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -101,11 +101,14 @@ fn resolve_fn(fd: &mut FnDef, type_info: &TypeInfo) {
     let mut state = ResolverState::new(type_info);
 
     // Params live in the outermost scope and own slots 0..N-1.
+    // `declare_param` (not `declare`) so wildcard `_` params still claim
+    // a slot — callsites push one value per declared param onto the
+    // stack regardless of source name, so `local_count` must match
+    // `params.len()` even when some params are unbound.
     state.scopes.push(HashMap::new());
     for (param_name, ty_str) in &fd.params {
         let ty = crate::types::parse_type_str_strict(ty_str).unwrap_or(Type::Invalid);
-        let slot = state.declare(param_name, ty);
-        state.last_alloc.insert(param_name.clone(), slot);
+        state.declare_param(param_name, ty);
     }
 
     // Walk body — clone, mutate, replace. Same Arc::make_mut cadence as
@@ -190,6 +193,23 @@ impl<'a> ResolverState<'a> {
             scope.insert(name.to_string(), slot);
         }
         self.last_alloc.insert(name.to_string(), slot);
+        slot
+    }
+
+    /// Like `declare`, but always allocates a slot — including for `_`.
+    /// Used for fn parameters: callsites push one value per declared
+    /// param onto the stack regardless of source name, so the callee
+    /// frame must reserve a slot per param to keep stack/locals aligned.
+    /// Wildcard params still skip the scope + `last_alloc` insert (the
+    /// body cannot read them).
+    fn declare_param(&mut self, name: &str, ty: Type) -> u16 {
+        let slot = self.alloc(ty);
+        if name != "_" {
+            if let Some(scope) = self.scopes.last_mut() {
+                scope.insert(name.to_string(), slot);
+            }
+            self.last_alloc.insert(name.to_string(), slot);
+        }
         slot
     }
 
@@ -437,6 +457,42 @@ mod tests {
             }
             other => panic!("unexpected body: {:?}", other),
         }
+    }
+
+    #[test]
+    fn wildcard_param_still_claims_slot() {
+        // AFL nightly fuzz_verify_runner regression: `fn f(_: Int)` used
+        // to leave `local_count == 0` while callsites still pushed 1
+        // arg, so CALL_KNOWN saw `local_count(0) - argc(1)` and the VM
+        // panicked on unsigned-sub overflow. `declare_param` now
+        // always allocates the slot — wildcard name skips the scope
+        // map insert, but the slot space matches `params.len()`.
+        let mut fd = FnDef {
+            name: "ignore".to_string(),
+            line: 1,
+            params: vec![("_".to_string(), "Int".to_string())],
+            return_type: "Int".to_string(),
+            effects: vec![],
+            desc: None,
+            body: Rc::new(FnBody::from_expr(Spanned::bare(Expr::Literal(
+                Literal::Int(42),
+            )))),
+            resolution: None,
+        };
+        resolve_fn(
+            &mut fd,
+            &TypeInfo {
+                variants: HashMap::new(),
+                variant_parents: HashMap::new(),
+                records: HashMap::new(),
+            },
+        );
+        let res = fd.resolution.as_ref().unwrap();
+        assert_eq!(res.local_count, 1, "wildcard param must claim a slot");
+        assert!(
+            !res.local_slots.contains_key("_"),
+            "wildcard param must not bind a readable name"
+        );
     }
 
     #[test]

--- a/src/vm/execute/dispatch.rs
+++ b/src/vm/execute/dispatch.rs
@@ -441,7 +441,14 @@ impl VM {
 
                     let target = self.code.get(target_fn_id);
                     let new_bp = self.stack.len() - argc;
-                    for _ in 0..(target.local_count as usize - argc) {
+                    let target_lc = target.local_count as usize;
+                    if target_lc < argc {
+                        return Err(VmError::runtime(format!(
+                            "CALL_KNOWN to fn_id {} with argc={} exceeds local_count={}",
+                            target_fn_id, argc, target_lc,
+                        )));
+                    }
+                    for _ in 0..(target_lc - argc) {
                         self.stack.push(NanValue::UNIT);
                     }
 
@@ -631,7 +638,14 @@ impl VM {
 
                     let target = self.code.get(target_fn_id);
                     let new_bp = self.stack.len() - argc;
-                    for _ in 0..(target.local_count as usize - argc) {
+                    let target_lc = target.local_count as usize;
+                    if target_lc < argc {
+                        return Err(VmError::runtime(format!(
+                            "CALL_VALUE to fn_id {} with argc={} exceeds local_count={}",
+                            target_fn_id, argc, target_lc,
+                        )));
+                    }
+                    for _ in 0..(target_lc - argc) {
                         self.stack.push(NanValue::UNIT);
                     }
 

--- a/tests/regressions/verify_runner/call_known_argc_exceeds_local_count.av
+++ b/tests/regressions/verify_runner/call_known_argc_exceeds_local_count.av
@@ -1,0 +1,47 @@
+module Types
+    intent =
+        "Seed corpus entry for Aver's two user-type famil es: sum types (variant constructors with payloads) and record types (named fields). Covers pattern matching across all three Shape arms, record construction and field access, and verify laws over a generated `given` list."
+    exposes [Shape, User, greet]
+    effects []
+
+type Shape
+    Circle(Float)
+    ching
+    across
+    allify
+    area
+    law
+    tal
+    exhaustive
+    mareaIsNo
+    three
+    Shape
+    arm
+    Rect(float, Float)
+    Point
+
+record User
+    name: String
+    age: Int
+
+fn area(s: Shape) -> Float
+    ? "Total exhaustive match on Shape — every arm produces a Float."
+    8.3
+
+verify area
+    area((Shape).Circle(3.0)) => 9.0
+    area((Shape).Rect(4.0, 2.5)) => 10.0
+    area((Shape).Point) => 0.0
+
+verify area law areaIsNonNegativeOnPositive
+    given r: Float = [0.1, (1.0 - 7.5), 100.0]
+    when (r > 0.0)
+    (area((Shape).Circle(r)) >= 0.0) => true
+
+fn greet(_: User) -> String
+    ? "Demonstrates record field access via `.name`/`.age`."
+    "fuzz"
+
+verify greet
+    greet(User(name = "Aver", age = 1)) => "hell````````````o, Aver (1)"
+    greet(User(name = "World", age = 42)) => "hello, World (42)"

--- a/tests/regressions/verify_runner/call_known_argc_exceeds_local_count.av
+++ b/tests/regressions/verify_runner/call_known_argc_exceeds_local_count.av
@@ -1,47 +1,8 @@
-module Types
-    intent =
-        "Seed corpus entry for Aver's two user-type famil es: sum types (variant constructors with payloads) and record types (named fields). Covers pattern matching across all three Shape arms, record construction and field access, and verify laws over a generated `given` list."
-    exposes [Shape, User, greet]
+module M
     effects []
 
-type Shape
-    Circle(Float)
-    ching
-    across
-    allify
-    area
-    law
-    tal
-    exhaustive
-    mareaIsNo
-    three
-    Shape
-    arm
-    Rect(float, Float)
-    Point
+fn ignore(_: Int) -> Int
+    42
 
-record User
-    name: String
-    age: Int
-
-fn area(s: Shape) -> Float
-    ? "Total exhaustive match on Shape — every arm produces a Float."
-    8.3
-
-verify area
-    area((Shape).Circle(3.0)) => 9.0
-    area((Shape).Rect(4.0, 2.5)) => 10.0
-    area((Shape).Point) => 0.0
-
-verify area law areaIsNonNegativeOnPositive
-    given r: Float = [0.1, (1.0 - 7.5), 100.0]
-    when (r > 0.0)
-    (area((Shape).Circle(r)) >= 0.0) => true
-
-fn greet(_: User) -> String
-    ? "Demonstrates record field access via `.name`/`.age`."
-    "fuzz"
-
-verify greet
-    greet(User(name = "Aver", age = 1)) => "hell````````````o, Aver (1)"
-    greet(User(name = "World", age = 42)) => "hello, World (42)"
+verify ignore
+    ignore(7) => 42

--- a/tests/regressions/verify_runner/mutual_recursion_hang_no_base_case.av
+++ b/tests/regressions/verify_runner/mutual_recursion_hang_no_base_case.av
@@ -1,0 +1,16 @@
+module RecursiveWithBase
+    intent =
+        "Tail-recursive fn with an explicit base case — the shape AFL nightly mutated into the verify_runner hangs (drop the base, the recursion becomes an infinite TCO loop). Seeds the neighbourhood so mutator byte-havoc + targeted strategies have a starting point that already exercises the step-limit boundary."
+    effects []
+
+fn countDown(n: Int) -> Int
+    ? "Counts down to zero. Real terminating recursion."
+    main()
+
+verify countDown
+    countDown(7) => 0
+    countDown(1) => 0
+    countDown((1 / 0)) => 0
+
+fn main() -> Int
+    countDown(5)


### PR DESCRIPTION
## Summary

AFL nightly `fuzz_verify_runner` (run [26577005872](https://github.com/jasisz/aver/actions/runs/26577005872)) found a deterministic SIGABRT panic in `src/vm/execute/dispatch.rs:444` — unsigned-sub overflow inside `CALL_KNOWN`. Minimal repro is **88 bytes**:

```aver
module M
    effects []

fn ignore(_: Int) -> Int
    42

verify ignore
    ignore(7) => 42
```

**Root cause** (commit 2): `ResolverState::declare("_")` short-circuits with `u16::MAX` and never calls `alloc()`. For wildcard *pattern bindings* (`let _ = ...`, match arms) that's correct — no slot needed. For wildcard *fn parameters* it's wrong — callsites still push one value per source-level param, so `FnResolution.local_count == 0` left CALL_KNOWN's `argc(1) - local_count(0)` underflowing in `usize`.

Fix splits the API: new `declare_param` always allocates a slot (wildcard name still skips scope + `last_alloc` so the body can't read it); `declare` keeps its skip-for-`_` semantics for pattern bindings.

**Defensive guard** (commit 1) lands alongside in `dispatch.rs` CALL_KNOWN (line 444) and CALL_VALUE (634): unsigned-sub panic → `VmError::runtime` with a descriptive message. A panic in the dispatch loop is never the right answer regardless of who emitted bad bytecode — this is layer-in-depth, not a substitute for the resolver fix.

**Step limit tightened** 10M → 1M (`VERIFY_VM_STEP_LIMIT` in `vm_verify.rs`). 100× above what real verify cases need (<10k steps on bench), bails in ~5-50ms on slow CI runners instead of 1-2s, so fuzz-discovered infinite loops surface as proper `VmError::StepLimit` rather than crossing AFL's default 1s `AFL_HANG_TMOUT` and getting counted as nightly hangs (run 26577005872 had 126 such hangs).

## Test plan

- [x] `cargo test --lib resolver::` — new `wildcard_param_still_claims_slot` unit test asserts `local_count == 1` for `fn ignore(_: Int)`; existing 5 resolver tests still pass
- [x] `cargo test --test verify_runner_regressions` — 8 fixtures (6 existing + 2 new from this AFL run: `call_known_argc_exceeds_local_count.av` minimized to 88 B, `mutual_recursion_hang_no_base_case.av`)
- [x] `cargo test --test vm_spec --test eval_spec` — 114 + 224 pass
- [x] `cargo test --test parser_regressions --test typed_hir_stamp_invariant` — pass
- [ ] Nightly Fuzz re-run after merge — expect `verify_runner` crashes 0 + hangs ≪ 126 (the 88B class now surfaces as proper VmError, mutual-recursion class bails 10× faster than AFL hang threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)