### PR TITLE
proof: SimpOverPreludeLemmas — wire prelude spec lemmas into universal-law emission

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1449,6 +1449,11 @@ pub fn emit_verify_law(
                     // where it can't. Byte-identical to before the
                     // strategy existed.
                     | crate::ir::ProofStrategy::FiniteDomainCases { .. }
+                    // Same guard for the prelude-simp strategy: Lean-only
+                    // (its registry maps to Lean prelude lemma names),
+                    // so Dafny treats the pin as `BackendDispatch` and
+                    // its exports stay byte-identical.
+                    | crate::ir::ProofStrategy::SimpOverPreludeLemmas { .. }
             )
         });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -567,6 +567,79 @@ pub fn emit_verify_law_forall_auto_proof(
                 replaces_theorem: false,
             })
         })
+        .or_else(|| {
+            // IR-pinned `SimpOverPreludeLemmas` — DELIBERATELY the last
+            // rung, after every legacy ad-hoc fallback above: it must
+            // fire only where the chain used to return `None` and the
+            // caller emitted a bare-`sorry` universal. The simp set is
+            // kept minimal (cone + fuel + registry hits + the single
+            // baked-in `Int.add_sub_cancel` rewrite the archived
+            // hand-proofs needed) — a fat set risks a simp LOOP, and a
+            // maxHeartbeats blow-up is a build error `first` cannot
+            // catch. `done` forces closure: simp succeeding but
+            // leaving a residual goal must fall to the honest `sorry`,
+            // never surface as an "unsolved goals" build error.
+            emit_simp_over_prelude_lemmas_law(vb, law, ctx, &proof_intro_names)
+        })
+}
+
+/// Render the `SimpOverPreludeLemmas` rung:
+/// `intro <givens>; first | (simp [<set>]; done) | sorry`.
+///
+/// Simp-set assembly, in order: unfold fns (subject first — source
+/// names via `aver_name_to_lean`), then per fuel fn the wrapper name +
+/// `<fn>__fuel` + measure helpers (probed from the actual proof-mode
+/// emission by `toplevel::law_fuel_simp_names` — a fuel fn that
+/// graduated to native `termination_by` contributes its wrapper name
+/// only, never a non-existent `__fuel` constant), then the prelude
+/// spec lemmas the registry maps from the cone's builtin calls
+/// (`lean::prelude_spec_lemmas_for_builtins` — the same names whose
+/// mention makes the demand-driven prelude ship the lemma texts), then
+/// `Int.add_sub_cancel`.
+fn emit_simp_over_prelude_lemmas_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    proof_intro_names: &[String],
+) -> Option<AutoProof> {
+    let Some(crate::ir::ProofStrategy::SimpOverPreludeLemmas {
+        unfold_fns,
+        fuel_fns,
+        builtins,
+    }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+    else {
+        return None;
+    };
+    let mut simp_set: Vec<String> = Vec::new();
+    let push_unique = |set: &mut Vec<String>, name: String| {
+        if !set.contains(&name) {
+            set.push(name);
+        }
+    };
+    for f in &unfold_fns {
+        push_unique(&mut simp_set, aver_name_to_lean(f));
+    }
+    for f in &fuel_fns {
+        push_unique(&mut simp_set, aver_name_to_lean(f));
+        for name in super::toplevel::law_fuel_simp_names(f, ctx) {
+            push_unique(&mut simp_set, name);
+        }
+    }
+    for lemma in super::prelude_spec_lemmas_for_builtins(&builtins) {
+        push_unique(&mut simp_set, lemma);
+    }
+    push_unique(&mut simp_set, "Int.add_sub_cancel".to_string());
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        proof_lines: intro_then(
+            proof_intro_names,
+            vec![format!(
+                "first | (simp [{}]; done) | sorry",
+                simp_set.join(", ")
+            )],
+        ),
+        replaces_theorem: false,
+    })
 }
 
 /// Try `simp [fn_names...] ; omega` for laws on Int-domain functions.

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -153,6 +153,84 @@ const LEAN_PRELUDE_OPTION_TO_EXCEPT: &str = r#"def Option.toExcept (o : Option �
 
 const LEAN_PRELUDE_STRING_HADD: &str = r#"instance : HAdd String String String := ⟨String.append⟩"#;
 
+// ---- String prelude spec lemmas -------------------------------------
+//
+// Demand-driven (mirrors the AverMap lemma family): each lemma ships
+// only when the emitted body mentions its name — which happens exactly
+// when the `SimpOverPreludeLemmas` law rung cites it. None carries
+// `@[simp]`: the rung references them explicitly in its `simp [...]`
+// set, and a global simp attribute would silently change simp behavior
+// for every other proof in the corpus (the archived hand-proofs that
+// motivated these lemmas close with the explicit spelling too).
+
+/// `s + t = s ++ t` — normalizes the custom `HAdd String` instance
+/// (above) so `++`-keyed lemmas (`String.slice_append_prefix`, core
+/// `List.append` simp set) fire on goals spelled with `+`. Ships in
+/// the `StringHadd` helper section because it is a statement *about*
+/// that instance and needs nothing else in scope.
+const LEAN_PRELUDE_STRING_ADD_EQ_APPEND: &str = r#"/-- The custom `HAdd String` instance is definitionally `++`. -/
+theorem String.add_eq_append (s t : String) : s + t = s ++ t := rfl"#;
+
+/// `String.intercalate sep [x] = x` — the singleton-join collapse
+/// (`String.join(List.concat([], [seg]), sep)` shapes). Pure `rfl`
+/// over core `String.intercalate`; ships with `StringHadd` (any
+/// String-mentioning body) because it does not depend on the
+/// `StringHelpers` defs.
+const LEAN_PRELUDE_STRING_INTERCALATE_SINGLETON: &str = r#"/-- Intercalating a singleton list is the element itself. -/
+theorem String.intercalate_singleton (sep x : String) : String.intercalate sep [x] = x := rfl"#;
+
+/// `String.slice s 0 s.length = s` — full-range slice identity.
+/// Depends on the `String.slice` def in the `StringHelpers` section.
+const LEAN_PRELUDE_STRING_SLICE_FULL: &str = r#"/-- Full-string slice identity: slicing [0, s.length) is the identity. -/
+theorem String.slice_full (s : String) : String.slice s 0 (s.length : Int) = s := by
+  have h0 : ¬ ((0 : Int) < 0) := by omega
+  have h1 : ¬ ((s.length : Int) < 0) := by omega
+  simp only [String.slice, if_neg h0, if_neg h1]
+  show String.mk (s.toList.take s.length) = s
+  cases s with
+  | mk data =>
+      show String.mk (data.take data.length) = String.mk data
+      rw [List.take_length]"#;
+
+/// `String.slice (t ++ u) 0 t.length = t` — prefix recovery from an
+/// appended string. One lemma covers the `+` spelling too once
+/// `String.add_eq_append` is in the same simp set (deliberate dedup —
+/// no second `+`-keyed spelling is shipped).
+const LEAN_PRELUDE_STRING_SLICE_APPEND_PREFIX: &str = r#"/-- Slicing [0, t.length) out of `t ++ u` recovers the prefix `t`. -/
+theorem String.slice_append_prefix (t u : String) :
+    String.slice (t ++ u) 0 (t.length : Int) = t := by
+  show String.mk ((t.data ++ u.data).take t.data.length) = t
+  rw [List.take_left]"#;
+
+/// Static registry: prelude builtin(s) → prelude spec lemma names.
+/// Single source of truth, living next to the lemma texts it indexes —
+/// the `SimpOverPreludeLemmas` detector records the builtin call names
+/// it saw in a law's cone, and this fn maps them to the lemma names the
+/// rung's `simp [...]` set cites (which in turn makes the demand-driven
+/// prelude inclusion above ship the texts). Keys are Aver source-level
+/// builtin names; `String.concat` is the detector's synthetic marker
+/// for string `+`. The (`Int.fromString`, `String.fromInt`) PAIR maps
+/// to the roundtrip lemma `Int.fromString_fromInt` (always shipped with
+/// the `NumericParse` prelude section).
+pub(crate) fn prelude_spec_lemmas_for_builtins(builtins: &[String]) -> Vec<String> {
+    let has = |name: &str| builtins.iter().any(|b| b == name);
+    let mut lemmas: Vec<String> = Vec::new();
+    if builtins.iter().any(|b| b.starts_with("String.")) {
+        lemmas.push("String.add_eq_append".to_string());
+    }
+    if has("String.slice") {
+        lemmas.push("String.slice_full".to_string());
+        lemmas.push("String.slice_append_prefix".to_string());
+    }
+    if has("String.join") {
+        lemmas.push("String.intercalate_singleton".to_string());
+    }
+    if has("Int.fromString") && has("String.fromInt") {
+        lemmas.push("Int.fromString_fromInt".to_string());
+    }
+    lemmas
+}
+
 /// Oracle v1: BranchPath mirrors the Aver-source opaque builtin. The
 /// dewey-decimal string under the hood is not user-observable — users
 /// construct paths through `.root`, `.child`, `.parse`.
@@ -1180,7 +1258,9 @@ fn generate_prelude_for_body(body: &str, include_all_helpers: bool) -> String {
         match helper.key {
             "BranchPath" => parts.push(LEAN_PRELUDE_BRANCH_PATH.to_string()),
             "AverList" => parts.push(LEAN_PRELUDE_AVER_LIST.to_string()),
-            "StringHelpers" => parts.push(LEAN_PRELUDE_STRING_HELPERS.to_string()),
+            "StringHelpers" => {
+                parts.push(generate_string_helpers_prelude(body, include_all_helpers))
+            }
             "NumericParse" => parts.push(LEAN_PRELUDE_NUMERIC_PARSE.to_string()),
             "CharByte" => parts.push(LEAN_PRELUDE_CHAR_BYTE.to_string()),
             "AverMeasure" => parts.push(LEAN_PRELUDE_AVER_MEASURE.to_string()),
@@ -1195,7 +1275,7 @@ fn generate_prelude_for_body(body: &str, include_all_helpers: bool) -> String {
                 LEAN_PRELUDE_EXCEPT_NS.to_string(),
                 LEAN_PRELUDE_OPTION_TO_EXCEPT.to_string(),
             ]),
-            "StringHadd" => parts.push(LEAN_PRELUDE_STRING_HADD.to_string()),
+            "StringHadd" => parts.push(generate_string_hadd_prelude(body, include_all_helpers)),
             // Dafny-side datatype declarations — Lean has Result/Option
             // natively (`Except`/`Option`) and BranchPath ships as part
             // of the BranchPath helper key, so all four are no-ops here.
@@ -1224,6 +1304,38 @@ fn mentions_has_set(body: &str) -> bool {
             .next()
             .is_none_or(|c| !(c.is_alphanumeric() || c == '_'))
     })
+}
+
+/// `StringHelpers` section: base defs + demand-driven `String.slice`
+/// spec lemmas. Mirrors [`generate_map_prelude`]'s inclusion pattern —
+/// a lemma ships only when the body (which includes law tactic text)
+/// mentions its name, so corpora that never cite it get byte-identical
+/// output.
+fn generate_string_helpers_prelude(body: &str, include_all_helpers: bool) -> String {
+    let mut parts = vec![LEAN_PRELUDE_STRING_HELPERS.to_string()];
+    if include_all_helpers || body.contains("String.slice_full") {
+        parts.push(LEAN_PRELUDE_STRING_SLICE_FULL.to_string());
+    }
+    if include_all_helpers || body.contains("String.slice_append_prefix") {
+        parts.push(LEAN_PRELUDE_STRING_SLICE_APPEND_PREFIX.to_string());
+    }
+    parts.join("\n\n")
+}
+
+/// `StringHadd` section: the `HAdd String` instance + demand-driven
+/// spec lemmas that need nothing from `StringHelpers`
+/// (`String.add_eq_append` is about the instance itself;
+/// `String.intercalate_singleton` is over core `String.intercalate`).
+/// Same inclusion pattern as [`generate_map_prelude`].
+fn generate_string_hadd_prelude(body: &str, include_all_helpers: bool) -> String {
+    let mut parts = vec![LEAN_PRELUDE_STRING_HADD.to_string()];
+    if include_all_helpers || body.contains("String.add_eq_append") {
+        parts.push(LEAN_PRELUDE_STRING_ADD_EQ_APPEND.to_string());
+    }
+    if include_all_helpers || body.contains("String.intercalate_singleton") {
+        parts.push(LEAN_PRELUDE_STRING_INTERCALATE_SINGLETON.to_string());
+    }
+    parts.join("\n\n")
 }
 
 fn generate_map_prelude(body: &str, include_all_helpers: bool) -> String {
@@ -1585,7 +1697,7 @@ fn build_common_lean(union_body: &str) -> String {
         match helper.key {
             "BranchPath" => parts.push(LEAN_PRELUDE_BRANCH_PATH.to_string()),
             "AverList" => parts.push(LEAN_PRELUDE_AVER_LIST.to_string()),
-            "StringHelpers" => parts.push(LEAN_PRELUDE_STRING_HELPERS.to_string()),
+            "StringHelpers" => parts.push(generate_string_helpers_prelude(union_body, false)),
             "NumericParse" => parts.push(LEAN_PRELUDE_NUMERIC_PARSE.to_string()),
             "CharByte" => parts.push(LEAN_PRELUDE_CHAR_BYTE.to_string()),
             "AverMeasure" => parts.push(LEAN_PRELUDE_AVER_MEASURE.to_string()),
@@ -1600,7 +1712,7 @@ fn build_common_lean(union_body: &str) -> String {
                 LEAN_PRELUDE_EXCEPT_NS.to_string(),
                 LEAN_PRELUDE_OPTION_TO_EXCEPT.to_string(),
             ]),
-            "StringHadd" => parts.push(LEAN_PRELUDE_STRING_HADD.to_string()),
+            "StringHadd" => parts.push(generate_string_hadd_prelude(union_body, false)),
             "ResultDatatype" | "OptionDatatype" | "OptionToResult" | "BranchPathDatatype" => {}
             other => panic!(
                 "Lean backend has no implementation for builtin helper key '{}'. \

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -478,6 +478,106 @@ fn fuel_helper_name(name: &str) -> String {
     crate::codegen::recursion::fuel_helper_name(name)
 }
 
+/// Simp-set names for a fuel-emitted fn cited by the
+/// `SimpOverPreludeLemmas` law rung: `<name>__fuel` plus the measure
+/// helper names (`averMeasure*` / `averStringPosFuel`) the wrapper's
+/// fuel expression references. Rather than re-deriving the
+/// plan→emission mapping (which `recognize_lex_list_wf_scc` can flip
+/// per-SCC to native `termination_by`, no `__fuel` def at all), this
+/// PROBES the proof-mode emission itself: re-emit the fn's SCC group
+/// through the exact dispatch `transpile_unified` uses and scan the
+/// text. Returns `[]` when the emission carries no `def <name>__fuel`
+/// — citing a non-existent constant in `simp [...]` would be a hard
+/// `unknown constant` build error, the one failure mode the rung's
+/// `first | … | sorry` floor cannot catch. Cost: one re-emit of one
+/// SCC per fuel-citing law (string building only, no side effects).
+/// Assumes proof-mode emission — every production Lean export goes
+/// through `transpile_for_proof_mode`.
+pub(super) fn law_fuel_simp_names(fn_name: &str, ctx: &CodegenContext) -> Vec<String> {
+    // Locate the fn's owning scope (entry first, then dep modules) and
+    // the pure-fn population of that scope — the same component
+    // universe `transpile_unified` routes.
+    let scopes: Vec<(Option<String>, Vec<&crate::ast::FnDef>)> =
+        std::iter::once((None, ctx.fn_defs.iter().collect::<Vec<_>>()))
+            .chain(
+                ctx.modules
+                    .iter()
+                    .map(|m| (Some(m.prefix.clone()), m.fn_defs.iter().collect())),
+            )
+            .collect();
+    for (scope, fns) in scopes {
+        let pure: Vec<&crate::ast::FnDef> = fns.into_iter().filter(|fd| is_pure_fn(fd)).collect();
+        if !pure.iter().any(|fd| fd.name == fn_name) {
+            continue;
+        }
+        let comps = crate::call_graph::ordered_fn_components(&pure, &ctx.module_prefixes);
+        let Some(comp) = comps
+            .into_iter()
+            .find(|c| c.iter().any(|fd| fd.name == fn_name))
+        else {
+            return Vec::new();
+        };
+        let emitted = ctx.with_module_scope(scope.as_deref(), || {
+            if comp.len() > 1 {
+                let all_supported = comp
+                    .iter()
+                    .all(|fd| crate::codegen::common::fn_contract_exists_for_fn(ctx, fd));
+                if all_supported {
+                    emit_mutual_group_proof(&comp, ctx)
+                } else {
+                    emit_mutual_group(&comp, ctx)
+                }
+            } else if let Some(fd) = comp.first() {
+                if crate::codegen::common::fn_contract_exists_for_fn(ctx, fd) {
+                    emit_fn_def_proof(fd, ctx).unwrap_or_default()
+                } else {
+                    emit_fn_def(fd, &std::collections::HashSet::from([fd.name.clone()]), ctx)
+                        .unwrap_or_default()
+                }
+            } else {
+                String::new()
+            }
+        });
+        let fuel = fuel_helper_name(fn_name);
+        if !emitted.contains(&format!("def {fuel}")) {
+            return Vec::new();
+        }
+        let mut names = vec![fuel];
+        names.extend(scan_measure_helper_names(&emitted));
+        return names;
+    }
+    Vec::new()
+}
+
+/// Harvest measure-helper identifiers (`averMeasure*`,
+/// `averStringPosFuel`) from emitted Lean text. These are the names a
+/// fuel wrapper's initial-fuel expression references; the
+/// `SimpOverPreludeLemmas` rung needs them in its simp set so the fuel
+/// value computes to a `Nat` literal before the `__fuel` equations
+/// fire. Sorted + deduped for deterministic emit.
+fn scan_measure_helper_names(text: &str) -> Vec<String> {
+    let mut found: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for prefix in ["averMeasure", "averStringPosFuel"] {
+        for (idx, _) in text.match_indices(prefix) {
+            // Reject mid-identifier hits (`xaverMeasure`).
+            if idx > 0
+                && text[..idx]
+                    .chars()
+                    .next_back()
+                    .is_some_and(|c| c.is_alphanumeric() || c == '_')
+            {
+                continue;
+            }
+            let rest = &text[idx..];
+            let end = rest
+                .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+                .unwrap_or(rest.len());
+            found.insert(rest[..end].to_string());
+        }
+    }
+    found.into_iter().collect()
+}
+
 fn emit_fn_param_names(params: &[(String, String)]) -> String {
     params
         .iter()
@@ -2580,6 +2680,13 @@ fn emit_verify_law_block(
                 | crate::ir::ProofStrategy::SimpOverLemmas(_)
                 | crate::ir::ProofStrategy::BackendDispatch
                 | crate::ir::ProofStrategy::Sorry
+                // SimpOverPreludeLemmas is a best-effort rung with an
+                // honest `sorry` floor — it does NOT promise to close
+                // a constant-RHS shape, so a singleton-given +
+                // constant-RHS law keeps today's skip (sample +
+                // checked_domain cover the point) instead of gaining
+                // a universal that would land as a caught sorry.
+                | crate::ir::ProofStrategy::SimpOverPreludeLemmas { .. }
         )
     });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -828,8 +828,14 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             None => Vec::new(),
         };
 
-        let strategy =
-            classify_law_strategy(law, &vb.fn_name, inputs, &ir.refined_types, law_scope_ref);
+        let strategy = classify_law_strategy(
+            law,
+            &vb.fn_name,
+            inputs,
+            &ir.refined_types,
+            &ir.fn_contracts,
+            law_scope_ref,
+        );
 
         // Verify laws are entry-only per current model — see
         // `LawTheorem.fn_id` doc. The bare `vb.fn_name` resolves
@@ -875,7 +881,10 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
 /// 9. `FiniteDomainCases { givens }` — every given ranges over a
 ///    closed finite domain (Bool / fieldless enum, product ≤ 16);
 ///    closes by exhaustive `cases` enumeration.
-/// 10. `BackendDispatch` — backend's ad-hoc chain decides.
+/// 10. `SimpOverPreludeLemmas { … }` — builtin-roundtrip shape; the
+///     Lean backend renders it AFTER its legacy chain, so it fires
+///     exactly where the bare-`sorry` universal used to.
+/// 11. `BackendDispatch` — backend's ad-hoc chain decides.
 ///
 /// (The induction/spec-equivalence/Map families detected between
 /// these rungs are documented at their detector sites below.)
@@ -884,6 +893,7 @@ fn classify_law_strategy(
     fn_name: &str,
     inputs: &ProofLowerInputs,
     refined_types: &std::collections::HashMap<crate::ir::TypeId, crate::ir::RefinedTypeDecl>,
+    fn_contracts: &std::collections::HashMap<crate::ir::FnId, crate::ir::FnContract>,
     scope: Option<&str>,
 ) -> crate::ir::ProofStrategy {
     use crate::ir::ProofStrategy;
@@ -1087,7 +1097,364 @@ fn classify_law_strategy(
     {
         return ProofStrategy::FiniteDomainCases { givens };
     }
+    // Builtin-roundtrip simp over the prelude's spec-lemma registry —
+    // the very last typed fallback. The Lean backend deliberately
+    // renders this strategy AFTER its whole legacy ad-hoc chain (see
+    // `lean::law_auto`), so pinning it here cannot steal a law any
+    // legacy fallback closes today: it fires exactly where the
+    // sampled-sorry path used to emit a bare-`sorry` universal.
+    if law.when.is_none()
+        && let Some(s) = detect_simp_over_prelude_lemmas(law, fn_name, inputs, fn_contracts)
+    {
+        return s;
+    }
     ProofStrategy::BackendDispatch
+}
+
+/// Builtin-roundtrip detector for [`ProofStrategy::SimpOverPreludeLemmas`]
+/// (the last typed fallback before `BackendDispatch`, after
+/// `detect_finite_domain_cases`). Fires for a no-when law with givens
+/// whose lhs calls resolve to user fns that are each either:
+/// - NON-recursive — these seed the transitive unfold cone (expanded
+///   through non-recursive bodies only), or
+/// - recursive AND classified (a `FnContract` exists — never a
+///   `partial def`, whose missing equation lemmas would make `simp
+///   [fn]` a hard build error) AND called with measure-closed args at
+///   every lhs call site: each arg is a literal or a constructor whose
+///   payload is literals/idents over scalar-only variant fields, so
+///   every fuel-metric family (`natAbs`, length, `sizeOf`, string-pos)
+///   computes to a `Nat` literal and simp drives the `__fuel`
+///   equations through (empirically `toString' (Json.jsonInt n) =
+///   String.fromInt n` is plain `rfl` despite fuel).
+///
+/// Recursive fns reached only TRANSITIVELY (inside cone bodies) do
+/// not block and are left out of the unfold set — under the law's
+/// pinned literal args their branches are usually dead (simp computes
+/// the dispatching match away, e.g. `afterIntChar … "]"` never reaches
+/// `scanFracFirst`); a live one just stops simp, which the emit's
+/// `first | (simp …; done) | sorry` alternation catches as an honest
+/// `sorry`, never a build error.
+///
+/// The builtin call names observed across the law sides + every cone
+/// body (recursive ones included — `String.fromInt` lives inside
+/// `toString`'s body) become the registry keys the Lean emitter maps
+/// to prelude spec lemma names (`lean::prelude_spec_lemmas_for_builtins`,
+/// single source of truth next to the lemmas themselves). String `+`
+/// is recorded as the synthetic `String.concat` marker so the
+/// `HAdd`-normalising `String.add_eq_append` fires for laws that
+/// concatenate without naming any `String.*` builtin.
+fn detect_simp_over_prelude_lemmas(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+    fn_contracts: &std::collections::HashMap<crate::ir::FnId, crate::ir::FnContract>,
+) -> Option<crate::ir::ProofStrategy> {
+    use std::collections::BTreeSet;
+
+    if law.givens.is_empty() {
+        return None;
+    }
+    let resolve_user_fn = |name: &str| -> Option<&FnDef> {
+        let fd = inputs.find_fn_def_by_call_name(name)?;
+        if !fd.effects.is_empty() || fd.name == "main" {
+            return None;
+        }
+        Some(fd)
+    };
+    // The law must actually exercise its subject fn in the lhs — the
+    // unfold list is anchored on it (subject first, mirroring
+    // `detect_enum_constant_fold`'s ordering contract).
+    resolve_user_fn(fn_name)?;
+    let recursive = inputs.recursive_pure_fn_names();
+
+    // Seed from direct lhs calls only (the rhs of roundtrip laws is a
+    // constructor expectation; a user fn there would also show up in
+    // the lhs cone for every shape this detector targets).
+    let mut lhs_calls: BTreeSet<String> = BTreeSet::new();
+    collect_fn_calls_expr(&law.lhs, &mut lhs_calls);
+    let mut cone: BTreeSet<String> = BTreeSet::new();
+    let mut fuel_fns: BTreeSet<String> = BTreeSet::new();
+    for name in &lhs_calls {
+        let Some(fd) = resolve_user_fn(name) else {
+            continue;
+        };
+        if !recursive.contains(&fd.name) {
+            cone.insert(fd.name.clone());
+            continue;
+        }
+        // Recursive direct seed: classified + measure-closed or bust.
+        // **syntax-discovery-only** (epic #170 Phase 8 guardrail):
+        // `fn_owning_scope` resolves the owning dep module via
+        // pointer-eq; its `None` IS the entry scope by construction,
+        // so the entry key is the correct typed identity here (same
+        // shape as `ProofLowerInputs::recursive_pure_fn_names`).
+        let fn_key = match inputs.fn_owning_scope(fd) {
+            Some(prefix) => crate::ir::FnKey::in_module(prefix.to_string(), &fd.name),
+            None => crate::ir::FnKey::entry(&fd.name),
+        };
+        let classified = inputs
+            .symbol_table
+            .fn_id_of(&fn_key)
+            .is_some_and(|id| fn_contracts.contains_key(&id));
+        if !classified || !calls_have_measure_closed_args(&law.lhs, &fd.name, inputs) {
+            return None;
+        }
+        fuel_fns.insert(fd.name.clone());
+    }
+    if !cone.contains(fn_name) && !fuel_fns.contains(fn_name) {
+        return None;
+    }
+
+    // Transitive cone expansion through NON-recursive bodies only.
+    loop {
+        let before = cone.len();
+        let snapshot: Vec<String> = cone.iter().cloned().collect();
+        for name in snapshot {
+            let Some(fd) = resolve_user_fn(&name) else {
+                continue;
+            };
+            let mut called: BTreeSet<String> = BTreeSet::new();
+            for stmt in fd.body.stmts() {
+                match stmt {
+                    crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => {
+                        collect_fn_calls_expr(e, &mut called);
+                    }
+                }
+            }
+            for c in called {
+                if let Some(callee) = resolve_user_fn(&c)
+                    && !recursive.contains(&callee.name)
+                {
+                    cone.insert(callee.name.clone());
+                }
+            }
+        }
+        if cone.len() == before {
+            break;
+        }
+    }
+
+    // Registry keys: builtin calls across law sides + every cone /
+    // fuel fn body (fuel bodies carry the partner builtins —
+    // `String.fromInt` lives inside `toString`).
+    let mut builtins: BTreeSet<String> = BTreeSet::new();
+    collect_builtin_calls_expr(&law.lhs, &mut builtins);
+    collect_builtin_calls_expr(&law.rhs, &mut builtins);
+    for name in cone.iter().chain(fuel_fns.iter()) {
+        if let Some(fd) = resolve_user_fn(name) {
+            for stmt in fd.body.stmts() {
+                match stmt {
+                    crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => {
+                        collect_builtin_calls_expr(e, &mut builtins);
+                    }
+                }
+            }
+        }
+    }
+
+    // Subject first (Lean peels the outermost call layer first), then
+    // the sorted rest — mirrors `detect_enum_constant_fold`.
+    let mut unfold_fns: Vec<String> = Vec::new();
+    if cone.contains(fn_name) {
+        unfold_fns.push(fn_name.to_string());
+    }
+    unfold_fns.extend(cone.iter().filter(|n| *n != fn_name).cloned());
+    Some(crate::ir::ProofStrategy::SimpOverPreludeLemmas {
+        unfold_fns,
+        fuel_fns: fuel_fns.into_iter().collect(),
+        builtins: builtins.into_iter().collect(),
+    })
+}
+
+/// True when every call to `target` inside `expr` passes only
+/// measure-closed args — see [`expr_is_measure_closed`]. Used by the
+/// `SimpOverPreludeLemmas` detector to admit a recursive (fuel-
+/// emitted) fn as a direct lhs seed: closed args mean the fuel value
+/// computes to a `Nat` literal, so simp can drive the `__fuel`
+/// equations regardless of which fuel-metric family the classifier
+/// picked.
+fn calls_have_measure_closed_args(
+    expr: &Spanned<crate::ast::Expr>,
+    target: &str,
+    inputs: &ProofLowerInputs,
+) -> bool {
+    use crate::ast::Expr;
+    let self_ok = match &expr.node {
+        Expr::FnCall(callee, args) => {
+            let is_target = expr_to_dotted_name(&callee.node)
+                .is_some_and(|n| n.rsplit('.').next().unwrap_or(&n) == target);
+            !is_target || args.iter().all(|a| expr_is_measure_closed(a, inputs))
+        }
+        _ => true,
+    };
+    if !self_ok {
+        return false;
+    }
+    match &expr.node {
+        Expr::FnCall(callee, args) => {
+            calls_have_measure_closed_args(callee, target, inputs)
+                && args
+                    .iter()
+                    .all(|a| calls_have_measure_closed_args(a, target, inputs))
+        }
+        Expr::BinOp(_, l, r) => {
+            calls_have_measure_closed_args(l, target, inputs)
+                && calls_have_measure_closed_args(r, target, inputs)
+        }
+        Expr::Neg(inner) | Expr::ErrorProp(inner) => {
+            calls_have_measure_closed_args(inner, target, inputs)
+        }
+        Expr::Attr(obj, _) => calls_have_measure_closed_args(obj, target, inputs),
+        Expr::Constructor(_, Some(inner)) => calls_have_measure_closed_args(inner, target, inputs),
+        Expr::List(elems) | Expr::Tuple(elems) => elems
+            .iter()
+            .all(|e| calls_have_measure_closed_args(e, target, inputs)),
+        _ => true,
+    }
+}
+
+/// Measure-closedness of a call arg fed to a recursive (fuel-emitted)
+/// fn: every fuel-metric family (`natAbs n`, list/string length,
+/// `sizeOf`/`averMeasure*`) reduces to a `Nat` literal when the arg is
+/// - a literal (possibly negated), or
+/// - a constructor of a user `Sum` type whose matched variant has only
+///   scalar fields (`Int`/`Float`/`String`/`Bool`) and whose payload
+///   exprs are literals or idents — the ADT measure is constant on
+///   such a constructor regardless of the payload values (e.g.
+///   `averMeasureJson (Json.jsonInt n) = 2` for free `n`).
+///
+/// A bare ident is OPEN (a free `String` given feeds `s.length`-shaped
+/// fuel; a free `Int` feeds `natAbs`), as is anything else.
+fn expr_is_measure_closed(expr: &Spanned<crate::ast::Expr>, inputs: &ProofLowerInputs) -> bool {
+    use crate::ast::Expr;
+    let payload_atom = |e: &Spanned<Expr>| -> bool {
+        matches!(
+            e.node,
+            Expr::Literal(_) | Expr::Ident(_) | Expr::Resolved { .. }
+        ) || matches!(&e.node, Expr::Neg(inner) if matches!(inner.node, Expr::Literal(_)))
+    };
+    let variant_fields_scalar = |ctor_name: &str| -> bool {
+        let (type_name, variant_name) = match ctor_name.rsplit_once('.') {
+            Some(pair) => pair,
+            None => return false,
+        };
+        let Some(crate::ast::TypeDef::Sum { variants, .. }) = inputs.find_type_def(type_name)
+        else {
+            return false;
+        };
+        variants.iter().any(|v| {
+            v.name == variant_name
+                && v.fields
+                    .iter()
+                    .all(|f| matches!(f.trim(), "Int" | "Float" | "String" | "Bool"))
+        })
+    };
+    match &expr.node {
+        Expr::Literal(_) => true,
+        Expr::Neg(inner) => matches!(inner.node, Expr::Literal(_)),
+        Expr::Constructor(name, payload) => {
+            let payload_ok = match payload.as_deref() {
+                None => true,
+                Some(Spanned {
+                    node: Expr::Tuple(items),
+                    ..
+                }) => items.iter().all(payload_atom),
+                Some(single) => payload_atom(single),
+            };
+            payload_ok && variant_fields_scalar(name)
+        }
+        // `Type.Variant(args…)` parses as a FnCall on a dotted
+        // uppercase-leaf name; `Type.Variant` (fieldless) as an Attr.
+        Expr::FnCall(callee, args) => expr_to_dotted_name(&callee.node).is_some_and(|n| {
+            n.rsplit('.')
+                .next()
+                .is_some_and(|leaf| leaf.chars().next().is_some_and(|c| c.is_uppercase()))
+                && variant_fields_scalar(&n)
+                && args.iter().all(payload_atom)
+        }),
+        Expr::Attr(obj, field) => {
+            let head = match &obj.node {
+                Expr::Ident(n) => n.clone(),
+                _ => return false,
+            };
+            field.chars().next().is_some_and(|c| c.is_uppercase())
+                && variant_fields_scalar(&format!("{head}.{field}"))
+        }
+        _ => false,
+    }
+}
+
+/// Collect builtin (`Namespace.method`) call names — the complement of
+/// [`collect_fn_calls_expr`], which deliberately FILTERS the builtin
+/// scalar namespaces out of the user-fn unfold set. Records every
+/// dotted callee whose head segment starts uppercase and whose leaf is
+/// lowercase (`String.slice`, `Int.fromString`, `List.concat`, …) plus
+/// the synthetic `String.concat` marker for `+` over a string operand
+/// (literal or interpolation — the type-blind AST signal for the
+/// custom `HAdd String` instance). Drives the registry keys of
+/// [`ProofStrategy::SimpOverPreludeLemmas`].
+fn collect_builtin_calls_expr(
+    expr: &Spanned<crate::ast::Expr>,
+    out: &mut std::collections::BTreeSet<String>,
+) {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::FnCall(f, args) => {
+            if let Some(name) = expr_to_dotted_name(&f.node)
+                && name.contains('.')
+            {
+                let head = name.split('.').next().unwrap_or(&name);
+                let leaf = name.rsplit('.').next().unwrap_or(&name);
+                if head.chars().next().is_some_and(|c| c.is_uppercase())
+                    && leaf.chars().next().is_some_and(|c| c.is_lowercase())
+                {
+                    out.insert(name);
+                }
+            }
+            collect_builtin_calls_expr(f, out);
+            for arg in args {
+                collect_builtin_calls_expr(arg, out);
+            }
+        }
+        Expr::BinOp(op, l, r) => {
+            let is_stringy = |e: &Spanned<Expr>| {
+                matches!(
+                    &e.node,
+                    Expr::Literal(crate::ast::Literal::Str(_)) | Expr::InterpolatedStr(_)
+                )
+            };
+            if matches!(op, crate::ast::BinOp::Add) && (is_stringy(l) || is_stringy(r)) {
+                out.insert("String.concat".to_string());
+            }
+            collect_builtin_calls_expr(l, out);
+            collect_builtin_calls_expr(r, out);
+        }
+        Expr::Attr(obj, _) => collect_builtin_calls_expr(obj, out),
+        Expr::Match { subject, arms, .. } => {
+            collect_builtin_calls_expr(subject, out);
+            for arm in arms {
+                collect_builtin_calls_expr(&arm.body, out);
+            }
+        }
+        Expr::TailCall(boxed) => {
+            for arg in &boxed.args {
+                collect_builtin_calls_expr(arg, out);
+            }
+        }
+        Expr::ErrorProp(inner) | Expr::Neg(inner) => collect_builtin_calls_expr(inner, out),
+        Expr::Constructor(_, Some(arg)) => collect_builtin_calls_expr(arg, out),
+        Expr::RecordCreate { fields, .. } => {
+            for (_, e) in fields {
+                collect_builtin_calls_expr(e, out);
+            }
+        }
+        Expr::List(elems) | Expr::Tuple(elems) | Expr::IndependentProduct(elems, _) => {
+            for e in elems {
+                collect_builtin_calls_expr(e, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Closed finite-domain enumeration detector (the last typed fallback

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -739,6 +739,60 @@ pub enum ProofStrategy {
         /// `cases` targets. Source names; backends translate.
         givens: Vec<String>,
     },
+    /// Builtin-roundtrip simp over the prelude's spec-lemma registry —
+    /// the last typed fallback before `BackendDispatch`, and the only
+    /// strategy the Lean backend renders AFTER its legacy ad-hoc chain
+    /// (so it fires precisely where the sampled-sorry fallback used to
+    /// emit a bare-`sorry` universal). A no-when law whose lhs call cone
+    /// reduces to builtin String/Int operations once the user fns
+    /// unfold: the Lean emit is `intro <givens>; first | (simp [<unfold
+    /// set>, <registry lemmas>, Int.add_sub_cancel]; done) | sorry`. The
+    /// `done` + `first | … | sorry` alternation is the honest floor — a
+    /// simp that fails OR leaves a residual goal degrades to a caught
+    /// `sorry`, NEVER a build error and NEVER `native_decide`.
+    /// Motivating shapes: `examples/data/json.av`
+    /// `finishInt.fromCanonicalInt` (closes via
+    /// `Int.fromString_fromInt`), `finishNumber.fromCanonicalIntSlice` /
+    /// `afterIntChar.terminatedIntRoundtrip` (slice-prefix lemmas
+    /// through the `toString` fuel wrapper) and
+    /// `finishString.plainSegmentRoundtrip` (`String.slice_append_prefix`
+    /// + `String.intercalate_singleton`).
+    ///
+    /// Deliberately a NEW variant and not a reuse of
+    /// [`ProofStrategy::SimpOverLemmas`]: that variant is the discovery
+    /// feedback loop's re-pin channel (`lemma_discovery::committed`
+    /// re-pins an `Induction` law when committed *discovered* lemma
+    /// texts are in scope, and the backend routes it through the
+    /// induction emit with embedded lemma bodies). This strategy carries
+    /// no lemma texts and never inducts — it names *static prelude*
+    /// lemmas that the Lean emitter ships demand-driven (see
+    /// `lean::prelude_spec_lemmas_for_builtins`, the single source of
+    /// truth for the builtin → lemma-name registry). Keeping the two
+    /// apart means neither the discovery CLI nor `committed.rs` ever
+    /// has to reason about this variant.
+    SimpOverPreludeLemmas {
+        /// Ordered fn unfold list — law subject fn first, then the
+        /// transitively-reached NON-recursive callees (sorted).
+        /// Source names; backends translate.
+        unfold_fns: Vec<String>,
+        /// Recursive (fuel-emitted) fns called DIRECTLY in the law lhs
+        /// with measure-closed args (constructor-headed over
+        /// scalar-only payloads, or literals) — the fuel value
+        /// computes to a Nat literal, so simp drives the `__fuel`
+        /// equations through. The Lean emitter expands each name to
+        /// wrapper + `<name>__fuel` + its measure-helper names.
+        /// Recursive fns reached only transitively (inside cone
+        /// bodies) are NOT listed: they stay opaque — usually dead
+        /// branches under the law's pinned literal args, and if live
+        /// the simp falls to the honest caught `sorry`.
+        fuel_fns: Vec<String>,
+        /// Builtin call names observed in the law sides + cone bodies
+        /// (sorted; includes the synthetic `String.concat` marker for
+        /// string `+`). Registry keys — the Lean emitter maps them to
+        /// prelude spec lemma names via
+        /// `prelude_spec_lemmas_for_builtins`.
+        builtins: Vec<String>,
+    },
     /// No automated strategy — emit with `sorry` (Lean) / `assume
     /// {:axiom}` (Dafny). User fills in manually.
     Sorry,

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1740,3 +1740,157 @@ fn finite_domain_cases_not_pinned_when_domain_product_exceeds_16() {
         within.strategy
     );
 }
+
+#[test]
+fn simp_over_prelude_lemmas_pinned_for_nonrecursive_builtin_roundtrip_law() {
+    // A builtin-roundtrip law over a non-recursive String fn — no
+    // earlier detector owns it (LinearArithmetic rejects String
+    // params, EnumConstantFold needs a constructor-pinned ADT param
+    // and a scalar return, FiniteDomainCases needs a closed-domain
+    // given), so it used to fall to BackendDispatch + bare `sorry`.
+    // The canonical real-corpus shape is `examples/data/json.av`
+    // `finishString.plainSegmentRoundtrip`. The pin must carry the
+    // subject-first unfold list and the registry keys (note the
+    // synthetic `String.concat` marker for the string `+`).
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn keepPrefix(s: String, n: Int) -> String\n\
+         \x20   String.slice(s, 0, n)\n\
+         \n\
+         verify keepPrefix law appendRoundtrip\n\
+         \x20   given s: String = [\"\", \"ab\"]\n\
+         \x20   keepPrefix(s + \"!\", String.len(s)) => s\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "keepPrefix", "appendRoundtrip")
+        .expect("keepPrefix::appendRoundtrip law theorem missing from ProofIR");
+    let aver::ir::ProofStrategy::SimpOverPreludeLemmas {
+        ref unfold_fns,
+        ref fuel_fns,
+        ref builtins,
+    } = theorem.strategy
+    else {
+        panic!(
+            "builtin-roundtrip law must pin SimpOverPreludeLemmas, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(unfold_fns, &vec!["keepPrefix".to_string()]);
+    assert!(fuel_fns.is_empty(), "no recursive seed: {:?}", fuel_fns);
+    assert_eq!(
+        builtins,
+        &vec![
+            "String.concat".to_string(),
+            "String.len".to_string(),
+            "String.slice".to_string()
+        ],
+        "registry keys must cover the cone's builtins + the string-`+` marker"
+    );
+}
+
+#[test]
+fn simp_over_prelude_lemmas_pinned_for_fuel_fn_with_constructor_headed_arg() {
+    // The lhs calls a RECURSIVE (fuel-emitted, SizeOfStructural) fn
+    // with a constructor-headed arg whose variant has only scalar
+    // fields — the ADT measure is constant on `Tree.Leaf(n)` for free
+    // `n`, so the fuel computes and the fn lands in `fuel_fns`
+    // (json.av's `toString(Json.JsonInt(n))` shape).
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         type Tree\n\
+         \x20   Leaf(Int)\n\
+         \x20   Node(Tree, Tree)\n\
+         \n\
+         fn render(t: Tree) -> String\n\
+         \x20   match t\n\
+         \x20       Tree.Leaf(n) -> String.fromInt(n)\n\
+         \x20       Tree.Node(l, r) -> render(l) + render(r)\n\
+         \n\
+         verify render law leafRoundtrip\n\
+         \x20   given n: Int = [1, 42]\n\
+         \x20   render(Tree.Leaf(n)) => String.fromInt(n)\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "render", "leafRoundtrip")
+        .expect("render::leafRoundtrip law theorem missing from ProofIR");
+    let aver::ir::ProofStrategy::SimpOverPreludeLemmas {
+        ref unfold_fns,
+        ref fuel_fns,
+        ref builtins,
+    } = theorem.strategy
+    else {
+        panic!(
+            "ctor-headed fuel-fn law must pin SimpOverPreludeLemmas, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert!(
+        unfold_fns.is_empty(),
+        "no non-recursive cone: {:?}",
+        unfold_fns
+    );
+    assert_eq!(fuel_fns, &vec!["render".to_string()]);
+    assert!(
+        builtins.contains(&"String.fromInt".to_string()),
+        "fuel-fn BODY builtins must feed the registry keys, got: {:?}",
+        builtins
+    );
+}
+
+#[test]
+fn simp_over_prelude_lemmas_not_pinned_for_when_law() {
+    // `when` premises are out of scope — the simp set has no premise
+    // handling, and the detector must mirror the no-when gates of the
+    // sibling fallbacks (EnumConstantFold / FiniteDomainCases).
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn keepPrefix(s: String, n: Int) -> String\n\
+         \x20   String.slice(s, 0, n)\n\
+         \n\
+         verify keepPrefix law guardedRoundtrip\n\
+         \x20   given s: String = [\"\", \"ab\"]\n\
+         \x20   when String.len(s) >= 0\n\
+         \x20   keepPrefix(s + \"!\", String.len(s)) => s\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "keepPrefix", "guardedRoundtrip")
+        .expect("keepPrefix::guardedRoundtrip law theorem missing from ProofIR");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::SimpOverPreludeLemmas { .. }
+        ),
+        "when-law must NOT pin SimpOverPreludeLemmas, got: {:?}",
+        theorem.strategy
+    );
+}
+
+#[test]
+fn simp_over_prelude_lemmas_not_pinned_for_recursive_seed_with_open_args() {
+    // The lhs calls a recursive fn with a FREE Int given — the fuel
+    // value (`natAbs n + 1`) stays symbolic, simp can't drive the
+    // `__fuel` equations, so the detector must decline (the law keeps
+    // today's bare-sorry honesty instead of a doomed simp attempt).
+    let src = "module M\n\
+         \x20   intent = \"t\"\n\
+         \n\
+         fn countDown(n: Int) -> Int\n\
+         \x20   match n <= 0\n\
+         \x20       true -> 0\n\
+         \x20       false -> countDown(n - 1)\n\
+         \n\
+         verify countDown law alwaysZero\n\
+         \x20   given n: Int = [0, 3]\n\
+         \x20   countDown(n) => 0\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "countDown", "alwaysZero")
+        .expect("countDown::alwaysZero law theorem missing from ProofIR");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::SimpOverPreludeLemmas { .. }
+        ),
+        "open-arg recursive seed must NOT pin SimpOverPreludeLemmas, got: {:?}",
+        theorem.strategy
+    );
+}

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -426,7 +426,20 @@ fn proof_export_builds_json_when_lake_is_available() {
     // laws (`parseEscape.escapeCodeRoundtrip`,
     // `escapeJsonChar.encodesEscapeCode`) close axiom-free via the
     // same strategy and add no sorries.
-    assert_proof_builds_with_sorry_budget("examples/data/json.av", "aver-proof-json", 7);
+    // SimpOverPreludeLemmas: 7 → 3 — `finishInt.fromCanonicalInt`,
+    // `finishNumber.fromCanonicalIntSlice`,
+    // `afterIntChar.terminatedIntRoundtrip` and
+    // `finishString.plainSegmentRoundtrip` now close genuinely via
+    // the String prelude spec lemmas (`String.add_eq_append`,
+    // `String.slice_full` / `String.slice_append_prefix`,
+    // `String.intercalate_singleton`) + `Int.fromString_fromInt`
+    // (#print axioms ⊆ [propext, Classical.choice, Quot.sound]). The
+    // remaining 3 are `escapeJsonString.parseStringRoundtrip`,
+    // `parseStringChunk.escapedStringRoundtrip` and
+    // `parseNumber.fromIntRoundtrip` — their cones stop at fuel fns
+    // with open string-position measures (`parseStringChunk`,
+    // `scanIntTail`), where the rung honestly falls to `sorry`.
+    assert_proof_builds_with_sorry_budget("examples/data/json.av", "aver-proof-json", 3);
 }
 
 #[test]
@@ -4701,6 +4714,68 @@ verify shade law neverEmpty
         summary["universal"].as_bool(),
         Some(true),
         "a closed finite-domain law must close kernel-clean via exhaustive cases\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+/// A no-when builtin-roundtrip law over a non-recursive String fn must close
+/// via the `SimpOverPreludeLemmas` strategy: the rung emits `intro …; first |
+/// (simp [<cone>, <registry lemmas>, Int.add_sub_cancel]; done) | sorry`, where
+/// the registry maps the cone's builtins (`String.slice`, the string-`+`
+/// marker) to the prelude spec lemmas (`String.add_eq_append`,
+/// `String.slice_full` / `String.slice_append_prefix`) that the demand-driven
+/// prelude then ships. No earlier detector owns the shape (LinearArithmetic
+/// rejects String params, EnumConstantFold needs a ctor-pinned ADT + scalar
+/// return, FiniteDomainCases needs a closed-domain given), so it used to fall
+/// to BackendDispatch + bare `sorry`. (Found on real `examples/data/json.av`:
+/// `finishString.plainSegmentRoundtrip` and the `finishInt` / `finishNumber` /
+/// `afterIntChar` canonical-Int roundtrips.)
+#[test]
+fn lean_proves_simp_over_prelude_law_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping simp-over-prelude test: `lake` not available");
+        return;
+    }
+    let source = r#"module PreludeSimp
+    intent = "a builtin-roundtrip law closing via prelude spec lemmas"
+    effects []
+
+fn keepPrefix(s: String, n: Int) -> String
+    String.slice(s, 0, n)
+
+verify keepPrefix law appendRoundtrip
+    given s: String = ["", "ab", "xyz"]
+    keepPrefix(s + "!", String.len(s)) => s
+"#;
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-preludesimp-src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(src.join("m.av"), source).expect("write");
+    let out = temp_output_dir("aver-preludesimp-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("aver proof ran");
+    let json = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON:\n{}", format_output(&run)));
+    let summary: serde_json::Value = serde_json::from_str(json).expect("json");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "a builtin-roundtrip law must close kernel-clean via the prelude spec lemmas\n{}",
         format_output(&run)
     );
     let _ = std::fs::remove_dir_all(&src);


### PR DESCRIPTION
## Summary

Chunk 2 of the json initiative (leaf-gap map: after #468, 7 sorries remained on `examples/data/json.av`).

**New `ProofStrategy::SimpOverPreludeLemmas`** — the gap it closes: `finishInt_law_fromCanonicalInt` is provable with `simp [finishInt, Int.fromString_fromInt]`, and `Int.fromString_fromInt` has been sitting in the AverCommon prelude all along — nothing wired prelude spec lemmas into law classification. Now:

- **Detector** (last rung before `BackendDispatch`, no-`when` only): law-lhs seed fns must be non-recursive (cone expands through non-recursive bodies only), or — for recursive seeds — classified (FnContract exists; partial defs have no equation lemmas, `simp [f]` on them is a hard build error) and called with measure-closed args at every lhs call site (fuel computes to a literal there). Transitively-reached recursive fns stay opaque — dead branches simp away, live ones fall to the honest sorry.
- **Emission**: `intro <givens>; first | (simp [<cone unfolds>, <fuel wrappers + measure helpers>, <registry lemmas>, Int.add_sub_cancel]; done) | sorry`. The `done` keeps the honest caught-sorry floor; `native_decide` never appears.
- **Why not reuse `SimpOverLemmas`**: that variant is the discovery feedback loop's re-pin channel (committed lemma texts, induction emit, `committed.rs`). This one carries no texts, never inducts, and names static prelude lemmas via a registry living next to the lemma texts (single source of truth).

**Prelude: String spec-lemma family** (demand-driven inclusion, AverMap pattern; **no `@[simp]` attributes** — the rung cites lemmas explicitly, avoiding corpus-wide simp drift): `String.add_eq_append` (normalizes the custom `HAdd String` instance so `++`-keyed lemmas can fire — the single highest-leverage line for String laws), `String.slice_full`, `String.slice_append_prefix`, `String.intercalate_singleton`. Proofs ported verbatim from the verified hand-proof probes (Lean 4.15.0 pin).

Dafny: strategy treated as BackendDispatch, exports byte-identical.

## Validation

- json.av Lean: **sorries 7 → 3**; the 4 targets all close kernel-clean (`finishInt` → `[propext, Quot.sound]`, `finishNumber`/`afterIntChar` → `[propext, Classical.choice, Quot.sound]`, `finishString` → `[propext]`); the remaining 3 are exactly the deep family (`escapeJsonString`, `parseStringChunk`, `parseNumber`).
- Representative corpus sweep vs HEAD baselines: map/rle/sparse/quicksort/red_black_tree summaries unchanged; map/sparse/quicksort/rbt Lean exports byte-identical; `aver verify json.av` byte-identical (402/403).
- Dafny: map.av and json.av exports byte-identical (stash round-trip).
- Tests: 4 detector pos/neg cases in `proof_ir_diff`; lake-gated `lean_proves_simp_over_prelude_law_when_lake_is_available`; json budget pin re-tightened 7 → 3.
- `cargo test --workspace` 2094 passed / 0 failed; both clippy halves clean; fmt clean. Independently re-verified by an adversarial review pass (own stash baselines, own `#print axioms` runs).

Known pre-existing flake (not this PR): `explain_mir_coverage_spec` tempfile names key on a nanosecond timestamp and can collide under load — follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)