### PR TITLE
cli: verify included files under Dafny proof --check

### DIFF
--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5017,7 +5017,18 @@ fn run_proof_check(
             };
             (
                 "dafny",
-                vec!["verify".to_string(), entry],
+                // `--verify-included-files`: by default `dafny verify` trusts
+                // every `include`d file, so a dependency module's termination
+                // obligations (native `decreases` / fuel lemmas) would go
+                // unchecked — a non-decreasing measure there would be silently
+                // accepted. Verifying includes closes that trust gap; the
+                // runtime prelude (`common.dfy`) verifies clean, so this adds
+                // coverage without introducing spurious errors.
+                vec![
+                    "verify".to_string(),
+                    "--verify-included-files".to_string(),
+                    entry,
+                ],
                 "Dafny / Z3",
                 "dafny",
             )


### PR DESCRIPTION
## Problem

`dafny verify <entry>` trusts every `include`d file by default. The verify-law lemmas live in the entry, but dependency **modules** are emitted as separate `.dfy` files (included by the entry) carrying their recursive functions' **termination obligations** (native `decreases` clauses / fuel lemmas). Those went unverified — a non-decreasing measure in an included module would be silently accepted.

Found by the adversarial soundness audit (reproduced: a `decreases 0` in an included module verified clean without the flag, errored with it).

## Fix

Pass `--verify-included-files` so included modules' obligations are verified too.

## Safety

The runtime prelude `common.dfy` (also an include) verifies **clean** — measured on `fibonacci`: `22 → 28 verified, 0 errors` with the flag — so this strictly adds coverage without introducing spurious errors. The full Dafny `proof_spec` corpus is unchanged at 18/18 (no error-count drift).

## Test note

A dedicated failing-obligation regression test isn't feasible through the compiler: the codegen only ever emits a `decreases`/fuel obligation it believes correct (otherwise it emits an opaque `function {:axiom}` with no obligation), so there's no compiler path that produces a *bad* included obligation to catch. The flag's effect is confirmed empirically (verified-count rises, errors stay 0) and the existing multi-module entry-selection test exercises the include path end-to-end.

Verified: 18/18 Dafny proof_spec, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)