### PR TITLE
shape: diagnostics drops recognition re-exports (#232 stage 2)

### DIFF
--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -23,9 +23,16 @@ use crate::ir::hir::{ResolvedFnDef, ResolvedTopLevel};
 use crate::ir::{FnId, PipelineConfig, TypecheckMode};
 use crate::types::Type;
 
-pub use crate::analysis::shape::{
-    ARCHETYPE_ORDER, Facts, classify, compute_sccs, extract_facts, primary_label, type_is_result,
-};
+// Recognition primitives moved to `aver::analysis::shape` in stage 1
+// (#232). Stage 2 drops the re-exports — callers import from
+// `analysis::shape` directly so the presentation tier doesn't double
+// as an API entry point for the recognition tier. This file holds
+// only the presentation surface from here on: `ModuleShape` vector +
+// `Kind` + Layer fingerprints + verify report + histogram + corpus
+// walker + renderers + `aver.toml` bridges. Internal use of the
+// recognition API in this file goes through `crate::analysis::shape`
+// directly (see imports below).
+use crate::analysis::shape::{Facts, classify, compute_sccs, extract_facts, primary_label};
 
 // ─── ModuleShape vector + derived Kind ───────────────────────────────────────
 

--- a/tests/research_archetype_clustering.rs
+++ b/tests/research_archetype_clustering.rs
@@ -22,8 +22,8 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use aver::analysis::shape::{Facts, classify, compute_sccs, extract_facts, primary_label};
 use aver::ast::TopLevel;
-use aver::diagnostics::shape::{Facts, classify, compute_sccs, extract_facts, primary_label};
 use aver::ir::hir::{ResolvedFnDef, ResolvedTopLevel};
 use aver::ir::{FnId, PipelineConfig, TypecheckMode};
 use aver::types::Type;


### PR DESCRIPTION
## Summary
Stage 2 of #232 (0.23 "Shape"). Stage 1 (#233) moved the recognition primitives into `aver::analysis::shape` while keeping re-exports in `diagnostics::shape` for compatibility. Stage 2 drops the re-exports and migrates the single outside consumer (the research test).

After this PR:

- **`aver::diagnostics::shape`** is purely a presentation tier — owns `ModuleShape` vector, `Kind`, Layer fingerprints, verify report, histogram, corpus walker, renderer, `aver.toml` bridges. Internal computation uses `crate::analysis::shape::{...}`, but doesn't re-surface those symbols upward.
- **External callers** (research test today; future inliner / monomorphizer / proof_lower routing in stages 4-6) import recognition directly from `aver::analysis::shape`.

Result: presentation vs recognition are now physically separated entry points. No single module owns both.

## Test plan
- [x] `cargo test --release --test shape_spec` — 14/14 (unchanged)
- [x] `cargo test --release --test shape_lint_cli_spec` — 3/3 (unchanged)
- [x] `cargo test --release --test research_archetype_clustering` builds + ignored
- [x] `cargo fmt --check` + `cargo clippy ... -D warnings` clean

## Next stage
String archetypes → typed enums (stage 3 of 6). Bigger mechanical diff — replaces `&'static str` archetype labels with a typed enum across the entire recognition pipeline. Strings only at rendering boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)