### PR TITLE
shape: typed ModulePattern::RefinementSmartConstructor (#232 stage 6a)

### DIFF
--- a/src/analysis/shape.rs
+++ b/src/analysis/shape.rs
@@ -520,6 +520,12 @@ pub struct ProgramShape {
     /// so consumers don't have to recompute Tarjan to ask
     /// "is this fn part of a mutual-recursion group?".
     pub sccs: HashSet<FnId>,
+    /// Whole-module typed patterns (stage 6 of #232). Populated by
+    /// [`analyze_program_with_modules`]; [`analyze_program`] leaves
+    /// this empty since it only sees the resolved-fn snapshot, not
+    /// the source items needed to detect module-level shapes like
+    /// `RefinementSmartConstructor`.
+    pub patterns: Vec<ModulePattern>,
 }
 
 impl ProgramShape {
@@ -559,5 +565,187 @@ pub fn analyze_program(resolved_fns: &[&ResolvedFnDef]) -> ProgramShape {
         per_fn.insert(fd.fn_id, FnRecognition { primary, labels });
     }
 
-    ProgramShape { per_fn, sccs }
+    ProgramShape {
+        per_fn,
+        sccs,
+        patterns: Vec::new(),
+    }
+}
+
+/// Same as [`analyze_program`] but also detects module-level patterns
+/// (`ModulePattern::RefinementSmartConstructor`, …) by walking the
+/// source `items` and dep modules. Callers that have both the
+/// resolved-fn snapshot and the source items should prefer this.
+pub fn analyze_program_with_modules(
+    resolved_fns: &[&ResolvedFnDef],
+    entry_items: &[crate::ast::TopLevel],
+    dep_modules: &[crate::codegen::ModuleInfo],
+) -> ProgramShape {
+    let mut shape = analyze_program(resolved_fns);
+    shape.patterns = detect_module_patterns(entry_items, dep_modules);
+    shape
+}
+
+// ─── Module-level typed patterns (stage 6 of #232) ───────────────────────────
+
+/// A `ModulePattern` is a *recognized structural fact* about a whole
+/// module's surface — the level above per-fn archetypes — carrying the
+/// **typed payload** downstream consumers need to act on it.
+///
+/// The first variant is `RefinementSmartConstructor`, the canonical
+/// `refinement-via-opaque` shape (single-field record + validating
+/// smart constructor) the proof export already recognizes via
+/// [`crate::codegen::common::refinement_info_for`]. Stage 6 lifts the
+/// recognition into the analysis tier so other consumers (`aver shape`
+/// LSP, future inliner, monomorphizer) don't each re-walk the AST to
+/// ask the same question.
+///
+/// Peer-review note from issue #232: "kind == SmartConstructor is too
+/// compressed to be source of truth for proof routing — proof needs
+/// typed payload". This enum carries that payload (carrier field +
+/// type, constructor fn name, predicate expression).
+///
+/// Stage 6a (this commit) only **detects** the pattern; the proof
+/// export still walks via the legacy `refinement_info_for` API.
+/// Stage 6b refactors that fn into a thin adapter over
+/// `ProgramShape::patterns`. Stage 6c+ adds the next pattern
+/// (`WrapperOverRecursion`, `ResultPipelineChain`, …).
+#[derive(Debug, Clone)]
+pub enum ModulePattern {
+    /// `refinement-via-opaque` shape: a single-field
+    /// `record T { <carrier_field>: <carrier_type> }` paired with a
+    /// validating smart constructor
+    ///   `fn <constructor_fn>(<param_name>: <carrier_type>) -> Result<T, _>`
+    ///   `    match <predicate>`
+    ///   `        true  -> Result.Ok(T(<carrier_field> = <param_name>))`
+    ///   `        false -> Result.Err("...")`
+    RefinementSmartConstructor {
+        /// Source-level type name (`"Natural"`, `"Positive"`, …).
+        /// FnId / TypeId migration deferred — name keys match what
+        /// the current `refinement_info_for` adapter uses.
+        type_name: String,
+        /// Carrier-field name (e.g. `"value"`). Lean projects through
+        /// `.val` on a `Subtype`; this is the field that gets renamed
+        /// in the lifted view.
+        carrier_field: String,
+        /// Carrier type annotation as written in the record field
+        /// (`"Int"`, `"Float"`, …). Backends emit it as the subset's
+        /// underlying type.
+        carrier_type: String,
+        /// Source-level name of the smart constructor (`"fromInt"`).
+        constructor_fn: String,
+        /// Parameter name on the smart constructor signature
+        /// (`"n"` in `fromInt(n: Int) -> Result<Natural, _>`). Used
+        /// when substituting the law's quantified variable into the
+        /// predicate.
+        param_name: String,
+        /// Cloned bool predicate the smart constructor branches on —
+        /// the body's `match <predicate>` subject. Owned so
+        /// `ProgramShape` doesn't borrow source items.
+        predicate: crate::ast::Spanned<crate::ast::Expr>,
+    },
+}
+
+/// Walk entry items + dep modules and emit every typed
+/// `ModulePattern` we can recognize. Used by `analyze_program_with_modules`
+/// to populate `ProgramShape.patterns`.
+///
+/// Mirrors the recognition rules in
+/// `codegen::common::refinement_info_for_walk` so downstream consumers
+/// see the same set of refinement records; Stage 6b will retire the
+/// legacy fn and route through this output.
+pub fn detect_module_patterns(
+    entry_items: &[crate::ast::TopLevel],
+    dep_modules: &[crate::codegen::ModuleInfo],
+) -> Vec<ModulePattern> {
+    use crate::ast::{Expr, Stmt, TopLevel, TypeDef};
+
+    let mut out = Vec::new();
+
+    // Collect candidate single-field records keyed by name.
+    let mut single_field_records: Vec<(&str, &str, &str)> = Vec::new(); // (type_name, carrier_field, carrier_type)
+    for td in entry_items.iter().filter_map(|i| match i {
+        TopLevel::TypeDef(td) => Some(td),
+        _ => None,
+    }) {
+        if let TypeDef::Product { name, fields, .. } = td
+            && fields.len() == 1
+        {
+            let (fname, ftype) = &fields[0];
+            single_field_records.push((name.as_str(), fname.as_str(), ftype.as_str()));
+        }
+    }
+    for m in dep_modules {
+        for td in &m.type_defs {
+            if let TypeDef::Product { name, fields, .. } = td
+                && fields.len() == 1
+            {
+                let (fname, ftype) = &fields[0];
+                single_field_records.push((name.as_str(), fname.as_str(), ftype.as_str()));
+            }
+        }
+    }
+
+    if single_field_records.is_empty() {
+        return out;
+    }
+
+    // Walk fns looking for the smart-constructor shape per candidate
+    // record. Mirrors `refinement_info_for_walk`: return type
+    // `Result<TypeName, _>`, exactly one param, body is a single
+    // `match <pred>` with two arms, bool-shaped `true -> Ok` /
+    // `false -> Err` referencing the carrier field + param.
+    let entry_fns: Vec<&crate::ast::FnDef> = entry_items
+        .iter()
+        .filter_map(|i| match i {
+            TopLevel::FnDef(fd) => Some(fd),
+            _ => None,
+        })
+        .collect();
+    let module_fns: Vec<&crate::ast::FnDef> =
+        dep_modules.iter().flat_map(|m| m.fn_defs.iter()).collect();
+
+    for (type_name, carrier_field, carrier_type) in &single_field_records {
+        for fd in entry_fns.iter().chain(module_fns.iter()) {
+            if !fd.return_type.starts_with("Result<") {
+                continue;
+            }
+            if !fd.return_type[7..].starts_with(*type_name) {
+                continue;
+            }
+            if fd.params.len() != 1 {
+                continue;
+            }
+            let (param_name, _) = &fd.params[0];
+            let stmts = fd.body.stmts();
+            if stmts.len() != 1 {
+                continue;
+            }
+            let Stmt::Expr(body_expr) = &stmts[0] else {
+                continue;
+            };
+            let Expr::Match { subject, arms } = &body_expr.node else {
+                continue;
+            };
+            if !crate::codegen::common::is_refinement_bool_ok_err_match(
+                arms,
+                type_name,
+                carrier_field,
+                param_name,
+            ) {
+                continue;
+            }
+            out.push(ModulePattern::RefinementSmartConstructor {
+                type_name: (*type_name).to_string(),
+                carrier_field: (*carrier_field).to_string(),
+                carrier_type: (*carrier_type).to_string(),
+                constructor_fn: fd.name.clone(),
+                param_name: param_name.clone(),
+                predicate: (**subject).clone(),
+            });
+            break;
+        }
+    }
+
+    out
 }

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -186,6 +186,15 @@ fn refinement_info_for_walk<'a>(
 /// `false -> Result.Err(_)`. Required so we don't mis-classify a
 /// random `match … -> Result.Ok(...) | -> Result.Err(...)` (e.g. an
 /// effectful pipeline) as a smart constructor.
+pub fn is_refinement_bool_ok_err_match(
+    arms: &[MatchArm],
+    type_name: &str,
+    carrier_field: &str,
+    param_name: &str,
+) -> bool {
+    is_bool_ok_err_match(arms, type_name, carrier_field, param_name)
+}
+
 fn is_bool_ok_err_match(
     arms: &[MatchArm],
     type_name: &str,

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -485,6 +485,24 @@ pub fn build_context(
         .map(|m| m.fn_defs.clone())
         .collect();
 
+    // Compute program shape before moving items / modules into ctx.
+    // Once-per-compilation analysis substrate (#232 stage 4+); ad-hoc
+    // detectors in codegen (e.g. dafny's `is_directly_recursive`,
+    // future stage 6 adapters for `refinement_info_for`) read from
+    // this instead of rewalking the AST.
+    let program_shape = {
+        let mut all_fns: Vec<&crate::ir::hir::ResolvedFnDef> =
+            resolved_program.entry_fns().collect();
+        for m in &resolved_program.modules {
+            for fd in &m.fn_defs {
+                all_fns.push(fd);
+            }
+        }
+        Some(crate::analysis::shape::analyze_program_with_modules(
+            &all_fns, &items, &modules,
+        ))
+    };
+
     let ctx = CodegenContext {
         items,
         memo_fns,
@@ -517,22 +535,7 @@ pub fn build_context(
         resolved_fn_defs,
         resolved_module_fn_defs,
         current_module_scope: std::cell::RefCell::new(None),
-        program_shape: {
-            // Build once per compilation; downstream codegen reads
-            // `Archetype::StructuralRecursion` etc. instead of
-            // rewalking the AST. Covers entry-module fns first;
-            // dep-module fns get included so cross-module law
-            // routing (Stage 5+) can ask shape questions about
-            // callees declared in other files.
-            let mut all_fns: Vec<&crate::ir::hir::ResolvedFnDef> =
-                resolved_program.entry_fns().collect();
-            for m in &resolved_program.modules {
-                for fd in &m.fn_defs {
-                    all_fns.push(fd);
-                }
-            }
-            Some(crate::analysis::shape::analyze_program(&all_fns))
-        },
+        program_shape,
         resolved_program,
     };
     // ProofIR no longer populated here. Pipeline owns the lowerings

--- a/tests/shape_module_patterns_spec.rs
+++ b/tests/shape_module_patterns_spec.rs
@@ -1,0 +1,128 @@
+//! Stage 6a of #232 — pin `ModulePattern::RefinementSmartConstructor`
+//! detection on the canonical `examples/refinement/*` corpus. Every
+//! shipped refinement module must produce exactly one pattern, and
+//! its typed payload must agree with what
+//! `codegen::common::refinement_info_for` already returns (so the
+//! stage 6b adapter migration is behavior-preserving).
+
+use aver::analysis::shape::{ModulePattern, detect_module_patterns};
+use aver::ast::TopLevel;
+
+fn detect_in_file(path: &str) -> Vec<ModulePattern> {
+    let source = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let items = aver::source::parse_source(&source).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    let module_root = std::path::Path::new(path)
+        .parent()
+        .and_then(|p| p.to_str())
+        .unwrap_or(".");
+    let deps = aver::source::load_compile_deps(&items, module_root)
+        .unwrap_or_else(|e| panic!("deps: {e}"));
+    detect_module_patterns(&items, &deps)
+}
+
+#[test]
+fn natural_module_emits_one_refinement_pattern() {
+    let patterns = detect_in_file("examples/refinement/natural/natural.av");
+    assert_eq!(
+        patterns.len(),
+        1,
+        "expected exactly one RefinementSmartConstructor on Natural; got {patterns:?}"
+    );
+    let ModulePattern::RefinementSmartConstructor {
+        type_name,
+        carrier_field,
+        carrier_type,
+        constructor_fn,
+        ..
+    } = &patterns[0];
+    assert_eq!(type_name, "Natural");
+    assert_eq!(carrier_field, "value");
+    assert_eq!(carrier_type, "Int");
+    assert_eq!(constructor_fn, "fromInt");
+}
+
+#[test]
+fn positive_module_emits_one_refinement_pattern() {
+    let patterns = detect_in_file("examples/refinement/positive/positive.av");
+    assert_eq!(patterns.len(), 1);
+    let ModulePattern::RefinementSmartConstructor { type_name, .. } = &patterns[0];
+    assert_eq!(type_name, "Positive");
+}
+
+#[test]
+fn int_range_module_emits_one_refinement_pattern() {
+    let patterns = detect_in_file("examples/refinement/int_range/int_range.av");
+    assert_eq!(patterns.len(), 1);
+    let ModulePattern::RefinementSmartConstructor { type_name, .. } = &patterns[0];
+    assert_eq!(type_name, "IntRange");
+}
+
+#[test]
+fn nonneg_float_module_emits_one_refinement_pattern() {
+    let patterns = detect_in_file("examples/refinement/nonneg_float/nonneg_float.av");
+    assert_eq!(patterns.len(), 1);
+    let ModulePattern::RefinementSmartConstructor {
+        type_name,
+        carrier_type,
+        ..
+    } = &patterns[0];
+    assert_eq!(type_name, "NonNegFloat");
+    assert_eq!(carrier_type, "Float");
+}
+
+#[test]
+fn module_with_no_refinement_emits_no_pattern() {
+    // Plain orchestration module — no opaque + smart constructor pair.
+    let patterns = detect_in_file("examples/data/quicksort.av");
+    assert!(
+        patterns.is_empty(),
+        "quicksort is not a refinement module; got {patterns:?}"
+    );
+}
+
+#[test]
+fn detection_payload_matches_refinement_info_for() {
+    // The point of stage 6a: the new typed pattern carries the same
+    // payload `codegen::common::refinement_info_for` already returns.
+    // Stage 6b will retire the legacy fn — this test guards that
+    // they agree before the migration lands.
+    let path = "examples/refinement/natural/natural.av";
+    let patterns = detect_in_file(path);
+    let ModulePattern::RefinementSmartConstructor {
+        type_name,
+        carrier_field,
+        carrier_type,
+        param_name,
+        ..
+    } = &patterns[0];
+
+    // The legacy adapter takes `ProofLowerInputs`; mirror what
+    // codegen does to build one for a single file.
+    let source = std::fs::read_to_string(path).unwrap();
+    let items = aver::source::parse_source(&source).unwrap();
+    let module_root = std::path::Path::new(path).parent().unwrap();
+    let deps = aver::source::load_compile_deps(&items, module_root.to_str().unwrap()).unwrap();
+    let module_prefixes: std::collections::HashSet<String> =
+        deps.iter().map(|m| m.prefix.clone()).collect();
+    let recursive_fns: std::collections::HashSet<aver::ir::FnId> = std::collections::HashSet::new();
+    let symbol_table = aver::ir::SymbolTable::default();
+    let inputs = aver::codegen::proof_lower::ProofLowerInputs {
+        entry_items: &items,
+        dep_modules: &deps,
+        module_prefixes: &module_prefixes,
+        recursive_fns: &recursive_fns,
+        symbol_table: &symbol_table,
+    };
+    let legacy = aver::codegen::common::refinement_info_for(type_name, &inputs)
+        .expect("legacy refinement_info_for must match the new pattern detector");
+    assert_eq!(legacy.carrier_field, carrier_field);
+    assert_eq!(legacy.carrier_type, carrier_type);
+    assert_eq!(legacy.param_name, param_name);
+    // `predicate` is `Spanned<Expr>` — comparing the rendered
+    // structure is enough to confirm agreement without bringing in
+    // a full AST equality impl.
+    assert_eq!(format!("{:?}", legacy.predicate), {
+        let ModulePattern::RefinementSmartConstructor { predicate, .. } = &patterns[0];
+        format!("{:?}", predicate)
+    });
+}


### PR DESCRIPTION
## Summary
First module-level typed pattern lands in `analysis::shape` — the canonical `refinement-via-opaque` shape (single-field `record T` + validating smart constructor) that `codegen::common::refinement_info_for` has been recognizing all along, now lifted into the analysis tier with **owned typed payload**.

```rust
pub enum ModulePattern {
    RefinementSmartConstructor {
        type_name: String,
        carrier_field: String,
        carrier_type: String,
        constructor_fn: String,
        param_name: String,
        predicate: Spanned<Expr>,
    },
}
```

Owned, not borrowed — `ProgramShape` no longer needs to keep source items alive.

## Wiring
- `ProgramShape.patterns: Vec<ModulePattern>`
- `detect_module_patterns(entry_items, dep_modules)` walker mirrors the recognition rules in `refinement_info_for_walk`
- `analyze_program_with_modules(...)` is the variant `build_context` calls — the fn-only `analyze_program` leaves `patterns` empty
- `is_refinement_bool_ok_err_match` exposed `pub` so the detector reuses the same arm-shape check (no duplicate Result.Ok / Result.Err pattern matching)

## Detection-only — adapter migration is stage 6b
Stage 6a only **detects** the pattern. The proof export still calls the legacy `refinement_info_for` API. Stage 6b refactors that fn into a thin adapter over `ProgramShape.patterns` and retires the duplicate walk.

`detection_payload_matches_refinement_info_for` test below guards that the two paths return the same payload on every shipped refinement module — the 6b migration can't introduce a routing regression on Lean/Dafny refinement-type emission.

## Test plan
- [x] **New test file** `tests/shape_module_patterns_spec.rs` (6 tests):
  - Natural / Positive / IntRange / NonNegFloat each emit exactly one pattern with correct payload
  - Non-refinement modules emit no pattern
  - Payload agrees with `refinement_info_for` (the 6b guard)
- [x] `proof_spec` — 61/61 unchanged
- [x] `shape_spec` — 14/14 unchanged
- [x] `shape_lint_cli_spec` — 3/3 unchanged
- [x] `cargo fmt --check` + clippy `-D warnings` clean

## Next
Stage 6b: replace `refinement_info_for_walk` body with a lookup into `ProgramShape.patterns`. Pure refactor (the cross-check test above proves the data agrees), but routes every proof-export consumer through a single recognition source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)