### PR TITLE
proof(lean): deep fuel measures for tuple-carrying types (C0)

### DIFF
--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -1520,6 +1520,31 @@ fn transpile_unified(
         .collect();
     let recursive_names = recursive_pure_fn_names(ctx);
     let recursive_types = recursive_type_names(ctx);
+    // Pure-fn param types + every type def's field types feed the
+    // entries-measure emission scan: an entries-list spelling
+    // (`Map<K, T>` / `List<Tuple<K, T>>`) may appear only in fn
+    // signatures or in ANOTHER type's fields, never in `T`'s own
+    // fields, yet the chooser (`type_measure_expr`) would reference
+    // `averMeasure<T>Entries_<K>` for it all the same.
+    let measure_sig_type_refs: Vec<String> = pure_fns(ctx)
+        .iter()
+        .flat_map(|fd| fd.params.iter().map(|(_, ty)| ty.clone()))
+        .chain(
+            ctx.modules
+                .iter()
+                .flat_map(|m| m.type_defs.iter())
+                .chain(ctx.type_defs.iter())
+                .flat_map(|td| match td {
+                    crate::ast::TypeDef::Sum { variants, .. } => variants
+                        .iter()
+                        .flat_map(|v| v.fields.iter().cloned())
+                        .collect::<Vec<_>>(),
+                    crate::ast::TypeDef::Product { fields, .. } => {
+                        fields.iter().map(|(_, ty)| ty.clone()).collect()
+                    }
+                }),
+        )
+        .collect();
 
     // Pure fns are SCC-routed per scope (per dependent module + entry)
     // independently — shared `route_pure_components_per_scope` handles
@@ -1626,8 +1651,11 @@ fn transpile_unified(
                         toplevel::type_def_name(td),
                     ));
                     if matches!(emit_mode, LeanEmitMode::Proof)
-                        && let Some(measure) =
-                            toplevel::emit_recursive_measure(td, &recursive_types)
+                        && let Some(measure) = toplevel::emit_recursive_measure(
+                            td,
+                            &recursive_types,
+                            &measure_sig_type_refs,
+                        )
                     {
                         body_sections.push(measure);
                     }
@@ -1683,7 +1711,8 @@ fn transpile_unified(
                 toplevel::type_def_name(td),
             ));
             if matches!(emit_mode, LeanEmitMode::Proof)
-                && let Some(measure) = toplevel::emit_recursive_measure(td, &recursive_types)
+                && let Some(measure) =
+                    toplevel::emit_recursive_measure(td, &recursive_types, &measure_sig_type_refs)
             {
                 entry_body_sections.push(measure);
             }

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -183,6 +183,15 @@ fn type_measure_expr(
                 value_expr
             ));
         }
+        if let Some((key_type, value_type)) =
+            entries_measure_tuple_item(inner.trim(), recursive_types)
+        {
+            return Some(format!(
+                "{} {}",
+                measure_entries_fn_name(&value_type, &key_type),
+                value_expr
+            ));
+        }
         let item_measure = type_measure_expr(inner, "item", recursive_types, self_type)
             .unwrap_or_else(|| "1".to_string());
         return Some(format!(
@@ -249,43 +258,140 @@ fn type_measure_expr(
         }
     }
 
+    // `Tuple<A, B>` is the canonical tuple spelling; the parenthesized
+    // `(A, B)` arm below is the legacy one. Both route through
+    // `tuple_parts_measure` so the two spellings stay behaviorally
+    // identical.
+    if let Some(inner) = unwrap_generic(trimmed, "Tuple<")
+        && let Some(measure) = tuple_parts_measure(
+            &split_top_level(inner, ','),
+            value_expr,
+            recursive_types,
+            self_type,
+        )
+    {
+        return Some(measure);
+    }
+
     if trimmed.starts_with('(') && trimmed.ends_with(')') {
         let inner = &trimmed[1..trimmed.len() - 1];
-        let parts = split_top_level(inner, ',');
-        if !parts.is_empty() {
-            let measures: Vec<String> = parts
-                .iter()
-                .enumerate()
-                .filter_map(|(idx, part)| {
-                    type_measure_expr(
-                        part,
-                        &format!("{}.{}", value_expr, idx + 1),
-                        recursive_types,
-                        self_type,
-                    )
-                })
-                .collect();
-            if !measures.is_empty() {
-                return Some(format!("({}) + 1", measures.join(" + ")));
-            }
+        if let Some(measure) = tuple_parts_measure(
+            &split_top_level(inner, ','),
+            value_expr,
+            recursive_types,
+            self_type,
+        ) {
+            return Some(measure);
         }
     }
 
     None
 }
 
-fn recursive_map_key_types(type_refs: &[String], value_type: &str) -> Vec<String> {
+/// Per-part measure for a tuple type's components — the shared body of
+/// the `Tuple<...>` arm and the legacy parenthesized `(A, B)` arm of
+/// [`type_measure_expr`]. Parts that carry no measure (scalars) are
+/// skipped; recursive parts get their deep `averMeasure*` term. Lean
+/// renders an N-tuple as a right-nested `Prod`, so part `i` of `n`
+/// projects as `.2`*i followed by `.1` (the last part is `.2`*(n-1)):
+/// `.1`/`.2` for pairs, `.1`/`.2.1`/`.2.2` for triples.
+///
+/// FUEL-WRAPPER CONTEXT ONLY (`self_type = None`): there every cited
+/// `averMeasure*` is a fully-defined closed call, so a reference under
+/// an `AverMeasure.list`/`.option` lambda elaborates fine. Inside a
+/// type's OWN measure def (`self_type = Some`) the same term is
+/// recursion through a higher-order argument — Lean cannot show
+/// termination for `averMeasureT item.2` under `AverMeasure.list
+/// (fun item => ...)` — so measure defs keep the old behavior (tuple
+/// parts skipped) except for the entries-list reuse, which routes the
+/// recursion through a structural `match` in the mutual block instead
+/// (see [`entries_measure_tuple_item`]).
+fn tuple_parts_measure(
+    parts: &[String],
+    value_expr: &str,
+    recursive_types: &HashSet<String>,
+    self_type: Option<&str>,
+) -> Option<String> {
+    if self_type.is_some() {
+        return None;
+    }
+    let measures: Vec<String> = parts
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, part)| {
+            let projection = if idx + 1 == parts.len() {
+                ".2".repeat(idx)
+            } else {
+                format!("{}.1", ".2".repeat(idx))
+            };
+            type_measure_expr(
+                part,
+                &format!("{value_expr}{projection}"),
+                recursive_types,
+                self_type,
+            )
+        })
+        .collect();
+    (!measures.is_empty()).then(|| format!("({}) + 1", measures.join(" + ")))
+}
+
+/// Recognize a `Tuple<K, V>` list-item type where `V` is a recursive
+/// ADT and `K` carries no measure of its own (`String`, `Int`, ...) —
+/// the `List<Tuple<K, V>>` spelling of an entries list. In Lean both
+/// that spelling and `Map<K, V>` render as `List (K × V)` (the map via
+/// `AverMap.entries`), so both reuse the one dedicated deep entries
+/// measure `averMeasure<V>Entries_<K>`: fuel bounds — and any lemmas
+/// later synthesized over them — agree across the two spellings.
+/// Returns `(key_type, value_type)` when the reuse applies. Keys that
+/// DO carry a measure fall back to the generic per-part tuple item
+/// measure (the entries measure ignores keys, which would under-count
+/// their depth). The same predicate gates the emission side
+/// ([`recursive_map_key_types`]) so a chosen entries measure is always
+/// actually defined.
+fn entries_measure_tuple_item(
+    item_type: &str,
+    recursive_types: &HashSet<String>,
+) -> Option<(String, String)> {
+    let inner = unwrap_generic(item_type, "Tuple<")?;
+    let args = split_top_level(inner, ',');
+    if args.len() != 2 {
+        return None;
+    }
+    let key_type = args[0].trim();
+    let value_type = args[1].trim();
+    (recursive_types.contains(value_type)
+        && type_measure_expr(key_type, "key", recursive_types, None).is_none())
+    .then(|| (key_type.to_string(), value_type.to_string()))
+}
+
+/// Key types whose dedicated entries measure
+/// (`averMeasure<value_type>Entries_<key>`) must be emitted alongside
+/// `value_type`'s measure: one per `Map<K, value_type>` ref plus one
+/// per `List<Tuple<K, value_type>>` ref (the two spellings of an
+/// entries list — see [`entries_measure_tuple_item`], which gates the
+/// reference side with the same predicate).
+fn recursive_map_key_types(
+    type_refs: &[String],
+    value_type: &str,
+    recursive_types: &HashSet<String>,
+) -> Vec<String> {
     let mut key_types = Vec::new();
     for type_ref in type_refs {
-        let Some(inner) = unwrap_generic(type_ref.trim(), "Map<") else {
-            continue;
+        let trimmed = type_ref.trim();
+        let key_type = if let Some(inner) = unwrap_generic(trimmed, "Map<") {
+            let args = split_top_level(inner, ',');
+            (args.len() == 2 && args[1].trim() == value_type).then(|| args[0].trim().to_string())
+        } else if let Some(inner) = unwrap_generic(trimmed, "List<") {
+            entries_measure_tuple_item(inner.trim(), recursive_types)
+                .filter(|(_, value)| value == value_type)
+                .map(|(key, _)| key)
+        } else {
+            None
         };
-        let args = split_top_level(inner, ',');
-        if args.len() == 2 && args[1].trim() == value_type {
-            let key_type = args[0].trim().to_string();
-            if !key_types.contains(&key_type) {
-                key_types.push(key_type);
-            }
+        if let Some(key_type) = key_type
+            && !key_types.contains(&key_type)
+        {
+            key_types.push(key_type);
         }
     }
     key_types
@@ -295,6 +401,7 @@ fn emit_recursive_sum_measure(
     name: &str,
     variants: &[TypeVariant],
     recursive_types: &HashSet<String>,
+    sig_type_refs: &[String],
 ) -> String {
     let mut lines = vec!["mutual".to_string()];
     lines.push(format!(
@@ -344,11 +451,16 @@ fn emit_recursive_sum_measure(
         measure_fn_name(name),
         measure_list_fn_name(name)
     ));
+    // Entries-list refs can sit in the ADT's own fields OR only in fn
+    // signatures (`fn f(entries: List<Tuple<String, T>>)` over a `T`
+    // whose fields never spell the list) — scan both so every entries
+    // measure `type_measure_expr` can choose is actually defined.
     let field_types: Vec<String> = variants
         .iter()
         .flat_map(|variant| variant.fields.iter().cloned())
+        .chain(sig_type_refs.iter().cloned())
         .collect();
-    for key_type in recursive_map_key_types(&field_types, name) {
+    for key_type in recursive_map_key_types(&field_types, name, recursive_types) {
         lines.push(format!(
             "  def {} (items : List ({} × {})) : Nat :=",
             measure_entries_fn_name(name, &key_type),
@@ -371,6 +483,7 @@ fn emit_recursive_product_measure(
     name: &str,
     fields: &[(String, String)],
     recursive_types: &HashSet<String>,
+    sig_type_refs: &[String],
 ) -> String {
     let field_measures: Vec<String> = fields
         .iter()
@@ -409,8 +522,12 @@ fn emit_recursive_product_measure(
             measure_list_fn_name(name)
         ),
     ];
-    let field_types: Vec<String> = fields.iter().map(|(_, ty)| ty.clone()).collect();
-    for key_type in recursive_map_key_types(&field_types, name) {
+    let field_types: Vec<String> = fields
+        .iter()
+        .map(|(_, ty)| ty.clone())
+        .chain(sig_type_refs.iter().cloned())
+        .collect();
+    for key_type in recursive_map_key_types(&field_types, name, recursive_types) {
         lines.push(format!(
             "  def {} (items : List ({} × {})) : Nat :=",
             measure_entries_fn_name(name, &key_type),
@@ -429,13 +546,17 @@ fn emit_recursive_product_measure(
     lines.join("\n")
 }
 
-pub fn emit_recursive_measure(td: &TypeDef, recursive_types: &HashSet<String>) -> Option<String> {
+pub fn emit_recursive_measure(
+    td: &TypeDef,
+    recursive_types: &HashSet<String>,
+    sig_type_refs: &[String],
+) -> Option<String> {
     match td {
-        TypeDef::Sum { name, variants, .. } if is_recursive_type(name, variants) => {
-            Some(emit_recursive_sum_measure(name, variants, recursive_types))
-        }
+        TypeDef::Sum { name, variants, .. } if is_recursive_type(name, variants) => Some(
+            emit_recursive_sum_measure(name, variants, recursive_types, sig_type_refs),
+        ),
         TypeDef::Product { name, fields, .. } if is_recursive_product(name, fields) => Some(
-            emit_recursive_product_measure(name, fields, recursive_types),
+            emit_recursive_product_measure(name, fields, recursive_types, sig_type_refs),
         ),
         _ => None,
     }

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -4910,6 +4910,99 @@ verify parseNum law fromIntRoundtrip
     let _ = std::fs::remove_dir_all(&out);
 }
 
+/// A recursive ADT carried through `Tuple<...>`-typed params must get DEEP
+/// ADT-measure fuel, not constant fuel. `type_measure_expr` had arms for
+/// `List<` / `Option<` / `Map<` / `Result<` and the legacy parenthesized
+/// `(A, B)` tuple spelling — but not for the `Tuple<A, B>` spelling Aver
+/// type names actually use. Consequence (found on `examples/data/json.av`,
+/// kernel-checked): a fn over `Tuple<String, Json>` got CONSTANT fuel and a
+/// fn over `List<Tuple<String, Json>>` got the shallow spine measure
+/// `AverMeasure.list (fun item => 1)`, so at nesting depth 5 the emitted
+/// Lean model exhausted fuel and returned `default` — a WRONG model,
+/// invisible to shallow samples. This test mirrors the Json object shape
+/// (recursive ADT whose constructor carries `List<Tuple<String, T>>`) with
+/// a depth-5 verify sample: with the `Tuple<` measure arm in place the
+/// sample's `native_decide` computes the real value (`passed: true`); with
+/// the arm reverted the wrapper's constant fuel exhausts mid-recursion and
+/// the deep case evaluates to `default` → lake build error → `passed: false`.
+#[test]
+fn lean_deep_tuple_entries_get_adt_measure_fuel_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping deep-tuple-entries test: `lake` not available");
+        return;
+    }
+    let source = r#"module DeepEntries
+    intent = "a recursive ADT carrying List<Tuple<String, T>> probed past constant fuel"
+    effects []
+
+type Tree
+    TreeLeaf(Int)
+    TreeNode(List<Tuple<String, Tree>>)
+
+fn renderTree(t: Tree) -> String
+    ? "Render a tree."
+    match t
+        Tree.TreeLeaf(n) -> String.fromInt(n)
+        Tree.TreeNode(entries) -> "(" + renderEntries(entries) + ")"
+
+fn renderEntries(entries: List<Tuple<String, Tree>>) -> String
+    ? "Render an entry list."
+    match entries
+        [] -> ""
+        [entry, ..tail] -> renderEntriesTail(entryString(entry), tail)
+
+fn renderEntriesTail(acc: String, rest: List<Tuple<String, Tree>>) -> String
+    ? "Render remaining entries onto an accumulator."
+    match rest
+        [] -> acc
+        [entry, ..tail] -> renderEntriesTail(acc + "," + entryString(entry), tail)
+
+fn entryString(entry: Tuple<String, Tree>) -> String
+    ? "Render one entry."
+    match entry
+        (key, value) -> key + ":" + renderTree(value)
+
+verify entryString
+    entryString(("a", Tree.TreeLeaf(1))) => "a:1"
+    entryString(("a", Tree.TreeNode([("b", Tree.TreeNode([("c", Tree.TreeNode([("d", Tree.TreeNode([("e", Tree.TreeNode([("f", Tree.TreeLeaf(1))]))]))]))]))]))) => "a:(b:(c:(d:(e:(f:1)))))"
+
+verify renderEntries
+    renderEntries([]) => ""
+    renderEntries([("a", Tree.TreeNode([("b", Tree.TreeNode([("c", Tree.TreeNode([("d", Tree.TreeNode([("e", Tree.TreeLeaf(2))]))]))]))]))]) => "a:(b:(c:(d:(e:2))))"
+"#;
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-deepentries-src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(src.join("m.av"), source).expect("write");
+    let out = temp_output_dir("aver-deepentries-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("aver proof ran");
+    let json = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON:\n{}", format_output(&run)));
+    let summary: serde_json::Value = serde_json::from_str(json).expect("json");
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "depth-5 entries through Tuple-typed params must compute (deep ADT-measure fuel), not exhaust constant fuel into `default`\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
 /// A LinearArithmetic law over a fn using `Int.max`/`Int.min` must close. Two
 /// bugs blocked it: (1) `Int.max` (lowercase leaf) leaked into the unfold set as
 /// the non-existent constant `Int.max` → `unknown constant` compile error;


### PR DESCRIPTION
## Summary

First prerequisite chunk of the when-aware-induction (LUKA 3) plan — an exporter bug found and kernel-checked during the research workflow, independently valuable.

`type_measure_expr` (the ADT-measure synthesizer that derives FUEL for fuel-wrapped fns) had no `Tuple<...>` arm — only the legacy parenthesized `(A, B)` spelling, which is unreachable from current surface syntax. On `examples/data/json.av`: `entryToString` got **constant fuel 7** and the `List<Tuple<String, Json>>` family got the **shallow spine measure**. Fuel exhaustion returns `default`, so the emitted Lean models of the object family were **wrong at depth** (kernel-checked counterexample at nesting depth 5 with a true premise) — invisible to shallow bounded samples.

Fix:
- A `Tuple<` arm sharing **one code path** with the paren arm (`tuple_parts_measure`); projections corrected to right-nested `Prod` (the old flat `.3` was never valid).
- `List<Tuple<K, V>>` with recursive `V` and measure-free `K` reuses the dedicated deep entries measure the `Map<K, V>` arm already uses — one measure name for both spellings (future lemma synthesis covers both).
- Chooser and measure emitter share a single predicate; `measure_sig_type_refs` (fn param types + type-def field types) guarantees a chosen entries measure is always defined.
- Measure margins match the kernel-checked congruence bounds from the research probes.

## Validation

- **Revert-tested**: new lake-gated `lean_deep_tuple_entries_get_adt_measure_fuel_when_lake_is_available` (recursive ADT with `List<Tuple<String, Tree>>`, depth-5 samples) **fails on HEAD** (deep sample evaluates to `default` → native_decide mismatch → lake error, reproduced independently by the reviewer) and **passes with the fix**.
- json.av: Lean sorries stay exactly 2; `aver verify` profile unchanged; a depth-5 object-family probe now computes real values where the HEAD export panicked on exhausted fuel.
- All 16 other tuple-carrying corpus exports **byte-identical** (incl. `independent_fanout.av`, `oracle_independent_products.av` — flagged by the reviewer for audit completeness); json's AverCommon drops the now-unreferenced `AverMeasure` prelude section (demand-driven emission, expected).
- Dafny exports byte-identical (Lean-only change; Dafny's fuel path uses structured `Type::Tuple` and has no analogous gap — audited).
- `cargo test --workspace` 2102 passed / 0 failed; both clippy halves + fmt clean; adversarial review pass with no code issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)