### PR TITLE
proof(leaf-reach): accumulator-generalizing induction (closes qrev↔rev)

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -659,23 +659,46 @@ fn emit_list_induction(
     // (closes the synchronous Nat+List family, e.g. `take n xs ++ drop n xs =
     // xs`). The `induction X generalizing Y` + `cases Y` shape already proves the
     // canonical-Peano `Sub`/`Le`/`Lt` bridges, so it is well-trodden.
-    let gen_given: Option<String> = ctx
+    // `(intro_name, needs_cases)`: the given to generalize over, and whether to
+    // `cases` it in each arm. A Peano param the fn decrements synchronously
+    // (`take`/`drop`'s `n`) is generalized AND case-split (the IH lands at the
+    // predecessor); a THREADED accumulator (`qrev`'s `acc`, fed
+    // `List.concat([h], acc)`) is generalized only (no scrutinee to split, the
+    // IH `∀ acc, P xs acc` applies at the threaded value).
+    use crate::codegen::recursion::detect::{
+        param_decremented_in_recursion, param_threaded_in_recursion,
+        single_list_structural_param_index,
+    };
+    let gen_given: Option<(String, bool)> = ctx
         .fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref())
         .and_then(|fd| {
-            let lidx = crate::codegen::recursion::detect::single_list_structural_param_index(fd)?;
-            let decr = fd.params.iter().enumerate().find(|(i, (_, ty))| {
+            let lidx = single_list_structural_param_index(fd)?;
+            let given_intro = |fn_param: &str| -> Option<String> {
+                law.givens
+                    .iter()
+                    .position(|g| g.name == fn_param)
+                    .map(|gi| intro_names[gi].clone())
+            };
+            // Peano sync-decremented param → generalize + cases.
+            if let Some((_, (pname, _))) = fd.params.iter().enumerate().find(|(i, (_, ty))| {
                 *i != lidx
                     && (ty.trim() == "Nat"
                         || crate::codegen::proof_recognize::peano_type_named(ctx, ty.trim())
                             .is_some())
-                    && crate::codegen::recursion::detect::param_decremented_in_recursion(fd, *i)
-            })?;
-            let decr_name = &decr.1.0;
-            // Map that fn param to the law given of the same name → its intro.
-            law.givens
+                    && param_decremented_in_recursion(fd, *i)
+            }) {
+                return given_intro(pname).map(|n| (n, true));
+            }
+            // Threaded accumulator param → generalize only.
+            if let Some((_, (pname, _))) = fd
+                .params
                 .iter()
-                .position(|g| &g.name == decr_name)
-                .map(|gi| intro_names[gi].clone())
+                .enumerate()
+                .find(|(i, _)| *i != lidx && param_threaded_in_recursion(fd, *i))
+            {
+                return given_intro(pname).map(|n| (n, false));
+            }
+            None
         });
 
     // `simp only` set for the split fallback below. `List.cons_append`
@@ -759,13 +782,14 @@ fn emit_list_induction(
     // committed pin OR an eligible earlier sibling law (`fast_simp` carries
     // both). With neither, the emit is byte-identical to the pre-feedback
     // ladder.
-    if let Some(gv) = gen_given.as_ref().filter(|_| fast_simp.is_empty()) {
-        // Generalizing induction (synchronous Nat+List family). Each arm
-        // `cases <gen> <;> (ladder)` splits the generalized Peano var so the
-        // cons IH (`∀ n, P n tail`) applies at the predecessor; the ladder is
-        // the same sound first|simp|omega|split|sorry chain, distributed over
-        // both zero/succ goals. nil also needs the split (`take n []` only
-        // reduces once `n` is a concrete constructor).
+    if let Some((gv, needs_cases)) = gen_given.as_ref().filter(|_| fast_simp.is_empty()) {
+        // Generalizing induction. `induction list generalizing <gv>` makes the
+        // cons IH `∀ <gv>, P <gv> tail`, so it applies at the recursion's
+        // threaded/decremented value. For a Peano `<gv>` (`take`/`drop`'s `n`)
+        // each arm `cases <gv> <;> (ladder)` splits zero/succ so the IH lands
+        // at the predecessor; for a threaded accumulator (`qrev`'s `acc`) no
+        // split is needed (the IH applies at `h::acc` directly). The ladder is
+        // the same sound first|simp|omega|split|sorry chain.
         let ladder = |s: &str| -> String {
             format!(
                 "first | ({s} [{d}]; done) | ({s} [{d}]; omega) | (simp only [{sp}]; split <;> simp_all [{d}] <;> omega) | sorry",
@@ -773,14 +797,21 @@ fn emit_list_induction(
                 sp = split_set
             )
         };
+        let wrap = |arm: &str| -> String {
+            if *needs_cases {
+                format!("cases {gv} <;> ({arm})")
+            } else {
+                arm.to_string()
+            }
+        };
         proof_lines.push(format!(
             "  induction {} generalizing {} with",
             target_lean, gv
         ));
-        proof_lines.push(format!("  | nil => cases {gv} <;> ({})", ladder("simp")));
+        proof_lines.push(format!("  | nil => {}", wrap(&ladder("simp"))));
         proof_lines.push(format!(
-            "  | cons head tail ih => cases {gv} <;> ({})",
-            ladder("simp_all")
+            "  | cons head tail ih => {}",
+            wrap(&ladder("simp_all"))
         ));
     } else if fast_simp.is_empty() {
         let (nil_arm, cons_arm) = mk_arms(&simp_list, &split_set, None, true);

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -916,7 +916,10 @@ fn classify_law_strategy(
     // proof. Reflexive could also fire on `f(t) = f(t)` for `t: Tree`
     // but induction subsumes (one trivial case per variant) and is
     // the legacy chain's first pick. `when` clauses block induction
-    // — the case-split would lose the premise binding.
+    // — a non-closing `when` law would emit a 2-arm induction ladder
+    // (2 sorries) instead of the bounded sampled-domain fallback,
+    // regressing output cleanliness; a non-regressing when-aware
+    // induction path is a follow-up.
     if law.when.is_none()
         && let Some(param) = detect_induction_target(law, inputs)
     {

--- a/src/codegen/recursion/detect.rs
+++ b/src/codegen/recursion/detect.rs
@@ -748,6 +748,28 @@ pub(crate) fn param_decremented_in_recursion(fd: &FnDef, param_index: usize) -> 
     })
 }
 
+/// `true` iff every recursive self-call passes at `param_index` a RECONSTRUCTED
+/// expression (not a bare identifier) — a THREADED accumulator (`qrev`'s `acc`
+/// gets `List.concat([h], acc)`). The "not a bare local" requirement is what
+/// separates a genuine accumulator from a SYNCHRONOUS second list: `zip(xs,
+/// ys)` recurses with `ys`'s tail binder `yt` (a bare local), which is a
+/// structural decrement to be inducted normally, NOT a threaded accumulator to
+/// generalize-without-cases. Such a param must be GENERALIZED (so the IH reads
+/// `∀ acc, P xs acc` and applies at the threaded value) but NOT case-split.
+pub(crate) fn param_threaded_in_recursion(fd: &FnDef, param_index: usize) -> bool {
+    let calls: Vec<(String, Vec<&Spanned<Expr>>)> = collect_calls_from_body(fd.body.as_ref())
+        .into_iter()
+        .filter(|(name, _)| call_matches(name, &fd.name))
+        .collect();
+    if calls.is_empty() {
+        return false;
+    }
+    calls.iter().all(|(_, args)| {
+        args.get(param_index)
+            .is_some_and(|a| local_name_of(a).is_none())
+    })
+}
+
 pub(crate) fn is_ident(expr: &Spanned<Expr>, name: &str) -> bool {
     local_name_of(expr).is_some_and(|id| id == name)
 }

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4379,3 +4379,53 @@ fn lean_escapes_user_max_min_collision_when_lake_is_available() {
         1,
     );
 }
+
+/// Leaf-reach: the Lean backend auto-proves an ACCUMULATOR-generalizing law —
+/// `qrev(xs, acc) = rev(xs) ++ acc`, where `qrev` recurses on `xs` while
+/// THREADING `acc` (fed `List.concat([h], acc)`). The IH must be `∀ acc,
+/// P xs acc`, so the backend emits `induction xs generalizing acc` (no `cases`
+/// — `acc` is not a Peano scrutinee, distinct from the take/drop Nat case).
+/// No helper, bare — the lemma that previously SORRIED. (The qrev↔rev
+/// equivalence `fastRev = rev` then closes by decomposition over it.)
+#[test]
+fn lean_proves_accumulator_generalizing_qrev_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping accumulator-gen test: `lake` not available");
+        return;
+    }
+    let source = "module QrevAccGen\n    intent = \"qrev acc-generalization\"\n    effects []\n\n\
+        fn rev(xs: List<Int>) -> List<Int>\n    match xs\n        [] -> []\n        [h, ..t] -> List.concat(rev(t), [h])\n\n\
+        fn qrev(xs: List<Int>, acc: List<Int>) -> List<Int>\n    match xs\n        [] -> acc\n        [h, ..t] -> qrev(t, List.concat([h], acc))\n\n\
+        verify qrev law qrevRevAppend\n    given xs: List<Int> = [[1], [1, 2, 3]]\n    given acc: List<Int> = [[9], [8, 7]]\n    qrev(xs, acc) => List.concat(rev(xs), acc)\n";
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-accgen-src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(src.join("m.av"), source).expect("write");
+    let out = temp_output_dir("aver-accgen-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("aver proof ran");
+    let json = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON:\n{}", format_output(&run)));
+    let summary: serde_json::Value = serde_json::from_str(json).expect("json");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "accumulator-generalizing must close qrev(xs,acc)=rev(xs)++acc bare\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
Extends the generalizing-induction strategy (#453) to a **threaded accumulator**.

## What
`qrev(xs, acc) = rev(xs) ++ acc` — `qrev` recurses on `xs` while feeding `acc` a reconstructed `List.concat([h], acc)`. The IH must be `∀ acc, P xs acc`, so the backend emits `induction xs generalizing acc` (WITHOUT the `cases` the Peano case uses — `acc` is no scrutinee).

`param_threaded_in_recursion` detects it: the recursive arg is a **reconstructed expression** (`local_name_of` is None) — exactly what separates a genuine accumulator from a synchronous **second list** (`zip(xs, ys)` threads `ys`'s bare tail binder `yt`, which inducts normally). The over-broad first cut mis-fired on `zip` (regressing prop_85); the non-local-expr requirement fixes that.

## Why it matters
Closes the qrev accumulator-generalization lemma **bare** — the exact lemma that SORRIED in the manual experiment (#449), blocking `fastRev xs = rev xs`. With it proved, the `fastRev = rev` decomposition closes end-to-end. Another multiplicative leaf-reach win.

## NOT included: when-routing
Un-gating `when`-laws to induction was tried and reverted: a non-closing `when`-law emits a 2-arm ladder (2 sorries) instead of the bounded sampled fallback, regressing json's sorry budget 8→14 for **no coverage gain** (those laws were never universal). A non-regressing when-aware induction path is a follow-up.

## Verification
proof_spec **105/105** (json back to 8 sorries, prop_85 stays bounded `passed:true/¬universal`, prop_01 Peano-sync + qrev accumulator both close) + new accumulator-gen pin. lib 821/821, clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)