### PR TITLE
ir/mir: textual dump for MirProgram / MirFn / MirExpr (#252 Phase 2b)

### DIFF
--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -36,7 +36,7 @@ use super::expr::{
     MirIndependentProduct, MirLet, MirMatch, MirMatchArm, MirPattern, MirProject, MirRecordCreate,
     MirRecordField, MirRecordUpdate, MirStrPart, MirTailCall, MirTryBind,
 };
-use super::program::{LocalId, MirFn, MirParam, MirProgram};
+use super::program::{MirFn, MirParam, MirProgram};
 
 impl fmt::Display for MirProgram {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -1,0 +1,347 @@
+//! Textual dump for Core MIR.
+//!
+//! Phase 2b of #252. Renders `MirProgram` / `MirFn` / `MirExpr` /
+//! `MirPattern` as a structured text view suitable for snapshot
+//! tests, pass reports, and the future `aver compile
+//! --emit-ir-after=mir` flag (the flag itself lands together with
+//! Phase 3's first lowering wave — there's no source-of-`MirProgram`
+//! until then).
+//!
+//! Format philosophy:
+//! - **Stable order**: functions sorted by `FnId`, fields by their
+//!   declared order, locals by introduction order. Snapshot tests
+//!   only stay green if every walker visits the same nodes in the
+//!   same sequence.
+//! - **Identity visible**: `FnId`, `TypeId`, `CtorId`, `LocalId`
+//!   all appear in the dump so a reviewer can tell whether the
+//!   lowerer wired references through the identity layer or fell
+//!   back to a string lookup.
+//! - **One concept per line**: each `Let`, each `Match` arm, each
+//!   constructor / record field gets its own line. Wide
+//!   expressions still wrap, but the structural skeleton stays
+//!   line-oriented so `diff` reads cleanly.
+//! - **No span noise by default**: source line numbers would
+//!   churn the snapshots whenever a fixture moves by one line.
+//!   When a future diagnostic consumer needs span output, it can
+//!   call into a richer formatter; the `Display` impl stays
+//!   span-free.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::ast::Spanned;
+
+use super::expr::{
+    MirBinOp, MirCall, MirCallee, MirConstruct, MirEffectAnnotation, MirExpr,
+    MirIndependentProduct, MirLet, MirMatch, MirMatchArm, MirPattern, MirProject, MirRecordCreate,
+    MirRecordField, MirRecordUpdate, MirStrPart, MirTailCall, MirTryBind,
+};
+use super::program::{LocalId, MirFn, MirParam, MirProgram};
+
+impl fmt::Display for MirProgram {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "MirProgram {{")?;
+        // Sort by FnId so dump order is independent of HashMap
+        // iteration order (which would otherwise drift across
+        // platforms + Rust versions).
+        let sorted: BTreeMap<_, _> = self.fns.iter().collect();
+        for (fn_id, mir_fn) in sorted {
+            writeln!(f, "  // FnId({})", fn_id.0)?;
+            write_fn(f, mir_fn, "  ")?;
+        }
+        if !self.modules.is_empty() {
+            writeln!(f, "  modules: [")?;
+            for m in &self.modules {
+                writeln!(f, "    ModuleId({})", m.0)?;
+            }
+            writeln!(f, "  ]")?;
+        }
+        writeln!(f, "}}")
+    }
+}
+
+impl fmt::Display for MirFn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_fn(f, self, "")
+    }
+}
+
+fn write_fn(f: &mut fmt::Formatter<'_>, mir_fn: &MirFn, indent: &str) -> fmt::Result {
+    write!(f, "{indent}fn {}(", mir_fn.name)?;
+    for (i, p) in mir_fn.params.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write_param(f, p)?;
+    }
+    writeln!(f, ") -> {} {{", mir_fn.return_type)?;
+    if !mir_fn.effects.is_empty() {
+        write!(f, "{indent}  effects: [")?;
+        for (i, e) in mir_fn.effects.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write_effect(f, e)?;
+        }
+        writeln!(f, "]")?;
+    }
+    write!(f, "{indent}  ")?;
+    write_expr(f, &mir_fn.body, &format!("{indent}  "))?;
+    writeln!(f)?;
+    writeln!(f, "{indent}}}")
+}
+
+fn write_param(f: &mut fmt::Formatter<'_>, p: &MirParam) -> fmt::Result {
+    write!(f, "{}{}: {}", p.local, p.name, p.ty)
+}
+
+fn write_effect(f: &mut fmt::Formatter<'_>, e: &MirEffectAnnotation) -> fmt::Result {
+    write!(f, "{}", e.name)
+}
+
+fn write_expr(f: &mut fmt::Formatter<'_>, expr: &Spanned<MirExpr>, indent: &str) -> fmt::Result {
+    match &expr.node {
+        MirExpr::Literal(lit) => write!(f, "{:?}", lit.node),
+        MirExpr::Local(local) => write!(f, "{}", local.node),
+        MirExpr::Let(spanned) => write_let(f, &spanned.node, indent),
+        MirExpr::Call(spanned) => write_call(f, &spanned.node, indent),
+        MirExpr::TailCall(spanned) => write_tail_call(f, &spanned.node, indent),
+        MirExpr::BinOp(spanned) => write_bin_op(f, &spanned.node, indent),
+        MirExpr::Neg(inner) => {
+            write!(f, "-(")?;
+            write_expr(f, inner, indent)?;
+            write!(f, ")")
+        }
+        MirExpr::Match(spanned) => write_match(f, &spanned.node, indent),
+        MirExpr::Construct(spanned) => write_construct(f, &spanned.node, indent),
+        MirExpr::RecordCreate(spanned) => write_record_create(f, &spanned.node, indent),
+        MirExpr::RecordUpdate(spanned) => write_record_update(f, &spanned.node, indent),
+        MirExpr::Project(spanned) => write_project(f, &spanned.node, indent),
+        MirExpr::Try(inner) => {
+            write_expr(f, inner, indent)?;
+            write!(f, "?")
+        }
+        MirExpr::TryBind(spanned) => write_try_bind(f, &spanned.node, indent),
+        MirExpr::List(items) => write_list_or_tuple(f, "List", items, indent),
+        MirExpr::Tuple(items) => write_list_or_tuple(f, "Tuple", items, indent),
+        MirExpr::MapLiteral(pairs) => write_map_literal(f, pairs, indent),
+        MirExpr::InterpolatedStr(parts) => write_interp_str(f, parts, indent),
+        MirExpr::IndependentProduct(spanned) => write_independent_product(f, &spanned.node, indent),
+        MirExpr::Return(inner) => {
+            write!(f, "return ")?;
+            write_expr(f, inner, indent)
+        }
+    }
+}
+
+fn write_let(f: &mut fmt::Formatter<'_>, let_node: &MirLet, indent: &str) -> fmt::Result {
+    writeln!(f, "let {} =", let_node.binding)?;
+    let inner = format!("{indent}  ");
+    write!(f, "{inner}")?;
+    write_expr(f, &let_node.value, &inner)?;
+    writeln!(f)?;
+    write!(f, "{indent}in ")?;
+    write_expr(f, &let_node.body, indent)
+}
+
+fn write_call(f: &mut fmt::Formatter<'_>, call: &MirCall, indent: &str) -> fmt::Result {
+    match &call.callee {
+        MirCallee::Fn(id) => write!(f, "FnId({}).call(", id.0)?,
+        MirCallee::Builtin(name) => write!(f, "Builtin({}).call(", name)?,
+    }
+    write_args(f, &call.args, indent)?;
+    write!(f, ")")
+}
+
+fn write_tail_call(f: &mut fmt::Formatter<'_>, tc: &MirTailCall, indent: &str) -> fmt::Result {
+    write!(f, "tail FnId({}).call(", tc.target.0)?;
+    write_args(f, &tc.args, indent)?;
+    write!(f, ")")
+}
+
+fn write_args(f: &mut fmt::Formatter<'_>, args: &[Spanned<MirExpr>], indent: &str) -> fmt::Result {
+    for (i, a) in args.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write_expr(f, a, indent)?;
+    }
+    Ok(())
+}
+
+fn write_bin_op(f: &mut fmt::Formatter<'_>, op: &MirBinOp, indent: &str) -> fmt::Result {
+    write!(f, "(")?;
+    write_expr(f, &op.lhs, indent)?;
+    write!(f, " {:?} ", op.op)?;
+    write_expr(f, &op.rhs, indent)?;
+    write!(f, ")")
+}
+
+fn write_match(f: &mut fmt::Formatter<'_>, m: &MirMatch, indent: &str) -> fmt::Result {
+    write!(f, "match ")?;
+    write_expr(f, &m.subject, indent)?;
+    writeln!(f, " {{")?;
+    let arm_indent = format!("{indent}  ");
+    for arm in &m.arms {
+        write_arm(f, arm, &arm_indent)?;
+    }
+    write!(f, "{indent}}}")
+}
+
+fn write_arm(f: &mut fmt::Formatter<'_>, arm: &MirMatchArm, indent: &str) -> fmt::Result {
+    write!(f, "{indent}")?;
+    write_pattern(f, &arm.pattern)?;
+    write!(f, " => ")?;
+    write_expr(f, &arm.body, indent)?;
+    writeln!(f, ",")
+}
+
+fn write_pattern(f: &mut fmt::Formatter<'_>, p: &MirPattern) -> fmt::Result {
+    match p {
+        MirPattern::Wildcard => write!(f, "_"),
+        MirPattern::Literal(lit) => write!(f, "{lit:?}"),
+        MirPattern::Bind(local) => write!(f, "{local}"),
+        MirPattern::EmptyList => write!(f, "[]"),
+        MirPattern::Cons { head, tail } => write!(f, "[{head}, ..{tail}]"),
+        MirPattern::Tuple(items) => {
+            write!(f, "(")?;
+            for (i, sub) in items.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write_pattern(f, sub)?;
+            }
+            write!(f, ")")
+        }
+        MirPattern::Ctor { ctor, bindings } => {
+            write!(f, "CtorId({})(", ctor.0)?;
+            for (i, b) in bindings.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{b}")?;
+            }
+            write!(f, ")")
+        }
+    }
+}
+
+fn write_construct(f: &mut fmt::Formatter<'_>, c: &MirConstruct, indent: &str) -> fmt::Result {
+    write!(f, "CtorId({})(", c.ctor.0)?;
+    write_args(f, &c.args, indent)?;
+    write!(f, ")")
+}
+
+fn write_record_create(
+    f: &mut fmt::Formatter<'_>,
+    r: &MirRecordCreate,
+    indent: &str,
+) -> fmt::Result {
+    write!(f, "TypeId({}) {{ ", r.type_id.0)?;
+    write_fields(f, &r.fields, indent)?;
+    write!(f, " }}")
+}
+
+fn write_record_update(
+    f: &mut fmt::Formatter<'_>,
+    r: &MirRecordUpdate,
+    indent: &str,
+) -> fmt::Result {
+    write!(f, "TypeId({}).update(", r.type_id.0)?;
+    write_expr(f, &r.base, indent)?;
+    write!(f, ", ")?;
+    write_fields(f, &r.updates, indent)?;
+    write!(f, ")")
+}
+
+fn write_fields(
+    f: &mut fmt::Formatter<'_>,
+    fields: &[MirRecordField],
+    indent: &str,
+) -> fmt::Result {
+    for (i, field) in fields.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write!(f, "{} = ", field.name)?;
+        write_expr(f, &field.value, indent)?;
+    }
+    Ok(())
+}
+
+fn write_project(f: &mut fmt::Formatter<'_>, p: &MirProject, indent: &str) -> fmt::Result {
+    write_expr(f, &p.base, indent)?;
+    write!(f, ".{}", p.field)
+}
+
+fn write_try_bind(f: &mut fmt::Formatter<'_>, tb: &MirTryBind, indent: &str) -> fmt::Result {
+    write!(f, "let {} =", tb.ok_binding)?;
+    let inner = format!("{indent}  ");
+    writeln!(f)?;
+    write!(f, "{inner}")?;
+    write_expr(f, &tb.value, &inner)?;
+    writeln!(f, "?")?;
+    write!(f, "{indent}in ")?;
+    write_expr(f, &tb.ok_body, indent)
+}
+
+fn write_list_or_tuple(
+    f: &mut fmt::Formatter<'_>,
+    tag: &str,
+    items: &[Spanned<MirExpr>],
+    indent: &str,
+) -> fmt::Result {
+    write!(f, "{tag}[")?;
+    write_args(f, items, indent)?;
+    write!(f, "]")
+}
+
+fn write_map_literal(
+    f: &mut fmt::Formatter<'_>,
+    pairs: &[(Spanned<MirExpr>, Spanned<MirExpr>)],
+    indent: &str,
+) -> fmt::Result {
+    write!(f, "Map{{")?;
+    for (i, (k, v)) in pairs.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write_expr(f, k, indent)?;
+        write!(f, " => ")?;
+        write_expr(f, v, indent)?;
+    }
+    write!(f, "}}")
+}
+
+fn write_interp_str(f: &mut fmt::Formatter<'_>, parts: &[MirStrPart], indent: &str) -> fmt::Result {
+    write!(f, "\"")?;
+    for part in parts {
+        match part {
+            MirStrPart::Literal(s) => write!(f, "{}", s.replace('"', "\\\""))?,
+            MirStrPart::Expr(e) => {
+                write!(f, "{{")?;
+                write_expr(f, e, indent)?;
+                write!(f, "}}")?;
+            }
+        }
+    }
+    write!(f, "\"")
+}
+
+fn write_independent_product(
+    f: &mut fmt::Formatter<'_>,
+    ip: &MirIndependentProduct,
+    indent: &str,
+) -> fmt::Result {
+    write!(f, "(")?;
+    write_args(f, &ip.items, indent)?;
+    if ip.unwrap_results {
+        write!(f, ")?!")
+    } else {
+        write!(f, ")!")
+    }
+}
+
+// `LocalId`'s `Display` impl lives in `program.rs` — search for it
+// there. The format (`%N`) is shared by both this dump and any
+// future pass-report code that consumes the same IDs.

--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -73,6 +73,7 @@
 //! See `RFC.md` next to this file for the full design write-up,
 //! open questions, and the per-phase checklist.
 
+pub mod dump;
 pub mod expr;
 pub mod program;
 

--- a/src/ir/mir/program.rs
+++ b/src/ir/mir/program.rs
@@ -9,6 +9,8 @@ use std::collections::HashMap;
 
 use crate::ir::{FnId, ModuleId};
 
+use crate::ast::Spanned;
+
 use super::expr::{MirEffectAnnotation, MirExpr};
 
 /// A whole compiled program in Core MIR. Keyed by `FnId` (stable
@@ -79,10 +81,12 @@ pub struct MirFn {
     /// the Phase 6 optimizer track per the RFC.
     pub effects: Vec<MirEffectAnnotation>,
     /// The single expression that, when evaluated, produces the
-    /// function's return value. Phase 2a treats this as a typed
-    /// hole — the actual `MirExpr` variants are defined alongside
-    /// in `expr.rs`. Phase 3 lowering fills it.
-    pub body: MirExpr,
+    /// function's return value. Wrapped in `Spanned` so the body's
+    /// own source location stays available to dumps / diagnostics
+    /// (the surrounding `MirFn` has its own identity layer via
+    /// `fn_id`, but the body span is needed for sub-expression
+    /// errors that don't carry a closer one).
+    pub body: Spanned<MirExpr>,
 }
 
 /// One formal parameter. The `LocalId` is assigned at lowering

--- a/tests/mir_phase2_model_spec.rs
+++ b/tests/mir_phase2_model_spec.rs
@@ -153,11 +153,11 @@ fn build_a_tiny_function_by_hand() {
     // here we build it manually so any rename / move on the
     // public API breaks this test.
     let x = LocalId(0);
-    let body = MirExpr::BinOp(span(MirBinOp {
+    let body = span(MirExpr::BinOp(span(MirBinOp {
         op: BinOp::Add,
         lhs: Box::new(span(MirExpr::Local(span(x)))),
         rhs: Box::new(span(MirExpr::Local(span(x)))),
-    }));
+    })));
     let f = MirFn {
         fn_id: fn_id(0),
         name: "double".to_string(),

--- a/tests/mir_phase2b_dump_spec.rs
+++ b/tests/mir_phase2b_dump_spec.rs
@@ -1,0 +1,287 @@
+//! Phase 2b of #252 — pin the Core MIR textual dump.
+//!
+//! Phase 3 will land HIR → MIR lowering and these fixtures will
+//! get replaced by real-program snapshots driven through
+//! `aver compile --emit-ir-after=mir`. Until then, we hand-
+//! construct small `MirProgram`s + assert their `Display` output.
+//! The point isn't to validate lowering; it's to lock the dump
+//! format so future passes don't quietly reshape it.
+
+use aver::ast::{BinOp, Literal, Spanned};
+use aver::ir::mir::{
+    LocalId, MirBinOp, MirCall, MirCallee, MirEffectAnnotation, MirExpr, MirFn, MirLet, MirMatch,
+    MirMatchArm, MirParam, MirPattern, MirProgram, MirTryBind,
+};
+use aver::ir::{CtorId, FnId};
+
+fn span<T>(node: T) -> Spanned<T> {
+    Spanned {
+        node,
+        line: 0,
+        ty: std::sync::OnceLock::new(),
+    }
+}
+
+fn fn_id(n: u32) -> FnId {
+    FnId(n)
+}
+
+#[test]
+fn empty_program_dumps_skeleton() {
+    let p = MirProgram::empty();
+    let dump = format!("{p}");
+    assert_eq!(dump, "MirProgram {\n}\n");
+}
+
+#[test]
+fn one_fn_dump_pins_skeleton() {
+    // fn double(x: Int) -> Int = (x + x)
+    let x = LocalId(0);
+    let body = span(MirExpr::BinOp(span(MirBinOp {
+        op: BinOp::Add,
+        lhs: Box::new(span(MirExpr::Local(span(x)))),
+        rhs: Box::new(span(MirExpr::Local(span(x)))),
+    })));
+    let mut program = MirProgram::empty();
+    program.fns.insert(
+        fn_id(0),
+        MirFn {
+            fn_id: fn_id(0),
+            name: "double".to_string(),
+            params: vec![MirParam {
+                local: x,
+                name: "x".to_string(),
+                ty: "Int".to_string(),
+            }],
+            return_type: "Int".to_string(),
+            effects: vec![],
+            body,
+        },
+    );
+
+    let dump = format!("{program}");
+    let expected = "\
+MirProgram {
+  // FnId(0)
+  fn double(%0x: Int) -> Int {
+    (%0 Add %0)
+  }
+}
+";
+    assert_eq!(
+        dump, expected,
+        "MirProgram dump drift:\n--- expected ---\n{expected}\n--- got ---\n{dump}"
+    );
+}
+
+#[test]
+fn try_bind_dump_shape() {
+    // fn use_step() -> Result<Int, String> = let %0 = step()?; %0
+    let body = span(MirExpr::TryBind(span(MirTryBind {
+        value: Box::new(span(MirExpr::Call(span(MirCall {
+            callee: MirCallee::Fn(fn_id(1)),
+            args: vec![],
+        })))),
+        ok_binding: LocalId(0),
+        ok_body: Box::new(span(MirExpr::Local(span(LocalId(0))))),
+    })));
+    let mut program = MirProgram::empty();
+    program.fns.insert(
+        fn_id(0),
+        MirFn {
+            fn_id: fn_id(0),
+            name: "use_step".to_string(),
+            params: vec![],
+            return_type: "Result<Int, String>".to_string(),
+            effects: vec![],
+            body,
+        },
+    );
+    let dump = format!("{program}");
+    // Spot-check key markers, not full equality — the inner
+    // indentation policy may evolve as Phase 3 lands and we don't
+    // want to thrash the fixture every time.
+    assert!(
+        dump.contains("fn use_step()"),
+        "dump missing fn header:\n{dump}"
+    );
+    assert!(
+        dump.contains("let %0 ="),
+        "dump missing TryBind let:\n{dump}"
+    );
+    assert!(
+        dump.contains("FnId(1).call()?"),
+        "dump missing FnId-typed callee + `?`:\n{dump}"
+    );
+}
+
+#[test]
+fn match_dump_shape() {
+    // fn first(xs: List<Int>) -> Int = match xs { [] => 0; [h, ..t] => h; }
+    let xs = LocalId(0);
+    let h = LocalId(1);
+    let t = LocalId(2);
+    let body = span(MirExpr::Match(span(MirMatch {
+        subject: Box::new(span(MirExpr::Local(span(xs)))),
+        arms: vec![
+            MirMatchArm {
+                pattern: MirPattern::EmptyList,
+                body: span(MirExpr::Literal(span(Literal::Int(0)))),
+            },
+            MirMatchArm {
+                pattern: MirPattern::Cons { head: h, tail: t },
+                body: span(MirExpr::Local(span(h))),
+            },
+        ],
+    })));
+    let mut program = MirProgram::empty();
+    program.fns.insert(
+        fn_id(0),
+        MirFn {
+            fn_id: fn_id(0),
+            name: "first".to_string(),
+            params: vec![MirParam {
+                local: xs,
+                name: "xs".to_string(),
+                ty: "List<Int>".to_string(),
+            }],
+            return_type: "Int".to_string(),
+            effects: vec![],
+            body,
+        },
+    );
+    let dump = format!("{program}");
+    assert!(
+        dump.contains("match %0"),
+        "match subject didn't render:\n{dump}"
+    );
+    assert!(
+        dump.contains("[] =>"),
+        "EmptyList arm didn't render:\n{dump}"
+    );
+    assert!(
+        dump.contains("[%1, ..%2] =>"),
+        "Cons arm didn't render:\n{dump}"
+    );
+}
+
+#[test]
+fn ctor_pattern_dump_uses_ctor_id() {
+    // pattern: Module.Variant(b1) — make sure CtorId appears (not
+    // a string name) so reviewers can confirm identity wiring.
+    let p = MirPattern::Ctor {
+        ctor: CtorId(7),
+        bindings: vec![LocalId(0)],
+    };
+    // Use the arm-rendering path via a tiny Match.
+    let body = span(MirExpr::Match(span(MirMatch {
+        subject: Box::new(span(MirExpr::Local(span(LocalId(99))))),
+        arms: vec![MirMatchArm {
+            pattern: p,
+            body: span(MirExpr::Local(span(LocalId(0)))),
+        }],
+    })));
+    let mut program = MirProgram::empty();
+    program.fns.insert(
+        fn_id(0),
+        MirFn {
+            fn_id: fn_id(0),
+            name: "match_ctor".to_string(),
+            params: vec![],
+            return_type: "Int".to_string(),
+            effects: vec![],
+            body,
+        },
+    );
+    let dump = format!("{program}");
+    assert!(
+        dump.contains("CtorId(7)(%0)"),
+        "ctor pattern should render the typed identity, not a string:\n{dump}"
+    );
+}
+
+#[test]
+fn effects_render_on_fn_header() {
+    let body = span(MirExpr::Literal(span(Literal::Int(0))));
+    let mut program = MirProgram::empty();
+    program.fns.insert(
+        fn_id(0),
+        MirFn {
+            fn_id: fn_id(0),
+            name: "noisy".to_string(),
+            params: vec![],
+            return_type: "Int".to_string(),
+            effects: vec![
+                MirEffectAnnotation {
+                    name: "Console.print".to_string(),
+                },
+                MirEffectAnnotation {
+                    name: "Disk.readText".to_string(),
+                },
+            ],
+            body,
+        },
+    );
+    let dump = format!("{program}");
+    assert!(
+        dump.contains("effects: [Console.print, Disk.readText]"),
+        "effects list missing or reordered:\n{dump}"
+    );
+}
+
+#[test]
+fn fns_render_in_fn_id_order() {
+    // Insert in reverse order; assert dump walks them ascending
+    // by FnId. Snapshot stability across HashMap iteration drift
+    // depends on this.
+    let mut program = MirProgram::empty();
+    for raw in [3u32, 1, 2, 0] {
+        program.fns.insert(
+            fn_id(raw),
+            MirFn {
+                fn_id: fn_id(raw),
+                name: format!("f{raw}"),
+                params: vec![],
+                return_type: "Int".to_string(),
+                effects: vec![],
+                body: span(MirExpr::Literal(span(Literal::Int(raw as i64)))),
+            },
+        );
+    }
+    let dump = format!("{program}");
+    let pos = |needle: &str| dump.find(needle).expect(needle);
+    assert!(
+        pos("// FnId(0)") < pos("// FnId(1)")
+            && pos("// FnId(1)") < pos("// FnId(2)")
+            && pos("// FnId(2)") < pos("// FnId(3)"),
+        "fns not rendered in ascending FnId order:\n{dump}"
+    );
+}
+
+#[test]
+fn let_dump_shape() {
+    // let %0 = 7; %0
+    let body = span(MirExpr::Let(span(MirLet {
+        binding: LocalId(0),
+        value: Box::new(span(MirExpr::Literal(span(Literal::Int(7))))),
+        body: Box::new(span(MirExpr::Local(span(LocalId(0))))),
+    })));
+    let mut program = MirProgram::empty();
+    program.fns.insert(
+        fn_id(0),
+        MirFn {
+            fn_id: fn_id(0),
+            name: "seven".to_string(),
+            params: vec![],
+            return_type: "Int".to_string(),
+            effects: vec![],
+            body,
+        },
+    );
+    let dump = format!("{program}");
+    assert!(dump.contains("let %0 ="), "Let header missing:\n{dump}");
+    assert!(
+        dump.contains("in %0"),
+        "Let body continuation missing:\n{dump}"
+    );
+}


### PR DESCRIPTION
## Summary
Phase 2b of #252 — textual dump via `fmt::Display` on `MirProgram` / `MirFn` / `MirExpr`. Snapshot tests pin the format. No CLI flag yet — `aver compile --emit-ir-after=mir` lands with Phase 3's first lowering wave (there's no source-of-`MirProgram` until then).

**Files**:
- `src/ir/mir/dump.rs` — `Display` impls + per-node writers
- `src/ir/mir/mod.rs` — module wire-up
- `src/ir/mir/program.rs` — `MirFn::body` is now `Spanned<MirExpr>` for span uniformity with sub-expressions
- `tests/mir_phase2b_dump_spec.rs` — 8 tests pinning the format

**Format philosophy** (also in `dump.rs` module doc):
- Stable order: fns sorted by `FnId`, fields by declared order, locals by introduction. Snapshot stability across `HashMap` iteration drift depends on this.
- Identity visible: `FnId(N)`, `CtorId(N)`, `TypeId(N)`, `%LocalId` all surface so reviewers spot identity wiring at a glance.
- One concept per line: `Let`, `Match` arms, record fields. Diff reads cleanly.
- No span noise: line numbers would churn snapshots on every fixture move. A diagnostic-rich formatter is a separate consumer.

**Snapshot test approach**: hand-built fixtures (no Phase 3 lowering yet). Some tests use exact-match (`empty_program_dumps_skeleton`, `one_fn_dump_pins_skeleton`); the rest use targeted `contains()` so the inner indentation policy can evolve as Phase 3 lands without thrashing every fixture.

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --release --test proof_spec --test shape_module_patterns_spec --test mir_phase2_model_spec --test mir_phase2b_dump_spec` — 67/15/6/8
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)