### PR TITLE
proof-corpus: 4 more decomposed TIP wins (decomposition-reach chunk #2)

### DIFF
--- a/proof-corpus/decomposed/README.md
+++ b/proof-corpus/decomposed/README.md
@@ -38,12 +38,14 @@ Problems)**, `github.com/tip-org/benchmarks`, BSD-3-Clause — see
 `../tip/PROVENANCE.md` and `../tip/LICENSE.TIP`. The helper laws are our
 authorship; the surrounding program is the upstream-derived task verbatim.
 
-## Contents (16)
+## Contents (20)
 
-The first ten are the original chunk; the last six are **decomposition-reach
+The first ten are the original chunk; the next six are **decomposition-reach
 chunk #1** (2026-06-10) — the reverse/accumulator family, opened up by the
 accumulator-generalizing induction that landed in the auto-prover (`induction xs
-generalizing acc`). All six were OPEN even to Z3/Dafny.
+generalizing acc`). The last four are **chunk #2** — a deterministic spread over
+the fresh open pool (drop/concat, length-comm, rev-rev-append, mult-accumulator).
+All were OPEN even to Z3/Dafny.
 
 | file | target | bare-`tip/` status | what the decomposition added |
 |------|--------|--------------------|------------------------------|
@@ -63,8 +65,12 @@ generalizing acc`). All six were OPEN even to Z3/Dafny.
 | `prod/prop_29.av` | `rev(qrev x []) = x` | OPEN (frontier) | qrev-spec + rev-append homomorphism + rev involution |
 | `prod/prop_30.av` | `rev(rev x ++ []) = x` | OPEN (frontier) | rev-snoc + rev involution |
 | `prod/prop_31.av` | `qrev(qrev x []) [] = x` | OPEN (frontier) | generalized `qrev` "master" law `qrev(qrev(x,y),[]) = qrev(y,x)` |
+| `isaplanner/prop_55.av` | `drop n (xs++ys) = drop n xs ++ drop (n−len xs) ys` | OPEN (frontier) | the generalized drop-over-concat split law |
+| `prod/prop_02.av` | `length(x++y) = length(y++x)` | OPEN (frontier) | `length = List.len` bridge (length-homomorphism via the builtin) |
+| `prod/prop_19.av` | `rev(rev x)++y = rev(rev(x++y))` | OPEN (frontier) | append-nil-right + append-assoc + rev-distribution + rev-involution |
+| `prod/prop_34.av` | `times x y = mult x y 0` | OPEN (frontier) | `plus`-right-zero + the mult-accumulator generalization |
 
-Fourteen of the sixteen move the **union frontier** — the unaided engine
+Eighteen of the twenty move the **union frontier** — the unaided engine
 (auto-mode, `--discover`, and single-shot Dafny/Z3) closes none of them. The
 other two upgrade a Dafny-only (Z3-automated) task to a kernel-checked Lean
 proof. Every helper is a CANONICAL lemma (reflexivity, a homomorphism, an

--- a/proof-corpus/decomposed/isaplanner/prop_55.av
+++ b/proof-corpus/decomposed/isaplanner/prop_55.av
@@ -1,0 +1,39 @@
+module Prop55
+    intent =
+        "TIP isaplanner prop_55: drop n (xs ++ ys) = drop n xs ++ drop (n - len xs) ys."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn len(x: List<Int>) -> Nat
+    match x
+        [] -> Nat.Z
+        [y, ..xs] -> Nat.S(len(xs))
+
+fn drop(x: Nat, y: List<Int>) -> List<Int>
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> match y
+            [] -> []
+            [x2, ..x3] -> drop(z, x3)
+
+fn minus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> Nat.Z
+        Nat.S(z) -> match y
+            Nat.Z -> x
+            Nat.S(x2) -> minus(z, x2)
+
+verify drop law dropConcatGen
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Int> = [[1], [1, 2], [1, 2, 3]]
+    given ys: List<Int> = [[4], [4, 5], [6]]
+    drop(x, List.concat(xs, ys)) => List.concat(drop(x, xs), drop(minus(x, len(xs)), ys))
+
+verify drop law dropConcat
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Int> = [[1], [1, 2], [1, 2, 3]]
+    given ys: List<Int> = [[4], [4, 5], [6]]
+    drop(n, List.concat(xs, ys)) => List.concat(drop(n, xs), drop(minus(n, len(xs)), ys))

--- a/proof-corpus/decomposed/prod/prop_02.av
+++ b/proof-corpus/decomposed/prod/prop_02.av
@@ -1,0 +1,22 @@
+module Prop02
+    intent =
+        "TIP prod prop_02: length(x ++ y) = length(y ++ x)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(x: List<Int>) -> Nat
+    match x
+        [] -> Nat.Z
+        [y, ..xs] -> Nat.S(length(xs))
+
+verify length law lengthIsLen
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    length(x) => List.len(x)
+
+verify length law lengthConcatComm
+    given x: List<Int> = [[1], [2, 3], [1, 2, 3]]
+    given y: List<Int> = [[4], [5], [4, 5]]
+    length(List.concat(x, y)) => length(List.concat(y, x))

--- a/proof-corpus/decomposed/prod/prop_19.av
+++ b/proof-corpus/decomposed/prod/prop_19.av
@@ -1,0 +1,38 @@
+module Prop19
+    intent =
+        "TIP prod prop_19: rev(rev(x)) ++ y = rev(rev(x ++ y))."
+    effects []
+
+fn append(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..xs] -> append(rev(xs), [y])
+
+verify append law appendNilR
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    append(x, []) => x
+
+verify append law appendAssoc
+    given x: List<Int> = [[], [1], [1, 2]]
+    given y: List<Int> = [[], [4], [4, 5]]
+    given z: List<Int> = [[], [7], [7, 8]]
+    append(append(x, y), z) => append(x, append(y, z))
+
+verify rev law revDist
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given y: List<Int> = [[], [4], [4, 5], [4, 5, 6]]
+    rev(append(x, y)) => append(rev(y), rev(x))
+
+verify rev law revInvolution
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    rev(rev(x)) => x
+
+verify rev law revRevAppend
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given y: List<Int> = [[], [4], [4, 5], [4, 5, 6]]
+    append(rev(rev(x)), y) => rev(rev(append(x, y)))

--- a/proof-corpus/decomposed/prod/prop_34.av
+++ b/proof-corpus/decomposed/prod/prop_34.av
@@ -1,0 +1,38 @@
+module Prop34
+    intent =
+        "TIP prod prop_34: *2 x y = mult x y Z (direct mult equals accumulator mult)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn mult(x: Nat, y: Nat, z: Nat) -> Nat
+    match x
+        Nat.Z -> z
+        Nat.S(x2) -> mult(x2, y, plus(y, z))
+
+fn times(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> Nat.Z
+        Nat.S(z) -> plus(y, times(z, y))
+
+verify plus law plusRightZero
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, Nat.Z) => x
+
+verify mult law multAccumGen
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given z: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    mult(x, y, z) => plus(times(x, y), z)
+
+verify times law multAccum
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    times(x, y) => mult(x, y, Nat.Z)

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4240,6 +4240,11 @@ fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
         "proof-corpus/decomposed/prod/prop_29.av",
         "proof-corpus/decomposed/prod/prop_30.av",
         "proof-corpus/decomposed/prod/prop_31.av",
+        // decomposition-reach chunk #2 (deterministic spread over fresh open pool).
+        "proof-corpus/decomposed/isaplanner/prop_55.av",
+        "proof-corpus/decomposed/prod/prop_02.av",
+        "proof-corpus/decomposed/prod/prop_19.av",
+        "proof-corpus/decomposed/prod/prop_34.av",
     ];
     for task in tasks {
         let out = temp_output_dir(&format!(


### PR DESCRIPTION
**Decomposition-reach chunk #2** on the post-4a/A/4b binary — a deterministic, pre-registered spread over the 73-task fresh open pool (prior 93 open − 6 closed by generalizing induction − 16 already-decomposed). Anti-cherry-pick: pure spread, all 15 reported.

- **Reach: 4/15** closed. **VM:lake = 51:40 (1.27x)** — the smart-generator ~1:1 profile (not enumeration's VM≫lake). Lower reach than chunk #1 by design: chunk #1 was the qrev near-miss cluster; chunk #2 is the harder fresh tail.

## The 4 wins (pulled in, independently verified)
Integrity-diff (core byte-identical, only helper laws added) + lake re-check (`universal:true, sorries:0`):

| task | target | helpers |
|------|--------|---------|
| `isaplanner/prop_55` | `drop n (xs++ys) = drop n xs ++ drop (n−len xs) ys` | drop-over-concat split |
| `prod/prop_02` | `length(x++y) = length(y++x)` | `length = List.len` bridge |
| `prod/prop_19` | `rev(rev x)++y = rev(rev(x++y))` | append-nil + assoc + rev-dist + rev-involution |
| `prod/prop_34` | `times x y = mult x y 0` | `plus`-right-zero + mult-accumulator gen |

## Gap-map from the 11 open (not this PR — informs the roadmap)
- **Biggest TIP wall: generalizing-induction-vs-sibling-injection mutual exclusion** (3 tasks: prop_74/81/08) — a known small fix (`induction.rs` `fast_simp.is_empty()` guard).
- **Genuine when-gate small on TIP (~2)** — confirming (with a parallel real-examples survey) that when-guarded laws are a **real-Aver phenomenon** (JSON roundtrips, refinement preconditions), not a TIP one.
- One more **false-universal corpus task** (`prop_59`: a `ys=nil` hypothesis encoded only via `given` examples → the ∀-over-all-params is false; the pipeline correctly refused + emitted a counterexample), same class as `prop_16`.

`decomposed/` stays a separate loop-reach metric, excluded from `run.sh`. README → 20; `proof_spec::decomposed_tip_tasks_stay_universal` → 20 (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)