### PR TITLE
lsp: shape CodeLens above `module X`

### DIFF
--- a/aver-lsp/src/backend.rs
+++ b/aver-lsp/src/backend.rs
@@ -231,7 +231,8 @@ impl LanguageServer for AverBackend {
             docs.get(&uri.to_string()).cloned().unwrap_or_default()
         };
 
-        Ok(symbols::document_symbols(&source))
+        let base_dir = self.get_base_dir(&uri);
+        Ok(symbols::document_symbols(&source, base_dir.as_deref()))
     }
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {

--- a/aver-lsp/src/hover.rs
+++ b/aver-lsp/src/hover.rs
@@ -155,7 +155,67 @@ pub fn hover_for_word(word: &str, source: &str, base_dir: Option<&str>) -> Optio
         }
     }
 
+    // Module name → shape report (Kind + ModuleShape vector + Layer).
+    // Best-effort: skip silently if shape analysis fails (typecheck
+    // error, missing deps).
+    for item in &items {
+        if let TopLevel::Module(module) = item
+            && module.name == word
+        {
+            if let Some(content) = build_module_shape_hover(source, base_dir, module) {
+                return Some(make_hover(content));
+            }
+        }
+    }
+
     None
+}
+
+fn build_module_shape_hover(
+    source: &str,
+    base_dir: Option<&str>,
+    module: &aver::ast::Module,
+) -> Option<String> {
+    use aver::diagnostics::shape;
+    let module_root = base_dir.unwrap_or(".");
+    let fingerprints = shape::builtin_v0_layer_fingerprints();
+    let report = shape::analyze_source_with(
+        source,
+        module_root,
+        "(buffer)",
+        &module.name,
+        &fingerprints,
+        "built-in v0",
+    )
+    .ok()?;
+
+    let layer_line = report
+        .layer
+        .as_ref()
+        .map(|v| {
+            format!(
+                "**Layer:** {} (confidence {:.2}, basis: {})",
+                v.layer.as_str(),
+                v.confidence,
+                v.basis
+            )
+        })
+        .unwrap_or_else(|| "**Layer:** insufficient data".to_string());
+
+    Some(format!(
+        "**module {}**\n\n**Kind:** {} — {}\n\n```\npurity        {}\nentry         {}\nstate_shape   {}\ntype_surface  {}\napi_shape     {}\n```\n\nVerify blocks: {} · Non-main fns: {}\n\n{}",
+        report.module,
+        report.kind.as_str(),
+        report.kind.rule(),
+        report.shape.purity.as_str(),
+        report.shape.entry.as_str(),
+        report.shape.state_shape.as_str(),
+        report.shape.type_surface.as_str(),
+        report.shape.api_shape.as_str(),
+        report.verify.blocks,
+        report.histogram.total_fns,
+        layer_line,
+    ))
 }
 
 fn build_fn_hover(fd: &FnDef, items: &[TopLevel], base_dir: Option<&str>) -> String {

--- a/aver-lsp/src/hover.rs
+++ b/aver-lsp/src/hover.rs
@@ -161,10 +161,9 @@ pub fn hover_for_word(word: &str, source: &str, base_dir: Option<&str>) -> Optio
     for item in &items {
         if let TopLevel::Module(module) = item
             && module.name == word
+            && let Some(content) = build_module_shape_hover(source, base_dir, module)
         {
-            if let Some(content) = build_module_shape_hover(source, base_dir, module) {
-                return Some(make_hover(content));
-            }
+            return Some(make_hover(content));
         }
     }
 

--- a/aver-lsp/src/lenses.rs
+++ b/aver-lsp/src/lenses.rs
@@ -28,6 +28,12 @@ pub fn code_lenses(source: &str, base_dir: Option<&str>, uri: &str) -> Vec<CodeL
     }
 
     let tc_result = run_type_check_full(&items, base_dir);
+
+    // Module-level shape lens: one CodeLens above `module X` with the
+    // derived Kind + nearest Layer. Best-effort — if shape analysis
+    // fails (typecheck error, missing deps), skip silently rather than
+    // breaking the rest of the lens output.
+    let shape_lenses = compute_module_shape_lens(source, base_dir, uri, &items);
     let verify_by_fn: HashMap<String, Vec<_>> =
         merge_verify_blocks(&items)
             .into_iter()
@@ -127,7 +133,84 @@ pub fn code_lenses(source: &str, base_dir: Option<&str>, uri: &str) -> Vec<CodeL
         }
     }
 
+    lenses.extend(shape_lenses);
     lenses
+}
+
+/// One CodeLens above `module X` showing the analyzer's verdict on
+/// what kind of module this is. Best-effort — needs a full pipeline
+/// run (resolver) and module-root deps to resolve; if that fails the
+/// lens is omitted rather than surfacing the error as an LSP
+/// diagnostic.
+fn compute_module_shape_lens(
+    source: &str,
+    base_dir: Option<&str>,
+    uri: &str,
+    items: &[TopLevel],
+) -> Vec<CodeLens> {
+    use aver::diagnostics::shape;
+
+    let Some(module_decl) = items.iter().find_map(|i| match i {
+        TopLevel::Module(m) => Some(m),
+        _ => None,
+    }) else {
+        return Vec::new();
+    };
+
+    let module_root = base_dir.unwrap_or(".");
+    let file_label = uri.strip_prefix("file://").unwrap_or(uri);
+    let fallback_name = &module_decl.name;
+    let fingerprints = shape::builtin_v0_layer_fingerprints();
+    let Ok(report) = shape::analyze_source_with(
+        source,
+        module_root,
+        file_label,
+        fallback_name,
+        &fingerprints,
+        "built-in v0",
+    ) else {
+        return Vec::new();
+    };
+
+    let layer_label = report
+        .layer
+        .as_ref()
+        .map(|v| format!(" · {} ({:.2})", v.layer.as_str(), v.confidence))
+        .unwrap_or_default();
+    let title = format!("shape: {}{}", report.kind.as_str(), layer_label);
+
+    let message = format!(
+        "{}{}\nKind:    {} — {}\n\nModuleShape:\n  purity        {}\n  entry         {}\n  state_shape   {}\n  type_surface  {}\n  api_shape     {}\n\nVerify blocks: {}\nNon-main fns:  {}\nLayer:         {}\nBasis:         {}",
+        "Module: ",
+        report.module,
+        report.kind.as_str(),
+        report.kind.rule(),
+        report.shape.purity.as_str(),
+        report.shape.entry.as_str(),
+        report.shape.state_shape.as_str(),
+        report.shape.type_surface.as_str(),
+        report.shape.api_shape.as_str(),
+        report.verify.blocks,
+        report.histogram.total_fns,
+        report
+            .layer
+            .as_ref()
+            .map(|v| v.layer.as_str())
+            .unwrap_or("insufficient data"),
+        report
+            .layer
+            .as_ref()
+            .map(|v| v.basis.as_str())
+            .unwrap_or("—"),
+    );
+
+    vec![make_lens(
+        uri,
+        module_decl.line,
+        module_decl.line,
+        title,
+        message,
+    )]
 }
 
 fn canonical_specs(
@@ -250,6 +333,17 @@ verify publicFn law publicFnSpec
         assert!(titles.contains(&"verify: 1 case, 1 law"));
         assert!(titles.contains(&"decisions: 1"));
         assert!(titles.contains(&"impacts: 1"));
+
+        // Module-shape lens — Demo declares `effects []` implicitly (no
+        // block); the analyzer should still pick a Kind. Kind label
+        // appears in the title; the exact Kind is whatever the
+        // classifier picks for this small fixture, so we just assert
+        // the prefix.
+        assert!(
+            titles.iter().any(|t| t.starts_with("shape: ")),
+            "expected a `shape: <Kind>` lens, got titles: {:?}",
+            titles
+        );
         let verify = lenses
             .iter()
             .find(|lens| {

--- a/aver-lsp/src/symbols.rs
+++ b/aver-lsp/src/symbols.rs
@@ -7,7 +7,7 @@ use aver::checker::merge_verify_blocks;
 
 use crate::completion;
 
-pub fn document_symbols(source: &str) -> Option<DocumentSymbolResponse> {
+pub fn document_symbols(source: &str, base_dir: Option<&str>) -> Option<DocumentSymbolResponse> {
     let items = completion::parse_items(source);
     if items.is_empty() {
         return None;
@@ -39,13 +39,21 @@ pub fn document_symbols(source: &str) -> Option<DocumentSymbolResponse> {
     let symbols = items
         .iter()
         .filter_map(|item| match item {
-            TopLevel::Module(module) => Some(make_symbol(
-                module.name.clone(),
-                Some("module".to_string()),
-                SymbolKind::MODULE,
-                line_range(module.line),
-                None,
-            )),
+            TopLevel::Module(module) => {
+                // Surface the analyzer's Kind verdict in the symbol
+                // detail so the outline reads e.g. "Redis — ServiceClient".
+                // Best-effort: if shape analysis fails, fall back to the
+                // plain "module" label.
+                let detail = module_shape_detail(source, base_dir, &module.name)
+                    .unwrap_or_else(|| "module".to_string());
+                Some(make_symbol(
+                    module.name.clone(),
+                    Some(detail),
+                    SymbolKind::MODULE,
+                    line_range(module.line),
+                    None,
+                ))
+            }
             TopLevel::Decision(decision) => Some(make_symbol(
                 decision.name.clone(),
                 Some(format!("chosen {}", decision.chosen.node.text())),
@@ -115,6 +123,22 @@ pub fn document_symbols(source: &str) -> Option<DocumentSymbolResponse> {
     Some(DocumentSymbolResponse::Nested(symbols))
 }
 
+fn module_shape_detail(source: &str, base_dir: Option<&str>, module_name: &str) -> Option<String> {
+    use aver::diagnostics::shape;
+    let module_root = base_dir.unwrap_or(".");
+    let fingerprints = shape::builtin_v0_layer_fingerprints();
+    let report = shape::analyze_source_with(
+        source,
+        module_root,
+        "(buffer)",
+        module_name,
+        &fingerprints,
+        "built-in v0",
+    )
+    .ok()?;
+    Some(format!("module — {}", report.kind.as_str()))
+}
+
 fn line_range(line: usize) -> Range {
     let line = line.saturating_sub(1) as u32;
     Range {
@@ -175,7 +199,7 @@ verify publicFn law grows
     publicFn(x) => x + 1
 "#;
 
-        let Some(DocumentSymbolResponse::Nested(symbols)) = document_symbols(source) else {
+        let Some(DocumentSymbolResponse::Nested(symbols)) = document_symbols(source, None) else {
             panic!("expected document symbols");
         };
 

--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -948,8 +948,6 @@ pub fn analyze_path_with(
     basis: &str,
 ) -> Result<ShapeReport, String> {
     let source = std::fs::read_to_string(path).map_err(|e| format!("read: {}", e))?;
-    let mut items = crate::source::parse_source(&source).map_err(|e| format!("parse: {}", e))?;
-
     let module_root = match module_root_hint {
         Some(r) => r.to_string(),
         None => path
@@ -958,6 +956,38 @@ pub fn analyze_path_with(
             .map(|s| s.to_string())
             .unwrap_or_else(|| ".".to_string()),
     };
+    let file_label = path.to_string_lossy().to_string();
+    let fallback_module_name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("<unnamed>")
+        .to_string();
+    analyze_source_with(
+        &source,
+        &module_root,
+        &file_label,
+        &fallback_module_name,
+        fingerprints,
+        basis,
+    )
+}
+
+/// Analyze a source string directly, without touching the filesystem
+/// for the entry file. Used by the LSP (editor buffer may differ from
+/// on-disk content) and any future embedder that holds the program in
+/// memory. `module_root` resolves `depends [...]`; `file_label` is the
+/// path string surfaced in the report's `file` field; `fallback_module_name`
+/// is used when the source has no `module` declaration.
+pub fn analyze_source_with(
+    source: &str,
+    module_root: &str,
+    file_label: &str,
+    fallback_module_name: &str,
+    fingerprints: &[LayerFingerprint],
+    basis: &str,
+) -> Result<ShapeReport, String> {
+    let mut items = crate::source::parse_source(source).map_err(|e| format!("parse: {}", e))?;
+    let module_root = module_root.to_string();
 
     let dep_modules = crate::source::load_compile_deps(&items, &module_root)
         .map_err(|e| format!("deps: {}", e))?;
@@ -995,10 +1025,7 @@ pub fn analyze_path_with(
             m.exposes.clone(),
         ),
         None => (
-            path.file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("<unnamed>")
-                .to_string(),
+            fallback_module_name.to_string(),
             vec![],
             vec![],
             vec![],
@@ -1069,7 +1096,7 @@ pub fn analyze_path_with(
 
     Ok(ShapeReport {
         module: module_name,
-        file: path.to_string_lossy().to_string(),
+        file: file_label.to_string(),
         depends,
         effects,
         exposes_opaque,


### PR DESCRIPTION
## Summary
One new CodeLens above every `module X` declaration showing the analyzer's verdict on what kind of module this is:

```
shape: ServiceClient · Infra (0.78)
module Redis
    intent = ...
```

Title carries Kind + nearest Layer with confidence. Click opens a popup with the full vector:

```
Module:  Redis
Kind:    ServiceClient — classified effects threaded through a runtime handle

ModuleShape:
  purity        ClassifiedEffectful
  entry         Main
  state_shape   PureStateMachine
  type_surface  RuntimeHandle
  api_shape     ServiceBoundary

Verify blocks: 4
Non-main fns:  16
Layer:         Infra
Basis:         built-in v0
```

## Best-effort
If shape analysis fails (typecheck error, missing deps from the LSP's view of `base_dir`), the lens is silently omitted — no LSP diagnostic, no error in the editor. The other lenses (verify, decisions, impacts) are unaffected.

## Library refactor
Extracted `shape::analyze_source_with` from `analyze_path_with`. LSP feeds the in-memory editor buffer directly — no need to write unsaved changes to disk. CLI's `analyze_path_with` now delegates to the source variant after reading the file.

## Test plan
- [x] `cargo test -p aver-lsp` — 25 + 1 new lens assertion pass
- [x] `cargo test --release --test shape_spec` — 11/11 pass (refactor preserves CLI behavior)
- [x] `cargo test --release --lib` — 671/671 pass
- [x] Manual: build aver-lsp binary, open redis.av in VS Code with the extension → lens appears above `module Redis`

🤖 Generated with [Claude Code](https://claude.com/claude-code)