### PR TITLE
ir/mir: coverage gate — LowerStats + SkipReason for Phase 4 readiness (#252 Phase 3)

### DIFF
--- a/src/ir/mir/RFC.md
+++ b/src/ir/mir/RFC.md
@@ -141,11 +141,32 @@ Each `MirExpr` carries a `Span` for diagnostics + future correlation with `Proof
 
 One PR per wave so review surface stays bounded:
 
-1. literals + locals + binops + `return` + `Project`
-2. user calls + builtin calls + constructors + record create / update
-3. `match` (structured), `Try`, `TailCall`, `IndependentProduct`
+1. literals + locals + binops + `Neg` (wave 1)
+2. user calls + builtin calls + user ctors + record create / update + `Project` (wave 2)
+3. wave 3, sub-waves:
+   - 3a — multi-stmt `Let` chains
+   - 3b — structured `match` arms + user-ctor patterns
+   - **coverage gate** (this PR) — `LowerStats { lowered, skipped: HashMap<SkipReason, _> }` riding on `MirProgram`; every dropped fn attributed to a single dominant reason; tests pin conservation + attribution
+   - 3c-i — built-in ctor identity (`Result.Ok` / `Option.Some` construction + pattern). Must land *before* `Try` because well-typed Aver fns using `?` always also construct a `Result.Ok` in the same body (early-return + happy-path), so the `Try` lowering only becomes exerciseable once built-in ctors stop dropping the fn
+   - 3c-ii — `Try` (`?` propagation)
+   - 3c-iii — tail calls + first-class fn callees
+   - 3c-iv — list / tuple / map / interpolated-string literals
+   - 3c-v — `IndependentProduct`
 
-Each wave: dump snapshot for a representative example, no behavioral change for any backend yet.
+Each wave: dump snapshot for a representative example, no behavioral change for any backend yet. After each wave, `LowerStats.skipped` should lose the reason(s) the wave covers.
+
+### Phase 3 → 4 coverage gate
+
+Phase 4 (VM slice) can only consume MIR honestly if MIR actually covers the corpus. The lowerer's "silent skip on unsupported shape" is fine *during* widening waves, but invisible without telemetry — `dump` renders, tests pass on the supported subset, and 60% of the corpus can disappear silently.
+
+`MirProgram.stats: LowerStats` is the gate:
+
+- `lowered` — fns successfully in `MirProgram.fns`.
+- `skipped: HashMap<SkipReason, u32>` — one bump per dropped fn, keyed by the first unsupported shape the lowerer hit.
+- `total() == lowered + skipped.values().sum()` — conservation invariant.
+- `coverage_ratio()` — for corpus-wide floor assertions.
+
+Phase 4's entry gate adds `coverage_ratio() ≥ X` on the shipped examples (`examples/core/`, `examples/data/`, `examples/games/`) with X rising as 3c sub-waves land. Phase 4 can't ship while `skipped` still contains a wave-3c reason that the VM slice would route through MIR.
 
 ### Phase 4 — VM vertical slice
 

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -47,8 +47,13 @@
 //! `TryBind` variant (dropped during wave 3 prep).
 //!
 //! Functions that use anything outside the waves' supported
-//! subset are silently skipped — `MirProgram.fns` only contains
-//! what the waves so far knew how to handle.
+//! subset are dropped — `MirProgram.fns` only contains what the
+//! waves so far knew how to handle. Every drop bumps a counter
+//! on `MirProgram.stats.skipped` keyed by the first
+//! [`SkipReason`](crate::ir::mir::SkipReason) the lowerer hit
+//! inside the fn. Phase 4's coverage gate consumes that to
+//! prove the lowered subset covers the corpus before the VM
+//! slice migrates.
 //!
 //! ## LocalId mapping
 //!
@@ -73,39 +78,49 @@ use super::expr::{
     MirMatchArm, MirPattern, MirProject, MirRecordCreate, MirRecordField, MirRecordUpdate,
 };
 use super::program::{LocalId, MirFn, MirParam, MirProgram};
+use super::stats::SkipReason;
 
 /// Lower an entry-module resolved-item list into a `MirProgram`.
-/// Function bodies outside wave 1's supported subset are silently
-/// skipped — `MirProgram.fns` only contains what this wave knew
-/// how to handle. Wave 2 and 3 will widen the coverage; a future
-/// "complete" assertion test can compare `lowered_fn_count` against
-/// the total `ResolvedFnDef` count to track progress.
+/// Function bodies outside the supported subset are dropped —
+/// `MirProgram.fns` only contains what the lowerer's waves so far
+/// knew how to handle. Every drop bumps a counter on
+/// `MirProgram.stats.skipped` keyed by the first `SkipReason` the
+/// lowerer hit inside the fn, so Phase 4's coverage gate can prove
+/// that the lowered subset actually covers the corpus.
 pub fn lower_program(items: &[ResolvedTopLevel]) -> MirProgram {
     let mut program = MirProgram::empty();
     for item in items {
-        if let ResolvedTopLevel::FnDef(fd) = item
-            && let Some(mir_fn) = lower_fn(fd)
-        {
-            program.fns.insert(fd.fn_id, mir_fn);
+        let ResolvedTopLevel::FnDef(fd) = item else {
+            continue;
+        };
+        match lower_fn(fd) {
+            Ok(mir_fn) => {
+                program.fns.insert(fd.fn_id, mir_fn);
+                program.stats.record_lowered();
+            }
+            Err(reason) => {
+                program.stats.record_skip(reason);
+            }
         }
     }
     program
 }
 
-/// Lower one `ResolvedFnDef` if its body fits wave 1. Returns
-/// `None` for everything else; the caller drops the fn from the
-/// MIR program in that case.
-fn lower_fn(fd: &ResolvedFnDef) -> Option<MirFn> {
+/// Lower one `ResolvedFnDef` if its body fits the supported subset.
+/// Returns `Err(SkipReason)` for the dominant unsupported shape —
+/// the caller drops the fn from the MIR program and records the
+/// reason in `LowerStats.skipped`.
+fn lower_fn(fd: &ResolvedFnDef) -> Result<MirFn, SkipReason> {
     let ResolvedFnBody::Block(stmts) = &*fd.body;
     if stmts.is_empty() {
-        return None;
+        return Err(SkipReason::EmptyBody);
     }
     let body = match stmts.len() {
         1 => {
             // Single-stmt body: must be `Expr`. Bindings alone
             // can't produce a value.
             let ResolvedStmt::Expr(expr) = &stmts[0] else {
-                return None;
+                return Err(SkipReason::BindingOnlyTail);
             };
             lower_expr(expr)?
         }
@@ -114,7 +129,10 @@ fn lower_fn(fd: &ResolvedFnDef) -> Option<MirFn> {
             // chains. Last stmt must be `Expr` — it's the body's
             // final value; everything before it gets opaque-let'd
             // so effectful intermediate calls survive into MIR.
-            let resolution = fd.resolution.as_ref()?;
+            let resolution = fd
+                .resolution
+                .as_ref()
+                .ok_or(SkipReason::MissingResolution)?;
             let mut next_synthetic_local = u32::from(resolution.local_count);
             lower_stmt_chain(stmts, resolution, &mut next_synthetic_local)?
         }
@@ -141,7 +159,7 @@ fn lower_fn(fd: &ResolvedFnDef) -> Option<MirFn> {
             name: e.node.clone(),
         })
         .collect();
-    Some(MirFn {
+    Ok(MirFn {
         fn_id: fd.fn_id,
         name: fd.name.clone(),
         params,
@@ -151,10 +169,10 @@ fn lower_fn(fd: &ResolvedFnDef) -> Option<MirFn> {
     })
 }
 
-/// Wave 1 expression lowering. Returns `None` for any construct
-/// outside the supported subset so `lower_fn` can drop the whole
-/// function rather than emit a half-lowered body.
-fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Option<Spanned<MirExpr>> {
+/// Expression lowering. Returns `Err(SkipReason)` for any
+/// construct outside the supported subset so `lower_fn` can drop
+/// the whole function and record the dominant reason.
+fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Result<Spanned<MirExpr>, SkipReason> {
     let mir = match &expr.node {
         // ── Wave 1 ──────────────────────────────────────────────
         ResolvedExpr::Literal(lit) => MirExpr::Literal(wrap(lit.clone(), expr)),
@@ -177,59 +195,60 @@ fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Option<Spanned<MirExpr>> {
                 ResolvedCallee::Fn(fn_id) => MirCallee::Fn(*fn_id),
                 ResolvedCallee::Builtin(name) => MirCallee::Builtin(name.clone()),
                 // First-class fn values, intrinsics, and unresolved
-                // callees aren't covered by wave 2. Wave 3+ will
-                // grow `MirCallee` (or a separate node) for the
-                // first-class-fn case once `Let` / closure shapes
-                // need it. Intrinsics arrive only after lowering
-                // passes the lowerer doesn't currently traverse.
+                // callees aren't covered yet. Wave 3+ will grow
+                // `MirCallee` (or a separate node) for the
+                // first-class-fn case once closure shapes need it.
                 ResolvedCallee::Intrinsic(_)
                 | ResolvedCallee::LocalSlot { .. }
-                | ResolvedCallee::Unresolved { .. } => return None,
+                | ResolvedCallee::Unresolved { .. } => return Err(SkipReason::UnsupportedCallee),
             };
-            let mir_args: Option<Vec<_>> = args.iter().map(lower_expr).collect();
+            let mir_args = args.iter().map(lower_expr).collect::<Result<Vec<_>, _>>()?;
             MirExpr::Call(wrap(
                 MirCall {
                     callee: mir_callee,
-                    args: mir_args?,
+                    args: mir_args,
                 },
                 expr,
             ))
         }
         ResolvedExpr::Ctor(ResolvedCtor::User { ctor_id, .. }, args) => {
-            let mir_args: Option<Vec<_>> = args.iter().map(lower_expr).collect();
+            let mir_args = args.iter().map(lower_expr).collect::<Result<Vec<_>, _>>()?;
             MirExpr::Construct(wrap(
                 MirConstruct {
                     ctor: *ctor_id,
-                    args: mir_args?,
+                    args: mir_args,
                 },
                 expr,
             ))
         }
-        // Built-in ctors (`Result.Ok` / `Option.Some` / etc.)
-        // don't carry user-program `CtorId`s. Wave 3 will introduce
-        // a typed identity for them — until then, fns that touch
-        // them get dropped from the MIR output.
-        ResolvedExpr::Ctor(ResolvedCtor::Builtin(_) | ResolvedCtor::Unresolved { .. }, _) => {
-            return None;
+        // Built-in ctors (`Result.Ok` / `Option.Some` / etc.) don't
+        // carry user-program `CtorId`s. Wave 3c-i will introduce a
+        // typed identity for them — until then, fns that construct
+        // them get dropped.
+        ResolvedExpr::Ctor(ResolvedCtor::Builtin(_), _) => {
+            return Err(SkipReason::BuiltinCtorConstruction);
+        }
+        ResolvedExpr::Ctor(ResolvedCtor::Unresolved { .. }, _) => {
+            return Err(SkipReason::UnresolvedCtor);
         }
         ResolvedExpr::RecordCreate {
             type_id: Some(type_id),
             fields,
             ..
         } => {
-            let mir_fields: Option<Vec<_>> = fields
+            let mir_fields = fields
                 .iter()
                 .map(|(name, value)| {
-                    Some(MirRecordField {
+                    Ok(MirRecordField {
                         name: name.clone(),
                         value: lower_expr(value)?,
                     })
                 })
-                .collect();
+                .collect::<Result<Vec<_>, SkipReason>>()?;
             MirExpr::RecordCreate(wrap(
                 MirRecordCreate {
                     type_id: *type_id,
-                    fields: mir_fields?,
+                    fields: mir_fields,
                 },
                 expr,
             ))
@@ -240,31 +259,31 @@ fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Option<Spanned<MirExpr>> {
             updates,
             ..
         } => {
-            let mir_updates: Option<Vec<_>> = updates
+            let mir_updates = updates
                 .iter()
                 .map(|(name, value)| {
-                    Some(MirRecordField {
+                    Ok(MirRecordField {
                         name: name.clone(),
                         value: lower_expr(value)?,
                     })
                 })
-                .collect();
+                .collect::<Result<Vec<_>, SkipReason>>()?;
             MirExpr::RecordUpdate(wrap(
                 MirRecordUpdate {
                     base: Box::new(lower_expr(base)?),
                     type_id: *type_id,
-                    updates: mir_updates?,
+                    updates: mir_updates,
                 },
                 expr,
             ))
         }
         // Records on built-in types (`HttpResponse`, `Header`,
-        // `Buffer`, …) carry no `TypeId`. Wave 2 skips them; a
-        // later phase will widen `MirRecordCreate` / `MirRecordUpdate`
-        // to carry an optional source-type-name when the consumer
-        // demands it (none does today).
+        // `Buffer`, …) carry no `TypeId`. Skipped until the
+        // consumer (currently nobody) demands a name-only fallback.
         ResolvedExpr::RecordCreate { type_id: None, .. }
-        | ResolvedExpr::RecordUpdate { type_id: None, .. } => return None,
+        | ResolvedExpr::RecordUpdate { type_id: None, .. } => {
+            return Err(SkipReason::BuiltinRecord);
+        }
         ResolvedExpr::Attr(base, field) => MirExpr::Project(wrap(
             MirProject {
                 base: Box::new(lower_expr(base)?),
@@ -276,52 +295,60 @@ fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Option<Spanned<MirExpr>> {
         // ── Wave 3b ─────────────────────────────────────────────
         ResolvedExpr::Match { subject, arms } => {
             let mir_subject = lower_expr(subject)?;
-            let mir_arms: Option<Vec<_>> = arms.iter().map(lower_arm).collect();
+            let mir_arms = arms.iter().map(lower_arm).collect::<Result<Vec<_>, _>>()?;
             MirExpr::Match(wrap(
                 MirMatch {
                     subject: Box::new(mir_subject),
-                    arms: mir_arms?,
+                    arms: mir_arms,
                 },
                 expr,
             ))
         }
 
         // ── Wave 3c+ ────────────────────────────────────────────
-        _ => return None,
+        ResolvedExpr::ErrorProp(_) => return Err(SkipReason::UnsupportedTry),
+        ResolvedExpr::TailCall { .. } => return Err(SkipReason::UnsupportedTailCall),
+        ResolvedExpr::List(_) => return Err(SkipReason::UnsupportedList),
+        ResolvedExpr::Tuple(_) => return Err(SkipReason::UnsupportedTuple),
+        ResolvedExpr::MapLiteral(_) => return Err(SkipReason::UnsupportedMap),
+        ResolvedExpr::InterpolatedStr(_) => {
+            return Err(SkipReason::UnsupportedInterpolatedStr);
+        }
+        ResolvedExpr::IndependentProduct(_, _) => {
+            return Err(SkipReason::UnsupportedIndependentProduct);
+        }
+        ResolvedExpr::Ident(_) => return Err(SkipReason::UnresolvedIdent),
     };
-    Some(wrap(mir, expr))
+    Ok(wrap(mir, expr))
 }
 
 /// Wave 3b — lower one resolved match arm. Pattern bindings draw
 /// their `LocalId`s from `arm.binding_slots`, which the resolver
 /// fills in preorder of the bindings as they appear in the
 /// pattern (same walk as `ast_rewrite::pattern_binding_names`).
-/// An arm with no resolved slots or with a built-in / unresolved
-/// ctor pattern returns `None`, causing the whole fn to be
-/// dropped from MIR.
-fn lower_arm(arm: &ResolvedMatchArm) -> Option<MirMatchArm> {
+/// Returns `Err(SkipReason)` for built-in / unresolved ctor
+/// patterns or for slot-count desyncs.
+fn lower_arm(arm: &ResolvedMatchArm) -> Result<MirMatchArm, SkipReason> {
     let slots: &[u16] = arm.binding_slots.get().map(Vec::as_slice).unwrap_or(&[]);
     let mut cursor = 0usize;
     let pattern = lower_pattern(&arm.pattern, slots, &mut cursor)?;
     if cursor != slots.len() {
-        // Slot count mismatch — defensive guard against future
-        // pattern shapes the lowerer doesn't yet understand.
-        return None;
+        return Err(SkipReason::PatternSlotShortfall);
     }
     let body = lower_expr(&arm.body)?;
-    Some(MirMatchArm { pattern, body })
+    Ok(MirMatchArm { pattern, body })
 }
 
 /// Wave 3b — lower a `ResolvedPattern` while consuming binding
-/// slots from `slots[*cursor..]` in preorder. Returns `None` on
-/// any unsupported pattern shape (built-in / unresolved ctor) so
-/// the caller can drop the whole fn cleanly.
+/// slots from `slots[*cursor..]` in preorder. Returns
+/// `Err(SkipReason)` on built-in / unresolved ctor patterns or on
+/// a slot shortfall.
 fn lower_pattern(
     pattern: &ResolvedPattern,
     slots: &[u16],
     cursor: &mut usize,
-) -> Option<MirPattern> {
-    Some(match pattern {
+) -> Result<MirPattern, SkipReason> {
+    Ok(match pattern {
         ResolvedPattern::Wildcard => MirPattern::Wildcard,
         ResolvedPattern::Literal(lit) => MirPattern::Literal(lit.clone()),
         ResolvedPattern::Ident(_) => {
@@ -338,11 +365,11 @@ fn lower_pattern(
             }
         }
         ResolvedPattern::Tuple(items) => {
-            let mir_items: Option<Vec<_>> = items
+            let mir_items = items
                 .iter()
                 .map(|p| lower_pattern(p, slots, cursor))
-                .collect();
-            MirPattern::Tuple(mir_items?)
+                .collect::<Result<Vec<_>, _>>()?;
+            MirPattern::Tuple(mir_items)
         }
         ResolvedPattern::Ctor(ResolvedCtor::User { ctor_id, .. }, names) => {
             let mut bindings = Vec::with_capacity(names.len());
@@ -355,18 +382,21 @@ fn lower_pattern(
                 bindings,
             }
         }
-        // Built-in / unresolved ctor patterns wait for wave 3c —
-        // same skip rule as wave 2's built-in ctor *constructions*.
-        ResolvedPattern::Ctor(ResolvedCtor::Builtin(_) | ResolvedCtor::Unresolved { .. }, _) => {
-            return None;
+        // Wave 3c-i — built-in / unresolved ctor patterns get typed
+        // identity alongside their construction-side counterparts.
+        ResolvedPattern::Ctor(ResolvedCtor::Builtin(_), _) => {
+            return Err(SkipReason::BuiltinCtorPattern);
+        }
+        ResolvedPattern::Ctor(ResolvedCtor::Unresolved { .. }, _) => {
+            return Err(SkipReason::UnresolvedCtor);
         }
     })
 }
 
-fn take_slot(slots: &[u16], cursor: &mut usize) -> Option<u16> {
-    let slot = *slots.get(*cursor)?;
+fn take_slot(slots: &[u16], cursor: &mut usize) -> Result<u16, SkipReason> {
+    let slot = *slots.get(*cursor).ok_or(SkipReason::PatternSlotShortfall)?;
     *cursor += 1;
-    Some(slot)
+    Ok(slot)
 }
 
 /// Wrap a freshly-lowered node in `Spanned` while inheriting the
@@ -400,11 +430,11 @@ fn lower_stmt_chain(
     stmts: &[ResolvedStmt],
     resolution: &FnResolution,
     next_synthetic_local: &mut u32,
-) -> Option<Spanned<MirExpr>> {
-    let (last, rest) = stmts.split_last()?;
+) -> Result<Spanned<MirExpr>, SkipReason> {
+    let (last, rest) = stmts.split_last().ok_or(SkipReason::EmptyBody)?;
     // Last stmt must produce a value.
     let ResolvedStmt::Expr(tail_expr) = last else {
-        return None;
+        return Err(SkipReason::BindingOnlyTail);
     };
     let mut body = lower_expr(tail_expr)?;
 
@@ -413,7 +443,10 @@ fn lower_stmt_chain(
     for stmt in rest.iter().rev() {
         let (binding, value_expr) = match stmt {
             ResolvedStmt::Binding { name, value, .. } => {
-                let slot = *resolution.local_slots.get(name)?;
+                let slot = *resolution
+                    .local_slots
+                    .get(name)
+                    .ok_or(SkipReason::BindingSlotLookupMissing)?;
                 (LocalId(u32::from(slot)), value)
             }
             ResolvedStmt::Expr(expr) => {
@@ -438,5 +471,5 @@ fn lower_stmt_chain(
             ty: std::sync::OnceLock::new(),
         };
     }
-    Some(body)
+    Ok(body)
 }

--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -77,6 +77,7 @@ pub mod dump;
 pub mod expr;
 pub mod lower;
 pub mod program;
+pub mod stats;
 
 pub use expr::{
     MirBinOp, MirCall, MirCallee, MirConstruct, MirEffectAnnotation, MirExpr,
@@ -85,3 +86,4 @@ pub use expr::{
 };
 pub use lower::lower_program;
 pub use program::{LocalId, MirFn, MirParam, MirProgram};
+pub use stats::{LowerStats, SkipReason};

--- a/src/ir/mir/program.rs
+++ b/src/ir/mir/program.rs
@@ -12,6 +12,7 @@ use crate::ir::{FnId, ModuleId};
 use crate::ast::Spanned;
 
 use super::expr::{MirEffectAnnotation, MirExpr};
+use super::stats::LowerStats;
 
 /// A whole compiled program in Core MIR. Keyed by `FnId` (stable
 /// across compilation units; same identity layer the rest of the
@@ -27,6 +28,12 @@ pub struct MirProgram {
     /// per-module IR dump). Empty when the program was assembled
     /// from a single entry file with no `depends [...]`.
     pub modules: Vec<ModuleId>,
+    /// Coverage telemetry for the lowering that produced this
+    /// program. `lowered + skipped.values().sum()` equals the
+    /// number of `ResolvedFnDef` items the lowerer saw — see
+    /// [`super::stats::LowerStats`] for the coverage gate that
+    /// Phase 4 (VM slice) consumes.
+    pub stats: LowerStats,
 }
 
 impl MirProgram {
@@ -114,6 +121,16 @@ pub struct MirParam {
 /// freedom to introduce fresh locals during optimization passes,
 /// and inheriting HIR's numbering would silently overlap with
 /// those.
+///
+/// **Seed during Phase 3 (waves 1-3b):** the lowerer seeds new
+/// `LocalId`s from the resolver's slot indices
+/// (`ResolvedExpr::Resolved { slot, .. }`, `FnResolution.local_slots`,
+/// `ResolvedMatchArm.binding_slots`) and grows synthetic locals
+/// from `local_count` upward for `Stmt::Expr` intermediates the
+/// resolver didn't see. The slot space is unique per function so
+/// reuse is safe. Later optimizer passes are still free to
+/// renumber — `LocalId` is just an opaque identity per body, not
+/// a promise about resolver lineage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct LocalId(pub u32);
 

--- a/src/ir/mir/stats.rs
+++ b/src/ir/mir/stats.rs
@@ -1,0 +1,173 @@
+//! `LowerStats` + `SkipReason` — coverage telemetry for the
+//! HIR → MIR lowerer.
+//!
+//! Phase 3 lowers `ResolvedProgramView` into `MirProgram` in
+//! widening waves. Until the lowerer covers everything, fns
+//! containing unsupported shapes get dropped from
+//! `MirProgram.fns` — `MirProgram` is "what MIR could lower so
+//! far", not "what HIR contained". Without telemetry, that drop
+//! is invisible: dump renders, tests pass on the supported
+//! subset, but Phase 4 (VM slice) could land thinking everything
+//! is wired when in fact 60% of the corpus silently disappeared.
+//!
+//! `LowerStats` is the gate. It rides on `MirProgram` so any
+//! consumer can ask "how complete is this lowering". Each
+//! skipped fn bumps a counter keyed by `SkipReason` — the first
+//! unsupported shape the lowerer hit — so widening-wave PRs can
+//! prove that the reason set shrinks.
+//!
+//! ## Coverage contract (Phase 3 → 4 gate)
+//!
+//! - Every dropped fn must produce exactly one `SkipReason`. No
+//!   silent drops, no double-counting.
+//! - The Phase 4 (VM slice) entry gate asserts a corpus-wide
+//!   coverage ratio (lowered / total ≥ target). Each wave PR
+//!   nudges the target up.
+
+use std::collections::HashMap;
+
+/// Why a single `ResolvedFnDef` failed to lower.
+///
+/// One variant per source-level reason — the dominant unsupported
+/// shape inside the fn body. Wave PRs sequentially remove
+/// reasons from the live set; once the set is empty the lowerer
+/// is corpus-complete on the shipped examples.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SkipReason {
+    /// `ResolvedFnDef.body` had no statements. Frontend should
+    /// have rejected this earlier; recorded for safety.
+    EmptyBody,
+    /// Single-stmt body whose only statement is a binding (no
+    /// tail expression). Well-typed Aver can't produce this, but
+    /// the lowerer guards anyway.
+    BindingOnlyTail,
+    /// Multi-stmt body, `FnResolution` not populated by the
+    /// resolver pass — usually means the fn wasn't visited.
+    MissingResolution,
+    /// Binding referenced by name didn't resolve to a slot via
+    /// `FnResolution.local_slots`. Indicates a resolver gap.
+    BindingSlotLookupMissing,
+    /// `Match` arm's `binding_slots` had fewer slots than the
+    /// pattern's preorder binding count. Indicates a resolver /
+    /// pattern desync.
+    PatternSlotShortfall,
+    /// Built-in constructor *construction* (`Result.Ok(v)`,
+    /// `Option.Some(v)`, …) — wave 3c-i territory. Built-in
+    /// ctors need a typed identity story beyond raw `CtorId`.
+    BuiltinCtorConstruction,
+    /// Built-in constructor *pattern* (`Result.Ok(v) -> ...`,
+    /// `Option.Some(v) -> ...`) — same wave 3c-i territory as
+    /// the construction side.
+    BuiltinCtorPattern,
+    /// `Result-`like ctor whose `CtorId` didn't resolve — usually
+    /// a typecheck error that leaked past the gate. Drops the fn
+    /// rather than panic on a half-resolved ctor.
+    UnresolvedCtor,
+    /// First-class fn value / intrinsic / unresolved call target.
+    /// Wave 3c-iii (closures / intrinsics) territory.
+    UnsupportedCallee,
+    /// `Record{...}` / `Record{base & ...}` on a built-in type
+    /// (`HttpResponse`, `Header`, `Buffer`, …) with no `TypeId`.
+    /// Wave 3c-i / 3c-iv territory depending on the type.
+    BuiltinRecord,
+    /// `Try` (the `?` propagation node) — wave 3c-ii.
+    UnsupportedTry,
+    /// Tail call — wave 3c-iii.
+    UnsupportedTailCall,
+    /// List literal — wave 3c-iv.
+    UnsupportedList,
+    /// Tuple literal — wave 3c-iv.
+    UnsupportedTuple,
+    /// Map literal — wave 3c-iv.
+    UnsupportedMap,
+    /// Interpolated string — wave 3c-iv.
+    UnsupportedInterpolatedStr,
+    /// `IndependentProduct` (`?!` / `!`) — wave 3c-v.
+    UnsupportedIndependentProduct,
+    /// Unresolved top-level `Ident` that survived past the
+    /// resolver — usually a resolver gap. Drops the fn rather than
+    /// emit a half-resolved name.
+    UnresolvedIdent,
+    /// A `ResolvedExpr` variant the lowerer doesn't recognise at
+    /// all. Should be empty after wave 3c lands — anything
+    /// here points to a missed variant.
+    UnsupportedOther,
+}
+
+impl SkipReason {
+    /// Short human-readable label for dumps / diagnostics.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::EmptyBody => "empty body",
+            Self::BindingOnlyTail => "binding-only tail",
+            Self::MissingResolution => "missing resolution",
+            Self::BindingSlotLookupMissing => "binding slot lookup missing",
+            Self::PatternSlotShortfall => "pattern slot shortfall",
+            Self::BuiltinCtorConstruction => "built-in ctor construction",
+            Self::BuiltinCtorPattern => "built-in ctor pattern",
+            Self::UnresolvedCtor => "unresolved ctor",
+            Self::UnsupportedCallee => "unsupported callee",
+            Self::BuiltinRecord => "built-in record type",
+            Self::UnsupportedTry => "unsupported Try (`?`)",
+            Self::UnsupportedTailCall => "unsupported tail call",
+            Self::UnsupportedList => "unsupported list literal",
+            Self::UnsupportedTuple => "unsupported tuple literal",
+            Self::UnsupportedMap => "unsupported map literal",
+            Self::UnsupportedInterpolatedStr => "unsupported interpolated string",
+            Self::UnsupportedIndependentProduct => "unsupported IndependentProduct",
+            Self::UnresolvedIdent => "unresolved Ident (resolver gap)",
+            Self::UnsupportedOther => "unsupported (other)",
+        }
+    }
+}
+
+/// Coverage counters for a single `lower_program` call.
+///
+/// `lowered` = fns successfully placed into `MirProgram.fns`.
+/// `skipped` = fns dropped, keyed by the first `SkipReason` the
+/// lowerer hit inside that fn. Total = `lowered + skipped.values().sum()`
+/// equals the number of `ResolvedFnDef` items the call saw.
+#[derive(Debug, Clone, Default)]
+pub struct LowerStats {
+    /// Number of fns whose body lowered successfully into
+    /// `MirProgram.fns`.
+    pub lowered: u32,
+    /// Skipped fns keyed by reason. One bump per dropped fn.
+    pub skipped: HashMap<SkipReason, u32>,
+}
+
+impl LowerStats {
+    /// Total fns the lowerer saw, lowered or not.
+    pub fn total(&self) -> u32 {
+        self.lowered + self.skipped.values().sum::<u32>()
+    }
+
+    /// Coverage ratio in `[0.0, 1.0]`. Returns `1.0` for an empty
+    /// program so empty corpora don't poison the gate.
+    pub fn coverage_ratio(&self) -> f64 {
+        let total = self.total();
+        if total == 0 {
+            return 1.0;
+        }
+        f64::from(self.lowered) / f64::from(total)
+    }
+
+    /// Record one lowered fn.
+    pub fn record_lowered(&mut self) {
+        self.lowered += 1;
+    }
+
+    /// Record one dropped fn with its dominant reason.
+    pub fn record_skip(&mut self, reason: SkipReason) {
+        *self.skipped.entry(reason).or_insert(0) += 1;
+    }
+
+    /// Iterate `(SkipReason, count)` pairs in a stable order
+    /// (variant order via `SkipReason as u8` ascending), so dumps
+    /// + test assertions don't depend on `HashMap` iteration drift.
+    pub fn skipped_sorted(&self) -> Vec<(SkipReason, u32)> {
+        let mut entries: Vec<_> = self.skipped.iter().map(|(r, c)| (*r, *c)).collect();
+        entries.sort_by_key(|(r, _)| *r as u8);
+        entries
+    }
+}

--- a/tests/mir_phase3_coverage_gate.rs
+++ b/tests/mir_phase3_coverage_gate.rs
@@ -1,0 +1,170 @@
+//! Phase 3 → 4 coverage gate of #252.
+//!
+//! Until the lowerer covers every `ResolvedExpr` shape, fns with
+//! unsupported constructs get dropped from `MirProgram.fns`. The
+//! drop is silent at the call-site level — `MirProgram::dump()`
+//! still renders cleanly for the lowered subset. That's a trap:
+//! Phase 4 (VM slice) could land thinking everything is wired
+//! when in fact 60% of the corpus silently disappeared.
+//!
+//! `MirProgram.stats` is the gate. Every wave PR can prove:
+//! 1. **Conservation** — `lowered + sum(skipped) == total fns seen`.
+//! 2. **Attribution** — each dropped fn names a single dominant
+//!    `SkipReason`.
+//! 3. **Direction** — newly-supported variants disappear from the
+//!    `skipped` map; nothing previously supported regresses.
+//!
+//! These tests pin those invariants on a mix of supported + each
+//! flavour of unsupported construct. Phase 4 gate adds a corpus-
+//! wide `coverage_ratio() ≥ X%` floor on the shipped examples.
+
+use aver::ir::mir::{SkipReason, lower_program};
+use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
+use aver::source::parse_source;
+
+fn lower_stats(source: &str) -> aver::ir::mir::LowerStats {
+    let mut items = parse_source(source).unwrap_or_else(|e| panic!("parse: {e}"));
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    let tc = result.typecheck.as_ref().expect("typecheck requested");
+    assert!(tc.errors.is_empty(), "typecheck failed: {:?}", tc.errors);
+    lower_program(&result.resolved_items).stats
+}
+
+#[test]
+fn conservation_lowered_plus_skipped_equals_total() {
+    // Mix of one wave-1 supported fn and one wave-3c-bound fn
+    // (`Result.Ok` construction). Total fns seen = 2; every fn
+    // accounted for in `lowered` or `skipped`.
+    let stats = lower_stats(
+        "fn keep(x: Int) -> Int\n    x + 1\n\nfn drops_me() -> Result<Int, String>\n    Result.Ok(1)\n",
+    );
+    assert_eq!(
+        stats.total(),
+        2,
+        "expected 2 fns seen, got {}: {:?}",
+        stats.total(),
+        stats
+    );
+    assert_eq!(stats.lowered, 1, "wave-1 fn must lower: {:?}", stats);
+    assert_eq!(
+        stats.skipped.values().sum::<u32>(),
+        1,
+        "exactly one fn dropped: {:?}",
+        stats
+    );
+}
+
+#[test]
+fn coverage_ratio_pins_one_for_empty_program() {
+    // Empty corpus → 1.0 by convention so empty source files
+    // don't poison the gate.
+    let stats = lower_stats("");
+    assert_eq!(stats.total(), 0);
+    assert!(
+        (stats.coverage_ratio() - 1.0).abs() < f64::EPSILON,
+        "empty program coverage_ratio should be 1.0, got {}",
+        stats.coverage_ratio()
+    );
+}
+
+#[test]
+fn builtin_ctor_construction_attributes_to_dedicated_reason() {
+    let stats = lower_stats("fn makes_ok(x: Int) -> Result<Int, String>\n    Result.Ok(x)\n");
+    assert_eq!(stats.lowered, 0, "fn constructing Result.Ok must drop");
+    let count = stats
+        .skipped
+        .get(&SkipReason::BuiltinCtorConstruction)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        count, 1,
+        "expected BuiltinCtorConstruction = 1, got {:?}",
+        stats.skipped
+    );
+}
+
+#[test]
+fn list_literal_attributes_to_list_reason() {
+    let stats = lower_stats("fn one() -> List<Int>\n    [1, 2, 3]\n");
+    assert_eq!(
+        stats.skipped.get(&SkipReason::UnsupportedList).copied(),
+        Some(1),
+        "list literal must skip with UnsupportedList:\n{:?}",
+        stats.skipped
+    );
+}
+
+#[test]
+fn tuple_literal_attributes_to_tuple_reason() {
+    let stats = lower_stats("fn pair() -> Tuple<Int, Int>\n    (1, 2)\n");
+    assert_eq!(
+        stats.skipped.get(&SkipReason::UnsupportedTuple).copied(),
+        Some(1),
+        "tuple literal must skip with UnsupportedTuple:\n{:?}",
+        stats.skipped
+    );
+}
+
+#[test]
+fn skipped_sorted_is_stable() {
+    // Two distinct skips → stable iteration order from
+    // `skipped_sorted()` regardless of `HashMap` internal layout.
+    let stats =
+        lower_stats("fn a() -> List<Int>\n    [1]\n\nfn b() -> Tuple<Int, Int>\n    (1, 2)\n");
+    let sorted = stats.skipped_sorted();
+    assert_eq!(sorted.len(), 2);
+    // SkipReason variant order is the declaration order in
+    // `stats.rs` — UnsupportedList comes before UnsupportedTuple.
+    let reasons: Vec<_> = sorted.iter().map(|(r, _)| *r).collect();
+    let list_pos = reasons
+        .iter()
+        .position(|r| *r == SkipReason::UnsupportedList);
+    let tuple_pos = reasons
+        .iter()
+        .position(|r| *r == SkipReason::UnsupportedTuple);
+    assert!(list_pos.is_some() && tuple_pos.is_some());
+    assert!(
+        list_pos.unwrap() < tuple_pos.unwrap(),
+        "UnsupportedList must precede UnsupportedTuple in sorted iteration: {:?}",
+        sorted
+    );
+}
+
+#[test]
+fn skip_reason_label_is_human_readable() {
+    // Smoke: every variant we use in the lowerer renders a
+    // non-empty label. Future dump / diagnostic surfaces consume
+    // these.
+    for reason in [
+        SkipReason::EmptyBody,
+        SkipReason::BindingOnlyTail,
+        SkipReason::MissingResolution,
+        SkipReason::BindingSlotLookupMissing,
+        SkipReason::PatternSlotShortfall,
+        SkipReason::BuiltinCtorConstruction,
+        SkipReason::BuiltinCtorPattern,
+        SkipReason::UnresolvedCtor,
+        SkipReason::UnsupportedCallee,
+        SkipReason::BuiltinRecord,
+        SkipReason::UnsupportedTry,
+        SkipReason::UnsupportedTailCall,
+        SkipReason::UnsupportedList,
+        SkipReason::UnsupportedTuple,
+        SkipReason::UnsupportedMap,
+        SkipReason::UnsupportedInterpolatedStr,
+        SkipReason::UnsupportedIndependentProduct,
+        SkipReason::UnresolvedIdent,
+        SkipReason::UnsupportedOther,
+    ] {
+        assert!(
+            !reason.label().is_empty(),
+            "every SkipReason variant must have a non-empty label"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Peer-review pushback on the lowerer's silent-skip strategy: dump renders, tests pass on the supported subset, and 60% of the corpus can silently disappear before Phase 4 (VM slice) notices. This adds the gate.

- `MirProgram.stats: LowerStats { lowered, skipped: HashMap<SkipReason, _> }` — one bump per dropped fn, attributed to the first unsupported shape the lowerer hit. Conservation invariant: `total() == lowered + skipped.values().sum()`.
- `SkipReason` — 19 variants covering every drop site (built-in ctors, `Try`, tail call, list/tuple/map/interp, IndependentProduct, resolver gaps, …).
- `lower_expr` / `lower_arm` / `lower_pattern` / `lower_stmt_chain` / `lower_fn` refactored from `Option<T>` to `Result<T, SkipReason>` so the first failed step's reason propagates up exactly once.

## Wave 3c reordered

Peer reviewer flagged that `Try` semantically depends on stable identity for built-in `Result.Ok` / `Result.Err`. Empirically confirmed: well-typed Aver fns using `?` always also construct a `Result.Ok` (early-return + happy-path) in the same body, so the `Try` drop is shadowed by the built-in-ctor drop. Wave 3c sub-waves now:

- **3c-i** built-in ctor identity (construction + pattern)
- **3c-ii** `Try` (`?` propagation)
- **3c-iii** tail calls + first-class fn callees
- **3c-iv** list / tuple / map / interpolated-string literals
- **3c-v** `IndependentProduct`

RFC.md updated with both the gate contract + the reordering.

## LocalId doc tightened

Per peer point #2 — `program.rs` now states explicitly that wave 1-3 seeds new `LocalId`s from resolver slots (`ResolvedExpr::Resolved.slot`, `FnResolution.local_slots`, `ResolvedMatchArm.binding_slots`) with synthetic locals counted from `local_count` upward; later optimizer passes remain free to renumber.

## Test plan
- [x] `cargo build` clean
- [x] `cargo fmt`
- [x] `cargo clippy --tests` clean on new code
- [x] `tests/mir_phase3_coverage_gate.rs` 7/7 ✅
  - conservation (`lowered + skipped == total`)
  - empty-program coverage ratio = 1.0
  - built-in ctor construction attribution
  - list / tuple literal attribution
  - `skipped_sorted()` stability across `HashMap` iteration drift
  - every `SkipReason` variant has a non-empty label
- [x] all existing MIR tests pass (34/34) across phases 2a/2b/3a/3b waves 1/2/3a/3b

## Out of scope (intentionally)
- Try test (`UnsupportedTry` attribution) — deferred to wave 3c-ii where it becomes empirically exerciseable.
- Corpus-wide `coverage_ratio() ≥ X` floor on `examples/` — that's Phase 4's entry gate; lands when the VM consumer arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)