### PR TITLE
ir/mir: HIR → MIR lowering, wave 3c-i — typed identity for built-in ctors (#252 Phase 3)

### DIFF
--- a/src/ir/mir/RFC.md
+++ b/src/ir/mir/RFC.md
@@ -146,8 +146,8 @@ One PR per wave so review surface stays bounded:
 3. wave 3, sub-waves:
    - 3a — multi-stmt `Let` chains
    - 3b — structured `match` arms + user-ctor patterns
-   - **coverage gate** (this PR) — `LowerStats { lowered, skipped: HashMap<SkipReason, _> }` riding on `MirProgram`; every dropped fn attributed to a single dominant reason; tests pin conservation + attribution
-   - 3c-i — built-in ctor identity (`Result.Ok` / `Option.Some` construction + pattern). Must land *before* `Try` because well-typed Aver fns using `?` always also construct a `Result.Ok` in the same body (early-return + happy-path), so the `Try` lowering only becomes exerciseable once built-in ctors stop dropping the fn
+   - **coverage gate** — `LowerStats { lowered, skipped: HashMap<SkipReason, _> }` riding on `MirProgram`; every dropped fn attributed to a single dominant reason; tests pin conservation + attribution
+   - **3c-i (this PR)** — built-in ctor identity. `MirCtor { User(CtorId), Builtin(BuiltinCtor) }` discriminates user vs language-level (`Result.Ok` / `Result.Err` / `Option.Some` / `Option.None`) ctors at the variant level. `MirConstruct.ctor` and `MirPattern::Ctor.ctor` both switch to `MirCtor`. Dump renders canonical builtin names (`Result.Ok(%0)`) so reviewers see typed identity at a glance. Lands before `Try` because well-typed Aver fns using `?` always also construct a `Result.Ok` in the same body — the `Try` lowering only becomes exerciseable once built-in ctors stop dropping the fn. Open follow-up: bare nullary `Option.None` as a body expression currently lowers to `Attr(Ident("Option"), "None")` — a preexisting resolver gap, not 3c-i scope.
    - 3c-ii — `Try` (`?` propagation)
    - 3c-iii — tail calls + first-class fn callees
    - 3c-iv — list / tuple / map / interpolated-string literals

--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -213,7 +213,8 @@ fn write_pattern(f: &mut fmt::Formatter<'_>, p: &MirPattern) -> fmt::Result {
             write!(f, ")")
         }
         MirPattern::Ctor { ctor, bindings } => {
-            write!(f, "CtorId({})(", ctor.0)?;
+            write_ctor(f, *ctor)?;
+            write!(f, "(")?;
             for (i, b) in bindings.iter().enumerate() {
                 if i > 0 {
                     write!(f, ", ")?;
@@ -226,9 +227,22 @@ fn write_pattern(f: &mut fmt::Formatter<'_>, p: &MirPattern) -> fmt::Result {
 }
 
 fn write_construct(f: &mut fmt::Formatter<'_>, c: &MirConstruct, indent: &str) -> fmt::Result {
-    write!(f, "CtorId({})(", c.ctor.0)?;
+    write_ctor(f, c.ctor)?;
+    write!(f, "(")?;
     write_args(f, &c.args, indent)?;
     write!(f, ")")
+}
+
+fn write_ctor(f: &mut fmt::Formatter<'_>, ctor: super::MirCtor) -> fmt::Result {
+    match ctor {
+        super::MirCtor::User(id) => write!(f, "CtorId({})", id.0),
+        super::MirCtor::Builtin(b) => match b {
+            super::BuiltinCtor::ResultOk => write!(f, "Result.Ok"),
+            super::BuiltinCtor::ResultErr => write!(f, "Result.Err"),
+            super::BuiltinCtor::OptionSome => write!(f, "Option.Some"),
+            super::BuiltinCtor::OptionNone => write!(f, "Option.None"),
+        },
+    }
 }
 
 fn write_record_create(

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -15,9 +15,31 @@
 //!   correlation with `ProofIR`.
 
 use crate::ast::{BinOp, Literal, Spanned};
+use crate::ir::hir::BuiltinCtor;
 use crate::ir::{CtorId, FnId, TypeId};
 
 use super::program::LocalId;
+
+/// Typed identity for a constructor reference inside MIR. Two
+/// flavors: user-declared variants identified by stable `CtorId`,
+/// and language-level built-in constructors (`Result.Ok` /
+/// `Result.Err` / `Option.Some` / `Option.None`) that don't get
+/// user-program ids because they're not user-declared.
+///
+/// Wave 3c-i pin: built-in ctors travel through the same
+/// `MirConstruct` / `MirPattern::Ctor` shape as user ctors, so
+/// every consumer reading constructor identity goes through one
+/// matchable enum — no separate "is this Result.Ok" string check
+/// scattered across backends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MirCtor {
+    /// User-declared sum-type variant or record constructor.
+    User(CtorId),
+    /// Language-level built-in (`Result.Ok` / `Result.Err` /
+    /// `Option.Some` / `Option.None`). Same `BuiltinCtor` enum
+    /// the resolver pass uses, re-exported by `super::*`.
+    Builtin(BuiltinCtor),
+}
 
 /// One MIR expression. Every variant is a value — there's no
 /// separate statement form at this phase. Sequencing happens via
@@ -185,20 +207,24 @@ pub enum MirPattern {
     Cons { head: LocalId, tail: LocalId },
     /// `(a, b, c)` — tuple pattern; each component is a sub-pattern.
     Tuple(Vec<MirPattern>),
-    /// `Module.Variant(b1, b2, …)` — constructor pattern. `ctor`
-    /// identifies the variant by stable id; `bindings` are the
-    /// fresh locals for the variant's fields, in declaration
-    /// order.
+    /// `Module.Variant(b1, b2, …)` / `Result.Ok(b)` / `Option.None`
+    /// — constructor pattern. `ctor` discriminates user vs built-in
+    /// variant via `MirCtor`; `bindings` are the fresh locals for
+    /// the variant's fields in declaration order (empty for
+    /// nullary variants like `Option.None`).
     Ctor {
-        ctor: CtorId,
+        ctor: MirCtor,
         bindings: Vec<LocalId>,
     },
 }
 
-/// Construct a sum-type variant.
+/// Construct a sum-type variant. `ctor` discriminates user vs
+/// built-in via `MirCtor` (wave 3c-i — built-in ctors now ride
+/// the same node as user ctors instead of being dropped from the
+/// MIR program).
 #[derive(Debug, Clone)]
 pub struct MirConstruct {
-    pub ctor: CtorId,
+    pub ctor: MirCtor,
     pub args: Vec<Spanned<MirExpr>>,
 }
 

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -28,7 +28,7 @@
 //! **Wave 3b (this commit)** — structured `match` + patterns:
 //! - `ResolvedExpr::Match { subject, arms }` → `MirExpr::Match`.
 //! - User-ctor patterns (`ResolvedCtor::User { ctor_id, .. }`)
-//!   lower to `MirPattern::Ctor { ctor: CtorId, bindings }`.
+//!   lower to `MirPattern::Ctor { ctor: MirCtor::User(_), bindings }`.
 //! - Cons / Tuple / Ident / Literal / Wildcard / EmptyList lower
 //!   structurally. Pattern bindings draw their `LocalId`s from
 //!   `ResolvedMatchArm.binding_slots` (preorder-flat, same shape
@@ -38,13 +38,24 @@
 //!   silently skipped, same skip-rule that wave 2 applied to
 //!   built-in ctor *constructions*.
 //!
-//! Wave 3c lands `Try`, tail calls, `IndependentProduct`,
-//! lists / tuples / maps / interpolation, and built-in constructors
-//! (`Result.Ok` / `Option.Some` — those need a typed identity
-//! story beyond raw `CtorId`). The bind-and-propagate shape
-//! `let x = step()?; body` lowers as
-//! `Let { binding, value: Try(step()), body }` — no dedicated
-//! `TryBind` variant (dropped during wave 3 prep).
+//! **Wave 3c-i (this commit)** — typed identity for built-in
+//!   constructors:
+//! - `ResolvedExpr::Ctor(Builtin(bc), args)` →
+//!   `MirConstruct { ctor: MirCtor::Builtin(bc), args }`.
+//! - `ResolvedPattern::Ctor(Builtin(bc), names)` →
+//!   `MirPattern::Ctor { ctor: MirCtor::Builtin(bc), bindings }`.
+//! - User ctors stay on `MirCtor::User(CtorId)`; the two flavors
+//!   ride the same node shape so backends pattern-match once.
+//! - `SkipReason::BuiltinCtorConstruction` /
+//!   `BuiltinCtorPattern` drop out of `LowerStats.skipped` (the
+//!   variants stay in the enum for historical attribution).
+//!
+//! Remaining wave 3c sub-waves: 3c-ii lands `Try`, 3c-iii tail
+//! calls + first-class fn callees, 3c-iv list / tuple / map /
+//! interpolated-string literals, 3c-v `IndependentProduct`. The
+//! bind-and-propagate shape `let x = step()?; body` will lower
+//! as `Let { binding, value: Try(step()), body }` — no
+//! dedicated `TryBind` variant (dropped during wave 3 prep).
 //!
 //! Functions that use anything outside the waves' supported
 //! subset are dropped — `MirProgram.fns` only contains what the
@@ -74,8 +85,9 @@ use crate::ir::hir::{
 };
 
 use super::expr::{
-    MirBinOp, MirCall, MirCallee, MirConstruct, MirEffectAnnotation, MirExpr, MirLet, MirMatch,
-    MirMatchArm, MirPattern, MirProject, MirRecordCreate, MirRecordField, MirRecordUpdate,
+    MirBinOp, MirCall, MirCallee, MirConstruct, MirCtor, MirEffectAnnotation, MirExpr, MirLet,
+    MirMatch, MirMatchArm, MirPattern, MirProject, MirRecordCreate, MirRecordField,
+    MirRecordUpdate,
 };
 use super::program::{LocalId, MirFn, MirParam, MirProgram};
 use super::stats::SkipReason;
@@ -215,18 +227,26 @@ fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Result<Spanned<MirExpr>, SkipReas
             let mir_args = args.iter().map(lower_expr).collect::<Result<Vec<_>, _>>()?;
             MirExpr::Construct(wrap(
                 MirConstruct {
-                    ctor: *ctor_id,
+                    ctor: MirCtor::User(*ctor_id),
                     args: mir_args,
                 },
                 expr,
             ))
         }
-        // Built-in ctors (`Result.Ok` / `Option.Some` / etc.) don't
-        // carry user-program `CtorId`s. Wave 3c-i will introduce a
-        // typed identity for them — until then, fns that construct
-        // them get dropped.
-        ResolvedExpr::Ctor(ResolvedCtor::Builtin(_), _) => {
-            return Err(SkipReason::BuiltinCtorConstruction);
+        // Wave 3c-i: built-in ctors (`Result.Ok` / `Result.Err` /
+        // `Option.Some` / `Option.None`) lower through
+        // `MirCtor::Builtin`, riding the same `MirConstruct` shape
+        // as user ctors. Backends pick their final emit; until
+        // then `Construct(Builtin(_), …)` is the canonical form.
+        ResolvedExpr::Ctor(ResolvedCtor::Builtin(bc), args) => {
+            let mir_args = args.iter().map(lower_expr).collect::<Result<Vec<_>, _>>()?;
+            MirExpr::Construct(wrap(
+                MirConstruct {
+                    ctor: MirCtor::Builtin(*bc),
+                    args: mir_args,
+                },
+                expr,
+            ))
         }
         ResolvedExpr::Ctor(ResolvedCtor::Unresolved { .. }, _) => {
             return Err(SkipReason::UnresolvedCtor);
@@ -372,25 +392,44 @@ fn lower_pattern(
             MirPattern::Tuple(mir_items)
         }
         ResolvedPattern::Ctor(ResolvedCtor::User { ctor_id, .. }, names) => {
-            let mut bindings = Vec::with_capacity(names.len());
-            for _ in names {
-                let slot = take_slot(slots, cursor)?;
-                bindings.push(LocalId(u32::from(slot)));
-            }
+            let bindings = take_pattern_bindings(slots, cursor, names.len())?;
             MirPattern::Ctor {
-                ctor: *ctor_id,
+                ctor: MirCtor::User(*ctor_id),
                 bindings,
             }
         }
-        // Wave 3c-i — built-in / unresolved ctor patterns get typed
-        // identity alongside their construction-side counterparts.
-        ResolvedPattern::Ctor(ResolvedCtor::Builtin(_), _) => {
-            return Err(SkipReason::BuiltinCtorPattern);
+        // Wave 3c-i — built-in ctor patterns ride the same shape
+        // as user-ctor patterns via `MirCtor::Builtin`.
+        ResolvedPattern::Ctor(ResolvedCtor::Builtin(bc), names) => {
+            let bindings = take_pattern_bindings(slots, cursor, names.len())?;
+            MirPattern::Ctor {
+                ctor: MirCtor::Builtin(*bc),
+                bindings,
+            }
         }
+        // Unresolved ctors still drop — typechecker already
+        // surfaced the error; MIR refuses to emit half-resolved
+        // identity.
         ResolvedPattern::Ctor(ResolvedCtor::Unresolved { .. }, _) => {
             return Err(SkipReason::UnresolvedCtor);
         }
     })
+}
+
+/// Helper for ctor-pattern lowering — consume `arity` slots in
+/// preorder. Used by both user-ctor and built-in-ctor branches so
+/// the slot-cursor advance rule lives in one place.
+fn take_pattern_bindings(
+    slots: &[u16],
+    cursor: &mut usize,
+    arity: usize,
+) -> Result<Vec<LocalId>, SkipReason> {
+    let mut bindings = Vec::with_capacity(arity);
+    for _ in 0..arity {
+        let slot = take_slot(slots, cursor)?;
+        bindings.push(LocalId(u32::from(slot)));
+    }
+    Ok(bindings)
 }
 
 fn take_slot(slots: &[u16], cursor: &mut usize) -> Result<u16, SkipReason> {

--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -79,8 +79,9 @@ pub mod lower;
 pub mod program;
 pub mod stats;
 
+pub use crate::ir::hir::BuiltinCtor;
 pub use expr::{
-    MirBinOp, MirCall, MirCallee, MirConstruct, MirEffectAnnotation, MirExpr,
+    MirBinOp, MirCall, MirCallee, MirConstruct, MirCtor, MirEffectAnnotation, MirExpr,
     MirIndependentProduct, MirLet, MirMatch, MirMatchArm, MirPattern, MirProject, MirRecordCreate,
     MirRecordField, MirRecordUpdate, MirStrPart, MirTailCall,
 };

--- a/tests/mir_phase2_model_spec.rs
+++ b/tests/mir_phase2_model_spec.rs
@@ -12,8 +12,8 @@
 
 use aver::ast::{BinOp, Literal, Spanned};
 use aver::ir::mir::{
-    LocalId, MirBinOp, MirCall, MirCallee, MirEffectAnnotation, MirExpr, MirFn, MirLet, MirMatch,
-    MirMatchArm, MirParam, MirPattern, MirProgram,
+    LocalId, MirBinOp, MirCall, MirCallee, MirCtor, MirEffectAnnotation, MirExpr, MirFn, MirLet,
+    MirMatch, MirMatchArm, MirParam, MirPattern, MirProgram,
 };
 use aver::ir::{CtorId, FnId};
 
@@ -112,13 +112,13 @@ fn pinned_decision_identity_is_typed() {
     assert_eq!(callee_id, fn_id(42));
 
     let ctor_pattern = MirPattern::Ctor {
-        ctor: ctor_id(7),
+        ctor: MirCtor::User(ctor_id(7)),
         bindings: vec![LocalId(0)],
     };
     let MirPattern::Ctor { ctor, bindings } = ctor_pattern else {
         unreachable!()
     };
-    assert_eq!(ctor, ctor_id(7));
+    assert_eq!(ctor, MirCtor::User(ctor_id(7)));
     assert_eq!(bindings, vec![LocalId(0)]);
 }
 

--- a/tests/mir_phase2b_dump_spec.rs
+++ b/tests/mir_phase2b_dump_spec.rs
@@ -9,8 +9,8 @@
 
 use aver::ast::{BinOp, Literal, Spanned};
 use aver::ir::mir::{
-    LocalId, MirBinOp, MirCall, MirCallee, MirEffectAnnotation, MirExpr, MirFn, MirLet, MirMatch,
-    MirMatchArm, MirParam, MirPattern, MirProgram,
+    LocalId, MirBinOp, MirCall, MirCallee, MirCtor, MirEffectAnnotation, MirExpr, MirFn, MirLet,
+    MirMatch, MirMatchArm, MirParam, MirPattern, MirProgram,
 };
 use aver::ir::{CtorId, FnId};
 
@@ -173,7 +173,7 @@ fn ctor_pattern_dump_uses_ctor_id() {
     // pattern: Module.Variant(b1) — make sure CtorId appears (not
     // a string name) so reviewers can confirm identity wiring.
     let p = MirPattern::Ctor {
-        ctor: CtorId(7),
+        ctor: MirCtor::User(CtorId(7)),
         bindings: vec![LocalId(0)],
     };
     // Use the arm-rendering path via a tiny Match.

--- a/tests/mir_phase3_coverage_gate.rs
+++ b/tests/mir_phase3_coverage_gate.rs
@@ -38,11 +38,11 @@ fn lower_stats(source: &str) -> aver::ir::mir::LowerStats {
 
 #[test]
 fn conservation_lowered_plus_skipped_equals_total() {
-    // Mix of one wave-1 supported fn and one wave-3c-bound fn
-    // (`Result.Ok` construction). Total fns seen = 2; every fn
-    // accounted for in `lowered` or `skipped`.
+    // Mix of one wave-1 supported fn and one fn that still drops
+    // (list literal — wave 3c-iv territory). Total fns seen = 2;
+    // every fn accounted for in `lowered` or `skipped`.
     let stats = lower_stats(
-        "fn keep(x: Int) -> Int\n    x + 1\n\nfn drops_me() -> Result<Int, String>\n    Result.Ok(1)\n",
+        "fn keep(x: Int) -> Int\n    x + 1\n\nfn drops_me() -> List<Int>\n    [1, 2, 3]\n",
     );
     assert_eq!(
         stats.total(),
@@ -74,17 +74,24 @@ fn coverage_ratio_pins_one_for_empty_program() {
 }
 
 #[test]
-fn builtin_ctor_construction_attributes_to_dedicated_reason() {
+fn wave_3c_i_builtin_ctor_construction_no_longer_drops() {
+    // Wave 3c-i landed typed identity for built-in ctors. A fn
+    // whose body is `Result.Ok(x)` now lowers cleanly — its skip
+    // counter for `BuiltinCtorConstruction` must be 0.
     let stats = lower_stats("fn makes_ok(x: Int) -> Result<Int, String>\n    Result.Ok(x)\n");
-    assert_eq!(stats.lowered, 0, "fn constructing Result.Ok must drop");
+    assert_eq!(
+        stats.lowered, 1,
+        "Result.Ok construction must lower after wave 3c-i: {:?}",
+        stats
+    );
     let count = stats
         .skipped
         .get(&SkipReason::BuiltinCtorConstruction)
         .copied()
         .unwrap_or(0);
     assert_eq!(
-        count, 1,
-        "expected BuiltinCtorConstruction = 1, got {:?}",
+        count, 0,
+        "BuiltinCtorConstruction must be 0 after wave 3c-i, got {:?}",
         stats.skipped
     );
 }

--- a/tests/mir_phase3_wave2_lowering.rs
+++ b/tests/mir_phase3_wave2_lowering.rs
@@ -107,13 +107,17 @@ fn lowers_record_update() {
 }
 
 #[test]
-fn builtin_ctor_fn_is_silently_dropped() {
-    // `Result.Ok(_)` is a built-in constructor — wave 2 leaves it
-    // for wave 3 (needs typed builtin identity). The lowerer must
-    // not panic; the fn just doesn't show up in the dump.
+fn builtin_ctor_fn_lowers_after_wave_3c_i() {
+    // `Result.Ok(_)` is a built-in constructor. Wave 2 dropped fns
+    // touching them; wave 3c-i landed `MirCtor::Builtin` so the fn
+    // now lowers cleanly with the canonical builtin name in the dump.
     let dump = lower("fn ok_seven() -> Result<Int, String>\n    Result.Ok(7)\n");
     assert!(
-        !dump.contains("fn ok_seven"),
-        "built-in ctor fn shouldn't be lowered in wave 2:\n{dump}"
+        dump.contains("fn ok_seven"),
+        "built-in ctor fn must lower after wave 3c-i:\n{dump}"
+    );
+    assert!(
+        dump.contains("Result.Ok("),
+        "dump should render the canonical builtin name (`Result.Ok`):\n{dump}"
     );
 }

--- a/tests/mir_phase3_wave3b_match_lowering.rs
+++ b/tests/mir_phase3_wave3b_match_lowering.rs
@@ -124,25 +124,30 @@ fn user_ctor_pattern_lowers_through_ctor_id() {
 }
 
 #[test]
-fn builtin_ctor_pattern_drops_the_fn() {
-    // `match Result.Ok(...) { Result.Ok(v) -> v; Result.Err(_) -> 0 }`
-    // — the ctor patterns reference `Result.Ok` / `Result.Err`,
-    // which are *built-in* ctors. Wave 3b drops the whole fn from
-    // MIR so wave 3c can later land typed identity for built-in
-    // result/option shapes.
-    //
-    // We pair the dropped fn with a wave-2 fn so the dump still
-    // has something to render — the assertion is that
-    // `drops_me` is absent.
+fn wave_3c_i_builtin_ctor_pattern_lowers() {
+    // Wave 3c-i landed typed identity for built-in ctors, so the
+    // wave-3b drop has flipped: a fn matching on `Result.Ok` /
+    // `Result.Err` now lowers cleanly. Both arms render via
+    // `MirPattern::Ctor { ctor: MirCtor::Builtin(_), … }`, and
+    // the dump renders the canonical builtin name (`Result.Ok` /
+    // `Result.Err`), not a fresh `CtorId(N)`.
     let dump = lower(
-        "fn keep(x: Int) -> Int\n    x + 1\n\nfn drops_me(r: Result<Int, String>) -> Int\n    match r\n        Result.Ok(v) -> v\n        Result.Err(_) -> 0\n",
+        "fn keep(x: Int) -> Int\n    x + 1\n\nfn match_result(r: Result<Int, String>) -> Int\n    match r\n        Result.Ok(v) -> v\n        Result.Err(_) -> 0\n",
     );
     assert!(
         dump.contains("fn keep"),
         "wave-2 fn should still lower:\n{dump}"
     );
     assert!(
-        !dump.contains("fn drops_me"),
-        "fn matching on built-in Result ctors must be dropped until wave 3c:\n{dump}"
+        dump.contains("fn match_result"),
+        "fn matching on built-in Result ctors must lower after wave 3c-i:\n{dump}"
+    );
+    assert!(
+        dump.contains("Result.Ok(%"),
+        "Result.Ok arm should render its canonical builtin name:\n{dump}"
+    );
+    assert!(
+        dump.contains("Result.Err(%"),
+        "Result.Err arm should render its canonical builtin name:\n{dump}"
     );
 }

--- a/tests/mir_phase3_wave3c_i_builtin_ctors.rs
+++ b/tests/mir_phase3_wave3c_i_builtin_ctors.rs
@@ -1,0 +1,139 @@
+//! Phase 3 wave 3c-i of #252 — typed identity for built-in
+//! constructors (`Result.Ok` / `Result.Err` / `Option.Some` /
+//! `Option.None`) in MIR.
+//!
+//! Construction and pattern sides ride the same shape as user
+//! ctors via `MirCtor::Builtin(BuiltinCtor)`. The dump renders
+//! the canonical builtin name unambiguously (`Result.Ok` /
+//! `Result.Err` / `Option.Some` / `Option.None`) so backends and
+//! reviewers can tell user vs builtin at a glance.
+//!
+//! End-to-end: parse → pipeline → lower → dump.
+
+use aver::ir::mir::lower_program;
+use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
+use aver::source::parse_source;
+
+fn lower(source: &str) -> String {
+    let mut items = parse_source(source).unwrap_or_else(|e| panic!("parse: {e}"));
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    let tc = result.typecheck.as_ref().expect("typecheck requested");
+    assert!(tc.errors.is_empty(), "typecheck failed: {:?}", tc.errors);
+    let program = lower_program(&result.resolved_items);
+    format!("{program}")
+}
+
+#[test]
+fn result_ok_construction_renders_with_canonical_name() {
+    let dump = lower("fn ok_one() -> Result<Int, String>\n    Result.Ok(1)\n");
+    assert!(dump.contains("fn ok_one"), "fn must lower:\n{dump}");
+    assert!(
+        dump.contains("Result.Ok(Int(1))"),
+        "Result.Ok construction should render with the canonical name + arg:\n{dump}"
+    );
+}
+
+#[test]
+fn result_err_construction_renders_with_canonical_name() {
+    let dump = lower("fn err_msg() -> Result<Int, String>\n    Result.Err(\"boom\")\n");
+    assert!(dump.contains("fn err_msg"), "fn must lower:\n{dump}");
+    // Literal::String renders as `Str(...)` in the dump (matches
+    // typecheck-stamp convention).
+    assert!(
+        dump.contains("Result.Err(Str(\"boom\"))"),
+        "Result.Err construction should render with the canonical name + arg:\n{dump}"
+    );
+}
+
+#[test]
+fn option_some_construction_renders_with_canonical_name() {
+    let dump = lower("fn some_seven() -> Option<Int>\n    Option.Some(7)\n");
+    assert!(dump.contains("fn some_seven"), "fn must lower:\n{dump}");
+    assert!(
+        dump.contains("Option.Some(Int(7))"),
+        "Option.Some construction should render with the canonical name + arg:\n{dump}"
+    );
+}
+
+// NOTE: there's no `option_none_is_nullary_construction` test
+// because bare `Option.None` as a body expression currently lowers
+// to `ResolvedExpr::Attr(Ident("Option"), "None")` rather than
+// `Ctor(Builtin(OptionNone), [])` — a preexisting resolver gap
+// for nullary builtin ctors in value position. Pattern-position
+// `Option.None` (which goes through a different parser path) is
+// covered by `option_match_lowers_with_none_nullary_pattern`
+// below and works correctly. Fixing the value-position case is
+// orthogonal to wave 3c-i.
+
+#[test]
+fn result_match_lowers_via_builtin_ctor_pattern() {
+    // fn classify(r: Result<Int, String>) -> Int
+    //   match r
+    //     Result.Ok(v) -> v
+    //     Result.Err(_) -> 0
+    let dump = lower(
+        "fn classify(r: Result<Int, String>) -> Int\n    match r\n        Result.Ok(v) -> v\n        Result.Err(_) -> 0\n",
+    );
+    assert!(dump.contains("fn classify"), "fn must lower:\n{dump}");
+    // Both arms appear with canonical builtin names.
+    assert!(
+        dump.contains("Result.Ok(%"),
+        "Result.Ok arm should render builtin name + bound slot:\n{dump}"
+    );
+    assert!(
+        dump.contains("Result.Err(%"),
+        "Result.Err arm should render builtin name + bound slot:\n{dump}"
+    );
+    // No stray `CtorId(N)` for the builtin arms — those would
+    // indicate the lowerer fell back to user-ctor identity.
+    let cid_count = dump.matches("CtorId(").count();
+    assert_eq!(
+        cid_count, 0,
+        "no CtorId numeric identity should appear for built-in arms:\n{dump}"
+    );
+}
+
+#[test]
+fn option_match_lowers_with_none_nullary_pattern() {
+    // fn unwrap_or_zero(o: Option<Int>) -> Int
+    //   match o
+    //     Option.Some(v) -> v
+    //     Option.None    -> 0
+    let dump = lower(
+        "fn unwrap_or_zero(o: Option<Int>) -> Int\n    match o\n        Option.Some(v) -> v\n        Option.None -> 0\n",
+    );
+    assert!(dump.contains("fn unwrap_or_zero"), "fn must lower:\n{dump}");
+    assert!(
+        dump.contains("Option.Some(%"),
+        "Option.Some arm should render builtin name + bound slot:\n{dump}"
+    );
+    // Option.None is nullary in pattern position — empty bindings.
+    assert!(
+        dump.contains("Option.None()"),
+        "Option.None arm should render as zero-arg pattern:\n{dump}"
+    );
+}
+
+#[test]
+fn user_and_builtin_ctors_coexist_in_dump() {
+    // Sanity: user-ctor identity stays numeric (`CtorId(N)`) while
+    // built-in ctor identity stays named. Both lower through the
+    // same `MirConstruct` / `MirPattern::Ctor` shape.
+    let dump = lower(
+        "type Shape\n  Circle(Int)\n  Square(Int)\n\nfn area(s: Shape) -> Result<Int, String>\n    match s\n        Shape.Circle(r) -> Result.Ok(r)\n        Shape.Square(side) -> Result.Ok(side)\n",
+    );
+    assert!(
+        dump.contains("CtorId("),
+        "user Shape variants must still render via CtorId(N):\n{dump}"
+    );
+    assert!(
+        dump.contains("Result.Ok("),
+        "Result.Ok construction must render via canonical builtin name:\n{dump}"
+    );
+}


### PR DESCRIPTION
## Summary

Built-in constructors (`Result.Ok` / `Result.Err` / `Option.Some` / `Option.None`) now lower through MIR with typed identity. New `MirCtor { User(CtorId), Builtin(BuiltinCtor) }` enum discriminates user vs language-level at the variant level — backends pattern-match without numeric collision risk, dump renders canonical builtin names.

`MirConstruct.ctor` and `MirPattern::Ctor.ctor` both switch from raw `CtorId` to `MirCtor`. The existing `BuiltinCtor` enum from `crate::ir::hir` is reused — no parallel MIR-private copy.

Coverage gate impact: `SkipReason::BuiltinCtorConstruction` and `BuiltinCtorPattern` drop out of `LowerStats.skipped` on the test corpus. Fns that touch Result/Option no longer disappear silently.

## Why before `Try`

Peer review pinned built-in ctors before `Try` in wave 3c. Empirically confirmed: well-typed Aver fns using `?` always also construct a `Result.Ok` in the same body (early-return + happy-path), so the `Try` skip is shadowed by the built-in-ctor skip. Wave 3c-ii can now land Try lowering and have it actually fire on the corpus.

## Test plan
- [x] `cargo build` clean
- [x] `cargo fmt`
- [x] `cargo clippy --tests` clean
- [x] `tests/mir_phase3_wave3c_i_builtin_ctors.rs` 6/6 ✅
  - `Result.Ok` / `Result.Err` / `Option.Some` construction render with canonical names
  - `match` on Result and Option lowers via `MirPattern::Ctor { ctor: MirCtor::Builtin(_), … }`
  - mixed user-Shape + builtin-Result fixture renders both identity kinds side-by-side
- [x] all existing MIR tests pass (41/41)
- [x] coverage gate flipped: `BuiltinCtorConstruction = 0` on the wave-3c-i fixture

## Out of scope (open follow-ups)
- Bare nullary `Option.None` in *value* position lowers to `Attr(Ident("Option"), "None")` — a preexisting resolver gap, not 3c-i scope. Pattern-position `Option.None` (different parser path) works.
- `SkipReason::BuiltinCtorConstruction` / `BuiltinCtorPattern` variants stay in the enum for historical attribution; can be removed once we're confident no future regression brings them back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)