### PR TITLE
vm: Phase 4g-2 — MIR Match walker covers Cons + EmptyList patterns (#252 Phase 4)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -400,12 +400,7 @@ pub(super) fn compile_mir_expr(
         //   end:
         MirExpr::Match(spanned_match) => {
             let m = &spanned_match.node;
-            if !m.arms.iter().all(|arm| {
-                matches!(
-                    &arm.pattern,
-                    MirPattern::Wildcard | MirPattern::Literal(Literal::Int(_))
-                )
-            }) {
+            if !m.arms.iter().all(|arm| pattern_in_4g_subset(&arm.pattern)) {
                 return Err(MirVmUnsupported::UnsupportedExpr("Match (complex pattern)"));
             }
             compile_mir_expr(fc, &m.subject)?;
@@ -415,23 +410,21 @@ pub(super) fn compile_mir_expr(
             for (i, arm) in m.arms.iter().enumerate() {
                 let is_last = i == last_idx;
                 let fail_patch: Option<usize> = if is_last {
+                    // Last arm — exhaustive, no pattern check.
+                    // Cons bindings must still be extracted
+                    // unconditionally (the value is on the
+                    // stack, we know the shape matches).
+                    if let MirPattern::Cons { head, tail } = &arm.pattern {
+                        fc.emit_op(DUP);
+                        fc.emit_op(LIST_HEAD_TAIL);
+                        fc.emit_op(STORE_LOCAL);
+                        fc.emit_u8(head.0 as u8);
+                        fc.emit_op(STORE_LOCAL);
+                        fc.emit_u8(tail.0 as u8);
+                    }
                     None
                 } else {
-                    match &arm.pattern {
-                        MirPattern::Wildcard => None,
-                        MirPattern::Literal(Literal::Int(v)) => {
-                            fc.emit_op(MATCH_INT_LITERAL);
-                            fc.emit_i64(*v);
-                            let patch = fc.offset();
-                            fc.emit_i16(0);
-                            Some(patch)
-                        }
-                        // Filtered by the preflight check above —
-                        // any other variant would have returned
-                        // `UnsupportedExpr` before we reached
-                        // here.
-                        _ => unreachable!("Phase 4g-1 preflight guarantees Wildcard|Literal(Int)"),
-                    }
+                    emit_pattern_check(fc, &arm.pattern)?
                 };
                 fc.emit_op(POP);
                 compile_mir_expr(fc, &arm.body)?;
@@ -522,18 +515,72 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
         MirExpr::RecordUpdate(ru) => {
             can_compile(&ru.node.base) && ru.node.updates.iter().all(|f| can_compile(&f.value))
         }
-        // Phase 4g-1: match with Wildcard + Literal(Int) arms only.
+        // Phase 4g-1/2: match with Wildcard + Literal(Int) + Cons + EmptyList arms.
         MirExpr::Match(m) => {
             can_compile(&m.node.subject)
-                && m.node.arms.iter().all(|arm| {
-                    let pattern_ok = matches!(
-                        &arm.pattern,
-                        MirPattern::Wildcard | MirPattern::Literal(Literal::Int(_))
-                    );
-                    pattern_ok && can_compile(&arm.body)
-                })
+                && m.node
+                    .arms
+                    .iter()
+                    .all(|arm| pattern_in_4g_subset(&arm.pattern) && can_compile(&arm.body))
         }
         _ => false,
+    }
+}
+
+/// Phase 4g preflight + can_compile — pattern variants the
+/// MIR Match walker handles. Wildcard / Literal(Int) (4g-1),
+/// Cons + EmptyList (4g-2). Further variants land in 4g-3+.
+fn pattern_in_4g_subset(p: &MirPattern) -> bool {
+    matches!(
+        p,
+        MirPattern::Wildcard
+            | MirPattern::Literal(Literal::Int(_))
+            | MirPattern::Cons { .. }
+            | MirPattern::EmptyList
+    )
+}
+
+/// Emit the pattern check for a non-last arm. Returns the
+/// `fail_offset` patch position the caller will fill in to
+/// point at the next arm's start (or `None` when the pattern
+/// always matches — currently just `Wildcard`).
+fn emit_pattern_check(
+    fc: &mut FnCompiler<'_>,
+    pattern: &MirPattern,
+) -> Result<Option<usize>, MirVmUnsupported> {
+    match pattern {
+        MirPattern::Wildcard => Ok(None),
+        MirPattern::Literal(Literal::Int(v)) => {
+            fc.emit_op(MATCH_INT_LITERAL);
+            fc.emit_i64(*v);
+            let patch = fc.offset();
+            fc.emit_i16(0);
+            Ok(Some(patch))
+        }
+        MirPattern::EmptyList => {
+            fc.emit_op(MATCH_NIL);
+            let patch = fc.offset();
+            fc.emit_i16(0);
+            Ok(Some(patch))
+        }
+        MirPattern::Cons { head, tail } => {
+            fc.emit_op(MATCH_CONS);
+            let patch = fc.offset();
+            fc.emit_i16(0);
+            // Successful match: extract head/tail and bind into
+            // the resolver-assigned slots. The HIR walker does
+            // the same shape; MIR's `LocalId` directly carries
+            // the slot.
+            fc.emit_op(DUP);
+            fc.emit_op(LIST_HEAD_TAIL);
+            fc.emit_op(STORE_LOCAL);
+            fc.emit_u8(head.0 as u8);
+            fc.emit_op(STORE_LOCAL);
+            fc.emit_u8(tail.0 as u8);
+            Ok(Some(patch))
+        }
+        // Preflight in the caller filters everything else out.
+        _ => unreachable!("Phase 4g subset preflight should have filtered this out"),
     }
 }
 

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -411,6 +411,41 @@ fn match_complex_pattern_falls_back_to_hir() {
 }
 
 #[test]
+fn match_cons_emptylist_runtime_parity() {
+    // Phase 4g-2 — `match xs { [] -> 0; [h, ..t] -> h }`.
+    // Runtime must agree on both branches across HIR vs
+    // MIR-fallback paths. We can't pass a `List<Int>` directly
+    // via `run_named_function` (NanValue arg encoding for
+    // lists isn't trivial from tests), so we drive it through
+    // an Int-returning fn that constructs the list inline.
+    let src = "fn head_or_zero(xs: List<Int>) -> Int\n    match xs\n        [] -> 0\n        [h, ..t] -> h\n\nfn check_empty(_dummy: Int) -> Int\n    head_or_zero([])\n\nfn check_cons(_dummy: Int) -> Int\n    head_or_zero([42, 7, 3])\n";
+    let hir_empty = run_via_path(src, "check_empty", &[0], Path::Hir);
+    let mir_empty = run_via_path(src, "check_empty", &[0], Path::MirFallback);
+    assert_eq!(hir_empty, mir_empty);
+    assert_eq!(hir_empty, Value::Int(0));
+
+    let hir_cons = run_via_path(src, "check_cons", &[0], Path::Hir);
+    let mir_cons = run_via_path(src, "check_cons", &[0], Path::MirFallback);
+    assert_eq!(hir_cons, mir_cons);
+    assert_eq!(hir_cons, Value::Int(42));
+}
+
+#[test]
+fn match_ctor_pattern_still_falls_back_to_hir() {
+    // 4g-2 explicitly does NOT cover Ctor patterns; those still
+    // ride HIR fallback. Test the fn still appears in the
+    // chunks (compile_program_with_mir_fallback dispatches
+    // correctly).
+    let src = "type Shape\n  Circle(Int)\n  Square(Int)\n\nfn area(s: Shape) -> Int\n    match s\n        Shape.Circle(r) -> r\n        Shape.Square(side) -> side\n";
+    let (hir, mir) = compile_both(src);
+    assert!(hir.find("area").is_some(), "area in HIR chunks");
+    assert!(
+        mir.find("area").is_some(),
+        "area still in MIR-path chunks via HIR fallback"
+    );
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output

--- a/tests/mir_vm_phase4_skeleton.rs
+++ b/tests/mir_vm_phase4_skeleton.rs
@@ -64,17 +64,18 @@ fn user_fn_call_lands_in_subset() {
 }
 
 #[test]
-fn match_fn_falls_back_to_hir() {
-    // `match` is outside the Phase 4 subset — the fn will need
-    // HIR fallback. The classifier should bucket it correctly.
+fn complex_pattern_match_fn_falls_back_to_hir() {
+    // 4g-2 covers Cons + EmptyList. To keep this test honest as
+    // the subset grows, use a `Ctor` pattern which is still
+    // outside the subset (Phase 4g-3 territory).
     let mir = lower(
-        "fn double(x: Int) -> Int\n    x + x\n\nfn first(xs: List<Int>) -> Int\n    match xs\n        [] -> 0\n        [h, ..t] -> h\n",
+        "fn double(x: Int) -> Int\n    x + x\n\ntype Shape\n  Circle(Int)\n  Square(Int)\n\nfn area(s: Shape) -> Int\n    match s\n        Shape.Circle(r) -> r\n        Shape.Square(side) -> side\n",
     );
     let cov = classify_mir_program_coverage(&mir);
     assert_eq!(cov.covered, 1, "double() in subset: {:?}", cov);
     assert_eq!(
         cov.needs_hir_fallback, 1,
-        "first() (match) needs HIR fallback: {:?}",
+        "area() (Ctor pattern) needs HIR fallback: {:?}",
         cov
     );
 }


### PR DESCRIPTION
## Summary

Second Match sub-PR. Extends 4g-1's subset:
- 4g-1: Wildcard, Literal(Int)
- **4g-2: + Cons, EmptyList**

Any other arm pattern → HIR fallback (Ctor in 4g-3, Tuple in 4g-5).

## Emit

| Pattern | Bytecode |
|---|---|
| EmptyList | `MATCH_NIL fail_offset` |
| Cons{head, tail} | `MATCH_CONS fail_offset DUP LIST_HEAD_TAIL STORE_LOCAL head STORE_LOCAL tail` |

Last-arm exhaustive: Cons binding extraction runs unconditionally (shape known, value on stack).

Helpers introduced (`pattern_in_4g_subset`, `emit_pattern_check`) so 4g-3..5 extend in one place.

## Parity proof (2 new tests, 23 total)

- `match_cons_emptylist_runtime_parity` — `head_or_zero(xs)`: `[]→0`, `[42, ..]→42` on both paths
- `match_ctor_pattern_still_falls_back_to_hir` — Ctor still HIR-fallback

Phase 4 skeleton `match_fn_falls_back_to_hir` rewritten to Ctor pattern (Cons is now covered).

## Test plan
- [x] cargo fmt + clippy clean (incl. tests)
- [x] 23/23 parity ✅
- [x] 4/4 skeleton ✅

## Next: 4g-3 — Ctor (User CtorId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)