### PR TITLE
wasm_gc: AVER_WASMGC_REQUIRE_MIR diagnostic mode (review #2)

### DIFF
--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -2386,6 +2386,29 @@ pub(super) fn emit_module_with(
         };
         mir_dispatch[i] = used_mir;
     }
+
+    // `AVER_WASMGC_REQUIRE_MIR=1` turns the per-fn HIR fallback into a
+    // hard error that lists every fn which did NOT emit from MIR — the
+    // graduation worklist (what still falls back), keyed off the real
+    // `mir_dispatch` decision, not the approximate coverage predicate.
+    // Diagnostic / development only: the production path leaves it unset
+    // and falls back silently.
+    if enable_mir && std::env::var_os("AVER_WASMGC_REQUIRE_MIR").is_some() {
+        let fell_back: Vec<&str> = (0..mir_dispatch.len())
+            .filter(|&i| !mir_dispatch[i])
+            .map(|i| resolved_fn_defs[i].name.as_str())
+            .collect();
+        if !fell_back.is_empty() {
+            return Err(WasmGcError::Validation(format!(
+                "AVER_WASMGC_REQUIRE_MIR: {} of {} fns fell back to the ResolvedExpr emitter \
+                 (not yet covered by the MIR body emitter): {}",
+                fell_back.len(),
+                mir_dispatch.len(),
+                fell_back.join(", ")
+            )));
+        }
+    }
+
     let caller_fn_segment_count = caller_fn_collector.borrow().names.len() as u32;
 
     // ── Data count section (must precede code when using passive


### PR DESCRIPTION
Implements the review's point #2 ("force MIR, then remove HIR paths piece by piece") as a diagnostic env var.

## What

`AVER_WASMGC_REQUIRE_MIR=1` turns the per-fn HIR fallback into a hard error that **lists every fn which did not emit from MIR**:

```
$ AVER_WASMGC_REQUIRE_MIR=1 aver compile examples/services/redis.av --target wasm-gc
... AVER_WASMGC_REQUIRE_MIR: 11 of 24 fns fell back to the ResolvedExpr emitter
    (not yet covered by the MIR body emitter): respBulkLen, sendArgAndRest,
    sendCommand, connect, disconnect, ping, set, get, del, run, main
```

The list is keyed off the **real** per-fn `mir_dispatch` decision (the actual `emit_fn_body_via_mir` `Some`/`None`), not the approximate `coverage_report` predicate — so it's the accurate graduation worklist of what still falls back, and the input for closing the remaining fallbacks one construct at a time.

## Notes

- Diagnostic / development only. The production path leaves the var unset and falls back silently; the whole block is behind the env check, so normal emit is **byte-identical** (365 single-file / 549 games unchanged).
- The suite-level regression guard stays the coverage **floor** in the byte-differential tests (#365); this is the complementary *find-the-fallbacks* tool.
- Consistent with the existing internal env vars (`AVER_WASMGC_FORCE_NO_MIR`, `AVER_WASMGC_MIR_COUNT`); not user-facing, so no CHANGELOG entry.

## Safety

`cargo clippy --features wasm -D warnings` clean; single-file **365** and games **549** still byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)