### PR TITLE
ir/mir + vm: Phase 6 wave 1 — type-stamp propagation + typed BinOp/Neg emit (#252 Phase 6)

### DIFF
--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -555,14 +555,19 @@ fn take_slot(slots: &[u16], cursor: &mut usize) -> Result<u16, SkipReason> {
 }
 
 /// Wrap a freshly-lowered node in `Spanned` while inheriting the
-/// source's line. The MIR type stamp starts uninitialised — Phase
-/// 6 optimizer passes may fill it later; consumers that need the
-/// HIR-side stamp can still read `expr.ty()` on the original.
+/// source's line. Phase 6 wave 1: propagate the HIR-side type
+/// stamp into MIR so downstream consumers (VM walker's typed
+/// opcodes, future inliner / monomorphizer) can read
+/// `mir_expr.ty()` without re-deriving the type.
 fn wrap<T, U>(node: T, source: &Spanned<U>) -> Spanned<T> {
+    let ty = std::sync::OnceLock::new();
+    if let Some(t) = source.ty() {
+        let _ = ty.set(t.clone());
+    }
     Spanned {
         node,
         line: source.line,
-        ty: std::sync::OnceLock::new(),
+        ty,
     }
 }
 

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -93,16 +93,26 @@ pub(super) fn compile_mir_expr(
             let bop = &spanned_binop.node;
             compile_mir_expr(fc, &bop.lhs)?;
             compile_mir_expr(fc, &bop.rhs)?;
-            // No type stamp on MIR sub-nodes yet; emit the generic
-            // BinOp opcode and let the VM's runtime tag dispatch
-            // pick the typed path. Phase 6's type-stamp propagation
-            // can later switch this to `emit_binop_typed`.
-            emit_binop_generic(fc, bop.op);
+            // Phase 6 wave 1: type stamps now propagate from HIR
+            // into MIR sub-nodes via `lower::wrap`. When both
+            // operands carry a primitive numeric stamp, emit the
+            // typed opcode (ADD_INT / ADD_FLOAT / …); otherwise
+            // fall back to the generic dispatcher.
+            emit_binop_typed(fc, bop.op, bop.lhs.ty(), bop.rhs.ty());
             Ok(())
         }
         MirExpr::Neg(inner) => {
             compile_mir_expr(fc, inner)?;
-            fc.emit_op(NEG);
+            // Same wave: pick the typed NEG when the operand
+            // carries a primitive numeric stamp. Float's typed
+            // path preserves `-0.0` IEEE-754 semantics (the
+            // generic NEG bounces through `0 - x`).
+            let op = match inner.ty() {
+                Some(crate::ast::Type::Int) => NEG_INT,
+                Some(crate::ast::Type::Float) => NEG_FLOAT,
+                _ => NEG,
+            };
+            fc.emit_op(op);
             Ok(())
         }
         MirExpr::Let(spanned_let) => {
@@ -1038,28 +1048,75 @@ fn emit_constructor_arg(
     }
 }
 
-fn emit_binop_generic(fc: &mut FnCompiler<'_>, op: crate::ast::BinOp) {
+fn emit_binop_typed(
+    fc: &mut FnCompiler<'_>,
+    op: crate::ast::BinOp,
+    lhs_ty: Option<&crate::ast::Type>,
+    rhs_ty: Option<&crate::ast::Type>,
+) {
     use crate::ast::BinOp::*;
+    use crate::ast::Type;
+    let both_int = matches!((lhs_ty, rhs_ty), (Some(Type::Int), Some(Type::Int)));
+    let both_float = matches!((lhs_ty, rhs_ty), (Some(Type::Float), Some(Type::Float)));
+    let lt_op = if both_int {
+        LT_INT
+    } else if both_float {
+        LT_FLOAT
+    } else {
+        LT
+    };
+    let gt_op = if both_int {
+        GT_INT
+    } else if both_float {
+        GT_FLOAT
+    } else {
+        GT
+    };
+    let add_op = if both_int {
+        ADD_INT
+    } else if both_float {
+        ADD_FLOAT
+    } else {
+        ADD
+    };
+    let sub_op = if both_int {
+        SUB_INT
+    } else if both_float {
+        SUB_FLOAT
+    } else {
+        SUB
+    };
+    let mul_op = if both_int {
+        MUL_INT
+    } else if both_float {
+        MUL_FLOAT
+    } else {
+        MUL
+    };
+    // No DIV_INT — integer division traps on `b == 0` and the
+    // generic `arith_div` already does that branch + propagates
+    // a typed runtime error.
+    let div_op = if both_float { DIV_FLOAT } else { DIV };
     match op {
-        Add => fc.emit_op(ADD),
-        Sub => fc.emit_op(SUB),
-        Mul => fc.emit_op(MUL),
-        Div => fc.emit_op(DIV),
-        Eq => fc.emit_op(EQ),
-        Lt => fc.emit_op(LT),
-        Gt => fc.emit_op(GT),
-        // `Neq` / `Lte` / `Gte` have no dedicated opcodes —
-        // they're invert-of-the-corresponding-comparison.
+        Add => fc.emit_op(add_op),
+        Sub => fc.emit_op(sub_op),
+        Mul => fc.emit_op(mul_op),
+        Div => fc.emit_op(div_op),
+        Eq => fc.emit_op(if both_int { EQ_INT } else { EQ }),
+        Lt => fc.emit_op(lt_op),
+        Gt => fc.emit_op(gt_op),
+        // `Neq` / `Lte` / `Gte` invert the corresponding
+        // comparison (same composition HIR uses).
         Neq => {
-            fc.emit_op(EQ);
+            fc.emit_op(if both_int { EQ_INT } else { EQ });
             fc.emit_op(NOT);
         }
         Lte => {
-            fc.emit_op(GT);
+            fc.emit_op(gt_op);
             fc.emit_op(NOT);
         }
         Gte => {
-            fc.emit_op(LT);
+            fc.emit_op(lt_op);
             fc.emit_op(NOT);
         }
     }

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -587,6 +587,63 @@ fn match_non_int_literal_pattern_runtime_parity() {
 }
 
 #[test]
+fn typed_int_arith_bytecode_parity() {
+    // Phase 6 wave 1 — MIR carries type stamps now, so the
+    // BinOp branch picks ADD_INT/SUB_INT/MUL_INT instead of the
+    // generic ADD/SUB/MUL. Byte-identical with HIR.
+    let (hir, mir) = compile_both("fn arith(a: Int, b: Int) -> Int\n    a + b - a * b\n");
+    let hir_fn = hir.get(hir.find("arith").expect("arith in HIR"));
+    let mir_fn = mir.get(mir.find("arith").expect("arith in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "Typed Int arith must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn typed_float_arith_bytecode_parity() {
+    // Float-typed BinOp picks ADD_FLOAT / SUB_FLOAT / MUL_FLOAT
+    // / DIV_FLOAT. Same emit as HIR.
+    let (hir, mir) =
+        compile_both("fn farith(a: Float, b: Float) -> Float\n    a + b - a * b / b\n");
+    let hir_fn = hir.get(hir.find("farith").expect("farith in HIR"));
+    let mir_fn = mir.get(mir.find("farith").expect("farith in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "Typed Float arith must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn typed_int_compare_bytecode_parity() {
+    // Int comparisons pick EQ_INT / LT_INT / GT_INT.
+    let (hir, mir) = compile_both("fn cmp(a: Int, b: Int) -> Bool\n    a == b\n");
+    let hir_fn = hir.get(hir.find("cmp").expect("cmp in HIR"));
+    let mir_fn = mir.get(mir.find("cmp").expect("cmp in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "Typed Int compare must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn typed_neg_float_bytecode_parity() {
+    // Float NEG picks NEG_FLOAT (preserves -0.0 IEEE-754
+    // semantics). Same emit as HIR.
+    let (hir, mir) = compile_both("fn flip(x: Float) -> Float\n    -x\n");
+    let hir_fn = hir.get(hir.find("flip").expect("flip in HIR"));
+    let mir_fn = mir.get(mir.find("flip").expect("flip in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "NEG_FLOAT emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output


### PR DESCRIPTION
## Summary

Pierwsza wave Phase 6 — pierwsze realne kupony z MIR. Walker do tej pory emit'ował generic ADD/SUB/MUL/DIV/EQ/LT/GT/NEG nawet gdy HIR znał typy. To była luka bytecode parity dla każdego numeric kernel.

## Co lands

- \`ir::mir::lower::wrap\` propaguje HIR-side \`Spanned::ty()\` do MIR node. Każdy MIR sub-node carries the type stamp typechecker computed.
- \`vm::compiler::mir::emit_binop_typed\` mirror HIR's emit. Reads \`bop.lhs.ty()\` / \`bop.rhs.ty()\` → typed opcode (ADD_INT/ADD_FLOAT/EQ_INT/LT_INT/LT_FLOAT/…) gdy oba operands tego samego primitive type; fallback do generic w przeciwnym razie.
- \`MirExpr::Neg\` walker reads \`inner.ty()\` → NEG_INT/NEG_FLOAT/NEG. Float NEG preserves -0.0 IEEE-754.
- \`emit_binop_generic\` usunięte.

## Parity proof (4 new tests, 36 total)

| Test | Co dowodzi |
|---|---|
| \`typed_int_arith_bytecode_parity\` | \`a + b - a * b\` (Int) → ADD_INT/SUB_INT/MUL_INT byte-identical |
| \`typed_float_arith_bytecode_parity\` | Float → ADD_FLOAT/SUB_FLOAT/MUL_FLOAT/DIV_FLOAT |
| \`typed_int_compare_bytecode_parity\` | \`a == b\` → EQ_INT |
| \`typed_neg_float_bytecode_parity\` | \`-x\` (Float) → NEG_FLOAT |

## Co to znaczy dla użytkowników

Dla każdej fn fully inside MIR walker subset: bytecode arithmetic/compare/NEG **byte-identical z HIR specialised emit**. VM tag-dispatch overhead per op znika na typed path.

## Pozostały bytecode gap (kolejne wave)

- MATCH_DISPATCH_CONST table fast-path — wave 2
- Per-builtin opcodes (LIST_LEN, MAP_GET, UNWRAP_OR) — wave 3
- last-use revival → owned_mask — wave 4
- inliner / monomorphizer — wave 5 (opt-in)

## Test plan
- [x] cargo fmt + clippy clean
- [x] 36/36 parity ✅
- [x] 4/4 skeleton ✅
- [x] no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)