### PR TITLE
vm: Phase 4c — extend MIR walker with Construct + Project (#252 Phase 4)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -30,7 +30,9 @@
 //! caller can fall back to HIR compilation for that fn.
 
 use crate::ast::Spanned;
-use crate::ir::mir::{MirCall, MirCallee, MirExpr, MirFn, MirLet, MirProgram};
+use crate::ir::hir::BuiltinCtor;
+use crate::ir::mir::{MirCall, MirCallee, MirCtor, MirExpr, MirFn, MirLet, MirProgram};
+use crate::nan_value::NanValue;
 use crate::vm::opcode::*;
 
 use super::{CompileError, FnCompiler};
@@ -137,13 +139,95 @@ pub(super) fn compile_mir_expr(
             fc.emit_op(RETURN);
             Ok(())
         }
+
+        // ── Phase 4c: ctor construction ─────────────────────────
+        MirExpr::Construct(spanned_construct) => {
+            let c = &spanned_construct.node;
+            match c.ctor {
+                MirCtor::Builtin(BuiltinCtor::ResultOk) => {
+                    emit_constructor_arg(fc, c.args.first())?;
+                    fc.emit_op(WRAP);
+                    fc.emit_u8(0);
+                    Ok(())
+                }
+                MirCtor::Builtin(BuiltinCtor::ResultErr) => {
+                    emit_constructor_arg(fc, c.args.first())?;
+                    fc.emit_op(WRAP);
+                    fc.emit_u8(1);
+                    Ok(())
+                }
+                MirCtor::Builtin(BuiltinCtor::OptionSome) => {
+                    emit_constructor_arg(fc, c.args.first())?;
+                    fc.emit_op(WRAP);
+                    fc.emit_u8(2);
+                    Ok(())
+                }
+                MirCtor::Builtin(BuiltinCtor::OptionNone) => {
+                    let idx = fc.add_constant(NanValue::NONE);
+                    fc.emit_op(LOAD_CONST);
+                    fc.emit_u16(idx);
+                    Ok(())
+                }
+                MirCtor::User(ctor_id) => {
+                    // CtorEntry → (owning_type, variant_name) →
+                    // canonical type name → arena type_id +
+                    // variant_id. Same path the HIR walker uses
+                    // for `ResolvedCtor::User`.
+                    let entry = fc.symbol_table.ctor_entry(ctor_id);
+                    let owning_type = entry.owning_type;
+                    let variant_name = entry.name.clone();
+                    let qualified_type_name = fc.canonical_type_name(owning_type)?;
+                    let arena_type_id =
+                        fc.resolve_type_id(&qualified_type_name).ok_or_else(|| {
+                            MirVmUnsupported::InnerError(CompileError {
+                                msg: format!(
+                                    "MIR-VM: unknown arena type for `{qualified_type_name}` \
+                                     (CtorId={ctor_id:?})"
+                                ),
+                            })
+                        })?;
+                    let variant_id =
+                        fc.arena.find_variant_id(arena_type_id, &variant_name).ok_or_else(
+                            || {
+                                MirVmUnsupported::InnerError(CompileError {
+                                    msg: format!(
+                                        "MIR-VM: unknown variant `{variant_name}` on `{qualified_type_name}`"
+                                    ),
+                                })
+                            },
+                        )?;
+                    for arg in &c.args {
+                        compile_mir_expr(fc, arg)?;
+                    }
+                    fc.emit_op(VARIANT_NEW);
+                    fc.emit_u16(arena_type_id as u16);
+                    fc.emit_u16(variant_id);
+                    fc.emit_u8(c.args.len() as u8);
+                    Ok(())
+                }
+            }
+        }
+
+        // ── Phase 4c: record field access ───────────────────────
+        MirExpr::Project(spanned_proj) => {
+            let p = &spanned_proj.node;
+            // RECORD_GET_NAMED is the universal path — VM resolves
+            // the field by symbol id at runtime. The HIR walker
+            // sometimes specializes to RECORD_GET when it can
+            // infer field index statically; that's a Phase 6
+            // optimization we skip here.
+            compile_mir_expr(fc, &p.base)?;
+            let field_symbol_id = fc.symbols.intern_name(&p.field);
+            fc.emit_op(RECORD_GET_NAMED);
+            fc.emit_u32(field_symbol_id);
+            Ok(())
+        }
+
         // Phase 4 subset boundary — everything else falls back.
         MirExpr::Match(_) => Err(MirVmUnsupported::UnsupportedExpr("Match")),
         MirExpr::TailCall(_) => Err(MirVmUnsupported::UnsupportedExpr("TailCall")),
-        MirExpr::Construct(_) => Err(MirVmUnsupported::UnsupportedExpr("Construct")),
         MirExpr::RecordCreate(_) => Err(MirVmUnsupported::UnsupportedExpr("RecordCreate")),
         MirExpr::RecordUpdate(_) => Err(MirVmUnsupported::UnsupportedExpr("RecordUpdate")),
-        MirExpr::Project(_) => Err(MirVmUnsupported::UnsupportedExpr("Project")),
         MirExpr::Try(_) => Err(MirVmUnsupported::UnsupportedExpr("Try")),
         MirExpr::List(_) => Err(MirVmUnsupported::UnsupportedExpr("List")),
         MirExpr::Tuple(_) => Err(MirVmUnsupported::UnsupportedExpr("Tuple")),
@@ -204,7 +288,27 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
             matches!(c.node.callee, MirCallee::Fn(_)) && c.node.args.iter().all(can_compile)
         }
         MirExpr::Return(inner) => can_compile(inner),
+        // Phase 4c additions:
+        MirExpr::Construct(c) => c.node.args.iter().all(can_compile),
+        MirExpr::Project(p) => can_compile(&p.node.base),
         _ => false,
+    }
+}
+
+/// Helper: emit a single ctor arg, or `LOAD_UNIT` when the ctor
+/// arg is absent (defensive — built-in Wrap-shaped ctors always
+/// take exactly one arg in well-typed Aver, but the lowerer
+/// only enforces that at the type level).
+fn emit_constructor_arg(
+    fc: &mut FnCompiler<'_>,
+    arg: Option<&Spanned<MirExpr>>,
+) -> Result<(), MirVmUnsupported> {
+    match arg {
+        Some(a) => compile_mir_expr(fc, a),
+        None => {
+            fc.emit_op(LOAD_UNIT);
+            Ok(())
+        }
     }
 }
 

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -142,6 +142,78 @@ fn bytecode_parity_for_double_in_phase_4_subset() {
 }
 
 #[test]
+fn user_ctor_construction_parity() {
+    // Phase 4c — `MirExpr::Construct(MirCtor::User(_))` walks
+    // through the CtorEntry → owning_type lookup and emits
+    // VARIANT_NEW just like the HIR walker. We verify by
+    // (a) running an Int-extractor through both paths, and
+    // (b) byte-comparing the FnChunk.
+    let src = "type Shape\n  Circle(Int)\n  Square(Int)\n\nfn makeCircle(r: Int) -> Shape\n    Shape.Circle(r)\n\nfn area(s: Shape) -> Int\n    match s\n        Shape.Circle(r) -> r\n        Shape.Square(side) -> side\n\nfn make_and_extract(r: Int) -> Int\n    area(makeCircle(r))\n";
+    let hir = run_via_path(src, "make_and_extract", &[7], Path::Hir);
+    let mir = run_via_path(src, "make_and_extract", &[7], Path::MirFallback);
+    assert_eq!(
+        hir, mir,
+        "User ctor + match parity: HIR={hir:?}, MIR={mir:?}"
+    );
+    assert_eq!(hir, Value::Int(7));
+}
+
+#[test]
+fn bytecode_parity_for_user_ctor_construction() {
+    // Just makeCircle alone — body is `Shape.Circle(r)`, fully
+    // inside the Phase 4c subset. The fn's bytecode must match
+    // exactly between HIR and MIR-fallback paths.
+    let (hir, mir) = compile_both(
+        "type Shape\n  Circle(Int)\n  Square(Int)\n\nfn makeCircle(r: Int) -> Shape\n    Shape.Circle(r)\n",
+    );
+    let hir_fn = hir.get(hir.find("makeCircle").expect("makeCircle in HIR"));
+    let mir_fn = mir.get(mir.find("makeCircle").expect("makeCircle in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "VARIANT_NEW emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn builtin_ctor_wrap_parity() {
+    // `Result.Ok(x)` lowers to MirCtor::Builtin(ResultOk) in
+    // MIR. The Phase 4c walker emits the same WRAP 0 sequence
+    // the HIR walker emits.
+    let src = "fn wrap_ok(x: Int) -> Result<Int, String>\n    Result.Ok(x)\n";
+    let (hir, mir) = compile_both(src);
+    let hir_fn = hir.get(hir.find("wrap_ok").expect("wrap_ok in HIR"));
+    let mir_fn = mir.get(mir.find("wrap_ok").expect("wrap_ok in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "WRAP emit for Result.Ok must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn record_field_access_parity() {
+    // `MirExpr::Project` → RECORD_GET_NAMED, mirroring the HIR
+    // path. We verify per-fn bytecode parity on a fn that takes
+    // a record and projects a field.
+    //
+    // Note: the HIR walker may optimize to RECORD_GET (typed
+    // index) when it can infer the type statically; the MIR
+    // walker uses RECORD_GET_NAMED universally for now. The
+    // record-creation call (`P(...)`) currently isn't in the
+    // Phase 4 subset (RecordCreate is still wave-future), so
+    // we test field access on a parameter — that path stays
+    // pure Project in both walkers.
+    let src = "record P\n  x: Int\n  y: Int\n\nfn px(p: P) -> Int\n    p.x\n";
+    let (_hir, _mir) = compile_both(src);
+    // We don't byte-compare here because HIR may use the typed
+    // RECORD_GET op while MIR uses RECORD_GET_NAMED — both
+    // semantically equivalent. Instead verify both compiled.
+    // Full bytecode parity for Project lands when MIR carries
+    // type stamps on its sub-nodes (Phase 6).
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output


### PR DESCRIPTION
## Summary

Phase 4c extends the MIR walker (Phase 4a/4b) to cover constructor construction and record-field projection. Subset now:

- Literal + Local + BinOp + Neg + Let + Call(Fn) + Return (Phase 4a)
- + **Construct(User CtorId)** → VARIANT_NEW via CtorEntry → owning_type → arena
- + **Construct(Builtin BuiltinCtor)** → WRAP{0,1,2} / LOAD_CONST NONE same as HIR
- + **Project { base, field }** → RECORD_GET_NAMED

## New parity tests

4 new tests (9 total in `tests/mir_vm_parity.rs`):

| Test | What it proves |
|---|---|
| `user_ctor_construction_parity` | `Shape.Circle(r)` → match roundtrip, runtime parity |
| `bytecode_parity_for_user_ctor_construction` | byte-identical VARIANT_NEW emit |
| `builtin_ctor_wrap_parity` | byte-identical WRAP 0 emit for `Result.Ok(x)` |
| `record_field_access_parity` | Project compiles on both paths |

All 9 pass. Phase 4a skeleton tests stay green. No regression on full suite.

## Test plan
- [x] cargo fmt + clippy clean
- [x] 9/9 parity tests ✅
- [x] 4/4 skeleton tests ✅

## What's left for Phase 4+
- Try, TailCall, RecordCreate/Update, collections (List/Tuple/Map), Match (needs MirPattern walker), MirCallee::Builtin (CALL_BUILTIN)
- Each adds another slice of the corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)