### PR TITLE
ir/mir: Phase 6 wave 9 — bool match → IfThenElse (#252 Phase 6)

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -476,6 +476,20 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                 }
             }
         }
+        MirExpr::IfThenElse(spanned_ite) => {
+            // Phase 6 wave 9: direct conditional. Emits as a
+            // Rust `if … { … } else { … }` expression. Each
+            // subtree must emit cleanly or the whole node
+            // falls back to HIR.
+            let ite = &spanned_ite.node;
+            let cond = emit_mir_expr(&ite.cond, emit_ctx)?;
+            let then_branch = emit_mir_expr(&ite.then_branch, emit_ctx)?;
+            let else_branch = emit_mir_expr(&ite.else_branch, emit_ctx)?;
+            Some(format!(
+                "if {} {{ {} }} else {{ {} }}",
+                cond, then_branch, else_branch
+            ))
+        }
         _ => None,
     }
 }

--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -113,6 +113,15 @@ fn write_expr(f: &mut fmt::Formatter<'_>, expr: &Spanned<MirExpr>, indent: &str)
             write!(f, ")")
         }
         MirExpr::Match(spanned) => write_match(f, &spanned.node, indent),
+        MirExpr::IfThenElse(spanned) => {
+            let ite = &spanned.node;
+            write!(f, "if ")?;
+            write_expr(f, &ite.cond, indent)?;
+            write!(f, " then ")?;
+            write_expr(f, &ite.then_branch, indent)?;
+            write!(f, " else ")?;
+            write_expr(f, &ite.else_branch, indent)
+        }
         MirExpr::Construct(spanned) => write_construct(f, &spanned.node, indent),
         MirExpr::RecordCreate(spanned) => write_record_create(f, &spanned.node, indent),
         MirExpr::RecordUpdate(spanned) => write_record_update(f, &spanned.node, indent),

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -131,6 +131,13 @@ pub enum MirExpr {
     RecordUpdate(Spanned<MirRecordUpdate>),
     /// Field access (`base.field`) on a record value.
     Project(Spanned<MirProject>),
+    /// `if cond { then } else { else }` — direct conditional
+    /// shape introduced by Phase 6 wave 9's `bool_match_to_if`
+    /// pass. Lowering never produces this node directly; the
+    /// optimizer pass rewrites qualifying two-arm `Bool` match
+    /// expressions into it so every backend gets a uniform
+    /// if/else node instead of re-implementing the recognition.
+    IfThenElse(Spanned<MirIfThenElse>),
     /// `value?` — the canonical `?` propagation. Phase 1's
     /// most-important pin: this stays a node. Lowering to nested
     /// `Match` is a per-backend choice, not a pipeline-wide
@@ -230,6 +237,21 @@ pub struct MirBinOp {
 pub struct MirMatch {
     pub subject: Box<Spanned<MirExpr>>,
     pub arms: Vec<MirMatchArm>,
+}
+
+/// `if cond { then_branch } else { else_branch }` — direct
+/// conditional, no pattern dispatch. Phase 6 wave 9 introduces
+/// this so every backend gets it for free instead of
+/// re-implementing the "two-arm bool match → if/else"
+/// recognition (HIR's `try_emit_bool_if_else` etc). The
+/// optimizer pass `bool_match_to_if` rewrites qualifying
+/// `Match` nodes into `IfThenElse`; backends consume only the
+/// rewritten form.
+#[derive(Debug, Clone)]
+pub struct MirIfThenElse {
+    pub cond: Box<Spanned<MirExpr>>,
+    pub then_branch: Box<Spanned<MirExpr>>,
+    pub else_branch: Box<Spanned<MirExpr>>,
 }
 
 /// One arm of a `match`. Pattern picks the variant; `body` is the

--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -83,10 +83,12 @@ pub mod stats;
 pub use crate::ir::hir::BuiltinCtor;
 pub use expr::{
     MirBinOp, MirCall, MirCallee, MirConstruct, MirCtor, MirEffectAnnotation, MirExpr,
-    MirIndependentProduct, MirLet, MirLocal, MirMatch, MirMatchArm, MirPattern, MirProject,
-    MirRecordCreate, MirRecordField, MirRecordUpdate, MirStrPart, MirTailCall,
+    MirIfThenElse, MirIndependentProduct, MirLet, MirLocal, MirMatch, MirMatchArm, MirPattern,
+    MirProject, MirRecordCreate, MirRecordField, MirRecordUpdate, MirStrPart, MirTailCall,
 };
 pub use lower::lower_program;
-pub use optimize::{algebraic_simplify, const_fold, dead_code, inline_nullary_literals};
+pub use optimize::{
+    algebraic_simplify, bool_match_to_if, const_fold, dead_code, inline_nullary_literals,
+};
 pub use program::{LocalId, MirFn, MirParam, MirProgram};
 pub use stats::{LowerStats, SkipReason};

--- a/src/ir/mir/optimize.rs
+++ b/src/ir/mir/optimize.rs
@@ -145,6 +145,11 @@ fn walk_children(node: &mut MirExpr) {
                 fold_arm(arm);
             }
         }
+        MirExpr::IfThenElse(spanned_ite) => {
+            fold_in_place(&mut spanned_ite.node.cond);
+            fold_in_place(&mut spanned_ite.node.then_branch);
+            fold_in_place(&mut spanned_ite.node.else_branch);
+        }
         MirExpr::Construct(spanned_ctor) => {
             let ctor: &mut MirConstruct = &mut spanned_ctor.node;
             for arg in &mut ctor.args {
@@ -347,6 +352,11 @@ fn dce_walk_children(node: &mut MirExpr) {
                 dce_in_place(&mut arm.body);
             }
         }
+        MirExpr::IfThenElse(spanned_ite) => {
+            dce_in_place(&mut spanned_ite.node.cond);
+            dce_in_place(&mut spanned_ite.node.then_branch);
+            dce_in_place(&mut spanned_ite.node.else_branch);
+        }
         MirExpr::Construct(spanned_ctor) => {
             for arg in &mut spanned_ctor.node.args {
                 dce_in_place(arg);
@@ -435,6 +445,11 @@ fn visit_locals(node: &MirExpr, visit: &mut impl FnMut(LocalId)) {
                 visit_locals(&arm.body.node, visit);
             }
         }
+        MirExpr::IfThenElse(spanned_ite) => {
+            visit_locals(&spanned_ite.node.cond.node, visit);
+            visit_locals(&spanned_ite.node.then_branch.node, visit);
+            visit_locals(&spanned_ite.node.else_branch.node, visit);
+        }
         MirExpr::Construct(spanned_ctor) => {
             for arg in &spanned_ctor.node.args {
                 visit_locals(&arg.node, visit);
@@ -512,6 +527,13 @@ fn is_pure(expr: &Spanned<MirExpr>) -> bool {
         MirExpr::Project(spanned_proj) => is_pure(&spanned_proj.node.base),
         MirExpr::Let(spanned_let) => {
             is_pure(&spanned_let.node.value) && is_pure(&spanned_let.node.body)
+        }
+        // IfThenElse is pure iff all three subtrees are pure —
+        // direct conditional, no dispatch overhead unlike Match.
+        MirExpr::IfThenElse(spanned_ite) => {
+            is_pure(&spanned_ite.node.cond)
+                && is_pure(&spanned_ite.node.then_branch)
+                && is_pure(&spanned_ite.node.else_branch)
         }
         // Anything that could call out (Call / TailCall),
         // unwind (Try / Return), dispatch (Match), produce
@@ -741,6 +763,11 @@ fn algebraic_walk_children(node: &mut MirExpr) {
                 algebraic_in_place(&mut arm.body);
             }
         }
+        MirExpr::IfThenElse(spanned_ite) => {
+            algebraic_in_place(&mut spanned_ite.node.cond);
+            algebraic_in_place(&mut spanned_ite.node.then_branch);
+            algebraic_in_place(&mut spanned_ite.node.else_branch);
+        }
         MirExpr::Construct(spanned_ctor) => {
             for arg in &mut spanned_ctor.node.args {
                 algebraic_in_place(arg);
@@ -880,6 +907,11 @@ fn inline_walk_children(node: &mut MirExpr, candidates: &HashMap<FnId, Literal>)
                 inline_in_place(&mut arm.body, candidates);
             }
         }
+        MirExpr::IfThenElse(spanned_ite) => {
+            inline_in_place(&mut spanned_ite.node.cond, candidates);
+            inline_in_place(&mut spanned_ite.node.then_branch, candidates);
+            inline_in_place(&mut spanned_ite.node.else_branch, candidates);
+        }
         MirExpr::Construct(spanned_ctor) => {
             for arg in &mut spanned_ctor.node.args {
                 inline_in_place(arg, candidates);
@@ -919,6 +951,192 @@ fn inline_walk_children(node: &mut MirExpr, candidates: &HashMap<FnId, Literal>)
         MirExpr::IndependentProduct(spanned_ip) => {
             for item in &mut spanned_ip.node.items {
                 inline_in_place(item, candidates);
+            }
+        }
+    }
+}
+
+/// Wave 9 — rewrite qualifying two-arm `Bool` match expressions
+/// into `IfThenElse`. Recognition shape (mirror of HIR's
+/// `try_emit_bool_if_else`):
+///
+/// - Match has exactly 2 arms
+/// - One arm's pattern is `Literal(Bool(true))`, the other is
+///   `Literal(Bool(false))` or `Wildcard` (catch-all default)
+/// - Bindings are empty (no captured locals)
+///
+/// When matched, replace with `IfThenElse { cond: subject,
+/// then_branch: <true-arm body>, else_branch: <false-arm body> }`.
+/// Backends consume only the rewritten form — no per-backend
+/// recognition logic.
+pub fn bool_match_to_if(mut program: MirProgram) -> MirProgram {
+    for mir_fn in program.fns.values_mut() {
+        bool_match_in_place(&mut mir_fn.body);
+    }
+    program
+}
+
+fn bool_match_in_place(expr: &mut Spanned<MirExpr>) {
+    bool_match_walk_children(&mut expr.node);
+
+    let replacement = if let MirExpr::Match(spanned_match) = &expr.node {
+        let m = &spanned_match.node;
+        try_bool_match_branches(&m.arms)
+    } else {
+        None
+    };
+
+    if let Some(branch_indices) = replacement {
+        let placeholder = MirExpr::Literal(Spanned {
+            node: Literal::Unit,
+            line: expr.line,
+            ty: std::sync::OnceLock::new(),
+        });
+        let original = std::mem::replace(&mut expr.node, placeholder);
+        if let MirExpr::Match(spanned_match) = original {
+            let m = spanned_match.node;
+            let subject = m.subject;
+            let mut arms_iter = m.arms.into_iter();
+            // Collect arms in source order so we can index.
+            let arms_vec: Vec<MirMatchArm> = arms_iter.by_ref().collect();
+            let then_branch = Box::new(arms_vec[branch_indices.true_idx].body.clone());
+            let else_branch = Box::new(arms_vec[branch_indices.false_idx].body.clone());
+            let ite = super::expr::MirIfThenElse {
+                cond: subject,
+                then_branch,
+                else_branch,
+            };
+            expr.node = MirExpr::IfThenElse(Spanned {
+                node: ite,
+                line: expr.line,
+                ty: std::sync::OnceLock::new(),
+            });
+        } else {
+            unreachable!("replacement only set inside the Match branch")
+        }
+    }
+}
+
+struct BoolBranchIndices {
+    true_idx: usize,
+    false_idx: usize,
+}
+
+/// Recognize the bool match shape over a 2-arm slice. Returns
+/// `Some` with the arm index for each branch on hit, `None`
+/// when the shape doesn't qualify.
+fn try_bool_match_branches(arms: &[MirMatchArm]) -> Option<BoolBranchIndices> {
+    if arms.len() != 2 {
+        return None;
+    }
+    let p0 = &arms[0].pattern;
+    let p1 = &arms[1].pattern;
+    let p0_bool = bool_pattern(p0);
+    let p1_bool = bool_pattern(p1);
+    match (p0_bool, p1_bool) {
+        // `true → A; false → B` or `true → A; _ → B`
+        (Some(BoolPat::True), Some(BoolPat::False))
+        | (Some(BoolPat::True), Some(BoolPat::Wildcard)) => Some(BoolBranchIndices {
+            true_idx: 0,
+            false_idx: 1,
+        }),
+        // `false → B; true → A` or `_ → B; true → A`
+        (Some(BoolPat::False), Some(BoolPat::True))
+        | (Some(BoolPat::Wildcard), Some(BoolPat::True)) => Some(BoolBranchIndices {
+            true_idx: 1,
+            false_idx: 0,
+        }),
+        _ => None,
+    }
+}
+
+enum BoolPat {
+    True,
+    False,
+    Wildcard,
+}
+
+fn bool_pattern(p: &MirPattern) -> Option<BoolPat> {
+    match p {
+        MirPattern::Literal(Literal::Bool(true)) => Some(BoolPat::True),
+        MirPattern::Literal(Literal::Bool(false)) => Some(BoolPat::False),
+        MirPattern::Wildcard => Some(BoolPat::Wildcard),
+        _ => None,
+    }
+}
+
+fn bool_match_walk_children(node: &mut MirExpr) {
+    match node {
+        MirExpr::Literal(_) | MirExpr::Local(_) => {}
+        MirExpr::Neg(inner) => bool_match_in_place(inner),
+        MirExpr::BinOp(spanned_bop) => {
+            bool_match_in_place(&mut spanned_bop.node.lhs);
+            bool_match_in_place(&mut spanned_bop.node.rhs);
+        }
+        MirExpr::Let(spanned_let) => {
+            bool_match_in_place(&mut spanned_let.node.value);
+            bool_match_in_place(&mut spanned_let.node.body);
+        }
+        MirExpr::Call(spanned_call) => {
+            for arg in &mut spanned_call.node.args {
+                bool_match_in_place(arg);
+            }
+        }
+        MirExpr::TailCall(spanned_tc) => {
+            for arg in &mut spanned_tc.node.args {
+                bool_match_in_place(arg);
+            }
+        }
+        MirExpr::Match(spanned_match) => {
+            bool_match_in_place(&mut spanned_match.node.subject);
+            for arm in &mut spanned_match.node.arms {
+                bool_match_in_place(&mut arm.body);
+            }
+        }
+        MirExpr::IfThenElse(spanned_ite) => {
+            bool_match_in_place(&mut spanned_ite.node.cond);
+            bool_match_in_place(&mut spanned_ite.node.then_branch);
+            bool_match_in_place(&mut spanned_ite.node.else_branch);
+        }
+        MirExpr::Construct(spanned_ctor) => {
+            for arg in &mut spanned_ctor.node.args {
+                bool_match_in_place(arg);
+            }
+        }
+        MirExpr::RecordCreate(spanned_rec) => {
+            for f in &mut spanned_rec.node.fields {
+                bool_match_in_place(&mut f.value);
+            }
+        }
+        MirExpr::RecordUpdate(spanned_upd) => {
+            bool_match_in_place(&mut spanned_upd.node.base);
+            for f in &mut spanned_upd.node.updates {
+                bool_match_in_place(&mut f.value);
+            }
+        }
+        MirExpr::Project(spanned_proj) => bool_match_in_place(&mut spanned_proj.node.base),
+        MirExpr::Try(inner) | MirExpr::Return(inner) => bool_match_in_place(inner),
+        MirExpr::List(items) | MirExpr::Tuple(items) => {
+            for item in items {
+                bool_match_in_place(item);
+            }
+        }
+        MirExpr::MapLiteral(entries) => {
+            for (k, v) in entries {
+                bool_match_in_place(k);
+                bool_match_in_place(v);
+            }
+        }
+        MirExpr::InterpolatedStr(parts) => {
+            for part in parts {
+                if let super::expr::MirStrPart::Expr(e) = part {
+                    bool_match_in_place(e);
+                }
+            }
+        }
+        MirExpr::IndependentProduct(spanned_ip) => {
+            for item in &mut spanned_ip.node.items {
+                bool_match_in_place(item);
             }
         }
     }
@@ -1520,6 +1738,133 @@ mod tests {
         assert!(
             matches!(&let_node.node.body.node, MirExpr::Local(_)),
             "let body's `x + 0` should simplify to `x` (Local)"
+        );
+    }
+
+    // ── Phase 6 wave 9: bool match → IfThenElse ─────────
+
+    fn bool_match_program(arms: Vec<MirMatchArm>) -> MirProgram {
+        use super::super::expr::MirMatch;
+        use super::super::program::LocalId;
+        let subject = MirExpr::Local(span(super::super::expr::MirLocal::at(LocalId(0))));
+        let m = MirExpr::Match(span(MirMatch {
+            subject: Box::new(span(subject)),
+            arms,
+        }));
+        one_fn_program(m)
+    }
+
+    #[test]
+    fn bool_match_rewrites_true_first_then_false() {
+        // match cond { true → 1; false → 2 } → if cond { 1 } else { 2 }
+        let arms = vec![
+            MirMatchArm {
+                pattern: MirPattern::Literal(Literal::Bool(true)),
+                body: span(MirExpr::Literal(span(Literal::Int(1)))),
+            },
+            MirMatchArm {
+                pattern: MirPattern::Literal(Literal::Bool(false)),
+                body: span(MirExpr::Literal(span(Literal::Int(2)))),
+            },
+        ];
+        let rewritten = bool_match_to_if(bool_match_program(arms));
+        let MirExpr::IfThenElse(ite) = body_of(&rewritten) else {
+            panic!("expected IfThenElse, got: {:?}", body_of(&rewritten));
+        };
+        assert!(
+            matches!(&ite.node.then_branch.node, MirExpr::Literal(s) if matches!(s.node, Literal::Int(1))),
+            "then branch should be 1"
+        );
+        assert!(
+            matches!(&ite.node.else_branch.node, MirExpr::Literal(s) if matches!(s.node, Literal::Int(2))),
+            "else branch should be 2"
+        );
+    }
+
+    #[test]
+    fn bool_match_rewrites_false_first_then_true() {
+        // match cond { false → 2; true → 1 } → if cond { 1 } else { 2 }
+        let arms = vec![
+            MirMatchArm {
+                pattern: MirPattern::Literal(Literal::Bool(false)),
+                body: span(MirExpr::Literal(span(Literal::Int(2)))),
+            },
+            MirMatchArm {
+                pattern: MirPattern::Literal(Literal::Bool(true)),
+                body: span(MirExpr::Literal(span(Literal::Int(1)))),
+            },
+        ];
+        let rewritten = bool_match_to_if(bool_match_program(arms));
+        let MirExpr::IfThenElse(ite) = body_of(&rewritten) else {
+            panic!("expected IfThenElse")
+        };
+        assert!(
+            matches!(&ite.node.then_branch.node, MirExpr::Literal(s) if matches!(s.node, Literal::Int(1))),
+            "then branch should still be 1 even though true-arm was second in source"
+        );
+    }
+
+    #[test]
+    fn bool_match_rewrites_true_with_wildcard_default() {
+        // match cond { true → 1; _ → 2 } → if cond { 1 } else { 2 }
+        let arms = vec![
+            MirMatchArm {
+                pattern: MirPattern::Literal(Literal::Bool(true)),
+                body: span(MirExpr::Literal(span(Literal::Int(1)))),
+            },
+            MirMatchArm {
+                pattern: MirPattern::Wildcard,
+                body: span(MirExpr::Literal(span(Literal::Int(2)))),
+            },
+        ];
+        let rewritten = bool_match_to_if(bool_match_program(arms));
+        assert!(matches!(body_of(&rewritten), MirExpr::IfThenElse(_)));
+    }
+
+    #[test]
+    fn bool_match_leaves_three_arm_match_intact() {
+        // match cond { true → 1; false → 2; _ → 3 } stays Match —
+        // wave 9 only handles two-arm shape, three+ wait for
+        // future passes.
+        let arms = vec![
+            MirMatchArm {
+                pattern: MirPattern::Literal(Literal::Bool(true)),
+                body: span(MirExpr::Literal(span(Literal::Int(1)))),
+            },
+            MirMatchArm {
+                pattern: MirPattern::Literal(Literal::Bool(false)),
+                body: span(MirExpr::Literal(span(Literal::Int(2)))),
+            },
+            MirMatchArm {
+                pattern: MirPattern::Wildcard,
+                body: span(MirExpr::Literal(span(Literal::Int(3)))),
+            },
+        ];
+        let rewritten = bool_match_to_if(bool_match_program(arms));
+        assert!(
+            matches!(body_of(&rewritten), MirExpr::Match(_)),
+            "three-arm match should stay a Match node"
+        );
+    }
+
+    #[test]
+    fn bool_match_leaves_non_bool_match_intact() {
+        // match xs { [] → 0; _ → 1 } — EmptyList isn't a Bool
+        // literal, so the pass doesn't fire.
+        let arms = vec![
+            MirMatchArm {
+                pattern: MirPattern::EmptyList,
+                body: span(MirExpr::Literal(span(Literal::Int(0)))),
+            },
+            MirMatchArm {
+                pattern: MirPattern::Wildcard,
+                body: span(MirExpr::Literal(span(Literal::Int(1)))),
+            },
+        ];
+        let rewritten = bool_match_to_if(bool_match_program(arms));
+        assert!(
+            matches!(body_of(&rewritten), MirExpr::Match(_)),
+            "non-Bool literal pattern should not trigger the rewrite"
         );
     }
 }

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -467,6 +467,25 @@ pub(super) fn compile_mir_expr(
         //   last arm: skip pattern check entirely (exhaustive),
         //             POP, <body>
         //   end:
+        MirExpr::IfThenElse(spanned_ite) => {
+            // Phase 6 wave 9: direct conditional shape.
+            // Emit:
+            //   compile_mir_expr(cond)
+            //   JUMP_IF_FALSE → else_start
+            //   compile_mir_expr(then_branch)
+            //   JUMP → end
+            //   else_start: compile_mir_expr(else_branch)
+            //   end:
+            let ite = &spanned_ite.node;
+            compile_mir_expr(fc, &ite.cond)?;
+            let else_patch = fc.emit_jump(JUMP_IF_FALSE);
+            compile_mir_expr(fc, &ite.then_branch)?;
+            let end_patch = fc.emit_jump(JUMP);
+            fc.patch_jump(else_patch);
+            compile_mir_expr(fc, &ite.else_branch)?;
+            fc.patch_jump(end_patch);
+            Ok(())
+        }
         MirExpr::Match(spanned_match) => {
             let m = &spanned_match.node;
             // Phase 6 wave 2 — try the MATCH_DISPATCH_CONST table
@@ -725,6 +744,14 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
         MirExpr::IndependentProduct(ip) => ip.node.items.iter().all(can_compile),
         // Phase 4i: all `MirPattern` variants supported (Tuple
         // recurses into subpatterns).
+        // Phase 6 wave 9: direct conditional shape introduced
+        // by `bool_match_to_if`. Every backend (incl. VM)
+        // supports it natively as branch + branch.
+        MirExpr::IfThenElse(ite) => {
+            can_compile(&ite.node.cond)
+                && can_compile(&ite.node.then_branch)
+                && can_compile(&ite.node.else_branch)
+        }
         MirExpr::Match(m) => {
             can_compile(&m.node.subject)
                 && m.node
@@ -1300,11 +1327,16 @@ fn contains_last_use_slot_mir(expr: &MirExpr, target: u32) -> bool {
             MirStrPart::Expr(e) => contains_last_use_slot_mir(&e.node, target),
             MirStrPart::Literal(_) => false,
         }),
-        // Match / Let / Return: structural recursion stays
-        // conservative — we only care about the immediate
-        // arg-evaluation context for the owned_mask, so deep
-        // recursion into match arms / let bodies isn't useful.
-        MirExpr::Match(_) | MirExpr::Let(_) | MirExpr::Return(_) | MirExpr::Literal(_) => false,
+        // Match / IfThenElse / Let / Return: structural
+        // recursion stays conservative — we only care about
+        // the immediate arg-evaluation context for the
+        // owned_mask, so deep recursion into match arms /
+        // if branches / let bodies isn't useful.
+        MirExpr::Match(_)
+        | MirExpr::IfThenElse(_)
+        | MirExpr::Let(_)
+        | MirExpr::Return(_)
+        | MirExpr::Literal(_) => false,
     }
 }
 

--- a/src/vm/compiler/mod.rs
+++ b/src/vm/compiler/mod.rs
@@ -100,20 +100,24 @@ pub fn compile_program_with_mir_fallback(
     arena: &mut Arena,
     analysis: Option<&crate::ir::AnalysisResult>,
 ) -> Result<(CodeStore, Vec<NanValue>), CompileError> {
-    // Phase 6 wave 5–8: optimize pipeline on the lowered MIR
+    // Phase 6 wave 5–9: optimize pipeline on the lowered MIR
     // before the VM walker consumes it. Order is deliberate:
     // (1) nullary-literal inlining unlocks call-site literals,
     // (2) const-fold collapses literal arithmetic,
     // (3) algebraic-simplify rewrites Int identities
     //     (`x + 0` / `x * 1` / `Neg(Neg(x))`) that const-fold
     //     leaves symbolic (no two-literal pattern to collapse),
-    // (4) DCE drops `let _ = <pure>; body` chains where the
+    // (4) bool-match-to-if rewrites qualifying two-arm `Bool`
+    //     match expressions into `IfThenElse` so backends get
+    //     a uniform conditional shape instead of re-implementing
+    //     the recognition (HIR's `try_emit_bool_if_else`),
+    // (5) DCE drops `let _ = <pure>; body` chains where the
     //     binding was never read.
     // Each pass is a `MirProgram → MirProgram` pure function;
     // future passes plug in by extending the chain.
-    let mir = crate::ir::mir::dead_code(crate::ir::mir::algebraic_simplify(
-        crate::ir::mir::const_fold(crate::ir::mir::inline_nullary_literals(
-            crate::ir::mir::lower_program(items),
+    let mir = crate::ir::mir::dead_code(crate::ir::mir::bool_match_to_if(
+        crate::ir::mir::algebraic_simplify(crate::ir::mir::const_fold(
+            crate::ir::mir::inline_nullary_literals(crate::ir::mir::lower_program(items)),
         )),
     ));
     compile_program_inner(


### PR DESCRIPTION
## Summary

Piąty MIR optimizer pass — i pierwszy który wprowadza nowy \`MirExpr\` variant. Rozpoznaje 2-arm Bool match idiom i podnosi do bezpośredniego \`IfThenElse\` — każdy backend (VM, Rust, future wasm-gc) dostaje uniform conditional zamiast re-implementować rozpoznanie.

## Architektoniczna znaczenie

Pierwsza realizacja MIR substrate promise: **shared recognition once, consumed by N backends**. Wcześniej HIR's \`try_emit_bool_if_else\` w Rust codegen + osobna MATCH_DISPATCH_CONST ścieżka w VM duplikowały rozpoznanie.

## Co lands

### Nowy variant
\`MirExpr::IfThenElse(Spanned<MirIfThenElse { cond, then_branch, else_branch }>)\`

### Pass \`bool_match_to_if\`
Recognition: 2 arms, jedna \`Literal(Bool(true))\` druga \`Literal(Bool(false))\` lub \`Wildcard\`, bindings empty. Arm-order independent.

### VM walker
\`JUMP_IF_FALSE → else_start; then; JUMP → end; else_start: else; end:\` — drop-in dla equivalent MATCH_DISPATCH_CONST chain.

### Rust walker
\`if {cond} { {then} } else { {else} }\` — natural Rust shape.

### Consumer updates
9 sites touched (dump.rs, 4 optimize walkers, visit_locals, is_pure, vm/can_compile, owned-mask scan).

## Pipeline composition (po tym PR)

\`\`\`
dead_code ∘ bool_match_to_if ∘ algebraic_simplify ∘ const_fold ∘ inline_nullary_literals ∘ lower_program
\`\`\`

## Tests (32 inline, +5 net)

- True-first / false-first arm-order independence
- Wildcard catch-all qualifies
- Three-arm match stays Match (only 2-arm qualifies)
- Non-Bool pattern (EmptyList) stays Match

## Test plan
- [x] cargo fmt + clippy clean
- [x] 32/32 inline ✅
- [x] 1811 full-suite tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)