### PR TITLE
fix(verify): label law blocks as `law`, not `spec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 - **Bounded proof checks now compare against actual program results, and any model panic in a proof is a hard check error.** Lean exports pin each `verify` example and law sample to the value the program actually computed (instead of model-vs-model equations that could certify vacuously when the exported model panics and quietly evaluates to a default value — fuel exhaustion and partial builtins like `Char.toCode` on an empty string share that failure mode), and `aver proof --check` fails — with a please-report-this-bug message and a `model_panicked` field in `--check-json` — whenever the build output shows the model panicked while evaluating a sample.
 - **Tuple-carrying functions get correct termination fuel in Lean exports** — deeply nested values (e.g. JSON object entries) no longer make the exported model disagree with the running program.
 - **wasm-gc: `String.split`/`String.join` used inside string interpolation now compile correctly.**
+- **`aver verify` output labels `law` blocks as `law`** — they were printed as `<fn> spec <name>` (a relic of the pre-rename keyword) in both the block listing and failure diagnostics.
 - Example corpus honesty: laws that were really single-example checks (red-black tree, `order_total` floats, oracle-pinned file-store) are now plain `verify` blocks or trace checks.
 
 ## 0.24.1 — 2026-06-06

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -80,7 +80,10 @@ pub struct VerifyLawContext {
 
 pub struct VerifyResult {
     pub fn_name: String,
-    pub block_label: String, // "add" or "sort spec isSorted"
+    /// True for `verify ... law ...` blocks. Carried as a field so
+    /// consumers never derive law-ness from the rendered label string.
+    pub is_law: bool,
+    pub block_label: String, // "add" or "sort law isSorted"
     pub passed: usize,
     pub failed: usize,
     pub skipped: usize,

--- a/src/diagnostics/verify_run.rs
+++ b/src/diagnostics/verify_run.rs
@@ -108,7 +108,7 @@ fn map_results_to_diagnostics(
     let mut blocks = Vec::with_capacity(results.len());
 
     for result in results {
-        let is_law = result.block_label.contains(" spec ");
+        let is_law = result.is_law;
         let (declared_passed, declared_failed, hostile_passed, hostile_failed) =
             split_hostile_counts(&result.case_results);
         let skipped_by_when = result

--- a/src/diagnostics/vm_verify.rs
+++ b/src/diagnostics/vm_verify.rs
@@ -1838,11 +1838,12 @@ fn run_verify_vm(plan: &VmVerifyPlan, machine: &mut vm::VM) -> VerifyResult {
     }
 
     let block_label = match &block.kind {
-        VerifyKind::Law(law) => format!("{} spec {}", block.fn_name, law.name),
+        VerifyKind::Law(law) => format!("{} law {}", block.fn_name, law.name),
         VerifyKind::Cases => block.fn_name.clone(),
     };
     VerifyResult {
         fn_name: block.fn_name.clone(),
+        is_law: matches!(&block.kind, VerifyKind::Law(_)),
         block_label,
         passed,
         failed,

--- a/src/diagnostics/wasm_gc_verify.rs
+++ b/src/diagnostics/wasm_gc_verify.rs
@@ -605,6 +605,7 @@ fn run_verify_cases_in_wasmtime(
 
         results.push(VerifyResult {
             fn_name: plan.block.fn_name.clone(),
+            is_law: matches!(&plan.block.kind, crate::ast::VerifyKind::Law(_)),
             block_label: plan.block.fn_name.clone(),
             passed,
             failed,


### PR DESCRIPTION
## Summary

`aver verify` printed `<fn> spec <name>` for `verify ... law` blocks — in the block listing and in failure diagnostics — a relic of the pre-rename keyword (spotted by the user on a public screenshot, of course).

Besides the one-word label fix, this kills a miniature of the name-keying disease M0 removed from the prover: `verify_run.rs` derived law-ness via `block_label.contains(" spec ")`. `VerifyResult` now carries an explicit `is_law` field, set at both construction sites (VM runner and the feature-gated wasm-gc runner), so no consumer keys behavior on a rendered label string.

## Validation

- `aver verify` now prints `✗ myReverse law reverseKeepsFirst` (smoke-tested).
- No test pinned the old label shape (swept tests/, src/, docs/diagnostics-schema.md).
- `cargo test --workspace` green (75 suites); clippy clean in all three variants (workspace-excl-aver-lang, aver-lang lib/bin, and `--features wasm,wasip2`); fmt clean.
- CHANGELOG line under 0.25.0 Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)