### PR TITLE
proof-corpus: 6 more decomposed TIP frontier wins (canonical helpers)

### DIFF
--- a/proof-corpus/decomposed/README.md
+++ b/proof-corpus/decomposed/README.md
@@ -38,18 +38,26 @@ Problems)**, `github.com/tip-org/benchmarks`, BSD-3-Clause — see
 `../tip/PROVENANCE.md` and `../tip/LICENSE.TIP`. The helper laws are our
 authorship; the surrounding program is the upstream-derived task verbatim.
 
-## Contents (4)
+## Contents (10)
 
 | file | target | bare-`tip/` status | what the decomposition added |
 |------|--------|--------------------|------------------------------|
 | `isaplanner/prop_03.av` | `count n xs ≤ count n (xs++ys)` | OPEN (frontier) | a cone-local count-monotonicity helper |
-| `prod/prop_25.av` | `even(length(x++y)) = even(length y + length x)` | OPEN (frontier) | length-homomorphism + `plus` commutativity |
-| `prod/prop_03.av` | `length(x++y) = plus(length y)(length x)` | Dafny-only → also Lean-genuine | the two "right" laws of `plus` |
+| `isaplanner/prop_04.av` | `S(count n xs) = count n (n::xs)` | OPEN (frontier) | `eqNat n n = true` (reflexivity) + count-cons |
+| `isaplanner/prop_20.av` | `length(sort xs) = length xs` | OPEN (frontier) | `insort` preserves length |
+| `isaplanner/prop_28.av` | `elem x (xs ++ [x])` | OPEN (frontier) | `eqNat x x = true` + elem-append |
+| `isaplanner/prop_29.av` | `elem x (ins1 x xs)` | OPEN (frontier) | `eqNat x x = true` + elem-insert |
+| `isaplanner/prop_30.av` | `elem x (insert x xs)` | OPEN (frontier) | `eqNat x x = true` + elem-insert |
+| `isaplanner/prop_38.av` | `count n (xs ++ [n]) = S(count n xs)` | OPEN (frontier) | `eqNat n n = true` + count-snoc |
 | `isaplanner/prop_75.av` | `count n [x] + count n xs = count n (x::xs)` | Dafny-only → also Lean-genuine | count-homomorphism + `plus` commutativity |
+| `prod/prop_03.av` | `length(x++y) = plus(length y)(length x)` | Dafny-only → also Lean-genuine | the two "right" laws of `plus` |
+| `prod/prop_25.av` | `even(length(x++y)) = even(length y + length x)` | OPEN (frontier) | length-homomorphism + `plus` commutativity |
 
-Two of the four (`isaplanner/prop_03`, `prod/prop_25`) move the **union
-frontier** — the unaided engine (auto-mode, `--discover`, and single-shot
-Dafny/Z3) closes none of them. The other two upgrade a Dafny-only (Z3-automated)
-task to a kernel-checked Lean proof. Each leaf helper bottoms out in something
-Aver's auto-prover discharges on its own (structural induction / homomorphism /
-the canonical-Peano bridge) — the loop is exactly as strong as that leaf reach.
+Eight of the ten move the **union frontier** — the unaided engine (auto-mode,
+`--discover`, and single-shot Dafny/Z3) closes none of them. The other two
+upgrade a Dafny-only (Z3-automated) task to a kernel-checked Lean proof. Every
+helper is a CANONICAL lemma (reflexivity, a homomorphism, a length/count
+preservation, the right-laws of `plus`) — textbook decompositions, not exotic
+tricks — and each bottoms out in something Aver's auto-prover discharges on its
+own (structural induction / homomorphism / the canonical-Peano bridge). The
+loop is exactly as strong as that leaf reach.

--- a/proof-corpus/decomposed/isaplanner/prop_04.av
+++ b/proof-corpus/decomposed/isaplanner/prop_04.av
@@ -1,0 +1,33 @@
+module Prop04
+    intent =
+        "TIP isaplanner prop_04: S(count n xs) = count n (cons n xs)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match eqNat(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+verify eqNat law eqNatRefl
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    eqNat(n, n) => true
+
+verify count law countCons
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.S(Nat.Z)]]
+    Nat.S(count(n, xs)) => count(n, List.concat([n], xs))

--- a/proof-corpus/decomposed/isaplanner/prop_20.av
+++ b/proof-corpus/decomposed/isaplanner/prop_20.av
@@ -1,0 +1,41 @@
+module Prop20
+    intent =
+        "TIP isaplanner prop_20: len (sort xs) = len xs for insertion sort over Nat lists."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn len(x: List<Nat>) -> Nat
+    match x
+        [] -> Nat.Z
+        [y, ..xs] -> Nat.S(len(xs))
+
+fn leq(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> leq(z, x2)
+
+fn insort(x: Nat, y: List<Nat>) -> List<Nat>
+    match y
+        [] -> [x]
+        [z, ..xs] -> match leq(x, z)
+            true -> List.concat([x], y)
+            false -> List.concat([z], insort(x, xs))
+
+fn sort(x: List<Nat>) -> List<Nat>
+    match x
+        [] -> []
+        [y, ..xs] -> insort(y, sort(xs))
+
+verify insort law insortPreservesLength
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given y: List<Nat> = [[], [Nat.S(Nat.Z)], [Nat.S(Nat.S(Nat.Z)), Nat.Z]]
+    len(insort(x, y)) => Nat.S(len(y))
+
+verify sort law sortPreservesLength
+    given xs: List<Nat> = [[], [Nat.S(Nat.Z)], [Nat.S(Nat.S(Nat.Z)), Nat.Z, Nat.S(Nat.Z)]]
+    len(sort(xs)) => len(xs)

--- a/proof-corpus/decomposed/isaplanner/prop_28.av
+++ b/proof-corpus/decomposed/isaplanner/prop_28.av
@@ -1,0 +1,33 @@
+module Prop28
+    intent =
+        "TIP isaplanner prop_28: elem x (xs ++ [x])."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> match eqNat(x, z)
+            true -> true
+            false -> elem(x, xs)
+
+verify eqNat law eqNatRefl
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    eqNat(x, x) => true
+
+verify elem law elemAppendSelf
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    elem(x, List.concat(xs, [x])) => true

--- a/proof-corpus/decomposed/isaplanner/prop_29.av
+++ b/proof-corpus/decomposed/isaplanner/prop_29.av
@@ -1,0 +1,40 @@
+module Prop29
+    intent =
+        "TIP isaplanner prop_29: elem x (ins1 x xs) holds."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> match eqNat(x, z)
+            true -> true
+            false -> elem(x, xs)
+
+fn ins1(x: Nat, y: List<Nat>) -> List<Nat>
+    match y
+        [] -> [x]
+        [z, ..xs] -> match eqNat(x, z)
+            true -> y
+            false -> List.concat([z], ins1(x, xs))
+
+verify eqNat law eqNatRefl
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    eqNat(x, x) => true
+
+verify elem law elemIns1
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]]
+    elem(x, ins1(x, xs)) => true

--- a/proof-corpus/decomposed/isaplanner/prop_30.av
+++ b/proof-corpus/decomposed/isaplanner/prop_30.av
@@ -1,0 +1,47 @@
+module Prop30
+    intent =
+        "TIP isaplanner prop_30: elem x (ins x xs) holds for all x and xs."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> match eqNat(x, z)
+            true -> true
+            false -> elem(x, xs)
+
+fn lt(x: Nat, y: Nat) -> Bool
+    match y
+        Nat.Z -> false
+        Nat.S(z) -> match x
+            Nat.Z -> true
+            Nat.S(x2) -> lt(x2, z)
+
+fn ins(x: Nat, y: List<Nat>) -> List<Nat>
+    match y
+        [] -> [x]
+        [z, ..xs] -> match lt(x, z)
+            true -> List.concat([x], y)
+            false -> List.concat([z], ins(x, xs))
+
+verify eqNat law eqNatRefl
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    eqNat(x, x) => true
+
+verify elem law elemInsInsert
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]]
+    elem(x, ins(x, xs)) => true

--- a/proof-corpus/decomposed/isaplanner/prop_38.av
+++ b/proof-corpus/decomposed/isaplanner/prop_38.av
@@ -1,0 +1,33 @@
+module Prop38
+    intent =
+        "TIP isaplanner prop_38: count n (xs ++ [n]) = S (count n xs)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match eqNat(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+verify eqNat law eqNatRefl
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    eqNat(n, n) => true
+
+verify count law countAppendSelf
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    count(n, List.concat(xs, [n])) => Nat.S(count(n, xs))

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4219,6 +4219,12 @@ fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
     let aver_bin = env!("CARGO_BIN_EXE_aver");
     let tasks = [
         "proof-corpus/decomposed/isaplanner/prop_03.av",
+        "proof-corpus/decomposed/isaplanner/prop_04.av",
+        "proof-corpus/decomposed/isaplanner/prop_20.av",
+        "proof-corpus/decomposed/isaplanner/prop_28.av",
+        "proof-corpus/decomposed/isaplanner/prop_29.av",
+        "proof-corpus/decomposed/isaplanner/prop_30.av",
+        "proof-corpus/decomposed/isaplanner/prop_38.av",
         "proof-corpus/decomposed/isaplanner/prop_75.av",
         "proof-corpus/decomposed/prod/prop_03.av",
         "proof-corpus/decomposed/prod/prop_25.av",


### PR DESCRIPTION
Six more bare-`tip/` OPEN tasks closed by LLM helper-law decomposition (the part A/C loop), all **union-OPEN frontier** (nothing unaided — auto-mode, `--discover`, single-shot Dafny/Z3 — closes them):

| task | target | helper (canonical) |
|------|--------|--------------------|
| `isaplanner/prop_04` | `S(count n xs) = count n (n::xs)` | `eqNat n n = true` + count-cons |
| `isaplanner/prop_20` | `length(sort xs) = length xs` | `insort` preserves length |
| `isaplanner/prop_28` | `elem x (xs ++ [x])` | `eqNat x x = true` + elem-append |
| `isaplanner/prop_29` | `elem x (ins1 x xs)` | `eqNat x x = true` + elem-insert |
| `isaplanner/prop_30` | `elem x (insert x xs)` | `eqNat x x = true` + elem-insert |
| `isaplanner/prop_38` | `count n (xs ++ [n]) = S(count n xs)` | `eqNat n n = true` + count-snoc |

**STRICT integrity** (verified locally, no `fn`/target changes): 0 lines of the bare task altered, fn count unchanged, exactly one helper `verify law` added per file. Every helper is a **canonical** lemma (reflexivity / preservation / snoc-cons) — textbook recall, not exotic cleverness.

`prop_38` is the exact #449 loss whose only gap was `eqNat n n = true`; the persistent run found that one-liner.

`decomposed/` stays excluded from `run.sh` (separate loop-reach metric — baseline 154 untouched). `proof_spec::decomposed_tip_tasks_stay_universal` re-verifies all **ten** stay `universal:true` — **CI's independent kernel re-judge** (so the wins aren't trusted on the agents' self-report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)