### PR TITLE
vm: execute CALL_KNOWN_OWNED (unblocks MIR-VM dispatch) (#252 Phase 6)

### DIFF
--- a/src/vm/execute/dispatch.rs
+++ b/src/vm/execute/dispatch.rs
@@ -433,9 +433,20 @@ impl VM {
                     }
                 }
 
-                CALL_KNOWN => {
+                CALL_KNOWN | CALL_KNOWN_OWNED => {
                     let target_fn_id = read_u16!(code, ip) as u32;
                     let argc = read_u8!(code, ip) as usize;
+                    // `CALL_KNOWN_OWNED` (emitted by the MIR walker) carries a
+                    // trailing owned-arg mask. A user-fn callee derives its
+                    // parameter ownership from its own alias analysis, so the
+                    // mask is inert at the call boundary today — this mirrors
+                    // the HIR walker, which ignores owned-ness for known calls
+                    // and only ever emits plain `CALL_KNOWN`. The byte is read
+                    // to keep the bytecode self-describing; a future cross-call
+                    // ownership pass can consume it to un-alias owned params.
+                    if op == CALL_KNOWN_OWNED {
+                        let _owned_mask = read_u8!(code, ip);
+                    }
 
                     self.frames.last_mut().unwrap().ip = ip as u32;
 

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -108,6 +108,25 @@ fn neg_parity() {
     assert_eq!(hir, Value::Int(-5));
 }
 
+#[test]
+fn recursive_owned_call_parity() {
+    // fib's recursive arms are non-tail `CALL_KNOWN`s whose argument
+    // (`n - 1` / `n - 2`) carries the last use of param `n`, so the MIR
+    // walker's `compute_owned_mask` is non-zero and it emits the
+    // `CALL_KNOWN_OWNED` opcode. That opcode previously had no handler
+    // in the execute dispatch, so this exact shape trapped with
+    // `unknown opcode: 0x47` on the MIR-fallback path while the HIR
+    // path (plain `CALL_KNOWN`) was fine. Guards the handler.
+    let src = "fn fib(n: Int) -> Int\n    match n < 2\n        true -> n\n        false -> fib(n - 1) + fib(n - 2)\n";
+    let hir = run_via_path(src, "fib", &[10], Path::Hir);
+    let mir = run_via_path(src, "fib", &[10], Path::MirFallback);
+    assert_eq!(
+        hir, mir,
+        "HIR and MIR-fallback paths must agree on fib(10): HIR={hir:?}, MIR={mir:?}"
+    );
+    assert_eq!(hir, Value::Int(55), "fib(10) = 55");
+}
+
 /// Compile both paths and return the per-fn bytecode pair so
 /// tests can byte-compare specific chunks.
 fn compile_both(src: &str) -> (aver::vm::CodeStore, aver::vm::CodeStore) {


### PR DESCRIPTION
## Summary

The MIR-VM walker emits **`CALL_KNOWN_OWNED` (0x47)** for a non-tail known call whose argument carries the last use of a parameter (`compute_owned_mask != 0`) — e.g. `fib(n - 2)`. The opcode was defined and emitted but **had no arm in the execute dispatch**, so any program with that shape trapped at runtime with `unknown opcode: 0x47` the moment the MIR-fallback path ran.

Found by temporarily switching the VM bench runner to `compile_program_with_mir_fallback`: `fib` crashed while `countdown`/`factorial` ran. An audit of the **41 opcodes** the MIR walker emits found this was the **only one** missing a handler.

## Why it matters for the wireup

This blocked wiring `compile_program_with_mir_fallback` as the default VM path (0.24 goal A). The per-fn HIR fallback only fires on a compile-time `MirVmUnsupported` — **not** on a successfully-emitted-but-unhandled opcode, so the crash would reach shipped programs.

## The fix

Handle `CALL_KNOWN_OWNED` alongside `CALL_KNOWN`, reading and discarding the trailing owned-arg mask. A user-fn callee derives parameter ownership from its own alias analysis, so the mask is **inert at the call boundary today** — this mirrors the HIR walker, which ignores owned-ness for known calls and only ever emits plain `CALL_KNOWN`. The byte stays in the bytecode so a future cross-call ownership pass can consume it (the path to recovering the Vector/Map accumulator fast path that the 0.17.1 alias-safety fix conservatively disabled).

## Test plan
- [x] New `recursive_owned_call_parity` (fib via HIR and MIR-fallback paths) — the exact shape that trapped
- [x] `cargo test --test mir_vm_parity` — 46 pass
- [x] Full `cargo test` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)