### PR TITLE
proof: universally-proven conditional laws export a plain-logic companion form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ## 0.25.1 (unreleased)
 
+### Added
+
+- **Conditional laws proven universally now export a ready-to-use plain-logic form** — alongside the universal proof of a `when`-law, the Lean export derives a companion statement of the same fact with its premises and conclusion stated as ordinary propositions, so a later proof can cite it directly without re-deriving the boolean-to-proposition bridges.
+
 ### Fixed
 
 - **wasm-gc strings count characters, not bytes** — `String.len`, `String.charAt`, `String.slice`, and `String.chars` now use Unicode character (scalar) counts and indices, matching the VM and the documentation on every multi-byte string. `String.byteLength` still counts UTF-8 bytes. `examples/data/json.av` passes `aver verify --wasm-gc` in full, including its emoji cases.

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -3351,6 +3351,25 @@ fn universal_lane_renders_sign_segment_twin() {
     // disjunctions gone.
     assert!(law.content.contains("(v > 0) = true ->"));
     assert!(!law.content.contains("v = 1 ∨"));
+    // Prop-form corollary derived from the twin, same module: the bare
+    // comparison premise is un-coerced to the Prop relation (no trailing
+    // `= true`), derived via the fixed bridge tactic. It is NOT a
+    // separate credited declaration — the surfaced `theorem` name and
+    // the lane index stay the `_universal` twin only.
+    assert!(
+        law.content.contains(
+            "theorem startDigits_law_positiveTokenRoundtrip_prop : ∀ (v : Int), (v > 0) ->"
+        )
+    );
+    assert!(
+        law.content
+            .contains("have hu := startDigits_law_positiveTokenRoundtrip_universal")
+    );
+    assert!(law.content.contains("simpa [beq_iff_eq] using hu"));
+    assert_eq!(
+        law.theorem, "startDigits_law_positiveTokenRoundtrip_universal",
+        "the surfaced/credited theorem stays the twin; the corollary is module-local"
+    );
     // Hashed module name + non-default lakefile libs appended after
     // the default target (first `roots :=` line stays the default's).
     assert!(
@@ -3426,12 +3445,29 @@ fn universal_lane_renders_bridge_premise_twins() {
             .contains("likeNat (bulk xs) (bulk ys) = true ->")
     );
     assert!(!zip.content.contains("xs = [] ∨"));
+    // Prop-form corollary, same module: the opaque Bool predicate
+    // premise stays at the Bool seam (`= true`), the conclusion lowered,
+    // derived from the twin. Not separately credited (theorem name and
+    // index stay the `_universal` twin).
+    assert!(
+        zip.content
+            .contains("theorem duoUp_law_duoFlip_prop : ∀ (xs : List Int) (ys : List Int), likeNat (bulk xs) (bulk ys) = true ->")
+    );
+    assert!(
+        zip.content
+            .contains("have hu := duoUp_law_duoFlip_universal")
+    );
     let tally = lane
         .iter()
         .find(|l| l.label == "tallyUp.tallyWedgeNeq")
         .unwrap();
     assert!(!tally.content.contains("sorry"));
     assert!(tally.content.contains("unlikeNat p q = true ->"));
+    assert!(
+        tally
+            .content
+            .contains("theorem tallyUp_law_tallyWedgeNeq_prop : ∀ (p : Nat) (q : Nat) (ws : List Nat), unlikeNat p q = true ->")
+    );
     // Sabotage stays per-law: only the matching module changes.
     let sabotaged = super::universal_lane::generate(&ctx, "entry-content-seed", Some("duoFlip"));
     let zip_sab = sabotaged

--- a/src/codegen/lean/universal_lane/bridge.rs
+++ b/src/codegen/lean/universal_lane/bridge.rs
@@ -1346,6 +1346,19 @@ induction {xs} with
         }
     }
 
+    // Prop-form corollary, derived from the twin above with the fixed
+    // Bool/Prop bridge tactic — same module, no separate credit.
+    content.push('\n');
+    let given_names: Vec<String> = law.givens.iter().map(|g| g.name.clone()).collect();
+    content.push_str(&super::shared::render_prop_corollary(
+        &theorem_base,
+        &quant_params,
+        &given_names,
+        law,
+        ctx,
+        &format!("{lhs_template} = {rhs_template}"),
+    ));
+
     // L2 of the iron guard: the lane grammar has no sorry carrier.
     debug_assert!(
         !content.contains("sorry"),

--- a/src/codegen/lean/universal_lane/shared.rs
+++ b/src/codegen/lean/universal_lane/shared.rs
@@ -1,7 +1,9 @@
 //! AST recognition helpers shared by both lane families
 //! (sign-premise and bridge-premise).
 
-use crate::ast::{Expr, Spanned};
+use super::super::expr::{aver_name_to_lean, emit_expr_legacy};
+use crate::ast::{BinOp, Expr, Literal, Spanned, VerifyLaw};
+use crate::codegen::CodegenContext;
 
 pub(super) fn ident_of(e: &Spanned<Expr>) -> Option<&str> {
     match &e.node {
@@ -44,4 +46,163 @@ pub(super) fn ctor_of(e: &Spanned<Expr>) -> Option<(String, Vec<&Spanned<Expr>>)
         }
         _ => None,
     }
+}
+
+/// Flatten a `when` predicate into the consumer-facing PROP premises of
+/// the derived corollary. The lane twin carries the premise at the Bool
+/// seam (`<when> = true`); the corollary normalizes it so a downstream
+/// consumer applies the helper with zero bridging:
+/// - a conjunction (`Bool.and(a, b)`) splits into its conjuncts, so
+///   each lands as its own Prop arrow rather than one `&&`-composed
+///   Bool equality;
+/// - a bare comparison atom (`n >= 0`, `w * b < a`) lowers to the
+///   Prop-level relation (it elaborates Prop-level already — the twin's
+///   `= true` only coerces `true` into Prop), surfaced WITHOUT the
+///   trailing `= true`;
+/// - everything else (an opaque Bool predicate fn, a `==`/`!=` atom)
+///   stays at the Bool seam as `<atom> = true` — still consumable, the
+///   consumer defers any further unfolding.
+fn flatten_when_props(when: &Spanned<Expr>, ctx: &CodegenContext, out: &mut Vec<String>) {
+    // `Bool.and(a, b)` — the canonical conjunction the lane families
+    // build their `when` from — flattens into independent conjuncts.
+    if let Some((callee, args)) = call_of(when)
+        && callee == "Bool.and"
+        && args.len() == 2
+    {
+        flatten_when_props(&args[0], ctx, out);
+        flatten_when_props(&args[1], ctx, out);
+        return;
+    }
+    let rendered = emit_expr_legacy(when, ctx, None).replace('\n', " ");
+    match &when.node {
+        // Order/(in)equality comparisons elaborate at the Prop level;
+        // keep the relation, drop the Bool coercion.
+        Expr::BinOp(BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte, _, _) => out.push(rendered),
+        // Anything else stays at the Bool seam (`= true`).
+        _ => out.push(format!("{rendered} = true")),
+    }
+}
+
+/// Prop-level conclusion of the derived corollary. The lane twin proves
+/// `<lhs> = <rhs>`; for a Bool-valued law whose claim is a `==` comparison
+/// pinned `=> true` (the `floorQ(..) == floorQ(..)` shape), the consumer
+/// wants the Prop equality `<l> = <r>` rather than the Bool equation
+/// `(<l> == <r>) = true` — `beq_iff_eq` bridges the two in the proof.
+/// Every other law keeps the twin's own `<lhs> = <rhs>` conclusion.
+fn corollary_conclusion(law: &VerifyLaw, ctx: &CodegenContext, conclusion: &str) -> String {
+    let rhs_true = matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true)));
+    if rhs_true && let Expr::BinOp(op @ (BinOp::Eq | BinOp::Neq), l, r) = &law.lhs.node {
+        let ls = emit_expr_legacy(l, ctx, None).replace('\n', " ");
+        let rs = emit_expr_legacy(r, ctx, None).replace('\n', " ");
+        let rel = if matches!(op, BinOp::Eq) { "=" } else { "≠" };
+        return format!("{ls} {rel} {rs}");
+    }
+    conclusion.to_string()
+}
+
+/// Derive the Prop-form corollary `<theorem_base>_prop` from the lane
+/// twin `<theorem_base>_universal` with the fixed Bool/Prop bridge
+/// tactic set ({`Bool.and_eq_true`, `decide_eq_true_eq`, `beq_iff_eq`}
+/// composed under `simpa`). The corollary's STATEMENT moves all three
+/// measured seams to the Prop side (conjunction split, bare comparison
+/// un-coerced, `==` conclusion lowered); its PROOF reconstructs the
+/// twin's Bool premise from the Prop hypotheses and lowers the twin's
+/// conclusion — both via a small fixed `first` ladder so the single
+/// derivation closes every emitted seam combination.
+///
+/// Returned as a text block to APPEND to the twin's module (same
+/// definition site, one module). It is NOT a separately credited
+/// declaration: the lane index records only the twin's `_universal`
+/// name, so the crediting probe (`#print axioms <theorem>`) never
+/// keys on the corollary — and because the corollary lives in the
+/// same module and references the twin, a sabotaged or non-closing
+/// twin takes the corollary's build down with it (fail-closed: a
+/// corollary can never outlive a dead twin).
+pub(super) fn render_prop_corollary(
+    theorem_base: &str,
+    quant_params: &str,
+    given_names: &[String],
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    conclusion: &str,
+) -> String {
+    let corollary = format!("{theorem_base}_prop");
+    let twin = format!("{theorem_base}_universal");
+
+    let mut props = Vec::new();
+    if let Some(when) = law.when.as_ref() {
+        flatten_when_props(when, ctx, &mut props);
+    }
+    let hyp_names: Vec<String> = (0..props.len()).map(|i| format!("hp{i}")).collect();
+    let hyp_binders: String = props
+        .iter()
+        .map(|p| format!("{p} -> "))
+        .collect::<Vec<_>>()
+        .concat();
+    let concl = corollary_conclusion(law, ctx, conclusion);
+
+    let givens_applied = given_names
+        .iter()
+        .map(|g| aver_name_to_lean(g))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let givens_applied = if givens_applied.is_empty() {
+        String::new()
+    } else {
+        format!(" {givens_applied}")
+    };
+    let intro_names: Vec<String> = given_names
+        .iter()
+        .map(|g| aver_name_to_lean(g))
+        .chain(hyp_names.iter().cloned())
+        .collect();
+    let intro_line = if intro_names.is_empty() {
+        String::new()
+    } else {
+        format!("  intro {}\n", intro_names.join(" "))
+    };
+
+    // Discharge the twin's Bool premise from the Prop hypotheses. The
+    // ladder is fixed and covers every emitted seam: a split `&&`
+    // conjunction (`Bool.and_eq_true` + the anonymous constructor over
+    // the un-curried Prop conjuncts), a single bare comparison
+    // (`decide_eq_true_eq` then `assumption`), and an opaque Bool atom
+    // kept as `= true` (direct `assumption`/`exact`).
+    let hyp_tuple = if hyp_names.is_empty() {
+        "True.intro".to_string()
+    } else {
+        format!("⟨{}⟩", hyp_names.join(", "))
+    };
+    let discharge = format!(
+        "(by\n    first\n      \
+         | (simp only [Bool.and_eq_true, decide_eq_true_eq]\n         \
+         first\n           | exact {hyp_tuple}\n           \
+         | (repeat' apply And.intro) <;> assumption\n           \
+         | (repeat' constructor) <;> assumption\n           | assumption)\n      \
+         | (simp only [decide_eq_true_eq]; assumption)\n      \
+         | assumption\n      | (first | exact {first_hyp} | (simpa using {first_hyp})))",
+        first_hyp = hyp_names
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "rfl".to_string()),
+    );
+
+    let mut block = String::new();
+    block.push_str(
+        "-- Prop-form corollary: the same proved claim with the Bool/Prop\n\
+         -- seams normalized (premise conjuncts un-curried to Prop, the\n\
+         -- conclusion lowered) so a downstream consumer applies it with no\n\
+         -- bridging. Derived purely from the twin above; carries no credit\n\
+         -- of its own (the lane index probes only the `_universal` name) and\n\
+         -- cannot outlive a broken twin (same module, references it).\n",
+    );
+    block.push_str(&format!(
+        "theorem {corollary} : ∀ {quant_params}, {hyp_binders}{concl} := by\n"
+    ));
+    block.push_str(&intro_line);
+    block.push_str(&format!(
+        "  have hu := {twin}{givens_applied} {discharge}\n"
+    ));
+    block.push_str("  simpa [beq_iff_eq] using hu\n");
+    block
 }

--- a/src/codegen/lean/universal_lane/sign.rs
+++ b/src/codegen/lean/universal_lane/sign.rs
@@ -699,6 +699,19 @@ rw [harm]
         }
     }
 
+    // Prop-form corollary, derived from the twin above with the fixed
+    // Bool/Prop bridge tactic — same module, no separate credit.
+    content.push('\n');
+    let given_names: Vec<String> = law.givens.iter().map(|g| g.name.clone()).collect();
+    content.push_str(&super::shared::render_prop_corollary(
+        &theorem_base,
+        &quant_params,
+        &given_names,
+        law,
+        ctx,
+        &format!("{lhs_template} = {rhs_template}"),
+    ));
+
     // L2 of the iron guard: the lane grammar has no sorry carrier.
     debug_assert!(
         !content.contains("sorry"),


### PR DESCRIPTION
First increment of conditional helper lemmas (measured feasibility probe: `prompts/conditional-helper-lemmas-probe.md`): every when-law with a universal proof in the side build now ships a **Prop-form companion** next to its twin — premises lowered to plain hypotheses, `==` conclusions lowered to `=`, one fixed bridge tactic covering all three measured Bool/Prop seams. Future increments let later laws consume these companions via explicit `have` (the probe proved the full chain on the 1996 paper's hardest-lemma shapes, including a 39-line core-Lean proof of the floor-stability brick).

## Fail-closed by construction

- The crediting audit is **index-driven**: it probes exactly the theorem names in the lane index, and companions are never indexed → no path to a forged credit (reviewer attempted collisions and filter games — withheld every time).
- A companion lives in its twin's module: sabotaged twin → module fails → companion can't compile, import, or outlive it (existing sabotage test extended over the pair; both directions measured).
- All emitted companions certify within the axiom whitelist on live builds (json ×5, synthetic sign/bridge fixtures, Peano bridge laws).

## Gates

- json lane crediting byte-identical (`when_universal` 5, exact credited set, counted summary identical across normal/sabotage/revert).
- Counted builds byte-identical corpus-wide; lane modules differ only by appended companions (+ the content-hash renames that follow by design).
- `cargo test --workspace` green (live proof_spec 145); fmt/clippy clean.

## Known sharp edge (measured, queued)

A sibling law deliberately named `<law>_prop` collides with the emitted name and **withholds** the original credit (never grants) — same pre-existing hazard class as `_universal` on the baseline (measured both). Collision guard queued for the next increment, which touches lane naming anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)