### PR TITLE
mir: const-fold Int.div/Int.mod with a constant divisor to bare division (#434 static half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
-## 0.24.0 "Divide" — 2026-06-05
+## 0.24.0 "Divide" — 2026-06-06
 
 > _One middle-end under every backend; the last operator that could crash is now a function._
 
@@ -27,6 +27,7 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 - **MIR is now the only runtime middle-end.** The VM compiles exclusively through Core MIR (`src/ir/mir/`); the old ~2200-line HIR tree-walking compiler is gone — a function that can't lower to MIR is a hard error, not a silent second path. wasm-gc and wasip2 emit from MIR too (resolved-HIR fallback for shapes they don't yet cover) and run the shared `ir::mir::optimize()` passes, so one optimizer improves every backend at once.
 - **`match` on `Int.div`/`Int.mod`'s `Result` lowers on every backend.** The directly-consumed (boxed) form now builds the `Result<Int, String>` on wasm-gc and exports faithfully to Lean/Dafny (guarding the zero divisor so the `Err` arm is reachable), so the Ok/Err idiom is no longer VM-only.
+- **A constant divisor compiles `Int.div`/`Int.mod` down to bare division.** The MIR const-folder rewrites `Int.div(a, k)` for a literal `k ∉ {0, -1}` to `Result.Ok(a div_euclid k)`, then folds the consumer (`withDefault` / `match`) over the now-literal constructor — so `match Int.div(a, 10) { Ok / Err }` and `Result.withDefault(Int.div(a, 10), d)` lower to a plain Euclidean division on every backend. The explicit `Result`-returning function disappears when it provably can't fail.
 - **wasm-gc modules are byte-reproducible across builds.** Carrier type slots are now registered in sorted order instead of `HashMap`-iteration order.
 
 ## 0.23.0 "Shape" — 2026-05-30

--- a/src/codegen/dafny/expr.rs
+++ b/src/codegen/dafny/expr.rs
@@ -350,12 +350,25 @@ fn emit_fn_call(
             format!("{}({})", aver_name_to_dafny(name), a.join(", "))
         }
         ResolvedCallee::Intrinsic(intr) => {
-            // Compiler-synthesised `__buf_*` / `__to_str` intrinsics
-            // don't reach the Dafny backend in practice (Dafny emit
-            // doesn't see post-interp-lower buffer shapes), but the
-            // resolver carries them through; render as bare-name call.
+            use crate::ir::hir::BuiltinIntrinsic;
             let a: Vec<String> = args.iter().map(|e| emit_expr(e, ctx)).collect();
-            format!("{}({})", intr.name(), a.join(", "))
+            // Const-fold Euclidean div/mod: for a non-zero constant divisor
+            // these are total, and Dafny's `/` / `%` on `int` are Euclidean,
+            // so render the bare op. (MIR-synthesis-only; the Dafny backend
+            // reads HIR, so this is unreachable today — kept total + correct.)
+            match intr {
+                BuiltinIntrinsic::IntDivEuclid if a.len() == 2 => {
+                    format!("({} / {})", a[0], a[1])
+                }
+                BuiltinIntrinsic::IntModEuclid if a.len() == 2 => {
+                    format!("({} % {})", a[0], a[1])
+                }
+                // Compiler-synthesised `__buf_*` / `__to_str` intrinsics
+                // don't reach the Dafny backend in practice (Dafny emit
+                // doesn't see post-interp-lower buffer shapes), but the
+                // resolver carries them through; render as bare-name call.
+                _ => format!("{}({})", intr.name(), a.join(", ")),
+            }
         }
         ResolvedCallee::Fn(fn_id) => {
             let entry = ctx.symbol_table.fn_entry(*fn_id);

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -315,16 +315,28 @@ fn emit_fn_call(
             }
         }
         ResolvedCallee::Intrinsic(intr) => {
-            // Compiler-synthesised `__buf_*` / `__to_str` intrinsics
-            // don't reach the Lean backend in practice (Lean emit
-            // doesn't see post-interp-lower buffer shapes), but the
-            // resolver carries them through; render as bare-name
-            // call so the diagnostic stays traceable.
+            use crate::ir::hir::BuiltinIntrinsic;
             let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
-            if arg_strs.is_empty() {
-                intr.name().to_string()
-            } else {
-                format!("{} {}", intr.name(), arg_strs.join(" "))
+            // Const-fold Euclidean div/mod: for a non-zero constant divisor
+            // `Int.div` / `Int.mod` are total, and Lean's `/` / `%` are
+            // Euclidean on `Int`, so render the bare op. (These intrinsics
+            // are MIR-synthesis-only and the Lean backend reads HIR, so this
+            // is unreachable today — kept total + correct if a future path
+            // ever routes them through.)
+            match intr {
+                BuiltinIntrinsic::IntDivEuclid if arg_strs.len() == 2 => {
+                    format!("({} / {})", arg_strs[0], arg_strs[1])
+                }
+                BuiltinIntrinsic::IntModEuclid if arg_strs.len() == 2 => {
+                    format!("({} % {})", arg_strs[0], arg_strs[1])
+                }
+                // Compiler-synthesised `__buf_*` / `__to_str` intrinsics
+                // don't reach the Lean backend in practice (Lean emit
+                // doesn't see post-interp-lower buffer shapes), but the
+                // resolver carries them through; render as bare-name
+                // call so the diagnostic stays traceable.
+                _ if arg_strs.is_empty() => intr.name().to_string(),
+                _ => format!("{} {}", intr.name(), arg_strs.join(" ")),
             }
         }
         ResolvedCallee::Fn(fn_id) => {

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -3134,19 +3134,22 @@ fn emit_mir_builtin_call(
         "Int.mod" => {
             let a = arg!(0);
             let b = arg!(1);
+            // Error string verbatim from the VM (`src/types/int.rs`) so the
+            // boxed `Result.Err` is byte-identical across backends.
             format!(
-                "if ({b}) == 0i64 {{ Err(\"Int.mod: divisor must not be zero\".to_string()) }} else {{ Ok(({a}).rem_euclid({b})) }}"
+                "if ({b}) == 0i64 {{ Err(\"division by zero\".to_string()) }} else {{ Ok(({a}).rem_euclid({b})) }}"
             )
         }
         "Int.div" => {
             let a = arg!(0);
             let b = arg!(1);
-            // Euclidean division (partner of Euclidean `Int.mod`).
-            // `checked_div_euclid` is `None` on BOTH a zero divisor and the
-            // `i64::MIN / -1` signed-overflow edge; a bare `/` would panic
-            // (debug) or silently wrap (release) on the latter.
+            // Euclidean division (partner of Euclidean `Int.mod`). Split the
+            // two failure modes so the `Result.Err` strings match the VM /
+            // wasm-gc verbatim: `"division by zero"` for a zero divisor,
+            // `"division overflow"` for the `i64::MIN / -1` edge (the only
+            // input on which `checked_div_euclid` is `None` for `b != 0`).
             format!(
-                "match ({a}).checked_div_euclid({b}) {{ Some(__q) => Ok(__q), None => Err(\"Int.div: divisor zero or overflow\".to_string()) }}"
+                "if ({b}) == 0i64 {{ Err(\"division by zero\".to_string()) }} else {{ match ({a}).checked_div_euclid({b}) {{ Some(__q) => Ok(__q), None => Err(\"division overflow\".to_string()) }} }}"
             )
         }
 
@@ -3536,6 +3539,22 @@ fn emit_mir_intrinsic_call(
                 arg
             ))
         }
+        // Const-divisor Euclidean div/mod (0.24 "Divide"). The MIR
+        // const-fold pass only emits these for a literal divisor that
+        // rules out the partial / overflow cases, so `div_euclid` /
+        // `rem_euclid` are always defined — emit the bare i64 op, no
+        // `Result`. Same routines `Int.div` / `Int.mod` use in
+        // `src/types/int.rs`.
+        BuiltinIntrinsic::IntDivEuclid => {
+            let a = emit_mir_expr(&args[0], ctx)?;
+            let b = emit_mir_expr(&args[1], ctx)?;
+            Some(format!("({}).div_euclid({})", a, b))
+        }
+        BuiltinIntrinsic::IntModEuclid => {
+            let a = emit_mir_expr(&args[0], ctx)?;
+            let b = emit_mir_expr(&args[1], ctx)?;
+            Some(format!("({}).rem_euclid({})", a, b))
+        }
     }
 }
 
@@ -3782,7 +3801,7 @@ mod tests {
         let emit = emit_mir_expr(&expr, &ctx_with_builtin("Int.mod")).expect("Int.mod emits");
         assert_eq!(
             emit,
-            "(if (3i64) == 0i64 { Err(\"Int.mod: divisor must not be zero\".to_string()) } else { Ok((7i64).rem_euclid(3i64)) }).into_aver()"
+            "(if (3i64) == 0i64 { Err(\"division by zero\".to_string()) } else { Ok((7i64).rem_euclid(3i64)) }).into_aver()"
         );
     }
 

--- a/src/ir/hir/mod.rs
+++ b/src/ir/hir/mod.rs
@@ -376,6 +376,19 @@ pub enum BuiltinIntrinsic {
     /// `__to_str(<value>)` — coerce any value to its display string
     /// (used by interpolation lowering before `__buf_append`).
     ToStr,
+    /// `__int_div_euclid(<a>, <k>)` — unchecked Euclidean (flooring)
+    /// `(Int, Int) -> Int` division. Synthesised by the MIR `const_fold`
+    /// pass when `Int.div(a, k)`'s divisor `k` is a literal `Int` outside
+    /// `{0, -1}` (the partial cases that would `Err`), so the surrounding
+    /// `Result` wrap collapses to bare division. Never produced by the
+    /// resolver — there is no `from_name` mapping; it appears only in MIR.
+    IntDivEuclid,
+    /// `__int_mod_euclid(<a>, <k>)` — unchecked Euclidean modulo
+    /// `(Int, Int) -> Int`, partner of `IntDivEuclid` so that
+    /// `div(a,k)*k + mod(a,k) == a` for every sign. Synthesised by the
+    /// MIR `const_fold` pass for `Int.mod(a, k)` with a non-zero literal
+    /// divisor `k`.
+    IntModEuclid,
 }
 
 impl BuiltinIntrinsic {
@@ -388,12 +401,18 @@ impl BuiltinIntrinsic {
             Self::BufAppendSepUnlessFirst => "__buf_append_sep_unless_first",
             Self::BufFinalize => "__buf_finalize",
             Self::ToStr => "__to_str",
+            Self::IntDivEuclid => "__int_div_euclid",
+            Self::IntModEuclid => "__int_mod_euclid",
         }
     }
 
     /// Recognise a bare identifier as one of the known intrinsics.
     /// Returns `None` for anything else — the resolver then falls
     /// through to its regular fn / Unresolved classification.
+    ///
+    /// `IntDivEuclid` / `IntModEuclid` are deliberately absent: they are
+    /// MIR-synthesis-only (emitted by `const_fold`), never recognised
+    /// from a source / resolver identifier.
     pub fn from_name(name: &str) -> Option<Self> {
         match name {
             "__buf_new" => Some(Self::BufNew),

--- a/src/ir/mir/optimize/const_fold.rs
+++ b/src/ir/mir/optimize/const_fold.rs
@@ -6,11 +6,34 @@
 //! over matching `Int` / `Float` / `Bool` / `Str` / `Unit`
 //! literal pairs collapse to `Bool` literals; unary `Neg` on
 //! `Int` / `Float` literals preserves IEEE-754 `-0.0`.
+//!
+//! ## 0.24 "Divide" — const-divisor `Int.div` / `Int.mod`
+//!
+//! Two composing structural folds make the `Int.div` / `Int.mod`
+//! idiom zero-cost when the divisor is a compile-time constant:
+//!
+//! - **Fold A** rewrites `Int.div(a, k)` / `Int.mod(a, k)` with a
+//!   literal `Int` divisor into the bare Euclidean intrinsic wrapped
+//!   in a *known* `Result` constructor (or, for the partial cases,
+//!   directly into `Result.Err("division by zero")`). The `k == -1`
+//!   case for `Int.div` is deliberately left untouched — `i64::MIN /
+//!   -1` overflows, so it stays the runtime `Result`.
+//! - **Fold B** collapses a consumer (`Result.withDefault` /
+//!   `Option.withDefault`, or a `match`) applied to a statically-known
+//!   constructor, dropping the dead branch.
+//!
+//! Post-order traversal makes them cascade in one pass:
+//! `Result.withDefault(Int.div(a, 10), 0)` → A →
+//! `Result.withDefault(Result.Ok(IntDivEuclid(a, 10)), 0)` → B →
+//! `IntDivEuclid(a, 10)` — bare division, no `Result`, no dead branch.
 
 use crate::ast::{BinOp, Literal, Spanned};
+use crate::ir::hir::{BuiltinCtor, BuiltinIntrinsic};
+use crate::types::Type;
 
 use super::super::expr::{
-    MirBinOp, MirCall, MirConstruct, MirExpr, MirLet, MirMatchArm, MirPattern,
+    MirBinOp, MirCall, MirCallee, MirConstruct, MirCtor, MirExpr, MirLet, MirMatch, MirMatchArm,
+    MirPattern,
 };
 use super::super::program::MirProgram;
 
@@ -18,22 +41,36 @@ use super::super::program::MirProgram;
 /// (transformed) program by value so the caller can chain
 /// further optimization passes.
 pub fn const_fold(mut program: MirProgram) -> MirProgram {
+    // The structural folds (A / B) resolve `MirCallee::Builtin(id)` to
+    // its canonical name through `program.builtins`; clone the table out
+    // up front so the fn-body walk can hold a shared `&[String]` while it
+    // mutably borrows `program.fns`.
+    let builtins = program.builtins.clone();
     for mir_fn in program.fns.values_mut() {
-        fold_in_place(&mut mir_fn.body);
+        fold_in_place(&mut mir_fn.body, &builtins);
     }
     program
 }
 
 /// Post-order fold: rewrite children first, then try the
 /// current node — this lets a fold cascade up through nested
-/// arithmetic (`(1 + 2) * 3` → `3 * 3` → `9`).
-fn fold_in_place(expr: &mut Spanned<MirExpr>) {
-    walk_children(&mut expr.node);
+/// arithmetic (`(1 + 2) * 3` → `3 * 3` → `9`) and lets Fold A's
+/// constructor feed Fold B's consumer in a single bottom-up pass.
+fn fold_in_place(expr: &mut Spanned<MirExpr>, builtins: &[String]) {
+    walk_children(&mut expr.node, builtins);
     if let Some(folded) = try_fold(&expr.node) {
         // Preserve the original `Spanned`'s line + type stamp;
         // only the node shape changes.
         let span = literal_span(folded, expr);
         expr.node = MirExpr::Literal(span);
+    }
+    // Structural rewrites (Fold A / Fold B) that replace the node with
+    // a non-literal `MirExpr`. Runs after the literal fold so a literal
+    // node is never reconsidered structurally. Takes the whole `Spanned`
+    // so it can carry type stamps onto synthesised nodes — the wasm-gc
+    // backend panics on an un-typed node.
+    if let Some(replacement) = try_struct_fold(expr, builtins) {
+        *expr = replacement;
     }
 }
 
@@ -49,94 +86,94 @@ fn literal_span(lit: Literal, source: &Spanned<MirExpr>) -> Spanned<Literal> {
     }
 }
 
-fn walk_children(node: &mut MirExpr) {
+fn walk_children(node: &mut MirExpr, builtins: &[String]) {
     match node {
         MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Neg(inner) => fold_in_place(inner),
+        MirExpr::Neg(inner) => fold_in_place(inner, builtins),
         MirExpr::BinOp(spanned_bop) => {
             let bop: &mut MirBinOp = &mut spanned_bop.node;
-            fold_in_place(&mut bop.lhs);
-            fold_in_place(&mut bop.rhs);
+            fold_in_place(&mut bop.lhs, builtins);
+            fold_in_place(&mut bop.rhs, builtins);
         }
         MirExpr::Let(spanned_let) => {
             let let_node: &mut MirLet = &mut spanned_let.node;
-            fold_in_place(&mut let_node.value);
-            fold_in_place(&mut let_node.body);
+            fold_in_place(&mut let_node.value, builtins);
+            fold_in_place(&mut let_node.body, builtins);
         }
         MirExpr::Call(spanned_call) => {
             let call: &mut MirCall = &mut spanned_call.node;
             for arg in &mut call.args {
-                fold_in_place(arg);
+                fold_in_place(arg, builtins);
             }
         }
         MirExpr::TailCall(spanned_tc) => {
             for arg in &mut spanned_tc.node.args {
-                fold_in_place(arg);
+                fold_in_place(arg, builtins);
             }
         }
         MirExpr::Match(spanned_match) => {
-            fold_in_place(&mut spanned_match.node.subject);
+            fold_in_place(&mut spanned_match.node.subject, builtins);
             for arm in &mut spanned_match.node.arms {
-                fold_arm(arm);
+                fold_arm(arm, builtins);
             }
         }
         MirExpr::IfThenElse(spanned_ite) => {
-            fold_in_place(&mut spanned_ite.node.cond);
-            fold_in_place(&mut spanned_ite.node.then_branch);
-            fold_in_place(&mut spanned_ite.node.else_branch);
+            fold_in_place(&mut spanned_ite.node.cond, builtins);
+            fold_in_place(&mut spanned_ite.node.then_branch, builtins);
+            fold_in_place(&mut spanned_ite.node.else_branch, builtins);
         }
         MirExpr::Construct(spanned_ctor) => {
             let ctor: &mut MirConstruct = &mut spanned_ctor.node;
             for arg in &mut ctor.args {
-                fold_in_place(arg);
+                fold_in_place(arg, builtins);
             }
         }
         MirExpr::RecordCreate(spanned_rec) => {
             for f in &mut spanned_rec.node.fields {
-                fold_in_place(&mut f.value);
+                fold_in_place(&mut f.value, builtins);
             }
         }
         MirExpr::RecordUpdate(spanned_upd) => {
-            fold_in_place(&mut spanned_upd.node.base);
+            fold_in_place(&mut spanned_upd.node.base, builtins);
             for f in &mut spanned_upd.node.updates {
-                fold_in_place(&mut f.value);
+                fold_in_place(&mut f.value, builtins);
             }
         }
-        MirExpr::Project(spanned_proj) => fold_in_place(&mut spanned_proj.node.base),
-        MirExpr::Try(inner) => fold_in_place(inner),
-        MirExpr::Return(inner) => fold_in_place(inner),
+        MirExpr::Project(spanned_proj) => fold_in_place(&mut spanned_proj.node.base, builtins),
+        MirExpr::Try(inner) => fold_in_place(inner, builtins),
+        MirExpr::Return(inner) => fold_in_place(inner, builtins),
         MirExpr::List(items) | MirExpr::Tuple(items) => {
             for item in items {
-                fold_in_place(item);
+                fold_in_place(item, builtins);
             }
         }
         MirExpr::MapLiteral(entries) => {
             for (k, v) in entries {
-                fold_in_place(k);
-                fold_in_place(v);
+                fold_in_place(k, builtins);
+                fold_in_place(v, builtins);
             }
         }
         MirExpr::InterpolatedStr(parts) => {
             for part in parts {
                 if let super::super::expr::MirStrPart::Expr(e) = part {
-                    fold_in_place(e);
+                    fold_in_place(e, builtins);
                 }
             }
         }
         MirExpr::IndependentProduct(spanned_ip) => {
             for item in &mut spanned_ip.node.items {
-                fold_in_place(item);
+                fold_in_place(item, builtins);
             }
         }
     }
 }
 
-fn fold_arm(arm: &mut MirMatchArm) {
+fn fold_arm(arm: &mut MirMatchArm, builtins: &[String]) {
     // Don't recurse into the pattern — patterns are structural
     // and don't contain `MirExpr` subtrees.
     let _ = &arm.pattern;
     let _: &MirPattern = &arm.pattern;
-    fold_in_place(&mut arm.body);
+    fold_in_place(&mut arm.body, builtins);
 }
 
 fn try_fold(node: &MirExpr) -> Option<Literal> {
@@ -161,6 +198,378 @@ fn literal_of(node: &MirExpr) -> Option<&Literal> {
     } else {
         None
     }
+}
+
+// ── 0.24 "Divide" structural folds (A + B) ────────────────────────
+
+/// Verbatim error string for both `Int.div(_, 0)` and `Int.mod(_, 0)` —
+/// must match `src/types/int.rs`.
+const DIV_BY_ZERO: &str = "division by zero";
+
+/// Resolve the canonical name of a `MirCallee::Builtin` against the
+/// program's interned builtin table. Returns `None` for any other
+/// callee kind (or an out-of-range id).
+fn builtin_callee_name<'a>(callee: &MirCallee, builtins: &'a [String]) -> Option<&'a str> {
+    if let MirCallee::Builtin(id) = callee {
+        builtins.get(id.0 as usize).map(String::as_str)
+    } else {
+        None
+    }
+}
+
+/// Build a `Spanned<T>` carrying no line and no type stamp.
+fn bare<T>(node: T) -> Spanned<T> {
+    Spanned::bare(node)
+}
+
+/// Build a `Spanned<MirExpr>` stamped with `ty` (when known). The wasm-gc
+/// backend panics on an un-typed node, so every synthesised node a fold
+/// produces must carry the type its value will have at runtime.
+fn typed(node: MirExpr, ty: Option<&Type>) -> Spanned<MirExpr> {
+    let s = Spanned::bare(node);
+    if let Some(t) = ty {
+        s.set_ty(t.clone());
+    }
+    s
+}
+
+/// `IntDivEuclid` / `IntModEuclid` call over `(a, k)`, typed `Int`.
+fn euclid_call(
+    intrinsic: BuiltinIntrinsic,
+    a: Spanned<MirExpr>,
+    k: Spanned<MirExpr>,
+) -> Spanned<MirExpr> {
+    typed(
+        MirExpr::Call(bare(MirCall {
+            callee: MirCallee::Intrinsic(intrinsic),
+            args: vec![a, k],
+        })),
+        Some(&Type::Int),
+    )
+}
+
+/// `Builtin(ctor)(args…)` constructor node, stamped `result_ty` (the
+/// `Result<Int,String>` the original `Int.div` / `Int.mod` call carried).
+fn builtin_ctor(
+    ctor: BuiltinCtor,
+    args: Vec<Spanned<MirExpr>>,
+    result_ty: Option<&Type>,
+) -> Spanned<MirExpr> {
+    typed(
+        MirExpr::Construct(bare(MirConstruct {
+            ctor: MirCtor::Builtin(ctor),
+            args,
+        })),
+        result_ty,
+    )
+}
+
+/// `Result.Err("division by zero")`, stamped `result_ty`.
+fn div_by_zero_err(result_ty: Option<&Type>) -> Spanned<MirExpr> {
+    builtin_ctor(
+        BuiltinCtor::ResultErr,
+        vec![typed(
+            MirExpr::Literal(Spanned::bare(Literal::Str(DIV_BY_ZERO.to_string()))),
+            Some(&Type::Str),
+        )],
+        result_ty,
+    )
+}
+
+/// Structural rewrites that replace `*expr` with a *non-literal*
+/// `Spanned<MirExpr>`. Returns `Some(replacement)` to swap the node,
+/// `None` to leave it. Takes the whole `Spanned` so it can read the
+/// original type stamp and move sub-expressions out without cloning.
+fn try_struct_fold(expr: &mut Spanned<MirExpr>, builtins: &[String]) -> Option<Spanned<MirExpr>> {
+    fold_a_partial_int_builtin(expr, builtins).or_else(|| fold_b_consume_ctor(expr, builtins))
+}
+
+/// Fold A — const-fold `Int.div` / `Int.mod` with a literal divisor.
+///
+/// ```text
+/// Int.div, k ∉ {0, -1}  → Result.Ok(IntDivEuclid(a, k))
+/// Int.div, k == 0       → Result.Err("division by zero")
+/// Int.div, k == -1      → UNCHANGED (i64::MIN / -1 overflows)
+/// Int.mod, k != 0       → Result.Ok(IntModEuclid(a, k))
+/// Int.mod, k == 0       → Result.Err("division by zero")
+/// ```
+fn fold_a_partial_int_builtin(
+    expr: &mut Spanned<MirExpr>,
+    builtins: &[String],
+) -> Option<Spanned<MirExpr>> {
+    let MirExpr::Call(spanned_call) = &expr.node else {
+        return None;
+    };
+    let call = &spanned_call.node;
+    if call.args.len() != 2 {
+        return None;
+    }
+    let name = builtin_callee_name(&call.callee, builtins)?;
+    let is_div = match name {
+        "Int.div" => true,
+        "Int.mod" => false,
+        _ => return None,
+    };
+    // The divisor must be a literal `Int`.
+    let Literal::Int(k) = literal_of(&call.args[1].node)? else {
+        return None;
+    };
+    let k = *k;
+    // The wrapping `Result.Ok` / `Result.Err` keeps the original call's
+    // `Result<Int,String>` type stamp.
+    let result_ty = expr.ty().cloned();
+
+    let MirExpr::Call(spanned_call) = &mut expr.node else {
+        unreachable!("guarded above");
+    };
+    // Move the dividend + divisor out of the call (no clone).
+    let mut drain = std::mem::take(&mut spanned_call.node.args).into_iter();
+    let a = drain.next()?;
+    let divisor = drain.next()?;
+
+    Some(if is_div {
+        match k {
+            0 => div_by_zero_err(result_ty.as_ref()),
+            // `i64::MIN / -1` overflows → leave the runtime `Result`.
+            // (Restore the moved-out args first; the node stays a Call.)
+            -1 => {
+                spanned_call.node.args = vec![a, divisor];
+                return None;
+            }
+            _ => builtin_ctor(
+                BuiltinCtor::ResultOk,
+                vec![euclid_call(BuiltinIntrinsic::IntDivEuclid, a, divisor)],
+                result_ty.as_ref(),
+            ),
+        }
+    } else {
+        match k {
+            0 => div_by_zero_err(result_ty.as_ref()),
+            _ => builtin_ctor(
+                BuiltinCtor::ResultOk,
+                vec![euclid_call(BuiltinIntrinsic::IntModEuclid, a, divisor)],
+                result_ty.as_ref(),
+            ),
+        }
+    })
+}
+
+/// Fold B — collapse a consumer over a statically-known constructor.
+///
+/// - `Result.withDefault(Result.Ok(x), _)` → `x`
+/// - `Result.withDefault(Result.Err(_), d)` → `d`
+/// - `Option.withDefault(Option.Some(x), _)` → `x`
+/// - `Option.withDefault(Option.None, d)` → `d`
+/// - `match Construct(Builtin(C), ctor_args) { … }` → the first arm whose
+///   pattern statically matches `C`, with each `ctor_args[i]` bound to
+///   the arm's `i`-th field-binding via a wrapping `Let` (so every arg
+///   is evaluated exactly once).
+fn fold_b_consume_ctor(
+    expr: &mut Spanned<MirExpr>,
+    builtins: &[String],
+) -> Option<Spanned<MirExpr>> {
+    match &expr.node {
+        MirExpr::Call(_) => fold_b_with_default(expr, builtins),
+        MirExpr::Match(_) => fold_b_match_over_ctor(expr),
+        _ => None,
+    }
+}
+
+/// `Result.withDefault` / `Option.withDefault` over a known constructor.
+/// The surviving sub-expression (`x` or `d`) already carries its own type
+/// stamp from lowering, so the replacement is correctly typed.
+fn fold_b_with_default(
+    expr: &mut Spanned<MirExpr>,
+    builtins: &[String],
+) -> Option<Spanned<MirExpr>> {
+    let MirExpr::Call(spanned_call) = &expr.node else {
+        return None;
+    };
+    if spanned_call.node.args.len() != 2 {
+        return None;
+    }
+    let name = builtin_callee_name(&spanned_call.node.callee, builtins)?;
+    let is_result = match name {
+        "Result.withDefault" => true,
+        "Option.withDefault" => false,
+        _ => return None,
+    };
+    // The first arg must be a statically-known constructor of the
+    // matching sum type.
+    let MirExpr::Construct(inner) = &spanned_call.node.args[0].node else {
+        return None;
+    };
+    let MirCtor::Builtin(ctor) = inner.node.ctor else {
+        return None;
+    };
+    let take_payload = match (is_result, ctor) {
+        (true, BuiltinCtor::ResultOk) | (false, BuiltinCtor::OptionSome) => true,
+        (true, BuiltinCtor::ResultErr) | (false, BuiltinCtor::OptionNone) => false,
+        // A `Result` consumer over an `Option` ctor (or vice-versa)
+        // can't happen on well-typed input; leave it untouched.
+        _ => return None,
+    };
+
+    let MirExpr::Call(spanned_call) = &mut expr.node else {
+        unreachable!("guarded above");
+    };
+    let mut args = std::mem::take(&mut spanned_call.node.args).into_iter();
+    let ctor_arg = args.next()?; // the Construct
+    let default = args.next()?; // the default value
+
+    if take_payload {
+        // `Ok(x)` / `Some(x)` → the constructor's payload (already typed).
+        let MirExpr::Construct(inner) = ctor_arg.node else {
+            return None;
+        };
+        inner.node.args.into_iter().next()
+    } else {
+        // `Err(_)` / `None` → the default (already typed). The `Err`
+        // payload is dropped; it's pure (a literal / already-evaluated
+        // value), so no eval is lost.
+        Some(default)
+    }
+}
+
+/// `match Construct(Builtin(C), ctor_args) { arms }` over a statically
+/// known constructor: pick the first arm that matches `C` and rewrite to
+/// its body, threading each `ctor_arg` into the arm's field bindings.
+///
+/// All the recognition (subject is a known ctor, an arm matches) runs on
+/// the *borrowed* node first; the node is only moved out once a definite
+/// rewrite is committed, so there is no reconstruction / bail-restore.
+fn fold_b_match_over_ctor(expr: &mut Spanned<MirExpr>) -> Option<Spanned<MirExpr>> {
+    // The whole `match` value-type (the arm bodies' common type) — used to
+    // stamp the wrapping `Let`s so every synthesised node is typed.
+    let match_ty = expr.ty().cloned();
+
+    let MirExpr::Match(spanned_match) = &expr.node else {
+        return None;
+    };
+    // Subject must be a *literal* constructor (statically known).
+    let MirExpr::Construct(subj) = &spanned_match.node.subject.node else {
+        return None;
+    };
+    let MirCtor::Builtin(subj_ctor) = subj.node.ctor else {
+        return None;
+    };
+    let subj_arity = subj.node.args.len();
+
+    // Find the first arm that statically matches this constructor. A
+    // matching `Ctor` arm must agree on field count — well-typed input
+    // guarantees this, so a mismatch means "no match" (skip the arm)
+    // rather than a fold we'd have to undo.
+    let arm_idx = spanned_match
+        .node
+        .arms
+        .iter()
+        .position(|arm| arm_matches_ctor(&arm.pattern, subj_ctor, subj_arity))?;
+
+    // The subject's `Result` / `Option` type — used to re-stamp the ctor
+    // if the chosen arm binds the whole subject (`Bind`).
+    let subj_ty = spanned_match.node.subject.ty().cloned();
+
+    // Committed: move the match out and consume the subject + chosen arm.
+    let MirExpr::Match(spanned_match) = std::mem::replace(
+        &mut expr.node,
+        MirExpr::Literal(Spanned::bare(Literal::Unit)),
+    ) else {
+        unreachable!("guarded by the let-else above");
+    };
+    let MirMatch { subject, mut arms } = spanned_match.node;
+    let MirExpr::Construct(subj) = subject.node else {
+        unreachable!("guarded by the Construct check above");
+    };
+    let ctor_args = subj.node.args;
+    let arm = arms.swap_remove(arm_idx);
+
+    Some(match arm.pattern {
+        // `Ctor(Builtin(C), bindings)` — bind each field, then the body.
+        // Arity already checked by `arm_matches_ctor`.
+        MirPattern::Ctor {
+            bindings,
+            binding_names,
+            ..
+        } => wrap_in_lets(
+            &bindings,
+            &binding_names,
+            ctor_args,
+            arm.body,
+            match_ty.as_ref(),
+        ),
+        // `Bind(local, name)` — bind the whole subject value (the ctor).
+        MirPattern::Bind(local, name) => typed(
+            MirExpr::Let(bare(MirLet {
+                binding: local,
+                binding_name: name,
+                value: Box::new(builtin_ctor(subj_ctor, ctor_args, subj_ty.as_ref())),
+                body: Box::new(arm.body),
+            })),
+            match_ty.as_ref(),
+        ),
+        // `Wildcard` — body unchanged (subject is pure / discarded).
+        MirPattern::Wildcard => arm.body,
+        // `arm_matches_ctor` only returns `true` for the three arms
+        // above, so this is unreachable; return the body to stay total.
+        _ => arm.body,
+    })
+}
+
+/// Does `pattern` statically match constructor `ctor` with `arity`
+/// fields? Catch-alls (`Wildcard` / `Bind`) match any subject; a
+/// `Ctor` pattern matches only the *same* built-in variant with the
+/// same field count.
+fn arm_matches_ctor(pattern: &MirPattern, ctor: BuiltinCtor, arity: usize) -> bool {
+    match pattern {
+        MirPattern::Wildcard | MirPattern::Bind(_, _) => true,
+        MirPattern::Ctor {
+            ctor: MirCtor::Builtin(pc),
+            bindings,
+            ..
+        } => *pc == ctor && bindings.len() == arity,
+        _ => false,
+    }
+}
+
+/// Wrap `body` in one `Let` per constructor field, binding `bindings[i]`
+/// to `ctor_args[i]`. Evaluation order matches source: the outermost
+/// `Let` binds the first field, so args evaluate left-to-right, once each.
+///
+/// Each `Let` carries the pattern field's source binder name
+/// (`binding_names[i]`) — this is load-bearing: the wasm-gc / Rust
+/// backends resolve a `Let`'s slot by *name* (`self_local_slot`), and an
+/// empty name routes them down the synthetic-discard path that drops the
+/// value. The VM keys off `binding` (the `LocalId`). Each `Let` also
+/// carries the body's value type (`match_ty`) so wasm-gc has a stamp on
+/// every node.
+fn wrap_in_lets(
+    bindings: &[crate::ir::mir::LocalId],
+    binding_names: &[String],
+    ctor_args: Vec<Spanned<MirExpr>>,
+    body: Spanned<MirExpr>,
+    match_ty: Option<&Type>,
+) -> Spanned<MirExpr> {
+    let mut acc = body;
+    // Build inside-out: fold from the last field to the first so the
+    // first field ends up as the outermost (first-evaluated) `Let`.
+    let n = ctor_args.len();
+    for (i, (slot, arg)) in bindings.iter().zip(ctor_args).enumerate().rev() {
+        // `binding_names` is parallel to `bindings`; fall back to empty
+        // (synthetic) only if it's somehow short — never for well-typed
+        // input. `_ = n` keeps the index in range for the zip.
+        let name = binding_names.get(i).cloned().unwrap_or_default();
+        debug_assert!(i < n);
+        acc = typed(
+            MirExpr::Let(bare(MirLet {
+                binding: *slot,
+                binding_name: name,
+                value: Box::new(arg),
+                body: Box::new(acc),
+            })),
+            match_ty,
+        );
+    }
+    acc
 }
 
 fn fold_neg(lit: &Literal) -> Option<Literal> {
@@ -356,5 +765,323 @@ mod tests {
             &let_node.node.body.node,
             MirExpr::Literal(s) if matches!(s.node, Literal::Int(7))
         ));
+    }
+
+    // ── 0.24 "Divide" Fold A / Fold B ─────────────────────────────
+
+    use super::super::super::expr::MirLocal;
+    use super::super::super::program::LocalId;
+    use crate::ir::BuiltinId;
+
+    fn int_lit(n: i64) -> Spanned<MirExpr> {
+        span(MirExpr::Literal(span(Literal::Int(n))))
+    }
+
+    /// Build a one-fn program whose body is `body`, with `builtin_name`
+    /// interned at `BuiltinId(0)` so a `MirCallee::Builtin(BuiltinId(0))`
+    /// inside `body` resolves to it during `const_fold`.
+    fn program_with_builtin(builtin_name: &str, body: MirExpr) -> MirProgram {
+        let mut p = one_fn_program(body);
+        let id = p.intern_builtin(builtin_name);
+        assert_eq!(id, BuiltinId(0), "test assumes the first interned id");
+        p
+    }
+
+    fn builtin_call(args: Vec<Spanned<MirExpr>>) -> MirExpr {
+        MirExpr::Call(span(MirCall {
+            callee: MirCallee::Builtin(BuiltinId(0)),
+            args,
+        }))
+    }
+
+    // ---- Fold A ----
+
+    #[test]
+    fn fold_a_div_const_to_euclid_ok() {
+        // `Int.div(a, 10)` → `Result.Ok(IntDivEuclid(a, 10))`.
+        let body = builtin_call(vec![
+            span(MirExpr::Local(span(MirLocal::at(LocalId(0))))),
+            int_lit(10),
+        ]);
+        let folded = const_fold(program_with_builtin("Int.div", body));
+        let MirExpr::Construct(c) = body_of(&folded) else {
+            panic!("expected Result.Ok Construct, got {:?}", body_of(&folded));
+        };
+        assert!(matches!(
+            c.node.ctor,
+            MirCtor::Builtin(BuiltinCtor::ResultOk)
+        ));
+        let MirExpr::Call(inner) = &c.node.args[0].node else {
+            panic!("expected IntDivEuclid call");
+        };
+        assert!(matches!(
+            inner.node.callee,
+            MirCallee::Intrinsic(BuiltinIntrinsic::IntDivEuclid)
+        ));
+    }
+
+    #[test]
+    fn fold_a_div_by_zero_to_err() {
+        let body = builtin_call(vec![int_lit(99), int_lit(0)]);
+        let folded = const_fold(program_with_builtin("Int.div", body));
+        let MirExpr::Construct(c) = body_of(&folded) else {
+            panic!("expected Result.Err Construct");
+        };
+        assert!(matches!(
+            c.node.ctor,
+            MirCtor::Builtin(BuiltinCtor::ResultErr)
+        ));
+        let MirExpr::Literal(s) = &c.node.args[0].node else {
+            panic!("expected Err payload literal");
+        };
+        assert!(matches!(&s.node, Literal::Str(m) if m == "division by zero"));
+    }
+
+    #[test]
+    fn fold_a_div_by_minus_one_left_unchanged() {
+        // `i64::MIN / -1` overflows → the fold must NOT touch the node;
+        // it stays the runtime `Int.div` Builtin call.
+        let body = builtin_call(vec![int_lit(123), int_lit(-1)]);
+        let folded = const_fold(program_with_builtin("Int.div", body));
+        let MirExpr::Call(c) = body_of(&folded) else {
+            panic!("expected the Int.div Builtin call to survive");
+        };
+        assert!(matches!(c.node.callee, MirCallee::Builtin(BuiltinId(0))));
+        assert_eq!(c.node.args.len(), 2, "args must be restored intact");
+    }
+
+    #[test]
+    fn fold_a_mod_const_to_euclid_ok() {
+        // `Int.mod(a, 7)` → `Result.Ok(IntModEuclid(a, 7))` (any non-zero).
+        let body = builtin_call(vec![
+            span(MirExpr::Local(span(MirLocal::at(LocalId(0))))),
+            int_lit(7),
+        ]);
+        let folded = const_fold(program_with_builtin("Int.mod", body));
+        let MirExpr::Construct(c) = body_of(&folded) else {
+            panic!("expected Result.Ok Construct");
+        };
+        assert!(matches!(
+            c.node.ctor,
+            MirCtor::Builtin(BuiltinCtor::ResultOk)
+        ));
+        let MirExpr::Call(inner) = &c.node.args[0].node else {
+            panic!("expected IntModEuclid call");
+        };
+        assert!(matches!(
+            inner.node.callee,
+            MirCallee::Intrinsic(BuiltinIntrinsic::IntModEuclid)
+        ));
+    }
+
+    #[test]
+    fn fold_a_mod_by_zero_to_err() {
+        let body = builtin_call(vec![int_lit(5), int_lit(0)]);
+        let folded = const_fold(program_with_builtin("Int.mod", body));
+        let MirExpr::Construct(c) = body_of(&folded) else {
+            panic!("expected Result.Err Construct");
+        };
+        assert!(matches!(
+            c.node.ctor,
+            MirCtor::Builtin(BuiltinCtor::ResultErr)
+        ));
+    }
+
+    #[test]
+    fn fold_a_div_non_literal_divisor_unchanged() {
+        // Divisor is a Local, not a literal → no fold.
+        let body = builtin_call(vec![
+            int_lit(40),
+            span(MirExpr::Local(span(MirLocal::at(LocalId(1))))),
+        ]);
+        let folded = const_fold(program_with_builtin("Int.div", body));
+        assert!(matches!(body_of(&folded), MirExpr::Call(_)));
+    }
+
+    // ---- Fold B: withDefault ----
+
+    /// `Result.Ok(payload)` / `Result.Err(payload)` etc. constructor.
+    fn ctor(c: BuiltinCtor, args: Vec<Spanned<MirExpr>>) -> Spanned<MirExpr> {
+        span(MirExpr::Construct(span(MirConstruct {
+            ctor: MirCtor::Builtin(c),
+            args,
+        })))
+    }
+
+    #[test]
+    fn fold_b_result_withdefault_ok_takes_payload() {
+        // `Result.withDefault(Result.Ok(7), 0)` → `7`.
+        let body = builtin_call(vec![
+            ctor(BuiltinCtor::ResultOk, vec![int_lit(7)]),
+            int_lit(0),
+        ]);
+        let folded = const_fold(program_with_builtin("Result.withDefault", body));
+        assert!(
+            matches!(body_of(&folded), MirExpr::Literal(s) if matches!(s.node, Literal::Int(7)))
+        );
+    }
+
+    #[test]
+    fn fold_b_result_withdefault_err_takes_default() {
+        // `Result.withDefault(Result.Err("x"), 0)` → `0`.
+        let body = builtin_call(vec![
+            ctor(
+                BuiltinCtor::ResultErr,
+                vec![span(MirExpr::Literal(span(Literal::Str("x".into()))))],
+            ),
+            int_lit(0),
+        ]);
+        let folded = const_fold(program_with_builtin("Result.withDefault", body));
+        assert!(
+            matches!(body_of(&folded), MirExpr::Literal(s) if matches!(s.node, Literal::Int(0)))
+        );
+    }
+
+    #[test]
+    fn fold_b_option_withdefault_some_takes_payload() {
+        let body = builtin_call(vec![
+            ctor(BuiltinCtor::OptionSome, vec![int_lit(9)]),
+            int_lit(0),
+        ]);
+        let folded = const_fold(program_with_builtin("Option.withDefault", body));
+        assert!(
+            matches!(body_of(&folded), MirExpr::Literal(s) if matches!(s.node, Literal::Int(9)))
+        );
+    }
+
+    #[test]
+    fn fold_b_option_withdefault_none_takes_default() {
+        let body = builtin_call(vec![ctor(BuiltinCtor::OptionNone, vec![]), int_lit(42)]);
+        let folded = const_fold(program_with_builtin("Option.withDefault", body));
+        assert!(
+            matches!(body_of(&folded), MirExpr::Literal(s) if matches!(s.node, Literal::Int(42)))
+        );
+    }
+
+    // ---- Fold B: match over a known ctor ----
+
+    #[test]
+    fn fold_b_match_ok_binds_payload_in_let() {
+        // `match Result.Ok(x) { Ok(q) -> q ; Err(_) -> -1 }`
+        // → `let q = x; q`.
+        let subject = ctor(
+            BuiltinCtor::ResultOk,
+            vec![span(MirExpr::Local(span(MirLocal::at(LocalId(0)))))],
+        );
+        let ok_arm = MirMatchArm {
+            pattern: MirPattern::Ctor {
+                ctor: MirCtor::Builtin(BuiltinCtor::ResultOk),
+                bindings: vec![LocalId(1)],
+                binding_names: vec!["q".to_string()],
+            },
+            body: span(MirExpr::Local(span(MirLocal::at(LocalId(1))))),
+        };
+        let err_arm = MirMatchArm {
+            pattern: MirPattern::Ctor {
+                ctor: MirCtor::Builtin(BuiltinCtor::ResultErr),
+                bindings: vec![LocalId(2)],
+                binding_names: vec!["_".to_string()],
+            },
+            body: int_lit(-1),
+        };
+        let body = MirExpr::Match(span(MirMatch {
+            subject: Box::new(subject),
+            arms: vec![ok_arm, err_arm],
+        }));
+        let folded = const_fold(one_fn_program(body));
+        let MirExpr::Let(l) = body_of(&folded) else {
+            panic!("expected `let q = x; q`, got {:?}", body_of(&folded));
+        };
+        assert_eq!(l.node.binding, LocalId(1));
+        assert_eq!(l.node.binding_name, "q");
+        // value is the bound payload local (slot 0), body reads slot 1.
+        assert!(matches!(
+            &l.node.value.node,
+            MirExpr::Local(s) if s.node.slot == LocalId(0)
+        ));
+        assert!(matches!(
+            &l.node.body.node,
+            MirExpr::Local(s) if s.node.slot == LocalId(1)
+        ));
+    }
+
+    #[test]
+    fn fold_b_match_none_picks_nullary_arm_no_let() {
+        // `match Option.None { Some(v) -> v ; None -> 5 }` → `5`.
+        let subject = ctor(BuiltinCtor::OptionNone, vec![]);
+        let some_arm = MirMatchArm {
+            pattern: MirPattern::Ctor {
+                ctor: MirCtor::Builtin(BuiltinCtor::OptionSome),
+                bindings: vec![LocalId(1)],
+                binding_names: vec!["v".to_string()],
+            },
+            body: span(MirExpr::Local(span(MirLocal::at(LocalId(1))))),
+        };
+        let none_arm = MirMatchArm {
+            pattern: MirPattern::Ctor {
+                ctor: MirCtor::Builtin(BuiltinCtor::OptionNone),
+                bindings: vec![],
+                binding_names: vec![],
+            },
+            body: int_lit(5),
+        };
+        let body = MirExpr::Match(span(MirMatch {
+            subject: Box::new(subject),
+            arms: vec![some_arm, none_arm],
+        }));
+        let folded = const_fold(one_fn_program(body));
+        // No fields → no `Let`; the None arm's body folds in directly.
+        assert!(
+            matches!(body_of(&folded), MirExpr::Literal(s) if matches!(s.node, Literal::Int(5)))
+        );
+    }
+
+    #[test]
+    fn fold_b_match_non_literal_subject_unchanged() {
+        // Subject is a Local, not a Construct → no fold.
+        let body = MirExpr::Match(span(MirMatch {
+            subject: Box::new(span(MirExpr::Local(span(MirLocal::at(LocalId(0)))))),
+            arms: vec![MirMatchArm {
+                pattern: MirPattern::Wildcard,
+                body: int_lit(1),
+            }],
+        }));
+        let folded = const_fold(one_fn_program(body));
+        assert!(matches!(body_of(&folded), MirExpr::Match(_)));
+    }
+
+    #[test]
+    fn fold_a_then_b_compose_to_bare_euclid() {
+        // The end-to-end win:
+        // `Result.withDefault(Int.div(a, 10), 0)` → bare `IntDivEuclid(a, 10)`.
+        let mut p = one_fn_program(MirExpr::Literal(span(Literal::Unit)));
+        let div_id = p.intern_builtin("Int.div");
+        let wd_id = p.intern_builtin("Result.withDefault");
+        let inner_div = MirExpr::Call(span(MirCall {
+            callee: MirCallee::Builtin(div_id),
+            args: vec![
+                span(MirExpr::Local(span(MirLocal::at(LocalId(0))))),
+                int_lit(10),
+            ],
+        }));
+        let body = MirExpr::Call(span(MirCall {
+            callee: MirCallee::Builtin(wd_id),
+            args: vec![span(inner_div), int_lit(0)],
+        }));
+        p.fns.get_mut(&crate::ir::FnId(0)).unwrap().body = span(body);
+        let folded = const_fold(p);
+        let MirExpr::Call(c) = body_of(&folded) else {
+            panic!(
+                "expected bare IntDivEuclid call, got {:?}",
+                body_of(&folded)
+            );
+        };
+        assert!(
+            matches!(
+                c.node.callee,
+                MirCallee::Intrinsic(BuiltinIntrinsic::IntDivEuclid)
+            ),
+            "withDefault(Int.div(a, 10), 0) must fold to a bare Euclidean intrinsic"
+        );
     }
 }

--- a/src/vm/compiler/resolve_helpers.rs
+++ b/src/vm/compiler/resolve_helpers.rs
@@ -9,7 +9,8 @@ use crate::ir::hir::BuiltinIntrinsic;
 use crate::ir::identity::{FnId, FnKey};
 use crate::nan_value::NanValue;
 use crate::vm::opcode::{
-    BUFFER_APPEND_SEP_UNLESS_FIRST, BUFFER_APPEND_STR, BUFFER_FINALIZE, BUFFER_NEW,
+    BUFFER_APPEND_SEP_UNLESS_FIRST, BUFFER_APPEND_STR, BUFFER_FINALIZE, BUFFER_NEW, INT_DIV_EUCLID,
+    INT_MOD_EUCLID,
 };
 
 use super::{CompileError, FnCompiler};
@@ -19,12 +20,18 @@ use super::{CompileError, FnCompiler};
 /// empty trick instead of a dedicated opcode. The arity is checked
 /// at the callsite so a future intrinsic with a different shape
 /// can't accidentally re-use the wrong opcode.
+///
+/// Covers the deforestation buffer ops *and* the const-fold Euclidean
+/// div/mod intrinsics (`__int_div_euclid` / `__int_mod_euclid`), both
+/// 2-arg → push the unchecked Euclidean result.
 pub(super) fn buffer_intrinsic_opcode(intrinsic: BuiltinIntrinsic) -> Option<(u8, usize)> {
     match intrinsic {
         BuiltinIntrinsic::BufNew => Some((BUFFER_NEW, 1)),
         BuiltinIntrinsic::BufAppend => Some((BUFFER_APPEND_STR, 2)),
         BuiltinIntrinsic::BufAppendSepUnlessFirst => Some((BUFFER_APPEND_SEP_UNLESS_FIRST, 2)),
         BuiltinIntrinsic::BufFinalize => Some((BUFFER_FINALIZE, 1)),
+        BuiltinIntrinsic::IntDivEuclid => Some((INT_DIV_EUCLID, 2)),
+        BuiltinIntrinsic::IntModEuclid => Some((INT_MOD_EUCLID, 2)),
         BuiltinIntrinsic::ToStr => None,
     }
 }

--- a/src/vm/execute/dispatch.rs
+++ b/src/vm/execute/dispatch.rs
@@ -1766,6 +1766,25 @@ impl VM {
                     self.stack.push(str_value);
                 }
 
+                // Const-divisor Euclidean div/mod (0.24 "Divide"). The MIR
+                // const-fold pass only emits these when the divisor is a
+                // literal that rules out the partial / overflow cases, so
+                // `div_euclid` / `rem_euclid` are always defined here — no
+                // trap, mirroring `i64::div_euclid` / `i64::rem_euclid` in
+                // `src/types/int.rs`.
+                INT_DIV_EUCLID => {
+                    let b = self.stack.pop().ok_or(VmError::StackUnderflow)?;
+                    let a = self.stack.pop().ok_or(VmError::StackUnderflow)?;
+                    let r = a.as_int(&self.arena).div_euclid(b.as_int(&self.arena));
+                    self.stack.push(NanValue::new_int(r, &mut self.arena));
+                }
+                INT_MOD_EUCLID => {
+                    let b = self.stack.pop().ok_or(VmError::StackUnderflow)?;
+                    let a = self.stack.pop().ok_or(VmError::StackUnderflow)?;
+                    let r = a.as_int(&self.arena).rem_euclid(b.as_int(&self.arena));
+                    self.stack.push(NanValue::new_int(r, &mut self.arena));
+                }
+
                 UNWRAP_RESULT_OR => {
                     let default = self.stack.pop().ok_or(VmError::StackUnderflow)?;
                     let result = self.stack.pop().ok_or(VmError::StackUnderflow)?;

--- a/src/vm/opcode.rs
+++ b/src/vm/opcode.rs
@@ -390,6 +390,22 @@ pub const BUFFER_APPEND_SEP_UNLESS_FIRST: u8 = 0x92;
 /// Frees the underlying `vm.buffer_pool` slot; the handle becomes invalid.
 pub const BUFFER_FINALIZE: u8 = 0x93;
 
+// -- Const-divisor Euclidean div/mod (0.24 "Divide") -------------------------
+//
+// Emitted by the MIR `const_fold` pass for `Int.div(a, k)` / `Int.mod(a, k)`
+// with a literal divisor `k` whose value rules out the partial cases
+// (`k == 0` for both, plus `k == -1` for div, which the fold leaves as the
+// runtime Result). Both pop two `Int`s and push the unchecked Euclidean
+// result, mirroring `i64::div_euclid` / `i64::rem_euclid` — the same routines
+// `Int.div` / `Int.mod` use in `src/types/int.rs`.
+
+/// Pop b, pop a, push `a.div_euclid(b)` (Int). Caller guarantees `b ∉ {0, -1}`
+/// (the const-fold divisor check), so no trap / overflow is possible.
+pub const INT_DIV_EUCLID: u8 = 0x94;
+
+/// Pop b, pop a, push `a.rem_euclid(b)` (Int). Caller guarantees `b != 0`.
+pub const INT_MOD_EUCLID: u8 = 0x95;
+
 /// Opcode name for debug/disassembly.
 pub fn opcode_name(op: u8) -> &'static str {
     match op {
@@ -479,6 +495,8 @@ pub fn opcode_name(op: u8) -> &'static str {
         BUFFER_APPEND_STR => "BUFFER_APPEND_STR",
         BUFFER_APPEND_SEP_UNLESS_FIRST => "BUFFER_APPEND_SEP_UNLESS_FIRST",
         BUFFER_FINALIZE => "BUFFER_FINALIZE",
+        INT_DIV_EUCLID => "INT_DIV_EUCLID",
+        INT_MOD_EUCLID => "INT_MOD_EUCLID",
         CALL_PAR => "CALL_PAR",
         NOP => "NOP",
         _ => "UNKNOWN",
@@ -535,6 +553,8 @@ pub fn opcode_operand_width(op: u8, code: &[u8], ip: usize) -> usize {
         | BUFFER_APPEND_STR
         | BUFFER_APPEND_SEP_UNLESS_FIRST
         | BUFFER_FINALIZE
+        | INT_DIV_EUCLID
+        | INT_MOD_EUCLID
         | NOP => 0,
 
         // 1-byte


### PR DESCRIPTION
The static half of #434, for 0.24 "Divide". Completes #408's "partial ops are functions": when the divisor is a literal, `Int.div`/`Int.mod` provably can't fail (except `i64::MIN / -1`), so the MIR optimizer folds the `Result` round-trip away — the explicit Result-returning function disappears in the binary when it can't fail.

- **Fold A** (`const_fold`): `Int.div(a, k)` for literal `k ∉ {0, -1}` → `Result.Ok(<unchecked Euclidean div>)`; `k == 0` → `Result.Err("division by zero")`; `k == -1` left to the runtime path (can overflow). Same for `Int.mod`. The unchecked Euclidean div/mod is a new synthesis-only `BuiltinIntrinsic`, lowered per backend (VM opcodes, wasm-gc helpers, Rust `div_euclid`, Lean/Dafny `/`/`%`).
- **Fold B** (`const_fold`, general): `withDefault` / `match` over a literal `Result.Ok/Err` or `Option.Some/None` collapses to the payload / default / matching arm (ctor fields bound via `let`). Any sum type.

So `match Int.div(a, 10) { Ok / Err }` and `Result.withDefault(Int.div(a, 10), d)` lower to plain Euclidean division on VM, wasm-gc, and Rust — verified byte-identical incl. negative dividends; the `-1` overflow edge stays a runtime `Err`. The fused `IntDivOrDefaultLiteral` leaf-op is untouched (now only sees non-const divisors); retiring it + moving runtime fusion to MIR is the 0.25 follow-on (#434).

Also fixes a pre-existing cosmetic divergence: the Rust backend's boxed `Int.div`/`Int.mod` error strings now match VM/wasm-gc verbatim.

12 new `const_fold` unit tests; full VM / wasm-gc / Rust matrix + `proof_spec` green; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)