### PR TITLE
ir/mir: data model — MirProgram + MirExpr + supporting types (#252 Phase 2a)

### DIFF
--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -1,0 +1,276 @@
+//! `MirExpr` + supporting node types.
+//!
+//! Phase 2a of #252. Expression-based (every `MirExpr` is a value),
+//! structured (no terminator-style basic blocks), and identity-typed
+//! (declaration refs go through `FnId` / `TypeId` / `CtorId`).
+//!
+//! The shape decisions pinned in the Phase 1 RFC live here as code:
+//!
+//! - `Try` is its own variant — *not* desugared to `Match`.
+//! - `Match` is structured with `Vec<MirMatchArm>` — no flat
+//!   switch / jump representation.
+//! - Constructors carry `CtorId`, record types carry `TypeId`,
+//!   tail-call targets carry `FnId`.
+//! - Each node carries a `Span` for diagnostics + future
+//!   correlation with `ProofIR`.
+
+use crate::ast::{BinOp, Literal, Spanned};
+use crate::ir::{CtorId, FnId, TypeId};
+
+use super::program::LocalId;
+
+/// One MIR expression. Every variant is a value — there's no
+/// separate statement form at this phase. Sequencing happens via
+/// `Let`.
+#[derive(Debug, Clone)]
+pub enum MirExpr {
+    /// A literal value (`Int`, `Float`, `Bool`, `String`, `Unit`).
+    /// Same vocabulary the existing typed AST already uses.
+    Literal(Spanned<Literal>),
+    /// Read a previously-bound local. The `LocalId` was introduced
+    /// either as a function parameter (`MirParam::local`) or via a
+    /// `Let` in this body's lexical scope.
+    Local(Spanned<LocalId>),
+    /// `let binding = value; body` — sequence two expressions and
+    /// surface the second's value. Phase 2a's only sequencing
+    /// primitive; everything else inside a function body composes
+    /// from this + the value-form variants below.
+    Let(Spanned<MirLet>),
+    /// Apply a callee (user fn / builtin) to arguments. The callee
+    /// kind discriminates so backends know whether to look up via
+    /// `FnId` (typed identity) or via the named-builtin registry.
+    Call(Spanned<MirCall>),
+    /// Tail call to a user fn — same SCC as the surrounding fn.
+    /// Backends decide the final shape (wasm-gc tail-call insn,
+    /// VM tail dispatch, Rust loop rewrite).
+    TailCall(Spanned<MirTailCall>),
+    /// Binary operator over numeric / boolean operands. Same set as
+    /// `ast::BinOp` — MIR doesn't normalize arithmetic here; that's
+    /// a Phase 6 optimizer concern.
+    BinOp(Spanned<MirBinOp>),
+    /// Unary numeric negation. Distinct from `BinOp(Sub, 0, x)` so
+    /// IEEE-754 `-0.0` semantics are preserved on `Float`.
+    Neg(Box<Spanned<MirExpr>>),
+    /// `match <subject> { arm₁ ; arm₂ ; … }` — structured. Phase 4
+    /// VM walks arms in order, picks the first matching pattern.
+    Match(Spanned<MirMatch>),
+    /// Construct a sum-type variant by `CtorId`. The variant's
+    /// declared fields are filled in argument order.
+    Construct(Spanned<MirConstruct>),
+    /// Build a fresh record of a named product type. Fields are
+    /// (`field_name`, value) pairs to keep the dump readable; the
+    /// declared field order is determined by `TypeId` and
+    /// validated at lowering time.
+    RecordCreate(Spanned<MirRecordCreate>),
+    /// `T.update(base, field = v, …)` — produce a new record that
+    /// matches `base` except for the named field overrides.
+    RecordUpdate(Spanned<MirRecordUpdate>),
+    /// Field access (`base.field`) on a record value.
+    Project(Spanned<MirProject>),
+    /// `value?` — the canonical `?` propagation. Phase 1's
+    /// most-important pin: this stays a node. Lowering to nested
+    /// `Match` is a per-backend choice, not a pipeline-wide
+    /// transform. Rust will eventually emit `?` native, VM emits
+    /// tag-check + early return.
+    Try(Box<Spanned<MirExpr>>),
+    /// `let ok_binding = value?; ok_body` — the bound form of
+    /// `Try`. Carries `ok_binding` so the body has a name for the
+    /// unwrapped `Ok(_)` value. Distinct variant from `Try` +
+    /// `Let` so the lowering pass keeps the bind-and-propagate
+    /// intent intact (and downstream consumers can recognize the
+    /// shape without re-walking).
+    TryBind(Spanned<MirTryBind>),
+    /// `[a, b, c]` — list literal. Elements lower to MIR
+    /// expressions; the resulting value is `List<T>` with `T`
+    /// inferred at type-check time.
+    List(Vec<Spanned<MirExpr>>),
+    /// `(a, b, c)` — tuple literal.
+    Tuple(Vec<Spanned<MirExpr>>),
+    /// `{"k" => v, …}` — map literal. Keys + values lower as MIR
+    /// expressions; the resulting value is `Map<K, V>`.
+    MapLiteral(Vec<(Spanned<MirExpr>, Spanned<MirExpr>)>),
+    /// `"…{expr}…"` — interpolated string. Each part is either a
+    /// literal text segment or an embedded MIR expression whose
+    /// value gets stringified at runtime.
+    InterpolatedStr(Vec<MirStrPart>),
+    /// Independent product: `(a, b, c)!` or `(a, b, c)?!`. The
+    /// `unwrap_results` flag captures the `?` form (every element
+    /// must be `Result<…>`; `Err` short-circuits with the first
+    /// error). Schedule (`complete` / `cancel` / `sequential`) is
+    /// an aver.toml runtime policy and is NOT carried in MIR.
+    IndependentProduct(Spanned<MirIndependentProduct>),
+    /// Early `return value;` — used in lowered bodies that have a
+    /// natural early-return shape (the `?` propagation lowering
+    /// inside a backend is the canonical example). Functions that
+    /// don't return early end their body with the final expression
+    /// itself; `Return` is only for the explicit early-exit case.
+    Return(Box<Spanned<MirExpr>>),
+}
+
+/// `let binding = value; body`.
+#[derive(Debug, Clone)]
+pub struct MirLet {
+    pub binding: LocalId,
+    pub value: Box<Spanned<MirExpr>>,
+    pub body: Box<Spanned<MirExpr>>,
+}
+
+/// Apply `callee` to `args`.
+#[derive(Debug, Clone)]
+pub struct MirCall {
+    pub callee: MirCallee,
+    pub args: Vec<Spanned<MirExpr>>,
+}
+
+/// What we're calling. Two flavors during Phase 2–3; richer
+/// `BuiltinId` may replace the string in a later phase.
+#[derive(Debug, Clone)]
+pub enum MirCallee {
+    /// User-defined function (any module, including the current
+    /// one). Resolved at HIR → MIR lowering — never a string.
+    Fn(FnId),
+    /// Built-in registered in the runtime's builtin table
+    /// (`Console.print`, `List.prepend`, …). String for now; a
+    /// later phase may introduce `BuiltinId` for full typed
+    /// identity.
+    Builtin(String),
+}
+
+/// `target(args…)` in tail position — same SCC as the surrounding fn.
+#[derive(Debug, Clone)]
+pub struct MirTailCall {
+    pub target: FnId,
+    pub args: Vec<Spanned<MirExpr>>,
+}
+
+/// `lhs <op> rhs`.
+#[derive(Debug, Clone)]
+pub struct MirBinOp {
+    pub op: BinOp,
+    pub lhs: Box<Spanned<MirExpr>>,
+    pub rhs: Box<Spanned<MirExpr>>,
+}
+
+/// Structured match expression.
+#[derive(Debug, Clone)]
+pub struct MirMatch {
+    pub subject: Box<Spanned<MirExpr>>,
+    pub arms: Vec<MirMatchArm>,
+}
+
+/// One arm of a `match`. Pattern picks the variant; `body` is the
+/// value produced when this arm fires.
+#[derive(Debug, Clone)]
+pub struct MirMatchArm {
+    pub pattern: MirPattern,
+    pub body: Spanned<MirExpr>,
+}
+
+/// Pattern shape for `match` arms. Identity-typed where applicable
+/// (constructor patterns reference `CtorId`); `LocalId` is the
+/// fresh local introduced by the binding form.
+#[derive(Debug, Clone)]
+pub enum MirPattern {
+    /// `_` — catch-all, binds nothing.
+    Wildcard,
+    /// Literal arm: `0`, `true`, `"foo"`.
+    Literal(Literal),
+    /// Identifier binding — captures the matched value into a
+    /// fresh local accessible in the arm body.
+    Bind(LocalId),
+    /// `[]` — empty-list pattern.
+    EmptyList,
+    /// `[head, ..tail]` — cons pattern; both bindings fresh.
+    Cons { head: LocalId, tail: LocalId },
+    /// `(a, b, c)` — tuple pattern; each component is a sub-pattern.
+    Tuple(Vec<MirPattern>),
+    /// `Module.Variant(b1, b2, …)` — constructor pattern. `ctor`
+    /// identifies the variant by stable id; `bindings` are the
+    /// fresh locals for the variant's fields, in declaration
+    /// order.
+    Ctor {
+        ctor: CtorId,
+        bindings: Vec<LocalId>,
+    },
+}
+
+/// Construct a sum-type variant.
+#[derive(Debug, Clone)]
+pub struct MirConstruct {
+    pub ctor: CtorId,
+    pub args: Vec<Spanned<MirExpr>>,
+}
+
+/// Build a fresh record.
+#[derive(Debug, Clone)]
+pub struct MirRecordCreate {
+    pub type_id: TypeId,
+    pub fields: Vec<MirRecordField>,
+}
+
+/// `T.update(base, …)` — produce a record matching `base` except
+/// for the named field overrides.
+#[derive(Debug, Clone)]
+pub struct MirRecordUpdate {
+    pub base: Box<Spanned<MirExpr>>,
+    pub type_id: TypeId,
+    pub updates: Vec<MirRecordField>,
+}
+
+/// One `field = value` pair inside a record create or update.
+#[derive(Debug, Clone)]
+pub struct MirRecordField {
+    pub name: String,
+    pub value: Spanned<MirExpr>,
+}
+
+/// `base.field` projection.
+#[derive(Debug, Clone)]
+pub struct MirProject {
+    pub base: Box<Spanned<MirExpr>>,
+    pub field: String,
+}
+
+/// `let ok_binding = value?; ok_body` — semantic bind-and-propagate.
+#[derive(Debug, Clone)]
+pub struct MirTryBind {
+    pub value: Box<Spanned<MirExpr>>,
+    pub ok_binding: LocalId,
+    pub ok_body: Box<Spanned<MirExpr>>,
+}
+
+/// `(a, b, c)!` or `(a, b, c)?!`.
+#[derive(Debug, Clone)]
+pub struct MirIndependentProduct {
+    pub items: Vec<Spanned<MirExpr>>,
+    /// `true` for `?!` (unwrap `Ok`, propagate first `Err`);
+    /// `false` for `!` (raw tuple of `Result`s).
+    pub unwrap_results: bool,
+}
+
+/// Part of an interpolated string.
+#[derive(Debug, Clone)]
+pub enum MirStrPart {
+    /// Literal text between interpolation slots.
+    Literal(String),
+    /// `{expr}` — value gets stringified at runtime.
+    Expr(Spanned<MirExpr>),
+}
+
+/// Declared effect on a `MirFn`. Carries the source name
+/// (`"Console.print"`, `"Disk.readText"`) for now; a later phase
+/// may swap in `EffectId` for typed identity once the effect
+/// registry grows ids.
+#[derive(Debug, Clone)]
+pub struct MirEffectAnnotation {
+    pub name: String,
+}
+
+// `Spanned<T>` is re-used from `crate::ast::Spanned` — it already
+// carries a `SourceLine` plus a `OnceLock<Type>` type stamp, which
+// matches MIR's need to surface type-check results into the
+// executable substrate for later optimization passes. Defining a
+// second MIR-private `Spanned` would mean either dropping the type
+// stamp (losing information) or duplicating the OnceLock wiring;
+// reusing the AST helper keeps lowering trivial and the dump
+// output uniform across IR layers.

--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -72,3 +72,13 @@
 //!
 //! See `RFC.md` next to this file for the full design write-up,
 //! open questions, and the per-phase checklist.
+
+pub mod expr;
+pub mod program;
+
+pub use expr::{
+    MirBinOp, MirCall, MirCallee, MirConstruct, MirEffectAnnotation, MirExpr,
+    MirIndependentProduct, MirLet, MirMatch, MirMatchArm, MirPattern, MirProject, MirRecordCreate,
+    MirRecordField, MirRecordUpdate, MirStrPart, MirTailCall, MirTryBind,
+};
+pub use program::{LocalId, MirFn, MirParam, MirProgram};

--- a/src/ir/mir/program.rs
+++ b/src/ir/mir/program.rs
@@ -1,0 +1,120 @@
+//! `MirProgram` + `MirFn` — the top-level shape of Core MIR.
+//!
+//! Phase 2a of #252. The data model is structured (not flat /
+//! basic-block), expression-based (every `MirExpr` is a value), and
+//! identity-typed (declaration refs go through `FnId` / `TypeId` /
+//! `CtorId`). See [`super::RFC.md`] for the full rationale.
+
+use std::collections::HashMap;
+
+use crate::ir::{FnId, ModuleId};
+
+use super::expr::{MirEffectAnnotation, MirExpr};
+
+/// A whole compiled program in Core MIR. Keyed by `FnId` (stable
+/// across compilation units; same identity layer the rest of the
+/// pipeline consumes). Phase 2a builds an empty `MirProgram`
+/// directly; Phase 3 grows the lowering that populates it from
+/// `ResolvedProgramView`.
+#[derive(Debug, Clone, Default)]
+pub struct MirProgram {
+    /// All compiled functions, keyed by their `FnId`.
+    pub fns: HashMap<FnId, MirFn>,
+    /// Optional module identity for tooling that wants to walk
+    /// `MirProgram` per source module (LSP outline, future
+    /// per-module IR dump). Empty when the program was assembled
+    /// from a single entry file with no `depends [...]`.
+    pub modules: Vec<ModuleId>,
+}
+
+impl MirProgram {
+    /// Construct an empty program. Phase 3 lowering will populate
+    /// `fns` and `modules` as it walks `ResolvedProgramView`.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Lookup a function by its `FnId`. Returns `None` if the id
+    /// wasn't part of this compilation (e.g. a stale id surviving
+    /// from a previous program view).
+    pub fn fn_by_id(&self, id: FnId) -> Option<&MirFn> {
+        self.fns.get(&id)
+    }
+
+    /// All functions in arbitrary (`HashMap`) order. Callers that
+    /// need a stable walk (snapshot tests, dump output) should sort
+    /// by `FnId` themselves.
+    pub fn iter(&self) -> impl Iterator<Item = (&FnId, &MirFn)> {
+        self.fns.iter()
+    }
+}
+
+/// One function in Core MIR. Body is a single `MirExpr` — MIR is
+/// expression-based, so the function's body is the expression that
+/// produces its return value. `Let` chains within the body bind
+/// intermediate results; there's no separate "block" or
+/// "terminator" concept at this phase.
+#[derive(Debug, Clone)]
+pub struct MirFn {
+    /// Stable identity for this function. Matches the `FnId` issued
+    /// by `SymbolTable` during the existing pipeline; downstream
+    /// consumers can cross-reference `ProofIR` / `ProgramShape` by
+    /// the same id.
+    pub fn_id: FnId,
+    /// Source-level name. Carried for dumps + diagnostics; backends
+    /// must not key off this string for identity — that's what
+    /// `fn_id` is for.
+    pub name: String,
+    /// Parameters in declaration order. Each gets a fresh `LocalId`
+    /// at lowering time so the body can refer to it.
+    pub params: Vec<MirParam>,
+    /// Source-level return type annotation as it appears on the fn
+    /// signature. Phase 4 backends consume this for VM stack-slot
+    /// layout; later phases may replace it with a richer type
+    /// representation when the typechecker's `Type` enum becomes
+    /// the universal vocabulary.
+    pub return_type: String,
+    /// Declared effects (`! [Namespace.method, ...]`). Function-
+    /// level only — per-call-site effect annotation is deferred to
+    /// the Phase 6 optimizer track per the RFC.
+    pub effects: Vec<MirEffectAnnotation>,
+    /// The single expression that, when evaluated, produces the
+    /// function's return value. Phase 2a treats this as a typed
+    /// hole — the actual `MirExpr` variants are defined alongside
+    /// in `expr.rs`. Phase 3 lowering fills it.
+    pub body: MirExpr,
+}
+
+/// One formal parameter. The `LocalId` is assigned at lowering
+/// time and is the binding the function body refers to.
+#[derive(Debug, Clone)]
+pub struct MirParam {
+    /// Local binding introduced for this parameter. The function
+    /// body refers to it via `MirExpr::Local(LocalId)`.
+    pub local: LocalId,
+    /// Source-level parameter name. For dumps + diagnostics only.
+    pub name: String,
+    /// Source-level type annotation. Same caveat as `MirFn::return_type`.
+    pub ty: String,
+}
+
+/// Local binding identifier. Unique per function body (not per
+/// program) — backends look up the binding by walking the body's
+/// `Let` chain, so collision across functions isn't a concern.
+///
+/// Phase 2 picks "assign at MIR construction time" over "carry the
+/// HIR slot index" (the latter was the strawman alternative listed
+/// in the RFC). The carry-from-HIR option would have meant MIR's
+/// local space matches whatever the resolver chose — fine for the
+/// VM consumer, but the future inliner / monomorphizer needs the
+/// freedom to introduce fresh locals during optimization passes,
+/// and inheriting HIR's numbering would silently overlap with
+/// those.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct LocalId(pub u32);
+
+impl std::fmt::Display for LocalId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "%{}", self.0)
+    }
+}

--- a/tests/mir_phase2_model_spec.rs
+++ b/tests/mir_phase2_model_spec.rs
@@ -1,0 +1,182 @@
+//! Phase 2a of #252 — pin the Core MIR data model.
+//!
+//! No HIR → MIR lowering yet; Phase 3 lands that in waves. These
+//! tests construct tiny `MirProgram` values by hand to:
+//!
+//! 1. lock the public API in (so a Phase 2b dump / Phase 3 lowering
+//!    PR can't quietly rename or move things), and
+//! 2. prove the design decisions pinned in `src/ir/mir/RFC.md`
+//!    survive contact with real Rust types — `Try` is its own
+//!    variant, `Match` carries `MirMatchArm`s, constructors use
+//!    `CtorId`, locals use `LocalId`.
+
+use aver::ast::{BinOp, Literal, Spanned};
+use aver::ir::mir::{
+    LocalId, MirBinOp, MirCall, MirCallee, MirEffectAnnotation, MirExpr, MirFn, MirMatch,
+    MirMatchArm, MirParam, MirPattern, MirProgram, MirTryBind,
+};
+use aver::ir::{CtorId, FnId};
+
+fn span<T>(node: T) -> Spanned<T> {
+    Spanned {
+        node,
+        line: 0,
+        ty: std::sync::OnceLock::new(),
+    }
+}
+
+fn fn_id(n: u32) -> FnId {
+    // `FnId(pub u32)` — the public field is the test-construction
+    // hook for now. Phase 3 lowering populates ids via
+    // `SymbolTable`; consumers in production code never construct
+    // raw ids.
+    FnId(n)
+}
+
+fn ctor_id(n: u32) -> CtorId {
+    CtorId(n)
+}
+
+#[test]
+fn empty_program_round_trips() {
+    let program = MirProgram::empty();
+    assert!(program.fns.is_empty());
+    assert!(program.modules.is_empty());
+    assert!(program.iter().next().is_none());
+    assert!(program.fn_by_id(fn_id(0)).is_none());
+}
+
+#[test]
+fn pinned_decision_try_is_its_own_variant() {
+    // RFC pin: `Try` lives as `MirExpr::Try` — not as `Match`
+    // sugar. If a future refactor desugars `?` into `Match`, this
+    // test stops compiling (variant gone) or stops type-checking
+    // (signature changed). Either way the design intent shows up
+    // in CI before review.
+    let value = Box::new(span(MirExpr::Literal(span(Literal::Int(7)))));
+    let try_expr = MirExpr::Try(value);
+    match try_expr {
+        MirExpr::Try(_) => {}
+        _ => panic!("Try must not be desugared at the MirExpr level"),
+    }
+}
+
+#[test]
+fn pinned_decision_match_is_structured() {
+    // RFC pin: `Match { subject, arms: Vec<MirMatchArm> }`. No
+    // basic-block jumps, no terminator-style switch.
+    let subject = Box::new(span(MirExpr::Local(span(LocalId(0)))));
+    let arms = vec![
+        MirMatchArm {
+            pattern: MirPattern::EmptyList,
+            body: span(MirExpr::Literal(span(Literal::Int(0)))),
+        },
+        MirMatchArm {
+            pattern: MirPattern::Cons {
+                head: LocalId(1),
+                tail: LocalId(2),
+            },
+            body: span(MirExpr::Local(span(LocalId(1)))),
+        },
+    ];
+    let m = MirExpr::Match(span(MirMatch { subject, arms }));
+    let MirExpr::Match(spanned_match) = m else {
+        panic!("expected Match variant");
+    };
+    assert_eq!(spanned_match.node.arms.len(), 2);
+    assert!(matches!(
+        &spanned_match.node.arms[0].pattern,
+        MirPattern::EmptyList
+    ));
+    assert!(matches!(
+        &spanned_match.node.arms[1].pattern,
+        MirPattern::Cons { .. }
+    ));
+}
+
+#[test]
+fn pinned_decision_identity_is_typed() {
+    // RFC pin: declaration refs go through `FnId` / `CtorId` /
+    // `TypeId`, never strings. `MirCallee::Fn` carries `FnId`,
+    // constructor patterns carry `CtorId`.
+    let call = MirExpr::Call(span(MirCall {
+        callee: MirCallee::Fn(fn_id(42)),
+        args: vec![span(MirExpr::Literal(span(Literal::Int(1))))],
+    }));
+    let MirExpr::Call(spanned_call) = call else {
+        unreachable!()
+    };
+    let MirCallee::Fn(callee_id) = spanned_call.node.callee else {
+        panic!("Fn callee must carry FnId, not String");
+    };
+    assert_eq!(callee_id, fn_id(42));
+
+    let ctor_pattern = MirPattern::Ctor {
+        ctor: ctor_id(7),
+        bindings: vec![LocalId(0)],
+    };
+    let MirPattern::Ctor { ctor, bindings } = ctor_pattern else {
+        unreachable!()
+    };
+    assert_eq!(ctor, ctor_id(7));
+    assert_eq!(bindings, vec![LocalId(0)]);
+}
+
+#[test]
+fn try_bind_pins_let_form() {
+    // `let x = step()?; body` — semantic bind-and-propagate.
+    // Distinct from a `Let` chaining a `Try` so downstream
+    // consumers can recognize the shape without re-walking.
+    let value = Box::new(span(MirExpr::Call(span(MirCall {
+        callee: MirCallee::Fn(fn_id(1)),
+        args: vec![],
+    }))));
+    let ok_body = Box::new(span(MirExpr::Local(span(LocalId(0)))));
+    let try_bind = MirExpr::TryBind(span(MirTryBind {
+        value,
+        ok_binding: LocalId(0),
+        ok_body,
+    }));
+    let MirExpr::TryBind(spanned) = try_bind else {
+        panic!("expected TryBind");
+    };
+    assert_eq!(spanned.node.ok_binding, LocalId(0));
+}
+
+#[test]
+fn build_a_tiny_function_by_hand() {
+    // Smoke-test the whole shape: a one-param int-doubling fn.
+    //
+    //     fn double(x: Int) -> Int :- x + x
+    //
+    // Phase 3 lowering would produce this from `ResolvedFnDef`;
+    // here we build it manually so any rename / move on the
+    // public API breaks this test.
+    let x = LocalId(0);
+    let body = MirExpr::BinOp(span(MirBinOp {
+        op: BinOp::Add,
+        lhs: Box::new(span(MirExpr::Local(span(x)))),
+        rhs: Box::new(span(MirExpr::Local(span(x)))),
+    }));
+    let f = MirFn {
+        fn_id: fn_id(0),
+        name: "double".to_string(),
+        params: vec![MirParam {
+            local: x,
+            name: "x".to_string(),
+            ty: "Int".to_string(),
+        }],
+        return_type: "Int".to_string(),
+        effects: vec![MirEffectAnnotation {
+            name: "Console.print".to_string(),
+        }],
+        body,
+    };
+    let mut program = MirProgram::empty();
+    program.fns.insert(f.fn_id, f);
+    assert_eq!(program.fns.len(), 1);
+    assert_eq!(
+        program.fn_by_id(fn_id(0)).map(|f| f.name.as_str()),
+        Some("double")
+    );
+}


### PR DESCRIPTION
## Summary
Phase 2a of #252 (the 0.24 Core MIR epic). Lands the structured, identity-typed data model the [Phase 1 RFC](https://github.com/jasisz/aver/pull/253) pinned. **No lowering or dump yet** — those are Phase 2b and Phase 3.

**Files**:
- `src/ir/mir/program.rs` — `MirProgram`, `MirFn`, `MirParam`, `LocalId`
- `src/ir/mir/expr.rs` — `MirExpr` + supporting node types
- `tests/mir_phase2_model_spec.rs` — 6 compile-time + smoke tests pinning the public API

**Pinned RFC decisions visible in the types**:
- `Try` is a node (`MirExpr::Try(Box<…>)`) — not desugared to `Match`
- `Match` is structured (`Vec<MirMatchArm>`) — no terminator-style switch
- Identity goes through `FnId` / `CtorId` / `TypeId` — `MirCallee::Fn(FnId)`, `MirPattern::Ctor { ctor: CtorId, … }`, `MirRecordCreate.type_id: TypeId`

**One open RFC question answered**: `LocalId` is assigned at MIR construction time, not carried from HIR slot indices. Reason: future optimizer passes (inliner, monomorphizer) need to introduce fresh locals without colliding with the resolver's numbering.

**Reuse over duplication**: `MirExpr` uses `ast::Spanned<T>` (which already carries an `OnceLock<Type>` typecheck stamp). Defining a second MIR-private `Spanned` would mean either dropping the type stamp or duplicating the `OnceLock` wiring — neither pays off.

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --release --test proof_spec --test shape_module_patterns_spec --test mir_phase2_model_spec` — 67/15/6
- [ ] CI green

## What's next
- Phase 2b: textual dump + `aver compile --emit-ir-after=mir` flag + snapshot tests on a small corpus
- Phase 3: HIR → MIR lowering in waves

🤖 Generated with [Claude Code](https://claude.com/claude-code)