### PR TITLE
wasm_gc: fix from_mir comment accuracy flagged by review

### DIFF
--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -295,7 +295,7 @@ pub(crate) fn emit_mir_list_builtin(
 /// MIR analogue of `EmitCtx::arg_uniquely_owned` (body.rs). The
 /// ownership fast-path key — `last_use` on a non-alias-prone local — is
 /// carried verbatim on `MirLocal` (the lowerer copies it from
-/// `ResolvedExpr::Resolved { last_use }`, see `lower.rs`), and
+/// `ResolvedExpr::Resolved { last_use }`, see `crate::ir::mir::lower`), and
 /// `is_aliased_slot` reads the same resolver `aliased_slots` table, so
 /// this returns the identical verdict to the HIR oracle for the same
 /// source expression. Anonymous / transient args are uniquely owned.
@@ -621,7 +621,3 @@ pub(crate) fn emit_mir_numeric_binop(
     func.instruction(&inst);
     Ok(Some(()))
 }
-
-// ---------------------------------------------------------------------------
-// Coverage diagnostic (mirrors `crate::codegen::rust::from_mir`)
-// ---------------------------------------------------------------------------

--- a/src/codegen/wasm_gc/body/from_mir/coverage.rs
+++ b/src/codegen/wasm_gc/body/from_mir/coverage.rs
@@ -120,8 +120,9 @@ pub(crate) fn mir_expr_coverable(expr: &Spanned<MirExpr>) -> bool {
             // predicate has no registry, so it can't model the Map.get
             // fused-Option fallback — a tolerable over-count, since this
             // only feeds `--explain-mir-coverage`; the real per-fn
-            // dispatch is what the wire-up + differential test use).
-            // Tuple arms are not yet covered.
+            // dispatch in `emit_mir_match` is what the byte-differential
+            // test checks). Tuple-pattern arms fall back to the
+            // `ResolvedExpr` emitter (mirror of `emit_mir_match`).
             let m = &spanned_match.node;
             let unsupported_pat = m
                 .arms

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -5,11 +5,10 @@
 //! **byte-identical** wasm — one semantic walker per construct lives in
 //! MIR, and every backend reads it instead of forking `ResolvedExpr`.
 //!
-//! [`emit_mir_expr`] is the dispatcher. Any construct it does not yet
-//! cover returns `Ok(None)`; the caller ([`emit_fn_body_via_mir`]) then
+//! [`emit_mir_expr`] is the dispatcher. Any construct it does not cover
+//! returns `Ok(None)`; the caller ([`emit_fn_body_via_mir`]) then
 //! discards `func` and re-runs the `ResolvedExpr` emitter for the whole
-//! function. Coverage therefore widens one construct at a time while the
-//! corpus and games stay green. Two byte-differential tests compile
+//! function. Two byte-differential tests compile
 //! every single-file example and every multi-module game both ways (MIR
 //! on vs forced off) and assert the modules are identical — the gate
 //! that keeps each mirror exact.
@@ -18,8 +17,9 @@
 //!
 //! Dispatcher ([`emit_mir_expr`], this module): `Literal`, `Local`
 //! (`local.get` of the resolver slot), numeric `BinOp` / `Neg`,
-//! `Return`, named `Let`, `Call(Fn)` / `TailCall`, and the `Tuple` /
-//! `MapLiteral` literals. Synthetic lets (`_ = expr`, intermediate
+//! `Return`, named `Let`, `Call(Fn)` / `TailCall`, `Project` (mirroring
+//! `emit_attr_get`), and the `Tuple` / `MapLiteral` literals. Synthetic
+//! lets (`_ = expr`, intermediate
 //! `Stmt::Expr`) and higher-order callees (`FnValue`, `LocalSlot`) fall
 //! back. Registered-helper builtins go through the `fn_map.builtins`
 //! lookup here.
@@ -27,7 +27,7 @@
 //! - [`pattern_match`] — `Match` over `Bool` / `Int` / `String`,
 //!   `Option` / `Result` / `List` carriers, and user sum types.
 //! - [`constructors`] — `Construct` (user variants, `Option`, `Result`).
-//! - [`records`] — `RecordCreate` / `RecordUpdate` / `Project`.
+//! - [`records`] — `RecordCreate` / `RecordUpdate`.
 //! - [`collections`] — `List` literals.
 //! - [`builtins`] — the custom-inline `Float` / `Int` / `Bool` scalar
 //!   ops, the `List` and `Vector` families, and the numeric `BinOp` tail.
@@ -596,9 +596,12 @@ pub(crate) fn emit_mir_expr(
         },
         MirExpr::Try(inner) => emit_mir_try(func, inner, slots, ctx),
         MirExpr::InterpolatedStr(parts) => emit_mir_interpolated_str(func, parts, slots, ctx),
-        // FnValue (a fn referenced as a value) is higher-order — wasm-gc
-        // has no first-class fn representation — so it falls back to the
-        // `ResolvedExpr` emitter pending a verified byte-identical shape.
+        // Catch-all fallback to the `ResolvedExpr` emitter. Reaches here:
+        // `FnValue` (a fn referenced as a value — wasm-gc has no
+        // first-class fn representation) and `IndependentProduct`
+        // (`(a, b, c)?!`). `IfThenElse` would too, but only the
+        // `bool_match_to_if` optimizer produces it and this path's
+        // `lower_program` runs no optimizer passes, so it never arrives.
         _ => Ok(None),
     }
 }

--- a/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
+++ b/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
@@ -5,12 +5,13 @@
 use super::*;
 
 /// Mirror of `emit_match` (emit.rs) for the primitive-subject shapes:
-/// `Bool` (a single `if`/`else`) and `Int` (an `i64.eq` cascade). Any
-/// arm carrying a constructor / list / tuple pattern is routed to the
-/// carrier / list / variant paths below (tuple falls back).
-/// `String`-subject matches
-/// (which need the reserved subject scratch + `__wasmgc_string_eq`) and
-/// any other subject type also fall back. Shapes `emit_match` rejects
+/// `Bool` (a single `if`/`else`) and `Int` (an `i64.eq` cascade). An
+/// arm carrying a constructor or list pattern is routed to the carrier
+/// / list / variant paths below; a tuple pattern falls back (handled by
+/// the `ResolvedExpr` emitter, not here). `String`-subject matches go to
+/// `emit_mir_string_match` below (which uses the reserved subject
+/// scratch + `__wasmgc_string_eq`); any other subject type falls back.
+/// Shapes `emit_match` rejects
 /// outright (a `Bool` match without exactly 2 true/false/wildcard arms,
 /// an `Int` match without a wildcard, a bind pattern on a primitive
 /// subject) return `Ok(None)` here — the `ResolvedExpr` emitter then

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -2275,8 +2275,8 @@ pub(super) fn emit_module_with(
     // MIR mirrors the resolved HIR shape 1:1 — the body walk that
     // follows emits byte-identical wasm to the `ResolvedExpr` emitter
     // for the variants it covers, and returns `None` (whole-fn
-    // fallback) for everything else, keeping the corpus + game suite
-    // green while MIR coverage widens.
+    // fallback) for everything else, so the corpus + game suite stay
+    // green over whatever subset of variants the body walk covers.
     // `enable_mir == false` forces the `ResolvedExpr` path everywhere;
     // the byte-differential test (`tests/wasm_gc_differential_mir.rs`)
     // compiles both ways and asserts the emitted fn bytes match.


### PR DESCRIPTION
A multi-agent re-read of the just-cleaned `from_mir` comments (per-module reviewers checking each comment **against the code**) surfaced three comments that misdescribe the code, plus leftover process framing. This fixes them.

## Inaccurate (lying / mis-attributing comments)

1. **`pattern_match.rs`** — the `emit_mir_match` doc claimed `String`-subject matches *fall back*. They don't: they're dispatched to `emit_mir_string_match` (a native impl in the same file). Reworded to say so.
2. **`mod.rs` header** — `Project` was listed under the `records` submodule, but `records.rs` only implements `RecordCreate` / `RecordUpdate`; `Project` is lowered **inline in the dispatcher** (mirror of `emit_attr_get`). Moved `Project` to the dispatcher's construct list, dropped it from the records bullet.
3. **`mod.rs` catch-all** — the `_ => Ok(None)` comment named only `FnValue`, but `IndependentProduct` also lands there. (`IfThenElse` would too, but the `bool_match_to_if` optimizer that produces it never runs on this path's `lower_program`, so it never arrives — now stated correctly rather than implied reachable.)

## Awkward / residual scaffolding / nits

- Reworded the self-contradicting `"routed to the … paths below (tuple falls back)"` clause.
- Deleted the orphaned `"Coverage diagnostic"` banner left at the tail of `builtins.rs` by the module split (the coverage code lives in `coverage.rs`).
- Replaced `"the wire-up"`, `"not yet covered"`, `"pending a verified byte-identical shape"`, and `"while MIR coverage widens"` with steady-state descriptions (no forward-looking chronology).
- Qualified a bare `lower.rs` reference to `crate::ir::mir::lower`.

## Safety

Comment-only change:
- single-file byte-differential **365** fns, all 48 examples byte-identical (unchanged);
- games byte-differential **549** fns, all 4 games byte-identical (unchanged);
- 48-example `wasmparser` regression validates; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)