### PR TITLE
ir/mir: HIR → MIR lowering, wave 1 (#252 Phase 3)

### DIFF
--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -1,0 +1,130 @@
+//! HIR → MIR lowering, wave 1.
+//!
+//! Phase 3 of #252 lowers `ResolvedProgramView` into `MirProgram`
+//! in widening waves so review surface stays small. **Wave 1 (this
+//! file)** covers the leaf subset that doesn't need a slot table,
+//! a callee resolver, or pattern matching:
+//!
+//! - `ResolvedExpr::Literal` → `MirExpr::Literal`
+//! - `ResolvedExpr::Resolved { slot, .. }` → `MirExpr::Local`
+//! - `ResolvedExpr::BinOp` → `MirExpr::BinOp`
+//! - `ResolvedExpr::Neg` → `MirExpr::Neg`
+//! - single-stmt `Stmt::Expr` body
+//!
+//! Any function body that uses constructs outside this subset is
+//! skipped (not added to the resulting `MirProgram.fns`). Wave 2
+//! adds calls + constructors + records; wave 3 adds match, Try /
+//! TryBind, tail calls, and independent products. Every wave is a
+//! separate PR.
+//!
+//! ## LocalId mapping
+//!
+//! Wave 1 uses the resolver's slot index (`ResolvedExpr::Resolved {
+//! slot, .. }`) directly as the `LocalId`. Phase 2's RFC pin was
+//! "assign at MIR construction time" — that means the optimizer
+//! can later renumber freely, but during lowering itself we use
+//! the slot the resolver already assigned. This is the simplest
+//! correct choice: the slot is already unique per function body.
+
+use crate::ast::Spanned;
+use crate::ir::hir::{ResolvedExpr, ResolvedFnBody, ResolvedFnDef, ResolvedStmt, ResolvedTopLevel};
+
+use super::expr::{MirBinOp, MirEffectAnnotation, MirExpr};
+use super::program::{LocalId, MirFn, MirParam, MirProgram};
+
+/// Lower an entry-module resolved-item list into a `MirProgram`.
+/// Function bodies outside wave 1's supported subset are silently
+/// skipped — `MirProgram.fns` only contains what this wave knew
+/// how to handle. Wave 2 and 3 will widen the coverage; a future
+/// "complete" assertion test can compare `lowered_fn_count` against
+/// the total `ResolvedFnDef` count to track progress.
+pub fn lower_program(items: &[ResolvedTopLevel]) -> MirProgram {
+    let mut program = MirProgram::empty();
+    for item in items {
+        if let ResolvedTopLevel::FnDef(fd) = item
+            && let Some(mir_fn) = lower_fn(fd)
+        {
+            program.fns.insert(fd.fn_id, mir_fn);
+        }
+    }
+    program
+}
+
+/// Lower one `ResolvedFnDef` if its body fits wave 1. Returns
+/// `None` for everything else; the caller drops the fn from the
+/// MIR program in that case.
+fn lower_fn(fd: &ResolvedFnDef) -> Option<MirFn> {
+    let ResolvedFnBody::Block(stmts) = &*fd.body;
+    if stmts.len() != 1 {
+        return None;
+    }
+    let ResolvedStmt::Expr(expr) = &stmts[0] else {
+        return None;
+    };
+    let body = lower_expr(expr)?;
+
+    let params = fd
+        .params
+        .iter()
+        .enumerate()
+        .map(|(i, (name, ty))| MirParam {
+            // Wave 1's local numbering matches the resolver's
+            // parameter-slot convention (params occupy the lowest
+            // slot indices). When wave 2 adds let bindings, they
+            // continue from `params.len()`.
+            local: LocalId(i as u32),
+            name: name.clone(),
+            ty: format!("{ty:?}"),
+        })
+        .collect();
+    let effects = fd
+        .effects
+        .iter()
+        .map(|e| MirEffectAnnotation {
+            name: e.node.clone(),
+        })
+        .collect();
+    Some(MirFn {
+        fn_id: fd.fn_id,
+        name: fd.name.clone(),
+        params,
+        return_type: format!("{:?}", fd.return_type),
+        effects,
+        body,
+    })
+}
+
+/// Wave 1 expression lowering. Returns `None` for any construct
+/// outside the supported subset so `lower_fn` can drop the whole
+/// function rather than emit a half-lowered body.
+fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Option<Spanned<MirExpr>> {
+    let mir = match &expr.node {
+        ResolvedExpr::Literal(lit) => MirExpr::Literal(wrap(lit.clone(), expr)),
+        ResolvedExpr::Resolved { slot, .. } => {
+            MirExpr::Local(wrap(LocalId(u32::from(*slot)), expr))
+        }
+        ResolvedExpr::BinOp(op, lhs, rhs) => MirExpr::BinOp(wrap(
+            MirBinOp {
+                op: *op,
+                lhs: Box::new(lower_expr(lhs)?),
+                rhs: Box::new(lower_expr(rhs)?),
+            },
+            expr,
+        )),
+        ResolvedExpr::Neg(inner) => MirExpr::Neg(Box::new(lower_expr(inner)?)),
+        _ => return None,
+    };
+    Some(wrap(mir, expr))
+}
+
+/// Wrap a freshly-lowered node in `Spanned` while inheriting the
+/// source's line. The MIR type stamp starts uninitialised — Phase
+/// 6 optimizer passes may fill it later; consumers that need the
+/// HIR-side stamp can still read `expr.ty()` on the original.
+fn wrap<T, U>(node: T, source: &Spanned<U>) -> Spanned<T> {
+    Spanned {
+        node,
+        line: source.line,
+        ty: std::sync::OnceLock::new(),
+    }
+}

--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -75,6 +75,7 @@
 
 pub mod dump;
 pub mod expr;
+pub mod lower;
 pub mod program;
 
 pub use expr::{
@@ -82,4 +83,5 @@ pub use expr::{
     MirIndependentProduct, MirLet, MirMatch, MirMatchArm, MirPattern, MirProject, MirRecordCreate,
     MirRecordField, MirRecordUpdate, MirStrPart, MirTailCall, MirTryBind,
 };
+pub use lower::lower_program;
 pub use program::{LocalId, MirFn, MirParam, MirProgram};

--- a/tests/mir_phase3_wave1_lowering.rs
+++ b/tests/mir_phase3_wave1_lowering.rs
@@ -1,0 +1,82 @@
+//! Phase 3 wave 1 of #252 — HIR → MIR lowering for the leaf
+//! subset (literals, locals, binops, unary neg, single-stmt expr
+//! bodies). These tests drive `lower_program` end-to-end: source
+//! → parse → pipeline → `ResolvedTopLevel` → `lower_program` →
+//! `MirProgram`. Snapshot via `Display`.
+
+use aver::ir::mir::lower_program;
+use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
+use aver::source::parse_source;
+
+fn lower(source: &str) -> String {
+    let mut items = parse_source(source).unwrap_or_else(|e| panic!("parse: {e}"));
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    let tc = result.typecheck.as_ref().expect("typecheck requested");
+    assert!(tc.errors.is_empty(), "typecheck failed: {:?}", tc.errors);
+    let program = lower_program(&result.resolved_items);
+    format!("{program}")
+}
+
+#[test]
+fn lowers_int_literal_body() {
+    let dump = lower("fn answer() -> Int\n    42\n");
+    assert!(dump.contains("fn answer()"), "fn header missing:\n{dump}");
+    assert!(
+        dump.contains("Int(42)"),
+        "int literal didn't render:\n{dump}"
+    );
+}
+
+#[test]
+fn lowers_binop_over_locals() {
+    let dump = lower("fn double(x: Int) -> Int\n    x + x\n");
+    assert!(
+        dump.contains("fn double(%0x:"),
+        "param didn't render:\n{dump}"
+    );
+    assert!(
+        dump.contains("(%0 Add %0)"),
+        "BinOp(Add, Local, Local) didn't render:\n{dump}"
+    );
+}
+
+#[test]
+fn lowers_neg_over_int_literal() {
+    let dump = lower("fn negone() -> Int\n    -1\n");
+    assert!(
+        dump.contains("Int(-1)") || dump.contains("-(Int(1))"),
+        "Neg or signed literal expected:\n{dump}"
+    );
+}
+
+#[test]
+fn drops_unsupported_fn_silently() {
+    // List literal isn't covered by wave 1, so this fn shouldn't
+    // appear in `MirProgram.fns`. The lowerer must not panic; it
+    // just leaves the fn out and wave 2/3 will pick it up.
+    let dump = lower("fn three_items() -> List<Int>\n    [1, 2, 3]\n");
+    assert!(
+        !dump.contains("fn three_items"),
+        "unsupported fn shouldn't be lowered in wave 1:\n{dump}"
+    );
+}
+
+#[test]
+fn lowers_multi_fn_program_in_fn_id_order() {
+    let dump =
+        lower("fn one() -> Int\n    1\n\nfn two() -> Int\n    2\n\nfn three() -> Int\n    3\n");
+    let pos = |needle: &str| {
+        dump.find(needle)
+            .unwrap_or_else(|| panic!("missing {needle} in:\n{dump}"))
+    };
+    assert!(
+        pos("fn one") < pos("fn two") && pos("fn two") < pos("fn three"),
+        "fns out of FnId order:\n{dump}"
+    );
+}


### PR DESCRIPTION
## Summary
Phase 3 wave 1 of #252 — lowers `ResolvedProgramView` to `MirProgram` for the leaf subset.

**Wave 1 coverage**:
- `Literal` → `MirExpr::Literal`
- `Resolved { slot, .. }` → `MirExpr::Local`
- `BinOp` → `MirExpr::BinOp`
- `Neg` → `MirExpr::Neg`
- single-stmt `Stmt::Expr` body

**Out of scope** (later waves):
- Wave 2: user calls, builtin calls, constructors, records (create / update / project)
- Wave 3: `match`, `Try` / `TryBind`, tail calls, `IndependentProduct`, lists / tuples / maps / interpolation

**Drop, don't fail**: function bodies outside wave 1 are silently omitted from `MirProgram.fns`. The lowerer doesn't panic. A future "complete" test can compare lowered-fn count against total `ResolvedFnDef` count to track wave progress.

**LocalId mapping**: wave 1 uses the resolver's slot index directly as `LocalId`. Phase 2's RFC pin was "assign at MIR construction time" — that gives the future optimizer renumbering freedom, but during lowering we reuse the slot the resolver already assigned. Simplest correct choice.

`tests/mir_phase3_wave1_lowering.rs` drives `lower_program` end-to-end: source → parse → pipeline → `ResolvedTopLevel` → `lower_program` → `Display`. 5/5 covers literals, binops over locals, unary neg, the "drop unsupported fn" behavior, and `FnId`-ordered multi-fn output.

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --release --test mir_phase3_wave1_lowering` — 5/5
- [x] `cargo test --release --test proof_spec --test shape_module_patterns_spec --test mir_phase2_model_spec --test mir_phase2b_dump_spec` — 67/15/6/8
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)