### PR TITLE
analysis: recognize raw-i64-eligible refinement types (diagnostic)

### DIFF
--- a/src/ir/interval.rs
+++ b/src/ir/interval.rs
@@ -335,6 +335,59 @@ impl OpClass {
     }
 }
 
+/// The raw-`i64`-carrier recognizer, factored to a single place so the
+/// `--explain-passes` diagnostic ([`RefinedTypeInterval::raw_i64_eligible`])
+/// and the persisted-fact gate
+/// ([`crate::ir::proof_ir::RefinedTypeDecl::raw_i64_eligible`]) can never
+/// disagree about which types are eligible.
+///
+/// Returns `true` IFF a refined type may have a raw `i64` carrier:
+///
+/// - `interval` is `Some` — a recognized enclosure (`None` is the
+///   analysis's conservative decline); AND
+/// - that interval [`Interval::fits_i64`] — both bounds finite AND within
+///   `[i64::MIN, i64::MAX]`, which is exactly "two-sided and machine-word
+///   sized" (a one-sided / open bound is `±inf`, which never fits); AND
+/// - every op in `ops` is [`OpClass::OverflowFree`] — a single
+///   `NeedsWiderScratch` / `Unbounded` op means some carrier arithmetic
+///   can wrap a raw `i64` before the guard re-validates.
+///
+/// Conservative in the soundness-critical direction: a wrongly-`true`
+/// answer would license a later codegen to lower a carrier whose ops can
+/// wrap. An **empty** `ops` slice with a finite-`i64` interval is
+/// eligible — storage fits `i64` and the `all(...)` is vacuously true, so
+/// nothing can overflow. See the `RefinedTypeDecl` method doc for the
+/// full empty-op reasoning.
+///
+/// WHITELIST SEMANTICS — load-bearing for any consumer that lowers a
+/// carrier to `i64`. `ops` is the set of carrier-*arithmetic* ops the
+/// analysis examined (a fn taking the refined type whose own body computes
+/// an arithmetic intermediate over the carrier). It is NOT every op the
+/// type exposes: an op whose overflow risk lives inside a *called helper*
+/// — e.g. `fromInt(widen(r.value))` with no arithmetic operator in its own
+/// body — is intentionally not enumerated. So `true` does NOT assert
+/// "every operation on the type is overflow-free". It asserts only: the
+/// carrier may be *stored* as `i64`, and the enumerated `OverflowFree` ops
+/// may compute on it with direct `i64` arithmetic. Any consumer that
+/// lowers the carrier to `i64` MUST therefore convert every OTHER read of
+/// the carrier (helper calls, projections, unenumerated ops) to a bignum
+/// `Int` — never raw-`i64` arithmetic outside the enumerated ops. That is
+/// the carrier-lowering contract the bignum runtime must honour; it is
+/// what keeps an unenumerated helper-call op sound (its `r.value` is read
+/// as a bignum `Int`, so the helper's arithmetic cannot wrap).
+pub fn raw_i64_eligible<'a>(
+    interval: Option<Interval>,
+    ops: impl IntoIterator<Item = &'a OpClass>,
+) -> bool {
+    let Some(interval) = interval else {
+        return false;
+    };
+    if !interval.fits_i64() {
+        return false;
+    }
+    ops.into_iter().all(|c| *c == OpClass::OverflowFree)
+}
+
 /// Per-refined-type interval analysis result.
 #[derive(Debug, Clone)]
 pub struct RefinedTypeInterval {
@@ -354,6 +407,19 @@ pub struct RefinedTypeInterval {
     /// Per-op classification, in module-walk order. Each entry pairs
     /// the operation's source name with its [`OpClass`].
     pub ops: Vec<(String, OpClass)>,
+}
+
+impl RefinedTypeInterval {
+    /// Whether this type may have a raw `i64` carrier — the diagnostic
+    /// mirror of the persisted-fact gate on `RefinedTypeDecl`. Delegates
+    /// to the shared [`raw_i64_eligible`] so the two paths agree by
+    /// construction. The persisted decl stores `interval: None` for a
+    /// declined invariant, so this passes `Some(self.interval)` only when
+    /// `interval_known` to match that exact representation.
+    pub fn raw_i64_eligible(&self) -> bool {
+        let interval = self.interval_known.then_some(self.interval);
+        raw_i64_eligible(interval, self.ops.iter().map(|(_, c)| c))
+    }
 }
 
 /// Whole-analysis result, keyed for cheap programmatic lookup.
@@ -392,6 +458,15 @@ impl IntervalAnalysisResult {
     /// Total ops across all types classified `Unbounded`.
     pub fn ops_unbounded(&self) -> usize {
         self.count_ops(OpClass::Unbounded)
+    }
+
+    /// Refined types whose carrier may lower to a raw `i64`
+    /// ([`RefinedTypeInterval::raw_i64_eligible`]) — the
+    /// recognizer's headline count, surfaced by `--explain-passes`. This
+    /// is the "proof the recognizer fires on the right types" metric;
+    /// nothing in codegen / runtime / proof consumes it.
+    pub fn raw_i64_eligible(&self) -> usize {
+        self.types.values().filter(|t| t.raw_i64_eligible()).count()
     }
 
     fn count_ops(&self, class: OpClass) -> usize {

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -322,6 +322,11 @@ pub enum PassReport {
         /// Ops with no derivable finite bound (one-sided / plain-`Int`
         /// operands).
         ops_unbounded: usize,
+        /// Refined types eligible for a raw `i64` carrier — two-sided,
+        /// `i64`-fitting interval with every op `OverflowFree`. The
+        /// recognizer slice's headline count; a pure diagnostic with no
+        /// downstream consumer yet.
+        raw_i64_eligible: usize,
     },
     ContractLower {
         /// Pure fns with a non-trivial `RecursionContract`. Currently
@@ -952,6 +957,7 @@ fn diag_for_interval_analyze(analysis: &crate::ir::IntervalAnalysisResult) -> Pa
             ops_overflow_free: analysis.ops_overflow_free(),
             ops_needs_wider: analysis.ops_needs_wider(),
             ops_unbounded: analysis.ops_unbounded(),
+            raw_i64_eligible: analysis.raw_i64_eligible(),
         },
     }
 }

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -217,6 +217,63 @@ pub struct RefinedTypeDecl {
     pub op_classes: Vec<(String, crate::ir::interval::OpClass)>,
 }
 
+impl RefinedTypeDecl {
+    /// Whether this refined type may have a **raw `i64` carrier** — the
+    /// gate a later codegen slice will trust to lower the bignum `Int`
+    /// carrier to a machine word. Derived ONLY from the persisted
+    /// [`Self::interval`] and [`Self::op_classes`] facts; it never
+    /// re-runs the interval analysis or inspects the invariant syntax.
+    ///
+    /// Returns `true` IFF, conservatively, the type is provably safe to
+    /// store and operate on as a raw `i64`:
+    ///
+    /// - [`Self::interval`] is `Some` — the analysis recognized the
+    ///   invariant shape (a `None` is the analysis's conservative
+    ///   *decline*, never eligible); AND
+    /// - that interval **fits `i64`** ([`crate::ir::interval::Interval::fits_i64`]),
+    ///   which holds IFF **both bounds are finite and within
+    ///   `[i64::MIN, i64::MAX]`**. This single test subsumes
+    ///   "two-sided" (an open / one-sided bound is `±inf`, which never
+    ///   fits) and the `i64`-range check — a `Natural` (`[0, +inf]`) or
+    ///   any interval wider than `i64` is rejected here; AND
+    /// - **every** entry in [`Self::op_classes`] is
+    ///   [`crate::ir::interval::OpClass::OverflowFree`] — a single
+    ///   `NeedsWiderScratch` or `Unbounded` op means some carrier
+    ///   arithmetic can wrap a raw `i64` before the smart constructor's
+    ///   guard re-validates, so the whole carrier stays bignum.
+    ///
+    /// Anything else → `false`. This is conservative in exactly the
+    /// soundness-critical direction: a wrongly-`true` answer would let
+    /// slice 4 lower a carrier whose ops can wrap, silently reintroducing
+    /// the model-vs-runtime gap the whole mechanism exists to close. The
+    /// predicate declines whenever the facts do not *prove* safety.
+    ///
+    /// ## Empty `op_classes`
+    ///
+    /// A type with a finite-`i64` interval but **no** carrier-reading
+    /// arithmetic ops (e.g. only `fromInt` / `toInt`, which
+    /// [`crate::ir::interval::classify_ops_in_scope`] skips) is reported
+    /// **eligible**. The decision is defensible because both soundness
+    /// obligations are met vacuously: storage of any inhabitant fits
+    /// `i64` (it is within the proven interval), and there is no op that
+    /// could overflow a raw `i64` (the `all(...)` over an empty op set is
+    /// `true`). The only thing the raw carrier adds over bignum — an op
+    /// that must not wrap before the guard — has nothing to apply to.
+    /// This is "eligible for storage", which is exactly what the gate
+    /// asks. If a future op is added to the type, it is re-classified and
+    /// can demote the type then; the determination is recomputed from the
+    /// persisted facts every time, never cached.
+    pub fn raw_i64_eligible(&self) -> bool {
+        // Delegates to the single shared recognizer so this persisted-
+        // fact gate and the `--explain-passes` diagnostic can never
+        // diverge about which types are eligible.
+        crate::ir::interval::raw_i64_eligible(
+            self.interval,
+            self.op_classes.iter().map(|(_, class)| class),
+        )
+    }
+}
+
 /// Per-pure-fn proof contract — what recursion shape (if any) the
 /// lowerer pinned for emit.
 #[derive(Debug, Clone)]
@@ -1160,4 +1217,106 @@ pub struct Predicate {
     /// caller-derived predicates have had caller-arg names
     /// substituted to callee-param names).
     pub expr: Spanned<crate::ir::hir::ResolvedExpr>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::hir::ResolvedExpr;
+    use crate::ir::interval::{Interval, OpClass};
+
+    /// A throwaway invariant predicate — `raw_i64_eligible` never reads
+    /// it (it derives only from the persisted `interval` / `op_classes`),
+    /// so a trivial `n` stub is enough to build a `RefinedTypeDecl`.
+    fn stub_predicate() -> Predicate {
+        Predicate {
+            free_vars: vec![("n".to_string(), QuantifierType::Plain("Int".to_string()))],
+            expr: Spanned::new(ResolvedExpr::Ident("n".to_string()), 0),
+        }
+    }
+
+    /// Build a `RefinedTypeDecl` directly from the two persisted facts
+    /// the recognizer reads, bypassing the pipeline entirely.
+    fn decl(interval: Option<Interval>, ops: Vec<(&str, OpClass)>) -> RefinedTypeDecl {
+        RefinedTypeDecl {
+            name: "T".to_string(),
+            carrier_type: "Int".to_string(),
+            carrier_field: "value".to_string(),
+            predicate_param: "n".to_string(),
+            invariant: stub_predicate(),
+            witness: Some("0".to_string()),
+            interval,
+            op_classes: ops.into_iter().map(|(n, c)| (n.to_string(), c)).collect(),
+        }
+    }
+
+    #[test]
+    fn two_sided_fits_i64_all_overflow_free_is_eligible() {
+        // The IntRange shape: [0,100], single `add` op OverflowFree.
+        let d = decl(
+            Some(Interval::between(0, 100)),
+            vec![("add", OpClass::OverflowFree)],
+        );
+        assert!(d.raw_i64_eligible());
+    }
+
+    #[test]
+    fn one_overflow_free_one_unbounded_is_not_eligible() {
+        // ALL ops must be OverflowFree — a single Unbounded op demotes.
+        let d = decl(
+            Some(Interval::between(0, 100)),
+            vec![
+                ("add", OpClass::OverflowFree),
+                ("scaledAdd", OpClass::Unbounded),
+            ],
+        );
+        assert!(!d.raw_i64_eligible());
+    }
+
+    #[test]
+    fn one_needs_wider_scratch_is_not_eligible() {
+        let d = decl(
+            Some(Interval::between(0, 100)),
+            vec![("widePath", OpClass::NeedsWiderScratch)],
+        );
+        assert!(!d.raw_i64_eligible());
+    }
+
+    #[test]
+    fn two_sided_interval_not_fitting_i64_is_not_eligible() {
+        // [0, i64::MAX + 1] is two-sided and finite but exceeds i64, so
+        // the carrier could not be stored in a machine word.
+        let d = decl(
+            Some(Interval::between(0, i64::MAX as i128 + 1)),
+            vec![("add", OpClass::OverflowFree)],
+        );
+        assert!(!d.raw_i64_eligible());
+    }
+
+    #[test]
+    fn declined_interval_none_is_not_eligible() {
+        // `interval: None` is the analysis's conservative decline (an
+        // unrecognized invariant shape) — never eligible.
+        let d = decl(None, vec![("add", OpClass::OverflowFree)]);
+        assert!(!d.raw_i64_eligible());
+    }
+
+    #[test]
+    fn one_sided_interval_is_not_eligible() {
+        // A `Natural`-shaped [0, +inf]: `fits_i64` is false because the
+        // upper bound is open, so the type is rejected even with no ops.
+        let d = decl(Some(Interval::ge(0)), vec![]);
+        assert!(!d.raw_i64_eligible());
+    }
+
+    #[test]
+    fn two_sided_fits_i64_empty_ops_is_eligible() {
+        // Empty op_classes: a finite-i64 interval with no carrier-reading
+        // arithmetic. Decision: ELIGIBLE — storage fits i64 and the
+        // all-OverflowFree check over an empty op set is vacuously true,
+        // so there is no op that could wrap a raw i64. See the doc-comment
+        // on `raw_i64_eligible` for the full reasoning.
+        let d = decl(Some(Interval::between(0, 100)), vec![]);
+        assert!(d.raw_i64_eligible());
+    }
 }

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -3943,11 +3943,13 @@ fn render_pass_diagnostics(diags: &[aver::ir::pipeline::PassDiagnostic]) -> Stri
                 ops_overflow_free,
                 ops_needs_wider,
                 ops_unbounded,
+                raw_i64_eligible,
             } => {
                 out.push_str(&format!(
                     "{label} {types_analyzed} refined type(s) analyzed: \
                      {two_sided_bounded} two-sided bounded; ops {ops_overflow_free} overflow-free, \
-                     {ops_needs_wider} needs-wider-scratch, {ops_unbounded} unbounded\n"
+                     {ops_needs_wider} needs-wider-scratch, {ops_unbounded} unbounded; \
+                     raw_i64_eligible: {raw_i64_eligible}\n"
                 ));
             }
             PassReport::ContractLower { fn_contracts } => {
@@ -4163,16 +4165,18 @@ fn render_pass_diagnostics_json(diags: &[aver::ir::pipeline::PassDiagnostic]) ->
                 ops_overflow_free,
                 ops_needs_wider,
                 ops_unbounded,
+                raw_i64_eligible,
             } => {
                 out.push_str(&format!(
                     "{{\"types_analyzed\":{},\"two_sided_bounded\":{},\
                      \"ops_overflow_free\":{},\"ops_needs_wider\":{},\
-                     \"ops_unbounded\":{}}}",
+                     \"ops_unbounded\":{},\"raw_i64_eligible\":{}}}",
                     types_analyzed,
                     two_sided_bounded,
                     ops_overflow_free,
                     ops_needs_wider,
-                    ops_unbounded
+                    ops_unbounded,
+                    raw_i64_eligible
                 ));
             }
             PassReport::ContractLower { fn_contracts } => {

--- a/tests/explain_passes_spec.rs
+++ b/tests/explain_passes_spec.rs
@@ -261,16 +261,71 @@ fn add(a: IntRange, b: IntRange) -> Result<IntRange, String>
         "ops_overflow_free",
         "ops_needs_wider",
         "ops_unbounded",
+        "raw_i64_eligible",
     ] {
         assert!(
             data[field].is_u64(),
             "interval_analyze.data.{field} missing or wrong type: {data:?}"
         );
     }
-    // IntRange: 1 type, two-sided, `add` overflow-free, nothing else.
+    // IntRange: 1 type, two-sided, `add` overflow-free, nothing else —
+    // and the recognizer certifies it raw-i64-eligible.
     assert_eq!(data["types_analyzed"], 1);
     assert_eq!(data["two_sided_bounded"], 1);
     assert_eq!(data["ops_overflow_free"], 1);
     assert_eq!(data["ops_needs_wider"], 0);
     assert_eq!(data["ops_unbounded"], 0);
+    assert_eq!(
+        data["raw_i64_eligible"], 1,
+        "IntRange [0,100] with an overflow-free `add` is raw-i64-eligible"
+    );
+}
+
+#[test]
+fn interval_analyze_pass_reports_natural_not_eligible() {
+    // A one-sided refinement (`Natural`, n >= 0 → [0, +inf]) is NOT
+    // raw-i64-eligible: the open upper bound never fits a machine word.
+    // The recognizer must report 0 even though the type IS analyzed.
+    let json = run_explain_passes(
+        r#"
+module Natural
+    exposes [fromInt, toInt, add]
+    exposes opaque [Natural]
+    intent = "Non-negative refinement (one-sided)."
+    effects []
+
+record Natural
+    value: Int
+
+fn fromInt(n: Int) -> Result<Natural, String>
+    ? "Smart constructor — admits non-negative ints."
+    match n >= 0
+        true  -> Result.Ok(Natural(value = n))
+        false -> Result.Err("Nat must be non-negative")
+
+fn toInt(n: Natural) -> Int
+    ? "Unwrap."
+    n.value
+
+fn add(a: Natural, b: Natural) -> Result<Natural, String>
+    ? "Sum, re-validated."
+    fromInt(a.value + b.value)
+"#,
+    );
+    let pass = json["passes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["stage"] == "interval_analyze")
+        .expect("interval_analyze pass present");
+    let data = &pass["data"];
+    // The type is seen (one-sided interval recognized), its `add` op is
+    // Unbounded ([0,+inf] + [0,+inf]), so it is NOT eligible.
+    assert_eq!(data["types_analyzed"], 1);
+    assert_eq!(data["two_sided_bounded"], 0);
+    assert_eq!(data["ops_unbounded"], 1);
+    assert_eq!(
+        data["raw_i64_eligible"], 0,
+        "Natural's open upper bound makes it NOT raw-i64-eligible"
+    );
 }

--- a/tests/interval_analysis_spec.rs
+++ b/tests/interval_analysis_spec.rs
@@ -211,6 +211,62 @@ fn int_range_aggregate_counters() {
     assert_eq!(r.ops_unbounded(), 0);
 }
 
+// ── raw-i64-carrier recognizer ─────────────────────────────────────
+//
+// The per-refined-type "raw i64 eligible" determination derived from
+// the analysis facts (`RefinedTypeInterval::raw_i64_eligible` and the
+// `IntervalAnalysisResult::raw_i64_eligible` aggregate). Pure diagnostic
+// — nothing consumes it — but it is the gate a later carrier-lowering
+// slice will trust, so a wrong `true` is a latent unsoundness.
+
+#[test]
+fn int_range_is_raw_i64_eligible() {
+    // [0,100] with an overflow-free `add` → eligible.
+    let src = include_str!("../examples/refinement/int_range/int_range.av");
+    let r = analyze_src(src);
+    let t = only_type(&r, "IntRange");
+    assert!(
+        t.raw_i64_eligible(),
+        "IntRange [0,100], `add` OverflowFree → raw-i64-eligible"
+    );
+    assert_eq!(r.raw_i64_eligible(), 1, "exactly one eligible type");
+}
+
+#[test]
+fn natural_is_not_raw_i64_eligible() {
+    // One-sided [0,+inf] → open upper bound never fits i64 → NOT eligible.
+    let src = include_str!("../examples/refinement/natural/natural.av");
+    let r = analyze_src(src);
+    let t = only_type(&r, "Natural");
+    assert!(
+        !t.raw_i64_eligible(),
+        "Natural's open upper bound → NOT raw-i64-eligible"
+    );
+    assert_eq!(r.raw_i64_eligible(), 0);
+}
+
+#[test]
+fn positive_is_not_raw_i64_eligible() {
+    // [1,+inf] → open upper bound → NOT eligible.
+    let src = include_str!("../examples/refinement/positive/positive.av");
+    let r = analyze_src(src);
+    let t = only_type(&r, "Positive");
+    assert!(!t.raw_i64_eligible());
+    assert_eq!(r.raw_i64_eligible(), 0);
+}
+
+#[test]
+fn aggregate_eligible_matches_explain_passes_count() {
+    // The aggregate the `--explain-passes` `raw_i64_eligible: N` field
+    // reports is the count of per-type eligible determinations. For the
+    // shipped IntRange program that is exactly 1.
+    let src = include_str!("../examples/refinement/int_range/int_range.av");
+    let r = analyze_src(src);
+    let by_hand = r.types.values().filter(|t| t.raw_i64_eligible()).count();
+    assert_eq!(r.raw_i64_eligible(), by_hand);
+    assert_eq!(r.raw_i64_eligible(), 1);
+}
+
 // ── soundness regressions: no spurious OverflowFree ────────────────
 //
 // Three independent under-approximations once let the analysis certify

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -314,6 +314,14 @@ fn int_range_persists_two_sided_interval_and_overflow_free_add() {
         OpClass::OverflowFree,
         "IntRange.add intermediate [0,200] fits i64 → persisted OverflowFree"
     );
+
+    // The persisted-fact recognizer (the gate a later carrier-lowering
+    // slice trusts, read off the decl WITHOUT the diagnostic flag):
+    // two-sided i64-fitting interval + every op OverflowFree → eligible.
+    assert!(
+        decl.raw_i64_eligible(),
+        "IntRange [0,100], `add` OverflowFree → persisted decl is raw-i64-eligible"
+    );
 }
 
 #[test]
@@ -336,6 +344,13 @@ fn natural_persists_one_sided_interval_and_unbounded_ops() {
     // finite bound, so every op persists `Unbounded` (must stay bignum).
     assert_eq!(persisted_op_class(decl, "add"), OpClass::Unbounded);
     assert_eq!(persisted_op_class(decl, "mul"), OpClass::Unbounded);
+
+    // One-sided interval (open upper bound) → the persisted decl is NOT
+    // raw-i64-eligible: the carrier could not fit a machine word.
+    assert!(
+        !decl.raw_i64_eligible(),
+        "Natural's open upper bound → persisted decl NOT raw-i64-eligible"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Adds `raw_i64_eligible`, a per-refined-type predicate derived from the persisted interval + per-operation overflow classification: `true` when the carrier interval is two-sided and fits `i64` **and** every analysed carrier-arithmetic op is overflow-free. Surfaced as an aggregate count in `--explain-passes` (human + JSON).

Pure diagnostic — no codegen, runtime, or proof change. Nothing consumes the determination yet; it just measures that the recognizer fires on the right types.

## Behaviour

- `IntRange` (`0..=100`, `add` overflow-free) → `raw_i64_eligible: 1`.
- `Natural` / `Positive` (one-sided) → `0`.

The recognizer logic is a single shared function used by both the persisted-fact path (`RefinedTypeDecl::raw_i64_eligible`, which codegen will read) and the diagnostic path, so the two can never disagree.

## Whitelist semantics (documented on the predicate)

The op set the predicate checks is the set of carrier-**arithmetic** ops the analysis examined — not every op the type exposes. An op whose overflow risk lives inside a *called helper* (no arithmetic operator in its own body) is intentionally not enumerated. So `true` does not assert "every operation is overflow-free"; it asserts the carrier may be **stored** as `i64` and the enumerated overflow-free ops may use direct `i64` arithmetic. A future carrier-lowering must therefore read every **other** carrier access as a bignum integer. This contract is spelled out in the predicate doc-comment so the lowering step cannot misread eligibility.

## Tests

7 direct predicate unit tests (incl. mixed overflow-free + unbounded → not eligible, needs-wider-scratch → not eligible, doesn't-fit-`i64` → not eligible, declined interval → not eligible, empty op set → eligible-for-storage), plus pipeline-driven and `--explain-passes` assertions on the real example types. Full suite green; zero behaviour change.

Refs #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
