### PR TITLE
tests: budget-only assert on the when-filtered-samples Dafny anchor

### DIFF
--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -546,10 +546,18 @@ fn proof_nonlinear_laws_degrade_to_honest_sorries() {
 /// Z3 fully proves. Post-fix the samples are checked under
 /// `if <instantiated premise> { … }` (mirroring Lean's `_sample_N`
 /// premise-as-hypothesis form) and the whole file verifies: 0 errors,
-/// 0 axioms, passed:true.
+/// 0 axioms.
+///
+/// Deliberately budget-only (no `passed` assert): this fixture's
+/// genuinely nonlinear universal lemmas have platform-sensitive
+/// verification wall-clock — a slower Z3 build can time an obligation
+/// out (exit 4) without erroring, which is jitter, not the regression
+/// under test. The when-filter regression itself surfaces as ERRORS
+/// (reverting the guard yields 2 "assertion might not hold"), so the
+/// error budget catches it on every platform.
 #[test]
 fn proof_dafny_when_filtered_samples() {
-    assert_dafny_verifies_and_passes("tests/fixtures/nr_wall.av", "aver-dafny-nr-wall");
+    assert_dafny_verifies("tests/fixtures/nr_wall.av", "aver-dafny-nr-wall");
 }
 
 /// Rationals fixture (`tests/fixtures/rational_probe.av`):


### PR DESCRIPTION
Follow-up to #478: the `Proof Export` CI job failed on `proof_dafny_when_filtered_samples` — Linux CI's Z3 timed out one of the nonlinear-wall fixture's genuinely nonlinear universal lemmas (exit 4, **0 errors**), tripping the defense-in-depth `passed:true` assert on a file whose checked regression was absent. That wall-clock is platform jitter (same rationale as the error-budget ceilings), not the regression under test.

- `proof_dafny_when_filtered_samples` → back to budget-only asserts. Its regression surfaces as **errors** (reverting the premise guard yields 2 "assertion might not hold"), caught on every platform.
- `proof_dafny_rational_samples_no_timeout` keeps the `passed` assert — there the timeout IS the regression under test, and it was green on the same CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)