### PR TITLE
wasm_gc: drop wave/phase scaffolding from MIR-emitter comments

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -357,7 +357,7 @@ pub(super) struct EmitCtx<'a> {
     /// and `wasi:io/streams.[method]output-stream.blocking-write-and-
     /// flush`. Phase 1.2b1.5.
     pub(super) wasip2_lowering: Option<&'a Wasip2Lowering>,
-    /// Phase 5 (#340) — interned built-in fn names from the
+    /// Interned built-in fn names from the
     /// [`crate::ir::mir::MirProgram`] driving the MIR body emitter, so
     /// `MirCallee::Builtin(BuiltinId)` resolves to its dotted name
     /// (`program.builtins[id]`). `None` on the `ResolvedExpr` emit

--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -21,15 +21,15 @@ pub(crate) enum MirBuiltinEmit {
 /// Mirror of the native scalar (`Float` / `Int` / `Bool`) arms of
 /// `emit_dotted_builtin` (builtins.rs): builtins that lower to a fixed
 /// inline wasm instruction sequence over `f64` / `i64` / `i32` values
-/// rather than a registered helper call (so the wave-2 `fn_map.builtins`
-/// lookup misses them and they fell back until now). Each recurses
+/// rather than a registered helper call (so the `fn_map.builtins`
+/// lookup misses them). Each recurses
 /// `emit_mir_expr` on its args — the byte-identical analogue of the
 /// oracle's `emit_expr`. `Int.abs` / `Int.min` / `Int.max` re-emit an
 /// arg more than once (an `if`/`else` select), exactly as the oracle
 /// does; a `None` from any re-emission is a clean whole-fn fallback
 /// (`func` is reset by the caller). `Int.mod` is deliberately absent: it
 /// builds a `Result<Int,String>` carrier and has a fused form, so it
-/// stays on the HIR path for a later sub-wave.
+/// stays on the HIR path.
 pub(crate) fn emit_mir_native_scalar_builtin(
     func: &mut Function,
     dotted: &str,

--- a/src/codegen/wasm_gc/body/from_mir/coverage.rs
+++ b/src/codegen/wasm_gc/body/from_mir/coverage.rs
@@ -6,7 +6,7 @@
 
 use super::*;
 
-/// Wave-0 backend reach over a lowered [`MirProgram`]: how many fns the
+/// Backend reach over a lowered [`MirProgram`]: how many fns the
 /// wasm-gc MIR walker emits standalone vs. how many would fall back to
 /// the `ResolvedExpr` emitter. Mirror of
 /// [`crate::codegen::rust::from_mir::CoverageReport`]; drives
@@ -59,8 +59,8 @@ pub(crate) fn mir_expr_coverable(expr: &Spanned<MirExpr>) -> bool {
         MirExpr::Literal(_) | MirExpr::Local(_) => true,
         MirExpr::BinOp(spanned_binop) => {
             let bop = &spanned_binop.node;
-            // Numeric ops (wave 0) or the `String` concat / eq / compare
-            // ops (wave 12). Compound-type eq helpers fall back.
+            // Numeric ops or the `String` concat / eq / compare ops.
+            // Compound-type eq helpers fall back.
             let numeric = matches!(bop.lhs.ty(), Some(Type::Int) | Some(Type::Float));
             let string_op = aver_type_str_of(&bop.lhs).trim() == "String"
                 && matches!(
@@ -121,7 +121,7 @@ pub(crate) fn mir_expr_coverable(expr: &Spanned<MirExpr>) -> bool {
             // fused-Option fallback — a tolerable over-count, since this
             // only feeds `--explain-mir-coverage`; the real per-fn
             // dispatch is what the wire-up + differential test use).
-            // Tuple arms are wave 4c — not yet covered.
+            // Tuple arms are not yet covered.
             let m = &spanned_match.node;
             let unsupported_pat = m
                 .arms

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -1,210 +1,42 @@
-//! Phase 5 wave 0 — wasm-gc backend consumes MIR.
+//! wasm-gc backend: emit function bodies from Core MIR.
 //!
 //! Mirror of [`super::emit::emit_expr`] that walks
-//! [`crate::ir::mir::MirExpr`] instead of `ResolvedExpr` and emits the
-//! **byte-identical** wasm. The point is the same deduplication #252
-//! Phase 4 brought to the VM and Phase 5 wave 1 brought to the Rust
-//! backend (`crate::codegen::rust::from_mir`): one semantic walker per
-//! construct lives in MIR, and every backend reads it instead of
-//! forking `ResolvedExpr`.
+//! [`crate::ir::mir::MirExpr`] instead of `ResolvedExpr` and emits
+//! **byte-identical** wasm — one semantic walker per construct lives in
+//! MIR, and every backend reads it instead of forking `ResolvedExpr`.
 //!
-//! ## Scope (waves 0–12)
+//! [`emit_mir_expr`] is the dispatcher. Any construct it does not yet
+//! cover returns `Ok(None)`; the caller ([`emit_fn_body_via_mir`]) then
+//! discards `func` and re-runs the `ResolvedExpr` emitter for the whole
+//! function. Coverage therefore widens one construct at a time while the
+//! corpus and games stay green. Two byte-differential tests compile
+//! every single-file example and every multi-module game both ways (MIR
+//! on vs forced off) and assert the modules are identical — the gate
+//! that keeps each mirror exact.
 //!
-//! Wave 0 (the canary):
-//! - `Literal(Int | Float | Bool | Unit | Str)` — mirror of
-//!   `emit_expr`'s literal arms (incl. the `array.new_data` string-
-//!   literal segment path).
-//! - `Local { slot, .. }` — `local.get slot`. The MIR `LocalId` is
-//!   seeded from the resolver's slot index (see
-//!   [`crate::ir::mir::program::LocalId`] doc), so it is the wasm
-//!   local index 1:1, exactly like `ResolvedExpr::Resolved { slot }`.
-//! - `BinOp` (numeric only) — the canary. Dispatches on `bop.lhs.ty()`
-//!   reading the MIR type stamp; `Int`/`Float` take the I64/F64 op set
-//!   `emit_expr` selects via `wasm_type_of`. `Str` and compound-type
-//!   operands return `None` (a later wave does string concat / eq).
-//! - `Neg` — numeric unary minus (`f64.neg` / `i64.const 0; …; i64.sub`).
-//! - `Return` — `… ; return` (never produced by the current lowering,
-//!   carried for symmetry with the Rust walker).
-//! - `Let { binding_name, value, body }` — named bindings emit
-//!   `value` then `local.set slot` (slot from
-//!   `ctx.self_local_slot(name)`), mirroring `emit_fn_body`'s
-//!   `Binding` arm; the tail `body` is the return value. Synthetic
-//!   lets (empty `binding_name`: non-tail `Stmt::Expr` intermediates
-//!   and `_ = expr` discards) return `None` → whole-fn HIR fallback,
-//!   same shape the Rust walker takes.
+//! ## Covered constructs
 //!
-//! Wave 1 (calls):
-//! - `Call` with `MirCallee::Fn(FnId)` — mirror of `emit_expr`'s
-//!   `ResolvedCallee::Fn` arm: `fn_map.by_id` lookup (same `FnId`
-//!   identity), emit args, `call $idx`; a missing entry whose name is a
-//!   local slot emits a polymorphic `unreachable` (higher-order
-//!   verify-only fns), otherwise a hard error. `Builtin` / `Intrinsic`
-//!   / `LocalSlot` callees fall back (later waves).
-//! - `TailCall` — mirror of `emit_tail_call`: emit args, then the
-//!   shared `emit_return_call_insn` (`return_call`, or `call` under
-//!   `AVER_WASM_GC_NO_TAIL_CALL`).
-//! - `FnValue` falls back — higher-order, no first-class fn lowering.
+//! Dispatcher ([`emit_mir_expr`], this module): `Literal`, `Local`
+//! (`local.get` of the resolver slot), numeric `BinOp` / `Neg`,
+//! `Return`, named `Let`, `Call(Fn)` / `TailCall`, and the `Tuple` /
+//! `MapLiteral` literals. Synthetic lets (`_ = expr`, intermediate
+//! `Stmt::Expr`) and higher-order callees (`FnValue`, `LocalSlot`) fall
+//! back. Registered-helper builtins go through the `fn_map.builtins`
+//! lookup here.
 //!
-//! Wave 2 (builtins, breadth only):
-//! - `Call` with `MirCallee::Builtin(BuiltinId)` / `MirCallee::Intrinsic`
-//!   — mirror of `emit_dotted_builtin`'s registered-helper first branch
-//!   (push args, `call $idx`). The dotted name comes from
-//!   `EmitCtx::mir_builtins`. Custom-inline builtins (effects, Args.get,
-//!   Float / String / List / Map / Vector, wasip2) + `List.prepend` /
-//!   `List.empty` fall back — that "depth" is a later sub-wave.
+//! - [`pattern_match`] — `Match` over `Bool` / `Int` / `String`,
+//!   `Option` / `Result` / `List` carriers, and user sum types.
+//! - [`constructors`] — `Construct` (user variants, `Option`, `Result`).
+//! - [`records`] — `RecordCreate` / `RecordUpdate` / `Project`.
+//! - [`collections`] — `List` literals.
+//! - [`builtins`] — the custom-inline `Float` / `Int` / `Bool` scalar
+//!   ops, the `List` and `Vector` families, and the numeric `BinOp` tail.
+//! - [`strings`] — `InterpolatedStr` and the `String` `BinOp` ops.
+//! - [`control`] — `Try` (`?` propagation).
+//! - [`coverage`] — the `--explain-mir-coverage` predicate (diagnostic).
 //!
-//! Wave 3a/3b (primitive-subject match):
-//! - `Match` over a `Bool` subject (a single `if`/`else`), an `Int`
-//!   subject (an `i64.eq` cascade, wildcard required), or a `String`
-//!   subject (subject stashed in the reserved scratch, then a
-//!   `__wasmgc_string_eq` cascade with the first non-literal arm as the
-//!   default) — mirror of `emit_match` / `emit_int_match_cascade` /
-//!   `emit_string_match`. Any constructor / list / tuple arm pattern, or
-//!   a shape `emit_match` rejects outright, falls back. (The dispatch
-//!   checks arm patterns before the subject type, the reverse of
-//!   `emit_match`'s order, but the two are equivalent: typecheck forbids
-//!   a primitive subject from carrying a constructor / list / tuple arm,
-//!   so neither path can reach a branch the other wouldn't.)
-//!
-//! Wave 4a (built-in carrier match):
-//! - `Match` over a `Result<T,E>` or `Option<T>` subject — mirror of
-//!   `emit_result_match` / `emit_option_match`: stash the subject in the
-//!   reserved scratch, test the tag field (struct field 0), and on each
-//!   branch extract the payload (field 1 for `Ok`/`Some`, field 2 for
-//!   `Err`) into the arm's binding slot before emitting the body. A
-//!   wildcard is the `Err` / `None` catch-all. An `Option` match whose
-//!   subject is `Map.get(m, k)` falls back (it has a fused HIR-only
-//!   lowering). User-variant / tuple matches are wave 4c–4d.
-//!
-//! Wave 4b (list match):
-//! - `Match` over a `List<T>` subject (`[] -> …; [head, ..tail] -> …`)
-//!   — mirror of `emit_list_match`: `ref.is_null` selects the empty
-//!   arm, else the cons arm extracts head (struct field 0) + tail
-//!   (field 1) into the `Cons` pattern's binding slots before its body.
-//!   Checked before Result/Option, matching `emit_match`'s order.
-//!
-//! Wave 4d (user-variant / sum-type match):
-//! - `Match` over a user sum type — mirror of `emit_single_variant_match`
-//!   (a single irrefutable `Ctor` arm: newtype-bind / nullary-drop /
-//!   inline `ref.cast` + `struct.get`) and `emit_variant_dispatch` +
-//!   `emit_arm_body` (multi-arm: a `ref.test` cascade over the variant
-//!   struct types, extracting each matched arm's fields from the
-//!   scratch-held subject). `MirCtor::User(CtorId)` resolves to its
-//!   `VariantInfo` via the symbol table + registry, identical to the
-//!   `ctor_dotted_name` lookup. The single-file corpus barely exercises
-//!   this; the multi-module games (`Tile`, `EntityKind`, …) do, and the
-//!   games byte-differential verifies it. Tuple (wave 4c) and the
-//!   multi-arm tuple-of-constructors path still fall back.
-//!
-//! Wave 5a (constructors):
-//! - `Construct` — mirror of `emit_expr`'s `Ctor` arm: user variants via
-//!   `emit_constructor_with_args` (newtype emits the payload directly,
-//!   else push args + `struct.new`), `Option.Some/None` via
-//!   `emit_option_constructor` (tag + payload / `default<T>`), and
-//!   `Result.Ok/Err` via `emit_result_constructor` (instantiation
-//!   resolved by single-registered / return-type / payload-type match,
-//!   then tag + T-slot + E-slot, with a `Unit` position pushing the i32
-//!   placeholder).
-//!
-//! Wave 5b (records):
-//! - `RecordCreate` / `RecordUpdate` — mirror of `emit_record_create` /
-//!   `emit_record_update`: a newtype emits its single field; otherwise
-//!   push every declared field in order (`struct.get` from the base for
-//!   un-overridden update fields) + `struct.new`. The `Option.None` /
-//!   empty-list field special-cases use the field's *declared* type (the
-//!   bare literal's own `.ty()` may be a generic `Var`).
-//! - `Project` — mirror of `emit_attr_get`: newtype `.field` is identity,
-//!   else `struct.get` the field index; unknown / `Invalid`
-//!   (namespace-handle) record types fall back.
-//!
-//! Wave 6a (tuple / map literals):
-//! - `Tuple` — mirror of `emit_tuple_literal`: canonical from the
-//!   elements' stamped types, push each + `struct.new`.
-//! - `MapLiteral` — mirror of `emit_map_literal`: `Map.empty` then a
-//!   `Map.set` per entry (canonical from the first entry's K/V, or the
-//!   sole registered `Map<K,V>` when empty).
-//!
-//! Wave 6b (list literals):
-//! - `List` — mirror of `emit_list_literal`: resolve the `List<T>`
-//!   instantiation (stamped type / first-element hint / sole registered
-//!   / return type), `ref.null` for empty, else push each element +
-//!   `ref.null` + N×`call $cons_T`. `Option.None` / empty-list elements
-//!   emit against the resolved element type.
-//!
-//! Wave 7 (`?` propagation):
-//! - `Try(inner)` — mirror of `emit_error_prop`: stash the
-//!   `Result<T,E>` subject in the reserved scratch, test its tag
-//!   (struct field 0). On `Ok` push the payload (field 1; nothing for a
-//!   `Result<Unit,E>`), on `Err` rebuild a fresh `Result<EnclosingT,E>`
-//!   (tag 0, `default<EnclosingT>`, the subject's err field 2) and
-//!   `return` it so the type matches the enclosing fn. `produces` is
-//!   `false` for a `Result<Unit,E>?`, else `true`.
-//!
-//! Wave 8 (string interpolation):
-//! - `InterpolatedStr(parts)` — mirror of `emit_interpolated_str`
-//!   (builtins.rs): build a `Vector<String>` of the parts and concat it
-//!   with `__wasmgc_concat_n`. Each `Literal` part is an `array.new_data`
-//!   over its segment; each `Expr` part is emitted then stringified by
-//!   the `String.from{Int,Float,Bool}` dispatch (`String` is identity).
-//!   An empty interpolation allocates a zero-length array directly. A
-//!   compound-type `Expr` part — which the oracle rejects — falls back
-//!   so the resolved-HIR path raises the identical error. The wasm-gc
-//!   pipeline runs with `run_buffer_build = false`, so interpolation
-//!   survives to MIR as `InterpolatedStr` (it is not deforested into
-//!   buffer-write intrinsics); this wave covers it on the seam path.
-//!
-//! Wave 9 (native scalar builtins — first builtin-inline-depth slice):
-//! - `Call` with `MirCallee::Builtin` whose dotted name is a native
-//!   scalar `Float` / `Int` / `Bool` op — mirror of the inline arms of
-//!   `emit_dotted_builtin`: `Float.{fromInt,floor,ceil,round,abs,sqrt,
-//!   min,max,pi}`, `Int.{fromFloat,abs,min,max}`, `Bool.{and,or,not}`.
-//!   These lower to a fixed `f64` / `i64` / `i32` instruction sequence
-//!   (not a registered helper), so the wave-2 `fn_map.builtins` lookup
-//!   missed them. The new `emit_mir_native_scalar_builtin` is tried
-//!   before that lookup; un-recognized builtins fall through to it
-//!   unchanged. `Int.mod` (a `Result` carrier with a fused form) and the
-//!   `Vector` custom-inline family are later builtin sub-waves.
-//!
-//! Wave 10 (`List` custom-inline builtins):
-//! - `Call` with `MirCallee::Builtin` whose dotted name is a `List` op —
-//!   `emit_mir_list_builtin`, mirror of the custom-inline `List.*` arms
-//!   of `emit_dotted_builtin` plus the `List.prepend` / `List.empty`
-//!   intercepts in `emit_expr`'s `Call` arm. `reverse` / `len` /
-//!   `length` / `concat` / `take` / `drop` / `contains` dispatch to the
-//!   per-`List<T>` `fn_map.list_ops` helper; `zip` to `zip_ops`,
-//!   `fromVector` to `vfl_ops`; `prepend` is a `struct.new $list_T`,
-//!   `empty` a `ref.null $list_T`. `contains` over a non-eq-able `T`
-//!   (no registered helper) falls back. Tried after the native-scalar
-//!   path and before the `fn_map.builtins` lookup (none of these are in
-//!   that table).
-//!
-//! Wave 11 (`Vector` custom-inline builtins):
-//! - `Call` with `MirCallee::Builtin` whose dotted name is a `Vector`
-//!   op — `emit_mir_vector_builtin`, mirror of the custom-inline
-//!   `Vector.*` arms: `len` / `new` / `fromList` inline, the boxed
-//!   `get` (bounds-checked `Option<T>`) and `set` (`Option<Vector<T>>`,
-//!   in-place fast path when `mir_arg_uniquely_owned` — the MIR analogue
-//!   of `arg_uniquely_owned`, keyed on `MirLocal.last_use` — else a
-//!   clone-on-write through the scratch local). The fused
-//!   `Option.withDefault(Vector.get/set, …)` shapes are not reached:
-//!   `Option.withDefault` is uncovered, so a fused call falls the whole
-//!   fn back before its inner `Vector` op.
-//!
-//! Wave 12 (`String` binary ops):
-//! - `BinOp` with a `String` LHS — `emit_mir_string_binop`, mirror of
-//!   the `String` branches of `emit_expr`'s `BinOp` arm: `+` is
-//!   `__wasmgc_concat_n` over a 2-element `Vector<String>`, `==` / `!=`
-//!   is `__wasmgc_string_eq` (+ `i32.eqz` for `!=`), and `<` / `>` /
-//!   `<=` / `>=` is `__wasmgc_string_compare` post-composed with the
-//!   matching `i32` comparison against `0`. Checked before the numeric
-//!   branch, exactly as the oracle orders it. Compound-type `==` / `!=`
-//!   (nullary-variant `ref.test`, sum / record `__eq_*` helpers) still
-//!   fall back.
-//!
-//! Everything else returns `Ok(None)` so the caller
-//! ([`super::emit_fn_body_via_mir`]) resets `func` and re-runs the
-//! `ResolvedExpr` emitter for the whole fn. That keeps the corpus +
-//! game suite green from PR 1 while coverage widens wave by wave.
+//! Each submodule documents the exact `emit_expr` helper it mirrors and
+//! the shapes that still fall back to the `ResolvedExpr` emitter.
 
 pub(super) use std::collections::{HashMap, HashSet};
 
@@ -282,10 +114,8 @@ pub(crate) fn emit_fn_body_via_mir(
     // parallel type table. Source it from the HIR `rfd`, NOT from
     // `mir_fn` — `EmitCtx` is shared with the `ResolvedExpr` emitter and
     // its recognition (`classify_leaf_op` / `classify_call_plan`) keys
-    // off resolver-assigned names. Wave 0 never reaches that recognition
-    // (no covered arm reads `binding_names`), but a later Call-coverage
-    // wave will, and must keep this HIR-sourced — do not repopulate it
-    // from `MirExpr`.
+    // off resolver-assigned names, so this set must stay HIR-sourced —
+    // do not repopulate it from `MirExpr`.
     let ResolvedFnBody::Block(stmts) = rfd.body.as_ref();
     let mut binding_names: HashSet<String> = HashSet::new();
     for s in stmts {
@@ -392,11 +222,10 @@ pub(crate) fn emit_mir_expr(
         }
         MirExpr::BinOp(spanned_binop) => {
             let bop = &spanned_binop.node;
-            // Read the operand type from the MIR type stamp — the
-            // canary for the whole port. Aver's checker proved both
-            // operands share a type, so the LHS suffices. `String`
-            // operands take the dedicated concat / eq / compare builtins
-            // (wave 12); numeric operands the primitive op set (wave 0);
+            // Read the operand type from the MIR type stamp. Aver's
+            // checker proved both operands share a type, so the LHS
+            // suffices. `String` operands take the dedicated concat / eq
+            // / compare builtins; numeric operands the primitive op set;
             // compound types (variant / record eq helpers) fall back.
             if aver_type_str_of(&bop.lhs).trim() == "String" {
                 return match emit_mir_string_binop(func, bop, slots, ctx)? {

--- a/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
+++ b/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
@@ -4,10 +4,11 @@
 
 use super::*;
 
-/// Mirror of `emit_match` (emit.rs) for the wave-3a primitive-subject
-/// shapes: `Bool` (a single `if`/`else`) and `Int` (an `i64.eq`
-/// cascade). Any arm carrying a constructor / list / tuple pattern is
-/// wave 4 → `Ok(None)` (whole-fn fallback). `String`-subject matches
+/// Mirror of `emit_match` (emit.rs) for the primitive-subject shapes:
+/// `Bool` (a single `if`/`else`) and `Int` (an `i64.eq` cascade). Any
+/// arm carrying a constructor / list / tuple pattern is routed to the
+/// carrier / list / variant paths below (tuple falls back).
+/// `String`-subject matches
 /// (which need the reserved subject scratch + `__wasmgc_string_eq`) and
 /// any other subject type also fall back. Shapes `emit_match` rejects
 /// outright (a `Bool` match without exactly 2 true/false/wildcard arms,
@@ -23,10 +24,9 @@ pub(crate) fn emit_mir_match(
     if m.arms.is_empty() {
         return Err(WasmGcError::Validation("match has no arms".into()));
     }
-    // Tuple arms are wave 4c (single-arm destructure) / the multi-arm
-    // tuple-of-constructors path — both still fall back. List (4b),
-    // built-in `Result` / `Option` (4a), and user-variant (4d)
-    // constructor patterns are handled below.
+    // Tuple arms (single-arm destructure / multi-arm tuple-of-
+    // constructors) still fall back. List, built-in `Result` / `Option`,
+    // and user-variant constructor patterns are handled below.
     if m.arms
         .iter()
         .any(|a| matches!(a.pattern, MirPattern::Tuple(_)))
@@ -316,9 +316,9 @@ pub(crate) fn arm_is_mir_option_ctor(arm: &MirMatchArm) -> bool {
 }
 
 /// `true` when `subject` is `Map.get(m, k)` — the fused-match shape
-/// `emit_match` lowers without allocating an `Option<V>`. Deferred
-/// (wave 4a falls back) so the plain Option-match emit can't diverge
-/// from `emit_map_get_match_fused`.
+/// `emit_match` lowers without allocating an `Option<V>`. This shape
+/// falls back so the plain Option-match emit can't diverge from
+/// `emit_map_get_match_fused`.
 pub(crate) fn subject_is_map_get(subject: &Spanned<MirExpr>, ctx: &EmitCtx<'_>) -> bool {
     if let MirExpr::Call(call) = &subject.node
         && let MirCallee::Builtin(id) = call.node.callee

--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -156,7 +156,7 @@ pub fn compile_to_wasm_gc(
     module::emit_module_with(items, None, TargetMode::AverBridge, true).map(|(bytes, _)| bytes)
 }
 
-/// `compile_to_wasm_gc` with an explicit MIR toggle — Phase 5 #340.
+/// `compile_to_wasm_gc` with an explicit MIR toggle.
 /// `enable_mir == true` is the production path (`compile_to_wasm_gc`):
 /// the MIR body emitter runs per-fn with a `ResolvedExpr` fallback.
 /// `enable_mir == false` forces the `ResolvedExpr` emitter everywhere.

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -2271,12 +2271,12 @@ pub(super) fn emit_module_with(
     });
 
     // Lower the post-link resolved fns to MIR for the MIR-preferred
-    // body emitter (Phase 5 #340). `lower_program` runs no optimizer
-    // passes, so the MIR mirrors the resolved HIR shape 1:1 — the
-    // body walk that follows emits byte-identical wasm to the
-    // `ResolvedExpr` emitter for the variants it covers, and returns
-    // `None` (whole-fn fallback) for everything else, keeping the
-    // corpus + game suite green while coverage widens wave by wave.
+    // body emitter. `lower_program` runs no optimizer passes, so the
+    // MIR mirrors the resolved HIR shape 1:1 — the body walk that
+    // follows emits byte-identical wasm to the `ResolvedExpr` emitter
+    // for the variants it covers, and returns `None` (whole-fn
+    // fallback) for everything else, keeping the corpus + game suite
+    // green while MIR coverage widens.
     // `enable_mir == false` forces the `ResolvedExpr` path everywhere;
     // the byte-differential test (`tests/wasm_gc_differential_mir.rs`)
     // compiles both ways and asserts the emitted fn bytes match.


### PR DESCRIPTION
The `from_mir` comments narrated the migration chronology — "Phase 5 wave N", "the canary", "#340", "for a later sub-wave" — which is process scaffolding, not a description of what the code does.

## What

- Rewrote the `from_mir/mod.rs` doc-header: the 200-line wave-by-wave "Scope (waves 0–12)" section is replaced with a concise **Covered constructs** overview organised by category, pointing at the domain submodules. Keeps the architectural intro (mirror of `emit_expr`, fallback mechanism, differential gate); drops the chronology.
- Stripped `wave` / `canary` / `Phase 5` / `#340` / "later sub-wave" tags from the inline comments across `pattern_match.rs`, `builtins.rs`, `coverage.rs`, and the seam (`body.rs`, `module.rs`, `mod.rs`). Comments now say which `emit_expr` helper each path mirrors and what falls back.
- Fixed an intra-doc link (`super::super::emit` → `super::emit`) introduced by the header rewrite.

## Safety

Comment-only change:
- single-file byte-differential: **365** fns, all 48 examples byte-identical (unchanged);
- games byte-differential: **549** fns, all 4 games byte-identical (unchanged);
- 48-example `wasmparser` regression validates;
- `cargo clippy --features wasm -D warnings` + `cargo fmt --check` clean.

(The Rust backend's `codegen/rust/from_mir.rs` carries the same kind of wave references — left out of scope here; can follow if wanted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)