### PR TITLE
ci(fuzz): bump nightly timeout 45 → 60 min

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -80,7 +80,11 @@ jobs:
     name: Fuzz nightly (${{ matrix.target }})
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 60 min (was 45) — `fuzz_codegen_wasip2` build+seed+fuzz+pack
+    # totals ~44-45 min on a GitHub-hosted runner, so the previous
+    # cap caught it at the hard limit roughly every other nightly.
+    # Other targets finish in 30-42 min and stay well under.
+    timeout-minutes: 60
     permissions:
       # `gh run download` needs `actions:read` to enumerate previous
       # workflow runs and pull their artifacts.


### PR DESCRIPTION
## Summary

\`fuzz_codegen_wasip2\` build+seed+fuzz+pack totals ~44-45 min on GitHub-hosted runners — the previous 45 min cap caught it at the hard limit roughly every other nightly:

- 2026-05-28 13:16 (success): 44m50s — tight
- 2026-05-28 morning (failure): 45m15s — timed out
- 2026-05-28 16:00 (the run we just dispatched on fresh main, after PR #206 merged): 45m15s — timed out again

Other targets finish in 30-42 min and stay well under the new 60 min ceiling.

## Test plan

- [x] Local sanity (PR #206 already exercised everything)
- [ ] Next nightly schedule shows wasip2 finishing under 60 min (typical ~44m45s); other targets unaffected