### PR TITLE
vm: Phase 4f — MIR walker covers List + Tuple + RecordCreate + RecordUpdate (#252 Phase 4)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -286,12 +286,100 @@ pub(super) fn compile_mir_expr(
             Ok(())
         }
 
+        // ── Phase 4f: record + list + tuple builders ────────────
+        MirExpr::List(items) => {
+            if items.is_empty() {
+                fc.emit_op(LIST_NIL);
+                return Ok(());
+            }
+            for item in items {
+                compile_mir_expr(fc, item)?;
+            }
+            fc.emit_op(LIST_NEW);
+            fc.emit_u8(items.len() as u8);
+            Ok(())
+        }
+        MirExpr::Tuple(items) => {
+            for item in items {
+                compile_mir_expr(fc, item)?;
+            }
+            fc.emit_op(TUPLE_NEW);
+            fc.emit_u8(items.len() as u8);
+            Ok(())
+        }
+        MirExpr::RecordCreate(spanned_rc) => {
+            let rc = &spanned_rc.node;
+            // Resolve TypeId → canonical name → arena type id +
+            // field order. Same path the HIR walker takes; MIR
+            // carries the `TypeId` already, so we just look up
+            // the canonical name to ask the arena for the type
+            // metadata (the arena's field order is the
+            // declaration order, which is what RECORD_NEW
+            // expects on the stack).
+            let qualified_type_name = fc.canonical_type_name(rc.type_id)?;
+            let arena_type_id = fc.resolve_type_id(&qualified_type_name).ok_or_else(|| {
+                MirVmUnsupported::InnerError(CompileError {
+                    msg: format!(
+                        "MIR-VM: unknown arena type `{qualified_type_name}` for \
+                         RecordCreate (TypeId={:?})",
+                        rc.type_id
+                    ),
+                })
+            })?;
+            let field_names = fc.arena.get_field_names(arena_type_id).to_vec();
+            // Push fields in declared order.
+            for expected_name in &field_names {
+                let field = rc.fields.iter().find(|f| f.name == *expected_name).ok_or_else(
+                    || {
+                        MirVmUnsupported::InnerError(CompileError {
+                            msg: format!(
+                                "MIR-VM: missing field `{expected_name}` in record `{qualified_type_name}`"
+                            ),
+                        })
+                    },
+                )?;
+                compile_mir_expr(fc, &field.value)?;
+            }
+            fc.emit_op(RECORD_NEW);
+            fc.emit_u16(arena_type_id as u16);
+            fc.emit_u8(field_names.len() as u8);
+            Ok(())
+        }
+        MirExpr::RecordUpdate(spanned_ru) => {
+            let ru = &spanned_ru.node;
+            let qualified_type_name = fc.canonical_type_name(ru.type_id)?;
+            let arena_type_id = fc.resolve_type_id(&qualified_type_name).ok_or_else(|| {
+                MirVmUnsupported::InnerError(CompileError {
+                    msg: format!(
+                        "MIR-VM: unknown arena type `{qualified_type_name}` for \
+                         RecordUpdate (TypeId={:?})",
+                        ru.type_id
+                    ),
+                })
+            })?;
+            let field_names = fc.arena.get_field_names(arena_type_id).to_vec();
+            let mut updated_indices = Vec::with_capacity(ru.updates.len());
+
+            compile_mir_expr(fc, &ru.base)?;
+
+            for (field_idx, field_name) in field_names.iter().enumerate() {
+                if let Some(field) = ru.updates.iter().find(|f| f.name == *field_name) {
+                    compile_mir_expr(fc, &field.value)?;
+                    updated_indices.push(field_idx as u8);
+                }
+            }
+            fc.emit_op(RECORD_UPDATE);
+            fc.emit_u16(arena_type_id as u16);
+            fc.emit_u8(updated_indices.len() as u8);
+            for idx in updated_indices {
+                fc.emit_u8(idx);
+            }
+            Ok(())
+        }
+
         // Phase 4 subset boundary — everything else falls back.
+        // Match: large pattern walker — separate Phase 4g.
         MirExpr::Match(_) => Err(MirVmUnsupported::UnsupportedExpr("Match")),
-        MirExpr::RecordCreate(_) => Err(MirVmUnsupported::UnsupportedExpr("RecordCreate")),
-        MirExpr::RecordUpdate(_) => Err(MirVmUnsupported::UnsupportedExpr("RecordUpdate")),
-        MirExpr::List(_) => Err(MirVmUnsupported::UnsupportedExpr("List")),
-        MirExpr::Tuple(_) => Err(MirVmUnsupported::UnsupportedExpr("Tuple")),
         MirExpr::MapLiteral(_) => Err(MirVmUnsupported::UnsupportedExpr("MapLiteral")),
         MirExpr::InterpolatedStr(_) => Err(MirVmUnsupported::UnsupportedExpr("InterpolatedStr")),
         MirExpr::IndependentProduct(_) => {
@@ -359,6 +447,13 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
         // Phase 4d additions:
         MirExpr::Try(inner) => can_compile(inner),
         MirExpr::TailCall(t) => t.node.args.iter().all(can_compile),
+        // Phase 4f additions:
+        MirExpr::List(items) => items.iter().all(can_compile),
+        MirExpr::Tuple(items) => items.iter().all(can_compile),
+        MirExpr::RecordCreate(rc) => rc.node.fields.iter().all(|f| can_compile(&f.value)),
+        MirExpr::RecordUpdate(ru) => {
+            can_compile(&ru.node.base) && ru.node.updates.iter().all(|f| can_compile(&f.value))
+        }
         _ => false,
     }
 }

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -327,6 +327,57 @@ fn corpus_hello_smoke_mir_walker_covers_it() {
 }
 
 #[test]
+fn list_literal_bytecode_parity() {
+    let (hir, mir) = compile_both("fn nums() -> List<Int>\n    [1, 2, 3]\n");
+    let hir_fn = hir.get(hir.find("nums").expect("nums in HIR"));
+    let mir_fn = mir.get(mir.find("nums").expect("nums in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "LIST_NEW emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn empty_list_bytecode_parity() {
+    let (hir, mir) = compile_both("fn empty() -> List<Int>\n    []\n");
+    let hir_fn = hir.get(hir.find("empty").expect("empty in HIR"));
+    let mir_fn = mir.get(mir.find("empty").expect("empty in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "LIST_NIL emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn tuple_literal_bytecode_parity() {
+    let (hir, mir) = compile_both("fn pair() -> Tuple<Int, Int>\n    (1, 2)\n");
+    let hir_fn = hir.get(hir.find("pair").expect("pair in HIR"));
+    let mir_fn = mir.get(mir.find("pair").expect("pair in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "TUPLE_NEW emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn record_create_bytecode_parity() {
+    // Field order follows declaration order in `get_field_names`,
+    // identical between HIR and MIR paths.
+    let (hir, mir) =
+        compile_both("record P\n  x: Int\n  y: Int\n\nfn makeP() -> P\n    P(x = 1, y = 2)\n");
+    let hir_fn = hir.get(hir.find("makeP").expect("makeP in HIR"));
+    let mir_fn = mir.get(mir.find("makeP").expect("makeP in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "RECORD_NEW emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output


### PR DESCRIPTION
## Summary

Phase 4f extends the MIR walker with collection literals and record builders. Subset now:

- 4a/4b: Literal + Local + BinOp + Neg + Let + Call(Fn) + Return
- 4c: Construct + Project
- 4d: Try + TailCall
- 4e: Call(Builtin)
- **4f: List + Tuple + RecordCreate + RecordUpdate**

## What lands

| Variant | Emit |
|---|---|
| List([]) | LIST_NIL |
| List(items) | walk + LIST_NEW len |
| Tuple(items) | walk + TUPLE_NEW len |
| RecordCreate { type_id, fields } | resolve TypeId → arena, push in declared field order, RECORD_NEW |
| RecordUpdate { base, type_id, updates } | base + updates in declared order, RECORD_UPDATE + indices |

## Parity proof (4 new tests, 19 total)

- `list_literal_bytecode_parity` — `[1, 2, 3]` byte-identical
- `empty_list_bytecode_parity` — `[]` byte-identical (LIST_NIL)
- `tuple_literal_bytecode_parity` — `(1, 2)` byte-identical
- `record_create_bytecode_parity` — `P(x=1, y=2)` byte-identical

All 19 ✅. Phase 4a skeleton 4/4 stays green.

## Why no Match yet

\`patterns.rs\` is **756 lines** of HIR pattern emit (MATCH_DISPATCH / MATCH_CONS / MATCH_UNWRAP / EXTRACT_*). Replicating that for MIR is too large for one PR. Match-bearing fns continue to ride HIR fallback — runtime parity holds, just not via the MIR walker directly.

Phase 4g will tackle Match in sub-PRs by pattern variant (literal → cons → user ctor → builtin ctor → tuple).

## Test plan
- [x] cargo fmt + clippy clean
- [x] 19/19 parity ✅
- [x] 4/4 skeleton ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)