### PR TITLE
cli,test: warn that Dafny backend doesn't check example-based verify cases

### DIFF
--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5285,6 +5285,32 @@ fn cmd_proof_lean(
 fn cmd_proof_dafny(file: &str, output_dir: &str, ctx: &codegen::CodegenContext) {
     use aver::codegen::dafny as dafny_codegen;
 
+    // Example-based `verify f` (concrete `f(x) => y` cases) are an
+    // EVALUATION check: Lean verifies them with `native_decide` (which
+    // runs the function) and `aver verify` samples them at runtime. The
+    // Dafny backend is a PROVER, not an evaluator — it cannot reduce a
+    // concrete recursive / List / String case (attempting it floods
+    // spurious errors and can hang the verifier), so it does not check
+    // case-form verify and only proves law-form `verify`. Warn so the
+    // silence isn't mistaken for a Dafny-verified pass (law blocks ARE
+    // proven; the Lean backend and `aver verify` cover the examples).
+    let unchecked_case_blocks = ctx
+        .items
+        .iter()
+        .filter(|i| matches!(i, TopLevel::Verify(vb) if matches!(vb.kind, VerifyKind::Cases)))
+        .count();
+    if unchecked_case_blocks > 0 {
+        eprintln!(
+            "{}",
+            format!(
+                "warning: {unchecked_case_blocks} example-based `verify` block(s) are NOT \
+                 checked by the Dafny backend (Dafny proves laws, not concrete examples) — \
+                 they are verified by `aver proof --backend lean` and `aver verify`"
+            )
+            .yellow()
+        );
+    }
+
     let output = dafny_codegen::transpile(ctx);
     let build_hint = format!(
         "cd {} && dafny verify {}.dfy",

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -525,6 +525,33 @@ fn proof_warns_when_dependency_module_has_verify_blocks() {
 }
 
 #[test]
+fn proof_dafny_warns_example_cases_not_checked() {
+    // Dafny proves LAWS, not concrete example-cases — it cannot evaluate
+    // a `f(x) => y` case the way Lean's `native_decide` does. It must say
+    // so rather than silently pass case-form verify. Pure codegen, no
+    // verifier binary needed. `sum_acc.av` carries case-form verify blocks.
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let out = temp_output_dir("aver-dafny-case-warn");
+    let run = Command::new(aver_bin)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .arg("proof")
+        .arg("examples/data/sum_acc.av")
+        .arg("--backend")
+        .arg("dafny")
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("expected `aver proof` to run");
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("example-based") && stderr.contains("NOT") && stderr.contains("Dafny"),
+        "expected a warning that example-based verify is not Dafny-checked, got:\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
 fn proof_export_builds_grok_s_language_when_lake_is_available() {
     assert_proof_builds("examples/core/grok_s_language.av", "aver-proof-grok");
 }


### PR DESCRIPTION
## Problem

Example-based `verify f` (concrete `f(x) => y` cases) is an **evaluation** check. Lean verifies it with `native_decide` (which *runs* the function); `aver verify` samples it at runtime. The Dafny backend emitted **nothing** for case-form verify and silently passed — a wrong case like `addOne(3) => 999` reported `passed:true` while Lean rejected the same program (backend divergence + vacuous pass). Found by the adversarial soundness audit.

## Why not just emit Dafny proof obligations?

Dafny is a **prover, not an evaluator**. I tried emitting `ensures f(args) == val { }` (with fuel attributes): it cannot reduce concrete recursive / List / String / Json cases, so it **floods spurious errors** (e.g. `json` 89 → 256) and on `fibonacci` it **hangs/crashes the verifier** (no summary line → harness exit 2). Emitting them is the wrong model. (User-confirmed design decision.)

## Fix

Warn that case-form verify is not checked by the Dafny backend (it proves laws, not concrete examples), so the silence isn't mistaken for a Dafny-verified pass:

```
warning: 3 example-based `verify` block(s) are NOT checked by the Dafny
backend (Dafny proves laws, not concrete examples) — they are verified
by `aver proof --backend lean` and `aver verify`
```

Law-form `verify` blocks are still proven by Dafny; Lean + `aver verify` cover the example-cases. Consistent with the dependency-module verify warning (#422).

## Test

`proof_dafny_warns_example_cases_not_checked` — `sum_acc.av` (case-form verify) emits the warning (pure codegen, no verifier needed).

Verified: Dafny proof_spec 19/19 (budgets unchanged — no flood), fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)