### PR TITLE
proof(discovery): lemma-discovery feedback loop — discovered lemmas close laws (SimpOverLemmas)

### DIFF
--- a/proof-corpus/README.md
+++ b/proof-corpus/README.md
@@ -33,10 +33,17 @@ A task is **covered** when `aver proof <f> --check --check-json` reports
 `"passed": true` — the Lean export of the universal law kernel-checks with no
 sorry/axiom over budget, via any auto-mode strategy (structural induction,
 accumulator-fold spec-equivalence, …). Lake-gated; run `cargo build --bin aver`
-first, then `./run.sh`. (The `--discover` lemma-discovery class — codec roundtrips,
-homomorphism enumeration — was measured to add nothing on the current TIP slice,
-since its law-closing classes are codec-roundtrip, absent here, and additive-monoid,
-already covered by the auto-mode strategy.)
+first, then `./run.sh`.
+
+`DISCOVER=1 ./run.sh` additionally runs `aver proof --discover` into each
+task's output dir before the Lean check, so the committed kernel-proved
+lemmas feed the law's own proof (the `ProofStrategy::SimpOverLemmas`
+feedback loop). The default run stays discovery-free — that is the honest
+no-discovery baseline, and the delta between the two runs is discovery's
+measured coverage value. First measured win on this corpus: prod `prop_03`,
+whose stated law needs the unstated `length (a ++ b) = plus (length a)
+(length b)` homomorphism that discovery conjectures, kernel-proves, and
+feeds back.
 
 KNOWN FLAKINESS: a sweep of all tasks transiently fails some `lake` builds under
 load, which records false "open" (never false "proved"). `run.sh` retries a

--- a/proof-corpus/discover.sh
+++ b/proof-corpus/discover.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Lemma-discovery REACH baseline — how many corpus TASKS `aver proof --discover`
+# proves >= 1 auxiliary lemma for, and the total proved-lemma count. This is the
+# CONJECTURE+PROVE reach of the discovery layer (a leading indicator), NOT the
+# main-law coverage number.
+#
+# ⚠️ IMPORTANT — this is NOT the same metric as run.sh:
+#   - run.sh measures whether the TASK'S UNIVERSAL LAW closes (currently 57/154).
+#   - this measures whether discovery CONJECTURES + KERNEL-PROVES any lemma for
+#     the task. Discovery does NOT yet feed those lemmas back into the main law's
+#     proof (the `ProofStrategy::SimpOverLemmas` re-entry is still pending), so a
+#     proved discovered lemma does NOT (yet) move the run.sh coverage number.
+#     This baseline exists to quantify discovery's reach BEFORE the structural
+#     homomorphism conjecturer (B1) lands — so its effect is measurable.
+#
+# Expensive: each `--discover` enumerates, VM-filters, and runs up to ~8 `lake
+# build`s. No retry (a transient lake failure only UNDER-counts → lower bound).
+#
+# Usage:  ./discover.sh            (uses ../target/debug/aver — build it first)
+#         AVER=/path/to/aver ./discover.sh
+set -u
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+AVER="${AVER:-$ROOT/../target/debug/aver}"
+
+if [ ! -x "$AVER" ]; then
+  echo "error: aver binary not found at $AVER (run: cargo build --bin aver)" >&2
+  exit 1
+fi
+
+tasks_with=0
+total_lemmas=0
+total=0
+for f in $(find "$ROOT" -name '*.av' | sort); do
+  [ -e "$f" ] || continue
+  total=$((total + 1))
+  out="$(mktemp -d)"
+  # Count the per-lemma "  ✓ <lemma>" lines discovery prints under
+  # "PROVED (Lean, kernel-checked): N".
+  n="$("$AVER" proof "$f" --discover -o "$out" 2>/dev/null | grep -c '✓')"
+  rm -rf "$out"
+  if [ "${n:-0}" -gt 0 ]; then
+    tasks_with=$((tasks_with + 1))
+    total_lemmas=$((total_lemmas + n))
+    printf '  %3d lemma(s)  %s\n' "$n" "${f#"$ROOT"/}"
+  fi
+done
+
+echo ""
+echo "discovery reach: ${tasks_with} / ${total} tasks proved >=1 lemma   |   ${total_lemmas} lemmas total"
+echo "(reach, NOT main-law coverage — see header; run.sh is the coverage metric)"

--- a/proof-corpus/run.sh
+++ b/proof-corpus/run.sh
@@ -26,6 +26,13 @@
 #
 # Usage:  ./run.sh            (uses ../target/debug/aver — build it first)
 #         AVER=/path/to/aver ./run.sh
+#         DISCOVER=1 ./run.sh (run `aver proof --discover` into the same
+#                              output dir before each Lean check, so committed
+#                              discovered lemmas feed the law's proof — the
+#                              SimpOverLemmas feedback loop. The default run
+#                              stays discovery-free: that is the honest
+#                              no-discovery baseline, and the delta between
+#                              the two runs is discovery's coverage value.)
 set -u
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
@@ -47,6 +54,12 @@ proves() {
   esac
   for attempt in 1 2; do
     out="$(mktemp -d)"
+    # DISCOVER=1 (Lean only): commit kernel-proved discovered lemmas into the
+    # same output dir first; the proof step below picks them up and re-pins
+    # in-scope laws to SimpOverLemmas.
+    if [ "${DISCOVER:-0}" = "1" ] && [ "$backend" = lean ]; then
+      "$AVER" proof "$f" --discover -o "$out" >/dev/null 2>&1 || true
+    fi
     json="$("$AVER" proof "$f" --backend "$backend" --check --check-json -o "$out" 2>/dev/null | grep '"passed"' | tail -1)"
     rm -rf "$out"
     printf '%s' "$json" | grep -q "$key" && { echo proved; return; }

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -2933,6 +2933,7 @@ mod tests {
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,
+            discovered_lemmas: Vec::new(),
         };
         ctx.proof_ir
             .refined_types

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -221,6 +221,7 @@ mod tests {
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,
+            discovered_lemmas: Vec::new(),
         }
     }
 

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -68,9 +68,22 @@ pub fn emit_verify_law_forall_auto_proof(
     // (still called for BackendDispatch laws that the lowerer
     // hasn't classified — shouldn't trigger for canonical recursive-
     // ADT shapes after Step 31).
+    //
+    // `SimpOverLemmas(names)` (the discovery feedback loop — the CLI
+    // re-pins an `Induction` law when committed discovered lemmas are
+    // in-scope) routes to the SAME induction emit with the lemma
+    // names threaded through: the emit embeds the lemma texts, adds
+    // the names to the simp sets, and tries a lemma-first fast path
+    // before inducting.
+    let pinned = law_strategy_for(ctx, &vb.fn_name, &law.name);
+    let discovered: Vec<String> = match &pinned {
+        Some(crate::ir::ProofStrategy::SimpOverLemmas(names)) => names.clone(),
+        _ => Vec::new(),
+    };
     if matches!(
-        law_strategy_for(ctx, &vb.fn_name, &law.name),
+        pinned,
         Some(crate::ir::ProofStrategy::Induction { .. })
+            | Some(crate::ir::ProofStrategy::SimpOverLemmas(_))
     ) && let Some(proof) = induction::emit_structural_induction_law(
         vb,
         law,
@@ -79,6 +92,7 @@ pub fn emit_verify_law_forall_auto_proof(
         theorem_base,
         quant_params,
         theorem_prop,
+        &discovered,
     ) {
         return Some(proof);
     }

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -65,20 +65,36 @@ fn lean_rev_support(
 /// honest `sorry` caught by the sorry-gate), never a false theorem. Names are
 /// law-scoped (`law_uid`) so multiple laws in one module don't collide.
 ///
-/// Returns `(support_theorems, simp_lemma_names)`. The simp set carries the
-/// bridge names plus, when a `*` bridge is present, the core distributivity /
-/// associativity lemmas (`*` is nonlinear so `omega` can't close it and core
-/// Lean has no `ring`; pure-commutativity laws fall through to `sorry`).
+/// Returns `(support_theorems, simp_lemma_names, bridged_fn_lean_names)`. The
+/// simp set carries the bridge names plus, when a `*` bridge is present, the
+/// core distributivity / associativity lemmas (`*` is nonlinear so `omega`
+/// can't close it and core Lean has no `ring`; pure-commutativity laws fall
+/// through to `sorry`). `bridged_fn_lean_names` are the Lean names of the
+/// lifted user fns themselves — callers building a combined `simp only` set
+/// must EXCLUDE those defs (mixing a fn's def equations with its `= a + b`
+/// bridge in one call leaves the rewrite stuck).
+///
+/// `extra_fns` extends the scan beyond the law's own call graph — the
+/// discovery feedback loop passes the fns its committed lemmas mention, so an
+/// op a homomorphism lemma INTRODUCES (e.g. `plus` rewriting into a law that
+/// only said `double`) still gets its bridge. Empty for the plain path.
 fn lean_nat_lift_support(
     law: &VerifyLaw,
     ctx: &CodegenContext,
     law_uid: &str,
-) -> (Vec<String>, Vec<String>) {
+    extra_fns: &BTreeSet<String>,
+) -> (Vec<String>, Vec<String>, BTreeSet<String>) {
     use crate::codegen::proof_recognize::{NatArithKind, NatCompareKind};
     let mut support = Vec::new();
     let mut simp_extra = Vec::new();
+    let mut bridged_fns: BTreeSet<String> = BTreeSet::new();
 
-    let arith = crate::codegen::proof_recognize::collect_nat_arith_ops_in_law(law, ctx);
+    let mut arith = crate::codegen::proof_recognize::collect_nat_arith_ops_in_law(law, ctx);
+    for op in crate::codegen::proof_recognize::collect_nat_arith_ops_for_names(extra_fns, ctx) {
+        if !arith.iter().any(|o| o.fn_name == op.fn_name) {
+            arith.push(op);
+        }
+    }
     // The `*` bridge proof rewrites with the `+` bridge, so resolve the addition
     // op's bridge name up front and emit Add/Sub before Mul.
     let add_bridge_name = arith
@@ -92,6 +108,7 @@ fn lean_nat_lift_support(
         .chain(arith.iter().filter(|o| o.kind == NatArithKind::Mul));
     for op in ordered {
         let f = aver_name_to_lean(&op.fn_name);
+        bridged_fns.insert(f.clone());
         match op.kind {
             NatArithKind::Add => {
                 let name = format!("{law_uid}_{f}_isNatAdd");
@@ -124,8 +141,15 @@ fn lean_nat_lift_support(
         }
     }
 
-    for op in crate::codegen::proof_recognize::collect_nat_compare_ops_in_law(law, ctx) {
+    let mut compare = crate::codegen::proof_recognize::collect_nat_compare_ops_in_law(law, ctx);
+    for op in crate::codegen::proof_recognize::collect_nat_compare_ops_for_names(extra_fns, ctx) {
+        if !compare.iter().any(|o| o.fn_name == op.fn_name) {
+            compare.push(op);
+        }
+    }
+    for op in compare {
         let f = aver_name_to_lean(&op.fn_name);
+        bridged_fns.insert(f.clone());
         match op.kind {
             // `(le a b = true) = (a ≤ b)`: a Prop-equality (propext) so `simp only`
             // rewrites the Bool goal `le _ _ = true` straight into `_ ≤ _` for omega.
@@ -168,7 +192,100 @@ fn lean_nat_lift_support(
         }
     }
 
-    (support, simp_extra)
+    (support, simp_extra, bridged_fns)
+}
+
+/// Source names of the program fns mentioned by the given pinned discovered
+/// lemmas (`ProofStrategy::SimpOverLemmas` names → `ctx.discovered_lemmas`
+/// texts → token scan against every pure program fn's Lean name). Drives the
+/// lemma-aware extension of [`lean_nat_lift_support`].
+fn discovered_lemma_source_fns(ctx: &CodegenContext, names: &[String]) -> BTreeSet<String> {
+    use std::collections::BTreeMap;
+    if names.is_empty() {
+        return BTreeSet::new();
+    }
+    let lean_index: BTreeMap<String, String> = ctx
+        .modules
+        .iter()
+        .flat_map(|m| m.fn_defs.iter())
+        .chain(ctx.fn_defs.iter())
+        .filter(|fd| crate::codegen::common::is_pure_fn(fd))
+        .map(|fd| (aver_name_to_lean(&fd.name), fd.name.clone()))
+        .collect();
+    ctx.discovered_lemmas
+        .iter()
+        .filter(|l| names.contains(&l.name))
+        .flat_map(|l| crate::codegen::lemma_discovery::mentioned_fns(&l.text, &lean_index))
+        .collect()
+}
+
+/// The pinned lemmas usable as `simp` rewrite rules, as ready-to-emit simp
+/// set entries (`lemma_discovery::simp_entries`): `name` for a Forward lemma
+/// (program-fn-headed LHS), `← name` for a Reversed one (builtin-headed LHS,
+/// program-fn-headed RHS — e.g. the trivia `(x0 ++ x1) = append x0 x1`,
+/// which reversed UNFOLDS the opaque wrapper into `++` so a forward
+/// homomorphism can fire), minus loop-prone forward/reversed combinations
+/// (a simp cycle is an uncatchable maxHeartbeats BUILD error). The pin
+/// carries EVERY in-scope lemma so embedded proofs keep their dependencies;
+/// only this selection joins the simp sets.
+fn discovered_simp_entries(ctx: &CodegenContext, names: &[String]) -> Vec<String> {
+    if names.is_empty() {
+        return Vec::new();
+    }
+    let program_fns: BTreeSet<String> = ctx
+        .modules
+        .iter()
+        .flat_map(|m| m.fn_defs.iter())
+        .chain(ctx.fn_defs.iter())
+        .filter(|fd| crate::codegen::common::is_pure_fn(fd))
+        .map(|fd| aver_name_to_lean(&fd.name))
+        .collect();
+    let pinned: Vec<&crate::codegen::lemma_discovery::CommittedLemma> = ctx
+        .discovered_lemmas
+        .iter()
+        .filter(|l| names.contains(&l.name))
+        .collect();
+    crate::codegen::lemma_discovery::simp_entries(&pinned, &program_fns)
+}
+
+/// Verbatim texts of the pinned discovered lemmas THIS law is responsible for
+/// emitting. A lemma is embedded exactly once per generated file: by the
+/// first law (in `proof_ir.law_theorems` order, which mirrors entry-item
+/// order) whose `SimpOverLemmas` pin carries its name — later laws only
+/// reference the name, which Lean resolves against the earlier definition.
+/// Embedding re-proves the lemma inside the same `lake build`, so a stale
+/// committed lemma fails the build loudly (the replay soundness guard) rather
+/// than being trusted via the cone hash.
+fn discovered_support_lines(
+    ctx: &CodegenContext,
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    names: &[String],
+) -> Vec<String> {
+    if names.is_empty() {
+        return Vec::new();
+    }
+    let Some(fn_id) = ctx
+        .symbol_table
+        .fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name))
+    else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for name in names {
+        let first_user = ctx.proof_ir.law_theorems.iter().find(|t| {
+            matches!(&t.strategy,
+                crate::ir::ProofStrategy::SimpOverLemmas(ns) if ns.contains(name))
+        });
+        let this_law_is_first =
+            first_user.is_some_and(|t| t.fn_id == fn_id && t.law_name == law.name);
+        if this_law_is_first
+            && let Some(lemma) = ctx.discovered_lemmas.iter().find(|l| &l.name == name)
+        {
+            out.push(lemma.text.clone());
+        }
+    }
+    out
 }
 
 enum VariantKind {
@@ -268,6 +385,13 @@ fn premise_intro_names(law: &VerifyLaw, intro_names: &[String]) -> Vec<String> {
     names
 }
 
+/// `discovered` carries the lemma names of an IR-pinned
+/// `ProofStrategy::SimpOverLemmas` (the discovery feedback loop): the emits
+/// below add them to the law's simp sets, embed their texts (first user
+/// only), and try a lemma-first `simp only … <;> omega` fast path before
+/// induction. Empty for a plain `Induction` pin — the output is then
+/// byte-identical to the pre-feedback emit.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn emit_structural_induction_law(
     vb: &VerifyBlock,
     law: &VerifyLaw,
@@ -276,6 +400,7 @@ pub(super) fn emit_structural_induction_law(
     _theorem_base: &str,
     _quant_params: &str,
     _theorem_prop: &str,
+    discovered: &[String],
 ) -> Option<AutoProof> {
     if law.when.is_some() {
         return None;
@@ -306,7 +431,7 @@ pub(super) fn emit_structural_induction_law(
     //     list-homomorphism universals that inducting on a co-occurring Nat
     //     given would leave at `sorry`.
     if verified_recurses_on_list && let Some(target_idx) = list_target {
-        return emit_list_induction(vb, law, ctx, intro_names, target_idx);
+        return emit_list_induction(vb, law, ctx, intro_names, target_idx, discovered);
     }
 
     // (b) A `given` is a user-defined recursive sum type: structural induction
@@ -316,12 +441,21 @@ pub(super) fn emit_structural_induction_law(
         if has_indirect_variants(variants, type_name) {
             return None;
         }
-        return emit_simple_induction(vb, law, ctx, intro_names, target_idx, type_name, variants);
+        return emit_simple_induction(
+            vb,
+            law,
+            ctx,
+            intro_names,
+            target_idx,
+            type_name,
+            variants,
+            discovered,
+        );
     }
 
     // (c) No sum-type given, but a builtin `List<T>` given is present.
     if let Some(target_idx) = list_target {
-        return emit_list_induction(vb, law, ctx, intro_names, target_idx);
+        return emit_list_induction(vb, law, ctx, intro_names, target_idx, discovered);
     }
 
     None
@@ -346,6 +480,7 @@ fn emit_list_induction(
     ctx: &CodegenContext,
     intro_names: &[String],
     target_idx: usize,
+    discovered: &[String],
 ) -> Option<AutoProof> {
     let mut simp_defs: BTreeSet<String> = law_simp_defs(ctx, vb, law);
     // Rev anti-homomorphism: prepend the proved aux lemmas (support_lines) and
@@ -359,6 +494,12 @@ fn emit_list_induction(
     let rev_ops = crate::codegen::proof_recognize::collect_rev_ops_in_law(law, ctx);
     let (rev_support, rev_simp) = lean_rev_support(&rev_ops, &law_uid);
     simp_defs.extend(rev_simp);
+    // Discovery feedback: the simp-oriented pinned lemmas join the induction
+    // arms' simp sets as rewrite rules (e.g. a count/length homomorphism
+    // collapsing `g (a ++ b)` so the inductive hypothesis lines up). The
+    // full `discovered` set is embedded; only the oriented subset rewrites.
+    let discovered_simp = discovered_simp_entries(ctx, discovered);
+    simp_defs.extend(discovered_simp.iter().cloned());
     let simp_list = simp_defs.into_iter().collect::<Vec<_>>().join(", ");
     let target_lean = &intro_names[target_idx];
 
@@ -399,28 +540,106 @@ fn emit_list_induction(
     // Purely additive: it runs only after the two `simp_all` branches fail, so
     // cases that already close are untouched, and `split`/`simp_all`/`omega`
     // are all sound — an unprovable goal still degrades to the honest `sorry`.
-    let proof_lines = vec![
-        format!("  intro {}", intro_names.join(" ")),
-        format!("  induction {} with", target_lean),
-        format!(
-            "  | nil => first | (simp [{d}]; done) | (simp [{d}]; omega) | (simp only [{s}]; split <;> simp_all [{d}] <;> omega) | sorry",
-            d = simp_list,
-            s = split_set
-        ),
-        format!(
-            "  | cons head tail ih => first | (simp_all [{d}]; done) | (simp_all [{d}]; omega) | (simp only [{s}]; split <;> simp_all [{d}] <;> omega) | sorry",
-            d = simp_list,
-            s = split_set
-        ),
-    ];
+    // Feedback mode adds two BRIDGE branches per arm (`bridges` = the
+    // canonical-Peano op bridges, e.g. `plus a b = a + b`): after the def
+    // unfolds + induction hypothesis, a goal like `S (plus a b) = plus a
+    // (S b)` is stuck (the op recurses on a symbolic arg) but is pure linear
+    // arithmetic once bridged — `simp only [bridges] <;> omega` decides it.
+    // The split variant covers the same residual under an inner Bool/enum
+    // match (`try` so a goal with nothing to bridge still reaches `omega`).
+    // All branches are sound, so each can only ADD closures.
+    let mk_arms = |bridges: Option<&str>| -> (String, String) {
+        let nil_bridge = bridges
+            .map(|b| format!(" | (simp [{d}]; simp only [{b}] <;> omega)", d = simp_list))
+            .unwrap_or_default();
+        let cons_bridge = bridges
+            .map(|b| {
+                format!(
+                    " | (simp_all [{d}]; simp only [{b}] <;> omega)",
+                    d = simp_list
+                )
+            })
+            .unwrap_or_default();
+        let split_bridge = bridges
+            .map(|b| format!(" <;> (try simp only [{b}])"))
+            .unwrap_or_default();
+        (
+            format!(
+                "| nil => first | (simp [{d}]; done) | (simp [{d}]; omega){nil_bridge} | (simp only [{s}]; split <;> simp_all [{d}]{split_bridge} <;> omega) | sorry",
+                d = simp_list,
+                s = split_set
+            ),
+            format!(
+                "| cons head tail ih => first | (simp_all [{d}]; done) | (simp_all [{d}]; omega){cons_bridge} | (simp only [{s}]; split <;> simp_all [{d}]{split_bridge} <;> omega) | sorry",
+                d = simp_list,
+                s = split_set
+            ),
+        )
+    };
+
+    let mut proof_lines = vec![format!("  intro {}", intro_names.join(" "))];
+    let mut support_lines = Vec::new();
+    if discovered.is_empty() {
+        let (nil_arm, cons_arm) = mk_arms(None);
+        proof_lines.push(format!("  induction {} with", target_lean));
+        proof_lines.push(format!("  {nil_arm}"));
+        proof_lines.push(format!("  {cons_arm}"));
+    } else {
+        // Discovery feedback (`SimpOverLemmas`): before inducting, try closing
+        // the goal OUTRIGHT with the pinned lemmas — many laws that NEED an
+        // auxiliary homomorphism are a pure rewrite once it exists (e.g.
+        // `length (x ++ y) = plus (length y) (length x)` under the length
+        // homomorphism + the `plus = +` bridge + `omega`). Two `simp only`
+        // shapes: lemmas+bridges alone (the goal already matches the lemma),
+        // then with the law's def unfolds added (a wrapper like `appendNat`
+        // must unfold to `++` before the lemma can fire) — minus the bridged
+        // fns' own defs (def + bridge in one simp call sticks). Both paths
+        // are sound (`simp only` rewrites with proved equations, `omega`
+        // decides), so a miss just falls through to the induction ladder,
+        // which is the exact pre-feedback emit with the lemmas joined to its
+        // simp sets. Coverage can only grow.
+        let lemma_fns = discovered_lemma_source_fns(ctx, discovered);
+        let (arith_support, arith_bridges, bridged_fns) =
+            lean_nat_lift_support(law, ctx, &law_uid, &lemma_fns);
+        let mut fast_lemmas: Vec<String> = discovered_simp.clone();
+        fast_lemmas.extend(arith_bridges.iter().cloned());
+        let fast_unfolds: BTreeSet<String> = law_simp_defs(ctx, vb, law)
+            .into_iter()
+            .chain(discovered_simp.iter().cloned())
+            .chain(arith_bridges.iter().cloned())
+            .filter(|n| !bridged_fns.contains(n))
+            .collect();
+        let bridge_set = if arith_bridges.is_empty() {
+            None
+        } else {
+            Some(arith_bridges.join(", "))
+        };
+        let (nil_arm, cons_arm) = mk_arms(bridge_set.as_deref());
+        proof_lines.push("  first".to_string());
+        proof_lines.push(format!(
+            "  | (simp only [{}] <;> omega)",
+            fast_lemmas.join(", ")
+        ));
+        proof_lines.push(format!(
+            "  | (simp only [{}] <;> omega)",
+            fast_unfolds.into_iter().collect::<Vec<_>>().join(", ")
+        ));
+        proof_lines.push(format!("  | (induction {} with", target_lean));
+        proof_lines.push(format!("     {nil_arm}"));
+        proof_lines.push(format!("     {cons_arm})"));
+        support_lines.extend(discovered_support_lines(ctx, vb, law, discovered));
+        support_lines.extend(arith_support);
+    }
+    support_lines.extend(rev_support);
 
     Some(AutoProof {
-        support_lines: rev_support,
+        support_lines,
         proof_lines,
         replaces_theorem: false,
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emit_simple_induction(
     vb: &VerifyBlock,
     law: &VerifyLaw,
@@ -429,8 +648,13 @@ fn emit_simple_induction(
     target_idx: usize,
     type_name: &str,
     variants: &[TypeVariant],
+    discovered: &[String],
 ) -> Option<AutoProof> {
-    let simp_defs: BTreeSet<String> = law_simp_defs(ctx, vb, law);
+    let mut simp_defs: BTreeSet<String> = law_simp_defs(ctx, vb, law);
+    // Discovery feedback: the simp-oriented pinned lemmas join the arm simp
+    // sets (see `emit_list_induction`); empty for a plain `Induction` pin.
+    let discovered_simp = discovered_simp_entries(ctx, discovered);
+    simp_defs.extend(discovered_simp.iter().cloned());
     let simp_list = simp_defs.into_iter().collect::<Vec<_>>().join(", ");
     let target_lean = &intro_names[target_idx];
     let premise_names = premise_intro_names(law, intro_names);
@@ -446,7 +670,9 @@ fn emit_simple_induction(
         aver_name_to_lean(&vb.fn_name),
         aver_name_to_lean(&law.name)
     );
-    let (arith_support, arith_bridges) = lean_nat_lift_support(law, ctx, &law_uid);
+    let lemma_fns = discovered_lemma_source_fns(ctx, discovered);
+    let (arith_support, arith_bridges, bridged_fns) =
+        lean_nat_lift_support(law, ctx, &law_uid, &lemma_fns);
 
     let mut intro_parts = intro_names.to_vec();
     intro_parts.extend(premise_names.iter().cloned());
@@ -464,6 +690,16 @@ fn emit_simple_induction(
     // `Nat`, the arm names must be Lean's `Nat` constructors (`zero`/`succ`),
     // not the user's lowercased `z`/`s`.
     let peano = crate::codegen::proof_recognize::peano_type_named(ctx, type_name);
+    // Feedback mode (`SimpOverLemmas` + canonical-op bridges present): each
+    // arm gets a bridge branch before `sorry` — defs/lemmas first, then
+    // `simp only [bridges] <;> omega` for the arithmetic residual a stuck
+    // Peano op leaves (see `emit_list_induction`'s `mk_arms`). Sound, so the
+    // branch can only add closures; absent in plain mode (byte-identical).
+    let arm_bridge = if !discovered_simp.is_empty() && !arith_bridges.is_empty() {
+        Some(arith_bridges.join(", "))
+    } else {
+        None
+    };
     let mut arm_lines: Vec<String> = Vec::new();
     for variant in variants {
         let lean_variant = match &peano {
@@ -482,8 +718,12 @@ fn emit_simple_induction(
                 } else {
                     format!(" {}", field_binders.join(" "))
                 };
+                let bridge = arm_bridge
+                    .as_deref()
+                    .map(|b| format!(" | (simp [{d}]; simp only [{b}] <;> omega)", d = simp_list))
+                    .unwrap_or_default();
                 arm_lines.push(format!(
-                    "| {v}{b} => first | (simp [{d}]; done) | (simp [{d}]; omega) | sorry",
+                    "| {v}{b} => first | (simp [{d}]; done) | (simp [{d}]; omega){bridge} | sorry",
                     v = lean_variant,
                     b = binders,
                     d = simp_list
@@ -498,8 +738,17 @@ fn emit_simple_induction(
                     .map(|(index, _)| format!("ih{}", index))
                     .collect();
 
+                let bridge = arm_bridge
+                    .as_deref()
+                    .map(|b| {
+                        format!(
+                            " | (simp_all [{d}]; simp only [{b}] <;> omega)",
+                            d = simp_list
+                        )
+                    })
+                    .unwrap_or_default();
                 arm_lines.push(format!(
-                    "| {v} {b} {ih} => first | (simp_all [{d}]; done) | (simp_all [{d}]; omega) | sorry",
+                    "| {v} {b} {ih} => first | (simp_all [{d}]; done) | (simp_all [{d}]; omega){bridge} | sorry",
                     v = lean_variant,
                     b = field_binders.join(" "),
                     ih = ih_names.join(" "),
@@ -511,8 +760,9 @@ fn emit_simple_induction(
     }
 
     let mut proof_lines = vec![format!("  intro {}", intro_parts.join(" "))];
-    if arith_bridges.is_empty() {
-        // No arithmetic to lift: plain structural induction.
+    if arith_bridges.is_empty() && discovered_simp.is_empty() {
+        // No arithmetic to lift, no discovered lemmas: plain structural
+        // induction.
         proof_lines.push(format!("  induction {} with", target_lean));
         proof_lines.extend(arm_lines.into_iter().map(|a| format!("  {a}")));
     } else {
@@ -521,12 +771,30 @@ fn emit_simple_induction(
         // induction leaves at `sorry`; the induction fallback preserves every
         // case the bare strategy already proved (a law that merely MENTIONS
         // `plus`/`minus` but needs induction just fails the fast path and
-        // proceeds), so the wrapping can only ever ADD coverage.
+        // proceeds), so the wrapping can only ever ADD coverage. With a
+        // `SimpOverLemmas` pin the discovered lemma names join the fast path
+        // (and a second def-unfolding variant is tried — see
+        // `emit_list_induction`); the bridged fns' own defs stay out of the
+        // `simp only` calls (def + bridge in one call sticks).
+        let mut fast_lemmas: Vec<String> = discovered_simp.clone();
+        fast_lemmas.extend(arith_bridges.iter().cloned());
         proof_lines.push("  first".to_string());
         proof_lines.push(format!(
             "  | (simp only [{}] <;> omega)",
-            arith_bridges.join(", ")
+            fast_lemmas.join(", ")
         ));
+        if !discovered_simp.is_empty() {
+            let fast_unfolds: BTreeSet<String> = law_simp_defs(ctx, vb, law)
+                .into_iter()
+                .chain(discovered_simp.iter().cloned())
+                .chain(arith_bridges.iter().cloned())
+                .filter(|n| !bridged_fns.contains(n))
+                .collect();
+            proof_lines.push(format!(
+                "  | (simp only [{}] <;> omega)",
+                fast_unfolds.into_iter().collect::<Vec<_>>().join(", ")
+            ));
+        }
         proof_lines.push(format!("  | (induction {} with", target_lean));
         let last = arm_lines.len().saturating_sub(1);
         for (idx, arm) in arm_lines.into_iter().enumerate() {
@@ -538,8 +806,10 @@ fn emit_simple_induction(
         }
     }
 
+    let mut support_lines = discovered_support_lines(ctx, vb, law, discovered);
+    support_lines.extend(arith_support);
     Some(AutoProof {
-        support_lines: arith_support,
+        support_lines,
         proof_lines,
         replaces_theorem: false,
     })

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1603,6 +1603,7 @@ mod tests {
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,
+            discovered_lemmas: Vec::new(),
         }
     }
 

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -2021,6 +2021,7 @@ fn emit_verify_law_block(
             !matches!(
                 t.strategy,
                 crate::ir::ProofStrategy::Induction { .. }
+                    | crate::ir::ProofStrategy::SimpOverLemmas(_)
                     | crate::ir::ProofStrategy::BackendDispatch
                     | crate::ir::ProofStrategy::Sorry
             )

--- a/src/codegen/lemma_discovery/committed.rs
+++ b/src/codegen/lemma_discovery/committed.rs
@@ -1,0 +1,704 @@
+//! The feedback half of the discovery loop (`ProofStrategy::SimpOverLemmas`):
+//! consume a previously-committed `DiscoveredLemmas.lean` so the kernel-proved
+//! lemmas JOIN the normal `aver proof` run instead of only being re-verified
+//! next to it.
+//!
+//! Flow (CLI-driven, Lean backend):
+//!
+//! ```text
+//!   <out>/DiscoveredLemmas.lean  ─►  parse_committed_lemmas  ─►  plan_simp_over_lemma_pins
+//!   (hash-gated: stale surface       (name + verbatim text        (per `verify … law`: every
+//!    means IGNORE — behave exactly    per `theorem` block)          committed lemma whose program-fn
+//!    like no discovery ran)                                         mentions ⊆ the law's cone)
+//!                                                  │
+//!                                                  ▼
+//!                       apply_simp_over_lemma_pins re-pins `Induction` → `SimpOverLemmas(names)`;
+//!                       the Lean backend then EMBEDS the lemma texts before the law theorem
+//!                       (re-verifying them in the same `lake build` — the soundness guard)
+//!                       and adds their names to the law's simp set.
+//! ```
+//!
+//! The cone-hash gate is a staleness key ONLY (skip-feedback, like
+//! skip-rediscovery on replay). Soundness never rests on it: an embedded lemma
+//! is re-proved by the kernel on every build, so a lemma staled by a
+//! same-signature body change fails the build loudly instead of being trusted.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::ast::{TopLevel, VerifyKind};
+use crate::codegen::proof_lower::{LawProofCone, ProofLowerInputs};
+use crate::ir::proof_ir::ProofIR;
+
+/// One kernel-proved lemma parsed back from a committed
+/// `DiscoveredLemmas.lean`: its theorem name plus the verbatim Lean text
+/// (statement AND tactic) to embed into the generated proof project.
+#[derive(Debug, Clone)]
+pub struct CommittedLemma {
+    pub name: String,
+    pub text: String,
+}
+
+/// Parse a committed `DiscoveredLemmas.lean` into its theorem blocks. A block
+/// starts at a column-0 `theorem ` line and runs until the next one (proof
+/// lines are indented, so this never splits a tactic). Header comments before
+/// the first theorem are dropped; comment/blank lines between theorems are
+/// absorbed into the preceding block's text (harmless Lean comments).
+pub fn parse_committed_lemmas(content: &str) -> Vec<CommittedLemma> {
+    let mut lemmas: Vec<CommittedLemma> = Vec::new();
+    let mut current: Option<CommittedLemma> = None;
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("theorem ") {
+            if let Some(mut done) = current.take() {
+                done.text.truncate(done.text.trim_end().len());
+                lemmas.push(done);
+            }
+            let name = rest
+                .split_whitespace()
+                .next()
+                .unwrap_or("")
+                .trim_end_matches(':')
+                .to_string();
+            current = Some(CommittedLemma {
+                name,
+                text: line.to_string(),
+            });
+        } else if let Some(block) = current.as_mut() {
+            block.text.push('\n');
+            block.text.push_str(line);
+        }
+    }
+    if let Some(mut done) = current.take() {
+        done.text.truncate(done.text.trim_end().len());
+        lemmas.push(done);
+    }
+    lemmas.retain(|l| !l.name.is_empty());
+    lemmas
+}
+
+/// Soundness validation for a parsed committed lemma: the embed path writes
+/// `text` VERBATIM into the generated entry root, where lake compiles it as
+/// top-level Lean — so a block absorbing anything beyond its own
+/// `theorem … := by` + tactic lines (the parser takes every non-`theorem `
+/// line as-is, and Lean accepts indented top-level commands) could smuggle a
+/// declaration like `axiom cheat : False` into the proof environment.
+/// Returns the first forbidden declaration keyword found outside `--` line
+/// comments (skipping the block's own leading `theorem`), or `None` when the
+/// block is clean. The CLI rejects the WHOLE artifact on any hit — a
+/// discovery-emitted file never contains these, so a hit means hand-edited
+/// or corrupted content that must not join a kernel-trust pipeline. (The
+/// axiom WHITELIST in the universal metric is the backstop; this check makes
+/// the failure loud and early instead.)
+pub fn forbidden_token_in_lemma(text: &str) -> Option<&'static str> {
+    const DENY: [&str; 30] = [
+        "axiom",
+        "opaque",
+        "unsafe",
+        "macro",
+        "macro_rules",
+        "notation",
+        "syntax",
+        "elab",
+        "attribute",
+        "set_option",
+        "instance",
+        "structure",
+        "inductive",
+        "class",
+        "def",
+        "abbrev",
+        "example",
+        "import",
+        "open",
+        "namespace",
+        "section",
+        "end",
+        "mutual",
+        "initialize",
+        "run_cmd",
+        "partial",
+        "noncomputable",
+        "deriving",
+        "theorem",
+        "sorry",
+    ];
+    for (line_idx, line) in text.lines().enumerate() {
+        let code = line.split("--").next().unwrap_or("");
+        for (tok_idx, tok) in code
+            .split(|c: char| !(c.is_alphanumeric() || c == '_' || c == '.' || c == '\''))
+            .filter(|t| !t.is_empty())
+            .enumerate()
+        {
+            // The block's own header keyword.
+            if line_idx == 0 && tok_idx == 0 && tok == "theorem" {
+                continue;
+            }
+            if let Some(hit) = DENY.iter().find(|d| **d == tok) {
+                return Some(hit);
+            }
+        }
+    }
+    None
+}
+
+/// Program fns a lemma's Lean text mentions, projected through `lean_index`
+/// (Lean name → caller-chosen value, e.g. the source name). Token scan over
+/// identifier-shaped chunks; builtin lemma names (`List.append_assoc`, …) and
+/// binder names simply miss the index.
+pub fn mentioned_fns(text: &str, lean_index: &BTreeMap<String, String>) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for token in text.split(|c: char| !(c.is_alphanumeric() || c == '_' || c == '.' || c == '\'')) {
+        if let Some(v) = lean_index.get(token) {
+            out.insert(v.clone());
+        }
+    }
+    out
+}
+
+/// How a committed lemma may join a `simp` set. Discovery commits equations
+/// in enumeration orientation, so usability as a rewrite rule is a property
+/// to RECOVER, not assume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimpDirection {
+    /// LHS head is a program fn (`count x2 (x0 ++ x1) = plus …`,
+    /// `decode (encode xs) = xs`): use as-is — rewrites toward
+    /// decomposed/builtin normal form.
+    Forward,
+    /// LHS is builtin-headed but the RHS head is a program fn (the trivia
+    /// `(x0 ++ x1) = append x0 x1`): use as `← name` — rewrites the opaque
+    /// program fn INTO its builtin shape (an unfolding equation the fn's own
+    /// def can't provide when its recursion is stuck on a symbolic arg).
+    Reversed,
+}
+
+/// Classify a committed lemma as a usable `simp` rewrite rule, or `None`
+/// (e.g. a `0 <= …` invariant, or an equation connecting nothing to a
+/// program fn head). A `None` lemma stays EMBEDDED (other committed lemmas'
+/// proofs may depend on it) but joins no simp set — a builtin-headed
+/// equation used left-to-right re-folds the very structure the induction
+/// ladder needs peeled, and loops against the fn's own def unfold.
+pub fn simp_orientation(text: &str, program_fns: &BTreeSet<String>) -> Option<SimpDirection> {
+    let stmt = statement_body(text)?;
+    if program_fns.contains(&head_token(stmt)) {
+        return Some(SimpDirection::Forward);
+    }
+    let rhs = split_after_top_eq(stmt)?;
+    if program_fns.contains(&head_token(rhs)) {
+        return Some(SimpDirection::Reversed);
+    }
+    None
+}
+
+/// Ready-to-emit `simp` set entries for a pinned lemma selection: a Forward
+/// lemma joins as `name`, a Reversed one as `← name` — minus the loop-prone
+/// combinations. A Forward rule whose RHS mentions a program fn that some
+/// Reversed rule in the SAME set unfolds (its RHS head) would compose into a
+/// rewrite cycle — e.g. `length (x0 ++ x1) = length (append x0 x1)` (forward)
+/// against `← ((x0 ++ x1) = append x0 x1)` ping-pongs `++ ↔ append` under
+/// `length` forever. `simp` loops are NOT a caught failure: they abort the
+/// build with a deterministic maxHeartbeats ERROR that `first` cannot
+/// recover from, so the exclusion is a build-safety requirement, not a
+/// quality preference.
+pub fn simp_entries(lemmas: &[&CommittedLemma], program_fns: &BTreeSet<String>) -> Vec<String> {
+    let classified: Vec<(&CommittedLemma, SimpDirection)> = lemmas
+        .iter()
+        .filter_map(|l| simp_orientation(&l.text, program_fns).map(|d| (*l, d)))
+        .collect();
+    let reversed_heads: BTreeSet<String> = classified
+        .iter()
+        .filter(|(_, d)| *d == SimpDirection::Reversed)
+        .filter_map(|(l, _)| {
+            let rhs = split_after_top_eq(statement_body(&l.text)?)?;
+            Some(head_token(rhs))
+        })
+        .collect();
+    classified
+        .into_iter()
+        .filter_map(|(l, d)| match d {
+            SimpDirection::Forward => {
+                let rhs = split_after_top_eq(statement_body(&l.text)?)?;
+                let mentions_unfolded = rhs
+                    .split(|c: char| !(c.is_alphanumeric() || c == '_' || c == '.' || c == '\''))
+                    .any(|tok| reversed_heads.contains(tok));
+                if mentions_unfolded {
+                    None
+                } else {
+                    Some(l.name.clone())
+                }
+            }
+            SimpDirection::Reversed => Some(format!("← {}", l.name)),
+        })
+        .collect()
+}
+
+/// [`statement_of`] with the `∀ binders,` prefix stripped — the equation body
+/// the orientation/loop analyses operate on.
+fn statement_body(text: &str) -> Option<&str> {
+    let stmt = statement_of(text)?.trim_start();
+    if let Some(rest) = stmt.strip_prefix('∀') {
+        split_after_depth0(rest, ',')
+    } else {
+        Some(stmt)
+    }
+}
+
+/// First identifier-shaped token, skipping leading whitespace and `(`.
+fn head_token(text: &str) -> String {
+    text.chars()
+        .skip_while(|c| c.is_whitespace() || *c == '(')
+        .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '.' || *c == '\'')
+        .collect()
+}
+
+/// The slice after the top-level `=` of an equation — depth-0, not part of
+/// `<=` / `>=` / `!=` / `==` (the only `=`-bearing operators the lemma
+/// templates emit; `:=` was already cut off by [`statement_of`]).
+fn split_after_top_eq(text: &str) -> Option<&str> {
+    let mut depth = 0i32;
+    let mut prev = ' ';
+    let bytes = text.as_bytes();
+    for (i, c) in text.char_indices() {
+        match c {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            '=' if depth == 0 => {
+                let next_eq = bytes.get(i + 1) == Some(&b'=');
+                if !matches!(prev, '<' | '>' | '!' | '=') && !next_eq {
+                    return Some(&text[i + 1..]);
+                }
+            }
+            _ => {}
+        }
+        prev = c;
+    }
+    None
+}
+
+/// The statement region of a theorem text: after the first depth-0 `:`
+/// (binders keep their `:`s inside parens/brackets), up to the depth-0 `:=`.
+fn statement_of(text: &str) -> Option<&str> {
+    let mut depth = 0i32;
+    let mut start = None;
+    let mut prev_colon = false;
+    for (i, c) in text.char_indices() {
+        match c {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            ':' if depth == 0 && start.is_none() => {
+                start = Some(i + 1);
+            }
+            '=' if depth == 0 && prev_colon => {
+                // `:=` — if it directly follows the colon that opened the
+                // statement, the statement is empty (malformed); else end.
+                let s = start?;
+                if i > s {
+                    return Some(&text[s..i - 1]);
+                }
+                return None;
+            }
+            _ => {}
+        }
+        prev_colon = c == ':' && depth == 0;
+    }
+    None
+}
+
+/// Byte offset just past the first depth-0 occurrence of `sep`, as a slice.
+fn split_after_depth0(text: &str, sep: char) -> Option<&str> {
+    let mut depth = 0i32;
+    for (i, c) in text.char_indices() {
+        match c {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            c2 if c2 == sep && depth == 0 => return Some(&text[i + c.len_utf8()..]),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// A planned re-pin: `(fn_id, law_name)` goes from `Induction` to
+/// `SimpOverLemmas(lemma_names)`.
+pub type SimpOverLemmaPin = (crate::ir::FnId, String, Vec<String>);
+
+/// Decide which laws get the committed lemmas. A lemma is in-scope for a law
+/// when every program fn its text mentions is inside the law's proof cone
+/// (plus the law's subject fn) — the same scope discovery enumerated over, so
+/// the embedded text can only reference fns already emitted before the law's
+/// theorem. Only laws the lowerer pinned `Induction` are re-pinned: that is
+/// the strategy the discovery cluster (list/Peano homomorphisms) lands on,
+/// and the Lean renderer for `SimpOverLemmas` reuses the same induction
+/// ladder, so the swap can only ADD proving power.
+pub fn plan_simp_over_lemma_pins(
+    inputs: &ProofLowerInputs,
+    ir: &ProofIR,
+    lemmas: &[CommittedLemma],
+) -> Vec<SimpOverLemmaPin> {
+    use crate::codegen::lean::aver_name_to_lean;
+    if lemmas.is_empty() {
+        return Vec::new();
+    }
+    // Lean name → Lean name over EVERY pure program fn: the universe the
+    // subset test runs in. A lemma mentioning no program fn at all carries no
+    // connection to the program and is never pinned.
+    let all_fns: BTreeMap<String, String> = inputs
+        .pure_fns()
+        .iter()
+        .map(|fd| {
+            let lean = aver_name_to_lean(&fd.name);
+            (lean.clone(), lean)
+        })
+        .collect();
+    let all_fn_names: BTreeSet<String> = all_fns.keys().cloned().collect();
+    let mentions: Vec<BTreeSet<String>> = lemmas
+        .iter()
+        .map(|l| mentioned_fns(&l.text, &all_fns))
+        .collect();
+    let oriented: Vec<bool> = lemmas
+        .iter()
+        .map(|l| simp_orientation(&l.text, &all_fn_names).is_some())
+        .collect();
+
+    let mut plan = Vec::new();
+    for item in inputs.entry_items {
+        let TopLevel::Verify(vb) = item else { continue };
+        let VerifyKind::Law(law) = &vb.kind else {
+            continue;
+        };
+        let Some(fn_id) = inputs
+            .symbol_table
+            .fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name))
+        else {
+            continue;
+        };
+        let Some(thm) = ir
+            .law_theorems
+            .iter()
+            .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        else {
+            continue;
+        };
+        if !matches!(thm.strategy, crate::ir::ProofStrategy::Induction { .. }) {
+            continue;
+        }
+        let cone = LawProofCone::compute(law, &vb.fn_name, inputs);
+        let mut scope: BTreeSet<String> = cone
+            .pure_fns()
+            .iter()
+            .map(|fd| aver_name_to_lean(&fd.name))
+            .collect();
+        scope.insert(aver_name_to_lean(&vb.fn_name));
+        // The pin carries every in-scope lemma (the EMBED set — committed
+        // lemmas may depend on each other, so dropping one could break
+        // another's embedded proof), but a law is only worth pinning when at
+        // least one of them is a usable simp rewrite rule — the Lean emit
+        // re-derives that selection for its `simp` sets.
+        let mut any_oriented = false;
+        let mut selected: BTreeSet<usize> = BTreeSet::new();
+        for (i, (m, o)) in mentions.iter().zip(&oriented).enumerate() {
+            if !m.is_empty() && m.is_subset(&scope) {
+                selected.insert(i);
+                any_oriented |= *o;
+            }
+        }
+        if !any_oriented {
+            continue;
+        }
+        // Dependency closure: a committed lemma's PROOF may reference a
+        // sibling committed theorem by name (the structural chains do —
+        // e.g. a guarded `…_succ` step rewriting with its `…_natAbs_succ`
+        // helper, which itself mentions no program fn and so failed the
+        // in-scope gate above). Embedding one without the other is an
+        // unknown-identifier BUILD error, so pull referenced siblings in
+        // until fixpoint. Every program fn is emitted before the verify
+        // theorems regardless of cone, so an added dependency always
+        // type-checks; preserving committed-file order (the BTreeSet index
+        // walk below) keeps each dependency ahead of its dependent.
+        loop {
+            let added: Vec<usize> = lemmas
+                .iter()
+                .enumerate()
+                .filter(|(j, lj)| {
+                    !selected.contains(j)
+                        && selected.iter().any(|&i| lemmas[i].text.contains(&lj.name))
+                })
+                .map(|(j, _)| j)
+                .collect();
+            if added.is_empty() {
+                break;
+            }
+            selected.extend(added);
+        }
+        let names: Vec<String> = selected.iter().map(|&i| lemmas[i].name.clone()).collect();
+        plan.push((fn_id, law.name.clone(), names));
+    }
+    plan
+}
+
+/// Apply a [`plan_simp_over_lemma_pins`] plan to the lowered IR.
+pub fn apply_simp_over_lemma_pins(ir: &mut ProofIR, plan: &[SimpOverLemmaPin]) {
+    for (fn_id, law_name, names) in plan {
+        if let Some(t) = ir
+            .law_theorems
+            .iter_mut()
+            .find(|t| t.fn_id == *fn_id && t.law_name == *law_name)
+        {
+            t.strategy = crate::ir::ProofStrategy::SimpOverLemmas(names.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The count-into-plus fold family (mirrors the conjecturer fixture in
+    /// the parent module), plus an `orphan` pure fn UNREACHABLE from the law —
+    /// the out-of-cone case the in-scope gate must reject.
+    const SRC: &str = r#"
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match eqNat(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn appendNat(xs: List<Nat>, ys: List<Nat>) -> List<Nat>
+    List.concat(xs, ys)
+
+fn orphan(x: Nat) -> Nat
+    x
+
+verify count law countPlusConcat
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given xs: List<Nat> = [[], [Nat.Z]]
+    given ys: List<Nat> = [[], [Nat.S(Nat.Z)]]
+    plus(count(n, xs), count(n, ys)) => count(n, appendNat(xs, ys))
+"#;
+
+    const COMMITTED: &str = "-- Discovered lemmas for prop_02.av — `aver proof --discover`\n\
+        -- cone-hash: 00deadbeef00\n\
+        -- Each theorem below was discovered and kernel-proved.\n\
+        \n\
+        theorem aver_helper_succ (n : Int) : Int.natAbs (n + 1) = Int.natAbs n + 1 := by\n\
+        \x20 omega\n\
+        \n\
+        theorem aver_discovered_lemma_0 (x0 : List Nat) (x1 : List Nat) (x2 : Nat) : count x2 (x0 ++ x1) = plus (count x2 x0) (count x2 x1) := by\n\
+        \x20 induction x0 with\n\
+        \x20 | nil => first | (simp [count]; done) | (simp [count, aver_helper_succ]; omega)\n\
+        \x20 | cons head tail ih => first | (simp_all [count]; done) | (simp_all [count]; omega)\n\
+        \n\
+        theorem aver_discovered_lemma_1 (x0 : Nat) : orphan (plus x0 x0) = plus x0 x0 := by\n\
+        \x20 simp [orphan]\n";
+
+    fn with_inputs<R>(src: &str, f: impl FnOnce(&ProofLowerInputs) -> R) -> R {
+        let mut lexer = crate::lexer::Lexer::new(src);
+        let tokens = lexer.tokenize().expect("lex");
+        let mut items = crate::parser::Parser::new(tokens).parse().expect("parse");
+        crate::ir::pipeline::tco(&mut items);
+        crate::ir::pipeline::resolve(&mut items);
+        let symbols = crate::ir::SymbolTable::build(&items, &[]);
+        let prefixes: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let recursive: std::collections::HashSet<crate::ir::FnId> =
+            std::collections::HashSet::new();
+        let no_modules: &[crate::codegen::ModuleInfo] = &[];
+        let inputs = ProofLowerInputs {
+            entry_items: &items,
+            dep_modules: no_modules,
+            module_prefixes: &prefixes,
+            recursive_fns: &recursive,
+            symbol_table: &symbols,
+            program_shape: None,
+        };
+        f(&inputs)
+    }
+
+    #[test]
+    fn parses_committed_theorem_blocks() {
+        let lemmas = parse_committed_lemmas(COMMITTED);
+        assert_eq!(lemmas.len(), 3);
+        assert_eq!(lemmas[0].name, "aver_helper_succ");
+        assert_eq!(lemmas[1].name, "aver_discovered_lemma_0");
+        assert_eq!(lemmas[2].name, "aver_discovered_lemma_1");
+        // Block boundaries: each text starts at its own `theorem` line and
+        // carries its full (indented) tactic, nothing of its neighbour.
+        assert!(
+            lemmas[1]
+                .text
+                .starts_with("theorem aver_discovered_lemma_0 ")
+        );
+        assert!(lemmas[1].text.contains("induction x0 with"));
+        assert!(!lemmas[1].text.contains("aver_discovered_lemma_1"));
+        assert!(lemmas[2].text.ends_with("simp [orphan]"));
+        // Header comments are not a lemma.
+        assert!(lemmas.iter().all(|l| !l.text.contains("cone-hash")));
+    }
+
+    #[test]
+    fn plan_pins_in_scope_lemma_and_rejects_out_of_cone() {
+        with_inputs(SRC, |inputs| {
+            let mut ir = ProofIR::default();
+            crate::codegen::proof_lower::populate_law_theorems(inputs, &mut ir);
+            assert_eq!(ir.law_theorems.len(), 1);
+            assert!(matches!(
+                ir.law_theorems[0].strategy,
+                crate::ir::ProofStrategy::Induction { .. }
+            ));
+
+            let lemmas = parse_committed_lemmas(COMMITTED);
+            let plan = plan_simp_over_lemma_pins(inputs, &ir, &lemmas);
+            // Exactly one law pinned. lemma_0 mentions {count, plus} ⊆ cone ∪
+            // {subject} — in. Its tactic references `aver_helper_succ` by
+            // name, so the helper (no program-fn mentions — it would fail the
+            // in-scope gate alone) rides in via the dependency closure, AHEAD
+            // of its dependent (committed-file order). lemma_1 mentions
+            // `orphan`, which the law never reaches — out-of-cone, rejected.
+            assert_eq!(plan.len(), 1);
+            assert_eq!(plan[0].1, "countPlusConcat");
+            assert_eq!(
+                plan[0].2,
+                vec![
+                    "aver_helper_succ".to_string(),
+                    "aver_discovered_lemma_0".to_string()
+                ]
+            );
+
+            apply_simp_over_lemma_pins(&mut ir, &plan);
+            match &ir.law_theorems[0].strategy {
+                crate::ir::ProofStrategy::SimpOverLemmas(names) => {
+                    assert_eq!(names.len(), 2);
+                }
+                other => panic!("expected SimpOverLemmas pin, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn simp_orientation_classifies_rewrite_direction() {
+        let fns: BTreeSet<String> = ["count", "plus", "appendNat", "decode", "encode"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        // Homomorphism: program-fn-headed LHS — a forward rewrite rule.
+        assert_eq!(
+            simp_orientation(
+                "theorem t0 (x0 : List Nat) (x2 : Nat) : (count x2 (x0 ++ x1)) = (plus (count x2 x0) (count x2 x1)) := by\n  simp",
+                &fns
+            ),
+            Some(SimpDirection::Forward)
+        );
+        // Roundtrip-shaped brick: also forward.
+        assert_eq!(
+            simp_orientation(
+                "theorem t1 (xs : List String) : decode (encode xs) = xs := by\n  simp",
+                &fns
+            ),
+            Some(SimpDirection::Forward)
+        );
+        // Builtin-headed LHS with a program-fn-headed RHS: usable REVERSED
+        // (`← name` unfolds the opaque wrapper into its builtin shape).
+        assert_eq!(
+            simp_orientation(
+                "theorem t2 (x0 : List Nat) : (x0 ++ x0) = (appendNat x0 x0) := by\n  simp",
+                &fns
+            ),
+            Some(SimpDirection::Reversed)
+        );
+        // ∀-quantified template: the binder list is skipped before the head.
+        assert_eq!(
+            simp_orientation(
+                "theorem t3 : ∀ (list : List Int) (acc : Int), plus list acc = acc := by\n  simp",
+                &fns
+            ),
+            Some(SimpDirection::Forward)
+        );
+        // Non-equation invariant (`0 <= …`) connecting no program-fn head on
+        // either side of an `=`: no usable direction (embed-only).
+        assert_eq!(
+            simp_orientation(
+                "theorem t4 (acc : Acc) (x : Int) : 0 <= (count acc x) := by\n  simp",
+                &fns
+            ),
+            None
+        );
+        // Builtin-to-builtin associativity trivia: no direction either.
+        assert_eq!(
+            simp_orientation(
+                "theorem t5 (x0 : List Nat) : ((x0 ++ x0) ++ x0) = (x0 ++ (x0 ++ x0)) := by\n  simp",
+                &fns
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn forbidden_tokens_reject_smuggled_declarations() {
+        // A genuine discovery block: clean.
+        let lemmas = parse_committed_lemmas(COMMITTED);
+        assert!(
+            lemmas
+                .iter()
+                .all(|l| forbidden_token_in_lemma(&l.text).is_none()),
+            "discovery-emitted blocks must validate clean"
+        );
+        // The smuggle vector the adversarial review found: a column-0 (or
+        // indented — Lean accepts indented top-level commands) `axiom` line
+        // absorbed into a block's verbatim text would join the kernel
+        // environment and defeat the universal metric.
+        assert_eq!(
+            forbidden_token_in_lemma("theorem t : True := by\n  trivial\naxiom cheat : False"),
+            Some("axiom")
+        );
+        assert_eq!(
+            forbidden_token_in_lemma("theorem t : True := by\n  trivial\n  set_option foo true"),
+            Some("set_option")
+        );
+        // `sorry` never appears in a committed lemma (proved-or-dropped).
+        assert_eq!(
+            forbidden_token_in_lemma("theorem t : P := by\n  first | simp | sorry"),
+            Some("sorry")
+        );
+        // Words inside `--` comments don't trip the scan.
+        assert_eq!(
+            forbidden_token_in_lemma("theorem t : True := by\n  trivial -- no axiom here"),
+            None
+        );
+        // A second `theorem` cannot hide inside a block either.
+        assert_eq!(
+            forbidden_token_in_lemma("theorem t : True := by\n  trivial\n  theorem u : True"),
+            Some("theorem")
+        );
+    }
+
+    #[test]
+    fn plan_ignores_lemmas_with_no_program_connection() {
+        with_inputs(SRC, |inputs| {
+            let mut ir = ProofIR::default();
+            crate::codegen::proof_lower::populate_law_theorems(inputs, &mut ir);
+            // A lemma mentioning NO program fn (pure builtin algebra) carries
+            // no connection to the program — never pinned.
+            let lemmas = vec![CommittedLemma {
+                name: "free_floating".to_string(),
+                text: "theorem free_floating (a : Nat) : a + 0 = a := by simp".to_string(),
+            }];
+            assert!(plan_simp_over_lemma_pins(inputs, &ir, &lemmas).is_empty());
+        });
+    }
+}

--- a/src/codegen/lemma_discovery/enumerate.rs
+++ b/src/codegen/lemma_discovery/enumerate.rs
@@ -101,10 +101,10 @@ fn homomorphism_conjectures(
     // the fold we want a homomorphism for (`verify count law …` → `count`), so
     // add it back to the candidate `g` set.
     let mut fns: Vec<&crate::ast::FnDef> = cone.pure_fns().to_vec();
-    if let Some(subj) = inputs.find_fn_def_by_call_name(subject_fn) {
-        if !fns.iter().any(|f| f.name == subj.name) {
-            fns.push(subj);
-        }
+    if let Some(subj) = inputs.find_fn_def_by_call_name(subject_fn)
+        && !fns.iter().any(|f| f.name == subj.name)
+    {
+        fns.push(subj);
     }
     let fns = &fns;
     // The monoid `⊕`: a cone fn that is the canonical addition over a Peano type.

--- a/src/codegen/lemma_discovery/enumerate.rs
+++ b/src/codegen/lemma_discovery/enumerate.rs
@@ -38,6 +38,16 @@ pub fn run_discovery(inputs: &ProofLowerInputs) -> Vec<LawDiscovery> {
             terms_truncated = tt;
             conjectures = conj;
             conjectures_truncated = ct;
+            // Structure-directed candidates the size-capped enumerator can't
+            // mint (a homomorphism is ~7 nodes > MAX_TERM_SIZE). Appended after
+            // the enumerated set; the VM-filter + proved-or-dropped gate still
+            // apply, so a non-homomorphism is dropped.
+            conjectures.extend(homomorphism_conjectures(
+                &cone,
+                &binders,
+                inputs,
+                &vb.fn_name,
+            ));
         }
 
         reports.push(LawDiscovery {
@@ -66,6 +76,129 @@ pub fn run_discovery(inputs: &ProofLowerInputs) -> Vec<LawDiscovery> {
         });
     }
     reports
+}
+
+/// Structure-directed conjecturer: synthesize the monoid homomorphism
+/// `g(..a++b..) = ⊕(g(..a..), g(..b..))` for each cone fn `g` that structurally
+/// recurses on a `List` parameter and returns a canonical Peano type, given a
+/// cone fn `⊕` that is the canonical addition over that type. These candidates
+/// are ~7 nodes — far past [`MAX_TERM_SIZE`] — so the blind enumerator can never
+/// produce them; this is the generation unlock. The recognizer is LIBERAL (it
+/// conjectures for any list→Peano recursive fn): a `g` that is not actually a
+/// homomorphism is refuted by the VM-filter and, failing that, dropped by the
+/// proved-or-dropped kernel gate — the same "conjecture liberally, kernel
+/// proves" discipline as the proof-only bridges.
+fn homomorphism_conjectures(
+    cone: &LawProofCone,
+    binders: &[Binder],
+    inputs: &ProofLowerInputs,
+    subject_fn: &str,
+) -> Vec<Conjecture> {
+    use crate::codegen::proof_recognize::{detect_canonical_peano, is_canonical_add};
+    use crate::codegen::recursion::detect::single_list_structural_param_index;
+
+    // The cone EXCLUDES the law's subject fn, but the subject is often exactly
+    // the fold we want a homomorphism for (`verify count law …` → `count`), so
+    // add it back to the candidate `g` set.
+    let mut fns: Vec<&crate::ast::FnDef> = cone.pure_fns().to_vec();
+    if let Some(subj) = inputs.find_fn_def_by_call_name(subject_fn) {
+        if !fns.iter().any(|f| f.name == subj.name) {
+            fns.push(subj);
+        }
+    }
+    let fns = &fns;
+    // The monoid `⊕`: a cone fn that is the canonical addition over a Peano type.
+    let add = fns.iter().find_map(|&fd| {
+        let p = inputs
+            .find_type_def(fd.return_type.trim())
+            .and_then(detect_canonical_peano)?;
+        is_canonical_add(fd, &p).then(|| (fd.name.clone(), p))
+    });
+    let Some((add_name, peano)) = add else {
+        return Vec::new();
+    };
+
+    // Binder indices whose rendered type matches `ann` (the variable_context
+    // keys binders by rendered type, so this is exact).
+    let render_of = |ann: &str| render_type(&crate::codegen::common::parse_type_annotation(ann));
+    let bidx = |ann: &str| -> Vec<usize> {
+        let want = render_of(ann);
+        binders
+            .iter()
+            .enumerate()
+            .filter(|(_, b)| render_type(&b.ty) == want)
+            .map(|(i, _)| i)
+            .collect()
+    };
+
+    let mut out = Vec::new();
+    for &g in fns {
+        if g.name == add_name {
+            continue;
+        }
+        // `g` must return the SAME Peano type `⊕` combines.
+        match inputs
+            .find_type_def(g.return_type.trim())
+            .and_then(detect_canonical_peano)
+        {
+            Some(gp) if gp.type_name == peano.type_name => {}
+            _ => continue,
+        }
+        let Some(list_idx) = single_list_structural_param_index(g) else {
+            continue;
+        };
+        // Two distinct list-typed binders `a`, `b` for the appended argument.
+        let list_bs = bidx(&g.params[list_idx].1);
+        if list_bs.len() < 2 {
+            continue;
+        }
+        let (a, b) = (list_bs[0], list_bs[1]);
+        // One binder per OTHER parameter, held fixed across all three g-calls.
+        let mut fixed: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut ok = true;
+        for (j, (_, ann)) in g.params.iter().enumerate() {
+            if j == list_idx {
+                continue;
+            }
+            match bidx(ann).first() {
+                Some(&bi) => {
+                    fixed.insert(j, bi);
+                }
+                None => {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if !ok {
+            continue;
+        }
+        let g_at = |list_val: TermNode| TermNode::App {
+            callee: g.name.clone(),
+            args: (0..g.params.len())
+                .map(|j| {
+                    if j == list_idx {
+                        list_val.clone()
+                    } else {
+                        TermNode::Var(fixed[&j])
+                    }
+                })
+                .collect(),
+        };
+        let concat = TermNode::App {
+            callee: "List.concat".to_string(),
+            args: vec![TermNode::Var(a), TermNode::Var(b)],
+        };
+        out.push(Conjecture {
+            lhs: g_at(concat),
+            rhs: TermNode::App {
+                callee: add_name.clone(),
+                args: vec![g_at(TermNode::Var(a)), g_at(TermNode::Var(b))],
+            },
+            ty: crate::codegen::common::parse_type_annotation(&g.return_type),
+        });
+    }
+    out
 }
 
 /// Mint the shared variable context: up to [`MAX_VARS_PER_TYPE`] variables for

--- a/src/codegen/lemma_discovery/mod.rs
+++ b/src/codegen/lemma_discovery/mod.rs
@@ -595,11 +595,27 @@ verify encode law roundtrip
         assert!(thm.contains("theorem L "), "{thm}");
         assert!(thm.contains(": List Run)"), "{thm}");
         assert!(thm.contains("decode (") && thm.contains("++"), "{thm}");
-        // Tactic: list-induction template with the decode unfold + append_assoc.
+        // Tactic: session-grade list-induction ladder (mirrors the user-stated-law
+        // prover) — the decode unfold + append_assoc, plus the `omega` and
+        // `split` branches that give discovered candidates the same reach.
         assert!(thm.contains("induction "), "{thm}");
-        assert!(thm.contains("| nil => simp [decode]"), "{thm}");
+        assert!(thm.contains("| nil => first | (simp [decode]"), "{thm}");
         assert!(thm.contains("List.append_assoc"), "{thm}");
         assert!(thm.contains("ih"), "{thm}");
+        assert!(
+            thm.contains("omega"),
+            "ladder must include the omega branch: {thm}"
+        );
+        assert!(
+            thm.contains("split <;>"),
+            "ladder must include the inner-match split branch: {thm}"
+        );
+        // Discovery is proved-or-dropped: NO `sorry` fallback (a sorry builds
+        // clean and would falsely mark a refuted candidate "proved").
+        assert!(
+            !thm.contains("sorry"),
+            "discovered-lemma tactic must never carry a sorry fallback: {thm}"
+        );
     }
 
     #[test]

--- a/src/codegen/lemma_discovery/mod.rs
+++ b/src/codegen/lemma_discovery/mod.rs
@@ -631,6 +631,75 @@ verify encode law roundtrip
         );
     }
 
+    /// A `count`-into-`plus` fold whose `count(n, a ++ b) = plus(count n a,
+    /// count n b)` monoid homomorphism is size ~7 — past the enumerator's
+    /// `MAX_TERM_SIZE = 5` — so only the structure-directed conjecturer can mint it.
+    const COUNT_HOMO_SRC: &str = r#"
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match eqNat(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn appendNat(xs: List<Nat>, ys: List<Nat>) -> List<Nat>
+    List.concat(xs, ys)
+
+verify count law countPlusConcat
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given xs: List<Nat> = [[], [Nat.Z]]
+    given ys: List<Nat> = [[], [Nat.S(Nat.Z)]]
+    plus(count(n, xs), count(n, ys)) => count(n, appendNat(xs, ys))
+"#;
+
+    #[test]
+    fn structural_homomorphism_conjectured_for_count_fold() {
+        // The conjecturer mints the count homomorphism (the subject fn `count`
+        // is excluded from the cone, so the conjecturer adds it back), and the
+        // VM-filter KEEPS it (it is a true homomorphism). A render like
+        // `count(x2, List.concat(x0, x1)) == plus(count(x2, x0), count(x2, x1))`.
+        let r = &discover(COUNT_HOMO_SRC)[0];
+        let found = r.conjectures.iter().any(|c| {
+            let s = c.render(&r.binders);
+            s.contains("List.concat(") && s.contains("plus(count(")
+        });
+        assert!(
+            found,
+            "count→plus homomorphism not conjectured/surviving; survivors:\n{}",
+            r.conjectures
+                .iter()
+                .map(|c| c.render(&r.binders))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        // It must also rank first — it is the highest-value target, so the
+        // bounded prove budget reaches it.
+        let ranked = rank_candidate_indices(r);
+        let top = r.conjectures[ranked[0]].render(&r.binders);
+        assert!(
+            top.contains("List.concat(") && top.contains("plus(count("),
+            "count homomorphism must rank first, got {top}"
+        );
+    }
+
     #[test]
     fn structural_conjecturer_on_real_rle() {
         // rle is a full encoder, so its counted-repeat (`repeat`) and

--- a/src/codegen/lemma_discovery/mod.rs
+++ b/src/codegen/lemma_discovery/mod.rs
@@ -53,13 +53,19 @@
 //!    REPLAYS (re-verifies the committed lemmas via `lake build`) instead of
 //!    re-enumerating. Re-verification — not the hash — is the soundness guard.
 //!
-//! Still ahead: re-enter the *law's own proof* with a discovered lemma (via the
-//! `ProofStrategy::SimpOverLemmas` hook) so a `verify ... law` that needs it
-//! closes under normal `aver proof` — for the flagship rle roundtrip that also
-//! needs the guarded accumulator-generalization family (charter layer 3), so
-//! it is deferred there. Entry [`run_discovery`] (+ [`vm_filter`], + the CLI
-//! prove/replay step) is invoked by `aver proof --discover`; normal
-//! `aver proof` never runs this (discovery is the explicit, cached step).
+//! 7. **Feedback into the law's own proof** ([`committed`] — the
+//!    `ProofStrategy::SimpOverLemmas` hook): on a NORMAL `aver proof` run the
+//!    CLI parses a committed `DiscoveredLemmas.lean` (hash-gated for
+//!    staleness only), re-pins each in-scope `Induction` law to
+//!    `SimpOverLemmas(names)`, and the Lean backend embeds the lemma texts
+//!    before the law theorem (re-proving them in the same `lake build`) and
+//!    simps over their names — so a law that NEEDS a discovered auxiliary
+//!    lemma closes under normal `aver proof` after one `--discover` run.
+//!
+//! Entry [`run_discovery`] (+ [`vm_filter`], + the CLI prove/replay step) is
+//! invoked by `aver proof --discover`; normal `aver proof` never enumerates
+//! (discovery is the explicit, cached step — it only CONSUMES the committed
+//! artifact via step 7).
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
@@ -240,11 +246,17 @@ pub struct LawDiscovery {
 }
 
 mod bricks;
+mod committed;
 mod enumerate;
 mod render;
 mod vm_filter;
 
 pub use bricks::structural_lemma_groups;
+pub use committed::{
+    CommittedLemma, SimpDirection, apply_simp_over_lemma_pins, forbidden_token_in_lemma,
+    mentioned_fns, parse_committed_lemmas, plan_simp_over_lemma_pins, simp_entries,
+    simp_orientation,
+};
 pub use enumerate::run_discovery;
 pub use render::{
     discovery_surface_hash, lean_lemma_theorem, rank_candidate_indices, render_report,

--- a/src/codegen/lemma_discovery/render.rs
+++ b/src/codegen/lemma_discovery/render.rs
@@ -56,18 +56,38 @@ pub fn lean_lemma_theorem(c: &Conjecture, binders: &[Binder], name: &str) -> Opt
     let lhs = term_to_lean(&c.lhs, binders);
     let rhs = term_to_lean(&c.rhs, binders);
     let iv = &binders[induct].name;
-    let nil_simp = unfolds.join(", ");
-    let cons_simp = {
+    // Session-grade list-induction ladder (mirrors `law_auto::induction::
+    // emit_list_induction`), so a discovered candidate gets the SAME reach the
+    // user-stated-law prover has: `omega` for the linear-arithmetic residual a
+    // count/length homomorphism leaves (`1 + (m+n) = (1+m)+n`), and a `split`
+    // branch that case-splits a recursive fn's inner Bool/enum `match` (e.g.
+    // `count`'s `match eqNat n head`) which plain `simp` leaves stuck.
+    //
+    // CRUCIAL difference from the session prover: NO trailing `| sorry`.
+    // Discovery is proved-or-dropped — a `sorry` builds clean (exit 0) and would
+    // FALSELY mark a refuted candidate "proved". Omitting it means a candidate
+    // that no branch closes leaves an `unsolved goals` ERROR, `lake build`
+    // fails, and the candidate is correctly dropped. `omega`/`split`/`simp` are
+    // all sound, so a candidate that DOES close is genuinely proved.
+    let nil_defs = unfolds.join(", ");
+    let cons_defs = {
         let mut v = unfolds.clone();
-        v.push("ih".to_string());
         v.push("List.append_assoc".to_string());
         v.join(", ")
     };
+    // `simp only [..]` set for the split branch — guard the empty-`unfolds` case
+    // so we never emit a leading-comma `simp only [, …]` (a parse error).
+    let nil_split = if unfolds.is_empty() {
+        "List.cons_append".to_string()
+    } else {
+        format!("{nil_defs}, List.cons_append")
+    };
+    let cons_split = format!("{cons_defs}, List.cons_append");
     Some(format!(
         "theorem {name} {binders} : {lhs} = {rhs} := by\n  \
          induction {iv} with\n  \
-         | nil => simp [{nil_simp}]\n  \
-         | cons head tail ih => simp [{cons_simp}]\n",
+         | nil => first | (simp [{nil_defs}]; done) | (simp [{nil_defs}]; omega) | (simp only [{nil_split}]; split <;> simp_all [{nil_defs}] <;> omega)\n  \
+         | cons head tail ih => first | (simp_all [{cons_defs}]; done) | (simp_all [{cons_defs}]; omega) | (simp only [{cons_split}]; split <;> simp_all [{cons_defs}] <;> omega)\n",
         binders = binder_decls.join(" "),
     ))
 }

--- a/src/codegen/lemma_discovery/render.rs
+++ b/src/codegen/lemma_discovery/render.rs
@@ -127,65 +127,91 @@ fn collect_user_fns(node: &TermNode, out: &mut BTreeSet<String>) {
     }
 }
 
-/// `true` iff the candidate is the list-homomorphism shape
-/// `g(a ++ b) == g(a) ++ g(b)` (either orientation), `g` a user fn, `a`/`b`
-/// distinct variables. These are the highest-value proof targets, ranked first.
+/// `true` iff the candidate is the monoid-homomorphism shape
+/// `g(a ++ b) == ⊕(g(a), g(b))` (either orientation), `g` a user fn, `⊕` any
+/// binary op (list `++` for a list-valued `g`, or e.g. `plus` for a Peano-valued
+/// fold like `count`/`length`), `a`/`b` distinct variables. These are the
+/// highest-value proof targets — including the structurally-synthesized ones
+/// the enumerator can't mint — so they are ranked first.
 fn is_homomorphism(c: &Conjecture) -> bool {
+    fn var(t: &TermNode) -> Option<usize> {
+        if let TermNode::Var(i) = t {
+            Some(*i)
+        } else {
+            None
+        }
+    }
+    // `l = g(.., a ++ b, ..)` with EXACTLY one argument `a ++ b` (a≠b) and every
+    // other argument a bare variable; `r = ⊕(g(.., a, ..), g(.., b, ..))` with
+    // the appended position replaced by `a` / `b` and all other positions
+    // identical. Generalizes the unary list-homomorphism to a multi-arg fold
+    // (`count(n, a++b)`, the fixed `n` held across all three calls).
     fn oriented(l: &TermNode, r: &TermNode) -> bool {
         let TermNode::App {
             callee: g,
-            args: la,
+            args: largs,
         } = l
         else {
             return false;
         };
-        if g == "List.concat" || la.len() != 1 {
+        if g == "List.concat" || largs.is_empty() {
             return false;
         }
-        let TermNode::App {
-            callee: cc,
-            args: ca,
-        } = &la[0]
-        else {
+        let mut pos: Option<usize> = None;
+        let mut ab: Option<(usize, usize)> = None;
+        for (i, arg) in largs.iter().enumerate() {
+            if let TermNode::App {
+                callee: cc,
+                args: ca,
+            } = arg
+                && cc == "List.concat"
+                && ca.len() == 2
+                && let (Some(a), Some(b)) = (var(&ca[0]), var(&ca[1]))
+                && a != b
+            {
+                if pos.is_some() {
+                    return false; // more than one appended position
+                }
+                pos = Some(i);
+                ab = Some((a, b));
+            } else if var(arg).is_none() {
+                return false; // a non-appended argument must be a bare variable
+            }
+        }
+        let (Some(pos), Some((a, b))) = (pos, ab) else {
             return false;
         };
-        if cc != "List.concat" || ca.len() != 2 {
-            return false;
-        }
-        let (TermNode::Var(a), TermNode::Var(b)) = (&ca[0], &ca[1]) else {
-            return false;
-        };
-        if a == b {
-            return false;
-        }
         let TermNode::App {
-            callee: rc,
+            callee: _op,
             args: ra,
         } = r
         else {
             return false;
         };
-        if rc != "List.concat" || ra.len() != 2 {
+        if ra.len() != 2 {
             return false;
         }
-        let (
-            TermNode::App {
-                callee: g1,
-                args: r1,
-            },
-            TermNode::App {
-                callee: g2,
-                args: r2,
-            },
-        ) = (&ra[0], &ra[1])
-        else {
-            return false;
+        // Each side is `g` applied to `largs` with the appended slot set to the
+        // matching half and every other slot the same variable as in `largs`.
+        let side_ok = |side: &TermNode, repl: usize| -> bool {
+            let TermNode::App {
+                callee: gg,
+                args: gargs,
+            } = side
+            else {
+                return false;
+            };
+            gg == g
+                && gargs.len() == largs.len()
+                && gargs.iter().enumerate().all(|(i, t)| {
+                    if i == pos {
+                        var(t) == Some(repl)
+                    } else {
+                        var(t).is_some() && var(t) == var(&largs[i])
+                    }
+                })
         };
-        g1 == g
-            && g2 == g
-            && r1.len() == 1
-            && r2.len() == 1
-            && matches!((&r1[0], &r2[0]), (TermNode::Var(a2), TermNode::Var(b2)) if a2 == a && b2 == b)
+        side_ok(&ra[0], a) && side_ok(&ra[1], b)
     }
     oriented(&c.lhs, &c.rhs) || oriented(&c.rhs, &c.lhs)
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -279,6 +279,14 @@ pub struct CodegenContext {
     /// runtime codegen after the HIR walker's deletion (W6/Stage-3).
     /// `None` for hand-assembled test contexts that skip `build_context`.
     pub mir_program: Option<crate::ir::mir::MirProgram>,
+    /// Kernel-proved lemmas parsed back from a committed
+    /// `DiscoveredLemmas.lean` (the `--discover` artifact), set by the CLI
+    /// on a normal `aver proof` run when the discovery-surface hash still
+    /// matches. The Lean backend embeds each pinned lemma's text before the
+    /// first law theorem that uses it (re-proving it in the same build) and
+    /// `simp`s over its name (`ProofStrategy::SimpOverLemmas`). Empty unless
+    /// the CLI wired it — discovery feedback is strictly opt-in.
+    pub discovered_lemmas: Vec<crate::codegen::lemma_discovery::CommittedLemma>,
 }
 
 /// Output files from a codegen backend.
@@ -565,6 +573,7 @@ pub fn build_context(
         program_shape,
         resolved_program,
         mir_program,
+        discovered_lemmas: Vec::new(),
     };
     // ProofIR no longer populated here. Pipeline owns the lowerings
     // (`PipelineStage::RefinementLower`, `PipelineStage::ContractLower`);

--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -448,17 +448,28 @@ fn call_or_ctor(e: &Spanned<Expr>) -> Option<(String, Vec<&Spanned<Expr>>)> {
     }
 }
 
-/// Recognize a canonical Peano `+` / truncated `-` (see [`NatArithKind`]).
-fn detect_nat_arith_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatArithKind> {
+/// Param checks + outer `match p0` split shared by the arithmetic recognizers.
+/// Returns `(p0, p1, base_arm_body, succ_binder, succ_arm_body)` for a binary fn
+/// over `peano`'s type whose body matches its FIRST param into the canonical
+/// base / succ(binder) arms; `None` otherwise.
+fn peano_outer_split<'a>(
+    fd: &'a FnDef,
+    peano: &PeanoType,
+) -> Option<(
+    &'a str,
+    &'a str,
+    &'a Spanned<Expr>,
+    &'a str,
+    &'a Spanned<Expr>,
+)> {
     if fd.params.len() != 2 {
         return None;
     }
     let (p0, t0) = &fd.params[0];
     let (p1, t1) = &fd.params[1];
-    if t0 != t1 || &fd.return_type != t0 {
+    if t0 != t1 || &fd.return_type != t0 || t0.trim() != peano.type_name {
         return None;
     }
-    let peano = peano_type_named(ctx, t0)?;
     let ln = crate::codegen::recursion::detect::local_name_of;
     let tail = fd.body.tail_expr()?;
     let Expr::Match { subject, arms, .. } = &tail.node else {
@@ -467,7 +478,6 @@ fn detect_nat_arith_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatArithKind>
     if ln(subject) != Some(p0.as_str()) || arms.len() != 2 {
         return None;
     }
-    // Split the outer match on `p0` into its base / succ(q) arms.
     let mut base_body: Option<&Spanned<Expr>> = None;
     let mut succ_q: Option<&String> = None;
     let mut succ_body: Option<&Spanned<Expr>> = None;
@@ -485,33 +495,54 @@ fn detect_nat_arith_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatArithKind>
             return None;
         }
     }
-    let (base_body, q, succ_body) = (base_body?, succ_q?.as_str(), succ_body?);
+    Some((
+        p0.as_str(),
+        p1.as_str(),
+        base_body?,
+        succ_q?.as_str(),
+        succ_body?,
+    ))
+}
 
-    // Add: `Base -> b` and `Succ(q) -> Succ(op(q, b))`.
+/// True iff `fd` is the canonical Peano addition over `peano`
+/// (`match a { Base -> b; Succ(q) -> Succ(op(q, b)) }`). Takes the `PeanoType`
+/// directly so it needs NO `CodegenContext` — the lemma-discovery layer (which
+/// has only a `ProofLowerInputs` type lookup) uses this to find the monoid `⊕`
+/// for a structural homomorphism conjecture.
+pub(crate) fn is_canonical_add(fd: &FnDef, peano: &PeanoType) -> bool {
+    let Some((_p0, p1, base_body, q, succ_body)) = peano_outer_split(fd, peano) else {
+        return false;
+    };
+    let ln = crate::codegen::recursion::detect::local_name_of;
     let add_succ_ok = call_or_ctor(succ_body).is_some_and(|(c, a)| {
         c == peano.succ_ctor
             && a.len() == 1
             && call_or_ctor(a[0]).is_some_and(|(rc, ra)| {
-                rc == fd.name
-                    && ra.len() == 2
-                    && ln(ra[0]) == Some(q)
-                    && ln(ra[1]) == Some(p1.as_str())
+                rc == fd.name && ra.len() == 2 && ln(ra[0]) == Some(q) && ln(ra[1]) == Some(p1)
             })
     });
-    if ln(base_body) == Some(p1.as_str()) && add_succ_ok {
+    ln(base_body) == Some(p1) && add_succ_ok
+}
+
+/// Recognize a canonical Peano `+` / truncated `-` / `*` (see [`NatArithKind`]).
+fn detect_nat_arith_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatArithKind> {
+    let peano = peano_type_named(ctx, &fd.params.first()?.1)?;
+    if is_canonical_add(fd, &peano) {
         return Some(NatArithKind::Add);
     }
-
-    // Sub (truncated): `Base -> Base` and `Succ(q) -> match b { Base -> a; Succ(r) -> op(q, r) }`.
+    let (p0, p1, base_body, q, succ_body) = peano_outer_split(fd, &peano)?;
+    let ln = crate::codegen::recursion::detect::local_name_of;
     let base_is_base =
         call_or_ctor(base_body).is_some_and(|(c, a)| c == peano.base_ctor && a.is_empty());
+
+    // Sub (truncated): `Base -> Base` and `Succ(q) -> match b { Base -> a; Succ(r) -> op(q, r) }`.
     if base_is_base
         && let Expr::Match {
             subject: inner_subj,
             arms: inner_arms,
             ..
         } = &succ_body.node
-        && ln(inner_subj) == Some(p1.as_str())
+        && ln(inner_subj) == Some(p1)
         && inner_arms.len() == 2
     {
         let mut inner_base_ok = false;
@@ -523,7 +554,7 @@ fn detect_nat_arith_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatArithKind>
             let short = short_ctor(cname);
             if short == peano.base_ctor && binders.is_empty() {
                 // `minus(S q, Z) = S q = p0` (the whole first argument).
-                inner_base_ok = ln(&arm.body) == Some(p0.as_str());
+                inner_base_ok = ln(&arm.body) == Some(p0);
             } else if short == peano.succ_ctor && binders.len() == 1 {
                 let r = binders[0].as_str();
                 inner_succ_ok = call_or_ctor(&arm.body).is_some_and(|(rc, ra)| {
@@ -539,21 +570,19 @@ fn detect_nat_arith_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatArithKind>
     }
 
     // Mul: `Base -> Base` and `Succ(q) -> add(b, op(q, b))` where `add` is itself a
-    // recognized canonical addition. `times x y = match x { Z -> Z; S z -> plus(y,
-    // times(z, y)) }`. The bridge `times a b = a * b` is proved USING the add
-    // bridge, so the renderer must emit the add bridge first.
+    // recognized canonical addition over the same Peano type. `times x y = match
+    // x { Z -> Z; S z -> plus(y, times(z, y)) }`. The bridge `times a b = a * b`
+    // is proved USING the add bridge, so the renderer emits the add bridge first.
     if base_is_base
         && let Some((add_fn, args)) = call_or_ctor(succ_body)
         && args.len() == 2
-        && ln(args[0]) == Some(p1.as_str())
+        && ln(args[0]) == Some(p1)
         && call_or_ctor(args[1]).is_some_and(|(rc, ra)| {
-            rc == fd.name && ra.len() == 2 && ln(ra[0]) == Some(q) && ln(ra[1]) == Some(p1.as_str())
+            rc == fd.name && ra.len() == 2 && ln(ra[0]) == Some(q) && ln(ra[1]) == Some(p1)
         })
         && ctx
             .fn_def_by_name(&add_fn, ctx.active_module_scope().as_deref())
-            .is_some_and(|afd| {
-                afd.name != fd.name && detect_nat_arith_op(afd, ctx) == Some(NatArithKind::Add)
-            })
+            .is_some_and(|afd| afd.name != fd.name && is_canonical_add(afd, &peano))
     {
         return Some(NatArithKind::Mul);
     }

--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -448,20 +448,21 @@ fn call_or_ctor(e: &Spanned<Expr>) -> Option<(String, Vec<&Spanned<Expr>>)> {
     }
 }
 
+/// `(p0, p1, base_arm_body, succ_binder, succ_arm_body)` — the decomposition
+/// [`peano_outer_split`] returns for a canonical binary Peano fn.
+type PeanoSplit<'a> = (
+    &'a str,
+    &'a str,
+    &'a Spanned<Expr>,
+    &'a str,
+    &'a Spanned<Expr>,
+);
+
 /// Param checks + outer `match p0` split shared by the arithmetic recognizers.
 /// Returns `(p0, p1, base_arm_body, succ_binder, succ_arm_body)` for a binary fn
 /// over `peano`'s type whose body matches its FIRST param into the canonical
 /// base / succ(binder) arms; `None` otherwise.
-fn peano_outer_split<'a>(
-    fd: &'a FnDef,
-    peano: &PeanoType,
-) -> Option<(
-    &'a str,
-    &'a str,
-    &'a Spanned<Expr>,
-    &'a str,
-    &'a Spanned<Expr>,
-)> {
+fn peano_outer_split<'a>(fd: &'a FnDef, peano: &PeanoType) -> Option<PeanoSplit<'a>> {
     if fd.params.len() != 2 {
         return None;
     }
@@ -708,11 +709,12 @@ fn detect_nat_compare_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatCompareK
     None
 }
 
-/// Collect the distinct canonical Peano comparison operators a law invokes.
-pub(crate) fn collect_nat_compare_ops_in_law(
+/// Fn names a law invokes directly plus one level of transitive callees —
+/// the shared name-gathering step of the canonical-op collectors below.
+fn law_called_fn_names(
     law: &VerifyLaw,
     ctx: &CodegenContext,
-) -> Vec<NatCompareOp> {
+) -> std::collections::BTreeSet<String> {
     let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     collect_called_fns(&law.lhs, &mut names);
     collect_called_fns(&law.rhs, &mut names);
@@ -723,6 +725,25 @@ pub(crate) fn collect_nat_compare_ops_in_law(
         }
     }
     names.extend(transitive);
+    names
+}
+
+/// Collect the distinct canonical Peano comparison operators a law invokes.
+pub(crate) fn collect_nat_compare_ops_in_law(
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Vec<NatCompareOp> {
+    collect_nat_compare_ops_for_names(&law_called_fn_names(law, ctx), ctx)
+}
+
+/// Canonical Peano comparison operators among an explicit fn-name set —
+/// the name-driven core of [`collect_nat_compare_ops_in_law`]. Also used by
+/// the discovery feedback loop, where a committed lemma can introduce an op
+/// (e.g. `lessEq`) the law itself never mentions.
+pub(crate) fn collect_nat_compare_ops_for_names(
+    names: &std::collections::BTreeSet<String>,
+    ctx: &CodegenContext,
+) -> Vec<NatCompareOp> {
     let mut seen = std::collections::BTreeSet::new();
     names
         .iter()
@@ -742,16 +763,17 @@ pub(crate) fn collect_nat_arith_ops_in_law(
     law: &VerifyLaw,
     ctx: &CodegenContext,
 ) -> Vec<NatArithOp> {
-    let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    collect_called_fns(&law.lhs, &mut names);
-    collect_called_fns(&law.rhs, &mut names);
-    let mut transitive: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    for f in &names {
-        if let Some(fd) = ctx.fn_def_by_name(f, ctx.active_module_scope().as_deref()) {
-            collect_called_fns_in_body(&fd.body, &mut transitive);
-        }
-    }
-    names.extend(transitive);
+    collect_nat_arith_ops_for_names(&law_called_fn_names(law, ctx), ctx)
+}
+
+/// Canonical Peano arithmetic operators among an explicit fn-name set —
+/// the name-driven core of [`collect_nat_arith_ops_in_law`]. Also used by
+/// the discovery feedback loop, where a committed homomorphism lemma can
+/// introduce an op (e.g. `plus`) the law itself never mentions.
+pub(crate) fn collect_nat_arith_ops_for_names(
+    names: &std::collections::BTreeSet<String>,
+    ctx: &CodegenContext,
+) -> Vec<NatArithOp> {
     let mut seen = std::collections::BTreeSet::new();
     names
         .iter()

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -1447,6 +1447,7 @@ mod tests {
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,
+            discovered_lemmas: Vec::new(),
         }
     }
 

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -398,10 +398,15 @@ pub enum QuantifierType {
 pub enum ProofStrategy {
     /// `rfl` / definitional equality — `lhs ≡ rhs` syntactically.
     Reflexive,
-    /// `simp` chain over named lemmas (e.g. `[Int.add_comm,
-    /// Int.mul_comm]`). Legacy draft variant; not yet emitted by
-    /// the lowerer — kept for future use when a strategy wants to
-    /// hand the backend a specific lemma list.
+    /// `simp` chain over named lemmas. The discovery feedback loop
+    /// (`lemma_discovery::committed`) pins this when a committed
+    /// `DiscoveredLemmas.lean` holds kernel-proved lemmas in-scope
+    /// for an `Induction` law: the names are the discovered theorem
+    /// names, and the Lean renderer reuses the induction ladder with
+    /// those lemmas embedded + joined to its simp sets. Pinned by
+    /// the CLI (post-lowering re-pin), never by
+    /// `classify_law_strategy` — discovery feedback is opt-in via
+    /// the committed artifact.
     SimpOverLemmas(Vec<String>),
     /// `∀ a b, f(a, b) = f(b, a)` — commutativity of the law's fn,
     /// whose body reduces to `a <op> b`. The `op` tag lets backends

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5003,6 +5003,94 @@ pub(super) fn cmd_proof(
         }
     }
 
+    // Discovery feedback loop (the `ProofStrategy::SimpOverLemmas` hook):
+    // when a prior `--discover` run committed kernel-proved lemmas for THIS
+    // surface into `<output>/DiscoveredLemmas.lean`, a normal Lean proof run
+    // re-pins each in-scope `Induction` law so the backend embeds the lemmas
+    // (re-proving them in the same `lake build` — the soundness guard) and
+    // `simp`s over them. The cone-hash gate is staleness-only: a stale file
+    // is IGNORED (behaves exactly like no discovery ran), never trusted.
+    // Lean-only — discovery commits no Dafny artifact today.
+    if matches!(backend, super::cli::ProofBackend::Lean) {
+        let lemmas_path = std::path::Path::new(output_dir).join("DiscoveredLemmas.lean");
+        // The cone-hash HEADER (any hash) is what identifies the file as the
+        // discovery artifact at all — a previously-emitted entry root from a
+        // user module that happens to be named `DiscoveredLemmas` has no such
+        // header and is silently ignored, not warned about as "stale".
+        if let Ok(content) = std::fs::read_to_string(&lemmas_path)
+            && content.contains("-- cone-hash:")
+        {
+            let lemmas = {
+                let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
+                let hash_tag = format!(
+                    "-- cone-hash: {}",
+                    aver::codegen::lemma_discovery::discovery_surface_hash(&inputs)
+                );
+                if content.contains(&hash_tag) {
+                    let parsed = aver::codegen::lemma_discovery::parse_committed_lemmas(&content);
+                    // Soundness gate: the texts are embedded VERBATIM into the
+                    // generated Lean, so a block carrying any top-level
+                    // declaration keyword (`axiom`, `set_option`, …) beyond
+                    // its own theorem would join the kernel environment.
+                    // Discovery never emits those — reject the whole artifact
+                    // loudly instead of trusting hand-edited content. (The
+                    // axiom whitelist in `--check`'s universal metric is the
+                    // backstop if anything ever slips through.)
+                    match parsed.iter().find_map(|l| {
+                        aver::codegen::lemma_discovery::forbidden_token_in_lemma(&l.text)
+                            .map(|tok| (l.name.clone(), tok))
+                    }) {
+                        Some((name, tok)) => {
+                            eprintln!(
+                                "{}",
+                                format!(
+                                    "warning: committed discovered lemma `{name}` contains a \
+                                     forbidden declaration token `{tok}` — the artifact was NOT \
+                                     emitted by `aver proof --discover`; ignoring it entirely. \
+                                     Delete {} and re-run `aver proof --discover`.",
+                                    lemmas_path.display()
+                                )
+                                .yellow()
+                            );
+                            Vec::new()
+                        }
+                        None => parsed,
+                    }
+                } else {
+                    eprintln!(
+                        "{}",
+                        "warning: committed discovered lemmas are stale (surface changed) — \
+                         ignored; re-run `aver proof --discover` to refresh"
+                            .yellow()
+                    );
+                    Vec::new()
+                }
+            };
+            if !lemmas.is_empty() {
+                let plan = {
+                    let inputs = aver::codegen::proof_lower::ProofLowerInputs::from_ctx(&ctx);
+                    aver::codegen::lemma_discovery::plan_simp_over_lemma_pins(
+                        &inputs,
+                        &ctx.proof_ir,
+                        &lemmas,
+                    )
+                };
+                if !plan.is_empty() {
+                    aver::codegen::lemma_discovery::apply_simp_over_lemma_pins(
+                        &mut ctx.proof_ir,
+                        &plan,
+                    );
+                    println!(
+                        "lemma feedback: {} committed lemma(s) joined {} law(s) (simp-over-lemmas)",
+                        lemmas.len(),
+                        plan.len()
+                    );
+                }
+                ctx.discovered_lemmas = lemmas;
+            }
+        }
+    }
+
     match backend {
         super::cli::ProofBackend::Lean => {
             cmd_proof_lean(file, output_dir, &mut ctx, verify_mode);
@@ -5610,6 +5698,19 @@ fn lean_universal_proof(dir: &str, sorries: usize) -> bool {
                 continue;
             }
             if let Ok(contents) = std::fs::read_to_string(entry.path()) {
+                // `DiscoveredLemmas.lean` WITH a cone-hash header is the
+                // committed `--discover` ARTIFACT, not an emitted proof file:
+                // lake doesn't build it (it's not a lakefile root), so
+                // theorems scanned from it wouldn't resolve in the
+                // axiom-checker environment — the lemmas that actually joined
+                // a proof are embedded in the entry root and scanned there.
+                // The header check keeps an entry MODULE legitimately named
+                // `DiscoveredLemmas` (whose emitted root has no such header)
+                // in the scan instead of silently zeroing its universal
+                // metric.
+                if name == "DiscoveredLemmas.lean" && contents.contains("-- cone-hash:") {
+                    continue;
+                }
                 for line in contents.lines() {
                     if let Some(rest) = line.strip_prefix("theorem ") {
                         let thm = rest
@@ -5659,17 +5760,47 @@ fn lean_universal_proof(dir: &str, sorries: usize) -> bool {
                 String::from_utf8_lossy(&o.stdout),
                 String::from_utf8_lossy(&o.stderr)
             );
-            // `ofReduceBool` = native_decide (bounded). `sorryAx` = a `sorry`
-            // reached transitively (e.g. a bridge lemma that failed to prove);
-            // the sorry-count gate above already covers the common case, but
-            // checking the axiom set too is belt-and-suspenders against a
-            // proof that depends on a sorried lemma without itself warning.
+            // WHITELIST: every axiom a law theorem depends on must be one of
+            // the three core logical axioms. A blacklist (no `ofReduceBool` =
+            // native_decide, no `sorryAx`) was equivalent while every line of
+            // emitted Lean came from typed IR — but the discovery feedback
+            // loop embeds COMMITTED `DiscoveredLemmas.lean` text verbatim, so
+            // an artifact smuggling e.g. a top-level `axiom` declaration must
+            // flip the metric to false, not slide past a name blacklist. The
+            // output format is `'name' depends on axioms: [a, b]` (or `does
+            // not depend on any axioms`); the two blacklist probes stay as a
+            // belt-and-suspenders floor against output-format drift.
             o.status.success()
+                && lean_axiom_lines_whitelisted(&combined)
                 && !combined.contains("Lean.ofReduceBool")
                 && !combined.contains("sorryAx")
         }
         Err(_) => false,
     }
+}
+
+/// `true` iff every `#print axioms` result line in `output` reports only the
+/// core logical axioms (`propext`, `Classical.choice`, `Quot.sound`). Lines
+/// not matching the `depends on axioms: […]` shape are ignored — the caller's
+/// blacklist probes remain the floor for those.
+fn lean_axiom_lines_whitelisted(output: &str) -> bool {
+    const ALLOWED: [&str; 3] = ["propext", "Classical.choice", "Quot.sound"];
+    for line in output.lines() {
+        let Some(idx) = line.find("depends on axioms:") else {
+            continue;
+        };
+        let list = line[idx + "depends on axioms:".len()..]
+            .trim()
+            .trim_start_matches('[')
+            .trim_end_matches(']');
+        for axiom in list.split(',') {
+            let axiom = axiom.trim();
+            if !axiom.is_empty() && !ALLOWED.contains(&axiom) {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 /// True for the main universal law theorem names emitted by the Lean
@@ -6069,6 +6200,24 @@ mod tests {
     }
 
     #[test]
+    fn lean_axiom_whitelist_rejects_foreign_axioms() {
+        // The universal metric must be a WHITELIST over `#print axioms`
+        // output: only the three core logical axioms pass. A custom axiom
+        // (e.g. smuggled through a tampered DiscoveredLemmas.lean and
+        // referenced transitively by a law's proof) is neither
+        // `Lean.ofReduceBool` nor `sorryAx`, so the old blacklist would have
+        // reported universal:true for a false law.
+        let clean = "'f_law_x' depends on axioms: [propext, Classical.choice, Quot.sound]";
+        let none = "'f_law_x' does not depend on any axioms";
+        let foreign = "'f_law_x' depends on axioms: [propext, cheat]";
+        let native = "'f_law_x' depends on axioms: [Lean.ofReduceBool]";
+        assert!(super::lean_axiom_lines_whitelisted(clean));
+        assert!(super::lean_axiom_lines_whitelisted(none));
+        assert!(!super::lean_axiom_lines_whitelisted(foreign));
+        assert!(!super::lean_axiom_lines_whitelisted(native));
+    }
+
+    #[test]
     fn count_lean_sorries_matches_both_quote_glyphs() {
         // Lean ≤4.15 prints straight quotes, ≥4.17 prints backticks.
         // `sorry` is a non-fatal warning (lake exits 0), so the count is
@@ -6113,6 +6262,7 @@ mod tests {
             resolved_program: aver::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,
+            discovered_lemmas: Vec::new(),
         }
     }
 

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4000,3 +4000,101 @@ fn discover_bounds_decreasing_accumulator_on_drain_when_lake_is_available() {
     }
     let _ = std::fs::remove_dir_all(&output_dir);
 }
+
+/// THE FEEDBACK LOOP (`ProofStrategy::SimpOverLemmas`) — the coverage win
+/// condition, end to end. The law states `plus(length(ys), length(xs)) =
+/// length(append(xs, ys))` — closing it needs the UNSTATED length-into-plus
+/// homomorphism (`length (a ++ b) = plus (length a) (length b)`), which the
+/// induction ladder alone cannot conjure (the `plus` recursion is stuck on a
+/// symbolic first argument, and `omega` sees only opaque atoms). The loop:
+///
+/// 1. baseline `aver proof --check` — builds, but the universal stays `sorry`
+///    (`universal:false`): the honest no-discovery floor;
+/// 2. `aver proof --discover` conjectures AND kernel-proves the homomorphism,
+///    committing it to `DiscoveredLemmas.lean`;
+/// 3. the SAME `aver proof --check` in the SAME output dir now re-pins the
+///    law to `SimpOverLemmas`, embeds + re-proves the lemma, and closes the
+///    universal for real (`universal:true`, zero sorries).
+///
+/// This is discovery moving COVERAGE, not just reach.
+#[test]
+fn discovered_lemmas_close_length_homomorphism_law_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping feedback-loop test: `lake` not available");
+        return;
+    }
+    let source = "module LenHomo\n    intent =\n        \"plus(length ys, length xs) = length(xs ++ ys) — needs the unstated length homomorphism\"\n    effects []\n\n\
+         type Nat\n    Z\n    S(Nat)\n\n\
+         fn length(xs: List<Int>) -> Nat\n    match xs\n        [] -> Nat.Z\n        [y, ..ys] -> Nat.S(length(ys))\n\n\
+         fn plus(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> y\n        Nat.S(z) -> Nat.S(plus(z, y))\n\n\
+         fn append(xs: List<Int>, ys: List<Int>) -> List<Int>\n    List.concat(xs, ys)\n\n\
+         verify length law lenAppendSwap\n    given xs: List<Int> = [[], [1], [1, 2]]\n    given ys: List<Int> = [[], [3]]\n    plus(length(ys), length(xs)) => length(append(xs, ys))\n";
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-feedback-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join("m.av"), source).expect("write m.av");
+    let out = temp_output_dir("aver-feedback-out");
+
+    let check = |label: &str| -> (bool, String) {
+        let run = Command::new(aver_bin)
+            .arg("proof")
+            .arg(src.join("m.av"))
+            .arg("--backend")
+            .arg("lean")
+            .arg("-o")
+            .arg(&out)
+            .arg("--check")
+            .arg("--check-json")
+            .output()
+            .unwrap_or_else(|e| panic!("{label}: aver proof failed to run: {e}"));
+        let json_line = run
+            .stdout
+            .split(|&b| b == b'\n')
+            .rev()
+            .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+            .unwrap_or_else(|| panic!("{label}: no JSON line:\n{}", format_output(&run)))
+            .to_string();
+        let summary: serde_json::Value = serde_json::from_str(&json_line)
+            .unwrap_or_else(|e| panic!("{label}: bad JSON ({e}):\n{json_line}"));
+        (
+            summary["universal"].as_bool().unwrap_or(false),
+            format_output(&run),
+        )
+    };
+
+    // 1. The honest floor: without discovery the universal must NOT close —
+    //    if it ever starts closing, the fixture stopped exercising the loop
+    //    (tighten it) rather than the loop having regressed.
+    let (universal_before, output_before) = check("baseline");
+    assert!(
+        !universal_before,
+        "fixture closes WITHOUT discovery — it no longer exercises the feedback loop:\n{output_before}"
+    );
+
+    // 2. Discover + commit into the same output dir.
+    let discover = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--discover")
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("expected `aver proof --discover` to run");
+    let committed = std::fs::read_to_string(out.join("DiscoveredLemmas.lean")).unwrap_or_default();
+    assert!(
+        committed.contains("length (") && committed.contains("plus (length"),
+        "discovery did not commit the length homomorphism:\n--- DiscoveredLemmas.lean ---\n{committed}\n--- discover output ---\n{}",
+        format_output(&discover)
+    );
+
+    // 3. The win: the SAME check now closes the universal via the committed
+    //    lemma (re-proved in the same build — no trust shortcut).
+    let (universal_after, output_after) = check("with-discovery");
+    assert!(
+        universal_after,
+        "committed discovered lemmas did not close the law (feedback loop broken):\n{output_after}"
+    );
+
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

Discovery stops being a side report and starts **closing laws**. This PR carries the full arc on `discovery-prover-reuse`:

1. **Session-grade discovered-lemma prover** (`987c721e`) — the discovered-lemma Lean template gets the same list-induction ladder as the user-stated-law prover (omega + inner-match split), with **no `sorry` fallback** (discovery stays proved-or-dropped).
2. **REACH baseline runner** (`1b5694be`) — `proof-corpus/discover.sh` counts tasks where discovery kernel-proves ≥1 lemma.
3. **Structural monoid-homomorphism conjecturer** (`fdc871a7`) — synthesizes `g(.., a++b, ..) = ⊕(g(.., a, ..), g(.., b, ..))` directly for any list-recursive Peano-valued fold, bypassing the size-capped enumerator.
4. **The feedback loop** (`49373279`, this PR's main payload) — `ProofStrategy::SimpOverLemmas` wired end-to-end: a normal `aver proof --backend lean` run consumes a committed `DiscoveredLemmas.lean`, re-pins in-scope `Induction` laws, embeds the lemma texts (re-proved in the same `lake build` — the soundness guard), and `simp`s over them with orientation classification (`Forward` / `← name` reversed / embed-only), simp-loop exclusion, dependency closure, and lemma+bridge fast paths.

## Measured coverage wins (baseline vs `--discover` + proof, honest `universal` metric)

- **TIP prod/prop_03** opens → `universal:true` — the stated law needs the unstated `length (a ++ b) = plus (length a) (length b)` homomorphism that discovery conjectures and kernel-proves. First law on the independent TIP corpus closed by discovery.
- **`examples/data/sparse.av` codec roundtrip** opens → `universal:true` via the committed relational chain — the charter layer-3 deferred goal.
- `examples/data/rle.av`: 2 sorries → 1; **zero regressions** across the 20-task homomorphism cluster (3× re-measured).

## Soundness hardening (adversarial review finding, fixed in-PR)

Opening a verbatim-embed channel for committed text made the old blacklist-based universal metric gameable (a smuggled top-level `axiom` is neither `ofReduceBool` nor `sorryAx`). Two-ended fix:
- committed blocks are validated against a deny-list of top-level declaration keywords — any hit rejects the whole artifact loudly;
- `lean_universal_proof` now **whitelists** `{propext, Classical.choice, Quot.sound}` over `#print axioms` output instead of blacklisting.

Plain mode (no committed artifact — all of CI, the default `run.sh`) emits **byte-identical** Lean/Dafny output, verified by a full 154-file two-backend diff sweep against the pre-change baseline.

## Tooling & tests

- `proof-corpus/run.sh` gains `DISCOVER=1` (discovery into the same output dir before each Lean check); the default run stays the honest no-discovery baseline — the delta is discovery's measured value.
- New lake-gated e2e test pins the full win condition (fixture must NOT close without discovery, must close after).
- lib 821/821, proof_spec discovery suite 15/15, `proof_export_builds` 16/16, identity guardrails, clippy clean (default + `wasm,wasip2`), fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)