### PR TITLE
ir/mir,vm: make own_param's multi-module guard real (was dead)

### DIFF
--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -137,8 +137,16 @@ pub fn own_param_refine(mut program: MirProgram) -> MirProgram {
     if std::env::var("AVER_NO_OWN_PARAM").is_ok() {
         return program;
     }
-    // Whole-program gate: only sound when every caller is visible here.
-    if program.modules.len() > 1 {
+    // Whole-program gate: graduating a param to owned is only sound when
+    // EVERY caller is visible in this program. A dependency-module
+    // fragment (the VM compiles each `depends [...]` module separately)
+    // is missing the entry/sibling call sites, so a param could be marked
+    // owned here while an unseen caller passes an aliased value — an
+    // in-place mutation would then corrupt the caller's value. Bail.
+    // (`program.modules` was the intended signal but is not yet populated
+    // by lowering; `external_callers_possible` is set explicitly by the
+    // VM's per-dep-module build.)
+    if program.external_callers_possible || program.modules.len() > 1 {
         return program;
     }
 
@@ -1300,5 +1308,78 @@ fn visit_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {
                 f(&i.node);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::own_param_refine;
+    use crate::ast::{Literal, Spanned};
+    use crate::ir::FnId;
+    use crate::ir::mir::expr::MirExpr;
+    use crate::ir::mir::program::{LocalId, MirFn, MirParam, MirProgram};
+    use std::sync::Arc;
+
+    fn span<T>(node: T) -> Spanned<T> {
+        Spanned {
+            node,
+            line: 0,
+            ty: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// A one-fn program: `f(v: Vector<Int>)` with `v` flagged
+    /// alias-prone, a body that does not retain `v`, and NO callers.
+    /// With every caller visible (a whole-program compile) own_param
+    /// graduates `v` to owned and clears the flag. As a dependency-module
+    /// fragment (`external_callers_possible`) an unseen cross-module
+    /// caller could pass an aliased value, so the guard must bail and
+    /// keep `v` flagged.
+    fn one_flagged_param_program(external_callers_possible: bool) -> (MirProgram, FnId) {
+        let id = FnId(0);
+        let mut p = MirProgram {
+            external_callers_possible,
+            ..MirProgram::default()
+        };
+        p.fns.insert(
+            id,
+            MirFn {
+                fn_id: id,
+                name: "f".to_string(),
+                params: vec![MirParam {
+                    local: LocalId(0),
+                    name: "v".to_string(),
+                    ty: "Vector<Int>".to_string(),
+                }],
+                return_type: "Int".to_string(),
+                effects: vec![],
+                body: span(MirExpr::Literal(span(Literal::Int(0)))),
+                local_count: 1,
+                aliased_slots: Arc::new(vec![true]),
+            },
+        );
+        (p, id)
+    }
+
+    #[test]
+    fn whole_program_graduates_unaliased_param() {
+        // Guards against a vacuous dependency-fragment test: confirm the
+        // param really WOULD graduate when all callers are visible.
+        let (prog, id) = one_flagged_param_program(false);
+        let out = own_param_refine(prog);
+        assert!(
+            !out.fns[&id].aliased_slots[0],
+            "whole-program: a non-retaining, uncalled collection param must graduate to owned"
+        );
+    }
+
+    #[test]
+    fn dependency_fragment_keeps_param_flagged() {
+        let (prog, id) = one_flagged_param_program(true);
+        let out = own_param_refine(prog);
+        assert!(
+            out.fns[&id].aliased_slots[0],
+            "dependency fragment: own_param must bail — an unseen cross-module caller may alias the param"
+        );
     }
 }

--- a/src/ir/mir/program.rs
+++ b/src/ir/mir/program.rs
@@ -42,6 +42,16 @@ pub struct MirProgram {
     /// instead of carrying the string inline on every
     /// `MirCallee::Builtin`.
     pub builtins: Vec<String>,
+    /// `true` when this program is a *fragment* of a larger build whose
+    /// other parts are compiled separately — specifically a dependency
+    /// module under the VM's per-module compile (the VM lowers each
+    /// `depends [...]` module to its own `MirProgram`). Such a fragment
+    /// does NOT see the entry/sibling call sites, so whole-program
+    /// analyses that rely on "every caller is visible" (notably
+    /// `own_param_refine`) must bail. `false` for a whole-program compile
+    /// (single entry, or the flattened wasm-gc / Rust builds), where all
+    /// callers are present and graduation is sound.
+    pub external_callers_possible: bool,
 }
 
 impl MirProgram {

--- a/src/vm/compiler/mod.rs
+++ b/src/vm/compiler/mod.rs
@@ -117,8 +117,18 @@ enum ModuleSource<'a> {
 /// drops the dead branch of a folded `IfThenElse`, (6) DCE drops unread
 /// `let _ = <pure>` chains. Shared by the entry compile and per-dep-module
 /// MIR builds so both backends see identical lowered+optimized shapes.
-fn build_optimized_mir(items: &[ResolvedTopLevel]) -> crate::ir::mir::MirProgram {
-    crate::ir::mir::optimize(crate::ir::mir::lower_program(items))
+fn build_optimized_mir(
+    items: &[ResolvedTopLevel],
+    external_callers_possible: bool,
+) -> crate::ir::mir::MirProgram {
+    let mut lowered = crate::ir::mir::lower_program(items);
+    // Mark dependency-module fragments so `own_param_refine` bails: the
+    // VM compiles each `depends [...]` module separately, so a dep
+    // fragment cannot see the entry/sibling call sites that may alias a
+    // param. The entry compile (and the flattened wasm-gc / Rust builds)
+    // see all callers, so graduation stays enabled there.
+    lowered.external_callers_possible = external_callers_possible;
+    crate::ir::mir::optimize(lowered)
 }
 
 fn compile_program_inner(
@@ -143,7 +153,7 @@ fn compile_program_inner(
     // Dep-module fns build their own MIR in `integrate_module` (same
     // `build_optimized_mir` pipeline); the per-fn loop there dispatches
     // through the MIR walker with the dep's module scope.
-    let mir_built = build_optimized_mir(items);
+    let mir_built = build_optimized_mir(items, false);
     let mir_program = &mir_built;
 
     let mut compiler = ProgramCompiler::new();
@@ -494,7 +504,7 @@ impl ProgramCompiler {
         // bytecode with the dep's module scope — the same path the entry
         // module takes. MIR is the only VM codegen path; a rejection
         // surfaces as a hard CompileError (no HIR fallback).
-        let dep_mir = build_optimized_mir(&dep_resolved);
+        let dep_mir = build_optimized_mir(&dep_resolved, true);
         let mut fn_idx = 0;
         for item in &dep_resolved {
             if let ResolvedTopLevel::FnDef(rfd) = item {


### PR DESCRIPTION
## Problem

`own_param_refine` graduates a `Vector`/`Map` param to *owned* (in-place mutable) only when **every caller is visible**. Its whole-program guard checked `program.modules.len() > 1` — but `modules` is **never populated** by lowering, so the guard never fired.

The VM compiles each `depends [...]` module **separately** (`build_optimized_mir` per dependency). So a dependency fragment's param could graduate based only on intra-module call sites, while the entry/sibling caller passes an **aliased** value → silent cross-module heap corruption on the in-place write.

Currently this is *masked*: dependency fns don't receive `last_use` markers, so the owned fast path (`owned = last_use && !aliased`) never fires regardless. But the obvious perf follow-up (give dep fns last_use) would unmask it — an adversarial probe from the soundness audit reproduced exactly that corruption. So the guard is load-bearing and was dead.

## Fix

Add an explicit `MirProgram::external_callers_possible` flag, set `true` by the VM's per-dependency-module build and `false` for the entry. `own_param_refine` bails when it's set. Whole-program compiles (single entry; the flattened wasm-gc / Rust builds, where all fns share one program) keep graduation enabled — no perf loss there.

## Tests

Unit tests pin the guard **both ways** (so neither is vacuous):
- `whole_program_graduates_unaliased_param` — a non-retaining, uncalled collection param graduates (flag cleared) in a whole-program compile.
- `dependency_fragment_keeps_param_flagged` — the same program as a dependency fragment keeps the param flagged (guard bails).

Verified: own_param_soundness 25/25, own_param_graduation 45/45, mir_vm_codegen + cross_backend_stress green, lib 772/772, fmt + clippy clean. Multi-module VM programs still run correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)