### PR TITLE
vm: Phase 6 waves 2+3 — MATCH_DISPATCH_CONST + specialised builtin opcodes (#252 Phase 6)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -419,6 +419,19 @@ pub(super) fn compile_mir_expr(
         //   end:
         MirExpr::Match(spanned_match) => {
             let m = &spanned_match.node;
+            // Phase 6 wave 2 — try the MATCH_DISPATCH_CONST table
+            // fast-path before falling back to the linear arm-by-
+            // arm emit. When every non-last arm has a literal
+            // pattern + literal body and the last arm is a
+            // wildcard/bind default, HIR's `compile_match` emits
+            // a single jump-table dispatch (MATCH_DISPATCH_CONST)
+            // with inline (kind, expected_bits, result_bits)
+            // entries — one VM op for the whole match. Mirror it
+            // here so MIR matches HIR byte-for-byte on the
+            // common shape.
+            if try_emit_match_dispatch_const(fc, &m.subject, &m.arms)?.is_some() {
+                return Ok(());
+            }
             compile_mir_expr(fc, &m.subject)?;
 
             let mut end_jumps: Vec<usize> = Vec::new();
@@ -902,6 +915,139 @@ fn emit_pattern_check(
             }
         }
     }
+}
+
+/// Phase 6 wave 2 — try the MATCH_DISPATCH_CONST table
+/// fast-path. Returns `Ok(Some(()))` when the table was emitted
+/// (caller skips the linear emit), `Ok(None)` when the arm
+/// shape doesn't fit the fast-path (caller proceeds with linear
+/// emit). Mirrors HIR's `emit_match_dispatch_const`.
+///
+/// Fast-path requirements (mirrors HIR's classifier):
+/// - At least one dispatchable arm (otherwise the table is
+///   pointless).
+/// - Every non-last arm: pattern is `Literal(Int | Bool | Unit)`
+///   (the bit-comparable subset) with a body that itself
+///   reduces to a `Literal` whose `NanValue::bits()` we can
+///   inline as the result.
+/// - The last arm is the default: `Wildcard` / `Bind`. We do
+///   not require its body to be a literal — the opcode pushes
+///   the subject back on miss and falls through to the default
+///   arm body, which we compile normally.
+fn try_emit_match_dispatch_const(
+    fc: &mut FnCompiler<'_>,
+    subject: &Spanned<MirExpr>,
+    arms: &[crate::ir::mir::MirMatchArm],
+) -> Result<Option<()>, MirVmUnsupported> {
+    if arms.len() < 2 {
+        return Ok(None);
+    }
+    let last_idx = arms.len() - 1;
+    let default_arm = &arms[last_idx];
+    let default_local = match &default_arm.pattern {
+        MirPattern::Wildcard => None,
+        MirPattern::Bind(local) => Some(*local),
+        _ => return Ok(None),
+    };
+
+    // Classify all non-default arms — every one must be a
+    // const-dispatchable literal pattern with a const literal
+    // body. Anything else aborts the fast-path.
+    let mut entries: Vec<(u8, u64, u64)> = Vec::with_capacity(last_idx);
+    for arm in &arms[..last_idx] {
+        let pattern_lit = match &arm.pattern {
+            MirPattern::Literal(lit) => lit,
+            _ => return Ok(None),
+        };
+        let body_lit = match &arm.body.node {
+            MirExpr::Literal(spanned_lit) => &spanned_lit.node,
+            _ => return Ok(None),
+        };
+        let expected = literal_dispatch_bits(fc, pattern_lit);
+        let result = literal_dispatch_bits(fc, body_lit);
+        // Strings would need DISPATCH_KIND_STRING + arena-side
+        // interning to compare; keep this wave focused on
+        // bit-equal dispatch (Int / Bool / Unit / Float-as-bits).
+        // Str / non-bit-comparable literals abort the fast-path.
+        if pattern_is_dispatchable_bits(pattern_lit) && body_is_dispatchable_bits(body_lit) {
+            entries.push((0u8, expected, result)); // DISPATCH_KIND_EXACT = 0
+        } else {
+            return Ok(None);
+        }
+    }
+
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    // ── Emit ────────────────────────────────────────────────
+    compile_mir_expr(fc, subject)?;
+
+    fc.emit_op(MATCH_DISPATCH_CONST);
+    fc.emit_u8(entries.len() as u8);
+    let default_offset_patch = fc.offset();
+    fc.emit_i16(0); // default_offset — patched after the table
+
+    for (kind, expected, result) in &entries {
+        fc.emit_u8(*kind);
+        fc.emit_u64(*expected);
+        fc.emit_u64(*result);
+    }
+    let table_end = fc.offset();
+
+    // On hit: opcode pushes the result and ip lands right after
+    // the table — emit a JUMP to skip past the default arm body.
+    let hit_skip = fc.emit_jump(JUMP);
+
+    // Default arm starts here. Default offset is relative to
+    // `table_end` (the opcode handler adds `default_offset` to
+    // ip-after-table-end).
+    let default_start = fc.offset();
+    let default_rel = (default_start as isize - table_end as isize) as i16;
+    let bytes = (default_rel as u16).to_be_bytes();
+    fc.code_mut()[default_offset_patch] = bytes[0];
+    fc.code_mut()[default_offset_patch + 1] = bytes[1];
+
+    // Default arm body — subject was popped+repushed by the
+    // opcode on miss. Bind it if the pattern is `Bind(local)`,
+    // then drop it via POP before the body.
+    if let Some(local) = default_local {
+        emit_dup_and_bind(fc, local);
+    }
+    fc.emit_op(POP);
+    compile_mir_expr(fc, &default_arm.body)?;
+
+    // Patch the hit-skip JUMP to land after the default body.
+    fc.patch_jump(hit_skip);
+    Ok(Some(()))
+}
+
+/// `true` when a literal's runtime bits are dispatch-comparable
+/// (Int / Bool / Unit / Float). Strings need a different
+/// dispatch kind (interning) so they abort the fast-path.
+fn pattern_is_dispatchable_bits(lit: &Literal) -> bool {
+    matches!(
+        lit,
+        Literal::Int(_) | Literal::Bool(_) | Literal::Unit | Literal::Float(_)
+    )
+}
+
+fn body_is_dispatchable_bits(lit: &Literal) -> bool {
+    // String *bodies* could in principle be supported by
+    // interning + inline result bits, but HIR's fast-path also
+    // skips them. Mirror that.
+    pattern_is_dispatchable_bits(lit)
+}
+
+fn literal_dispatch_bits(fc: &mut FnCompiler<'_>, lit: &Literal) -> u64 {
+    let nv = match lit {
+        Literal::Int(i) => NanValue::new_int(*i, fc.arena),
+        Literal::Float(f) => NanValue::new_float(*f),
+        Literal::Bool(b) => NanValue::new_bool(*b),
+        Literal::Unit => NanValue::UNIT,
+        Literal::Str(s) => NanValue::new_string_value(s, fc.arena),
+    };
+    nv.bits()
 }
 
 /// Last-arm exhaustive binding extraction. The pattern is

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -148,29 +148,36 @@ pub(super) fn compile_mir_expr(
                     Ok(())
                 }
                 MirCallee::Builtin(name) => {
-                    // Phase 4e — generic CALL_BUILTIN dispatch.
-                    // The HIR walker specializes ~6 builtins
-                    // (ListLen → LIST_LEN, MapGet → MAP_GET,
-                    // OptionWithDefault → UNWRAP_OR, …) into
-                    // dedicated opcodes; we don't replicate that
-                    // here yet, so bytecode parity only holds for
-                    // the generic path. Runtime parity holds for
-                    // all builtins — the VM's CALL_BUILTIN
-                    // dispatch lands on the same handler the
-                    // specialised opcodes wrap.
                     let builtin =
                         lookup_vm_builtin(name).ok_or(MirVmUnsupported::UnsupportedCallee)?;
                     for arg in args {
                         compile_mir_expr(fc, arg)?;
                     }
-                    let symbol_id = fc.symbols.intern_builtin(builtin).map_err(|e| {
-                        MirVmUnsupported::InnerError(CompileError {
-                            msg: format!("MIR-VM: intern_builtin failed: {e:?}"),
-                        })
-                    })?;
-                    fc.emit_op(CALL_BUILTIN);
-                    fc.emit_u32(symbol_id);
-                    fc.emit_u8(args.len() as u8);
+                    // Phase 6 wave 3 — pick the specialised
+                    // single-opcode emit when the builtin has
+                    // one (mirror of HIR's `emit_builtin_after_args`
+                    // dispatch). Owned/CALL_BUILTIN_OWNED variants
+                    // wait for wave 4's last-use revival; until
+                    // then `owned_mask = 0` everywhere on the
+                    // MIR path, same as Phase 4e.
+                    match builtin {
+                        VmBuiltin::ListLen => fc.emit_op(LIST_LEN),
+                        VmBuiltin::ListPrepend => fc.emit_op(LIST_PREPEND),
+                        VmBuiltin::VectorGet => fc.emit_op(VECTOR_GET),
+                        VmBuiltin::VectorSet => fc.emit_op(VECTOR_SET),
+                        VmBuiltin::OptionWithDefault => fc.emit_op(UNWRAP_OR),
+                        VmBuiltin::ResultWithDefault => fc.emit_op(UNWRAP_RESULT_OR),
+                        _ => {
+                            let symbol_id = fc.symbols.intern_builtin(builtin).map_err(|e| {
+                                MirVmUnsupported::InnerError(CompileError {
+                                    msg: format!("MIR-VM: intern_builtin failed: {e:?}"),
+                                })
+                            })?;
+                            fc.emit_op(CALL_BUILTIN);
+                            fc.emit_u32(symbol_id);
+                            fc.emit_u8(args.len() as u8);
+                        }
+                    }
                     Ok(())
                 }
             }

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -644,6 +644,53 @@ fn typed_neg_float_bytecode_parity() {
 }
 
 #[test]
+fn match_dispatch_const_table_bytecode_parity() {
+    // Phase 6 wave 2 — `match n { 0 -> 100; 1 -> 200; _ -> 999 }`
+    // is the canonical literal-only match HIR fast-paths through
+    // MATCH_DISPATCH_CONST. MIR walker now mirrors the same
+    // table emit byte-for-byte.
+    let (hir, mir) = compile_both(
+        "fn classify(n: Int) -> Int\n    match n\n        0 -> 100\n        1 -> 200\n        _ -> 999\n",
+    );
+    let hir_fn = hir.get(hir.find("classify").expect("classify in HIR"));
+    let mir_fn = mir.get(mir.find("classify").expect("classify in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "MATCH_DISPATCH_CONST emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn match_dispatch_const_runtime_parity() {
+    // Same shape — runtime parity on every branch.
+    let src = "fn classify(n: Int) -> Int\n    match n\n        0 -> 100\n        1 -> 200\n        _ -> 999\n";
+    for (input, expected) in &[(0, 100), (1, 200), (2, 999), (-1, 999)] {
+        let hir = run_via_path(src, "classify", &[*input], Path::Hir);
+        let mir = run_via_path(src, "classify", &[*input], Path::MirFallback);
+        assert_eq!(
+            hir, mir,
+            "classify({input}) parity: HIR={hir:?}, MIR={mir:?}"
+        );
+        assert_eq!(hir, Value::Int(*expected as i64));
+    }
+}
+
+#[test]
+fn match_non_dispatchable_arm_still_uses_linear_emit() {
+    // Body is an expression, not a const literal — fast-path
+    // aborts and MIR falls through to its linear emit. The
+    // result is still correct on both paths.
+    let src = "fn double_or_zero(n: Int) -> Int\n    match n\n        0 -> 0\n        _ -> n + n\n";
+    for (input, expected) in &[(0, 0), (3, 6), (7, 14)] {
+        let hir = run_via_path(src, "double_or_zero", &[*input], Path::Hir);
+        let mir = run_via_path(src, "double_or_zero", &[*input], Path::MirFallback);
+        assert_eq!(hir, mir);
+        assert_eq!(hir, Value::Int(*expected as i64));
+    }
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -691,6 +691,61 @@ fn match_non_dispatchable_arm_still_uses_linear_emit() {
 }
 
 #[test]
+fn specialised_builtin_list_len_bytecode_parity() {
+    // Phase 6 wave 3 — `List.len(xs)` picks the LIST_LEN
+    // single-opcode emit instead of CALL_BUILTIN.
+    let (hir, mir) = compile_both("fn count(xs: List<Int>) -> Int\n    List.len(xs)\n");
+    let hir_fn = hir.get(hir.find("count").expect("count in HIR"));
+    let mir_fn = mir.get(mir.find("count").expect("count in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "LIST_LEN emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn specialised_builtin_list_prepend_bytecode_parity() {
+    let (hir, mir) =
+        compile_both("fn cons(x: Int, xs: List<Int>) -> List<Int>\n    List.prepend(x, xs)\n");
+    let hir_fn = hir.get(hir.find("cons").expect("cons in HIR"));
+    let mir_fn = mir.get(mir.find("cons").expect("cons in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "LIST_PREPEND emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn specialised_builtin_option_with_default_bytecode_parity() {
+    let (hir, mir) = compile_both(
+        "fn unwrap(o: Option<Int>, fallback: Int) -> Int\n    Option.withDefault(o, fallback)\n",
+    );
+    let hir_fn = hir.get(hir.find("unwrap").expect("unwrap in HIR"));
+    let mir_fn = mir.get(mir.find("unwrap").expect("unwrap in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "UNWRAP_OR emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
+fn specialised_builtin_result_with_default_bytecode_parity() {
+    let (hir, mir) = compile_both(
+        "fn unwrap(r: Result<Int, String>, fallback: Int) -> Int\n    Result.withDefault(r, fallback)\n",
+    );
+    let hir_fn = hir.get(hir.find("unwrap").expect("unwrap in HIR"));
+    let mir_fn = mir.get(mir.find("unwrap").expect("unwrap in MIR"));
+    assert_eq!(
+        hir_fn.code, mir_fn.code,
+        "UNWRAP_RESULT_OR emit must match byte-for-byte:\n  HIR={:?}\n  MIR={:?}",
+        hir_fn.code, mir_fn.code
+    );
+}
+
+#[test]
 fn match_fn_uses_hir_fallback_and_remains_present_in_mir_path() {
     // `match` isn't in the Phase 4 subset → MIR-fallback path
     // falls back to HIR. The fn must still appear in the output


### PR DESCRIPTION
## Summary

Trzeci wave. HIR routuje 6 buil­tinów przez specialised single-opcodes zamiast generic CALL_BUILTIN. Każdy \`List.len(xs)\` to JEDEN op zamiast 3 (CALL_BUILTIN + symbol_id u32 + argc u8).

## Co lands

\`MirCallee::Builtin\` matches:

| Builtin | Opcode |
|---|---|
| ListLen | LIST_LEN |
| ListPrepend | LIST_PREPEND |
| VectorGet | VECTOR_GET |
| VectorSet | VECTOR_SET |
| OptionWithDefault | UNWRAP_OR |
| ResultWithDefault | UNWRAP_RESULT_OR |

Reszta na generic CALL_BUILTIN. owned_mask=0 wszędzie (wave 4 doda last-use).

## Parity proof (4 new tests, 43 total)

Wszystkie 4 byte-identical bytecode parity dla specjalizowanych emitów.

**Base: #282 (wave 2)** — rebase po mergu.

## Pozostały gap

- CALL_BUILTIN_OWNED / VECTOR_SET_OWNED — wave 4
- HIR call-classifier paths (MapGet/Set, VectorNew, IntMod) — przyszły mini-wave 3.1 jak będzie potrzeba
- inliner — wave 5

## Test plan
- [x] cargo fmt + clippy clean
- [x] 43/43 parity ✅
- [x] 4/4 skeleton ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)