### PR TITLE
rust-on-MIR W6/Stage-0: route main() + top-level statements through MIR

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -988,6 +988,78 @@ pub(super) fn emit_mir_verify_expr(
     emit_mir_expr(&lowered, &emit_ctx)
 }
 
+/// rust-on-MIR W6/Stage-0: render the **`main` fn body** through the MIR
+/// walker. `main` is the one entry-point that DOES carry a
+/// `ResolvedFnDef` (reachable via `fn_id_for_decl` →
+/// `resolved_program.fn_by_id` → `mir_program.fn_by_id`), so — unlike the
+/// free-standing verify / top-stmt exprs — its body has a real fn anchor:
+/// we build the borrow policy from the resolved main (`from_resolved`,
+/// borrow-by-default like the non-TCO HIR path) and emit via the same
+/// `for_fn` ctx + `emit_mir_fn_body` the production parity gate uses for
+/// every other fn.
+///
+/// `fn_id` is the resolved-main FnId the caller already computed
+/// (`entry_module_sections` runs `fn_id_for_decl` for every fn). Returns
+/// `None` when there's no MIR program, the main FnId has no lowered
+/// `MirFn` (body outside the lowerable subset — e.g. multi-statement
+/// bodies whose intermediate `Stmt::Expr` lower to synthetic-named lets),
+/// or the walker can't render the body — the signal for the caller to
+/// fall back to the HIR per-statement main-body emit. The `fn main()` /
+/// `-> Result<…>` signature and the guest/replay wrappers are unaffected;
+/// only the body string moves onto MIR.
+pub(super) fn emit_mir_main_body(fn_id: crate::ir::FnId, ctx: &CodegenContext) -> Option<String> {
+    let mir_fn = ctx.mir_program.as_ref()?.fn_by_id(fn_id)?;
+    let resolved = ctx.resolved_program.fn_by_id(fn_id)?;
+    // Main lives in the entry module → no module scope. Borrow-by-default
+    // matches the non-TCO HIR path the main body uses (`build_fn_ectx`).
+    let policy = MirFnEmitPolicy::from_resolved(resolved, None, /* borrow_by_default */ true);
+    let emit_ctx = MirEmitCtx::for_fn(ctx, &policy);
+    emit_mir_fn_body(&mir_fn.body, &emit_ctx)
+}
+
+/// rust-on-MIR W6/Stage-0: render every **top-level statement value**
+/// through the MIR walker, all-or-nothing. Free-standing module-scope
+/// statements (`x = expr` / a bare `expr`) belong to no `ResolvedFnDef`,
+/// so this mirrors the VM top-level path (#338): clone the entry
+/// `MirProgram` ONCE (so the lowerer's builtin / instantiation table
+/// growth stays consistent across all the statements that share it),
+/// lower each statement's already-resolved value via
+/// `lower_top_level_value`, and **pre-check** that every value both
+/// lowers AND the walker renders it — deciding before emitting anything
+/// so a mid-walk reject never leaves a half-written main body (exactly
+/// what the VM `compile_top_level` does with `mir_expr_compilable`).
+///
+/// Returns the rendered value strings in statement order on full success
+/// (the caller wraps each in the `let {name} = …;` / bare-expr-discard
+/// `…;` templating, identical to the HIR `emit_stmt` shapes), or `None`
+/// if there's no MIR program or ANY statement falls outside the lowerable
+/// / renderable subset — the signal for the caller to fall back to the
+/// HIR per-statement `emit_stmt_legacy` path for the whole block.
+pub(super) fn emit_mir_top_stmt_values(
+    resolved_values: &[&Spanned<crate::ir::hir::ResolvedExpr>],
+    ctx: &CodegenContext,
+) -> Option<Vec<String>> {
+    let base = ctx.mir_program.as_ref()?;
+    // One clone shared across every statement: the lowerer grows its
+    // builtin / instantiation tables in place, so all the `Call(Builtin)`
+    // ids the walker resolves key off the same grown table (mirrors the
+    // VM lowering one `prog` for the whole `__top_level__` chunk).
+    let mut prog = base.clone();
+    let lowered: Vec<Spanned<MirExpr>> = resolved_values
+        .iter()
+        .map(|value| crate::ir::mir::lower_top_level_value(value, &mut prog).ok())
+        .collect::<Option<_>>()?;
+    let policy = MirFnEmitPolicy::empty();
+    let emit_ctx = MirEmitCtx::program_level(ctx, &policy, &prog.builtins);
+    // All-or-nothing: render every value before returning any, so a
+    // single un-renderable statement falls the WHOLE block back to HIR
+    // rather than leaving a half-MIR / half-HIR main body.
+    lowered
+        .iter()
+        .map(|low| emit_mir_expr(low, &emit_ctx))
+        .collect::<Option<Vec<_>>>()
+}
+
 /// Emit `MirExpr::IndependentProduct` (`(a, b, c)!` / `(a, b, c)?!`)
 /// byte-identical to HIR's `ResolvedExpr::IndependentProduct` arm
 /// (`super::expr`). The Rust backend is the one target that truly
@@ -1652,6 +1724,36 @@ pub(super) fn mir_tco_enabled() -> bool {
 /// path cannot regress until W6 retires the HIR walker.
 pub(super) fn mir_verify_enabled() -> bool {
     std::env::var_os("AVER_RUST_MIR_VERIFY").is_some_and(|v| v == "1")
+}
+
+/// Is the rust-on-MIR W6/Stage-0 main / top-level-statement path active
+/// (`AVER_RUST_MIR_MAIN=1`)?
+///
+/// When set, the `main` fn BODY is rendered by the MIR walker (via
+/// [`emit_mir_main_body`] — main carries a real `ResolvedFnDef`, so it
+/// uses the same `for_fn` borrow policy as the production parity gate)
+/// and the TOP-LEVEL STATEMENT values are rendered all-or-nothing through
+/// [`emit_mir_top_stmt_values`] (the VM #338 isolation: one cloned
+/// program, pre-check every value renders before emitting any), instead
+/// of the source-AST HIR emitters (`emit_stmt_legacy` / `emit_expr_legacy`).
+/// The `fn main()` / `-> Result<…>` signature and the
+/// `aver_replay::with_guest_scope[_result]` guest wrapper stay unchanged
+/// template text; only the body / statement-value strings move onto MIR.
+/// Per-surface fallback to the HIR emit when the MIR body / any top-stmt
+/// value doesn't lower / the walker returns `None`.
+///
+/// A SEPARATE flag from `AVER_RUST_MIR_VERIFY` / `AVER_RUST_MIR_TCO` /
+/// `AVER_RUST_MIR_ONLY`: routing main / top-stmt emission through MIR is
+/// independent of verify routing, TCO synthesis, and effect-emission
+/// ownership.
+///
+/// Read from the env each call (cheap; only on the codegen path) so a
+/// test can toggle it per-process without a rebuild. Production default
+/// (UNSET) keeps the proven HIR main emitter — the emitted `fn main`
+/// is byte-identical to the pre-port output, so the self-host regen path
+/// cannot regress until W6 retires the HIR walker.
+pub(super) fn mir_main_enabled() -> bool {
+    std::env::var_os("AVER_RUST_MIR_MAIN").is_some_and(|v| v == "1")
 }
 
 /// `(graduated, considered)` since the last [`reset_parity_counters`].
@@ -3094,6 +3196,35 @@ mod tests {
         };
         let lit = span(MirExpr::Literal(span(crate::ast::Literal::Int(7))));
         assert_eq!(emit_mir_expr(&lit, &ctx).as_deref(), Some("7i64"));
+    }
+
+    #[test]
+    fn main_body_policy_borrows_by_default_like_hir() {
+        // `emit_mir_main_body` builds its policy from the resolved-main
+        // via `from_resolved(.., borrow_by_default = true)` — the same
+        // non-TCO borrow rules the HIR main body uses (`build_fn_ectx`).
+        // A `List<Int>` param borrows; an `Int` param does not. (Main
+        // usually has no params, but the policy must honour the same
+        // rule so a `main(args: List<String>)`-style entry borrows
+        // identically to every other fn.)
+        let resolved = crate::ir::hir::ResolvedFnDef {
+            fn_id: crate::ir::FnId(0),
+            name: "main".to_string(),
+            line: 1,
+            params: vec![
+                ("xs".to_string(), Type::List(Box::new(Type::Int))),
+                ("n".to_string(), Type::Int),
+            ],
+            return_type: Type::Unit,
+            effects: vec![],
+            desc: None,
+            body: std::sync::Arc::new(crate::ir::hir::ResolvedFnBody::Block(vec![])),
+            resolution: None,
+        };
+        let policy = MirFnEmitPolicy::from_resolved(&resolved, None, true);
+        assert!(policy.borrowed_params.contains("xs"));
+        assert!(!policy.borrowed_params.contains("n"));
+        assert!(policy.current_module_scope.is_none());
     }
 
     #[test]

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -562,7 +562,18 @@ fn entry_module_sections(
     }
 
     if main_fn.is_some() || !top_level_stmts.is_empty() {
-        sections.push(toplevel::emit_public_main(main_fn, top_level_stmts, ctx));
+        // rust-on-MIR W6/Stage-0: `main` carries a `ResolvedFnDef` (and so
+        // a lowered `MirFn`), reachable through the same identity-keyed
+        // `fn_id_for_decl` lookup the entry loop above runs for every
+        // other fn. Thread the FnId so the main-body emit can route the
+        // body through the MIR walker behind `AVER_RUST_MIR_MAIN`.
+        let main_fn_id = main_fn.and_then(|fd| crate::codegen::common::fn_id_for_decl(ctx, fd));
+        sections.push(toplevel::emit_public_main(
+            main_fn,
+            top_level_stmts,
+            ctx,
+            main_fn_id,
+        ));
     }
 
     sections

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -2864,23 +2864,35 @@ fn try_emit_trampoline_bool_if_else(
 }
 
 /// Emit the main function, incorporating top-level statements.
+///
+/// `main_fn_id` is the resolved-main `FnId` (the caller computes it via
+/// `fn_id_for_decl`); it lets the body route through the MIR walker under
+/// `AVER_RUST_MIR_MAIN`. `None` when there is no `main` fn (top-stmts-only
+/// entry) or the decl has no resolved twin.
 #[allow(dead_code)]
-pub fn emit_main(main_fn: Option<&FnDef>, top_stmts: &[&Stmt], ctx: &CodegenContext) -> String {
-    emit_main_with_visibility(main_fn, top_stmts, ctx, false)
+pub fn emit_main(
+    main_fn: Option<&FnDef>,
+    top_stmts: &[&Stmt],
+    ctx: &CodegenContext,
+    main_fn_id: Option<crate::ir::FnId>,
+) -> String {
+    emit_main_with_visibility(main_fn, top_stmts, ctx, main_fn_id, false)
 }
 
 pub fn emit_public_main(
     main_fn: Option<&FnDef>,
     top_stmts: &[&Stmt],
     ctx: &CodegenContext,
+    main_fn_id: Option<crate::ir::FnId>,
 ) -> String {
-    emit_main_with_visibility(main_fn, top_stmts, ctx, true)
+    emit_main_with_visibility(main_fn, top_stmts, ctx, main_fn_id, true)
 }
 
 fn emit_main_with_visibility(
     main_fn: Option<&FnDef>,
     top_stmts: &[&Stmt],
     ctx: &CodegenContext,
+    main_fn_id: Option<crate::ir::FnId>,
     public: bool,
 ) -> String {
     let mut out = String::new();
@@ -2914,39 +2926,111 @@ fn emit_main_with_visibility(
         }
     }
 
-    // Top-level statements first
-    for stmt in top_stmts {
-        let indent = if guest_wrap_main { "        " } else { "    " };
-        writeln!(out, "{}{}", indent, emit_stmt_legacy(stmt, ctx, &ectx)).unwrap();
+    let indent = if guest_wrap_main { "        " } else { "    " };
+
+    // Top-level statements first. rust-on-MIR W6/Stage-0: behind
+    // `AVER_RUST_MIR_MAIN`, render every statement VALUE through the MIR
+    // walker all-or-nothing (the VM #338 isolation), then re-apply the
+    // `let {name} = …;` / bare-expr `…;` templating per statement so the
+    // emitted shape matches `emit_stmt` exactly. If any statement value
+    // falls outside the lowerable / renderable subset, the helper returns
+    // `None` and the whole block falls back to the HIR `emit_stmt_legacy`
+    // path (so we never leave a half-MIR / half-HIR set of statements).
+    let mir_top_stmts = if super::from_mir::mir_main_enabled() && !top_stmts.is_empty() {
+        let resolved: Vec<Spanned<crate::ir::hir::ResolvedExpr>> = top_stmts
+            .iter()
+            .map(|stmt| {
+                let value = match stmt {
+                    Stmt::Binding(_, _, value) => value,
+                    Stmt::Expr(value) => value,
+                };
+                ctx.resolve_expr(value, ectx.current_module_scope.as_deref())
+            })
+            .collect();
+        let refs: Vec<&Spanned<crate::ir::hir::ResolvedExpr>> = resolved.iter().collect();
+        super::from_mir::emit_mir_top_stmt_values(&refs, ctx)
+    } else {
+        None
+    };
+    match mir_top_stmts {
+        Some(values) => {
+            for (stmt, value) in top_stmts.iter().zip(values.iter()) {
+                // Same templating as `emit_stmt`: `Binding` → a named
+                // `let`, `Expr` → a discarded statement.
+                let rendered = match stmt {
+                    Stmt::Binding(name, _, _) => {
+                        format!("let {} = {};", aver_name_to_rust(name), value)
+                    }
+                    Stmt::Expr(_) => format!("{};", value),
+                };
+                writeln!(out, "{}{}", indent, rendered).unwrap();
+            }
+        }
+        None => {
+            for stmt in top_stmts {
+                writeln!(out, "{}{}", indent, emit_stmt_legacy(stmt, ctx, &ectx)).unwrap();
+            }
+        }
     }
 
-    // Main function body
+    // Main function body. rust-on-MIR W6/Stage-0: behind
+    // `AVER_RUST_MIR_MAIN`, main carries a `ResolvedFnDef` (and a lowered
+    // `MirFn`), so render its whole body via the MIR walker
+    // (`emit_mir_main_body` — `for_fn` borrow policy, same as the
+    // production parity gate) and splice it in (re-indented one level
+    // deeper under the guest-scope wrapper). Falls back to the HIR
+    // per-statement emit when there's no MIR program / the main FnId has
+    // no lowered body / the walker can't render it.
     if let Some(fd) = main_fn {
-        let main_ectx = build_fn_ectx(fd, ctx, None);
-        let stmts = fd.body.stmts();
-        for (i, stmt) in stmts.iter().enumerate() {
-            let is_last = i == stmts.len() - 1;
-            if is_last && returns_result {
-                match stmt {
-                    Stmt::Binding(_, _, _) => {
-                        let indent = if guest_wrap_main { "        " } else { "    " };
+        let mir_body = if super::from_mir::mir_main_enabled() {
+            main_fn_id.and_then(|fn_id| super::from_mir::emit_mir_main_body(fn_id, ctx))
+        } else {
+            None
+        };
+        match mir_body {
+            Some(body) => {
+                // `emit_mir_main_body` returns a 4-space-indented body
+                // (`    crate::cancel_checkpoint();\n    …`); bump it one
+                // more level when wrapped in the guest scope so it lines
+                // up under the closure.
+                let body = if guest_wrap_main {
+                    indent_block(&body, 1)
+                } else {
+                    body
+                };
+                writeln!(out, "{}", body).unwrap();
+            }
+            None => {
+                let main_ectx = build_fn_ectx(fd, ctx, None);
+                let stmts = fd.body.stmts();
+                for (i, stmt) in stmts.iter().enumerate() {
+                    let is_last = i == stmts.len() - 1;
+                    if is_last && returns_result {
+                        match stmt {
+                            Stmt::Binding(_, _, _) => {
+                                writeln!(
+                                    out,
+                                    "{}{}",
+                                    indent,
+                                    emit_stmt_legacy(stmt, ctx, &main_ectx)
+                                )
+                                .unwrap();
+                            }
+                            Stmt::Expr(expr) => {
+                                writeln!(
+                                    out,
+                                    "{}{}",
+                                    indent,
+                                    emit_expr_legacy(&expr.node, ctx, &main_ectx)
+                                )
+                                .unwrap();
+                            }
+                        }
+                    } else {
                         writeln!(out, "{}{}", indent, emit_stmt_legacy(stmt, ctx, &main_ectx))
                             .unwrap();
                     }
-                    Stmt::Expr(expr) => {
-                        let indent = if guest_wrap_main { "        " } else { "    " };
-                        writeln!(
-                            out,
-                            "{}{}",
-                            indent,
-                            emit_expr_legacy(&expr.node, ctx, &main_ectx)
-                        )
-                        .unwrap();
-                    }
                 }
-            } else {
-                let indent = if guest_wrap_main { "        " } else { "    " };
-                writeln!(out, "{}{}", indent, emit_stmt_legacy(stmt, ctx, &main_ectx)).unwrap();
             }
         }
     }

--- a/tests/explain_passes_spec.rs
+++ b/tests/explain_passes_spec.rs
@@ -8,14 +8,23 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+// Parallel test fns share this binary's process, so a process-wide atomic
+// counter (plus pid) makes every `tempfile` path unique. nanos alone raced:
+// same-nanosecond callers got the same path and clobbered / removed each
+// other's files mid-compile, so a varying subset of tests failed per run.
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
 fn tempfile(prefix: &str, suffix: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    std::env::temp_dir().join(format!("{prefix}-{nanos}{suffix}"))
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("{prefix}-{pid}-{nanos}-{seq}{suffix}"))
 }
 
 fn run_explain_passes(source: &str) -> serde_json::Value {


### PR DESCRIPTION
Next **W6/Stage-0** wave — closing the construct gaps that pin the rust HIR walker so it can be deleted (after VM #339 / wasm-gc #384). `main()` + top-level statements were emitted via the HIR expr/stmt walkers; this routes them through the MIR walker behind a flag. Plus a drive-by fix for a flaky test that has been intermittently reddening CI.

## main() / top-stmts → MIR (behind `AVER_RUST_MIR_MAIN=1`)
- **main body** (`emit_mir_main_body`): main is the one entry-point carrying a `ResolvedFnDef` → lowered `MirFn`. Threads the main `fn_id` (computed at the `entry_module_sections` call site, where `fn_id_for_decl` already runs for every other fn) into `emit_main_with_visibility`, and renders the body via the same `MirEmitCtx::for_fn` + `emit_mir_fn_body` the production parity gate uses. Falls back to the HIR per-statement emit when there's no MIR body / walker returns None.
- **top-level statements** (`emit_mir_top_stmt_values`): mirrors VM #338 — clones the entry `MirProgram`, lowers each value via `lower_top_level_value`, then **all-or-nothing** pre-checks every value lowers AND `emit_mir_expr(...).is_some()` before emitting any (so a mid-walk reject never leaves half-written output); whole-block fallback to `emit_stmt_legacy`. The `let {name} = …;` / bare-expr templating is re-applied by the caller.
- The `fn main()` / `-> Result<…>` signature and the `aver_replay::with_guest_scope[_result]` guest wrapper stay pure templates around the MIR body. Reuses the program-level `MirEmitCtx` infra from the verify wave (#394).
- Flag OFF (production default) → byte-identical to pre-port (the original logic is preserved verbatim in the `None =>` fallback arms).

## Drive-by: fix flaky `explain_passes_spec` tempfile race
Its `tempfile` helper keyed only on a nanos timestamp + a shared prefix, so parallel test fns occasionally got the same path and removed/clobbered each other's source mid-compile — a *varying subset* of cases failed per run (the signature of a race, not a regression). Added a process-wide atomic counter + pid for unique paths. This flake intermittently reddened CI across the session; now stable (verified 3× green in a row).

## Verified (independently re-run)
- Flag-off byte-identical confirmed across 13 examples vs a baseline binary built from pre-change `f668c753`; guest_wrap_main / Result templates preserved.
- **`cargo clippy --workspace --all-targets`** (the gate that caught #393 — sibling crates): clean. `aver-lang` lib/bin clippy: clean.
- Full `cargo test` (default): green, 0 failed (incl. the now-stable explain_passes_spec). `--features wasm`: 1987 passed. wasip2 codegen: green.
- **Self-host regen under `AVER_RUST_MIR_MAIN=1`: green** — regenerates, builds, corpus parity 3/3; the self-host `main` body takes the MIR path. Flag-off self-host regen: green.
- Forced-flag single-expr main + pure top-stmts build + run == VM; real examples build+run parity-OK (safe fallback where the subset isn't covered).
- `cargo build`/`fmt --check` clean, zero new warnings.

Note: top-stmt graduation is currently bounded by reading a prior global binding as a fn arg lowering to `MirExpr::FnValue` (not yet rendered) — the all-or-nothing pre-check catches it and falls back safely. That's the next (final) Stage-0 wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)