### PR TITLE
scc: unify the two Tarjan SCC implementations into one generic core

### DIFF
--- a/src/analysis/shape.rs
+++ b/src/analysis/shape.rs
@@ -410,77 +410,12 @@ pub fn compute_sccs(fns: &[&ResolvedFnDef], facts_by_id: &HashMap<FnId, &Facts>)
             graph.insert(fd.fn_id, edges);
         }
     }
-    let mut index = 0u32;
-    let mut stack: Vec<FnId> = Vec::new();
-    let mut on_stack: HashSet<FnId> = HashSet::new();
-    let mut indices: HashMap<FnId, u32> = HashMap::new();
-    let mut lowlinks: HashMap<FnId, u32> = HashMap::new();
-    let mut multi_scc: HashSet<FnId> = HashSet::new();
-
-    #[allow(clippy::too_many_arguments)]
-    fn strongconnect(
-        v: FnId,
-        graph: &HashMap<FnId, Vec<FnId>>,
-        index: &mut u32,
-        stack: &mut Vec<FnId>,
-        on_stack: &mut HashSet<FnId>,
-        indices: &mut HashMap<FnId, u32>,
-        lowlinks: &mut HashMap<FnId, u32>,
-        multi_scc: &mut HashSet<FnId>,
-    ) {
-        indices.insert(v, *index);
-        lowlinks.insert(v, *index);
-        *index += 1;
-        stack.push(v);
-        on_stack.insert(v);
-        if let Some(neighbors) = graph.get(&v).cloned() {
-            for w in neighbors {
-                if !indices.contains_key(&w) {
-                    strongconnect(
-                        w, graph, index, stack, on_stack, indices, lowlinks, multi_scc,
-                    );
-                    let lv = *lowlinks.get(&v).unwrap();
-                    let lw = *lowlinks.get(&w).unwrap();
-                    lowlinks.insert(v, lv.min(lw));
-                } else if on_stack.contains(&w) {
-                    let lv = *lowlinks.get(&v).unwrap();
-                    let iw = *indices.get(&w).unwrap();
-                    lowlinks.insert(v, lv.min(iw));
-                }
-            }
-        }
-        if lowlinks.get(&v) == indices.get(&v) {
-            let mut scc: Vec<FnId> = Vec::new();
-            loop {
-                let w = stack.pop().unwrap();
-                on_stack.remove(&w);
-                scc.push(w);
-                if w == v {
-                    break;
-                }
-            }
-            if scc.len() > 1 {
-                multi_scc.extend(scc);
-            }
-        }
-    }
-
+    // Mutual-recursion set: members of a multi-element SCC. Self-edges were
+    // excluded when building `graph` above, so a self-recursive fn is a
+    // 1-element component and is intentionally NOT reported here. The Tarjan
+    // core is shared with `call_graph` via `crate::scc`.
     let nodes: Vec<FnId> = graph.keys().copied().collect();
-    for v in nodes {
-        if !indices.contains_key(&v) {
-            strongconnect(
-                v,
-                &graph,
-                &mut index,
-                &mut stack,
-                &mut on_stack,
-                &mut indices,
-                &mut lowlinks,
-                &mut multi_scc,
-            );
-        }
-    }
-    multi_scc
+    crate::scc::mutually_recursive(&nodes, &graph)
 }
 
 // ─── Program-level shape (stage 4 of #232) ───────────────────────────────────

--- a/src/call_graph/scc.rs
+++ b/src/call_graph/scc.rs
@@ -4,69 +4,10 @@ pub(super) fn tarjan_sccs(
     nodes: &[String],
     graph: &HashMap<String, Vec<String>>,
 ) -> Vec<Vec<String>> {
-    struct TarjanAllState {
-        index: usize,
-        indices: HashMap<String, usize>,
-        lowlink: HashMap<String, usize>,
-        stack: Vec<String>,
-        on_stack: HashSet<String>,
-        components: Vec<Vec<String>>,
-    }
-
-    fn strong_connect(v: String, graph: &HashMap<String, Vec<String>>, st: &mut TarjanAllState) {
-        st.indices.insert(v.clone(), st.index);
-        st.lowlink.insert(v.clone(), st.index);
-        st.index += 1;
-        st.stack.push(v.clone());
-        st.on_stack.insert(v.clone());
-
-        if let Some(neighbors) = graph.get(&v) {
-            for w in neighbors {
-                if !st.indices.contains_key(w) {
-                    strong_connect(w.clone(), graph, st);
-                    let low_v = st.lowlink[&v];
-                    let low_w = st.lowlink[w];
-                    st.lowlink.insert(v.clone(), low_v.min(low_w));
-                } else if st.on_stack.contains(w) {
-                    let low_v = st.lowlink[&v];
-                    let idx_w = st.indices[w];
-                    st.lowlink.insert(v.clone(), low_v.min(idx_w));
-                }
-            }
-        }
-
-        if st.lowlink[&v] == st.indices[&v] {
-            let mut comp = Vec::new();
-            while let Some(w) = st.stack.pop() {
-                st.on_stack.remove(&w);
-                let done = w == v;
-                comp.push(w);
-                if done {
-                    break;
-                }
-            }
-            comp.sort();
-            st.components.push(comp);
-        }
-    }
-
-    let mut sorted_nodes = nodes.to_vec();
-    sorted_nodes.sort();
-    let mut st = TarjanAllState {
-        index: 0,
-        indices: HashMap::new(),
-        lowlink: HashMap::new(),
-        stack: Vec::new(),
-        on_stack: HashSet::new(),
-        components: Vec::new(),
-    };
-    for node in sorted_nodes {
-        if !st.indices.contains_key(&node) {
-            strong_connect(node, graph, &mut st);
-        }
-    }
-    st.components.sort_by(|a, b| a[0].cmp(&b[0]));
-    st.components
+    // String-keyed call-graph SCCs (fn names) — the generic core lives in
+    // `crate::scc`, shared with `analysis::shape`'s `FnId`-keyed recursion
+    // classification.
+    crate::scc::tarjan_sccs(nodes, graph)
 }
 
 pub(super) fn topo_components(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod resolver;
 pub mod runtime;
 #[cfg(feature = "runtime")]
 pub mod runtime_bench_cases;
+pub mod scc;
 #[cfg(feature = "runtime")]
 pub mod services;
 pub mod source;

--- a/src/scc.rs
+++ b/src/scc.rs
@@ -1,0 +1,103 @@
+//! Generic strongly-connected-components (Tarjan).
+//!
+//! One algorithm, two callers: `call_graph::scc` (string-keyed fn names, for
+//! TCO grouping + topo order) and `analysis::shape::compute_sccs` (`FnId`-keyed,
+//! for recursion classification feeding the proof path) both wrap this. Before
+//! unification each maintained its own copy of the `strong_connect` DFS.
+//!
+//! Deterministic: vertices are sorted, each component is sorted, and the
+//! components are ordered by their least member, so two runs over the same
+//! input agree. A vertex with no self-edge is its own 1-element component;
+//! mutual recursion shows up as a component with `len() > 1`.
+
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+
+/// Tarjan's SCC partition of `graph` over the given `nodes`. Out-edges to
+/// vertices absent from `graph` are treated as having no further edges.
+pub fn tarjan_sccs<K>(nodes: &[K], graph: &HashMap<K, Vec<K>>) -> Vec<Vec<K>>
+where
+    K: Clone + Eq + Hash + Ord,
+{
+    struct State<K> {
+        index: usize,
+        indices: HashMap<K, usize>,
+        lowlink: HashMap<K, usize>,
+        stack: Vec<K>,
+        on_stack: HashSet<K>,
+        components: Vec<Vec<K>>,
+    }
+
+    fn strong_connect<K>(v: K, graph: &HashMap<K, Vec<K>>, st: &mut State<K>)
+    where
+        K: Clone + Eq + Hash + Ord,
+    {
+        st.indices.insert(v.clone(), st.index);
+        st.lowlink.insert(v.clone(), st.index);
+        st.index += 1;
+        st.stack.push(v.clone());
+        st.on_stack.insert(v.clone());
+
+        if let Some(neighbors) = graph.get(&v) {
+            for w in neighbors {
+                if !st.indices.contains_key(w) {
+                    strong_connect(w.clone(), graph, st);
+                    let low_v = st.lowlink[&v];
+                    let low_w = st.lowlink[w];
+                    st.lowlink.insert(v.clone(), low_v.min(low_w));
+                } else if st.on_stack.contains(w) {
+                    let low_v = st.lowlink[&v];
+                    let idx_w = st.indices[w];
+                    st.lowlink.insert(v.clone(), low_v.min(idx_w));
+                }
+            }
+        }
+
+        if st.lowlink[&v] == st.indices[&v] {
+            let mut comp = Vec::new();
+            while let Some(w) = st.stack.pop() {
+                st.on_stack.remove(&w);
+                let done = w == v;
+                comp.push(w);
+                if done {
+                    break;
+                }
+            }
+            comp.sort();
+            st.components.push(comp);
+        }
+    }
+
+    let mut sorted_nodes = nodes.to_vec();
+    sorted_nodes.sort();
+    let mut st = State {
+        index: 0,
+        indices: HashMap::new(),
+        lowlink: HashMap::new(),
+        stack: Vec::new(),
+        on_stack: HashSet::new(),
+        components: Vec::new(),
+    };
+    for node in sorted_nodes {
+        if !st.indices.contains_key(&node) {
+            strong_connect(node, graph, &mut st);
+        }
+    }
+    st.components.sort_by(|a, b| a[0].cmp(&b[0]));
+    st.components
+}
+
+/// The set of vertices that participate in mutual recursion — i.e. live in a
+/// strongly-connected component of size > 1. (Self-recursion via a self-edge
+/// is intentionally NOT captured here; callers that exclude self-edges from
+/// `graph` get exactly the mutual-recursion set.)
+pub fn mutually_recursive<K>(nodes: &[K], graph: &HashMap<K, Vec<K>>) -> HashSet<K>
+where
+    K: Clone + Eq + Hash + Ord,
+{
+    tarjan_sccs(nodes, graph)
+        .into_iter()
+        .filter(|c| c.len() > 1)
+        .flatten()
+        .collect()
+}


### PR DESCRIPTION
## What

`call_graph::scc` (string-keyed fn names → TCO grouping + topo order) and `analysis::shape::compute_sccs` (`FnId`-keyed → recursion classification that feeds the proof path) each carried their own copy of Tarjan's `strong_connect` DFS. This extracts the algorithm into a generic `crate::scc::tarjan_sccs<K>` + a `mutually_recursive<K>` helper; both callers are now thin wrappers.

## Why

Surfaced by the ProofIR-substrate reality-check (the maintainer's "does ProofIR belong under MIR?" question). The verdict: **no** — proof reasons about source-faithful pre-optimization shape, and the optimized MIR every runtime backend consumes erases exactly that structure (`algebraic` folds `x+0→x` = the literal `SpecEquivalenceSimpNormalized` condition; `inline`/`dead_code` erase the unfold targets; `bool_match→IfThenElse` erases match arms). The one genuine duplication the audit found was *not* on the proof-vs-MIR axis — it was these **two Tarjan implementations**. This PR collapses them; it does not touch the HIR-fed ProofIR design.

## Behavior-preserving

The generic reproduces `call_graph`'s deterministic ordering (sorted nodes, sorted components, components ordered by least member). `shape` keeps its self-edge exclusion + multi-element-SCC filter at the call site, so its mutual-recursion `HashSet<FnId>` is identical. Net −20 lines, one algorithm to maintain.

## Verified

`cargo test` (full, incl. `call_graph` SCC/TCO tests, recursion, proof_spec, shape), `clippy --workspace -D warnings`, `fmt --check` all green.
