### PR TITLE
shape: route is_directly_recursive through ProgramShape (#232 stage 5a)

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -2807,6 +2807,7 @@ mod tests {
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
+            program_shape: None,
         };
         ctx.proof_ir
             .refined_types

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -802,7 +802,27 @@ fn law_top_level_fn(expr: &Spanned<Expr>) -> Option<String> {
 }
 
 /// Check if a function is directly recursive (calls itself in its own body).
+///
+/// Stage 5 of #232: routes through `ctx.program_shape` when available
+/// (set by `build_context`), reading the typed `Archetype::StructuralRecursion`
+/// label that `analyze_program` already computed once. Falls back to
+/// the legacy AST-walk path when `program_shape` is `None` (test
+/// harnesses that bypass `build_context`).
+///
+/// Both paths must agree on every existing law's pinned ProofStrategy;
+/// the snapshot-style proof tests in `tests/proof_spec.rs` cover
+/// that invariant.
 fn is_directly_recursive(fn_name: &str, ctx: &CodegenContext) -> bool {
+    if let Some(shape) = ctx.program_shape.as_ref()
+        && let Some(fd) = ctx.resolved_program.fn_by_name(fn_name)
+        && let Some(recognition) = shape.for_fn(fd.fn_id)
+    {
+        return recognition
+            .labels
+            .contains(&crate::analysis::shape::Archetype::StructuralRecursion);
+    }
+    // Legacy fallback: walks the typed AST. Kept for ctx-by-hand
+    // test setups; production paths route through shape.
     ctx.fn_defs
         .iter()
         .any(|fd| fd.name == fn_name && body_has_recursive_call(&fd.body, &fd.name))

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -206,6 +206,7 @@ mod tests {
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
+            program_shape: None,
         }
     }
 

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1581,6 +1581,7 @@ mod tests {
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
+            program_shape: None,
         }
     }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -262,6 +262,15 @@ pub struct CodegenContext {
     /// their primary input; this field is the foundation those PRs
     /// build on.
     pub resolved_program: crate::codegen::program_view::ResolvedProgramView,
+    /// Whole-program shape facts — typed Archetype labels + call-graph
+    /// SCC per `FnId`. Computed once per compilation by
+    /// [`analyze_program`](crate::analysis::shape::analyze_program) at
+    /// `build_context` time. Stage 5+ of #232 (0.23 "Shape") migrates
+    /// ad-hoc fn-shape detectors in proof codegen to read this instead
+    /// of rewalking the AST. `None` only for tests that assemble the
+    /// ctx by hand without calling `build_context`; downstream callers
+    /// should treat that as opt-out (preserve legacy detection path).
+    pub program_shape: Option<crate::analysis::shape::ProgramShape>,
 }
 
 /// Output files from a codegen backend.
@@ -508,6 +517,22 @@ pub fn build_context(
         resolved_fn_defs,
         resolved_module_fn_defs,
         current_module_scope: std::cell::RefCell::new(None),
+        program_shape: {
+            // Build once per compilation; downstream codegen reads
+            // `Archetype::StructuralRecursion` etc. instead of
+            // rewalking the AST. Covers entry-module fns first;
+            // dep-module fns get included so cross-module law
+            // routing (Stage 5+) can ask shape questions about
+            // callees declared in other files.
+            let mut all_fns: Vec<&crate::ir::hir::ResolvedFnDef> =
+                resolved_program.entry_fns().collect();
+            for m in &resolved_program.modules {
+                for fd in &m.fn_defs {
+                    all_fns.push(fd);
+                }
+            }
+            Some(crate::analysis::shape::analyze_program(&all_fns))
+        },
         resolved_program,
     };
     // ProofIR no longer populated here. Pipeline owns the lowerings

--- a/src/codegen/program_view.rs
+++ b/src/codegen/program_view.rs
@@ -248,6 +248,32 @@ impl ResolvedProgramView {
             Some(i) => self.modules.get(i)?.fn_defs.get(entry.pos),
         }
     }
+
+    /// First fn (entry first, then dep modules in declaration order)
+    /// whose source-level name matches. Stage 5+ of #232 uses this to
+    /// bridge ad-hoc detectors that historically searched by string
+    /// name (`is_directly_recursive` in dafny codegen) into the typed
+    /// `FnId`-keyed `ProgramShape`. Returns `None` if no such fn
+    /// exists in the resolved view.
+    ///
+    /// Note: bare-name lookup is ambiguous when the same name lives
+    /// in two dep modules. Entry-first ordering matches what the
+    /// legacy string-name detectors already assumed.
+    pub fn fn_by_name(&self, name: &str) -> Option<&ResolvedFnDef> {
+        for fd in self.entry_fns() {
+            if fd.name == name {
+                return Some(fd);
+            }
+        }
+        for m in &self.modules {
+            for fd in &m.fn_defs {
+                if fd.name == name {
+                    return Some(fd);
+                }
+            }
+        }
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -1044,6 +1044,7 @@ mod tests {
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
+            program_shape: None,
         }
     }
 

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -3134,6 +3134,7 @@ mod tests {
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
+            program_shape: None,
         }
     }
 

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4990,6 +4990,7 @@ mod tests {
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
             resolved_program: aver::codegen::program_view::ResolvedProgramView::default(),
+            program_shape: None,
         }
     }
 


### PR DESCRIPTION
## Summary
First detector migration in stage 5 of #232 (0.23 "Shape"). Dafny codegen's `is_directly_recursive(fn_name, ctx)` — used in 3 sites in `dafny/toplevel.rs` to gate list-induction / self-recursive-Int hint emission for `verify ... law` lemmas — now reads `Archetype::StructuralRecursion` from `ctx.program_shape` instead of rewalking the AST.

## Wiring
- `CodegenContext` gains `program_shape: Option<ProgramShape>`. `build_context` populates it with `analyze_program` over **entry + dep-module** resolved fns (cross-module law routing in later stages will need shape facts about callees declared in other files).
- `ResolvedProgramView::fn_by_name(name)` bridges legacy string-name detectors into the typed `FnId`-keyed `ProgramShape`. Entry-first ordering matches what the existing lookup already assumed.
- Test fixtures that hand-roll `CodegenContext` set `program_shape: None`; the migrated detector keeps a legacy AST-walk fallback for that path.

## Behavior-preserving
- `cargo test --release --test proof_spec` — 61/61, every Lean sorry / Dafny error budget unchanged across `rle`, `quicksort`, `json`, `date`, `fibonacci`. Strategy snapshot.
- `shape_spec` (14/14) + `shape_lint_cli_spec` (3/3) pass.
- `cargo fmt --check` + workspace + aver-lang clippy `-D warnings` clean.

## Why this site first
`is_directly_recursive` is the cleanest 1:1 match between an existing ad-hoc detector and a typed Archetype label. Subsequent detectors (`refinement_info_for`, `wrapper_binop`) need typed *payload* that Stage 6 will add (`RefinementSmartConstructor`, `PipelineResult` with predicate/step expressions). Doing the easy one first proves the routing wires work end-to-end before the payload story lands.

## proof_lower next?
Today the detectors in `classify_law_strategy` (`detect_induction_target`, `wrapper_binop`, `detect_*_spec_equivalence`) work on type-level / body-shape facts that don't map cleanly to the current Archetype enum. Their migration waits for Stage 6's typed patterns / relations — at which point the strategy router reads from `ProgramShape` rather than re-walking from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)