### PR TITLE
shape: typed Archetype enum (#232 stage 3)

### DIFF
--- a/src/analysis/shape.rs
+++ b/src/analysis/shape.rs
@@ -188,40 +188,40 @@ pub fn extract_facts(fd: &ResolvedFnDef) -> Facts {
 
 // ─── Per-fn classification ───────────────────────────────────────────────────
 
-pub fn classify(fd: &ResolvedFnDef, facts: &Facts, scc: &HashSet<FnId>) -> Vec<&'static str> {
+pub fn classify(fd: &ResolvedFnDef, facts: &Facts, scc: &HashSet<FnId>) -> Vec<Archetype> {
     let mut labels = Vec::new();
 
     let self_call = facts.calls_to.contains(&fd.fn_id) || facts.tail_calls.contains(&fd.fn_id);
     if self_call {
-        labels.push("structural-recursion");
+        labels.push(Archetype::StructuralRecursion);
     }
     if scc.contains(&fd.fn_id) {
-        labels.push("scc-mutual");
+        labels.push(Archetype::SccMutual);
     }
 
     if facts.last_stmt_is_match {
         if facts.ctor_match_patterns >= facts.other_match_patterns && facts.ctor_match_patterns > 0
         {
-            labels.push("match-dispatcher");
+            labels.push(Archetype::MatchDispatcher);
         } else {
-            labels.push("match-on-value");
+            labels.push(Archetype::MatchOnValue);
         }
     }
 
     if !fd.effects.is_empty() {
         let total_calls = facts.calls_to.len() + facts.builtin_calls.len();
         if total_calls >= 2 {
-            labels.push("orchestration");
+            labels.push(Archetype::Orchestration);
         } else {
-            labels.push("effectful-leaf");
+            labels.push(Archetype::EffectfulLeaf);
         }
     }
 
     let is_result_ret = type_is_result(&fd.return_type);
     if is_result_ret && facts.has_error_prop {
-        labels.push("pipeline-result");
+        labels.push(Archetype::PipelineResult);
     } else if is_result_ret && facts.has_match_with_err_arm {
-        labels.push("manual-result-adapter");
+        labels.push(Archetype::ManualResultAdapter);
     }
 
     let is_string_ret = matches!(&fd.return_type, Type::Named { name, .. } if name == "String");
@@ -230,14 +230,14 @@ pub fn classify(fd: &ResolvedFnDef, facts: &Facts, scc: &HashSet<FnId>) -> Vec<&
         && (facts.has_interp_str || facts.string_builtin_calls >= 1)
         && (facts.body_stmt_count >= 2 || facts.has_interp_str)
     {
-        labels.push("renderer-formatter");
+        labels.push(Archetype::RendererFormatter);
     }
 
     if facts.body_stmt_count == 1
         && (!facts.ctor_constructs.is_empty() || facts.record_creates > 0)
         && !facts.has_match
     {
-        labels.push("constructor-wrapper");
+        labels.push(Archetype::ConstructorWrapper);
     }
 
     if fd.params.is_empty()
@@ -246,7 +246,7 @@ pub fn classify(fd: &ResolvedFnDef, facts: &Facts, scc: &HashSet<FnId>) -> Vec<&
         && fd.effects.is_empty()
         && facts.only_stmt_is_literal
     {
-        labels.push("data-as-function");
+        labels.push(Archetype::DataAsFunction);
     }
 
     if facts.body_stmt_count == 1
@@ -255,7 +255,7 @@ pub fn classify(fd: &ResolvedFnDef, facts: &Facts, scc: &HashSet<FnId>) -> Vec<&
         && fd.effects.is_empty()
         && (!facts.builtin_calls.is_empty() || !facts.calls_to.is_empty())
     {
-        labels.push("trivial-helper");
+        labels.push(Archetype::TrivialHelper);
     }
 
     if facts.body_stmt_count == 1
@@ -267,7 +267,7 @@ pub fn classify(fd: &ResolvedFnDef, facts: &Facts, scc: &HashSet<FnId>) -> Vec<&
         && facts.ctor_constructs.is_empty()
         && !fd.params.is_empty()
     {
-        labels.push("pure-expression");
+        labels.push(Archetype::PureExpression);
     }
 
     if facts.body_stmt_count >= 2
@@ -276,7 +276,7 @@ pub fn classify(fd: &ResolvedFnDef, facts: &Facts, scc: &HashSet<FnId>) -> Vec<&
         && (!facts.builtin_calls.is_empty() || !facts.calls_to.is_empty())
         && !self_call
     {
-        labels.push("let-pipeline");
+        labels.push(Archetype::LetPipeline);
     }
 
     labels
@@ -286,30 +286,112 @@ pub fn type_is_result(t: &Type) -> bool {
     matches!(t, Type::Named { name, .. } if name == "Result")
 }
 
-pub const ARCHETYPE_ORDER: &[&str] = &[
-    "scc-mutual",
-    "structural-recursion",
-    "match-dispatcher",
-    "pipeline-result",
-    "manual-result-adapter",
-    "renderer-formatter",
-    "match-on-value",
-    "orchestration",
-    "effectful-leaf",
-    "let-pipeline",
-    "constructor-wrapper",
-    "data-as-function",
-    "trivial-helper",
-    "pure-expression",
-];
+/// Per-fn archetype label. Multi-label per fn — `classify` returns
+/// a `Vec<Archetype>`; `primary_label` picks one by the precedence
+/// declared in [`Archetype::all`]. Stringified only at presentation
+/// boundaries (renderer, JSON, LSP hover).
+///
+/// Stage 3 of #232 ("Shape") replaced the prior `&'static str`-keyed
+/// representation with this typed enum. The string forms are still
+/// the public JSON / text contract; `as_str` / `parse` translate
+/// at the edges.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Archetype {
+    SccMutual,
+    StructuralRecursion,
+    MatchDispatcher,
+    PipelineResult,
+    ManualResultAdapter,
+    RendererFormatter,
+    MatchOnValue,
+    Orchestration,
+    EffectfulLeaf,
+    LetPipeline,
+    ConstructorWrapper,
+    DataAsFunction,
+    TrivialHelper,
+    PureExpression,
+    /// Fallback for fn bodies that don't match any classifier rule.
+    /// Surfaces as `"unclassified"` in JSON / text output.
+    Unclassified,
+}
 
-pub fn primary_label(labels: &[&str]) -> &'static str {
-    for &want in ARCHETYPE_ORDER {
+impl Archetype {
+    /// Precedence-ordered list. `primary_label` walks this in order;
+    /// the first archetype that fires on a fn wins. Renderers also
+    /// use this for histogram tie-breaking.
+    pub fn all() -> &'static [Archetype] {
+        &[
+            Archetype::SccMutual,
+            Archetype::StructuralRecursion,
+            Archetype::MatchDispatcher,
+            Archetype::PipelineResult,
+            Archetype::ManualResultAdapter,
+            Archetype::RendererFormatter,
+            Archetype::MatchOnValue,
+            Archetype::Orchestration,
+            Archetype::EffectfulLeaf,
+            Archetype::LetPipeline,
+            Archetype::ConstructorWrapper,
+            Archetype::DataAsFunction,
+            Archetype::TrivialHelper,
+            Archetype::PureExpression,
+        ]
+    }
+
+    /// Canonical kebab-case label. Used by renderers, JSON, hover.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Archetype::SccMutual => "scc-mutual",
+            Archetype::StructuralRecursion => "structural-recursion",
+            Archetype::MatchDispatcher => "match-dispatcher",
+            Archetype::PipelineResult => "pipeline-result",
+            Archetype::ManualResultAdapter => "manual-result-adapter",
+            Archetype::RendererFormatter => "renderer-formatter",
+            Archetype::MatchOnValue => "match-on-value",
+            Archetype::Orchestration => "orchestration",
+            Archetype::EffectfulLeaf => "effectful-leaf",
+            Archetype::LetPipeline => "let-pipeline",
+            Archetype::ConstructorWrapper => "constructor-wrapper",
+            Archetype::DataAsFunction => "data-as-function",
+            Archetype::TrivialHelper => "trivial-helper",
+            Archetype::PureExpression => "pure-expression",
+            Archetype::Unclassified => "unclassified",
+        }
+    }
+
+    /// Parse a string back into the typed form. Used by callers that
+    /// receive the public JSON shape and want to operate on the typed
+    /// enum (e.g. the research test reading per-folder histograms).
+    pub fn parse(s: &str) -> Option<Archetype> {
+        Some(match s {
+            "scc-mutual" => Archetype::SccMutual,
+            "structural-recursion" => Archetype::StructuralRecursion,
+            "match-dispatcher" => Archetype::MatchDispatcher,
+            "pipeline-result" => Archetype::PipelineResult,
+            "manual-result-adapter" => Archetype::ManualResultAdapter,
+            "renderer-formatter" => Archetype::RendererFormatter,
+            "match-on-value" => Archetype::MatchOnValue,
+            "orchestration" => Archetype::Orchestration,
+            "effectful-leaf" => Archetype::EffectfulLeaf,
+            "let-pipeline" => Archetype::LetPipeline,
+            "constructor-wrapper" => Archetype::ConstructorWrapper,
+            "data-as-function" => Archetype::DataAsFunction,
+            "trivial-helper" => Archetype::TrivialHelper,
+            "pure-expression" => Archetype::PureExpression,
+            "unclassified" => Archetype::Unclassified,
+            _ => return None,
+        })
+    }
+}
+
+pub fn primary_label(labels: &[Archetype]) -> Archetype {
+    for &want in Archetype::all() {
         if labels.contains(&want) {
             return want;
         }
     }
-    "unclassified"
+    Archetype::Unclassified
 }
 
 // ─── Call-graph SCC (multi-node strongly connected components) ───────────────

--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -32,7 +32,9 @@ use crate::types::Type;
 // walker + renderers + `aver.toml` bridges. Internal use of the
 // recognition API in this file goes through `crate::analysis::shape`
 // directly (see imports below).
-use crate::analysis::shape::{Facts, classify, compute_sccs, extract_facts, primary_label};
+use crate::analysis::shape::{
+    Archetype, Facts, classify, compute_sccs, extract_facts, primary_label,
+};
 
 // ─── ModuleShape vector + derived Kind ───────────────────────────────────────
 
@@ -145,7 +147,7 @@ impl ApiShape {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Kind {
     PureHelpers,
     DataModule,
@@ -290,28 +292,28 @@ pub struct VerifyReport {
 
 #[derive(Debug, Clone, Default)]
 pub struct Histogram {
-    pub counts: BTreeMap<&'static str, usize>,
+    pub counts: BTreeMap<Archetype, usize>,
     pub total_fns: usize,
 }
 
 impl Histogram {
-    pub fn percentage(&self, archetype: &str) -> f64 {
+    pub fn percentage(&self, archetype: Archetype) -> f64 {
         if self.total_fns == 0 {
             return 0.0;
         }
-        let c = self.counts.get(archetype).copied().unwrap_or(0) as f64;
+        let c = self.counts.get(&archetype).copied().unwrap_or(0) as f64;
         100.0 * c / self.total_fns as f64
     }
 
     /// Returns archetype-percentage pairs in descending count order.
-    pub fn sorted(&self) -> Vec<(&'static str, usize, f64)> {
-        let mut entries: Vec<(&'static str, usize)> = self
+    pub fn sorted(&self) -> Vec<(Archetype, usize, f64)> {
+        let mut entries: Vec<(Archetype, usize)> = self
             .counts
             .iter()
             .filter(|(_, c)| **c > 0)
             .map(|(k, c)| (*k, *c))
             .collect();
-        entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.as_str().cmp(b.0.as_str())));
         entries
             .into_iter()
             .map(|(name, count)| {
@@ -397,18 +399,20 @@ impl Bucket {
     }
 }
 
-pub fn archetype_to_bucket(archetype: &str) -> Option<Bucket> {
+pub fn archetype_to_bucket(archetype: Archetype) -> Option<Bucket> {
     match archetype {
-        "match-dispatcher" | "match-on-value" => Some(Bucket::Match),
-        "scc-mutual" | "structural-recursion" => Some(Bucket::Recursion),
-        "pipeline-result" | "let-pipeline" | "manual-result-adapter" => Some(Bucket::Pipeline),
-        "orchestration" | "effectful-leaf" => Some(Bucket::Orchestration),
-        "trivial-helper"
-        | "pure-expression"
-        | "constructor-wrapper"
-        | "data-as-function"
-        | "renderer-formatter" => Some(Bucket::Helpers),
-        _ => None,
+        Archetype::MatchDispatcher | Archetype::MatchOnValue => Some(Bucket::Match),
+        Archetype::SccMutual | Archetype::StructuralRecursion => Some(Bucket::Recursion),
+        Archetype::PipelineResult | Archetype::LetPipeline | Archetype::ManualResultAdapter => {
+            Some(Bucket::Pipeline)
+        }
+        Archetype::Orchestration | Archetype::EffectfulLeaf => Some(Bucket::Orchestration),
+        Archetype::TrivialHelper
+        | Archetype::PureExpression
+        | Archetype::ConstructorWrapper
+        | Archetype::DataAsFunction
+        | Archetype::RendererFormatter => Some(Bucket::Helpers),
+        Archetype::Unclassified => None,
     }
 }
 
@@ -489,7 +493,7 @@ fn histogram_to_buckets(hist: &Histogram) -> [(Bucket, f64); 5] {
     use Bucket::*;
     let mut counts: HashMap<Bucket, usize> = HashMap::new();
     for (arch, c) in &hist.counts {
-        if let Some(b) = archetype_to_bucket(arch) {
+        if let Some(b) = archetype_to_bucket(*arch) {
             *counts.entry(b).or_insert(0) += c;
         }
     }
@@ -600,8 +604,8 @@ pub fn classify_layer(
 #[derive(Debug, Clone)]
 pub struct FnShape {
     pub name: String,
-    pub primary: &'static str,
-    pub labels: Vec<&'static str>,
+    pub primary: Archetype,
+    pub labels: Vec<Archetype>,
 }
 
 #[derive(Debug, Clone)]
@@ -1028,7 +1032,7 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
         let sorted = report.histogram.sorted();
         let name_w = sorted
             .iter()
-            .map(|(n, _, _)| n.len())
+            .map(|(n, _, _)| n.as_str().len())
             .max()
             .unwrap_or(0)
             .max(20);
@@ -1036,7 +1040,7 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
             let bar = histogram_bar(*pct, 20);
             out.push_str(&format!(
                 "    {:<width$}  {}  {:>3.0}%  ({})\n",
-                name,
+                name.as_str(),
                 bar,
                 pct,
                 count,
@@ -1089,11 +1093,14 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
             .unwrap_or(0)
             .max(16);
         for f in &report.fns {
-            let labels: Vec<&str> = f.labels.to_vec();
-            let labels_str = if labels.is_empty() {
+            let labels_str = if f.labels.is_empty() {
                 "unclassified".to_string()
             } else {
-                labels.join(", ")
+                f.labels
+                    .iter()
+                    .map(|a| a.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             };
             out.push_str(&format!(
                 "    {:<width$}  {}\n",
@@ -1143,17 +1150,18 @@ pub fn render_json(report: &ShapeReport) -> serde_json::Value {
         .counts
         .iter()
         .filter(|(_, c)| **c > 0)
-        .map(|(k, c)| (k.to_string(), serde_json::Value::from(*c)))
+        .map(|(k, c)| (k.as_str().to_string(), serde_json::Value::from(*c)))
         .collect::<serde_json::Map<_, _>>()
         .into();
     let fns: Vec<serde_json::Value> = report
         .fns
         .iter()
         .map(|f| {
+            let labels: Vec<&str> = f.labels.iter().map(|a| a.as_str()).collect();
             json!({
                 "name": f.name,
-                "primary": f.primary,
-                "labels": f.labels,
+                "primary": f.primary.as_str(),
+                "labels": labels,
             })
         })
         .collect();
@@ -1295,9 +1303,9 @@ pub struct CorpusSummary {
     pub analyzed_files: usize,
     pub skipped_files: usize,
     pub total_fns: usize,
-    pub kind_counts: BTreeMap<&'static str, usize>,
-    pub layer_counts: BTreeMap<&'static str, usize>,
-    pub archetype_counts: BTreeMap<&'static str, usize>,
+    pub kind_counts: BTreeMap<Kind, usize>,
+    pub layer_counts: BTreeMap<Layer, usize>,
+    pub archetype_counts: BTreeMap<Archetype, usize>,
 }
 
 pub fn summarize_corpus(entries: &[CorpusEntry]) -> CorpusSummary {
@@ -1310,12 +1318,12 @@ pub fn summarize_corpus(entries: &[CorpusEntry]) -> CorpusSummary {
             CorpusEntry::Analyzed { report, .. } => {
                 s.analyzed_files += 1;
                 s.total_fns += report.histogram.total_fns;
-                *s.kind_counts.entry(report.kind.as_str()).or_insert(0) += 1;
+                *s.kind_counts.entry(report.kind).or_insert(0) += 1;
                 if let Some(v) = &report.layer {
-                    *s.layer_counts.entry(v.layer.as_str()).or_insert(0) += 1;
+                    *s.layer_counts.entry(v.layer).or_insert(0) += 1;
                 }
                 for (arch, c) in &report.histogram.counts {
-                    *s.archetype_counts.entry(arch).or_insert(0) += c;
+                    *s.archetype_counts.entry(*arch).or_insert(0) += c;
                 }
             }
             CorpusEntry::Skipped { .. } => {
@@ -1401,7 +1409,7 @@ pub fn render_corpus_text(entries: &[CorpusEntry], opts: &RenderOptions) -> Stri
         let mut kinds: Vec<_> = summary.kind_counts.iter().collect();
         kinds.sort_by(|a, b| b.1.cmp(a.1));
         for (kind, count) in kinds {
-            out.push_str(&format!("    {:<24}  {}\n", kind, count));
+            out.push_str(&format!("    {:<24}  {}\n", kind.as_str(), count));
         }
     }
     if !summary.layer_counts.is_empty() {
@@ -1409,7 +1417,7 @@ pub fn render_corpus_text(entries: &[CorpusEntry], opts: &RenderOptions) -> Stri
         let mut layers: Vec<_> = summary.layer_counts.iter().collect();
         layers.sort_by(|a, b| b.1.cmp(a.1));
         for (layer, count) in layers {
-            out.push_str(&format!("    {:<24}  {}\n", layer, count));
+            out.push_str(&format!("    {:<24}  {}\n", layer.as_str(), count));
         }
     }
     if !summary.archetype_counts.is_empty() {
@@ -1422,7 +1430,7 @@ pub fn render_corpus_text(entries: &[CorpusEntry], opts: &RenderOptions) -> Stri
         archs.sort_by(|a, b| b.1.cmp(a.1));
         let name_w = archs
             .iter()
-            .map(|(n, _)| n.len())
+            .map(|(n, _)| n.as_str().len())
             .max()
             .unwrap_or(0)
             .max(20);
@@ -1435,7 +1443,7 @@ pub fn render_corpus_text(entries: &[CorpusEntry], opts: &RenderOptions) -> Stri
             let bar = histogram_bar(pct, 20);
             out.push_str(&format!(
                 "    {:<width$}  {}  {:>3.0}%  ({})\n",
-                arch,
+                arch.as_str(),
                 bar,
                 pct,
                 count,

--- a/tests/research_archetype_clustering.rs
+++ b/tests/research_archetype_clustering.rs
@@ -22,7 +22,9 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use aver::analysis::shape::{Facts, classify, compute_sccs, extract_facts, primary_label};
+use aver::analysis::shape::{
+    Archetype, Facts, classify, compute_sccs, extract_facts, primary_label,
+};
 use aver::ast::TopLevel;
 use aver::ir::hir::{ResolvedFnDef, ResolvedTopLevel};
 use aver::ir::{FnId, PipelineConfig, TypecheckMode};
@@ -40,8 +42,8 @@ struct FnRecord {
     fn_id: FnId,
     param_count: usize,
     verify_count: usize,
-    primary: &'static str,
-    labels: Vec<&'static str>,
+    primary: Archetype,
+    labels: Vec<Archetype>,
     calls_to: HashSet<FnId>,
     /// All param types — for accumulator semantic-significance check
     /// in the seeded-driver pair analysis.
@@ -181,8 +183,8 @@ fn research_archetype_clustering_full_corpus() {
     use std::collections::BTreeMap;
 
     // ── Sec 1: primary archetype distribution ─────────────────────────
-    let mut primary_counts: BTreeMap<&'static str, usize> = BTreeMap::new();
-    let mut label_counts: BTreeMap<&'static str, usize> = BTreeMap::new();
+    let mut primary_counts: BTreeMap<Archetype, usize> = BTreeMap::new();
+    let mut label_counts: BTreeMap<Archetype, usize> = BTreeMap::new();
     for r in &all_files {
         for f in &r.fns {
             *primary_counts.entry(f.primary).or_insert(0) += 1;
@@ -198,7 +200,7 @@ fn research_archetype_clustering_full_corpus() {
     for (l, c) in &sorted_p {
         eprintln!(
             "  {:30} {:5}  {:5.1}%",
-            l,
+            l.as_str(),
             c,
             100.0 * (**c as f64) / (total_fns.max(1) as f64)
         );
@@ -207,7 +209,7 @@ fn research_archetype_clustering_full_corpus() {
     // ── H2: Verify density per archetype ──────────────────────────────
     eprintln!();
     eprintln!("# H2: Verify density per primary archetype (cases / fn)");
-    let mut verify_sum: BTreeMap<&'static str, (usize, usize)> = BTreeMap::new(); // (verify_total, fn_total)
+    let mut verify_sum: BTreeMap<Archetype, (usize, usize)> = BTreeMap::new(); // (verify_total, fn_total)
     for r in &all_files {
         for f in &r.fns {
             let entry = verify_sum.entry(f.primary).or_insert((0, 0));
@@ -225,7 +227,10 @@ fn research_archetype_clustering_full_corpus() {
         let density = (*v as f64) / (*n as f64).max(1.0);
         eprintln!(
             "  {:30} {:5.2} verify/fn  ({} cases over {} fns)",
-            label, density, v, n
+            label.as_str(),
+            density,
+            v,
+            n
         );
     }
 
@@ -291,7 +296,7 @@ fn research_archetype_clustering_full_corpus() {
         let entry = pe_per_root.entry(top).or_insert((0, 0));
         for f in &r.fns {
             entry.1 += 1;
-            if f.primary == "pure-expression" {
+            if f.primary == Archetype::PureExpression {
                 entry.0 += 1;
             }
         }
@@ -313,13 +318,13 @@ fn research_archetype_clustering_full_corpus() {
     // ── H3: Call graph between archetypes ─────────────────────────────
     eprintln!();
     eprintln!("# H3: Call graph — caller archetype → callee archetype (raw counts)");
-    let mut fn_archetype: HashMap<FnId, &'static str> = HashMap::new();
+    let mut fn_archetype: HashMap<FnId, Archetype> = HashMap::new();
     for r in &all_files {
         for f in &r.fns {
             fn_archetype.insert(f.fn_id, f.primary);
         }
     }
-    let mut edge_counts: BTreeMap<(&'static str, &'static str), usize> = BTreeMap::new();
+    let mut edge_counts: BTreeMap<(Archetype, Archetype), usize> = BTreeMap::new();
     for r in &all_files {
         for f in &r.fns {
             for callee_id in &f.calls_to {
@@ -333,12 +338,12 @@ fn research_archetype_clustering_full_corpus() {
     // Header
     eprint!("  {:>26} |", "caller↓ / callee→");
     for a in archs.iter() {
-        eprint!(" {:>4}", abbrev(a));
+        eprint!(" {:>4}", abbrev(*a));
     }
     eprintln!();
     eprintln!("  {:>26}-+{}", "", "-----".repeat(archs.len()));
     for caller in archs.iter() {
-        eprint!("  {:>26} |", caller);
+        eprint!("  {:>26} |", caller.as_str());
         for callee in archs.iter() {
             let v = edge_counts.get(&(*caller, *callee)).copied().unwrap_or(0);
             if v == 0 {
@@ -354,7 +359,7 @@ fn research_archetype_clustering_full_corpus() {
     eprintln!();
     eprintln!("# H1: Layer × archetype Z-scores (deviation from corpus-wide mean rate)");
     eprintln!("#     z > 2 means archetype is over-represented in that layer.");
-    let mut per_folder: BTreeMap<String, BTreeMap<&'static str, usize>> = BTreeMap::new();
+    let mut per_folder: BTreeMap<String, BTreeMap<Archetype, usize>> = BTreeMap::new();
     let mut per_folder_totals: BTreeMap<String, usize> = BTreeMap::new();
     for r in &all_files {
         let top = r.folder.split('/').next().unwrap_or(&r.folder).to_string();
@@ -366,7 +371,7 @@ fn research_archetype_clustering_full_corpus() {
     }
     eprint!("  {:>15} |", "layer ↓");
     for a in archs.iter() {
-        eprint!(" {:>5}", abbrev(a));
+        eprint!(" {:>5}", abbrev(*a));
     }
     eprintln!();
     eprintln!("  {:>15}-+{}", "", "------".repeat(archs.len()));
@@ -397,7 +402,7 @@ fn research_archetype_clustering_full_corpus() {
     // ── Per-folder primary top-3 (qualitative anchor) ─────────────────
     eprintln!();
     eprintln!("# Per-folder primary top-3 (qualitative anchor)");
-    let mut folder_top: BTreeMap<String, BTreeMap<&'static str, usize>> = BTreeMap::new();
+    let mut folder_top: BTreeMap<String, BTreeMap<Archetype, usize>> = BTreeMap::new();
     for r in &all_files {
         let top = r.folder.split('/').next().unwrap_or(&r.folder).to_string();
         let entry = folder_top.entry(top).or_default();
@@ -412,7 +417,7 @@ fn research_archetype_clustering_full_corpus() {
         let top3 = top
             .iter()
             .take(3)
-            .map(|(l, c)| format!("{}={}", l, c))
+            .map(|(l, c)| format!("{}={}", l.as_str(), c))
             .collect::<Vec<_>>()
             .join(", ");
         eprintln!("  {:30} (n={:4}) {}", folder, total, top3);
@@ -528,36 +533,36 @@ fn short_type_name(ty: &Type) -> String {
     }
 }
 
-fn primary_label_order() -> &'static [&'static str] {
+fn primary_label_order() -> &'static [Archetype] {
     &[
-        "scc-mutual",
-        "structural-recursion",
-        "match-dispatcher",
-        "match-on-value",
-        "orchestration",
-        "let-pipeline",
-        "constructor-wrapper",
-        "trivial-helper",
-        "pure-expression",
-        "effectful-leaf",
-        "data-as-function",
+        Archetype::SccMutual,
+        Archetype::StructuralRecursion,
+        Archetype::MatchDispatcher,
+        Archetype::MatchOnValue,
+        Archetype::Orchestration,
+        Archetype::LetPipeline,
+        Archetype::ConstructorWrapper,
+        Archetype::TrivialHelper,
+        Archetype::PureExpression,
+        Archetype::EffectfulLeaf,
+        Archetype::DataAsFunction,
     ]
 }
 
-fn abbrev(label: &str) -> &str {
+fn abbrev(label: Archetype) -> &'static str {
     match label {
-        "scc-mutual" => "scc",
-        "structural-recursion" => "rec",
-        "match-dispatcher" => "mD",
-        "match-on-value" => "mV",
-        "orchestration" => "orch",
-        "let-pipeline" => "let",
-        "constructor-wrapper" => "ctor",
-        "trivial-helper" => "triv",
-        "pure-expression" => "pure",
-        "effectful-leaf" => "leaf",
-        "data-as-function" => "data",
-        _ => label,
+        Archetype::SccMutual => "scc",
+        Archetype::StructuralRecursion => "rec",
+        Archetype::MatchDispatcher => "mD",
+        Archetype::MatchOnValue => "mV",
+        Archetype::Orchestration => "orch",
+        Archetype::LetPipeline => "let",
+        Archetype::ConstructorWrapper => "ctor",
+        Archetype::TrivialHelper => "triv",
+        Archetype::PureExpression => "pure",
+        Archetype::EffectfulLeaf => "leaf",
+        Archetype::DataAsFunction => "data",
+        _ => label.as_str(),
     }
 }
 


### PR DESCRIPTION
## Summary
Stage 3 of #232 (0.23 "Shape"). String-keyed archetypes (`&'static str`) become a typed `Archetype` enum. Strings stay the public contract (JSON / text / LSP); `Archetype::as_str` / `Archetype::parse` translate at the boundary. Internal call paths operate on the typed form — exhaustive matches catch missing cases on any new variant.

## Touched APIs (internal — public JSON/text unchanged)
- `aver::analysis::shape::Archetype` — typed enum, 14 + `Unclassified`. `Archetype::all()` replaces the `ARCHETYPE_ORDER` constant.
- `classify(...)` returns `Vec<Archetype>`, `primary_label(...)` returns `Archetype`.
- `diagnostics::shape::Histogram::counts` keyed by `Archetype`; `FnShape::{primary, labels}` typed; `archetype_to_bucket(Archetype)` exhaustive; `CorpusSummary::{kind_counts, layer_counts, archetype_counts}` keyed by typed enums (Kind + Layer gained `Hash`, `Ord`).
- Renderers convert at format boundary via `.as_str()`.
- Research test migrated end-to-end.

## Test plan
- [x] `cargo test --release --test shape_spec` — 14/14 (unchanged)
- [x] `cargo test --release --test shape_lint_cli_spec` — 3/3 (unchanged)
- [x] `cargo test --release --test research_archetype_clustering -- --ignored` — runs to completion (2521 fns surveyed, output unchanged)
- [x] `cargo fmt --check` + workspace + aver-lang clippy `-D warnings` clean

## Next
Stage 4 — `ProgramShape` as pipeline input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)