### PR TITLE
website: /grandfather article typography

### DIFF
--- a/tools/website/grandfather.html
+++ b/tools/website/grandfather.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Aver meets its grandfather ACL2: implementing the 1996 AMD K5 division paper as executable laws surfaced a 30-year-old bug in the paper's presentation.">
     <link rel="stylesheet" href="style.css">
     <style>
-        .grandfather-page { max-width: 52rem; margin: 0 auto; padding: 0 1.5rem; }
+        .grandfather-page { max-width: 48rem; margin: 0 auto; padding: 0 1.5rem; }
 
         .grandfather-hero { padding: 3rem 0 1.2rem; }
         .grandfather-hero .eyebrow {
@@ -30,7 +30,7 @@
         .grandfather-hero h1 .accent { color: var(--accent); opacity: 0.92; }
         .grandfather-hero .subhead {
             color: var(--muted);
-            font-size: 1.05rem;
+            font-size: 1.125rem;
             line-height: 1.62;
         }
         .tldr-box {
@@ -60,15 +60,15 @@
         }
         .grandfather-section p {
             color: var(--text);
-            line-height: 1.7;
-            margin-bottom: 0.9rem;
-            font-size: 0.98rem;
+            line-height: 1.54;
+            margin-bottom: 0.95rem;
+            font-size: 1.125rem;
             overflow-wrap: anywhere; /* bare-URL link text must not force horizontal scroll on phones */
         }
         .grandfather-section ol {
             color: var(--text);
-            line-height: 1.7;
-            font-size: 0.98rem;
+            line-height: 1.54;
+            font-size: 1.125rem;
             margin: 0 0 0.9rem 1.4rem;
         }
         .grandfather-section ol li { margin-bottom: 0.25rem; }


### PR DESCRIPTION
Body prose to 1.125rem with 1.54 line-height (long-form standard); column measure back to 48rem so lines stay ~70ch at the larger size; standfirst matches body size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)