### PR TITLE
vm: Phase 4e — MIR walker covers MirCallee::Builtin via CALL_BUILTIN (#252 Phase 4)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -33,6 +33,7 @@ use crate::ast::Spanned;
 use crate::ir::hir::BuiltinCtor;
 use crate::ir::mir::{MirCall, MirCallee, MirCtor, MirExpr, MirFn, MirLet, MirProgram};
 use crate::nan_value::NanValue;
+use crate::vm::builtin::VmBuiltin;
 use crate::vm::opcode::*;
 
 use super::{CompileError, FnCompiler};
@@ -107,32 +108,52 @@ pub(super) fn compile_mir_expr(
         }
         MirExpr::Call(spanned_call) => {
             let MirCall { callee, args } = &spanned_call.node;
-            let fn_id = match callee {
-                MirCallee::Fn(fn_id) => *fn_id,
-                MirCallee::Builtin(_) => {
-                    return Err(MirVmUnsupported::UnsupportedCallee);
+            match callee {
+                MirCallee::Fn(fn_id) => {
+                    for arg in args {
+                        compile_mir_expr(fc, arg)?;
+                    }
+                    let name = fc.canonical_fn_name(*fn_id)?;
+                    let vm_fn_id = fc.resolve_fn_id_by_name(&name).ok_or_else(|| {
+                        MirVmUnsupported::InnerError(CompileError {
+                            msg: format!(
+                                "MIR-VM: unresolved fn `{name}` (FnId={fn_id:?}) — \
+                                 module not loaded?"
+                            ),
+                        })
+                    })?;
+                    fc.emit_op(CALL_KNOWN);
+                    fc.emit_u16(vm_fn_id as u16);
+                    fc.emit_u8(args.len() as u8);
+                    Ok(())
                 }
-            };
-            for arg in args {
-                compile_mir_expr(fc, arg)?;
+                MirCallee::Builtin(name) => {
+                    // Phase 4e — generic CALL_BUILTIN dispatch.
+                    // The HIR walker specializes ~6 builtins
+                    // (ListLen → LIST_LEN, MapGet → MAP_GET,
+                    // OptionWithDefault → UNWRAP_OR, …) into
+                    // dedicated opcodes; we don't replicate that
+                    // here yet, so bytecode parity only holds for
+                    // the generic path. Runtime parity holds for
+                    // all builtins — the VM's CALL_BUILTIN
+                    // dispatch lands on the same handler the
+                    // specialised opcodes wrap.
+                    let builtin =
+                        lookup_vm_builtin(name).ok_or(MirVmUnsupported::UnsupportedCallee)?;
+                    for arg in args {
+                        compile_mir_expr(fc, arg)?;
+                    }
+                    let symbol_id = fc.symbols.intern_builtin(builtin).map_err(|e| {
+                        MirVmUnsupported::InnerError(CompileError {
+                            msg: format!("MIR-VM: intern_builtin failed: {e:?}"),
+                        })
+                    })?;
+                    fc.emit_op(CALL_BUILTIN);
+                    fc.emit_u32(symbol_id);
+                    fc.emit_u8(args.len() as u8);
+                    Ok(())
+                }
             }
-            // Same dispatch path the HIR compiler uses:
-            // FnId → canonical name → VM fn_id (u16) via
-            // `module_scope` / `code_store.find`.
-            let name = fc.canonical_fn_name(fn_id)?;
-            let vm_fn_id = fc.resolve_fn_id_by_name(&name).ok_or_else(|| {
-                MirVmUnsupported::InnerError(CompileError {
-                    msg: format!(
-                        "MIR-VM: unresolved fn `{name}` (FnId={fn_id:?}) — \
-                         module not loaded?"
-                    ),
-                })
-            })?;
-            // CALL_KNOWN layout: fn_id u16, argc u8.
-            fc.emit_op(CALL_KNOWN);
-            fc.emit_u16(vm_fn_id as u16);
-            fc.emit_u8(args.len() as u8);
-            Ok(())
         }
         MirExpr::Return(inner) => {
             compile_mir_expr(fc, inner)?;
@@ -325,7 +346,11 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
         MirExpr::Neg(inner) => can_compile(inner),
         MirExpr::Let(l) => can_compile(&l.node.value) && can_compile(&l.node.body),
         MirExpr::Call(c) => {
-            matches!(c.node.callee, MirCallee::Fn(_)) && c.node.args.iter().all(can_compile)
+            let callee_ok = match &c.node.callee {
+                MirCallee::Fn(_) => true,
+                MirCallee::Builtin(name) => lookup_vm_builtin(name).is_some(),
+            };
+            callee_ok && c.node.args.iter().all(can_compile)
         }
         MirExpr::Return(inner) => can_compile(inner),
         // Phase 4c additions:
@@ -336,6 +361,15 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
         MirExpr::TailCall(t) => t.node.args.iter().all(can_compile),
         _ => false,
     }
+}
+
+/// Linear-search lookup `name → VmBuiltin`. Returns `None` for
+/// names not in the builtin table — the caller drops back to HIR
+/// via `MirVmUnsupported::UnsupportedCallee`. The table is small
+/// (~60 entries) so linear scan is fine; a future Phase 6 can
+/// memoize.
+fn lookup_vm_builtin(name: &str) -> Option<VmBuiltin> {
+    VmBuiltin::ALL.iter().copied().find(|b| b.name() == name)
 }
 
 /// Helper: emit a single ctor arg, or `LOAD_UNIT` when the ctor

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -266,6 +266,67 @@ fn tail_call_runtime_parity() {
 }
 
 #[test]
+fn builtin_call_runtime_parity() {
+    // Phase 4e — `MirCallee::Builtin(_)` lowers to CALL_BUILTIN.
+    // Tested with `String.len` (pure builtin, no effects) so we
+    // can verify runtime parity without effect plumbing.
+    let src = "fn name_length(s: String) -> Int\n    String.len(s)\n";
+    let (hir, mir) = compile_both(src);
+    let hir_fn = hir.get(hir.find("name_length").expect("name_length in HIR"));
+    let mir_fn = mir.get(mir.find("name_length").expect("name_length in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "CALL_BUILTIN emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn console_print_effect_bearing_call_lowers_under_mir_path() {
+    // Effect-bearing builtin in non-tail position. Bytecode is
+    // NOT byte-identical because HIR's `compile_stmt(is_tail=false)`
+    // emits POP after the call, while MIR's wave-3a stmt-chain
+    // wraps non-tail Expr stmts in `Let { binding: synthetic,
+    // value: expr, body: ... }` → STORE_LOCAL instead of POP.
+    // Both are semantically equivalent (effect happens, value
+    // discarded), and the parity question for effect-bearing
+    // intermediates moves to the runtime side. Until we have a
+    // safe way to observe the effect from a test (without a
+    // real stdout sink), we just verify both fns lower.
+    let (hir, mir) = compile_both(
+        "fn shout(msg: String) -> Int\n    ! [Console.print]\n    Console.print(msg)\n    0\n",
+    );
+    assert!(
+        hir.find("shout").is_some(),
+        "shout() should be present in HIR-only chunks"
+    );
+    assert!(
+        mir.find("shout").is_some(),
+        "shout() should be present in MIR-fallback chunks (Console.print is now in subset)"
+    );
+}
+
+#[test]
+fn corpus_hello_smoke_mir_walker_covers_it() {
+    // examples/core/hello.av is a small program that uses
+    // Console.print — Phase 4e's CALL_BUILTIN coverage should
+    // land the main fn in the MIR-covered set.
+    let src = std::fs::read_to_string("examples/core/hello.av")
+        .expect("examples/core/hello.av should exist");
+    let mut items = parse(&src);
+    tco::transform_program(&mut items);
+    resolver::resolve_program(&mut items);
+    let (resolved, _) = resolve(&items);
+    let mir = aver::ir::mir::lower_program(&resolved);
+    let cov = aver::vm::mir_vm::classify_mir_program_coverage(&mir);
+    assert!(
+        cov.covered >= 1,
+        "examples/core/hello.av should have at least one fn in MIR-covered: {:?}",
+        cov
+    );
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output

--- a/tests/mir_vm_phase4_skeleton.rs
+++ b/tests/mir_vm_phase4_skeleton.rs
@@ -80,21 +80,21 @@ fn match_fn_falls_back_to_hir() {
 }
 
 #[test]
-fn builtin_call_falls_back_to_hir() {
-    // `MirCallee::Builtin(_)` (e.g. `Int.add`-style methods)
-    // isn't in the Phase 4 subset — the walker needs the symbol
-    // table to resolve a builtin id, which Phase 4b will land
-    // alongside parity.
+fn builtin_call_now_lands_in_subset_after_phase_4e() {
+    // Phase 4e landed `MirCallee::Builtin(_)` → CALL_BUILTIN
+    // dispatch via the VmBuiltin lookup. A fn that uses
+    // `Console.print` (or any builtin in the VmBuiltin::ALL
+    // table) now lands in `covered`. The test was previously
+    // pinned to the opposite — Phase 4d's "falls back to HIR"
+    // — so the assertion is flipped here to track the new
+    // reality.
     let mir = lower(
         "fn print_hello() -> Int\n    ! [Console.print]\n    Console.print(\"hello\")\n    0\n",
     );
     let cov = classify_mir_program_coverage(&mir);
-    // The fn may or may not appear in MIR depending on whether
-    // the inner Console.print effect path resolves cleanly — we
-    // only assert it does NOT land in `covered`.
     assert_eq!(
-        cov.covered, 0,
-        "Console.print fn must NOT be in the Phase 4 subset: {:?}",
+        cov.covered, 1,
+        "Console.print fn must land in the Phase 4 subset after 4e: {:?}",
         cov
     );
 }


### PR DESCRIPTION
## Summary

Phase 4e extends the MIR walker to handle `MirCallee::Builtin(name)`. Subset now:

- 4a: Literal + Local + BinOp + Neg + Let + Call(Fn) + Return
- 4c: Construct (User + Builtin) + Project
- 4d: Try + TailCall
- **4e: Call(Builtin) — CALL_BUILTIN dispatch via VmBuiltin::ALL lookup**

## Approach

Linear search over \`VmBuiltin::ALL\` (~60 entries) maps name → variant. Matching builtin → \`intern_builtin → symbol_id → CALL_BUILTIN symbol_id argc\`. Unknown name → \`UnsupportedCallee\` (HIR fallback).

## Limitations (deliberate)

HIR specializes ~6 builtins to dedicated opcodes (LIST_LEN, MAP_GET, UNWRAP_OR, …). MIR doesn't replicate that yet:
- **Runtime parity** holds for *all* builtins (CALL_BUILTIN lands on the same handler)
- **Bytecode parity** holds only for the generic path. The specialised cases need type-stamp propagation, which is Phase 6 work.

## Parity proof additions

3 new tests (15 total):
- \`builtin_call_runtime_parity\` — \`String.len(s)\` byte-identical bytecode
- \`console_print_effect_bearing_call_lowers_under_mir_path\` — effect-bearing non-tail builtin lowers (bytecode differs because of stmt-chain wrap, runtime semantically identical)
- \`corpus_hello_smoke_mir_walker_covers_it\` — \`examples/core/hello.av\` has ≥1 covered fn after 4e

Skeleton test flipped: \`builtin_call_falls_back_to_hir\` → \`builtin_call_now_lands_in_subset_after_phase_4e\`.

## Test plan
- [x] cargo fmt + clippy clean
- [x] 15/15 parity ✅
- [x] 4/4 skeleton ✅

## Next: Phase 4f
- **Match** + MirPattern walker (analogous to \`src/vm/compiler/patterns.rs\`) — biggest remaining leverage; every fn with \`match\` currently rides HIR fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)