### PR TITLE
shape: ProgramShape — recognition substrate as a separate view (#232 stage 4)

### DIFF
--- a/src/analysis/shape.rs
+++ b/src/analysis/shape.rs
@@ -482,3 +482,82 @@ pub fn compute_sccs(fns: &[&ResolvedFnDef], facts_by_id: &HashMap<FnId, &Facts>)
     }
     multi_scc
 }
+
+// ─── Program-level shape (stage 4 of #232) ───────────────────────────────────
+
+/// Per-fn recognition output: precedence-picked primary archetype +
+/// the full multi-label set the classifier fired on.
+///
+/// Facts (the AST walker output) intentionally don't escape here —
+/// they're cheap to recompute if a future consumer wants them, and
+/// keeping the `ProgramShape` value small means downstream passes
+/// (proof_lower, future inliner / monomorphizer) can clone it freely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FnRecognition {
+    pub primary: Archetype,
+    pub labels: Vec<Archetype>,
+}
+
+/// Whole-program shape facts produced by [`analyze_program`].
+///
+/// Stage 4 of issue #232 (0.23 "Shape"). This is the *recognition*
+/// substrate every downstream consumer reads from — `aver shape` CLI,
+/// proof_lower's strategy router, future inliner / monomorphizer.
+/// Stage 6 will grow `patterns: Vec<ModulePattern>` and
+/// `relations: Vec<FnRelation>` next to `per_fn` for the higher-arity
+/// recognitions (`WrapperOverRecursion`, `RefinementSmartConstructor`,
+/// `ResultPipelineChain`, …).
+///
+/// Computed once per compilation per the peer-review note ("compute
+/// ProgramShape once per compilation / per HIR snapshot — don't
+/// persistent-cache per FnId yet"). Threaded as a read-only borrow
+/// from the call site; the analysis tier never mutates it.
+#[derive(Debug, Clone, Default)]
+pub struct ProgramShape {
+    /// Per-fn recognition keyed by stable `FnId`.
+    pub per_fn: std::collections::HashMap<FnId, FnRecognition>,
+    /// Multi-node SCC participants in the local call graph. Kept here
+    /// so consumers don't have to recompute Tarjan to ask
+    /// "is this fn part of a mutual-recursion group?".
+    pub sccs: HashSet<FnId>,
+}
+
+impl ProgramShape {
+    /// Recognition for one fn by id. Returns `None` for fns that
+    /// weren't included in the call to [`analyze_program`] (e.g. an
+    /// out-of-tree id or a stale lookup against a refreshed view).
+    pub fn for_fn(&self, fn_id: FnId) -> Option<&FnRecognition> {
+        self.per_fn.get(&fn_id)
+    }
+}
+
+/// Build a [`ProgramShape`] over the post-resolver fn snapshot in one
+/// pass. Caller picks which fns participate (typically every
+/// `ResolvedTopLevel::FnDef` of the entry module, sometimes plus
+/// dep-module fns when a cross-module analysis needs the broader
+/// view).
+///
+/// Two-pass internally: facts first (needed to build the call graph
+/// for SCC detection), then classify with the facts + SCC ready.
+/// `O(N)` over fn bodies, `O(N+E)` Tarjan over the call graph; the
+/// per-compilation cache budget the peer-review pinned.
+pub fn analyze_program(resolved_fns: &[&ResolvedFnDef]) -> ProgramShape {
+    let mut facts_by_id: std::collections::HashMap<FnId, Facts> =
+        std::collections::HashMap::with_capacity(resolved_fns.len());
+    for fd in resolved_fns {
+        facts_by_id.insert(fd.fn_id, extract_facts(fd));
+    }
+    let facts_refs: std::collections::HashMap<FnId, &Facts> =
+        facts_by_id.iter().map(|(k, v)| (*k, v)).collect();
+    let sccs = compute_sccs(resolved_fns, &facts_refs);
+
+    let mut per_fn = std::collections::HashMap::with_capacity(resolved_fns.len());
+    for fd in resolved_fns {
+        let facts = &facts_by_id[&fd.fn_id];
+        let labels = classify(fd, facts, &sccs);
+        let primary = primary_label(&labels);
+        per_fn.insert(fd.fn_id, FnRecognition { primary, labels });
+    }
+
+    ProgramShape { per_fn, sccs }
+}

--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 
 use crate::ast::TopLevel;
 use crate::ir::hir::{ResolvedFnDef, ResolvedTopLevel};
-use crate::ir::{FnId, PipelineConfig, TypecheckMode};
+use crate::ir::{PipelineConfig, TypecheckMode};
 use crate::types::Type;
 
 // Recognition primitives moved to `aver::analysis::shape` in stage 1
@@ -32,9 +32,7 @@ use crate::types::Type;
 // walker + renderers + `aver.toml` bridges. Internal use of the
 // recognition API in this file goes through `crate::analysis::shape`
 // directly (see imports below).
-use crate::analysis::shape::{
-    Archetype, Facts, classify, compute_sccs, extract_facts, primary_label,
-};
+use crate::analysis::shape::{Archetype, analyze_program};
 
 // ─── ModuleShape vector + derived Kind ───────────────────────────────────────
 
@@ -742,12 +740,12 @@ pub fn analyze_source_with(
         })
         .collect();
 
-    let mut facts_by_id: HashMap<FnId, Facts> = HashMap::new();
-    for fd in &resolved_fns {
-        facts_by_id.insert(fd.fn_id, extract_facts(fd));
-    }
-    let facts_refs: HashMap<FnId, &Facts> = facts_by_id.iter().map(|(k, v)| (*k, v)).collect();
-    let scc = compute_sccs(&resolved_fns, &facts_refs);
+    // Stage 4 of #232: recognition substrate. `analyze_program` runs
+    // facts walk + SCC + classify in one go and returns the per-fn
+    // ProgramShape. Presentation tier (this fn) just adds the
+    // module-level Kind / verify / histogram / Layer scaffolding on
+    // top — the actual per-fn recognition no longer lives here.
+    let program_shape = analyze_program(&resolved_fns);
 
     let exposes_set: HashSet<&str> = exposes.iter().map(|s| s.as_str()).collect();
     let mut fn_shapes = Vec::with_capacity(resolved_fns.len());
@@ -774,9 +772,11 @@ pub fn analyze_source_with(
                 exposed_uses_handle = true;
             }
         }
-        let facts = &facts_by_id[&fd.fn_id];
-        let labels = classify(fd, facts, &scc);
-        let primary = primary_label(&labels);
+        let recognition = program_shape
+            .for_fn(fd.fn_id)
+            .expect("analyze_program populates per_fn for every resolved fn");
+        let primary = recognition.primary;
+        let labels = recognition.labels.clone();
         if fd.name != "main" {
             *histogram.counts.entry(primary).or_insert(0) += 1;
             histogram.total_fns += 1;


### PR DESCRIPTION
## Summary
Stage 4 of #232 (0.23 "Shape"). Adds `ProgramShape` — the program-level recognition substrate every downstream consumer reads from.

```rust
pub struct ProgramShape {
    pub per_fn: HashMap<FnId, FnRecognition>,
    pub sccs: HashSet<FnId>,
}

pub struct FnRecognition {
    pub primary: Archetype,
    pub labels: Vec<Archetype>,
}

pub fn analyze_program(resolved_fns: &[&ResolvedFnDef]) -> ProgramShape;
```

## Separate view, not annotations
Explicit choice (per architectural discussion): shape is the **output** of analysis over HIR, not a field of HIR. Annotations on `ResolvedFnDef` would:
- couple IR struct to recognition concepts
- risk stale state when a pass mutates the fn but forgets to invalidate shape
- force every analysis (call graph, escape, future inliner facts) to grow the struct

Separate view: each analysis ships its own typed substrate, consumers ask for what they want.

## First consumer migrated
`diagnostics::shape::analyze_path_with` now calls `analyze_program` instead of running `extract_facts` / SCC / `classify` / `primary_label` inline. Presentation tier still adds Kind / verify / histogram / Layer on top — but doesn't redo the recognition.

## Compute once per compilation
Per peer-review pin: build `ProgramShape` once, pass by reference. No per-FnId persistent cache — invalidation would outrun the pass.

## Test plan
- [x] `cargo test --release --test shape_spec` — 14/14 unchanged
- [x] `cargo test --release --test shape_lint_cli_spec` — 3/3 unchanged
- [x] `cargo test --release --test research_archetype_clustering` builds + ignored
- [x] `cargo fmt --check` + workspace + aver-lang clippy `-D warnings` clean

## Next
Stage 5: migrate `proof_lower::classify_law_strategy` detectors (self-call, match-dispatcher, Result-return-wrap, `refinement_info_for`) to read from `ProgramShape`. Each detector its own PR with strategy-snapshot tests guarding against routing regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)