### PR TITLE
ir/mir,vm: MIR-lower top-level module statements (#252 Phase 6)

### DIFF
--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -156,6 +156,24 @@ pub fn lower_program(items: &[ResolvedTopLevel]) -> MirProgram {
     program
 }
 
+/// Lower a single top-level statement's value expression to MIR.
+///
+/// Top-level module statements (`x = expr` / a bare `expr` at module
+/// scope) aren't part of any `ResolvedFnDef`, so they don't go through
+/// `lower_program`. The VM compiler resolves them on the fly and lowers
+/// each value here against the supplied `program` (whose builtin /
+/// instantiation tables grow consistently with the entry program). The
+/// caller walks the result with the MIR walker and emits the
+/// `STORE_GLOBAL` / `POP` itself, so no MIR-level global-binding node is
+/// needed. Returns `Err(SkipReason)` if the expression is outside the
+/// lowerable subset.
+pub fn lower_top_level_value(
+    value: &Spanned<ResolvedExpr>,
+    program: &mut MirProgram,
+) -> Result<Spanned<MirExpr>, SkipReason> {
+    lower_expr(value, program)
+}
+
 /// Lower one `ResolvedFnDef` if its body fits the supported subset.
 /// Returns `Err(SkipReason)` for the dominant unsupported shape —
 /// the caller drops the fn from the MIR program and records the

--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -88,7 +88,7 @@ pub use expr::{
     MirProject, MirRecordCreate, MirRecordField, MirRecordUpdate, MirStrPart, MirTailCall,
 };
 pub use instantiations::{InstantiationRegistry, discover_instantiations};
-pub use lower::lower_program;
+pub use lower::{lower_program, lower_top_level_value};
 pub use optimize::{
     algebraic_simplify, bool_match_to_if, branch_collapse, const_fold, dead_code,
     inline_nullary_literals,

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -68,6 +68,28 @@ impl From<CompileError> for MirVmUnsupported {
     }
 }
 
+impl MirVmUnsupported {
+    /// Surface a walker rejection as a `CompileError`. `compile_top_level`
+    /// pre-checks every lowered top-level expression with
+    /// `mir_expr_compilable` before committing to the MIR walk, so this
+    /// only fires on the optimistic edge cases `can_compile` reports as
+    /// compilable (e.g. an unknown builtin name) — a real internal error
+    /// rather than a routine fallback.
+    pub(super) fn into_compile_error(self, context: &str) -> CompileError {
+        match self {
+            MirVmUnsupported::InnerError(e) => e,
+            MirVmUnsupported::UnsupportedExpr(what) => CompileError {
+                msg: format!("internal error: VM backend cannot lower `{what}` in {context}"),
+            },
+            MirVmUnsupported::UnsupportedCallee => CompileError {
+                msg: format!(
+                    "internal error: VM backend hit an unsupported callee shape in {context}"
+                ),
+            },
+        }
+    }
+}
+
 /// Walk a `MirExpr` and emit VM bytecode into the supplied
 /// `FnCompiler`. Returns `Err(MirVmUnsupported)` for any MirExpr
 /// variant outside the Phase 4 subset — the caller drops back to
@@ -808,6 +830,15 @@ pub fn classify_mir_program_coverage(mir: &MirProgram) -> MirVmCoverage {
 pub struct MirVmCoverage {
     pub covered: u32,
     pub needs_hir_fallback: u32,
+}
+
+/// Whether the MIR walker can emit bytecode for `expr` without hitting
+/// an `MirVmUnsupported`. Used by `compile_top_level` to pre-check a
+/// batch of lowered top-level value expressions before committing to
+/// the MIR walk, so a mid-emit rejection can't leave half-written
+/// bytecode — it falls back to a clean alternative path instead.
+pub(super) fn mir_expr_compilable(expr: &Spanned<MirExpr>) -> bool {
+    can_compile(expr)
 }
 
 fn can_compile(expr: &Spanned<MirExpr>) -> bool {

--- a/src/vm/compiler/mod.rs
+++ b/src/vm/compiler/mod.rs
@@ -291,7 +291,7 @@ fn compile_program_inner(
         }
     }
 
-    compiler.compile_top_level(items, symbols, arena)?;
+    compiler.compile_top_level(items, symbols, arena, mir_program)?;
     compiler.code.symbols = compiler.symbols.clone();
     classify::classify_thin_functions(&mut compiler.code, arena)?;
 
@@ -878,6 +878,7 @@ impl ProgramCompiler {
         items: &[ResolvedTopLevel],
         symbols: &SymbolTable,
         arena: &mut Arena,
+        mir_program: Option<&crate::ir::mir::MirProgram>,
     ) -> Result<(), CompileError> {
         let has_stmts = items
             .iter()
@@ -895,9 +896,59 @@ impl ProgramCompiler {
         // Top-level statements never went through the resolver pass
         // (Phase E lifts `FnDef` bodies but leaves `TopLevel::Stmt`
         // as passthrough). Resolve them here against the entry's
-        // symbol table so the bytecode-emit walk operates on the
-        // same `ResolvedExpr` shape it does inside fn bodies.
+        // symbol table.
         let resolver_ctx = crate::ir::hir::ResolveCtx::new(symbols);
+        let resolved: Vec<ResolvedStmt> = items
+            .iter()
+            .filter_map(|i| match i {
+                ResolvedTopLevel::Passthrough(TopLevel::Stmt(stmt)) => {
+                    Some(resolve_stmt_for_top_level(&resolver_ctx, stmt))
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Each statement stores its value to a global (`Binding`) or pops
+        // it (`Expr`); compute the store targets up front so the borrow
+        // of `self.global_names` doesn't collide with the `FnCompiler`.
+        let store_targets: Vec<Option<u16>> = resolved
+            .iter()
+            .map(|rs| match rs {
+                ResolvedStmt::Binding { name, .. } => Some(self.global_names[name.as_str()]),
+                ResolvedStmt::Expr(_) => None,
+            })
+            .collect();
+
+        // Try the MIR path: lower every value expression (the builtin /
+        // instantiation tables grow on a clone of the entry program so
+        // the BuiltinId / FnId references match the walker's program),
+        // then pre-check the whole batch with `mir_expr_compilable`. The
+        // walker emits the value; the `STORE_GLOBAL` / `POP` is emitted
+        // here, so no MIR-level global-binding node is needed. If any
+        // statement falls outside the lowerable subset (or there is no
+        // MIR program, i.e. the pure-HIR entry), the whole top-level
+        // block uses the HIR `compile_expr` walk — deciding before any
+        // emit keeps the choice clean.
+        let mut prog = mir_program.cloned().unwrap_or_default();
+        let lowered: Vec<Option<crate::ast::Spanned<crate::ir::mir::MirExpr>>> = if mir_program
+            .is_some()
+        {
+            resolved
+                .iter()
+                .map(|rs| {
+                    let value = match rs {
+                        ResolvedStmt::Binding { value, .. } | ResolvedStmt::Expr(value) => value,
+                    };
+                    crate::ir::mir::lower_top_level_value(value, &mut prog).ok()
+                })
+                .collect()
+        } else {
+            vec![None; resolved.len()]
+        };
+        let use_mir = mir_program.is_some()
+            && lowered
+                .iter()
+                .all(|low| low.as_ref().is_some_and(mir::mir_expr_compilable));
 
         let empty_mod_scope = HashMap::new();
         let mut fc = FnCompiler::new(
@@ -912,24 +963,26 @@ impl ProgramCompiler {
             &mut self.symbols,
             arena,
             symbols,
-            None,
+            if use_mir { Some(&prog) } else { None },
         );
 
-        for item in items {
-            if let ResolvedTopLevel::Passthrough(TopLevel::Stmt(stmt)) = item {
-                let resolved_stmt = resolve_stmt_for_top_level(&resolver_ctx, stmt);
-                match &resolved_stmt {
-                    ResolvedStmt::Binding { name, value, .. } => {
-                        fc.compile_expr(value)?;
-                        let idx = self.global_names[name.as_str()];
-                        fc.emit_op(STORE_GLOBAL);
-                        fc.emit_u16(idx);
-                    }
-                    ResolvedStmt::Expr(value) => {
-                        fc.compile_expr(value)?;
-                        fc.emit_op(POP);
-                    }
+        for (idx, rs) in resolved.iter().enumerate() {
+            if use_mir {
+                let low = lowered[idx].as_ref().expect("pre-checked compilable");
+                mir::compile_mir_expr(&mut fc, low)
+                    .map_err(|e| e.into_compile_error("a top-level statement"))?;
+            } else {
+                let value = match rs {
+                    ResolvedStmt::Binding { value, .. } | ResolvedStmt::Expr(value) => value,
+                };
+                fc.compile_expr(value)?;
+            }
+            match store_targets[idx] {
+                Some(global_idx) => {
+                    fc.emit_op(STORE_GLOBAL);
+                    fc.emit_u16(global_idx);
                 }
+                None => fc.emit_op(POP),
             }
         }
 


### PR DESCRIPTION
## What

Top-level module statements (`x = expr` / a bare `expr` at module scope — the REPL's bread and butter) were the one VM-compile path still wired straight to the HIR `compile_expr` walker. `lower_program` only covers `ResolvedFnDef`, so `compile_top_level` resolved each statement on the fly and walked the `ResolvedExpr` directly.

Route them through the **MIR walker** instead. `compile_top_level` now:
- resolves the statements (unchanged),
- lowers each value expression with the new `lower_top_level_value` (a thin wrapper over `lower_expr`) against a **clone of the entry MIR program**, so the `BuiltinId` / `FnId` references line up with the program the walker resolves against,
- pre-checks the whole batch with `mir_expr_compilable` (exposed from the VM MIR walker), and
- if every value lowers + is compilable, emits via `compile_mir_expr`; otherwise walks the batch with the HIR `compile_expr` path.

The `STORE_GLOBAL` (binding) / `POP` (bare expr) is emitted by `compile_top_level` after the value walk, so **MIR needs no global-binding node**. The all-or-nothing decision happens before any bytecode is emitted, so the fallback never sees half-written output.

## Why

This removes the last **production** caller of `compile_expr` outside the per-fn HIR fallback — a prerequisite for retiring the expression walker (the goal you picked). The pure-HIR `compile_program` entry (no MIR program) keeps using the HIR path via the `mir_program: None` branch.

After this + the eval_spec resolution fix (#337), the only thing still holding `compile_expr` is the per-fn HIR fallback, which the next PR converts to fail-soft before deleting `compile_program` + `compile_fn`/`compile_body`/`compile_stmt` + `compile_expr` + `calls.rs` + `patterns.rs`.

## Tests

Validated by the 10 `eval_spec` top-level-statement tests (record creation / field access / update, sum-type constructors, typed bindings), which compile through the `use_mir=true` entry and now ride the MIR walker. Full suite green; `clippy -p aver-lang --lib --bin aver --features wasm -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)