### PR TITLE
ir/alias: sound-by-construction owned-eligibility for collection locals (#410)

### DIFF
--- a/src/ir/alias.rs
+++ b/src/ir/alias.rs
@@ -9,36 +9,43 @@
 //! mutation would be observed there too. Wasm-gc may use the same
 //! flag to skip clone-on-write when a slot is provably non-aliased.
 //!
-//! ## Sources of arena sharing in Aver
+//! ## When is a collection slot owned-eligible (NOT flagged)?
 //!
-//! 1. **Vector / Map params.** A caller may keep its own ref to the
-//!    same arena entry, so every `Vector<T>` / `Map<K, V>` parameter
-//!    starts out aliased.
-//! 2. **`Vector.get` / `Map.get` results.** The returned handle shares
-//!    the source vector's arena entry at that index — mutating it
-//!    rewrites the source. Pattern variants behind common shapes
-//!    (`Option.withDefault(Vector.get(_, i), …)`, `match` arms over
-//!    `Vector.get`) all produce the same alias.
-//! 3. **`Vector.new(n, compound)`.** Every cell of the produced outer
-//!    vec holds the same `compound` ref, so two rows pulled out of
-//!    the same outer alias each other transitively.
-//! 4. **Transitive copy `b = a` where `a` is already aliased.**
+//! Sound-by-construction whitelist. A `Vector<T>` / `Map<K, V>` local stays
+//! unflagged (eligible for the owned in-place fast path) ONLY when both hold:
+//!
+//! - **Fresh source (destination half, `rhs_is_fresh_collection`).** Its
+//!   binding RHS is a *provably fresh* collection — a `MapLiteral`, an
+//!   allocating builtin (`Vector.new` of a non-compound element, `Vector.set`,
+//!   `Vector.fromList`, `Map.set`, `Map.remove`), or a self-keep rebuild
+//!   `withDefault(set(L,..), L)`. Any other collection RHS — field / element
+//!   extraction (`rec.held`, a tuple item), a `Vector.get` / `Map.get` result,
+//!   a rename `b = a`, a user-fn result — may alias an existing arena entry,
+//!   so the destination is flagged.
+//! - **No escape (source half, `flag_escaping_collection_locals`).** Its
+//!   handle is not RETAINED by any other binding — not stored into an
+//!   aggregate (record / tuple / list / map value), not passed as a builtin
+//!   value-arg, not passed to a user fn that might return it, not renamed. The
+//!   receiver (arg 0) of a `Vector` / `Map` builtin and the self-keep fallback
+//!   are consuming moves, not escapes.
+//!
+//! Vector / Map PARAMS are always flagged here (a caller may hold the same
+//! entry); the MIR `own_param` pass later clears that bit interprocedurally
+//! when every call site passes a uniquely-owned argument.
 //!
 //! ## Conservative
 //!
-//! False positives only cost the VM's owned fast path for the flagged
-//! slot — the slow path (clone backing items, push fresh arena
-//! entry) is always sound. False negatives are unsound: they put
-//! shared bindings on the fast path and silently mutate the user's
-//! data. So we err on the side of flagging — every fn-call result
-//! whose tree contains a `Vector.get` / `Map.get` / `Vector.new(_,
-//! compound)` anywhere is treated as a possible alias source.
+//! False positives only cost the owned fast path for the flagged slot — the
+//! slow path (clone backing, fresh arena entry) is always sound. False
+//! negatives are unsound: a shared binding on the fast path silently mutates
+//! the user's data (issue #410). So the default is FLAGGED, and a slot clears
+//! only on positive proof of fresh-AND-non-escaping.
 //!
 //! Runs after `last_use`. Stamps `FnResolution.aliased_slots` in place.
 
 use std::sync::Arc;
 
-use crate::ast::{Expr, FnBody, FnDef, Stmt, StrPart, TopLevel};
+use crate::ast::{Expr, FnBody, FnDef, Spanned, Stmt, StrPart, TopLevel, Type};
 
 pub fn annotate_program_alias_slots(items: &mut [TopLevel]) {
     for item in items {
@@ -64,9 +71,10 @@ fn annotate_fn(fd: &mut FnDef) {
         }
     }
 
-    // (2)/(3)/(4) walk body bindings forward. Two passes propagate
-    // transitive aliases (`b = a` where `a` is rebind earlier in the
-    // same statement list).
+    // Body bindings, two forward passes (transitive aliases propagate: a
+    // later `b = a` sees `a` flagged in an earlier pass). For each binding of
+    // a Vector / Map local, ownership is decided SOUND-BY-CONSTRUCTION by two
+    // complementary halves.
     let body = fd.body.clone();
     let FnBody::Block(stmts) = body.as_ref();
     for _ in 0..2 {
@@ -75,7 +83,27 @@ fn annotate_fn(fd: &mut FnDef) {
                 let Some(&slot) = res.local_slots.get(name) else {
                     continue;
                 };
-                if expr_is_alias_source(&expr.node, &aliased)
+                // Source half: flag every bare collection local whose handle
+                // ESCAPES into this binding's value — a rename (`b = a`), a
+                // match arm tail, an aggregate member (record / tuple / list /
+                // map value), a builtin value-arg, or an arg to a user fn that
+                // may return it. Without it, `a = {..}; b = a; Map.set(a, ..)`
+                // would own-mutate `a` in place and silently rewrite `b`. The
+                // receiver (arg 0) of a Vector/Map builtin and the self-keep
+                // `withDefault(set(L,..), L)` rebind are consuming moves, NOT
+                // escapes, so they stay eligible for the owned fast path.
+                flag_escaping_collection_locals(&expr.node, &res.local_slot_types, &mut aliased);
+                // Destination half: a collection-typed binding is owned-
+                // eligible ONLY if its RHS is a PROVABLY-FRESH collection
+                // (literal / allocating builtin / self-keep rebuild). Any other
+                // collection RHS — field/element extraction, a `get`, a rename,
+                // a user-fn result — yields a handle that may alias an existing
+                // arena entry, so flag the destination. This whitelist replaces
+                // the former enumerate-the-alias-sources blacklist, which was
+                // unsound by omission (it missed aggregate-field extraction —
+                // `x = rec.held; Map.set(x, ..)` clobbered `rec`'s field).
+                if slot_is_collection(slot, &res.local_slot_types)
+                    && !rhs_is_fresh_collection(expr)
                     && let Some(s) = aliased.get_mut(slot as usize)
                 {
                     *s = true;
@@ -100,91 +128,188 @@ fn param_type_is_alias_prone(ty: &str) -> bool {
     trimmed.starts_with("Vector<") || trimmed.starts_with("Map<")
 }
 
-fn expr_is_alias_source(expr: &Expr, aliased: &[bool]) -> bool {
-    if let Expr::Resolved { slot, .. } = expr
-        && aliased.get(*slot as usize).copied().unwrap_or(false)
-    {
-        return true;
+/// A binding RHS that yields a PROVABLY-FRESH `Vector` / `Map` — a `MapLiteral`,
+/// an allocating builtin (`Vector.new` of a non-compound element, `Vector.set`,
+/// `Vector.fromList`, `Map.set`, `Map.remove`), a self-keep rebuild
+/// `withDefault(set(L,..), L)`, or a `withDefault` whose branches are each
+/// fresh — produces a uniquely-owned arena entry, so the destination local is
+/// safe for the owned in-place fast path. Every other collection-typed RHS may
+/// alias an existing entry (field/element extraction, `get`, a rename, a
+/// user-fn result), so the destination must be flagged. Conservative:
+/// anything unrecognized is NOT fresh (flagging only costs the fast path).
+fn rhs_is_fresh_collection(expr: &Spanned<Expr>) -> bool {
+    match &expr.node {
+        Expr::MapLiteral(_) => true,
+        // Fresh only if EVERY arm is fresh — one aliasing arm taints the value.
+        Expr::Match { arms, .. } => arms.iter().all(|a| rhs_is_fresh_collection(&a.body)),
+        Expr::FnCall(callee, args) => {
+            if is_option_with_default(&callee.node) && args.len() == 2 {
+                return self_keep_slot(&args[0].node, &args[1].node).is_some()
+                    || (rhs_is_fresh_collection(&args[0]) && rhs_is_fresh_collection(&args[1]));
+            }
+            is_fresh_collection_builtin(&callee.node, args)
+        }
+        _ => false,
     }
-    contains_alias_source_call(expr)
 }
 
-fn contains_alias_source_call(expr: &Expr) -> bool {
+/// Vector / Map builtins that ALLOCATE a fresh outer collection. `Vector.new`
+/// is fresh only when its element is non-compound — a compound element is
+/// shared by every cell (the old rule 3 aliasing). `get` is excluded: it
+/// returns an element that aliases the source.
+fn is_fresh_collection_builtin(callee: &Expr, args: &[Spanned<Expr>]) -> bool {
+    let Expr::Attr(parent, member) = callee else {
+        return false;
+    };
+    let Expr::Ident(ns) = &parent.node else {
+        return false;
+    };
+    match (ns.as_str(), member.as_str()) {
+        ("Vector", "set") | ("Vector", "fromList") | ("Map", "set") | ("Map", "remove") => true,
+        ("Vector", "new") => args
+            .get(1)
+            .and_then(|a| a.ty())
+            .is_some_and(|t| !type_is_compound(&t.display())),
+        _ => false,
+    }
+}
+
+fn slot_is_collection(slot: u16, slot_types: &[Type]) -> bool {
+    slot_types
+        .get(slot as usize)
+        .is_some_and(|t| matches!(t, Type::Vector(_) | Type::Map(_, _)))
+}
+
+/// `Vector` / `Map` builtin call (`Vector.set`, `Map.get`, …) whose arg 0 is
+/// the collection receiver — consumed / read in place, never retained into the
+/// result (a `get` result aliases an *element*, handled by rule 2 on the
+/// destination, not by the receiver here).
+fn is_vector_map_builtin(callee: &Expr) -> bool {
+    matches!(callee, Expr::Attr(parent, _)
+        if matches!(&parent.node, Expr::Ident(p) if p == "Vector" || p == "Map"))
+}
+
+/// `Option.withDefault(Vector.set(L, ..) | Map.set(L, ..), L)` — the self-keep
+/// rebuild fusion. The result IS `L` (mutated, or unchanged on the fallback),
+/// so this is a consuming rebind of `L`, not an escape. Returns the kept slot.
+fn self_keep_slot(op1: &Expr, op2: &Expr) -> Option<u16> {
+    let Expr::Resolved { slot: kept, .. } = op2 else {
+        return None;
+    };
+    let Expr::FnCall(callee, set_args) = op1 else {
+        return None;
+    };
+    let Expr::Attr(parent, member) = &callee.node else {
+        return None;
+    };
+    let Expr::Ident(ns) = &parent.node else {
+        return None;
+    };
+    if !((ns == "Vector" || ns == "Map") && member == "set") {
+        return None;
+    }
+    match set_args.first().map(|a| &a.node) {
+        Some(Expr::Resolved { slot, .. }) if slot == kept => Some(*kept),
+        _ => None,
+    }
+}
+
+fn is_option_with_default(callee: &Expr) -> bool {
+    matches!(callee, Expr::Attr(parent, member)
+        if member == "withDefault"
+            && matches!(&parent.node, Expr::Ident(p) if p == "Option"))
+}
+
+/// Flag (as aliased) every bare collection local whose handle is RETAINED by
+/// `expr` (the value of a binding) — see the call site for the rationale and
+/// the non-escape exceptions (builtin receiver arg 0, self-keep rebuild).
+fn flag_escaping_collection_locals(expr: &Expr, slot_types: &[Type], aliased: &mut [bool]) {
     match expr {
-        Expr::FnCall(callee, args) => {
-            if let Expr::Attr(parent, member) = &callee.node
-                && let Expr::Ident(p) = &parent.node
+        // A bare collection local in an escaping position: its handle flows
+        // into the binding's value, so it can no longer be owned-mutated.
+        Expr::Resolved { slot, .. } => {
+            if slot_is_collection(*slot, slot_types)
+                && let Some(s) = aliased.get_mut(*slot as usize)
             {
-                if (p == "Vector" || p == "Map") && member == "get" {
-                    return true;
-                }
-                if p == "Vector"
-                    && member == "new"
-                    && args.len() == 2
-                    && let Some(t) = args[1].ty()
-                    && type_is_compound(&t.display())
-                {
-                    return true;
-                }
-                // Module-qualified call into a USER module (not a built-in
-                // namespace): the callee may return an alias of a
-                // Vector/Map argument (`fn id(v) = v`), which neither RULE
-                // 1 nor the get/new cases can see. Conservatively treat the
-                // result as a possible alias source so a binding fed by it
-                // never takes the owned in-place path. Built-in namespaces
-                // (`Vector.set`, `Map.set`, `String.fromInt`, …) return
-                // fresh or derived values — handled above or fall through.
-                if !crate::ir::is_builtin_namespace(p) {
-                    return true;
-                }
-            } else if matches!(&callee.node, Expr::Ident(_)) {
-                // Bare-ident callee — a user fn (or fn value); may return an
-                // alias of an argument. Same conservative treatment. (The
-                // precise alternative is a returns-fresh interprocedural
-                // analysis; deferred — over-flagging only costs the owned
-                // fast path on a user-fn-derived binding, never soundness.)
-                return true;
+                *s = true;
             }
-            if contains_alias_source_call(&callee.node) {
-                return true;
-            }
-            args.iter().any(|a| contains_alias_source_call(&a.node))
         }
-        Expr::Attr(inner, _) => contains_alias_source_call(&inner.node),
+        Expr::FnCall(callee, args) => {
+            // Self-keep rebuild `withDefault(set(L,..), L)`: L is consumed, not
+            // aliased. Recurse only into the set's value-args (which may carry
+            // a *different* escaping collection), skipping the receiver and the
+            // kept fallback.
+            if is_option_with_default(&callee.node)
+                && args.len() == 2
+                && self_keep_slot(&args[0].node, &args[1].node).is_some()
+            {
+                if let Expr::FnCall(_, set_args) = &args[0].node {
+                    for a in set_args.iter().skip(1) {
+                        flag_escaping_collection_locals(&a.node, slot_types, aliased);
+                    }
+                }
+                return;
+            }
+            let recv_skip = is_vector_map_builtin(&callee.node);
+            for (i, a) in args.iter().enumerate() {
+                // Receiver (arg 0 of a Vector/Map builtin): a bare local here is
+                // consumed in place, not retained — skip it. A compound arg 0
+                // still recurses (its own nested receivers self-handle).
+                if recv_skip && i == 0 && matches!(&a.node, Expr::Resolved { .. }) {
+                    continue;
+                }
+                flag_escaping_collection_locals(&a.node, slot_types, aliased);
+            }
+            flag_escaping_collection_locals(&callee.node, slot_types, aliased);
+        }
+        Expr::Attr(inner, _) | Expr::Neg(inner) | Expr::ErrorProp(inner) => {
+            flag_escaping_collection_locals(&inner.node, slot_types, aliased);
+        }
         Expr::BinOp(_, lhs, rhs) => {
-            contains_alias_source_call(&lhs.node) || contains_alias_source_call(&rhs.node)
+            flag_escaping_collection_locals(&lhs.node, slot_types, aliased);
+            flag_escaping_collection_locals(&rhs.node, slot_types, aliased);
         }
-        Expr::Neg(inner) => contains_alias_source_call(&inner.node),
-        Expr::Match { subject, arms } => {
-            contains_alias_source_call(&subject.node)
-                || arms
-                    .iter()
-                    .any(|a| contains_alias_source_call(&a.body.node))
+        // The scrutinee is read/consumed; each arm tail becomes the value.
+        Expr::Match { subject: _, arms } => {
+            for a in arms {
+                flag_escaping_collection_locals(&a.body.node, slot_types, aliased);
+            }
         }
-        Expr::Constructor(_, payload) => payload
-            .as_ref()
-            .is_some_and(|p| contains_alias_source_call(&p.node)),
-        Expr::ErrorProp(inner) => contains_alias_source_call(&inner.node),
+        Expr::Constructor(_, payload) => {
+            if let Some(p) = payload {
+                flag_escaping_collection_locals(&p.node, slot_types, aliased);
+            }
+        }
         Expr::Tuple(items) | Expr::List(items) | Expr::IndependentProduct(items, _) => {
-            items.iter().any(|i| contains_alias_source_call(&i.node))
+            for i in items {
+                flag_escaping_collection_locals(&i.node, slot_types, aliased);
+            }
         }
-        Expr::MapLiteral(pairs) => pairs.iter().any(|(k, v)| {
-            contains_alias_source_call(&k.node) || contains_alias_source_call(&v.node)
-        }),
-        Expr::RecordCreate { fields, .. } => fields
-            .iter()
-            .any(|(_, e)| contains_alias_source_call(&e.node)),
+        Expr::MapLiteral(pairs) => {
+            for (k, v) in pairs {
+                flag_escaping_collection_locals(&k.node, slot_types, aliased);
+                flag_escaping_collection_locals(&v.node, slot_types, aliased);
+            }
+        }
+        Expr::RecordCreate { fields, .. } => {
+            for (_, e) in fields {
+                flag_escaping_collection_locals(&e.node, slot_types, aliased);
+            }
+        }
         Expr::RecordUpdate { base, updates, .. } => {
-            contains_alias_source_call(&base.node)
-                || updates
-                    .iter()
-                    .any(|(_, e)| contains_alias_source_call(&e.node))
+            flag_escaping_collection_locals(&base.node, slot_types, aliased);
+            for (_, e) in updates {
+                flag_escaping_collection_locals(&e.node, slot_types, aliased);
+            }
         }
-        Expr::InterpolatedStr(parts) => parts.iter().any(|p| match p {
-            StrPart::Parsed(e) => contains_alias_source_call(&e.node),
-            StrPart::Literal(_) => false,
-        }),
-        Expr::Literal(_) | Expr::Ident(_) | Expr::Resolved { .. } | Expr::TailCall(_) => false,
+        Expr::InterpolatedStr(parts) => {
+            for p in parts {
+                if let StrPart::Parsed(e) = p {
+                    flag_escaping_collection_locals(&e.node, slot_types, aliased);
+                }
+            }
+        }
+        Expr::Literal(_) | Expr::Ident(_) | Expr::TailCall(_) => {}
     }
 }
 

--- a/tests/alias_soundness.rs
+++ b/tests/alias_soundness.rs
@@ -1,0 +1,239 @@
+//! Soundness regression net for the alias-slot annotation pass
+//! (`ir::alias`), which decides when a `Vector` / `Map` local is safe for
+//! the VM's owned in-place fast path (`VECTOR_SET_OR_KEEP` /
+//! `compute_builtin_owned_mask`).
+//!
+//! Issue #410: the pass flagged the *destination* of an alias but not the
+//! *source*. When a collection local's handle is retained by another live
+//! binding — a rename `b = a`, a match arm tail, an aggregate member, a
+//! builtin value-arg, or an arg to a user fn that returns it — the source
+//! must NOT take the owned path, or the in-place mutation silently rewrites
+//! the other binding. Every shape below corrupted on the VM (both with and
+//! without `own_param`, since these are plain `main` locals, not params)
+//! before the fix; the self-hosted interpreter (immutable by construction)
+//! was always correct and is the oracle here.
+//!
+//! Each test fails on the pre-fix `ir::alias` (VM yields the mutated value);
+//! the trailing `rebuild` test pins that the receiver / self-keep fast path
+//! is preserved, so the fix can't pass by flagging everything.
+
+use std::fs;
+use std::process::Command;
+
+#[derive(Clone, Copy)]
+enum Mode {
+    /// VM, `own_param` on (default).
+    Vm,
+    /// VM, `own_param` off — exercises `ir::alias` flags without the param
+    /// refinement that incidentally masks some source-aliasing bugs.
+    VmNoOwnParam,
+    /// Self-hosted interpreter — immutable by construction, the oracle.
+    SelfHost,
+}
+
+fn run(name: &str, source: &str, mode: Mode) -> String {
+    let dir = std::env::temp_dir().join(format!("aver_alias_{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let file = dir.join(format!("{name}.av"));
+    fs::write(&file, source).expect("write source");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_aver"));
+    cmd.arg("run");
+    if matches!(mode, Mode::SelfHost) {
+        cmd.arg("--self-host");
+    }
+    cmd.arg(&file);
+    if matches!(mode, Mode::VmNoOwnParam) {
+        cmd.env("AVER_NO_OWN_PARAM", "1");
+    }
+    let out = cmd.output().expect("spawn aver run");
+    assert!(
+        out.status.success(),
+        "`aver run {}` failed: {}",
+        file.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = fs::remove_dir_all(&dir);
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// The VM (owned fast path, `own_param` on AND off) must agree with the
+/// self-hosted interpreter (immutable model) and the hand-computed value.
+/// The off run matters: `own_param` masks some source-aliasing corruptions
+/// (e.g. the user-fn passthrough), so the on run alone wouldn't catch them.
+fn assert_immutable(name: &str, source: &str, expected: &str) {
+    let host = run(name, source, Mode::SelfHost);
+    assert_eq!(
+        host, expected,
+        "{name}: self-host (immutable oracle) must produce the model value"
+    );
+    for mode in [Mode::Vm, Mode::VmNoOwnParam] {
+        let vm = run(name, source, mode);
+        assert_eq!(
+            vm, expected,
+            "{name}: VM diverged from the immutable model — an aliased source \
+             was own-mutated in place ({vm} != {expected})"
+        );
+    }
+}
+
+#[test]
+fn rename_source_is_not_mutated_in_place() {
+    assert_immutable(
+        "rename",
+        r#"fn main() -> Unit
+  ! [Console.print]
+  base = {1 => 7}
+  snap = base
+  arg = Map.set(base, 1, 500)
+  Console.print("{Option.withDefault(Map.get(snap, 1), 0 - 1)}")
+"#,
+        "7",
+    );
+}
+
+#[test]
+fn user_fn_passthrough_source_is_not_mutated_in_place() {
+    assert_immutable(
+        "userfn",
+        r#"fn idMap(m: Map<Int, Int>) -> Map<Int, Int>
+  ? "passthrough returns its arg"
+  m
+
+fn main() -> Unit
+  ! [Console.print]
+  base = {1 => 7}
+  snap = idMap(base)
+  arg = Map.set(base, 1, 500)
+  Console.print("{Option.withDefault(Map.get(snap, 1), 0 - 1)}")
+"#,
+        "7",
+    );
+}
+
+#[test]
+fn match_arm_passthrough_source_is_not_mutated_in_place() {
+    assert_immutable(
+        "matcharm",
+        r#"fn main() -> Unit
+  ! [Console.print]
+  base = {1 => 7}
+  snap = match true
+    true -> base
+    false -> base
+  arg = Map.set(base, 1, 500)
+  Console.print("{Option.withDefault(Map.get(snap, 1), 0 - 1)}")
+"#,
+        "7",
+    );
+}
+
+#[test]
+fn list_capture_source_is_not_mutated_in_place() {
+    assert_immutable(
+        "listcap",
+        r#"fn main() -> Unit
+  ! [Console.print]
+  base = {1 => 7}
+  held = [base]
+  arg = Map.set(base, 1, 500)
+  snap = match held
+    [] -> {0 => 0}
+    [h, ..t] -> h
+  Console.print("{Option.withDefault(Map.get(snap, 1), 0 - 1)}")
+"#,
+        "7",
+    );
+}
+
+#[test]
+fn vector_rename_source_is_not_mutated_in_place() {
+    assert_immutable(
+        "vecrename",
+        r#"fn main() -> Unit
+  ! [Console.print]
+  base = Vector.new(2, 7)
+  snap = base
+  arg = Option.withDefault(Vector.set(base, 0, 500), base)
+  Console.print("{Option.withDefault(Vector.get(snap, 0), 0 - 1)}")
+"#,
+        "7",
+    );
+}
+
+#[test]
+fn map_value_capture_source_is_not_mutated_in_place() {
+    assert_immutable(
+        "mapvalcap",
+        r#"fn main() -> Unit
+  ! [Console.print]
+  base = {1 => 7}
+  holder = {0 => base}
+  arg = Map.set(base, 1, 500)
+  snap = Option.withDefault(Map.get(holder, 0), {9 => 9})
+  Console.print("{Option.withDefault(Map.get(snap, 1), 0 - 1)}")
+"#,
+        "7",
+    );
+}
+
+// --- value-OUT-of-aggregate (the mirror direction, found by the adversarial
+// audit): a whole collection EXTRACTED from an aggregate into a local aliases
+// the aggregate's arena entry, so own-mutating the local clobbers the
+// aggregate. Closed by the fresh-producer whitelist (extraction is not fresh).
+
+#[test]
+fn record_field_extraction_is_not_mutated_in_place() {
+    assert_immutable(
+        "fieldextract",
+        r#"record Box
+  held: Map<Int, Int>
+
+fn main() -> Unit
+  ! [Console.print]
+  inner = {8 => 110}
+  b = Box(held = inner)
+  extracted = b.held
+  arg = Map.set(extracted, 8, 999)
+  Console.print("{Option.withDefault(Map.get(b.held, 8), 0 - 1)}")
+"#,
+        "110",
+    );
+}
+
+#[test]
+fn map_value_extraction_is_not_mutated_in_place() {
+    assert_immutable(
+        "mapvalextract",
+        r#"fn main() -> Unit
+  ! [Console.print]
+  inner = {8 => 110}
+  holder = {0 => inner}
+  extracted = Option.withDefault(Map.get(holder, 0), {9 => 9})
+  arg = Map.set(extracted, 8, 999)
+  reread = Option.withDefault(Map.get(holder, 0), {9 => 9})
+  v = Option.withDefault(Map.get(reread, 8), 0 - 1)
+  Console.print("{v}")
+"#,
+        "110",
+    );
+}
+
+/// Non-vacuity: the receiver / self-keep rebuild idiom must stay correct
+/// (and eligible for the owned path) — the fix must not flag everything.
+#[test]
+fn self_keep_rebuild_is_preserved() {
+    assert_immutable(
+        "rebuild",
+        r#"fn main() -> Unit
+  ! [Console.print]
+  v = Vector.new(3, 0)
+  v1 = Option.withDefault(Vector.set(v, 0, 10), v)
+  v2 = Option.withDefault(Vector.set(v1, 1, 20), v1)
+  v3 = Option.withDefault(Vector.set(v2, 2, 30), v2)
+  Console.print("{Option.withDefault(Vector.get(v3, 1), 0 - 1)}")
+"#,
+        "20",
+    );
+}


### PR DESCRIPTION
Closes #410.

## What

`ir::alias` decided when a `Vector`/`Map` value is safe for the VM's owned in-place fast path (`VECTOR_SET_OR_KEEP` / `compute_builtin_owned_mask`). It used a **blacklist** — enumerate the alias-*sources* and flag the binding *destination*. That was unsound by omission: it missed (a) the escaping *source* (`a = {..}; b = a; Map.set(a,..)` own-mutated `a` in place and rewrote `b`) and (b) the *field-extraction* direction (`x = rec.held; Map.set(x,..)` clobbered the record's field).

This replaces it with a **sound-by-construction whitelist**. A `Vector`/`Map` local is owned-eligible (unflagged) only when **both** hold:
- **Fresh source** (`rhs_is_fresh_collection`) — the binding RHS is a provably-fresh collection: a `MapLiteral`, an allocating builtin (`Vector.new` of a non-compound element, `Vector.set`, `Vector.fromList`, `Map.set`, `Map.remove`), or the self-keep rebuild `withDefault(set(L,..), L)`. Any other collection RHS (field/element extraction, `get`, a rename, a user-fn result) may alias an existing entry → flag.
- **No escape** (`flag_escaping_collection_locals`) — the handle is not retained by another binding (aggregate member, builtin value-arg, user-fn arg, rename, match arm). The builtin receiver arg-0 and the self-keep fallback are consuming moves, not escapes.

Default is FLAGGED; a slot clears only on positive proof of fresh-AND-non-escape. The whitelist subsumes the old rules 2/3/4 and closes the whole aliasing class for non-param locals. Vector/Map **params** stay flagged here as before — `own_param` clears them interprocedurally at MIR.

## Why it's safe / perf-neutral

The builtin receiver and self-keep `withDefault(Vector.set(v,..), v)` rebuild stay on the fast path, so the imperative rebuild idiom is preserved. `own_param` graduation is unchanged (params are a separate path).

## Verification

- New `tests/alias_soundness.rs` (9): rename, match-arm passthrough, user-fn passthrough, list capture, map-value capture, **record-field extraction**, **map-value extraction**, vector rename, self-keep rebuild (non-vacuity). Each asserts VM (own_param on **and** off) == self-host immutable oracle == hand-computed value; 5+ fail on the pre-fix blacklist (revert-disciplined).
- `own_param_soundness` (25) + `own_param_graduation` (5) unchanged and green.
- **Adversarial VM-vs-self-host convergence audit**: 4 angles (passthrough depth, nested aggregates, the two non-escape exceptions, mixed/compound flows), 52 programs, **zero divergences**, recommendation ship. The same audit's mixed-flows angle found the field-extraction hole on the interim source-only fix; it is clean here.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --exclude aver-lang -D warnings`, full `cargo test` + `--features wasm` green locally.

Found during the third own_param convergence re-audit (the toggle oracle is not clean for this source-aliasing shape; `--self-host` is).
