### PR TITLE
vm_verify: load dep modules so multi-module verify works (closes #213)

### DIFF
--- a/src/diagnostics/vm_verify.rs
+++ b/src/diagnostics/vm_verify.rs
@@ -641,6 +641,19 @@ pub fn run_verify_for_items_vm_with_mode(
         inject_hostile_effect_stubs_for_blocks(&mut items, &preview_blocks);
     }
 
+    // Load dep modules so `SymbolTable::build` below sees cross-module
+    // fns. Without this the resolver classifies `Module.fn(...)`
+    // callsites as `Passthrough`, the VM compiler later errors with
+    // "missing VM symbol for exposed function", and any multi-module
+    // verify fails — exactly the bug #213 surfaced on the 0.22 release.
+    // Mirrors what `aver run` / `aver compile` / `bench/runner` /
+    // `wasm_gc_verify` all do.
+    let dep_modules = if let Some(root) = base_dir {
+        crate::source::load_compile_deps(&items, root)?
+    } else {
+        Vec::new()
+    };
+
     let tc_result =
         crate::ir::pipeline::typecheck(&items, &crate::ir::TypecheckMode::Full { base_dir });
     if !tc_result.errors.is_empty() {
@@ -669,7 +682,7 @@ pub fn run_verify_for_items_vm_with_mode(
     // "assume allocates" branch (no per-fn `no_alloc` promotion).
     // Build the resolved-identity table + lift the items to resolved
     // HIR ourselves so the VM compiler stays on the Phase E contract.
-    let symbol_table = crate::ir::SymbolTable::build(&items, &[]);
+    let symbol_table = crate::ir::SymbolTable::build(&items, &dep_modules);
     let resolved_items = crate::ir::hir::resolve_program(&symbol_table, &items);
     let (code, globals) = vm::compile_program_with_modules(
         &resolved_items,
@@ -760,7 +773,14 @@ pub fn run_verify_for_items_vm_with_loaded_and_mode(
 
     let mut arena = Arena::new();
     vm::register_service_types(&mut arena);
-    let symbol_table = crate::ir::SymbolTable::build(&items, &[]);
+    // Mirror of the disk-loader path's dep_modules wiring (#213 fix):
+    // turn the pre-loaded virtual-fs modules into `ModuleInfo` records
+    // so `SymbolTable::build` sees every cross-module fn. Without this
+    // the playground's multi-file programs would hit the same
+    // "missing VM symbol for exposed function" path that the disk path
+    // hit before the fix.
+    let dep_modules = crate::source::loaded_to_module_info(&loaded);
+    let symbol_table = crate::ir::SymbolTable::build(&items, &dep_modules);
     let resolved_items = crate::ir::hir::resolve_program(&symbol_table, &items);
     let (code, globals) = vm::compile_program_with_loaded_modules(
         &resolved_items,

--- a/src/source.rs
+++ b/src/source.rs
@@ -289,6 +289,51 @@ fn load_recursive(
     Ok(())
 }
 
+/// Convert pre-loaded modules (parsed virtual-fs items from the
+/// playground / LSP / audit paths) into `ModuleInfo` records suitable
+/// for `PipelineConfig.dep_modules` and `SymbolTable::build`.
+///
+/// Mirrors what [`load_compile_deps`] produces but skips disk IO and
+/// per-dep pipeline runs — the entry-level pipeline (typecheck +
+/// resolve) handles cross-module typing through `TypecheckMode::
+/// WithLoaded`. `analysis: None` here means the VM compiler falls
+/// through to the conservative "assume allocates" branch (no per-fn
+/// `no_alloc` promotion), which is the same trade-off the verify path
+/// already accepts.
+pub fn loaded_to_module_info(loaded: &[LoadedModule]) -> Vec<crate::codegen::ModuleInfo> {
+    loaded
+        .iter()
+        .map(|m| {
+            let depends = visibility::module_decl(&m.items)
+                .map(|md| md.depends.clone())
+                .unwrap_or_default();
+            let type_defs: Vec<_> = m
+                .items
+                .iter()
+                .filter_map(|i| match i {
+                    TopLevel::TypeDef(td) => Some(td.clone()),
+                    _ => None,
+                })
+                .collect();
+            let fn_defs: Vec<_> = m
+                .items
+                .iter()
+                .filter_map(|i| match i {
+                    TopLevel::FnDef(fd) if fd.name != "main" => Some(fd.clone()),
+                    _ => None,
+                })
+                .collect();
+            crate::codegen::ModuleInfo {
+                prefix: m.dep_name.clone(),
+                depends,
+                type_defs,
+                fn_defs,
+                analysis: None,
+            }
+        })
+        .collect()
+}
+
 /// Load every dep module declared by `items`'s `Module.depends`, plus
 /// every transitive dep, into `codegen::ModuleInfo` records ready to
 /// hand to `PipelineConfig.dep_modules`.

--- a/tests/regression_vm_verify_multi_module.rs
+++ b/tests/regression_vm_verify_multi_module.rs
@@ -1,0 +1,41 @@
+//! Regression for #213: `aver verify` on a multi-module program used
+//! to fail with "missing VM symbol for exposed function
+//! Refinement.Natural.Natural.fromInt" because `vm_verify` built the
+//! entry's `SymbolTable` without dep modules — the resolver then
+//! classified cross-module callsites as `Passthrough` and the VM
+//! compiler had no interned symbol when wiring exports.
+//!
+//! Hits the same code path as `aver verify <file>` from the CLI,
+//! against the canonical refinement-via-opaque flagship example.
+
+use aver::diagnostics::vm_verify::run_verify_for_items_vm;
+use aver::lexer::Lexer;
+use aver::parser::Parser;
+
+#[test]
+fn vm_verify_multi_module_natural_app_passes_31_cases() {
+    let path = "examples/refinement/natural_app.av";
+    let source = std::fs::read_to_string(path).expect("read natural_app.av");
+
+    let mut lexer = Lexer::new(&source);
+    let tokens = lexer.tokenize().expect("tokenize");
+    let mut parser = Parser::new(tokens);
+    let items = parser.parse().expect("parse");
+
+    // No pre-pipeline run — vm_verify runs tco/typecheck/resolve on
+    // raw items itself (mirrors `aver verify` CLI path), and pre-
+    // running buffer_build / interp_lower here would emit intrinsics
+    // the verify pipeline then can't resolve.
+    let results =
+        run_verify_for_items_vm(items, None, Some("examples"), path).expect("verify succeeds");
+
+    // natural_app.av has three verify blocks: safeSum (4 cases),
+    // safeSum law commutative (25 cases), render (2 cases) = 31 total.
+    let total_passed: usize = results.iter().map(|r| r.passed).sum();
+    let total_failed: usize = results.iter().map(|r| r.failed).sum();
+    assert!(
+        total_passed >= 31,
+        "expected at least 31 passing cases, got {total_passed}",
+    );
+    assert_eq!(total_failed, 0, "no cases should fail");
+}


### PR DESCRIPTION
## Summary

Fixes #213 — \`aver verify\` on any multi-module program (entry that declares \`depends [Foo.Bar]\`) failed with \"missing VM symbol for exposed function Foo.Bar.someFn\" because \`vm_verify\` built the entry's \`SymbolTable\` from raw items, without dep modules. The resolver then classified cross-module callsites as \`Passthrough\`, the VM compiler's \`integrate_module\` step found no interned symbol when wiring exports, and the verify path errored out.

This bit every multi-module example under \`examples/refinement/\` and \`examples/apps/notepad/\` — including the refinement-via-opaque smart-constructor flow that shipped as 0.22 \"Lift\"'s headline.

## Both vm_verify siblings fixed

- **\`run_verify_for_items_vm_with_mode\`** — disk-loader path (\`aver verify <file>\` from the CLI). Pulls dep modules via the shared \`crate::source::load_compile_deps\` from #214 and feeds them to \`SymbolTable::build\`.
- **\`run_verify_for_items_vm_with_loaded_and_mode\`** — pre-loaded path (playground / LSP / audit). New \`crate::source::loaded_to_module_info\` converts \`Vec<LoadedModule>\` to \`Vec<ModuleInfo>\` and feeds the same symbol-table builder. \`analysis: None\` here means the VM compiler falls through to the conservative \"assume allocates\" branch — same trade-off the verify path already accepts on this path.

## Regression coverage

\`tests/regression_vm_verify_multi_module.rs\` hits the disk-loader path against the canonical \`examples/refinement/natural_app.av\` flagship and asserts 31/31 passing cases (3 verify blocks: \`safeSum\` 4 cases + \`safeSum law commutative\` 25 cases + \`render\` 2 cases). Failing the fix would surface as the \"missing VM symbol\" error string verbatim.

## Test plan

- [x] \`cargo test --release\` — 39 suites, 0 failures (no playground / LSP regression)
- [x] \`aver verify examples/refinement/natural_app.av --module-root examples\` — passes 31/31 (was \"missing VM symbol\" on 0.22.0)
- [x] \`aver verify examples/refinement/natural_app.av --module-root examples --wasm-gc\` — still passes 31/31 (was already green; this PR doesn't touch the wasm-gc path)
- [ ] CI: Check & Test + WASM pass on this branch

## 0.22.1 stack

PR 2/3 of the 0.22.1 patch release stack:

1. #214 (merged) — extract shared \`load_compile_deps\` so we stop maintaining 3 copies
2. this PR — the actual #213 fix, both siblings, with regression test
3. (next) fuzz multi-module input parser in \`fuzz_targets/common.rs\` so every fuzz target gets multi-module coverage — would have caught #208 and #213 before release

After all three merge, release 0.22.1.