### PR TITLE
proof: collect ?-wrapped calls into the unfold set (real-Aver refinement-pipeline laws)

### DIFF
--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -1403,6 +1403,24 @@ fn collect_fn_calls_expr(
                 collect_fn_calls_expr(arg, out);
             }
         }
+        // Value-carrying expressions whose sub-exprs hold fn calls the proof's
+        // unfold set needs. Crucially `ErrorProp` (`?`): a refinement-pipeline
+        // body like `na = fromInt(a)?; add(na, nb)?` hides every call behind `?`,
+        // so without this arm the unfold set misses `fromInt`/`add` and the
+        // LinearArithmetic tactic stalls with "simp made no progress". Mirrors
+        // `proof_recognize::collect_called_fns`.
+        Expr::ErrorProp(inner) | Expr::Neg(inner) => collect_fn_calls_expr(inner, out),
+        Expr::Constructor(_, Some(arg)) => collect_fn_calls_expr(arg, out),
+        Expr::RecordCreate { fields, .. } => {
+            for (_, e) in fields {
+                collect_fn_calls_expr(e, out);
+            }
+        }
+        Expr::List(elems) | Expr::Tuple(elems) | Expr::IndependentProduct(elems, _) => {
+            for e in elems {
+                collect_fn_calls_expr(e, out);
+            }
+        }
         _ => {}
     }
 }

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4448,6 +4448,75 @@ fn lean_proves_accumulator_generalizing_qrev_when_lake_is_available() {
     let _ = std::fs::remove_dir_all(&out);
 }
 
+/// A law whose verified fn body propagates errors with `?` must still collect
+/// the `?`-wrapped calls into its unfold set. `sumSafe`'s body is
+/// `x = safe(a)?; y = safe(b)?; Ok(x + y)` — every call hides behind `?`
+/// (`Expr::ErrorProp`). Before `collect_fn_calls_expr` handled `ErrorProp`, the
+/// unfold set missed `safe`, so the LinearArithmetic tactic stalled with "simp
+/// made no progress" and the commutativity law stayed open. With the arm, `safe`
+/// unfolds and the law closes kernel-clean. (Found on the real
+/// `refinement/natural_app.av` safeSum commutativity — a `?`-pipeline the TIP
+/// corpus never exercises.)
+#[test]
+fn lean_proves_error_prop_pipeline_law_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping ?-pipeline test: `lake` not available");
+        return;
+    }
+    let source = r#"module QPipe
+    intent = "a law over a ?-propagating body must unfold the ?-wrapped calls"
+    effects []
+
+fn safe(x: Int) -> Result<Int, String>
+    ? "non-negative gate"
+    match x >= 0
+        true -> Result.Ok(x)
+        false -> Result.Err("neg")
+
+fn sumSafe(a: Int, b: Int) -> Result<Int, String>
+    ? "add two gated ints; ? short-circuits"
+    x = safe(a)?
+    y = safe(b)?
+    Result.Ok(x + y)
+
+verify sumSafe law commutative
+    given a: Int = [0, 1, 7]
+    given b: Int = [0, 2, 9]
+    sumSafe(a, b) => sumSafe(b, a)
+"#;
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-qpipe-src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(src.join("m.av"), source).expect("write");
+    let out = temp_output_dir("aver-qpipe-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("aver proof ran");
+    let json = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON:\n{}", format_output(&run)));
+    let summary: serde_json::Value = serde_json::from_str(json).expect("json");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "a law over a ?-propagating body must unfold its ?-wrapped calls and close\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
 /// LUKA 2: generalizing induction and sibling-lemma injection must COMBINE. The
 /// `dropRevLen` law's verified fn (`drop`) threads a Peano param (`n`) while
 /// recursing on a list, so it needs `induction xs generalizing n`; AND it needs


### PR DESCRIPTION
A **real compiler bug** surfaced by measuring the prover against real example ∀-laws (not TIP).

## Bug
`collect_fn_calls_expr` (builds the LinearArithmetic / simp-omega unfold set) had no arm for `Expr::ErrorProp` (the `?` operator). A law over a body that propagates errors with `?` lost every `?`-wrapped call. `safeSum` —
```
na = fromInt(a)?
nb = fromInt(b)?
sum = add(na, nb)?
Result.Ok(toInt(sum))
```
— collected only `toInt`; `fromInt`/`add` were dropped → `simp only [unfold] <;> omega` stalled ("simp made no progress") → the commutativity law stayed open.

## Fix
Add `ErrorProp` (+ the other value-carrying variants that can hold calls: `Neg`, `Constructor`, `RecordCreate`, `List`, `Tuple`, `IndependentProduct`), mirroring `proof_recognize::collect_called_fns`. The `?`-wrapped fns now enter the unfold set; the existing tactic closes the law kernel-clean.

## Why TIP never caught it
TIP has no `?`-pipelines or refinement smart-constructors. This came from the real-Aver ∀-law survey: `refinement/natural_app.av`'s `safeSum` commutativity now closes (`--module-root examples`, `universal:true`, `#print axioms = [propext, Quot.sound]`).

## Verification
New self-contained regression test `lean_proves_error_prop_pipeline_law` (QPipe/`sumSafe`). `cargo test --workspace` **2077/2077** — no regression (wider unfold sets only ADD fn names). clippy `--lib --bin -D warnings` clean; fmt clean. Independently re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)