### PR TITLE
proof: universal credit keyed on explicit statement class, not theorem names (M0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,23 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
-## 0.24.2 (unreleased)
+## 0.25.0 (unreleased)
+
+### Added
+
+- **The auto-prover closes far more laws on its own.** New strategies cover: laws whose givens range over finite domains (`Bool`, field-less enums), decimal render/parse roundtrips (the prover synthesizes the scanner lemmas it needs), laws that follow from built-in string/int facts (slicing, `Int.fromString`/`String.fromInt`), ground laws over fixed enum constructors, `Int.max`/`Int.min` arithmetic, general-key `Map` laws, and laws whose pipelines use `?`.
+- **Your proven laws now help prove your later laws.** A proved `verify ... law` becomes ammunition for the laws below it in the same file — decomposing a hard law into helper laws written in plain Aver is now a working proof strategy. An opt-in `aver proof --discover` mode additionally conjectures and kernel-proves helper lemmas automatically.
+- **Recursive functions over your own types prove termination structurally** — no more fuel wrappers blocking universal proofs for tree-shaped data, and mutual recursion (e.g. quicksort) gets genuine well-founded termination with auto-proved length lemmas.
+
+### Changed
+
+- **`aver proof --check` reports `universal: true` only for genuinely universal theorems.** Bounded `when`-law checks still pass — they just no longer count as proven-for-all-inputs.
 
 ### Fixed
 
-- **`aver proof --check` reports `universal: true` only for genuinely universal theorems.** A law with a `when` premise over plain (non-refinement) givens exports a domain-bounded statement; previously, if tactics happened to prove that bounded statement, the law could be credited as universal. The emitted Lean now carries an explicit per-theorem statement class and the checker credits only universal-class theorems — bounded `when`-law checks still pass, they just no longer count as proven-for-all-inputs.
-- **Functions over tuples get correct termination fuel in Lean proofs.** Types spelled `Tuple<...>` were missed by the proof exporter's measure synthesis, so deeply nested tuple-carrying values (e.g. JSON object entries) could exhaust fuel and make the exported model disagree with the program at depth. Both tuple spellings now share one deep-measure path.
+- **Tuple-carrying functions get correct termination fuel in Lean exports** — deeply nested values (e.g. JSON object entries) no longer make the exported model disagree with the running program.
+- **wasm-gc: `String.split`/`String.join` used inside string interpolation now compile correctly.**
+- Example corpus honesty: laws that were really single-example checks (red-black tree, `order_total` floats, oracle-pinned file-store) are now plain `verify` blocks or trace checks.
 
 ## 0.24.1 — 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
+## 0.24.2 (unreleased)
+
+### Fixed
+
+- **`aver proof --check` reports `universal: true` only for genuinely universal theorems.** A law with a `when` premise over plain (non-refinement) givens exports a domain-bounded statement; previously, if tactics happened to prove that bounded statement, the law could be credited as universal. The emitted Lean now carries an explicit per-theorem statement class and the checker credits only universal-class theorems — bounded `when`-law checks still pass, they just no longer count as proven-for-all-inputs.
+- **Functions over tuples get correct termination fuel in Lean proofs.** Types spelled `Tuple<...>` were missed by the proof exporter's measure synthesis, so deeply nested tuple-carrying values (e.g. JSON object entries) could exhaust fuel and make the exported model disagree with the program at depth. Both tuple spellings now share one deep-measure path.
+
 ## 0.24.1 — 2026-06-06
 
 Patch release on top of "Divide" — a correctness fix in the optimizer and broader `aver check` hints.

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -24,6 +24,39 @@ use std::collections::{HashMap, HashSet};
 use crate::ast::{FnDef, Spanned, TopLevel, VerifyKind};
 use crate::codegen::{CodegenContext, ProjectOutput};
 
+/// Statement-class channel for emitted law theorems.
+///
+/// `aver proof --check`'s `universal` metric must know, per law theorem,
+/// whether the emitted STATEMENT is genuinely universal or bounded: for a
+/// `when`-law over non-refinement-lifted givens, `law_theorem_prop` prepends
+/// sampled-domain disjunction premises (`a = 0 ∨ a = 1 ∨ …`) — the theorem
+/// then only claims the law on the finite sample domain, even when it is
+/// proven by real tactics with a kernel-clean axiom profile. Refinement-lifted
+/// `when`-laws drop those premises (the Subtype carries the invariant) and
+/// stay genuinely universal.
+///
+/// Only the code that BUILDS the statement knows which premises it prepended,
+/// so the emitter records the class as one structured marker comment per
+/// emitted law theorem, preceding it in the generated `.lean` source
+/// (self-contained artifact — the classification travels with the export):
+///
+/// ```text
+/// -- aver:law-class <theorem_name> universal
+/// -- aver:law-class <theorem_name> bounded-domain
+/// ```
+///
+/// The checker (`lean_universal_proof` in the CLI) consumes these markers and
+/// must NEVER re-derive the class from theorem names or by re-parsing
+/// statements. A law theorem without a marker earns no universal credit
+/// (fail-closed for stale/foreign export dirs).
+pub const LAW_CLASS_MARKER_PREFIX: &str = "-- aver:law-class ";
+/// Marker class tag: no sampled-domain premises — the `∀`-statement is the
+/// law's genuine universal claim.
+pub const LAW_CLASS_UNIVERSAL: &str = "universal";
+/// Marker class tag: sampled-domain disjunction premises bound the statement
+/// to the finite sample domain.
+pub const LAW_CLASS_BOUNDED_DOMAIN: &str = "bounded-domain";
+
 /// How verify blocks should be emitted in generated Lean.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum VerifyEmitMode {

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -2996,7 +2996,7 @@ fn emit_verify_law_block(
             ctx,
             &theorem_base,
         ));
-        let theorem_prop = law_theorem_prop(
+        let (theorem_prop, bounded_domain) = law_theorem_prop(
             law,
             ctx,
             &lhs_template,
@@ -3004,6 +3004,25 @@ fn emit_verify_law_block(
             when_template.as_deref(),
             &lifted_vars,
         );
+        // Statement-class marker — the channel `aver proof --check`'s
+        // `universal` metric keys on (see `LAW_CLASS_MARKER_PREFIX`).
+        // Recorded HERE because this is where the statement was built:
+        // `bounded_domain` says whether sampled-domain disjunction
+        // premises bound the claim to the finite sample domain. For a
+        // `replaces_theorem` auto-proof the strategy emits its own
+        // (universal-form) statement; keeping this class for it is
+        // conservative — a mislabel can only withhold credit, never
+        // grant it.
+        lines.push(format!(
+            "{}{} {}",
+            super::LAW_CLASS_MARKER_PREFIX,
+            theorem_base,
+            if bounded_domain {
+                super::LAW_CLASS_BOUNDED_DOMAIN
+            } else {
+                super::LAW_CLASS_UNIVERSAL
+            }
+        ));
         // Oracle v1: the auto-proof matchers compare law.lhs / law.rhs
         // ASTs. For effectful laws the theorem statement has been
         // rewritten to target the lifted fn (BranchPath.root() + oracle
@@ -3300,6 +3319,16 @@ pub(crate) fn law_as_lemma_statement(
     Some((theorem_base, format!("{lhs} = {rhs}")))
 }
 
+/// Build the law theorem's statement body. Returns `(prop, bounded_domain)`:
+/// `bounded_domain` is `true` iff sampled-domain disjunction premises
+/// (`a = 0 ∨ a = 1 ∨ …`) were prepended — the statement then only claims the
+/// law over the finite sample domain, NOT universally. This flag is the
+/// single source of truth for the `-- aver:law-class` marker the caller
+/// emits (see `LAW_CLASS_MARKER_PREFIX`): the checker's `universal` metric
+/// keys on it instead of re-deriving the class from names or statements.
+/// A `when`-premise alone (`… = true ->`) does NOT bound the statement —
+/// it is a conditional but still universally quantified claim (the
+/// refinement-lifted case, where every given's domain premise is dropped).
 fn law_theorem_prop(
     law: &VerifyLaw,
     ctx: &CodegenContext,
@@ -3307,7 +3336,7 @@ fn law_theorem_prop(
     rhs_template: &str,
     when_template: Option<&str>,
     lifted_vars: &std::collections::HashMap<String, String>,
-) -> String {
+) -> (String, bool) {
     let mut premises = Vec::new();
     let when_redundant_with_lifts = law
         .when
@@ -3330,6 +3359,7 @@ fn law_theorem_prop(
             }
         }));
     }
+    let bounded_domain = !premises.is_empty();
     // `when` drop is only sound when the predicate is syntactically
     // equivalent (via commutator-relaxed compare) to the conjunction
     // of lifted givens' refinement invariants — otherwise stronger /
@@ -3343,11 +3373,12 @@ fn law_theorem_prop(
         premises.push(format!("{when_expr} = true"));
     }
     let conclusion = format!("{lhs_template} = {rhs_template}");
-    if premises.is_empty() {
+    let prop = if premises.is_empty() {
         conclusion
     } else {
         format!("{} -> {}", premises.join(" -> "), conclusion)
-    }
+    };
+    (prop, bounded_domain)
 }
 
 fn law_given_domain_to_lean(domain: &VerifyGivenDomain, ctx: &CodegenContext) -> String {

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5665,9 +5665,33 @@ fn count_lean_sorries(s: &str) -> usize {
 /// universal claim. We collect the main law theorems (`*_law_*` / `*_eq_*`,
 /// excluding the `_checked_domain` and `_sample_N` bounded cross-checks
 /// built off the same base) and run `#print axioms` on each against the
-/// freshly built environment. The law is universal iff EVERY main theorem
-/// is `ofReduceBool`-free — and at least one exists, and there are no
-/// sorries.
+/// freshly built environment. The law is universal iff EVERY participating
+/// theorem is `ofReduceBool`-free — and at least one exists, and there are
+/// no sorries.
+///
+/// Axiom-cleanliness alone is NOT enough: the theorem's STATEMENT must also
+/// be the law's genuine `∀`-claim. A `when`-law over non-refinement-lifted
+/// givens is emitted with sampled-domain disjunction premises prepended
+/// (`a = 0 ∨ a = 1 ∨ … ->`), so even a real-tactic, axiom-clean proof of it
+/// only establishes the law on the finite sample domain. Whether those
+/// premises were prepended is knowable only at the statement-construction
+/// site, so the emitter records a per-theorem class marker in the `.lean`
+/// source (`-- aver:law-class <name> universal|bounded-domain`, see
+/// `lean::LAW_CLASS_MARKER_PREFIX`) and this checker consumes it — it never
+/// re-derives the class from names or by parsing statements:
+///   - `bounded-domain`-classed theorems are EXCLUDED from universal
+///     crediting (their axiom profile no longer matters here; sorries still
+///     count file-wide via the `sorries` gate above);
+///   - universal credit requires at least one emitted law theorem
+///     explicitly classed `universal` — a dir with law theorems but no
+///     markers (stale/foreign export not produced by this emitter) FAILS
+///     CLOSED to `false` instead of reverting to name heuristics. The
+///     `--check` flow always runs on a fresh emission (`cmd_proof` emits,
+///     then calls `run_proof_check`, the only caller), so the channel is
+///     present in practice;
+///   - a name-matched theorem WITHOUT a marker (auxiliary `*_eq_*`-shaped
+///     helper lemmas some strategies emit) stays in the axiom check —
+///     conservative: it can only withhold credit, never grant it.
 ///
 /// A task whose universal theorem was dropped entirely (`skip_universal`:
 /// const-RHS singleton or a fuel-bounded recursive callee — the Lean analog
@@ -5689,8 +5713,10 @@ fn lean_universal_proof(dir: &str, sorries: usize) -> bool {
     if roots.is_empty() {
         return false;
     }
-    // Collect the main universal law theorems across the emitted sources.
+    // Collect the main universal law theorems across the emitted sources,
+    // plus the emitter's per-theorem statement-class markers.
     let mut law_thms: Vec<String> = Vec::new();
+    let mut classes: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     if let Ok(rd) = std::fs::read_dir(dir) {
         for entry in rd.flatten() {
             let name = entry.file_name().to_string_lossy().into_owned();
@@ -5712,6 +5738,13 @@ fn lean_universal_proof(dir: &str, sorries: usize) -> bool {
                     continue;
                 }
                 for line in contents.lines() {
+                    if let Some(rest) = line.strip_prefix(lean_codegen::LAW_CLASS_MARKER_PREFIX) {
+                        let mut parts = rest.split_whitespace();
+                        if let (Some(thm), Some(class)) = (parts.next(), parts.next()) {
+                            classes.insert(thm.to_string(), class.to_string());
+                        }
+                        continue;
+                    }
                     if let Some(rest) = line.strip_prefix("theorem ") {
                         let thm = rest
                             .split_whitespace()
@@ -5731,6 +5764,24 @@ fn lean_universal_proof(dir: &str, sorries: usize) -> bool {
     }
     law_thms.sort();
     law_thms.dedup();
+    // Consume the statement-class channel (see the doc comment above):
+    // bounded-domain theorems leave the crediting set; at least one
+    // explicitly universal-classed theorem must remain or the dir earns no
+    // universal credit (fail-closed when the channel is absent).
+    let mut universal_class_present = false;
+    law_thms.retain(|thm| match classes.get(thm).map(String::as_str) {
+        Some(lean_codegen::LAW_CLASS_BOUNDED_DOMAIN) => false,
+        Some(lean_codegen::LAW_CLASS_UNIVERSAL) => {
+            universal_class_present = true;
+            true
+        }
+        // Unmarked (or unknown class tag): keep it in the axiom check —
+        // conservative — but it cannot by itself earn universal credit.
+        _ => true,
+    });
+    if !universal_class_present {
+        return false;
+    }
     // Throwaway checker: print each main law theorem's axiom dependency
     // against the already-built environment.
     let mut src = String::new();

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -1349,6 +1349,82 @@ fn proof_lean_vacuous_when_premise_law_builds_and_passes() {
 }
 
 #[test]
+fn proof_lean_bounded_when_law_proof_is_not_credited_universal() {
+    // The false-credit probe for the `universal` metric. A `when`-law over a
+    // non-refinement-lifted Int given is emitted with sampled-domain
+    // disjunction premises prepended (`a = 0 ∨ a = 1 ∨ … ->`), so its
+    // theorem is BOUNDED — it claims the law only on the finite sample
+    // domain. This exact shape is one the LinearArithmetic `h_when` path
+    // proves with real tactics (`intro a h_a h_when; simp_all`-style), so the
+    // proof is axiom-clean: before the statement-class channel
+    // (`-- aver:law-class`, emitted by `law_theorem_prop`'s caller and
+    // consumed by `lean_universal_proof`), the file FALSELY flipped
+    // `universal: true`. The honest summary is: passed (the bounded claim IS
+    // proven), zero sorries, but NO universal credit. Reverting only the
+    // classification change (emitter marker + checker consumption) makes
+    // this test fail with `universal: true` — the false credit.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean bounded-when universal-credit test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-lean-bounded-when-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    let av = src.join("clamp.av");
+    std::fs::write(
+        &av,
+        "module ClampFloor\n\n\
+         fn clampFloor(a: Int) -> Int\n    ? \"Clamps negative values to zero.\"\n\
+         \x20   match a >= 0\n        true -> a\n        false -> 0\n\n\
+         verify clampFloor law identityOnNonNegative\n\
+         \x20   given a: Int = [0, 1, 7, 42]\n\
+         \x20   when a >= 0\n\
+         \x20   clampFloor(a) => a\n",
+    )
+    .expect("write clamp.av");
+    let out = temp_output_dir("aver-lean-bounded-when-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(&av)
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check` to run");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "the bounded `when`-law claim itself must still prove and pass\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "the bounded `when`-law proof must be sorry-free\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(false),
+        "a bounded-statement law proof must NOT be credited universal\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
 fn proof_export_builds_grok_s_language_when_lake_is_available() {
     assert_proof_builds("examples/core/grok_s_language.av", "aver-proof-grok");
 }


### PR DESCRIPTION
## Summary

Second prerequisite of the when-aware-induction plan (and an independently real metric-honesty fix; flagged by the external design consult, confirmed by research probes).

**The hole**: `lean_universal_proof` collected "main law theorems" by name and credited `universal:true` iff every one was axiom-clean — but `law_theorem_prop` prepends sampled-domain disjunction premises to every when-law statement over non-refinement-lifted givens, so those theorems are **bounded**, not universal. **Reproduced on HEAD**: a when-law over `Int` (`when a >= 0`, clampFloor shape) proven by real tactics on its bounded statement reported `universal:true` — a false credit.

**The fix**:
- The statement-construction site (`law_theorem_prop`) returns whether domain premises were prepended; `emit_verify_law_block` writes one structured marker per law theorem into the generated `.lean` (`-- aver:law-class <name> universal|bounded-domain`). The class travels with the export; the checker never re-derives it from names or statement parsing. Marker and theorem are emitted in the same guarded block — they cannot desync (incl. the `replaces_theorem` path, audited).
- The checker excludes bounded-domain theorems from universal crediting (sorries still count file-wide), requires at least one explicitly universal-class law theorem, and **fails closed** on exports without markers (no silent reversion to name heuristics).
- A sole `when … = true` premise does NOT bound — refinement-lifted when-laws keep their universal credit (verified on `natural.av` add/mul commutative).
- Dafny untouched, exports byte-identical.

## Validation

- **Revert-tested false-credit probe**: new lake-gated `proof_lean_bounded_when_law_proof_is_not_credited_universal`; with only the classification reverted the test fails with `universal` flipping `true` (the false credit), with the fix `universal:false` while `passed:true, sorries:0`. Mixed-module probe: a genuine universal law alongside the bounded when-law still credits `universal:true` — exclusion, not punishment.
- Corpus sweep vs HEAD baselines: map/rle/sparse/quicksort/red_black_tree/natural_app/natural (+2 tip tasks) — summaries identical; `.lean` diffs are marker-lines-only.
- `cargo test --workspace` green (proof_spec 115 passed, lake+dafny really ran); both clippy halves + fmt clean; adversarial review pass (2 optional minors: CHANGELOG — included here under 0.24.2 (unreleased) together with a user-facing line for #471; fail-closed unit test — defense-in-depth, the path is unreachable via the CLI today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)