### PR TITLE
rust+wasm-gc: emit BranchPath builtins + fix Fn-param phantom-tuple — last corpus blocker

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -1111,6 +1111,12 @@ fn emit_mir_static_ref(name: &str, ctx: &MirEmitCtx<'_>) -> String {
     if name == "Option.None" || name == "None" {
         return "None".to_string();
     }
+    // `BranchPath.Root` is the canonical-root nullary value (Oracle
+    // structural addressing). It lowers to a `FnValue` rather than a
+    // call, so it surfaces here — emit the `aver_rt` root constructor.
+    if name == "BranchPath.Root" {
+        return "aver_rt::BranchPath::root()".to_string();
+    }
     if let Some((type_name, variant_name)) = name.rsplit_once('.')
         && let Some(cg) = ctx.codegen
     {
@@ -3155,6 +3161,30 @@ fn emit_mir_builtin_call(
         }
         "Vector.len" => format!("({}.len() as i64)", arg!(0)),
         "Vector.fromList" => format!("aver_rt::AverVector::from_vec({}.to_vec())", arg!(0)),
+
+        // ---- BranchPath ----
+        // Oracle structural-addressing constructors. The `aver_rt`
+        // `BranchPath` struct (+ `root`/`child`/`parse` impls) is
+        // re-exported into the generated crate. `BranchPath.Root` is a
+        // nullary value, not a call — it lowers to a `FnValue` and is
+        // handled in `emit_mir_static_ref`. `.child` / `.parse` are
+        // builtin method calls and land here.
+        //
+        // `child(path: &BranchPath, idx: i64)`: the path arg goes
+        // through `mir_borrow_arg` so a borrowed-param `&BranchPath` is
+        // passed directly while a fresh owned value (e.g. a nested
+        // `BranchPath.child(...)` or `BranchPath.Root`) gets a `&`.
+        "BranchPath.child" => {
+            let path = mir_borrow_arg(emit_mir_expr(&args[0], ctx)?, &args[0].node, ctx);
+            let idx = arg!(1);
+            format!("aver_rt::BranchPath::child({}, {})", path, idx)
+        }
+        // `parse(raw: &str)`: `mir_str_arg_or_deref` yields a bare
+        // string literal or the `&*` deref form, both `&str`.
+        "BranchPath.parse" => {
+            let raw = mir_str_arg_or_deref(&args[0], ctx)?;
+            format!("aver_rt::BranchPath::parse({})", raw)
+        }
 
         // Not a covered pure builtin (effectful builtins never reach
         // here — gated at the call arm). HIR fallback.

--- a/src/codegen/wasm_gc/types_discovery.rs
+++ b/src/codegen/wasm_gc/types_discovery.rs
@@ -253,15 +253,26 @@ pub(super) fn collect_tuples_from_str(
             }
             if depth == 0 && top_commas >= 1 {
                 let inner = &trimmed[i + 1..j - 1];
+                // A `(` immediately preceded by `Fn` is a function-type
+                // parameter list (`Fn(BranchPath, Int, Int) -> Int`), NOT
+                // a tuple. Recurse into the inner so any genuinely-nested
+                // tuple param (`Fn((Int, Int), Int) -> Int`) is still
+                // discovered, but never intern the param list itself —
+                // doing so registered a phantom `Tuple<…>` whose eq/hash
+                // helpers later tried to dispatch on opaque param types
+                // (e.g. `BranchPath`) that have no structural eq.
+                let preceded_by_fn = trimmed[..i].trim_end().ends_with("Fn");
                 collect_tuples_from_str(inner, out, order, next_idx);
-                // Build canonical `Tuple<A,B,...>` form
-                let canonical_inner: String =
-                    inner.chars().filter(|c| !c.is_whitespace()).collect();
-                let canonical = format!("Tuple<{canonical_inner}>");
-                if !out.contains_key(&canonical) {
-                    out.insert(canonical.clone(), *next_idx);
-                    order.push(canonical);
-                    *next_idx += 1;
+                if !preceded_by_fn {
+                    // Build canonical `Tuple<A,B,...>` form
+                    let canonical_inner: String =
+                        inner.chars().filter(|c| !c.is_whitespace()).collect();
+                    let canonical = format!("Tuple<{canonical_inner}>");
+                    if !out.contains_key(&canonical) {
+                        out.insert(canonical.clone(), *next_idx);
+                        order.push(canonical);
+                        *next_idx += 1;
+                    }
                 }
                 i = j;
                 continue;
@@ -893,5 +904,54 @@ pub(super) fn collect_maps_from_expr(
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tuple_discovery_tests {
+    use super::collect_tuples_from_str;
+    use std::collections::HashMap;
+
+    fn collect(type_str: &str) -> Vec<String> {
+        let mut out: HashMap<String, u32> = HashMap::new();
+        let mut order: Vec<String> = Vec::new();
+        let mut next = 0u32;
+        collect_tuples_from_str(type_str, &mut out, &mut order, &mut next);
+        order
+    }
+
+    #[test]
+    fn fn_param_list_is_not_a_tuple() {
+        // The param list of a `Fn(...)` type is a function-type
+        // parameter list, NOT a tuple. Registering it as
+        // `Tuple<BranchPath,Int,Int,Int>` produced a phantom carrier
+        // whose eq helper dispatched on the opaque `BranchPath`
+        // param and failed wasm-gc validation.
+        let order = collect("Fn(BranchPath, Int, Int, Int) -> Int");
+        assert!(
+            order.is_empty(),
+            "a Fn(..) param list must not register any tuple, got {order:?}"
+        );
+    }
+
+    #[test]
+    fn genuine_surface_tuple_still_registers() {
+        let order = collect("(Int, String)");
+        assert_eq!(order, vec!["Tuple<Int,String>".to_string()]);
+    }
+
+    #[test]
+    fn nested_tuple_inside_fn_param_still_registers() {
+        // A real tuple nested inside a Fn param list is still a tuple
+        // and must be discovered — only the param-list parens are not.
+        let order = collect("Fn((Int, Int), String) -> Bool");
+        assert_eq!(order, vec!["Tuple<Int,Int>".to_string()]);
+    }
+
+    #[test]
+    fn tuple_return_of_fn_still_registers() {
+        // `Fn(Int) -> (Int, Int)` — the return tuple is genuine.
+        let order = collect("Fn(Int) -> (Int, Int)");
+        assert_eq!(order, vec!["Tuple<Int,Int>".to_string()]);
     }
 }

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -1513,37 +1513,43 @@ fn assert_forced_mir_parity(relative: &str, module_root: Option<&str>) -> Result
     result
 }
 
-// ─── Residual Oracle-shape exclusion (honest corpus denominator) ─────────
+// ─── Oracle-shape full-corpus build (no residual Rust exclusions) ────────
 //
 // The Oracle-only `BranchPath` type and the Terminal-only `Terminal.Size`
-// type are now emitted by the Rust backend (a `pub use aver_rt::BranchPath`
+// type are emitted by the Rust backend (a `pub use aver_rt::BranchPath`
 // / `Terminal_Size` alias, mirroring `Tcp.Connection`), and the verify
 // module skips the verify-only Oracle / trace / given-universal cases, so
-// the previously-excluded Oracle programs (`oracle_trace`,
-// `hostile_order_axis`, `clock_as_data`, `randomness_paradox`,
-// `terminal_size_snapshot`, `file_store_shell`, `services/redis`) now
-// `cargo build` + `cargo test` cleanly on Rust and run with VM parity.
+// the Oracle programs (`oracle_trace`, `hostile_order_axis`,
+// `clock_as_data`, `randomness_paradox`, `terminal_size_snapshot`,
+// `file_store_shell`, `services/redis`) `cargo build` + `cargo test`
+// cleanly on Rust and run with VM parity.
 //
-// The lone residual is `oracle_independent_products.av`: its `pairSpec`
-// uses a higher-order `?!` independent-product shape the MIR walker can't
-// render yet (`compile_error!("MIR walker could not render fn pairSpec")`)
-// — a separate higher-order MIR-walker gap, NOT a BranchPath /
-// Terminal.Size emit gap. It stays excluded until that gap is closed.
+// The last residual was `oracle_independent_products.av`: its higher-order
+// spec fn `pairSpec(path, rnd: Fn(BranchPath, …) -> Int)` builds a tuple
+// from calls to the `rnd` fn-pointer param over `BranchPath.child(path, n)`
+// — the MIR walker bailed because the `BranchPath.child` / `.parse` builtin
+// calls and the `BranchPath.Root` nullary value had no emit arm (they fell
+// through to `_ => None`, yielding a `compile_error!`). Adding those arms
+// (the `aver_rt::BranchPath::{child,parse,root}` constructors) closes the
+// gap — the higher-order tuple-of-LocalSlot-calls shape already emitted.
+// There is now NO residual Rust-build exclusion in the example corpus.
 
-/// (relative path, optional module root) of the examples that still fail
-/// the Rust `cargo build` on the MIR walker. The BranchPath / Terminal.Size
-/// emit gap is fixed; the residual is the higher-order MIR-walker gap in
-/// `oracle_independent_products`'s `pairSpec`. The test below flags a stale
-/// entry that started building ("move it into the run-parity corpus").
-const BRANCH_PATH_EXCLUSIONS: &[(&str, Option<&str>)] = &[(
+/// (relative path, optional module root) of the Oracle-shape examples that
+/// must `cargo build` cleanly on the (sole) MIR codegen path with zero
+/// `compile_error!` stubs. Previously these were the *exclusions*; the
+/// BranchPath builtin-emit gap is now closed, so the assertion flipped to
+/// a positive build proof. A regression (a dropped `BranchPath.*` arm, an
+/// undefined `BranchPath` symbol, or a re-introduced higher-order None)
+/// fails the `cargo build` and this test catches it.
+const BRANCH_PATH_BUILDS: &[(&str, Option<&str>)] = &[(
     "examples/formal/oracle_independent_products.av",
     Some("examples"),
 )];
 
 /// `cargo build` an example through the (sole) MIR codegen path,
 /// returning Ok(()) on a clean build or Err(stderr) on failure. Used by
-/// the exclusion proof to confirm the residual examples still don't
-/// build on Rust.
+/// the BranchPath build proof to confirm the Oracle-shape examples build
+/// on Rust without `compile_error!` stubs.
 fn try_build_walker(
     relative: &str,
     module_root: Option<&str>,
@@ -1564,6 +1570,24 @@ fn try_build_walker(
     if let Err(e) = compile_rust(&file, &project, &name, root.as_deref(), &[]) {
         return Ok(Err(format!("compile: {e}")));
     }
+    // Guard against a silent `compile_error!` stub slipping through: any
+    // such stub fails `cargo build` below, but assert explicitly too so a
+    // regression names the exact failure mode.
+    let emitted = fs::read_to_string(
+        project
+            .join("src")
+            .join("aver_generated")
+            .join("entry")
+            .join("mod.rs"),
+    )
+    .map_err(|e| format!("read emitted module: {e}"))?;
+    if emitted.contains("compile_error!") {
+        return Ok(Err(
+            "emitted Rust still carries a `compile_error!` stub — a fn body \
+             the MIR walker could not render"
+                .to_string(),
+        ));
+    }
     match cargo_build_in(&project, &name, &ws.join(format!("target-{tag}"))) {
         Ok(_) => Ok(Ok(())),
         Err(e) => Ok(Err(e)),
@@ -1572,11 +1596,11 @@ fn try_build_walker(
 
 #[test]
 #[ignore = "full tier: cargo build wall-time; set AVER_RUST_DIFF_FULL=1 and run with --ignored"]
-fn oracle_shape_exclusions_still_fail_to_build_on_rust() {
+fn oracle_shape_examples_build_clean_on_rust() {
     if std::env::var("AVER_RUST_DIFF_FULL").is_err() {
         eprintln!(
-            "skipping Oracle-shape-exclusion proof — set AVER_RUST_DIFF_FULL=1 \
-             (proves the residual higher-order Oracle example still doesn't build on Rust)"
+            "skipping Oracle-shape build proof — set AVER_RUST_DIFF_FULL=1 \
+             (proves the higher-order BranchPath Oracle example builds clean on Rust)"
         );
         return;
     }
@@ -1584,45 +1608,30 @@ fn oracle_shape_exclusions_still_fail_to_build_on_rust() {
     let mut failures = Vec::new();
     let mut confirmed = 0usize;
 
-    for (relative, root) in BRANCH_PATH_EXCLUSIONS {
+    for (relative, root) in BRANCH_PATH_BUILDS {
         let ws = temp_dir(&format!("bp-{}", sanitise(relative)));
         let built = try_build_walker(relative, *root, &ws, "mir");
         let _ = fs::remove_dir_all(&ws);
 
         match built {
-            // The residual exclusion is the higher-order MIR-walker gap
-            // (`pairSpec`'s `?!` independent-product shape): the walker
-            // emits a `compile_error!("MIR walker could not render fn …")`.
-            // Confirm the gap is still that MIR-walker render failure, not a
-            // regressed BranchPath / Terminal.Size undefined-symbol error.
-            Ok(Err(err)) => {
-                if err.contains("MIR walker could not render") || err.contains("compile_error") {
-                    confirmed += 1;
-                } else {
-                    failures.push(format!(
-                        "{relative}: failed to build, but NOT with the expected \
-                         higher-order MIR-walker render gap.\n  err:\n{err}"
-                    ));
-                }
-            }
-            Ok(Ok(())) => failures.push(format!(
-                "{relative}: BUILT on Rust — it is no longer an Oracle-shape \
-                 exclusion; move it into the MIR run-parity corpus"
+            Ok(Ok(())) => confirmed += 1,
+            Ok(Err(err)) => failures.push(format!(
+                "{relative}: expected a clean Rust build (BranchPath builtin-emit \
+                 gap is closed), but it failed:\n  err:\n{err}"
             )),
             Err(e) => failures.push(format!("{relative}: harness error: {e}")),
         }
     }
 
     eprintln!(
-        "oracle_shape_exclusions_still_fail_to_build_on_rust: {confirmed}/{} confirmed \
-         higher-order MIR-walker render gap",
-        BRANCH_PATH_EXCLUSIONS.len()
+        "oracle_shape_examples_build_clean_on_rust: {confirmed}/{} built clean",
+        BRANCH_PATH_BUILDS.len()
     );
     assert!(
         failures.is_empty(),
-        "{} of {} Oracle-shape exclusions did not fail as expected:\n  - {}",
+        "{} of {} Oracle-shape examples did not build clean:\n  - {}",
         failures.len(),
-        BRANCH_PATH_EXCLUSIONS.len(),
+        BRANCH_PATH_BUILDS.len(),
         failures.join("\n  - ")
     );
 }

--- a/tests/wasip2_codegen_regression.rs
+++ b/tests/wasip2_codegen_regression.rs
@@ -34,8 +34,8 @@ fn examples_dir() -> PathBuf {
 }
 
 /// Paths skipped from the regression walk:
-///   * `examples/diagnostics/` + `oracle_independent_products.av`
-///     — same exclusions as `tests/wasm_gc_codegen_regression.rs`.
+///   * `examples/diagnostics/` — same exclusions as
+///     `tests/wasm_gc_codegen_regression.rs`.
 ///   * Three `Terminal.*` users — `status_board.av`,
 ///     `oracle_trace.av`, `terminal_size_snapshot.av`. The wasip2
 ///     backend lowered 10 effects in 0.18 "Span" (all of `Disk`,
@@ -44,10 +44,15 @@ fn examples_dir() -> PathBuf {
 ///     codegen errors with "no helper registered, no effect
 ///     import, no inline lowering". Tracked as a follow-up; this
 ///     suite is the regression net, the wiring is its own ticket.
+///
+/// `oracle_independent_products.av` used to be skipped (its
+/// higher-order `Fn(BranchPath, …)` spec param was mis-discovered as a
+/// phantom `Tuple<BranchPath, …>` carrier that the eq helper couldn't
+/// dispatch). That discovery bug is fixed, so it rides the walk like
+/// every other single-file example.
 fn is_skipped(path: &Path) -> bool {
     let s = path.to_string_lossy();
     s.contains("/examples/diagnostics/")
-        || s.ends_with("/examples/formal/oracle_independent_products.av")
         || s.ends_with("/examples/apps/status_board.av")
         || s.ends_with("/examples/formal/oracle_trace.av")
         || s.ends_with("/examples/formal/terminal_size_snapshot.av")

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -43,13 +43,18 @@ fn single_file_examples() -> Vec<PathBuf> {
 /// Paths skipped from the regression walk:
 ///   * `examples/diagnostics/` — intentionally type-broken examples used
 ///     to demo error messages; they must not typecheck cleanly.
-///   * `examples/formal/oracle_independent_products.av` — uses a
-///     `BranchPath` carrier the wasm-gc backend doesn't yet dispatch.
-///     Tracked under the wasm-gc verify limitations doc.
+///
+/// `examples/formal/oracle_independent_products.av` used to be skipped
+/// because its `pairSpec` higher-order spec fn carries a
+/// `Fn(BranchPath, …)` param whose param list was mis-discovered as a
+/// phantom `Tuple<BranchPath, …>`, whose eq helper then tried to
+/// dispatch on the opaque `BranchPath` carrier. That discovery bug is
+/// fixed (a `Fn(`-preceded paren group is a function-type parameter
+/// list, not a tuple), so the file now compiles + validates and rides
+/// the walk like every other single-file example.
 fn is_skipped(path: &Path) -> bool {
     let s = path.to_string_lossy();
     s.contains("/examples/diagnostics/")
-        || s.ends_with("/examples/formal/oracle_independent_products.av")
 }
 
 fn walk(dir: &Path, out: &mut Vec<PathBuf>) {


### PR DESCRIPTION
Closes the LAST construct blocking the full example corpus from building on rust + wasm-gc: `pairSpec` (a higher-order Oracle-spec fn in `oracle_independent_products.av`). Both failures were narrow general gaps — **not** a higher-order-codegen feature (the tuple-of-fn-pointer-calls shape already emitted on both backends).

## Causes + fixes
- **rust** (`from_mir.rs`, +30): the MIR walker had no `emit_mir_builtin_call` arm for `BranchPath.child`/`.parse` (and no `BranchPath.Root` static-ref) — #403 added the `aver_rt::BranchPath` type but never wired the walker's emit arms, so the body fell to `_ => None` → `compile_error!`. Added `BranchPath.{child,parse}` → `aver_rt::BranchPath::{child,parse}` and `BranchPath.Root` → `aver_rt::BranchPath::root()`.
- **wasm-gc** (`types_discovery.rs`, +76): `collect_tuples_from_str` matched the `(BranchPath, Int, Int, Int)` parens of a `Fn(...)`-typed param's display string as a surface tuple and interned a phantom `Tuple<BranchPath,…>`, whose structural-eq helper then dispatched on opaque `BranchPath` (`(ref null eq)`, no eq) → `validation failed — carrier eq inner type BranchPath has no eq dispatch`. Fix: a `(` immediately preceded by `Fn` is a function-type param list, not a tuple — don't intern it (still recurse for genuinely-nested tuple params like `Fn((Int,Int), …)`).

## Result — full corpus builds on all backends, no exception
- rust: `oracle_independent_products` → 0 `compile_error!` stubs, `cargo build` 0 errors. wasm-gc: compiles + `wasm-tools validate` VALID. `aver verify` 13/13. Un-skipped it in the wasm-gc + wasip2 codegen walks; flipped the rust-differential Oracle exclusion to a positive clean-build proof. +4 unit tests for the Fn-param-list-vs-tuple distinction.

## Verified (independently)
- `cargo clippy --workspace --all-targets`: clean. Full `cargo test` (default): 0 failed. `--features wasm` (incl. the un-skipped wasm-gc walk): green. wasip2 codegen: green. Self-host regen: green.
- rust `oracle_independent_products` builds (0 compile_error, 0 rustc-errors); `aver verify` 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)