### PR TITLE
docs: document that `aver run` allows module-less files while `aver check` requires `module`

### DIFF
--- a/.claude/commands/aver.md
+++ b/.claude/commands/aver.md
@@ -123,6 +123,7 @@ module Billing
 
 Rules:
 - `module` must be the first top-level item in file-based programs
+- `aver run` will execute a single file with no `module` as a convenience for quick throwaway scripts, but `aver check` requires the declaration (`error[missing-module]`) — declare `module <Name>` for anything you intend to keep, import, or check
 - `intent` may be inline or multiline; formatter prefers multiline for multiline text
 - `depends [...]` and `exposes [...]` are explicit
 - opaque types: `exposes opaque [Discount]` — visible in signatures but cannot be constructed or destructured from outside

--- a/tools/website/llms.txt
+++ b/tools/website/llms.txt
@@ -180,6 +180,7 @@ module Billing
 
 Rules:
 - `module` must be the first top-level item in file-based programs
+- `aver run` will execute a single file with no `module` as a convenience for quick throwaway scripts, but `aver check` requires the declaration (`error[missing-module]`) — declare `module <Name>` for anything you intend to keep, import, or check
 - `intent` may be inline or multiline; formatter prefers multiline for multiline text
 - `depends [...]` and `exposes [...]` are explicit
 - opaque types: `exposes opaque [Discount]` — visible in signatures but cannot be constructed or destructured from outside


### PR DESCRIPTION
## What

One sentence added to the language guide (`.claude/commands/aver.md`, regenerated into `tools/website/llms.txt`) documenting the one place `aver run` and `aver check` diverge on accept/reject:

- a single file with **no** `module` declaration **runs** fine under `aver run` (convenience for quick throwaway scripts)
- but `aver check` rejects it with `error[missing-module]`

The guide already says `module` must be the first top-level item; this just makes the run-vs-check asymmetry explicit so models (and quick-script authors) aren't surprised.

## Why

The AILANG benchmark harness uses `aver run` as the authoritative grader and surfaced this asymmetry. The behaviour is intentional — `run` stays lenient for throwaway scripts — so no code change, only the doc note.

## Scope

Docs only. `llms-full.txt` / `docs/cli.md` are unchanged (they build from the toolchain skill, not the language guide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)