### PR TITLE
cli,docs: --emit-ir-after=mir dump + 0.24 MIR CHANGELOG (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ## Unreleased
 
+### Added
+
+- **`aver compile FILE --emit-ir-after=mir`** dumps the textual `MirProgram` — every function's body after HIR → MIR lowering and the MIR optimize pipeline. The same diagnostic surface as the other `--emit-ir-after` stages, now reaching the executable middle-end the VM actually runs. `diff` two stages to see exactly what each rewrote.
+- **`aver compile FILE --explain-mir-coverage`** reports how much of a program lowers to MIR (per function, with the dominant blocking shape for any that don't) — the meter used to drive the VM onto MIR.
+
 ### Compiler internals
 
-- **Core MIR scaffolding lands (Phase 1 of #252).** `src/ir/mir/` exists with a doc-comment summary in `mod.rs` and a full design RFC in `RFC.md`. Pinned decisions: `Try` stays a node (no desugar to `match`), `match` stays structured, identity goes through `FnId` / `TypeId` / `CtorId` / `ModuleId`, ProofIR stays separate. No data model yet — Phase 2 lands the enums + textual dump, Phase 3 lands HIR → MIR lowering in waves, Phase 4 wires the VM as the first consumer. The 0.23 stage 8b workaround (`step_fns` side-channel on `ModulePattern::ResultPipelineChain`) is the concrete motivator: with `?` preserved as a `Try` node through MIR, that side-channel goes away in 0.24.
+- **The VM now compiles through Core MIR exclusively — the second codegen path is gone.** Aver grew a canonical mid-level IR (`src/ir/mir/`, design RFC in `RFC.md`): `Try` stays a semantic node (no desugar to `match`), `match` stays structured, identity travels through `FnId` / `TypeId` / `CtorId` / `ModuleId`, and every node carries its type stamp. HIR → MIR lowering covers the full executable expression set; the VM bytecode compiler walks `MirExpr` for every function body, every dependency-module function, and top-level / REPL statements. Once MIR coverage reached 100% of the shipped corpus, the old HIR tree-walking compiler (`compile_expr` plus its call / pattern / record emitters, ~2200 lines) was deleted — a function that can't lower to MIR is now a hard compile error, not a silent fall-back to a second walker. Behavior is unchanged; there is simply one codegen path where there were two. The 0.23 stage 8b workaround (`step_fns` side-channel on `ModulePattern::ResultPipelineChain`) is the concrete motivator: with `?` preserved as a `Try` node through MIR, that side-channel is gone.
 
 ## 0.23.0 "Shape" — 2026-05-30
 

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -3067,8 +3067,15 @@ fn run_bench_dir(dir: &Path, target: aver::bench::BenchTarget, opts: &BenchOptio
 pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, stage_name: &str) {
     use aver::ir::{PipelineConfig, PipelineStage, TypecheckMode, dump};
 
+    // MIR isn't a pipeline stage — it's lowered from the resolved HIR
+    // after the pipeline (the same `lower_program` + optimize the VM
+    // backend runs). Recognise it here, run the pipeline to completion,
+    // and dump the `MirProgram` below.
+    let want_mir = stage_name == "mir";
     let target_stage = match stage_name {
         "parse" => None, // pre-pipeline snapshot
+        // Run the full pipeline so the resolved HIR is available to lower.
+        "mir" => Some(PipelineStage::NameResolve),
         "tco" => Some(PipelineStage::Tco),
         "typecheck" => Some(PipelineStage::Typecheck),
         "interp_lower" => Some(PipelineStage::InterpLower),
@@ -3087,7 +3094,7 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
                 "{}",
                 format!(
                     "unknown --emit-ir-after stage '{}'; expected one of: \
-                     parse, tco, typecheck, interp_lower, buffer_build, resolve, last_use, analyze, escape, build_symbols, name_resolve, refinement_lower, contract_lower, law_lower",
+                     parse, tco, typecheck, interp_lower, buffer_build, resolve, last_use, analyze, escape, build_symbols, name_resolve, refinement_lower, contract_lower, law_lower, mir",
                     other
                 )
                 .red()
@@ -3173,6 +3180,20 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
     {
         eprintln!("{}", super::shared::format_type_errors(&tc.errors).red());
         process::exit(1);
+    }
+
+    // `--emit-ir-after=mir` — lower the resolved HIR to MIR and run the
+    // optimize pipeline (the exact lowering the VM backend consumes),
+    // then print the textual `MirProgram` dump.
+    if want_mir {
+        use aver::ir::mir;
+        let program = mir::dead_code(mir::branch_collapse(mir::bool_match_to_if(
+            mir::algebraic_simplify(mir::const_fold(mir::inline_nullary_literals(
+                mir::lower_program(&pipeline_result.resolved_items),
+            ))),
+        )));
+        print!("{program}");
+        return;
     }
 
     // Proof stages don't transform items — they produce a side


### PR DESCRIPTION
Closes the two remaining #252 Definition-of-Done items that weren't pure release-prep.

## `--emit-ir-after=mir`

#252's DoD lists *"`aver compile --emit-ir-after=mir` works on every shipped example"* — it didn't (MIR wasn't a recognized stage). MIR isn't a pipeline stage; it's lowered from the resolved HIR *after* the pipeline (the same `lower_program` + optimize the VM backend runs). `cmd_emit_ir_after` now special-cases `mir`: run the pipeline to completion, lower `resolved_items`, print the `MirProgram` dump. Behaves exactly like a normal compile — works on every example that compiles, errors where compile errors (the 9 corpus examples it "fails" on are intentionally-broken diagnostics fixtures + module-root mismatches that fail plain `compile` identically).

```
$ aver compile examples/core/hello.av --emit-ir-after=mir
MirProgram {
  // FnId(0)
  fn greet(%0name: Str) -> Str { ... }
  ...
```

## CHANGELOG

The Unreleased "Core MIR" entry described only Phase 1 scaffolding (*"no data model yet — Phase 2 lands…"*) — long stale. Rewritten as the actual 0.24 story: **the VM compiles through MIR exclusively, the HIR tree-walking compiler (~2200 lines) is deleted, one codegen path where there were two.** Plus the two new diagnostics (`--emit-ir-after=mir`, `--explain-mir-coverage`) under **Added**.

## #252 status after this

Technical DoD complete. The only remaining DoD line is *"Codename + tagline chosen (deferred — picked during release prep)"* + the version bump — i.e. #252 is now blocked only on the 0.24 release itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)