### PR TITLE
vm: Phase 4g-5 — MIR Match walker covers Tuple patterns (#252 Phase 4, final Match sub-PR)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -433,6 +433,22 @@ pub(super) fn compile_mir_expr(
                                 emit_store_or_pop(fc, *b);
                             }
                         }
+                        MirPattern::Tuple(items) => {
+                            // Last-arm Tuple: shape known —
+                            // skip MATCH_TUPLE preamble, just
+                            // EXTRACT each item + bind/pop.
+                            for (i, sub) in items.iter().enumerate() {
+                                fc.emit_op(EXTRACT_TUPLE_ITEM);
+                                fc.emit_u8(i as u8);
+                                match sub {
+                                    MirPattern::Wildcard => fc.emit_op(POP),
+                                    MirPattern::Bind(local) => emit_store_or_pop(fc, *local),
+                                    _ => unreachable!(
+                                        "preflight: Tuple subpatterns restricted to Wildcard | Bind"
+                                    ),
+                                }
+                            }
+                        }
                         MirPattern::Ctor {
                             ctor: MirCtor::Builtin(bc),
                             bindings,
@@ -611,14 +627,18 @@ fn pattern_in_4g_subset(p: &MirPattern) -> bool {
             ctor: MirCtor::User(_),
             ..
         } => true,
-        // 4g-4: built-in ctor patterns. Result.Ok / Result.Err /
-        // Option.Some lower via MATCH_UNWRAP + DUP + STORE_LOCAL.
-        // Option.None (no bindings) uses DUP + LOAD_CONST NONE +
-        // EQ + JUMP_IF_FALSE.
+        // 4g-4: built-in ctor patterns.
         MirPattern::Ctor {
             ctor: MirCtor::Builtin(_),
             ..
         } => true,
+        // 4g-5: Tuple patterns with flat Wildcard / Bind
+        // subpatterns. Nested structural patterns (Cons / Ctor
+        // inside a Tuple) need cleanup-jump emit and are
+        // deferred.
+        MirPattern::Tuple(items) => items
+            .iter()
+            .all(|sub| matches!(sub, MirPattern::Wildcard | MirPattern::Bind(_))),
         _ => false,
     }
 }
@@ -715,6 +735,32 @@ fn emit_pattern_check(
                 fc.emit_op(EXTRACT_FIELD);
                 fc.emit_u8(i as u8);
                 emit_store_or_pop(fc, *b);
+            }
+            Ok(Some(patch))
+        }
+        MirPattern::Tuple(items) => {
+            // Phase 4g-5 — tuple pattern with flat subpatterns
+            // (Wildcard / Bind). Emit MATCH_TUPLE arity +
+            // fail_offset; for each subpattern emit
+            // EXTRACT_TUPLE_ITEM idx then store-or-pop.
+            //
+            // Nested structural subpatterns (Cons / Ctor inside
+            // a Tuple) need cleanup-jump emit similar to HIR's
+            // `compile_extracted_subpattern`; deferred.
+            fc.emit_op(MATCH_TUPLE);
+            fc.emit_u8(items.len() as u8);
+            let patch = fc.offset();
+            fc.emit_i16(0);
+            for (i, sub) in items.iter().enumerate() {
+                fc.emit_op(EXTRACT_TUPLE_ITEM);
+                fc.emit_u8(i as u8);
+                match sub {
+                    MirPattern::Wildcard => fc.emit_op(POP),
+                    MirPattern::Bind(local) => emit_store_or_pop(fc, *local),
+                    _ => unreachable!(
+                        "preflight should have restricted subpatterns to Wildcard | Bind"
+                    ),
+                }
             }
             Ok(Some(patch))
         }

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -486,6 +486,29 @@ fn match_option_builtin_ctor_pattern_runtime_parity() {
 }
 
 #[test]
+fn match_tuple_pattern_runtime_parity() {
+    // Phase 4g-5 — flat tuple pattern with Bind subpatterns.
+    // `(a, b) -> a + b` runs identically on both paths.
+    let src = "fn pair_sum(p: Tuple<Int, Int>) -> Int\n    match p\n        (a, b) -> a + b\n\nfn check(_d: Int) -> Int\n    pair_sum((3, 4))\n";
+    let hir = run_via_path(src, "check", &[0], Path::Hir);
+    let mir = run_via_path(src, "check", &[0], Path::MirFallback);
+    assert_eq!(hir, mir, "Tuple match parity: HIR={hir:?}, MIR={mir:?}");
+    assert_eq!(hir, Value::Int(7));
+}
+
+#[test]
+fn match_tuple_with_wildcard_subpattern_parity() {
+    // `(_, b) -> b` — wildcard subpattern collapses to POP in
+    // the MIR walker (mirror of HIR's bind_top_to_local on
+    // wildcard).
+    let src = "fn second(p: Tuple<Int, Int>) -> Int\n    match p\n        (_, b) -> b\n\nfn check(_d: Int) -> Int\n    second((11, 22))\n";
+    let hir = run_via_path(src, "check", &[0], Path::Hir);
+    let mir = run_via_path(src, "check", &[0], Path::MirFallback);
+    assert_eq!(hir, mir);
+    assert_eq!(hir, Value::Int(22));
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output

--- a/tests/mir_vm_phase4_skeleton.rs
+++ b/tests/mir_vm_phase4_skeleton.rs
@@ -64,18 +64,24 @@ fn user_fn_call_lands_in_subset() {
 }
 
 #[test]
-fn complex_pattern_match_fn_falls_back_to_hir() {
-    // 4g-3 covers user-ctor patterns. To keep this test honest
-    // as the subset grows, use a Tuple pattern — still outside
-    // the subset (Phase 4g-5 territory).
+fn nested_tuple_pattern_falls_back_to_hir() {
+    // Phase 4g-5 covers flat Tuple patterns (Wildcard / Bind
+    // subpatterns). Nested structural subpatterns (Cons / Ctor
+    // inside a Tuple) still need HIR fallback — they require
+    // cleanup-jump emit logic deferred to a future sub-PR.
+    //
+    // Use `match (xs, n) { ([], _) -> 0; ([_, ..], 0) -> 1;
+    // _ -> 2 }` — the outer pattern is a Tuple whose first
+    // subpattern is EmptyList/Cons (nested non-flat), so the
+    // 4g-5 walker drops back to HIR.
     let mir = lower(
-        "fn double(x: Int) -> Int\n    x + x\n\nfn pair_sum(p: Tuple<Int, Int>) -> Int\n    match p\n        (a, b) -> a + b\n",
+        "fn double(x: Int) -> Int\n    x + x\n\nfn classify(p: Tuple<List<Int>, Int>) -> Int\n    match p\n        ([], _) -> 0\n        _ -> 1\n",
     );
     let cov = classify_mir_program_coverage(&mir);
     assert_eq!(cov.covered, 1, "double() in subset: {:?}", cov);
     assert_eq!(
         cov.needs_hir_fallback, 1,
-        "pair_sum() (Tuple pattern) needs HIR fallback: {:?}",
+        "classify() (nested tuple subpattern) needs HIR fallback: {:?}",
         cov
     );
 }


### PR DESCRIPTION
## Summary

**Final Match sub-PR.** Subset:
- 4g-1: Wildcard, Literal(Int)
- 4g-2: + Cons, EmptyList
- 4g-3: + Ctor(User CtorId)
- 4g-4: + Ctor(Builtin BuiltinCtor)
- **4g-5: + Tuple(items) — flat Wildcard / Bind subpatterns**

Nested structural subpatterns (Cons / Ctor inside a Tuple) need cleanup-jump emit and stay HIR-fallback.

## Emit

\`\`\`
MATCH_TUPLE arity fail_offset
per (i, sub):
  EXTRACT_TUPLE_ITEM i
  Wildcard      → POP
  Bind(local)   → store_or_pop(local)
\`\`\`

Last-arm exhaustive: skip MATCH_TUPLE, just per-item EXTRACT + bind.

## Parity proof (2 new tests, 29 total)

- \`match_tuple_pattern_runtime_parity\` — \`(a, b) -> a + b\` on \`(3, 4)\` → 7
- \`match_tuple_with_wildcard_subpattern_parity\` — \`(_, b) -> b\` on \`(11, 22)\` → 22 (wildcard via 4g-4's WILDCARD_SLOT_SENTINEL helper)

## Phase 4 vertical slice complete

| MirExpr | MIR walker coverage |
|---|---|
| Literal / Local / BinOp / Neg / Let / Return | ✓ |
| Call(Fn / Builtin) | ✓ |
| Construct(User / Builtin) + Project | ✓ |
| Try + TailCall | ✓ |
| List / Tuple / RecordCreate / RecordUpdate | ✓ |
| **Match** | **✓ (this stack)** |
| MapLiteral / InterpolatedStr / IndependentProduct | deferred |

Every MirPattern variant has some walker coverage (flat / single-level — nested structural patterns deferred).

## Test plan
- [x] cargo fmt + clippy clean
- [x] 29/29 parity ✅
- [x] 4/4 skeleton ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)