### PR TITLE
examples:  propagation audit + Oracle verify on flagship apps (#210, #211)

### DIFF
--- a/examples/apps/notepad/store.av
+++ b/examples/apps/notepad/store.av
@@ -232,11 +232,41 @@ verify withoutId
 
 // --- CRUD ---
 
+// Oracle stubs for loadAll: exercise the Disk.readText branches without
+// touching the real filesystem. Each stub matches the `Disk.readText`
+// Oracle signature `(path, n, file) -> Result<String, String>`.
+
+fn fakeDiskEmpty(path: BranchPath, n: Int, file: String) -> Result<String, String>
+    ? "Deterministic Disk.readText stub: empty notes file."
+    Result.Ok("")
+
+fn fakeDiskOneNote(path: BranchPath, n: Int, file: String) -> Result<String, String>
+    ? "Deterministic Disk.readText stub: a single well-formed note line."
+    Result.Ok("1\tBuy milk\tFrom the store\n")
+
+fn fakeDiskGone(path: BranchPath, n: Int, file: String) -> Result<String, String>
+    ? "Deterministic Disk.readText stub: file does not exist — exercises the Err short-circuit."
+    Result.Err("ENOENT")
+
+verify fakeDiskEmpty
+    fakeDiskEmpty(BranchPath.Root, 0, "/tmp/aver_notepad/notes.txt") => Result.Ok("")
+
+verify fakeDiskOneNote
+    fakeDiskOneNote(BranchPath.Root, 0, "/tmp/aver_notepad/notes.txt") => Result.Ok("1\tBuy milk\tFrom the store\n")
+
+verify fakeDiskGone
+    fakeDiskGone(BranchPath.Root, 0, "/tmp/aver_notepad/notes.txt") => Result.Err("ENOENT")
+
 fn loadAll() -> Result<List<Note>, String>
     ? "Reads all notes from disk."
     ! [Disk.readText]
     content = Disk.readText(notesPath())?
     parseNotes(content)
+
+verify loadAll trace
+    given disk: Disk.readText = [fakeDiskEmpty, fakeDiskOneNote, fakeDiskGone]
+    loaded = loadAll()
+    loaded.trace.contains(Disk.readText("/tmp/aver_notepad/notes.txt")) => true
 
 fn saveAll(notes: List<Note>) -> Result<Unit, String>
     ? "Overwrites the notes file with the given list."

--- a/examples/apps/notepad/store.av
+++ b/examples/apps/notepad/store.av
@@ -165,12 +165,10 @@ verify noteRoundtripSafe
     noteRoundtripSafe(Note(id = 2, title = "bad\ttitle", body = "ok")) => false
 
 fn foldNote(acc: Result<List<Note>, String>, line: String) -> Result<List<Note>, String>
-    ? "Fold step: parses a line and appends the resulting note."
-    match acc
-        Result.Err(e) -> Result.Err(e)
-        Result.Ok(notes) -> match deserializeLine(line)
-            Result.Err(e) -> Result.Err(e)
-            Result.Ok(note) -> Result.Ok(List.concat(notes, [note]))
+    ? "Fold step: parses a line and appends the resulting note. Both the running accumulator and the per-line parse are Result-shaped, so `?` collapses the nested match into a linear happy-path."
+    notes = acc?
+    note = deserializeLine(line)?
+    Result.Ok(List.concat(notes, [note]))
 
 verify foldNote
     foldNote(Result.Err("x"), "1\tA\tB") => Result.Err("x")

--- a/examples/core/result_pipeline.av
+++ b/examples/core/result_pipeline.av
@@ -1,0 +1,123 @@
+module ResultPipeline
+    intent =
+        "Worked example for `?` propagation: a chain of fallible steps"
+        "where every Err in the middle aborts the whole pipeline with the"
+        "same error value, and the happy path stays linear. The shape"
+        "Aver code reaches for when a `let x = step()?` chain is more"
+        "readable than nested `match` arms."
+    exposes [validateAndCombine]
+    effects []
+
+// Domain — three smart-constructor steps, each returning Result. They
+// don't matter much in isolation; the point is composing them.
+
+fn parsePositive(s: String) -> Result<Int, String>
+    ? "Parse and reject non-positive integers."
+    match Int.fromString(s)
+        Result.Err(msg) -> Result.Err("not an int: {msg}")
+        Result.Ok(n)    -> match (n > 0)
+            true  -> Result.Ok(n)
+            false -> Result.Err("expected positive, got {n}")
+
+verify parsePositive
+    parsePositive("7")  => Result.Ok(7)
+    parsePositive("0")  => Result.Err("expected positive, got 0")
+    parsePositive("-3") => Result.Err("expected positive, got -3")
+    parsePositive("x")  => Result.Err("not an int: Cannot parse 'x' as Int")
+
+fn doubled(n: Int) -> Result<Int, String>
+    ? "Double the input, fail if the result would overflow Aver's bounded i64."
+    match (n > 4611686018427387903)
+        true  -> Result.Err("overflow when doubling {n}")
+        false -> Result.Ok(n * 2)
+
+verify doubled
+    doubled(7)   => Result.Ok(14)
+    doubled(0)   => Result.Ok(0)
+    doubled(4611686018427387904) => Result.Err("overflow when doubling 4611686018427387904")
+
+fn capAtThousand(n: Int) -> Result<Int, String>
+    ? "Reject values above 1000."
+    match (n > 1000)
+        true  -> Result.Err("over cap: {n}")
+        false -> Result.Ok(n)
+
+verify capAtThousand
+    capAtThousand(7)    => Result.Ok(7)
+    capAtThousand(1001) => Result.Err("over cap: 1001")
+
+// The composition — this is the file's whole point. `?` propagates the
+// first Err it sees with its own value; the surrounding fn keeps the
+// linear shape it would have if every step couldn't fail.
+//
+// Compare with the equivalent manual chain (kept below as
+// `validateAndCombineNoOp` for side-by-side reading): four arms of
+// `Result.Err(e) -> Result.Err(e)` collapse to four `?` operators.
+
+fn validateAndCombine(a: String, b: String) -> Result<Int, String>
+    ? "Parse two positive ints, double each, cap at 1000, return the sum. The first failing step short-circuits and carries its error to the caller."
+    x = parsePositive(a)?
+    y = parsePositive(b)?
+    xd = doubled(x)?
+    yd = doubled(y)?
+    xc = capAtThousand(xd)?
+    yc = capAtThousand(yd)?
+    Result.Ok(xc + yc)
+
+verify validateAndCombine
+    validateAndCombine("3", "5")   => Result.Ok(16)
+    validateAndCombine("3", "x")   => Result.Err("not an int: Cannot parse 'x' as Int")
+    validateAndCombine("-3", "5")  => Result.Err("expected positive, got -3")
+    validateAndCombine("600", "5") => Result.Err("over cap: 1200")
+    validateAndCombine("3", "600") => Result.Err("over cap: 1200")
+
+// Counter-example: the same fn written without `?`. Four manual
+// Err -> Err arms; the happy path drifts off the right edge of the
+// screen instead of staying at the top level. Both versions verify
+// against the same `validateAndCombine` cases — they're behaviourally
+// identical, just one is two screens shorter than the other.
+
+fn validateAndCombineNoOp(a: String, b: String) -> Result<Int, String>
+    ? "Manual chain of `match Result.Err -> Result.Err` arms. Kept for side-by-side comparison with the `?` version above. Real Aver code should prefer `?` whenever the Err branch is pure pass-through."
+    match parsePositive(a)
+        Result.Err(e) -> Result.Err(e)
+        Result.Ok(x)  -> match parsePositive(b)
+            Result.Err(e) -> Result.Err(e)
+            Result.Ok(y)  -> match doubled(x)
+                Result.Err(e) -> Result.Err(e)
+                Result.Ok(xd) -> match doubled(y)
+                    Result.Err(e) -> Result.Err(e)
+                    Result.Ok(yd) -> match capAtThousand(xd)
+                        Result.Err(e) -> Result.Err(e)
+                        Result.Ok(xc) -> match capAtThousand(yd)
+                            Result.Err(e) -> Result.Err(e)
+                            Result.Ok(yc) -> Result.Ok(xc + yc)
+
+verify validateAndCombineNoOp
+    validateAndCombineNoOp("3", "5")   => Result.Ok(16)
+    validateAndCombineNoOp("3", "x")   => Result.Err("not an int: Cannot parse 'x' as Int")
+    validateAndCombineNoOp("-3", "5")  => Result.Err("expected positive, got -3")
+    validateAndCombineNoOp("600", "5") => Result.Err("over cap: 1200")
+    validateAndCombineNoOp("3", "600") => Result.Err("over cap: 1200")
+
+// When NOT to reach for `?`
+// ─────────────────────────
+//
+// `?` is short-circuit Err propagation: it returns the Err value
+// unchanged. It's a great fit when:
+//
+//   - every Err arm in the chain is `Result.Err(e) -> Result.Err(e)`
+//     with no transformation, and
+//   - the surrounding fn's Err type matches the step's Err type.
+//
+// Use a manual `match` instead when:
+//
+//   - the Err needs a transform — adding context, mapping to a domain
+//     error type, redacting a message. Example from `examples/data/
+//     json.av`: parseValue's `ParseResult.Err(msg, p)` gets rewritten to
+//     `Result.Err(msg + " at position " + String.fromInt(p))` before
+//     leaving fromString — a real transform, not pass-through.
+//   - the Err arm should branch on the error value (retry, fall back to
+//     a default, log + continue).
+//   - the step returns a non-Result sum type (`ParseResult.Ok / Err(msg,
+//     p)` etc.); `?` only operates on `Result<T, E>`.

--- a/examples/data/quicksort.av
+++ b/examples/data/quicksort.av
@@ -26,6 +26,10 @@ verify sort law lengthPreserved
     given xs: List<Int> = [[], [1], [2, 1], [3, 1, 2], [5, 1, 5, 2, 3], [9, 4, 7, 1, 3, 8, 2]]
     List.len(sort(xs)) => List.len(xs)
 
+verify sort law idempotent
+    given xs: List<Int> = [[], [1], [2, 1], [3, 1, 2], [5, 1, 5, 2, 3], [9, 4, 7, 1, 3, 8, 2], [1, 1, 1, 1]]
+    sort(sort(xs)) => sort(xs)
+
 fn sortWithPivot(pivot: Int, rest: List<Int>) -> List<Int>
     ? "Sorts both partitions around one pivot and joins them back together."
     smaller = sort(smallerOrEqual(rest, pivot))

--- a/examples/services/http_demo.av
+++ b/examples/services/http_demo.av
@@ -33,6 +33,51 @@ fn post(url: String, payload: String, token: String) -> Result<HttpResponse, Str
     headers = {"authorization" => ["Bearer {token}"]}
     Http.post(url, payload, "application/json", headers)
 
+// Oracle stubs for fetch / checkStatus / post: pin Http without
+// hitting the network. Each stub matches the matching Http.* Oracle
+// signature, so the verify blocks below can pre-pick a deterministic
+// world.
+
+fn fakeGet200(path: BranchPath, n: Int, url: String) -> Result<HttpResponse, String>
+    ? "Deterministic Http.get stub: 200 OK with a short body."
+    Result.Ok(HttpResponse(status = 200, body = "{{\"ok\": true}}", headers = {}))
+
+fn fakeGet404(path: BranchPath, n: Int, url: String) -> Result<HttpResponse, String>
+    ? "Deterministic Http.get stub: server reachable, returns 404."
+    Result.Ok(HttpResponse(status = 404, body = "not found", headers = {}))
+
+fn fakeGetDown(path: BranchPath, n: Int, url: String) -> Result<HttpResponse, String>
+    ? "Deterministic Http.get stub: transport error. Exercises the `?` Err short-circuit in checkStatus."
+    Result.Err("timeout")
+
+fn fakePost200(path: BranchPath, n: Int, url: String, body: String, contentType: String, headers: Map<String, List<String>>) -> Result<HttpResponse, String>
+    ? "Deterministic Http.post stub: 200 OK echoing a fixed body."
+    Result.Ok(HttpResponse(status = 200, body = "accepted", headers = {}))
+
+verify fakeGet200
+    fakeGet200(BranchPath.Root, 0, "https://x") => Result.Ok(HttpResponse(status = 200, body = "{{\"ok\": true}}", headers = {}))
+
+verify fakeGet404
+    fakeGet404(BranchPath.Root, 0, "https://x") => Result.Ok(HttpResponse(status = 404, body = "not found", headers = {}))
+
+verify fakeGetDown
+    fakeGetDown(BranchPath.Root, 0, "https://x") => Result.Err("timeout")
+
+verify fetch trace
+    given http: Http.get = [fakeGet200, fakeGet404, fakeGetDown]
+    fetched = fetch("https://example.com")
+    fetched.trace.contains(Http.get("https://example.com")) => true
+
+verify checkStatus trace
+    given http: Http.get = [fakeGet200, fakeGet404, fakeGetDown]
+    checked = checkStatus("https://example.com")
+    checked.trace.contains(Http.get("https://example.com")) => true
+
+verify post trace
+    given http: Http.post = [fakePost200]
+    posted = post("https://example.com", "{{}}", "demo-token")
+    posted.trace.contains(Http.post) => true
+
 fn main() -> Unit
     ! [Console.print, Http.get, Http.post]
     url = "https://httpbin.org/get"

--- a/examples/services/weather.av
+++ b/examples/services/weather.av
@@ -138,6 +138,36 @@ fn fetchWeather(config: WeatherConfig, city: String) -> Result<String, String>
             true  -> Result.Ok(resp.body)
             false -> Result.Err("API returned HTTP {resp.status}")
 
+// Oracle stubs for fetchWeather: pin Http.get without hitting the network.
+// Each stub is deterministic in its arguments and matches the
+// `Http.get` Oracle signature `(path, n, url) -> Result<HttpResponse, String>`.
+
+fn fakeHttp200(path: BranchPath, n: Int, url: String) -> Result<HttpResponse, String>
+    ? "Deterministic Http.get stub returning a 200 with a fixed body."
+    Result.Ok(HttpResponse(status = 200, body = "\"sunny\"", headers = {}))
+
+fn fakeHttp500(path: BranchPath, n: Int, url: String) -> Result<HttpResponse, String>
+    ? "Deterministic Http.get stub returning a 500 — exercises the non-200 branch."
+    Result.Ok(HttpResponse(status = 500, body = "boom", headers = {}))
+
+fn fakeHttpDown(path: BranchPath, n: Int, url: String) -> Result<HttpResponse, String>
+    ? "Deterministic Http.get stub returning a transport error — exercises the Err branch."
+    Result.Err("connection refused")
+
+verify fakeHttp200
+    fakeHttp200(BranchPath.Root, 0, "https://api.weather.com/v1/current?city=Warsaw&key=demo-key") => Result.Ok(HttpResponse(status = 200, body = "\"sunny\"", headers = {}))
+
+verify fakeHttp500
+    fakeHttp500(BranchPath.Root, 0, "https://api.weather.com/v1/current?city=Warsaw&key=demo-key") => Result.Ok(HttpResponse(status = 500, body = "boom", headers = {}))
+
+verify fakeHttpDown
+    fakeHttpDown(BranchPath.Root, 0, "https://api.weather.com/v1/current?city=Warsaw&key=demo-key") => Result.Err("connection refused")
+
+verify fetchWeather trace
+    given http: Http.get = [fakeHttp200, fakeHttp500, fakeHttpDown]
+    fetched = fetchWeather(WeatherConfig(apiHost = "api.weather.com", apiKey = "demo-key", redisHost = "h", redisPort = 6379, serverPort = 8080), "Warsaw")
+    fetched.trace.contains(Http.get("https://api.weather.com/v1/current?city=Warsaw&key=demo-key")) => true
+
 fn fetchAndCache(config: WeatherConfig, conn: Tcp.Connection, city: String) -> Result<String, String>
     ? "Fetches from API and stores result in Redis before returning it."
     ! [Http.get, Tcp.readLine, Tcp.writeLine]

--- a/tools/website/llms.txt
+++ b/tools/website/llms.txt
@@ -276,7 +276,7 @@ Rules:
 
 - Arithmetic: `+`, `-`, `*`, `/` (operands must match types)
 - Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`
-- Error propagation: `expr?` (unwraps `Result.Ok`, propagates `Result.Err`). **Result-only** — does not work on `Option`. For `Option`, use `Option.withDefault(opt, fallback)` or pattern-match.
+- Error propagation: `expr?` (unwraps `Result.Ok`, propagates `Result.Err`). **Result-only** — does not work on `Option`. For `Option`, use `Option.withDefault(opt, fallback)` or pattern-match. Prefer `?` whenever every `Err` arm is pass-through (`Result.Err(e) -> Result.Err(e)`); keep a manual `match` when the `Err` needs transforming or branching. Worked example: `examples/core/result_pipeline.av`.
 - Independence: `(a, b)!` (parallel), `(a, b)?!` (parallel + Result unwrap)
 - String interpolation: `"Hello, {name}!"`
 


### PR DESCRIPTION
## Summary
- New worked example `examples/core/result_pipeline.av` puts a six-step `?` chain side-by-side with the same fn written as a nested `match`, plus a comment block naming the cases where `?` is the wrong tool.
- `examples/apps/notepad/store.av:foldNote` collapses a nested-match into two `?` operators — both the running accumulator and the per-line parse are Result-shaped.
- `tools/website/llms.txt` (`llms.txt` symlink target) gets one extra sentence under the existing `?` bullet, pointing at the worked example and naming the when-to-reach / when-not-to-reach rule. Deliberately not 15 sentences.
- Oracle verify added to three flagship orchestration apps: `services/weather.av` (Http.get stubs for fetchWeather), `services/http_demo.av` (Http.get + Http.post stubs for fetch/checkStatus/post), `apps/notepad/store.av` (Disk.readText stubs for loadAll). Each stub matches the canonical Oracle signature and carries its own verify anchor.

## Closes
- #210 (`?` audit across examples)
- #211 (Oracle verify on flagship orchestration)

## Test plan
- [x] `target/release/aver verify examples --module-root examples` → 2013/2021 passed, 0 failed, 8 when-skipped, 19 multi-module files skipped (known — they need per-game `--module-root`)
- [x] `target/release/aver verify examples/core/result_pipeline.av` → 19/19
- [x] `target/release/aver verify examples/apps/notepad/store.av --module-root examples/apps/notepad` → 52/55 (3 when-skipped)
- [x] `target/release/aver verify examples/services/weather.av --module-root examples` → 18/18
- [x] `target/release/aver verify examples/services/http_demo.av` → 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)