### PR TITLE
proof: add `aver proof --check` flag (#222 partial)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,7 @@ fn main() {
             module_root,
             backend,
             verify_mode,
+            check,
         } => {
             commands::cmd_proof(
                 file,
@@ -372,6 +373,7 @@ fn main() {
                 module_root.as_deref(),
                 backend,
                 verify_mode,
+                *check,
             );
         }
     }

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -573,12 +573,47 @@ pub(super) enum Commands {
         /// How to emit `verify` cases and law theorems in generated Lean
         #[arg(long, default_value = "auto")]
         verify_mode: ProofVerifyMode,
+        /// After generating the proof project, invoke the backend
+        /// verifier (`dafny verify` / `lake build`) inside the
+        /// output directory and report its exit status. Non-zero
+        /// exit on any verification failure. Useful in CI to gate
+        /// regressions on pinned `ProofStrategy` choices.
+        #[arg(long)]
+        check: bool,
     },
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn proof_accepts_check_flag() {
+        let cli = Cli::parse_from([
+            "aver",
+            "proof",
+            "examples/data/sum_acc.av",
+            "--backend",
+            "dafny",
+            "--check",
+        ]);
+        match cli.command {
+            Commands::Proof { file, check, .. } => {
+                assert_eq!(file, "examples/data/sum_acc.av");
+                assert!(check, "--check must parse to true");
+            }
+            _ => panic!("expected proof command"),
+        }
+    }
+
+    #[test]
+    fn proof_check_defaults_to_false() {
+        let cli = Cli::parse_from(["aver", "proof", "examples/data/sum_acc.av"]);
+        match cli.command {
+            Commands::Proof { check, .. } => assert!(!check, "--check defaults to false"),
+            _ => panic!("expected proof command"),
+        }
+    }
 
     #[test]
     fn verify_accepts_deps_flag() {

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4607,6 +4607,7 @@ pub(super) fn cmd_proof(
     module_root_override: Option<&str>,
     backend: &super::cli::ProofBackend,
     verify_mode: &super::cli::ProofVerifyMode,
+    check: bool,
 ) {
     let (mut ctx, _module_root) = build_codegen_context(
         file,
@@ -4661,6 +4662,87 @@ pub(super) fn cmd_proof(
         }
         super::cli::ProofBackend::Dafny => {
             cmd_proof_dafny(file, output_dir, &ctx);
+        }
+    }
+
+    if check {
+        run_proof_check(output_dir, backend);
+    }
+}
+
+/// `aver proof --check` harness: invoke the backend's verifier inside
+/// `output_dir`, stream its output to the user, exit non-zero on
+/// failure. MVP — no residual-diagnostic mapping back to source
+/// `verify` blocks yet; that's a follow-up (issue #222 `--try-auto`).
+fn run_proof_check(output_dir: &str, backend: &super::cli::ProofBackend) {
+    use std::process::{Command, Stdio};
+
+    let (cmd, args, label): (&str, Vec<String>, &str) = match backend {
+        super::cli::ProofBackend::Lean => ("lake", vec!["build".to_string()], "Lean / lake"),
+        super::cli::ProofBackend::Dafny => {
+            // Find the single `.dfy` entry file in `output_dir` — the
+            // generator emits exactly one (plus `common.dfy`).
+            let entry = match std::fs::read_dir(output_dir) {
+                Ok(rd) => rd
+                    .filter_map(|e| e.ok())
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .find(|n| n.ends_with(".dfy") && n != "common.dfy"),
+                Err(e) => {
+                    eprintln!(
+                        "{}",
+                        format!("--check: read_dir({}) failed: {}", output_dir, e).red()
+                    );
+                    std::process::exit(2);
+                }
+            };
+            let Some(entry) = entry else {
+                eprintln!(
+                    "{}",
+                    format!(
+                        "--check: no .dfy entry file found in {} (besides common.dfy)",
+                        output_dir
+                    )
+                    .red()
+                );
+                std::process::exit(2);
+            };
+            ("dafny", vec!["verify".to_string(), entry], "Dafny / Z3")
+        }
+    };
+
+    println!("{}", format!("--check: running {} verifier…", label).blue());
+    let status = Command::new(cmd)
+        .args(&args)
+        .current_dir(output_dir)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status();
+    match status {
+        Ok(s) if s.success() => {
+            println!("{}", format!("--check: {} verifier passed", label).green());
+        }
+        Ok(s) => {
+            eprintln!(
+                "{}",
+                format!(
+                    "--check: {} verifier reported failures (exit {})",
+                    label,
+                    s.code().unwrap_or(-1)
+                )
+                .red()
+            );
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!(
+                "{}",
+                format!(
+                    "--check: failed to spawn `{}`: {} — is the verifier installed and on PATH?",
+                    cmd, e
+                )
+                .red()
+            );
+            std::process::exit(2);
         }
     }
 }


### PR DESCRIPTION
## Summary
First half of #222: invoke the backend verifier after generating the proof project.

- `aver proof <file> --backend dafny --check` runs `dafny verify <Module>.dfy` in the output dir
- `aver proof <file> --backend lean --check` runs `lake build` in the output dir
- Non-zero exit on any verification failure (exit 1), exit 2 when the verifier binary isn't on PATH
- Verifier output is streamed verbatim — no fancy mapping yet

**MVP** — issue #222's `--try-auto` (residual-diagnostic harness + bounded candidate proof bodies) is the follow-up.

Useful in CI to gate regressions on pinned `ProofStrategy` choices.

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --bin aver cli::tests` — 15/15, includes 2 new (`proof_accepts_check_flag`, `proof_check_defaults_to_false`)
- [x] `cargo test --release --test proof_spec --test shape_module_patterns_spec` — 67/15
- [x] Manual: `aver proof --backend dafny examples/data/sum_acc.av -o /tmp/x --check` → exit 0, `--check: Dafny / Z3 verifier passed`
- [x] Manual: `aver proof --backend dafny examples/data/rle.av -o /tmp/y --check` → exit 1, `--check: Dafny / Z3 verifier reported failures (exit 4)`
- [x] Manual: `aver proof --backend lean examples/data/sum_acc.av -o /tmp/z --check` → exit 0, `--check: Lean / lake verifier passed`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)