### PR TITLE
proof: accumulator-roundtrip proves on Lean + Dafny; recognize count field by role

### DIFF
--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -643,6 +643,41 @@ function StringJoin(sep: string, parts: seq<string>): string
   else parts[0] + sep + StringJoin(sep, parts[1..])
 }
 
+// The tail of StringChars(s) is StringChars of the tail of s. A
+// support lemma for StringJoinEmptyChars below.
+lemma StringCharsTail(s: string)
+  requires |s| >= 1
+  ensures StringChars(s)[1..] == StringChars(s[1..])
+{
+  assert |StringChars(s)[1..]| == |StringChars(s[1..])|;
+  forall j | 0 <= j < |s| - 1
+    ensures StringChars(s)[1..][j] == StringChars(s[1..])[j]
+  {
+    assert s[1..][j] == s[j + 1];
+  }
+}
+
+// Joining the single-character pieces of a string with the empty
+// separator rebuilds the string: StringJoin("", StringChars(s)) == s.
+// The proof-export inverse of the chars/join pair; the Dafny
+// counterpart of the Lean prelude's String roundtrip theorem.
+lemma {:fuel StringJoin, 2} StringJoinEmptyChars(s: string)
+  ensures StringJoin("", StringChars(s)) == s
+  decreases |s|
+{
+  if |s| == 0 {
+    assert StringChars(s) == [];
+  } else if |s| == 1 {
+    assert StringChars(s) == [[s[0]]];
+    assert s == [s[0]];
+  } else {
+    StringCharsTail(s);
+    StringJoinEmptyChars(s[1..]);
+    assert StringChars(s)[0] == [s[0]];
+    assert s == [s[0]] + s[1..];
+  }
+}
+
 function StringSplit(s: string, sep: string): seq<string>
 function StringContains(s: string, sub: string): bool
 function StringStartsWith(s: string, prefix: string): bool

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -4,7 +4,7 @@ use crate::codegen::CodegenContext;
 use crate::codegen::common::parse_type_annotation;
 use crate::types::Type;
 
-use super::expr::{aver_name_to_dafny, emit_expr_legacy};
+use super::expr::{aver_name_to_dafny, emit_expr, emit_expr_legacy};
 
 /// Emit a Dafny type from an Aver type annotation string.
 /// Ghost-predicate names emitted by `oracle_subtypes::dafny_subtype_predicates`
@@ -1179,6 +1179,29 @@ pub fn emit_law_samples(
             ));
         }
     } else {
+        // A roundtrip law (accumulator-roundtrip or its string wrapper)
+        // has a proven universal lemma `{fn}_{law}` whose postcondition
+        // is `lhs(x) == x`. A deep concrete sample (e.g. an 8-char string)
+        // exceeds Dafny's default fuel for direct evaluation, so discharge
+        // each sample from that lemma at the sample's value (== the RHS
+        // for a roundtrip law) instead of re-deriving it by unfolding.
+        let roundtrip_thm = ctx
+            .symbol_table
+            .fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name))
+            .and_then(|fn_id| {
+                ctx.proof_ir
+                    .law_theorems
+                    .iter()
+                    .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+            })
+            .filter(|t| {
+                matches!(
+                    t.strategy,
+                    crate::ir::ProofStrategy::AccumulatorRoundtrip { .. }
+                        | crate::ir::ProofStrategy::StringRoundtripViaList { .. }
+                )
+            })
+            .map(|_| format!("{fn_name}_{law_name}"));
         lines.push(format!(
             "method test_{}_{}{}_samples() {{",
             fn_name, law_name, suffix
@@ -1186,6 +1209,9 @@ pub fn emit_law_samples(
         for (lhs_rw, rhs_rw) in &rewritten {
             let l = emit_expr_legacy(lhs_rw, ctx, None);
             let r = emit_expr_legacy(rhs_rw, ctx, None);
+            if let Some(thm) = &roundtrip_thm {
+                lines.push(format!("  {}({});", thm, r));
+            }
             // `{:split_here}` tells Dafny to check the preceding assert as
             // its own VC — without it, Z3 accumulates hypothesis state
             // across all samples in the method and occasionally times out
@@ -1422,6 +1448,104 @@ fn emit_wrapper_over_recursion_support_stack(
     lines.join("\n")
 }
 
+/// Emits the support-lemma stack + main law lemma for an
+/// accumulator-threaded encoder/inverse roundtrip
+/// (`examples/data/rle.av` is the canonical case). The lowerer
+/// recognized the wrapper/loop/step/finish/inverse/repeat shape and
+/// the synthesized `count >= 0` well-formedness invariant; this is the
+/// Dafny counterpart of the Lean `accumulator_roundtrip` emit. All
+/// lemmas are proven — no `assume {:axiom}`:
+///
+///   * `repeat_succ`       — counted-repeat advances by one under n >= 0
+///   * `decode_append`     — the inverse distributes over `++`
+///   * `flush_fold_step`   — one fold step preserves decoded output (WF-guarded)
+///   * `step_count_nonneg` — the step preserves the `count >= 0` invariant
+///   * `loop_gen`          — the generalized invariant over all accumulators
+///   * `{law_thm}`         — the user law, derived at the initial accumulator
+///
+/// The Run literal is reconstructed from `run_value_field`/`count_field`
+/// because Dafny (unlike Lean's `simp`) needs the explicit split point
+/// to apply `decode_append`. The run's count field is assumed to share
+/// `count_field`'s name, which holds across the RLE-shaped family the
+/// lowerer recognizes.
+#[allow(clippy::too_many_arguments)]
+fn emit_accumulator_roundtrip_support_stack(
+    ctx: &CodegenContext,
+    wrapper_fn: &str,
+    loop_fn: &str,
+    step_fn: &str,
+    finish_fn: &str,
+    inverse_fn: &str,
+    expand_fn: &str,
+    repeat_fn: &str,
+    acc_type: &str,
+    run_type: &str,
+    item_type: &str,
+    runs_field: &str,
+    current_field: &str,
+    count_field: &str,
+    run_value_field: &str,
+    initial_acc: &Spanned<crate::ir::hir::ResolvedExpr>,
+    law_thm: &str,
+) -> String {
+    let wrapper_d = aver_name_to_dafny(wrapper_fn);
+    let loop_d = aver_name_to_dafny(loop_fn);
+    let step_d = aver_name_to_dafny(step_fn);
+    let finish_d = aver_name_to_dafny(finish_fn);
+    let inverse_d = aver_name_to_dafny(inverse_fn);
+    let expand_d = aver_name_to_dafny(expand_fn);
+    let repeat_d = aver_name_to_dafny(repeat_fn);
+    let acc_d = emit_type(acc_type);
+    let run_d = emit_type(run_type);
+    let item_d = emit_type(item_type);
+    let runs_f = aver_name_to_dafny(runs_field);
+    let current_f = aver_name_to_dafny(current_field);
+    let count_f = aver_name_to_dafny(count_field);
+    let value_f = aver_name_to_dafny(run_value_field);
+    let initial_d = emit_expr(initial_acc, ctx);
+
+    let repeat_succ = format!("{law_thm}_repeat_succ");
+    let decode_append = format!("{law_thm}_decode_append");
+    let flush_step = format!("{law_thm}_flush_fold_step");
+    let count_nonneg = format!("{law_thm}_step_count_nonneg");
+    let loop_gen = format!("{law_thm}_loop_gen");
+
+    let run_lit = |c: &str, n: &str| format!("{run_d}({value_f} := {c}, {count_f} := {n})");
+    let run_new = run_lit("c", "1");
+    let run_cur_succ = run_lit(&format!("acc.{current_f}"), &format!("acc.{count_f} + 1"));
+    let run_cur = run_lit(&format!("acc.{current_f}"), &format!("acc.{count_f}"));
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "// Law: {wrapper_fn}.<roundtrip> — accumulator-roundtrip support stack"
+    ));
+    // Helper: counted-repeat advances by one (near-definitional for n >= 0).
+    lines.push(format!(
+        "lemma {{:fuel {repeat_d}, 2}} {repeat_succ}(c: {item_d}, n: int)\n  requires 0 <= n\n  ensures {repeat_d}(c, n + 1) == {repeat_d}(c, n) + [c]\n{{\n}}"
+    ));
+    // Helper: the inverse distributes over ++.
+    lines.push(format!(
+        "lemma {{:fuel {inverse_d}, 2}} {decode_append}(a: seq<{run_d}>, b: seq<{run_d}>)\n  ensures {inverse_d}(a + b) == {inverse_d}(a) + {inverse_d}(b)\n  decreases |a|\n{{\n  if |a| == 0 {{\n    assert a + b == b;\n  }} else {{\n    assert (a + b)[0] == a[0];\n    assert (a + b)[1..] == a[1..] + b;\n    {decode_append}(a[1..], b);\n  }}\n}}"
+    ));
+    // The fold step preserves decoded output, under the count >= 0 invariant.
+    lines.push(format!(
+        "lemma {{:fuel {repeat_d}, 3}} {{:fuel {expand_d}, 2}} {flush_step}(acc: {acc_d}, c: {item_d})\n  requires 0 <= acc.{count_f}\n  ensures {inverse_d}({finish_d}({step_d}(acc, c))) == {inverse_d}({finish_d}(acc)) + [c]\n{{\n  if acc.{count_f} == 0 {{\n    {decode_append}(acc.{runs_f}, [{run_new}]);\n  }} else if acc.{current_f} == c {{\n    {decode_append}(acc.{runs_f}, [{run_cur_succ}]);\n    {decode_append}(acc.{runs_f}, [{run_cur}]);\n    {repeat_succ}(acc.{current_f}, acc.{count_f});\n  }} else {{\n    {decode_append}(acc.{runs_f} + [{run_cur}], [{run_new}]);\n  }}\n}}"
+    ));
+    // The step preserves count >= 0.
+    lines.push(format!(
+        "lemma {count_nonneg}(acc: {acc_d}, c: {item_d})\n  requires 0 <= acc.{count_f}\n  ensures 0 <= {step_d}(acc, c).{count_f}\n{{\n}}"
+    ));
+    // The synthesized invariant: generalized over acc, guarded by count >= 0.
+    lines.push(format!(
+        "lemma {{:fuel {loop_d}, 2}} {loop_gen}(xs: seq<{item_d}>, acc: {acc_d})\n  requires 0 <= acc.{count_f}\n  ensures {inverse_d}({loop_d}(xs, acc)) == {inverse_d}({finish_d}(acc)) + xs\n  decreases |xs|\n{{\n  if |xs| == 0 {{\n  }} else {{\n    assert xs == [xs[0]] + xs[1..];\n    {count_nonneg}(acc, xs[0]);\n    {loop_gen}(xs[1..], {step_d}(acc, xs[0]));\n    {flush_step}(acc, xs[0]);\n  }}\n}}"
+    ));
+    // The law, derived from the invariant at the initial accumulator.
+    lines.push(format!(
+        "lemma {{:fuel {inverse_d}, 5}} {{:fuel {wrapper_d}, 5}} {{:fuel {loop_d}, 5}} {{:fuel {expand_d}, 5}} {law_thm}(xs: seq<{item_d}>)\n  ensures {inverse_d}({wrapper_d}(xs)) == xs\n{{\n  {loop_gen}(xs, {initial_d});\n}}\n"
+    ));
+    lines.join("\n")
+}
+
 pub fn emit_verify_law(
     vb: &VerifyBlock,
     law: &VerifyLaw,
@@ -1574,6 +1698,89 @@ pub fn emit_verify_law(
             combine_op,
             &fn_name,
             &law_name,
+        );
+    }
+
+    // Accumulator-threaded encoder/inverse roundtrip — the Dafny
+    // counterpart of the Lean `accumulator_roundtrip` emit. Returns a
+    // proven support stack (no `assume {:axiom}`); the default fuel-only
+    // head/tail-induction body Dafny would otherwise emit can't bridge
+    // the threaded accumulator to the wrapper's initial seed (the IH is
+    // about a different accumulator than the recursive call produces).
+    if let Some(crate::ir::ProofStrategy::AccumulatorRoundtrip {
+        wrapper_fn,
+        loop_fn,
+        step_fn,
+        finish_fn,
+        inverse_fn,
+        expand_fn,
+        repeat_fn,
+        acc_type,
+        run_type,
+        item_type,
+        runs_field,
+        current_field,
+        count_field,
+        run_value_field,
+        initial_acc,
+    }) = vb_fn_id
+        .and_then(|fn_id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        })
+        .map(|t| t.strategy.clone())
+    {
+        return emit_accumulator_roundtrip_support_stack(
+            ctx,
+            &wrapper_fn,
+            &loop_fn,
+            &step_fn,
+            &finish_fn,
+            &inverse_fn,
+            &expand_fn,
+            &repeat_fn,
+            &acc_type,
+            &run_type,
+            &item_type,
+            &runs_field,
+            &current_field,
+            &count_field,
+            &run_value_field,
+            &initial_acc,
+            &format!("{fn_name}_{law_name}"),
+        );
+    }
+
+    // String wrapper over a proven list roundtrip: prove
+    // `decodeString(encodeString(s)) == s` by instantiating the sibling
+    // list-roundtrip lemma at `StringChars(s)` and rebuilding the string
+    // with the `StringJoinEmptyChars` prelude lemma. Mirror of the Lean
+    // `string_roundtrip_via_list` emit.
+    if let Some(crate::ir::ProofStrategy::StringRoundtripViaList {
+        string_encoder_fn,
+        string_decoder_fn,
+        list_encoder_fn,
+        list_law_name,
+    }) = vb_fn_id
+        .and_then(|fn_id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        })
+        .map(|t| t.strategy.clone())
+    {
+        let string_enc_d = aver_name_to_dafny(&string_encoder_fn);
+        let string_dec_d = aver_name_to_dafny(&string_decoder_fn);
+        let list_law_thm = format!(
+            "{}_{}",
+            aver_name_to_dafny(&list_encoder_fn),
+            aver_name_to_dafny(&list_law_name)
+        );
+        return format!(
+            "// Law: {fn_name}.{law_name} — string wrapper over the list roundtrip\nlemma {{:fuel {string_dec_d}, 5}} {{:fuel {string_enc_d}, 5}} {fn_name}_{law_name}(s: string)\n  ensures {string_dec_d}({string_enc_d}(s)) == s\n{{\n  {list_law_thm}(StringChars(s));\n  StringJoinEmptyChars(s);\n}}\n"
         );
     }
 

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -306,6 +306,63 @@ pub fn emit_verify_law_forall_auto_proof(
         return Some(proof);
     }
 
+    // Accumulator-threaded encoder/inverse roundtrip. The lowerer
+    // recognized the wrapper/loop/step/finish/inverse/repeat shape
+    // and captured the synthesized `count >= 0` invariant data.
+    if let Some(crate::ir::ProofStrategy::AccumulatorRoundtrip {
+        ref wrapper_fn,
+        ref loop_fn,
+        ref step_fn,
+        ref finish_fn,
+        ref inverse_fn,
+        ref expand_fn,
+        ref repeat_fn,
+        ref acc_type,
+        ref run_type,
+        ref item_type,
+        ref current_field,
+        ref count_field,
+        ref initial_acc,
+        ..
+    }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+        && let Some(proof) = spec::emit_accumulator_roundtrip_law(
+            vb,
+            law,
+            ctx,
+            theorem_base,
+            wrapper_fn,
+            loop_fn,
+            step_fn,
+            finish_fn,
+            inverse_fn,
+            expand_fn,
+            repeat_fn,
+            acc_type,
+            run_type,
+            item_type,
+            current_field,
+            count_field,
+            initial_acc,
+        )
+    {
+        return Some(proof);
+    }
+
+    if let Some(crate::ir::ProofStrategy::StringRoundtripViaList {
+        ref string_encoder_fn,
+        ref string_decoder_fn,
+        ref list_encoder_fn,
+        ref list_law_name,
+    }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+    {
+        return Some(spec::emit_string_roundtrip_via_list_law(
+            string_encoder_fn,
+            string_decoder_fn,
+            list_encoder_fn,
+            list_law_name,
+        ));
+    }
+
     spec::emit_spec_function_equivalence_law(vb, law, ctx, &proof_intro_names)
         .or_else(|| {
             // IR-pinned Map library axiom (has_set_self / get_set_self).

--- a/src/codegen/lean/law_auto/spec/accumulator_roundtrip.rs
+++ b/src/codegen/lean/law_auto/spec/accumulator_roundtrip.rs
@@ -1,0 +1,163 @@
+//! Lean emit for accumulator-threaded encoder/inverse roundtrips.
+//!
+//! The lowerer has already checked the RLE-like source shape:
+//! wrapper over a self-recursive loop, a step function that either
+//! starts/increments/flushes a run accumulator, a finish function, and
+//! an inverse that appends expanded runs. The proof here is the
+//! mechanical helper stack a human would write: decode distributes
+//! over append, repeat advances by one under `n >= 0`, the fold step
+//! preserves decoded output, the step preserves `count >= 0`, then the
+//! loop theorem generalizes over the accumulator.
+
+use crate::ast::{Spanned, VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+use crate::ir::hir::ResolvedExpr;
+
+use super::super::super::expr::{aver_name_to_lean, emit_expr};
+use super::super::super::types::type_annotation_to_lean;
+use super::super::AutoProof;
+
+#[allow(clippy::too_many_arguments)]
+pub(in super::super) fn emit_accumulator_roundtrip_law(
+    _vb: &VerifyBlock,
+    _law: &VerifyLaw,
+    ctx: &CodegenContext,
+    theorem_base: &str,
+    wrapper_fn: &str,
+    loop_fn: &str,
+    step_fn: &str,
+    finish_fn: &str,
+    inverse_fn: &str,
+    expand_fn: &str,
+    repeat_fn: &str,
+    acc_type: &str,
+    run_type: &str,
+    item_type: &str,
+    current_field: &str,
+    count_field: &str,
+    initial_acc: &Spanned<ResolvedExpr>,
+) -> Option<AutoProof> {
+    let wrapper_l = aver_name_to_lean(wrapper_fn);
+    let loop_l = aver_name_to_lean(loop_fn);
+    let step_l = aver_name_to_lean(step_fn);
+    let finish_l = aver_name_to_lean(finish_fn);
+    let inverse_l = aver_name_to_lean(inverse_fn);
+    let expand_l = aver_name_to_lean(expand_fn);
+    let repeat_l = aver_name_to_lean(repeat_fn);
+    let repeat_fuel_l = aver_name_to_lean(&crate::codegen::recursion::fuel_helper_name(repeat_fn));
+    let acc_ty = type_annotation_to_lean(acc_type);
+    let run_ty = type_annotation_to_lean(run_type);
+    let item_ty = type_annotation_to_lean(item_type);
+    let current_l = aver_name_to_lean(current_field);
+    let count_l = aver_name_to_lean(count_field);
+    let initial_acc_l = emit_expr(initial_acc, ctx);
+
+    let nat_abs_succ = format!("{theorem_base}_natAbs_succ");
+    let repeat_succ = format!("{theorem_base}_repeat_succ");
+    let decode_append = format!("{theorem_base}_decode_append");
+    let flush_fold_step = format!("{theorem_base}_flush_fold_step");
+    let step_count_nonneg = format!("{theorem_base}_{step_l}_count_nonneg");
+    let loop_gen = format!("{theorem_base}_{loop_l}_gen");
+
+    let support_lines = vec![
+        format!(
+            "theorem {nat_abs_succ} (n : Int) (hn : 0 <= n) :\n    Int.natAbs (n + 1) = Int.natAbs n + 1 := by"
+        ),
+        "  apply Int.ofNat_inj.mp".to_string(),
+        "  change (Int.natAbs (n + 1) : Int) = (Int.natAbs n : Int) + 1".to_string(),
+        "  rw [Int.natAbs_of_nonneg (by omega), Int.natAbs_of_nonneg hn]".to_string(),
+        String::new(),
+        format!(
+            "theorem {repeat_succ} (c : {item_ty}) (n : Int) (hn : 0 <= n) :\n    {repeat_l} c (n + 1) = {repeat_l} c n ++ [c] := by"
+        ),
+        format!("  unfold {repeat_l}"),
+        format!("  rw [{nat_abs_succ} n hn]"),
+        "  have hpos : ¬ n + 1 <= 0 := by omega".to_string(),
+        format!("  simp [{repeat_fuel_l}, hpos]"),
+        String::new(),
+        format!(
+            "theorem {decode_append} (a b : List {run_ty}) :\n    {inverse_l} (a ++ b) = {inverse_l} a ++ {inverse_l} b := by"
+        ),
+        "  induction a with".to_string(),
+        "  | nil =>".to_string(),
+        format!("      simp [{inverse_l}]"),
+        "  | cons run rest ih =>".to_string(),
+        format!("      simp [{inverse_l}, ih, List.append_assoc]"),
+        String::new(),
+        format!(
+            "theorem {flush_fold_step} (acc : {acc_ty}) (c : {item_ty}) (hcount : 0 <= acc.{count_l}) :\n    {inverse_l} ({finish_l} ({step_l} acc c)) = {inverse_l} ({finish_l} acc) ++ [c] := by"
+        ),
+        format!("  by_cases hzero : acc.{count_l} = 0"),
+        format!(
+            "  · simp [{step_l}, {finish_l}, hzero, {decode_append}, {inverse_l}, {expand_l}, {repeat_l}, {repeat_fuel_l}]"
+        ),
+        format!("  · by_cases hsame : acc.{current_l} = c"),
+        format!("    · have hsucc_ne : acc.{count_l} + 1 ≠ 0 := by omega"),
+        format!(
+            "      simp [{step_l}, {finish_l}, hzero, hsame, hsucc_ne, {decode_append}, {inverse_l}, {expand_l}, {repeat_succ}, hcount, List.append_assoc]"
+        ),
+        format!(
+            "    · simp [{step_l}, {finish_l}, hzero, hsame, {decode_append}, {inverse_l}, {expand_l}, {repeat_l}, {repeat_fuel_l}, List.append_assoc]"
+        ),
+        String::new(),
+        format!(
+            "theorem {step_count_nonneg} (acc : {acc_ty}) (c : {item_ty}) (hcount : 0 <= acc.{count_l}) :\n    0 <= ({step_l} acc c).{count_l} := by"
+        ),
+        format!("  by_cases hzero : acc.{count_l} = 0"),
+        format!("  · simp [{step_l}, hzero]"),
+        format!("  · by_cases hsame : acc.{current_l} = c"),
+        format!("    · simp [{step_l}, hzero, hsame]"),
+        "      omega".to_string(),
+        format!("    · simp [{step_l}, hzero, hsame]"),
+        String::new(),
+        format!(
+            "theorem {loop_gen} (xs : List {item_ty}) (acc : {acc_ty}) (hcount : 0 <= acc.{count_l}) :\n    {inverse_l} ({loop_l} xs acc) = {inverse_l} ({finish_l} acc) ++ xs := by"
+        ),
+        "  induction xs generalizing acc with".to_string(),
+        "  | nil =>".to_string(),
+        format!("      simp [{loop_l}]"),
+        "  | cons char rest ih =>".to_string(),
+        format!("      simp [{loop_l}]"),
+        format!("      rw [ih ({step_l} acc char) ({step_count_nonneg} acc char hcount)]"),
+        format!("      rw [{flush_fold_step} acc char hcount]"),
+        "      simp [List.append_assoc]".to_string(),
+    ];
+
+    let proof_lines = vec![
+        "  intro xs".to_string(),
+        format!("  simp [{wrapper_l}]"),
+        format!("  simpa [{finish_l}, {inverse_l}] using {loop_gen} xs {initial_acc_l} (by simp)"),
+    ];
+
+    Some(AutoProof {
+        support_lines,
+        proof_lines,
+        replaces_theorem: false,
+    })
+}
+
+pub(in super::super) fn emit_string_roundtrip_via_list_law(
+    string_encoder_fn: &str,
+    string_decoder_fn: &str,
+    list_encoder_fn: &str,
+    list_law_name: &str,
+) -> AutoProof {
+    let string_encoder_l = aver_name_to_lean(string_encoder_fn);
+    let string_decoder_l = aver_name_to_lean(string_decoder_fn);
+    let list_theorem = format!(
+        "{}_law_{}",
+        aver_name_to_lean(list_encoder_fn),
+        aver_name_to_lean(list_law_name)
+    );
+
+    AutoProof {
+        support_lines: Vec::new(),
+        proof_lines: vec![
+            "  intro s".to_string(),
+            format!(
+                "  simp [{string_decoder_l}, {string_encoder_l}, {list_theorem}, String.intercalate_empty_chars]"
+            ),
+        ],
+        replaces_theorem: false,
+    }
+}

--- a/src/codegen/lean/law_auto/spec/mod.rs
+++ b/src/codegen/lean/law_auto/spec/mod.rs
@@ -1,3 +1,4 @@
+mod accumulator_roundtrip;
 mod linear_int;
 mod linear_recurrence2;
 mod match_dispatcher_fold;
@@ -5,6 +6,9 @@ mod result_pipeline_chain;
 mod simp_normalized;
 mod wrapper_over_recursion;
 
+pub(super) use accumulator_roundtrip::{
+    emit_accumulator_roundtrip_law, emit_string_roundtrip_via_list_law,
+};
 pub(super) use linear_recurrence2::emit_second_order_linear_recurrence_spec_equivalence_law;
 pub(super) use match_dispatcher_fold::emit_match_dispatcher_fold_law;
 pub(super) use result_pipeline_chain::emit_result_pipeline_chain_law;

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -4421,9 +4421,14 @@ fn echoConn(conn: Tcp.Connection) -> Tcp.Connection
         let lean = generated_lean_file(&out);
 
         assert!(
-            lean.contains("sorry"),
-            "expected rle proof export to contain sorry for unproved universal theorems"
+            !lean.contains("sorry"),
+            "expected rle proof export to prove roundtrip laws, got:\n{}",
+            lean
         );
+        assert!(lean.contains("theorem encode_law_roundtrip_encodeLoop_gen"));
+        assert!(lean.contains(
+            "simp [decodeString, encodeString, encode_law_roundtrip, String.intercalate_empty_chars]"
+        ));
         assert!(lean.contains(
             "theorem encode_law_roundtrip_sample_1 : decode (encode []) = [] := by native_decide"
         ));

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -2074,9 +2074,17 @@ fn emit_verify_law_block(
                 "theorem {} : ∀ {}, {} := by",
                 theorem_base, quant_params, theorem_prop
             ));
-            lines.push(
-                "  -- verify law is sampled; universal proof must be provided manually".to_string(),
-            );
+            if law_mentions_recursive_fn(vb, law, ctx) {
+                lines.push(
+                    "  -- can't auto-prove this recursive law yet; provide a direct-recurrence spec function and an equivalence law"
+                        .to_string(),
+                );
+            } else {
+                lines.push(
+                    "  -- verify law is sampled; universal proof must be provided manually"
+                        .to_string(),
+                );
+            }
             lines.push("  sorry".to_string());
         }
     }
@@ -2218,6 +2226,75 @@ fn emit_verify_law_block(
         }
     }
     (lines.join("\n"), case_index_start + vb.cases.len())
+}
+
+fn law_mentions_recursive_fn(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenContext) -> bool {
+    fn name_is_recursive(name: &str, ctx: &CodegenContext) -> bool {
+        let bare = name.rsplit('.').next().unwrap_or(name);
+        ctx.symbol_table
+            .fn_id_of(&crate::ir::FnKey::entry(bare))
+            .is_some_and(|id| ctx.recursive_fns.contains(&id))
+    }
+
+    fn expr_mentions_recursive(expr: &Spanned<Expr>, ctx: &CodegenContext) -> bool {
+        match &expr.node {
+            Expr::FnCall(callee, args) => {
+                let callee_recursive = crate::codegen::common::expr_to_dotted_name(&callee.node)
+                    .is_some_and(|name| name_is_recursive(&name, ctx));
+                callee_recursive || args.iter().any(|arg| expr_mentions_recursive(arg, ctx))
+            }
+            Expr::Attr(base, _) => expr_mentions_recursive(base, ctx),
+            Expr::BinOp(_, left, right) => {
+                expr_mentions_recursive(left, ctx) || expr_mentions_recursive(right, ctx)
+            }
+            Expr::Neg(inner) | Expr::Constructor(_, Some(inner)) | Expr::ErrorProp(inner) => {
+                expr_mentions_recursive(inner, ctx)
+            }
+            Expr::Match { subject, arms } => {
+                expr_mentions_recursive(subject, ctx)
+                    || arms
+                        .iter()
+                        .any(|arm| expr_mentions_recursive(&arm.body, ctx))
+            }
+            Expr::InterpolatedStr(parts) => parts.iter().any(|part| {
+                matches!(part, StrPart::Parsed(inner) if expr_mentions_recursive(inner, ctx))
+            }),
+            Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+                items.iter().any(|item| expr_mentions_recursive(item, ctx))
+            }
+            Expr::MapLiteral(entries) => entries.iter().any(|(key, value)| {
+                expr_mentions_recursive(key, ctx) || expr_mentions_recursive(value, ctx)
+            }),
+            Expr::RecordCreate { fields, .. } => fields
+                .iter()
+                .any(|(_, value)| expr_mentions_recursive(value, ctx)),
+            Expr::RecordUpdate { base, updates, .. } => {
+                expr_mentions_recursive(base, ctx)
+                    || updates
+                        .iter()
+                        .any(|(_, value)| expr_mentions_recursive(value, ctx))
+            }
+            Expr::TailCall(call) => {
+                name_is_recursive(&call.target, ctx)
+                    || call
+                        .args
+                        .iter()
+                        .any(|arg| expr_mentions_recursive(arg, ctx))
+            }
+            Expr::Constructor(_, None)
+            | Expr::Literal(_)
+            | Expr::Ident(_)
+            | Expr::Resolved { .. } => false,
+        }
+    }
+
+    name_is_recursive(&vb.fn_name, ctx)
+        || expr_mentions_recursive(&law.lhs, ctx)
+        || expr_mentions_recursive(&law.rhs, ctx)
+        || law
+            .when
+            .as_ref()
+            .is_some_and(|when| expr_mentions_recursive(when, ctx))
 }
 
 fn law_theorem_prop(

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -911,6 +911,24 @@ fn classify_law_strategy(
     {
         return s;
     }
+    // Accumulator-threaded encoder/inverse roundtrips (RLE shape).
+    // Runs before generic list induction because the useful IH must
+    // quantify over the threaded accumulator plus its synthesized
+    // well-formedness predicate.
+    if law.when.is_none()
+        && let Some(s) = detect_accumulator_roundtrip(law, fn_name, inputs, scope)
+    {
+        return s;
+    }
+    // String wrappers over the proven list roundtrip: once
+    // `decode(encode(xs)) = xs` is pinned as an accumulator
+    // roundtrip, `decodeString(encodeString(s)) = s` follows from
+    // the generated prelude's String.intercalate/children lemma.
+    if law.when.is_none()
+        && let Some(s) = detect_string_roundtrip_via_list(law, fn_name, inputs)
+    {
+        return s;
+    }
     // Structural induction runs first — when any given binds a
     // recursive ADT, induction over its variants is the canonical
     // proof. Reflexive could also fire on `f(t) = f(t)` for `t: Tree`
@@ -2956,6 +2974,708 @@ fn detect_wrapper_over_recursion(
         other_fn,
         combine_op,
     })
+}
+
+#[derive(Debug, Clone)]
+struct AccumulatorRoundtripPlan {
+    wrapper_fn: String,
+    loop_fn: String,
+    step_fn: String,
+    finish_fn: String,
+    inverse_fn: String,
+    expand_fn: String,
+    repeat_fn: String,
+    acc_type: String,
+    run_type: String,
+    item_type: String,
+    runs_field: String,
+    current_field: String,
+    count_field: String,
+    run_value_field: String,
+    initial_acc: Spanned<crate::ast::Expr>,
+}
+
+/// **syntax-discovery-only** (epic #170 Phase 7). Recognize the
+/// accumulator-threaded encoder/inverse roundtrip shape that needs
+/// an accumulator-generalized invariant instead of plain list
+/// induction. Conservative by design: the emitted helper stack is
+/// specialized to the RLE-like record layout and repeat-by-count
+/// inverse, so every source branch is checked before pinning.
+fn detect_accumulator_roundtrip(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+    scope: Option<&str>,
+) -> Option<crate::ir::ProofStrategy> {
+    let plan = detect_accumulator_roundtrip_plan(law, fn_name, inputs)?;
+    Some(crate::ir::ProofStrategy::AccumulatorRoundtrip {
+        wrapper_fn: plan.wrapper_fn,
+        loop_fn: plan.loop_fn,
+        step_fn: plan.step_fn,
+        finish_fn: plan.finish_fn,
+        inverse_fn: plan.inverse_fn,
+        expand_fn: plan.expand_fn,
+        repeat_fn: plan.repeat_fn,
+        acc_type: plan.acc_type,
+        run_type: plan.run_type,
+        item_type: plan.item_type,
+        runs_field: plan.runs_field,
+        current_field: plan.current_field,
+        count_field: plan.count_field,
+        run_value_field: plan.run_value_field,
+        initial_acc: inputs.resolve_expr(&plan.initial_acc, scope),
+    })
+}
+
+fn detect_accumulator_roundtrip_plan(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<AccumulatorRoundtripPlan> {
+    use crate::ast::{Expr, Literal};
+
+    if law.givens.len() != 1 {
+        return None;
+    }
+    let given = &law.givens[0];
+    let item_type = list_type_arg(&given.type_name)?.to_string();
+
+    let (inverse_fn, wrapper_arg_on_lhs) =
+        extract_inverse_wrapper_call(&law.lhs, fn_name, &given.name)
+            .map(|inverse| (inverse, true))
+            .or_else(|| {
+                extract_inverse_wrapper_call(&law.rhs, fn_name, &given.name)
+                    .map(|inverse| (inverse, false))
+            })?;
+    let other_side = if wrapper_arg_on_lhs {
+        &law.rhs
+    } else {
+        &law.lhs
+    };
+    if !matches_ident_expr(other_side, &given.name) {
+        return None;
+    }
+
+    let wrapper_fd = inputs.find_fn_def_by_call_name(fn_name)?;
+    if wrapper_fd.params.len() != 1 || wrapper_fd.params[0].1 != given.type_name {
+        return None;
+    }
+    let wrapper_param = wrapper_fd.params[0].0.as_str();
+    let wrapper_body = body_terminal_expr(&wrapper_fd.body)?;
+    let (loop_fn, wrapper_args) = fn_call_name_args(wrapper_body)?;
+    if wrapper_args.len() != 2 || !matches_ident_expr(&wrapper_args[0], wrapper_param) {
+        return None;
+    }
+    let initial_acc = wrapper_args[1].clone();
+    let Expr::RecordCreate {
+        type_name: acc_type,
+        fields: initial_fields,
+    } = &initial_acc.node
+    else {
+        return None;
+    };
+    let (_, initial_count) = initial_fields.iter().find(|(name, _)| name == "count")?;
+    if !matches!(&initial_count.node, Expr::Literal(Literal::Int(0))) {
+        return None;
+    }
+
+    let loop_fd = inputs.find_fn_def_by_call_name(&loop_fn)?;
+    if loop_fd.params.len() != 2
+        || loop_fd.params[0].1 != given.type_name
+        || loop_fd.params[1].1 != *acc_type
+    {
+        return None;
+    }
+    let chars_param = loop_fd.params[0].0.as_str();
+    let acc_param = loop_fd.params[1].0.as_str();
+    let loop_body = body_terminal_expr(&loop_fd.body)?;
+    let (nil_body, head_name, tail_name, cons_body) = list_match_arms(loop_body, chars_param)?;
+    let (finish_fn, finish_args) = fn_call_name_args(nil_body)?;
+    if finish_args.len() != 1 || !matches_ident_expr(&finish_args[0], acc_param) {
+        return None;
+    }
+    let (recursive_name, recursive_args) = call_or_tail_name_args(cons_body)?;
+    if recursive_name != loop_fn
+        || recursive_args.len() != 2
+        || !matches_ident_expr(&recursive_args[0], &tail_name)
+    {
+        return None;
+    }
+    let (step_fn, step_args) = fn_call_name_args(&recursive_args[1])?;
+    if step_args.len() != 2
+        || !matches_ident_expr(&step_args[0], acc_param)
+        || !matches_ident_expr(&step_args[1], &head_name)
+    {
+        return None;
+    }
+
+    let finish_fd = inputs.find_fn_def_by_call_name(&finish_fn)?;
+    if finish_fd.params.len() != 1 || finish_fd.params[0].1 != *acc_type {
+        return None;
+    }
+    let finish_acc = finish_fd.params[0].0.as_str();
+    let finish_shape =
+        detect_finish_acc_shape(body_terminal_expr(&finish_fd.body)?, finish_acc, acc_type)?;
+
+    let inverse_fd = inputs.find_fn_def_by_call_name(&inverse_fn)?;
+    if inverse_fd.params.len() != 1 {
+        return None;
+    }
+    let inverse_runs = inverse_fd.params[0].0.as_str();
+    let (expand_fn, run_param) = detect_inverse_decode_shape(
+        body_terminal_expr(&inverse_fd.body)?,
+        inverse_runs,
+        &inverse_fn,
+    )?;
+
+    let expand_fd = inputs.find_fn_def_by_call_name(&expand_fn)?;
+    if expand_fd.params.len() != 1 || expand_fd.params[0].1 != finish_shape.run_type {
+        return None;
+    }
+    let expand_run = expand_fd.params[0].0.as_str();
+    let repeat_fn = detect_expand_repeat_shape(
+        body_terminal_expr(&expand_fd.body)?,
+        expand_run,
+        &finish_shape.run_value_field,
+        &finish_shape.count_field,
+    )?;
+
+    let repeat_fd = inputs.find_fn_def_by_call_name(&repeat_fn)?;
+    if !repeat_matches_counted_append(repeat_fd, &item_type) {
+        return None;
+    }
+
+    let step_fd = inputs.find_fn_def_by_call_name(&step_fn)?;
+    if step_fd.params.len() != 2
+        || step_fd.params[0].1 != *acc_type
+        || step_fd.params[1].1 != item_type
+    {
+        return None;
+    }
+    let step_acc = step_fd.params[0].0.as_str();
+    let step_item = step_fd.params[1].0.as_str();
+    if !step_matches_rle_fold(
+        body_terminal_expr(&step_fd.body)?,
+        step_acc,
+        step_item,
+        acc_type,
+        &finish_shape,
+    ) {
+        return None;
+    }
+
+    let _ = run_param;
+
+    Some(AccumulatorRoundtripPlan {
+        wrapper_fn: fn_name.to_string(),
+        loop_fn,
+        step_fn,
+        finish_fn,
+        inverse_fn,
+        expand_fn,
+        repeat_fn,
+        acc_type: acc_type.clone(),
+        run_type: finish_shape.run_type,
+        item_type,
+        runs_field: finish_shape.runs_field,
+        current_field: finish_shape.current_field,
+        count_field: finish_shape.count_field,
+        run_value_field: finish_shape.run_value_field,
+        initial_acc,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct FinishAccShape {
+    run_type: String,
+    runs_field: String,
+    current_field: String,
+    count_field: String,
+    run_value_field: String,
+}
+
+fn detect_string_roundtrip_via_list(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+) -> Option<crate::ir::ProofStrategy> {
+    use crate::ast::{Expr, Literal, TopLevel, VerifyKind};
+
+    if law.givens.len() != 1 || law.givens[0].type_name != "String" {
+        return None;
+    }
+    let given_name = &law.givens[0].name;
+    let (string_decoder_fn, on_lhs) = extract_inverse_wrapper_call(&law.lhs, fn_name, given_name)
+        .map(|inverse| (inverse, true))
+        .or_else(|| {
+            extract_inverse_wrapper_call(&law.rhs, fn_name, given_name)
+                .map(|inverse| (inverse, false))
+        })?;
+    let other_side = if on_lhs { &law.rhs } else { &law.lhs };
+    if !matches_ident_expr(other_side, given_name) {
+        return None;
+    }
+
+    let encoder_fd = inputs.find_fn_def_by_call_name(fn_name)?;
+    if encoder_fd.params.len() != 1 || encoder_fd.params[0].1 != "String" {
+        return None;
+    }
+    let encoder_param = encoder_fd.params[0].0.as_str();
+    let (list_encoder_fn, encoder_args) = fn_call_name_args(body_terminal_expr(&encoder_fd.body)?)?;
+    if encoder_args.len() != 1 {
+        return None;
+    }
+    let chars_args = call_named_args(&encoder_args[0], "String.chars")?;
+    if chars_args.len() != 1 || !matches_ident_expr(&chars_args[0], encoder_param) {
+        return None;
+    }
+
+    let decoder_fd = inputs.find_fn_def_by_call_name(&string_decoder_fn)?;
+    if decoder_fd.params.len() != 1 {
+        return None;
+    }
+    let decoder_param = decoder_fd.params[0].0.as_str();
+    let join_args = call_named_args(body_terminal_expr(&decoder_fd.body)?, "String.join")?;
+    if join_args.len() != 2
+        || !matches!(&join_args[1].node, Expr::Literal(Literal::Str(s)) if s.is_empty())
+    {
+        return None;
+    }
+    let (list_decoder_fn, list_decoder_args) = fn_call_name_args(&join_args[0])?;
+    if list_decoder_args.len() != 1 || !matches_ident_expr(&list_decoder_args[0], decoder_param) {
+        return None;
+    }
+
+    let list_law_name = inputs.entry_items.iter().find_map(|item| {
+        let TopLevel::Verify(vb) = item else {
+            return None;
+        };
+        if vb.fn_name != list_encoder_fn {
+            return None;
+        }
+        let VerifyKind::Law(candidate) = &vb.kind else {
+            return None;
+        };
+        let plan = detect_accumulator_roundtrip_plan(candidate, &list_encoder_fn, inputs)?;
+        (plan.inverse_fn == list_decoder_fn).then(|| candidate.name.clone())
+    })?;
+
+    Some(crate::ir::ProofStrategy::StringRoundtripViaList {
+        string_encoder_fn: fn_name.to_string(),
+        string_decoder_fn,
+        list_encoder_fn,
+        list_law_name,
+    })
+}
+
+fn list_type_arg(type_name: &str) -> Option<&str> {
+    type_name
+        .trim()
+        .strip_prefix("List<")
+        .and_then(|rest| rest.strip_suffix('>'))
+        .map(str::trim)
+}
+
+fn fn_call_name_args(
+    expr: &Spanned<crate::ast::Expr>,
+) -> Option<(String, &[Spanned<crate::ast::Expr>])> {
+    use crate::ast::Expr;
+    let Expr::FnCall(callee, args) = &expr.node else {
+        return None;
+    };
+    Some((expr_to_dotted_name(&callee.node)?, args.as_slice()))
+}
+
+fn call_or_tail_name_args(
+    expr: &Spanned<crate::ast::Expr>,
+) -> Option<(String, Vec<Spanned<crate::ast::Expr>>)> {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::FnCall(callee, args) => Some((expr_to_dotted_name(&callee.node)?, args.clone())),
+        Expr::TailCall(td) => Some((td.target.clone(), td.args.clone())),
+        _ => None,
+    }
+}
+
+fn extract_inverse_wrapper_call(
+    expr: &Spanned<crate::ast::Expr>,
+    wrapper_fn: &str,
+    arg_name: &str,
+) -> Option<String> {
+    let (inverse_fn, inverse_args) = fn_call_name_args(expr)?;
+    if inverse_args.len() != 1 {
+        return None;
+    }
+    let (inner_fn, inner_args) = fn_call_name_args(&inverse_args[0])?;
+    if inner_fn != wrapper_fn
+        || inner_args.len() != 1
+        || !matches_ident_expr(&inner_args[0], arg_name)
+    {
+        return None;
+    }
+    Some(inverse_fn)
+}
+
+fn list_match_arms<'a>(
+    expr: &'a Spanned<crate::ast::Expr>,
+    subject_name: &str,
+) -> Option<(
+    &'a Spanned<crate::ast::Expr>,
+    String,
+    String,
+    &'a Spanned<crate::ast::Expr>,
+)> {
+    use crate::ast::{Expr, Pattern};
+    let Expr::Match { subject, arms } = &expr.node else {
+        return None;
+    };
+    if !matches_ident_expr(subject, subject_name) || arms.len() != 2 {
+        return None;
+    }
+    let mut nil_body = None;
+    let mut cons = None;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::EmptyList => nil_body = Some(arm.body.as_ref()),
+            Pattern::Cons(head, tail) => {
+                cons = Some((head.clone(), tail.clone(), arm.body.as_ref()));
+            }
+            _ => return None,
+        }
+    }
+    let (head, tail, cons_body) = cons?;
+    Some((nil_body?, head, tail, cons_body))
+}
+
+fn bool_match_arms(
+    expr: &Spanned<crate::ast::Expr>,
+) -> Option<(
+    &Spanned<crate::ast::Expr>,
+    &Spanned<crate::ast::Expr>,
+    &Spanned<crate::ast::Expr>,
+)> {
+    use crate::ast::{Expr, Literal, Pattern};
+    let Expr::Match { subject, arms } = &expr.node else {
+        return None;
+    };
+    if arms.len() != 2 {
+        return None;
+    }
+    let mut true_body = None;
+    let mut false_body = None;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::Literal(Literal::Bool(true)) => true_body = Some(arm.body.as_ref()),
+            Pattern::Literal(Literal::Bool(false)) => false_body = Some(arm.body.as_ref()),
+            _ => return None,
+        }
+    }
+    Some((subject.as_ref(), true_body?, false_body?))
+}
+
+fn attr_field_of_ident<'a>(
+    expr: &'a Spanned<crate::ast::Expr>,
+    base_name: &str,
+) -> Option<&'a str> {
+    use crate::ast::Expr;
+    let Expr::Attr(base, field) = &expr.node else {
+        return None;
+    };
+    matches_ident_expr(base, base_name).then_some(field.as_str())
+}
+
+fn is_attr_of_ident(expr: &Spanned<crate::ast::Expr>, base_name: &str, field_name: &str) -> bool {
+    attr_field_of_ident(expr, base_name) == Some(field_name)
+}
+
+fn is_eq_attr_int_zero(expr: &Spanned<crate::ast::Expr>, base_name: &str) -> Option<String> {
+    use crate::ast::{BinOp, Expr, Literal};
+    let Expr::BinOp(BinOp::Eq, left, right) = &expr.node else {
+        return None;
+    };
+    if !matches!(&right.node, Expr::Literal(Literal::Int(0))) {
+        return None;
+    }
+    attr_field_of_ident(left, base_name).map(str::to_string)
+}
+
+fn is_eq_attr_ident(
+    expr: &Spanned<crate::ast::Expr>,
+    base_name: &str,
+    field_name: &str,
+    ident_name: &str,
+) -> bool {
+    use crate::ast::{BinOp, Expr};
+    let Expr::BinOp(BinOp::Eq, left, right) = &expr.node else {
+        return false;
+    };
+    is_attr_of_ident(left, base_name, field_name) && matches_ident_expr(right, ident_name)
+}
+
+fn detect_finish_acc_shape(
+    expr: &Spanned<crate::ast::Expr>,
+    acc_param: &str,
+    acc_type: &str,
+) -> Option<FinishAccShape> {
+    let (subject, true_body, false_body) = bool_match_arms(expr)?;
+    let count_field = is_eq_attr_int_zero(subject, acc_param)?;
+    let runs_field = attr_field_of_ident(true_body, acc_param)?.to_string();
+    let concat_args = call_named_args(false_body, "List.concat")?;
+    if concat_args.len() != 2 || !is_attr_of_ident(&concat_args[0], acc_param, &runs_field) {
+        return None;
+    }
+    let (run_type, run_fields) = singleton_record_list(&concat_args[1])?;
+    let run_value_field = run_fields.iter().find_map(|(name, value)| {
+        attr_field_of_ident(value, acc_param)
+            .filter(|field| *field != count_field && *field != runs_field)
+            .map(|_| name.clone())
+    })?;
+    let current_value = field_expr(&run_fields, &run_value_field)?;
+    let current_field = attr_field_of_ident(current_value, acc_param)?.to_string();
+    let count_ok = run_fields.iter().any(|(name, value)| {
+        name == &count_field && is_attr_of_ident(value, acc_param, &count_field)
+    });
+    if !count_ok {
+        return None;
+    }
+    let _ = acc_type;
+    Some(FinishAccShape {
+        run_type,
+        runs_field,
+        current_field,
+        count_field,
+        run_value_field,
+    })
+}
+
+type RecordFieldList = Vec<(String, Spanned<crate::ast::Expr>)>;
+
+fn singleton_record_list(expr: &Spanned<crate::ast::Expr>) -> Option<(String, RecordFieldList)> {
+    use crate::ast::Expr;
+    let Expr::List(items) = &expr.node else {
+        return None;
+    };
+    let [item] = items.as_slice() else {
+        return None;
+    };
+    let Expr::RecordCreate { type_name, fields } = &item.node else {
+        return None;
+    };
+    Some((type_name.clone(), fields.clone()))
+}
+
+fn detect_inverse_decode_shape(
+    expr: &Spanned<crate::ast::Expr>,
+    runs_param: &str,
+    inverse_fn: &str,
+) -> Option<(String, String)> {
+    use crate::ast::Expr;
+    let (nil_body, run_name, rest_name, cons_body) = list_match_arms(expr, runs_param)?;
+    if !matches!(&nil_body.node, Expr::List(items) if items.is_empty()) {
+        return None;
+    }
+    let concat_args = call_named_args(cons_body, "List.concat")?;
+    if concat_args.len() != 2 {
+        return None;
+    }
+    let (expand_fn, expand_args) = fn_call_name_args(&concat_args[0])?;
+    if expand_args.len() != 1 || !matches_ident_expr(&expand_args[0], &run_name) {
+        return None;
+    }
+    let (recursive_inverse, recursive_args) = fn_call_name_args(&concat_args[1])?;
+    if recursive_inverse != inverse_fn
+        || recursive_args.len() != 1
+        || !matches_ident_expr(&recursive_args[0], &rest_name)
+    {
+        return None;
+    }
+    Some((expand_fn, run_name))
+}
+
+fn detect_expand_repeat_shape(
+    expr: &Spanned<crate::ast::Expr>,
+    run_param: &str,
+    run_value_field: &str,
+    count_field: &str,
+) -> Option<String> {
+    let (repeat_fn, args) = fn_call_name_args(expr)?;
+    if args.len() != 2
+        || !is_attr_of_ident(&args[0], run_param, run_value_field)
+        || !is_attr_of_ident(&args[1], run_param, count_field)
+    {
+        return None;
+    }
+    Some(repeat_fn)
+}
+
+fn repeat_matches_counted_append(fd: &crate::ast::FnDef, item_type: &str) -> bool {
+    use crate::ast::{BinOp, Expr, Literal};
+    if fd.params.len() != 2 || fd.params[0].1 != item_type || fd.params[1].1 != "Int" {
+        return false;
+    }
+    let item_param = fd.params[0].0.as_str();
+    let count_param = fd.params[1].0.as_str();
+    let Some((subject, true_body, false_body)) =
+        body_terminal_expr(&fd.body).and_then(bool_match_arms)
+    else {
+        return false;
+    };
+    let Expr::BinOp(BinOp::Lte, left, right) = &subject.node else {
+        return false;
+    };
+    if !matches_ident_expr(left, count_param)
+        || !matches!(&right.node, Expr::Literal(Literal::Int(0)))
+        || !matches!(&true_body.node, Expr::List(items) if items.is_empty())
+    {
+        return false;
+    }
+    let Some(concat_args) = call_named_args(false_body, "List.concat") else {
+        return false;
+    };
+    if concat_args.len() != 2 {
+        return false;
+    }
+    let Some((recursive_fn, recursive_args)) = fn_call_name_args(&concat_args[0]) else {
+        return false;
+    };
+    if recursive_fn != fd.name || recursive_args.len() != 2 {
+        return false;
+    }
+    let Expr::BinOp(BinOp::Sub, n_left, n_right) = &recursive_args[1].node else {
+        return false;
+    };
+    matches_ident_expr(&recursive_args[0], item_param)
+        && matches_ident_expr(n_left, count_param)
+        && matches!(&n_right.node, Expr::Literal(Literal::Int(1)))
+        && matches!(&concat_args[1].node, Expr::List(items)
+            if items.len() == 1 && matches_ident_expr(&items[0], item_param))
+}
+
+fn step_matches_rle_fold(
+    expr: &Spanned<crate::ast::Expr>,
+    acc_param: &str,
+    item_param: &str,
+    acc_type: &str,
+    finish: &FinishAccShape,
+) -> bool {
+    let Some((subject, zero_body, nonzero_body)) = bool_match_arms(expr) else {
+        return false;
+    };
+    if is_eq_attr_int_zero(subject, acc_param).as_deref() != Some(finish.count_field.as_str()) {
+        return false;
+    }
+    if !record_is_acc_zero_start(zero_body, acc_param, item_param, acc_type, finish) {
+        return false;
+    }
+    let Some((same_subject, same_body, different_body)) = bool_match_arms(nonzero_body) else {
+        return false;
+    };
+    is_eq_attr_ident(same_subject, acc_param, &finish.current_field, item_param)
+        && record_is_acc_same_run(same_body, acc_param, acc_type, finish)
+        && record_is_acc_new_run(different_body, acc_param, item_param, acc_type, finish)
+}
+
+fn record_fields_if_type<'a>(
+    expr: &'a Spanned<crate::ast::Expr>,
+    type_name: &str,
+) -> Option<&'a [(String, Spanned<crate::ast::Expr>)]> {
+    use crate::ast::Expr;
+    let Expr::RecordCreate {
+        type_name: actual,
+        fields,
+    } = &expr.node
+    else {
+        return None;
+    };
+    (actual == type_name).then_some(fields.as_slice())
+}
+
+fn field_expr<'a>(
+    fields: &'a [(String, Spanned<crate::ast::Expr>)],
+    field_name: &str,
+) -> Option<&'a Spanned<crate::ast::Expr>> {
+    fields
+        .iter()
+        .find_map(|(name, value)| (name == field_name).then_some(value))
+}
+
+fn record_is_acc_zero_start(
+    expr: &Spanned<crate::ast::Expr>,
+    acc_param: &str,
+    item_param: &str,
+    acc_type: &str,
+    finish: &FinishAccShape,
+) -> bool {
+    use crate::ast::{Expr, Literal};
+    let Some(fields) = record_fields_if_type(expr, acc_type) else {
+        return false;
+    };
+    field_expr(fields, &finish.runs_field)
+        .is_some_and(|v| is_attr_of_ident(v, acc_param, &finish.runs_field))
+        && field_expr(fields, &finish.current_field)
+            .is_some_and(|v| matches_ident_expr(v, item_param))
+        && field_expr(fields, &finish.count_field)
+            .is_some_and(|v| matches!(&v.node, Expr::Literal(Literal::Int(1))))
+}
+
+fn record_is_acc_same_run(
+    expr: &Spanned<crate::ast::Expr>,
+    acc_param: &str,
+    acc_type: &str,
+    finish: &FinishAccShape,
+) -> bool {
+    use crate::ast::{BinOp, Expr, Literal};
+    let Some(fields) = record_fields_if_type(expr, acc_type) else {
+        return false;
+    };
+    let count_inc = field_expr(fields, &finish.count_field).is_some_and(|v| {
+        let Expr::BinOp(BinOp::Add, left, right) = &v.node else {
+            return false;
+        };
+        is_attr_of_ident(left, acc_param, &finish.count_field)
+            && matches!(&right.node, Expr::Literal(Literal::Int(1)))
+    });
+    field_expr(fields, &finish.runs_field)
+        .is_some_and(|v| is_attr_of_ident(v, acc_param, &finish.runs_field))
+        && field_expr(fields, &finish.current_field)
+            .is_some_and(|v| is_attr_of_ident(v, acc_param, &finish.current_field))
+        && count_inc
+}
+
+fn record_is_acc_new_run(
+    expr: &Spanned<crate::ast::Expr>,
+    acc_param: &str,
+    item_param: &str,
+    acc_type: &str,
+    finish: &FinishAccShape,
+) -> bool {
+    use crate::ast::{Expr, Literal};
+    let Some(fields) = record_fields_if_type(expr, acc_type) else {
+        return false;
+    };
+    let runs_ok = field_expr(fields, &finish.runs_field).is_some_and(|v| {
+        let Some(concat_args) = call_named_args(v, "List.concat") else {
+            return false;
+        };
+        if concat_args.len() != 2
+            || !is_attr_of_ident(&concat_args[0], acc_param, &finish.runs_field)
+        {
+            return false;
+        }
+        let Some((run_type, run_fields)) = singleton_record_list(&concat_args[1]) else {
+            return false;
+        };
+        run_type == finish.run_type
+            && field_expr(&run_fields, &finish.run_value_field)
+                .is_some_and(|rv| is_attr_of_ident(rv, acc_param, &finish.current_field))
+            && field_expr(&run_fields, &finish.count_field)
+                .is_some_and(|rv| is_attr_of_ident(rv, acc_param, &finish.count_field))
+    });
+    runs_ok
+        && field_expr(fields, &finish.current_field)
+            .is_some_and(|v| matches_ident_expr(v, item_param))
+        && field_expr(fields, &finish.count_field)
+            .is_some_and(|v| matches!(&v.node, Expr::Literal(Literal::Int(1))))
 }
 
 fn detect_induction_target(

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -3074,10 +3074,6 @@ fn detect_accumulator_roundtrip_plan(
     else {
         return None;
     };
-    let (_, initial_count) = initial_fields.iter().find(|(name, _)| name == "count")?;
-    if !matches!(&initial_count.node, Expr::Literal(Literal::Int(0))) {
-        return None;
-    }
 
     let loop_fd = inputs.find_fn_def_by_call_name(&loop_fn)?;
     if loop_fd.params.len() != 2
@@ -3116,6 +3112,19 @@ fn detect_accumulator_roundtrip_plan(
     let finish_acc = finish_fd.params[0].0.as_str();
     let finish_shape =
         detect_finish_acc_shape(body_terminal_expr(&finish_fd.body)?, finish_acc, acc_type)?;
+
+    // The initial accumulator's count field must be zero — the base of
+    // the `count >= 0` invariant and what makes `finish(initial)` reduce
+    // to the empty run list. The count field is identified by its
+    // structural role (the field `step` tests against 0 and `finish`
+    // re-emits), discovered in `finish_shape`, not by a hard-coded name —
+    // so the recognizer fires regardless of what the field is called.
+    let initial_count = initial_fields
+        .iter()
+        .find_map(|(name, value)| (*name == finish_shape.count_field).then_some(value))?;
+    if !matches!(&initial_count.node, Expr::Literal(Literal::Int(0))) {
+        return None;
+    }
 
     let inverse_fd = inputs.find_fn_def_by_call_name(&inverse_fn)?;
     if inverse_fd.params.len() != 1 {

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -690,6 +690,43 @@ pub enum ProofStrategy {
         /// (`Add` / `Mul` / `Sub`). Drives the aux lemma's RHS.
         combine_op: crate::ast::BinOp,
     },
+    /// Accumulator-threaded encoder/inverse roundtrip. The wrapper has
+    /// shape `encode(xs) = encodeLoop(xs, emptyAcc)`; the loop has
+    /// shape `match xs { [] -> flushAcc(acc); h :: t ->
+    /// encodeLoop(t, encodeFold(acc, h)) }`; the inverse decodes a
+    /// list by appending each expanded run. Backends prove a
+    /// generalized invariant over all accumulators satisfying the
+    /// synthesized sign predicate `0 ≤ acc.<count_field>`, then derive
+    /// the user law at the wrapper's initial accumulator.
+    AccumulatorRoundtrip {
+        wrapper_fn: String,
+        loop_fn: String,
+        step_fn: String,
+        finish_fn: String,
+        inverse_fn: String,
+        expand_fn: String,
+        repeat_fn: String,
+        acc_type: String,
+        run_type: String,
+        item_type: String,
+        runs_field: String,
+        current_field: String,
+        count_field: String,
+        run_value_field: String,
+        initial_acc: Spanned<crate::ir::hir::ResolvedExpr>,
+    },
+    /// String wrapper over a proven list roundtrip:
+    /// `decodeString(encodeString(s)) = s` where `encodeString(s)`
+    /// calls the list wrapper on `String.chars(s)`, `decodeString`
+    /// joins the inverse list with `""`, and a sibling
+    /// [`ProofStrategy::AccumulatorRoundtrip`] theorem proves
+    /// `decode(encode(xs)) = xs`.
+    StringRoundtripViaList {
+        string_encoder_fn: String,
+        string_decoder_fn: String,
+        list_encoder_fn: String,
+        list_law_name: String,
+    },
     /// No automated strategy — emit with `sorry` (Lean) / `assume
     /// {:axiom}` (Dafny). User fills in manually.
     Sorry,

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -359,12 +359,66 @@ fn proof_export_builds_rle_when_lake_is_available() {
 
 #[test]
 fn proof_dafny_verifies_rle_when_dafny_is_available() {
-    // Three postcondition gaps on the encode/decode roundtrip shape
-    // (one universal lemma, one sample assertion, one
-    // `decodeString` universal). Z3 can't auto-discharge them
-    // without a richer list-induction tactic the lowerer doesn't
-    // emit yet. Tracked in issue #114.
-    assert_dafny_verifies_with_budgets("examples/data/rle.av", "aver-dafny-rle", 3, 0);
+    // The accumulator-roundtrip support stack (repeat-succ, decode-append,
+    // WF-guarded fold step, count-nonneg, the generalized-over-accumulator
+    // invariant) plus the `StringJoinEmptyChars` prelude lemma close both
+    // the list roundtrip and its string wrapper, with the deep sample
+    // discharged from the proven lemma instead of fuel. 0 errors, 0 axioms.
+    assert_dafny_verifies_with_budgets("examples/data/rle.av", "aver-dafny-rle", 0, 0);
+}
+
+#[test]
+fn proof_dafny_recognizes_roundtrip_with_renamed_count_field() {
+    // The recognizer identifies the count field by its structural role
+    // (tested `== 0` in the step, re-emitted by finish), not a hard-coded
+    // "count" name. A field-renamed clone of rle.av must still prove at
+    // budget 0/0: before the relaxation the recognizer bailed on any
+    // non-"count" field name and the roundtrip fell to `assume {:axiom}`.
+    if Command::new("dafny").arg("--version").output().is_err() {
+        eprintln!("skipping dafny verify smoke test: `dafny` not available");
+        return;
+    }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let rle = std::fs::read_to_string(repo_root.join("examples/data/rle.av")).expect("read rle.av");
+    let renamed = rle.replace("count", "tally");
+    let dir = temp_output_dir("aver-dafny-rle-renamed");
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let src_path = dir.join("rle_renamed.av");
+    std::fs::write(&src_path, renamed).expect("write renamed rle");
+
+    let run = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg(&src_path)
+        .arg("--backend")
+        .arg("dafny")
+        .arg("-o")
+        .arg(dir.join("out"))
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).expect("parse --check-json output");
+    assert_eq!(
+        summary["errors"].as_u64(),
+        Some(0),
+        "renamed-field rle: dafny errors (recognizer must fire name-agnostically)\n{}",
+        json_line
+    );
+    assert_eq!(
+        summary["axioms"].as_u64(),
+        Some(0),
+        "renamed-field rle: dafny axioms (must prove, not axiomatize)\n{}",
+        json_line
+    );
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -350,14 +350,11 @@ fn proof_export_builds_result_chain_when_lake_is_available() {
 
 #[test]
 fn proof_export_builds_rle_when_lake_is_available() {
-    // The encode/decode roundtrip laws are list-given, so #409 attempts Lean
-    // list-induction — but `encode` threads an accumulator (`encodeLoop`) so a
-    // plain `induction xs` IH does not align; both roundtrips fall to an honest
-    // `sorry` (per-arm `first | (simp_all; done) | sorry`, which BUILDS). The
-    // earlier #409 revision claimed 1 here, a false green — the tactic left
-    // unsolved goals that `lake build` rejects but the sorry-count metric was
-    // blind to (fixed in commands.rs to gate on lake's exit status).
-    assert_proof_builds_with_sorry_budget("examples/data/rle.av", "aver-proof-rle", 2);
+    // Accumulator roundtrip synthesis generalizes `encodeLoop` over
+    // the threaded accumulator plus `count >= 0`, then derives the
+    // string wrapper from the list theorem and the Lean prelude's
+    // `String.intercalate_empty_chars`.
+    assert_proof_builds_with_sorry_budget("examples/data/rle.av", "aver-proof-rle", 0);
 }
 
 #[test]


### PR DESCRIPTION
## What

Makes the **accumulator-threaded encoder/inverse roundtrip** law prove on **both** proof backends, and removes the recognizer's brittle field-name coupling.

`examples/data/rle.av` carries `verify encode law roundtrip: decode(encode(xs)) => xs`. Naive head/tail induction can't close it — `encode = encodeLoop(xs, freshAcc)` threads an accumulator, so after peeling the head the induction hypothesis is about a *different* accumulator than the recursive call produces. The fix is the helper stack a human would write: generalize the loop over **all** accumulators satisfying a synthesized `count >= 0` well-formedness guard (the guard came from a counterexample — `count = -1` falsifies the fold step), then derive the user law at the initial accumulator.

## Commits

1. **`aa51162a` — Lean synthesis** (core, authored by a separate autonomous agent; clippy/fmt + verification only here).
2. **`af67008e` — Dafny port + name-agnostic recognizer** (this session's work):
   - **Dafny port.** The Dafny backend now emits the same proven support stack (repeat-succ, decode-append, WF-guarded fold step, count-nonneg, the generalized invariant) plus a `StringJoinEmptyChars` prelude lemma in `common.dfy` (the chars/join inverse — the Dafny counterpart of Lean's `String.intercalate_empty_chars`). The list roundtrip **and** its string wrapper now verify under Z3; deep concrete samples that exceed Dafny's evaluation fuel are discharged from the proven universal lemma instead of re-derived by unfolding. rle Dafny budget **3 errors → 0 errors, 0 axioms**.
   - **Name-agnostic recognizer.** The count field is now identified by its structural role (the field the step tests `== 0` and finish re-emits) instead of a hard-coded `"count"` name. A field-renamed clone of rle.av proves at `0/0` where it previously fell to `assume {:axiom}` — locked in by a regression test.

## Verification

- rle proves on Lean (`0 sorry`) **and** Dafny (`0 errors, 0 axioms`).
- Full `proof_spec` **72/72**, no regressions (the shared `common.dfy` additions are self-contained proven lemmas).
- `clippy -D warnings` clean, `fmt` clean.

## Not in this PR (follow-ups)

- Port the relaxation breadth beyond the RLE-shaped family (general accumulator invariant synthesis stays research-level).
- A general "samples ride the proven universal lemma" path (here it's gated to the two roundtrip strategies).

## Provenance

The Lean core (commit 1) was authored by a separate autonomous coding agent from a hand-off spec. The Dafny port, recognizer relaxation, and tests (commit 2) are this session's work. Flagged here at the author's request — not claimed as hand-authored by the repo owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
