### PR TITLE
codegen/wasm-gc: support first-class functions via call_indirect

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -83,6 +83,18 @@ pub(super) struct FnMap {
     /// Per-(record/sum) `__eq_<TypeName>` helpers used by `BinOp::Eq`
     /// / `BinOp::Neq` over nominal types. Key = bare type name.
     pub(super) eq_helpers: std::collections::HashMap<String, u32>,
+    /// Address-taken user fn name → dense funcref-table index (table 0).
+    /// A `MirExpr::FnValue(name)` lowers to `i32.const <idx>`; a
+    /// `Fn`-param call dispatches that index via `call_indirect`. Names
+    /// absent here (builtins / variants / let-bound fn values with no
+    /// table slot) fall back to the trap stub.
+    pub(super) funcref_table: std::collections::HashMap<String, u32>,
+    /// `fn_sig_key(params, results)` → pre-registered `call_indirect`
+    /// functype index, one per distinct `Fn(..)` param signature. The
+    /// body emitter recomputes the key via `EmitCtx::fn_param_fn_sig`
+    /// and must hit the SAME entry the module-assembly registration
+    /// recorded (both derive the key from `fn_sig_wasm` + `fn_sig_key`).
+    pub(super) call_indirect_types: std::collections::HashMap<String, u32>,
 }
 
 impl FnMap {
@@ -489,6 +501,22 @@ impl<'a> EmitCtx<'a> {
             .get(slot as usize)
             .copied()
             .unwrap_or(false)
+    }
+
+    /// `fn_sig_key` for the `Fn(..)` param named `name`, used to look up
+    /// the pre-registered `call_indirect` functype at a `LocalSlot`
+    /// call site. Returns `None` when `name` is not a param or not a
+    /// `Fn` type. Derives the key via the SAME `fn_sig_wasm` +
+    /// `fn_sig_key` the module-assembly registration used, so the two
+    /// keys agree exactly. `EmitCtx::params` carries each param's
+    /// resolved `Type`; `registry` drives the type lowering.
+    pub(super) fn fn_param_fn_sig(&self, name: &str) -> Option<String> {
+        let (_, ty) = self.params.iter().find(|(n, _)| n == name)?;
+        let Type::Fn(args, ret, _) = ty else {
+            return None;
+        };
+        let (params, results) = super::types::fn_sig_wasm(args, ret, Some(self.registry)).ok()?;
+        Some(super::types::fn_sig_key(&params, &results))
     }
 }
 

--- a/src/codegen/wasm_gc/body/from_mir/coverage.rs
+++ b/src/codegen/wasm_gc/body/from_mir/coverage.rs
@@ -17,8 +17,9 @@ pub struct CoverageReport {
     pub total: usize,
     /// Fns whose entire body the walker emits standalone.
     pub mir_covered: usize,
-    /// Fns that hit at least one unsupported variant (HIR fallback).
-    pub hir_fallback: usize,
+    /// Fns that hit at least one unsupported variant and so get a
+    /// `unreachable` trap-stub body instead of MIR emission.
+    pub trap_stub: usize,
 }
 
 impl CoverageReport {
@@ -46,7 +47,7 @@ pub fn coverage_report(program: &MirProgram) -> CoverageReport {
         if mir_expr_coverable(&mir_fn.body) {
             report.mir_covered += 1;
         } else {
-            report.hir_fallback += 1;
+            report.trap_stub += 1;
         }
     }
     report
@@ -56,7 +57,11 @@ pub fn coverage_report(program: &MirProgram) -> CoverageReport {
 /// `None`). Structural mirror of the emitter's match arms.
 pub(crate) fn mir_expr_coverable(expr: &Spanned<MirExpr>) -> bool {
     match &expr.node {
-        MirExpr::Literal(_) | MirExpr::Local(_) => true,
+        // `FnValue` lowers to an `i32.const` of the fn's funcref-table
+        // index (when address-taken to a user fn). The ctx-free
+        // predicate can't see the table, so it over-counts the
+        // builtin/variant case that falls back — tolerable here.
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => true,
         MirExpr::BinOp(spanned_binop) => {
             let bop = &spanned_binop.node;
             // Numeric ops or the `String` concat / eq / compare ops.
@@ -83,8 +88,16 @@ pub(crate) fn mir_expr_coverable(expr: &Spanned<MirExpr>) -> bool {
             mir_expr_coverable(&l.value) && mir_expr_coverable(&l.body)
         }
         MirExpr::Call(spanned_call) => {
-            matches!(spanned_call.node.callee, MirCallee::Fn(_))
-                && spanned_call.node.args.iter().all(mir_expr_coverable)
+            // `Fn` (direct) and `LocalSlot` (first-class `Fn`-param via
+            // `call_indirect`) callees are both emitted standalone. The
+            // ctx-free predicate can't see whether a `LocalSlot` resolves
+            // to a registered functype, so it over-counts those that fall
+            // back — tolerable for `--explain-mir-coverage`; the byte-
+            // differential test is the real gate.
+            matches!(
+                spanned_call.node.callee,
+                MirCallee::Fn(_) | MirCallee::LocalSlot { .. }
+            ) && spanned_call.node.args.iter().all(mir_expr_coverable)
         }
         MirExpr::TailCall(spanned_tc) => spanned_tc.node.args.iter().all(mir_expr_coverable),
         MirExpr::Construct(spanned_ctor) => spanned_ctor.node.args.iter().all(mir_expr_coverable),

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -21,8 +21,14 @@
 //! synthetic lets — `_ = expr` discards and non-tail `Stmt::Expr`, which
 //! emit the value, `drop` it if it produced one, then the body),
 //! `Call(Fn)` / `TailCall`, `Project` (mirroring `emit_attr_get`), and
-//! the `Tuple` / `MapLiteral` literals. Higher-order callees (`FnValue`,
-//! `LocalSlot`) fall back. Registered-helper builtins and effect imports (`Console.*` /
+//! the `Tuple` / `MapLiteral` literals. First-class fn values are
+//! supported: `FnValue(name)` lowers to an `i32.const` of the fn's
+//! dense funcref-table index, and a `Fn`-param call (`LocalSlot`)
+//! dispatches that index via `call_indirect` on table 0 (the funcref
+//! table + functypes are set up in `module.rs`). Only the residual
+//! cases with no table slot (a `FnValue` of a builtin / variant, or a
+//! `LocalSlot` whose name is a let-bound fn value rather than a `Fn`
+//! param) fall back to the trap stub. Registered-helper builtins and effect imports (`Console.*` /
 //! `Disk.*` / `Tcp.*` / `Http.*` / `Random.*` / `Time.*`, each carrying
 //! the host's `caller_fn` stamp) go through the `fn_map.builtins` /
 //! `fn_map.effects` lookups here.
@@ -572,9 +578,36 @@ pub(crate) fn emit_mir_expr(
                         None => Ok(None),
                     }
                 }
-                // First-class local-slot calls are higher-order (wasm-gc
-                // has no first-class fn lowering) → fall back.
-                MirCallee::LocalSlot { .. } => Ok(None),
+                // First-class local-slot call: dispatch the `Fn`-param
+                // through `call_indirect` on the funcref table (table 0).
+                // The slot holds an i32 = the target fn's dense table
+                // index (placed there by the `FnValue` arm at the
+                // pass-the-fn call site). Recover the param's `Fn(..)`
+                // sig key, look up the pre-registered functype; either
+                // missing (e.g. a let-bound fn value with no table slot)
+                // → fall back to the trap stub.
+                MirCallee::LocalSlot { slot, ref name, .. } => {
+                    let Some(key) = ctx.fn_param_fn_sig(name) else {
+                        return Ok(None);
+                    };
+                    let Some(&type_index) = ctx.fn_map.call_indirect_types.get(&key) else {
+                        return Ok(None);
+                    };
+                    // STACK ORDER: args first, then the i32 table index
+                    // on top, then `call_indirect` (which pops index +
+                    // args, pushes results).
+                    for arg in &call.args {
+                        if emit_mir_expr(func, arg, slots, ctx)?.is_none() {
+                            return Ok(None);
+                        }
+                    }
+                    func.instruction(&Instruction::LocalGet(slot as u32));
+                    func.instruction(&Instruction::CallIndirect {
+                        type_index,
+                        table_index: 0,
+                    });
+                    Ok(Some(aver_type_str_of(expr).trim() != "Unit"))
+                }
             }
         }
         MirExpr::TailCall(spanned_tc) => {
@@ -793,10 +826,18 @@ pub(crate) fn emit_mir_expr(
             func.instruction(&Instruction::End);
             Ok(Some(produces))
         }
-        // Catch-all fallback to the `ResolvedExpr` emitter. Reaches here:
-        // `FnValue` (a fn referenced as a value — wasm-gc has no
-        // first-class fn representation).
-        _ => Ok(None),
+        // A fn referenced as a value (`callWith(inc)`): push its dense
+        // funcref-table index as an `i32`. A `Fn`-param call later reads
+        // this i32 from its slot and dispatches via `call_indirect`.
+        // Names absent from the funcref table (builtins / variants) have
+        // no table slot — fall back to the trap stub.
+        MirExpr::FnValue(name) => match ctx.fn_map.funcref_table.get(name) {
+            Some(&idx) => {
+                func.instruction(&Instruction::I32Const(idx as i32));
+                Ok(Some(true))
+            }
+            None => Ok(None),
+        },
     }
 }
 

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -14,7 +14,15 @@
 //! 4. **Code section** — `_start` calls `main` and drops any return
 //!    value; user fns get their bodies from the MIR body emitter
 //!    (`body::emit_fn_body_via_mir`), with an `unreachable` trap stub
-//!    for the rare shape it doesn't cover (higher-order dispatch).
+//!    for the rare shape it doesn't cover (a first-class fn value with
+//!    no funcref-table slot — a builtin/variant `FnValue` or a
+//!    let-bound fn-value call).
+//!
+//! First-class `Fn` values lower to an `i32` dense index into a single
+//! funcref table (table 0); `Fn`-param calls dispatch via
+//! `call_indirect`. The Table section (after Function) sizes the table,
+//! the Element section (after Export) initialises it, and the per-sig
+//! `call_indirect` functypes are pre-registered in the Type section.
 //!
 //! Validation runs `wasmparser` with GC + tail-call features before
 //! returning bytes.
@@ -22,8 +30,9 @@
 use std::collections::HashMap;
 
 use wasm_encoder::{
-    CodeSection, DataCountSection, DataSection, EntityType, ExportKind, ExportSection, Function,
-    FunctionSection, ImportSection, Instruction, Module, TypeSection, ValType,
+    CodeSection, ConstExpr, DataCountSection, DataSection, ElementSection, Elements, EntityType,
+    ExportKind, ExportSection, Function, FunctionSection, ImportSection, Instruction, Module,
+    RefType, TableSection, TableType, TypeSection, ValType,
 };
 
 use super::WasmGcError;
@@ -100,13 +109,14 @@ use crate::ast::{FnDef, TopLevel, TypeDef};
 
 /// Emit a trap-stub body into `func`: just `unreachable; end`.
 ///
-/// Used for the (sole) fn shape the MIR body emitter doesn't cover —
-/// higher-order dynamic dispatch (`MirCallee::LocalSlot`, e.g. the
-/// verify-only `pairSpec`). `unreachable` is a polymorphic stack-type
+/// Used for the residual fn shapes the MIR body emitter doesn't cover.
+/// First-class `Fn`-param dispatch now lowers to `call_indirect` on the
+/// funcref table, so the only fns that still trap are those reaching a
+/// first-class fn value with no table slot — a `FnValue` of a builtin /
+/// variant, or a `LocalSlot` whose name is a let-bound fn value rather
+/// than a `Fn` param. `unreachable` is a polymorphic stack-type
 /// instruction, so it validates for ANY fn signature with zero extra
-/// locals. This is observably equivalent to the retired `ResolvedExpr`
-/// walker, whose output for those shapes also trapped at runtime —
-/// wasm-gc cannot execute first-class callable values.
+/// locals.
 fn emit_trap_stub_body(func: &mut Function) {
     func.instruction(&Instruction::Unreachable);
     func.instruction(&Instruction::End);
@@ -131,6 +141,28 @@ pub(super) fn emit_module_with(
 
     let registry =
         TypeRegistry::build_with_handler(items, &resolved_fn_defs, handler_name.is_some());
+
+    // Lower the post-link resolved fns to MIR and run the shared
+    // `optimize` pipeline — the SAME six passes the VM consumes
+    // (`ir::mir::optimize`). MIR is the only codegen path. Hoisted to
+    // before the type section so the address-taken-fn scan + the
+    // `call_indirect` functype pre-registration (first-class `Fn`
+    // support) can run while `next_type_idx` is still being assembled;
+    // the body-emit loop below reads it back.
+    //
+    // The body walk emits the optimized form for the variants it
+    // covers; the shape it does NOT cover is a let-bound first-class fn
+    // value or a builtin/variant `FnValue` (no funcref-table slot),
+    // for which it returns `None`. Such fns get a `unreachable`
+    // trap-stub body (`emit_trap_stub_body`).
+    let mir_program: crate::ir::mir::MirProgram = {
+        let mir_items: Vec<crate::ir::hir::ResolvedTopLevel> = resolved_fn_defs
+            .iter()
+            .cloned()
+            .map(crate::ir::hir::ResolvedTopLevel::FnDef)
+            .collect();
+        crate::ir::mir::optimize(crate::ir::mir::lower_program(&mir_items))
+    };
 
     // Lazy caller_fn name registry — populated during user-fn body
     // emit by `emit_caller_fn_idx` call sites. Threaded into every
@@ -738,6 +770,29 @@ pub(super) fn emit_module_with(
         next_type_idx += 1;
     }
 
+    // 4b) `call_indirect` functypes for first-class `Fn`-param calls.
+    //     One unique functype per distinct `Fn(..)` param signature
+    //     reached by a `MirCallee::LocalSlot` call site. Emitted right
+    //     after the user-fn types so `next_type_idx` stays monotonic;
+    //     the body emitter looks each one up by the SAME `fn_sig_key`
+    //     the registration computed (`call_indirect_types`). Each
+    //     functype is byte-identical to the target fn's own functype
+    //     (built from the same lowering), so a `Fn`-value index from
+    //     the funcref table dispatches correctly through it.
+    let fn_params_by_id: HashMap<crate::ir::FnId, &[(String, crate::types::Type)]> =
+        resolved_fn_defs
+            .iter()
+            .map(|rfd| (rfd.fn_id, rfd.params.as_slice()))
+            .collect();
+    let mut call_indirect_types: HashMap<String, u32> = HashMap::new();
+    for (key, (params, results)) in
+        collect_call_indirect_sigs(&mir_program, &fn_params_by_id, &registry)?
+    {
+        types.ty().function(params, results);
+        call_indirect_types.insert(key, next_type_idx);
+        next_type_idx += 1;
+    }
+
     // 5) One fn type per registered builtin.
     //
     //    `import_count` is the wasm-fn-idx offset every other
@@ -747,6 +802,27 @@ pub(super) fn emit_module_with(
         super::TargetMode::AverBridge => effect_registry.import_count(),
         super::TargetMode::Wasip2 => wasip2_imports.import_count(),
     };
+
+    // ── Funcref table for first-class `Fn` values ──────────────────
+    //
+    // Every address-taken fn (referenced via `MirExpr::FnValue`) that
+    // resolves to a USER fn gets a dense table index `0..N`. A `Fn`
+    // value lowers to that i32 index (`from_mir`'s `FnValue` arm); a
+    // `Fn`-param call dispatches via `call_indirect` against this
+    // table (table 0). Names that don't match a user fn (builtins /
+    // variants) are excluded — those `FnValue` sites fall back to the
+    // trap stub. The i-th user fn lives at wasm fn idx
+    // `import_count + 1 + i` (`_start` is at `import_count`).
+    let mut funcref_table: HashMap<String, u32> = HashMap::new();
+    let mut funcref_wasm_idxs: Vec<u32> = Vec::new();
+    for name in collect_address_taken(&mir_program) {
+        if let Some(i) = fn_defs.iter().position(|fd| fd.name == name) {
+            let table_idx = funcref_wasm_idxs.len() as u32;
+            funcref_table.insert(name, table_idx);
+            funcref_wasm_idxs.push(import_count + 1 + (i as u32));
+        }
+    }
+
     let mut next_builtin_fn_idx = import_count + 1 + (fn_defs.len() as u32);
     builtin_registry.assign_slots(&mut next_builtin_fn_idx, &mut next_type_idx);
     for name in builtin_registry.iter() {
@@ -1785,6 +1861,27 @@ pub(super) fn emit_module_with(
     });
     module.section(&funcs);
 
+    // ── Table section (funcref table for first-class `Fn` values) ──
+    //
+    // One funcref table (table 0) sized to the number of address-taken
+    // user fns. Each `Fn` value is a dense index into it; `Fn`-param
+    // calls dispatch via `call_indirect 0`. Emitted only when at least
+    // one fn is address-taken — empty programs skip the section. Binary
+    // section order: Table (id 4) follows Function (id 3) and precedes
+    // Memory (id 5).
+    if !funcref_wasm_idxs.is_empty() {
+        let n = funcref_wasm_idxs.len() as u64;
+        let mut tables = TableSection::new();
+        tables.table(TableType {
+            element_type: RefType::FUNCREF,
+            table64: false,
+            minimum: n,
+            maximum: Some(n),
+            shared: false,
+        });
+        module.section(&tables);
+    }
+
     // ── Memory section ─────────────────────────────────────────────
     //
     // 1 page initial, 2048 max (128 MiB ceiling — matches Cloudflare
@@ -2187,6 +2284,8 @@ pub(super) fn emit_module_with(
         zip_ops: zip_ops_lookup,
         string_split_ops,
         eq_helpers: eq_helpers_lookup,
+        funcref_table,
+        call_indirect_types,
     };
 
     // ── Export section ─────────────────────────────────────────────
@@ -2268,6 +2367,24 @@ pub(super) fn emit_module_with(
     }
     module.section(&exports);
 
+    // ── Element section (active funcref-table init) ────────────────
+    //
+    // Active segment at table 0, offset 0, initialising every slot with
+    // the wasm fn idx of the i-th address-taken user fn (so table[i]
+    // points at the fn whose `Fn` value carries index `i`). Emitted
+    // only when the funcref table exists. Binary section order: Element
+    // (id 9) follows Export (id 7) and precedes the DataCount / Code
+    // sections below.
+    if !funcref_wasm_idxs.is_empty() {
+        let mut elements = ElementSection::new();
+        elements.active(
+            None,
+            &ConstExpr::i32_const(0),
+            Elements::Functions((&funcref_wasm_idxs[..]).into()),
+        );
+        module.section(&elements);
+    }
+
     // (No StartSection — 0.16.2's caller_fn globals init is gone;
     // host reads the caller_fn name table via `__caller_fn_count`
     // + `__caller_fn_name(i)` exports at instantiation instead.)
@@ -2285,28 +2402,11 @@ pub(super) fn emit_module_with(
             .register("aver_http_handle")
     });
 
-    // Lower the post-link resolved fns to MIR and run the shared
-    // `optimize` pipeline — the SAME six passes the VM consumes
-    // (`ir::mir::optimize`). This is the realization of "one optimizer
-    // pass benefits every backend": wasm-gc and wasip2 (which reuses
-    // this seam) emit from optimized MIR, not the raw 1:1-HIR shape.
+    // `mir_program` was lowered + optimized up front (before the type
+    // section), so the address-taken-fn scan + `call_indirect` functype
+    // pre-registration could run during type-section assembly. It is
+    // the SAME `optimize`d program the VM consumes.
     //
-    // MIR is the only codegen path. The body walk emits the optimized
-    // form for the variants it covers; the single shape it does NOT
-    // cover is higher-order dynamic dispatch (`MirCallee::LocalSlot`,
-    // e.g. the verify-only `pairSpec`), for which it returns `None`. Such
-    // fns get a `unreachable` trap-stub body (`emit_trap_stub_body`) —
-    // observably equivalent to the retired `ResolvedExpr` walker, which
-    // also trapped at runtime on those shapes since wasm-gc cannot
-    // execute first-class callable values.
-    let mir_program: crate::ir::mir::MirProgram = {
-        let mir_items: Vec<crate::ir::hir::ResolvedTopLevel> = resolved_fn_defs
-            .iter()
-            .cloned()
-            .map(crate::ir::hir::ResolvedTopLevel::FnDef)
-            .collect();
-        crate::ir::mir::optimize(crate::ir::mir::lower_program(&mir_items))
-    };
     // `mir_fn_for[i]` is `Some(&MirFn)` when the i-th fn lowered to
     // MIR (always true on valid input — every resolved fn lowers).
     // `mir_dispatch[i]` is the final per-fn decision: `true` when the
@@ -5033,6 +5133,250 @@ fn discover_builtins_in_expr(
         }
         _ => {}
     }
+}
+
+/// Every fn name referenced as a value (`MirExpr::FnValue(name)`)
+/// anywhere in the program, insertion-order deduped. These are the
+/// "address-taken" fns — each needs a slot in the module's funcref
+/// table so a `Fn`-param can carry its dense index. Mirror of the
+/// full-tree walk shape `own_param.rs::visit_children` uses; built
+/// here standalone so module assembly doesn't depend on optimizer
+/// internals.
+fn collect_address_taken(mir_program: &crate::ir::mir::MirProgram) -> Vec<String> {
+    use crate::ir::mir::{MirExpr, MirStrPart};
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut order: Vec<String> = Vec::new();
+    fn walk(
+        e: &crate::ir::mir::MirExpr,
+        seen: &mut std::collections::HashSet<String>,
+        order: &mut Vec<String>,
+    ) {
+        match e {
+            MirExpr::Literal(_) | MirExpr::Local(_) => {}
+            MirExpr::FnValue(name) => {
+                if seen.insert(name.clone()) {
+                    order.push(name.clone());
+                }
+            }
+            MirExpr::Let(l) => {
+                walk(&l.node.value.node, seen, order);
+                walk(&l.node.body.node, seen, order);
+            }
+            MirExpr::Call(c) => {
+                for a in &c.node.args {
+                    walk(&a.node, seen, order);
+                }
+            }
+            MirExpr::TailCall(tc) => {
+                for a in &tc.node.args {
+                    walk(&a.node, seen, order);
+                }
+            }
+            MirExpr::BinOp(b) => {
+                walk(&b.node.lhs.node, seen, order);
+                walk(&b.node.rhs.node, seen, order);
+            }
+            MirExpr::Neg(inner) | MirExpr::Try(inner) | MirExpr::Return(inner) => {
+                walk(&inner.node, seen, order);
+            }
+            MirExpr::Match(m) => {
+                walk(&m.node.subject.node, seen, order);
+                for arm in &m.node.arms {
+                    walk(&arm.body.node, seen, order);
+                }
+            }
+            MirExpr::Construct(c) => {
+                for a in &c.node.args {
+                    walk(&a.node, seen, order);
+                }
+            }
+            MirExpr::RecordCreate(r) => {
+                for field in &r.node.fields {
+                    walk(&field.value.node, seen, order);
+                }
+            }
+            MirExpr::RecordUpdate(u) => {
+                walk(&u.node.base.node, seen, order);
+                for field in &u.node.updates {
+                    walk(&field.value.node, seen, order);
+                }
+            }
+            MirExpr::Project(p) => walk(&p.node.base.node, seen, order),
+            MirExpr::IfThenElse(ite) => {
+                walk(&ite.node.cond.node, seen, order);
+                walk(&ite.node.then_branch.node, seen, order);
+                walk(&ite.node.else_branch.node, seen, order);
+            }
+            MirExpr::List(items) | MirExpr::Tuple(items) => {
+                for i in items {
+                    walk(&i.node, seen, order);
+                }
+            }
+            MirExpr::MapLiteral(pairs) => {
+                for (k, v) in pairs {
+                    walk(&k.node, seen, order);
+                    walk(&v.node, seen, order);
+                }
+            }
+            MirExpr::InterpolatedStr(parts) => {
+                for p in parts {
+                    if let MirStrPart::Expr(e) = p {
+                        walk(&e.node, seen, order);
+                    }
+                }
+            }
+            MirExpr::IndependentProduct(ip) => {
+                for i in &ip.node.items {
+                    walk(&i.node, seen, order);
+                }
+            }
+        }
+    }
+    // Deterministic fn order — sort by FnId so the table index assigned
+    // to each name is stable across runs (HashMap iteration is not).
+    let mut fns: Vec<(&crate::ir::FnId, &crate::ir::mir::MirFn)> = mir_program.iter().collect();
+    fns.sort_by_key(|(id, _)| **id);
+    for (_, mir_fn) in fns {
+        walk(&mir_fn.body.node, &mut seen, &mut order);
+    }
+    order
+}
+
+/// Collect the unique `call_indirect` functypes the program needs: for
+/// every `MirCallee::LocalSlot { name, .. }` call site, find the
+/// enclosing fn's `Fn(..)` param whose name matches and lower its sig
+/// to `(params, results)` + a dedupe key. Returns
+/// `(key, (params, results))` per unique functype, in first-seen order.
+/// LocalSlot names that are NOT a `Fn`-typed param (let-bound fn
+/// values) are skipped — those call sites fall back to the trap stub.
+///
+/// `fn_params_by_id` resolves a `FnId` to the enclosing fn's params as
+/// real `Type`s — the SAME `(String, Type)` slice `EmitCtx::params`
+/// (the call-site key source) holds, so the key the body emitter
+/// recomputes hits the entry registered here. (The `MirParam::ty`
+/// string is a `{:?}` debug form, not parseable, so it can't be used.)
+#[allow(clippy::type_complexity)]
+fn collect_call_indirect_sigs(
+    mir_program: &crate::ir::mir::MirProgram,
+    fn_params_by_id: &HashMap<crate::ir::FnId, &[(String, crate::types::Type)]>,
+    registry: &super::types::TypeRegistry,
+) -> Result<Vec<(String, (Vec<ValType>, Vec<ValType>))>, WasmGcError> {
+    use crate::ir::mir::{MirCallee, MirExpr, MirStrPart};
+    use crate::types::Type;
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out: Vec<(String, (Vec<ValType>, Vec<ValType>))> = Vec::new();
+
+    // Walk `e`, calling `note(name)` for every `LocalSlot` callee name.
+    fn walk(e: &crate::ir::mir::MirExpr, note: &mut dyn FnMut(&str)) {
+        match e {
+            MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
+            MirExpr::Let(l) => {
+                walk(&l.node.value.node, note);
+                walk(&l.node.body.node, note);
+            }
+            MirExpr::Call(c) => {
+                if let MirCallee::LocalSlot { name, .. } = &c.node.callee {
+                    note(name);
+                }
+                for a in &c.node.args {
+                    walk(&a.node, note);
+                }
+            }
+            MirExpr::TailCall(tc) => {
+                for a in &tc.node.args {
+                    walk(&a.node, note);
+                }
+            }
+            MirExpr::BinOp(b) => {
+                walk(&b.node.lhs.node, note);
+                walk(&b.node.rhs.node, note);
+            }
+            MirExpr::Neg(inner) | MirExpr::Try(inner) | MirExpr::Return(inner) => {
+                walk(&inner.node, note)
+            }
+            MirExpr::Match(m) => {
+                walk(&m.node.subject.node, note);
+                for arm in &m.node.arms {
+                    walk(&arm.body.node, note);
+                }
+            }
+            MirExpr::Construct(c) => {
+                for a in &c.node.args {
+                    walk(&a.node, note);
+                }
+            }
+            MirExpr::RecordCreate(r) => {
+                for field in &r.node.fields {
+                    walk(&field.value.node, note);
+                }
+            }
+            MirExpr::RecordUpdate(u) => {
+                walk(&u.node.base.node, note);
+                for field in &u.node.updates {
+                    walk(&field.value.node, note);
+                }
+            }
+            MirExpr::Project(p) => walk(&p.node.base.node, note),
+            MirExpr::IfThenElse(ite) => {
+                walk(&ite.node.cond.node, note);
+                walk(&ite.node.then_branch.node, note);
+                walk(&ite.node.else_branch.node, note);
+            }
+            MirExpr::List(items) | MirExpr::Tuple(items) => {
+                for i in items {
+                    walk(&i.node, note);
+                }
+            }
+            MirExpr::MapLiteral(pairs) => {
+                for (k, v) in pairs {
+                    walk(&k.node, note);
+                    walk(&v.node, note);
+                }
+            }
+            MirExpr::InterpolatedStr(parts) => {
+                for p in parts {
+                    if let MirStrPart::Expr(e) = p {
+                        walk(&e.node, note);
+                    }
+                }
+            }
+            MirExpr::IndependentProduct(ip) => {
+                for i in &ip.node.items {
+                    walk(&i.node, note);
+                }
+            }
+        }
+    }
+
+    let mut fns: Vec<(&crate::ir::FnId, &crate::ir::mir::MirFn)> = mir_program.iter().collect();
+    fns.sort_by_key(|(id, _)| **id);
+    for (fn_id, mir_fn) in fns {
+        let Some(params_real) = fn_params_by_id.get(fn_id) else {
+            continue;
+        };
+        // Per enclosing fn: collect every `LocalSlot` callee name.
+        let mut pending: Vec<String> = Vec::new();
+        walk(&mir_fn.body.node, &mut |name| {
+            pending.push(name.to_string())
+        });
+        for name in pending {
+            let Some((_, ty)) = params_real.iter().find(|(n, _)| *n == name) else {
+                // LocalSlot name isn't a param (let-bound fn value) →
+                // skip; that call site falls back to the trap stub.
+                continue;
+            };
+            let Type::Fn(args, ret, _) = ty else {
+                continue;
+            };
+            let (params, results) = super::types::fn_sig_wasm(args, ret, Some(registry))?;
+            let key = super::types::fn_sig_key(&params, &results);
+            if seen.insert(key.clone()) {
+                out.push((key, (params, results)));
+            }
+        }
+    }
+    Ok(out)
 }
 
 /// True iff any reachable fn body calls `String.split` or `String.join`.

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -1676,23 +1676,19 @@ pub(super) fn aver_to_wasm(
         })));
     }
 
-    // First-class Fn types reach the wasm-gc backend only through
-    // verify / oracle givens (`fn pairSpec(rnd: Fn(BranchPath, Int,
-    // Int, Int) -> Int) -> ...`). The body is dead from `_start` —
-    // verify blocks never execute in runtime — so the param slot just
-    // needs *some* representable carrier. `(ref null eq)` works the
-    // same way it does for `BranchPath`. Higher-order calls in real
-    // runtime code aren't supported on wasm-gc yet; if they reach
-    // here through `_start`, the validator will reject them at the
-    // call site and the user gets a clear error.
+    // First-class Fn values lower to an `i32` — a dense index into the
+    // module's single funcref table (table 0). Calling through a
+    // `Fn(..)` param emits `call_indirect` on that table (see
+    // `module.rs` table/element sections + `from_mir`'s `FnValue` /
+    // `LocalSlot` arms), mirroring the VM's symbol-id-value + dynamic
+    // dispatch. The index identifies the target fn; the `call_indirect`
+    // functype is pre-registered from the param's `Fn(..)` sig so it
+    // matches the target fn's own functype exactly. Verify / oracle
+    // givens (`fn pairSpec(rnd: Fn(BranchPath, Int, Int, Int) -> Int)`)
+    // whose bodies are dead from `_start` carry the same i32 slot
+    // harmlessly.
     if trimmed.starts_with("Fn(") {
-        return Ok(Some(ValType::Ref(RefType {
-            nullable: true,
-            heap_type: HeapType::Abstract {
-                shared: false,
-                ty: AbstractHeapType::Eq,
-            },
-        })));
+        return Ok(Some(ValType::I32));
     }
 
     // Compound types not yet lowered.
@@ -1742,6 +1738,37 @@ pub(super) fn param_types(
         }
     }
     Ok(out)
+}
+
+/// Lower a `Fn(args) -> ret` signature to the wasm `(params, results)`
+/// the matching direct call uses, so a `call_indirect` through a
+/// `Fn`-param resolves to a functype byte-identical to the target fn's
+/// own functype. Each arg lowers via `aver_to_wasm` (skipping `None` —
+/// `Unit` params contribute no wasm value), the result via
+/// `return_results`. SAME lowering the direct-call path
+/// (`param_types` / `return_results` in `module.rs`) uses.
+pub(super) fn fn_sig_wasm(
+    args: &[crate::ast::Type],
+    ret: &crate::ast::Type,
+    registry: Option<&TypeRegistry>,
+) -> Result<(Vec<ValType>, Vec<ValType>), WasmGcError> {
+    let mut params = Vec::with_capacity(args.len());
+    for a in args {
+        if let Some(v) = aver_to_wasm(&a.display(), registry)? {
+            params.push(v);
+        }
+    }
+    let results = return_results(&ret.display(), registry)?;
+    Ok((params, results))
+}
+
+/// Dedupe / lookup key for a `call_indirect` functype, derived from the
+/// LOWERED `ValType`s so the register-site (`module.rs`) and the
+/// call-site (`from_mir`) agree exactly. Both paths MUST build it via
+/// `fn_sig_wasm` + this helper from a `Type::Fn(args, ret, _)` — never
+/// hand-roll a second derivation.
+pub(super) fn fn_sig_key(params: &[ValType], results: &[ValType]) -> String {
+    format!("{params:?}=>{results:?}")
 }
 
 /// Build the `StructType` body for a record: one `FieldType` per

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -3655,10 +3655,10 @@ fn explain_wasm_gc_mir_coverage(mir: &aver::ir::mir::MirProgram, json: bool) {
     let report = aver::codegen::wasm_gc::coverage_report(mir);
     if json {
         println!(
-            "{{\"schema_version\":1,\"backend\":\"wasm-gc\",\"total\":{total},\"mir_covered\":{covered},\"hir_fallback\":{fallback},\"coverage_ratio\":{ratio:.4}}}",
+            "{{\"schema_version\":1,\"backend\":\"wasm-gc\",\"total\":{total},\"mir_covered\":{covered},\"trap_stub\":{fallback},\"coverage_ratio\":{ratio:.4}}}",
             total = report.total,
             covered = report.mir_covered,
-            fallback = report.hir_fallback,
+            fallback = report.trap_stub,
             ratio = report.ratio(),
         );
     } else {
@@ -3671,7 +3671,7 @@ fn explain_wasm_gc_mir_coverage(mir: &aver::ir::mir::MirProgram, json: bool) {
             report.mir_covered,
             report.ratio() * 100.0
         ));
-        out.push_str(&format!("HIR fallback:  {}\n", report.hir_fallback));
+        out.push_str(&format!("trap stub:     {}\n", report.trap_stub));
         print!("{out}");
     }
 }

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -996,3 +996,56 @@ fn main() -> Int
         4
     );
 }
+
+#[test]
+fn higher_order_fn_param_via_call_indirect() {
+    // First-class `Fn`-param: `inc` is passed as a value (FnValue → i32
+    // funcref-table index) and applied twice through the `f` param
+    // (LocalSlot → call_indirect). Previously the wasm-gc backend
+    // compiled this to an `unreachable` trap stub; it must now return
+    // inc(inc(5)) = 7, matching the VM.
+    assert_eq!(
+        run_int(
+            r#"
+module ApplyTwice
+
+fn inc(n: Int) -> Int
+    n + 1
+
+fn applyTwice(f: Fn(Int) -> Int, x: Int) -> Int
+    f(f(x))
+
+fn main() -> Int
+    applyTwice(inc, 5)
+"#
+        ),
+        7
+    );
+}
+
+#[test]
+fn higher_order_two_distinct_fn_values() {
+    // Two distinct address-taken fns → two funcref-table entries; both
+    // share one `call_indirect` functype (same `Fn(Int) -> Int` sig).
+    // inc(10) + dbl(10) = 11 + 20 = 31.
+    assert_eq!(
+        run_int(
+            r#"
+module Combine
+
+fn inc(n: Int) -> Int
+    n + 1
+
+fn dbl(n: Int) -> Int
+    n + n
+
+fn applyBoth(f: Fn(Int) -> Int, g: Fn(Int) -> Int, x: Int) -> Int
+    f(x) + g(x)
+
+fn main() -> Int
+    applyBoth(inc, dbl, 10)
+"#
+        ),
+        31
+    );
+}


### PR DESCRIPTION
## Problem

A legal param-position `Fn` value runs on the VM but the wasm-gc backend compiled it silently to an `unreachable` trap stub — `MirCallee::LocalSlot` had no lowering. So `fn applyTwice(f: Fn(Int) -> Int, x: Int) = f(f(x))` + `applyTwice(inc, 5)`: VM returns 7; `aver compile --target wasm-gc` succeeded with **no diagnostic** and `aver run --wasm-gc` **trapped**. An accept-then-trap backend divergence with no compile-time signal (found by the adversarial audit). User chose to **support** higher-order on wasm-gc (over rejecting at compile time).

## Approach

A `Fn` value lowers to an **`i32`** = dense index into a single module **funcref table** (table 0); a call through a `Fn`-param dispatches via **`call_indirect`** — mirroring the VM's symbol-id-value + dynamic dispatch.

- **types.rs:** `Fn(...)` → `ValType::I32`; shared `fn_sig_wasm` + `fn_sig_key` so the `call_indirect` functype is byte-identical to the target fn's own functype (same lowering used at the register-site and the call-site → keys always agree — the riskiest part, eliminated by construction).
- **module.rs:** scan the *optimized* MIR for address-taken fns (`FnValue`) and for `Fn`-param call sites (`LocalSlot`); pre-register one functype per distinct `Fn` signature in the Type section; build a funcref Table (after Function) + active Element segment (after Export); thread `name→table-index` and `sig-key→functype` maps into `FnMap`. Table-index assignment is **FnId-sorted** → deterministic output.
- **from_mir:** `FnValue(name)` → `i32.const <table idx>`; `LocalSlot` call → args, then the i32 index, then `call_indirect 0`.
- **coverage:** accept `LocalSlot`/`FnValue`; rename the stale `hir_fallback` field/label/JSON-key to `trap_stub` (the HIR walker is gone; it's a trap stub now).

Residual trap-stub cases (now the only ones): a `FnValue` of a builtin/variant, or a `LocalSlot` whose name is a *let-bound* fn value rather than a `Fn` param — flagged as follow-ups.

## Tests / verification (re-run locally, not taken on the implementer's word)

- New `wasm_gc_spec` tests: `applyTwice(inc,5) == 7` and `applyBoth(inc,dbl,10) == 31` run on wasm-gc under wasmtime, matching the VM.
- CLI: `aver run --wasm-gc` on the applyTwice program prints **7** (VM also 7); `AVER_WASMGC_REQUIRE_MIR=1` compiles with **no trap stub** (applyTwice + main genuinely MIR-emitted).
- Regression: `wasm_gc_spec` 33/33, `wasm_gc_codegen_regression`, **7/7 games** (`wasm_gc_games_differential_mir`), `wasm_gc_differential_mir` all green; default (no-wasm) build + lib 772/772; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)