### PR TITLE
proof: ProofStrategy::WrapperOverRecursion closes monoidal-accum laws (Dafny + Lean) (#232 stage 8)

### DIFF
--- a/examples/data/sum_acc.av
+++ b/examples/data/sum_acc.av
@@ -1,0 +1,43 @@
+module SumAcc
+    intent =
+        "Wrapper-over-recursion demo for proof export."
+        "sum/sumTR is the canonical accumulator-threading wrapper-over-recursion shape:"
+        "a non-recursive wrapper calls a self-recursive inner with neutral element."
+        "Paired with sumDirect (the direct recurrence) to enable a closable equivalence law."
+    effects []
+
+fn sumTR(xs: List<Int>, acc: Int) -> Int
+    ? "Tail-recursive sum: returns acc + total(xs)."
+    match xs
+        [] -> acc
+        [h, ..t] -> sumTR(t, acc + h)
+
+verify sumTR
+    sumTR([], 0)        => 0
+    sumTR([], 7)        => 7
+    sumTR([1, 2, 3], 0) => 6
+    sumTR([1, 2, 3], 4) => 10
+
+fn sum(xs: List<Int>) -> Int
+    ? "Sum of a list via a tail-recursive worker with neutral initial accumulator."
+    sumTR(xs, 0)
+
+verify sum
+    sum([])        => 0
+    sum([1, 2, 3]) => 6
+    sum([42])      => 42
+
+fn sumDirect(xs: List<Int>) -> Int
+    ? "Direct-recurrence sum: matches the algebraic content sum/sumTR encode."
+    match xs
+        [] -> 0
+        [h, ..t] -> h + sumDirect(t)
+
+verify sumDirect
+    sumDirect([])        => 0
+    sumDirect([1, 2, 3]) => 6
+    sumDirect([42])      => 42
+
+verify sum law equalsDirect
+    given xs: List<Int> = [[], [1], [1, 2, 3], [4, 5, 6, 7]]
+    sum(xs) => sumDirect(xs)

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1367,6 +1367,61 @@ fn emit_linear_recurrence2_support_stack(
     lines.join("\n")
 }
 
+/// Stage 8 of #232: support stack for `ProofStrategy::WrapperOverRecursion`.
+/// Emits the accumulator-decomposition aux lemma and the main universal
+/// lemma — `examples/data/sum_acc.av` is the canonical case. Z3 closes
+/// both via list induction; the aux lemma is the lifting that naive
+/// induction on the law can't supply by itself.
+///
+/// Output shape:
+/// ```dafny
+/// lemma <inner>_acc(xs: seq<int>, a: int)
+///   ensures <inner>(xs, a) == a <op> <inner>(xs, <neutral>)
+///   decreases |xs|
+/// { if |xs| > 0 { <inner>_acc(xs[1..], a <op> xs[0]); <inner>_acc(xs[1..], xs[0]); } }
+///
+/// lemma <law_theorem>(xs: seq<int>)
+///   ensures <wrapper>(xs) == <other>(xs)
+///   decreases |xs|
+/// { if |xs| > 0 { <inner>_acc(xs[1..], xs[0]); <law_theorem>(xs[1..]); } }
+/// ```
+fn emit_wrapper_over_recursion_support_stack(
+    wrapper_fn: &str,
+    inner_fn: &str,
+    other_fn: &str,
+    combine_op: crate::ast::BinOp,
+    impl_dafny: &str,
+    law_name_dafny: &str,
+) -> String {
+    let op_dafny = match combine_op {
+        crate::ast::BinOp::Add => "+",
+        crate::ast::BinOp::Mul => "*",
+        crate::ast::BinOp::Sub => "-",
+        _ => "+",
+    };
+    let neutral = match combine_op {
+        crate::ast::BinOp::Mul => "1",
+        _ => "0",
+    };
+    let wrapper_d = aver_name_to_dafny(wrapper_fn);
+    let inner_d = aver_name_to_dafny(inner_fn);
+    let other_d = aver_name_to_dafny(other_fn);
+    let acc_thm = format!("{inner_d}__acc");
+    let main_thm = format!("{impl_dafny}_{law_name_dafny}");
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "// Law: {wrapper_fn}.{law_name_dafny} — wrapper-over-recursion support stack"
+    ));
+    lines.push(format!(
+        "lemma {acc_thm}(xs: seq<int>, a: int)\n  ensures {inner_d}(xs, a) == a {op_dafny} {inner_d}(xs, {neutral})\n  decreases |xs|\n{{\n  if |xs| > 0 {{\n    {acc_thm}(xs[1..], a {op_dafny} xs[0]);\n    {acc_thm}(xs[1..], xs[0]);\n  }}\n}}"
+    ));
+    lines.push(format!(
+        "lemma {{:fuel {wrapper_d}, 5}} {{:fuel {other_d}, 5}} {main_thm}(xs: seq<int>)\n  ensures {wrapper_d}(xs) == {other_d}(xs)\n  decreases |xs|\n{{\n  if |xs| > 0 {{\n    {acc_thm}(xs[1..], xs[0]);\n    {main_thm}(xs[1..]);\n  }}\n}}\n"
+    ));
+    lines.join("\n")
+}
+
 pub fn emit_verify_law(
     vb: &VerifyBlock,
     law: &VerifyLaw,
@@ -1461,6 +1516,31 @@ pub fn emit_verify_law(
     {
         return emit_linear_recurrence2_support_stack(
             &impl_fn, &spec_fn, &helper_fn, &fn_name, &law_name,
+        );
+    }
+
+    // Stage 8 of #232 — `WrapperOverRecursion` support stack.
+    if let Some(crate::ir::ProofStrategy::WrapperOverRecursion {
+        wrapper_fn,
+        inner_fn,
+        other_fn,
+        combine_op,
+    }) = vb_fn_id
+        .and_then(|fn_id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        })
+        .map(|t| t.strategy.clone())
+    {
+        return emit_wrapper_over_recursion_support_stack(
+            &wrapper_fn,
+            &inner_fn,
+            &other_fn,
+            combine_op,
+            &fn_name,
+            &law_name,
         );
     }
 

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -255,6 +255,28 @@ pub fn emit_verify_law_forall_auto_proof(
         return Some(proof);
     }
 
+    // Stage 8 of #232 — `WrapperOverRecursion` support stack.
+    // Aux acc-decomposition lemma + main universal lemma; both
+    // close in core Lean 4 (`omega`) without Mathlib.
+    if let Some(crate::ir::ProofStrategy::WrapperOverRecursion {
+        wrapper_fn,
+        inner_fn,
+        other_fn,
+        combine_op,
+    }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+        && let Some(proof) = spec::emit_wrapper_over_recursion_law(
+            vb,
+            law,
+            ctx,
+            &wrapper_fn,
+            &inner_fn,
+            &other_fn,
+            combine_op,
+        )
+    {
+        return Some(proof);
+    }
+
     spec::emit_spec_function_equivalence_law(vb, law, ctx, &proof_intro_names)
         .or_else(|| {
             // IR-pinned Map library axiom (has_set_self / get_set_self).

--- a/src/codegen/lean/law_auto/spec/mod.rs
+++ b/src/codegen/lean/law_auto/spec/mod.rs
@@ -1,8 +1,10 @@
 mod linear_int;
 mod linear_recurrence2;
 mod simp_normalized;
+mod wrapper_over_recursion;
 
 pub(super) use linear_recurrence2::emit_second_order_linear_recurrence_spec_equivalence_law;
+pub(super) use wrapper_over_recursion::emit_wrapper_over_recursion_law;
 
 use crate::ast::{Expr, Spanned, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;

--- a/src/codegen/lean/law_auto/spec/wrapper_over_recursion.rs
+++ b/src/codegen/lean/law_auto/spec/wrapper_over_recursion.rs
@@ -1,0 +1,74 @@
+//! Stage 8 of #232: Lean emit for `ProofStrategy::WrapperOverRecursion`.
+//!
+//! Mirror of the Dafny support-stack emit in `dafny::toplevel`. The IR
+//! pin gives us `(wrapper_fn, inner_fn, other_fn, combine_op)` —
+//! enough to render the accumulator-decomposition aux lemma plus the
+//! main universal lemma. Both close in core Lean 4 (`omega`) without
+//! a Mathlib dependency, matching the existing AverCommon shape.
+
+use crate::ast::{BinOp, VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+use super::super::super::expr::aver_name_to_lean;
+use super::super::AutoProof;
+
+/// Render the Lean 4 support stack and main proof body for a
+/// `WrapperOverRecursion` law. Returns `None` when the strategy
+/// payload doesn't carry the data the template needs (defensive —
+/// the lowerer should always provide it).
+pub(in super::super) fn emit_wrapper_over_recursion_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    _ctx: &CodegenContext,
+    wrapper_fn: &str,
+    inner_fn: &str,
+    other_fn: &str,
+    combine_op: BinOp,
+) -> Option<AutoProof> {
+    let op = match combine_op {
+        BinOp::Add => "+",
+        BinOp::Mul => "*",
+        BinOp::Sub => "-",
+        _ => return None,
+    };
+    let neutral = match combine_op {
+        BinOp::Mul => "1",
+        _ => "0",
+    };
+    let wrapper_l = aver_name_to_lean(wrapper_fn);
+    let inner_l = aver_name_to_lean(inner_fn);
+    let other_l = aver_name_to_lean(other_fn);
+    let acc_thm = format!("{inner_l}_acc");
+
+    let support_lines = vec![
+        format!(
+            "theorem {acc_thm} (xs : List Int) (a : Int) : {inner_l} xs a = a {op} {inner_l} xs {neutral} := by"
+        ),
+        "  induction xs generalizing a with".to_string(),
+        format!("  | nil => simp [{inner_l}]"),
+        format!(
+            "  | cons h t ih => simp only [{inner_l}]; rw [ih (a {op} h), ih ({neutral} {op} h)]; omega"
+        ),
+    ];
+
+    // The toplevel renderer emits `theorem ... := by` and then extends
+    // the proof_lines verbatim under it — so every line here needs
+    // the two-space indent that puts it inside the `by` block.
+    let proof_lines = vec![
+        "  intro xs".to_string(),
+        "  induction xs with".to_string(),
+        format!("  | nil => simp [{wrapper_l}, {inner_l}, {other_l}]"),
+        "  | cons h t ih =>".to_string(),
+        format!("    simp only [{wrapper_l}, {inner_l}, {other_l}]"),
+        format!("    rw [{acc_thm} t ({neutral} {op} h)]"),
+        format!("    simp only [{wrapper_l}] at ih"),
+        "    omega".to_string(),
+    ];
+
+    let _ = (vb, law);
+    Some(AutoProof {
+        support_lines,
+        proof_lines,
+        replaces_theorem: false,
+    })
+}

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -880,6 +880,19 @@ fn classify_law_strategy(
 ) -> crate::ir::ProofStrategy {
     use crate::ir::ProofStrategy;
 
+    // Wrapper-over-recursion with monoidal accumulator (stage 8 of
+    // #232) — runs before generic induction because its aux-lemma
+    // template closes laws naive induction can't (e.g. `sum(xs) ==
+    // sumDirect(xs)` where `sum(xs) = sumTR(xs, 0)`). Detected
+    // when `fn_name` is registered as a `WrapperOverRecursion`
+    // pattern in `ProgramShape` AND the law shape is
+    // `wrapper(g) == other(g)` AND the inner fn body matches the
+    // monoidal-accumulator template.
+    if law.when.is_none()
+        && let Some(s) = detect_wrapper_over_recursion(law, fn_name, inputs)
+    {
+        return s;
+    }
     // Structural induction runs first — when any given binds a
     // recursive ADT, induction over its variants is the canonical
     // proof. Reflexive could also fire on `f(t) = f(t)` for `t: Tree`
@@ -2531,6 +2544,190 @@ fn is_bool_true(expr: &Spanned<crate::ast::Expr>) -> bool {
 /// shapes are rejected here — the backend's emit can't handle
 /// them and would fail at lake-build time; better to fall through
 /// to `BackendDispatch` than pin a bad strategy.
+/// Stage 8 of #232: detect `wrapper(g) == other(g)` where `wrapper`
+/// is a `ModulePattern::WrapperOverRecursion` and the inner fn has a
+/// monoidal-accumulator shape we know how to emit Dafny support
+/// theorems for. Returns the typed strategy carrying enough payload
+/// for the backend to emit the aux acc-decomposition lemma without
+/// re-walking the AST.
+fn detect_wrapper_over_recursion(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<crate::ir::ProofStrategy> {
+    use crate::analysis::shape::ModulePattern;
+    use crate::ast::{BinOp, Expr, Pattern, Stmt};
+
+    // Pre-pipeline AST has `Expr::Ident(n)`; post-pipeline the
+    // resolver rewrites local/param idents to `Expr::Resolved { name }`.
+    // Both forms identify the same surface name.
+    fn ident_name(e: &Spanned<Expr>) -> Option<&str> {
+        match &e.node {
+            Expr::Ident(n) => Some(n.as_str()),
+            Expr::Resolved { name, .. } => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
+    let shape = inputs.program_shape?;
+
+    // Only handle single-given laws — the template is parameterized
+    // by one universal `xs`.
+    if law.givens.len() != 1 {
+        return None;
+    }
+    let given_name = &law.givens[0].name;
+
+    // Find the matching pattern in the shape — wrapper_fn must
+    // equal the law's surrounding fn.
+    let (wrapper_fn, inner_fn) = shape.patterns.iter().find_map(|p| match p {
+        ModulePattern::WrapperOverRecursion {
+            wrapper_fn,
+            inner_fn,
+            ..
+        } if wrapper_fn == fn_name => Some((wrapper_fn.clone(), inner_fn.clone())),
+        _ => None,
+    })?;
+
+    // Law shape: `wrapper(g) == other(g)` (either side).
+    let extract = |expr: &Spanned<crate::ast::Expr>| -> Option<String> {
+        let Expr::FnCall(callee, args) = &expr.node else {
+            return None;
+        };
+        let name = ident_name(callee)?;
+        if args.len() != 1 {
+            return None;
+        }
+        if ident_name(&args[0])? != given_name {
+            return None;
+        }
+        Some(name.to_string())
+    };
+    let lhs_call = extract(&law.lhs);
+    let rhs_call = extract(&law.rhs);
+    let other_fn = match (lhs_call, rhs_call) {
+        (Some(l), Some(r)) if l == wrapper_fn && r != wrapper_fn => r,
+        (Some(l), Some(r)) if r == wrapper_fn && l != wrapper_fn => l,
+        _ => return None,
+    };
+
+    // Inner fn must have body shape
+    //   match xs { [] -> acc; [h, ..t] -> inner(t, acc OP h) }
+    // — extract OP.
+    let inner_fd = inputs.find_fn_def_by_call_name(&inner_fn)?;
+    if inner_fd.params.len() != 2 {
+        return None;
+    }
+    let stmts = inner_fd.body.stmts();
+    if stmts.len() != 1 {
+        return None;
+    }
+    let Stmt::Expr(body) = &stmts[0] else {
+        return None;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return None;
+    };
+    if ident_name(subject)? != inner_fd.params[0].0 {
+        return None;
+    }
+    if arms.len() != 2 {
+        return None;
+    }
+    let mut nil_acc_ok = false;
+    let mut cons_op: Option<BinOp> = None;
+    let acc_name = &inner_fd.params[1].0;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::EmptyList => {
+                if ident_name(&arm.body) == Some(acc_name.as_str()) {
+                    nil_acc_ok = true;
+                }
+            }
+            Pattern::Cons(head_name, tail_name) => {
+                // Body must be `inner(tail, acc OP head)` (or with `head OP acc`).
+                // Post-pipeline the call can also be a `TailCall`.
+                let (callee_name, args) = match &arm.body.node {
+                    Expr::FnCall(c, a) => (ident_name(c)?, a.clone()),
+                    Expr::TailCall(td) => (td.target.as_str(), td.args.clone()),
+                    _ => return None,
+                };
+                if callee_name != inner_fn {
+                    return None;
+                }
+                if args.len() != 2 {
+                    return None;
+                }
+                if ident_name(&args[0])? != tail_name.as_str() {
+                    return None;
+                }
+                let Expr::BinOp(op, l, r) = &args[1].node else {
+                    return None;
+                };
+                if !matches!(op, BinOp::Add | BinOp::Mul) {
+                    return None;
+                }
+                let l_n = ident_name(l);
+                let r_n = ident_name(r);
+                let l_is_acc = l_n == Some(acc_name.as_str());
+                let r_is_head = r_n == Some(head_name.as_str());
+                let l_is_head = l_n == Some(head_name.as_str());
+                let r_is_acc = r_n == Some(acc_name.as_str());
+                if !((l_is_acc && r_is_head) || (l_is_head && r_is_acc)) {
+                    return None;
+                }
+                cons_op = Some(*op);
+            }
+            _ => return None,
+        }
+    }
+    if !nil_acc_ok {
+        return None;
+    }
+    let combine_op = cons_op?;
+
+    // Wrapper body must be `inner(<given>, neutral)` where neutral is
+    // 0 for Add and 1 for Mul. Verify against the fn def to be sure.
+    let wrapper_fd = inputs.find_fn_def_by_call_name(&wrapper_fn)?;
+    let wstmts = wrapper_fd.body.stmts();
+    if wstmts.len() != 1 {
+        return None;
+    }
+    let Stmt::Expr(wbody) = &wstmts[0] else {
+        return None;
+    };
+    let (wcallee_name, wargs) = match &wbody.node {
+        Expr::FnCall(c, a) => (ident_name(c)?, a.clone()),
+        Expr::TailCall(td) => (td.target.as_str(), td.args.clone()),
+        _ => return None,
+    };
+    if wcallee_name != inner_fn {
+        return None;
+    }
+    if wargs.len() != 2 {
+        return None;
+    }
+    let expected_neutral: i64 = match combine_op {
+        BinOp::Add | BinOp::Sub => 0,
+        BinOp::Mul => 1,
+        _ => return None,
+    };
+    let neutral_matches = matches!(
+        &wargs[1].node,
+        Expr::Literal(crate::ast::Literal::Int(n)) if *n == expected_neutral
+    );
+    if !neutral_matches {
+        return None;
+    }
+
+    Some(crate::ir::ProofStrategy::WrapperOverRecursion {
+        wrapper_fn,
+        inner_fn,
+        other_fn,
+        combine_op,
+    })
+}
+
 fn detect_induction_target(
     law: &crate::ast::VerifyLaw,
     inputs: &ProofLowerInputs,

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -629,6 +629,30 @@ pub enum ProofStrategy {
     /// Bounded universal: case-split over the declared `given`
     /// domain, dispatch each case to a per-sample lemma.
     BoundedUniversal,
+    /// Monoidal-accumulator wrapper-over-recursion: a non-recursive
+    /// `wrapper_fn(xs) = inner_fn(xs, neutral)` paired with a direct-
+    /// recurrence `other_fn` such that the law states
+    /// `wrapper_fn(xs) == other_fn(xs)`. The inner fn has shape
+    /// `match xs { [] -> acc; [h, ..t] -> inner_fn(t, acc <op> h) }`
+    /// where `<op>` is monoidal (`Add` / `Mul` / `Sub` on Int) with
+    /// known neutral element. Strategy emits an aux accumulator-
+    /// decomposition lemma plus the main universal lemma; Z3 closes
+    /// both via list induction. Demonstrated by `examples/data/sum_acc.av`.
+    ///
+    /// Stage 8 of #232 — first ProofStrategy variant that consumes
+    /// a `ModulePattern` from `analysis::shape`.
+    WrapperOverRecursion {
+        /// Source name of the non-recursive wrapper (e.g. `"sum"`).
+        wrapper_fn: String,
+        /// Source name of the self-recursive inner (e.g. `"sumTR"`).
+        inner_fn: String,
+        /// Source name of the direct-recurrence fn the law compares
+        /// the wrapper against (e.g. `"sumDirect"`).
+        other_fn: String,
+        /// Binary op the inner threads through its accumulator
+        /// (`Add` / `Mul` / `Sub`). Drives the aux lemma's RHS.
+        combine_op: crate::ast::BinOp,
+    },
     /// No automated strategy — emit with `sorry` (Lean) / `assume
     /// {:axiom}` (Dafny). User fills in manually.
     Sorry,

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -254,11 +254,11 @@ fn proof_dafny_verifies_sum_acc_when_dafny_is_available() {
 
 #[test]
 fn proof_export_builds_sum_acc_when_lake_is_available() {
-    // Lean side still emits `sorry` on the universal proof — the
-    // Lean template for `WrapperOverRecursion` is a planned
-    // follow-up. Per-sample lemmas (`_sample_N`) verify on the
-    // declared domain via `native_decide`.
-    assert_proof_builds_with_sorry_budget("examples/data/sum_acc.av", "aver-proof-sum-acc", 1);
+    // Lean template for `WrapperOverRecursion` emits the aux
+    // accumulator-decomposition theorem + main universal lemma; both
+    // close in core Lean 4 (`omega`) without Mathlib. Sorry budget
+    // 0 — the strategy fully closes the universal proof.
+    assert_proof_builds_with_sorry_budget("examples/data/sum_acc.av", "aver-proof-sum-acc", 0);
 }
 
 #[test]

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -239,6 +239,29 @@ fn proof_dafny_verifies_fibonacci_when_dafny_is_available() {
 }
 
 #[test]
+fn proof_dafny_verifies_sum_acc_when_dafny_is_available() {
+    // Stage 8 of #232: `ProofStrategy::WrapperOverRecursion` closes
+    // the `sum(xs) == sumDirect(xs)` law on the `sum_acc` example by
+    // emitting an accumulator-decomposition aux lemma plus the main
+    // universal lemma. Both close in Z3 via list induction —
+    // demonstrates the first real consumer of the
+    // `analysis::shape::ModulePattern::WrapperOverRecursion` typed
+    // pattern. Regression guard: if a future change disables the
+    // strategy or breaks the aux template, this lemma falls back to
+    // naive induction and Dafny reports 1 error.
+    assert_dafny_verifies("examples/data/sum_acc.av", "aver-dafny-sum-acc");
+}
+
+#[test]
+fn proof_export_builds_sum_acc_when_lake_is_available() {
+    // Lean side still emits `sorry` on the universal proof — the
+    // Lean template for `WrapperOverRecursion` is a planned
+    // follow-up. Per-sample lemmas (`_sample_N`) verify on the
+    // declared domain via `native_decide`.
+    assert_proof_builds_with_sorry_budget("examples/data/sum_acc.av", "aver-proof-sum-acc", 1);
+}
+
+#[test]
 fn proof_export_builds_rle_when_lake_is_available() {
     // Two sampled-domain laws (encodeString / decodeString roundtrip
     // shapes) hit the universal-not-auto-proved fallback. Same gate


### PR DESCRIPTION
## Summary
First `ProofStrategy` variant that consumes a typed `ModulePattern` from `analysis::shape`. Closes the `sum(xs) == sumDirect(xs)` shape on both Dafny and Lean backends — no aux invariant supplied by the user.

**Detected** when:
- `fn_name` is registered as `ModulePattern::WrapperOverRecursion` in `ProgramShape.patterns`
- law shape is `wrapper(g) == other(g)` with one given
- inner fn body: `match xs { [] -> acc; [h, ..t] -> inner(t, acc <op> h) }` with `<op>` ∈ { Add, Mul }
- wrapper passes the neutral element (0 for Add, 1 for Mul)

**Emits** an accumulator-decomposition aux lemma + main universal lemma. Both close via list induction:

- **Dafny**: Z3 closes both via list induction
- **Lean**: `induction xs generalizing a` + `omega` — pure core Lean 4, no Mathlib

New `examples/data/sum_acc.av` is the canonical demo. Before: Dafny `1 error`, Lean `sorry`. After: both close cleanly.

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --release --test proof_spec` — 63/63 (61 pre-existing + 2 new sum_acc tests, snapshot guard trzyma)
- [x] `cargo test --release --test shape_module_patterns_spec` — 15/15
- [x] Manual `aver proof --backend dafny examples/data/sum_acc.av && dafny verify` — 8 verified, 0 errors
- [x] Manual `aver proof --backend lean examples/data/sum_acc.av && lake build` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)