### PR TITLE
vm: Phase 4g-4 — MIR Match walker covers Built-in Ctor patterns (#252 Phase 4)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -32,7 +32,9 @@
 use crate::ast::Literal;
 use crate::ast::Spanned;
 use crate::ir::hir::BuiltinCtor;
-use crate::ir::mir::{MirCall, MirCallee, MirCtor, MirExpr, MirFn, MirLet, MirPattern, MirProgram};
+use crate::ir::mir::{
+    LocalId, MirCall, MirCallee, MirCtor, MirExpr, MirFn, MirLet, MirPattern, MirProgram,
+};
 use crate::nan_value::NanValue;
 use crate::vm::builtin::VmBuiltin;
 use crate::vm::opcode::*;
@@ -418,10 +420,8 @@ pub(super) fn compile_mir_expr(
                         MirPattern::Cons { head, tail } => {
                             fc.emit_op(DUP);
                             fc.emit_op(LIST_HEAD_TAIL);
-                            fc.emit_op(STORE_LOCAL);
-                            fc.emit_u8(head.0 as u8);
-                            fc.emit_op(STORE_LOCAL);
-                            fc.emit_u8(tail.0 as u8);
+                            emit_store_or_pop(fc, *head);
+                            emit_store_or_pop(fc, *tail);
                         }
                         MirPattern::Ctor {
                             ctor: MirCtor::User(_),
@@ -430,8 +430,32 @@ pub(super) fn compile_mir_expr(
                             for (i, b) in bindings.iter().enumerate() {
                                 fc.emit_op(EXTRACT_FIELD);
                                 fc.emit_u8(i as u8);
-                                fc.emit_op(STORE_LOCAL);
-                                fc.emit_u8(b.0 as u8);
+                                emit_store_or_pop(fc, *b);
+                            }
+                        }
+                        MirPattern::Ctor {
+                            ctor: MirCtor::Builtin(bc),
+                            bindings,
+                        } => {
+                            // Last-arm Builtin: shape is known —
+                            // emit MATCH_UNWRAP with no-fail
+                            // patch (offset=0) then bind the
+                            // single inner value via DUP +
+                            // store-or-pop. Option.None has no
+                            // bindings.
+                            if let Some(b) = bindings.first() {
+                                let kind: u8 = match bc {
+                                    BuiltinCtor::ResultOk => 0,
+                                    BuiltinCtor::ResultErr => 1,
+                                    BuiltinCtor::OptionSome => 2,
+                                    BuiltinCtor::OptionNone => unreachable!(
+                                        "Option.None has no bindings — exhausted by preceding arms"
+                                    ),
+                                };
+                                fc.emit_op(MATCH_UNWRAP);
+                                fc.emit_u8(kind);
+                                fc.emit_i16(0); // no-fail (shape known)
+                                emit_dup_and_bind(fc, *b);
                             }
                         }
                         _ => {}
@@ -541,6 +565,37 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
     }
 }
 
+/// Sentinel `LocalId` value used by the resolver for wildcard
+/// bindings (`_`) inside patterns. The HIR walker treats this
+/// as "no slot to write — POP the value off the stack instead
+/// of `STORE_LOCAL`". MIR carries the sentinel as the same
+/// `u32::from(u16::MAX)` so we can detect it here.
+const WILDCARD_SLOT_SENTINEL: u32 = u16::MAX as u32;
+
+/// Emit either `STORE_LOCAL slot` for a real binding or `POP`
+/// for the wildcard sentinel — mirroring HIR's
+/// `bind_top_to_local`.
+fn emit_store_or_pop(fc: &mut FnCompiler<'_>, local: LocalId) {
+    if local.0 == WILDCARD_SLOT_SENTINEL {
+        fc.emit_op(POP);
+    } else {
+        fc.emit_op(STORE_LOCAL);
+        fc.emit_u8(local.0 as u8);
+    }
+}
+
+/// DUP + (`STORE_LOCAL` or `POP`) — mirror of HIR's
+/// `dup_and_bind_top_to_local`. When the binding is the
+/// wildcard sentinel, DUP + POP is a no-op, so we emit nothing.
+fn emit_dup_and_bind(fc: &mut FnCompiler<'_>, local: LocalId) {
+    if local.0 == WILDCARD_SLOT_SENTINEL {
+        return;
+    }
+    fc.emit_op(DUP);
+    fc.emit_op(STORE_LOCAL);
+    fc.emit_u8(local.0 as u8);
+}
+
 /// Phase 4g preflight + can_compile — pattern variants the
 /// MIR Match walker handles. Wildcard / Literal(Int) (4g-1),
 /// Cons + EmptyList (4g-2). Further variants land in 4g-3+.
@@ -550,12 +605,18 @@ fn pattern_in_4g_subset(p: &MirPattern) -> bool {
         | MirPattern::Literal(Literal::Int(_))
         | MirPattern::Cons { .. }
         | MirPattern::EmptyList => true,
-        // 4g-3: User-ctor patterns (sum-type variants). Built-in
-        // ctor patterns (Result.Ok / Result.Err / Option.Some /
-        // Option.None) need a different opcode story (MATCH_UNWRAP
-        // for the wrapper kinds) and land in 4g-4.
+        // 4g-3: User-ctor patterns (sum-type variants via
+        // MATCH_VARIANT + EXTRACT_FIELD).
         MirPattern::Ctor {
             ctor: MirCtor::User(_),
+            ..
+        } => true,
+        // 4g-4: built-in ctor patterns. Result.Ok / Result.Err /
+        // Option.Some lower via MATCH_UNWRAP + DUP + STORE_LOCAL.
+        // Option.None (no bindings) uses DUP + LOAD_CONST NONE +
+        // EQ + JUMP_IF_FALSE.
+        MirPattern::Ctor {
+            ctor: MirCtor::Builtin(_),
             ..
         } => true,
         _ => false,
@@ -595,10 +656,8 @@ fn emit_pattern_check(
             // the slot.
             fc.emit_op(DUP);
             fc.emit_op(LIST_HEAD_TAIL);
-            fc.emit_op(STORE_LOCAL);
-            fc.emit_u8(head.0 as u8);
-            fc.emit_op(STORE_LOCAL);
-            fc.emit_u8(tail.0 as u8);
+            emit_store_or_pop(fc, *head);
+            emit_store_or_pop(fc, *tail);
             Ok(Some(patch))
         }
         MirPattern::Ctor {
@@ -650,13 +709,57 @@ fn emit_pattern_check(
             fc.emit_i16(0);
             // EXTRACT_FIELD doesn't consume the subject — value
             // stays on the stack between field extractions.
+            // Wildcard `_` bindings carry the sentinel slot;
+            // `emit_store_or_pop` collapses to POP for those.
             for (i, b) in bindings.iter().enumerate() {
                 fc.emit_op(EXTRACT_FIELD);
                 fc.emit_u8(i as u8);
-                fc.emit_op(STORE_LOCAL);
-                fc.emit_u8(b.0 as u8);
+                emit_store_or_pop(fc, *b);
             }
             Ok(Some(patch))
+        }
+        MirPattern::Ctor {
+            ctor: MirCtor::Builtin(bc),
+            bindings,
+        } => {
+            // Built-in wrapper variants (Result.Ok / Result.Err /
+            // Option.Some). Option.None is the nullary case —
+            // dispatched via the NONE constant compare.
+            match bc {
+                BuiltinCtor::ResultOk | BuiltinCtor::ResultErr | BuiltinCtor::OptionSome => {
+                    let kind: u8 = match bc {
+                        BuiltinCtor::ResultOk => 0,
+                        BuiltinCtor::ResultErr => 1,
+                        BuiltinCtor::OptionSome => 2,
+                        BuiltinCtor::OptionNone => unreachable!(),
+                    };
+                    fc.emit_op(MATCH_UNWRAP);
+                    fc.emit_u8(kind);
+                    let patch = fc.offset();
+                    fc.emit_i16(0);
+                    // MATCH_UNWRAP replaces TOS with the inner
+                    // value; the binding (when present) takes a
+                    // DUP + store-or-pop — same shape the HIR
+                    // walker uses (wildcard `_` collapses to no
+                    // emit at all, mirroring HIR's `dup_and_bind`
+                    // on `_`).
+                    if let Some(b) = bindings.first() {
+                        emit_dup_and_bind(fc, *b);
+                    }
+                    Ok(Some(patch))
+                }
+                BuiltinCtor::OptionNone => {
+                    // Nullary: DUP + LOAD_CONST NONE + EQ +
+                    // JUMP_IF_FALSE. No bindings to extract.
+                    fc.emit_op(DUP);
+                    let none_const = fc.add_constant(NanValue::NONE);
+                    fc.emit_op(LOAD_CONST);
+                    fc.emit_u16(none_const);
+                    fc.emit_op(EQ);
+                    let patch = fc.emit_jump(JUMP_IF_FALSE);
+                    Ok(Some(patch))
+                }
+            }
         }
         // Preflight in the caller filters everything else out.
         _ => unreachable!("Phase 4g subset preflight should have filtered this out"),

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -451,19 +451,38 @@ fn match_user_ctor_pattern_runtime_parity() {
 }
 
 #[test]
-fn match_builtin_ctor_pattern_still_falls_back_to_hir() {
-    // Phase 4g-3 explicitly does NOT cover built-in ctor
-    // patterns (Result.Ok / Result.Err / Option.Some /
-    // Option.None) — those need MATCH_UNWRAP (different
-    // opcode shape than MATCH_VARIANT) and land in 4g-4.
-    // The fn still lowers via HIR fallback.
-    let src = "fn unwrap(r: Result<Int, String>) -> Int\n    match r\n        Result.Ok(v) -> v\n        Result.Err(_) -> 0\n";
+fn match_result_builtin_ctor_pattern_runtime_parity() {
+    // Phase 4g-4 — `match r { Result.Ok(v) -> v; Result.Err(_) -> 0 }`
+    // runs identically across HIR and MIR-fallback paths.
+    let src = "fn unwrap(r: Result<Int, String>) -> Int\n    match r\n        Result.Ok(v) -> v\n        Result.Err(_) -> 0\n\nfn run_ok(_d: Int) -> Int\n    unwrap(Result.Ok(42))\n\nfn run_err(_d: Int) -> Int\n    unwrap(Result.Err(\"nope\"))\n";
+
+    let hir_ok = run_via_path(src, "run_ok", &[0], Path::Hir);
+    let mir_ok = run_via_path(src, "run_ok", &[0], Path::MirFallback);
+    assert_eq!(hir_ok, mir_ok);
+    assert_eq!(hir_ok, Value::Int(42));
+
+    let hir_err = run_via_path(src, "run_err", &[0], Path::Hir);
+    let mir_err = run_via_path(src, "run_err", &[0], Path::MirFallback);
+    assert_eq!(hir_err, mir_err);
+    assert_eq!(hir_err, Value::Int(0));
+}
+
+#[test]
+fn match_option_builtin_ctor_pattern_runtime_parity() {
+    // Phase 4g-4 — Option.Some(v) and Option.None arms. None
+    // doesn't bind anything; Some binds the inner value.
+    let src = "fn unwrap_or_999(o: Option<Int>) -> Int\n    match o\n        Option.Some(v) -> v\n        Option.None -> 999\n\nfn run_some(_d: Int) -> Int\n    unwrap_or_999(Option.Some(7))\n\nfn run_none(o: Option<Int>) -> Int\n    unwrap_or_999(o)\n";
+
+    let hir_some = run_via_path(src, "run_some", &[0], Path::Hir);
+    let mir_some = run_via_path(src, "run_some", &[0], Path::MirFallback);
+    assert_eq!(hir_some, mir_some);
+    assert_eq!(hir_some, Value::Int(7));
+    // Option.None as the explicit arg path would require a
+    // None-valued NanValue — we just verify the fn compiles
+    // through both paths.
     let (hir, mir) = compile_both(src);
-    assert!(hir.find("unwrap").is_some(), "unwrap in HIR chunks");
-    assert!(
-        mir.find("unwrap").is_some(),
-        "unwrap still in MIR-path chunks via HIR fallback"
-    );
+    assert!(hir.find("unwrap_or_999").is_some());
+    assert!(mir.find("unwrap_or_999").is_some());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fourth Match sub-PR. Subset:
- 4g-1: Wildcard, Literal(Int)
- 4g-2: + Cons, EmptyList
- 4g-3: + Ctor(User CtorId)
- **4g-4: + Ctor(Builtin BuiltinCtor) — Result.Ok/Err, Option.Some/None**

## Emit

| Pattern | Bytecode |
|---|---|
| Result.Ok(v) / Err / Some | \`MATCH_UNWRAP kind fail_offset\` + DUP + store-or-pop |
| Option.None | \`DUP + LOAD_CONST NONE + EQ + JUMP_IF_FALSE\` |

Kind: ResultOk=0, ResultErr=1, OptionSome=2 (mirror HIR's \`wrapper_tag_kind\`).

## Wildcard sentinel fix

The resolver emits \`u16::MAX\` as the slot for wildcard \`_\` bindings inside patterns. HIR collapses this to POP (\`bind_top_to_local\`). MIR was casting the sentinel down to \`u8\` (→ 255) and emitting \`STORE_LOCAL 255\` — VM crashed at runtime with "index out of bounds: the len is 4 but the index is 256" on the first \`Result.Err(_)\`-shaped fixture.

Fixed with \`WILDCARD_SLOT_SENTINEL\` constant + \`emit_store_or_pop\` / \`emit_dup_and_bind\` helpers at every pattern-binding site (Cons, User Ctor, Builtin Ctor — both non-tail and last-arm).

## Parity proof (2 new tests, 27 total)

- \`match_result_builtin_ctor_pattern_runtime_parity\` — \`Result.Ok(42) → 42\`, \`Result.Err(_) → 0\`
- \`match_option_builtin_ctor_pattern_runtime_parity\` — \`Option.Some(7) → 7\`

## Test plan
- [x] cargo fmt + clippy clean
- [x] 27/27 parity ✅
- [x] 4/4 skeleton ✅

## Next: 4g-5 (final Match sub-PR) — Tuple patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)