### PR TITLE
proof: widen the --check panic gate to any model panic line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
-- **Bounded proof checks now compare against actual program results, and fuel exhaustion in proofs is a hard check error.** Lean exports pin each `verify` example and law sample to the value the program actually computed (instead of model-vs-model equations that could certify vacuously when the exported model runs out of fuel), and `aver proof --check` fails — with a please-report-this-bug message and a `fuel_exhausted` field in `--check-json` — whenever the build output shows the model exhausted fuel while evaluating a sample.
+- **Bounded proof checks now compare against actual program results, and any model panic in a proof is a hard check error.** Lean exports pin each `verify` example and law sample to the value the program actually computed (instead of model-vs-model equations that could certify vacuously when the exported model panics and quietly evaluates to a default value — fuel exhaustion and partial builtins like `Char.toCode` on an empty string share that failure mode), and `aver proof --check` fails — with a please-report-this-bug message and a `model_panicked` field in `--check-json` — whenever the build output shows the model panicked while evaluating a sample.
 - **Tuple-carrying functions get correct termination fuel in Lean exports** — deeply nested values (e.g. JSON object entries) no longer make the exported model disagree with the running program.
 - **wasm-gc: `String.split`/`String.join` used inside string interpolation now compile correctly.**
 - Example corpus honesty: laws that were really single-example checks (red-black tree, `order_total` floats, oracle-pinned file-store) are now plain `verify` blocks or trace checks.

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -79,23 +79,53 @@ pub use crate::codegen::recursion::{ProofModeIssue, RecursionPlan};
 
 pub use toplevel::PROOF_FUEL_EXHAUSTED_MSG;
 
-/// Count fuel-exhaustion panic hits in captured `lake build` output.
+/// The marker every Lean runtime panic prints into captured build output.
+/// Empirically pinned against real `lake build` transcripts (both panic
+/// sites below produce it):
 ///
-/// The fuel wrappers' exhaustion arm is `panic! "<PROOF_FUEL_EXHAUSTED_MSG>"`,
-/// and Lean's `panic!` does NOT abort: at `native_decide` evaluation time it
-/// prints `PANIC at <fn> <file>:<line>: <msg>` (to lake's captured output) and
-/// returns the result type's `default` value. When BOTH sides of a bounded
-/// sample route through the model (`verify f(x) => g(x)` cases, every
-/// `_sample_N` / `_checked_domain` theorem), exhausted fuel reduces both sides
-/// to `default` and the kernel certifies a vacuous — possibly FALSE — equation
-/// while `lake` exits 0 with zero sorries. The panic line in the build output
-/// is the only trace, so `aver proof --check` charges ANY hit as a hard
-/// failure. Counts matching LINES (one panic prints exactly one line; the
-/// same wrapper can fire on several theorems).
-pub fn count_fuel_exhaustion_panics(output: &str) -> usize {
+/// ```text
+/// info: ././././FuelProbe.lean:27:0: PANIC at stepSum__fuel FuelProbe:8:9: Aver proof fuel exhausted
+/// PANIC at stepSumAcc__fuel FuelProbe:19:9: Aver proof fuel exhausted
+/// info: ././././PanicProbe.lean:11:0: PANIC at Char.toCode AverCommon:11:12: Char.toCode: string is empty
+/// ```
+///
+/// (lake prefixes the first diagnostic of a build step with `info: <loc>:`,
+/// later ones print raw — both carry `PANIC at `.)
+pub const LEAN_PANIC_LINE_MARKER: &str = "PANIC at ";
+
+/// Count model panic lines in captured `lake build` output.
+///
+/// Lean's `panic!` does NOT abort: at `native_decide` evaluation time it
+/// prints `PANIC at <fn> <file>:<line>: <msg>` (to lake's captured output)
+/// and returns the result type's `default` value. When BOTH sides of a
+/// bounded sample route through the model (`verify f(x) => g(x)` cases,
+/// every `_sample_N` / `_checked_domain` theorem), a panicking evaluation
+/// reduces both sides to `default` and the kernel certifies a vacuous —
+/// possibly FALSE — equation while `lake` exits 0 with zero sorries. The
+/// panic line in the build output is the only trace, so `aver proof --check`
+/// charges ANY hit as a hard failure.
+///
+/// Scans for the generic `PANIC at ` line marker, not a per-site message:
+/// the emitted exports contain `panic!` only at compiler-generated sites —
+/// the fuel wrappers' exhaustion arm ([`PROOF_FUEL_EXHAUSTED_MSG`]) and
+/// partial prelude builtins (e.g. `Char.toCode` on an empty string) — and
+/// every one of them shares the same panic-returns-`default` vacuity vector.
+/// A green check has no legitimate panic, and the generic marker also
+/// catches panics raised inside Lean's own stdlib (e.g. a `get!` deep in a
+/// future prelude helper) that a per-message scan could never enumerate.
+/// Counts matching LINES (one panic prints exactly one line; the same site
+/// can fire on several theorems).
+///
+/// Known false-positive boundary, accepted: on an ALREADY-FAILING build, a
+/// native_decide error can echo the false proposition, and a user string
+/// literal containing `PANIC at ` inside it would inflate the count (and
+/// set `model_panicked`). The verdict stays correct — the build already
+/// failed on exit status — so a spurious match can only turn a red redder,
+/// never a green red.
+pub fn count_model_panic_lines(output: &str) -> usize {
     output
         .lines()
-        .filter(|l| l.contains(PROOF_FUEL_EXHAUSTED_MSG))
+        .filter(|l| l.contains(LEAN_PANIC_LINE_MARKER))
         .count()
 }
 

--- a/src/codegen/lean/toplevel.rs
+++ b/src/codegen/lean/toplevel.rs
@@ -596,10 +596,12 @@ const STRING_POS_FUEL_VAR: &str = "fuel'";
 /// `default` value, so under `native_decide` an exhausted-fuel sample reduces
 /// both sides of a model-vs-model equation to `default` and the kernel
 /// certifies a vacuous (possibly FALSE) equality with `lake` still exiting 0.
-/// `aver proof --check` therefore scans captured lake output for this exact
-/// string ([`crate::codegen::lean::count_fuel_exhaustion_panics`]) and treats
-/// any hit as a hard check failure. Keep emission and scan keyed on this one
-/// constant so they can never drift apart.
+/// `aver proof --check` therefore scans captured lake output for panic lines
+/// ([`crate::codegen::lean::count_model_panic_lines`]) and treats any hit as
+/// a hard check failure. The scan keys on Lean's generic `PANIC at ` line
+/// marker — every prelude `panic!` site shares the vacuity vector, not just
+/// this one — so this constant is purely the emission message; changing it
+/// cannot blind the gate.
 pub const PROOF_FUEL_EXHAUSTED_MSG: &str = "Aver proof fuel exhausted";
 
 fn fuel_helper_name(name: &str) -> String {

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5597,14 +5597,16 @@ fn run_proof_check(
     // law, and neither backend charges that fn-level trust to the budget.)
     let error_budget_v = error_budget.unwrap_or(0);
     let sorry_budget_v = sorry_budget.unwrap_or(0);
-    // Lean only: fuel-exhaustion panic lines in the captured build output.
-    // The fuel wrappers panic on exhaustion, but Lean's `panic!` RETURNS the
-    // type's `default` instead of aborting — under `native_decide` both sides
-    // of a model-vs-model sample equation then reduce to `default` and the
-    // kernel certifies a vacuous (possibly false) equality with lake exit 0
-    // and zero sorries. The panic line is the only trace, so ANY hit is a
-    // hard check failure (see `count_fuel_exhaustion_panics`).
-    let mut fuel_exhausted_hits = 0usize;
+    // Lean only: model panic lines in the captured build output. The emitted
+    // exports panic only at compiler-generated sites (fuel-wrapper
+    // exhaustion, partial prelude builtins like `Char.toCode` on an empty
+    // string), and Lean's `panic!` RETURNS the type's `default` instead of
+    // aborting — under `native_decide` both sides of a model-vs-model sample
+    // equation then reduce to `default` and the kernel certifies a vacuous
+    // (possibly false) equality with lake exit 0 and zero sorries. The panic
+    // line is the only trace, so ANY hit is a hard check failure (see
+    // `count_model_panic_lines`).
+    let mut model_panic_hits = 0usize;
     let (errors, sorries, axioms, omitted, budget, passed) = match backend {
         super::cli::ProofBackend::Dafny => {
             let errors = match parse_dafny_error_count(&stdout) {
@@ -5647,24 +5649,24 @@ fn run_proof_check(
         }
         super::cli::ProofBackend::Lean => {
             let sorries = count_lean_sorries(&stderr) + count_lean_sorries(&stdout);
-            fuel_exhausted_hits = lean_codegen::count_fuel_exhaustion_panics(&stdout)
-                + lean_codegen::count_fuel_exhaustion_panics(&stderr);
+            model_panic_hits = lean_codegen::count_model_panic_lines(&stdout)
+                + lean_codegen::count_model_panic_lines(&stderr);
             let passed =
-                output.status.success() && sorries <= sorry_budget_v && fuel_exhausted_hits == 0;
+                output.status.success() && sorries <= sorry_budget_v && model_panic_hits == 0;
             (None, Some(sorries), None, None, sorry_budget_v, passed)
         }
     };
 
-    if fuel_exhausted_hits > 0 {
+    if model_panic_hits > 0 {
         eprintln!(
             "{}",
             format!(
-                "--check: the Lean model exhausted fuel while evaluating a bounded sample \
-                 ({} \"{}\" panic line(s) in the build output) — the exported model may \
+                "--check: the Lean model panicked while evaluating a bounded sample \
+                 ({} \"{}\" line(s) in the build output) — the exported model may \
                  disagree with the program, so its sample equations prove nothing; this is \
                  an Aver bug, please report it",
-                fuel_exhausted_hits,
-                lean_codegen::PROOF_FUEL_EXHAUSTED_MSG
+                model_panic_hits,
+                lean_codegen::LEAN_PANIC_LINE_MARKER.trim_end()
             )
             .red()
         );
@@ -5682,7 +5684,7 @@ fn run_proof_check(
     let universal: Option<bool> = match backend {
         super::cli::ProofBackend::Lean => Some(
             output.status.success()
-                && fuel_exhausted_hits == 0
+                && model_panic_hits == 0
                 && lean_universal_proof(output_dir, sorries.unwrap_or(0)),
         ),
         super::cli::ProofBackend::Dafny => None,
@@ -5708,11 +5710,14 @@ fn run_proof_check(
             obj.insert("universal".into(), u.into());
         }
         if matches!(backend, super::cli::ProofBackend::Lean) {
-            // Additive field — existing consumers (proof-corpus/run.sh, the
-            // proof_spec gating tests) key on passed/universal/sorries and
-            // ignore unknown fields. `true` means the check FAILED with the
-            // compiler-model bug above regardless of budgets.
-            obj.insert("fuel_exhausted".into(), (fuel_exhausted_hits > 0).into());
+            // Renamed from the short-lived `fuel_exhausted` (0.25.0-unreleased
+            // only; no consumer outside this repo's tests reads it —
+            // proof-corpus/run.sh and the proof_spec gating tests key on
+            // passed/universal/sorries) now that the gate scans for ANY model
+            // panic line, not just the fuel-exhaustion marker. `true` means
+            // the check FAILED with the compiler-model bug above regardless
+            // of budgets.
+            obj.insert("model_panicked".into(), (model_panic_hits > 0).into());
         }
         obj.insert("budget".into(), budget.into());
         obj.insert("passed".into(), passed.into());

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -5262,24 +5262,35 @@ const FUEL_PROBE_AV: &str = "module FuelProbe\n\
     \x20   stepSum(20) => stepSumAcc(20)\n";
 
 #[test]
-fn count_fuel_exhaustion_panics_matches_lake_panic_lines() {
-    // Unit check on the exact output shape the real toolchain produces (see
-    // the lake-gated test below, which pins this against a live build):
-    // lake prefixes the first panic with its info diagnostic, later panics
-    // print raw. Both carry the message; success lines don't.
+fn count_model_panic_lines_matches_lake_panic_lines() {
+    // Unit check on the exact output shapes the real toolchain produces (see
+    // the lake-gated tests below, which pin these against live builds):
+    // lake prefixes the first panic of a build step with its info
+    // diagnostic, later panics print raw. All carry `PANIC at `; success
+    // lines don't. The third line is a REAL captured non-fuel prelude panic
+    // (`Char.toCode` on an empty string) — same panic-returns-`default`
+    // vacuity vector, different message — which the original
+    // fuel-marker-only scan was blind to.
     let captured = "\u{2714} [2/4] Built AverCommon\n\
         \u{2139} [3/4] Built FuelProbe\n\
         info: ././././FuelProbe.lean:27:0: PANIC at stepSum__fuel FuelProbe:8:9: Aver proof fuel exhausted\n\
         PANIC at stepSumAcc__fuel FuelProbe:19:9: Aver proof fuel exhausted\n\
+        info: ././././PanicProbe.lean:11:0: PANIC at Char.toCode AverCommon:11:12: Char.toCode: string is empty\n\
         Build completed successfully.\n";
+    assert_eq!(aver::codegen::lean::count_model_panic_lines(captured), 3);
     assert_eq!(
-        aver::codegen::lean::count_fuel_exhaustion_panics(captured),
-        2
-    );
-    assert_eq!(
-        aver::codegen::lean::count_fuel_exhaustion_panics("Build completed successfully.\n"),
+        aver::codegen::lean::count_model_panic_lines("Build completed successfully.\n"),
         0
     );
+    // The widening is load-bearing: the old scan keyed on the fuel-wrapper
+    // message and counts only 2 of the 3 panic lines here — the
+    // `Char.toCode` panic slips through a marker-only gate (the #473 review
+    // gap this test family closes).
+    let old_marker_scan = captured
+        .lines()
+        .filter(|l| l.contains(aver::codegen::lean::PROOF_FUEL_EXHAUSTED_MSG))
+        .count();
+    assert_eq!(old_marker_scan, 2);
 }
 
 /// FIX A revert probe (no real `lake` needed — a PATH shim plays the
@@ -5353,9 +5364,9 @@ fn proof_check_charges_fuel_exhaustion_panic_as_hard_failure() {
         format_output(&run)
     );
     assert_eq!(
-        summary["fuel_exhausted"].as_bool(),
+        summary["model_panicked"].as_bool(),
         Some(true),
-        "--check-json must surface the fuel-exhaustion hit\n{}",
+        "--check-json must surface the model panic\n{}",
         format_output(&run)
     );
     assert_eq!(
@@ -5372,13 +5383,210 @@ fn proof_check_charges_fuel_exhaustion_panic_as_hard_failure() {
     );
     let stderr = String::from_utf8_lossy(&run.stderr);
     assert!(
-        stderr.contains("exhausted fuel") && stderr.contains("Aver bug"),
+        stderr.contains("model panicked") && stderr.contains("Aver bug"),
         "the failure must be reported as a compiler-model bug\n{}",
         format_output(&run)
     );
 
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&shim_dir);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+/// Shared probe source for the NON-fuel prelude-panic soundness tests: the
+/// model routes through the partial prelude builtin `Char.toCode`, and the
+/// second verify case drives it with an empty string. The VM REJECTS that
+/// case ("Char.toCode: string is empty" is a runtime error, the case fails,
+/// so no ground-truth literal is collected and the source RHS `0` is
+/// emitted), but the Lean model's `Char.toCode ""` PANICS and returns
+/// `default` (= 0 for Int) — `native_decide` kernel-certifies the vacuous
+/// `firstCode "" = 0` and lake exits 0. Exactly the fuel-exhaustion vector
+/// through a different `panic!` site; the fuel-marker-only scan from #473
+/// was blind to it.
+const CHAR_PANIC_PROBE_AV: &str = "module PanicProbe\n\
+    \x20   intent = \"non-fuel prelude panic probe\"\n\
+    \n\
+    fn firstCode(s: String) -> Int\n\
+    \x20   ? \"Unicode code of the first char.\"\n\
+    \x20   Char.toCode(s)\n\
+    \n\
+    verify firstCode\n\
+    \x20   firstCode(\"a\") => 97\n\
+    \x20   firstCode(\"\") => 0\n";
+
+/// Widening revert probe (no real `lake` needed — a PATH shim plays the
+/// false-green build with the REAL captured `Char.toCode` panic line): a
+/// non-fuel prelude panic shares the panic-returns-`default` vacuity vector,
+/// so `aver proof --check` must fail hard on it too. With the widening
+/// reverted (scan keyed on the fuel-exhaustion marker only) this scenario
+/// exits 0 / `passed: true` — the #473 review gap this test pins shut.
+#[cfg(unix)]
+#[test]
+fn proof_check_charges_non_fuel_prelude_panic_as_hard_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-panic-gate-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    let av = src.join("probe.av");
+    std::fs::write(&av, CHAR_PANIC_PROBE_AV).expect("write probe.av");
+
+    // PATH shim: a fake `lake` reproducing the captured false-green output —
+    // the real Char.toCode panic line shape + exit 0 (see the lake-gated
+    // test below for the live-toolchain capture of the same scenario).
+    let shim_dir = temp_output_dir("aver-panic-gate-shim");
+    std::fs::create_dir_all(&shim_dir).expect("create shim dir");
+    let shim = shim_dir.join("lake");
+    std::fs::write(
+        &shim,
+        "#!/bin/sh\n\
+         echo \"info: ././././PanicProbe.lean:11:0: PANIC at Char.toCode AverCommon:11:12: Char.toCode: string is empty\"\n\
+         echo \"Build completed successfully.\"\n\
+         exit 0\n",
+    )
+    .expect("write lake shim");
+    std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod lake shim");
+    let path_env = format!(
+        "{}:{}",
+        shim_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let out = temp_output_dir("aver-panic-gate-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(&av)
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .env("PATH", &path_env)
+        .output()
+        .expect("expected `aver proof --check` to run");
+
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "shim scenario must be sorry-free (that's what makes it a false green)\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["model_panicked"].as_bool(),
+        Some(true),
+        "--check-json must surface a NON-fuel model panic\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(false),
+        "a non-fuel prelude panic in lake output must fail the check — \
+         the kernel-certified sample equations are vacuous\n{}",
+        format_output(&run)
+    );
+    assert!(
+        !run.status.success(),
+        "`aver proof --check` must exit non-zero on a model panic\n{}",
+        format_output(&run)
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("model panicked") && stderr.contains("Aver bug"),
+        "the failure must be reported as a compiler-model bug\n{}",
+        format_output(&run)
+    );
+
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&shim_dir);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+/// Pins the non-fuel panic gate against the REAL toolchain (lake-gated), no
+/// shim and no post-edit: `aver proof --check` end-to-end on a crafted
+/// module whose emitted sample drives the model into `Char.toCode ""`. The
+/// VM rejects that case, but proof emission doesn't gate on verify outcomes
+/// — the source RHS goes out, lake kernel-certifies the vacuous equation
+/// and exits 0 (verified live: on pre-widening main this exact scenario
+/// reported `passed: true` with the old field `fuel_exhausted: false`).
+/// The widened gate must hard-fail it.
+#[test]
+fn proof_check_fails_on_real_char_tocode_panic_in_lake_build() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping non-fuel panic toolchain test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-panic-toolchain-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    let av = src.join("probe.av");
+    std::fs::write(&av, CHAR_PANIC_PROBE_AV).expect("write probe.av");
+
+    let out = temp_output_dir("aver-panic-toolchain-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(&av)
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check` to run");
+
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+
+    // The export must contain the vacuous sample (this is what makes the
+    // scenario real, not contrived post-editing).
+    let entry = std::fs::read_to_string(out.join("PanicProbe.lean")).expect("read emitted entry");
+    assert!(
+        entry.contains("example : firstCode \"\" = 0"),
+        "expected the empty-string sample in the export:\n{entry}"
+    );
+
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "the false green is sorry-free\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["model_panicked"].as_bool(),
+        Some(true),
+        "--check-json must surface the real Char.toCode panic\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(false),
+        "a real non-fuel prelude panic must fail the check\n{}",
+        format_output(&run)
+    );
+    assert!(
+        !run.status.success(),
+        "`aver proof --check` must exit non-zero on a model panic\n{}",
+        format_output(&run)
+    );
+
+    let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
 
@@ -5454,12 +5662,20 @@ fn lake_build_false_greens_on_forced_fuel_exhaustion_and_scan_catches_it() {
          (if this starts failing, Lean's panic semantics changed — re-evaluate \
          the gate):\n{captured}"
     );
-    // (b) The panic marker is in the captured output and the scan the
-    // `--check` harness uses counts it — the gate flips the verdict.
+    // (b) The panic line is in the captured output and the scan the
+    // `--check` harness uses counts it — the gate flips the verdict. Also
+    // pin that the line still carries the emitted fuel message: if the
+    // emission constant and the build output ever drift apart, this fails
+    // loudly here instead of silently downgrading the diagnostic.
     assert!(
-        aver::codegen::lean::count_fuel_exhaustion_panics(&captured) > 0,
+        aver::codegen::lean::count_model_panic_lines(&captured) > 0,
         "fuel-exhaustion panic line missing from lake output — the --check \
          gate would go blind:\n{captured}"
+    );
+    assert!(
+        captured.contains(aver::codegen::lean::PROOF_FUEL_EXHAUSTED_MSG),
+        "the emitted fuel-exhaustion message should appear verbatim in lake \
+         output:\n{captured}"
     );
 
     let _ = std::fs::remove_dir_all(&src);
@@ -5551,9 +5767,9 @@ fn proof_lean_verify_case_expected_side_is_literalized_from_vm_ground_truth() {
         format_output(&run)
     );
     assert_eq!(
-        summary["fuel_exhausted"].as_bool(),
+        summary["model_panicked"].as_bool(),
         Some(false),
-        "a healthy build must report no fuel exhaustion\n{}",
+        "a healthy build must report no model panic\n{}",
         format_output(&run)
     );
 


### PR DESCRIPTION
## Summary

Follow-up to #473 (its review flagged the gap): the gate scanned only the fuel-exhaustion message, but other emitted panic! sites share the identical panic-returns-default vacuity vector. **Demonstrated live on pre-change main**: a crafted module driving `Char.toCode("")` under `native_decide` kernel-certified a vacuous equation with a green check (`fuel_exhausted:false, passed:true`, exit 0) — proof emission does not gate on verify outcomes, so no shimming was needed.

- One generalized scan keyed on the Lean panic line shape (`PANIC at `), empirically pinned against real lake transcripts; `PROOF_FUEL_EXHAUSTED_MSG` survives only as the emission constant (drift-guard test included).
- `--check-json` field renamed `fuel_exhausted` → `model_panicked` (unreleased, zero consumers — rg over proof-corpus/tools/.github/docs); red message generalized; the #473 CHANGELOG line updated in place under 0.25.0.
- Rationale + accepted false-positive boundary documented on the scan fn (an echoed counterexample containing the marker on an already-red build can only turn a red redder, never a green red — reviewer reproduced and accepted).

## Validation

- Revert-tested both directions: narrowing the scan back to the fuel marker makes the new tests fail and reproduces the false green on the real-lake end-to-end test; the unit test permanently encodes the gap (old scan counts 2 of 3 real panic lines, new scan counts 3).
- `cargo test --workspace` green (75 suites, proof_spec 121); both clippy halves + fmt clean.
- Corpus spot-check (map/json/quicksort): summaries identical except the renamed field; exports **byte-identical** (scanner-only change); json sorries == 2.
- Adversarial review: **pass** (one optional doc minor, folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)