### PR TITLE
vm: make MIR the default VM compile path (#252 Phase 6)

### DIFF
--- a/src/ir/mir/instantiations.rs
+++ b/src/ir/mir/instantiations.rs
@@ -439,6 +439,7 @@ mod tests {
                 return_type: "Int".to_string(),
                 effects: vec![],
                 body,
+                local_count: 0,
             },
         );
         p

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -162,10 +162,22 @@ fn lower_fn(fd: &ResolvedFnDef, program: &mut MirProgram) -> Result<MirFn, SkipR
     if stmts.is_empty() {
         return Err(SkipReason::EmptyBody);
     }
+    // Synthetic-local counter starts past the resolver's slots so the
+    // stmt-chain lowering can mint fresh slots for opaque-let temps.
+    // Its final value is the function's true local_count — the VM
+    // walker must reserve this many frame slots, not just the
+    // resolver's `local_count`, or a `STORE_LOCAL` to a synthetic slot
+    // overruns the frame.
+    let base_local_count = fd
+        .resolution
+        .as_ref()
+        .map_or(fd.params.len() as u32, |r| u32::from(r.local_count));
+    let mut next_synthetic_local = base_local_count;
     let body = match stmts.len() {
         1 => {
             // Single-stmt body: must be `Expr`. Bindings alone
-            // can't produce a value.
+            // can't produce a value. No opaque-let temps here, so the
+            // counter stays at `base_local_count`.
             let ResolvedStmt::Expr(expr) = &stmts[0] else {
                 return Err(SkipReason::BindingOnlyTail);
             };
@@ -180,10 +192,10 @@ fn lower_fn(fd: &ResolvedFnDef, program: &mut MirProgram) -> Result<MirFn, SkipR
                 .resolution
                 .as_ref()
                 .ok_or(SkipReason::MissingResolution)?;
-            let mut next_synthetic_local = u32::from(resolution.local_count);
             lower_stmt_chain(stmts, resolution, &mut next_synthetic_local, program)?
         }
     };
+    let local_count = next_synthetic_local;
 
     let params = fd
         .params
@@ -213,6 +225,7 @@ fn lower_fn(fd: &ResolvedFnDef, program: &mut MirProgram) -> Result<MirFn, SkipR
         return_type: format!("{:?}", fd.return_type),
         effects,
         body,
+        local_count,
     })
 }
 

--- a/src/ir/mir/optimize/inline.rs
+++ b/src/ir/mir/optimize/inline.rs
@@ -171,6 +171,7 @@ mod tests {
                 return_type: "Int".to_string(),
                 effects: vec![],
                 body: span(callee_body),
+                local_count: 0,
             },
         );
         p.fns.insert(
@@ -182,6 +183,7 @@ mod tests {
                 return_type: "Int".to_string(),
                 effects: vec![],
                 body: span(caller_body),
+                local_count: 0,
             },
         );
         p
@@ -221,6 +223,7 @@ mod tests {
                 return_type: "Int".to_string(),
                 effects: vec![],
                 body: span(MirExpr::Literal(span(Literal::Int(42)))),
+                local_count: 1,
             },
         );
         let caller_body_expr = MirExpr::Call(span(MirCall {
@@ -236,6 +239,7 @@ mod tests {
                 return_type: "Int".to_string(),
                 effects: vec![],
                 body: span(caller_body_expr),
+                local_count: 0,
             },
         );
         let inlined = inline_nullary_literals(p);

--- a/src/ir/mir/optimize/test_helpers.rs
+++ b/src/ir/mir/optimize/test_helpers.rs
@@ -27,6 +27,7 @@ pub(crate) fn one_fn_program(body: MirExpr) -> MirProgram {
             return_type: "Int".to_string(),
             effects: vec![],
             body: span(body),
+            local_count: 0,
         },
     );
     p

--- a/src/ir/mir/program.rs
+++ b/src/ir/mir/program.rs
@@ -131,6 +131,12 @@ pub struct MirFn {
     /// `fn_id`, but the body span is needed for sub-expression
     /// errors that don't carry a closer one).
     pub body: Spanned<MirExpr>,
+    /// Number of frame slots the lowered body needs: the resolver's
+    /// `local_count` plus any synthetic slots minted for opaque-let
+    /// temps during stmt-chain lowering. The VM walker reserves this
+    /// many slots; using the resolver's count alone underruns the
+    /// frame when the body stores into a synthetic slot.
+    pub local_count: u32,
 }
 
 /// One formal parameter. The `LocalId` is assigned at lowering

--- a/src/vm/compiler/mod.rs
+++ b/src/vm/compiler/mod.rs
@@ -31,13 +31,26 @@ use super::types::{CodeStore, FnChunk};
 /// `analysis` carries per-fn `FnAnalysis.allocates` from the
 /// pipeline's analyze stage; the VM compiler reads `chunk.no_alloc`
 /// from it directly.
+/// HIR-only compile. Retained as the differential reference path:
+/// the MIR-VM parity tests compile the same source through here and
+/// through the MIR-default module-aware entry points and assert
+/// identical VM-observable behavior. Production callers use the
+/// module-aware entry points below, which take the MIR-default path.
 pub fn compile_program(
     items: &[ResolvedTopLevel],
     symbols: &SymbolTable,
     arena: &mut Arena,
     analysis: Option<&crate::ir::AnalysisResult>,
 ) -> Result<(CodeStore, Vec<NanValue>), CompileError> {
-    compile_program_with_modules(items, symbols, arena, None, "", analysis)
+    compile_program_inner(
+        items,
+        symbols,
+        arena,
+        "",
+        ModuleSource::Disk(None),
+        analysis,
+        false,
+    )
 }
 
 /// Compile with explicit module root for `depends` resolution.
@@ -56,7 +69,7 @@ pub fn compile_program_with_modules(
         source_file,
         ModuleSource::Disk(module_root),
         analysis,
-        None,
+        true,
     )
 }
 
@@ -78,7 +91,7 @@ pub fn compile_program_with_loaded_modules(
         source_file,
         ModuleSource::Loaded(loaded),
         analysis,
-        None,
+        true,
     )
 }
 
@@ -100,27 +113,11 @@ pub fn compile_program_with_mir_fallback(
     arena: &mut Arena,
     analysis: Option<&crate::ir::AnalysisResult>,
 ) -> Result<(CodeStore, Vec<NanValue>), CompileError> {
-    // Phase 6 wave 5–10: optimize pipeline on the lowered MIR
-    // before the VM walker consumes it. Order is deliberate:
-    // (1) nullary-literal inlining unlocks call-site literals,
-    // (2) const-fold collapses literal arithmetic,
-    // (3) algebraic-simplify rewrites Int identities
-    //     (`x + 0` / `x * 1` / `Neg(Neg(x))`),
-    // (4) bool-match-to-if rewrites qualifying two-arm `Bool`
-    //     match expressions into `IfThenElse`,
-    // (5) branch-collapse drops the dead branch of an
-    //     `IfThenElse` whose `cond` folded to a literal `Bool`,
-    // (6) DCE drops `let _ = <pure>; body` chains where the
-    //     binding was never read.
-    // Each pass is a `MirProgram → MirProgram` pure function;
-    // future passes plug in by extending the chain.
-    let mir = crate::ir::mir::dead_code(crate::ir::mir::branch_collapse(
-        crate::ir::mir::bool_match_to_if(crate::ir::mir::algebraic_simplify(
-            crate::ir::mir::const_fold(crate::ir::mir::inline_nullary_literals(
-                crate::ir::mir::lower_program(items),
-            )),
-        )),
-    ));
+    // Single-module MIR-default entry, kept for the parity tests
+    // (`tests/mir_vm_parity.rs`) that exercise the MIR path without a
+    // module root. The optimize pipeline + per-fn MIR dispatch now
+    // live in `compile_program_inner` under `use_mir`, shared with the
+    // module-aware production entry points.
     compile_program_inner(
         items,
         symbols,
@@ -128,7 +125,7 @@ pub fn compile_program_with_mir_fallback(
         "",
         ModuleSource::Disk(None),
         analysis,
-        Some(&mir),
+        true,
     )
 }
 
@@ -144,8 +141,35 @@ fn compile_program_inner(
     source_file: &str,
     module_source: ModuleSource<'_>,
     analysis: Option<&crate::ir::AnalysisResult>,
-    mir_program: Option<&crate::ir::mir::MirProgram>,
+    use_mir: bool,
 ) -> Result<(CodeStore, Vec<NanValue>), CompileError> {
+    // MIR-default path. Lower the entry items to MIR and run the
+    // optimize pipeline; the per-fn loop below dispatches each fn
+    // through the MIR walker and falls back to the HIR walker for
+    // shapes outside the MIR subset. Built here — not in the caller —
+    // so every module-aware entry point shares one pipeline. Order is
+    // deliberate: (1) nullary-literal inlining unlocks call-site
+    // literals, (2) const-fold collapses literal arithmetic,
+    // (3) algebraic-simplify rewrites Int identities, (4) bool-match-
+    // to-if rewrites two-arm `Bool` matches into `IfThenElse`,
+    // (5) branch-collapse drops the dead branch of a folded
+    // `IfThenElse`, (6) DCE drops unread `let _ = <pure>` chains.
+    // Module fns are compiled by `load_modules` / `integrate_module`
+    // on the HIR walker; only the entry `items` ride MIR for now
+    // (the per-fn coverage counter surfaces the gap).
+    let mir_built = if use_mir {
+        Some(crate::ir::mir::dead_code(crate::ir::mir::branch_collapse(
+            crate::ir::mir::bool_match_to_if(crate::ir::mir::algebraic_simplify(
+                crate::ir::mir::const_fold(crate::ir::mir::inline_nullary_literals(
+                    crate::ir::mir::lower_program(items),
+                )),
+            )),
+        )))
+    } else {
+        None
+    };
+    let mir_program = mir_built.as_ref();
+
     let mut compiler = ProgramCompiler::new();
     compiler.source_file = source_file.to_string();
     compiler.sync_record_field_symbols(arena)?;
@@ -772,7 +796,13 @@ impl ProgramCompiler {
         mir_program: &crate::ir::mir::MirProgram,
     ) -> Result<FnChunk, mir::MirVmUnsupported> {
         let resolution = rfd.resolution.as_ref();
-        let local_count = resolution.map_or(rfd.params.len() as u16, |r| r.local_count);
+        // The MIR body may mint synthetic slots past the resolver's
+        // `local_count` (opaque-let temps for effectful intermediates),
+        // so trust the MIR fn's own count — the resolver's is a lower
+        // bound and underruns the frame on `STORE_LOCAL` to a temp.
+        let local_count = mir_fn.local_count.max(
+            resolution.map_or(rfd.params.len() as u32, |r| u32::from(r.local_count)),
+        ) as u16;
         let local_slots: HashMap<String, u16> = resolution
             .map(|r| r.local_slots.as_ref().clone())
             .unwrap_or_else(|| {

--- a/tests/mir_phase2_model_spec.rs
+++ b/tests/mir_phase2_model_spec.rs
@@ -183,6 +183,7 @@ fn build_a_tiny_function_by_hand() {
             name: "Console.print".to_string(),
         }],
         body,
+        local_count: 1,
     };
     let mut program = MirProgram::empty();
     program.fns.insert(f.fn_id, f);

--- a/tests/mir_phase2b_dump_spec.rs
+++ b/tests/mir_phase2b_dump_spec.rs
@@ -56,6 +56,7 @@ fn one_fn_dump_pins_skeleton() {
             return_type: "Int".to_string(),
             effects: vec![],
             body,
+            local_count: 0,
         },
     );
 
@@ -102,6 +103,7 @@ fn try_bind_via_let_composition_dump_shape() {
             return_type: "Result<Int, String>".to_string(),
             effects: vec![],
             body,
+            local_count: 0,
         },
     );
     let dump = format!("{program}");
@@ -157,6 +159,7 @@ fn match_dump_shape() {
             return_type: "Int".to_string(),
             effects: vec![],
             body,
+            local_count: 0,
         },
     );
     let dump = format!("{program}");
@@ -201,6 +204,7 @@ fn ctor_pattern_dump_uses_ctor_id() {
             return_type: "Int".to_string(),
             effects: vec![],
             body,
+            local_count: 0,
         },
     );
     let dump = format!("{program}");
@@ -230,6 +234,7 @@ fn effects_render_on_fn_header() {
                 },
             ],
             body,
+            local_count: 0,
         },
     );
     let dump = format!("{program}");
@@ -255,6 +260,7 @@ fn fns_render_in_fn_id_order() {
                 return_type: "Int".to_string(),
                 effects: vec![],
                 body: span(MirExpr::Literal(span(Literal::Int(raw as i64)))),
+                local_count: 0,
             },
         );
     }
@@ -287,6 +293,7 @@ fn let_dump_shape() {
             return_type: "Int".to_string(),
             effects: vec![],
             body,
+            local_count: 0,
         },
     );
     let dump = format!("{program}");


### PR DESCRIPTION
## Summary

Production VM compilation now takes the **MIR path by default**. The optimize pipeline + per-fn MIR-walker dispatch (HIR fallback for shapes outside the MIR subset) moves from the standalone `compile_program_with_mir_fallback` into `compile_program_inner` under a `use_mir` flag, shared by every module-aware entry point. `aver run`, `aver compile --target vm`, `aver bench`, the REPL, replay, verify, and the profiler all route through those — so they're on MIR now. Bare `compile_program` stays HIR-only as the differential reference the parity suite compiles against.

**No `--legacy-hir-walker` escape hatch** — MIR is *the* path; HIR survives only as the per-fn fallback for unlowered shapes. A coverage counter to drive that fallback toward zero is a fast-follow.

## Two correctness bugs the wireup surfaced (both fixed here)

1. **Multi-module crash.** The old single-module MIR entry used `ModuleSource::Disk(None)`, so a cross-module call (`Fractal.fullView`) failed to resolve. Threading the real module source through the shared inner loads deps before the entry fns compile. `fractal_seahorse` (multi-module) now runs on the MIR path.

2. **Synthetic-local frame underrun.** MIR stmt-chain lowering mints synthetic slots past the resolver's `local_count` for opaque-let temps (effectful intermediates). `compile_fn_via_mir` reserved only the resolver's count, so a `STORE_LOCAL` into a synthetic slot ran off the frame and panicked (`stack[bp + slot]` OOB) for effect-bearing fns. `MirFn` now carries its own `local_count`; the walker reserves that. (Caught two `eval_spec` effect tests once they hit the MIR path.)

## Measured (MIR path vs HIR path, release, macOS)

Wins preserved: match_dispatch +1%, newtype/record −1..−5%, string_interp +0%. Modest per-call overhead on loop-heavy: vector_ops +25%, map_build +13% (both already at the alias soundness floor).

## Test plan
- [x] Full `cargo test` green
- [x] `mir_vm_parity` 46/46
- [x] previously-failing `eval_spec` effect tests pass
- [x] `fractal_seahorse` multi-module runs on the MIR path

> Stacked on #321 (needs the `CALL_KNOWN_OWNED` handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)