### PR TITLE
rust-on-MIR W6/Stage-0: emit IndependentProduct (?!/!) from MIR

### DIFF
--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -72,7 +72,7 @@ pub fn emit_expr(expr: &ResolvedExpr, ctx: &CodegenContext, ectx: &EmitCtx) -> S
     emit_expr_with_options(expr, ctx, ectx, true)
 }
 
-fn emit_tuple_from_vars(prefix: &str, count: usize) -> String {
+pub(super) fn emit_tuple_from_vars(prefix: &str, count: usize) -> String {
     match count {
         0 => "()".to_string(),
         1 => format!("({prefix}0,)"),
@@ -86,7 +86,11 @@ fn emit_tuple_from_vars(prefix: &str, count: usize) -> String {
     }
 }
 
-fn emit_result_tuple_unwrap(result_prefix: &str, value_prefix: &str, count: usize) -> String {
+pub(super) fn emit_result_tuple_unwrap(
+    result_prefix: &str,
+    value_prefix: &str,
+    count: usize,
+) -> String {
     let matched_results = emit_tuple_from_vars(result_prefix, count);
     let ok_pattern = match count {
         0 => "()".to_string(),
@@ -114,7 +118,7 @@ fn emit_result_tuple_unwrap(result_prefix: &str, value_prefix: &str, count: usiz
     out
 }
 
-fn emit_parallel_result_tuple_unwrap(
+pub(super) fn emit_parallel_result_tuple_unwrap(
     branch_prefix: &str,
     result_prefix: &str,
     value_prefix: &str,

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -61,7 +61,8 @@ use crate::ir::{MatchDispatchPlan, SymbolTable};
 use super::emit_ctx::{is_copy_type, should_borrow_param};
 use super::expr::{
     callee_borrow_mask, constructor_boxed_positions, emit_dispatch_table_match, emit_list_match,
-    emit_literal, emit_pattern_rebindings, emit_ref_match_rebindings, has_list_patterns,
+    emit_literal, emit_parallel_result_tuple_unwrap, emit_pattern_rebindings,
+    emit_ref_match_rebindings, emit_result_tuple_unwrap, emit_tuple_from_vars, has_list_patterns,
     has_string_literal_patterns,
 };
 use super::pattern::emit_pattern;
@@ -896,8 +897,160 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
         }
         MirExpr::IfThenElse(spanned_ite) => emit_mir_if_then_else(&spanned_ite.node, emit_ctx),
         MirExpr::Match(spanned_match) => emit_mir_match(&spanned_match.node, emit_ctx),
+        MirExpr::IndependentProduct(spanned_ip) => {
+            emit_mir_independent_product(&spanned_ip.node, emit_ctx)
+        }
         _ => None,
     }
+}
+
+/// Emit `MirExpr::IndependentProduct` (`(a, b, c)!` / `(a, b, c)?!`)
+/// byte-identical to HIR's `ResolvedExpr::IndependentProduct` arm
+/// (`super::expr`). The Rust backend is the one target that truly
+/// PARALLELIZES the product (the VM and wasm-gc lower it sequentially):
+/// each element runs on its own `std::thread::scope` thread.
+///
+/// Mirror notes (the three behaviors this arm must preserve to stay
+/// byte-equal under the parity gate):
+///
+/// 1. **`?!` (`unwrap_results == true`).** A shared `__cancel_flag`
+///    (`Arc<AtomicBool>`) is threaded into every branch via
+///    `run_cancelable_branch`; a branch that produces `Err` sets the
+///    flag so siblings can short-circuit (the *cancel* independence
+///    mode — `complete` ignores the flag, but the emitted shape is the
+///    same; the runtime decides). Joined branches are folded by
+///    `emit_parallel_result_tuple_unwrap` (which unwraps the
+///    `ParallelBranch::Completed` wrapper, then propagates the first
+///    `Err` with `?`).
+/// 2. **`!` (`unwrap_results == false`).** Same `thread::scope`/`spawn`,
+///    but no cancel flag and no unwrap — joined branch values fold
+///    straight into a tuple via `emit_tuple_from_vars` (a bare product
+///    of `Result`s, preserved positionally).
+/// 3. **Replay sequential fallback.** When `emit_replay_runtime` is on,
+///    the parallel body is wrapped in
+///    `if is_effect_tracking_active() { <sequential replay groups> }
+///    else { <parallel> }`. The sequential arm uses
+///    `enter_effect_group` / `set_effect_branch(i)` / `exit_effect_group`
+///    so per-branch effects record/replay deterministically on one
+///    thread; the parallel arm additionally captures + re-installs the
+///    parallel scope context per spawned branch.
+///
+/// Each element is rendered through `mir_clone_arg` (the byte-identical
+/// mirror of HIR's `clone_arg`). The `run_cancelable_branch` /
+/// `ParallelBranch` / parallel-scope runtime is emitted UNCONDITIONALLY
+/// by `super::runtime`, so no new runtime is needed.
+fn emit_mir_independent_product(
+    ip: &crate::ir::mir::MirIndependentProduct,
+    emit_ctx: &MirEmitCtx<'_>,
+) -> Option<String> {
+    let mut parts: Vec<String> = Vec::with_capacity(ip.items.len());
+    for it in &ip.items {
+        parts.push(mir_clone_arg(
+            emit_mir_expr(it, emit_ctx)?,
+            &it.node,
+            emit_ctx,
+        ));
+    }
+
+    let n = parts.len();
+    // The replay flag lives on the full `CodegenContext`; the coverage /
+    // test path has none → treat as no replay (mirror of HIR's
+    // `ctx.emit_replay_runtime`, conservative on the coverage walk).
+    let has_replay = emit_ctx.codegen.is_some_and(|c| c.emit_replay_runtime);
+    let unwrap = ip.unwrap_results;
+
+    let mut code = String::new();
+    if has_replay {
+        // Runtime branch: if recording/replaying, execute sequentially
+        // with replay groups (thread_local state stays on one thread).
+        code.push_str("if crate::aver_replay::is_effect_tracking_active() { ");
+        code.push_str("crate::aver_replay::enter_effect_group(); ");
+        for (i, part) in parts.iter().enumerate() {
+            code.push_str(&format!(
+                "crate::aver_replay::set_effect_branch({i}); let _r{i} = {part}; "
+            ));
+        }
+        code.push_str("crate::aver_replay::exit_effect_group(); ");
+        if unwrap {
+            code.push_str(&emit_result_tuple_unwrap("_r", "__v", n));
+            code.push('?');
+        } else {
+            code.push_str(&emit_tuple_from_vars("_r", n));
+        }
+        code.push_str(" } else { ");
+    }
+
+    if unwrap {
+        code.push_str("{ ");
+        if has_replay {
+            code.push_str(
+                "let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); ",
+            );
+        }
+        code.push_str(
+            "let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); ",
+        );
+        code.push_str("std::thread::scope(|_s| { ");
+        for (i, part) in parts.iter().enumerate() {
+            if has_replay {
+                code.push_str(&format!(
+                    "let __parallel_scope{i} = __parallel_scope.clone(); "
+                ));
+            }
+            code.push_str(&format!("let __cancel_flag{i} = __cancel_flag.clone(); "));
+            code.push_str(&format!("let _h{i} = _s.spawn(move || "));
+            if has_replay {
+                code.push_str(&format!(
+                    "crate::aver_replay::with_parallel_scope_context(__parallel_scope{i}.clone(), move || "
+                ));
+            }
+            code.push_str("{ crate::run_cancelable_branch(__cancel_flag");
+            code.push_str(&i.to_string());
+            code.push_str(".clone(), move || { let __result = ");
+            code.push_str(part);
+            code.push_str("; if let Err(_) = &__result { __cancel_flag");
+            code.push_str(&i.to_string());
+            code.push_str(".store(true, std::sync::atomic::Ordering::Relaxed); } __result }) }");
+            if has_replay {
+                code.push(')');
+            }
+            code.push_str("); ");
+        }
+        for i in 0..n {
+            code.push_str(&format!("let _b{i} = _h{i}.join().unwrap(); "));
+        }
+        code.push_str(&emit_parallel_result_tuple_unwrap("_b", "_r", "__v", n));
+        code.push_str(" })? }");
+    } else {
+        if has_replay {
+            code.push_str(
+                "let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); ",
+            );
+        }
+        code.push_str("std::thread::scope(|_s| { ");
+        for (i, part) in parts.iter().enumerate() {
+            if has_replay {
+                code.push_str(&format!(
+                    "let __parallel_scope{i} = __parallel_scope.clone(); "
+                ));
+                code.push_str(&format!(
+                    "let _h{i} = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope{i}.clone(), move || {part})); "
+                ));
+            } else {
+                code.push_str(&format!("let _h{i} = _s.spawn(move || {part}); "));
+            }
+        }
+        for i in 0..n {
+            code.push_str(&format!("let _r{i} = _h{i}.join().unwrap(); "));
+        }
+        code.push_str(&emit_tuple_from_vars("_r", n));
+        code.push_str(" }) ");
+    }
+
+    if has_replay {
+        code.push('}');
+    }
+    Some(code)
 }
 
 /// Emit `MirExpr::IfThenElse` byte-identical to HIR's
@@ -3135,14 +3288,15 @@ mod tests {
 
     #[test]
     fn returns_none_for_unsupported_variant() {
-        // Pick a variant the walker doesn't cover — IndependentProduct.
-        let ip = span(MirExpr::IndependentProduct(span(
-            crate::ir::mir::MirIndependentProduct {
-                items: vec![],
-                unwrap_results: false,
-            },
-        )));
-        assert!(emit_mir_expr(&ip, &empty_ctx()).is_none());
+        // Pick a variant the walker doesn't cover — `InterpolatedStr`.
+        // (The pipeline contract guarantees `ir::interp_lower` rewrites it
+        // away before Rust codegen, so the walker deliberately leaves it in
+        // the `_ => None` catch-all; reaching it raw signals fall back to
+        // HIR.)
+        let interp = span(MirExpr::InterpolatedStr(vec![
+            crate::ir::mir::MirStrPart::Literal("x".to_string()),
+        ]));
+        assert!(emit_mir_expr(&interp, &empty_ctx()).is_none());
     }
 
     #[test]
@@ -3185,6 +3339,68 @@ mod tests {
         let expr = span(MirExpr::Tuple(vec![a, b]));
         let emit = emit_mir_expr(&expr, &empty_ctx()).expect("tuple should emit");
         assert_eq!(emit, "(7i64, 9i64)");
+    }
+
+    #[test]
+    fn emits_bare_independent_product_as_parallel_tuple() {
+        // `(7, 9)!` — bare product (no unwrap). No replay (empty ctx),
+        // so the parallel `thread::scope` body folds straight into a
+        // tuple via `emit_tuple_from_vars`. Byte-identical to HIR's
+        // `ResolvedExpr::IndependentProduct` `!` arm.
+        let a = span(MirExpr::Literal(span(crate::ast::Literal::Int(7))));
+        let b = span(MirExpr::Literal(span(crate::ast::Literal::Int(9))));
+        let expr = span(MirExpr::IndependentProduct(span(
+            crate::ir::mir::MirIndependentProduct {
+                items: vec![a, b],
+                unwrap_results: false,
+            },
+        )));
+        let emit = emit_mir_expr(&expr, &empty_ctx()).expect("bare product should emit");
+        assert_eq!(
+            emit,
+            "std::thread::scope(|_s| { let _h0 = _s.spawn(move || 7i64); \
+             let _h1 = _s.spawn(move || 9i64); let _r0 = _h0.join().unwrap(); \
+             let _r1 = _h1.join().unwrap(); (_r0, _r1) }) "
+        );
+    }
+
+    #[test]
+    fn emits_unwrap_independent_product_with_cancel_flag() {
+        // `(7, 9)?!` — unwrap product. No replay (empty ctx), so the
+        // `?!` path emits the shared `__cancel_flag`, one
+        // `run_cancelable_branch` spawn per element, joins, then the
+        // `emit_parallel_result_tuple_unwrap` fold + trailing `?`.
+        // Byte-identical to HIR's `ResolvedExpr::IndependentProduct`
+        // `?!` arm.
+        let a = span(MirExpr::Literal(span(crate::ast::Literal::Int(7))));
+        let b = span(MirExpr::Literal(span(crate::ast::Literal::Int(9))));
+        let expr = span(MirExpr::IndependentProduct(span(
+            crate::ir::mir::MirIndependentProduct {
+                items: vec![a, b],
+                unwrap_results: true,
+            },
+        )));
+        let emit = emit_mir_expr(&expr, &empty_ctx()).expect("unwrap product should emit");
+        assert!(
+            emit.starts_with(
+                "{ let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); \
+                 std::thread::scope(|_s| { "
+            ),
+            "got: {emit}"
+        );
+        assert!(
+            emit.contains("crate::run_cancelable_branch(__cancel_flag0"),
+            "got: {emit}"
+        );
+        assert!(
+            emit.contains("crate::run_cancelable_branch(__cancel_flag1"),
+            "got: {emit}"
+        );
+        assert!(
+            emit.contains("crate::ParallelBranch::Completed"),
+            "got: {emit}"
+        );
+        assert!(emit.trim_end().ends_with("})? }"), "got: {emit}");
     }
 
     #[test]

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -1112,3 +1112,98 @@ fn mir_tco_deep_self_and_mutual_recursion_behaves() {
     let _ = fs::remove_dir_all(&ws);
     result.unwrap_or_else(|e| panic!("{e}"));
 }
+
+// ─── Mode (f): MIR-emitted IndependentProduct (`?!` / `!`) ────────────────
+//
+// The MIR walker now emits `MirExpr::IndependentProduct` — the Rust
+// backend's truly-PARALLEL product (`std::thread::scope` + per-branch
+// `spawn`, the cancel-flag machinery for `?!`, the bare tuple fold for
+// `!`). The `?!` fns byte-graduate under the normal parity gate; the
+// bare `!` fns that carry a literal negation in an argument diverge only
+// on a pre-existing `Neg` fold (`(0i64 - 5i64)` vs `(-5i64)`, which is
+// semantically equal), orthogonal to the product shape. Under
+// `AVER_RUST_MIR_ONLY=1` ALL of them are forced onto the MIR path, so
+// this probe proves the MIR walker OWNS the parallel emission and the
+// built binary still produces VM-identical output.
+//
+// `independent_fanout.av` exercises `?!` (flatOk, processStep — recursive
+// fan-out), bare `!` (flatFail, bareProduct), and the `Err`-propagation
+// path, so a dropped cancel flag, a wrong tuple fold, or a dropped
+// unwrap would change stdout here.
+
+#[test]
+fn mir_forced_independent_product_builds_and_matches_vm() {
+    let relative = "examples/core/independent_fanout.av";
+    let file = repo_root().join(relative);
+    if !file.exists() {
+        panic!("{relative}: corpus file missing");
+    }
+
+    let vm_stdout = run_vm(&file, None).unwrap_or_else(|e| panic!("VM run failed: {e}"));
+
+    let ws = temp_dir("mir-ip");
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let name = "mir_ip_fanout";
+    let hatch = [("AVER_RUST_MIR_ONLY", "1")];
+
+    let result = (|| -> Result<(), String> {
+        // (0) PROVE the MIR path is exercised: the IndependentProduct fns
+        // must graduate onto MIR under the hatch. Without this guard a
+        // silent HIR fallback would let the probe pass for the wrong
+        // reason.
+        let grad = graduated_count(&file, None, &[], &hatch)?;
+        if grad == 0 {
+            return Err(
+                "no fn graduated onto the MIR path under AVER_RUST_MIR_ONLY=1 — the \
+                 IndependentProduct emit is not being exercised by the MIR walker"
+                    .to_string(),
+            );
+        }
+
+        // Force the MIR body onto production for every renderable fn, so
+        // the parallel IndependentProduct shape is MIR-emitted (not the
+        // byte-equal HIR fallback), then build + run.
+        compile_rust_env(&file, &project, name, None, &[], &hatch)?;
+
+        // Structural tripwire: the emitted Rust must carry the MIR-
+        // emitted parallel product machinery (the cancel-flag branch
+        // runner for `?!` and the `thread::scope` fan-out).
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted module: {e}"))?;
+        if !emitted.contains("run_cancelable_branch") || !emitted.contains("std::thread::scope") {
+            return Err(format!(
+                "emitted Rust is missing the parallel IndependentProduct machinery \
+                 (run_cancelable_branch / thread::scope) — the MIR product emit was \
+                 dropped:\n{emitted}"
+            ));
+        }
+
+        let bin = cargo_build(&project, name)?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("failed to run compiled binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "MIR IndependentProduct binary exited non-zero:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "MIR IndependentProduct stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust (MIR) ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}


### PR DESCRIPTION
First **W6/Stage-0** wave — closing the construct gaps that pin the rust HIR walker so it can eventually be deleted (completing all-backends-on-MIR, after VM #339 / wasm-gc #384).

The MIR walker now emits `MirExpr::IndependentProduct` (the `?!` / `!` independent-products operator) byte-identical to the HIR walker, behind the existing per-fn parity gate. This was the #1 construct gap (~13 corpus fns). The MIR node already existed and was fully lowered (VM + wasm-gc consume it) — this teaches the rust walker to render it, replacing a `_ => None`.

## What
- New `emit_mir_independent_product` mirrors the HIR arm (`expr.rs:249-352`) line-for-line, with `clone_arg` → `mir_clone_arg(emit_mir_expr(it)?, …)` and `ctx.emit_replay_runtime` reached via `ctx.codegen`. Covers `?!` (unwrap, shared `Arc<AtomicBool>` cancel flag + `std::thread::scope`/`run_cancelable_branch` per element + `emit_parallel_result_tuple_unwrap` + `?`), `!` (bare tuple via `emit_tuple_from_vars`), and the `is_effect_tracking_active()` sequential replay fallback.
- Reuses the three pure tuple/unwrap helpers (widened to `pub(super)`, no body change) and the parallel runtime (already emitted unconditionally) — **no new runtime**. Rust keeps its true parallelism; VM/wasm-gc stay sequential (independence ≠ parallelism, by design).
- HIR walker behaviorally unchanged (only the 3 helper visibilities widened).

## Result
IndependentProduct is no longer a None-blocker: `?!` fns byte-graduate; bare-`!` fns differ only on a pre-existing orthogonal `Neg`-fold (the documented W4 bucket) and fall back safely — the IndependentProduct shape itself is byte-identical.

## Verified (independently re-run)
- Diff is 3 files: `expr.rs` (+10, three `pub(super)` widenings only — grep-confirmed zero behavior change), `from_mir.rs` (+234, the arm — grep-confirmed no policy/replay machinery added), `tests/rust_codegen_differential.rs` (+95, the new forced-MIR test).
- New `mir_forced_independent_product_builds_and_matches_vm` (graduation>0 guard + parallel-machinery tripwire + cargo build + run-vs-VM): green in my independent run.
- Full `cargo test` (default): green. `--features wasm` + wasip2: green. Differential full tier (`--include-ignored`): **8/8**. Self-host regen: green. HIR output byte-identical with the flag off (raw self-host regen diff = 0).
- `cargo build`/`clippy`/`fmt --check` clean, zero new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)