### PR TITLE
vm: Phase 4d — extend MIR walker with Try + TailCall (#252 Phase 4)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -269,7 +269,6 @@ pub(super) fn compile_mir_expr(
         MirExpr::Match(_) => Err(MirVmUnsupported::UnsupportedExpr("Match")),
         MirExpr::RecordCreate(_) => Err(MirVmUnsupported::UnsupportedExpr("RecordCreate")),
         MirExpr::RecordUpdate(_) => Err(MirVmUnsupported::UnsupportedExpr("RecordUpdate")),
-        MirExpr::Try(_) => Err(MirVmUnsupported::UnsupportedExpr("Try")),
         MirExpr::List(_) => Err(MirVmUnsupported::UnsupportedExpr("List")),
         MirExpr::Tuple(_) => Err(MirVmUnsupported::UnsupportedExpr("Tuple")),
         MirExpr::MapLiteral(_) => Err(MirVmUnsupported::UnsupportedExpr("MapLiteral")),

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -223,9 +223,50 @@ pub(super) fn compile_mir_expr(
             Ok(())
         }
 
+        // ── Phase 4d: `?` propagation ───────────────────────────
+        MirExpr::Try(inner) => {
+            compile_mir_expr(fc, inner)?;
+            fc.emit_op(PROPAGATE_ERR);
+            Ok(())
+        }
+
+        // ── Phase 4d: tail-call dispatch ────────────────────────
+        MirExpr::TailCall(spanned_tail) => {
+            let tc = &spanned_tail.node;
+            for arg in &tc.args {
+                compile_mir_expr(fc, arg)?;
+            }
+            let target_name = fc.canonical_fn_name(tc.target)?;
+            // Self-recursive vs cross-fn dispatch. The HIR walker
+            // also derives an `owned_mask` from last-use
+            // annotations; MIR doesn't carry last-use bits yet
+            // (Phase 6 work), so we emit `0` — bytecode stays
+            // semantically equivalent, the optimizer pass can
+            // later rebuild the mask off MIR liveness.
+            if target_name == fc.name() {
+                fc.emit_op(TAIL_CALL_SELF);
+                fc.emit_u8(tc.args.len() as u8);
+                fc.emit_u8(0);
+            } else {
+                let vm_fn_id = fc.resolve_fn_id_by_name(&target_name).ok_or_else(|| {
+                    MirVmUnsupported::InnerError(CompileError {
+                        msg: format!(
+                            "MIR-VM: unresolved tail-call target `{target_name}` \
+                             (FnId={:?})",
+                            tc.target
+                        ),
+                    })
+                })?;
+                fc.emit_op(TAIL_CALL_KNOWN);
+                fc.emit_u16(vm_fn_id as u16);
+                fc.emit_u8(tc.args.len() as u8);
+                fc.emit_u8(0);
+            }
+            Ok(())
+        }
+
         // Phase 4 subset boundary — everything else falls back.
         MirExpr::Match(_) => Err(MirVmUnsupported::UnsupportedExpr("Match")),
-        MirExpr::TailCall(_) => Err(MirVmUnsupported::UnsupportedExpr("TailCall")),
         MirExpr::RecordCreate(_) => Err(MirVmUnsupported::UnsupportedExpr("RecordCreate")),
         MirExpr::RecordUpdate(_) => Err(MirVmUnsupported::UnsupportedExpr("RecordUpdate")),
         MirExpr::Try(_) => Err(MirVmUnsupported::UnsupportedExpr("Try")),
@@ -291,6 +332,9 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
         // Phase 4c additions:
         MirExpr::Construct(c) => c.node.args.iter().all(can_compile),
         MirExpr::Project(p) => can_compile(&p.node.base),
+        // Phase 4d additions:
+        MirExpr::Try(inner) => can_compile(inner),
+        MirExpr::TailCall(t) => t.node.args.iter().all(can_compile),
         _ => false,
     }
 }

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -214,6 +214,58 @@ fn record_field_access_parity() {
 }
 
 #[test]
+fn try_propagation_parity_runtime() {
+    // `relay(7)` should succeed with `Result.Ok(7)`. Both paths
+    // emit PROPAGATE_ERR after the inner `fetch()` call; the
+    // happy-path Result.Ok wrapper goes through WRAP 0.
+    let src = "fn fetch(x: Int) -> Result<Int, String>\n    Result.Ok(x)\n\nfn relay(x: Int) -> Result<Int, String>\n    Result.Ok(fetch(x)?)\n";
+    let hir = run_via_path(src, "relay", &[7], Path::Hir);
+    let mir = run_via_path(src, "relay", &[7], Path::MirFallback);
+    assert_eq!(
+        hir, mir,
+        "Try (`?`) propagation parity: HIR={hir:?}, MIR={mir:?}"
+    );
+}
+
+#[test]
+fn bytecode_parity_for_try_propagation() {
+    // Per-fn bytecode parity: `relay` body lowers to
+    //   Construct(Builtin(ResultOk), [Try(Call(fetch, [x]))])
+    // → CALL_KNOWN fetch / PROPAGATE_ERR / WRAP 0 / RETURN
+    // Same byte sequence from both walkers.
+    let (hir, mir) = compile_both(
+        "fn fetch(x: Int) -> Result<Int, String>\n    Result.Ok(x)\n\nfn relay(x: Int) -> Result<Int, String>\n    Result.Ok(fetch(x)?)\n",
+    );
+    let hir_fn = hir.get(hir.find("relay").expect("relay in HIR"));
+    let mir_fn = mir.get(mir.find("relay").expect("relay in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "Try emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn tail_call_runtime_parity() {
+    // Self-recursive countdown: tail call to self inside a match
+    // arm body. The match itself rides HIR fallback (out of
+    // Phase 4 subset), so this is technically an HIR-vs-HIR
+    // parity test — both paths produce identical chunks
+    // because the MIR path drops to HIR for the whole fn. Still
+    // verifies the MIR walker doesn't break tail-call-bearing
+    // fns when it can't cover them.
+    let src =
+        "fn countdown(n: Int) -> Int\n    match n\n        0 -> 0\n        _ -> countdown(n - 1)\n";
+    let hir = run_via_path(src, "countdown", &[10], Path::Hir);
+    let mir = run_via_path(src, "countdown", &[10], Path::MirFallback);
+    assert_eq!(
+        hir, mir,
+        "countdown(10) must agree: HIR={hir:?}, MIR={mir:?}"
+    );
+    assert_eq!(hir, Value::Int(0));
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output


### PR DESCRIPTION
## Summary

Phase 4d extends the MIR walker to cover `?` propagation and tail calls. Subset now:

- 4a/4b: Literal + Local + BinOp + Neg + Let + Call(Fn) + Return
- 4c: Construct (User CtorId / Builtin BuiltinCtor) + Project
- **4d: Try (PROPAGATE_ERR) + TailCall (TAIL_CALL_SELF / TAIL_CALL_KNOWN)**

## What lands

- `MirExpr::Try(inner)` → walk inner + emit PROPAGATE_ERR. VM does the tag-check + early-return.
- `MirExpr::TailCall { target, args }` → walk args, then:
  - self-recursive → `TAIL_CALL_SELF argc owned_mask=0`
  - cross-fn → `TAIL_CALL_KNOWN fn_id argc owned_mask=0`
- owned_mask=0 is intentional — MIR doesn't carry last-use bits yet (Phase 6 will rebuild the mask off MIR liveness).

## Parity proof additions

3 new tests (12 total):
- `try_propagation_parity_runtime` — `relay(7)` succeeds via both paths
- `bytecode_parity_for_try_propagation` — byte-identical PROPAGATE_ERR emit
- `tail_call_runtime_parity` — `countdown(10) = 0` via both paths (match drops to HIR fallback)

All 12 ✅. Phase 4a skeleton (4/4) stays green.

## Test plan
- [x] cargo fmt + clippy clean
- [x] 12/12 parity tests
- [x] 4/4 skeleton tests
- [x] no regression on full suite (run locally)

## What's left for Phase 4e+
- **Match** — MirPattern → opcode walker mirroring `src/vm/compiler/patterns.rs`. Highest leverage remaining (every fn with `match` rides HIR fallback).
- RecordCreate / RecordUpdate
- List / Tuple / Map literals
- `MirCallee::Builtin` — CALL_BUILTIN dispatch (dominates UnsupportedCallee drops on corpus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)