### PR TITLE
ir/mir: add binding_name to MirLet (#252 Phase 5 prep)

### DIFF
--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -173,9 +173,18 @@ pub enum MirExpr {
 }
 
 /// `let binding = value; body`.
+///
+/// Phase 5 wave-Let foundation: `binding_name` carries the
+/// source-level binder when the let came from `Stmt::Binding`,
+/// or stays empty for synthetic locals introduced by stmt-chain
+/// lowering (`Stmt::Expr` at non-tail position). Same propagation
+/// shape `MirLocal { name }` uses on the read side, so Rust /
+/// wasm-gc backends can emit `let x = …` for source-named
+/// bindings and fall back to HIR for the unnamed synthetics.
 #[derive(Debug, Clone)]
 pub struct MirLet {
     pub binding: LocalId,
+    pub binding_name: String,
     pub value: Box<Spanned<MirExpr>>,
     pub body: Box<Spanned<MirExpr>>,
 }

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -610,18 +610,19 @@ fn lower_stmt_chain(
     // Right-fold: walk earlier stmts in reverse, wrapping each
     // around the accumulating `body`.
     for stmt in rest.iter().rev() {
-        let (binding, value_expr) = match stmt {
+        let (binding, binding_name, value_expr) = match stmt {
             ResolvedStmt::Binding { name, value, .. } => {
                 let slot = *resolution
                     .local_slots
                     .get(name)
                     .ok_or(SkipReason::BindingSlotLookupMissing)?;
-                (LocalId(u32::from(slot)), value)
+                (LocalId(u32::from(slot)), name.clone(), value)
             }
             ResolvedStmt::Expr(expr) => {
                 let fresh = LocalId(*next_synthetic_local);
                 *next_synthetic_local += 1;
-                (fresh, expr)
+                // Synthetic introduction — no source-level name.
+                (fresh, String::new(), expr)
             }
         };
         let mir_value = lower_expr(value_expr)?;
@@ -630,6 +631,7 @@ fn lower_stmt_chain(
             node: MirExpr::Let(Spanned {
                 node: MirLet {
                     binding,
+                    binding_name,
                     value: Box::new(mir_value),
                     body: Box::new(body),
                 },

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -125,6 +125,7 @@ pub(super) fn compile_mir_expr(
         MirExpr::Let(spanned_let) => {
             let MirLet {
                 binding,
+                binding_name: _,
                 value,
                 body,
             } = &spanned_let.node;

--- a/tests/mir_phase2_model_spec.rs
+++ b/tests/mir_phase2_model_spec.rs
@@ -136,6 +136,7 @@ fn try_bind_is_let_with_try_value() {
     }));
     let bind = MirExpr::Let(span(MirLet {
         binding: LocalId(0),
+        binding_name: String::new(),
         value: Box::new(span(MirExpr::Try(Box::new(span(step_call))))),
         body: Box::new(span(MirExpr::Local(span(MirLocal::at(LocalId(0)))))),
     }));

--- a/tests/mir_phase2b_dump_spec.rs
+++ b/tests/mir_phase2b_dump_spec.rs
@@ -83,6 +83,7 @@ fn try_bind_via_let_composition_dump_shape() {
     // same dump appearance (one `let`, one `?`).
     let body = span(MirExpr::Let(span(MirLet {
         binding: LocalId(0),
+        binding_name: String::new(),
         value: Box::new(span(MirExpr::Try(Box::new(span(MirExpr::Call(span(
             MirCall {
                 callee: MirCallee::Fn(fn_id(1)),
@@ -266,6 +267,7 @@ fn let_dump_shape() {
     // let %0 = 7; %0
     let body = span(MirExpr::Let(span(MirLet {
         binding: LocalId(0),
+        binding_name: String::new(),
         value: Box::new(span(MirExpr::Literal(span(Literal::Int(7))))),
         body: Box::new(span(MirExpr::Local(span(MirLocal::at(LocalId(0)))))),
     })));

--- a/tests/mir_phase3_wave3a_let_lowering.rs
+++ b/tests/mir_phase3_wave3a_let_lowering.rs
@@ -28,6 +28,36 @@ fn lower(source: &str) -> String {
 }
 
 #[test]
+fn lowers_let_carries_source_binding_name() {
+    // Phase 5 prep: `MirLet::binding_name` carries the source
+    // identifier when the let came from `Stmt::Binding`. Rust /
+    // wasm-gc backends use it as the emitted let-binder.
+    let src = "fn add_one(n: Int) -> Int\n    bumped = n + 1\n    bumped\n";
+    let mut items = parse_source(src).unwrap();
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    assert!(result.typecheck.as_ref().unwrap().errors.is_empty());
+    let program = lower_program(&result.resolved_items);
+    let mir_fn = program
+        .fns
+        .values()
+        .find(|f| f.name == "add_one")
+        .expect("add_one in MIR");
+    let aver::ir::mir::MirExpr::Let(let_node) = &mir_fn.body.node else {
+        panic!("expected Let at body root, got: {:?}", mir_fn.body.node);
+    };
+    assert_eq!(
+        let_node.node.binding_name, "bumped",
+        "Let.binding_name should propagate source ident"
+    );
+}
+
+#[test]
 fn lowers_single_let_binding_then_expr() {
     // let x = 7
     // x


### PR DESCRIPTION
## Summary

Phase 5 foundation #2a — mirror #287 (MirLocal.name) dla MirLet bindings. Rust / wasm-gc walkery nie mogą emit \`let x = …\` bez source identifier, samo \`LocalId\` to slot number.

## Co lands

- \`MirLet { binding, binding_name: String, value, body }\` — propagacja z \`ResolvedStmt::Binding.name\` w \`lower_stmt_chain\`
- Synthetic locals (intermediate \`Stmt::Expr\`) → \`binding_name: String::new()\` — same shape co \`MirLocal { name }\` na read side
- VM consumer: extra field jako \`_\` (VM addressuje slotami, name nie używa)
- Test fixtures (\`mir_phase2_model_spec\`, \`mir_phase2b_dump_spec\`) → \`binding_name: String::new()\`

## Tests

- New: \`lowers_let_carries_source_binding_name\` — source-level Binding(\"bumped\") survives lowering
- Wszystko pozostałe unchanged

## Why now

Niezależny od stosu Phase 5 wave 1/2/3. Wave Let (po merge wave 2/3) skonsumuje to pole. Foundation #2b (MirPattern bindings) — następny PR, dla wave 4 Match.

Independent z main — można merge bez czekania na resztę stosu.

## Test plan
- [x] cargo fmt + clippy clean
- [x] cargo test (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)