### PR TITLE
proof: IntDecimalRoundtrip — synthesized scan lemmas crack the fuel barrier for string-pos scanners

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1454,6 +1454,12 @@ pub fn emit_verify_law(
                     // so Dafny treats the pin as `BackendDispatch` and
                     // its exports stay byte-identical.
                     | crate::ir::ProofStrategy::SimpOverPreludeLemmas { .. }
+                    // Same guard for the decimal-Int roundtrip strategy:
+                    // Lean-only (its skeleton cites the synthesized
+                    // `__fuel_scan` lemma and Lean prelude names), so
+                    // Dafny treats the pin as `BackendDispatch` and its
+                    // exports stay byte-identical.
+                    | crate::ir::ProofStrategy::IntDecimalRoundtrip { .. }
             )
         });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -2,6 +2,7 @@
 ///
 /// This module is intentionally isolated from `toplevel.rs` so all heuristic
 /// matching and proof-shape logic lives in one place.
+mod decimal;
 mod induction;
 mod sampled;
 mod shared;
@@ -235,6 +236,42 @@ pub fn emit_verify_law_forall_auto_proof(
             ),
             replaces_theorem: false,
         });
+    }
+
+    // IR-pinned `IntDecimalRoundtrip` — the lowerer validated the
+    // ENTIRE canonical decimal-parser shape (head-char dispatch arms,
+    // single recognized string-pos scanner with the synthesized
+    // `__fuel_scan` companion, slice + `Int.fromString` leaf), so the
+    // backend renders the fixed sign-split skeleton ported from the
+    // verified json hand proof. Wrapped in `first | (…; done) | sorry`
+    // — a non-closing case degrades to a caught honest sorry.
+    if let Some(crate::ir::ProofStrategy::IntDecimalRoundtrip {
+        ref parse_fn,
+        ref neg_fn,
+        ref pos_fn,
+        ref sign_fn,
+        ref scanner_fn,
+        ref predicate_fn,
+        ref finish_fn,
+        ref finish_int_fn,
+        ref serializer_fn,
+    }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+        && let Some(proof) = decimal::emit_int_decimal_roundtrip_law(
+            law,
+            ctx,
+            theorem_base,
+            parse_fn,
+            neg_fn,
+            pos_fn,
+            sign_fn,
+            scanner_fn,
+            predicate_fn,
+            finish_fn,
+            finish_int_fn,
+            serializer_fn,
+        )
+    {
+        return Some(proof);
     }
 
     // IR-pinned `LinearIntSpecEquivalence` — Step 40: lowerer

--- a/src/codegen/lean/law_auto/decimal.rs
+++ b/src/codegen/lean/law_auto/decimal.rs
@@ -1,0 +1,283 @@
+//! Lean renderer for [`crate::ir::ProofStrategy::IntDecimalRoundtrip`] —
+//! the canonical decimal-Int parse/serialize roundtrip
+//! (`examples/data/json.av` `parseNumber.fromIntRoundtrip`).
+//!
+//! The proof skeleton is ported VERBATIM from the verified json hand
+//! proof (closed kernel-clean on Lean 4.15, #print axioms ⊆ [propext,
+//! Classical.choice, Quot.sound]) with the fn names parameterized from
+//! the IR pin:
+//!
+//! 1. `hts` — the serializer reduces to `String.fromInt n` by `rfl`
+//!    (the mutual-SCC fuel is computable from the ADT measure of the
+//!    constructor, so `rfl` forces it even for symbolic `n`), with a
+//!    `simp` fallback;
+//! 2. `hfin` — the finish leaf: full-range slice identity (inlined
+//!    verbatim — the prelude's `String.slice_full` is `s.length`-keyed
+//!    while this goal is `s.data.length`-keyed) + the prelude's
+//!    `Int.fromString_fromInt` roundtrip;
+//! 3. `rcases n with Int.ofNat m | Int.negSucc m` sign split; zero
+//!    sub-case computes by `rfl` on the closed string `"0"`;
+//! 4. head-char dispatch via `String.mk`-form `rfl` (NOT simp under
+//!    `getElem` — simp cannot discharge the getElem validity
+//!    side-goal) and `split` + `digitChar` `Char.toString`
+//!    disequalities for the dead `"-"` / `"0"` arms;
+//! 5. the scanner's auto-synthesized `<fn>__fuel_scan` companion lemma
+//!    (emitted at the scanner's def site by the SAME shape gate the
+//!    detector validated, so the citation cannot dangle) runs the
+//!    all-digit suffix to the end of the string;
+//! 6. `exact hfin`.
+//!
+//! HONEST FLOOR: the whole script is one `first | (… done) | sorry`
+//! alternative — a non-closing case degrades to a caught `sorry`,
+//! never an unsolved-goals build error, and `native_decide` never
+//! appears. The single support lemma (digit-pred: the predicate
+//! accepts all ten `digitChar` images) carries its own per-goal
+//! `first | decide | omega | sorry` floor for the same reason.
+
+use super::super::expr::aver_name_to_lean;
+use super::AutoProof;
+use crate::ast::{Expr, Spanned, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+/// Render the `IntDecimalRoundtrip` proof. Returns `None` (caller
+/// falls through to the bare-sorry universal) only when the rendered
+/// law text doesn't carry the serializer sub-term — a belt-and-braces
+/// guard; the detector's gates make it unreachable today.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit_int_decimal_roundtrip_law(
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    theorem_base: &str,
+    parse_fn: &str,
+    neg_fn: &str,
+    pos_fn: &str,
+    sign_fn: &str,
+    scanner_fn: &str,
+    predicate_fn: &str,
+    finish_fn: &str,
+    finish_int_fn: &str,
+    serializer_fn: &str,
+) -> Option<AutoProof> {
+    let emit = |e: &Spanned<Expr>| super::super::expr::emit_expr_legacy(e, ctx, None);
+
+    // The detector validated `lhs = parse(ser(C(n)), 0)`.
+    let Expr::FnCall(_, lhs_args) = &law.lhs.node else {
+        return None;
+    };
+    let ser_arg = lhs_args.first()?;
+    let n = aver_name_to_lean(&law.givens.first()?.name);
+    let ser_text = emit(ser_arg);
+    let rhs_text = emit(&law.rhs).replace('\n', " ");
+    if !rhs_text.contains(&ser_text) {
+        return None;
+    }
+    // Goal rhs after `rw [hts]`: every serializer occurrence becomes
+    // `String.fromInt n`. Text-level replace is exact because both
+    // renders come from the same emitter over the same ASTs.
+    let rhs = rhs_text.replace(&ser_text, &format!("(String.fromInt {n})"));
+
+    let parse = aver_name_to_lean(parse_fn);
+    let neg = aver_name_to_lean(neg_fn);
+    let posf = aver_name_to_lean(pos_fn);
+    let sign = aver_name_to_lean(sign_fn);
+    let scan = aver_name_to_lean(scanner_fn);
+    let pred = aver_name_to_lean(predicate_fn);
+    let finish = aver_name_to_lean(finish_fn);
+    let fint = aver_name_to_lean(finish_int_fn);
+    let scan_lemma = format!(
+        "{}_scan",
+        crate::codegen::recursion::fuel_helper_name(scanner_fn)
+    );
+    let pred_lemma = format!("{theorem_base}_digit_pred");
+
+    // hts fallback simp set: serializer wrapper + its fuel/measure
+    // helper names (probed from the actual proof-mode emission — a
+    // serializer that graduated to native termination contributes its
+    // wrapper name only, so no `unknown constant`).
+    let mut ser_simp: Vec<String> = vec![aver_name_to_lean(serializer_fn)];
+    for name in super::super::toplevel::law_fuel_simp_names(serializer_fn, ctx) {
+        if !ser_simp.contains(&name) {
+            ser_simp.push(name);
+        }
+    }
+    let ser_simp = ser_simp.join(", ");
+
+    let support_lines = vec![format!(
+        r#"private theorem {pred_lemma} : ∀ d : Nat, d < 10 → {pred} (Char.toString (AverDigits.digitChar d)) = true := by
+  intro d h
+  rcases d with _|_|_|_|_|_|_|_|_|_|d
+  all_goals first | decide | omega | sorry"#
+    )];
+
+    // One sign case's digits-scan tail (everything after the head-char
+    // facts), shared by the positive and negative branches.
+    let scan_tail = |case_int: &str, scan_pos: &str| -> String {
+        format!(
+            r#"have hfuel : averStringPosFuel (String.fromInt {case_int}) {scan_pos} 1
+    = ((String.fromInt {case_int}).data.length - (({scan_pos} : Int)).toNat) + 1 := by
+  simp [averStringPosFuel]"#
+        )
+    };
+
+    let positive = format!(
+        r#"· by_cases hm : m = 0
+  · subst hm
+    have h0 : String.fromInt (Int.ofNat 0) = "0" := by
+      show String.mk (AverDigits.natDigitsChars 0) = "0"
+      unfold AverDigits.natDigitsChars
+      rw [AverDigits.natDigits.eq_1]
+      decide
+    rw [h0]
+    rfl
+  · have hsl : (String.fromInt (Int.ofNat m)).data = (AverDigits.natDigits m).map AverDigits.digitChar := rfl
+    rcases hnd : AverDigits.natDigits m with _ | ⟨d, ds⟩
+    · exact absurd hnd (AverDigits.natDigits_nonempty m)
+    · have hd10 : d < 10 := AverDigits.natDigits_digits_lt_ten m d (by rw [hnd]; exact List.mem_cons_self _ _)
+      have hdne0 : d ≠ 0 := AverDigits.natDigits_head_ne_zero m hm d ds hnd
+      have hlen : (String.fromInt (Int.ofNat m)).data.length = ds.length + 1 := by
+        rw [hsl, hnd]; simp
+      have hmk : String.fromInt (Int.ofNat m) = String.mk ((d :: ds).map AverDigits.digitChar) := by
+        rw [← hnd]
+        rfl
+      have hch : String.charAt (String.fromInt (Int.ofNat m)) 0
+          = some (Char.toString (AverDigits.digitChar d)) := by
+        rw [hmk]
+        rfl
+      have hds10 : ∀ x ∈ ds, x < 10 := fun x hx =>
+        AverDigits.natDigits_digits_lt_ten m x (by rw [hnd]; exact List.mem_cons_of_mem _ hx)
+      have hdigits : ∀ ch ∈ (String.fromInt (Int.ofNat m)).data.drop ((1 : Int)).toNat,
+          {pred} (Char.toString ch) = true := by
+        intro ch hc
+        rw [hsl, hnd] at hc
+        simp at hc
+        rcases hc with ⟨x, hx, rfl⟩
+        exact {pred_lemma} x (hds10 x hx)
+      {hfuel_pos}
+      simp only [{parse}, hch]
+      split
+      · rename_i heq
+        exact absurd heq (AverDigits.digitChar_toString_ne_minus d hd10)
+      · rename_i heq
+        exact absurd heq (AverDigits.digitChar_toString_ne_zero d hd10 hdne0)
+      · have harm : {posf} (String.fromInt (Int.ofNat m)) 0 (Char.toString (AverDigits.digitChar d))
+            = {scan} (String.fromInt (Int.ofNat m)) 1 0 false := by
+          simp [{posf}, {pred_lemma} d hd10]
+        rw [harm]
+        simp only [{scan}]
+        rw [{scan_lemma} (averStringPosFuel (String.fromInt (Int.ofNat m)) 1 1)
+              (String.fromInt (Int.ofNat m)) 1 0 (by omega) (by omega)
+              (by rw [hfuel]; omega) hdigits]
+        exact hfin"#,
+        hfuel_pos = indent_block(&scan_tail("(Int.ofNat m)", "1"), 6),
+    );
+
+    let negative = format!(
+        r#"· have hsl : (String.fromInt (Int.negSucc m)).data = '-' :: (AverDigits.natDigits (m + 1)).map AverDigits.digitChar := rfl
+  rcases hnd : AverDigits.natDigits (m + 1) with _ | ⟨d, ds⟩
+  · exact absurd hnd (AverDigits.natDigits_nonempty (m + 1))
+  · have hd10 : d < 10 := AverDigits.natDigits_digits_lt_ten (m + 1) d (by rw [hnd]; exact List.mem_cons_self _ _)
+    have hdne0 : d ≠ 0 := AverDigits.natDigits_head_ne_zero (m + 1) (by omega) d ds hnd
+    have hlen : (String.fromInt (Int.negSucc m)).data.length = ds.length + 2 := by
+      rw [hsl, hnd]; simp
+    have hch0 : String.charAt (String.fromInt (Int.negSucc m)) 0 = some "-" := by
+      have h := String.charAt_eq_of_lt (String.fromInt (Int.negSucc m)) 0 (by omega) (by omega)
+      simpa [hsl, show Char.toString '-' = "-" from rfl] using h
+    have hch1 : String.charAt (String.fromInt (Int.negSucc m)) 1
+        = some (Char.toString (AverDigits.digitChar d)) := by
+      have h := String.charAt_eq_of_lt (String.fromInt (Int.negSucc m)) 1 (by omega) (by omega)
+      simpa [hsl, hnd] using h
+    have hds10 : ∀ x ∈ ds, x < 10 := fun x hx =>
+      AverDigits.natDigits_digits_lt_ten (m + 1) x (by rw [hnd]; exact List.mem_cons_of_mem _ hx)
+    have hdigits : ∀ ch ∈ (String.fromInt (Int.negSucc m)).data.drop ((2 : Int)).toNat,
+        {pred} (Char.toString ch) = true := by
+      intro ch hc
+      rw [hsl, hnd] at hc
+      simp at hc
+      rcases hc with ⟨x, hx, rfl⟩
+      exact {pred_lemma} x (hds10 x hx)
+    {hfuel_neg}
+    have hdisp1 : {parse} (String.fromInt (Int.negSucc m)) 0
+        = {neg} (String.fromInt (Int.negSucc m)) 1 0 := by
+      simp only [{parse}]
+      rw [hch0]
+      rfl
+    rw [hdisp1]
+    simp only [{neg}, hch1]
+    split
+    · rename_i heq
+      exact absurd heq (AverDigits.digitChar_toString_ne_zero d hd10 hdne0)
+    · have harm : {sign} (String.fromInt (Int.negSucc m)) 1 0 (Char.toString (AverDigits.digitChar d))
+          = {scan} (String.fromInt (Int.negSucc m)) 2 0 false := by
+        simp [{sign}, {pred_lemma} d hd10]
+      rw [harm]
+      simp only [{scan}]
+      rw [{scan_lemma} (averStringPosFuel (String.fromInt (Int.negSucc m)) 2 1)
+            (String.fromInt (Int.negSucc m)) 2 0 (by omega) (by omega)
+            (by rw [hfuel]; omega) hdigits]
+      exact hfin"#,
+        hfuel_neg = indent_block(&scan_tail("(Int.negSucc m)", "2"), 4),
+    );
+
+    let inner = format!(
+        r#"have hts : {ser_text} = String.fromInt {n} := by
+  first
+    | rfl
+    | simp [{ser_simp}]
+rw [hts]
+have hfin : {finish} (String.fromInt {n}) 0 ((String.fromInt {n}).data.length : Int) false
+    = {rhs} := by
+  have h1 : ¬ (((String.fromInt {n}).data.length : Int) < 0) := by omega
+  have hslice : String.slice (String.fromInt {n}) 0 ((String.fromInt {n}).data.length : Int) = String.fromInt {n} := by
+    simp [String.slice, String.toList, h1]
+  have hlen0 : (String.fromInt {n}).data.length = (String.fromInt {n}).length := rfl
+  have h2 : {finish} (String.fromInt {n}) 0 ((String.fromInt {n}).data.length : Int) false
+      = {fint} (String.slice (String.fromInt {n}) 0 ((String.fromInt {n}).data.length : Int)) ((String.fromInt {n}).data.length : Int) := by
+    simp [{finish}]
+  rw [h2, hslice]
+  simp [{fint}, Int.fromString_fromInt {n}, hlen0]
+rcases {n} with m | m
+{positive}
+{negative}
+done"#
+    );
+
+    // Wrap as one `first` alternative: a parenthesized tacticSeq whose
+    // lines all sit at the column of its first tactic.
+    let mut proof_lines = vec![format!("  intro {n}"), "  first".to_string()];
+    for (i, line) in inner.lines().enumerate() {
+        if i == 0 {
+            proof_lines.push(format!("  | ({line}"));
+        } else if line.is_empty() {
+            proof_lines.push(String::new());
+        } else {
+            proof_lines.push(format!("     {line}"));
+        }
+    }
+    let last = proof_lines.last_mut()?;
+    last.push(')');
+    proof_lines.push("  | sorry".to_string());
+
+    Some(AutoProof {
+        support_lines,
+        proof_lines,
+        replaces_theorem: false,
+    })
+}
+
+/// Re-indent a multi-line block so it can be spliced at `spaces` depth
+/// (the first line is spliced in place; later lines get the prefix).
+fn indent_block(block: &str, spaces: usize) -> String {
+    let pad = " ".repeat(spaces);
+    block
+        .lines()
+        .enumerate()
+        .map(|(i, l)| {
+            if i == 0 || l.is_empty() {
+                l.to_string()
+            } else {
+                format!("{pad}{l}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -202,6 +202,62 @@ theorem String.slice_append_prefix (t u : String) :
   show String.mk ((t.data ++ u.data).take t.data.length) = t
   rw [List.take_left]"#;
 
+/// `String.charAt` at an in-bounds non-negative position computes to
+/// the indexed char. Bridges the prelude's `charAt` to `s.data` getElem
+/// form so synthesized scan lemmas (`<fn>__fuel_scan`) can dispatch a
+/// symbolic head char. Proof ported verbatim from the verified json
+/// hand proof.
+const LEAN_PRELUDE_STRING_CHARAT_EQ_OF_LT: &str = r#"/-- `String.charAt` at an in-bounds non-negative position is the indexed char. -/
+theorem String.charAt_eq_of_lt (s : String) (pos : Int) (h0 : 0 ≤ pos) (h : pos.toNat < s.data.length) :
+    String.charAt s pos = some (Char.toString (s.data[pos.toNat])) := by
+  have hn : ¬ pos < 0 := by omega
+  simp [String.charAt, String.toList, hn, List.getElem?_eq_getElem, h]"#;
+
+/// `String.charAt` past the end is `none` — the scan lemma's exit case.
+/// Proof ported verbatim from the verified json hand proof.
+const LEAN_PRELUDE_STRING_CHARAT_NONE_OF_GE: &str = r#"/-- `String.charAt` at/past the end of the string is `none`. -/
+theorem String.charAt_none_of_ge (s : String) (pos : Int) (h0 : 0 ≤ pos) (h : s.data.length ≤ pos.toNat) :
+    String.charAt s pos = none := by
+  have hn : ¬ pos < 0 := by omega
+  simp [String.charAt, String.toList, hn, List.getElem?_eq_none, h]"#;
+
+/// Decimal-digit facts over the `NumericParse` prelude — reopened
+/// `AverDigits` namespace, demand-driven like the String spec lemmas.
+/// `natDigits_head_ne_zero` (a canonical decimal render never starts
+/// with '0' for a nonzero Nat) plus the `digitChar` `Char.toString`
+/// disequalities kill the `"-"` / `"0"` dispatch arms on a SYMBOLIC
+/// head char in `IntDecimalRoundtrip` emissions. Proofs ported verbatim
+/// from the verified json hand proof.
+const LEAN_PRELUDE_NUMERIC_PARSE_HEAD_NE_ZERO: &str = r#"namespace AverDigits
+theorem natDigits_head_ne_zero : ∀ (m : Nat), m ≠ 0 → ∀ d ds, natDigits m = d :: ds → d ≠ 0 := by
+  intro m hm d ds hds
+  by_cases h : m < 10
+  · rw [natDigits.eq_1] at hds
+    simp [h] at hds
+    rcases hds with ⟨h1, h2⟩
+    omega
+  · rw [natDigits.eq_1] at hds
+    simp [h] at hds
+    rcases hh : natDigits (m / 10) with _ | ⟨d', ds'⟩
+    · exact absurd hh (natDigits_nonempty _)
+    · rw [hh, List.cons_append] at hds
+      injection hds with h1 h2
+      rw [← h1]
+      exact natDigits_head_ne_zero (m / 10) (by omega) d' ds' hh
+end AverDigits"#;
+
+const LEAN_PRELUDE_NUMERIC_PARSE_TOSTRING_NE: &str = r#"namespace AverDigits
+theorem digitChar_toString_ne_minus : ∀ d : Nat, d < 10 → Char.toString (digitChar d) ≠ "-" := by
+  intro d h
+  rcases d with _|_|_|_|_|_|_|_|_|_|d
+  all_goals first | decide | omega
+
+theorem digitChar_toString_ne_zero : ∀ d : Nat, d < 10 → d ≠ 0 → Char.toString (digitChar d) ≠ "0" := by
+  intro d h hne
+  rcases d with _|_|_|_|_|_|_|_|_|_|d
+  all_goals first | decide | omega
+end AverDigits"#;
+
 /// Static registry: prelude builtin(s) → prelude spec lemma names.
 /// Single source of truth, living next to the lemma texts it indexes —
 /// the `SimpOverPreludeLemmas` detector records the builtin call names
@@ -1261,7 +1317,7 @@ fn generate_prelude_for_body(body: &str, include_all_helpers: bool) -> String {
             "StringHelpers" => {
                 parts.push(generate_string_helpers_prelude(body, include_all_helpers))
             }
-            "NumericParse" => parts.push(LEAN_PRELUDE_NUMERIC_PARSE.to_string()),
+            "NumericParse" => parts.push(generate_numeric_parse_prelude(body, include_all_helpers)),
             "CharByte" => parts.push(LEAN_PRELUDE_CHAR_BYTE.to_string()),
             "AverMeasure" => parts.push(LEAN_PRELUDE_AVER_MEASURE.to_string()),
             "AverMap" => parts.push(generate_map_prelude(body, include_all_helpers)),
@@ -1318,6 +1374,31 @@ fn generate_string_helpers_prelude(body: &str, include_all_helpers: bool) -> Str
     }
     if include_all_helpers || body.contains("String.slice_append_prefix") {
         parts.push(LEAN_PRELUDE_STRING_SLICE_APPEND_PREFIX.to_string());
+    }
+    if include_all_helpers || body.contains("String.charAt_eq_of_lt") {
+        parts.push(LEAN_PRELUDE_STRING_CHARAT_EQ_OF_LT.to_string());
+    }
+    if include_all_helpers || body.contains("String.charAt_none_of_ge") {
+        parts.push(LEAN_PRELUDE_STRING_CHARAT_NONE_OF_GE.to_string());
+    }
+    parts.join("\n\n")
+}
+
+/// `NumericParse` section: base `AverDigits` + demand-driven decimal-
+/// digit spec lemmas (reopened namespace). Same inclusion pattern as
+/// [`generate_string_helpers_prelude`] — a lemma ships only when the
+/// emitted body (which includes law tactic text and synthesized scan
+/// lemmas) mentions its name.
+fn generate_numeric_parse_prelude(body: &str, include_all_helpers: bool) -> String {
+    let mut parts = vec![LEAN_PRELUDE_NUMERIC_PARSE.to_string()];
+    if include_all_helpers || body.contains("AverDigits.natDigits_head_ne_zero") {
+        parts.push(LEAN_PRELUDE_NUMERIC_PARSE_HEAD_NE_ZERO.to_string());
+    }
+    if include_all_helpers
+        || body.contains("AverDigits.digitChar_toString_ne_minus")
+        || body.contains("AverDigits.digitChar_toString_ne_zero")
+    {
+        parts.push(LEAN_PRELUDE_NUMERIC_PARSE_TOSTRING_NE.to_string());
     }
     parts.join("\n\n")
 }
@@ -1698,7 +1779,7 @@ fn build_common_lean(union_body: &str) -> String {
             "BranchPath" => parts.push(LEAN_PRELUDE_BRANCH_PATH.to_string()),
             "AverList" => parts.push(LEAN_PRELUDE_AVER_LIST.to_string()),
             "StringHelpers" => parts.push(generate_string_helpers_prelude(union_body, false)),
-            "NumericParse" => parts.push(LEAN_PRELUDE_NUMERIC_PARSE.to_string()),
+            "NumericParse" => parts.push(generate_numeric_parse_prelude(union_body, false)),
             "CharByte" => parts.push(LEAN_PRELUDE_CHAR_BYTE.to_string()),
             "AverMeasure" => parts.push(LEAN_PRELUDE_AVER_MEASURE.to_string()),
             "AverMap" => parts.push(generate_map_prelude(union_body, false)),
@@ -3608,6 +3689,74 @@ verify mirror law involutive
         assert!(lean.contains("def down (n : Int) : Int :="));
         assert!(lean.contains("if h_dom : n ≥ 0 then down__aux n h_dom"));
         assert!(!lean.contains("def down__fuel"));
+    }
+
+    /// Shared module body for the scan-lemma gate probes: `isDigit` is
+    /// the canonical single-String-param Bool predicate.
+    const SCAN_GATE_PRELUDE: &str = r#"module ScanGate
+    intent = "scan-lemma synthesis gate probes"
+    effects []
+
+fn isDigit(c: String) -> Bool
+    code = Char.toCode(c)
+    match code >= 48
+        true -> code <= 57
+        false -> false
+"#;
+
+    fn lean_for_scan_gate(scanner: &str) -> String {
+        let source = format!("{SCAN_GATE_PRELUDE}\n{scanner}");
+        let mut ctx = ctx_from_source(&source, "scan_gate");
+        let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
+        out.files
+            .iter()
+            .map(|(_, content)| content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn scan_lemma_emitted_for_canonical_pos_returning_scanner() {
+        // Positive control for the gates below: EXIT mentions `pos`, so
+        // the `<fn>__fuel_scan` companion is synthesized.
+        let lean = lean_for_scan_gate(
+            r#"fn scanEnd(s: String, pos: Int) -> Int
+    match String.charAt(s, pos)
+        Option.None -> pos
+        Option.Some(c) -> match isDigit(c)
+            true -> scanEnd(s, pos + 1)
+            false -> 0 - 1
+"#,
+        );
+        assert!(
+            lean.contains("scanEnd__fuel_scan"),
+            "expected the scan companion lemma for the canonical shape, got:\n{lean}"
+        );
+    }
+
+    #[test]
+    fn scan_lemma_not_emitted_for_pos_free_exit_scanner() {
+        // EXIT without any `pos` occurrence (a constant-exit validator):
+        // the lemma template's `rw [hpos]` would have no work to do and
+        // FAIL — a build error in the export. The recognizer must
+        // decline so nothing is synthesized.
+        let lean = lean_for_scan_gate(
+            r#"fn scanAll(s: String, pos: Int) -> Bool
+    match String.charAt(s, pos)
+        Option.None -> true
+        Option.Some(c) -> match isDigit(c)
+            true -> scanAll(s, pos + 1)
+            false -> false
+"#,
+        );
+        assert!(
+            !lean.contains("__fuel_scan"),
+            "pos-free EXIT must not get a scan lemma, got:\n{lean}"
+        );
+        assert!(
+            lean.contains("def scanAll__fuel"),
+            "the scanner itself still gets its fuel emission, got:\n{lean}"
+        );
     }
 
     #[test]

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -766,11 +766,157 @@ fn emit_fuelized_string_pos_fn(fd: &FnDef, ctx: &CodegenContext) -> String {
         emit_fuel_helper_def(&helper_name, &params, &ret_type, &body, ""),
         vec![String::new()],
         emit_string_pos_wrapper(fd, &helper_name, 1),
+        emit_string_pos_scan_lemma(fd, &helper_name, ctx)
+            .map(|lemma| vec![String::new(), lemma])
+            .unwrap_or_default(),
     ]
     .into_iter()
     .flatten()
     .collect::<Vec<_>>()
     .join("\n")
+}
+
+/// Companion theorem for a fuelized string-position SCANNER — the
+/// general crack in the fuel-unfolding barrier (#125 family): when the
+/// body matches the canonical shape `match String.charAt s pos with |
+/// none => EXIT | some c => if P c then SELF(s, pos+1, …) else OTHER`
+/// (recognized by `proof_recognize::detect_string_pos_scan`), emit
+///
+/// ```text
+/// theorem <fn>__fuel_scan : ∀ fuel s pos <carried>,
+///   0 ≤ pos → pos.toNat ≤ s.data.length →
+///   s.data.length - pos.toNat < fuel →
+///   (∀ ch ∈ s.data.drop pos.toNat, P (Char.toString ch) = true) →
+///   <fn>__fuel fuel s pos <args@pins> = EXIT[pos := ↑s.data.length]
+/// ```
+///
+/// proved by a FIXED fuel-induction template (`String.charAt_eq_of_lt`
+/// / `String.charAt_none_of_ge` + `List.drop_eq_getElem_cons` + omega —
+/// ported verbatim from the verified json hand proof). Universal-law
+/// emissions (`IntDecimalRoundtrip`) rewrite through this lemma to run
+/// a symbolic all-`P` suffix to the end of the string.
+///
+/// CONSERVATIVELY SHAPE-GATED: when the body does not match the exact
+/// recognizer shape, NOTHING is emitted — every emission must be
+/// provable by the uniform template BY CONSTRUCTION of the gate (a
+/// synthesized lemma that fails to prove would be a build error in the
+/// export). The predicate must also resolve to a pure single-`String`-
+/// param `Bool` fn (the lemma cites it by name as a hypothesis key; it
+/// is never unfolded).
+fn emit_string_pos_scan_lemma(
+    fd: &FnDef,
+    helper_name: &str,
+    ctx: &CodegenContext,
+) -> Option<String> {
+    let shape = crate::codegen::proof_recognize::detect_string_pos_scan(fd)?;
+    let scope = ctx.active_module_scope();
+    let pred_fd = ctx
+        .fn_def_by_name(&shape.predicate_fn, scope.as_deref())
+        .or_else(|| ctx.fn_def_by_name(&shape.predicate_fn, None))?;
+    if !crate::codegen::proof_recognize::scan_predicate_fn_ok(pred_fd) {
+        return None;
+    }
+
+    let s = aver_name_to_lean(&fd.params[0].0);
+    let pos = aver_name_to_lean(&fd.params[1].0);
+    let pred = aver_name_to_lean(&shape.predicate_fn);
+    let lemma_name = format!("{helper_name}_scan");
+
+    // Trailing args: carried params stay variables (quantified), pinned
+    // params bake their Bool literal into statement + calc steps.
+    let mut carried_binders: Vec<String> = Vec::new();
+    let mut carried_names: Vec<String> = Vec::new();
+    let mut trailing_args: Vec<String> = Vec::new();
+    for (i, pin) in shape.param_pins.iter().enumerate() {
+        let (name, ty) = &fd.params[i + 2];
+        match pin {
+            None => {
+                let lean = aver_name_to_lean(name);
+                carried_binders.push(format!(" ({} : {})", lean, type_annotation_to_lean(ty)));
+                carried_names.push(lean.clone());
+                trailing_args.push(lean);
+            }
+            Some(b) => trailing_args.push(b.to_string()),
+        }
+    }
+    let args = trailing_args
+        .iter()
+        .map(|a| format!(" {a}"))
+        .collect::<String>();
+    let carried_binder_text: String = carried_binders.concat();
+    let carried_intro = carried_names
+        .iter()
+        .map(|n| format!("{n} "))
+        .collect::<String>();
+
+    // EXIT[pos := ↑s.data.length, pinned := literal]: substitute at the
+    // AST level (a unique marker stands in for the length cast, which
+    // has no Aver-AST form), render through the SAME expr emitter the
+    // body used, then swap the marker for the cast.
+    const LEN_MARKER: &str = "AVERSCANLEN";
+    let mut subst: std::collections::HashMap<String, crate::ast::Expr> =
+        std::collections::HashMap::new();
+    subst.insert(
+        fd.params[1].0.clone(),
+        crate::ast::Expr::Ident(LEN_MARKER.to_string()),
+    );
+    for (i, pin) in shape.param_pins.iter().enumerate() {
+        if let Some(b) = pin {
+            subst.insert(
+                fd.params[i + 2].0.clone(),
+                crate::ast::Expr::Literal(crate::ast::Literal::Bool(*b)),
+            );
+        }
+    }
+    let exit_subst =
+        crate::codegen::proof_recognize::substitute_idents_in_expr(&shape.exit_expr, &subst);
+    let exit = emit_expr_legacy(&exit_subst, ctx, None)
+        .replace('\n', " ")
+        .replace(LEN_MARKER, &format!("(({s}.data.length : Int))"));
+
+    Some(format!(
+        r#"/-- Auto-synthesized scan lemma: an all-`{pred}` suffix scan runs to the
+    end of the string. Companion to the `{helper_name}` fuel def; proved by
+    the fixed fuel-induction template. -/
+theorem {lemma_name} :
+    ∀ (fuel : Nat) ({s} : String) ({pos} : Int){carried_binder_text},
+      0 ≤ {pos} → {pos}.toNat ≤ {s}.data.length →
+      {s}.data.length - {pos}.toNat < fuel →
+      (∀ ch ∈ {s}.data.drop {pos}.toNat, {pred} (Char.toString ch) = true) →
+      {helper_name} fuel {s} {pos}{args} = {exit} := by
+  intro fuel
+  induction fuel with
+  | zero =>
+    intro {s} {pos} {carried_intro}h0 h1 h2 h3
+    omega
+  | succ fuel ih =>
+    intro {s} {pos} {carried_intro}h0 h1 h2 h3
+    by_cases hlt : {pos}.toNat < {s}.data.length
+    · have hch := String.charAt_eq_of_lt {s} {pos} h0 hlt
+      have hdrop := List.drop_eq_getElem_cons (l := {s}.data) (n := {pos}.toNat) hlt
+      have hdig : {pred} (Char.toString ({s}.data[{pos}.toNat])) = true := by
+        apply h3
+        rw [hdrop]
+        exact List.mem_cons_self _ _
+      have hstep : ∀ ch ∈ {s}.data.drop (({pos} + 1).toNat), {pred} (Char.toString ch) = true := by
+        intro ch hc
+        apply h3
+        rw [hdrop]
+        refine List.mem_cons_of_mem _ ?_
+        have he : ({pos} + 1).toNat = {pos}.toNat + 1 := by omega
+        rw [he] at hc
+        exact hc
+      have hrec := ih {s} ({pos} + 1) {carried_intro}(by omega) (by omega) (by omega) hstep
+      calc {helper_name} (fuel + 1) {s} {pos}{args}
+          = {helper_name} fuel {s} ({pos} + 1){args} := by
+            simp only [{helper_name}, hch, hdig]
+            simp
+        _ = {exit} := hrec
+    · have hpos : {pos} = ({s}.data.length : Int) := by omega
+      have hch := String.charAt_none_of_ge {s} {pos} h0 (by omega)
+      simp only [{helper_name}, hch]
+      rw [hpos]"#
+    ))
 }
 
 fn strip_match_eq_binders(body: String) -> String {
@@ -2687,6 +2833,12 @@ fn emit_verify_law_block(
                 // checked_domain cover the point) instead of gaining
                 // a universal that would land as a caught sorry.
                 | crate::ir::ProofStrategy::SimpOverPreludeLemmas { .. }
+                // IntDecimalRoundtrip shares the same honest-sorry
+                // floor (`first | (…; done) | sorry`); its detector
+                // also requires a given-dependent rhs, so the
+                // singleton-const-rhs skip can't apply — listed for
+                // the same conservatism.
+                | crate::ir::ProofStrategy::IntDecimalRoundtrip { .. }
         )
     });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs

--- a/src/codegen/proof_lower.rs
+++ b/src/codegen/proof_lower.rs
@@ -881,10 +881,14 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
 /// 9. `FiniteDomainCases { givens }` — every given ranges over a
 ///    closed finite domain (Bool / fieldless enum, product ≤ 16);
 ///    closes by exhaustive `cases` enumeration.
-/// 10. `SimpOverPreludeLemmas { … }` — builtin-roundtrip shape; the
+/// 10. `IntDecimalRoundtrip { … }` — canonical decimal-Int
+///     parse/serialize roundtrip over a recognized string-pos scanner;
+///     runs before the prelude-simp rung, which would otherwise claim
+///     the shape and park it on a caught sorry.
+/// 11. `SimpOverPreludeLemmas { … }` — builtin-roundtrip shape; the
 ///     Lean backend renders it AFTER its legacy chain, so it fires
 ///     exactly where the bare-`sorry` universal used to.
-/// 11. `BackendDispatch` — backend's ad-hoc chain decides.
+/// 12. `BackendDispatch` — backend's ad-hoc chain decides.
 ///
 /// (The induction/spec-equivalence/Map families detected between
 /// these rungs are documented at their detector sites below.)
@@ -1097,6 +1101,20 @@ fn classify_law_strategy(
     {
         return ProofStrategy::FiniteDomainCases { givens };
     }
+    // Decimal-Int parse/serialize roundtrip — runs BEFORE the prelude-
+    // simp rung because that rung would otherwise claim the shape (the
+    // lhs cone is fuel-wrapped with measure-closed args) and park it on
+    // a caught sorry the scanner barrier guarantees. The detector
+    // validates the ENTIRE canonical parser shape (head-char dispatch
+    // arms, single recognized scanner, slice + `Int.fromString` leaf),
+    // so it cannot fire on the #469 prelude-simp laws (`finishInt` /
+    // `finishNumber` / `afterIntChar` / `finishString` — wrong arity or
+    // non-literal second arg at the law call site).
+    if law.when.is_none()
+        && let Some(s) = detect_int_decimal_roundtrip(law, fn_name, inputs, fn_contracts)
+    {
+        return s;
+    }
     // Builtin-roundtrip simp over the prelude's spec-lemma registry —
     // the very last typed fallback. The Lean backend deliberately
     // renders this strategy AFTER its whole legacy ad-hoc chain (see
@@ -1109,6 +1127,482 @@ fn classify_law_strategy(
         return s;
     }
     ProofStrategy::BackendDispatch
+}
+
+/// Detector for [`crate::ir::ProofStrategy::IntDecimalRoundtrip`] — the
+/// canonical decimal-Int parse/serialize roundtrip
+/// (`examples/data/json.av` `parseNumber.fromIntRoundtrip`).
+///
+/// Law shape: no `when`, exactly one `given n: Int`, lhs
+/// `parse(ser(C(n)), 0)`, rhs `Ok(C(n), String.len(ser(C(n))))`. Fn
+/// shape, validated transitively and EXACTLY (every gate is load-
+/// bearing for the Lean emission's fixed proof skeleton — see the
+/// variant doc):
+///
+/// ```text
+/// parse(s, start)   = match charAt(s, start) { None -> _,
+///                       Some(c) -> match c { "-" -> neg(s, start+1, start),
+///                                            "0" -> scan(s, start+1, start, true),
+///                                            _   -> pos(s, start, c) } }
+/// pos(s, start, c)  = match P(c) { true -> scan(s, start+1, start, false), false -> _ }
+/// neg(s, p, start)  = match charAt(s, p) { None -> _,
+///                       Some(c) -> match c { "0" -> scan(s, p+1, start, true),
+///                                            _   -> sign(s, p, start, c) } }
+/// sign(s, p, start, c) = match P(c) { true -> scan(s, p+1, start, false), false -> _ }
+/// scan              = recognized string-pos scanner (predicate P,
+///                     pins [carried, false], string-pos fuel contract,
+///                     exit finish(s, start, p, false))
+/// finish(s, a, e, asFloat) = num = String.slice(s, a, e);
+///                     match asFloat { true -> _, false -> fint(num, e) }
+/// fint(num, p)      = match Int.fromString(num) { Result.Ok(v) -> Ok(C(v), p), _ -> _ }
+/// ser               = match … { C(x) -> String.fromInt(x), … }
+/// ```
+///
+/// A shape that deviates anywhere pins nothing (falls through to the
+/// prelude-simp rung / `BackendDispatch`) — the conservative gate is
+/// what lets the emission cite the scanner's synthesized
+/// `<fn>__fuel_scan` lemma knowing it exists.
+fn detect_int_decimal_roundtrip(
+    law: &crate::ast::VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs,
+    fn_contracts: &std::collections::HashMap<crate::ir::FnId, crate::ir::FnContract>,
+) -> Option<crate::ir::ProofStrategy> {
+    use crate::ast::{Expr, Literal, Pattern, Stmt};
+
+    if law.when.is_some() || law.givens.len() != 1 || law.givens[0].type_name != "Int" {
+        return None;
+    }
+    let given = law.givens[0].name.as_str();
+    // The Lean emission's fixed skeleton binds these names; a colliding
+    // given would be shadowed mid-proof.
+    const SKELETON_RESERVED: &[&str] = &[
+        "m", "d", "ds", "x", "hx", "hm", "hnd", "hsl", "hch", "hch0", "hch1", "hlen", "hmk",
+        "hds10", "hdigits", "hfuel", "harm", "heq", "hdisp1", "hts", "hfin", "h0", "h1", "h2",
+        "hlen0", "hslice",
+    ];
+    if SKELETON_RESERVED.contains(&given) {
+        return None;
+    }
+
+    fn ident_of(e: &Spanned<Expr>) -> Option<&str> {
+        match &e.node {
+            Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.as_str()),
+            _ => None,
+        }
+    }
+    fn call_of(e: &Spanned<Expr>) -> Option<(String, &[Spanned<Expr>])> {
+        match &e.node {
+            Expr::FnCall(callee, args) => {
+                Some((expr_to_dotted_name(&callee.node)?, args.as_slice()))
+            }
+            Expr::TailCall(data) => Some((data.target.clone(), data.args.as_slice())),
+            _ => None,
+        }
+    }
+    // Constructor application: `Type.Variant(args…)` parses as a FnCall
+    // on a dotted uppercase-leaf name; resolved bodies may carry
+    // `Expr::Constructor`.
+    fn ctor_of(e: &Spanned<Expr>) -> Option<(String, Vec<&Spanned<Expr>>)> {
+        match &e.node {
+            Expr::FnCall(callee, args) => {
+                let name = expr_to_dotted_name(&callee.node)?;
+                let leaf = name.rsplit('.').next()?;
+                if !leaf.chars().next().is_some_and(|c| c.is_uppercase()) {
+                    return None;
+                }
+                Some((name, args.iter().collect()))
+            }
+            Expr::Constructor(name, payload) => {
+                let args: Vec<&Spanned<Expr>> = match payload.as_deref() {
+                    None => Vec::new(),
+                    Some(Spanned {
+                        node: Expr::Tuple(items),
+                        ..
+                    }) => items.iter().collect(),
+                    Some(single) => vec![single],
+                };
+                Some((name.clone(), args))
+            }
+            _ => None,
+        }
+    }
+    fn is_ident(e: &Spanned<Expr>, name: &str) -> bool {
+        ident_of(e) == Some(name)
+    }
+    fn is_plus_one(e: &Spanned<Expr>, name: &str) -> bool {
+        matches!(&e.node, Expr::BinOp(crate::ast::BinOp::Add, l, r)
+            if ident_of(l) == Some(name)
+                && matches!(&r.node, Expr::Literal(Literal::Int(1))))
+    }
+    let resolve_user_fn = |name: &str| -> Option<&FnDef> {
+        let fd = inputs.find_fn_def_by_call_name(name)?;
+        (fd.effects.is_empty() && fd.name != "main").then_some(fd)
+    };
+    fn single_match(fd: &FnDef) -> Option<(&Spanned<Expr>, &[crate::ast::MatchArm])> {
+        let [Stmt::Expr(body)] = fd.body.stmts() else {
+            return None;
+        };
+        let Expr::Match { subject, arms } = &body.node else {
+            return None;
+        };
+        Some((subject, arms.as_slice()))
+    }
+    /// (Some-binder name, Some arm) of a 2-arm charAt(p0, p1) match.
+    fn charat_match(fd: &FnDef) -> Option<(String, &crate::ast::MatchArm)> {
+        let (subject, arms) = single_match(fd)?;
+        let (callee, args) = call_of(subject)?;
+        if callee != "String.charAt"
+            || args.len() != 2
+            || !is_ident(&args[0], &fd.params[0].0)
+            || !is_ident(&args[1], &fd.params[1].0)
+            || arms.len() != 2
+        {
+            return None;
+        }
+        arms.iter()
+            .any(|a| matches!(&a.pattern, Pattern::Constructor(n, b) if n == "Option.None" && b.is_empty()))
+            .then_some(())?;
+        let some_arm = arms.iter().find(
+            |a| matches!(&a.pattern, Pattern::Constructor(n, b) if n == "Option.Some" && b.len() == 1),
+        )?;
+        let Pattern::Constructor(_, binders) = &some_arm.pattern else {
+            return None;
+        };
+        Some((binders[0].clone(), some_arm))
+    }
+    /// `match P(c) { true -> scan(s, pos+1, start, false), false -> _ }`
+    /// dispatcher tail shared by `pos_fn` and `sign_fn`. Returns
+    /// (predicate name, scanner name).
+    fn digit_dispatch(
+        fd: &FnDef,
+        s_param: &str,
+        pos_param: &str,
+        start_param: &str,
+        c_param: &str,
+    ) -> Option<(String, String)> {
+        let (subject, arms) = single_match(fd)?;
+        let (pred, pred_args) = call_of(subject)?;
+        if pred.contains('.') || pred_args.len() != 1 || !is_ident(&pred_args[0], c_param) {
+            return None;
+        }
+        if arms.len() != 2
+            || !arms
+                .iter()
+                .any(|a| matches!(&a.pattern, Pattern::Literal(Literal::Bool(false))))
+        {
+            return None;
+        }
+        let true_arm = arms
+            .iter()
+            .find(|a| matches!(&a.pattern, Pattern::Literal(Literal::Bool(true))))?;
+        let (scan, scan_args) = call_of(&true_arm.body)?;
+        (scan_args.len() == 4
+            && is_ident(&scan_args[0], s_param)
+            && is_plus_one(&scan_args[1], pos_param)
+            && is_ident(&scan_args[2], start_param)
+            && matches!(&scan_args[3].node, Expr::Literal(Literal::Bool(false))))
+        .then_some((pred, scan))
+    }
+
+    // ---- Law shape -------------------------------------------------
+    let (lhs_callee, lhs_args) = call_of(&law.lhs)?;
+    if lhs_callee.rsplit('.').next()? != fn_name || lhs_args.len() != 2 {
+        return None;
+    }
+    let ser_arg = &lhs_args[0];
+    if !matches!(&lhs_args[1].node, Expr::Literal(Literal::Int(0))) {
+        return None;
+    }
+    let (ser_name, ser_args) = call_of(ser_arg)?;
+    if ser_args.len() != 1 {
+        return None;
+    }
+    let ctor_expr = &ser_args[0];
+    let (ctor_name, ctor_args) = ctor_of(ctor_expr)?;
+    if ctor_args.len() != 1 || !is_ident(ctor_args[0], given) {
+        return None;
+    }
+    // The constructor's variant must carry exactly one Int field — the
+    // serializer's ADT measure is then constant on `C(n)` for free `n`
+    // (fuel computes; `ser(C(n)) = String.fromInt n` can be `rfl`).
+    {
+        let (type_name, variant_name) = ctor_name.rsplit_once('.')?;
+        let Some(crate::ast::TypeDef::Sum { variants, .. }) = inputs.find_type_def(type_name)
+        else {
+            return None;
+        };
+        variants
+            .iter()
+            .any(|v| v.name == variant_name && v.fields.len() == 1 && v.fields[0].trim() == "Int")
+            .then_some(())?;
+    }
+    let (ok_name, rhs_args) = ctor_of(&law.rhs)?;
+    if rhs_args.len() != 2 || rhs_args[0].node != ctor_expr.node {
+        return None;
+    }
+    let (len_callee, len_args) = call_of(rhs_args[1])?;
+    if len_callee != "String.len" || len_args.len() != 1 || len_args[0].node != ser_arg.node {
+        return None;
+    }
+
+    // ---- Serializer: has the `C(x) -> String.fromInt(x)` arm --------
+    let ser_fd = resolve_user_fn(&ser_name)?;
+    {
+        let (_, arms) = single_match(ser_fd)?;
+        arms.iter()
+            .any(|a| {
+                let Pattern::Constructor(n, binders) = &a.pattern else {
+                    return false;
+                };
+                if n != &ctor_name || binders.len() != 1 {
+                    return false;
+                }
+                call_of(&a.body).is_some_and(|(callee, args)| {
+                    callee == "String.fromInt" && args.len() == 1 && is_ident(&args[0], &binders[0])
+                })
+            })
+            .then_some(())?;
+    }
+
+    // ---- Parser: head-char dispatch ---------------------------------
+    let parse_fd = resolve_user_fn(fn_name)?;
+    if parse_fd.params.len() != 2
+        || parse_fd.params[0].1 != "String"
+        || parse_fd.params[1].1 != "Int"
+    {
+        return None;
+    }
+    let (p_s, p_start) = (parse_fd.params[0].0.as_str(), parse_fd.params[1].0.as_str());
+    let (c_name, some_arm) = charat_match(parse_fd)?;
+    let Expr::Match {
+        subject: c_subject,
+        arms: c_arms,
+    } = &some_arm.body.node
+    else {
+        return None;
+    };
+    if !is_ident(c_subject, &c_name) || c_arms.len() != 3 {
+        return None;
+    }
+    // Arm order is load-bearing: the emission's `split` bullets follow
+    // the textual arm order of the emitted Lean match.
+    if !matches!(&c_arms[0].pattern, Pattern::Literal(Literal::Str(s)) if s == "-")
+        || !matches!(&c_arms[1].pattern, Pattern::Literal(Literal::Str(s)) if s == "0")
+        || !matches!(&c_arms[2].pattern, Pattern::Wildcard)
+    {
+        return None;
+    }
+    let (neg_name, neg_args) = call_of(&c_arms[0].body)?;
+    (neg_args.len() == 3
+        && is_ident(&neg_args[0], p_s)
+        && is_plus_one(&neg_args[1], p_start)
+        && is_ident(&neg_args[2], p_start))
+    .then_some(())?;
+    let (scan_zero, zero_args) = call_of(&c_arms[1].body)?;
+    (zero_args.len() == 4
+        && is_ident(&zero_args[0], p_s)
+        && is_plus_one(&zero_args[1], p_start)
+        && is_ident(&zero_args[2], p_start)
+        && matches!(&zero_args[3].node, Expr::Literal(Literal::Bool(true))))
+    .then_some(())?;
+    let (pos_name, pos_args) = call_of(&c_arms[2].body)?;
+    (pos_args.len() == 3
+        && is_ident(&pos_args[0], p_s)
+        && is_ident(&pos_args[1], p_start)
+        && is_ident(&pos_args[2], &c_name))
+    .then_some(())?;
+
+    // ---- pos_fn / neg_fn / sign_fn ----------------------------------
+    let pos_fd = resolve_user_fn(&pos_name)?;
+    if pos_fd.params.len() != 3 {
+        return None;
+    }
+    let (pred_a, scan_a) = digit_dispatch(
+        pos_fd,
+        &pos_fd.params[0].0,
+        &pos_fd.params[1].0,
+        &pos_fd.params[1].0,
+        &pos_fd.params[2].0,
+    )?;
+
+    let neg_fd = resolve_user_fn(&neg_name)?;
+    if neg_fd.params.len() != 3 {
+        return None;
+    }
+    let (n_s, n_pos, n_start) = (
+        neg_fd.params[0].0.as_str(),
+        neg_fd.params[1].0.as_str(),
+        neg_fd.params[2].0.as_str(),
+    );
+    let (c2_name, neg_some_arm) = charat_match(neg_fd)?;
+    let Expr::Match {
+        subject: c2_subject,
+        arms: c2_arms,
+    } = &neg_some_arm.body.node
+    else {
+        return None;
+    };
+    if !is_ident(c2_subject, &c2_name) || c2_arms.len() != 2 {
+        return None;
+    }
+    if !matches!(&c2_arms[0].pattern, Pattern::Literal(Literal::Str(s)) if s == "0")
+        || !matches!(&c2_arms[1].pattern, Pattern::Wildcard)
+    {
+        return None;
+    }
+    let (scan_b, nz_args) = call_of(&c2_arms[0].body)?;
+    (nz_args.len() == 4
+        && is_ident(&nz_args[0], n_s)
+        && is_plus_one(&nz_args[1], n_pos)
+        && is_ident(&nz_args[2], n_start)
+        && matches!(&nz_args[3].node, Expr::Literal(Literal::Bool(true))))
+    .then_some(())?;
+    let (sign_name, sign_args) = call_of(&c2_arms[1].body)?;
+    (sign_args.len() == 4
+        && is_ident(&sign_args[0], n_s)
+        && is_ident(&sign_args[1], n_pos)
+        && is_ident(&sign_args[2], n_start)
+        && is_ident(&sign_args[3], &c2_name))
+    .then_some(())?;
+
+    let sign_fd = resolve_user_fn(&sign_name)?;
+    if sign_fd.params.len() != 4 {
+        return None;
+    }
+    let (pred_b, scan_c) = digit_dispatch(
+        sign_fd,
+        &sign_fd.params[0].0,
+        &sign_fd.params[1].0,
+        &sign_fd.params[2].0,
+        &sign_fd.params[3].0,
+    )?;
+
+    // One scanner, one predicate, everywhere.
+    if pred_a != pred_b || scan_a != scan_b || scan_a != scan_c || scan_a != scan_zero {
+        return None;
+    }
+    let scanner_name = scan_a;
+    let pred_name = pred_a;
+
+    // ---- Scanner: recognized shape + string-pos fuel contract -------
+    let scan_fd = resolve_user_fn(&scanner_name)?;
+    let shape = crate::codegen::proof_recognize::detect_string_pos_scan(scan_fd)?;
+    if shape.predicate_fn != pred_name || shape.param_pins != vec![None, Some(false)] {
+        return None;
+    }
+    let pred_fd = resolve_user_fn(&pred_name)?;
+    if !crate::codegen::proof_recognize::scan_predicate_fn_ok(pred_fd) {
+        return None;
+    }
+    let scan_key = match inputs.fn_owning_scope(scan_fd) {
+        Some(prefix) => crate::ir::FnKey::in_module(prefix.to_string(), &scan_fd.name),
+        None => crate::ir::FnKey::entry(&scan_fd.name),
+    };
+    let scan_contract = inputs
+        .symbol_table
+        .fn_id_of(&scan_key)
+        .and_then(|id| fn_contracts.get(&id))?;
+    if !matches!(
+        scan_contract.recursion,
+        Some(crate::ir::RecursionContract::Fuel {
+            fuel_metric: crate::ir::FuelMetric::StringLenMinusPos { .. },
+        })
+    ) {
+        return None;
+    }
+    // Exit: `finish(s, start, pos, false)`.
+    let (finish_name, exit_args) = call_of(&shape.exit_expr)?;
+    (exit_args.len() == 4
+        && is_ident(&exit_args[0], &scan_fd.params[0].0)
+        && is_ident(&exit_args[1], &scan_fd.params[2].0)
+        && is_ident(&exit_args[2], &scan_fd.params[1].0)
+        && matches!(&exit_args[3].node, Expr::Literal(Literal::Bool(false))))
+    .then_some(())?;
+
+    // ---- finish_fn: slice + asFloat dispatch -------------------------
+    let finish_fd = resolve_user_fn(&finish_name)?;
+    if finish_fd.params.len() != 4 {
+        return None;
+    }
+    let [
+        Stmt::Binding(num_name, _, slice_expr),
+        Stmt::Expr(finish_match),
+    ] = finish_fd.body.stmts()
+    else {
+        return None;
+    };
+    {
+        let (slice_callee, slice_args) = call_of(slice_expr)?;
+        (slice_callee == "String.slice"
+            && slice_args.len() == 3
+            && is_ident(&slice_args[0], &finish_fd.params[0].0)
+            && is_ident(&slice_args[1], &finish_fd.params[1].0)
+            && is_ident(&slice_args[2], &finish_fd.params[2].0))
+        .then_some(())?;
+    }
+    let Expr::Match {
+        subject: float_subject,
+        arms: float_arms,
+    } = &finish_match.node
+    else {
+        return None;
+    };
+    if !is_ident(float_subject, &finish_fd.params[3].0) || float_arms.len() != 2 {
+        return None;
+    }
+    float_arms
+        .iter()
+        .any(|a| matches!(&a.pattern, Pattern::Literal(Literal::Bool(true))))
+        .then_some(())?;
+    let int_arm = float_arms
+        .iter()
+        .find(|a| matches!(&a.pattern, Pattern::Literal(Literal::Bool(false))))?;
+    let (finish_int_name, fi_args) = call_of(&int_arm.body)?;
+    (fi_args.len() == 2
+        && is_ident(&fi_args[0], num_name)
+        && is_ident(&fi_args[1], &finish_fd.params[2].0))
+    .then_some(())?;
+
+    // ---- finish_int_fn: Int.fromString leaf rebuilding the law's rhs --
+    let fint_fd = resolve_user_fn(&finish_int_name)?;
+    if fint_fd.params.len() != 2 {
+        return None;
+    }
+    {
+        let (subject, arms) = single_match(fint_fd)?;
+        let (callee, args) = call_of(subject)?;
+        (callee == "Int.fromString" && args.len() == 1 && is_ident(&args[0], &fint_fd.params[0].0))
+            .then_some(())?;
+        let ok_arm = arms.iter().find(
+            |a| matches!(&a.pattern, Pattern::Constructor(n, b) if n == "Result.Ok" && b.len() == 1),
+        )?;
+        let Pattern::Constructor(_, ok_binders) = &ok_arm.pattern else {
+            return None;
+        };
+        let (arm_ok_name, arm_args) = ctor_of(&ok_arm.body)?;
+        (arm_ok_name == ok_name
+            && arm_args.len() == 2
+            && is_ident(arm_args[1], &fint_fd.params[1].0))
+        .then_some(())?;
+        let (arm_ctor, arm_ctor_args) = ctor_of(arm_args[0])?;
+        (arm_ctor == ctor_name
+            && arm_ctor_args.len() == 1
+            && is_ident(arm_ctor_args[0], &ok_binders[0]))
+        .then_some(())?;
+    }
+
+    Some(crate::ir::ProofStrategy::IntDecimalRoundtrip {
+        parse_fn: fn_name.to_string(),
+        neg_fn: neg_name,
+        pos_fn: pos_name,
+        sign_fn: sign_name,
+        scanner_fn: scanner_name,
+        predicate_fn: pred_name,
+        finish_fn: finish_name,
+        finish_int_fn: finish_int_name,
+        serializer_fn: ser_name,
+    })
 }
 
 /// Builtin-roundtrip detector for [`ProofStrategy::SimpOverPreludeLemmas`]

--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -917,3 +917,489 @@ pub(crate) fn collect_nat_arith_ops_for_names(
         })
         .collect()
 }
+
+// ---- String-position scanner shape ----------------------------------
+
+/// Canonical fuelized string-position scanner shape:
+///
+/// ```text
+/// fn scan(s: String, pos: Int, carried..., pinned...) -> R
+///     match String.charAt(s, pos)
+///         Option.None -> EXIT
+///         Option.Some(c) -> match P(c)
+///             true -> SELF(s, pos + 1, carried..., <literal pins>)
+///             false -> OTHER
+/// ```
+///
+/// where the `true` arm may interpose Bool matches on PINNED params
+/// (params the unique self-call fixes to a Bool literal) on the path to
+/// the self-call — `scanIntTail`'s `match leadingZero` shape. The shape
+/// is what makes the synthesized `<fn>__fuel_scan` lemma provable by
+/// the fixed fuel-induction template: an all-`P` suffix scan runs to
+/// the end of the string and returns `EXIT[pos := s.data.length]`.
+///
+/// CONSERVATIVE BY CONSTRUCTION — every gate below exists so that the
+/// emitted companion lemma proves on every body the recognizer accepts
+/// (a synthesized lemma that fails to prove is a build error in the
+/// export, the worst failure mode):
+/// - params: `(String, Int, ...)`, none named like a template binder;
+/// - body: exactly the two-arm `String.charAt` match above;
+/// - dispatch: a two-arm `true`/`false` match on `P(c)` where `P` is a
+///   single-argument call on the scrutinee binder (no wildcard arms —
+///   the Lean emitter's Bool-match → `ite` lowering is only certain
+///   for explicit literal arms);
+/// - exactly ONE self-call in the whole body, in the `true` arm, with
+///   args `(s, pos + 1, ...)` where every trailing arg is the matching
+///   param ident (carried) or a Bool literal (pinned);
+/// - the `true` arm reduces to the self-call under the pins;
+/// - `EXIT` is built from substitution-safe forms only (idents,
+///   literals, calls, binops, constructors) so the lemma statement can
+///   render `EXIT[pos := s.data.length, pins]` exactly.
+#[derive(Clone, Debug)]
+pub(crate) struct StringPosScanShape {
+    /// Source name of the single-arg Bool predicate fn (`isDigit`).
+    pub predicate_fn: String,
+    /// For each param at index ≥ 2: `None` = carried through the
+    /// self-call unchanged, `Some(b)` = pinned to the Bool literal.
+    pub param_pins: Vec<Option<bool>>,
+    /// The `Option.None` arm's exit expression (substitution-safe).
+    pub exit_expr: Spanned<Expr>,
+}
+
+/// Names the synthesized scan-lemma template binds. A scanner whose
+/// params (or predicate/exit identifiers) collide would have the
+/// template shadow them — reject instead.
+const SCAN_TEMPLATE_RESERVED: &[&str] = &[
+    "fuel",
+    "ih",
+    "h0",
+    "h1",
+    "h2",
+    "h3",
+    "hch",
+    "hdrop",
+    "hdig",
+    "hstep",
+    "hrec",
+    "hlt",
+    "hpos",
+    "ch",
+    // The Lean emitter's textual end-of-string marker (`LEN_MARKER` in
+    // lean/toplevel.rs): an identifier with this literal name would be
+    // clobbered by the post-render replace.
+    "AVERSCANLEN",
+];
+
+/// Variable reference name: matches both pre-resolver `Ident` and the
+/// resolver's `Resolved { name, .. }` forms (FnDef bodies in a
+/// `CodegenContext` are post-resolver).
+fn ident_name(e: &Spanned<Expr>) -> Option<&str> {
+    match &e.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.as_str()),
+        _ => None,
+    }
+}
+
+/// Recognize the canonical string-position scanner shape on a single
+/// fn definition. Pure AST walk; the caller separately validates the
+/// predicate fn via [`scan_predicate_fn_ok`] and that the fn actually
+/// got the string-pos fuel emission.
+pub(crate) fn detect_string_pos_scan(fd: &FnDef) -> Option<StringPosScanShape> {
+    let dotted = |e: &Spanned<Expr>| crate::codegen::common::expr_to_dotted_name(&e.node);
+
+    if fd.params.len() < 2 || fd.params[0].1 != "String" || fd.params[1].1 != "Int" {
+        return None;
+    }
+    if fd
+        .params
+        .iter()
+        .any(|(n, _)| SCAN_TEMPLATE_RESERVED.contains(&n.as_str()))
+    {
+        return None;
+    }
+    let s_name = fd.params[0].0.as_str();
+    let pos_name = fd.params[1].0.as_str();
+
+    // Body: a single charAt match (no leading bindings).
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return None;
+    };
+    let Expr::FnCall(callee, args) = &subject.node else {
+        return None;
+    };
+    if dotted(callee).as_deref() != Some("String.charAt") || args.len() != 2 {
+        return None;
+    }
+    if ident_name(&args[0]) != Some(s_name) || ident_name(&args[1]) != Some(pos_name) {
+        return None;
+    }
+    if arms.len() != 2 {
+        return None;
+    }
+    let none_arm = arms.iter().find(
+        |a| matches!(&a.pattern, Pattern::Constructor(n, b) if n == "Option.None" && b.is_empty()),
+    )?;
+    let some_arm = arms.iter().find(
+        |a| matches!(&a.pattern, Pattern::Constructor(n, b) if n == "Option.Some" && b.len() == 1),
+    )?;
+    let Pattern::Constructor(_, some_binders) = &some_arm.pattern else {
+        return None;
+    };
+    let c_name = some_binders[0].as_str();
+
+    // Some arm: two-arm true/false match on `P(c)`.
+    let Expr::Match {
+        subject: pred_subject,
+        arms: pred_arms,
+    } = &some_arm.body.node
+    else {
+        return None;
+    };
+    let Expr::FnCall(pred_callee, pred_args) = &pred_subject.node else {
+        return None;
+    };
+    let predicate_fn = dotted(pred_callee)?;
+    if predicate_fn.contains('.') {
+        return None; // user fn only — builtins aren't re-emittable hypotheses
+    }
+    if SCAN_TEMPLATE_RESERVED.contains(&predicate_fn.as_str()) {
+        return None;
+    }
+    // A param sharing the predicate's name (or the fuel wrapper's)
+    // would shadow it inside the lemma's ∀-binder — reject.
+    let fuel_wrapper = format!("{}__fuel", fd.name);
+    if fd
+        .params
+        .iter()
+        .any(|(n, _)| *n == predicate_fn || *n == fuel_wrapper)
+    {
+        return None;
+    }
+    if pred_args.len() != 1 || ident_name(&pred_args[0]) != Some(c_name) {
+        return None;
+    }
+    if pred_arms.len() != 2 {
+        return None;
+    }
+    let true_arm = pred_arms.iter().find(|a| {
+        matches!(
+            &a.pattern,
+            Pattern::Literal(crate::ast::Literal::Bool(true))
+        )
+    })?;
+    pred_arms.iter().find(|a| {
+        matches!(
+            &a.pattern,
+            Pattern::Literal(crate::ast::Literal::Bool(false))
+        )
+    })?;
+
+    // Exactly one self-call in the whole body, and it lives in the true arm.
+    if count_calls_to(body, &fd.name) != 1 || count_calls_to(&true_arm.body, &fd.name) != 1 {
+        return None;
+    }
+    let self_args = find_self_call_args(&true_arm.body, &fd.name)?;
+    if self_args.len() != fd.params.len() {
+        return None;
+    }
+    if ident_name(&self_args[0]) != Some(s_name) {
+        return None;
+    }
+    let Expr::BinOp(crate::ast::BinOp::Add, l, r) = &self_args[1].node else {
+        return None;
+    };
+    if ident_name(l) != Some(pos_name)
+        || !matches!(&r.node, Expr::Literal(crate::ast::Literal::Int(1)))
+    {
+        return None;
+    }
+    let mut param_pins: Vec<Option<bool>> = Vec::new();
+    for (i, arg) in self_args.iter().enumerate().skip(2) {
+        match (&arg.node, ident_name(arg)) {
+            (_, Some(n)) if n == fd.params[i].0 => param_pins.push(None),
+            (Expr::Literal(crate::ast::Literal::Bool(b)), _) => param_pins.push(Some(*b)),
+            _ => return None,
+        }
+    }
+
+    // The true arm must reduce to the self-call under the pins.
+    if !reduces_to_self_call(&true_arm.body, fd, &param_pins) {
+        return None;
+    }
+
+    // EXIT: substitution-safe forms; identifiers limited to the
+    // scanner's own params (minus the Some-binder) and template-safe
+    // callee names.
+    let allowed: Vec<&str> = fd.params.iter().map(|(n, _)| n.as_str()).collect();
+    if !exit_expr_substitution_safe(&none_arm.body, &allowed) {
+        return None;
+    }
+    // The lemma template's conclusion rewrites `pos` occurrences in
+    // EXIT to the string length (`rw [hpos]` must have work to do); a
+    // pos-free EXIT leaves the goal already closed after `simp only`
+    // and the rewrite FAILS — a build error in the export, the exact
+    // failure mode this gate exists to prevent. Provable-by-construction
+    // therefore requires `pos` to occur in EXIT.
+    if !expr_mentions_ident(&none_arm.body, pos_name) {
+        return None;
+    }
+
+    Some(StringPosScanShape {
+        predicate_fn,
+        param_pins,
+        exit_expr: (*none_arm.body).clone(),
+    })
+}
+
+/// The predicate gate shared by the scan-lemma emission (Lean backend)
+/// and the `IntDecimalRoundtrip` law detector (`proof_lower`): a pure
+/// single-`String`-param fn returning `Bool`. The lemma never unfolds
+/// the predicate — it only needs the name to exist as an emitted def —
+/// so no recursion gate is needed.
+pub(crate) fn scan_predicate_fn_ok(fd: &FnDef) -> bool {
+    fd.effects.is_empty()
+        && fd.params.len() == 1
+        && fd.params[0].1 == "String"
+        && fd.return_type == "Bool"
+}
+
+fn count_calls_to(expr: &Spanned<Expr>, target: &str) -> usize {
+    let mut count = 0;
+    walk_calls(expr, &mut |name| {
+        if name == target {
+            count += 1;
+        }
+    });
+    count
+}
+
+fn walk_calls(expr: &Spanned<Expr>, on_call: &mut impl FnMut(&str)) {
+    match &expr.node {
+        Expr::FnCall(callee, args) => {
+            if let Some(name) = crate::codegen::common::expr_to_dotted_name(&callee.node) {
+                on_call(&name);
+            }
+            walk_calls(callee, on_call);
+            for a in args {
+                walk_calls(a, on_call);
+            }
+        }
+        Expr::TailCall(data) => {
+            on_call(&data.target);
+            for a in &data.args {
+                walk_calls(a, on_call);
+            }
+        }
+        Expr::BinOp(_, l, r) => {
+            walk_calls(l, on_call);
+            walk_calls(r, on_call);
+        }
+        Expr::Neg(inner) | Expr::ErrorProp(inner) | Expr::Attr(inner, _) => {
+            walk_calls(inner, on_call);
+        }
+        Expr::Match { subject, arms } => {
+            walk_calls(subject, on_call);
+            for arm in arms {
+                walk_calls(&arm.body, on_call);
+            }
+        }
+        Expr::Constructor(_, Some(inner)) => walk_calls(inner, on_call),
+        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+            for i in items {
+                walk_calls(i, on_call);
+            }
+        }
+        Expr::MapLiteral(pairs) => {
+            for (k, v) in pairs {
+                walk_calls(k, on_call);
+                walk_calls(v, on_call);
+            }
+        }
+        Expr::RecordCreate { fields, .. } => {
+            for (_, v) in fields {
+                walk_calls(v, on_call);
+            }
+        }
+        Expr::RecordUpdate { base, updates, .. } => {
+            walk_calls(base, on_call);
+            for (_, v) in updates {
+                walk_calls(v, on_call);
+            }
+        }
+        Expr::InterpolatedStr(parts) => {
+            for p in parts {
+                if let crate::ast::StrPart::Parsed(inner) = p {
+                    walk_calls(inner, on_call);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Args of the unique self-call (plain or tail-call form) inside `expr`.
+fn find_self_call_args<'a>(expr: &'a Spanned<Expr>, target: &str) -> Option<&'a [Spanned<Expr>]> {
+    match &expr.node {
+        Expr::FnCall(callee, args)
+            if crate::codegen::common::expr_to_dotted_name(&callee.node).as_deref()
+                == Some(target) =>
+        {
+            Some(args)
+        }
+        Expr::TailCall(data) if data.target == target => Some(&data.args),
+        Expr::Match { arms, .. } => arms
+            .iter()
+            .find_map(|arm| find_self_call_args(&arm.body, target)),
+        _ => None,
+    }
+}
+
+/// True when `expr` IS the self-call, or is a two-arm Bool match on a
+/// PINNED param whose selected (pinned-literal) arm recursively reduces
+/// to the self-call. The Lean emitter lowers explicit-Bool-literal
+/// matches to `ite`, which the lemma template's trailing `simp`
+/// computes away once the pin substitutes the scrutinee.
+fn reduces_to_self_call(expr: &Spanned<Expr>, fd: &FnDef, pins: &[Option<bool>]) -> bool {
+    match &expr.node {
+        Expr::FnCall(callee, _)
+            if crate::codegen::common::expr_to_dotted_name(&callee.node).as_deref()
+                == Some(fd.name.as_str()) =>
+        {
+            true
+        }
+        Expr::TailCall(data) if data.target == fd.name => true,
+        Expr::Match { subject, arms } => {
+            let Some(subj) = ident_name(subject) else {
+                return false;
+            };
+            let Some(idx) = fd.params.iter().position(|(n, _)| n.as_str() == subj) else {
+                return false;
+            };
+            if idx < 2 {
+                return false;
+            }
+            let Some(Some(pin)) = pins.get(idx - 2) else {
+                return false;
+            };
+            if arms.len() != 2 {
+                return false;
+            }
+            let selected = arms.iter().find(
+                |a| matches!(&a.pattern, Pattern::Literal(crate::ast::Literal::Bool(b)) if b == pin),
+            );
+            let other = arms.iter().any(
+                |a| matches!(&a.pattern, Pattern::Literal(crate::ast::Literal::Bool(b)) if b != pin),
+            );
+            match selected {
+                Some(arm) if other => reduces_to_self_call(&arm.body, fd, pins),
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+/// EXIT gate: only forms [`substitute_idents_in_expr`] handles, with
+/// identifiers drawn from `allowed` (the scanner's params) and callee /
+/// constructor names outside the template-reserved set.
+/// True when `name` occurs as an identifier anywhere in an EXIT-gated
+/// expression (same form set as [`exit_expr_substitution_safe`]).
+fn expr_mentions_ident(expr: &Spanned<Expr>, name: &str) -> bool {
+    match &expr.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => n == name,
+        Expr::Neg(inner) | Expr::ErrorProp(inner) => expr_mentions_ident(inner, name),
+        Expr::BinOp(_, l, r) => expr_mentions_ident(l, name) || expr_mentions_ident(r, name),
+        Expr::FnCall(callee, args) => {
+            expr_mentions_ident(callee, name) || args.iter().any(|a| expr_mentions_ident(a, name))
+        }
+        Expr::Constructor(_, payload) => payload
+            .as_deref()
+            .is_some_and(|p| expr_mentions_ident(p, name)),
+        Expr::Tuple(items) | Expr::List(items) => {
+            items.iter().any(|i| expr_mentions_ident(i, name))
+        }
+        _ => false,
+    }
+}
+
+fn exit_expr_substitution_safe(expr: &Spanned<Expr>, allowed: &[&str]) -> bool {
+    match &expr.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => allowed.contains(&n.as_str()),
+        Expr::Literal(_) => true,
+        Expr::Neg(inner) | Expr::ErrorProp(inner) => exit_expr_substitution_safe(inner, allowed),
+        Expr::BinOp(_, l, r) => {
+            exit_expr_substitution_safe(l, allowed) && exit_expr_substitution_safe(r, allowed)
+        }
+        Expr::FnCall(callee, args) => {
+            let Some(name) = crate::codegen::common::expr_to_dotted_name(&callee.node) else {
+                return false;
+            };
+            !SCAN_TEMPLATE_RESERVED.contains(&name.as_str())
+                && args.iter().all(|a| exit_expr_substitution_safe(a, allowed))
+        }
+        Expr::Constructor(_, payload) => payload
+            .as_deref()
+            .is_none_or(|p| exit_expr_substitution_safe(p, allowed)),
+        Expr::Tuple(items) | Expr::List(items) => items
+            .iter()
+            .all(|i| exit_expr_substitution_safe(i, allowed)),
+        _ => false,
+    }
+}
+
+/// Substitute identifiers by name in an EXIT-gated expression. Total
+/// over the forms [`exit_expr_substitution_safe`] admits; other forms
+/// are returned unchanged (the gate guarantees they don't occur).
+pub(crate) fn substitute_idents_in_expr(
+    expr: &Spanned<Expr>,
+    subst: &std::collections::HashMap<String, Expr>,
+) -> Spanned<Expr> {
+    let node = match &expr.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => match subst.get(n) {
+            Some(replacement) => replacement.clone(),
+            None => expr.node.clone(),
+        },
+        Expr::Neg(inner) => Expr::Neg(Box::new(substitute_idents_in_expr(inner, subst))),
+        Expr::ErrorProp(inner) => {
+            Expr::ErrorProp(Box::new(substitute_idents_in_expr(inner, subst)))
+        }
+        Expr::BinOp(op, l, r) => Expr::BinOp(
+            *op,
+            Box::new(substitute_idents_in_expr(l, subst)),
+            Box::new(substitute_idents_in_expr(r, subst)),
+        ),
+        Expr::FnCall(callee, args) => Expr::FnCall(
+            callee.clone(),
+            args.iter()
+                .map(|a| substitute_idents_in_expr(a, subst))
+                .collect(),
+        ),
+        Expr::Constructor(name, payload) => Expr::Constructor(
+            name.clone(),
+            payload
+                .as_ref()
+                .map(|p| Box::new(substitute_idents_in_expr(p, subst))),
+        ),
+        Expr::Tuple(items) => Expr::Tuple(
+            items
+                .iter()
+                .map(|i| substitute_idents_in_expr(i, subst))
+                .collect(),
+        ),
+        Expr::List(items) => Expr::List(
+            items
+                .iter()
+                .map(|i| substitute_idents_in_expr(i, subst))
+                .collect(),
+        ),
+        other => other.clone(),
+    };
+    Spanned {
+        node,
+        line: expr.line,
+        ty: std::sync::OnceLock::new(),
+    }
+}

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -793,6 +793,55 @@ pub enum ProofStrategy {
         /// `prelude_spec_lemmas_for_builtins`.
         builtins: Vec<String>,
     },
+    /// Decimal-Int parse/serialize roundtrip over the canonical
+    /// single-scanner decimal parser shape: the law states
+    /// `parse(ser(C(n)), 0) = Ok(C(n), String.len(ser(C(n))))` for an
+    /// unconstrained `given n: Int`, where `parse` dispatches the head
+    /// char (`"-"` → sign path, `"0"` → leading-zero scan, `_` → digit
+    /// path), both paths funnel into ONE recognized fuelized
+    /// string-position scanner (`proof_recognize::detect_string_pos_scan`
+    /// — the same gate that makes the Lean backend synthesize the
+    /// scanner's `<fn>__fuel_scan` companion lemma), and the cone
+    /// bottoms out in `String.fromInt` / `Int.fromString`.
+    ///
+    /// The detector validates the ENTIRE canonical shape (arm literals,
+    /// arm order, scanner pins, finish-fn slice + `Int.fromString`
+    /// leaf), so the Lean emission can render the fixed
+    /// sign-split proof skeleton ported from the verified json hand
+    /// proof: serializer reduces by `rfl` (ADT-measure fuel),
+    /// `rcases Int.ofNat | Int.negSucc`, head-char dispatch via
+    /// `String.mk`-form `rfl`, `split` + `digitChar` contradiction
+    /// lemmas, the synthesized scan lemma, and `Int.fromString_fromInt`
+    /// at the `finish_int_fn` leaf. The whole emission is wrapped in
+    /// `first | (… ; done) | sorry` — a non-closing case degrades to a
+    /// caught honest `sorry`, never a build error, and `native_decide`
+    /// never appears. Dafny treats the pin as `BackendDispatch`
+    /// (exports byte-identical).
+    ///
+    /// Demonstrated by `examples/data/json.av`
+    /// `parseNumber.fromIntRoundtrip` — the first universal close
+    /// through the fuel-unfolding barrier on a string whose length is
+    /// symbolic.
+    IntDecimalRoundtrip {
+        /// Subject parser fn (`parseNumber`). Source names throughout.
+        parse_fn: String,
+        /// `"-"`-arm continuation (`parseNumberSign`).
+        neg_fn: String,
+        /// Wildcard-arm digit dispatcher (`startNumberDigits`).
+        pos_fn: String,
+        /// Sign path's digit dispatcher (`startSignDigit`).
+        sign_fn: String,
+        /// The recognized fuelized scanner (`scanIntTail`).
+        scanner_fn: String,
+        /// The scanner's char-class predicate (`isDigit`).
+        predicate_fn: String,
+        /// Scanner exit continuation (`finishNumber`).
+        finish_fn: String,
+        /// Int leaf — slices + `Int.fromString` (`finishInt`).
+        finish_int_fn: String,
+        /// Serializer the law's lhs feeds the parser (`toString`).
+        serializer_fn: String,
+    },
     /// No automated strategy — emit with `sorry` (Lean) / `assume
     /// {:axiom}` (Dafny). User fills in manually.
     Sorry,

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1894,3 +1894,185 @@ fn simp_over_prelude_lemmas_not_pinned_for_recursive_seed_with_open_args() {
         theorem.strategy
     );
 }
+
+/// Canonical decimal-parser source for the `IntDecimalRoundtrip`
+/// detector tests — a minimal standalone replica of the
+/// `examples/data/json.av` number-parsing family (head-char dispatch,
+/// sign path, one fuelized digit scanner, slice + `Int.fromString`
+/// leaf, `C(x) -> String.fromInt(x)` serializer arm).
+const DECIMAL_ROUNDTRIP_SRC: &str = r#"module DecimalRt
+    intent = "decimal int render/parse roundtrip"
+    effects []
+
+type Num
+    NumInt(Int)
+
+type ParseOut
+    Got(Num, Int)
+    Bad(String, Int)
+
+fn render(v: Num) -> String
+    match v
+        Num.NumInt(n) -> String.fromInt(n)
+
+fn isDigit(c: String) -> Bool
+    code = Char.toCode(c)
+    match code >= 48
+        true -> code <= 57
+        false -> false
+
+fn finishInt(num: String, pos: Int) -> ParseOut
+    match Int.fromString(num)
+        Result.Ok(n) -> ParseOut.Got(Num.NumInt(n), pos)
+        Result.Err(_) -> ParseOut.Bad("bad int", pos)
+
+fn finishNumber(s: String, start: Int, endPos: Int, asFloat: Bool) -> ParseOut
+    num = String.slice(s, start, endPos)
+    match asFloat
+        true -> ParseOut.Bad("float unsupported", endPos)
+        false -> finishInt(num, endPos)
+
+fn scanIntTail(s: String, pos: Int, start: Int, leadingZero: Bool) -> ParseOut
+    match String.charAt(s, pos)
+        Option.None -> finishNumber(s, start, pos, false)
+        Option.Some(c) -> match isDigit(c)
+            true -> match leadingZero
+                true -> ParseOut.Bad("leading zero", pos)
+                false -> scanIntTail(s, pos + 1, start, false)
+            false -> ParseOut.Bad("trailing", pos)
+
+fn startDigits(s: String, start: Int, c: String) -> ParseOut
+    match isDigit(c)
+        true -> scanIntTail(s, start + 1, start, false)
+        false -> ParseOut.Bad("expected digit", start)
+
+fn signDigit(s: String, pos: Int, start: Int, c: String) -> ParseOut
+    match isDigit(c)
+        true -> scanIntTail(s, pos + 1, start, false)
+        false -> ParseOut.Bad("expected digit", pos)
+
+fn parseSign(s: String, pos: Int, start: Int) -> ParseOut
+    match String.charAt(s, pos)
+        Option.None -> ParseOut.Bad("expected digit", pos)
+        Option.Some(c) -> match c
+            "0" -> scanIntTail(s, pos + 1, start, true)
+            _ -> signDigit(s, pos, start, c)
+
+fn parseNum(s: String, start: Int) -> ParseOut
+    match String.charAt(s, start)
+        Option.None -> ParseOut.Bad("empty", start)
+        Option.Some(c) -> match c
+            "-" -> parseSign(s, start + 1, start)
+            "0" -> scanIntTail(s, start + 1, start, true)
+            _ -> startDigits(s, start, c)
+
+verify parseNum law fromIntRoundtrip
+    given n: Int = [-7, 0, 42, 2500]
+    parseNum(render(Num.NumInt(n)), 0) => ParseOut.Got(Num.NumInt(n), String.len(render(Num.NumInt(n))))
+"#;
+
+#[test]
+fn int_decimal_roundtrip_pinned_for_canonical_decimal_parser() {
+    // The full canonical decimal-parser shape (json.av's
+    // `parseNumber.fromIntRoundtrip` family) must pin
+    // `IntDecimalRoundtrip` with every cone fn captured — the Lean
+    // emission renders the fixed sign-split skeleton from these names
+    // and cites the scanner's synthesized `__fuel_scan` lemma.
+    let ctx = build_ctx(DECIMAL_ROUNDTRIP_SRC);
+    let theorem = law_theorem(&ctx, "parseNum", "fromIntRoundtrip")
+        .expect("parseNum::fromIntRoundtrip law theorem missing from ProofIR");
+    let aver::ir::ProofStrategy::IntDecimalRoundtrip {
+        ref parse_fn,
+        ref neg_fn,
+        ref pos_fn,
+        ref sign_fn,
+        ref scanner_fn,
+        ref predicate_fn,
+        ref finish_fn,
+        ref finish_int_fn,
+        ref serializer_fn,
+    } = theorem.strategy
+    else {
+        panic!(
+            "canonical decimal parser must pin IntDecimalRoundtrip, got: {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(parse_fn, "parseNum");
+    assert_eq!(neg_fn, "parseSign");
+    assert_eq!(pos_fn, "startDigits");
+    assert_eq!(sign_fn, "signDigit");
+    assert_eq!(scanner_fn, "scanIntTail");
+    assert_eq!(predicate_fn, "isDigit");
+    assert_eq!(finish_fn, "finishNumber");
+    assert_eq!(finish_int_fn, "finishInt");
+    assert_eq!(serializer_fn, "render");
+}
+
+#[test]
+fn int_decimal_roundtrip_not_pinned_for_when_law() {
+    // `when` premises are out of scope — the fixed proof skeleton has
+    // no premise handling (mirrors the no-when gates of the sibling
+    // fallbacks).
+    let src = DECIMAL_ROUNDTRIP_SRC.replace(
+        "    given n: Int = [-7, 0, 42, 2500]\n",
+        "    given n: Int = [0, 42, 2500]\n    when n >= 0\n",
+    );
+    let ctx = build_ctx(&src);
+    let theorem = law_theorem(&ctx, "parseNum", "fromIntRoundtrip")
+        .expect("parseNum::fromIntRoundtrip law theorem missing from ProofIR");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::IntDecimalRoundtrip { .. }
+        ),
+        "when-law must NOT pin IntDecimalRoundtrip, got: {:?}",
+        theorem.strategy
+    );
+}
+
+#[test]
+fn int_decimal_roundtrip_not_pinned_when_head_dispatch_arms_deviate() {
+    // Arm order is load-bearing for the emission's `split` bullets —
+    // a parser with the "0" arm before the "-" arm must not pin (it
+    // falls through to the prelude-simp rung's honest floor instead).
+    let src = DECIMAL_ROUNDTRIP_SRC.replace(
+        "            \"-\" -> parseSign(s, start + 1, start)\n            \"0\" -> scanIntTail(s, start + 1, start, true)\n",
+        "            \"0\" -> scanIntTail(s, start + 1, start, true)\n            \"-\" -> parseSign(s, start + 1, start)\n",
+    );
+    assert_ne!(src, DECIMAL_ROUNDTRIP_SRC, "mutation must apply");
+    let ctx = build_ctx(&src);
+    let theorem = law_theorem(&ctx, "parseNum", "fromIntRoundtrip")
+        .expect("parseNum::fromIntRoundtrip law theorem missing from ProofIR");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::IntDecimalRoundtrip { .. }
+        ),
+        "flipped dispatch arms must NOT pin IntDecimalRoundtrip, got: {:?}",
+        theorem.strategy
+    );
+}
+
+#[test]
+fn int_decimal_roundtrip_not_pinned_when_scanner_exit_deviates() {
+    // The scanner's none-arm EXIT must be the canonical
+    // `finish(s, start, pos, false)` continuation; an early-error exit
+    // breaks the `hfin` leaf, so the detector must decline.
+    let src = DECIMAL_ROUNDTRIP_SRC.replace(
+        "        Option.None -> finishNumber(s, start, pos, false)\n",
+        "        Option.None -> ParseOut.Bad(\"eof\", pos)\n",
+    );
+    assert_ne!(src, DECIMAL_ROUNDTRIP_SRC, "mutation must apply");
+    let ctx = build_ctx(&src);
+    let theorem = law_theorem(&ctx, "parseNum", "fromIntRoundtrip")
+        .expect("parseNum::fromIntRoundtrip law theorem missing from ProofIR");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::IntDecimalRoundtrip { .. }
+        ),
+        "non-finish scanner exit must NOT pin IntDecimalRoundtrip, got: {:?}",
+        theorem.strategy
+    );
+}

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -433,13 +433,20 @@ fn proof_export_builds_json_when_lake_is_available() {
     // the String prelude spec lemmas (`String.add_eq_append`,
     // `String.slice_full` / `String.slice_append_prefix`,
     // `String.intercalate_singleton`) + `Int.fromString_fromInt`
-    // (#print axioms ⊆ [propext, Classical.choice, Quot.sound]). The
-    // remaining 3 are `escapeJsonString.parseStringRoundtrip`,
-    // `parseStringChunk.escapedStringRoundtrip` and
-    // `parseNumber.fromIntRoundtrip` — their cones stop at fuel fns
-    // with open string-position measures (`parseStringChunk`,
-    // `scanIntTail`), where the rung honestly falls to `sorry`.
-    assert_proof_builds_with_sorry_budget("examples/data/json.av", "aver-proof-json", 3);
+    // (#print axioms ⊆ [propext, Classical.choice, Quot.sound]).
+    // IntDecimalRoundtrip: 3 → 2 — `parseNumber.fromIntRoundtrip`
+    // now closes genuinely (#print axioms = [propext,
+    // Classical.choice, Quot.sound]): the synthesized
+    // `scanIntTail__fuel_scan` lemma runs the symbolic all-digit
+    // suffix through the fuel barrier, and the fixed sign-split
+    // skeleton (serializer `rfl`, `String.mk`-form head-char
+    // dispatch, `digitChar` disequalities, `Int.fromString_fromInt`
+    // leaf) closes both sign branches. The remaining 2 are exactly
+    // `escapeJsonString.parseStringRoundtrip` and
+    // `parseStringChunk.escapedStringRoundtrip` — the string-escape
+    // family, whose scanners thread accumulator chunks (not a
+    // single all-`P` suffix), outside the scan-lemma shape.
+    assert_proof_builds_with_sorry_budget("examples/data/json.av", "aver-proof-json", 2);
 }
 
 #[test]
@@ -4776,6 +4783,127 @@ verify keepPrefix law appendRoundtrip
         summary["universal"].as_bool(),
         Some(true),
         "a builtin-roundtrip law must close kernel-clean via the prelude spec lemmas\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+/// A no-when universal `parse(render(C(n)), 0) = Ok(C(n), len)` law over the
+/// canonical decimal parser must close GENUINELY via `IntDecimalRoundtrip`:
+/// the Lean backend synthesizes the scanner's `<fn>__fuel_scan` companion
+/// lemma at the fuel-def site (the general crack in the fuel-unfolding
+/// barrier — an all-digit suffix scan runs to the end of a SYMBOLIC string)
+/// and renders the fixed sign-split skeleton from the verified json hand
+/// proof (serializer `rfl` through ADT-measure fuel, `String.mk`-form
+/// head-char dispatch, `digitChar` `Char.toString` disequalities for the
+/// dead arms, `Int.fromString_fromInt` at the leaf). `universal:true` means
+/// every theorem closed with axioms ⊆ [propext, Classical.choice,
+/// Quot.sound] — no sorry, no native_decide. (Found on real
+/// `examples/data/json.av`: `parseNumber.fromIntRoundtrip`.)
+#[test]
+fn lean_proves_int_decimal_roundtrip_law_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping int-decimal-roundtrip test: `lake` not available");
+        return;
+    }
+    let source = r#"module DecimalRt
+    intent = "a decimal int render/parse roundtrip closing via IntDecimalRoundtrip"
+    effects []
+
+type Num
+    NumInt(Int)
+
+type ParseOut
+    Got(Num, Int)
+    Bad(String, Int)
+
+fn render(v: Num) -> String
+    match v
+        Num.NumInt(n) -> String.fromInt(n)
+
+fn isDigit(c: String) -> Bool
+    code = Char.toCode(c)
+    match code >= 48
+        true -> code <= 57
+        false -> false
+
+fn finishInt(num: String, pos: Int) -> ParseOut
+    match Int.fromString(num)
+        Result.Ok(n) -> ParseOut.Got(Num.NumInt(n), pos)
+        Result.Err(_) -> ParseOut.Bad("bad int", pos)
+
+fn finishNumber(s: String, start: Int, endPos: Int, asFloat: Bool) -> ParseOut
+    num = String.slice(s, start, endPos)
+    match asFloat
+        true -> ParseOut.Bad("float unsupported", endPos)
+        false -> finishInt(num, endPos)
+
+fn scanIntTail(s: String, pos: Int, start: Int, leadingZero: Bool) -> ParseOut
+    match String.charAt(s, pos)
+        Option.None -> finishNumber(s, start, pos, false)
+        Option.Some(c) -> match isDigit(c)
+            true -> match leadingZero
+                true -> ParseOut.Bad("leading zero", pos)
+                false -> scanIntTail(s, pos + 1, start, false)
+            false -> ParseOut.Bad("trailing", pos)
+
+fn startDigits(s: String, start: Int, c: String) -> ParseOut
+    match isDigit(c)
+        true -> scanIntTail(s, start + 1, start, false)
+        false -> ParseOut.Bad("expected digit", start)
+
+fn signDigit(s: String, pos: Int, start: Int, c: String) -> ParseOut
+    match isDigit(c)
+        true -> scanIntTail(s, pos + 1, start, false)
+        false -> ParseOut.Bad("expected digit", pos)
+
+fn parseSign(s: String, pos: Int, start: Int) -> ParseOut
+    match String.charAt(s, pos)
+        Option.None -> ParseOut.Bad("expected digit", pos)
+        Option.Some(c) -> match c
+            "0" -> scanIntTail(s, pos + 1, start, true)
+            _ -> signDigit(s, pos, start, c)
+
+fn parseNum(s: String, start: Int) -> ParseOut
+    match String.charAt(s, start)
+        Option.None -> ParseOut.Bad("empty", start)
+        Option.Some(c) -> match c
+            "-" -> parseSign(s, start + 1, start)
+            "0" -> scanIntTail(s, start + 1, start, true)
+            _ -> startDigits(s, start, c)
+
+verify parseNum law fromIntRoundtrip
+    given n: Int = [-7, 0, 42, 2500]
+    parseNum(render(Num.NumInt(n)), 0) => ParseOut.Got(Num.NumInt(n), String.len(render(Num.NumInt(n))))
+"#;
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-decimalrt-src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(src.join("m.av"), source).expect("write");
+    let out = temp_output_dir("aver-decimalrt-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("aver proof ran");
+    let json = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON:\n{}", format_output(&run)));
+    let summary: serde_json::Value = serde_json::from_str(json).expect("json");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "a canonical decimal roundtrip law must close kernel-clean via the synthesized scan lemma + sign-split skeleton\n{}",
         format_output(&run)
     );
     let _ = std::fs::remove_dir_all(&src);


### PR DESCRIPTION
## Summary

Chunk 3 of the json initiative (after #468/#469: 3 sorries remained). Closes `parseNumber_law_fromIntRoundtrip` — **json.av Lean sorries 3 → 2**; the remaining two are exactly the string-escape family (`escapeJsonString`, `parseStringChunk`).

Three general layers, zero json-specific code:

1. **Prelude** (demand-driven, #469 pattern): `String.charAt_eq_of_lt` / `charAt_none_of_ge` + an `AverDigits` family (`natDigits_head_ne_zero`, `digitChar` `Char.toString` disequalities) — ported verbatim from the verified hand proof.

2. **Scan-lemma synthesis** — the general crack in the fuel-unfolding barrier: a conservative backend-neutral recognizer matches the canonical string-position scanner shape (`charAt(s, pos)` two-arm match; predicate dispatch; unique self-call at `pos + 1` with carried/Bool-pinned params; substitution-safe EXIT), and the Lean fuel emitter appends a companion theorem `<fn>__fuel_scan` ("an all-predicate suffix scan runs to end of string") proved by a fixed fuel-induction template. **Provable-by-construction**: when the shape gate fails, nothing is emitted. Gates hardened per the adversarial review pass: EXIT must mention `pos` (a pos-free EXIT would leave the template's `rw [hpos]` with no work → build error in someone's export — the exact failure mode the gate exists to prevent); the emitter's `AVERSCANLEN` marker is template-reserved; params shadowing the predicate or fuel wrapper are rejected. Positive + negative emission lib tests cover the gates.

3. **Routing**: new `ProofStrategy::IntDecimalRoundtrip`, pinned ahead of the #469 rung, for laws of the shape `parse(serialize(C(n)), 0) = Ok(C(n), len)` with a recognized scanner in the cone. The Lean arm renders the verified hand-proof skeleton (serializer `rfl` through ADT-measure fuel; sign `rcases`; `String.mk`-form head-char dispatch — not simp-under-getElem; `digitChar` disequalities; the synthesized scan lemma; `Int.fromString_fromInt` at the leaf) as a single `first | (…; done) | sorry` alternative — honest caught-sorry floor, no `native_decide`. Dafny: BackendDispatch, exports byte-identical.

## Validation

- `#print axioms parseNumber_law_fromIntRoundtrip` = `[propext, Classical.choice, Quot.sound]`; the three synthesized scan lemmas (`scanIntTail`/`scanFracTail`/`scanExpTail`) prove kernel-clean; the four #469 closes are byte-untouched in the export and re-verified clean.
- Generality pinned end-to-end by a lake-gated synthetic decimal-parser module (different names) closing `{passed:true, sorries:0, universal:true}`.
- Corpus no-regression: Lean exports for map/rle/sparse/quicksort/red_black_tree and `grok_s_language` (the only other string-pos fuel file) byte-identical; Dafny map+json byte-identical.
- Adversarially reviewed: one blocker (pos-free-EXIT gate) found and fixed + re-tested; `cargo test --workspace` green post-fix (75 binaries, incl. 4 detector tests and 2 new scan-gate emission tests); both clippy halves + fmt clean; json budget pin re-tightened 3 → 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)