### PR TITLE
vm: Phase 4g-3 — MIR Match walker covers User-Ctor patterns (#252 Phase 4)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -411,16 +411,30 @@ pub(super) fn compile_mir_expr(
                 let is_last = i == last_idx;
                 let fail_patch: Option<usize> = if is_last {
                     // Last arm — exhaustive, no pattern check.
-                    // Cons bindings must still be extracted
-                    // unconditionally (the value is on the
-                    // stack, we know the shape matches).
-                    if let MirPattern::Cons { head, tail } = &arm.pattern {
-                        fc.emit_op(DUP);
-                        fc.emit_op(LIST_HEAD_TAIL);
-                        fc.emit_op(STORE_LOCAL);
-                        fc.emit_u8(head.0 as u8);
-                        fc.emit_op(STORE_LOCAL);
-                        fc.emit_u8(tail.0 as u8);
+                    // Bindings still need extracting (value on
+                    // stack, shape known from preceding arm
+                    // failures).
+                    match &arm.pattern {
+                        MirPattern::Cons { head, tail } => {
+                            fc.emit_op(DUP);
+                            fc.emit_op(LIST_HEAD_TAIL);
+                            fc.emit_op(STORE_LOCAL);
+                            fc.emit_u8(head.0 as u8);
+                            fc.emit_op(STORE_LOCAL);
+                            fc.emit_u8(tail.0 as u8);
+                        }
+                        MirPattern::Ctor {
+                            ctor: MirCtor::User(_),
+                            bindings,
+                        } => {
+                            for (i, b) in bindings.iter().enumerate() {
+                                fc.emit_op(EXTRACT_FIELD);
+                                fc.emit_u8(i as u8);
+                                fc.emit_op(STORE_LOCAL);
+                                fc.emit_u8(b.0 as u8);
+                            }
+                        }
+                        _ => {}
                     }
                     None
                 } else {
@@ -531,13 +545,21 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
 /// MIR Match walker handles. Wildcard / Literal(Int) (4g-1),
 /// Cons + EmptyList (4g-2). Further variants land in 4g-3+.
 fn pattern_in_4g_subset(p: &MirPattern) -> bool {
-    matches!(
-        p,
+    match p {
         MirPattern::Wildcard
-            | MirPattern::Literal(Literal::Int(_))
-            | MirPattern::Cons { .. }
-            | MirPattern::EmptyList
-    )
+        | MirPattern::Literal(Literal::Int(_))
+        | MirPattern::Cons { .. }
+        | MirPattern::EmptyList => true,
+        // 4g-3: User-ctor patterns (sum-type variants). Built-in
+        // ctor patterns (Result.Ok / Result.Err / Option.Some /
+        // Option.None) need a different opcode story (MATCH_UNWRAP
+        // for the wrapper kinds) and land in 4g-4.
+        MirPattern::Ctor {
+            ctor: MirCtor::User(_),
+            ..
+        } => true,
+        _ => false,
+    }
 }
 
 /// Emit the pattern check for a non-last arm. Returns the
@@ -577,6 +599,63 @@ fn emit_pattern_check(
             fc.emit_u8(head.0 as u8);
             fc.emit_op(STORE_LOCAL);
             fc.emit_u8(tail.0 as u8);
+            Ok(Some(patch))
+        }
+        MirPattern::Ctor {
+            ctor: MirCtor::User(ctor_id),
+            bindings,
+        } => {
+            // Resolve `CtorId → arena ctor_id` via the same path
+            // the HIR walker uses (symbol table → canonical name
+            // → arena type id → variant id → arena ctor id).
+            let entry = fc.symbol_table.ctor_entry(*ctor_id);
+            let owning_type = entry.owning_type;
+            let variant_name = entry.name.clone();
+            let qualified_type_name = fc.canonical_type_name(owning_type)?;
+            let arena_type_id = fc.resolve_type_id(&qualified_type_name).ok_or_else(|| {
+                MirVmUnsupported::InnerError(CompileError {
+                    msg: format!(
+                        "MIR-VM: unknown arena type `{qualified_type_name}` for ctor pattern"
+                    ),
+                })
+            })?;
+            let variant_id = fc
+                .arena
+                .find_variant_id(arena_type_id, &variant_name)
+                .ok_or_else(|| {
+                    MirVmUnsupported::InnerError(CompileError {
+                        msg: format!(
+                            "MIR-VM: unknown variant `{variant_name}` on `{qualified_type_name}`"
+                        ),
+                    })
+                })?;
+            let arena_ctor_id =
+                fc.arena.find_ctor_id(arena_type_id, variant_id).ok_or_else(|| {
+                    MirVmUnsupported::InnerError(CompileError {
+                        msg: format!(
+                            "MIR-VM: unknown arena ctor id for `{qualified_type_name}.{variant_name}`"
+                        ),
+                    })
+                })?;
+            if arena_ctor_id > u16::MAX as u32 {
+                return Err(MirVmUnsupported::InnerError(CompileError {
+                    msg: format!(
+                        "MIR-VM: ctor id too large for MATCH_VARIANT: {qualified_type_name}.{variant_name}"
+                    ),
+                }));
+            }
+            fc.emit_op(MATCH_VARIANT);
+            fc.emit_u16(arena_ctor_id as u16);
+            let patch = fc.offset();
+            fc.emit_i16(0);
+            // EXTRACT_FIELD doesn't consume the subject — value
+            // stays on the stack between field extractions.
+            for (i, b) in bindings.iter().enumerate() {
+                fc.emit_op(EXTRACT_FIELD);
+                fc.emit_u8(i as u8);
+                fc.emit_op(STORE_LOCAL);
+                fc.emit_u8(b.0 as u8);
+            }
             Ok(Some(patch))
         }
         // Preflight in the caller filters everything else out.

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -431,17 +431,38 @@ fn match_cons_emptylist_runtime_parity() {
 }
 
 #[test]
-fn match_ctor_pattern_still_falls_back_to_hir() {
-    // 4g-2 explicitly does NOT cover Ctor patterns; those still
-    // ride HIR fallback. Test the fn still appears in the
-    // chunks (compile_program_with_mir_fallback dispatches
-    // correctly).
-    let src = "type Shape\n  Circle(Int)\n  Square(Int)\n\nfn area(s: Shape) -> Int\n    match s\n        Shape.Circle(r) -> r\n        Shape.Square(side) -> side\n";
+fn match_user_ctor_pattern_runtime_parity() {
+    // Phase 4g-3 — `match s { Shape.Circle(r) -> r;
+    // Shape.Square(side) -> side }` runs identically through
+    // both paths. The MIR walker resolves CtorId → CtorEntry →
+    // arena ctor id and emits MATCH_VARIANT, mirroring the
+    // HIR walker exactly.
+    let src = "type Shape\n  Circle(Int)\n  Square(Int)\n\nfn extract(s: Shape) -> Int\n    match s\n        Shape.Circle(r) -> r\n        Shape.Square(side) -> side\n\nfn circle_eight(_d: Int) -> Int\n    extract(Shape.Circle(8))\n\nfn square_three(_d: Int) -> Int\n    extract(Shape.Square(3))\n";
+
+    let hir_circle = run_via_path(src, "circle_eight", &[0], Path::Hir);
+    let mir_circle = run_via_path(src, "circle_eight", &[0], Path::MirFallback);
+    assert_eq!(hir_circle, mir_circle);
+    assert_eq!(hir_circle, Value::Int(8));
+
+    let hir_square = run_via_path(src, "square_three", &[0], Path::Hir);
+    let mir_square = run_via_path(src, "square_three", &[0], Path::MirFallback);
+    assert_eq!(hir_square, mir_square);
+    assert_eq!(hir_square, Value::Int(3));
+}
+
+#[test]
+fn match_builtin_ctor_pattern_still_falls_back_to_hir() {
+    // Phase 4g-3 explicitly does NOT cover built-in ctor
+    // patterns (Result.Ok / Result.Err / Option.Some /
+    // Option.None) — those need MATCH_UNWRAP (different
+    // opcode shape than MATCH_VARIANT) and land in 4g-4.
+    // The fn still lowers via HIR fallback.
+    let src = "fn unwrap(r: Result<Int, String>) -> Int\n    match r\n        Result.Ok(v) -> v\n        Result.Err(_) -> 0\n";
     let (hir, mir) = compile_both(src);
-    assert!(hir.find("area").is_some(), "area in HIR chunks");
+    assert!(hir.find("unwrap").is_some(), "unwrap in HIR chunks");
     assert!(
-        mir.find("area").is_some(),
-        "area still in MIR-path chunks via HIR fallback"
+        mir.find("unwrap").is_some(),
+        "unwrap still in MIR-path chunks via HIR fallback"
     );
 }
 

--- a/tests/mir_vm_phase4_skeleton.rs
+++ b/tests/mir_vm_phase4_skeleton.rs
@@ -65,17 +65,17 @@ fn user_fn_call_lands_in_subset() {
 
 #[test]
 fn complex_pattern_match_fn_falls_back_to_hir() {
-    // 4g-2 covers Cons + EmptyList. To keep this test honest as
-    // the subset grows, use a `Ctor` pattern which is still
-    // outside the subset (Phase 4g-3 territory).
+    // 4g-3 covers user-ctor patterns. To keep this test honest
+    // as the subset grows, use a Tuple pattern — still outside
+    // the subset (Phase 4g-5 territory).
     let mir = lower(
-        "fn double(x: Int) -> Int\n    x + x\n\ntype Shape\n  Circle(Int)\n  Square(Int)\n\nfn area(s: Shape) -> Int\n    match s\n        Shape.Circle(r) -> r\n        Shape.Square(side) -> side\n",
+        "fn double(x: Int) -> Int\n    x + x\n\nfn pair_sum(p: Tuple<Int, Int>) -> Int\n    match p\n        (a, b) -> a + b\n",
     );
     let cov = classify_mir_program_coverage(&mir);
     assert_eq!(cov.covered, 1, "double() in subset: {:?}", cov);
     assert_eq!(
         cov.needs_hir_fallback, 1,
-        "area() (Ctor pattern) needs HIR fallback: {:?}",
+        "pair_sum() (Tuple pattern) needs HIR fallback: {:?}",
         cov
     );
 }


### PR DESCRIPTION
## Summary

Third Match sub-PR. Subset:
- 4g-1: Wildcard, Literal(Int)
- 4g-2: + Cons, EmptyList
- **4g-3: + Ctor(User CtorId)**

Built-in ctor patterns (Result.Ok / Option.Some / etc.) need MATCH_UNWRAP — different opcode shape — and land in 4g-4.

## Emit

\`MirPattern::Ctor { ctor: MirCtor::User(ctor_id), bindings }\`:

\`\`\`
MATCH_VARIANT arena_ctor_id u16 fail_offset i16
per binding (i, LocalId):
  EXTRACT_FIELD i u8
  STORE_LOCAL slot u8
\`\`\`

Resolution: CtorId → CtorEntry { owning_type, name } → canonical_type_name → arena type id → variant_id → arena ctor_id. Mirrors HIR's `compile_constructor_pattern` exactly.

Last-arm exhaustive: skip MATCH_VARIANT, still EXTRACT_FIELD per binding.

## Parity proof (25 total)

- `match_user_ctor_pattern_runtime_parity` — `Shape.Circle(8) → 8`, `Shape.Square(3) → 3` agree
- `match_builtin_ctor_pattern_still_falls_back_to_hir` — Result.Ok arm stays HIR-fallback

Skeleton `complex_pattern_match_fn_falls_back_to_hir` rewired to Tuple pattern (4g-5 territory).

## Test plan
- [x] cargo fmt + clippy clean
- [x] 25/25 parity ✅
- [x] 4/4 skeleton ✅

## Next: 4g-4 — Built-in ctor patterns (MATCH_UNWRAP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)