### PR TITLE
ir/mir: lower built-in record construction — full corpus MIR coverage 100% (#252 Phase 6)

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -388,7 +388,9 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             // — HIR hardcodes the rename. The walker bounces so
             // HIR handles it.
             let rec = &spanned_rec.node;
-            let entry = emit_ctx.symbol_table.type_entry(rec.type_id);
+            // Built-in records (no user `TypeId`) ride the HIR walker.
+            let type_id = rec.type_id?;
+            let entry = emit_ctx.symbol_table.type_entry(type_id);
             if entry.key.canonical() == "Tcp.Connection" {
                 return None;
             }
@@ -405,7 +407,9 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             // `{type_name} { field: value, …, ..base }`. Same
             // bare-name + Tcp.Connection gating as RecordCreate.
             let upd = &spanned_upd.node;
-            let entry = emit_ctx.symbol_table.type_entry(upd.type_id);
+            // Built-in records (no user `TypeId`) ride the HIR walker.
+            let type_id = upd.type_id?;
+            let entry = emit_ctx.symbol_table.type_entry(type_id);
             if entry.key.canonical() == "Tcp.Connection" {
                 return None;
             }
@@ -686,7 +690,8 @@ mod tests {
             value: span(MirExpr::Literal(span(crate::ast::Literal::Int(2)))),
         };
         let rec = crate::ir::mir::MirRecordCreate {
-            type_id: crate::ir::TypeId(0),
+            type_id: Some(crate::ir::TypeId(0)),
+            type_name: "Test".to_string(),
             fields: vec![field_x, field_y],
         };
         let expr = span(MirExpr::RecordCreate(span(rec)));
@@ -704,7 +709,8 @@ mod tests {
         // `Tcp_Connection`) — the walker bounces so HIR
         // handles the rename.
         let rec = crate::ir::mir::MirRecordCreate {
-            type_id: crate::ir::TypeId(0),
+            type_id: Some(crate::ir::TypeId(0)),
+            type_name: "Test".to_string(),
             fields: vec![],
         };
         let expr = span(MirExpr::RecordCreate(span(rec)));
@@ -726,7 +732,8 @@ mod tests {
             value: span(MirExpr::Literal(span(crate::ast::Literal::Int(1)))),
         };
         let rec = crate::ir::mir::MirRecordCreate {
-            type_id: crate::ir::TypeId(0),
+            type_id: Some(crate::ir::TypeId(0)),
+            type_name: "Test".to_string(),
             fields: vec![field],
         };
         let expr = span(MirExpr::RecordCreate(span(rec)));
@@ -764,7 +771,8 @@ mod tests {
         };
         let upd = crate::ir::mir::MirRecordUpdate {
             base: Box::new(span(MirExpr::Local(span(base)))),
-            type_id: crate::ir::TypeId(0),
+            type_id: Some(crate::ir::TypeId(0)),
+            type_name: "Test".to_string(),
             updates: vec![update],
         };
         let expr = span(MirExpr::RecordUpdate(span(upd)));

--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -261,7 +261,10 @@ fn write_record_create(
     r: &MirRecordCreate,
     indent: &str,
 ) -> fmt::Result {
-    write!(f, "TypeId({}) {{ ", r.type_id.0)?;
+    match r.type_id {
+        Some(id) => write!(f, "TypeId({}) {{ ", id.0)?,
+        None => write!(f, "{} {{ ", r.type_name)?,
+    }
     write_fields(f, &r.fields, indent)?;
     write!(f, " }}")
 }
@@ -271,7 +274,10 @@ fn write_record_update(
     r: &MirRecordUpdate,
     indent: &str,
 ) -> fmt::Result {
-    write!(f, "TypeId({}).update(", r.type_id.0)?;
+    match r.type_id {
+        Some(id) => write!(f, "TypeId({}).update(", id.0)?,
+        None => write!(f, "{}.update(", r.type_name)?,
+    }
     write_expr(f, &r.base, indent)?;
     write!(f, ", ")?;
     write_fields(f, &r.updates, indent)?;

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -331,19 +331,25 @@ pub struct MirConstruct {
     pub args: Vec<Spanned<MirExpr>>,
 }
 
-/// Build a fresh record.
+/// Build a fresh record. `type_id` is `Some` for user-declared
+/// records; built-in product types (`HttpResponse`, `Header`,
+/// `Buffer`, …) carry no user `TypeId`, so they ride `type_name`
+/// alone (the canonical builtin name the arena registers them under).
 #[derive(Debug, Clone)]
 pub struct MirRecordCreate {
-    pub type_id: TypeId,
+    pub type_id: Option<TypeId>,
+    pub type_name: String,
     pub fields: Vec<MirRecordField>,
 }
 
 /// `T.update(base, …)` — produce a record matching `base` except
-/// for the named field overrides.
+/// for the named field overrides. `type_id` / `type_name` follow the
+/// same user-vs-built-in split as [`MirRecordCreate`].
 #[derive(Debug, Clone)]
 pub struct MirRecordUpdate {
     pub base: Box<Spanned<MirExpr>>,
-    pub type_id: TypeId,
+    pub type_id: Option<TypeId>,
+    pub type_name: String,
     pub updates: Vec<MirRecordField>,
 }
 

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -85,15 +85,12 @@
 //!   recovery) now. Buffer intrinsics (`MirCallee::Intrinsic`) and
 //!   first-class-fn *calls* (`MirCallee::LocalSlot` → `CALL_VALUE`)
 //!   lower.
-//! - `BuiltinRecord` — records on built-in product types (no
-//!   `TypeId`); waits for a consumer that needs them.
-//! - `BuiltinCtorConstruction` / `BuiltinCtorPattern` /
-//!   `UnsupportedTry` / `UnsupportedTailCall` /
-//!   `UnsupportedList` / `UnsupportedTuple` / `UnsupportedMap` /
-//!   `UnsupportedInterpolatedStr` /
-//!   `UnsupportedIndependentProduct` — kept in the enum for
-//!   historical attribution; no longer reachable from the
-//!   lowerer.
+//! - `BuiltinRecord` / `BuiltinCtorConstruction` / `BuiltinCtorPattern`
+//!   / `UnsupportedTry` / `UnsupportedTailCall` / `UnsupportedList` /
+//!   `UnsupportedTuple` / `UnsupportedMap` / `UnsupportedInterpolatedStr`
+//!   / `UnsupportedIndependentProduct` — kept in the enum for historical
+//!   attribution; no longer reachable from the lowerer (built-in records
+//!   now ride `MirRecordCreate.type_name` when they carry no `TypeId`).
 //!
 //! Functions that use anything outside the waves' supported
 //! subset are dropped — `MirProgram.fns` only contains what the
@@ -333,10 +330,15 @@ fn lower_expr(
         ResolvedExpr::Ctor(ResolvedCtor::Unresolved { .. }, _) => {
             return Err(SkipReason::UnresolvedCtor);
         }
+        // User records carry a `TypeId`; built-in product types
+        // (`HttpResponse`, `Header`, `Buffer`, …) carry `None` and ride
+        // their canonical `type_name`. Both lower the same shape — the
+        // walker resolves the arena type via `TypeId` when present, else
+        // by name.
         ResolvedExpr::RecordCreate {
-            type_id: Some(type_id),
+            type_id,
+            type_name,
             fields,
-            ..
         } => {
             let mir_fields = fields
                 .iter()
@@ -350,16 +352,17 @@ fn lower_expr(
             MirExpr::RecordCreate(wrap(
                 MirRecordCreate {
                     type_id: *type_id,
+                    type_name: type_name.clone(),
                     fields: mir_fields,
                 },
                 expr,
             ))
         }
         ResolvedExpr::RecordUpdate {
-            type_id: Some(type_id),
+            type_id,
+            type_name,
             base,
             updates,
-            ..
         } => {
             let mir_updates = updates
                 .iter()
@@ -374,17 +377,11 @@ fn lower_expr(
                 MirRecordUpdate {
                     base: Box::new(lower_expr(base, program)?),
                     type_id: *type_id,
+                    type_name: type_name.clone(),
                     updates: mir_updates,
                 },
                 expr,
             ))
-        }
-        // Records on built-in types (`HttpResponse`, `Header`,
-        // `Buffer`, …) carry no `TypeId`. Skipped until the
-        // consumer (currently nobody) demands a name-only fallback.
-        ResolvedExpr::RecordCreate { type_id: None, .. }
-        | ResolvedExpr::RecordUpdate { type_id: None, .. } => {
-            return Err(SkipReason::BuiltinRecord);
         }
         ResolvedExpr::Attr(base, field) => MirExpr::Project(wrap(
             MirProject {

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -456,14 +456,17 @@ pub(super) fn compile_mir_expr(
         }
         MirExpr::RecordCreate(spanned_rc) => {
             let rc = &spanned_rc.node;
-            // Resolve TypeId → canonical name → arena type id +
-            // field order. Same path the HIR walker takes; MIR
-            // carries the `TypeId` already, so we just look up
-            // the canonical name to ask the arena for the type
-            // metadata (the arena's field order is the
-            // declaration order, which is what RECORD_NEW
-            // expects on the stack).
-            let qualified_type_name = fc.canonical_type_name(rc.type_id)?;
+            // Resolve to the arena type id + field order. User records
+            // carry a `TypeId` → canonical name; built-in records
+            // (`HttpResponse`, …) carry no `TypeId` and ride their
+            // canonical `type_name` directly (the arena registers
+            // built-in record types by that name). The arena's field
+            // order is declaration order, which is what RECORD_NEW
+            // expects on the stack.
+            let qualified_type_name = match rc.type_id {
+                Some(id) => fc.canonical_type_name(id)?,
+                None => rc.type_name.clone(),
+            };
             let arena_type_id = fc.resolve_type_id(&qualified_type_name).ok_or_else(|| {
                 MirVmUnsupported::InnerError(CompileError {
                     msg: format!(
@@ -494,7 +497,10 @@ pub(super) fn compile_mir_expr(
         }
         MirExpr::RecordUpdate(spanned_ru) => {
             let ru = &spanned_ru.node;
-            let qualified_type_name = fc.canonical_type_name(ru.type_id)?;
+            let qualified_type_name = match ru.type_id {
+                Some(id) => fc.canonical_type_name(id)?,
+                None => ru.type_name.clone(),
+            };
             let arena_type_id = fc.resolve_type_id(&qualified_type_name).ok_or_else(|| {
                 MirVmUnsupported::InnerError(CompileError {
                     msg: format!(

--- a/tests/hir_mir_differential.rs
+++ b/tests/hir_mir_differential.rs
@@ -202,6 +202,20 @@ fn newtype_specialization() {
 }
 
 #[test]
+fn builtin_record_construction_and_projection() {
+    // `HttpResponse(...)` is a built-in product type — it carries no
+    // user `TypeId`, so MIR's RecordCreate rides its canonical
+    // `type_name` and the walker resolves the arena type by name. Build
+    // one and read a field back; identical on both paths.
+    let src = prog(
+        "fn mk(code: Int) -> HttpResponse\n    \
+         HttpResponse(status = code, body = \"ok\", headers = {})\n\n\
+         fn run() -> Int\n    mk(200).status\n",
+    );
+    assert_parity("builtin_record", &src, "run");
+}
+
+#[test]
 fn discard_binding_evaluates_for_effect() {
     // `_ = step(5)?` — the idiomatic "run it, drop the Ok, continue"
     // form. The resolver assigns `_` no slot; the lowerer evaluates the


### PR DESCRIPTION
## Summary

`HttpResponse(status = 200, body = "...", headers = {})` and other built-in product types (`Header`, `Buffer`, `Terminal.Size`, …) dropped the whole fn to the HIR fallback: they carry no user `TypeId`, and MIR's `RecordCreate`/`RecordUpdate` keyed on `TypeId` alone → `SkipReason::BuiltinRecord` (the last 4 corpus drops — `http_demo.av`, `terminal_size_snapshot.av`).

Carry the canonical type name alongside the optional id: `MirRecordCreate`/`MirRecordUpdate` now hold `type_id: Option<TypeId>` + `type_name: String`. User records keep their `TypeId`; built-in records ride the name. The VM walker resolves the arena type by `TypeId` when present, else by name — the same path the HIR walker takes.

## Measured

The **full** examples corpus now lowers at **100% (1331/1331 fns, 0 drops)** — up from 99.7% (after A1) and the headline 86.6% earlier in the push. The only un-lowered shape left is a fn referenced *as a value* (bare-ident first-class-fn pass), corpus-absent today.

## Test plan
- [x] `builtin_record_construction_and_projection` in the full-pipeline differential harness (`HttpResponse(...).status` = 200, identical HIR vs MIR)
- [x] full `cargo test` green; fmt clean

> A2 of the "full VM-on-MIR" push (A1 #331 + A2 here close all entry-module drops; A3 = dep-module fns next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)