### PR TITLE
proof(emit): tighten feedback ladder — drop duplicate alt + inert siblings

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -368,7 +368,17 @@ fn earlier_law_lemmas(
         // synthesized downstream. Tight enough to stay relevant (a length-homo
         // in a count file shares neither cone nor subject → rejected); loop
         // safety is handled separately by `simp_entries`.
-        if mentions.is_subset(&scope) || mentions.contains(&subject) {
+        // Admit by the subject rule only when the sibling is a law ABOUT a fn
+        // this law's proof actually involves (its OWN subject fn ∈ scope). A
+        // sibling that merely mentions the subject incidentally on its RHS —
+        // `length (x ++ y) = plus …` carrying `plus` into a `plus`-commutativity
+        // proof — is inert in the goal (nothing to rewrite) and only adds noise.
+        // The genuine decomposition case is preserved: a count-homomorphism
+        // helper IS a law about `count`, the very subject it shares.
+        let prev_subject = aver_name_to_lean(&prev.fn_name);
+        if mentions.is_subset(&scope)
+            || (mentions.contains(&subject) && scope.contains(&prev_subject))
+        {
             out.push(crate::codegen::lemma_discovery::CommittedLemma::reference(
                 name, text,
             ));
@@ -873,10 +883,16 @@ fn emit_list_induction(
             "  | (simp only [{}] <;> omega)",
             fast_lemmas.join(", ")
         ));
-        proof_lines.push(format!(
-            "  | (simp only [{}] <;> omega)",
-            fast_unfolds.into_iter().collect::<Vec<_>>().join(", ")
-        ));
+        // The def-unfolding variant is a distinct alternative only when it adds
+        // a def beyond the lemma+bridge set; when every law def is bridged out
+        // it collapses to the line above, so emit it once — not as a duplicate.
+        let fast_lemmas_set: BTreeSet<String> = fast_lemmas.iter().cloned().collect();
+        if fast_unfolds != fast_lemmas_set {
+            proof_lines.push(format!(
+                "  | (simp only [{}] <;> omega)",
+                fast_unfolds.into_iter().collect::<Vec<_>>().join(", ")
+            ));
+        }
         if arm_forward_siblings.is_empty() {
             // No in-arm sibling to add: one committed-only ladder, with sorry.
             let (nil_arm, cons_arm) = mk_arms(&simp_list, &split_set, bridge_set.as_deref(), true);
@@ -1073,10 +1089,15 @@ fn emit_simple_induction(
                 .chain(arith_bridges.iter().cloned())
                 .filter(|n| !bridged_fns.contains(n))
                 .collect();
-            proof_lines.push(format!(
-                "  | (simp only [{}] <;> omega)",
-                fast_unfolds.into_iter().collect::<Vec<_>>().join(", ")
-            ));
+            // Skip the def-unfolding variant when it collapses to the lemma+
+            // bridge line above (every law def bridged out) — no duplicate alt.
+            let fast_lemmas_set: BTreeSet<String> = fast_lemmas.iter().cloned().collect();
+            if fast_unfolds != fast_lemmas_set {
+                proof_lines.push(format!(
+                    "  | (simp only [{}] <;> omega)",
+                    fast_unfolds.into_iter().collect::<Vec<_>>().join(", ")
+                ));
+            }
         }
         proof_lines.push(format!("  | (induction {} with", target_lean));
         let last = arm_lines.len().saturating_sub(1);


### PR DESCRIPTION
Aesthetic/quality pass on the `SimpOverLemmas` (część A) Lean emit, prompted by a fair "why ten tactics, `first`, `sorry`?" — measured the actual cruft across the 164-file proof corpus and cut exactly what was sloppy, leaving the essential portfolio intact.

## What was actually sloppy (measured, not guessed)
Across the whole corpus there were **45 top-level `first` portfolios**; of those only **2 carried a genuine duplicate alternative**, and a handful of laws carried an **inert sibling** in their simp set. The rest of the "wall of tactics" is essential: the 4-strategy arm ladder (reflexive / simp / omega / split), the kernel-proved Peano bridge lemmas, and the bounded `native_decide` verify-on-samples layer.

## Two surgical, soundness-neutral cleanups
1. **De-duplicate the top-level `first` portfolio.** The feedback emit tries a lemma+bridge `simp only` then a def-unfolding variant; when every law def is bridged out (a pure-`plus` law whose only def is the bridged `plus`), the def-unfolding set collapses to the lemma+bridge set and the two alternatives were byte-identical. Emit the second only when its set differs. **Corpus-wide: 2 → 0.**
2. **Narrow the część-A sibling subject rule.** `earlier_law_lemmas` admitted any earlier law that mentions the consumer's subject fn *anywhere* — including incidentally on its RHS (`length (x ++ y) = plus …` carrying `plus` into a `plus`-commutativity proof, where it can never fire). Now admitted by the subject rule only when the sibling is a law *about* a fn this proof actually involves (its own subject fn ∈ scope). The genuine decomposition case (a count-homomorphism helper, a law about `count`) is preserved.

Both removals are closure-neutral: a removed alternative was either an exact duplicate or an inert rewrite — neither can change which tactic closes the goal.

## Verification
- `proof_spec` **105/105** — incl. `decomposed_tip_tasks_stay_universal` (10-file część A/C gate) and `count_plus_concat_homomorphism_kernel_clean` (the genuine subject-rule case, kept).
- `cargo test --lib` **821/821**; clippy clean; `cargo fmt --all` clean.
- Touched files (`decomposed/prod/prop_25`, `prop_03`) re-checked `universal:true, sorries:0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)