### PR TITLE
ir/mir: lower fn-value passing via MirExpr::FnValue (#252 Phase 6)

### DIFF
--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -103,6 +103,7 @@ fn write_expr(f: &mut fmt::Formatter<'_>, expr: &Spanned<MirExpr>, indent: &str)
     match &expr.node {
         MirExpr::Literal(lit) => write!(f, "{:?}", lit.node),
         MirExpr::Local(local) => write!(f, "{}", local.node),
+        MirExpr::FnValue(name) => write!(f, "fn_value({name})"),
         MirExpr::Let(spanned) => write_let(f, &spanned.node, indent),
         MirExpr::Call(spanned) => write_call(f, &spanned.node, indent),
         MirExpr::TailCall(spanned) => write_tail_call(f, &spanned.node, indent),

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -177,6 +177,13 @@ pub enum MirExpr {
     /// don't return early end their body with the final expression
     /// itself; `Return` is only for the explicit early-exit case.
     Return(Box<Spanned<MirExpr>>),
+    /// A fn referenced as a *value* (not called): `callWith(dbl)` passes
+    /// `dbl`. Carries the canonical fn / builtin name; the backend
+    /// resolves it to a symbol reference (the VM pushes a `symbol_ref`
+    /// constant, mirroring the HIR walker's `StaticRef` leaf-op). The
+    /// walker falls back to HIR if the name doesn't resolve (a genuinely
+    /// unresolved ident — typecheck-rejected input).
+    FnValue(String),
 }
 
 /// `let binding = value; body`.

--- a/src/ir/mir/instantiations.rs
+++ b/src/ir/mir/instantiations.rs
@@ -140,7 +140,7 @@ impl Walker {
         // from `Spanned<MirExpr>`, so we register that level's
         // stamp before recursing into children.
         match expr {
-            MirExpr::Literal(_) | MirExpr::Local(_) => {}
+            MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
             MirExpr::Neg(inner) => {
                 self.register_ty(inner.ty());
                 self.visit_expr(&inner.node);

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -74,10 +74,7 @@
 //! `sequential`) is NOT carried in MIR per RFC — that's an
 //! aver.toml runtime policy decision.
 //!
-//! Final remaining `SkipReason`s after wave 3c:
-//! - `UnresolvedIdent` — a fn referenced as a value (`callWith(dbl)`
-//!   passes `dbl` as a bare ident). Calling a fn value already lowers;
-//!   referencing one is the remaining first-class-fn shape.
+//! Final remaining `SkipReason`s after the first-class-fn waves:
 //! - `MissingResolution` / `EmptyBody` / `BindingOnlyTail` /
 //!   `BindingSlotLookupMissing` / `PatternSlotShortfall` —
 //!   defensive guards for upstream pipeline gaps.
@@ -85,6 +82,12 @@
 //!   recovery) now. Buffer intrinsics (`MirCallee::Intrinsic`) and
 //!   first-class-fn *calls* (`MirCallee::LocalSlot` → `CALL_VALUE`)
 //!   lower.
+//!
+//! Fn-value *passing* (`callWith(dbl)` → bare `dbl`) used to drop as
+//! `UnresolvedIdent`; it now lowers to `MirExpr::FnValue`, which the VM
+//! walker resolves through the shared `compile_ident` symbol path. The
+//! `UnresolvedIdent` variant is retained for the coverage gate's
+//! "no-longer-drops" assertion but is no longer produced.
 //! - `BuiltinRecord` / `BuiltinCtorConstruction` / `BuiltinCtorPattern`
 //!   / `UnsupportedTry` / `UnsupportedTailCall` / `UnsupportedList` /
 //!   `UnsupportedTuple` / `UnsupportedMap` / `UnsupportedInterpolatedStr`
@@ -503,7 +506,15 @@ fn lower_expr(
         }
 
         // ── Final catch-all ─────────────────────────────────────
-        ResolvedExpr::Ident(_) => return Err(SkipReason::UnresolvedIdent),
+        // A bare ident that survived resolution is a fn referenced as
+        // a *value* (`callWith(dbl)` passes `dbl`) — the resolver
+        // already turned locals into `Resolved`, nullary ctors into
+        // `Ctor`, and builtins into `Builtin`, so what's left is a
+        // static fn/builtin name. Carry it as `FnValue`; the backend
+        // resolves the symbol. A genuinely-dangling name (typecheck-
+        // rejected input) flows through too and surfaces as an
+        // unresolved-symbol error at the backend, not a lowering drop.
+        ResolvedExpr::Ident(name) => MirExpr::FnValue(name.clone()),
     };
     Ok(wrap(mir, expr))
 }

--- a/src/ir/mir/optimize/algebraic.rs
+++ b/src/ir/mir/optimize/algebraic.rs
@@ -166,7 +166,7 @@ fn int_literal(node: &MirExpr) -> Option<i64> {
 
 fn algebraic_walk_children(node: &mut MirExpr) {
     match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) => {}
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
         MirExpr::Neg(inner) => algebraic_in_place(inner),
         MirExpr::BinOp(spanned_bop) => {
             algebraic_in_place(&mut spanned_bop.node.lhs);

--- a/src/ir/mir/optimize/bool_match.rs
+++ b/src/ir/mir/optimize/bool_match.rs
@@ -108,7 +108,7 @@ fn bool_pattern(p: &MirPattern) -> Option<BoolPat> {
 
 fn bool_match_walk_children(node: &mut MirExpr) {
     match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) => {}
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
         MirExpr::Neg(inner) => bool_match_in_place(inner),
         MirExpr::BinOp(spanned_bop) => {
             bool_match_in_place(&mut spanned_bop.node.lhs);

--- a/src/ir/mir/optimize/branch_collapse.rs
+++ b/src/ir/mir/optimize/branch_collapse.rs
@@ -71,7 +71,7 @@ enum BranchSide {
 
 fn branch_collapse_walk_children(node: &mut MirExpr) {
     match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) => {}
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
         MirExpr::Neg(inner) => branch_collapse_in_place(inner),
         MirExpr::BinOp(spanned_bop) => {
             branch_collapse_in_place(&mut spanned_bop.node.lhs);

--- a/src/ir/mir/optimize/const_fold.rs
+++ b/src/ir/mir/optimize/const_fold.rs
@@ -51,7 +51,7 @@ fn literal_span(lit: Literal, source: &Spanned<MirExpr>) -> Spanned<Literal> {
 
 fn walk_children(node: &mut MirExpr) {
     match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) => {}
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
         MirExpr::Neg(inner) => fold_in_place(inner),
         MirExpr::BinOp(spanned_bop) => {
             let bop: &mut MirBinOp = &mut spanned_bop.node;

--- a/src/ir/mir/optimize/dead_code.rs
+++ b/src/ir/mir/optimize/dead_code.rs
@@ -55,7 +55,7 @@ fn dce_in_place(expr: &mut Spanned<MirExpr>) {
 
 fn dce_walk_children(node: &mut MirExpr) {
     match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) => {}
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
         MirExpr::Neg(inner) => dce_in_place(inner),
         MirExpr::BinOp(spanned_bop) => {
             let bop: &mut MirBinOp = &mut spanned_bop.node;
@@ -148,7 +148,7 @@ fn local_is_read(target: LocalId, body: &Spanned<MirExpr>) -> bool {
 
 fn visit_locals(node: &MirExpr, visit: &mut impl FnMut(LocalId)) {
     match node {
-        MirExpr::Literal(_) => {}
+        MirExpr::Literal(_) | MirExpr::FnValue(_) => {}
         MirExpr::Local(spanned_local) => visit(spanned_local.node.slot),
         MirExpr::Neg(inner) => visit_locals(&inner.node, visit),
         MirExpr::BinOp(spanned_bop) => {
@@ -231,7 +231,7 @@ fn visit_locals(node: &MirExpr, visit: &mut impl FnMut(LocalId)) {
 /// operand is pure).
 pub(super) fn is_pure(expr: &Spanned<MirExpr>) -> bool {
     match &expr.node {
-        MirExpr::Literal(_) | MirExpr::Local(_) => true,
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => true,
         MirExpr::Neg(inner) => is_pure(inner),
         MirExpr::BinOp(spanned_bop) => {
             is_pure(&spanned_bop.node.lhs) && is_pure(&spanned_bop.node.rhs)

--- a/src/ir/mir/optimize/inline.rs
+++ b/src/ir/mir/optimize/inline.rs
@@ -75,7 +75,7 @@ fn inline_in_place(expr: &mut Spanned<MirExpr>, candidates: &HashMap<FnId, Liter
 
 fn inline_walk_children(node: &mut MirExpr, candidates: &HashMap<FnId, Literal>) {
     match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) => {}
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
         MirExpr::Neg(inner) => inline_in_place(inner, candidates),
         MirExpr::BinOp(spanned_bop) => {
             inline_in_place(&mut spanned_bop.node.lhs, candidates);

--- a/src/vm/compiler/expr.rs
+++ b/src/vm/compiler/expr.rs
@@ -140,7 +140,7 @@ impl<'a> FnCompiler<'a> {
         Ok(())
     }
 
-    fn compile_ident(&mut self, name: &str) -> Result<(), CompileError> {
+    pub(super) fn compile_ident(&mut self, name: &str) -> Result<(), CompileError> {
         if let Some(&slot) = self.local_slots.get(name) {
             self.emit_op(LOAD_LOCAL);
             self.emit_u8(slot as u8);

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -310,6 +310,20 @@ pub(super) fn compile_mir_expr(
             Ok(())
         }
 
+        // ── Phase 6: fn referenced as a value ───────────────────
+        // `callWith(dbl)` passes `dbl` — a top-level fn / builtin in
+        // value position. Reuse the HIR walker's `compile_ident`
+        // verbatim: it tries local slot → global → module-scope fn
+        // (symbol_ref of the qualified name) → interned symbol with a
+        // kind. Sharing the path guarantees byte-identical emit with
+        // the HIR walker, and an unresolved name surfaces as the same
+        // `CompileError` (folded to `InnerError`, so a malformed input
+        // still drops to the HIR fallback rather than miscompiling).
+        MirExpr::FnValue(name) => {
+            fc.compile_ident(name)?;
+            Ok(())
+        }
+
         // ── Phase 4c: ctor construction ─────────────────────────
         MirExpr::Construct(spanned_construct) => {
             let c = &spanned_construct.node;
@@ -825,6 +839,11 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
             callee_ok && c.node.args.iter().all(can_compile)
         }
         MirExpr::Return(inner) => can_compile(inner),
+        // Phase 6: fn-as-value. Optimistic, same rationale as the
+        // `Builtin` callee above — `compile_ident` resolves the
+        // symbol on the hot path and surfaces a real error (→ HIR
+        // fallback) if the name doesn't resolve.
+        MirExpr::FnValue(_) => true,
         // Phase 4c additions:
         MirExpr::Construct(c) => c.node.args.iter().all(can_compile),
         MirExpr::Project(p) => can_compile(&p.node.base),
@@ -1527,6 +1546,8 @@ fn contains_last_use_slot_mir(expr: &MirExpr, target: u32) -> bool {
         | MirExpr::IfThenElse(_)
         | MirExpr::Let(_)
         | MirExpr::Return(_)
+        // FnValue is a bare symbol reference — no slot read.
+        | MirExpr::FnValue(_)
         | MirExpr::Literal(_) => false,
     }
 }

--- a/tests/mir_phase3_coverage_gate.rs
+++ b/tests/mir_phase3_coverage_gate.rs
@@ -38,17 +38,18 @@ fn lower_stats(source: &str) -> aver::ir::mir::LowerStats {
 
 #[test]
 fn conservation_lowered_plus_skipped_equals_total() {
-    // `dbl` and `callWith` lower (`callWith` calls its `Fn(..)` param
-    // via the CALL_VALUE first-class-fn path); `caller` still drops
-    // because it PASSES a fn as a value (`callWith(dbl)` → `dbl`
-    // resolves to a bare ident that the lowerer bounces). Passing /
-    // referencing a fn value is the remaining un-lowered shape —
-    // calling one already lowers. Total fns seen = 3; every fn
-    // accounted for in `lowered` or `skipped`.
+    // `dbl`, `callWith`, and `caller` all lower now: `callWith` calls
+    // its `Fn(..)` param via the CALL_VALUE path, and `caller` PASSES a
+    // fn as a value (`callWith(dbl)` → `dbl`), which the lowerer now
+    // carries as `MirExpr::FnValue` instead of bouncing. Fn-value
+    // passing was the last corpus-relevant drop shape; with it closed,
+    // a clean-typechecking program has no un-lowered shapes among
+    // ordinary Aver. The conservation invariant still holds:
+    // `lowered + skipped == total`, now with `skipped == 0`.
     //
     // List / Tuple / Map / Result.Ok / interpolation / nullary-ctor-in-
-    // value-position / first-class-fn *calls* no longer work as drop
-    // fixtures here — they all lower now.
+    // value-position / first-class-fn *calls* / fn-value *passing* all
+    // lower now — none survive as drop fixtures here.
     let stats = lower_stats(
         "fn dbl(n: Int) -> Int\n    n + n\n\n\
          fn callWith(f: Fn(Int) -> Int) -> Int\n    f(3)\n\n\
@@ -62,14 +63,34 @@ fn conservation_lowered_plus_skipped_equals_total() {
         stats
     );
     assert_eq!(
-        stats.lowered, 2,
-        "the two non-passing fns must lower: {:?}",
+        stats.lowered, 3,
+        "all three fns must lower (fn-value passing now carries as FnValue): {:?}",
         stats
     );
     assert_eq!(
         stats.skipped.values().sum::<u32>(),
-        1,
-        "exactly one fn (the fn-passer) dropped: {:?}",
+        0,
+        "no fn drops — fn-value passing lowers via MirExpr::FnValue: {:?}",
+        stats
+    );
+}
+
+#[test]
+fn fn_value_passing_no_longer_drops() {
+    // `callWith(dbl)` passes the top-level fn `dbl` by bare ident into a
+    // higher-order fn. Before `MirExpr::FnValue` this resolved to a bare
+    // `ResolvedExpr::Ident` the lowerer dropped as `UnresolvedIdent`;
+    // now it lowers and the VM walker resolves the symbol via the shared
+    // `compile_ident` path. The `UnresolvedIdent` skip counter must be 0.
+    let stats = lower_stats(
+        "fn dbl(n: Int) -> Int\n    n + n\n\n\
+         fn callWith(f: Fn(Int) -> Int) -> Int\n    f(3)\n\n\
+         fn caller() -> Int\n    callWith(dbl)\n",
+    );
+    assert_eq!(
+        stats.skipped.get(&SkipReason::UnresolvedIdent).copied(),
+        None,
+        "fn-value passing must not drop as UnresolvedIdent: {:?}",
         stats
     );
 }
@@ -141,17 +162,18 @@ fn wave_3c_iv_tuple_literal_no_longer_drops() {
 
 #[test]
 fn skipped_sorted_is_stable() {
-    // Skips that *still* fire after wave 3c + intrinsic + nullary-ctor +
-    // first-class-fn-call lowering — two fns that PASS a fn as a value
-    // (`callWith(dbl)` → the bare `dbl` ident the lowerer bounces).
-    // Sorted iteration follows `SkipReason as u8`; a single reason is
-    // trivially monotonic, and the map stays non-empty.
-    let stats = lower_stats(
-        "fn dbl(n: Int) -> Int\n    n + n\n\n\
-         fn callWith(f: Fn(Int) -> Int) -> Int\n    f(3)\n\n\
-         fn a() -> Int\n    callWith(dbl)\n\n\
-         fn b() -> Int\n    callWith(dbl)\n",
-    );
+    // No ordinary typecheck-clean program drops anymore (fn-value
+    // passing was the last shape, now lowered via `MirExpr::FnValue`),
+    // so the sort invariant of `skipped_sorted()` is tested by recording
+    // the remaining *defensive-guard* reasons directly. Sorted iteration
+    // must follow `SkipReason as u8` ascending regardless of insertion
+    // order, so dumps + diagnostics don't depend on `HashMap` drift.
+    let mut stats = aver::ir::mir::LowerStats::default();
+    // Insert out of discriminant order on purpose.
+    stats.record_skip(SkipReason::UnsupportedCallee);
+    stats.record_skip(SkipReason::EmptyBody);
+    stats.record_skip(SkipReason::EmptyBody);
+    stats.record_skip(SkipReason::MissingResolution);
     let sorted = stats.skipped_sorted();
     assert!(
         !sorted.is_empty(),

--- a/tests/mir_phase3_wave1_lowering.rs
+++ b/tests/mir_phase3_wave1_lowering.rs
@@ -93,24 +93,27 @@ fn lowers_neg_over_int_literal() {
 }
 
 #[test]
-fn drops_unsupported_fn_silently() {
+fn lowers_fn_value_passing() {
     // Passing a fn as a value (`callWith(dbl)` → the bare `dbl` ident)
-    // is the remaining un-lowered shape — the MIR lowerer bounces it
-    // with `UnresolvedIdent`. The lowerer must not panic; it just leaves
-    // the fn out. (Calling a fn value, `f(x)`, already lowers via the
-    // CALL_VALUE first-class-fn path; only referencing one as a value
-    // is left.)
+    // was the last un-lowered ordinary shape. It now lowers: the bare
+    // ident becomes `MirExpr::FnValue`, so `passesFn` appears in the
+    // dump with a `fn_value(dbl)` node. (Calling a fn value, `f(x)`,
+    // already lowered via the CALL_VALUE first-class-fn path.)
     //
     // The fixture was previously a list literal, then `Option.None`,
-    // then a first-class-fn call — all lower now.
+    // then a first-class-fn call — all of which lower; this one too now.
     let dump = lower(
         "fn dbl(n: Int) -> Int\n    n + n\n\n\
          fn callWith(f: Fn(Int) -> Int) -> Int\n    f(3)\n\n\
          fn passesFn() -> Int\n    callWith(dbl)\n",
     );
     assert!(
-        !dump.contains("fn passesFn"),
-        "fn passing a fn value shouldn't lower yet:\n{dump}"
+        dump.contains("fn passesFn"),
+        "fn passing a fn value must lower now:\n{dump}"
+    );
+    assert!(
+        dump.contains("fn_value(dbl)"),
+        "the passed fn must render as a fn_value node:\n{dump}"
     );
 }
 


### PR DESCRIPTION
## What

Closes the last ordinary-Aver shape the MIR lowerer dropped: **passing a top-level fn as a value** (`callWith(dbl)` → the bare `dbl` ident). The resolver leaves a fn reference as `ResolvedExpr::Ident`; the lowerer used to bounce it as `SkipReason::UnresolvedIdent`, and the enclosing fn fell back to the HIR walker.

It now lowers to a new leaf node `MirExpr::FnValue(name)`. The VM walker resolves it through the **same `compile_ident` path** the HIR walker uses for an ident in value position (local slot → global → module-scope fn `symbol_ref` → interned symbol), so emit is byte-identical to the HIR fallback, and an unresolved name surfaces as the same `CompileError` (folded to `InnerError`, so malformed input still drops to HIR rather than miscompiling).

## Why

This is step 1 of retiring the HIR walker. Before deleting it we need nothing well-formed to fall back. After A1–A3 the corpus already lowered 100%, but bare-ident fn passing (corpus-absent, still valid Aver) was the one real shape that dropped. With `FnValue` in place, **no typecheck-clean program drops** — the only remaining `SkipReason`s are defensive guards on malformed / typecheck-rejected input.

## Scope

- `FnValue` is a childless leaf: the six optimize passes, instantiation discovery, the last-use scan, and `can_compile` treat it as a no-op / pure / always-compilable leaf; `dump` renders `fn_value(name)`.
- The typechecker still only admits fn values in **call-argument position** (binding one to a local stays an error), so this closes the passing case without widening the language.
- `UnresolvedIdent` is retained (no longer produced) for the coverage gate's "no-longer-drops" assertion, matching the `BuiltinRecord` / `BuiltinCtorConstruction` precedent.

## Tests

- differential `first_class_fn` now lowers instead of falling back (parity holds either way)
- coverage gate `conservation_*` flips to all-lower + new `fn_value_passing_no_longer_drops`
- wave1 `lowers_fn_value_passing` (asserts the `fn_value(dbl)` dump node)
- `skipped_sorted_is_stable` rebuilt on recorded defensive reasons (no typecheck-clean program drops anymore)
- full suite green (60 suites); `clippy -p aver-lang --lib --bin aver --features wasm -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)