### PR TITLE
ir/mir: lower first-class fn calls via CALL_VALUE (#252 Phase 6)

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -263,7 +263,9 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                 // many shapes to mirror in wave 2. Buffer intrinsics
                 // likewise fall back (the Rust backend deforests
                 // differently).
-                MirCallee::Builtin(_) | MirCallee::Intrinsic(_) => None,
+                MirCallee::Builtin(_) | MirCallee::Intrinsic(_) | MirCallee::LocalSlot { .. } => {
+                    None
+                }
             }
         }
         MirExpr::Return(inner) => Some(format!("return {}", emit_mir_expr(inner, emit_ctx)?)),

--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -157,6 +157,7 @@ fn write_call(f: &mut fmt::Formatter<'_>, call: &MirCall, indent: &str) -> fmt::
         MirCallee::Fn(id) => write!(f, "FnId({}).call(", id.0)?,
         MirCallee::Builtin(id) => write!(f, "Builtin(#{}).call(", id.0)?,
         MirCallee::Intrinsic(i) => write!(f, "Intrinsic({i:?}).call(")?,
+        MirCallee::LocalSlot { slot, .. } => write!(f, "slot({slot}).call(")?,
     }
     write_args(f, &call.args, indent)?;
     write!(f, ")")

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -227,6 +227,12 @@ pub enum MirCallee {
     /// `BUFFER_*` / CONCAT opcodes the HIR walker does instead of
     /// dropping the whole fn to the HIR fallback.
     Intrinsic(BuiltinIntrinsic),
+    /// First-class fn value held in a local slot — calling a `Fn(..)`
+    /// parameter or a let-bound fn value (`f(x)` where `f` is a slot).
+    /// The backend pushes the slot value (the callee) then the args and
+    /// dispatches dynamically (the VM's `CALL_VALUE`). `last_use` lets
+    /// the read use `MOVE_LOCAL` over `LOAD_LOCAL`.
+    LocalSlot { slot: u16, last_use: bool },
 }
 
 /// `target(args…)` in tail position — same SCC as the surrounding fn.

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -75,13 +75,16 @@
 //! aver.toml runtime policy decision.
 //!
 //! Final remaining `SkipReason`s after wave 3c:
-//! - `UnresolvedIdent` — resolver gap (e.g. bare `Option.None` in
-//!   value position), not a MIR concern.
+//! - `UnresolvedIdent` — a fn referenced as a value (`callWith(dbl)`
+//!   passes `dbl` as a bare ident). Calling a fn value already lowers;
+//!   referencing one is the remaining first-class-fn shape.
 //! - `MissingResolution` / `EmptyBody` / `BindingOnlyTail` /
 //!   `BindingSlotLookupMissing` / `PatternSlotShortfall` —
 //!   defensive guards for upstream pipeline gaps.
-//! - `UnsupportedCallee` — first-class fn / intrinsic / unresolved
-//!   call targets; future closures work.
+//! - `UnsupportedCallee` — only `Unresolved` callees (typecheck-error
+//!   recovery) now. Buffer intrinsics (`MirCallee::Intrinsic`) and
+//!   first-class-fn *calls* (`MirCallee::LocalSlot` → `CALL_VALUE`)
+//!   lower.
 //! - `BuiltinRecord` — records on built-in product types (no
 //!   `TypeId`); waits for a consumer that needs them.
 //! - `BuiltinCtorConstruction` / `BuiltinCtorPattern` /
@@ -271,10 +274,16 @@ fn lower_expr(
                 // emits the BUFFER_* / CONCAT opcodes instead of dropping
                 // the fn to the HIR fallback.
                 ResolvedCallee::Intrinsic(intrinsic) => MirCallee::Intrinsic(*intrinsic),
-                // First-class fn values and unresolved callees aren't
-                // covered yet — a later wave grows `MirCallee` for the
-                // first-class-fn / closure case.
-                ResolvedCallee::LocalSlot { .. } | ResolvedCallee::Unresolved { .. } => {
+                // First-class fn value in a local slot — `f(x)` where `f`
+                // is a `Fn(..)` param / let-bound fn. Dispatches through
+                // the VM's `CALL_VALUE` at the walker.
+                ResolvedCallee::LocalSlot { slot, last_use, .. } => MirCallee::LocalSlot {
+                    slot: *slot,
+                    last_use: last_use.0,
+                },
+                // Unresolved callees (typecheck-rejected recovery) still
+                // ride the HIR fallback.
+                ResolvedCallee::Unresolved { .. } => {
                     return Err(SkipReason::UnsupportedCallee);
                 }
             };

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -286,6 +286,22 @@ pub(super) fn compile_mir_expr(
                     }
                     Ok(())
                 }
+                MirCallee::LocalSlot { slot, last_use } => {
+                    // First-class fn value: push the slot (the callee),
+                    // then the args, then dynamic-dispatch via CALL_VALUE.
+                    // Mirror of the HIR walker's compile_call fallback +
+                    // compile_callee_as_value(LocalSlot). CALL_VALUE reads
+                    // the callee at `stack.len() - 1 - argc`, so it must be
+                    // pushed before the args.
+                    fc.emit_op(if *last_use { MOVE_LOCAL } else { LOAD_LOCAL });
+                    fc.emit_u8(*slot as u8);
+                    for arg in args {
+                        compile_mir_expr(fc, arg)?;
+                    }
+                    fc.emit_op(CALL_VALUE);
+                    fc.emit_u8(args.len() as u8);
+                    Ok(())
+                }
             }
         }
         MirExpr::Return(inner) => {
@@ -714,8 +730,9 @@ pub(super) fn compile_mir_expr(
                     }
                     // A synthesis intrinsic can't appear as an
                     // independent-product branch callee (intrinsics are
-                    // never first-class values); fall back conservatively.
-                    MirCallee::Intrinsic(_) => {
+                    // never first-class values); a first-class-fn-valued
+                    // IP branch is rare — both fall back conservatively.
+                    MirCallee::Intrinsic(_) | MirCallee::LocalSlot { .. } => {
                         return Err(MirVmUnsupported::UnsupportedCallee);
                     }
                 }
@@ -796,6 +813,8 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
                 // Buffer-build / stringify intrinsics emit dedicated
                 // BUFFER_* / CONCAT opcodes — always compilable.
                 MirCallee::Intrinsic(_) => true,
+                // First-class fn value → CALL_VALUE dynamic dispatch.
+                MirCallee::LocalSlot { .. } => true,
             };
             callee_ok && c.node.args.iter().all(can_compile)
         }

--- a/tests/hir_mir_differential.rs
+++ b/tests/hir_mir_differential.rs
@@ -202,6 +202,21 @@ fn newtype_specialization() {
 }
 
 #[test]
+fn first_class_fn_call_via_call_value() {
+    // `applyTwice` calls its `Fn(..)` parameter `f` — a first-class fn
+    // value in a local slot. The MIR walker lowers `f(x)` to a
+    // CALL_VALUE dynamic dispatch (push the slot, then the args), the
+    // same shape the HIR walker's compile_call fallback emits. Result:
+    // applyTwice(inc, 5) = inc(inc(5)) = 7.
+    let src = prog(
+        "fn applyTwice(f: Fn(Int) -> Int, x: Int) -> Int\n    f(f(x))\n\n\
+         fn inc(n: Int) -> Int\n    n + 1\n\n\
+         fn run() -> Int\n    applyTwice(inc, 5)\n",
+    );
+    assert_parity("first_class_fn", &src, "run");
+}
+
+#[test]
 fn nullary_ctor_value_position() {
     // `Option.None` and a nullary user variant (`Color.Black`) used in
     // value position (as arguments / bindings), not called. The resolver

--- a/tests/mir_phase3_coverage_gate.rs
+++ b/tests/mir_phase3_coverage_gate.rs
@@ -38,31 +38,38 @@ fn lower_stats(source: &str) -> aver::ir::mir::LowerStats {
 
 #[test]
 fn conservation_lowered_plus_skipped_equals_total() {
-    // Mix of one wave-1 supported fn and one fn that still drops:
-    // a first-class-fn call (`f(x)` where `f` is a `Fn(..)` param)
-    // lowers to a `LocalSlot` callee, which the MIR lowerer bounces
-    // with `UnsupportedCallee` — closures / first-class fns are the
-    // remaining un-lowered shape. Total fns seen = 2; every fn
+    // `dbl` and `callWith` lower (`callWith` calls its `Fn(..)` param
+    // via the CALL_VALUE first-class-fn path); `caller` still drops
+    // because it PASSES a fn as a value (`callWith(dbl)` → `dbl`
+    // resolves to a bare ident that the lowerer bounces). Passing /
+    // referencing a fn value is the remaining un-lowered shape —
+    // calling one already lowers. Total fns seen = 3; every fn
     // accounted for in `lowered` or `skipped`.
     //
-    // List / Tuple / Map / Result.Ok / interpolation / nullary-ctor-
-    // in-value-position (`Option.None`) no longer work as drop
+    // List / Tuple / Map / Result.Ok / interpolation / nullary-ctor-in-
+    // value-position / first-class-fn *calls* no longer work as drop
     // fixtures here — they all lower now.
     let stats = lower_stats(
-        "fn keep(x: Int) -> Int\n    x + 1\n\nfn drops_me(f: Fn(Int) -> Int, x: Int) -> Int\n    f(x)\n",
+        "fn dbl(n: Int) -> Int\n    n + n\n\n\
+         fn callWith(f: Fn(Int) -> Int) -> Int\n    f(3)\n\n\
+         fn caller() -> Int\n    callWith(dbl)\n",
     );
     assert_eq!(
         stats.total(),
-        2,
-        "expected 2 fns seen, got {}: {:?}",
+        3,
+        "expected 3 fns seen, got {}: {:?}",
         stats.total(),
         stats
     );
-    assert_eq!(stats.lowered, 1, "wave-1 fn must lower: {:?}", stats);
+    assert_eq!(
+        stats.lowered, 2,
+        "the two non-passing fns must lower: {:?}",
+        stats
+    );
     assert_eq!(
         stats.skipped.values().sum::<u32>(),
         1,
-        "exactly one fn dropped: {:?}",
+        "exactly one fn (the fn-passer) dropped: {:?}",
         stats
     );
 }
@@ -134,13 +141,16 @@ fn wave_3c_iv_tuple_literal_no_longer_drops() {
 
 #[test]
 fn skipped_sorted_is_stable() {
-    // Skips that *still* fire after wave 3c + intrinsic + nullary-ctor
-    // lowering — two fns calling a first-class-fn param (`LocalSlot`
-    // callee → `UnsupportedCallee`). Sorted iteration follows
-    // `SkipReason as u8`; a single reason is trivially monotonic, and
-    // the map stays non-empty.
+    // Skips that *still* fire after wave 3c + intrinsic + nullary-ctor +
+    // first-class-fn-call lowering — two fns that PASS a fn as a value
+    // (`callWith(dbl)` → the bare `dbl` ident the lowerer bounces).
+    // Sorted iteration follows `SkipReason as u8`; a single reason is
+    // trivially monotonic, and the map stays non-empty.
     let stats = lower_stats(
-        "fn a(f: Fn(Int) -> Int, x: Int) -> Int\n    f(x)\n\nfn b(g: Fn(Int) -> Int, y: Int) -> Int\n    g(y)\n",
+        "fn dbl(n: Int) -> Int\n    n + n\n\n\
+         fn callWith(f: Fn(Int) -> Int) -> Int\n    f(3)\n\n\
+         fn a() -> Int\n    callWith(dbl)\n\n\
+         fn b() -> Int\n    callWith(dbl)\n",
     );
     let sorted = stats.skipped_sorted();
     assert!(

--- a/tests/mir_phase3_wave1_lowering.rs
+++ b/tests/mir_phase3_wave1_lowering.rs
@@ -94,19 +94,23 @@ fn lowers_neg_over_int_literal() {
 
 #[test]
 fn drops_unsupported_fn_silently() {
-    // A first-class-fn call (`f(x)` where `f` is a `Fn(..)` param)
-    // lowers to a `LocalSlot` callee, which the MIR lowerer bounces
-    // with `UnsupportedCallee` — closures / first-class fns are the
-    // remaining un-lowered shape. The lowerer must not panic; it just
-    // leaves the fn out.
+    // Passing a fn as a value (`callWith(dbl)` → the bare `dbl` ident)
+    // is the remaining un-lowered shape — the MIR lowerer bounces it
+    // with `UnresolvedIdent`. The lowerer must not panic; it just leaves
+    // the fn out. (Calling a fn value, `f(x)`, already lowers via the
+    // CALL_VALUE first-class-fn path; only referencing one as a value
+    // is left.)
     //
-    // The fixture was previously a list literal, then `Option.None` —
-    // both lower now (wave 3c-iv / the nullary-ctor-in-value-position
-    // resolver fix). First-class fns are what's left.
-    let dump = lower("fn nothing(f: Fn(Int) -> Int, x: Int) -> Int\n    f(x)\n");
+    // The fixture was previously a list literal, then `Option.None`,
+    // then a first-class-fn call — all lower now.
+    let dump = lower(
+        "fn dbl(n: Int) -> Int\n    n + n\n\n\
+         fn callWith(f: Fn(Int) -> Int) -> Int\n    f(3)\n\n\
+         fn passesFn() -> Int\n    callWith(dbl)\n",
+    );
     assert!(
-        !dump.contains("fn nothing"),
-        "fn calling a first-class-fn param shouldn't lower yet:\n{dump}"
+        !dump.contains("fn passesFn"),
+        "fn passing a fn value shouldn't lower yet:\n{dump}"
     );
 }
 


### PR DESCRIPTION
## Summary

Calling a first-class fn value — `f(x)` where `f` is a `Fn(..)` parameter or a let-bound fn — dropped the whole fn to the HIR fallback (`ResolvedCallee::LocalSlot` → `UnsupportedCallee`). This is the **core of first-class-fn support** and the last commonly-reachable un-lowered shape after buffer intrinsics (#328) and nullary ctors (#329).

Add `MirCallee::LocalSlot { slot, last_use }`, lower `ResolvedCallee::LocalSlot`, and emit the same shape the HIR walker's `compile_call` fallback does: push the slot value (the callee) with `MOVE_LOCAL`/`LOAD_LOCAL`, then the args, then dynamic-dispatch via `CALL_VALUE` (which reads the callee at `stack.len() - 1 - argc`).

## What's left of first-class fns

*Referencing* a fn as a value (`callWith(dbl)` passes `dbl`, a bare ident the resolver leaves unresolved → `UnresolvedIdent`). **Calling** one now lowers; **passing** one is a follow-up (needs a fn-value MIR node + walker symbol resolution).

## Test plan
- [x] `first_class_fn_call_via_call_value` in the full-pipeline differential harness — `applyTwice(inc, 5)` = inc(inc(5)) = 7, identical on HIR and MIR
- [x] The three `mir_phase3_*` drop-fixture tests now use the fn-**passing** shape (the genuine remaining un-lowered shape)
- [x] full `cargo test` green; fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)