### PR TITLE
shape: 3 substrate patterns +  Module patterns section (#232 stage 6d/e/f + visible)

### DIFF
--- a/src/analysis/shape.rs
+++ b/src/analysis/shape.rs
@@ -683,6 +683,70 @@ pub enum ModulePattern {
         /// Source-level inner fn name (the recursive one).
         inner_fn: String,
     },
+    /// `?`-propagating Result pipeline: a fn whose body is a sequence
+    /// of `let x = step()?` bindings followed by a tail expression
+    /// (typically `Result.Ok(final)`). Canonical example:
+    /// `examples/core/result_pipeline.av::validateAndCombine` — six
+    /// `?` steps that short-circuit on the first Err.
+    ///
+    /// Detection rules (stage 6d):
+    /// - fn return type starts with `Result<`
+    /// - body has at least two `Stmt::Binding` whose value is
+    ///   `Expr::ErrorProp(...)` (the `?` operator)
+    /// - the tail stmt is an expression, not a binding
+    ///
+    /// `step_count` is the number of `?` bindings; downstream
+    /// consumers can use it to size the staged result type or to
+    /// pick between inlined and trampoline lowerings. No proof-export
+    /// consumer yet — this is substrate-only.
+    ResultPipelineChain {
+        scope: Option<String>,
+        fn_name: String,
+        step_count: usize,
+    },
+    /// Non-recursive pure renderer: a fn whose return type is `String`,
+    /// effects list is empty, and body contains an `InterpolatedStr`
+    /// or a `String`-typed `+` concatenation. Canonical examples are
+    /// `examples/data/rle.av::showRun` (single interpolation) and the
+    /// `show*` family in `examples/data/fibonacci.av`.
+    ///
+    /// Detection rules (stage 6e):
+    /// - return type is exactly `String`
+    /// - effects list is empty
+    /// - fn does not call itself anywhere in its body
+    /// - body contains at least one `Expr::InterpolatedStr` or
+    ///   `Expr::BinOp(Add, ..)` reachable through nesting
+    ///
+    /// Recursive structural renderers (`showRuns`, `showListIntInner`)
+    /// are intentionally excluded — they belong to a future
+    /// `StructuralRenderer` pattern paired with structural induction.
+    RendererFormatter {
+        scope: Option<String>,
+        fn_name: String,
+    },
+    /// Self-recursive structural fold over a `List<T>` parameter:
+    /// fn body is a single `match <param>` with at minimum
+    /// `[] -> ...` and `[head, ..tail] -> ...` arms, and the fn
+    /// calls itself somewhere in its body (typically passing
+    /// `tail` to recur). `nthOrZero(xs, index)` from
+    /// `examples/data/fibonacci.av` is the canonical example.
+    ///
+    /// Detection rules (stage 6f):
+    /// - body is a single `Stmt::Expr(Match)`
+    /// - subject is `Ident(p)` where `p` is one of the fn's params
+    /// - arms include both `Pattern::EmptyList` and `Pattern::Cons`
+    /// - fn is self-recursive
+    ///
+    /// Aver's stdlib has no `List.map/fold`, so this hand-rolled
+    /// structural fold shows up across the corpus. Recognizing it
+    /// unlocks two future moves: list-induction proof obligation
+    /// emission, and a deforestation rewrite that fuses the fold
+    /// with its consumer.
+    MatchDispatcherFold {
+        scope: Option<String>,
+        fn_name: String,
+        list_param: String,
+    },
 }
 
 /// Walk entry items + dep modules and emit every typed
@@ -824,7 +888,195 @@ pub fn detect_module_patterns(
         detect_wrapper_over_recursion(Some(m.prefix.clone()), &fns, &mut out);
     }
 
+    // Stage 6d of #232: `ResultPipelineChain` per-scope detection.
+    detect_result_pipeline_chain(None, &entry_fns, &mut out);
+    for m in dep_modules {
+        let fns: Vec<&crate::ast::FnDef> = m.fn_defs.iter().collect();
+        detect_result_pipeline_chain(Some(m.prefix.clone()), &fns, &mut out);
+    }
+
+    // Stage 6e of #232: `RendererFormatter` per-scope detection.
+    detect_renderer_formatter(None, &entry_fns, &mut out);
+    for m in dep_modules {
+        let fns: Vec<&crate::ast::FnDef> = m.fn_defs.iter().collect();
+        detect_renderer_formatter(Some(m.prefix.clone()), &fns, &mut out);
+    }
+
+    // Stage 6f of #232: `MatchDispatcherFold` per-scope detection.
+    detect_match_dispatcher_fold(None, &entry_fns, &mut out);
+    for m in dep_modules {
+        let fns: Vec<&crate::ast::FnDef> = m.fn_defs.iter().collect();
+        detect_match_dispatcher_fold(Some(m.prefix.clone()), &fns, &mut out);
+    }
+
     out
+}
+
+/// Per-scope detector for [`ModulePattern::MatchDispatcherFold`]. See
+/// the variant docs for the detection contract.
+fn detect_match_dispatcher_fold(
+    scope: Option<String>,
+    fns: &[&crate::ast::FnDef],
+    out: &mut Vec<ModulePattern>,
+) {
+    use crate::ast::{Expr, Pattern, Stmt};
+    for fd in fns {
+        let stmts = fd.body.stmts();
+        if stmts.len() != 1 {
+            continue;
+        }
+        let Stmt::Expr(body_expr) = &stmts[0] else {
+            continue;
+        };
+        let Expr::Match { subject, arms } = &body_expr.node else {
+            continue;
+        };
+        let Expr::Ident(subj_name) = &subject.node else {
+            continue;
+        };
+        if !fd.params.iter().any(|(n, _)| n == subj_name) {
+            continue;
+        }
+        let has_nil = arms.iter().any(|a| matches!(a.pattern, Pattern::EmptyList));
+        let has_cons = arms
+            .iter()
+            .any(|a| matches!(a.pattern, Pattern::Cons(_, _)));
+        if !(has_nil && has_cons) {
+            continue;
+        }
+        if !body_calls_name(&fd.body, &fd.name) {
+            continue;
+        }
+        out.push(ModulePattern::MatchDispatcherFold {
+            scope: scope.clone(),
+            fn_name: fd.name.clone(),
+            list_param: subj_name.clone(),
+        });
+    }
+}
+
+/// Per-scope detector for [`ModulePattern::RendererFormatter`]. See
+/// the variant docs for the detection contract.
+fn detect_renderer_formatter(
+    scope: Option<String>,
+    fns: &[&crate::ast::FnDef],
+    out: &mut Vec<ModulePattern>,
+) {
+    for fd in fns {
+        if fd.return_type != "String" {
+            continue;
+        }
+        if !fd.effects.is_empty() {
+            continue;
+        }
+        if body_calls_name(&fd.body, &fd.name) {
+            continue;
+        }
+        if !body_has_string_building(&fd.body) {
+            continue;
+        }
+        out.push(ModulePattern::RendererFormatter {
+            scope: scope.clone(),
+            fn_name: fd.name.clone(),
+        });
+    }
+}
+
+/// Walk `body` looking for any `Expr::InterpolatedStr` or string-typed
+/// `+` (`BinOp(Add, ..)`). Conservative: any addition counts since
+/// the typechecker has already restricted what `+` can do at a
+/// `String`-returning callsite — false positives here would be
+/// numeric adds that never reach the return slot, which the
+/// `return_type == "String"` guard already excludes for trivial
+/// arithmetic-only bodies.
+fn body_has_string_building(body: &crate::ast::FnBody) -> bool {
+    for stmt in body.stmts() {
+        let expr = match stmt {
+            crate::ast::Stmt::Binding(_, _, e) => e,
+            crate::ast::Stmt::Expr(e) => e,
+        };
+        if expr_has_string_building(expr) {
+            return true;
+        }
+    }
+    false
+}
+
+fn expr_has_string_building(expr: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::InterpolatedStr(_) => true,
+        Expr::BinOp(crate::ast::BinOp::Add, _, _) => true,
+        Expr::FnCall(callee, args) => {
+            expr_has_string_building(callee) || args.iter().any(expr_has_string_building)
+        }
+        Expr::TailCall(td) => td.args.iter().any(expr_has_string_building),
+        Expr::Match { subject, arms } => {
+            expr_has_string_building(subject)
+                || arms.iter().any(|a| expr_has_string_building(&a.body))
+        }
+        Expr::BinOp(_, l, r) => expr_has_string_building(l) || expr_has_string_building(r),
+        Expr::Neg(e) | Expr::Attr(e, _) | Expr::ErrorProp(e) => expr_has_string_building(e),
+        Expr::Constructor(_, Some(e)) => expr_has_string_building(e),
+        Expr::List(xs) | Expr::Tuple(xs) | Expr::IndependentProduct(xs, _) => {
+            xs.iter().any(expr_has_string_building)
+        }
+        Expr::MapLiteral(pairs) => pairs
+            .iter()
+            .any(|(k, v)| expr_has_string_building(k) || expr_has_string_building(v)),
+        Expr::RecordCreate { fields, .. } => {
+            fields.iter().any(|(_, e)| expr_has_string_building(e))
+        }
+        Expr::RecordUpdate { base, updates, .. } => {
+            expr_has_string_building(base)
+                || updates.iter().any(|(_, e)| expr_has_string_building(e))
+        }
+        Expr::Literal(_) | Expr::Ident(_) | Expr::Constructor(_, None) | Expr::Resolved { .. } => {
+            false
+        }
+    }
+}
+
+/// Per-scope detector for [`ModulePattern::ResultPipelineChain`].
+/// Counts `Stmt::Binding(_, _, ErrorProp(...))` (the `?` operator)
+/// in each fn body; emits the pattern when there are ≥2 such
+/// bindings, the fn returns `Result<…>`, and the tail stmt is an
+/// expression (`Stmt::Expr`, not another binding).
+fn detect_result_pipeline_chain(
+    scope: Option<String>,
+    fns: &[&crate::ast::FnDef],
+    out: &mut Vec<ModulePattern>,
+) {
+    use crate::ast::{Expr, Stmt};
+    for fd in fns {
+        if !fd.return_type.starts_with("Result<") {
+            continue;
+        }
+        let stmts = fd.body.stmts();
+        if stmts.len() < 2 {
+            continue;
+        }
+        if !matches!(stmts.last(), Some(Stmt::Expr(_))) {
+            continue;
+        }
+        let step_count = stmts
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s,
+                    Stmt::Binding(_, _, e) if matches!(e.node, Expr::ErrorProp(_))
+                )
+            })
+            .count();
+        if step_count < 2 {
+            continue;
+        }
+        out.push(ModulePattern::ResultPipelineChain {
+            scope: scope.clone(),
+            fn_name: fd.name.clone(),
+            step_count,
+        });
+    }
 }
 
 /// Per-scope detector for [`ModulePattern::WrapperOverRecursion`].

--- a/src/analysis/shape.rs
+++ b/src/analysis/shape.rs
@@ -931,8 +931,14 @@ fn detect_match_dispatcher_fold(
         let Expr::Match { subject, arms } = &body_expr.node else {
             continue;
         };
-        let Expr::Ident(subj_name) = &subject.node else {
-            continue;
+        // Pre-pipeline: subject is `Expr::Ident(name)`. Post-pipeline:
+        // the resolver rewrites local/param idents to
+        // `Expr::Resolved { name, .. }`. Both forms identify the
+        // matched parameter.
+        let subj_name = match &subject.node {
+            Expr::Ident(n) => n.as_str(),
+            Expr::Resolved { name, .. } => name.as_str(),
+            _ => continue,
         };
         if !fd.params.iter().any(|(n, _)| n == subj_name) {
             continue;
@@ -950,7 +956,7 @@ fn detect_match_dispatcher_fold(
         out.push(ModulePattern::MatchDispatcherFold {
             scope: scope.clone(),
             fn_name: fd.name.clone(),
-            list_param: subj_name.clone(),
+            list_param: subj_name.to_string(),
         });
     }
 }
@@ -1215,20 +1221,44 @@ fn collect_qualifying_in_expr(
     out: &mut Vec<String>,
 ) {
     use crate::ast::Expr;
-    if let Expr::FnCall(callee, args) = &expr.node
-        && let Expr::Ident(name) = &callee.node
-        && recursive.contains(name)
-        && args.len() > outer_params.len()
-    {
+    let try_qualify = |callee: &str, args: &[crate::ast::Spanned<Expr>], out: &mut Vec<String>| {
+        if !recursive.contains(callee) {
+            return;
+        }
+        if args.len() <= outer_params.len() {
+            return;
+        }
+        // Pre-pipeline args are `Expr::Ident(name)`; post-pipeline the
+        // resolver rewrites local/param idents to
+        // `Expr::Resolved { name, .. }`. Both shapes need to count.
         let mut arg_idents: HashSet<&str> = HashSet::new();
         for a in args {
-            if let Expr::Ident(n) = &a.node {
-                arg_idents.insert(n.as_str());
+            match &a.node {
+                Expr::Ident(n) => {
+                    arg_idents.insert(n.as_str());
+                }
+                Expr::Resolved { name, .. } => {
+                    arg_idents.insert(name.as_str());
+                }
+                _ => {}
             }
         }
         if outer_params.iter().all(|p| arg_idents.contains(*p)) {
-            out.push(name.clone());
+            out.push(callee.to_string());
         }
+    };
+    if let Expr::FnCall(callee, args) = &expr.node
+        && let Expr::Ident(name) = &callee.node
+    {
+        try_qualify(name, args, out);
+    }
+    // Post-pipeline AST: tail-position calls become `TailCall`,
+    // which loses the `FnCall(Ident, ...)` wrapper. The
+    // `fib(n) -> fibTR(n, 0, 1)` shape is a typical case — pipeline
+    // recognizes the tail call inside the `match` arm even though
+    // `fib` itself isn't recursive.
+    if let Expr::TailCall(td) = &expr.node {
+        try_qualify(&td.target, &td.args, out);
     }
     match &expr.node {
         Expr::FnCall(callee, args) => {

--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -989,6 +989,7 @@ pub struct RenderOptions {
 /// Scope-qualified names are rendered as `prefix::name` when the
 /// pattern lives in a dep module.
 fn render_module_pattern_line(p: &ModulePattern) -> String {
+    use colored::Colorize;
     let scoped = |scope: &Option<String>, name: &str| -> String {
         match scope {
             Some(prefix) => format!("{prefix}::{name}"),
@@ -1004,9 +1005,12 @@ fn render_module_pattern_line(p: &ModulePattern) -> String {
             constructor_fn,
             ..
         } => format!(
-            "RefinementSmartConstructor  {type_name}({carrier_field}: {carrier_type})  via {ctor}",
-            type_name = scoped(scope, type_name),
-            ctor = scoped(scope, constructor_fn),
+            "{}  {}({}: {})  via {}",
+            "RefinementSmartConstructor".magenta().bold(),
+            scoped(scope, type_name).bold(),
+            carrier_field,
+            carrier_type.cyan(),
+            scoped(scope, constructor_fn).bold(),
         ),
         ModulePattern::WrapperOverRecursion {
             wrapper_scope,
@@ -1014,68 +1018,84 @@ fn render_module_pattern_line(p: &ModulePattern) -> String {
             inner_scope,
             inner_fn,
         } => format!(
-            "WrapperOverRecursion        {} → {}",
-            scoped(wrapper_scope, wrapper_fn),
-            scoped(inner_scope, inner_fn),
+            "{}        {} → {}",
+            "WrapperOverRecursion".magenta().bold(),
+            scoped(wrapper_scope, wrapper_fn).bold(),
+            scoped(inner_scope, inner_fn).bold(),
         ),
         ModulePattern::ResultPipelineChain {
             scope,
             fn_name,
             step_count,
         } => format!(
-            "ResultPipelineChain         {}  ({step_count} steps)",
-            scoped(scope, fn_name),
+            "{}         {}  ({} steps)",
+            "ResultPipelineChain".magenta().bold(),
+            scoped(scope, fn_name).bold(),
+            step_count.to_string().yellow(),
         ),
-        ModulePattern::RendererFormatter { scope, fn_name } => {
-            format!("RendererFormatter           {}", scoped(scope, fn_name))
-        }
+        ModulePattern::RendererFormatter { scope, fn_name } => format!(
+            "{}           {}",
+            "RendererFormatter".magenta().bold(),
+            scoped(scope, fn_name).bold(),
+        ),
         ModulePattern::MatchDispatcherFold {
             scope,
             fn_name,
             list_param,
         } => format!(
-            "MatchDispatcherFold         {}  (over {list_param})",
-            scoped(scope, fn_name),
+            "{}         {}  (over {})",
+            "MatchDispatcherFold".magenta().bold(),
+            scoped(scope, fn_name).bold(),
+            list_param.cyan(),
         ),
     }
 }
 
 pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
+    use colored::Colorize;
     let mut out = String::new();
     // Header: `Module:` and `Kind:` share the value column. `Module:` is
     // 7 chars + space, `Kind:` is 5 chars + 3 spaces — same total width.
-    out.push_str(&format!("Module:  {}\n", report.module));
-    out.push_str(&format!("Kind:    {}\n\n", report.kind.as_str()));
-    out.push_str("  ModuleShape:\n");
+    // Colors auto-disable on non-TTY (the `colored` crate detects
+    // pipes and the NO_COLOR env var), so tests + JSON consumers see
+    // plain text.
+    out.push_str(&format!("{}  {}\n", "Module:".bold(), report.module.bold()));
     out.push_str(&format!(
-        "    purity        {}\n",
+        "{}    {}\n\n",
+        "Kind:".bold(),
+        report.kind.as_str().cyan().bold()
+    ));
+    out.push_str(&format!("{}\n", "ModuleShape:".bold()));
+    out.push_str(&format!(
+        "  purity        {}\n",
         report.shape.purity.as_str()
     ));
     out.push_str(&format!(
-        "    entry         {}\n",
+        "  entry         {}\n",
         report.shape.entry.as_str()
     ));
     out.push_str(&format!(
-        "    state_shape   {}\n",
+        "  state_shape   {}\n",
         report.shape.state_shape.as_str()
     ));
     out.push_str(&format!(
-        "    type_surface  {}\n",
+        "  type_surface  {}\n",
         report.shape.type_surface.as_str()
     ));
     out.push_str(&format!(
-        "    api_shape     {}\n\n",
+        "  api_shape     {}\n\n",
         report.shape.api_shape.as_str()
     ));
 
     // Verification: collapse the zero-block case to a single line — the
     // "0 (no) blocks, 0/0 fns covered" reading was confusing.
     if report.verify.blocks == 0 {
-        out.push_str("  Verification:  no verify blocks\n\n");
+        out.push_str(&format!("{}  no verify blocks\n\n", "Verification:".bold()));
     } else {
         out.push_str(&format!(
-            "  Verification:  {} {} block{}, {}/{} fns covered\n\n",
-            report.verify.blocks,
+            "{}  {} {} block{}, {}/{} fns covered\n\n",
+            "Verification:".bold(),
+            report.verify.blocks.to_string().yellow(),
             match report.verify.level {
                 VerifyLevel::None => "(no)",
                 VerifyLevel::Cases => "cases",
@@ -1084,17 +1104,21 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
                 VerifyLevel::Mixed => "mixed",
             },
             if report.verify.blocks == 1 { "" } else { "s" },
-            report.verify.covered_fns,
-            report.verify.eligible_fns,
+            report.verify.covered_fns.to_string().yellow(),
+            report.verify.eligible_fns.to_string().yellow(),
         ));
     }
 
     if report.histogram.total_fns == 0 {
-        out.push_str("  Histogram:     no classifiable fns (module only has `main` or no fns)\n");
+        out.push_str(&format!(
+            "{}     no classifiable fns (module only has `main` or no fns)\n",
+            "Histogram:".bold()
+        ));
     } else {
         out.push_str(&format!(
-            "  Histogram ({} fns):\n",
-            report.histogram.total_fns
+            "{} ({} fns):\n",
+            "Histogram".bold(),
+            report.histogram.total_fns.to_string().yellow()
         ));
         let sorted = report.histogram.sorted();
         let name_w = sorted
@@ -1106,11 +1130,11 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
         for (name, count, pct) in &sorted {
             let bar = histogram_bar(*pct, 20);
             out.push_str(&format!(
-                "    {:<width$}  {}  {:>3.0}%  ({})\n",
+                "  {:<width$}  {}  {:>3}  ({})\n",
                 name.as_str(),
-                bar,
-                pct,
-                count,
+                bar.cyan(),
+                format!("{:.0}%", pct).yellow(),
+                count.to_string().dimmed(),
                 width = name_w,
             ));
         }
@@ -1118,19 +1142,22 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
     if let Some(verdict) = &report.layer {
         if verdict.uncertain {
             out.push_str(&format!(
-                "\n  Layer: uncertain  (best: {}, confidence {:.2}, margin Δ{:.1}, basis: {})\n",
-                verdict.layer.as_str(),
-                verdict.confidence,
-                verdict.margin,
-                verdict.basis,
+                "\n{} {}  (best: {}, confidence {}, margin Δ{}, basis: {})\n",
+                "Layer:".bold(),
+                "uncertain".yellow().bold(),
+                verdict.layer.as_str().cyan().bold(),
+                format!("{:.2}", verdict.confidence).yellow(),
+                format!("{:.1}", verdict.margin).yellow(),
+                verdict.basis.dimmed(),
             ));
         } else {
             out.push_str(&format!(
-                "\n  Layer: {}  (confidence {:.2}, margin Δ{:.1}, basis: {})\n",
-                verdict.layer.as_str(),
-                verdict.confidence,
-                verdict.margin,
-                verdict.basis,
+                "\n{} {}  (confidence {}, margin Δ{}, basis: {})\n",
+                "Layer:".bold(),
+                verdict.layer.as_str().cyan().bold(),
+                format!("{:.2}", verdict.confidence).yellow(),
+                format!("{:.1}", verdict.margin).yellow(),
+                verdict.basis.dimmed(),
             ));
         }
         // Runners-up (top 3 minus best). Hides nothing — even when
@@ -1144,23 +1171,27 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
             .map(|(layer, dist)| format!("{} Δ{:.1}", layer.as_str(), dist))
             .collect();
         if !runners.is_empty() {
-            out.push_str(&format!("         next: {}\n", runners.join(", ")));
+            out.push_str(&format!(
+                "       {} {}\n",
+                "next:".dimmed(),
+                runners.join(", ").dimmed()
+            ));
         }
     } else {
-        out.push_str("\n  Layer: insufficient data\n");
+        out.push_str(&format!("\n{} insufficient data\n", "Layer:".bold()));
     }
 
     if !report.patterns.is_empty() {
-        out.push_str("\n  Module patterns:\n");
+        out.push_str(&format!("\n{}\n", "Module patterns:".bold()));
         for p in &report.patterns {
-            out.push_str("    ");
+            out.push_str("  ");
             out.push_str(&render_module_pattern_line(p));
             out.push('\n');
         }
     }
 
     if !opts.summary {
-        out.push_str("\n  Functions:\n");
+        out.push_str(&format!("\n{}\n", "Functions:".bold()));
         let name_w = report
             .fns
             .iter()
@@ -1179,9 +1210,9 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
                     .join(", ")
             };
             out.push_str(&format!(
-                "    {:<width$}  {}\n",
+                "  {:<width$}  {}\n",
                 f.name,
-                labels_str,
+                labels_str.dimmed(),
                 width = name_w,
             ));
         }
@@ -1241,6 +1272,8 @@ pub fn render_json(report: &ShapeReport) -> serde_json::Value {
             })
         })
         .collect();
+    let patterns: Vec<serde_json::Value> =
+        report.patterns.iter().map(module_pattern_to_json).collect();
     json!({
         "module": report.module,
         "file": report.file,
@@ -1274,7 +1307,76 @@ pub fn render_json(report: &ShapeReport) -> serde_json::Value {
         },
         "layer": layer,
         "fns": fns,
+        "patterns": patterns,
     })
+}
+
+/// JSON encoding of one [`ModulePattern`]. Each variant becomes an
+/// object with a `kind` tag plus the variant's typed payload, mirror
+/// of the text renderer's grep-friendly format. `null` instead of
+/// `None` keeps the schema explicit for downstream tooling.
+fn module_pattern_to_json(p: &ModulePattern) -> serde_json::Value {
+    use serde_json::json;
+    let scope_json = |s: &Option<String>| match s {
+        Some(prefix) => serde_json::Value::String(prefix.clone()),
+        None => serde_json::Value::Null,
+    };
+    match p {
+        ModulePattern::RefinementSmartConstructor {
+            scope,
+            type_name,
+            carrier_field,
+            carrier_type,
+            constructor_fn,
+            param_name,
+            ..
+        } => json!({
+            "kind": "RefinementSmartConstructor",
+            "scope": scope_json(scope),
+            "type_name": type_name,
+            "carrier_field": carrier_field,
+            "carrier_type": carrier_type,
+            "constructor_fn": constructor_fn,
+            "param_name": param_name,
+        }),
+        ModulePattern::WrapperOverRecursion {
+            wrapper_scope,
+            wrapper_fn,
+            inner_scope,
+            inner_fn,
+        } => json!({
+            "kind": "WrapperOverRecursion",
+            "wrapper_scope": scope_json(wrapper_scope),
+            "wrapper_fn": wrapper_fn,
+            "inner_scope": scope_json(inner_scope),
+            "inner_fn": inner_fn,
+        }),
+        ModulePattern::ResultPipelineChain {
+            scope,
+            fn_name,
+            step_count,
+        } => json!({
+            "kind": "ResultPipelineChain",
+            "scope": scope_json(scope),
+            "fn_name": fn_name,
+            "step_count": step_count,
+        }),
+        ModulePattern::RendererFormatter { scope, fn_name } => json!({
+            "kind": "RendererFormatter",
+            "scope": scope_json(scope),
+            "fn_name": fn_name,
+        }),
+        ModulePattern::MatchDispatcherFold {
+            scope,
+            fn_name,
+            list_param,
+        } => json!({
+            "kind": "MatchDispatcherFold",
+            "scope": scope_json(scope),
+            "fn_name": fn_name,
+            "list_param": list_param,
+        }),
+    }
 }
 
 // ─── Corpus (directory) mode ────────────────────────────────────────────────

--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -32,7 +32,7 @@ use crate::types::Type;
 // walker + renderers + `aver.toml` bridges. Internal use of the
 // recognition API in this file goes through `crate::analysis::shape`
 // directly (see imports below).
-use crate::analysis::shape::{Archetype, analyze_program};
+use crate::analysis::shape::{Archetype, ModulePattern, analyze_program_with_modules};
 
 // ─── ModuleShape vector + derived Kind ───────────────────────────────────────
 
@@ -625,6 +625,12 @@ pub struct ShapeReport {
     pub histogram: Histogram,
     pub layer: Option<LayerVerdict>,
     pub fns: Vec<FnShape>,
+    /// Module-level typed patterns recognized by `analysis::shape`
+    /// (stage 6 of #232). Populated from `program_shape.patterns`;
+    /// the renderer surfaces them in their own section so callers see
+    /// every refinement / wrapper / pipeline / renderer / fold the
+    /// substrate identified.
+    pub patterns: Vec<ModulePattern>,
 }
 
 pub fn analyze_path(path: &Path, module_root_hint: Option<&str>) -> Result<ShapeReport, String> {
@@ -740,12 +746,15 @@ pub fn analyze_source_with(
         })
         .collect();
 
-    // Stage 4 of #232: recognition substrate. `analyze_program` runs
-    // facts walk + SCC + classify in one go and returns the per-fn
-    // ProgramShape. Presentation tier (this fn) just adds the
-    // module-level Kind / verify / histogram / Layer scaffolding on
-    // top — the actual per-fn recognition no longer lives here.
-    let program_shape = analyze_program(&resolved_fns);
+    // Stage 4/6 of #232: recognition substrate.
+    // `analyze_program_with_modules` runs facts walk + SCC + classify
+    // and also populates `patterns` (module-level typed patterns:
+    // `RefinementSmartConstructor`, `WrapperOverRecursion`,
+    // `ResultPipelineChain`, `RendererFormatter`,
+    // `MatchDispatcherFold`). Presentation tier reads both —
+    // per-fn archetypes drive the histogram + Kind / Layer
+    // scaffolding; patterns get their own section in the renderer.
+    let program_shape = analyze_program_with_modules(&resolved_fns, &items, &dep_modules);
 
     let exposes_set: HashSet<&str> = exposes.iter().map(|s| s.as_str()).collect();
     let mut fn_shapes = Vec::with_capacity(resolved_fns.len());
@@ -823,6 +832,7 @@ pub fn analyze_source_with(
         histogram,
         layer,
         fns: fn_shapes,
+        patterns: program_shape.patterns,
     })
 }
 
@@ -973,6 +983,63 @@ pub struct RenderOptions {
     pub summary: bool,
 }
 
+/// One human-readable line for a single `ModulePattern`. Format:
+/// `<VariantName>  <key facts>` with the variant on the left so a
+/// `grep RefinementSmartConstructor` over the corpus output works.
+/// Scope-qualified names are rendered as `prefix::name` when the
+/// pattern lives in a dep module.
+fn render_module_pattern_line(p: &ModulePattern) -> String {
+    let scoped = |scope: &Option<String>, name: &str| -> String {
+        match scope {
+            Some(prefix) => format!("{prefix}::{name}"),
+            None => name.to_string(),
+        }
+    };
+    match p {
+        ModulePattern::RefinementSmartConstructor {
+            scope,
+            type_name,
+            carrier_field,
+            carrier_type,
+            constructor_fn,
+            ..
+        } => format!(
+            "RefinementSmartConstructor  {type_name}({carrier_field}: {carrier_type})  via {ctor}",
+            type_name = scoped(scope, type_name),
+            ctor = scoped(scope, constructor_fn),
+        ),
+        ModulePattern::WrapperOverRecursion {
+            wrapper_scope,
+            wrapper_fn,
+            inner_scope,
+            inner_fn,
+        } => format!(
+            "WrapperOverRecursion        {} → {}",
+            scoped(wrapper_scope, wrapper_fn),
+            scoped(inner_scope, inner_fn),
+        ),
+        ModulePattern::ResultPipelineChain {
+            scope,
+            fn_name,
+            step_count,
+        } => format!(
+            "ResultPipelineChain         {}  ({step_count} steps)",
+            scoped(scope, fn_name),
+        ),
+        ModulePattern::RendererFormatter { scope, fn_name } => {
+            format!("RendererFormatter           {}", scoped(scope, fn_name))
+        }
+        ModulePattern::MatchDispatcherFold {
+            scope,
+            fn_name,
+            list_param,
+        } => format!(
+            "MatchDispatcherFold         {}  (over {list_param})",
+            scoped(scope, fn_name),
+        ),
+    }
+}
+
 pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
     let mut out = String::new();
     // Header: `Module:` and `Kind:` share the value column. `Module:` is
@@ -1081,6 +1148,15 @@ pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
         }
     } else {
         out.push_str("\n  Layer: insufficient data\n");
+    }
+
+    if !report.patterns.is_empty() {
+        out.push_str("\n  Module patterns:\n");
+        for p in &report.patterns {
+            out.push_str("    ");
+            out.push_str(&render_module_pattern_line(p));
+            out.push('\n');
+        }
     }
 
     if !opts.summary {

--- a/tests/shape_module_patterns_spec.rs
+++ b/tests/shape_module_patterns_spec.rs
@@ -96,12 +96,19 @@ fn nonneg_float_module_emits_one_refinement_pattern() {
 }
 
 #[test]
-fn module_with_no_refinement_emits_no_pattern() {
+fn module_with_no_refinement_emits_no_refinement_pattern() {
     // Plain orchestration module — no opaque + smart constructor pair.
+    // It may still emit other module patterns (e.g. RendererFormatter
+    // for `showListInt`); the contract here is only that
+    // `RefinementSmartConstructor` does not fire.
     let patterns = detect_in_file("examples/data/quicksort.av");
+    let refinements: Vec<_> = patterns
+        .iter()
+        .filter(|p| matches!(p, ModulePattern::RefinementSmartConstructor { .. }))
+        .collect();
     assert!(
-        patterns.is_empty(),
-        "quicksort is not a refinement module; got {patterns:?}"
+        refinements.is_empty(),
+        "quicksort has no refinement record; got {refinements:?}"
     );
 }
 
@@ -191,6 +198,121 @@ fn fibonacci_module_pins_fib_over_fibtr_wrapper() {
     assert!(
         wrappers.contains(&(None, "fib".to_string(), None, "fibTR".to_string())),
         "expected fib→fibTR wrapper; got {wrappers:?}"
+    );
+}
+
+// ─── Stage 6d: ResultPipelineChain ──────────────────────────────────────────
+
+#[test]
+fn result_pipeline_module_pins_validate_and_combine_chain() {
+    let patterns = detect_in_file("examples/core/result_pipeline.av");
+    let chains: Vec<_> = patterns
+        .iter()
+        .filter_map(|p| match p {
+            ModulePattern::ResultPipelineChain {
+                fn_name,
+                step_count,
+                scope,
+            } => Some((scope.clone(), fn_name.clone(), *step_count)),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        chains.contains(&(None, "validateAndCombine".to_string(), 6)),
+        "expected validateAndCombine with 6 `?` steps; got {chains:?}"
+    );
+    // The single-step smart constructors (parsePositive, doubled,
+    // capAtThousand) don't qualify — body is one match, not a
+    // binding chain. The manual `match Result.Err -> Err` version
+    // (`validateAndCombineNoOp`) has zero `?` bindings.
+    assert!(
+        chains
+            .iter()
+            .all(|(_, name, _)| name == "validateAndCombine"),
+        "no other fn should match in this module; got {chains:?}"
+    );
+}
+
+#[test]
+fn refinement_module_emits_no_pipeline_chain() {
+    let patterns = detect_in_file("examples/refinement/natural/natural.av");
+    let chains: Vec<_> = patterns
+        .iter()
+        .filter(|p| matches!(p, ModulePattern::ResultPipelineChain { .. }))
+        .collect();
+    assert!(
+        chains.is_empty(),
+        "smart-constructor module has no `?` chains; got {chains:?}"
+    );
+}
+
+// ─── Stage 6e: RendererFormatter ────────────────────────────────────────────
+
+#[test]
+fn rle_module_pins_show_run_as_renderer() {
+    let patterns = detect_in_file("examples/data/rle.av");
+    let renderers: Vec<_> = patterns
+        .iter()
+        .filter_map(|p| match p {
+            ModulePattern::RendererFormatter { fn_name, scope } => {
+                Some((scope.clone(), fn_name.clone()))
+            }
+            _ => None,
+        })
+        .collect();
+    // `showRun` is a non-recursive pure interpolation.
+    assert!(
+        renderers.contains(&(None, "showRun".to_string())),
+        "expected showRun renderer; got {renderers:?}"
+    );
+    // `showRuns` is recursive (self-call in tail arm) — must NOT be
+    // emitted by this pattern.
+    assert!(
+        !renderers.contains(&(None, "showRuns".to_string())),
+        "recursive showRuns must not match RendererFormatter; got {renderers:?}"
+    );
+}
+
+// ─── Stage 6f: MatchDispatcherFold ──────────────────────────────────────────
+
+#[test]
+fn fibonacci_module_pins_nth_or_zero_fold() {
+    let patterns = detect_in_file("examples/data/fibonacci.av");
+    let folds: Vec<_> = patterns
+        .iter()
+        .filter_map(|p| match p {
+            ModulePattern::MatchDispatcherFold {
+                fn_name,
+                list_param,
+                scope,
+            } => Some((scope.clone(), fn_name.clone(), list_param.clone())),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        folds.contains(&(None, "nthOrZero".to_string(), "xs".to_string())),
+        "expected nthOrZero fold; got {folds:?}"
+    );
+    // `showListIntInner` also folds over a list but nests its match —
+    // the outer subject is `xs`, both nil and cons arms exist, and
+    // the fn self-recurses. This is intentional: the pattern claims
+    // *structural* list-fold shape, not "single match arm depth".
+    assert!(
+        folds.contains(&(None, "showListIntInner".to_string(), "xs".to_string())),
+        "expected showListIntInner fold; got {folds:?}"
+    );
+}
+
+#[test]
+fn refinement_module_emits_no_fold_pattern() {
+    let patterns = detect_in_file("examples/refinement/natural/natural.av");
+    let folds: Vec<_> = patterns
+        .iter()
+        .filter(|p| matches!(p, ModulePattern::MatchDispatcherFold { .. }))
+        .collect();
+    assert!(
+        folds.is_empty(),
+        "smart-constructor module has no list folds; got {folds:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
Two commits land the rest of stage 6 of #232:

1. **Three substrate patterns** (originally PR #241, auto-closed when its base merged):
   - `ResultPipelineChain` — `validateAndCombine` shape (\`?\`-bindings + tail Result.Ok)
   - `RendererFormatter` — non-recursive pure `String`-returning fn with interpolation
   - `MatchDispatcherFold` — self-recursive structural fold over a `List<T>` parameter

2. **CLI exposure** — `aver shape` now renders a `Module patterns:` section between `Layer:` and `Functions:`. The whole substrate becomes visible to humans + LLMs reading the output. Two AST walker tweaks make the detectors work on post-pipeline items (TailCall + Resolved name handling), not just parse-only test fixtures.

Sample output:
```
  Module patterns:
    WrapperOverRecursion        fib → fibTR
    MatchDispatcherFold         nthOrZero  (over xs)
    MatchDispatcherFold         showListIntInner  (over xs)
```

```
  Module patterns:
    ResultPipelineChain         validateAndCombine  (6 steps)
```

```
  Module patterns:
    RefinementSmartConstructor  Natural(value: Int)  via fromInt
```

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --release --test proof_spec` — 61/61
- [x] `cargo test --release --test shape_module_patterns_spec` — 13/13
- [x] `cargo test --release --test shape_spec --test shape_lint_cli_spec` — 3/3 + 14/14
- [x] Smoke test: `aver shape` on fibonacci / result_pipeline / rle / natural — all 5 pattern variants surfaced
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)