### PR TITLE
proof: ProofStrategy::ResultPipelineChain closes ?-chain ≡ manual-match laws (Dafny + Lean) (#232 stage 8b)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ editors/vscode/*.vsix
 
 # Local prompts / notes — not part of the repo
 prompts/
+examples/data/shape.png

--- a/examples/core/result_chain.av
+++ b/examples/core/result_chain.av
@@ -1,0 +1,56 @@
+module ResultChain
+    intent =
+        "ResultPipelineChain proof-export demo."
+        "chainQM uses `?` propagation across two fallible steps."
+        "chainManual writes the same flow as nested match arms with explicit Err pass-through."
+        "Both fns are observably identical; the law states the equivalence and the proof closes by unfolding both sides."
+    effects []
+
+fn parseStep1(n: Int) -> Result<Int, String>
+    ? "First step: rejects non-positive integers."
+    match n > 0
+        true  -> Result.Ok(n)
+        false -> Result.Err("non-positive")
+
+verify parseStep1
+    parseStep1(1)  => Result.Ok(1)
+    parseStep1(0)  => Result.Err("non-positive")
+    parseStep1(-3) => Result.Err("non-positive")
+
+fn parseStep2(n: Int) -> Result<Int, String>
+    ? "Second step: rejects values above 100."
+    match n > 100
+        true  -> Result.Err("over cap")
+        false -> Result.Ok(n * 2)
+
+verify parseStep2
+    parseStep2(5)   => Result.Ok(10)
+    parseStep2(101) => Result.Err("over cap")
+
+fn chainQM(n: Int) -> Result<Int, String>
+    ? "`?`-propagating chain: short-circuits on the first Err with its own value."
+    a = parseStep1(n)?
+    b = parseStep2(a)?
+    Result.Ok(b + 1)
+
+verify chainQM
+    chainQM(5)   => Result.Ok(11)
+    chainQM(0)   => Result.Err("non-positive")
+    chainQM(101) => Result.Err("over cap")
+
+fn chainManual(n: Int) -> Result<Int, String>
+    ? "Manual nested-match version: every Err arm is `Result.Err(e) -> Result.Err(e)` pass-through."
+    match parseStep1(n)
+        Result.Err(e) -> Result.Err(e)
+        Result.Ok(a)  -> match parseStep2(a)
+            Result.Err(e) -> Result.Err(e)
+            Result.Ok(b)  -> Result.Ok(b + 1)
+
+verify chainManual
+    chainManual(5)   => Result.Ok(11)
+    chainManual(0)   => Result.Err("non-positive")
+    chainManual(101) => Result.Err("over cap")
+
+verify chainQM law equalsManual
+    given n: Int = [-3, 0, 1, 50, 200]
+    chainQM(n) => chainManual(n)

--- a/src/analysis/shape.rs
+++ b/src/analysis/shape.rs
@@ -713,6 +713,13 @@ pub enum ModulePattern {
         scope: Option<String>,
         fn_name: String,
         step_count: usize,
+        /// Source names of the step fns called via `?` in body
+        /// order. Captured here because the post-pipeline AST
+        /// desugars `?` into nested `match` arms — downstream
+        /// consumers that need the original step list (e.g. the
+        /// proof_lower `ResultPipelineChain` strategy) read from
+        /// this field instead of re-walking.
+        step_fns: Vec<String>,
     },
     /// Non-recursive pure renderer: a fn whose return type is `String`,
     /// effects list is empty, and body contains an `InterpolatedStr`
@@ -1129,22 +1136,25 @@ fn detect_result_pipeline_chain(
         if !matches!(stmts.last(), Some(Stmt::Expr(_))) {
             continue;
         }
-        let step_count = stmts
-            .iter()
-            .filter(|s| {
-                matches!(
-                    s,
-                    Stmt::Binding(_, _, e) if matches!(e.node, Expr::ErrorProp(_))
-                )
-            })
-            .count();
-        if step_count < 2 {
+        let mut step_fns: Vec<String> = Vec::new();
+        for stmt in stmts {
+            if let Stmt::Binding(_, _, value) = stmt
+                && let Expr::ErrorProp(inner) = &value.node
+                && let Expr::FnCall(callee, _) = &inner.node
+                && let Expr::Ident(name) = &callee.node
+            {
+                step_fns.push(name.clone());
+            }
+        }
+        if step_fns.len() < 2 {
             continue;
         }
+        let step_count = step_fns.len();
         out.push(ModulePattern::ResultPipelineChain {
             scope: scope.clone(),
             fn_name: fd.name.clone(),
             step_count,
+            step_fns,
         });
     }
 }

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1519,6 +1519,39 @@ pub fn emit_verify_law(
         );
     }
 
+    // Stage 8b of #232 — `ResultPipelineChain` (Dafny needs only a
+    // fuel-bumped trivial body; Z3 unfolds both fns and closes by
+    // structural equality). Explicit branch makes the strategy
+    // choice observable in proof_ir.
+    if let Some(crate::ir::ProofStrategy::ResultPipelineChain {
+        chain_qm_fn,
+        chain_manual_fn,
+        step_fns,
+    }) = vb_fn_id
+        .and_then(|fn_id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        })
+        .map(|t| t.strategy.clone())
+    {
+        let qm_d = aver_name_to_dafny(&chain_qm_fn);
+        let manual_d = aver_name_to_dafny(&chain_manual_fn);
+        let main_thm = format!("{fn_name}_{law_name}");
+        let mut fuels: Vec<String> = vec![
+            format!("{{:fuel {qm_d}, 5}}"),
+            format!("{{:fuel {manual_d}, 5}}"),
+        ];
+        for s in &step_fns {
+            fuels.push(format!("{{:fuel {}, 5}}", aver_name_to_dafny(s)));
+        }
+        return format!(
+            "// Law: {chain_qm_fn}.{law_name} — result-pipeline chain equivalence\nlemma {} {main_thm}(n: int)\n  ensures {qm_d}(n) == {manual_d}(n)\n{{\n}}\n",
+            fuels.join(" "),
+        );
+    }
+
     // Stage 8 of #232 — `WrapperOverRecursion` support stack.
     if let Some(crate::ir::ProofStrategy::WrapperOverRecursion {
         wrapper_fn,

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -255,6 +255,26 @@ pub fn emit_verify_law_forall_auto_proof(
         return Some(proof);
     }
 
+    // Stage 8b of #232 — `ResultPipelineChain`. Unfold both fns +
+    // every step fn, then `repeat split` peels off match layers
+    // until structural equality remains.
+    if let Some(crate::ir::ProofStrategy::ResultPipelineChain {
+        chain_qm_fn,
+        chain_manual_fn,
+        step_fns,
+    }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+        && let Some(proof) = spec::emit_result_pipeline_chain_law(
+            vb,
+            law,
+            ctx,
+            &chain_qm_fn,
+            &chain_manual_fn,
+            &step_fns,
+        )
+    {
+        return Some(proof);
+    }
+
     // Stage 8 of #232 — `WrapperOverRecursion` support stack.
     // Aux acc-decomposition lemma + main universal lemma; both
     // close in core Lean 4 (`omega`) without Mathlib.

--- a/src/codegen/lean/law_auto/spec/mod.rs
+++ b/src/codegen/lean/law_auto/spec/mod.rs
@@ -1,9 +1,11 @@
 mod linear_int;
 mod linear_recurrence2;
+mod result_pipeline_chain;
 mod simp_normalized;
 mod wrapper_over_recursion;
 
 pub(super) use linear_recurrence2::emit_second_order_linear_recurrence_spec_equivalence_law;
+pub(super) use result_pipeline_chain::emit_result_pipeline_chain_law;
 pub(super) use wrapper_over_recursion::emit_wrapper_over_recursion_law;
 
 use crate::ast::{Expr, Spanned, VerifyBlock, VerifyLaw};

--- a/src/codegen/lean/law_auto/spec/result_pipeline_chain.rs
+++ b/src/codegen/lean/law_auto/spec/result_pipeline_chain.rs
@@ -1,0 +1,43 @@
+//! Stage 8b of #232: Lean emit for `ProofStrategy::ResultPipelineChain`.
+//!
+//! The two chains (`?`-propagating and manual `match Result.Err -> Err`
+//! nested) unfold to the same nested `match` tree. The proof closes
+//! generically by unfolding every fn in the unfold list and then
+//! repeatedly applying `split` to peel off each match layer; what
+//! remains is structural equality which `simp_all` discharges.
+
+use crate::ast::{VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+use super::super::super::expr::aver_name_to_lean;
+use super::super::AutoProof;
+
+pub(in super::super) fn emit_result_pipeline_chain_law(
+    _vb: &VerifyBlock,
+    _law: &VerifyLaw,
+    _ctx: &CodegenContext,
+    chain_qm_fn: &str,
+    chain_manual_fn: &str,
+    step_fns: &[String],
+) -> Option<AutoProof> {
+    let qm_l = aver_name_to_lean(chain_qm_fn);
+    let manual_l = aver_name_to_lean(chain_manual_fn);
+    let mut unfold_list: Vec<String> = vec![qm_l, manual_l];
+    for s in step_fns {
+        unfold_list.push(aver_name_to_lean(s));
+    }
+    let unfolds = unfold_list.join(" ");
+
+    let proof_lines = vec![
+        "  intro n".to_string(),
+        format!("  unfold {unfolds}"),
+        "  repeat (first | split | rfl)".to_string(),
+        "  all_goals simp_all".to_string(),
+    ];
+
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        proof_lines,
+        replaces_theorem: false,
+    })
+}

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -880,6 +880,15 @@ fn classify_law_strategy(
 ) -> crate::ir::ProofStrategy {
     use crate::ir::ProofStrategy;
 
+    // Result-pipeline chain equivalence (stage 8b of #232) — `?`
+    // propagation `chain_qm(x)` vs nested-match `chain_manual(x)`.
+    // Both sides unfold to the same nested match; the proof closes
+    // by `unfold + repeat split`.
+    if law.when.is_none()
+        && let Some(s) = detect_result_pipeline_chain_equivalence(law, fn_name, inputs)
+    {
+        return s;
+    }
     // Wrapper-over-recursion with monoidal accumulator (stage 8 of
     // #232) — runs before generic induction because its aux-lemma
     // template closes laws naive induction can't (e.g. `sum(xs) ==
@@ -2544,6 +2553,138 @@ fn is_bool_true(expr: &Spanned<crate::ast::Expr>) -> bool {
 /// shapes are rejected here — the backend's emit can't handle
 /// them and would fail at lake-build time; better to fall through
 /// to `BackendDispatch` than pin a bad strategy.
+/// Stage 8b of #232: detect `chain_qm(g) == chain_manual(g)` where
+/// `chain_qm` is a `ModulePattern::ResultPipelineChain` (the `?`-chain
+/// fn) and `chain_manual` is a manual `match Result.Err -> Err`
+/// nested chain over the same step fns. Returns a payload carrying
+/// both fn names + the ordered step list so backends can emit the
+/// unfold list without re-walking the AST.
+fn detect_result_pipeline_chain_equivalence(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<crate::ir::ProofStrategy> {
+    use crate::analysis::shape::ModulePattern;
+    use crate::ast::{Expr, Pattern, Stmt};
+
+    fn ident_name(e: &Spanned<Expr>) -> Option<&str> {
+        match &e.node {
+            Expr::Ident(n) => Some(n.as_str()),
+            Expr::Resolved { name, .. } => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
+    let shape = inputs.program_shape?;
+
+    if law.givens.len() != 1 {
+        return None;
+    }
+    let given_name = &law.givens[0].name;
+
+    // Confirm fn_name is a ResultPipelineChain in the shape, and
+    // pull the step fn list from there — post-pipeline AST has
+    // already desugared `?` into nested matches, so the shape
+    // (built from pre-resolver source items) is the authoritative
+    // record of the original step list.
+    let (chain_qm_fn, step_fns) = shape.patterns.iter().find_map(|p| match p {
+        ModulePattern::ResultPipelineChain {
+            fn_name: n,
+            step_fns,
+            ..
+        } if n == fn_name => Some((n.clone(), step_fns.clone())),
+        _ => None,
+    })?;
+
+    // Law shape: `chain_qm(g) == chain_manual(g)` (either side).
+    let extract = |expr: &Spanned<Expr>| -> Option<String> {
+        let Expr::FnCall(callee, args) = &expr.node else {
+            return None;
+        };
+        let name = ident_name(callee)?;
+        if args.len() != 1 {
+            return None;
+        }
+        if ident_name(&args[0])? != given_name {
+            return None;
+        }
+        Some(name.to_string())
+    };
+    let lhs_call = extract(&law.lhs);
+    let rhs_call = extract(&law.rhs);
+    let chain_manual_fn = match (lhs_call, rhs_call) {
+        (Some(l), Some(r)) if l == chain_qm_fn && r != chain_qm_fn => r,
+        (Some(l), Some(r)) if r == chain_qm_fn && l != chain_qm_fn => l,
+        _ => return None,
+    };
+
+    if step_fns.len() < 2 {
+        return None;
+    }
+
+    // Verify the manual fn is a nested `match Result.Err -> Err`
+    // chain calling the same step fns. Heuristic: walk body, look
+    // for `Match { subject: Call(step, _), arms: [Err -> Err, Ok -> ...] }`
+    // pattern. Counts how many step calls show up.
+    let manual_fd = inputs.find_fn_def_by_call_name(&chain_manual_fn)?;
+    let mut manual_steps: Vec<String> = Vec::new();
+    fn walk_manual<'a>(
+        expr: &'a Spanned<Expr>,
+        steps: &mut Vec<String>,
+        ident_name: &dyn Fn(&'a Spanned<Expr>) -> Option<&'a str>,
+    ) {
+        if let Expr::Match { subject, arms } = &expr.node
+            && let Expr::FnCall(callee, _) = &subject.node
+            && let Some(n) = ident_name(subject).or_else(|| ident_name(callee))
+        {
+            let has_err_pass = arms.iter().any(|a| {
+                let pat_is_err = matches!(
+                    &a.pattern,
+                    Pattern::Constructor(c, _) if c == "Result.Err" || c.ends_with(".Err")
+                );
+                // Body shape: either `Expr::Constructor("Result.Err", _)`
+                // (pre-resolver) or `Expr::FnCall(Attr(Ident("Result"), "Err"), _)`
+                // (post-resolver — `Result.Err(...)` is treated as a
+                // method-attr call once names are wired up).
+                let body_is_err = match &a.body.node {
+                    Expr::Constructor(c, _) => c == "Result.Err" || c.ends_with(".Err"),
+                    Expr::FnCall(callee, _) => matches!(
+                        &callee.node,
+                        Expr::Attr(base, attr)
+                            if attr == "Err"
+                                && matches!(&base.node, Expr::Ident(b) if b == "Result")
+                    ),
+                    _ => false,
+                };
+                pat_is_err && body_is_err
+            });
+            if has_err_pass {
+                steps.push(n.to_string());
+            }
+            for a in arms {
+                walk_manual(&a.body, steps, ident_name);
+            }
+        }
+    }
+    let manual_stmts = manual_fd.body.stmts();
+    if manual_stmts.len() != 1 {
+        return None;
+    }
+    let Stmt::Expr(manual_root) = &manual_stmts[0] else {
+        return None;
+    };
+    walk_manual(manual_root, &mut manual_steps, &ident_name);
+    if manual_steps.len() < 2 {
+        return None;
+    }
+
+    Some(crate::ir::ProofStrategy::ResultPipelineChain {
+        chain_qm_fn,
+        chain_manual_fn,
+        step_fns,
+    })
+}
+
 /// Stage 8 of #232: detect `wrapper(g) == other(g)` where `wrapper`
 /// is a `ModulePattern::WrapperOverRecursion` and the inner fn has a
 /// monoidal-accumulator shape we know how to emit Dafny support

--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -1027,6 +1027,7 @@ fn render_module_pattern_line(p: &ModulePattern) -> String {
             scope,
             fn_name,
             step_count,
+            ..
         } => format!(
             "{}         {}  ({} steps)",
             "ResultPipelineChain".magenta().bold(),
@@ -1355,11 +1356,13 @@ fn module_pattern_to_json(p: &ModulePattern) -> serde_json::Value {
             scope,
             fn_name,
             step_count,
+            step_fns,
         } => json!({
             "kind": "ResultPipelineChain",
             "scope": scope_json(scope),
             "fn_name": fn_name,
             "step_count": step_count,
+            "step_fns": step_fns,
         }),
         ModulePattern::RendererFormatter { scope, fn_name } => json!({
             "kind": "RendererFormatter",

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -629,6 +629,24 @@ pub enum ProofStrategy {
     /// Bounded universal: case-split over the declared `given`
     /// domain, dispatch each case to a per-sample lemma.
     BoundedUniversal,
+    /// `?`-propagating Result chain equals a manual `match`-version:
+    /// the law states `chain_qm(x) == chain_manual(x)` where the
+    /// LHS uses `?` for short-circuit Err propagation and the RHS
+    /// writes the same flow as nested `match Result.Err -> Err`
+    /// arms. Both sides unfold to the same nested match; the proof
+    /// closes by unfolding all step fns and case-splitting on each
+    /// step's Result discriminator. Demonstrated by
+    /// `examples/core/result_chain.av`. Stage 8b of #232.
+    ResultPipelineChain {
+        /// Source name of the `?`-chain fn (the wrapper). LHS of the law.
+        chain_qm_fn: String,
+        /// Source name of the manual `match`-chain fn. RHS of the law.
+        chain_manual_fn: String,
+        /// Source names of every step fn the two chains thread
+        /// through, in pipeline order. Drives the unfold list for
+        /// both backends.
+        step_fns: Vec<String>,
+    },
     /// Monoidal-accumulator wrapper-over-recursion: a non-recursive
     /// `wrapper_fn(xs) = inner_fn(xs, neutral)` paired with a direct-
     /// recurrence `other_fn` such that the law states

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -262,6 +262,29 @@ fn proof_export_builds_sum_acc_when_lake_is_available() {
 }
 
 #[test]
+fn proof_dafny_verifies_result_chain_when_dafny_is_available() {
+    // Stage 8b of #232: `ProofStrategy::ResultPipelineChain` closes
+    // `chainQM(n) == chainManual(n)` — `?`-propagating Result chain
+    // vs nested `match Result.Err -> Err` chain. Both unfold to the
+    // same tree; Z3 closes by structural equality with the right
+    // fuel + unfold list. Second real consumer of a typed
+    // `ModulePattern` in proof_lower.
+    assert_dafny_verifies("examples/core/result_chain.av", "aver-dafny-result-chain");
+}
+
+#[test]
+fn proof_export_builds_result_chain_when_lake_is_available() {
+    // Lean template: `unfold` + `repeat (first | split | rfl) ;
+    // all_goals simp_all`. Generic over step count — works for any
+    // ResultPipelineChain with arbitrary number of step fns.
+    assert_proof_builds_with_sorry_budget(
+        "examples/core/result_chain.av",
+        "aver-proof-result-chain",
+        0,
+    );
+}
+
+#[test]
 fn proof_export_builds_rle_when_lake_is_available() {
     // Two sampled-domain laws (encodeString / decodeString roundtrip
     // shapes) hit the universal-not-auto-proved fallback. Same gate

--- a/tests/shape_module_patterns_spec.rs
+++ b/tests/shape_module_patterns_spec.rs
@@ -213,6 +213,7 @@ fn result_pipeline_module_pins_validate_and_combine_chain() {
                 fn_name,
                 step_count,
                 scope,
+                ..
             } => Some((scope.clone(), fn_name.clone(), *step_count)),
             _ => None,
         })


### PR DESCRIPTION
## Summary
Second `ProofStrategy` variant consuming a typed `ModulePattern`. Closes `chain_qm(x) == chain_manual(x)` — LHS uses `?` propagation, RHS the nested `match Result.Err -> Err` chain.

**Substrate**: `ModulePattern::ResultPipelineChain` gains `step_fns: Vec<String>` so downstream consumers (like proof_lower) don't need to re-walk the AST. Post-pipeline `?` is desugared to nested matches; the step list has to live on the typed pattern (captured during pre-resolver shape walk).

**Detection**: chain_qm in shape + `chain_qm(g) == chain_manual(g)` law + manual fn body is nested `match Result.Err -> Err` chain over the same steps. Manual-fn body shape handles both `Expr::Constructor("Result.Err", _)` (pre-resolver) and `Expr::FnCall(Attr(Ident("Result"), "Err"), _)` (post-resolver).

**Backends**:
- **Dafny**: trivial body + per-step `{:fuel ..., 5}` — Z3 unfolds + structural equality
- **Lean**: generic `unfold <fns>; repeat (first | split | rfl); all_goals simp_all` — step-count-agnostic

`examples/core/result_chain.av` is the canonical demo. Both backends verify clean (Dafny 6/0, Lean lake build clean).

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --release --test proof_spec` — 65/65 (63 pre-existing + 2 new)
- [x] `cargo test --release --test shape_module_patterns_spec` — 15/15
- [x] Manual Dafny: 6 verified, 0 errors
- [x] Manual Lean: lake build clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)