### PR TITLE
aver shape: tighten render_text formatting

### DIFF
--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -1232,8 +1232,10 @@ pub struct RenderOptions {
 
 pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
     let mut out = String::new();
-    out.push_str(&format!("Module: {}\n", report.module));
-    out.push_str(&format!("  Kind:  {}\n\n", report.kind.as_str()));
+    // Header: `Module:` and `Kind:` share the value column. `Module:` is
+    // 7 chars + space, `Kind:` is 5 chars + 3 spaces — same total width.
+    out.push_str(&format!("Module:  {}\n", report.module));
+    out.push_str(&format!("Kind:    {}\n\n", report.kind.as_str()));
     out.push_str("  ModuleShape:\n");
     out.push_str(&format!(
         "    purity        {}\n",
@@ -1256,42 +1258,52 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
         report.shape.api_shape.as_str()
     ));
 
-    out.push_str(&format!(
-        "  Verification:   {} {} block{}, {}/{} fns covered\n\n",
-        report.verify.blocks,
-        match report.verify.level {
-            VerifyLevel::None => "(no)",
-            VerifyLevel::Cases => "cases",
-            VerifyLevel::Laws => "law",
-            VerifyLevel::Trace => "trace",
-            VerifyLevel::Mixed => "mixed",
-        },
-        if report.verify.blocks == 1 { "" } else { "s" },
-        report.verify.covered_fns,
-        report.verify.eligible_fns,
-    ));
-
-    out.push_str(&format!(
-        "  Histogram ({} fns):\n",
-        report.histogram.total_fns
-    ));
-    let sorted = report.histogram.sorted();
-    let name_w = sorted
-        .iter()
-        .map(|(n, _, _)| n.len())
-        .max()
-        .unwrap_or(0)
-        .max(20);
-    for (name, count, pct) in &sorted {
-        let bar = histogram_bar(*pct, 20);
+    // Verification: collapse the zero-block case to a single line — the
+    // "0 (no) blocks, 0/0 fns covered" reading was confusing.
+    if report.verify.blocks == 0 {
+        out.push_str("  Verification:  no verify blocks\n\n");
+    } else {
         out.push_str(&format!(
-            "    {:<width$}  {}  {:>3.0}%  ({})\n",
-            name,
-            bar,
-            pct,
-            count,
-            width = name_w,
+            "  Verification:  {} {} block{}, {}/{} fns covered\n\n",
+            report.verify.blocks,
+            match report.verify.level {
+                VerifyLevel::None => "(no)",
+                VerifyLevel::Cases => "cases",
+                VerifyLevel::Laws => "law",
+                VerifyLevel::Trace => "trace",
+                VerifyLevel::Mixed => "mixed",
+            },
+            if report.verify.blocks == 1 { "" } else { "s" },
+            report.verify.covered_fns,
+            report.verify.eligible_fns,
         ));
+    }
+
+    if report.histogram.total_fns == 0 {
+        out.push_str("  Histogram:     no classifiable fns (module only has `main` or no fns)\n");
+    } else {
+        out.push_str(&format!(
+            "  Histogram ({} fns):\n",
+            report.histogram.total_fns
+        ));
+        let sorted = report.histogram.sorted();
+        let name_w = sorted
+            .iter()
+            .map(|(n, _, _)| n.len())
+            .max()
+            .unwrap_or(0)
+            .max(20);
+        for (name, count, pct) in &sorted {
+            let bar = histogram_bar(*pct, 20);
+            out.push_str(&format!(
+                "    {:<width$}  {}  {:>3.0}%  ({})\n",
+                name,
+                bar,
+                pct,
+                count,
+                width = name_w,
+            ));
+        }
     }
     if let Some(verdict) = &report.layer {
         out.push_str(&format!(

--- a/tests/shape_spec.rs
+++ b/tests/shape_spec.rs
@@ -71,8 +71,8 @@ fn redis_is_service_client() {
 fn render_text_includes_kind_and_layer() {
     let r = analyze("examples/services/redis.av");
     let text = shape::render_text(&r, &RenderOptions { summary: false });
-    assert!(text.contains("Module: Redis"));
-    assert!(text.contains("Kind:  ServiceClient"));
+    assert!(text.contains("Module:  Redis"));
+    assert!(text.contains("Kind:    ServiceClient"));
     assert!(text.contains("ModuleShape:"));
     assert!(text.contains("purity        ClassifiedEffectful"));
     assert!(text.contains("type_surface  RuntimeHandle"));


### PR DESCRIPTION
## Summary
Three small cleanups in the human-readable `aver shape` output:

1. **Align `Module:` and `Kind:` value columns.** Pre-fix `Module:` had one space after the colon and `Kind:` had two — values landed in different columns and the header looked askew.
2. **Collapse zero-block Verification line.** "Verification: 0 (no) blocks, 0/0 fns covered" → "Verification: no verify blocks". One short sentence instead of a literal-zero + `(no)` placeholder mix.
3. **Skip empty histogram body.** Modules with only `main` (no non-main fns) used to print "Histogram (0 fns):" followed by nothing. Now prints one explanatory line: "Histogram: no classifiable fns (module only has `main` or no fns)".

Before / after for an `effects [Console]` + just `main` module:

```
- Verification:   0 (no) blocks, 0/0 fns covered
-
- Histogram (0 fns):
-
- Layer: insufficient data

+ Verification:  no verify blocks
+
+ Histogram:     no classifiable fns (module only has `main` or no fns)
+
+ Layer: insufficient data
```

## Test plan
- [x] `cargo test --release --test shape_spec` — 11/11 pass (one assertion updated for the new alignment)
- [x] Manual: `aver shape examples/services/redis.av` looks the same except header alignment
- [x] Manual: tiny single-`main` module prints the new no-blocks / no-histogram lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)