### PR TITLE
shape: route detect_induction_target through ProgramShape (#232 stage 7)

### DIFF
--- a/src/analysis/shape.rs
+++ b/src/analysis/shape.rs
@@ -526,6 +526,14 @@ pub struct ProgramShape {
     /// the source items needed to detect module-level shapes like
     /// `RefinementSmartConstructor`.
     pub patterns: Vec<ModulePattern>,
+    /// Source-level sum type names that are eligible as induction
+    /// targets: directly self-referential in at least one variant
+    /// and not indirectly recursive through nested generics the
+    /// per-variant emit can't case-split (e.g. `Some(List<Self>)`).
+    /// Mirrors `proof_lower::detect_induction_target`'s inline
+    /// scan so the detector can read this set instead of
+    /// re-walking type defs.
+    pub inductable_sum_types: HashSet<String>,
 }
 
 impl ProgramShape {
@@ -569,6 +577,7 @@ pub fn analyze_program(resolved_fns: &[&ResolvedFnDef]) -> ProgramShape {
         per_fn,
         sccs,
         patterns: Vec::new(),
+        inductable_sum_types: HashSet::new(),
     }
 }
 
@@ -583,6 +592,7 @@ pub fn analyze_program_with_modules(
 ) -> ProgramShape {
     let mut shape = analyze_program(resolved_fns);
     shape.patterns = detect_module_patterns(entry_items, dep_modules);
+    shape.inductable_sum_types = collect_inductable_sum_types(entry_items, dep_modules);
     shape
 }
 
@@ -747,6 +757,60 @@ pub enum ModulePattern {
         fn_name: String,
         list_param: String,
     },
+}
+
+/// Walk entry items + dep modules and collect the names of sum types
+/// that pass the proof-export induction eligibility check: directly
+/// self-referential in at least one variant, and not indirectly
+/// recursive through nested generics that the per-variant emit
+/// would have to give up on. Mirrors the inline scan that
+/// `proof_lower::detect_induction_target` used to perform so the
+/// detector can read from `ProgramShape.inductable_sum_types` and
+/// avoid re-walking the AST.
+pub fn collect_inductable_sum_types(
+    entry_items: &[crate::ast::TopLevel],
+    dep_modules: &[crate::codegen::ModuleInfo],
+) -> HashSet<String> {
+    use crate::ast::{TopLevel, TypeDef};
+    let mut out = HashSet::new();
+    let mut consider = |td: &TypeDef| {
+        if let TypeDef::Sum { name, variants, .. } = td
+            && crate::codegen::common::is_recursive_sum(name, variants)
+            && !indirect_rec_variants(variants, name)
+        {
+            out.insert(name.clone());
+        }
+    };
+    for item in entry_items {
+        if let TopLevel::TypeDef(td) = item {
+            consider(td);
+        }
+    }
+    for m in dep_modules {
+        for td in &m.type_defs {
+            consider(td);
+        }
+    }
+    out
+}
+
+/// Mirror of `proof_lower::has_indirect_rec_variants`: a variant
+/// field that contains `type_name` nested past one `<` is rejected
+/// because the per-variant induction case-split can't decompose it.
+fn indirect_rec_variants(variants: &[crate::ast::TypeVariant], type_name: &str) -> bool {
+    for variant in variants {
+        for field in &variant.fields {
+            let f = field.trim();
+            if f == type_name {
+                continue;
+            }
+            let opens = f.matches('<').count();
+            if opens > 1 && f.contains(type_name) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Walk entry items + dep modules and emit every typed

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -2535,6 +2535,28 @@ fn detect_induction_target(
     law: &crate::ast::VerifyLaw,
     inputs: &ProofLowerInputs,
 ) -> Option<String> {
+    // Stage 7 of #232: read the eligibility set from `ProgramShape`
+    // when threaded through `ProofLowerInputs`. The shape pass
+    // computes the same direct-rec + not-indirect-rec predicate
+    // once per compilation; the inline scan below is the
+    // pre-shape fallback so callers without a shape (legacy test
+    // fixtures, tools that build `ProofLowerInputs` by hand) keep
+    // working unchanged.
+    if let Some(shape) = inputs.program_shape {
+        for given in &law.givens {
+            if shape.inductable_sum_types.contains(&given.type_name) {
+                return Some(given.name.clone());
+            }
+        }
+        return None;
+    }
+    detect_induction_target_legacy(law, inputs)
+}
+
+fn detect_induction_target_legacy(
+    law: &crate::ast::VerifyLaw,
+    inputs: &ProofLowerInputs,
+) -> Option<String> {
     use crate::ast::TypeDef;
     for given in &law.givens {
         let Some(TypeDef::Sum {
@@ -2545,9 +2567,6 @@ fn detect_induction_target(
         else {
             continue;
         };
-        // Require at least one variant to reference the type
-        // itself — that's the recursion the induction case-split
-        // pivots on.
         let direct_rec = variants.iter().any(|variant| {
             variant.fields.iter().any(|field| {
                 let f = field.trim();
@@ -2561,8 +2580,6 @@ fn detect_induction_target(
         if !direct_rec {
             continue;
         }
-        // Reject indirect-recursion (e.g. via Option<Self> in a
-        // way the backend can't case-split cleanly).
         if has_indirect_rec_variants(variants, type_name) {
             continue;
         }

--- a/tests/shape_module_patterns_spec.rs
+++ b/tests/shape_module_patterns_spec.rs
@@ -5,7 +5,7 @@
 //! `codegen::common::refinement_info_for` already returns (so the
 //! stage 6b adapter migration is behavior-preserving).
 
-use aver::analysis::shape::{ModulePattern, detect_module_patterns};
+use aver::analysis::shape::{ModulePattern, collect_inductable_sum_types, detect_module_patterns};
 
 fn detect_in_file(path: &str) -> Vec<ModulePattern> {
     let source = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
@@ -327,4 +327,33 @@ fn refinement_module_emits_no_wrapper_pattern() {
         wrappers.is_empty(),
         "refinement module has no recursive inner fns; got {wrappers:?}"
     );
+}
+
+// ─── Stage 7: inductable_sum_types ──────────────────────────────────────────
+
+fn inductable_in_file(path: &str) -> std::collections::HashSet<String> {
+    let source = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let items = aver::source::parse_source(&source).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    let module_root = std::path::Path::new(path)
+        .parent()
+        .and_then(|p| p.to_str())
+        .unwrap_or(".");
+    let deps = aver::source::load_compile_deps(&items, module_root)
+        .unwrap_or_else(|e| panic!("deps: {e}"));
+    collect_inductable_sum_types(&items, &deps)
+}
+
+#[test]
+fn red_black_tree_module_pins_tree_as_inductable() {
+    let s = inductable_in_file("examples/data/red_black_tree.av");
+    assert!(
+        s.contains("Tree"),
+        "Tree is direct-recursive (Empty | Red(Tree,_,Tree) | Black(Tree,_,Tree)); got {s:?}"
+    );
+}
+
+#[test]
+fn refinement_module_emits_no_inductable_sum_types() {
+    let s = inductable_in_file("examples/refinement/natural/natural.av");
+    assert!(s.is_empty(), "Natural carries no sum types; got {s:?}");
 }


### PR DESCRIPTION
## Summary
Second `proof_lower` ad-hoc detector migrated to the substrate. `detect_induction_target` used to scan `TypeDef::Sum` variants inline; that check now lives in `analysis::shape::collect_inductable_sum_types` and the result is pinned on `ProgramShape.inductable_sum_types` (direct-rec ∩ not-indirect-rec).

Detector is a thin adapter — reads the set when a `ProgramShape` is threaded through `ProofLowerInputs`, falls back to the legacy inline scan otherwise (so hand-built test fixtures keep working).

Part of the post-DoD cleanup for #232: removing remaining ad-hoc shape walks in `proof_lower`.

## Test plan
- [x] `cargo test --release --test proof_spec` — 61/61 (snapshot guard: same strategies pinned before/after)
- [x] `cargo test --release --test shape_module_patterns_spec` — 15/15, two new tests pin `Tree` as inductable and assert refinement modules emit none
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)