### PR TITLE
proof(lean): combine generalizing induction with sibling-lemma injection (LUKA 2)

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -835,7 +835,7 @@ fn emit_list_induction(
             "  | cons head tail ih => {}",
             wrap(&ladder("simp_all"))
         ));
-    } else if fast_simp.is_empty() {
+    } else if fast_simp.is_empty() && gen_given.is_none() {
         let (nil_arm, cons_arm) = mk_arms(&simp_list, &split_set, None, true);
         proof_lines.push(format!("  induction {} with", target_lean));
         proof_lines.push(format!("  {nil_arm}"));
@@ -905,7 +905,78 @@ fn emit_list_induction(
                 fast_unfolds.into_iter().collect::<Vec<_>>().join(", ")
             ));
         }
-        if arm_forward_siblings.is_empty() {
+        if let Some((gv, needs_cases)) = gen_given.as_ref() {
+            // LUKA 2 — GENERALIZING induction WITH in-arm Forward siblings.
+            // This is the missing combination: the subject fn threads/decrements
+            // a Peano `<gv>` synchronously with the recursing list (`take`/`drop`'s
+            // `n`, or `qrev`'s threaded `acc`) AND earlier-sibling helper laws are
+            // in scope. The plain feedback ladder below would induct on the list
+            // WITHOUT `generalizing <gv>`, fixing the cons IH at the original
+            // `<gv>` — after `cases <gv>` the residual needs the IH at the
+            // predecessor, which doesn't exist, so it `sorry`s. Emitting the
+            // generalizing form makes the cons IH `∀ <gv>, P <gv> tail`, so it
+            // applies at the recursion's threaded/decremented value, while the
+            // Forward siblings rewrite the helper-shaped residual in-arm (e.g.
+            // `rev (drop n xs) = take (len xs - n) (rev xs)` needs `len (rev _)`,
+            // take-all, and a take-over-append split inside the succ arm).
+            //
+            // SOUNDNESS / no-loop: the arm set is `simp_list ∪ arm_forward_siblings`
+            // — Forward-only and loop-excluded, EXACTLY as część C's ladderB. We
+            // do NOT inject Reversed (`← `) rules into the arms: an unfold rule
+            // mixed with the fn's own def in an arm can simp-loop, and a simp loop
+            // is an uncatchable `maxHeartbeats` build hang. Reversed rules stay on
+            // the fast path above. Each arm keeps the sound
+            // `first | (simp…;done) | (…;omega) | (split…) | sorry` shape, so a
+            // non-closing arm degrades to an honest `sorry` (caught by the
+            // universal metric), never an unsolved-goals build error.
+            let gen_simp = {
+                let mut v: Vec<String> = simp_list.split(", ").map(String::from).collect();
+                v.extend(arm_forward_siblings.iter().cloned());
+                v.retain(|s| !s.is_empty());
+                v.join(", ")
+            };
+            let gen_split = if gen_simp.is_empty() {
+                "List.cons_append".to_string()
+            } else {
+                format!("{gen_simp}, List.cons_append")
+            };
+            // Same sound chain as the gen-only branch, with the Peano-op bridge
+            // (`plus a b = a + b`, `minus`'s `= a - b`) appended after the def
+            // unfolds + IH: a goal like `take (minus (len t) z) (rev t ++ [h]) =
+            // …` is pure once `minus` is bridged and the take-over-append sibling
+            // has fired. The bridge variant only runs after the plain `simp`/`omega`
+            // arms fail, so closing arms are untouched; `simp only [bridge] <;>
+            // omega` is a sound decision step.
+            let ladder = |s: &str| -> String {
+                let bridge_arm = bridge_set
+                    .as_deref()
+                    .map(|b| format!(" | ({s} [{gen_simp}]; simp only [{b}] <;> omega)"))
+                    .unwrap_or_default();
+                let split_bridge = bridge_set
+                    .as_deref()
+                    .map(|b| format!(" <;> (try simp only [{b}])"))
+                    .unwrap_or_default();
+                format!(
+                    "first | ({s} [{gen_simp}]; done) | ({s} [{gen_simp}]; omega){bridge_arm} | (simp only [{gen_split}]; split <;> simp_all [{gen_simp}]{split_bridge} <;> omega) | sorry"
+                )
+            };
+            let wrap = |arm: &str| -> String {
+                if *needs_cases {
+                    format!("cases {gv} <;> ({arm})")
+                } else {
+                    arm.to_string()
+                }
+            };
+            proof_lines.push(format!(
+                "  | (induction {} generalizing {} with",
+                target_lean, gv
+            ));
+            proof_lines.push(format!("     | nil => {}", wrap(&ladder("simp"))));
+            proof_lines.push(format!(
+                "     | cons head tail ih => {})",
+                wrap(&ladder("simp_all"))
+            ));
+        } else if arm_forward_siblings.is_empty() {
             // No in-arm sibling to add: one committed-only ladder, with sorry.
             let (nil_arm, cons_arm) = mk_arms(&simp_list, &split_set, bridge_set.as_deref(), true);
             proof_lines.push(format!("  | (induction {} with", target_lean));

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4442,3 +4442,104 @@ fn lean_proves_accumulator_generalizing_qrev_when_lake_is_available() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+/// LUKA 2: generalizing induction and sibling-lemma injection must COMBINE. The
+/// `dropRevLen` law's verified fn (`drop`) threads a Peano param (`n`) while
+/// recursing on a list, so it needs `induction xs generalizing n`; AND it needs
+/// the forward-homomorphism siblings (`lenAppend`, `lenRev`) rewriting inside
+/// the induction arms. Before the fix these were mutually exclusive (the
+/// `gen_given` branch was gated on `fast_simp.is_empty()`), so a law needing
+/// both fell to plain `induction` and left a `sorry`. The arm simp set carries
+/// Forward siblings only (loop-excluded via `simp_entries`) — no `←` unfold
+/// rules — so no `maxHeartbeats` simp loop.
+#[test]
+fn lean_proves_generalizing_induction_with_siblings_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping gen+siblings test: `lake` not available");
+        return;
+    }
+    let source = r#"module GenSiblings
+    intent = "generalizing induction + forward-sibling arm injection combined"
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn len(xs: List<Int>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(len(ys))
+
+fn drop(n: Nat, xs: List<Int>) -> List<Int>
+    match n
+        Nat.Z -> xs
+        Nat.S(z) -> match xs
+            [] -> []
+            [x2, ..x3] -> drop(z, x3)
+
+fn minus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> Nat.Z
+        Nat.S(z) -> match y
+            Nat.Z -> x
+            Nat.S(x2) -> minus(z, x2)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn rev(xs: List<Int>) -> List<Int>
+    match xs
+        [] -> []
+        [y, ..ys] -> List.concat(rev(ys), [y])
+
+verify len law lenAppend
+    given a: List<Int> = [[1], [1, 2, 3]]
+    given b: List<Int> = [[7], [8, 9]]
+    len(List.concat(a, b)) => plus(len(a), len(b))
+
+verify len law lenRev
+    given xs: List<Int> = [[], [1], [1, 2, 3]]
+    len(rev(xs)) => len(xs)
+
+verify drop law dropRevLen
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Int> = [[], [1], [1, 2, 3]]
+    given ys: List<Int> = [[2], [3, 4]]
+    len(List.concat(rev(drop(n, xs)), ys)) => plus(minus(len(xs), n), len(ys))
+"#;
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-gensib-src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(src.join("m.av"), source).expect("write");
+    let out = temp_output_dir("aver-gensib-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("aver proof ran");
+    let json = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON:\n{}", format_output(&run)));
+    let summary: serde_json::Value = serde_json::from_str(json).expect("json");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "generalizing induction + forward-sibling arm injection must combine to \
+         close dropRevLen (the gen-vs-sibling mutual-exclusion gap)\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
Closes the **generalizing-induction-vs-sibling-injection mutual exclusion** in `emit_list_induction` — the biggest auto-prover wall the decomposition sweeps surfaced.

## The gap
The generalizing branch was gated `gen_given.filter(|_| fast_simp.is_empty())`. So a law that BOTH needs `induction xs generalizing n` (its verified fn threads a Peano param while recursing on a list — take/drop's `n`) AND has earlier-sibling helper laws in scope fell to the feedback path's **plain** `induction xs` (no generalizing) → cons IH fixed at the original `n` → `sorry`. The two capabilities couldn't combine.

## Fix
Add the missing fourth combination: when `gen_given` is Some and `fast_simp` is non-empty, emit generalizing induction with the **Forward** siblings threaded into the arm simp set. Reuses the część-C `arm_forward_siblings` filter — Forward-only, `←` Reversed rules stay on the fast path — so the `simp_entries` loop-exclusion applies. **A Reversed unfold mixed with the fn's own def in an arm can simp-loop into an uncatchable `maxHeartbeats` hang — exactly why the original guard existed; this preserves that safety.**

## Honest scope — this is banked infrastructure, currently LATENT
Sound, regression-safe expressiveness fix, but the combination is **not hit by any current corpus task** — the sweep tasks that motivated it (e.g. `prop_72`) have orthogonal co-blockers (a conditional `k ≤ len` fact, a separate gap). It's banked because real list laws that need both generalizing induction AND an earlier lemma will hit it. Guarded by a new lake-gated regression test (`GenSiblings`/`dropRevLen`) that reaches `universal:true` ONLY with the combination and `sorry`s without it (`#print axioms = [propext, Quot.sound]`).

## Verification
`cargo test --workspace` **2076/2076** — **no `maxHeartbeats`/hang**, existing gen-only/plain/feedback paths byte-identical for their cases. clippy `--lib --bin -D warnings` clean; fmt clean. Independently re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)