### PR TITLE
ir/mir: lower buffer-build intrinsics — MIR coverage 86.6% → 96.4% (#252 Phase 6)

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -260,8 +260,10 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                 }
                 // Builtin / closure / unresolved callees ride the
                 // HIR walker's classification (`CallPlan`) — too
-                // many shapes to mirror in wave 2.
-                MirCallee::Builtin(_) => None,
+                // many shapes to mirror in wave 2. Buffer intrinsics
+                // likewise fall back (the Rust backend deforests
+                // differently).
+                MirCallee::Builtin(_) | MirCallee::Intrinsic(_) => None,
             }
         }
         MirExpr::Return(inner) => Some(format!("return {}", emit_mir_expr(inner, emit_ctx)?)),

--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -156,6 +156,7 @@ fn write_call(f: &mut fmt::Formatter<'_>, call: &MirCall, indent: &str) -> fmt::
     match &call.callee {
         MirCallee::Fn(id) => write!(f, "FnId({}).call(", id.0)?,
         MirCallee::Builtin(id) => write!(f, "Builtin(#{}).call(", id.0)?,
+        MirCallee::Intrinsic(i) => write!(f, "Intrinsic({i:?}).call(")?,
     }
     write_args(f, &call.args, indent)?;
     write!(f, ")")

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -15,7 +15,7 @@
 //!   correlation with `ProofIR`.
 
 use crate::ast::{BinOp, Literal, Spanned};
-use crate::ir::hir::BuiltinCtor;
+use crate::ir::hir::{BuiltinCtor, BuiltinIntrinsic};
 use crate::ir::{BuiltinId, CtorId, FnId, TypeId};
 
 use super::program::LocalId;
@@ -219,6 +219,14 @@ pub enum MirCallee {
     /// resolve the canonical name through
     /// `SymbolTable::builtin_entry(id).name`.
     Builtin(BuiltinId),
+    /// Synthesis-only intrinsic — the buffer-build / stringify ops the
+    /// deforestation pass (`interp_lower`) emits for `String.join` and
+    /// interpolation chains (`__buf_new` / `__buf_append` /
+    /// `__buf_append_sep_unless_first` / `__buf_finalize` / `__to_str`).
+    /// Never user-visible; carried so the MIR walker emits the same
+    /// `BUFFER_*` / CONCAT opcodes the HIR walker does instead of
+    /// dropping the whole fn to the HIR fallback.
+    Intrinsic(BuiltinIntrinsic),
 }
 
 /// `target(args…)` in tail position — same SCC as the surrounding fn.

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -266,13 +266,17 @@ fn lower_expr(
             let mir_callee = match callee {
                 ResolvedCallee::Fn(fn_id) => MirCallee::Fn(*fn_id),
                 ResolvedCallee::Builtin(name) => MirCallee::Builtin(program.intern_builtin(name)),
-                // First-class fn values, intrinsics, and unresolved
-                // callees aren't covered yet. Wave 3+ will grow
-                // `MirCallee` (or a separate node) for the
-                // first-class-fn case once closure shapes need it.
-                ResolvedCallee::Intrinsic(_)
-                | ResolvedCallee::LocalSlot { .. }
-                | ResolvedCallee::Unresolved { .. } => return Err(SkipReason::UnsupportedCallee),
+                // Synthesis-only buffer-build / stringify intrinsics from
+                // the deforestation pass — carried through so the walker
+                // emits the BUFFER_* / CONCAT opcodes instead of dropping
+                // the fn to the HIR fallback.
+                ResolvedCallee::Intrinsic(intrinsic) => MirCallee::Intrinsic(*intrinsic),
+                // First-class fn values and unresolved callees aren't
+                // covered yet — a later wave grows `MirCallee` for the
+                // first-class-fn / closure case.
+                ResolvedCallee::LocalSlot { .. } | ResolvedCallee::Unresolved { .. } => {
+                    return Err(SkipReason::UnsupportedCallee);
+                }
             };
             let mir_args = args
                 .iter()

--- a/src/vm/compiler/calls.rs
+++ b/src/vm/compiler/calls.rs
@@ -23,7 +23,7 @@ type SpannedResolvedTriple<'a> = (
 /// empty trick instead of a dedicated opcode. The arity is checked
 /// at the callsite so a future intrinsic with a different shape
 /// can't accidentally re-use the wrong opcode.
-fn buffer_intrinsic_opcode(intrinsic: BuiltinIntrinsic) -> Option<(u8, usize)> {
+pub(super) fn buffer_intrinsic_opcode(intrinsic: BuiltinIntrinsic) -> Option<(u8, usize)> {
     match intrinsic {
         BuiltinIntrinsic::BufNew => Some((BUFFER_NEW, 1)),
         BuiltinIntrinsic::BufAppend => Some((BUFFER_APPEND_STR, 2)),

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -45,6 +45,7 @@ use crate::vm::builtin::VmBuiltin;
 use crate::vm::opcode::*;
 
 use super::VmSymbolTable;
+use super::calls::buffer_intrinsic_opcode;
 
 use super::{CompileError, FnCompiler};
 
@@ -237,6 +238,50 @@ pub(super) fn compile_mir_expr(
                                 fc.emit_u32(symbol_id);
                                 fc.emit_u8(args.len() as u8);
                             }
+                        }
+                    }
+                    Ok(())
+                }
+                MirCallee::Intrinsic(intrinsic) => {
+                    // Mirror of the HIR walker's `compile_intrinsic_call`:
+                    // the deforestation pass's buffer-build ops map to
+                    // dedicated BUFFER_* opcodes; `__to_str` lowers to the
+                    // CONCAT-against-empty stringify trick.
+                    match buffer_intrinsic_opcode(*intrinsic) {
+                        Some((opcode, arity)) => {
+                            if args.len() != arity {
+                                return Err(MirVmUnsupported::InnerError(CompileError {
+                                    msg: format!(
+                                        "intrinsic {} expects {arity} arg(s), got {}",
+                                        intrinsic.name(),
+                                        args.len()
+                                    ),
+                                }));
+                            }
+                            for arg in args {
+                                compile_mir_expr(fc, arg)?;
+                            }
+                            fc.emit_op(opcode);
+                        }
+                        None => {
+                            // `__to_str(x)`: CONCAT against an empty string
+                            // — CONCAT calls `NanValue::repr` on both sides,
+                            // so any value lowers to its display string.
+                            if args.len() != 1 {
+                                return Err(MirVmUnsupported::InnerError(CompileError {
+                                    msg: format!(
+                                        "intrinsic {} expects 1 arg, got {}",
+                                        intrinsic.name(),
+                                        args.len()
+                                    ),
+                                }));
+                            }
+                            compile_mir_expr(fc, &args[0])?;
+                            let empty = fc.nan_literal(&Literal::Str(String::new()));
+                            let idx = fc.add_constant(empty);
+                            fc.emit_op(LOAD_CONST);
+                            fc.emit_u16(idx);
+                            fc.emit_op(CONCAT);
                         }
                     }
                     Ok(())
@@ -667,6 +712,12 @@ pub(super) fn compile_mir_expr(
                         fc.emit_op(LOAD_CONST);
                         fc.emit_u16(idx);
                     }
+                    // A synthesis intrinsic can't appear as an
+                    // independent-product branch callee (intrinsics are
+                    // never first-class values); fall back conservatively.
+                    MirCallee::Intrinsic(_) => {
+                        return Err(MirVmUnsupported::UnsupportedCallee);
+                    }
                 }
                 for arg in &call.args {
                     compile_mir_expr(fc, arg)?;
@@ -742,6 +793,9 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
                 // worst costs one rejected compilation attempt
                 // rather than silently mis-emitting.
                 MirCallee::Builtin(_) => true,
+                // Buffer-build / stringify intrinsics emit dedicated
+                // BUFFER_* / CONCAT opcodes — always compilable.
+                MirCallee::Intrinsic(_) => true,
             };
             callee_ok && c.node.args.iter().all(can_compile)
         }

--- a/tests/hir_mir_differential.rs
+++ b/tests/hir_mir_differential.rs
@@ -202,6 +202,22 @@ fn newtype_specialization() {
 }
 
 #[test]
+fn string_interpolation_buffer_intrinsics() {
+    // Interpolation chains lower (via `interp_lower` deforestation) to
+    // the synthesized buffer intrinsics (`__buf_new` / `__buf_append` /
+    // `__buf_finalize` / `__to_str`). The MIR walker emits the same
+    // BUFFER_* / CONCAT opcodes the HIR walker does; this pins parity on
+    // that path.
+    let src = prog(
+        "fn build(n: Int, acc: String) -> String\n    \
+         match n\n        0 -> acc\n        \
+         _ -> build(n - 1, \"{acc}-{String.fromInt(n)}\")\n\n\
+         fn run() -> String\n    build(6, \"start\")\n",
+    );
+    assert_parity("string_interp", &src, "run");
+}
+
+#[test]
 fn bench_scenario_corpus_parity() {
     // Drive the real single-module bench programs (`depends []`, entry
     // `main`) through both walkers. These exercise the production shapes


### PR DESCRIPTION
## Summary

The dominant MIR-lowering blocker was **not** higher-order functions, as the `unsupported callee` bucket name suggested. Measured on the games + JSON corpus, **all 33 cases were `Intrinsic(BufFinalize)`** — the synthesized buffer-build / stringify ops the deforestation pass (`interp_lower`) emits for `String.join` and interpolation chains (`__buf_new` / `__buf_append` / `__buf_append_sep_unless_first` / `__buf_finalize` / `__to_str`). The lowerer dropped the whole fn to the HIR fallback on the first one.

Carry them through: add `MirCallee::Intrinsic(BuiltinIntrinsic)`, lower `ResolvedCallee::Intrinsic`, and emit the same `BUFFER_*` / CONCAT opcodes the HIR walker does (`buffer_intrinsic_opcode` is now shared; `__to_str` lowers to the CONCAT-against-empty stringify trick).

## Measured

Aggregate MIR coverage on the games + JSON corpus (336 fns): **86.6% → 96.4%** (324/336). The only remaining blocker is the `unresolved Ident` (nullary-ctor-in-value-position) bucket.

## Test plan
- [x] New `string_interpolation_buffer_intrinsics` in the full-pipeline differential harness (HIR vs MIR), plus the existing `string_interp` bench scenario — identical on both paths
- [x] `aver compile --explain-mir-coverage` confirms the jump
- [x] full `cargo test` green; fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)