### PR TITLE
vm: stop MIR emitting CALL_KNOWN_OWNED — fixes leaf-classifier VM crash (#252 Phase 6)

### DIFF
--- a/src/vm/compiler/classify.rs
+++ b/src/vm/compiler/classify.rs
@@ -200,7 +200,13 @@ fn parent_thin_calls_are_safe(
         let op = bytes[ip];
         ip += 1;
         match op {
-            CALL_KNOWN => {
+            // CALL_KNOWN_OWNED carries the same leading `fn_id:u16` as
+            // CALL_KNOWN (only a trailing owned byte differs, absorbed by
+            // `opcode_operand_width`), so the same self-recursion /
+            // effectful-target safety check applies. It isn't emitted
+            // today, but stays guarded so a future emitter can't bypass
+            // this gate.
+            CALL_KNOWN | CALL_KNOWN_OWNED => {
                 if ip + 3 > bytes.len() {
                     return Err(CompileError {
                         msg: format!("truncated bytecode in {}", chunk.name),
@@ -230,7 +236,14 @@ fn classify_leaf_chunk(chunk: &FnChunk) -> Result<bool, CompileError> {
         let op = code[ip];
         ip += 1;
         match op {
-            CALL_KNOWN | CALL_VALUE | TAIL_CALL_SELF | TAIL_CALL_KNOWN | TAIL_CALL_SELF_THIN => {
+            CALL_KNOWN | CALL_KNOWN_OWNED | CALL_VALUE | TAIL_CALL_SELF | TAIL_CALL_KNOWN
+            | TAIL_CALL_SELF_THIN => {
+                // CALL_KNOWN_OWNED counts as a call: a chunk that makes
+                // one is NOT a leaf. The MIR walker no longer emits it
+                // (it emits plain CALL_KNOWN), but it stays a live opcode
+                // with an execute handler, so a future emitter must not be
+                // able to slip a non-leaf fn past this gate and have a
+                // caller's CALL_KNOWN upgraded to the frameless CALL_LEAF.
                 return Ok(false);
             }
             _ => {}
@@ -322,4 +335,49 @@ pub fn find_opcode_positions(chunk: &FnChunk, target_op: u8) -> Vec<usize> {
         ip += opcode_operand_width(op, code, ip);
     }
     positions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chunk_with_code(code: Vec<u8>) -> FnChunk {
+        FnChunk {
+            name: "t".to_string(),
+            arity: 1,
+            local_count: 1,
+            code,
+            constants: vec![],
+            effects: vec![],
+            thin: false,
+            parent_thin: false,
+            leaf: false,
+            no_alloc: false,
+            source_file: String::new(),
+            line_table: vec![],
+        }
+    }
+
+    #[test]
+    fn call_known_owned_chunk_is_not_a_leaf() {
+        // A chunk that calls out via CALL_KNOWN_OWNED makes a call, so it
+        // must not be classified as a leaf — otherwise a caller's
+        // CALL_KNOWN to it gets upgraded to the frameless CALL_LEAF and
+        // the non-leaf fn is invoked without a CallFrame. (CALL_KNOWN_OWNED
+        // is fn_id:u16, argc:u8, owned:u8.)
+        let owned = chunk_with_code(vec![CALL_KNOWN_OWNED, 0x00, 0x02, 0x01, 0x00, RETURN]);
+        assert!(
+            !classify_leaf_chunk(&owned).unwrap(),
+            "CALL_KNOWN_OWNED must disqualify a chunk from leaf status"
+        );
+
+        // Sanity: the same chunk shape with plain CALL_KNOWN is likewise
+        // non-leaf (the established behavior this mirrors).
+        let plain = chunk_with_code(vec![CALL_KNOWN, 0x00, 0x02, 0x01, RETURN]);
+        assert!(!classify_leaf_chunk(&plain).unwrap());
+
+        // And a builtin-only chunk stays a leaf.
+        let leaf = chunk_with_code(vec![LIST_LEN, RETURN]);
+        assert!(classify_leaf_chunk(&leaf).unwrap());
+    }
 }

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -150,24 +150,27 @@ pub(super) fn compile_mir_expr(
                             ),
                         })
                     })?;
-                    // Phase 6 wave 4 — derive owned_mask from
-                    // args' last-use flags. Each bit `i` set
-                    // means arg `i` was a `MirLocal { last_use:
-                    // true }` AND its slot maps positionally to
-                    // parameter `i`. The HIR walker constrains
-                    // this to `slot == i`; we apply the same
-                    // rule.
-                    let owned_mask = compute_owned_mask(args, fc);
-                    if owned_mask != 0 {
-                        fc.emit_op(CALL_KNOWN_OWNED);
-                        fc.emit_u16(vm_fn_id as u16);
-                        fc.emit_u8(args.len() as u8);
-                        fc.emit_u8(owned_mask);
-                    } else {
-                        fc.emit_op(CALL_KNOWN);
-                        fc.emit_u16(vm_fn_id as u16);
-                        fc.emit_u8(args.len() as u8);
-                    }
+                    // Always plain CALL_KNOWN, matching the HIR walker
+                    // exactly. The owned mask is inert for a known
+                    // user-fn call at the call boundary (the callee
+                    // derives its parameter ownership from its own alias
+                    // analysis, and the runtime reads the trailing owned
+                    // byte but ignores it), so emitting CALL_KNOWN_OWNED
+                    // bought nothing — and it desynced the leaf /
+                    // parent-thin classifier, which only recognizes
+                    // CALL_KNOWN as a call. A fn calling out via
+                    // CALL_KNOWN_OWNED was wrongly flagged `leaf=true`,
+                    // its callers' plain CALL_KNOWN got upgraded to the
+                    // frameless CALL_LEAF, and the non-leaf fn was then
+                    // invoked without a CallFrame → VM out-of-bounds
+                    // crash on the shipped default path. A future
+                    // cross-call ownership pass that re-enables the owned
+                    // variant must also teach the classifier about it
+                    // (CALL_KNOWN_OWNED is recognized there now as
+                    // defense, but no longer emitted here).
+                    fc.emit_op(CALL_KNOWN);
+                    fc.emit_u16(vm_fn_id as u16);
+                    fc.emit_u8(args.len() as u8);
                     Ok(())
                 }
                 MirCallee::Builtin(id) => {

--- a/tests/mir_call_known_owned_regression.rs
+++ b/tests/mir_call_known_owned_regression.rs
@@ -1,0 +1,88 @@
+//! Regression: `CALL_KNOWN_OWNED` must not desync the leaf classifier.
+//!
+//! The MIR walker used to emit `CALL_KNOWN_OWNED` for a known-fn call
+//! whose argument carried a last-use slot read (`compute_owned_mask`
+//! non-zero). The leaf / parent-thin classifier only recognized
+//! `CALL_KNOWN` as a call, so a fn that called out via
+//! `CALL_KNOWN_OWNED` was wrongly flagged `leaf = true`; a caller's
+//! plain `CALL_KNOWN` to it was then upgraded to the frameless
+//! `CALL_LEAF`, and invoking the non-leaf fn without a `CallFrame`
+//! corrupted control flow into a VM out-of-bounds panic.
+//!
+//! This shells `aver run` so the program executes through the FULL
+//! production pipeline (including `last_use`, which the in-process
+//! `mir_vm_parity` harness skips — the reason this class of divergence
+//! stayed invisible) on the MIR-default VM path. `aver run` actually
+//! executes `main` through the VM dispatch (the `verify` executor takes
+//! a different path that does not reproduce the frameless-leaf crash),
+//! so the panic surfaces as a non-zero exit.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn tempfile(prefix: &str, suffix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!("{prefix}-{nanos}{suffix}"))
+}
+
+/// A chain of single-call functions. `pair(a, b) -> bump(b)` reads `b`
+/// (slot 1) as argument 0, so `compute_owned_mask`'s positional
+/// `slot == index` rule leaves the call as a plain `CALL_KNOWN`
+/// (upgradeable). `bump(x) -> bump2(x)` reads `x` (slot 0) as argument 0
+/// — slot == index — so the pre-fix walker emitted `CALL_KNOWN_OWNED`,
+/// the shape that mis-flagged `bump`/`bump2` as leaves. The `verify`
+/// block forces compilation + execution on the VM (MIR-default) path.
+const REPRO: &str = r#"module L
+    intent = "CALL_KNOWN_OWNED leaf-misclassification regression"
+    depends []
+
+fn deep(y: Int) -> Int
+    y
+
+fn bump2(x: Int) -> Int
+    deep(x)
+
+fn bump(x: Int) -> Int
+    bump2(x)
+
+fn pair(a: Int, b: Int) -> Int
+    bump(b)
+
+fn topB(n: Int) -> Int
+    pair(n, n)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(topB(5)))
+"#;
+
+#[test]
+fn call_known_owned_chain_does_not_crash_the_vm() {
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let path = tempfile("call-known-owned", ".av");
+    fs::write(&path, REPRO).expect("write tempfile");
+    let output = Command::new(aver_bin)
+        .arg("run")
+        .arg(&path)
+        .output()
+        .expect("invoke aver");
+    fs::remove_file(&path).ok();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "aver run crashed (the leaf-classifier desync regression — VM out-of-bounds panic): \
+         status={:?}\nstdout={stdout}\nstderr={stderr}",
+        output.status.code()
+    );
+    // topB(5) = pair(5,5) = bump(5) = bump2(5) = deep(5) = 5
+    assert!(
+        stdout.contains('5'),
+        "expected topB(5) = 5 on stdout, got: {stdout:?} (stderr={stderr:?})"
+    );
+}

--- a/tests/mir_vm_parity.rs
+++ b/tests/mir_vm_parity.rs
@@ -109,14 +109,15 @@ fn neg_parity() {
 }
 
 #[test]
-fn recursive_owned_call_parity() {
-    // fib's recursive arms are non-tail `CALL_KNOWN`s whose argument
-    // (`n - 1` / `n - 2`) carries the last use of param `n`, so the MIR
-    // walker's `compute_owned_mask` is non-zero and it emits the
-    // `CALL_KNOWN_OWNED` opcode. That opcode previously had no handler
-    // in the execute dispatch, so this exact shape trapped with
-    // `unknown opcode: 0x47` on the MIR-fallback path while the HIR
-    // path (plain `CALL_KNOWN`) was fine. Guards the handler.
+fn recursive_non_tail_call_parity() {
+    // fib's recursive arms are non-tail known calls. Both walkers emit
+    // plain `CALL_KNOWN` for them (the MIR walker no longer emits the
+    // owned `CALL_KNOWN_OWNED` variant for user-fn calls — it desynced
+    // the leaf classifier; see tests/mir_call_known_owned_regression.rs).
+    // NOTE: this in-process harness runs tco + resolve but NOT the
+    // pipeline `last_use` pass, so owned masks are 0 here regardless —
+    // owned-emission divergences are exercised by the full-pipeline
+    // integration regression, not this harness.
     let src = "fn fib(n: Int) -> Int\n    match n < 2\n        true -> n\n        false -> fib(n - 1) + fib(n - 2)\n";
     let hir = run_via_path(src, "fib", &[10], Path::Hir);
     let mir = run_via_path(src, "fib", &[10], Path::MirFallback);


### PR DESCRIPTION
## A trivial program crashes the VM on the MIR-default path

```aver
fn deep(y: Int) -> Int
    y
fn bump2(x: Int) -> Int
    deep(x)
fn bump(x: Int) -> Int
    bump2(x)
fn pair(a: Int, b: Int) -> Int
    bump(b)
fn topB(n: Int) -> Int
    pair(n, n)
```

`aver run` (release, current `main`) panics: `index out of bounds: the len is 7 but the index is 7` in the execute dispatch. The HIR walker runs it correctly. **Found by an exhaustive HIR-vs-MIR emission parity audit** — the manual review of the MIR-default wireup (#323) missed it.

## The bug chain

1. The MIR walker emitted **`CALL_KNOWN_OWNED`** for a known user-fn call whose arg carried a last-use slot read (`compute_owned_mask != 0`). HIR **never** emits it for user fns — always plain `CALL_KNOWN`. The runtime treats the owned byte as inert, so on its own this was byte-divergent-but-behavior-equal.
2. The leaf / parent-thin classifier (`classify_leaf_chunk`, `parent_thin_calls_are_safe`) only recognized `CALL_KNOWN` as a call, so a fn that called out via `CALL_KNOWN_OWNED` was wrongly flagged **`leaf = true`**.
3. The `CALL_KNOWN → CALL_LEAF` post-pass then upgraded a caller's plain `CALL_KNOWN` to the mis-flagged "leaf" target. `CALL_LEAF` is **frameless** (no `CallFrame`), so invoking the actually-non-leaf fn corrupted control flow → out-of-bounds panic.

## Fix

The MIR walker emits plain `CALL_KNOWN` for `MirCallee::Fn`, matching HIR exactly. The owned mask for a known user-fn call is inert at the call boundary, so emitting `CALL_KNOWN_OWNED` bought nothing and only created the classifier hazard.

**Defense in depth:** `classify_leaf_chunk` / `parent_thin_calls_are_safe` now recognize `CALL_KNOWN_OWNED` as a call (it stays a live opcode with an execute handler), so a future cross-call-ownership emitter can't re-introduce the hazard silently. The `CALL_KNOWN → CALL_LEAF` upgrade is intentionally **not** extended to it (width mismatch: 3 vs 4 bytes).

## Tests
- `tests/mir_call_known_owned_regression.rs` — shells `aver run` on the repro through the **full** pipeline (incl. `last_use`). **Verified it FAILS with the fix reverted.** The in-process `mir_vm_parity` harness skips `last_use` — exactly why this stayed invisible (noted on the renamed `recursive_non_tail_call_parity` test).
- `classify.rs` unit test: a `CALL_KNOWN_OWNED` chunk is not a leaf.
- full `cargo test` green; fmt clean.

> Supersedes the substrate framing from #321: `CALL_KNOWN_OWNED` is no longer emitted, but kept (opcode + execute handler + classifier recognition) as sound dormant substrate for a future cross-call ownership pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)