### PR TITLE
analysis: persist refinement interval + op classification on the IR

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -2838,6 +2838,8 @@ mod tests {
                 )),
             },
             witness: Some(witness.to_string()),
+            interval: None,
+            op_classes: Vec::new(),
         };
         let symbols = crate::ir::SymbolTable::build(&[], &modules);
         let a_id = symbols
@@ -2920,6 +2922,8 @@ mod tests {
                 )),
             },
             witness: Some(witness.to_string()),
+            interval: None,
+            op_classes: Vec::new(),
         };
 
         let items = vec![TopLevel::TypeDef(entry_natural)];

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -466,8 +466,45 @@ pub fn populate_refined_types(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
                 predicate_param: info.param_name.to_string(),
                 invariant,
                 witness: Some(witness),
+                // Filled in immediately below by `populate_refined_type_intervals`,
+                // which runs the interval analysis once over the just-built
+                // `refined_types` map. Left empty here so the two passes share
+                // a single source of truth (`interval::analyze`) instead of
+                // each construction site re-deriving the bound.
+                interval: None,
+                op_classes: Vec::new(),
             },
         );
+    }
+
+    // Back-fill each decl's derived interval + per-op classification by
+    // running the existing per-module interval analysis over the map we
+    // just built. Reuses `interval::analyze` verbatim (no forked logic),
+    // so the persisted fact on every `RefinedTypeDecl` is byte-identical
+    // to what `aver compile --explain-passes` reports for the same type.
+    // This makes the bound a queryable fact on the standard refinement-
+    // lower path — the home a future carrier-lowering codegen recognizer
+    // reads via `ctx.proof_ir.refined_types` (TypeId-keyed) without
+    // re-running the analysis behind the diagnostic flag.
+    populate_refined_type_intervals(inputs, ir);
+}
+
+/// Attach the interval analysis result to each `RefinedTypeDecl` in
+/// `ir.refined_types`. Called once at the tail of
+/// [`populate_refined_types`]; the analysis is keyed by the same opaque
+/// `TypeId` the decl map uses, so the join is a direct id lookup.
+fn populate_refined_type_intervals(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
+    let analysis = crate::ir::interval::analyze(&ir.refined_types, inputs);
+    for (type_id, decl) in ir.refined_types.iter_mut() {
+        let Some(per_type) = analysis.types.get(type_id) else {
+            continue;
+        };
+        // `interval_known` distinguishes a recognized bound from the
+        // conservative `Interval::unbounded()` decline; persist `None`
+        // for the decline so consumers don't mistake `[-inf, +inf]` for
+        // a real enclosure.
+        decl.interval = per_type.interval_known.then_some(per_type.interval);
+        decl.op_classes = per_type.ops.clone();
     }
 }
 

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -186,6 +186,35 @@ pub struct RefinedTypeDecl {
     /// witness must either reject the type or fall back to a target-
     /// default (Dafny picks `0` and crosses fingers).
     pub witness: Option<String>,
+    /// Constant integer interval over-approximating `invariant`, as
+    /// derived by [`crate::ir::interval::interval_of_invariant`] from
+    /// the same predicate. `Some([lo, hi])` when the invariant shape
+    /// was recognized (a comparison / `Bool.and` against integer
+    /// literals); `None` when the analysis declined (unrecognized
+    /// shape — `Bool.or`, non-literal bound, structural carrier).
+    ///
+    /// Persisted here so a carrier-lowering codegen recognizer (the
+    /// next slice of the Int-semantics effort) can read the bound
+    /// directly off the `TypeId`-keyed decl — the same identity key
+    /// the interval analysis uses — without re-running the analysis
+    /// behind the `--explain-passes` diagnostic flag. The value is
+    /// identical to what `aver compile --explain-passes` reports for
+    /// the same type; both paths call the one `interval` analysis.
+    pub interval: Option<crate::ir::interval::Interval>,
+    /// Per-arithmetic-op overflow classification, in module-walk
+    /// order. Each entry pairs the operation's source name with its
+    /// [`crate::ir::interval::OpClass`] — `OverflowFree` when every
+    /// `i64` intermediate across the op body provably fits `i64`
+    /// (the carrier-lowering candidate), `NeedsWiderScratch` /
+    /// `Unbounded` otherwise. Empty when the type exposes no
+    /// carrier arithmetic or when `interval` is `None`.
+    ///
+    /// Populated by [`crate::ir::interval::analyze`] over the same
+    /// `ProofLowerInputs` `populate_refined_types` consumed, so the
+    /// classification is byte-identical to the `--explain-passes`
+    /// report. The codegen recognizer reads this to flag a carrier
+    /// "raw-i64-eligible" per op.
+    pub op_classes: Vec<(String, crate::ir::interval::OpClass)>,
 }
 
 /// Per-pure-fn proof contract — what recursion shape (if any) the

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -245,6 +245,169 @@ fn int_range_refinement_decision_matches_legacy() {
     assert_equiv(src, &["IntRange"]);
 }
 
+// ── persisted interval / op-class facts on RefinedTypeDecl ──────────
+//
+// `populate_refined_types` back-fills each `RefinedTypeDecl` with the
+// interval analysis's derived bound + per-op classification, reusing
+// `interval::analyze`. The fact is queryable on the standard
+// refinement-lower path — `build_ctx` runs with
+// `run_interval_analyze: false`, so these tests prove the persisted
+// fields are populated WITHOUT the `--explain-passes` diagnostic flag.
+// This is the home a future carrier-lowering codegen recognizer reads
+// via `ctx.proof_ir.refined_types` (TypeId-keyed).
+
+/// Look up the persisted decl for a refined type by source name.
+fn refined_decl<'a>(
+    ctx: &'a CodegenContext,
+    type_name: &str,
+) -> &'a aver::ir::proof_ir::RefinedTypeDecl {
+    let matches: Vec<_> = ctx
+        .proof_ir
+        .refined_types
+        .values()
+        .filter(|d| d.name == type_name)
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one `{type_name}` refined type, got {}",
+        matches.len()
+    );
+    matches[0]
+}
+
+/// Persisted op-class for a named op on a decl.
+fn persisted_op_class(
+    decl: &aver::ir::proof_ir::RefinedTypeDecl,
+    op: &str,
+) -> aver::ir::interval::OpClass {
+    decl.op_classes
+        .iter()
+        .find(|(name, _)| name == op)
+        .map(|(_, c)| *c)
+        .unwrap_or_else(|| panic!("op `{op}` not classified; ops = {:?}", decl.op_classes))
+}
+
+#[test]
+fn int_range_persists_two_sided_interval_and_overflow_free_add() {
+    use aver::ir::Interval;
+    use aver::ir::interval::OpClass;
+
+    let src = include_str!("../examples/refinement/int_range/int_range.av");
+    let ctx = build_ctx(src);
+    let decl = refined_decl(&ctx, "IntRange");
+
+    // The `Bool.and(n >= 0, n <= 100)` guard yields the two-sided
+    // `[0, 100]` enclosure, persisted as `Some`.
+    assert_eq!(
+        decl.interval,
+        Some(Interval::between(0, 100)),
+        "IntRange's [0,100] guard is recognized and persisted on the decl"
+    );
+
+    // `add` of two `[0,100]` values has intermediate `[0,200]`, which
+    // fits i64 — the native-i64 candidate. (The `fromInt` guard still
+    // re-validates the [0,100] bound; OverflowFree is about the
+    // intermediate, not the result.)
+    assert_eq!(
+        persisted_op_class(decl, "add"),
+        OpClass::OverflowFree,
+        "IntRange.add intermediate [0,200] fits i64 → persisted OverflowFree"
+    );
+}
+
+#[test]
+fn natural_persists_one_sided_interval_and_unbounded_ops() {
+    use aver::ir::interval::{Bound, OpClass};
+
+    let src = include_str!("../examples/refinement/natural/natural.av");
+    let ctx = build_ctx(src);
+    let decl = refined_decl(&ctx, "Natural");
+
+    // `n >= 0` is a recognized one-sided shape → `[0, +inf]`, persisted
+    // as `Some` (recognized, even though it is not two-sided).
+    let interval = decl
+        .interval
+        .expect("Natural's n>=0 guard is recognized and persisted");
+    assert_eq!(interval.lo, Bound::Finite(0));
+    assert_eq!(interval.hi, Bound::PosInf, "Natural is [0,+inf]");
+
+    // `[0,+inf]` operands give `[0,+inf]` intermediates — no derivable
+    // finite bound, so every op persists `Unbounded` (must stay bignum).
+    assert_eq!(persisted_op_class(decl, "add"), OpClass::Unbounded);
+    assert_eq!(persisted_op_class(decl, "mul"), OpClass::Unbounded);
+}
+
+#[test]
+fn persisted_classification_equals_explain_passes_interval_analysis() {
+    // The persisted decl fields must be IDENTICAL to what the
+    // `--explain-passes` diagnostic path (`run_interval_analyze: true`,
+    // `PipelineResult.interval_analysis`) reports for the same program.
+    // Both paths call the one `interval::analyze`; this test pins that
+    // there is no divergence between the persisted home and the
+    // diagnostic flag.
+    let src = include_str!("../examples/refinement/int_range/int_range.av");
+
+    // Persisted path: standard refinement-lower (interval_analyze OFF).
+    let ctx = build_ctx(src);
+
+    // Diagnostic path: same pipeline shape but interval_analyze ON,
+    // reading the standalone `IntervalAnalysisResult`.
+    let mut items = parse_source(src).expect("parse");
+    let diag = aver::ir::pipeline::run(
+        &mut items,
+        aver::ir::PipelineConfig {
+            run_tco: true,
+            typecheck: Some(aver::ir::TypecheckMode::Full { base_dir: None }),
+            run_interp_lower: false,
+            run_buffer_build: false,
+            run_resolve: false,
+            run_last_use: false,
+            run_analyze: true,
+            run_escape: false,
+            run_refinement_lower: true,
+            run_interval_analyze: true,
+            run_contract_lower: false,
+            run_law_lower: false,
+            run_build_symbols: true,
+            dep_modules: &[],
+            alloc_policy: None,
+            call_ctx: None,
+            on_after_pass: None,
+        },
+    );
+    let diag_analysis = diag
+        .interval_analysis
+        .expect("interval analysis present when run_interval_analyze=true");
+
+    // For every persisted decl, the diagnostic result keyed by the same
+    // TypeId must agree on both the interval and the per-op classes.
+    assert!(
+        !ctx.proof_ir.refined_types.is_empty(),
+        "IntRange must be lifted into refined_types"
+    );
+    for (type_id, decl) in &ctx.proof_ir.refined_types {
+        let per_type = diag_analysis
+            .types
+            .get(type_id)
+            .expect("every persisted decl has a diagnostic counterpart by TypeId");
+
+        // Persisted `interval` is `Some(..)` exactly when the diagnostic
+        // recognized the shape (`interval_known`), and the value matches.
+        let expected_interval = per_type.interval_known.then_some(per_type.interval);
+        assert_eq!(
+            decl.interval, expected_interval,
+            "persisted interval for `{}` diverges from --explain-passes",
+            decl.name
+        );
+        assert_eq!(
+            decl.op_classes, per_type.ops,
+            "persisted op classes for `{}` diverge from --explain-passes",
+            decl.name
+        );
+    }
+}
+
 #[test]
 fn non_refinement_records_dont_appear_in_proof_ir() {
     // A non-refinement record (multiple fields, no smart constructor)


### PR DESCRIPTION
## What

Persists each refinement type's derived integer interval and per-operation overflow classification on `RefinedTypeDecl`, populated on the standard refinement-lowering path (not only behind `--explain-passes`).

Pure refactor — reuses the existing interval analysis, duplicates no logic, and changes no existing output.

## Why

Makes the classification a queryable, `TypeId`-keyed fact on `ProofIR`, which codegen already threads in (`CodegenContext.proof_ir`, read via `find_refined_type_by_id`). This is the groundwork for the codegen recognizer that will lower a bounded, overflow-free refinement carrier to a raw machine integer — it can read the fact directly instead of re-running the analysis behind a diagnostic flag. Part of #510.

## Notes

- Home choice: `RefinedTypeDecl` (persisted, `TypeId`-keyed, reachable from codegen) over `RefinementInfo` (a transient lookup that re-walks per call).
- A test pins that the persisted classification is identical, by `TypeId`, to what `--explain-passes` reports — the two paths cannot diverge.
- Minor: on the proof / `--explain-passes` path the analysis now runs twice (producer + diagnostic stage); negligible for refined types (rare, few per program).

Refs #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
