### PR TITLE
self-host: Int.div + float-literal interpolation lexing + replay Unit normalization

### DIFF
--- a/self_hosted/domain/builtins/primitives.av
+++ b/self_hosted/domain/builtins/primitives.av
@@ -12,6 +12,7 @@ fn callInt(name: String, args: List<Val>) -> Result<Val, String>
         "Int.fromString" -> builtinIntFromString(args)
         "Int.abs" -> builtinIntAbs(args)
         "Int.mod" -> builtinIntMod(args)
+        "Int.div" -> builtinIntDiv(args)
         "Int.max" -> builtinIntMax(args)
         "Int.min" -> builtinIntMin(args)
         _ -> Result.Err("unknown int builtin: {name}")
@@ -156,6 +157,29 @@ verify builtinIntModInner
     builtinIntModInner(Val.ValInt(7), Val.ValInt(3)) => Result.Ok(Val.ValOk(Val.ValInt(1)))
     builtinIntModInner(Val.ValInt(5), Val.ValInt(0)) => Result.Ok(Val.ValErr(Val.ValStr("modulo by zero")))
     builtinIntModInner(Val.ValStr("x"), Val.ValInt(3)) => Result.Err("expected int argument")
+
+fn builtinIntDiv(args: List<Val>) -> Result<Val, String>
+    ? "Int.div(a, b) -> a div b as a Result value."
+    pair = Domain.Builtins.Helpers.twoArgs(args)?
+    match pair
+        (aV, bV) -> builtinIntDivInner(aV, bV)
+
+verify builtinIntDiv
+    builtinIntDiv([Val.ValInt(7), Val.ValInt(2)]) => Result.Ok(Val.ValOk(Val.ValInt(3)))
+    builtinIntDiv([Val.ValInt(1)]) => Result.Err("expected 2 arguments")
+
+fn builtinIntDivInner(aV: Val, bV: Val) -> Result<Val, String>
+    ? "Inner impl of Int.div — Euclidean, Err on zero divisor or overflow."
+    a = Domain.Builtins.Helpers.expectInt(aV)?
+    b = Domain.Builtins.Helpers.expectInt(bV)?
+    match Int.div(a, b)
+        Result.Ok(q)  -> Result.Ok(Val.ValOk(Val.ValInt(q)))
+        Result.Err(e) -> Result.Ok(Val.ValErr(Val.ValStr(e)))
+
+verify builtinIntDivInner
+    builtinIntDivInner(Val.ValInt(7), Val.ValInt(2)) => Result.Ok(Val.ValOk(Val.ValInt(3)))
+    builtinIntDivInner(Val.ValInt(5), Val.ValInt(0)) => Result.Ok(Val.ValErr(Val.ValStr("division by zero")))
+    builtinIntDivInner(Val.ValStr("x"), Val.ValInt(3)) => Result.Err("expected int argument")
 
 fn builtinStringLen(args: List<Val>) -> Result<Val, String>
     ? "String.len(s) -> length as Int."

--- a/self_hosted/domain/lexer.av
+++ b/self_hosted/domain/lexer.av
@@ -328,12 +328,43 @@ verify tokenizeInterpString
     tokenizeInterpString("hi\"}", 0, "") => [Token.TkStr("hi"), Token.TkInterpEnd, Token.TkStr(""), Token.TkEof]
 
 fn tokenizeInterpDigit(src: String, pos: Int) -> List<Token>
-    ? "Read number inside interpolation."
+    ? "Read number inside interpolation; may be an int or a float literal."
     match Domain.Lexer.Chars.readNumber(src, pos, 0)
-        (n, newPos) -> List.prepend(Token.TkInt(n), tokenizeInterpExpr(src, newPos))
+        (n, newPos) -> tokenizeInterpAfterInt(src, newPos, n)
 
 verify tokenizeInterpDigit
     tokenizeInterpDigit("42}", 0) => [Token.TkInt(42), Token.TkInterpEnd, Token.TkStr(""), Token.TkEof]
+    tokenizeInterpDigit("3.5}", 0) => [Token.TkFloat(3.5), Token.TkInterpEnd, Token.TkStr(""), Token.TkEof]
+
+fn tokenizeInterpAfterInt(src: String, pos: Int, n: Int) -> List<Token>
+    ? "After integer part inside interpolation, check for a decimal point."
+    match String.charAt(src, pos)
+        Option.Some(c) -> match c == "."
+            true -> tokenizeInterpAfterIntDot(src, pos, n)
+            false -> List.prepend(Token.TkInt(n), tokenizeInterpExpr(src, pos))
+        Option.None -> List.prepend(Token.TkInt(n), tokenizeInterpExpr(src, pos))
+
+fn tokenizeInterpAfterIntDot(src: String, pos: Int, n: Int) -> List<Token>
+    ? "After integer and dot inside interpolation: digit -> float, else int + dot."
+    nextPos = pos + 1
+    match String.charAt(src, nextPos)
+        Option.Some(d) -> match Domain.Lexer.Chars.isDigit(d)
+            true -> tokenizeInterpFloat(src, nextPos, n)
+            false -> List.prepend(Token.TkInt(n), tokenizeInterpExpr(src, pos))
+        Option.None -> List.prepend(Token.TkInt(n), tokenizeInterpExpr(src, pos))
+
+fn tokenizeInterpFloat(src: String, pos: Int, intPart: Int) -> List<Token>
+    ? "Read decimal digits and build a float token inside interpolation."
+    match Domain.Lexer.Chars.readNumber(src, pos, 0)
+        (decPart, newPos) -> tokenizeInterpBuildFloat(src, newPos, intPart, decPart, newPos - pos)
+
+fn tokenizeInterpBuildFloat(src: String, pos: Int, intPart: Int, decPart: Int, decDigits: Int) -> List<Token>
+    ? "Construct a float from integer and decimal parts inside interpolation."
+    f = Float.fromInt(intPart) + Float.fromInt(decPart) / pow10(decDigits)
+    List.prepend(Token.TkFloat(f), tokenizeInterpExpr(src, pos))
+
+verify tokenizeInterpBuildFloat
+    tokenizeInterpBuildFloat("", 0, 3, 14, 2) => [Token.TkFloat(3.14), Token.TkInterpEnd, Token.TkEof]
 
 fn tokenizeInterpAlpha(src: String, pos: Int) -> List<Token>
     ? "Read identifier inside interpolation."

--- a/self_hosted/domain/resolver/calls.av
+++ b/self_hosted/domain/resolver/calls.av
@@ -199,6 +199,7 @@ fn isBuiltinCallName(name: String) -> Bool
         "HttpServer.listen",
         "HttpServer.listenWith",
         "Int.abs",
+        "Int.div",
         "Int.fromString",
         "Int.max",
         "Int.min",

--- a/src/codegen/rust/replay.rs
+++ b/src/codegen/rust/replay.rs
@@ -1432,6 +1432,23 @@ __POLICY_CHECK__
         ScopeMode::Normal
     }
 
+    fn canonical_unit(value: ReplayJson) -> ReplayJson {
+        // A Unit return serializes as JSON null in the VM / wasm-gc
+        // replay format; the self-host interpreter's value type wraps
+        // it as a `ValUnit` variant object. Map that variant back to
+        // null so a recording made by any backend replays cleanly on
+        // the self-host (and vice versa). Every other value passes
+        // through untouched.
+        if let ReplayJson::Object(ref map) = value {
+            if let Some(ReplayJson::Object(variant)) = map.get("$variant") {
+                if variant.get("name").and_then(|n| n.as_str()) == Some("ValUnit") {
+                    return ReplayJson::Null;
+                }
+            }
+        }
+        value
+    }
+
     fn finish_scope_success<T: ReplayValue>(value: &T) {
         SCOPE_STATE.with(|cell| {
             let mut state = cell.borrow_mut();
@@ -1442,7 +1459,7 @@ __POLICY_CHECK__
                 ScopeMode::Normal => {}
                 ScopeMode::Record { path, session } => {
                     session.output = RecordedOutcome::Value {
-                        value: value.to_replay_json(),
+                        value: canonical_unit(value.to_replay_json()),
                     };
                     write_recording(path, session);
                 }
@@ -1457,7 +1474,7 @@ __POLICY_CHECK__
                             session.effects.len().saturating_sub(*position)
                         );
                     }
-                    let actual_json = value.to_replay_json();
+                    let actual_json = canonical_unit(value.to_replay_json());
                     // Surface the live return value to the parent
                     // process via a stdout marker so the host
                     // (`run_self_host_replay` in

--- a/src/self_host/aver_generated/domain/ast/mod.rs
+++ b/src/self_host/aver_generated/domain/ast/mod.rs
@@ -2922,19 +2922,18 @@ pub fn ctorNameToTag(name: AverStr) -> i64 {
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Result.Ok" {
-            crate::aver_generated::domain::ast::tagResultOk()
+            1i64
         } else {
             if &*__dispatch_subject == "Result.Err" {
-                crate::aver_generated::domain::ast::tagResultErr()
+                2i64
             } else {
                 if &*__dispatch_subject == "Option.Some" {
-                    crate::aver_generated::domain::ast::tagOptionSome()
+                    3i64
                 } else {
                     if &*__dispatch_subject == "Option.None" {
-                        crate::aver_generated::domain::ast::tagOptionNone()
+                        4i64
                     } else {
-                        (crate::aver_generated::domain::ast::tagUserBase()
-                            + &crate::aver_generated::domain::ast::userCtorTagOffset(name))
+                        (100i64 + crate::aver_generated::domain::ast::userCtorTagOffset(name))
                     }
                 }
             }
@@ -2955,23 +2954,25 @@ pub fn userCtorTagOffsetLoop(mut name: AverStr, mut pos: i64, mut acc: i64) -> i
     loop {
         crate::cancel_checkpoint();
         let accPlusOne = (acc + 1i64);
-        return if (pos >= (name.chars().count() as i64)) {
-            accPlusOne
-        } else {
+        if (pos < (name.chars().count() as i64)) {
             match (name.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(ch) => {
-                    let __tmp1 = (pos + 1i64);
-                    let __tmp2 = crate::aver_generated::domain::ast::userCtorTagStep(
+                    let __tco1 = (pos + 1i64);
+                    let __tco2 = crate::aver_generated::domain::ast::userCtorTagStep(
                         acc,
                         (ch.chars().next().map(|c| c as i64).unwrap_or(0i64)),
                     );
-                    pos = __tmp1;
-                    acc = __tmp2;
+                    pos = __tco1;
+                    acc = __tco2;
                     continue;
                 }
-                None => accPlusOne,
+                None => {
+                    return accPlusOne;
+                }
             }
-        };
+        } else {
+            return accPlusOne;
+        }
     }
 }
 
@@ -2979,14 +2980,7 @@ pub fn userCtorTagOffsetLoop(mut name: AverStr, mut pos: i64, mut acc: i64) -> i
 pub fn userCtorTagStep(acc: i64, code: i64) -> i64 {
     crate::cancel_checkpoint();
     let next = ((acc * 131i64) + code);
-    {
-        let __b = crate::aver_generated::domain::ast::userTagSpan();
-        if __b == 0i64 {
-            0i64
-        } else {
-            (next).rem_euclid(__b)
-        }
-    }
+    (next).rem_euclid(1000003i64)
 }
 
 /// Map builtin function names to integer IDs for fast dispatch.

--- a/src/self_host/aver_generated/domain/builtins/list/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/list/mod.rs
@@ -157,16 +157,17 @@ pub fn builtinListDropInner(lstV: &Val, nV: &Val) -> Result<Val, AverStr> {
 pub fn listDrop(mut items: aver_rt::AverList<Val>, mut count: i64) -> aver_rt::AverList<Val> {
     loop {
         crate::cancel_checkpoint();
-        return if (count <= 0i64) {
-            items
-        } else {
-            aver_list_match!(items, [] => aver_rt::AverList::empty(), [_item, rest] => { {
-            let __tmp1 = (count - 1i64);
-            items = rest;
-            count = __tmp1;
+        if (count > 0i64) {
+            aver_list_match!(items, [] => { return aver_rt::AverList::empty(); }, [_item, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = (count - 1i64);
+            items = __tco0;
+            count = __tco1;
             continue;
         } })
-        };
+        } else {
+            return items;
+        }
     }
 }
 
@@ -224,10 +225,11 @@ pub fn builtinListContainsInner(lstV: &Val, needle: &Val) -> Result<Val, AverStr
 pub fn listContainsVal(mut items: aver_rt::AverList<Val>, mut needle: Val) -> bool {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(items, [] => false, [v, rest] => { if (crate::aver_generated::domain::value::valRepr(&v) == crate::aver_generated::domain::value::valRepr(&needle)) { true } else { {
-            items = rest;
+        aver_list_match!(items, [] => { return false; }, [v, rest] => { if (crate::aver_generated::domain::value::valRepr(&v) == crate::aver_generated::domain::value::valRepr(&needle)) { return true; } else { {
+            let __tco0 = rest;
+            items = __tco0;
             continue;
-        } } });
+        } } })
     }
 }
 
@@ -272,13 +274,15 @@ pub fn zipListsAcc(
     loop {
         crate::cancel_checkpoint();
         let reversed = acc.reverse();
-        return aver_list_match!(a, [] => reversed, [x, xs] => { aver_list_match!(b, [] => reversed, [y, ys] => { {
-            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValTuple(aver_rt::AverList::from_vec(vec![x, y])), &acc);
-            a = xs;
-            b = ys;
-            acc = __tmp2;
+        aver_list_match!(a, [] => { return reversed; }, [x, xs] => { aver_list_match!(b, [] => { return reversed; }, [y, ys] => { {
+            let __tco0 = xs;
+            let __tco1 = ys;
+            let __tco2 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValTuple(aver_rt::AverList::from_vec(vec![x, y])), &acc);
+            a = __tco0;
+            b = __tco1;
+            acc = __tco2;
             continue;
-        } }) });
+        } }) })
     }
 }
 
@@ -287,7 +291,7 @@ pub fn builtinListHead(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
-    aver_list_match!(items, [] => Ok(Val::ValNone.clone()), [h, rest] => Ok(crate::aver_generated::domain::value::Val::ValSome(std::sync::Arc::new(h))))
+    aver_list_match!(items, [] => Ok(crate::aver_generated::domain::value::Val::ValNone), [h, rest] => Ok(crate::aver_generated::domain::value::Val::ValSome(std::sync::Arc::new(h))))
 }
 
 /// List.tail(list) -> Option of rest.
@@ -295,5 +299,5 @@ pub fn builtinListTail(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
-    aver_list_match!(items, [] => Ok(Val::ValNone.clone()), [h, rest] => Ok(crate::aver_generated::domain::value::Val::ValSome(std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValList(rest)))))
+    aver_list_match!(items, [] => Ok(crate::aver_generated::domain::value::Val::ValNone), [h, rest] => Ok(crate::aver_generated::domain::value::Val::ValSome(std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValList(rest)))))
 }

--- a/src/self_host/aver_generated/domain/builtins/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/mod.rs
@@ -31,8 +31,12 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverMap<Aver
             __MutualTco1::TuplesToMap(mut items, mut acc) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(items, [] => { return acc }, [item, rest] => match item {
-                crate::aver_generated::domain::value::Val::ValTuple(parts) => __MutualTco1::TuplesToMapOne(parts, rest, acc),
-                _ => __MutualTco1::TuplesToMap(rest, acc)
+                    crate::aver_generated::domain::value::Val::ValTuple(parts) => {
+                        __MutualTco1::TuplesToMapOne(parts, rest, acc)
+                    },
+                    _ => {
+                        __MutualTco1::TuplesToMap(rest, acc)
+                    }
                 })
             }
             __MutualTco1::TuplesToMapOne(mut parts, mut rest, mut acc) => {
@@ -135,7 +139,7 @@ pub fn callBuiltinFast(
                                                         Some(crate::aver_generated::domain::builtins::vector::call(name, args))
                                                     } else {
                                                         if &*__dispatch_subject == "Option.None" {
-                                                            Some(Ok(Val::ValNone.clone()))
+                                                            Some(Ok(crate::aver_generated::domain::value::Val::ValNone))
                                                         } else {
                                                             if &*__dispatch_subject == "Option.Some"
                                                             {
@@ -235,7 +239,7 @@ pub fn callBuiltinByIdValues(id: i64, args: &aver_rt::AverList<Val>) -> Result<V
                                                         crate::aver_generated::domain::builtins::vector::call(AverStr::from("List.fromVector"), args)
                                                     } else {
                                                         if __dispatch_subject == 13i64 {
-                                                            Ok(Val::ValNone.clone())
+                                                            Ok(crate::aver_generated::domain::value::Val::ValNone)
                                                         } else {
                                                             if __dispatch_subject == 14i64 {
                                                                 crate::aver_generated::domain::builtins::wrappers::call(AverStr::from("Option.Some"), args)
@@ -371,7 +375,7 @@ pub fn callBuiltinOther(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<
                                                                             {
                                                                                 crate::aver_generated::domain::builtins::wrappers::call(name, args)
                                                                             } else {
-                                                                                if &*__dispatch_subject == "Result.Err" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Result.withDefault" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.Some" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.None" { Ok(Val::ValNone.clone()) } else { if &*__dispatch_subject == "Option.withDefault" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.toResult" { crate::aver_generated::domain::builtins::wrappers::callOptionToResult(args) } else { if &*__dispatch_subject == "Bool.or" { crate::aver_generated::domain::builtins::builtinBoolOr(args) } else { if &*__dispatch_subject == "Bool.and" { crate::aver_generated::domain::builtins::builtinBoolAnd(args) } else { if &*__dispatch_subject == "Bool.not" { crate::aver_generated::domain::builtins::builtinBoolNot(args) } else { if &*__dispatch_subject == "Map.set" { crate::aver_generated::domain::builtins::builtinMapSet(args) } else { if &*__dispatch_subject == "Map.get" { crate::aver_generated::domain::builtins::builtinMapGet(args) } else { if &*__dispatch_subject == "Map.has" { crate::aver_generated::domain::builtins::builtinMapHas(args) } else { if &*__dispatch_subject == "Map.entries" { crate::aver_generated::domain::builtins::builtinMapEntries(args) } else { if &*__dispatch_subject == "Map.keys" { crate::aver_generated::domain::builtins::builtinMapKeys(args) } else { if &*__dispatch_subject == "Map.values" { crate::aver_generated::domain::builtins::builtinMapValues(args) } else { if &*__dispatch_subject == "Map.fromList" { crate::aver_generated::domain::builtins::builtinMapFromList(args) } else { if &*__dispatch_subject == "Map.size" { crate::aver_generated::domain::builtins::builtinMapSize(args) } else { if &*__dispatch_subject == "Map.len" { crate::aver_generated::domain::builtins::builtinMapSize(args) } else { if &*__dispatch_subject == "Map.remove" { crate::aver_generated::domain::builtins::builtinMapRemove(args) } else { crate::aver_generated::domain::builtins::callBuiltinServices(name, args) } } } } } } } } } } } } } } } } } } }
+                                                                                if &*__dispatch_subject == "Result.Err" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Result.withDefault" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.Some" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.None" { Ok(crate::aver_generated::domain::value::Val::ValNone) } else { if &*__dispatch_subject == "Option.withDefault" { crate::aver_generated::domain::builtins::wrappers::call(name, args) } else { if &*__dispatch_subject == "Option.toResult" { crate::aver_generated::domain::builtins::wrappers::callOptionToResult(args) } else { if &*__dispatch_subject == "Bool.or" { crate::aver_generated::domain::builtins::builtinBoolOr(args) } else { if &*__dispatch_subject == "Bool.and" { crate::aver_generated::domain::builtins::builtinBoolAnd(args) } else { if &*__dispatch_subject == "Bool.not" { crate::aver_generated::domain::builtins::builtinBoolNot(args) } else { if &*__dispatch_subject == "Map.set" { crate::aver_generated::domain::builtins::builtinMapSet(args) } else { if &*__dispatch_subject == "Map.get" { crate::aver_generated::domain::builtins::builtinMapGet(args) } else { if &*__dispatch_subject == "Map.has" { crate::aver_generated::domain::builtins::builtinMapHas(args) } else { if &*__dispatch_subject == "Map.entries" { crate::aver_generated::domain::builtins::builtinMapEntries(args) } else { if &*__dispatch_subject == "Map.keys" { crate::aver_generated::domain::builtins::builtinMapKeys(args) } else { if &*__dispatch_subject == "Map.values" { crate::aver_generated::domain::builtins::builtinMapValues(args) } else { if &*__dispatch_subject == "Map.fromList" { crate::aver_generated::domain::builtins::builtinMapFromList(args) } else { if &*__dispatch_subject == "Map.size" { crate::aver_generated::domain::builtins::builtinMapSize(args) } else { if &*__dispatch_subject == "Map.len" { crate::aver_generated::domain::builtins::builtinMapSize(args) } else { if &*__dispatch_subject == "Map.remove" { crate::aver_generated::domain::builtins::builtinMapRemove(args) } else { crate::aver_generated::domain::builtins::callBuiltinServices(name, args) } } } } } } } } } } } } } } } } } } }
                                                                             }
                                                                         }
                                                                     }
@@ -406,7 +410,7 @@ pub fn builtinConsolePrint(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
             || aver_rt::console_print(&__effect_arg0),
         )
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Console.error(v) -> print to stderr.
@@ -422,7 +426,7 @@ pub fn builtinConsoleError(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
             || aver_rt::console_error(&__effect_arg0),
         )
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Console.warn(v) -> print warning.
@@ -438,7 +442,7 @@ pub fn builtinConsoleWarn(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
             || aver_rt::console_warn(&__effect_arg0),
         )
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Console.readLine() -> Result<String, String>.
@@ -511,7 +515,7 @@ pub fn builtinEnvGet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
         Some(value) => Ok(crate::aver_generated::domain::value::Val::ValSome(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(value)),
         )),
-        None => Ok(Val::ValNone.clone()),
+        None => Ok(crate::aver_generated::domain::value::Val::ValNone),
     }
 }
 
@@ -543,7 +547,7 @@ pub fn builtinEnvSetInner(keyV: &Val, valueV: &Val) -> Result<Val, AverStr> {
             || aver_rt::env_set(&__effect_arg0, &__effect_arg1).expect("Env.set failed"),
         )
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Convert list of strings to list of ValStr.
@@ -554,12 +558,13 @@ pub fn stringsToVals(
 ) -> aver_rt::AverList<Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(strs, [] => acc.reverse(), [s, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValStr(s), &acc);
-            strs = rest;
-            acc = __tmp1;
+        aver_list_match!(strs, [] => { return acc.reverse(); }, [s, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValStr(s), &acc);
+            strs = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -593,14 +598,13 @@ pub fn mapEntriesToTuples(
 ) -> aver_rt::AverList<Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(entries, [] => acc.reverse(), [pair, rest] => { match pair {
-            (k, v) => {
-            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValTuple(aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::value::Val::ValStr(k), v])), &acc);
-            entries = rest;
-            acc = __tmp1;
+        aver_list_match!(entries, [] => { return acc.reverse(); }, [pair, rest] => { { let (k, v) = pair; {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValTuple(aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::value::Val::ValStr(k), v])), &acc);
+            entries = __tco0;
+            acc = __tco1;
             continue;
-        }
-        } });
+        } } })
     }
 }
 
@@ -833,7 +837,7 @@ pub fn builtinHttpServerListenInner(portV: &Val, handlerV: &Val) -> Result<Val, 
             || crate::self_host_support::http_server_listen(__effect_arg0, __effect_arg1),
         )
     } {
-        Ok(_) => Ok(Val::ValUnit.clone()),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValUnit),
         Err(e) => Err(e),
     }
 }
@@ -896,7 +900,7 @@ pub fn builtinHttpServerListenWithInner(
             },
         )
     } {
-        Ok(_) => Ok(Val::ValUnit.clone()),
+        Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValUnit),
         Err(e) => Err(e),
     }
 }
@@ -945,7 +949,7 @@ pub fn builtinTimeSleep(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
             || aver_rt::time_sleep(__effect_arg0),
         )
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Time.unixMs() -> Int.
@@ -1016,7 +1020,7 @@ pub fn termClear() -> Result<Val, AverStr> {
             aver_rt::terminal_clear().unwrap()
         })
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Flush terminal output.
@@ -1028,7 +1032,7 @@ pub fn termFlush() -> Result<Val, AverStr> {
             aver_rt::terminal_flush().unwrap()
         })
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Enable terminal raw mode.
@@ -1040,7 +1044,7 @@ pub fn termEnableRawMode() -> Result<Val, AverStr> {
             aver_rt::terminal_enable_raw_mode().unwrap()
         })
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Disable terminal raw mode.
@@ -1052,7 +1056,7 @@ pub fn termDisableRawMode() -> Result<Val, AverStr> {
             aver_rt::terminal_disable_raw_mode().unwrap()
         })
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Hide terminal cursor.
@@ -1064,7 +1068,7 @@ pub fn termHideCursor() -> Result<Val, AverStr> {
             aver_rt::terminal_hide_cursor().unwrap()
         })
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Show terminal cursor.
@@ -1076,7 +1080,7 @@ pub fn termShowCursor() -> Result<Val, AverStr> {
             aver_rt::terminal_show_cursor().unwrap()
         })
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Reset terminal color.
@@ -1088,7 +1092,7 @@ pub fn termResetColor() -> Result<Val, AverStr> {
             aver_rt::terminal_reset_color().unwrap()
         })
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Terminal.readKey() -> Option<String>.
@@ -1103,7 +1107,7 @@ pub fn builtinTerminalReadKey(args: &aver_rt::AverList<Val>) -> Result<Val, Aver
         Some(k) => Ok(crate::aver_generated::domain::value::Val::ValSome(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(k)),
         )),
-        None => Ok(Val::ValNone.clone()),
+        None => Ok(crate::aver_generated::domain::value::Val::ValNone),
     }
 }
 
@@ -1164,7 +1168,7 @@ pub fn termPrintStr(s: AverStr) -> Result<Val, AverStr> {
             },
         )
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Terminal.setColor(color) -> Unit.
@@ -1181,7 +1185,7 @@ pub fn builtinTerminalSetColor(args: &aver_rt::AverList<Val>) -> Result<Val, Ave
             || aver_rt::terminal_set_color(&__effect_arg0).unwrap(),
         )
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Terminal.moveTo(x, y) -> Unit.
@@ -1212,7 +1216,7 @@ pub fn builtinTerminalMoveToInner(xV: &Val, yV: &Val) -> Result<Val, AverStr> {
             || aver_rt::terminal_move_to(__effect_arg0, __effect_arg1).unwrap(),
         )
     };
-    Ok(Val::ValUnit.clone())
+    Ok(crate::aver_generated::domain::value::Val::ValUnit)
 }
 
 /// Disk.writeText(path, content) -> Result.
@@ -1244,7 +1248,7 @@ pub fn builtinDiskWriteTextInner(pathV: &Val, contentV: &Val) -> Result<Val, Ave
         )
     } {
         Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
-            std::sync::Arc::new(Val::ValUnit.clone()),
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValUnit),
         )),
         Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
@@ -1281,7 +1285,7 @@ pub fn builtinDiskAppendTextInner(pathV: &Val, contentV: &Val) -> Result<Val, Av
         )
     } {
         Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
-            std::sync::Arc::new(Val::ValUnit.clone()),
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValUnit),
         )),
         Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
@@ -1304,7 +1308,7 @@ pub fn builtinDiskDelete(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
         )
     } {
         Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
-            std::sync::Arc::new(Val::ValUnit.clone()),
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValUnit),
         )),
         Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
@@ -1327,7 +1331,7 @@ pub fn builtinDiskDeleteDir(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
         )
     } {
         Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
-            std::sync::Arc::new(Val::ValUnit.clone()),
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValUnit),
         )),
         Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
@@ -1350,7 +1354,7 @@ pub fn builtinDiskMakeDir(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
         )
     } {
         Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
-            std::sync::Arc::new(Val::ValUnit.clone()),
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValUnit),
         )),
         Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
@@ -1444,27 +1448,29 @@ pub fn splitDottedLoop(
 ) -> Option<(AverStr, AverStr)> {
     loop {
         crate::cancel_checkpoint();
-        return if (pos >= total) {
-            None
-        } else {
+        if (pos < total) {
             match (name.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
-                    if (&*c == ".") {
-                        Some((
+                    if (c == AverStr::from(".")) {
+                        return Some((
                             (aver_rt::string_slice(&name, 0i64, pos)).into_aver(),
                             (aver_rt::string_slice(&name, (pos + 1i64), total)).into_aver(),
-                        ))
+                        ));
                     } else {
                         {
-                            let __tmp1 = (pos + 1i64);
-                            pos = __tmp1;
+                            let __tco1 = (pos + 1i64);
+                            pos = __tco1;
                             continue;
                         }
                     }
                 }
-                None => None,
+                None => {
+                    return None;
+                }
             }
-        };
+        } else {
+            return None;
+        }
     }
 }
 
@@ -1605,7 +1611,7 @@ pub fn builtinMapGetInner(mapV: &Val, keyV: &Val) -> Result<Val, AverStr> {
                 Some(v) => Ok(crate::aver_generated::domain::value::Val::ValSome(
                     std::sync::Arc::new(v),
                 )),
-                None => Ok(Val::ValNone.clone()),
+                None => Ok(crate::aver_generated::domain::value::Val::ValNone),
             }
         }
         _ => Err(AverStr::from("Map.get requires a Map")),
@@ -1890,17 +1896,19 @@ pub fn headersToValMap(
 ) -> aver_rt::AverMap<AverStr, Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(names, [] => acc, [name, rest] => { match headers.get(&name).cloned() { Some(values) => { {
-            let __tmp2 = acc.insert_owned(name, crate::aver_generated::domain::value::Val::ValList(crate::aver_generated::domain::builtins::stringsToValStrs(values, aver_rt::AverList::empty())));
-            names = rest;
-            acc = __tmp2;
+        aver_list_match!(names, [] => { return acc; }, [name, rest] => { match headers.get(&name).cloned() { Some(values) => { {
+            let __tco1 = rest;
+            let __tco2 = acc.insert_owned(name, crate::aver_generated::domain::value::Val::ValList(crate::aver_generated::domain::builtins::stringsToValStrs(values, aver_rt::AverList::empty())));
+            names = __tco1;
+            acc = __tco2;
             continue;
         } }, None => { {
-            let __tmp2 = acc.insert_owned(name, crate::aver_generated::domain::value::Val::ValList(aver_rt::AverList::empty()));
-            names = rest;
-            acc = __tmp2;
+            let __tco1 = rest;
+            let __tco2 = acc.insert_owned(name, crate::aver_generated::domain::value::Val::ValList(aver_rt::AverList::empty()));
+            names = __tco1;
+            acc = __tco2;
             continue;
-        } } } });
+        } } } })
     }
 }
 
@@ -1912,12 +1920,13 @@ pub fn stringsToValStrs(
 ) -> aver_rt::AverList<Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(values, [] => acc.reverse(), [v, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValStr(v), &acc);
-            values = rest;
-            acc = __tmp1;
+        aver_list_match!(values, [] => { return acc.reverse(); }, [v, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValStr(v), &acc);
+            values = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -2009,7 +2018,7 @@ pub fn builtinTcpPingInner(hostV: &Val, portV: &Val) -> Result<Val, AverStr> {
         )
     } {
         Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
-            std::sync::Arc::new(Val::ValUnit.clone()),
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValUnit),
         )),
         Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
@@ -2125,12 +2134,11 @@ pub fn valToTcpConnFields(
 pub fn lookupFieldVal(mut fields: aver_rt::AverList<(AverStr, Val)>, mut name: AverStr) -> Val {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fields, [] => Val::ValUnit, [pair, rest] => { match pair {
-            (k, v) => if (k == name) { v } else { {
-            fields = rest;
+        aver_list_match!(fields, [] => { return crate::aver_generated::domain::value::Val::ValUnit; }, [pair, rest] => { { let (k, v) = pair; if (k == name) { return v; } else { {
+            let __tco0 = rest;
+            fields = __tco0;
             continue;
-        } }
-        } });
+        } } } })
     }
 }
 
@@ -2163,7 +2171,7 @@ pub fn builtinTcpWriteLineInner(connV: &Val, lineV: &Val) -> Result<Val, AverStr
         )
     } {
         Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
-            std::sync::Arc::new(Val::ValUnit.clone()),
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValUnit),
         )),
         Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
@@ -2209,7 +2217,7 @@ pub fn builtinTcpClose(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
         )
     } {
         Ok(_) => Ok(crate::aver_generated::domain::value::Val::ValOk(
-            std::sync::Arc::new(Val::ValUnit.clone()),
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValUnit),
         )),
         Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),

--- a/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
@@ -26,26 +26,33 @@ pub fn callInt(name: AverStr, args: &aver_rt::AverList<Val>) -> Result<Val, Aver
                         if &*__dispatch_subject == "Int.mod" {
                             crate::aver_generated::domain::builtins::primitives::builtinIntMod(args)
                         } else {
-                            if &*__dispatch_subject == "Int.max" {
-                                crate::aver_generated::domain::builtins::primitives::builtinIntMax(
+                            if &*__dispatch_subject == "Int.div" {
+                                crate::aver_generated::domain::builtins::primitives::builtinIntDiv(
                                     args,
                                 )
                             } else {
-                                if &*__dispatch_subject == "Int.min" {
-                                    crate::aver_generated::domain::builtins::primitives::builtinIntMin(args)
+                                if &*__dispatch_subject == "Int.max" {
+                                    crate::aver_generated::domain::builtins::primitives::builtinIntMax(args)
                                 } else {
-                                    Err(aver_rt::AverStr::from({
-                                        let mut __b = {
-                                            let mut __b =
-                                                aver_rt::Buffer::with_capacity((37i64) as usize);
-                                            __b.push_str(&AverStr::from("unknown int builtin: "));
+                                    if &*__dispatch_subject == "Int.min" {
+                                        crate::aver_generated::domain::builtins::primitives::builtinIntMin(args)
+                                    } else {
+                                        Err(aver_rt::AverStr::from({
+                                            let mut __b = {
+                                                let mut __b = aver_rt::Buffer::with_capacity(
+                                                    (37i64) as usize,
+                                                );
+                                                __b.push_str(&AverStr::from(
+                                                    "unknown int builtin: ",
+                                                ));
+                                                __b
+                                            };
+                                            __b.push_str(&aver_rt::AverStr::from(
+                                                aver_rt::aver_display(&(name)),
+                                            ));
                                             __b
-                                        };
-                                        __b.push_str(&aver_rt::AverStr::from(
-                                            aver_rt::aver_display(&(name)),
-                                        ));
-                                        __b
-                                    }))
+                                        }))
+                                    }
                                 }
                             }
                         }
@@ -277,6 +284,40 @@ pub fn builtinIntModInner(aV: &Val, bV: &Val) -> Result<Val, AverStr> {
     }
 }
 
+/// Int.div(a, b) -> a div b as a Result value.
+pub fn builtinIntDiv(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
+    crate::cancel_checkpoint();
+    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    {
+        let (aV, bV) = pair;
+        crate::aver_generated::domain::builtins::primitives::builtinIntDivInner(&aV, &bV)
+    }
+}
+
+/// Inner impl of Int.div — Euclidean, Err on zero divisor or overflow.
+pub fn builtinIntDivInner(aV: &Val, bV: &Val) -> Result<Val, AverStr> {
+    crate::cancel_checkpoint();
+    let a = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
+    let b = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
+    match (if (b) == 0i64 {
+        Err("division by zero".to_string())
+    } else {
+        match (a).checked_div_euclid(b) {
+            Some(__q) => Ok(__q),
+            None => Err("division overflow".to_string()),
+        }
+    })
+    .into_aver()
+    {
+        Ok(q) => Ok(crate::aver_generated::domain::value::Val::ValOk(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValInt(q)),
+        )),
+        Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
+            std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
+        )),
+    }
+}
+
 /// String.len(s) -> length as Int.
 pub fn builtinStringLen(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
@@ -306,7 +347,7 @@ pub fn builtinStringCharAtInner(sV: &Val, idxV: &Val) -> Result<Val, AverStr> {
         Some(c) => Ok(crate::aver_generated::domain::value::Val::ValSome(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(c)),
         )),
-        None => Ok(Val::ValNone.clone()),
+        None => Ok(crate::aver_generated::domain::value::Val::ValNone),
     }
 }
 
@@ -342,15 +383,20 @@ pub fn extractStrings(
 ) -> Result<aver_rt::AverList<AverStr>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(items, [] => Ok(acc.reverse()), [v, rest] => { match v {
-            crate::aver_generated::domain::value::Val::ValStr(s) => {
-            let __tmp1 = aver_rt::AverList::prepend(s, &acc);
-            items = rest;
-            acc = __tmp1;
+        aver_list_match!(items, [] => { return Ok(acc.reverse()); }, [v, rest] => { match v {
+        crate::aver_generated::domain::value::Val::ValStr(s) => {
+            {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(s, &acc);
+            items = __tco0;
+            acc = __tco1;
             continue;
+        }
         },
-            _ => Err(AverStr::from("String.join requires list of strings"))
-        } });
+        _ => {
+            return Err(AverStr::from("String.join requires list of strings"));
+        }
+    } })
     }
 }
 
@@ -492,7 +538,7 @@ pub fn builtinCharFromCode(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr
         Some(c) => Ok(crate::aver_generated::domain::value::Val::ValSome(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(c)),
         )),
-        None => Ok(Val::ValNone.clone()),
+        None => Ok(crate::aver_generated::domain::value::Val::ValNone),
     }
 }
 
@@ -511,7 +557,13 @@ pub fn builtinIntFromString(args: &aver_rt::AverList<Val>) -> Result<Val, AverSt
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
-    match (s.parse::<i64>().map_err(|e| e.to_string())).into_aver() {
+    match ({
+        let __s = &(s);
+        __s.parse::<i64>()
+            .map_err(|_| format!("Cannot parse '{}' as Int", __s))
+    })
+    .into_aver()
+    {
         Ok(n) => Ok(crate::aver_generated::domain::value::Val::ValOk(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValInt(n)),
         )),
@@ -547,23 +599,25 @@ pub fn stringToCharList(
     loop {
         crate::cancel_checkpoint();
         let reversed = acc.reverse();
-        return if (pos >= total) {
-            reversed
-        } else {
+        if (pos < total) {
             match (s.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
-                    let __tmp1 = (pos + 1i64);
-                    let __tmp3 = aver_rt::AverList::prepend(
+                    let __tco1 = (pos + 1i64);
+                    let __tco3 = aver_rt::AverList::prepend(
                         crate::aver_generated::domain::value::Val::ValStr(c),
                         &acc,
                     );
-                    pos = __tmp1;
-                    acc = __tmp3;
+                    pos = __tco1;
+                    acc = __tco3;
                     continue;
                 }
-                None => reversed,
+                None => {
+                    return reversed;
+                }
             }
-        };
+        } else {
+            return reversed;
+        }
     }
 }
 
@@ -657,7 +711,13 @@ pub fn builtinFloatFromString(args: &aver_rt::AverList<Val>) -> Result<Val, Aver
     crate::cancel_checkpoint();
     let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
-    match (s.parse::<f64>().map_err(|e| e.to_string())).into_aver() {
+    match ({
+        let __s = &(s);
+        __s.parse::<f64>()
+            .map_err(|_| format!("Cannot parse '{}' as Float", __s))
+    })
+    .into_aver()
+    {
         Ok(f) => Ok(crate::aver_generated::domain::value::Val::ValOk(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValFloat(f)),
         )),
@@ -922,12 +982,13 @@ pub fn strPartsToVals(
 ) -> aver_rt::AverList<Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(parts, [] => acc.reverse(), [s, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValStr(s), &acc);
-            parts = rest;
-            acc = __tmp1;
+        aver_list_match!(parts, [] => { return acc.reverse(); }, [s, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::value::Val::ValStr(s), &acc);
+            parts = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -956,19 +1017,19 @@ pub fn builtinStringRepeatInner(sV: &Val, nV: &Val) -> Result<Val, AverStr> {
 pub fn repeatStr(mut s: AverStr, mut n: i64, mut acc: AverStr) -> AverStr {
     loop {
         crate::cancel_checkpoint();
-        return if (n <= 0i64) {
-            acc
-        } else {
+        if (n > 0i64) {
             {
-                let __tmp0 = s.clone();
-                let __tmp1 = (n - 1i64);
-                let __tmp2 = (acc + &s);
-                s = __tmp0;
-                n = __tmp1;
-                acc = __tmp2;
+                let __tco0 = s.clone();
+                let __tco1 = (n - 1i64);
+                let __tco2 = (acc + &s);
+                s = __tco0;
+                n = __tco1;
+                acc = __tco2;
                 continue;
             }
-        };
+        } else {
+            return acc;
+        }
     }
 }
 

--- a/src/self_host/aver_generated/domain/builtins/vector/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/vector/mod.rs
@@ -80,7 +80,7 @@ pub fn builtinVectorGet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
             Some(v) => Ok(crate::aver_generated::domain::value::Val::ValSome(
                 std::sync::Arc::new(v),
             )),
-            None => Ok(Val::ValNone.clone()),
+            None => Ok(crate::aver_generated::domain::value::Val::ValNone),
         },
         _ => Err(AverStr::from("Vector.get: expected (Vector, Int)")),
     }
@@ -124,12 +124,12 @@ pub fn builtinVectorSetInner(vecV: &Val, idxV: &Val, valV: &Val) -> Result<Val, 
             match idxV.clone() {
                 crate::aver_generated::domain::value::Val::ValInt(idx) => {
                     if (idx < 0i64) {
-                        Ok(Val::ValNone.clone())
+                        Ok(crate::aver_generated::domain::value::Val::ValNone)
                     } else {
                         if (idx < (vec.len() as i64)) {
                             crate::aver_generated::domain::builtins::vector::builtinVectorSetInBounds(&vec, idx, valV)
                         } else {
-                            Ok(Val::ValNone.clone())
+                            Ok(crate::aver_generated::domain::value::Val::ValNone)
                         }
                     }
                 }

--- a/src/self_host/aver_generated/domain/eval/common/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/common/mod.rs
@@ -45,14 +45,14 @@ pub fn propagationPrefix() -> AverStr {
 /// Mark a language-level Result.Err so function boundaries can convert it back into a value.
 pub fn wrapPropagatedError(msg: AverStr) -> AverStr {
     crate::cancel_checkpoint();
-    (crate::aver_generated::domain::eval::common::propagationPrefix() + &msg)
+    (AverStr::from("__aver_prop__:") + &msg)
 }
 
 /// Return the propagated payload when the evaluator error is an internal ? marker.
 #[inline(always)]
 pub fn unwrapPropagatedError(err: AverStr) -> Option<AverStr> {
     crate::cancel_checkpoint();
-    let prefix = crate::aver_generated::domain::eval::common::propagationPrefix();
+    let prefix = AverStr::from("__aver_prop__:");
     if err.starts_with(&*prefix) {
         Some(
             (aver_rt::string_slice(
@@ -92,11 +92,10 @@ pub fn lookupField(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fields, [] => Err((AverStr::from("unknown field: ") + &name)), [pair, rest] => { match pair {
-            (k, v) => if (k == name) { Ok(v) } else { {
-            fields = rest;
+        aver_list_match!(fields, [] => { return Err((AverStr::from("unknown field: ") + &name)); }, [pair, rest] => { { let (k, v) = pair; if (k == name) { return Ok(v); } else { {
+            let __tco0 = rest;
+            fields = __tco0;
             continue;
-        } }
-        } });
+        } } } })
     }
 }

--- a/src/self_host/aver_generated/domain/eval/core/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/core/mod.rs
@@ -393,7 +393,9 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                         __MutualTco3::EvalBoolBranch(cond, thenExpr, elseExpr, env, fns)
                     }
                     crate::aver_generated::domain::ast::Expr::ExprVar(name) => {
-                        return crate::aver_generated::domain::eval::core::evalVar(name, &env, &fns);
+                        return crate::aver_generated::domain::eval::core::evalVar(
+                            name, &env, &fns,
+                        );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprSlot(_) => {
                         return Err(AverStr::from("ExprSlot in map-based eval path"));

--- a/src/self_host/aver_generated/domain/eval/core/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/core/mod.rs
@@ -393,9 +393,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                         __MutualTco3::EvalBoolBranch(cond, thenExpr, elseExpr, env, fns)
                     }
                     crate::aver_generated::domain::ast::Expr::ExprVar(name) => {
-                        return crate::aver_generated::domain::eval::core::evalVar(
-                            name, &env, &fns,
-                        );
+                        return crate::aver_generated::domain::eval::core::evalVar(name, &env, &fns);
                     }
                     crate::aver_generated::domain::ast::Expr::ExprSlot(_) => {
                         return Err(AverStr::from("ExprSlot in map-based eval path"));
@@ -456,7 +454,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &BinOp::OpAdd,
+                            &crate::aver_generated::domain::ast::BinOp::OpAdd,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
@@ -467,7 +465,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &BinOp::OpSub,
+                            &crate::aver_generated::domain::ast::BinOp::OpSub,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
@@ -478,7 +476,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &BinOp::OpMul,
+                            &crate::aver_generated::domain::ast::BinOp::OpMul,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
@@ -489,7 +487,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &BinOp::OpDiv,
+                            &crate::aver_generated::domain::ast::BinOp::OpDiv,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprNeg(inner) => {
@@ -506,7 +504,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &CmpOp::CmpEq,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpEq,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
@@ -517,7 +515,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &CmpOp::CmpNeq,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpNeq,
                         );
                     }
                     _ => __MutualTco3::EvalExprAggregate(expr, env, fns),
@@ -534,7 +532,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &CmpOp::CmpLt,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpLt,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
@@ -545,7 +543,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &CmpOp::CmpGt,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpGt,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
@@ -556,7 +554,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &CmpOp::CmpLte,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpLte,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
@@ -567,7 +565,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                             &b,
                             &env,
                             &fns,
-                            &CmpOp::CmpGte,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpGte,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
@@ -687,16 +685,9 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                 crate::cancel_checkpoint();
                 match id {
                     15i64 => __MutualTco3::EvalOptionWithDefaultExpr(argExprs, env, fns),
-                    _ => match crate::aver_generated::domain::eval::core::evalArgs(
-                        &argExprs, &env, &fns,
-                    ) {
-                        Err(e) => return Err(e),
-                        Ok(args) => {
-                            return crate::aver_generated::domain::builtins::callBuiltinByIdValues(
-                                id, &args,
-                            );
-                        }
-                    },
+                    _ => {
+                        match crate::aver_generated::domain::eval::core::evalArgs(&argExprs, &env, &fns) { Err(e) => { return Err(e) }, Ok(args) => { return crate::aver_generated::domain::builtins::callBuiltinByIdValues(id, &args) } }
+                    }
                 }
             }
             __MutualTco3::EvalCallBuiltinMaybeSpecial(mut name, mut argExprs, mut env, mut fns) => {
@@ -1483,7 +1474,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &BinOp::OpAdd,
+                            &crate::aver_generated::domain::ast::BinOp::OpAdd,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprSub(a, b) => {
@@ -1495,7 +1486,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &BinOp::OpSub,
+                            &crate::aver_generated::domain::ast::BinOp::OpSub,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprMul(a, b) => {
@@ -1507,7 +1498,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &BinOp::OpMul,
+                            &crate::aver_generated::domain::ast::BinOp::OpMul,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprDiv(a, b) => {
@@ -1519,7 +1510,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &BinOp::OpDiv,
+                            &crate::aver_generated::domain::ast::BinOp::OpDiv,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprNeg(inner) => {
@@ -1537,7 +1528,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &CmpOp::CmpEq,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpEq,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprNeq(a, b) => {
@@ -1549,7 +1540,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &CmpOp::CmpNeq,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpNeq,
                         );
                     }
                     _ => __MutualTco4::EvalExprSlotAggregate(expr, env, slotMap, fns),
@@ -1567,7 +1558,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &CmpOp::CmpLt,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpLt,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprGt(a, b) => {
@@ -1579,7 +1570,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &CmpOp::CmpGt,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpGt,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
@@ -1591,7 +1582,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &CmpOp::CmpLte,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpLte,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprGte(a, b) => {
@@ -1603,7 +1594,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                             &env,
                             &slotMap,
                             &fns,
-                            &CmpOp::CmpGte,
+                            &crate::aver_generated::domain::ast::CmpOp::CmpGte,
                         );
                     }
                     crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
@@ -1647,14 +1638,30 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
             __MutualTco4::EvalExprSlotCalls(mut expr, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
-                crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, argExprs) => return crate::aver_generated::domain::eval::core::evalCallDirectSlot(fnId, &argExprs, &env, &slotMap, &fns),
-                crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, argExprs) => __MutualTco4::EvalCallBuiltinSlotMaybeSpecial(name, argExprs, env, slotMap, fns),
-                crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, argExprs) => __MutualTco4::EvalCallBuiltinByIdSlot(id, argExprs, env, slotMap, fns),
-                crate::aver_generated::domain::ast::Expr::ExprMatch(scrutinee, arms) => { let scrutinee = (*scrutinee).clone(); __MutualTco4::EvalMatchExprSlot(scrutinee, arms, env, slotMap, fns) },
-                crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => { let inner = (*inner).clone(); return crate::aver_generated::domain::eval::core::evalPropagateSlot(&inner, &env, &slotMap, &fns) },
-                crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => return crate::aver_generated::domain::eval::core::evalIndependentProductSlot(&exprs, unwrap, &env, &slotMap, &fns),
-                _ => return Err(aver_rt::AverStr::from({ let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((45i64) as usize); __b.push_str(&AverStr::from("unsupported slot expression: ")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(expr)))); __b }))
-                }
+        crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, argExprs) => {
+            return crate::aver_generated::domain::eval::core::evalCallDirectSlot(fnId, &argExprs, &env, &slotMap, &fns)
+        },
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, argExprs) => {
+            __MutualTco4::EvalCallBuiltinSlotMaybeSpecial(name, argExprs, env, slotMap, fns)
+        },
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, argExprs) => {
+            __MutualTco4::EvalCallBuiltinByIdSlot(id, argExprs, env, slotMap, fns)
+        },
+        crate::aver_generated::domain::ast::Expr::ExprMatch(scrutinee, arms) => {
+            let scrutinee = (*scrutinee).clone();
+            __MutualTco4::EvalMatchExprSlot(scrutinee, arms, env, slotMap, fns)
+        },
+        crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => {
+            let inner = (*inner).clone();
+            return crate::aver_generated::domain::eval::core::evalPropagateSlot(&inner, &env, &slotMap, &fns)
+        },
+        crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => {
+            return crate::aver_generated::domain::eval::core::evalIndependentProductSlot(&exprs, unwrap, &env, &slotMap, &fns)
+        },
+        _ => {
+            return Err(aver_rt::AverStr::from({ let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((45i64) as usize); __b.push_str(&AverStr::from("unsupported slot expression: ")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(expr)))); __b }))
+        }
+    }
             }
             __MutualTco4::EvalBoolBranchSlot(
                 mut cond,
@@ -1695,16 +1702,9 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
                     15i64 => {
                         __MutualTco4::EvalOptionWithDefaultExprSlot(argExprs, env, slotMap, fns)
                     }
-                    _ => match crate::aver_generated::domain::eval::core::evalArgsSlot(
-                        &argExprs, &env, &slotMap, &fns,
-                    ) {
-                        Err(e) => return Err(e),
-                        Ok(args) => {
-                            return crate::aver_generated::domain::builtins::callBuiltinByIdValues(
-                                id, &args,
-                            );
-                        }
-                    },
+                    _ => {
+                        match crate::aver_generated::domain::eval::core::evalArgsSlot(&argExprs, &env, &slotMap, &fns) { Err(e) => { return Err(e) }, Ok(args) => { return crate::aver_generated::domain::builtins::callBuiltinByIdValues(id, &args) } }
+                    }
                 }
             }
             __MutualTco4::EvalCallBuiltinSlotMaybeSpecial(
@@ -2423,10 +2423,16 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> Result<Val, AverStr> 
             }
             __MutualTco5::EvalStmtsSlot(mut stmts, mut env, mut slotMap, mut fns) => {
                 crate::cancel_checkpoint();
-                aver_list_match!(stmts, [] => { return Ok(Val::ValUnit.clone()) }, [stmt, rest] => match stmt {
-                crate::aver_generated::domain::ast::Stmt::StmtBindSlot(slot, e) => __MutualTco5::EvalStmtBindSlotNext(slot, e, rest, env, slotMap, fns),
-                crate::aver_generated::domain::ast::Stmt::StmtExpr(e) => __MutualTco5::EvalStmtExprSlotNext(e, rest, env, slotMap, fns),
-                crate::aver_generated::domain::ast::Stmt::StmtBind(name, e) => __MutualTco5::EvalStmtBindFallbackSlotNext(name, e, rest, env, slotMap, fns)
+                aver_list_match!(stmts, [] => { return Ok(crate::aver_generated::domain::value::Val::ValUnit) }, [stmt, rest] => match stmt {
+                    crate::aver_generated::domain::ast::Stmt::StmtBindSlot(slot, e) => {
+                        __MutualTco5::EvalStmtBindSlotNext(slot, e, rest, env, slotMap, fns)
+                    },
+                    crate::aver_generated::domain::ast::Stmt::StmtExpr(e) => {
+                        __MutualTco5::EvalStmtExprSlotNext(e, rest, env, slotMap, fns)
+                    },
+                    crate::aver_generated::domain::ast::Stmt::StmtBind(name, e) => {
+                        __MutualTco5::EvalStmtBindFallbackSlotNext(name, e, rest, env, slotMap, fns)
+                    }
                 })
             }
         };
@@ -2555,7 +2561,7 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<SlotTailStep, 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                aver_list_match!(stmts, [] => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(Val::ValUnit.clone())) }, [stmt, rest] => { { let __list_subject = rest.clone(); if __list_subject.is_empty() { return crate::aver_generated::domain::eval::core::evalTailStmtSlot(selfId, &stmt, slotCount, &env, &slotMap, &fns) } else { __MutualTco6::EvalStmtsSlotTailNext(selfId, stmt, rest, slotCount, env, slotMap, fns) } } })
+                aver_list_match!(stmts, [] => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(crate::aver_generated::domain::value::Val::ValUnit)) }, [stmt, rest] => { { let __list_subject = rest.clone(); if __list_subject.is_empty() { return crate::aver_generated::domain::eval::core::evalTailStmtSlot(selfId, &stmt, slotCount, &env, &slotMap, &fns) } else { __MutualTco6::EvalStmtsSlotTailNext(selfId, stmt, rest, slotCount, env, slotMap, fns) } } })
             }
             __MutualTco6::EvalStmtsSlotTailNext(
                 mut selfId,
@@ -2618,9 +2624,7 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<SlotTailStep, 
                 mut fns,
             ) => {
                 crate::cancel_checkpoint();
-                let _ = crate::aver_generated::domain::eval::core::evalExprSlot(
-                    &e, &env, &slotMap, &fns,
-                )?;
+                crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns)?;
                 __MutualTco6::EvalStmtsSlotTail(selfId, rest, slotCount, env, slotMap, fns)
             }
         };
@@ -2766,7 +2770,7 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<SlotTailStep, 
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, argExprs) => {
                         if (fnId == selfId) {
-                            match crate::aver_generated::domain::eval::core::evalArgsSlotToSlotEnv(argExprs, env, slotMap, fns, aver_rt::AverVector::new(slotCount as usize, Val::ValUnit.clone()), 0i64) { Ok(nextEnv) => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailRecurEnv(nextEnv)) }, Err(e) => { return Err(e) } }
+                            match crate::aver_generated::domain::eval::core::evalArgsSlotToSlotEnv(argExprs, env, slotMap, fns, aver_rt::AverVector::new(slotCount as usize, crate::aver_generated::domain::value::Val::ValUnit), 0i64) { Ok(nextEnv) => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailRecurEnv(nextEnv)) }, Err(e) => { return Err(e) } }
                         } else {
                             match crate::aver_generated::domain::eval::core::evalCallDirectSlot(fnId, &argExprs, &env, &slotMap, &fns) { Ok(v) => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v)) }, Err(e) => { return Err(e) } }
                         }
@@ -2789,16 +2793,9 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<SlotTailStep, 
                             selfId, scrutinee, arms, slotCount, env, slotMap, fns,
                         )
                     }
-                    _ => match crate::aver_generated::domain::eval::core::evalExprSlot(
-                        &expr, &env, &slotMap, &fns,
-                    ) {
-                        Ok(v) => return Ok(
-                            crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(
-                                v,
-                            ),
-                        ),
-                        Err(e) => return Err(e),
-                    },
+                    _ => {
+                        match crate::aver_generated::domain::eval::core::evalExprSlot(&expr, &env, &slotMap, &fns) { Ok(v) => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v)) }, Err(e) => { return Err(e) } }
+                    }
                 }
             }
             __MutualTco7::EvalTailBoolBranchSlot(
@@ -2970,9 +2967,7 @@ fn __mutual_tco_trampoline_8(mut __state: __MutualTco8) -> aver_rt::AverVector<V
         __state = match __state {
             __MutualTco8::MergeBindingsSlot(mut bindings, mut bindingSlots, mut env) => {
                 crate::cancel_checkpoint();
-                aver_list_match!(bindings, [] => { return env }, [pair, rest] => match pair {
-                (name, val) => __MutualTco8::MergeOneBindingSlot(name, val, rest, bindingSlots, env)
-                })
+                aver_list_match!(bindings, [] => { return env }, [pair, rest] => { { let (name, val) = pair; __MutualTco8::MergeOneBindingSlot(name, val, rest, bindingSlots, env) } })
             }
             __MutualTco8::MergeOneBindingSlot(
                 mut name,
@@ -3056,10 +3051,10 @@ pub fn evalVar(
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Unit" {
-            Ok(Val::ValUnit.clone())
+            Ok(crate::aver_generated::domain::value::Val::ValUnit)
         } else {
             if &*__dispatch_subject == "Option.None" {
-                Ok(Val::ValNone.clone())
+                Ok(crate::aver_generated::domain::value::Val::ValNone)
             } else {
                 match crate::aver_generated::domain::eval::store::lookupVar(env, name.clone()) {
                     Ok(v) => Ok(v),
@@ -3169,19 +3164,23 @@ pub fn splitIndependentExprs(
 ) -> (aver_rt::AverList<Expr>, aver_rt::AverList<Expr>) {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => (leftAcc.reverse(), rightAcc.reverse()), [expr, rest] => { if sendLeft { {
-            let __tmp1 = aver_rt::AverList::prepend(expr, &leftAcc);
-            exprs = rest;
-            leftAcc = __tmp1;
-            sendLeft = false;
+        aver_list_match!(exprs, [] => { return (leftAcc.reverse(), rightAcc.reverse()); }, [expr, rest] => { if sendLeft { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(expr, &leftAcc);
+            let __tco3 = false;
+            exprs = __tco0;
+            leftAcc = __tco1;
+            sendLeft = __tco3;
             continue;
         } } else { {
-            let __tmp2 = aver_rt::AverList::prepend(expr, &rightAcc);
-            exprs = rest;
-            rightAcc = __tmp2;
-            sendLeft = true;
+            let __tco0 = rest;
+            let __tco2 = aver_rt::AverList::prepend(expr, &rightAcc);
+            let __tco3 = true;
+            exprs = __tco0;
+            rightAcc = __tco2;
+            sendLeft = __tco3;
             continue;
-        } } });
+        } } })
     }
 }
 
@@ -3195,23 +3194,27 @@ pub fn interleaveIndependentVals(
 ) -> aver_rt::AverList<Val> {
     loop {
         crate::cancel_checkpoint();
-        return if takeLeft {
-            aver_list_match!(left, [] => crate::aver_generated::domain::eval::core::finishIndependentVals(right, acc), [v, rest] => { {
-            let __tmp3 = aver_rt::AverList::prepend(v, &acc);
-            left = rest;
-            takeLeft = false;
-            acc = __tmp3;
+        if takeLeft {
+            aver_list_match!(left, [] => { return crate::aver_generated::domain::eval::core::finishIndependentVals(right, acc); }, [v, rest] => { {
+            let __tco0 = rest;
+            let __tco2 = false;
+            let __tco3 = aver_rt::AverList::prepend(v, &acc);
+            left = __tco0;
+            takeLeft = __tco2;
+            acc = __tco3;
             continue;
         } })
         } else {
-            aver_list_match!(right, [] => crate::aver_generated::domain::eval::core::finishIndependentVals(left, acc), [v, rest] => { {
-            let __tmp3 = aver_rt::AverList::prepend(v, &acc);
-            right = rest;
-            takeLeft = true;
-            acc = __tmp3;
+            aver_list_match!(right, [] => { return crate::aver_generated::domain::eval::core::finishIndependentVals(left, acc); }, [v, rest] => { {
+            let __tco1 = rest;
+            let __tco2 = true;
+            let __tco3 = aver_rt::AverList::prepend(v, &acc);
+            right = __tco1;
+            takeLeft = __tco2;
+            acc = __tco3;
             continue;
         } })
-        };
+        }
     }
 }
 
@@ -3223,12 +3226,13 @@ pub fn finishIndependentVals(
 ) -> aver_rt::AverList<Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(items, [] => acc.reverse(), [v, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(v, &acc);
-            items = rest;
-            acc = __tmp1;
+        aver_list_match!(items, [] => { return acc.reverse(); }, [v, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(v, &acc);
+            items = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -3240,19 +3244,32 @@ pub fn unwrapProductResults(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(items, [] => Ok(crate::aver_generated::domain::value::Val::ValTuple(acc.reverse())), [v, rest] => { match v {
-            crate::aver_generated::domain::value::Val::ValOk(x) => { let x = (*x).clone(); {
-            let __tmp1 = aver_rt::AverList::prepend(x, &acc);
-            items = rest;
-            acc = __tmp1;
+        aver_list_match!(items, [] => { return Ok(crate::aver_generated::domain::value::Val::ValTuple(acc.reverse())); }, [v, rest] => { match v {
+        crate::aver_generated::domain::value::Val::ValOk(x) => {
+            let x = (*x).clone();
+            {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(x, &acc);
+            items = __tco0;
+            acc = __tco1;
             continue;
-        } },
-            crate::aver_generated::domain::value::Val::ValErr(e) => { let e = (*e).clone(); match e {
-            crate::aver_generated::domain::value::Val::ValStr(msg) => Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(msg)),
-            _ => Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(AverStr::from("propagated error")))
-        } },
-            _ => Err(AverStr::from("?! operator requires all elements to be Result values"))
-        } });
+        }
+        },
+        crate::aver_generated::domain::value::Val::ValErr(e) => {
+            let e = (*e).clone();
+            match e {
+        crate::aver_generated::domain::value::Val::ValStr(msg) => {
+            return Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(msg));
+        },
+        _ => {
+            return Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(AverStr::from("propagated error")));
+        }
+    }
+        },
+        _ => {
+            return Err(AverStr::from("?! operator requires all elements to be Result values"));
+        }
+    } })
     }
 }
 
@@ -3353,12 +3370,13 @@ pub fn evalConcatParts(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(parts, [] => Ok(crate::aver_generated::domain::value::Val::ValStr(acc)), [p, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&p, &env, &fns) { Err(e) => { Err(e) }, Ok(v) => { {
-            let __tmp3 = (acc + &crate::aver_generated::domain::value::valRepr(&v));
-            parts = rest;
-            acc = __tmp3;
+        aver_list_match!(parts, [] => { return Ok(crate::aver_generated::domain::value::Val::ValStr(acc)); }, [p, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&p, &env, &fns) { Err(e) => { return Err(e); }, Ok(v) => { {
+            let __tco0 = rest;
+            let __tco3 = (acc + &crate::aver_generated::domain::value::valRepr(&v));
+            parts = __tco0;
+            acc = __tco3;
             continue;
-        } } } });
+        } } } })
     }
 }
 
@@ -3465,12 +3483,13 @@ pub fn evalListItemsRev(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
-            let __tmp3 = aver_rt::AverList::prepend(v, &acc);
-            exprs = rest;
-            acc = __tmp3;
+        aver_list_match!(exprs, [] => { return Ok(acc.reverse()); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { return Err(err); }, Ok(v) => { {
+            let __tco0 = rest;
+            let __tco3 = aver_rt::AverList::prepend(v, &acc);
+            exprs = __tco0;
+            acc = __tco3;
             continue;
-        } } } });
+        } } } })
     }
 }
 
@@ -3498,12 +3517,13 @@ pub fn evalArgsRev(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
-            let __tmp3 = aver_rt::AverList::prepend(v, &acc);
-            exprs = rest;
-            acc = __tmp3;
+        aver_list_match!(exprs, [] => { return Ok(acc.reverse()); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { return Err(err); }, Ok(v) => { {
+            let __tco0 = rest;
+            let __tco3 = aver_rt::AverList::prepend(v, &acc);
+            exprs = __tco0;
+            acc = __tco3;
             continue;
-        } } } });
+        } } } })
     }
 }
 
@@ -3605,15 +3625,16 @@ pub fn evalResolvedSlotLoop(
         let step = crate::aver_generated::domain::eval::core::evalResolvedSlotStep(
             fnId, &fd, &calleeEnv, &fns,
         )?;
-        return match step {
+        match step {
             crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(v) => {
-                crate::aver_generated::domain::eval::common::normalizeFnReturn(&Ok(v))
+                return crate::aver_generated::domain::eval::common::normalizeFnReturn(&Ok(v));
             }
             crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailRecurEnv(nextEnv) => {
-                calleeEnv = nextEnv;
+                let __tco2 = nextEnv;
+                calleeEnv = __tco2;
                 continue;
             }
-        };
+        }
     }
 }
 
@@ -4072,12 +4093,13 @@ pub fn collectFastForwardArgs(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(slotArgs, [] => Ok(acc.reverse()), [slot, rest] => { match crate::aver_generated::domain::eval::slots::lookupSlot(&calleeEnv, slot) { Ok(v) => { {
-            let __tmp2 = aver_rt::AverList::prepend(v, &acc);
-            slotArgs = rest;
-            acc = __tmp2;
+        aver_list_match!(slotArgs, [] => { return Ok(acc.reverse()); }, [slot, rest] => { match crate::aver_generated::domain::eval::slots::lookupSlot(&calleeEnv, slot) { Ok(v) => { {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::AverList::prepend(v, &acc);
+            slotArgs = __tco0;
+            acc = __tco2;
             continue;
-        } }, Err(e) => { Err(e) } } });
+        } }, Err(e) => { return Err(e); } } })
     }
 }
 
@@ -4126,7 +4148,10 @@ pub fn evalCallDirectMapToSlot(
         argExprs.clone(),
         env.clone(),
         fns.clone(),
-        aver_rt::AverVector::new(fd.slotCount as usize, Val::ValUnit.clone()),
+        aver_rt::AverVector::new(
+            fd.slotCount as usize,
+            crate::aver_generated::domain::value::Val::ValUnit,
+        ),
         0i64,
     )?;
     crate::aver_generated::domain::eval::core::evalResolvedSlotFn(fnId, fd, &calleeEnv, fns)
@@ -4219,13 +4244,13 @@ pub fn evalStmts(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(stmts, [] => Ok(Val::ValUnit.clone()), [s, rest] => { match crate::aver_generated::domain::eval::core::evalStmt(&s, &env, &fns) { Err(e) => { Err(e) }, Ok(pair) => { match pair {
-            (v, newEnv) => { let __list_subject = rest.clone(); if __list_subject.is_empty() { Ok(v) } else { {
-            stmts = rest;
-            env = newEnv;
+        aver_list_match!(stmts, [] => { return Ok(crate::aver_generated::domain::value::Val::ValUnit); }, [s, rest] => { match crate::aver_generated::domain::eval::core::evalStmt(&s, &env, &fns) { Err(e) => { return Err(e); }, Ok(pair) => { { let (v, newEnv) = pair; { let __list_subject = rest.clone(); if __list_subject.is_empty() { return Ok(v); } else { {
+            let __tco0 = rest;
+            let __tco1 = newEnv;
+            stmts = __tco0;
+            env = __tco1;
             continue;
-        } } }
-        } } } });
+        } } } } } } })
     }
 }
 
@@ -4304,10 +4329,10 @@ pub fn evalVarSlot(name: AverStr, fns: &FnStore) -> Result<Val, AverStr> {
     {
         let __dispatch_subject = name.clone();
         if &*__dispatch_subject == "Unit" {
-            Ok(Val::ValUnit.clone())
+            Ok(crate::aver_generated::domain::value::Val::ValUnit)
         } else {
             if &*__dispatch_subject == "Option.None" {
-                Ok(Val::ValNone.clone())
+                Ok(crate::aver_generated::domain::value::Val::ValNone)
             } else {
                 crate::aver_generated::domain::eval::common::evalVarFallback(name, fns)
             }
@@ -4472,12 +4497,13 @@ pub fn evalConcatPartsSlot(
 ) -> Result<Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(parts, [] => Ok(crate::aver_generated::domain::value::Val::ValStr(acc)), [p, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&p, &env, &slotMap, &fns) { Err(e) => { Err(e) }, Ok(v) => { {
-            let __tmp4 = (acc + &crate::aver_generated::domain::value::valRepr(&v));
-            parts = rest;
-            acc = __tmp4;
+        aver_list_match!(parts, [] => { return Ok(crate::aver_generated::domain::value::Val::ValStr(acc)); }, [p, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&p, &env, &slotMap, &fns) { Err(e) => { return Err(e); }, Ok(v) => { {
+            let __tco0 = rest;
+            let __tco4 = (acc + &crate::aver_generated::domain::value::valRepr(&v));
+            parts = __tco0;
+            acc = __tco4;
             continue;
-        } } } });
+        } } } })
     }
 }
 
@@ -4534,12 +4560,13 @@ pub fn evalListItemsSlotRev(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
-            let __tmp4 = aver_rt::AverList::prepend(v, &acc);
-            exprs = rest;
-            acc = __tmp4;
+        aver_list_match!(exprs, [] => { return Ok(acc.reverse()); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { return Err(err); }, Ok(v) => { {
+            let __tco0 = rest;
+            let __tco4 = aver_rt::AverList::prepend(v, &acc);
+            exprs = __tco0;
+            acc = __tco4;
             continue;
-        } } } });
+        } } } })
     }
 }
 
@@ -4655,7 +4682,10 @@ pub fn evalCallDirectSlotToSlot(
         env.clone(),
         slotMap.clone(),
         fns.clone(),
-        aver_rt::AverVector::new(fd.slotCount as usize, Val::ValUnit.clone()),
+        aver_rt::AverVector::new(
+            fd.slotCount as usize,
+            crate::aver_generated::domain::value::Val::ValUnit,
+        ),
         0i64,
     )?;
     crate::aver_generated::domain::eval::core::evalResolvedSlotFn(fnId, fd, &calleeEnv, fns)
@@ -4758,12 +4788,13 @@ pub fn evalArgsSlotRev(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc.reverse()), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
-            let __tmp4 = aver_rt::AverList::prepend(v, &acc);
-            exprs = rest;
-            acc = __tmp4;
+        aver_list_match!(exprs, [] => { return Ok(acc.reverse()); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { return Err(err); }, Ok(v) => { {
+            let __tco0 = rest;
+            let __tco4 = aver_rt::AverList::prepend(v, &acc);
+            exprs = __tco0;
+            acc = __tco4;
             continue;
-        } } } });
+        } } } })
     }
 }
 
@@ -4777,14 +4808,15 @@ pub fn evalArgsMapToSlotEnv(
 ) -> Result<aver_rt::AverVector<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
-            let __tmp3 = crate::aver_generated::domain::eval::slots::setSlot(&acc, idx, &v);
-            let __tmp4 = (idx + 1i64);
-            exprs = rest;
-            acc = __tmp3;
-            idx = __tmp4;
+        aver_list_match!(exprs, [] => { return Ok(acc); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &env, &fns) { Err(err) => { return Err(err); }, Ok(v) => { {
+            let __tco0 = rest;
+            let __tco3 = crate::aver_generated::domain::eval::slots::setSlot(&acc, idx, &v);
+            let __tco4 = (idx + 1i64);
+            exprs = __tco0;
+            acc = __tco3;
+            idx = __tco4;
             continue;
-        } } } });
+        } } } })
     }
 }
 
@@ -4799,14 +4831,15 @@ pub fn evalArgsSlotToSlotEnv(
 ) -> Result<aver_rt::AverVector<Val>, AverStr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => Ok(acc), [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { Err(err) }, Ok(v) => { {
-            let __tmp4 = crate::aver_generated::domain::eval::slots::setSlot(&acc, idx, &v);
-            let __tmp5 = (idx + 1i64);
-            exprs = rest;
-            acc = __tmp4;
-            idx = __tmp5;
+        aver_list_match!(exprs, [] => { return Ok(acc); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &env, &slotMap, &fns) { Err(err) => { return Err(err); }, Ok(v) => { {
+            let __tco0 = rest;
+            let __tco4 = crate::aver_generated::domain::eval::slots::setSlot(&acc, idx, &v);
+            let __tco5 = (idx + 1i64);
+            exprs = __tco0;
+            acc = __tco4;
+            idx = __tco5;
             continue;
-        } } } });
+        } } } })
     }
 }
 

--- a/src/self_host/aver_generated/domain/eval/fast/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/fast/mod.rs
@@ -260,7 +260,7 @@ pub fn fastMapGetSlotInner(mapV: &Val, keyV: &Val) -> Result<Val, AverStr> {
                 Some(v) => Ok(crate::aver_generated::domain::value::Val::ValSome(
                     std::sync::Arc::new(v),
                 )),
-                None => Ok(Val::ValNone.clone()),
+                None => Ok(crate::aver_generated::domain::value::Val::ValNone),
             }
         }
         _ => Err(AverStr::from("Map.get requires a Map")),

--- a/src/self_host/aver_generated/domain/eval/ops/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/ops/mod.rs
@@ -22,7 +22,9 @@ pub fn applyBinop(x: i64, y: i64, op: &BinOp) -> Result<Val, AverStr> {
             if (y == 0i64) {
                 Err(AverStr::from("division by zero"))
             } else {
-                Ok(crate::aver_generated::domain::value::Val::ValInt((x / y)))
+                Ok(crate::aver_generated::domain::value::Val::ValInt(
+                    (x).checked_div_euclid(y).unwrap_or(0i64),
+                ))
             }
         }
     }
@@ -318,7 +320,7 @@ pub fn evalIntModOrIntVals(aV: &Val, bV: &Val, defaultValue: i64) -> Result<Val,
                 } else {
                     Ok(crate::aver_generated::domain::value::Val::ValInt(
                         (if (b) == 0i64 {
-                            Err("Int.mod: divisor must not be zero".to_string())
+                            Err("division by zero".to_string())
                         } else {
                             Ok((a).rem_euclid(b))
                         })

--- a/src/self_host/aver_generated/domain/eval/records/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/records/mod.rs
@@ -24,9 +24,7 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverList<(Av
         __state = match __state {
             __MutualTco1::MergeRecordFieldsAcc(mut existing, mut overrides, mut acc) => {
                 crate::cancel_checkpoint();
-                aver_list_match!(existing, [] => { return aver_rt::AverList::concat(&acc.reverse(), &overrides) }, [pair, rest] => match pair {
-                (k, v) => __MutualTco1::MergeOneField(k, v, rest, overrides, acc)
-                })
+                aver_list_match!(existing, [] => { return aver_rt::AverList::concat(&acc.reverse(), &overrides) }, [pair, rest] => { { let (k, v) = pair; __MutualTco1::MergeOneField(k, v, rest, overrides, acc) } })
             }
             __MutualTco1::MergeOneField(mut k, mut v, mut rest, mut overrides, mut acc) => {
                 crate::cancel_checkpoint();
@@ -200,12 +198,11 @@ pub fn findOverride(
 ) -> Option<Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(overrides, [] => None, [pair, rest] => { match pair {
-            (ok, ov) => if (ok == k) { Some(ov) } else { {
-            overrides = rest;
+        aver_list_match!(overrides, [] => { return None; }, [pair, rest] => { { let (ok, ov) = pair; if (ok == k) { return Some(ov); } else { {
+            let __tco1 = rest;
+            overrides = __tco1;
             continue;
-        } }
-        } });
+        } } } })
     }
 }
 
@@ -233,13 +230,12 @@ pub fn removeOverrideAcc(
     loop {
         crate::cancel_checkpoint();
         let reversed = acc.reverse();
-        return aver_list_match!(overrides, [] => reversed, [pair, rest] => { match pair {
-            (ok, ov) => if (ok == k) { aver_rt::AverList::concat(&reversed, &rest) } else { {
-            let __tmp2 = aver_rt::AverList::prepend((ok, ov), &acc);
-            overrides = rest;
-            acc = __tmp2;
+        aver_list_match!(overrides, [] => { return reversed; }, [pair, rest] => { { let (ok, ov) = pair; if (ok == k) { return aver_rt::AverList::concat(&reversed, &rest); } else { {
+            let __tco1 = rest;
+            let __tco2 = aver_rt::AverList::prepend((ok, ov), &acc);
+            overrides = __tco1;
+            acc = __tco2;
             continue;
-        } }
-        } });
+        } } } })
     }
 }

--- a/src/self_host/aver_generated/domain/eval/slots/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/slots/mod.rs
@@ -9,7 +9,10 @@ pub fn buildSlotEnv(args: &aver_rt::AverList<Val>, slotCount: i64) -> aver_rt::A
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::slots::buildSlotEnvLoop(
         args.clone(),
-        aver_rt::AverVector::new(slotCount as usize, Val::ValUnit.clone()),
+        aver_rt::AverVector::new(
+            slotCount as usize,
+            crate::aver_generated::domain::value::Val::ValUnit,
+        ),
         0i64,
     )
 }
@@ -23,14 +26,15 @@ pub fn buildSlotEnvLoop(
 ) -> aver_rt::AverVector<Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(args, [] => acc, [a, rest] => { {
-            let __tmp1 = { let __vec = acc.clone(); let __idx = idx as usize; if __idx < __vec.len() { __vec.set_unchecked(__idx, a) } else { __vec } };
-            let __tmp2 = (idx + 1i64);
-            args = rest;
-            acc = __tmp1;
-            idx = __tmp2;
+        aver_list_match!(args, [] => { return acc; }, [a, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = { let __vec = acc.clone(); let __idx = idx as usize; if __idx < __vec.len() { __vec.set_unchecked(__idx, a) } else { __vec } };
+            let __tco2 = (idx + 1i64);
+            args = __tco0;
+            acc = __tco1;
+            idx = __tco2;
             continue;
-        } });
+        } })
     }
 }
 

--- a/src/self_host/aver_generated/domain/eval/store/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/store/mod.rs
@@ -91,7 +91,7 @@ pub fn lookupVar(env: &aver_rt::AverMap<AverStr, Val>, name: AverStr) -> Result<
 /// Create an empty function store.
 pub fn emptyFnStore() -> FnStore {
     crate::cancel_checkpoint();
-    FnStore {
+    crate::aver_generated::domain::eval::store::FnStore {
         nameToId: HashMap::new(),
         byId: aver_rt::AverVector::from_vec(aver_rt::AverList::empty().to_vec()),
     }
@@ -156,13 +156,15 @@ pub fn zipArgs(
 ) -> aver_rt::AverMap<AverStr, Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(params, [] => acc, [p, ps] => { aver_list_match!(args, [] => acc, [a, as_] => { {
-            let __tmp2 = acc.insert_owned(p, a);
-            params = ps;
-            args = as_;
-            acc = __tmp2;
+        aver_list_match!(params, [] => { return acc; }, [p, ps] => { aver_list_match!(args, [] => { return acc; }, [a, as_] => { {
+            let __tco0 = ps;
+            let __tco1 = as_;
+            let __tco2 = acc.insert_owned(p, a);
+            params = __tco0;
+            args = __tco1;
+            acc = __tco2;
             continue;
-        } }) });
+        } }) })
     }
 }
 
@@ -174,14 +176,13 @@ pub fn mergeBindings(
 ) -> aver_rt::AverMap<AverStr, Val> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(bindings, [] => env, [pair, rest] => { match pair {
-            (k, v) => {
-            let __tmp1 = env.insert_owned(k, v);
-            bindings = rest;
-            env = __tmp1;
+        aver_list_match!(bindings, [] => { return env; }, [pair, rest] => { { let (k, v) = pair; {
+            let __tco0 = rest;
+            let __tco1 = env.insert_owned(k, v);
+            bindings = __tco0;
+            env = __tco1;
             continue;
-        }
-        } });
+        } } })
     }
 }
 
@@ -190,7 +191,7 @@ pub fn fnsToStore(fns: &aver_rt::AverList<FnDef>) -> FnStore {
     crate::cancel_checkpoint();
     let nameToId =
         crate::aver_generated::domain::eval::store::fnsToIdMap(fns.clone(), HashMap::new(), 0i64);
-    FnStore {
+    crate::aver_generated::domain::eval::store::FnStore {
         nameToId: nameToId,
         byId: aver_rt::AverVector::from_vec(fns.to_vec()),
     }
@@ -205,13 +206,14 @@ pub fn fnsToIdMap(
 ) -> aver_rt::AverMap<AverStr, i64> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fns, [] => acc, [f, rest] => { {
-            let __tmp1 = acc.insert_owned(f.name.clone(), idx);
-            let __tmp2 = (idx + 1i64);
-            fns = rest;
-            acc = __tmp1;
-            idx = __tmp2;
+        aver_list_match!(fns, [] => { return acc; }, [f, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = acc.insert_owned(f.name.clone(), idx);
+            let __tco2 = (idx + 1i64);
+            fns = __tco0;
+            acc = __tco1;
+            idx = __tco2;
             continue;
-        } });
+        } })
     }
 }

--- a/src/self_host/aver_generated/domain/lexer/chars/mod.rs
+++ b/src/self_host/aver_generated/domain/lexer/chars/mod.rs
@@ -167,27 +167,29 @@ pub fn digitVal(c: AverStr) -> i64 {
 pub fn readNumberLoop(mut src: AverStr, mut pos: i64, mut acc: i64) -> (i64, i64) {
     loop {
         crate::cancel_checkpoint();
-        return if (pos < (src.chars().count() as i64)) {
+        if (pos < (src.chars().count() as i64)) {
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
                     if crate::aver_generated::domain::lexer::chars::isDigit(c.clone()) {
                         {
-                            let __tmp1 = (pos + 1i64);
-                            let __tmp2 = ((acc * 10i64)
+                            let __tco1 = (pos + 1i64);
+                            let __tco2 = ((acc * 10i64)
                                 + crate::aver_generated::domain::lexer::chars::digitVal(c));
-                            pos = __tmp1;
-                            acc = __tmp2;
+                            pos = __tco1;
+                            acc = __tco2;
                             continue;
                         }
                     } else {
-                        (acc, pos)
+                        return (acc, pos);
                     }
                 }
-                None => (acc, pos),
+                None => {
+                    return (acc, pos);
+                }
             }
         } else {
-            (acc, pos)
-        };
+            return (acc, pos);
+        }
     }
 }
 
@@ -221,26 +223,28 @@ pub fn isIdentCharPlain(c: AverStr) -> bool {
 pub fn readIdentLoopDotted(mut src: AverStr, mut pos: i64, mut acc: AverStr) -> (AverStr, i64) {
     loop {
         crate::cancel_checkpoint();
-        return if (pos < (src.chars().count() as i64)) {
+        if (pos < (src.chars().count() as i64)) {
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
                     if crate::aver_generated::domain::lexer::chars::isIdentCharDotted(c.clone()) {
                         {
-                            let __tmp1 = (pos + 1i64);
-                            let __tmp2 = (acc + &c);
-                            pos = __tmp1;
-                            acc = __tmp2;
+                            let __tco1 = (pos + 1i64);
+                            let __tco2 = (acc + &c);
+                            pos = __tco1;
+                            acc = __tco2;
                             continue;
                         }
                     } else {
-                        (acc, pos)
+                        return (acc, pos);
                     }
                 }
-                None => (acc, pos),
+                None => {
+                    return (acc, pos);
+                }
             }
         } else {
-            (acc, pos)
-        };
+            return (acc, pos);
+        }
     }
 }
 
@@ -249,26 +253,28 @@ pub fn readIdentLoopDotted(mut src: AverStr, mut pos: i64, mut acc: AverStr) -> 
 pub fn readIdentLoopPlain(mut src: AverStr, mut pos: i64, mut acc: AverStr) -> (AverStr, i64) {
     loop {
         crate::cancel_checkpoint();
-        return if (pos < (src.chars().count() as i64)) {
+        if (pos < (src.chars().count() as i64)) {
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
                     if crate::aver_generated::domain::lexer::chars::isIdentCharPlain(c.clone()) {
                         {
-                            let __tmp1 = (pos + 1i64);
-                            let __tmp2 = (acc + &c);
-                            pos = __tmp1;
-                            acc = __tmp2;
+                            let __tco1 = (pos + 1i64);
+                            let __tco2 = (acc + &c);
+                            pos = __tco1;
+                            acc = __tco2;
                             continue;
                         }
                     } else {
-                        (acc, pos)
+                        return (acc, pos);
                     }
                 }
-                None => (acc, pos),
+                None => {
+                    return (acc, pos);
+                }
             }
         } else {
-            (acc, pos)
-        };
+            return (acc, pos);
+        }
     }
 }
 
@@ -290,16 +296,16 @@ pub fn keywordOrIdent(s: AverStr) -> Token {
     {
         let __dispatch_subject = s.clone();
         if &*__dispatch_subject == "fn" {
-            Token::TkFn.clone()
+            crate::aver_generated::domain::token::Token::TkFn
         } else {
             if &*__dispatch_subject == "match" {
-                Token::TkMatch.clone()
+                crate::aver_generated::domain::token::Token::TkMatch
             } else {
                 if &*__dispatch_subject == "true" {
-                    Token::TkTrue.clone()
+                    crate::aver_generated::domain::token::Token::TkTrue
                 } else {
                     if &*__dispatch_subject == "false" {
-                        Token::TkFalse.clone()
+                        crate::aver_generated::domain::token::Token::TkFalse
                     } else {
                         if &*__dispatch_subject == "module" {
                             crate::aver_generated::domain::token::Token::TkIdent(AverStr::from(

--- a/src/self_host/aver_generated/domain/lexer/mod.rs
+++ b/src/self_host/aver_generated/domain/lexer/mod.rs
@@ -16,10 +16,10 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> (i64, i64) {
         __state = match __state {
             __MutualTco1::CountIndent(mut src, mut pos, mut spaces) => {
                 crate::cancel_checkpoint();
-                if (pos >= (src.chars().count() as i64)) {
-                    return (spaces, pos);
-                } else {
+                if (pos < (src.chars().count() as i64)) {
                     __MutualTco1::CountIndentChar(src, pos, spaces)
+                } else {
+                    return (spaces, pos);
                 }
             }
             __MutualTco1::CountIndentChar(mut src, mut pos, mut spaces) => {
@@ -85,13 +85,13 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
                 let nextPos = (pos + 1i64);
                 if (c == crate::aver_generated::domain::lexer::openBrace()) {
                     return aver_rt::AverList::prepend(
-                        Token::TkLBrace.clone(),
+                        crate::aver_generated::domain::token::Token::TkLBrace,
                         &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                     );
                 } else {
                     if (c == crate::aver_generated::domain::lexer::closeBrace()) {
                         return aver_rt::AverList::prepend(
-                            Token::TkRBrace.clone(),
+                            crate::aver_generated::domain::token::Token::TkRBrace,
                             &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                         );
                     } else {
@@ -119,7 +119,7 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
                             } else {
                                 if &*__dispatch_subject == "+" {
                                     return aver_rt::AverList::prepend(
-                                        Token::TkPlus.clone(),
+                                        crate::aver_generated::domain::token::Token::TkPlus,
                                         &crate::aver_generated::domain::lexer::tokenize(
                                             src, nextPos,
                                         ),
@@ -127,7 +127,7 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
                                 } else {
                                     if &*__dispatch_subject == "*" {
                                         return aver_rt::AverList::prepend(
-                                            Token::TkStar.clone(),
+                                            crate::aver_generated::domain::token::Token::TkStar,
                                             &crate::aver_generated::domain::lexer::tokenize(
                                                 src, nextPos,
                                             ),
@@ -145,31 +145,31 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
                                                     return crate::aver_generated::domain::lexer::tokenizeBang(src, pos);
                                                 } else {
                                                     if &*__dispatch_subject == "?" {
-                                                        return aver_rt::AverList::prepend(Token::TkQuestion.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
+                                                        return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkQuestion, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                     } else {
                                                         if &*__dispatch_subject == "\"" {
                                                             return crate::aver_generated::domain::lexer::tokenizeString(src, nextPos, AverStr::from(""));
                                                         } else {
                                                             if &*__dispatch_subject == "(" {
-                                                                return aver_rt::AverList::prepend(Token::TkLParen.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
+                                                                return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkLParen, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                             } else {
                                                                 if &*__dispatch_subject == ")" {
-                                                                    return aver_rt::AverList::prepend(Token::TkRParen.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
+                                                                    return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkRParen, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                                 } else {
                                                                     if &*__dispatch_subject == "[" {
-                                                                        return aver_rt::AverList::prepend(Token::TkLBracket.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
+                                                                        return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkLBracket, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                                     } else {
                                                                         if &*__dispatch_subject
                                                                             == "]"
                                                                         {
-                                                                            return aver_rt::AverList::prepend(Token::TkRBracket.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
+                                                                            return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkRBracket, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                                         } else {
                                                                             if &*__dispatch_subject
                                                                                 == "."
                                                                             {
                                                                                 return crate::aver_generated::domain::lexer::tokenizeDot(src, pos);
                                                                             } else {
-                                                                                if &*__dispatch_subject == "," { return aver_rt::AverList::prepend(Token::TkComma.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if &*__dispatch_subject == ":" { return aver_rt::AverList::prepend(Token::TkColon.clone(), &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if &*__dispatch_subject == "=" { return crate::aver_generated::domain::lexer::tokenizeEq(src, pos) } else { if &*__dispatch_subject == "-" { return crate::aver_generated::domain::lexer::tokenizeMinus(src, pos) } else { __MutualTco2::TokenizeDefault(c, src, pos) } } } }
+                                                                                if &*__dispatch_subject == "," { return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkComma, &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if &*__dispatch_subject == ":" { return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkColon, &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if &*__dispatch_subject == "=" { return crate::aver_generated::domain::lexer::tokenizeEq(src, pos) } else { if &*__dispatch_subject == "-" { return crate::aver_generated::domain::lexer::tokenizeMinus(src, pos) } else { __MutualTco2::TokenizeDefault(c, src, pos) } } } }
                                                                             }
                                                                         }
                                                                     }
@@ -194,16 +194,22 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
             __MutualTco2::TokenizeAtPos(mut src, mut pos) => {
                 crate::cancel_checkpoint();
                 match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
-                    None => return aver_rt::AverList::from_vec(vec![Token::TkEof.clone()]),
+                    None => {
+                        return aver_rt::AverList::from_vec(vec![
+                            crate::aver_generated::domain::token::Token::TkEof,
+                        ]);
+                    }
                     Some(c) => __MutualTco2::TokenizeSome(c, src, pos),
                 }
             }
             __MutualTco2::Tokenize(mut src, mut pos) => {
                 crate::cancel_checkpoint();
-                if (pos >= (src.chars().count() as i64)) {
-                    return aver_rt::AverList::from_vec(vec![Token::TkEof.clone()]);
-                } else {
+                if (pos < (src.chars().count() as i64)) {
                     __MutualTco2::TokenizeAtPos(src, pos)
+                } else {
+                    return aver_rt::AverList::from_vec(vec![
+                        crate::aver_generated::domain::token::Token::TkEof,
+                    ]);
                 }
             }
         };
@@ -256,13 +262,13 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
         __state = match __state {
             __MutualTco3::TokenizeInterpExpr(mut src, mut pos) => {
                 crate::cancel_checkpoint();
-                if (pos >= (src.chars().count() as i64)) {
-                    return aver_rt::AverList::from_vec(vec![
-                        Token::TkInterpEnd.clone(),
-                        Token::TkEof.clone(),
-                    ]);
-                } else {
+                if (pos < (src.chars().count() as i64)) {
                     __MutualTco3::TokenizeInterpExprAt(src, pos)
+                } else {
+                    return aver_rt::AverList::from_vec(vec![
+                        crate::aver_generated::domain::token::Token::TkInterpEnd,
+                        crate::aver_generated::domain::token::Token::TkEof,
+                    ]);
                 }
             }
             __MutualTco3::TokenizeInterpExprAt(mut src, mut pos) => {
@@ -271,8 +277,8 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                     Some(c) => __MutualTco3::TokenizeInterpExprC(src, pos, c),
                     None => {
                         return aver_rt::AverList::from_vec(vec![
-                            Token::TkInterpEnd.clone(),
-                            Token::TkEof.clone(),
+                            crate::aver_generated::domain::token::Token::TkInterpEnd,
+                            crate::aver_generated::domain::token::Token::TkEof,
                         ]);
                     }
                 }
@@ -281,7 +287,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                 crate::cancel_checkpoint();
                 if (c == crate::aver_generated::domain::lexer::closeBrace()) {
                     return aver_rt::AverList::prepend(
-                        Token::TkInterpEnd.clone(),
+                        crate::aver_generated::domain::token::Token::TkInterpEnd,
                         &crate::aver_generated::domain::lexer::tokenizeString(
                             src,
                             (pos + 1i64),
@@ -318,7 +324,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                     } else {
                         if &*__dispatch_subject == "(" {
                             return aver_rt::AverList::prepend(
-                                Token::TkLParen.clone(),
+                                crate::aver_generated::domain::token::Token::TkLParen,
                                 &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
                                     src, nextPos,
                                 ),
@@ -326,7 +332,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                         } else {
                             if &*__dispatch_subject == ")" {
                                 return aver_rt::AverList::prepend(
-                                    Token::TkRParen.clone(),
+                                    crate::aver_generated::domain::token::Token::TkRParen,
                                     &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
                                         src, nextPos,
                                     ),
@@ -334,29 +340,29 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                             } else {
                                 if &*__dispatch_subject == "+" {
                                     return aver_rt::AverList::prepend(
-                                        Token::TkPlus.clone(),
+                                        crate::aver_generated::domain::token::Token::TkPlus,
                                         &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
                                             src, nextPos,
                                         ),
                                     );
                                 } else {
                                     if &*__dispatch_subject == "-" {
-                                        return aver_rt::AverList::prepend(Token::TkMinus.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
+                                        return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkMinus, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                     } else {
                                         if &*__dispatch_subject == "*" {
-                                            return aver_rt::AverList::prepend(Token::TkStar.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
+                                            return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkStar, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                         } else {
                                             if &*__dispatch_subject == "," {
-                                                return aver_rt::AverList::prepend(Token::TkComma.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
+                                                return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkComma, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                             } else {
                                                 if &*__dispatch_subject == "." {
-                                                    return aver_rt::AverList::prepend(Token::TkDot.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
+                                                    return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkDot, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                                 } else {
                                                     if &*__dispatch_subject == "[" {
-                                                        return aver_rt::AverList::prepend(Token::TkLBracket.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
+                                                        return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkLBracket, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                                     } else {
                                                         if &*__dispatch_subject == "]" {
-                                                            return aver_rt::AverList::prepend(Token::TkRBracket.clone(), &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
+                                                            return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkRBracket, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                                         } else {
                                                             if &*__dispatch_subject == "\"" {
                                                                 return crate::aver_generated::domain::lexer::tokenizeInterpString(src, nextPos, AverStr::from(""));
@@ -381,23 +387,16 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                 crate::cancel_checkpoint();
                 match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                     Some(c) => {
-                        match crate::aver_generated::domain::lexer::chars::readIdent(
+                        let (word, newPos) = crate::aver_generated::domain::lexer::chars::readIdent(
                             src.clone(),
                             pos,
                             AverStr::from(""),
                             crate::aver_generated::domain::lexer::chars::isUpper(c),
-                        ) {
-                            (word, newPos) => {
-                                return aver_rt::AverList::prepend(
-                                    crate::aver_generated::domain::lexer::chars::keywordOrIdent(
-                                        word,
-                                    ),
-                                    &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
-                                        src, newPos,
-                                    ),
-                                );
-                            }
-                        }
+                        );
+                        return aver_rt::AverList::prepend(
+                            crate::aver_generated::domain::lexer::chars::keywordOrIdent(word),
+                            &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, newPos),
+                        );
                     }
                     None => __MutualTco3::TokenizeInterpExpr(src, pos),
                 }
@@ -457,20 +456,20 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
         __state = match __state {
             __MutualTco4::TokenizeString(mut src, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                if (pos >= (src.chars().count() as i64)) {
+                if (pos < (src.chars().count() as i64)) {
+                    __MutualTco4::TokenizeStringAt(src, pos, acc)
+                } else {
                     return aver_rt::AverList::from_vec(vec![
                         crate::aver_generated::domain::token::Token::TkStr(acc),
-                        Token::TkEof.clone(),
+                        crate::aver_generated::domain::token::Token::TkEof,
                     ]);
-                } else {
-                    __MutualTco4::TokenizeStringAt(src, pos, acc)
                 }
             }
             __MutualTco4::TokenizeStringAt(mut src, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                     Some(c) => {
-                        if (&*c == "\\") {
+                        if (c == AverStr::from("\\")) {
                             __MutualTco4::TokenizeStringEscape(src, (pos + 1i64), acc)
                         } else {
                             __MutualTco4::TokenizeStringChar(src, pos, acc, c)
@@ -479,7 +478,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
                     None => {
                         return aver_rt::AverList::from_vec(vec![
                             crate::aver_generated::domain::token::Token::TkStr(acc),
-                            Token::TkEof.clone(),
+                            crate::aver_generated::domain::token::Token::TkEof,
                         ]);
                     }
                 }
@@ -551,14 +550,14 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
                     None => {
                         return aver_rt::AverList::from_vec(vec![
                             crate::aver_generated::domain::token::Token::TkStr(acc),
-                            Token::TkEof.clone(),
+                            crate::aver_generated::domain::token::Token::TkEof,
                         ]);
                     }
                 }
             }
             __MutualTco4::TokenizeStringChar(mut src, mut pos, mut acc, mut c) => {
                 crate::cancel_checkpoint();
-                if (&*c == "\"") {
+                if (c == AverStr::from("\"")) {
                     return aver_rt::AverList::prepend(
                         crate::aver_generated::domain::token::Token::TkStr(acc),
                         &crate::aver_generated::domain::lexer::tokenize(src, (pos + 1i64)),
@@ -773,17 +772,17 @@ pub fn pow10(n: i64) -> f64 {
 pub fn pow10Acc(mut n: i64, mut acc: f64) -> f64 {
     loop {
         crate::cancel_checkpoint();
-        return if (n <= 0i64) {
-            acc
-        } else {
+        if (n > 0i64) {
             {
-                let __tmp0 = (n - 1i64);
-                let __tmp1 = (acc * 10.0f64);
-                n = __tmp0;
-                acc = __tmp1;
+                let __tco0 = (n - 1i64);
+                let __tco1 = (acc * 10.0f64);
+                n = __tco0;
+                acc = __tco1;
                 continue;
             }
-        };
+        } else {
+            return acc;
+        }
     }
 }
 
@@ -797,7 +796,9 @@ pub fn tokenizeAlpha(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
             pos,
             crate::aver_generated::domain::lexer::chars::isUpper(c),
         ),
-        None => aver_rt::AverList::from_vec(vec![Token::TkEof.clone()]),
+        None => {
+            aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::token::Token::TkEof])
+        }
     }
 }
 
@@ -833,18 +834,18 @@ pub fn tokenizeMinus(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
         Some(c) => {
             if crate::aver_generated::domain::lexer::isGreaterThan(c) {
                 aver_rt::AverList::prepend(
-                    Token::TkArrow.clone(),
+                    crate::aver_generated::domain::token::Token::TkArrow,
                     &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
                 )
             } else {
                 aver_rt::AverList::prepend(
-                    Token::TkMinus.clone(),
+                    crate::aver_generated::domain::token::Token::TkMinus,
                     &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                 )
             }
         }
         None => aver_rt::AverList::prepend(
-            Token::TkMinus.clone(),
+            crate::aver_generated::domain::token::Token::TkMinus,
             &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
         ),
     }
@@ -866,7 +867,7 @@ pub fn tokenizeInterp(src: AverStr, pos: i64, acc: AverStr) -> aver_rt::AverList
     aver_rt::AverList::prepend(
         crate::aver_generated::domain::token::Token::TkStr(acc),
         &aver_rt::AverList::prepend(
-            Token::TkInterpStart.clone(),
+            crate::aver_generated::domain::token::Token::TkInterpStart,
             &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, (pos + 1i64)),
         ),
     )
@@ -891,48 +892,126 @@ pub fn tokenizeInterpString(
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return if (pos >= (src.chars().count() as i64)) {
-            aver_rt::AverList::prepend(
-                crate::aver_generated::domain::token::Token::TkStr(acc),
-                &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
-            )
-        } else {
+        if (pos < (src.chars().count() as i64)) {
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
-                    if (&*c == "\"") {
-                        aver_rt::AverList::prepend(
+                    if (c == AverStr::from("\"")) {
+                        return aver_rt::AverList::prepend(
                             crate::aver_generated::domain::token::Token::TkStr(acc),
                             &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos),
-                        )
+                        );
                     } else {
                         {
-                            let __tmp2 = (acc + &c);
-                            pos = nextPos;
-                            acc = __tmp2;
+                            let __tco1 = nextPos;
+                            let __tco2 = (acc + &c);
+                            pos = __tco1;
+                            acc = __tco2;
                             continue;
                         }
                     }
                 }
-                None => aver_rt::AverList::prepend(
-                    crate::aver_generated::domain::token::Token::TkStr(acc),
-                    &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
-                ),
+                None => {
+                    return aver_rt::AverList::prepend(
+                        crate::aver_generated::domain::token::Token::TkStr(acc),
+                        &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
+                    );
+                }
             }
-        };
+        } else {
+            return aver_rt::AverList::prepend(
+                crate::aver_generated::domain::token::Token::TkStr(acc),
+                &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
+            );
+        }
     }
 }
 
-/// Read number inside interpolation.
+/// Read number inside interpolation; may be an int or a float literal.
 pub fn tokenizeInterpDigit(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
     {
         let (n, newPos) =
             crate::aver_generated::domain::lexer::chars::readNumber(src.clone(), pos, 0i64);
-        aver_rt::AverList::prepend(
+        crate::aver_generated::domain::lexer::tokenizeInterpAfterInt(src, newPos, n)
+    }
+}
+
+/// After integer part inside interpolation, check for a decimal point.
+#[inline(always)]
+pub fn tokenizeInterpAfterInt(src: AverStr, pos: i64, n: i64) -> aver_rt::AverList<Token> {
+    crate::cancel_checkpoint();
+    match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
+        Some(c) => {
+            if (c == AverStr::from(".")) {
+                crate::aver_generated::domain::lexer::tokenizeInterpAfterIntDot(src, pos, n)
+            } else {
+                aver_rt::AverList::prepend(
+                    crate::aver_generated::domain::token::Token::TkInt(n),
+                    &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
+                )
+            }
+        }
+        None => aver_rt::AverList::prepend(
             crate::aver_generated::domain::token::Token::TkInt(n),
-            &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, newPos),
+            &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
+        ),
+    }
+}
+
+/// After integer and dot inside interpolation: digit -> float, else int + dot.
+#[inline(always)]
+pub fn tokenizeInterpAfterIntDot(src: AverStr, pos: i64, n: i64) -> aver_rt::AverList<Token> {
+    crate::cancel_checkpoint();
+    let nextPos = (pos + 1i64);
+    match (src.chars().nth(nextPos as usize).map(|c| c.to_string())).into_aver() {
+        Some(d) => {
+            if crate::aver_generated::domain::lexer::chars::isDigit(d) {
+                crate::aver_generated::domain::lexer::tokenizeInterpFloat(src, nextPos, n)
+            } else {
+                aver_rt::AverList::prepend(
+                    crate::aver_generated::domain::token::Token::TkInt(n),
+                    &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
+                )
+            }
+        }
+        None => aver_rt::AverList::prepend(
+            crate::aver_generated::domain::token::Token::TkInt(n),
+            &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
+        ),
+    }
+}
+
+/// Read decimal digits and build a float token inside interpolation.
+pub fn tokenizeInterpFloat(src: AverStr, pos: i64, intPart: i64) -> aver_rt::AverList<Token> {
+    crate::cancel_checkpoint();
+    {
+        let (decPart, newPos) =
+            crate::aver_generated::domain::lexer::chars::readNumber(src.clone(), pos, 0i64);
+        crate::aver_generated::domain::lexer::tokenizeInterpBuildFloat(
+            src,
+            newPos.clone(),
+            intPart,
+            decPart,
+            (newPos - pos),
         )
     }
+}
+
+/// Construct a float from integer and decimal parts inside interpolation.
+pub fn tokenizeInterpBuildFloat(
+    src: AverStr,
+    pos: i64,
+    intPart: i64,
+    decPart: i64,
+    decDigits: i64,
+) -> aver_rt::AverList<Token> {
+    crate::cancel_checkpoint();
+    let f = (intPart as f64
+        + (decPart as f64 / crate::aver_generated::domain::lexer::pow10(decDigits)));
+    aver_rt::AverList::prepend(
+        crate::aver_generated::domain::token::Token::TkFloat(f),
+        &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, pos),
+    )
 }
 
 /// Tokenize / (division) or // (line comment).
@@ -946,13 +1025,13 @@ pub fn tokenizeSlashOrComment(src: AverStr, pos: i64) -> aver_rt::AverList<Token
                 crate::aver_generated::domain::lexer::skipLineComment(src, (pos + 2i64))
             } else {
                 aver_rt::AverList::prepend(
-                    Token::TkSlash.clone(),
+                    crate::aver_generated::domain::token::Token::TkSlash,
                     &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                 )
             }
         }
         None => aver_rt::AverList::prepend(
-            Token::TkSlash.clone(),
+            crate::aver_generated::domain::token::Token::TkSlash,
             &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
         ),
     }
@@ -964,23 +1043,30 @@ pub fn skipLineComment(mut src: AverStr, mut pos: i64) -> aver_rt::AverList<Toke
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return if (pos >= (src.chars().count() as i64)) {
-            aver_rt::AverList::from_vec(vec![Token::TkEof.clone()])
-        } else {
+        if (pos < (src.chars().count() as i64)) {
             match (src.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
-                    if (&*c == "\n") {
-                        crate::aver_generated::domain::lexer::tokenizeNewline(src, nextPos)
+                    if (c == AverStr::from("\n")) {
+                        return crate::aver_generated::domain::lexer::tokenizeNewline(src, nextPos);
                     } else {
                         {
-                            pos = nextPos;
+                            let __tco1 = nextPos;
+                            pos = __tco1;
                             continue;
                         }
                     }
                 }
-                None => aver_rt::AverList::from_vec(vec![Token::TkEof.clone()]),
+                None => {
+                    return aver_rt::AverList::from_vec(vec![
+                        crate::aver_generated::domain::token::Token::TkEof,
+                    ]);
+                }
             }
-        };
+        } else {
+            return aver_rt::AverList::from_vec(vec![
+                crate::aver_generated::domain::token::Token::TkEof,
+            ]);
+        }
     }
 }
 
@@ -993,18 +1079,18 @@ pub fn tokenizeDot(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
         Some(c) => {
             if (c == AverStr::from(".")) {
                 aver_rt::AverList::prepend(
-                    Token::TkDotDot.clone(),
+                    crate::aver_generated::domain::token::Token::TkDotDot,
                     &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
                 )
             } else {
                 aver_rt::AverList::prepend(
-                    Token::TkDot.clone(),
+                    crate::aver_generated::domain::token::Token::TkDot,
                     &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                 )
             }
         }
         None => aver_rt::AverList::prepend(
-            Token::TkDot.clone(),
+            crate::aver_generated::domain::token::Token::TkDot,
             &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
         ),
     }
@@ -1019,18 +1105,18 @@ pub fn tokenizeLt(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
         Some(c) => {
             if (c == AverStr::from("=")) {
                 aver_rt::AverList::prepend(
-                    Token::TkLte.clone(),
+                    crate::aver_generated::domain::token::Token::TkLte,
                     &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
                 )
             } else {
                 aver_rt::AverList::prepend(
-                    Token::TkLt.clone(),
+                    crate::aver_generated::domain::token::Token::TkLt,
                     &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                 )
             }
         }
         None => aver_rt::AverList::prepend(
-            Token::TkLt.clone(),
+            crate::aver_generated::domain::token::Token::TkLt,
             &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
         ),
     }
@@ -1045,18 +1131,18 @@ pub fn tokenizeGt(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
         Some(c) => {
             if (c == AverStr::from("=")) {
                 aver_rt::AverList::prepend(
-                    Token::TkGte.clone(),
+                    crate::aver_generated::domain::token::Token::TkGte,
                     &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
                 )
             } else {
                 aver_rt::AverList::prepend(
-                    Token::TkGt.clone(),
+                    crate::aver_generated::domain::token::Token::TkGt,
                     &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                 )
             }
         }
         None => aver_rt::AverList::prepend(
-            Token::TkGt.clone(),
+            crate::aver_generated::domain::token::Token::TkGt,
             &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
         ),
     }
@@ -1071,18 +1157,18 @@ pub fn tokenizeBang(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
         Some(c) => {
             if (c == AverStr::from("=")) {
                 aver_rt::AverList::prepend(
-                    Token::TkNeq.clone(),
+                    crate::aver_generated::domain::token::Token::TkNeq,
                     &crate::aver_generated::domain::lexer::tokenize(src, (pos + 2i64)),
                 )
             } else {
                 aver_rt::AverList::prepend(
-                    Token::TkBang.clone(),
+                    crate::aver_generated::domain::token::Token::TkBang,
                     &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                 )
             }
         }
         None => aver_rt::AverList::prepend(
-            Token::TkBang.clone(),
+            crate::aver_generated::domain::token::Token::TkBang,
             &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
         ),
     }
@@ -1099,25 +1185,25 @@ pub fn tokenizeEq(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
             let __dispatch_subject = c;
             if &*__dispatch_subject == "=" {
                 aver_rt::AverList::prepend(
-                    Token::TkEqEq.clone(),
+                    crate::aver_generated::domain::token::Token::TkEqEq,
                     &crate::aver_generated::domain::lexer::tokenize(src, pos2),
                 )
             } else {
                 if &*__dispatch_subject == ">" {
                     aver_rt::AverList::prepend(
-                        Token::TkFatArrow.clone(),
+                        crate::aver_generated::domain::token::Token::TkFatArrow,
                         &crate::aver_generated::domain::lexer::tokenize(src, pos2),
                     )
                 } else {
                     aver_rt::AverList::prepend(
-                        Token::TkEq.clone(),
+                        crate::aver_generated::domain::token::Token::TkEq,
                         &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
                     )
                 }
             }
         }
         None => aver_rt::AverList::prepend(
-            Token::TkEq.clone(),
+            crate::aver_generated::domain::token::Token::TkEq,
             &crate::aver_generated::domain::lexer::tokenize(src, nextPos),
         ),
     }
@@ -1130,7 +1216,7 @@ pub fn tokenizeNewline(src: AverStr, pos: i64) -> aver_rt::AverList<Token> {
     {
         let (indent, newPos) = r;
         aver_rt::AverList::prepend(
-            Token::TkNewline.clone(),
+            crate::aver_generated::domain::token::Token::TkNewline,
             &aver_rt::AverList::prepend(
                 crate::aver_generated::domain::token::Token::TkInt(((0i64 - indent) - 1i64)),
                 &crate::aver_generated::domain::lexer::tokenize(src, newPos),
@@ -1173,7 +1259,7 @@ pub fn processIndentToken(
         }
         crate::aver_generated::domain::token::Token::TkEof => aver_rt::AverList::concat(
             &crate::aver_generated::domain::lexer::emitFinalDedents(stack),
-            &aver_rt::AverList::from_vec(vec![Token::TkEof.clone()]),
+            &aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::token::Token::TkEof]),
         ),
         _ => aver_rt::AverList::prepend(
             t.clone(),
@@ -1189,7 +1275,7 @@ pub fn processAfterNewline(
     stack: &aver_rt::AverList<i64>,
 ) -> aver_rt::AverList<Token> {
     crate::cancel_checkpoint();
-    aver_list_match!(tokens.clone(), [] => aver_rt::AverList::prepend(Token::TkNewline.clone(), &crate::aver_generated::domain::lexer::emitFinalDedents(stack)), [t, rest] => crate::aver_generated::domain::lexer::processAfterNewlineToken(&t, &rest, stack))
+    aver_list_match!(tokens.clone(), [] => aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkNewline, &crate::aver_generated::domain::lexer::emitFinalDedents(stack)), [t, rest] => crate::aver_generated::domain::lexer::processAfterNewlineToken(&t, &rest, stack))
 }
 
 /// Check if token after newline is a raw indent marker.
@@ -1209,7 +1295,7 @@ pub fn processAfterNewlineToken(
                 )
             } else {
                 aver_rt::AverList::prepend(
-                    Token::TkNewline.clone(),
+                    crate::aver_generated::domain::token::Token::TkNewline,
                     &aver_rt::AverList::prepend(
                         t.clone(),
                         &crate::aver_generated::domain::lexer::processIndentation(rest, stack),
@@ -1218,7 +1304,7 @@ pub fn processAfterNewlineToken(
             }
         }
         _ => aver_rt::AverList::prepend(
-            Token::TkNewline.clone(),
+            crate::aver_generated::domain::token::Token::TkNewline,
             &aver_rt::AverList::prepend(
                 t.clone(),
                 &crate::aver_generated::domain::lexer::processIndentation(rest, stack),
@@ -1238,9 +1324,9 @@ pub fn emitIndentChange(
     let currentIndent = crate::aver_generated::domain::lexer::stackTop(stack);
     if (indent > currentIndent) {
         aver_rt::AverList::prepend(
-            Token::TkNewline.clone(),
+            crate::aver_generated::domain::token::Token::TkNewline,
             &aver_rt::AverList::prepend(
-                Token::TkIndent.clone(),
+                crate::aver_generated::domain::token::Token::TkIndent,
                 &crate::aver_generated::domain::lexer::processIndentation(
                     rest,
                     &aver_rt::AverList::prepend(indent, &stack.clone()),
@@ -1252,7 +1338,7 @@ pub fn emitIndentChange(
             crate::aver_generated::domain::lexer::emitDedents(indent, rest, stack)
         } else {
             aver_rt::AverList::prepend(
-                Token::TkNewline.clone(),
+                crate::aver_generated::domain::token::Token::TkNewline,
                 &crate::aver_generated::domain::lexer::processIndentation(rest, stack),
             )
         }
@@ -1285,12 +1371,13 @@ pub fn emitDedentsAcc(
     loop {
         crate::cancel_checkpoint();
         let reversed = acc.reverse();
-        return aver_list_match!(stack.clone(), [] => aver_rt::AverList::concat(&reversed, &crate::aver_generated::domain::lexer::processIndentation(&rest, &aver_rt::AverList::from_vec(vec![0i64]))), [top, below] => { if (top <= targetIndent) { aver_rt::AverList::concat(&reversed, &aver_rt::AverList::prepend(Token::TkNewline.clone(), &crate::aver_generated::domain::lexer::processIndentation(&rest, &stack))) } else { {
-            let __tmp3 = aver_rt::AverList::prepend(Token::TkDedent.clone(), &acc);
-            stack = below;
-            acc = __tmp3;
+        aver_list_match!(stack.clone(), [] => { return aver_rt::AverList::concat(&reversed, &crate::aver_generated::domain::lexer::processIndentation(&rest, &aver_rt::AverList::from_vec(vec![0i64]))); }, [top, below] => { if (top > targetIndent) { {
+            let __tco2 = below;
+            let __tco3 = aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkDedent, &acc);
+            stack = __tco2;
+            acc = __tco3;
             continue;
-        } } });
+        } } else { return aver_rt::AverList::concat(&reversed, &aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkNewline, &crate::aver_generated::domain::lexer::processIndentation(&rest, &stack))); } })
     }
 }
 
@@ -1313,12 +1400,13 @@ pub fn emitFinalDedentsAcc(
     loop {
         crate::cancel_checkpoint();
         let reversed = acc.reverse();
-        return aver_list_match!(stack, [] => reversed, [top, rest] => { if (top > 0i64) { {
-            let __tmp1 = aver_rt::AverList::prepend(Token::TkDedent.clone(), &acc);
-            stack = rest;
-            acc = __tmp1;
+        aver_list_match!(stack, [] => { return reversed; }, [top, rest] => { if (top > 0i64) { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkDedent, &acc);
+            stack = __tco0;
+            acc = __tco1;
             continue;
-        } } else { reversed } });
+        } } else { return reversed; } })
     }
 }
 

--- a/src/self_host/aver_generated/domain/match_mod/mod.rs
+++ b/src/self_host/aver_generated/domain/match_mod/mod.rs
@@ -516,12 +516,14 @@ pub fn zipBindingsAcc(
     loop {
         crate::cancel_checkpoint();
         let reversed = acc.reverse();
-        return aver_list_match!(names, [] => reversed, [n, ns] => { aver_list_match!(vals, [] => reversed, [v, vs] => { {
-            let __tmp2 = aver_rt::AverList::prepend((n, v), &acc);
-            names = ns;
-            vals = vs;
-            acc = __tmp2;
+        aver_list_match!(names, [] => { return reversed; }, [n, ns] => { aver_list_match!(vals, [] => { return reversed; }, [v, vs] => { {
+            let __tco0 = ns;
+            let __tco1 = vs;
+            let __tco2 = aver_rt::AverList::prepend((n, v), &acc);
+            names = __tco0;
+            vals = __tco1;
+            acc = __tco2;
             continue;
-        } }) });
+        } }) })
     }
 }

--- a/src/self_host/aver_generated/domain/parser/expr/mod.rs
+++ b/src/self_host/aver_generated/domain/parser/expr/mod.rs
@@ -33,27 +33,26 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> Result<(Expr, i64), A
             __MutualTco1::ParseAddExprRight(mut tokens, mut pos, mut left, mut op) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::expr::parseMulExpr(&tokens, pos)?;
-                match r {
-                    (right, pos2) => {
-                        if (op == 0i64) {
-                            __MutualTco1::ParseAddExprTail(
-                                tokens,
-                                pos2,
-                                crate::aver_generated::domain::ast::Expr::ExprAdd(
-                                    std::sync::Arc::new(left),
-                                    std::sync::Arc::new(right),
-                                ),
-                            )
-                        } else {
-                            __MutualTco1::ParseAddExprTail(
-                                tokens,
-                                pos2,
-                                crate::aver_generated::domain::ast::Expr::ExprSub(
-                                    std::sync::Arc::new(left),
-                                    std::sync::Arc::new(right),
-                                ),
-                            )
-                        }
+                {
+                    let (right, pos2) = r;
+                    if (op == 0i64) {
+                        __MutualTco1::ParseAddExprTail(
+                            tokens,
+                            pos2,
+                            crate::aver_generated::domain::ast::Expr::ExprAdd(
+                                std::sync::Arc::new(left),
+                                std::sync::Arc::new(right),
+                            ),
+                        )
+                    } else {
+                        __MutualTco1::ParseAddExprTail(
+                            tokens,
+                            pos2,
+                            crate::aver_generated::domain::ast::Expr::ExprSub(
+                                std::sync::Arc::new(left),
+                                std::sync::Arc::new(right),
+                            ),
+                        )
                     }
                 }
             }
@@ -124,13 +123,14 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> Result<(Expr, i64), A
             __MutualTco2::ParseCallArgsList(mut tokens, mut pos, mut name, mut acc) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
-                match r {
-                    (expr, pos2) => __MutualTco2::ParseCallArgsListTail(
+                {
+                    let (expr, pos2) = r;
+                    __MutualTco2::ParseCallArgsListTail(
                         tokens,
                         pos2,
                         name,
                         aver_rt::AverList::prepend(expr, &acc),
-                    ),
+                    )
                 }
             }
             __MutualTco2::ParseCallArgsListTail(mut tokens, mut pos0, mut name, mut args) => {
@@ -343,12 +343,13 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<(Expr, i64), A
             __MutualTco4::ParseInterpParts(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
-                match r {
-                    (expr, pos2) => __MutualTco4::ParseInterpAfterExpr(
+                {
+                    let (expr, pos2) = r;
+                    __MutualTco4::ParseInterpAfterExpr(
                         tokens,
                         pos2,
                         aver_rt::AverList::prepend(expr, &acc),
-                    ),
+                    )
                 }
             }
             __MutualTco4::ParseInterpAfterExpr(mut tokens, mut pos, mut acc) => {
@@ -468,12 +469,13 @@ fn __mutual_tco_trampoline_5(mut __state: __MutualTco5) -> Result<(Expr, i64), A
             __MutualTco5::ParseListItems(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
-                match r {
-                    (expr, pos2) => __MutualTco5::ParseListItemsTail(
+                {
+                    let (expr, pos2) = r;
+                    __MutualTco5::ParseListItemsTail(
                         tokens,
                         pos2,
                         aver_rt::AverList::prepend(expr, &acc),
-                    ),
+                    )
                 }
             }
             __MutualTco5::ParseListItemsTail(mut tokens, mut pos0, mut items) => {
@@ -567,8 +569,9 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<(Expr, i64), A
             __MutualTco6::ParseMapEntries(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 let kr = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
-                match kr {
-                    (keyExpr, pos2) => __MutualTco6::ParseMapAfterKey(tokens, pos2, acc, keyExpr),
+                {
+                    let (keyExpr, pos2) = kr;
+                    __MutualTco6::ParseMapAfterKey(tokens, pos2, acc, keyExpr)
                 }
             }
             __MutualTco6::ParseMapAfterKey(mut tokens, mut pos, mut acc, mut keyExpr) => {
@@ -576,11 +579,12 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<(Expr, i64), A
                 let pos2 = crate::aver_generated::domain::parser_match::expect(
                     &tokens,
                     pos,
-                    &Token::TkFatArrow,
+                    &crate::aver_generated::domain::token::Token::TkFatArrow,
                 )?;
                 let vr = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
-                match vr {
-                    (valExpr, pos3) => __MutualTco6::ParseMapEntryTail(
+                {
+                    let (valExpr, pos3) = vr;
+                    __MutualTco6::ParseMapEntryTail(
                         tokens,
                         pos3,
                         aver_rt::AverList::prepend(
@@ -589,7 +593,7 @@ fn __mutual_tco_trampoline_6(mut __state: __MutualTco6) -> Result<(Expr, i64), A
                             ),
                             &acc,
                         ),
-                    ),
+                    )
                 }
             }
             __MutualTco6::ParseMapEntryTail(mut tokens, mut pos, mut acc) => {
@@ -732,8 +736,9 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<(Expr, i64), A
             __MutualTco7::ParseOneArm(mut tokens, mut pos, mut subject, mut acc) => {
                 crate::cancel_checkpoint();
                 let pr = crate::aver_generated::domain::parser_match::parsePattern(&tokens, pos)?;
-                match pr {
-                    (pat, pos2) => __MutualTco7::ParseOneArmBody(tokens, pos2, subject, acc, pat),
+                {
+                    let (pat, pos2) = pr;
+                    __MutualTco7::ParseOneArmBody(tokens, pos2, subject, acc, pat)
                 }
             }
             __MutualTco7::ParseOneArmBody(mut tokens, mut pos, mut subject, mut acc, mut pat) => {
@@ -741,23 +746,24 @@ fn __mutual_tco_trampoline_7(mut __state: __MutualTco7) -> Result<(Expr, i64), A
                 let pos2 = crate::aver_generated::domain::parser_match::expect(
                     &tokens,
                     pos,
-                    &Token::TkArrow,
+                    &crate::aver_generated::domain::token::Token::TkArrow,
                 )?;
                 let er = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
-                match er {
-                    (body, pos3) => __MutualTco7::ParseMatchArms(
+                {
+                    let (body, pos3) = er;
+                    __MutualTco7::ParseMatchArms(
                         tokens.clone(),
                         crate::aver_generated::domain::parser_match::skipNewlines(tokens, pos3),
                         subject,
                         aver_rt::AverList::prepend(
-                            MatchArm {
+                            crate::aver_generated::domain::ast::MatchArm {
                                 pattern: pat,
                                 body: body,
                                 bindingSlots: HashMap::new(),
                             },
                             &acc,
                         ),
-                    ),
+                    )
                 }
             }
         };
@@ -861,10 +867,9 @@ fn __mutual_tco_trampoline_8(mut __state: __MutualTco8) -> Result<(Expr, i64), A
             __MutualTco8::ParseOneArmFlat(mut tokens, mut pos, mut subject, mut acc) => {
                 crate::cancel_checkpoint();
                 let pr = crate::aver_generated::domain::parser_match::parsePattern(&tokens, pos)?;
-                match pr {
-                    (pat, pos2) => {
-                        __MutualTco8::ParseOneArmFlatBody(tokens, pos2, subject, acc, pat)
-                    }
+                {
+                    let (pat, pos2) = pr;
+                    __MutualTco8::ParseOneArmFlatBody(tokens, pos2, subject, acc, pat)
                 }
             }
             __MutualTco8::ParseOneArmFlatBody(
@@ -878,23 +883,24 @@ fn __mutual_tco_trampoline_8(mut __state: __MutualTco8) -> Result<(Expr, i64), A
                 let pos2 = crate::aver_generated::domain::parser_match::expect(
                     &tokens,
                     pos,
-                    &Token::TkArrow,
+                    &crate::aver_generated::domain::token::Token::TkArrow,
                 )?;
                 let er = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
-                match er {
-                    (body, pos3) => __MutualTco8::ParseMatchArmsFlat(
+                {
+                    let (body, pos3) = er;
+                    __MutualTco8::ParseMatchArmsFlat(
                         tokens.clone(),
                         crate::aver_generated::domain::parser_match::skipNewlines(tokens, pos3),
                         subject,
                         aver_rt::AverList::prepend(
-                            MatchArm {
+                            crate::aver_generated::domain::ast::MatchArm {
                                 pattern: pat,
                                 body: body,
                                 bindingSlots: HashMap::new(),
                             },
                             &acc,
                         ),
-                    ),
+                    )
                 }
             }
         };
@@ -973,27 +979,26 @@ fn __mutual_tco_trampoline_9(mut __state: __MutualTco9) -> Result<(Expr, i64), A
             __MutualTco9::ParseMulExprRight(mut tokens, mut pos, mut left, mut op) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::expr::parseAtom(&tokens, pos)?;
-                match r {
-                    (right, pos2) => {
-                        if (op == 0i64) {
-                            __MutualTco9::ParseMulExprTail(
-                                tokens,
-                                pos2,
-                                crate::aver_generated::domain::ast::Expr::ExprMul(
-                                    std::sync::Arc::new(left),
-                                    std::sync::Arc::new(right),
-                                ),
-                            )
-                        } else {
-                            __MutualTco9::ParseMulExprTail(
-                                tokens,
-                                pos2,
-                                crate::aver_generated::domain::ast::Expr::ExprDiv(
-                                    std::sync::Arc::new(left),
-                                    std::sync::Arc::new(right),
-                                ),
-                            )
-                        }
+                {
+                    let (right, pos2) = r;
+                    if (op == 0i64) {
+                        __MutualTco9::ParseMulExprTail(
+                            tokens,
+                            pos2,
+                            crate::aver_generated::domain::ast::Expr::ExprMul(
+                                std::sync::Arc::new(left),
+                                std::sync::Arc::new(right),
+                            ),
+                        )
+                    } else {
+                        __MutualTco9::ParseMulExprTail(
+                            tokens,
+                            pos2,
+                            crate::aver_generated::domain::ast::Expr::ExprDiv(
+                                std::sync::Arc::new(left),
+                                std::sync::Arc::new(right),
+                            ),
+                        )
                     }
                 }
             }
@@ -1113,17 +1118,18 @@ fn __mutual_tco_trampoline_10(mut __state: __MutualTco10) -> Result<(Expr, i64),
                 let pos2 = crate::aver_generated::domain::parser_match::expect(
                     &tokens,
                     pos,
-                    &Token::TkEq,
+                    &crate::aver_generated::domain::token::Token::TkEq,
                 )?;
                 let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
-                match r {
-                    (expr, pos3) => __MutualTco10::ParseNamedArgsTail(
+                {
+                    let (expr, pos3) = r;
+                    __MutualTco10::ParseNamedArgsTail(
                         tokens,
                         pos3,
                         name,
                         positionalArgs,
                         aver_rt::AverList::prepend((field, expr), &namedAcc),
-                    ),
+                    )
                 }
             }
             __MutualTco10::ParseNamedArgsTail(
@@ -1271,16 +1277,17 @@ fn __mutual_tco_trampoline_11(mut __state: __MutualTco11) -> Result<(Expr, i64),
                 let pos2 = crate::aver_generated::domain::parser_match::expect(
                     &tokens,
                     pos,
-                    &Token::TkEq,
+                    &crate::aver_generated::domain::token::Token::TkEq,
                 )?;
                 let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos2)?;
-                match r {
-                    (expr, pos3) => __MutualTco11::ParseRecordFieldsTail(
+                {
+                    let (expr, pos3) = r;
+                    __MutualTco11::ParseRecordFieldsTail(
                         tokens,
                         pos3,
                         name,
                         aver_rt::AverList::prepend((field, expr), &acc),
-                    ),
+                    )
                 }
             }
             __MutualTco11::ParseRecordFieldsTail(mut tokens, mut pos, mut name, mut fields) => {
@@ -1401,12 +1408,13 @@ fn __mutual_tco_trampoline_12(mut __state: __MutualTco12) -> Result<(Expr, i64),
             __MutualTco12::ParseTupleRest(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::expr::parseExpr(&tokens, pos)?;
-                match r {
-                    (expr, pos2) => __MutualTco12::ParseTupleRestTail(
+                {
+                    let (expr, pos2) = r;
+                    __MutualTco12::ParseTupleRestTail(
                         tokens,
                         pos2,
                         aver_rt::AverList::prepend(expr, &acc),
-                    ),
+                    )
                 }
             }
             __MutualTco12::ParseTupleRestTail(mut tokens, mut pos0, mut items) => {
@@ -1918,21 +1926,26 @@ pub fn skipNl(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+        match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
             crate::aver_generated::domain::token::Token::TkNewline => {
-                pos = nextPos;
+                let __tco1 = nextPos;
+                pos = __tco1;
                 continue;
             }
             crate::aver_generated::domain::token::Token::TkIndent => {
-                pos = nextPos;
+                let __tco1 = nextPos;
+                pos = __tco1;
                 continue;
             }
             crate::aver_generated::domain::token::Token::TkDedent => {
-                pos = nextPos;
+                let __tco1 = nextPos;
+                pos = __tco1;
                 continue;
             }
-            _ => pos,
-        };
+            _ => {
+                return pos;
+            }
+        }
     }
 }
 

--- a/src/self_host/aver_generated/domain/parser/mod.rs
+++ b/src/self_host/aver_generated/domain/parser/mod.rs
@@ -34,12 +34,13 @@ fn __mutual_tco_trampoline_1(
             __MutualTco1::ParseFnBodyOneStmtFlat(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::parseStmt(&tokens, pos)?;
-                match r {
-                    (stmt, pos2) => __MutualTco1::ParseFnBodyAfterStmtFlat(
+                {
+                    let (stmt, pos2) = r;
+                    __MutualTco1::ParseFnBodyAfterStmtFlat(
                         tokens,
                         pos2,
                         aver_rt::AverList::prepend(stmt, &acc),
-                    ),
+                    )
                 }
             }
             __MutualTco1::ParseFnBodyAfterStmtFlat(mut tokens, mut pos, mut acc) => {
@@ -120,12 +121,13 @@ fn __mutual_tco_trampoline_2(
             __MutualTco2::ParseFnBodyOneStmtIndented(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::parseStmt(&tokens, pos)?;
-                match r {
-                    (stmt, pos2) => __MutualTco2::ParseFnBodyStmtsIndented(
+                {
+                    let (stmt, pos2) = r;
+                    __MutualTco2::ParseFnBodyStmtsIndented(
                         tokens,
                         pos2,
                         aver_rt::AverList::prepend(stmt, &acc),
-                    ),
+                    )
                 }
             }
         };
@@ -208,7 +210,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Program, AverS
                 );
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos2.clone()) {
                     crate::aver_generated::domain::token::Token::TkEof => {
-                        return Ok(Program {
+                        return Ok(crate::aver_generated::domain::ast::Program {
                             deps: deps,
                             fns: fns.reverse(),
                             stmts: stmts.reverse(),
@@ -296,36 +298,37 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Program, AverS
                 crate::cancel_checkpoint();
                 let r =
                     crate::aver_generated::domain::parser_match::parseModuleHeader(&tokens, pos);
-                match r {
-                    (depList, endPos) => {
-                        __MutualTco3::ParseProgram(tokens, endPos, depList, fns, stmts)
-                    }
+                {
+                    let (depList, endPos) = r;
+                    __MutualTco3::ParseProgram(tokens, endPos, depList, fns, stmts)
                 }
             }
             __MutualTco3::ParseProgramFn(mut tokens, mut pos, mut deps, mut fns, mut stmts) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::parseFnDef(&tokens, pos)?;
-                match r {
-                    (fd, pos2) => __MutualTco3::ParseProgram(
+                {
+                    let (fd, pos2) = r;
+                    __MutualTco3::ParseProgram(
                         tokens.clone(),
                         crate::aver_generated::domain::parser_match::skipNewlines(tokens, pos2),
                         deps,
                         aver_rt::AverList::prepend(fd, &fns),
                         stmts,
-                    ),
+                    )
                 }
             }
             __MutualTco3::ParseProgramStmt(mut tokens, mut pos, mut deps, mut fns, mut stmts) => {
                 crate::cancel_checkpoint();
                 let r = crate::aver_generated::domain::parser::parseStmt(&tokens, pos)?;
-                match r {
-                    (st, pos2) => __MutualTco3::ParseProgram(
+                {
+                    let (st, pos2) = r;
+                    __MutualTco3::ParseProgram(
                         tokens.clone(),
                         crate::aver_generated::domain::parser_match::skipNewlines(tokens, pos2),
                         deps,
                         fns,
                         aver_rt::AverList::prepend(st, &stmts),
-                    ),
+                    )
                 }
             }
         };
@@ -503,28 +506,31 @@ pub fn countIndentsInRange(
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return if (pos >= endPos) {
-            count
-        } else {
+        if (pos < endPos) {
             match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
                 crate::aver_generated::domain::token::Token::TkIndent => {
-                    let __tmp3 = (count + 1i64);
-                    pos = nextPos;
-                    count = __tmp3;
+                    let __tco1 = nextPos;
+                    let __tco3 = (count + 1i64);
+                    pos = __tco1;
+                    count = __tco3;
                     continue;
                 }
                 crate::aver_generated::domain::token::Token::TkDedent => {
-                    let __tmp3 = (count - 1i64);
-                    pos = nextPos;
-                    count = __tmp3;
+                    let __tco1 = nextPos;
+                    let __tco3 = (count - 1i64);
+                    pos = __tco1;
+                    count = __tco3;
                     continue;
                 }
                 _ => {
-                    pos = nextPos;
+                    let __tco1 = nextPos;
+                    pos = __tco1;
                     continue;
                 }
             }
-        };
+        } else {
+            return count;
+        }
     }
 }
 
@@ -534,24 +540,27 @@ pub fn skipNDedents(mut tokens: aver_rt::AverList<Token>, mut pos: i64, mut n: i
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return if (n <= 0i64) {
-            pos
-        } else {
+        if (n > 0i64) {
             match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
                 crate::aver_generated::domain::token::Token::TkNewline => {
-                    pos = nextPos;
+                    let __tco1 = nextPos;
+                    pos = __tco1;
                     continue;
                 }
                 crate::aver_generated::domain::token::Token::TkDedent => {
-                    let __tmp1 = nextPos;
-                    let __tmp2 = (n - 1i64);
-                    pos = __tmp1;
-                    n = __tmp2;
+                    let __tco1 = nextPos;
+                    let __tco2 = (n - 1i64);
+                    pos = __tco1;
+                    n = __tco2;
                     continue;
                 }
-                _ => pos,
+                _ => {
+                    return pos;
+                }
             }
-        };
+        } else {
+            return pos;
+        }
     }
 }
 
@@ -658,7 +667,11 @@ pub fn parseFnDefParams(
     name: AverStr,
 ) -> Result<(FnDef, i64), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::expect(tokens, pos, &Token::TkLParen)?;
+    let pos2 = crate::aver_generated::domain::parser_match::expect(
+        tokens,
+        pos,
+        &crate::aver_generated::domain::token::Token::TkLParen,
+    )?;
     let pr = crate::aver_generated::domain::parser_match::parseParamList(
         tokens,
         pos2,
@@ -710,13 +723,13 @@ pub fn parseFnDefBodyIndented(
     {
         let (stmts, pos3) = sr;
         Ok((
-            FnDef {
+            crate::aver_generated::domain::ast::FnDef {
                 name: name,
                 params: params.clone(),
                 body: stmts.reverse(),
                 slotCount: 0i64,
                 slotMap: HashMap::new(),
-                fastPath: FnFastPath::FastNone.clone(),
+                fastPath: crate::aver_generated::domain::ast::FnFastPath::FastNone,
                 tailLoop: false,
             },
             pos3,
@@ -741,13 +754,13 @@ pub fn parseFnDefBodyFlat(
     {
         let (stmts, pos3) = sr;
         Ok((
-            FnDef {
+            crate::aver_generated::domain::ast::FnDef {
                 name: name,
                 params: params.clone(),
                 body: stmts.reverse(),
                 slotCount: 0i64,
                 slotMap: HashMap::new(),
-                fastPath: FnFastPath::FastNone.clone(),
+                fastPath: crate::aver_generated::domain::ast::FnFastPath::FastNone,
                 tailLoop: false,
             },
             pos3,

--- a/src/self_host/aver_generated/domain/parser_match/mod.rs
+++ b/src/self_host/aver_generated/domain/parser_match/mod.rs
@@ -126,10 +126,16 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> Result<(Pattern, i64)
                 crate::cancel_checkpoint();
                 let nextPos = (pos + 1i64);
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                crate::aver_generated::domain::token::Token::TkDot => __MutualTco2::ParseIdentPatternDotted(tokens, nextPos, name),
-                crate::aver_generated::domain::token::Token::TkLParen => return crate::aver_generated::domain::parser_match::parseConstructorPatternBindings(&tokens, nextPos, name, &aver_rt::AverList::empty()),
-                _ => if name.contains(".") { return Ok((crate::aver_generated::domain::ast::Pattern::PatConstructor(name, aver_rt::AverList::empty()), pos)) } else { return Ok((crate::aver_generated::domain::ast::Pattern::PatVar(name), pos)) }
-                }
+        crate::aver_generated::domain::token::Token::TkDot => {
+            __MutualTco2::ParseIdentPatternDotted(tokens, nextPos, name)
+        },
+        crate::aver_generated::domain::token::Token::TkLParen => {
+            return crate::aver_generated::domain::parser_match::parseConstructorPatternBindings(&tokens, nextPos, name, &aver_rt::AverList::empty())
+        },
+        _ => {
+            if name.contains(".") { return Ok((crate::aver_generated::domain::ast::Pattern::PatConstructor(name, aver_rt::AverList::empty()), pos)) } else { return Ok((crate::aver_generated::domain::ast::Pattern::PatVar(name), pos)) }
+        }
+    }
             }
             __MutualTco2::ParseIdentPatternDotted(mut tokens, mut pos, mut prefix) => {
                 crate::cancel_checkpoint();
@@ -271,12 +277,13 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<(Pattern, i64)
             __MutualTco4::ParseTuplePatternElement(mut tokens, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
                 let pr = crate::aver_generated::domain::parser_match::parsePattern(&tokens, pos)?;
-                match pr {
-                    (pat, pos2) => __MutualTco4::ParseTuplePatternElementTail(
+                {
+                    let (pat, pos2) = pr;
+                    __MutualTco4::ParseTuplePatternElementTail(
                         tokens,
                         pos2,
                         aver_rt::AverList::prepend(pat, &acc),
-                    ),
+                    )
                 }
             }
             __MutualTco4::ParseTuplePatternElementTail(mut tokens, mut pos, mut acc) => {
@@ -416,12 +423,13 @@ pub fn tokenAt(tokens: &aver_rt::AverList<Token>, pos: i64) -> Token {
 pub fn tokenAtWalk(mut tokens: aver_rt::AverList<Token>, mut target: i64, mut idx: i64) -> Token {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(tokens, [] => Token::TkEof, [t, rest] => { if (idx == target) { t } else { {
-            let __tmp2 = (idx + 1i64);
-            tokens = rest;
-            idx = __tmp2;
+        aver_list_match!(tokens, [] => { return crate::aver_generated::domain::token::Token::TkEof; }, [t, rest] => { if (idx == target) { return t; } else { {
+            let __tco0 = rest;
+            let __tco2 = (idx + 1i64);
+            tokens = __tco0;
+            idx = __tco2;
             continue;
-        } } });
+        } } })
     }
 }
 
@@ -472,14 +480,16 @@ pub fn expect(
 pub fn skipNewlines(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
-        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+        match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
             crate::aver_generated::domain::token::Token::TkNewline => {
-                let __tmp1 = (pos + 1i64);
-                pos = __tmp1;
+                let __tco1 = (pos + 1i64);
+                pos = __tco1;
                 continue;
             }
-            _ => pos,
-        };
+            _ => {
+                return pos;
+            }
+        }
     }
 }
 
@@ -488,17 +498,21 @@ pub fn skipNewlinesAndDedents(mut tokens: aver_rt::AverList<Token>, mut pos: i64
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+        match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
             crate::aver_generated::domain::token::Token::TkNewline => {
-                pos = nextPos;
+                let __tco1 = nextPos;
+                pos = __tco1;
                 continue;
             }
             crate::aver_generated::domain::token::Token::TkDedent => {
-                pos = nextPos;
+                let __tco1 = nextPos;
+                pos = __tco1;
                 continue;
             }
-            _ => pos,
-        };
+            _ => {
+                return pos;
+            }
+        }
     }
 }
 
@@ -563,7 +577,7 @@ pub fn parseIdentPattern(
 ) -> Result<(Pattern, i64), AverStr> {
     crate::cancel_checkpoint();
     if (name == AverStr::from("_")) {
-        Ok((Pattern::PatWild.clone(), pos))
+        Ok((crate::aver_generated::domain::ast::Pattern::PatWild, pos))
     } else {
         crate::aver_generated::domain::parser_match::parseIdentPatternMaybeConstructor(
             tokens, pos, name,
@@ -591,9 +605,10 @@ pub fn parseListPattern(
 ) -> Result<(Pattern, i64), AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos) {
-        crate::aver_generated::domain::token::Token::TkRBracket => {
-            Ok((Pattern::PatEmpty.clone(), (pos + 1i64)))
-        }
+        crate::aver_generated::domain::token::Token::TkRBracket => Ok((
+            crate::aver_generated::domain::ast::Pattern::PatEmpty,
+            (pos + 1i64),
+        )),
         crate::aver_generated::domain::token::Token::TkIdent(head) => {
             crate::aver_generated::domain::parser_match::parseConsPattern(
                 tokens,
@@ -612,8 +627,16 @@ pub fn parseConsPattern(
     head: AverStr,
 ) -> Result<(Pattern, i64), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::expect(tokens, pos, &Token::TkComma)?;
-    let pos3 = crate::aver_generated::domain::parser_match::expect(tokens, pos2, &Token::TkDotDot)?;
+    let pos2 = crate::aver_generated::domain::parser_match::expect(
+        tokens,
+        pos,
+        &crate::aver_generated::domain::token::Token::TkComma,
+    )?;
+    let pos3 = crate::aver_generated::domain::parser_match::expect(
+        tokens,
+        pos2,
+        &crate::aver_generated::domain::token::Token::TkDotDot,
+    )?;
     let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos3.clone());
     match t {
         crate::aver_generated::domain::token::Token::TkIdent(tail) => Ok((
@@ -621,7 +644,7 @@ pub fn parseConsPattern(
             crate::aver_generated::domain::parser_match::expect(
                 tokens,
                 (pos3 + 1i64),
-                &Token::TkRBracket,
+                &crate::aver_generated::domain::token::Token::TkRBracket,
             )?,
         )),
         _ => Err(AverStr::from("Expected tail identifier in cons pattern")),
@@ -663,22 +686,28 @@ pub fn skipTypeExprTail(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> i
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+        match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
             crate::aver_generated::domain::token::Token::TkLt => {
-                crate::aver_generated::domain::parser_match::skipUntilGt(tokens, nextPos, 1i64)
+                return crate::aver_generated::domain::parser_match::skipUntilGt(
+                    tokens, nextPos, 1i64,
+                );
             }
             crate::aver_generated::domain::token::Token::TkDot => {
                 match crate::aver_generated::domain::parser_match::tokenAt(&tokens, nextPos) {
                     crate::aver_generated::domain::token::Token::TkIdent(_) => {
-                        let __tmp1 = (pos + 2i64);
-                        pos = __tmp1;
+                        let __tco1 = (pos + 2i64);
+                        pos = __tco1;
                         continue;
                     }
-                    _ => pos,
+                    _ => {
+                        return pos;
+                    }
                 }
             }
-            _ => pos,
-        };
+            _ => {
+                return pos;
+            }
+        }
     }
 }
 
@@ -688,29 +717,34 @@ pub fn skipUntilGt(mut tokens: aver_rt::AverList<Token>, mut pos: i64, mut depth
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return if (depth == 0i64) {
-            pos
+        if (depth == 0i64) {
+            return pos;
         } else {
             match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                crate::aver_generated::domain::token::Token::TkEof => pos,
+                crate::aver_generated::domain::token::Token::TkEof => {
+                    return pos;
+                }
                 crate::aver_generated::domain::token::Token::TkLt => {
-                    let __tmp2 = (depth + 1i64);
-                    pos = nextPos;
-                    depth = __tmp2;
+                    let __tco1 = nextPos;
+                    let __tco2 = (depth + 1i64);
+                    pos = __tco1;
+                    depth = __tco2;
                     continue;
                 }
                 crate::aver_generated::domain::token::Token::TkGt => {
-                    let __tmp2 = (depth - 1i64);
-                    pos = nextPos;
-                    depth = __tmp2;
+                    let __tco1 = nextPos;
+                    let __tco2 = (depth - 1i64);
+                    pos = __tco1;
+                    depth = __tco2;
                     continue;
                 }
                 _ => {
-                    pos = nextPos;
+                    let __tco1 = nextPos;
+                    pos = __tco1;
                     continue;
                 }
             }
-        };
+        }
     }
 }
 
@@ -720,29 +754,34 @@ pub fn skipUntilClose(mut tokens: aver_rt::AverList<Token>, mut pos: i64, mut de
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return if (depth == 0i64) {
-            pos
+        if (depth == 0i64) {
+            return pos;
         } else {
             match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                crate::aver_generated::domain::token::Token::TkEof => pos,
+                crate::aver_generated::domain::token::Token::TkEof => {
+                    return pos;
+                }
                 crate::aver_generated::domain::token::Token::TkLParen => {
-                    let __tmp2 = (depth + 1i64);
-                    pos = nextPos;
-                    depth = __tmp2;
+                    let __tco1 = nextPos;
+                    let __tco2 = (depth + 1i64);
+                    pos = __tco1;
+                    depth = __tco2;
                     continue;
                 }
                 crate::aver_generated::domain::token::Token::TkRParen => {
-                    let __tmp2 = (depth - 1i64);
-                    pos = nextPos;
-                    depth = __tmp2;
+                    let __tco1 = nextPos;
+                    let __tco2 = (depth - 1i64);
+                    pos = __tco1;
+                    depth = __tco2;
                     continue;
                 }
                 _ => {
-                    pos = nextPos;
+                    let __tco1 = nextPos;
+                    pos = __tco1;
                     continue;
                 }
             }
-        };
+        }
     }
 }
 
@@ -762,25 +801,27 @@ pub fn skipDescAndEffects(mut tokens: aver_rt::AverList<Token>, mut pos: i64) ->
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+        match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
             crate::aver_generated::domain::token::Token::TkQuestion => {
-                let __tmp0 = tokens.clone();
-                let __tmp1 =
+                let __tco0 = tokens.clone();
+                let __tco1 =
                     crate::aver_generated::domain::parser_match::skipToNextLine(tokens, nextPos);
-                tokens = __tmp0;
-                pos = __tmp1;
+                tokens = __tco0;
+                pos = __tco1;
                 continue;
             }
             crate::aver_generated::domain::token::Token::TkBang => {
-                let __tmp0 = tokens.clone();
-                let __tmp1 =
+                let __tco0 = tokens.clone();
+                let __tco1 =
                     crate::aver_generated::domain::parser_match::skipEffectsBlock(&tokens, nextPos);
-                tokens = __tmp0;
-                pos = __tmp1;
+                tokens = __tco0;
+                pos = __tco1;
                 continue;
             }
-            _ => pos,
-        };
+            _ => {
+                return pos;
+            }
+        }
     }
 }
 
@@ -803,16 +844,19 @@ pub fn skipUntilRBracket(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> 
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-            crate::aver_generated::domain::token::Token::TkEof => pos,
+        match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkEof => {
+                return pos;
+            }
             crate::aver_generated::domain::token::Token::TkRBracket => {
-                crate::aver_generated::domain::parser_match::skipNewlines(tokens, nextPos)
+                return crate::aver_generated::domain::parser_match::skipNewlines(tokens, nextPos);
             }
             _ => {
-                pos = nextPos;
+                let __tco1 = nextPos;
+                pos = __tco1;
                 continue;
             }
-        };
+        }
     }
 }
 
@@ -821,14 +865,19 @@ pub fn skipToNextLine(mut tokens: aver_rt::AverList<Token>, mut pos: i64) -> i64
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-            crate::aver_generated::domain::token::Token::TkEof => pos,
-            crate::aver_generated::domain::token::Token::TkNewline => nextPos,
+        match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkEof => {
+                return pos;
+            }
+            crate::aver_generated::domain::token::Token::TkNewline => {
+                return nextPos;
+            }
             _ => {
-                pos = nextPos;
+                let __tco1 = nextPos;
+                pos = __tco1;
                 continue;
             }
-        };
+        }
     }
 }
 
@@ -854,31 +903,36 @@ pub fn skipIndentBlock(mut tokens: aver_rt::AverList<Token>, mut pos: i64, mut d
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-            crate::aver_generated::domain::token::Token::TkEof => pos,
+        match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
+            crate::aver_generated::domain::token::Token::TkEof => {
+                return pos;
+            }
             crate::aver_generated::domain::token::Token::TkIndent => {
-                let __tmp2 = (depth + 1i64);
-                pos = nextPos;
-                depth = __tmp2;
+                let __tco1 = nextPos;
+                let __tco2 = (depth + 1i64);
+                pos = __tco1;
+                depth = __tco2;
                 continue;
             }
             crate::aver_generated::domain::token::Token::TkDedent => {
-                if (depth <= 1i64) {
-                    nextPos
-                } else {
+                if (depth > 1i64) {
                     {
-                        let __tmp2 = (depth - 1i64);
-                        pos = nextPos;
-                        depth = __tmp2;
+                        let __tco1 = nextPos;
+                        let __tco2 = (depth - 1i64);
+                        pos = __tco1;
+                        depth = __tco2;
                         continue;
                     }
+                } else {
+                    return nextPos;
                 }
             }
             _ => {
-                pos = nextPos;
+                let __tco1 = nextPos;
+                pos = __tco1;
                 continue;
             }
-        };
+        }
     }
 }
 
@@ -907,28 +961,30 @@ pub fn findDependsInRange(
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return if (pos >= endPos) {
-            aver_rt::AverList::empty()
-        } else {
+        if (pos < endPos) {
             match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
                 crate::aver_generated::domain::token::Token::TkIdent(kw) => {
-                    if (&*kw == "depends") {
-                        crate::aver_generated::domain::parser_match::findDependsListAt(
+                    if (kw == AverStr::from("depends")) {
+                        return crate::aver_generated::domain::parser_match::findDependsListAt(
                             &tokens, nextPos, endPos,
-                        )
+                        );
                     } else {
                         {
-                            pos = nextPos;
+                            let __tco1 = nextPos;
+                            pos = __tco1;
                             continue;
                         }
                     }
                 }
                 _ => {
-                    pos = nextPos;
+                    let __tco1 = nextPos;
+                    pos = __tco1;
                     continue;
                 }
             }
-        };
+        } else {
+            return aver_rt::AverList::empty();
+        }
     }
 }
 
@@ -963,23 +1019,27 @@ pub fn collectDependsNames(
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return if (pos >= endPos) {
-            acc.reverse()
-        } else {
+        if (pos < endPos) {
             match crate::aver_generated::domain::parser_match::tokenAt(&tokens, pos) {
-                crate::aver_generated::domain::token::Token::TkRBracket => acc.reverse(),
+                crate::aver_generated::domain::token::Token::TkRBracket => {
+                    return acc.reverse();
+                }
                 crate::aver_generated::domain::token::Token::TkIdent(name) => {
-                    let __tmp3 = aver_rt::AverList::prepend(name, &acc);
-                    pos = nextPos;
-                    acc = __tmp3;
+                    let __tco1 = nextPos;
+                    let __tco3 = aver_rt::AverList::prepend(name, &acc);
+                    pos = __tco1;
+                    acc = __tco3;
                     continue;
                 }
                 _ => {
-                    pos = nextPos;
+                    let __tco1 = nextPos;
+                    pos = __tco1;
                     continue;
                 }
             }
-        };
+        } else {
+            return acc.reverse();
+        }
     }
 }
 

--- a/src/self_host/aver_generated/domain/resolver/calls/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/calls/mod.rs
@@ -12,14 +12,15 @@ pub fn buildFnMap(
 ) -> aver_rt::AverMap<AverStr, i64> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fns, [] => acc, [f, rest] => { {
-            let __tmp1 = acc.insert_owned(f.name.clone(), idx);
-            let __tmp2 = (idx + 1i64);
-            fns = rest;
-            acc = __tmp1;
-            idx = __tmp2;
+        aver_list_match!(fns, [] => { return acc; }, [f, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = acc.insert_owned(f.name.clone(), idx);
+            let __tco2 = (idx + 1i64);
+            fns = __tco0;
+            acc = __tco1;
+            idx = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -32,21 +33,22 @@ pub fn resolveCallsInFns(
 ) -> aver_rt::AverList<FnDef> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fns, [] => acc.reverse(), [f, rest] => { {
-            let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::calls::resolveCallsInFn(&f, &fnMap), &acc);
-            fns = rest;
-            fnMap = __tmp1;
-            acc = __tmp2;
+        aver_list_match!(fns, [] => { return acc.reverse(); }, [f, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::calls::resolveCallsInFn(&f, &fnMap), &acc);
+            fns = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
 /// Transform calls in one function body.
 pub fn resolveCallsInFn(fd: &FnDef, fnMap: &aver_rt::AverMap<AverStr, i64>) -> FnDef {
     crate::cancel_checkpoint();
-    FnDef {
+    crate::aver_generated::domain::ast::FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
         body: crate::aver_generated::domain::resolver::calls::resolveCallsInStmts(
@@ -70,14 +72,15 @@ pub fn resolveCallsInStmts(
 ) -> aver_rt::AverList<Stmt> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(stmts, [] => acc.reverse(), [s, rest] => { {
-            let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::calls::resolveCallsInStmt(&s, &fnMap), &acc);
-            stmts = rest;
-            fnMap = __tmp1;
-            acc = __tmp2;
+        aver_list_match!(stmts, [] => { return acc.reverse(); }, [s, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::calls::resolveCallsInStmt(&s, &fnMap), &acc);
+            stmts = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -519,6 +522,7 @@ pub fn isBuiltinCallName(name: AverStr) -> bool {
             AverStr::from("HttpServer.listen"),
             AverStr::from("HttpServer.listenWith"),
             AverStr::from("Int.abs"),
+            AverStr::from("Int.div"),
             AverStr::from("Int.fromString"),
             AverStr::from("Int.max"),
             AverStr::from("Int.min"),
@@ -610,10 +614,11 @@ pub fn isBuiltinCallNameFrom(
 ) -> bool {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(knownNames, [] => false, [knownName, rest] => { if (name == knownName) { true } else { {
-            knownNames = rest;
+        aver_list_match!(knownNames, [] => { return false; }, [knownName, rest] => { if (name == knownName) { return true; } else { {
+            let __tco1 = rest;
+            knownNames = __tco1;
             continue;
-        } } });
+        } } })
     }
 }
 
@@ -626,14 +631,15 @@ pub fn resolveCallsInExprs(
 ) -> aver_rt::AverList<Expr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => acc.reverse(), [e, rest] => { {
-            let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&e, &fnMap), &acc);
-            exprs = rest;
-            fnMap = __tmp1;
-            acc = __tmp2;
+        aver_list_match!(exprs, [] => { return acc.reverse(); }, [e, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&e, &fnMap), &acc);
+            exprs = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -646,14 +652,15 @@ pub fn resolveCallsInArms(
 ) -> aver_rt::AverList<MatchArm> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(arms, [] => acc.reverse(), [arm, rest] => { {
-            let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(MatchArm { pattern: arm.pattern.clone(), body: crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&arm.body, &fnMap), bindingSlots: arm.bindingSlots.clone() }, &acc);
-            arms = rest;
-            fnMap = __tmp1;
-            acc = __tmp2;
+        aver_list_match!(arms, [] => { return acc.reverse(); }, [arm, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::AverList::prepend(crate::aver_generated::domain::ast::MatchArm { pattern: arm.pattern.clone(), body: crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&arm.body, &fnMap), bindingSlots: arm.bindingSlots.clone() }, &acc);
+            arms = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -666,15 +673,14 @@ pub fn resolveCallsInFields(
 ) -> aver_rt::AverList<(AverStr, Expr)> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fields, [] => acc.reverse(), [pair, rest] => { match pair {
-            (name, expr) => {
-            let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&expr, &fnMap)), &acc);
-            fields = rest;
-            fnMap = __tmp1;
-            acc = __tmp2;
+        aver_list_match!(fields, [] => { return acc.reverse(); }, [pair, rest] => { { let (name, expr) = pair; {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&expr, &fnMap)), &acc);
+            fields = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
             continue;
-        }
-        } });
+        } } })
     }
 }

--- a/src/self_host/aver_generated/domain/resolver/core/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/core/mod.rs
@@ -266,12 +266,14 @@ fn __mutual_tco_trampoline_2(
             }
             __MutualTco2::ResolveOneArm(mut arm, mut rest, mut slots, mut acc) => {
                 crate::cancel_checkpoint();
-                match crate::aver_generated::domain::resolver::core::resolveArm(&arm, &slots) {
-                    (resolvedArm, mergedSlots) => __MutualTco2::ResolveArms(
+                {
+                    let (resolvedArm, mergedSlots) =
+                        crate::aver_generated::domain::resolver::core::resolveArm(&arm, &slots);
+                    __MutualTco2::ResolveArms(
                         rest,
                         mergedSlots,
                         aver_rt::AverList::prepend(resolvedArm, &acc),
-                    ),
+                    )
                 }
             }
         };
@@ -376,8 +378,10 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::ResolveStmtExpr(mut expr, mut rest, mut slots, mut next, mut acc) => {
                 crate::cancel_checkpoint();
-                match crate::aver_generated::domain::resolver::core::resolveExpr(&expr, &slots) {
-                    (re, newSlots) => __MutualTco3::ResolveStmts(
+                {
+                    let (re, newSlots) =
+                        crate::aver_generated::domain::resolver::core::resolveExpr(&expr, &slots);
+                    __MutualTco3::ResolveStmts(
                         rest,
                         newSlots.clone(),
                         crate::aver_generated::domain::resolver::core::maxInt(
@@ -389,7 +393,7 @@ fn __mutual_tco_trampoline_3(
                             crate::aver_generated::domain::ast::Stmt::StmtExpr(re),
                             &acc,
                         ),
-                    ),
+                    )
                 }
             }
             __MutualTco3::ResolveStmtBind(
@@ -401,10 +405,10 @@ fn __mutual_tco_trampoline_3(
                 mut acc,
             ) => {
                 crate::cancel_checkpoint();
-                match crate::aver_generated::domain::resolver::core::resolveExpr(&expr, &slots) {
-                    (newExpr, exprSlots) => __MutualTco3::ResolveStmtBindFinish(
-                        name, newExpr, rest, exprSlots, next, acc,
-                    ),
+                {
+                    let (newExpr, exprSlots) =
+                        crate::aver_generated::domain::resolver::core::resolveExpr(&expr, &slots);
+                    __MutualTco3::ResolveStmtBindFinish(name, newExpr, rest, exprSlots, next, acc)
                 }
             }
             __MutualTco3::ResolveStmtBindFinish(
@@ -526,12 +530,13 @@ pub fn resolveFns(
 ) -> aver_rt::AverList<FnDef> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fns, [] => acc.reverse(), [f, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::core::resolveFn(&f), &acc);
-            fns = rest;
-            acc = __tmp1;
+        aver_list_match!(fns, [] => { return acc.reverse(); }, [f, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::core::resolveFn(&f), &acc);
+            fns = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -558,14 +563,15 @@ pub fn buildParamSlots(
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(params, [] => (slots, next), [p, rest] => { {
-            let __tmp1 = slots.insert_owned(p, next);
-            let __tmp2 = (next + 1i64);
-            params = rest;
-            slots = __tmp1;
-            next = __tmp2;
+        aver_list_match!(params, [] => { return (slots, next); }, [p, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = slots.insert_owned(p, next);
+            let __tco2 = (next + 1i64);
+            params = __tco0;
+            slots = __tco1;
+            next = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -601,13 +607,13 @@ pub fn computeSlotCount(
         body.clone(),
         (baseSlot - 1i64),
     );
-    FnDef {
+    crate::aver_generated::domain::ast::FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
         body: body.clone(),
         slotCount: (maxFromBody + 1i64),
         slotMap: slotMap.clone(),
-        fastPath: FnFastPath::FastNone.clone(),
+        fastPath: crate::aver_generated::domain::ast::FnFastPath::FastNone,
         tailLoop: false,
     }
 }
@@ -617,12 +623,13 @@ pub fn computeSlotCount(
 pub fn maxSlotInStmts(mut stmts: aver_rt::AverList<Stmt>, mut acc: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(stmts, [] => acc, [s, rest] => { {
-            let __tmp1 = crate::aver_generated::domain::resolver::core::maxSlotInStmt(&s, acc);
-            stmts = rest;
-            acc = __tmp1;
+        aver_list_match!(stmts, [] => { return acc; }, [s, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = crate::aver_generated::domain::resolver::core::maxSlotInStmt(&s, acc);
+            stmts = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -650,12 +657,13 @@ pub fn maxSlotInStmt(s: &Stmt, acc: i64) -> i64 {
 pub fn maxSlotInExprs(mut exprs: aver_rt::AverList<Expr>, mut acc: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => acc, [e, rest] => { {
-            let __tmp1 = crate::aver_generated::domain::resolver::core::maxSlotInExpr(&e, acc);
-            exprs = rest;
-            acc = __tmp1;
+        aver_list_match!(exprs, [] => { return acc; }, [e, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = crate::aver_generated::domain::resolver::core::maxSlotInExpr(&e, acc);
+            exprs = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -664,14 +672,13 @@ pub fn maxSlotInExprs(mut exprs: aver_rt::AverList<Expr>, mut acc: i64) -> i64 {
 pub fn maxSlotInFields(mut fields: aver_rt::AverList<(AverStr, Expr)>, mut acc: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fields, [] => acc, [pair, rest] => { match pair {
-            (_, expr) => {
-            let __tmp1 = crate::aver_generated::domain::resolver::core::maxSlotInExpr(&expr, acc);
-            fields = rest;
-            acc = __tmp1;
+        aver_list_match!(fields, [] => { return acc; }, [pair, rest] => { { let (_, expr) = pair; {
+            let __tco0 = rest;
+            let __tco1 = crate::aver_generated::domain::resolver::core::maxSlotInExpr(&expr, acc);
+            fields = __tco0;
+            acc = __tco1;
             continue;
-        }
-        } });
+        } } })
     }
 }
 
@@ -680,12 +687,13 @@ pub fn maxSlotInFields(mut fields: aver_rt::AverList<(AverStr, Expr)>, mut acc: 
 pub fn maxSlotInArms(mut arms: aver_rt::AverList<MatchArm>, mut acc: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(arms, [] => acc, [arm, rest] => { {
-            let __tmp1 = crate::aver_generated::domain::resolver::core::maxSlotInExpr(&arm.body, acc);
-            arms = rest;
-            acc = __tmp1;
+        aver_list_match!(arms, [] => { return acc; }, [arm, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = crate::aver_generated::domain::resolver::core::maxSlotInExpr(&arm.body, acc);
+            arms = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -1310,14 +1318,15 @@ pub fn resolveExprs(
 ) -> aver_rt::AverList<Expr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => acc.reverse(), [e, rest] => { {
-            let __tmp1 = slots.clone();
-            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::core::resolveExprSimple(&e, &slots), &acc);
-            exprs = rest;
-            slots = __tmp1;
-            acc = __tmp2;
+        aver_list_match!(exprs, [] => { return acc.reverse(); }, [e, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = slots.clone();
+            let __tco2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::core::resolveExprSimple(&e, &slots), &acc);
+            exprs = __tco0;
+            slots = __tco1;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -1330,16 +1339,15 @@ pub fn resolveFields(
 ) -> aver_rt::AverList<(AverStr, Expr)> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fields, [] => acc.reverse(), [pair, rest] => { match pair {
-            (name, expr) => {
-            let __tmp1 = slots.clone();
-            let __tmp2 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::core::resolveExprSimple(&expr, &slots)), &acc);
-            fields = rest;
-            slots = __tmp1;
-            acc = __tmp2;
+        aver_list_match!(fields, [] => { return acc.reverse(); }, [pair, rest] => { { let (name, expr) = pair; {
+            let __tco0 = rest;
+            let __tco1 = slots.clone();
+            let __tco2 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::core::resolveExprSimple(&expr, &slots)), &acc);
+            fields = __tco0;
+            slots = __tco1;
+            acc = __tco2;
             continue;
-        }
-        } });
+        } } })
     }
 }
 
@@ -1375,7 +1383,7 @@ pub fn resolveArmBody(
         let (re, finalSlots) =
             crate::aver_generated::domain::resolver::core::resolveExpr(&arm.body, newSlots);
         (
-            MatchArm {
+            crate::aver_generated::domain::ast::MatchArm {
                 pattern: arm.pattern.clone(),
                 body: re,
                 bindingSlots: bindingSlots.clone(),
@@ -1468,14 +1476,15 @@ pub fn patternBindingSlotsConstructor(
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(bindings, [] => (bindingSlots, next), [name, rest] => { {
-            let __tmp1 = bindingSlots.insert_owned(name, next);
-            let __tmp2 = (next + 1i64);
-            bindings = rest;
-            bindingSlots = __tmp1;
-            next = __tmp2;
+        aver_list_match!(bindings, [] => { return (bindingSlots, next); }, [name, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = bindingSlots.insert_owned(name, next);
+            let __tco2 = (next + 1i64);
+            bindings = __tco0;
+            bindingSlots = __tco1;
+            next = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -1488,14 +1497,15 @@ pub fn patternBindingSlotsTuple(
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(pats, [] => (bindingSlots, next), [p, rest] => { match crate::aver_generated::domain::resolver::core::patternBindingSlotsInner(&p, &bindingSlots, next) {
-            (newBindingSlots, newNext) => {
-            pats = rest;
-            bindingSlots = newBindingSlots;
-            next = newNext;
+        aver_list_match!(pats, [] => { return (bindingSlots, next); }, [p, rest] => { { let (newBindingSlots, newNext) = crate::aver_generated::domain::resolver::core::patternBindingSlotsInner(&p, &bindingSlots, next); {
+            let __tco0 = rest;
+            let __tco1 = newBindingSlots;
+            let __tco2 = newNext;
+            pats = __tco0;
+            bindingSlots = __tco1;
+            next = __tco2;
             continue;
-        }
-        } });
+        } } })
     }
 }
 
@@ -1514,7 +1524,7 @@ pub fn addPatternSlots(
 pub fn mapMaxVal(m: &aver_rt::AverMap<AverStr, i64>) -> i64 {
     crate::cancel_checkpoint();
     let vals = aver_rt::AverList::from_vec(m.values().cloned().collect::<Vec<_>>());
-    crate::aver_generated::domain::resolver::core::maxInList(vals, (0i64 - 1i64))
+    crate::aver_generated::domain::resolver::core::maxInList(vals, (-1i64))
 }
 
 /// Find maximum value in a list.
@@ -1522,14 +1532,17 @@ pub fn mapMaxVal(m: &aver_rt::AverMap<AverStr, i64>) -> i64 {
 pub fn maxInList(mut vals: aver_rt::AverList<i64>, mut acc: i64) -> i64 {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(vals, [] => acc, [v, rest] => { if (v > acc) { {
-            vals = rest;
-            acc = v;
+        aver_list_match!(vals, [] => { return acc; }, [v, rest] => { if (v > acc) { {
+            let __tco0 = rest;
+            let __tco1 = v;
+            vals = __tco0;
+            acc = __tco1;
             continue;
         } } else { {
-            vals = rest;
+            let __tco0 = rest;
+            vals = __tco0;
             continue;
-        } } });
+        } } })
     }
 }
 
@@ -1593,14 +1606,15 @@ pub fn addConstructorSlots(
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(bindings, [] => (slots, next), [name, rest] => { {
-            let __tmp1 = slots.insert_owned(name, next);
-            let __tmp2 = (next + 1i64);
-            bindings = rest;
-            slots = __tmp1;
-            next = __tmp2;
+        aver_list_match!(bindings, [] => { return (slots, next); }, [name, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = slots.insert_owned(name, next);
+            let __tco2 = (next + 1i64);
+            bindings = __tco0;
+            slots = __tco1;
+            next = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -1613,13 +1627,14 @@ pub fn addTuplePatternSlots(
 ) -> (aver_rt::AverMap<AverStr, i64>, i64) {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(pats, [] => (slots, next), [p, rest] => { match crate::aver_generated::domain::resolver::core::addPatternSlotsInner(&p, &slots, next) {
-            (newSlots, newNext) => {
-            pats = rest;
-            slots = newSlots;
-            next = newNext;
+        aver_list_match!(pats, [] => { return (slots, next); }, [p, rest] => { { let (newSlots, newNext) = crate::aver_generated::domain::resolver::core::addPatternSlotsInner(&p, &slots, next); {
+            let __tco0 = rest;
+            let __tco1 = newSlots;
+            let __tco2 = newNext;
+            pats = __tco0;
+            slots = __tco1;
+            next = __tco2;
             continue;
-        }
-        } });
+        } } })
     }
 }

--- a/src/self_host/aver_generated/domain/resolver/fast/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/fast/mod.rs
@@ -12,14 +12,15 @@ pub fn annotateFastFns(
 ) -> aver_rt::AverList<FnDef> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fns, [] => acc.reverse(), [f, rest] => { {
-            let __tmp1 = fnMap.clone();
-            let __tmp2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::fast::annotateFastFn(&f, &fnMap), &acc);
-            fns = rest;
-            fnMap = __tmp1;
-            acc = __tmp2;
+        aver_list_match!(fns, [] => { return acc.reverse(); }, [f, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::fast::annotateFastFn(&f, &fnMap), &acc);
+            fns = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -27,7 +28,7 @@ pub fn annotateFastFns(
 pub fn annotateFastFn(fd: &FnDef, fnMap: &aver_rt::AverMap<AverStr, i64>) -> FnDef {
     crate::cancel_checkpoint();
     let selfId = fnMap.get(&fd.name).cloned().unwrap_or((-1i64));
-    FnDef {
+    crate::aver_generated::domain::ast::FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
         body: fd.body.clone(),
@@ -46,10 +47,11 @@ pub fn annotateFastFn(fd: &FnDef, fnMap: &aver_rt::AverMap<AverStr, i64>) -> FnD
 pub fn classifyTailLoop(mut selfId: i64, mut body: aver_rt::AverList<Stmt>) -> bool {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(body, [] => false, [stmt, rest] => { { let __list_subject = rest.clone(); if __list_subject.is_empty() { crate::aver_generated::domain::resolver::fast::stmtNeedsTailLoop(selfId, &stmt) } else { {
-            body = rest;
+        aver_list_match!(body, [] => { return false; }, [stmt, rest] => { { let __list_subject = rest.clone(); if __list_subject.is_empty() { return crate::aver_generated::domain::resolver::fast::stmtNeedsTailLoop(selfId, &stmt); } else { {
+            let __tco1 = rest;
+            body = __tco1;
             continue;
-        } } } });
+        } } } })
     }
 }
 
@@ -68,27 +70,34 @@ pub fn stmtNeedsTailLoop(selfId: i64, stmt: &Stmt) -> bool {
 pub fn exprNeedsTailLoop(mut selfId: i64, mut expr: Expr) -> bool {
     loop {
         crate::cancel_checkpoint();
-        return match expr {
-            crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, _) => (fnId == selfId),
+        match expr {
+            crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, _) => {
+                return (fnId == selfId);
+            }
             crate::aver_generated::domain::ast::Expr::ExprBoolBranch(_, thenExpr, elseExpr) => {
                 let thenExpr = (*thenExpr).clone();
                 let elseExpr = (*elseExpr).clone();
                 if crate::aver_generated::domain::resolver::fast::exprNeedsTailLoop(
                     selfId, thenExpr,
                 ) {
-                    true
+                    return true;
                 } else {
                     {
-                        expr = elseExpr;
+                        let __tco1 = elseExpr;
+                        expr = __tco1;
                         continue;
                     }
                 }
             }
             crate::aver_generated::domain::ast::Expr::ExprMatch(_, arms) => {
-                crate::aver_generated::domain::resolver::fast::armsNeedTailLoop(selfId, arms)
+                return crate::aver_generated::domain::resolver::fast::armsNeedTailLoop(
+                    selfId, arms,
+                );
             }
-            _ => false,
-        };
+            _ => {
+                return false;
+            }
+        }
     }
 }
 
@@ -97,10 +106,11 @@ pub fn exprNeedsTailLoop(mut selfId: i64, mut expr: Expr) -> bool {
 pub fn armsNeedTailLoop(mut selfId: i64, mut arms: aver_rt::AverList<MatchArm>) -> bool {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(arms, [] => false, [arm, rest] => { if crate::aver_generated::domain::resolver::fast::exprNeedsTailLoop(selfId, arm.body.clone()) { true } else { {
-            arms = rest;
+        aver_list_match!(arms, [] => { return false; }, [arm, rest] => { if crate::aver_generated::domain::resolver::fast::exprNeedsTailLoop(selfId, arm.body.clone()) { return true; } else { {
+            let __tco1 = rest;
+            arms = __tco1;
             continue;
-        } } });
+        } } })
     }
 }
 
@@ -113,10 +123,10 @@ pub fn classifyFastPath(body: &aver_rt::AverList<Stmt>) -> FnFastPath {
             if (rest == aver_rt::AverList::empty()) {
                 crate::aver_generated::domain::resolver::fast::classifyFastStmt(&stmt)
             } else {
-                FnFastPath::FastNone.clone()
+                crate::aver_generated::domain::ast::FnFastPath::FastNone
             }
         } else {
-            FnFastPath::FastNone.clone()
+            crate::aver_generated::domain::ast::FnFastPath::FastNone
         }
     }
 }
@@ -128,7 +138,7 @@ pub fn classifyFastStmt(stmt: &Stmt) -> FnFastPath {
         crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
             crate::aver_generated::domain::resolver::fast::classifyFastExpr(&expr)
         }
-        _ => FnFastPath::FastNone.clone(),
+        _ => crate::aver_generated::domain::ast::FnFastPath::FastNone,
     }
 }
 
@@ -146,7 +156,7 @@ pub fn classifyFastExpr(expr: &Expr) -> FnFastPath {
                 let scrutinee = (*scrutinee).clone();
                 crate::aver_generated::domain::resolver::fast::classifyFastMatch(&scrutinee, &arms)
             }
-            _ => FnFastPath::FastSingleExpr.clone(),
+            _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
         },
     }
 }
@@ -181,7 +191,7 @@ pub fn classifyFastLeafExpr(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastBinopSlots(
-                &BinOp::OpAdd,
+                &crate::aver_generated::domain::ast::BinOp::OpAdd,
                 &a,
                 &b,
             )
@@ -190,7 +200,7 @@ pub fn classifyFastLeafExpr(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastBinopSlots(
-                &BinOp::OpSub,
+                &crate::aver_generated::domain::ast::BinOp::OpSub,
                 &a,
                 &b,
             )
@@ -207,7 +217,7 @@ pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastBinopSlots(
-                &BinOp::OpMul,
+                &crate::aver_generated::domain::ast::BinOp::OpMul,
                 &a,
                 &b,
             )
@@ -216,7 +226,7 @@ pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastBinopSlots(
-                &BinOp::OpDiv,
+                &crate::aver_generated::domain::ast::BinOp::OpDiv,
                 &a,
                 &b,
             )
@@ -225,7 +235,7 @@ pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
-                &CmpOp::CmpEq,
+                &crate::aver_generated::domain::ast::CmpOp::CmpEq,
                 &a,
                 &b,
             )
@@ -234,7 +244,7 @@ pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
-                &CmpOp::CmpNeq,
+                &crate::aver_generated::domain::ast::CmpOp::CmpNeq,
                 &a,
                 &b,
             )
@@ -243,7 +253,7 @@ pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
-                &CmpOp::CmpLt,
+                &crate::aver_generated::domain::ast::CmpOp::CmpLt,
                 &a,
                 &b,
             )
@@ -252,7 +262,7 @@ pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
-                &CmpOp::CmpGt,
+                &crate::aver_generated::domain::ast::CmpOp::CmpGt,
                 &a,
                 &b,
             )
@@ -261,7 +271,7 @@ pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
-                &CmpOp::CmpLte,
+                &crate::aver_generated::domain::ast::CmpOp::CmpLte,
                 &a,
                 &b,
             )
@@ -270,7 +280,7 @@ pub fn classifyFastLeafExprTail(expr: &Expr) -> Option<FastLeaf> {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::fast::classifyFastCmpSlots(
-                &CmpOp::CmpGte,
+                &crate::aver_generated::domain::ast::CmpOp::CmpGte,
                 &a,
                 &b,
             )
@@ -700,7 +710,7 @@ pub fn classifyFastListMatch(scrutinee: &Expr, arms: &aver_rt::AverList<MatchArm
         crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
             crate::aver_generated::domain::resolver::fast::classifyFastListArms(slot, arms)
         }
-        _ => FnFastPath::FastSingleExpr.clone(),
+        _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }
 
@@ -718,14 +728,14 @@ pub fn classifyFastListArms(slot: i64, arms: &aver_rt::AverList<MatchArm>) -> Fn
                             slot, &arm1, &arm2,
                         )
                     } else {
-                        FnFastPath::FastSingleExpr.clone()
+                        crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr
                     }
                 } else {
-                    FnFastPath::FastSingleExpr.clone()
+                    crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr
                 }
             }
         } else {
-            FnFastPath::FastSingleExpr.clone()
+            crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr
         }
     }
 }
@@ -747,9 +757,9 @@ pub fn classifyFastListArmPair(slot: i64, arm1: &MatchArm, arm2: &MatchArm) -> F
                 &arm2.bindingSlots,
                 &v2,
             ),
-            None => FnFastPath::FastSingleExpr.clone(),
+            None => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
         },
-        None => FnFastPath::FastSingleExpr.clone(),
+        None => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }
 
@@ -785,7 +795,7 @@ pub fn classifyFastListPatterns(
                 leaf2,
             )
         }
-        _ => FnFastPath::FastSingleExpr.clone(),
+        _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }
 
@@ -809,7 +819,7 @@ pub fn classifyFastListOther(
                 otherLeaf,
             )
         }
-        _ => FnFastPath::FastSingleExpr.clone(),
+        _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }
 
@@ -835,7 +845,7 @@ pub fn classifyFastListConsFirst(
                 consLeaf,
             )
         }
-        _ => FnFastPath::FastSingleExpr.clone(),
+        _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }
 
@@ -859,9 +869,9 @@ pub fn classifyFastListCons(
                 tailSlot,
                 consLeaf.clone(),
             ),
-            None => FnFastPath::FastSingleExpr.clone(),
+            None => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
         },
-        None => FnFastPath::FastSingleExpr.clone(),
+        None => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }
 
@@ -876,7 +886,7 @@ pub fn classifyFastForwardCall(fnId: i64, args: &aver_rt::AverList<Expr>) -> FnF
         Some(slotArgs) => {
             crate::aver_generated::domain::ast::FnFastPath::FastForwardCall(fnId, slotArgs)
         }
-        None => FnFastPath::FastSingleExpr.clone(),
+        None => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }
 
@@ -888,15 +898,20 @@ pub fn classifyFastForwardSlots(
 ) -> Option<aver_rt::AverList<i64>> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(args, [] => Some(acc.reverse()), [arg, rest] => { match arg {
-            crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
-            let __tmp1 = aver_rt::AverList::prepend(slot, &acc);
-            args = rest;
-            acc = __tmp1;
+        aver_list_match!(args, [] => { return Some(acc.reverse()); }, [arg, rest] => { match arg {
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+            {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(slot, &acc);
+            args = __tco0;
+            acc = __tco1;
             continue;
+        }
         },
-            _ => None
-        } });
+        _ => {
+            return None;
+        }
+    } })
     }
 }
 
@@ -1033,7 +1048,7 @@ pub fn classifyFastMatchScrutinee(
                 &b, &a, thenLeaf, elseLeaf,
             )
         }
-        _ => FnFastPath::FastSingleExpr.clone(),
+        _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }
 
@@ -1057,7 +1072,7 @@ pub fn classifyFastEqScrutinee(
                     slot, a, thenLeaf, elseLeaf,
                 )
             }
-            _ => FnFastPath::FastSingleExpr.clone(),
+            _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
         },
     }
 }
@@ -1087,7 +1102,7 @@ pub fn classifyFastEqOther(
                 elseLeaf.clone(),
             )
         }
-        _ => FnFastPath::FastSingleExpr.clone(),
+        _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }
 
@@ -1109,8 +1124,8 @@ pub fn classifyFastLtScrutinee(
                     elseLeaf.clone(),
                 )
             }
-            _ => FnFastPath::FastSingleExpr.clone(),
+            _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
         },
-        _ => FnFastPath::FastSingleExpr.clone(),
+        _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
     }
 }

--- a/src/self_host/aver_generated/domain/resolver/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/mod.rs
@@ -33,7 +33,7 @@ pub fn resolveProgram(prog: &Program) -> Program {
         fnMap,
         aver_rt::AverList::empty(),
     );
-    Program {
+    crate::aver_generated::domain::ast::Program {
         deps: prog.deps.clone(),
         fns: crate::aver_generated::domain::resolver::rewrite::rewriteInternalFns(
             annotatedFns,

--- a/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
@@ -11,19 +11,20 @@ pub fn rewriteInternalFns(
 ) -> aver_rt::AverList<FnDef> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fns, [] => acc.reverse(), [f, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewriteInternalFn(&f), &acc);
-            fns = rest;
-            acc = __tmp1;
+        aver_list_match!(fns, [] => { return acc.reverse(); }, [f, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewriteInternalFn(&f), &acc);
+            fns = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
 /// Rewrite the body of one resolved function into lighter internal expression shapes.
 pub fn rewriteInternalFn(fd: &FnDef) -> FnDef {
     crate::cancel_checkpoint();
-    FnDef {
+    crate::aver_generated::domain::ast::FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
         body: crate::aver_generated::domain::resolver::rewrite::rewriteInternalStmts(
@@ -45,12 +46,13 @@ pub fn rewriteInternalStmts(
 ) -> aver_rt::AverList<Stmt> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(stmts, [] => acc.reverse(), [stmt, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewriteInternalStmt(&stmt), &acc);
-            stmts = rest;
-            acc = __tmp1;
+        aver_list_match!(stmts, [] => { return acc.reverse(); }, [stmt, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewriteInternalStmt(&stmt), &acc);
+            stmts = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -148,7 +150,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinop(
-                &BinOp::OpAdd,
+                &crate::aver_generated::domain::ast::BinOp::OpAdd,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -157,7 +159,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinop(
-                &BinOp::OpSub,
+                &crate::aver_generated::domain::ast::BinOp::OpSub,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -166,7 +168,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinop(
-                &BinOp::OpMul,
+                &crate::aver_generated::domain::ast::BinOp::OpMul,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -175,7 +177,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalBinop(
-                &BinOp::OpDiv,
+                &crate::aver_generated::domain::ast::BinOp::OpDiv,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -190,7 +192,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
-                &CmpOp::CmpEq,
+                &crate::aver_generated::domain::ast::CmpOp::CmpEq,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -199,7 +201,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
-                &CmpOp::CmpNeq,
+                &crate::aver_generated::domain::ast::CmpOp::CmpNeq,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -208,7 +210,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
-                &CmpOp::CmpLt,
+                &crate::aver_generated::domain::ast::CmpOp::CmpLt,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -217,7 +219,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
-                &CmpOp::CmpGt,
+                &crate::aver_generated::domain::ast::CmpOp::CmpGt,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -226,7 +228,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
-                &CmpOp::CmpLte,
+                &crate::aver_generated::domain::ast::CmpOp::CmpLte,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -235,7 +237,7 @@ pub fn rewriteInternalExprAfterLeaf(expr: &Expr) -> Expr {
             let a = (*a).clone();
             let b = (*b).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalCmp(
-                &CmpOp::CmpGte,
+                &crate::aver_generated::domain::ast::CmpOp::CmpGte,
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&a),
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&b),
             )
@@ -363,12 +365,13 @@ pub fn rewriteInternalExprs(
 ) -> aver_rt::AverList<Expr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => acc.reverse(), [expr, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr), &acc);
-            exprs = rest;
-            acc = __tmp1;
+        aver_list_match!(exprs, [] => { return acc.reverse(); }, [expr, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr), &acc);
+            exprs = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -380,14 +383,13 @@ pub fn rewriteInternalFields(
 ) -> aver_rt::AverList<(AverStr, Expr)> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fields, [] => acc.reverse(), [pair, rest] => { match pair {
-            (name, expr) => {
-            let __tmp1 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr)), &acc);
-            fields = rest;
-            acc = __tmp1;
+        aver_list_match!(fields, [] => { return acc.reverse(); }, [pair, rest] => { { let (name, expr) = pair; {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr)), &acc);
+            fields = __tco0;
+            acc = __tco1;
             continue;
-        }
-        } });
+        } } })
     }
 }
 
@@ -399,12 +401,13 @@ pub fn rewriteInternalArms(
 ) -> aver_rt::AverList<MatchArm> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(arms, [] => acc.reverse(), [arm, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(MatchArm { pattern: crate::aver_generated::domain::resolver::rewrite::rewritePattern(&arm.pattern), body: crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&arm.body), bindingSlots: arm.bindingSlots.clone() }, &acc);
-            arms = rest;
-            acc = __tmp1;
+        aver_list_match!(arms, [] => { return acc.reverse(); }, [arm, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::ast::MatchArm { pattern: crate::aver_generated::domain::resolver::rewrite::rewritePattern(&arm.pattern), body: crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&arm.body), bindingSlots: arm.bindingSlots.clone() }, &acc);
+            arms = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -442,12 +445,13 @@ pub fn rewritePatterns(
 ) -> aver_rt::AverList<Pattern> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(pats, [] => acc.reverse(), [p, rest] => { {
-            let __tmp1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewritePattern(&p), &acc);
-            pats = rest;
-            acc = __tmp1;
+        aver_list_match!(pats, [] => { return acc.reverse(); }, [p, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::resolver::rewrite::rewritePattern(&p), &acc);
+            pats = __tco0;
+            acc = __tco1;
             continue;
-        } });
+        } })
     }
 }
 
@@ -969,12 +973,24 @@ pub fn rebuildInternalCmp(op: &CmpOp, left: &Expr, right: &Expr) -> Expr {
 pub fn flipCmp(op: &CmpOp) -> CmpOp {
     crate::cancel_checkpoint();
     match op {
-        crate::aver_generated::domain::ast::CmpOp::CmpEq => CmpOp::CmpEq.clone(),
-        crate::aver_generated::domain::ast::CmpOp::CmpNeq => CmpOp::CmpNeq.clone(),
-        crate::aver_generated::domain::ast::CmpOp::CmpLt => CmpOp::CmpGt.clone(),
-        crate::aver_generated::domain::ast::CmpOp::CmpGt => CmpOp::CmpLt.clone(),
-        crate::aver_generated::domain::ast::CmpOp::CmpLte => CmpOp::CmpGte.clone(),
-        crate::aver_generated::domain::ast::CmpOp::CmpGte => CmpOp::CmpLte.clone(),
+        crate::aver_generated::domain::ast::CmpOp::CmpEq => {
+            crate::aver_generated::domain::ast::CmpOp::CmpEq
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpNeq => {
+            crate::aver_generated::domain::ast::CmpOp::CmpNeq
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLt => {
+            crate::aver_generated::domain::ast::CmpOp::CmpGt
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGt => {
+            crate::aver_generated::domain::ast::CmpOp::CmpLt
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpLte => {
+            crate::aver_generated::domain::ast::CmpOp::CmpGte
+        }
+        crate::aver_generated::domain::ast::CmpOp::CmpGte => {
+            crate::aver_generated::domain::ast::CmpOp::CmpLte
+        }
     }
 }
 

--- a/src/self_host/aver_generated/domain/value/mod.rs
+++ b/src/self_host/aver_generated/domain/value/mod.rs
@@ -396,18 +396,23 @@ pub fn valListRepr(
 ) -> AverStr {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(items, [] => { aver_rt::AverStr::from({ let mut __b = { let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((18i64) as usize); __b.push_str(&AverStr::from("[")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(acc)))); __b }; __b.push_str(&AverStr::from("]")); __b }) }, [v, rest] => { if first { {
-            items = rest;
-            acc = crate::aver_generated::domain::value::valReprInner(&v);
-            first = false;
+        aver_list_match!(items, [] => { return aver_rt::AverStr::from({ let mut __b = { let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((18i64) as usize); __b.push_str(&AverStr::from("[")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(acc)))); __b }; __b.push_str(&AverStr::from("]")); __b }); }, [v, rest] => { if first { {
+            let __tco0 = rest;
+            let __tco1 = crate::aver_generated::domain::value::valReprInner(&v);
+            let __tco2 = false;
+            items = __tco0;
+            acc = __tco1;
+            first = __tco2;
             continue;
         } } else { {
-            let __tmp1 = ((acc + &AverStr::from(", ")) + &crate::aver_generated::domain::value::valReprInner(&v));
-            items = rest;
-            acc = __tmp1;
-            first = false;
+            let __tco0 = rest;
+            let __tco1 = ((acc + &AverStr::from(", ")) + &crate::aver_generated::domain::value::valReprInner(&v));
+            let __tco2 = false;
+            items = __tco0;
+            acc = __tco1;
+            first = __tco2;
             continue;
-        } } });
+        } } })
     }
 }
 
@@ -607,20 +612,23 @@ pub fn valMapRepr(
 ) -> AverStr {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(entries, [] => { aver_rt::AverStr::from({ let mut __b = { let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((18i64) as usize); __b.push_str(&AverStr::from("{")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(acc)))); __b }; __b.push_str(&AverStr::from("}")); __b }) }, [pair, rest] => { match pair {
-            (k, v) => if first { {
-            entries = rest;
-            acc = ((crate::aver_generated::domain::value::quoteString(k) + &AverStr::from(": ")) + &crate::aver_generated::domain::value::valReprInner(&v));
-            first = false;
+        aver_list_match!(entries, [] => { return aver_rt::AverStr::from({ let mut __b = { let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((18i64) as usize); __b.push_str(&AverStr::from("{")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(acc)))); __b }; __b.push_str(&AverStr::from("}")); __b }); }, [pair, rest] => { { let (k, v) = pair; if first { {
+            let __tco0 = rest;
+            let __tco1 = ((crate::aver_generated::domain::value::quoteString(k) + &AverStr::from(": ")) + &crate::aver_generated::domain::value::valReprInner(&v));
+            let __tco2 = false;
+            entries = __tco0;
+            acc = __tco1;
+            first = __tco2;
             continue;
         } } else { {
-            let __tmp1 = ((((acc + &AverStr::from(", ")) + &crate::aver_generated::domain::value::quoteString(k)) + &AverStr::from(": ")) + &crate::aver_generated::domain::value::valReprInner(&v));
-            entries = rest;
-            acc = __tmp1;
-            first = false;
+            let __tco0 = rest;
+            let __tco1 = ((((acc + &AverStr::from(", ")) + &crate::aver_generated::domain::value::quoteString(k)) + &AverStr::from(": ")) + &crate::aver_generated::domain::value::valReprInner(&v));
+            let __tco2 = false;
+            entries = __tco0;
+            acc = __tco1;
+            first = __tco2;
             continue;
-        } }
-        } });
+        } } } })
     }
 }
 
@@ -682,17 +690,22 @@ pub fn valFieldsRepr(
 ) -> AverStr {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(items, [] => acc, [v, rest] => { if first { {
-            items = rest;
-            acc = crate::aver_generated::domain::value::valReprInner(&v);
-            first = false;
+        aver_list_match!(items, [] => { return acc; }, [v, rest] => { if first { {
+            let __tco0 = rest;
+            let __tco1 = crate::aver_generated::domain::value::valReprInner(&v);
+            let __tco2 = false;
+            items = __tco0;
+            acc = __tco1;
+            first = __tco2;
             continue;
         } } else { {
-            let __tmp1 = ((acc + &AverStr::from(", ")) + &crate::aver_generated::domain::value::valReprInner(&v));
-            items = rest;
-            acc = __tmp1;
-            first = false;
+            let __tco0 = rest;
+            let __tco1 = ((acc + &AverStr::from(", ")) + &crate::aver_generated::domain::value::valReprInner(&v));
+            let __tco2 = false;
+            items = __tco0;
+            acc = __tco1;
+            first = __tco2;
             continue;
-        } } });
+        } } })
     }
 }

--- a/src/self_host/aver_generated/entry/mod.rs
+++ b/src/self_host/aver_generated/entry/mod.rs
@@ -58,8 +58,9 @@ fn __mutual_tco_trampoline_1(
                 let moduleFns = resolveQualifiedModuleFns(&prog, dep.clone());
                 let loaded2 = loaded.insert_owned(dep, true);
                 let innerResult = loadModules(&prog.deps, moduleRoot.clone(), &acc, &loaded2)?;
-                match innerResult {
-                    (accWithInner, loaded3) => __MutualTco1::LoadModules(
+                {
+                    let (accWithInner, loaded3) = innerResult;
+                    __MutualTco1::LoadModules(
                         rest,
                         moduleRoot,
                         aver_rt::AverList::concat(
@@ -71,7 +72,7 @@ fn __mutual_tco_trampoline_1(
                             ),
                         ),
                         loaded3,
-                    ),
+                    )
                 }
             }
         };
@@ -130,7 +131,7 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<FnD
             }
             __MutualTco2::QualifyFnsOne(mut f, mut rest, mut prefix, mut acc) => {
                 crate::cancel_checkpoint();
-                let qualified = FnDef {
+                let qualified = crate::aver_generated::domain::ast::FnDef {
                     name: ((prefix.clone() + &AverStr::from(".")) + &f.name),
                     params: f.params.clone(),
                     body: f.body.clone(),
@@ -263,7 +264,7 @@ pub fn findModulePath(mut dep: AverStr, mut root: AverStr, mut depth: i64) -> Av
     loop {
         crate::cancel_checkpoint();
         let path = modulePathFromName(dep.clone(), root.clone());
-        return if {
+        if {
             let __effect_arg0 = path.clone();
             crate::cancel_checkpoint();
             aver_replay::invoke_effect(
@@ -272,20 +273,20 @@ pub fn findModulePath(mut dep: AverStr, mut root: AverStr, mut depth: i64) -> Av
                 || aver_rt::path_exists(&__effect_arg0),
             )
         } {
-            path
+            return path;
         } else {
-            if (depth >= 3i64) {
-                path
-            } else {
+            if (depth < 3i64) {
                 {
-                    let __tmp1 = (root + &AverStr::from("/.."));
-                    let __tmp2 = (depth + 1i64);
-                    root = __tmp1;
-                    depth = __tmp2;
+                    let __tco1 = (root + &AverStr::from("/.."));
+                    let __tco2 = (depth + 1i64);
+                    root = __tco1;
+                    depth = __tco2;
                     continue;
                 }
+            } else {
+                return path;
             }
-        };
+        }
     }
 }
 
@@ -308,37 +309,41 @@ pub fn dotToSlash(mut name: AverStr, mut pos: i64, mut total: i64, mut acc: Aver
     loop {
         crate::cancel_checkpoint();
         let nextPos = (pos + 1i64);
-        return if (pos >= total) {
-            acc
-        } else {
+        if (pos < total) {
             match (name.chars().nth(pos as usize).map(|c| c.to_string())).into_aver() {
                 Some(c) => {
-                    if (&*c == ".") {
+                    if (c == AverStr::from(".")) {
                         {
-                            let __tmp3 = (acc + &AverStr::from("/"));
-                            pos = nextPos;
-                            acc = __tmp3;
+                            let __tco1 = nextPos;
+                            let __tco3 = (acc + &AverStr::from("/"));
+                            pos = __tco1;
+                            acc = __tco3;
                             continue;
                         }
                     } else {
                         {
-                            let __tmp3 = (acc + &(c.to_lowercase()).into_aver());
-                            pos = nextPos;
-                            acc = __tmp3;
+                            let __tco1 = nextPos;
+                            let __tco3 = (acc + &(c.to_lowercase()).into_aver());
+                            pos = __tco1;
+                            acc = __tco3;
                             continue;
                         }
                     }
                 }
-                None => acc,
+                None => {
+                    return acc;
+                }
             }
-        };
+        } else {
+            return acc;
+        }
     }
 }
 
 /// Duplicate module function names first, then resolve locally so direct-call ids are consistent within that module.
 pub fn resolveQualifiedModuleFns(prog: &Program, dep: AverStr) -> aver_rt::AverList<FnDef> {
     crate::cancel_checkpoint();
-    let qualifiedProg = Program {
+    let qualifiedProg = crate::aver_generated::domain::ast::Program {
         deps: prog.deps.clone(),
         fns: qualifyFns(&prog.fns, dep, &aver_rt::AverList::empty()),
         stmts: prog.stmts.clone(),
@@ -355,19 +360,20 @@ pub fn shiftFnIdsInFns(
 ) -> aver_rt::AverList<FnDef> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fns, [] => acc.reverse(), [fd, rest] => { {
-            let __tmp2 = aver_rt::AverList::prepend(shiftFnIdsInFn(&fd, offset), &acc);
-            fns = rest;
-            acc = __tmp2;
+        aver_list_match!(fns, [] => { return acc.reverse(); }, [fd, rest] => { {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::AverList::prepend(shiftFnIdsInFn(&fd, offset), &acc);
+            fns = __tco0;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
 /// Shift entry-program direct-call ids before prepending loaded module functions.
 pub fn shiftFnIdsInProgram(prog: &Program, offset: i64) -> Program {
     crate::cancel_checkpoint();
-    Program {
+    crate::aver_generated::domain::ast::Program {
         deps: prog.deps.clone(),
         fns: shiftFnIdsInFns(prog.fns.clone(), offset, aver_rt::AverList::empty()),
         stmts: shiftFnIdsInStmts(prog.stmts.clone(), offset, aver_rt::AverList::empty()),
@@ -377,7 +383,7 @@ pub fn shiftFnIdsInProgram(prog: &Program, offset: i64) -> Program {
 /// Shift all embedded direct-call ids in one function definition.
 pub fn shiftFnIdsInFn(fd: &FnDef, offset: i64) -> FnDef {
     crate::cancel_checkpoint();
-    FnDef {
+    crate::aver_generated::domain::ast::FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
         body: shiftFnIdsInStmts(fd.body.clone(), offset, aver_rt::AverList::empty()),
@@ -411,12 +417,13 @@ pub fn shiftFnIdsInStmts(
 ) -> aver_rt::AverList<Stmt> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(stmts, [] => acc.reverse(), [stmt, rest] => { {
-            let __tmp2 = aver_rt::AverList::prepend(shiftFnIdsInStmt(&stmt, offset), &acc);
-            stmts = rest;
-            acc = __tmp2;
+        aver_list_match!(stmts, [] => { return acc.reverse(); }, [stmt, rest] => { {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::AverList::prepend(shiftFnIdsInStmt(&stmt, offset), &acc);
+            stmts = __tco0;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -664,12 +671,13 @@ pub fn shiftFnIdsInExprs(
 ) -> aver_rt::AverList<Expr> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(exprs, [] => acc.reverse(), [expr, rest] => { {
-            let __tmp2 = aver_rt::AverList::prepend(shiftFnIdsInExpr(&expr, offset), &acc);
-            exprs = rest;
-            acc = __tmp2;
+        aver_list_match!(exprs, [] => { return acc.reverse(); }, [expr, rest] => { {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::AverList::prepend(shiftFnIdsInExpr(&expr, offset), &acc);
+            exprs = __tco0;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -682,14 +690,13 @@ pub fn shiftFnIdsInFields(
 ) -> aver_rt::AverList<(AverStr, Expr)> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fields, [] => acc.reverse(), [pair, rest] => { match pair {
-            (name, expr) => {
-            let __tmp2 = aver_rt::AverList::prepend((name, shiftFnIdsInExpr(&expr, offset)), &acc);
-            fields = rest;
-            acc = __tmp2;
+        aver_list_match!(fields, [] => { return acc.reverse(); }, [pair, rest] => { { let (name, expr) = pair; {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::AverList::prepend((name, shiftFnIdsInExpr(&expr, offset)), &acc);
+            fields = __tco0;
+            acc = __tco2;
             continue;
-        }
-        } });
+        } } })
     }
 }
 
@@ -702,12 +709,13 @@ pub fn shiftFnIdsInArms(
 ) -> aver_rt::AverList<MatchArm> {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(arms, [] => acc.reverse(), [arm, rest] => { {
-            let __tmp2 = aver_rt::AverList::prepend(MatchArm { pattern: arm.pattern.clone(), body: shiftFnIdsInExpr(&arm.body, offset), bindingSlots: arm.bindingSlots.clone() }, &acc);
-            arms = rest;
-            acc = __tmp2;
+        aver_list_match!(arms, [] => { return acc.reverse(); }, [arm, rest] => { {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::AverList::prepend(crate::aver_generated::domain::ast::MatchArm { pattern: arm.pattern.clone(), body: shiftFnIdsInExpr(&arm.body, offset), bindingSlots: arm.bindingSlots.clone() }, &acc);
+            arms = __tco0;
+            acc = __tco2;
             continue;
-        } });
+        } })
     }
 }
 
@@ -822,10 +830,11 @@ pub fn finishCliMainResult(result: &Val) -> Result<Val, AverStr> {
 pub fn hasLocalMain(mut fns: aver_rt::AverList<FnDef>) -> bool {
     loop {
         crate::cancel_checkpoint();
-        return aver_list_match!(fns, [] => false, [f, rest] => { if (&*f.name == "main") { true } else { {
-            fns = rest;
+        aver_list_match!(fns, [] => { return false; }, [f, rest] => { if (f.name == AverStr::from("main")) { return true; } else { {
+            let __tco0 = rest;
+            fns = __tco0;
             continue;
-        } } });
+        } } })
     }
 }
 
@@ -969,6 +978,7 @@ pub fn runDemo() -> Result<(), AverStr> {
 }
 
 pub fn main() -> Result<(), AverStr> {
+    crate::cancel_checkpoint();
     let args = {
         crate::cancel_checkpoint();
         aver_replay::invoke_effect("Args.get", vec![], || aver_replay::current_cli_args())

--- a/src/self_host/replay_support.rs
+++ b/src/self_host/replay_support.rs
@@ -1048,6 +1048,23 @@ pub mod aver_replay {
         ScopeMode::Normal
     }
 
+    fn canonical_unit(value: ReplayJson) -> ReplayJson {
+        // A Unit return serializes as JSON null in the VM / wasm-gc
+        // replay format; the self-host interpreter's value type wraps
+        // it as a `ValUnit` variant object. Map that variant back to
+        // null so a recording made by any backend replays cleanly on
+        // the self-host (and vice versa). Every other value passes
+        // through untouched.
+        if let ReplayJson::Object(ref map) = value {
+            if let Some(ReplayJson::Object(variant)) = map.get("$variant") {
+                if variant.get("name").and_then(|n| n.as_str()) == Some("ValUnit") {
+                    return ReplayJson::Null;
+                }
+            }
+        }
+        value
+    }
+
     fn finish_scope_success<T: ReplayValue>(value: &T) {
         SCOPE_STATE.with(|cell| {
             let mut state = cell.borrow_mut();
@@ -1058,7 +1075,7 @@ pub mod aver_replay {
                 ScopeMode::Normal => {}
                 ScopeMode::Record { path, session } => {
                     session.output = RecordedOutcome::Value {
-                        value: value.to_replay_json(),
+                        value: canonical_unit(value.to_replay_json()),
                     };
                     write_recording(path, session);
                 }
@@ -1071,7 +1088,7 @@ pub mod aver_replay {
                             session.effects.len().saturating_sub(*position)
                         );
                     }
-                    let actual_json = value.to_replay_json();
+                    let actual_json = canonical_unit(value.to_replay_json());
                     // Surface the live return value to the parent
                     // process via a stdout marker so the host
                     // (`run_self_host_replay` in

--- a/src/self_host/runtime_support.rs
+++ b/src/self_host/runtime_support.rs
@@ -154,25 +154,31 @@ pub(crate) fn should_skip_http_server() -> bool {
     crate::aver_replay::is_record_mode()
 }
 
-pub fn http_server_listen<F>(port: i64, handler: F) -> Result<(), AverStr>
+pub fn http_server_listen<F>(port: i64, mut handler: F) -> Result<(), AverStr>
 where
-    F: FnMut(aver_rt::HttpRequest) -> aver_rt::HttpResponse,
+    F: FnMut(&aver_rt::HttpRequest) -> aver_rt::HttpResponse,
 {
     if should_skip_http_server() {
         return Ok(());
     }
-    aver_rt::http_server::listen(port, handler).map_err(AverStr::from)
+    // User handlers are emitted borrow-by-default (`fn(&HttpRequest)`),
+    // so adapt the owned-value `aver_rt` callback to a by-reference call.
+    aver_rt::http_server::listen(port, move |req| handler(&req)).map_err(AverStr::from)
 }
 
-pub fn http_server_listen_with<C, F>(port: i64, context: C, handler: F) -> Result<(), AverStr>
+pub fn http_server_listen_with<C, F>(port: i64, context: C, mut handler: F) -> Result<(), AverStr>
 where
     C: Clone,
-    F: FnMut(C, aver_rt::HttpRequest) -> aver_rt::HttpResponse,
+    F: FnMut(&C, &aver_rt::HttpRequest) -> aver_rt::HttpResponse,
 {
     if should_skip_http_server() {
         return Ok(());
     }
-    aver_rt::http_server::listen_with(port, context, handler).map_err(AverStr::from)
+    // User handlers take both the context and the request by reference
+    // (`fn(&Ctx, &HttpRequest)`); adapt the owned-value `aver_rt`
+    // callback accordingly.
+    aver_rt::http_server::listen_with(port, context, move |ctx, req| handler(&ctx, &req))
+        .map_err(AverStr::from)
 }
 
 pub use aver_rt::TcpConnection as Tcp_Connection;
@@ -180,3 +186,5 @@ pub use aver_rt::TcpConnection as Tcp_Connection;
 pub use aver_rt::HttpResponse;
 
 pub use aver_rt::HttpRequest;
+
+pub use aver_rt::TerminalSize as Terminal_Size;


### PR DESCRIPTION
A VM-vs-self-host parity audit during 0.24 prep found the self-hosted interpreter lagged the other backends. This PR closes the three tractable gaps; the two larger ones (higher-order functions, multi-module type resolution) are tracked in #436.

### Int.div on self-host
The interpreter's builtin registry knew `Int.mod` but not `Int.div`, so any program using the 0.24 `Int.div` idiom hit `unknown int builtin: Int.div`. Added `builtinIntDiv`, delegating to the real `Int.div` so it inherits full partiality (division by zero + overflow) and the canonical error strings.

### Float literals in string interpolation
`"{1.5}"` lexed as `TkInt` then choked on the `.` — the interpolation lexer (`tokenizeInterpDigit`) always emitted an int and never checked for a decimal point. Mirrored the main-path float handling with interpolation-aware variants. (Float literals outside interpolation already worked.)

### Replay Unit normalization (all rust/self-host targets)
The VM and wasm-gc replay formats serialize a Unit return as JSON `null`; the rust/self-host backend wrapped it as a `ValUnit` variant object, so a recording made by one backend spuriously failed to replay on the self-host (mismatch → panic) for any Unit-returning `main`. The `--with-replay` codegen now canonicalizes `ValUnit` back to `null` at the record/replay serialization points.

### Result
- Non-interactive example corpus, `aver run` vs `aver run --self-host`: **17/25 → 21/25** parity (remaining 4 are the multi-module/refinement cases in #436).
- A 0.23-recorded wumpus game session (116 effects) now replays **MATCH** on the self-host — matching VM and wasm-gc, so the cross-version replay safety net holds on every backend.
- `src/self_host/` regenerated via `aver compile --target rust`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)