### PR TITLE
build: add release-fast profile for local development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,3 +110,18 @@ required-features = ["wasm"]
 [profile.release]
 lto = true
 codegen-units = 1
+
+# Local-iteration profile: skips LTO and uses 16 codegen units, so a
+# rebuild after a one-line change typically finishes in ~30 s instead
+# of 3-4 min. Use for `cargo build --profile release-fast --bin aver`
+# and `cargo install --path . --profile release-fast` during development.
+# Runtime perf is slightly lower (no cross-crate inlining) but well
+# above debug — fine for testing `aver shape`, `aver verify`, etc.
+# `cargo install` without `--profile` and CI / crates.io artifacts
+# stay on the default `release` profile, so shipped binaries are
+# unaffected.
+[profile.release-fast]
+inherits = "release"
+lto = false
+codegen-units = 16
+incremental = true

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ aver compile  hello.av -o out/
 ```bash
 git clone https://github.com/jasisz/aver
 cd aver
-cargo install --path . --force
+cargo install --path . --force                              # full release build (LTO, ~3 min)
+cargo install --path . --force --profile release-fast       # local dev build  (no LTO,  ~30 s)
 
 aver run      examples/core/calculator.av
 aver run      examples/core/calculator.av --self-host


### PR DESCRIPTION
## Summary
Adds `[profile.release-fast]` which inherits from `release` but flips:
- `lto = false` — no whole-program optimization pass
- `codegen-units = 16` — parallel codegen across crates
- `incremental = true` — reuse codegen across rebuilds

## Numbers (current repo, Apple M-series)
| Profile         | First clean build | Touch one file, rebuild |
|-----------------|-------------------|-------------------------|
| `release`       | ~3+ min           | ~3 min                  |
| `release-fast`  | ~1m 18s           | **~3.3 s**              |

Runtime perf is slightly lower (no cross-crate inlining) but well above debug — fine for testing `aver shape`, `aver verify`, `aver check`, and the rest of the CLI during development.

## Shipped binaries unaffected
`cargo install --path . --force` and CI / crates.io artifacts stay on the default `release` profile. Only opt-in via `--profile release-fast`.

## Usage
```bash
cargo build   --profile release-fast --bin aver --features wasm
cargo install --path . --force --profile release-fast
```

README "Build from source" block lists both side by side with rough timings.

## Test plan
- [x] Clean build: `cargo build --profile release-fast --bin aver --features wasm` → ~1m 18s (exit 0)
- [x] Incremental: `touch src/diagnostics/shape.rs && cargo build --profile release-fast --bin aver --features wasm` → 3.3s (exit 0)
- [x] No changes to `release` profile — full release build still produces the same artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)