### PR TITLE
corpus: honesty pass — demote false Float ∀-laws (order_total) and oracle-pinned laws (file_store_shell)

### DIFF
--- a/examples/core/order_total.av
+++ b/examples/core/order_total.av
@@ -73,11 +73,10 @@ fn sumItems(items: List<Item>) -> Float
 verify sumItems
     sumItems([]) => 0.0
     sumItems([Item(price = 7.0, quantity = 4)]) => 7.0 * 4.0
-
-verify sumItems law sumSplitsOverConcat
-    given a: Item = [Item(price = 5.0, quantity = 3), Item(price = 10.0, quantity = 1)]
-    given b: Item = [Item(price = 7.0, quantity = 2), Item(price = 3.0, quantity = 4)]
-    sumItems([a, b]) => sumItems([a]) + sumItems([b])
+    sumItems([Item(price = 5.0, quantity = 3), Item(price = 7.0, quantity = 2)]) => sumItems([Item(price = 5.0, quantity = 3)]) + sumItems([Item(price = 7.0, quantity = 2)])
+    sumItems([Item(price = 5.0, quantity = 3), Item(price = 3.0, quantity = 4)]) => sumItems([Item(price = 5.0, quantity = 3)]) + sumItems([Item(price = 3.0, quantity = 4)])
+    sumItems([Item(price = 10.0, quantity = 1), Item(price = 7.0, quantity = 2)]) => sumItems([Item(price = 10.0, quantity = 1)]) + sumItems([Item(price = 7.0, quantity = 2)])
+    sumItems([Item(price = 10.0, quantity = 1), Item(price = 3.0, quantity = 4)]) => sumItems([Item(price = 10.0, quantity = 1)]) + sumItems([Item(price = 3.0, quantity = 4)])
 
 fn applyDiscount(subtotal: Float, d: Discount) -> Float
     ? "Reduces subtotal by the discount percentage."
@@ -86,11 +85,15 @@ fn applyDiscount(subtotal: Float, d: Discount) -> Float
 verify applyDiscount
     applyDiscount(100.0, Discount(percent = 0.0))   => 100.0
     applyDiscount(100.0, Discount(percent = 100.0))  => 0.0
-
-verify applyDiscount law discountNeverIncreasesPositive
-    given subtotal: Float = [50.0, 100.0, 200.0]
-    given d: Discount = [Discount(percent = 0.0), Discount(percent = 25.0), Discount(percent = 100.0)]
-    applyDiscount(subtotal, d) <= subtotal => true
+    applyDiscount(50.0, Discount(percent = 0.0)) <= 50.0 => true
+    applyDiscount(50.0, Discount(percent = 25.0)) <= 50.0 => true
+    applyDiscount(50.0, Discount(percent = 100.0)) <= 50.0 => true
+    applyDiscount(100.0, Discount(percent = 0.0)) <= 100.0 => true
+    applyDiscount(100.0, Discount(percent = 25.0)) <= 100.0 => true
+    applyDiscount(100.0, Discount(percent = 100.0)) <= 100.0 => true
+    applyDiscount(200.0, Discount(percent = 0.0)) <= 200.0 => true
+    applyDiscount(200.0, Discount(percent = 25.0)) <= 200.0 => true
+    applyDiscount(200.0, Discount(percent = 100.0)) <= 200.0 => true
 
 fn applyTax(amount: Float, t: TaxRate) -> Float
     ? "Adds tax on top of amount."
@@ -98,16 +101,21 @@ fn applyTax(amount: Float, t: TaxRate) -> Float
 
 verify applyTax
     applyTax(100.0, TaxRate(percent = 0.0)) => 100.0
-
-verify applyTax law taxNeverDecreasesPositive
-    given amount: Float = [50.0, 100.0, 200.0]
-    given t: TaxRate = [TaxRate(percent = 0.0), TaxRate(percent = 10.0), TaxRate(percent = 50.0)]
-    applyTax(amount, t) >= amount => true
-
-verify applyTax law doubleAmountDoublesTax
-    given amount: Float = [50.0, 100.0]
-    given t: TaxRate = [TaxRate(percent = 0.0), TaxRate(percent = 10.0), TaxRate(percent = 25.0)]
-    applyTax(2.0 * amount, t) => 2.0 * applyTax(amount, t)
+    applyTax(50.0, TaxRate(percent = 0.0)) >= 50.0 => true
+    applyTax(50.0, TaxRate(percent = 10.0)) >= 50.0 => true
+    applyTax(50.0, TaxRate(percent = 50.0)) >= 50.0 => true
+    applyTax(100.0, TaxRate(percent = 0.0)) >= 100.0 => true
+    applyTax(100.0, TaxRate(percent = 10.0)) >= 100.0 => true
+    applyTax(100.0, TaxRate(percent = 50.0)) >= 100.0 => true
+    applyTax(200.0, TaxRate(percent = 0.0)) >= 200.0 => true
+    applyTax(200.0, TaxRate(percent = 10.0)) >= 200.0 => true
+    applyTax(200.0, TaxRate(percent = 50.0)) >= 200.0 => true
+    applyTax(2.0 * 50.0, TaxRate(percent = 0.0)) => 2.0 * applyTax(50.0, TaxRate(percent = 0.0))
+    applyTax(2.0 * 50.0, TaxRate(percent = 10.0)) => 2.0 * applyTax(50.0, TaxRate(percent = 10.0))
+    applyTax(2.0 * 50.0, TaxRate(percent = 25.0)) => 2.0 * applyTax(50.0, TaxRate(percent = 25.0))
+    applyTax(2.0 * 100.0, TaxRate(percent = 0.0)) => 2.0 * applyTax(100.0, TaxRate(percent = 0.0))
+    applyTax(2.0 * 100.0, TaxRate(percent = 10.0)) => 2.0 * applyTax(100.0, TaxRate(percent = 10.0))
+    applyTax(2.0 * 100.0, TaxRate(percent = 25.0)) => 2.0 * applyTax(100.0, TaxRate(percent = 25.0))
 
 fn calculateTotal(items: List<Item>, d: Discount, t: TaxRate) -> Float
     ? "Sums items, applies discount, applies tax. Assumes valid Discount and TaxRate."
@@ -118,10 +126,8 @@ fn calculateTotal(items: List<Item>, d: Discount, t: TaxRate) -> Float
 verify calculateTotal
     calculateTotal([], Discount(percent = 50.0), TaxRate(percent = 20.0)) => 0.0
     calculateTotal([Item(price = 10.0, quantity = 2)], Discount(percent = 50.0), TaxRate(percent = 10.0)) => 11.0
-
-verify calculateTotal law zeroDiscountZeroTaxIsSubtotal
-    given items: List<Item> = [[Item(price = 10.0, quantity = 2)], [Item(price = 5.0, quantity = 3), Item(price = 10.0, quantity = 1)]]
-    calculateTotal(items, Discount(percent = 0.0), TaxRate(percent = 0.0)) => sumItems(items)
+    calculateTotal([Item(price = 10.0, quantity = 2)], Discount(percent = 0.0), TaxRate(percent = 0.0)) => sumItems([Item(price = 10.0, quantity = 2)])
+    calculateTotal([Item(price = 5.0, quantity = 3), Item(price = 10.0, quantity = 1)], Discount(percent = 0.0), TaxRate(percent = 0.0)) => sumItems([Item(price = 5.0, quantity = 3), Item(price = 10.0, quantity = 1)])
 
 verify calculateTotal law equalsStepByStep
     given items: List<Item> = [[Item(price = 10.0, quantity = 2)], [Item(price = 5.0, quantity = 1)]]

--- a/examples/formal/file_store_shell.av
+++ b/examples/formal/file_store_shell.av
@@ -19,13 +19,15 @@ fn fakeWriteErr(path: BranchPath, n: Int, file: String, content: String) -> Resu
     ? "Stub: every write fails."
     Result.Err("disk full")
 
-verify persistEntry law happyPath
+verify persistEntry trace
     given write: Disk.writeText = [fakeWriteOk]
-    persistEntry("a.txt", "hi") => Result.Ok(Unit)
+    report = persistEntry("a.txt", "hi")
+    report.result => Result.Ok(Unit)
 
-verify persistEntry law unhappyPath
+verify persistEntry trace
     given write: Disk.writeText = [fakeWriteErr]
-    persistEntry("a.txt", "hi") => Result.Err("disk full")
+    report = persistEntry("a.txt", "hi")
+    report.result => Result.Err("disk full")
 
 fn main() -> Unit
     ! [Console.print]


### PR DESCRIPTION
## Summary

Closes the two remaining cheap corpus-honesty items after #464 (RBT). A full sweep of `examples/` + `proof-corpus/` found the post-#464 mislabel residue is exactly 6 laws in 2 files (proof-corpus has zero); this PR fixes the 2 files that are pure honesty fixes. The 4 remaining hits (`json.av` dummy-given escape laws) are deliberately left as seed material for the json initiative, where they should be generalized into real escape-roundtrip laws rather than deleted.

### `examples/core/order_total.av`

5 of 6 laws were false universals:
- `zeroDiscountZeroTaxIsSubtotal` — falsified by overflow→inf→NaN propagation (multiplication by exact 0.0 is exact; the failure class is inf/NaN, not rounding).
- `discountNeverIncreasesPositive` / `taxNeverDecreasesPositive` — false even over exact reals for negative amounts (the file deliberately allows refunds); Dafny rejected both under its real model.
- `doubleAmountDoublesTax` — falsified by overflow (`2.0 * 1.0e308 = +inf`).
- All Float ∀-laws fail on NaN inputs.

No `when` guard can repair them: the builtin registry has no finiteness predicate, and `>= 0.0`-style guards admit `+inf`. Demoted per the #464 pattern, with given cross-products expanded into explicit cases (case count unchanged). `equalsStepByStep` is kept — definitionally true, machine-proven.

### `examples/formal/file_store_shell.av`

`happyPath`/`unhappyPath` pinned a single `Disk.writeText` stub and asserted stub-specific results; as oracle laws they claim a ∀ over the handler, which the other stub refutes. Converted to anonymous `verify persistEntry trace` blocks with `.result =>` projections (`clock_as_data.av` pattern). Drops 4 law-labeled pinned `native_decide` theorems, emits 2 honest examples.

## Validation (independently re-verified by an adversarial review pass)

- `aver verify`: order_total 52/52 (count unchanged), file_store_shell 2/2; `--hostile` green on both.
- Lean (lake): order_total `{passed:false, sorries:5, universal:false}` → `{passed:true, sorries:0, universal:true}`; file_store_shell emits only 2 anonymous examples (no law theorems, no sorries).
- Dafny 4.11: order_total `{errors:2}` → `{errors:0, axioms:0}`; file_store_shell `{errors:0}`.
- Targeted suites: `mir_phase3_corpus_coverage_floor` (3 passed), `rust_codegen_differential full_plain_stdout_parity_with_vm` (passed, includes order_total), `research_archetype_clustering` (passed, sweeps all of examples/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)