### PR TITLE
proof: FiniteDomainCases strategy — exhaustive cases enumeration for finite-domain givens

### DIFF
--- a/examples/data/json.av
+++ b/examples/data/json.av
@@ -670,21 +670,52 @@ verify parseEscape
     parseEscape("\\u0041\"", 1, 0, 0, []) => ParseResult.Ok(Json.JsonString("A"), 7)
     parseEscape("\\x\"", 1, 0, 0, []) => ParseResult.Err("Unknown escape: \\x", 1)
 
-verify parseEscape law escapedChunkRoundtrip
-    given dummy: Int = [0]
-    parseEscape("\\\"\"", 1, 0, 0, []) => ParseResult.Ok(Json.JsonString("\""), 3)
+type EscapeCode
+    Quote
+    Backslash
+    Newline
+    Tab
+    CarriageReturn
+    Backspace
+    FormFeed
 
-verify parseEscape law slashEscapeRoundtrip
-    given dummy: Int = [0]
-    parseEscape("\\\\\"", 1, 0, 0, []) => ParseResult.Ok(Json.JsonString("\\"), 3)
+fn escapeSeq(code: EscapeCode) -> String
+    ? "Two-character JSON escape sequence the encoder emits for each escapable character."
+    match code
+        EscapeCode.Quote -> "\\\""
+        EscapeCode.Backslash -> "\\\\"
+        EscapeCode.Newline -> "\\n"
+        EscapeCode.Tab -> "\\t"
+        EscapeCode.CarriageReturn -> "\\r"
+        EscapeCode.Backspace -> "\\b"
+        EscapeCode.FormFeed -> "\\f"
 
-verify parseEscape law newlineEscapeRoundtrip
-    given dummy: Int = [0]
-    parseEscape("\\n\"", 1, 0, 0, []) => ParseResult.Ok(Json.JsonString("\n"), 3)
+verify escapeSeq
+    escapeSeq(EscapeCode.Quote) => "\\\""
+    escapeSeq(EscapeCode.Newline) => "\\n"
 
-verify parseEscape law unicodeEscapeRoundtrip
-    given dummy: Int = [0]
-    parseEscape("\\u0041\"", 1, 0, 0, []) => ParseResult.Ok(Json.JsonString("A"), 7)
+fn unescapedChar(code: EscapeCode) -> String
+    ? "The single character each escape code denotes."
+    match code
+        EscapeCode.Quote -> "\""
+        EscapeCode.Backslash -> "\\"
+        EscapeCode.Newline -> "\n"
+        EscapeCode.Tab -> "\t"
+        EscapeCode.CarriageReturn -> "\r"
+        EscapeCode.Backspace -> "\b"
+        EscapeCode.FormFeed -> "\f"
+
+verify unescapedChar
+    unescapedChar(EscapeCode.Quote) => "\""
+    unescapedChar(EscapeCode.Newline) => "\n"
+
+verify parseEscape law escapeCodeRoundtrip
+    given code: EscapeCode = [EscapeCode.Quote, EscapeCode.Backslash, EscapeCode.Newline, EscapeCode.Tab, EscapeCode.CarriageReturn, EscapeCode.Backspace, EscapeCode.FormFeed]
+    parseEscape(escapeSeq(code) + "\"", 1, 0, 0, []) => ParseResult.Ok(Json.JsonString(unescapedChar(code)), 3)
+
+verify escapeJsonChar law encodesEscapeCode
+    given code: EscapeCode = [EscapeCode.Quote, EscapeCode.Backslash, EscapeCode.Newline, EscapeCode.Tab, EscapeCode.CarriageReturn, EscapeCode.Backspace, EscapeCode.FormFeed]
+    escapeJsonChar(unescapedChar(code)) => escapeSeq(code)
 
 fn parseUnicode(s: String, pos: Int, escapePos: Int, chunks: List<String>) -> ParseResult
     ? "Parse \\uXXXX, including surrogate pairs."

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1441,6 +1441,14 @@ pub fn emit_verify_law(
                     // Dafny's behaviour is unchanged from before the
                     // Lean-only strategy existed.
                     | crate::ir::ProofStrategy::EnumConstantFold { .. }
+                    // Same guard for the finite-domain-cases strategy:
+                    // it is Lean-only (exhaustive `cases` enumeration),
+                    // Dafny keeps its pre-strategy behaviour — the
+                    // default fuel-bumped lemma where it can, the
+                    // singleton-domain / fuel-bounded sample-only gates
+                    // where it can't. Byte-identical to before the
+                    // strategy existed.
+                    | crate::ir::ProofStrategy::FiniteDomainCases { .. }
             )
         });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -207,6 +207,36 @@ pub fn emit_verify_law_forall_auto_proof(
         });
     }
 
+    // IR-pinned `FiniteDomainCases` — every given ranges over a closed
+    // finite domain (Bool or an all-fieldless user enum, ≤ 16 total
+    // combinations), so exhaustive `cases` enumeration yields one
+    // closed ground goal per combination. Fuel-wrapped callees compute
+    // through (constant-measure constructor args), which is why the
+    // detector has no call-shape / recursion gate. Per-leaf cascade:
+    // `rfl` first (the workhorse — kernel defeq computes ground
+    // terms), then `decide` (kernel-rechecked; can be weak on derived
+    // DecidableEq over nested ADTs), then the iron guard — an HONEST
+    // `sorry`. A non-closing leaf must surface as a caught sorry,
+    // NEVER a build error and NEVER `native_decide` (which would
+    // inject `Lean.ofReduceBool` and silently kill `universal:true`).
+    if let Some(crate::ir::ProofStrategy::FiniteDomainCases { ref givens }) =
+        law_strategy_for(ctx, &vb.fn_name, &law.name)
+    {
+        let cascade = givens
+            .iter()
+            .map(|g| format!("cases {}", aver_name_to_lean(g)))
+            .collect::<Vec<_>>()
+            .join(" <;> ");
+        return Some(AutoProof {
+            support_lines: Vec::new(),
+            proof_lines: intro_then(
+                &proof_intro_names,
+                vec![format!("{cascade} <;> (first | rfl | decide | sorry)")],
+            ),
+            replaces_theorem: false,
+        });
+    }
+
     // IR-pinned `LinearIntSpecEquivalence` — Step 40: lowerer
     // validated substituted bodies are pure linear arithmetic over
     // Int givens. Backend emits `change <impl> = <spec> ; omega`.

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -2563,7 +2563,7 @@ fn emit_verify_law_block(
     // constant-RHS shapes (Reflexive, Commutative, Associative,
     // MapUpdatePostcondition, …) stay in the keep-set; Induction
     // / BackendDispatch / Sorry don't.
-    let ir_strategy_closes_const_rhs = ctx
+    let pinned_law_strategy = ctx
         .symbol_table
         .fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name))
         .and_then(|fn_id| {
@@ -2572,15 +2572,16 @@ fn emit_verify_law_block(
                 .iter()
                 .find(|t| t.fn_id == fn_id && t.law_name == law.name)
         })
-        .is_some_and(|t| {
-            !matches!(
-                t.strategy,
-                crate::ir::ProofStrategy::Induction { .. }
-                    | crate::ir::ProofStrategy::SimpOverLemmas(_)
-                    | crate::ir::ProofStrategy::BackendDispatch
-                    | crate::ir::ProofStrategy::Sorry
-            )
-        });
+        .map(|t| &t.strategy);
+    let ir_strategy_closes_const_rhs = pinned_law_strategy.is_some_and(|s| {
+        !matches!(
+            s,
+            crate::ir::ProofStrategy::Induction { .. }
+                | crate::ir::ProofStrategy::SimpOverLemmas(_)
+                | crate::ir::ProofStrategy::BackendDispatch
+                | crate::ir::ProofStrategy::Sorry
+        )
+    });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs
         && crate::codegen::common::all_givens_are_singletons(law)
         && crate::codegen::common::law_rhs_is_independent_of_givens(law);
@@ -2592,9 +2593,22 @@ fn emit_verify_law_block(
     // The expanded per-sample lemmas unfold fuel finitely (concrete
     // inputs) and stay decidable — skip the universal instead of
     // shipping `induction` tactics that don't close.
+    //
+    // EXCEPTION — `FiniteDomainCases`: closed enumeration defeats
+    // fuel. The strategy's `cases` cascade reduces the universal to
+    // ground goals over constant-measure constructor args, which
+    // compute straight through `<fn>__fuel` wrappers (`rfl`/`decide`
+    // evaluate them like the per-sample lemmas do). Skipping here
+    // would drop the very theorems the strategy exists to close
+    // (e.g. `parseEscape.escapeCodeRoundtrip`, whose `parseEscape`
+    // is fuel-bounded), so the fuel gate does not apply.
     let unclassified = crate::codegen::common::unclassified_fn_names(ctx);
     let calls_fuel_bounded = crate::codegen::common::law_calls_unclassified_fn(law, &unclassified);
-    let skip_universal = singleton_const_rhs || calls_fuel_bounded;
+    let pinned_finite_domain_cases = matches!(
+        pinned_law_strategy,
+        Some(crate::ir::ProofStrategy::FiniteDomainCases { .. })
+    );
+    let skip_universal = singleton_const_rhs || (calls_fuel_bounded && !pinned_finite_domain_cases);
     if !quant_params.is_empty() && !skip_universal {
         lines.extend(emit_verify_law_support_theorems(
             vb,

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -870,7 +870,15 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
 ///    binds it to the inner binary fn at a constant.
 /// 7. `LinearArithmetic { unfold_fns, ... }` — catch-all when the
 ///    law reduces to linear arith after unfolding the call chain.
-/// 8. `BackendDispatch` — backend's ad-hoc chain decides.
+/// 8. `EnumConstantFold { unfold_fns }` — ground law over fixed
+///    enum/ADT constructor args, scalar return (#466).
+/// 9. `FiniteDomainCases { givens }` — every given ranges over a
+///    closed finite domain (Bool / fieldless enum, product ≤ 16);
+///    closes by exhaustive `cases` enumeration.
+/// 10. `BackendDispatch` — backend's ad-hoc chain decides.
+///
+/// (The induction/spec-equivalence/Map families detected between
+/// these rungs are documented at their detector sites below.)
 fn classify_law_strategy(
     law: &crate::ast::VerifyLaw,
     fn_name: &str,
@@ -1063,7 +1071,81 @@ fn classify_law_strategy(
     {
         return ProofStrategy::EnumConstantFold { unfold_fns };
     }
+    // Closed finite-domain enumeration — the final typed fallback
+    // before `BackendDispatch`. Fires when EVERY given ranges over a
+    // closed, small domain (Bool or an all-fieldless user enum, ≤ 16
+    // total combinations): exhaustive `cases` over the givens yields
+    // ground goals per leaf, so deliberately NO call-shape inspection,
+    // NO return-type gate and NO recursion gate — closed enumeration
+    // makes those irrelevant (fuel-wrapped callees compute through
+    // constant-measure constructor args). That is exactly why this is
+    // a NEW detector and not a relaxation of `EnumConstantFold`, whose
+    // literal-pinning / non-recursive / scalar-return gates are
+    // load-bearing for its simp cascade.
+    if law.when.is_none()
+        && let Some(givens) = detect_finite_domain_cases(law, inputs)
+    {
+        return ProofStrategy::FiniteDomainCases { givens };
+    }
     ProofStrategy::BackendDispatch
+}
+
+/// Closed finite-domain enumeration detector (the last typed fallback
+/// before `BackendDispatch`, after `detect_enum_constant_fold`). Fires
+/// iff the law has at least one given and EVERY given's type has a
+/// closed, small, enumerable domain:
+/// - `Bool` (domain size 2), or
+/// - a user-declared enum (`TypeDef::Sum`) whose constructors are ALL
+///   fieldless (domain size = constructor count),
+///
+/// with the product of domain sizes ≤ 16. Exhaustive `cases` over the
+/// givens then yields one closed ground goal per domain combination,
+/// which `rfl` / `decide` compute out — even through fuel wrappers
+/// (constant-measure constructor args compute through fuel) — so
+/// unlike `detect_enum_constant_fold` there is deliberately NO
+/// call-shape inspection, NO return-type gate and NO recursion gate.
+/// A leaf the cascade can't close degrades to an honest caught `sorry`
+/// in the Lean emit, never a false universal claim. Returns the given
+/// names in intro order (the Lean emitter's `cases` targets); `None`
+/// otherwise.
+fn detect_finite_domain_cases(
+    law: &crate::ast::VerifyLaw,
+    inputs: &ProofLowerInputs,
+) -> Option<Vec<String>> {
+    if law.givens.is_empty() {
+        return None;
+    }
+    let mut domain_product: usize = 1;
+    for given in &law.givens {
+        let size = finite_domain_size(&given.type_name, inputs)?;
+        domain_product = domain_product.checked_mul(size)?;
+        if domain_product > 16 {
+            return None;
+        }
+    }
+    Some(law.givens.iter().map(|g| g.name.clone()).collect())
+}
+
+/// Size of a type's closed enumerable domain: 2 for `Bool`, the
+/// constructor count for a user-declared enum whose constructors are
+/// ALL fieldless. `None` for everything else — open domains
+/// (`Int` / `String` / collections), payload-carrying ADTs (whose
+/// `cases` would introduce fresh free variables the per-leaf
+/// `rfl`/`decide` cascade can't compute out), records, and effect
+/// oracle types (`Random.int`, …) which `find_type_def` doesn't
+/// resolve.
+fn finite_domain_size(type_name: &str, inputs: &ProofLowerInputs) -> Option<usize> {
+    if type_name == "Bool" {
+        return Some(2);
+    }
+    match inputs.find_type_def(type_name)? {
+        crate::ast::TypeDef::Sum { variants, .. }
+            if variants.iter().all(|v| v.fields.is_empty()) =>
+        {
+            Some(variants.len())
+        }
+        _ => None,
+    }
 }
 
 /// Ground enum/ADT constant-fold detector (new fallback before

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -715,6 +715,30 @@ pub enum ProofStrategy {
         /// backends translate to their lemma vocabulary.
         unfold_fns: Vec<String>,
     },
+    /// Closed finite-domain enumeration over the law's givens. Every
+    /// given ranges over a closed, small domain — `Bool` or a
+    /// user-declared enum whose constructors are ALL fieldless — with
+    /// the product of domain sizes ≤ 16, so exhaustive `cases` over
+    /// the givens yields ground goals that compute out (`rfl` /
+    /// `decide`). Fuel-wrapped callees are NOT an obstacle:
+    /// constant-measure constructor args compute through fuel. The
+    /// detector deliberately has NO call-shape inspection, NO
+    /// return-type gate and NO recursion gate — closed enumeration
+    /// makes those irrelevant, which is why this is a NEW strategy and
+    /// not a relaxation of [`ProofStrategy::EnumConstantFold`], whose
+    /// literal-pinning / non-recursive / scalar-return gates are
+    /// load-bearing for its simp cascade. Motivating shapes:
+    /// `examples/data/json.av` `parseLiteral.boolRoundtrip` (closes
+    /// genuinely with `intro b; cases b <;> rfl`) and the `EscapeCode`
+    /// laws (`escapeJsonChar.encodesEscapeCode`,
+    /// `parseEscape.escapeCodeRoundtrip`). A non-closing leaf degrades
+    /// to an honest caught `sorry` — never a build error and never
+    /// `native_decide`.
+    FiniteDomainCases {
+        /// Law given names in intro order — the Lean emitter's
+        /// `cases` targets. Source names; backends translate.
+        givens: Vec<String>,
+    },
     /// No automated strategy — emit with `sorry` (Lean) / `assume
     /// {:axiom}` (Dafny). User fills in manually.
     Sorry,

--- a/src/verify_law.rs
+++ b/src/verify_law.rs
@@ -255,6 +255,16 @@ pub fn collect_contextual_helper_law_hints(
             let VerifyKind::Law(law) = &vb.kind else {
                 return None;
             };
+            // A law whose every given ranges over a closed finite
+            // domain closes by exhaustive `cases` enumeration
+            // (`ProofStrategy::FiniteDomainCases`) — the per-leaf
+            // ground goals compute straight through helper fns, fuel
+            // wrappers included, so the auto-proof does NOT stop at
+            // helper boundaries and the ladder hint would be stale
+            // advice.
+            if law.when.is_none() && law_givens_are_closed_finite_domain(law, items) {
+                return None;
+            }
             contextual_helper_law_hint_for_block(
                 vb,
                 law,
@@ -264,6 +274,47 @@ pub fn collect_contextual_helper_law_hints(
             )
         })
         .collect()
+}
+
+/// True when `law` has at least one given and EVERY given ranges over
+/// a closed finite domain — `Bool` (size 2) or a user-declared enum
+/// whose constructors are ALL fieldless (size = constructor count) —
+/// with the product of domain sizes ≤ 16. AST-level mirror of the
+/// `ProofStrategy::FiniteDomainCases` detector in
+/// `codegen::proof_lower` (kept in sync by the json.av
+/// helper-law-ladder checker test); the caller must also mirror the
+/// detector's `law.when.is_none()` gate — when-laws never get the
+/// strategy, so their hints must not be suppressed. Such a law's
+/// universal theorem is closed by exhaustive `cases` enumeration, not
+/// by the helper-law ladder.
+fn law_givens_are_closed_finite_domain(law: &VerifyLaw, items: &[TopLevel]) -> bool {
+    if law.givens.is_empty() {
+        return false;
+    }
+    let mut domain_product: usize = 1;
+    for given in &law.givens {
+        let size = if given.type_name == "Bool" {
+            2
+        } else {
+            let fieldless_enum_size = items.iter().find_map(|item| match item {
+                TopLevel::TypeDef(crate::ast::TypeDef::Sum { name, variants, .. })
+                    if *name == given.type_name && variants.iter().all(|v| v.fields.is_empty()) =>
+                {
+                    Some(variants.len())
+                }
+                _ => None,
+            });
+            match fieldless_enum_size {
+                Some(n) => n,
+                None => return false,
+            }
+        };
+        domain_product = match domain_product.checked_mul(size) {
+            Some(p) if p <= 16 => p,
+            _ => return false,
+        };
+    }
+    true
 }
 
 pub fn contextual_helper_law_message(hint: &ContextualHelperLawHint) -> String {

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1514,3 +1514,229 @@ fn enum_constant_fold_not_pinned_when_adt_param_unpinned() {
         theorem.strategy
     );
 }
+
+#[test]
+fn finite_domain_cases_pinned_for_bool_given_law() {
+    // A law whose only given is `Bool` — closed two-value domain, so
+    // exhaustive `cases` enumeration yields ground goals regardless of
+    // the verified fn's shape. The canonical real-corpus shape is
+    // `examples/data/json.av` `parseLiteral.boolRoundtrip` (closes
+    // genuinely with `intro b; cases b <;> rfl`). The fn here returns
+    // a String (EnumConstantFold's scalar-return gate rejects it) and
+    // the given is a free quantified variable (its literal-pinning
+    // gate rejects it too) — only FiniteDomainCases can own this law.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn tag(b: Bool) -> String\n\
+         \x20   match b\n\
+         \x20       true -> \"yes\"\n\
+         \x20       false -> \"no\"\n\
+         \n\
+         verify tag law nonEmpty\n\
+         \x20   given b: Bool = [true, false]\n\
+         \x20   tag(b) == \"\" => false\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "tag", "nonEmpty")
+        .expect("tag::nonEmpty law theorem missing from ProofIR");
+    let aver::ir::ProofStrategy::FiniteDomainCases { ref givens } = theorem.strategy else {
+        panic!(
+            "Bool-given law must pin FiniteDomainCases, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(
+        givens,
+        &vec!["b".to_string()],
+        "cases targets must be the given names in intro order"
+    );
+}
+
+#[test]
+fn finite_domain_cases_pinned_for_fieldless_enum_given_law() {
+    // A law quantified over a user-declared all-fieldless enum (3
+    // ctors → domain size 3 ≤ 16). The verified fn is RECURSIVE —
+    // FiniteDomainCases deliberately has no recursion gate (closed
+    // enumeration computes through fuel wrappers), which is exactly
+    // what distinguishes it from EnumConstantFold.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         type Color\n\
+         \x20   Red\n\
+         \x20   Green\n\
+         \x20   Blue\n\
+         \n\
+         fn spin(c: Color, n: Int) -> Int\n\
+         \x20   match n <= 0\n\
+         \x20       true -> 0\n\
+         \x20       false -> spin(c, n - 1)\n\
+         \n\
+         verify spin law drains\n\
+         \x20   given c: Color = [Color.Red, Color.Green, Color.Blue]\n\
+         \x20   spin(c, 2) => 0\n";
+    let ctx = build_ctx(src);
+    let theorem =
+        law_theorem(&ctx, "spin", "drains").expect("spin::drains law theorem missing from ProofIR");
+    let aver::ir::ProofStrategy::FiniteDomainCases { ref givens } = theorem.strategy else {
+        panic!(
+            "fieldless-enum-given law must pin FiniteDomainCases, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(givens, &vec!["c".to_string()]);
+}
+
+#[test]
+fn finite_domain_cases_not_pinned_for_int_given() {
+    // Int is an OPEN domain — `cases` can't enumerate it. The detector
+    // must decline even though another given is Bool: EVERY given must
+    // be finitely enumerable for the cascade to yield closed goals.
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn pick(b: Bool, x: Int) -> String\n\
+         \x20   match b\n\
+         \x20       true -> \"yes\"\n\
+         \x20       false -> \"no\"\n\
+         \n\
+         verify pick law nonEmpty\n\
+         \x20   given b: Bool = [true, false]\n\
+         \x20   given x: Int = [0, 1]\n\
+         \x20   pick(b, x) == \"\" => false\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "pick", "nonEmpty")
+        .expect("pick::nonEmpty law theorem missing from ProofIR");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::FiniteDomainCases { .. }
+        ),
+        "law with an Int given must NOT pin FiniteDomainCases, got: {:?}",
+        theorem.strategy
+    );
+}
+
+#[test]
+fn finite_domain_cases_not_pinned_for_when_law() {
+    // `when` premises are out of scope: the cascade has no premise
+    // handling (the hypothesis would block the per-leaf `rfl`).
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn tag(b: Bool) -> String\n\
+         \x20   match b\n\
+         \x20       true -> \"yes\"\n\
+         \x20       false -> \"no\"\n\
+         \n\
+         verify tag law yesWhenTrue\n\
+         \x20   given b: Bool = [true, false]\n\
+         \x20   when b\n\
+         \x20   tag(b) => \"yes\"\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "tag", "yesWhenTrue")
+        .expect("tag::yesWhenTrue law theorem missing from ProofIR");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::FiniteDomainCases { .. }
+        ),
+        "when-law must NOT pin FiniteDomainCases, got: {:?}",
+        theorem.strategy
+    );
+}
+
+#[test]
+fn finite_domain_cases_not_pinned_for_payload_enum_given() {
+    // An enum with a payload-carrying ctor is NOT a closed finite
+    // domain — `cases` on it introduces a fresh free variable
+    // (`Cell.Piece v`) the per-leaf `rfl`/`decide` cascade can't
+    // compute out. The detector must decline. (The law's lhs/rhs are
+    // deliberately NOT syntactically equal so `Reflexive` can't pin
+    // first and mask the payload gate under test.)
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         type Cell\n\
+         \x20   Empty\n\
+         \x20   Piece(Int)\n\
+         \n\
+         fn isEmpty(c: Cell) -> Bool\n\
+         \x20   match c\n\
+         \x20       Cell.Empty -> true\n\
+         \x20       Cell.Piece(_) -> false\n\
+         \n\
+         verify isEmpty law selfConsistent\n\
+         \x20   given c: Cell = [Cell.Empty, Cell.Piece(1)]\n\
+         \x20   isEmpty(c) == isEmpty(c) => true\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "isEmpty", "selfConsistent")
+        .expect("isEmpty::selfConsistent law theorem missing from ProofIR");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::FiniteDomainCases { .. }
+        ),
+        "payload-enum given must NOT pin FiniteDomainCases, got: {:?}",
+        theorem.strategy
+    );
+}
+
+#[test]
+fn finite_domain_cases_not_pinned_when_domain_product_exceeds_16() {
+    // Domain-size budget: 3 Color givens (3^3 = 27 > 16) would emit a
+    // 27-leaf cascade — past the deliberate cap. The detector must
+    // decline; 2 givens of the same enum (3^2 = 9 ≤ 16) still fire
+    // (asserted as the in-budget control below).
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         type Color\n\
+         \x20   Red\n\
+         \x20   Green\n\
+         \x20   Blue\n\
+         \n\
+         fn same(a: Color, b: Color, c: Color) -> Bool\n\
+         \x20   match a\n\
+         \x20       Color.Red -> true\n\
+         \x20       Color.Green -> true\n\
+         \x20       Color.Blue -> true\n\
+         \n\
+         verify same law alwaysTrue\n\
+         \x20   given a: Color = [Color.Red, Color.Green, Color.Blue]\n\
+         \x20   given b: Color = [Color.Red, Color.Green, Color.Blue]\n\
+         \x20   given c: Color = [Color.Red, Color.Green, Color.Blue]\n\
+         \x20   same(a, b, c) => true\n\
+         \n\
+         fn pair(a: Color, b: Color) -> Bool\n\
+         \x20   match a\n\
+         \x20       Color.Red -> true\n\
+         \x20       Color.Green -> true\n\
+         \x20       Color.Blue -> true\n\
+         \n\
+         verify pair law alwaysTrue\n\
+         \x20   given a: Color = [Color.Red, Color.Green, Color.Blue]\n\
+         \x20   given b: Color = [Color.Red, Color.Green, Color.Blue]\n\
+         \x20   pair(a, b) => true\n";
+    let ctx = build_ctx(src);
+    let over = law_theorem(&ctx, "same", "alwaysTrue")
+        .expect("same::alwaysTrue law theorem missing from ProofIR");
+    assert!(
+        !matches!(
+            over.strategy,
+            aver::ir::ProofStrategy::FiniteDomainCases { .. }
+        ),
+        "domain product 27 > 16 must NOT pin FiniteDomainCases, got: {:?}",
+        over.strategy
+    );
+    let within = law_theorem(&ctx, "pair", "alwaysTrue")
+        .expect("pair::alwaysTrue law theorem missing from ProofIR");
+    assert!(
+        matches!(
+            within.strategy,
+            aver::ir::ProofStrategy::FiniteDomainCases { .. }
+        ),
+        "domain product 9 ≤ 16 control must pin FiniteDomainCases, got: {:?}",
+        within.strategy
+    );
+}

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -420,7 +420,13 @@ fn proof_export_builds_json_when_lake_is_available() {
     // constant-RHS gate elides 4 universal-with-sorry shapes whose
     // ∀ form was vacuous (or false). Per-sample lemmas still cover
     // the declared domain.
-    assert_proof_builds_with_sorry_budget("examples/data/json.av", "aver-proof-json", 8);
+    // FiniteDomainCases: 8 → 7 — `parseLiteral.boolRoundtrip` now
+    // closes genuinely (`intro b; cases b <;> rfl`-class cascade,
+    // #print axioms = [propext, Quot.sound]); the two new EscapeCode
+    // laws (`parseEscape.escapeCodeRoundtrip`,
+    // `escapeJsonChar.encodesEscapeCode`) close axiom-free via the
+    // same strategy and add no sorries.
+    assert_proof_builds_with_sorry_budget("examples/data/json.av", "aver-proof-json", 7);
 }
 
 #[test]
@@ -431,7 +437,16 @@ fn proof_dafny_verifies_json_when_dafny_is_available() {
     // closing this cleanly is probably out of scope for a single
     // fix per issue #114, and would need a different proof
     // strategy entirely.
-    assert_dafny_verifies_with_budgets("examples/data/json.av", "aver-dafny-json", 89, 16);
+    // 89 → 91 errors / 16 → 17 axioms: pure corpus delta from the
+    // EscapeCode swap (the FiniteDomainCases strategy itself is
+    // Lean-only; Dafny treats it as BackendDispatch). The 4 deleted
+    // mislabeled dummy laws each had ONE failing parseEscape sample
+    // lemma (-4); `parseEscape.escapeCodeRoundtrip` adds 5 sample
+    // lemmas in the same Z3-can't-compute-parseEscape class (+5) and
+    // its universal becomes the standard fuel-bounded
+    // `assume {:axiom}` (+1 axiom); `escapeJsonChar.encodesEscapeCode`
+    // gets a real universal lemma attempt Z3 can't discharge (+1).
+    assert_dafny_verifies_with_budgets("examples/data/json.av", "aver-dafny-json", 91, 17);
 }
 
 #[test]
@@ -4619,6 +4634,73 @@ verify bonus law emptyZero
         summary["universal"].as_bool(),
         Some(true),
         "a ground enum/ADT constant-fold law must close kernel-clean\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+/// A no-when law whose every given ranges over a closed finite domain (here a
+/// fieldless 3-ctor enum) must close via the `FiniteDomainCases` strategy:
+/// `intro …; cases <given> <;> … <;> (first | rfl | decide | sorry)`. No earlier
+/// detector owns it — the given is a free quantified enum (EnumConstantFold's
+/// literal-pinning gate rejects it), the return is String (its scalar-return
+/// gate rejects it too), and the enum isn't recursive (no Induction target) —
+/// so it used to fall to BackendDispatch + `sorry`. (Found on real
+/// `examples/data/json.av`: `parseLiteral.boolRoundtrip` + the `EscapeCode`
+/// laws, which close genuinely with `cases … <;> rfl`.)
+#[test]
+fn lean_proves_finite_domain_cases_law_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping finite-domain-cases test: `lake` not available");
+        return;
+    }
+    let source = r#"module FiniteDomain
+    intent = "a no-when law quantified over a closed fieldless-enum domain"
+    effects []
+
+type Color
+    Red
+    Green
+    Blue
+
+fn shade(c: Color) -> String
+    match c
+        Color.Red -> "warm"
+        Color.Green -> "cool"
+        Color.Blue -> "cool"
+
+verify shade law neverEmpty
+    given c: Color = [Color.Red, Color.Green, Color.Blue]
+    shade(c) == "" => false
+"#;
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-finitedomain-src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(src.join("m.av"), source).expect("write");
+    let out = temp_output_dir("aver-finitedomain-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("aver proof ran");
+    let json = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON:\n{}", format_output(&run)));
+    let summary: serde_json::Value = serde_json::from_str(json).expect("json");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "a closed finite-domain law must close kernel-clean via exhaustive cases\n{}",
         format_output(&run)
     );
     let _ = std::fs::remove_dir_all(&src);


### PR DESCRIPTION
## Summary

First compiler chunk of the json initiative (leaf-gap map measured against `examples/data/json.av`: 8 sorries / 31 laws, all on no-`when` laws).

**New `ProofStrategy::FiniteDomainCases`** (mirrors the #466 end-to-end shape): a no-`when` law whose every given ranges over a closed finite domain — `Bool`, or a user enum with all-fieldless constructors, domain-size product ≤ 16 — closes by exhaustive enumeration. Lean emits `intro <givens>; cases g1 <;> … <;> (first | rfl | decide | sorry)`.

Design points:
- **No call-shape / return-type / recursion gates** — closed enumeration computes through fuel wrappers (constant-measure constructor args reduce by `rfl`, verified empirically). That's why this is a new detector, not a relaxation of `EnumConstantFold`, whose literal-pinning/scalar-return gates are load-bearing for its simp cascade. Placed after `detect_enum_constant_fold`, before `BackendDispatch`.
- **Soundness contract**: `native_decide` never appears in the tactic (it would inject `Lean.ofReduceBool` and silently kill `universal:true`); a non-closing leaf degrades to an honest caught `sorry`.
- Dafny treats the strategy as `BackendDispatch` (guard mirrors #466); `map.av` exports byte-identical pre/post.
- The `calls_fuel_bounded` universal-skip is bypassed for pinned FiniteDomainCases laws (closed enumeration defeats fuel), and the contextual helper-law-ladder hint is suppressed for no-`when` finite-domain laws (provably stale advice there).

**Corpus (`examples/data/json.av`)**: the 4 mislabeled dummy-given parseEscape laws (vacuous ∀ over an unused `dummy`; assertions duplicated verbatim in the plain `verify parseEscape` block — measured zero coverage loss) are replaced by an honest finite-domain pair: `EscapeCode` fieldless enum (7 ctors; `/` deliberately excluded — decode-only escape) + `escapeSeq`/`unescapedChar` + two genuine no-`when` laws (`escapeCodeRoundtrip`, `encodesEscapeCode`).

## Validation

- json.av Lean: **sorries 8 → 7** — `parseLiteral_law_boolRoundtrip` now closes, `#print axioms = [propext, Quot.sound]`.
- Both EscapeCode law theorems close **axiom-free** (pure `rfl` defeq through the `parseEscape` fuel wrapper).
- `aver verify examples/data/json.av`: 112 blocks, 402/403 (1 pre-existing `when`-skip), 0 failed.
- Dafny json.av: errors 89→91 / axioms 16→17 / omitted 4→0 — pure corpus delta (deleted dummy sample lemmas −4, new escape sample lemmas +5, one fuel-bounded universal axiom +1), isolated by diffing failing-declaration sets pre/post with the same binary.
- Tests: 6 detector pos/neg cases in `proof_ir_diff` (incl. recursive-fn positive and payload-enum/when/Int/cap negatives), lake-gated `lean_proves_finite_domain_cases_law_when_lake_is_available` (synthetic enum module, asserts `universal == true`), json budget pins re-tightened.
- `cargo test --workspace` 2089 passed / 0 failed; both clippy halves clean; fmt clean.
- Independently re-verified by an adversarial review pass (own stash-baselines for Dafny byte-identity, own `#print axioms` runs, payload-enum masking probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)