### PR TITLE
wasm-gc → MIR, wave 2 (#340): Call(Builtin) registered-helper path + Intrinsic

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -217,6 +217,7 @@ pub(super) fn emit_fn_body(
         effect_idx_lookup,
         caller_fn_collector,
         wasip2_lowering,
+        mir_builtins: None,
     };
 
     for (i, stmt) in stmts.iter().enumerate() {
@@ -356,6 +357,12 @@ pub(super) struct EmitCtx<'a> {
     /// and `wasi:io/streams.[method]output-stream.blocking-write-and-
     /// flush`. Phase 1.2b1.5.
     pub(super) wasip2_lowering: Option<&'a Wasip2Lowering>,
+    /// Phase 5 (#340) — interned built-in fn names from the
+    /// [`crate::ir::mir::MirProgram`] driving the MIR body emitter, so
+    /// `MirCallee::Builtin(BuiltinId)` resolves to its dotted name
+    /// (`program.builtins[id]`). `None` on the `ResolvedExpr` emit
+    /// path, which never reads it (it carries the dotted name inline).
+    pub(super) mir_builtins: Option<&'a [String]>,
 }
 
 /// Concrete fn / global / helper indices the wasip2 call-site

--- a/src/codegen/wasm_gc/body/from_mir.rs
+++ b/src/codegen/wasm_gc/body/from_mir.rs
@@ -84,6 +84,7 @@ pub(crate) fn emit_fn_body_via_mir(
     func: &mut Function,
     rfd: &ResolvedFnDef,
     mir_fn: &MirFn,
+    mir_program: &MirProgram,
     fn_map: &FnMap,
     self_wasm_idx: u32,
     registry: &TypeRegistry,
@@ -125,6 +126,7 @@ pub(crate) fn emit_fn_body_via_mir(
         effect_idx_lookup,
         caller_fn_collector,
         wasip2_lowering,
+        mir_builtins: Some(&mir_program.builtins),
     };
 
     // Walk the body. `Ok(None)` mid-walk → caller falls back.
@@ -305,23 +307,73 @@ fn emit_mir_expr(
                         }
                         Some(entry) => {
                             let wasm_idx = entry.wasm_idx;
-                            for arg in &call.args {
-                                if emit_mir_expr(func, arg, slots, ctx)?.is_none() {
-                                    return Ok(None);
-                                }
+                            if emit_mir_args_then_call(func, &call.args, slots, ctx, wasm_idx)?
+                                .is_none()
+                            {
+                                return Ok(None);
                             }
-                            func.instruction(&Instruction::Call(wasm_idx));
                             Ok(Some(aver_type_str_of(expr).trim() != "Unit"))
                         }
                     }
                 }
-                // Builtin / Intrinsic dispatch is wave 2; first-class
-                // local-slot calls are higher-order (wasm-gc has no
-                // first-class fn lowering). All fall back to the
-                // `ResolvedExpr` emitter for now.
-                MirCallee::Builtin(_) | MirCallee::Intrinsic(_) | MirCallee::LocalSlot { .. } => {
-                    Ok(None)
+                MirCallee::Builtin(id) => {
+                    // Resolve the dotted name lowering interned for this
+                    // `BuiltinId`, then mirror `emit_dotted_builtin`'s
+                    // first branch: a builtin with a registered helper
+                    // wasm fn is just "push args, call $idx". List
+                    // cons/empty (intercepted by the `ResolvedExpr` Call
+                    // arm before `emit_dotted_builtin`) and every custom
+                    // inline lowering (effects, Args.get, Float / List /
+                    // Map / Vector / String, wasip2) are NOT registered
+                    // helpers, so they fall back to the `ResolvedExpr`
+                    // emitter.
+                    // An out-of-range `BuiltinId` is a lowering-invariant
+                    // violation (every `MirCallee::Builtin` is minted via
+                    // `program.intern_builtin`, so `id` always indexes
+                    // `program.builtins`); fall back safely rather than panic.
+                    let Some(dotted) = ctx.mir_builtins.and_then(|names| names.get(id.0 as usize))
+                    else {
+                        return Ok(None);
+                    };
+                    let dotted = dotted.as_str();
+                    if (dotted == "List.prepend" && call.args.len() == 2)
+                        || (dotted == "List.empty" && call.args.is_empty())
+                    {
+                        return Ok(None);
+                    }
+                    match ctx.fn_map.builtins.get(dotted) {
+                        Some(&wasm_idx) => {
+                            if emit_mir_args_then_call(func, &call.args, slots, ctx, wasm_idx)?
+                                .is_none()
+                            {
+                                return Ok(None);
+                            }
+                            Ok(Some(aver_type_str_of(expr).trim() != "Unit"))
+                        }
+                        None => Ok(None),
+                    }
                 }
+                MirCallee::Intrinsic(intr) => {
+                    // Mirror of `emit_expr`'s `Intrinsic` arm: route the
+                    // bare intrinsic name through the registered-builtin
+                    // fast path. (Buffer intrinsics aren't produced on the
+                    // wasm-gc path — it skips `buffer_build` — so this is
+                    // effectively unreachable; kept for parity.)
+                    match ctx.fn_map.builtins.get(intr.name()) {
+                        Some(&wasm_idx) => {
+                            if emit_mir_args_then_call(func, &call.args, slots, ctx, wasm_idx)?
+                                .is_none()
+                            {
+                                return Ok(None);
+                            }
+                            Ok(Some(aver_type_str_of(expr).trim() != "Unit"))
+                        }
+                        None => Ok(None),
+                    }
+                }
+                // First-class local-slot calls are higher-order (wasm-gc
+                // has no first-class fn lowering) → fall back.
+                MirCallee::LocalSlot { .. } => Ok(None),
             }
         }
         MirExpr::TailCall(spanned_tc) => {
@@ -354,6 +406,27 @@ fn emit_mir_expr(
         // `ResolvedExpr` emitter pending a verified byte-identical shape.
         _ => Ok(None),
     }
+}
+
+/// Emit each MIR `arg` (returning `None` if any falls outside the
+/// supported subset, propagated as a whole-fn fallback) then
+/// `call $wasm_idx`. Shared by the `Fn` / `Builtin` / `Intrinsic`
+/// callee arms; the caller adds the `produces_value` read from the
+/// call expr's own type stamp.
+fn emit_mir_args_then_call(
+    func: &mut Function,
+    args: &[Spanned<MirExpr>],
+    slots: &SlotTable,
+    ctx: &EmitCtx<'_>,
+    wasm_idx: u32,
+) -> Result<Option<()>, WasmGcError> {
+    for arg in args {
+        if emit_mir_expr(func, arg, slots, ctx)?.is_none() {
+            return Ok(None);
+        }
+    }
+    func.instruction(&Instruction::Call(wasm_idx));
+    Ok(Some(()))
 }
 
 /// The numeric (`Int` / `Float`) tail of `emit_expr`'s `BinOp` arm —

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -2297,6 +2297,14 @@ pub(super) fn emit_module_with(
     // code-emit loops — all three see the same path per fn, so the
     // discovered locals match the emitted body and caller_fn
     // registration stays consistent.
+    //
+    // Invariant the three `emit_fn_body_via_mir` call sites rely on:
+    // `mir_program == None ⇒ mir_fn_for[i] == None` (the `and_then`
+    // below short-circuits), and `mir_dispatch[i]` is only set `true`
+    // inside `if let Some(mir_fn) = mir_fn_for[i]`. So whenever a site
+    // dispatches to MIR (`mir_dispatch[i]` true, or the pre-pass's
+    // `Some(mir_fn)`), `mir_program` is necessarily `Some` — the
+    // `.expect("MIR dispatch ⇒ program present")` is unreachable.
     let mir_fn_for: Vec<Option<&crate::ir::mir::MirFn>> = resolved_fn_defs
         .iter()
         .map(|rfd| mir_program.as_ref().and_then(|p| p.fn_by_id(rfd.fn_id)))
@@ -2322,6 +2330,9 @@ pub(super) fn emit_module_with(
                 &mut probe,
                 &resolved_fn_defs[i],
                 mir_fn,
+                mir_program
+                    .as_ref()
+                    .expect("MIR dispatch ⇒ program present"),
                 &fn_map,
                 self_wasm_idx,
                 &registry,
@@ -2586,6 +2597,9 @@ pub(super) fn emit_module_with(
                 &mut probe,
                 &resolved_fn_defs[i],
                 mir_fn_for[i].expect("mir_dispatch ⇒ mir_fn_for is Some"),
+                mir_program
+                    .as_ref()
+                    .expect("MIR dispatch ⇒ program present"),
                 &fn_map,
                 self_wasm_idx,
                 &registry,
@@ -2621,6 +2635,9 @@ pub(super) fn emit_module_with(
                 &mut func,
                 &resolved_fn_defs[i],
                 mir_fn_for[i].expect("mir_dispatch ⇒ mir_fn_for is Some"),
+                mir_program
+                    .as_ref()
+                    .expect("MIR dispatch ⇒ program present"),
                 &fn_map,
                 self_wasm_idx,
                 &registry,


### PR DESCRIPTION
Wave 2 of the wasm-gc → MIR body-emitter port (epic #340), on top of waves 0 (#343) and 1 (#344). Lands the **builtin-call seam**.

## What lands (`src/codegen/wasm_gc/body/from_mir.rs`)

- **`Call` with `MirCallee::Builtin(BuiltinId)`** — resolves the dotted name via the `MirProgram`'s interned `builtins` table (threaded into `EmitCtx` as `mir_builtins`) and mirrors `emit_dotted_builtin`'s **first branch**: a builtin backed by a registered helper wasm fn is just "push args, `call $idx`". `List.prepend` / `List.empty` (intercepted by the `ResolvedExpr` Call arm *before* `emit_dotted_builtin`) and every custom inline lowering (effects, `Args.get`, `Float` / `String` / `List` / `Map` / `Vector`, wasip2) are **not** registered helpers → `Ok(None)` fallback to the `ResolvedExpr` emitter.
- **`MirCallee::Intrinsic`** — same registered-helper path keyed by `intr.name()` (buffer intrinsics aren't produced on the wasm-gc path, which skips `buffer_build`, so this is parity-only).
- Shared `emit_mir_args_then_call` factored out, used by the `Fn` / `Builtin` / `Intrinsic` arms.

## Scope honesty: this is the registered-helper *breadth*, not builtin *depth*

The generic registered-helper path covers **+2** corpus fns (32 via MIR, up from 30). Most builtins in the corpus use **custom inline lowering** (`Float` / `String` / `List` / `Map` / `Vector` / effects) — that "depth" (the 19 inline `aver_type_str_of` dispatch sites the plan flagged as the wave-2 (L) risk) is a later sub-wave. The value of *this* PR is the seam + `BuiltinId`→name resolution + the `mir_builtins` threading those waves need, landed byte-identical and low-risk.

## Validation

- Byte-differential: still **48/48** single-file examples byte-identical (MIR on vs off); MIR body emitter renders **32 fns** (real per-fn dispatch count).
- Regression **48/48** validate; clippy `-D warnings` + `cargo fmt --check` clean; `wasm_gc` spec/capture/record-replay pass.
- 15-agent adversarial review: **safe to push**. The three `emit_fn_body_via_mir` `expect("MIR dispatch ⇒ program present")` sites were proved unreachable (`mir_program == None ⇒ mir_fn_for[i] == None`, and `mir_dispatch[i]` is only set under `Some(mir_fn)`); the `BuiltinId` out-of-range fallback is a defensive lowering-invariant guard. Both rationales are now documented in comments. The one open finding is cosmetic (the structural coverage predicate understates builtin coverage — it's diagnostic-only; the byte-differential's real dispatch count is the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)