### PR TITLE
Add agent-discovered helper-law decompositions (12 Lean closures) + the-method skill

### DIFF
--- a/.claude/skills/the-method/SKILL.md
+++ b/.claude/skills/the-method/SKILL.md
@@ -1,0 +1,55 @@
+---
+description: The Method — close an OPEN Aver proof law by having an agent propose auxiliary helper lemmas, test them with `aver proof --discover`/`--check`, and refine until the Lean kernel / Z3 certifies the law. Works on any Aver project; the agent proposes, the judge decides.
+allowed-tools: Bash, Read, Write, Workflow
+---
+
+# The Method
+
+A reusable loop for closing an OPEN Aver `verify ... law` in **any** Aver project. An agent
+PROPOSES auxiliary helper lemmas, `aver` TESTS them, and the Lean kernel / Z3 JUDGES whether the
+target law now closes — looping until it closes or a budget runs out. The LLM proposer is the only
+unbounded source of new lemmas; the judge keeps it sound.
+
+## When to use
+- A `verify ... law` is open in Lean (often already provable by Z3/Dafny — then this kernel-
+  certifies it in Lean).
+- A goal that needs an auxiliary lemma the auto-prover can't find on its own (a missing
+  homomorphism / associativity / distributivity / an equation relating subterms of the goal).
+
+## Usage
+```
+/the-method <task.av> [<task2.av> ...]
+```
+Run from your Aver project root. Paths are relative to that root, or absolute. The loop auto-detects
+the `aver` binary (`./target/release/aver`, `./target/debug/aver`, or `aver` on PATH; it will build
+it if missing). You can also invoke the engine directly:
+```
+Workflow({ scriptPath: "<this-skill-dir>/the-method-loop.js", args: { tasks: ["path/to/task.av"], attempts: 4 } })
+```
+
+## How it runs
+One autonomous agent per task (in parallel). Each agent:
+1. Reads the target task; if the project has example decompositions (e.g. a `decomposed/`
+   directory of solved tasks), learns the exact splice form from one of them.
+2. Proposes 1–3 true, general helper laws aimed at the open goal (not a restatement of it).
+3. Splices them into a `/tmp` copy — **before** the target `verify ... law` (order matters; rendering
+   matters too) — and runs `aver proof <scratch> --discover -o <dir>` then
+   `aver proof <scratch> --check --check-json --backend lean -o <dir>`; success ⟺ `"universal":true`.
+4. Refines on failure, up to `attempts` tries.
+
+Then a **Verify** phase independently re-checks each claimed closure from scratch (a separate agent,
+a fresh dir) — a self-reported closure is not trusted on its own. Only verified closures are
+returned.
+
+## Output
+Per task: `closed`, `verified`, `attempts`, `helperLaws` ({name, source}), `summary`; plus a
+`verifiedClosed` count and a `winners` list ([{task, helperLaws}]) ready to save as `decomposed/`
+entries.
+
+## Do no harm
+Keep a proposed lemma set only if the augmented task still closes — never let a committed lemma
+regress a proof that worked without it.
+
+## Safety
+READ-ONLY on the project. All edits happen on `/tmp` scratch copies. The loop never runs
+state-changing `git` commands and never modifies project files.

--- a/.claude/skills/the-method/the-method-loop.js
+++ b/.claude/skills/the-method/the-method-loop.js
@@ -1,0 +1,119 @@
+export const meta = {
+  name: 'the-method',
+  description: 'The Method: an agent proposes helper lemmas -> aver tests -> Lean/Z3 judges -> refine, with an independent verify gate. Closes open Aver proof laws on any Aver project.',
+  phases: [
+    { title: 'Method', detail: 'one agent per open task: propose helper lemmas, test with aver, refine until Lean closes or budget out' },
+    { title: 'Verify', detail: "independent re-verify of each self-reported closure (fresh dir) — the proposer's own verdict is not trusted" },
+  ],
+}
+
+// Inputs (via Workflow `args`): either an array of task .av paths, or { tasks: [...], attempts? }.
+// Paths are relative to the project root (the cwd the workflow runs in) or absolute.
+let a = typeof args === 'string'
+  ? (() => { try { return JSON.parse(args) } catch { return args.trim() ? [args.trim()] : null } })()
+  : args
+const TASKS = Array.isArray(a) ? a : (a && Array.isArray(a.tasks) ? a.tasks : [])
+const MAX_ATTEMPTS = (a && a.attempts) || 4
+if (!TASKS.length) {
+  log('the-method: pass one or more Aver task .av paths as args, e.g. { tasks: ["path/to/task.av"] }')
+  return { error: 'no tasks given' }
+}
+log(`The Method: ${TASKS.length} task(s), up to ${MAX_ATTEMPTS} attempts each`)
+
+const RESULT_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['task', 'closed', 'attempts', 'helperLaws', 'finalError', 'summary'],
+  properties: {
+    task: { type: 'string' },
+    closed: { type: 'boolean', description: 'true iff the augmented task reached "universal":true on Lean' },
+    attempts: { type: 'integer' },
+    helperLaws: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false, required: ['name', 'source'],
+        properties: { name: { type: 'string' }, source: { type: 'string', description: 'the helper law as valid Aver source' } },
+      },
+    },
+    finalError: { type: 'string', description: 'empty if closed, else short Lean error / reason it stayed open' },
+    summary: { type: 'string', description: '2-3 sentences: what was tried and why it did/did not work' },
+  },
+}
+
+const FIND_AVER = 'Locate the aver binary: try ./target/release/aver, then ./target/debug/aver, then `aver` on PATH; if none exists, run `cargo build --bin aver` first.'
+const SAFETY = 'SAFETY: READ-ONLY on the project. Do ALL edits on COPIES under /tmp. Never run state-changing git commands and never modify project files.'
+
+const METHOD_PROMPT = (t) => `You ARE "The Method": close an OPEN Aver proof obligation by proposing auxiliary helper lemmas, testing them with the Aver toolchain, and refining on failure. You propose; the Lean kernel / Z3 judges.
+
+You are working inside an Aver project (the current working directory).
+- ${FIND_AVER}
+- TARGET task file (contains an OPEN "verify ... law"): ${t}  (relative to the project root, or absolute).
+
+${SAFETY}
+
+STEP 1 — understand the mechanism for THIS project:
+- Read the target task: its datatypes, functions, and the OPEN law.
+- If the project has example decompositions (e.g. a "decomposed/" directory of already-solved tasks), read one solved task plus its base to learn EXACTLY how helper laws are written into a .av. The closing command sequence is:
+    <aver> proof <scratch.av> --discover -o <dir>            (proves + commits the helper lemmas)
+    <aver> proof <scratch.av> --check --check-json --backend lean -o <dir>   (SAME dir; closed <=> output contains "universal":true)
+
+STEP 2 — the loop (max ${MAX_ATTEMPTS} attempts; stop the instant it closes):
+1. Propose 1-3 TRUE, GENERAL helper laws about the task's OWN functions that the main proof needs — a missing homomorphism / associativity / distributivity / an equation relating subterms of the goal. Do NOT merely restate the goal.
+2. Copy the target to a fresh /tmp scratch and splice the helper laws in BEFORE the target "verify ... law" line. ORDER MATTERS (appending at the END can fail to fire); RENDERING MATTERS (how a constructor/operator is written changes how it elaborates). Valid Aver only: first-order, no closures.
+3. Run discover then check into a FRESH /tmp dir. Closed <=> "universal":true with "sorries":0.
+4. Retry once on a transient lake error. On failure, read the Lean error / see which helper failed, refine, try again.
+
+Return: task="${t}"; closed (bool); attempts used; helperLaws = the WINNING set [{name, source}] if closed (else your best attempt); finalError ("" if closed); summary (2-3 sentences).`
+
+// VERIFY GATE — an autonomous agent's self-reported `closed` is not trustworthy on its own. An
+// INDEPENDENT agent re-checks each claimed closure from scratch before we count it.
+const VERIFY_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['verified', 'note'],
+  properties: {
+    verified: { type: 'boolean', description: 'true ONLY if you yourself observed "universal":true with "sorries":0 on the augmented task' },
+    note: { type: 'string', description: '1-2 sentences: observed universal/sorries values, or why it failed' },
+  },
+}
+
+const VERIFY_PROMPT = (t, helperLaws) => `INDEPENDENT verification gate. Do NOT trust any prior "closed" claim — verify from scratch yourself.
+You are in an Aver project. ${FIND_AVER}
+- TARGET (OPEN in baseline): ${t}
+- candidate helper laws (JSON): ${JSON.stringify(helperLaws)}
+
+Steps:
+1. Copy ${t} to a fresh /tmp scratch.
+2. Splice the helper laws in BEFORE the target "verify ... law" line (order and rendering matter — appending at the end can fail). Use the helper source strings verbatim.
+3. Run: <aver> proof <scratch> --discover -o <freshdir> ; then <aver> proof <scratch> --check --check-json --backend lean -o <freshdir>.
+4. verified = true ONLY if the check output contains "universal":true AND "sorries":0. Retry once on a transient lake error.
+5. Sanity: confirm the BASE task (no helpers) is still OPEN ("universal":true ABSENT).
+${SAFETY}
+Return: verified (bool), note.`
+
+phase('Method')
+// pipeline: each task is proposed, then (if self-reported closed) independently verified — no
+// barrier, so verification starts the moment an agent finishes.
+const results = (await pipeline(
+  TASKS,
+  (t) => agent(METHOD_PROMPT(t), { label: `method:${t}`, phase: 'Method', schema: RESULT_SCHEMA, agentType: 'general-purpose' }),
+  (r, t) => {
+    if (!r) return { task: t, closed: false, verified: false, attempts: 0, helperLaws: [], finalError: 'agent died', summary: '' }
+    if (!r.closed) return { ...r, verified: false }
+    return agent(VERIFY_PROMPT(r.task, r.helperLaws), { label: `verify:${r.task}`, phase: 'Verify', schema: VERIFY_SCHEMA, agentType: 'general-purpose' })
+      .then((v) => ({ ...r, verified: !!(v && v.verified), verifyNote: v ? v.note : 'verifier died' }))
+  },
+)).filter(Boolean)
+
+for (const r of results) {
+  const status = r.closed ? (r.verified ? 'CLOSED+VERIFIED' : 'self-CLOSED but VERIFY FAILED') : 'open'
+  log(`${r.task}: ${status}`)
+}
+const verifiedClosed = results.filter((r) => r.closed && r.verified)
+const overReported = results.filter((r) => r.closed && !r.verified)
+log(`The Method: ${verifiedClosed.length}/${results.length} verified-closed${overReported.length ? ` (${overReported.length} self-reported but failed verification)` : ''}`)
+return {
+  verifiedClosed: verifiedClosed.length,
+  selfReported: results.filter((r) => r.closed).length,
+  total: results.length,
+  winners: verifiedClosed.map((r) => ({ task: r.task, helperLaws: r.helperLaws })),
+  results,
+}

--- a/proof-corpus/decomposed/isaplanner/prop_05.av
+++ b/proof-corpus/decomposed/isaplanner/prop_05.av
@@ -1,0 +1,40 @@
+module Prop05
+    intent =
+        "TIP isaplanner prop_05: n = x => S (count n xs) = count n (cons x xs)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match eqNat(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+verify count law countCons
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    when eqNat(n, x)
+    Nat.S(count(n, xs)) => count(n, List.concat([x], xs))
+
+verify eqNat law eqNatRefl
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    eqNat(n, n) => true
+
+verify count law countConsEq
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    Nat.S(count(n, xs)) => count(n, List.concat([n], xs))

--- a/proof-corpus/decomposed/isaplanner/prop_51.av
+++ b/proof-corpus/decomposed/isaplanner/prop_51.av
@@ -1,0 +1,23 @@
+module Prop51
+    intent =
+        "TIP isaplanner prop_51: butlast (xs ++ [x]) = xs."
+    effects []
+
+fn butlast(xs: List<Int>) -> List<Int>
+    match xs
+        [] -> []
+        [y, ..z] -> match z
+            [] -> []
+            [x2, ..x3] -> List.concat([y], butlast(z))
+
+
+verify butlast law butlastConsSnoc
+    given y: Int = [1, 7]
+    given ys: List<Int> = [[], [2], [2, 3]]
+    given z: Int = [0, 5]
+    butlast(List.prepend(y, List.concat(ys, [z]))) => List.prepend(y, butlast(List.concat(ys, [z])))
+
+verify butlast law butlastAppendSingleton
+    given xs: List<Int> = [[], [1], [1, 2, 3]]
+    given x: Int = [0, 5, 9]
+    butlast(List.concat(xs, [x])) => xs

--- a/proof-corpus/decomposed/prod/lemma_05.av
+++ b/proof-corpus/decomposed/prod/lemma_05.av
@@ -1,0 +1,37 @@
+module Lemma05
+    intent =
+        "TIP prod lemma_05: drop (S v) (drop (S w) (x::y::zs)) = drop (S v) (drop w (x::zs))."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn drop(x: Nat, y: List<Int>) -> List<Int>
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> match y
+            [] -> []
+            [x2, ..x3] -> drop(z, x3)
+
+
+verify drop law dropSuccCons
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given a: Int = [1, 2, 3]
+    given y: List<Int> = [[], [7], [7, 8]]
+    drop(Nat.S(x), List.concat([a], y)) => drop(x, y)
+
+verify drop law dropOuterHeadNorm
+    given v: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given a: Int = [1, 2, 3]
+    given y: List<Int> = [[], [7], [7, 8]]
+    drop(Nat.S(v), drop(x, List.concat([a], y))) => drop(Nat.S(v), drop(x, List.concat([0], y)))
+
+verify drop law dropDropCons
+    given v: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given w: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given x: Int = [1, 2, 3]
+    given y: Int = [4, 5, 6]
+    given zs: List<Int> = [[], [7], [7, 8]]
+    drop(Nat.S(v), drop(Nat.S(w), List.concat([x], List.concat([y], zs)))) => drop(Nat.S(v), drop(w, List.concat([x], zs)))

--- a/proof-corpus/decomposed/prod/lemma_16.av
+++ b/proof-corpus/decomposed/prod/lemma_16.av
@@ -1,0 +1,35 @@
+module Lemma16
+    intent =
+        "TIP prod lemma_16: even(x + y) = even(x + S(S(y)))."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn even(x: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(y) -> match y
+            Nat.Z -> false
+            Nat.S(z) -> even(z)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+
+verify plus law plusSuccRight
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    plus(x, Nat.S(y)) => Nat.S(plus(x, y))
+
+verify even law evenSuccSucc
+    given z: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    even(Nat.S(Nat.S(z))) => even(z)
+
+verify even law evenPlusShift
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    even(plus(x, y)) => even(plus(x, Nat.S(Nat.S(y))))

--- a/proof-corpus/decomposed/prod/lemma_19.av
+++ b/proof-corpus/decomposed/prod/lemma_19.av
@@ -1,0 +1,59 @@
+module Lemma19
+    intent =
+        "TIP prod lemma_19: x /= y and elem x (insert y z) implies elem x z."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn barbar(x: Bool, y: Bool) -> Bool
+    match x
+        true -> true
+        false -> y
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> barbar(eqNat(x, z), elem(x, xs))
+
+fn lessEq(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> lessEq(z, x2)
+
+fn insert(x: Nat, y: List<Nat>) -> List<Nat>
+    match y
+        [] -> [x]
+        [z, ..xs] -> match lessEq(x, z)
+            true -> List.concat([x], y)
+            false -> List.concat([z], insert(x, xs))
+
+fn neqNat(x: Nat, y: Nat) -> Bool
+    match eqNat(x, y)
+        true -> false
+        false -> true
+
+verify elem law insertElemImplies
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.S(Nat.Z), Nat.Z, Nat.S(Nat.S(Nat.Z))]
+    given z: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    when neqNat(x, y)
+    elem(x, insert(y, z)) => elem(x, z)
+
+verify elem law elemConcat
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given a: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    given b: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    elem(x, List.concat(a, b)) => barbar(elem(x, a), elem(x, b))

--- a/proof-corpus/decomposed/prod/lemma_21.av
+++ b/proof-corpus/decomposed/prod/lemma_21.av
@@ -1,0 +1,54 @@
+module Lemma21
+    intent =
+        "TIP prod lemma_21: x /= y => count x (insert y z) = count x z."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..xs] -> match eqNat(x, z)
+            true -> Nat.S(count(x, xs))
+            false -> count(x, xs)
+
+fn lessEq(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> lessEq(z, x2)
+
+fn insert(x: Nat, y: List<Nat>) -> List<Nat>
+    match y
+        [] -> [x]
+        [z, ..xs] -> match lessEq(x, z)
+            true -> List.concat([x], y)
+            false -> List.concat([z], insert(x, xs))
+
+fn notEqNat(x: Nat, y: Nat) -> Bool
+    match eqNat(x, y)
+        true -> false
+        false -> true
+
+verify count law countInsertNeq
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.S(Nat.Z), Nat.Z, Nat.S(Nat.S(Nat.Z))]
+    given z: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    when notEqNat(x, y)
+    count(x, insert(y, z)) => count(x, z)
+
+verify eqNat law eqNatRefl
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    eqNat(x, x) => true

--- a/proof-corpus/decomposed/prod/prop_05.av
+++ b/proof-corpus/decomposed/prod/prop_05.av
@@ -1,0 +1,28 @@
+module Prop05
+    intent =
+        "TIP prod prop_05: length (rev x) = length x."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(x: List<Int>) -> Nat
+    match x
+        [] -> Nat.Z
+        [y, ..xs] -> Nat.S(length(xs))
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..xs] -> List.concat(rev(xs), [y])
+
+
+verify length law lengthSnoc
+    given a: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given y: Int = [1, 2]
+    length(List.concat(a, [y])) => Nat.S(length(a))
+
+verify length law revPreservesLength
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    length(rev(x)) => length(x)

--- a/proof-corpus/decomposed/prod/prop_24.av
+++ b/proof-corpus/decomposed/prod/prop_24.av
@@ -1,0 +1,31 @@
+module Prop24
+    intent =
+        "TIP prod prop_24: even (x + y) = even (y + x)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn even(x: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(y) -> match y
+            Nat.Z -> false
+            Nat.S(z) -> even(z)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+
+verify plus law plusComm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, y) => plus(y, x)
+
+verify even law evenPlusComm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    even(plus(x, y)) => even(plus(y, x))

--- a/proof-corpus/decomposed/prod/prop_26.av
+++ b/proof-corpus/decomposed/prod/prop_26.av
@@ -1,0 +1,31 @@
+module Prop26
+    intent =
+        "TIP prod prop_26: half (x + y) = half (y + x)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn half(x: Nat) -> Nat
+    match x
+        Nat.Z -> Nat.Z
+        Nat.S(y) -> match y
+            Nat.Z -> Nat.Z
+            Nat.S(z) -> Nat.S(half(z))
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+
+verify plus law plusComm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, y) => plus(y, x)
+
+verify half law halfPlusComm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.S(Nat.Z), Nat.Z, Nat.S(Nat.S(Nat.Z))]
+    half(plus(x, y)) => half(plus(y, x))

--- a/proof-corpus/decomposed/prod/prop_37.av
+++ b/proof-corpus/decomposed/prod/prop_37.av
@@ -1,0 +1,49 @@
+module Prop37
+    intent =
+        "TIP prod prop_37: elem x z => elem x (y ++ z)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn barbar(x: Bool, y: Bool) -> Bool
+    match x
+        true -> true
+        false -> y
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> barbar(eqNat(x, z), elem(x, xs))
+
+fn append(x: List<Nat>, y: List<Nat>) -> List<Nat>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+verify elem law elemAppend
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    given z: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z)], [Nat.Z, Nat.S(Nat.Z)]]
+    when elem(x, z)
+    elem(x, append(y, z)) => true
+
+verify barbar law barbarTrueRight
+    given x: Bool = [true, false]
+    barbar(x, true) => true
+
+verify elem law elemAppendHomo
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    given z: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z)], [Nat.Z, Nat.S(Nat.Z)]]
+    elem(x, append(y, z)) => barbar(elem(x, y), elem(x, z))

--- a/proof-corpus/decomposed/prod/prop_41.av
+++ b/proof-corpus/decomposed/prod/prop_41.av
@@ -1,0 +1,58 @@
+module Prop41
+    intent =
+        "TIP prod prop_41: subset x y implies intersect x y = x."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn barbar(x: Bool, y: Bool) -> Bool
+    match x
+        true -> true
+        false -> y
+
+fn andd(x: Bool, y: Bool) -> Bool
+    match x
+        true -> y
+        false -> false
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> barbar(eqNat(x, z), elem(x, xs))
+
+fn intersect(x: List<Nat>, y: List<Nat>) -> List<Nat>
+    match x
+        [] -> []
+        [z, ..xs] -> match elem(z, y)
+            true -> List.concat([z], intersect(xs, y))
+            false -> intersect(xs, y)
+
+fn subset(x: List<Nat>, y: List<Nat>) -> Bool
+    match x
+        [] -> true
+        [z, ..xs] -> andd(elem(z, y), subset(xs, y))
+
+verify intersect law subsetIntersect
+    given x: List<Nat> = [[], [Nat.Z], [Nat.Z, Nat.S(Nat.Z)]]
+    given y: List<Nat> = [[], [Nat.Z], [Nat.Z, Nat.S(Nat.Z)]]
+    when subset(x, y)
+    intersect(x, y) => x
+
+verify andd law anddTrueRight
+    given x: Bool = [true, false]
+    andd(x, true) => x
+
+verify eqNat law eqNatRefl
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    eqNat(x, x) => true

--- a/proof-corpus/decomposed/prod/prop_47.av
+++ b/proof-corpus/decomposed/prod/prop_47.av
@@ -1,0 +1,57 @@
+module Prop47
+    intent =
+        "TIP prod prop_47: x /= y => elem x (insert y z) = elem x z."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn barbar(x: Bool, y: Bool) -> Bool
+    match x
+        true -> true
+        false -> y
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> barbar(eqNat(x, z), elem(x, xs))
+
+fn lessEq(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> lessEq(z, x2)
+
+fn insert(x: Nat, y: List<Nat>) -> List<Nat>
+    match y
+        [] -> [x]
+        [z, ..xs] -> match lessEq(x, z)
+            true -> List.concat([x], y)
+            false -> List.concat([z], insert(x, xs))
+
+fn notEq(x: Nat, y: Nat) -> Bool
+    match eqNat(x, y)
+        true -> false
+        false -> true
+
+verify elem law insertElem
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.S(Nat.Z), Nat.Z, Nat.S(Nat.S(Nat.Z))]
+    given z: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    when notEq(x, y)
+    elem(x, insert(y, z)) => elem(x, z)
+
+verify barbar law barbarFalse
+    given b: Bool = [true, false]
+    barbar(false, b) => b


### PR DESCRIPTION
## What

Twelve previously-open dafny-only TIP proof tasks now close in **Lean**
(kernel-clean, `universal:true`, 0 sorries, no extra axioms) by adding auxiliary
**helper laws** under `proof-corpus/decomposed/`, plus a `.claude/skills/the-method`
skill that produced them.

## Why

On this corpus, mechanical `aver proof --discover` proves many lemmas but converts
**0** open tasks to closed (and can even regress working proofs). These twelve are
genuine conversions: an agent proposes helper laws aimed at the specific open goal,
the Lean kernel / Z3 judges, and the loop refines until the target law closes. All
were Lean-open but Z3-proved (dafny-only) -> now kernel-certified in Lean.

## How they were produced

`.claude/skills/the-method` runs a propose -> test -> judge loop:
1. An LLM proposes 1-3 true helper laws for an open task.
2. `aver proof --discover` kernel-proves them; `aver proof --check` decides whether
   the target law closes via the SimpOverLemmas feedback.
3. Refine on failure. An independent **Verify** step then re-checks each claimed
   closure from scratch -- a self-reported closure is not trusted on its own (a scale
   run had ~14% over-reports).

Scale run: 22 dafny-only targets with no existing `decomposed/` solution -> 14
self-reported closed, **12 independently verified** (~55%). The 8 that stayed open
are one located tactic-coverage gap in the Lean backend's induction templates
(`last`/`butlast` matching on the tail), not false conjectures.

## Scope / risk

No compiler change -- corpus data and tooling only. `proof-corpus/decomposed/` is not
wired into the test gate, and no Rust changed, so CI is unaffected. Each of the twelve
re-verified `universal:true` on a clean build before inclusion.

Tasks: isaplanner prop_05, prop_51; prod lemma_05, lemma_16, lemma_19, lemma_21,
prop_05, prop_24, prop_26, prop_37, prop_41, prop_47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
