### PR TITLE
ir/mir: Phase 6 wave 8 — algebraic identities (#252 Phase 6)

### DIFF
--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -87,6 +87,6 @@ pub use expr::{
     MirRecordCreate, MirRecordField, MirRecordUpdate, MirStrPart, MirTailCall,
 };
 pub use lower::lower_program;
-pub use optimize::{const_fold, dead_code, inline_nullary_literals};
+pub use optimize::{algebraic_simplify, const_fold, dead_code, inline_nullary_literals};
 pub use program::{LocalId, MirFn, MirParam, MirProgram};
 pub use stats::{LowerStats, SkipReason};

--- a/src/ir/mir/optimize.rs
+++ b/src/ir/mir/optimize.rs
@@ -26,6 +26,25 @@
 //! collapses to a `Literal` (pure) and unlocks its enclosing
 //! `Let` for elimination.
 //!
+//! ## Wave 8 — algebraic identities
+//!
+//! Rewrite `BinOp` / `Neg` shapes whose result is determined by
+//! an algebraic identity over `Int`:
+//!
+//! - `x + 0` / `0 + x` / `x - 0` → `x`
+//! - `x * 1` / `1 * x` / `x / 1` → `x`
+//! - `x * 0` / `0 * x` → `0` (when `x` is pure — otherwise the
+//!   multiplication's side effects must run)
+//! - `Neg(Neg(x))` → `x`
+//!
+//! Float is deliberately *not* simplified — `x + 0.0` differs
+//! from `x` for `x = -0.0` (IEEE-754 signed-zero), `x * 0.0`
+//! differs for `x = NaN` / ±∞, and so on. Skipping float keeps
+//! the simplifier sound without a per-shape proof of safety.
+//!
+//! No string / list / map rewrites; those would need
+//! reference-equality reasoning the optimizer doesn't carry.
+//!
 //! ## Wave 7 — nullary literal inlining
 //!
 //! For every fn whose body is exactly a `MirExpr::Literal` and
@@ -517,6 +536,252 @@ fn literal_eq(a: &Literal, b: &Literal) -> Option<bool> {
         (Literal::Str(x), Literal::Str(y)) => Some(x == y),
         (Literal::Unit, Literal::Unit) => Some(true),
         _ => None,
+    }
+}
+
+/// Wave 8 — algebraic identity simplification. Rewrite
+/// `BinOp` / `Neg` shapes whose result is determined by a
+/// purely algebraic identity over `Int`. Float is skipped
+/// (signed-zero / NaN), other types untouched.
+pub fn algebraic_simplify(mut program: MirProgram) -> MirProgram {
+    for mir_fn in program.fns.values_mut() {
+        algebraic_in_place(&mut mir_fn.body);
+    }
+    program
+}
+
+fn algebraic_in_place(expr: &mut Spanned<MirExpr>) {
+    algebraic_walk_children(&mut expr.node);
+
+    // Try to simplify the current node post-order.
+    if let Some(replacement) = try_algebraic(&expr.node) {
+        match replacement {
+            AlgReplace::Identity(side) => {
+                // Replace the BinOp with whichever operand
+                // survives the identity (lhs or rhs).
+                if let MirExpr::BinOp(spanned_bop) = std::mem::replace(
+                    &mut expr.node,
+                    MirExpr::Literal(Spanned {
+                        node: Literal::Unit,
+                        line: expr.line,
+                        ty: std::sync::OnceLock::new(),
+                    }),
+                ) {
+                    let bop = spanned_bop.node;
+                    let surviving = match side {
+                        Side::Lhs => *bop.lhs,
+                        Side::Rhs => *bop.rhs,
+                    };
+                    *expr = surviving;
+                } else {
+                    unreachable!("AlgReplace::Identity only set inside BinOp branch")
+                }
+            }
+            AlgReplace::Literal(lit) => {
+                expr.node = MirExpr::Literal(Spanned {
+                    node: lit,
+                    line: expr.line,
+                    ty: std::sync::OnceLock::new(),
+                });
+            }
+            AlgReplace::UnwrapNeg => {
+                // `Neg(Neg(inner))` → `inner`
+                if let MirExpr::Neg(outer) = std::mem::replace(
+                    &mut expr.node,
+                    MirExpr::Literal(Spanned {
+                        node: Literal::Unit,
+                        line: expr.line,
+                        ty: std::sync::OnceLock::new(),
+                    }),
+                ) {
+                    if let MirExpr::Neg(inner) = outer.node {
+                        *expr = *inner;
+                    } else {
+                        unreachable!("UnwrapNeg only set when outer is Neg(Neg)")
+                    }
+                } else {
+                    unreachable!("UnwrapNeg only set inside Neg branch")
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Side {
+    Lhs,
+    Rhs,
+}
+
+enum AlgReplace {
+    /// Keep one operand from the BinOp.
+    Identity(Side),
+    /// Replace the whole node with a literal.
+    Literal(Literal),
+    /// Unwrap a `Neg(Neg(x))` to `x`.
+    UnwrapNeg,
+}
+
+fn try_algebraic(node: &MirExpr) -> Option<AlgReplace> {
+    match node {
+        MirExpr::Neg(inner) => {
+            if matches!(&inner.node, MirExpr::Neg(_)) {
+                Some(AlgReplace::UnwrapNeg)
+            } else {
+                None
+            }
+        }
+        MirExpr::BinOp(spanned_bop) => {
+            let bop = &spanned_bop.node;
+            try_algebraic_binop(bop.op, &bop.lhs, &bop.rhs)
+        }
+        _ => None,
+    }
+}
+
+fn try_algebraic_binop(
+    op: BinOp,
+    lhs: &Spanned<MirExpr>,
+    rhs: &Spanned<MirExpr>,
+) -> Option<AlgReplace> {
+    let lhs_int = int_literal(&lhs.node);
+    let rhs_int = int_literal(&rhs.node);
+    match op {
+        BinOp::Add => {
+            // x + 0 → x
+            if rhs_int == Some(0) {
+                return Some(AlgReplace::Identity(Side::Lhs));
+            }
+            // 0 + x → x
+            if lhs_int == Some(0) {
+                return Some(AlgReplace::Identity(Side::Rhs));
+            }
+            None
+        }
+        BinOp::Sub => {
+            // x - 0 → x. `0 - x` is NOT `-x` here because we'd
+            // produce a Neg node and that's a different shape;
+            // const-fold / Neg-Neg already covers the literal
+            // cases, and a symbolic `-x` rewrite is a separate
+            // peephole that doesn't belong here.
+            if rhs_int == Some(0) {
+                return Some(AlgReplace::Identity(Side::Lhs));
+            }
+            None
+        }
+        BinOp::Mul => {
+            // x * 1 → x
+            if rhs_int == Some(1) {
+                return Some(AlgReplace::Identity(Side::Lhs));
+            }
+            // 1 * x → x
+            if lhs_int == Some(1) {
+                return Some(AlgReplace::Identity(Side::Rhs));
+            }
+            // x * 0 → 0 / 0 * x → 0, but ONLY when the
+            // surviving operand is pure — otherwise dropping it
+            // would skip its side effect.
+            if rhs_int == Some(0) && is_pure(lhs) {
+                return Some(AlgReplace::Literal(Literal::Int(0)));
+            }
+            if lhs_int == Some(0) && is_pure(rhs) {
+                return Some(AlgReplace::Literal(Literal::Int(0)));
+            }
+            None
+        }
+        BinOp::Div => {
+            // x / 1 → x. `0 / x` stays as-is (div-by-zero
+            // diagnostic must still fire when `x = 0`).
+            if rhs_int == Some(1) {
+                return Some(AlgReplace::Identity(Side::Lhs));
+            }
+            None
+        }
+        // Comparisons / Eq / Neq don't get algebraic
+        // rewrites here — those need structural equality
+        // (`x == x` → `true`), which is a separate analysis.
+        _ => None,
+    }
+}
+
+fn int_literal(node: &MirExpr) -> Option<i64> {
+    if let MirExpr::Literal(spanned) = node
+        && let Literal::Int(i) = spanned.node
+    {
+        return Some(i);
+    }
+    None
+}
+
+fn algebraic_walk_children(node: &mut MirExpr) {
+    match node {
+        MirExpr::Literal(_) | MirExpr::Local(_) => {}
+        MirExpr::Neg(inner) => algebraic_in_place(inner),
+        MirExpr::BinOp(spanned_bop) => {
+            algebraic_in_place(&mut spanned_bop.node.lhs);
+            algebraic_in_place(&mut spanned_bop.node.rhs);
+        }
+        MirExpr::Let(spanned_let) => {
+            algebraic_in_place(&mut spanned_let.node.value);
+            algebraic_in_place(&mut spanned_let.node.body);
+        }
+        MirExpr::Call(spanned_call) => {
+            for arg in &mut spanned_call.node.args {
+                algebraic_in_place(arg);
+            }
+        }
+        MirExpr::TailCall(spanned_tc) => {
+            for arg in &mut spanned_tc.node.args {
+                algebraic_in_place(arg);
+            }
+        }
+        MirExpr::Match(spanned_match) => {
+            algebraic_in_place(&mut spanned_match.node.subject);
+            for arm in &mut spanned_match.node.arms {
+                algebraic_in_place(&mut arm.body);
+            }
+        }
+        MirExpr::Construct(spanned_ctor) => {
+            for arg in &mut spanned_ctor.node.args {
+                algebraic_in_place(arg);
+            }
+        }
+        MirExpr::RecordCreate(spanned_rec) => {
+            for f in &mut spanned_rec.node.fields {
+                algebraic_in_place(&mut f.value);
+            }
+        }
+        MirExpr::RecordUpdate(spanned_upd) => {
+            algebraic_in_place(&mut spanned_upd.node.base);
+            for f in &mut spanned_upd.node.updates {
+                algebraic_in_place(&mut f.value);
+            }
+        }
+        MirExpr::Project(spanned_proj) => algebraic_in_place(&mut spanned_proj.node.base),
+        MirExpr::Try(inner) | MirExpr::Return(inner) => algebraic_in_place(inner),
+        MirExpr::List(items) | MirExpr::Tuple(items) => {
+            for item in items {
+                algebraic_in_place(item);
+            }
+        }
+        MirExpr::MapLiteral(entries) => {
+            for (k, v) in entries {
+                algebraic_in_place(k);
+                algebraic_in_place(v);
+            }
+        }
+        MirExpr::InterpolatedStr(parts) => {
+            for part in parts {
+                if let super::expr::MirStrPart::Expr(e) = part {
+                    algebraic_in_place(e);
+                }
+            }
+        }
+        MirExpr::IndependentProduct(spanned_ip) => {
+            for item in &mut spanned_ip.node.items {
+                algebraic_in_place(item);
+            }
+        }
     }
 }
 
@@ -1098,6 +1363,163 @@ mod tests {
         assert!(
             matches!(caller_body(&optimized), MirExpr::Literal(s) if matches!(s.node, Literal::Int(99))),
             "full pipeline should collapse caller body to `99`"
+        );
+    }
+
+    // ── Phase 6 wave 8: algebraic simplification ────────
+
+    fn local_at(slot: u32) -> MirExpr {
+        use super::super::expr::MirLocal;
+        use super::super::program::LocalId;
+        MirExpr::Local(span(MirLocal::at(LocalId(slot))))
+    }
+
+    #[test]
+    fn algebraic_x_plus_zero_drops_to_x() {
+        let body = MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Add,
+            lhs: Box::new(span(local_at(0))),
+            rhs: Box::new(span(MirExpr::Literal(span(Literal::Int(0))))),
+        }));
+        let simplified = algebraic_simplify(one_fn_program(body));
+        assert!(
+            matches!(body_of(&simplified), MirExpr::Local(_)),
+            "x + 0 should collapse to x"
+        );
+    }
+
+    #[test]
+    fn algebraic_zero_plus_x_drops_to_x() {
+        let body = MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Add,
+            lhs: Box::new(span(MirExpr::Literal(span(Literal::Int(0))))),
+            rhs: Box::new(span(local_at(0))),
+        }));
+        let simplified = algebraic_simplify(one_fn_program(body));
+        assert!(matches!(body_of(&simplified), MirExpr::Local(_)));
+    }
+
+    #[test]
+    fn algebraic_x_times_one_drops_to_x() {
+        let body = MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Mul,
+            lhs: Box::new(span(local_at(0))),
+            rhs: Box::new(span(MirExpr::Literal(span(Literal::Int(1))))),
+        }));
+        let simplified = algebraic_simplify(one_fn_program(body));
+        assert!(matches!(body_of(&simplified), MirExpr::Local(_)));
+    }
+
+    #[test]
+    fn algebraic_x_times_zero_collapses_when_pure() {
+        // `x * 0` → `0` ONLY when `x` is pure. Local read is pure.
+        let body = MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Mul,
+            lhs: Box::new(span(local_at(0))),
+            rhs: Box::new(span(MirExpr::Literal(span(Literal::Int(0))))),
+        }));
+        let simplified = algebraic_simplify(one_fn_program(body));
+        assert!(
+            matches!(body_of(&simplified), MirExpr::Literal(s) if matches!(s.node, Literal::Int(0))),
+            "x * 0 with pure x should collapse to literal 0"
+        );
+    }
+
+    #[test]
+    fn algebraic_x_times_zero_keeps_when_impure() {
+        // `some_call() * 0` — Call is impure, dropping it would
+        // skip a possible effect.
+        use super::super::expr::{MirCall, MirCallee};
+        use crate::ir::FnId;
+        let impure_call = MirExpr::Call(span(MirCall {
+            callee: MirCallee::Fn(FnId(0)),
+            args: vec![],
+        }));
+        let body = MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Mul,
+            lhs: Box::new(span(impure_call)),
+            rhs: Box::new(span(MirExpr::Literal(span(Literal::Int(0))))),
+        }));
+        let simplified = algebraic_simplify(one_fn_program(body));
+        assert!(
+            matches!(body_of(&simplified), MirExpr::BinOp(_)),
+            "impure x * 0 must stay a BinOp so the side effect runs"
+        );
+    }
+
+    #[test]
+    fn algebraic_x_div_one_drops_to_x() {
+        let body = MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Div,
+            lhs: Box::new(span(local_at(0))),
+            rhs: Box::new(span(MirExpr::Literal(span(Literal::Int(1))))),
+        }));
+        let simplified = algebraic_simplify(one_fn_program(body));
+        assert!(matches!(body_of(&simplified), MirExpr::Local(_)));
+    }
+
+    #[test]
+    fn algebraic_double_neg_unwraps() {
+        // Neg(Neg(x)) → x
+        let body = MirExpr::Neg(Box::new(span(MirExpr::Neg(Box::new(span(local_at(0)))))));
+        let simplified = algebraic_simplify(one_fn_program(body));
+        assert!(matches!(body_of(&simplified), MirExpr::Local(_)));
+    }
+
+    #[test]
+    fn algebraic_does_not_simplify_floats() {
+        // `x + 0.0` should stay — signed-zero / NaN edge cases
+        // mean float identities are unsafe without a per-shape
+        // proof. Walker skips floats by structure (literal value
+        // matcher reads `Int`-only).
+        let body = MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Add,
+            lhs: Box::new(span(local_at(0))),
+            rhs: Box::new(span(MirExpr::Literal(span(Literal::Float(0.0))))),
+        }));
+        let simplified = algebraic_simplify(one_fn_program(body));
+        assert!(
+            matches!(body_of(&simplified), MirExpr::BinOp(_)),
+            "float identity must NOT be simplified (signed-zero, NaN)"
+        );
+    }
+
+    #[test]
+    fn pipeline_compose_const_fold_algebraic_dce() {
+        // `let x = 1 + 0; x + 0` →
+        //  const-fold → `let x = 1; x + 0` (1+0 folds to 1, x+0 symbolic stays)
+        //  algebraic  → `let x = 1; x`
+        //  dce        → `1` (x used? yes, so dce keeps the let)
+        // Final: `let x = 1; x` (binding read, so kept).
+        use super::super::expr::MirLet;
+        use super::super::program::LocalId;
+        let value = MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Add,
+            lhs: Box::new(span(MirExpr::Literal(span(Literal::Int(1))))),
+            rhs: Box::new(span(MirExpr::Literal(span(Literal::Int(0))))),
+        }));
+        let body_expr = MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Add,
+            lhs: Box::new(span(local_at(0))),
+            rhs: Box::new(span(MirExpr::Literal(span(Literal::Int(0))))),
+        }));
+        let body = MirExpr::Let(span(MirLet {
+            binding: LocalId(0),
+            binding_name: "x".to_string(),
+            value: Box::new(span(value)),
+            body: Box::new(span(body_expr)),
+        }));
+        let optimized = dead_code(algebraic_simplify(const_fold(one_fn_program(body))));
+        let MirExpr::Let(let_node) = body_of(&optimized) else {
+            panic!("expected Let at root, got: {:?}", body_of(&optimized));
+        };
+        assert!(
+            matches!(&let_node.node.value.node, MirExpr::Literal(s) if matches!(s.node, Literal::Int(1))),
+            "let value should fold to 1"
+        );
+        assert!(
+            matches!(&let_node.node.body.node, MirExpr::Local(_)),
+            "let body's `x + 0` should simplify to `x` (Local)"
         );
     }
 }

--- a/src/vm/compiler/mod.rs
+++ b/src/vm/compiler/mod.rs
@@ -100,16 +100,21 @@ pub fn compile_program_with_mir_fallback(
     arena: &mut Arena,
     analysis: Option<&crate::ir::AnalysisResult>,
 ) -> Result<(CodeStore, Vec<NanValue>), CompileError> {
-    // Phase 6 wave 5–7: optimize pipeline on the lowered MIR
+    // Phase 6 wave 5–8: optimize pipeline on the lowered MIR
     // before the VM walker consumes it. Order is deliberate:
     // (1) nullary-literal inlining unlocks call-site literals,
-    // (2) const-fold collapses literal arithmetic, (3) DCE
-    // drops `let _ = <pure>; body` chains where the binding
-    // was never read. Each pass is a `MirProgram → MirProgram`
-    // pure function; future passes plug in by extending the
-    // chain.
-    let mir = crate::ir::mir::dead_code(crate::ir::mir::const_fold(
-        crate::ir::mir::inline_nullary_literals(crate::ir::mir::lower_program(items)),
+    // (2) const-fold collapses literal arithmetic,
+    // (3) algebraic-simplify rewrites Int identities
+    //     (`x + 0` / `x * 1` / `Neg(Neg(x))`) that const-fold
+    //     leaves symbolic (no two-literal pattern to collapse),
+    // (4) DCE drops `let _ = <pure>; body` chains where the
+    //     binding was never read.
+    // Each pass is a `MirProgram → MirProgram` pure function;
+    // future passes plug in by extending the chain.
+    let mir = crate::ir::mir::dead_code(crate::ir::mir::algebraic_simplify(
+        crate::ir::mir::const_fold(crate::ir::mir::inline_nullary_literals(
+            crate::ir::mir::lower_program(items),
+        )),
     ));
     compile_program_inner(
         items,


### PR DESCRIPTION
## Summary

Czwarty MIR optimizer pass. Rewrite \`BinOp\` / \`Neg\` shapes z algebraicznymi tożsamościami nad \`Int\`. Const-fold collapses two-literal cases; \`algebraic_simplify\` catches symbolic ones (\`x + 0\`, \`x * 1\`).

## Identities

- \`x + 0\` / \`0 + x\` / \`x - 0\` → \`x\`
- \`x * 1\` / \`1 * x\` / \`x / 1\` → \`x\`
- \`x * 0\` / \`0 * x\` → \`0\` (tylko gdy operand pure — reuse \`is_pure\` z wave 6 DCE)
- \`Neg(Neg(x))\` → \`x\`

## Co NIE jest simplified

- Float: signed-zero, NaN, ±∞ edge cases. Skipping → sound bez per-shape proof.
- \`x == x\` → \`true\` etc — wymaga structural equality, deferred.
- Strings / collections — reference-equality reasoning poza scope.

## Pipeline (po tym PR)

\`\`\`
dead_code ∘ algebraic_simplify ∘ const_fold ∘ inline_nullary_literals ∘ lower_program
\`\`\`

## Tests (27 inline, +9 net)

- 4× identity patterns
- \`x * 0\` pure vs impure (gating na is_pure)
- \`Neg(Neg)\` unwrap
- Float NOT simplified (signed-zero pin)
- End-to-end pipeline compose test

## Test plan
- [x] cargo fmt + clippy clean
- [x] 27/27 inline ✅
- [x] 1806 full-suite, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)