### PR TITLE
ir/mir: HIR → MIR lowering, wave 2 (#252 Phase 3)

### DIFF
--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -1,35 +1,55 @@
-//! HIR → MIR lowering, wave 1.
+//! HIR → MIR lowering, waves 1 + 2.
 //!
 //! Phase 3 of #252 lowers `ResolvedProgramView` into `MirProgram`
-//! in widening waves so review surface stays small. **Wave 1 (this
-//! file)** covers the leaf subset that doesn't need a slot table,
-//! a callee resolver, or pattern matching:
+//! in widening waves so review surface stays small.
 //!
+//! **Wave 1** — leaf subset, no callee resolver, no patterns:
 //! - `ResolvedExpr::Literal` → `MirExpr::Literal`
 //! - `ResolvedExpr::Resolved { slot, .. }` → `MirExpr::Local`
 //! - `ResolvedExpr::BinOp` → `MirExpr::BinOp`
 //! - `ResolvedExpr::Neg` → `MirExpr::Neg`
-//! - single-stmt `Stmt::Expr` body
 //!
-//! Any function body that uses constructs outside this subset is
-//! skipped (not added to the resulting `MirProgram.fns`). Wave 2
-//! adds calls + constructors + records; wave 3 adds match, Try /
-//! TryBind, tail calls, and independent products. Every wave is a
-//! separate PR.
+//! **Wave 2 (added in this commit)** — call shapes + product types:
+//! - `ResolvedExpr::Call(Fn, args)` → `MirExpr::Call` w/ `MirCallee::Fn(FnId)`
+//! - `ResolvedExpr::Call(Builtin, args)` → `MirExpr::Call` w/ `MirCallee::Builtin(name)`
+//! - `ResolvedExpr::Ctor(User { ctor_id, .. }, args)` → `MirExpr::Construct`
+//! - `ResolvedExpr::RecordCreate { type_id: Some(_), … }` → `MirExpr::RecordCreate`
+//! - `ResolvedExpr::RecordUpdate { type_id: Some(_), … }` → `MirExpr::RecordUpdate`
+//! - `ResolvedExpr::Attr(base, field)` → `MirExpr::Project`
+//!
+//! Wave 3 adds match arms, `Try` / `TryBind`, tail calls,
+//! `IndependentProduct`, `Let` chains, and built-in constructors
+//! (`Result.Ok` / `Option.Some` / etc. — those need a typed
+//! identity story beyond raw `CtorId`).
+//!
+//! Bodies still must be single-stmt `Stmt::Expr` (multi-stmt
+//! bodies with `Let` bindings land in wave 3 alongside `match`).
+//! Functions that use anything outside the wave's supported subset
+//! are silently skipped — `MirProgram.fns` only contains what the
+//! waves so far knew how to handle.
 //!
 //! ## LocalId mapping
 //!
-//! Wave 1 uses the resolver's slot index (`ResolvedExpr::Resolved {
-//! slot, .. }`) directly as the `LocalId`. Phase 2's RFC pin was
-//! "assign at MIR construction time" — that means the optimizer
-//! can later renumber freely, but during lowering itself we use
-//! the slot the resolver already assigned. This is the simplest
-//! correct choice: the slot is already unique per function body.
+//! Wave 1+2 use the resolver's slot index
+//! (`ResolvedExpr::Resolved { slot, .. }`) directly as the
+//! `LocalId`. Phase 2's RFC pin was "assign at MIR construction
+//! time" — that gives the future optimizer freedom to renumber,
+//! but during lowering itself we use the slot the resolver
+//! already assigned. The slot is already unique per function
+//! body, so wave 1+2 don't need a fresh counter yet. Wave 3
+//! will introduce one when `Let` bindings start producing fresh
+//! locals that the resolver didn't see.
 
 use crate::ast::Spanned;
-use crate::ir::hir::{ResolvedExpr, ResolvedFnBody, ResolvedFnDef, ResolvedStmt, ResolvedTopLevel};
+use crate::ir::hir::{
+    ResolvedCallee, ResolvedCtor, ResolvedExpr, ResolvedFnBody, ResolvedFnDef, ResolvedStmt,
+    ResolvedTopLevel,
+};
 
-use super::expr::{MirBinOp, MirEffectAnnotation, MirExpr};
+use super::expr::{
+    MirBinOp, MirCall, MirCallee, MirConstruct, MirEffectAnnotation, MirExpr, MirProject,
+    MirRecordCreate, MirRecordField, MirRecordUpdate,
+};
 use super::program::{LocalId, MirFn, MirParam, MirProgram};
 
 /// Lower an entry-module resolved-item list into a `MirProgram`.
@@ -99,6 +119,7 @@ fn lower_fn(fd: &ResolvedFnDef) -> Option<MirFn> {
 /// function rather than emit a half-lowered body.
 fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Option<Spanned<MirExpr>> {
     let mir = match &expr.node {
+        // ── Wave 1 ──────────────────────────────────────────────
         ResolvedExpr::Literal(lit) => MirExpr::Literal(wrap(lit.clone(), expr)),
         ResolvedExpr::Resolved { slot, .. } => {
             MirExpr::Local(wrap(LocalId(u32::from(*slot)), expr))
@@ -112,6 +133,110 @@ fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Option<Spanned<MirExpr>> {
             expr,
         )),
         ResolvedExpr::Neg(inner) => MirExpr::Neg(Box::new(lower_expr(inner)?)),
+
+        // ── Wave 2 ──────────────────────────────────────────────
+        ResolvedExpr::Call(callee, args) => {
+            let mir_callee = match callee {
+                ResolvedCallee::Fn(fn_id) => MirCallee::Fn(*fn_id),
+                ResolvedCallee::Builtin(name) => MirCallee::Builtin(name.clone()),
+                // First-class fn values, intrinsics, and unresolved
+                // callees aren't covered by wave 2. Wave 3+ will
+                // grow `MirCallee` (or a separate node) for the
+                // first-class-fn case once `Let` / closure shapes
+                // need it. Intrinsics arrive only after lowering
+                // passes the lowerer doesn't currently traverse.
+                ResolvedCallee::Intrinsic(_)
+                | ResolvedCallee::LocalSlot { .. }
+                | ResolvedCallee::Unresolved { .. } => return None,
+            };
+            let mir_args: Option<Vec<_>> = args.iter().map(lower_expr).collect();
+            MirExpr::Call(wrap(
+                MirCall {
+                    callee: mir_callee,
+                    args: mir_args?,
+                },
+                expr,
+            ))
+        }
+        ResolvedExpr::Ctor(ResolvedCtor::User { ctor_id, .. }, args) => {
+            let mir_args: Option<Vec<_>> = args.iter().map(lower_expr).collect();
+            MirExpr::Construct(wrap(
+                MirConstruct {
+                    ctor: *ctor_id,
+                    args: mir_args?,
+                },
+                expr,
+            ))
+        }
+        // Built-in ctors (`Result.Ok` / `Option.Some` / etc.)
+        // don't carry user-program `CtorId`s. Wave 3 will introduce
+        // a typed identity for them — until then, fns that touch
+        // them get dropped from the MIR output.
+        ResolvedExpr::Ctor(ResolvedCtor::Builtin(_) | ResolvedCtor::Unresolved { .. }, _) => {
+            return None;
+        }
+        ResolvedExpr::RecordCreate {
+            type_id: Some(type_id),
+            fields,
+            ..
+        } => {
+            let mir_fields: Option<Vec<_>> = fields
+                .iter()
+                .map(|(name, value)| {
+                    Some(MirRecordField {
+                        name: name.clone(),
+                        value: lower_expr(value)?,
+                    })
+                })
+                .collect();
+            MirExpr::RecordCreate(wrap(
+                MirRecordCreate {
+                    type_id: *type_id,
+                    fields: mir_fields?,
+                },
+                expr,
+            ))
+        }
+        ResolvedExpr::RecordUpdate {
+            type_id: Some(type_id),
+            base,
+            updates,
+            ..
+        } => {
+            let mir_updates: Option<Vec<_>> = updates
+                .iter()
+                .map(|(name, value)| {
+                    Some(MirRecordField {
+                        name: name.clone(),
+                        value: lower_expr(value)?,
+                    })
+                })
+                .collect();
+            MirExpr::RecordUpdate(wrap(
+                MirRecordUpdate {
+                    base: Box::new(lower_expr(base)?),
+                    type_id: *type_id,
+                    updates: mir_updates?,
+                },
+                expr,
+            ))
+        }
+        // Records on built-in types (`HttpResponse`, `Header`,
+        // `Buffer`, …) carry no `TypeId`. Wave 2 skips them; a
+        // later phase will widen `MirRecordCreate` / `MirRecordUpdate`
+        // to carry an optional source-type-name when the consumer
+        // demands it (none does today).
+        ResolvedExpr::RecordCreate { type_id: None, .. }
+        | ResolvedExpr::RecordUpdate { type_id: None, .. } => return None,
+        ResolvedExpr::Attr(base, field) => MirExpr::Project(wrap(
+            MirProject {
+                base: Box::new(lower_expr(base)?),
+                field: field.clone(),
+            },
+            expr,
+        )),
+
+        // ── Wave 3+ ─────────────────────────────────────────────
         _ => return None,
     };
     Some(wrap(mir, expr))

--- a/tests/mir_phase3_wave2_lowering.rs
+++ b/tests/mir_phase3_wave2_lowering.rs
@@ -1,0 +1,119 @@
+//! Phase 3 wave 2 of #252 — HIR → MIR lowering for call shapes
+//! and product types: user calls, builtin calls, user constructors,
+//! record create / update / project.
+//!
+//! Same `parse → pipeline → lower → Display` rig as wave 1. New
+//! coverage:
+//! - `Fn(FnId).call(...)` — user fn invocation, identity-typed
+//! - `Builtin(...).call(...)` — built-in namespace methods
+//! - `CtorId(N)(...)` — user variant constructors
+//! - `TypeId(N) { … }` — record create
+//! - `TypeId(N).update(...)` — record update
+//! - `base.field` — projection
+//!
+//! Wave 2 still requires single-stmt expr bodies (multi-stmt with
+//! `Let` lands in wave 3 alongside `match` / `Try`). Built-in
+//! constructors (`Result.Ok`, `Option.Some`, …) and record types
+//! with no `TypeId` (`HttpResponse`, `Header`, …) are also wave 3.
+
+use aver::ir::mir::lower_program;
+use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
+use aver::source::parse_source;
+
+fn lower(source: &str) -> String {
+    let mut items = parse_source(source).unwrap_or_else(|e| panic!("parse: {e}"));
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    let tc = result.typecheck.as_ref().expect("typecheck requested");
+    assert!(tc.errors.is_empty(), "typecheck failed: {:?}", tc.errors);
+    let program = lower_program(&result.resolved_items);
+    format!("{program}")
+}
+
+#[test]
+fn lowers_user_fn_call_with_typed_callee() {
+    let dump = lower(
+        "fn double(x: Int) -> Int\n    x + x\n\n\
+         fn use_double() -> Int\n    double(7)\n",
+    );
+    // The `use_double` body is `double(7)`. The dump should carry
+    // the typed callee identity, not a string name.
+    assert!(
+        dump.contains("FnId(") && dump.contains(").call(Int(7))"),
+        "expected typed `FnId(N).call(Int(7))` in dump:\n{dump}"
+    );
+}
+
+#[test]
+fn lowers_builtin_call() {
+    // `String.len(s)` is a built-in namespace method.
+    let dump = lower("fn length_of(s: String) -> Int\n    String.len(s)\n");
+    assert!(
+        dump.contains("Builtin(String.len).call(%0)"),
+        "expected built-in callee + local arg:\n{dump}"
+    );
+}
+
+#[test]
+fn lowers_user_ctor_to_construct_with_ctor_id() {
+    // `record Shape { name: String }` then `Shape.create(\"x\")` —
+    // hmm, records don't take ctor args like sum types. Use a sum
+    // type instead so we exercise the `Ctor` path.
+    let dump = lower(
+        "type Color\n  Red\n  Green(Int)\n\n\
+         fn make() -> Color\n    Color.Green(42)\n",
+    );
+    // User constructors carry `CtorId(N)` in the dump; the source
+    // name (\"Green\") is the source-level diagnostic field on
+    // `ResolvedCtor` but doesn't ride into MIR — identity-only.
+    assert!(
+        dump.contains("CtorId(") && dump.contains(")(Int(42))"),
+        "expected CtorId-typed construct with Int(42) arg:\n{dump}"
+    );
+}
+
+#[test]
+fn lowers_record_create_and_project() {
+    let dump = lower(
+        "record Point\n  x: Int\n  y: Int\n\n\
+         fn origin() -> Point\n    Point(x = 0, y = 0)\n\n\
+         fn x_of(p: Point) -> Int\n    p.x\n",
+    );
+    assert!(
+        dump.contains("TypeId(") && dump.contains("{ x = Int(0), y = Int(0) }"),
+        "expected TypeId-typed record-create with field list:\n{dump}"
+    );
+    assert!(
+        dump.contains("%0.x"),
+        "expected `%0.x` projection in x_of dump:\n{dump}"
+    );
+}
+
+#[test]
+fn lowers_record_update() {
+    let dump = lower(
+        "record Point\n  x: Int\n  y: Int\n\n\
+         fn shift_x(p: Point) -> Point\n    Point.update(p, x = 99)\n",
+    );
+    assert!(
+        dump.contains(".update(%0, x = Int(99))"),
+        "expected record-update with base local + override:\n{dump}"
+    );
+}
+
+#[test]
+fn builtin_ctor_fn_is_silently_dropped() {
+    // `Result.Ok(_)` is a built-in constructor — wave 2 leaves it
+    // for wave 3 (needs typed builtin identity). The lowerer must
+    // not panic; the fn just doesn't show up in the dump.
+    let dump = lower("fn ok_seven() -> Result<Int, String>\n    Result.Ok(7)\n");
+    assert!(
+        !dump.contains("fn ok_seven"),
+        "built-in ctor fn shouldn't be lowered in wave 2:\n{dump}"
+    );
+}


### PR DESCRIPTION
## Summary
Phase 3 wave 2 of #252 — widens `lower_program` to cover call shapes + product types.

**Wave 2 coverage**:
- `Fn(FnId).call(...)` — user fn, identity-typed callee
- `Builtin(...).call(...)` — built-in namespace methods (`String.len`, `Console.print`, …)
- `CtorId(N)(...)` — user variant constructors
- `TypeId(N) { … }` — record create
- `TypeId(N).update(...)` — record update
- `base.field` — projection

**Still wave 3 territory**:
- match arms / patterns
- `Try` / `TryBind` (the `?` operator)
- tail calls, independent products, lists / tuples / maps / interpolation
- `Let` bindings / multi-stmt bodies
- built-in constructors (`Result.Ok`, `Option.Some`, …)
- records on built-in types (`HttpResponse`, `Header`, …)

Anything outside wave 1+2 still drops the fn silently — no panic.

**Tests** (`tests/mir_phase3_wave2_lowering.rs`, 6/6): user fn call w/ FnId, built-in call, user ctor w/ CtorId, record create + project, record update, silent-skip for `Result.Ok`.

## Test plan
- [x] `cargo build --bin aver --features wasm` — clean
- [x] `cargo test --release --test mir_phase3_wave2_lowering` — 6/6
- [x] All other suites green: proof_spec 67, shape 15, mir_phase2 6, mir_phase2b 8, mir_phase3_wave1 5
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)