### PR TITLE
ir/mir: const-fold must not drop effectful sub-expressions (soundness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
+## 0.24.1 (unreleased)
+
+Patch release on top of "Divide" — a correctness fix in the optimizer and broader `aver check` hints.
+
+### Fixed
+
+- **Constant folding no longer drops a side effect or a non-terminating computation.** When the optimizer collapsed a `match` / `Result.withDefault` / `?` over a statically-known `Result`/`Option`, or an `Int.div`/`Int.mod` by a literal zero, it could discard a sub-expression that still had to run — silently dropping its effects (e.g. a `Console.print`), or turning a program that should loop forever into one that returns; one wildcard case could also crash the VM. Folded expressions now always run their effects, in source order.
+
+### Changed
+
+- **`aver check` flags more redundant work** — a loop invariant built directly inside a recursive call's arguments, and a pure function computed more than once with the same arguments in a single expression.
+
 ## 0.24.0 "Divide" — 2026-06-06
 
 > _One middle-end under every backend; the last operator that could crash is now a function._

--- a/src/ir/mir/optimize/const_fold.rs
+++ b/src/ir/mir/optimize/const_fold.rs
@@ -36,6 +36,7 @@ use super::super::expr::{
     MirPattern,
 };
 use super::super::program::MirProgram;
+use super::dead_code::is_pure;
 
 /// Apply const-fold to every fn body in `program`. Returns the
 /// (transformed) program by value so the caller can chain
@@ -206,6 +207,14 @@ fn literal_of(node: &MirExpr) -> Option<&Literal> {
 /// must match `src/types/int.rs`.
 const DIV_BY_ZERO: &str = "division by zero";
 
+/// MIR `LocalId` sentinel for a `_` pattern binding — the resolver mints
+/// `u16::MAX` ("no slot, drop the value"). A Fold-B rewrite that would drop
+/// the strictly-evaluated arg bound here is sound only when that arg is
+/// pure: otherwise its effects / divergence vanish, and emitting a `Let` on
+/// the sentinel panics the VM (`STORE_LOCAL` reads a u8 slot) and drops the
+/// value on the wasm-gc / Rust backends. The folds decline rather than risk it.
+const WILDCARD_SLOT: u32 = u16::MAX as u32;
+
 /// Resolve the canonical name of a `MirCallee::Builtin` against the
 /// program's interned builtin table. Returns `None` for any other
 /// callee kind (or an out-of-range id).
@@ -315,6 +324,13 @@ fn fold_a_partial_int_builtin(
         return None;
     };
     let k = *k;
+    // `k == 0` makes the result an unconditional `Err`, discarding the
+    // dividend entirely. Folding would drop the dividend's strict
+    // evaluation — its effects and its divergence — so only fold when the
+    // dividend is pure; otherwise leave the runtime `Result` call.
+    if k == 0 && !is_pure(&call.args[0]) {
+        return None;
+    }
     // The wrapping `Result.Ok` / `Result.Err` keeps the original call's
     // `Result<Int,String>` type stamp.
     let result_ty = expr.ty().cloned();
@@ -465,6 +481,18 @@ fn fold_b_with_default(
         _ => return None,
     };
 
+    // The `Err(_)` / `None` branch drops the constructor's payload, which is
+    // evaluated strictly before `withDefault` runs — so dropping it loses
+    // its effects / divergence unless it is pure. Decline the fold then.
+    if !take_payload {
+        let MirExpr::Construct(inner) = &spanned_call.node.args[0].node else {
+            return None;
+        };
+        if !inner.node.args.iter().all(is_pure) {
+            return None;
+        }
+    }
+
     let MirExpr::Call(spanned_call) = &mut expr.node else {
         unreachable!("guarded above");
     };
@@ -479,9 +507,8 @@ fn fold_b_with_default(
         };
         inner.node.args.into_iter().next()
     } else {
-        // `Err(_)` / `None` → the default (already typed). The `Err`
-        // payload is dropped; it's pure (a literal / already-evaluated
-        // value), so no eval is lost.
+        // `Err(_)` / `None` → the default (already typed). The dropped
+        // payload was proven pure above, so no evaluation is lost.
         Some(default)
     }
 }
@@ -519,6 +546,24 @@ fn fold_b_match_over_ctor(expr: &mut Spanned<MirExpr>) -> Option<Spanned<MirExpr
         .arms
         .iter()
         .position(|arm| arm_matches_ctor(&arm.pattern, subj_ctor, subj_arity))?;
+
+    // A fold that drops a strictly-evaluated ctor arg — a `Wildcard` arm
+    // (drops every arg) or a `_`-bound field of a `Ctor` arm (drops that
+    // arg) — is sound only when the dropped arg is pure; otherwise its
+    // effects / divergence would silently vanish. Decline the fold (leave
+    // the `match`, which evaluates the subject strictly) when any dropped
+    // arg is impure.
+    let drops_impure = match &spanned_match.node.arms[arm_idx].pattern {
+        MirPattern::Wildcard => subj.node.args.iter().any(|a| !is_pure(a)),
+        MirPattern::Ctor { bindings, .. } => bindings
+            .iter()
+            .zip(&subj.node.args)
+            .any(|(slot, arg)| slot.0 == WILDCARD_SLOT && !is_pure(arg)),
+        _ => false,
+    };
+    if drops_impure {
+        return None;
+    }
 
     // The subject's `Result` / `Option` type — used to re-stamp the ctor
     // if the chosen arm binds the whole subject (`Bind`).
@@ -609,6 +654,15 @@ fn wrap_in_lets(
     // first field ends up as the outermost (first-evaluated) `Let`.
     let n = ctor_args.len();
     for (i, (slot, arg)) in bindings.iter().zip(ctor_args).enumerate().rev() {
+        // A `_` field has no slot (the wildcard sentinel). Its arg is
+        // guaranteed pure by the caller's gate, so drop it instead of
+        // binding it: a `Let` on the sentinel slot panics the VM
+        // (`STORE_LOCAL` reads a u8 slot) and drops the value on the
+        // wasm-gc / Rust backends.
+        if slot.0 == WILDCARD_SLOT {
+            let _ = arg;
+            continue;
+        }
         // `binding_names` is parallel to `bindings`; fall back to empty
         // (synthetic) only if it's somehow short — never for well-typed
         // input. `_ = n` keeps the index in range for the zip.
@@ -1197,6 +1251,156 @@ mod tests {
                 MirCallee::Intrinsic(BuiltinIntrinsic::IntDivEuclid)
             ),
             "withDefault(Int.div(a, 10), 0) must fold to a bare Euclidean intrinsic"
+        );
+    }
+
+    // ---- Fold drop-soundness (0.24.1): a fold must never silently drop a
+    // strictly-evaluated sub-expression. Each test FAILs without the
+    // purity gate — confirmed by running the matching .av repro on the
+    // pre-fix binary (it dropped the effect / panicked). ----
+
+    /// A side-effecting expression. `is_pure` classifies every `Call` as
+    /// impure, and an `Intrinsic` call is never re-folded by Fold A/B, so
+    /// it survives a fold pass unchanged and stands in for "has effects".
+    fn impure() -> Spanned<MirExpr> {
+        span(MirExpr::Call(span(MirCall {
+            callee: MirCallee::Intrinsic(BuiltinIntrinsic::IntDivEuclid),
+            args: vec![int_lit(1), int_lit(1)],
+        })))
+    }
+
+    #[test]
+    fn fold_a_div_by_zero_keeps_impure_dividend() {
+        // `Int.div(<impure>, 0)`: folding to `Result.Err` would drop the
+        // dividend's strict evaluation (its effects / divergence). The fold
+        // must decline — the node stays the runtime `Int.div` call.
+        let body = builtin_call(vec![impure(), int_lit(0)]);
+        let folded = const_fold(program_with_builtin("Int.div", body));
+        let MirExpr::Call(c) = body_of(&folded) else {
+            panic!(
+                "impure dividend must keep the runtime Int.div call, got {:?}",
+                body_of(&folded)
+            );
+        };
+        assert!(matches!(c.node.callee, MirCallee::Builtin(BuiltinId(0))));
+        assert_eq!(c.node.args.len(), 2, "both args restored intact");
+    }
+
+    #[test]
+    fn fold_a_div_by_zero_still_folds_pure_dividend() {
+        // The win must survive: a pure dividend over a zero divisor still
+        // folds to the `Result.Err` (no eval is lost when the arg is pure).
+        let body = builtin_call(vec![int_lit(99), int_lit(0)]);
+        let folded = const_fold(program_with_builtin("Int.div", body));
+        let MirExpr::Construct(c) = body_of(&folded) else {
+            panic!("pure dividend over /0 must still fold to Err");
+        };
+        assert!(matches!(
+            c.node.ctor,
+            MirCtor::Builtin(BuiltinCtor::ResultErr)
+        ));
+    }
+
+    #[test]
+    fn fold_b_withdefault_err_keeps_impure_payload() {
+        // `Result.withDefault(Result.Err(<impure>), 0)`: folding to the
+        // default would drop the Err payload's strict evaluation. Decline.
+        let body = builtin_call(vec![
+            ctor(BuiltinCtor::ResultErr, vec![impure()]),
+            int_lit(0),
+        ]);
+        let folded = const_fold(program_with_builtin("Result.withDefault", body));
+        assert!(
+            matches!(body_of(&folded), MirExpr::Call(_)),
+            "impure Err payload must keep the runtime withDefault call, got {:?}",
+            body_of(&folded)
+        );
+    }
+
+    #[test]
+    fn fold_b_match_wildcard_keeps_impure_subject_arg() {
+        // `match Result.Ok(<impure>) { _ -> 42 }`: a Wildcard arm drops the
+        // ctor arg; folding to the body would lose its strict evaluation.
+        let body = MirExpr::Match(span(MirMatch {
+            subject: Box::new(ctor(BuiltinCtor::ResultOk, vec![impure()])),
+            arms: vec![MirMatchArm {
+                pattern: MirPattern::Wildcard,
+                body: int_lit(42),
+            }],
+        }));
+        let folded = const_fold(one_fn_program(body));
+        assert!(
+            matches!(body_of(&folded), MirExpr::Match(_)),
+            "impure ctor arg under a Wildcard arm must keep the match, got {:?}",
+            body_of(&folded)
+        );
+    }
+
+    #[test]
+    fn fold_b_match_ctor_discard_field_keeps_impure_arg() {
+        // `match Result.Ok(<impure>) { Result.Ok(_) -> 42 ; Err(_) -> 0 }`:
+        // the `_` field's binding is the wildcard slot sentinel. Folding an
+        // impure arg here would either drop the effect or — emitting a Let
+        // on the sentinel slot — panic the VM. Decline.
+        let ok_arm = MirMatchArm {
+            pattern: MirPattern::Ctor {
+                ctor: MirCtor::Builtin(BuiltinCtor::ResultOk),
+                bindings: vec![LocalId(WILDCARD_SLOT)],
+                binding_names: vec![String::new()],
+            },
+            body: int_lit(42),
+        };
+        let err_arm = MirMatchArm {
+            pattern: MirPattern::Ctor {
+                ctor: MirCtor::Builtin(BuiltinCtor::ResultErr),
+                bindings: vec![LocalId(WILDCARD_SLOT)],
+                binding_names: vec![String::new()],
+            },
+            body: int_lit(0),
+        };
+        let body = MirExpr::Match(span(MirMatch {
+            subject: Box::new(ctor(BuiltinCtor::ResultOk, vec![impure()])),
+            arms: vec![ok_arm, err_arm],
+        }));
+        let folded = const_fold(one_fn_program(body));
+        assert!(
+            matches!(body_of(&folded), MirExpr::Match(_)),
+            "impure arg at a `_` field must keep the match, got {:?}",
+            body_of(&folded)
+        );
+    }
+
+    #[test]
+    fn fold_b_match_ctor_discard_field_pure_folds_without_sentinel_let() {
+        // `match Result.Ok(7) { Result.Ok(_) -> 42 ; Err(_) -> 0 }`: the arg
+        // is pure, so the fold proceeds — but it must drop the `_` field
+        // cleanly, NOT emit a `Let` bound to the wildcard sentinel (which
+        // would panic the VM's u8 `STORE_LOCAL`). Result: the bare body 42.
+        let ok_arm = MirMatchArm {
+            pattern: MirPattern::Ctor {
+                ctor: MirCtor::Builtin(BuiltinCtor::ResultOk),
+                bindings: vec![LocalId(WILDCARD_SLOT)],
+                binding_names: vec![String::new()],
+            },
+            body: int_lit(42),
+        };
+        let err_arm = MirMatchArm {
+            pattern: MirPattern::Ctor {
+                ctor: MirCtor::Builtin(BuiltinCtor::ResultErr),
+                bindings: vec![LocalId(WILDCARD_SLOT)],
+                binding_names: vec![String::new()],
+            },
+            body: int_lit(0),
+        };
+        let body = MirExpr::Match(span(MirMatch {
+            subject: Box::new(ctor(BuiltinCtor::ResultOk, vec![int_lit(7)])),
+            arms: vec![ok_arm, err_arm],
+        }));
+        let folded = const_fold(one_fn_program(body));
+        assert!(
+            matches!(body_of(&folded), MirExpr::Literal(s) if matches!(s.node, Literal::Int(42))),
+            "pure `_`-field fold must collapse to the bare body with no sentinel Let, got {:?}",
+            body_of(&folded)
         );
     }
 }

--- a/tests/const_fold_drop_soundness.rs
+++ b/tests/const_fold_drop_soundness.rs
@@ -1,0 +1,209 @@
+//! Soundness regression net for const-fold "drop" bugs.
+//!
+//! A structural fold that statically collapses a consumer over a known
+//! constructor (Fold B) or a const-divisor `Int.div`/`Int.mod` (Fold A)
+//! must NEVER drop a strictly-evaluated sub-expression. In 0.24 four folds
+//! did, silently discarding an effectful / diverging sub-expression:
+//!
+//!   - B1: `match Result.Ok(noisy()) { _ -> .. }` — the Wildcard arm
+//!     dropped the ctor arg, so its effect vanished;
+//!   - B2: `Result.withDefault(Result.Err(noisy()), d)` — the Err payload
+//!     was dropped, so its effect vanished;
+//!   - B3: `Int.div(noisy(), 0)` — the dividend was dropped, so its effect
+//!     vanished (and a *diverging* dividend turned non-termination into
+//!     termination);
+//!   - panic: `match Result.Ok(x) { Result.Ok(_) -> .. }` — the `_` field's
+//!     sentinel-slot `Let` made the VM's u8 `STORE_LOCAL` index out of
+//!     bounds and panic.
+//!
+//! Each program runs through the real VM (`aver run`) — NOT `aver verify` —
+//! per the audit-crash lesson (verify ≠ run; a test that passes with AND
+//! without the fix proves nothing). On the pre-fix binary the asserted
+//! effect is absent / the VM panics, so each test FAILs without the fix.
+//! The final test pins the headline win (const-divisor fold still computes)
+//! so the fix can't pass by neutering const-fold.
+
+use std::fs;
+use std::process::Command;
+
+/// Run an Aver program via the built `aver` binary; assert it exits
+/// successfully (a panic is a non-success exit) and return trimmed stdout.
+fn run_aver(name: &str, source: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("aver_const_fold_drop_{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let file = dir.join(format!("{name}.av"));
+    fs::write(&file, source).expect("write source");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .arg("run")
+        .arg(&file)
+        .output()
+        .expect("spawn aver run");
+    assert!(
+        out.status.success(),
+        "`aver run {}` failed (panic / non-zero exit): {}",
+        file.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = fs::remove_dir_all(&dir);
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[test]
+fn b1_wildcard_arm_keeps_ctor_arg_effect() {
+    let src = r#"module B1
+    intent = "Wildcard arm over Result.Ok(effectful) must not drop the effect."
+    exposes [main]
+    depends []
+    effects [Console]
+
+fn noisy(n: Int) -> Int
+    ? "Prints, returns n."
+    ! [Console.print]
+    _ = Console.print("noisy ran with {n}")
+    n
+
+fn pick() -> Int
+    ? "Match over Result.Ok(effectful) with a wildcard arm."
+    ! [Console.print]
+    match Result.Ok(noisy(7))
+        _ -> 42
+
+fn main() -> Unit
+    ! [Console.print]
+    r = pick()
+    Console.print("result {r}")
+"#;
+    let out = run_aver("b1_wildcard", src);
+    assert!(
+        out.contains("noisy ran with 7"),
+        "Wildcard-arm fold dropped the ctor arg's effect; got:\n{out}"
+    );
+    assert!(out.contains("result 42"), "got:\n{out}");
+}
+
+#[test]
+fn b2_withdefault_err_keeps_payload_effect() {
+    let src = r#"module B2
+    intent = "withDefault over Result.Err(effectful) must not drop the payload effect."
+    exposes [main]
+    depends []
+    effects [Console]
+
+fn boom(n: Int) -> String
+    ? "Prints, returns an error string."
+    ! [Console.print]
+    _ = Console.print("boom ran with {n}")
+    "the error"
+
+fn pick() -> String
+    ? "withDefault over a statically-Err result."
+    ! [Console.print]
+    Result.withDefault(Result.Err(boom(3)), "fallback")
+
+fn main() -> Unit
+    ! [Console.print]
+    r = pick()
+    Console.print("result {r}")
+"#;
+    let out = run_aver("b2_withdefault", src);
+    assert!(
+        out.contains("boom ran with 3"),
+        "withDefault Err fold dropped the payload's effect; got:\n{out}"
+    );
+    assert!(out.contains("result fallback"), "got:\n{out}");
+}
+
+#[test]
+fn b3_div_by_zero_keeps_dividend_effect() {
+    let src = r#"module B3
+    intent = "Int.div by literal zero must not drop the dividend's effect."
+    exposes [main]
+    depends []
+    effects [Console]
+
+fn loud(n: Int) -> Int
+    ? "Prints, returns n — this is the dividend."
+    ! [Console.print]
+    _ = Console.print("dividend evaluated")
+    n
+
+fn compute() -> Result<Int, String>
+    ? "Divide an effectful dividend by literal zero."
+    ! [Console.print]
+    Int.div(loud(5), 0)
+
+fn main() -> Unit
+    ! [Console.print]
+    match compute()
+        Result.Ok(v) -> Console.print("ok {v}")
+        Result.Err(e) -> Console.print("err {e}")
+"#;
+    let out = run_aver("b3_divzero", src);
+    assert!(
+        out.contains("dividend evaluated"),
+        "Int.div(_, 0) fold dropped the dividend's effect; got:\n{out}"
+    );
+    assert!(out.contains("err division by zero"), "got:\n{out}");
+}
+
+#[test]
+fn panic_ctor_discard_field_runs_without_vm_panic() {
+    let src = r#"module Discard
+    intent = "Ctor arm with a `_` field over a known ctor must not panic the VM."
+    exposes [main]
+    depends []
+    effects [Console]
+
+fn noisy(n: Int) -> Int
+    ? "Prints, returns n."
+    ! [Console.print]
+    _ = Console.print("noisy ran with {n}")
+    n
+
+fn pick() -> Int
+    ? "Ctor arm binds the payload field to `_` (discard)."
+    ! [Console.print]
+    match Result.Ok(noisy(7))
+        Result.Ok(_) -> 42
+        Result.Err(_) -> 0
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("result {pick()}")
+"#;
+    let out = run_aver("panic_discard", src);
+    assert!(
+        out.contains("noisy ran with 7"),
+        "ctor `_`-field fold dropped the arg's effect; got:\n{out}"
+    );
+    assert!(out.contains("result 42"), "got:\n{out}");
+}
+
+#[test]
+fn win_const_divisor_fold_still_computes() {
+    // The headline win must survive the soundness gate: a const-divisor
+    // `Int.div` still folds and computes the right Euclidean quotient.
+    let src = r#"module Win
+    intent = "const-divisor Int.div folds and still computes correctly."
+    exposes [main]
+    depends []
+    effects [Console]
+
+fn half(a: Int) -> Result<Int, String>
+    ? "Divide by a literal 2 — folds to a bare Euclid at MIR."
+    Int.div(a, 2)
+
+fn main() -> Unit
+    ! [Console.print]
+    match half(10)
+        Result.Ok(v) -> Console.print("half {v}")
+        Result.Err(e) -> Console.print("err {e}")
+"#;
+    let out = run_aver("win_const_divisor", src);
+    assert_eq!(
+        out, "half 5",
+        "const-divisor fold must still compute; got:\n{out}"
+    );
+}


### PR DESCRIPTION
## What

Soundness fix for the MIR const-fold pass. Four folds dropped a strictly-evaluated sub-expression, silently discarding its effects / divergence; one path panicked the VM. Surfaced by adversarial verification (same discipline as the #326 audit-crash finding) and confirmed empirically on the VM.

### The bugs (all shipped in 0.24)

| | fold | dropped | symptom |
|--|--|--|--|
| B1 | `match Result.Ok(e) { _ -> .. }` | the ctor arg `e` | effect vanishes |
| B2 | `Result.withDefault(Result.Err(e), d)` | the payload `e` | effect vanishes |
| B3 | `Int.div(e, 0)` | the dividend `e` | effect vanishes; divergence → termination |
| panic | `match Result.Ok(e) { Result.Ok(_) -> .. }` | — | `_`-field `Let` on the wildcard sentinel → VM `STORE_LOCAL` (u8) indexes out of bounds → panic |

Example (B1): `match Result.Ok(noisy(7)) { _ -> 42 }` printed only `result 42` — the `Console.print` in `noisy` vanished; MIR folded `pick()` to a bare `Int(42)`.

### The fix

One principle: a fold must never drop a strictly-evaluated sub-expression. Gate each drop site on `is_pure` — decline the fold when the discarded expr is impure (the node stays a runtime call / match, evaluated strictly), and drop `_`-field args cleanly without ever emitting a `Let` bound to the wildcard sentinel. Pure const-divisor folds (the 0.24 headline) are unaffected — verified (`Int.div(a, 10)?` still lowers to a bare `IntDivEuclid`).

### Tests (revert-tests — each FAILs without the fix)

- 6 unit tests in `const_fold`: decline on impure dividend / payload / ctor-arg, fold-without-sentinel-`Let` on a pure `_` field, and win-preservation.
- `tests/const_fold_drop_soundness.rs`: the four repros run through the real VM (`aver run`, not `verify` — verify ≠ run) plus a const-divisor win check.

Candidate for a **0.24.1** patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
