### PR TITLE
vm/mir: bring owned-op emission to HIR parity (#252 Phase 6)

### DIFF
--- a/src/vm/compiler/calls.rs
+++ b/src/vm/compiler/calls.rs
@@ -705,7 +705,7 @@ impl<'a> FnCompiler<'a> {
         mask
     }
 
-    fn nan_literal(&mut self, lit: &Literal) -> NanValue {
+    pub(super) fn nan_literal(&mut self, lit: &Literal) -> NanValue {
         match lit {
             Literal::Int(i) => NanValue::new_int(*i, self.arena),
             Literal::Float(f) => NanValue::new_float(*f),

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -174,6 +174,18 @@ pub(super) fn compile_mir_expr(
                     let name = fc.mir_program.map(|p| p.builtin_name(*id)).unwrap_or("");
                     let builtin =
                         lookup_vm_builtin(name).ok_or(MirVmUnsupported::UnsupportedCallee)?;
+                    // Compound leaf-op recognition — parity with the HIR
+                    // walker's fused VECTOR_GET_OR / VECTOR_SET_OR_KEEP.
+                    // Without it `Option.withDefault(Vector.set(v, i, x), v)`
+                    // emits a generic VECTOR_SET + UNWRAP_OR pair that
+                    // allocates the intermediate `Option<Vector>` and skips
+                    // the in-place mutate / OOB-keep fast path (~+25% on the
+                    // vector_ops accumulator loop once MIR became the default).
+                    if builtin == VmBuiltin::OptionWithDefault
+                        && try_emit_vector_compound(fc, args)?
+                    {
+                        return Ok(());
+                    }
                     for arg in args {
                         compile_mir_expr(fc, arg)?;
                     }
@@ -1258,6 +1270,88 @@ where
     let outer_fail = fc.emit_jump(JUMP);
     fc.patch_jump(success_skip);
     Ok(vec![outer_fail])
+}
+
+/// Extract `(slot, last_use)` if `expr` is a bare local read.
+fn mir_local_slot_last_use(expr: &MirExpr) -> Option<(u32, bool)> {
+    match expr {
+        MirExpr::Local(l) => Some((l.node.slot.0, l.node.last_use)),
+        _ => None,
+    }
+}
+
+/// Recognize the two fused vector compound shapes the HIR walker emits
+/// as single opcodes, and emit the same opcode from MIR so the
+/// VM-default path keeps the in-place / no-`Option`-alloc fast path:
+///
+/// - `Option.withDefault(Vector.set(v, i, x), v)` (same `v`) →
+///   `VECTOR_SET_OR_KEEP`. `owned` mirrors the HIR rule: last use of the
+///   inner vector slot AND the slot is not alias-prone.
+/// - `Option.withDefault(Vector.get(v, i), <literal>)` → `VECTOR_GET_OR`
+///   with the literal default inlined as a constant.
+///
+/// Returns `Ok(true)` when it emitted a fused op; `Ok(false)` leaves the
+/// generic `UNWRAP_OR` path to the caller.
+fn try_emit_vector_compound(
+    fc: &mut FnCompiler<'_>,
+    args: &[Spanned<MirExpr>],
+) -> Result<bool, MirVmUnsupported> {
+    if args.len() != 2 {
+        return Ok(false);
+    }
+    let MirExpr::Call(inner_call) = &args[0].node else {
+        return Ok(false);
+    };
+    let MirCall {
+        callee: MirCallee::Builtin(inner_id),
+        args: inner_args,
+    } = &inner_call.node
+    else {
+        return Ok(false);
+    };
+    let inner_name = fc
+        .mir_program
+        .map(|p| p.builtin_name(*inner_id))
+        .unwrap_or("");
+    match lookup_vm_builtin(inner_name) {
+        Some(VmBuiltin::VectorSet) if inner_args.len() == 3 => {
+            // The default must be the same vector the set targets —
+            // compared by slot, since the two reads carry different
+            // last-use bits and a structural compare would miss it.
+            let vec = mir_local_slot_last_use(&inner_args[0].node);
+            let def = mir_local_slot_last_use(&args[1].node);
+            let (Some((vec_slot, _)), Some((def_slot, _))) = (vec, def) else {
+                return Ok(false);
+            };
+            if vec_slot != def_slot {
+                return Ok(false);
+            }
+            // Mirror the HIR walker: `owned` keys off the INNER vector
+            // occurrence's last-use flag and the slot's alias status.
+            let owned = vec
+                .map(|(slot, last_use)| last_use && !fc.is_aliased_slot(slot as u16))
+                .unwrap_or(false);
+            compile_mir_expr(fc, &inner_args[0])?;
+            compile_mir_expr(fc, &inner_args[1])?;
+            compile_mir_expr(fc, &inner_args[2])?;
+            fc.emit_op(VECTOR_SET_OR_KEEP);
+            fc.emit_u8(u8::from(owned));
+            Ok(true)
+        }
+        Some(VmBuiltin::VectorGet) if inner_args.len() == 2 => {
+            let MirExpr::Literal(lit) = &args[1].node else {
+                return Ok(false);
+            };
+            compile_mir_expr(fc, &inner_args[0])?;
+            compile_mir_expr(fc, &inner_args[1])?;
+            let default_value = fc.nan_literal(&lit.node);
+            let const_idx = fc.add_constant(default_value);
+            fc.emit_op(VECTOR_GET_OR);
+            fc.emit_u16(const_idx);
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
 }
 
 /// Phase 6 wave 4 — derive `owned_mask` for a call's args.

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -1359,14 +1359,18 @@ fn try_emit_vector_compound(
 /// read of slot `i`. Mirrors HIR's `compute_builtin_owned_mask`
 /// / tail-call mask derivation. Caps at 8 args (mask is u8).
 ///
-/// The alias-prone slot guard HIR applies (skipping bits when
-/// the slot is aliased by another binding) isn't ported here
-/// yet — MIR doesn't carry the alias annotation from
-/// `FnResolution`. We emit conservatively when in doubt.
-fn compute_owned_mask(args: &[Spanned<MirExpr>], _fc: &FnCompiler<'_>) -> u8 {
+/// The alias-prone slot guard mirrors HIR's `compute_builtin_owned_mask`:
+/// a bit is dropped when its slot is flagged on `FnResolution.aliased_slots`
+/// (propagated onto `fc` via `set_aliased_slots`). The guard is load-bearing
+/// — the owned builtin path empties the arena slot in place
+/// (`take_map_value` / vector take), so marking an aliased `Vector`/`Map`
+/// param owned would mutate a binding the caller still holds. Without it the
+/// MIR walker diverged from HIR, emitting `owned = 1` on a slot it knew was
+/// aliased.
+fn compute_owned_mask(args: &[Spanned<MirExpr>], fc: &FnCompiler<'_>) -> u8 {
     let mut mask = 0u8;
     for (i, arg) in args.iter().enumerate().take(8) {
-        if contains_last_use_slot_mir(&arg.node, i as u32) {
+        if contains_last_use_slot_mir(&arg.node, i as u32) && !fc.is_aliased_slot(i as u16) {
             mask |= 1 << i;
         }
     }

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -127,6 +127,24 @@ fn recursive_owned_call_parity() {
     assert_eq!(hir, Value::Int(55), "fib(10) = 55");
 }
 
+#[test]
+fn vector_compound_leaf_op_parity() {
+    // `Option.withDefault(Vector.set(v, i, x), v)` and
+    // `Option.withDefault(Vector.get(v, i), <lit>)` are the fused
+    // compound shapes the HIR walker emits as single VECTOR_SET_OR_KEEP /
+    // VECTOR_GET_OR opcodes. The MIR walker recognizes the same shapes
+    // (rather than the generic VECTOR_SET/GET + UNWRAP_OR pair); this
+    // pins behavioral parity for both.
+    let src = "fn build(n: Int) -> Int\n    v = Vector.new(3, 0)\n    w = Option.withDefault(Vector.set(v, 0, n), v)\n    Option.withDefault(Vector.get(w, 0), 0)\n";
+    let hir = run_via_path(src, "build", &[7], Path::Hir);
+    let mir = run_via_path(src, "build", &[7], Path::MirFallback);
+    assert_eq!(
+        hir, mir,
+        "HIR and MIR paths must agree on the vector compound shapes: HIR={hir:?}, MIR={mir:?}"
+    );
+    assert_eq!(hir, Value::Int(7), "set slot 0 to 7, read it back");
+}
+
 /// Compile both paths and return the per-fn bytecode pair so
 /// tests can byte-compare specific chunks.
 fn compile_both(src: &str) -> (aver::vm::CodeStore, aver::vm::CodeStore) {


### PR DESCRIPTION
## Summary

Two related fixes that bring the MIR-VM walker's owned-op emission to parity with the (proven-correct) HIR walker, now that MIR is the default VM path. Both are about not diverging from HIR on the in-place-mutation fast path.

### 1. Fused vector compound leaf-ops (perf)

The MIR walker emitted the generic `Vector.set`/`Vector.get` + `UNWRAP_OR` pair for `Option.withDefault(Vector.set(v, i, x), v)` and `Option.withDefault(Vector.get(v, i), <lit>)`, allocating the intermediate `Option<Vector>` and skipping the in-place mutate / OOB-keep fast path. The HIR walker fuses these into `VECTOR_SET_OR_KEEP` / `VECTOR_GET_OR`.

Once MIR became the default this was a **live regression**: `vector_ops` ran **~+25% slower** than HIR (17.3ms vs 13.8ms, macOS release). Porting the recognition closes it — `vector_ops` back to **13.0ms**. Guarded by `vector_compound_leaf_op_parity`.

### 2. Alias guard on the owned-arg mask (soundness)

`compute_owned_mask` set an owned bit from a last-use slot read alone, omitting the alias-prone guard HIR's `compute_builtin_owned_mask` applies. Instrumentation confirmed the divergence: on `Map.set(m, …)` with `m` a `Map` parameter, MIR emitted `owned = 1` for a slot it had flagged aliased.

That is unsound — the owned builtin path empties the arena slot in place (`take_map_value` → `mem::replace(slot, Map::new())`), so an aliased `Vector`/`Map` param the caller still holds would be mutated through that other binding (the corruption the 0.17.1 alias-aware fix prevents on HIR). The MIR walker now carries the alias annotation via `set_aliased_slots`, so it applies the same guard. Strictly conservative: it only ever *suppresses* owned, falling back to the always-sound clone path.

## Test plan
- [x] `vector_compound_leaf_op_parity` added; full MIR-VM parity suite 47 pass
- [x] full `cargo test` green
- [x] measured: `vector_ops` 17.3ms → 13.0ms on the production MIR path

🤖 Generated with [Claude Code](https://claude.com/claude-code)