### PR TITLE
examples: the corpus check fixes that #490 was supposed to carry

### DIFF
--- a/examples/core/independent_fanout.av
+++ b/examples/core/independent_fanout.av
@@ -116,6 +116,11 @@ fn showListIntInner(xs: List<Int>) -> String
             [] -> "{head}"
             _  -> "{head}, {showListIntInner(tail)}"
 
+verify showListIntInner
+    showListIntInner([]) => ""
+    showListIntInner([7]) => "7"
+    showListIntInner([1, 2, 3]) => "1, 2, 3"
+
 fn showListInt(xs: List<Int>) -> String
     ? "Render a List<Int> as `[1, 2, 3]`. Aver doesn't have map/Show; the helper sits at the call site."
     "[{showListIntInner(xs)}]"

--- a/examples/core/lists.av
+++ b/examples/core/lists.av
@@ -18,6 +18,11 @@ fn showListIntInner(xs: List<Int>) -> String
             [] -> "{head}"
             _  -> "{head}, {showListIntInner(tail)}"
 
+verify showListIntInner
+    showListIntInner([]) => ""
+    showListIntInner([7]) => "7"
+    showListIntInner([1, 2, 3]) => "1, 2, 3"
+
 fn showListString(xs: List<String>) -> String
     ? "Render a List<String> as `[\"a\", \"b\"]`. String elements quoted to disambiguate from bare identifiers."
     "[{showListStringInner(xs)}]"
@@ -29,6 +34,11 @@ fn showListStringInner(xs: List<String>) -> String
         [head, ..tail] -> match tail
             [] -> "\"{head}\""
             _  -> "\"{head}\", {showListStringInner(tail)}"
+
+verify showListStringInner
+    showListStringInner([]) => ""
+    showListStringInner(["a"]) => "\"a\""
+    showListStringInner(["a", "b"]) => "\"a\", \"b\""
 
 fn main() -> Unit
     ! [Console.print]

--- a/examples/core/order_total.av
+++ b/examples/core/order_total.av
@@ -73,10 +73,10 @@ fn sumItems(items: List<Item>) -> Float
 verify sumItems
     sumItems([]) => 0.0
     sumItems([Item(price = 7.0, quantity = 4)]) => 7.0 * 4.0
-    sumItems([Item(price = 5.0, quantity = 3), Item(price = 7.0, quantity = 2)]) => sumItems([Item(price = 5.0, quantity = 3)]) + sumItems([Item(price = 7.0, quantity = 2)])
-    sumItems([Item(price = 5.0, quantity = 3), Item(price = 3.0, quantity = 4)]) => sumItems([Item(price = 5.0, quantity = 3)]) + sumItems([Item(price = 3.0, quantity = 4)])
-    sumItems([Item(price = 10.0, quantity = 1), Item(price = 7.0, quantity = 2)]) => sumItems([Item(price = 10.0, quantity = 1)]) + sumItems([Item(price = 7.0, quantity = 2)])
-    sumItems([Item(price = 10.0, quantity = 1), Item(price = 3.0, quantity = 4)]) => sumItems([Item(price = 10.0, quantity = 1)]) + sumItems([Item(price = 3.0, quantity = 4)])
+    sumItems([Item(price = 5.0, quantity = 3), Item(price = 7.0, quantity = 2)]) => 29.0
+    sumItems([Item(price = 5.0, quantity = 3), Item(price = 3.0, quantity = 4)]) => 27.0
+    sumItems([Item(price = 10.0, quantity = 1), Item(price = 7.0, quantity = 2)]) => 24.0
+    sumItems([Item(price = 10.0, quantity = 1), Item(price = 3.0, quantity = 4)]) => 22.0
 
 fn applyDiscount(subtotal: Float, d: Discount) -> Float
     ? "Reduces subtotal by the discount percentage."
@@ -110,12 +110,12 @@ verify applyTax
     applyTax(200.0, TaxRate(percent = 0.0)) >= 200.0 => true
     applyTax(200.0, TaxRate(percent = 10.0)) >= 200.0 => true
     applyTax(200.0, TaxRate(percent = 50.0)) >= 200.0 => true
-    applyTax(2.0 * 50.0, TaxRate(percent = 0.0)) => 2.0 * applyTax(50.0, TaxRate(percent = 0.0))
-    applyTax(2.0 * 50.0, TaxRate(percent = 10.0)) => 2.0 * applyTax(50.0, TaxRate(percent = 10.0))
-    applyTax(2.0 * 50.0, TaxRate(percent = 25.0)) => 2.0 * applyTax(50.0, TaxRate(percent = 25.0))
-    applyTax(2.0 * 100.0, TaxRate(percent = 0.0)) => 2.0 * applyTax(100.0, TaxRate(percent = 0.0))
-    applyTax(2.0 * 100.0, TaxRate(percent = 10.0)) => 2.0 * applyTax(100.0, TaxRate(percent = 10.0))
-    applyTax(2.0 * 100.0, TaxRate(percent = 25.0)) => 2.0 * applyTax(100.0, TaxRate(percent = 25.0))
+    applyTax(2.0 * 50.0, TaxRate(percent = 0.0)) => 100.0
+    applyTax(2.0 * 50.0, TaxRate(percent = 10.0)) => 110.0
+    applyTax(2.0 * 50.0, TaxRate(percent = 25.0)) => 125.0
+    applyTax(2.0 * 100.0, TaxRate(percent = 0.0)) => 200.0
+    applyTax(2.0 * 100.0, TaxRate(percent = 10.0)) => 220.0
+    applyTax(2.0 * 100.0, TaxRate(percent = 25.0)) => 250.0
 
 fn calculateTotal(items: List<Item>, d: Discount, t: TaxRate) -> Float
     ? "Sums items, applies discount, applies tax. Assumes valid Discount and TaxRate."
@@ -140,6 +140,11 @@ fn showDiscount(r: Result<Discount, String>) -> String
     match r
         Result.Ok(d)    -> "Discount({d.percent})"
         Result.Err(msg) -> "Err(\"{msg}\")"
+
+verify showDiscount
+    showDiscount(Result.Err("Discount cannot be negative")) => "Err(\"Discount cannot be negative\")"
+    showDiscount(mkDiscount(100.1)) => "Err(\"Discount cannot exceed 100%\")"
+    String.startsWith(showDiscount(Result.Ok(Discount(percent = 25.0))), "Discount(") => true
 
 fn main() -> Unit
     ! [Console.print]

--- a/examples/core/temperature.av
+++ b/examples/core/temperature.av
@@ -106,6 +106,11 @@ fn showKelvin(r: Result<Float, String>) -> String
         Result.Ok(k)    -> "K({k})"
         Result.Err(msg) -> "Err(\"{msg}\")"
 
+verify showKelvin
+    showKelvin(Result.Err("Below absolute zero")) => "Err(\"Below absolute zero\")"
+    String.startsWith(showKelvin(Result.Ok(273.15)), "K(") => true
+    String.endsWith(showKelvin(Result.Ok(273.15)), ")") => true
+
 fn showListFloatInner(xs: List<Float>) -> String
     ? "Comma-separated body of a List<Float> render."
     match xs
@@ -113,6 +118,11 @@ fn showListFloatInner(xs: List<Float>) -> String
         [head, ..tail] -> match tail
             [] -> "{head}"
             _  -> "{head}, {showListFloatInner(tail)}"
+
+verify showListFloatInner
+    showListFloatInner([]) => ""
+    String.contains(showListFloatInner([1.5]), ", ") => false
+    String.contains(showListFloatInner([0.0, -10.0]), ", ") => true
 
 fn showListFloat(xs: List<Float>) -> String
     ? "Render List<Float> as `[1.0, 2.0]`."

--- a/examples/data/fibonacci.av
+++ b/examples/data/fibonacci.av
@@ -197,6 +197,11 @@ fn showListIntInner(xs: List<Int>) -> String
             [] -> "{head}"
             _  -> "{head}, {showListIntInner(tail)}"
 
+verify showListIntInner
+    showListIntInner([]) => ""
+    showListIntInner([7]) => "7"
+    showListIntInner([0, 1, 1, 2]) => "0, 1, 1, 2"
+
 fn showListInt(xs: List<Int>) -> String
     ? "Render List<Int> as `[1, 2, 3]`."
     "[{showListIntInner(xs)}]"
@@ -247,6 +252,11 @@ fn showGolden(r: Result<Float, String>) -> String
     match r
         Result.Ok(x)    -> "Ok({x})"
         Result.Err(msg) -> "Err(\"{msg}\")"
+
+verify showGolden
+    showGolden(Result.Err("Need n >= 1")) => "Err(\"Need n >= 1\")"
+    String.startsWith(showGolden(Result.Ok(1.5)), "Ok(") => true
+    String.endsWith(showGolden(Result.Ok(1.5)), ")") => true
 
 fn main() -> Unit
     ! [Console.print]

--- a/examples/data/quicksort.av
+++ b/examples/data/quicksort.av
@@ -99,6 +99,11 @@ fn showListIntInner(xs: List<Int>) -> String
             [] -> "{head}"
             _  -> "{head}, {showListIntInner(tail)}"
 
+verify showListIntInner
+    showListIntInner([]) => ""
+    showListIntInner([7]) => "7"
+    showListIntInner([1, 2, 3]) => "1, 2, 3"
+
 fn showListInt(xs: List<Int>) -> String
     ? "Render List<Int> as `[1, 2, 3]`."
     "[{showListIntInner(xs)}]"

--- a/examples/data/red_black_tree.av
+++ b/examples/data/red_black_tree.av
@@ -401,6 +401,11 @@ fn showListIntInner(xs: List<Int>) -> String
       [] -> "{head}"
       _  -> "{head}, {showListIntInner(tail)}"
 
+verify showListIntInner
+  showListIntInner([]) => ""
+  showListIntInner([7]) => "7"
+  showListIntInner([1, 2, 3]) => "1, 2, 3"
+
 fn showListInt(xs: List<Int>) -> String
   ? "Render a List<Int> as `[1, 2, 3]`. Aver doesn't have map/Show; the helper sits at the call site."
   "[{showListIntInner(xs)}]"

--- a/examples/data/sparse.av
+++ b/examples/data/sparse.av
@@ -21,11 +21,21 @@ fn repeat0(n: Int) -> List<Int>
         true -> []
         false -> List.concat(repeat0(n - 1), [0])
 
+verify repeat0
+    repeat0(0) => []
+    repeat0(-2) => []
+    repeat0(3) => [0, 0, 0]
+
 fn expandTok(t: Token) -> List<Int>
     ? "Expand one token back to the Int run it stands for."
     match t
         Token.Zeros(n) -> repeat0(n)
         Token.Lit(x) -> [x]
+
+verify expandTok
+    expandTok(Token.Lit(7)) => [7]
+    expandTok(Token.Zeros(2)) => [0, 0]
+    expandTok(Token.Zeros(0)) => []
 
 fn decodeSparse(toks: List<Token>) -> List<Int>
     ? "Decompress a token list by concatenating each token's expansion."
@@ -43,6 +53,11 @@ fn flushSparse(acc: SparseAcc) -> List<Token>
         true -> acc.out
         false -> List.concat(acc.out, [Token.Zeros(acc.pending)])
 
+verify flushSparse
+    flushSparse(SparseAcc(out = [], pending = 0)) => []
+    flushSparse(SparseAcc(out = [Token.Lit(5)], pending = 0)) => [Token.Lit(5)]
+    flushSparse(SparseAcc(out = [Token.Lit(5)], pending = 2)) => [Token.Lit(5), Token.Zeros(2)]
+
 fn sparseStep(acc: SparseAcc, x: Int) -> SparseAcc
     ? "Fold step: grow the pending zero-run, or flush it and emit a literal."
     match x == 0
@@ -58,6 +73,11 @@ fn sparseLoop(xs: List<Int>, acc: SparseAcc) -> List<Token>
     match xs
         [] -> flushSparse(acc)
         [x, ..rest] -> sparseLoop(rest, sparseStep(acc, x))
+
+verify sparseLoop
+    sparseLoop([], SparseAcc(out = [], pending = 0)) => []
+    sparseLoop([5, 0, 0, 7], SparseAcc(out = [], pending = 0)) => [Token.Lit(5), Token.Zeros(2), Token.Lit(7)]
+    sparseLoop([0, 9], SparseAcc(out = [Token.Lit(5)], pending = 1)) => [Token.Lit(5), Token.Zeros(2), Token.Lit(9)]
 
 fn encodeSparse(xs: List<Int>) -> List<Token>
     ? "Compresses runs of zero in an Int list."


### PR DESCRIPTION
#490's squash shipped only the CHANGELOG hunks — the atomic `git apply --3way` rolled back all eight example files when the CHANGELOG hunk conflicted, and the follow-up gate masked it behind a piped exit code (`aver check ... | tail` reports tail's status). Caught during the final pre-release re-verification.

This lands the (already adversarially reviewed, mutation-tested) example changes themselves:
- `order_total.av`: expected sides as VM-computed literals + the missing `showDiscount` block (11 errors → 0)
- `sparse.av`: meaningful verify blocks for the four scanner helpers (4 errors → 0)
- six files with pre-existing missing-verify on render helpers: minimal VM-verified blocks

Gates re-run on bare exit codes: `aver check examples/core` → 0, `examples/data` → 0; `aver verify` 55/55 and 21/21 on the two main files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)