### PR TITLE
rust: fix 3 unmasked codegen bugs (AverMap FromIterator, ?-on-borrowed-Result, cross-module fn-ref)

### DIFF
--- a/aver-rt/src/lib.rs
+++ b/aver-rt/src/lib.rs
@@ -316,6 +316,18 @@ where
     }
 }
 
+impl<K, V> FromIterator<(K, V)> for AverMap<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Self {
+            inner: Rc::new(iter.into_iter().collect()),
+        }
+    }
+}
+
 // ── AverVector: COW indexed sequence ─────────────────────────────────────────
 
 pub struct AverVector<T> {

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -746,10 +746,20 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             emit_named_call(&name, &tc.args, emit_ctx)
         }
         MirExpr::Try(inner) => {
-            // `value?` propagation. Mirror of
-            // HIR's `ResolvedExpr::ErrorProp` emit — append `?`
-            // to the inner expression's Rust form.
-            Some(format!("{}?", emit_mir_expr(inner, emit_ctx)?))
+            // `value?` propagation. `?` (the `Try` trait) is implemented
+            // for an owned `Result<T, E>`, not a borrowed `&Result`. When
+            // the inner is a borrowed-by-default `Result`-typed param
+            // (`fn foldNote(acc: &Result<…>, …)` then `acc?`), append `?`
+            // to a *cloned* owned value rather than the `&Result` read —
+            // otherwise rustc rejects `&Result` as not implementing
+            // `Try`. `mir_clone_arg` produces the right owning shape
+            // (`.clone()` for a borrowed param, `(*x).clone()` for an
+            // rc-wrapped pass-through), and leaves an owned last-use local
+            // a bare move — exactly what `?` consumes. Mirror of HIR's
+            // `ErrorProp` once the inner is in an owning position.
+            let inner_code = emit_mir_expr(inner, emit_ctx)?;
+            let owned = mir_clone_arg(inner_code, &inner.node, emit_ctx);
+            Some(format!("{}?", owned))
         }
         MirExpr::Tuple(items) => {
             // `(a, b, c)` tuple literal. Mirror
@@ -833,6 +843,25 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             // No clone insertion here; the HIR walker handles
             // that via `maybe_clone` at outer call sites.
             let proj = &spanned_proj.node;
+            // A cross-module first-class fn reference used as a value
+            // (`HttpServer.listen(port, Apps.Notepad.Routes.handleRequest)`)
+            // lowers to a `Project` chain over a `FnValue` head
+            // (`Project(Project(FnValue("Apps"), "Notepad"), "Routes"), "handleRequest")`)
+            // because the resolver leaves the leading segment an `Ident`
+            // and the rest dotted `Attr`. Collapse such a chain back to
+            // the canonical dotted name and, when it names a registered
+            // module-qualified symbol, emit the path-mangled static ref
+            // (`crate::aver_generated::apps::notepad::routes::handleRequest`)
+            // exactly as the `MirCallee::Fn` call path does — instead of
+            // the verbatim `Apps.Notepad.Routes.handleRequest` field
+            // access, which is not a valid Rust path. The HIR walker saw
+            // this as a single `StaticRef(full_name)`; on MIR the chain is
+            // re-flattened here.
+            if let Some(dotted) = collapse_fnvalue_projection(&expr.node)
+                && resolve_module_call(&dotted, emit_ctx.module_prefixes).is_some()
+            {
+                return Some(emit_mir_static_ref(&dotted, emit_ctx));
+            }
             let base = emit_mir_expr(&proj.base, emit_ctx)?;
             Some(format!("{}.{}", base, aver_name_to_rust(&proj.field)))
         }
@@ -980,6 +1009,23 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
         // refinement + module-path mangling) so the emit is byte-identical.
         // The VM does the same (`compile_ident` → `symbol_ref`).
         MirExpr::FnValue(name) => Some(emit_mir_static_ref(name, emit_ctx)),
+        _ => None,
+    }
+}
+
+/// Reconstruct the dotted source name of a `Project` chain whose head
+/// is a `FnValue` — e.g. `Project(Project(FnValue("Apps"), "Notepad"),
+/// "Routes")` → `"Apps.Notepad.Routes"`. Returns `None` for any chain
+/// whose head is not a `FnValue` (a genuine record-field access). Used
+/// to recover a cross-module first-class fn reference that the resolver
+/// split into an `Ident` head plus dotted `Attr` tail.
+fn collapse_fnvalue_projection(expr: &MirExpr) -> Option<String> {
+    match expr {
+        MirExpr::FnValue(name) => Some(name.clone()),
+        MirExpr::Project(p) => {
+            let base = collapse_fnvalue_projection(&p.node.base.node)?;
+            Some(format!("{}.{}", base, p.node.field))
+        }
         _ => None,
     }
 }

--- a/src/codegen/rust/runtime.rs
+++ b/src/codegen/rust/runtime.rs
@@ -187,25 +187,31 @@ pub(crate) fn should_skip_http_server() -> bool {{
     {replay_guard}
 }}
 
-pub fn http_server_listen<F>(port: i64, handler: F) -> Result<(), AverStr>
+pub fn http_server_listen<F>(port: i64, mut handler: F) -> Result<(), AverStr>
 where
-    F: FnMut(aver_rt::HttpRequest) -> aver_rt::HttpResponse,
+    F: FnMut(&aver_rt::HttpRequest) -> aver_rt::HttpResponse,
 {{
     if should_skip_http_server() {{
         return Ok(());
     }}
-    aver_rt::http_server::listen(port, handler).map_err(AverStr::from)
+    // User handlers are emitted borrow-by-default (`fn(&HttpRequest)`),
+    // so adapt the owned-value `aver_rt` callback to a by-reference call.
+    aver_rt::http_server::listen(port, move |req| handler(&req)).map_err(AverStr::from)
 }}
 
-pub fn http_server_listen_with<C, F>(port: i64, context: C, handler: F) -> Result<(), AverStr>
+pub fn http_server_listen_with<C, F>(port: i64, context: C, mut handler: F) -> Result<(), AverStr>
 where
     C: Clone,
-    F: FnMut(C, aver_rt::HttpRequest) -> aver_rt::HttpResponse,
+    F: FnMut(&C, &aver_rt::HttpRequest) -> aver_rt::HttpResponse,
 {{
     if should_skip_http_server() {{
         return Ok(());
     }}
-    aver_rt::http_server::listen_with(port, context, handler).map_err(AverStr::from)
+    // User handlers take both the context and the request by reference
+    // (`fn(&Ctx, &HttpRequest)`); adapt the owned-value `aver_rt`
+    // callback accordingly.
+    aver_rt::http_server::listen_with(port, context, move |ctx, req| handler(&ctx, &req))
+        .map_err(AverStr::from)
 }}"#
     )
 }


### PR DESCRIPTION
Fixes 3 pre-existing rust-codegen bugs (+1 coupled handler-ABI) that blocked 5 service/app examples once #403 made BranchPath emit. These were always present but masked — those programs never built on rust (they failed at BranchPath first), so their own codegen paths were never exercised. Root fixes, no per-example hacks. Diff: 3 files, +74/−10.

## Bugs
1. **`AverMap` had no `FromIterator`** (E0277) — map literals lower to `…into_iter().collect::<HashMap>()` and generated code aliases `HashMap = aver_rt::AverMap`, which lacked the impl. Added `impl<K,V> FromIterator<(K,V)> for AverMap` in `aver-rt`. Fixes `http_demo` + `weather` (the `Map<String,List<String>>` headers).
2. **`?` on a borrowed `&Result`** (E0277) — `foldNote(acc: &Result<…>) { … acc? }`: `Try` is on owned `Result`, not `&Result`. The MIR `Try` arm now routes the inner through `mir_clone_arg`, so a borrowed Result emits `acc.clone()?` while owned last-use values stay a bare move. Fixes `notepad/store` + `routes`.
3. **Cross-module fn-ref emitted verbatim** (E0425) — `Apps.Notepad.Routes.handleRequest` as a value lowers to a `Project`-chain rooted at a `FnValue`, emitted as the dotted source name. Added `collapse_fnvalue_projection` to re-flatten it and route through the same module-path mangling `MirCallee::Fn` uses. Fixes `notepad/app`.
- Coupled: HTTP-handler ABI — the `http_server_listen[_with]` shims now take `&HttpRequest`/`&C` to match the borrow-by-default user-fn ABI (was owned, E0631).

## Result
All 5 build on rust (0 rustc errors): `http_demo`, `weather`, `notepad/{store,routes,app}`. Verify-case parity vs VM confirmed for http_demo/weather/app.

**Known residuals (out of scope, `cargo test`-only, `cargo build` clean)**: `Int/Float.fromString` emits rustc's native parse error vs the VM's Aver-formatted message (a real cross-backend message divergence — separate follow-up); `routes` verify-test references a cross-module type `Note` unqualified (the verify-codegen sibling of bug #3). Both pre-existing.

## Verified (independently)
- `cargo clippy --workspace --all-targets`: clean. Full `cargo test` (default): 0 failed. `--features wasm`: 0 failed. Self-host regen: green.
- http_demo/weather/app → `cargo build` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)