### PR TITLE
rust-on-MIR: route guest-entry body through MIR (last construct pin)

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -1090,6 +1090,42 @@ pub(super) fn emit_mir_main_body(fn_id: crate::ir::FnId, ctx: &CodegenContext) -
     emit_mir_fn_body(&mir_fn.body, &emit_ctx)
 }
 
+/// rust-on-MIR W6/Stage-2 (guest-entry): render a **guest-entry fn's
+/// inner body** through the MIR walker. The guest-entry fn (the
+/// self-host's `runGuestCliProgram`) is the last construct still pinned
+/// to the HIR expr walker: its body is wrapped in the
+/// `aver_replay::with_guest_scope[_args][_result]` (replay scope) and
+/// `crate::self_host_support::with_program_fn_store` (self-host state)
+/// templates — pure string wrappers the caller keeps unchanged — but the
+/// INNER body string was still produced by `emit_fn_body` (HIR).
+///
+/// Unlike `main`, the caller already holds the `&ResolvedFnDef` (and its
+/// `fn_id`), so this takes the resolved fn directly rather than looking it
+/// up by `FnId`. The borrow policy is rebuilt exactly as the guest-entry
+/// HIR path's `ectx` is (`build_fn_ectx_from_resolved` — borrow-by-default,
+/// the non-TCO shape; guest-entry returns before the `has_tco` branch).
+/// `scope` is the owning module prefix (`None` for the entry-module
+/// guest-entry).
+///
+/// Returns `None` (→ HIR `emit_fn_body` fallback, so this stays
+/// non-regressing while HIR is still compiled) when there's no MIR
+/// program, the guest-entry FnId has no lowered `MirFn`, or the walker
+/// can't render the body. The covered subset (a `Match` over a user-fn
+/// call + `Str`-concat) renders cleanly, so under forced-MIR this is the
+/// MIR path; only the body string moves onto MIR, the replay /
+/// self-host-state wrappers stay template text.
+pub(super) fn emit_mir_guest_entry_body(
+    resolved_fd: &crate::ir::hir::ResolvedFnDef,
+    scope: Option<&str>,
+    ctx: &CodegenContext,
+) -> Option<String> {
+    let mir_fn = ctx.mir_program.as_ref()?.fn_by_id(resolved_fd.fn_id)?;
+    let policy =
+        MirFnEmitPolicy::from_resolved(resolved_fd, scope, /* borrow_by_default */ true);
+    let emit_ctx = MirEmitCtx::for_fn(ctx, &policy);
+    emit_mir_fn_body(&mir_fn.body, &emit_ctx)
+}
+
 /// rust-on-MIR W6/Stage-0: render every **top-level statement value**
 /// through the MIR walker, all-or-nothing. Free-standing module-scope
 /// statements (`x = expr` / a bare `expr`) belong to no `ResolvedFnDef`,

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -706,7 +706,23 @@ fn emit_fn_def_with_visibility(
             "{}fn {}({}) -> {} {{",
             visibility, fn_name, params, ret_type
         ));
-        let mut wrapped_body = emit_fn_body(&resolved_fd.body, ctx, &ectx);
+        // rust-on-MIR W6/Stage-2 (guest-entry): render the INNER body
+        // through the MIR walker behind the same `AVER_RUST_MIR_MAIN`
+        // gate the main wave (#395) uses — guest-entry is the last
+        // construct still pinned to the HIR expr walker. The
+        // `with_guest_scope[_args][_result]` / `with_program_fn_store`
+        // wrappers below stay UNCHANGED template text around the body.
+        // Falls back to the HIR `emit_fn_body` when there's no MIR program
+        // / the guest-entry FnId has no lowered `MirFn` / the walker
+        // returns `None`, so it stays non-regressing while HIR is still
+        // compiled.
+        let mir_body = if super::from_mir::mir_main_enabled() {
+            super::from_mir::emit_mir_guest_entry_body(resolved_fd, scope, ctx)
+        } else {
+            None
+        };
+        let mut wrapped_body =
+            mir_body.unwrap_or_else(|| emit_fn_body(&resolved_fd.body, ctx, &ectx));
         if let Some((prog_name, module_fns_name)) = &self_host_state {
             wrapped_body = format!(
                 "crate::self_host_support::with_program_fn_store({}.fns.clone(), {}.clone(), || {{\n{}\n}})",


### PR DESCRIPTION
Routes the guest-entry fn body through the MIR walker — the last CONSTRUCT pinning the rust HIR expr walker. `emit_mir_guest_entry_body` (analog of the main wave's `emit_mir_main_body`, #395) renders the inner body via the shared `emit_mir_fn_body`; the `with_guest_scope[_args][_result]` / `with_program_fn_store` / Result-`?` wrappers stay unchanged template text. Behind the (now default-on) `mir_main_enabled()` gate, with HIR `emit_fn_body` as the `None`-fallback. Diff: +53/−1.

`runGuestCliProgram` (the self-host's guest entry) now emits via MIR — confirmed by regenerating the self-host under forced-MIR.

## Verified (independently)
- `cargo clippy --workspace --all-targets`: clean. Full `cargo test` (MIR-default): 0 failed. `--features wasm`: green. wasip2: green.
- `AVER_SELF_HOST_REGEN=1` regen (both production-HIR and forced-MIR-all-flags): 2 passed, corpus parity 3/3.

## Stage-3 readiness — NOT yet (the zero-None dry-run is informative)
Guest-entry was the last *construct*, but not the last *None*. A forced-MIR dry-run found residual fns that still fall back to HIR: self-host 17 (effectful-builtin bodies + 1 mutual-TCO group), example corpus 219 (dominated by the **discarded-intermediate-statement** shape — a bare `Stmt::Expr` like `Console.print(g)` after a binding lowers to a synthetic empty-name `Let` that `emit_mir_let_chain_flat` rejects; plus mutual-TCO groups and free verify exprs). So deleting the HIR walker (making `None` a hard error) is not safe yet — those gaps must close first. This PR clears the construct pin; the `None`-closure waves follow before Stage 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)