### PR TITLE
analysis: classify refinement-typed integer ops by i64 overflow safety

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -34,6 +34,11 @@ pub struct RefinementInfo<'a> {
     /// `fromInt(n: Int) → Result<X, _>`). Used when substituting
     /// the law's quantified variable into the predicate.
     pub param_name: &'a str,
+    /// Source-level name of the smart constructor itself (`"fromInt"`).
+    /// The interval analysis gates its transparent-wrapper peel on this
+    /// name so only the real smart constructor — never an arbitrary
+    /// one-arg helper — is treated as identity over its argument.
+    pub constructor_fn: &'a str,
     /// AST node for the bool predicate the smart constructor
     /// branches on — the body's `Match { subject = <here>, ... }`.
     pub predicate: &'a Spanned<Expr>,
@@ -192,6 +197,7 @@ fn refinement_info_from_shape<'a>(
         carrier_type,
         carrier_field,
         param_name,
+        constructor_fn: constructor_fd.name.as_str(),
         predicate: subject,
     })
 }
@@ -292,6 +298,7 @@ fn refinement_info_for_walk_legacy<'a>(
             carrier_type,
             carrier_field,
             param_name,
+            constructor_fn: fd.name.as_str(),
             predicate: subject,
         });
     }

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -763,6 +763,7 @@ mod tests {
                 run_analyze: true,
                 run_escape: false,
                 run_refinement_lower: true,
+                run_interval_analyze: false,
                 run_contract_lower: true,
                 run_law_lower: true,
                 // BuildSymbols is needed for fn_contracts lookup

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -89,6 +89,7 @@ fn ctx_from_source(source: &str, project_name: &str) -> CodegenContext {
             run_analyze: true,
             run_escape: false,
             run_refinement_lower: true,
+            run_interval_analyze: false,
             run_contract_lower: true,
             run_law_lower: true,
             // BuildSymbols is needed for fn_contracts lookup

--- a/src/ir/interval.rs
+++ b/src/ir/interval.rs
@@ -1,0 +1,1050 @@
+//! Per-module interval analysis over refinement-type carriers.
+//!
+//! This is a **pure, read-only diagnostic**. It derives, for each
+//! refinement-via-opaque type the proof side already lifted into
+//! [`crate::ir::proof_ir::RefinedTypeDecl`], a constant integer
+//! interval `[lo, hi]` that over-approximates the type's invariant,
+//! and then classifies every arithmetic operation the defining module
+//! exposes on that type as one of [`OpClass::OverflowFree`],
+//! [`OpClass::NeedsWiderScratch`], or [`OpClass::Unbounded`].
+//!
+//! Nothing here changes codegen, the runtime, or proof output. The
+//! result is surfaced only through `aver compile --explain-passes`
+//! and stored on [`crate::ir::pipeline::PipelineResult`] for future
+//! opt-in consumers (the carrier-lowering recognizer is a later
+//! slice). See `prompts/int-semantics-refinement-perf-optin.md` for
+//! the why.
+//!
+//! ## Soundness direction
+//!
+//! The dangerous mistake is wrongly certifying an operation as
+//! [`OpClass::OverflowFree`] — that would let a future codegen lower
+//! an intermediate to a raw `i64` that can actually wrap. So the
+//! analysis is conservative in exactly one direction: when any input
+//! shape is unrecognized, or any operand is unbounded, it **declines**
+//! (`Unbounded` / `interval_known = false`). It never over-claims a
+//! bound it cannot derive.
+//!
+//! The interval carrier is `i128` internally so the analysis can
+//! represent and reason about values *outside* `i64` without itself
+//! wrapping — this is what lets it prove `a + b` for `a, b ∈ [0, 100]`
+//! stays `≤ 200 < i64::MAX`. All `i128` arithmetic **saturates** to
+//! ±infinity on overflow; it never wraps.
+
+use std::collections::HashMap;
+
+use crate::ast::{BinOp, Expr, FnBody, FnDef, Literal, Spanned, Stmt};
+use crate::codegen::proof_lower::ProofLowerInputs;
+use crate::ir::TypeId;
+use crate::ir::proof_ir::{Predicate, RefinedTypeDecl};
+
+/// One endpoint of an [`Interval`]. `Finite(k)` is an exact `i128`
+/// bound; `NegInf` / `PosInf` are the open ends the saturating
+/// arithmetic produces when a value escapes the `i128` range or when
+/// the source invariant is one-sided (e.g. `Natural`'s `n >= 0`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Bound {
+    NegInf,
+    Finite(i128),
+    PosInf,
+}
+
+impl Bound {
+    /// `true` for a `Finite` bound that fits the `i64` range.
+    fn fits_i64(self) -> bool {
+        match self {
+            Bound::Finite(k) => k >= i64::MIN as i128 && k <= i64::MAX as i128,
+            Bound::NegInf | Bound::PosInf => false,
+        }
+    }
+
+    /// Saturating addition over the extended integers. Any `inf`
+    /// dominates; two `Finite` bounds add in `i128` and saturate to
+    /// the matching infinity on overflow (never wrap).
+    fn add(self, other: Bound) -> Bound {
+        match (self, other) {
+            // ∞ + (-∞) cannot arise for a well-formed interval (a
+            // `lo` is never `PosInf` and a `hi` is never `NegInf`),
+            // but guard it anyway: collapse to the conservative open
+            // end so we never fabricate a finite bound.
+            (Bound::PosInf, Bound::NegInf) | (Bound::NegInf, Bound::PosInf) => Bound::NegInf,
+            (Bound::PosInf, _) | (_, Bound::PosInf) => Bound::PosInf,
+            (Bound::NegInf, _) | (_, Bound::NegInf) => Bound::NegInf,
+            (Bound::Finite(a), Bound::Finite(b)) => match a.checked_add(b) {
+                Some(s) => Bound::Finite(s),
+                None if a > 0 => Bound::PosInf,
+                None => Bound::NegInf,
+            },
+        }
+    }
+
+    /// Negate an endpoint. `Finite(i128::MIN)` cannot be negated in
+    /// `i128`, so it saturates to `PosInf` rather than wrapping.
+    fn neg(self) -> Bound {
+        match self {
+            Bound::NegInf => Bound::PosInf,
+            Bound::PosInf => Bound::NegInf,
+            Bound::Finite(k) => match k.checked_neg() {
+                Some(n) => Bound::Finite(n),
+                None => Bound::PosInf,
+            },
+        }
+    }
+
+    /// Saturating multiplication of two endpoints. The sign of an
+    /// infinity is determined by the sign of the finite factor.
+    fn mul(self, other: Bound) -> Bound {
+        // Resolve the sign and magnitude of each factor.
+        let sign = |b: Bound| -> i32 {
+            match b {
+                Bound::NegInf => -1,
+                Bound::PosInf => 1,
+                Bound::Finite(0) => 0,
+                Bound::Finite(k) => {
+                    if k > 0 {
+                        1
+                    } else {
+                        -1
+                    }
+                }
+            }
+        };
+        // 0 * ∞ is treated as 0: a `Finite(0)` factor pins the
+        // product to 0 regardless of the other endpoint. This is the
+        // correct interval-arithmetic answer because a 0 endpoint
+        // only arises from a `Finite(0)` operand, never from an open
+        // end (an open end has no finite witness to multiply).
+        if matches!(self, Bound::Finite(0)) || matches!(other, Bound::Finite(0)) {
+            return Bound::Finite(0);
+        }
+        match (self, other) {
+            (Bound::Finite(a), Bound::Finite(b)) => match a.checked_mul(b) {
+                Some(p) => Bound::Finite(p),
+                None => {
+                    if sign(self) * sign(other) >= 0 {
+                        Bound::PosInf
+                    } else {
+                        Bound::NegInf
+                    }
+                }
+            },
+            _ => {
+                if sign(self) * sign(other) >= 0 {
+                    Bound::PosInf
+                } else {
+                    Bound::NegInf
+                }
+            }
+        }
+    }
+
+    /// Order for picking a `min` lower bound: `NegInf < Finite < PosInf`.
+    fn min(self, other: Bound) -> Bound {
+        if self.le(other) { self } else { other }
+    }
+
+    /// Order for picking a `max` upper bound.
+    fn max(self, other: Bound) -> Bound {
+        if self.le(other) { other } else { self }
+    }
+
+    /// `self <= other` over the extended integers.
+    fn le(self, other: Bound) -> bool {
+        match (self, other) {
+            (Bound::NegInf, _) => true,
+            (_, Bound::NegInf) => false,
+            (_, Bound::PosInf) => true,
+            (Bound::PosInf, _) => false,
+            (Bound::Finite(a), Bound::Finite(b)) => a <= b,
+        }
+    }
+}
+
+/// A constant integer interval `[lo, hi]` over the extended integers.
+/// Produced by [`interval_of_invariant`] from a refinement predicate
+/// and propagated bottom-up through an operation body by the abstract
+/// interpreter in [`classify_op`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Interval {
+    pub lo: Bound,
+    pub hi: Bound,
+}
+
+impl Interval {
+    /// The whole extended integer line — the conservative "I know
+    /// nothing" answer the analysis returns whenever it declines.
+    pub fn unbounded() -> Interval {
+        Interval {
+            lo: Bound::NegInf,
+            hi: Bound::PosInf,
+        }
+    }
+
+    /// A single point `[k, k]`.
+    pub fn point(k: i128) -> Interval {
+        Interval {
+            lo: Bound::Finite(k),
+            hi: Bound::Finite(k),
+        }
+    }
+
+    /// `[k, +inf]` — the over-approximation of `n >= k`.
+    pub fn ge(k: i128) -> Interval {
+        Interval {
+            lo: Bound::Finite(k),
+            hi: Bound::PosInf,
+        }
+    }
+
+    /// `[-inf, k]` — the over-approximation of `n <= k`.
+    pub fn le(k: i128) -> Interval {
+        Interval {
+            lo: Bound::NegInf,
+            hi: Bound::Finite(k),
+        }
+    }
+
+    /// `[lo, hi]` from two literal bounds.
+    pub fn between(lo: i128, hi: i128) -> Interval {
+        Interval {
+            lo: Bound::Finite(lo),
+            hi: Bound::Finite(hi),
+        }
+    }
+
+    /// Intersection — used to combine the conjuncts of a compound
+    /// `Bool.and` guard into a single two-sided interval.
+    pub fn intersect(self, other: Interval) -> Interval {
+        Interval {
+            lo: self.lo.max(other.lo),
+            hi: self.hi.min(other.hi),
+        }
+    }
+
+    /// `true` when both bounds are finite and within the `i64` range.
+    /// This is the headroom test: an intermediate whose interval
+    /// `fits_i64` cannot overflow a raw `i64` before the smart
+    /// constructor's guard re-validates it.
+    pub fn fits_i64(self) -> bool {
+        self.lo.fits_i64() && self.hi.fits_i64()
+    }
+
+    /// `true` when neither bound is infinite (the interval is a real
+    /// finite range, even if wider than `i64`).
+    fn is_finite(self) -> bool {
+        matches!(self.lo, Bound::Finite(_)) && matches!(self.hi, Bound::Finite(_))
+    }
+
+    /// Saturating interval addition. (Inherent, not `std::ops::Add`:
+    /// the operation saturates rather than panicking, so the std trait
+    /// would carry the wrong contract.)
+    #[allow(clippy::should_implement_trait)]
+    pub fn add(self, other: Interval) -> Interval {
+        Interval {
+            lo: self.lo.add(other.lo),
+            hi: self.hi.add(other.hi),
+        }
+    }
+
+    /// Saturating interval subtraction (`a - b = a + (-b)`, with the
+    /// endpoints flipped so `lo` stays the lower bound).
+    #[allow(clippy::should_implement_trait)]
+    pub fn sub(self, other: Interval) -> Interval {
+        Interval {
+            lo: self.lo.add(other.hi.neg()),
+            hi: self.hi.add(other.lo.neg()),
+        }
+    }
+
+    /// Saturating interval multiplication. The product range is the
+    /// min/max over the four endpoint products, which is the standard
+    /// sound interval-arithmetic rule and handles negative operands.
+    #[allow(clippy::should_implement_trait)]
+    pub fn mul(self, other: Interval) -> Interval {
+        let products = [
+            self.lo.mul(other.lo),
+            self.lo.mul(other.hi),
+            self.hi.mul(other.lo),
+            self.hi.mul(other.hi),
+        ];
+        let mut lo = products[0];
+        let mut hi = products[0];
+        for p in &products[1..] {
+            lo = lo.min(*p);
+            hi = hi.max(*p);
+        }
+        Interval { lo, hi }
+    }
+}
+
+/// Classification of an operation's worst-case `i64` intermediate.
+///
+/// **`OverflowFree` means EVERY `i64` intermediate across the WHOLE op
+/// body provably fits `i64` — the smart-constructor guard (`fromInt` /
+/// `fromX`) is STILL REQUIRED.** The verdict is the join over the final
+/// tail interval, every intermediate subexpression interval, and every
+/// earlier binding's interval (see [`classify_op`]): a single
+/// out-of-`i64` intermediate anywhere — even one whose value never
+/// reaches the tail — pulls the class out of `OverflowFree`. It does
+/// NOT mean "the result is in range without the guard": the result of
+/// e.g. `IntRange.add([0,100], [0,100]) = [0,200]` fits `i64` but
+/// exceeds the type's `[0,100]` bound, so `fromInt` must still run to
+/// re-validate the invariant. A future codegen recognizer that lowers
+/// the arithmetic to raw `i64` on the strength of this class must keep
+/// the `fromInt` call. Dropping it reintroduces the model-vs-runtime
+/// gap this whole mechanism exists to close.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpClass {
+    /// The arithmetic intermediate provably fits `i64`, so it can run
+    /// on raw `i64` without wrapping before the guard re-validates.
+    OverflowFree,
+    /// The intermediate exceeds `i64` but is a proven-finite range, so
+    /// a future codegen could compute it in a wider scratch type
+    /// (`i128` or bignum) and then narrow through the guard. None of
+    /// the current example types reach this band; it exists so the
+    /// classifier is honest about the middle case rather than
+    /// collapsing it into `Unbounded`.
+    NeedsWiderScratch,
+    /// The intermediate has no derivable finite bound — typically
+    /// because an operand is a one-sided refinement (`[0, +inf]`) or a
+    /// plain `Int` (unbounded by construction). The honest decline:
+    /// the analysis cannot certify the operation as native-`i64`-safe.
+    Unbounded,
+}
+
+impl OpClass {
+    /// Classify an arithmetic intermediate interval. Conservative:
+    /// only a fully-`i64`-fitting interval earns `OverflowFree`.
+    fn of_interval(i: Interval) -> OpClass {
+        if i.fits_i64() {
+            OpClass::OverflowFree
+        } else if i.is_finite() {
+            OpClass::NeedsWiderScratch
+        } else {
+            OpClass::Unbounded
+        }
+    }
+
+    /// Stable lowercase label for diagnostics / JSON.
+    pub fn label(self) -> &'static str {
+        match self {
+            OpClass::OverflowFree => "overflow_free",
+            OpClass::NeedsWiderScratch => "needs_wider_scratch",
+            OpClass::Unbounded => "unbounded",
+        }
+    }
+}
+
+/// Per-refined-type interval analysis result.
+#[derive(Debug, Clone)]
+pub struct RefinedTypeInterval {
+    /// Opaque type identity — the same key the type carries in
+    /// `ProofIR.refined_types`, so two same-named types in different
+    /// modules stay distinct.
+    pub type_id: TypeId,
+    /// Source-level type name (for diagnostics only; not a key).
+    pub name: String,
+    /// The derived constant interval over-approximating the invariant.
+    /// `Interval::unbounded()` when the shape was unrecognized.
+    pub interval: Interval,
+    /// `true` when [`interval_of_invariant`] recognized the invariant
+    /// shape and the interval is a real (non-trivial) enclosure;
+    /// `false` when it declined (the interval is `unbounded()`).
+    pub interval_known: bool,
+    /// Per-op classification, in module-walk order. Each entry pairs
+    /// the operation's source name with its [`OpClass`].
+    pub ops: Vec<(String, OpClass)>,
+}
+
+/// Whole-analysis result, keyed for cheap programmatic lookup.
+#[derive(Debug, Clone, Default)]
+pub struct IntervalAnalysisResult {
+    /// One entry per refined type the analysis saw, keyed by opaque
+    /// `TypeId`.
+    pub types: HashMap<TypeId, RefinedTypeInterval>,
+}
+
+impl IntervalAnalysisResult {
+    /// Number of types analyzed.
+    pub fn types_analyzed(&self) -> usize {
+        self.types.len()
+    }
+
+    /// Types whose invariant yielded a two-sided constant interval
+    /// (both bounds finite) — the carrier-lowering candidates.
+    pub fn two_sided_bounded(&self) -> usize {
+        self.types
+            .values()
+            .filter(|t| t.interval_known && t.interval.is_finite())
+            .count()
+    }
+
+    /// Total ops across all types classified `OverflowFree`.
+    pub fn ops_overflow_free(&self) -> usize {
+        self.count_ops(OpClass::OverflowFree)
+    }
+
+    /// Total ops across all types classified `NeedsWiderScratch`.
+    pub fn ops_needs_wider(&self) -> usize {
+        self.count_ops(OpClass::NeedsWiderScratch)
+    }
+
+    /// Total ops across all types classified `Unbounded`.
+    pub fn ops_unbounded(&self) -> usize {
+        self.count_ops(OpClass::Unbounded)
+    }
+
+    fn count_ops(&self, class: OpClass) -> usize {
+        self.types
+            .values()
+            .flat_map(|t| t.ops.iter())
+            .filter(|(_, c)| *c == class)
+            .count()
+    }
+}
+
+/// Derive a constant interval from a refinement invariant.
+///
+/// Returns `(interval, interval_known)`. Recognizes exactly the
+/// comparison / `Bool.and` shapes the refinement examples produce; any
+/// other shape (`Bool.or`, a bare identifier, a structural carrier,
+/// non-literal bounds) yields `(Interval::unbounded(), false)` — the
+/// conservative decline.
+///
+/// The free variable matched against the bound is taken from
+/// `pred.free_vars[0]` (the smart constructor's parameter). Operand-
+/// flipped comparisons (`k <= n` as well as `n >= k`) are normalized.
+pub fn interval_of_invariant(pred: &Predicate) -> (Interval, bool) {
+    let Some((var, _)) = pred.free_vars.first() else {
+        return (Interval::unbounded(), false);
+    };
+    match interval_of_resolved(&pred.expr, var) {
+        Some(i) => (i, true),
+        None => (Interval::unbounded(), false),
+    }
+}
+
+/// Recognize a single resolved predicate expression as an interval
+/// over `var`. `None` = unrecognized shape (caller declines).
+fn interval_of_resolved(
+    expr: &Spanned<crate::ir::hir::ResolvedExpr>,
+    var: &str,
+) -> Option<Interval> {
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr};
+    match &expr.node {
+        // Compound guard `Bool.and(l, r)` → intersect both sides.
+        // Recurses, so deeply-nested conjunctions also collapse.
+        ResolvedExpr::Call(ResolvedCallee::Builtin(name), args)
+            if name == "Bool.and" && args.len() == 2 =>
+        {
+            let l = interval_of_resolved(&args[0], var)?;
+            let r = interval_of_resolved(&args[1], var)?;
+            Some(l.intersect(r))
+        }
+        // A comparison between the predicate variable and a literal.
+        ResolvedExpr::BinOp(op, lhs, rhs) => interval_of_comparison(*op, lhs, rhs, var),
+        // Anything else (Bool.or, Bool.not, arbitrary predicate, the
+        // bare variable) is not a recognized interval shape.
+        _ => None,
+    }
+}
+
+/// Recognize `var <op> k` (or the operand-flipped `k <op> var`) as an
+/// interval. Only `>`, `>=`, `<`, `<=` against an integer literal
+/// produce a bound; `==` / `!=` and non-literal operands decline.
+fn interval_of_comparison(
+    op: BinOp,
+    lhs: &Spanned<crate::ir::hir::ResolvedExpr>,
+    rhs: &Spanned<crate::ir::hir::ResolvedExpr>,
+    var: &str,
+) -> Option<Interval> {
+    // Identify which side is the variable and which is the literal,
+    // normalizing the operator if the operands are flipped.
+    let (op, k) = if is_var(lhs, var) {
+        (op, int_literal(rhs)?)
+    } else if is_var(rhs, var) {
+        (flip_comparison(op)?, int_literal(lhs)?)
+    } else {
+        return None;
+    };
+    let k = k as i128;
+    match op {
+        BinOp::Gte => Some(Interval::ge(k)),    // n >= k  → [k, +inf]
+        BinOp::Gt => Some(Interval::ge(k + 1)), // n >  k  → [k+1, +inf]
+        BinOp::Lte => Some(Interval::le(k)),    // n <= k  → [-inf, k]
+        BinOp::Lt => Some(Interval::le(k - 1)), // n <  k  → [-inf, k-1]
+        _ => None,
+    }
+}
+
+/// `true` when the resolved expression is a reference to `var`
+/// (whether it survived as a bare `Ident` or carries a resolved slot).
+fn is_var(expr: &Spanned<crate::ir::hir::ResolvedExpr>, var: &str) -> bool {
+    use crate::ir::hir::ResolvedExpr;
+    match &expr.node {
+        ResolvedExpr::Ident(name) => name == var,
+        ResolvedExpr::Resolved { name, .. } => name == var,
+        _ => false,
+    }
+}
+
+/// Extract an integer literal from a resolved leaf, if it is one.
+fn int_literal(expr: &Spanned<crate::ir::hir::ResolvedExpr>) -> Option<i64> {
+    use crate::ir::hir::ResolvedExpr;
+    match &expr.node {
+        ResolvedExpr::Literal(Literal::Int(k)) => Some(*k),
+        ResolvedExpr::Neg(inner) => match &inner.node {
+            ResolvedExpr::Literal(Literal::Int(k)) => Some(-*k),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Operator with operands swapped: `a < b` ⇔ `b > a`, etc.
+fn flip_comparison(op: BinOp) -> Option<BinOp> {
+    match op {
+        BinOp::Lt => Some(BinOp::Gt),
+        BinOp::Gt => Some(BinOp::Lt),
+        BinOp::Lte => Some(BinOp::Gte),
+        BinOp::Gte => Some(BinOp::Lte),
+        _ => None,
+    }
+}
+
+/// Classify one operation function over a refined type.
+///
+/// `op_fn` is the raw-AST fn def the defining module exposes (e.g.
+/// `IntRange.add`). `carrier_interval` is the interval of the refined
+/// type's carrier. `refined_type_name` is the source name of that
+/// type so the analyzer can tell a refined-typed parameter apart from
+/// a plain `Int` one.
+///
+/// The body is abstractly interpreted bottom-up over [`Interval`]: a
+/// `param.value` access on a refined-typed parameter contributes
+/// `carrier_interval`; an integer literal contributes a point; `+` /
+/// `-` / `*` combine sub-intervals via saturating interval arithmetic;
+/// the smart-constructor call (`fromInt(inner)`, where the callee is
+/// the type's actual constructor `constructor_fn`) is transparent — the
+/// classified intermediate is the argument feeding the guard. ANY OTHER
+/// call (a user helper, a builtin, an unknown callee), a plain-`Int`
+/// operand entering the arithmetic, or any unrecognized shape evaluates
+/// to `Interval::unbounded()` — the conservative decline.
+///
+/// The verdict is NOT the tail interval alone. Every binding in the
+/// op body and every intermediate subexpression node within an
+/// expression joins its own interval into a worst-case accumulator;
+/// the returned [`OpClass`] is `of_interval` over the JOIN of the tail
+/// interval and every intermediate/binding interval. So an out-of-`i64`
+/// (or unbounded) value computed in an earlier statement, or buried in
+/// a tail subexpression that later cancels out, still demotes the op
+/// below `OverflowFree`.
+pub fn classify_op(
+    op_fn: &FnDef,
+    carrier_interval: Interval,
+    refined_type_name: &str,
+    carrier_field: &str,
+    constructor_fn: &str,
+) -> OpClass {
+    // Map each parameter name to whether it carries the refined type.
+    let mut refined_params: HashMap<&str, bool> = HashMap::new();
+    for (pname, ptype) in &op_fn.params {
+        refined_params.insert(pname.as_str(), ptype == refined_type_name);
+    }
+    let ctx = OpCtx {
+        carrier_interval,
+        carrier_field,
+        refined_params: &refined_params,
+        constructor_fn,
+    };
+
+    // Worst-case (least-headroom) interval seen anywhere in the body.
+    // Starts at a point so that a body with no recognized arithmetic
+    // intermediate stays neutral; every binding and the tail join into
+    // it. `worst` is the running join the evaluator widens at each
+    // arithmetic / call / negation node.
+    let mut worst = Interval::point(0);
+
+    // Walk every statement in execution order. Each binding's value
+    // expression and the tail expression are evaluated; both their
+    // final intervals and every intermediate node they contain land in
+    // `worst`.
+    let FnBody::Block(stmts) = op_fn.body.as_ref();
+    for stmt in stmts {
+        let value = match stmt {
+            Stmt::Expr(e) | Stmt::Binding(_, _, e) => e,
+        };
+        let i = eval_expr(value, &ctx, &mut worst);
+        worst = join(worst, i);
+    }
+
+    OpClass::of_interval(worst)
+}
+
+/// Read-only context threaded through the op-body abstract evaluator.
+struct OpCtx<'a> {
+    carrier_interval: Interval,
+    carrier_field: &'a str,
+    refined_params: &'a HashMap<&'a str, bool>,
+    /// The refined type's actual smart constructor name (`"fromInt"`).
+    /// ONLY a one-arg call to this exact callee is peeled transparently;
+    /// every other call evaluates to `Interval::unbounded()`.
+    constructor_fn: &'a str,
+}
+
+/// Convex hull of two intervals — the "worst case includes both"
+/// join. Widening to the union keeps the headroom verdict sound: if
+/// either operand escapes `i64`, so does the join.
+fn join(a: Interval, b: Interval) -> Interval {
+    Interval {
+        lo: a.lo.min(b.lo),
+        hi: a.hi.max(b.hi),
+    }
+}
+
+/// Abstractly evaluate a raw-AST expression to its interval, joining
+/// the result of every arithmetic / negation / constructor-call node
+/// into `worst` so the caller can classify over the whole body rather
+/// than just the final value. Unknown or unbounded shapes evaluate to
+/// `Interval::unbounded()`, which propagates through the arithmetic and
+/// forces an `Unbounded` class — the conservative direction.
+fn eval_expr(expr: &Spanned<Expr>, ctx: &OpCtx<'_>, worst: &mut Interval) -> Interval {
+    match &expr.node {
+        Expr::Literal(Literal::Int(k)) => Interval::point(*k as i128),
+        // `param.value` where `param` is a refined-typed parameter and
+        // the field is the carrier field → the carrier interval. Any
+        // other field access (or access on a non-refined param) is an
+        // unknown integer. The object leaf may be a bare `Ident` (proof
+        // mode, resolve off) or a `Resolved` slot (resolve on) — both
+        // carry the param name.
+        Expr::Attr(obj, field) => {
+            if field == ctx.carrier_field
+                && let Some(pname) = param_name(obj)
+                && ctx.refined_params.get(pname).copied() == Some(true)
+            {
+                ctx.carrier_interval
+            } else {
+                Interval::unbounded()
+            }
+        }
+        Expr::BinOp(op, lhs, rhs) => {
+            let l = eval_expr(lhs, ctx, worst);
+            let r = eval_expr(rhs, ctx, worst);
+            let result = match op {
+                BinOp::Add => l.add(r),
+                BinOp::Sub => l.sub(r),
+                BinOp::Mul => l.mul(r),
+                // Division and comparisons don't feed the headroom
+                // question we model; decline rather than guess.
+                _ => Interval::unbounded(),
+            };
+            // This arithmetic node is itself an `i64` intermediate —
+            // record it before it is folded into an enclosing op (which
+            // may cancel it back into range, as in `(a + MAX) - MAX`).
+            *worst = join(*worst, result);
+            result
+        }
+        Expr::Neg(inner) => {
+            let result = Interval::point(0).sub(eval_expr(inner, ctx, worst));
+            *worst = join(*worst, result);
+            result
+        }
+        // The smart constructor is transparent: the intermediate we
+        // care about is the value handed to the guard, i.e. its
+        // argument. ONLY the type's real constructor (`constructor_fn`)
+        // is peeled — a one-arg helper like `widen(x)` must NOT be
+        // treated as identity, or its widened return value would be
+        // hidden. Every non-constructor call is opaque → unbounded.
+        Expr::FnCall(callee, args)
+            if args.len() == 1 && is_constructor_call(callee, ctx.constructor_fn) =>
+        {
+            eval_expr(&args[0], ctx, worst)
+        }
+        // A bare identifier of a refined param read without `.value`,
+        // a plain-`Int` param, any non-constructor call, or any other
+        // shape: unbounded.
+        _ => Interval::unbounded(),
+    }
+}
+
+/// `true` for a `FnCall` whose callee is a bare identifier naming the
+/// refined type's actual smart constructor. A top-level fn name like
+/// `fromInt` stays an `Ident` through the resolver (it has no local
+/// slot), so checking `Ident` + name equality covers both proof mode
+/// (resolve off) and the resolved pipeline. Module-qualified or
+/// computed callees, and any other helper, are not the constructor.
+fn is_constructor_call(callee: &Spanned<Expr>, constructor_fn: &str) -> bool {
+    matches!(&callee.node, Expr::Ident(name) if name == constructor_fn)
+}
+
+/// Extract the parameter name a leaf refers to, whether it survived as
+/// a bare `Ident` (resolve off) or was rewritten to a `Resolved` slot
+/// (resolve on). `None` for any other expression.
+fn param_name(expr: &Spanned<Expr>) -> Option<&str> {
+    match &expr.node {
+        Expr::Ident(name) => Some(name.as_str()),
+        Expr::Resolved { name, .. } => Some(name.as_str()),
+        _ => None,
+    }
+}
+
+/// Run the interval analysis over every refined type in `refined`,
+/// classifying each one's module-exposed arithmetic ops.
+///
+/// `refined` is `ProofIR.refined_types`, already keyed by opaque
+/// `TypeId` and scoped per module by `populate_refined_types`. `inputs`
+/// is the same [`ProofLowerInputs`] the proof-lower stage consumed, so
+/// the op fns are looked up with the identical module-scoped discipline
+/// (never bare-name matching).
+pub fn analyze(
+    refined: &HashMap<TypeId, RefinedTypeDecl>,
+    inputs: &ProofLowerInputs<'_>,
+) -> IntervalAnalysisResult {
+    let mut result = IntervalAnalysisResult::default();
+    let symbols = inputs.symbol_table;
+
+    for (type_id, decl) in refined {
+        let (interval, interval_known) = interval_of_invariant(&decl.invariant);
+
+        // Find the module scope this type lives in by resolving its
+        // opaque `TypeId` back through the symbol table, then walk that
+        // scope's fns for arithmetic ops over the type. Same scoping
+        // discipline as `populate_refined_types` — two same-named
+        // types in different modules never share an op set.
+        let scope = scope_of_type(*type_id, decl, inputs, symbols);
+
+        // Recover this type's actual smart constructor name in the SAME
+        // module scope, so the op-body evaluator only peels the real
+        // `fromInt`-style wrapper transparently (never an arbitrary
+        // one-arg helper). If the refinement shape can't be re-resolved
+        // (it always can here — the type was lifted from it), there is
+        // no trustworthy constructor to gate on, so every op declines.
+        let constructor_fn = crate::codegen::common::refinement_info_for_in_scope(
+            &decl.name,
+            inputs,
+            scope.as_deref(),
+        )
+        .map(|info| info.constructor_fn.to_string());
+
+        let ops = classify_ops_in_scope(
+            decl,
+            interval,
+            interval_known,
+            constructor_fn.as_deref(),
+            inputs.pure_fns_in_scope(scope.as_deref()),
+        );
+
+        result.types.insert(
+            *type_id,
+            RefinedTypeInterval {
+                type_id: *type_id,
+                name: decl.name.clone(),
+                interval,
+                interval_known,
+                ops,
+            },
+        );
+    }
+    result
+}
+
+/// Resolve the module scope (`None` = entry, `Some(prefix)` = a dep
+/// module) that declares the refined type with `type_id`. Matches the
+/// `TypeKey` the symbol table holds for that id against the candidate
+/// scopes, so the answer is keyed by opaque identity, never bare name.
+fn scope_of_type(
+    type_id: TypeId,
+    decl: &RefinedTypeDecl,
+    inputs: &ProofLowerInputs<'_>,
+    symbols: &crate::ir::SymbolTable,
+) -> Option<String> {
+    for scope in inputs.scopes() {
+        let key = match &scope {
+            Some(prefix) => crate::ir::TypeKey::in_module(prefix.clone(), &decl.name),
+            None => crate::ir::TypeKey::entry(&decl.name),
+        };
+        if symbols.type_id_of(&key) == Some(type_id) {
+            return scope;
+        }
+    }
+    None
+}
+
+/// Classify every arithmetic op a module exposes over the refined
+/// type. An op qualifies when it takes at least one parameter of the
+/// refined type; ops with no refined-typed parameter (the smart
+/// constructor `fromInt(n: Int)`, the unwrapper `toInt(n: T) -> Int`)
+/// are skipped — they aren't arithmetic over two carriers.
+fn classify_ops_in_scope(
+    decl: &RefinedTypeDecl,
+    interval: Interval,
+    interval_known: bool,
+    constructor_fn: Option<&str>,
+    fns: Vec<&FnDef>,
+) -> Vec<(String, OpClass)> {
+    let mut ops = Vec::new();
+    for fd in fns {
+        // The op must take the refined type as a parameter AND its
+        // body must do carrier arithmetic (a `param.value` access).
+        // `toInt` takes the refined type but just projects the
+        // carrier — no arithmetic intermediate — so it never needs an
+        // overflow verdict.
+        let takes_refined = fd.params.iter().any(|(_, t)| t == &decl.name);
+        if !takes_refined || !body_does_carrier_arithmetic(fd, &decl.carrier_field) {
+            continue;
+        }
+        // When the carrier interval is unknown (declined invariant), or
+        // we couldn't recover the smart constructor to gate the
+        // transparent peel on, the op is necessarily `Unbounded` —
+        // there's no derived bound to reason from, and without the
+        // constructor name no call can be safely treated as identity.
+        let class = match (interval_known, constructor_fn) {
+            (true, Some(ctor)) => classify_op(fd, interval, &decl.name, &decl.carrier_field, ctor),
+            _ => OpClass::Unbounded,
+        };
+        ops.push((fd.name.clone(), class));
+    }
+    ops
+}
+
+/// `true` when the fn body's tail expression contains a `BinOp`
+/// (Add/Sub/Mul) anywhere — i.e. it computes an arithmetic
+/// intermediate over the carrier rather than just projecting it.
+fn body_does_carrier_arithmetic(fd: &FnDef, _carrier_field: &str) -> bool {
+    let FnBody::Block(stmts) = fd.body.as_ref();
+    stmts.iter().any(|s| match s {
+        Stmt::Expr(e) | Stmt::Binding(_, _, e) => expr_has_arithmetic(e),
+    })
+}
+
+/// Recursively scan for an arithmetic `BinOp` node.
+fn expr_has_arithmetic(expr: &Spanned<Expr>) -> bool {
+    match &expr.node {
+        Expr::BinOp(BinOp::Add | BinOp::Sub | BinOp::Mul, _, _) => true,
+        Expr::BinOp(_, l, r) => expr_has_arithmetic(l) || expr_has_arithmetic(r),
+        Expr::FnCall(_, args) => args.iter().any(expr_has_arithmetic),
+        Expr::Attr(o, _) => expr_has_arithmetic(o),
+        Expr::Neg(i) | Expr::ErrorProp(i) => expr_has_arithmetic(i),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::SourceLine;
+    use crate::ir::hir::ResolvedExpr;
+    use crate::ir::proof_ir::QuantifierType;
+
+    const LINE: SourceLine = 0;
+
+    fn sp_r(node: ResolvedExpr) -> Spanned<ResolvedExpr> {
+        Spanned::new(node, LINE)
+    }
+
+    fn ident_r(name: &str) -> Spanned<ResolvedExpr> {
+        sp_r(ResolvedExpr::Ident(name.to_string()))
+    }
+
+    fn int_r(k: i64) -> Spanned<ResolvedExpr> {
+        sp_r(ResolvedExpr::Literal(Literal::Int(k)))
+    }
+
+    fn cmp_r(
+        op: BinOp,
+        l: Spanned<ResolvedExpr>,
+        r: Spanned<ResolvedExpr>,
+    ) -> Spanned<ResolvedExpr> {
+        sp_r(ResolvedExpr::BinOp(op, Box::new(l), Box::new(r)))
+    }
+
+    fn pred(expr: Spanned<ResolvedExpr>) -> Predicate {
+        Predicate {
+            free_vars: vec![("n".to_string(), QuantifierType::Plain("Int".to_string()))],
+            expr,
+        }
+    }
+
+    // ── Bound saturating arithmetic ─────────────────────────────────
+
+    #[test]
+    fn bound_posinf_plus_finite_is_posinf() {
+        assert_eq!(Bound::PosInf.add(Bound::Finite(5)), Bound::PosInf);
+        assert_eq!(Bound::Finite(5).add(Bound::PosInf), Bound::PosInf);
+    }
+
+    #[test]
+    fn bound_finite_mul_exact_in_i128() {
+        // 100 * 100 = 10_000 — exact, no saturation.
+        assert_eq!(
+            Bound::Finite(100).mul(Bound::Finite(100)),
+            Bound::Finite(10_000)
+        );
+    }
+
+    #[test]
+    fn bound_i64_max_squared_is_exact_finite_not_i64() {
+        // `(i64::MAX)^2 ≈ 2^126` fits i128 (max ≈ 2^127), so the
+        // product is an EXACT finite i128 value — it does NOT wrap and
+        // does NOT need to saturate. The soundness consequence: such a
+        // product is finite-but-outside-i64, so the op that produced
+        // it classifies `NeedsWiderScratch`, never `OverflowFree`.
+        let m = Bound::Finite(i64::MAX as i128);
+        let expected = (i64::MAX as i128) * (i64::MAX as i128);
+        assert_eq!(m.mul(m), Bound::Finite(expected));
+        assert!(!Bound::Finite(expected).fits_i64());
+    }
+
+    #[test]
+    fn bound_i128_overflow_saturates_not_wraps() {
+        // The keystone soundness unit test: a product that overflows
+        // i128 itself MUST saturate to ±inf, never wrap to a small (or
+        // negative) finite value that would fake headroom. `i128::MAX *
+        // i128::MAX` is the canonical case.
+        let big = Bound::Finite(i128::MAX);
+        assert_eq!(big.mul(big), Bound::PosInf);
+        // Opposite signs saturate to -inf.
+        let neg = Bound::Finite(i128::MIN + 1);
+        assert_eq!(big.mul(neg), Bound::NegInf);
+        // Addition overflow saturates too.
+        assert_eq!(big.add(Bound::Finite(1)), Bound::PosInf);
+        assert_eq!(
+            Bound::Finite(i128::MIN).add(Bound::Finite(-1)),
+            Bound::NegInf
+        );
+    }
+
+    #[test]
+    fn bound_neg_min_saturates() {
+        // i128::MIN cannot be negated in i128 → saturates to +inf.
+        assert_eq!(Bound::Finite(i128::MIN).neg(), Bound::PosInf);
+    }
+
+    #[test]
+    fn interval_add_keeps_finite_in_band() {
+        let a = Interval::between(0, 100);
+        let sum = a.add(a);
+        assert_eq!(sum, Interval::between(0, 200));
+        assert!(sum.fits_i64());
+    }
+
+    #[test]
+    fn interval_mul_handles_negatives() {
+        // [-2, 3] * [-2, 3] → min of {4,-6,-6,9} = -6, max = 9.
+        let a = Interval::between(-2, 3);
+        assert_eq!(a.mul(a), Interval::between(-6, 9));
+    }
+
+    // ── interval_of_invariant: 5 recognized shapes ─────────────────
+
+    #[test]
+    fn invariant_ge_natural() {
+        // n >= 0  → [0, +inf]
+        let (i, known) = interval_of_invariant(&pred(cmp_r(BinOp::Gte, ident_r("n"), int_r(0))));
+        assert!(known);
+        assert_eq!(i, Interval::ge(0));
+    }
+
+    #[test]
+    fn invariant_gt_positive() {
+        // n > 0  → [1, +inf]
+        let (i, known) = interval_of_invariant(&pred(cmp_r(BinOp::Gt, ident_r("n"), int_r(0))));
+        assert!(known);
+        assert_eq!(i, Interval::ge(1));
+    }
+
+    #[test]
+    fn invariant_lte() {
+        // n <= 100  → [-inf, 100]
+        let (i, known) = interval_of_invariant(&pred(cmp_r(BinOp::Lte, ident_r("n"), int_r(100))));
+        assert!(known);
+        assert_eq!(i, Interval::le(100));
+    }
+
+    #[test]
+    fn invariant_lt() {
+        // n < 10  → [-inf, 9]
+        let (i, known) = interval_of_invariant(&pred(cmp_r(BinOp::Lt, ident_r("n"), int_r(10))));
+        assert!(known);
+        assert_eq!(i, Interval::le(9));
+    }
+
+    #[test]
+    fn invariant_bool_and_intrange() {
+        // Bool.and(n >= 0, n <= 100)  → [0, 100]
+        use crate::ir::hir::ResolvedCallee;
+        let and = sp_r(ResolvedExpr::Call(
+            ResolvedCallee::Builtin("Bool.and".to_string()),
+            vec![
+                cmp_r(BinOp::Gte, ident_r("n"), int_r(0)),
+                cmp_r(BinOp::Lte, ident_r("n"), int_r(100)),
+            ],
+        ));
+        let (i, known) = interval_of_invariant(&pred(and));
+        assert!(known);
+        assert_eq!(i, Interval::between(0, 100));
+    }
+
+    #[test]
+    fn invariant_operand_flipped() {
+        // 0 <= n  (literal on the left) normalizes to n >= 0 → [0, +inf]
+        let (i, known) = interval_of_invariant(&pred(cmp_r(BinOp::Lte, int_r(0), ident_r("n"))));
+        assert!(known);
+        assert_eq!(i, Interval::ge(0));
+    }
+
+    // ── interval_of_invariant: declined shapes ─────────────────────
+
+    #[test]
+    fn invariant_bool_or_declines() {
+        use crate::ir::hir::ResolvedCallee;
+        let or = sp_r(ResolvedExpr::Call(
+            ResolvedCallee::Builtin("Bool.or".to_string()),
+            vec![
+                cmp_r(BinOp::Gte, ident_r("n"), int_r(0)),
+                cmp_r(BinOp::Lte, ident_r("n"), int_r(100)),
+            ],
+        ));
+        let (i, known) = interval_of_invariant(&pred(or));
+        assert!(!known);
+        assert_eq!(i, Interval::unbounded());
+    }
+
+    #[test]
+    fn invariant_bare_ident_declines() {
+        let (i, known) = interval_of_invariant(&pred(ident_r("n")));
+        assert!(!known);
+        assert_eq!(i, Interval::unbounded());
+    }
+
+    #[test]
+    fn invariant_non_literal_bound_declines() {
+        // n >= m  (m is another variable, not a literal) → decline.
+        let (i, known) =
+            interval_of_invariant(&pred(cmp_r(BinOp::Gte, ident_r("n"), ident_r("m"))));
+        assert!(!known);
+        assert_eq!(i, Interval::unbounded());
+    }
+
+    // ── fits_i64 boundary ──────────────────────────────────────────
+
+    #[test]
+    fn fits_i64_at_boundary() {
+        assert!(Interval::between(0, i64::MAX as i128).fits_i64());
+        // One past i64::MAX no longer fits → NeedsWiderScratch band.
+        let over = Interval::between(0, i64::MAX as i128 + 1);
+        assert!(!over.fits_i64());
+        assert!(over.is_finite());
+        assert_eq!(OpClass::of_interval(over), OpClass::NeedsWiderScratch);
+    }
+
+    #[test]
+    fn opclass_overflow_free_vs_unbounded() {
+        assert_eq!(
+            OpClass::of_interval(Interval::between(0, 200)),
+            OpClass::OverflowFree
+        );
+        // [0, +inf] (Natural) is NOT overflow-free.
+        assert_eq!(OpClass::of_interval(Interval::ge(0)), OpClass::Unbounded);
+    }
+}

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -9,6 +9,7 @@ pub mod escape;
 pub mod hir;
 pub mod identity;
 mod interp_lower;
+pub mod interval;
 pub mod last_use;
 mod leaf;
 mod matches;
@@ -24,6 +25,10 @@ pub mod vars;
 
 pub use analyze::{AnalysisResult, BodyShape, FnAnalysis, NeutralAllocPolicy, analyze};
 pub use identity::{BuiltinId, CtorId, FnId, FnKey, LawKey, ModuleId, TypeId, TypeKey};
+pub use interval::{
+    Bound, Interval, IntervalAnalysisResult, OpClass, RefinedTypeInterval,
+    analyze as interval_analyze,
+};
 pub use pipeline::{
     FnCountChange, NonTailEntry, PassDiagnostic, PassReport, PipelineConfig, PipelineResult,
     PipelineStage, TypecheckMode,

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -47,6 +47,14 @@ pub enum PipelineStage {
     /// proof exporters (Lean → subtype, Dafny → subset type) enable
     /// it, runtime backends leave it off.
     RefinementLower,
+    /// Per-module interval analysis over refinement-type carriers —
+    /// read-only diagnostic. Derives a constant interval for each
+    /// refined type's invariant and classifies its arithmetic ops as
+    /// overflow-free / needs-wider-scratch / unbounded. Opt-in via
+    /// `run_interval_analyze`; runs right after `RefinementLower`
+    /// (consumes `ProofIR.refined_types`). No codegen / runtime /
+    /// proof-output consumer yet — only `--explain-passes` reads it.
+    IntervalAnalyze,
     /// Recursion-shape contract derivation — fn-level proof-export
     /// stage. Walks recursion plans, populates `ProofIR.fn_contracts`
     /// with Fuel / Native decisions and proof obligations. Opt-in via
@@ -95,6 +103,7 @@ impl PipelineStage {
             Self::Analyze => "analyze",
             Self::Escape => "escape",
             Self::RefinementLower => "refinement_lower",
+            Self::IntervalAnalyze => "interval_analyze",
             Self::ContractLower => "contract_lower",
             Self::LawLower => "law_lower",
             Self::BuildSymbols => "build_symbols",
@@ -160,6 +169,14 @@ pub struct PipelineConfig<'a> {
     /// always enable both. Both stages share the same
     /// `PipelineResult.proof_ir` output sink.
     pub run_refinement_lower: bool,
+    /// Whether to run the per-module interval analysis (read-only
+    /// diagnostic) after `RefinementLower`. Derives a constant
+    /// interval for each refined type's invariant and classifies its
+    /// arithmetic ops. Requires `run_refinement_lower` to have
+    /// populated `ProofIR.refined_types`; a no-op (empty result) when
+    /// there are no refined types. Default off — only `--explain-passes`
+    /// turns it on.
+    pub run_interval_analyze: bool,
     /// Whether to run the recursion-contract derivation pass. Walks
     /// recursion plans (Fuel / Native shapes) and populates
     /// `ProofIR.fn_contracts`. Independent of `run_refinement_lower`.
@@ -213,6 +230,7 @@ impl<'a> Default for PipelineConfig<'a> {
             run_analyze: true,
             run_escape: true,
             run_refinement_lower: false,
+            run_interval_analyze: false,
             run_contract_lower: false,
             run_law_lower: false,
             run_build_symbols: false,
@@ -289,6 +307,21 @@ pub enum PassReport {
         /// User types lifted into refinement subtypes (records with
         /// a single carrier field + matching smart constructor).
         refined_types: usize,
+    },
+    IntervalAnalyze {
+        /// Refined types the interval analysis saw.
+        types_analyzed: usize,
+        /// Of those, how many yielded a two-sided constant interval
+        /// (both bounds finite) — the carrier-lowering candidates.
+        two_sided_bounded: usize,
+        /// Arithmetic ops whose intermediate provably fits `i64`
+        /// (guard still required — see `OpClass::OverflowFree`).
+        ops_overflow_free: usize,
+        /// Ops whose intermediate exceeds `i64` but is finite.
+        ops_needs_wider: usize,
+        /// Ops with no derivable finite bound (one-sided / plain-`Int`
+        /// operands).
+        ops_unbounded: usize,
     },
     ContractLower {
         /// Pure fns with a non-trivial `RecursionContract`. Currently
@@ -408,6 +441,12 @@ pub struct PipelineResult {
     /// populated by the stages that ran (an opt-in to only
     /// RefinementLower leaves `fn_contracts` empty, vice versa).
     pub proof_ir: Option<crate::ir::ProofIR>,
+    /// Per-module interval analysis facts (read-only diagnostic) when
+    /// `run_interval_analyze` was on alongside `run_refinement_lower`.
+    /// `None` when the stage was disabled. The queryable fact for
+    /// future opt-in consumers (the carrier-lowering recognizer);
+    /// nothing in codegen / runtime / proof emission reads it yet.
+    pub interval_analysis: Option<crate::ir::IntervalAnalysisResult>,
     /// Resolved-identity table — opaque `FnId` / `TypeId` /
     /// `CtorId` / `ModuleId` for every named declaration in the
     /// program (#138 phase E). Always populated: the pipeline
@@ -628,7 +667,11 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
         fire(&mut cfg, PipelineStage::NameResolve, items);
     }
 
-    if cfg.run_refinement_lower || cfg.run_contract_lower || cfg.run_law_lower {
+    if cfg.run_refinement_lower
+        || cfg.run_interval_analyze
+        || cfg.run_contract_lower
+        || cfg.run_law_lower
+    {
         // Round-5: union entry's analyze with each dep module's
         // `analysis.recursive_fns`. Without this, multi-module proof
         // export's `populate_fn_contracts` only sees entry-recursive
@@ -700,6 +743,18 @@ pub fn run(items: &mut Vec<TopLevel>, mut cfg: PipelineConfig<'_>) -> PipelineRe
             crate::codegen::proof_lower::populate_refined_types(&inputs, &mut ir);
             result.pass_diagnostics.push(diag_for_refinement_lower(&ir));
             fire(&mut cfg, PipelineStage::RefinementLower, items);
+        }
+        if cfg.run_interval_analyze {
+            // Read-only: consumes the just-built `ir.refined_types`
+            // plus the same `ProofLowerInputs` to look up each type's
+            // module-scoped ops. Stores the result on the pipeline
+            // output and pushes a diagnostic; no IR mutation.
+            let analysis = crate::ir::interval::analyze(&ir.refined_types, &inputs);
+            result
+                .pass_diagnostics
+                .push(diag_for_interval_analyze(&analysis));
+            result.interval_analysis = Some(analysis);
+            fire(&mut cfg, PipelineStage::IntervalAnalyze, items);
         }
         if cfg.run_contract_lower {
             crate::codegen::proof_lower::populate_fn_contracts(&inputs, &mut ir);
@@ -884,6 +939,19 @@ fn diag_for_refinement_lower(ir: &crate::ir::ProofIR) -> PassDiagnostic {
         stage: PipelineStage::RefinementLower,
         report: PassReport::RefinementLower {
             refined_types: ir.refined_types.len(),
+        },
+    }
+}
+
+fn diag_for_interval_analyze(analysis: &crate::ir::IntervalAnalysisResult) -> PassDiagnostic {
+    PassDiagnostic {
+        stage: PipelineStage::IntervalAnalyze,
+        report: PassReport::IntervalAnalyze {
+            types_analyzed: analysis.types_analyzed(),
+            two_sided_bounded: analysis.two_sided_bounded(),
+            ops_overflow_free: analysis.ops_overflow_free(),
+            ops_needs_wider: analysis.ops_needs_wider(),
+            ops_unbounded: analysis.ops_unbounded(),
         },
     }
 }

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -3524,6 +3524,7 @@ pub(super) fn cmd_explain_passes(file: &str, module_root_override: Option<&str>,
             }),
             alloc_policy: Some(&neutral_policy),
             run_refinement_lower: true,
+            run_interval_analyze: true,
             run_contract_lower: true,
             run_law_lower: true,
             dep_modules: &dep_modules,
@@ -3936,6 +3937,19 @@ fn render_pass_diagnostics(diags: &[aver::ir::pipeline::PassDiagnostic]) -> Stri
                     "{label} {refined_types} refined type(s) lifted to subtype/subset\n"
                 ));
             }
+            PassReport::IntervalAnalyze {
+                types_analyzed,
+                two_sided_bounded,
+                ops_overflow_free,
+                ops_needs_wider,
+                ops_unbounded,
+            } => {
+                out.push_str(&format!(
+                    "{label} {types_analyzed} refined type(s) analyzed: \
+                     {two_sided_bounded} two-sided bounded; ops {ops_overflow_free} overflow-free, \
+                     {ops_needs_wider} needs-wider-scratch, {ops_unbounded} unbounded\n"
+                ));
+            }
             PassReport::ContractLower { fn_contracts } => {
                 out.push_str(&format!("{label} {fn_contracts} fn contract(s) decided\n"));
             }
@@ -4142,6 +4156,24 @@ fn render_pass_diagnostics_json(diags: &[aver::ir::pipeline::PassDiagnostic]) ->
             }
             PassReport::RefinementLower { refined_types } => {
                 out.push_str(&format!("{{\"refined_types\":{}}}", refined_types));
+            }
+            PassReport::IntervalAnalyze {
+                types_analyzed,
+                two_sided_bounded,
+                ops_overflow_free,
+                ops_needs_wider,
+                ops_unbounded,
+            } => {
+                out.push_str(&format!(
+                    "{{\"types_analyzed\":{},\"two_sided_bounded\":{},\
+                     \"ops_overflow_free\":{},\"ops_needs_wider\":{},\
+                     \"ops_unbounded\":{}}}",
+                    types_analyzed,
+                    two_sided_bounded,
+                    ops_overflow_free,
+                    ops_needs_wider,
+                    ops_unbounded
+                ));
             }
             PassReport::ContractLower { fn_contracts } => {
                 out.push_str(&format!("{{\"fn_contracts\":{}}}", fn_contracts));

--- a/tests/explain_passes_spec.rs
+++ b/tests/explain_passes_spec.rs
@@ -100,6 +100,9 @@ fn main() -> Int
             // of re-resolving `Expr` themselves.
             "name_resolve",
             "refinement_lower",
+            // Per-module interval analysis (read-only diagnostic) runs
+            // right after refinement_lower, consuming its refined types.
+            "interval_analyze",
             "contract_lower",
             "law_lower",
         ]
@@ -211,4 +214,63 @@ fn main() -> Int
         );
     }
     assert!(data["total_fns"].as_u64().unwrap() >= 1);
+}
+
+#[test]
+fn interval_analyze_pass_exposes_count_fields() {
+    // Drive a real two-sided refinement (`IntRange`, [0,100]) through
+    // the diagnostic and pin the interval_analyze report's COUNT
+    // fields (not free text). `IntRange.add` is the keystone
+    // overflow-free op.
+    let json = run_explain_passes(
+        r#"
+module IntRange
+    exposes [fromInt, toInt, add]
+    exposes opaque [IntRange]
+    intent = "Range-bounded refinement [0,100]."
+    effects []
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    ? "Smart constructor — admits 0..=100."
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("IntRange must be in 0..=100")
+
+fn toInt(n: IntRange) -> Int
+    ? "Unwrap."
+    n.value
+
+fn add(a: IntRange, b: IntRange) -> Result<IntRange, String>
+    ? "Sum, re-validated."
+    fromInt(a.value + b.value)
+"#,
+    );
+    let pass = json["passes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["stage"] == "interval_analyze")
+        .expect("interval_analyze pass present");
+    let data = &pass["data"];
+    for field in [
+        "types_analyzed",
+        "two_sided_bounded",
+        "ops_overflow_free",
+        "ops_needs_wider",
+        "ops_unbounded",
+    ] {
+        assert!(
+            data[field].is_u64(),
+            "interval_analyze.data.{field} missing or wrong type: {data:?}"
+        );
+    }
+    // IntRange: 1 type, two-sided, `add` overflow-free, nothing else.
+    assert_eq!(data["types_analyzed"], 1);
+    assert_eq!(data["two_sided_bounded"], 1);
+    assert_eq!(data["ops_overflow_free"], 1);
+    assert_eq!(data["ops_needs_wider"], 0);
+    assert_eq!(data["ops_unbounded"], 0);
 }

--- a/tests/interval_analysis_spec.rs
+++ b/tests/interval_analysis_spec.rs
@@ -1,0 +1,470 @@
+//! Integration tests for the per-module interval analysis
+//! (`src/ir/interval.rs`), driven through the real pipeline on the
+//! shipped `examples/refinement/*` types.
+//!
+//! These pin the headline behavior: a two-sided refinement
+//! (`IntRange`, `[0,100]`) classifies its `add` op as `OverflowFree`
+//! (the native-`i64` candidate), while single-sided refinements
+//! (`Natural`/`Positive`, `[0,+inf]`/`[1,+inf]`) classify their ops
+//! `Unbounded` (must stay bignum). Float / structural carriers never
+//! reach the analysis at all (the refinement-lift stage upstream
+//! declines them), so the analysis simply sees zero refined types for
+//! those files.
+
+use aver::codegen::ModuleInfo;
+use aver::ir::interval::{Bound, IntervalAnalysisResult, OpClass};
+use aver::ir::{Interval, PipelineConfig, TypecheckMode};
+use aver::source::{LoadedModule, parse_source};
+use std::path::PathBuf;
+
+/// Run the proof-mode pipeline with interval analysis on and return
+/// its result. Mirrors `tests/proof_ir_diff.rs::build_ctx` (rewrite
+/// stages off so source-level shapes survive) but flips
+/// `run_interval_analyze` on.
+fn analyze_src(src: &str) -> IntervalAnalysisResult {
+    let mut items = parse_source(src).expect("parse");
+    let result = aver::ir::pipeline::run(
+        &mut items,
+        PipelineConfig {
+            run_tco: true,
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            run_interp_lower: false,
+            run_buffer_build: false,
+            run_resolve: false,
+            run_last_use: false,
+            run_analyze: true,
+            run_escape: false,
+            run_refinement_lower: true,
+            run_interval_analyze: true,
+            run_contract_lower: false,
+            run_law_lower: false,
+            run_build_symbols: true,
+            dep_modules: &[],
+            alloc_policy: None,
+            call_ctx: None,
+            on_after_pass: None,
+        },
+    );
+    let tc = result.typecheck.expect("typecheck requested");
+    assert!(tc.errors.is_empty(), "source typechecks: {:?}", tc.errors);
+    result
+        .interval_analysis
+        .expect("interval analysis present when run_interval_analyze=true")
+}
+
+/// Run the analysis over an entry file plus pre-loaded dep modules
+/// (multi-module shape). Mirrors `tests/cross_module_type_keys.rs`.
+fn analyze_multi(entry: &str, deps: &[(&str, &str)]) -> IntervalAnalysisResult {
+    let mut entry_items = parse_source(entry).expect("entry parse");
+    let loaded: Vec<LoadedModule> = deps
+        .iter()
+        .map(|(name, src)| LoadedModule {
+            dep_name: name.to_string(),
+            items: parse_source(src).unwrap_or_else(|e| panic!("{name} parse: {e}")),
+            path: PathBuf::from(format!("{name}.av")),
+        })
+        .collect();
+    let modules: Vec<ModuleInfo> = loaded.iter().map(ModuleInfo::from_loaded).collect();
+    let result = aver::ir::pipeline::run(
+        &mut entry_items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::WithLoaded(&loaded)),
+            run_refinement_lower: true,
+            run_interval_analyze: true,
+            run_build_symbols: true,
+            run_analyze: true,
+            dep_modules: &modules,
+            ..Default::default()
+        },
+    );
+    let tc = result.typecheck.expect("typecheck requested");
+    assert!(
+        tc.errors.is_empty(),
+        "multi-module typechecks: {:?}",
+        tc.errors
+    );
+    result
+        .interval_analysis
+        .expect("interval analysis present when run_interval_analyze=true")
+}
+
+/// Look up the single refined type's analysis entry by source name.
+fn only_type<'a>(r: &'a IntervalAnalysisResult, name: &str) -> &'a aver::ir::RefinedTypeInterval {
+    let matches: Vec<_> = r.types.values().filter(|t| t.name == name).collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one `{name}` refined type, got {}",
+        matches.len()
+    );
+    matches[0]
+}
+
+fn op_class(t: &aver::ir::RefinedTypeInterval, op: &str) -> OpClass {
+    t.ops
+        .iter()
+        .find(|(name, _)| name == op)
+        .map(|(_, c)| *c)
+        .unwrap_or_else(|| panic!("op `{op}` not classified; ops = {:?}", t.ops))
+}
+
+// ── int_range: the keystone OverflowFree case ──────────────────────
+
+#[test]
+fn int_range_add_is_overflow_free() {
+    let src = include_str!("../examples/refinement/int_range/int_range.av");
+    let r = analyze_src(src);
+    let t = only_type(&r, "IntRange");
+
+    assert!(t.interval_known, "IntRange's [0,100] guard is recognized");
+    assert_eq!(
+        t.interval,
+        Interval::between(0, 100),
+        "Bool.and(n>=0, n<=100) → [0,100]"
+    );
+
+    // The whole point: `add` of two `[0,100]` values has intermediate
+    // `[0,200]`, which fits i64, so the i64 fast path is licensed
+    // (the `fromInt` guard still re-validates the [0,100] bound).
+    assert_eq!(
+        op_class(t, "add"),
+        OpClass::OverflowFree,
+        "IntRange.add intermediate [0,200] fits i64"
+    );
+}
+
+// ── natural: single-sided → Unbounded ──────────────────────────────
+
+#[test]
+fn natural_ops_are_unbounded() {
+    let src = include_str!("../examples/refinement/natural/natural.av");
+    let r = analyze_src(src);
+    let t = only_type(&r, "Natural");
+
+    assert!(t.interval_known, "n>=0 is a recognized one-sided shape");
+    assert_eq!(t.interval.lo, Bound::Finite(0));
+    assert_eq!(t.interval.hi, Bound::PosInf, "Natural is [0,+inf]");
+
+    // `[0,+inf] + [0,+inf] = [0,+inf]` — NOT overflow-free.
+    assert_eq!(op_class(t, "add"), OpClass::Unbounded);
+    assert_eq!(op_class(t, "mul"), OpClass::Unbounded);
+}
+
+// ── positive: n>0 → [1,+inf], ops Unbounded ────────────────────────
+
+#[test]
+fn positive_interval_and_ops() {
+    let src = include_str!("../examples/refinement/positive/positive.av");
+    let r = analyze_src(src);
+    let t = only_type(&r, "Positive");
+
+    assert!(t.interval_known);
+    // `n > 0` strictness → lo = 1.
+    assert_eq!(t.interval.lo, Bound::Finite(1), "n>0 → lo=1");
+    assert_eq!(t.interval.hi, Bound::PosInf);
+    assert_eq!(op_class(t, "mul"), OpClass::Unbounded);
+}
+
+// ── nonneg_float: Float carrier → declined upstream (0 types) ───────
+
+#[test]
+fn nonneg_float_yields_no_refined_types() {
+    // The carrier is `Float`, which the refinement-lift stage does NOT
+    // lift to a refined type (the i64 story is Int-only). So the
+    // interval analysis sees zero refined types — there is nothing to
+    // classify, and no spurious `OverflowFree` ever appears.
+    let src = include_str!("../examples/refinement/nonneg_float/nonneg_float.av");
+    let r = analyze_src(src);
+    assert_eq!(
+        r.types_analyzed(),
+        0,
+        "Float-carrier refinement is declined before the analysis sees it"
+    );
+}
+
+// ── bigint: List<Int> structural carrier → declined upstream ───────
+
+#[test]
+fn bigint_yields_no_refined_types() {
+    // BigInt's carrier is `List<Int>` (a structural, unbounded-width
+    // type), so it is never lifted to a constant-interval refinement
+    // type. The analysis sees zero refined types.
+    let src = include_str!("../examples/refinement/bigint/bigint.av");
+    let r = analyze_src(src);
+    assert_eq!(
+        r.types_analyzed(),
+        0,
+        "structural List carrier is declined before the analysis sees it"
+    );
+}
+
+// ── aggregate counters on int_range ────────────────────────────────
+
+#[test]
+fn int_range_aggregate_counters() {
+    let src = include_str!("../examples/refinement/int_range/int_range.av");
+    let r = analyze_src(src);
+    assert_eq!(r.types_analyzed(), 1);
+    assert_eq!(r.two_sided_bounded(), 1, "IntRange is two-sided [0,100]");
+    assert_eq!(r.ops_overflow_free(), 1, "only `add` is arithmetic");
+    assert_eq!(r.ops_needs_wider(), 0);
+    assert_eq!(r.ops_unbounded(), 0);
+}
+
+// ── soundness regressions: no spurious OverflowFree ────────────────
+//
+// Three independent under-approximations once let the analysis certify
+// an operation `OverflowFree` even though a real i64 intermediate
+// wraps. Each module below reproduces one of them; all three must
+// classify NOT `OverflowFree` (the conservative direction), while the
+// legitimate `IntRange.add` shape they are built from stays
+// `OverflowFree`. The malicious modules share `IntRange`'s `[0,100]`
+// carrier so the only difference from the legitimate case is the
+// op-body shape under test.
+
+/// Carrier + smart constructor shared by the regression modules below:
+/// the exact `IntRange` `[0,100]` refinement from `int_range.av`.
+const RANGE_HEADER: &str = "\
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    ? \"Smart constructor — admits only ints in 0..=100.\"
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err(\"IntRange must be in 0..=100\")
+";
+
+/// Look up the single arithmetic op a regression module exposes and
+/// assert it is NOT `OverflowFree` (the soundness requirement).
+fn assert_not_overflow_free(src: &str, type_name: &str, op: &str) -> OpClass {
+    let r = analyze_src(src);
+    let t = only_type(&r, type_name);
+    let class = op_class(t, op);
+    assert_ne!(
+        class,
+        OpClass::OverflowFree,
+        "`{type_name}.{op}` must NOT be certified OverflowFree (got {class:?})"
+    );
+    class
+}
+
+// Regression 1 — transparent-wrapper hole. A one-arg helper `widen`
+// must NOT be peeled as identity: it scales the carrier far past i64,
+// so the intermediate handed to `fromInt` wraps. Before the fix the
+// transparent arm fired for ANY bare-ident one-arg call → OverflowFree.
+#[test]
+fn widen_helper_is_not_overflow_free() {
+    let src = format!(
+        "\
+module Scaled
+    exposes [fromInt, toInt, scaledAdd]
+    exposes opaque [IntRange]
+    intent = \"A widening helper hides an out-of-i64 intermediate.\"
+    effects []
+
+{RANGE_HEADER}
+fn toInt(n: IntRange) -> Int
+    ? \"Unwrap.\"
+    n.value
+
+fn widen(x: Int) -> Int
+    ? \"Scales far past i64 — must not be peeled as identity.\"
+    x * 100000000000000000
+
+fn scaledAdd(a: IntRange, b: IntRange) -> Result<IntRange, String>
+    ? \"widen(a+b) overflows i64 before fromInt re-validates.\"
+    fromInt(widen(a.value + b.value))
+"
+    );
+    // `widen` is opaque (not the constructor) → its argument's widening
+    // is invisible, so the whole op evaluates Unbounded.
+    assert_eq!(
+        assert_not_overflow_free(&src, "IntRange", "scaledAdd"),
+        OpClass::Unbounded
+    );
+}
+
+// Regression 2 — non-tail statements ignored. An earlier binding whose
+// value overflows i64 must demote the op even though the tail itself is
+// the legitimate `fromInt(a + b)`. Before the fix only the tail was
+// classified → OverflowFree.
+#[test]
+fn non_tail_overflowing_binding_is_not_overflow_free() {
+    let src = format!(
+        "\
+module Hidden
+    exposes [fromInt, toInt, hiddenOverflow]
+    exposes opaque [IntRange]
+    intent = \"An earlier binding overflows i64; the tail is benign.\"
+    effects []
+
+{RANGE_HEADER}
+fn toInt(n: IntRange) -> Int
+    ? \"Unwrap.\"
+    n.value
+
+fn hiddenOverflow(a: IntRange, b: IntRange) -> Result<IntRange, String>
+    ? \"`doomed` overflows i64 before the benign tail runs.\"
+    doomed = a.value * 100000000000000000
+    fromInt(a.value + b.value)
+"
+    );
+    // `doomed`'s interval is `[0,100] * 1e17 = [0, 1e19]` — finite but
+    // out of i64 → NeedsWiderScratch. (If the binding were unbounded it
+    // would be Unbounded; either way it is not OverflowFree.)
+    let class = assert_not_overflow_free(&src, "IntRange", "hiddenOverflow");
+    assert!(
+        matches!(class, OpClass::NeedsWiderScratch | OpClass::Unbounded),
+        "non-tail binding overflows i64 → NeedsWiderScratch/Unbounded, got {class:?}"
+    );
+}
+
+// Regression 3 — intermediate intervals discarded within the tail. The
+// inner `a + i64::MAX` overflows even though the outer `- i64::MAX`
+// cancels it back into `[0,100]`. This uses the GENUINE `fromInt`, so
+// the constructor gate (regression 1's fix) does not catch it; the wide
+// value is a true intermediate, so only joining intermediate intervals
+// (regression 2's fix walking inside the tail) demotes it.
+#[test]
+fn cancelling_intermediate_is_not_overflow_free() {
+    let src = format!(
+        "\
+module Cancel
+    exposes [fromInt, toInt, addBig]
+    exposes opaque [IntRange]
+    intent = \"An inner term overflows i64, then cancels in the tail.\"
+    effects []
+
+{RANGE_HEADER}
+fn toInt(n: IntRange) -> Int
+    ? \"Unwrap.\"
+    n.value
+
+fn addBig(a: IntRange) -> Result<IntRange, String>
+    ? \"(a + i64::MAX) - i64::MAX cancels, but the inner add wraps.\"
+    fromInt((a.value + 9223372036854775807) - 9223372036854775807)
+"
+    );
+    // The inner `[i64::MAX, i64::MAX+100]` is finite but out of i64 →
+    // NeedsWiderScratch (or Unbounded); never OverflowFree.
+    let class = assert_not_overflow_free(&src, "IntRange", "addBig");
+    assert!(
+        matches!(class, OpClass::NeedsWiderScratch | OpClass::Unbounded),
+        "inner add is finite-out-of-i64 → NeedsWiderScratch/Unbounded, got {class:?}"
+    );
+}
+
+// Anti-regression — the legitimate case the whole analysis exists for
+// must stay OverflowFree even under the worst-intermediate walk: the
+// only intermediate is `[0,200]`, which fits i64. Phrased exactly like
+// the malicious modules above (same header, real `fromInt`) so it
+// isolates the op-body shape as the sole difference.
+#[test]
+fn legitimate_add_stays_overflow_free_under_worst_intermediate() {
+    let src = format!(
+        "\
+module Legit
+    exposes [fromInt, toInt, add]
+    exposes opaque [IntRange]
+    intent = \"The keystone OverflowFree case, in regression form.\"
+    effects []
+
+{RANGE_HEADER}
+fn toInt(n: IntRange) -> Int
+    ? \"Unwrap.\"
+    n.value
+
+fn add(a: IntRange, b: IntRange) -> Result<IntRange, String>
+    ? \"Sum of two [0,100] values — intermediate [0,200] fits i64.\"
+    fromInt(a.value + b.value)
+"
+    );
+    let r = analyze_src(&src);
+    let t = only_type(&r, "IntRange");
+    assert_eq!(
+        op_class(t, "add"),
+        OpClass::OverflowFree,
+        "intermediate [0,200] fits i64 — must stay OverflowFree"
+    );
+}
+
+// ── cross-module distinctness: same name, different bounds ─────────
+
+#[test]
+fn cross_module_same_named_types_get_distinct_intervals() {
+    // Two dep modules each declare a refined `Natural` with the SAME
+    // bare name but DIFFERENT bounds (`n>=0` vs `n>=10`). The analysis
+    // is keyed by opaque `TypeId`, so the two must land in distinct
+    // entries with distinct intervals — nothing merges by bare name.
+    // This is the same shape as
+    // `tests/proof_spec/export_structure.rs`'s AAA/BBB Natural test,
+    // driven in-memory through the pipeline.
+    const ENTRY: &str = "\
+module Entry
+    depends [AAA, BBB]
+    intent = \"Touches both Naturals so both surface in the analysis.\"
+
+fn main() -> Int
+    0
+";
+    const AAA: &str = "\
+module AAA
+    exposes [fromInt]
+    exposes opaque [Natural]
+    intent = \"Module AAA's Natural — non-negative.\"
+    effects []
+
+record Natural
+    value: Int
+
+fn fromInt(n: Int) -> Result<Natural, String>
+    ? \"Smart constructor — non-negative.\"
+    match n >= 0
+        true  -> Result.Ok(Natural(value = n))
+        false -> Result.Err(\"AAA: must be non-negative\")
+";
+    const BBB: &str = "\
+module BBB
+    exposes [fromInt]
+    exposes opaque [Natural]
+    intent = \"Module BBB's Natural — at least 10.\"
+    effects []
+
+record Natural
+    value: Int
+
+fn fromInt(n: Int) -> Result<Natural, String>
+    ? \"Smart constructor — at least 10.\"
+    match n >= 10
+        true  -> Result.Ok(Natural(value = n))
+        false -> Result.Err(\"BBB: must be >= 10\")
+";
+    let r = analyze_multi(ENTRY, &[("AAA", AAA), ("BBB", BBB)]);
+    assert_eq!(
+        r.types_analyzed(),
+        2,
+        "both modules' Natural surface as distinct refined types"
+    );
+
+    // Two entries named `Natural`, distinct TypeIds, distinct lower
+    // bounds — proving the opaque-TypeId keying carries through the
+    // interval map and nothing merges by bare name.
+    let naturals: Vec<_> = r.types.values().filter(|t| t.name == "Natural").collect();
+    assert_eq!(naturals.len(), 2, "two distinct `Natural` entries");
+    assert_ne!(
+        naturals[0].type_id, naturals[1].type_id,
+        "distinct opaque TypeIds"
+    );
+    let mut los: Vec<Bound> = naturals.iter().map(|t| t.interval.lo).collect();
+    los.sort_by_key(|b| match b {
+        Bound::Finite(k) => *k,
+        Bound::NegInf => i128::MIN,
+        Bound::PosInf => i128::MAX,
+    });
+    assert_eq!(
+        los,
+        vec![Bound::Finite(0), Bound::Finite(10)],
+        "AAA.Natural is [0,+inf], BBB.Natural is [10,+inf] — not merged"
+    );
+}

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -41,6 +41,7 @@ fn build_ctx(src: &str) -> CodegenContext {
             run_analyze: true,
             run_escape: false,
             run_refinement_lower: true,
+            run_interval_analyze: false,
             run_contract_lower: true,
             run_law_lower: true,
             // Build the symbol table alongside proof IR so downstream


### PR DESCRIPTION
## What

A pure, per-module interval analysis (surfaced via `--explain-passes`) that, for each refinement type, derives a constant integer interval from its smart-constructor invariant and classifies the type's operations by whether their i64 intermediate can overflow: `overflow-free`, `needs-wider-scratch`, or `unbounded`.

Diagnostic only — no codegen, runtime, or proof-output change. It runs on the current i64 codebase, behind `--explain-passes`.

## Why

Foundation for letting a two-sided bounded refinement type (e.g. `IntRange` in `0..=100`) lower its carrier to a raw machine integer where its arithmetic is provably overflow-free, while one-sided or unbounded code stays on the safe path. Part of #510.

## Behaviour

- `IntRange` (`0..=100`) → two-sided bounded; `add` → **overflow-free** (intermediate `0..=200` fits i64).
- `Natural` (`n >= 0`) → one-sided; ops → **unbounded** (open upper bound).
- Non-Int or structurally-carried refinements (Float, arbitrary precision) → declined.

## Soundness

Conservative by construction: any shape it cannot prove → declines. Wrongly certifying overflow-free is the only unsound direction; the analysis is built never to do it. Hardened in review against three adversarial cases — a non-constructor helper hiding a widening op, an overflowing non-tail binding, and an intermediate subexpression that overflows before the final value narrows back into range — with regression tests for all three plus the legitimate `IntRange.add`.

Refs #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
