### PR TITLE
cli: document that proof --check budgets are whole-file totals

### DIFF
--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -591,11 +591,15 @@ pub(super) enum Commands {
         check: bool,
         /// `--check` only: tolerate up to N Dafny verification
         /// errors. Gates regressions upward for examples whose laws
-        /// don't yet have a closing strategy.
+        /// don't yet have a closing strategy. N is a WHOLE-FILE total,
+        /// not per-law: `--error-budget 2` passes a file with two
+        /// independently-failing laws. Defaults to 0 (strict).
         #[arg(long, requires = "check")]
         error_budget: Option<usize>,
-        /// `--check` only: tolerate up to N residual Lean `sorry`s.
-        /// Symmetric to `--error-budget` on Dafny.
+        /// `--check` only: tolerate up to N residual Lean `sorry`s (and,
+        /// on Dafny, `assume {:axiom}` trust-escapes). Symmetric to
+        /// `--error-budget`. Like it, N is a WHOLE-FILE total, not
+        /// per-law. Defaults to 0 (strict).
         #[arg(long, requires = "check")]
         sorry_budget: Option<usize>,
         /// `--check` only: emit a structured JSON summary


### PR DESCRIPTION
## Problem

`--error-budget` / `--sorry-budget` gate on a **whole-file** count, so `--error-budget 2` passes a file with two independently-failing laws — the slack is fungible across laws, not per-law. This is by design (a budget is a total regression-gating tolerance, and the default is 0 = strict, so it's never a default false-green), but the audit flagged it as an implicit footgun.

## Fix

Spell out the whole-file/fungible semantics in the flag help, note the default is 0 (strict), and note `--sorry-budget` now also covers Dafny `assume {:axiom}` trust-escapes (from #417). Documentation-only; no behavior change. True per-law budgets would need per-law budget syntax and aren't currently requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)