### PR TITLE
docs(site+readme): Happy Path Programming #120 social proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ The intended workflow is explicit: AI writes Aver, humans review contracts and i
 
 ---
 
+## Talks
+
+I discussed Aver on Happy Path Programming #120 with Bruce Eckel and James Ward: why the optimization target is the reviewer and not the generator; why effects, intent, verify blocks, and decisions belong in the language itself; and what "AI-native" should actually mean when generated code still has to be trusted by a human.
+
+Watch / listen: https://www.youtube.com/watch?v=D_mPxGtSzbQ
+
+---
+
 ## Execution modes
 
 ### Default (VM)

--- a/tools/website/index.html
+++ b/tools/website/index.html
@@ -83,6 +83,9 @@
     </div>
 </section>
 
+<!-- ── Social proof ─────────────────────────────────────────────────── -->
+<p class="hero-podcast">Discussed on <em>Happy Path Programming</em> #120 with Bruce Eckel and James Ward — why a language should optimize for reviewer trust over generation speed. <a href="https://www.youtube.com/watch?v=D_mPxGtSzbQ" target="_blank" rel="noopener">Watch / listen →</a></p>
+
 <!-- ── Features ─────────────────────────────────────────────────────── -->
 <section class="features" id="features">
     <h2>Why Aver?</h2>

--- a/tools/website/style.css
+++ b/tools/website/style.css
@@ -194,6 +194,32 @@ body { overflow-x: hidden; }
 }
 .hero-proof a:hover { color: var(--accent); }
 
+/* Thin social-proof line under the hero — one elegant line, not a banner. */
+.hero-podcast {
+    max-width: 760px;
+    margin: -0.5rem auto 0;
+    padding: 0 1.5rem;
+    text-align: center;
+    font-size: 0.86rem;
+    line-height: 1.5;
+    color: var(--muted);
+}
+.hero-podcast em {
+    font-style: normal;
+    font-weight: 620;
+    color: var(--text);
+}
+.hero-podcast a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 650;
+    white-space: nowrap;
+}
+.hero-podcast a:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.16em;
+}
+
 .btn {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
Adds external social proof for the [Happy Path Programming #120](https://www.youtube.com/watch?v=D_mPxGtSzbQ) episode (Bruce Eckel + James Ward).

**Landing page** (`tools/website/index.html` + `style.css`): one thin, centered line under the hero — not a banner:
> Discussed on *Happy Path Programming* #120 with Bruce Eckel and James Ward — why a language should optimize for reviewer trust over generation speed. **Watch / listen →**

Worded to avoid echoing the hero subhead ("optimization target is the reviewer, not the generator") verbatim. `.hero-podcast` mirrors the muted `.hero-proof` styling.

**README**: a `## Talks` section placed after "Why Aver exists" — the section the episode actually argues, so it reads as "want the philosophy without reading everything?". Single long line per the README style.

Notes:
- Source-only — does **not** deploy the site (that's `tools/release.py --deploy-edge`).
- Names no peer languages, per the public-copy convention.
- Independent of the proof-lemma-discovery work (#445); branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)