### PR TITLE
proof: a conditional law's proof can apply an earlier proven conditional law

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 - **Conditional laws proven universally now export a ready-to-use plain-logic form** — alongside the universal proof of a `when`-law, the Lean export derives a companion statement of the same fact with its premises and conclusion stated as ordinary propositions, so a later proof can cite it directly without re-deriving the boolean-to-proposition bridges.
 - **A universally-proven `when`-law can build on earlier ones** — the Lean export can have one law's side proof reuse an earlier law's, and editing the earlier law now re-checks every law that depends on it (no stale results survive an upstream change).
+- **Proofs of conditional laws can now build on earlier proven laws in the same file** — when a later `when`-law's claim contains the shape of an earlier proven `when`-law's conclusion and carries all of its premises, the Lean export proves the later law universally by applying the earlier one, and the proof report shows the dependency. A law missing one of the premises simply keeps its sampled-domain check — nothing fails. First proof family on board: floored division is stable across a finer-grid cell (`a / (b*d) = w / d` when `w*b < a < (w+1)*b`).
 
 ### Fixed
 

--- a/src/codegen/lean/universal_lane/consume.rs
+++ b/src/codegen/lean/universal_lane/consume.rs
@@ -1,0 +1,745 @@
+//! Consumption figure: a later `when`-law (the CONSUMER) proves
+//! universally by applying an EARLIER lane-proved `when`-law (the
+//! HELPER) at matched instantiations, instead of needing its own
+//! recognized proof family.
+//!
+//! Recognition is the premise-subset rule:
+//! 1. the helper's conclusion-LHS shape is matched into the consumer's
+//!    proof cone (the consumer subject's body at the law's arguments),
+//!    yielding a substitution over the helper's givens;
+//! 2. the substitution is completed by matching the helper's premise
+//!    conjuncts against the consumer's premise conjuncts (the ACL2
+//!    free-variables discipline: every substitution image is a given
+//!    bound by the consumer's own statement);
+//! 3. EVERY helper premise conjunct under the substitution must be one
+//!    of the consumer's premise conjuncts. A consumer missing even one
+//!    conjunct DECLINES — no lane module, zero cost, never a failing
+//!    build.
+//!
+//! The emitted proof opens with explicit `have` applications of the
+//! helper's plain-logic companion (`<helper>_prop`) at the matched
+//! instantiations, then unfolds the subject and rewrites with those
+//! local facts. The application is ALWAYS an explicit `have` against
+//! local hypotheses — never a `first | exact <companion>` alternative,
+//! which would silently absorb a broken companion's axioms into a
+//! green build. The fail-closed walls are the lane's own: a helper
+//! that did not prove is never emitted (its absence makes the
+//! consumer's import fail the tolerated build), and the consumer's
+//! credit keys on its OWN per-declaration `#print axioms` line, where
+//! any absorbed axiom surfaces.
+//!
+//! Measured subset shipped here: ONE helper per consumer (at any
+//! number of instantiations), substitution images restricted to plain
+//! Int given names, consumer subject = a pure non-recursive Bool fn
+//! whose body is `lhs == rhs`. Compound instantiation images (helper
+//! applied at product terms) are hand-validated but not yet
+//! recognized.
+
+use std::collections::BTreeMap;
+
+use super::super::expr::{aver_name_to_lean, emit_expr_legacy};
+use crate::ast::{BinOp, Expr, Literal, Spanned, Stmt, VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+use super::shared::{call_of, ident_of, when_conjuncts};
+use super::{LaneLawFile, lane_module_id};
+
+/// A source-earlier lane-emitted when-law, viewed as a helper
+/// candidate for a later consumer.
+pub(super) struct HelperView<'a> {
+    /// Index of the helper's module in the emitted lane file list —
+    /// the dependency edge the consumer records.
+    pub(super) file: usize,
+    /// The helper's plain-logic companion theorem name
+    /// (`<fn>_law_<law>_prop`).
+    pub(super) companion: String,
+    /// The helper law's AST (premise conjuncts + conclusion shape).
+    pub(super) law: &'a VerifyLaw,
+}
+
+/// One matched application site of the helper inside the consumer's
+/// cone.
+struct Instantiation {
+    /// Substitution images per helper given, in helper-given order
+    /// (consumer given names, Lean-rendered at emission).
+    args: Vec<String>,
+    /// Consumer premise-conjunct index per helper premise conjunct, in
+    /// helper-conjunct order.
+    hyps: Vec<usize>,
+}
+
+/// Recognized consumption: which helper, at which instantiations.
+pub(super) struct ConsumptionPlan {
+    pub(super) helper_file: usize,
+    helper_companion: String,
+    instantiations: Vec<Instantiation>,
+    /// Number of consumer premise conjuncts (for the `obtain` pattern).
+    conjuncts: usize,
+}
+
+/// Substitution over the helper's given names; images are consumer
+/// given names (idents only — the measured subset).
+type Sigma = BTreeMap<String, String>;
+
+/// Structural equality over the law/cone expression grammar,
+/// normalizing `Ident` vs `Resolved` by name and calls by dotted
+/// callee name. Anything outside the grammar compares unequal (and so
+/// declines upstream).
+fn expr_eq(a: &Spanned<Expr>, b: &Spanned<Expr>) -> bool {
+    if let (Some(x), Some(y)) = (ident_of(a), ident_of(b)) {
+        return x == y;
+    }
+    if let (Some((ca, aa)), Some((cb, ab))) = (call_of(a), call_of(b)) {
+        return ca == cb
+            && aa.len() == ab.len()
+            && aa.iter().zip(ab.iter()).all(|(x, y)| expr_eq(x, y));
+    }
+    match (&a.node, &b.node) {
+        (Expr::Literal(x), Expr::Literal(y)) => x == y,
+        (Expr::BinOp(o1, l1, r1), Expr::BinOp(o2, l2, r2)) => {
+            o1 == o2 && expr_eq(l1, l2) && expr_eq(r1, r2)
+        }
+        (Expr::Neg(x), Expr::Neg(y)) => expr_eq(x, y),
+        _ => false,
+    }
+}
+
+/// `true` iff `e` contains a call whose callee resolves to `name`
+/// (via the shared suffix-canonicalizing helper) — the non-recursion
+/// gate on the consumer subject, whose proof relies on a plain
+/// `unfold`.
+fn calls_fn(e: &Spanned<Expr>, name: &str) -> bool {
+    let targets: std::collections::HashSet<String> = std::iter::once(name.to_string()).collect();
+    fn walk(e: &Spanned<Expr>, targets: &std::collections::HashSet<String>) -> bool {
+        if let Some((callee, args)) = call_of(e) {
+            if crate::codegen::recursion::detect::call_matches_any(&callee, targets) {
+                return true;
+            }
+            return args.iter().any(|a| walk(a, targets));
+        }
+        match &e.node {
+            Expr::BinOp(_, l, r) => walk(l, targets) || walk(r, targets),
+            Expr::Neg(x) => walk(x, targets),
+            _ => false,
+        }
+    }
+    walk(e, &targets)
+}
+
+/// `true` iff `pat` occurs as a subterm of `e` (under [`expr_eq`]).
+fn occurs_in(e: &Spanned<Expr>, pat: &Spanned<Expr>) -> bool {
+    if expr_eq(e, pat) {
+        return true;
+    }
+    match &e.node {
+        Expr::BinOp(_, l, r) => occurs_in(l, pat) || occurs_in(r, pat),
+        Expr::Neg(x) => occurs_in(x, pat),
+        Expr::FnCall(_, args) => args.iter().any(|a| occurs_in(a, pat)),
+        Expr::TailCall(data) => data.args.iter().any(|a| occurs_in(a, pat)),
+        _ => false,
+    }
+}
+
+/// Clone `e` with every occurrence of `pat` (under [`expr_eq`])
+/// replaced by `repl` — the emission-time simulation of what `rw`
+/// will do to the goal, so non-closing shapes decline instead of
+/// failing a tolerated build.
+fn replace_all(e: &Spanned<Expr>, pat: &Spanned<Expr>, repl: &Spanned<Expr>) -> Spanned<Expr> {
+    if expr_eq(e, pat) {
+        return repl.clone();
+    }
+    let node = match &e.node {
+        Expr::BinOp(op, l, r) => Expr::BinOp(
+            *op,
+            Box::new(replace_all(l, pat, repl)),
+            Box::new(replace_all(r, pat, repl)),
+        ),
+        Expr::Neg(x) => Expr::Neg(Box::new(replace_all(x, pat, repl))),
+        Expr::FnCall(callee, args) => Expr::FnCall(
+            callee.clone(),
+            args.iter().map(|a| replace_all(a, pat, repl)).collect(),
+        ),
+        other => other.clone(),
+    };
+    Spanned::new(node, e.line)
+}
+
+/// Clone a law-side expression with the substitution applied to its
+/// given idents.
+fn apply_sigma(e: &Spanned<Expr>, sigma: &Sigma) -> Spanned<Expr> {
+    if let Some(name) = ident_of(e)
+        && let Some(image) = sigma.get(name)
+    {
+        return Spanned::new(Expr::Ident(image.clone()), e.line);
+    }
+    let node = match &e.node {
+        Expr::BinOp(op, l, r) => Expr::BinOp(
+            *op,
+            Box::new(apply_sigma(l, sigma)),
+            Box::new(apply_sigma(r, sigma)),
+        ),
+        Expr::Neg(x) => Expr::Neg(Box::new(apply_sigma(x, sigma))),
+        Expr::FnCall(callee, args) => Expr::FnCall(
+            callee.clone(),
+            args.iter().map(|a| apply_sigma(a, sigma)).collect(),
+        ),
+        other => other.clone(),
+    };
+    Spanned::new(node, e.line)
+}
+
+/// Clone the subject body with each param occurrence replaced by the
+/// law-call argument name. `None` when the body leaves the supported
+/// grammar (literals, idents, comparisons/arithmetic, plain calls).
+fn substitute_params(e: &Spanned<Expr>, map: &BTreeMap<&str, &str>) -> Option<Spanned<Expr>> {
+    if let Some(name) = ident_of(e) {
+        let node = match map.get(name) {
+            Some(arg) => Expr::Ident((*arg).to_string()),
+            None => Expr::Ident(name.to_string()),
+        };
+        return Some(Spanned::new(node, e.line));
+    }
+    let node = match &e.node {
+        Expr::Literal(_) => e.node.clone(),
+        Expr::BinOp(op, l, r) => Expr::BinOp(
+            *op,
+            Box::new(substitute_params(l, map)?),
+            Box::new(substitute_params(r, map)?),
+        ),
+        Expr::Neg(x) => Expr::Neg(Box::new(substitute_params(x, map)?)),
+        Expr::FnCall(callee, args) => Expr::FnCall(
+            callee.clone(),
+            args.iter()
+                .map(|a| substitute_params(a, map))
+                .collect::<Option<Vec<_>>>()?,
+        ),
+        _ => return None,
+    };
+    Some(Spanned::new(node, e.line))
+}
+
+/// Match the helper-side shape `pat` against the consumer-side term
+/// `target`, binding helper givens (`vars`) to consumer given idents
+/// (`images`) in `sigma`. Consistent rebinding required; everything
+/// else is structural.
+fn match_shape(
+    pat: &Spanned<Expr>,
+    target: &Spanned<Expr>,
+    vars: &[&str],
+    images: &[&str],
+    sigma: &mut Sigma,
+) -> bool {
+    if let Some(v) = ident_of(pat)
+        && vars.contains(&v)
+    {
+        let Some(image) = ident_of(target) else {
+            return false;
+        };
+        if !images.contains(&image) {
+            return false;
+        }
+        return match sigma.get(v) {
+            Some(prev) => prev == image,
+            None => {
+                sigma.insert(v.to_string(), image.to_string());
+                true
+            }
+        };
+    }
+    if let (Some((cp, ap)), Some((ct, at))) = (call_of(pat), call_of(target)) {
+        return cp == ct
+            && ap.len() == at.len()
+            && ap
+                .iter()
+                .zip(at.iter())
+                .all(|(p, t)| match_shape(p, t, vars, images, sigma));
+    }
+    match (&pat.node, &target.node) {
+        (Expr::Literal(x), Expr::Literal(y)) => x == y,
+        (Expr::BinOp(o1, l1, r1), Expr::BinOp(o2, l2, r2)) => {
+            o1 == o2
+                && match_shape(l1, l2, vars, images, sigma)
+                && match_shape(r1, r2, vars, images, sigma)
+        }
+        (Expr::Neg(x), Expr::Neg(y)) => match_shape(x, y, vars, images, sigma),
+        _ => ident_of(pat).is_some() && ident_of(pat) == ident_of(target),
+    }
+}
+
+/// The premise-subset completion: map every helper conjunct (in
+/// order) onto SOME consumer conjunct under `sigma`, extending `sigma`
+/// for helper givens the conclusion match left unbound. Small
+/// backtracking search; first full assignment wins.
+fn complete_premises(
+    h_conj: &[&Spanned<Expr>],
+    t_conj: &[&Spanned<Expr>],
+    vars: &[&str],
+    images: &[&str],
+    sigma: &Sigma,
+) -> Option<(Sigma, Vec<usize>)> {
+    fn go(
+        i: usize,
+        h_conj: &[&Spanned<Expr>],
+        t_conj: &[&Spanned<Expr>],
+        vars: &[&str],
+        images: &[&str],
+        sigma: &Sigma,
+        picked: &mut Vec<usize>,
+    ) -> Option<Sigma> {
+        let Some(pat) = h_conj.get(i) else {
+            return Some(sigma.clone());
+        };
+        for (j, cand) in t_conj.iter().enumerate() {
+            let mut next = sigma.clone();
+            if match_shape(pat, cand, vars, images, &mut next) {
+                picked.push(j);
+                if let Some(done) = go(i + 1, h_conj, t_conj, vars, images, &next, picked) {
+                    return Some(done);
+                }
+                picked.pop();
+            }
+        }
+        None
+    }
+    let mut picked = Vec::new();
+    let done = go(0, h_conj, t_conj, vars, images, sigma, &mut picked)?;
+    Some((done, picked))
+}
+
+/// Try to match one side of the consumer's cone against the helper's
+/// conclusion-LHS, then complete the substitution from the premises.
+fn match_side(
+    side: &Spanned<Expr>,
+    helper_lhs: &Spanned<Expr>,
+    h_conj: &[&Spanned<Expr>],
+    t_conj: &[&Spanned<Expr>],
+    vars: &[&str],
+    images: &[&str],
+) -> Option<(Sigma, Vec<usize>)> {
+    let mut sigma = Sigma::new();
+    if !match_shape(helper_lhs, side, vars, images, &mut sigma) {
+        return None;
+    }
+    let (sigma, hyps) = complete_premises(h_conj, t_conj, vars, images, &sigma)?;
+    // Every helper given must be bound (the instantiation must be a
+    // closed application).
+    if vars.iter().any(|v| !sigma.contains_key(*v)) {
+        return None;
+    }
+    Some((sigma, hyps))
+}
+
+/// Recognize a consumer law against the source-earlier helpers. First
+/// matching helper wins (single-helper consumption — the measured
+/// subset).
+pub(super) fn classify_consumption(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    helpers: &[HelperView],
+) -> Option<ConsumptionPlan> {
+    let when = law.when.as_ref()?;
+    if law.givens.is_empty() || law.givens.iter().any(|g| g.type_name != "Int") {
+        return None;
+    }
+    if !matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true))) {
+        return None;
+    }
+    // Claim: a plain call of the subject over given idents.
+    let (callee, call_args) = call_of(&law.lhs)?;
+    if callee.rsplit('.').next()? != vb.fn_name {
+        return None;
+    }
+    let given_names: Vec<&str> = law.givens.iter().map(|g| g.name.as_str()).collect();
+    let mut arg_names = Vec::with_capacity(call_args.len());
+    for arg in call_args {
+        let name = ident_of(arg)?;
+        if !given_names.contains(&name) {
+            return None;
+        }
+        arg_names.push(name);
+    }
+    // Subject: pure, Bool-valued, non-recursive, body `lhs == rhs`.
+    let fd = ctx.fn_def_by_name(&vb.fn_name, None)?;
+    if !fd.effects.is_empty() || fd.params.len() != arg_names.len() || fd.return_type != "Bool" {
+        return None;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::BinOp(BinOp::Eq, body_l, body_r) = &body.node else {
+        return None;
+    };
+    if calls_fn(body, &vb.fn_name) {
+        return None;
+    }
+    // The cone: the subject body at the law's arguments.
+    let param_map: BTreeMap<&str, &str> = fd
+        .params
+        .iter()
+        .zip(arg_names.iter())
+        .map(|((p, _), a)| (p.as_str(), *a))
+        .collect();
+    let left = substitute_params(body_l, &param_map)?;
+    let right = substitute_params(body_r, &param_map)?;
+    // Consumer premise conjuncts (right-nested conjunction, >= 2 — the
+    // single-atom premise renders at a different Bool/Prop seam and is
+    // not in the measured subset).
+    let t_conj = when_conjuncts(when)?;
+    if t_conj.len() < 2 {
+        return None;
+    }
+    // Proof-local binder hygiene: declines instead of shadowing.
+    let reserved: Vec<String> = std::iter::once("h_when".to_string())
+        .chain((0..t_conj.len()).map(|i| format!("h{i}")))
+        .chain((0..2).map(|i| format!("hh{i}")))
+        .collect();
+    if given_names.iter().any(|g| reserved.iter().any(|r| r == g)) {
+        return None;
+    }
+
+    for helper in helpers {
+        let Some(h_when) = helper.law.when.as_ref() else {
+            continue;
+        };
+        if helper.law.givens.iter().any(|g| g.type_name != "Int") {
+            continue;
+        }
+        if !matches!(&helper.law.rhs.node, Expr::Literal(Literal::Bool(true))) {
+            continue;
+        }
+        // Helper conclusion must be an equation pinned `=> true` — its
+        // companion then concludes the plain equality `lhs = rhs` the
+        // consumer rewrites with.
+        let Expr::BinOp(BinOp::Eq, h_lhs, h_rhs) = &helper.law.lhs.node else {
+            continue;
+        };
+        let Some(h_conj) = when_conjuncts(h_when) else {
+            continue;
+        };
+        let h_vars: Vec<&str> = helper.law.givens.iter().map(|g| g.name.as_str()).collect();
+
+        let mut sites: Vec<(Sigma, Vec<usize>)> = Vec::new();
+        for side in [&left, &right] {
+            if let Some(site) = match_side(side, h_lhs, &h_conj, &t_conj, &h_vars, &given_names)
+                && !sites.iter().any(|(s, _)| s == &site.0)
+            {
+                sites.push(site);
+            }
+        }
+        if sites.is_empty() {
+            continue;
+        }
+        // Simulate the rewrites: after replacing every matched
+        // conclusion-LHS image with its RHS image, both sides must be
+        // syntactically identical (`simp` then closes the reflexive
+        // `==`). Otherwise decline — never emit a non-closing proof.
+        let mut sim_l = left.clone();
+        let mut sim_r = right.clone();
+        let mut used: Vec<&(Sigma, Vec<usize>)> = Vec::new();
+        for site in &sites {
+            let pat = apply_sigma(h_lhs, &site.0);
+            let repl = apply_sigma(h_rhs, &site.0);
+            if !occurs_in(&sim_l, &pat) && !occurs_in(&sim_r, &pat) {
+                continue;
+            }
+            sim_l = replace_all(&sim_l, &pat, &repl);
+            sim_r = replace_all(&sim_r, &pat, &repl);
+            used.push(site);
+        }
+        if used.is_empty() || !expr_eq(&sim_l, &sim_r) {
+            continue;
+        }
+        let instantiations = used
+            .into_iter()
+            .map(|(sigma, hyps)| Instantiation {
+                args: h_vars
+                    .iter()
+                    .map(|v| sigma.get(*v).expect("bound by match_side").clone())
+                    .collect(),
+                hyps: hyps.clone(),
+            })
+            .collect();
+        return Some(ConsumptionPlan {
+            helper_file: helper.file,
+            helper_companion: helper.companion.clone(),
+            instantiations,
+            conjuncts: t_conj.len(),
+        });
+    }
+    None
+}
+
+pub(super) fn render_consumption(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    plan: &ConsumptionPlan,
+    entry_root: &str,
+    entry_content: &str,
+    sabotage: bool,
+) -> Option<LaneLawFile> {
+    let emit = |e: &Spanned<Expr>| emit_expr_legacy(e, ctx, None);
+
+    let fn_lean = aver_name_to_lean(&vb.fn_name);
+    let law_lean = aver_name_to_lean(&law.name);
+    let theorem_base = format!("{fn_lean}_law_{law_lean}");
+    let theorem = format!("{theorem_base}_universal");
+
+    let lhs_template = emit(&law.lhs);
+    let rhs_template = emit(&law.rhs).replace('\n', " ");
+    let when_template = emit(law.when.as_ref()?).replace('\n', " ");
+
+    let lifted = std::collections::HashMap::new();
+    let (prop, bounded) = super::super::toplevel::law_theorem_prop(
+        law,
+        ctx,
+        &lhs_template,
+        &rhs_template,
+        Some(&when_template),
+        &lifted,
+        true,
+    );
+    debug_assert!(!bounded);
+    let given_lean: Vec<String> = law
+        .givens
+        .iter()
+        .map(|g| aver_name_to_lean(&g.name))
+        .collect();
+    let quant_params = given_lean
+        .iter()
+        .map(|g| format!("({g} : Int)"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let sabotage_line = if sabotage {
+        // TEST-ONLY (`AVER_PROOF_LANE_SABOTAGE`): see the twin comment
+        // in the other renderers.
+        "\n  exact averLaneSabotageInjectedByTest"
+    } else {
+        ""
+    };
+
+    let mut content = String::new();
+    content.push_str(&format!(
+        "-- Aver when-universal quarantine lane — verify law {}.{}\n\
+         -- NOT part of the counted default build. Built by a separate,\n\
+         -- failure-tolerated per-law `lake build` invocation; credited only\n\
+         -- on per-declaration `#print axioms` evidence (whitelist: propext,\n\
+         -- Classical.choice, Quot.sound).\n\
+         -- This law's proof CONSUMES an earlier proven law of this file: it\n\
+         -- imports that law's lane module and applies its plain-logic\n\
+         -- companion via explicit `have` at the matched instantiations. If\n\
+         -- the helper failed to prove, its module does not build and this\n\
+         -- module's tolerated build fails with it — both stay bounded.\n",
+        vb.fn_name, law.name,
+    ));
+    content.push_str(&format!("import {entry_root}\n\n"));
+    content.push_str("set_option linter.unusedVariables false\n\n");
+    content.push_str(&format!(
+        "{}{} {}\n",
+        super::super::LAW_CLASS_MARKER_PREFIX,
+        theorem,
+        super::super::LAW_CLASS_UNIVERSAL
+    ));
+    content.push_str(&format!(
+        "theorem {theorem} : ∀ {quant_params}, {prop} := by\n"
+    ));
+    content.push_str(&format!(
+        "  intro {} h_when{sabotage_line}\n",
+        given_lean.join(" ")
+    ));
+    content.push_str("  simp only [Bool.and_eq_true, decide_eq_true_eq] at h_when\n");
+    let obtain_pat: Vec<String> = (0..plan.conjuncts).map(|i| format!("h{i}")).collect();
+    content.push_str(&format!("  obtain ⟨{}⟩ := h_when\n", obtain_pat.join(", ")));
+    for (i, inst) in plan.instantiations.iter().enumerate() {
+        let args: Vec<String> = inst.args.iter().map(|a| aver_name_to_lean(a)).collect();
+        let hyps: Vec<String> = inst.hyps.iter().map(|j| format!("h{j}")).collect();
+        content.push_str(&format!(
+            "  have hh{i} := {} {} {}\n",
+            plan.helper_companion,
+            args.join(" "),
+            hyps.join(" ")
+        ));
+    }
+    content.push_str(&format!("  unfold {fn_lean}\n"));
+    let rw_list: Vec<String> = (0..plan.instantiations.len())
+        .map(|i| format!("hh{i}"))
+        .collect();
+    content.push_str(&format!("  rw [{}]\n", rw_list.join(", ")));
+    content.push_str("  simp\n");
+
+    // Prop-form corollary, derived from the twin above — same module,
+    // no separate credit; a later law may consume THIS law through it.
+    content.push('\n');
+    let given_names: Vec<String> = law.givens.iter().map(|g| g.name.clone()).collect();
+    content.push_str(&super::shared::render_prop_corollary(
+        &theorem_base,
+        &quant_params,
+        &given_names,
+        law,
+        ctx,
+        &format!("{lhs_template} = {rhs_template}"),
+    ));
+
+    // L2 of the iron guard: the lane grammar has no sorry carrier.
+    debug_assert!(
+        !content.contains("sorry"),
+        "universal-lane module must not contain a sorry token"
+    );
+
+    // The helper import (and the module-hash folding of the helper's
+    // content) is wired by the caller via `with_lane_imports`, which
+    // also records the dependency edge in the lane index.
+    let module = lane_module_id(&theorem_base, &content, entry_content);
+
+    Some(LaneLawFile {
+        label: format!("{}.{}", vb.fn_name, law.name),
+        companion: format!("{theorem_base}_prop"),
+        theorem,
+        theorem_base,
+        module,
+        imports: Vec::new(),
+        content,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sp(node: Expr) -> Spanned<Expr> {
+        Spanned::new(node, 0)
+    }
+    fn ident(n: &str) -> Spanned<Expr> {
+        sp(Expr::Ident(n.to_string()))
+    }
+    fn int(v: i64) -> Spanned<Expr> {
+        sp(Expr::Literal(Literal::Int(v)))
+    }
+    fn bin(op: BinOp, l: Spanned<Expr>, r: Spanned<Expr>) -> Spanned<Expr> {
+        sp(Expr::BinOp(op, Box::new(l), Box::new(r)))
+    }
+    fn call(name: &str, args: Vec<Spanned<Expr>>) -> Spanned<Expr> {
+        sp(Expr::FnCall(Box::new(ident(name)), args))
+    }
+
+    /// Conclusion-LHS matching binds the helper's givens through
+    /// nested structure, consistently.
+    #[test]
+    fn match_shape_binds_through_products() {
+        // pattern: f(a, b * d) — target: f(xn, xs * scale)
+        let pat = call(
+            "binFloor",
+            vec![ident("a"), bin(BinOp::Mul, ident("b"), ident("d"))],
+        );
+        let target = call(
+            "binFloor",
+            vec![ident("xn"), bin(BinOp::Mul, ident("xs"), ident("scale"))],
+        );
+        let vars = ["a", "b", "d", "w"];
+        let images = ["xn", "xs", "scale", "cell"];
+        let mut sigma = Sigma::new();
+        assert!(match_shape(&pat, &target, &vars, &images, &mut sigma));
+        assert_eq!(sigma.get("a").map(String::as_str), Some("xn"));
+        assert_eq!(sigma.get("b").map(String::as_str), Some("xs"));
+        assert_eq!(sigma.get("d").map(String::as_str), Some("scale"));
+        // a different callee never matches
+        let other = call(
+            "otherFloor",
+            vec![ident("xn"), bin(BinOp::Mul, ident("xs"), ident("scale"))],
+        );
+        let mut sigma2 = Sigma::new();
+        assert!(!match_shape(&pat, &other, &vars, &images, &mut sigma2));
+        // an image outside the consumer's givens never binds
+        let stray = call(
+            "binFloor",
+            vec![ident("zz"), bin(BinOp::Mul, ident("xs"), ident("scale"))],
+        );
+        let mut sigma3 = Sigma::new();
+        assert!(!match_shape(&pat, &stray, &vars, &images, &mut sigma3));
+    }
+
+    /// Premise completion binds the helper givens the conclusion left
+    /// free (the cell index) and records which consumer conjunct pays
+    /// for each helper conjunct.
+    #[test]
+    fn premise_subset_completes_free_given_and_maps_indices() {
+        // helper premises: b > 0; d > 0; w*b < a; a < (w+1)*b
+        let h0 = bin(BinOp::Gt, ident("b"), int(0));
+        let h1 = bin(BinOp::Gt, ident("d"), int(0));
+        let h2 = bin(
+            BinOp::Lt,
+            bin(BinOp::Mul, ident("w"), ident("b")),
+            ident("a"),
+        );
+        let h3 = bin(
+            BinOp::Lt,
+            ident("a"),
+            bin(BinOp::Mul, bin(BinOp::Add, ident("w"), int(1)), ident("b")),
+        );
+        let h_conj_owned = [h0, h1, h2, h3];
+        let h_conj: Vec<&Spanned<Expr>> = h_conj_owned.iter().collect();
+        // consumer premises: xs > 0; scale > 0; cell*xs < xn; xn < (cell+1)*xs
+        let t0 = bin(BinOp::Gt, ident("xs"), int(0));
+        let t1 = bin(BinOp::Gt, ident("scale"), int(0));
+        let t2 = bin(
+            BinOp::Lt,
+            bin(BinOp::Mul, ident("cell"), ident("xs")),
+            ident("xn"),
+        );
+        let t3 = bin(
+            BinOp::Lt,
+            ident("xn"),
+            bin(
+                BinOp::Mul,
+                bin(BinOp::Add, ident("cell"), int(1)),
+                ident("xs"),
+            ),
+        );
+        let t_conj_owned = [t0, t1, t2, t3];
+        let t_conj: Vec<&Spanned<Expr>> = t_conj_owned.iter().collect();
+        let vars = ["a", "b", "w", "d"];
+        let images = ["xn", "xs", "cell", "scale"];
+        // conclusion-LHS match bound a, b, d; w is still free
+        let mut seed = Sigma::new();
+        seed.insert("a".to_string(), "xn".to_string());
+        seed.insert("b".to_string(), "xs".to_string());
+        seed.insert("d".to_string(), "scale".to_string());
+        let (sigma, hyps) =
+            complete_premises(&h_conj, &t_conj, &vars, &images, &seed).expect("must complete");
+        assert_eq!(sigma.get("w").map(String::as_str), Some("cell"));
+        assert_eq!(hyps, vec![0, 1, 2, 3]);
+        // drop one consumer conjunct (`scale > 0`) -> the subset rule
+        // fails and the consumer must decline.
+        let t_missing: Vec<&Spanned<Expr>> = [&t_conj_owned[0], &t_conj_owned[2], &t_conj_owned[3]]
+            .into_iter()
+            .collect();
+        assert!(complete_premises(&h_conj, &t_missing, &vars, &images, &seed).is_none());
+    }
+
+    /// The rewrite simulation: both cone sides must collapse to the
+    /// same term, otherwise the figure declines.
+    #[test]
+    fn rewrite_simulation_requires_closing_shape() {
+        let lhs_img = call(
+            "binFloor",
+            vec![ident("xn"), bin(BinOp::Mul, ident("xs"), ident("scale"))],
+        );
+        let rhs_img = call("binFloor", vec![ident("cell"), ident("scale")]);
+        let other = call(
+            "binFloor",
+            vec![ident("yn"), bin(BinOp::Mul, ident("ys"), ident("scale"))],
+        );
+        // replacing the left image yields the right image -> equal
+        let rewritten = replace_all(&lhs_img, &lhs_img, &rhs_img);
+        assert!(expr_eq(&rewritten, &rhs_img));
+        // an unmatched side stays distinct -> the caller must decline
+        let rewritten_other = replace_all(&other, &lhs_img, &rhs_img);
+        assert!(!expr_eq(&rewritten_other, &rhs_img));
+        assert!(occurs_in(
+            &bin(BinOp::Eq, lhs_img.clone(), other.clone()),
+            &lhs_img
+        ));
+    }
+}

--- a/src/codegen/lean/universal_lane/floor.rs
+++ b/src/codegen/lean/universal_lane/floor.rs
@@ -1,0 +1,385 @@
+//! FAMILY 3 — coarse-floor stability: a `when`-law stating that the
+//! floored quotient is stable when the numerator moves inside one open
+//! cell of a finer grid. Shape (over a 2-Int-param floor wrapper `f`
+//! built on `Int.div` with a 0 default for the zero divisor):
+//!
+//! ```text
+//! when  b > 0  ∧  d > 0  ∧  w*b < a  ∧  a < (w+1)*b
+//! f(a, b*d) == f(w, d)  =>  true
+//! ```
+//!
+//! The lane proof instantiates a hand-validated arithmetic core (proved
+//! kernel-clean over core Lean v4.15: `Int.ediv_add_emod` bounds on
+//! `w/d` lifted through `Int.le_ediv_iff_mul_le`, nonlinear products
+//! aligned by `calc`/`rw` so `omega` only ever sees identical opaque
+//! atoms), then discharges the `Int.div` Result wrapper with the
+//! divisor-nonzero facts. Anything off this exact shape declines at
+//! zero cost. See the module doc in `mod.rs` for the lane's crediting
+//! and iron-guard model.
+
+use super::super::expr::{aver_name_to_lean, emit_expr_legacy};
+use crate::ast::{BinOp, Expr, Literal, Pattern, Spanned, Stmt, VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+use super::shared::{call_of, ident_of, when_conjuncts};
+use super::{LaneLawFile, lane_module_id};
+
+/// Recognized law, with the given names mapped to their roles and the
+/// premise conjuncts located (any order within a right-nested spine).
+pub(super) struct FloorPlan {
+    /// Role-ordered given names: numerator, fine step, cell index,
+    /// coarsening factor — the `(a, b, w, d)` of the statement.
+    roles: [String; 4],
+    /// Premise conjunct index per role premise, in the order the core
+    /// lemma consumes them: `b > 0`, `d > 0`, `w*b < a`, `a < (w+1)*b`.
+    hyps: [usize; 4],
+}
+
+/// Proof-local binder names of the rendered twin; a colliding `given`
+/// would be shadowed mid-proof, so such laws decline.
+const FLOOR_RESERVED: &[&str] = &["h_when", "h0", "h1", "h2", "h3", "key", "hbd", "hd0"];
+
+fn is_int_lit(e: &Spanned<Expr>, v: i64) -> bool {
+    matches!(&e.node, Expr::Literal(Literal::Int(n)) if *n == v)
+}
+
+/// `name > 0`.
+fn is_gt_zero(e: &Spanned<Expr>, name: &str) -> bool {
+    matches!(&e.node, Expr::BinOp(BinOp::Gt, l, r)
+        if ident_of(l) == Some(name) && is_int_lit(r, 0))
+}
+
+/// `w * b < a`.
+fn is_cell_low(e: &Spanned<Expr>, w: &str, b: &str, a: &str) -> bool {
+    let Expr::BinOp(BinOp::Lt, l, r) = &e.node else {
+        return false;
+    };
+    if ident_of(r) != Some(a) {
+        return false;
+    }
+    matches!(&l.node, Expr::BinOp(BinOp::Mul, lw, lb)
+        if ident_of(lw) == Some(w) && ident_of(lb) == Some(b))
+}
+
+/// `a < (w + 1) * b`.
+fn is_cell_high(e: &Spanned<Expr>, a: &str, w: &str, b: &str) -> bool {
+    let Expr::BinOp(BinOp::Lt, l, r) = &e.node else {
+        return false;
+    };
+    if ident_of(l) != Some(a) {
+        return false;
+    }
+    let Expr::BinOp(BinOp::Mul, rl, rb) = &r.node else {
+        return false;
+    };
+    if ident_of(rb) != Some(b) {
+        return false;
+    }
+    matches!(&rl.node, Expr::BinOp(BinOp::Add, aw, one)
+        if ident_of(aw) == Some(w) && is_int_lit(one, 1))
+}
+
+/// The subject must be the floor wrapper: two Int params -> Int, pure,
+/// body = `match Int.div(p0, p1) { Ok(q) -> q; Err(_) -> 0 }`.
+fn is_floor_div_wrapper(vb: &VerifyBlock, ctx: &CodegenContext) -> bool {
+    let Some(fd) = ctx.fn_def_by_name(&vb.fn_name, None) else {
+        return false;
+    };
+    if !fd.effects.is_empty()
+        || fd.params.len() != 2
+        || fd.params.iter().any(|(_, ty)| ty != "Int")
+        || fd.return_type != "Int"
+    {
+        return false;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return false;
+    };
+    let Some((callee, args)) = call_of(subject) else {
+        return false;
+    };
+    if callee != "Int.div"
+        || args.len() != 2
+        || ident_of(&args[0]) != Some(fd.params[0].0.as_str())
+        || ident_of(&args[1]) != Some(fd.params[1].0.as_str())
+        || arms.len() != 2
+    {
+        return false;
+    }
+    let ok_arm = arms.iter().any(|arm| {
+        matches!(&arm.pattern, Pattern::Constructor(n, binders)
+            if n == "Result.Ok"
+                && binders.len() == 1
+                && ident_of(&arm.body) == Some(binders[0].as_str()))
+    });
+    let err_arm = arms.iter().any(|arm| {
+        matches!(&arm.pattern, Pattern::Constructor(n, binders)
+            if n == "Result.Err" && binders.len() == 1 && is_int_lit(&arm.body, 0))
+    });
+    ok_arm && err_arm
+}
+
+/// Validate one when-law against the coarse-floor stability shape.
+/// Any deviation declines — the law simply stays bounded, the manifest
+/// bytes untouched.
+pub(super) fn classify_floor_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Option<FloorPlan> {
+    let when = law.when.as_ref()?;
+    if law.givens.len() != 4 || law.givens.iter().any(|g| g.type_name != "Int") {
+        return None;
+    }
+    if !matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true))) {
+        return None;
+    }
+    // Claim: `f(a, b*d) == f(w, d)` over the subject fn.
+    let Expr::BinOp(BinOp::Eq, claim_l, claim_r) = &law.lhs.node else {
+        return None;
+    };
+    let (lc, la) = call_of(claim_l)?;
+    let (rc, ra) = call_of(claim_r)?;
+    if lc.rsplit('.').next()? != vb.fn_name || rc != lc || la.len() != 2 || ra.len() != 2 {
+        return None;
+    }
+    let a = ident_of(&la[0])?;
+    let Expr::BinOp(BinOp::Mul, mul_b, mul_d) = &la[1].node else {
+        return None;
+    };
+    let b = ident_of(mul_b)?;
+    let d = ident_of(mul_d)?;
+    let w = ident_of(&ra[0])?;
+    if ident_of(&ra[1])? != d {
+        return None;
+    }
+    // The four roles are distinct names covering the givens exactly.
+    let roles = [a, b, w, d];
+    let given_names: Vec<&str> = law.givens.iter().map(|g| g.name.as_str()).collect();
+    let mut sorted_roles = roles.to_vec();
+    sorted_roles.sort_unstable();
+    sorted_roles.dedup();
+    if sorted_roles.len() != 4 || roles.iter().any(|r| !given_names.contains(r)) {
+        return None;
+    }
+    if given_names.iter().any(|g| FLOOR_RESERVED.contains(g)) {
+        return None;
+    }
+    if !is_floor_div_wrapper(vb, ctx) {
+        return None;
+    }
+    // Premise: exactly the four cell conjuncts, located by shape.
+    let conjuncts = when_conjuncts(when)?;
+    if conjuncts.len() != 4 {
+        return None;
+    }
+    let find = |pred: &dyn Fn(&Spanned<Expr>) -> bool| -> Option<usize> {
+        conjuncts.iter().position(|c| pred(c))
+    };
+    let hyps = [
+        find(&|c| is_gt_zero(c, b))?,
+        find(&|c| is_gt_zero(c, d))?,
+        find(&|c| is_cell_low(c, w, b, a))?,
+        find(&|c| is_cell_high(c, a, w, b))?,
+    ];
+    let mut sorted_hyps = hyps.to_vec();
+    sorted_hyps.sort_unstable();
+    sorted_hyps.dedup();
+    if sorted_hyps.len() != 4 {
+        return None;
+    }
+    Some(FloorPlan {
+        roles: roles.map(str::to_string),
+        hyps,
+    })
+}
+
+/// The hand-validated arithmetic core (kernel axioms
+/// `[propext, Quot.sound]` on core Lean v4.15), rendered as a private
+/// lane-local lemma — never a hole.
+fn floor_core_lemma(name: &str) -> String {
+    format!(
+        r#"/-- Floors at a coarser grid are stable across an open finer-grid
+cell: `W*b < a < (W+1)*b` and `D > 0` give `a / (b*D) = W / D`. -/
+private theorem {name} (a b W D : Int) (hb : 0 < b) (hD : 0 < D)
+    (hlo : W * b < a) (hhi : a < (W + 1) * b) :
+    a / (b * D) = W / D := by
+  have hbD : 0 < b * D := Int.mul_pos hb hD
+  have hmod : D * (W / D) + W % D = W := Int.ediv_add_emod W D
+  have hr0 : 0 ≤ W % D := Int.emod_nonneg W (by omega)
+  have hrD : W % D < D := Int.emod_lt_of_pos W hD
+  have hqDW : (W / D) * D ≤ W := by
+    calc (W / D) * D = D * (W / D) := Int.mul_comm _ _
+      _ ≤ D * (W / D) + W % D := Int.le_add_of_nonneg_right hr0
+      _ = W := hmod
+  have hW1 : W + 1 ≤ (W / D + 1) * D := by
+    calc W + 1 = D * (W / D) + W % D + 1 := by rw [hmod]
+      _ ≤ D * (W / D) + D := by omega
+      _ = (W / D + 1) * D := by
+            rw [Int.add_mul, Int.one_mul, Int.mul_comm]
+  have hlow : (W / D) * (b * D) ≤ a := by
+    have h1 : ((W / D) * D) * b ≤ W * b :=
+      Int.mul_le_mul_of_nonneg_right hqDW (Int.le_of_lt hb)
+    have h2 : (W / D) * (b * D) = ((W / D) * D) * b := by
+      rw [Int.mul_assoc, Int.mul_comm b D]
+    omega
+  have hup : a < (W / D + 1) * (b * D) := by
+    have h1 : (W + 1) * b ≤ ((W / D + 1) * D) * b :=
+      Int.mul_le_mul_of_nonneg_right hW1 (Int.le_of_lt hb)
+    have h2 : (W / D + 1) * (b * D) = ((W / D + 1) * D) * b := by
+      rw [Int.mul_assoc, Int.mul_comm b D]
+    omega
+  have hle : W / D ≤ a / (b * D) := (Int.le_ediv_iff_mul_le hbD).mpr hlow
+  have hlt : a / (b * D) < W / D + 1 := by
+    rcases Int.lt_trichotomy (a / (b * D)) (W / D + 1) with h | h | h
+    · exact h
+    · have hge : W / D + 1 ≤ a / (b * D) := by rw [h]; exact Int.le_refl _
+      have := (Int.le_ediv_iff_mul_le hbD).mp hge
+      omega
+    · have := (Int.le_ediv_iff_mul_le hbD).mp (Int.le_of_lt h)
+      omega
+  omega
+"#
+    )
+}
+
+pub(super) fn render_floor_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    plan: &FloorPlan,
+    entry_root: &str,
+    entry_content: &str,
+    sabotage: bool,
+) -> Option<LaneLawFile> {
+    let emit = |e: &Spanned<Expr>| emit_expr_legacy(e, ctx, None);
+
+    let fn_lean = aver_name_to_lean(&vb.fn_name);
+    let law_lean = aver_name_to_lean(&law.name);
+    let theorem_base = format!("{fn_lean}_law_{law_lean}");
+    let theorem = format!("{theorem_base}_universal");
+    let core = format!("{theorem_base}__floor_stable");
+
+    let lhs_template = emit(&law.lhs);
+    let rhs_template = emit(&law.rhs).replace('\n', " ");
+    let when_template = emit(law.when.as_ref()?).replace('\n', " ");
+
+    // Same statement builder as the manifest theorem, minus the
+    // sampled-domain disjunctions (`omit_domain`) — the twin is the
+    // manifest claim with the bounding premises removed.
+    let lifted = std::collections::HashMap::new();
+    let (prop, bounded) = super::super::toplevel::law_theorem_prop(
+        law,
+        ctx,
+        &lhs_template,
+        &rhs_template,
+        Some(&when_template),
+        &lifted,
+        true,
+    );
+    debug_assert!(!bounded);
+    let given_lean: Vec<String> = law
+        .givens
+        .iter()
+        .map(|g| aver_name_to_lean(&g.name))
+        .collect();
+    let quant_params = given_lean
+        .iter()
+        .map(|g| format!("({g} : Int)"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let [a, b, w, d] = &plan.roles;
+    let (a, b, w, d) = (
+        aver_name_to_lean(a),
+        aver_name_to_lean(b),
+        aver_name_to_lean(w),
+        aver_name_to_lean(d),
+    );
+    let [hb, hd, hlo, hhi] = plan.hyps.map(|i| format!("h{i}"));
+
+    let sabotage_line = if sabotage {
+        // TEST-ONLY (`AVER_PROOF_LANE_SABOTAGE`): an unknown identifier
+        // makes this module's build fail hard — the lane must absorb it
+        // with zero effect on budgets and neighbors.
+        "\n  exact averLaneSabotageInjectedByTest"
+    } else {
+        ""
+    };
+
+    let mut content = String::new();
+    content.push_str(&format!(
+        "-- Aver when-universal quarantine lane — verify law {}.{}\n\
+         -- NOT part of the counted default build. Built by a separate,\n\
+         -- failure-tolerated per-law `lake build` invocation; credited only\n\
+         -- on per-declaration `#print axioms` evidence (whitelist: propext,\n\
+         -- Classical.choice, Quot.sound). This module carries no honest-\n\
+         -- floor fallback: a non-closing proof is a tolerated build failure\n\
+         -- (the law stays bounded), never a counted warning.\n",
+        vb.fn_name, law.name,
+    ));
+    content.push_str(&format!("import {entry_root}\n\n"));
+    content.push_str("set_option linter.unusedVariables false\n\n");
+    content.push_str(&floor_core_lemma(&core));
+    content.push('\n');
+    content.push_str(&format!(
+        "{}{} {}\n",
+        super::super::LAW_CLASS_MARKER_PREFIX,
+        theorem,
+        super::super::LAW_CLASS_UNIVERSAL
+    ));
+    content.push_str(&format!(
+        "theorem {theorem} : ∀ {quant_params}, {prop} := by\n"
+    ));
+    content.push_str(&format!(
+        "  intro {} h_when{sabotage_line}\n",
+        given_lean.join(" ")
+    ));
+    content.push_str("  simp only [Bool.and_eq_true, decide_eq_true_eq] at h_when\n");
+    content.push_str("  obtain ⟨h0, h1, h2, h3⟩ := h_when\n");
+    content.push_str(&format!(
+        "  have key := {core} {a} {b} {w} {d} {hb} {hd} {hlo} {hhi}\n"
+    ));
+    content.push_str(&format!("  have hbd : ¬ ({b} * {d} = 0) := by\n"));
+    content.push_str(&format!("    have := Int.mul_pos {hb} {hd}\n"));
+    content.push_str("    omega\n");
+    content.push_str(&format!("  have hd0 : ¬ ({d} = 0) := by omega\n"));
+    content.push_str(&format!(
+        "  simp only [{fn_lean}, hbd, hd0, if_false, beq_iff_eq, beq_self_eq_true]\n"
+    ));
+    content.push_str("  simpa using key\n");
+
+    // Prop-form corollary, derived from the twin above with the fixed
+    // Bool/Prop bridge tactic — same module, no separate credit.
+    content.push('\n');
+    let given_names: Vec<String> = law.givens.iter().map(|g| g.name.clone()).collect();
+    content.push_str(&super::shared::render_prop_corollary(
+        &theorem_base,
+        &quant_params,
+        &given_names,
+        law,
+        ctx,
+        &format!("{lhs_template} = {rhs_template}"),
+    ));
+
+    // L2 of the iron guard: the lane grammar has no sorry carrier.
+    debug_assert!(
+        !content.contains("sorry"),
+        "universal-lane module must not contain a sorry token"
+    );
+
+    let module = lane_module_id(&theorem_base, &content, entry_content);
+
+    Some(LaneLawFile {
+        label: format!("{}.{}", vb.fn_name, law.name),
+        companion: format!("{theorem_base}_prop"),
+        theorem,
+        theorem_base,
+        module,
+        imports: Vec::new(),
+        content,
+    })
+}

--- a/src/codegen/lean/universal_lane/mod.rs
+++ b/src/codegen/lean/universal_lane/mod.rs
@@ -68,6 +68,31 @@
 //! unbound by the conclusion's match side would make conditional
 //! rewriting guess, so such laws decline instead.
 //!
+//! FAMILY 3 — coarse-floor stability (`floor.rs`): the law states that
+//! a floored quotient is unchanged while the numerator stays inside an
+//! open cell of a finer grid (`when b>0 ∧ d>0 ∧ w*b<a ∧ a<(w+1)*b`,
+//! claim `f(a, b*d) == f(w, d)` over an `Int.div`-with-0-default
+//! wrapper). Rendered from a hand-validated arithmetic core; exactly
+//! this shape is recognized, everything else declines.
+//!
+//! CONSUMPTION (`consume.rs`): a when-law with NO recognized family of
+//! its own may still prove by CONSUMING a source-earlier lane-proved
+//! when-law: the helper's conclusion-LHS shape is matched into the
+//! consumer's proof cone, the substitution is completed against the
+//! premises, and EVERY helper premise conjunct under the substitution
+//! must already be one of the consumer's premise conjuncts (the
+//! premise-subset rule) — otherwise the consumer declines at zero
+//! cost. The consumer's module imports the helper's module (the
+//! [`with_lane_imports`] machinery) and applies the helper's
+//! plain-logic companion via explicit `have` — never a
+//! `first | exact <companion>` alternative, which is the measured
+//! silent-absorption shape: it can succeed against a broken companion
+//! and carry its axioms into a green build. Fail-closed: a helper that
+//! did not prove is never emitted, so the consumer's import fails its
+//! tolerated build (both stay bounded), and the consumer's credit
+//! keys on its OWN `#print axioms` line where any absorbed axiom
+//! surfaces.
+//!
 //! Paid-for landmines from the hand-proof probe, baked into the
 //! rendered tactic text:
 //! - the rendered premise is decide-coerced (`(n > 0) = true`) —
@@ -94,10 +119,14 @@ use crate::ast::TopLevel;
 use crate::codegen::CodegenContext;
 
 mod bridge;
+mod consume;
+mod floor;
 mod shared;
 mod sign;
 
 use bridge::{classify_bridge_law, render_bridge_law};
+use consume::{HelperView, classify_consumption, render_consumption};
+use floor::{classify_floor_law, render_floor_law};
 use sign::{classify_lane_law, collect_pins, render_lane_law};
 
 /// Subdirectory (relative to the proof output dir) holding lane
@@ -133,19 +162,20 @@ pub struct LaneLawFile {
     /// `.olean` under an old name is unreachable.
     pub module: String,
     /// Module names of the SOURCE-EARLIER lane helpers this module
-    /// imports — the dependency edges the lane manifest records. Empty
-    /// until a consumption figure (CH-3) populates it; the import
-    /// machinery itself ([`with_lane_imports`]) is built here.
+    /// imports — the dependency edges the lane manifest records.
+    /// Populated when this law's proof consumes an earlier lane law
+    /// (`consume.rs`), via [`with_lane_imports`].
     pub imports: Vec<String>,
     /// Full `.lean` source. Contains NO `sorry` token.
     pub content: String,
 }
 
-/// One lane law the collision guard refused to emit: its twin or
-/// companion name clashed with a theorem already emitted (a manifest
-/// theorem, or an earlier lane law's twin/companion). Surfaced in the
-/// lane detail artifact as an honest note rather than letting the
-/// tolerated build fail and silently withhold a neighbor's credit.
+/// One lane law the collision guard refused to emit: a name its module
+/// declares (twin, companion, or an aux lemma) clashed with a theorem
+/// already emitted (a manifest theorem, or any declaration of an
+/// earlier lane module). Surfaced in the lane detail artifact as an
+/// honest note rather than letting the tolerated build fail and
+/// silently withhold a neighbor's credit.
 pub struct OmittedLaw {
     /// `fn.law` label for surfacing.
     pub label: String,
@@ -172,11 +202,13 @@ pub struct LaneOutput {
 /// proof that one broken lane proof cannot touch budgets or
 /// neighbors.
 ///
-/// COLLISION GUARD: before a lane module is emitted, its twin
-/// (`…_universal`) and companion (`…_prop`) names are checked against
-/// the names already in play — the counted-build manifest theorems
-/// (parsed from `entry_content`) and every earlier lane law's twin and
-/// companion. A clash (e.g. a sibling law literally named
+/// COLLISION GUARD: before a lane module is emitted, every name it
+/// declares — its twin (`…_universal`), its companion (`…_prop`), and
+/// any aux lemma in its content — is checked against the names already
+/// in play: the counted-build manifest theorems (parsed from
+/// `entry_content`) and every declaration of every earlier lane
+/// module (in guard scope because consumption imports lane modules
+/// into one another). A clash (e.g. a sibling law literally named
 /// `<law>_universal` or `<law>_prop`) would make the tolerated build
 /// fail and SILENTLY withhold a neighbor's credit; instead the
 /// colliding law is honestly OMITTED (no module, no credit attempt) and
@@ -186,10 +218,11 @@ pub struct LaneOutput {
 /// `chain` is a TEST-ONLY hook (`AVER_PROOF_LANE_CHAIN`): with it set,
 /// each emitted lane law imports every SOURCE-EARLIER emitted lane law
 /// ([`with_lane_imports`]), wiring a real lane-to-lane dependency graph
-/// against live `lake`. No emitter path drives imports yet (the
-/// consumption figure is CH-3); the hook lets the two-module-chain
-/// sabotage and stale-`.olean`-retirement gates exercise the
-/// machinery end to end.
+/// against live `lake` regardless of recognition. The production path
+/// that drives imports is consumption (`consume.rs`): a consumer
+/// imports exactly its helper's module. The hook keeps the
+/// two-module-chain sabotage and stale-`.olean`-retirement gates
+/// exercising the machinery independently of any recognizer.
 pub fn generate(
     ctx: &CodegenContext,
     entry_content: &str,
@@ -199,11 +232,16 @@ pub fn generate(
     let pins = collect_pins(ctx);
     let entry_root = crate::codegen::common::entry_basename(ctx);
     // Names already emitted into the counted build (manifest theorems)
-    // seed the guard; each emitted lane law then adds its twin and
-    // companion before the next law is checked.
+    // seed the guard; each emitted lane law then adds EVERY declaration
+    // its module carries (twin, companion, aux lemmas) before the next
+    // law is checked — consumption wires lane-to-lane imports, so a
+    // later module's namespace now sees earlier modules' declarations.
     let mut emitted_names = manifest_theorem_names(entry_content);
     let mut out: Vec<LaneLawFile> = Vec::new();
     let mut omitted = Vec::new();
+    // Source-earlier emitted when-laws, viewable as helpers by the
+    // consumption figure (index into `out` + the law's AST).
+    let mut helper_records: Vec<(usize, &crate::ast::VerifyLaw)> = Vec::new();
     for item in &ctx.items {
         let TopLevel::Verify(vb) = item else { continue };
         let crate::ast::VerifyKind::Law(law) = &vb.kind else {
@@ -242,9 +280,51 @@ pub fn generate(
                 sabotage_this,
             );
         }
+        if candidate.is_none()
+            && let Some(plan) = classify_floor_law(vb, law, ctx)
+        {
+            candidate = render_floor_law(
+                vb,
+                law,
+                ctx,
+                &plan,
+                &entry_root,
+                entry_content,
+                sabotage_this,
+            );
+        }
+        // No family of its own: try CONSUMING a source-earlier lane
+        // law (premise-subset matcher). The plan remembers which
+        // helper module to import.
+        let mut consumed_helper: Option<usize> = None;
+        if candidate.is_none() {
+            let helpers: Vec<HelperView> = helper_records
+                .iter()
+                .map(|(file, h_law)| HelperView {
+                    file: *file,
+                    companion: out[*file].companion.clone(),
+                    law: h_law,
+                })
+                .collect();
+            if let Some(plan) = classify_consumption(vb, law, ctx, &helpers) {
+                candidate = render_consumption(
+                    vb,
+                    law,
+                    ctx,
+                    &plan,
+                    &entry_root,
+                    entry_content,
+                    sabotage_this,
+                );
+                if candidate.is_some() {
+                    consumed_helper = Some(plan.helper_file);
+                }
+            }
+        }
         let Some(file) = candidate else { continue };
-        // Collision guard: refuse to emit if either emitted name clashes
-        // with an existing manifest or earlier emitted theorem name.
+        // Collision guard: refuse to emit if any name this module
+        // declares clashes with an existing manifest or earlier
+        // emitted lane declaration name.
         if let Some(collides) = collides_with(&file, &emitted_names) {
             omitted.push(OmittedLaw {
                 label: file.label.clone(),
@@ -258,12 +338,23 @@ pub fn generate(
             });
             continue;
         }
+        for name in manifest_theorem_names(&file.content) {
+            emitted_names.insert(name);
+        }
         emitted_names.insert(file.theorem.clone());
         emitted_names.insert(file.companion.clone());
-        // Test hook: wire this law to import every source-earlier
-        // emitted lane law, exercising the import + hash-folding
-        // machinery against live lake.
-        let file = if chain && !out.is_empty() {
+        // Wire the dependency edge: a consumer imports its helper's
+        // module and folds the helper's content into its hash. The
+        // `chain` test hook (`AVER_PROOF_LANE_CHAIN`) instead wires
+        // every law to import every source-earlier law.
+        let file = if let Some(h) = consumed_helper {
+            let helper = &out[h];
+            with_lane_imports(
+                &file,
+                &[(helper.module.clone(), helper.content.clone())],
+                entry_content,
+            )
+        } else if chain && !out.is_empty() {
             let helpers: Vec<(String, String)> = out
                 .iter()
                 .map(|h| (h.module.clone(), h.content.clone()))
@@ -273,6 +364,7 @@ pub fn generate(
             file
         };
         out.push(file);
+        helper_records.push((out.len() - 1, law));
     }
     LaneOutput {
         files: out,
@@ -280,8 +372,11 @@ pub fn generate(
     }
 }
 
-/// Twin or companion name that clashes with an already-emitted theorem
-/// name, if any. Both are checked (the review measured both hazards).
+/// First name the candidate module declares (twin, companion, or any
+/// aux lemma in its content) that clashes with an already-emitted
+/// theorem name, if any. Aux lemmas are in scope because consumption
+/// imports lane modules into one another — a clash anywhere in the
+/// module would fail a tolerated build and silently strip credit.
 fn collides_with(
     file: &LaneLawFile,
     emitted: &std::collections::HashSet<String>,
@@ -292,20 +387,47 @@ fn collides_with(
     if emitted.contains(&file.companion) {
         return Some(file.companion.clone());
     }
-    None
+    let mut declared: Vec<String> = manifest_theorem_names(&file.content).into_iter().collect();
+    declared.sort_unstable();
+    declared.into_iter().find(|name| emitted.contains(name))
 }
 
 /// Theorem names emitted into the counted build, parsed from the
 /// manifest entry `.lean` — every `theorem <name>` / `private theorem
-/// <name>` declaration. This is the ground truth the collision guard
-/// ranges over (a sibling law named `<law>_universal` / `<law>_prop`
-/// surfaces here as a `<fn>_law_<law>_universal` / `…_prop` manifest
-/// theorem, the exact name a neighbor's lane twin/companion would
-/// claim).
+/// <name>` declaration, including those behind a leading attribute
+/// block (`@[simp] theorem <name>`). This is the ground truth the
+/// collision guard ranges over (a sibling law named `<law>_universal`
+/// / `<law>_prop` surfaces here as a `<fn>_law_<law>_universal` /
+/// `…_prop` manifest theorem, the exact name a neighbor's lane
+/// twin/companion would claim). Also applied to emitted lane module
+/// content, so aux lemma names join the guarded set.
 fn manifest_theorem_names(entry_content: &str) -> std::collections::HashSet<String> {
     let mut names = std::collections::HashSet::new();
     for line in entry_content.lines() {
-        let trimmed = line.trim_start();
+        let mut trimmed = line.trim_start();
+        // Strip a leading attribute block: `@[simp] theorem foo` (the
+        // parser would otherwise miss the declaration entirely).
+        if let Some(rest) = trimmed.strip_prefix("@[") {
+            let mut depth = 1usize;
+            let mut end = None;
+            for (i, c) in rest.char_indices() {
+                match c {
+                    '[' => depth += 1,
+                    ']' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = Some(i);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            match end {
+                Some(i) => trimmed = rest[i + 1..].trim_start(),
+                None => continue,
+            }
+        }
         let rest = trimmed
             .strip_prefix("theorem ")
             .or_else(|| trimmed.strip_prefix("private theorem "));
@@ -329,9 +451,9 @@ fn manifest_theorem_names(entry_content: &str) -> std::collections::HashSet<Stri
 /// consumer module, retiring stale `.olean`s. The dependency edges are
 /// recorded on [`LaneLawFile::imports`].
 ///
-/// This is the lane-imports MACHINERY. Nothing in the emitter drives it
-/// yet (the consumption figure is CH-3); it is exercised by tests and
-/// stands ready for that figure to call. `helpers` is the list of
+/// This is the lane-imports MACHINERY, driven by consumption
+/// (`consume.rs` — a consumer imports its helper's module) and by the
+/// `AVER_PROOF_LANE_CHAIN` test hook. `helpers` is the list of
 /// `(module, content)` of the lane modules to import; `entry_content`
 /// is the same manifest seed `generate` folds in, so the consumer hash
 /// stays a pure function of (its own text, its helpers' text, the

--- a/src/codegen/lean/universal_lane/shared.rs
+++ b/src/codegen/lean/universal_lane/shared.rs
@@ -48,6 +48,33 @@ pub(super) fn ctor_of(e: &Spanned<Expr>) -> Option<(String, Vec<&Spanned<Expr>>)
     }
 }
 
+/// Split a `when` predicate into its conjuncts along a RIGHT-NESTED
+/// `Bool.and` spine: `Bool.and(p, Bool.and(q, r))` → `[p, q, r]`.
+/// Returns `None` when a LEFT arm is itself a conjunction — a flat
+/// `obtain ⟨h0, …, hN⟩` pattern only destructures right-nested `And`,
+/// so emitting against a left-nested spine would be a guaranteed
+/// tolerated-build failure; declining keeps the zero-cost contract.
+pub(super) fn when_conjuncts(when: &Spanned<Expr>) -> Option<Vec<&Spanned<Expr>>> {
+    fn walk<'a>(e: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) -> bool {
+        if let Some((callee, args)) = call_of(e)
+            && callee == "Bool.and"
+            && args.len() == 2
+        {
+            let left_is_and =
+                call_of(&args[0]).is_some_and(|(c, a)| c == "Bool.and" && a.len() == 2);
+            if left_is_and {
+                return false;
+            }
+            out.push(&args[0]);
+            return walk(&args[1], out);
+        }
+        out.push(e);
+        true
+    }
+    let mut out = Vec::new();
+    walk(when, &mut out).then_some(out)
+}
+
 /// Flatten a `when` predicate into the consumer-facing PROP premises of
 /// the derived corollary. The lane twin carries the premise at the Bool
 /// seam (`<when> = true`); the corollary normalizes it so a downstream

--- a/tests/fixtures/when_lane_floor.av
+++ b/tests/fixtures/when_lane_floor.av
@@ -1,0 +1,55 @@
+module FloorLane
+    intent =
+        "When-universal lane fixture: a conditional floor-stability law proves universally in"
+        "the side build, and a later conditional law's proof consumes it — the consumer's lane"
+        "module imports the helper's and applies its plain-logic companion. A third law missing"
+        "one premise conjunct shows the honest decline (no side module, bounded credit only)."
+    effects []
+
+fn binFloor(value: Int, span: Int) -> Int
+    ? "Floor of value/span: Aver Int.div is Euclidean, which is floor for positive spans."
+    match Int.div(value, span)
+        Result.Ok(q) -> q
+        Result.Err(msg) -> 0
+
+verify binFloor
+    binFloor(7, 2) => 3
+    binFloor(-7, 2) => -4
+    binFloor(64, 3) => 21
+    binFloor(5, 0) => 0
+
+verify binFloor law cellStable
+    given v: Int = [13, 15]
+    given s: Int = [4]
+    given cell: Int = [3]
+    given scale: Int = [2]
+    when Bool.and(s > 0, Bool.and(scale > 0, Bool.and(cell * s < v, v < (cell + 1) * s)))
+    binFloor(v, s * scale) == binFloor(cell, scale) => true
+
+fn coarseAgree(pn: Int, ps: Int, qn: Int, qs: Int, scale: Int) -> Bool
+    ? "Both ratios pn/ps and qn/qs floored on the scale-times coarser grid agree."
+    binFloor(pn, ps * scale) == binFloor(qn, qs * scale)
+
+verify coarseAgree
+    coarseAgree(13, 4, 25, 8, 2) => true
+    coarseAgree(13, 4, 60, 8, 2) => false
+
+verify coarseAgree law sharedCell
+    given xn: Int = [13, 15]
+    given xs: Int = [4]
+    given yn: Int = [25, 30]
+    given ys: Int = [8]
+    given cell: Int = [3]
+    given scale: Int = [2]
+    when Bool.and(xs > 0, Bool.and(ys > 0, Bool.and(scale > 0, Bool.and(cell * xs < xn, Bool.and(xn < (cell + 1) * xs, Bool.and(cell * ys < yn, yn < (cell + 1) * ys))))))
+    coarseAgree(xn, xs, yn, ys, scale) => true
+
+verify coarseAgree law sharedCellUnguarded
+    given xn: Int = [13, 15]
+    given xs: Int = [4]
+    given yn: Int = [25, 30]
+    given ys: Int = [8]
+    given cell: Int = [3]
+    given scale: Int = [2]
+    when Bool.and(xs > 0, Bool.and(ys > 0, Bool.and(cell * xs < xn, Bool.and(xn < (cell + 1) * xs, Bool.and(cell * ys < yn, yn < (cell + 1) * ys)))))
+    coarseAgree(xn, xs, yn, ys, scale) => true

--- a/tests/proof_spec/when_lane.rs
+++ b/tests/proof_spec/when_lane.rs
@@ -1,5 +1,50 @@
 use super::*;
 
+/// Tripwire against the silent-absorption proof shape: emitted lane
+/// text must never apply a lane-law twin or companion through a
+/// `first | exact …` alternative. That shape was measured to succeed
+/// against a broken companion and carry its axioms into a green build;
+/// lane proofs reference other lane laws ONLY via explicit
+/// `have … := <companion> …` applications. Scans every module listed
+/// in the lane index of `output_dir`.
+fn assert_lane_never_first_exact_lane_theorem(output_dir: &std::path::Path) {
+    let Ok(raw) = std::fs::read_to_string(output_dir.join("_aver_universal_lane.json")) else {
+        return; // no lane emitted — nothing to scan
+    };
+    let index: serde_json::Value = serde_json::from_str(&raw).expect("lane index must parse");
+    let laws = index["laws"].as_array().cloned().unwrap_or_default();
+    let mut lane_names: Vec<String> = Vec::new();
+    for law in &laws {
+        let theorem = law["theorem"].as_str().expect("theorem name");
+        lane_names.push(theorem.to_string());
+        if let Some(base) = theorem.strip_suffix("_universal") {
+            lane_names.push(format!("{base}_prop"));
+        }
+    }
+    for law in &laws {
+        let module = law["module"].as_str().expect("module name");
+        let content = std::fs::read_to_string(
+            output_dir
+                .join("universal_lane")
+                .join(format!("{module}.lean")),
+        )
+        .expect("lane module file must exist");
+        for line in content.lines() {
+            let in_alternative = line.trim_start().starts_with('|') || line.contains("first");
+            if !in_alternative {
+                continue;
+            }
+            for name in &lane_names {
+                assert!(
+                    !line.contains(&format!("exact {name}")),
+                    "lane module {module} applies lane theorem {name} inside a \
+                     `first`/`|` alternative — the silent-absorption shape: {line}"
+                );
+            }
+        }
+    }
+}
+
 /// Nonlinear-arithmetic wall (`tests/fixtures/nr_wall.av`):
 /// laws whose unfolded cone multiplies two VARIABLES (`x * x`,
 /// `(s*s - d*x)^2`) must DEGRADE to honest caught sorries, never to a
@@ -101,6 +146,7 @@ fn proof_when_universal_lane_closes_synthetic_sign_law() {
          (when_universal >= 1).\n{}",
         format_output(&run)
     );
+    assert_lane_never_first_exact_lane_theorem(&output_dir);
     let _ = std::fs::remove_dir_all(&output_dir);
 }
 
@@ -220,6 +266,7 @@ fn proof_when_universal_lane_json_end_to_end() {
             "no_sorry_token_in_universal_module violated by {module}"
         );
     }
+    assert_lane_never_first_exact_lane_theorem(&output_dir);
 
     // ---- run 2: sabotage -------------------------------------------------
     let (sabotaged, run2) = run_lean_check_json(
@@ -360,6 +407,7 @@ fn proof_when_universal_lane_closes_tip_prop_85() {
             "the snoc-distribution aux lemma must be emitted as a lane-local lemma"
         );
     }
+    assert_lane_never_first_exact_lane_theorem(&output_dir);
     // Sabotage: the broken lane proof costs exactly "prop_85 stays
     // bounded" — counted summary byte-identical, no credit.
     let (sabotaged, run2) = run_lean_check_json(
@@ -426,6 +474,7 @@ fn proof_when_universal_lane_closes_synthetic_bridge_laws() {
         vec!["duoUp.duoFlip", "tallyUp.tallyWedgeNeq"],
         "exact lane law set (exact in both directions, like the budgets)"
     );
+    assert_lane_never_first_exact_lane_theorem(&output_dir);
 
     // Sabotage one bridge law: neighbors keep credit, counted untouched.
     let (sabotaged, run2) = run_lean_check_json(
@@ -682,6 +731,238 @@ fn proof_when_universal_lane_stale_olean_retirement() {
     let _ = std::fs::remove_file(&edited_path);
     let _ = std::fs::remove_dir_all(&out_a);
     let _ = std::fs::remove_dir_all(&out_b);
+}
+
+/// Lane consumption, pure generation (no lake): on the floor fixture
+/// (`tests/fixtures/when_lane_floor.av`) the emitter
+/// 1. proves the conditional floor-stability HELPER law in the lane;
+/// 2. recognizes the later `sharedCell` law as a CONSUMER — the
+///    helper's conclusion shape matches both sides of its proof cone
+///    and every helper premise conjunct maps onto one of the
+///    consumer's (the premise-subset rule) — and emits a module that
+///    imports the helper's and applies its companion via explicit
+///    `have` at both instantiations;
+/// 3. DECLINES the `sharedCellUnguarded` variant, which is missing the
+///    helper's `scale > 0` conjunct: no lane module, no failing build,
+///    not even an omission note — recognition simply does not fire.
+#[test]
+fn proof_when_universal_lane_floor_consumption_emission() {
+    use std::path::PathBuf;
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let output_dir = temp_output_dir("aver-proof-floor-emit");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/when_lane_floor.av")
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("aver proof must run");
+    assert!(run.status.success(), "{}", format_output(&run));
+
+    let index: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output_dir.join("_aver_universal_lane.json"))
+            .expect("lane index must be written"),
+    )
+    .expect("lane index must parse");
+    let laws = index["laws"].as_array().expect("laws");
+    let labels: Vec<&str> = laws.iter().filter_map(|l| l["law"].as_str()).collect();
+    assert_eq!(
+        labels,
+        vec!["binFloor.cellStable", "coarseAgree.sharedCell"],
+        "exactly the helper and the consumer emit; the premise-dropping \
+         variant declines (exact in both directions)"
+    );
+    assert!(
+        index["omitted"].as_array().is_some_and(|o| o.is_empty()),
+        "a declined consumer is not an omission note — recognition simply does not fire"
+    );
+    let helper = &laws[0];
+    let consumer = &laws[1];
+    assert!(
+        helper["imports"].as_array().is_some_and(|a| a.is_empty()),
+        "the helper imports no lane module"
+    );
+    assert_eq!(
+        consumer["imports"][0].as_str(),
+        helper["module"].as_str(),
+        "the lane index records the consumer -> helper dependency edge"
+    );
+
+    // The consumer module: imports the helper, applies its companion
+    // via explicit `have` at BOTH instantiations, and carries no sorry.
+    let consumer_src = std::fs::read_to_string(
+        output_dir
+            .join("universal_lane")
+            .join(format!("{}.lean", consumer["module"].as_str().unwrap())),
+    )
+    .expect("consumer lane module must exist");
+    assert!(
+        consumer_src.contains(&format!("import {}", helper["module"].as_str().unwrap())),
+        "the consumer module imports the helper module"
+    );
+    assert!(
+        consumer_src.contains("have hh0 := binFloor_law_cellStable_prop xn xs cell scale")
+            && consumer_src.contains("have hh1 := binFloor_law_cellStable_prop yn ys cell scale"),
+        "the helper companion is applied via explicit `have` at both matched \
+         instantiations:\n{consumer_src}"
+    );
+    let helper_src = std::fs::read_to_string(
+        output_dir
+            .join("universal_lane")
+            .join(format!("{}.lean", helper["module"].as_str().unwrap())),
+    )
+    .expect("helper lane module must exist");
+    for (name, content) in [("consumer", &consumer_src), ("helper", &helper_src)] {
+        assert!(
+            !content.contains("sorry"),
+            "no_sorry_token_in_universal_module violated by the {name} module"
+        );
+    }
+    assert_lane_never_first_exact_lane_theorem(&output_dir);
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// Lane consumption end-to-end against live lake — a conditional law's
+/// universal proof BUILDS ON an earlier proven conditional law of the
+/// same file, both credited kernel-clean by the plain
+/// `aver proof --check` pipeline (no test hooks):
+/// 1. normal run: helper AND consumer earn per-declaration universal
+///    credit (`when_universal == 2`, axiom evidence within the kernel
+///    whitelist), while the premise-dropping variant stays bounded;
+/// 2. SABOTAGE the helper: its tolerated build fails, and the consumer
+///    — which imports the helper's module — fails WITH it in the same
+///    run (`when_universal == 0`). No credited declaration can carry a
+///    broken helper: the consumer's own `#print axioms` line is the
+///    crediting evidence, and an absorbed axiom (sorryAx included)
+///    surfaces there by axiom transitivity;
+/// 3. SABOTAGE only the consumer: the upstream helper keeps its credit
+///    (`when_universal == 1`) — the dependency edge does not leak
+///    backwards.
+/// The counted summary is byte-identical across all three runs.
+#[test]
+fn proof_when_universal_lane_floor_consumption_end_to_end() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lane consumption test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-floor-e2e");
+
+    // ---- run 1: normal -------------------------------------------------
+    let (normal, run) =
+        run_lean_check_json("tests/fixtures/when_lane_floor.av", &output_dir, 0, &[]);
+    assert_eq!(
+        normal["sorries"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(normal["passed"].as_bool(), Some(true));
+    assert_eq!(
+        normal["when_universal"].as_u64(),
+        Some(2),
+        "helper and consumer both close universally in the lane.\n{}",
+        format_output(&run)
+    );
+    let detail: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output_dir.join("when_universal_laws.json"))
+            .expect("when_universal_laws.json must be written"),
+    )
+    .expect("detail artifact must parse");
+    let laws = detail["laws"].as_array().expect("laws array");
+    let labels: Vec<&str> = laws.iter().filter_map(|l| l["law"].as_str()).collect();
+    assert_eq!(
+        labels,
+        vec!["binFloor.cellStable", "coarseAgree.sharedCell"]
+    );
+    for law in laws {
+        assert_eq!(
+            law["universal"].as_bool(),
+            Some(true),
+            "law {} lost lane credit: {}",
+            law["law"],
+            law["evidence"]
+        );
+        assert_eq!(
+            law["evidence"].as_str(),
+            Some(
+                format!(
+                    "'{}' depends on axioms: [propext, Quot.sound]",
+                    law["theorem"].as_str().unwrap()
+                )
+                .as_str()
+            ),
+            "per-declaration #print axioms evidence must be quoted verbatim"
+        );
+    }
+    assert_lane_never_first_exact_lane_theorem(&output_dir);
+
+    // ---- run 2: sabotage the HELPER -> the consumer falls with it -----
+    let (sab_helper, run2) = run_lean_check_json(
+        "tests/fixtures/when_lane_floor.av",
+        &output_dir,
+        0,
+        &[("AVER_PROOF_LANE_SABOTAGE", "cellStable")],
+    );
+    assert_eq!(
+        counted_summary(&sab_helper),
+        counted_summary(&normal),
+        "a broken helper cannot perturb the counted summary.\n{}",
+        format_output(&run2)
+    );
+    assert_eq!(
+        sab_helper["when_universal"].as_u64(),
+        Some(0),
+        "a consumer must lose credit in the SAME run its helper breaks.\n{}",
+        format_output(&run2)
+    );
+    let detail2: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output_dir.join("when_universal_laws.json")).expect("artifact"),
+    )
+    .expect("detail artifact must parse");
+    for law in detail2["laws"].as_array().expect("laws") {
+        assert_eq!(
+            law["universal"].as_bool(),
+            Some(false),
+            "no declaration may stay credited above a broken helper: {} -> {}",
+            law["law"],
+            law["evidence"]
+        );
+        assert!(
+            !law["evidence"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("sorryAx"),
+            "the audit must never see sorryAx on a credited declaration: {}",
+            law["evidence"]
+        );
+    }
+
+    // ---- run 3: sabotage only the CONSUMER -> helper survives ----------
+    let (sab_consumer, run3) = run_lean_check_json(
+        "tests/fixtures/when_lane_floor.av",
+        &output_dir,
+        0,
+        &[("AVER_PROOF_LANE_SABOTAGE", "sharedCell")],
+    );
+    assert_eq!(
+        counted_summary(&sab_consumer),
+        counted_summary(&normal),
+        "a broken consumer cannot perturb the counted summary.\n{}",
+        format_output(&run3)
+    );
+    assert_eq!(
+        sab_consumer["when_universal"].as_u64(),
+        Some(1),
+        "the upstream helper keeps its credit when only the consumer breaks.\n{}",
+        format_output(&run3)
+    );
+
+    let _ = std::fs::remove_dir_all(&output_dir);
 }
 
 /// CH-2 collision guard, live: a sibling law literally named


### PR DESCRIPTION
First step where one law's proof stands on another's: a universally-proven conditional law can now be applied as a lemma inside a later conditional law's proof.

## How it works

- The exporter structurally matches the helper's conclusion inside the consumer's goal (helper parameters are pattern variables that may only bind to the consumer's own quantified variables).
- Premise-subset gate: every helper premise must be implied, under that match, by the consumer's own premises. This is checked conjunct-by-conjunct; any miss declines the whole figure at zero cost (no side-build file, no omission note).
- Emission applies the helper through an explicit `have := <helper>_prop ...` followed by the rewrite — never through a `first | exact <companion>` fallback, which would let a sorry-floored companion silently taint the theorem (a scanner test pins this ban).
- Credit stays per-declaration on kernel axiom evidence (`#print axioms`, whitelist `[propext, Classical.choice, Quot.sound]`). Sabotaging the helper fails the consumer's side build in the same run, so a false helper cannot launder credit through a consumer.

## Also in this change

- The floor-stability helper family the end-to-end pair needs: integer-division cell stability proven from core lemmas (`Int.ediv_add_emod`, `Int.le_ediv_iff_mul_le`).
- Name-collision guard hardening for the side build: the guarded set now covers every declaration of every emitted module (auxiliary lemmas included) and strips leading `@[...]` attributes before parsing declaration names.
- End-to-end fixture (`tests/fixtures/when_lane_floor.av`): helper and consumer both credit kernel-clean through plain `aver proof --check` — `when_universal: 2` with quoted per-declaration evidence.

## Verification

- End-to-end with live Lean: both laws credited on `[propext, Quot.sound]`; the side-build index records the consumer→helper import edge.
- Negative test: dropping one premise from the consumer declines emission entirely, with helper and consumer crediting unchanged.
- Sorry-contamination gauntlet: sabotaging the helper drops `when_universal` to 0 in the same run; the counted summary stays byte-identical.
- Byte-identity: 12 corpus/fixture proof exports diffed against a main-built binary — identical.
- Full battery in a fresh worktree: proof_spec 150/150 (live lake), `cargo test --workspace`, fmt, clippy — all green; independently re-verified after apply (this branch): build / proof_spec 150 / fmt / clippy all exit 0.
- Adversarially reviewed (fresh worktree, revert-tested against a main-built baseline): verdict pass, no blocking findings.

Known honest boundary: only ident-only substitution images are recognized; a helper instantiated at compound terms (validated by hand in research notes) is the named next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)