### PR TITLE
proof(discovery): część A — earlier proved user laws feed later laws (no --discover)

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -288,6 +288,137 @@ fn discovered_support_lines(
     out
 }
 
+/// Lean names of every pure program fn — the membership universe for
+/// orientation / scope / source-fn analysis.
+fn program_fn_lean_names(ctx: &CodegenContext) -> BTreeSet<String> {
+    ctx.modules
+        .iter()
+        .flat_map(|m| m.fn_defs.iter())
+        .chain(ctx.fn_defs.iter())
+        .filter(|fd| crate::codegen::common::is_pure_fn(fd))
+        .map(|fd| aver_name_to_lean(&fd.name))
+        .collect()
+}
+
+/// The discovery feedback loop, część A: earlier proved user `verify … law`
+/// blocks in the same file, usable as `simp` rewrite rules for THIS law.
+///
+/// Eligibility mirrors the committed-lemma planner: a sibling joins only if
+/// every program fn its statement mentions is in this law's proof cone ∪
+/// subject (keeps the simp set focused and bounds loop surface). Only blocks
+/// EARLIER in source are eligible — source order is emit order, so the
+/// referenced theorem precedes this one, and the strict ordering makes cyclic
+/// lemma use impossible by construction. Each result is a `reference`
+/// (`embed = false`): the theorem is already emitted, so only its NAME joins
+/// the simp set; the synthesized statement text drives orientation + loop
+/// analysis. Soundness rides on the same guard as everything else — if the
+/// referenced law itself only `sorry`s, this law's proof inherits `sorryAx`
+/// and the universal metric reports false.
+fn earlier_law_lemmas(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Vec<crate::codegen::lemma_discovery::CommittedLemma> {
+    use crate::ast::{TopLevel, VerifyKind};
+    let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
+    let cone = crate::codegen::proof_lower::LawProofCone::compute(law, &vb.fn_name, &inputs);
+    let mut scope: BTreeSet<String> = cone
+        .pure_fns()
+        .iter()
+        .map(|fd| aver_name_to_lean(&fd.name))
+        .collect();
+    scope.insert(aver_name_to_lean(&vb.fn_name));
+
+    let program_index: std::collections::BTreeMap<String, String> = program_fn_lean_names(ctx)
+        .into_iter()
+        .map(|l| (l.clone(), l))
+        .collect();
+
+    let mut out = Vec::new();
+    for item in &ctx.items {
+        let TopLevel::Verify(prev) = item else {
+            continue;
+        };
+        // Stop at the consumer law itself; only earlier blocks are eligible.
+        if prev.line == vb.line && prev.fn_name == vb.fn_name {
+            break;
+        }
+        let VerifyKind::Law(prev_law) = &prev.kind else {
+            continue;
+        };
+        let Some((name, stmt)) =
+            crate::codegen::lean::toplevel::law_as_lemma_statement(prev, prev_law, ctx)
+        else {
+            continue;
+        };
+        let text = format!("theorem {name} : {stmt} := by");
+        let mentions = crate::codegen::lemma_discovery::mentioned_fns(&text, &program_index);
+        if mentions.is_empty() || !mentions.is_subset(&scope) {
+            continue;
+        }
+        out.push(crate::codegen::lemma_discovery::CommittedLemma::reference(
+            name, text,
+        ));
+    }
+    out
+}
+
+/// Fast-path `simp` set for the feedback emit: the committed pinned lemmas
+/// (`committed_names` → `ctx.discovered_lemmas`) PLUS the eligible earlier
+/// sibling laws, run together through `lemma_discovery::simp_entries` so the
+/// loop-exclusion sees the whole set (a committed Reversed rule + a sibling
+/// Forward rule that would cycle is dropped — a simp loop is an uncatchable
+/// maxHeartbeats build error). Siblings feed ONLY this fast path, never the
+/// induction-arm simp sets, so a law that already closed on its ladder keeps
+/// that ladder byte-identical as the fallback.
+fn fastpath_simp_entries(
+    ctx: &CodegenContext,
+    committed_names: &[String],
+    siblings: &[crate::codegen::lemma_discovery::CommittedLemma],
+) -> Vec<String> {
+    let program_fns = program_fn_lean_names(ctx);
+    let mut pool: Vec<&crate::codegen::lemma_discovery::CommittedLemma> = ctx
+        .discovered_lemmas
+        .iter()
+        .filter(|l| committed_names.contains(&l.name))
+        .collect();
+    pool.extend(siblings.iter());
+    if pool.is_empty() {
+        return Vec::new();
+    }
+    crate::codegen::lemma_discovery::simp_entries(&pool, &program_fns)
+}
+
+/// Program fns mentioned by the committed pins AND the sibling laws — drives
+/// the bridge scan (`lean_nat_lift_support`'s `extra_fns`) so a Peano op a
+/// homomorphism introduces (`plus` rewriting into a law that only said
+/// `length`) still gets its `= a + b` bridge for the fast path's `omega`.
+fn feedback_source_fns(
+    ctx: &CodegenContext,
+    committed_names: &[String],
+    siblings: &[crate::codegen::lemma_discovery::CommittedLemma],
+) -> BTreeSet<String> {
+    // Lean-name → SOURCE-name: the bridge collector (`collect_nat_arith_ops_
+    // for_names`) resolves source names via `fn_def_by_name`, so the projection
+    // must land on source names (not Lean names).
+    let lean_to_source: std::collections::BTreeMap<String, String> = ctx
+        .modules
+        .iter()
+        .flat_map(|m| m.fn_defs.iter())
+        .chain(ctx.fn_defs.iter())
+        .filter(|fd| crate::codegen::common::is_pure_fn(fd))
+        .map(|fd| (aver_name_to_lean(&fd.name), fd.name.clone()))
+        .collect();
+    let mut out = discovered_lemma_source_fns(ctx, committed_names);
+    for s in siblings {
+        out.extend(crate::codegen::lemma_discovery::mentioned_fns(
+            &s.text,
+            &lean_to_source,
+        ));
+    }
+    out
+}
+
 enum VariantKind {
     Leaf,
     DirectRec,
@@ -494,11 +625,14 @@ fn emit_list_induction(
     let rev_ops = crate::codegen::proof_recognize::collect_rev_ops_in_law(law, ctx);
     let (rev_support, rev_simp) = lean_rev_support(&rev_ops, &law_uid);
     simp_defs.extend(rev_simp);
-    // Discovery feedback: the simp-oriented pinned lemmas join the induction
-    // arms' simp sets as rewrite rules (e.g. a count/length homomorphism
-    // collapsing `g (a ++ b)` so the inductive hypothesis lines up). The
-    // full `discovered` set is embedded; only the oriented subset rewrites.
+    // Discovery feedback: the COMMITTED pinned lemmas (from `--discover`) join
+    // the induction arms' simp sets as rewrite rules (e.g. a count/length
+    // homomorphism collapsing `g (a ++ b)`). EARLIER sibling user laws
+    // (część A) feed ONLY the fast path below, never the arms — so a law that
+    // already closed on its ladder keeps that ladder byte-identical here.
     let discovered_simp = discovered_simp_entries(ctx, discovered);
+    let siblings = earlier_law_lemmas(vb, law, ctx);
+    let fast_simp = fastpath_simp_entries(ctx, discovered, &siblings);
     simp_defs.extend(discovered_simp.iter().cloned());
     let simp_list = simp_defs.into_iter().collect::<Vec<_>>().join(", ");
     let target_lean = &intro_names[target_idx];
@@ -579,33 +713,36 @@ fn emit_list_induction(
 
     let mut proof_lines = vec![format!("  intro {}", intro_names.join(" "))];
     let mut support_lines = Vec::new();
-    if discovered.is_empty() {
+    // Feedback mode fires when any usable rewrite rule is in scope — a
+    // committed pin OR an eligible earlier sibling law (`fast_simp` carries
+    // both). With neither, the emit is byte-identical to the pre-feedback
+    // ladder.
+    if fast_simp.is_empty() {
         let (nil_arm, cons_arm) = mk_arms(None);
         proof_lines.push(format!("  induction {} with", target_lean));
         proof_lines.push(format!("  {nil_arm}"));
         proof_lines.push(format!("  {cons_arm}"));
     } else {
-        // Discovery feedback (`SimpOverLemmas`): before inducting, try closing
-        // the goal OUTRIGHT with the pinned lemmas — many laws that NEED an
-        // auxiliary homomorphism are a pure rewrite once it exists (e.g.
-        // `length (x ++ y) = plus (length y) (length x)` under the length
-        // homomorphism + the `plus = +` bridge + `omega`). Two `simp only`
-        // shapes: lemmas+bridges alone (the goal already matches the lemma),
-        // then with the law's def unfolds added (a wrapper like `appendNat`
-        // must unfold to `++` before the lemma can fire) — minus the bridged
-        // fns' own defs (def + bridge in one simp call sticks). Both paths
-        // are sound (`simp only` rewrites with proved equations, `omega`
-        // decides), so a miss just falls through to the induction ladder,
-        // which is the exact pre-feedback emit with the lemmas joined to its
-        // simp sets. Coverage can only grow.
-        let lemma_fns = discovered_lemma_source_fns(ctx, discovered);
+        // Discovery feedback: before inducting, try closing the goal OUTRIGHT
+        // with the available lemmas — many laws that NEED an auxiliary
+        // homomorphism are a pure rewrite once it exists (e.g. `length (x ++
+        // y) = plus (length y) (length x)` under the length homomorphism + the
+        // `plus = +` bridge + `omega`). Two `simp only` shapes: lemmas+bridges
+        // alone (the goal already matches a lemma), then with the law's def
+        // unfolds added (a wrapper like `appendNat` must unfold to `++` before
+        // the lemma can fire) — minus the bridged fns' own defs (def + bridge
+        // in one simp call sticks). Both paths are sound, so a miss falls
+        // through to the induction ladder; the ladder's arm simp sets carry
+        // only the COMMITTED pins (`discovered_simp`), keeping a previously-
+        // closing ladder unchanged. Coverage can only grow.
+        let lemma_fns = feedback_source_fns(ctx, discovered, &siblings);
         let (arith_support, arith_bridges, bridged_fns) =
             lean_nat_lift_support(law, ctx, &law_uid, &lemma_fns);
-        let mut fast_lemmas: Vec<String> = discovered_simp.clone();
+        let mut fast_lemmas: Vec<String> = fast_simp.clone();
         fast_lemmas.extend(arith_bridges.iter().cloned());
         let fast_unfolds: BTreeSet<String> = law_simp_defs(ctx, vb, law)
             .into_iter()
-            .chain(discovered_simp.iter().cloned())
+            .chain(fast_simp.iter().cloned())
             .chain(arith_bridges.iter().cloned())
             .filter(|n| !bridged_fns.contains(n))
             .collect();
@@ -651,9 +788,13 @@ fn emit_simple_induction(
     discovered: &[String],
 ) -> Option<AutoProof> {
     let mut simp_defs: BTreeSet<String> = law_simp_defs(ctx, vb, law);
-    // Discovery feedback: the simp-oriented pinned lemmas join the arm simp
-    // sets (see `emit_list_induction`); empty for a plain `Induction` pin.
+    // Discovery feedback: COMMITTED pins join the arm simp sets (see
+    // `emit_list_induction`); EARLIER sibling laws (część A) feed only the
+    // fast path. Empty `fast_simp` (no committed, no eligible sibling) keeps
+    // the emit byte-identical to the pre-feedback ladder.
     let discovered_simp = discovered_simp_entries(ctx, discovered);
+    let siblings = earlier_law_lemmas(vb, law, ctx);
+    let fast_simp = fastpath_simp_entries(ctx, discovered, &siblings);
     simp_defs.extend(discovered_simp.iter().cloned());
     let simp_list = simp_defs.into_iter().collect::<Vec<_>>().join(", ");
     let target_lean = &intro_names[target_idx];
@@ -670,7 +811,7 @@ fn emit_simple_induction(
         aver_name_to_lean(&vb.fn_name),
         aver_name_to_lean(&law.name)
     );
-    let lemma_fns = discovered_lemma_source_fns(ctx, discovered);
+    let lemma_fns = feedback_source_fns(ctx, discovered, &siblings);
     let (arith_support, arith_bridges, bridged_fns) =
         lean_nat_lift_support(law, ctx, &law_uid, &lemma_fns);
 
@@ -760,8 +901,8 @@ fn emit_simple_induction(
     }
 
     let mut proof_lines = vec![format!("  intro {}", intro_parts.join(" "))];
-    if arith_bridges.is_empty() && discovered_simp.is_empty() {
-        // No arithmetic to lift, no discovered lemmas: plain structural
+    if arith_bridges.is_empty() && fast_simp.is_empty() {
+        // No arithmetic to lift, no committed/sibling lemmas: plain structural
         // induction.
         proof_lines.push(format!("  induction {} with", target_lean));
         proof_lines.extend(arm_lines.into_iter().map(|a| format!("  {a}")));
@@ -776,17 +917,17 @@ fn emit_simple_induction(
         // (and a second def-unfolding variant is tried — see
         // `emit_list_induction`); the bridged fns' own defs stay out of the
         // `simp only` calls (def + bridge in one call sticks).
-        let mut fast_lemmas: Vec<String> = discovered_simp.clone();
+        let mut fast_lemmas: Vec<String> = fast_simp.clone();
         fast_lemmas.extend(arith_bridges.iter().cloned());
         proof_lines.push("  first".to_string());
         proof_lines.push(format!(
             "  | (simp only [{}] <;> omega)",
             fast_lemmas.join(", ")
         ));
-        if !discovered_simp.is_empty() {
+        if !fast_simp.is_empty() {
             let fast_unfolds: BTreeSet<String> = law_simp_defs(ctx, vb, law)
                 .into_iter()
-                .chain(discovered_simp.iter().cloned())
+                .chain(fast_simp.iter().cloned())
                 .chain(arith_bridges.iter().cloned())
                 .filter(|n| !bridged_fns.contains(n))
                 .collect();

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -2245,6 +2245,112 @@ fn emit_verify_law_block(
     (lines.join("\n"), case_index_start + vb.cases.len())
 }
 
+/// The discovery feedback loop, część A: a proved earlier `verify … law`
+/// becomes a lemma for later laws. Returns `(theorem_name, "lhs = rhs")` for a
+/// law usable as a `simp` rewrite rule, mirroring `emit_verify_law_block`'s
+/// name + lhs/rhs template computation EXACTLY (so the referenced name and the
+/// orientation-analysis text match the actually-emitted theorem). `None` for
+/// shapes that aren't a clean equational rewrite rule: trace-projection LHS
+/// (no theorem emitted), a `when` premise (a conditional equation, not a plain
+/// rewrite), or a refinement-lifted given (the statement quantifies over a
+/// subtype — not a useful rewrite over the carrier). The name is the SAME
+/// `<fn>_eq_<spec>` / `<fn>_law_<name>` the block emits, so a later law's
+/// `simp [<name>]` resolves against the earlier theorem already in scope.
+pub(crate) fn law_as_lemma_statement(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Option<(String, String)> {
+    if law.when.is_some() {
+        return None;
+    }
+    if crate::codegen::common::law_lhs_has_trace_projection(&law.lhs) {
+        return None;
+    }
+    // A referenceable lemma must actually be EMITTED as a `∀`-theorem with the
+    // name we synthesize below — otherwise a later law's `simp [<name>]` hits
+    // an unknown identifier and fails the whole file's build. Decline exactly
+    // the cases `emit_verify_law_block` skips the universal theorem:
+    //   - no givens → no quantified theorem (only concrete samples);
+    //   - `skip_universal` — a singleton-domain const-RHS law (vacuous/false
+    //     universal) or a law calling a fuel-bounded recursive helper (the
+    //     auto-prover can't close it, only per-sample lemmas are emitted).
+    // Mirrors the guard in `emit_verify_law_block` (kept in sync by the
+    // część A regression test); a false decline only forgoes a helper, never
+    // references a missing theorem.
+    if law.givens.is_empty() {
+        return None;
+    }
+    let ir_strategy_closes_const_rhs = ctx
+        .symbol_table
+        .fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name))
+        .and_then(|fn_id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        })
+        .is_some_and(|t| {
+            !matches!(
+                t.strategy,
+                crate::ir::ProofStrategy::Induction { .. }
+                    | crate::ir::ProofStrategy::SimpOverLemmas(_)
+                    | crate::ir::ProofStrategy::BackendDispatch
+                    | crate::ir::ProofStrategy::Sorry
+            )
+        });
+    let singleton_const_rhs = !ir_strategy_closes_const_rhs
+        && crate::codegen::common::all_givens_are_singletons(law)
+        && crate::codegen::common::law_rhs_is_independent_of_givens(law);
+    let unclassified = crate::codegen::common::unclassified_fn_names(ctx);
+    if singleton_const_rhs || crate::codegen::common::law_calls_unclassified_fn(law, &unclassified)
+    {
+        return None;
+    }
+    let fn_name = aver_name_to_lean(&vb.fn_name);
+    let law_name = aver_name_to_lean(&law.name);
+    let spec_ref = canonical_spec_ref(&vb.fn_name, law, ctx);
+    let theorem_base = match &spec_ref {
+        Some(spec_ref) => format!(
+            "{}_eq_{}",
+            fn_name,
+            aver_name_to_lean(&spec_ref.spec_fn_name)
+        ),
+        None => format!("{}_law_{}", fn_name, law_name),
+    };
+    let law_lhs = crate::codegen::common::rewrite_effectful_calls_in_law(
+        &law.lhs,
+        law,
+        |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
+        crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
+    );
+    let law_rhs = crate::codegen::common::rewrite_effectful_calls_in_law(
+        &law.rhs,
+        law,
+        |n| ctx.fn_def_by_name(n, ctx.active_module_scope().as_deref()),
+        crate::codegen::common::OracleInjectionMode::LemmaBindingProjected,
+    );
+    // A refinement-lifted given would change the quantifier type (the theorem
+    // reads `∀ a : Natural, …`); such a statement isn't a plain rewrite rule
+    // over the carrier, so decline rather than mis-orient it.
+    for given in &law.givens {
+        if crate::codegen::common::refinement_lift_for_given(
+            &given.name,
+            &given.type_name,
+            &law_lhs,
+            &law_rhs,
+            ctx,
+        )
+        .is_some()
+        {
+            return None;
+        }
+    }
+    let lhs = emit_expr_legacy(&law_lhs, ctx, None);
+    let rhs = emit_expr_legacy(&law_rhs, ctx, None);
+    Some((theorem_base, format!("{lhs} = {rhs}")))
+}
+
 fn law_theorem_prop(
     law: &VerifyLaw,
     ctx: &CodegenContext,

--- a/src/codegen/lemma_discovery/committed.rs
+++ b/src/codegen/lemma_discovery/committed.rs
@@ -29,13 +29,39 @@ use crate::ast::{TopLevel, VerifyKind};
 use crate::codegen::proof_lower::{LawProofCone, ProofLowerInputs};
 use crate::ir::proof_ir::ProofIR;
 
-/// One kernel-proved lemma parsed back from a committed
-/// `DiscoveredLemmas.lean`: its theorem name plus the verbatim Lean text
-/// (statement AND tactic) to embed into the generated proof project.
+/// A lemma available to a law's proof: its theorem name plus Lean text
+/// (statement, and for embedded ones the tactic too). Two provenances flow
+/// through the same orientation / loop-exclusion / simp-selection machinery:
+///
+/// - **embedded** (`embed = true`) — a kernel-proved lemma parsed back from a
+///   committed `DiscoveredLemmas.lean`; its full text is written into the
+///   generated proof project (re-proved in the same `lake build`).
+/// - **reference** (`embed = false`) — an already-proved EARLIER user
+///   `verify … law` in the same file (część A): its theorem is already
+///   emitted, so only the NAME joins later laws' simp sets; `text` carries
+///   just the synthesized `theorem <name> : <lhs> = <rhs>` statement, used
+///   for orientation + loop analysis, never written out.
 #[derive(Debug, Clone)]
 pub struct CommittedLemma {
     pub name: String,
     pub text: String,
+    /// Write `text` verbatim into the proof project (`true`), or only
+    /// reference `name` in simp sets because it is already emitted (`false`).
+    pub embed: bool,
+}
+
+impl CommittedLemma {
+    /// A reference to an already-emitted theorem (an earlier user law) — name
+    /// plus synthesized statement, never written out. `text` should be a
+    /// well-formed `theorem <name> : <stmt> := by` head so the shared
+    /// orientation / loop analysis reads it like any other lemma.
+    pub fn reference(name: String, text: String) -> Self {
+        Self {
+            name,
+            text,
+            embed: false,
+        }
+    }
 }
 
 /// Parse a committed `DiscoveredLemmas.lean` into its theorem blocks. A block
@@ -61,6 +87,7 @@ pub fn parse_committed_lemmas(content: &str) -> Vec<CommittedLemma> {
             current = Some(CommittedLemma {
                 name,
                 text: line.to_string(),
+                embed: true,
             });
         } else if let Some(block) = current.as_mut() {
             block.text.push('\n');
@@ -697,6 +724,7 @@ verify count law countPlusConcat
             let lemmas = vec![CommittedLemma {
                 name: "free_floating".to_string(),
                 text: "theorem free_floating (a : Nat) : a + 0 = a := by simp".to_string(),
+                embed: true,
             }];
             assert!(plan_simp_over_lemma_pins(inputs, &ir, &lemmas).is_empty());
         });

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -3558,20 +3558,28 @@ fn proof_export_lake_builds_red_black_tree_after_singleton_and_fuel_gates() {
     // lemmas remain (concrete inputs stay decidable). Lake build
     // succeeds; `aver verify` runtime hits every declared case.
     //
-    // Sorry budget 2: the `detect.rs` resolved-subject fix (which lets
+    // Sorry budget 1 (was 2): the `detect.rs` resolved-subject fix (which lets
     // Dafny/Z3 prove the Peano-fold homomorphism family) also admits
     // `size` / `toSorted`'s structural recursion into the proof subset, so
-    // their two universals now EMIT a `∀ … induction t with …` proof rather
-    // than gating to sample-only. On Lean those still can't close — the
+    // their two universals EMIT a `∀ … induction t with …` proof rather than
+    // gating to sample-only. On Lean those can't close on the ladder — the
     // `__fuel`-wrapped recursion needs a fuel-saturation lemma the auto
-    // template lacks — so the tactic chain honestly falls through to
-    // `sorry` (lake stays green; the claim is visibly unproven, not
-    // dropped). Z3 supplies that induction automatically, which is why the
-    // same two laws DO prove on the Dafny backend.
+    // template lacks.
+    //
+    // The drop 2→1 is the discovery feedback loop, część A: `toSorted_law_
+    // sizePreserved` now closes its TACTIC BLOCK via the fast path `simp only
+    // [size_law_equalsSortedLen] <;> omega`, referencing the earlier sibling
+    // theorem — so it no longer emits its OWN `sorry`. This is a textual-count
+    // drop only, NOT a new genuine universal: `size_law_equalsSortedLen` still
+    // `sorry`s, so the consumer inherits `sorryAx` and the `universal` metric
+    // correctly stays false for both (verified via `#print axioms`). The
+    // honest coverage number is unchanged; only the weaker sorry-count metric
+    // moved. Z3 supplies the missing induction automatically, which is why the
+    // same laws DO prove on the Dafny backend.
     assert_proof_builds_with_sorry_budget(
         "examples/data/red_black_tree.av",
         "aver-proof-red-black-tree",
-        2,
+        1,
     );
 }
 
@@ -4097,4 +4105,97 @@ fn discovered_lemmas_close_length_homomorphism_law_when_lake_is_available() {
 
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
+}
+
+/// THE FEEDBACK LOOP, część A — an already-proved EARLIER user `verify … law`
+/// feeds a later law's proof, with NO `--discover` step at all. The file holds
+/// two laws over `length`: `lengthHomo` (the homomorphism `length (append xs
+/// ys) = plus (length xs) (length ys)`, provable on its own by induction) and,
+/// AFTER it, `lengthAppendSwap` (`length (append xs ys) = plus (length ys)
+/// (length xs)`), which needs the homomorphism plus commutativity. The later
+/// law must close ONLY because the earlier one is in scope:
+///
+/// 1. `lengthAppendSwap` ALONE (its own file) must NOT close — it has no
+///    helper, so the universal stays `sorry`;
+/// 2. the same law AFTER `lengthHomo` in one file must close `universal:true`
+///    — the backend references the earlier theorem in the later proof's `simp`
+///    set (verified by inspecting the emitted Lean), no discovery artifact
+///    involved.
+///
+/// This is the user-written-decomposition half of the loop: a hard law closes
+/// because an earlier proved law is available as a lemma.
+#[test]
+fn earlier_user_law_feeds_later_law_proof_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping część A test: `lake` not available");
+        return;
+    }
+    let nat_helpers = "type Nat\n    Z\n    S(Nat)\n\n\
+         fn length(xs: List<Int>) -> Nat\n    match xs\n        [] -> Nat.Z\n        [y, ..ys] -> Nat.S(length(ys))\n\n\
+         fn plus(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> y\n        Nat.S(z) -> Nat.S(plus(z, y))\n\n\
+         fn append(xs: List<Int>, ys: List<Int>) -> List<Int>\n    match xs\n        [] -> ys\n        [z, ..zs] -> List.concat([z], append(zs, ys))\n\n";
+    let swap_law = "verify length law lengthAppendSwap\n    given xs: List<Int> = [[], [1], [1, 2]]\n    given ys: List<Int> = [[], [3]]\n    length(append(xs, ys)) => plus(length(ys), length(xs))\n";
+    let homo_law = "verify length law lengthHomo\n    given xs: List<Int> = [[], [1], [1, 2]]\n    given ys: List<Int> = [[], [3]]\n    length(append(xs, ys)) => plus(length(xs), length(ys))\n\n";
+
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let universal_of = |source: &str, prefix: &str| -> (bool, String, String) {
+        let src = temp_output_dir(&format!("{prefix}-src"));
+        std::fs::create_dir_all(&src).expect("create src dir");
+        std::fs::write(src.join("m.av"), source).expect("write m.av");
+        let out = temp_output_dir(&format!("{prefix}-out"));
+        let run = Command::new(aver_bin)
+            .arg("proof")
+            .arg(src.join("m.av"))
+            .arg("--backend")
+            .arg("lean")
+            .arg("-o")
+            .arg(&out)
+            .arg("--check")
+            .arg("--check-json")
+            .output()
+            .expect("aver proof ran");
+        let json = run
+            .stdout
+            .split(|&b| b == b'\n')
+            .rev()
+            .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+            .unwrap_or_else(|| panic!("{prefix}: no JSON line:\n{}", format_output(&run)))
+            .to_string();
+        let summary: serde_json::Value =
+            serde_json::from_str(&json).unwrap_or_else(|e| panic!("{prefix}: bad JSON ({e})"));
+        let emitted = std::fs::read_to_string(out.join("M.lean")).unwrap_or_default();
+        let _ = std::fs::remove_dir_all(&src);
+        let _ = std::fs::remove_dir_all(&out);
+        (
+            summary["universal"].as_bool().unwrap_or(false),
+            format_output(&run),
+            emitted,
+        )
+    };
+
+    // 1. swap law alone — no helper in scope → must stay open.
+    let solo =
+        format!("module M\n    intent = \"solo\"\n    effects []\n\n{nat_helpers}{swap_law}");
+    let (solo_universal, solo_out, _) = universal_of(&solo, "aver-partA-solo");
+    assert!(
+        !solo_universal,
+        "swap law closed WITHOUT a helper — the fixture no longer exercises część A:\n{solo_out}"
+    );
+
+    // 2. helper FIRST, then swap law — must close via the earlier theorem.
+    let paired = format!(
+        "module M\n    intent = \"paired\"\n    effects []\n\n{nat_helpers}{homo_law}{swap_law}"
+    );
+    let (paired_universal, paired_out, emitted) = universal_of(&paired, "aver-partA-paired");
+    assert!(
+        paired_universal,
+        "swap law did not close with the earlier homomorphism law in scope (część A broken):\n{paired_out}"
+    );
+    // The later proof must actually reference the earlier law's theorem — proof
+    // that the close came from the sibling lemma, not some incidental tactic.
+    assert!(
+        emitted.contains("length_law_lengthAppendSwap")
+            && emitted.contains("simp only [length_law_lengthHomo"),
+        "the swap law's proof does not simp over the earlier homomorphism theorem:\n{emitted}"
+    );
 }


### PR DESCRIPTION
## What

The user-written half of the lemma-discovery feedback loop, stacked on #447. A proved **earlier** `verify … law` in the same file now becomes a `simp` lemma for later `Induction`-strategy laws — so a hard law closes because an earlier law (a helper the user, or an LLM, wrote) is in scope. **No `--discover`, no committed artifact: this works from plain source.**

This is the mechanism the [feedback-loop tweet](https://github.com/jasisz/aver) describes as "an LLM can decompose a hard theorem into small helper laws, directly in Aver, never touching generated Lean or Dafny" — część A is the substrate that makes survivors compound: a proved helper is permanently available to the next law.

## How

- `toplevel::law_as_lemma_statement` synthesizes an earlier law's **exact** emitted theorem name (`<fn>_eq_<spec>` / `<fn>_law_<name>`) + `lhs = rhs` statement via the same renderers the emit uses, and declines any law whose universal theorem is **not** emitted (no givens, `when`, trace-projection, refinement-lift, or `skip_universal`) — referencing a non-emitted theorem would poison the file's build.
- `earlier_law_lemmas` gathers those for **strictly earlier** blocks (source order = emit order ⇒ acyclic by construction), cone-filtered, as `CommittedLemma::reference` (`embed = false` — already emitted, only the NAME joins the simp set).
- Siblings feed **only the fast path** (through the shared `simp_entries` loop-exclusion); arm ladders stay committed-only, so a law that already closed keeps its ladder byte-identical as the fallback.

## Soundness

Same guard as the committed path: a referenced earlier law that itself `sorry`s propagates `sorryAx` to the consumer → the `universal` metric (axiom whitelist) reports it false. **część A cannot manufacture a false `universal:true`** — adversarially verified with a live `#print axioms` repro (13-agent review, 2 findings confirmed, 8 dismissed).

## Tests

- New e2e test: the swap law `length(append xs ys) = plus (length ys)(length xs)` does **not** close alone, but closes `universal:true` when the homomorphism law precedes it; the emitted proof is shown to `simp` over the earlier theorem.
- `proof_export_builds` 16/16 (json/rle/law_auto/grok unchanged), full `proof_spec` 100/100, lib 821/821, clippy + fmt clean.
- `red_black_tree` sorry budget 2→1: `toSorted_law_sizePreserved` closes its tactic block via the earlier `size_law_equalsSortedLen` reference (count-only — the referenced law still `sorry`s, both stay `universal:false`; honest coverage unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)