### PR TITLE
0.22.1 changelog + ? propagation audit on three examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
+## 0.22.1 — 2026-05-29
+
+### Hardening
+
+- **`aver verify` works on multi-module programs.** 0.22.0 shipped with a regression: running `aver verify <entry>` on any program that declared `depends [...]` failed with `"missing VM symbol for exposed function Foo.Bar.baz"`. Every multi-module example under `examples/refinement/` (including the refinement-via-opaque flagship that Lift introduced), `examples/apps/notepad/`, and `projects/payment_ops/` hit it; `aver run`, `aver compile`, and `aver verify --wasm-gc` were unaffected. The VM verify path now loads dep modules the same way the other paths already do (both the disk-loader CLI shape and the pre-loaded playground/LSP shape).
+
 ## 0.22.0 "Lift" — 2026-05-28
 
 > _Aver source stays ordinary. The proof export lifts it to the backend's native mathematical shape — refinements become subtypes, mutual recursion becomes a structural block, every verify-law passes through one classifier, and Dafny closes more obligations on its own._

--- a/examples/modules/pricing_app.av
+++ b/examples/modules/pricing_app.av
@@ -6,10 +6,9 @@ module PricingApp
     effects [Console]
 
 fn applyDiscount(price: Float, rawDiscount: Float) -> Result<Float, String>
-    ? "Constructs discount, applies it to price."
-    match Modules.Pricing.Discount.mkDiscount(rawDiscount)
-        Result.Err(e) -> Result.Err(e)
-        Result.Ok(d) -> Result.Ok(price - price * (Modules.Pricing.Discount.percent(d) / 100.0))
+    ? "Constructs discount, applies it to price. Uses `?` to short-circuit on construction failure."
+    d = Modules.Pricing.Discount.mkDiscount(rawDiscount)?
+    Result.Ok(price - price * (Modules.Pricing.Discount.percent(d) / 100.0))
 
 verify applyDiscount
     applyDiscount(100.0, 50.0)  => Result.Ok(50.0)

--- a/examples/refinement/natural_app.av
+++ b/examples/refinement/natural_app.av
@@ -10,14 +10,11 @@ module NaturalApp
     effects [Console.print]
 
 fn safeSum(a: Int, b: Int) -> Result<Int, String>
-    ? "Validate both inputs through the smart constructor, add the two Naturals, unwrap to Int. Either side being negative — or the sum overflowing i64 — surfaces as Err."
-    match Refinement.Natural.Natural.fromInt(a)
-        Result.Err(msg) -> Result.Err(msg)
-        Result.Ok(na) -> match Refinement.Natural.Natural.fromInt(b)
-            Result.Err(msg) -> Result.Err(msg)
-            Result.Ok(nb) -> match Refinement.Natural.Natural.add(na, nb)
-                Result.Err(msg) -> Result.Err(msg)
-                Result.Ok(sum) -> Result.Ok(Refinement.Natural.Natural.toInt(sum))
+    ? "Validate both inputs through the smart constructor, add the two Naturals, unwrap to Int. Either side being negative — or the sum overflowing i64 — surfaces as Err. The `?` operator propagates Err short-circuit at each step so the happy path stays linear."
+    na = Refinement.Natural.Natural.fromInt(a)?
+    nb = Refinement.Natural.Natural.fromInt(b)?
+    sum = Refinement.Natural.Natural.add(na, nb)?
+    Result.Ok(Refinement.Natural.Natural.toInt(sum))
 
 verify safeSum
     safeSum(3, 4)   => Result.Ok(7)

--- a/examples/services/http_demo.av
+++ b/examples/services/http_demo.av
@@ -22,12 +22,10 @@ fn fetch(url: String) -> Result<HttpResponse, String>
     Http.get(url)
 
 fn checkStatus(url: String) -> Result<Int, String>
-    ? "Returns Ok(status code as Int) or Err(transport error)."
+    ? "Returns Ok(status code as Int) or Err(transport error). `?` propagates the Err shape from the underlying Http.get."
     ! [Http.get]
-    result = Http.get(url)
-    match result
-        Result.Ok(resp) -> Result.Ok(resp.status)
-        Result.Err(msg) -> Result.Err(msg)
+    resp = Http.get(url)?
+    Result.Ok(resp.status)
 
 fn post(url: String, payload: String, token: String) -> Result<HttpResponse, String>
     ? "POST JSON with a Bearer token. Builds the Authorization header explicitly."


### PR DESCRIPTION
## Summary

Two scoped changes for the 0.22.1 stack tail:

1. **CHANGELOG entry for 0.22.1** — single user-facing bullet documenting the multi-module \`aver verify\` regression that the previous three PRs (#214 / #215 / #216) closed. Refactor / fuzz infra / examples cleanup don't earn their own bullets in patch notes.

2. **\`?\` propagation audit on three examples** (partial close on #210). Swap manual \`match Result.Ok / Err -> Err\` chains for \`?\` in three Result-returning fns:
   - \`examples/refinement/natural_app.av:safeSum\` — the textbook three-arm nested match → \`na = fromInt(a)?\` / \`nb = fromInt(b)?\` / \`sum = add(na, nb)?\` / \`Ok(toInt(sum))\`. Picked up by the existing \`tests/regression_vm_verify_multi_module.rs\` (still 31/31 cases).
   - \`examples/modules/pricing_app.av:applyDiscount\` — single dep-module Result chained into an Ok-arm computation.
   - \`examples/services/http_demo.av:checkStatus\` — \`Http.get(url)?\` then \`Ok(resp.status)\`.

Picked because each was already idiomatic-\`?\` shape with just the operator missing. Other manual matches in the corpus either transform the error message, branch on more than two arms, or work with custom non-Result error types — those aren't idiomatic \`?\` candidates and stay as-is.

#210 stays open for the wider audit (worked example file dedicated to \`?\` chaining, plus an LLM-facing snippet in \`SKILL.md\`).

## Test plan

- [x] \`aver run examples/refinement/natural_app.av --module-root examples\` — output \`sum = 7\`
- [x] \`aver check examples/modules/pricing_app.av --module-root examples\` — clean (the preexisting \`missing-verify\` warning on \`show\` is not from this PR)
- [x] \`aver check examples/services/http_demo.av\` — clean
- [ ] CI: Check & Test + WASM pass on this branch

## 0.22.1 stack

This is the tail of the stack — once merged, sync main and run \`tools/release.py 0.22.1\`. Stack so far:

1. #214 (merged) — extract shared \`load_compile_deps\`
2. #215 (merged) — fix #213 verify multi-module
3. #216 (merged) — fuzz multi-module input dispatcher
4. **this PR** — CHANGELOG + examples cleanup