### PR TITLE
ir/mir: lower `_ = effect()?` discard bindings — corpus drops 16 → 4 (#252 Phase 6)

### DIFF
--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -660,6 +660,17 @@ fn lower_stmt_chain(
     // around the accumulating `body`.
     for stmt in rest.iter().rev() {
         let (binding, binding_name, value_expr) = match stmt {
+            ResolvedStmt::Binding { name, value, .. } if name == "_" => {
+                // Discard binding `_ = effect()?` — the idiomatic "run an
+                // effect, drop the Ok, continue" form. The resolver
+                // assigns `_` no slot (it returns `u16::MAX` and never
+                // inserts it), so there's nothing to look up. Evaluate the
+                // value for its effects under a fresh synthetic slot the
+                // body never reads, exactly as a non-tail `Stmt::Expr`.
+                let fresh = LocalId(*next_synthetic_local);
+                *next_synthetic_local += 1;
+                (fresh, String::new(), value)
+            }
             ResolvedStmt::Binding { name, value, .. } => {
                 let slot = *resolution
                     .local_slots

--- a/tests/hir_mir_differential.rs
+++ b/tests/hir_mir_differential.rs
@@ -202,6 +202,21 @@ fn newtype_specialization() {
 }
 
 #[test]
+fn discard_binding_evaluates_for_effect() {
+    // `_ = step(5)?` — the idiomatic "run it, drop the Ok, continue"
+    // form. The resolver assigns `_` no slot; the lowerer evaluates the
+    // value under a fresh synthetic slot the body never reads. The
+    // discarded call must still run (and its `?` still short-circuit),
+    // identically on both paths. run() = drop step(5)=Ok(6), then
+    // step(10) = Ok(11).
+    let src = prog(
+        "fn step(n: Int) -> Result<Int, String>\n    Result.Ok(n + 1)\n\n\
+         fn run() -> Result<Int, String>\n    _ = step(5)?\n    step(10)\n",
+    );
+    assert_parity("discard_binding", &src, "run");
+}
+
+#[test]
 fn first_class_fn_call_via_call_value() {
     // `applyTwice` calls its `Fn(..)` parameter `f` — a first-class fn
     // value in a local slot. The MIR walker lowers `f(x)` to a


### PR DESCRIPTION
## Summary

The dominant remaining MIR-lowering drop across the **full** examples corpus was the discard binding `_ = effect()?` — the idiomatic "run an effect, drop the Ok, continue" form (**12 of 16** dropped fns: `redis.av`, `status_board.av`, `notepad/store.av`, …).

**Root cause:** the resolver assigns `_` no slot (returns `u16::MAX`, never inserts `_` into `FnResolution.local_slots`), so the stmt-chain lowering's `Stmt::Binding` arm hit `local_slots.get("_")` → `None` → `SkipReason::BindingSlotLookupMissing` → dropped the whole fn.

**Fix:** lower a `_`-named binding the same way a non-tail `Stmt::Expr` is — evaluate the value under a fresh synthetic local the body never reads. The discarded call still runs (and its `?` still short-circuits); only the binding is unread. Non-`_` names keep the slot lookup (a miss there is a genuine resolver gap that should still drop).

## Measured

Full `examples/` corpus drops **16 → 4** (only built-in record construction left); 1331 fns, 99.7% lowered.

## Test plan
- [x] `discard_binding_evaluates_for_effect` in the full-pipeline differential harness — `_ = step(5)?; step(10)` = Ok(11), identical HIR vs MIR
- [x] full `cargo test` green; fmt clean

> Part of the "full VM-on-MIR" push (A1 of A1/A2/A3). Closes the dominant corpus drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)