### PR TITLE
rust: match VM's fromString error message + qualify cross-module verify-test types

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -322,6 +322,74 @@ fn resolve_module_call<'a>(
     best
 }
 
+/// Resolve a bare record `type_name` (`"Note"`) to the Rust path that
+/// names its struct. For a type defined in a `depends`-ed module the
+/// symbol table carries a scoped [`TypeKey`] (`scope = "Apps.Notepad.
+/// Store"`), so the canonical name is dotted and routes through
+/// [`resolve_module_call`] to the module-mangled path
+/// (`crate::aver_generated::apps::notepad::store::Note`). For an
+/// entry-scope type (`scope = None`) the canonical name is bare and
+/// no qualification is needed, so this returns `None` and the caller
+/// keeps the verbatim name (resolved in scope by the entry module's
+/// own `use`).
+///
+/// This is the verify-test-path sibling of the `Construct(User)`
+/// emit's module-path mangling: a `RecordCreate`/`RecordUpdate` of a
+/// cross-module type inside a `#[cfg(test)]` verify module has no
+/// glob `use` bringing the dep type into scope, so the reference must
+/// be fully qualified. Reuses [`resolve_module_call`] +
+/// [`module_prefix_to_rust_path`], the same helpers the runtime
+/// cross-module ctor / fn-ref emit uses.
+///
+/// Identity comes from the `MirRecordCreate.type_id` when present (the
+/// resolver's precise handle — robust against two dep modules sharing a
+/// bare type name); a `None` `type_id` falls back to the first
+/// symbol-table entry whose bare name matches.
+fn qualify_record_type(
+    type_id: Option<crate::ir::TypeId>,
+    type_name: &str,
+    ctx: &MirEmitCtx<'_>,
+) -> Option<String> {
+    let entry = match type_id {
+        Some(id) => ctx.symbol_table.type_entry(id),
+        None => ctx
+            .symbol_table
+            .types
+            .iter()
+            .find(|e| e.key.name == type_name)?,
+    };
+    let canonical = entry.key.canonical();
+    let (prefix, suffix) = resolve_module_call(&canonical, ctx.module_prefixes)?;
+    Some(format!(
+        "{}::{}",
+        module_prefix_to_rust_path(prefix),
+        suffix
+    ))
+}
+
+/// Pick the Rust type name for a `RecordCreate` / `RecordUpdate`.
+/// Precedence, mirroring HIR's verbatim-type-name shape plus the
+/// new cross-module qualification:
+///  1. built-in dotted record rename (`Tcp.Connection` →
+///     `Tcp_Connection`),
+///  2. module-qualified path for a `depends`-ed user record (so a
+///     verify-test reference compiles without a glob `use`),
+///  3. the verbatim source `type_name` (entry-scope records, in
+///     scope via the entry module's own `use`).
+fn mir_record_rust_type(
+    type_id: Option<crate::ir::TypeId>,
+    type_name: &str,
+    ctx: &MirEmitCtx<'_>,
+) -> String {
+    if let Some(renamed) = builtin_dotted_record_rename(type_name) {
+        return renamed.to_string();
+    }
+    if let Some(qualified) = qualify_record_type(type_id, type_name, ctx) {
+        return qualified;
+    }
+    type_name.to_string()
+}
+
 /// How many fns the MIR walker can emit
 /// standalone vs how many need HIR fallback. Pre-wire-up signal
 /// so callers can track walker reach across the shipped corpus
@@ -874,8 +942,7 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             // re-exported `Tcp_Connection` struct. Fields route
             // through `clone_arg`.
             let rec = &spanned_rec.node;
-            let rust_type =
-                builtin_dotted_record_rename(&rec.type_name).unwrap_or(rec.type_name.as_str());
+            let rust_type = mir_record_rust_type(rec.type_id, &rec.type_name, emit_ctx);
             let mut parts = Vec::with_capacity(rec.fields.len());
             for f in &rec.fields {
                 let val =
@@ -891,8 +958,7 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             // RecordCreate; base + updates route through
             // `clone_arg`.
             let upd = &spanned_upd.node;
-            let rust_type =
-                builtin_dotted_record_rename(&upd.type_name).unwrap_or(upd.type_name.as_str());
+            let rust_type = mir_record_rust_type(upd.type_id, &upd.type_name, emit_ctx);
             let base = mir_clone_arg(
                 emit_mir_expr(&upd.base, emit_ctx)?,
                 &upd.base.node,
@@ -2853,7 +2919,21 @@ fn emit_mir_builtin_call(
         // ---- Int ----
         "Int.abs" => format!("{}.abs()", arg!(0)),
         "Int.fromFloat" => format!("({} as i64)", arg!(0)),
-        "Int.fromString" => format!("{}.parse::<i64>().map_err(|e| e.to_string())", arg!(0)),
+        "Int.fromString" => {
+            // Match the VM's Err message BYTE-FOR-BYTE: `Int.fromString`
+            // in `src/types/int.rs` returns `Cannot parse '{input}' as
+            // Int`, not rustc's native `parse` error ("invalid digit
+            // found in string"). A program that reads the `Result.Err`
+            // string (and verify cases asserting it) must see identical
+            // bytes on rust and the VM. Bind a *reference* to the input
+            // (parse + the message both borrow), so a non-trivial arg
+            // expr is evaluated once and the original owned value stays
+            // available to surrounding code (the HIR emit borrowed too).
+            let s = arg!(0);
+            format!(
+                "{{ let __s = &({s}); __s.parse::<i64>().map_err(|_| format!(\"Cannot parse '{{}}' as Int\", __s)) }}"
+            )
+        }
         "Int.min" => format!("{}.min({})", arg!(0), arg!(1)),
         "Int.max" => format!("{}.max({})", arg!(0), arg!(1)),
         "Int.mod" => {
@@ -2869,7 +2949,15 @@ fn emit_mir_builtin_call(
         "Float.round" => format!("{}.round() as i64", arg!(0)),
         "Float.floor" => format!("{}.floor() as i64", arg!(0)),
         "Float.ceil" => format!("{}.ceil() as i64", arg!(0)),
-        "Float.fromString" => format!("{}.parse::<f64>().map_err(|e| e.to_string())", arg!(0)),
+        "Float.fromString" => {
+            // Match the VM's Err message BYTE-FOR-BYTE: `Float.fromString`
+            // in `src/types/float.rs` returns `Cannot parse '{input}' as
+            // Float`, not rustc's native `parse` error.
+            let s = arg!(0);
+            format!(
+                "{{ let __s = &({s}); __s.parse::<f64>().map_err(|_| format!(\"Cannot parse '{{}}' as Float\", __s)) }}"
+            )
+        }
         "Float.sqrt" => format!("{}.sqrt()", arg!(0)),
         "Float.pow" => format!("{}.powf({})", arg!(0), arg!(1)),
         "Float.min" => format!("{}.min({})", arg!(0), arg!(1)),
@@ -3662,6 +3750,46 @@ mod tests {
         let ctx = MirEmitCtx::for_test(&st, &prefixes);
         let emit = emit_mir_expr(&expr, &ctx).expect("dep-module record should emit");
         assert_eq!(emit, "Expr { tag: 1i64 }");
+    }
+
+    #[test]
+    fn emits_record_create_dep_module_qualified_when_prefix_registered() {
+        // Residual-2 fix: when the owning module's prefix IS registered
+        // in `module_prefixes` (the verify-test codegen path, where the
+        // `#[cfg(test)]` module has no glob `use` bringing the dep type
+        // into scope), a cross-module `RecordCreate` must emit the
+        // module-mangled Rust path — not the bare name. This is the
+        // sibling of the `Construct(User)` ctor mangling.
+        let field = crate::ir::mir::MirRecordField {
+            name: "id".to_string(),
+            value: span(MirExpr::Literal(span(crate::ast::Literal::Int(1)))),
+        };
+        let rec = crate::ir::mir::MirRecordCreate {
+            type_id: Some(crate::ir::TypeId(0)),
+            type_name: "Note".to_string(),
+            fields: vec![field],
+        };
+        let expr = span(MirExpr::RecordCreate(span(rec)));
+        use crate::ir::ModuleId;
+        use crate::ir::identity::TypeKey;
+        use crate::ir::symbol_table::{ModuleEntry, TypeEntry};
+        let mut st = SymbolTable::default();
+        st.modules.push(ModuleEntry { prefix: None });
+        st.types.push(TypeEntry {
+            key: TypeKey::in_module("Apps.Notepad.Store", "Note"),
+            module: ModuleId(0),
+            index_in_module: 0,
+            variants: vec![],
+            is_product: true,
+        });
+        let mut prefixes = HashSet::new();
+        prefixes.insert("Apps.Notepad.Store".to_string());
+        let ctx = MirEmitCtx::for_test(&st, &prefixes);
+        let emit = emit_mir_expr(&expr, &ctx).expect("qualified dep-module record should emit");
+        assert_eq!(
+            emit,
+            "crate::aver_generated::apps::notepad::store::Note { id: 1i64 }"
+        );
     }
 
     #[test]

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -1323,6 +1323,114 @@ fn mir_first_class_fn_value_builds_and_matches_vm() {
     result.unwrap_or_else(|e| panic!("{e}"));
 }
 
+// ─── Mode (h): Int.fromString / Float.fromString Err-message bytes ────────
+//
+// `Int.fromString` / `Float.fromString` return a `Result<_, String>`.
+// On a failed parse the VM (`src/types/int.rs` / `float.rs`) formats the
+// Err string as `Cannot parse '{input}' as Int` / `… as Float`. The Rust
+// emit used to delegate to rustc's NATIVE `parse` error ("invalid digit
+// found in string"), a real cross-backend SEMANTIC divergence: a program
+// that reads the `Result.Err(String)` got different bytes on Rust vs the
+// VM, and verify cases asserting the message failed under `cargo test`.
+//
+// This probe reads BOTH parse Results back as strings and prints them, so
+// the built binary's stdout carries the exact Err bytes. A regression to
+// the native rustc message would change the bytes here and fail parity.
+const MIR_FROMSTRING_ERR_PROBE: &str = r#"module FromStringErrProbe
+    intent =
+        "Probes Int.fromString / Float.fromString Err-message bytes."
+        "The Err string must match the VM byte-for-byte, not rustc's native parse error."
+    effects [Console]
+
+fn showInt(s: String) -> String
+    ? "Render the Int.fromString Result as a string."
+    match Int.fromString(s)
+        Result.Ok(n) -> "ok:{n}"
+        Result.Err(e) -> "err:{e}"
+
+fn showFloat(s: String) -> String
+    ? "Render the Float.fromString Result as a string."
+    match Float.fromString(s)
+        Result.Ok(f) -> "ok:{f}"
+        Result.Err(e) -> "err:{e}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(showInt("bad"))
+    Console.print(showInt("12x"))
+    Console.print(showInt(""))
+    Console.print(showInt("42"))
+    Console.print(showFloat("nope"))
+    Console.print(showFloat("3.14"))
+"#;
+
+#[test]
+fn mir_fromstring_err_message_matches_vm() {
+    let ws = temp_dir("mir_fromstring");
+    let src = ws.join("fromstring_err_probe.av");
+    fs::write(&src, MIR_FROMSTRING_ERR_PROBE).expect("write fromString probe source");
+
+    let vm_stdout = run_vm(&src, None).unwrap_or_else(|e| panic!("VM run failed: {e}"));
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let name = "mir_fromstring_probe";
+
+    let result = (|| -> Result<(), String> {
+        // NOTE: no `mir_lowered_count` guard here — every fn in this probe
+        // calls a builtin (`Int.fromString` / `Console.print`), and the
+        // coverage walk's `--explain-mir-coverage` reports `Call(Builtin)`
+        // as a fallback (its `for_test` ctx carries an empty builtin
+        // table), so it would report `mir_lowered = 0` even though the
+        // production path emits these fns fine. The structural tripwire
+        // below (the VM-format message must appear in the emitted Rust)
+        // is the real "fromString emit is exercised" guard.
+        compile_rust(&src, &project, name, None, &[])?;
+
+        // Structural tripwire: the emitted Rust must format the Aver Err
+        // message, NOT delegate to rustc's native parse error.
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted module: {e}"))?;
+        if !emitted.contains("Cannot parse '{}' as Int")
+            || !emitted.contains("Cannot parse '{}' as Float")
+        {
+            return Err(format!(
+                "emitted Rust is missing the VM-format fromString Err message \
+                 (`Cannot parse '{{}}' as Int/Float`) — it likely regressed to \
+                 rustc's native parse error:\n{emitted}"
+            ));
+        }
+
+        let bin = cargo_build(&project, name)?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("failed to run compiled binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "MIR fromString binary exited non-zero:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "MIR fromString Err-bytes mismatch (Rust must match VM byte-for-byte)\n\
+                 --- VM ---\n{vm_stdout}\n--- Rust (MIR) ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // The MIR behavioral net (MIR is the sole Rust codegen path)
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Two pre-existing rust-codegen residuals so the remaining example programs pass `cargo test` (not just `cargo build`). Diff: 2 files, +242/−6.

## Residual 1 (semantic — cross-backend consistency): Int/Float.fromString error message
The rust emit was `{arg}.parse::<i64>().map_err(|e| e.to_string())` → rustc's native `"invalid digit found in string"`, while the VM returns the Aver-formatted `Cannot parse '{s}' as Int` (src/types/int.rs:70, float.rs:95; `{s}` = raw input). A program reading `Result.Err(String)` from `fromString` got DIFFERENT bytes on rust vs VM — a real cross-backend divergence. Fixed: emit `{ let __s = &(arg); __s.parse::<i64>().map_err(|_| format!("Cannot parse '{}' as Int", __s)) }`, byte-matching the VM. (A `&`-borrow, not a move — moving broke `Data.Json`'s `parseInt`, which reuses the input afterward.)

## Residual 2: cross-module verify-test type/ctor qualification
`notepad/routes.av` verify cases construct `Note` (a type from the `Apps.Notepad.Store` dep); the `#[cfg(test)]` verify module emitted it unqualified → E0422. The `RecordCreate`/`RecordUpdate` MIR arms now route the type name through `mir_record_rust_type` → `qualify_record_type`, reusing the existing `resolve_module_call` + `module_prefix_to_rust_path` mangling (the verify-codegen sibling of #404's cross-module fn-ref fix). Identity keys on `type_id` (robust to shared bare names); entry-scope records stay verbatim.

## Result
`notepad/store` `cargo test`: 40/0 (covers the `Cannot parse 'bad' as Int` verify cases). `notepad/routes` `cargo test`: 23/0 (the `Note` verify module builds). fromString rust↔VM byte-identical.

## Verified (independently)
- `cargo clippy --workspace --all-targets`: clean. Full `cargo test` (default, incl. new `mir_fromstring_err_message_matches_vm`): 0 failed. `--features wasm` + wasip2: green. Self-host regen: green (the fromString change doesn't break self-host parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)