### PR TITLE
proof(lean): retire fuel for structural recursion + generalizing Nat induction (max/min/double/tree)

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -589,6 +589,18 @@ pub(super) fn emit_structural_induction_law(
         return emit_list_induction(vb, law, ctx, intro_names, target_idx, discovered);
     }
 
+    // (a2) The verified fn peels a constructor off BOTH args synchronously
+    //      (the `max`/`min` monoid shape) and the law is a commutativity /
+    //      associativity statement whose givens are all that Peano type:
+    //      `induction g1 generalizing <rest> with … cases <rest> …`. Inducting
+    //      on a single arg (branch (b)) leaves the other arg's peel stuck at
+    //      `sorry`; generalizing + case-splitting the remaining givens exposes
+    //      every constructor pairing so the cons IH applies. Tried before the
+    //      single-variable structural branch.
+    if let Some(proof) = emit_both_args_peeling_law(vb, law, ctx, intro_names) {
+        return Some(proof);
+    }
+
     // (b) A `given` is a user-defined recursive sum type: structural induction
     //     over its variants.
     if let Some((target_idx, _target_name, type_name)) = sum_target {
@@ -934,6 +946,136 @@ fn emit_list_induction(
     })
 }
 
+/// Kernel-proved commutativity (`f a b = f b a`) theorem for a both-args-peeling
+/// commutative Peano fn (`max`/`min`), using the same generalizing-induction
+/// ladder as [`emit_both_args_peeling_law`]. Returns `(theorem_text, name)`.
+/// Proved, not trusted: a non-commutative fn never reaches here (the caller
+/// gates on `both_args_peeling_is_commutative`), and even if it did the ladder
+/// would degrade to `sorry` (caught by the universal metric), never minting a
+/// false theorem.
+fn both_args_peeling_comm_theorem(fn_lean: &str, law_uid: &str) -> (String, String) {
+    let name = format!("{law_uid}_{fn_lean}_comm");
+    let ladder = format!(
+        "first | (cases b <;> simp_all [{fn_lean}]; done) | (cases b <;> simp_all [{fn_lean}]; omega) | sorry"
+    );
+    let text = format!(
+        "theorem {name} : ∀ (a b : Nat), {fn_lean} a b = {fn_lean} b a := by\n  intro a b\n  induction a generalizing b with\n  | zero => {ladder}\n  | succ k ih => {ladder}"
+    );
+    (text, name)
+}
+
+/// Commutative both-args-peeling Peano fns in THIS law's proof cone — each gets
+/// a kernel-proved `comm` support lemma whose name is injected into the
+/// induction arms. `height (mirror t) = height t` reduces (after the IH) to
+/// `max (height r) (height l) = max (height l) (height r)`, which only closes if
+/// `max`'s commutativity is available as a rewrite. The verified fn itself is
+/// excluded (a `max`-commutativity law is proven directly by
+/// [`emit_both_args_peeling_law`], not via a self-referential support lemma).
+/// Returns `(support_theorem_texts, lemma_names)`.
+fn consumed_comm_lemmas(
+    ctx: &CodegenContext,
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    law_uid: &str,
+) -> (Vec<String>, Vec<String>) {
+    let mut support = Vec::new();
+    let mut names = Vec::new();
+    for src_name in super::shared::law_simp_source_names(ctx, vb, law) {
+        if src_name == vb.fn_name {
+            continue;
+        }
+        let Some(fd) = ctx.fn_def_by_name(&src_name, ctx.active_module_scope().as_deref()) else {
+            continue;
+        };
+        if crate::codegen::proof_recognize::both_args_peeling_is_commutative(fd, ctx).is_none() {
+            continue;
+        }
+        let fn_lean = aver_name_to_lean(&src_name);
+        let (text, name) = both_args_peeling_comm_theorem(&fn_lean, law_uid);
+        support.push(text);
+        names.push(name);
+    }
+    (support, names)
+}
+
+/// Generalizing induction for a commutativity / associativity law of a
+/// both-args-peeling Nat fn (`max`/`min`). Fires only when:
+/// - the verified fn has the synchronous two-arg-peeling recursion shape
+///   (`detect::recurses_decrementing_both_args`), and
+/// - every law `given` is that fn's (canonical-Peano) parameter type, and
+/// - the law has 2 givens (commutativity) or 3 (associativity) — the families
+///   whose proof needs the other arg(s) case-split inside each induction arm.
+///
+/// Emits `induction g1 generalizing g2 [g3] with | zero => … | succ k ih => …`,
+/// where each arm `cases`-splits the remaining givens then runs the same sound
+/// `first | (cases…<;> simp_all [defs]; done) | (… ; omega) | sorry` ladder used
+/// elsewhere. `simp_all` carries the `succ`-arm IH (`∀ g2 [g3], P k g2 [g3]`)
+/// automatically, so the recursion's both-args peel rewrites in lockstep. Every
+/// branch is sound (`simp_all`/`omega` close only true goals; a non-closing arm
+/// degrades to the honest `sorry` the universal metric catches), so this can
+/// only ever ADD closures — a false law still reports `universal:false`.
+fn emit_both_args_peeling_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    intro_names: &[String],
+) -> Option<AutoProof> {
+    // 2 (comm) or 3 (assoc) givens, all the verified fn's both-args-peeling
+    // Peano param type.
+    if law.givens.len() != 2 && law.givens.len() != 3 {
+        return None;
+    }
+    let fd = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref())?;
+    if !crate::codegen::recursion::detect::recurses_decrementing_both_args(fd) {
+        return None;
+    }
+    let param_type = fd.params.first()?.1.trim().to_string();
+    crate::codegen::proof_recognize::peano_type_named(ctx, &param_type)?;
+    if law.givens.iter().any(|g| g.type_name.trim() != param_type) {
+        return None;
+    }
+    if intro_names.len() != law.givens.len() {
+        return None;
+    }
+    // The law must be a genuine commutativity / associativity of THIS fn over
+    // its givens — not merely some 2-/3-given law that happens to mention a
+    // both-args-peeling fn. A `minus(plus(n,m),n)=m` or a `n ≤ m+n` keeps its
+    // existing bridge proof; this generalizing template fires only on
+    // `f a b = f b a` / `f (f a b) c = f a (f b c)`.
+    let given_names: Vec<String> = law.givens.iter().map(|g| g.name.clone()).collect();
+    crate::codegen::proof_recognize::recognize_binary_law_shape(law, &vb.fn_name, &given_names)?;
+
+    let simp_list = law_simp_defs(ctx, vb, law)
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join(", ");
+    let induct_on = &intro_names[0];
+    let rest = &intro_names[1..];
+    let generalizing = rest.join(" ");
+    // Case-split every remaining given so each constructor pairing is exposed;
+    // `simp_all` then unfolds the defs, applies the succ-arm IH, and closes.
+    let cases_prefix = rest
+        .iter()
+        .map(|g| format!("cases {g} <;> "))
+        .collect::<String>();
+    let ladder = format!(
+        "first | ({cases_prefix}simp_all [{simp_list}]; done) | ({cases_prefix}simp_all [{simp_list}]; omega) | sorry"
+    );
+
+    let proof_lines = vec![
+        format!("  intro {}", intro_names.join(" ")),
+        format!("  induction {induct_on} generalizing {generalizing} with"),
+        format!("  | zero => {ladder}"),
+        format!("  | succ k ih => {ladder}"),
+    ];
+
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        proof_lines,
+        replaces_theorem: false,
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn emit_simple_induction(
     vb: &VerifyBlock,
@@ -993,12 +1135,54 @@ fn emit_simple_induction(
     // arm gets a bridge branch before `sorry` — defs/lemmas first, then
     // `simp only [bridges] <;> omega` for the arithmetic residual a stuck
     // Peano op leaves (see `emit_list_induction`'s `mk_arms`). Sound, so the
-    // branch can only add closures; absent in plain mode (byte-identical).
-    let arm_bridge = if !discovered_simp.is_empty() && !arith_bridges.is_empty() {
+    // branch can only add closures.
+    //
+    // część A2 — the arm bridge fires whenever a canonical-Peano op bridge is
+    // in scope, NOT only in `--discover` mode. `double x = plus x x` needs the
+    // `plus = +` bridge applied INSIDE the succ arm: after `simp [double]` +
+    // the IH the goal is `S (S (plus y y)) = plus (S y) (S y)`, whose RHS is
+    // stuck (`plus` recurses on a symbolic arg) but is pure linear arithmetic
+    // once `plus` rewrites to `+`. The top-level `simp only [bridge] <;> omega`
+    // fast path can't reach it (`double x` stays opaque there), so the bridge
+    // must ride the induction arm. Sound — `omega` decides only true goals; a
+    // residual it can't close still degrades to the honest `sorry`.
+    let arm_bridge = if !arith_bridges.is_empty() {
         Some(arith_bridges.join(", "))
     } else {
         None
     };
+
+    // część A2 (the `max`/`min` consumer) — kernel-proved commutativity lemmas
+    // for both-args-peeling Peano fns this law's cone consumes. `height (mirror
+    // t) = height t` collapses (after the node-arm IH) to `max (height r)
+    // (height l) = max (height l) (height r)`, closable only with `max`'s
+    // commutativity in the simp set. The lemma's simp set DROPS the comm'd fn's
+    // own def (unfolding `max'` alongside its `= flip` rewrite leaves the goal
+    // stuck), keeping every other law def. Both branches sound: a goal needing
+    // no commutativity still reaches the plain ladder, and the lemma is proved
+    // (a non-commutative fn never reaches here), never minting a false theorem.
+    let (comm_support, comm_lemma_names) = consumed_comm_lemmas(ctx, vb, law, &law_uid);
+    let comm_arm: Option<(String, String)> = if comm_lemma_names.is_empty() {
+        None
+    } else {
+        let commd_fns: BTreeSet<String> = comm_lemma_names
+            .iter()
+            .filter_map(|n| n.strip_suffix("_comm"))
+            .filter_map(|s| s.strip_prefix(&format!("{law_uid}_")))
+            .map(str::to_string)
+            .collect();
+        let mut comm_set: Vec<String> = law_simp_defs(ctx, vb, law)
+            .into_iter()
+            .filter(|d| !commd_fns.contains(d))
+            .collect();
+        comm_set.extend(comm_lemma_names.iter().cloned());
+        let set = comm_set.join(", ");
+        Some((
+            format!(" | (simp [{set}]; done)"),
+            format!(" | (simp_all [{set}]; done)"),
+        ))
+    };
+
     let mut arm_lines: Vec<String> = Vec::new();
     for variant in variants {
         let lean_variant = match &peano {
@@ -1021,8 +1205,12 @@ fn emit_simple_induction(
                     .as_deref()
                     .map(|b| format!(" | (simp [{d}]; simp only [{b}] <;> omega)", d = simp_list))
                     .unwrap_or_default();
+                let comm = comm_arm
+                    .as_ref()
+                    .map(|(leaf, _)| leaf.as_str())
+                    .unwrap_or_default();
                 arm_lines.push(format!(
-                    "| {v}{b} => first | (simp [{d}]; done) | (simp [{d}]; omega){bridge} | sorry",
+                    "| {v}{b} => first | (simp [{d}]; done) | (simp [{d}]; omega){bridge}{comm} | sorry",
                     v = lean_variant,
                     b = binders,
                     d = simp_list
@@ -1046,8 +1234,12 @@ fn emit_simple_induction(
                         )
                     })
                     .unwrap_or_default();
+                let comm = comm_arm
+                    .as_ref()
+                    .map(|(_, rec)| rec.as_str())
+                    .unwrap_or_default();
                 arm_lines.push(format!(
-                    "| {v} {b} {ih} => first | (simp_all [{d}]; done) | (simp_all [{d}]; omega){bridge} | sorry",
+                    "| {v} {b} {ih} => first | (simp_all [{d}]; done) | (simp_all [{d}]; omega){bridge}{comm} | sorry",
                     v = lean_variant,
                     b = field_binders.join(" "),
                     ih = ih_names.join(" "),
@@ -1112,6 +1304,7 @@ fn emit_simple_induction(
 
     let mut support_lines = discovered_support_lines(ctx, vb, law, discovered);
     support_lines.extend(arith_support);
+    support_lines.extend(comm_support);
     Some(AutoProof {
         support_lines,
         proof_lines,

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -35,7 +35,7 @@ pub(super) fn law_simp_defs(
         .collect()
 }
 
-fn law_simp_source_names(
+pub(super) fn law_simp_source_names(
     ctx: &CodegenContext,
     vb: &VerifyBlock,
     law: &VerifyLaw,

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -4732,9 +4732,17 @@ verify weird law weirdSpec
 
         let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
         let lean = generated_lean_file(&out);
-        assert!(lean.contains("def termToString__fuel"));
-        assert!(lean.contains("def subst__fuel"));
-        assert!(lean.contains("def countS__fuel"));
+        // termToString / subst / countS recurse structurally on the `Term`
+        // ADT, so they emit as plain structural defs (Lean infers termination,
+        // definitional unfolds) — the fuel retirement for SizeOfStructural. No
+        // `__fuel` helper. `eval` stays outside the proof subset (`partial def`);
+        // step/stepApp remain a mutual-fuel SCC (computed-arg recursion).
+        assert!(lean.contains("def termToString (t : Term)"));
+        assert!(lean.contains("def subst (x : String) (s : Term) (t : Term)"));
+        assert!(lean.contains("def countS (t : Term)"));
+        assert!(!lean.contains("def termToString__fuel"));
+        assert!(!lean.contains("def subst__fuel"));
+        assert!(!lean.contains("def countS__fuel"));
         assert!(!lean.contains("partial def termToString"));
         assert!(!lean.contains("partial def subst"));
         assert!(!lean.contains("partial def countS"));

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -876,37 +876,6 @@ fn emit_int_ascending_wrapper(
     ]
 }
 
-fn emit_fuelized_sizeof_fn(fd: &FnDef, ctx: &CodegenContext) -> String {
-    let helper_name = fuel_helper_name(&fd.name);
-    let params = emit_fn_params(&fd.params);
-    let ret_type = ret_type_or_unit(fd);
-    let recursive_types: HashSet<String> = ctx
-        .modules
-        .iter()
-        .flat_map(|m| m.type_defs.iter())
-        .chain(ctx.type_defs.iter())
-        .filter(|td| is_recursive_type_def(td))
-        .map(|td| type_def_name(td).to_string())
-        .collect();
-    let rewritten = rewrite_recursive_calls_body(
-        &fd.body,
-        &HashSet::from([fd.name.clone()]),
-        STRING_POS_FUEL_VAR,
-    );
-    let body = emit_fn_body_for(fd, &rewritten, ctx);
-
-    [
-        emit_doc_comment(&fd.desc),
-        emit_fuel_helper_def(&helper_name, &params, &ret_type, &body, ""),
-        vec![String::new()],
-        emit_mutual_sizeof_wrapper(fd, &helper_name, 1, &recursive_types),
-    ]
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>()
-    .join("\n")
-}
-
 /// Read the rank component of a `Fuel { Lex { .., rank } }` contract.
 /// Returns `None` when the fn has no contract or the contract isn't
 /// a Lex shape (non-mutual variant or non-recursive).
@@ -1372,25 +1341,26 @@ pub fn emit_fn_def_proof(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
         ));
     }
 
-    // SizeOfStructural — `Fuel { SizeOfPlusOne }`. No params bound;
-    // sizeOf walks the whole call frame.
+    // SizeOfStructural — `Fuel { SizeOfPlusOne }`. The classifier only assigns
+    // this contract when the recursion strictly shrinks a recursive sub-term
+    // binder (`supports_single_sizeof_structural`), i.e. it is genuine
+    // structural recursion on the user ADT's immediate sub-fields. Lean's
+    // equation compiler accepts exactly that natively, so we emit a plain `def`
+    // (fall through below) and let Lean infer structural termination — NO fuel.
     //
-    // EXCEPT when the structural recursion is on a canonical Peano parameter
-    // lifted to builtin `Nat`: then the recursion is structural on `Nat`
-    // (`Nat.rec`), so it falls through to the plain `def` below and Lean infers
-    // termination — fuel would only re-introduce the unfolding barrier the lift
-    // removes (no `simp [f]`, no `omega`).
-    if let Some(contract) = crate::codegen::common::find_fn_contract_for_fn(ctx, fd)
-        && matches!(
-            contract.recursion,
-            Some(crate::ir::RecursionContract::Fuel {
-                fuel_metric: crate::ir::FuelMetric::SizeOfPlusOne,
-            })
-        )
-        && !crate::codegen::proof_recognize::recurses_on_peano(fd, ctx)
-    {
-        return Some(emit_fuelized_sizeof_fn(fd, ctx));
-    }
+    // This is strictly better than the old fuel helper: a plain structural `def`
+    // has DEFINITIONAL recursive equations (`height (Node l y r) = …` is `rfl`),
+    // whereas a fuel counter destroys that (the fuel arg on a child differs from
+    // the child's own measure, so `simp [f]`/`omega` can't unfold it for
+    // symbolic/universal proofs — the very reason fuel forced the universal law
+    // to be skipped, Issue #128). Empirically (Lean 4.15) naive structural also
+    // covers mutual / accumulator / lexicographic recursion; only recursion
+    // hidden inside a higher-order container combinator (e.g. `kids.map f` over a
+    // nested-recursive field) needs an explicit well-founded measure, and that
+    // shape is never classified SizeOfStructural.
+    //
+    // The Peano-lift case already fell through here for the same reason
+    // (`recurses_on_peano` → structural on `Nat.rec`); it now shares the path.
 
     // StringPosAdvance — `Fuel { StringLenMinusPos { string, pos } }`.
     // Lean's emit reads the params from fd.params directly so the

--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -98,18 +98,6 @@ pub(crate) fn peano_ctor_role(
     }
 }
 
-/// Does function `fd` recurse structurally on a (lifted) Peano parameter? Such a
-/// function must NOT be fuel-encoded on a proof backend that lifts the type to a
-/// host builtin `Nat`: the recursion is then structural on `Nat` (host `Nat.rec`)
-/// and a fuel wrapper would only re-introduce the unfolding barrier the lift
-/// removes. Conservative: requires a parameter of a canonical Peano type.
-pub(crate) fn recurses_on_peano(fd: &FnDef, ctx: &CodegenContext) -> bool {
-    let peanos = collect_peano_types(ctx);
-    fd.params
-        .iter()
-        .any(|(_, ty)| peanos.iter().any(|p| ty.trim() == p.type_name))
-}
-
 /// Collect all function names called in an expression (top-level only).
 pub(crate) fn collect_called_fns(
     expr: &Spanned<Expr>,

--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -436,6 +436,96 @@ fn call_or_ctor(e: &Spanned<Expr>) -> Option<(String, Vec<&Spanned<Expr>>)> {
     }
 }
 
+/// Whether a law is a commutativity or associativity statement of a binary fn.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum BinaryLawShape {
+    /// `f a b = f b a` over two givens.
+    Commutativity,
+    /// `f (f a b) c = f a (f b c)` over three givens.
+    Associativity,
+}
+
+/// Recognize a law as the commutativity (`f a b = f b a`) or associativity
+/// (`f (f a b) c = f a (f b c)`) of `fn_name`, where each leaf argument is a
+/// distinct law `given`. Pure syntactic match against the law's `lhs`/`rhs`:
+/// every operand of `f` is a bare given identifier (no nested user calls, no
+/// constructors), the givens used are exactly the law's givens, and `f` is the
+/// only fn applied. Returns `None` for anything else — including a `when`
+/// premise (a conditional law is not an unconditional algebraic identity).
+///
+/// This is what gates the both-args-peeling generalizing-induction emit: it
+/// fires ONLY on these two genuine algebraic shapes, so a same-shaped fn used
+/// in an unrelated law (`minus(plus(n,m),n) = m`, a comparison `n ≤ m+n`) is
+/// NOT matched and keeps its existing proof path.
+pub(crate) fn recognize_binary_law_shape(
+    law: &VerifyLaw,
+    fn_name: &str,
+    given_names: &[String],
+) -> Option<BinaryLawShape> {
+    if law.when.is_some() {
+        return None;
+    }
+    // `f(x, y)` where `f`'s short name is `fn_name` → `(x, y)`.
+    let as_self_call = |e: &Spanned<Expr>| -> Option<(Spanned<Expr>, Spanned<Expr>)> {
+        let (callee, args) = match &e.node {
+            Expr::FnCall(c, a) => (crate::codegen::common::expr_to_dotted_name(&c.node)?, a),
+            _ => return None,
+        };
+        if short_ctor(&callee) != short_ctor(fn_name) || args.len() != 2 {
+            return None;
+        }
+        Some((args[0].clone(), args[1].clone()))
+    };
+    let given_name_of = |e: &Spanned<Expr>| -> Option<String> {
+        crate::codegen::recursion::detect::local_name_of(e)
+            .filter(|id| given_names.iter().any(|g| g == id))
+            .map(str::to_string)
+    };
+
+    // Commutativity: `f(a, b) = f(b, a)`, both args bare distinct givens.
+    if given_names.len() == 2
+        && let Some((la, lb)) = as_self_call(&law.lhs)
+        && let Some((ra, rb)) = as_self_call(&law.rhs)
+        && let (Some(la), Some(lb), Some(ra), Some(rb)) = (
+            given_name_of(&la),
+            given_name_of(&lb),
+            given_name_of(&ra),
+            given_name_of(&rb),
+        )
+        && la != lb
+        && la == rb
+        && lb == ra
+    {
+        return Some(BinaryLawShape::Commutativity);
+    }
+
+    // Associativity: `f(f(a, b), c) = f(a, f(b, c))`.
+    if given_names.len() == 3
+        && let Some((l_inner, lc)) = as_self_call(&law.lhs)
+        && let Some((la_inner, lb_inner)) = as_self_call(&l_inner)
+        && let Some((ra, r_inner)) = as_self_call(&law.rhs)
+        && let Some((rb_inner, rc_inner)) = as_self_call(&r_inner)
+        && let (Some(la), Some(lb), Some(lc), Some(ra), Some(rb), Some(rc)) = (
+            given_name_of(&la_inner),
+            given_name_of(&lb_inner),
+            given_name_of(&lc),
+            given_name_of(&ra),
+            given_name_of(&rb_inner),
+            given_name_of(&rc_inner),
+        )
+        && la == ra
+        && lb == rb
+        && lc == rc
+        && la != lb
+        && lb != lc
+        && la != lc
+    {
+        return Some(BinaryLawShape::Associativity);
+    }
+
+    None
+}
+
 /// `(p0, p1, base_arm_body, succ_binder, succ_arm_body)` — the decomposition
 /// [`peano_outer_split`] returns for a canonical binary Peano fn.
 type PeanoSplit<'a> = (
@@ -511,6 +601,59 @@ pub(crate) fn is_canonical_add(fd: &FnDef, peano: &PeanoType) -> bool {
             })
     });
     ln(base_body) == Some(p1) && add_succ_ok
+}
+
+/// `true` iff `fd` is a STRUCTURALLY COMMUTATIVE both-args-peeling Peano binary
+/// fn — the `max`/`min` shape whose two base arms are symmetric:
+/// `match a { Base -> A; Succ(q) -> match b { Base -> B; Succ(w) -> Succ(op(q, w)) } }`
+/// is commutative exactly when `(A, B)` is a symmetric pair: either `A = b` and
+/// `B = a` (the `B` reads as the whole first arg) — the `max` shape — or `A` and
+/// `B` are both the base constructor — the `min` shape. Both readings give
+/// `op(Base, y) = op(y, Base)` for every `y`, which together with the symmetric
+/// `Succ(op(q, w))` recursion makes `op a b = op b a` a theorem (proved by
+/// `induction a generalizing b … cases b`). Used to gate emitting a kernel-proved
+/// `comm` support lemma for a consumed `max`/`min`: a non-commutative
+/// both-args-peeling fn is rejected here, so no spurious `comm` lemma (which
+/// would only `sorry`) is ever emitted.
+pub(crate) fn both_args_peeling_is_commutative(fd: &FnDef, ctx: &CodegenContext) -> Option<()> {
+    if !crate::codegen::recursion::detect::recurses_decrementing_both_args(fd) {
+        return None;
+    }
+    let peano = peano_type_named(ctx, &fd.params.first()?.1)?;
+    let (p0, p1, base_body, q, succ_body) = peano_outer_split(fd, &peano)?;
+    let ln = crate::codegen::recursion::detect::local_name_of;
+    let is_base = |e: &Spanned<Expr>| {
+        call_or_ctor(e).is_some_and(|(c, a)| c == peano.base_ctor && a.is_empty())
+    };
+    // succ arm is an inner match on p1 with the canonical `Succ(op(q, w))` rec.
+    let Expr::Match {
+        subject: inner_subj,
+        arms: inner_arms,
+        ..
+    } = &succ_body.node
+    else {
+        return None;
+    };
+    if ln(inner_subj) != Some(p1) {
+        return None;
+    }
+    let (inner_base, w, inner_succ) = split_peano_match(inner_arms, &peano)?;
+    let rec_ok = call_or_ctor(inner_succ).is_some_and(|(c, a)| {
+        c == peano.succ_ctor
+            && a.len() == 1
+            && call_or_ctor(a[0]).is_some_and(|(rc, ra)| {
+                rc == fd.name && ra.len() == 2 && ln(ra[0]) == Some(q) && ln(ra[1]) == Some(w)
+            })
+    });
+    if !rec_ok {
+        return None;
+    }
+    // max shape: outer-base returns the other param (`b`), inner-base returns
+    // the first param (`a`, bound as the whole `Succ(q)` value).
+    let max_shape = ln(base_body) == Some(p1) && ln(inner_base) == Some(p0);
+    // min shape: both base arms return the base constructor.
+    let min_shape = is_base(base_body) && is_base(inner_base);
+    (max_shape || min_shape).then_some(())
 }
 
 /// Recognize a canonical Peano `+` / truncated `-` / `*` (see [`NatArithKind`]).

--- a/src/codegen/recursion/detect.rs
+++ b/src/codegen/recursion/detect.rs
@@ -770,6 +770,85 @@ pub(crate) fn param_threaded_in_recursion(fd: &FnDef, param_index: usize) -> boo
     })
 }
 
+/// `true` iff `fd` is a binary fn that recurses by peeling a constructor off
+/// BOTH arguments synchronously — the canonical `max`/`min` shape:
+/// `match p0 { base -> …; succ(z) -> match p1 { base -> …; succ(w) -> …rec(z, w)… } }`.
+/// Exactly one self-call, reached only from inside both succ arms, passing the
+/// two inner succ binders (NOT either original param) at positions 0 and 1.
+///
+/// This is the recursion shape that a commutativity (`f a b = f b a`) or
+/// associativity (`f (f a b) c = f a (f b c)`) proof must induct on with
+/// `induction a generalizing <rest> with | zero => cases <rest> … | succ k ih =>
+/// cases <rest> …`: inducting on one arg alone leaves the other arg's peel
+/// stuck. Conservative — both params must share one type, there must be exactly
+/// one self-call, and its two args must be the freshly-bound succ predecessors,
+/// so it fires only on the genuine both-args-peeling family and never on a
+/// single-arg-recursive fn (whose self-call repeats one original param).
+pub(crate) fn recurses_decrementing_both_args(fd: &FnDef) -> bool {
+    if fd.params.len() != 2 {
+        return false;
+    }
+    let (p0, t0) = &fd.params[0];
+    let (p1, t1) = &fd.params[1];
+    if t0 != t1 {
+        return false;
+    }
+    // Exactly one self-call, both args bare locals distinct from the originals.
+    let calls: Vec<Vec<&Spanned<Expr>>> = collect_calls_from_body(fd.body.as_ref())
+        .into_iter()
+        .filter(|(name, _)| call_matches(name, &fd.name))
+        .map(|(_, args)| args)
+        .collect();
+    if calls.len() != 1 {
+        return false;
+    }
+    let args = &calls[0];
+    let (Some(a0), Some(a1)) = (
+        args.first().and_then(|a| local_name_of(a)),
+        args.get(1).and_then(|a| local_name_of(a)),
+    ) else {
+        return false;
+    };
+    if a0 == p0 || a0 == p1 || a1 == p0 || a1 == p1 || a0 == a1 {
+        return false;
+    }
+    // Outer match on p0 with a succ arm binding `a0`, whose body is an inner
+    // match on p1 with a succ arm binding `a1`. Mirrors `peano_outer_split` but
+    // stays local to detect.rs (which has no `CodegenContext`/Peano lookup).
+    let Some(tail) = fd.body.tail_expr() else {
+        return false;
+    };
+    let Expr::Match { subject, arms, .. } = &tail.node else {
+        return false;
+    };
+    if local_name_of(subject) != Some(p0.as_str()) {
+        return false;
+    }
+    arms.iter().any(|arm| {
+        let Pattern::Constructor(_, binders) = &arm.pattern else {
+            return false;
+        };
+        if binders.len() != 1 || binders[0] != a0 {
+            return false;
+        }
+        let Expr::Match {
+            subject: inner_subj,
+            arms: inner_arms,
+            ..
+        } = &arm.body.node
+        else {
+            return false;
+        };
+        if local_name_of(inner_subj) != Some(p1.as_str()) {
+            return false;
+        }
+        inner_arms.iter().any(|inner| {
+            matches!(&inner.pattern,
+                Pattern::Constructor(_, b) if b.len() == 1 && b[0] == a1)
+        })
+    })
+}
+
 pub(crate) fn is_ident(expr: &Spanned<Expr>, name: &str) -> bool {
     local_name_of(expr).is_some_and(|id| id == name)
 }

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4373,17 +4373,18 @@ fn lean_proves_generalizing_induction_take_drop_when_lake_is_available() {
 /// Leaf-reach: a user fn named `max` (colliding with Lean 4's Max-typeclass
 /// `max`) is emitted as `max'`, so the proof can reference the user's
 /// recursion instead of the typeclass form. Before the escape the generated
-/// Lean failed to build (ambiguous/typeclass `max`); now it builds clean —
-/// proven by `assert_proof_builds` (which fails if lake errors) with the law
-/// honestly falling to one `sorry` (max-associativity is a 3-var induction the
-/// bare prover leaves open; the point is the file BUILDS, unblocking the
-/// decomposition loop on the max/min family). TIP isaplanner prop_22.
+/// Lean failed to build (ambiguous/typeclass `max`); now it builds clean.
+/// max-associativity USED to fall to one honest `sorry` (a 3-var induction the
+/// bare prover left open); the both-args-peeling generalizing emit now closes
+/// it as a GENUINE universal — `induction a generalizing b c with … cases b
+/// <;> cases c <;> simp_all`, `#print axioms = [propext]`. Budget is 0:
+/// fully proven. TIP isaplanner prop_22.
 #[test]
 fn lean_escapes_user_max_min_collision_when_lake_is_available() {
     assert_proof_builds_with_sorry_budget(
         "proof-corpus/tip/isaplanner/prop_22.av",
         "aver-max-escape",
-        1,
+        0,
     );
 }
 


### PR DESCRIPTION
Two stacked proof-emitter changes that close a whole cluster of open TIP tasks **bare** (no `--discover`, no helper laws) by giving user-ADT/Nat recursion the proof treatment lists already had.

## Commit 1 — retire fuel for structural recursion
User-ADT recursive fns (`SizeOfStructural`: recursion strictly shrinks a recursive sub-term binder) were emitted via a sizeOf-guarded fuel helper. Lean's equation compiler accepts that recursion natively, so we now emit a plain structural `def` and let Lean infer termination.

A fuel counter destroys the **definitional** recursive equation (`height (Node l y r) = …` is no longer `rfl` — the child's fuel arg differs from its own measure), which is exactly why a law calling a fuel-bounded helper had its universal proof skipped (Issue #128). Plain structural restores definitional unfolds → tree/user-ADT laws become provable. Empirically (Lean 4.15) naive structural also covers mutual/accumulator/lexicographic recursion; only recursion hidden inside a higher-order container combinator needs an explicit measure (never classified SizeOfStructural). Removes dead `emit_fuelized_sizeof_fn` + `recurses_on_peano`.

## Commit 2 — generalizing induction for Nat max/min + arm-injected bridges
Extends `emit_simple_induction` with the two things `emit_list_induction` already had:
- **A1**: `induction g1 generalizing g2 [g3] with … cases …` for both-args-peeling Nat fns (max/min) — needed for commutativity/associativity. Heavily gated (two-arg-peeling recursion shape + all-givens-Peano + genuine comm/assoc law shape) so bridge-proved laws like `minus(plus(n,m),n)=m` are untouched.
- **A2**: the canonical-op bridge + kernel-proved commutativity lemmas ride the induction **arms** (not just the top-level fast path) — `double x = plus x x` and `height(mirror t)=height t`.

All emitted tactics are sound (simp/simp_all/omega close only true goals; non-closing arm → honest `sorry` the universal metric catches; comm support lemma is itself kernel-proved).

## Result — closes bare (`universal:true, sorries:0`)
`prop_22`/`prop_23`/`prop_31`/`prop_32` (max/min comm+assoc), `prop_47` (height∘mirror), `prod/prop_01` (double) — **+6 to the bare Lean baseline**, from general compiler fixes (keyed on recursion/type structure, not names or benchmark shapes).

`proof_spec` **105/105** (the max-escape test's sorry budget drops 1→0: `prop_22` is now a genuine universal). clippy + fmt clean. Independently re-verified (proof_spec + all 6 targets via lake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)