### PR TITLE
rust-on-MIR Wave 3b: emit EFFECTFUL builtins from MIR (policy/replay/cancel_checkpoint)

### DIFF
--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -189,8 +189,35 @@ fn emit_replay_effect_call(
     ctx: &CodegenContext,
     ectx: &EmitCtx,
 ) -> Option<String> {
+    // The only walker-specific input is how each arg is rendered as an
+    // owning binding for the `__effect_argN` temp (HIR's `clone_arg`).
+    // Everything downstream (the raw effect call, the arg-json shapes,
+    // the `cancel_checkpoint` + `invoke_effect` framing) keys off the
+    // *temp names*, not the source exprs, so it lives in the shared
+    // `compose_replay_effect_call` that both HIR and the MIR walker
+    // call with the same temp count.
+    let arg_clones: Vec<String> = args
+        .iter()
+        .map(|arg| clone_arg(&arg.node, ctx, ectx))
+        .collect();
+    compose_replay_effect_call(name, &arg_clones)
+}
+
+/// Shared replay-reroute composer (security-sensitive: a dropped
+/// `invoke_effect` here silently disables record/replay capture for an
+/// effect). Both the HIR oracle (`emit_replay_effect_call`) and the MIR
+/// walker (`from_mir::emit_mir_effectful_builtin_call`) call this with
+/// the per-arg owning-binding strings already rendered by their own
+/// `clone_arg` mirror, so the emitted block is byte-identical across
+/// backends by construction.
+///
+/// `arg_clones[i]` is the Rust expression bound to `__effect_argi`. The
+/// raw effect call + the arg-json both reference those temps, so they
+/// depend only on the *count* of args, not on how each was rendered —
+/// which is why the shared composer can stay walker-agnostic.
+pub(super) fn compose_replay_effect_call(name: &str, arg_clones: &[String]) -> Option<String> {
     let effect_name = builtin_effect_name(name);
-    let temp_names = (0..args.len())
+    let temp_names = (0..arg_clones.len())
         .map(|idx| format!("__effect_arg{}", idx))
         .collect::<Vec<_>>();
     let raw = emit_effectful_builtin_call_with_temps(name, &temp_names)?;
@@ -202,9 +229,8 @@ fn emit_replay_effect_call(
 
     let mut lines = Vec::new();
     lines.push("{".to_string());
-    for (idx, arg) in args.iter().enumerate() {
-        let emitted = clone_arg(&arg.node, ctx, ectx);
-        lines.push(format!("    let {} = {};", temp_names[idx], emitted));
+    for (idx, clone) in arg_clones.iter().enumerate() {
+        lines.push(format!("    let {} = {};", temp_names[idx], clone));
     }
     lines.push("    crate::cancel_checkpoint();".to_string());
     let json_args = emit_replay_effect_arg_json(effect_name, &temp_names).join(", ");
@@ -266,35 +292,72 @@ pub fn emit_builtin_call(
         result
     };
 
-    // Wrap Http/Disk/Env calls with policy checks when aver.toml policy is present.
-    if ctx.policy.is_some() && !ctx.emit_replay_runtime {
-        if name.starts_with("Http.") && !args.is_empty() {
-            let url_arg = emit_expr(&args[0].node, ctx, ectx);
-            return Some(format!(
-                "{{ crate::cancel_checkpoint(); aver_policy::check_http(\"{}\", &{}).expect(\"aver.toml policy violation\"); {} }}",
-                name, url_arg, result
-            ));
-        }
-        if name.starts_with("Disk.") && !args.is_empty() {
-            let path_arg = emit_expr(&args[0].node, ctx, ectx);
-            return Some(format!(
-                "{{ crate::cancel_checkpoint(); aver_policy::check_disk(\"{}\", &{}).expect(\"aver.toml policy violation\"); {} }}",
-                name, path_arg, result
-            ));
-        }
-        if name.starts_with("Env.") && !args.is_empty() {
-            let key_arg = emit_expr(&args[0].node, ctx, ectx);
-            return Some(format!(
-                "{{ crate::cancel_checkpoint(); aver_policy::check_env(\"{}\", &{}).expect(\"aver.toml policy violation\"); {} }}",
-                name, key_arg, result
-            ));
-        }
+    // Policy-wrap / bare-frame the (already `.into_aver()`-converted)
+    // result. The only walker-specific input is the first arg rendered
+    // as a borrowable value for the `check_*` call (HIR's `emit_expr`);
+    // the rest of the wrapping is shared with the MIR walker via
+    // `compose_effect_wrap` so both emit byte-identical framing.
+    let policy_active = ctx.policy.is_some() && !ctx.emit_replay_runtime;
+    let first_arg = if policy_active && !args.is_empty() {
+        Some(emit_expr(&args[0].node, ctx, ectx))
+    } else {
+        None
+    };
+    Some(compose_effect_wrap(name, result, policy_active, first_arg))
+}
+
+/// Which policy `check_*` helper guards a built-in namespace, if any.
+/// Returns the helper name for `Http.` / `Disk.` / `Env.` prefixes,
+/// `None` for every other (effectful or pure) builtin. Shared between
+/// the HIR oracle and the MIR walker so the policy-prefix decision is
+/// made in exactly one place.
+fn policy_check_helper(name: &str) -> Option<&'static str> {
+    if name.starts_with("Http.") {
+        Some("aver_policy::check_http")
+    } else if name.starts_with("Disk.") {
+        Some("aver_policy::check_disk")
+    } else if name.starts_with("Env.") {
+        Some("aver_policy::check_env")
+    } else {
+        None
+    }
+}
+
+/// Shared policy-wrap / bare-frame composer (security-sensitive: a
+/// dropped `check_*` here silently disables aver.toml DENY enforcement
+/// for an effect). Applies, in HIR's exact order:
+///
+/// 1. **policy wrap** — when `policy_active` and `name` is an
+///    `Http.`/`Disk.`/`Env.` call with a first arg
+///    (`first_arg = Some(emitted)`): prepend `cancel_checkpoint()` +
+///    the matching `check_*(<method>, &<arg0>).expect(...)`.
+/// 2. **bare framing** — every other effectful builtin gets the bare
+///    `{ cancel_checkpoint(); <result> }`.
+/// 3. **pure passthrough** — a non-effectful builtin returns `result`
+///    unwrapped.
+///
+/// Both backends call this with `result` already `.into_aver()`-
+/// converted and `first_arg` rendered by their own `emit_expr` mirror,
+/// so the emitted framing is byte-identical by construction.
+pub(super) fn compose_effect_wrap(
+    name: &str,
+    result: String,
+    policy_active: bool,
+    first_arg: Option<String>,
+) -> String {
+    if policy_active
+        && let Some(arg) = first_arg
+        && let Some(helper) = policy_check_helper(name)
+    {
+        return format!(
+            "{{ crate::cancel_checkpoint(); {helper}(\"{name}\", &{arg}).expect(\"aver.toml policy violation\"); {result} }}"
+        );
     }
 
     if builtin_is_effectful(name) {
-        Some(format!("{{ crate::cancel_checkpoint(); {} }}", result))
+        format!("{{ crate::cancel_checkpoint(); {} }}", result)
     } else {
-        Some(result)
+        result
     }
 }
 
@@ -354,22 +417,6 @@ fn emit_builtin_call_inner(
                 arg
             ))
         }
-
-        // ---- Console ----
-        "Console.print" => {
-            let arg = emit_arg(0);
-            Some(format!("aver_rt::console_print(&{})", arg))
-        }
-        "Console.error" | "Console.warn" => {
-            let arg = emit_arg(0);
-            let helper = if name == "Console.warn" {
-                "console_warn"
-            } else {
-                "console_error"
-            };
-            Some(format!("aver_rt::{}(&{})", helper, arg))
-        }
-        "Console.readLine" => Some("aver_rt::read_line()".to_string()),
 
         // ---- Result ----
         "Result.Ok" => {
@@ -775,184 +822,146 @@ fn emit_builtin_call_inner(
             Some(format!("{}.to_list()", vec))
         }
 
+        // ---- Effectful families (Console / Tcp / Http / HttpServer /
+        // SelfHostRuntime / Disk / Env / Args / Time / Random /
+        // Terminal) ----
+        // Every effectful arm renders each arg with a plain `emit_arg`
+        // (raw `emit_expr`, no clone / borrow), so the bodies depend
+        // only on the arg *strings* and live in the shared
+        // `compose_effectful_builtin_raw` that the MIR walker also calls
+        // (Wave 3b). Render the args here and delegate; `None` means
+        // not-a-builtin (→ caller's fallback).
+        _ if builtin_is_effectful(name) => {
+            let arg_strs: Vec<String> = (0..args.len()).map(emit_arg).collect();
+            compose_effectful_builtin_raw(name, &arg_strs)
+        }
+
+        _ => None,
+    }
+}
+
+/// Shared raw-body composer for the effectful builtins' NON-replay
+/// path: the `aver_rt::*` / `crate::*` call before any
+/// `cancel_checkpoint` / policy / `.into_aver()` wrapping. Every arm
+/// renders its args by-value (the caller's `emit_arg` mirror), so this
+/// keys off the pre-emitted arg strings only and is byte-identical
+/// across the HIR oracle (`emit_builtin_call_inner`) and the MIR walker
+/// (`from_mir::emit_mir_effectful_builtin_call`). Returns `None` for a
+/// non-effectful / unknown name.
+///
+/// NOTE: this is the NON-replay raw body. The replay path uses
+/// [`emit_effectful_builtin_call_with_temps`], which differs for a few
+/// arms (`Args.get` → `aver_replay::current_cli_args()`, `Terminal.print`
+/// → `format!` instead of `aver_display`); both are reachable from both
+/// backends so the divergence is preserved identically on each.
+pub(super) fn compose_effectful_builtin_raw(name: &str, args: &[String]) -> Option<String> {
+    let a = |i: usize| args[i].as_str();
+    match name {
+        // ---- Console ----
+        "Console.print" => Some(format!("aver_rt::console_print(&{})", a(0))),
+        "Console.error" | "Console.warn" => {
+            let helper = if name == "Console.warn" {
+                "console_warn"
+            } else {
+                "console_error"
+            };
+            Some(format!("aver_rt::{}(&{})", helper, a(0)))
+        }
+        "Console.readLine" => Some("aver_rt::read_line()".to_string()),
+
         // ---- Tcp ----
-        "Tcp.connect" => {
-            let host = emit_arg(0);
-            let port = emit_arg(1);
-            Some(format!("aver_rt::tcp::connect(&{}, {})", host, port))
-        }
-        "Tcp.writeLine" => {
-            let conn = emit_arg(0);
-            let line = emit_arg(1);
-            Some(format!("aver_rt::tcp::write_line(&{}, &{})", conn, line))
-        }
-        "Tcp.readLine" => {
-            let conn = emit_arg(0);
-            Some(format!("aver_rt::tcp::read_line(&{})", conn))
-        }
-        "Tcp.close" => {
-            let conn = emit_arg(0);
-            Some(format!("aver_rt::tcp::close(&{})", conn))
-        }
-        "Tcp.send" => {
-            let host = emit_arg(0);
-            let port = emit_arg(1);
-            let msg = emit_arg(2);
-            Some(format!("aver_rt::tcp::send(&{}, {}, &{})", host, port, msg))
-        }
-        "Tcp.ping" => {
-            let host = emit_arg(0);
-            let port = emit_arg(1);
-            Some(format!("aver_rt::tcp::ping(&{}, {})", host, port))
-        }
+        "Tcp.connect" => Some(format!("aver_rt::tcp::connect(&{}, {})", a(0), a(1))),
+        "Tcp.writeLine" => Some(format!("aver_rt::tcp::write_line(&{}, &{})", a(0), a(1))),
+        "Tcp.readLine" => Some(format!("aver_rt::tcp::read_line(&{})", a(0))),
+        "Tcp.close" => Some(format!("aver_rt::tcp::close(&{})", a(0))),
+        "Tcp.send" => Some(format!(
+            "aver_rt::tcp::send(&{}, {}, &{})",
+            a(0),
+            a(1),
+            a(2)
+        )),
+        "Tcp.ping" => Some(format!("aver_rt::tcp::ping(&{}, {})", a(0), a(1))),
 
         // ---- Http ----
-        "Http.get" => {
-            let url = emit_arg(0);
-            Some(format!("aver_rt::http::get(&{})", url))
-        }
-        "Http.head" => {
-            let url = emit_arg(0);
-            Some(format!("aver_rt::http::head(&{})", url))
-        }
-        "Http.delete" => {
-            let url = emit_arg(0);
-            Some(format!("aver_rt::http::delete(&{})", url))
-        }
-        "Http.post" => {
-            let url = emit_arg(0);
-            let body = emit_arg(1);
-            let ct = emit_arg(2);
-            let headers = emit_arg(3);
-            Some(format!(
-                "aver_rt::http::post(&{}, &{}, &{}, &{})",
-                url, body, ct, headers
-            ))
-        }
-        "Http.put" => {
-            let url = emit_arg(0);
-            let body = emit_arg(1);
-            let ct = emit_arg(2);
-            let headers = emit_arg(3);
-            Some(format!(
-                "aver_rt::http::put(&{}, &{}, &{}, &{})",
-                url, body, ct, headers
-            ))
-        }
-        "Http.patch" => {
-            let url = emit_arg(0);
-            let body = emit_arg(1);
-            let ct = emit_arg(2);
-            let headers = emit_arg(3);
-            Some(format!(
-                "aver_rt::http::patch(&{}, &{}, &{}, &{})",
-                url, body, ct, headers
-            ))
-        }
+        "Http.get" => Some(format!("aver_rt::http::get(&{})", a(0))),
+        "Http.head" => Some(format!("aver_rt::http::head(&{})", a(0))),
+        "Http.delete" => Some(format!("aver_rt::http::delete(&{})", a(0))),
+        "Http.post" => Some(format!(
+            "aver_rt::http::post(&{}, &{}, &{}, &{})",
+            a(0),
+            a(1),
+            a(2),
+            a(3)
+        )),
+        "Http.put" => Some(format!(
+            "aver_rt::http::put(&{}, &{}, &{}, &{})",
+            a(0),
+            a(1),
+            a(2),
+            a(3)
+        )),
+        "Http.patch" => Some(format!(
+            "aver_rt::http::patch(&{}, &{}, &{}, &{})",
+            a(0),
+            a(1),
+            a(2),
+            a(3)
+        )),
 
         // ---- HttpServer ----
-        "HttpServer.listen" => {
-            let port = emit_arg(0);
-            let handler = emit_arg(1);
-            Some(format!(
-                "{{ if let Err(e) = crate::http_server_listen({}, {}) {{ panic!(\"{{}}\", e); }} }}",
-                port, handler
-            ))
-        }
-        "HttpServer.listenWith" => {
-            let port = emit_arg(0);
-            let context = emit_arg(1);
-            let handler = emit_arg(2);
-            Some(format!(
-                "{{ if let Err(e) = crate::http_server_listen_with({}, {}.clone(), {}) {{ panic!(\"{{}}\", e); }} }}",
-                port, context, handler
-            ))
-        }
-        "SelfHostRuntime.httpServerListen" => {
-            let port = emit_arg(0);
-            let handler = emit_arg(1);
-            Some(format!(
-                "crate::self_host_support::http_server_listen({}, {})",
-                port, handler
-            ))
-        }
-        "SelfHostRuntime.httpServerListenWith" => {
-            let port = emit_arg(0);
-            let context = emit_arg(1);
-            let handler = emit_arg(2);
-            Some(format!(
-                "crate::self_host_support::http_server_listen_with({}, {}.clone(), {})",
-                port, context, handler
-            ))
-        }
+        "HttpServer.listen" => Some(format!(
+            "{{ if let Err(e) = crate::http_server_listen({}, {}) {{ panic!(\"{{}}\", e); }} }}",
+            a(0),
+            a(1)
+        )),
+        "HttpServer.listenWith" => Some(format!(
+            "{{ if let Err(e) = crate::http_server_listen_with({}, {}.clone(), {}) {{ panic!(\"{{}}\", e); }} }}",
+            a(0),
+            a(1),
+            a(2)
+        )),
+        "SelfHostRuntime.httpServerListen" => Some(format!(
+            "crate::self_host_support::http_server_listen({}, {})",
+            a(0),
+            a(1)
+        )),
+        "SelfHostRuntime.httpServerListenWith" => Some(format!(
+            "crate::self_host_support::http_server_listen_with({}, {}.clone(), {})",
+            a(0),
+            a(1),
+            a(2)
+        )),
 
         // ---- Disk ----
-        "Disk.readText" => {
-            let path = emit_arg(0);
-            Some(format!("aver_rt::read_text(&{})", path))
-        }
-        "Disk.writeText" => {
-            let path = emit_arg(0);
-            let content = emit_arg(1);
-            Some(format!("aver_rt::write_text(&{}, &{})", path, content))
-        }
-        "Disk.appendText" => {
-            let path = emit_arg(0);
-            let content = emit_arg(1);
-            Some(format!("aver_rt::append_text(&{}, &{})", path, content))
-        }
-        "Disk.exists" => {
-            let path = emit_arg(0);
-            Some(format!("aver_rt::path_exists(&{})", path))
-        }
-        "Disk.delete" => {
-            let path = emit_arg(0);
-            Some(format!("aver_rt::delete_file(&{})", path))
-        }
-        "Disk.deleteDir" => {
-            let path = emit_arg(0);
-            Some(format!("aver_rt::delete_dir(&{})", path))
-        }
-        "Disk.listDir" => {
-            let path = emit_arg(0);
-            Some(format!("aver_rt::list_dir(&{})", path))
-        }
-        "Disk.makeDir" => {
-            let path = emit_arg(0);
-            Some(format!("aver_rt::make_dir(&{})", path))
-        }
+        "Disk.readText" => Some(format!("aver_rt::read_text(&{})", a(0))),
+        "Disk.writeText" => Some(format!("aver_rt::write_text(&{}, &{})", a(0), a(1))),
+        "Disk.appendText" => Some(format!("aver_rt::append_text(&{}, &{})", a(0), a(1))),
+        "Disk.exists" => Some(format!("aver_rt::path_exists(&{})", a(0))),
+        "Disk.delete" => Some(format!("aver_rt::delete_file(&{})", a(0))),
+        "Disk.deleteDir" => Some(format!("aver_rt::delete_dir(&{})", a(0))),
+        "Disk.listDir" => Some(format!("aver_rt::list_dir(&{})", a(0))),
+        "Disk.makeDir" => Some(format!("aver_rt::make_dir(&{})", a(0))),
 
         // ---- Env ----
-        "Env.get" => {
-            let key = emit_arg(0);
-            Some(format!("aver_rt::env_get(&{})", key))
-        }
-        "Env.set" => {
-            let key = emit_arg(0);
-            let value = emit_arg(1);
-            Some(format!(
-                "aver_rt::env_set(&{}, &{}).expect(\"Env.set failed\")",
-                key, value
-            ))
-        }
+        "Env.get" => Some(format!("aver_rt::env_get(&{})", a(0))),
+        "Env.set" => Some(format!(
+            "aver_rt::env_set(&{}, &{}).expect(\"Env.set failed\")",
+            a(0),
+            a(1)
+        )),
         "Args.get" => Some("aver_rt::cli_args().into_aver()".to_string()),
 
         // ---- Time ----
         "Time.now" => Some("aver_rt::time_now()".to_string()),
         "Time.unixMs" => Some("aver_rt::time_unix_ms()".to_string()),
-        "Time.sleep" => {
-            let ms = emit_arg(0);
-            Some(format!("aver_rt::time_sleep({})", ms))
-        }
+        "Time.sleep" => Some(format!("aver_rt::time_sleep({})", a(0))),
 
-        "Random.int" => {
-            let min = emit_arg(0);
-            let max = emit_arg(1);
-            Some(format!(
-                "aver_rt::random::random_int({}, {}).unwrap()",
-                min, max
-            ))
-        }
+        // ---- Random ----
+        "Random.int" => Some(format!(
+            "aver_rt::random::random_int({}, {}).unwrap()",
+            a(0),
+            a(1)
+        )),
         "Random.float" => Some("aver_rt::random::random_float()".to_string()),
 
         // ---- Terminal ----
@@ -963,27 +972,21 @@ fn emit_builtin_call_inner(
             Some("aver_rt::terminal_disable_raw_mode().unwrap()".to_string())
         }
         "Terminal.clear" => Some("aver_rt::terminal_clear().unwrap()".to_string()),
-        "Terminal.moveTo" => {
-            let x = emit_arg(0);
-            let y = emit_arg(1);
-            Some(format!("aver_rt::terminal_move_to({}, {}).unwrap()", x, y))
-        }
-        "Terminal.print" => {
-            let s = emit_arg(0);
-            Some(format!(
-                "{{ let __s = aver_rt::aver_display(&{}); aver_rt::terminal_print(&__s).unwrap() }}",
-                s
-            ))
-        }
-        "Terminal.setColor" => {
-            let c = emit_arg(0);
-            Some(format!("aver_rt::terminal_set_color(&{}).unwrap()", c))
-        }
+        "Terminal.moveTo" => Some(format!(
+            "aver_rt::terminal_move_to({}, {}).unwrap()",
+            a(0),
+            a(1)
+        )),
+        "Terminal.print" => Some(format!(
+            "{{ let __s = aver_rt::aver_display(&{}); aver_rt::terminal_print(&__s).unwrap() }}",
+            a(0)
+        )),
+        "Terminal.setColor" => Some(format!("aver_rt::terminal_set_color(&{}).unwrap()", a(0))),
         "Terminal.resetColor" => Some("aver_rt::terminal_reset_color().unwrap()".to_string()),
         "Terminal.readKey" => Some("aver_rt::terminal_read_key()".to_string()),
-        "Terminal.size" => {
-            Some("{ let (w, h) = aver_rt::terminal_size().unwrap(); aver_rt::TerminalSize { width: w, height: h } }".to_string())
-        }
+        "Terminal.size" => Some(
+            "{ let (w, h) = aver_rt::terminal_size().unwrap(); aver_rt::TerminalSize { width: w, height: h } }".to_string(),
+        ),
         "Terminal.hideCursor" => Some("aver_rt::terminal_hide_cursor().unwrap()".to_string()),
         "Terminal.showCursor" => Some("aver_rt::terminal_show_cursor().unwrap()".to_string()),
         "Terminal.flush" => Some("aver_rt::terminal_flush().unwrap()".to_string()),

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -620,18 +620,21 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                     let name = emit_ctx.symbol_table.fn_entry(*fn_id).key.canonical();
                     emit_named_call(&name, &call.args, emit_ctx)
                 }
-                // Wave 3a: resolve the interned dotted name and
-                // dispatch the PURE builtins through
-                // `emit_mir_builtin_call`. EFFECTFUL builtins (and any
-                // out-of-range id, a lowering-invariant violation we
-                // tolerate defensively) return `None` → HIR fallback;
-                // they stay on the HIR walker (Wave 3b).
+                // Resolve the interned dotted name and dispatch:
+                //   - EFFECTFUL builtins (Wave 3b) →
+                //     `emit_mir_effectful_builtin_call`, which mirrors
+                //     HIR's `emit_builtin_call` replay-reroute / policy-
+                //     wrap / bare-frame machinery byte-for-byte.
+                //   - PURE builtins (Wave 3a) → `emit_mir_builtin_call`.
+                // An out-of-range id (a lowering-invariant violation we
+                // tolerate defensively) returns `None` → HIR fallback.
                 MirCallee::Builtin(id) => {
                     let name = emit_ctx.mir_builtins.get(id.0 as usize)?.as_str();
                     if super::builtins::builtin_is_effectful(name) {
-                        return None;
+                        emit_mir_effectful_builtin_call(name, &call.args, emit_ctx)
+                    } else {
+                        emit_mir_builtin_call(name, &call.args, emit_ctx)
                     }
-                    emit_mir_builtin_call(name, &call.args, emit_ctx)
                 }
                 // Wave 3a: the 5 deforestation intrinsics (buffer build
                 // + `__to_str`). Args are by-value (no clone / borrow),
@@ -1376,6 +1379,16 @@ pub(super) fn reset_parity_counters() {
     CONSIDERED.store(0, Ordering::Relaxed);
 }
 
+/// Is the `AVER_RUST_MIR_ONLY=1` escape hatch active? When set, the
+/// parity gate forces the MIR walker's body onto the production path
+/// (even when it diverges from HIR) for any fn the walker can render,
+/// so the security differential test can make the MIR path own effect
+/// emission. Read from the env each call (cheap; only on the codegen
+/// path) so a test can toggle it per-process without a rebuild.
+fn mir_only_hatch_enabled() -> bool {
+    std::env::var_os("AVER_RUST_MIR_ONLY").is_some_and(|v| v == "1")
+}
+
 /// `(graduated, considered)` since the last [`reset_parity_counters`].
 pub fn parity_counters() -> (usize, usize) {
     (
@@ -1413,6 +1426,22 @@ pub(super) fn parity_gated_body(
     };
     let policy = MirFnEmitPolicy::from_resolved(resolved, scope, borrow_by_default);
     let emit_ctx = MirEmitCtx::for_fn(ctx, &policy);
+    // SECURITY-TEST ESCAPE HATCH (`AVER_RUST_MIR_ONLY=1`): when set,
+    // force the MIR body onto the production path for any fn whose MIR
+    // walker renders successfully, even if it is NOT byte-identical to
+    // HIR — disabling the byte-exact fallback. Production default (env
+    // UNSET) is unchanged: the parity gate still governs, so normal
+    // compiles never see this branch and cannot regress. The hatch
+    // exists solely so the differential security test can force the MIR
+    // walker to OWN effect emission (replay / policy / bare framing) —
+    // otherwise an effectful fn always falls back to HIR and the test
+    // would silently exercise the HIR path instead.
+    if mir_only_hatch_enabled()
+        && let Some(mir_body) = emit_mir_fn_body(&mir_fn.body, &emit_ctx)
+    {
+        GRADUATED.fetch_add(1, Ordering::Relaxed);
+        return mir_body;
+    }
     match emit_mir_fn_body(&mir_fn.body, &emit_ctx) {
         Some(mir_body) if mir_body == hir_body => {
             GRADUATED.fetch_add(1, Ordering::Relaxed);
@@ -1639,9 +1668,9 @@ fn mir_borrow_arg(code: String, expr: &MirExpr, ctx: &MirEmitCtx<'_>) -> String 
 // (`builtins.rs`) for the ~88 PURE builtins (Result / Option / Int /
 // Float / String / List / Map / Vector / Bool / Char / Byte). The
 // EFFECTFUL families (Args / Console / Http / HttpServer / Disk / Env /
-// Random / SelfHostRuntime / Tcp / Terminal / Time) are gated out at the
-// `Call(Builtin)` arm (`builtin_is_effectful` → `None` → HIR fallback) —
-// Wave 3b, deliberately left on the HIR walker and never reached here.
+// Random / SelfHostRuntime / Tcp / Terminal / Time) are split off at the
+// `Call(Builtin)` arm to `emit_mir_effectful_builtin_call` (Wave 3b,
+// below) — they are NOT handled here.
 //
 // Each arm copies its HIR sibling's shape verbatim, substituting:
 //   `emit_arg(i)`                  → `emit_mir_expr(&args[i], ctx)?`
@@ -1934,6 +1963,95 @@ fn emit_mir_builtin_call(
     }
 }
 
+// ── Wave 3b: EFFECTFUL builtin calls (replay / policy / bare framing) ───
+//
+// SECURITY-SENSITIVE. Mirror of the HIR oracle `emit_builtin_call`
+// (`builtins.rs`) for the 11 EFFECTFUL families (Args / Console / Http /
+// HttpServer / Disk / Env / Random / SelfHostRuntime / Tcp / Terminal /
+// Time). Wave 3a gated these out (`builtin_is_effectful` → `None` → HIR
+// fallback); Wave 3b emits them, threading `ctx.policy` +
+// `ctx.emit_replay_runtime` (reachable through `ctx.codegen`).
+//
+// The three wrappers HIR applies are reproduced by the SAME shared
+// composers `emit_builtin_call` calls — `compose_replay_effect_call`
+// (replay reroute), `compose_effectful_builtin_raw` (the raw `aver_rt::*`
+// body), and `compose_effect_wrap` (policy `check_*` + bare
+// `cancel_checkpoint` framing) — so the MIR output is byte-identical to
+// HIR by construction. The only walker-specific inputs are the per-arg
+// renders: `mir_clone_arg` (the replay temps, HIR's `clone_arg`) and the
+// raw `emit_mir_expr` (the non-replay args + the policy first arg, HIR's
+// `emit_expr`).
+//
+// A dropped composer here silently disables aver.toml DENY enforcement
+// or record/replay capture (invisible to rustc + coverage + happy-path
+// stdout) — the differential security test under `AVER_RUST_MIR_ONLY=1`
+// forces this path and is revert-proofed against exactly that drop.
+
+/// Emit an EFFECTFUL builtin call from MIR, byte-identical to the HIR
+/// oracle's `emit_builtin_call`. `name` is already known effectful (the
+/// `Call(Builtin)` arm routed it here). Returns `None` (→ HIR fallback)
+/// when an arg can't render, when the production `CodegenContext` is
+/// absent (coverage path — no policy/replay info), or when the raw
+/// effect body isn't one the oracle covers.
+fn emit_mir_effectful_builtin_call(
+    name: &str,
+    args: &[Spanned<MirExpr>],
+    ctx: &MirEmitCtx<'_>,
+) -> Option<String> {
+    // The policy / replay flags live on the full `CodegenContext`. The
+    // coverage / test path has none → fall back to HIR (which the
+    // coverage walk reads as a `None`, conservative + fine). The
+    // production parity gate always carries a ctx.
+    let codegen = ctx.codegen?;
+
+    // (1) Replay reroute — mirror of `emit_builtin_call`'s
+    //     `if ctx.emit_replay_runtime && builtin_is_effectful(name)`.
+    //     Each arg is bound to `__effect_argN` via the `clone_arg`
+    //     mirror; the shared composer emits the
+    //     `cancel_checkpoint` + `invoke_effect(<effect>, vec![json], || raw)`
+    //     block from the temp names.
+    if codegen.emit_replay_runtime {
+        let mut arg_clones = Vec::with_capacity(args.len());
+        for a in args {
+            arg_clones.push(mir_clone_arg(emit_mir_expr(a, ctx)?, &a.node, ctx));
+        }
+        return super::builtins::compose_replay_effect_call(name, &arg_clones);
+    }
+
+    // (2) Raw effect body — mirror of `emit_builtin_call_inner`'s
+    //     effectful arms, every arg by-value (raw `emit_mir_expr`, HIR's
+    //     `emit_arg`). The shared composer renders the `aver_rt::*` call.
+    let mut arg_strs = Vec::with_capacity(args.len());
+    for a in args {
+        arg_strs.push(emit_mir_expr(a, ctx)?);
+    }
+    let result = super::builtins::compose_effectful_builtin_raw(name, &arg_strs)?;
+
+    // `.into_aver()` post-step for String-returning effectful builtins
+    // (mirror of `emit_builtin_call`'s `builtin_needs_str_conversion`).
+    let result = if super::builtins::builtin_needs_str_conversion(name) {
+        format!("({}).into_aver()", result)
+    } else {
+        result
+    };
+
+    // (3) Policy wrap (Http/Disk/Env) + bare `cancel_checkpoint` framing
+    //     — mirror of `emit_builtin_call`'s tail. The first arg for the
+    //     `check_*` call is rendered raw (HIR's `emit_expr`).
+    let policy_active = codegen.policy.is_some() && !codegen.emit_replay_runtime;
+    let first_arg = if policy_active && !args.is_empty() {
+        Some(emit_mir_expr(&args[0], ctx)?)
+    } else {
+        None
+    };
+    Some(super::builtins::compose_effect_wrap(
+        name,
+        result,
+        policy_active,
+        first_arg,
+    ))
+}
+
 /// Emit one of the 5 deforestation intrinsics from MIR, byte-identical
 /// to the HIR oracle's `emit_builtin_call_inner` intrinsic arms. Args
 /// are by-value (raw `emit_mir_expr`, no clone / borrow), matching the
@@ -2181,9 +2299,13 @@ mod tests {
     }
 
     #[test]
-    fn effectful_builtin_returns_none() {
-        // EFFECTFUL builtins are gated out at the call arm — they stay
-        // on the HIR walker (Wave 3b). `Console.print` must NOT emit.
+    fn effectful_builtin_returns_none_without_codegen_ctx() {
+        // Wave 3b: effectful builtins DO emit on the production path, but
+        // they need the `CodegenContext` (for `ctx.policy` /
+        // `ctx.emit_replay_runtime`). The coverage / test path carries no
+        // ctx, so `Console.print` returns `None` → HIR fallback there,
+        // which the coverage walk reads conservatively. (Production emit
+        // is exercised by the differential security test.)
         let call = MirCall {
             callee: MirCallee::Builtin(crate::ir::BuiltinId(0)),
             args: vec![span(MirExpr::Literal(span(crate::ast::Literal::Str(
@@ -2193,7 +2315,8 @@ mod tests {
         let expr = span(MirExpr::Call(span(call)));
         assert!(
             emit_mir_expr(&expr, &ctx_with_builtin("Console.print")).is_none(),
-            "effectful Console.print must fall back to HIR"
+            "effectful Console.print needs a CodegenContext; without one it \
+             falls back to HIR"
         );
     }
 

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -125,6 +125,22 @@ fn compile_rust(
     module_root: Option<&Path>,
     extra: &[&str],
 ) -> Result<(), String> {
+    compile_rust_env(file, project_dir, name, module_root, extra, &[])
+}
+
+/// As [`compile_rust`], but sets extra env vars on the `aver compile`
+/// process. Used by the MIR-forced security test to set
+/// `AVER_RUST_MIR_ONLY=1` so the parity gate forces the MIR walker to
+/// OWN the effectful builtin emission (replay / policy / bare framing)
+/// instead of falling back to the byte-equal HIR body.
+fn compile_rust_env(
+    file: &Path,
+    project_dir: &Path,
+    name: &str,
+    module_root: Option<&Path>,
+    extra: &[&str],
+    env: &[(&str, &str)],
+) -> Result<(), String> {
     let mut cmd = Command::new(aver_bin());
     cmd.current_dir(repo_root())
         .arg("compile")
@@ -139,6 +155,9 @@ fn compile_rust(
         cmd.arg("--module-root").arg(root);
     }
     cmd.args(extra);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
     let out = cmd
         .output()
         .expect("expected `aver compile --target rust` to spawn");
@@ -149,6 +168,57 @@ fn compile_rust(
         ));
     }
     Ok(())
+}
+
+/// `aver compile … --explain-mir-coverage --target rust --json` →
+/// parse the `graduated` count. Used by the MIR-forced security test to
+/// PROVE the parity gate actually graduated the effectful fn onto the
+/// MIR path (so the deny / replay assertions exercise MIR-emitted
+/// effects, not an accidental HIR fallback).
+fn graduated_count(
+    file: &Path,
+    module_root: Option<&Path>,
+    extra: &[&str],
+    env: &[(&str, &str)],
+) -> Result<u64, String> {
+    let mut cmd = Command::new(aver_bin());
+    cmd.current_dir(repo_root())
+        .arg("compile")
+        .arg(file)
+        .arg("--explain-mir-coverage")
+        .arg("--target")
+        .arg("rust")
+        .arg("--json");
+    if let Some(root) = module_root {
+        cmd.arg("--module-root").arg(root);
+    }
+    cmd.args(extra);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let out = cmd
+        .output()
+        .expect("expected `aver compile --explain-mir-coverage` to spawn");
+    if !out.status.success() {
+        return Err(format!(
+            "explain-mir-coverage failed:\n{}",
+            format_output(&out)
+        ));
+    }
+    let json = String::from_utf8_lossy(&out.stdout);
+    // Tiny field extractor — avoids pulling serde into the test.
+    let needle = "\"graduated\":";
+    let start = json
+        .find(needle)
+        .ok_or_else(|| format!("no `graduated` field in coverage JSON:\n{json}"))?
+        + needle.len();
+    let rest = &json[start..];
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    rest[..end]
+        .parse::<u64>()
+        .map_err(|e| format!("bad graduated count {:?}: {e}", &rest[..end]))
 }
 
 /// `cargo build` the emitted project against the shared target dir.
@@ -479,6 +549,345 @@ fn record_replay_roundtrips_effects_through_invoke_wrapper() {
         if !replayed.status.success() {
             return Err(format!(
                 "replay run failed — the recorded session did not roundtrip:\n{}",
+                format_output(&replayed)
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
+// ─── Mode (d): MIR-FORCED effectful security probe (Wave 3b) ─────────────
+//
+// SECURITY-SENSITIVE. Wave 3b lets the MIR walker OWN effectful builtin
+// emission (replay / policy / bare framing). A dropped wrapper there
+// silently disables aver.toml DENY enforcement or record/replay capture
+// — and it's invisible to rustc, to coverage, and to happy-path stdout.
+//
+// The byte-parity gate would normally fall an effectful fn back to HIR
+// the instant the MIR body diverged, so a dropped MIR wrapper would
+// hide behind the HIR fallback. The `AVER_RUST_MIR_ONLY=1` escape hatch
+// disables the byte-exact fallback: for any fn the MIR walker renders,
+// the MIR body is forced onto production EVEN IF it diverges from HIR.
+// That makes the MIR walker provably OWN the effect emission, so a
+// dropped MIR wrapper actually reaches the built binary and these
+// probes catch it.
+//
+// `graduated_count(... AVER_RUST_MIR_ONLY=1)` asserts up front that the
+// effectful fn really graduated onto the MIR path — without that guard
+// a silent HIR fallback would let the probe pass for the wrong reason.
+
+/// Single-fn Disk-write program for the embedded-policy probe. The
+/// write rides a helper fn (`writeIt`) that is a single-expr body — the
+/// shape the parity gate graduates onto MIR — so the `aver_policy::
+/// check_disk` wrapper is emitted by the MIR walker under the hatch.
+/// `__PATH__` is substituted at test time.
+const MIR_DISK_WRITE_PROBE: &str = r#"module MirDiskProbe
+    intent =
+        "Writes one file then prints DONE. Probes the MIR-emitted policy"
+        "wrapper: under a deny policy the write must be rejected at runtime."
+    effects [Console, Disk]
+
+fn writeIt(path: String) -> Result<Unit, String>
+    ? "Writes a fixed payload to the given path."
+    ! [Disk.writeText]
+    Disk.writeText(path, "payload")
+
+fn main() -> Result<Unit, String>
+    ! [Console.print, Disk.writeText]
+    written = writeIt("__PATH__")?
+    shown = Console.print("DONE")
+    Result.Ok(Unit)
+"#;
+
+fn write_embedded_disk_policy(dir: &Path, allowed_path: &str) {
+    fs::create_dir_all(dir).expect("create policy dir");
+    fs::write(
+        dir.join("aver.toml"),
+        format!("[effects.Disk]\npaths = [{allowed_path:?}]\n"),
+    )
+    .expect("write aver.toml");
+}
+
+#[test]
+#[ignore = "full tier: cargo build wall-time; set AVER_RUST_DIFF_FULL=1 and run with --include-ignored"]
+fn mir_forced_embedded_policy_rejects_denied_disk_write() {
+    if std::env::var("AVER_RUST_DIFF_FULL").is_err() {
+        eprintln!("skipping MIR-forced policy probe — set AVER_RUST_DIFF_FULL=1");
+        return;
+    }
+
+    let ws = temp_dir("mir-deny");
+    // The embedded aver.toml is read from the module root at compile
+    // time, so the source + the deny aver.toml share a dir.
+    let proj_root = ws.join("src-root");
+    fs::create_dir_all(&proj_root).expect("create src root");
+    let out_path = ws.join("out.txt");
+    let src = proj_root.join("disk_probe.av");
+    fs::write(
+        &src,
+        MIR_DISK_WRITE_PROBE.replace("__PATH__", &aver_path_literal(&out_path)),
+    )
+    .expect("write probe source");
+
+    let hatch = [("AVER_RUST_MIR_ONLY", "1")];
+
+    let result = (|| -> Result<(), String> {
+        // (0) PROVE the MIR path is actually exercised: the effectful
+        // `writeIt` must graduate onto MIR under the hatch. Without
+        // this, a silent HIR fallback would make the probe meaningless.
+        let grad = graduated_count(&src, Some(&proj_root), &["--policy", "embed"], &hatch)?;
+        if grad == 0 {
+            return Err(
+                "no fn graduated onto the MIR path under AVER_RUST_MIR_ONLY=1 — the \
+                 effectful builtin emit is not being exercised by the MIR walker; \
+                 the probe would be testing the HIR fallback instead"
+                    .to_string(),
+            );
+        }
+
+        // (1) DENY: embed an aver.toml whose allow-list names a
+        // DIFFERENT path → the write to out.txt is denied at compile-
+        // baked policy. Compile under the hatch so the MIR walker emits
+        // the `aver_policy::check_disk` wrapper, then build + run.
+        write_embedded_disk_policy(&proj_root, "/aver/nonexistent/allowed/only");
+        let project = ws.join("project-deny");
+        fs::create_dir_all(&project).expect("create project dir");
+        let name = "mir_deny_disk_probe";
+        compile_rust_env(
+            &src,
+            &project,
+            name,
+            Some(&proj_root),
+            &["--policy", "embed"],
+            &hatch,
+        )?;
+        // Sanity: the emitted source must carry the MIR-emitted policy
+        // wrapper. (If a future refactor drops it, the run-time assert
+        // below is the real gate; this is a fast structural tripwire.)
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted module: {e}"))?;
+        if !emitted.contains("aver_policy::check_disk") {
+            return Err(format!(
+                "emitted Rust is missing the `aver_policy::check_disk` wrapper — \
+                 the MIR effectful policy wrap was dropped:\n{emitted}"
+            ));
+        }
+
+        let bin = cargo_build(&project, name)?;
+        let denied = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("run denied binary: {e}"))?;
+        if denied.status.success() {
+            return Err(format!(
+                "deny run unexpectedly SUCCEEDED — the MIR-emitted policy wrapper \
+                 was not enforced:\n{}",
+                format_output(&denied)
+            ));
+        }
+        let denied_stderr = String::from_utf8_lossy(&denied.stderr);
+        if !denied_stderr.contains("denied by aver.toml policy") {
+            return Err(format!(
+                "deny run failed for the wrong reason (expected a policy \
+                 violation):\n{}",
+                format_output(&denied)
+            ));
+        }
+        if out_path.exists() {
+            return Err(format!(
+                "deny run wrote {} despite the deny policy — the MIR-emitted \
+                 check ran AFTER the effect (or not at all)",
+                out_path.display()
+            ));
+        }
+
+        // (2) ALLOW: re-embed an aver.toml whose allow-list names the
+        // real write path → the write is permitted. Proves the deny in
+        // (1) was the policy, not an unconditional failure.
+        write_embedded_disk_policy(&proj_root, &out_path.to_string_lossy());
+        let project_allow = ws.join("project-allow");
+        fs::create_dir_all(&project_allow).expect("create allow project dir");
+        let name_allow = "mir_allow_disk_probe";
+        compile_rust_env(
+            &src,
+            &project_allow,
+            name_allow,
+            Some(&proj_root),
+            &["--policy", "embed"],
+            &hatch,
+        )?;
+        let bin_allow = cargo_build(&project_allow, name_allow)?;
+        let allowed = Command::new(&bin_allow)
+            .output()
+            .map_err(|e| format!("run allowed binary: {e}"))?;
+        if !allowed.status.success() {
+            return Err(format!(
+                "allow run failed — the probe should succeed when the write path \
+                 is permitted:\n{}",
+                format_output(&allowed)
+            ));
+        }
+        if !out_path.exists() {
+            return Err(format!(
+                "allow run did not write {} — the effect was suppressed even \
+                 though the policy allowed it",
+                out_path.display()
+            ));
+        }
+        if !String::from_utf8_lossy(&allowed.stdout).contains("DONE") {
+            return Err(format!(
+                "allow run did not print DONE:\n{}",
+                format_output(&allowed)
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
+/// Reads a file, then echoes its contents via Console.print — same
+/// shape as `READ_ECHO_PROBE`, but compiled under
+/// `AVER_RUST_MIR_ONLY=1` so the MIR walker emits the
+/// `aver_replay::invoke_effect` reroute for BOTH effects. `__PATH__` is
+/// substituted at test time.
+const MIR_READ_ECHO_PROBE: &str = r#"module MirRwProbe
+    intent =
+        "Reads a file and echoes its contents. The record captures the read"
+        "result; replay serves it back. Probes the MIR-emitted replay wrapper."
+    effects [Console, Disk]
+
+fn readIt(path: String) -> Result<String, String>
+    ? "Reads the file at the given path."
+    ! [Disk.readText]
+    Disk.readText(path)
+
+fn main() -> Result<Unit, String>
+    ! [Console.print, Disk.readText]
+    content = readIt("__PATH__")?
+    shown = Console.print("READ:{content}")
+    Result.Ok(Unit)
+"#;
+
+#[test]
+#[ignore = "full tier: cargo build wall-time; set AVER_RUST_DIFF_FULL=1 and run with --include-ignored"]
+fn mir_forced_record_replay_captures_effects_through_invoke_wrapper() {
+    if std::env::var("AVER_RUST_DIFF_FULL").is_err() {
+        eprintln!("skipping MIR-forced replay probe — set AVER_RUST_DIFF_FULL=1");
+        return;
+    }
+
+    let ws = temp_dir("mir-replay");
+    let data_path = ws.join("data.txt");
+    fs::write(&data_path, "recorded-bytes").expect("write probe data");
+    let src = ws.join("rw_probe.av");
+    fs::write(
+        &src,
+        MIR_READ_ECHO_PROBE.replace("__PATH__", &aver_path_literal(&data_path)),
+    )
+    .expect("write probe source");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let name = "mir_rw_probe";
+    let hatch = [("AVER_RUST_MIR_ONLY", "1")];
+
+    let result = (|| -> Result<(), String> {
+        // (0) PROVE the MIR path is exercised: the effectful `readIt`
+        // must graduate onto MIR under the hatch.
+        let grad = graduated_count(&src, None, &["--with-replay"], &hatch)?;
+        if grad == 0 {
+            return Err(
+                "no fn graduated onto the MIR path under AVER_RUST_MIR_ONLY=1 — the \
+                 MIR replay reroute is not being exercised"
+                    .to_string(),
+            );
+        }
+
+        compile_rust_env(&src, &project, name, None, &["--with-replay"], &hatch)?;
+
+        // Structural tripwire: the emitted Rust must carry the MIR-
+        // emitted `invoke_effect` reroute for the read.
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted module: {e}"))?;
+        if !emitted.contains("aver_replay::invoke_effect") {
+            return Err(format!(
+                "emitted Rust is missing the `aver_replay::invoke_effect` reroute — \
+                 the MIR effectful replay wrap was dropped:\n{emitted}"
+            ));
+        }
+
+        let bin = cargo_build(&project, name)?;
+
+        // (1) RECORD: run live, capturing the effects into a session.
+        let session = ws.join("session.json");
+        let recorded = Command::new(&bin)
+            .env("AVER_REPLAY_RECORD", &session)
+            .output()
+            .map_err(|e| format!("run record binary: {e}"))?;
+        if !recorded.status.success() {
+            return Err(format!("record run failed:\n{}", format_output(&recorded)));
+        }
+        if !String::from_utf8_lossy(&recorded.stdout).contains("READ:recorded-bytes") {
+            return Err(format!(
+                "record run did not echo the read bytes (live read broken):\n{}",
+                format_output(&recorded)
+            ));
+        }
+        if !session.exists() {
+            return Err("record run did not write the session JSON".to_string());
+        }
+
+        // BOTH effects must be captured through invoke_effect — a
+        // dropped MIR replay wrapper makes one (or both) vanish.
+        let session_json = fs::read_to_string(&session).expect("read session");
+        if !session_json.contains("\"Disk.readText\"") {
+            return Err(format!(
+                "session is missing the Disk.readText effect — the MIR replay \
+                 wrapper was dropped on the read:\n{session_json}"
+            ));
+        }
+        if !session_json.contains("\"Console.print\"") {
+            return Err(format!(
+                "session is missing the Console.print effect — the MIR replay \
+                 wrapper was dropped on the print:\n{session_json}"
+            ));
+        }
+        if !session_json.contains("READ:recorded-bytes") {
+            return Err(format!(
+                "session does not carry the woven read result in the Console.print \
+                 arg — per-effect arg-json shape is wrong:\n{session_json}"
+            ));
+        }
+
+        // (2) REPLAY: mutate the data file so a LIVE read would differ,
+        // then replay. Replay must serve the recorded bytes (not re-read
+        // the mutated file) and roundtrip without a position mismatch.
+        fs::write(&data_path, "MUTATED-ON-DISK").expect("mutate data file");
+        let replayed = Command::new(&bin)
+            .env("AVER_REPLAY_REPLAY", &session)
+            .output()
+            .map_err(|e| format!("run replay binary: {e}"))?;
+        if !replayed.status.success() {
+            return Err(format!(
+                "replay run failed — the recorded session did not roundtrip (a \
+                 dropped or mis-ordered MIR invoke_effect reroute trips a position \
+                 mismatch here):\n{}",
                 format_output(&replayed)
             ));
         }


### PR DESCRIPTION
**Wave 3b** of the rust-on-MIR port — the security-sensitive wave. The MIR walker now emits all **11 effectful builtin families** (Args, Console, Http, HttpServer, Disk, Env, Random, SelfHostRuntime, Tcp, Terminal, Time) WITH the policy / replay / cancel_checkpoint wrappers, byte-identical to the HIR walker.

## What
- New `emit_mir_effectful_builtin_call` (`from_mir.rs`) reproduces HIR's three wrapping modes: **replay reroute** (`aver_replay::invoke_effect` when `emit_replay_runtime`), **policy wrap** (`aver_policy::check_{http,disk,env}` when `policy.is_some() && !replay`, for Http/Disk/Env), and **bare framing** (`{ cancel_checkpoint(); … }`).
- **Lockstep by construction**: the three wrappers are factored into shared `pub(super)` composers in `builtins.rs` (`compose_replay_effect_call`, `compose_effect_wrap`, `compose_effectful_builtin_raw`) that BOTH the HIR emitter and the MIR walker call with their own pre-rendered arg strings. HIR's emitted output is unchanged; MIR byte-matches it → effectful fns graduate under the normal parity gate.
- **Escape hatch** `AVER_RUST_MIR_ONLY=1` (env, test-only): forces the MIR body onto production even when it diverges from HIR — i.e. the W6 end-state world where MIR *owns* effect emission. Production default (env unset) is byte-identical to main; the parity gate still governs → zero regression.
- Guest-entry / self-host-support fns stay HIR-only (they return before the parity gate); `toplevel.rs` untouched.

## Security discipline (the point of this wave)
A dropped policy wrapper silently disables aver.toml DENY enforcement; a dropped `invoke_effect` drops the effect from the replay recording — both invisible to rustc + coverage + happy-path stdout. So:
- **Two MIR-forced differential security tests** added (`mir_forced_embedded_policy_rejects_denied_disk_write`, `mir_forced_record_replay_captures_effects_through_invoke_wrapper`) that run under the hatch so the MIR path provably owns emission.
- **Revert-proof**: dropping the MIR-specific policy `check_*` → deny test RED; dropping the MIR-specific `invoke_effect` → replay test RED. Both reproduced independently.

## Verified (independently)
- Diff is 3 files: `builtins.rs` (composer extraction — HIR output unchanged), `from_mir.rs` (+153, the MIR emitter + hatch), `tests/rust_codegen_differential.rs` (+409, the two security tests). `toplevel.rs` untouched; composers confirmed shared by both backends; hatch confirmed env-gated with no production leak.
- Full `cargo test` (default): green. `--features wasm`/wasip2 codegen: green. Differential full tier (`--include-ignored`): **6/6** incl. both new security tests. Self-host regen: green. clippy/fmt clean.
- **Adversarial security audit** (7-agent sweep across all 11 effectful namespaces + independent revert-proof re-run + hatch-integrity + composer-wiring): all SAFE on the committed code. Directly confirmed on the clean commit that Random/Time/Args/Tcp route through `invoke_effect` under replay+hatch (effect not dropped).
- Graduated example-corpus fns: **313 → 357 (+44)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)