### PR TITLE
proof-corpus: fix isaplanner/prop_16 — it stated a FALSE universal

### DIFF
--- a/proof-corpus/tip/isaplanner/prop_16.av
+++ b/proof-corpus/tip/isaplanner/prop_16.av
@@ -1,6 +1,11 @@
 module Prop16
     intent =
         "TIP isaplanner prop_16: if xs = nil then last(cons(x, xs)) = x."
+        "The premise xs = nil makes cons(x, xs) = [x], so the faithful"
+        "obligation is last([x]) = x. The earlier encoding stated an"
+        "UNCONDITIONAL last(cons(x, xs)) = x and hid its falseness behind a"
+        "nil-only given domain — a false universal (counterexample:"
+        "last([1] ++ [2, 3]) = 3, not 1). Corrected to the xs = nil instance."
     effects []
 
 type Nat
@@ -16,5 +21,4 @@ fn last(xs: List<Nat>) -> Nat
 
 verify last law lastSingleton
     given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
-    given xs: List<Nat> = [[], [], []]
-    last(List.concat([x], xs)) => x
+    last([x]) => x


### PR DESCRIPTION
## What

`tip/isaplanner/prop_16` stated `last(cons(x, xs)) = x` quantified over **all** `xs`, with the falseness hidden behind a nil-only given domain — a false universal (counterexample: `last([1] ++ [2,3]) = 3`). The honest `universal` metric correctly refused it (the fail-closed pipeline never produced a false `universal:true`), so it sat as a permanently-open "loss" that was actually a translation bug.

TIP isaplanner prop_16 is the **conditional** `xs = nil ==> last(cons x xs) = x`. Under that premise `cons(x, xs) = [x]`, so the faithful obligation is `last([x]) = x` — restated as exactly that. Now genuinely proves on **both** backends (Lean `universal:true`, Dafny passed / 0 axioms), so the bare-corpus baseline ticks **57 → 58**.

## How it surfaced

The manual-decomposition experiment (#449): the agent attacking prop_16 proved the *old* statement false in Lean (`example : ¬ (∀ x xs, last ([x] ++ xs) = x)`) rather than fabricating a proof — exactly the "the model's confidence doesn't matter, the pipeline decides" property. A nice incidental: the loop doubles as a benchmark-bug finder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)