### PR TITLE
vm: Phase 4g-1 — MIR walker covers Match with Wildcard + Literal(Int) arms (#252 Phase 4)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -400,10 +400,11 @@ pub(super) fn compile_mir_expr(
         //   end:
         MirExpr::Match(spanned_match) => {
             let m = &spanned_match.node;
-            if !m.arms.iter().all(|arm| match &arm.pattern {
-                MirPattern::Wildcard => true,
-                MirPattern::Literal(Literal::Int(_)) => true,
-                _ => false,
+            if !m.arms.iter().all(|arm| {
+                matches!(
+                    &arm.pattern,
+                    MirPattern::Wildcard | MirPattern::Literal(Literal::Int(_))
+                )
             }) {
                 return Err(MirVmUnsupported::UnsupportedExpr("Match (complex pattern)"));
             }

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -29,9 +29,10 @@
 //! IndependentProduct) returns `Err(MirVmUnsupported)` so the
 //! caller can fall back to HIR compilation for that fn.
 
+use crate::ast::Literal;
 use crate::ast::Spanned;
 use crate::ir::hir::BuiltinCtor;
-use crate::ir::mir::{MirCall, MirCallee, MirCtor, MirExpr, MirFn, MirLet, MirProgram};
+use crate::ir::mir::{MirCall, MirCallee, MirCtor, MirExpr, MirFn, MirLet, MirPattern, MirProgram};
 use crate::nan_value::NanValue;
 use crate::vm::builtin::VmBuiltin;
 use crate::vm::opcode::*;
@@ -377,9 +378,75 @@ pub(super) fn compile_mir_expr(
             Ok(())
         }
 
-        // Phase 4 subset boundary — everything else falls back.
-        // Match: large pattern walker — separate Phase 4g.
-        MirExpr::Match(_) => Err(MirVmUnsupported::UnsupportedExpr("Match")),
+        // ── Phase 4g-1: match with Wildcard + Literal(Int) arms ──
+        // The HIR walker's `compile_match` is 756 lines and
+        // includes fast-paths (MATCH_DISPATCH_CONST, bool-branch
+        // optimization) we don't replicate here. This sub-PR
+        // handles the smallest reviewable subset: arm patterns
+        // restricted to `Wildcard` and `Literal(Int)`. Any other
+        // pattern variant in any arm falls back to HIR.
+        //
+        // Emit shape (linear fallback, mirrors HIR's tail of
+        // `compile_match`):
+        //   <subject>
+        //   per arm (except last):
+        //     [MATCH_INT_LITERAL imm fail]  // skipped for Wildcard
+        //     POP
+        //     <body>
+        //     JUMP end
+        //     fail: <next arm>
+        //   last arm: skip pattern check entirely (exhaustive),
+        //             POP, <body>
+        //   end:
+        MirExpr::Match(spanned_match) => {
+            let m = &spanned_match.node;
+            if !m.arms.iter().all(|arm| match &arm.pattern {
+                MirPattern::Wildcard => true,
+                MirPattern::Literal(Literal::Int(_)) => true,
+                _ => false,
+            }) {
+                return Err(MirVmUnsupported::UnsupportedExpr("Match (complex pattern)"));
+            }
+            compile_mir_expr(fc, &m.subject)?;
+
+            let mut end_jumps: Vec<usize> = Vec::new();
+            let last_idx = m.arms.len() - 1;
+            for (i, arm) in m.arms.iter().enumerate() {
+                let is_last = i == last_idx;
+                let fail_patch: Option<usize> = if is_last {
+                    None
+                } else {
+                    match &arm.pattern {
+                        MirPattern::Wildcard => None,
+                        MirPattern::Literal(Literal::Int(v)) => {
+                            fc.emit_op(MATCH_INT_LITERAL);
+                            fc.emit_i64(*v);
+                            let patch = fc.offset();
+                            fc.emit_i16(0);
+                            Some(patch)
+                        }
+                        // Filtered by the preflight check above —
+                        // any other variant would have returned
+                        // `UnsupportedExpr` before we reached
+                        // here.
+                        _ => unreachable!("Phase 4g-1 preflight guarantees Wildcard|Literal(Int)"),
+                    }
+                };
+                fc.emit_op(POP);
+                compile_mir_expr(fc, &arm.body)?;
+                if !is_last {
+                    end_jumps.push(fc.emit_jump(JUMP));
+                    if let Some(patch) = fail_patch {
+                        let next_arm_start = fc.offset();
+                        fc.patch_jump_to(patch, next_arm_start);
+                    }
+                }
+            }
+            for patch in end_jumps {
+                fc.patch_jump(patch);
+            }
+            Ok(())
+        }
         MirExpr::MapLiteral(_) => Err(MirVmUnsupported::UnsupportedExpr("MapLiteral")),
         MirExpr::InterpolatedStr(_) => Err(MirVmUnsupported::UnsupportedExpr("InterpolatedStr")),
         MirExpr::IndependentProduct(_) => {
@@ -453,6 +520,17 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
         MirExpr::RecordCreate(rc) => rc.node.fields.iter().all(|f| can_compile(&f.value)),
         MirExpr::RecordUpdate(ru) => {
             can_compile(&ru.node.base) && ru.node.updates.iter().all(|f| can_compile(&f.value))
+        }
+        // Phase 4g-1: match with Wildcard + Literal(Int) arms only.
+        MirExpr::Match(m) => {
+            can_compile(&m.node.subject)
+                && m.node.arms.iter().all(|arm| {
+                    let pattern_ok = matches!(
+                        &arm.pattern,
+                        MirPattern::Wildcard | MirPattern::Literal(Literal::Int(_))
+                    );
+                    pattern_ok && can_compile(&arm.body)
+                })
         }
         _ => false,
     }

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -378,6 +378,39 @@ fn record_create_bytecode_parity() {
 }
 
 #[test]
+fn match_int_literal_runtime_parity() {
+    // Phase 4g-1 — match arms with Wildcard + Literal(Int) only.
+    // Runtime must agree between HIR and MIR-fallback paths for
+    // each branch.
+    let src = "fn classify(n: Int) -> Int\n    match n\n        0 -> 100\n        1 -> 200\n        _ -> 999\n";
+    for (input, expected) in &[(0, 100), (1, 200), (2, 999), (-1, 999)] {
+        let hir = run_via_path(src, "classify", &[*input], Path::Hir);
+        let mir = run_via_path(src, "classify", &[*input], Path::MirFallback);
+        assert_eq!(
+            hir, mir,
+            "classify({input}) parity: HIR={hir:?}, MIR={mir:?}"
+        );
+        assert_eq!(hir, Value::Int(*expected as i64));
+    }
+}
+
+#[test]
+fn match_complex_pattern_falls_back_to_hir() {
+    // Cons / EmptyList patterns are NOT in 4g-1 — those fns
+    // must fall back to HIR and still produce the right answer.
+    let src = "fn first_or_zero(xs: List<Int>) -> Int\n    match xs\n        [] -> 0\n        [h, ..t] -> h\n";
+    let (hir, mir) = compile_both(src);
+    assert!(
+        hir.find("first_or_zero").is_some(),
+        "fn should exist in HIR chunks"
+    );
+    assert!(
+        mir.find("first_or_zero").is_some(),
+        "fn should still exist in MIR-path chunks via HIR fallback"
+    );
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output


### PR DESCRIPTION
## Summary

First Match sub-PR. \`patterns.rs\` is 756 lines of HIR pattern emit with optimizations (MATCH_DISPATCH_CONST table fast-path, bool-branch JUMP_IF_FALSE). Replicating all of that for MIR is too large for one PR; this lands the smallest reviewable subset.

## What lands

\`MirExpr::Match\` lowers when **every arm pattern** is either:
- \`Wildcard\`
- \`Literal(Int)\`

Any other pattern (Cons, Tuple, Ctor, Bind, EmptyList, non-Int literal) → fallback to HIR.

Linear emit (mirrors HIR's `compile_match` tail):

\`\`\`
<subject>
per non-last arm:
  [MATCH_INT_LITERAL imm fail]  // skipped for Wildcard
  POP
  <body>
  JUMP end
  fail: <next arm>
last arm (exhaustive):
  POP
  <body>
end:
\`\`\`

\`MATCH_INT_LITERAL\` is a fused peek + i64-compare + branch the VM already provides.

## Parity proof (2 new tests, 21 total)

- \`match_int_literal_runtime_parity\` — \`classify(n)\` from 3-arm match agrees on all inputs across HIR vs MIR-fallback paths
- \`match_complex_pattern_falls_back_to_hir\` — Cons-pattern fn still lowers via HIR fallback

Bytecode parity is **not** asserted — HIR uses MATCH_DISPATCH_CONST table fast-path for literal-only matches; MIR uses linear-fallback shape. Both semantically identical, different bytes. Bytecode parity for matches lands when MIR picks up the table fast-path (later sub-PR).

## Test plan
- [x] cargo fmt + clippy clean
- [x] 21/21 parity ✅
- [x] 4/4 skeleton ✅

## Next: Phase 4g-2…5
| Sub-PR | Adds |
|---|---|
| 4g-2 | Cons + EmptyList |
| 4g-3 | Ctor (User CtorId) |
| 4g-4 | Ctor (Builtin BuiltinCtor — Result/Option) |
| 4g-5 | Tuple |

Each reviewable in one pass; cumulative coverage grows with no flag-day risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)