### PR TITLE
rust-on-MIR W6/Stage-0 (final): emit FnValue + LocalSlot from MIR

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -24,13 +24,16 @@
 //! `Literal`, `Local`, `Neg`, `BinOp` (numeric ops, plus `Str` `+`
 //! concat — the right side borrowed for `AverStr`'s `Add<&AverStr>` —
 //! disambiguated from numeric add by the operands' type stamps),
-//! `Call` (`Fn` / `Builtin`), `Return`, `TailCall` (emitted as a plain
-//! call; the HIR self-TCO `continue` rewrite needs `ectx`, so the
-//! wire-up's parity check is the safety net), `Try` (`?`), `Tuple`,
-//! `List`, `MapLiteral`, `Let` (block-expr `{ let x = …; … }`),
+//! `Call` (`Fn` / `Builtin` / `Intrinsic` / `LocalSlot` — the last a
+//! first-class fn-pointer call `name(args…)`, post-#379 always a plain
+//! fn-pointer since `Type::Fn` is param-only), `Return`, `TailCall`
+//! (emitted as a plain call; the HIR self-TCO `continue` rewrite needs
+//! `ectx`, so the wire-up's parity check is the safety net), `Try` (`?`),
+//! `Tuple`, `List`, `MapLiteral`, `Let` (block-expr `{ let x = …; … }`),
 //! `Project`, `RecordCreate` / `RecordUpdate`, `Construct` (built-in and
 //! user ctors, including dep-module records resolved through
-//! `module_prefixes`), and `IfThenElse`.
+//! `module_prefixes`), `IfThenElse`, `IndependentProduct`, and `FnValue`
+//! (a fn referenced as a value — the `StaticRef` shape).
 //!
 //! `Match` (Wave 2) — `MirExpr::Match` emits through [`emit_mir_match`],
 //! mirroring HIR's `emit_match` / `emit_dispatch_table_match` /
@@ -42,9 +45,11 @@
 //! matches never reach this arm — the MIR optimizer's `bool_match_to_if`
 //! pass already rewrote them to `IfThenElse` (handled above).
 //!
-//! Not covered — these fall back to the HIR walker:
-//! `IndependentProduct` and `FnValue`. `InterpolatedStr` never reaches
-//! the walker — `interp_lower` lowers it away before codegen runs.
+//! `InterpolatedStr` never reaches the walker — `interp_lower` lowers it
+//! away before codegen runs. With `FnValue` + `LocalSlot` graduated
+//! (W6/Stage-0), every reachable MIR construct now has a walker arm; the
+//! remaining HIR fallbacks are per-fn byte-parity misses (e.g. the
+//! TCO-loop `continue` rewrite), not construct gaps.
 
 use std::collections::{HashMap, HashSet};
 
@@ -403,17 +408,13 @@ fn first_blocker(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) -> Option<&
             .or_else(|| first_blocker(&b.node.rhs, emit_ctx))
             .or(Some("BinOp")),
         MirExpr::Call(c) => {
-            // A `LocalSlot` callee (first-class fn value) is itself the
-            // blocker — the walker never recurses into it. `Fn`,
-            // `Builtin` and `Intrinsic` callees can all emit cleanly
-            // (Wave 3a graduated the pure builtins + intrinsics), so
-            // recurse into the args first and only report the callee
-            // kind when every arg emits but the call as a whole still
-            // returned `None` (an effectful / unresolved builtin, or an
-            // intrinsic / Fn shape the walker can't render).
-            if let MirCallee::LocalSlot { .. } = &c.node.callee {
-                return Some("Call(LocalSlot)");
-            }
+            // `Fn`, `Builtin`, `Intrinsic` and `LocalSlot` callees can all
+            // emit cleanly (Wave 3a graduated the pure builtins +
+            // intrinsics; W6/Stage-0 graduated the first-class `LocalSlot`
+            // fn-pointer call), so recurse into the args first and only
+            // report the callee kind when every arg emits but the call as a
+            // whole still returned `None` (an effectful / unresolved
+            // builtin, or a shape the walker can't render).
             for a in &c.node.args {
                 if let Some(b) = first_blocker(a, emit_ctx) {
                     return Some(b);
@@ -699,10 +700,25 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                 MirCallee::Intrinsic(intrinsic) => {
                     emit_mir_intrinsic_call(*intrinsic, &call.args, emit_ctx)
                 }
-                // First-class fn value held in a slot — too many
-                // dynamic-dispatch shapes to mirror here; ride the HIR
-                // walker.
-                MirCallee::LocalSlot { .. } => None,
+                // First-class fn value held in a slot — calling a `Fn(..)`
+                // param. Post-#379 the slot holds a plain fn-pointer (no
+                // closures / `dyn Fn` — `Type::Fn` is param-only), so this
+                // emits the direct call-by-name `name(args…)`. Mirror of
+                // HIR's `CallPlan::Dynamic` (`emit_fn_call_with_options`):
+                // the head is `aver_name_to_rust(name)` and every arg goes
+                // through `clone_arg`.
+                MirCallee::LocalSlot { name, .. } => {
+                    let func = aver_name_to_rust(name);
+                    let mut arg_strs = Vec::with_capacity(call.args.len());
+                    for a in &call.args {
+                        arg_strs.push(mir_clone_arg(
+                            emit_mir_expr(a, emit_ctx)?,
+                            &a.node,
+                            emit_ctx,
+                        ));
+                    }
+                    Some(format!("{}({})", func, arg_strs.join(", ")))
+                }
             }
         }
         MirExpr::Return(inner) => Some(format!("return {}", emit_mir_expr(inner, emit_ctx)?)),
@@ -953,7 +969,64 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
         MirExpr::IndependentProduct(spanned_ip) => {
             emit_mir_independent_product(&spanned_ip.node, emit_ctx)
         }
+        // A fn referenced as a *value* (`callWith(dbl)` passes `dbl`).
+        // Post-#379, a fn value only ever enters through a `Fn(..)` param,
+        // so the name is always a plain fn name — but mirror HIR's
+        // `ResolvedLeafOp::StaticRef` in full (incl. the variant-vs-fn
+        // refinement + module-path mangling) so the emit is byte-identical.
+        // The VM does the same (`compile_ident` → `symbol_ref`).
+        MirExpr::FnValue(name) => Some(emit_mir_static_ref(name, emit_ctx)),
         _ => None,
+    }
+}
+
+/// Mirror of HIR's `ResolvedLeafOp::StaticRef` emit
+/// (`src/codegen/rust/expr.rs`): a fn / variant referenced as a value.
+/// Refines a dotted name that resolves to a known user-defined variant to
+/// the Rust enum-variant form (`Shape::Point`); otherwise emits the
+/// module-mangled fn reference (`Fibonacci::fib`) or the bare
+/// `aver_name_to_rust(name)`. `Option.None` / `None` collapse to `None`.
+///
+/// `is_user_type` needs the full `CodegenContext`; on the coverage /
+/// test path (`codegen` is `None`) the variant refinement is skipped —
+/// the parity gate isn't active there, so the conservative fn-reference
+/// shape is fine (coverage only inspects `Some` vs `None`).
+fn emit_mir_static_ref(name: &str, ctx: &MirEmitCtx<'_>) -> String {
+    if name == "Option.None" || name == "None" {
+        return "None".to_string();
+    }
+    if let Some((type_name, variant_name)) = name.rsplit_once('.')
+        && let Some(cg) = ctx.codegen
+    {
+        let is_user = |n: &str| crate::codegen::common::is_user_type(n, cg);
+        if is_user(type_name) {
+            return if let Some((prefix, _)) = resolve_module_call(name, ctx.module_prefixes) {
+                let module_path = module_prefix_to_rust_path(prefix);
+                let bare_type = type_name
+                    .rsplit_once('.')
+                    .map(|(_, t)| t)
+                    .unwrap_or(type_name);
+                format!("{}::{}::{}", module_path, bare_type, variant_name)
+            } else {
+                format!("{}::{}", type_name, variant_name)
+            };
+        }
+        if let Some((_, bare_type)) = type_name.rsplit_once('.')
+            && is_user(bare_type)
+        {
+            return if let Some((prefix, _)) = resolve_module_call(name, ctx.module_prefixes) {
+                let module_path = module_prefix_to_rust_path(prefix);
+                format!("{}::{}::{}", module_path, bare_type, variant_name)
+            } else {
+                format!("{}::{}", bare_type, variant_name)
+            };
+        }
+    }
+    if let Some((prefix, bare)) = resolve_module_call(name, ctx.module_prefixes) {
+        let module_path = module_prefix_to_rust_path(prefix);
+        format!("{}::{}", module_path, aver_name_to_rust(bare))
+    } else {
+        aver_name_to_rust(name)
     }
 }
 

--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -158,7 +158,7 @@ fn write_call(f: &mut fmt::Formatter<'_>, call: &MirCall, indent: &str) -> fmt::
         MirCallee::Fn(id) => write!(f, "FnId({}).call(", id.0)?,
         MirCallee::Builtin(id) => write!(f, "Builtin(#{}).call(", id.0)?,
         MirCallee::Intrinsic(i) => write!(f, "Intrinsic({i:?}).call(")?,
-        MirCallee::LocalSlot { slot, .. } => write!(f, "slot({slot}).call(")?,
+        MirCallee::LocalSlot { slot, name, .. } => write!(f, "slot({slot}, {name}).call(")?,
     }
     write_args(f, &call.args, indent)?;
     write!(f, ")")

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -215,7 +215,14 @@ pub struct MirCall {
 /// — backends look up the canonical name via
 /// `SymbolTable::builtin_entry(id)` when they need to dispatch
 /// against the existing string-keyed runtime registries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Not `Copy`: the `LocalSlot` variant carries the source param
+/// `name` (re-added in W6/Stage-0 so the Rust walker can emit the
+/// fn-pointer call by name), and `String` isn't `Copy`. The
+/// slot-/id-keyed consumers (VM, wasm-gc) never copied the callee
+/// out by value — they pattern-match through a `&MirCall` — so the
+/// loss of `Copy` is inert there.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MirCallee {
     /// User-defined function (any module, including the current
     /// one). Resolved at HIR → MIR lowering — never a string.
@@ -239,7 +246,17 @@ pub enum MirCallee {
     /// The backend pushes the slot value (the callee) then the args and
     /// dispatches dynamically (the VM's `CALL_VALUE`). `last_use` lets
     /// the read use `MOVE_LOCAL` over `LOAD_LOCAL`.
-    LocalSlot { slot: u16, last_use: bool },
+    ///
+    /// `name` carries the source-level binder of the slot (the `Fn(..)`
+    /// param name). The slot-addressed VM ignores it; the Rust walker
+    /// needs it to emit the fn-pointer call by name (`name(args…)`),
+    /// mirroring HIR's `ResolvedCallee::LocalSlot { name, .. }`. Threaded
+    /// through verbatim from HIR at lowering (`lower.rs`).
+    LocalSlot {
+        slot: u16,
+        name: String,
+        last_use: bool,
+    },
 }
 
 /// `target(args…)` in tail position — same SCC as the surrounding fn.

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -305,9 +305,16 @@ fn lower_expr(
                 ResolvedCallee::Intrinsic(intrinsic) => MirCallee::Intrinsic(*intrinsic),
                 // First-class fn value in a local slot — `f(x)` where `f`
                 // is a `Fn(..)` param / let-bound fn. Dispatches through
-                // the VM's `CALL_VALUE` at the walker.
-                ResolvedCallee::LocalSlot { slot, last_use, .. } => MirCallee::LocalSlot {
+                // the VM's `CALL_VALUE` at the walker. `name` is threaded
+                // verbatim so the Rust walker can emit the fn-pointer call
+                // by name; the VM addresses by slot and ignores it.
+                ResolvedCallee::LocalSlot {
+                    slot,
+                    name,
+                    last_use,
+                } => MirCallee::LocalSlot {
                     slot: *slot,
+                    name: name.clone(),
                     last_use: last_use.0,
                 },
                 // Unresolved callees (typecheck-rejected recovery) still

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -308,7 +308,11 @@ pub(super) fn compile_mir_expr(
                     }
                     Ok(())
                 }
-                MirCallee::LocalSlot { slot, last_use } => {
+                MirCallee::LocalSlot {
+                    slot,
+                    last_use,
+                    name: _,
+                } => {
                     // First-class fn value: push the slot (the callee),
                     // then the args, then dynamic-dispatch via CALL_VALUE.
                     // Mirror of the HIR walker's compile_call fallback +

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -1207,3 +1207,144 @@ fn mir_forced_independent_product_builds_and_matches_vm() {
     let _ = fs::remove_dir_all(&ws);
     result.unwrap_or_else(|e| panic!("{e}"));
 }
+
+// ─── Mode (g): MIR-emitted first-class fn values ──────────────────────────
+//
+// W6/Stage-0 (the final construct gap): the MIR walker now emits
+// `MirExpr::FnValue` (a named fn used as a value — `applyIt(dbl, 21)`
+// passes `dbl`) and `MirCallee::LocalSlot` (calling a fn-typed param —
+// `f(v)` inside `applyIt`). Post-#379 a fn value can only enter through a
+// `Fn(..)` param, so the emitted Rust is a plain fn-pointer
+// (`fn(i64)->i64`) — no closure / `dyn Fn`, no monomorphization. Rust CAN
+// execute these (unlike wasm-gc, which traps), so this is an EMIT path,
+// not a trap-stub, and must produce VM-identical output.
+//
+// The corpus is thin on higher-order (only `pairSpec` in
+// `examples/formal/oracle_independent_products.av`, verify-only), so this
+// is an inline RUNTIME probe: `dbl` / `inc` are passed into `applyIt`
+// (FnValue in arg position), `applyIt` calls them through its slot
+// (LocalSlot). Under `AVER_RUST_MIR_ONLY=1` the FnValue / LocalSlot fns
+// are FORCED onto the MIR path, so the built binary's `a=42 b=42` proves
+// the MIR walker OWNS the first-class-fn emission (a dropped FnValue arg
+// or a mis-emitted slot call would change stdout or fail to build).
+const MIR_HIGHER_ORDER_PROBE: &str = r#"module HigherOrderProbe
+    intent =
+        "Probes first-class fn values: a fn passed as a Fn(..) param value"
+        "(MirExpr::FnValue) and called through that slot (MirCallee::LocalSlot)."
+    effects [Console]
+
+fn dbl(x: Int) -> Int
+    ? "Double a number."
+    x * 2
+
+fn inc(x: Int) -> Int
+    ? "Increment a number."
+    x + 1
+
+fn applyIt(f: Fn(Int) -> Int, v: Int) -> Int
+    ? "Apply a first-class fn value to v (calls through the slot — LocalSlot)."
+    f(v)
+
+fn runDouble(v: Int) -> Int
+    ? "Pass dbl as a fn value into applyIt (FnValue in arg position)."
+    applyIt(dbl, v)
+
+fn runInc(v: Int) -> Int
+    ? "Pass inc as a fn value into applyIt (FnValue in arg position)."
+    applyIt(inc, v)
+
+fn main() -> Unit
+    ! [Console.print]
+    a = runDouble(21)
+    b = runInc(41)
+    Console.print("a={a} b={b}")
+"#;
+
+#[test]
+fn mir_first_class_fn_value_builds_and_matches_vm() {
+    let ws = temp_dir("mir_ho");
+    let src = ws.join("higher_order_probe.av");
+    fs::write(&src, MIR_HIGHER_ORDER_PROBE).expect("write higher-order probe source");
+
+    let vm_stdout = run_vm(&src, None).unwrap_or_else(|e| panic!("VM run failed: {e}"));
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let name = "mir_ho_probe";
+    let hatch = [("AVER_RUST_MIR_ONLY", "1")];
+
+    let result = (|| -> Result<(), String> {
+        // (0) PROVE the MIR path is exercised: the FnValue / LocalSlot fns
+        // (`applyIt`, `runDouble`, `runInc`) must graduate onto MIR under
+        // the hatch. Without this guard a silent HIR fallback would let
+        // the probe pass for the wrong reason (the FnValue / LocalSlot
+        // emit would never run). `dbl` / `inc` / the three higher-order
+        // fns graduate; only `main` (a `Console.print` interpolation,
+        // `Call(Builtin)`) stays on HIR — so ≥ 5 must graduate.
+        let grad = graduated_count(&src, None, &[], &hatch)?;
+        if grad < 5 {
+            return Err(format!(
+                "expected ≥ 5 fns to graduate onto MIR under AVER_RUST_MIR_ONLY=1 \
+                 (dbl, inc, applyIt, runDouble, runInc) — got {grad}. The FnValue / \
+                 LocalSlot emit is not being exercised by the MIR walker."
+            ));
+        }
+
+        // Force the MIR body onto production for every renderable fn, so
+        // the FnValue arg + LocalSlot call are MIR-emitted (not the
+        // byte-equal HIR fallback), then build + run.
+        compile_rust_env(&src, &project, name, None, &[], &hatch)?;
+
+        // Structural tripwire: the emitted Rust must carry the fn-pointer
+        // param (`f: fn(i64) -> i64`), the FnValue passed by bare name
+        // (`applyIt(dbl, v)`), and the call-through-slot (`f(v)`). A
+        // dropped FnValue or a mis-emitted slot call would erase these.
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted module: {e}"))?;
+        if !emitted.contains("f: fn(i64) -> i64") {
+            return Err(format!(
+                "emitted Rust is missing the fn-pointer param `f: fn(i64) -> i64` — \
+                 the LocalSlot param lowering was dropped:\n{emitted}"
+            ));
+        }
+        if !emitted.contains("applyIt(dbl, v)") || !emitted.contains("applyIt(inc, v)") {
+            return Err(format!(
+                "emitted Rust is missing the FnValue arg `applyIt(dbl, v)` / \
+                 `applyIt(inc, v)` — the FnValue emit was dropped:\n{emitted}"
+            ));
+        }
+        if !emitted.contains("f(v)") {
+            return Err(format!(
+                "emitted Rust is missing the call-through-slot `f(v)` — the \
+                 LocalSlot call emit was dropped:\n{emitted}"
+            ));
+        }
+
+        let bin = cargo_build(&project, name)?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("failed to run compiled binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "MIR first-class-fn binary exited non-zero:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "MIR first-class-fn stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust (MIR) ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}


### PR DESCRIPTION
The **final** W6/Stage-0 wave — closes the LAST construct gap pinning the rust HIR walker. The MIR walker now emits `MirExpr::FnValue` (a named fn used as a value) and `MirCallee::LocalSlot` (calling a first-class fn held in a fn-typed param), byte-identical to the HIR walker. After this, every reachable MIR construct has a Rust walker arm → the HIR walker is deletable.

## What
- **FnValue** (`emit_mir_static_ref`): mirrors HIR's `ResolvedLeafOp::StaticRef` in full (None-collapse, user-variant-vs-fn refinement, module mangling). VM does the same (`compile_ident`).
- **LocalSlot** — the data-model fix: HIR's `ResolvedCallee::LocalSlot` carries `{slot, name, last_use}`, but MIR lowering had dropped the `name`. **Re-added `name: String` to `MirCallee::LocalSlot`** (which removes `#[derive(Copy)]` from `MirCallee` — a `String` field can't be `Copy`; the loss is inert because all slot-/id-keyed consumers pattern-match through `&MirCall`). The `emit_mir_expr` `LocalSlot` arm now emits `name(args…)` (args via `mir_clone_arg`), mirroring HIR's `CallPlan::Dynamic`. Post-#379 these are plain **fn-pointers** (`fn(P)->R`), not closures.
- Ripple (mechanical): `lower.rs` threads `name`; `dump.rs` renders `slot(idx, name)`; `vm/compiler/mir.rs` ignores it (`name: _`); wasm-gc needs no change. Rust **emits** real fn-pointer code (mirroring VM/HIR) — unlike wasm-gc which traps (it structurally can't execute first-class callables).
- These byte-match HIR → they graduate via the existing per-fn parity gate, **no new flag**.

## Verified (independently re-run)
- `MirCallee` Copy-removal is inert: **`cargo clippy --workspace --all-targets`** clean (the ripple compiles across all crates); full `cargo test` (default): 0 failed — VM/wasm-gc/dump MIR suites green (hir_mir_differential 45, vm_codegen 16, dump 3, phase4 6, explain_mir_coverage 4). `--features wasm`: 0 failed (wasm_gc differential MIR + games — behavior unchanged). wasip2 codegen: green.
- **Self-host regen: green with zero regen diff** — byte-parity preserved across the data-model change.
- **New higher-order regression** `mir_first_class_fn_value_builds_and_matches_vm`: an `applyIt(dbl, v)` program forced onto MIR, real `cargo build` + run → stdout == VM (`a=42 b=42`), with structural tripwires for the fn-pointer param, the FnValue arg, and the slot call. The corpus was thin on higher-order (only the verify-only `pairSpec`), so this fills the runtime gap.
- `cargo build`/`fmt --check` clean, zero new warnings.

With FnValue + LocalSlot graduated, **all reachable MIR constructs now emit from the Rust MIR walker** — Stage 0 complete. Remaining: Stage 1 (expand the forced-MIR behavioral net), Stage 2 (flip the flags default-on with HIR fallback for one release), Stage 3 (delete the HIR walker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)