### PR TITLE
test/wasm_gc: MIR-coverage regression floor (review #3)

### DIFF
--- a/tests/wasm_gc_differential_mir.rs
+++ b/tests/wasm_gc_differential_mir.rs
@@ -1,4 +1,4 @@
-//! wasm-gc MIR body-emitter byte-differential (Phase 5 #340 wave 0).
+//! wasm-gc MIR body-emitter byte-differential.
 //!
 //! For every single-file `examples/**/*.av` program, compile it twice
 //! through `compile_to_wasm_gc_mir_toggle`:
@@ -14,19 +14,18 @@
 //! (Whole-module byte-identity across two independent builds is only
 //! meaningful because the type registry's carrier-slot ordering is
 //! deterministic; this test therefore also guards that determinism.)
-//! This is the safety net the port leans on: it lets each wave widen
-//! coverage knowing a divergence is caught mechanically, not by
-//! eyeballing wasm.
+//! This is the safety net the port leans on: a divergence is caught
+//! mechanically, not by eyeballing wasm.
 //!
-//! A second check proves the MIR walk actually fires somewhere in the
-//! corpus (otherwise byte-identity would hold vacuously with zero MIR
-//! coverage): `compile_to_wasm_gc_mir_toggle` returns how many fns the
-//! body emitter *actually rendered* from MIR — the real
-//! `emit_fn_body_via_mir` Some/None decision the seam fixed, not the
-//! structural `coverage_report` predicate — and the test asserts that
-//! count is non-zero. Keying the canary off the emitter rather than the
-//! predicate means an over-conservative predicate can't make this pass
-//! vacuously.
+//! A second check holds a coverage floor so byte-identity can't pass
+//! vacuously with zero MIR coverage, and so a covered construct
+//! silently regressing to the HIR fallback fails CI:
+//! `compile_to_wasm_gc_mir_toggle` returns how many fns the body emitter
+//! *actually rendered* from MIR — the real `emit_fn_body_via_mir`
+//! Some/None decision the seam makes, not the structural
+//! `coverage_report` predicate — and the test asserts that count stays
+//! at or above the floor. Keying it off the emitter rather than the
+//! predicate means an over-conservative predicate can't move it.
 
 #![cfg(feature = "wasm-compile")]
 
@@ -178,16 +177,21 @@ fn mir_and_resolved_body_emitters_agree_byte_for_byte() {
         );
     }
 
-    // Canary: byte-identity is meaningless if the MIR body emitter never
-    // fired. This counts the *real* per-fn MIR dispatch the seam made
-    // (the `emit_fn_body_via_mir` Some/None decision), not the structural
-    // coverage predicate — so an over-conservative predicate can't make
-    // it pass vacuously. Wave 0 covers Literal / Local / numeric BinOp /
-    // Neg / Return / named Let, so the corpus must surface at least one.
+    // Coverage floor. Byte-identity is meaningless if the MIR body
+    // emitter never fired, so this counts the *real* per-fn MIR dispatch
+    // the seam made (the `emit_fn_body_via_mir` Some/None decision), not
+    // the structural coverage predicate — an over-conservative predicate
+    // can't make it pass vacuously. The floor is the gate the review
+    // asked for: a drop below it (a covered construct silently regressing
+    // to the HIR fallback) fails CI rather than passing quietly. Raise
+    // `MIN_MIR_EMITTED` when new coverage lands; never lower it without a
+    // deliberate reason.
+    const MIN_MIR_EMITTED: usize = 365;
     assert!(
-        total_mir_emitted > 0,
-        "MIR body emitter rendered 0 fns across {compared} examples — byte-identity is vacuous; \
-         the wave-0 emitter or the seam dispatch regressed"
+        total_mir_emitted >= MIN_MIR_EMITTED,
+        "MIR body emitter rendered {total_mir_emitted} fns across {compared} examples, \
+         below the floor of {MIN_MIR_EMITTED} — MIR coverage regressed (a covered construct \
+         fell back to the `ResolvedExpr` emitter). If this drop is intentional, lower the floor."
     );
 
     eprintln!(

--- a/tests/wasm_gc_games_differential_mir.rs
+++ b/tests/wasm_gc_games_differential_mir.rs
@@ -19,8 +19,8 @@
 //! many fns the MIR emitter actually rendered, so the identity check
 //! can't pass vacuously with the MIR path dead on the flattened game.
 //!
-//! This is the gate that verifies every later match wave (variant /
-//! record / collection) byte-for-byte on the shapes that exercise them.
+//! This is the gate that verifies the richer shapes (variant / record /
+//! collection / Vector) byte-for-byte on the programs that exercise them.
 
 #![cfg(feature = "wasm")]
 
@@ -172,11 +172,17 @@ fn mir_and_resolved_emitters_agree_byte_for_byte_on_games() {
         );
     }
 
-    // Non-vacuous: the MIR emitter must actually render fns on the
-    // flattened games (else byte-identity is meaningless).
+    // Coverage floor on the flattened games (richer shapes than the
+    // single-file corpus: variant / record / collection / Vector). A
+    // drop below the floor means a covered construct silently regressed
+    // to the HIR fallback — fail CI rather than pass quietly. Raise
+    // `MIN_MIR_EMITTED` when new coverage lands; never lower it without
+    // a deliberate reason.
+    const MIN_MIR_EMITTED: usize = 549;
     assert!(
-        total_mir_emitted > 0,
-        "MIR emitter rendered 0 fns across {compared} games — byte-identity is vacuous"
+        total_mir_emitted >= MIN_MIR_EMITTED,
+        "MIR emitter rendered {total_mir_emitted} fns across {compared} games, below the floor \
+         of {MIN_MIR_EMITTED} — MIR coverage regressed. If this drop is intentional, lower the floor."
     );
 
     let _ = fs::remove_dir_all(&tmp);


### PR DESCRIPTION
Implements the review's point #3: don't let MIR coverage silently regress, and don't rest any gate on the approximate `coverage_report` predicate.

## What

The two byte-differential tests asserted only that the MIR body emitter rendered **>0** fns (non-vacuity). This raises that to a **coverage floor**:

```rust
const MIN_MIR_EMITTED: usize = 365;  // single-file
const MIN_MIR_EMITTED: usize = 549;  // games
```

If a covered construct silently falls back to the `ResolvedExpr` emitter, the rendered count drops below the floor and CI goes red — instead of byte-identity passing quietly with reduced coverage.

The count is the **real** per-fn `emit_fn_body_via_mir` `Some`/`None` decision (the seam's actual dispatch), not the structural `coverage_report` predicate — so no gate depends on that approximate predicate. `>=` lets coverage grow without editing the test; the floor is raised deliberately when a wave lands.

Also dropped the stale wave/phase references from the two test doc-headers.

## Verification

Tests pass at the floor — single-file **365**, games **549**, all byte-identical (unchanged). `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)