### PR TITLE
typecheck: allow opaque runtime-handle construction inside verify-trace context

### DIFF
--- a/examples/services/redis.av
+++ b/examples/services/redis.av
@@ -119,6 +119,60 @@ fn del(conn: Tcp.Connection, key: String) -> Result<String, String>
     _ = sendCommand(conn, ["DEL", key])?
     Tcp.readLine(conn)
 
+// Oracle stubs for ping/set/get: pin Tcp.writeLine + Tcp.readLine
+// without touching a real socket. Each stub matches the Oracle
+// signature for its method.
+//
+// Tcp.Connection is an opaque runtime handle. Outside this verify
+// block the typechecker rejects `Tcp.Connection(...)` construction;
+// here, inside verify-trace context, the systemic-handle relaxation
+// allows fabricating one as test-only input (no field is inspected,
+// every effect that would touch the handle is stubbed).
+
+fn fakeWriteOk(path: BranchPath, n: Int, conn: Tcp.Connection, line: String) -> Result<Unit, String>
+    ? "Deterministic Tcp.writeLine stub: write always succeeds."
+    Result.Ok(Unit)
+
+fn fakeWriteFail(path: BranchPath, n: Int, conn: Tcp.Connection, line: String) -> Result<Unit, String>
+    ? "Deterministic Tcp.writeLine stub: socket dead — exercises the `?` Err short-circuit in sendCommand."
+    Result.Err("broken pipe")
+
+fn fakeReadPong(path: BranchPath, n: Int, conn: Tcp.Connection) -> Result<String, String>
+    ? "Deterministic Tcp.readLine stub: server returns +PONG."
+    Result.Ok("+PONG")
+
+fn fakeReadOk(path: BranchPath, n: Int, conn: Tcp.Connection) -> Result<String, String>
+    ? "Deterministic Tcp.readLine stub: server returns +OK (SET acknowledgement)."
+    Result.Ok("+OK")
+
+fn fakeReadNil(path: BranchPath, n: Int, conn: Tcp.Connection) -> Result<String, String>
+    ? "Deterministic Tcp.readLine stub: server returns $-1 (RESP nil)."
+    Result.Ok("$-1")
+
+// Oracle trace records DIRECT effect emissions from the root fn under
+// test. ping/set/get all dispatch Tcp.writeLine through helper fns
+// (sendCommand → sendArgs → sendArgAndRest), so writeLine doesn't
+// surface here. Tcp.readLine, however, is invoked at the root level
+// — that's what we anchor on.
+
+verify ping trace
+    given write: Tcp.writeLine = [fakeWriteOk]
+    given read:  Tcp.readLine  = [fakeReadPong]
+    pinged = ping(Tcp.Connection(id = "fake", host = "127.0.0.1", port = 6379))
+    pinged.trace.contains(Tcp.readLine) => true
+
+verify set trace
+    given write: Tcp.writeLine = [fakeWriteOk]
+    given read:  Tcp.readLine  = [fakeReadOk]
+    setted = set(Tcp.Connection(id = "fake", host = "127.0.0.1", port = 6379), "k", "v")
+    setted.trace.contains(Tcp.readLine) => true
+
+verify get trace
+    given write: Tcp.writeLine = [fakeWriteOk]
+    given read:  Tcp.readLine  = [fakeReadNil, fakeReadOk]
+    got = get(Tcp.Connection(id = "fake", host = "127.0.0.1", port = 6379), "k")
+    got.trace.contains(Tcp.readLine) => true
+
 // Demo entry point
 
 fn run() -> Result<Unit, String>

--- a/src/types/checker/effect_classification.rs
+++ b/src/types/checker/effect_classification.rs
@@ -440,6 +440,30 @@ pub fn is_classified(method: &str) -> bool {
     classify(method).is_some()
 }
 
+/// Opaque types that are runtime handles (id + connection metadata),
+/// not domain-invariant smart-constructor types. These may be fabricated
+/// inside verify-trace context so that Oracle stubs can return them
+/// without going through the live effect that normally produces them
+/// (e.g. `Tcp.connect`). All four soundness conditions from PR 221 apply:
+///
+/// 1. Every effect that can observe/consume the fake handle must be
+///    stubbed, or the verify block is rejected (existing behavior in
+///    `flow.rs` — see "needs a `given` stub" error).
+/// 2. Pure code outside the defining module cannot inspect fields or
+///    pattern-match the value just because it was fabricated. Field
+///    access on opaque types is rejected outside the defining module
+///    regardless of this flag.
+/// 3. Verify-block bodies are not lowered to executable artifacts, so
+///    fabricated handles cannot escape to compiled programs.
+/// 4. Runtime handle identity is uninterpreted test data unless an
+///    Oracle stub assigns meaning to it.
+///
+/// User-defined opaque types are NOT eligible — their opacity protects
+/// domain invariants that this fabrication would erase.
+pub fn is_verify_fabricable_handle(canonical_type: &str) -> bool {
+    matches!(canonical_type, "Tcp.Connection")
+}
+
 /// Oracle signature for use in lifted specs.
 ///
 /// - Snapshot: capability reader — unchanged from runtime signature,

--- a/src/types/checker/infer/records.rs
+++ b/src/types/checker/infer/records.rs
@@ -14,11 +14,20 @@ impl TypeChecker {
         // qualified form would be.
         let canonical_type = self.canonical_type_name(type_name);
         if !self.self_host_mode && self.opaque_types.contains(canonical_type.as_str()) {
-            self.error(format!(
-                "Cannot construct opaque type '{}' — use its module's constructor function",
-                type_name
-            ));
-            return self.canonicalize_named(Type::named(canonical_type));
+            let fabricable_in_verify = self.in_verify_trace_context
+                && crate::types::checker::effect_classification::is_verify_fabricable_handle(
+                    canonical_type.as_str(),
+                );
+            if !fabricable_in_verify {
+                self.error(format!(
+                    "Cannot construct opaque type '{}' — use its module's constructor function",
+                    type_name
+                ));
+                return self.canonicalize_named(Type::named(canonical_type));
+            }
+            // Fall through: verify-trace context may fabricate flagged
+            // runtime handles. Field inference below still type-checks
+            // each provided field against the record's declared types.
         }
 
         // Iron — A5: `fields_for_type` canonicalises `type_name`

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -1379,6 +1379,103 @@ fn error_tcp_connection_manual_construction_is_opaque() {
 }
 
 #[test]
+fn verify_trace_may_fabricate_tcp_connection_handle() {
+    // Verify-trace context relaxes opaque-construction for runtime
+    // handles flagged in `effect_classification::is_verify_fabricable_handle`.
+    // Tcp.Connection is the first such handle: lets Oracle stubs feed
+    // a deterministic conn into the SUT without going through Tcp.connect.
+    let src = concat!(
+        "fn fakeWrite(p: BranchPath, n: Int, c: Tcp.Connection, line: String) -> Result<Unit, String>\n",
+        "    ? \"stub\"\n",
+        "    Result.Ok(Unit)\n",
+        "\n",
+        "fn fakeRead(p: BranchPath, n: Int, c: Tcp.Connection) -> Result<String, String>\n",
+        "    ? \"stub\"\n",
+        "    Result.Ok(\"+PONG\")\n",
+        "\n",
+        "fn ping(conn: Tcp.Connection) -> Result<String, String>\n",
+        "    ? \"ping\"\n",
+        "    ! [Tcp.readLine, Tcp.writeLine]\n",
+        "    _ = Tcp.writeLine(conn, \"PING\")?\n",
+        "    Tcp.readLine(conn)\n",
+        "\n",
+        "verify ping trace\n",
+        "    given w: Tcp.writeLine = [fakeWrite]\n",
+        "    given r: Tcp.readLine  = [fakeRead]\n",
+        "    pinged = ping(Tcp.Connection(id = \"fake\", host = \"127.0.0.1\", port = 6379))\n",
+        "    pinged.trace.contains(Tcp.writeLine) => true\n",
+    );
+    assert_no_errors(src);
+}
+
+#[test]
+fn error_tcp_connection_fabrication_still_rejected_outside_verify() {
+    // Regression: relaxation is scoped to verify-trace context. A
+    // regular fn that constructs Tcp.Connection is still rejected.
+    // (The original "fake()" test above guards the same property
+    // without the verify-context flag flipped; this test makes the
+    // scoping explicit by also covering a fn that DOES participate
+    // in oracle stub signatures.)
+    let src = concat!(
+        "fn forgeOutsideVerify() -> Tcp.Connection\n",
+        "    Tcp.Connection(id = \"forged\", host = \"x\", port = 80)\n",
+    );
+    assert_error_containing(src, "opaque type 'Tcp.Connection'");
+}
+
+#[test]
+fn error_user_defined_opaque_not_fabricable_in_verify_trace() {
+    // The relaxation is opt-in via `is_verify_fabricable_handle`.
+    // User-defined opaque types protect domain invariants (smart
+    // constructors), so verify-trace context MUST NOT erode that
+    // protection — the typechecker should reject construction of an
+    // imported opaque even from inside a verify block.
+    let root = temp_module_root("verify_opaque_no_fabricate");
+    let bounded_dir = root.join("Bounded");
+    std::fs::create_dir_all(&bounded_dir).expect("create Bounded dir failed");
+    std::fs::write(
+        bounded_dir.join("Positive.av"),
+        r#"module Positive
+    exposes [fromInt]
+    exposes opaque [Positive]
+    intent = "Positive integer with smart-constructor invariant."
+
+record Positive
+    value: Int
+
+fn fromInt(n: Int) -> Result<Positive, String>
+    ? "Smart constructor: rejects non-positive inputs."
+    match n > 0
+        true  -> Result.Ok(Positive(value = n))
+        false -> Result.Err("non-positive")
+"#,
+    )
+    .expect("write Positive.av failed");
+
+    let src = r#"module App
+    depends [Bounded.Positive]
+    intent = "Tries to fabricate Positive inside a verify trace."
+
+fn echo(p: Positive) -> Positive
+    ? "Identity over Positive."
+    p
+
+verify echo trace
+    echoed = echo(Positive(value = -1))
+    echoed => Positive(value = -1)
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("Cannot construct opaque type")),
+        "expected opaque construction error inside verify trace, got: {:?}",
+        errs
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn error_tcp_write_line_with_string() {
     let src = concat!(
         "fn send(conn: String, msg: String) -> Result<Unit, String>\n",


### PR DESCRIPTION
## Summary
Oracle verify on session effects (Tcp.writeLine, Tcp.readLine, Tcp.close) used to be impossible because the only legal way to obtain a `Tcp.Connection` is to call `Tcp.connect` — the exact effect a verify-trace block stubs out. `verify ping trace` couldn't even type-check.

This PR relaxes opaque-construction inside `verify ... trace` (and law) blocks, but only for opaque types explicitly flagged as runtime handles in `effect_classification::is_verify_fabricable_handle`. Tcp.Connection is the only flagged type today.

Peer-AI review picked the discriminator (explicit per-type metadata, not a structural heuristic over `runtime_return`) and the four soundness conditions; this PR threads them through:

1. Every effect that can observe/consume the fake handle must be stubbed, or the verify block is rejected (existing `flow.rs` error).
2. Field access on opaque types remains blocked outside the defining module, fabricated or not.
3. Verify blocks aren't lowered to the executable artifact — fabricated handles cannot escape.
4. Runtime handle identity stays uninterpreted test data unless a stub assigns meaning.

User-defined opaque types stay protected: the relaxation is opt-in per type, the table only lists systemic handles, and a regression test asserts a user-defined opaque imported across modules still rejects fabrication inside verify.

## Worked example
`examples/services/redis.av` gains `verify ping/set/get trace` blocks. They fabricate a `Tcp.Connection`, stub `Tcp.writeLine` + `Tcp.readLine`, and anchor on the direct `Tcp.readLine` emission in the trace (Tcp.writeLine is dispatched through helpers and doesn't surface in `.trace.contains` by design).

## Test plan
- [x] `cargo test --release` passes
- [x] New tests in `tests/typechecker_spec.rs`:
  - `verify_trace_may_fabricate_tcp_connection_handle` — positive
  - `error_tcp_connection_fabrication_still_rejected_outside_verify` — regression
  - `error_user_defined_opaque_not_fabricable_in_verify_trace` — cross-module, user-defined opaque stays protected
- [x] Existing `error_tcp_connection_manual_construction_is_opaque` still passes
- [x] `target/release/aver verify examples/services/redis.av` — 8/8 cases
- [x] `target/release/aver verify examples --module-root examples` — 1976/1984 (0 failed, 8 when-skipped)

## Closes
n/a — direct fix, no issue (per user instruction: "tak, chyba ze to po prostu zrobisz bez pierdolenia sie z issues").

🤖 Generated with [Claude Code](https://claude.com/claude-code)