### PR TITLE
test: migrate VM test oracles off the HIR walker (#252 Phase 6)

### DIFF
--- a/tests/hir_mir_differential.rs
+++ b/tests/hir_mir_differential.rs
@@ -1,18 +1,21 @@
-//! Full-pipeline HIR-vs-MIR differential execution harness.
+//! Full-pipeline MIR-path golden execution harness.
 //!
-//! MIR is the default VM compile path. This compiles each program
-//! through BOTH the HIR walker (`compile_program`) and the MIR-default
-//! walker (`compile_program_with_mir_fallback`) using the FULL pipeline
-//! — crucially including `last_use`, which the in-process
-//! `mir_vm_parity` harness skips — runs the entry fn on each, and
-//! asserts identical VM-observable values. A divergence is a latent bug
-//! on the shipped default path.
+//! MIR is the default (and now only) VM compile path. This compiles
+//! each program through `compile_program_with_mir_fallback` using the
+//! FULL pipeline — crucially including `last_use` — runs the entry fn,
+//! and asserts the VM-observable value against a captured golden. The
+//! goldens were captured while the now-retired HIR walker and the MIR
+//! path were proven byte-for-byte equal by this harness; with the HIR
+//! walker gone they pin the MIR/VM codegen output directly. A change in
+//! a golden is a latent bug on the shipped default path.
 //!
-//! The program set targets the shapes most likely to diverge between
-//! the walkers: owned/in-place mutation (Vector/Map accumulators), the
+//! The program set targets the shapes most exercised by the codegen:
+//! owned/in-place mutation (Vector/Map accumulators), the
 //! leaf-classifier interaction (chains of non-tail known calls), fused
 //! compound leaf-ops, deep/mutual recursion, nested matches, and
-//! record/tuple construction.
+//! record/tuple construction. Cross-*implementation* validation (the
+//! values agree on an independent backend) is provided by the wasm-gc
+//! suites and `aver verify --wasm-gc`, not by a second VM walker.
 
 use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
 use aver::nan_value::{Arena, NanValue, NanValueConvert};
@@ -20,7 +23,7 @@ use aver::source::parse_source;
 use aver::value::Value;
 use aver::vm;
 
-fn run_both(src: &str, entry: &str) -> (Value, Value) {
+fn run_mir(src: &str, entry: &str) -> Value {
     let mut items = parse_source(src).expect("parse failed");
     let result = pipeline::run(
         &mut items,
@@ -36,27 +39,12 @@ fn run_both(src: &str, entry: &str) -> (Value, Value) {
     let symbols = result.symbol_table;
     let analysis = result.analysis;
 
-    let hir = {
-        let mut arena = Arena::new();
-        vm::register_service_types(&mut arena);
-        let (code, globals) =
-            vm::compile_program(&resolved, &symbols, &mut arena, analysis.as_ref())
-                .expect("HIR compile failed");
-        run_entry(code, globals, arena, entry)
-    };
-    let mir = {
-        let mut arena = Arena::new();
-        vm::register_service_types(&mut arena);
-        let (code, globals) = vm::compile_program_with_mir_fallback(
-            &resolved,
-            &symbols,
-            &mut arena,
-            analysis.as_ref(),
-        )
-        .expect("MIR compile failed");
-        run_entry(code, globals, arena, entry)
-    };
-    (hir, mir)
+    let mut arena = Arena::new();
+    vm::register_service_types(&mut arena);
+    let (code, globals) =
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, analysis.as_ref())
+            .expect("MIR compile failed");
+    run_entry(code, globals, arena, entry)
 }
 
 fn run_entry(code: vm::CodeStore, globals: Vec<NanValue>, arena: Arena, entry: &str) -> Value {
@@ -68,11 +56,21 @@ fn run_entry(code: vm::CodeStore, globals: Vec<NanValue>, arena: Arena, entry: &
     result.to_value(&machine.arena)
 }
 
-fn assert_parity(name: &str, src: &str, entry: &str) {
-    let (hir, mir) = run_both(src, entry);
+/// Compile `src` via the MIR-default VM path, run `entry`, and assert
+/// the VM-observable value's `Debug` form equals `expected`. The
+/// golden was captured while the now-retired HIR walker and the MIR
+/// path were proven equal by this same harness; with the HIR walker
+/// gone the golden pins the MIR/VM codegen output directly. The
+/// independent-implementation cross-check (these shapes' values agree
+/// across backends) is covered by the wasm-gc suites
+/// (`wasm_gc_spec`, `wasm_gc_codegen_regression`) and
+/// `aver verify --wasm-gc`.
+fn assert_golden(name: &str, src: &str, entry: &str, expected: &str) {
+    let got = run_mir(src, entry);
     assert_eq!(
-        hir, mir,
-        "[{name}] HIR vs MIR execution divergence: HIR={hir:?} MIR={mir:?}"
+        format!("{got:?}"),
+        expected,
+        "[{name}] MIR golden mismatch: got {got:?}"
     );
 }
 
@@ -93,7 +91,7 @@ fn leaf_classifier_call_chain() {
          fn pair(a: Int, b: Int) -> Int\n    bump(b)\n\n\
          fn run() -> Int\n    pair(2, 5) + pair(7, 9)\n",
     );
-    assert_parity("leaf_chain", &src, "run");
+    assert_golden("leaf_chain", &src, "run", "Int(14)");
 }
 
 #[test]
@@ -107,7 +105,7 @@ fn owned_vector_accumulator() {
          false -> sum(v, n, i + 1, acc + Option.withDefault(Vector.get(v, i), 0))\n\n\
          fn run() -> Int\n    sum(fill(Vector.new(20, 0), 20, 0), 20, 0, 0)\n",
     );
-    assert_parity("owned_vector", &src, "run");
+    assert_golden("owned_vector", &src, "run", "Int(2470)");
 }
 
 #[test]
@@ -118,7 +116,7 @@ fn owned_map_accumulator() {
          _ -> build(n - 1, Map.set(m, String.fromInt(n), n))\n\n\
          fn run() -> Int\n    Map.len(build(25, {}))\n",
     );
-    assert_parity("owned_map", &src, "run");
+    assert_golden("owned_map", &src, "run", "Int(25)");
 }
 
 #[test]
@@ -132,7 +130,7 @@ fn aliased_param_threaded_then_read() {
          other = ins(base)\n    \
          Option.withDefault(Map.get(base, \"k\"), 0) * 1000 + Option.withDefault(Map.get(other, \"k\"), 0)\n",
     );
-    assert_parity("aliased_map", &src, "run");
+    assert_golden("aliased_map", &src, "run", "Int(7099)");
 }
 
 #[test]
@@ -142,7 +140,7 @@ fn deep_self_recursion() {
          match n\n        0 -> acc\n        _ -> countdown(n - 1, acc + n)\n\n\
          fn run() -> Int\n    countdown(1000, 0)\n",
     );
-    assert_parity("deep_recursion", &src, "run");
+    assert_golden("deep_recursion", &src, "run", "Int(500500)");
 }
 
 #[test]
@@ -154,7 +152,7 @@ fn mutual_recursion() {
          match n\n        0 -> false\n        _ -> isEven(n - 1)\n\n\
          fn run() -> Bool\n    isEven(100)\n",
     );
-    assert_parity("mutual_recursion", &src, "run");
+    assert_golden("mutual_recursion", &src, "run", "Bool(true)");
 }
 
 #[test]
@@ -166,7 +164,7 @@ fn nested_match_and_arithmetic() {
          false -> match n == 0\n            true -> 0\n            false -> 1\n\n\
          fn run() -> Int\n    classify(0 - 5) + classify(0) + classify(5)\n",
     );
-    assert_parity("nested_match", &src, "run");
+    assert_golden("nested_match", &src, "run", "Int(0)");
 }
 
 #[test]
@@ -177,7 +175,7 @@ fn record_and_tuple_roundtrip() {
          fn sumP(p: P) -> Int\n    p.x + p.y\n\n\
          fn run() -> Int\n    sumP(mk(3, 4)) + sumP(P(x = 10, y = 20))\n",
     );
-    assert_parity("record_tuple", &src, "run");
+    assert_golden("record_tuple", &src, "run", "Int(37)");
 }
 
 #[test]
@@ -187,7 +185,7 @@ fn fib_doubly_recursive() {
          match n < 2\n        true -> n\n        false -> fib(n - 1) + fib(n - 2)\n\n\
          fn run() -> Int\n    fib(20)\n",
     );
-    assert_parity("fib", &src, "run");
+    assert_golden("fib", &src, "run", "Int(6765)");
 }
 
 #[test]
@@ -198,7 +196,7 @@ fn newtype_specialization() {
          match w\n        Wrapped.W(n) -> n\n\n\
          fn run() -> Int\n    unwrap(Wrapped.W(41)) + unwrap(Wrapped.W(1))\n",
     );
-    assert_parity("newtype", &src, "run");
+    assert_golden("newtype", &src, "run", "Int(42)");
 }
 
 #[test]
@@ -212,7 +210,7 @@ fn builtin_record_construction_and_projection() {
          HttpResponse(status = code, body = \"ok\", headers = {})\n\n\
          fn run() -> Int\n    mk(200).status\n",
     );
-    assert_parity("builtin_record", &src, "run");
+    assert_golden("builtin_record", &src, "run", "Int(200)");
 }
 
 #[test]
@@ -227,7 +225,7 @@ fn discard_binding_evaluates_for_effect() {
         "fn step(n: Int) -> Result<Int, String>\n    Result.Ok(n + 1)\n\n\
          fn run() -> Result<Int, String>\n    _ = step(5)?\n    step(10)\n",
     );
-    assert_parity("discard_binding", &src, "run");
+    assert_golden("discard_binding", &src, "run", "Ok(Int(11))");
 }
 
 #[test]
@@ -242,7 +240,7 @@ fn first_class_fn_call_via_call_value() {
          fn inc(n: Int) -> Int\n    n + 1\n\n\
          fn run() -> Int\n    applyTwice(inc, 5)\n",
     );
-    assert_parity("first_class_fn", &src, "run");
+    assert_golden("first_class_fn", &src, "run", "Int(7)");
 }
 
 #[test]
@@ -260,7 +258,7 @@ fn nullary_ctor_value_position() {
          fn run() -> Int\n    \
          ci(Color.Black) + ci(Color.White) + oi(Option.None) + oi(Option.Some(5))\n",
     );
-    assert_parity("nullary_ctor", &src, "run");
+    assert_golden("nullary_ctor", &src, "run", "Int(35)");
 }
 
 #[test]
@@ -276,15 +274,20 @@ fn string_interpolation_buffer_intrinsics() {
          _ -> build(n - 1, \"{acc}-{String.fromInt(n)}\")\n\n\
          fn run() -> String\n    build(6, \"start\")\n",
     );
-    assert_parity("string_interp", &src, "run");
+    assert_golden("string_interp", &src, "run", "Str(\"start-6-5-4-3-2-1\")");
 }
 
 #[test]
-fn bench_scenario_corpus_parity() {
+fn bench_scenario_corpus_runs_via_mir() {
     // Drive the real single-module bench programs (`depends []`, entry
-    // `main`) through both walkers. These exercise the production shapes
-    // (typed numeric loops, owned Vector/Map accumulators, record /
-    // newtype specialization, string interpolation) on actual source.
+    // `main`) through the MIR-default VM path. These exercise the
+    // production shapes (typed numeric loops, owned Vector/Map
+    // accumulators, record / newtype specialization, string
+    // interpolation) on actual source: every scenario must compile and
+    // run to a value without panicking. Cross-backend agreement on the
+    // bench corpus is validated separately by the wasm-gc suites and by
+    // `aver bench --target={wasm-local,rust}`; this is the MIR-path
+    // smoke gate that those don't cover (full pipeline, incl. last_use).
     let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("bench/scenarios");
     let mut checked = 0usize;
     let mut entries: Vec<_> = std::fs::read_dir(&dir)
@@ -296,12 +299,10 @@ fn bench_scenario_corpus_parity() {
     entries.sort();
     for path in entries {
         let src = std::fs::read_to_string(&path).expect("read scenario");
-        let name = path.file_stem().unwrap().to_string_lossy().to_string();
-        let (hir, mir) = run_both(&src, "main");
-        assert_eq!(
-            hir, mir,
-            "[bench:{name}] HIR vs MIR execution divergence: HIR={hir:?} MIR={mir:?}"
-        );
+        // `run_mir` asserts a clean typecheck + compile + run; a panic
+        // here is the regression signal. The returned value is ignored —
+        // this gate is about the path not failing, not a fixed output.
+        let _ = run_mir(&src, "main");
         checked += 1;
     }
     assert!(

--- a/tests/vm_spec.rs
+++ b/tests/vm_spec.rs
@@ -72,7 +72,8 @@ fn vm_run(src: &str) -> NanValue {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, globals) =
-        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None)
+            .expect("compile failed");
     let mut machine = vm::VM::new(code, globals, arena);
     machine.run().expect("VM execution failed")
 }
@@ -105,7 +106,8 @@ fn vm_run_with_arena(src: &str) -> (NanValue, Arena) {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, globals) =
-        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None)
+            .expect("compile failed");
     let mut machine = vm::VM::new(code, globals, arena);
     let result = machine.run().expect("VM execution failed");
     let arena = std::mem::replace(&mut machine.arena, Arena::new());
@@ -120,7 +122,8 @@ fn vm_machine(src: &str) -> vm::VM {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, globals) =
-        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None)
+            .expect("compile failed");
     vm::VM::new(code, globals, arena)
 }
 
@@ -132,7 +135,8 @@ fn vm_compile(src: &str) -> vm::CodeStore {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, _globals) =
-        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None)
+            .expect("compile failed");
     code
 }
 
@@ -1600,7 +1604,8 @@ fn vm_effect_violation() {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, globals) =
-        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None)
+            .expect("compile failed");
     let mut machine = vm::VM::new(code, globals, arena);
     let result = machine.run();
     assert!(result.is_err(), "should fail with effect violation");
@@ -1701,7 +1706,8 @@ fn main() -> Result<Unit, String>
         let mut arena = Arena::new();
         let (resolved, symbols) = resolve_for_vm(&items);
         let (code, globals) =
-            vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
+            vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None)
+                .expect("compile failed");
         let mut machine = vm::VM::new(code, globals, arena);
         machine.set_runtime_policy(
             ProjectConfig::parse(&format!("[independence]\nmode = \"{mode}\"\n"))

--- a/tests/vm_spec.rs
+++ b/tests/vm_spec.rs
@@ -72,7 +72,7 @@ fn vm_run(src: &str) -> NanValue {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, globals) =
-        vm::compile_program(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
     let mut machine = vm::VM::new(code, globals, arena);
     machine.run().expect("VM execution failed")
 }
@@ -105,7 +105,7 @@ fn vm_run_with_arena(src: &str) -> (NanValue, Arena) {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, globals) =
-        vm::compile_program(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
     let mut machine = vm::VM::new(code, globals, arena);
     let result = machine.run().expect("VM execution failed");
     let arena = std::mem::replace(&mut machine.arena, Arena::new());
@@ -120,7 +120,7 @@ fn vm_machine(src: &str) -> vm::VM {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, globals) =
-        vm::compile_program(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
     vm::VM::new(code, globals, arena)
 }
 
@@ -132,7 +132,7 @@ fn vm_compile(src: &str) -> vm::CodeStore {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, _globals) =
-        vm::compile_program(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
     code
 }
 
@@ -1600,7 +1600,7 @@ fn vm_effect_violation() {
     let mut arena = Arena::new();
     let (resolved, symbols) = resolve_for_vm(&items);
     let (code, globals) =
-        vm::compile_program(&resolved, &symbols, &mut arena, None).expect("compile failed");
+        vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
     let mut machine = vm::VM::new(code, globals, arena);
     let result = machine.run();
     assert!(result.is_err(), "should fail with effect violation");
@@ -1701,7 +1701,7 @@ fn main() -> Result<Unit, String>
         let mut arena = Arena::new();
         let (resolved, symbols) = resolve_for_vm(&items);
         let (code, globals) =
-            vm::compile_program(&resolved, &symbols, &mut arena, None).expect("compile failed");
+            vm::compile_program_with_mir_fallback(&resolved, &symbols, &mut arena, None).expect("compile failed");
         let mut machine = vm::VM::new(code, globals, arena);
         machine.set_runtime_policy(
             ProjectConfig::parse(&format!("[independence]\nmode = \"{mode}\"\n"))


### PR DESCRIPTION
## What

Step toward **retiring the HIR walker**: stop two major VM test suites from depending on `compile_program` (the pure-HIR entry point), so the walker can be deleted once `mir_vm_parity` is handled too.

### `hir_mir_differential` → MIR golden
The full-pipeline harness compiled each program through **both** `compile_program` (HIR) and `compile_program_with_mir_fallback` (MIR) and asserted the values matched. With the migration proven, it's now a **MIR-only golden** harness: run the MIR path, assert the VM-observable value's `Debug` form against a golden captured while the two walkers were proven equal. The bench-corpus case becomes a **MIR-path smoke gate** (every scenario compiles + runs to a value without panicking).

Independent-implementation cross-validation (values agree on a *second backend*) is provided by the wasm-gc suites (`wasm_gc_spec`, `wasm_gc_codegen_regression`) and `aver verify --wasm-gc` — not by a second VM walker.

### `vm_spec` → production MIR path
All six `compile_program` call sites swap to `compile_program_with_mir_fallback`. These tests assert VM *execution behavior*, not walker internals, so running them through the production (MIR-default) path is strictly better — **114 VM behavior tests now validate the shipped path**.

## Why

After A1–A3 (#331/#332/#333) the HIR fallback never fires on well-formed code, and #334 (`FnValue`) closed the last ordinary shape that dropped. The HIR walker is now a dead second implementation kept alive mainly as a test oracle — circular duplication MIR was meant to kill. This PR removes that oracle role from the two suites where it's a clean swap.

## Scope / not in this PR

`mir_vm_parity.rs` still uses `compile_program`. Its rewrite (runtime tests → golden, bytecode-parity → opcode-presence assertions, and the two HIR-fallback-premised tests) lands **with the walker deletion itself** (next PR), where the fallback becomes a fail-soft `CompileError` and `compile_program` + the `ResolvedExpr` tree-walkers in `calls.rs`/`expr.rs` are removed (the shared leaf/emit helpers `mir.rs` reuses stay).

## Tests

- `hir_mir_differential`: 16 pass (15 goldens + bench smoke)
- `vm_spec`: 114 pass via the MIR path
- full suite green; `clippy -p aver-lang --lib --bin aver --features wasm -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)