### PR TITLE
codegen/lean: fix false-RED on when-premised laws (malformed emit + opaque premise)

### DIFF
--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -448,11 +448,18 @@ fn emit_match(
         // their `by omega` proof obligation. Plain `if` everywhere
         // else keeps spec-equivalence and other auto-provers (which
         // pattern-match on the plain `if`-shape) working.
+        // Parenthesize: an `if/then/else` is greedy, so an unwrapped
+        // emission breaks in two places the Bool-match path actually
+        // hits — a NESTED match (`if c1 then (if c2 …) else …`, where the
+        // inner `else` would otherwise be swallowed) and an appended
+        // operator (a `when` premise gets `= true` appended, and
+        // `else f = true` would parse as `else (f = true)`). Wrapping is
+        // transparent to Lean's elaborator and tactics (same `ite`).
         if true_body_uses_refinement_subtype(true_body, ctx) {
             let hyp = format!("h_{line}");
-            return format!("if {hyp} : {cond} then {t}\n  else {f}");
+            return format!("(if {hyp} : {cond} then {t}\n  else {f})");
         }
-        return format!("if {cond} then {t}\n  else {f}");
+        return format!("(if {cond} then {t}\n  else {f})");
     }
     let subj = emit_expr(subject, ctx);
     let mut arm_strs = Vec::new();

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -480,6 +480,7 @@ pub fn emit_verify_law_forall_auto_proof(
                         smart_guard.as_ref(),
                         lifted,
                         chosen_intro,
+                        law.when.is_some(),
                         ctx,
                     ),
                     replaces_theorem: false,
@@ -511,6 +512,7 @@ fn emit_simp_omega_from_ir(
     smart_guard: Option<&crate::ir::SmartGuard>,
     lifted: bool,
     intro_names: &[String],
+    has_when: bool,
     ctx: &CodegenContext,
 ) -> Vec<String> {
     let lean_names: Vec<String> = unfold_fns.iter().map(|n| aver_name_to_lean(n)).collect();
@@ -561,10 +563,20 @@ fn emit_simp_omega_from_ir(
             ],
         )
     } else {
-        intro_then(
-            intro_names,
-            vec![format!("simp only [{}] <;> omega", lean_names.join(", "))],
-        )
+        // A `when` premise is introduced as a hypothesis (`h_when`).
+        // `simp_all` simplifies it — e.g. a nested Bool `match` lowered to
+        // an `if/then/else` — so `omega` can use the premise; for an
+        // unsatisfiable premise it derives the contradiction and closes
+        // the (vacuously-true) law. Plain `simp only` leaves the Bool
+        // premise opaque and `omega` fails ("no usable constraints"),
+        // wrongly rejecting a valid law. Without a `when`, keep the
+        // conservative `simp only` — there is no premise to simplify.
+        let tac = if has_when {
+            format!("simp_all [{}] <;> omega", lean_names.join(", "))
+        } else {
+            format!("simp only [{}] <;> omega", lean_names.join(", "))
+        };
+        intro_then(intro_names, vec![tac])
     }
 }
 

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -1962,10 +1962,13 @@ fn emit_verify_law_block(
         ));
     }
     if let Some(when_expr) = &law.when {
-        lines.push(format!(
-            "-- when {}",
-            emit_expr_legacy(when_expr, ctx, None)
-        ));
+        // Flatten to one physical line: a `--` line comment only covers
+        // the first line, so a multi-line premise (e.g. a nested Bool
+        // match lowering to a multi-line `if/then/else`) would leak its
+        // continuation lines out as stray Lean commands ("unexpected
+        // token 'else'").
+        let when_comment = emit_expr_legacy(when_expr, ctx, None).replace('\n', " ");
+        lines.push(format!("-- when {when_comment}"));
     }
     // Issue #128: singleton-domain givens + RHS that references no
     // given + IR didn't pin a strategy that closes the constant-RHS

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -552,6 +552,63 @@ fn proof_dafny_warns_example_cases_not_checked() {
 }
 
 #[test]
+fn proof_lean_vacuous_when_premise_law_builds_and_passes() {
+    // A `when` premise that is unsatisfiable (here a nested Bool `match`
+    // requiring `n > 0` AND `n < 0`) makes the law vacuously true, so a
+    // sound prover must ACCEPT it. The premise lowers to a multi-line
+    // `if/then/else`; previously the emit was unparseable Lean (the
+    // unparenthesized `if` swallowed the trailing `= true`, and the
+    // `-- when` comment leaked its continuation lines), and even parsed
+    // `simp only` left the Bool premise opaque so `omega` failed — a
+    // valid law wrongly REJECTED (false-RED). Pins parens + single-line
+    // comment + `simp_all` so it builds and passes.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean vacuous-when test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-lean-vacuous-when-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    let av = src.join("vac.av");
+    std::fs::write(
+        &av,
+        "module VacuousLaw\n\nfn dbl(n: Int) -> Int\n    ? \"double\"\n    n + n\n\n\
+         verify dbl law vac\n    given n: Int = -2..2\n    when match n > 0\n\
+         \x20       true -> match n < 0\n            true -> true\n            false -> false\n\
+         \x20       false -> false\n    dbl(n) => n + 999\n",
+    )
+    .expect("write vac.av");
+    let out = temp_output_dir("aver-lean-vacuous-when-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(&av)
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check` to run");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "vacuously-true `when`-premised law must build and pass on Lean\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
 fn proof_export_builds_grok_s_language_when_lake_is_available() {
     assert_proof_builds("examples/core/grok_s_language.av", "aver-proof-grok");
 }


### PR DESCRIPTION
## Problem

A law with a `when` premise whose Bool expression lowers to a multi-line `if/then/else` (e.g. a nested `match`) was emitted as **unparseable Lean** and, even once parsed, couldn't be discharged — so a **vacuously-true** law was wrongly **rejected** (false-RED, the safe direction but still a completeness bug + a Lean/Dafny divergence). Found by the adversarial audit. Three compounding causes:

1. The emitted `if/then/else` was **unparenthesized**, so the `= true` appended to turn the Bool premise into a `Prop` bound to the wrong `else` branch (`else f = true` parsed as `else (f = true)`).
2. The `-- when <expr>` **comment** is a `--` line comment, but the expression spanned multiple lines, so its continuation lines leaked out as stray Lean commands (`unexpected token 'else'`).
3. `simp only [defs] <;> omega` left the Bool premise opaque, so `omega` reported "no usable constraints" and failed.

## Fix

1. Parenthesize the emitted `if/then/else` (transparent to Lean's elaborator and tactics — same `ite`).
2. Flatten the `-- when` comment to a single physical line.
3. Use `simp_all` instead of `simp only` for **`when`-premised** laws, so the premise is simplified into `omega`'s reach (an unsatisfiable premise then closes the law vacuously). Scoped to `when` laws only — non-`when` laws keep the conservative `simp only`.

## Test

`proof_lean_vacuous_when_premise_law_builds_and_passes` — a vacuously-true nested-Bool-`when` law builds and reports `passed:true` (pre-fix: unparseable → `passed:false`).

Verified: proof_spec 71/71 (the parenthesization is global to Lean if/else emit — no regression), lean codegen unit tests 68/68, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)