### PR TITLE
cli: count Lean sorry warnings regardless of quote glyph

### DIFF
--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5177,9 +5177,18 @@ fn count_dafny_axioms(dir: &str) -> usize {
 /// Count Lean's `declaration uses 'sorry'` warnings in build output.
 /// Lake emits one such warning per `sorry` in the residual program;
 /// counting them matches the budget the proof_spec gating tests use.
+///
+/// The quote glyph around `sorry` is toolchain-dependent: Lean ≤4.15
+/// (the pinned toolchain) prints straight quotes `'sorry'`, but ≥4.17
+/// switched to backticks `` `sorry` ``. A `sorry` is only a non-fatal
+/// warning, so `lake` exits 0 and the exit-status gate does NOT catch
+/// it — the count is the sole signal. Matching the literal `'sorry'`
+/// alone would silently return 0 on a backtick-era toolchain, turning
+/// a proof full of `sorry`s into a false-green. So match `declaration
+/// uses` + `sorry` regardless of the surrounding glyph.
 fn count_lean_sorries(s: &str) -> usize {
     s.lines()
-        .filter(|l| l.contains("declaration uses 'sorry'"))
+        .filter(|l| l.contains("declaration uses") && l.contains("sorry"))
         .count()
 }
 
@@ -5479,6 +5488,24 @@ mod tests {
             .map(|d| d.as_nanos())
             .unwrap_or(0);
         std::env::temp_dir().join(format!("aver_commands_{tag}_{nanos}"))
+    }
+
+    #[test]
+    fn count_lean_sorries_matches_both_quote_glyphs() {
+        // Lean ≤4.15 prints straight quotes, ≥4.17 prints backticks.
+        // `sorry` is a non-fatal warning (lake exits 0), so the count is
+        // the only signal — it must survive the glyph switch or every
+        // `sorry` silently passes as a false-green.
+        let straight = "warning: Foo.lean:1:8: declaration uses 'sorry'";
+        let backtick = "warning: Foo.lean:1:8: declaration uses `sorry`";
+        assert_eq!(super::count_lean_sorries(straight), 1, "straight quotes");
+        assert_eq!(super::count_lean_sorries(backtick), 1, "backticks");
+        assert_eq!(
+            super::count_lean_sorries(&format!("{straight}\n{backtick}\nunrelated line")),
+            2,
+            "both glyphs counted, unrelated lines ignored"
+        );
+        assert_eq!(super::count_lean_sorries("Build completed successfully"), 0);
     }
 
     fn empty_codegen_ctx() -> CodegenContext {


### PR DESCRIPTION
## Problem

`count_lean_sorries` matched the literal `declaration uses 'sorry'` (straight quotes). Lean **≥4.17** prints that warning with **backticks** instead, which the literal match misses → the count silently drops to **0**.

`sorry` is a non-fatal warning (lake exits 0), so the exit-status gate added in the false-green fix (#416/#417) does **not** catch it — the count is the only signal. A proof full of `sorry`s would therefore false-green on any backtick-era toolchain; today only the hardcoded `v4.15` toolchain pin keeps the literal match correct (a routine pin bump would silently re-open the hole on every Lean proof).

Surfaced by the adversarial soundness audit as a latent landmine.

## Fix

Match `declaration uses` + `sorry` regardless of the surrounding glyph. Strict superset of the old behavior on the pinned v4.15 path, so existing counts are unchanged.

## Test

`count_lean_sorries_matches_both_quote_glyphs` — straight quotes, backticks, mixed, and a clean build all count correctly.

Verified: unit test passes, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)