### PR TITLE
vm: don't panic on a zero-arm match in MIR codegen (fuzz_verify_runner)

### DIFF
--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -611,6 +611,20 @@ pub(super) fn compile_mir_expr(
         }
         MirExpr::Match(spanned_match) => {
             let m = &spanned_match.node;
+            // A match with no arms can't produce a value — type-check
+            // rejects it as non-exhaustive, so reaching codegen with zero
+            // arms is an invariant violation, not user-reachable on valid
+            // input. Bail with a compile error rather than underflowing
+            // `arms.len() - 1` below (the `last_idx` computation). Found by
+            // the verify-runner fuzzer on a mutated program that slips a
+            // zero-arm match past the front-end.
+            if m.arms.is_empty() {
+                return Err(CompileError {
+                    msg: "match expression has no arms (non-exhaustive match reached codegen)"
+                        .to_string(),
+                }
+                .into());
+            }
             // Phase 6 wave 2 — try the MATCH_DISPATCH_CONST table
             // fast-path before falling back to the linear arm-by-
             // arm emit. When every non-last arm has a literal

--- a/tests/regressions/verify_runner/zero_arm_match_panics_mir_codegen.av
+++ b/tests/regressions/verify_runner/zero_arm_match_panics_mir_codegen.av
@@ -1,0 +1,18 @@
+module ResultUnit
+    intent =
+        "Minimal-ish repro for fuzz_verify_runner crashes id:000000-000007 (sig:06), an AFL byte-havoc mutation of a Result<Unit,_> verify seed. The mutated `main` body below parses to a `match` whose arms were dropped; the verify runner then walked it into the VM MIR compiler, which computed `arms.len() - 1` (the last-arm index) and panicked with usize subtract-with-overflow at vm/compiler/mir.rs. The MIR Match handler now bails with a CompileError on zero arms instead of underflowing, so the verify runner returns Err rather than aborting. Raw crash bytes kept verbatim so the exact parse/coverage path stays pinned."
+    effects []
+
+fn ensurePositive(n: Int) -> Result<Unit, String>
+    ? "Returns Ok(Unit) when n > 0, Err with reason otherwise."
+    match (n > 0)
+        true -> (Result).Ok(Unit)
+        false -> (Result).Err("non-positive")
+
+verify ensurePositive
+    ensurePositive(1) => (Result).Ok(Unit)
+    ensurePositive(0) => (Result).Err("non-positive")
+    ensurePositive((-5)) => (Result).Err("non-positive")
+
+fn main() -> Int
+ 4  match ensurePositive// ins      Resujn,Pw)e&	.?	1								Xcziho-Kapywq-FyuPn'c%	,=	Vector.getResult.Ok(d) -> 0*        Result.Err(_) -> 1


### PR DESCRIPTION
## Problem

The nightly **Fuzz** workflow went red: `fuzz_verify_runner` produced **8 crashes** (`sig:06`). Reproduced locally — `aver verify <crash>` panics:

```
thread 'main' panicked at src/vm/compiler/mir.rs:630:28:
attempt to subtract with overflow
```

A byte-havoc mutation of a `Result<Unit, _>` verify corpus seed produced a `match` whose arms were dropped. The VM MIR compiler computes `last_idx = arms.len() - 1`; with **zero arms** that underflows `usize`. Non-exhaustive matches are rejected by the type-checker, but the verify runner compiles the VM **regardless of type errors**, so a zero-arm match can still reach codegen. Pre-existing — `arms.len() - 1` dates to #274; AFL reached it stochastically (not caused by the recent soundness sweep, which the other 7 targets — incl. `codegen_wasm_gc` / `parity` — passed cleanly).

## Fix

Guard the MIR `Match` handler: a zero-arm match returns a `CompileError` instead of underflowing, so the verify runner returns `Err` (a legitimate "can't compile this") rather than aborting. The sibling `arms.len() - 1` at the bounded-form site is already guarded by an `arms.len() < 2` early return.

## Regression

The raw AFL crash input (verbatim, valid UTF-8) lands under `tests/regressions/verify_runner/`, run by the existing `verify_runner_regressions` harness through both the VM and wasm-gc verify paths. **Revert-tested**: it panics at `mir.rs:630` without the guard (test FAILS), passes with it. Covers all 8 crashes (same source seed).

The 13 AFL **hangs** in the same run are pre-existing non-blocking wall-clock noise (the step-limit already caps them) — not part of this fix.

Verified: lib 772/772, verify_runner_regressions 2/2 (VM + wasm-gc), fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)