### PR TITLE
fuzz: deterministic multimodule tempdir so AFL stability stays high

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -135,7 +135,6 @@ version = "0.0.0"
 dependencies = [
  "afl",
  "aver-lang",
- "tempfile",
  "wasmparser 0.248.0",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -30,10 +30,6 @@ aver-lang = { path = "..", default-features = false, features = ["runtime", "was
 # the same minor as `aver-lang`'s optional dep so the workspace
 # resolver picks a single version.
 wasmparser = "0.248"
-# RAII tempdir for the multi-module fuzz harness — every target's
-# `try_multimodule_input` writes a synthetic file tree under here
-# and the tempdir cleans itself up when the fuzz callback returns.
-tempfile = "3"
 
 [[bin]]
 name = "fuzz_parse_bytes"

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -275,19 +275,21 @@ pub fn counters() -> &'static Counters {
 //
 // Anything malformed → `None`, target falls back to single-file.
 // Names are lowercased and rendered as `<name>.av` files under a
-// fresh tempdir; entry's directory becomes the `module_root`.
+// deterministically-named directory keyed on `hash(data)`. Same input
+// → same directory path → AFL's coverage map stays stable. A fresh
+// random tempdir would mean every exec sees different paths inside
+// `LoadedModule.path` / Aver error messages, which AFL reads as
+// path-noise jitter and ends up tagging the target as
+// non-deterministic — slows convergence and dilutes the crash signal.
 
 const MULTIMODULE_MAGIC: &[u8; 4] = &[0xA7, 0xE2, 0x40, 0x01];
 
 pub struct MultiModuleSetup {
-    /// RAII tempdir — clean on drop, lives at least as long as the
-    /// returned struct.
-    pub tmp_dir: tempfile::TempDir,
-    /// Path to the entry .av file inside `tmp_dir`.
+    /// Path to the entry .av file inside the deterministic dir.
     pub entry_path: std::path::PathBuf,
     /// Module root for `--module-root` / `find_module_file` lookups
     /// — same directory as the entry, since all synthetic files
-    /// land flat at the tmpdir root.
+    /// land flat at the dir root.
     pub module_root: std::path::PathBuf,
     /// Raw entry source — handed to targets that only need the
     /// bytes (e.g. `parse_bytes`, `replay_codec`).
@@ -308,7 +310,21 @@ pub fn try_multimodule_input(data: &[u8]) -> Option<MultiModuleSetup> {
         return None;
     }
 
-    let tmp_dir = tempfile::tempdir().ok()?;
+    // Deterministic directory name keyed on `hash(data)` — see the
+    // module-level comment above for why this matters for AFL
+    // stability. We don't drop the directory at the end of the fn:
+    // the next exec with this input will reuse the same dir
+    // (idempotent overwrite per file), and the OS reclaims `/tmp`
+    // on reboot. Persistent-mode AFL workers benefit from the
+    // warm filesystem cache too.
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    data.hash(&mut hasher);
+    let dir_hash = hasher.finish();
+    let dir = std::env::temp_dir().join(format!("aver-fuzz-mm-{dir_hash:016x}"));
+    std::fs::create_dir_all(&dir).ok()?;
+
     let mut file_paths: Vec<std::path::PathBuf> = Vec::with_capacity(n_files as usize);
 
     for _ in 0..n_files {
@@ -341,7 +357,7 @@ pub fn try_multimodule_input(data: &[u8]) -> Option<MultiModuleSetup> {
         let body = std::str::from_utf8(&data[pos..pos + body_len]).ok()?;
         pos += body_len;
 
-        let file_path = tmp_dir.path().join(format!("{name}.av"));
+        let file_path = dir.join(format!("{name}.av"));
         std::fs::write(&file_path, body).ok()?;
         file_paths.push(file_path);
     }
@@ -354,13 +370,8 @@ pub fn try_multimodule_input(data: &[u8]) -> Option<MultiModuleSetup> {
     let entry_source = std::fs::read_to_string(&entry_path).ok()?;
 
     Some(MultiModuleSetup {
-        tmp_dir,
         entry_path,
-        module_root: std::path::PathBuf::from("."), // overridden below
+        module_root: dir,
         entry_source,
-    })
-    .map(|mut setup| {
-        setup.module_root = setup.tmp_dir.path().to_path_buf();
-        setup
     })
 }


### PR DESCRIPTION
## Summary

#216 introduced a multi-module input dispatcher in every fuzz target. The implementation used \`tempfile::tempdir()\` to write the synthetic file tree, which gave every exec a fresh random path under \`/tmp/.tmpXxxXxx/\`. That path landed in:

- \`LoadedModule.path\` (interned as String)
- Aver compile error messages (\`Cannot find module 'X' in module root '/tmp/.tmpXxxXxx'\`)
- Stamped \`Spanned\` line info / source-file labels in the resolver

So identical input bytes gave **slightly different coverage maps** every exec — AFL flagged the target as non-deterministic, dropped stability, and started spending budget on confirmation passes (\"is this real progress or path noise?\") instead of exploration. Slows convergence and dilutes the crash signal — exactly the failure mode this stack was trying to avoid.

## Fix

Hash-keyed directory: \`aver-fuzz-mm-{u64 hash of data, hex}\` under \`std::env::temp_dir()\`. Same bytes → same dir. Files overwrite idempotently on repeat exec, the OS reclaims \`/tmp\` on reboot, persistent-mode AFL workers benefit from warm filesystem cache. \`tempfile\` crate dependency drops.

## Why this matters for 0.22.1

Without this fix, the multi-module fuzz coverage from #216 ships at \"AFL knows the bytes flicker, so it slow-pedals\" instead of \"AFL pins the bytes, finds divergences fast.\" Net is on the wire either way, but the fix lets it actually do its job.

## Test plan

- [x] \`cargo check --bins\` from \`fuzz/\` — all 8 targets compile clean
- [ ] CI: Check & Test + WASM pass on this branch
- [ ] Post-merge: cancel the in-flight nightly fuzz run, dispatch a fresh one on the patched main. AFL stability metric (visible in \`fuzzer_stats\`) should hold close to 100% on multi-module inputs.

## 0.22.1 stack

Tail fix-up for #216. After merge → cancel current run 26624203984, redispatch fuzz on main, watch the stability number.