### PR TITLE
bench/runner: load dep modules into pipeline so multi-module scenarios compile

### DIFF
--- a/src/bench/runner.rs
+++ b/src/bench/runner.rs
@@ -74,6 +74,14 @@ fn run_vm(manifest: &Manifest) -> Result<BenchReport, RunError> {
         .map_err(|e| RunError::Read(format!("{}: {}", entry_str, e)))?;
     let mut items: Vec<TopLevel> = parse_source(&source).map_err(RunError::Parse)?;
 
+    // Pre-load dep modules so the entry pipeline's `SymbolTable` knows
+    // about every cross-module fn. Mirrors what `aver run` / `aver
+    // compile` already do — without it the resolver classifies
+    // `Module.fn(...)` callsites as `Passthrough` and the VM compiler
+    // later errors out with "missing VM symbol for exposed function".
+    let dep_modules = load_compile_deps(&items, &module_root)
+        .map_err(|e| RunError::Setup(format!("load deps: {}", e)))?;
+
     let passes_applied = std::cell::RefCell::new(Vec::<String>::new());
     let pipeline_result = crate::ir::pipeline::run(
         &mut items,
@@ -81,6 +89,7 @@ fn run_vm(manifest: &Manifest) -> Result<BenchReport, RunError> {
             typecheck: Some(TypecheckMode::Full {
                 base_dir: Some(&module_root),
             }),
+            dep_modules: &dep_modules,
             on_after_pass: Some(Box::new(|stage: PipelineStage, _| {
                 passes_applied.borrow_mut().push(stage.name().to_string());
             })),
@@ -747,4 +756,120 @@ fn compute_visible_allocs(manifest: &Manifest) -> Option<usize> {
     }
     let policy = crate::ir::NeutralAllocPolicy;
     Some(crate::ir::count_alloc_sites_in_program(&items, &policy))
+}
+
+// ── Dependency loader ──────────────────────────────────────────────────
+//
+// Mirror of `wasm_gc_verify::load_compile_deps` so the bench harness
+// runs the same multi-module setup that `aver run` / `aver compile`
+// already use. Without these dep modules in `PipelineConfig`, the
+// entry's `SymbolTable` never sees cross-module fns and the VM
+// compiler later errors with "missing VM symbol for exposed function".
+// Followup: extract this + the two copies in commands.rs and
+// wasm_gc_verify.rs into one shared util in `crate::source` or
+// `crate::ir`.
+
+fn load_compile_deps(
+    items: &[TopLevel],
+    module_root: &str,
+) -> Result<Vec<crate::codegen::ModuleInfo>, String> {
+    let module = items.iter().find_map(|i| match i {
+        TopLevel::Module(m) => Some(m),
+        _ => None,
+    });
+    let Some(module) = module else {
+        return Ok(vec![]);
+    };
+    let mut result = Vec::new();
+    let mut loaded = std::collections::HashSet::new();
+    for dep_name in &module.depends {
+        load_module_recursive(dep_name, module_root, &mut result, &mut loaded)?;
+    }
+    Ok(result)
+}
+
+fn load_module_recursive(
+    name: &str,
+    module_root: &str,
+    result: &mut Vec<crate::codegen::ModuleInfo>,
+    loaded: &mut std::collections::HashSet<String>,
+) -> Result<(), String> {
+    if !loaded.insert(name.to_string()) {
+        return Ok(());
+    }
+
+    let path = crate::source::find_module_file(name, module_root).ok_or_else(|| {
+        format!(
+            "Cannot find module '{}' in module root '{}'",
+            name, module_root
+        )
+    })?;
+    let source =
+        std::fs::read_to_string(&path).map_err(|e| format!("Read '{}': {}", path.display(), e))?;
+    let mut items = crate::source::parse_source(&source)
+        .map_err(|e| format!("Parse '{}': {}", path.display(), e))?;
+    crate::source::require_module_declaration(&items, path.to_str().unwrap_or(name))?;
+
+    let neutral_policy = crate::ir::NeutralAllocPolicy;
+    let pipeline_result = crate::ir::pipeline::run(
+        &mut items,
+        crate::ir::PipelineConfig {
+            typecheck: Some(crate::ir::TypecheckMode::Full {
+                base_dir: Some(module_root),
+            }),
+            run_interp_lower: false,
+            run_buffer_build: false,
+            alloc_policy: Some(&neutral_policy),
+            ..Default::default()
+        },
+    );
+    if let Some(tc) = pipeline_result.typecheck.as_ref()
+        && !tc.errors.is_empty()
+    {
+        return Err(format!(
+            "Type errors in dependency module '{}':\n{}",
+            name,
+            tc.errors
+                .iter()
+                .map(|e| format!("  {}:{}: {}", e.line, e.col, e.message))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ));
+    }
+
+    let transitive: Vec<String> = items
+        .iter()
+        .find_map(|i| match i {
+            TopLevel::Module(m) => Some(m.depends.clone()),
+            _ => None,
+        })
+        .unwrap_or_default();
+    for dep in &transitive {
+        load_module_recursive(dep, module_root, result, loaded)?;
+    }
+
+    let depends = transitive;
+    let type_defs: Vec<_> = items
+        .iter()
+        .filter_map(|i| match i {
+            TopLevel::TypeDef(td) => Some(td.clone()),
+            _ => None,
+        })
+        .collect();
+    let fn_defs: Vec<_> = items
+        .iter()
+        .filter_map(|i| match i {
+            TopLevel::FnDef(fd) if fd.name != "main" => Some(fd.clone()),
+            _ => None,
+        })
+        .collect();
+
+    result.push(crate::codegen::ModuleInfo {
+        prefix: name.to_string(),
+        depends,
+        type_defs,
+        fn_defs,
+        analysis: pipeline_result.analysis,
+    });
+    Ok(())
 }


### PR DESCRIPTION
## Summary

\`aver bench\` on a manifest whose entry pulls in dep modules (e.g. \`bench/scenarios/fractal_seahorse.toml\` → \`tools/edge/bench.av\` which \`depends [Fractal]\`) failed with:

\`\`\`
bench run (fractal_seahorse): VM compile: Compile error: missing VM symbol for exposed function Fractal.fullView
\`\`\`

**Root cause:** \`bench::runner::run_vm\` called \`pipeline::run\` with \`dep_modules = []\`, so the entry's \`SymbolTable\` never saw cross-module fns. The resolver then classified \`Module.fn(...)\` callsites as \`Passthrough\`, and the VM compiler's \`integrate_module\` step found no interned symbol when wiring exports.

\`aver run\` and \`aver compile\` already mirror this — \`cmd_run_vm\` calls \`load_compile_deps\` before \`pipeline::run\`. The bench harness was missing that step. Fix mirrors the same loader shape (private copy of \`wasm_gc_verify\`'s, same Result error handling).

Followup: extract \`load_compile_deps\` into a shared util in \`crate::source\` or \`crate::ir\` so \`commands.rs\`, \`wasm_gc_verify.rs\`, and \`bench/runner.rs\` all consume one copy.

## Test plan

- [x] \`aver bench bench/scenarios/fractal_seahorse.toml\` — p50 ~1050ms on this Mac (200x120 Mandelbrot full + 220-iter zoom), exit 0
- [x] \`aver bench bench/scenarios/ --json\` — all 13 scenarios run cleanly, exit 0 (was exit 1 stopping after countdown/factorial/fib)
- [ ] CI: Check & Test + WASM pass on this branch