### PR TITLE
vm: Phase 4b driver + parity proof — MIR-first compile with HIR fallback (#252 Phase 4)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -58,11 +58,6 @@ impl From<CompileError> for MirVmUnsupported {
 /// `FnCompiler`. Returns `Err(MirVmUnsupported)` for any MirExpr
 /// variant outside the Phase 4 subset — the caller drops back to
 /// HIR compilation in that case.
-///
-/// Dead-code-allowed until Phase 4b lands the driver
-/// (`compile_program_with_mir_fallback`) that actually invokes
-/// this walker on a `ProgramCompiler`-built `FnCompiler`.
-#[allow(dead_code)]
 pub(super) fn compile_mir_expr(
     fc: &mut FnCompiler<'_>,
     expr: &Spanned<MirExpr>,
@@ -164,9 +159,6 @@ pub(super) fn compile_mir_expr(
 /// with `RETURN`. Caller has already constructed `fc` with the
 /// right arity / local_count / local_slots — same path the HIR
 /// compiler takes through `compile_fn_with_scope`.
-///
-/// Dead-code-allowed until Phase 4b lands the driver.
-#[allow(dead_code)]
 pub(super) fn compile_mir_fn_body(
     fc: &mut FnCompiler<'_>,
     mir_fn: &MirFn,
@@ -216,7 +208,6 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
     }
 }
 
-#[allow(dead_code)]
 fn emit_binop_generic(fc: &mut FnCompiler<'_>, op: crate::ast::BinOp) {
     use crate::ast::BinOp::*;
     match op {

--- a/src/vm/compiler/mod.rs
+++ b/src/vm/compiler/mod.rs
@@ -56,6 +56,7 @@ pub fn compile_program_with_modules(
         source_file,
         ModuleSource::Disk(module_root),
         analysis,
+        None,
     )
 }
 
@@ -77,6 +78,37 @@ pub fn compile_program_with_loaded_modules(
         source_file,
         ModuleSource::Loaded(loaded),
         analysis,
+        None,
+    )
+}
+
+/// Phase 4b of #252: compile with MIR-first dispatch + HIR
+/// fallback. Per fn: if the fn's body lowers cleanly to MIR
+/// *and* MIR-emit produces bytecode, use that chunk; otherwise
+/// fall back to the existing HIR walker. The fallback is
+/// deliberate — every fn that lands in `MirVmUnsupported`
+/// territory (Match / Try / TailCall / Construct / Record* /
+/// Project / List / Tuple / Map / InterpolatedStr /
+/// IndependentProduct / builtin callees / first-class fn
+/// values) keeps the well-tested HIR shape.
+///
+/// Same I/O contract as [`compile_program`]; the only
+/// difference is the per-fn dispatch.
+pub fn compile_program_with_mir_fallback(
+    items: &[ResolvedTopLevel],
+    symbols: &SymbolTable,
+    arena: &mut Arena,
+    analysis: Option<&crate::ir::AnalysisResult>,
+) -> Result<(CodeStore, Vec<NanValue>), CompileError> {
+    let mir = crate::ir::mir::lower_program(items);
+    compile_program_inner(
+        items,
+        symbols,
+        arena,
+        "",
+        ModuleSource::Disk(None),
+        analysis,
+        Some(&mir),
     )
 }
 
@@ -92,6 +124,7 @@ fn compile_program_inner(
     source_file: &str,
     module_source: ModuleSource<'_>,
     analysis: Option<&crate::ir::AnalysisResult>,
+    mir_program: Option<&crate::ir::mir::MirProgram>,
 ) -> Result<(CodeStore, Vec<NanValue>), CompileError> {
     let mut compiler = ProgramCompiler::new();
     compiler.source_file = source_file.to_string();
@@ -181,7 +214,20 @@ fn compile_program_inner(
     for item in items {
         if let ResolvedTopLevel::FnDef(rfd) = item {
             let fn_id = compiler.code.find(&rfd.name).unwrap();
-            let chunk = compiler.compile_fn(rfd, symbols, arena)?;
+            // Phase 4b dispatch: if the caller supplied a
+            // `MirProgram` *and* MIR has a body for this fn
+            // *and* the MIR walker accepts the body, use the
+            // MIR-emitted chunk. Otherwise fall back to the
+            // HIR walker — same chunk path every other caller
+            // takes.
+            let chunk = if let Some(mir) = mir_program
+                && let Some(mir_fn) = mir.fn_by_id(rfd.fn_id)
+                && let Ok(mir_chunk) = compiler.compile_fn_via_mir(rfd, mir_fn, symbols, arena)
+            {
+                mir_chunk
+            } else {
+                compiler.compile_fn(rfd, symbols, arena)?
+            };
             compiler.code.functions[fn_id as usize] = chunk;
         }
     }
@@ -687,6 +733,58 @@ impl ProgramCompiler {
             ResolvedFnBody::Block(stmts) => fc.compile_body(stmts)?,
         }
 
+        Ok(fc.finish())
+    }
+
+    /// Phase 4b: emit a fn's bytecode by walking the MIR body
+    /// instead of the HIR body. Mirrors `compile_fn_with_scope`'s
+    /// `FnCompiler` setup exactly — same arity / local_count /
+    /// effects / aliased slots — so the resulting `FnChunk` is
+    /// drop-in for the HIR-emitted version when the MIR walker
+    /// covers the body shape.
+    fn compile_fn_via_mir(
+        &mut self,
+        rfd: &ResolvedFnDef,
+        mir_fn: &crate::ir::mir::MirFn,
+        symbols: &SymbolTable,
+        arena: &mut Arena,
+    ) -> Result<FnChunk, mir::MirVmUnsupported> {
+        let resolution = rfd.resolution.as_ref();
+        let local_count = resolution.map_or(rfd.params.len() as u16, |r| r.local_count);
+        let local_slots: HashMap<String, u16> = resolution
+            .map(|r| r.local_slots.as_ref().clone())
+            .unwrap_or_else(|| {
+                rfd.params
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (name, _))| (name.clone(), i as u16))
+                    .collect()
+            });
+
+        let empty_scope = HashMap::new();
+        let mut fc = FnCompiler::new(
+            &rfd.name,
+            rfd.params.len() as u8,
+            local_count,
+            rfd.effects
+                .iter()
+                .map(|effect| self.symbols.intern_name(&effect.node))
+                .collect(),
+            local_slots,
+            &self.global_names,
+            &empty_scope,
+            &self.code,
+            &mut self.symbols,
+            arena,
+            symbols,
+        );
+        fc.source_file = self.source_file.clone();
+        fc.note_line(rfd.line);
+        if let Some(res) = resolution {
+            fc.set_aliased_slots(res.aliased_slots.clone());
+        }
+
+        mir::compile_mir_fn_body(&mut fc, mir_fn)?;
         Ok(fc.finish())
     }
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -9,7 +9,8 @@ mod symbol;
 mod types;
 
 pub use compiler::{
-    compile_program, compile_program_with_loaded_modules, compile_program_with_modules,
+    compile_program, compile_program_with_loaded_modules, compile_program_with_mir_fallback,
+    compile_program_with_modules,
 };
 /// Phase 4 of #252 — MIR vertical slice for the VM. Re-exported
 /// so tests + future external consumers can reach

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -1,0 +1,160 @@
+//! Phase 4b of #252 — VM parity between HIR and MIR codegen
+//! paths.
+//!
+//! `compile_program` walks `ResolvedExpr` (HIR) and emits VM
+//! bytecode. `compile_program_with_mir_fallback` walks
+//! `MirExpr` for fns whose body fits the Phase 4 subset, falling
+//! back to the HIR walker otherwise. Both paths must produce
+//! identical VM-observable behavior — same `Value` from
+//! `run_named_function` on the same input.
+//!
+//! Phase 4 subset (per `src/vm/compiler/mir.rs`): Literal +
+//! Local + BinOp + Neg + Let + Call(Fn) + Return. Tests here
+//! exercise just that subset; fns outside it ride the HIR
+//! fallback and parity holds trivially.
+
+use aver::ast::TopLevel;
+use aver::ir::SymbolTable;
+use aver::ir::hir::{self, ResolvedTopLevel};
+use aver::lexer::Lexer;
+use aver::nan_value::{Arena, NanValue, NanValueConvert};
+use aver::parser::Parser;
+use aver::resolver;
+use aver::tco;
+use aver::value::Value;
+use aver::vm;
+
+fn parse(src: &str) -> Vec<TopLevel> {
+    let mut lexer = Lexer::new(src);
+    let tokens = lexer.tokenize().expect("lex failed");
+    let mut parser = Parser::new(tokens);
+    parser.parse().expect("parse failed")
+}
+
+fn resolve(items: &[TopLevel]) -> (Vec<ResolvedTopLevel>, SymbolTable) {
+    let symbols = SymbolTable::build(items, &[]);
+    let resolved = hir::resolve_program(&symbols, items);
+    (resolved, symbols)
+}
+
+/// Compile `src` through the requested path and call
+/// `fn_name(args)` on the result. Returns `Value` (decoded from
+/// `NanValue` against the path's own arena) so the test asserts
+/// run on a stable comparison form.
+fn run_via_path(src: &str, fn_name: &str, args: &[i64], path: Path) -> Value {
+    let mut items = parse(src);
+    tco::transform_program(&mut items);
+    resolver::resolve_program(&mut items);
+    let (resolved, symbols) = resolve(&items);
+
+    let mut arena = Arena::new();
+    let (code, globals) = match path {
+        Path::Hir => {
+            vm::compile_program(&resolved, &symbols, &mut arena, None).expect("HIR compile failed")
+        }
+        Path::MirFallback => {
+            vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None)
+                .expect("MIR-fallback compile failed")
+        }
+    };
+    let nv_args: Vec<NanValue> = args
+        .iter()
+        .map(|i| NanValue::new_int(*i, &mut arena))
+        .collect();
+    let mut machine = vm::VM::new(code, globals, arena);
+    let result = machine
+        .run_named_function(fn_name, &nv_args)
+        .expect("VM run failed");
+    result.to_value(&machine.arena)
+}
+
+enum Path {
+    Hir,
+    MirFallback,
+}
+
+#[test]
+fn double_parity_hir_vs_mir_fallback() {
+    let src = "fn double(x: Int) -> Int\n    x + x\n";
+    let hir = run_via_path(src, "double", &[7], Path::Hir);
+    let mir = run_via_path(src, "double", &[7], Path::MirFallback);
+    assert_eq!(
+        hir, mir,
+        "HIR and MIR-fallback paths must agree on double(7): HIR={hir:?}, MIR={mir:?}"
+    );
+    assert_eq!(hir, Value::Int(14), "double(7) should be 14");
+}
+
+#[test]
+fn arithmetic_chain_parity() {
+    // Two-fn corpus exercising CALL_KNOWN dispatch and inline
+    // arithmetic, both inside the Phase 4 subset.
+    let src = "fn double(x: Int) -> Int\n    x + x\n\nfn quad(y: Int) -> Int\n    double(y + y)\n";
+    let hir = run_via_path(src, "quad", &[3], Path::Hir);
+    let mir = run_via_path(src, "quad", &[3], Path::MirFallback);
+    assert_eq!(
+        hir, mir,
+        "HIR and MIR-fallback paths must agree on quad(3): HIR={hir:?}, MIR={mir:?}"
+    );
+    assert_eq!(hir, Value::Int(12), "quad(3) = double(6) = 12");
+}
+
+#[test]
+fn neg_parity() {
+    let src = "fn flip(x: Int) -> Int\n    -x\n";
+    let hir = run_via_path(src, "flip", &[5], Path::Hir);
+    let mir = run_via_path(src, "flip", &[5], Path::MirFallback);
+    assert_eq!(hir, mir);
+    assert_eq!(hir, Value::Int(-5));
+}
+
+/// Compile both paths and return the per-fn bytecode pair so
+/// tests can byte-compare specific chunks.
+fn compile_both(src: &str) -> (aver::vm::CodeStore, aver::vm::CodeStore) {
+    let mut items = parse(src);
+    tco::transform_program(&mut items);
+    resolver::resolve_program(&mut items);
+    let (resolved, symbols) = resolve(&items);
+    let mut a1 = Arena::new();
+    let mut a2 = Arena::new();
+    let (hir, _) =
+        vm::compile_program(&resolved, &symbols, &mut a1, None).expect("HIR compile failed");
+    let (mir, _) = vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut a2, None)
+        .expect("MIR-fallback compile failed");
+    (hir, mir)
+}
+
+#[test]
+fn bytecode_parity_for_double_in_phase_4_subset() {
+    // Same source → identical FnChunk.code between HIR and
+    // MIR-fallback paths for fns in the Phase 4 subset. This is
+    // the strongest possible parity assertion: not just runtime
+    // result, but actual emitted bytecode (LOAD_LOCAL / ADD /
+    // RETURN sequence) is byte-identical.
+    let (hir, mir) = compile_both("fn double(x: Int) -> Int\n    x + x\n");
+    let hir_fn = hir.get(hir.find("double").expect("double in HIR"));
+    let mir_fn = mir.get(mir.find("double").expect("double in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "double() bytecode must be byte-identical: HIR={:?}, MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
+    // `match` isn't in the Phase 4 subset → MIR-fallback path
+    // falls back to HIR. The fn must still appear in the output
+    // (HIR walker emits the chunk); only the dispatch differs.
+    let (hir, mir) = compile_both(
+        "fn first(xs: List<Int>) -> Int\n    match xs\n        [] -> 0\n        [h, ..t] -> h\n",
+    );
+    assert!(
+        hir.find("first").is_some(),
+        "first() should be present in HIR-only chunks"
+    );
+    assert!(
+        mir.find("first").is_some(),
+        "first() should still be present in MIR-fallback chunks (HIR fallback path)"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 4b — wires the MIR walker from #268 into a per-fn dispatcher. New entry `vm::compile_program_with_mir_fallback(items, symbols, arena, analysis)`:

- per fn: lower to MIR, try `compile_mir_fn_body`, fall back to HIR walker on `MirVmUnsupported`
- same I/O contract as `compile_program` — drop-in
- fallback is deliberate; the well-tested HIR shape keeps emitting for everything outside the Phase 4 subset

## Parity proof

`tests/mir_vm_parity.rs` — 5 tests:

1. **double_parity_hir_vs_mir_fallback** — `double(7) = 14` from both paths
2. **arithmetic_chain_parity** — `quad(3) = double(6) = 12` via CALL_KNOWN
3. **neg_parity** — `flip(5) = -5`
4. **bytecode_parity_for_double_in_phase_4_subset** — **byte-identical \`FnChunk.code\`** between HIR and MIR paths. Strongest possible parity assertion.
5. **match_fn_uses_hir_fallback_and_remains_present_in_mir_path** — fn outside subset still emitted (via fallback), no silent drops

All 5 pass.

The dead-code allows from #268 are dropped — every walker helper has a live caller now.

## Test plan
- [x] cargo fmt + clippy clean
- [x] 5/5 parity tests ✅
- [x] all 4 Phase 4a skeleton tests still pass
- [x] no regression on existing VM/HIR tests

## Phase 4c+ (out of scope)
- Extend MIR walker (Match, Try, Construct, ...) — broader corpus rides MIR
- Larger parity corpus (examples/core, examples/data)
- Per-fn dispatch counter on `CodeStore` for telemetry
- Switch default to MIR-fallback once coverage hits ~80%

🤖 Generated with [Claude Code](https://claude.com/claude-code)