### PR TITLE
Lean auto-proofs: cases-tail branch closes two-level list-match laws (last/butlast)

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1394,8 +1394,19 @@ fn emit_list_induction(
             format!(
                 "| nil => first | (simp [{arm_simp}]; done) | (simp [{arm_simp}]; omega){nil_bridge} | (simp only [{arm_split}]; split <;> simp_all [{arm_simp}]{split_bridge} <;> omega){tail}"
             ),
+            // Trailing `cases tail` branch: a fn whose body matches TWO levels
+            // deep on the list (`last`/`butlast`: `match x | [] | y::z => match z
+            // | [] | …`) generates equational lemmas keyed on the two-deep
+            // pattern, so `simp [fn]` can't unfold `fn (head :: tail)` while
+            // `tail` is a variable — and the earlier `split` branch then finds no
+            // `match` to peel. Decomposing `tail` one level exposes the inner
+            // constructor (`[head]` vs `head :: h2 :: …`), the equation fires, and
+            // the cons IH lands on the recursive call. Runs only after the three
+            // simp/split branches fail; `<;> omega` throws on any leftover so a
+            // non-closing arm still degrades to the honest `sorry`. Sound, so it
+            // can only ADD closures.
             format!(
-                "| cons head tail ih => first | (simp_all [{arm_simp}]; done) | (simp_all [{arm_simp}]; omega){cons_bridge} | (simp only [{arm_split}]; split <;> simp_all [{arm_simp}]{split_bridge} <;> omega){tail}"
+                "| cons head tail ih => first | (simp_all [{arm_simp}]; done) | (simp_all [{arm_simp}]; omega){cons_bridge} | (simp only [{arm_split}]; split <;> simp_all [{arm_simp}]{split_bridge} <;> omega) | (cases tail <;> simp_all [{arm_simp}] <;> omega){tail}"
             ),
         )
     };


### PR DESCRIPTION
A single additive, sound change to the Lean law-auto induction emitter: a trailing `cases tail` branch in the cons arm.

## Why

A function that matches two levels deep on a list (`last`/`butlast`: `match x | [] | y::z => match z | …`) gets equational lemmas keyed on the two-deep pattern, so `simp [fn]` cannot unfold `fn (head :: tail)` while `tail` is a variable — and the existing `split` branch then finds no `match` to peel. Decomposing `tail` one level exposes the inner constructor and lets the cons induction hypothesis land.

## Soundness

The branch runs only after the existing `simp`/`simp_all`/`split` branches fail, and ends in `<;> omega`, which throws on any leftover goal. So a non-closing arm still degrades to the honest `sorry`, and an arm that already closed never reaches it. It can therefore only **add** closures — a proved law cannot regress.

## Result

Newly kernel-universal:
- `tip/isaplanner/prop_64` — `last (xs ++ [x]) = x`
- `tip/isaplanner/prop_51`

Baseline laws confirmed unchanged locally; the Proof Export gate is the authoritative regression check.

## Note

An earlier version of this branch also `_root_.`-qualified user-fn names in simp sets to fix user functions shadowing Lean stdlib symbols (e.g. a user `insert` vs `Insert.insert`). That was pulled out: it breaks cross-module proofs because dependency-module functions live under their module namespace (`Lib.qrev`, brought in via `open Lib`), so a blanket `_root_.qrev` fails to resolve. The name-clash fix needs module-aware qualification and will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)