### PR TITLE
ir/mir,rust: own_param sound-by-construction + rust owned-by-value codegen (#252)

### DIFF
--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -170,36 +170,97 @@ fn borrow_mask_from_fn_def(
 pub(super) fn callee_borrow_mask(name: &str, arg_count: usize, ctx: &CodegenContext) -> Vec<bool> {
     // First, try to find the FnDef to check for TCO (which overrides everything)
     let fd = find_fn_def_by_name(name, ctx);
-    if let Some(fd) = fd {
-        return borrow_mask_from_fn_def(fd, arg_count, ctx);
-    }
+    let mut mask = if let Some(fd) = fd {
+        borrow_mask_from_fn_def(fd, arg_count, ctx)
+    } else {
+        // No FnDef found — read param types from the resolved-program
+        // view. The qualified lookup hits cross-module callsites that
+        // arrive as bare dotted names; the bare-name fallback covers
+        // entry-scope synthesised wrappers.
+        let lookup_name = if let Some((prefix, bare)) = resolve_module_call(name, ctx) {
+            crate::visibility::qualified_name(prefix, bare)
+        } else {
+            name.to_string()
+        };
+        let resolved = crate::codegen::common::fn_id_for_dotted_name(ctx, &lookup_name)
+            .or_else(|| crate::codegen::common::fn_id_for_dotted_name(ctx, name))
+            .and_then(|id| ctx.resolved_program.fn_by_id(id));
+        match resolved {
+            // Self-TCO functions always resolve via `find_fn_def_by_name`
+            // above, so this path is safe for borrow-by-default on all
+            // non-scalar types including Named.
+            Some(rfd) => rfd
+                .params
+                .iter()
+                .take(arg_count)
+                .map(|(_, ty)| should_borrow_param(ty))
+                .collect(),
+            // Unknown function -- don't borrow (conservative)
+            None => vec![false; arg_count],
+        }
+    };
 
-    // No FnDef found — read param types from the resolved-program
-    // view. The qualified lookup hits cross-module callsites that
-    // arrive as bare dotted names; the bare-name fallback covers
-    // entry-scope synthesised wrappers.
+    // own_param graduation: a NON-TCO collection param the `own_param`
+    // pass PROVED uniquely owned is emitted owned-by-value (`mut p: T`,
+    // see `MirFnEmitPolicy::apply_own_param` / `emit_fn_params_with_owned`),
+    // so the CALLER must pass it BY VALUE, not `&T`. Clear the borrow bit
+    // at every graduated param position so the call site matches the
+    // graduated signature. (Self-/mutual-TCO callees already return an
+    // all-`false` / borrow-by-default mask above; the graduation only
+    // applies on the non-TCO emit, so overriding here is the single place
+    // that keeps call sites and signatures in lockstep.) A missing MIR fn
+    // / aliased_slots leaves the mask unchanged (conservative borrow).
+    clear_owned_param_borrows(name, &mut mask, ctx);
+    mask
+}
+
+/// Clear the borrow bit for every own_param-graduated collection param of
+/// callee `name`, so the call site passes those args by value (matching
+/// the graduated `mut p: T` signature). Resolves the callee's `MirFn` +
+/// `ResolvedFnDef` by the SAME identity-keyed lookup the signature emit
+/// uses, then applies `from_mir::owned_collection_param_names` (the single
+/// source of the owned-param set). Graduation only happens on non-TCO
+/// emits; a self-/mutual-TCO callee carries no graduated params here
+/// because `apply_own_param` on those paths never populates the non-TCO
+/// signature's owned set, so this is a no-op for them.
+fn clear_owned_param_borrows(name: &str, mask: &mut [bool], ctx: &CodegenContext) {
     let lookup_name = if let Some((prefix, bare)) = resolve_module_call(name, ctx) {
         crate::visibility::qualified_name(prefix, bare)
     } else {
         name.to_string()
     };
-    let resolved = crate::codegen::common::fn_id_for_dotted_name(ctx, &lookup_name)
-        .or_else(|| crate::codegen::common::fn_id_for_dotted_name(ctx, name))
-        .and_then(|id| ctx.resolved_program.fn_by_id(id));
-    if let Some(rfd) = resolved {
-        // Self-TCO functions always resolve via `find_fn_def_by_name`
-        // above, so this path is safe for borrow-by-default on all
-        // non-scalar types including Named.
-        return rfd
-            .params
-            .iter()
-            .take(arg_count)
-            .map(|(_, ty)| should_borrow_param(ty))
-            .collect();
+    let fn_id = crate::codegen::common::fn_id_for_dotted_name(ctx, &lookup_name)
+        .or_else(|| crate::codegen::common::fn_id_for_dotted_name(ctx, name));
+    let Some(fn_id) = fn_id else { return };
+    // A self-/mutual-TCO callee never graduates a param on the path that
+    // governs its call-site ABI, so skip it (its signature ABI is fixed
+    // by the TCO wrapper, not by own_param). This mirrors the `has_tco`
+    // guard in `emit_fn_def_with_visibility`.
+    if let Some(fd) = find_fn_def_by_name(name, ctx) {
+        let is_mutual_tco = crate::codegen::common::fn_id_for_decl(ctx, fd)
+            .is_some_and(|id| ctx.mutual_tco_members.contains(&id));
+        if is_mutual_tco || super::toplevel::body_has_self_tailcall(&fd.body, &fd.name) {
+            return;
+        }
     }
-
-    // Unknown function -- don't borrow (conservative)
-    vec![false; arg_count]
+    let Some(mir_fn) = ctx.mir_program.as_ref().and_then(|p| p.fn_by_id(fn_id)) else {
+        return;
+    };
+    let Some(rfd) = ctx.resolved_program.fn_by_id(fn_id) else {
+        return;
+    };
+    let owned = super::from_mir::owned_collection_param_names(mir_fn, &rfd.params);
+    if owned.is_empty() {
+        return;
+    }
+    for (i, (pname, _)) in rfd.params.iter().enumerate() {
+        if i >= mask.len() {
+            break;
+        }
+        if owned.contains(&aver_name_to_rust(pname)) {
+            mask[i] = false;
+        }
+    }
 }
 
 /// Find a FnDef by name, checking top-level, modules (qualified), and all modules (unqualified).

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -108,6 +108,15 @@ pub struct MirEmitCtx<'a> {
     /// Params emitted as `&T` (borrow-by-default for non-Copy,
     /// non-Str params).
     pub borrowed_params: &'a HashSet<String>,
+    /// Collection (`Vector`/`Map`) params that the `own_param` MIR pass
+    /// PROVED uniquely owned (cleared their `aliased_slots` bit). These
+    /// are emitted owned-by-value (`mut p: T`, NOT `&T`) and, at a
+    /// last-use read, skip the `.clone()` so an in-place `Rc::make_mut`
+    /// runs on a refcount-1 backing (native O(n) mutate instead of the
+    /// O(n²) borrow+clone COW). SOUNDNESS: a name is in this set only
+    /// when `own_param` cleared its bit — never broadened past what the
+    /// pass proved. Disjoint from `borrowed_params` by construction.
+    pub owned_params: &'a HashSet<String>,
     /// Owning module prefix for the fn whose body this ctx emits.
     pub current_module_scope: Option<&'a str>,
     /// Interned built-in fn names, indexed by `BuiltinId`
@@ -138,6 +147,7 @@ impl<'a> MirEmitCtx<'a> {
             local_types: EMPTY_TYPES.get_or_init(HashMap::new),
             rc_wrapped: EMPTY_SET.get_or_init(HashSet::new),
             borrowed_params: EMPTY_SET.get_or_init(HashSet::new),
+            owned_params: EMPTY_SET.get_or_init(HashSet::new),
             current_module_scope: None,
             // No builtin table on the coverage path: `Call(Builtin)`
             // resolves to `None` and the fn reports as HIR-fallback,
@@ -181,6 +191,7 @@ impl<'a> MirEmitCtx<'a> {
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
             borrowed_params: &policy.borrowed_params,
+            owned_params: &policy.owned_params,
             current_module_scope: policy.current_module_scope.as_deref(),
             mir_builtins,
         }
@@ -199,6 +210,7 @@ impl<'a> MirEmitCtx<'a> {
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
             borrowed_params: &policy.borrowed_params,
+            owned_params: &policy.owned_params,
             current_module_scope: policy.current_module_scope.as_deref(),
             // The builtin table the parity gate already built into the
             // `CodegenContext`. `Call(Builtin(id))` resolves `id`
@@ -236,6 +248,10 @@ pub(super) struct MirFnEmitPolicy {
     pub local_types: HashMap<String, Type>,
     pub rc_wrapped: HashSet<String>,
     pub borrowed_params: HashSet<String>,
+    /// Collection params `own_param` proved uniquely owned — see the
+    /// `MirEmitCtx::owned_params` doc. Default empty (no own_param facts
+    /// applied); populated by [`Self::apply_own_param`].
+    pub owned_params: HashSet<String>,
     pub current_module_scope: Option<String>,
 }
 
@@ -249,6 +265,7 @@ impl MirFnEmitPolicy {
             local_types: HashMap::new(),
             rc_wrapped: HashSet::new(),
             borrowed_params: HashSet::new(),
+            owned_params: HashSet::new(),
             current_module_scope: None,
         }
     }
@@ -282,9 +299,101 @@ impl MirFnEmitPolicy {
             local_types,
             rc_wrapped: HashSet::new(),
             borrowed_params,
+            owned_params: HashSet::new(),
             current_module_scope: scope.map(String::from),
         }
     }
+
+    /// Apply the `own_param` MIR pass's ownership facts to this policy:
+    /// every `Vector`/`Map` param whose `MirFn.aliased_slots` bit was
+    /// CLEARED (proven uniquely owned) graduates from borrow-by-default
+    /// to **owned-by-value** — moved OUT of `borrowed_params` and INTO
+    /// `owned_params` so the signature emits `mut p: T` and the body
+    /// skips the `.clone()` at a last-use mutation site (native in-place
+    /// `Rc::make_mut`, refcount-1).
+    ///
+    /// SOUNDNESS (the #383 corruption class): a collection param is
+    /// graduated ONLY when `own_param` cleared its bit. `own_param`'s
+    /// RULE 1 flags EVERY `Vector`/`Map` param `true` up front and only
+    /// clears the bit on a whole-program proof of unique ownership
+    /// (every visible call site passes a fresh / linearly-threaded
+    /// value, captured-into-aggregate slots stay flagged, multi-module
+    /// returns early leaving every bit set). So a cleared bit on a
+    /// collection param is exactly the pass's proof — never a heuristic.
+    /// A missing bit defaults to flagged (`true`) → not graduated
+    /// (conservative). Params still flagged keep borrow-by-default.
+    pub(super) fn apply_own_param(&mut self, mir_fn: &crate::ir::mir::MirFn) {
+        for (i, param) in mir_fn.params.iter().enumerate() {
+            // Only collection params are candidates (the only thing
+            // `own_param`'s RULE 1 ever flags). A non-collection param is
+            // never owned-graduated by this pass, so leave it untouched.
+            // Check the REAL `Type` (from the policy's `local_types`,
+            // sourced from `ResolvedFnDef`) — the `MirParam.ty` is a
+            // `format!("{ty:?}")` Debug string (`Vector(Int)`), fragile to
+            // parse.
+            let rust_name = aver_name_to_rust(&param.name);
+            let Some(ty) = self.local_types.get(&rust_name) else {
+                continue;
+            };
+            if !is_owned_collection_candidate(ty) {
+                continue;
+            }
+            // `own_param`'s `prone`/clearing both index `aliased_slots`
+            // by PARAM POSITION `i` (its `(0..nparams).filter(|&i| …)`),
+            // matching `MirParam.local = LocalId(i)`; match that exactly.
+            //
+            // Cleared bit ⟺ own_param proved unique ownership. Missing →
+            // treat as flagged (conservative). Still-flagged → keep the
+            // existing borrow-by-default decision (do not graduate).
+            let flagged = mir_fn.aliased_slots.get(i).copied().unwrap_or(true);
+            if flagged {
+                continue;
+            }
+            // Graduate: owned-by-value. On the borrow-by-default path the
+            // param was in `borrowed_params`; remove it. On the TCO
+            // no-borrow path it was never borrowed (already `mut`-owned),
+            // but it still needs to land in `owned_params` so the body's
+            // clone-skip fires.
+            self.borrowed_params.remove(&rust_name);
+            self.owned_params.insert(rust_name);
+        }
+    }
+}
+
+/// Is this the type of a param `own_param` can prove owned — a `Vector`
+/// or `Map`? These are the only param shapes `alias.rs` RULE 1 flags and
+/// thus the only ones `own_param` ever clears; nothing else is a sound
+/// clone-skip candidate. (`List` is an `Rc`-COW persistent list whose
+/// clone is cheap and is NOT flagged by RULE 1, so it stays borrowed.)
+fn is_owned_collection_candidate(ty: &Type) -> bool {
+    matches!(ty, Type::Vector(_) | Type::Map(_, _))
+}
+
+/// The Rust-mangled names of a fn's `Vector`/`Map` params that
+/// `own_param` PROVED uniquely owned (cleared `aliased_slots` bit) — the
+/// set the non-TCO SIGNATURE emits owned-by-value (`mut p: T`). The
+/// `param_types` are the `ResolvedFnDef` param `(name, Type)` pairs (real
+/// `Type`, not the `MirParam.ty` Debug string); the `mir_fn` supplies the
+/// optimized `aliased_slots`. Computed exactly as
+/// [`MirFnEmitPolicy::apply_own_param`] (same param-position indexing,
+/// same RULE-1 candidate filter, same missing-bit-is-flagged default) so
+/// signature and body never disagree.
+pub(super) fn owned_collection_param_names(
+    mir_fn: &crate::ir::mir::MirFn,
+    param_types: &[(String, Type)],
+) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for (i, (name, ty)) in param_types.iter().enumerate() {
+        if !is_owned_collection_candidate(ty) {
+            continue;
+        }
+        let flagged = mir_fn.aliased_slots.get(i).copied().unwrap_or(true);
+        if flagged {
+            continue;
+        }
+        out.insert(aver_name_to_rust(name));
+    }
+    out
 }
 
 /// Dotted built-in record/service types whose source `type_name`
@@ -1885,7 +1994,13 @@ pub(super) fn emit_mir_fn_body_routed(
     borrow_by_default: bool,
     ctx: &CodegenContext,
 ) -> Option<String> {
-    let policy = MirFnEmitPolicy::from_resolved(resolved, scope, borrow_by_default);
+    let mut policy = MirFnEmitPolicy::from_resolved(resolved, scope, borrow_by_default);
+    // Graduate own_param-proven collection params to owned-by-value so
+    // the body skips the `.clone()` at last-use mutation sites. The
+    // SIGNATURE (`emit_fn_def_with_visibility`) computes the SAME owned
+    // set from the same `mir_fn.aliased_slots` and emits `mut p: T`, so
+    // body and signature agree on which params are owned.
+    policy.apply_own_param(mir_fn);
     let emit_ctx = MirEmitCtx::for_fn(ctx, &policy);
     emit_mir_fn_body(&mir_fn.body, &emit_ctx)
 }
@@ -1957,6 +2072,17 @@ pub(super) fn emit_mir_tco_fn(
     // `with_rc_wrapped`.
     let mut policy = MirFnEmitPolicy::from_resolved(resolved_fd, scope, /* borrow */ false);
     policy.rc_wrapped = rc_names.clone();
+    // own_param-proven collection params are already `mut`-owned in the
+    // TCO signature (`emit_tco_params_mir`); graduating them only flips
+    // the body's clone-skip on. A pass-through param Arc-wrapped via
+    // `rc_wrapped` keeps its `&T` / `(*x).clone()` shape — rc-wrapping is
+    // a structural TCO decision that takes precedence, so drop any
+    // rc-wrapped name back out of `owned_params` to keep signature and
+    // body consistent.
+    policy.apply_own_param(mir_fn);
+    for n in &rc_names {
+        policy.owned_params.remove(n);
+    }
     let emit_ctx = MirEmitCtx::for_fn(ctx, &policy);
 
     // Render the body in tail position FIRST — bail before emitting any
@@ -2262,6 +2388,14 @@ pub(super) fn emit_mir_mutual_tco_block(
     let mut arm_bodies: Vec<String> = Vec::with_capacity(group_fns.len());
     for (i, mir_fn) in mir_fns.iter().enumerate() {
         // Trampoline arm policy: no borrow-by-default, rc params wrapped.
+        // NB: own_param graduation is deliberately NOT applied to the
+        // mutual-TCO path — graduating a collection param to owned here
+        // would require coordinating the trampoline enum payload type, the
+        // wrapper signatures, and the arg passing across every member, a
+        // far larger and riskier change for no measured win (the perf
+        // flagship `vector_ops` is self-TCO, handled in `emit_mir_tco_fn`).
+        // Keeping borrow-by-default is always sound — not graduating never
+        // skips a clone.
         let mut policy = MirFnEmitPolicy::from_resolved(resolved_fns[i], scope, false);
         policy.rc_wrapped = rc_names.clone();
         let arm_ctx = MirEmitCtx::for_fn(ctx, &policy);
@@ -2807,12 +2941,43 @@ fn try_emit_mir_fusion(
             if !mir_same_local(&args[1].node, &inner_args[0].node) {
                 return None;
             }
-            // HIR: vector + value via `clone_arg`, index via raw emit.
-            let vector = mir_clone_arg(
-                emit_mir_expr(&inner_args[0], ctx)?,
-                &inner_args[0].node,
-                ctx,
-            );
+            // own_param self-keep collapse (the perf flagship): when the
+            // set-target is an OWNED collection param (its `aliased_slots`
+            // bit was cleared by `own_param` → in `ctx.owned_params`) and
+            // the slot is dead after this fusion, MOVE it into `__vec`
+            // instead of cloning. The fusion consumes the slot exactly
+            // once (it returns either the mutated handle or the same
+            // handle), so liveness is the OR of the two `v` occurrences'
+            // `last_use` bits — the inner `Vector.set` read carries
+            // `last_use=false` (the textually-last read is the default
+            // arm), so without the OR we would wrongly clone and the
+            // refcount-2 `Rc::make_mut` would deep-copy every iteration
+            // (the O(n²) the VM/own_param fix already eliminated). This is
+            // the exact mirror of own_param's `Option.withDefault` self-
+            // keep shape + the VM fusion-collapse in `vm/compiler/mir.rs`.
+            let set_local = local_of(&inner_args[0].node);
+            let default_local = local_of(&args[1].node);
+            let move_vec = match (set_local, default_local) {
+                (Some(sv), Some(dv)) => {
+                    ctx.owned_params.contains(sv.name.as_str())
+                        && !ctx.is_borrowed_param(&sv.name)
+                        && !ctx.is_rc_wrapped(&sv.name)
+                        && (sv.last_use || dv.last_use)
+                }
+                _ => false,
+            };
+            let vector = if move_vec {
+                // Owned + dead-after: move (no `.clone()`) → in-place
+                // `set_unchecked` on a refcount-1 `Rc`.
+                emit_mir_expr(&inner_args[0], ctx)?
+            } else {
+                // HIR: vector via `clone_arg` (borrowed / not-proven-owned).
+                mir_clone_arg(
+                    emit_mir_expr(&inner_args[0], ctx)?,
+                    &inner_args[0].node,
+                    ctx,
+                )
+            };
             let index = emit_mir_expr(&inner_args[1], ctx)?;
             let value = mir_clone_arg(
                 emit_mir_expr(&inner_args[2], ctx)?,
@@ -3443,6 +3608,7 @@ mod tests {
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
             borrowed_params: &policy.borrowed_params,
+            owned_params: &policy.owned_params,
             current_module_scope: policy.current_module_scope.as_deref(),
             mir_builtins: BUILTINS.get_or_init(Vec::new),
         };

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -422,8 +422,28 @@ fn emit_fn_def_with_visibility(
     // Check if function uses self-TCO (has TailCall to itself in body)
     let has_tco = body_has_self_tailcall(&fd.body, &fd.name);
 
+    // own_param-proven owned collection params (cleared `aliased_slots`
+    // bit) graduate from `&T` borrow-by-default to `mut p: T`
+    // owned-by-value, so the body's clone-skip yields a refcount-1
+    // in-place `Rc::make_mut`. Read off the same optimized `MirFn` the
+    // body emit (`emit_mir_fn_body_routed` → `apply_own_param`) reads, so
+    // signature and body agree. Only the NON-TCO signature consumes this
+    // here — the self-/mutual-TCO signatures are emitted inside the MIR
+    // TCO helpers (`emit_tco_params_mir` is already `mut`-owned).
+    let owned_collection_params: HashSet<String> = if has_tco {
+        HashSet::new()
+    } else {
+        ctx.mir_program
+            .as_ref()
+            .and_then(|p| p.fn_by_id(resolved_fd.fn_id))
+            .map(|mir_fn| {
+                super::from_mir::owned_collection_param_names(mir_fn, &resolved_fd.params)
+            })
+            .unwrap_or_default()
+    };
+
     // Function signature
-    let params = emit_fn_params(&fd.params, has_tco);
+    let params = emit_fn_params_with_owned(&fd.params, has_tco, &owned_collection_params);
     let ret_type = if fd.return_type.is_empty() {
         "()".to_string()
     } else {
@@ -650,6 +670,29 @@ fn emit_fn_params_with_rc(
     mutable: bool,
     rc_indices: &HashSet<usize>,
 ) -> String {
+    emit_fn_params_inner(params, mutable, rc_indices, &HashSet::new())
+}
+
+/// Emit the non-TCO param signature, graduating `own_param`-proven
+/// collection params (Rust-mangled names in `owned_params`) from `&T`
+/// borrow-by-default to `mut p: T` owned-by-value. The body's
+/// clone-skip (`MirEmitCtx::owned_params`) is derived from the same
+/// `MirFn`, so the two stay in lockstep. Used only on the non-TCO path
+/// (`mutable == false`); the TCO signatures are emitted elsewhere.
+fn emit_fn_params_with_owned(
+    params: &[(String, String)],
+    mutable: bool,
+    owned_params: &HashSet<String>,
+) -> String {
+    emit_fn_params_inner(params, mutable, &HashSet::new(), owned_params)
+}
+
+fn emit_fn_params_inner(
+    params: &[(String, String)],
+    mutable: bool,
+    rc_indices: &HashSet<usize>,
+    owned_params: &HashSet<String>,
+) -> String {
     params
         .iter()
         .enumerate()
@@ -660,6 +703,13 @@ fn emit_fn_params_with_rc(
                 // Borrowed pass-through param: &T instead of owned T
                 format!("{}: &{}", rust_name, rust_type)
             } else if mutable {
+                format!("mut {}: {}", rust_name, rust_type)
+            } else if owned_params.contains(&rust_name) {
+                // own_param proved this collection param uniquely owned:
+                // take it by value (`mut p: T`) so the body's in-place
+                // mutate runs on a refcount-1 backing. `mut` because the
+                // owned-mutate builtins (`Vector.set` → `set_owned`,
+                // `Map.set` → `insert_owned`) consume `self` by value.
                 format!("mut {}: {}", rust_name, rust_type)
             } else {
                 // Borrow-by-default: non-Copy, non-Str params are `&T`
@@ -1050,6 +1100,22 @@ fn emit_main_with_visibility(
     // Check if main returns a Result (needed for ? operator support)
     let returns_result = main_fn.is_some_and(|fd| fd.return_type.starts_with("Result<"));
 
+    // A `main` whose declared return type is neither Unit nor `Result<…>`
+    // (e.g. the bench `fn main() -> Int … fib(15)`) lowers to a Rust `fn
+    // main()` body whose tail is a non-`()` value. Rust's `main` returns
+    // `()` (or a `Termination`), so the tail value must be DISCARDED or
+    // rustc rejects it (`expected (), found i64`). The MIR main port (#395)
+    // dropped the tail-value discard the deleted HIR walker did; restore it
+    // here by suffixing the rendered body with `;`, which turns the tail
+    // expression into a value-dropping statement. Unit mains already end in
+    // `()` / a statement (no-op), and `Result<…>` mains keep their tail (it
+    // flows into the `-> Result<…>` return), so neither needs the discard.
+    let discard_main_tail = main_fn.is_some_and(|fd| {
+        !fd.return_type.is_empty()
+            && fd.return_type != "Unit"
+            && !fd.return_type.starts_with("Result<")
+    });
+
     if returns_result {
         let ret_type = type_annotation_to_rust(&main_fn.unwrap().return_type);
         writeln!(out, "{}fn main() -> {} {{", visibility, ret_type).unwrap();
@@ -1136,6 +1202,17 @@ fn emit_main_with_visibility(
                     )
                 )
             });
+        // Non-Unit, non-Result main: discard the tail value so the body
+        // type-checks against Rust's `()` main return (see
+        // `discard_main_tail` above). Suffixing the whole body string with
+        // `;` drops the final tail expression — correct whether the body is
+        // a single expression or a flat `let`-chain whose last line is the
+        // tail expression.
+        let body = if discard_main_tail {
+            format!("{};", body)
+        } else {
+            body
+        };
         // `emit_mir_main_body` returns a 4-space-indented body
         // (`    crate::cancel_checkpoint();\n    …`); bump it one more
         // level when wrapped in the guest scope so it lines up under the

--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -92,19 +92,41 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
         return program;
     }
 
-    // Aggregate-capture aliasing. A slot whose value is stored DIRECTLY
-    // into an aggregate (record / record-update / variant / tuple / list /
-    // map literal / independent product) is shared with that aggregate —
-    // an in-place mutation of the slot would corrupt the aggregate's copy.
-    // `last_use` marks the slot dead (the aggregate field, not the slot,
-    // is read later) and alias.rs RULE 2 does not model the capture, so
-    // without this the analysis would treat such a slot as uniquely owned
-    // and un-flag a param fed by it — a silent corruption (a vector
-    // aliased into a record field, then own-mutated through that param).
-    // Flag every captured slot up front so it is never un-flagged and
-    // never owned-mutated. (Only DIRECT `Local` field/element values
-    // alias; a `Local` nested inside a sub-computation is consumed by it,
-    // not stored into the aggregate.)
+    // Per-fn slot → binding-RHS provenance (from the body's `Let`s).
+    // Computed first: the capture/escape analysis below resolves a
+    // captured / escaping value back through its alias chain (a
+    // `let w = v` rename, a `match`-bound rename, a passthrough-fn
+    // result) to the originating slot, which needs the provenance map.
+    let mut provenance: HashMap<FnId, HashMap<u32, Spanned<MirExpr>>> = HashMap::new();
+    for (id, f) in program.iter() {
+        let mut m = HashMap::new();
+        collect_let_bindings(&f.body.node, &mut m);
+        provenance.insert(*id, m);
+    }
+
+    // Interprocedural capture summary: `captures_param[f] = { i | param
+    // i of f escapes into an aggregate, either DIRECTLY in f's body or
+    // by being passed (through its alias chain) to a callee at a param
+    // index that callee itself captures }`. Monotone-growing fixpoint
+    // over the call graph; a captured param can never be in-place
+    // mutated by any backend, so this drives both the same-fn pins
+    // (below) and the cross-fn escape detection (a caller slot flowing
+    // into a capturing callee param escapes in the caller too).
+    let captures_param = compute_capture_summary(&program, &provenance);
+
+    // Aggregate-capture + escape aliasing. A slot whose value is shared
+    // with an aggregate (record / record-update / variant / tuple / list
+    // / map literal / independent product) — DIRECTLY or through an alias
+    // binding — must never be mutated in place: the aggregate keeps a
+    // handle to the same backing. The same is true for a slot whose value
+    // escapes into a callee that captures the corresponding param.
+    // `last_use` marks the slot dead at the capture site (only the
+    // aggregate field / callee is read after), and `alias.rs` RULE 2 does
+    // not model either escape, so without this the analysis would treat
+    // such a slot as uniquely owned and un-flag a param fed by it — a
+    // silent corruption (the #383 / escape-audit class). `escaping_slots`
+    // resolves every captured / escaping operand back through its alias
+    // chain to the set of source slots and flags all of them.
     //
     // SOUNDNESS (the #383 corruption class): flagging `aliased_slots`
     // here is NOT enough for a PARAM slot. `prone` (computed above) keys
@@ -114,25 +136,52 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
     // set here whenever the fn's callers all pass a fresh value (e.g. a
     // single `main` caller passing `Vector.new(..)`). That silently
     // un-flags a captured param and re-opens the corruption. So record
-    // each fn's captured PARAM slots and force their owned-lattice entry
+    // each fn's escaping PARAM slots and force their owned-lattice entry
     // to `false` (and keep it pinned there) below, so the proof can never
-    // un-flag a slot whose value escaped into an aggregate.
+    // un-flag a slot whose value escaped into an aggregate or a
+    // capturing callee.
+    let builtins_pre = program.builtins.clone();
     let mut captured_param_slots: HashMap<FnId, HashSet<usize>> = HashMap::new();
+    let mut escaping: HashMap<FnId, HashSet<u32>> = HashMap::new();
+    for (id, f) in program.iter() {
+        let prov = provenance.get(id).cloned().unwrap_or_default();
+        let mut esc: HashSet<u32> = HashSet::new();
+        collect_escaping_slots(
+            &f.body.node,
+            &prov,
+            &captures_param,
+            &builtins_pre,
+            &mut esc,
+        );
+        // Live-alias-across-mutation (the `snap = v; … set(v,…); read
+        // snap` class): a param `p` that has a still-live alias — a
+        // let-binding whose RHS aliases `p` and whose slot is read in the
+        // body — is NOT uniquely owned and must never be mutated in
+        // place. A genuinely linear param (threaded through builtins /
+        // the tail call with no alias binding, e.g. the `fillVector`
+        // fast path) creates no such binding, so this never pins it.
+        let nparams = f.params.len();
+        collect_live_aliased_params(&f.body.node, &prov, &builtins_pre, nparams, &mut esc);
+        if !esc.is_empty() {
+            escaping.insert(*id, esc);
+        }
+    }
     for (id, f) in program.fns.iter_mut() {
-        let mut captured: HashSet<u32> = HashSet::new();
-        collect_captured_slots(&f.body.node, &mut captured);
-        if captured.is_empty() {
+        let Some(esc) = escaping.get(id) else {
+            continue;
+        };
+        if esc.is_empty() {
             continue;
         }
         let nparams = f.params.len();
         let mut slots = f.aliased_slots.as_ref().clone();
-        if let Some(&max) = captured.iter().max()
+        if let Some(&max) = esc.iter().max()
             && (max as usize) >= slots.len()
         {
             slots.resize(max as usize + 1, false);
         }
         let mut cap_params: HashSet<usize> = HashSet::new();
-        for s in captured {
+        for &s in esc {
             slots[s as usize] = true;
             if (s as usize) < nparams {
                 cap_params.insert(s as usize);
@@ -157,14 +206,6 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
         .filter(|(_, f)| f.name == "main" || address_taken.contains(&f.name))
         .map(|(id, _)| *id)
         .collect();
-
-    // Per-fn slot → binding-RHS provenance (from the body's `Let`s).
-    let mut provenance: HashMap<FnId, HashMap<u32, Spanned<MirExpr>>> = HashMap::new();
-    for (id, f) in program.iter() {
-        let mut m = HashMap::new();
-        collect_let_bindings(&f.body.node, &mut m);
-        provenance.insert(*id, m);
-    }
 
     // Visible call edges (Call(Fn) + TailCall). LocalSlot/Builtin/
     // Intrinsic callees are not attributed to any fn's params.
@@ -470,54 +511,400 @@ fn collect_let_bindings(e: &MirExpr, out: &mut HashMap<u32, Spanned<MirExpr>>) {
     visit_children(e, &mut |c| collect_let_bindings(c, out));
 }
 
-/// Collect slots whose value is captured DIRECTLY as a field/element of
-/// an aggregate constructor — the aggregate then shares the slot's
-/// backing, so mutating the slot in place would corrupt the aggregate.
-/// Only direct `Local` operands alias; a `Local` nested inside a
-/// sub-computation is consumed by it (its result, not the slot, lands in
-/// the aggregate), so the recursive `visit_children` walk picks up
-/// deeper aggregates without over-flagging those consumed operands.
-fn collect_captured_slots(e: &MirExpr, out: &mut HashSet<u32>) {
-    fn flag(item: &Spanned<MirExpr>, out: &mut HashSet<u32>) {
-        if let MirExpr::Local(l) = &item.node {
-            out.insert(l.node.slot.0);
-        }
+/// The set of source slots whose backing the value of `e` may share —
+/// the "alias roots" of `e`. Storing `e` into an aggregate, or passing
+/// it where it can be retained, shares the backing of every slot in
+/// this set, so none of them may be mutated in place afterwards.
+///
+/// This is the precise replacement for the old "only a DIRECT bare
+/// `Local` aliases" rule, which missed every indirection the escape
+/// audit found:
+/// - `Local(s)` aliases `s` AND (if `s` is a let-bound local) every
+///   root of its binding RHS — so a `let w = v` / `match`-bound rename
+///   resolves back to the param `v`.
+/// - a user-fn call (`f(a, b, …)`) result may alias ANY of its args
+///   (the RULE-2 passthrough gap — `idv(v)` returns `v`), so its roots
+///   are the union of the args' roots.
+/// - `Vector.set` / `Map.set` return a value sharing their target's
+///   backing (COW may keep it); `Option.withDefault(a, b)` returns one
+///   of its two handles; `Vector.get` / `Map.get` may return an alias
+///   into the source (nested collections) — all propagate roots.
+///
+/// A value built fresh (literal, constructor, `Vector.new` / `Map.new`,
+/// arithmetic) has no roots: storing it shares nothing. The recursion
+/// is depth-capped like `uniquely_owned`.
+fn alias_roots(
+    e: &MirExpr,
+    prov: &HashMap<u32, Spanned<MirExpr>>,
+    builtins: &[String],
+    depth: u32,
+    out: &mut HashSet<u32>,
+) {
+    if depth > MAX_DEPTH {
+        return;
     }
+    match e {
+        MirExpr::Local(l) => {
+            let slot = l.node.slot.0;
+            out.insert(slot);
+            // A let-bound local also carries its binding's roots (a
+            // rename / fused chain). Params have no provenance entry,
+            // so the recursion stops at the param slot itself.
+            if let Some(rhs) = prov.get(&slot) {
+                alias_roots(&rhs.node, prov, builtins, depth + 1, out);
+            }
+        }
+        MirExpr::Match(m) => {
+            for arm in &m.node.arms {
+                alias_roots(&arm.body.node, prov, builtins, depth + 1, out);
+            }
+        }
+        MirExpr::IfThenElse(ite) => {
+            alias_roots(&ite.node.then_branch.node, prov, builtins, depth + 1, out);
+            alias_roots(&ite.node.else_branch.node, prov, builtins, depth + 1, out);
+        }
+        MirExpr::Call(c) => match &c.node.callee {
+            // A user fn / fn-value / intrinsic result may alias any of
+            // its args (the RULE-2 passthrough gap).
+            MirCallee::Fn(_) | MirCallee::LocalSlot { .. } | MirCallee::Intrinsic(_) => {
+                for a in &c.node.args {
+                    alias_roots(&a.node, prov, builtins, depth + 1, out);
+                }
+            }
+            MirCallee::Builtin(id) => {
+                let name = builtins
+                    .get(id.0 as usize)
+                    .map(String::as_str)
+                    .unwrap_or("");
+                match name {
+                    // Fresh collections share nothing.
+                    "Vector.new" | "Map.new" => {}
+                    // set / get return a value sharing the target's
+                    // backing; withDefault returns one of its handles.
+                    "Vector.set" | "Map.set" | "Vector.get" | "Map.get" => {
+                        if let Some(t) = c.node.args.first() {
+                            alias_roots(&t.node, prov, builtins, depth + 1, out);
+                        }
+                    }
+                    "Option.withDefault" => {
+                        for a in &c.node.args {
+                            alias_roots(&a.node, prov, builtins, depth + 1, out);
+                        }
+                    }
+                    // Any other builtin result is not provably fresh;
+                    // be conservative and propagate every arg's roots.
+                    _ => {
+                        for a in &c.node.args {
+                            alias_roots(&a.node, prov, builtins, depth + 1, out);
+                        }
+                    }
+                }
+            }
+        },
+        MirExpr::Return(inner) | MirExpr::Try(inner) => {
+            alias_roots(&inner.node, prov, builtins, depth + 1, out)
+        }
+        // Literals, fresh constructors, record/tuple/list/map literals,
+        // projections, arithmetic, interpolation, tail calls: building
+        // them shares no caller-visible backing slot.
+        _ => {}
+    }
+}
+
+/// Collect every slot that ESCAPES in this fn body: stored (directly or
+/// through an alias chain) into an aggregate, or passed to a callee at a
+/// param index that callee captures. Such a slot must stay flagged — an
+/// in-place mutation would corrupt the aggregate's / callee's retained
+/// handle. Generalizes the old direct-`Local`-only capture detection via
+/// `alias_roots`, closing the let-rename / match-rename / passthrough-fn
+/// capture classes and the cross-fn store-then-mutate class.
+fn collect_escaping_slots(
+    e: &MirExpr,
+    prov: &HashMap<u32, Spanned<MirExpr>>,
+    captures_param: &HashMap<FnId, HashSet<usize>>,
+    builtins: &[String],
+    out: &mut HashSet<u32>,
+) {
+    let capture = |item: &Spanned<MirExpr>, out: &mut HashSet<u32>| {
+        alias_roots(&item.node, prov, builtins, 0, out);
+    };
     match e {
         MirExpr::RecordCreate(r) => {
             for f in &r.node.fields {
-                flag(&f.value, out);
+                capture(&f.value, out);
             }
         }
         MirExpr::RecordUpdate(u) => {
+            // The base record retains its own backing; an update keeps
+            // the un-updated fields, which may alias the base's slots.
+            capture(&u.node.base, out);
             for f in &u.node.updates {
-                flag(&f.value, out);
+                capture(&f.value, out);
             }
         }
         MirExpr::Construct(c) => {
             for a in &c.node.args {
-                flag(a, out);
+                capture(a, out);
             }
         }
         MirExpr::Tuple(items) | MirExpr::List(items) => {
             for i in items {
-                flag(i, out);
+                capture(i, out);
             }
         }
         MirExpr::MapLiteral(pairs) => {
             for (k, v) in pairs {
-                flag(k, out);
-                flag(v, out);
+                capture(k, out);
+                capture(v, out);
             }
         }
         MirExpr::IndependentProduct(ip) => {
             for i in &ip.node.items {
-                flag(i, out);
+                capture(i, out);
+            }
+        }
+        // Cross-fn escape: an arg passed at a param index the callee
+        // captures escapes in this fn too. (TailCall stays in the same
+        // SCC and threads ownership through frame reuse — it is the
+        // linear fast path, not a capture — so it is NOT an escape.)
+        MirExpr::Call(c) => {
+            if let MirCallee::Fn(target) = &c.node.callee
+                && let Some(captured_idxs) = captures_param.get(target)
+            {
+                for &i in captured_idxs {
+                    if let Some(arg) = c.node.args.get(i) {
+                        alias_roots(&arg.node, prov, builtins, 0, out);
+                    }
+                }
             }
         }
         _ => {}
     }
-    visit_children(e, &mut |c| collect_captured_slots(c, out));
+    visit_children(e, &mut |c| {
+        collect_escaping_slots(c, prov, captures_param, builtins, out)
+    });
+}
+
+/// Pin every PARAM that has a still-live alias: a let-bound slot whose
+/// binding RHS aliases the param (its `alias_roots` contains the param
+/// slot) and whose own slot is read somewhere in the body. Such a param
+/// is not uniquely owned — a second binding observes the same backing —
+/// so an in-place mutation would corrupt the alias (the `snap = v; …
+/// set(v,…); read snap` class). A genuinely linear param threads through
+/// builtins / the tail call without any alias binding, so this never
+/// pins the fast path.
+fn collect_live_aliased_params(
+    body: &MirExpr,
+    prov: &HashMap<u32, Spanned<MirExpr>>,
+    builtins: &[String],
+    nparams: usize,
+    out: &mut HashSet<u32>,
+) {
+    // Every slot read by a bare `Local` anywhere in the body.
+    let mut read: HashSet<u32> = HashSet::new();
+    collect_local_reads(body, &mut read);
+    for (&binding, rhs) in prov {
+        // The binding slot must itself be live (read), else no alias is
+        // observed.
+        if !read.contains(&binding) {
+            continue;
+        }
+        // Use `rename_roots`, NOT `alias_roots`: only a *pure value-copy*
+        // alias (a `let w = v` rename, match/if of a param read, a
+        // passthrough-fn result) keeps the param co-live for a
+        // read-after-mutation. A `Vector.set` / `Map.set` / self-keep
+        // `withDefault(set(p,…), p)` is the param's mutated SUCCESSOR
+        // (it consumes `p`), so binding the result does NOT keep `p`
+        // problematically live — that is the linear fast path, and
+        // `alias_roots` (which treats the set result as sharing `p`'s
+        // backing, correct for the CAPTURE check) would wrongly pin it.
+        let mut roots: HashSet<u32> = HashSet::new();
+        rename_roots(&rhs.node, prov, builtins, 0, &mut roots);
+        for &r in &roots {
+            // `r` is an aliased param distinct from this binding slot.
+            if r != binding && (r as usize) < nparams {
+                out.insert(r);
+            }
+        }
+    }
+}
+
+/// Param slots that `e` is a *pure value-copy alias* of — the subset of
+/// `alias_roots` that keeps the source slot CO-LIVE rather than
+/// consuming it. Used only by the live-alias-across-mutation pin
+/// (`collect_live_aliased_params`); the capture / cross-fn escape paths
+/// use the full `alias_roots` semantics.
+///
+/// The key difference from `alias_roots`: a `Vector.set` / `Map.set`
+/// result, and the self-keep `withDefault(set(p,…), p)` fusion shape,
+/// are the param's MUTATED SUCCESSOR — they consume `p` and the result
+/// IS the new value, so binding them does not create a problematic
+/// co-live alias (this is the `fillVector` fast path). They therefore
+/// contribute NO rename roots. Everything that genuinely keeps the
+/// source live — a bare `Local`, a match/if of one, a passthrough-fn
+/// result, a `withDefault`/`get` that selects/projects a still-live
+/// source — propagates, so the read-after-mutation classes stay caught.
+fn rename_roots(
+    e: &MirExpr,
+    prov: &HashMap<u32, Spanned<MirExpr>>,
+    builtins: &[String],
+    depth: u32,
+    out: &mut HashSet<u32>,
+) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    match e {
+        MirExpr::Local(l) => {
+            let slot = l.node.slot.0;
+            out.insert(slot);
+            if let Some(rhs) = prov.get(&slot) {
+                rename_roots(&rhs.node, prov, builtins, depth + 1, out);
+            }
+        }
+        MirExpr::Match(m) => {
+            for arm in &m.node.arms {
+                rename_roots(&arm.body.node, prov, builtins, depth + 1, out);
+            }
+        }
+        MirExpr::IfThenElse(ite) => {
+            rename_roots(&ite.node.then_branch.node, prov, builtins, depth + 1, out);
+            rename_roots(&ite.node.else_branch.node, prov, builtins, depth + 1, out);
+        }
+        MirExpr::Call(c) => match &c.node.callee {
+            // A user-fn / fn-value / intrinsic result may alias an arg
+            // while leaving it live (the RULE-2 passthrough gap).
+            MirCallee::Fn(_) | MirCallee::LocalSlot { .. } | MirCallee::Intrinsic(_) => {
+                for a in &c.node.args {
+                    rename_roots(&a.node, prov, builtins, depth + 1, out);
+                }
+            }
+            MirCallee::Builtin(id) => {
+                let name = builtins
+                    .get(id.0 as usize)
+                    .map(String::as_str)
+                    .unwrap_or("");
+                match name {
+                    // Mutated successor / fresh value — consumes the
+                    // target, so it is NOT a co-live alias.
+                    "Vector.set" | "Map.set" | "Vector.new" | "Map.new" => {}
+                    // `withDefault` surfaces one of its handles; the
+                    // self-keep `withDefault(set(p,…), p)` fusion is the
+                    // linear successor (consumes `p`) — contribute
+                    // nothing for it; any other `withDefault` may select
+                    // a still-live aliased branch, so propagate.
+                    "Option.withDefault"
+                        if c.node.args.len() == 2
+                            && is_self_keep_set(
+                                &c.node.args[0].node,
+                                &c.node.args[1].node,
+                                builtins,
+                            ) => {}
+                    "Option.withDefault" => {
+                        for a in &c.node.args {
+                            rename_roots(&a.node, prov, builtins, depth + 1, out);
+                        }
+                    }
+                    // `get` may project a still-live inner collection
+                    // (nested case); any other builtin is conservative.
+                    _ => {
+                        for a in &c.node.args {
+                            rename_roots(&a.node, prov, builtins, depth + 1, out);
+                        }
+                    }
+                }
+            }
+        },
+        MirExpr::Return(inner) | MirExpr::Try(inner) => {
+            rename_roots(&inner.node, prov, builtins, depth + 1, out)
+        }
+        _ => {}
+    }
+}
+
+/// Recognize the self-keep fusion shape `withDefault(Vector.set|Map.set(
+/// Local(s), …), Local(s))` — the linear in-place mutation idiom whose
+/// two operands both reference the same slot `s`. Mirrors the
+/// recognition in `uniquely_owned`; used by `rename_roots` to treat the
+/// successor as consuming (not aliasing) `s`.
+fn is_self_keep_set(set_arg: &MirExpr, default_arg: &MirExpr, builtins: &[String]) -> bool {
+    if let MirExpr::Call(inner) = set_arg
+        && let MirCallee::Builtin(iid) = inner.node.callee
+        && matches!(
+            builtins.get(iid.0 as usize).map(String::as_str),
+            Some("Vector.set") | Some("Map.set")
+        )
+        && let Some(set_vec) = inner.node.args.first()
+        && let MirExpr::Local(v) = &set_vec.node
+        && let MirExpr::Local(d) = default_arg
+    {
+        return v.node.slot == d.node.slot;
+    }
+    false
+}
+
+/// Collect every slot referenced by a bare `MirExpr::Local` read.
+fn collect_local_reads(e: &MirExpr, out: &mut HashSet<u32>) {
+    if let MirExpr::Local(l) = e {
+        out.insert(l.node.slot.0);
+    }
+    visit_children(e, &mut |c| collect_local_reads(c, out));
+}
+
+/// Interprocedural "fn captures param i" summary. `captures_param[f]`
+/// holds the indices of `f`'s params whose value escapes into an
+/// aggregate — directly in `f`, or transitively by being passed to a
+/// callee that captures the corresponding param. Monotone-growing
+/// fixpoint over the visible `Call(Fn)` edges; recursion / cycles are
+/// safe because the set only grows. A param not in the summary is NOT a
+/// proof of no-capture across unseen edges — but this pass already runs
+/// only on whole, single-module programs (every caller visible), and
+/// any genuinely externally-reachable fn (`main` / address-taken) keeps
+/// all params flagged regardless.
+fn compute_capture_summary(
+    program: &MirProgram,
+    provenance: &HashMap<FnId, HashMap<u32, Spanned<MirExpr>>>,
+) -> HashMap<FnId, HashSet<usize>> {
+    let builtins = &program.builtins;
+    // Param-slot → param-index per fn (params occupy the leading slots,
+    // but resolve by the declared `local` to be safe).
+    let mut param_slot_to_idx: HashMap<FnId, HashMap<u32, usize>> = HashMap::new();
+    for (id, f) in program.iter() {
+        let m: HashMap<u32, usize> = f
+            .params
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (p.local.0, i))
+            .collect();
+        param_slot_to_idx.insert(*id, m);
+    }
+
+    let mut captures: HashMap<FnId, HashSet<usize>> = HashMap::new();
+    loop {
+        let mut changed = false;
+        for (id, f) in program.iter() {
+            let prov = provenance.get(id).cloned().unwrap_or_default();
+            let nparams = f.params.len();
+            // Slots that escape into an aggregate or a (already-known)
+            // capturing callee within this fn body.
+            let mut esc: HashSet<u32> = HashSet::new();
+            collect_escaping_slots(&f.body.node, &prov, &captures, builtins, &mut esc);
+            let idx_map = &param_slot_to_idx[id];
+            let entry = captures.entry(*id).or_default();
+            for &s in &esc {
+                if (s as usize) < nparams
+                    && let Some(&i) = idx_map.get(&s)
+                    && entry.insert(i)
+                {
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    captures
 }
 
 /// Collect visible `Call(Fn)` / `TailCall` edges made from `caller`.

--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -105,20 +105,41 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
     // never owned-mutated. (Only DIRECT `Local` field/element values
     // alias; a `Local` nested inside a sub-computation is consumed by it,
     // not stored into the aggregate.)
-    for (_, f) in program.fns.iter_mut() {
+    //
+    // SOUNDNESS (the #383 corruption class): flagging `aliased_slots`
+    // here is NOT enough for a PARAM slot. `prone` (computed above) keys
+    // off RULE 1, so every Vector/Map param — captured or not — is
+    // already in the owned-lattice; the fixpoint then seeds it optimistic
+    // `true` and the apply step (`to_clear`) would CLEAR the very bit we
+    // set here whenever the fn's callers all pass a fresh value (e.g. a
+    // single `main` caller passing `Vector.new(..)`). That silently
+    // un-flags a captured param and re-opens the corruption. So record
+    // each fn's captured PARAM slots and force their owned-lattice entry
+    // to `false` (and keep it pinned there) below, so the proof can never
+    // un-flag a slot whose value escaped into an aggregate.
+    let mut captured_param_slots: HashMap<FnId, HashSet<usize>> = HashMap::new();
+    for (id, f) in program.fns.iter_mut() {
         let mut captured: HashSet<u32> = HashSet::new();
         collect_captured_slots(&f.body.node, &mut captured);
         if captured.is_empty() {
             continue;
         }
+        let nparams = f.params.len();
         let mut slots = f.aliased_slots.as_ref().clone();
         if let Some(&max) = captured.iter().max()
             && (max as usize) >= slots.len()
         {
             slots.resize(max as usize + 1, false);
         }
+        let mut cap_params: HashSet<usize> = HashSet::new();
         for s in captured {
             slots[s as usize] = true;
+            if (s as usize) < nparams {
+                cap_params.insert(s as usize);
+            }
+        }
+        if !cap_params.is_empty() {
+            captured_param_slots.insert(*id, cap_params);
         }
         f.aliased_slots = Arc::new(slots);
     }
@@ -153,12 +174,18 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
     }
 
     // Fixpoint lattice: owned[(fn, param_idx)] for alias-prone params.
-    // Init optimistic true; pinned fns start (and stay) false.
+    // Init optimistic true; pinned fns start (and stay) false. A param
+    // slot whose value escaped into an aggregate (captured_param_slots)
+    // also starts false — its backing is shared with the aggregate's copy,
+    // so it must never be owned-mutated in place (the #383 class). The
+    // lattice is monotone-descending, so a `false` seed stays `false`.
     let mut owned: HashMap<(FnId, usize), bool> = HashMap::new();
     for (id, idxs) in &prone {
         let pin = pinned.contains(id);
+        let captured = captured_param_slots.get(id);
         for &i in idxs {
-            owned.insert((*id, i), !pin);
+            let escaped = captured.is_some_and(|c| c.contains(&i));
+            owned.insert((*id, i), !pin && !escaped);
         }
     }
 

--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -8,35 +8,72 @@
 //! tail recursion (`fn fill(v, ..) -> .. = fill(set(v, ..), ..)`), which
 //! clones the backing array on every call: O(n²).
 //!
-//! This pass refines that decision interprocedurally: a Vector/Map param
-//! `p` of fn `f` is un-flagged (cleared from `aliased_slots`) only when
-//! **every** call site of `f` passes `p` a *uniquely-owned* argument,
-//! computed as a monotone-descending fixpoint (recursion couples a
-//! param's ownership to its own call sites). Default is to keep the
-//! conservative flag — un-flagging is the exception, gated on proof.
+//! This pass refines that decision interprocedurally and clears a
+//! Vector/Map param's `aliased_slots` bit — graduating it to the
+//! owned/in-place fast path — only when the clear is **sound by
+//! construction**.
 //!
-//! ## Soundness
+//! ## Sound-by-construction: default-flag, clear-on-proof
 //!
-//! A false negative (un-flag a param that *is* aliased) lets a backend
-//! mutate shared data in place → silent corruption. Every uncertain
-//! point therefore resolves to **not-owned** (keep flagged):
+//! Two adversarial audits found five distinct corruption classes by
+//! enumerating escape/capture *sites*; each audit found a site the
+//! enumeration missed (direct capture, alias-rename chains, cross-fn
+//! capture, live-alias, a param fed as the VALUE/ELEMENT/DEFAULT arg of
+//! `Vector.set`/`Map.set`/`Vector.new`/a map literal). A blacklist of
+//! escape sites is unsound by omission: any unforeseen site is a silent
+//! corruption (a backend mutates shared data in place).
+//!
+//! So the polarity is flipped. The default for every collection param is
+//! **flagged** (kept aliased — never mutated in place). The bit is
+//! cleared only when a *positive proof* succeeds, i.e. when **every**
+//! occurrence of the param `P` — and of every let-local that may share
+//! `P`'s backing (its alias closure) — is one of these RECOGNIZED
+//! non-retaining-linear uses:
+//!
+//! - `P` (or an alias) as the TARGET/receiver arg (arg 0) of a
+//!   mutating/reading collection builtin (`Vector.set`/`get`/`len`,
+//!   `Map.set`/`get`/`has`/`remove`/`keys`/`values`/`len`/`entries`) —
+//!   these consume/read the target, they do not retain it beyond the
+//!   result that replaces it;
+//! - the self-keep fusion `Option.withDefault(Vector.set(P,..), P)` /
+//!   `Map.set` — the fused `VECTOR_SET_OR_KEEP` consumes `P` once and
+//!   returns one of its two handles;
+//! - `P` (or an alias) in the fn's tail/return position — `P` moves out
+//!   as the result (linear);
+//! - `P` (or an alias) threaded to a callee at a param index that an
+//!   interprocedural summary PROVES the callee never retains.
+//!
+//! ANY other occurrence is a POTENTIAL ESCAPE → `P` stays flagged:
+//! `P` (or an alias) as a NON-target argument (value/element/default/key
+//! arg) of ANY builtin, a field/element of ANY aggregate
+//! (record / record-update / variant / tuple / list / map literal /
+//! independent product), an argument to ANY user fn that the summary
+//! does not clear, or an alias that is read while `P` is still live. The
+//! scan defaults every *unrecognized* position to retaining, so it
+//! cannot miss an escape — the audits converge.
+//!
+//! The body-local proof above is one half; the other is the
+//! interprocedural call-site proof: even a body-locally-linear param
+//! graduates only when **every** visible call site of its fn passes it a
+//! uniquely-owned argument (a fresh constructor, an owned set-chain, a
+//! `last_use` non-aliased local with no live caller-side alias),
+//! computed as a monotone-descending fixpoint. Default is keep-flagged;
+//! un-flagging is the gated exception.
+//!
+//! ## Soundness gates
 //!
 //! - Runs only on a whole-program `MirProgram` (`modules` empty / one):
-//!   a multi-module or per-module-VM fragment can have callers we can't
-//!   see, and a missed aliased caller is unsound. Multi-module is skipped
-//!   wholesale.
+//!   a multi-module fragment can have callers we can't see, and a missed
+//!   aliased caller is unsound. Multi-module is skipped wholesale.
 //! - `main`/entry and any address-taken fn (its name appears in a
 //!   `MirExpr::FnValue`) keep all params flagged — their callers are not
 //!   all visible `Call`/`TailCall` edges.
 //! - A call site reached through `MirCallee::LocalSlot` (a fn value) has
 //!   no statically-known target, so it never counts as a visible caller;
 //!   such fns are already pinned via the address-taken set.
-//! - An argument is uniquely-owned only when proven so: a fresh
-//!   scalar-defaulted constructor, an owned `Vector.set`/`Map.set` chain,
-//!   `Option.withDefault` of owned branches, or a `last_use`,
-//!   non-aliased local whose binding provenance is itself owned (never a
-//!   user-fn-call result — that may alias an argument, the gap `alias.rs`
-//!   RULE 2 cannot see). Anything unrecognized is not-owned.
+//! - An argument is uniquely-owned only when proven so (never a user-fn
+//!   result — that may alias an arg, the gap `alias.rs` RULE 2 cannot
+//!   see — and never a local that still has a live alias in the caller).
 //! - Two alias-prone params receiving the same slot at one call site are
 //!   both rejected (the value is shared between them inside the callee).
 //!
@@ -54,9 +91,38 @@ use crate::ir::FnId;
 use super::super::expr::{MirCallee, MirExpr};
 use super::super::program::MirProgram;
 
-/// Recursion cap for `uniquely_owned` — defends against a pathological
-/// let-provenance chain; exceeding it resolves to not-owned.
+/// Recursion cap for the alias / ownership walks — defends against a
+/// pathological let-provenance chain; exceeding it resolves to the
+/// conservative answer (not-owned / leaking).
 const MAX_DEPTH: u32 = 64;
+
+/// Collection builtins whose arg 0 is the TARGET/receiver: a
+/// non-retaining read/consume of the collection. `P` appearing there
+/// does not escape — the builtin reads or replaces the target and its
+/// result (which may itself alias the target) is checked separately
+/// wherever it lands. Args at index >= 1 are value/element/key/default
+/// positions and ARE retaining.
+///
+/// `Vector.new` / `Map.new` / `Vector.fromList` / `Map.fromList` are
+/// deliberately absent: they CONSTRUCT a collection, so they have no
+/// target arg — their collection-valued args (the `Vector.new` default
+/// cell, the `fromList` list elements) are retaining and must flag.
+fn is_target_consuming_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "Vector.set"
+            | "Vector.get"
+            | "Vector.len"
+            | "Map.set"
+            | "Map.get"
+            | "Map.has"
+            | "Map.remove"
+            | "Map.keys"
+            | "Map.values"
+            | "Map.len"
+            | "Map.entries"
+    )
+}
 
 /// A single visible call edge: `target(args…)` made from `caller`.
 struct CallSite {
@@ -92,11 +158,10 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
         return program;
     }
 
-    // Per-fn slot → binding-RHS provenance (from the body's `Let`s).
-    // Computed first: the capture/escape analysis below resolves a
-    // captured / escaping value back through its alias chain (a
-    // `let w = v` rename, a `match`-bound rename, a passthrough-fn
-    // result) to the originating slot, which needs the provenance map.
+    // Per-fn slot → binding-RHS provenance (from the body's `Let`s). The
+    // alias walks (`alias_roots` / `rename_roots`) resolve a value back
+    // through its alias chain (a `let w = v` rename, a `match`-bound
+    // rename, a passthrough-fn result) to the originating slot.
     let mut provenance: HashMap<FnId, HashMap<u32, Spanned<MirExpr>>> = HashMap::new();
     for (id, f) in program.iter() {
         let mut m = HashMap::new();
@@ -105,90 +170,78 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
     }
 
     // Interprocedural capture summary: `captures_param[f] = { i | param
-    // i of f escapes into an aggregate, either DIRECTLY in f's body or
-    // by being passed (through its alias chain) to a callee at a param
-    // index that callee itself captures }`. Monotone-growing fixpoint
-    // over the call graph; a captured param can never be in-place
-    // mutated by any backend, so this drives both the same-fn pins
-    // (below) and the cross-fn escape detection (a caller slot flowing
-    // into a capturing callee param escapes in the caller too).
-    let captures_param = compute_capture_summary(&program, &provenance);
+    // i of f is NOT proven non-retaining in f's body — i.e. some
+    // occurrence of param i is not a recognized linear use, OR it is
+    // threaded to a callee that itself captures }`. This is the dual of
+    // the body-local proof: a param the proof clears does NOT retain its
+    // arg, so a caller passing a value at that index does not escape
+    // through it. Monotone-growing fixpoint over the call graph; a
+    // captured param can never be safely fed an owned value, so this
+    // drives the cross-fn escape detection (a caller slot flowing into a
+    // capturing callee param escapes in the caller too).
+    let builtins = program.builtins.clone();
+    let captures_param = compute_capture_summary(&program, &provenance, &builtins);
 
-    // Aggregate-capture + escape aliasing. A slot whose value is shared
-    // with an aggregate (record / record-update / variant / tuple / list
-    // / map literal / independent product) — DIRECTLY or through an alias
-    // binding — must never be mutated in place: the aggregate keeps a
-    // handle to the same backing. The same is true for a slot whose value
-    // escapes into a callee that captures the corresponding param.
-    // `last_use` marks the slot dead at the capture site (only the
-    // aggregate field / callee is read after), and `alias.rs` RULE 2 does
-    // not model either escape, so without this the analysis would treat
-    // such a slot as uniquely owned and un-flag a param fed by it — a
-    // silent corruption (the #383 / escape-audit class). `escaping_slots`
-    // resolves every captured / escaping operand back through its alias
-    // chain to the set of source slots and flags all of them.
+    // --- BODY-LOCAL PROOF -------------------------------------------------
     //
-    // SOUNDNESS (the #383 corruption class): flagging `aliased_slots`
-    // here is NOT enough for a PARAM slot. `prone` (computed above) keys
-    // off RULE 1, so every Vector/Map param — captured or not — is
-    // already in the owned-lattice; the fixpoint then seeds it optimistic
-    // `true` and the apply step (`to_clear`) would CLEAR the very bit we
-    // set here whenever the fn's callers all pass a fresh value (e.g. a
-    // single `main` caller passing `Vector.new(..)`). That silently
-    // un-flags a captured param and re-opens the corruption. So record
-    // each fn's escaping PARAM slots and force their owned-lattice entry
-    // to `false` (and keep it pinned there) below, so the proof can never
-    // un-flag a slot whose value escaped into an aggregate or a
-    // capturing callee.
-    let builtins_pre = program.builtins.clone();
-    let mut captured_param_slots: HashMap<FnId, HashSet<usize>> = HashMap::new();
-    let mut escaping: HashMap<FnId, HashSet<u32>> = HashMap::new();
+    // For each fn, compute the set of slots that LEAK in its body: slots
+    // that appear (directly or through an alias chain) in any position
+    // the whitelist does NOT recognize as non-retaining-linear. The scan
+    // is positive — it walks every operand position, marks the
+    // recognized-safe ones, and treats every other (and every position
+    // it does not explicitly recognize) as retaining. A bare `Local` in
+    // a retaining position contributes its alias roots to the leak set.
+    //
+    // A param slot in the leak set MUST stay flagged: some occurrence of
+    // it (or of a value sharing its backing) is retained beyond a linear
+    // consume, so an in-place mutation would corrupt the retained handle.
+    // This single scan subsumes the old `collect_escaping_slots`
+    // blacklist (aggregate capture, value-into-collection,
+    // cross-fn capture) by construction — default is leak.
+    //
+    // The live-alias class (`snap = v; … set(v,…); read snap`) is a
+    // distinct shape: the param appears only in recognized-safe
+    // positions, yet a still-live RENAME alias observes the pre-mutation
+    // backing. `collect_live_aliased_params` pins those separately.
+    let mut leaking: HashMap<FnId, HashSet<u32>> = HashMap::new();
     for (id, f) in program.iter() {
         let prov = provenance.get(id).cloned().unwrap_or_default();
-        let mut esc: HashSet<u32> = HashSet::new();
-        collect_escaping_slots(
-            &f.body.node,
-            &prov,
-            &captures_param,
-            &builtins_pre,
-            &mut esc,
-        );
-        // Live-alias-across-mutation (the `snap = v; … set(v,…); read
-        // snap` class): a param `p` that has a still-live alias — a
-        // let-binding whose RHS aliases `p` and whose slot is read in the
-        // body — is NOT uniquely owned and must never be mutated in
-        // place. A genuinely linear param (threaded through builtins /
-        // the tail call with no alias binding, e.g. the `fillVector`
-        // fast path) creates no such binding, so this never pins it.
+        let mut leak: HashSet<u32> = HashSet::new();
+        scan_leaks(&f.body.node, &prov, &captures_param, &builtins, &mut leak);
         let nparams = f.params.len();
-        collect_live_aliased_params(&f.body.node, &prov, &builtins_pre, nparams, &mut esc);
-        if !esc.is_empty() {
-            escaping.insert(*id, esc);
+        collect_live_aliased_params(&f.body.node, &prov, &builtins, nparams, &mut leak);
+        if !leak.is_empty() {
+            leaking.insert(*id, leak);
         }
     }
+
+    // Apply the body-local leaks to `aliased_slots` (so a leaked PARAM
+    // slot stays flagged) and record which PARAM slots leaked, so the
+    // call-site fixpoint can never un-flag them.
+    let mut leaked_param_slots: HashMap<FnId, HashSet<usize>> = HashMap::new();
     for (id, f) in program.fns.iter_mut() {
-        let Some(esc) = escaping.get(id) else {
+        let Some(leak) = leaking.get(id) else {
             continue;
         };
-        if esc.is_empty() {
+        if leak.is_empty() {
             continue;
         }
         let nparams = f.params.len();
         let mut slots = f.aliased_slots.as_ref().clone();
-        if let Some(&max) = esc.iter().max()
+        if let Some(&max) = leak.iter().max()
             && (max as usize) >= slots.len()
         {
             slots.resize(max as usize + 1, false);
         }
-        let mut cap_params: HashSet<usize> = HashSet::new();
-        for &s in esc {
+        let mut leaked_params: HashSet<usize> = HashSet::new();
+        for &s in leak {
             slots[s as usize] = true;
             if (s as usize) < nparams {
-                cap_params.insert(s as usize);
+                leaked_params.insert(s as usize);
             }
         }
-        if !cap_params.is_empty() {
-            captured_param_slots.insert(*id, cap_params);
+        if !leaked_params.is_empty() {
+            leaked_param_slots.insert(*id, leaked_params);
         }
         f.aliased_slots = Arc::new(slots);
     }
@@ -214,23 +267,37 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
         collect_call_sites(*caller, &f.body.node, &mut call_sites);
     }
 
-    // Fixpoint lattice: owned[(fn, param_idx)] for alias-prone params.
-    // Init optimistic true; pinned fns start (and stay) false. A param
-    // slot whose value escaped into an aggregate (captured_param_slots)
-    // also starts false — its backing is shared with the aggregate's copy,
-    // so it must never be owned-mutated in place (the #383 class). The
-    // lattice is monotone-descending, so a `false` seed stays `false`.
-    let mut owned: HashMap<(FnId, usize), bool> = HashMap::new();
-    for (id, idxs) in &prone {
-        let pin = pinned.contains(id);
-        let captured = captured_param_slots.get(id);
-        for &i in idxs {
-            let escaped = captured.is_some_and(|c| c.contains(&i));
-            owned.insert((*id, i), !pin && !escaped);
+    // Per-fn set of let-bound slots that have a still-live RENAME alias
+    // of another slot — used by `uniquely_owned` to reject a call-site
+    // arg whose slot the CALLER still observes through a live alias (the
+    // live-alias-at-callsite class). Computed once: a slot `s` is in
+    // `live_aliased[caller]` when some read let-binding renames `s`.
+    let mut live_aliased: HashMap<FnId, HashSet<u32>> = HashMap::new();
+    for (id, f) in program.iter() {
+        let prov = provenance.get(id).cloned().unwrap_or_default();
+        let mut set: HashSet<u32> = HashSet::new();
+        collect_live_aliased_slots(&f.body.node, &prov, &builtins, &mut set);
+        if !set.is_empty() {
+            live_aliased.insert(*id, set);
         }
     }
 
-    let builtins = program.builtins.clone();
+    // Fixpoint lattice: owned[(fn, param_idx)] for alias-prone params.
+    // Init optimistic true; pinned fns start (and stay) false. A param
+    // slot that LEAKED in its body (leaked_param_slots) also starts
+    // false — its backing is retained somewhere, so it must never be
+    // owned-mutated in place. The lattice is monotone-descending, so a
+    // `false` seed stays `false`.
+    let mut owned: HashMap<(FnId, usize), bool> = HashMap::new();
+    for (id, idxs) in &prone {
+        let pin = pinned.contains(id);
+        let leaked = leaked_param_slots.get(id);
+        for &i in idxs {
+            let body_leak = leaked.is_some_and(|c| c.contains(&i));
+            owned.insert((*id, i), !pin && !body_leak);
+        }
+    }
+
     loop {
         let mut changed = false;
         for cs in &call_sites {
@@ -250,6 +317,7 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
                     *slot_counts.entry(l.node.slot.0).or_insert(0) += 1;
                 }
             }
+            let caller_live_aliased = live_aliased.get(&cs.caller);
             for &i in idxs {
                 let key = (cs.target, i);
                 if !owned.get(&key).copied().unwrap_or(false) {
@@ -267,7 +335,15 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
                     }
                 };
                 let dup = matches!(&arg.node, MirExpr::Local(l) if slot_counts.get(&l.node.slot.0).copied().unwrap_or(0) > 1);
+                // Live-alias-at-callsite: an owned local passed here is
+                // NOT uniquely owned if the CALLER still observes its
+                // slot through a live rename alias (`alias = base;
+                // mutate(base); read alias`). The callee graduates and
+                // mutates in place, corrupting the caller's alias.
+                let caller_aliased = matches!(&arg.node, MirExpr::Local(l)
+                    if caller_live_aliased.is_some_and(|s| s.contains(&l.node.slot.0)));
                 let ok = !dup
+                    && !caller_aliased
                     && uniquely_owned(
                         &arg.node,
                         cs.caller,
@@ -516,9 +592,6 @@ fn collect_let_bindings(e: &MirExpr, out: &mut HashMap<u32, Spanned<MirExpr>>) {
 /// it where it can be retained, shares the backing of every slot in
 /// this set, so none of them may be mutated in place afterwards.
 ///
-/// This is the precise replacement for the old "only a DIRECT bare
-/// `Local` aliases" rule, which missed every indirection the escape
-/// audit found:
 /// - `Local(s)` aliases `s` AND (if `s` is a let-bound local) every
 ///   root of its binding RHS — so a `let w = v` / `match`-bound rename
 ///   resolves back to the param `v`.
@@ -611,82 +684,264 @@ fn alias_roots(
     }
 }
 
-/// Collect every slot that ESCAPES in this fn body: stored (directly or
-/// through an alias chain) into an aggregate, or passed to a callee at a
-/// param index that callee captures. Such a slot must stay flagged — an
-/// in-place mutation would corrupt the aggregate's / callee's retained
-/// handle. Generalizes the old direct-`Local`-only capture detection via
-/// `alias_roots`, closing the let-rename / match-rename / passthrough-fn
-/// capture classes and the cross-fn store-then-mutate class.
-fn collect_escaping_slots(
+/// Positive (whitelist) leak scan. Walks every operand position of the
+/// fn body and adds to `out` the alias roots of every value that lands
+/// in a RETAINING position — i.e. any position not recognized as a
+/// non-retaining-linear use. This is the sound-by-construction core: the
+/// default for an unrecognized position is "retaining" (leak), so no
+/// escape site can be silently missed.
+///
+/// Recognized-safe (non-retaining) positions:
+/// - the tail/return position (a bare `Local` moves out as the result —
+///   handled implicitly: a `Local` reached as a whole sub-expression of
+///   a safe-scanned position is a no-op leaf, so a move-out never leaks);
+/// - arg 0 of a target-consuming collection builtin
+///   (`is_target_consuming_builtin`);
+/// - both operands of `Option.withDefault` (it SELECTS and returns one
+///   handle, retaining nothing — TRANSPARENT), which subsumes the
+///   self-keep fusion `withDefault(set(P,..), P)`;
+/// - an arg threaded to a user fn at a param index the interprocedural
+///   capture summary PROVES the callee does not retain (not in
+///   `captures_param`).
+///
+/// Everything else — aggregate fields/elements, non-target builtin args,
+/// constructor args, the default cell of `Vector.new`, args to an
+/// unproven callee, interpolation operands — is retaining.
+fn scan_leaks(
     e: &MirExpr,
     prov: &HashMap<u32, Spanned<MirExpr>>,
     captures_param: &HashMap<FnId, HashSet<usize>>,
     builtins: &[String],
     out: &mut HashSet<u32>,
 ) {
-    let capture = |item: &Spanned<MirExpr>, out: &mut HashSet<u32>| {
-        alias_roots(&item.node, prov, builtins, 0, out);
+    // A child in a RETAINING position: record the alias roots of any
+    // value that flows there, then keep scanning it for nested leaks.
+    let mut retain = |child: &Spanned<MirExpr>, out: &mut HashSet<u32>| {
+        alias_roots(&child.node, prov, builtins, 0, out);
+        scan_leaks(&child.node, prov, captures_param, builtins, out);
     };
+
     match e {
+        // --- Control flow: tail-transparent. A bare `Local` value
+        //     produced by any of these positions moves out as the
+        //     fn/branch result (linear), so it is NOT retained — scanning
+        //     it as a non-retaining read is correct (a Local leaf is a
+        //     no-op). Only the SUBJECT / bound-VALUE positions consume a
+        //     value to drive the control flow; they are likewise reads. ---
+        MirExpr::Let(l) => {
+            scan_leaks(&l.node.value.node, prov, captures_param, builtins, out);
+            scan_leaks(&l.node.body.node, prov, captures_param, builtins, out);
+        }
+        MirExpr::Match(m) => {
+            scan_leaks(&m.node.subject.node, prov, captures_param, builtins, out);
+            for arm in &m.node.arms {
+                scan_leaks(&arm.body.node, prov, captures_param, builtins, out);
+            }
+        }
+        MirExpr::IfThenElse(ite) => {
+            scan_leaks(&ite.node.cond.node, prov, captures_param, builtins, out);
+            scan_leaks(
+                &ite.node.then_branch.node,
+                prov,
+                captures_param,
+                builtins,
+                out,
+            );
+            scan_leaks(
+                &ite.node.else_branch.node,
+                prov,
+                captures_param,
+                builtins,
+                out,
+            );
+        }
+        MirExpr::Return(inner) | MirExpr::Try(inner) => {
+            scan_leaks(&inner.node, prov, captures_param, builtins, out);
+        }
+
+        // --- Calls: classify each arg position. ---
+        MirExpr::Call(c) => match &c.node.callee {
+            MirCallee::Builtin(bid) => {
+                let name = builtins
+                    .get(bid.0 as usize)
+                    .map(String::as_str)
+                    .unwrap_or("");
+                if name == "Option.withDefault" {
+                    // `withDefault(a, b)` SELECTS and returns one of its
+                    // two handles — it retains NOTHING beyond the value it
+                    // surfaces. So it is TRANSPARENT: scan both operands as
+                    // non-retaining reads. Whether the selected value
+                    // escapes is decided at the withDefault RESULT's
+                    // position (the parent), and a still-live aliased
+                    // branch is caught by the live-alias pin (which
+                    // propagates through `withDefault` in `rename_roots`).
+                    // This subsumes the self-keep fusion
+                    // `withDefault(set(P,..), P)`: the inner `set` flags
+                    // its own value/index args, `P` at the set's arg 0 and
+                    // as the default are both safe reads, so the linear
+                    // param does not leak.
+                    for a in &c.node.args {
+                        scan_leaks(&a.node, prov, captures_param, builtins, out);
+                    }
+                    return;
+                }
+                // Target-consuming builtins read/replace arg 0 (the
+                // receiver) without retaining it; args >= 1 are
+                // value/element/key positions and DO retain. A
+                // constructor (`Vector.new` / `Map.new` / `*.fromList`)
+                // has no target arg — every collection-valued arg
+                // retains, so `target_safe = false`.
+                let target_safe = is_target_consuming_builtin(name);
+                scan_builtin_args(
+                    c,
+                    target_safe,
+                    prov,
+                    captures_param,
+                    builtins,
+                    &mut retain,
+                    out,
+                );
+            }
+            MirCallee::Fn(target) => {
+                let captured = captures_param.get(target);
+                for (i, a) in c.node.args.iter().enumerate() {
+                    // An arg at an index the callee does NOT retain is
+                    // safe (the callee threads it linearly); otherwise it
+                    // escapes into the callee. The summary is a
+                    // least-fixpoint (starts empty = nothing captured,
+                    // grows monotonically), so a param ABSENT from the
+                    // summary is treated as non-retaining — sound once the
+                    // fixpoint reaches it, and it is the only direction
+                    // that lets a linear self-recursive param converge.
+                    if captured.is_some_and(|c| c.contains(&i)) {
+                        retain(a, out);
+                    } else {
+                        // Provably non-retaining param: safe, scan deeper.
+                        scan_leaks(&a.node, prov, captures_param, builtins, out);
+                    }
+                }
+            }
+            MirCallee::LocalSlot { .. } | MirCallee::Intrinsic(_) => {
+                // No statically-known target / summary — every arg may
+                // be retained. Default to retaining.
+                for a in &c.node.args {
+                    retain(a, out);
+                }
+            }
+        },
+
+        // --- Tail calls: same-SCC threading. An arg at a param index
+        //     the callee does NOT retain threads linearly (the fast
+        //     path); otherwise it escapes into the callee. ---
+        MirExpr::TailCall(tc) => {
+            let captured = captures_param.get(&tc.node.target);
+            for (i, a) in tc.node.args.iter().enumerate() {
+                // Same least-fixpoint semantics as `Call(Fn)`: an arg at
+                // a param index NOT in the (monotone-growing) capture
+                // summary threads linearly (the fast path); one at a
+                // captured index escapes into the callee.
+                if captured.is_some_and(|c| c.contains(&i)) {
+                    retain(a, out);
+                } else {
+                    scan_leaks(&a.node, prov, captures_param, builtins, out);
+                }
+            }
+        }
+
+        // --- Aggregates: every field / element / value is retaining. ---
         MirExpr::RecordCreate(r) => {
             for f in &r.node.fields {
-                capture(&f.value, out);
+                retain(&f.value, out);
             }
         }
         MirExpr::RecordUpdate(u) => {
-            // The base record retains its own backing; an update keeps
-            // the un-updated fields, which may alias the base's slots.
-            capture(&u.node.base, out);
+            retain(&u.node.base, out);
             for f in &u.node.updates {
-                capture(&f.value, out);
+                retain(&f.value, out);
             }
         }
         MirExpr::Construct(c) => {
             for a in &c.node.args {
-                capture(a, out);
+                retain(a, out);
             }
         }
         MirExpr::Tuple(items) | MirExpr::List(items) => {
             for i in items {
-                capture(i, out);
+                retain(i, out);
             }
         }
         MirExpr::MapLiteral(pairs) => {
             for (k, v) in pairs {
-                capture(k, out);
-                capture(v, out);
+                retain(k, out);
+                retain(v, out);
             }
         }
         MirExpr::IndependentProduct(ip) => {
             for i in &ip.node.items {
-                capture(i, out);
+                retain(i, out);
             }
         }
-        // Cross-fn escape: an arg passed at a param index the callee
-        // captures escapes in this fn too. (TailCall stays in the same
-        // SCC and threads ownership through frame reuse — it is the
-        // linear fast path, not a capture — so it is NOT an escape.)
-        MirExpr::Call(c) => {
-            if let MirCallee::Fn(target) = &c.node.callee
-                && let Some(captured_idxs) = captures_param.get(target)
-            {
-                for &i in captured_idxs {
-                    if let Some(arg) = c.node.args.get(i) {
-                        alias_roots(&arg.node, prov, builtins, 0, out);
-                    }
+
+        // --- Scalar / structural operands: a collection value flowing
+        //     into these is consumed for a scalar result, never retained;
+        //     recurse to find nested leaks. ---
+        MirExpr::BinOp(b) => {
+            scan_leaks(&b.node.lhs.node, prov, captures_param, builtins, out);
+            scan_leaks(&b.node.rhs.node, prov, captures_param, builtins, out);
+        }
+        MirExpr::Neg(inner) => scan_leaks(&inner.node, prov, captures_param, builtins, out),
+        MirExpr::Project(p) => {
+            // `base.field` reads a field; the projected value may itself
+            // alias `base`'s backing, but `base` is not retained by the
+            // projection — recurse to scan `base`.
+            scan_leaks(&p.node.base.node, prov, captures_param, builtins, out)
+        }
+        MirExpr::InterpolatedStr(parts) => {
+            for p in parts {
+                if let super::super::expr::MirStrPart::Expr(e) = p {
+                    // Stringification reads the value (non-retaining).
+                    scan_leaks(&e.node, prov, captures_param, builtins, out);
                 }
             }
         }
-        _ => {}
+
+        // --- Leaves. A bare `Local` reaches here only when its parent
+        //     scanned it as a non-retaining position (a safe builtin
+        //     receiver / `withDefault` operand / control-flow result / a
+        //     scalar operand) — a retaining parent records its roots via
+        //     `retain` BEFORE recursing. So a `Local` reaching this arm is
+        //     a move-out / read that retains nothing: nothing to add. ---
+        MirExpr::Local(_) | MirExpr::Literal(_) | MirExpr::FnValue(_) => {}
     }
-    visit_children(e, &mut |c| {
-        collect_escaping_slots(c, prov, captures_param, builtins, out)
-    });
+}
+
+/// Scan the args of a builtin call where `target_safe` says arg 0 is the
+/// non-retaining receiver. Arg 0 (if `target_safe`) is scanned for
+/// nested leaks only; every other arg is retaining.
+#[allow(clippy::too_many_arguments)]
+fn scan_builtin_args(
+    c: &Spanned<super::super::expr::MirCall>,
+    target_safe: bool,
+    prov: &HashMap<u32, Spanned<MirExpr>>,
+    captures_param: &HashMap<FnId, HashSet<usize>>,
+    builtins: &[String],
+    retain: &mut dyn FnMut(&Spanned<MirExpr>, &mut HashSet<u32>),
+    out: &mut HashSet<u32>,
+) {
+    for (i, a) in c.node.args.iter().enumerate() {
+        if i == 0 && target_safe {
+            // Receiver: consumed/read, not retained. Scan for nested
+            // leaks (e.g. a `set(set(P,..),..)` chain) but do not record
+            // P here.
+            scan_leaks(&a.node, prov, captures_param, builtins, out);
+        } else {
+            retain(a, out);
+        }
+    }
 }
 
 /// Pin every PARAM that has a still-live alias: a let-bound slot whose
-/// binding RHS aliases the param (its `alias_roots` contains the param
+/// binding RHS aliases the param (its `rename_roots` contains the param
 /// slot) and whose own slot is read somewhere in the body. Such a param
 /// is not uniquely owned — a second binding observes the same backing —
 /// so an in-place mutation would corrupt the alias (the `snap = v; …
@@ -715,9 +970,7 @@ fn collect_live_aliased_params(
         // read-after-mutation. A `Vector.set` / `Map.set` / self-keep
         // `withDefault(set(p,…), p)` is the param's mutated SUCCESSOR
         // (it consumes `p`), so binding the result does NOT keep `p`
-        // problematically live — that is the linear fast path, and
-        // `alias_roots` (which treats the set result as sharing `p`'s
-        // backing, correct for the CAPTURE check) would wrongly pin it.
+        // problematically live — that is the linear fast path.
         let mut roots: HashSet<u32> = HashSet::new();
         rename_roots(&rhs.node, prov, builtins, 0, &mut roots);
         for &r in &roots {
@@ -729,11 +982,42 @@ fn collect_live_aliased_params(
     }
 }
 
+/// Every slot that has a still-live RENAME alias in the body: a let-bound
+/// slot whose binding RHS renames it AND that is read. Used at the
+/// CALL-SITE to reject an owned arg whose slot the caller still observes
+/// through an alias (the live-alias-at-callsite class). Unlike
+/// `collect_live_aliased_params` (which records the PARAM that is
+/// aliased), this records the ROOT slot that an alias still observes —
+/// any slot, param or let-local — so a call-site arg reading that slot
+/// can be rejected.
+fn collect_live_aliased_slots(
+    body: &MirExpr,
+    prov: &HashMap<u32, Spanned<MirExpr>>,
+    builtins: &[String],
+    out: &mut HashSet<u32>,
+) {
+    let mut read: HashSet<u32> = HashSet::new();
+    collect_local_reads(body, &mut read);
+    for (&binding, rhs) in prov {
+        if !read.contains(&binding) {
+            continue;
+        }
+        let mut roots: HashSet<u32> = HashSet::new();
+        rename_roots(&rhs.node, prov, builtins, 0, &mut roots);
+        for &r in &roots {
+            // The binding `r != binding` so the source slot is co-live
+            // with a distinct alias binding that is still read.
+            if r != binding {
+                out.insert(r);
+            }
+        }
+    }
+}
+
 /// Param slots that `e` is a *pure value-copy alias* of — the subset of
 /// `alias_roots` that keeps the source slot CO-LIVE rather than
-/// consuming it. Used only by the live-alias-across-mutation pin
-/// (`collect_live_aliased_params`); the capture / cross-fn escape paths
-/// use the full `alias_roots` semantics.
+/// consuming it. Used only by the live-alias-across-mutation pins; the
+/// capture / cross-fn escape paths use the full `alias_roots` semantics.
 ///
 /// The key difference from `alias_roots`: a `Vector.set` / `Map.set`
 /// result, and the self-keep `withDefault(set(p,…), p)` fusion shape,
@@ -825,8 +1109,8 @@ fn rename_roots(
 /// Recognize the self-keep fusion shape `withDefault(Vector.set|Map.set(
 /// Local(s), …), Local(s))` — the linear in-place mutation idiom whose
 /// two operands both reference the same slot `s`. Mirrors the
-/// recognition in `uniquely_owned`; used by `rename_roots` to treat the
-/// successor as consuming (not aliasing) `s`.
+/// recognition in `uniquely_owned`; used by `scan_leaks` / `rename_roots`
+/// to treat the successor as consuming (not aliasing) `s`.
 fn is_self_keep_set(set_arg: &MirExpr, default_arg: &MirExpr, builtins: &[String]) -> bool {
     if let MirExpr::Call(inner) = set_arg
         && let MirCallee::Builtin(iid) = inner.node.callee
@@ -852,20 +1136,28 @@ fn collect_local_reads(e: &MirExpr, out: &mut HashSet<u32>) {
 }
 
 /// Interprocedural "fn captures param i" summary. `captures_param[f]`
-/// holds the indices of `f`'s params whose value escapes into an
-/// aggregate — directly in `f`, or transitively by being passed to a
-/// callee that captures the corresponding param. Monotone-growing
-/// fixpoint over the visible `Call(Fn)` edges; recursion / cycles are
-/// safe because the set only grows. A param not in the summary is NOT a
-/// proof of no-capture across unseen edges — but this pass already runs
-/// only on whole, single-module programs (every caller visible), and
-/// any genuinely externally-reachable fn (`main` / address-taken) keeps
-/// all params flagged regardless.
+/// holds the indices of `f`'s params that are NOT proven
+/// non-retaining-linear in `f`'s body — i.e. some occurrence escapes
+/// (the body-local leak scan flags the param slot), directly or
+/// transitively by being passed to a callee that captures the
+/// corresponding param. Monotone-growing fixpoint over the visible
+/// `Call(Fn)` / `TailCall` edges; recursion / cycles are safe because
+/// the set only grows.
+///
+/// This is exactly the dual the `scan_leaks` whitelist consumes: a param
+/// NOT in `captures_param[f]` is proven not to retain its arg, so a
+/// caller passing a value at that index does not escape through `f`. A
+/// param not yet in the summary during the fixpoint is treated as
+/// capturing (the seed is empty and grows), which is the conservative
+/// direction. The whole pass already runs only on whole, single-module
+/// programs (every caller visible), and any genuinely
+/// externally-reachable fn (`main` / address-taken) keeps all params
+/// flagged regardless.
 fn compute_capture_summary(
     program: &MirProgram,
     provenance: &HashMap<FnId, HashMap<u32, Spanned<MirExpr>>>,
+    builtins: &[String],
 ) -> HashMap<FnId, HashSet<usize>> {
-    let builtins = &program.builtins;
     // Param-slot → param-index per fn (params occupy the leading slots,
     // but resolve by the declared `local` to be safe).
     let mut param_slot_to_idx: HashMap<FnId, HashMap<u32, usize>> = HashMap::new();
@@ -885,13 +1177,15 @@ fn compute_capture_summary(
         for (id, f) in program.iter() {
             let prov = provenance.get(id).cloned().unwrap_or_default();
             let nparams = f.params.len();
-            // Slots that escape into an aggregate or a (already-known)
-            // capturing callee within this fn body.
-            let mut esc: HashSet<u32> = HashSet::new();
-            collect_escaping_slots(&f.body.node, &prov, &captures, builtins, &mut esc);
+            // Slots that leak (escape a recognized linear use) in this fn
+            // body given the current (monotone-growing) summary, plus
+            // live-alias pins. A param leaking ⇒ it captures its arg.
+            let mut leak: HashSet<u32> = HashSet::new();
+            scan_leaks(&f.body.node, &prov, &captures, builtins, &mut leak);
+            collect_live_aliased_params(&f.body.node, &prov, builtins, nparams, &mut leak);
             let idx_map = &param_slot_to_idx[id];
             let entry = captures.entry(*id).or_default();
-            for &s in &esc {
+            for &s in &leak {
                 if (s as usize) < nparams
                     && let Some(&i) = idx_map.get(&s)
                     && entry.insert(i)

--- a/tests/own_param_graduation.rs
+++ b/tests/own_param_graduation.rs
@@ -1,0 +1,209 @@
+//! Direct graduation assertions for the `own_param` refinement.
+//!
+//! The soundness suite (`own_param_soundness.rs`) proves the pass never
+//! *corrupts* (an aliased param is never un-flagged). This file proves
+//! the dual, precision side: a genuinely linearly-threaded collection
+//! param MUST still graduate (its `aliased_slots` bit cleared) so the
+//! VM #382 / wasm-gc owned-mutate fast path keeps firing — a sound but
+//! over-conservative pass would silently regress `vector_ops` /
+//! `map_build`. Where the soundness suite uses observable values, this
+//! reaches into the lowered MIR and reads the bit directly.
+
+use aver::ir::mir::lower_program;
+use aver::ir::mir::optimize::own_param_refine;
+use aver::ir::mir::program::MirProgram;
+use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
+use aver::source::parse_source;
+
+/// Lower `source` to MIR and run the `own_param` refinement, returning
+/// the refined program.
+fn refine(source: &str) -> MirProgram {
+    let mut items = parse_source(source).unwrap_or_else(|e| panic!("parse: {e}"));
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    let tc = result.typecheck.as_ref().expect("typecheck requested");
+    assert!(tc.errors.is_empty(), "typecheck failed: {:?}", tc.errors);
+    let program = lower_program(&result.resolved_items);
+    own_param_refine(program)
+}
+
+/// Read the `aliased_slots` bit for param `idx` of fn `name`.
+fn param_flagged(program: &MirProgram, name: &str, idx: usize) -> bool {
+    let f = program
+        .iter()
+        .map(|(_, f)| f)
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("fn {name} not found"));
+    let slot = f.params[idx].local.0 as usize;
+    f.aliased_slots.get(slot).copied().unwrap_or(false)
+}
+
+/// The headline fast path: `fillVector` threads its Vector param linearly
+/// through `Vector.set` + the tail call, with no alias binding and no
+/// capture. The refinement MUST clear its `aliased_slots` bit so the
+/// owned-mutate fast path fires. (Soundness side checked in
+/// `own_param_soundness::linearly_threaded_fill_sum_is_correct`.)
+#[test]
+fn fill_vector_param_graduates() {
+    let src = r#"module Fill
+    intent = "linearly-threaded vector fill — the refinement target"
+    depends []
+    effects []
+
+fn fillVector(v: Vector<Int>, n: Int, i: Int) -> Vector<Int>
+    ? "tail-recursive fill: write i*i at position i"
+    match i == n
+        true -> v
+        false -> fillVector(Option.withDefault(Vector.set(v, i, i * i), v), n, i + 1)
+
+fn main() -> Int
+    v = fillVector(Vector.new(5, 0), 5, 0)
+    Option.withDefault(Vector.get(v, 0), 0)
+"#;
+    let program = refine(src);
+    assert!(
+        !param_flagged(&program, "fillVector", 0),
+        "fillVector's Vector param must graduate (bit cleared) — the fast path regressed"
+    );
+}
+
+/// The Map fast path: `buildMap` threads its Map param linearly through
+/// `Map.set` + the tail call. The refinement MUST clear its bit.
+#[test]
+fn build_map_param_graduates() {
+    let src = r#"module MapBuild
+    intent = "linearly-threaded map build — the refinement target"
+    depends []
+    effects []
+
+fn buildMap(n: Int, m: Map<String, Int>) -> Map<String, Int>
+    ? "tail-recursively insert n entries"
+    match n
+        0 -> m
+        _ -> buildMap(n - 1, Map.set(m, String.fromInt(n), n))
+
+fn main() -> Int
+    m = buildMap(5, {})
+    Map.len(m)
+"#;
+    let program = refine(src);
+    assert!(
+        !param_flagged(&program, "buildMap", 1),
+        "buildMap's Map param must graduate (bit cleared) — the fast path regressed"
+    );
+}
+
+/// Precision dual of the escape soundness suite: the aliased params from
+/// the three corruption classes must STAY flagged after the refinement.
+/// (Their observable correctness is covered in `own_param_soundness`;
+/// here we pin the bit so a future change can't silently re-clear it.)
+#[test]
+fn aliased_corruption_class_params_stay_flagged() {
+    // Class 1 — let-rename capture: `cap`'s `v` is captured through an
+    // alias, so it must stay flagged.
+    let class1 = r#"module C1Let
+    intent = "let-rename aliased capture"
+    depends []
+    effects []
+
+record Box
+    inner: Vector<Int>
+
+fn cap(v: Vector<Int>) -> Int
+    ? "w = v aliases v; capture w; own-mutate v"
+    w = v
+    b = Box(inner = w)
+    mutated = Option.withDefault(Vector.set(v, 0, 999), v)
+    Option.withDefault(Vector.get(b.inner, 0), 0 - 1)
+
+fn main() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+"#;
+    let p1 = refine(class1);
+    assert!(
+        param_flagged(&p1, "cap", 0),
+        "class-1 aliased-capture param must stay flagged"
+    );
+
+    // Class 3 — cross-fn capture: `mutateBacking`'s param must stay
+    // flagged because its caller's value escaped into `store`'s capture.
+    let class3 = r#"module C3Vec
+    intent = "cross-fn capture-then-mutate"
+    depends []
+    effects []
+
+record Box
+    items: Vector<Int>
+
+fn store(v: Vector<Int>) -> Box
+    ? "captures v"
+    Box(items = v)
+
+fn mutateBacking(v: Vector<Int>) -> Vector<Int>
+    ? "own-mutate"
+    Option.withDefault(Vector.set(v, 0, 999), v)
+
+fn main() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    b = store(base)
+    m = mutateBacking(base)
+    Option.withDefault(Vector.get(b.items, 0), 0 - 1)
+"#;
+    let p3 = refine(class3);
+    // `store` captures its param — must stay flagged.
+    assert!(
+        param_flagged(&p3, "store", 0),
+        "class-3 capturing-fn param (store) must stay flagged"
+    );
+    // `mutateBacking` mutates a value that escaped in its caller —
+    // must stay flagged.
+    assert!(
+        param_flagged(&p3, "mutateBacking", 0),
+        "class-3 own-mutating param (mutateBacking) must stay flagged"
+    );
+}
+
+/// Per-slot precision: a single fn that CAPTURES one Vector param (`a`)
+/// while threading another (`b`) linearly must keep `a` flagged AND
+/// still graduate `b`. The pass flags slots, not whole fns, so the
+/// linear `b` is not collateral-damaged by `a`'s capture — the fast
+/// path survives alongside the soundness pin.
+#[test]
+fn capturing_one_param_still_graduates_a_linear_sibling() {
+    let src = r#"module Mixed
+    intent = "capture param a, thread param b linearly"
+    depends []
+    effects []
+
+record Box
+    held: Vector<Int>
+
+fn f(a: Vector<Int>, b: Vector<Int>) -> Int
+    ? "capture a into a Box; mutate b in place; read both"
+    box = Box(held = a)
+    b2 = Option.withDefault(Vector.set(b, 0, 999), b)
+    h = Option.withDefault(Vector.get(box.held, 0), 0 - 1)
+    m = Option.withDefault(Vector.get(b2, 0), 0 - 1)
+    h * 1000 + m
+
+fn main() -> Int
+    va = Option.withDefault(Vector.set(Vector.new(2, 0), 0, 7), Vector.new(2, 0))
+    vb = Option.withDefault(Vector.set(Vector.new(2, 0), 0, 3), Vector.new(2, 0))
+    f(va, vb)
+"#;
+    let program = refine(src);
+    assert!(
+        param_flagged(&program, "f", 0),
+        "captured param `a` must stay flagged"
+    );
+    assert!(
+        !param_flagged(&program, "f", 1),
+        "linearly-threaded param `b` must still graduate (per-slot precision)"
+    );
+}

--- a/tests/own_param_graduation.rs
+++ b/tests/own_param_graduation.rs
@@ -207,3 +207,34 @@ fn main() -> Int
         "linearly-threaded param `b` must still graduate (per-slot precision)"
     );
 }
+
+/// Round-3 precision dual: a param stored as the VALUE/ELEMENT arg of a
+/// collection builtin (not the target arg 0) must STAY flagged. The
+/// sound-by-construction scan treats every builtin arg at index >= 1 as
+/// retaining, so `cap`'s `p` — used as the element of `Vector.new(1, p)`
+/// — never graduates. (Observable correctness in
+/// `own_param_soundness::round3_value_into_vector_set_*`.)
+#[test]
+fn value_into_collection_param_stays_flagged() {
+    let src = r#"module ValIntoVecSet
+    intent = "param stored as the element arg of a collection builtin"
+    depends []
+    effects []
+
+fn cap(p: Vector<Int>) -> Int
+    ? "store p as the element of a vector-of-vectors, then own-mutate p"
+    outer = Vector.new(1, p)
+    mutated = Option.withDefault(Vector.set(p, 0, 999), p)
+    inner = Option.withDefault(Vector.get(outer, 0), Vector.new(3, 0 - 1))
+    Option.withDefault(Vector.get(inner, 0), 0 - 1)
+
+fn main() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+"#;
+    let program = refine(src);
+    assert!(
+        param_flagged(&program, "cap", 0),
+        "param stored as a collection element/value arg must stay flagged"
+    );
+}

--- a/tests/own_param_soundness.rs
+++ b/tests/own_param_soundness.rs
@@ -328,3 +328,375 @@ fn main() -> Unit
 "#;
     assert_sound("fill_sum", src, "30");
 }
+
+// ---------------------------------------------------------------------
+// Escape-soundness regression net (the audit's classes 1–3). Each of
+// these CORRUPTS on parent `main` (own_param un-flags an aliased param,
+// the backend mutates it in place) and is FIXED on this branch by the
+// alias-provenance + interprocedural-capture analysis. Each is a
+// revert-discipline candidate: it fails on parent main, passes here.
+// ---------------------------------------------------------------------
+
+/// Class 1 — same-fn aliased capture via a `let`-rename. `w = v` aliases
+/// the param `v`; `w` is captured into a record. The old capture
+/// detection recorded `w`'s slot, not `v`'s, so it un-flagged `v` and the
+/// in-place `Vector.set(v, …)` corrupted the record's retained handle.
+/// Correct = `7` (the captured copy keeps the original); corruption = `999`.
+#[test]
+fn class1_let_rename_capture_vector_not_mutated_in_place() {
+    let src = r#"module C1Let
+    intent = "let-rename aliased capture of a Vector param"
+    depends []
+    effects [Console.print]
+
+record Box
+    inner: Vector<Int>
+
+fn cap(v: Vector<Int>) -> Int
+    ? "w = v aliases v; capture w; then own-mutate v; read the capture"
+    w = v
+    b = Box(inner = w)
+    mutated = Option.withDefault(Vector.set(v, 0, 999), v)
+    Option.withDefault(Vector.get(b.inner, 0), 0 - 1)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class1_let_rename_vec", src, "7");
+}
+
+/// Class 1 — same-fn aliased capture via a `match`-rename. `w = match _ ->
+/// v` aliases `v` through a match arm; same corruption as the `let`-rename
+/// case. Correct = `7`; corruption = `999`.
+#[test]
+fn class1_match_rename_capture_vector_not_mutated_in_place() {
+    let src = r#"module C1Match
+    intent = "match-rename aliased capture of a Vector param"
+    depends []
+    effects [Console.print]
+
+record Box
+    inner: Vector<Int>
+
+fn cap(v: Vector<Int>) -> Int
+    ? "w bound through a match arm aliases v; capture w; own-mutate v"
+    w = match 0
+        _ -> v
+    b = Box(inner = w)
+    mutated = Option.withDefault(Vector.set(v, 0, 999), v)
+    Option.withDefault(Vector.get(b.inner, 0), 0 - 1)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class1_match_rename_vec", src, "7");
+}
+
+/// Class 1 — same-fn aliased capture through a passthrough fn. `idv(v)`
+/// returns its arg, so the value captured into the record aliases `v`
+/// (the RULE-2 passthrough gap). Correct = `7`; corruption = `999`.
+#[test]
+fn class1_passthrough_capture_vector_not_mutated_in_place() {
+    let src = r#"module C1Pass
+    intent = "passthrough-fn aliased capture of a Vector param"
+    depends []
+    effects [Console.print]
+
+record Box
+    inner: Vector<Int>
+
+fn idv(v: Vector<Int>) -> Vector<Int>
+    ? "returns its arg — result aliases backing"
+    v
+
+fn cap(v: Vector<Int>) -> Int
+    ? "capture idv(v) (aliases v); then own-mutate v; read the capture"
+    b = Box(inner = idv(v))
+    mutated = Option.withDefault(Vector.set(v, 0, 999), v)
+    Option.withDefault(Vector.get(b.inner, 0), 0 - 1)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class1_passthrough_vec", src, "7");
+}
+
+/// Class 1 — Map analogue of the `let`-rename aliased capture. Correct =
+/// `7`; corruption = `999`.
+#[test]
+fn class1_let_rename_capture_map_not_mutated_in_place() {
+    let src = r#"module C1MapLet
+    intent = "let-rename aliased capture of a Map param"
+    depends []
+    effects [Console.print]
+
+record MapBox
+    inner: Map<String, Int>
+
+fn cap(m: Map<String, Int>) -> Int
+    ? "w = m aliases m; capture w; then own-mutate m; read the capture"
+    w = m
+    b = MapBox(inner = w)
+    mutated = Map.set(m, "k", 999)
+    Option.withDefault(Map.get(b.inner, "k"), 0 - 1)
+
+fn run() -> Int
+    base = Map.set({}, "k", 7)
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class1_let_rename_map", src, "7");
+}
+
+/// Class 2 — live-alias skip-clone. `snap = v` aliases the param; `v` is
+/// then own-mutated and `snap` is read afterwards. The param was un-flagged
+/// though a live alias still observes the original backing. Correct = `7`;
+/// corruption = `999`.
+#[test]
+fn class2_live_alias_vector_not_mutated_in_place() {
+    let src = r#"module C2Vec
+    intent = "live-alias of a Vector param read after an in-place mutation"
+    depends []
+    effects [Console.print]
+
+fn cap(v: Vector<Int>) -> Int
+    ? "snap aliases v; own-mutate v; read snap — must see the original"
+    snap = v
+    mutated = Option.withDefault(Vector.set(v, 0, 999), v)
+    Option.withDefault(Vector.get(snap, 0), 0 - 1)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class2_live_alias_vec", src, "7");
+}
+
+/// Class 2 — Map analogue of the live-alias skip-clone. Correct = `7`;
+/// corruption = `999`.
+#[test]
+fn class2_live_alias_map_not_mutated_in_place() {
+    let src = r#"module C2Map
+    intent = "live-alias of a Map param read after an in-place mutation"
+    depends []
+    effects [Console.print]
+
+fn cap(m: Map<String, Int>) -> Int
+    ? "snap aliases m; own-mutate m; read snap — must see the original"
+    snap = m
+    mutated = Map.set(m, "k", 999)
+    Option.withDefault(Map.get(snap, "k"), 0 - 1)
+
+fn run() -> Int
+    base = Map.set({}, "k", 7)
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class2_live_alias_map", src, "7");
+}
+
+/// Class 3 — cross-fn capture-then-mutate. `store(base)` captures `base`
+/// into a record; a second fn `mutateBacking(base)` own-mutates the same
+/// value. The old analysis cleared `mutateBacking`'s param (its sole
+/// caller looked owned) without seeing that `base` had escaped into
+/// `store`'s capture. The interprocedural capture summary now marks
+/// `store` as capturing param 0, so `base` escapes in `run` and stays
+/// flagged. Correct = `7`; corruption = `999`.
+#[test]
+fn class3_cross_fn_store_then_mutate_vector_not_mutated_in_place() {
+    let src = r#"module C3Vec
+    intent = "cross-fn: one fn captures the value, another own-mutates it"
+    depends []
+    effects [Console.print]
+
+record Box
+    items: Vector<Int>
+
+fn store(v: Vector<Int>) -> Box
+    ? "captures v into a Box"
+    Box(items = v)
+
+fn mutateBacking(v: Vector<Int>) -> Vector<Int>
+    ? "own-mutate the same value"
+    Option.withDefault(Vector.set(v, 0, 999), v)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    b = store(base)
+    m = mutateBacking(base)
+    Option.withDefault(Vector.get(b.items, 0), 0 - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class3_cross_fn_vec", src, "7");
+}
+
+/// Class 3 — Map analogue of the cross-fn capture-then-mutate. Correct =
+/// `7`; corruption = `999`.
+#[test]
+fn class3_cross_fn_store_then_mutate_map_not_mutated_in_place() {
+    let src = r#"module C3Map
+    intent = "cross-fn capture-then-mutate, Map"
+    depends []
+    effects [Console.print]
+
+record MapBox
+    items: Map<String, Int>
+
+fn store(m: Map<String, Int>) -> MapBox
+    ? "captures m into a MapBox"
+    MapBox(items = m)
+
+fn mutateBacking(m: Map<String, Int>) -> Map<String, Int>
+    ? "own-mutate the same value"
+    Map.set(m, "k", 999)
+
+fn run() -> Int
+    base = Map.set({}, "k", 7)
+    b = store(base)
+    upd = mutateBacking(base)
+    Option.withDefault(Map.get(b.items, "k"), 0 - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class3_cross_fn_map", src, "7");
+}
+
+/// Class 2 variant — the alias is created by wrapping the param in an
+/// `Option.Some(v)` (a constructor capture) and selecting it back out
+/// with `Option.withDefault`. The constructor capture must flag the
+/// param even though the surrounding shape looks like a `withDefault`
+/// select. Correct = `7`; corruption = `999`.
+#[test]
+fn class2_some_wrapped_alias_not_mutated_in_place() {
+    let src = r#"module C2W
+    intent = "alias a Vector param by wrapping it in Option.Some, then mutate"
+    depends []
+    effects [Console.print]
+
+fn cap(v: Vector<Int>) -> Int
+    ? "snap selects v back out of Option.Some(v); own-mutate v; read snap"
+    fb = Vector.new(3, 0)
+    snap = Option.withDefault(Option.Some(v), fb)
+    mutated = Option.withDefault(Vector.set(v, 0, 999), v)
+    Option.withDefault(Vector.get(snap, 0), 0 - 1)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class2_some_wrapped", src, "7");
+}
+
+/// Precision guard at the value level: a fn that CAPTURES one Vector
+/// param (`a`) while threading another (`b`) linearly must keep `a`
+/// uncorrupted AND still mutate `b` in place. `box.held[0]` reads the
+/// original `a` (7), `b2[0]` reads the mutated `b` (999): 7*1000+999 =
+/// 7999. Over-flagging `b` would still give 7999 (correctness), so the
+/// graduation half is pinned structurally in `own_param_graduation`;
+/// this guards the soundness half (a must not be corrupted). A run with
+/// the refinement off must agree.
+#[test]
+fn capture_one_thread_other_value_is_correct() {
+    let src = r#"module Mixed
+    intent = "capture param a, thread param b linearly"
+    depends []
+    effects [Console.print]
+
+record Box
+    held: Vector<Int>
+
+fn f(a: Vector<Int>, b: Vector<Int>) -> Int
+    ? "capture a into a Box; mutate b in place; read both"
+    box = Box(held = a)
+    b2 = Option.withDefault(Vector.set(b, 0, 999), b)
+    h = Option.withDefault(Vector.get(box.held, 0), 0 - 1)
+    m = Option.withDefault(Vector.get(b2, 0), 0 - 1)
+    h * 1000 + m
+
+fn run() -> Int
+    va = Option.withDefault(Vector.set(Vector.new(2, 0), 0, 7), Vector.new(2, 0))
+    vb = Option.withDefault(Vector.set(Vector.new(2, 0), 0, 3), Vector.new(2, 0))
+    f(va, vb)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("mixed_capture_thread", src, "7999");
+}
+
+/// Class 3 — TRANSITIVE cross-fn capture. `store2` doesn't capture
+/// directly; it forwards its param to `store`, which does. The
+/// interprocedural capture-summary fixpoint must propagate "captures
+/// param 0" from `store` to `store2`, so the value passed to `store2`
+/// in `run` escapes and `mutateBacking`'s param stays flagged. This
+/// exercises the summary's transitive propagation that the direct
+/// class-3 case does not. Correct = `7`; corruption = `999`.
+#[test]
+fn class3_transitive_cross_fn_capture_not_mutated_in_place() {
+    let src = r#"module C3T
+    intent = "transitive cross-fn capture through a forwarding fn"
+    depends []
+    effects [Console.print]
+
+record Box
+    items: Vector<Int>
+
+fn store(v: Vector<Int>) -> Box
+    ? "captures v into a Box"
+    Box(items = v)
+
+fn store2(v: Vector<Int>) -> Box
+    ? "forwards v to store — transitively captures param 0"
+    store(v)
+
+fn mutateBacking(v: Vector<Int>) -> Vector<Int>
+    ? "own-mutate the same value"
+    Option.withDefault(Vector.set(v, 0, 999), v)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    b = store2(base)
+    m = mutateBacking(base)
+    Option.withDefault(Vector.get(b.items, 0), 0 - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("class3_transitive", src, "7");
+}

--- a/tests/own_param_soundness.rs
+++ b/tests/own_param_soundness.rs
@@ -19,7 +19,6 @@
 //!   sum, so the optimization can't pass by being a no-op.
 
 use std::fs;
-use std::path::PathBuf;
 use std::process::Command;
 
 /// Run an Aver program via the built `aver` binary, returning trimmed
@@ -216,6 +215,83 @@ fn main() -> Unit
     Console.print(String.fromInt(run()))
 "#;
     assert_sound("record_capture", src, "7");
+}
+
+/// Same-fn capture-then-mutate: a Vector PARAM captured into a record
+/// field AND own-mutated, BOTH inside the SAME fn, on the SAME param. The
+/// capture guard flags the slot, but the fixpoint (which seeds every
+/// RULE-1 Vector/Map param optimistic-`true` and only descends on a
+/// not-owned call-site arg) would re-`true` it — every caller passes a
+/// fresh vector, so nothing pulls it back down — and the apply step would
+/// then CLEAR the captured-slot bit, re-opening the corruption. This is
+/// the gap the earlier `vector_aliased_into_record_field` test missed: it
+/// split the capture and the mutation across two fns, so the mutated
+/// param wasn't itself the captured slot. Correct = `1006`
+/// (snapshot[0]=7, mutated[0]=999); corruption surfaces as `1998`
+/// (the in-place set overwrote the record's snapshot too). The fix seeds
+/// captured PARAM slots `false` in the ownership lattice so the proof can
+/// never un-flag them.
+#[test]
+fn param_captured_and_mutated_in_same_fn_is_not_mutated_in_place() {
+    let src = r#"module SameFnCapture
+    intent = "a Vector param captured into a record AND mutated in the same fn"
+    depends []
+    effects [Console.print]
+
+record Holder
+    snapshot: Vector<Int>
+
+fn captureAndMutate(v: Vector<Int>) -> Int
+    ? "store v in a record, then set position 0 to 999 on v; the snapshot must read the original"
+    h = Holder(snapshot = v)
+    mutated = Option.withDefault(Vector.set(v, 0, 999), v)
+    snap0 = Option.withDefault(Vector.get(h.snapshot, 0), 0 - 1)
+    mut0 = Option.withDefault(Vector.get(mutated, 0), 0 - 1)
+    snap0 + mut0
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    captureAndMutate(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("same_fn_capture", src, "1006");
+}
+
+/// The Map analogue of the same-fn capture-then-mutate: a Map param
+/// captured into a record field AND `Map.set`-mutated in the same fn. The
+/// captured slot must stay flagged so the insert does not corrupt the
+/// record's snapshot. Correct = `107` (snapshot["k"]=7, mutated["k"]=100);
+/// corruption surfaces as `200`.
+#[test]
+fn map_param_captured_and_mutated_in_same_fn_is_not_mutated_in_place() {
+    let src = r#"module SameFnMapCapture
+    intent = "a Map param captured into a record AND mutated in the same fn"
+    depends []
+    effects [Console.print]
+
+record MapHolder
+    snapshot: Map<String, Int>
+
+fn captureAndSet(m: Map<String, Int>) -> Int
+    ? "store m in a record, then Map.set k=100 on m; the snapshot must read the original 7"
+    h = MapHolder(snapshot = m)
+    updated = Map.set(m, "k", 100)
+    snap0 = Option.withDefault(Map.get(h.snapshot, "k"), 0 - 1)
+    new0 = Option.withDefault(Map.get(updated, "k"), 0 - 1)
+    snap0 + new0
+
+fn run() -> Int
+    base = Map.set({}, "k", 7)
+    captureAndSet(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("same_fn_map_capture", src, "107");
 }
 
 /// The headline win: a linearly-threaded vector param the refinement

--- a/tests/own_param_soundness.rs
+++ b/tests/own_param_soundness.rs
@@ -700,3 +700,193 @@ fn main() -> Unit
 "#;
     assert_sound("class3_transitive", src, "7");
 }
+
+// ---------------------------------------------------------------------
+// Round-3 regression net (the third adversarial audit's two new
+// classes). These CORRUPT on parent `own-param-escape-soundness` (the
+// blacklist enumeration missed the escape site) and are FIXED here by
+// the sound-by-construction redesign (default-flag, clear-on-whitelist).
+// Each is a revert-discipline candidate: it fails on parent, passes here.
+// ---------------------------------------------------------------------
+
+/// Round 3, class (a) — value-into-collection via `Vector.set`. The
+/// param `p` is stored as the VALUE/ELEMENT arg (index 2) of a
+/// `Vector.set` building a vector-of-vectors, then own-mutated in place.
+/// The old `alias_roots` followed only `args.first()` (the target) of a
+/// set, so the element `p` was not seen to escape; the old
+/// `collect_escaping_slots` only handled `MirCallee::Fn` args, not
+/// builtin value args. The new whitelist scan treats every builtin arg
+/// at index >= 1 as retaining. Correct = `7` (the stored copy keeps the
+/// original); corruption surfaces as `999`.
+#[test]
+fn round3_value_into_vector_set_is_not_mutated_in_place() {
+    let src = r#"module ValIntoVecSet
+    intent = "param P stored as the value/element arg of Vector.set, then mutated"
+    depends []
+    effects [Console.print]
+
+fn cap(p: Vector<Int>) -> Int
+    ? "store p as the element of an outer vector-of-vectors; own-mutate p; read the stored copy"
+    outer = Vector.new(1, p)
+    mutated = Option.withDefault(Vector.set(p, 0, 999), p)
+    inner = Option.withDefault(Vector.get(outer, 0), Vector.new(3, 0 - 1))
+    Option.withDefault(Vector.get(inner, 0), 0 - 1)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("round3_value_into_vector_set", src, "7");
+}
+
+/// Round 3, class (a) — value-into-collection via `Map.set`. The param
+/// `p` is stored as the VALUE arg (index 2) of a `Map.set`, then
+/// own-mutated. Same missed escape site as the `Vector.set` case, on the
+/// `Map.set` value position. Correct = `7`; corruption surfaces as `999`.
+#[test]
+fn round3_value_into_map_set_is_not_mutated_in_place() {
+    let src = r#"module ValIntoMapSet
+    intent = "param P stored as the value arg of Map.set, then mutated"
+    depends []
+    effects [Console.print]
+
+fn cap(p: Vector<Int>) -> Int
+    ? "store p as a map value; own-mutate p; read the stored copy back"
+    holder = Map.set({}, "key", p)
+    mutated = Option.withDefault(Vector.set(p, 0, 999), p)
+    inner = Option.withDefault(Map.get(holder, "key"), Vector.new(3, 0 - 1))
+    Option.withDefault(Vector.get(inner, 0), 0 - 1)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("round3_value_into_map_set", src, "7");
+}
+
+/// Round 3, class (a) — value-into-collection via a MAP LITERAL. The
+/// param `p` is stored as the VALUE of a `{"k" => p}` literal entry,
+/// then own-mutated. Correct = `7`; corruption surfaces as `999`.
+#[test]
+fn round3_value_into_map_literal_is_not_mutated_in_place() {
+    let src = r#"module ValIntoMapLit
+    intent = "param P stored as a value in a map literal, then mutated"
+    depends []
+    effects [Console.print]
+
+fn cap(p: Vector<Int>) -> Int
+    ? "store p as a map-literal value; own-mutate p; read the stored copy"
+    holder = {"key" => p}
+    mutated = Option.withDefault(Vector.set(p, 0, 999), p)
+    inner = Option.withDefault(Map.get(holder, "key"), Vector.new(3, 0 - 1))
+    Option.withDefault(Vector.get(inner, 0), 0 - 1)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("round3_value_into_map_literal", src, "7");
+}
+
+/// Round 3, class (a) — value-into-collection via the DEFAULT arg of
+/// `Vector.new`. `Vector.new(2, p)` fills both cells with `p` (every
+/// cell shares its backing), then `p` is own-mutated. The old
+/// `uniquely_owned` treated `Vector.new` with a non-literal default as
+/// not-owned but `alias_roots`/the escape scan never flagged `p`'s
+/// occurrence as the default cell. Correct = `7`; corruption = `999`.
+#[test]
+fn round3_value_into_vector_new_default_is_not_mutated_in_place() {
+    let src = r#"module ValIntoVecNew
+    intent = "param P used as the default element of Vector.new, then mutated"
+    depends []
+    effects [Console.print]
+
+fn cap(p: Vector<Int>) -> Int
+    ? "Vector.new(2, p) fills both cells with p; own-mutate p; read a cell"
+    outer = Vector.new(2, p)
+    mutated = Option.withDefault(Vector.set(p, 0, 999), p)
+    inner = Option.withDefault(Vector.get(outer, 1), Vector.new(3, 0 - 1))
+    Option.withDefault(Vector.get(inner, 0), 0 - 1)
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    cap(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("round3_value_into_vector_new", src, "7");
+}
+
+/// Round 3, class (b) — live-alias-at-callsite. An owned let-local
+/// (`base`) is passed to a graduated linear mutator (`mutate`) while a
+/// live alias (`alias = base`) remains in the caller. The old
+/// `uniquely_owned` proved the arg owned by its `last_use` flag but
+/// never checked whether the CALLER still observes the slot through a
+/// live rename alias. `mutate` graduates and mutates `base` in place,
+/// corrupting `alias`. The redesign rejects a call-site arg whose slot
+/// the caller still aliases (`live_aliased`). Correct = `7` (the alias
+/// keeps the original); corruption surfaces as `999`.
+#[test]
+fn round3_live_alias_at_callsite_is_not_mutated_in_place() {
+    let src = r#"module LiveAliasCallsite
+    intent = "owned local passed to a graduated callee while a live alias remains in the caller"
+    depends []
+    effects [Console.print]
+
+fn mutate(w: Vector<Int>) -> Vector<Int>
+    ? "graduated linear mutator: own-mutate w in place and return it"
+    Option.withDefault(Vector.set(w, 0, 999), w)
+
+fn run() -> Int
+    ? "base is owned; alias aliases base; pass base to mutate, then read alias"
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    alias = base
+    m = mutate(base)
+    Option.withDefault(Vector.get(alias, 0), 0 - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("round3_live_alias_at_callsite", src, "7");
+}
+
+/// Round 3, class (b) — Map analogue of live-alias-at-callsite. Correct
+/// = `7`; corruption surfaces as `999`.
+#[test]
+fn round3_live_alias_at_callsite_map_is_not_mutated_in_place() {
+    let src = r#"module LiveAliasCallsiteMap
+    intent = "owned map passed to a graduated callee while a live alias remains"
+    depends []
+    effects [Console.print]
+
+fn mutate(w: Map<String, Int>) -> Map<String, Int>
+    ? "graduated linear mutator: Map.set w in place and return it"
+    Map.set(w, "k", 999)
+
+fn run() -> Int
+    base = Map.set({}, "k", 7)
+    alias = base
+    m = mutate(base)
+    Option.withDefault(Map.get(alias, "k"), 0 - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    assert_sound("round3_live_alias_at_callsite_map", src, "7");
+}

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -328,6 +328,145 @@ fn fast_plain_stdout_parity_with_vm() {
     );
 }
 
+// ─── own_param ownership: build+run rust vs VM + emitted-shape guard ─────
+
+/// Build+run an inline Aver program through the Rust backend and return
+/// trimmed stdout. Shares the fast-tier compile + cargo-build path.
+fn build_run_rust_inline(name: &str, source: &str) -> Result<String, String> {
+    let ws = temp_dir(name);
+    let src = ws.join(format!("{name}.av"));
+    fs::write(&src, source).expect("write source");
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| {
+        compile_rust(&src, &project, name, None, &[])?;
+        let bin = cargo_build(&project, name)?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("failed to run compiled binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!("binary exited non-zero:\n{}", format_output(&out)));
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    })();
+    let _ = fs::remove_dir_all(&ws);
+    result
+}
+
+/// Run an inline Aver program on the VM and return trimmed stdout.
+fn run_vm_inline(name: &str, source: &str) -> Result<String, String> {
+    let ws = temp_dir(&format!("{name}_vm"));
+    let src = ws.join(format!("{name}.av"));
+    fs::write(&src, source).expect("write source");
+    let out = run_vm(&src, None);
+    let _ = fs::remove_dir_all(&ws);
+    out
+}
+
+/// The #383 corruption class on the RUST backend: a Vector PARAM captured
+/// into a record field AND own-mutated, both in the SAME fn on the SAME
+/// param. `own_param`'s capture guard must keep the slot flagged so the
+/// Rust emit keeps the `.clone()` at the mutation site (refcount-2
+/// `Rc::make_mut` deep-copies → the record's snapshot is protected).
+/// Build+run the emitted Rust and assert it equals the VM — a wrongly
+/// skipped clone would diverge (1998 vs the correct 1006).
+#[test]
+fn rust_param_captured_and_mutated_in_same_fn_matches_vm() {
+    let src = r#"module SameFnCapture
+    intent = "Vector param captured into a record AND mutated in the same fn (#383 class)"
+    depends []
+    effects [Console.print]
+
+record Holder
+    snapshot: Vector<Int>
+
+fn captureAndMutate(v: Vector<Int>) -> Int
+    ? "store v in a record, then set position 0 to 999 on v; snapshot must read the original"
+    h = Holder(snapshot = v)
+    mutated = Option.withDefault(Vector.set(v, 0, 999), v)
+    snap0 = Option.withDefault(Vector.get(h.snapshot, 0), 0 - 1)
+    mut0 = Option.withDefault(Vector.get(mutated, 0), 0 - 1)
+    snap0 + mut0
+
+fn run() -> Int
+    base = Option.withDefault(Vector.set(Vector.new(3, 0), 0, 7), Vector.new(3, 0))
+    captureAndMutate(base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    let vm = run_vm_inline("samecap", src).expect("vm run");
+    let rust = build_run_rust_inline("samecap", src).expect("rust build+run");
+    assert_eq!(vm, "1006", "VM must compute the immutable-model value");
+    assert_eq!(
+        rust, vm,
+        "Rust diverged from VM — a captured param's clone was wrongly skipped"
+    );
+}
+
+/// The own_param perf win on the RUST backend, verified end-to-end: a
+/// linearly-threaded Vector param the pass proves uniquely owned must (a)
+/// build+run to the same result as the VM, and (b) emit the OWNED-by-value
+/// in-place shape — `let __vec = v;` (a MOVE) NOT `let __vec = v.clone();`
+/// — so the `Rc::make_mut` runs on a refcount-1 backing (native O(n)),
+/// the whole point of wiring own_param into rust. A regression that drops
+/// the graduation would re-introduce the `.clone()` (O(n²) COW) and trip
+/// the emitted-shape assert even if the result stays correct.
+#[test]
+fn rust_owned_vector_param_emits_in_place_move_and_matches_vm() {
+    let src = r#"module Fill
+    intent = "linearly-threaded vector fill+sum — the own_param rust target"
+    depends []
+    effects [Console.print]
+
+fn fillVector(v: Vector<Int>, n: Int, i: Int) -> Vector<Int>
+    ? "tail-recursive fill: write i*i at position i"
+    match i == n
+        true -> v
+        false -> fillVector(Option.withDefault(Vector.set(v, i, i * i), v), n, i + 1)
+
+fn sumVector(v: Vector<Int>, n: Int, i: Int, acc: Int) -> Int
+    ? "tail-recursive sum across positions 0..n"
+    match i == n
+        true -> acc
+        false -> sumVector(v, n, i + 1, acc + Option.withDefault(Vector.get(v, i), 0))
+
+fn run() -> Int
+    v = fillVector(Vector.new(5, 0), 5, 0)
+    sumVector(v, 5, 0, 0)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(run()))
+"#;
+    // (a) build+run vs VM
+    let vm = run_vm_inline("fillmove", src).expect("vm run");
+    let rust = build_run_rust_inline("fillmove", src).expect("rust build+run");
+    assert_eq!(vm, "30", "VM fill+sum value");
+    assert_eq!(rust, vm, "Rust fill+sum diverged from VM");
+
+    // (b) emitted-shape guard: the fusion in `fillVector` must MOVE the
+    // owned param (no `.clone()`).
+    let ws = temp_dir("fillmove_emit");
+    let f = ws.join("fillmove.av");
+    fs::write(&f, src).expect("write");
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("project dir");
+    compile_rust(&f, &project, "fillmove", None, &[]).expect("compile rust");
+    let emitted = fs::read_to_string(project.join("src/aver_generated/entry/mod.rs"))
+        .expect("read generated entry module");
+    let _ = fs::remove_dir_all(&ws);
+    assert!(
+        emitted.contains("let __vec = v;"),
+        "expected owned-by-value MOVE (`let __vec = v;`) in fillVector, got:\n{emitted}"
+    );
+    assert!(
+        !emitted.contains("let __vec = v.clone();"),
+        "fillVector still clones the owned vector param (O(n²) COW regressed):\n{emitted}"
+    );
+}
+
 // ─── Mode (b): deny-policy ──────────────────────────────────────────────
 
 /// A Disk-write program. `__PATH__` is substituted with the real


### PR DESCRIPTION
## What

Makes the `own_param` MIR pass **sound-by-construction** and wires it into the **Rust codegen** path (owned-by-value collections). Net effect: the in-place / clone-skip fast path for uniquely-owned `Vector`/`Map` params now holds across VM, wasm-gc, and Rust **without** the latent corruption the prior blacklist had.

Three commits (each a coherent step):
- `48b7cfd3` — wire `own_param` into Rust codegen (owned-by-value collections) + fix non-Unit/non-Result `main` return + an own_param capture-clearing soundness fix.
- `f0478f21` — harden the escape analysis: alias-provenance (`alias_roots`) + interprocedural capture summary.
- `772e2d98` — **redesign**: flip from a blacklist-of-escape-sites (unsound by omission) to a positive whitelist — default every collection param *flagged*, clear the bit only on a top-down proof that **every** occurrence (and its alias closure) is a recognized non-retaining-linear use.

## Soundness

The blacklist approach was unsound by omission — each prior audit found a new missed escape site (5 corruption classes total). The whitelist cannot miss an escape by construction.

A **third independent adversarial convergence re-audit** (5 attack angles — value/element/key positions, interprocedural capture summary, alias-closure + live-alias-at-callsite, whitelisted builtins + `Option.withDefault` transparency + self-keep fusion, nested collections + tail/return move-out; ~90 adversarial programs run `AVER_NO_OWN_PARAM` ON-vs-OFF on the VM oracle) found **zero** corruptions attributable to `own_param`. The two ON-vs-OFF divergences it surfaced were verified as a **pre-existing baseline** VM hole (alias.rs + last_use + VM owned-mask), independent of this pass — see #410. `own_param` is structurally incapable of causing that baseline bug: it only ever *sets* `aliased_slots` or *clears* it on `Vector`/`Map` **param** slots.

## Perf (preserved, zero give-back)

- VM `vector_ops`: ~14.7 ms → **~0.48 ms** (~30×).
- VM `map_build`: ~54 ms → **~0.39 ms** (~110×).
- Rust: owned-by-value collections (skip the defensive `Rc` clone when the param is proven uniquely owned).
- Graduation unchanged: 6 / 36 prone params graduate — **identical to the prior blacklist** — and `fillVector` / `buildMap` still graduate. The whitelist admits exactly the same linear params while closing the holes.

## Tests / gates

- `tests/own_param_soundness.rs` (25, toggle-confirmed ON==OFF==correct, revert-tested: the genuine corruption cases FAIL on the parent), `tests/own_param_graduation.rs` (graduation-bit precision), `tests/rust_codegen_differential.rs` (build+run vs VM).
- Full `cargo test` green; `cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings` green; `cargo fmt --check` green (run locally).

## Discovered follow-up (not caused by this PR)

#410 — latent VM corruption when a `Map.set`/`Vector.set` runs on a value that has a live rename alias (the alias *source* is mutated in place). Reproduces with `own_param` disabled; `--self-host` is correct.

Refs #252.
