### PR TITLE
ir/mir: foundation for Phase 5 — `name` field on `MirLocal` (#252 Phase 5 prep)

### DIFF
--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -24,20 +24,26 @@ use super::program::LocalId;
 /// the binding identity; `last_use = true` when this is the
 /// final read of that slot in the enclosing fn body, mirroring
 /// HIR's `AnnotBool` last-use stamp.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Phase 5 prep: `name` carries the source-level binding name
+/// (param name, let binding name, pattern binding name). VM
+/// backends ignore it (dispatch by slot). Rust / wasm-gc
+/// backends use it as the emitted Rust ident / export name.
+/// Empty for synthetic locals.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MirLocal {
     pub slot: LocalId,
     pub last_use: bool,
+    pub name: String,
 }
 
 impl MirLocal {
-    /// Construct a `MirLocal` with `last_use = false`. Convenience
-    /// for hand-built test fixtures + lowering sites that don't
-    /// carry last-use info (yet).
+    /// Construct a `MirLocal` with `last_use = false` and empty
+    /// name. Convenience for hand-built test fixtures.
     pub fn at(slot: LocalId) -> Self {
         Self {
             slot,
             last_use: false,
+            name: String::new(),
         }
     }
 }

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -223,10 +223,15 @@ fn lower_expr(expr: &Spanned<ResolvedExpr>) -> Result<Spanned<MirExpr>, SkipReas
     let mir = match &expr.node {
         // ── Wave 1 ──────────────────────────────────────────────
         ResolvedExpr::Literal(lit) => MirExpr::Literal(wrap(lit.clone(), expr)),
-        ResolvedExpr::Resolved { slot, last_use, .. } => {
+        ResolvedExpr::Resolved {
+            slot,
+            name,
+            last_use,
+        } => {
             let local = super::expr::MirLocal {
                 slot: LocalId(u32::from(*slot)),
                 last_use: last_use.0,
+                name: name.clone(),
             };
             MirExpr::Local(wrap(local, expr))
         }

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -82,7 +82,7 @@ pub(super) fn compile_mir_expr(
             Ok(())
         }
         MirExpr::Local(spanned_local) => {
-            let local = spanned_local.node;
+            let local = &spanned_local.node;
             // Phase 6 wave 4: emit MOVE_LOCAL when this is the
             // last read of the slot in the enclosing fn body.
             // Mirrors HIR's last-use revival; skips ref-count

--- a/tests/mir_phase3_wave1_lowering.rs
+++ b/tests/mir_phase3_wave1_lowering.rs
@@ -34,6 +34,40 @@ fn lowers_int_literal_body() {
 }
 
 #[test]
+fn lowers_local_carries_source_name() {
+    // Phase 5 prep: `MirExpr::Local` carries `name` from
+    // `ResolvedExpr::Resolved.name`. Rust / wasm-gc backends
+    // use it as the emitted ident.
+    let src = "fn double(x: Int) -> Int\n    x + x\n";
+    let mut items = parse_source(src).unwrap();
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    assert!(result.typecheck.as_ref().unwrap().errors.is_empty());
+    let program = lower_program(&result.resolved_items);
+    let mir_fn = program
+        .fns
+        .values()
+        .find(|f| f.name == "double")
+        .expect("double in MIR");
+    let aver::ir::mir::MirExpr::BinOp(b) = &mir_fn.body.node else {
+        panic!("expected BinOp at body root");
+    };
+    let aver::ir::mir::MirExpr::Local(l) = &b.node.lhs.node else {
+        panic!("expected Local lhs");
+    };
+    let aver::ir::mir::MirExpr::Local(r) = &b.node.rhs.node else {
+        panic!("expected Local rhs");
+    };
+    assert_eq!(l.node.name, "x", "lhs Local name should be `x`");
+    assert_eq!(r.node.name, "x", "rhs Local name should be `x`");
+}
+
+#[test]
 fn lowers_binop_over_locals() {
     let dump = lower("fn double(x: Int) -> Int\n    x + x\n");
     assert!(


### PR DESCRIPTION
## Summary

Foundation dla Phase 5. VM dispatches by slot — name dead weight. Rust/wasm-gc/wasip2 backendy potrzebują source-level binding name żeby emit ident.

Dodaję \`name: String\` do \`MirLocal\`. Lower propaguje z \`ResolvedExpr::Resolved.name\`. Empty dla synthetic locals.

## Why now, separately from the consumer

Bez \`name\` Phase 5 wave 1 musiałby:
- side-channel MIR → FnResolution lookup, lub
- re-derive names z positional slot indices

Oba to ten sam anti-pattern co \`step_fns\` smuggle na \`ResultPipelineChain\` że RFC explicit'nie odrzuca. Foundation osobno = MIR self-contained.

## Compat

- \`MirLocal\` no longer \`Copy\` (String owned). Konsumenci którzy brali \`let local = spanned_local.node\` switched do \`&spanned_local.node\` — no extra clone, same behavior.
- \`MirLocal::at(slot)\` defaults \`name = \"\"\`. Hand-built fixtures unchanged.
- \`Display\` formats \`%N\` / \`%N*\` — name nie część dump identity contract.

## Test

\`lowers_local_carries_source_name\` — dla \`fn double(x) :- x + x\` oba \`Local\` nodes mają \`name = \"x\"\`.

Wszystkie istniejące testy zielone.

## Next: Phase 5 wave 1

Z \`name\` w miejscu, \`src/codegen/rust/from_mir.rs\` to straight mirror HIR's \`emit_expr\`:
- Literal → \`emit_literal\`
- Local(local) → \`aver_name_to_rust(&local.name)\`
- BinOp → "(l op r)"
- … widening waves jak Phase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)