### PR TITLE
codegen/lean,cli: fix false-green in Lean proof --check + honest list-induction emit

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -172,19 +172,25 @@ fn emit_list_induction(
     let simp_list = simp_defs.into_iter().collect::<Vec<_>>().join(", ");
     let target_lean = &intro_names[target_idx];
 
-    // `try simp[_all]` has the same closing power as bare `simp[_all]` (it IS
-    // simp when simp succeeds) but never throws, so any goal it can't discharge
-    // survives the induction and is admitted by the trailing `all_goals sorry`.
-    // Net: a law simp can prove closes (no sorry); anything else (rle/json
-    // roundtrips) degrades to the same `sorry` it emitted before — never a
-    // hard lake-build error. Closed arms leave 0 goals, so `all_goals sorry`
-    // is a no-op there (no spurious sorry).
+    // Each arm closes fully or admits `sorry` — and crucially BUILDS either
+    // way. `induction .. with | arm => tac` requires each arm's `tac` to close
+    // its goal; a leftover goal is an `unsolved goals` ERROR at the arm (a hard
+    // lake-build failure), NOT something a trailing `all_goals sorry` can mop
+    // up (that tactic is unreachable past a failing arm). So gate each arm on
+    // `first | (simp[_all] [defs]; done) | sorry`: the `; done` turns a
+    // didn't-close (or no-progress) `simp` into a throw that `first` catches
+    // and admits via `sorry`. A law simp can prove closes (no sorry); anything
+    // else (rle/json roundtrips, the fuel-wrapped quicksort SCC) degrades to an
+    // honest `sorry` that lake still builds — never a silent unsolved-goals
+    // error.
     let proof_lines = vec![
         format!("  intro {}", intro_names.join(" ")),
         format!("  induction {} with", target_lean),
-        format!("  | nil => try simp [{}]", simp_list),
-        format!("  | cons head tail ih => try simp_all [{}]", simp_list),
-        "  all_goals sorry".to_string(),
+        format!("  | nil => first | (simp [{}]; done) | sorry", simp_list),
+        format!(
+            "  | cons head tail ih => first | (simp_all [{}]; done) | sorry",
+            simp_list
+        ),
     ];
 
     Some(AutoProof {

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5044,7 +5044,19 @@ fn run_proof_check(
         }
     };
 
-    let passed = count <= budget;
+    // Lean: the build itself must SUCCEED, not just stay within the sorry
+    // budget. `count_lean_sorries` only sees `declaration uses 'sorry'`
+    // warnings (which are non-fatal — lake exits 0); it is blind to hard
+    // errors like `unsolved goals`, which fail the build (lake exit 1) while
+    // emitting zero sorry-warnings. Gating on lake's exit status closes that
+    // false-green (a law whose tactic leaves an open goal is a build failure,
+    // not a 0-sorry pass). Dafny is unchanged: `dafny verify` exits non-zero
+    // on ANY verification error, so its pass/fail is driven by the parsed
+    // error count against the error budget, not the exit status.
+    let passed = match backend {
+        super::cli::ProofBackend::Dafny => count <= budget,
+        super::cli::ProofBackend::Lean => output.status.success() && count <= budget,
+    };
 
     if check_json {
         let mut obj = serde_json::Map::new();

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -63,6 +63,14 @@ fn assert_proof_builds_with_sorry_budget(
         .arg(&output_dir)
         .arg("--check")
         .arg("--check-json")
+        // Budget = the expected count, so `passed` means "lake build SUCCEEDED
+        // and stayed within this count". Asserting `passed` below (with the
+        // count asserted equal) certifies the build actually succeeded — not
+        // just that the sorry-warning count matched. Guards the false-green
+        // where a tactic leaves unsolved goals (lake exit 1, zero sorry
+        // warnings) yet a count-only check would pass.
+        .arg("--sorry-budget")
+        .arg(expected_sorries.to_string())
         .output()
         .expect("expected `aver proof --check --check-json` to run");
 
@@ -98,6 +106,23 @@ fn assert_proof_builds_with_sorry_budget(
         example_path,
         expected_sorries,
         actual,
+        format_output(&run)
+    );
+
+    // Build-success guard (the false-green fix): with --sorry-budget set to the
+    // expected count and the count asserted equal above, `passed:false` here
+    // means `lake build` itself FAILED (e.g. a tactic left unsolved goals —
+    // lake exit 1 with zero `sorry` warnings, which the count-only check is
+    // blind to). The generated proof must actually build, not merely match a
+    // sorry count.
+    let passed = summary["passed"].as_bool().unwrap_or(false);
+    assert!(
+        passed,
+        "{}: generated Lean proof does NOT build (lake reported failure within \
+         the sorry budget {}). A count match alone is not enough — the build \
+         must succeed.\n{}",
+        example_path,
+        expected_sorries,
         format_output(&run)
     );
 
@@ -286,11 +311,14 @@ fn proof_export_builds_result_chain_when_lake_is_available() {
 
 #[test]
 fn proof_export_builds_rle_when_lake_is_available() {
-    // The encode/decode roundtrip laws are list-given. #409's Lean
-    // list-induction (`induction xs with | nil | cons`) closes one; the other
-    // roundtrip is beyond a single `simp_all` and degrades to one `sorry` via
-    // the `all_goals sorry` tail (was 2 before #409).
-    assert_proof_builds_with_sorry_budget("examples/data/rle.av", "aver-proof-rle", 1);
+    // The encode/decode roundtrip laws are list-given, so #409 attempts Lean
+    // list-induction — but `encode` threads an accumulator (`encodeLoop`) so a
+    // plain `induction xs` IH does not align; both roundtrips fall to an honest
+    // `sorry` (per-arm `first | (simp_all; done) | sorry`, which BUILDS). The
+    // earlier #409 revision claimed 1 here, a false green — the tactic left
+    // unsolved goals that `lake build` rejects but the sorry-count metric was
+    // blind to (fixed in commands.rs to gate on lake's exit status).
+    assert_proof_builds_with_sorry_budget("examples/data/rle.av", "aver-proof-rle", 2);
 }
 
 #[test]
@@ -305,12 +333,17 @@ fn proof_dafny_verifies_rle_when_dafny_is_available() {
 
 #[test]
 fn proof_export_builds_quicksort_when_lake_is_available() {
-    // #409: the three list-given laws (`sort.resultOrdered` /
-    // `sort.lengthPreserved` / `sort.idempotent`) now close universally under
-    // the Lean list-induction strategy (`induction xs`; `simp_all` over the
-    // unfolded sort/partition defs discharges each), so the universal proofs
-    // are no longer sorries. (Was 3 before #409.)
-    assert_proof_builds_with_sorry_budget("examples/data/quicksort.av", "aver-proof-quicksort", 0);
+    // The three list-given laws (`sort.resultOrdered` / `sort.lengthPreserved`
+    // / `sort.idempotent`) are attempted via #409 Lean list-induction, but
+    // `sort` is a fuel-wrapped partition recursion that `simp_all` cannot
+    // reduce, so each falls to an honest `sorry` that BUILDS (per-arm
+    // `first | (simp_all; done) | sorry`). An earlier #409 revision reported 0
+    // here — a FALSE GREEN: the tactic left unsolved goals that `lake build`
+    // rejects (exit 1), which the `declaration uses 'sorry'` count metric was
+    // blind to. Fixed: commands.rs gates pass on lake's exit status, so this
+    // budget is now the build-verified count. (Native universal closure for the
+    // partition SCC is the #125 native-decreases epic, not reachable here.)
+    assert_proof_builds_with_sorry_budget("examples/data/quicksort.av", "aver-proof-quicksort", 3);
 }
 
 #[test]


### PR DESCRIPTION
Fix-forward on #415 (which shipped a false green). Refs #409.

## The bug

The Lean `aver proof --check` path computed `passed` purely from the `declaration uses 'sorry'` warning count and **ignored lake's exit status** (`commands.rs:5047`). So a Lean build that FAILED with `unsolved goals` (lake exit 1, **zero** sorry-warnings) was reported as `{"sorries":0,"passed":true}`.

#415's list-induction emit was `induction xs with | nil => try simp [..] | cons => try simp_all [..]` + a trailing `all_goals sorry`. In Lean 4 an `induction ... with` arm-tactic must close its goal; a non-closing `try simp` leaves an `unsolved goals` error **at the arm**, and the trailing `all_goals sorry` is unreachable past it. So quicksort and rle **did not build** — but the count-only metric reported `sorries:0, passed:true`, and `proof_spec` + CI (both via `--check-json`) were blind to it. The #415 ratchets quicksort 3→0 and rle 2→1 were **false greens**.

Confirmed: `aver proof --check-json` quicksort → `{sorries:0,passed:true}` while a raw `lake build` on the identical files → 6 `unsolved goals` errors, exit 1.

## Fixes

1. **`commands.rs`** — Lean `passed` now requires `output.status.success()` (the build must succeed), not just `count <= budget`. Dafny is unchanged (`dafny verify` exits non-zero on any error, so its pass is error-budget-driven).
2. **`induction.rs`** — emit each arm as `first | (simp[_all] [defs]; done) | sorry`. The `; done` turns a didn't-close `simp` into a throw that `first` catches and admits via `sorry`, so a law `simp` can't prove degrades to an **honest `sorry` that builds**, never an unsolved-goals error.
3. **`proof_spec.rs`** — correct budgets to build-verified counts (**quicksort 0→3, rle 1→2**), and add a **build-success guard** (`--sorry-budget=expected` + assert `passed`) so a future non-building proof is caught even when its sorry count happens to match.

## Honest net of #409

The real wins are the **length-preserving** laws (`len_law`, `list_length_fold` — close genuinely, 0 sorry, build). The quicksort (ordering/idempotent/length over fuel-wrapped partition recursion) and rle (accumulator-threaded `encode`) list-given laws **do not close** — `simp` can't discharge them — so they build with honest sorries (3 and 2). Universal closure for the partition SCC is the #125 native-decreases epic.

`proof_spec` 67/67 (now with the build-success guard, no false greens remain across the corpus), `cargo test`, `clippy --workspace -D warnings`, `fmt --check` green.
