### PR TITLE
tech debt: playground rebuild structural fix + LoadedModule analysis

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -293,14 +293,16 @@ fn load_recursive(
 /// playground / LSP / audit paths) into `ModuleInfo` records suitable
 /// for `PipelineConfig.dep_modules` and `SymbolTable::build`.
 ///
-/// Mirrors what [`load_compile_deps`] produces but skips disk IO and
-/// per-dep pipeline runs — the entry-level pipeline (typecheck +
-/// resolve) handles cross-module typing through `TypecheckMode::
-/// WithLoaded`. `analysis: None` here means the VM compiler falls
-/// through to the conservative "assume allocates" branch (no per-fn
-/// `no_alloc` promotion), which is the same trade-off the verify path
-/// already accepts.
+/// Each dep goes through `pipeline::run` with
+/// `TypecheckMode::WithLoaded(&siblings)` so the resulting
+/// `AnalysisResult` populates the same `no_alloc` / recursion facts
+/// the disk-loader path produces. The entry-level pipeline still
+/// handles cross-module typing separately; per-dep analysis here
+/// just unlocks the VM compiler's `no_alloc` fast paths on dep
+/// functions instead of forcing the conservative "assume allocates"
+/// branch.
 pub fn loaded_to_module_info(loaded: &[LoadedModule]) -> Vec<crate::codegen::ModuleInfo> {
+    let neutral_policy = crate::ir::NeutralAllocPolicy;
     loaded
         .iter()
         .map(|m| {
@@ -323,12 +325,30 @@ pub fn loaded_to_module_info(loaded: &[LoadedModule]) -> Vec<crate::codegen::Mod
                     _ => None,
                 })
                 .collect();
+            // Run the canonical pipeline on a clone of this dep's
+            // items, type-checking against the other loaded modules
+            // as the source of cross-module references. We feed the
+            // analysis result alone back into ModuleInfo; the
+            // pipeline-mutated items themselves stay local — the
+            // entry's pipeline run sees the original `m.items` shape
+            // via WithLoaded just like the typechecker did pre-fix.
+            let mut dep_items = m.items.clone();
+            let pipeline_result = crate::ir::pipeline::run(
+                &mut dep_items,
+                crate::ir::PipelineConfig {
+                    typecheck: Some(crate::ir::TypecheckMode::WithLoaded(loaded)),
+                    run_interp_lower: false,
+                    run_buffer_build: false,
+                    alloc_policy: Some(&neutral_policy),
+                    ..Default::default()
+                },
+            );
             crate::codegen::ModuleInfo {
                 prefix: m.dep_name.clone(),
                 depends,
                 type_defs,
                 fn_defs,
-                analysis: None,
+                analysis: pipeline_result.analysis,
             }
         })
         .collect()

--- a/tools/release.py
+++ b/tools/release.py
@@ -243,18 +243,17 @@ def regenerate_playground(dry_run: bool) -> None:
         print("  [dry-run] would run: python3 tools/website/rebuild_playground.py")
         return
 
-    rebuild = REPO_ROOT / "tools" / "website" / "rebuild_playground.py"
-    aver_bin = REPO_ROOT / "target" / "release" / "aver"
-
-    # `wasm-pack build --features playground --no-default-features` (inside
-    # `rebuild_playground.py:build_compiler`) flips the workspace feature
-    # set, which invalidates cargo's feature cache for `aver-lang` and
-    # rebuilds `target/release/aver` without the `wasm` feature. So we
-    # split into three steps: build the compiler bundle, restore the
-    # wasm-capable aver bin, then run the per-game wasm-gc compile.
-    run([sys.executable, str(rebuild), "--skip-build", "--skip-html"])
+    # `rebuild_playground.py` restores the wasm-capable aver bin
+    # itself after `wasm-pack` invalidates cargo's feature cache
+    # (the script's `main` re-runs `cargo build --release --bin aver
+    // --features wasm` between `build_compiler` and `build_wasm`).
+    # Pre-build once so the wasm-pack invocation has a warm cache
+    # to invalidate — saves a few minutes on cold runs.
     run(["cargo", "build", "--release", "--bin", "aver", "--features", "wasm"])
-    run([sys.executable, str(rebuild), "--skip-compiler", "--aver-bin", str(aver_bin)])
+    run([
+        sys.executable,
+        str(REPO_ROOT / "tools" / "website" / "rebuild_playground.py"),
+    ])
 
 
 def verify(dry_run: bool) -> None:

--- a/tools/website/rebuild_playground.py
+++ b/tools/website/rebuild_playground.py
@@ -286,6 +286,21 @@ def main() -> int:
 
     if not args.skip_compiler:
         build_compiler()
+        # `wasm-pack build --features playground --no-default-features`
+        # (inside `build_compiler`) flips the workspace feature set,
+        # which invalidates cargo's feature cache for `aver-lang` and
+        # rebuilds `target/release/aver` without the `wasm` feature.
+        # If the next step is `build_wasm`, restore the wasm-capable
+        # aver bin first — otherwise `aver compile --target wasm-gc`
+        # would error out with "WASM target requires --features wasm".
+        if not args.skip_build:
+            print("Restoring aver bin with --features wasm after wasm-pack ...")
+            result = subprocess.run(
+                ["cargo", "build", "--release", "--bin", "aver", "--features", "wasm"],
+                cwd=REPO_ROOT,
+            )
+            if result.returncode != 0:
+                raise SystemExit("cargo build --features wasm failed")
 
     if not args.skip_source_sync:
         sync_sources()


### PR DESCRIPTION
## Summary

Two small follow-ups that previous PRs flagged and deferred. No user-facing behavior change, no CHANGELOG entry — patch hygiene.

### 1. Playground rebuild restores aver bin after wasm-pack

\`wasm-pack build --features playground --no-default-features\` (inside \`build_compiler\`) flips the workspace feature set; cargo invalidates the \`aver-lang\` cache and rebuilds \`target/release/aver\` without the \`wasm\` feature. The next step (\`build_wasm\`, which runs \`aver compile --target wasm-gc\` per game) then errors out with \"WASM target requires --features wasm\".

The 0.22.0 release tripped on this hard enough that \`tools/release.py:regenerate_playground\` ended up with a **three-step workaround** that bypassed \`rebuild_playground.py:main\` entirely: build the compiler bundle with \`--skip-build\`, manually rebuild the aver bin, then re-invoke with \`--skip-compiler\`.

This PR moves the fix where it belongs. \`rebuild_playground.py:main\` itself re-runs \`cargo build --release --bin aver --features wasm\` between \`build_compiler\` and \`build_wasm\`. \`release.py\` collapses back to pre-build (to warm the cache) + a single \`rebuild_playground.py\` call. Direct \`python3 tools/website/rebuild_playground.py\` now works without the caller having to know about the wasm-pack feature-set trap.

### 2. \`loaded_to_module_info\` runs the canonical pipeline per dep

The loaded-modules verify path (playground / LSP / audit) was passing \`analysis: None\` for every dep \`ModuleInfo\`, which forced the VM compiler's conservative \"assume allocates\" branch on every dep fn. The disk-loader sibling has run \`pipeline::run\` per dep since the shared util landed (#214); mirror the same shape here using \`TypecheckMode::WithLoaded(loaded)\` so the analysis result actually populates. \`no_alloc\` fast paths on dep functions now light up in the playground / LSP path too.

## Test plan

- [x] \`cargo build --release --bin aver --features wasm\` — clean
- [x] \`cargo test --release\` — 39 suites, 0 failures
- [x] \`aver verify examples/refinement/natural_app.av --module-root examples\` — still 31/31 cases
- [ ] CI: Check & Test + WASM pass on this branch