### PR TITLE
shape: gate `colored` behind `tty-render` so fuzz builds compile

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aver-lang"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "aver-memory",
  "aver-rt",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ afl = "0.15"
 # `aver-lang` as a library) has to ask explicitly. Keeping them in
 # the parity build means the wasm-gc executor sees the same effect
 # surface AFL might generate from real Aver corpus seeds.
-aver-lang = { path = "..", default-features = false, features = ["runtime", "wasm-compile", "wasm", "wasip2", "runtime-net", "terminal", "tty-render"] }
+aver-lang = { path = "..", default-features = false, features = ["runtime", "wasm-compile", "wasm", "wasip2", "runtime-net", "terminal"] }
 # Validate codegen output bytes after `compile_to_wasm_gc`. We pin
 # the same minor as `aver-lang`'s optional dep so the workspace
 # resolver picks a single version.

--- a/fuzz/mutator/Cargo.lock
+++ b/fuzz/mutator/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aver-lang"
-version = "0.21.1"
+version = "0.22.1"
 dependencies = [
  "aver-memory",
  "aver-rt",

--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -23,6 +23,51 @@ use crate::ir::hir::{ResolvedFnDef, ResolvedTopLevel};
 use crate::ir::{PipelineConfig, TypecheckMode};
 use crate::types::Type;
 
+/// ANSI styling shim for the `render_text` renderer. With
+/// `tty-render` enabled (the default for the CLI / LSP / playground
+/// builds), `Colorize` is re-exported from the `colored` crate so
+/// calls like `"X".bold().cyan()` produce the actual escape
+/// sequences. Without `tty-render` (the fuzz crates and any
+/// future `--no-default-features` consumer), the trait still
+/// resolves but every method is a no-op that returns the input as
+/// `String` — the renderer keeps working, just emits plain text.
+#[cfg(feature = "tty-render")]
+use colored::Colorize as _shape_colorize;
+#[cfg(not(feature = "tty-render"))]
+use shape_color::Colorize as _shape_colorize;
+
+#[cfg(not(feature = "tty-render"))]
+mod shape_color {
+    /// No-op stand-in for `colored::Colorize` when the `tty-render`
+    /// feature is off. Every method returns the input as `String`,
+    /// so `"X".bold().cyan()` chains the same way it does with the
+    /// real crate — just without escapes.
+    pub trait Colorize {
+        fn bold(&self) -> String;
+        fn cyan(&self) -> String;
+        fn yellow(&self) -> String;
+        fn magenta(&self) -> String;
+        fn dimmed(&self) -> String;
+    }
+    impl<S: AsRef<str> + ?Sized> Colorize for S {
+        fn bold(&self) -> String {
+            self.as_ref().to_string()
+        }
+        fn cyan(&self) -> String {
+            self.as_ref().to_string()
+        }
+        fn yellow(&self) -> String {
+            self.as_ref().to_string()
+        }
+        fn magenta(&self) -> String {
+            self.as_ref().to_string()
+        }
+        fn dimmed(&self) -> String {
+            self.as_ref().to_string()
+        }
+    }
+}
+
 // Recognition primitives moved to `aver::analysis::shape` in stage 1
 // (#232). Stage 2 drops the re-exports — callers import from
 // `analysis::shape` directly so the presentation tier doesn't double
@@ -989,7 +1034,8 @@ pub struct RenderOptions {
 /// Scope-qualified names are rendered as `prefix::name` when the
 /// pattern lives in a dep module.
 fn render_module_pattern_line(p: &ModulePattern) -> String {
-    use colored::Colorize;
+    // `_shape_colorize` is in module scope above — its methods
+    // (`bold`, `cyan`, …) are usable directly without a local import.
     let scoped = |scope: &Option<String>, name: &str| -> String {
         match scope {
             Some(prefix) => format!("{prefix}::{name}"),
@@ -1053,7 +1099,9 @@ fn render_module_pattern_line(p: &ModulePattern) -> String {
 }
 
 pub fn render_text(report: &ShapeReport, opts: &RenderOptions) -> String {
-    use colored::Colorize;
+    // `_shape_colorize` is in module scope above (see top-of-file
+    // shim). Auto-disables coloring on non-TTY pipes and when the
+    // `tty-render` feature is off (e.g. fuzz / mutator builds).
     let mut out = String::new();
     // Header: `Module:` and `Kind:` share the value column. `Module:` is
     // 7 chars + space, `Kind:` is 5 chars + 3 spaces — same total width.


### PR DESCRIPTION
## Summary
Proper fix for the fuzz-build break introduced by the 0.23 colored CLI output. Replaces the `tty-render` hack on `fuzz/Cargo.toml` (#250) with a feature-aware shim inside `diagnostics::shape`.

**Problem**: `diagnostics::shape::render_text` calls `colored::Colorize` for the flat + colored output. `colored` is optional under the `tty-render` feature. The default CLI build enables it, the fuzz crates do not — so `cargo afl build` fails on every target except `fuzz_replay_codec`, plus the custom AST mutator (`fuzz/mutator/`) hits the same wall.

**Fix**:
- `#[cfg(feature = "tty-render")]` re-exports `colored::Colorize` under alias `_shape_colorize`
- `#[cfg(not(feature = "tty-render"))]` provides a stub trait of the same shape — every method returns input as `String`
- `.bold().cyan()` chains in the renderer compile either way; visible output for the default CLI build is unchanged (colors emit via real `colored`)
- Backed out the `tty-render` feature addition from `fuzz/Cargo.toml`

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --release --test proof_spec --test shape_*` — 67/3/15/14
- [x] `cd fuzz/mutator && cargo check --release` — clean
- [x] `cd fuzz && cargo check --release --bin fuzz_parse_bytes` — clean
- [ ] CI green
- [ ] Fuzz nightly green on next dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)