### PR TITLE
proof-corpus: decomposed/ — LLM closes OPEN TIP tasks via helper-law decomposition

### DIFF
--- a/proof-corpus/README.md
+++ b/proof-corpus/README.md
@@ -24,6 +24,10 @@ per-PR; coverage = a number from `run.sh`, informational.
   `tip/LICENSE.TIP` (upstream license retained for attribution; the repo itself
   stays MIT).
 - `handwritten/` — license-clean canonical tasks we authored.
+- `decomposed/` — OPEN `tip/` tasks closed by **LLM-written helper laws** via
+  the discovery feedback loop (część A). A SEPARATE "loop reach" metric, NOT the
+  baseline — `run.sh` excludes it so the coverage number stays "unaided on bare
+  `tip/`". See `decomposed/README.md`.
 - `run.sh` — the coverage runner (lives with the corpus so it travels if the
   corpus ever graduates to its own repo).
 

--- a/proof-corpus/decomposed/README.md
+++ b/proof-corpus/decomposed/README.md
@@ -1,0 +1,55 @@
+# decomposed/ — LLM-written helper-law decompositions of TIP tasks
+
+Each file here is a **bare TIP task from `../tip/` that the unaided engine leaves
+OPEN**, plus one or more **helper `verify ... law` blocks written by an LLM** so
+the target law closes through the discovery feedback loop (część A: a proved
+earlier law becomes a `simp` lemma for a later one). They demonstrate the
+loop's reach — *what an LLM can close by decomposition, with the pipeline as a
+fail-closed judge* — NOT the automated baseline.
+
+## This is a SEPARATE metric — it does NOT touch the baseline
+
+`../run.sh` measures what Aver proves **unaided** on the bare `tip/` tasks
+(`coverage (union)`). It explicitly **excludes this directory** (`find ... -not
+-path '*/decomposed/*'`), so adding files here never inflates that number. The
+bare task in `tip/` is left untouched; the honest baseline stays honest.
+
+The number here answers a different question: *given the loop, how many
+otherwise-open TIP theorems can an LLM close by writing helper laws?*
+
+## Integrity rules (every file here satisfies them)
+
+- The **target law statement, the function definitions, the `intent`, and the
+  module name are byte-for-byte the bare `tip/` original** — only earlier
+  `verify ... law` helper blocks were added, before the target.
+- **Every law in the file — helpers included — is kernel-clean** (`aver proof
+  --backend lean --check` reports `"universal": true`, `#print axioms` over
+  `{propext, Classical.choice, Quot.sound}` only, zero `sorry`). A helper that
+  only `sorry`s would propagate `sorryAx` and the whole file would report
+  `universal: false` — so a helper can never be a trust shortcut. The judge,
+  not the model's confidence, decides.
+- `proof_spec.rs` re-verifies every file here stays `universal: true`
+  (`decomposed_tip_tasks_stay_universal_when_lake_is_available`).
+
+## Provenance
+
+The underlying problems are translated from **TIP (Tons of Inductive
+Problems)**, `github.com/tip-org/benchmarks`, BSD-3-Clause — see
+`../tip/PROVENANCE.md` and `../tip/LICENSE.TIP`. The helper laws are our
+authorship; the surrounding program is the upstream-derived task verbatim.
+
+## Contents (4)
+
+| file | target | bare-`tip/` status | what the decomposition added |
+|------|--------|--------------------|------------------------------|
+| `isaplanner/prop_03.av` | `count n xs ≤ count n (xs++ys)` | OPEN (frontier) | a cone-local count-monotonicity helper |
+| `prod/prop_25.av` | `even(length(x++y)) = even(length y + length x)` | OPEN (frontier) | length-homomorphism + `plus` commutativity |
+| `prod/prop_03.av` | `length(x++y) = plus(length y)(length x)` | Dafny-only → also Lean-genuine | the two "right" laws of `plus` |
+| `isaplanner/prop_75.av` | `count n [x] + count n xs = count n (x::xs)` | Dafny-only → also Lean-genuine | count-homomorphism + `plus` commutativity |
+
+Two of the four (`isaplanner/prop_03`, `prod/prop_25`) move the **union
+frontier** — the unaided engine (auto-mode, `--discover`, and single-shot
+Dafny/Z3) closes none of them. The other two upgrade a Dafny-only (Z3-automated)
+task to a kernel-checked Lean proof. Each leaf helper bottoms out in something
+Aver's auto-prover discharges on its own (structural induction / homomorphism /
+the canonical-Peano bridge) — the loop is exactly as strong as that leaf reach.

--- a/proof-corpus/decomposed/isaplanner/prop_03.av
+++ b/proof-corpus/decomposed/isaplanner/prop_03.av
@@ -1,0 +1,46 @@
+module Prop03
+    intent =
+        "TIP isaplanner prop_03: count n xs <= count n (xs ++ ys)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match eqNat(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+fn lessEq(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> lessEq(z, x2)
+
+fn countMonotone(n: Nat, xs: List<Nat>, ys: List<Nat>) -> Bool
+    lessEq(count(n, xs), count(n, List.concat(xs, ys)))
+
+verify count law countConcatMonotone
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[Nat.Z], [Nat.Z, Nat.S(Nat.Z)]]
+    given ys: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z)]]
+    lessEq(count(n, xs), count(n, List.concat(xs, ys))) => true
+
+verify countMonotone law countAppendMonotone
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[Nat.Z], [Nat.Z, Nat.S(Nat.Z)], []]
+    given ys: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z)], []]
+    countMonotone(n, xs, ys) => true

--- a/proof-corpus/decomposed/isaplanner/prop_75.av
+++ b/proof-corpus/decomposed/isaplanner/prop_75.av
@@ -1,0 +1,46 @@
+module Prop75
+    intent =
+        "TIP isaplanner prop_75: count n xs + count n [m] = count n (m :: xs)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match eqNat(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+verify plus law plusComm
+    given a: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given b: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(a, b) => plus(b, a)
+
+verify count law countHomo
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    given ys: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    count(n, List.concat(xs, ys)) => plus(count(n, xs), count(n, ys))
+
+verify count law countConsSplit
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given m: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z, Nat.S(Nat.Z)]]
+    plus(count(n, xs), count(n, [m])) => count(n, List.concat([m], xs))

--- a/proof-corpus/decomposed/prod/prop_03.av
+++ b/proof-corpus/decomposed/prod/prop_03.av
@@ -1,0 +1,37 @@
+module Prop03
+    intent =
+        "TIP prod prop_03: length(x ++ y) = length(y) + length(x)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(x: List<Int>) -> Nat
+    match x
+        [] -> Nat.Z
+        [y, ..xs] -> Nat.S(length(xs))
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn append(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+verify plus law plusZeroRight
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, Nat.Z) => x
+
+verify plus law plusSuccRight
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    plus(x, Nat.S(y)) => Nat.S(plus(x, y))
+
+verify length law lengthAppend
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[], [2], [4, 5]]
+    length(append(x, y)) => plus(length(y), length(x))

--- a/proof-corpus/decomposed/prod/prop_25.av
+++ b/proof-corpus/decomposed/prod/prop_25.av
@@ -1,0 +1,40 @@
+module Prop25
+    intent =
+        "TIP prod prop_25: even(length(x ++ y)) = even(length y + length x)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(x: List<Int>) -> Nat
+    match x
+        [] -> Nat.Z
+        [y, ..xs] -> Nat.S(length(xs))
+
+fn even(x: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(y) -> match y
+            Nat.Z -> false
+            Nat.S(z) -> even(z)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+verify length law lengthConcatHomo
+    given x: List<Int> = [[1], [2, 3], [4, 5, 6]]
+    given y: List<Int> = [[7], [8, 9], [0]]
+    length(List.concat(x, y)) => plus(length(x), length(y))
+
+verify plus law plusComm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, y) => plus(y, x)
+
+verify even law evenLengthConcat
+    given x: List<Int> = [[1], [2, 3], [4, 5, 6]]
+    given y: List<Int> = [[7], [8, 9], [0]]
+    even(length(List.concat(x, y))) => even(plus(length(y), length(x)))

--- a/proof-corpus/discover.sh
+++ b/proof-corpus/discover.sh
@@ -32,7 +32,9 @@ fi
 tasks_with=0
 total_lemmas=0
 total=0
-for f in $(find "$ROOT" -name '*.av' | sort); do
+# Exclude decomposed/ (LLM helper-augmented copies — a separate metric; see
+# decomposed/README.md). Reach is measured on the bare tip/ tasks.
+for f in $(find "$ROOT" -name '*.av' -not -path '*/decomposed/*' | sort); do
   [ -e "$f" ] || continue
   total=$((total + 1))
   out="$(mktemp -d)"

--- a/proof-corpus/run.sh
+++ b/proof-corpus/run.sh
@@ -71,7 +71,11 @@ lean=0
 dafny=0
 union=0
 total=0
-for f in $(find "$ROOT" -name '*.av' | sort); do
+# `decomposed/` holds LLM helper-law-augmented copies of OPEN tip/ tasks (a
+# SEPARATE "loop reach" metric, see decomposed/README.md). Excluded here so the
+# baseline `coverage (union)` stays "what the engine proves UNAIDED on bare
+# tip/" — counting the augmented copies would double-count + inflate it.
+for f in $(find "$ROOT" -name '*.av' -not -path '*/decomposed/*' | sort); do
   [ -e "$f" ] || continue
   total=$((total + 1))
   l=$(proves "$f" lean)

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4199,3 +4199,63 @@ fn earlier_user_law_feeds_later_law_proof_when_lake_is_available() {
         "the swap law's proof does not simp over the earlier homomorphism theorem:\n{emitted}"
     );
 }
+
+/// The `proof-corpus/decomposed/` artifacts: OPEN bare-`tip/` TIP tasks that an
+/// LLM closed by writing helper `verify ... law` blocks (część A / the loop).
+/// Each must stay `universal:true` on its own merits — every law in the file,
+/// helpers included, kernel-clean (no `sorry`, axiom set ⊆ {propext,
+/// Classical.choice, Quot.sound}). This guards the feedback loop AND the
+/// auto-prover's leaf reach from regressing: if a future change stops closing
+/// any helper, its file drops to universal:false and this test fails loudly.
+/// Distinct from the corpus coverage runner — these are NOT counted in the
+/// baseline (run.sh excludes decomposed/); they are the loop-reach record.
+#[test]
+fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping decomposed-corpus test: `lake` not available");
+        return;
+    }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let tasks = [
+        "proof-corpus/decomposed/isaplanner/prop_03.av",
+        "proof-corpus/decomposed/isaplanner/prop_75.av",
+        "proof-corpus/decomposed/prod/prop_03.av",
+        "proof-corpus/decomposed/prod/prop_25.av",
+    ];
+    for task in tasks {
+        let out = temp_output_dir(&format!(
+            "aver-decomposed-{}",
+            task.rsplit('/').next().unwrap().trim_end_matches(".av")
+        ));
+        let run = Command::new(aver_bin)
+            .current_dir(&repo_root)
+            .arg("proof")
+            .arg(task)
+            .arg("--backend")
+            .arg("lean")
+            .arg("-o")
+            .arg(&out)
+            .arg("--check")
+            .arg("--check-json")
+            .output()
+            .unwrap_or_else(|e| panic!("{task}: aver proof failed to run: {e}"));
+        let json = run
+            .stdout
+            .split(|&b| b == b'\n')
+            .rev()
+            .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+            .unwrap_or_else(|| panic!("{task}: no JSON line:\n{}", format_output(&run)));
+        let summary: serde_json::Value =
+            serde_json::from_str(json).unwrap_or_else(|e| panic!("{task}: bad JSON ({e})"));
+        assert_eq!(
+            summary["universal"].as_bool(),
+            Some(true),
+            "{task}: decomposed artifact must stay universal:true (every law, helpers \
+             included, kernel-clean). A drop means część A or an auto-prover leaf \
+             regressed.\n{}",
+            format_output(&run)
+        );
+        let _ = std::fs::remove_dir_all(&out);
+    }
+}


### PR DESCRIPTION
## What

A measured demonstration of the feedback loop's thesis: **an LLM closes OPEN TIP theorems by writing helper laws in Aver, never touching generated Lean/Dafny, with the pipeline as a fail-closed judge.**

`proof-corpus/decomposed/` holds 4 bare-`tip/` tasks the unaided engine leaves OPEN, each plus LLM-written helper `verify ... law` blocks so the target closes via część A (a proved earlier law becomes a `simp` lemma for a later one).

## The experiment (pre-registered, honest)

15 currently-OPEN TIP tasks were pre-registered (anti-cherry-pick) and attacked by one agent each, running the loop: **decompose → `aver verify` cheap sample filter (ms) → `aver proof --check` (lake) → judge on `universal:true` → keep only kernel-clean helpers → iterate (≤6 builds)**. Result: **4/15 closed**, each then **independently re-verified** (not the agent's self-report):

| task | bare-`tip/` status | independent verdict | integrity |
|------|--------------------|---------------------|-----------|
| `isaplanner/prop_03` | **union-OPEN (frontier)** | `universal:true` | 0 orig lines changed, +1 helper |
| `prod/prop_25` | **union-OPEN (frontier)** | `universal:true` | 0 changed, +2 |
| `prod/prop_03` | Dafny-only | `universal:true` | 0 changed, +2 |
| `isaplanner/prop_75` | Dafny-only | `universal:true` | 0 changed, +2 |

Two **move the union frontier** — nothing unaided (auto-mode, `--discover`, single-shot Z3) closes them. Two upgrade a Z3-automated task to a kernel-checked Lean proof.

## Does NOT touch the baseline

`run.sh` / `discover.sh` now exclude `*/decomposed/*`, so `coverage (union)` stays **57/154** ("what the engine proves UNAIDED on bare `tip/`"). The augmented copies are a SEPARATE "loop reach" metric, never double-counted. The bare tasks in `tip/` are untouched.

## Integrity (verified independently, not self-reported)

Every file: target law statement + fn defs + intent + module name byte-for-byte the bare original (0 lines changed); only earlier helper verify-laws added. Every law incl. helpers is kernel-clean (`universal:true`, axioms ⊆ {propext, Classical.choice, Quot.sound}, no `sorry`) — a sorry'd helper would propagate `sorryAx` and fail the whole file, so a helper can never be a trust shortcut. `proof_spec::decomposed_tip_tasks_stay_universal` re-checks all four.

## Honest read of the 11 losses

Not expressibility — every law is statable. The walls map the **auto-prover's leaf reach**: część A injects sibling lemmas only into the top-level fast-path (not induction arms, blocking count-rev / length-rev); no generalizing-induction (take/drop); append-on-symbolic-2nd-arg (even-comm); and one corpus bug surfaced — `isaplanner/prop_16` is a FALSE universal (a dropped `xs = nil` premise masked by a nil-only given domain; the pipeline correctly refused). Each is a concrete, fixable prover improvement that would multiplicatively widen the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)