### PR TITLE
ir/mir: add binding names to MirPattern (#252 Phase 5 prep)

### DIFF
--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -199,9 +199,9 @@ fn write_pattern(f: &mut fmt::Formatter<'_>, p: &MirPattern) -> fmt::Result {
     match p {
         MirPattern::Wildcard => write!(f, "_"),
         MirPattern::Literal(lit) => write!(f, "{lit:?}"),
-        MirPattern::Bind(local) => write!(f, "{local}"),
+        MirPattern::Bind(local, _name) => write!(f, "{local}"),
         MirPattern::EmptyList => write!(f, "[]"),
-        MirPattern::Cons { head, tail } => write!(f, "[{head}, ..{tail}]"),
+        MirPattern::Cons { head, tail, .. } => write!(f, "[{head}, ..{tail}]"),
         MirPattern::Tuple(items) => {
             write!(f, "(")?;
             for (i, sub) in items.iter().enumerate() {
@@ -212,7 +212,7 @@ fn write_pattern(f: &mut fmt::Formatter<'_>, p: &MirPattern) -> fmt::Result {
             }
             write!(f, ")")
         }
-        MirPattern::Ctor { ctor, bindings } => {
+        MirPattern::Ctor { ctor, bindings, .. } => {
             write_ctor(f, *ctor)?;
             write!(f, "(")?;
             for (i, b) in bindings.iter().enumerate() {

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -241,22 +241,34 @@ pub enum MirPattern {
     /// Literal arm: `0`, `true`, `"foo"`.
     Literal(Literal),
     /// Identifier binding — captures the matched value into a
-    /// fresh local accessible in the arm body.
-    Bind(LocalId),
+    /// fresh local accessible in the arm body. The `String`
+    /// carries the source-level binder name (Phase 5 prep) so
+    /// Rust / wasm-gc walkers can emit the binding ident.
+    Bind(LocalId, String),
     /// `[]` — empty-list pattern.
     EmptyList,
     /// `[head, ..tail]` — cons pattern; both bindings fresh.
-    Cons { head: LocalId, tail: LocalId },
+    /// `head_name` / `tail_name` carry the source idents (Phase 5
+    /// prep) for backends that emit named locals.
+    Cons {
+        head: LocalId,
+        head_name: String,
+        tail: LocalId,
+        tail_name: String,
+    },
     /// `(a, b, c)` — tuple pattern; each component is a sub-pattern.
     Tuple(Vec<MirPattern>),
     /// `Module.Variant(b1, b2, …)` / `Result.Ok(b)` / `Option.None`
     /// — constructor pattern. `ctor` discriminates user vs built-in
     /// variant via `MirCtor`; `bindings` are the fresh locals for
     /// the variant's fields in declaration order (empty for
-    /// nullary variants like `Option.None`).
+    /// nullary variants like `Option.None`). `binding_names` is a
+    /// parallel array of source idents (Phase 5 prep) — same
+    /// length as `bindings`.
     Ctor {
         ctor: MirCtor,
         bindings: Vec<LocalId>,
+        binding_names: Vec<String>,
     },
 }
 

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -496,17 +496,19 @@ fn lower_pattern(
     Ok(match pattern {
         ResolvedPattern::Wildcard => MirPattern::Wildcard,
         ResolvedPattern::Literal(lit) => MirPattern::Literal(lit.clone()),
-        ResolvedPattern::Ident(_) => {
+        ResolvedPattern::Ident(name) => {
             let slot = take_slot(slots, cursor)?;
-            MirPattern::Bind(LocalId(u32::from(slot)))
+            MirPattern::Bind(LocalId(u32::from(slot)), name.clone())
         }
         ResolvedPattern::EmptyList => MirPattern::EmptyList,
-        ResolvedPattern::Cons(_, _) => {
+        ResolvedPattern::Cons(head_name, tail_name) => {
             let head = take_slot(slots, cursor)?;
             let tail = take_slot(slots, cursor)?;
             MirPattern::Cons {
                 head: LocalId(u32::from(head)),
+                head_name: head_name.clone(),
                 tail: LocalId(u32::from(tail)),
+                tail_name: tail_name.clone(),
             }
         }
         ResolvedPattern::Tuple(items) => {
@@ -521,6 +523,7 @@ fn lower_pattern(
             MirPattern::Ctor {
                 ctor: MirCtor::User(*ctor_id),
                 bindings,
+                binding_names: names.clone(),
             }
         }
         // Wave 3c-i — built-in ctor patterns ride the same shape
@@ -530,6 +533,7 @@ fn lower_pattern(
             MirPattern::Ctor {
                 ctor: MirCtor::Builtin(*bc),
                 bindings,
+                binding_names: names.clone(),
             }
         }
         // Unresolved ctors still drop — typechecker already

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -772,7 +772,7 @@ fn emit_dup_and_bind(fc: &mut FnCompiler<'_>, local: LocalId) {
 fn pattern_supported(p: &MirPattern) -> bool {
     match p {
         MirPattern::Wildcard
-        | MirPattern::Bind(_)
+        | MirPattern::Bind(_, _)
         | MirPattern::Literal(_)
         | MirPattern::EmptyList
         | MirPattern::Cons { .. }
@@ -791,7 +791,7 @@ fn emit_pattern_check(
 ) -> Result<Vec<usize>, MirVmUnsupported> {
     match pattern {
         MirPattern::Wildcard => Ok(Vec::new()),
-        MirPattern::Bind(local) => {
+        MirPattern::Bind(local, _name) => {
             // Always matches; DUP the value and bind. Mirror of
             // HIR's `dup_and_bind_top_to_local` on a top-level
             // ident pattern. Wildcard sentinel collapses the
@@ -822,7 +822,7 @@ fn emit_pattern_check(
             fc.emit_i16(0);
             Ok(vec![patch])
         }
-        MirPattern::Cons { head, tail } => {
+        MirPattern::Cons { head, tail, .. } => {
             fc.emit_op(MATCH_CONS);
             let patch = fc.offset();
             fc.emit_i16(0);
@@ -839,6 +839,7 @@ fn emit_pattern_check(
         MirPattern::Ctor {
             ctor: MirCtor::User(ctor_id),
             bindings,
+            ..
         } => {
             // Resolve `CtorId → arena ctor_id` via the same path
             // the HIR walker uses (symbol table → canonical name
@@ -923,6 +924,7 @@ fn emit_pattern_check(
         MirPattern::Ctor {
             ctor: MirCtor::Builtin(bc),
             bindings,
+            ..
         } => {
             // Built-in wrapper variants (Result.Ok / Result.Err /
             // Option.Some). Option.None is the nullary case —
@@ -995,7 +997,7 @@ fn try_emit_match_dispatch_const(
     let default_arm = &arms[last_idx];
     let default_local = match &default_arm.pattern {
         MirPattern::Wildcard => None,
-        MirPattern::Bind(local) => Some(*local),
+        MirPattern::Bind(local, _name) => Some(*local),
         _ => return Ok(None),
     };
 
@@ -1110,11 +1112,11 @@ fn emit_last_arm_bindings(
 ) -> Result<(), MirVmUnsupported> {
     match pattern {
         MirPattern::Wildcard | MirPattern::Literal(_) | MirPattern::EmptyList => Ok(()),
-        MirPattern::Bind(local) => {
+        MirPattern::Bind(local, _name) => {
             emit_dup_and_bind(fc, *local);
             Ok(())
         }
-        MirPattern::Cons { head, tail } => {
+        MirPattern::Cons { head, tail, .. } => {
             fc.emit_op(DUP);
             fc.emit_op(LIST_HEAD_TAIL);
             emit_store_or_pop(fc, *head);
@@ -1124,6 +1126,7 @@ fn emit_last_arm_bindings(
         MirPattern::Ctor {
             ctor: MirCtor::User(_),
             bindings,
+            ..
         } => {
             for (i, b) in bindings.iter().enumerate() {
                 fc.emit_op(EXTRACT_FIELD);
@@ -1135,6 +1138,7 @@ fn emit_last_arm_bindings(
         MirPattern::Ctor {
             ctor: MirCtor::Builtin(bc),
             bindings,
+            ..
         } => {
             if let Some(b) = bindings.first() {
                 let kind: u8 = match bc {

--- a/tests/mir_phase2_model_spec.rs
+++ b/tests/mir_phase2_model_spec.rs
@@ -74,7 +74,9 @@ fn pinned_decision_match_is_structured() {
         MirMatchArm {
             pattern: MirPattern::Cons {
                 head: LocalId(1),
+                head_name: String::new(),
                 tail: LocalId(2),
+                tail_name: String::new(),
             },
             body: span(MirExpr::Local(span(MirLocal::at(LocalId(1))))),
         },
@@ -114,8 +116,9 @@ fn pinned_decision_identity_is_typed() {
     let ctor_pattern = MirPattern::Ctor {
         ctor: MirCtor::User(ctor_id(7)),
         bindings: vec![LocalId(0)],
+        binding_names: vec![String::new()],
     };
-    let MirPattern::Ctor { ctor, bindings } = ctor_pattern else {
+    let MirPattern::Ctor { ctor, bindings, .. } = ctor_pattern else {
         unreachable!()
     };
     assert_eq!(ctor, MirCtor::User(ctor_id(7)));

--- a/tests/mir_phase2b_dump_spec.rs
+++ b/tests/mir_phase2b_dump_spec.rs
@@ -132,7 +132,12 @@ fn match_dump_shape() {
                 body: span(MirExpr::Literal(span(Literal::Int(0)))),
             },
             MirMatchArm {
-                pattern: MirPattern::Cons { head: h, tail: t },
+                pattern: MirPattern::Cons {
+                    head: h,
+                    head_name: String::new(),
+                    tail: t,
+                    tail_name: String::new(),
+                },
                 body: span(MirExpr::Local(span(MirLocal::at(h)))),
             },
         ],
@@ -175,6 +180,7 @@ fn ctor_pattern_dump_uses_ctor_id() {
     let p = MirPattern::Ctor {
         ctor: MirCtor::User(CtorId(7)),
         bindings: vec![LocalId(0)],
+        binding_names: vec![String::new()],
     };
     // Use the arm-rendering path via a tiny Match.
     let body = span(MirExpr::Match(span(MirMatch {

--- a/tests/mir_phase3_wave3a_let_lowering.rs
+++ b/tests/mir_phase3_wave3a_let_lowering.rs
@@ -115,3 +115,50 @@ fn binding_only_body_is_dropped() {
         "normal multi-stmt fn must still lower:\n{dump}"
     );
 }
+
+#[test]
+fn lowers_match_carries_pattern_binding_names() {
+    // Phase 5 prep: `MirPattern::{Bind, Cons, Ctor}` carry source
+    // identifiers so Rust / wasm-gc walkers can emit them as
+    // arm-binding idents. Same propagation shape as
+    // `MirLocal.name` on the value side.
+    let src = "fn first(xs: List<Int>) -> Int\n    match xs\n        [] -> 0\n        [head, ..tail] -> head\n";
+    let mut items = parse_source(src).unwrap();
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    assert!(
+        result.typecheck.as_ref().unwrap().errors.is_empty(),
+        "typecheck failed: {:?}",
+        result.typecheck.as_ref().unwrap().errors
+    );
+    let program = lower_program(&result.resolved_items);
+    let mir_fn = program
+        .fns
+        .values()
+        .find(|f| f.name == "first")
+        .expect("first in MIR");
+    let aver::ir::mir::MirExpr::Match(m) = &mir_fn.body.node else {
+        panic!("expected Match at body root, got: {:?}", mir_fn.body.node);
+    };
+    let cons_arm = m
+        .node
+        .arms
+        .iter()
+        .find(|arm| matches!(arm.pattern, aver::ir::mir::MirPattern::Cons { .. }))
+        .expect("Cons arm present");
+    let aver::ir::mir::MirPattern::Cons {
+        head_name,
+        tail_name,
+        ..
+    } = &cons_arm.pattern
+    else {
+        unreachable!()
+    };
+    assert_eq!(head_name, "head", "Cons.head_name should be `head`");
+    assert_eq!(tail_name, "tail", "Cons.tail_name should be `tail`");
+}


### PR DESCRIPTION
## Summary

Phase 5 foundation #2b — mirror #287 (MirLocal.name) dla \`MirPattern\` binding sites (Bind / Cons / Ctor). Match-arm patterns wprowadzają fresh locale; Rust / wasm-gc walkery nie mogą emit \`Cons(head, tail)\` / \`Variant(b1, b2)\` bez source idents.

## Shape change

- \`MirPattern::Bind(LocalId)\` → \`Bind(LocalId, String)\`
- \`MirPattern::Cons { head, tail }\` → \`Cons { head, head_name, tail, tail_name }\`
- \`MirPattern::Ctor { ctor, bindings }\` → \`Ctor { ctor, bindings, binding_names: Vec<String> }\` (parallel array)
- \`ResolvedPattern\` już ma names (Ident(String), Cons(String, String), Ctor(_, Vec<String>)). lower_pattern propaguje.

## Consumers updated

- \`dump.rs\` — Display ignoruje names (slot-only) → snapshot bez zmian
- \`vm::compiler::mir\` — \`_name\` / \`..\` destructure. 7 sites mechanicznych.
- Test fixtures (\`mir_phase2_model_spec\`, \`mir_phase2b_dump_spec\`) → \`String::new()\`

## Tests

- New: \`lowers_match_carries_pattern_binding_names\` — pins Cons head_name=\"head\", tail_name=\"tail\" survive lowering

## Why now

Wave Match (biggest wave) w Rust MIR walkerze nie zadziała bez names. Foundation #2a (MirLet.binding_name #293) covers value-side; #2b covers pattern-side. Niezależny od stosu, można merge przed wave 4.

Independent z main.

## Test plan
- [x] cargo fmt + clippy clean
- [x] cargo test (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)