### PR TITLE
perf(rust): unbox provably-bounded non-escaping Int counters to bare i64

### DIFF
--- a/docs/research.md
+++ b/docs/research.md
@@ -98,6 +98,22 @@ closest research context for Aver's design choices.
   economics of a prover steered by source-language lemmas.
   https://doi.org/10.1098/rsta.2015.0399
 
+## Integer Range Analysis
+
+- Raphael Ernani Rodrigues, Victor Hugo Sperle Campos, and Fernando Magno
+  Quintão Pereira, **A Fast and Low-Overhead Technique to Secure Programs
+  Against Integer Overflows** (CGO 2013). A sparse range analysis proves the
+  large majority of integer operations stay within machine-word bounds, so the
+  few that remain can be guarded cheaply. Aver's unboxing analysis shares the
+  goal of proving an integer stays in i64 range, but uses it for representation
+  selection — a provably-bounded `Int` lowers to a native `i64` instead of the
+  default arbitrary-precision carrier — rather than to insert runtime overflow
+  checks. Aver has no loops (tail recursion only), so the paper's loop-header
+  "future bounds" do not apply directly; Aver bounds a counter through a
+  bounded-tail-recursion recognizer over its own interval domain, and is
+  fail-closed (an unproven value stays arbitrary-precision).
+  https://doi.org/10.1109/CGO.2013.6494996
+
 ## Not Currently Claimed
 
 Aver is also broadly adjacent to monads, property-based testing, model checking,

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -2963,6 +2963,7 @@ mod tests {
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,
+            bare_i64: Default::default(),
             discovered_lemmas: Vec::new(),
             sample_expected: std::collections::HashMap::new(),
         };

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -221,6 +221,7 @@ mod tests {
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,
+            bare_i64: Default::default(),
             discovered_lemmas: Vec::new(),
             sample_expected: std::collections::HashMap::new(),
         }

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -62,6 +62,7 @@ fn empty_ctx() -> CodegenContext {
         resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
         program_shape: None,
         mir_program: None,
+        bare_i64: Default::default(),
         discovered_lemmas: Vec::new(),
         sample_expected: std::collections::HashMap::new(),
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -330,6 +330,14 @@ pub struct CodegenContext {
     /// runtime codegen after the HIR walker's deletion (W6/Stage-3).
     /// `None` for hand-assembled test contexts that skip `build_context`.
     pub mir_program: Option<crate::ir::mir::MirProgram>,
+    /// Per-`(FnId, LocalId)` bare-`i64` representation facts for the Int
+    /// "unboxing" optimization, computed from `mir_program` by
+    /// `bare_i64::analyze`. The Rust backend reads a per-fn slice at
+    /// signature + body emit to select native `i64` vs the default
+    /// `aver_rt::AverInt` for provably-bounded, non-escaping Int values.
+    /// Fail-closed: empty (all-`Boxed`) for hand-assembled test contexts
+    /// and for dependency-module fragments (callers unseen).
+    pub bare_i64: crate::ir::mir::BareI64Facts,
     /// Kernel-proved lemmas parsed back from a committed
     /// `DiscoveredLemmas.lean` (the `--discover` artifact), set by the CLI
     /// on a normal `aver proof` run when the discovery-surface hash still
@@ -603,6 +611,15 @@ pub fn build_context(
         )))
     };
 
+    // Int "unboxing": derive the per-(FnId, LocalId) bare-`i64`
+    // representation facts from the optimized MIR. Read-only — never
+    // mutates the program. Empty (all-`Boxed`) when there is no MIR
+    // (defensive) or for fragments the analysis bails on.
+    let bare_i64 = mir_program
+        .as_ref()
+        .map(crate::ir::mir::bare_i64::analyze)
+        .unwrap_or_default();
+
     let ctx = CodegenContext {
         items,
         type_defs,
@@ -622,6 +639,7 @@ pub fn build_context(
         buffer_build_sinks,
         buffer_fusion_sites,
         synthesized_buffered_fns,
+        bare_i64,
         #[cfg(feature = "runtime")]
         proof_ir: crate::ir::ProofIR::default(),
         // Symbol table threaded through from the pipeline (or

--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -346,6 +346,7 @@ pub(super) fn emit_dispatch_table_match<F>(
     subject: String,
     arms: &[ResolvedMatchArm],
     shape: &DispatchTableShape,
+    subject_is_bare: bool,
     body_for_arm: F,
 ) -> String
 where
@@ -375,7 +376,7 @@ where
         .rev()
         .fold(fallback, |else_branch, entry| {
             let arm = &arms[entry.arm_index];
-            let cond = emit_dispatch_condition(subject_name, &entry.pattern);
+            let cond = emit_dispatch_condition(subject_name, &entry.pattern, subject_is_bare);
             let body = emit_dispatch_arm_body(subject_name, arm, entry, &body_for_arm);
             format!("if {} {{ {} }} else {{ {} }}", cond, body, else_branch)
         });
@@ -452,12 +453,24 @@ where
     Some(format!("match {} {{ {} }}", subject, match_arms.join(", ")))
 }
 
-fn emit_dispatch_condition(subject_name: &str, pattern: &SemanticDispatchPattern) -> String {
+fn emit_dispatch_condition(
+    subject_name: &str,
+    pattern: &SemanticDispatchPattern,
+    subject_is_bare: bool,
+) -> String {
     match pattern {
         SemanticDispatchPattern::Literal(lit) => match lit {
             // `AverInt: PartialEq`, so an equality guard works directly;
             // `AverInt` cannot be a `match` pattern literal, hence the
-            // dispatch path lowers Int-literal arms to guards.
+            // dispatch path lowers Int-literal arms to guards. A bare-`i64`
+            // subject (a proven-bare counter, `Copy`) compares against a raw
+            // `{K}i64` literal — comparing it against `AverInt::from_i64(K)`
+            // would be `i64 == AverInt` (`rustc` E0308). This mirrors the
+            // single-arm `try_emit_int_literal_match` `subject_is_bare` path
+            // so the ≥2-literal-arm dispatch table stays in the fast loop.
+            DispatchLiteral::Int(i) if subject_is_bare => {
+                format!("{subject_name} == {i}i64")
+            }
             DispatchLiteral::Int(i) => {
                 format!("{subject_name} == aver_rt::AverInt::from_i64({i})")
             }

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -1257,6 +1257,19 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             // shape.
             let let_node = &spanned_let.node;
             let value = emit_mir_expr(&let_node.value, emit_ctx)?;
+            // Int unboxing boundary (defect esc_match): when the binding slot
+            // is BOXED but its value renders bare `i64` (a bare `Local` /
+            // compound over a bare counter, e.g. `let x = n - 1`), the raw
+            // `i64` would be re-read later in an `AverInt` position (`[x, x]`
+            // aggregate) — a `rustc` E0308. The escape analysis already marked
+            // such a binding boxed; align codegen by boxing the value at the
+            // binding crossing with `from_i64`. A bare binding (its later uses
+            // are all bare-emittable) keeps the raw value untouched.
+            let value = if !emit_ctx.bare.is_bare(let_node.binding) {
+                boxed_int_operand(value, &let_node.value, emit_ctx)
+            } else {
+                value
+            };
             let body = emit_mir_expr(&let_node.body, emit_ctx)?;
             if let_node.binding_name.is_empty() {
                 Some(format!("{{ {}; {} }}", value, body))
@@ -2010,11 +2023,20 @@ fn emit_mir_match_with(
     // ── 1. Single-arm irrefutable → `let` destructuring. ──
     // Mirror of `emit_match`'s first branch.
     if arms.len() == 1 && resolved_pattern_is_irrefutable(&arms[0].pattern) {
-        let subj = mir_clone_arg(
-            emit_mir_expr(&m.subject, emit_ctx)?,
-            &m.subject.node,
-            emit_ctx,
-        );
+        let mut subj_code = emit_mir_expr(&m.subject, emit_ctx)?;
+        // Int unboxing boundary (defect esc_match): a `match (n - 1) { x -> … }`
+        // binds the subject to `x`. When the analysis marked the bound slot
+        // BOXED (because `x` later escapes — `[x, x]`) but the subject renders
+        // bare `i64`, box it at the binding crossing with `from_i64`, so the
+        // bound `x` is the `AverInt` its later uses expect. A bare bound slot
+        // keeps the raw subject. (Only the `Bind` arm carries a slot; a
+        // wildcard / destructuring pattern is unaffected.)
+        if let MirPattern::Bind(slot, _) = &m.arms[0].pattern
+            && !emit_ctx.bare.is_bare(*slot)
+        {
+            subj_code = boxed_int_operand(subj_code, &m.subject, emit_ctx);
+        }
+        let subj = mir_clone_arg(subj_code, &m.subject.node, emit_ctx);
         let codegen = emit_ctx.codegen?;
         let pat = emit_pattern(&arms[0].pattern, false, codegen);
         let body = arm_bodies[0].clone();
@@ -2103,7 +2125,13 @@ fn emit_mir_match_with(
 
     // ── 4. Dispatch table (literals / wrapper tags). ──
     if let Some(MatchDispatchPlan::Table(shape)) = dispatch_plan.as_ref() {
-        return Some(emit_dispatch_table_match(subj, &arms, shape, body_for_arm));
+        return Some(emit_dispatch_table_match(
+            subj,
+            &arms,
+            shape,
+            subject_is_bare,
+            body_for_arm,
+        ));
     }
 
     // ── 4b. Int-literal match → if/else-if equality-guard chain. ──
@@ -2456,6 +2484,17 @@ pub(super) fn emit_mir_fn_body(
         return Some(format!("    crate::cancel_checkpoint();\n    {}", tail));
     }
 
+    // Int unboxing boundary (defect Q5): a BOXED-return non-TCO fn whose tail
+    // value renders bare `i64` (e.g. `h() -> Int` returning the bare-returning
+    // call `g(2)`) would land a raw `i64` in the `AverInt` return — box every
+    // bare leaf with `from_i64` at the return crossing.
+    if !emit_ctx.bare.bare_return
+        && tail_renders_bare_i64(body, emit_ctx)
+        && let Some(tail) = emit_boxed_return_tail(body, emit_ctx)
+    {
+        return Some(format!("    crate::cancel_checkpoint();\n    {}", tail));
+    }
+
     let mut code = emit_mir_expr(body, emit_ctx)?;
     // Return-position field access on a borrowed param → clone for
     // an owned result. Mirror of HIR's
@@ -2502,6 +2541,116 @@ fn emit_bare_return_tail(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Optio
             None
         }
         _ => None,
+    }
+}
+
+/// Does the value in RETURN/tail position render as a bare `i64` at any
+/// reachable leaf? Mirrors the descent of [`emit_bare_return_tail`] /
+/// [`emit_boxed_return_tail`] but only inspects the leaf representation. A
+/// `Match`/`IfThenElse` is bare-leafed if ANY arm/branch tail is; a `Let`
+/// body inherits its final expr; a direct leaf is bare iff
+/// [`mir_expr_is_bare_i64`]. Used to decide whether a BOXED-return fn whose
+/// tail value emits bare needs the `from_i64` boundary conversion (defects
+/// Q5 / subj_ret: a bare `Local`/compound aliased into an `AverInt` return).
+fn tail_renders_bare_i64(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> bool {
+    match &expr.node {
+        // A standalone `Int` literal is NOT a bare-rendering leaf for the
+        // boxing decision: its normal boxed-path emit is already
+        // `AverInt::from_i64(N)` (the correct boxed form), so it needs no
+        // return conversion. Only a bare `Local` / compound / call result —
+        // which would render as raw `i64` — does. (Mirrors `boxed_int_operand`,
+        // which likewise leaves a literal untouched.)
+        MirExpr::Literal(_) => false,
+        _ if mir_expr_is_bare_i64(expr, ctx) => true,
+        // A call to a fn whose RETURN the analysis proved bare renders as a
+        // raw `i64` (its signature is `-> i64`). Consumed in a boxed-return
+        // position this is the Q5 mismatch.
+        MirExpr::Call(_) | MirExpr::TailCall(_) => mir_call_returns_bare(expr, ctx),
+        MirExpr::Match(m) => m
+            .node
+            .arms
+            .iter()
+            .any(|arm| tail_renders_bare_i64(&arm.body, ctx)),
+        MirExpr::IfThenElse(ite) => {
+            tail_renders_bare_i64(&ite.node.then_branch, ctx)
+                || tail_renders_bare_i64(&ite.node.else_branch, ctx)
+        }
+        MirExpr::Let(l) => tail_renders_bare_i64(&l.node.body, ctx),
+        MirExpr::Return(inner) => tail_renders_bare_i64(inner, ctx),
+        _ => false,
+    }
+}
+
+/// Is `expr` a `Call(Fn)` / outside-loop `TailCall` whose callee's RETURN
+/// the whole-program unboxing analysis proved bare (`bare_return`)? Such a
+/// call renders as raw `i64`; in a boxed-return position it needs the
+/// `from_i64` boundary conversion. `None` codegen ctx (coverage/test) has no
+/// facts → `false` (conservative).
+fn mir_call_returns_bare(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> bool {
+    let target = match &expr.node {
+        MirExpr::Call(c) => match c.node.callee {
+            MirCallee::Fn(t) => t,
+            _ => return false,
+        },
+        MirExpr::TailCall(tc) => tc.node.target,
+        _ => return false,
+    };
+    ctx.codegen
+        .and_then(|cg| cg.bare_i64.for_fn(target))
+        .is_some_and(|f| f.bare_return)
+}
+
+/// Emit a tail/return value as a boxed `AverInt`, converting every bare-`i64`
+/// leaf at the boundary with `from_i64`. The structural mirror of
+/// [`emit_bare_return_tail`], but for a fn whose declared return is the
+/// general `AverInt` while some tail leaf is a proven-bare value (a bare
+/// `Local` aliased from a bare param, or a bare-returning call result). This
+/// is the return-position counterpart of [`boxed_int_operand`]: it keeps the
+/// loop counter bare (no demotion, win preserved) and only coerces at the
+/// single return crossing.
+///
+/// A non-bare leaf is emitted via the normal value path (`emit_mir_value_return`
+/// without the bare branch) — it is already an `AverInt`, so it is left as-is.
+/// Returns `None` for any shape the descent can't render (the caller then
+/// falls back to the default emit).
+fn emit_boxed_return_tail(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<String> {
+    match &expr.node {
+        // A standalone `Int` literal already emits as `AverInt::from_i64(N)`
+        // on the normal boxed path — emit it there (re-boxing would double-box
+        // into `from_i64(Ni64)`). Mirrors the `tail_renders_bare_i64` skip.
+        MirExpr::Literal(_) => {
+            let code = emit_mir_expr(expr, ctx)?;
+            Some(mir_maybe_clone(code, &expr.node, ctx))
+        }
+        // A directly bare-eligible leaf (a bare `Local` / compound): box it.
+        _ if mir_expr_is_bare_i64(expr, ctx) => {
+            emit_bare_i64(expr).map(|bare| format!("aver_rt::AverInt::from_i64({})", bare))
+        }
+        // A call to a bare-return callee: its result is a raw `i64`; box it.
+        MirExpr::Call(_) | MirExpr::TailCall(_) if mir_call_returns_bare(expr, ctx) => {
+            let code = emit_mir_expr(expr, ctx)?;
+            Some(format!("aver_rt::AverInt::from_i64({})", code))
+        }
+        MirExpr::Match(m) => emit_mir_match_with(&m.node, ctx, &|arm_body, ctx| {
+            emit_boxed_return_tail(arm_body, ctx)
+        }),
+        MirExpr::IfThenElse(ite) => {
+            let (cond, then_src, else_src) = mir_if_cond_and_branches(&ite.node, ctx)?;
+            let then_b = emit_boxed_return_tail(then_src, ctx)?;
+            let else_b = emit_boxed_return_tail(else_src, ctx)?;
+            Some(format!(
+                "if {} {{ {} }} else {{ {} }}",
+                cond, then_b, else_b
+            ))
+        }
+        MirExpr::Return(inner) => emit_boxed_return_tail(inner, ctx),
+        // A non-bare leaf is already an `AverInt` — emit it through the
+        // normal value path (which itself never takes the bare branch here,
+        // since this fn's return is boxed).
+        _ => {
+            let code = emit_mir_expr(expr, ctx)?;
+            Some(mir_maybe_clone(code, &expr.node, ctx))
+        }
     }
 }
 
@@ -2898,6 +3047,19 @@ fn emit_mir_value_return(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Optio
     {
         return Some(bare);
     }
+    // Int unboxing boundary (defects Q5 / subj_ret): when the fn's return is
+    // BOXED (`!bare_return`) but a tail leaf renders bare `i64` — a bare
+    // `Local` aliased from a bare param, or a bare-returning call result —
+    // the raw `i64` would land in the `AverInt` return slot (`rustc` E0308).
+    // Box every bare leaf with `from_i64` at the return crossing, keeping the
+    // counter bare (no demotion). Only when the type is actually Int, which a
+    // bare-rendering leaf implies.
+    if !ctx.bare.bare_return
+        && tail_renders_bare_i64(expr, ctx)
+        && let Some(boxed) = emit_boxed_return_tail(expr, ctx)
+    {
+        return Some(boxed);
+    }
     let code = emit_mir_expr(expr, ctx)?;
     Some(mir_maybe_clone(code, &expr.node, ctx))
 }
@@ -2929,7 +3091,13 @@ fn emit_mir_self_tco_continue(
             };
             arg_strs.push(bare?);
         } else {
-            arg_strs.push(mir_clone_arg(emit_mir_expr(a, ctx)?, &a.node, ctx));
+            // A BOXED rebind slot needs an `AverInt`. A bare-emittable arg
+            // (a bare compound `n + 1` / bare `Local`) renders raw `i64` on
+            // the default path, which would assign a bare value into the
+            // `AverInt` loop variable (`rustc` E0308). Convert at the
+            // boundary with `from_i64`, mirroring the named-call path.
+            let code = boxed_int_operand(emit_mir_expr(a, ctx)?, a, ctx);
+            arg_strs.push(mir_clone_arg(code, &a.node, ctx));
         }
     }
 
@@ -3493,7 +3661,16 @@ fn emit_named_call_to(
             // effectively unreachable for well-formed facts).
             return None;
         }
+        // A BOXED callee param: the arg must be an `AverInt`. A bare-emittable
+        // arg (a bare `Local`, or an `Add`/`Sub`/`Mul` tree the analysis proved
+        // in-range) renders as raw `i64` on the default path, which would land
+        // a bare value in an `AverInt` slot (`rustc` E0308). Convert it at the
+        // boundary with `from_i64` — exactly the bare→boxed coercion
+        // `boxed_int_operand` performs for a boxed-arithmetic operand. A literal
+        // already emits as `AverInt::from_i64(N)` (handled inside
+        // `boxed_int_operand`), and a boxed / unanalyzable arg is left untouched.
         let code = emit_mir_expr(a, ctx)?;
+        let code = boxed_int_operand(code, a, ctx);
         let s = if borrow_mask.get(i).copied().unwrap_or(false) {
             mir_borrow_arg(code, &a.node, ctx)
         } else {

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -248,12 +248,6 @@ impl<'a> MirEmitCtx<'a> {
     fn is_borrowed_param(&self, name: &str) -> bool {
         self.borrowed_params.contains(name)
     }
-
-    /// Is the MIR slot `slot` proven a bare `i64` by the unboxing analysis?
-    /// Fail-closed: an absent fact returns `false` (keep `AverInt`).
-    fn slot_is_bare(&self, slot: crate::ir::mir::LocalId) -> bool {
-        self.bare.is_bare(slot)
-    }
 }
 
 /// A shared empty `FnBareFacts` (all-`Boxed`) for the coverage / test /
@@ -269,25 +263,23 @@ fn empty_bare_facts() -> &'static crate::ir::mir::FnBareFacts {
 ///
 /// - A `Local` whose slot the analysis proved `Bare`.
 /// - An `Int` literal (an exact constant — always representable as `i64`
-///   in a bare arithmetic context; the enclosing op's `i64`-fit was proven
-///   by the analysis's worst-join).
-/// - A `Neg` / `Add` / `Sub` / `Mul` over bare operands (the whole tree is
-///   bare).
+///   in a bare arithmetic context).
+/// - A `Neg` / `Add` / `Sub` / `Mul` over bare operands WHOSE RESULT
+///   INTERVAL provably fits `i64` (a tree like `n + i64::MAX` whose operands
+///   are each bare but whose result leaves `i64` is NOT bare — emitting raw
+///   `i64` there would silently wrap with `overflow-checks = false`).
+///
+/// SINGLE SOURCE OF TRUTH: this is a thin delegate to
+/// [`crate::ir::mir::FnBareFacts::expr_is_bare_i64`] — the SAME interval-
+/// checked predicate the analysis's `tail_value_is_bare` uses — so codegen
+/// never re-decides bareness structurally and can never disagree with the
+/// analysis that drove the signature.
 ///
 /// Fail-closed: any other shape (a boxed `Local`, a call result, a
-/// non-Int operand) is NOT bare, so the emit keeps `AverInt`.
+/// non-Int operand, an overflowing compound) is NOT bare, so the emit
+/// keeps `AverInt`.
 fn mir_expr_is_bare_i64(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> bool {
-    match &expr.node {
-        MirExpr::Literal(l) => matches!(l.node, crate::ast::Literal::Int(_)),
-        MirExpr::Local(local) => ctx.slot_is_bare(local.node.slot),
-        MirExpr::Neg(inner) => mir_expr_is_bare_i64(inner, ctx),
-        MirExpr::BinOp(b) => {
-            matches!(b.node.op, BinOp::Add | BinOp::Sub | BinOp::Mul)
-                && mir_expr_is_bare_i64(&b.node.lhs, ctx)
-                && mir_expr_is_bare_i64(&b.node.rhs, ctx)
-        }
-        _ => false,
-    }
+    ctx.bare.expr_is_bare_i64(&expr.node)
 }
 
 /// Emit `expr` as a raw `i64` expression, assuming [`mir_expr_is_bare_i64`]
@@ -942,16 +934,28 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             let int_arith = matches!(bop.op, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div)
                 && (ty_is_int(bop.lhs.ty()) || ty_is_int(bop.rhs.ty()));
             if int_arith {
-                // Int unboxing: when BOTH operands are proven bare `i64`
-                // the result is bare too (the analysis's worst-join proved
-                // the binding interval fits `i64`), so emit native integer
-                // arithmetic. SOUNDNESS: only fires when
-                // `mir_expr_is_bare_i64` holds on each operand — a missing
-                // fact keeps the `AverInt` method path below. Div keeps the
-                // zero-divisor panic via an explicit guard, matching the
-                // `AverInt::div_trunc(..).expect(..)` trap.
-                if mir_expr_is_bare_i64(&bop.lhs, emit_ctx)
-                    && mir_expr_is_bare_i64(&bop.rhs, emit_ctx)
+                // Int unboxing: emit native integer arithmetic ONLY when the
+                // WHOLE result is proven bare `i64`. SOUNDNESS (BUG 2): the
+                // gate is `mir_expr_is_bare_i64(expr)` — the interval-checked
+                // predicate over the ENTIRE `Add`/`Sub`/`Mul` tree, NOT a
+                // per-operand check. `n + i64::MAX` has each operand bare but
+                // a result interval OUTSIDE `i64`, so it fails this gate and
+                // falls through to the boxed `AverInt` path below (which
+                // converts each bare operand via `from_i64`). A missing fact
+                // also keeps the boxed path. For `Add`/`Sub`/`Mul` we check
+                // the whole expression; `Div` is not modelled by the interval
+                // analysis (raw `/` over `Int` is a source type error — the
+                // builtin is `Int.div`), so it keeps the per-operand check
+                // plus the zero-divisor trap.
+                let whole_bare = match bop.op {
+                    BinOp::Add | BinOp::Sub | BinOp::Mul => mir_expr_is_bare_i64(expr, emit_ctx),
+                    BinOp::Div => {
+                        mir_expr_is_bare_i64(&bop.lhs, emit_ctx)
+                            && mir_expr_is_bare_i64(&bop.rhs, emit_ctx)
+                    }
+                    _ => false,
+                };
+                if whole_bare
                     && let Some(lb) = emit_bare_i64(&bop.lhs)
                     && let Some(rb) = emit_bare_i64(&bop.rhs)
                 {

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -126,6 +126,14 @@ pub struct MirEmitCtx<'a> {
     /// `BuiltinId` then resolves to nothing (`None` → HIR fallback),
     /// which is fine because that path only inspects `Some` vs `None`.
     pub mir_builtins: &'a [String],
+    /// Per-`LocalId` bare-`i64` representation facts for the fn whose body
+    /// this ctx emits — the Int "unboxing" analysis output. A slot proven
+    /// `Bare` emits native `i64` (raw literal / raw arithmetic / `i64`
+    /// param-return signature); every other slot keeps `aver_rt::AverInt`.
+    /// Empty (all-`Boxed`) on the coverage / test / free-standing paths.
+    /// SOUNDNESS: a slot is read here as `Bare` only when the analysis
+    /// proved `raw_i64_eligible && !escapes`; a missing fact is `Boxed`.
+    pub bare: &'a crate::ir::mir::FnBareFacts,
 }
 
 impl<'a> MirEmitCtx<'a> {
@@ -153,6 +161,7 @@ impl<'a> MirEmitCtx<'a> {
             // resolves to `None` and the fn reports as HIR-fallback,
             // matching the pre-Wave-3a coverage walk's reach.
             mir_builtins: &[],
+            bare: empty_bare_facts(),
         }
     }
 
@@ -194,6 +203,7 @@ impl<'a> MirEmitCtx<'a> {
             owned_params: &policy.owned_params,
             current_module_scope: policy.current_module_scope.as_deref(),
             mir_builtins,
+            bare: &policy.bare,
         }
     }
 
@@ -222,6 +232,7 @@ impl<'a> MirEmitCtx<'a> {
                 .as_ref()
                 .map(|p| p.builtins.as_slice())
                 .unwrap_or(&[]),
+            bare: &policy.bare,
         }
     }
 
@@ -236,6 +247,111 @@ impl<'a> MirEmitCtx<'a> {
 
     fn is_borrowed_param(&self, name: &str) -> bool {
         self.borrowed_params.contains(name)
+    }
+
+    /// Is the MIR slot `slot` proven a bare `i64` by the unboxing analysis?
+    /// Fail-closed: an absent fact returns `false` (keep `AverInt`).
+    fn slot_is_bare(&self, slot: crate::ir::mir::LocalId) -> bool {
+        self.bare.is_bare(slot)
+    }
+}
+
+/// A shared empty `FnBareFacts` (all-`Boxed`) for the coverage / test /
+/// free-standing emit paths that have no per-fn unboxing facts. Returning
+/// a `'static` reference keeps `MirEmitCtx` `Copy`.
+fn empty_bare_facts() -> &'static crate::ir::mir::FnBareFacts {
+    static EMPTY: std::sync::OnceLock<crate::ir::mir::FnBareFacts> = std::sync::OnceLock::new();
+    EMPTY.get_or_init(crate::ir::mir::FnBareFacts::default)
+}
+
+/// Does `expr` evaluate to a provably-bare `i64` value (so it may be
+/// emitted with native integer arithmetic rather than `AverInt` methods)?
+///
+/// - A `Local` whose slot the analysis proved `Bare`.
+/// - An `Int` literal (an exact constant — always representable as `i64`
+///   in a bare arithmetic context; the enclosing op's `i64`-fit was proven
+///   by the analysis's worst-join).
+/// - A `Neg` / `Add` / `Sub` / `Mul` over bare operands (the whole tree is
+///   bare).
+///
+/// Fail-closed: any other shape (a boxed `Local`, a call result, a
+/// non-Int operand) is NOT bare, so the emit keeps `AverInt`.
+fn mir_expr_is_bare_i64(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> bool {
+    match &expr.node {
+        MirExpr::Literal(l) => matches!(l.node, crate::ast::Literal::Int(_)),
+        MirExpr::Local(local) => ctx.slot_is_bare(local.node.slot),
+        MirExpr::Neg(inner) => mir_expr_is_bare_i64(inner, ctx),
+        MirExpr::BinOp(b) => {
+            matches!(b.node.op, BinOp::Add | BinOp::Sub | BinOp::Mul)
+                && mir_expr_is_bare_i64(&b.node.lhs, ctx)
+                && mir_expr_is_bare_i64(&b.node.rhs, ctx)
+        }
+        _ => false,
+    }
+}
+
+/// Emit `expr` as a raw `i64` expression, assuming [`mir_expr_is_bare_i64`]
+/// already returned `true`. Literals become the bare `{N}i64` form,
+/// arithmetic uses native operators, and a bare `Local` is its plain
+/// ident. `None` only if a nested operand can't render (e.g. a synthetic
+/// unnamed local) — the caller then falls back to the boxed path. Takes no
+/// `ctx`: the bare gate (`mir_expr_is_bare_i64`) already consulted it, and
+/// the emit itself is purely structural.
+fn emit_bare_i64(expr: &Spanned<MirExpr>) -> Option<String> {
+    match &expr.node {
+        MirExpr::Literal(l) => match l.node {
+            crate::ast::Literal::Int(k) => Some(format!("{}i64", k)),
+            _ => None,
+        },
+        MirExpr::Local(local) => {
+            let name = &local.node.name;
+            if name.is_empty() {
+                return None;
+            }
+            Some(aver_name_to_rust(name))
+        }
+        MirExpr::Neg(_) => {
+            // Sound only when the interval excludes `i64::MIN`; the
+            // analysis proves the operand fits `i64`, but `-i64::MIN`
+            // wraps. We bail to the boxed path for a bare `Neg` (the
+            // const-fold pass collapses `Neg(Literal)` before here, so a
+            // real bare `Neg` is rare) — keeping `AverInt` is always sound.
+            None
+        }
+        MirExpr::BinOp(b) => {
+            let op = match b.node.op {
+                BinOp::Add => "+",
+                BinOp::Sub => "-",
+                BinOp::Mul => "*",
+                _ => return None,
+            };
+            let l = emit_bare_i64(&b.node.lhs)?;
+            let r = emit_bare_i64(&b.node.rhs)?;
+            Some(format!("({} {} {})", l, op, r))
+        }
+        _ => None,
+    }
+}
+
+/// Coerce an operand of a BOXED `AverInt` arithmetic op to an `AverInt`
+/// expression. A bare-`i64` operand whose boxed-path emission would be a
+/// raw `i64` (a bare `Local` or bare arithmetic tree) crosses the
+/// bare→`AverInt` boundary via `from_i64`. A literal is NOT converted: its
+/// boxed-path `code` is already `AverInt::from_i64(N)` (the correct boxed
+/// form), so wrapping it would double-box. A boxed / unanalyzable operand
+/// is left as the already-emitted `code`.
+fn boxed_int_operand(code: String, expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> String {
+    // A standalone literal already emits as `AverInt::from_i64(N)` on the
+    // boxed path — never re-wrap it.
+    if matches!(&expr.node, MirExpr::Literal(_)) {
+        return code;
+    }
+    if mir_expr_is_bare_i64(expr, ctx)
+        && let Some(bare) = emit_bare_i64(expr)
+    {
+        format!("aver_rt::AverInt::from_i64({})", bare)
+    } else {
+        code
     }
 }
 
@@ -252,6 +368,12 @@ pub(super) struct MirFnEmitPolicy {
     /// `MirEmitCtx::owned_params` doc. Default empty (no own_param facts
     /// applied); populated by [`Self::apply_own_param`].
     pub owned_params: HashSet<String>,
+    /// Per-`LocalId` bare-`i64` facts for this fn (the Int unboxing
+    /// analysis output), owned so the borrowing `MirEmitCtx` can reference
+    /// it. Default empty (all-`Boxed`); populated by
+    /// [`Self::apply_bare_i64`] from the `CodegenContext`'s program-wide
+    /// `BareI64Facts`.
+    pub bare: crate::ir::mir::FnBareFacts,
     pub current_module_scope: Option<String>,
 }
 
@@ -266,6 +388,7 @@ impl MirFnEmitPolicy {
             rc_wrapped: HashSet::new(),
             borrowed_params: HashSet::new(),
             owned_params: HashSet::new(),
+            bare: crate::ir::mir::FnBareFacts::default(),
             current_module_scope: None,
         }
     }
@@ -300,7 +423,21 @@ impl MirFnEmitPolicy {
             rc_wrapped: HashSet::new(),
             borrowed_params,
             owned_params: HashSet::new(),
+            bare: crate::ir::mir::FnBareFacts::default(),
             current_module_scope: scope.map(String::from),
+        }
+    }
+
+    /// Apply the Int "unboxing" facts to this policy: clone the per-fn
+    /// `FnBareFacts` slice out of the program-wide `BareI64Facts` so the
+    /// body emit and the signature emit read the SAME per-`LocalId`
+    /// representation decisions. A bare `Int` param is ALSO dropped from
+    /// `borrowed_params` — a bare `i64` is `Copy`, taken by value, never
+    /// borrowed. Fail-closed: a fn with no facts keeps the default empty
+    /// (all-`Boxed`).
+    pub(super) fn apply_bare_i64(&mut self, fn_id: crate::ir::FnId, ctx: &CodegenContext) {
+        if let Some(facts) = ctx.bare_i64.for_fn(fn_id) {
+            self.bare = facts.clone();
         }
     }
 
@@ -805,6 +942,45 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             let int_arith = matches!(bop.op, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div)
                 && (ty_is_int(bop.lhs.ty()) || ty_is_int(bop.rhs.ty()));
             if int_arith {
+                // Int unboxing: when BOTH operands are proven bare `i64`
+                // the result is bare too (the analysis's worst-join proved
+                // the binding interval fits `i64`), so emit native integer
+                // arithmetic. SOUNDNESS: only fires when
+                // `mir_expr_is_bare_i64` holds on each operand — a missing
+                // fact keeps the `AverInt` method path below. Div keeps the
+                // zero-divisor panic via an explicit guard, matching the
+                // `AverInt::div_trunc(..).expect(..)` trap.
+                if mir_expr_is_bare_i64(&bop.lhs, emit_ctx)
+                    && mir_expr_is_bare_i64(&bop.rhs, emit_ctx)
+                    && let Some(lb) = emit_bare_i64(&bop.lhs)
+                    && let Some(rb) = emit_bare_i64(&bop.rhs)
+                {
+                    match bop.op {
+                        BinOp::Add => return Some(format!("({} + {})", lb, rb)),
+                        BinOp::Sub => return Some(format!("({} - {})", lb, rb)),
+                        BinOp::Mul => return Some(format!("({} * {})", lb, rb)),
+                        BinOp::Div => {
+                            // Truncating `/` over `i64`, keeping the
+                            // zero-divisor trap (the `AverInt::div_trunc`
+                            // parity). Bind the divisor once so it is
+                            // evaluated a single time.
+                            return Some(format!(
+                                "{{ let __d = {}; if __d == 0i64 {{ panic!(\"divide by zero\") }} else {{ ({}) / __d }} }}",
+                                rb, lb
+                            ));
+                        }
+                        _ => {}
+                    }
+                }
+                // Mixed-representation boundary: this is the boxed
+                // `AverInt` arithmetic path, but ONE operand may be a bare
+                // `i64` (e.g. `acc * n` where `acc` stays boxed and `n`
+                // went bare). The `AverInt` method takes `&AverInt`, so a
+                // bare operand re-enters the boxed world via `from_i64`
+                // (the bare→AverInt escape edge). A boxed operand is left
+                // as-is.
+                let l = boxed_int_operand(l, &bop.lhs, emit_ctx);
+                let r = boxed_int_operand(r, &bop.rhs, emit_ctx);
                 let method = match bop.op {
                     BinOp::Add => "add",
                     BinOp::Sub => "sub",
@@ -825,6 +1001,32 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                     _ => unreachable!("int_arith only set for Add/Sub/Mul/Div"),
                 };
                 return Some(format!("{}.{}(&{})", l, method, r));
+            }
+            // Int unboxing: a comparison (`==`, `<`, `<=`, `>`, `>=`, `!=`)
+            // between two proven-bare `i64` operands emits a raw operator
+            // over `i64` (rather than `&AverInt == &AverInt`). `AverInt`
+            // derives `PartialEq`/`PartialOrd`, and so does `i64`, so the
+            // boxed path below also works — but on a bare subject the boxed
+            // path would compare a bare `i64` against an `AverInt`, a type
+            // error. So when both sides are bare we MUST take the raw path.
+            if matches!(
+                bop.op,
+                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
+            ) && mir_expr_is_bare_i64(&bop.lhs, emit_ctx)
+                && mir_expr_is_bare_i64(&bop.rhs, emit_ctx)
+                && let Some(lb) = emit_bare_i64(&bop.lhs)
+                && let Some(rb) = emit_bare_i64(&bop.rhs)
+            {
+                let op = match bop.op {
+                    BinOp::Eq => "==",
+                    BinOp::Neq => "!=",
+                    BinOp::Lt => "<",
+                    BinOp::Gt => ">",
+                    BinOp::Lte => "<=",
+                    BinOp::Gte => ">=",
+                    _ => unreachable!(),
+                };
+                return Some(format!("({} {} {})", lb, op, rb));
             }
             let op_str = match bop.op {
                 BinOp::Add => "+",
@@ -904,7 +1106,7 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                     // `clone_arg` (owned), and the module-qualified
                     // head is path-mangled via `resolve_module_call`.
                     let name = emit_ctx.symbol_table.fn_entry(*fn_id).key.canonical();
-                    emit_named_call(&name, &call.args, emit_ctx)
+                    emit_named_call_to(&name, Some(*fn_id), &call.args, emit_ctx)
                 }
                 // Resolve the interned dotted name and dispatch:
                 //   - EFFECTFUL builtins (Wave 3b) →
@@ -1359,7 +1561,9 @@ pub(super) fn emit_mir_main_body(fn_id: crate::ir::FnId, ctx: &CodegenContext) -
     let resolved = ctx.resolved_program.fn_by_id(fn_id)?;
     // Main lives in the entry module → no module scope. Borrow-by-default
     // matches the non-TCO shape the main body uses.
-    let policy = MirFnEmitPolicy::from_resolved(resolved, None, /* borrow_by_default */ true);
+    let mut policy =
+        MirFnEmitPolicy::from_resolved(resolved, None, /* borrow_by_default */ true);
+    policy.apply_bare_i64(fn_id, ctx);
     let emit_ctx = MirEmitCtx::for_fn(ctx, &policy);
     emit_mir_fn_body(&mir_fn.body, &emit_ctx)
 }
@@ -1389,8 +1593,9 @@ pub(super) fn emit_mir_guest_entry_body(
     ctx: &CodegenContext,
 ) -> Option<String> {
     let mir_fn = ctx.mir_program.as_ref()?.fn_by_id(resolved_fd.fn_id)?;
-    let policy =
+    let mut policy =
         MirFnEmitPolicy::from_resolved(resolved_fd, scope, /* borrow_by_default */ true);
+    policy.apply_bare_i64(resolved_fd.fn_id, ctx);
     let emit_ctx = MirEmitCtx::for_fn(ctx, &policy);
     emit_mir_fn_body(&mir_fn.body, &emit_ctx)
 }
@@ -1845,7 +2050,16 @@ fn emit_mir_match_with(
     let match_on_ref = no_bindings
         && !any_int_literal_pattern
         && mir_subject_is_borrowed_param(&m.subject.node, emit_ctx);
-    let subj = if match_on_ref {
+
+    // Int unboxing: a bare-`i64` subject (a proven-bare counter) is `Copy`,
+    // so it is read by value WITHOUT `.clone()` and the Int-literal guards
+    // compare against raw `{N}i64` rather than `AverInt::from_i64(N)`.
+    let subject_is_bare = any_int_literal_pattern && mir_expr_is_bare_i64(&m.subject, emit_ctx);
+
+    let subj = if subject_is_bare {
+        // A bare i64 subject: emit the plain value (no clone — Copy).
+        emit_bare_i64(&m.subject).or_else(|| emit_mir_expr(&m.subject, emit_ctx))?
+    } else if match_on_ref {
         emit_mir_expr(&m.subject, emit_ctx)?
     } else {
         mir_clone_arg(
@@ -1897,7 +2111,7 @@ fn emit_mir_match_with(
     // would emit `AverInt::from_i64(N)` as a pattern), so the guard emitter
     // is REQUIRED to render; if it can't, return `None` (hard diagnostic).
     if any_int_literal_pattern {
-        return try_emit_int_literal_match(&subj, &arms, &arm_bodies, codegen);
+        return try_emit_int_literal_match(&subj, &arms, &arm_bodies, subject_is_bare, codegen);
     }
 
     // ── 5. Generic `match`. ──
@@ -1964,6 +2178,7 @@ fn try_emit_int_literal_match(
     subj: &str,
     arms: &[ResolvedMatchArm],
     arm_bodies: &[String],
+    subject_is_bare: bool,
     codegen: &CodegenContext,
 ) -> Option<String> {
     // Bind the subject once so a non-trivial expr is evaluated a single time
@@ -2029,13 +2244,25 @@ fn try_emit_int_literal_match(
                 ));
             }
             ResolvedPattern::Ident(name) => {
-                // Catch-all binding: bind the whole subject by value.
+                // Catch-all binding: bind the whole subject by value. A bare
+                // `i64` subject is `Copy` (no `.clone()` needed and binding
+                // it keeps the bare repr the body's arithmetic reads).
                 let rust = aver_name_to_rust(name);
-                let prelude = format!("let {} = {}.clone(); ", rust, subject_name);
+                let prelude = if subject_is_bare {
+                    format!("let {} = {}; ", rust, subject_name)
+                } else {
+                    format!("let {} = {}.clone(); ", rust, subject_name)
+                };
                 plans.push((ArmPlan::Default { prelude }, body));
             }
             ResolvedPattern::Literal(crate::ast::Literal::Int(n)) => {
-                let cond = format!("{} == aver_rt::AverInt::from_i64({})", subject_name, n);
+                // Int unboxing: a bare subject compares against a raw `i64`
+                // literal; a boxed subject compares against `AverInt`.
+                let cond = if subject_is_bare {
+                    format!("{} == {}i64", subject_name, n)
+                } else {
+                    format!("{} == aver_rt::AverInt::from_i64({})", subject_name, n)
+                };
                 plans.push((
                     ArmPlan::Guard {
                         cond,
@@ -2045,6 +2272,12 @@ fn try_emit_int_literal_match(
                 ));
             }
             ResolvedPattern::Tuple(pats) => {
+                // Tuple subjects are never bare in this slice (only scalar
+                // counters go bare); the bare guard machinery does not
+                // model tuple-element reps. Bail rather than mis-emit.
+                if subject_is_bare {
+                    return None;
+                }
                 if pats.len() != tuple_temps.len() {
                     return None;
                 }
@@ -2205,6 +2438,20 @@ pub(super) fn emit_mir_fn_body(
         return Some(format!("    crate::cancel_checkpoint();\n    {}", lines));
     }
 
+    // Int unboxing: a non-TCO fn whose return is bare `i64` must emit its
+    // tail value bare. The tail is the whole body (or, for a `Match` /
+    // `IfThenElse`, every arm value). `emit_bare_return_tail` handles those
+    // shapes; a `None` means the tail isn't a renderable-bare shape, in
+    // which case we fall through to the boxed emit (which would be a type
+    // error — but `bare_return` was only set when `tail_value_is_bare`
+    // proved every leaf bare, so this renders for the shapes that earned
+    // the bare return).
+    if emit_ctx.bare.bare_return
+        && let Some(tail) = emit_bare_return_tail(body, emit_ctx)
+    {
+        return Some(format!("    crate::cancel_checkpoint();\n    {}", tail));
+    }
+
     let mut code = emit_mir_expr(body, emit_ctx)?;
     // Return-position field access on a borrowed param → clone for
     // an owned result. Mirror of HIR's
@@ -2216,6 +2463,42 @@ pub(super) fn emit_mir_fn_body(
         code = format!("{}.clone()", code);
     }
     Some(format!("    crate::cancel_checkpoint();\n    {}", code))
+}
+
+/// Emit a non-TCO body's tail value as a bare `i64` expression. The tail
+/// is the value the fn returns; for `Match` / `IfThenElse` it is every arm
+/// value (each rendered bare). A bare leaf (`Local` / literal / arithmetic)
+/// renders via [`emit_bare_i64`]. Returns `None` for any shape the bare
+/// path can't render (the caller then falls back to the boxed emit). Only
+/// invoked when the analysis proved `bare_return` (every tail leaf
+/// bare-eligible), so the supported shapes cover the bare-return cases.
+fn emit_bare_return_tail(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<String> {
+    match &expr.node {
+        // A directly bare-eligible leaf / arithmetic tail.
+        _ if mir_expr_is_bare_i64(expr, ctx) => emit_bare_i64(expr),
+        // A `Match` over Int literals whose arm bodies are bare tails. Reuse
+        // the Int-literal guard chain but render each arm's tail bare.
+        MirExpr::Match(m) => emit_mir_match_with(&m.node, ctx, &|arm_body, ctx| {
+            emit_bare_return_tail(arm_body, ctx)
+        }),
+        MirExpr::IfThenElse(ite) => {
+            let (cond, then_src, else_src) = mir_if_cond_and_branches(&ite.node, ctx)?;
+            let then_b = emit_bare_return_tail(then_src, ctx)?;
+            let else_b = emit_bare_return_tail(else_src, ctx)?;
+            Some(format!(
+                "if {} {{ {} }} else {{ {} }}",
+                cond, then_b, else_b
+            ))
+        }
+        MirExpr::Let(l) => {
+            // A let-chain ending in a bare tail: render the bindings via the
+            // flat emitter, then the bare final. Fall back to None if the
+            // chain isn't flat-renderable.
+            let _ = l;
+            None
+        }
+        _ => None,
+    }
 }
 
 /// Emit a top-level `Let` chain as flat Rust statement lines: each
@@ -2261,7 +2544,16 @@ fn emit_mir_let_chain_flat(
                 current = &next.node;
             }
             _ => {
-                let final_expr = emit_mir_expr(&current.body, ctx)?;
+                // Int unboxing: a bare-return fn's let-chain tail emits the
+                // final value bare so the returned expression's type is
+                // `i64`.
+                let final_expr = if ctx.bare.bare_return
+                    && let Some(bare) = emit_bare_return_tail(&current.body, ctx)
+                {
+                    bare
+                } else {
+                    emit_mir_expr(&current.body, ctx)?
+                };
                 lines.push(final_expr);
                 break;
             }
@@ -2300,6 +2592,11 @@ pub(super) fn emit_mir_fn_body_routed(
     // set from the same `mir_fn.aliased_slots` and emits `mut p: T`, so
     // body and signature agree on which params are owned.
     policy.apply_own_param(mir_fn);
+    // Apply the Int unboxing facts so a proven-bare slot emits native
+    // `i64`. Same per-fn slice the signature emit reads (via
+    // `bare_fn_facts`), so body and signature agree on which params /
+    // return are bare.
+    policy.apply_bare_i64(mir_fn.fn_id, ctx);
     let emit_ctx = MirEmitCtx::for_fn(ctx, &policy);
     emit_mir_fn_body(&mir_fn.body, &emit_ctx)
 }
@@ -2387,6 +2684,12 @@ pub(super) fn emit_mir_tco_fn(
     // rc-wrapped name back out of `owned_params` to keep signature and
     // body consistent.
     policy.apply_own_param(mir_fn);
+    // Int unboxing: a bare `i64` counter param is `Copy`-by-value, so it
+    // is never rc-wrapped — a param bare in the summary is disjoint from
+    // `rc_wrapped` by construction (rc only wraps non-Copy pass-through
+    // collection params). The signature emit (`emit_tco_params_mir`)
+    // reads the same per-fn facts so both agree.
+    policy.apply_bare_i64(mir_fn.fn_id, ctx);
     for n in &rc_names {
         policy.owned_params.remove(n);
     }
@@ -2402,7 +2705,13 @@ pub(super) fn emit_mir_tco_fn(
         &emit_ctx,
     )?;
 
-    let params = emit_tco_params_mir(&fd.params, &rc_indices);
+    // Int unboxing: a bare-`i64` param/return emits `i64` in the signature
+    // (the load-bearing cross-frame change), read off the SAME per-fn facts
+    // the body emit applied (`apply_bare_i64`). Every caller converts at the
+    // boundary, so the ABI stays self-consistent.
+    let bare_facts = ctx.bare_i64.for_fn(mir_fn.fn_id);
+    let params = emit_tco_params_mir(&fd.params, &rc_indices, bare_facts);
+    let ret_type = bare_return_type(ret_type, bare_facts);
     let mut lines = Vec::new();
     lines.push(format!(
         "{}fn {}({}) -> {} {{",
@@ -2426,16 +2735,24 @@ pub(super) fn emit_mir_tco_fn(
 
 /// Self-TCO param signature: non-rc params are `mut T` (rebound in the
 /// loop), rc params are plain `T` (shadowed by the Arc::new binding).
-/// Mirror of `emit_fn_params_tco`.
+/// Mirror of `emit_fn_params_tco`. A param the unboxing analysis proved
+/// bare (`bare_facts.param_is_bare(i)`) emits `mut p: i64` instead of
+/// `mut p: aver_rt::AverInt`.
 fn emit_tco_params_mir(
     params: &[(String, String)],
     rc_indices: &std::collections::HashSet<usize>,
+    bare_facts: Option<&crate::ir::mir::FnBareFacts>,
 ) -> String {
     params
         .iter()
         .enumerate()
         .map(|(i, (name, type_ann))| {
-            let rust_type = super::types::type_annotation_to_rust(type_ann);
+            let is_bare = bare_facts.is_some_and(|f| f.param_is_bare(i));
+            let rust_type = if is_bare {
+                "i64".to_string()
+            } else {
+                super::types::type_annotation_to_rust(type_ann)
+            };
             let rust_name = aver_name_to_rust(name);
             if rc_indices.contains(&i) {
                 format!("{}: {}", rust_name, rust_type)
@@ -2445,6 +2762,17 @@ fn emit_tco_params_mir(
         })
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// The return type for a fn whose return the unboxing analysis proved bare:
+/// `i64`, else the original `ret_type` string. Used by the self-TCO and
+/// non-TCO signature emit.
+fn bare_return_type(ret_type: &str, bare_facts: Option<&crate::ir::mir::FnBareFacts>) -> String {
+    if bare_facts.is_some_and(|f| f.bare_return) {
+        "i64".to_string()
+    } else {
+        ret_type.to_string()
+    }
 }
 
 /// Emit the self-TCO loop body (inside `loop { … }`). Leads with
@@ -2555,6 +2883,17 @@ fn emit_mir_tco_if_then_else(
 /// returning a pass-through param (Arc<T> / &T) needs `(*x).clone()` to
 /// yield an owned `T`.
 fn emit_mir_value_return(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<String> {
+    // Int unboxing: when the fn's return type is bare `i64`, the base-case
+    // value must be emitted bare too (a bare `Local`, a bare literal, or
+    // bare arithmetic) so the returned expression's type is `i64`. The
+    // analysis only set `bare_return` when EVERY tail leaf is bare-eligible
+    // (`tail_value_is_bare`), so this path renders.
+    if ctx.bare.bare_return
+        && mir_expr_is_bare_i64(expr, ctx)
+        && let Some(bare) = emit_bare_i64(expr)
+    {
+        return Some(bare);
+    }
     let code = emit_mir_expr(expr, ctx)?;
     Some(mir_maybe_clone(code, &expr.node, ctx))
 }
@@ -2572,8 +2911,22 @@ fn emit_mir_self_tco_continue(
     ctx: &MirEmitCtx<'_>,
 ) -> Option<String> {
     let mut arg_strs = Vec::with_capacity(args.len());
-    for a in args {
-        arg_strs.push(mir_clone_arg(emit_mir_expr(a, ctx)?, &a.node, ctx));
+    for (i, a) in args.iter().enumerate() {
+        // Int unboxing: a bare param's rebind value must be bare `i64`
+        // (the loop variable is `mut p: i64`). A bare-eligible arg emits
+        // raw; a non-bare arg flowing into a bare param narrows via
+        // `to_i64` (rare). A boxed param keeps the clone path.
+        if ctx.bare.param_is_bare(i) {
+            let bare = if mir_expr_is_bare_i64(a, ctx) {
+                emit_bare_i64(a)
+            } else {
+                emit_mir_expr(a, ctx)
+                    .map(|c| format!("{}.to_i64().expect(\"Int out of i64 range\")", c))
+            };
+            arg_strs.push(bare?);
+        } else {
+            arg_strs.push(mir_clone_arg(emit_mir_expr(a, ctx)?, &a.node, ctx));
+        }
     }
 
     // Which positions are actually rebound (non-passthrough, non-identity)?
@@ -2634,8 +2987,19 @@ fn mir_if_cond_and_branches<'a>(
         MirExpr::BinOp(spanned_binop) if canonical_compare(spanned_binop.node.op).is_some() => {
             let bop = &spanned_binop.node;
             let (op_str, invert) = canonical_compare(bop.op).expect("checked by guard");
-            let l = emit_mir_expr(&bop.lhs, ctx)?;
-            let r = emit_mir_expr(&bop.rhs, ctx)?;
+            // Int unboxing: a comparison between two bare `i64` operands
+            // emits raw `i64` operands (a bare counter `i == 0` compares
+            // `i64 == 0i64`, not `i64 == AverInt`). Mirror of the
+            // comparison bare path in `emit_mir_expr`.
+            let (l, r) = if mir_expr_is_bare_i64(&bop.lhs, ctx)
+                && mir_expr_is_bare_i64(&bop.rhs, ctx)
+                && let Some(lb) = emit_bare_i64(&bop.lhs)
+                && let Some(rb) = emit_bare_i64(&bop.rhs)
+            {
+                (lb, rb)
+            } else {
+                (emit_mir_expr(&bop.lhs, ctx)?, emit_mir_expr(&bop.rhs, ctx)?)
+            };
             let cond = format!("({} {} {})", l, op_str, r);
             if invert {
                 Some((cond, &ite.else_branch, &ite.then_branch))
@@ -3081,12 +3445,50 @@ fn mir_attr_result_is_copy(proj: &crate::ir::mir::MirProject, ctx: &MirEmitCtx<'
 /// rides `clone_arg` (conservative — coverage only reads Some/None,
 /// and the production parity gate never runs without a ctx).
 fn emit_named_call(name: &str, args: &[Spanned<MirExpr>], ctx: &MirEmitCtx<'_>) -> Option<String> {
+    emit_named_call_to(name, None, args, ctx)
+}
+
+/// Like [`emit_named_call`] but threads the callee's `FnId` so the Int
+/// unboxing facts can convert each arg at the call boundary: when the
+/// callee's i-th param is bare `i64`, the arg is emitted as a raw `i64`
+/// (an already-bare arg directly; a boxed `AverInt` arg narrowed via a
+/// checked `to_i64`). A `None` `callee` (a foreign tail-call helper with
+/// no facts) keeps every arg boxed.
+fn emit_named_call_to(
+    name: &str,
+    callee: Option<crate::ir::FnId>,
+    args: &[Spanned<MirExpr>],
+    ctx: &MirEmitCtx<'_>,
+) -> Option<String> {
     let borrow_mask = match ctx.codegen {
         Some(cg) => callee_borrow_mask(name, args.len(), cg),
         None => vec![false; args.len()],
     };
+    let callee_bare = callee.and_then(|id| ctx.codegen.and_then(|cg| cg.bare_i64.for_fn(id)));
     let mut arg_strs = Vec::with_capacity(args.len());
     for (i, a) in args.iter().enumerate() {
+        // Int unboxing boundary: a bare callee param takes a raw `i64`.
+        if callee_bare.is_some_and(|f| f.param_is_bare(i)) {
+            let bare_arg = if mir_expr_is_bare_i64(a, ctx) {
+                // The arg is itself bare — emit it raw.
+                emit_bare_i64(a)
+            } else {
+                // A boxed `AverInt` arg narrows to `i64` via the checked
+                // `to_i64` (rare by construction — the caller usually has
+                // a literal or a bare value here).
+                emit_mir_expr(a, ctx)
+                    .map(|c| format!("{}.to_i64().expect(\"Int out of i64 range\")", c))
+            };
+            if let Some(s) = bare_arg {
+                arg_strs.push(s);
+                continue;
+            }
+            // Could not render bare — bail to keep soundness (the boxed
+            // signature would then mismatch, but `for_fn` only marks a
+            // param bare when every caller can supply it, so this is
+            // effectively unreachable for well-formed facts).
+            return None;
+        }
         let code = emit_mir_expr(a, ctx)?;
         let s = if borrow_mask.get(i).copied().unwrap_or(false) {
             mir_borrow_arg(code, &a.node, ctx)
@@ -4062,6 +4464,7 @@ mod tests {
             owned_params: &policy.owned_params,
             current_module_scope: policy.current_module_scope.as_deref(),
             mir_builtins: BUILTINS.get_or_init(Vec::new),
+            bare: &policy.bare,
         };
         let lit = span(MirExpr::Literal(span(crate::ast::Literal::Int(7))));
         assert_eq!(

--- a/src/codegen/rust/project.rs
+++ b/src/codegen/rust/project.rs
@@ -92,17 +92,22 @@ pub fn generate_cargo_toml(
     lines.push("lto = true".to_string());
     lines.push("codegen-units = 1".to_string());
 
-    // Aver `Int` is i64 with wrapping arithmetic — that is the
-    // semantics the VM, WASM (i32/i64 wrap by spec), and verify
-    // hostile-boundary expansion all share. Disable overflow-checks
-    // in dev/test so debug builds match release: a hostile case like
-    // `i64::MAX * 2` returns the wrapped value instead of panicking.
+    // Aver `Int` is arbitrary-precision (ℤ): both the VM and this Rust
+    // backend carry it as `aver_rt::AverInt`, and the unboxing analysis
+    // lowers a value to a bare `i64` only when it has PROVEN the value
+    // stays in i64 range — so a bare op never overflows in a correctly
+    // compiled program. Turn overflow-checks ON in dev/test as a
+    // defense-in-depth trip-wire: it has zero false positives on correct
+    // code, but turns any future unboxing miscompile (a value wrongly
+    // lowered to bare) into a loud panic instead of a silent i64 wrap.
+    // Release keeps the default (off) so the proven-bounded fast path
+    // carries no per-op check.
     lines.push(String::new());
     lines.push("[profile.dev]".to_string());
-    lines.push("overflow-checks = false".to_string());
+    lines.push("overflow-checks = true".to_string());
     lines.push(String::new());
     lines.push("[profile.test]".to_string());
-    lines.push("overflow-checks = false".to_string());
+    lines.push("overflow-checks = true".to_string());
 
     lines.join("\n")
 }

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -442,10 +442,24 @@ fn emit_fn_def_with_visibility(
             .unwrap_or_default()
     };
 
+    // Int unboxing facts for this fn (the bare-`i64` param/return summary).
+    // Read off the same `BareI64Facts` the body emit applies, so the
+    // non-TCO signature and body never disagree on which params/return are
+    // bare. `None` for fns the analysis didn't see (fail-closed → boxed).
+    // The self-TCO signature emits its own bare params inside
+    // `emit_mir_tco_fn`; here we only touch the non-TCO branch.
+    let bare_facts = ctx.bare_i64.for_fn(resolved_fd.fn_id);
+
     // Function signature
-    let params = emit_fn_params_with_owned(&fd.params, has_tco, &owned_collection_params);
+    let params = if has_tco {
+        emit_fn_params_with_owned(&fd.params, has_tco, &owned_collection_params)
+    } else {
+        emit_fn_params_with_bare(&fd.params, &owned_collection_params, bare_facts)
+    };
     let ret_type = if fd.return_type.is_empty() {
         "()".to_string()
+    } else if !has_tco && bare_facts.is_some_and(|f| f.bare_return) {
+        "i64".to_string()
     } else {
         type_annotation_to_rust(&fd.return_type)
     };
@@ -685,6 +699,36 @@ fn emit_fn_params_with_owned(
     owned_params: &HashSet<String>,
 ) -> String {
     emit_fn_params_inner(params, mutable, &HashSet::new(), owned_params)
+}
+
+/// Emit the non-TCO param signature with Int-unboxing applied: a param the
+/// analysis proved bare emits `p: i64` (by value, `Copy`); every other
+/// param falls through to [`emit_fn_params_inner`]'s owned / borrow /
+/// by-value decision. Used on the non-TCO path; the self-TCO signature
+/// handles its own bare params in `emit_mir_tco_fn`.
+fn emit_fn_params_with_bare(
+    params: &[(String, String)],
+    owned_params: &HashSet<String>,
+    bare_facts: Option<&crate::ir::mir::FnBareFacts>,
+) -> String {
+    params
+        .iter()
+        .enumerate()
+        .map(|(i, (name, type_ann))| {
+            if bare_facts.is_some_and(|f| f.param_is_bare(i)) {
+                return format!("{}: i64", aver_name_to_rust(name));
+            }
+            // Fall back to the single-param shape the inner emitter would
+            // produce for a non-bare, non-rc param.
+            emit_fn_params_inner(
+                std::slice::from_ref(&(name.clone(), type_ann.clone())),
+                false,
+                &HashSet::new(),
+                owned_params,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn emit_fn_params_inner(
@@ -1447,6 +1491,7 @@ mod tests {
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,
+            bare_i64: Default::default(),
             discovered_lemmas: Vec::new(),
             sample_expected: std::collections::HashMap::new(),
         }

--- a/src/ir/interval.rs
+++ b/src/ir/interval.rs
@@ -139,12 +139,12 @@ impl Bound {
     }
 
     /// Order for picking a `min` lower bound: `NegInf < Finite < PosInf`.
-    fn min(self, other: Bound) -> Bound {
+    pub fn min(self, other: Bound) -> Bound {
         if self.le(other) { self } else { other }
     }
 
     /// Order for picking a `max` upper bound.
-    fn max(self, other: Bound) -> Bound {
+    pub fn max(self, other: Bound) -> Bound {
         if self.le(other) { other } else { self }
     }
 
@@ -218,6 +218,19 @@ impl Interval {
         Interval {
             lo: self.lo.max(other.lo),
             hi: self.hi.min(other.hi),
+        }
+    }
+
+    /// Convex hull (worst-case widening join) — the merge operator for
+    /// control-flow joins and the per-value `worst` accumulator the
+    /// general range pass uses. If either operand escapes `i64`, so does
+    /// the hull, keeping the headroom verdict sound. Public mirror of the
+    /// crate-private `join` free fn so the bare-`i64` consumer (outside
+    /// this module) can widen without re-deriving the rule.
+    pub fn hull(self, other: Interval) -> Interval {
+        Interval {
+            lo: self.lo.min(other.lo),
+            hi: self.hi.max(other.hi),
         }
     }
 
@@ -315,7 +328,7 @@ pub enum OpClass {
 impl OpClass {
     /// Classify an arithmetic intermediate interval. Conservative:
     /// only a fully-`i64`-fitting interval earns `OverflowFree`.
-    fn of_interval(i: Interval) -> OpClass {
+    pub fn of_interval(i: Interval) -> OpClass {
         if i.fits_i64() {
             OpClass::OverflowFree
         } else if i.is_finite() {

--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -89,9 +89,10 @@ pub use expr::{
 };
 pub use instantiations::{InstantiationRegistry, discover_instantiations};
 pub use lower::{lower_program, lower_top_level_value};
+pub use optimize::bare_i64;
 pub use optimize::{
-    algebraic_simplify, bool_match_to_if, branch_collapse, const_fold, dead_code,
-    inline_nullary_literals, optimize,
+    BareI64Facts, FnBareFacts, Repr, ValueFact, algebraic_simplify, bool_match_to_if,
+    branch_collapse, const_fold, dead_code, inline_nullary_literals, optimize,
 };
 pub use program::{LocalId, MirFn, MirParam, MirProgram};
 pub use stats::{LowerStats, SkipReason};

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -1,0 +1,1407 @@
+//! Int "unboxing": pick a bare `i64` representation for provably-bounded,
+//! non-escaping `Int` values so the Rust backend emits native integer
+//! arithmetic instead of the default arbitrary-precision `aver_rt::AverInt`.
+//!
+//! This is a **read-only codegen analysis** — it never mutates the
+//! `MirProgram`. It produces a [`BareI64Facts`] table the Rust walker reads
+//! to select `i64` vs `AverInt` at each emit site, exactly the way the Rust
+//! walker reads `aliased_slots` (the `own_param` pass) to select owned vs
+//! borrowed collection params.
+//!
+//! ## What reuses the #511 interval domain
+//!
+//! The arithmetic-bound half reuses [`crate::ir::interval`] verbatim: the
+//! `Interval` lattice element (i128-saturating, never wraps), its
+//! `add`/`sub`/`mul`/`hull`/`fits_i64`, the `OpClass` verdict band, and the
+//! `raw_i64_eligible` gate. We only swap the LEAF source — instead of a
+//! refined-type carrier read, the leaf is an SSA-value (`LocalId`) range
+//! query over the `MirFn` body.
+//!
+//! ## What reuses the existing escape / use-flow machinery
+//!
+//! The escape half mirrors the NOTION the `own_param` pass already uses (a
+//! single use-flow scan over the body, defaulting every unrecognized
+//! position to "escapes"), but with a REPRESENTATION-escape predicate
+//! ("does this Int reach a general-Int context") rather than the ownership-
+//! escape predicate ("does this collection leave the frame"). The call
+//! graph used for the cross-frame summary is the `MirCallee::Fn` /
+//! `MirTailCall` edge set, the same edges `own_param` walks.
+//!
+//! ## Soundness — fail-closed (the C0 guard)
+//!
+//! A value is `Bare` ONLY when PROVEN `raw_i64_eligible` (interval `Some`,
+//! `fits_i64`, every participating op `OverflowFree`) AND non-escaping. Any
+//! missing or unknown fact ⇒ `Boxed` (`AverInt`), never `Bare`. So a bug
+//! here is a MISSED optimization (lost speed), never a wrong value — the
+//! opposite of the wasm-gc silent-wrong-value risk. A wrongly-bare value
+//! would reintroduce silent two's-complement wrapping, and additionally
+//! the emitted Rust would not type-check (a bare value reaching an
+//! `AverInt` slot is a `rustc` error), which is itself a backstop.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::ast::{BinOp, Literal, Spanned, Type};
+use crate::ir::FnId;
+use crate::ir::interval::{Interval, OpClass, raw_i64_eligible};
+
+use super::super::expr::{MirCallee, MirExpr, MirPattern};
+use super::super::program::{LocalId, MirFn, MirProgram};
+
+/// Representation chosen for a value: a native machine `i64` or the
+/// default arbitrary-precision `AverInt`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Repr {
+    /// Native `i64` — emitted only when proven sound.
+    Bare,
+    /// `aver_rt::AverInt` — the safe default.
+    Boxed,
+}
+
+/// Per-value representation-selection fact, keyed by `LocalId` within a
+/// `MirFn`. `repr == Bare` ⟺ `raw_i64_eligible(interval, ops) && !escapes`.
+#[derive(Debug, Clone)]
+pub struct ValueFact {
+    /// Derived interval over-approximation (`None` = the analysis could
+    /// not derive a bound, the conservative decline).
+    pub interval: Option<Interval>,
+    /// Worst-case op class over every arithmetic node the value flows
+    /// through. `OverflowFree` is the only band that may be `Bare`.
+    pub op_class: OpClass,
+    /// `true` when the value reaches a general-Int context (returned as a
+    /// general Int, passed to a general-Int param, stored in an aggregate,
+    /// or stringified). A `Bare` value never escapes by construction.
+    pub escapes: bool,
+    /// The chosen representation.
+    pub repr: Repr,
+}
+
+impl ValueFact {
+    /// The safe default — `Boxed`, unknown interval, declined.
+    fn boxed() -> Self {
+        Self {
+            interval: None,
+            op_class: OpClass::Unbounded,
+            escapes: true,
+            repr: Repr::Boxed,
+        }
+    }
+
+    pub fn is_bare(&self) -> bool {
+        self.repr == Repr::Bare
+    }
+}
+
+/// Per-`MirFn` representation facts the Rust walker consumes.
+#[derive(Debug, Clone, Default)]
+pub struct FnBareFacts {
+    /// Per-`LocalId` value fact. A slot absent from this map defaults to
+    /// `Boxed` (fail-closed).
+    pub values: HashMap<LocalId, ValueFact>,
+    /// Per-param-index representation: `true` ⟺ the param is emitted as a
+    /// bare `i64` in the fn signature (and every caller converts at the
+    /// boundary). Indexed by declaration order, same indexing
+    /// `own_param`'s `aliased_slots` uses.
+    pub bare_params: Vec<bool>,
+    /// `true` ⟺ the fn's return type is emitted as a bare `i64`.
+    pub bare_return: bool,
+}
+
+impl FnBareFacts {
+    /// Is the value bound to `slot` emitted as a bare `i64`?
+    pub fn is_bare(&self, slot: LocalId) -> bool {
+        self.values.get(&slot).is_some_and(ValueFact::is_bare)
+    }
+
+    /// Is param index `i` bare in the signature?
+    pub fn param_is_bare(&self, i: usize) -> bool {
+        self.bare_params.get(i).copied().unwrap_or(false)
+    }
+}
+
+/// Whole-program representation-selection facts, keyed by `FnId`. Built
+/// once per compilation alongside the optimized `MirProgram`; the Rust
+/// backend reads a per-fn slice at signature + body emit.
+#[derive(Debug, Clone, Default)]
+pub struct BareI64Facts {
+    fns: HashMap<FnId, FnBareFacts>,
+}
+
+impl BareI64Facts {
+    /// Per-fn facts, or `None` when the fn is absent (fail-closed: the
+    /// caller then treats every value as `Boxed`).
+    pub fn for_fn(&self, id: FnId) -> Option<&FnBareFacts> {
+        self.fns.get(&id)
+    }
+
+    /// Total values proven `Bare` across the whole program — a diagnostic
+    /// counter (proof the recognizer fired), nothing in codegen keys off it.
+    pub fn bare_values(&self) -> usize {
+        self.fns
+            .values()
+            .flat_map(|f| f.values.values())
+            .filter(|v| v.is_bare())
+            .count()
+    }
+}
+
+/// Entry point: compute the bare-`i64` representation facts for `program`.
+///
+/// The analysis is whole-program: a tail-recursion counter that crosses a
+/// self-tail-call frame can only go bare if the param it crosses to is
+/// ALSO bare, so the per-fn param/return summary is computed against the
+/// visible `MirCallee::Fn` / `MirTailCall` call graph. A dependency-module
+/// fragment (callers unseen) bails to all-`Boxed`, exactly like
+/// `own_param`.
+pub fn analyze(program: &MirProgram) -> BareI64Facts {
+    // Diagnostic / bench-differential escape hatch: skip the analysis so a
+    // run keeps the conservative all-Boxed baseline.
+    if std::env::var("AVER_NO_BARE_I64").is_ok() {
+        return BareI64Facts::default();
+    }
+    // Whole-program gate: a bare param/return changes a fn's Rust ABI, so
+    // EVERY caller must be visible to convert at the boundary. A
+    // dependency-module fragment is missing the entry/sibling call sites,
+    // so bail to all-Boxed.
+    if program.external_callers_possible || program.modules.len() > 1 {
+        return BareI64Facts::default();
+    }
+
+    // Param Int-typedness per fn (a bare param must itself be `Int`).
+    let mut int_params: HashMap<FnId, Vec<bool>> = HashMap::new();
+    for (id, f) in program.iter() {
+        int_params.insert(*id, f.params.iter().map(|p| ty_str_is_int(&p.ty)).collect());
+    }
+
+    // The minimal cross-frame summary: which params are bare, whether the
+    // return is bare.
+    let summary = compute_summary(program, &int_params);
+
+    let mut fns: HashMap<FnId, FnBareFacts> = HashMap::new();
+    for (id, f) in program.iter() {
+        fns.insert(*id, analyze_fn(f, &summary));
+    }
+
+    BareI64Facts { fns }
+}
+
+/// Cross-frame summary: per-fn, which params are bare and whether the
+/// return is bare. Computed as a monotone-descending fixpoint (a param /
+/// return starts optimistically bare, demoted to boxed when any
+/// constraint fails), mirroring `own_param`'s lattice.
+struct Summary {
+    bare_params: HashMap<FnId, Vec<bool>>,
+    bare_return: HashMap<FnId, bool>,
+}
+
+impl Summary {
+    fn param_bare(&self, id: FnId, i: usize) -> bool {
+        self.bare_params
+            .get(&id)
+            .and_then(|v| v.get(i).copied())
+            .unwrap_or(false)
+    }
+
+    fn return_bare(&self, id: FnId) -> bool {
+        self.bare_return.get(&id).copied().unwrap_or(false)
+    }
+}
+
+fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) -> Summary {
+    // Address-taken fns (name appears as a `FnValue`) have callers we
+    // cannot attribute — pin all their params/return boxed.
+    let mut address_taken: HashSet<String> = HashSet::new();
+    for (_, f) in program.iter() {
+        collect_fn_values(&f.body.node, &mut address_taken);
+    }
+
+    // Seed: optimistic. A param is candidate-bare iff it is Int-typed and
+    // the fn is not externally reachable (main / address-taken). The
+    // return is candidate-bare iff Int-typed and not externally reachable.
+    let mut bare_params: HashMap<FnId, Vec<bool>> = HashMap::new();
+    let mut bare_return: HashMap<FnId, bool> = HashMap::new();
+    for (id, f) in program.iter() {
+        let externally_reachable = f.name == "main" || address_taken.contains(&f.name);
+        let ip = &int_params[id];
+        let seed: Vec<bool> = ip.iter().map(|&i| i && !externally_reachable).collect();
+        bare_params.insert(*id, seed);
+        bare_return.insert(*id, ty_str_is_int(&f.return_type) && !externally_reachable);
+    }
+
+    // Collect visible call edges (`Call(Fn)` + `TailCall`) with their args.
+    let mut edges: Vec<CallEdge> = Vec::new();
+    for (caller, f) in program.iter() {
+        collect_call_edges(*caller, &f.body.node, &mut edges);
+    }
+
+    // A fn's return may be bare only when it has at least one visible
+    // NON-tail (ordinary `Call(Fn)`) caller — a fn with no such caller is
+    // externally reachable (a library entry), so changing its return ABI
+    // to `i64` would break an unseen caller. (A self-tail-call is the
+    // recurrence edge, not an external consumer, so it does not count.)
+    let mut has_ordinary_caller: HashSet<FnId> = HashSet::new();
+    for edge in &edges {
+        if !edge.is_tail_self() {
+            has_ordinary_caller.insert(edge.target);
+        }
+    }
+    for (id, br) in bare_return.iter_mut() {
+        if !has_ordinary_caller.contains(id) {
+            *br = false;
+        }
+    }
+
+    loop {
+        let mut changed = false;
+
+        // (A) A bare callee param stays bare only if every caller can
+        //     supply a bare/literal/bounded value at that position.
+        for edge in &edges {
+            let Some(callee_params) = bare_params.get(&edge.target).cloned() else {
+                continue;
+            };
+            for (i, arg) in edge.args.iter().enumerate() {
+                if !callee_params.get(i).copied().unwrap_or(false) {
+                    continue; // already boxed — skip
+                }
+                let ok =
+                    arg_supplies_bare(&arg.node, edge.caller, program, &bare_params, &bare_return);
+                if !ok {
+                    demote_param(&mut bare_params, edge.target, i, &mut changed);
+                }
+            }
+        }
+
+        // (B) The counter must remain in `i64` range across the recurrence
+        //     and the literal-bounded entry. A param is bare only when its
+        //     derived interval provably fits `i64`.
+        for (id, f) in program.iter() {
+            let ip = &int_params[id];
+            for (i, &is_int) in ip.iter().enumerate() {
+                if !bare_params[id].get(i).copied().unwrap_or(false) {
+                    continue;
+                }
+                if !is_int {
+                    demote_param(&mut bare_params, *id, i, &mut changed);
+                    continue;
+                }
+                let bound = param_recurrence_bound(f, i, &edges);
+                let eligible = bound.is_some_and(|iv| {
+                    raw_i64_eligible(Some(iv), std::iter::once(&OpClass::OverflowFree))
+                });
+                if !eligible {
+                    demote_param(&mut bare_params, *id, i, &mut changed);
+                }
+            }
+        }
+
+        // (B2) A bare PARAM must not ESCAPE in its own body. If the counter
+        //      flows into a general-Int context (a boxed callee param, a
+        //      builtin like `Float.fromInt(n)`, an aggregate, or a
+        //      stringify), its representation must be `AverInt` — emitting
+        //      a bare `i64` param whose body reads it through an `AverInt`
+        //      method is a `rustc` type error (and a missed conversion).
+        //      This couples the signature (driven by `bare_params`) to the
+        //      body's escape predicate so the two never disagree. The
+        //      escape set depends on the current bare-param seed (a bare
+        //      callee param does not escape its arg), so recompute it inside
+        //      the fixpoint; demotion is monotone.
+        let tmp = Summary {
+            bare_params: bare_params.clone(),
+            bare_return: bare_return.clone(),
+        };
+        for (id, f) in program.iter() {
+            let mut escaping: HashSet<LocalId> = HashSet::new();
+            scan_escapes(&f.body.node, &tmp, &mut escaping);
+            for (i, p) in f.params.iter().enumerate() {
+                if bare_params[id].get(i).copied().unwrap_or(false) && escaping.contains(&p.local) {
+                    demote_param(&mut bare_params, *id, i, &mut changed);
+                }
+            }
+        }
+
+        // (C) The return is bare only when the body's tail value is itself
+        //     bare-eligible. Recompute the body facts against the current
+        //     seed and demote when the body says the return cannot be bare.
+        for (id, f) in program.iter() {
+            if !bare_return.get(id).copied().unwrap_or(false) {
+                continue;
+            }
+            let tmp = Summary {
+                bare_params: bare_params.clone(),
+                bare_return: bare_return.clone(),
+            };
+            let facts = analyze_fn(f, &tmp);
+            if !facts.bare_return && bare_return.insert(*id, false) != Some(false) {
+                changed = true;
+            }
+        }
+
+        // (C2) A fn's return is bare only if EVERY caller consumes the
+        //      result in an i64-safe position. A bare `i64` return value
+        //      consumed in a general-Int context (an `AverInt`-method
+        //      arithmetic operand, a boxed callee param, an aggregate
+        //      field) would be a `rustc` type error and a missed
+        //      conversion. We do NOT insert per-call-site return
+        //      conversions in this slice, so the conservative rule is:
+        //      mark `bare_return` only when every call result is discarded,
+        //      stringified, or fed where a bare value is accepted (a bare
+        //      param). Any other use demotes the callee's return. This is
+        //      what keeps factorial/countdown (their results are discarded
+        //      or stringified by `main`) bare while a return flowing into
+        //      arithmetic stays boxed.
+        let unsafe_returns = collect_unsafe_return_consumers(program, &bare_params);
+        for id in &unsafe_returns {
+            if bare_return.get(id).copied().unwrap_or(false)
+                && bare_return.insert(*id, false) != Some(false)
+            {
+                changed = true;
+            }
+        }
+
+        if !changed {
+            break;
+        }
+    }
+
+    Summary {
+        bare_params,
+        bare_return,
+    }
+}
+
+/// The set of callee `FnId`s whose return value is consumed in at least
+/// one i64-UNSAFE position by some caller. A bare `i64` return reaching
+/// such a position (an `AverInt` arithmetic operand, a boxed callee param,
+/// an aggregate field, a stringify-incompatible context) would not
+/// type-check, and this slice inserts no per-call-site return conversion —
+/// so any unsafe consumer demotes the callee's `bare_return`.
+///
+/// SAFE consumers (do NOT demote): a discarded result (a `Let` whose
+/// binding is never re-read as a boxed value — approximated as: the call
+/// is the whole RHS and the binding is a fresh i64), a stringify
+/// (`String.fromInt` / interpolation embed), the direct tail value of a
+/// fn whose own return is bare, and an argument at a bare callee param
+/// index. Everything else is unsafe.
+fn collect_unsafe_return_consumers(
+    program: &MirProgram,
+    bare_params: &HashMap<FnId, Vec<bool>>,
+) -> HashSet<FnId> {
+    let mut unsafe_set: HashSet<FnId> = HashSet::new();
+    for (_, f) in program.iter() {
+        scan_return_consumers(&f.body.node, program, bare_params, &mut unsafe_set);
+    }
+    unsafe_set
+}
+
+/// Walk `e`, flagging every `Call(Fn(target))` whose RESULT lands in an
+/// i64-unsafe position. A call reached as a direct child of a SAFE position
+/// (a discard statement, a stringify, a bare param arg, a tail/return that
+/// is itself bare) is not flagged; one reached anywhere else IS. We
+/// approximate by walking each node and classifying the position of any
+/// DIRECT `Call(Fn)` child; nested calls are handled when the walk reaches
+/// their own parent.
+fn scan_return_consumers(
+    e: &MirExpr,
+    program: &MirProgram,
+    bare_params: &HashMap<FnId, Vec<bool>>,
+    unsafe_set: &mut HashSet<FnId>,
+) {
+    // Helper: flag a direct `Call(Fn)` child as unsafe (its result is
+    // consumed in a general-Int position here).
+    let flag_if_call = |child: &MirExpr, unsafe_set: &mut HashSet<FnId>| {
+        if let MirExpr::Call(c) = child
+            && let MirCallee::Fn(t) = c.node.callee
+        {
+            unsafe_set.insert(t);
+        }
+    };
+
+    match e {
+        // Arithmetic / negation operands are i64-UNSAFE for a boxed result
+        // (the boxed-path emit calls `AverInt` methods on the operand).
+        MirExpr::BinOp(b) => {
+            flag_if_call(&b.node.lhs.node, unsafe_set);
+            flag_if_call(&b.node.rhs.node, unsafe_set);
+        }
+        MirExpr::Neg(inner) => flag_if_call(&inner.node, unsafe_set),
+        // Aggregate fields/elements are general-Int contexts.
+        MirExpr::List(items) | MirExpr::Tuple(items) => {
+            for it in items {
+                flag_if_call(&it.node, unsafe_set);
+            }
+        }
+        MirExpr::MapLiteral(pairs) => {
+            for (k, v) in pairs {
+                flag_if_call(&k.node, unsafe_set);
+                flag_if_call(&v.node, unsafe_set);
+            }
+        }
+        MirExpr::Construct(c) => {
+            for a in &c.node.args {
+                flag_if_call(&a.node, unsafe_set);
+            }
+        }
+        MirExpr::RecordCreate(r) => {
+            for fld in &r.node.fields {
+                flag_if_call(&fld.value.node, unsafe_set);
+            }
+        }
+        MirExpr::RecordUpdate(u) => {
+            flag_if_call(&u.node.base.node, unsafe_set);
+            for fld in &u.node.updates {
+                flag_if_call(&fld.value.node, unsafe_set);
+            }
+        }
+        // A call's args: a call result passed at a BOXED callee param index
+        // is unsafe; at a BARE index it is safe (the param accepts i64). A
+        // builtin/intrinsic/fn-value callee that takes Int args treats the
+        // result as a general Int (e.g. `String.fromInt` reads the value) —
+        // those are SAFE for stringify but UNSAFE for arithmetic builtins.
+        // We conservatively treat only `String.fromInt` and interpolation
+        // (handled below) as the stringify-safe sinks; every other builtin
+        // Int arg is unsafe.
+        MirExpr::Call(c) => match c.node.callee {
+            MirCallee::Fn(target) => {
+                for (i, a) in c.node.args.iter().enumerate() {
+                    let bare_param = bare_params
+                        .get(&target)
+                        .and_then(|v| v.get(i).copied())
+                        .unwrap_or(false);
+                    if !bare_param {
+                        flag_if_call(&a.node, unsafe_set);
+                    }
+                }
+            }
+            MirCallee::Builtin(bid) => {
+                let name = program.builtin_name(bid);
+                // `String.fromInt(x)` stringifies its arg — `x.to_string()`
+                // works on both `i64` and `AverInt`, so a bare return here
+                // is SAFE. Every other builtin reads the Int generally.
+                if name != "String.fromInt" {
+                    for a in &c.node.args {
+                        flag_if_call(&a.node, unsafe_set);
+                    }
+                }
+            }
+            MirCallee::Intrinsic(_) | MirCallee::LocalSlot { .. } => {
+                for a in &c.node.args {
+                    flag_if_call(&a.node, unsafe_set);
+                }
+            }
+        },
+        // Interpolation embeds stringify their values — `to_string()` works
+        // on `i64` too, so a call result there is SAFE (do not flag).
+        // A `Let` whose VALUE is a call: the binding holds the result; we
+        // cannot cheaply prove the binding is only re-read safely, so be
+        // conservative and DO NOT flag here (the binding's later uses are
+        // scanned as their own positions). This keeps the discard /
+        // tail-return case bare while still flagging direct arithmetic /
+        // aggregate / boxed-param uses above.
+        _ => {}
+    }
+
+    // Recurse into all children to catch nested consumer positions.
+    visit_children(e, &mut |c| {
+        scan_return_consumers(c, program, bare_params, unsafe_set)
+    });
+}
+
+fn demote_param(
+    bare_params: &mut HashMap<FnId, Vec<bool>>,
+    id: FnId,
+    i: usize,
+    changed: &mut bool,
+) {
+    if let Some(v) = bare_params.get_mut(&id)
+        && let Some(slot) = v.get_mut(i)
+        && *slot
+    {
+        *slot = false;
+        *changed = true;
+    }
+}
+
+/// A visible call edge `target(args…)` made from `caller`. `tail_self` is
+/// `true` for a `MirTailCall` whose target is the caller itself (the
+/// recurrence edge).
+struct CallEdge {
+    target: FnId,
+    caller: FnId,
+    args: Vec<Spanned<MirExpr>>,
+    tail_self: bool,
+}
+
+impl CallEdge {
+    fn is_tail_self(&self) -> bool {
+        self.tail_self
+    }
+}
+
+fn collect_call_edges(caller: FnId, e: &MirExpr, out: &mut Vec<CallEdge>) {
+    match e {
+        MirExpr::Call(c) => {
+            if let MirCallee::Fn(target) = c.node.callee {
+                out.push(CallEdge {
+                    target,
+                    caller,
+                    args: c.node.args.clone(),
+                    tail_self: false,
+                });
+            }
+        }
+        MirExpr::TailCall(tc) => {
+            out.push(CallEdge {
+                target: tc.node.target,
+                caller,
+                args: tc.node.args.clone(),
+                tail_self: tc.node.target == caller,
+            });
+        }
+        _ => {}
+    }
+    visit_children(e, &mut |c| collect_call_edges(caller, c, out));
+}
+
+/// Can the call argument `arg` (evaluated in `caller`) supply a bare /
+/// bounded value at a bare callee param?
+///
+/// - A literal `Int` is always supplyable bare.
+/// - The recurrence arithmetic `n - 1`, `acc * n`, `acc + n` … over bare
+///   operands stays bare (the `i64`-bound is checked separately).
+/// - A read of a caller param that is itself bare is supplyable.
+/// - A call to another fn whose return is bare supplies bare.
+/// - Anything else cannot be supplied bare ⇒ the callee param demotes.
+fn arg_supplies_bare(
+    arg: &MirExpr,
+    caller: FnId,
+    program: &MirProgram,
+    bare_params: &HashMap<FnId, Vec<bool>>,
+    bare_return: &HashMap<FnId, bool>,
+) -> bool {
+    match arg {
+        MirExpr::Literal(l) => matches!(l.node, Literal::Int(_)),
+        MirExpr::Neg(inner) => {
+            arg_supplies_bare(&inner.node, caller, program, bare_params, bare_return)
+        }
+        MirExpr::Local(local) => local_supplies_bare(local.node.slot, caller, program, bare_params),
+        MirExpr::BinOp(b) if matches!(b.node.op, BinOp::Add | BinOp::Sub | BinOp::Mul) => {
+            arg_supplies_bare(&b.node.lhs.node, caller, program, bare_params, bare_return)
+                && arg_supplies_bare(&b.node.rhs.node, caller, program, bare_params, bare_return)
+        }
+        MirExpr::Call(c) => match c.node.callee {
+            MirCallee::Fn(target) => bare_return.get(&target).copied().unwrap_or(false),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+/// Is the caller's slot `slot` a bare param? (Let-bound locals are not
+/// tracked across frames in this minimal summary — they demote.)
+fn local_supplies_bare(
+    slot: LocalId,
+    caller: FnId,
+    program: &MirProgram,
+    bare_params: &HashMap<FnId, Vec<bool>>,
+) -> bool {
+    let Some(f) = program.fn_by_id(caller) else {
+        return false;
+    };
+    for (i, p) in f.params.iter().enumerate() {
+        if p.local == slot {
+            return bare_params
+                .get(&caller)
+                .and_then(|v| v.get(i).copied())
+                .unwrap_or(false);
+        }
+    }
+    false
+}
+
+/// Derive the recurrence bound for param index `i` of `f`: combine the
+/// base-case guard (which bounds the counter on the decrement side) with
+/// the literal entry values from non-recursive callers (which bound it on
+/// the other side) and the monotone decrement.
+///
+/// Returns `Some(interval)` only when the param is provably confined to a
+/// finite `i64` range; `None` is the conservative decline.
+fn param_recurrence_bound(f: &MirFn, i: usize, edges: &[CallEdge]) -> Option<Interval> {
+    let param_slot = f.params.get(i)?.local;
+
+    // 1. The entry envelope: the convex hull of every literal value passed
+    //    at param index `i` by a NON-recursive caller. If any non-literal
+    //    value reaches the param, we cannot bound the entry — decline.
+    let mut entry: Option<Interval> = None;
+    let mut saw_entry = false;
+    for edge in edges {
+        if edge.target != f.fn_id || edge.is_tail_self() {
+            continue;
+        }
+        saw_entry = true;
+        let arg = edge.args.get(i)?;
+        let iv = literal_interval(&arg.node)?;
+        entry = Some(match entry {
+            Some(prev) => prev.hull(iv),
+            None => iv,
+        });
+    }
+    if !saw_entry {
+        // No non-recursive caller — we cannot bound the entry value.
+        return None;
+    }
+    let entry = entry?;
+
+    // 2. The base-case guard + monotone decrement recurrence at the same
+    //    param index. Recognizes `match counter { K -> base; _ ->
+    //    tailcall(counter - step, …) }` (and the lowered `IfThenElse`).
+    let recur = recurrence_for_param(f, param_slot, i)?;
+
+    // 3. Combine. The counter ranges between the base guard (minus the
+    //    transient last step) and the entry envelope. For `n - 1` toward
+    //    `0` with entry `[lo, hi]`, that is `[min(lo, K-step), max(hi, K)]`.
+    let lo = entry.lo.min(Interval::point(recur.guard_k - recur.step).lo);
+    let hi = entry.hi.max(Interval::point(recur.guard_k).hi);
+    Some(Interval { lo, hi })
+}
+
+/// The recognized recurrence shape for a bounded counter.
+struct Recurrence {
+    /// The base-case guard literal `K` (`match counter { K -> … }`).
+    guard_k: i128,
+    /// The decrement step magnitude (`counter - step`, positive literal).
+    step: i128,
+}
+
+/// Recognize the bounded-counter recurrence for param `param_slot` (index
+/// `i`) in `f`'s body: a base-case guard on the counter and a monotone
+/// `counter - step` recursive arg at the SAME index. Returns `None` for
+/// any other shape (accumulators, non-monotone recurrences, missing
+/// guard) — the conservative decline.
+fn recurrence_for_param(f: &MirFn, param_slot: LocalId, i: usize) -> Option<Recurrence> {
+    let guard_k = guard_literal_for(&f.body.node, param_slot)?;
+    let mut recur: Option<Recurrence> = None;
+    find_self_tailcall_recurrence(&f.body.node, f.fn_id, param_slot, i, guard_k, &mut recur);
+    recur
+}
+
+/// Walk for a `Match`/`IfThenElse` that guards the counter against a
+/// literal `K`. Returns the first literal guard `K` found on the counter.
+fn guard_literal_for(e: &MirExpr, counter: LocalId) -> Option<i128> {
+    match e {
+        MirExpr::Match(m) => {
+            if subject_is_local(&m.node.subject.node, counter) {
+                for arm in &m.node.arms {
+                    if let MirPattern::Literal(Literal::Int(k)) = &arm.pattern {
+                        return Some(*k as i128);
+                    }
+                }
+            }
+            guard_literal_for(&m.node.subject.node, counter).or_else(|| {
+                m.node
+                    .arms
+                    .iter()
+                    .find_map(|arm| guard_literal_for(&arm.body.node, counter))
+            })
+        }
+        MirExpr::IfThenElse(ite) => {
+            if let MirExpr::BinOp(b) = &ite.node.cond.node
+                && matches!(
+                    b.node.op,
+                    BinOp::Eq | BinOp::Lt | BinOp::Lte | BinOp::Gt | BinOp::Gte
+                )
+            {
+                if subject_is_local(&b.node.lhs.node, counter)
+                    && let MirExpr::Literal(l) = &b.node.rhs.node
+                    && let Literal::Int(k) = l.node
+                {
+                    return Some(k as i128);
+                }
+                if subject_is_local(&b.node.rhs.node, counter)
+                    && let MirExpr::Literal(l) = &b.node.lhs.node
+                    && let Literal::Int(k) = l.node
+                {
+                    return Some(k as i128);
+                }
+            }
+            guard_literal_for(&ite.node.cond.node, counter)
+                .or_else(|| guard_literal_for(&ite.node.then_branch.node, counter))
+                .or_else(|| guard_literal_for(&ite.node.else_branch.node, counter))
+        }
+        MirExpr::Let(l) => guard_literal_for(&l.node.value.node, counter)
+            .or_else(|| guard_literal_for(&l.node.body.node, counter)),
+        _ => {
+            let mut found = None;
+            visit_children(e, &mut |c| {
+                if found.is_none() {
+                    found = guard_literal_for(c, counter);
+                }
+            });
+            found
+        }
+    }
+}
+
+/// Find a self-`TailCall` and check whether its arg at index `i` is a
+/// monotone `counter - step` (decrement of a positive literal). Records the
+/// [`Recurrence`] on the first match.
+fn find_self_tailcall_recurrence(
+    e: &MirExpr,
+    self_fn: FnId,
+    counter: LocalId,
+    i: usize,
+    guard_k: i128,
+    out: &mut Option<Recurrence>,
+) {
+    if out.is_some() {
+        return;
+    }
+    if let MirExpr::TailCall(tc) = e
+        && tc.node.target == self_fn
+        && let Some(arg) = tc.node.args.get(i)
+        && let Some(step) = decrement_step(&arg.node, counter)
+    {
+        *out = Some(Recurrence { guard_k, step });
+        return;
+    }
+    visit_children(e, &mut |c| {
+        find_self_tailcall_recurrence(c, self_fn, counter, i, guard_k, out)
+    });
+}
+
+/// If `e` is `counter - K` (a positive literal `K`), return `K`. The only
+/// monotone-decrement shape we recognize today.
+fn decrement_step(e: &MirExpr, counter: LocalId) -> Option<i128> {
+    if let MirExpr::BinOp(b) = e
+        && matches!(b.node.op, BinOp::Sub)
+        && subject_is_local(&b.node.lhs.node, counter)
+        && let MirExpr::Literal(l) = &b.node.rhs.node
+        && let Literal::Int(k) = l.node
+        && k > 0
+    {
+        return Some(k as i128);
+    }
+    None
+}
+
+fn subject_is_local(e: &MirExpr, slot: LocalId) -> bool {
+    matches!(e, MirExpr::Local(l) if l.node.slot == slot)
+}
+
+/// Extract a bounded literal interval from a call argument (a bare `Int`
+/// literal, or a negated one). `None` for any non-literal — the
+/// conservative decline.
+fn literal_interval(arg: &MirExpr) -> Option<Interval> {
+    match arg {
+        MirExpr::Literal(l) => match l.node {
+            Literal::Int(k) => Some(Interval::point(k as i128)),
+            _ => None,
+        },
+        MirExpr::Neg(inner) => match &inner.node {
+            MirExpr::Literal(l) => match l.node {
+                Literal::Int(k) => Some(Interval::point(-(k as i128))),
+                _ => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+// ── Per-fn body analysis (range + escape) ───────────────────────────────
+
+/// Compute the per-`LocalId` value facts for `f` given the cross-frame
+/// `summary` (which params/returns are bare). The body walk derives an
+/// interval per slot (bottom-up over the `Let` chain), an escape predicate
+/// (a single use-flow scan), and combines them via `raw_i64_eligible`.
+fn analyze_fn(f: &MirFn, summary: &Summary) -> FnBareFacts {
+    let mut facts = FnBareFacts::default();
+
+    // 1. Range: seed param intervals from the summary. A bare param is by
+    //    construction confined to `i64`, so seed a full-`i64` interval;
+    //    a boxed param is unbounded.
+    let mut intervals: HashMap<LocalId, Interval> = HashMap::new();
+    let mut bare_params = vec![false; f.params.len()];
+    for (i, p) in f.params.iter().enumerate() {
+        let is_bare = summary.param_bare(f.fn_id, i);
+        bare_params[i] = is_bare;
+        let iv = if is_bare {
+            Interval::between(i64::MIN as i128, i64::MAX as i128)
+        } else {
+            Interval::unbounded()
+        };
+        intervals.insert(p.local, iv);
+    }
+    facts.bare_params = bare_params;
+
+    // 2. Walk the body's `Let` chain, deriving an interval (+ worst-join
+    //    op class) for each bound slot.
+    let mut op_classes: HashMap<LocalId, OpClass> = HashMap::new();
+    walk_let_chain(&f.body.node, &mut intervals, &mut op_classes);
+
+    // 3. Escape: a single use-flow scan. A slot escapes if any use-site is
+    //    a general-Int context.
+    let mut escaping: HashSet<LocalId> = HashSet::new();
+    scan_escapes(&f.body.node, summary, &mut escaping);
+
+    // 4. Combine.
+    for (slot, iv) in &intervals {
+        let op_class = op_classes
+            .get(slot)
+            .copied()
+            .unwrap_or(OpClass::OverflowFree);
+        let escapes = escaping.contains(slot);
+        let eligible = raw_i64_eligible(Some(*iv), std::iter::once(&op_class));
+        let repr = if eligible && !escapes {
+            Repr::Bare
+        } else {
+            Repr::Boxed
+        };
+        facts.values.insert(
+            *slot,
+            ValueFact {
+                interval: Some(*iv),
+                op_class,
+                escapes,
+                repr,
+            },
+        );
+    }
+    // Params absent from the Let walk still get a fact (their seed).
+    for (i, p) in f.params.iter().enumerate() {
+        let is_bare = summary.param_bare(f.fn_id, i);
+        facts.values.entry(p.local).or_insert_with(|| {
+            if is_bare {
+                ValueFact {
+                    interval: intervals.get(&p.local).copied(),
+                    op_class: OpClass::OverflowFree,
+                    escapes: false,
+                    repr: Repr::Bare,
+                }
+            } else {
+                ValueFact::boxed()
+            }
+        });
+    }
+
+    // 5. Return: bare iff the summary says so AND the body's tail value is
+    //    itself bare-eligible.
+    facts.bare_return =
+        summary.return_bare(f.fn_id) && tail_value_is_bare(&f.body.node, &facts, &escaping);
+
+    facts
+}
+
+/// Walk the `Let` chain, recording each bound slot's interval and worst-
+/// join op class. `env` holds param + already-bound intervals and is grown
+/// in place; branches recurse so nested bindings are seen.
+fn walk_let_chain(
+    e: &MirExpr,
+    env: &mut HashMap<LocalId, Interval>,
+    op_classes: &mut HashMap<LocalId, OpClass>,
+) {
+    match e {
+        MirExpr::Let(l) => {
+            let mut worst = Interval::point(0);
+            let iv = eval_interval(&l.node.value.node, env, &mut worst);
+            env.insert(l.node.binding, iv);
+            // The binding's op class is the worst-join over its value
+            // expression (so a transient out-of-i64 intermediate demotes).
+            op_classes.insert(l.node.binding, OpClass::of_interval(worst.hull(iv)));
+            walk_let_chain(&l.node.value.node, env, op_classes);
+            walk_let_chain(&l.node.body.node, env, op_classes);
+        }
+        _ => {
+            visit_children(e, &mut |c| walk_let_chain(c, env, op_classes));
+        }
+    }
+}
+
+/// Abstractly evaluate a MIR expression to its interval, joining each
+/// arithmetic node into `worst` (so a transient out-of-i64 intermediate
+/// demotes the binding). Unknown shapes evaluate to `unbounded()`.
+fn eval_interval(e: &MirExpr, env: &HashMap<LocalId, Interval>, worst: &mut Interval) -> Interval {
+    match e {
+        MirExpr::Literal(l) => match l.node {
+            Literal::Int(k) => Interval::point(k as i128),
+            _ => Interval::unbounded(),
+        },
+        MirExpr::Local(local) => env
+            .get(&local.node.slot)
+            .copied()
+            .unwrap_or_else(Interval::unbounded),
+        MirExpr::Neg(inner) => {
+            let r = Interval::point(0).sub(eval_interval(&inner.node, env, worst));
+            *worst = worst.hull(r);
+            r
+        }
+        MirExpr::BinOp(b) => {
+            let l = eval_interval(&b.node.lhs.node, env, worst);
+            let r = eval_interval(&b.node.rhs.node, env, worst);
+            let result = match b.node.op {
+                BinOp::Add => l.add(r),
+                BinOp::Sub => l.sub(r),
+                BinOp::Mul => l.mul(r),
+                _ => Interval::unbounded(),
+            };
+            *worst = worst.hull(result);
+            result
+        }
+        _ => Interval::unbounded(),
+    }
+}
+
+/// Single use-flow escape scan. A slot escapes if it (a) is passed to a
+/// general (boxed) Int param of a callee, (b) is stored in an aggregate,
+/// or (c) is stringified. We over-approximate: any unrecognized use of a
+/// slot defaults to escaping.
+fn scan_escapes(e: &MirExpr, summary: &Summary, out: &mut HashSet<LocalId>) {
+    match e {
+        // Aggregates: every Int element/field escapes.
+        MirExpr::List(items) | MirExpr::Tuple(items) => {
+            for it in items {
+                mark_operand_escapes(&it.node, out);
+                scan_escapes(&it.node, summary, out);
+            }
+        }
+        MirExpr::MapLiteral(pairs) => {
+            for (k, v) in pairs {
+                mark_operand_escapes(&k.node, out);
+                mark_operand_escapes(&v.node, out);
+                scan_escapes(&k.node, summary, out);
+                scan_escapes(&v.node, summary, out);
+            }
+        }
+        MirExpr::Construct(c) => {
+            for a in &c.node.args {
+                mark_operand_escapes(&a.node, out);
+                scan_escapes(&a.node, summary, out);
+            }
+        }
+        MirExpr::RecordCreate(r) => {
+            for fld in &r.node.fields {
+                mark_operand_escapes(&fld.value.node, out);
+                scan_escapes(&fld.value.node, summary, out);
+            }
+        }
+        MirExpr::RecordUpdate(u) => {
+            mark_operand_escapes(&u.node.base.node, out);
+            scan_escapes(&u.node.base.node, summary, out);
+            for fld in &u.node.updates {
+                mark_operand_escapes(&fld.value.node, out);
+                scan_escapes(&fld.value.node, summary, out);
+            }
+        }
+        MirExpr::IndependentProduct(ip) => {
+            for it in &ip.node.items {
+                mark_operand_escapes(&it.node, out);
+                scan_escapes(&it.node, summary, out);
+            }
+        }
+        // Stringification: every embedded value escapes.
+        MirExpr::InterpolatedStr(parts) => {
+            for p in parts {
+                if let super::super::expr::MirStrPart::Expr(ex) = p {
+                    mark_operand_escapes(&ex.node, out);
+                    scan_escapes(&ex.node, summary, out);
+                }
+            }
+        }
+        // A call: an arg at a BOXED callee-param index escapes; an arg at a
+        // BARE param index converts at the boundary and does NOT escape. A
+        // builtin / intrinsic / fn-value callee is conservative — every Int
+        // arg escapes (we don't model builtin param reps).
+        MirExpr::Call(c) => match c.node.callee {
+            MirCallee::Fn(target) => {
+                for (i, a) in c.node.args.iter().enumerate() {
+                    if !summary.param_bare(target, i) {
+                        mark_operand_escapes(&a.node, out);
+                    }
+                    scan_escapes(&a.node, summary, out);
+                }
+            }
+            _ => {
+                for a in &c.node.args {
+                    mark_operand_escapes(&a.node, out);
+                    scan_escapes(&a.node, summary, out);
+                }
+            }
+        },
+        // A tail call: same, against the (self) callee's bare params.
+        MirExpr::TailCall(tc) => {
+            for (i, a) in tc.node.args.iter().enumerate() {
+                if !summary.param_bare(tc.node.target, i) {
+                    mark_operand_escapes(&a.node, out);
+                }
+                scan_escapes(&a.node, summary, out);
+            }
+        }
+        // Control flow + arithmetic: recurse. A bare Local in tail/return
+        // or arithmetic-operand position is consumed bare (no escape).
+        _ => {
+            visit_children(e, &mut |c| scan_escapes(c, summary, out));
+        }
+    }
+}
+
+/// Mark the slot of a value that flows DIRECTLY into an escaping position.
+///
+/// Only a bare `Local` read placed verbatim at a general-Int context
+/// escapes — its representation must then be `AverInt` (the value itself
+/// crosses the boundary). An ARITHMETIC expression (`acc * n`) at an
+/// escaping position does NOT escape its operands: the operands are
+/// consumed to compute a FRESH result, and that result (a new temp) is
+/// what crosses the boundary; each operand is converted at the arithmetic
+/// site (`boxed_int_operand` wraps a bare operand with `from_i64`) and
+/// keeps its own representation. So a counter read inside `acc * n` that
+/// feeds a boxed accumulator must NOT be flagged — flagging it was the bug
+/// that demoted the factorial counter. Hence: do not recurse into
+/// `BinOp` / `Neg`.
+fn mark_operand_escapes(e: &MirExpr, out: &mut HashSet<LocalId>) {
+    if let MirExpr::Local(l) = e {
+        out.insert(l.node.slot);
+    }
+}
+
+/// Does the fn's tail value evaluate to a bare-eligible value? The tail is
+/// the base-case value(s) reached after the `Let` chain / branches. We
+/// require every reachable tail leaf to be a bare-eligible Local or a bare
+/// literal; anything else demotes the return.
+fn tail_value_is_bare(e: &MirExpr, facts: &FnBareFacts, escaping: &HashSet<LocalId>) -> bool {
+    match e {
+        MirExpr::Local(l) => facts.is_bare(l.node.slot) && !escaping.contains(&l.node.slot),
+        MirExpr::Literal(l) => matches!(l.node, Literal::Int(_)),
+        MirExpr::Let(let_node) => tail_value_is_bare(&let_node.node.body.node, facts, escaping),
+        MirExpr::Match(m) => m
+            .node
+            .arms
+            .iter()
+            .all(|arm| tail_value_is_bare(&arm.body.node, facts, escaping)),
+        MirExpr::IfThenElse(ite) => {
+            tail_value_is_bare(&ite.node.then_branch.node, facts, escaping)
+                && tail_value_is_bare(&ite.node.else_branch.node, facts, escaping)
+        }
+        // A self-tail-call's value is the recurrence, not a base value; it
+        // does not constrain the return repr.
+        MirExpr::TailCall(_) => true,
+        MirExpr::Return(inner) => tail_value_is_bare(&inner.node, facts, escaping),
+        MirExpr::BinOp(b) if matches!(b.node.op, BinOp::Add | BinOp::Sub | BinOp::Mul) => {
+            tail_value_is_bare(&b.node.lhs.node, facts, escaping)
+                && tail_value_is_bare(&b.node.rhs.node, facts, escaping)
+        }
+        _ => false,
+    }
+}
+
+// ── shared traversal + helpers ──────────────────────────────────────────
+
+fn collect_fn_values(e: &MirExpr, out: &mut HashSet<String>) {
+    if let MirExpr::FnValue(name) = e {
+        out.insert(name.clone());
+    }
+    visit_children(e, &mut |c| collect_fn_values(c, out));
+}
+
+/// `true` when the source type-annotation string is exactly `Int`.
+fn ty_str_is_int(ty: &str) -> bool {
+    ty == "Int"
+}
+
+/// `true` when the `Type` stamp is exactly `Int`. Exposed for the Rust
+/// walker's consumption sites.
+pub fn type_is_int(ty: Option<&Type>) -> bool {
+    matches!(ty, Some(Type::Int))
+}
+
+/// Apply `f` to every immediate sub-expression of `e`. Kept in sync with
+/// the exhaustive walk in `own_param.rs` / `instantiations.rs`.
+fn visit_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {
+    match e {
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
+        MirExpr::Let(l) => {
+            f(&l.node.value.node);
+            f(&l.node.body.node);
+        }
+        MirExpr::Call(c) => {
+            for a in &c.node.args {
+                f(&a.node);
+            }
+        }
+        MirExpr::TailCall(tc) => {
+            for a in &tc.node.args {
+                f(&a.node);
+            }
+        }
+        MirExpr::BinOp(b) => {
+            f(&b.node.lhs.node);
+            f(&b.node.rhs.node);
+        }
+        MirExpr::Neg(inner) | MirExpr::Try(inner) | MirExpr::Return(inner) => f(&inner.node),
+        MirExpr::Match(m) => {
+            f(&m.node.subject.node);
+            for arm in &m.node.arms {
+                f(&arm.body.node);
+            }
+        }
+        MirExpr::Construct(c) => {
+            for a in &c.node.args {
+                f(&a.node);
+            }
+        }
+        MirExpr::RecordCreate(r) => {
+            for field in &r.node.fields {
+                f(&field.value.node);
+            }
+        }
+        MirExpr::RecordUpdate(u) => {
+            f(&u.node.base.node);
+            for field in &u.node.updates {
+                f(&field.value.node);
+            }
+        }
+        MirExpr::Project(p) => f(&p.node.base.node),
+        MirExpr::IfThenElse(ite) => {
+            f(&ite.node.cond.node);
+            f(&ite.node.then_branch.node);
+            f(&ite.node.else_branch.node);
+        }
+        MirExpr::List(items) | MirExpr::Tuple(items) => {
+            for i in items {
+                f(&i.node);
+            }
+        }
+        MirExpr::MapLiteral(pairs) => {
+            for (k, v) in pairs {
+                f(&k.node);
+                f(&v.node);
+            }
+        }
+        MirExpr::InterpolatedStr(parts) => {
+            for p in parts {
+                if let super::super::expr::MirStrPart::Expr(e) = p {
+                    f(&e.node);
+                }
+            }
+        }
+        MirExpr::IndependentProduct(ip) => {
+            for i in &ip.node.items {
+                f(&i.node);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::mir::{lower_program, optimize};
+    use crate::source::parse_source;
+
+    fn facts_for(src: &str) -> (MirProgram, BareI64Facts) {
+        let mut items = parse_source(src).expect("parse");
+        let cfg = crate::ir::pipeline::PipelineConfig {
+            typecheck: Some(crate::ir::pipeline::TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        };
+        let result = crate::ir::pipeline::run(&mut items, cfg);
+        assert!(
+            result
+                .typecheck
+                .as_ref()
+                .is_none_or(|t| t.errors.is_empty()),
+            "typecheck errors: {:?}",
+            result.typecheck.map(|t| t.errors)
+        );
+        let mir_items: Vec<crate::ir::hir::ResolvedTopLevel> = result.resolved_items.clone();
+        let program = optimize(lower_program(&mir_items));
+        let facts = analyze(&program);
+        (program, facts)
+    }
+
+    fn fn_id_by_name<'a>(program: &'a MirProgram, name: &str) -> crate::ir::FnId {
+        program
+            .iter()
+            .find(|(_, f)| f.name == name)
+            .map(|(id, _)| *id)
+            .unwrap_or_else(|| panic!("fn `{name}` not in program"))
+    }
+
+    #[test]
+    fn countdown_counter_is_bare() {
+        let src = r#"
+module Countdown
+    intent = "t"
+    depends []
+
+fn countdown(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> countdown(n - 1)
+
+fn main() -> Int
+    countdown(20000)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "countdown");
+        let f = facts.for_fn(id).expect("countdown facts");
+        assert!(
+            f.param_is_bare(0),
+            "the countdown counter must be proven bare i64"
+        );
+    }
+
+    #[test]
+    fn factorial_counter_is_bare() {
+        let src = r#"
+module Factorial
+    intent = "t"
+    depends []
+
+fn factorial(n: Int, acc: Int) -> Int
+    match n
+        0 -> acc
+        _ -> factorial(n - 1, acc * n)
+
+fn main() -> Int
+    factorial(10, 1)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "factorial");
+        let f = facts.for_fn(id).expect("factorial facts");
+        assert!(
+            f.param_is_bare(0),
+            "the factorial counter `n` must be proven bare i64"
+        );
+    }
+
+    #[test]
+    fn unbounded_param_stays_boxed() {
+        // A fn called with a non-literal arg cannot bound its counter, so
+        // the param must stay boxed (fail-closed).
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn down(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> down(n - 1)
+
+fn caller(x: Int) -> Int
+    down(x)
+
+fn main() -> Int
+    caller(5)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "down");
+        let f = facts.for_fn(id).expect("down facts");
+        // `down` is called with `x` (a non-literal param of `caller`), and
+        // `caller`'s `x` comes from a literal — but the minimal summary
+        // only bounds DIRECT literal callers, so `down`'s counter is not
+        // provably bounded here and must stay boxed.
+        assert!(
+            !f.param_is_bare(0),
+            "a counter reached via a non-literal arg must stay boxed (fail-closed)"
+        );
+    }
+
+    #[test]
+    fn non_recursive_fn_param_stays_boxed() {
+        // A non-recursive fn has no recurrence to bound its param; with no
+        // base-case guard the counter is unbounded ⇒ boxed (fail-closed).
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn twice(n: Int) -> Int
+    n + n
+
+fn main() -> Int
+    twice(10)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "twice");
+        let f = facts.for_fn(id).expect("twice facts");
+        assert!(
+            !f.param_is_bare(0),
+            "a param with no bounding recurrence must stay boxed"
+        );
+    }
+
+    #[test]
+    fn counter_stored_in_aggregate_demotes_via_escape() {
+        // A bounded counter whose value is STORED in a list escapes (reaches
+        // a general-Int aggregate), so the analysis must not mark the
+        // value bare. We assert the body's escape predicate flags it: a
+        // counter read into `[n]` is a general-Int aggregate store.
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn collect(n: Int) -> List<Int>
+    match n
+        0 -> [0]
+        _ -> [n]
+
+fn main() -> List<Int>
+    collect(10)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "collect");
+        let f = facts.for_fn(id).expect("collect facts");
+        // The return type is `List<Int>`, not `Int`, so the return is never
+        // bare; and `n` flows into the `[n]` aggregate, an escape. The
+        // param must stay boxed.
+        assert!(
+            !f.param_is_bare(0),
+            "a counter stored in a List aggregate escapes → must stay boxed"
+        );
+        assert!(!f.bare_return, "a List<Int> return is never bare i64");
+    }
+
+    #[test]
+    fn worst_join_demotes_transient_out_of_i64_intermediate() {
+        // The reused #511 worst-join discipline: `(n + i64::MAX) - i64::MAX`
+        // cancels back into range, but the transient `n + i64::MAX`
+        // overflows i64, so the binding's op class must NOT be
+        // `OverflowFree`. Exercise the `eval_interval` + worst-join the body
+        // pass uses, over a bare-param-seeded `n ∈ [0, 10]`.
+        let mut env = HashMap::new();
+        let n = LocalId(0);
+        env.insert(n, Interval::between(0, 10));
+        let big = i64::MAX as i128;
+
+        // Build the MIR for `(n + MAX) - MAX`.
+        let lit = |k: i128| Spanned::bare(MirExpr::Literal(Spanned::bare(Literal::Int(k as i64))));
+        let local_n = Spanned::bare(MirExpr::Local(Spanned::bare(
+            super::super::super::expr::MirLocal::at(n),
+        )));
+        let add = Spanned::bare(MirExpr::BinOp(Spanned::bare(
+            super::super::super::expr::MirBinOp {
+                op: BinOp::Add,
+                lhs: Box::new(local_n),
+                rhs: Box::new(lit(big)),
+            },
+        )));
+        let sub = MirExpr::BinOp(Spanned::bare(super::super::super::expr::MirBinOp {
+            op: BinOp::Sub,
+            lhs: Box::new(add),
+            rhs: Box::new(lit(big)),
+        }));
+
+        let mut worst = Interval::point(0);
+        let result = eval_interval(&sub, &env, &mut worst);
+        // The final value cancels back into [0, 10] (fits i64) …
+        assert!(result.fits_i64(), "final value cancels back into range");
+        // … but the worst-join saw the transient `n + i64::MAX` (out of i64),
+        // so the op class over the whole expression is NOT OverflowFree.
+        assert_ne!(
+            OpClass::of_interval(worst.hull(result)),
+            OpClass::OverflowFree,
+            "the transient out-of-i64 intermediate must demote below OverflowFree"
+        );
+    }
+}

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -116,6 +116,78 @@ impl FnBareFacts {
     pub fn param_is_bare(&self, i: usize) -> bool {
         self.bare_params.get(i).copied().unwrap_or(false)
     }
+
+    /// The interval over-approximation of a value bound to `slot`, when the
+    /// analysis derived one and proved the slot `Bare`. `None` for a boxed
+    /// or unknown slot — the conservative decline.
+    fn bare_slot_interval(&self, slot: LocalId) -> Option<Interval> {
+        let fact = self.values.get(&slot)?;
+        if !fact.is_bare() {
+            return None;
+        }
+        fact.interval
+    }
+
+    /// Compute the result interval of an EXPRESSION TREE built only from
+    /// bare leaves (`Local`s the analysis proved `Bare`, `Int` literals) and
+    /// `Add`/`Sub`/`Mul`/`Neg` nodes, using the saturating #511 interval
+    /// arithmetic. Returns `None` if any leaf is non-bare / unknown or the
+    /// node is an unsupported shape — the conservative decline.
+    ///
+    /// This is the SINGLE SOURCE OF TRUTH for "what interval does this
+    /// inline compound evaluate to": both the analysis's `tail_value_is_bare`
+    /// and the Rust backend's `mir_expr_is_bare_i64` route a compound through
+    /// here, so neither can accept a tree whose result leaves `i64`.
+    pub fn bare_expr_interval(&self, e: &MirExpr) -> Option<Interval> {
+        match e {
+            MirExpr::Literal(l) => match l.node {
+                Literal::Int(k) => Some(Interval::point(k as i128)),
+                _ => None,
+            },
+            MirExpr::Local(local) => self.bare_slot_interval(local.node.slot),
+            MirExpr::Neg(inner) => {
+                let r = Interval::point(0).sub(self.bare_expr_interval(&inner.node)?);
+                Some(r)
+            }
+            MirExpr::BinOp(b) => {
+                let l = self.bare_expr_interval(&b.node.lhs.node)?;
+                let r = self.bare_expr_interval(&b.node.rhs.node)?;
+                match b.node.op {
+                    BinOp::Add => Some(l.add(r)),
+                    BinOp::Sub => Some(l.sub(r)),
+                    BinOp::Mul => Some(l.mul(r)),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Is `e` a bare-`i64`-eligible expression? A `Local`/`Int` leaf the
+    /// analysis proved `Bare`, or an `Add`/`Sub`/`Mul`/`Neg` tree over such
+    /// leaves WHOSE RESULT INTERVAL provably fits `i64` (every intermediate
+    /// stays `OverflowFree` under the saturating interval arithmetic).
+    ///
+    /// SOUNDNESS (BUG 2): a compound is bare ONLY when its result interval
+    /// ⊆ `i64`. An overflowing compound like `n + i64::MAX` (result
+    /// `[MAX+1, …]`, outside `i64`) is NOT bare, so codegen must emit the
+    /// boxed `AverInt` arithmetic with `from_i64` boundary conversions — the
+    /// raw-`i64` path would silently wrap (`overflow-checks = false`).
+    pub fn expr_is_bare_i64(&self, e: &MirExpr) -> bool {
+        match e {
+            // A direct bare leaf: `Local` proven `Bare`, or an `Int` literal
+            // (an exact point — its `i64`-fit is checked by the enclosing
+            // compound's interval; a standalone literal is always a sound
+            // `{N}i64` constant on a bare path the analysis already gated).
+            MirExpr::Literal(l) => matches!(l.node, Literal::Int(_)),
+            MirExpr::Local(local) => self.is_bare(local.node.slot),
+            // A compound: require the WHOLE-TREE result interval to fit i64.
+            MirExpr::Neg(_) | MirExpr::BinOp(_) => self.bare_expr_interval(e).is_some_and(|iv| {
+                raw_i64_eligible(Some(iv), std::iter::once(&OpClass::OverflowFree))
+            }),
+            _ => false,
+        }
+    }
 }
 
 /// Whole-program representation-selection facts, keyed by `FnId`. Built
@@ -191,6 +263,14 @@ pub fn analyze(program: &MirProgram) -> BareI64Facts {
 struct Summary {
     bare_params: HashMap<FnId, Vec<bool>>,
     bare_return: HashMap<FnId, bool>,
+    /// Per-param TIGHT recurrence interval (`param_recurrence_bound`), so the
+    /// body pass can seed a bare counter with its PROVEN range
+    /// (`[K-step, entry]`) instead of the full `i64` line. This is what keeps
+    /// `n - 1` / `acc * n` over a bare counter in the OverflowFree band: a
+    /// full-`i64` seed makes every `+`/`-`/`*` over the counter look like it
+    /// could overflow, demoting the fast decrement to a boxed round-trip. A
+    /// `None` entry (or a missing param) falls back to the full-`i64` seed.
+    bare_param_intervals: HashMap<FnId, Vec<Option<Interval>>>,
 }
 
 impl Summary {
@@ -203,6 +283,15 @@ impl Summary {
 
     fn return_bare(&self, id: FnId) -> bool {
         self.bare_return.get(&id).copied().unwrap_or(false)
+    }
+
+    /// The proven recurrence interval for param `i` of `id`, if one was
+    /// derived. `None` ⇒ the body pass seeds the full `i64` range.
+    fn param_interval(&self, id: FnId, i: usize) -> Option<Interval> {
+        self.bare_param_intervals
+            .get(&id)
+            .and_then(|v| v.get(i).copied())
+            .flatten()
     }
 }
 
@@ -250,6 +339,20 @@ fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) 
         }
     }
 
+    // Tight per-param recurrence intervals, computed ONCE: they are a pure
+    // function of the recurrence shape + literal entry callers, independent
+    // of the fixpoint's escape/return state, so they stay valid across
+    // iterations. A bare counter is seeded with this proven range in the
+    // body pass instead of the full `i64` line, keeping `n - 1` / `acc * n`
+    // OverflowFree (see `Summary::bare_param_intervals`).
+    let mut bare_param_intervals: HashMap<FnId, Vec<Option<Interval>>> = HashMap::new();
+    for (id, f) in program.iter() {
+        let ivs: Vec<Option<Interval>> = (0..f.params.len())
+            .map(|i| param_recurrence_bound(f, i, &edges))
+            .collect();
+        bare_param_intervals.insert(*id, ivs);
+    }
+
     loop {
         let mut changed = false;
 
@@ -273,8 +376,9 @@ fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) 
 
         // (B) The counter must remain in `i64` range across the recurrence
         //     and the literal-bounded entry. A param is bare only when its
-        //     derived interval provably fits `i64`.
-        for (id, f) in program.iter() {
+        //     derived interval (precomputed in `bare_param_intervals`)
+        //     provably fits `i64`.
+        for (id, _f) in program.iter() {
             let ip = &int_params[id];
             for (i, &is_int) in ip.iter().enumerate() {
                 if !bare_params[id].get(i).copied().unwrap_or(false) {
@@ -284,7 +388,10 @@ fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) 
                     demote_param(&mut bare_params, *id, i, &mut changed);
                     continue;
                 }
-                let bound = param_recurrence_bound(f, i, &edges);
+                let bound = bare_param_intervals
+                    .get(id)
+                    .and_then(|v| v.get(i).copied())
+                    .flatten();
                 let eligible = bound.is_some_and(|iv| {
                     raw_i64_eligible(Some(iv), std::iter::once(&OpClass::OverflowFree))
                 });
@@ -308,6 +415,7 @@ fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) 
         let tmp = Summary {
             bare_params: bare_params.clone(),
             bare_return: bare_return.clone(),
+            bare_param_intervals: bare_param_intervals.clone(),
         };
         for (id, f) in program.iter() {
             let mut escaping: HashSet<LocalId> = HashSet::new();
@@ -329,6 +437,7 @@ fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) 
             let tmp = Summary {
                 bare_params: bare_params.clone(),
                 bare_return: bare_return.clone(),
+                bare_param_intervals: bare_param_intervals.clone(),
             };
             let facts = analyze_fn(f, &tmp);
             if !facts.bare_return && bare_return.insert(*id, false) != Some(false) {
@@ -366,6 +475,7 @@ fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) 
     Summary {
         bare_params,
         bare_return,
+        bare_param_intervals,
     }
 }
 
@@ -628,9 +738,37 @@ fn local_supplies_bare(
 fn param_recurrence_bound(f: &MirFn, i: usize, edges: &[CallEdge]) -> Option<Interval> {
     let param_slot = f.params.get(i)?.local;
 
-    // 1. The entry envelope: the convex hull of every literal value passed
+    // 1. The base-case guard + monotone decrement recurrence at the same
+    //    param index. Recognizes `match counter { K -> base; _ ->
+    //    tailcall(counter - step, …) }` (and the lowered `IfThenElse`).
+    //    Done FIRST so we can validate each entry literal against the
+    //    recognized `(guard_k, step)` as we hull it.
+    let recur = recurrence_for_param(f, param_slot, i)?;
+
+    // A decrement counter toward an EQUALITY guard `K` (`match n { K -> … }`)
+    // only certifies a finite range when the sequence `entry - m*step`
+    // actually LANDS on `K`. A comparison-direction guard (`<`/`<=`/`>`/`>=`)
+    // does not pin the stopping value, so we cannot bound the far endpoint —
+    // DECLINE (box; sound, only costs speed on a shape that may not occur).
+    if recur.guard_kind != GuardKind::Equality {
+        return None;
+    }
+
+    // 2. The entry envelope: the convex hull of every literal value passed
     //    at param index `i` by a NON-recursive caller. If any non-literal
     //    value reaches the param, we cannot bound the entry — decline.
+    //
+    //    REACHABILITY (the BUG-1 guard): for a decrement counter (step > 0)
+    //    toward the equality guard `K`, the `entry - m*step` sequence hits
+    //    `K` exactly when BOTH:
+    //      (a) `entry >= K` — the decrement moves TOWARD K, not away; and
+    //      (b) `(entry - K) % step == 0` — `K` is congruent to `entry`
+    //          mod `step`, so the sequence lands ON `K` rather than
+    //          stepping OVER it (which would diverge to -inf, leaving the
+    //          certified interval and wrapping i64).
+    //    `step == 1` always divides, so countdown / factorial (guard 0,
+    //    step 1, positive entry) still pass. Any entry literal that fails
+    //    EITHER condition makes the recurrence unbounded ⇒ decline.
     let mut entry: Option<Interval> = None;
     let mut saw_entry = false;
     for edge in edges {
@@ -640,6 +778,17 @@ fn param_recurrence_bound(f: &MirFn, i: usize, edges: &[CallEdge]) -> Option<Int
         saw_entry = true;
         let arg = edge.args.get(i)?;
         let iv = literal_interval(&arg.node)?;
+        // `literal_interval` yields a point `[v, v]`, so validating the
+        // single endpoint validates the whole point.
+        let v = match iv.lo {
+            crate::ir::interval::Bound::Finite(v) => v,
+            _ => return None,
+        };
+        if v < recur.guard_k || (v - recur.guard_k) % recur.step != 0 {
+            // The decrement never lands on the equality guard from this
+            // entry — the counter diverges past `K`. Decline.
+            return None;
+        }
         entry = Some(match entry {
             Some(prev) => prev.hull(iv),
             None => iv,
@@ -651,11 +800,6 @@ fn param_recurrence_bound(f: &MirFn, i: usize, edges: &[CallEdge]) -> Option<Int
     }
     let entry = entry?;
 
-    // 2. The base-case guard + monotone decrement recurrence at the same
-    //    param index. Recognizes `match counter { K -> base; _ ->
-    //    tailcall(counter - step, …) }` (and the lowered `IfThenElse`).
-    let recur = recurrence_for_param(f, param_slot, i)?;
-
     // 3. Combine. The counter ranges between the base guard (minus the
     //    transient last step) and the entry envelope. For `n - 1` toward
     //    `0` with entry `[lo, hi]`, that is `[min(lo, K-step), max(hi, K)]`.
@@ -664,12 +808,30 @@ fn param_recurrence_bound(f: &MirFn, i: usize, edges: &[CallEdge]) -> Option<Int
     Some(Interval { lo, hi })
 }
 
+/// How the base-case guard `K` compares the counter against the literal.
+/// ONLY an `Equality` guard (`match counter { K -> … }` / the lowered
+/// `IfThenElse` over `counter == K`) lets the decrement sequence be proven
+/// to LAND on `K`; every comparison-direction guard (`<`, `<=`, `>`, `>=`)
+/// is a half-bounded test that does not pin the exact stopping value, so it
+/// cannot be used to bound the recurrence's far endpoint — those DECLINE.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuardKind {
+    /// `counter == K` (a `Match` literal arm, or `IfThenElse` over `Eq`).
+    Equality,
+    /// `<`, `<=`, `>`, `>=` against `K` — a half-bounded comparison whose
+    /// exact stopping value is unknown. The conservative decline.
+    Comparison,
+}
+
 /// The recognized recurrence shape for a bounded counter.
 struct Recurrence {
     /// The base-case guard literal `K` (`match counter { K -> … }`).
     guard_k: i128,
     /// The decrement step magnitude (`counter - step`, positive literal).
     step: i128,
+    /// Whether the guard is an equality (the only kind that pins the
+    /// stopping value) or a comparison (declines).
+    guard_kind: GuardKind,
 }
 
 /// Recognize the bounded-counter recurrence for param `param_slot` (index
@@ -678,21 +840,33 @@ struct Recurrence {
 /// any other shape (accumulators, non-monotone recurrences, missing
 /// guard) — the conservative decline.
 fn recurrence_for_param(f: &MirFn, param_slot: LocalId, i: usize) -> Option<Recurrence> {
-    let guard_k = guard_literal_for(&f.body.node, param_slot)?;
+    let (guard_k, guard_kind) = guard_literal_for(&f.body.node, param_slot)?;
     let mut recur: Option<Recurrence> = None;
-    find_self_tailcall_recurrence(&f.body.node, f.fn_id, param_slot, i, guard_k, &mut recur);
+    find_self_tailcall_recurrence(
+        &f.body.node,
+        f.fn_id,
+        param_slot,
+        i,
+        guard_k,
+        guard_kind,
+        &mut recur,
+    );
     recur
 }
 
 /// Walk for a `Match`/`IfThenElse` that guards the counter against a
-/// literal `K`. Returns the first literal guard `K` found on the counter.
-fn guard_literal_for(e: &MirExpr, counter: LocalId) -> Option<i128> {
+/// literal `K`. Returns the first literal guard `(K, kind)` found on the
+/// counter — `kind` distinguishes an equality guard (the only kind that
+/// pins the stopping value) from a comparison guard.
+fn guard_literal_for(e: &MirExpr, counter: LocalId) -> Option<(i128, GuardKind)> {
     match e {
         MirExpr::Match(m) => {
+            // A `match counter { K -> … }` literal arm is an EQUALITY guard:
+            // the arm fires exactly when `counter == K`.
             if subject_is_local(&m.node.subject.node, counter) {
                 for arm in &m.node.arms {
                     if let MirPattern::Literal(Literal::Int(k)) = &arm.pattern {
-                        return Some(*k as i128);
+                        return Some((*k as i128, GuardKind::Equality));
                     }
                 }
             }
@@ -710,17 +884,24 @@ fn guard_literal_for(e: &MirExpr, counter: LocalId) -> Option<i128> {
                     BinOp::Eq | BinOp::Lt | BinOp::Lte | BinOp::Gt | BinOp::Gte
                 )
             {
+                // Only `==` pins the exact stopping value; `<`/`<=`/`>`/`>=`
+                // are half-bounded tests whose stopping value is unknown.
+                let kind = if matches!(b.node.op, BinOp::Eq) {
+                    GuardKind::Equality
+                } else {
+                    GuardKind::Comparison
+                };
                 if subject_is_local(&b.node.lhs.node, counter)
                     && let MirExpr::Literal(l) = &b.node.rhs.node
                     && let Literal::Int(k) = l.node
                 {
-                    return Some(k as i128);
+                    return Some((k as i128, kind));
                 }
                 if subject_is_local(&b.node.rhs.node, counter)
                     && let MirExpr::Literal(l) = &b.node.lhs.node
                     && let Literal::Int(k) = l.node
                 {
-                    return Some(k as i128);
+                    return Some((k as i128, kind));
                 }
             }
             guard_literal_for(&ite.node.cond.node, counter)
@@ -750,6 +931,7 @@ fn find_self_tailcall_recurrence(
     counter: LocalId,
     i: usize,
     guard_k: i128,
+    guard_kind: GuardKind,
     out: &mut Option<Recurrence>,
 ) {
     if out.is_some() {
@@ -760,11 +942,15 @@ fn find_self_tailcall_recurrence(
         && let Some(arg) = tc.node.args.get(i)
         && let Some(step) = decrement_step(&arg.node, counter)
     {
-        *out = Some(Recurrence { guard_k, step });
+        *out = Some(Recurrence {
+            guard_k,
+            step,
+            guard_kind,
+        });
         return;
     }
     visit_children(e, &mut |c| {
-        find_self_tailcall_recurrence(c, self_fn, counter, i, guard_k, out)
+        find_self_tailcall_recurrence(c, self_fn, counter, i, guard_k, guard_kind, out)
     });
 }
 
@@ -816,16 +1002,22 @@ fn literal_interval(arg: &MirExpr) -> Option<Interval> {
 fn analyze_fn(f: &MirFn, summary: &Summary) -> FnBareFacts {
     let mut facts = FnBareFacts::default();
 
-    // 1. Range: seed param intervals from the summary. A bare param is by
-    //    construction confined to `i64`, so seed a full-`i64` interval;
-    //    a boxed param is unbounded.
+    // 1. Range: seed param intervals from the summary. A bare param is
+    //    seeded with its PROVEN recurrence interval (`[K-step, entry]`) when
+    //    one was derived, so an in-body `n - 1` / `acc * n` over the counter
+    //    stays in the OverflowFree band; a bare param with no tight interval
+    //    falls back to the full-`i64` line (still sound — bare ⟹ confined to
+    //    `i64` by construction); a boxed param is unbounded.
     let mut intervals: HashMap<LocalId, Interval> = HashMap::new();
     let mut bare_params = vec![false; f.params.len()];
     for (i, p) in f.params.iter().enumerate() {
         let is_bare = summary.param_bare(f.fn_id, i);
         bare_params[i] = is_bare;
         let iv = if is_bare {
-            Interval::between(i64::MIN as i128, i64::MAX as i128)
+            summary
+                .param_interval(f.fn_id, i)
+                .filter(|iv| iv.fits_i64())
+                .unwrap_or_else(|| Interval::between(i64::MIN as i128, i64::MAX as i128))
         } else {
             Interval::unbounded()
         };
@@ -956,52 +1148,56 @@ fn eval_interval(e: &MirExpr, env: &HashMap<LocalId, Interval>, worst: &mut Inte
 /// slot defaults to escaping.
 fn scan_escapes(e: &MirExpr, summary: &Summary, out: &mut HashSet<LocalId>) {
     match e {
-        // Aggregates: every Int element/field escapes.
+        // Aggregates: every Int element/field escapes — INCLUDING a bare
+        // leaf reached through a `BinOp`/`Neg` (the aggregate emit does not
+        // convert a bare compound), hence `*_deep` (BUG 3).
         MirExpr::List(items) | MirExpr::Tuple(items) => {
             for it in items {
-                mark_operand_escapes(&it.node, out);
+                mark_operand_escapes_deep(&it.node, out);
                 scan_escapes(&it.node, summary, out);
             }
         }
         MirExpr::MapLiteral(pairs) => {
             for (k, v) in pairs {
-                mark_operand_escapes(&k.node, out);
-                mark_operand_escapes(&v.node, out);
+                mark_operand_escapes_deep(&k.node, out);
+                mark_operand_escapes_deep(&v.node, out);
                 scan_escapes(&k.node, summary, out);
                 scan_escapes(&v.node, summary, out);
             }
         }
         MirExpr::Construct(c) => {
             for a in &c.node.args {
-                mark_operand_escapes(&a.node, out);
+                mark_operand_escapes_deep(&a.node, out);
                 scan_escapes(&a.node, summary, out);
             }
         }
         MirExpr::RecordCreate(r) => {
             for fld in &r.node.fields {
-                mark_operand_escapes(&fld.value.node, out);
+                mark_operand_escapes_deep(&fld.value.node, out);
                 scan_escapes(&fld.value.node, summary, out);
             }
         }
         MirExpr::RecordUpdate(u) => {
-            mark_operand_escapes(&u.node.base.node, out);
+            mark_operand_escapes_deep(&u.node.base.node, out);
             scan_escapes(&u.node.base.node, summary, out);
             for fld in &u.node.updates {
-                mark_operand_escapes(&fld.value.node, out);
+                mark_operand_escapes_deep(&fld.value.node, out);
                 scan_escapes(&fld.value.node, summary, out);
             }
         }
         MirExpr::IndependentProduct(ip) => {
             for it in &ip.node.items {
-                mark_operand_escapes(&it.node, out);
+                mark_operand_escapes_deep(&it.node, out);
                 scan_escapes(&it.node, summary, out);
             }
         }
-        // Stringification: every embedded value escapes.
+        // Stringification: every embedded value escapes (including a bare
+        // leaf inside a `BinOp`/`Neg` — the interpolation emit stringifies
+        // the whole compound, not the operands).
         MirExpr::InterpolatedStr(parts) => {
             for p in parts {
                 if let super::super::expr::MirStrPart::Expr(ex) = p {
-                    mark_operand_escapes(&ex.node, out);
+                    mark_operand_escapes_deep(&ex.node, out);
                     scan_escapes(&ex.node, summary, out);
                 }
             }
@@ -1013,15 +1209,23 @@ fn scan_escapes(e: &MirExpr, summary: &Summary, out: &mut HashSet<LocalId>) {
         MirExpr::Call(c) => match c.node.callee {
             MirCallee::Fn(target) => {
                 for (i, a) in c.node.args.iter().enumerate() {
+                    // A user-fn boxed-param position: the boxed-arithmetic
+                    // emit converts a bare compound operand, so only a DIRECT
+                    // bare `Local` escapes here (shallow), not a leaf buried
+                    // in a `BinOp` (which `boxed_int_operand` converts).
                     if !summary.param_bare(target, i) {
                         mark_operand_escapes(&a.node, out);
                     }
                     scan_escapes(&a.node, summary, out);
                 }
             }
+            // A builtin / intrinsic / fn-value callee is a NON-converting
+            // position: its Int args emit without `boxed_int_operand`, so a
+            // bare leaf inside a `BinOp`/`Neg` arg (`String.fromInt(n + 1)`)
+            // escapes too — `*_deep` (BUG 3).
             _ => {
                 for a in &c.node.args {
-                    mark_operand_escapes(&a.node, out);
+                    mark_operand_escapes_deep(&a.node, out);
                     scan_escapes(&a.node, summary, out);
                 }
             }
@@ -1043,22 +1247,47 @@ fn scan_escapes(e: &MirExpr, summary: &Summary, out: &mut HashSet<LocalId>) {
     }
 }
 
-/// Mark the slot of a value that flows DIRECTLY into an escaping position.
+/// Mark the slot of a value flowing into a USER-FN-CALL boxed-param
+/// position (an ordinary `Call(Fn)` / `TailCall` arg at a boxed index).
 ///
-/// Only a bare `Local` read placed verbatim at a general-Int context
-/// escapes — its representation must then be `AverInt` (the value itself
-/// crosses the boundary). An ARITHMETIC expression (`acc * n`) at an
-/// escaping position does NOT escape its operands: the operands are
-/// consumed to compute a FRESH result, and that result (a new temp) is
-/// what crosses the boundary; each operand is converted at the arithmetic
-/// site (`boxed_int_operand` wraps a bare operand with `from_i64`) and
-/// keeps its own representation. So a counter read inside `acc * n` that
-/// feeds a boxed accumulator must NOT be flagged — flagging it was the bug
-/// that demoted the factorial counter. Hence: do not recurse into
-/// `BinOp` / `Neg`.
+/// Only a bare `Local` read placed verbatim there escapes — its
+/// representation must then be `AverInt` (the value itself crosses the
+/// boundary). An ARITHMETIC expression (`acc * n`) at such a position does
+/// NOT escape its operands: the boxed-arithmetic emit (`boxed_int_operand`)
+/// converts each bare operand with `from_i64` and the FRESH result is what
+/// crosses, so the operand keeps its own bare representation. Flagging a
+/// counter read inside `acc * n` was the bug that demoted the factorial
+/// counter — hence this variant does NOT recurse into `BinOp` / `Neg`.
 fn mark_operand_escapes(e: &MirExpr, out: &mut HashSet<LocalId>) {
     if let MirExpr::Local(l) = e {
         out.insert(l.node.slot);
+    }
+}
+
+/// Mark every bare-`Local` leaf reaching a NON-CONVERTING escaping
+/// position — an aggregate element/field (`[n + 1]`, a tuple/map/record
+/// slot), a stringify embed, or a builtin/intrinsic Int arg
+/// (`String.fromInt(n + 1)`).
+///
+/// BUG 3: unlike the user-fn boxed-param position, these emit sites do NOT
+/// run `boxed_int_operand`, so a bare compound like `n + 1` is emitted as
+/// raw `(n + 1)i64` straight into an `AverInt`-typed slot — a `rustc` type
+/// mismatch, and (without `overflow-checks`) a wrong value if the compound
+/// could wrap. So a bare leaf reaching these positions THROUGH a `BinOp` /
+/// `Neg` tree must escape (→ boxed), exactly like a direct `Local` does.
+/// Hence this variant RECURSES into `BinOp` / `Neg` (a literal leaf carries
+/// no slot, so it is harmlessly ignored).
+fn mark_operand_escapes_deep(e: &MirExpr, out: &mut HashSet<LocalId>) {
+    match e {
+        MirExpr::Local(l) => {
+            out.insert(l.node.slot);
+        }
+        MirExpr::Neg(inner) => mark_operand_escapes_deep(&inner.node, out),
+        MirExpr::BinOp(b) => {
+            mark_operand_escapes_deep(&b.node.lhs.node, out);
+            mark_operand_escapes_deep(&b.node.rhs.node, out);
+        }
+        _ => {}
     }
 }
 
@@ -1084,9 +1313,15 @@ fn tail_value_is_bare(e: &MirExpr, facts: &FnBareFacts, escaping: &HashSet<Local
         // does not constrain the return repr.
         MirExpr::TailCall(_) => true,
         MirExpr::Return(inner) => tail_value_is_bare(&inner.node, facts, escaping),
+        // A compound `Add`/`Sub`/`Mul` tail value is bare ONLY when its
+        // RESULT interval provably fits `i64` (BUG 2): a tree whose operands
+        // are each bare can still overflow (`n + i64::MAX`), so route through
+        // the interval-checked `expr_is_bare_i64` — the same gate codegen
+        // uses, so analysis and emit never disagree. (A `Bare` leaf already
+        // carries `escapes == false`, so an escaping operand is `Boxed` and
+        // `expr_is_bare_i64` declines it.)
         MirExpr::BinOp(b) if matches!(b.node.op, BinOp::Add | BinOp::Sub | BinOp::Mul) => {
-            tail_value_is_bare(&b.node.lhs.node, facts, escaping)
-                && tail_value_is_bare(&b.node.rhs.node, facts, escaping)
+            facts.expr_is_bare_i64(e)
         }
         _ => false,
     }
@@ -1402,6 +1637,207 @@ fn main() -> List<Int>
             OpClass::of_interval(worst.hull(result)),
             OpClass::OverflowFree,
             "the transient out-of-i64 intermediate must demote below OverflowFree"
+        );
+    }
+
+    // ── BUG 1: recurrence guard REACHABILITY ────────────────────────────
+
+    /// A decrement counter whose step does NOT divide `entry - K` steps OVER
+    /// the equality guard `K` and diverges to -inf — the certified interval
+    /// is fiction, so the param must NOT be bare (congruence skip).
+    #[test]
+    fn congruence_skip_declines() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn loopit(n: Int, acc: Int) -> Int
+    match n
+        0 -> acc
+        _ -> loopit(n - 4611686018427387905, acc)
+
+fn main() -> Int
+    loopit(4, 0)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "loopit");
+        let f = facts.for_fn(id).expect("loopit facts");
+        assert!(
+            !f.param_is_bare(0),
+            "a counter that steps OVER its equality guard (4 % (2^62+1) != 0) must box"
+        );
+    }
+
+    /// Entry below the guard: the decrement moves AWAY from `K`, diverging —
+    /// must box.
+    #[test]
+    fn entry_below_guard_declines() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn down(n: Int, acc: Int) -> Int
+    match n
+        100 -> acc
+        _ -> down(n - 1, acc)
+
+fn main() -> Int
+    down(5, 0)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "down");
+        let f = facts.for_fn(id).expect("down facts");
+        assert!(
+            !f.param_is_bare(0),
+            "entry 5 < guard 100 decrements away from K → diverges → must box"
+        );
+    }
+
+    /// Odd entry, step 2 toward guard 0: parity-skip, never lands on 0 —
+    /// must box.
+    #[test]
+    fn parity_skip_declines() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn skip(n: Int, acc: Int) -> Int
+    match n
+        0 -> acc
+        _ -> skip(n - 2, acc)
+
+fn main() -> Int
+    skip(25, 0)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "skip");
+        let f = facts.for_fn(id).expect("skip facts");
+        assert!(
+            !f.param_is_bare(0),
+            "odd entry 25 with step 2 toward guard 0 steps over 0 → must box"
+        );
+    }
+
+    /// Even entry, step 2 toward guard 0: the sequence LANDS on 0 — the fix
+    /// declines only UNREACHABLE guards, not all step>1, so this stays BARE.
+    #[test]
+    fn divisible_reachable_guard_stays_bare() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn skip(n: Int, acc: Int) -> Int
+    match n
+        0 -> acc
+        _ -> skip(n - 2, acc)
+
+fn main() -> Int
+    skip(24, 0)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "skip");
+        let f = facts.for_fn(id).expect("skip facts");
+        assert!(
+            f.param_is_bare(0),
+            "even entry 24 with step 2 reaches guard 0 → must stay bare (win survives)"
+        );
+    }
+
+    // ── BUG 2: compound interval gate ───────────────────────────────────
+
+    /// A compound `n + i64::MAX` whose result interval leaves `i64` is NOT
+    /// bare, even though both operands are bare — `expr_is_bare_i64` must
+    /// decline it so codegen boxes the arithmetic.
+    #[test]
+    fn overflowing_compound_is_not_bare() {
+        let mut facts = FnBareFacts::default();
+        let n = LocalId(0);
+        // `n` is a bare counter confined to `[1, 1]`.
+        facts.values.insert(
+            n,
+            ValueFact {
+                interval: Some(Interval::point(1)),
+                op_class: OpClass::OverflowFree,
+                escapes: false,
+                repr: Repr::Bare,
+            },
+        );
+        let big = i64::MAX as i128;
+        let local_n = Spanned::bare(MirExpr::Local(Spanned::bare(
+            super::super::super::expr::MirLocal::at(n),
+        )));
+        let lit = Spanned::bare(MirExpr::Literal(Spanned::bare(Literal::Int(big as i64))));
+        let add = MirExpr::BinOp(Spanned::bare(super::super::super::expr::MirBinOp {
+            op: BinOp::Add,
+            lhs: Box::new(local_n),
+            rhs: Box::new(lit),
+        }));
+        assert!(
+            !facts.expr_is_bare_i64(&add),
+            "`n + i64::MAX` (result [MAX+1, MAX+1]) leaves i64 → must NOT be bare"
+        );
+    }
+
+    /// A compound `n - 1` over a tight bare counter `[0, 20000]` STAYS in
+    /// i64 → bare (the legitimate fast decrement must survive).
+    #[test]
+    fn in_range_compound_stays_bare() {
+        let mut facts = FnBareFacts::default();
+        let n = LocalId(0);
+        facts.values.insert(
+            n,
+            ValueFact {
+                interval: Some(Interval::between(-1, 20000)),
+                op_class: OpClass::OverflowFree,
+                escapes: false,
+                repr: Repr::Bare,
+            },
+        );
+        let local_n = Spanned::bare(MirExpr::Local(Spanned::bare(
+            super::super::super::expr::MirLocal::at(n),
+        )));
+        let lit = Spanned::bare(MirExpr::Literal(Spanned::bare(Literal::Int(1))));
+        let sub = MirExpr::BinOp(Spanned::bare(super::super::super::expr::MirBinOp {
+            op: BinOp::Sub,
+            lhs: Box::new(local_n),
+            rhs: Box::new(lit),
+        }));
+        assert!(
+            facts.expr_is_bare_i64(&sub),
+            "`n - 1` over a tight `[-1, 20000]` counter stays in i64 → bare"
+        );
+    }
+
+    // ── BUG 3: escape scan recurses into BinOp ──────────────────────────
+
+    /// A bare counter reaching a `List<Int>` aggregate THROUGH a `BinOp`
+    /// (`[n + 1]`) escapes — the escape scan must mark it so the param boxes
+    /// (the aggregate emit does not convert a bare compound).
+    #[test]
+    fn binop_in_aggregate_escapes() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn collect(n: Int) -> List<Int>
+    match n
+        1 -> [n + 1]
+        _ -> collect(n - 1)
+
+fn main() -> List<Int>
+    collect(2)
+"#;
+        let (program, facts) = facts_for(src);
+        let id = fn_id_by_name(&program, "collect");
+        let f = facts.for_fn(id).expect("collect facts");
+        assert!(
+            !f.param_is_bare(0),
+            "a counter reaching `[n + 1]` through a BinOp escapes the aggregate → must box"
         );
     }
 }

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -1102,6 +1102,30 @@ fn walk_let_chain(
             walk_let_chain(&l.node.value.node, env, op_classes);
             walk_let_chain(&l.node.body.node, env, op_classes);
         }
+        // A `match subject { y -> … }` Ident-binding arm ALIASES the subject:
+        // the binder `y` carries the subject's interval. Without this, a
+        // base-case `match n { y -> y }` (subj_ret) leaves `y` unknown, so the
+        // body pass can't prove `y` bare and the return-repr / escape facts
+        // disagree with codegen (which declares `y` at the subject's bare
+        // type). Recognize the alias so `y` inherits `n`'s bound — the same
+        // representation codegen emits. The subject's interval is evaluated in
+        // the current `env` (the subject is already in scope).
+        MirExpr::Match(m) => {
+            let mut worst = Interval::point(0);
+            let subj_iv = eval_interval(&m.node.subject.node, env, &mut worst);
+            walk_let_chain(&m.node.subject.node, env, op_classes);
+            for arm in &m.node.arms {
+                if let MirPattern::Bind(slot, _) = &arm.pattern {
+                    // Alias: the binder takes the subject's interval + op
+                    // class (the subject is read verbatim, no new arithmetic).
+                    env.entry(*slot).or_insert(subj_iv);
+                    op_classes
+                        .entry(*slot)
+                        .or_insert_with(|| OpClass::of_interval(subj_iv));
+                }
+                walk_let_chain(&arm.body.node, env, op_classes);
+            }
+        }
         _ => {
             visit_children(e, &mut |c| walk_let_chain(c, env, op_classes));
         }

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -1864,4 +1864,192 @@ fn main() -> List<Int>
             "a counter reaching `[n + 1]` through a BinOp escapes the aggregate → must box"
         );
     }
+
+    // ── BOUNDARY-COMPLETENESS regressions (PR #519 four defects) ─────────
+    //
+    // Each defect was a valid Aver program whose emitted Rust failed to
+    // compile because the analysis/codegen disagreed on a value's
+    // representation at a use position. The fix is fail-closed: the counter
+    // stays bare (fast loop preserved) while the single crossing converts at
+    // the boundary, OR the escaping value demotes. These assert the
+    // analysis-observable half (the codegen boundary conversions are covered
+    // by `tests/rust_codegen_regression.rs`).
+
+    /// Defect Q4: a bare compound `n + 1` flows as a Call arg to a BOXED
+    /// param (`keep(x: Int)`). The counter stays bare — codegen converts the
+    /// arg with `from_i64` at the boxed-param boundary (the value itself does
+    /// not cross; a fresh `AverInt` does), so the fast loop is preserved.
+    #[test]
+    fn call_arg_to_boxed_param_keeps_counter_bare() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn keep(x: Int) -> Int
+    x
+
+fn down(n: Int) -> Int
+    match n
+        0 -> keep(n + 1)
+        _ -> down(n - 1)
+
+fn main() -> Int
+    down(2)
+"#;
+        let (program, facts) = facts_for(src);
+        let down = facts
+            .for_fn(fn_id_by_name(&program, "down"))
+            .expect("down facts");
+        // `down`'s counter stays bare (converted at the boxed-param boundary).
+        assert!(
+            down.param_is_bare(0),
+            "the down counter stays bare; the boxed-param arg `n + 1` converts at the boundary"
+        );
+        // `keep`'s param is a general-Int (boxed) — it has a non-literal,
+        // non-bare-supplyable caller arg shape, so it never goes bare.
+        let keep = facts
+            .for_fn(fn_id_by_name(&program, "keep"))
+            .expect("keep facts");
+        assert!(
+            !keep.param_is_bare(0),
+            "keep's general-Int param stays boxed (no bounding recurrence)"
+        );
+    }
+
+    /// Defect Q5: a fn `g` whose return is proven bare is consumed by `h`
+    /// whose own return is the general Int. `g` keeps its bare return + bare
+    /// counter (the fast loop); codegen boxes the call result with `from_i64`
+    /// at `h`'s return crossing. The whole-program summary must still mark
+    /// `g.bare_return` (the consumer demotion is a CODEGEN conversion, not an
+    /// analysis demotion, so the win is preserved).
+    #[test]
+    fn bare_return_consumed_by_boxed_return_fn_stays_bare() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn g(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> g(n - 1)
+
+fn h() -> Int
+    g(2)
+
+fn main() -> Int
+    h()
+"#;
+        let (program, facts) = facts_for(src);
+        let g = facts.for_fn(fn_id_by_name(&program, "g")).expect("g facts");
+        assert!(g.param_is_bare(0), "g's bounded counter stays bare");
+        assert!(
+            g.bare_return,
+            "g's return stays bare; the boxed consumer `h` converts at its return boundary"
+        );
+    }
+
+    /// Defect subj_ret (opus Area 3): a bare counter `n` aliased through an
+    /// inner match binding `match n { y -> y }`. The alias must be TRACKED so
+    /// `y` inherits `n`'s bare interval — otherwise the body facts and codegen
+    /// (which declares `y` at `n`'s bare type) disagree. The counter stays
+    /// bare; the return crossing boxes `y` with `from_i64`.
+    #[test]
+    fn match_binding_alias_is_tracked_bare() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn loopit(n: Int) -> Int
+    match n
+        0 -> match n
+            y -> y
+        _ -> loopit(n - 1)
+
+fn main() -> Int
+    loopit(3)
+"#;
+        let (program, facts) = facts_for(src);
+        let f = facts
+            .for_fn(fn_id_by_name(&program, "loopit"))
+            .expect("loopit facts");
+        assert!(
+            f.param_is_bare(0),
+            "the counter stays bare; the aliased binding `y` inherits its bare interval"
+        );
+        // The aliased binding `y` must carry a fact (not absent → unknown):
+        // it aliases the bare param, so the analysis proves it bare and the
+        // codegen agrees on the representation at the return crossing.
+        let bare_y = f.values.values().any(|v| v.is_bare());
+        assert!(
+            bare_y,
+            "at least the counter / its bare alias is proven bare"
+        );
+    }
+
+    /// Defect esc_match (opus Area 3, escaping alias): a bare compound
+    /// `let x = n - 1` aliased into an `Int` aggregate `[x, x]`. `x` must
+    /// DEMOTE (it reaches a general-Int aggregate); the counter `n` stays
+    /// bare. Codegen boxes the binding value with `from_i64` at the let
+    /// crossing.
+    #[test]
+    fn match_let_alias_into_aggregate_demotes() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn loopit(n: Int) -> List<Int>
+    match n
+        0 -> match n - 1
+            x -> [x, x]
+        _ -> loopit(n - 1)
+
+fn main() -> List<Int>
+    loopit(4)
+"#;
+        let (program, facts) = facts_for(src);
+        let f = facts
+            .for_fn(fn_id_by_name(&program, "loopit"))
+            .expect("loopit facts");
+        // The counter `n` stays bare (its only escaping use is via the boxed
+        // `x` binding, not `n` itself).
+        assert!(f.param_is_bare(0), "the counter `n` stays bare");
+        // The `List<Int>` return is never bare.
+        assert!(!f.bare_return, "a List<Int> return is never bare i64");
+    }
+
+    /// Defect marms: a bare counter whose guard has ≥2 Int-literal base-case
+    /// arms lowers to the dispatch-table match path. The counter legitimately
+    /// stays bare and is compared against the literals — the codegen dispatch
+    /// path must emit `subject == {K}i64` (not `i64 == AverInt`). This asserts
+    /// the analysis keeps the multi-literal-arm counter bare (the codegen
+    /// dispatch-bare path is covered by `tests/rust_codegen_regression.rs`).
+    #[test]
+    fn multi_literal_arm_counter_stays_bare() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn loopit(n: Int, acc: Int) -> Int
+    match n
+        2 -> acc
+        0 -> acc
+        _ -> loopit(n - 1, acc + 1)
+
+fn main() -> Int
+    loopit(5, 0)
+"#;
+        let (program, facts) = facts_for(src);
+        let f = facts
+            .for_fn(fn_id_by_name(&program, "loopit"))
+            .expect("loopit facts");
+        assert!(
+            f.param_is_bare(0),
+            "a ≥2-literal-arm bounded counter stays bare (dispatch path emits `== Ki64`)"
+        );
+    }
 }

--- a/src/ir/mir/optimize/mod.rs
+++ b/src/ir/mir/optimize/mod.rs
@@ -46,6 +46,7 @@
 //! - CSE / loop-invariant hoisting — future waves.
 
 pub mod algebraic;
+pub mod bare_i64;
 pub mod bool_match;
 pub mod branch_collapse;
 pub mod const_fold;
@@ -57,6 +58,7 @@ pub mod own_param;
 pub(crate) mod test_helpers;
 
 pub use algebraic::algebraic_simplify;
+pub use bare_i64::{BareI64Facts, FnBareFacts, Repr, ValueFact};
 pub use bool_match::bool_match_to_if;
 pub use branch_collapse::branch_collapse;
 pub use const_fold::const_fold;

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -8351,6 +8351,7 @@ mod tests {
             resolved_program: aver::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,
+            bare_i64: Default::default(),
             discovered_lemmas: Vec::new(),
             sample_expected: std::collections::HashMap::new(),
         }

--- a/tests/rust_codegen_regression.rs
+++ b/tests/rust_codegen_regression.rs
@@ -162,3 +162,176 @@ fn sanitise(relative: &str) -> String {
         .map(|c| if c.is_alphanumeric() { c } else { '-' })
         .collect()
 }
+
+/// The four BOUNDARY-COMPLETENESS regressions (PR #519): valid Aver
+/// programs whose emitted Rust used to fail `rustc` with `E0308` because
+/// the bare-i64 unboxing analysis marked a value bare while codegen emitted
+/// it (or a callee's bare result) into an `AverInt` position without the
+/// `from_i64` boundary conversion. Each `(name, source)` must now emit Rust
+/// that type-checks. Inline (not in the file corpus) so the regression is
+/// self-documenting and travels with the test.
+const UNBOX_BOUNDARY_REGRESSIONS: &[(&str, &str)] = &[
+    // Q4: a bare compound `n + 1` as a Call arg to a BOXED param `keep(x)`.
+    (
+        "q4_call_arg_to_boxed_param",
+        r#"module Q4
+    intent = "bare compound in Call arg to a boxed param"
+    depends []
+    effects [Console.print]
+
+fn keep(x: Int) -> Int
+    x
+
+fn down(n: Int) -> Int
+    match n
+        0 -> keep(n + 1)
+        _ -> down(n - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("r={down(2)}")
+"#,
+    ),
+    // Q5: a bare-return fn `g` consumed by a boxed-return fn `h`.
+    (
+        "q5_bare_return_into_boxed_return",
+        r#"module Q5
+    intent = "bare return flowing into a boxed return position"
+    depends []
+    effects [Console.print]
+
+fn g(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> g(n - 1)
+
+fn h() -> Int
+    g(2)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("r={h()}")
+"#,
+    ),
+    // opus Area 3 (escaping alias): `let x = n - 1; [x, x]` into an Int list.
+    (
+        "esc_match_let_alias_into_aggregate",
+        r#"module EscM
+    intent = "bare compound aliased into an Int aggregate"
+    depends []
+    effects [Console.print]
+
+fn loopit(n: Int) -> List<Int>
+    match n
+        0 -> match n - 1
+            x -> [x, x]
+        _ -> loopit(n - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("r={List.len(loopit(4))}")
+"#,
+    ),
+    // opus Area 3 (subject alias): `match n { y -> y }` returned as Int.
+    (
+        "subj_ret_match_binding_alias",
+        r#"module SubjRet
+    intent = "bare subject aliased through a match binding, returned as Int"
+    depends []
+    effects [Console.print]
+
+fn loopit(n: Int) -> Int
+    match n
+        0 -> match n
+            y -> y
+        _ -> loopit(n - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("r={loopit(3)}")
+"#,
+    ),
+    // marms: a ≥2-literal-arm bounded counter → dispatch-table guard path.
+    (
+        "marms_multi_literal_arm_dispatch",
+        r#"module Marms
+    intent = "multi base-case literal arms over a bare counter"
+    depends []
+    effects [Console.print]
+
+fn loopit(n: Int, acc: Int) -> Int
+    match n
+        2 -> acc
+        0 -> acc
+        _ -> loopit(n - 1, acc + 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("r={loopit(5, 0)}")
+"#,
+    ),
+];
+
+#[test]
+fn rust_codegen_compiles_unbox_boundary_regressions() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let shared_target = shared_target_dir();
+    fs::create_dir_all(&shared_target).expect("create shared target dir");
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for (name, source) in UNBOX_BOUNDARY_REGRESSIONS {
+        let workspace = temp_output_dir(&format!("rust-codegen-unbox-{name}"));
+        let src_path = workspace.join(format!("{name}.av"));
+        let project_dir = workspace.join("project");
+        fs::create_dir_all(&workspace).expect("create per-example workspace");
+        fs::write(&src_path, source).expect("write repro .av");
+
+        let compile = Command::new(aver_bin)
+            .current_dir(&repo_root)
+            .arg("compile")
+            .arg(&src_path)
+            .arg("--target")
+            .arg("rust")
+            .arg("-o")
+            .arg(&project_dir)
+            .output()
+            .expect("expected `aver compile --target rust` to spawn");
+        if !compile.status.success() {
+            failures.push(format!(
+                "{name}: aver compile --target rust failed\n{}",
+                format_output(&compile)
+            ));
+            let _ = fs::remove_dir_all(&workspace);
+            continue;
+        }
+
+        // `cargo check` is the load-bearing assertion: `aver compile` exit 0
+        // does NOT imply the emitted Rust type-checks — the whole point of
+        // these regressions is that it used to emit `i64`-into-`AverInt`
+        // E0308 mismatches.
+        let check = Command::new("cargo")
+            .arg("check")
+            .arg("--manifest-path")
+            .arg(project_dir.join("Cargo.toml"))
+            .env("CARGO_TARGET_DIR", &shared_target)
+            .output()
+            .expect("expected `cargo check` to spawn");
+        if !check.status.success() {
+            failures.push(format!(
+                "{name}: cargo check failed on emitted project (E0308 boundary regression?)\n{}",
+                format_output(&check)
+            ));
+        }
+        let _ = fs::remove_dir_all(&workspace);
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} unbox-boundary regressions failed Rust codegen + cargo check:\n  - {}",
+        failures.len(),
+        UNBOX_BOUNDARY_REGRESSIONS.len(),
+        failures.join("\n  - ")
+    );
+}


### PR DESCRIPTION
## What

A read-only codegen analysis (`ir::mir::optimize::bare_i64`) that proves when an `Int` value is confined to the `i64` range **and** never reaches a general-`Int` context, then selects a native `i64` representation for it in the Rust backend instead of the default arbitrary-precision `aver_rt::AverInt`. This recovers native integer speed on int-heavy loops while keeping `Int = ℤ` semantics intact everywhere else.

## How it reuses what we already have

- **Range half** reuses the interval domain verbatim — `Interval` lattice, saturating i128 arithmetic, `OpClass`, `raw_i64_eligible`, the worst-join discipline. Only the leaf source changes: from a refined-type carrier to an SSA-value (`LocalId`) range query over the `MirFn` body.
- **Escape half** mirrors the use-flow notion the `own_param` pass already uses (a single backward scan, default-escapes), but with a representation-escape predicate.
- A minimal whole-program summary over the `MirCallee::Fn` / `MirTailCall` call graph lets a self-recursive loop counter cross its own tail-call frame bare, recognizing the bounded-tail-recursion shape (base-case guard + monotone `n - k` decrement + literal-bounded entry).

## Soundness — fail-closed

A value emits bare `i64` **only** when proven `raw_i64_eligible && !escapes`; any missing fact stays boxed. So a bug is a missed optimization, never a wrong value. Backstops preserved: the worst-join demotes transient out-of-i64 intermediates, `NeedsWiderScratch` is not bare-eligible, mixed bare/boxed arithmetic re-boxes via `from_i64`, `Div` keeps the zero-divisor panic, and the emitted Rust must compile (a bare value reaching an `AverInt` slot is a rustc error). `AVER_NO_BARE_I64=1` disables the analysis for differential measurement.

## Measured (rust target, same binary, `AVER_NO_BARE_I64` toggles only this analysis)

| scenario | before p50 | after p50 | ratio |
|---|---|---|---|
| countdown (20000-iter pure loop) | 17.8 µs | 0.04 µs | counter is bare and the side-effect-free loop is additionally DCE'd by rustc |
| factorial (counter bare, accumulator stays boxed) | 1.04 µs | 0.54 µs | ~1.9× |

`factorial`'s accumulator grows unboundedly so it correctly stays boxed; only the counter `n` unboxes — the mixed-representation boundary emits `acc.mul(&AverInt::from_i64(n))`. `fib` stays fully boxed (non-tail recursion, no bounding recurrence).

## Checks

- `cargo build` + `cargo test`: all 76 result-blocks pass, zero regressions
- `cargo clippy -p aver-lang --lib --bin aver --features wasm,wasip2 -- -D warnings`: clean
- `cargo fmt --check`: clean
- 65 examples + all 12 bench scenarios compile and run correctly; `factorial` prints `3628800` (not wrapped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)