### PR TITLE
proof(discovery): część C — arm-injection of Forward sibling laws (closes count-rev, length-rev)

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -327,7 +327,8 @@ fn earlier_law_lemmas(
         .iter()
         .map(|fd| aver_name_to_lean(&fd.name))
         .collect();
-    scope.insert(aver_name_to_lean(&vb.fn_name));
+    let subject = aver_name_to_lean(&vb.fn_name);
+    scope.insert(subject.clone());
 
     let program_index: std::collections::BTreeMap<String, String> = program_fn_lean_names(ctx)
         .into_iter()
@@ -353,12 +354,25 @@ fn earlier_law_lemmas(
         };
         let text = format!("theorem {name} : {stmt} := by");
         let mentions = crate::codegen::lemma_discovery::mentioned_fns(&text, &program_index);
-        if mentions.is_empty() || !mentions.is_subset(&scope) {
+        if mentions.is_empty() {
             continue;
         }
-        out.push(crate::codegen::lemma_discovery::CommittedLemma::reference(
-            name, text,
-        ));
+        // Eligibility: either the sibling stays entirely inside the consumer's
+        // proof cone (the conservative rule), OR it mentions the consumer's
+        // SUBJECT fn — the strongest "this decomposes THIS law" signal, which
+        // also lets a decomposition INTRODUCE a new combinator. A count-homo
+        // helper `count n (a++b) = plus (count n a)(count n b)` mentions
+        // `plus` (outside count-rev's cone {count,rev,eqNat}) but shares the
+        // subject `count`, so it must be admitted — that `plus` is exactly the
+        // combinator the decomposition needs, and its `= a+b` bridge is
+        // synthesized downstream. Tight enough to stay relevant (a length-homo
+        // in a count file shares neither cone nor subject → rejected); loop
+        // safety is handled separately by `simp_entries`.
+        if mentions.is_subset(&scope) || mentions.contains(&subject) {
+            out.push(crate::codegen::lemma_discovery::CommittedLemma::reference(
+                name, text,
+            ));
+        }
     }
     out
 }
@@ -682,31 +696,32 @@ fn emit_list_induction(
     // The split variant covers the same residual under an inner Bool/enum
     // match (`try` so a goal with nothing to bridge still reaches `omega`).
     // All branches are sound, so each can only ADD closures.
-    let mk_arms = |bridges: Option<&str>| -> (String, String) {
+    // Build the nil/cons arms over an explicit `arm_simp`/`arm_split` set, with
+    // the trailing `| sorry` only when `with_sorry`. część C uses this to emit
+    // TWO ladders: ladderA over the committed-only set WITHOUT sorry (so it
+    // THROWS on an open arm and `first` falls through) and ladderB over the
+    // committed + Forward-sibling set WITH sorry (the honest building floor).
+    let mk_arms = |arm_simp: &str,
+                   arm_split: &str,
+                   bridges: Option<&str>,
+                   with_sorry: bool|
+     -> (String, String) {
         let nil_bridge = bridges
-            .map(|b| format!(" | (simp [{d}]; simp only [{b}] <;> omega)", d = simp_list))
+            .map(|b| format!(" | (simp [{arm_simp}]; simp only [{b}] <;> omega)"))
             .unwrap_or_default();
         let cons_bridge = bridges
-            .map(|b| {
-                format!(
-                    " | (simp_all [{d}]; simp only [{b}] <;> omega)",
-                    d = simp_list
-                )
-            })
+            .map(|b| format!(" | (simp_all [{arm_simp}]; simp only [{b}] <;> omega)"))
             .unwrap_or_default();
         let split_bridge = bridges
             .map(|b| format!(" <;> (try simp only [{b}])"))
             .unwrap_or_default();
+        let tail = if with_sorry { " | sorry" } else { "" };
         (
             format!(
-                "| nil => first | (simp [{d}]; done) | (simp [{d}]; omega){nil_bridge} | (simp only [{s}]; split <;> simp_all [{d}]{split_bridge} <;> omega) | sorry",
-                d = simp_list,
-                s = split_set
+                "| nil => first | (simp [{arm_simp}]; done) | (simp [{arm_simp}]; omega){nil_bridge} | (simp only [{arm_split}]; split <;> simp_all [{arm_simp}]{split_bridge} <;> omega){tail}"
             ),
             format!(
-                "| cons head tail ih => first | (simp_all [{d}]; done) | (simp_all [{d}]; omega){cons_bridge} | (simp only [{s}]; split <;> simp_all [{d}]{split_bridge} <;> omega) | sorry",
-                d = simp_list,
-                s = split_set
+                "| cons head tail ih => first | (simp_all [{arm_simp}]; done) | (simp_all [{arm_simp}]; omega){cons_bridge} | (simp only [{arm_split}]; split <;> simp_all [{arm_simp}]{split_bridge} <;> omega){tail}"
             ),
         )
     };
@@ -718,7 +733,7 @@ fn emit_list_induction(
     // both). With neither, the emit is byte-identical to the pre-feedback
     // ladder.
     if fast_simp.is_empty() {
-        let (nil_arm, cons_arm) = mk_arms(None);
+        let (nil_arm, cons_arm) = mk_arms(&simp_list, &split_set, None, true);
         proof_lines.push(format!("  induction {} with", target_lean));
         proof_lines.push(format!("  {nil_arm}"));
         proof_lines.push(format!("  {cons_arm}"));
@@ -731,10 +746,8 @@ fn emit_list_induction(
         // alone (the goal already matches a lemma), then with the law's def
         // unfolds added (a wrapper like `appendNat` must unfold to `++` before
         // the lemma can fire) — minus the bridged fns' own defs (def + bridge
-        // in one simp call sticks). Both paths are sound, so a miss falls
-        // through to the induction ladder; the ladder's arm simp sets carry
-        // only the COMMITTED pins (`discovered_simp`), keeping a previously-
-        // closing ladder unchanged. Coverage can only grow.
+        // in one simp call sticks). Both sound, so a miss falls through to the
+        // induction ladder.
         let lemma_fns = feedback_source_fns(ctx, discovered, &siblings);
         let (arith_support, arith_bridges, bridged_fns) =
             lean_nat_lift_support(law, ctx, &law_uid, &lemma_fns);
@@ -751,7 +764,29 @@ fn emit_list_induction(
         } else {
             Some(arith_bridges.join(", "))
         };
-        let (nil_arm, cons_arm) = mk_arms(bridge_set.as_deref());
+
+        // część C — ARM injection of Forward siblings. Some laws need the
+        // helper applied INSIDE the cons arm, not just at the top level (e.g.
+        // `count n xs = count n (rev xs)`: the cons goal `count n (rev t ++
+        // [h])` only collapses if the count-homomorphism rewrites in-arm).
+        // The fast-path (committed + ALL siblings, Reversed included) is tried
+        // first; then ladderA over the COMMITTED-only arm set WITHOUT a sorry
+        // — so a previously-closing ladder closes here IDENTICALLY, but an open
+        // arm THROWS and `first` falls to ladderB. ladderB injects the Forward
+        // siblings into the arms (Reversed stay fast-path-only — an unfold rule
+        // mixed with the fn's own def in an arm can loop, and a simp loop is an
+        // uncatchable maxHeartbeats build error) and carries the sorry floor.
+        // Forward homomorphisms CONSUME appends as they rewrite, so they
+        // terminate in `simp_all`; the loop-exclusion in `simp_entries` already
+        // dropped any cyclic forward/reversed pair. When no Forward sibling
+        // adds anything beyond the committed arm set, stay single-ladder
+        // (byte-identical to the committed-only feedback emit).
+        let arm_forward_siblings: Vec<String> = fast_simp
+            .iter()
+            .filter(|e| !e.starts_with("← ") && !discovered_simp.contains(*e))
+            .cloned()
+            .collect();
+
         proof_lines.push("  first".to_string());
         proof_lines.push(format!(
             "  | (simp only [{}] <;> omega)",
@@ -761,9 +796,35 @@ fn emit_list_induction(
             "  | (simp only [{}] <;> omega)",
             fast_unfolds.into_iter().collect::<Vec<_>>().join(", ")
         ));
-        proof_lines.push(format!("  | (induction {} with", target_lean));
-        proof_lines.push(format!("     {nil_arm}"));
-        proof_lines.push(format!("     {cons_arm})"));
+        if arm_forward_siblings.is_empty() {
+            // No in-arm sibling to add: one committed-only ladder, with sorry.
+            let (nil_arm, cons_arm) = mk_arms(&simp_list, &split_set, bridge_set.as_deref(), true);
+            proof_lines.push(format!("  | (induction {} with", target_lean));
+            proof_lines.push(format!("     {nil_arm}"));
+            proof_lines.push(format!("     {cons_arm})"));
+        } else {
+            // ladderA: committed-only arms, NO sorry (throws → ladderB).
+            let (nil_a, cons_a) = mk_arms(&simp_list, &split_set, bridge_set.as_deref(), false);
+            proof_lines.push(format!("  | (induction {} with", target_lean));
+            proof_lines.push(format!("     {nil_a}"));
+            proof_lines.push(format!("     {cons_a})"));
+            // ladderB: committed + Forward siblings in the arms, WITH sorry.
+            let simp_b = {
+                let mut v: Vec<String> = simp_list.split(", ").map(String::from).collect();
+                v.extend(arm_forward_siblings.iter().cloned());
+                v.retain(|s| !s.is_empty());
+                v.join(", ")
+            };
+            let split_b = if simp_b.is_empty() {
+                "List.cons_append".to_string()
+            } else {
+                format!("{simp_b}, List.cons_append")
+            };
+            let (nil_b, cons_b) = mk_arms(&simp_b, &split_b, bridge_set.as_deref(), true);
+            proof_lines.push(format!("  | (induction {} with", target_lean));
+            proof_lines.push(format!("     {nil_b}"));
+            proof_lines.push(format!("     {cons_b})"));
+        }
         support_lines.extend(discovered_support_lines(ctx, vb, law, discovered));
         support_lines.extend(arith_support);
     }

--- a/src/codegen/lemma_discovery/committed.rs
+++ b/src/codegen/lemma_discovery/committed.rs
@@ -205,11 +205,27 @@ pub enum SimpDirection {
 /// ladder needs peeled, and loops against the fn's own def unfold.
 pub fn simp_orientation(text: &str, program_fns: &BTreeSet<String>) -> Option<SimpDirection> {
     let stmt = statement_body(text)?;
-    if program_fns.contains(&head_token(stmt)) {
+    let rhs = split_after_top_eq(stmt);
+    // A Forward rule is usable only if it does not GROW the term — if the RHS
+    // textually contains the whole LHS (`dbl x = idNat (dbl x)`), rewriting
+    // LHS→RHS re-exposes the LHS and `simp` never terminates (a maxHeartbeats
+    // BUILD error `first` cannot catch). The `simp_entries` loop-exclusion
+    // only drops forward/reversed PAIRS, not a single self-growing forward
+    // rule — so reject it here. The shrinking REVERSED direction (RHS→LHS) is
+    // still safe and is tried next.
+    let lhs = rhs.map(|r| {
+        let end = stmt.len() - r.len() - 1; // strip the `=` between lhs and rhs
+        stmt[..end].trim()
+    });
+    let forward_grows = matches!((lhs, rhs), (Some(l), Some(r)) if !l.is_empty() && r.contains(l));
+    if program_fns.contains(&head_token(stmt)) && !forward_grows {
         return Some(SimpDirection::Forward);
     }
-    let rhs = split_after_top_eq(stmt)?;
-    if program_fns.contains(&head_token(rhs)) {
+    let rhs = rhs?;
+    // Symmetric guard for the reversed direction: a self-growing reversed rule
+    // (LHS contains the RHS) would loop the other way.
+    let reversed_grows = matches!(lhs, Some(l) if !rhs.trim().is_empty() && l.contains(rhs.trim()));
+    if program_fns.contains(&head_token(rhs)) && !reversed_grows {
         return Some(SimpDirection::Reversed);
     }
     None
@@ -670,6 +686,29 @@ verify count law countPlusConcat
             simp_orientation(
                 "theorem t5 (x0 : List Nat) : ((x0 ++ x0) ++ x0) = (x0 ++ (x0 ++ x0)) := by\n  simp",
                 &fns
+            ),
+            None
+        );
+        // SELF-GROWING forward rule (`dbl x = idNat (dbl x)`, RHS contains the
+        // whole LHS): rewriting LHS→RHS never terminates, so Forward is
+        // forbidden — but the shrinking REVERSED direction (RHS head `idNat` is
+        // a program fn, LHS does not contain the RHS) is safe.
+        let dfns: BTreeSet<String> = ["dbl", "idNat"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(
+            simp_orientation(
+                "theorem t6 (x : Nat) : dbl x = idNat (dbl x) := by\n  simp",
+                &dfns
+            ),
+            Some(SimpDirection::Reversed)
+        );
+        // A reflexive equation (`loopy x = loopy x`) grows in BOTH directions
+        // (each side contains the other), so neither direction is a usable
+        // rewrite — dropped.
+        let efns: BTreeSet<String> = ["loopy"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(
+            simp_orientation(
+                "theorem t7 (x : Nat) : loopy x = loopy x := by\n  rfl",
+                &efns
             ),
             None
         );

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4259,3 +4259,85 @@ fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
         let _ = std::fs::remove_dir_all(&out);
     }
 }
+
+/// część C — ARM injection of Forward sibling laws. Some laws need a helper
+/// applied INSIDE the induction cons-arm, not just at the top-level fast path:
+/// `count n xs = count n (rev xs)` only closes if the count-homomorphism
+/// rewrites `count n (rev t ++ [h])` within the arm. część A (fast-path only)
+/// leaves these open; część C adds a second ladder whose arms carry the
+/// Forward siblings (Reversed stay fast-path-only — loop safety). Two checks:
+///
+/// 1. count-rev closes when a count-homomorphism helper precedes it (the
+///    homo is used in-arm; it also INTRODUCES `plus`, exercising the
+///    subject-sharing cone relaxation — `plus` is outside count-rev's cone but
+///    the helper shares the subject `count`);
+/// 2. length-rev closes via a CHAIN — length-homo, then a length-rev-invariant
+///    whose OWN cons-arm needs the length-homo sibling, then the target.
+///
+/// Both are union-OPEN frontier TIP shapes (isaplanner/prop_52, prod/prop_06)
+/// that the manual experiment (#449) could NOT close before część C.
+#[test]
+fn part_c_arm_injection_closes_in_arm_helpers_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping część C test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let nat = "type Nat\n    Z\n    S(Nat)\n\n";
+    let plus = "fn plus(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> y\n        Nat.S(z) -> Nat.S(plus(z, y))\n\n";
+
+    let count_rev = format!(
+        "module M\n    intent = \"count-rev via in-arm homo\"\n    effects []\n\n{nat}\
+         fn eqNat(x: Nat, y: Nat) -> Bool\n    match x\n        Nat.Z -> match y\n            Nat.Z -> true\n            Nat.S(z) -> false\n        Nat.S(x2) -> match y\n            Nat.Z -> false\n            Nat.S(y2) -> eqNat(x2, y2)\n\n\
+         fn count(x: Nat, y: List<Nat>) -> Nat\n    match y\n        [] -> Nat.Z\n        [z, ..ys] -> match eqNat(x, z)\n            true -> Nat.S(count(x, ys))\n            false -> count(x, ys)\n\n{plus}\
+         fn rev(x: List<Nat>) -> List<Nat>\n    match x\n        [] -> []\n        [y, ..xs] -> List.concat(rev(xs), [y])\n\n\
+         verify count law countHomo\n    given n: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given xs: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z]]\n    given ys: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z)]]\n    count(n, List.concat(xs, ys)) => plus(count(n, xs), count(n, ys))\n\n\
+         verify count law countRev\n    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]\n    given xs: List<Nat> = [[], [Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.Z]]\n    count(n, xs) => count(n, rev(xs))\n"
+    );
+
+    let length_rev = format!(
+        "module M\n    intent = \"length-rev via chain\"\n    effects []\n\n{nat}\
+         fn length(xs: List<Int>) -> Nat\n    match xs\n        [] -> Nat.Z\n        [y, ..ys] -> Nat.S(length(ys))\n\n{plus}\
+         fn append(x: List<Int>, y: List<Int>) -> List<Int>\n    match x\n        [] -> y\n        [z, ..xs] -> List.concat([z], append(xs, y))\n\n\
+         fn rev(x: List<Int>) -> List<Int>\n    match x\n        [] -> []\n        [y, ..ys] -> append(rev(ys), [y])\n\n\
+         verify length law lengthHomo\n    given x: List<Int> = [[1], [2, 3]]\n    given y: List<Int> = [[4], [5, 6]]\n    length(append(x, y)) => plus(length(x), length(y))\n\n\
+         verify length law lengthRevInv\n    given x: List<Int> = [[], [1], [1, 2, 3]]\n    length(rev(x)) => length(x)\n\n\
+         verify length law revAppendLength\n    given x: List<Int> = [[], [1], [1, 2, 3]]\n    given y: List<Int> = [[], [2], [4, 5]]\n    length(rev(append(x, y))) => plus(length(x), length(y))\n"
+    );
+
+    let check_universal = |source: &str, label: &str| {
+        let src = temp_output_dir(&format!("aver-partc-{label}-src"));
+        std::fs::create_dir_all(&src).expect("src dir");
+        std::fs::write(src.join("m.av"), source).expect("write");
+        let out = temp_output_dir(&format!("aver-partc-{label}-out"));
+        let run = Command::new(aver_bin)
+            .arg("proof")
+            .arg(src.join("m.av"))
+            .arg("--backend")
+            .arg("lean")
+            .arg("-o")
+            .arg(&out)
+            .arg("--check")
+            .arg("--check-json")
+            .output()
+            .expect("aver proof ran");
+        let json = run
+            .stdout
+            .split(|&b| b == b'\n')
+            .rev()
+            .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+            .unwrap_or_else(|| panic!("{label}: no JSON:\n{}", format_output(&run)));
+        let summary: serde_json::Value =
+            serde_json::from_str(json).unwrap_or_else(|e| panic!("{label}: bad JSON ({e})"));
+        assert_eq!(
+            summary["universal"].as_bool(),
+            Some(true),
+            "{label}: część C must close this in-arm-helper law universal:true\n{}",
+            format_output(&run)
+        );
+        let _ = std::fs::remove_dir_all(&src);
+        let _ = std::fs::remove_dir_all(&out);
+    };
+    check_universal(&count_rev, "count-rev");
+    check_universal(&length_rev, "length-rev");
+}


### PR DESCRIPTION
## What

Closes the **two hardest losses** from the manual-decomposition experiment (#449) — both union-OPEN TIP frontier shapes that nothing unaided closes:
- `isaplanner/prop_52` — `count n xs = count n (rev xs)` (count-rev)
- `prod/prop_06` — `length(rev(x++y)) = length x + length y` (length-rev)

części A fed sibling helper laws to the top-level fast path only. But some laws need the helper applied **inside the induction cons-arm** (`count n (rev t ++ [h])` only collapses if the count-homomorphism rewrites within the arm). część C adds that.

## How

**Two-ladder feedback emit** (`emit_list_induction`): `first | fastpath1 | fastpath2 | ladderA | ladderB`.
- `ladderA` — committed-only arms, **no `| sorry`** → a closing law closes here identically to części A; an open arm throws so `first` falls to ladderB.
- `ladderB` — committed + **Forward-sibling** arms, with the sorry floor. Reversed (`← name`) siblings stay fast-path-only (an unfold rule + the fn's def in an arm can loop; a simp loop is an *uncatchable* maxHeartbeats build error). Forward homomorphisms consume appends as they rewrite → terminating.
- No Forward sibling to add → single ladder, byte-identical to części A.

**Relaxed cone** (`earlier_law_lemmas`): admit a sibling if its fns ⊆ the consumer's cone **OR** it mentions the consumer's **subject** fn — so a decomposition may INTRODUCE a combinator (count-homomorphism mentions `plus`, outside count-rev's cone, but shares subject `count`). Stays relevant (a length-homo in a count file shares neither → rejected).

**Self-loop guard** (`simp_orientation`, defense in depth): a Forward rule whose RHS contains the whole LHS (`dbl x = idNat (dbl x)`) grows unboundedly under simp → Forward rejected, shrinking Reversed tried instead. Closes the one gap the adversarial review flagged.

## The bigger picture

This directly **widens the LLM-loop's reach**: the manual experiment (#449) lost count-rev and length-rev precisely because część A couldn't inject helpers in-arm. With część C, re-running that decomposition closes them. Fixing the auto-prover's leaf reach multiplicatively expands what the loop can prove — the thesis from the loss analysis, now demonstrated.

## Verification

- `proof_spec::part_c_arm_injection_closes_in_arm_helpers` pins count-rev + length-rev (the latter via a 3-law CHAIN where a helper's own arm needs an earlier sibling).
- Full `proof_spec` **102/102** (json 116-law, rle, law_auto, grok, red_black_tree — no regression), lib 821/821, clippy + fmt clean.
- **13-agent adversarial review: 0 confirmed / 13 dismissed** (independent lake repros); the single flagged gap — a relaxed-cone-admitted Forward self-loop the F×R loop-exclusion missed — is hardened by the self-loop guard above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)