### PR TITLE
honesty: CI example gate, audit verify-rhs, wasm-gc string scalars and Result equality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,20 @@ jobs:
           PROPTEST_CASES: '2000'
         run: cargo test --workspace
 
+      - name: Check shipped examples
+        # Gate the shipped example corpus: a merge that breaks an
+        # example under `aver check` must fail CI, not ship silently.
+        # `cargo test --workspace` above already compiled the debug
+        # `aver` binary (the CLI integration tests run it via
+        # CARGO_BIN_EXE_aver), so `cargo run` here is a cache hit, not
+        # a rebuild. Only `examples/core` and `examples/data` are
+        # gated — `examples/diagnostics` contains deliberately broken
+        # files (lint/error demos) and stays ungated. Bare exit codes:
+        # each command's status fails the step directly, no pipes.
+        run: |
+          cargo run --bin aver -- check examples/core
+          cargo run --bin aver -- check examples/data
+
   wasm:
     name: WASM
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
+## 0.25.1 (unreleased)
+
+### Fixed
+
+- **wasm-gc strings count characters, not bytes** — `String.len`, `String.charAt`, `String.slice`, and `String.chars` now use Unicode character (scalar) counts and indices, matching the VM and the documentation on every multi-byte string. `String.byteLength` still counts UTF-8 bytes. `examples/data/json.av` passes `aver verify --wasm-gc` in full, including its emoji cases.
+- **Comparing `Result` values no longer traps on wasm-gc** when one module wraps two different record types in `Result<…, String>` — `Result.Ok`/`Result.Err` now build the instantiation the type checker resolved at the site instead of guessing from the payload type. `examples/core/order_total.av` passes `aver verify --wasm-gc` in full.
+- **`aver audit` counts every check error in its total and exit code** — `error[verify-rhs]` (a verify case calling the function under test on the right side of `=>`) was printed but excluded from both, so a file with only such errors audited green.
+
+### Changed
+
+- **CI gates the shipped example corpus** — `examples/core` and `examples/data` must pass `aver check` on every pull request; a merge can no longer silently break a shipped example.
+
 ## 0.25.0 "The Method" — 2026-06-12
 
 The release where the prover learned to be steered by lemmas — named after the proof methodology of ACL2's Kaufmann & Moore, whose 30-year-old terrain this release kept rediscovering.

--- a/docs/services.md
+++ b/docs/services.md
@@ -110,18 +110,18 @@ Source: `src/types/string.rs`
 
 | Function | Signature | Notes |
 |---|---|---|
-| `String.len` | `String -> Int` | |
-| `String.byteLength` | `String -> Int` | |
-| `String.charAt` | `(String, Int) -> Option<String>` | Single char or `Option.None` on out-of-bounds |
+| `String.len` | `String -> Int` | Number of characters (Unicode scalar values), on every backend |
+| `String.byteLength` | `String -> Int` | UTF-8 byte count |
+| `String.charAt` | `(String, Int) -> Option<String>` | Character at character index, or `Option.None` on out-of-bounds |
 | `String.startsWith` | `(String, String) -> Bool` | |
 | `String.endsWith` | `(String, String) -> Bool` | |
 | `String.contains` | `(String, String) -> Bool` | |
-| `String.slice` | `(String, Int, Int) -> String` | |
+| `String.slice` | `(String, Int, Int) -> String` | Character indices; out-of-range ends clamp |
 | `String.trim` | `String -> String` | |
 | `String.split` | `(String, String) -> List<String>` | |
 | `String.replace` | `(String, String, String) -> String` | |
 | `String.join` | `(List<String>, String) -> String` | |
-| `String.chars` | `String -> List<String>` | |
+| `String.chars` | `String -> List<String>` | Splits into characters (Unicode scalar values) |
 | `String.fromInt` | `Int -> String` | |
 | `String.fromFloat` | `Float -> String` | |
 | `String.fromBool` | `Bool -> String` | |

--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -1,6 +1,6 @@
 //! Built-in call lowering: the custom-inline `Float` / `Int` / `Bool`
 //! scalar ops, `Char.toCode`, the custom-inline `String` ops
-//! (`length` / `byteLength` / `split` / `join`), the `List` / `Vector`
+//! (`length` / `split` / `join`), the `List` / `Vector`
 //! / `Map` families, the fused `Option.withDefault(Vector.get,
 //! <literal>)` / `Option.withDefault(Vector.set, v)` /
 //! `Result.withDefault(Int.mod, default)`, and the numeric `BinOp`
@@ -96,7 +96,7 @@ pub(crate) fn emit_mir_wasip2_effect(
 /// `fn_map.builtins.get(dotted)` lookup misses them. Covers the native
 /// scalar `Float` / `Int` / `Bool` ops, `Char.toCode`, and the `String`
 /// ops whose helper is keyed under a *different* name than the surface
-/// builtin — `String.length` / `String.byteLength` dispatch to the
+/// builtin — `String.length` dispatches to the
 /// `String.len` helper, and `String.split` / `String.join` to the
 /// singleton `string_split_ops`. Each recurses `emit_mir_expr` on its
 /// args — the byte-identical analogue of the oracle's `emit_expr`.
@@ -230,16 +230,18 @@ pub(crate) fn emit_mir_native_scalar_builtin(
             func.instruction(&Instruction::ArrayGetU(s_idx));
             func.instruction(&Instruction::I64ExtendI32U);
         }
-        // Both surface spellings dispatch to the one `String.len`
-        // helper (keyed under `String.len`, not the surface name).
-        "String.length" | "String.byteLength" if args.len() == 1 => {
+        // Alias spelling for `String.len` (scalar count) — the helper
+        // is keyed under `String.len`, not the surface name.
+        // `String.byteLength` has its own helper (keyed by surface
+        // name) and rides the generic `fn_map.builtins` path.
+        "String.length" if args.len() == 1 => {
             let len_idx =
                 ctx.fn_map
                     .builtins
                     .get("String.len")
                     .copied()
                     .ok_or(WasmGcError::Validation(
-                        "String.length / byteLength require the String.len builtin".into(),
+                        "String.length requires the String.len builtin".into(),
                     ))?;
             arg!(0);
             func.instruction(&Instruction::Call(len_idx));

--- a/src/codegen/wasm_gc/body/from_mir/constructors.rs
+++ b/src/codegen/wasm_gc/body/from_mir/constructors.rs
@@ -85,15 +85,23 @@ pub(crate) fn emit_mir_option_constructor(
     Ok(Some(()))
 }
 
-/// Mirror of `emit_result_constructor` (emit.rs): resolve the
-/// `Result<T,E>` instantiation (single registered / by return type / by
-/// payload-type match), then `i32.const <tag>; <T-slot>; <E-slot>;
-/// struct.new $result`. A `Unit` payload position pushes the `i32`
-/// placeholder rather than the (no-value) `Unit`.
+/// Resolve the `Result<T,E>` instantiation (constructor's stamped type
+/// / single registered / by return type / by payload-type match), then
+/// `i32.const <tag>; <T-slot>; <E-slot>; struct.new $result`. A `Unit`
+/// payload position pushes the `i32` placeholder rather than the
+/// (no-value) `Unit`.
+///
+/// The stamped type comes first: payload-type matching is ambiguous
+/// whenever two instantiations share a position type (two records in
+/// one module each wrapped in `Result<RecordX, String>` — an
+/// `Result.Err("…")` payload `String` matches both, and picking the
+/// wrong one builds a struct the per-instantiation eq helper later
+/// `ref.cast`s to the other instantiation's heap type → runtime trap).
 pub(crate) fn emit_mir_result_constructor(
     func: &mut Function,
     variant: &str,
     payload: Option<&Spanned<MirExpr>>,
+    stamped_ty: Option<&crate::types::Type>,
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<Option<()>, WasmGcError> {
@@ -101,7 +109,18 @@ pub(crate) fn emit_mir_result_constructor(
         "Result.{variant} requires a payload"
     )))?;
     let payload_ty = aver_type_str_of(payload);
-    let canonical = if ctx.registry.result_order.len() == 1 {
+    // The type checker stamps the constructor node with the concrete
+    // `Result<T,E>` it unified at this site (e.g. the compared LHS's
+    // type inside a synthesized verify `==` check fn). Trust it when
+    // it names a registered instantiation; types containing `Unknown`
+    // or unregistered shapes fall through to the positional heuristics.
+    let stamped_canonical: Option<String> =
+        stamped_ty.map(|t| t.display().chars().filter(|c| !c.is_whitespace()).collect());
+    let canonical = if let Some(stamped) =
+        stamped_canonical.filter(|c| ctx.registry.result_type_idx(c).is_some())
+    {
+        stamped
+    } else if ctx.registry.result_order.len() == 1 {
         ctx.registry.result_order[0].clone()
     } else {
         let return_canonical: String = ctx

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -40,7 +40,7 @@
 //! - [`collections`] — `List` literals.
 //! - [`builtins`] — the custom-inline `Float` / `Int` / `Bool` scalar
 //!   ops, `Char.toCode`, the custom-inline `String` ops (`length` /
-//!   `byteLength` / `split` / `join`), the `List` / `Vector` / `Map`
+//!   `split` / `join`), the `List` / `Vector` / `Map`
 //!   families, the
 //!   fused `Option.withDefault(Vector.get(v, i), <literal>)` /
 //!   `Option.withDefault(Vector.set(v, i, x), v)` /
@@ -683,12 +683,22 @@ pub(crate) fn emit_mir_expr(
                         });
                     emit_mir_option_constructor(func, None, Some(&hint), slots, ctx)?
                 }
-                MirCtor::Builtin(BuiltinCtor::ResultOk) => {
-                    emit_mir_result_constructor(func, "Ok", con.args.first(), slots, ctx)?
-                }
-                MirCtor::Builtin(BuiltinCtor::ResultErr) => {
-                    emit_mir_result_constructor(func, "Err", con.args.first(), slots, ctx)?
-                }
+                MirCtor::Builtin(BuiltinCtor::ResultOk) => emit_mir_result_constructor(
+                    func,
+                    "Ok",
+                    con.args.first(),
+                    expr.ty(),
+                    slots,
+                    ctx,
+                )?,
+                MirCtor::Builtin(BuiltinCtor::ResultErr) => emit_mir_result_constructor(
+                    func,
+                    "Err",
+                    con.args.first(),
+                    expr.ty(),
+                    slots,
+                    ctx,
+                )?,
                 MirCtor::User(ctor_id) => {
                     let info = mir_user_variant_info(ctor_id, ctx)?;
                     emit_mir_constructor_with_args(func, info, &con.args, slots, ctx)?

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -74,7 +74,15 @@ use super::wat_helper;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) enum BuiltinName {
     StringFromInt,
+    /// `String.len(s) -> Int` — Unicode scalar value count, matching
+    /// the VM's `s.chars().count()` semantics (docs: "number of
+    /// characters"). One pass over the UTF-8 byte array counting
+    /// non-continuation bytes.
     StringLength,
+    /// `String.byteLength(s) -> Int` — UTF-8 byte count (`array.len`).
+    /// The VM's `s.len()` counterpart; distinct from `String.len`
+    /// whenever the string holds multi-byte characters.
+    StringByteLength,
     /// Variadic-by-array string concatenation: `(array (ref null $string))
     /// -> (ref null $string)`. Sums the per-part lengths once,
     /// allocates the result, copies each part. O(total_len) regardless
@@ -141,7 +149,8 @@ impl BuiltinName {
         match s {
             "String.fromInt" => Some(Self::StringFromInt),
             "String.fromFloat" => Some(Self::StringFromFloat),
-            "String.len" | "String.length" | "String.byteLength" => Some(Self::StringLength),
+            "String.len" | "String.length" => Some(Self::StringLength),
+            "String.byteLength" => Some(Self::StringByteLength),
             "String.startsWith" => Some(Self::StringStartsWith),
             "String.contains" => Some(Self::StringContains),
             "String.slice" => Some(Self::StringSlice),
@@ -166,6 +175,7 @@ impl BuiltinName {
         match self {
             Self::StringFromInt => "String.fromInt",
             Self::StringLength => "String.len",
+            Self::StringByteLength => "String.byteLength",
             Self::StringConcatN => "__wasmgc_concat_n",
             Self::StringStartsWith => "String.startsWith",
             Self::StringContains => "String.contains",
@@ -194,7 +204,7 @@ impl BuiltinName {
     pub(super) fn params(self, registry: &TypeRegistry) -> Result<Vec<ValType>, WasmGcError> {
         match self {
             Self::StringFromInt => Ok(vec![ValType::I64]),
-            Self::StringLength => Ok(vec![string_ref_ty(registry)?]),
+            Self::StringLength | Self::StringByteLength => Ok(vec![string_ref_ty(registry)?]),
             Self::StringConcatN => Ok(vec![string_array_ref_ty(registry)?]),
             Self::StringStartsWith | Self::StringContains => {
                 Ok(vec![string_ref_ty(registry)?, string_ref_ty(registry)?])
@@ -227,7 +237,7 @@ impl BuiltinName {
     pub(super) fn results(self, registry: &TypeRegistry) -> Result<Vec<ValType>, WasmGcError> {
         match self {
             Self::StringFromInt => Ok(vec![string_ref_ty(registry)?]),
-            Self::StringLength => Ok(vec![ValType::I64]),
+            Self::StringLength | Self::StringByteLength => Ok(vec![ValType::I64]),
             Self::StringConcatN => Ok(vec![string_ref_ty(registry)?]),
             Self::StringStartsWith | Self::StringContains => Ok(vec![ValType::I32]),
             Self::StringSlice
@@ -259,6 +269,7 @@ impl BuiltinName {
         match self {
             Self::StringFromInt => emit_string_from_int(registry),
             Self::StringLength => emit_string_length(registry),
+            Self::StringByteLength => emit_string_byte_length(registry),
             Self::StringConcatN => emit_string_concat_n(registry),
             Self::StringStartsWith => emit_string_starts_with(registry),
             Self::StringContains => emit_string_contains(registry),
@@ -703,13 +714,69 @@ fn emit_string_concat_n(registry: &TypeRegistry) -> Result<Function, WasmGcError
     wat_helper::compile_wat_helper(&wat)
 }
 
-/// `String.length(s) -> Int`. Trivial wrapper over the wasm-gc
-/// `array.len` instruction; widened to i64 to match Aver's `Int`.
+/// `String.len(s) -> Int` — Unicode scalar value count, matching the
+/// VM's `s.chars().count()`. Strings are stored as UTF-8 `(array i8)`,
+/// so the scalar count equals the number of non-continuation bytes:
+/// one pass adding `(b & 0xC0) != 0x80` per byte. O(len) instead of
+/// the old O(1) `array.len` — the price of matching the documented
+/// "number of characters" semantics (`array.len` counted bytes, which
+/// diverged from the VM on any multi-byte character).
 fn emit_string_length(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let string_idx = registry
         .string_array_type_idx
         .ok_or(WasmGcError::Validation(
-            "String.length helper requires String slot to be allocated".into(),
+            "String.len helper requires String slot to be allocated".into(),
+        ))?;
+    let padding = wat_helper::padding_types(string_idx);
+    let wat = format!(
+        r#"
+        (module
+          {padding}
+          (type $string (array (mut i8)))
+          (func (export "helper") (param $s (ref null $string)) (result i64)
+            (local $i i32) (local $n i32) (local $count i32)
+            local.get $s
+            array.len
+            local.set $n
+            (block $done
+              (loop $scan
+                local.get $i
+                local.get $n
+                i32.ge_u
+                br_if $done
+
+                ;; count += (s[i] & 0xC0) != 0x80
+                local.get $count
+                local.get $s
+                local.get $i
+                array.get_u $string
+                i32.const 0xC0
+                i32.and
+                i32.const 0x80
+                i32.ne
+                i32.add
+                local.set $count
+
+                local.get $i
+                i32.const 1
+                i32.add
+                local.set $i
+                br $scan))
+            local.get $count
+            i64.extend_i32_u)
+        )
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `String.byteLength(s) -> Int`. Trivial wrapper over the wasm-gc
+/// `array.len` instruction; widened to i64 to match Aver's `Int`.
+fn emit_string_byte_length(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let string_idx = registry
+        .string_array_type_idx
+        .ok_or(WasmGcError::Validation(
+            "String.byteLength helper requires String slot to be allocated".into(),
         ))?;
     let padding = wat_helper::padding_types(string_idx);
     let wat = format!(
@@ -915,10 +982,14 @@ fn emit_string_contains(registry: &TypeRegistry) -> Result<Function, WasmGcError
     wat_helper::compile_wat_helper(&wat)
 }
 
-/// `String.slice(s, start, end) -> String`. Byte-indexed slice;
-/// clamps both ends to `[0, len(s)]` and `start..end`. Empty when
-/// `start >= end`. Same byte-based semantics as the wasm-gc
-/// `String.len` (both report bytes, not code points).
+/// `String.slice(s, start, end) -> String`. `start` / `end` are
+/// Unicode scalar indices, mirroring the VM's `aver_rt::string_slice`
+/// (negative ends clamp to 0; `start >= end` is empty; indices past
+/// the last character clamp to the end of the string). One pass over
+/// the UTF-8 byte array translates both scalar indices to byte
+/// offsets, then a single `array.copy` extracts the range. The old
+/// body treated the indices as byte offsets, which diverged from the
+/// VM on any multi-byte character and could slice characters in half.
 fn emit_string_slice(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let (_, preamble) = string_module_preamble(registry)?;
     let wat = format!(
@@ -930,70 +1001,105 @@ fn emit_string_slice(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
                 (param $start64 i64)
                 (param $end64 i64)
                 (result (ref null $string))
-            (local $slen i32)
-            (local $start i32)
-            (local $end i32)
+            (local $n i32)
+            (local $start i64)
+            (local $end i64)
+            (local $b i32)
+            (local $k i64)
+            (local $start_byte i32)
+            (local $end_byte i32)
             (local $len i32)
             (local $out (ref null $string))
 
-            local.get $s array.len local.set $slen
+            local.get $s array.len local.set $n
 
-            ;; start = clamp(start64, 0, slen)
+            ;; start = max(start64, 0); end = max(end64, 0)
             local.get $start64
             i64.const 0
             i64.lt_s
-            (if (result i32)
-              (then i32.const 0)
-              (else
-                local.get $start64
-                local.get $slen
-                i64.extend_i32_u
-                i64.gt_s
-                (if (result i32)
-                  (then local.get $slen)
-                  (else local.get $start64 i32.wrap_i64))))
+            (if (result i64) (then i64.const 0) (else local.get $start64))
             local.set $start
-
             local.get $end64
             i64.const 0
             i64.lt_s
-            (if (result i32)
-              (then i32.const 0)
-              (else
-                local.get $end64
-                local.get $slen
-                i64.extend_i32_u
-                i64.gt_s
-                (if (result i32)
-                  (then local.get $slen)
-                  (else local.get $end64 i32.wrap_i64))))
+            (if (result i64) (then i64.const 0) (else local.get $end64))
             local.set $end
 
-            ;; len = max(0, end - start)
-            local.get $end
+            ;; start >= end → ""
             local.get $start
-            i32.le_s
-            (if (result i32)
-              (then i32.const 0)
-              (else
-                local.get $end
-                local.get $start
-                i32.sub))
-            local.set $len
+            local.get $end
+            i64.ge_s
+            (if (then i32.const 0 array.new_default $string return))
 
+            ;; walk scalars; -1 = byte offset not found yet
+            i32.const -1 local.set $start_byte
+            i32.const -1 local.set $end_byte
+            (block $done
+              (loop $scan
+                local.get $b
+                local.get $n
+                i32.ge_u
+                br_if $done
+
+                ;; k == start → start_byte = b
+                local.get $k
+                local.get $start
+                i64.eq
+                (if (then local.get $b local.set $start_byte))
+
+                ;; k == end → end_byte = b, stop
+                local.get $k
+                local.get $end
+                i64.eq
+                (if (then local.get $b local.set $end_byte br $done))
+
+                ;; b += UTF-8 length of the scalar starting at b
+                ;; (<0xC0 → 1, <0xE0 → 2, <0xF0 → 3, else 4)
+                local.get $b i32.const 1 i32.add local.set $len
+                local.get $s local.get $b array.get_u $string
+                i32.const 0xC0 i32.ge_u
+                (if (then local.get $b i32.const 2 i32.add local.set $len))
+                local.get $s local.get $b array.get_u $string
+                i32.const 0xE0 i32.ge_u
+                (if (then local.get $b i32.const 3 i32.add local.set $len))
+                local.get $s local.get $b array.get_u $string
+                i32.const 0xF0 i32.ge_u
+                (if (then local.get $b i32.const 4 i32.add local.set $len))
+                local.get $len local.set $b
+
+                local.get $k i64.const 1 i64.add local.set $k
+                br $scan))
+
+            ;; scalar index exactly at the end of the string
+            local.get $start_byte i32.const -1 i32.eq
+            local.get $k local.get $start i64.eq
+            i32.and
+            (if (then local.get $n local.set $start_byte))
+            local.get $end_byte i32.const -1 i32.eq
+            local.get $k local.get $end i64.eq
+            i32.and
+            (if (then local.get $n local.set $end_byte))
+
+            ;; unresolved (index past the end) → clamp to byte length
+            local.get $start_byte i32.const -1 i32.eq
+            (if (then local.get $n local.set $start_byte))
+            local.get $end_byte i32.const -1 i32.eq
+            (if (then local.get $n local.set $end_byte))
+
+            ;; start_byte >= end_byte → ""
+            local.get $start_byte
+            local.get $end_byte
+            i32.ge_s
+            (if (then i32.const 0 array.new_default $string return))
+
+            local.get $end_byte local.get $start_byte i32.sub local.set $len
             local.get $len
             array.new_default $string
             local.set $out
-
-            local.get $len
-            i32.eqz
-            (if (then local.get $out return))
-
-            ;; array.copy out[0..len] <- s[start..start+len]
             local.get $out
             i32.const 0
             local.get $s
-            local.get $start
+            local.get $start_byte
             local.get $len
             array.copy $string $string
 
@@ -2119,13 +2225,15 @@ fn emit_string_from_bool(registry: &TypeRegistry) -> Result<Function, WasmGcErro
     wat_helper::compile_wat_helper(&wat)
 }
 
-/// `String.charAt(s: String, i: Int) -> Option<String>`. Bounds-
-/// check `i`, return `Option.Some(<one-byte string>)` on hit or
-/// `Option.None` on out-of-range. Uses `wasm_encoder` directly
-/// (instead of WAT compile) since the helper needs to materialise
-/// an `Option<String>` struct, which needs a known type idx.
+/// `String.charAt(s: String, i: Int) -> Option<String>`. `i` is a
+/// Unicode scalar index (the VM's `s.chars().nth(i)`), NOT a byte
+/// index: scan the UTF-8 byte array scalar by scalar, and on hit
+/// return `Option.Some(<full character>)` — all 1–4 bytes of it.
+/// `Option.None` on a negative or past-the-end index. The old body
+/// indexed bytes and returned a single byte, which both diverged
+/// from the VM and tore multi-byte characters apart.
 fn emit_string_char_at(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
-    let s_idx = registry
+    let string_idx = registry
         .string_array_type_idx
         .ok_or(WasmGcError::Validation(
             "String.charAt: String slot not registered".into(),
@@ -2135,56 +2243,103 @@ fn emit_string_char_at(registry: &TypeRegistry) -> Result<Function, WasmGcError>
         .ok_or(WasmGcError::Validation(
             "String.charAt: Option<String> slot not registered".into(),
         ))?;
-    let string_ref = ValType::Ref(wasm_encoder::RefType {
-        nullable: true,
-        heap_type: wasm_encoder::HeapType::Concrete(s_idx),
-    });
-    let opt_ref = ValType::Ref(wasm_encoder::RefType {
-        nullable: true,
-        heap_type: wasm_encoder::HeapType::Concrete(opt_idx),
-    });
-    // params: 0=s, 1=i (i64). locals: 2=out, 3=i32_idx.
-    let mut f = Function::new([(1, string_ref), (1, ValType::I32)]);
-    let block_ty = wasm_encoder::BlockType::Result(opt_ref);
-    // i >= 0 ?
-    f.instruction(&Instruction::LocalGet(1));
-    f.instruction(&Instruction::I64Const(0));
-    f.instruction(&Instruction::I64GeS);
-    // i < s.len ?
-    f.instruction(&Instruction::LocalGet(1));
-    f.instruction(&Instruction::I32WrapI64);
-    f.instruction(&Instruction::LocalSet(3));
-    f.instruction(&Instruction::LocalGet(3));
-    f.instruction(&Instruction::LocalGet(0));
-    f.instruction(&Instruction::ArrayLen);
-    f.instruction(&Instruction::I32LtU);
-    // and
-    f.instruction(&Instruction::I32And);
-    f.instruction(&Instruction::If(block_ty));
-    // in-range: build 1-byte string, return Some(it)
-    f.instruction(&Instruction::I32Const(1));
-    f.instruction(&Instruction::ArrayNewDefault(s_idx));
-    f.instruction(&Instruction::LocalSet(2));
-    f.instruction(&Instruction::LocalGet(2));
-    f.instruction(&Instruction::I32Const(0));
-    f.instruction(&Instruction::LocalGet(0));
-    f.instruction(&Instruction::LocalGet(3));
-    f.instruction(&Instruction::ArrayGetU(s_idx));
-    f.instruction(&Instruction::ArraySet(s_idx));
-    // Option layout: (mut i32 tag) (mut T value). tag=1 = Some.
-    f.instruction(&Instruction::I32Const(1));
-    f.instruction(&Instruction::LocalGet(2));
-    f.instruction(&Instruction::StructNew(opt_idx));
-    f.instruction(&Instruction::Else);
-    // OOB: tag=0, value=null
-    f.instruction(&Instruction::I32Const(0));
-    f.instruction(&Instruction::RefNull(wasm_encoder::HeapType::Concrete(
-        s_idx,
-    )));
-    f.instruction(&Instruction::StructNew(opt_idx));
-    f.instruction(&Instruction::End);
-    f.instruction(&Instruction::End);
-    Ok(f)
+    if opt_idx <= string_idx {
+        return Err(WasmGcError::Validation(format!(
+            "String.charAt helper expects opt_idx > string_idx (got {opt_idx} vs {string_idx})"
+        )));
+    }
+    let pre_string = wat_helper::padding_types(string_idx);
+    let between = wat_helper::padding_types(opt_idx - string_idx - 1);
+    let wat = format!(
+        r#"
+        (module
+          {pre_string}
+          (type $string (array (mut i8)))
+          {between}
+          (type $option_string (struct (field $tag i32) (field $val (ref null $string))))
+          (func (export "helper")
+                (param $s (ref null $string))
+                (param $i i64)
+                (result (ref null $option_string))
+            (local $n i32)
+            (local $b i32)
+            (local $k i64)
+            (local $clen i32)
+            (local $out (ref null $string))
+
+            local.get $s array.len local.set $n
+
+            ;; negative index → None
+            local.get $i
+            i64.const 0
+            i64.lt_s
+            (if (then
+              i32.const 0
+              ref.null $string
+              struct.new $option_string
+              return))
+
+            (block $found
+              (loop $scan
+                ;; cursor past the last byte → index out of range → None
+                local.get $b
+                local.get $n
+                i32.ge_u
+                (if (then
+                  i32.const 0
+                  ref.null $string
+                  struct.new $option_string
+                  return))
+
+                ;; clen = UTF-8 length from the lead byte:
+                ;; <0xC0 → 1 (ASCII; stray continuation defends as 1),
+                ;; <0xE0 → 2, <0xF0 → 3, else 4
+                i32.const 1
+                local.set $clen
+                local.get $s local.get $b array.get_u $string
+                i32.const 0xC0 i32.ge_u
+                (if (then i32.const 2 local.set $clen))
+                local.get $s local.get $b array.get_u $string
+                i32.const 0xE0 i32.ge_u
+                (if (then i32.const 3 local.set $clen))
+                local.get $s local.get $b array.get_u $string
+                i32.const 0xF0 i32.ge_u
+                (if (then i32.const 4 local.set $clen))
+
+                ;; reached the target scalar?
+                local.get $k
+                local.get $i
+                i64.eq
+                br_if $found
+
+                local.get $b local.get $clen i32.add local.set $b
+                local.get $k i64.const 1 i64.add local.set $k
+                br $scan))
+
+            ;; clamp clen to the remaining bytes (truncated UTF-8 tail)
+            local.get $b local.get $clen i32.add
+            local.get $n
+            i32.gt_u
+            (if (then
+              local.get $n local.get $b i32.sub local.set $clen))
+
+            local.get $clen
+            array.new_default $string
+            local.set $out
+            local.get $out
+            i32.const 0
+            local.get $s
+            local.get $b
+            local.get $clen
+            array.copy $string $string
+
+            i32.const 1
+            local.get $out
+            struct.new $option_string)
+        )
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
 }
 
 /// `Char.fromCode(code: Int) -> Option<String>`. Encodes a Unicode
@@ -2352,8 +2507,7 @@ fn emit_char_from_code(registry: &TypeRegistry) -> Result<Function, WasmGcError>
 
 /// `String.chars(s: String) -> List<String>`. Iterates `s` right-to-
 /// left building a cons list directly (no reverse pass). Each
-/// character is its own 1-byte string allocation — N allocations
-/// for an N-byte input. Same shape the legacy backend uses.
+/// Unicode scalar value is its own 1–4 byte string allocation.
 fn emit_string_chars(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let s_idx = registry
         .string_array_type_idx
@@ -2373,13 +2527,27 @@ fn emit_string_chars(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
         nullable: true,
         heap_type: wasm_encoder::HeapType::Concrete(list_idx),
     });
-    // params: 0=s. locals: 1=acc, 2=i, 3=cell.
-    let mut f = Function::new([(1, list_ref), (1, ValType::I32), (1, string_ref)]);
+    // Splits into Unicode scalar values (the VM's `s.chars()`), not
+    // single bytes. Reverse byte scan so the list cons-builds in
+    // source order without a final reverse pass: a byte with
+    // `(b & 0xC0) != 0x80` starts a character, and `end` tracks the
+    // exclusive end of the character being collected.
+    // params: 0=s. locals: 1=acc, 2=i, 3=cell, 4=end, 5=clen.
+    let mut f = Function::new([
+        (1, list_ref),
+        (1, ValType::I32),
+        (1, string_ref),
+        (2, ValType::I32),
+    ]);
     // acc = null
     f.instruction(&Instruction::RefNull(wasm_encoder::HeapType::Concrete(
         list_idx,
     )));
     f.instruction(&Instruction::LocalSet(1));
+    // end = s.len
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::ArrayLen);
+    f.instruction(&Instruction::LocalSet(4));
     // i = s.len - 1
     f.instruction(&Instruction::LocalGet(0));
     f.instruction(&Instruction::ArrayLen);
@@ -2393,22 +2561,43 @@ fn emit_string_chars(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     f.instruction(&Instruction::I32Const(0));
     f.instruction(&Instruction::I32LtS);
     f.instruction(&Instruction::BrIf(1));
-    // cell = array.new_default $string 1
-    f.instruction(&Instruction::I32Const(1));
+    // if (s[i] & 0xC0) != 0x80 — character start
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::ArrayGetU(s_idx));
+    f.instruction(&Instruction::I32Const(0xC0));
+    f.instruction(&Instruction::I32And);
+    f.instruction(&Instruction::I32Const(0x80));
+    f.instruction(&Instruction::I32Ne);
+    f.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+    // clen = end - i
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::LocalSet(5));
+    // cell = array.new_default $string clen
+    f.instruction(&Instruction::LocalGet(5));
     f.instruction(&Instruction::ArrayNewDefault(s_idx));
     f.instruction(&Instruction::LocalSet(3));
-    // cell[0] = s[i]
+    // array.copy cell[0..clen] <- s[i..end]
     f.instruction(&Instruction::LocalGet(3));
     f.instruction(&Instruction::I32Const(0));
     f.instruction(&Instruction::LocalGet(0));
     f.instruction(&Instruction::LocalGet(2));
-    f.instruction(&Instruction::ArrayGetU(s_idx));
-    f.instruction(&Instruction::ArraySet(s_idx));
+    f.instruction(&Instruction::LocalGet(5));
+    f.instruction(&Instruction::ArrayCopy {
+        array_type_index_dst: s_idx,
+        array_type_index_src: s_idx,
+    });
     // acc = struct.new $list (cell, acc)
     f.instruction(&Instruction::LocalGet(3));
     f.instruction(&Instruction::LocalGet(1));
     f.instruction(&Instruction::StructNew(list_idx));
     f.instruction(&Instruction::LocalSet(1));
+    // end = i
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::End);
     // i--
     f.instruction(&Instruction::LocalGet(2));
     f.instruction(&Instruction::I32Const(1));

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -1578,12 +1578,20 @@ pub(super) fn cmd_audit(path: &str, module_root_override: Option<&str>, json: bo
             total_format_needed += 1;
         }
 
+        // Check errors = static-analysis errors (`Severity::Error`:
+        // parse errors, type errors, intent-checker errors such as
+        // `verify-rhs`). Verify EXECUTION failures carry
+        // `Severity::Fail` and are counted through `verify_summary`
+        // below, so excluding them here avoids double counting — but
+        // exclusion must key on the severity, not the slug. The old
+        // `!slug.starts_with("verify-")` filter also swallowed
+        // `error[verify-rhs]` (a static check error that happens to
+        // share the prefix), so a file whose only problems were
+        // verify-rhs errors audited as "0 check errors" with exit 0.
         let file_check_errors = report
             .diagnostics
             .iter()
-            .filter(|d| {
-                d.is_error() && d.slug != "verify-mismatch" && !d.slug.starts_with("verify-")
-            })
+            .filter(|d| matches!(d.severity, aver::diagnostics::Severity::Error))
             .count();
         let file_verify_failures = report
             .verify_summary

--- a/tests/audit_check_error_count_regression.rs
+++ b/tests/audit_check_error_count_regression.rs
@@ -1,0 +1,154 @@
+//! Regression — `aver audit` must count `error[verify-rhs]` (and every
+//! other static check error) in the check-error total and the exit code.
+//!
+//! The audit's per-file aggregation excluded every diagnostic whose slug
+//! starts with `verify-` from the check-error count. The intent was to
+//! avoid double-counting verify EXECUTION failures (slugs
+//! `verify-mismatch` / `verify-runtime-error` / …, already counted via
+//! the verify scorecard) — but `verify-rhs` is a STATIC check error (a
+//! verify case calling the function under test on the right side of
+//! `=>`) that happens to share the slug prefix. It was printed as
+//! `error[verify-rhs]` yet contributed to neither total, so a file whose
+//! only problems were verify-rhs errors audited as "0 check errors" with
+//! exit 0. The fix keys the exclusion on severity (`Fail` = verify
+//! execution, counted elsewhere; `Error` = static check error, counted
+//! here) instead of the slug prefix.
+
+use std::fs;
+use std::process::Command;
+
+/// Run `aver audit --json` on `source` written to a temp file; return
+/// (exit_code, stdout).
+fn run_audit_json(name: &str, source: &str) -> (Option<i32>, String) {
+    let dir = std::env::temp_dir().join(format!("aver_audit_count_{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let file = dir.join(format!("{name}.av"));
+    fs::write(&file, source).expect("write source");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .arg("audit")
+        .arg(&file)
+        .arg("--json")
+        .output()
+        .expect("spawn aver audit");
+    let _ = fs::remove_dir_all(&dir);
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+    )
+}
+
+/// Extract the `"check_errors":N` count from the audit's trailing
+/// summary JSON line.
+fn summary_check_errors(stdout: &str) -> usize {
+    let summary = stdout
+        .lines()
+        .find(|l| l.contains("\"kind\":\"summary\""))
+        .unwrap_or_else(|| panic!("no summary line in audit output:\n{stdout}"));
+    let tail = summary
+        .split("\"check_errors\":")
+        .nth(1)
+        .unwrap_or_else(|| panic!("no check_errors field in summary: {summary}"));
+    tail.chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .parse()
+        .unwrap_or_else(|_| panic!("unparseable check_errors in summary: {summary}"))
+}
+
+/// A verify case calling the target on the right side of `=>` is a
+/// static check error (`error[verify-rhs]`). Audit must report a
+/// nonzero check-error count and exit 1 — before the fix it printed
+/// the error but reported "0 check errors" and exited 0.
+#[test]
+fn verify_rhs_error_counts_and_fails_audit() {
+    let (code, stdout) = run_audit_json(
+        "verify_rhs",
+        r#"module VerifyRhsAudit
+    intent = "Fixture: verify case calls the target on the right side"
+    exposes [double]
+    effects []
+
+fn double(x: Int) -> Int
+    ? "Doubles the input"
+    x * 2
+
+verify double
+    double(2) => double(2)
+    double(3) => 6
+"#,
+    );
+    let check_errors = summary_check_errors(&stdout);
+    assert!(
+        check_errors >= 1,
+        "verify-rhs error must count as a check error, got {check_errors}:\n{stdout}"
+    );
+    assert_eq!(
+        code,
+        Some(1),
+        "audit with a verify-rhs error must exit 1:\n{stdout}"
+    );
+}
+
+/// Control — a clean file still audits green (0 check errors, exit 0),
+/// so the severity-keyed counting did not start counting warnings or
+/// passing verify blocks.
+#[test]
+fn clean_file_still_audits_green() {
+    let (code, stdout) = run_audit_json(
+        "clean",
+        r#"module CleanAudit
+    intent = "Fixture: clean module for the audit control case"
+    exposes [double]
+    effects []
+
+fn double(x: Int) -> Int
+    ? "Doubles the input"
+    x * 2
+
+verify double
+    double(2) => 4
+    double(3) => 6
+"#,
+    );
+    let check_errors = summary_check_errors(&stdout);
+    assert_eq!(check_errors, 0, "clean file: {stdout}");
+    assert_eq!(code, Some(0), "clean file must exit 0:\n{stdout}");
+}
+
+/// Control — a failing verify CASE is a verify failure, not a check
+/// error: it must not be double-counted in both totals, and the exit
+/// code stays 1 through the verify-failures axis.
+#[test]
+fn failing_verify_case_counts_as_verify_failure_not_check_error() {
+    let (code, stdout) = run_audit_json(
+        "verify_fail",
+        r#"module VerifyFailAudit
+    intent = "Fixture: one failing verify case, no static errors"
+    exposes [inc]
+    effects []
+
+fn inc(x: Int) -> Int
+    ? "Adds one"
+    x + 1
+
+verify inc
+    inc(1) => 3
+"#,
+    );
+    let check_errors = summary_check_errors(&stdout);
+    assert_eq!(
+        check_errors, 0,
+        "verify execution failure must not inflate check errors:\n{stdout}"
+    );
+    let summary = stdout
+        .lines()
+        .find(|l| l.contains("\"kind\":\"summary\""))
+        .unwrap();
+    assert!(
+        summary.contains("\"verify_failures\":1"),
+        "expected 1 verify failure in summary: {summary}"
+    );
+    assert_eq!(code, Some(1), "failing verify case must exit 1:\n{stdout}");
+}

--- a/tests/wasm_gc_string_scalar_semantics_regression.rs
+++ b/tests/wasm_gc_string_scalar_semantics_regression.rs
@@ -1,0 +1,163 @@
+#![cfg(feature = "wasm")]
+
+//! Regression — `String.len` / `String.charAt` / `String.slice` /
+//! `String.chars` on wasm-gc must count and index Unicode scalar
+//! values, exactly like the VM (the canonical semantics: docs say
+//! "number of characters", the VM uses `s.chars()`).
+//!
+//! Strings lower to UTF-8 `(array i8)` on wasm-gc, and the original
+//! helpers worked directly in byte space: `String.len` was `array.len`
+//! (so `len("ż") == 2`), `charAt` returned a single byte (tearing
+//! multi-byte characters apart), `slice` cut at byte offsets, and
+//! `chars` split into bytes. Any program mixing these with multi-byte
+//! text diverged from the VM — `examples/data/json.av` under
+//! `verify --wasm-gc` failed its emoji cases. `String.byteLength`
+//! (explicit byte count on every backend) keeps the old `array.len`
+//! body under its own helper.
+//!
+//! Every block here runs through BOTH the VM verify runner and the
+//! wasm-gc verify runner; the expected values are the VM's answers, so
+//! a pass on both runners is a cross-backend parity proof for these
+//! cases.
+
+use aver::checker::VerifyResult;
+use aver::diagnostics::vm_verify::run_verify_for_items_vm;
+use aver::diagnostics::wasm_gc_verify::run_verify_for_items_wasm_gc;
+use aver::source::parse_source;
+
+fn run_both_backends(source: &str) -> [(&'static str, Vec<VerifyResult>); 2] {
+    let items = parse_source(source).unwrap_or_else(|e| {
+        panic!("parse failed: {e}\n--- source ---\n{source}");
+    });
+    let vm = run_verify_for_items_vm(
+        items.clone(),
+        None,
+        None,
+        "wasm_gc_string_scalar_semantics_regression.av",
+    )
+    .unwrap_or_else(|e| panic!("VM verify failed: {e}\n--- source ---\n{source}"));
+    let gc = run_verify_for_items_wasm_gc(
+        items,
+        None,
+        None,
+        "wasm_gc_string_scalar_semantics_regression.av",
+    )
+    .unwrap_or_else(|e| panic!("wasm-gc verify failed: {e}\n--- source ---\n{source}"));
+    [("vm", vm), ("wasm-gc", gc)]
+}
+
+fn assert_all_pass_on_both(source: &str, expected_passed: usize) {
+    for (backend, results) in run_both_backends(source) {
+        let passed: usize = results.iter().map(|r| r.passed).sum();
+        let failed: usize = results.iter().map(|r| r.failed).sum();
+        let skipped: usize = results.iter().map(|r| r.skipped).sum();
+        assert_eq!(
+            (passed, failed, skipped),
+            (expected_passed, 0, 0),
+            "[{backend}] expected {expected_passed}/0/0 passed/failed/skipped, got {passed}/{failed}/{skipped}\n--- source ---\n{source}"
+        );
+    }
+}
+
+/// `String.len` over 2-byte (ż), 3-byte (—) and 4-byte (😀) characters:
+/// one character, one unit of length. Red on the byte-counting helper
+/// (`len("ż")` was 2, `len("😀")` was 4).
+#[test]
+fn len_counts_scalar_values() {
+    assert_all_pass_on_both(
+        r#"
+fn lenOf(s: String) -> Int
+    ? "Length of the string in characters"
+    String.len(s)
+
+verify lenOf
+    lenOf("") => 0
+    lenOf("abc") => 3
+    lenOf("zażółć") => 6
+    lenOf("😀") => 1
+    lenOf("a—b") => 3
+"#,
+        5,
+    );
+}
+
+/// `String.byteLength` stays byte-based on every backend — the
+/// explicit escape hatch must NOT inherit the scalar semantics.
+#[test]
+fn byte_length_still_counts_bytes() {
+    assert_all_pass_on_both(
+        r#"
+fn byteLen(s: String) -> Int
+    ? "UTF-8 byte length of the string"
+    String.byteLength(s)
+
+verify byteLen
+    byteLen("abc") => 3
+    byteLen("ż") => 2
+    byteLen("😀") => 4
+"#,
+        3,
+    );
+}
+
+/// `String.charAt` indexes scalars and returns the FULL character
+/// (1–4 bytes). Red on the byte helper twice over: the index was a
+/// byte offset and the result a single byte of a torn character.
+#[test]
+fn char_at_indexes_scalars_and_returns_full_character() {
+    assert_all_pass_on_both(
+        r#"
+fn charAtOf(s: String, i: Int) -> Option<String>
+    ? "Character at index i"
+    String.charAt(s, i)
+
+verify charAtOf
+    charAtOf("zażółć", 2) => Option.Some("ż")
+    charAtOf("😀x", 0) => Option.Some("😀")
+    charAtOf("😀x", 1) => Option.Some("x")
+    charAtOf("😀x", 2) => Option.None
+    charAtOf("abc", 0 - 1) => Option.None
+"#,
+        5,
+    );
+}
+
+/// `String.slice` takes scalar indices with the VM's clamping rules
+/// (negatives to 0, past-the-end to the end, `start >= end` empty).
+#[test]
+fn slice_uses_scalar_indices_with_vm_clamping() {
+    assert_all_pass_on_both(
+        r#"
+fn sliceOf(s: String, a: Int, b: Int) -> String
+    ? "Slice of the string from a to b"
+    String.slice(s, a, b)
+
+verify sliceOf
+    sliceOf("zażółć", 1, 4) => "ażó"
+    sliceOf("😀abc", 0, 1) => "😀"
+    sliceOf("😀abc", 1, 3) => "ab"
+    sliceOf("abc", 2, 99) => "c"
+    sliceOf("abc", 0 - 5, 2) => "ab"
+    sliceOf("abc", 2, 1) => ""
+"#,
+        6,
+    );
+}
+
+/// `String.chars` splits into whole characters, not bytes.
+#[test]
+fn chars_splits_into_scalar_values() {
+    assert_all_pass_on_both(
+        r#"
+fn charsOf(s: String) -> List<String>
+    ? "List of characters"
+    String.chars(s)
+
+verify charsOf
+    charsOf("aż😀") => ["a", "ż", "😀"]
+    charsOf("ab") => ["a", "b"]
+    charsOf("") => []
+"#,
+        3,
+    );
+}

--- a/tests/wasm_gc_verify_result_record_eq_regression.rs
+++ b/tests/wasm_gc_verify_result_record_eq_regression.rs
@@ -1,0 +1,128 @@
+#![cfg(feature = "wasm")]
+
+//! Regression — comparing `Result` values on wasm-gc when one module
+//! registers TWO `Result<RecordX, String>` instantiations.
+//!
+//! The `Result.Ok` / `Result.Err` constructor emitter resolved which
+//! `Result<T,E>` struct to build by, in order: the single registered
+//! instantiation, the enclosing fn's return type, then the first
+//! registered instantiation whose payload-position type matches the
+//! payload. Inside a synthesized verify `==` check fn the return type
+//! is `Bool`, so an RHS `Result.Err("…")` fell to the payload match —
+//! and with two instantiations sharing the error type `String`
+//! (`Result<Point, String>` and `Result<Label, String>`) the FIRST one
+//! always won. The per-instantiation eq helper for the LHS's actual
+//! type then `ref.cast`s the mis-built struct to the other
+//! instantiation's heap type and traps at runtime: the second record's
+//! `=> Result.Err(…)` case aborted with a wasm trap while the first
+//! record's identical shape passed. (`examples/core/order_total.av`:
+//! `mkDiscount` green, `mkTaxRate` trapped.)
+//!
+//! The fix consults the constructor expression's own stamped type
+//! first — the type checker already unified the concrete
+//! `Result<T,E>` at the comparison site — and only falls back to the
+//! positional heuristics when the stamp is not a registered
+//! instantiation.
+
+use aver::checker::VerifyResult;
+use aver::diagnostics::wasm_gc_verify::run_verify_for_items_wasm_gc;
+use aver::source::parse_source;
+
+fn run_verify(source: &str) -> Vec<VerifyResult> {
+    let items = parse_source(source).unwrap_or_else(|e| {
+        panic!("parse failed: {e}\n--- source ---\n{source}");
+    });
+    run_verify_for_items_wasm_gc(
+        items,
+        None,
+        None,
+        "wasm_gc_verify_result_record_eq_regression.av",
+    )
+    .unwrap_or_else(|e| panic!("wasm-gc verify failed: {e}\n--- source ---\n{source}"))
+}
+
+fn assert_all_cases_pass(source: &str, expected_passed: usize) {
+    let results = run_verify(source);
+    let passed: usize = results.iter().map(|r| r.passed).sum();
+    let failed: usize = results.iter().map(|r| r.failed).sum();
+    let skipped: usize = results.iter().map(|r| r.skipped).sum();
+    assert_eq!(
+        (passed, failed, skipped),
+        (expected_passed, 0, 0),
+        "expected {expected_passed}/0/0 passed/failed/skipped, got {passed}/{failed}/{skipped}\n--- source ---\n{source}"
+    );
+}
+
+/// Two records, each wrapped in its own `Result<RecordX, String>`,
+/// both verified against `Result.Ok(...)` and `Result.Err("...")`.
+/// Before the fix the SECOND block's Err case trapped (the Err
+/// constructor built the first instantiation's struct; the eq helper
+/// cast it to the second's heap type).
+#[test]
+fn two_result_record_instantiations_err_cases_pass() {
+    assert_all_cases_pass(
+        r#"
+record Point
+    x: Int
+    y: Int
+
+record Label
+    text: String
+
+fn mkPoint(x: Int, y: Int) -> Result<Point, String>
+    ? "Builds a point, rejecting negatives"
+    match x < 0
+        true  -> Result.Err("negative")
+        false -> Result.Ok(Point(x = x, y = y))
+
+fn mkLabel(text: String) -> Result<Label, String>
+    ? "Builds a label, rejecting empty text"
+    match text == ""
+        true  -> Result.Err("empty")
+        false -> Result.Ok(Label(text = text))
+
+verify mkPoint
+    mkPoint(1, 2) => Result.Ok(Point(x = 1, y = 2))
+    mkPoint(0 - 1, 2) => Result.Err("negative")
+
+verify mkLabel
+    mkLabel("hi") => Result.Ok(Label(text = "hi"))
+    mkLabel("") => Result.Err("empty")
+"#,
+        4,
+    );
+}
+
+/// The dual ambiguity: two instantiations sharing the OK type
+/// (`Result<Int, …>` twice) so the `Result.Ok` payload match is the
+/// ambiguous one. The stamped-type resolution covers both positions.
+#[test]
+fn two_result_instantiations_sharing_ok_type() {
+    assert_all_cases_pass(
+        r#"
+record ParseFault
+    at: Int
+
+fn positive(n: Int) -> Result<Int, String>
+    ? "Accepts positive numbers"
+    match n > 0
+        true  -> Result.Ok(n)
+        false -> Result.Err("not positive")
+
+fn parsed(n: Int) -> Result<Int, ParseFault>
+    ? "Accepts non-negative numbers"
+    match n < 0
+        true  -> Result.Err(ParseFault(at = n))
+        false -> Result.Ok(n)
+
+verify positive
+    positive(4) => Result.Ok(4)
+    positive(0) => Result.Err("not positive")
+
+verify parsed
+    parsed(5) => Result.Ok(5)
+    parsed(0 - 2) => Result.Err(ParseFault(at = 0 - 2))
+"#,
+        4,
+    );
+}


### PR DESCRIPTION
The four follow-ups from the 0.25.0 release lessons (two tooling holes that let a broken corpus ride green CI, and the two cross-target divergences the release documented as residuals):

| # | Fix | Measured |
|---|---|---|
| 1 | **CI gates `examples/core` + `examples/data`** (bare exit codes, new step in Check & Test; `examples/diagnostics` stays deliberately ungated) | negative control: a broken example fails the step |
| 2 | **`aver audit` counts `error[verify-rhs]`** — the filter excluded every `verify-*` slug to avoid double-counting execution failures, swallowing this *static* error; now keyed on severity | a 1-error fixture: audit `0 errors/exit 0` → `1 error/exit 1`; no double-count of genuine verify failures |
| 3 | **wasm-gc strings move to the VM's character index space** — `String.len` counts scalars, `charAt`/`slice`/`chars` follow, `String.byteLength` split off keeping bytes. A len-only fix measurably made json.av *worse* (1→5 failures), so the family moved together | `json.av` verify --wasm-gc: 400/403 +1 fail → **identical summary to VM** (402/403); bonus: `grok_s_language.av` 90/105 → 101/105, VM parity. Perf: len O(n); doom +166 B, six games byte-identical |
| 4 | **Result equality trap** with two `Result<Record, String>` instantiations in one module — constructor resolution ignored the stamped type and took the first payload-position match; the eq helper then cast the wrong heap type | repro 3/4+trap → 4/4; `order_total.av` → 55/55 exit 0 |

10 new regression tests (each revert-tested red); full corpus proof exports byte-identical (88/88); proof_spec 145/145; workspace tests with wasm features green; clippy ×3 gates clean.

Known residuals documented in the commit: `Char.toCode` still byte-based on wasm-gc; `Tuple<Result<A,_>, Result<B,_>>` equality rejected by the verify typechecker (both pre-existing).

CHANGELOG: new `## 0.25.1 (unreleased)` section; 0.25.0 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)