### PR TITLE
fix: convert Int to i64 at the two wasm-feature entry boundaries

### DIFF
--- a/src/playground.rs
+++ b/src/playground.rs
@@ -227,7 +227,14 @@ fn value_to_literal_expr(
 ) -> Result<crate::ast::Spanned<crate::ast::Expr>, String> {
     use crate::ast::{Expr, Literal, Spanned};
     let lit = match v {
-        crate::value::Value::Int(n) => Literal::Int(*n),
+        crate::value::Value::Int(n) => match n.to_i64() {
+            Some(i) => Literal::Int(i),
+            None => {
+                return Err(format!(
+                    "synthetic `__entry__` only supports Int args within 64-bit range; got {n}"
+                ));
+            }
+        },
         crate::value::Value::Float(f) => Literal::Float(*f),
         crate::value::Value::Str(s) => Literal::Str(s.clone()),
         crate::value::Value::Bool(b) => Literal::Bool(*b),

--- a/src/runtime/wasm_gc/decode.rs
+++ b/src/runtime/wasm_gc/decode.rs
@@ -122,7 +122,16 @@ pub(super) fn encode_entry_args_for_wasm_gc(
     let mut out = Vec::with_capacity(args.len());
     for (idx, value) in args.iter().enumerate() {
         let val = match value {
-            Value::Int(n) => Val::I64(*n),
+            Value::Int(n) => match n.to_i64() {
+                Some(i) => Val::I64(i),
+                None => {
+                    return Err(format!(
+                        "wasm-gc entry arg #{}: Int value out of 64-bit range \
+                         (the wasm-gc backend uses 64-bit integers)",
+                        idx + 1
+                    ));
+                }
+            },
             Value::Float(f) => Val::F64(f.to_bits()),
             Value::Bool(b) => Val::I32(if *b { 1 } else { 0 }),
             Value::Unit => continue, // Unit-typed param: no slot.


### PR DESCRIPTION
## What

The arbitrary-precision `Int` change (#514) missed two `Value::Int` match sites that only compile under `--features wasm`, so the default `cargo build` / `cargo test` did not catch them and the WASM CI job failed to compile:

- `src/runtime/wasm_gc/decode.rs` — the wasm-gc entry-arg encoder fed the carrier into a wasmtime `Val::I64`.
- `src/playground.rs` — the synthetic-entry value-to-literal mapper fed it into an AST `Literal::Int` (i64).

Both now go through the checked `AverInt::to_i64()` and return a clear error when the value exceeds 64 bits (the wasm-gc backend and the AST `Int` literal are both 64-bit).

Verified locally with the exact failing command: `cargo clippy -p aver-lang --lib --bin aver --features wasm,wasip2 -- -D warnings` — clean.

Refs #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
