### PR TITLE
proof-corpus: 6 more decomposed TIP wins (decomposition-reach chunk #1)

### DIFF
--- a/proof-corpus/decomposed/README.md
+++ b/proof-corpus/decomposed/README.md
@@ -38,7 +38,12 @@ Problems)**, `github.com/tip-org/benchmarks`, BSD-3-Clause — see
 `../tip/PROVENANCE.md` and `../tip/LICENSE.TIP`. The helper laws are our
 authorship; the surrounding program is the upstream-derived task verbatim.
 
-## Contents (10)
+## Contents (16)
+
+The first ten are the original chunk; the last six are **decomposition-reach
+chunk #1** (2026-06-10) — the reverse/accumulator family, opened up by the
+accumulator-generalizing induction that landed in the auto-prover (`induction xs
+generalizing acc`). All six were OPEN even to Z3/Dafny.
 
 | file | target | bare-`tip/` status | what the decomposition added |
 |------|--------|--------------------|------------------------------|
@@ -52,12 +57,19 @@ authorship; the surrounding program is the upstream-derived task verbatim.
 | `isaplanner/prop_75.av` | `count n [x] + count n xs = count n (x::xs)` | Dafny-only → also Lean-genuine | count-homomorphism + `plus` commutativity |
 | `prod/prop_03.av` | `length(x++y) = plus(length y)(length x)` | Dafny-only → also Lean-genuine | the two "right" laws of `plus` |
 | `prod/prop_25.av` | `even(length(x++y)) = even(length y + length x)` | OPEN (frontier) | length-homomorphism + `plus` commutativity |
+| `handwritten/qrev_rev.av` | `fastRev x = rev x` | OPEN (frontier) | accumulator-generalization: `qrev(xs,acc) = rev(xs)++acc` |
+| `isaplanner/prop_19.av` | `len(drop n xs) = len xs − n` | OPEN (frontier) | the generalized `len∘drop` law over `n` |
+| `prod/prop_27.av` | `rev x = qrev x []` | OPEN (frontier) | `qrev` spec `qrev(x,y) = rev(x)++y` |
+| `prod/prop_29.av` | `rev(qrev x []) = x` | OPEN (frontier) | qrev-spec + rev-append homomorphism + rev involution |
+| `prod/prop_30.av` | `rev(rev x ++ []) = x` | OPEN (frontier) | rev-snoc + rev involution |
+| `prod/prop_31.av` | `qrev(qrev x []) [] = x` | OPEN (frontier) | generalized `qrev` "master" law `qrev(qrev(x,y),[]) = qrev(y,x)` |
 
-Eight of the ten move the **union frontier** — the unaided engine (auto-mode,
-`--discover`, and single-shot Dafny/Z3) closes none of them. The other two
-upgrade a Dafny-only (Z3-automated) task to a kernel-checked Lean proof. Every
-helper is a CANONICAL lemma (reflexivity, a homomorphism, a length/count
-preservation, the right-laws of `plus`) — textbook decompositions, not exotic
-tricks — and each bottoms out in something Aver's auto-prover discharges on its
-own (structural induction / homomorphism / the canonical-Peano bridge). The
-loop is exactly as strong as that leaf reach.
+Fourteen of the sixteen move the **union frontier** — the unaided engine
+(auto-mode, `--discover`, and single-shot Dafny/Z3) closes none of them. The
+other two upgrade a Dafny-only (Z3-automated) task to a kernel-checked Lean
+proof. Every helper is a CANONICAL lemma (reflexivity, a homomorphism, an
+accumulator/qrev specification, a length/count preservation, the right-laws of
+`plus`) — textbook decompositions, not exotic tricks — and each bottoms out in
+something Aver's auto-prover discharges on its own (structural induction /
+accumulator-generalizing induction / homomorphism / the canonical-Peano
+bridge). The loop is exactly as strong as that leaf reach.

--- a/proof-corpus/decomposed/handwritten/qrev_rev.av
+++ b/proof-corpus/decomposed/handwritten/qrev_rev.av
@@ -1,0 +1,28 @@
+module QrevRev
+    intent =
+        "TIP isaplanner: fast reverse via a cons-accumulator equals naive reverse."
+        "Probes whether the accumulator-generalization reaches a CONS-accumulator"
+        "step (List.concat([h], acc)) — not just an additive or named-fn step."
+    effects []
+
+fn rev(xs: List<Int>) -> List<Int>
+    match xs
+        [] -> []
+        [h, ..t] -> List.concat(rev(t), [h])
+
+fn qrev(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> acc
+        [h, ..t] -> qrev(t, List.concat([h], acc))
+
+fn fastRev(xs: List<Int>) -> List<Int>
+    qrev(xs, [])
+
+verify qrev law accGeneralizes
+    given xs: List<Int> = [[], [1], [1, 2, 3], [3, 1, 2]]
+    given acc: List<Int> = [[], [9], [8, 7]]
+    qrev(xs, acc) => List.concat(rev(xs), acc)
+
+verify fastRev law equalsRev
+    given xs: List<Int> = [[], [1], [1, 2, 3], [3, 1, 2]]
+    fastRev(xs) => rev(xs)

--- a/proof-corpus/decomposed/isaplanner/prop_19.av
+++ b/proof-corpus/decomposed/isaplanner/prop_19.av
@@ -1,0 +1,37 @@
+module Prop19
+    intent =
+        "TIP isaplanner prop_19: len (drop n xs) = len xs - n (Nat subtraction)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn len(xs: List<Int>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(len(ys))
+
+fn drop(x: Nat, y: List<Int>) -> List<Int>
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> match y
+            [] -> []
+            [x2, ..x3] -> drop(z, x3)
+
+fn sub(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> Nat.Z
+        Nat.S(z) -> match y
+            Nat.Z -> x
+            Nat.S(x2) -> sub(z, x2)
+
+verify drop law lenDropSubGen
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: List<Int> = [[], [1], [1, 2, 3]]
+    len(drop(x, y)) => sub(len(y), x)
+
+verify len law lenDropSub
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Int> = [[], [1], [1, 2, 3]]
+    len(drop(n, xs)) => sub(len(xs), n)

--- a/proof-corpus/decomposed/prod/prop_27.av
+++ b/proof-corpus/decomposed/prod/prop_27.av
@@ -1,0 +1,23 @@
+module Prop27
+    intent =
+        "TIP prod prop_27: rev x = qrev x nil."
+    effects []
+
+fn qrev(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> qrev(xs, List.concat([z], y))
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..xs] -> List.concat(rev(xs), [y])
+
+verify qrev law qrevSpec
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[], [9], [8, 7]]
+    qrev(x, y) => List.concat(rev(x), y)
+
+verify rev law revQrev
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    rev(x) => qrev(x, [])

--- a/proof-corpus/decomposed/prod/prop_29.av
+++ b/proof-corpus/decomposed/prod/prop_29.av
@@ -1,0 +1,32 @@
+module Prop29
+    intent =
+        "TIP prod prop_29: rev (qrev x nil) = x."
+    effects []
+
+fn qrev(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> qrev(xs, List.concat([z], y))
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..xs] -> List.concat(rev(xs), [y])
+
+verify qrev law qrevRevAppend
+    given x: List<Int> = [[1], [1, 2, 3]]
+    given y: List<Int> = [[9], [8, 9]]
+    qrev(x, y) => List.concat(rev(x), y)
+
+verify rev law revAppendHomo
+    given a: List<Int> = [[1], [1, 2, 3]]
+    given b: List<Int> = [[4], [4, 5]]
+    rev(List.concat(a, b)) => List.concat(rev(b), rev(a))
+
+verify rev law revInvolution
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    rev(rev(x)) => x
+
+verify rev law revQrevNil
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    rev(qrev(x, [])) => x

--- a/proof-corpus/decomposed/prod/prop_30.av
+++ b/proof-corpus/decomposed/prod/prop_30.av
@@ -1,0 +1,22 @@
+module Prop30
+    intent =
+        "TIP prod prop_30: rev (rev x ++ nil) = x."
+    effects []
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..xs] -> List.concat(rev(xs), [y])
+
+verify rev law revSnoc
+    given a: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given y: Int = [1, 2]
+    rev(List.concat(a, [y])) => List.concat([y], rev(a))
+
+verify rev law revInvolution
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    rev(rev(x)) => x
+
+verify rev law revRevAppendNil
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    rev(List.concat(rev(x), [])) => x

--- a/proof-corpus/decomposed/prod/prop_31.av
+++ b/proof-corpus/decomposed/prod/prop_31.av
@@ -1,0 +1,18 @@
+module Prop31
+    intent =
+        "TIP prod prop_31: qrev (qrev x nil) nil = x."
+    effects []
+
+fn qrev(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> qrev(xs, List.concat([z], y))
+
+verify qrev law qrevMaster
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given y: List<Int> = [[], [9], [8, 7], [6]]
+    qrev(qrev(x, y), []) => qrev(y, x)
+
+verify qrev law qrevQrev
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    qrev(qrev(x, []), []) => x

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4228,6 +4228,13 @@ fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
         "proof-corpus/decomposed/isaplanner/prop_75.av",
         "proof-corpus/decomposed/prod/prop_03.av",
         "proof-corpus/decomposed/prod/prop_25.av",
+        // decomposition-reach chunk #1 (reverse/accumulator family).
+        "proof-corpus/decomposed/handwritten/qrev_rev.av",
+        "proof-corpus/decomposed/isaplanner/prop_19.av",
+        "proof-corpus/decomposed/prod/prop_27.av",
+        "proof-corpus/decomposed/prod/prop_29.av",
+        "proof-corpus/decomposed/prod/prop_30.av",
+        "proof-corpus/decomposed/prod/prop_31.av",
     ];
     for task in tasks {
         let out = temp_output_dir(&format!(


### PR DESCRIPTION
**Decomposition-reach chunk #1** on the post-leaf-reach binary (#453 max/min + Peano-sync generalizing, #454 accumulator-generalizing, #455 emission tightening).

## Method (honest, anti-cherry-pick)
15 **pre-registered** open TIP tasks (the 93-task OPEN set, deliberately *excluding* the 10 already in `decomposed/`), one LLM agent per task writing helper `verify ... law` blocks, forced VM-first (∞ VM filter, ≤5 lake builds), the pipeline as a **fail-closed judge** (`universal:true` or honest loss). All 15 reported — wins and losses.

- **Reach: 6/15 closed.**
- **VM:lake = 40:34 ≈ 1.07–1.18x** — the smart-generator profile (lake-heavy, ~1:1), *not* enumeration's VM≫lake. Quantifies the "trustworthy candidate filter" thesis: a good generator's candidates mostly survive to the expensive verifier and close.

## The 6 wins (pulled in here)
All were OPEN even to Z3/Dafny (frontier). Each verified independently before pulling — **integrity-diff** (fn/type/module/intent/target byte-identical to the bare `tip/` original, only helper laws added) + **lake re-check** (`universal:true, sorries:0`, not the agent's self-report).

| task | target | helper decomposition |
|------|--------|----------------------|
| `handwritten/qrev_rev` | `fastRev x = rev x` | accumulator-generalization `qrev(xs,acc) = rev(xs)++acc` |
| `isaplanner/prop_19` | `len(drop n xs) = len xs − n` | generalized `len∘drop` over `n` |
| `prod/prop_27` | `rev x = qrev x []` | `qrev` spec `qrev(x,y)=rev(x)++y` |
| `prod/prop_29` | `rev(qrev x []) = x` | qrev-spec + rev-append homomorphism + rev involution |
| `prod/prop_30` | `rev(rev x ++ []) = x` | rev-snoc + rev involution |
| `prod/prop_31` | `qrev(qrev x []) [] = x` | `qrev` "master" law `qrev(qrev(x,y),[]) = qrev(y,x)` |

These ride the **accumulator-generalizing induction** that landed in the auto-prover (#454): leaf-reach unblocked the shape, decomposition closes it — the loop is exactly as strong as the auto-prover's leaf reach.

## Honesty guardrails (unchanged)
`decomposed/` is a **separate loop-reach metric**, excluded from `run.sh` (`-not -path '*/decomposed/*'`) — the bare baseline stays honest. README updated to 16 entries; `proof_spec::decomposed_tip_tasks_stay_universal` extended to 16 (passes locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)