### PR TITLE
proof: prove `when`-laws with equality premises universally (zip, insert, count)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
-## 0.25.0 (unreleased)
+## 0.25.0 (unreleased) — "The Method"
+
+The release where the prover learned to be steered by lemmas — named after the proof methodology of ACL2's Kaufmann & Moore, whose 30-year-old terrain this release kept rediscovering.
 
 ### Added
 
 - **The auto-prover closes far more laws on its own.** New strategies cover: laws whose givens range over finite domains (`Bool`, field-less enums), decimal render/parse roundtrips (the prover synthesizes the scanner lemmas it needs), laws that follow from built-in string/int facts (slicing, `Int.fromString`/`String.fromInt`), ground laws over fixed enum constructors, `Int.max`/`Int.min` arithmetic, general-key `Map` laws, and laws whose pipelines use `?`.
 - **Your proven laws now help prove your later laws.** A proved `verify ... law` becomes ammunition for the laws below it in the same file — decomposing a hard law into helper laws written in plain Aver is now a working proof strategy. An opt-in `aver proof --discover` mode additionally conjectures and kernel-proves helper lemmas automatically.
 - **Recursive functions over your own types prove termination structurally** — no more fuel wrappers blocking universal proofs for tree-shaped data, and mutual recursion (e.g. quicksort) gets genuine well-founded termination with auto-proved length lemmas.
-- **Conditional `when` laws over integer sign premises (`when n > 0` / `n < 0` / `n >= 0`) can now be proven universally** — genuinely, for every integer satisfying the premise, not just the sampled domain. `aver proof --check` reports the per-law count as `when_universal` in `--check-json` (details in `when_universal_laws.json`); the proofs live in a quarantined side build, so existing budgets and the bounded checks are untouched.
+- **Conditional `when` laws over integer sign premises (`when n > 0` / `n < 0` / `n >= 0`) and over equality premises on Peano-shaped naturals (length equality `when natEq(len(xs), len(ys))`, element equality `when eqNat(x, y)`, and their negations) can now be proven universally** — genuinely, for every input satisfying the premise, not just the sampled domain. `aver proof --check` reports the per-law count as `when_universal` in `--check-json` (details in `when_universal_laws.json`); the proofs live in a quarantined side build, so existing budgets and the bounded checks are untouched.
 
 ### Changed
 

--- a/proof-corpus/run.sh
+++ b/proof-corpus/run.sh
@@ -43,11 +43,17 @@ if [ ! -x "$AVER" ]; then
   exit 1
 fi
 
-# proves <file> <backend> -> "proved" | "open" (retry once to absorb flakiness).
-# The honest key differs per backend: Dafny -> "passed":true, Lean ->
-# "universal":true (see the metric note above).
+# proves <file> <backend> -> "proved <N>" | "open <N>" (retry once to absorb
+# flakiness). The honest key differs per backend: Dafny -> "passed":true,
+# Lean -> "universal":true (see the metric note above). The second word is the
+# ADDITIVE when-universal lane count (the numeric "when_universal" key — Lean
+# only, always 0 for Dafny): conditional `when`-laws whose quarantined twin
+# earned per-declaration kernel credit. It is reported SEPARATELY below and
+# deliberately does NOT feed the proved/open accounting — the headline
+# Lean-genuine metric keys on the file-level "universal":true exactly as
+# before (the numeric when_universal key cannot match that grep).
 proves() {
-  local f="$1" backend="$2" key attempt out json
+  local f="$1" backend="$2" key attempt out json wu=0
   case "$backend" in
     lean) key='"universal":true' ;;
     *)    key='"passed":true' ;;
@@ -62,15 +68,20 @@ proves() {
     fi
     json="$("$AVER" proof "$f" --backend "$backend" --check --check-json -o "$out" 2>/dev/null | grep '"passed"' | tail -1)"
     rm -rf "$out"
-    printf '%s' "$json" | grep -q "$key" && { echo proved; return; }
+    if [ "$backend" = lean ]; then
+      wu="$(printf '%s' "$json" | sed -n 's/.*"when_universal":\([0-9][0-9]*\).*/\1/p')"
+      wu="${wu:-0}"
+    fi
+    printf '%s' "$json" | grep -q "$key" && { echo "proved $wu"; return; }
   done
-  echo open
+  echo "open $wu"
 }
 
 lean=0
 dafny=0
 union=0
 total=0
+when_universal=0
 # `decomposed/` holds LLM helper-law-augmented copies of OPEN tip/ tasks (a
 # SEPARATE "loop reach" metric, see decomposed/README.md). Excluded here so the
 # baseline `coverage (union)` stays "what the engine proves UNAIDED on bare
@@ -78,8 +89,11 @@ total=0
 for f in $(find "$ROOT" -name '*.av' -not -path '*/decomposed/*' | sort); do
   [ -e "$f" ] || continue
   total=$((total + 1))
-  l=$(proves "$f" lean)
-  d=$(proves "$f" dafny)
+  lres=$(proves "$f" lean)
+  l="${lres%% *}"
+  lw="${lres##* }"
+  dres=$(proves "$f" dafny)
+  d="${dres%% *}"
   [ "$l" = proved ] && lean=$((lean + 1))
   [ "$d" = proved ] && dafny=$((dafny + 1))
   if [ "$l" = proved ] || [ "$d" = proved ]; then
@@ -89,7 +103,16 @@ for f in $(find "$ROOT" -name '*.av' -not -path '*/decomposed/*' | sort); do
     [ "$d" = open ] && tag="lean-only"
     printf '  proved  [%-10s] %s\n' "$tag" "${f#"$ROOT"/}"
   fi
+  # ADDITIVE when-universal lane: per-law kernel-credited conditional laws.
+  # Reported separately and never folded into the proved/open numbers above —
+  # a when-law file stays "open" on the headline metric even when its lane
+  # twin closes (the file-level universal flag keeps counted-build semantics).
+  if [ "${lw:-0}" -gt 0 ] 2>/dev/null; then
+    when_universal=$((when_universal + lw))
+    printf '  when-lane [universal ] %s (%s conditional law(s))\n' "${f#"$ROOT"/}" "$lw"
+  fi
 done
 
 echo ""
 echo "coverage (union): ${union} / ${total}   |   lean: ${lean}   dafny: ${dafny}"
+echo "when-universal lane (additive, NOT in the numbers above): ${when_universal} conditional law(s)"

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -5315,4 +5315,114 @@ verify weird law weirdSpec
             super::universal_lane::generate(&ctx, "entry-content-seed", Some("noSuchLaw"));
         assert_eq!(unmatched[0].module, law.module);
     }
+
+    /// When-universal quarantine lane, bridge-premise family, render
+    /// level (no lake): the fresh-named fixture's two bridge-shaped
+    /// when-laws (zip-rev under length equality, count-insert under a
+    /// negated equality) each get exactly one lane twin in the TRUE
+    /// universal form, with zero `sorry` tokens, the `universal`
+    /// law-class marker, and the probe-proven proof kit (use-side
+    /// inversion bridge, reintroduction bridge, snoc-distribution aux
+    /// lemma — never a sorry). The sabotage hook stays per-law.
+    #[test]
+    fn universal_lane_renders_bridge_premise_twins() {
+        let src = include_str!("../../../tests/fixtures/when_lane_bridge.av");
+        let ctx = ctx_from_source(src, "BridgeLane");
+        let lane = super::universal_lane::generate(&ctx, "entry-content-seed", None);
+        let mut labels: Vec<&str> = lane.iter().map(|l| l.label.as_str()).collect();
+        labels.sort_unstable();
+        assert_eq!(
+            labels,
+            vec!["duoUp.duoFlip", "tallyUp.tallyWedgeNeq"],
+            "exactly the two bridge-premise figures are recognized (exact in both directions)"
+        );
+        let zip = lane.iter().find(|l| l.label == "duoUp.duoFlip").unwrap();
+        assert_eq!(zip.theorem, "duoUp_law_duoFlip_universal");
+        // L2 of the iron guard: no sorry carrier — in particular the
+        // snoc-distribution aux lemma is a rendered template, not a hole.
+        assert!(!zip.content.contains("sorry"));
+        assert!(
+            zip.content
+                .contains("private theorem duoUp_law_duoFlip_universal_snoc")
+        );
+        // The four probe mechanics are all present: use-side bridge,
+        // reintroduction bridge, premise stepping, vacuous discharge.
+        assert!(
+            zip.content
+                .contains("duoUp_law_duoFlip_universal_bridge_eq")
+        );
+        assert!(
+            zip.content
+                .contains("duoUp_law_duoFlip_universal_bridge_refl")
+        );
+        // M0 marker + TRUE universal statement (when kept, domains gone).
+        assert!(
+            zip.content
+                .contains("-- aver:law-class duoUp_law_duoFlip_universal universal")
+        );
+        assert!(
+            zip.content
+                .contains("likeNat (bulk xs) (bulk ys) = true ->")
+        );
+        assert!(!zip.content.contains("xs = [] ∨"));
+        let tally = lane
+            .iter()
+            .find(|l| l.label == "tallyUp.tallyWedgeNeq")
+            .unwrap();
+        assert!(!tally.content.contains("sorry"));
+        assert!(tally.content.contains("unlikeNat p q = true ->"));
+        // Sabotage stays per-law: only the matching module changes.
+        let sabotaged =
+            super::universal_lane::generate(&ctx, "entry-content-seed", Some("duoFlip"));
+        let zip_sab = sabotaged
+            .iter()
+            .find(|l| l.label == "duoUp.duoFlip")
+            .unwrap();
+        assert!(zip_sab.content.contains("averLaneSabotageInjectedByTest"));
+        assert_ne!(zip_sab.module, zip.module);
+        let tally_sab = sabotaged
+            .iter()
+            .find(|l| l.label == "tallyUp.tallyWedgeNeq")
+            .unwrap();
+        assert_eq!(tally_sab.module, tally.module);
+    }
+
+    /// ACL2 free-variables gate: a bridge premise whose variable is NOT
+    /// bound by the law's lhs (here `q` appears only in the rhs) makes
+    /// conditional rewriting guess — the lane must DECLINE, even though
+    /// every participating fn shape would otherwise match the
+    /// neq-count-insert figure.
+    #[test]
+    fn universal_lane_declines_free_variable_premise() {
+        let src = include_str!("../../../tests/fixtures/when_lane_bridge.av");
+        // Swap the count-insert law's sides: lhs `tallyUp(p, ws)` no
+        // longer binds the premise variable `q`.
+        let swapped = src.replace(
+            "    tallyUp(p, wedge(q, ws)) => tallyUp(p, ws)",
+            "    tallyUp(p, ws) => tallyUp(p, wedge(q, ws))",
+        );
+        assert_ne!(swapped, src);
+        let ctx = ctx_from_source(&swapped, "BridgeLane");
+        let lane = super::universal_lane::generate(&ctx, "entry-content-seed", None);
+        assert!(
+            lane.iter().all(|l| l.label != "tallyUp.tallyWedgeNeq"),
+            "premise variable q unbound by the lhs must decline the law"
+        );
+    }
+
+    /// Non-recognized boolRel: a premise over a recursive Bool fn that
+    /// does NOT mirror Prop equality (here the `rankLe` ≤-shape) is not
+    /// a bridge — the lane must decline the law.
+    #[test]
+    fn universal_lane_declines_non_bridge_predicate() {
+        let src = include_str!("../../../tests/fixtures/when_lane_bridge.av");
+        let lessy = src.replace("    when unlikeNat(p, q)", "    when rankLe(p, q)");
+        assert_ne!(lessy, src);
+        let ctx = ctx_from_source(&lessy, "BridgeLane");
+        let lane = super::universal_lane::generate(&ctx, "entry-content-seed", None);
+        assert!(
+            lane.iter().all(|l| l.label != "tallyUp.tallyWedgeNeq"),
+            "a non-equality recursive Bool premise (≤-shape) must decline the law"
+        );
+    }
 }

--- a/src/codegen/lean/universal_lane.rs
+++ b/src/codegen/lean/universal_lane.rs
@@ -29,22 +29,44 @@
 //!   content-hashed so a stale `.olean` can never masquerade as a
 //!   fresh success.
 //!
-//! The v1 prover content is the scalar-sign family: the law's `when`
-//! is a sign guard (`n > 0` / `n < 0` / `n >= 0`) on a single Int
-//! given, and the LHS enters the SAME canonical decimal parser
-//! pipeline an `IntDecimalRoundtrip` pin (#470) already certified for
-//! the file — the lane proof is a segment/polarity parameterization
-//! of that skeleton (`law_auto/decimal.rs`), with the premise
-//! consumed ONCE at the existing `rcases` sign split. Exactly the
-//! five empirically validated (kernel-clean on the emitted json
-//! project, Lean 4.15) entry-segment × polarity combinations are
-//! recognized; everything else declines at zero cost:
+//! The prover content comes in two recognized families:
+//!
+//! FAMILY 1 — scalar-sign: the law's `when` is a sign guard (`n > 0` /
+//! `n < 0` / `n >= 0`) on a single Int given, and the LHS enters the
+//! SAME canonical decimal parser pipeline an `IntDecimalRoundtrip`
+//! pin (#470) already certified for the file — the lane proof is a
+//! segment/polarity parameterization of that skeleton
+//! (`law_auto/decimal.rs`), with the premise consumed ONCE at the
+//! existing `rcases` sign split. Exactly the five empirically
+//! validated (kernel-clean on the emitted json project, Lean 4.15)
+//! entry-segment × polarity combinations are recognized; everything
+//! else declines at zero cost:
 //! - digit-dispatch wrapper entry, `when n >= 0` (dispatchNumberOrErr)
 //! - `pos_fn` entry, `when n > 0` (startNumberDigits)
 //! - `neg_fn` entry, `when n < 0` (parseNumberSign)
 //! - `sign_fn` entry, `when n < 0` (startSignDigit)
 //! - scanner entry with pinned `n == 0` Bool arg, `when n >= 0`
 //!   (scanIntTail)
+//!
+//! FAMILY 2 — bridge-shaped premise: the `when` is `boolRel(a, b) =
+//! true` where `boolRel` is a recursive Bool fn mirroring a Prop
+//! relation — concretely a canonical Peano structural equality
+//! (`natEq`-shape, lifted to builtin `Nat`), possibly negated through
+//! `Bool.not` or a 2-arm not-wrapper fn. The probe-proven mechanics
+//! (TIP prop_85 hand proof, kernel-genuine `[propext, Quot.sound]`):
+//! (1) a use-side Bool→Prop inversion bridge `(natEq a b = true) → a
+//! = b`; (2) a REINTRODUCTION bridge `natEq a a = true` (without it
+//! the emitter cannot instantiate its own induction hypothesis);
+//! (3) per-step premise stepping (`simp only [measure-fns] at h` +
+//! `omega`, re-bridged for the structurally smaller call); (4) for
+//! the zip-rev figure, a snoc-distribution aux lemma (zip over
+//! append-singleton under length equality) emitted as a lane-local
+//! lemma from the validated template — never as a sorry. Exactly the
+//! hand-validated figures are recognized (see [`BridgePlan`]);
+//! everything else declines. An ACL2-style free-variables gate
+//! additionally requires vars(when) ⊆ vars(lhs) — a premise variable
+//! unbound by the conclusion's match side would make conditional
+//! rewriting guess, so such laws decline instead.
 //!
 //! Paid-for landmines from the hand-proof probe, baked into the
 //! rendered tactic text:
@@ -69,7 +91,9 @@
 //! retires a stale index. Neither can grant credit, only withhold it.
 
 use super::expr::{aver_name_to_lean, emit_expr_legacy};
-use crate::ast::{BinOp, Expr, Literal, Pattern, Spanned, Stmt, TopLevel, VerifyBlock, VerifyLaw};
+use crate::ast::{
+    BinOp, Expr, FnDef, Literal, Pattern, Spanned, Stmt, TopLevel, VerifyBlock, VerifyLaw,
+};
 use crate::codegen::CodegenContext;
 
 /// Subdirectory (relative to the proof output dir) holding lane
@@ -197,9 +221,6 @@ pub fn generate(
     sabotage: Option<&str>,
 ) -> Vec<LaneLawFile> {
     let pins = collect_pins(ctx);
-    if pins.is_empty() {
-        return Vec::new();
-    }
     let entry_root = crate::codegen::common::entry_basename(ctx);
     let mut out = Vec::new();
     for item in &ctx.items {
@@ -207,13 +228,14 @@ pub fn generate(
         let crate::ast::VerifyKind::Law(law) = &vb.kind else {
             continue;
         };
+        let sabotage_this = sabotage
+            .is_some_and(|s| format!("{}.{}", vb.fn_name, law.name).contains(s) && !s.is_empty());
+        // Family 1: scalar-sign over an IntDecimalRoundtrip pin.
+        let mut rendered = false;
         for pin in &pins {
             let Some(plan) = classify_lane_law(vb, law, ctx, pin) else {
                 continue;
             };
-            let sabotage_this = sabotage.is_some_and(|s| {
-                format!("{}.{}", vb.fn_name, law.name).contains(s) && !s.is_empty()
-            });
             if let Some(file) = render_lane_law(
                 vb,
                 law,
@@ -225,8 +247,27 @@ pub fn generate(
                 sabotage_this,
             ) {
                 out.push(file);
+                rendered = true;
             }
             break; // first matching pin wins
+        }
+        if rendered {
+            continue;
+        }
+        // Family 2: bridge-shaped premise (recursive Bool equality
+        // bridge over a canonical Peano type).
+        if let Some(plan) = classify_bridge_law(vb, law, ctx)
+            && let Some(file) = render_bridge_law(
+                vb,
+                law,
+                ctx,
+                &plan,
+                &entry_root,
+                entry_content,
+                sabotage_this,
+            )
+        {
+            out.push(file);
         }
     }
     out
@@ -535,6 +576,25 @@ fn fnv1a64(bytes: &[u8]) -> u64 {
         h = h.wrapping_mul(0x100000001b3);
     }
     h
+}
+
+/// Content-hashed lane module name (`U_<theorem-base>_<hash>`): the
+/// hash covers the module's own content AND the manifest entry file,
+/// so a stale `.olean` under an old name is unreachable after any
+/// change to either. Shared by both lane families.
+fn lane_module_id(theorem_base: &str, content: &str, entry_content: &str) -> String {
+    let hash = fnv1a64(content.as_bytes()) ^ fnv1a64(entry_content.as_bytes()).rotate_left(1);
+    let sanitized: String = theorem_base
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("U_{sanitized}_{:08x}", (hash & 0xffff_ffff) as u32)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -931,19 +991,1364 @@ rw [harm]
         "universal-lane module must not contain a sorry token"
     );
 
-    let hash = fnv1a64(content.as_bytes()) ^ fnv1a64(entry_content.as_bytes()).rotate_left(1);
-    let sanitized: String = theorem_base
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let module = format!("U_{sanitized}_{:08x}", (hash & 0xffff_ffff) as u32);
+    let module = lane_module_id(&theorem_base, &content, entry_content);
 
+    Some(LaneLawFile {
+        label: format!("{}.{}", vb.fn_name, law.name),
+        theorem,
+        module,
+        content,
+    })
+}
+
+// ===================== FAMILY 2: bridge-shaped premises ============
+//
+// `when boolRel(a, b)` where boolRel mirrors Prop equality on a
+// canonical Peano type (lifted to builtin Nat). All proof text below
+// is a verbatim parameterization of scripts hand-validated kernel-
+// genuine on the emitted Lean 4.15 projects of TIP prop_85 (zip-rev
+// under length equality, [propext, Quot.sound]), prop_46/47,
+// lemma_19/21 and prop_76. User fns are referenced as `_root_.<fn>`
+// inside simp sets: emitted defs live at the root namespace, and a
+// bare name there can resolve against a colliding core export
+// (e.g. `insert` → `Insert.insert`), which fails with "proposition
+// expected" — paid-for landmine from the hand validation.
+
+/// How a negated bridge premise reaches the equality fn.
+enum BridgeNeg {
+    /// `when Bool.not(eq(a, b))` — rendered `(!eq a b) = true`.
+    BoolNot,
+    /// `when w(a, b)` where `w` is the 2-arm not-wrapper
+    /// `match eq(a, b) { true -> false, false -> true }`.
+    Wrapper(String),
+}
+
+/// The hand-validated bridge-premise figures. Source fn names only;
+/// the renderer converts to Lean names. Anything outside these exact
+/// constellations declines at zero cost.
+enum BridgePlan {
+    /// TIP prop_85: `when eq(len(xs), len(ys))`,
+    /// `zip(rev(xs), rev(ys)) = revPair(zip(xs, ys))`. Needs the full
+    /// probe kit: both bridges, measure lemmas over append/rev, a
+    /// premise-driven shape inversion of the non-induction variable,
+    /// and the snoc-distribution aux lemma.
+    ZipRevLenEq {
+        eq_fn: String,
+        len_fn: String,
+        zip_fn: String,
+        rev_fn: String,
+        rev_pair_fn: String,
+        append_fn: String,
+        append_pair_fn: String,
+        /// Rendered Lean element type of the two list givens (`Int`).
+        elem_ty: String,
+        /// The two list givens, in quantifier order (xs = induction target).
+        xs: String,
+        ys: String,
+    },
+    /// TIP prop_46: `when eq(x, y)`, `elem(x, insert(y, z)) = true`.
+    /// Bridge + subst, then list induction with the REINTRODUCTION
+    /// bridge discharging the `eq x x` dispatch.
+    EqElemInsert {
+        eq_fn: String,
+        elem_fn: String,
+        or_fn: String,
+        insert_fn: String,
+        x: String,
+        y: String,
+        z: String,
+    },
+    /// TIP prop_47 / lemma_19: `when neq(x, y)`,
+    /// `elem(x, insert(y, z)) = elem(x, z)`.
+    NeqElemInsert {
+        eq_fn: String,
+        neg: BridgeNeg,
+        elem_fn: String,
+        or_fn: String,
+        insert_fn: String,
+        x: String,
+        y: String,
+        z: String,
+    },
+    /// TIP lemma_21: `when neq(x, y)`,
+    /// `count(x, insert(y, z)) = count(x, z)`.
+    NeqCountInsert {
+        eq_fn: String,
+        neg: BridgeNeg,
+        count_fn: String,
+        insert_fn: String,
+        x: String,
+        y: String,
+        z: String,
+    },
+    /// TIP prop_76: `when Bool.not(eq(n, m))`,
+    /// `count(n, List.concat(xs, [m])) = count(n, xs)`.
+    NeqCountAppendSingleton {
+        eq_fn: String,
+        neg: BridgeNeg,
+        count_fn: String,
+        n: String,
+        m: String,
+        xs: String,
+    },
+}
+
+/// Internal binder names of the insert/count figure templates — a
+/// colliding given would be shadowed mid-proof, so such laws decline.
+const BRIDGE_RESERVED_INSERT: &[&str] = &["c", "cs", "ih", "hc", "heq", "h_when"];
+
+/// Internal binder names of the zip-rev MAIN theorem template (the
+/// support lemmas are closed terms — their binders cannot collide).
+const BRIDGE_RESERVED_ZIPREV: &[&str] = &[
+    "z", "x2", "y", "x4", "h", "hh", "h0", "hy", "hlen", "hrevlen", "hih", "h_when",
+];
+
+fn as_bool_lit(e: &Spanned<Expr>) -> Option<bool> {
+    match &e.node {
+        Expr::Literal(Literal::Bool(b)) => Some(*b),
+        _ => None,
+    }
+}
+
+/// `List<elem>` annotation check, whitespace-insensitive.
+fn is_list_of(list_ann: &str, elem_ann: &str) -> bool {
+    let squash = |s: &str| s.chars().filter(|c| !c.is_whitespace()).collect::<String>();
+    squash(list_ann) == format!("List<{}>", squash(elem_ann))
+}
+
+/// Split `match <ident> { Base -> e1, Succ(b) -> e2 }` over `peano`
+/// into (subject ident, base body, succ binder, succ body).
+fn peano_match_split<'a>(
+    e: &'a Spanned<Expr>,
+    peano: &crate::codegen::proof_recognize::PeanoType,
+) -> Option<(&'a str, &'a Spanned<Expr>, &'a str, &'a Spanned<Expr>)> {
+    let Expr::Match { subject, arms } = &e.node else {
+        return None;
+    };
+    let subj = ident_of(subject)?;
+    if arms.len() != 2 {
+        return None;
+    }
+    let mut base = None;
+    let mut succ = None;
+    for arm in arms {
+        let Pattern::Constructor(name, binders) = &arm.pattern else {
+            return None;
+        };
+        let short = crate::codegen::proof_recognize::short_ctor(name);
+        if short == peano.base_ctor && binders.is_empty() {
+            base = Some(&arm.body);
+        } else if short == peano.succ_ctor && binders.len() == 1 {
+            succ = Some((binders[0].as_str(), &arm.body));
+        } else {
+            return None;
+        }
+    }
+    let (q, sb) = succ?;
+    Some((subj, base?, q, sb))
+}
+
+/// (subject ident, nil body, head binder, tail binder, cons body) —
+/// the result of [`list_match_split`].
+type ListMatchSplit<'a> = (
+    &'a str,
+    &'a Spanned<Expr>,
+    &'a str,
+    &'a str,
+    &'a Spanned<Expr>,
+);
+
+/// Split `match <ident> { [] -> e1, [h, ..t] -> e2 }` into
+/// (subject ident, nil body, head binder, tail binder, cons body).
+fn list_match_split(e: &Spanned<Expr>) -> Option<ListMatchSplit<'_>> {
+    let Expr::Match { subject, arms } = &e.node else {
+        return None;
+    };
+    let subj = ident_of(subject)?;
+    if arms.len() != 2 {
+        return None;
+    }
+    let mut nil = None;
+    let mut cons = None;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::EmptyList => nil = Some(&arm.body),
+            Pattern::Cons(h, t) => cons = Some((h.as_str(), t.as_str(), &arm.body)),
+            _ => return None,
+        }
+    }
+    let (h, t, cb) = cons?;
+    Some((subj, nil?, h, t, cb))
+}
+
+/// The base (`Nat.Z`) constructor of `peano` as a payload-free
+/// expression — covers both `Constructor` and `Attr` parses.
+fn is_peano_base(e: &Spanned<Expr>, peano: &crate::codegen::proof_recognize::PeanoType) -> bool {
+    if let Some((name, args)) = ctor_of(e) {
+        return crate::codegen::proof_recognize::short_ctor(&name) == peano.base_ctor
+            && args.is_empty();
+    }
+    if let Expr::Attr(base, leaf) = &e.node {
+        return ident_of(base) == Some(peano.type_name.as_str()) && *leaf == peano.base_ctor;
+    }
+    false
+}
+
+/// `Succ(inner)` of `peano` — returns the payload expression.
+fn peano_succ_of<'a>(
+    e: &'a Spanned<Expr>,
+    peano: &crate::codegen::proof_recognize::PeanoType,
+) -> Option<&'a Spanned<Expr>> {
+    let (name, args) = ctor_of(e)?;
+    (crate::codegen::proof_recognize::short_ctor(&name) == peano.succ_ctor && args.len() == 1)
+        .then(|| args[0])
+}
+
+/// `[<ident>]` — a singleton list literal of exactly one identifier.
+fn is_singleton_list_of_ident(e: &Spanned<Expr>, name: &str) -> bool {
+    matches!(&e.node, Expr::List(items)
+        if items.len() == 1 && ident_of(&items[0]) == Some(name))
+}
+
+/// Canonical Peano structural equality (`natEq`-shape): a pure binary
+/// Bool fn on a canonical Peano type whose body mirrors `=` exactly —
+/// `match a { Z -> match b { Z -> true, S _ -> false },
+///            S x -> match b { Z -> false, S y -> rec(x, y) } }`.
+/// The Peano type must be spelled `Nat`: the lift renders constructors
+/// as `0` / `+ 1` while signatures keep the source type name, so only
+/// the builtin spelling elaborates — and only that emission shape was
+/// hand-validated.
+fn is_peano_eq_fn(fd: &FnDef, ctx: &CodegenContext) -> bool {
+    if fd.params.len() != 2 || fd.return_type.trim() != "Bool" || !fd.effects.is_empty() {
+        return false;
+    }
+    let (p0, t0) = &fd.params[0];
+    let (p1, t1) = &fd.params[1];
+    if t0 != t1 {
+        return false;
+    }
+    let Some(peano) = crate::codegen::proof_recognize::peano_type_named(ctx, t0.trim()) else {
+        return false;
+    };
+    if peano.type_name.trim() != "Nat" {
+        return false;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    let Some((subj, base_body, q, succ_body)) = peano_match_split(body, &peano) else {
+        return false;
+    };
+    if subj != p0.as_str() {
+        return false;
+    }
+    // Z arm: match b { Z -> true, S _ -> false }.
+    let Some((s2, b2, _, sb2)) = peano_match_split(base_body, &peano) else {
+        return false;
+    };
+    if s2 != p1.as_str() || as_bool_lit(b2) != Some(true) || as_bool_lit(sb2) != Some(false) {
+        return false;
+    }
+    // S(q) arm: match b { Z -> false, S(r) -> rec(q, r) }.
+    let Some((s3, b3, r, sb3)) = peano_match_split(succ_body, &peano) else {
+        return false;
+    };
+    if s3 != p1.as_str() || as_bool_lit(b3) != Some(false) {
+        return false;
+    }
+    call_of(sb3).is_some_and(|(rc, ra)| {
+        rc == fd.name && ra.len() == 2 && ident_of(&ra[0]) == Some(q) && ident_of(&ra[1]) == Some(r)
+    })
+}
+
+/// 2-arm not-wrapper over a recognized Peano equality:
+/// `match eq(p0, p1) { true -> false, false -> true }`. Returns the
+/// wrapped equality fn's name.
+fn neg_eq_wrapper(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
+    if fd.params.len() != 2 || fd.return_type.trim() != "Bool" || !fd.effects.is_empty() {
+        return None;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return None;
+    };
+    let (eq_name, eq_args) = call_of(subject)?;
+    let eq_fd = ctx.fn_def_by_name(&eq_name, None)?;
+    if !is_peano_eq_fn(eq_fd, ctx)
+        || eq_args.len() != 2
+        || ident_of(&eq_args[0]) != Some(fd.params[0].0.as_str())
+        || ident_of(&eq_args[1]) != Some(fd.params[1].0.as_str())
+        || arms.len() != 2
+    {
+        return None;
+    }
+    let mut t_to_f = false;
+    let mut f_to_t = false;
+    for arm in arms {
+        match (&arm.pattern, as_bool_lit(&arm.body)) {
+            (Pattern::Literal(Literal::Bool(true)), Some(false)) => t_to_f = true,
+            (Pattern::Literal(Literal::Bool(false)), Some(true)) => f_to_t = true,
+            _ => return None,
+        }
+    }
+    (t_to_f && f_to_t).then_some(eq_name)
+}
+
+/// 2-arm Bool-or wrapper (`barbar`-shape):
+/// `match p0 { true -> true, false -> p1 }`.
+fn is_bool_or_wrapper(fd: &FnDef) -> bool {
+    if fd.params.len() != 2
+        || fd.return_type.trim() != "Bool"
+        || !fd.effects.is_empty()
+        || fd.params[0].1.trim() != "Bool"
+        || fd.params[1].1.trim() != "Bool"
+    {
+        return false;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return false;
+    };
+    if ident_of(subject) != Some(fd.params[0].0.as_str()) || arms.len() != 2 {
+        return false;
+    }
+    let mut ok_t = false;
+    let mut ok_f = false;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::Literal(Literal::Bool(true)) => ok_t = as_bool_lit(&arm.body) == Some(true),
+            Pattern::Literal(Literal::Bool(false)) => {
+                ok_f = ident_of(&arm.body) == Some(fd.params[1].0.as_str())
+            }
+            _ => return false,
+        }
+    }
+    ok_t && ok_f
+}
+
+/// `elem`-shape: `fn (k: Nat, l: List<Nat>) -> Bool` with body
+/// `match l { [] -> false, [z, ..xs] -> or(eq(k, z), rec(k, xs)) }`.
+/// Returns the or-wrapper fn's name.
+fn elem_shape(fd: &FnDef, ctx: &CodegenContext, eq_fn: &str) -> Option<String> {
+    if fd.params.len() != 2 || fd.return_type.trim() != "Bool" || !fd.effects.is_empty() {
+        return None;
+    }
+    let k = fd.params[0].0.as_str();
+    if !is_list_of(&fd.params[1].1, &fd.params[0].1) {
+        return None;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let (subj, nil_body, hd, tl, cons_body) = list_match_split(body)?;
+    if subj != fd.params[1].0.as_str() || as_bool_lit(nil_body) != Some(false) {
+        return None;
+    }
+    let (or_name, or_args) = call_of(cons_body)?;
+    if or_args.len() != 2 {
+        return None;
+    }
+    let (c1, a1) = call_of(&or_args[0])?;
+    if c1 != eq_fn || a1.len() != 2 || ident_of(&a1[0]) != Some(k) || ident_of(&a1[1]) != Some(hd) {
+        return None;
+    }
+    let (c2, a2) = call_of(&or_args[1])?;
+    if c2 != fd.name || a2.len() != 2 || ident_of(&a2[0]) != Some(k) || ident_of(&a2[1]) != Some(tl)
+    {
+        return None;
+    }
+    let or_fd = ctx.fn_def_by_name(&or_name, None)?;
+    is_bool_or_wrapper(or_fd).then_some(or_name)
+}
+
+/// `count`-shape: `fn (k: Nat, l: List<Nat>) -> Nat` with body
+/// `match l { [] -> Z, [z, ..ys] -> match eq(k, z)
+///   { true -> S(rec(k, ys)), false -> rec(k, ys) } }`.
+fn count_shape(fd: &FnDef, ctx: &CodegenContext, eq_fn: &str) -> bool {
+    if fd.params.len() != 2 || !fd.effects.is_empty() {
+        return false;
+    }
+    let (k, kt) = (&fd.params[0].0, &fd.params[0].1);
+    let Some(peano) = crate::codegen::proof_recognize::peano_type_named(ctx, kt.trim()) else {
+        return false;
+    };
+    if fd.return_type.trim() != peano.type_name || !is_list_of(&fd.params[1].1, kt) {
+        return false;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    let Some((subj, nil_body, hd, tl, cons_body)) = list_match_split(body) else {
+        return false;
+    };
+    if subj != fd.params[1].0.as_str() || !is_peano_base(nil_body, &peano) {
+        return false;
+    }
+    let Expr::Match { subject, arms } = &cons_body.node else {
+        return false;
+    };
+    let dispatch_ok = call_of(subject).is_some_and(|(c, a)| {
+        c == eq_fn && a.len() == 2 && ident_of(&a[0]) == Some(k) && ident_of(&a[1]) == Some(hd)
+    });
+    if !dispatch_ok || arms.len() != 2 {
+        return false;
+    }
+    let rec_ok = |e: &Spanned<Expr>| {
+        call_of(e).is_some_and(|(rc, ra)| {
+            rc == fd.name
+                && ra.len() == 2
+                && ident_of(&ra[0]) == Some(k.as_str())
+                && ident_of(&ra[1]) == Some(tl)
+        })
+    };
+    let mut ok_t = false;
+    let mut ok_f = false;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::Literal(Literal::Bool(true)) => {
+                ok_t = peano_succ_of(&arm.body, &peano).is_some_and(rec_ok)
+            }
+            Pattern::Literal(Literal::Bool(false)) => ok_f = rec_ok(&arm.body),
+            _ => return false,
+        }
+    }
+    ok_t && ok_f
+}
+
+/// `insert`-shape: `fn (k: Nat, l: List<Nat>) -> List<Nat>` with body
+/// `match l { [] -> [k], [z, ..xs] -> match le(k, z)
+///   { true -> List.concat([k], l), false -> List.concat([z], rec(k, xs)) } }`
+/// for SOME pure binary Bool dispatch `le` — the templates split on
+/// the dispatch without consuming its meaning, so its shape is free.
+fn insert_shape(fd: &FnDef, ctx: &CodegenContext) -> bool {
+    if fd.params.len() != 2 || !fd.effects.is_empty() {
+        return false;
+    }
+    let (k, kt) = (&fd.params[0].0, &fd.params[0].1);
+    if crate::codegen::proof_recognize::peano_type_named(ctx, kt.trim()).is_none()
+        || !is_list_of(&fd.params[1].1, kt)
+        || !is_list_of(&fd.return_type, kt)
+    {
+        return false;
+    }
+    let l = fd.params[1].0.as_str();
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    let Some((subj, nil_body, hd, tl, cons_body)) = list_match_split(body) else {
+        return false;
+    };
+    if subj != l || !is_singleton_list_of_ident(nil_body, k) {
+        return false;
+    }
+    let Expr::Match { subject, arms } = &cons_body.node else {
+        return false;
+    };
+    let dispatch_ok = call_of(subject).is_some_and(|(c, a)| {
+        a.len() == 2
+            && ident_of(&a[0]) == Some(k.as_str())
+            && ident_of(&a[1]) == Some(hd)
+            && ctx.fn_def_by_name(&c, None).is_some_and(|le| {
+                le.params.len() == 2 && le.return_type.trim() == "Bool" && le.effects.is_empty()
+            })
+    });
+    if !dispatch_ok || arms.len() != 2 {
+        return false;
+    }
+    fn concat_of(e: &Spanned<Expr>) -> Option<(&Spanned<Expr>, &Spanned<Expr>)> {
+        let (c, a) = call_of(e)?;
+        (c == "List.concat" && a.len() == 2).then(|| (&a[0], &a[1]))
+    }
+    let mut ok_t = false;
+    let mut ok_f = false;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::Literal(Literal::Bool(true)) => {
+                ok_t = concat_of(&arm.body).is_some_and(|(h, t)| {
+                    is_singleton_list_of_ident(h, k) && ident_of(t) == Some(l)
+                })
+            }
+            Pattern::Literal(Literal::Bool(false)) => {
+                ok_f = concat_of(&arm.body).is_some_and(|(h, t)| {
+                    is_singleton_list_of_ident(h, hd)
+                        && call_of(t).is_some_and(|(rc, ra)| {
+                            rc == fd.name
+                                && ra.len() == 2
+                                && ident_of(&ra[0]) == Some(k.as_str())
+                                && ident_of(&ra[1]) == Some(tl)
+                        })
+                })
+            }
+            _ => return false,
+        }
+    }
+    ok_t && ok_f
+}
+
+/// `len`-shape measure: `fn (xs: List<T>) -> Nat` with body
+/// `match xs { [] -> Z, [_, ..ys] -> S(rec(ys)) }`.
+fn len_shape(fd: &FnDef, ctx: &CodegenContext) -> bool {
+    if fd.params.len() != 1 || !fd.effects.is_empty() {
+        return false;
+    }
+    let Some(peano) = crate::codegen::proof_recognize::peano_type_named(ctx, fd.return_type.trim())
+    else {
+        return false;
+    };
+    if peano.type_name.trim() != "Nat" {
+        return false;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    let Some((subj, nil_body, _, tl, cons_body)) = list_match_split(body) else {
+        return false;
+    };
+    subj == fd.params[0].0.as_str()
+        && is_peano_base(nil_body, &peano)
+        && peano_succ_of(cons_body, &peano).is_some_and(|inner| {
+            call_of(inner).is_some_and(|(rc, ra)| {
+                rc == fd.name && ra.len() == 1 && ident_of(&ra[0]) == Some(tl)
+            })
+        })
+}
+
+/// `append`-shape: `fn (xs: List<T>, ys: List<T>) -> List<T>` with body
+/// `match xs { [] -> ys, [z, ..zs] -> List.concat([z], rec(zs, ys)) }`.
+fn append_shape(fd: &FnDef, elem_ann: &str) -> bool {
+    if fd.params.len() != 2
+        || !fd.effects.is_empty()
+        || !is_list_of(&fd.params[0].1, elem_ann)
+        || !is_list_of(&fd.params[1].1, elem_ann)
+        || !is_list_of(&fd.return_type, elem_ann)
+    {
+        return false;
+    }
+    let ys = fd.params[1].0.as_str();
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    let Some((subj, nil_body, hd, tl, cons_body)) = list_match_split(body) else {
+        return false;
+    };
+    subj == fd.params[0].0.as_str()
+        && ident_of(nil_body) == Some(ys)
+        && call_of(cons_body).is_some_and(|(c, a)| {
+            c == "List.concat"
+                && a.len() == 2
+                && is_singleton_list_of_ident(&a[0], hd)
+                && call_of(&a[1]).is_some_and(|(rc, ra)| {
+                    rc == fd.name
+                        && ra.len() == 2
+                        && ident_of(&ra[0]) == Some(tl)
+                        && ident_of(&ra[1]) == Some(ys)
+                })
+        })
+}
+
+/// `rev`-shape: `fn (xs: List<T>) -> List<T>` with body
+/// `match xs { [] -> [], [y, ..ys] -> app(rec(ys), [y]) }` where `app`
+/// is an [`append_shape`] fn over the same element type. Returns the
+/// append fn's name.
+fn rev_shape(fd: &FnDef, ctx: &CodegenContext, elem_ann: &str) -> Option<String> {
+    if fd.params.len() != 1
+        || !fd.effects.is_empty()
+        || !is_list_of(&fd.params[0].1, elem_ann)
+        || !is_list_of(&fd.return_type, elem_ann)
+    {
+        return None;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let (subj, nil_body, hd, tl, cons_body) = list_match_split(body)?;
+    if subj != fd.params[0].0.as_str()
+        || !matches!(&nil_body.node, Expr::List(items) if items.is_empty())
+    {
+        return None;
+    }
+    let (app, args) = call_of(cons_body)?;
+    if args.len() != 2
+        || !call_of(&args[0])
+            .is_some_and(|(rc, ra)| rc == fd.name && ra.len() == 1 && ident_of(&ra[0]) == Some(tl))
+        || !is_singleton_list_of_ident(&args[1], hd)
+    {
+        return None;
+    }
+    let app_fd = ctx.fn_def_by_name(&app, None)?;
+    append_shape(app_fd, elem_ann).then_some(app)
+}
+
+/// `zip`-shape: `fn (xs: List<A>, ys: List<B>) -> List<Tuple<A, B>>`
+/// with body `match xs { [] -> [], [z, ..x2] -> match ys
+///   { [] -> [], [x3, ..x4] -> List.concat([(z, x3)], rec(x2, x4)) } }`.
+fn zip_shape(fd: &FnDef, elem_ann: &str) -> bool {
+    let squash = |s: &str| s.chars().filter(|c| !c.is_whitespace()).collect::<String>();
+    let pair_ann = format!("Tuple<{},{}>", squash(elem_ann), squash(elem_ann));
+    if fd.params.len() != 2
+        || !fd.effects.is_empty()
+        || !is_list_of(&fd.params[0].1, elem_ann)
+        || !is_list_of(&fd.params[1].1, elem_ann)
+        || !is_list_of(&fd.return_type, &pair_ann)
+    {
+        return false;
+    }
+    let is_empty_list =
+        |e: &Spanned<Expr>| matches!(&e.node, Expr::List(items) if items.is_empty());
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    let Some((subj, nil_body, hd, tl, cons_body)) = list_match_split(body) else {
+        return false;
+    };
+    if subj != fd.params[0].0.as_str() || !is_empty_list(nil_body) {
+        return false;
+    }
+    let Some((subj2, nil2, hd2, tl2, cons2)) = list_match_split(cons_body) else {
+        return false;
+    };
+    if subj2 != fd.params[1].0.as_str() || !is_empty_list(nil2) {
+        return false;
+    }
+    call_of(cons2).is_some_and(|(c, a)| {
+        c == "List.concat"
+            && a.len() == 2
+            && matches!(&a[0].node, Expr::List(items)
+                if items.len() == 1
+                    && matches!(&items[0].node, Expr::Tuple(pair)
+                        if pair.len() == 2
+                            && ident_of(&pair[0]) == Some(hd)
+                            && ident_of(&pair[1]) == Some(hd2)))
+            && call_of(&a[1]).is_some_and(|(rc, ra)| {
+                rc == fd.name
+                    && ra.len() == 2
+                    && ident_of(&ra[0]) == Some(tl)
+                    && ident_of(&ra[1]) == Some(tl2)
+            })
+    })
+}
+
+/// Given-named identifiers occurring in `e` — the variable sets of the
+/// ACL2 free-variables gate. Returns `None` on any expression node the
+/// walker does not positively recognize: the gate must never
+/// under-collect on the `when` side, so unknown structure declines.
+fn given_vars_in(
+    e: &Spanned<Expr>,
+    givens: &std::collections::BTreeSet<&str>,
+    out: &mut std::collections::BTreeSet<String>,
+) -> Option<()> {
+    match &e.node {
+        Expr::Literal(_) => Some(()),
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => {
+            if givens.contains(n.as_str()) {
+                out.insert(n.clone());
+            }
+            Some(())
+        }
+        Expr::Attr(base, _) => given_vars_in(base, givens, out),
+        Expr::FnCall(callee, args) => {
+            given_vars_in(callee, givens, out)?;
+            args.iter().try_for_each(|a| given_vars_in(a, givens, out))
+        }
+        Expr::TailCall(data) => data
+            .args
+            .iter()
+            .try_for_each(|a| given_vars_in(a, givens, out)),
+        Expr::BinOp(_, l, r) => {
+            given_vars_in(l, givens, out)?;
+            given_vars_in(r, givens, out)
+        }
+        Expr::Neg(inner) | Expr::ErrorProp(inner) => given_vars_in(inner, givens, out),
+        Expr::Constructor(_, payload) => payload
+            .as_deref()
+            .map_or(Some(()), |p| given_vars_in(p, givens, out)),
+        Expr::List(items) | Expr::Tuple(items) => {
+            items.iter().try_for_each(|a| given_vars_in(a, givens, out))
+        }
+        _ => None,
+    }
+}
+
+/// `(eq_fn, negation route, lhs arg, rhs arg)` — the result of
+/// [`bridge_premise`].
+type BridgePremise<'a> = (
+    String,
+    Option<BridgeNeg>,
+    &'a Spanned<Expr>,
+    &'a Spanned<Expr>,
+);
+
+/// Normalize a bridge-shaped `when` to
+/// `(eq_fn, negation route, lhs arg, rhs arg)`.
+fn bridge_premise<'a>(when: &'a Spanned<Expr>, ctx: &CodegenContext) -> Option<BridgePremise<'a>> {
+    let (callee, args) = call_of(when)?;
+    if callee == "Bool.not" && args.len() == 1 {
+        let (inner, in_args) = call_of(&args[0])?;
+        let fd = ctx.fn_def_by_name(&inner, None)?;
+        return (in_args.len() == 2 && is_peano_eq_fn(fd, ctx))
+            .then(|| (inner, Some(BridgeNeg::BoolNot), &in_args[0], &in_args[1]));
+    }
+    if args.len() != 2 {
+        return None;
+    }
+    let fd = ctx.fn_def_by_name(&callee, None)?;
+    if is_peano_eq_fn(fd, ctx) {
+        return Some((callee, None, &args[0], &args[1]));
+    }
+    let eq_fn = neg_eq_wrapper(fd, ctx)?;
+    Some((eq_fn, Some(BridgeNeg::Wrapper(callee)), &args[0], &args[1]))
+}
+
+/// Validate one when-law against the bridge-premise figures. Mirrors
+/// the lane discipline: exact hand-validated constellations only,
+/// everything else declines (the law stays bounded, manifest bytes
+/// untouched).
+fn classify_bridge_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Option<BridgePlan> {
+    let when = law.when.as_ref()?;
+    let given_names: std::collections::BTreeSet<&str> =
+        law.givens.iter().map(|g| g.name.as_str()).collect();
+    if given_names.len() != law.givens.len() {
+        return None;
+    }
+
+    // ACL2 free-variables gate: vars(when) ⊆ vars(lhs). A premise
+    // variable unbound by the conclusion's match side would make
+    // conditional rewriting guess — decline instead.
+    let mut when_vars = std::collections::BTreeSet::new();
+    given_vars_in(when, &given_names, &mut when_vars)?;
+    let mut lhs_vars = std::collections::BTreeSet::new();
+    given_vars_in(&law.lhs, &given_names, &mut lhs_vars)?;
+    if !when_vars.is_subset(&lhs_vars) {
+        return None;
+    }
+
+    let (eq_fn, neg, a, b) = bridge_premise(when, ctx)?;
+    let given_type = |name: &str| -> Option<&str> {
+        law.givens
+            .iter()
+            .find(|g| g.name == name)
+            .map(|g| g.type_name.as_str())
+    };
+    let (lhs_callee, lhs_args) = call_of(&law.lhs)?;
+    if lhs_callee.rsplit('.').next()? != vb.fn_name {
+        return None;
+    }
+
+    // ---- ZipRevLenEq: when eq(len(xs), len(ys)) ---------------------
+    if let (Some((len_a, la)), Some((len_b, lb))) = (call_of(a), call_of(b)) {
+        if law.givens.len() != 2
+            || len_a != len_b
+            || la.len() != 1
+            || lb.len() != 1
+            || law
+                .givens
+                .iter()
+                .any(|g| BRIDGE_RESERVED_ZIPREV.contains(&g.name.as_str()))
+        {
+            return None;
+        }
+        if neg.is_some() {
+            return None;
+        }
+        let xs = law.givens[0].name.as_str();
+        let ys = law.givens[1].name.as_str();
+        if ident_of(&la[0]) != Some(xs) || ident_of(&lb[0]) != Some(ys) {
+            return None;
+        }
+        let xs_ty = law.givens[0].type_name.as_str();
+        if law.givens[1].type_name != xs_ty {
+            return None;
+        }
+        // Element type from `List<T>`.
+        let elem_ann = {
+            let squash: String = xs_ty.chars().filter(|c| !c.is_whitespace()).collect();
+            squash.strip_prefix("List<")?.strip_suffix('>')?.to_string()
+        };
+        let len_fd = ctx.fn_def_by_name(&len_a, None)?;
+        if !len_shape(len_fd, ctx) || !is_list_of(xs_ty, &elem_ann) {
+            return None;
+        }
+        // lhs: zip(rev(xs), rev(ys)); rhs: revPair(zip(xs, ys)).
+        if lhs_args.len() != 2 {
+            return None;
+        }
+        let (rev_a, ra) = call_of(&lhs_args[0])?;
+        let (rev_b, rb) = call_of(&lhs_args[1])?;
+        if rev_a != rev_b
+            || ra.len() != 1
+            || rb.len() != 1
+            || ident_of(&ra[0]) != Some(xs)
+            || ident_of(&rb[0]) != Some(ys)
+        {
+            return None;
+        }
+        let (rev_pair, rp_args) = call_of(&law.rhs)?;
+        if rp_args.len() != 1 {
+            return None;
+        }
+        let (zip_inner, zi) = call_of(&rp_args[0])?;
+        if zip_inner != lhs_callee
+            || zi.len() != 2
+            || ident_of(&zi[0]) != Some(xs)
+            || ident_of(&zi[1]) != Some(ys)
+        {
+            return None;
+        }
+        let zip_fd = ctx.fn_def_by_name(&lhs_callee, None)?;
+        if !zip_shape(zip_fd, &elem_ann) {
+            return None;
+        }
+        let rev_fd = ctx.fn_def_by_name(&rev_a, None)?;
+        let append_fn = rev_shape(rev_fd, ctx, &elem_ann)?;
+        let pair_ann = format!("Tuple<{elem_ann}, {elem_ann}>");
+        let rev_pair_fd = ctx.fn_def_by_name(&rev_pair, None)?;
+        let append_pair_fn = rev_shape(rev_pair_fd, ctx, &pair_ann)?;
+        // Compound element types must parenthesize inside `List _` /
+        // binder positions of the rendered templates.
+        let elem_ty = {
+            let t = super::types::type_annotation_to_lean(&elem_ann);
+            if t.contains(' ') { format!("({t})") } else { t }
+        };
+        return Some(BridgePlan::ZipRevLenEq {
+            eq_fn,
+            len_fn: len_a,
+            zip_fn: lhs_callee,
+            rev_fn: rev_a,
+            rev_pair_fn: rev_pair,
+            append_fn,
+            append_pair_fn,
+            elem_ty,
+            xs: xs.to_string(),
+            ys: ys.to_string(),
+        });
+    }
+
+    // ---- insert/count figures: premise args are plain Peano givens --
+    let x = ident_of(a)?;
+    let y = ident_of(b)?;
+    if x == y {
+        // `eq(x, x)` / `neq(x, x)`: the positive figure's `subst`
+        // cannot eliminate a self-equality — decline (zero cost)
+        // instead of a noisy tolerated build failure.
+        return None;
+    }
+    let xt = given_type(x)?;
+    if given_type(y)? != xt
+        || crate::codegen::proof_recognize::peano_type_named(ctx, xt.trim()).is_none()
+        || law.givens.len() != 3
+        || law
+            .givens
+            .iter()
+            .any(|g| BRIDGE_RESERVED_INSERT.contains(&g.name.as_str()))
+    {
+        return None;
+    }
+    if lhs_args.len() != 2 || ident_of(&lhs_args[0]) != Some(x) {
+        return None;
+    }
+
+    // count(x, List.concat(z_list, [y])) = count(x, z_list) — prop_76.
+    if let Some((cc, ca)) = call_of(&lhs_args[1])
+        && cc == "List.concat"
+    {
+        // Only the negated premise is a validated figure over the
+        // concat-singleton conclusion shape.
+        let neg = neg?;
+        if ca.len() != 2 || !is_singleton_list_of_ident(&ca[1], y) {
+            return None;
+        }
+        let zs = ident_of(&ca[0])?;
+        if !is_list_of(given_type(zs)?, xt) {
+            return None;
+        }
+        let count_fd = ctx.fn_def_by_name(&lhs_callee, None)?;
+        if !count_shape(count_fd, ctx, &eq_fn) {
+            return None;
+        }
+        let (rc, ra) = call_of(&law.rhs)?;
+        return (rc == lhs_callee
+            && ra.len() == 2
+            && ident_of(&ra[0]) == Some(x)
+            && ident_of(&ra[1]) == Some(zs))
+        .then(|| BridgePlan::NeqCountAppendSingleton {
+            eq_fn,
+            neg,
+            count_fn: lhs_callee,
+            n: x.to_string(),
+            m: y.to_string(),
+            xs: zs.to_string(),
+        });
+    }
+
+    // elem/count over insert: lhs = f(x, insert(y, z)).
+    let (insert_fn, ins_args) = call_of(&lhs_args[1])?;
+    if ins_args.len() != 2 || ident_of(&ins_args[0]) != Some(y) {
+        return None;
+    }
+    let z = ident_of(&ins_args[1])?;
+    if !is_list_of(given_type(z)?, xt) {
+        return None;
+    }
+    let insert_fd = ctx.fn_def_by_name(&insert_fn, None)?;
+    if !insert_shape(insert_fd, ctx) {
+        return None;
+    }
+    let head_fd = ctx.fn_def_by_name(&lhs_callee, None)?;
+    match neg {
+        // when eq(x, y): elem(x, insert(y, z)) = true — prop_46.
+        None => {
+            let or_fn = elem_shape(head_fd, ctx, &eq_fn)?;
+            (as_bool_lit(&law.rhs) == Some(true)).then(|| BridgePlan::EqElemInsert {
+                eq_fn,
+                elem_fn: lhs_callee,
+                or_fn,
+                insert_fn,
+                x: x.to_string(),
+                y: y.to_string(),
+                z: z.to_string(),
+            })
+        }
+        // when neq(x, y): f(x, insert(y, z)) = f(x, z) — prop_47 /
+        // lemma_19 (elem) and lemma_21 (count).
+        Some(neg) => {
+            let (rc, ra) = call_of(&law.rhs)?;
+            if rc != lhs_callee
+                || ra.len() != 2
+                || ident_of(&ra[0]) != Some(x)
+                || ident_of(&ra[1]) != Some(z)
+            {
+                return None;
+            }
+            if let Some(or_fn) = elem_shape(head_fd, ctx, &eq_fn) {
+                return Some(BridgePlan::NeqElemInsert {
+                    eq_fn,
+                    neg,
+                    elem_fn: lhs_callee,
+                    or_fn,
+                    insert_fn,
+                    x: x.to_string(),
+                    y: y.to_string(),
+                    z: z.to_string(),
+                });
+            }
+            count_shape(head_fd, ctx, &eq_fn).then(|| BridgePlan::NeqCountInsert {
+                eq_fn,
+                neg,
+                count_fn: lhs_callee,
+                insert_fn,
+                x: x.to_string(),
+                y: y.to_string(),
+                z: z.to_string(),
+            })
+        }
+    }
+}
+
+/// Render one bridge-premise lane law: the validated proof template
+/// for `plan`, support lemmas included, into a single hashed module.
+/// Statement built by the SAME `law_theorem_prop` as the manifest
+/// theorem with `omit_domain` — when-premise kept, sampled-domain
+/// disjunctions dropped. Zero `sorry` tokens by construction.
+fn render_bridge_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    plan: &BridgePlan,
+    entry_root: &str,
+    entry_content: &str,
+    sabotage: bool,
+) -> Option<LaneLawFile> {
+    let emit = |e: &Spanned<Expr>| emit_expr_legacy(e, ctx, None).replace('\n', " ");
+    let fn_lean = aver_name_to_lean(&vb.fn_name);
+    let law_lean = aver_name_to_lean(&law.name);
+    let theorem_base = format!("{fn_lean}_law_{law_lean}");
+    let theorem = format!("{theorem_base}_universal");
+
+    let lhs_template = emit(&law.lhs);
+    let rhs_template = emit(&law.rhs);
+    let when_template = emit(law.when.as_ref()?);
+    let lifted = std::collections::HashMap::new();
+    let (prop, bounded) = super::toplevel::law_theorem_prop(
+        law,
+        ctx,
+        &lhs_template,
+        &rhs_template,
+        Some(&when_template),
+        &lifted,
+        true,
+    );
+    debug_assert!(!bounded);
+    let quant_params = law
+        .givens
+        .iter()
+        .map(|g| {
+            format!(
+                "({} : {})",
+                aver_name_to_lean(&g.name),
+                super::types::type_annotation_to_lean(&g.type_name)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    let intro_givens = law
+        .givens
+        .iter()
+        .map(|g| aver_name_to_lean(&g.name))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let sab = if sabotage {
+        // TEST-ONLY (`AVER_PROOF_LANE_SABOTAGE`): an unknown
+        // identifier makes this module's build fail hard — the lane
+        // must absorb it with zero effect on budgets and neighbors.
+        "\nexact averLaneSabotageInjectedByTest"
+    } else {
+        ""
+    };
+
+    // Use-side Bool→Prop inversion bridge: follows the predicate's own
+    // recursion (mismatch arms close from the contradicted equations,
+    // the step arm feeds the IH through `simpa`).
+    let bridge_eq_lemma = |eq: &str| {
+        format!(
+            r#"private theorem {theorem}_bridge_eq : ∀ (a b : Nat), _root_.{eq} a b = true → a = b := by
+  intro a
+  induction a with
+  | zero =>
+    intro b h
+    cases b with
+    | zero => rfl
+    | succ y => simp [_root_.{eq}] at h
+  | succ x ih =>
+    intro b h
+    cases b with
+    | zero => simp [_root_.{eq}] at h
+    | succ y =>
+      have hx := ih y (by simpa [_root_.{eq}] using h)
+      omega
+"#
+        )
+    };
+    // REINTRODUCTION bridge (`eq a a = true`) — without it the main
+    // proof cannot instantiate its own induction hypothesis.
+    let bridge_refl_lemma = |eq: &str| {
+        format!(
+            r#"private theorem {theorem}_bridge_refl : ∀ (a : Nat), _root_.{eq} a a = true := by
+  intro a
+  induction a with
+  | zero => rfl
+  | succ x ih => simpa [_root_.{eq}] using ih
+"#
+        )
+    };
+    // Negated-premise normalization: derive `heq : eq x y = false`
+    // from `h_when` by cases on the Bool — the `true` case refutes
+    // the rendered premise (`!eq` or the not-wrapper unfolding).
+    let neg_norm = |eq: &str, neg: &BridgeNeg, x: &str, y: &str| {
+        let on_true = match neg {
+            BridgeNeg::BoolNot => "rw [hc] at h_when\n    simp at h_when".to_string(),
+            BridgeNeg::Wrapper(w) => {
+                format!("simp [_root_.{}, hc] at h_when", aver_name_to_lean(w))
+            }
+        };
+        format!(
+            "have heq : _root_.{eq} {x} {y} = false := by\n  cases hc : _root_.{eq} {x} {y}\n  · rfl\n  · {on_true}"
+        )
+    };
+
+    let (supports, body): (Vec<String>, String) = match plan {
+        BridgePlan::ZipRevLenEq {
+            eq_fn,
+            len_fn,
+            zip_fn,
+            rev_fn,
+            rev_pair_fn,
+            append_fn,
+            append_pair_fn,
+            elem_ty,
+            xs,
+            ys,
+        } => {
+            let eq = aver_name_to_lean(eq_fn);
+            let len = aver_name_to_lean(len_fn);
+            let zip = aver_name_to_lean(zip_fn);
+            let rev = aver_name_to_lean(rev_fn);
+            let revp = aver_name_to_lean(rev_pair_fn);
+            let app = aver_name_to_lean(append_fn);
+            let appp = aver_name_to_lean(append_pair_fn);
+            let a_ty = elem_ty;
+            let xs = aver_name_to_lean(xs);
+            let ys = aver_name_to_lean(ys);
+            let supports = vec![
+                bridge_eq_lemma(&eq),
+                bridge_refl_lemma(&eq),
+                // Measure homomorphism over append — the premise-stepping
+                // arithmetic below rides on it.
+                format!(
+                    r#"private theorem {theorem}_len_append : ∀ (xs ys : List {a_ty}),
+    _root_.{len} (_root_.{app} xs ys) = _root_.{len} xs + _root_.{len} ys := by
+  intro xs
+  induction xs with
+  | nil => intro ys; simp [_root_.{app}, _root_.{len}]
+  | cons z zs ih =>
+    intro ys
+    simp only [_root_.{app}, List.singleton_append, _root_.{len}, ih]
+    omega
+"#
+                ),
+                format!(
+                    r#"private theorem {theorem}_len_rev : ∀ (xs : List {a_ty}), _root_.{len} (_root_.{rev} xs) = _root_.{len} xs := by
+  intro xs
+  induction xs with
+  | nil => simp [_root_.{rev}]
+  | cons y ys ih =>
+    simp only [_root_.{rev}, {theorem}_len_append, _root_.{len}, ih]
+"#
+                ),
+                // Premise-driven shape inversion of the non-induction
+                // variable: `len ys = 0 → ys = []`.
+                format!(
+                    r#"private theorem {theorem}_len_zero : ∀ (ys : List {a_ty}), _root_.{len} ys = 0 → ys = [] := by
+  intro ys h
+  cases ys with
+  | nil => rfl
+  | cons y ys =>
+    simp only [_root_.{len}] at h
+    exact absurd h (by omega)
+"#
+                ),
+                // The snoc-distribution aux lemma (zip over
+                // append-singleton under length equality) — emitted
+                // from the validated template, never as a sorry. Its
+                // own premise threads by per-step stepping (C) and
+                // vacuous discharge (D).
+                format!(
+                    r#"private theorem {theorem}_snoc (x y : {a_ty}) : ∀ (as bs : List {a_ty}),
+    _root_.{len} as = _root_.{len} bs →
+    _root_.{zip} (_root_.{app} as [x]) (_root_.{app} bs [y])
+      = _root_.{appp} (_root_.{zip} as bs) [(x, y)] := by
+  intro as
+  induction as with
+  | nil =>
+    intro bs h
+    have hb : bs = [] := {theorem}_len_zero bs (by simp only [_root_.{len}] at h; omega)
+    subst hb
+    simp [_root_.{app}, _root_.{zip}, _root_.{appp}]
+  | cons a as ih =>
+    intro bs h
+    cases bs with
+    | nil =>
+      simp only [_root_.{len}] at h
+      exact absurd h (by omega)
+    | cons b bs =>
+      have h' : _root_.{len} as = _root_.{len} bs := by simp only [_root_.{len}] at h; omega
+      simp only [_root_.{app}, List.singleton_append, _root_.{zip}, _root_.{appp}, ih bs h']
+"#
+                ),
+            ];
+            let body = format!(
+                r#"intro {xs}{sab}
+induction {xs} with
+| nil =>
+  intro {ys} h
+  have h0 : _root_.{len} {ys} = 0 := by
+    have hh := {theorem}_bridge_eq (_root_.{len} []) (_root_.{len} {ys}) h
+    simp only [_root_.{len}] at hh
+    omega
+  have hy : {ys} = [] := {theorem}_len_zero {ys} h0
+  subst hy
+  simp [_root_.{rev}, _root_.{zip}, _root_.{revp}]
+| cons z x2 ih =>
+  intro {ys} h
+  cases {ys} with
+  | nil =>
+    have hh := {theorem}_bridge_eq (_root_.{len} (z :: x2)) (_root_.{len} []) h
+    simp only [_root_.{len}] at hh
+    exact absurd hh (by omega)
+  | cons y x4 =>
+    have hlen : _root_.{len} x2 = _root_.{len} x4 := by
+      have hh := {theorem}_bridge_eq (_root_.{len} (z :: x2)) (_root_.{len} (y :: x4)) h
+      simp only [_root_.{len}] at hh
+      omega
+    have hrevlen : _root_.{len} (_root_.{rev} x2) = _root_.{len} (_root_.{rev} x4) := by
+      rw [{theorem}_len_rev, {theorem}_len_rev]; exact hlen
+    have hih : _root_.{zip} (_root_.{rev} x2) (_root_.{rev} x4) = _root_.{revp} (_root_.{zip} x2 x4) := by
+      apply ih
+      rw [hlen]
+      exact {theorem}_bridge_refl (_root_.{len} x4)
+    calc _root_.{zip} (_root_.{rev} (z :: x2)) (_root_.{rev} (y :: x4))
+        = _root_.{zip} (_root_.{app} (_root_.{rev} x2) [z]) (_root_.{app} (_root_.{rev} x4) [y]) := by
+          simp only [_root_.{rev}]
+      _ = _root_.{appp} (_root_.{zip} (_root_.{rev} x2) (_root_.{rev} x4)) [(z, y)] :=
+          {theorem}_snoc z y (_root_.{rev} x2) (_root_.{rev} x4) hrevlen
+      _ = _root_.{appp} (_root_.{revp} (_root_.{zip} x2 x4)) [(z, y)] := by rw [hih]
+      _ = _root_.{revp} (_root_.{zip} (z :: x2) (y :: x4)) := by
+          simp only [_root_.{zip}, _root_.{revp}, List.singleton_append]"#
+            );
+            (supports, body)
+        }
+        BridgePlan::EqElemInsert {
+            eq_fn,
+            elem_fn,
+            or_fn,
+            insert_fn,
+            x,
+            y,
+            z,
+        } => {
+            let eq = aver_name_to_lean(eq_fn);
+            let elem = aver_name_to_lean(elem_fn);
+            let or = aver_name_to_lean(or_fn);
+            let ins = aver_name_to_lean(insert_fn);
+            let x = aver_name_to_lean(x);
+            let y = aver_name_to_lean(y);
+            let z = aver_name_to_lean(z);
+            let supports = vec![bridge_eq_lemma(&eq), bridge_refl_lemma(&eq)];
+            let body = format!(
+                r#"intro {intro_givens} h_when{sab}
+have heq : {x} = {y} := {theorem}_bridge_eq {x} {y} h_when
+subst heq
+induction {z} with
+| nil => simp [_root_.{ins}, _root_.{elem}, _root_.{or}, {theorem}_bridge_refl]
+| cons c cs ih =>
+  simp only [_root_.{ins}]
+  split
+  · simp [_root_.{elem}, _root_.{or}, {theorem}_bridge_refl, List.singleton_append]
+  · simp only [List.singleton_append, _root_.{elem}, ih, _root_.{or}]
+    split <;> simp"#
+            );
+            (supports, body)
+        }
+        BridgePlan::NeqElemInsert {
+            eq_fn,
+            neg,
+            elem_fn,
+            or_fn,
+            insert_fn,
+            x,
+            y,
+            z,
+        } => {
+            let eq = aver_name_to_lean(eq_fn);
+            let elem = aver_name_to_lean(elem_fn);
+            let or = aver_name_to_lean(or_fn);
+            let ins = aver_name_to_lean(insert_fn);
+            let heq = neg_norm(&eq, neg, &aver_name_to_lean(x), &aver_name_to_lean(y));
+            let z = aver_name_to_lean(z);
+            let body = format!(
+                r#"intro {intro_givens} h_when{sab}
+{heq}
+induction {z} with
+| nil => simp [_root_.{ins}, _root_.{elem}, _root_.{or}, heq]
+| cons c cs ih =>
+  simp only [_root_.{ins}]
+  split
+  · simp [_root_.{elem}, _root_.{or}, heq, List.singleton_append]
+  · simp only [List.singleton_append, _root_.{elem}, ih]"#
+            );
+            (Vec::new(), body)
+        }
+        BridgePlan::NeqCountInsert {
+            eq_fn,
+            neg,
+            count_fn,
+            insert_fn,
+            x,
+            y,
+            z,
+        } => {
+            let eq = aver_name_to_lean(eq_fn);
+            let count = aver_name_to_lean(count_fn);
+            let ins = aver_name_to_lean(insert_fn);
+            let heq = neg_norm(&eq, neg, &aver_name_to_lean(x), &aver_name_to_lean(y));
+            let z = aver_name_to_lean(z);
+            let body = format!(
+                r#"intro {intro_givens} h_when{sab}
+{heq}
+induction {z} with
+| nil => simp [_root_.{ins}, _root_.{count}, heq]
+| cons c cs ih =>
+  simp only [_root_.{ins}]
+  split
+  · simp [_root_.{count}, heq, List.singleton_append]
+  · simp only [List.singleton_append, _root_.{count}, ih]"#
+            );
+            (Vec::new(), body)
+        }
+        BridgePlan::NeqCountAppendSingleton {
+            eq_fn,
+            neg,
+            count_fn,
+            n,
+            m,
+            xs,
+        } => {
+            let eq = aver_name_to_lean(eq_fn);
+            let count = aver_name_to_lean(count_fn);
+            let heq = neg_norm(&eq, neg, &aver_name_to_lean(n), &aver_name_to_lean(m));
+            let xs = aver_name_to_lean(xs);
+            let body = format!(
+                r#"intro {intro_givens} h_when{sab}
+{heq}
+induction {xs} with
+| nil => simp [_root_.{count}, heq]
+| cons c cs ih => simp only [List.cons_append, _root_.{count}, ih]"#
+            );
+            (Vec::new(), body)
+        }
+    };
+
+    let mut content = String::new();
+    content.push_str(&format!(
+        "-- Aver when-universal quarantine lane — verify law {}.{}\n\
+         -- NOT part of the counted default build. Built by a separate,\n\
+         -- failure-tolerated per-law `lake build` invocation; credited only\n\
+         -- on per-declaration `#print axioms` evidence (whitelist: propext,\n\
+         -- Classical.choice, Quot.sound). This module carries no honest-\n\
+         -- floor fallback: a non-closing proof is a tolerated build failure\n\
+         -- (the law stays bounded), never a counted warning.\n",
+        vb.fn_name, law.name,
+    ));
+    content.push_str(&format!("import {entry_root}\n\n"));
+    content.push_str("set_option linter.unusedVariables false\n\n");
+    for support in &supports {
+        content.push_str(support);
+        content.push('\n');
+    }
+    content.push_str(&format!(
+        "{}{} {}\n",
+        super::LAW_CLASS_MARKER_PREFIX,
+        theorem,
+        super::LAW_CLASS_UNIVERSAL
+    ));
+    content.push_str(&format!(
+        "theorem {theorem} : ∀ {quant_params}, {prop} := by\n"
+    ));
+    for line in body.lines() {
+        if line.is_empty() {
+            content.push('\n');
+        } else {
+            content.push_str("  ");
+            content.push_str(line);
+            content.push('\n');
+        }
+    }
+
+    // L2 of the iron guard: the lane grammar has no sorry carrier.
+    debug_assert!(
+        !content.contains("sorry"),
+        "universal-lane module must not contain a sorry token"
+    );
+
+    let module = lane_module_id(&theorem_base, &content, entry_content);
     Some(LaneLawFile {
         label: format!("{}.{}", vb.fn_name, law.name),
         theorem,

--- a/tests/fixtures/when_lane_bridge.av
+++ b/tests/fixtures/when_lane_bridge.av
@@ -1,0 +1,147 @@
+module BridgeLane
+    intent =
+        "Synthetic bridge-premise fixture for the proof_spec when-universal lane generality pin."
+        "Mirrors the TIP zip-rev length-equality (prop_85) and neq-count-insert (lemma_21)"
+        "constellations under fresh names, so the quarantine lane must recognize the recursive"
+        "Bool equality bridge structurally, not by the proof-corpus identifiers."
+    exposes [duoUp, tallyUp]
+
+type Nat
+    Z
+    S(Nat)
+
+fn likeNat(a: Nat, b: Nat) -> Bool
+    ? "Recursive structural equality on Peano Nat — the premise bridge."
+    match a
+        Nat.Z -> match b
+            Nat.Z -> true
+            Nat.S(v) -> false
+        Nat.S(u) -> match b
+            Nat.Z -> false
+            Nat.S(v) -> likeNat(u, v)
+
+verify likeNat
+    likeNat(Nat.Z, Nat.Z) => true
+    likeNat(Nat.Z, Nat.S(Nat.Z)) => false
+    likeNat(Nat.S(Nat.Z), Nat.S(Nat.Z)) => true
+
+fn unlikeNat(a: Nat, b: Nat) -> Bool
+    ? "Negated bridge: the 2-arm not-wrapper over likeNat."
+    match likeNat(a, b)
+        true -> false
+        false -> true
+
+verify unlikeNat
+    unlikeNat(Nat.Z, Nat.Z) => false
+    unlikeNat(Nat.Z, Nat.S(Nat.Z)) => true
+
+fn bulk(xs: List<Int>) -> Nat
+    ? "List length as a Peano measure."
+    match xs
+        [] -> Nat.Z
+        [v, ..vs] -> Nat.S(bulk(vs))
+
+verify bulk
+    bulk([]) => Nat.Z
+    bulk([4]) => Nat.S(Nat.Z)
+
+fn weld(xs: List<Int>, ys: List<Int>) -> List<Int>
+    ? "Append two Int lists."
+    match xs
+        [] -> ys
+        [v, ..vs] -> List.concat([v], weld(vs, ys))
+
+verify weld
+    weld([], [1]) => [1]
+    weld([1], [2]) => [1, 2]
+
+fn weldDuo(xs: List<Tuple<Int, Int>>, ys: List<Tuple<Int, Int>>) -> List<Tuple<Int, Int>>
+    ? "Append two pair lists."
+    match xs
+        [] -> ys
+        [v, ..vs] -> List.concat([v], weldDuo(vs, ys))
+
+verify weldDuo
+    weldDuo([], [(1, 2)]) => [(1, 2)]
+
+fn tumble(xs: List<Int>) -> List<Int>
+    ? "Reverse an Int list via weld."
+    match xs
+        [] -> []
+        [v, ..vs] -> weld(tumble(vs), [v])
+
+verify tumble
+    tumble([]) => []
+    tumble([1, 2]) => [2, 1]
+
+fn tumbleDuo(xs: List<Tuple<Int, Int>>) -> List<Tuple<Int, Int>>
+    ? "Reverse a pair list via weldDuo."
+    match xs
+        [] -> []
+        [v, ..vs] -> weldDuo(tumbleDuo(vs), [v])
+
+verify tumbleDuo
+    tumbleDuo([(1, 2), (3, 4)]) => [(3, 4), (1, 2)]
+
+fn duoUp(xs: List<Int>, ys: List<Int>) -> List<Tuple<Int, Int>>
+    ? "Zip two Int lists into pairs."
+    match xs
+        [] -> []
+        [v, ..vs] -> match ys
+            [] -> []
+            [w, ..wss] -> List.concat([(v, w)], duoUp(vs, wss))
+
+verify duoUp
+    duoUp([], []) => []
+    duoUp([1], [4]) => [(1, 4)]
+    duoUp([1, 2], [4, 5]) => [(1, 4), (2, 5)]
+
+verify duoUp law duoFlip
+    given xs: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given ys: List<Int> = [[], [4], [4, 5], [4, 5, 6]]
+    when likeNat(bulk(xs), bulk(ys))
+    duoUp(tumble(xs), tumble(ys)) => tumbleDuo(duoUp(xs, ys))
+
+fn rankLe(a: Nat, b: Nat) -> Bool
+    ? "Peano less-or-equal — the insert dispatch."
+    match a
+        Nat.Z -> true
+        Nat.S(u) -> match b
+            Nat.Z -> false
+            Nat.S(v) -> rankLe(u, v)
+
+verify rankLe
+    rankLe(Nat.Z, Nat.S(Nat.Z)) => true
+    rankLe(Nat.S(Nat.Z), Nat.Z) => false
+
+fn wedge(a: Nat, xs: List<Nat>) -> List<Nat>
+    ? "Ordered insert into a Nat list."
+    match xs
+        [] -> [a]
+        [v, ..vs] -> match rankLe(a, v)
+            true -> List.concat([a], xs)
+            false -> List.concat([v], wedge(a, vs))
+
+verify wedge
+    wedge(Nat.Z, []) => [Nat.Z]
+    wedge(Nat.Z, [Nat.S(Nat.Z)]) => [Nat.Z, Nat.S(Nat.Z)]
+
+fn tallyUp(a: Nat, xs: List<Nat>) -> Nat
+    ? "Count occurrences of a in the list."
+    match xs
+        [] -> Nat.Z
+        [v, ..vs] -> match likeNat(a, v)
+            true -> Nat.S(tallyUp(a, vs))
+            false -> tallyUp(a, vs)
+
+verify tallyUp
+    tallyUp(Nat.Z, []) => Nat.Z
+    tallyUp(Nat.Z, [Nat.Z]) => Nat.S(Nat.Z)
+    tallyUp(Nat.Z, [Nat.S(Nat.Z)]) => Nat.Z
+
+verify tallyUp law tallyWedgeNeq
+    given p: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given q: Nat = [Nat.S(Nat.Z), Nat.Z, Nat.S(Nat.S(Nat.Z))]
+    given ws: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    when unlikeNat(p, q)
+    tallyUp(p, wedge(q, ws)) => tallyUp(p, ws)

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -650,6 +650,184 @@ fn proof_when_universal_lane_json_end_to_end() {
     let _ = std::fs::remove_dir_all(&output_dir);
 }
 
+/// Bridge-premise family, hard floor: TIP isaplanner prop_85 (zip-rev
+/// under the relational premise `natEq(len(xs), len(ys))`) closes
+/// GENUINELY through the quarantine lane — `when_universal == 1` keyed
+/// on per-declaration `#print axioms` evidence within the kernel
+/// whitelist — while the COUNTED summary stays byte-identical to
+/// main's (passed, 0 sorries, file-level universal:false). A sabotage
+/// run pins the iron guard on this family too.
+#[test]
+fn proof_when_universal_lane_closes_tip_prop_85() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping when-universal lane test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-when-lane-prop85");
+    let (normal, run) = run_lean_check_json(
+        "proof-corpus/tip/isaplanner/prop_85.av",
+        &output_dir,
+        0,
+        &[],
+    );
+    assert_eq!(
+        normal["sorries"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(normal["passed"].as_bool(), Some(true));
+    assert_eq!(
+        normal["universal"].as_bool(),
+        Some(false),
+        "file-level `universal` keeps counted-build semantics; the lane \
+         credit is per-law via when_universal"
+    );
+    assert_eq!(
+        normal["when_universal"].as_u64(),
+        Some(1),
+        "prop_85's zip.zipRev must close universally in the lane.\n{}",
+        format_output(&run)
+    );
+    // Per-law detail artifact: kernel-genuine evidence, quoted.
+    let detail: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output_dir.join("when_universal_laws.json"))
+            .expect("when_universal_laws.json must be written"),
+    )
+    .expect("detail artifact must parse");
+    let laws = detail["laws"].as_array().expect("laws array");
+    assert_eq!(laws.len(), 1);
+    assert_eq!(laws[0]["law"].as_str(), Some("zip.zipRev"));
+    assert_eq!(laws[0]["universal"].as_bool(), Some(true));
+    assert_eq!(
+        laws[0]["evidence"].as_str(),
+        Some("'zip_law_zipRev_universal' depends on axioms: [propext, Quot.sound]"),
+        "per-declaration #print axioms evidence must be quoted verbatim"
+    );
+    // L2 of the iron guard: zero sorry tokens in the lane module — the
+    // snoc-distribution aux lemma is rendered from the validated
+    // template, never emitted as a hole.
+    let lane_index: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output_dir.join("_aver_universal_lane.json"))
+            .expect("lane index must be written"),
+    )
+    .expect("lane index must parse");
+    for law in lane_index["laws"].as_array().expect("laws") {
+        let module = law["module"].as_str().expect("module");
+        let content = std::fs::read_to_string(
+            output_dir
+                .join("universal_lane")
+                .join(format!("{module}.lean")),
+        )
+        .expect("lane module file must exist");
+        assert!(
+            !content.contains("sorry"),
+            "no_sorry_token_in_universal_module violated by {module}"
+        );
+        assert!(
+            content.contains("_snoc"),
+            "the snoc-distribution aux lemma must be emitted as a lane-local lemma"
+        );
+    }
+    // Sabotage: the broken lane proof costs exactly "prop_85 stays
+    // bounded" — counted summary byte-identical, no credit.
+    let (sabotaged, run2) = run_lean_check_json(
+        "proof-corpus/tip/isaplanner/prop_85.av",
+        &output_dir,
+        0,
+        &[("AVER_PROOF_LANE_SABOTAGE", "zipRev")],
+    );
+    assert_eq!(
+        counted_summary(&sabotaged),
+        counted_summary(&normal),
+        "a hard lane failure must leave the counted summary byte-identical.\n{}",
+        format_output(&run2)
+    );
+    assert_eq!(sabotaged["when_universal"].as_u64(), Some(0));
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// Generality pin for the bridge-premise family: the fresh-named
+/// fixture (`tests/fixtures/when_lane_bridge.av`) closes BOTH its
+/// bridge-shaped when-laws end-to-end — the zip-rev figure under
+/// `likeNat(bulk(xs), bulk(ys))` and the count-insert figure under the
+/// negated `unlikeNat(p, q)` — proving the recognizer keys on the
+/// premise's structure, not on the proof-corpus identifiers. The
+/// sabotage run additionally pins neighbor isolation on a two-law
+/// lane file: the broken law reports bounded, its neighbor keeps
+/// credit, the counted summary is untouched.
+#[test]
+fn proof_when_universal_lane_closes_synthetic_bridge_laws() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping when-universal lane test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-when-lane-bridge");
+    let (normal, run) =
+        run_lean_check_json("tests/fixtures/when_lane_bridge.av", &output_dir, 0, &[]);
+    assert_eq!(
+        normal["sorries"].as_u64(),
+        Some(0),
+        "the bridge fixture must stay sorry-free in the counted build.\n{}",
+        format_output(&run)
+    );
+    assert_eq!(normal["passed"].as_bool(), Some(true));
+    assert_eq!(
+        normal["when_universal"].as_u64(),
+        Some(2),
+        "both fresh-named bridge laws must close in the lane.\n{}",
+        format_output(&run)
+    );
+    let detail: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output_dir.join("when_universal_laws.json")).expect("artifact"),
+    )
+    .expect("detail artifact must parse");
+    let mut labels: Vec<&str> = detail["laws"]
+        .as_array()
+        .expect("laws")
+        .iter()
+        .filter_map(|l| l["law"].as_str())
+        .collect();
+    labels.sort_unstable();
+    assert_eq!(
+        labels,
+        vec!["duoUp.duoFlip", "tallyUp.tallyWedgeNeq"],
+        "exact lane law set (exact in both directions, like the budgets)"
+    );
+
+    // Sabotage one bridge law: neighbors keep credit, counted untouched.
+    let (sabotaged, run2) = run_lean_check_json(
+        "tests/fixtures/when_lane_bridge.av",
+        &output_dir,
+        0,
+        &[("AVER_PROOF_LANE_SABOTAGE", "duoFlip")],
+    );
+    assert_eq!(
+        counted_summary(&sabotaged),
+        counted_summary(&normal),
+        "a hard lane failure must leave the counted summary byte-identical.\n{}",
+        format_output(&run2)
+    );
+    assert_eq!(sabotaged["when_universal"].as_u64(), Some(1));
+    let detail2: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output_dir.join("when_universal_laws.json")).expect("artifact"),
+    )
+    .expect("detail artifact must parse");
+    for law in detail2["laws"].as_array().expect("laws") {
+        let expected = law["law"].as_str() != Some("duoUp.duoFlip");
+        assert_eq!(
+            law["universal"].as_bool(),
+            Some(expected),
+            "sabotage must not leak into neighbors: {} -> {}",
+            law["law"],
+            law["evidence"]
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
 #[test]
 fn proof_export_builds_json_when_lake_is_available() {
     // 13 sampled-domain laws (parseString / parseLiteral / escape


### PR DESCRIPTION
## Summary

Conditional laws whose premise is a recursive boolean **equality over Peano-shaped naturals** — length equality (`when natEq(len(xs), len(ys))`), element equality (`when eqNat(x, y)`), and their negations — now receive genuine universal proofs in the isolated side build introduced in #475, credited per theorem via `#print axioms`.

What the prover learned:
- convert the boolean premise into a propositional equality (and back — re-establishing the premise across induction steps so its own induction hypothesis applies);
- derive shape facts from the premise (`len ys = 0` forces `ys = []`);
- emit any helper lemma a proof needs (e.g. zip distributing over append-of-a-singleton) as a fully **proven** theorem in the same module — never an assumption;
- **decline** any law whose premise mentions a variable absent from the claim's left-hand side (the prover would have to guess its value — the classic conditional-rewriting trap).

**First proven cases**: six benchmark tasks previously only example-checked, each with axiom receipts within `{propext, Classical.choice, Quot.sound}` — zip-reversal under equal lengths, element-of-insert under equality/inequality, count-after-insert and count-after-append-singleton under inequality. 13 remaining conditional benchmark tasks are declined with verified, per-law reasons (membership/sortedness premises — different premise shapes, future work).

The benchmark runner gains a **separately labeled, additive** count of conditional proofs; headline proved/open numbers and grep keys are untouched (verified against the unmodified binary).

Also names the unreleased 0.25.0 **"The Method"** in the CHANGELOG.

## Validation

- Per-theorem `#print axioms` receipts (run independently by the adversarial reviewer as well).
- Sabotage test: breaking one proof via the documented test hook leaves every other law's credit and all counted budgets **byte-identical**; the broken law honestly reports as example-checked only.
- Full corpus sweep vs the unmodified binary: every counted summary identical key-for-key; only additive deltas. Dafny exports byte-identical.
- `cargo test --workspace` 2120 passed / 0 failed; clippy clean in all three variants; fmt clean.
- Adversarial review **pass** (3 non-blocking notes; the source-file split into smaller modules is queued as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)