### PR TITLE
rust-on-MIR W6/Stage-2: flip MIR codegen default-on (HIR retained as fallback)

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -1754,7 +1754,8 @@ pub(super) fn reset_parity_counters() {
 /// emission. Read from the env each call (cheap; only on the codegen
 /// path) so a test can toggle it per-process without a rebuild.
 fn mir_only_hatch_enabled() -> bool {
-    std::env::var_os("AVER_RUST_MIR_ONLY").is_some_and(|v| v == "1")
+    // W6/Stage-2: default ON; set `AVER_RUST_MIR_ONLY=0` to restore the byte-exact HIR fallback.
+    std::env::var_os("AVER_RUST_MIR_ONLY").is_none_or(|v| v != "0")
 }
 
 /// Is the rust-on-MIR Wave-5 TCO path active (`AVER_RUST_MIR_TCO=1`)?
@@ -1768,11 +1769,10 @@ fn mir_only_hatch_enabled() -> bool {
 /// not change effect-emission ownership, and vice versa.
 ///
 /// Read from the env each call (cheap; only on the codegen path) so a
-/// test can toggle it per-process without a rebuild. Production default
-/// (UNSET) keeps the proven HIR TCO emitter — zero regression risk to
-/// the self-host regen path until W6 retires the HIR walker.
+/// test can toggle it per-process without a rebuild. W6/Stage-2: default
+/// ON; set `AVER_RUST_MIR_TCO=0` to restore the HIR TCO emitter (rollback).
 pub(super) fn mir_tco_enabled() -> bool {
-    std::env::var_os("AVER_RUST_MIR_TCO").is_some_and(|v| v == "1")
+    std::env::var_os("AVER_RUST_MIR_TCO").is_none_or(|v| v != "0")
 }
 
 /// Is the rust-on-MIR W6/Stage-0 verify path active
@@ -1791,12 +1791,10 @@ pub(super) fn mir_tco_enabled() -> bool {
 /// and of effect-emission ownership.
 ///
 /// Read from the env each call (cheap; only on the codegen path) so a
-/// test can toggle it per-process without a rebuild. Production default
-/// (UNSET) keeps the proven HIR verify emitter — the emitted test
-/// module is identical to the pre-port output, so the self-host regen
-/// path cannot regress until W6 retires the HIR walker.
+/// test can toggle it per-process without a rebuild. W6/Stage-2: default
+/// ON; set `AVER_RUST_MIR_VERIFY=0` to restore the HIR verify emitter.
 pub(super) fn mir_verify_enabled() -> bool {
-    std::env::var_os("AVER_RUST_MIR_VERIFY").is_some_and(|v| v == "1")
+    std::env::var_os("AVER_RUST_MIR_VERIFY").is_none_or(|v| v != "0")
 }
 
 /// Is the rust-on-MIR W6/Stage-0 main / top-level-statement path active
@@ -1821,12 +1819,10 @@ pub(super) fn mir_verify_enabled() -> bool {
 /// ownership.
 ///
 /// Read from the env each call (cheap; only on the codegen path) so a
-/// test can toggle it per-process without a rebuild. Production default
-/// (UNSET) keeps the proven HIR main emitter — the emitted `fn main`
-/// is byte-identical to the pre-port output, so the self-host regen path
-/// cannot regress until W6 retires the HIR walker.
+/// test can toggle it per-process without a rebuild. W6/Stage-2: default
+/// ON; set `AVER_RUST_MIR_MAIN=0` to restore the HIR main emitter.
 pub(super) fn mir_main_enabled() -> bool {
-    std::env::var_os("AVER_RUST_MIR_MAIN").is_some_and(|v| v == "1")
+    std::env::var_os("AVER_RUST_MIR_MAIN").is_none_or(|v| v != "0")
 }
 
 /// `(graduated, considered)` since the last [`reset_parity_counters`].

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -1094,7 +1094,7 @@ record Audit
 
 fn useTwice(audit: Audit) -> List<Audit>
     first = [audit]
-    [audit]
+    List.concat(first, [audit])
 "#,
             "demo",
         );
@@ -1102,6 +1102,9 @@ fn useTwice(audit: Audit) -> List<Audit>
         let out = transpile(&mut ctx);
         let entry = generated_rust_entry_file(&out);
 
+        // `first` is consumed by `List.concat` so it stays live (an unused
+        // binding is correctly dead-code-eliminated); both `[audit]` literals
+        // then clone the borrowed `audit` because it is used more than once.
         assert!(entry.contains("let first = aver_rt::AverList::from_vec(vec![audit.clone()]);"));
         // Borrowed param always needs .clone() when consumed
         assert!(entry.contains("aver_rt::AverList::from_vec(vec![audit.clone()])"));
@@ -1119,7 +1122,7 @@ record PaymentState
 
 fn touch(state: PaymentState) -> String
     updated = PaymentState.update(state, currency = "EUR")
-    state.paymentId
+    "{updated.currency}-{state.paymentId}"
 "#,
             "demo",
         );
@@ -1127,6 +1130,9 @@ fn touch(state: PaymentState) -> String
         let out = transpile(&mut ctx);
         let entry = generated_rust_entry_file(&out);
 
+        // `updated` is consumed by the interpolation so it stays live; the
+        // record update then clones the borrowed `state` because `state` is
+        // used again afterward (`state.paymentId`).
         assert!(entry.contains("..state.clone()"));
     }
 


### PR DESCRIPTION
**W6/Stage-2** — the production flip. The four MIR routing flags (`AVER_RUST_MIR_ONLY`/`TCO`/`VERIFY`/`MAIN`) now **default to ON**: production Rust codegen emits from the MIR walker wherever it renders, falling back to the HIR walker only when MIR returns `None`. Set any flag to `0` to restore the HIR path (**rollback lever**). The HIR walker stays compiled in as the `None`-fallback this release; **Stage 3 deletes it** once this bakes (per the W6 audit: don't collapse Stage 2 into Stage 3).

## Why it's safe
- The standing forced-MIR behavioral net (#397) is green: full-corpus build+run-vs-VM (26/26), self-host regen, effect modes.
- Self-host regen is green on **MIR-default** (no flags): the ~26k-line compiler regenerates + builds + corpus parity 3/3.
- The 3 HIR codegen fusions the MIR walker had been missing were ported in #398 (`VectorSetOrDefaultSameVector`, `IntModOrDefaultLiteral`, `Vector.get(Vector.fromList)`), so MIR's output is **>= HIR** — flipping loses no optimization. (A full `AVER_RUST_MIR_DIFF` sweep found MIR is *better* in 49 places — clone-elision on correctly-typed locals, const-folding — and worse in none after #398.)
- Full `cargo test` (default, now MIR-default): **0 failed**. The 7 unit tests that pinned HIR-walker emit details are resolved: 5 in #398 (fusion ports + a `ctx_from_source` harness fix that switched it to the real `pipeline::run`), and 2 here — `list_literal_clones_ident_when_used_afterward` + `record_update_clones_base_when_value_is_used_afterward` now use live bindings so they exercise the genuine clone-on-reuse path (MIR correctly dead-code-eliminates the unused bindings the old sources happened to rely on).

## Verified (independently re-run)
- Full `cargo test` (default = MIR-default): 0 failed. `--features wasm`: 0 failed. `cargo clippy --workspace --all-targets`: clean. `cargo fmt --check`: clean.
- `AVER_SELF_HOST_REGEN=1` self-host regen (MIR-default): green, parity 3/3.
- Diff: `from_mir.rs` (the 4 flag helpers flipped to default-on via `is_none_or`, docs updated) + `mod.rs` (2 test sources → live bindings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)