### PR TITLE
cli,test: warn when dependency-module verify blocks are dropped

### DIFF
--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5392,6 +5392,30 @@ fn load_module_recursive(
         process::exit(1);
     }
 
+    // Module-scoped `verify` blocks are not checked: only the ENTRY
+    // module's verify blocks become theorems / lemmas / samples. A
+    // `verify ... law` in a dependency module is silently dropped here
+    // (ModuleInfo carries no verify field), so it would never fail —
+    // a vacuous pass on every backend and the runtime sampler. Warn
+    // loudly so an unchecked dependency law isn't mistaken for a proven
+    // one. (Actually checking module-scoped verify is a separate, larger
+    // feature.)
+    let dep_verify_count = items
+        .iter()
+        .filter(|i| matches!(i, TopLevel::Verify(_)))
+        .count();
+    if dep_verify_count > 0 {
+        eprintln!(
+            "{}",
+            format!(
+                "warning: {dep_verify_count} verify block(s) in dependency module \
+                 '{name}' are NOT checked (module-scoped verify is not yet supported) — \
+                 move them to the entry module to prove or sample them"
+            )
+            .yellow()
+        );
+    }
+
     // Dep modules go through the same pipeline shape as the entry, AND
     // they typecheck against the same on-disk module tree. Typecheck
     // here populates `Spanned::ty()` on this module's expressions so

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -481,6 +481,50 @@ fn proof_dafny_check_verifies_entry_module_not_arbitrary_dependency() {
 }
 
 #[test]
+fn proof_warns_when_dependency_module_has_verify_blocks() {
+    // A `verify ... law` in a dependency module is silently dropped
+    // (module-scoped verify is unsupported), so it would never fail — a
+    // vacuous pass. The compiler must warn loudly. Pure codegen, no
+    // verifier binary needed.
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-dep-verify-warn-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("dep.av"),
+        "module Dep\n    depends []\n\nfn ident(n: Int) -> Int\n    ? \"id\"\n    n\n\n\
+         verify ident law refl\n    given n: Int = -1..1\n    ident(n) => n\n",
+    )
+    .expect("write dep.av");
+    std::fs::write(
+        src.join("app.av"),
+        "module App\n    depends [Dep]\n    effects [Console.print]\n\n\
+         fn wrap(n: Int) -> Int\n    ? \"w\"\n    Dep.ident(n)\n\n\
+         fn main() -> Unit\n    ! [Console.print]\n    Console.print(\"x\")\n",
+    )
+    .expect("write app.av");
+    let out = temp_output_dir("aver-dep-verify-warn-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("app.av"))
+        .arg("--backend")
+        .arg("dafny")
+        .arg("--module-root")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("expected `aver proof` to run");
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("verify block") && stderr.contains("Dep") && stderr.contains("NOT checked"),
+        "expected a warning that dependency module `Dep`'s verify blocks are unchecked, got:\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
 fn proof_export_builds_grok_s_language_when_lake_is_available() {
     assert_proof_builds("examples/core/grok_s_language.av", "aver-proof-grok");
 }


### PR DESCRIPTION
## Problem

Only the **entry** module's `verify` blocks are emitted (as Lean theorems / Dafny lemmas / runtime samples). A `verify ... law` in a **dependency** module is silently dropped at load time — `ModuleInfo` carries no verify field — so it never reaches any backend or the runtime sampler. The result is a vacuous pass: a blatantly false dependency law reports `passed:true` on Lean, Dafny, **and** `aver verify`.

Found by the adversarial soundness audit (a false `badLenInDep` law in a dependency module went green everywhere).

## Fix

Warn loudly at load time when a dependency module contains `verify` blocks, naming the module and the count, so an unchecked law isn't mistaken for a proven one:

```
warning: 1 verify block(s) in dependency module 'Dep' are NOT checked
(module-scoped verify is not yet supported) — move them to the entry
module to prove or sample them
```

Actually checking module-scoped verify (emitting dep laws into the artifact + sampler) is a separate, larger feature; this is the honest-diagnostic fix so the gap is loud, not silent.

## Test

`proof_warns_when_dependency_module_has_verify_blocks` — a 2-module project where the dependency carries a `verify` block; asserts the warning fires (pure codegen, no verifier needed).

Verified: proof_spec 69/69, lib 770/770, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)