### PR TITLE
ci: harden Dafny install against CDN 504 + migrate Node-20 actions to Node-24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -50,7 +50,7 @@ jobs:
     name: WASM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check, wasm]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build (wasm release)
@@ -115,7 +115,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload bench results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bench-results
           path: bench-results.ndjson

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -125,7 +125,7 @@ jobs:
             corpus: corpus/parser
             dict: dicts/aver.dict
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -254,7 +254,7 @@ jobs:
                  2>&1; then
               # The artifact is a tarball — colon-bearing AFL filenames
               # (`id:000000,sig:06,...`) cannot survive the
-              # actions/upload-artifact@v4 Windows-compat filename
+              # actions/upload-artifact (v4+) Windows-compat filename
               # validator unwrapped, so the upload step tars the whole
               # `default/` directory before publishing. Unpack here.
               if [ -f seed/prev/afl-nightly-${{ matrix.target }}.tar.gz ]; then
@@ -396,7 +396,7 @@ jobs:
       - name: Pack AFL output
         # AFL filenames contain `:` characters that
         # mandatory: AFL filenames contain `:` characters that
-        # actions/upload-artifact@v4 silently drops, producing a
+        # actions/upload-artifact (v4+) silently drops, producing a
         # zero-byte artifact and breaking the resume mechanism.
         if: always()
         working-directory: fuzz
@@ -414,7 +414,7 @@ jobs:
         # queue. `if: failure()` would lose the queue every time we
         # have a clean run, defeating the resume mechanism.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: afl-nightly-${{ matrix.target }}
           path: fuzz/afl-nightly-${{ matrix.target }}.tar.gz

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -63,24 +63,35 @@ jobs:
         run: lake --version
 
       - name: Install Dafny
-        # `tests/proof_spec.rs` already gates the Dafny arms on
-        # `Command::new("dafny").arg("--version").output().is_ok()`,
-        # so locally these tests skip cleanly. On nightly we install
-        # the toolchain so the same `cargo test` invocation exercises
-        # both backends — `aver proof --backend dafny <example>`
-        # followed by `dafny verify Prog.dfy` against the emitted
-        # project. A Dafny-side proof failure on any fixture fails
-        # the job.
-        uses: dafny-lang/setup-dafny-action@v1.9.1
-        with:
-          # 4.11.0: 4.9.0 leaves 2 quicksort postconditions un-
-          # discharged on top of the 5-budget (left: 7, right: 5)
-          # and drifts on rle in the same direction; 4.11.0's SMT
-          # encoding closes both within budget on the same source.
-          # Bumping in lockstep with the macOS Homebrew Dafny used
-          # by local contributors keeps `cargo test --test
-          # proof_spec` behaviour identical between dev + CI.
-          dafny-version: 4.11.0
+        # Manual download of the self-contained (62 MB — bundles its own
+        # .NET runtime and Z3) Dafny release zip, replacing
+        # dafny-lang/setup-dafny-action. Two reasons:
+        #   1. Robustness. The action's internal 3x retry gave up after
+        #      ~40s on a transient GitHub-releases CDN 504 and failed the
+        #      nightly; `curl --retry 6 --retry-all-errors` rides a
+        #      multi-minute CDN blip instead.
+        #   2. Node-20 EOL. The action is pinned at v1.9.1 (no newer
+        #      release) and its internal setup-node@v4 / setup-dotnet@v4
+        #      are Node-20 only — GitHub force-migrates those to Node-24
+        #      on 2026-06-16 and removes Node-20 on 2026-09-16. A self-
+        #      contained zip needs no dotnet, so a plain download + PATH
+        #      sidesteps the whole chain.
+        # The next step double-checks the install via `dafny --version`
+        # (which `tests/proof_spec.rs` also gates the Dafny arms on). Keep
+        # the version in lockstep with the macOS Homebrew Dafny local
+        # contributors use so `cargo test --test proof_spec` behaves
+        # identically dev + CI (4.11.0 closes quicksort + rle within the
+        # 5-budget where 4.9.0 left 2 undischarged).
+        env:
+          DAFNY_VERSION: '4.11.0'
+        run: |
+          set -euo pipefail
+          url="https://github.com/dafny-lang/dafny/releases/download/v${DAFNY_VERSION}/dafny-${DAFNY_VERSION}-x64-ubuntu-22.04.zip"
+          curl -fSL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o /tmp/dafny.zip "$url"
+          unzip -q /tmp/dafny.zip -d "$HOME/dafny-install"
+          dafny_dir="$(dirname "$(find "$HOME/dafny-install" -name dafny -type f | head -1)")"
+          chmod +x "$dafny_dir/dafny" || true
+          echo "$dafny_dir" >> "$GITHUB_PATH"
 
       - name: Verify `dafny` reachable
         run: dafny --version

--- a/.github/workflows/rust-codegen.yml
+++ b/.github/workflows/rust-codegen.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
## What

Two CI-workflow fixes, both triggered by the Proof nightly failing on a transient GitHub-releases **HTTP 504** while installing Dafny (run [27085693297](https://github.com/jasisz/aver/actions/runs/27085693297) — re-run is green; this hardens against the next one).

### 1. Harden the Dafny install (the 504)

`dafny-lang/setup-dafny-action@v1.9.1` downloads the Dafny release zip, and its internal 3× retry gave up after ~40s on the CDN 504. Replaced with a manual `curl -fSL --retry 6 --retry-all-errors --retry-delay 15` download of the **self-contained** `x64-ubuntu` zip (62 MB — it bundles its own .NET runtime + Z3, so no `dotnet` setup is needed) → `unzip` → PATH. Rides a multi-minute CDN blip; the existing `dafny --version` step validates the install.

### 2. Node-20 → Node-24 (GitHub deprecation, 2026-06-16 / 2026-09-16)

GitHub force-migrates Node-20 JS actions to Node-24 on **2026-06-16** and removes Node-20 on **2026-09-16**. Verified each action's `runs.using` and bumped only the Node-20 ones to their first Node-24 major:

| action | was | now |
|--|--|--|
| `actions/checkout` | v4 (node20) | **v5** (node24) — proof, ci ×4, rust-codegen, fuzz |
| `actions/upload-artifact` | v4 (node20; v5 also node20) | **v6** (node24) — ci bench + fuzz |
| dafny-action internal `setup-node@v4` / `setup-dotnet@v4` | node20 | **gone** (removed with change #1; action had no Node-24 release) |
| `Swatinem/rust-cache@v2` | node24 already | unchanged |
| `dtolnay/rust-toolchain` | composite (no Node) | unchanged |

The PR's own **Proof** run exercises the manual Dafny install on ubuntu end-to-end (and the `dafny --version` + `cargo test --test proof_spec` steps prove it works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
