### PR TITLE
proof: ProofStrategy::MatchDispatcherFold closes list-fold equivalence on Lean (#232 stage 8c)

### DIFF
--- a/examples/data/list_length_fold.av
+++ b/examples/data/list_length_fold.av
@@ -1,0 +1,33 @@
+module ListLengthFold
+    intent =
+        "MatchDispatcherFold proof-export demo."
+        "Two structurally-identical list folds compute list length differently:"
+        "lengthFwd uses `1 + length(t)` (left-folding the +) and lengthSwap uses `length(t) + 1` (right-folding)."
+        "The law states their equivalence — proved by structural induction on xs."
+    effects []
+
+fn lengthFwd(xs: List<Int>) -> Int
+    ? "Length via `1 + length(tail)`."
+    match xs
+        [] -> 0
+        [_, ..t] -> 1 + lengthFwd(t)
+
+verify lengthFwd
+    lengthFwd([])        => 0
+    lengthFwd([7])       => 1
+    lengthFwd([1, 2, 3]) => 3
+
+fn lengthSwap(xs: List<Int>) -> Int
+    ? "Length via `length(tail) + 1`."
+    match xs
+        [] -> 0
+        [_, ..t] -> lengthSwap(t) + 1
+
+verify lengthSwap
+    lengthSwap([])        => 0
+    lengthSwap([7])       => 1
+    lengthSwap([1, 2, 3]) => 3
+
+verify lengthFwd law equalsSwap
+    given xs: List<Int> = [[], [7], [1, 2, 3], [1, 2, 3, 4, 5]]
+    lengthFwd(xs) => lengthSwap(xs)

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -255,6 +255,15 @@ pub fn emit_verify_law_forall_auto_proof(
         return Some(proof);
     }
 
+    // Stage 8c of #232 — `MatchDispatcherFold`. Structural induction
+    // on `xs` + per-arm `simp` + `omega` for arithmetic identity.
+    if let Some(crate::ir::ProofStrategy::MatchDispatcherFold { fold_fn, spec_fn }) =
+        law_strategy_for(ctx, &vb.fn_name, &law.name)
+        && let Some(proof) = spec::emit_match_dispatcher_fold_law(vb, law, ctx, &fold_fn, &spec_fn)
+    {
+        return Some(proof);
+    }
+
     // Stage 8b of #232 — `ResultPipelineChain`. Unfold both fns +
     // every step fn, then `repeat split` peels off match layers
     // until structural equality remains.

--- a/src/codegen/lean/law_auto/spec/match_dispatcher_fold.rs
+++ b/src/codegen/lean/law_auto/spec/match_dispatcher_fold.rs
@@ -1,0 +1,37 @@
+//! Stage 8c of #232: Lean emit for `ProofStrategy::MatchDispatcherFold`.
+//!
+//! Two `MatchDispatcherFold` fns over a `List<T>` param compute the
+//! same result via slightly different structural recursions. The
+//! proof closes by induction on `xs`: nil case unfolds both bodies,
+//! cons case unfolds, applies the inductive hypothesis, and
+//! discharges the arithmetic identity via `omega`.
+
+use crate::ast::{VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+use super::super::super::expr::aver_name_to_lean;
+use super::super::AutoProof;
+
+pub(in super::super) fn emit_match_dispatcher_fold_law(
+    _vb: &VerifyBlock,
+    _law: &VerifyLaw,
+    _ctx: &CodegenContext,
+    fold_fn: &str,
+    spec_fn: &str,
+) -> Option<AutoProof> {
+    let fold_l = aver_name_to_lean(fold_fn);
+    let spec_l = aver_name_to_lean(spec_fn);
+
+    let proof_lines = vec![
+        "  intro xs".to_string(),
+        "  induction xs with".to_string(),
+        format!("  | nil => simp [{fold_l}, {spec_l}]"),
+        format!("  | cons h t ih => simp [{fold_l}, {spec_l}]; omega"),
+    ];
+
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        proof_lines,
+        replaces_theorem: false,
+    })
+}

--- a/src/codegen/lean/law_auto/spec/mod.rs
+++ b/src/codegen/lean/law_auto/spec/mod.rs
@@ -1,10 +1,12 @@
 mod linear_int;
 mod linear_recurrence2;
+mod match_dispatcher_fold;
 mod result_pipeline_chain;
 mod simp_normalized;
 mod wrapper_over_recursion;
 
 pub(super) use linear_recurrence2::emit_second_order_linear_recurrence_spec_equivalence_law;
+pub(super) use match_dispatcher_fold::emit_match_dispatcher_fold_law;
 pub(super) use result_pipeline_chain::emit_result_pipeline_chain_law;
 pub(super) use wrapper_over_recursion::emit_wrapper_over_recursion_law;
 

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -880,6 +880,15 @@ fn classify_law_strategy(
 ) -> crate::ir::ProofStrategy {
     use crate::ir::ProofStrategy;
 
+    // Match-dispatcher fold equivalence (stage 8c of #232) — two
+    // self-recursive `MatchDispatcherFold` fns over the same list
+    // param. Closes by structural induction on `xs` + `omega` on
+    // each arm.
+    if law.when.is_none()
+        && let Some(s) = detect_match_dispatcher_fold_equivalence(law, fn_name, inputs)
+    {
+        return s;
+    }
     // Result-pipeline chain equivalence (stage 8b of #232) — `?`
     // propagation `chain_qm(x)` vs nested-match `chain_manual(x)`.
     // Both sides unfold to the same nested match; the proof closes
@@ -2559,6 +2568,86 @@ fn is_bool_true(expr: &Spanned<crate::ast::Expr>) -> bool {
 /// nested chain over the same step fns. Returns a payload carrying
 /// both fn names + the ordered step list so backends can emit the
 /// unfold list without re-walking the AST.
+/// Stage 8c of #232: detect `fold(g) == spec(g)` where both `fold`
+/// and `spec` are registered `ModulePattern::MatchDispatcherFold`
+/// fns over a `List<T>` param. Both sides are list folds with
+/// identical match structure; structural induction on `xs` plus
+/// `omega` per arm closes the equivalence — emit lives on the
+/// backend.
+fn detect_match_dispatcher_fold_equivalence(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<crate::ir::ProofStrategy> {
+    use crate::analysis::shape::ModulePattern;
+    use crate::ast::Expr;
+
+    fn ident_name(e: &Spanned<Expr>) -> Option<&str> {
+        match &e.node {
+            Expr::Ident(n) => Some(n.as_str()),
+            Expr::Resolved { name, .. } => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
+    let shape = inputs.program_shape?;
+
+    if law.givens.len() != 1 {
+        return None;
+    }
+    let given_name = &law.givens[0].name;
+
+    // fn_name must be a MatchDispatcherFold in the shape.
+    let fold_fn_pinned = shape.patterns.iter().any(|p| {
+        matches!(
+            p,
+            ModulePattern::MatchDispatcherFold { fn_name: n, .. } if n == fn_name
+        )
+    });
+    if !fold_fn_pinned {
+        return None;
+    }
+
+    // Extract `fold(g)` and `spec(g)` from law sides.
+    let extract = |expr: &Spanned<Expr>| -> Option<String> {
+        let Expr::FnCall(callee, args) = &expr.node else {
+            return None;
+        };
+        let name = ident_name(callee)?;
+        if args.len() != 1 {
+            return None;
+        }
+        if ident_name(&args[0])? != given_name {
+            return None;
+        }
+        Some(name.to_string())
+    };
+    let lhs_call = extract(&law.lhs)?;
+    let rhs_call = extract(&law.rhs)?;
+    let (fold_fn, spec_fn) = if lhs_call == fn_name && rhs_call != fn_name {
+        (lhs_call, rhs_call)
+    } else if rhs_call == fn_name && lhs_call != fn_name {
+        (rhs_call, lhs_call)
+    } else {
+        return None;
+    };
+
+    // The spec side must also be a MatchDispatcherFold — otherwise
+    // the structural-induction template's `simp` step on the RHS
+    // won't have a fold to unfold.
+    let spec_pinned = shape.patterns.iter().any(|p| {
+        matches!(
+            p,
+            ModulePattern::MatchDispatcherFold { fn_name: n, .. } if n == &spec_fn
+        )
+    });
+    if !spec_pinned {
+        return None;
+    }
+
+    Some(crate::ir::ProofStrategy::MatchDispatcherFold { fold_fn, spec_fn })
+}
+
 fn detect_result_pipeline_chain_equivalence(
     law: &crate::ast::VerifyLaw,
     fn_name: &str,

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -629,6 +629,25 @@ pub enum ProofStrategy {
     /// Bounded universal: case-split over the declared `given`
     /// domain, dispatch each case to a per-sample lemma.
     BoundedUniversal,
+    /// Two `MatchDispatcherFold` fns over the same `List<T>` param
+    /// compute the same result via slightly different but structurally
+    /// identical match-on-list bodies. The law states
+    /// `fold_fn(xs) == spec_fn(xs)`; the proof closes by induction on
+    /// `xs` with both nil and cons cases reducing to arithmetic
+    /// identities. Demonstrated by `examples/data/list_length_fold.av`
+    /// (`lengthFwd(xs) = 1 + lengthFwd(t)` vs
+    /// `lengthSwap(xs) = lengthSwap(t) + 1` — equivalent via
+    /// commutativity, closes via `omega`).
+    ///
+    /// Stage 8c of #232 — third typed-pattern consumer in
+    /// `proof_lower`.
+    MatchDispatcherFold {
+        /// Source name of the LHS fold fn (the law's surrounding fn).
+        fold_fn: String,
+        /// Source name of the RHS spec fn — also a list-fold of the
+        /// same shape.
+        spec_fn: String,
+    },
     /// `?`-propagating Result chain equals a manual `match`-version:
     /// the law states `chain_qm(x) == chain_manual(x)` where the
     /// LHS uses `?` for short-circuit Err propagation and the RHS

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -262,6 +262,30 @@ fn proof_export_builds_sum_acc_when_lake_is_available() {
 }
 
 #[test]
+fn proof_dafny_verifies_list_length_fold_when_dafny_is_available() {
+    // Stage 8c of #232: `ProofStrategy::MatchDispatcherFold` — two
+    // structural list folds (`1 + length(t)` vs `length(t) + 1`)
+    // closing by induction on `xs`. Dafny's default Induction path
+    // already verifies this shape; the explicit strategy makes the
+    // recognition observable in proof_ir.
+    assert_dafny_verifies(
+        "examples/data/list_length_fold.av",
+        "aver-dafny-list-length-fold",
+    );
+}
+
+#[test]
+fn proof_export_builds_list_length_fold_when_lake_is_available() {
+    // Lean template: `induction xs with | nil => simp | cons => simp;
+    // omega`. The omega discharge handles `1 + x = x + 1`.
+    assert_proof_builds_with_sorry_budget(
+        "examples/data/list_length_fold.av",
+        "aver-proof-list-length-fold",
+        0,
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_result_chain_when_dafny_is_available() {
     // Stage 8b of #232: `ProofStrategy::ResultPipelineChain` closes
     // `chainQM(n) == chainManual(n)` — `?`-propagating Result chain


### PR DESCRIPTION
## Summary
Third `ProofStrategy` variant consuming a typed `ModulePattern`. Closes `fold(xs) == spec(xs)` where both sides are self-recursive `MatchDispatcherFold` shapes over the same list param.

**Detection**: both fns pinned as `MatchDispatcherFold` in shape, single-given law, both sides are unary calls of the same given.

**Backends**:
- **Lean**: `induction xs with | nil => simp | cons => simp; omega`. `omega` discharges `1 + length(t) = length(t) + 1`.
- **Dafny**: no explicit emit — default Induction path already closes this shape. Strategy still recognized so the choice is observable in `proof_ir.law_theorems`.

`examples/data/list_length_fold.av` is the canonical demo: two length implementations differing only in `+` arg order. Both verify cleanly (Dafny 7/0; Lean drops from `sorry` to clean lake build).

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --release --test proof_spec` — 67/67 (65 pre-existing + 2 new)
- [x] `cargo test --release --test shape_module_patterns_spec` — 15/15
- [x] Manual Dafny: 7 verified, 0 errors
- [x] Manual Lean: lake build clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)