### PR TITLE
test: resolve cross-module ctor in eval_spec via dep-preloading (#252 Phase 6)

### DIFF
--- a/tests/eval_spec.rs
+++ b/tests/eval_spec.rs
@@ -2466,31 +2466,16 @@ fn startedAt() -> String
 "#;
         std::fs::write(root.join("App.av"), app_src).expect("write App.av failed");
 
-        // Compile the App module — its source file is already on disk
-        let app_source = std::fs::read_to_string(root.join("App.av")).expect("read App.av");
-        let mut items = parse(&app_source);
-        // Add a test wrapper
-        let test_items = parse("fn __test() -> String\n    startedAt()");
-        items.extend(test_items);
-        tco::transform_program(&mut items);
-        resolve_program(&mut items);
-        let mut arena = Arena::new();
-        vm::register_service_types(&mut arena);
-        let root_str = root.to_str().expect("utf-8");
-        let (resolved, symbols) = super::resolve_for_vm(&items);
-        let (code, globals) = vm::compile_program_with_modules(
-            &resolved,
-            &symbols,
-            &mut arena,
-            Some(root_str),
-            "<test>",
-            None,
-        )
-        .expect("VM compile failed");
-        let mut machine = vm::VM::new(code, globals, arena);
-        machine.run_top_level().expect("top-level failed");
+        // Build via the dep-preloading helper so the unified `SymbolTable`
+        // covers `Domain.Types`' constructors. The fully-qualified ctor in
+        // the pattern then resolves to a `CtorId` — the same shape
+        // production's typechecked path produces. (A bare
+        // `SymbolTable::build(items, &[])` leaves the cross-module ctor
+        // unresolved, which the MIR lowerer can't carry; resolving it up
+        // front is what production always does.)
+        let mut machine = vm_build_with_modules(app_src, &root);
         let out = machine
-            .run_named_function("__test", &[])
+            .run_named_function("startedAt", &[])
             .expect("call failed")
             .to_value(&machine.arena);
         assert_eq!(out, Value::Str("2026-03-08T12:00:00Z".to_string()));


### PR DESCRIPTION
## What

`fully_qualified_imported_constructor_pattern_matches_at_runtime` built its program with `resolve_for_vm` (= `SymbolTable::build(items, &[])`), which leaves the fully-qualified imported constructor `Domain.Types.TaskEvent.TaskStarted` **unresolved** in the match pattern. The HIR walker tolerated that (resolving the ctor by name at runtime); the MIR lowerer can't carry an unresolved ctor pattern, so the test only passed via the HIR fn-body fallback.

Switch it to the `vm_build_with_modules` helper the other multi-module tests already use: it preloads the dependency tree (`load_module_tree` → `SymbolTable::build(&items, &dep_modules)`), so the unified symbol table covers `Domain.Types`' constructors and the qualified ctor resolves to a `CtorId` up front — exactly what production's typechecked path always does.

## Why

Prep for retiring the HIR fn-body walker. After #334/#335/#336, this was the **one** test (out of the whole suite) that relied on the walker's tolerance for under-resolved input — it deliberately bypassed the resolution that production always runs. Aligning it with the dep-preloading path removes that dependency without weakening the test (same program, same assertion, now resolved like production).

Verified the test passes both on the current `main` (fallback present) and under a fail-soft MIR-only dispatch.

## Tests

- `eval_spec`: 224 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)