### PR TITLE
fix: own_param must not un-flag a Vector/Map param aliased into an aggregate

### DIFF
--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -92,6 +92,37 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
         return program;
     }
 
+    // Aggregate-capture aliasing. A slot whose value is stored DIRECTLY
+    // into an aggregate (record / record-update / variant / tuple / list /
+    // map literal / independent product) is shared with that aggregate —
+    // an in-place mutation of the slot would corrupt the aggregate's copy.
+    // `last_use` marks the slot dead (the aggregate field, not the slot,
+    // is read later) and alias.rs RULE 2 does not model the capture, so
+    // without this the analysis would treat such a slot as uniquely owned
+    // and un-flag a param fed by it — a silent corruption (a vector
+    // aliased into a record field, then own-mutated through that param).
+    // Flag every captured slot up front so it is never un-flagged and
+    // never owned-mutated. (Only DIRECT `Local` field/element values
+    // alias; a `Local` nested inside a sub-computation is consumed by it,
+    // not stored into the aggregate.)
+    for (_, f) in program.fns.iter_mut() {
+        let mut captured: HashSet<u32> = HashSet::new();
+        collect_captured_slots(&f.body.node, &mut captured);
+        if captured.is_empty() {
+            continue;
+        }
+        let mut slots = f.aliased_slots.as_ref().clone();
+        if let Some(&max) = captured.iter().max()
+            && (max as usize) >= slots.len()
+        {
+            slots.resize(max as usize + 1, false);
+        }
+        for s in captured {
+            slots[s as usize] = true;
+        }
+        f.aliased_slots = Arc::new(slots);
+    }
+
     // Address-taken fns: any name appearing in a `MirExpr::FnValue`.
     let mut address_taken: HashSet<String> = HashSet::new();
     for (_, f) in program.iter() {
@@ -410,6 +441,56 @@ fn collect_let_bindings(e: &MirExpr, out: &mut HashMap<u32, Spanned<MirExpr>>) {
             .or_insert_with(|| (*l.node.value).clone());
     }
     visit_children(e, &mut |c| collect_let_bindings(c, out));
+}
+
+/// Collect slots whose value is captured DIRECTLY as a field/element of
+/// an aggregate constructor — the aggregate then shares the slot's
+/// backing, so mutating the slot in place would corrupt the aggregate.
+/// Only direct `Local` operands alias; a `Local` nested inside a
+/// sub-computation is consumed by it (its result, not the slot, lands in
+/// the aggregate), so the recursive `visit_children` walk picks up
+/// deeper aggregates without over-flagging those consumed operands.
+fn collect_captured_slots(e: &MirExpr, out: &mut HashSet<u32>) {
+    fn flag(item: &Spanned<MirExpr>, out: &mut HashSet<u32>) {
+        if let MirExpr::Local(l) = &item.node {
+            out.insert(l.node.slot.0);
+        }
+    }
+    match e {
+        MirExpr::RecordCreate(r) => {
+            for f in &r.node.fields {
+                flag(&f.value, out);
+            }
+        }
+        MirExpr::RecordUpdate(u) => {
+            for f in &u.node.updates {
+                flag(&f.value, out);
+            }
+        }
+        MirExpr::Construct(c) => {
+            for a in &c.node.args {
+                flag(a, out);
+            }
+        }
+        MirExpr::Tuple(items) | MirExpr::List(items) => {
+            for i in items {
+                flag(i, out);
+            }
+        }
+        MirExpr::MapLiteral(pairs) => {
+            for (k, v) in pairs {
+                flag(k, out);
+                flag(v, out);
+            }
+        }
+        MirExpr::IndependentProduct(ip) => {
+            for i in &ip.node.items {
+                flag(i, out);
+            }
+        }
+        _ => {}
+    }
+    visit_children(e, &mut |c| collect_captured_slots(c, out));
 }
 
 /// Collect visible `Call(Fn)` / `TailCall` edges made from `caller`.

--- a/tests/own_param_soundness.rs
+++ b/tests/own_param_soundness.rs
@@ -183,6 +183,41 @@ fn main() -> Unit
     assert_sound("map_set", src, "7");
 }
 
+/// Aggregate-capture aliasing: a vector stored into a record field, then
+/// own-mutated through a param the refinement would otherwise un-flag.
+/// `last_use` marks the slot dead (only the record field is read after),
+/// but the field aliases the same backing — so an in-place mutation would
+/// corrupt it. Correct = `7`; corruption surfaces as `99`. This is the
+/// class the first soundness suite missed (a shipped VM corruption found
+/// by an adversarial pass): the captured slot must stay flagged.
+#[test]
+fn vector_aliased_into_record_field_is_not_mutated_in_place() {
+    let src = r#"module Rec
+    intent = "vector aliased into a record field, then own-mutated through a param"
+    depends []
+    effects [Console.print]
+
+record Box
+    v: Vector<Int>
+
+fn clobber(w: Vector<Int>) -> Int
+    ? "self-keep set on param w"
+    c = Option.withDefault(Vector.set(w, 0, 99), w)
+    Option.withDefault(Vector.get(c, 0), 0 - 1)
+
+fn run() -> Int
+    a = Vector.new(2, 7)
+    box = Box(v = a)
+    x = clobber(a)
+    Option.withDefault(Vector.get(box.v, 0), 0 - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("record_capture", src, "7");
+}
+
 /// The headline win: a linearly-threaded vector param the refinement
 /// *should* un-flag. Asserts the fill+sum result is correct (so the
 /// optimization is exercised, not silently a no-op) and identical with


### PR DESCRIPTION
## The bug (shipped in #382)

`own_param` un-flags a `Vector`/`Map` param when every call site passes a uniquely-owned argument. But `uniquely_owned` trusted `last_use` + the alias table — neither models a value **captured into an aggregate**. A vector stored into a record field (or tuple / list / map literal / variant) and then own-mutated through such a param was mutated **in place**, corrupting the aggregate's copy.

```aver
record Box
    v: Vector<Int>
fn clobber(w: Vector<Int>) -> Int
    c = Option.withDefault(Vector.set(w, 0, 99), w)
    Option.withDefault(Vector.get(c, 0), 0 - 1)
fn run() -> Int
    a = Vector.new(2, 7)
    box = Box(v = a)        # a aliased into box.v
    x = clobber(a)          # a-the-slot textually-last → last_use=true, but box.v aliases it
    Option.withDefault(Vector.get(box.v, 0), 0 - 1)
```

On the VM this printed **99** (corruption) instead of **7**. Found by an adversarial review pass; the original soundness suite missed the aggregate-aliasing class.

(The Rust target's `Rc::make_mut` copy-on-write happens to mask this dynamically — a real alias is a live `Rc` clone so `make_mut` deep-clones — but the VM's owned-mask `mem::take` has no such runtime backstop.)

## The fix

Flag every slot captured **directly** as an aggregate field/element up front (in `own_param`, before the fixpoint) so it is never un-flagged and never owned-mutated. Only direct `Local` operands alias; a `Local` nested inside a sub-computation is consumed by it, so the recursive walk covers deeper aggregates without over-flagging.

## Verified

- record-capture counterexample → **7** (was 99) on the VM.
- `vector_ops` / `map_build` keep their ~17–18× win — they thread params through builtins, not aggregates, so nothing is captured and nothing regresses.
- 794 tests green (lib + MIR specs + wasm-gc differentials + the soundness suite, which gains the record-capture case run through the real VM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)