### PR TITLE
codegen/lean: harden simple structural-induction arms to honest sorry

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -226,13 +226,26 @@ fn emit_simple_induction(
             .map(|index| format!("f{}", index))
             .collect();
 
+        // Each arm closes fully or degrades to an honest `sorry` — and
+        // BUILDS either way. `induction .. with | arm => tac` requires the
+        // arm tactic to close its goal; a leftover goal is an
+        // `unsolved goals` ERROR (a hard lake-build failure), not a
+        // countable `sorry`. Gate on `first | (simp[_all] [defs]; done) |
+        // sorry` (matching the List-induction path): `; done` turns a
+        // non-closing `simp` into a throw that `first` catches and admits
+        // via `sorry`. A law simp proves closes (no sorry); anything else
+        // (e.g. an arm needing `omega`) becomes an honest building sorry
+        // rather than a false-RED hard error.
         match classify_variant(variant, type_name) {
             VariantKind::Leaf => {
                 if field_binders.is_empty() {
-                    proof_lines.push(format!("  | {} => simp [{}]", lean_variant, simp_list));
+                    proof_lines.push(format!(
+                        "  | {} => first | (simp [{}]; done) | sorry",
+                        lean_variant, simp_list
+                    ));
                 } else {
                     proof_lines.push(format!(
-                        "  | {} {} => simp [{}]",
+                        "  | {} {} => first | (simp [{}]; done) | sorry",
                         lean_variant,
                         field_binders.join(" "),
                         simp_list
@@ -249,7 +262,7 @@ fn emit_simple_induction(
                     .collect();
 
                 proof_lines.push(format!(
-                    "  | {} {} {} => simp_all [{}]",
+                    "  | {} {} {} => first | (simp_all [{}]; done) | sorry",
                     lean_variant,
                     field_binders.join(" "),
                     ih_names.join(" "),

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -2879,8 +2879,10 @@ verify mirror law involutive
             )
         );
         assert!(lean.contains("  induction t with"));
-        assert!(lean.contains("  | leaf f0 => simp [mirror]"));
-        assert!(lean.contains("  | node f0 f1 ih0 ih1 => simp_all [mirror]"));
+        assert!(lean.contains("  | leaf f0 => first | (simp [mirror]; done) | sorry"));
+        assert!(
+            lean.contains("  | node f0 f1 ih0 ih1 => first | (simp_all [mirror]; done) | sorry")
+        );
         assert!(!lean.contains(
             "-- universal theorem mirror_law_involutive omitted: sampled law shape is not auto-proved yet"
         ));


### PR DESCRIPTION
## Problem

`emit_simple_induction` (the Lean auto-proof for user-defined **recursive sum-type** givens) emitted bare `simp [defs]` / `simp_all [defs]` per `induction .. with` arm. In Lean 4 an arm tactic must close its goal — a leftover goal is an `unsolved goals` **error** (a hard build failure), not a countable `sorry`. So a recursive-sum law whose arm `simp` can't fully discharge (e.g. one needing `omega`) was a **false-RED**, inconsistent with the List-induction path, which already degrades to an honest `sorry` (the config from #416).

## Fix

Apply the same `first | (simp[_all] [defs]; done) | sorry` guard to all three arm shapes (leaf / leaf-with-fields / direct-recursive). A closing law stays sorry-free; a non-closing one becomes an honest **building** sorry (counted against the sorry budget) instead of a hard error. Consistent with `emit_list_induction`.

The structural-induction unit test is updated to the guarded emit.

Verified: lean codegen unit tests 68/68, proof_spec 71/71, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)