### PR TITLE
ir/hir: lower nullary ctors in value position — MIR coverage → 100% (#252 Phase 6)

### DIFF
--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -943,15 +943,26 @@ fn emit_type_constructor_call(
         })
         .collect();
 
+    // A nullary variant is generated as a Rust *unit* variant
+    // (`enum E { Point }`), so it's referenced as `E::Point` with no
+    // parens — `E::Point()` is `error[E0618]: expected function, found
+    // enum variant`. (Reached now that nullary ctors in value position
+    // resolve to the zero-arg `Ctor` shape rather than an `Attr`.)
     if let Some((prefix, bare_type_name)) = resolve_module_call(qualified_type_name, ctx) {
         let module_path = module_prefix_to_rust_path(prefix);
-        format!(
-            "{}::{}::{}({})",
-            module_path,
-            bare_type_name,
-            variant_name,
-            arg_strs.join(", ")
-        )
+        if arg_strs.is_empty() {
+            format!("{}::{}::{}", module_path, bare_type_name, variant_name)
+        } else {
+            format!(
+                "{}::{}::{}({})",
+                module_path,
+                bare_type_name,
+                variant_name,
+                arg_strs.join(", ")
+            )
+        }
+    } else if arg_strs.is_empty() {
+        format!("{}::{}", qualified_type_name, variant_name)
     } else {
         format!(
             "{}::{}({})",

--- a/src/ir/hir/resolve.rs
+++ b/src/ir/hir/resolve.rs
@@ -300,6 +300,27 @@ fn resolve_expr(ctx: &ResolveCtx<'_>, expr: &Spanned<Expr>) -> ResolvedExpr {
             last_use: *last_use,
         },
         Expr::Attr(obj, field) => {
+            // Nullary constructor in value position — `Option.None`,
+            // `Color.Black`, etc. These only got recognized in call
+            // position (`Expr::FnCall`); in value position they arrived
+            // here as a bare `Attr(Ident(Type), Variant)` and stalled MIR
+            // lowering with `UnresolvedIdent`. A non-nullary ctor can't
+            // appear un-applied as a value (Aver has no first-class
+            // partial constructors), so an `Attr` whose `Type.Member`
+            // resolves to a ctor is necessarily a nullary reference —
+            // lower it to the zero-arg `Ctor` shape both walkers already
+            // handle (LOAD_CONST NONE / VARIANT_NEW with no fields).
+            if let Expr::Ident(ns) = &obj.node {
+                let qualified = format!("{ns}.{field}");
+                let ctor = classify_ctor(ctx, &qualified);
+                let nullary = matches!(
+                    ctor,
+                    ResolvedCtor::Builtin(BuiltinCtor::OptionNone) | ResolvedCtor::User { .. }
+                );
+                if nullary {
+                    return ResolvedExpr::Ctor(ctor, vec![]);
+                }
+            }
             ResolvedExpr::Attr(Box::new(resolve_spanned(ctx, obj)), field.clone())
         }
         Expr::FnCall(callee, args) => {

--- a/tests/hir_mir_differential.rs
+++ b/tests/hir_mir_differential.rs
@@ -202,6 +202,24 @@ fn newtype_specialization() {
 }
 
 #[test]
+fn nullary_ctor_value_position() {
+    // `Option.None` and a nullary user variant (`Color.Black`) used in
+    // value position (as arguments / bindings), not called. The resolver
+    // now lowers these to the zero-arg `Ctor` shape; both walkers must
+    // emit the same thing (LOAD_CONST NONE / VARIANT_NEW no-fields).
+    let src = prog(
+        "type Color\n  Black\n  White\n\n\
+         fn ci(c: Color) -> Int\n    \
+         match c\n        Color.Black -> 10\n        Color.White -> 20\n\n\
+         fn oi(o: Option<Int>) -> Int\n    \
+         match o\n        Option.None -> 0\n        Option.Some(n) -> n\n\n\
+         fn run() -> Int\n    \
+         ci(Color.Black) + ci(Color.White) + oi(Option.None) + oi(Option.Some(5))\n",
+    );
+    assert_parity("nullary_ctor", &src, "run");
+}
+
+#[test]
 fn string_interpolation_buffer_intrinsics() {
     // Interpolation chains lower (via `interp_lower` deforestation) to
     // the synthesized buffer intrinsics (`__buf_new` / `__buf_append` /

--- a/tests/mir_phase3_coverage_gate.rs
+++ b/tests/mir_phase3_coverage_gate.rs
@@ -38,19 +38,18 @@ fn lower_stats(source: &str) -> aver::ir::mir::LowerStats {
 
 #[test]
 fn conservation_lowered_plus_skipped_equals_total() {
-    // Mix of one wave-1 supported fn and one fn that drops on
-    // the still-reachable resolver gap for bare nullary
-    // builtin ctors in value position (`Option.None`). The
-    // typechecker accepts `Option.None` as a known builtin
-    // value, but the resolver lowers it to
-    // `Attr(Ident("Option"), "None")`, which the MIR lowerer
-    // bounces with `UnresolvedIdent`. Total fns seen = 2;
-    // every fn accounted for in `lowered` or `skipped`.
+    // Mix of one wave-1 supported fn and one fn that still drops:
+    // a first-class-fn call (`f(x)` where `f` is a `Fn(..)` param)
+    // lowers to a `LocalSlot` callee, which the MIR lowerer bounces
+    // with `UnsupportedCallee` — closures / first-class fns are the
+    // remaining un-lowered shape. Total fns seen = 2; every fn
+    // accounted for in `lowered` or `skipped`.
     //
-    // List / Tuple / Map / Result.Ok no longer work as drop
-    // fixtures here — wave 3c lowered all of them.
+    // List / Tuple / Map / Result.Ok / interpolation / nullary-ctor-
+    // in-value-position (`Option.None`) no longer work as drop
+    // fixtures here — they all lower now.
     let stats = lower_stats(
-        "fn keep(x: Int) -> Int\n    x + 1\n\nfn drops_me() -> Option<Int>\n    Option.None\n",
+        "fn keep(x: Int) -> Int\n    x + 1\n\nfn drops_me(f: Fn(Int) -> Int, x: Int) -> Int\n    f(x)\n",
     );
     assert_eq!(
         stats.total(),
@@ -135,12 +134,13 @@ fn wave_3c_iv_tuple_literal_no_longer_drops() {
 
 #[test]
 fn skipped_sorted_is_stable() {
-    // Two distinct skips via in-bounds reasons that *still* fire
-    // — two fns with unresolved bare idents (resolver gap) and an
-    // empty body (defensive guard). Both reasons reachable from
-    // the lowerer; sorted iteration follows `SkipReason as u8`.
+    // Skips that *still* fire after wave 3c + intrinsic + nullary-ctor
+    // lowering — two fns calling a first-class-fn param (`LocalSlot`
+    // callee → `UnsupportedCallee`). Sorted iteration follows
+    // `SkipReason as u8`; a single reason is trivially monotonic, and
+    // the map stays non-empty.
     let stats = lower_stats(
-        "fn a() -> Option<Int>\n    Option.None\n\nfn b() -> Option<Int>\n    Option.None\n",
+        "fn a(f: Fn(Int) -> Int, x: Int) -> Int\n    f(x)\n\nfn b(g: Fn(Int) -> Int, y: Int) -> Int\n    g(y)\n",
     );
     let sorted = stats.skipped_sorted();
     assert!(

--- a/tests/mir_phase3_wave1_lowering.rs
+++ b/tests/mir_phase3_wave1_lowering.rs
@@ -94,18 +94,19 @@ fn lowers_neg_over_int_literal() {
 
 #[test]
 fn drops_unsupported_fn_silently() {
-    // Bare nullary builtin ctor `Option.None` in value position
-    // lowers to `Attr(Ident("Option"), "None")` (resolver gap),
-    // which the MIR lowerer bounces with `UnresolvedIdent`. The
-    // lowerer must not panic; it just leaves the fn out.
+    // A first-class-fn call (`f(x)` where `f` is a `Fn(..)` param)
+    // lowers to a `LocalSlot` callee, which the MIR lowerer bounces
+    // with `UnsupportedCallee` — closures / first-class fns are the
+    // remaining un-lowered shape. The lowerer must not panic; it just
+    // leaves the fn out.
     //
-    // Previously the test used a list literal — wave 3c-iv now
-    // lowers those, so the fixture was repurposed to a still-
-    // dropped shape.
-    let dump = lower("fn nothing() -> Option<Int>\n    Option.None\n");
+    // The fixture was previously a list literal, then `Option.None` —
+    // both lower now (wave 3c-iv / the nullary-ctor-in-value-position
+    // resolver fix). First-class fns are what's left.
+    let dump = lower("fn nothing(f: Fn(Int) -> Int, x: Int) -> Int\n    f(x)\n");
     assert!(
         !dump.contains("fn nothing"),
-        "fn referencing the bare-nullary-ctor resolver gap shouldn't lower:\n{dump}"
+        "fn calling a first-class-fn param shouldn't lower yet:\n{dump}"
     );
 }
 


### PR DESCRIPTION
## Summary

The last MIR-lowering blocker on the games + JSON corpus was the `unresolved Ident` bucket: **nullary constructors in value position** (`Option.None`, `Color.Black`) that the resolver only recognized in *call* position. In value position they arrived as a bare `Attr(Ident(Type), Variant)`, which the MIR lowerer bounced with `UnresolvedIdent`.

Resolve them at the source: when `Attr(Ident(ns), field)` names a constructor, lower it to the zero-arg `Ctor` shape. A non-nullary ctor can't appear un-applied as a value (Aver has no first-class partial constructors), so an `Attr` resolving to a ctor is necessarily a **nullary** reference. Builtins are restricted to `Option.None`; user variants are accepted. Both walkers already handle the `Ctor` form (`LOAD_CONST NONE` / `VARIANT_NEW` no-fields).

## Rust-backend fix it surfaced

A nullary variant is generated as a Rust **unit** variant (`enum E { Point }`), so it must be referenced as `E::Point`, not `E::Point()` (`error[E0618]: expected function, found enum variant`). `emit_type_constructor_call` now omits the parens when there are no args. (This path was newly exercised — nullary ctors used to arrive as `Attr`, not `Ctor`.)

## Measured + validated

- **Aggregate MIR coverage on the games + JSON corpus: 336/336 = 100%** (up from 96.4%).
- Cross-backend: full-pipeline differential harness (new `nullary_ctor_value_position`), VM↔wasm-gc cross-backend proptest, Rust-codegen corpus build, games on VM + wasm-gc — all green.
- Three `mir_phase3_*` drop-fixture tests that used `Option.None` / list literals as "still-dropped" shapes now use a first-class-fn fixture (the genuine remaining un-lowered shape).

> Builds on #328 (buffer intrinsics, 86.6% → 96.4%); together they take the corpus to 100%. The only un-lowered shape left is first-class fn values / closures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)