### PR TITLE
proof: handle Int.max/Int.min in LinearArithmetic laws (real-Aver game law)

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -486,6 +486,7 @@ pub fn emit_verify_law_forall_auto_proof(
                 } else {
                     &proof_intro_names
                 };
+                let uses_max_min = linear_arith_uses_max_min(unfold_fns, ctx);
                 return Some(AutoProof {
                     support_lines: Vec::new(),
                     proof_lines: emit_simp_omega_from_ir(
@@ -495,6 +496,7 @@ pub fn emit_verify_law_forall_auto_proof(
                         lifted,
                         chosen_intro,
                         law.when.is_some(),
+                        uses_max_min,
                         ctx,
                     ),
                     replaces_theorem: false,
@@ -520,6 +522,7 @@ pub fn emit_verify_law_forall_auto_proof(
 /// emit body of the legacy `emit_simp_omega_law` (kept as fallback
 /// for `BackendDispatch`) but sources `unfold_fns` / `wrapper_
 /// return` / `smart_guard` from `ProofIR.law_theorems[*].strategy`.
+#[allow(clippy::too_many_arguments)]
 fn emit_simp_omega_from_ir(
     unfold_fns: &[String],
     wrapper_return: bool,
@@ -527,6 +530,7 @@ fn emit_simp_omega_from_ir(
     lifted: bool,
     intro_names: &[String],
     has_when: bool,
+    uses_max_min: bool,
     ctx: &CodegenContext,
 ) -> Vec<String> {
     let lean_names: Vec<String> = unfold_fns.iter().map(|n| aver_name_to_lean(n)).collect();
@@ -585,12 +589,95 @@ fn emit_simp_omega_from_ir(
         // premise opaque and `omega` fails ("no usable constraints"),
         // wrongly rejecting a valid law. Without a `when`, keep the
         // conservative `simp only` — there is no premise to simplify.
-        let tac = if has_when {
+        let tac = if uses_max_min {
+            // `Int.max`/`Int.min` lower to core `max`/`min`, which
+            // `omega` treats as opaque atoms (it has no `max`/`min`
+            // theory). Unfolding `Int.max_def`/`Int.min_def` exposes
+            // the underlying `if a ≤ b then …` so `split` peels each
+            // branch into a linear goal `omega` can close. `try split`
+            // (not bare `split`) keeps this safe when the unfold leaves
+            // nothing to split — a bare `split` on a split-free goal is
+            // an error. `simp_all` discharges the residual `if`/premise
+            // shape before `omega`. GATED: only laws whose unfold chain
+            // actually calls `Int.max`/`Int.min` take this path; every
+            // other linear-arithmetic law stays byte-identical to the
+            // `simp only [...] <;> omega` / `simp_all [...] <;> omega`
+            // forms below so no existing law regresses.
+            let lemmas: Vec<String> = lean_names
+                .iter()
+                .cloned()
+                .chain(["Int.max_def".to_string(), "Int.min_def".to_string()])
+                .collect();
+            format!(
+                "simp only [{}] <;> (try split) <;> simp_all <;> omega",
+                lemmas.join(", ")
+            )
+        } else if has_when {
             format!("simp_all [{}] <;> omega", lean_names.join(", "))
         } else {
             format!("simp only [{}] <;> omega", lean_names.join(", "))
         };
         intro_then(intro_names, vec![tac])
+    }
+}
+
+/// Detect whether the LinearArithmetic unfold chain calls
+/// `Int.max` / `Int.min`. Drives the gated `Int.max_def`/`Int.min_def`
+/// split tactic in [`emit_simp_omega_from_ir`] — only laws that
+/// actually involve min/max take the split path; everything else stays
+/// on the byte-identical `simp only`/`simp_all` + `omega` forms.
+///
+/// Walks the *bodies* of every fn named in `unfold_fns` (the same fns
+/// the tactic will `simp only [...]`-unfold), so an `Int.max` buried in
+/// a helper that the law transitively unfolds is still caught. Resolves
+/// each name via the symbol table (entry scope, then every dep module),
+/// matching how the unfold list itself is sourced.
+fn linear_arith_uses_max_min(unfold_fns: &[String], ctx: &CodegenContext) -> bool {
+    unfold_fns.iter().any(|name| {
+        let fd = ctx.fn_def_by_name(name, None).or_else(|| {
+            ctx.modules
+                .iter()
+                .find_map(|m| ctx.fn_def_by_name(name, Some(&m.prefix)))
+        });
+        fd.is_some_and(|fd| fn_body_calls_max_min(&fd.body))
+    })
+}
+
+/// True when `body` contains a call to `Int.max` or `Int.min`.
+fn fn_body_calls_max_min(body: &crate::ast::FnBody) -> bool {
+    body.stmts().iter().any(|stmt| match stmt {
+        crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => expr_calls_max_min(e),
+    })
+}
+
+fn expr_calls_max_min(expr: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::FnCall(f, args) => {
+            let is_max_min = crate::codegen::common::expr_to_dotted_name(&f.node)
+                .is_some_and(|n| n == "Int.max" || n == "Int.min");
+            is_max_min || args.iter().any(expr_calls_max_min)
+        }
+        Expr::BinOp(_, l, r) => expr_calls_max_min(l) || expr_calls_max_min(r),
+        Expr::Neg(inner) | Expr::Attr(inner, _) | Expr::ErrorProp(inner) => {
+            expr_calls_max_min(inner)
+        }
+        Expr::Match { subject, arms } => {
+            expr_calls_max_min(subject) || arms.iter().any(|arm| expr_calls_max_min(&arm.body))
+        }
+        Expr::Constructor(_, Some(inner)) => expr_calls_max_min(inner),
+        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+            items.iter().any(expr_calls_max_min)
+        }
+        Expr::MapLiteral(entries) => entries
+            .iter()
+            .any(|(k, v)| expr_calls_max_min(k) || expr_calls_max_min(v)),
+        Expr::RecordCreate { fields, .. } => fields.iter().any(|(_, e)| expr_calls_max_min(e)),
+        Expr::RecordUpdate { base, updates, .. } => {
+            expr_calls_max_min(base) || updates.iter().any(|(_, e)| expr_calls_max_min(e))
+        }
+        Expr::TailCall(boxed) => boxed.args.iter().any(expr_calls_max_min),
+        _ => false,
     }
 }
 

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -1377,8 +1377,21 @@ fn collect_fn_calls_expr(
                 // segment's case discriminates user fns from
                 // namespace types (cross-module user calls survive
                 // because the leaf fn name starts lower-case).
+                //
+                // Builtin *scalar*-namespace methods (`Int.max`,
+                // `Float.abs`, `Bool.and`, `String.len`, …) have a
+                // lowercase leaf but lower to **core** Lean ops, not
+                // to unfoldable user defs — `Int.max` becomes `max`,
+                // there is no constant named `Int.max` in scope. Citing
+                // them in `simp only [...]` is a hard `unknown constant`
+                // error, so the scalar namespaces are excluded by their
+                // HEAD segment. Cross-module USER calls (`MyModule.helper`)
+                // keep flowing through — only the four builtin scalar
+                // namespaces are filtered.
                 let last = name.rsplit('.').next().unwrap_or(&name);
-                if last.chars().next().is_some_and(|c| c.is_lowercase()) {
+                let head = name.split('.').next().unwrap_or(&name);
+                let is_builtin_scalar_ns = matches!(head, "Int" | "Float" | "Bool" | "String");
+                if !is_builtin_scalar_ns && last.chars().next().is_some_and(|c| c.is_lowercase()) {
                     out.insert(name);
                 }
             }

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4517,6 +4517,65 @@ verify sumSafe law commutative
     let _ = std::fs::remove_dir_all(&out);
 }
 
+/// A LinearArithmetic law over a fn using `Int.max`/`Int.min` must close. Two
+/// bugs blocked it: (1) `Int.max` (lowercase leaf) leaked into the unfold set as
+/// the non-existent constant `Int.max` → `unknown constant` compile error;
+/// (2) even removed, `omega` treats `max` as opaque. Fix: filter `Int`/`Float`/
+/// `Bool`/`String` scalar-namespace methods from the unfold set, and — gated on
+/// the law actually using max/min — emit `simp only […, Int.max_def, Int.min_def]
+/// <;> (try split) <;> simp_all <;> omega` (byte-identical otherwise). (Found on
+/// the real `games/rogue/types.av` calcDamage = `Int.max(1, atk-def)`.)
+#[test]
+fn lean_proves_int_max_linear_arith_law_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping Int.max test: `lake` not available");
+        return;
+    }
+    let source = r#"module MaxPos
+    intent = "an Int.max LinearArithmetic law must unfold Int.max_def + split"
+    effects []
+
+fn dmg(atk: Int, def: Int) -> Int
+    Int.max(1, atk - def)
+
+verify dmg law alwaysPositive
+    given atk: Int = [0, 5, 10]
+    given def: Int = [0, 3, 20]
+    dmg(atk, def) > 0 => true
+"#;
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-maxpos-src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(src.join("m.av"), source).expect("write");
+    let out = temp_output_dir("aver-maxpos-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("aver proof ran");
+    let json = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON:\n{}", format_output(&run)));
+    let summary: serde_json::Value = serde_json::from_str(json).expect("json");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "an Int.max LinearArithmetic law must close kernel-clean\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
 /// LUKA 2: generalizing induction and sibling-lemma injection must COMBINE. The
 /// `dropRevLen` law's verified fn (`drop`) threads a Peano param (`n`) while
 /// recursing on a list, so it needs `induction xs generalizing n`; AND it needs


### PR DESCRIPTION
Second **real compiler bug** from measuring the prover against real example ∀-laws — `games/rogue/types.av`'s `calcDamage law alwaysPositive` (`calcDamage = Int.max(1, atk-def)`, law `calcDamage(...) > 0`) failed to close.

## Two compounding bugs
1. **Unfold-set pollution.** `collect_fn_calls_expr` inserted any callee with a lowercase leaf, so `Int.max` (leaf `max`) entered the unfold set as the non-existent constant `Int.max` → `simp only [..., Int.max] <;> omega` was a HARD `unknown constant 'Int.max'` error. Builtin **scalar-namespace** methods (`Int`/`Float`/`Bool`/`String`) emit to core Lean ops, not unfoldable user defs — now excluded by head segment. Cross-module USER calls (`Module.fn`) and dotless user fns still flow through.
2. **omega can't decide `max`/`min`** (opaque atoms). The LinearArithmetic emit now detects whether the law's unfold chain actually calls `Int.max`/`Int.min` (`linear_arith_uses_max_min`) and **only then** emits `simp only [unfold, Int.max_def, Int.min_def] <;> (try split) <;> simp_all <;> omega`. Non-max/min laws stay **byte-identical** (`simp only [unfold] <;> omega`); `try split` (not bare `split`) is a no-op on split-free goals.

## Result
`calcDamage.alwaysPositive` → `universal:true, sorries:0`, `#print axioms = [propext, Quot.sound]`. New self-contained regression test `lean_proves_int_max_linear_arith_law` (MaxPos/`dmg`). proof_spec **108/108** (rebased on #462; both `?`-pipeline and Int.max tests pass together). `cargo test --workspace` green, no regression (the max/min branch is gated). clippy `--lib --bin -D warnings` clean; fmt clean. Independently re-verified.

Found by measuring REAL example ∀-laws (TIP has no `Int.max` in laws). Stacked on #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)