### PR TITLE
rust-on-MIR: port 3 codegen fusions to the MIR walker (Stage-2 prep)

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -2755,6 +2755,145 @@ fn mir_str_arg_or_deref(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option
     Some(format!("&*{}", code))
 }
 
+/// Resolve a nested expression that is itself a `Call(Builtin(id))` to
+/// its canonical dotted name + arg slice. MIR lowering wipes the
+/// syntactic shape the HIR `ResolvedLeafOp` classifiers key off
+/// (`Option.withDefault` / `Result.withDefault` / `Vector.get` over a
+/// nested builtin), so the fusion recognizers
+/// ([`try_emit_mir_fusion`]) re-match the pattern over this resolved
+/// `(name, args)` form instead. Returns `None` for any non-`Call`, a
+/// non-`Builtin` callee, or an out-of-range / unresolved `BuiltinId`
+/// (the same defensive fallthrough the `Call(Builtin)` arm takes).
+fn mir_builtin_call_parts<'a, 'c>(
+    expr: &'a MirExpr,
+    ctx: &MirEmitCtx<'c>,
+) -> Option<(&'c str, &'a [Spanned<MirExpr>])> {
+    let MirExpr::Call(spanned_call) = expr else {
+        return None;
+    };
+    let call = &spanned_call.node;
+    let MirCallee::Builtin(id) = &call.callee else {
+        return None;
+    };
+    let name = ctx.mir_builtins.get(id.0 as usize)?.as_str();
+    Some((name, &call.args))
+}
+
+/// Two MIR exprs that name the SAME source local. Used by the
+/// `VectorSetOrDefaultSameVector` fusion's same-vector guard (HIR's
+/// `default_expr.node != inner_args[0].node` check). Compares by slot,
+/// not the whole `MirLocal`, because the two reads can carry different
+/// `last_use` flags (the outer default read is typically the last use
+/// of the slot, the inner `Vector.set` read is not) yet still denote
+/// the same vector. Synthetic / unnamed locals never match.
+fn mir_same_local(a: &MirExpr, b: &MirExpr) -> bool {
+    match (local_of(a), local_of(b)) {
+        (Some(la), Some(lb)) => la.slot == lb.slot,
+        _ => false,
+    }
+}
+
+/// Re-recognize the three codegen FUSIONS the HIR walker performs over
+/// pre-lowering `ResolvedLeafOp` shapes but MIR lowering flattens into
+/// nested builtin `Call`s. The HIR classifiers
+/// (`classify_vector_set_or_default` / `classify_int_mod_or_default` /
+/// `classify_list_index_get` in `ir::hir::classify`) match the
+/// syntactic AST; here we re-match the equivalent `MirExpr::Call`
+/// nesting and emit the EXACT fused Rust form the HIR `ResolvedLeafOp`
+/// emitter (`emit_leaf_op_with_options`, `expr.rs`) produces, so the
+/// byte-parity gate graduates these fns instead of falling back to the
+/// (un-fused, slower) generic builtin emit. Returns `None` when the
+/// outer call isn't one of the three fusion heads or the nested shape
+/// doesn't match — the caller then emits the generic builtin form.
+fn try_emit_mir_fusion(
+    name: &str,
+    args: &[Spanned<MirExpr>],
+    ctx: &MirEmitCtx<'_>,
+) -> Option<String> {
+    match name {
+        // Fusion #1: `Option.withDefault(Vector.set(v, i, x), v)` where
+        // both `v` are the SAME local → in-place bounds-checked set.
+        // HIR: `ResolvedLeafOp::VectorSetOrDefaultSameVector`.
+        "Option.withDefault" if args.len() == 2 => {
+            let (inner_name, inner_args) = mir_builtin_call_parts(&args[0].node, ctx)?;
+            if inner_name != "Vector.set" || inner_args.len() != 3 {
+                return None;
+            }
+            // Same-vector guard: the default arm (`args[1]`) must be the
+            // same local as the vector being set (`inner_args[0]`).
+            if !mir_same_local(&args[1].node, &inner_args[0].node) {
+                return None;
+            }
+            // HIR: vector + value via `clone_arg`, index via raw emit.
+            let vector = mir_clone_arg(
+                emit_mir_expr(&inner_args[0], ctx)?,
+                &inner_args[0].node,
+                ctx,
+            );
+            let index = emit_mir_expr(&inner_args[1], ctx)?;
+            let value = mir_clone_arg(
+                emit_mir_expr(&inner_args[2], ctx)?,
+                &inner_args[2].node,
+                ctx,
+            );
+            Some(format!(
+                "{{ let __vec = {}; let __idx = {} as usize; if __idx < __vec.len() {{ __vec.set_unchecked(__idx, {}) }} else {{ __vec }} }}",
+                vector, index, value
+            ))
+        }
+        // Fusion #2: `Result.withDefault(Int.mod(a, b), default)` → skip
+        // the `Result` allocation. HIR:
+        // `ResolvedLeafOp::IntModOrDefaultLiteral`.
+        "Result.withDefault" if args.len() == 2 => {
+            let (inner_name, inner_args) = mir_builtin_call_parts(&args[0].node, ctx)?;
+            if inner_name != "Int.mod" || inner_args.len() != 2 {
+                return None;
+            }
+            // The default arm must be a literal (HIR's
+            // `classify_int_mod_or_default` requires a literal default).
+            let MirExpr::Literal(default_lit) = &args[1].node else {
+                return None;
+            };
+            let a = &inner_args[0];
+            let b = &inner_args[1];
+            // Non-zero literal divisor → skip the runtime zero check.
+            if let MirExpr::Literal(b_lit) = &b.node
+                && let crate::ast::Literal::Int(n) = &b_lit.node
+                && *n != 0
+            {
+                let a_str = emit_mir_expr(a, ctx)?;
+                let b_str = emit_literal(&crate::ast::Literal::Int(*n));
+                Some(format!("({}).rem_euclid({})", a_str, b_str))
+            } else {
+                let a_str = emit_mir_expr(a, ctx)?;
+                let b_str = emit_mir_expr(b, ctx)?;
+                let default = emit_literal(&default_lit.node);
+                Some(format!(
+                    "{{ let __b = {}; if __b == 0i64 {{ {} }} else {{ ({}).rem_euclid(__b) }} }}",
+                    b_str, default, a_str
+                ))
+            }
+        }
+        // Fusion #3: `Vector.get(Vector.fromList(list), index)` → index
+        // the materialized `Vec` directly, skipping the intermediate
+        // `AverVector::from_vec` (an extra `Rc::new`). HIR:
+        // `ResolvedLeafOp::ListIndexGet`.
+        "Vector.get" if args.len() == 2 => {
+            let (inner_name, inner_args) = mir_builtin_call_parts(&args[0].node, ctx)?;
+            if inner_name != "Vector.fromList" || inner_args.len() != 1 {
+                return None;
+            }
+            let list = emit_mir_expr(&inner_args[0], ctx)?;
+            let index = emit_mir_expr(&args[1], ctx)?;
+            Some(format!(
+                "{}.to_vec().get({} as usize).cloned()",
+                list, index
+            ))
+        }
+        _ => None,
+    }
+}
+
 /// Emit a PURE builtin call from MIR, byte-identical to the HIR
 /// oracle's `emit_builtin_call` (minus the effectful / replay / policy
 /// branches, which never reach here). Returns `None` for any builtin
@@ -2765,6 +2904,17 @@ fn emit_mir_builtin_call(
     args: &[Spanned<MirExpr>],
     ctx: &MirEmitCtx<'_>,
 ) -> Option<String> {
+    // FUSIONS first: the HIR walker recognizes these
+    // `Option.withDefault` / `Result.withDefault` / `Vector.get` over a
+    // nested builtin shapes PRE-lowering and emits a fused form. MIR
+    // lowering flattens the shape, so re-recognize it here before the
+    // generic per-builtin arms below produce the un-fused (slower)
+    // output. Anything that doesn't match falls through to the generic
+    // emit, byte-identical to HIR's non-fused path.
+    if let Some(fused) = try_emit_mir_fusion(name, args, ctx) {
+        return Some(fused);
+    }
+
     // `emit_arg(i)`: raw emit (HIR's `emit_expr(&args[i].node, …)`).
     macro_rules! arg {
         ($i:expr) => {

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -769,29 +769,38 @@ mod tests {
 
     fn ctx_from_source(source: &str, project_name: &str) -> crate::codegen::CodegenContext {
         let mut items = parse_source(source).expect("source should parse");
-        crate::ir::pipeline::tco(&mut items);
-        let tc = crate::ir::pipeline::typecheck(
-            &items,
-            &crate::ir::TypecheckMode::Full { base_dir: None },
+        // Run the canonical compiler pipeline exactly as the CLI
+        // (`main::commands::compile`) does, so the in-process
+        // `resolved_items` / `symbol_table` / `analysis` — and the MIR
+        // `build_context` lowers from them — match the real pipeline.
+        // The previous hand-rolled tco + typecheck + `resolve_program`
+        // skipped the `last_use` and `analyze` stages, so its resolved
+        // AST carried no `last_use` stamps; the per-fn MIR then diverged
+        // from the CLI's (e.g. the `Option.withDefault(Vector.set(v, …),
+        // v)` fusion's same-vector reads lost their last-use ownership),
+        // silently testing a different MIR shape than production emits.
+        let pipeline_result = crate::ir::pipeline::run(
+            &mut items,
+            crate::ir::PipelineConfig {
+                typecheck: Some(crate::ir::TypecheckMode::Full { base_dir: None }),
+                run_build_symbols: true,
+                ..Default::default()
+            },
         );
+        let tc = pipeline_result.typecheck.expect("typecheck was requested");
         assert!(
             tc.errors.is_empty(),
             "source should typecheck without errors: {:?}",
             tc.errors
         );
-        // No pipeline analyze stage run here — supply a locally-built
-        // SymbolTable so build_context can populate its FnId-keyed
-        // sets. Cheap traversal, no analysis.
-        let symbol_table = crate::ir::SymbolTable::build(&items, &[]);
-        let resolved_items = crate::ir::hir::resolve_program(&symbol_table, &items);
         build_context(
             items,
             &tc,
-            None,
+            pipeline_result.analysis.as_ref(),
             project_name.to_string(),
             vec![],
-            symbol_table,
-            resolved_items,
+            pipeline_result.symbol_table,
+            pipeline_result.resolved_items,
         )
     }
 
@@ -1466,8 +1475,11 @@ fn loop(r: Result<Int, String>) -> Int
         let out = transpile(&mut ctx);
         let entry = generated_rust_entry_file(&out);
 
-        // Uses native Rust match directly (r cloned since not-Copy Ident without last_use info)
-        assert!(entry.contains("match r.clone() {"));
+        // Uses native Rust match directly. `r` is the match subject's
+        // last use, so the `last_use` pass (now run by `ctx_from_source`
+        // via the full pipeline, matching the CLI) lets it move into the
+        // match without a `.clone()`.
+        assert!(entry.contains("match r {"));
         assert!(entry.contains("Ok(n)"));
         assert!(!entry.contains("__dispatch_subject"));
     }
@@ -1494,8 +1506,11 @@ fn right(r: Result<Int, String>) -> Int
         let out = transpile(&mut ctx);
         let entry = generated_rust_entry_file(&out);
 
-        // Uses native Rust match directly (r cloned since not-Copy Ident without last_use info)
-        assert!(entry.contains("match r.clone() {"));
+        // Uses native Rust match directly. `r` is the match subject's
+        // last use, so the `last_use` pass (now run by `ctx_from_source`
+        // via the full pipeline, matching the CLI) lets it move into the
+        // match without a `.clone()`.
+        assert!(entry.contains("match r {"));
         assert!(entry.contains("Ok(n)"));
         assert!(!entry.contains("__dispatch_subject"));
     }


### PR DESCRIPTION
Ports the 3 HIR codegen fusions the MIR walker was missing, so its output is **>= HIR** everywhere — clearing the last optimization-fidelity blocker before the W6/Stage-2 flip (MIR flags default-on).

## Why
The Stage-2 flip probe surfaced that the per-fn byte-parity gate was silently protecting 3 HIR codegen fusions the MIR walker didn't replicate (byte-divergent fns fall back to HIR, so the fusion survives — but under MIR-default it would be lost). A full `AVER_RUST_MIR_DIFF` sweep classified all divergences: 49 are **MIR-better** (cleaner — leave them), and exactly 3 patterns were MIR-worse. MIR lowering flattens the syntactic shapes the HIR `ResolvedLeafOp` classifiers key off into nested builtin `Call`s, so the recognizers are re-expressed over the `MirExpr::Call(Builtin …)` nesting.

## The 3 fusions (`try_emit_mir_fusion` at the top of `emit_mir_builtin_call`)
1. **VectorSetOrDefaultSameVector** — `Option.withDefault(Vector.set(v,i,x), v)` (same slot) → `{ let __vec = v.clone(); let __idx = i as usize; if __idx < __vec.len() { __vec.set_unchecked(__idx, x) } else { __vec } }` (in-place fast path, not the generic `set_owned(...).unwrap_or(v.clone())`).
2. **IntModOrDefaultLiteral** — `Result.withDefault(Int.mod(a,b), lit)` → `(a).rem_euclid(litB)` for a non-zero literal divisor (skips the zero-check), else the guarded form.
3. **ListIndexGet** — `Vector.get(Vector.fromList(list), idx)` → `list.to_vec().get(idx as usize).cloned()`, dropping the extra `AverVector::from_vec` (`Rc::new`).

Helpers: `mir_builtin_call_parts` (resolve a nested `Call(Builtin)` to name+args via `ctx.mir_builtins`) + `mir_same_local` (compare by slot, ignoring the differing `last_use` flags).

## Test-harness fix
`ctx_from_source` hand-rolled `tco + typecheck + resolve`, skipping the `last_use`/`analyze` stages — so its resolved AST carried no ownership stamps and the in-process MIR diverged from the real CLI pipeline (this made 3 unit tests look like MIR regressions when MIR was already correct on CLI input). Replaced it with `pipeline::run` (the CLI's config). Re-pinned 2 TCO-match tests that had been pinned to the old last-use-less output (`match r.clone()` → the correct `match r {`).

## Verified (independently re-run)
- **Byte-parity / graduation** (`AVER_RUST_MIR_DIFF=1`): life.av `place`/`toggle`/`unplace` (#1), `formatFps` (#2), wumpus `neighbors` (#3) no longer appear as `[mir-diff]` — they byte-match HIR and graduate. Remaining diffs are the documented MIR-better cases (untouched).
- `cargo clippy --workspace --all-targets`: clean. Full `cargo test` (default): 0 failed — all codegen unit tests pass with the new `pipeline::run` harness (incl. the 5 previously-failing). `--features wasm` + wasip2: green. Self-host regen: green.
- `cargo build`/`fmt --check` clean, zero new warnings. Diff: 2 files, +181/−16.

After this, the MIR walker's output is >= HIR for every pattern → the Stage-2 flip (default-on) loses no optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)