### PR TITLE
codegen/rust + release: fix Arc-wrap on dep-module recursive variants

### DIFF
--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -1723,10 +1723,21 @@ pub(super) fn constructor_boxed_positions(name: &str, ctx: &CodegenContext) -> H
     let Some(decl) = find_ctor_owning_type(name, ctx) else {
         return out;
     };
+    // Bare-name suffix of the owning type — for a dep-module type like
+    // `ast.Expr` the field annotation in the .av source is `Expr`, not
+    // `ast.Expr`, so the id-less fallback must compare against the
+    // bare suffix as well.
+    let owning_bare = decl
+        .owning_type_name
+        .as_deref()
+        .map(|n| n.rsplit_once('.').map(|(_, b)| b).unwrap_or(n));
     for (idx, field_ty) in decl.field_types.iter().enumerate() {
         let matches = match (decl.owning_type_id, field_ty.named_id()) {
             (Some(r), Some(p)) => r == p,
-            _ => field_ty.named_name() == decl.owning_type_name.as_deref(),
+            _ => {
+                field_ty.named_name() == decl.owning_type_name.as_deref()
+                    || field_ty.named_name() == owning_bare
+            }
         };
         if matches {
             out.insert(idx);

--- a/tools/release.py
+++ b/tools/release.py
@@ -243,25 +243,34 @@ def regenerate_playground(dry_run: bool) -> None:
         print("  [dry-run] would run: python3 tools/website/rebuild_playground.py")
         return
 
-    # Build release binary for playground
-    run(["cargo", "build", "--release", "--features", "wasm"])
-    run([
-        sys.executable,
-        str(REPO_ROOT / "tools" / "website" / "rebuild_playground.py"),
-        "--aver-bin", str(REPO_ROOT / "target" / "release" / "aver"),
-    ])
+    rebuild = REPO_ROOT / "tools" / "website" / "rebuild_playground.py"
+    aver_bin = REPO_ROOT / "target" / "release" / "aver"
+
+    # `wasm-pack build --features playground --no-default-features` (inside
+    # `rebuild_playground.py:build_compiler`) flips the workspace feature
+    # set, which invalidates cargo's feature cache for `aver-lang` and
+    # rebuilds `target/release/aver` without the `wasm` feature. So we
+    # split into three steps: build the compiler bundle, restore the
+    # wasm-capable aver bin, then run the per-game wasm-gc compile.
+    run([sys.executable, str(rebuild), "--skip-build", "--skip-html"])
+    run(["cargo", "build", "--release", "--bin", "aver", "--features", "wasm"])
+    run([sys.executable, str(rebuild), "--skip-compiler", "--aver-bin", str(aver_bin)])
 
 
 def verify(dry_run: bool) -> None:
-    print("Running verification...")
+    print("Running verification...", flush=True)
     if dry_run:
         print("  [dry-run] would run: cargo fmt --check, clippy, test, bench scenarios, edge compile")
         return
 
+    print("  verify: cargo fmt", flush=True)
     run(["cargo", "fmt"])
     # Skip generated self-host code in clippy (same as CI)
+    print("  verify: cargo clippy --workspace (no aver-lang)", flush=True)
     run(["cargo", "clippy", "--workspace", "--all-targets", "--exclude", "aver-lang", "--", "-D", "warnings"])
+    print("  verify: cargo clippy -p aver-lang --features wasm", flush=True)
     run(["cargo", "clippy", "-p", "aver-lang", "--lib", "--bin", "aver", "--features", "wasm", "--", "-D", "warnings"])
+    print("  verify: cargo test --features wasm", flush=True)
     run(["cargo", "test", "--features", "wasm"])
 
     # Bench smoke. Runs every scenario in `bench/scenarios/` end-to-end on


### PR DESCRIPTION
## Summary

Found while preparing the 0.22.0 release: \`aver compile --target rust\` on \`self_hosted/main.av\` regenerated **179 type errors** in \`src/self_host/aver_generated/\` because \`Expr.ExprPropagate(inner)\` (recursive variant in dep module \`ast\`) lost its \`Arc::new(...)\` wrap.

**Root cause:** \`emit_type_constructor_call\` calls \`constructor_boxed_positions\` to decide which arg positions need \`Arc::new\` wrapping. The id-less fallback compared \`field_ty.named_name()\` (bare \"Expr\" from the .av annotation) against \`decl.owning_type_name\` (fully-qualified \"ast.Expr\" because the type lives in a dep module). Mismatch → empty boxed_positions → no Arc wrap → broken generated Rust.

Fix: also accept a bare-suffix match in the fallback. Id-stamped resolution still wins; bare-name dep-module types get the wrap they need.

**Plus two release.py hardening bullets** uncovered debugging this:
- \`regenerate_playground\` splits into three steps so \`wasm-pack --no-default-features\` doesn't strip wasm support off \`target/release/aver\` between compiler-build and game-wasm-build phases.
- \`verify()\` prints a header per cargo invocation with \`flush=True\` so a failed step doesn't leave you staring at a silent \"Running verification...\".

## Test plan

- [x] Manual: \`target/debug/aver compile self_hosted/main.av --target rust …\` regenerates \`src/self_host/aver_generated/entry/mod.rs:382\` as \`Expr::ExprPropagate(std::sync::Arc::new(shiftFnIdsInExpr(...)))\` and \`cargo test --features wasm\` passes (was 179 errors)
- [x] CI: Check & Test + WASM should pass on this branch