### PR TITLE
proof: `--check` gains budgets + JSON; proof_spec migrates to CLI (#222 partial)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -365,6 +365,9 @@ fn main() {
             backend,
             verify_mode,
             check,
+            error_budget,
+            sorry_budget,
+            check_json,
         } => {
             commands::cmd_proof(
                 file,
@@ -374,6 +377,9 @@ fn main() {
                 backend,
                 verify_mode,
                 *check,
+                *error_budget,
+                *sorry_budget,
+                *check_json,
             );
         }
     }

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -580,6 +580,22 @@ pub(super) enum Commands {
         /// regressions on pinned `ProofStrategy` choices.
         #[arg(long)]
         check: bool,
+        /// `--check` only: tolerate up to N Dafny verification
+        /// errors. Gates regressions upward for examples whose laws
+        /// don't yet have a closing strategy.
+        #[arg(long, requires = "check")]
+        error_budget: Option<usize>,
+        /// `--check` only: tolerate up to N residual Lean `sorry`s.
+        /// Symmetric to `--error-budget` on Dafny.
+        #[arg(long, requires = "check")]
+        sorry_budget: Option<usize>,
+        /// `--check` only: emit a structured JSON summary
+        /// (`{backend, errors, sorries, budget, passed}`) to stdout
+        /// instead of streaming the verifier's raw output. Exit
+        /// codes unchanged: 0 within budget, 1 over, 2 on harness
+        /// failure.
+        #[arg(long, requires = "check")]
+        check_json: bool,
     },
 }
 

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4600,6 +4600,7 @@ pub(super) struct CompileOptions<'a> {
     pub(super) optimize: Option<super::cli::WasmOptMode>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn cmd_proof(
     file: &str,
     output_dir: &str,

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4608,6 +4608,9 @@ pub(super) fn cmd_proof(
     backend: &super::cli::ProofBackend,
     verify_mode: &super::cli::ProofVerifyMode,
     check: bool,
+    error_budget: Option<usize>,
+    sorry_budget: Option<usize>,
+    check_json: bool,
 ) {
     let (mut ctx, _module_root) = build_codegen_context(
         file,
@@ -4666,22 +4669,35 @@ pub(super) fn cmd_proof(
     }
 
     if check {
-        run_proof_check(output_dir, backend);
+        run_proof_check(output_dir, backend, error_budget, sorry_budget, check_json);
     }
 }
 
 /// `aver proof --check` harness: invoke the backend's verifier inside
-/// `output_dir`, stream its output to the user, exit non-zero on
-/// failure. MVP — no residual-diagnostic mapping back to source
-/// `verify` blocks yet; that's a follow-up (issue #222 `--try-auto`).
-fn run_proof_check(output_dir: &str, backend: &super::cli::ProofBackend) {
-    use std::process::{Command, Stdio};
+/// `output_dir`, count errors (Dafny) or residual `sorry`s (Lean),
+/// compare against the optional budget, and exit accordingly:
+/// - exit 0: count ≤ budget (budget defaults to 0 when unset)
+/// - exit 1: count > budget
+/// - exit 2: harness failure (verifier not on PATH, missing .dfy entry,
+///   verifier output didn't parse)
+///
+/// With `--check-json`, prints a structured summary to stdout
+/// instead of streaming verifier output verbatim — same exit codes,
+/// for CI consumption.
+fn run_proof_check(
+    output_dir: &str,
+    backend: &super::cli::ProofBackend,
+    error_budget: Option<usize>,
+    sorry_budget: Option<usize>,
+    check_json: bool,
+) {
+    use std::process::Command;
 
-    let (cmd, args, label): (&str, Vec<String>, &str) = match backend {
-        super::cli::ProofBackend::Lean => ("lake", vec!["build".to_string()], "Lean / lake"),
+    let (cmd, args, label, backend_tag): (&str, Vec<String>, &str, &str) = match backend {
+        super::cli::ProofBackend::Lean => {
+            ("lake", vec!["build".to_string()], "Lean / lake", "lean")
+        }
         super::cli::ProofBackend::Dafny => {
-            // Find the single `.dfy` entry file in `output_dir` — the
-            // generator emits exactly one (plus `common.dfy`).
             let entry = match std::fs::read_dir(output_dir) {
                 Ok(rd) => rd
                     .filter_map(|e| e.ok())
@@ -4706,33 +4722,24 @@ fn run_proof_check(output_dir: &str, backend: &super::cli::ProofBackend) {
                 );
                 std::process::exit(2);
             };
-            ("dafny", vec!["verify".to_string(), entry], "Dafny / Z3")
+            (
+                "dafny",
+                vec!["verify".to_string(), entry],
+                "Dafny / Z3",
+                "dafny",
+            )
         }
     };
 
-    println!("{}", format!("--check: running {} verifier…", label).blue());
-    let status = Command::new(cmd)
+    if !check_json {
+        println!("{}", format!("--check: running {} verifier…", label).blue());
+    }
+    let output = match Command::new(cmd)
         .args(&args)
         .current_dir(output_dir)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status();
-    match status {
-        Ok(s) if s.success() => {
-            println!("{}", format!("--check: {} verifier passed", label).green());
-        }
-        Ok(s) => {
-            eprintln!(
-                "{}",
-                format!(
-                    "--check: {} verifier reported failures (exit {})",
-                    label,
-                    s.code().unwrap_or(-1)
-                )
-                .red()
-            );
-            std::process::exit(1);
-        }
+        .output()
+    {
+        Ok(o) => o,
         Err(e) => {
             eprintln!(
                 "{}",
@@ -4744,7 +4751,108 @@ fn run_proof_check(output_dir: &str, backend: &super::cli::ProofBackend) {
             );
             std::process::exit(2);
         }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let (errors, sorries, budget, count) = match backend {
+        super::cli::ProofBackend::Dafny => {
+            let errors = match parse_dafny_error_count(&stdout) {
+                Some(n) => n,
+                None => {
+                    eprintln!(
+                        "{}",
+                        "--check: could not parse Dafny verifier output (missing \"finished with X verified, Y errors\" line)".red()
+                    );
+                    if !check_json {
+                        eprint!("{}", stderr);
+                        print!("{}", stdout);
+                    }
+                    std::process::exit(2);
+                }
+            };
+            (Some(errors), None, error_budget.unwrap_or(0), errors)
+        }
+        super::cli::ProofBackend::Lean => {
+            let sorries = count_lean_sorries(&stderr) + count_lean_sorries(&stdout);
+            (None, Some(sorries), sorry_budget.unwrap_or(0), sorries)
+        }
+    };
+
+    let passed = count <= budget;
+
+    if check_json {
+        let mut obj = serde_json::Map::new();
+        obj.insert("backend".into(), backend_tag.into());
+        if let Some(e) = errors {
+            obj.insert("errors".into(), e.into());
+        }
+        if let Some(s) = sorries {
+            obj.insert("sorries".into(), s.into());
+        }
+        obj.insert("budget".into(), budget.into());
+        obj.insert("passed".into(), passed.into());
+        println!(
+            "{}",
+            serde_json::to_string(&serde_json::Value::Object(obj))
+                .unwrap_or_else(|_| "{}".to_string())
+        );
+    } else {
+        // Stream the verifier's own output so the user sees the
+        // diagnostics; we already parsed counts above.
+        print!("{}", stdout);
+        eprint!("{}", stderr);
+        let metric = match backend {
+            super::cli::ProofBackend::Dafny => format!("{count} errors"),
+            super::cli::ProofBackend::Lean => format!("{count} sorries"),
+        };
+        if passed {
+            let suffix = if budget > 0 {
+                format!(" (within budget {budget})")
+            } else {
+                String::new()
+            };
+            println!("{}", format!("--check: {label} — {metric}{suffix}").green());
+        } else {
+            eprintln!(
+                "{}",
+                format!("--check: {label} — {metric} over budget {budget}").red()
+            );
+        }
     }
+
+    if !passed {
+        std::process::exit(1);
+    }
+}
+
+/// Parse `Dafny program verifier finished with N verified, M errors`
+/// out of the verifier's stdout. Returns `Some(M)` on a match,
+/// `None` when the line isn't present.
+fn parse_dafny_error_count(stdout: &str) -> Option<usize> {
+    for line in stdout.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("Dafny program verifier finished with ") {
+            // Shape: "<N> verified, <M> errors"
+            if let Some((_, after_comma)) = rest.split_once(", ")
+                && let Some(m) = after_comma.split_whitespace().next()
+                && let Ok(n) = m.parse::<usize>()
+            {
+                return Some(n);
+            }
+        }
+    }
+    None
+}
+
+/// Count Lean's `declaration uses 'sorry'` warnings in build output.
+/// Lake emits one such warning per `sorry` in the residual program;
+/// counting them matches the budget the proof_spec gating tests use.
+fn count_lean_sorries(s: &str) -> usize {
+    s.lines()
+        .filter(|l| l.contains("declaration uses 'sorry'"))
+        .count()
 }
 
 fn cmd_proof_lean(

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -44,63 +44,61 @@ fn assert_proof_builds_with_sorry_budget(
     let output_dir = temp_output_dir(prefix);
     let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let proof = Command::new(aver_bin)
+    // One subprocess: `aver proof --check --check-json` generates the
+    // project, runs `lake build`, parses the residual `sorry` count
+    // from the build's `declaration uses 'sorry'` warnings, and emits
+    // a JSON summary. Exit code is ignored — the test asserts
+    // exact-match on the count for regression detection (the CLI's
+    // `≤ budget` semantics let CI tolerate noisy examples, but tests
+    // want a drift-up-or-down signal both ways).
+    let run = Command::new(aver_bin)
         .current_dir(&repo_root)
         .arg("proof")
         .arg(example_path)
+        .arg("--backend")
+        .arg("lean")
         .arg("--verify-mode")
         .arg("auto")
         .arg("-o")
         .arg(&output_dir)
+        .arg("--check")
+        .arg("--check-json")
         .output()
-        .expect("expected `aver proof` to run");
-    assert!(
-        proof.status.success(),
-        "`aver proof` failed:\n{}",
-        format_output(&proof)
-    );
+        .expect("expected `aver proof --check --check-json` to run");
 
-    // Count `sorry` tokens in the entry Lean file (skip `AverCommon.
-    // lean`, which carries prelude lemmas that legitimately use
-    // `sorry` for runtime-only obligations). The match is whole-word
-    // to avoid counting identifiers like `sorry_substring`.
-    let entry_lean = std::fs::read_dir(&output_dir)
-        .expect("read output_dir")
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .find(|p| {
-            p.extension().is_some_and(|x| x == "lean")
-                && p.file_name()
-                    .and_then(|n| n.to_str())
-                    .is_some_and(|n| n != "AverCommon.lean" && n != "lakefile.lean")
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| {
+            panic!(
+                "`aver proof --check --check-json` produced no JSON line:\n{}",
+                format_output(&run)
+            )
         });
-    if let Some(path) = entry_lean {
-        let text = std::fs::read_to_string(&path).expect("read entry .lean");
-        let actual = text
-            .lines()
-            .filter(|line| {
-                line.split_whitespace().any(|tok| tok == "sorry")
-                    && !line.trim_start().starts_with("--")
-            })
-            .count();
-        assert_eq!(
-            actual, expected_sorries,
-            "{}: sorry count drift (expected {}, got {}). \
-             If the count dropped, lower the budget. If it grew, a new shape regressed — \
-             investigate before raising the budget.",
-            example_path, expected_sorries, actual
-        );
-    }
-
-    let build = Command::new("lake")
-        .current_dir(&output_dir)
-        .arg("build")
-        .output()
-        .expect("expected `lake build` to run");
-    assert!(
-        build.status.success(),
-        "`lake build` failed:\n{}",
-        format_output(&build)
+    let summary: serde_json::Value = serde_json::from_str(json_line).unwrap_or_else(|e| {
+        panic!(
+            "failed to parse `aver proof --check --check-json` output as JSON ({}):\n{}",
+            e, json_line
+        )
+    });
+    let actual = summary["sorries"].as_u64().unwrap_or_else(|| {
+        panic!(
+            "`sorries` field missing from --check-json summary:\n{}",
+            json_line
+        )
+    }) as usize;
+    assert_eq!(
+        actual,
+        expected_sorries,
+        "{}: sorry count drift (expected {}, got {}). \
+         If the count dropped, lower the budget. If it grew, a new shape regressed — \
+         investigate before raising the budget.\n{}",
+        example_path,
+        expected_sorries,
+        actual,
+        format_output(&run)
     );
 
     let _ = std::fs::remove_dir_all(&output_dir);
@@ -139,7 +137,13 @@ fn assert_dafny_verifies_with_error_budget(
     let output_dir = temp_output_dir(prefix);
     let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let proof = Command::new(aver_bin)
+    // Same single-subprocess shape as the Lean side: generate, run
+    // `dafny verify`, parse the error count out of the verifier
+    // summary, emit JSON. Exit code is ignored — tests assert an
+    // exact-match on `errors` for regression detection in both
+    // directions (drift up = lost a strategy, drift down = budget can
+    // be tightened).
+    let run = Command::new(aver_bin)
         .current_dir(&repo_root)
         .arg("proof")
         .arg(example_path)
@@ -147,75 +151,47 @@ fn assert_dafny_verifies_with_error_budget(
         .arg("dafny")
         .arg("-o")
         .arg(&output_dir)
+        .arg("--check")
+        .arg("--check-json")
         .output()
-        .expect("expected `aver proof --backend dafny` to run");
-    assert!(
-        proof.status.success(),
-        "`aver proof --backend dafny` failed:\n{}",
-        format_output(&proof)
-    );
+        .expect("expected `aver proof --check --check-json` to run");
 
-    let dfy = std::fs::read_dir(&output_dir)
-        .expect("read output_dir")
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .find(|p| {
-            p.extension().is_some_and(|x| x == "dfy")
-                && p.file_name()
-                    .and_then(|n| n.to_str())
-                    .is_some_and(|n| n != "common.dfy")
-        })
-        .expect("expected a non-`common.dfy` Dafny file in output");
-    let verify = Command::new("dafny")
-        .current_dir(&output_dir)
-        .arg("verify")
-        .arg(&dfy)
-        .output()
-        .expect("expected `dafny verify` to run");
-
-    if expected_errors == 0 {
-        assert!(
-            verify.status.success(),
-            "`dafny verify` failed:\n{}",
-            format_output(&verify)
-        );
-    } else {
-        let stdout = String::from_utf8_lossy(&verify.stdout);
-        let actual = parse_dafny_error_count(&stdout).unwrap_or_else(|| {
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| {
             panic!(
-                "could not parse Dafny verifier summary from output:\n{}",
-                format_output(&verify)
+                "`aver proof --check --check-json` produced no JSON line:\n{}",
+                format_output(&run)
             )
         });
-        assert_eq!(
-            actual,
-            expected_errors,
-            "{}: dafny error count drift (expected {}, got {}). \
-             If the count dropped, lower the budget. If it grew, a new shape regressed — \
-             investigate before raising the budget.\n{}",
-            example_path,
-            expected_errors,
-            actual,
-            format_output(&verify)
-        );
-    }
+    let summary: serde_json::Value = serde_json::from_str(json_line).unwrap_or_else(|e| {
+        panic!(
+            "failed to parse `aver proof --check --check-json` output as JSON ({}):\n{}",
+            e, json_line
+        )
+    });
+    let actual = summary["errors"].as_u64().unwrap_or_else(|| {
+        panic!(
+            "`errors` field missing from --check-json summary:\n{}",
+            json_line
+        )
+    }) as usize;
+    assert_eq!(
+        actual,
+        expected_errors,
+        "{}: dafny error count drift (expected {}, got {}). \
+         If the count dropped, lower the budget. If it grew, a new shape regressed — \
+         investigate before raising the budget.\n{}",
+        example_path,
+        expected_errors,
+        actual,
+        format_output(&run)
+    );
 
     let _ = std::fs::remove_dir_all(&output_dir);
-}
-
-/// Extract the trailing error count from a Dafny verifier run.
-///
-/// Dafny prints `Dafny program verifier finished with N verified, M
-/// error(s)` (singular `error` when M == 1). Returns `M` or `None`
-/// if the summary line is missing.
-fn parse_dafny_error_count(stdout: &str) -> Option<usize> {
-    let line = stdout
-        .lines()
-        .rev()
-        .find(|l| l.contains("Dafny program verifier finished with"))?;
-    let after = line.split(", ").nth(1)?;
-    let n: usize = after.split_whitespace().next()?.parse().ok()?;
-    Some(n)
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Closes the loop on #247's boolean MVP. `--check` now knows the exact error / sorry count, the budget, and whether the run is within tolerance.

**CLI surface (new flags, all opt-in)**:
- `--check --error-budget=N` (Dafny): exit 0 when errors ≤ N
- `--check --sorry-budget=N` (Lean): exit 0 when `declaration uses 'sorry'` count ≤ N
- `--check --check-json`: emit `{backend, errors|sorries, budget, passed}` to stdout instead of streaming raw verifier output. Exit codes unchanged (0 / 1 / 2)

Defaults remain backwards-compat — `--check` alone is still "budget 0, stream raw output" as in #247.

**proof_spec migration**: both gating helpers (`assert_proof_builds_with_sorry_budget`, `assert_dafny_verifies_with_error_budget`) now invoke `aver proof --check --check-json` as a single subprocess and assert exact equality on the count. The CLI's `≤` semantics stay the right default for user CI; tests use exact-match for two-sided regression detection (drift up = lost a strategy, drift down = budget should tighten).

`tests/proof_spec.rs` shrinks by 143 lines as the two-step shell-out boilerplate (parse Dafny summary line, count `sorry` tokens, dispatch `lake build` / `dafny verify`) all moves into the CLI.

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --release --test proof_spec` — 67/67 (unchanged from main)
- [x] `cargo test --release --test shape_module_patterns_spec --test shape_spec --test shape_lint_cli_spec` — 15/3/14
- [x] Manual: `aver proof --backend dafny rle.av --check --error-budget=3 --check-json` → exit 0, `{"passed":true, "errors":3}`
- [x] Manual: `aver proof --backend dafny rle.av --check --error-budget=2 --check-json` → exit 1, `{"passed":false}`
- [x] Manual: `aver proof --backend lean sum_acc.av --check --sorry-budget=0 --check-json` → exit 0, `{"sorries":0}`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)