### PR TITLE
ci,release: run wasip2 tests + clippy in the gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,16 +69,18 @@ jobs:
           test -x "$PWD/binaryen-${BINARYEN_VERSION}/bin/wasm-opt"
           test -x "$PWD/binaryen-${BINARYEN_VERSION}/bin/wasm-metadce"
 
-      - name: Clippy (wasm)
-        run: cargo clippy -p aver-lang --lib --bin aver --features wasm -- -D warnings
+      - name: Clippy (wasm + wasip2)
+        run: cargo clippy -p aver-lang --lib --bin aver --features wasm,wasip2 -- -D warnings
 
-      - name: Test (wasm)
-        # Same proptest budget as the Check & Test job — applies to
-        # any wasm-feature-gated proptest fixtures the feature flag
-        # pulls in. No-op for non-proptest tests.
+      - name: Test (wasm + wasip2)
+        # `wasip2` is a separate feature; `wasm` alone leaves every
+        # `#![cfg(feature = "wasip2")]` test file at 0 tests, so the
+        # wasip2 codegen / component-model surface went unchecked by the
+        # gate. Enable both (they share `wasm-compile`) so the wasip2_*
+        # suites run. Same proptest budget as the Check & Test job.
         env:
           PROPTEST_CASES: '2000'
-        run: cargo test -p aver-lang --features wasm
+        run: cargo test -p aver-lang --features wasm,wasip2
 
   wasm_release_build:
     # Post-merge release-build verification under `--features wasm`.

--- a/tools/release.py
+++ b/tools/release.py
@@ -267,10 +267,15 @@ def verify(dry_run: bool) -> None:
     # Skip generated self-host code in clippy (same as CI)
     print("  verify: cargo clippy --workspace (no aver-lang)", flush=True)
     run(["cargo", "clippy", "--workspace", "--all-targets", "--exclude", "aver-lang", "--", "-D", "warnings"])
-    print("  verify: cargo clippy -p aver-lang --features wasm", flush=True)
-    run(["cargo", "clippy", "-p", "aver-lang", "--lib", "--bin", "aver", "--features", "wasm", "--", "-D", "warnings"])
-    print("  verify: cargo test --features wasm", flush=True)
-    run(["cargo", "test", "--features", "wasm"])
+    print("  verify: cargo clippy -p aver-lang --features wasm,wasip2", flush=True)
+    run(["cargo", "clippy", "-p", "aver-lang", "--lib", "--bin", "aver", "--features", "wasm,wasip2", "--", "-D", "warnings"])
+    # `wasip2` is a separate feature; with `wasm` alone every
+    # `#![cfg(feature = "wasip2")]` test file reports 0 tests, so the
+    # wasip2 codegen / component-model surface was never gated by the
+    # release check. Enable both (they share `wasm-compile`) so the
+    # wasip2_* suites actually run.
+    print("  verify: cargo test --features wasm,wasip2", flush=True)
+    run(["cargo", "test", "--features", "wasm,wasip2"])
 
     # Bench smoke. Runs every scenario in `bench/scenarios/` end-to-end on
     # the VM target — catches pipeline / VM regressions that the unit tests


### PR DESCRIPTION
## Problem

`wasip2` is a separate Cargo feature, but the release check (`tools/release.py`) and CI only passed `--features wasm`. Every `#![cfg(feature = "wasip2")]` test file (`wasip2_poc`, `wasip2_codegen_regression`, `wasip2_stress`, `wasip2_tcp`, `wasip2_http`, `wasip2_http_server`, `wasip2_tcp_stress`, `wasip2_http_server_stress`) therefore reported **0 tests** in the gate. The wasip2 codegen / component-model surface (`TargetMode::Wasip2`, component wrap, Tcp/Http/Disk effect lowering) was never exercised, even though unreleased changes routinely touch the shared wasm-gc/wasip2 backend.

Found by the adversarial audit.

## Fix

Enable both features (`--features wasm,wasip2`; they share `wasm-compile`, so they compose) in the **test** and **clippy** steps of `tools/release.py` and the CI `wasm` job.

## Verification

- `cargo test --features wasm,wasip2` (full suite) is green — the wasip2_* suites now run (a few runtime cases are env-gated/`ignored` when `wasmtime`/`python` aren't present, which is expected).
- `cargo clippy -p aver-lang --features wasm,wasip2 -- -D warnings` is clean.

(The shipped release binary's feature set is unchanged — whether to ship `--target wasip2` in the binary is a separate release decision.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)