### PR TITLE
cli,test: verify the real Dafny entry under proof --check (multi-module false-green)

### DIFF
--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4933,7 +4933,24 @@ pub(super) fn cmd_proof(
     }
 
     if check {
-        run_proof_check(output_dir, backend, error_budget, sorry_budget, check_json);
+        // For Dafny, hand the harness the real entry module filename so it
+        // verifies the file that carries the verify-law lemmas (not an
+        // arbitrary dependency module).
+        let dafny_entry = match backend {
+            super::cli::ProofBackend::Dafny => Some(format!(
+                "{}.dfy",
+                aver::codegen::common::entry_basename(&ctx)
+            )),
+            super::cli::ProofBackend::Lean => None,
+        };
+        run_proof_check(
+            output_dir,
+            backend,
+            error_budget,
+            sorry_budget,
+            check_json,
+            dafny_entry,
+        );
     }
 }
 
@@ -4955,6 +4972,7 @@ fn run_proof_check(
     error_budget: Option<usize>,
     sorry_budget: Option<usize>,
     check_json: bool,
+    dafny_entry: Option<String>,
 ) {
     use std::process::Command;
 
@@ -4963,19 +4981,29 @@ fn run_proof_check(
             ("lake", vec!["build".to_string()], "Lean / lake", "lean")
         }
         super::cli::ProofBackend::Dafny => {
-            let entry = match std::fs::read_dir(output_dir) {
-                Ok(rd) => rd
-                    .filter_map(|e| e.ok())
-                    .map(|e| e.file_name().to_string_lossy().into_owned())
-                    .find(|n| n.ends_with(".dfy") && n != "common.dfy"),
-                Err(e) => {
-                    eprintln!(
-                        "{}",
-                        format!("--check: read_dir({}) failed: {}", output_dir, e).red()
-                    );
-                    std::process::exit(2);
-                }
-            };
+            // Verify the ACTUAL entry module, not whatever `read_dir`
+            // happens to yield first. The entry file holds the verify-law
+            // lemmas; in a multi-module project a dependency module picked
+            // by chance does NOT include the entry, so the entry's laws
+            // would go unverified and the check would false-green.
+            // `dafny_entry` is the entry basename derived from the codegen
+            // context (the same source the build hint prints); fall back to
+            // a directory scan only if that file is somehow absent.
+            let entry = dafny_entry
+                .filter(|e| std::path::Path::new(output_dir).join(e).is_file())
+                .or_else(|| match std::fs::read_dir(output_dir) {
+                    Ok(rd) => rd
+                        .filter_map(|e| e.ok())
+                        .map(|e| e.file_name().to_string_lossy().into_owned())
+                        .find(|n| n.ends_with(".dfy") && n != "common.dfy"),
+                    Err(e) => {
+                        eprintln!(
+                            "{}",
+                            format!("--check: read_dir({}) failed: {}", output_dir, e).red()
+                        );
+                        std::process::exit(2);
+                    }
+                });
             let Some(entry) = entry else {
                 eprintln!(
                     "{}",

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -415,6 +415,72 @@ fn proof_dafny_verifies_json_when_dafny_is_available() {
 }
 
 #[test]
+fn proof_dafny_check_verifies_entry_module_not_arbitrary_dependency() {
+    // Regression: `--check` must verify the ENTRY module (which carries the
+    // verify-law lemmas), not whatever `.dfy` a directory scan yields first.
+    // The dependency module here (`Aaa`) sorts before the entry (`Zzz`) and
+    // does NOT include it, so a naive `read_dir().find()` verifies `Aaa.dfy`
+    // and never checks `Zzz`'s deliberately-false law → false-green.
+    if Command::new("dafny").arg("--version").output().is_err() {
+        eprintln!("skipping dafny entry-selection test: `dafny` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-mm-entry-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("aaa.av"),
+        "module Aaa\n    depends []\n\nfn ident(n: Int) -> Int\n    ? \"id\"\n    n\n\n\
+         verify ident law refl\n    given n: Int = -1..1\n    ident(n) => n\n",
+    )
+    .expect("write aaa.av");
+    std::fs::write(
+        src.join("zzz.av"),
+        "module Zzz\n    depends [Aaa]\n    effects [Console.print]\n\n\
+         fn wrong(n: Int) -> Int\n    ? \"doubles; the law lies\"\n    Aaa.ident(n) + n\n\n\
+         verify wrong law falseRefl\n    given n: Int = -1..1\n    wrong(n) => n\n\n\
+         fn main() -> Unit\n    ! [Console.print]\n    Console.print(\"mm\")\n",
+    )
+    .expect("write zzz.av");
+    let out = temp_output_dir("aver-mm-entry-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("zzz.av"))
+        .arg("--backend")
+        .arg("dafny")
+        .arg("--module-root")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(false),
+        "entry `Zzz`'s false law `wrong(n) => n` must be caught — `--check` must \
+         verify the ENTRY module, not an arbitrary dependency.\n{}",
+        format_output(&run)
+    );
+    assert!(
+        summary["errors"].as_u64().unwrap_or(0) >= 1,
+        "expected >=1 Dafny error from the false entry law\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
 fn proof_export_builds_grok_s_language_when_lake_is_available() {
     assert_proof_builds("examples/core/grok_s_language.av", "aver-proof-grok");
 }


### PR DESCRIPTION
## Problem

`run_proof_check` picked the Dafny file to verify via `read_dir(output_dir).find(|n| n.ends_with(".dfy") && n != "common.dfy")` — the **first** file in non-deterministic filesystem order. In a multi-module project that can be a **dependency** module, which does not `include` the entry. The verify-law lemmas live in the **entry** file, so they go unverified and `--check` reports `passed:true` for a provably-false entry law. (The user-facing build hint, meanwhile, correctly names the entry — so the harness silently diverged from what it advertised.)

Found by the adversarial soundness audit (reproduced live: a `Zzz` entry with a false law + an `Aaa` dependency → harness verified `Aaa.dfy`, reported `passed:true`).

## Fix

Thread the real entry filename (`{entry_basename}.dfy`, the same source the build hint prints) into the harness and verify that file. Fall back to the directory scan only if the entry file is somehow absent.

## Test

`proof_dafny_check_verifies_entry_module_not_arbitrary_dependency` builds a 2-module project where the dependency (`Aaa`) sorts before the entry (`Zzz`) and the entry carries a deliberately-false law. Pre-fix: `passed:true`. Post-fix: `errors >= 1`, `passed:false`.

Verified: 18/18 Dafny proof_spec tests (incl. the new one), fmt + clippy clean.

Note: this verifies the entry's lemmas. Trust of *included* dependency-module obligations (e.g. a non-decreasing `decreases`) is a separate gap tracked as `--verify-included-files` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)