### PR TITLE
ir/mir: HIR → MIR lowering, wave 3b — structured `match` + patterns (#252 Phase 3)

### DIFF
--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -1,4 +1,4 @@
-//! HIR → MIR lowering, waves 1 + 2.
+//! HIR → MIR lowering, waves 1 + 2 + 3a + 3b.
 //!
 //! Phase 3 of #252 lowers `ResolvedProgramView` into `MirProgram`
 //! in widening waves so review surface stays small.
@@ -25,13 +25,26 @@
 //!   intermediate `Stmt::Expr` gets a fresh synthetic `LocalId`
 //!   drawn from a counter starting at `local_count`.
 //!
-//! Wave 3b lands `match` arms + patterns; wave 3c lands `Try`,
-//! tail calls, `IndependentProduct`, lists / tuples / maps /
-//! interpolation, and built-in constructors (`Result.Ok` /
-//! `Option.Some` — those need a typed identity story beyond raw
-//! `CtorId`). The bind-and-propagate shape `let x = step()?; body`
-//! lowers as `Let { binding, value: Try(step()), body }` — no
-//! dedicated `TryBind` variant (dropped during wave 3 prep).
+//! **Wave 3b (this commit)** — structured `match` + patterns:
+//! - `ResolvedExpr::Match { subject, arms }` → `MirExpr::Match`.
+//! - User-ctor patterns (`ResolvedCtor::User { ctor_id, .. }`)
+//!   lower to `MirPattern::Ctor { ctor: CtorId, bindings }`.
+//! - Cons / Tuple / Ident / Literal / Wildcard / EmptyList lower
+//!   structurally. Pattern bindings draw their `LocalId`s from
+//!   `ResolvedMatchArm.binding_slots` (preorder-flat, same shape
+//!   `ast_rewrite::pattern_binding_names` walks).
+//! - Built-in constructor patterns (`Result.Ok`, `Option.Some`,
+//!   …) stay wave 3c territory — fns matching on them are
+//!   silently skipped, same skip-rule that wave 2 applied to
+//!   built-in ctor *constructions*.
+//!
+//! Wave 3c lands `Try`, tail calls, `IndependentProduct`,
+//! lists / tuples / maps / interpolation, and built-in constructors
+//! (`Result.Ok` / `Option.Some` — those need a typed identity
+//! story beyond raw `CtorId`). The bind-and-propagate shape
+//! `let x = step()?; body` lowers as
+//! `Let { binding, value: Try(step()), body }` — no dedicated
+//! `TryBind` variant (dropped during wave 3 prep).
 //!
 //! Functions that use anything outside the waves' supported
 //! subset are silently skipped — `MirProgram.fns` only contains
@@ -51,13 +64,13 @@
 
 use crate::ast::{FnResolution, Spanned};
 use crate::ir::hir::{
-    ResolvedCallee, ResolvedCtor, ResolvedExpr, ResolvedFnBody, ResolvedFnDef, ResolvedStmt,
-    ResolvedTopLevel,
+    ResolvedCallee, ResolvedCtor, ResolvedExpr, ResolvedFnBody, ResolvedFnDef, ResolvedMatchArm,
+    ResolvedPattern, ResolvedStmt, ResolvedTopLevel,
 };
 
 use super::expr::{
-    MirBinOp, MirCall, MirCallee, MirConstruct, MirEffectAnnotation, MirExpr, MirLet, MirProject,
-    MirRecordCreate, MirRecordField, MirRecordUpdate,
+    MirBinOp, MirCall, MirCallee, MirConstruct, MirEffectAnnotation, MirExpr, MirLet, MirMatch,
+    MirMatchArm, MirPattern, MirProject, MirRecordCreate, MirRecordField, MirRecordUpdate,
 };
 use super::program::{LocalId, MirFn, MirParam, MirProgram};
 
@@ -260,10 +273,100 @@ fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Option<Spanned<MirExpr>> {
             expr,
         )),
 
-        // ── Wave 3+ ─────────────────────────────────────────────
+        // ── Wave 3b ─────────────────────────────────────────────
+        ResolvedExpr::Match { subject, arms } => {
+            let mir_subject = lower_expr(subject)?;
+            let mir_arms: Option<Vec<_>> = arms.iter().map(lower_arm).collect();
+            MirExpr::Match(wrap(
+                MirMatch {
+                    subject: Box::new(mir_subject),
+                    arms: mir_arms?,
+                },
+                expr,
+            ))
+        }
+
+        // ── Wave 3c+ ────────────────────────────────────────────
         _ => return None,
     };
     Some(wrap(mir, expr))
+}
+
+/// Wave 3b — lower one resolved match arm. Pattern bindings draw
+/// their `LocalId`s from `arm.binding_slots`, which the resolver
+/// fills in preorder of the bindings as they appear in the
+/// pattern (same walk as `ast_rewrite::pattern_binding_names`).
+/// An arm with no resolved slots or with a built-in / unresolved
+/// ctor pattern returns `None`, causing the whole fn to be
+/// dropped from MIR.
+fn lower_arm(arm: &ResolvedMatchArm) -> Option<MirMatchArm> {
+    let slots: &[u16] = arm.binding_slots.get().map(Vec::as_slice).unwrap_or(&[]);
+    let mut cursor = 0usize;
+    let pattern = lower_pattern(&arm.pattern, slots, &mut cursor)?;
+    if cursor != slots.len() {
+        // Slot count mismatch — defensive guard against future
+        // pattern shapes the lowerer doesn't yet understand.
+        return None;
+    }
+    let body = lower_expr(&arm.body)?;
+    Some(MirMatchArm { pattern, body })
+}
+
+/// Wave 3b — lower a `ResolvedPattern` while consuming binding
+/// slots from `slots[*cursor..]` in preorder. Returns `None` on
+/// any unsupported pattern shape (built-in / unresolved ctor) so
+/// the caller can drop the whole fn cleanly.
+fn lower_pattern(
+    pattern: &ResolvedPattern,
+    slots: &[u16],
+    cursor: &mut usize,
+) -> Option<MirPattern> {
+    Some(match pattern {
+        ResolvedPattern::Wildcard => MirPattern::Wildcard,
+        ResolvedPattern::Literal(lit) => MirPattern::Literal(lit.clone()),
+        ResolvedPattern::Ident(_) => {
+            let slot = take_slot(slots, cursor)?;
+            MirPattern::Bind(LocalId(u32::from(slot)))
+        }
+        ResolvedPattern::EmptyList => MirPattern::EmptyList,
+        ResolvedPattern::Cons(_, _) => {
+            let head = take_slot(slots, cursor)?;
+            let tail = take_slot(slots, cursor)?;
+            MirPattern::Cons {
+                head: LocalId(u32::from(head)),
+                tail: LocalId(u32::from(tail)),
+            }
+        }
+        ResolvedPattern::Tuple(items) => {
+            let mir_items: Option<Vec<_>> = items
+                .iter()
+                .map(|p| lower_pattern(p, slots, cursor))
+                .collect();
+            MirPattern::Tuple(mir_items?)
+        }
+        ResolvedPattern::Ctor(ResolvedCtor::User { ctor_id, .. }, names) => {
+            let mut bindings = Vec::with_capacity(names.len());
+            for _ in names {
+                let slot = take_slot(slots, cursor)?;
+                bindings.push(LocalId(u32::from(slot)));
+            }
+            MirPattern::Ctor {
+                ctor: *ctor_id,
+                bindings,
+            }
+        }
+        // Built-in / unresolved ctor patterns wait for wave 3c —
+        // same skip rule as wave 2's built-in ctor *constructions*.
+        ResolvedPattern::Ctor(ResolvedCtor::Builtin(_) | ResolvedCtor::Unresolved { .. }, _) => {
+            return None;
+        }
+    })
+}
+
+fn take_slot(slots: &[u16], cursor: &mut usize) -> Option<u16> {
+    let slot = *slots.get(*cursor)?;
+    *cursor += 1;
+    Some(slot)
 }
 
 /// Wrap a freshly-lowered node in `Spanned` while inheriting the

--- a/tests/mir_phase3_wave3b_match_lowering.rs
+++ b/tests/mir_phase3_wave3b_match_lowering.rs
@@ -1,0 +1,148 @@
+//! Phase 3 wave 3b of #252 — `match` arms + `MirPattern`
+//! lowering. End-to-end: parse → pipeline → lower → dump.
+//!
+//! Pattern bindings draw their `LocalId`s from the resolver's
+//! `ResolvedMatchArm.binding_slots`, which fills in preorder of
+//! the bindings as they appear in the pattern (same walk as
+//! `ast_rewrite::pattern_binding_names`). Built-in / unresolved
+//! ctor patterns stay wave 3c territory — fns matching on them
+//! get silently skipped.
+
+use aver::ir::mir::lower_program;
+use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
+use aver::source::parse_source;
+
+fn lower(source: &str) -> String {
+    let mut items = parse_source(source).unwrap_or_else(|e| panic!("parse: {e}"));
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    let tc = result.typecheck.as_ref().expect("typecheck requested");
+    assert!(tc.errors.is_empty(), "typecheck failed: {:?}", tc.errors);
+    let program = lower_program(&result.resolved_items);
+    format!("{program}")
+}
+
+#[test]
+fn list_match_head_or_zero_lowers_through_to_dump() {
+    // The canonical wave-3b shape from the RFC:
+    //   fn first(xs: List<Int>) -> Int
+    //     match xs
+    //       [] -> 0
+    //       [h, ..t] -> h
+    let dump = lower(
+        "fn first(xs: List<Int>) -> Int\n    match xs\n        [] -> 0\n        [h, ..t] -> h\n",
+    );
+    assert!(dump.contains("fn first"), "fn header missing:\n{dump}");
+    assert!(
+        dump.contains("match %0"),
+        "match subject didn't render against the param slot:\n{dump}"
+    );
+    assert!(
+        dump.contains("[] => Int(0)"),
+        "EmptyList arm didn't render:\n{dump}"
+    );
+    // `[h, ..t] => h` — the cons head LocalId reappears in the body.
+    // Slot numbering: xs=%0, h=%1, t=%2 (resolver order).
+    assert!(
+        dump.contains("[%1, ..%2] =>"),
+        "Cons pattern didn't render with the right slots:\n{dump}"
+    );
+    assert!(
+        dump.contains("[%1, ..%2] => %1"),
+        "Cons arm body didn't reference the head binding:\n{dump}"
+    );
+}
+
+#[test]
+fn wildcard_and_literal_arms_render_structurally() {
+    // fn classify(n: Int) -> Int
+    //   match n
+    //     0 -> 100
+    //     _ -> 200
+    let dump =
+        lower("fn classify(n: Int) -> Int\n    match n\n        0 -> 100\n        _ -> 200\n");
+    assert!(
+        dump.contains("Int(0) =>"),
+        "literal arm didn't render:\n{dump}"
+    );
+    assert!(dump.contains("_ =>"), "wildcard arm didn't render:\n{dump}");
+}
+
+#[test]
+fn ident_pattern_binds_to_slot() {
+    // fn pick(n: Int) -> Int
+    //   match n
+    //     x -> x
+    //
+    // Ident patternu LocalId pochodzi z resolver-assigned slot
+    // (preorder), nie z param slot — different from the subject.
+    let dump = lower("fn pick(n: Int) -> Int\n    match n\n        x -> x\n");
+    // `x =>` form — Bind(LocalId) renders as `%N`, and the body
+    // references that same `%N`.
+    assert!(
+        dump.contains("match %0"),
+        "match subject (param n=%0) missing:\n{dump}"
+    );
+    // The bound local for `x` is slot 1 (n is slot 0, x is the
+    // next slot the resolver assigns inside the arm scope).
+    assert!(
+        dump.contains("%1 => %1"),
+        "Ident pattern bind didn't pin to slot %1:\n{dump}"
+    );
+}
+
+#[test]
+fn user_ctor_pattern_lowers_through_ctor_id() {
+    // type Shape :- Circle(Int) | Square(Int)
+    //
+    // fn area(s: Shape) -> Int
+    //   match s
+    //     Shape.Circle(r) -> r
+    //     Shape.Square(side) -> side
+    //
+    // Both arms ride `MirPattern::Ctor { ctor: CtorId(_), bindings }`.
+    // Dump renders `CtorId(N)(%M) =>` per the wave-3b contract.
+    let dump = lower(
+        "type Shape\n  Circle(Int)\n  Square(Int)\n\nfn area(s: Shape) -> Int\n    match s\n        Shape.Circle(r) -> r\n        Shape.Square(side) -> side\n",
+    );
+    assert!(dump.contains("fn area"), "area fn missing:\n{dump}");
+    assert!(
+        dump.contains("CtorId("),
+        "user ctor pattern didn't render typed identity:\n{dump}"
+    );
+    // Two arms → two CtorId pattern lines, each with one bound slot.
+    let ctor_arm_count = dump.matches("CtorId(").count();
+    assert!(
+        ctor_arm_count >= 2,
+        "expected ≥2 CtorId-pattern arms, got {ctor_arm_count}:\n{dump}"
+    );
+}
+
+#[test]
+fn builtin_ctor_pattern_drops_the_fn() {
+    // `match Result.Ok(...) { Result.Ok(v) -> v; Result.Err(_) -> 0 }`
+    // — the ctor patterns reference `Result.Ok` / `Result.Err`,
+    // which are *built-in* ctors. Wave 3b drops the whole fn from
+    // MIR so wave 3c can later land typed identity for built-in
+    // result/option shapes.
+    //
+    // We pair the dropped fn with a wave-2 fn so the dump still
+    // has something to render — the assertion is that
+    // `drops_me` is absent.
+    let dump = lower(
+        "fn keep(x: Int) -> Int\n    x + 1\n\nfn drops_me(r: Result<Int, String>) -> Int\n    match r\n        Result.Ok(v) -> v\n        Result.Err(_) -> 0\n",
+    );
+    assert!(
+        dump.contains("fn keep"),
+        "wave-2 fn should still lower:\n{dump}"
+    );
+    assert!(
+        !dump.contains("fn drops_me"),
+        "fn matching on built-in Result ctors must be dropped until wave 3c:\n{dump}"
+    );
+}


### PR DESCRIPTION
## Summary

Wave 3b of #252 Phase 3 — lowers `ResolvedExpr::Match { subject, arms }` to `MirExpr::Match`. Pattern coverage:

- `Wildcard` → `MirPattern::Wildcard`
- `Literal(lit)` → `MirPattern::Literal(lit)`
- `Ident(_)` → `MirPattern::Bind(LocalId)`
- `EmptyList` → `MirPattern::EmptyList`
- `Cons(_, _)` → `MirPattern::Cons { head, tail }`
- `Tuple(items)` → `MirPattern::Tuple(items)` (recursively)
- `Ctor(User { ctor_id, .. }, names)` → `MirPattern::Ctor { ctor: CtorId, bindings }`

Pattern bindings draw their `LocalId`s from `ResolvedMatchArm.binding_slots` via a preorder cursor (same walk `ast_rewrite::pattern_binding_names` uses, same slots the resolver fills in `resolver.rs:264`).

Built-in / unresolved ctor patterns (`Result.Ok`, `Option.Some`, …) return `None` and drop the whole fn — mirroring wave 2's skip-rule for built-in ctor *constructions*. Wave 3c lands typed identity for built-in ctors alongside `Try`, tail calls, `IndependentProduct`, lists/tuples/maps/interp.

## Test plan
- [x] `cargo build` clean
- [x] `cargo fmt`
- [x] `cargo clippy --tests` clean on new code
- [x] `tests/mir_phase3_wave3b_match_lowering.rs` 5/5 ✅
  - canonical `match xs { [] => 0; [h, ..t] => h }`
  - wildcard + literal arms
  - ident pattern slot
  - user ctor pattern (`Shape.Circle(r)` / `Shape.Square(side)`) → `CtorId(_)(%M) =>`
  - built-in `Result.Ok` patterns → fn dropped, peer wave-2 fn pozostaje

🤖 Generated with [Claude Code](https://claude.com/claude-code)