### PR TITLE
source: extract shared load_compile_deps from wasm_gc_verify + bench/runner

### DIFF
--- a/src/bench/runner.rs
+++ b/src/bench/runner.rs
@@ -79,7 +79,7 @@ fn run_vm(manifest: &Manifest) -> Result<BenchReport, RunError> {
     // compile` already do — without it the resolver classifies
     // `Module.fn(...)` callsites as `Passthrough` and the VM compiler
     // later errors out with "missing VM symbol for exposed function".
-    let dep_modules = load_compile_deps(&items, &module_root)
+    let dep_modules = crate::source::load_compile_deps(&items, &module_root)
         .map_err(|e| RunError::Setup(format!("load deps: {}", e)))?;
 
     let passes_applied = std::cell::RefCell::new(Vec::<String>::new());
@@ -758,118 +758,5 @@ fn compute_visible_allocs(manifest: &Manifest) -> Option<usize> {
     Some(crate::ir::count_alloc_sites_in_program(&items, &policy))
 }
 
-// ── Dependency loader ──────────────────────────────────────────────────
-//
-// Mirror of `wasm_gc_verify::load_compile_deps` so the bench harness
-// runs the same multi-module setup that `aver run` / `aver compile`
-// already use. Without these dep modules in `PipelineConfig`, the
-// entry's `SymbolTable` never sees cross-module fns and the VM
-// compiler later errors with "missing VM symbol for exposed function".
-// Followup: extract this + the two copies in commands.rs and
-// wasm_gc_verify.rs into one shared util in `crate::source` or
-// `crate::ir`.
-
-fn load_compile_deps(
-    items: &[TopLevel],
-    module_root: &str,
-) -> Result<Vec<crate::codegen::ModuleInfo>, String> {
-    let module = items.iter().find_map(|i| match i {
-        TopLevel::Module(m) => Some(m),
-        _ => None,
-    });
-    let Some(module) = module else {
-        return Ok(vec![]);
-    };
-    let mut result = Vec::new();
-    let mut loaded = std::collections::HashSet::new();
-    for dep_name in &module.depends {
-        load_module_recursive(dep_name, module_root, &mut result, &mut loaded)?;
-    }
-    Ok(result)
-}
-
-fn load_module_recursive(
-    name: &str,
-    module_root: &str,
-    result: &mut Vec<crate::codegen::ModuleInfo>,
-    loaded: &mut std::collections::HashSet<String>,
-) -> Result<(), String> {
-    if !loaded.insert(name.to_string()) {
-        return Ok(());
-    }
-
-    let path = crate::source::find_module_file(name, module_root).ok_or_else(|| {
-        format!(
-            "Cannot find module '{}' in module root '{}'",
-            name, module_root
-        )
-    })?;
-    let source =
-        std::fs::read_to_string(&path).map_err(|e| format!("Read '{}': {}", path.display(), e))?;
-    let mut items = crate::source::parse_source(&source)
-        .map_err(|e| format!("Parse '{}': {}", path.display(), e))?;
-    crate::source::require_module_declaration(&items, path.to_str().unwrap_or(name))?;
-
-    let neutral_policy = crate::ir::NeutralAllocPolicy;
-    let pipeline_result = crate::ir::pipeline::run(
-        &mut items,
-        crate::ir::PipelineConfig {
-            typecheck: Some(crate::ir::TypecheckMode::Full {
-                base_dir: Some(module_root),
-            }),
-            run_interp_lower: false,
-            run_buffer_build: false,
-            alloc_policy: Some(&neutral_policy),
-            ..Default::default()
-        },
-    );
-    if let Some(tc) = pipeline_result.typecheck.as_ref()
-        && !tc.errors.is_empty()
-    {
-        return Err(format!(
-            "Type errors in dependency module '{}':\n{}",
-            name,
-            tc.errors
-                .iter()
-                .map(|e| format!("  {}:{}: {}", e.line, e.col, e.message))
-                .collect::<Vec<_>>()
-                .join("\n")
-        ));
-    }
-
-    let transitive: Vec<String> = items
-        .iter()
-        .find_map(|i| match i {
-            TopLevel::Module(m) => Some(m.depends.clone()),
-            _ => None,
-        })
-        .unwrap_or_default();
-    for dep in &transitive {
-        load_module_recursive(dep, module_root, result, loaded)?;
-    }
-
-    let depends = transitive;
-    let type_defs: Vec<_> = items
-        .iter()
-        .filter_map(|i| match i {
-            TopLevel::TypeDef(td) => Some(td.clone()),
-            _ => None,
-        })
-        .collect();
-    let fn_defs: Vec<_> = items
-        .iter()
-        .filter_map(|i| match i {
-            TopLevel::FnDef(fd) if fd.name != "main" => Some(fd.clone()),
-            _ => None,
-        })
-        .collect();
-
-    result.push(crate::codegen::ModuleInfo {
-        prefix: name.to_string(),
-        depends,
-        type_defs,
-        fn_defs,
-        analysis: pipeline_result.analysis,
-    });
-    Ok(())
-}
+// Dependency loader is now in `crate::source::load_compile_deps`
+// — see the callsite at the top of `run_vm`.

--- a/src/diagnostics/wasm_gc_verify.rs
+++ b/src/diagnostics/wasm_gc_verify.rs
@@ -166,7 +166,7 @@ pub fn run_verify_for_items_wasm_gc_with_mode(
     // self-contained AST. Mirrors the `try_run_wasm_gc` setup in
     // `src/main/run_wasm_gc.rs`.
     let dep_modules = if let Some(root) = base_dir {
-        load_compile_deps(&items, root)?
+        crate::source::load_compile_deps(&items, root)?
     } else {
         Vec::new()
     };
@@ -612,111 +612,6 @@ fn run_verify_cases_in_wasmtime(
     }
 
     Ok(results)
-}
-
-fn load_compile_deps(
-    items: &[TopLevel],
-    module_root: &str,
-) -> Result<Vec<crate::codegen::ModuleInfo>, String> {
-    let module = items.iter().find_map(|i| match i {
-        TopLevel::Module(m) => Some(m),
-        _ => None,
-    });
-    let Some(module) = module else {
-        return Ok(vec![]);
-    };
-    let mut result = Vec::new();
-    let mut loaded = std::collections::HashSet::new();
-    for dep_name in &module.depends {
-        load_module_recursive(dep_name, module_root, &mut result, &mut loaded)?;
-    }
-    Ok(result)
-}
-
-fn load_module_recursive(
-    name: &str,
-    module_root: &str,
-    result: &mut Vec<crate::codegen::ModuleInfo>,
-    loaded: &mut std::collections::HashSet<String>,
-) -> Result<(), String> {
-    if !loaded.insert(name.to_string()) {
-        return Ok(());
-    }
-
-    let path = crate::source::find_module_file(name, module_root).ok_or_else(|| {
-        format!(
-            "Cannot find module '{}' in module root '{}'",
-            name, module_root
-        )
-    })?;
-    let source =
-        std::fs::read_to_string(&path).map_err(|e| format!("Read '{}': {}", path.display(), e))?;
-    let mut items = crate::source::parse_source(&source)
-        .map_err(|e| format!("Parse '{}': {}", path.display(), e))?;
-    crate::source::require_module_declaration(&items, path.to_str().unwrap_or(name))?;
-
-    let neutral_policy = crate::ir::NeutralAllocPolicy;
-    let pipeline_result = crate::ir::pipeline::run(
-        &mut items,
-        crate::ir::PipelineConfig {
-            typecheck: Some(crate::ir::TypecheckMode::Full {
-                base_dir: Some(module_root),
-            }),
-            run_interp_lower: false,
-            run_buffer_build: false,
-            alloc_policy: Some(&neutral_policy),
-            ..Default::default()
-        },
-    );
-    if let Some(tc) = pipeline_result.typecheck.as_ref()
-        && !tc.errors.is_empty()
-    {
-        return Err(format!(
-            "Type errors in dependency module '{}':\n{}",
-            name,
-            tc.errors
-                .iter()
-                .map(|e| format!("  {}:{}: {}", e.line, e.col, e.message))
-                .collect::<Vec<_>>()
-                .join("\n")
-        ));
-    }
-
-    let transitive: Vec<String> = items
-        .iter()
-        .find_map(|i| match i {
-            TopLevel::Module(m) => Some(m.depends.clone()),
-            _ => None,
-        })
-        .unwrap_or_default();
-    for dep in &transitive {
-        load_module_recursive(dep, module_root, result, loaded)?;
-    }
-
-    let depends = transitive;
-    let type_defs: Vec<_> = items
-        .iter()
-        .filter_map(|i| match i {
-            TopLevel::TypeDef(td) => Some(td.clone()),
-            _ => None,
-        })
-        .collect();
-    let fn_defs: Vec<_> = items
-        .iter()
-        .filter_map(|i| match i {
-            TopLevel::FnDef(fd) if fd.name != "main" => Some(fd.clone()),
-            _ => None,
-        })
-        .collect();
-
-    result.push(crate::codegen::ModuleInfo {
-        prefix: name.to_string(),
-        depends,
-        type_defs,
-        fn_defs,
-        analysis: pipeline_result.analysis,
-    });
-    Ok(())
 }
 
 /// Recursive scan: does `expr` (or any subexpression) reference the

--- a/src/source.rs
+++ b/src/source.rs
@@ -339,8 +339,8 @@ fn load_module_recursive_for_compile(
     })?;
     let source =
         std::fs::read_to_string(&path).map_err(|e| format!("Read '{}': {}", path.display(), e))?;
-    let mut items = parse_source(&source)
-        .map_err(|e| format!("Parse '{}': {}", path.display(), e))?;
+    let mut items =
+        parse_source(&source).map_err(|e| format!("Parse '{}': {}", path.display(), e))?;
     require_module_declaration(&items, path.to_str().unwrap_or(name))?;
 
     let neutral_policy = crate::ir::NeutralAllocPolicy;

--- a/src/source.rs
+++ b/src/source.rs
@@ -289,6 +289,123 @@ fn load_recursive(
     Ok(())
 }
 
+/// Load every dep module declared by `items`'s `Module.depends`, plus
+/// every transitive dep, into `codegen::ModuleInfo` records ready to
+/// hand to `PipelineConfig.dep_modules`.
+///
+/// Each dep goes through the same canonical pipeline as the entry —
+/// `pipeline::run` with `TypecheckMode::Full { base_dir: module_root }`,
+/// `run_interp_lower: false`, `run_buffer_build: false`, and the
+/// neutral alloc policy. Type errors in any dep surface as `Err`.
+///
+/// Callers that need the legacy `commands.rs` shape (run_interp_lower /
+/// run_buffer_build / self_host_mode flags) still own their local copy;
+/// every other call site — `vm_verify`, `wasm_gc_verify`, `bench/runner`,
+/// the research test — should go through here so the dep-loading
+/// contract stays in one place.
+pub fn load_compile_deps(
+    items: &[TopLevel],
+    module_root: &str,
+) -> Result<Vec<crate::codegen::ModuleInfo>, String> {
+    let module = items.iter().find_map(|i| match i {
+        TopLevel::Module(m) => Some(m),
+        _ => None,
+    });
+    let Some(module) = module else {
+        return Ok(vec![]);
+    };
+    let mut result = Vec::new();
+    let mut loaded = HashSet::new();
+    for dep_name in &module.depends {
+        load_module_recursive_for_compile(dep_name, module_root, &mut result, &mut loaded)?;
+    }
+    Ok(result)
+}
+
+fn load_module_recursive_for_compile(
+    name: &str,
+    module_root: &str,
+    result: &mut Vec<crate::codegen::ModuleInfo>,
+    loaded: &mut HashSet<String>,
+) -> Result<(), String> {
+    if !loaded.insert(name.to_string()) {
+        return Ok(());
+    }
+    let path = find_module_file(name, module_root).ok_or_else(|| {
+        format!(
+            "Cannot find module '{}' in module root '{}'",
+            name, module_root
+        )
+    })?;
+    let source =
+        std::fs::read_to_string(&path).map_err(|e| format!("Read '{}': {}", path.display(), e))?;
+    let mut items = parse_source(&source)
+        .map_err(|e| format!("Parse '{}': {}", path.display(), e))?;
+    require_module_declaration(&items, path.to_str().unwrap_or(name))?;
+
+    let neutral_policy = crate::ir::NeutralAllocPolicy;
+    let pipeline_result = crate::ir::pipeline::run(
+        &mut items,
+        crate::ir::PipelineConfig {
+            typecheck: Some(crate::ir::TypecheckMode::Full {
+                base_dir: Some(module_root),
+            }),
+            run_interp_lower: false,
+            run_buffer_build: false,
+            alloc_policy: Some(&neutral_policy),
+            ..Default::default()
+        },
+    );
+    if let Some(tc) = pipeline_result.typecheck.as_ref()
+        && !tc.errors.is_empty()
+    {
+        return Err(format!(
+            "Type errors in dependency module '{}':\n{}",
+            name,
+            tc.errors
+                .iter()
+                .map(|e| format!("  {}:{}: {}", e.line, e.col, e.message))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ));
+    }
+
+    let transitive: Vec<String> = items
+        .iter()
+        .find_map(|i| match i {
+            TopLevel::Module(m) => Some(m.depends.clone()),
+            _ => None,
+        })
+        .unwrap_or_default();
+    for dep in &transitive {
+        load_module_recursive_for_compile(dep, module_root, result, loaded)?;
+    }
+
+    let depends = transitive;
+    let type_defs: Vec<_> = items
+        .iter()
+        .filter_map(|i| match i {
+            TopLevel::TypeDef(td) => Some(td.clone()),
+            _ => None,
+        })
+        .collect();
+    let fn_defs: Vec<_> = items
+        .iter()
+        .filter_map(|i| match i {
+            TopLevel::FnDef(fd) if fd.name != "main" => Some(fd.clone()),
+            _ => None,
+        })
+        .collect();
+    result.push(crate::codegen::ModuleInfo {
+        prefix: name.to_string(),
+        depends,
+        type_defs,
+        fn_defs,
+        analysis: pipeline_result.analysis,
+    });
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{parse_source, require_module_declaration};


### PR DESCRIPTION
## Summary

Two identical ~100-line copies of the same dep-module loader lived in \`diagnostics/wasm_gc_verify.rs\` and \`bench/runner.rs\`, both already labeled \"mirror of …; followup: extract shared util\". This lifts the shape into \`crate::source::load_compile_deps\` (public) + \`load_module_recursive_for_compile\` (private helper).

Net: **-222 / +117**. Behavior unchanged.

## Why now

The #213 fix (\`aver verify\` multi-module \"missing VM symbol\") needs to add a *third* copy of the same loader to \`vm_verify.rs\`. Going from 2→3 copies is the wrong direction; consolidating to 1 first means the #213 PR only adds the actual fix, no duplicated infrastructure.

## What's NOT in scope

\`commands.rs::load_compile_deps\` keeps its own copy:

- Different signature: 5 args including \`run_interp_lower\` / \`run_buffer_build\` / \`self_host_mode\` flags that are meaningful for \`aver run\` and \`aver compile\` paths.
- Lives in the binary crate, not the lib — bench/runner and wasm_gc_verify are lib-side; vm_verify will be too.

Migrating commands.rs would mean either widening the shared util's API to carry those flags (uglier signature for every caller that doesn't need them) or breaking the commands.rs path's contract. Out of scope for 0.22.1.

## Test plan

- [x] \`cargo test --release\` — 37 suites, 0 failures
- [x] \`aver verify examples/refinement/natural_app.av --module-root examples --wasm-gc\` — still passes 31/31 cases on the multi-module example
- [ ] CI: Check & Test + WASM pass on this branch

Foundation for #213 (next PR on the 0.22.1 stack).