### PR TITLE
wasm-gc: arbitrary-precision Int arithmetic behind an opt-in flag (slice 1)

### DIFF
--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -1374,6 +1374,23 @@ pub(crate) fn emit_mir_numeric_binop(
     if operand == Some(ValType::F64) && r_ty == Some(ValType::I64) {
         func.instruction(&Instruction::F64ConvertI64S);
     }
+    // bignum slice 1 — when Int is the `$AverInt` ref, both operands are
+    // already on the stack as refs; route arithmetic + comparisons
+    // through the limb helpers instead of the wrapping `i64.*` opcodes.
+    // Div is slice 2 — bail to the whole-fn fallback rather than
+    // miscompile (returns `None`).
+    if ctx.registry.bignum
+        && operand != Some(ValType::F64)
+        && operand != Some(ValType::I32)
+        && ctx.registry.aint_struct_idx.is_some()
+        && l_ty
+            == ctx
+                .registry
+                .aint_struct_idx
+                .map(crate::codegen::wasm_gc::types::struct_ref)
+    {
+        return emit_aint_binop(func, bop.op, ctx);
+    }
     let inst = match (operand, bop.op) {
         (Some(ValType::F64), BinOp::Add) => Instruction::F64Add,
         (Some(ValType::F64), BinOp::Sub) => Instruction::F64Sub,
@@ -1406,5 +1423,70 @@ pub(crate) fn emit_mir_numeric_binop(
         (_, BinOp::Gte) => Instruction::I64GeS,
     };
     func.instruction(&inst);
+    Ok(Some(()))
+}
+
+/// bignum slice 1 — emit the arithmetic/comparison for two `$AverInt`
+/// operands already on the stack. Arithmetic (`+`/`-`/`*`) leaves an
+/// `$AverInt` ref; comparisons (`==`/`!=`/`<`/`>`/`<=`/`>=`) leave an
+/// i32 bool. `Div` is slice 2 — returns `None` to fall back to the
+/// whole-fn path rather than emit a wrong result.
+fn emit_aint_binop(
+    func: &mut Function,
+    op: BinOp,
+    ctx: &EmitCtx<'_>,
+) -> Result<Option<()>, WasmGcError> {
+    let call = |name: &str| -> Result<u32, WasmGcError> {
+        ctx.fn_map
+            .builtins
+            .get(name)
+            .copied()
+            .ok_or(WasmGcError::Validation(format!(
+                "bignum active but {name} helper not registered"
+            )))
+    };
+    match op {
+        BinOp::Add => {
+            func.instruction(&Instruction::Call(call("__aint_add")?));
+        }
+        BinOp::Sub => {
+            func.instruction(&Instruction::Call(call("__aint_sub")?));
+        }
+        BinOp::Mul => {
+            func.instruction(&Instruction::Call(call("__aint_mul")?));
+        }
+        BinOp::Div => {
+            // slice 2 — not yet supported under bignum; bail.
+            return Ok(None);
+        }
+        BinOp::Eq => {
+            func.instruction(&Instruction::Call(call("__aint_eq")?));
+        }
+        BinOp::Neq => {
+            func.instruction(&Instruction::Call(call("__aint_eq")?));
+            func.instruction(&Instruction::I32Eqz);
+        }
+        // Ordering: `__aint_cmp` → i32 in {-1,0,1}; compare to 0.
+        BinOp::Lt => {
+            func.instruction(&Instruction::Call(call("__aint_cmp")?));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::I32LtS);
+        }
+        BinOp::Gt => {
+            func.instruction(&Instruction::Call(call("__aint_cmp")?));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::I32GtS);
+        }
+        BinOp::Lte => {
+            func.instruction(&Instruction::Call(call("__aint_cmp")?));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::I32LeS);
+        }
+        BinOp::Gte => {
+            func.instruction(&Instruction::Call(call("__aint_cmp")?));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::I32GeS);
+        }
+    }
     Ok(Some(()))
 }

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -222,7 +222,21 @@ pub(crate) fn emit_mir_expr(
     match &expr.node {
         MirExpr::Literal(lit) => match &lit.node {
             Literal::Int(n) => {
-                func.instruction(&Instruction::I64Const(*n));
+                // bignum slice 1 — under the opt-in flag every Int value
+                // is the `$AverInt` struct ref, so an Int literal lowers
+                // to `i64.const n; call $__aint_from_i64` (the canonical
+                // Small constructor) instead of a bare `i64.const`.
+                if ctx.registry.bignum {
+                    func.instruction(&Instruction::I64Const(*n));
+                    let from_i64 = ctx.fn_map.builtins.get("__aint_from_i64").copied().ok_or(
+                        WasmGcError::Validation(
+                            "bignum active but __aint_from_i64 helper not registered".into(),
+                        ),
+                    )?;
+                    func.instruction(&Instruction::Call(from_i64));
+                } else {
+                    func.instruction(&Instruction::I64Const(*n));
+                }
                 Ok(Some(true))
             }
             Literal::Float(f) => {
@@ -357,6 +371,19 @@ pub(crate) fn emit_mir_expr(
                     return Ok(None);
                 }
                 func.instruction(&Instruction::F64Neg);
+            } else if ctx.registry.bignum {
+                // bignum slice 1 — Int Neg routes through `__aint_neg`
+                // (handles the `-i64::MIN` promotion to Big); the operand
+                // is already an `$AverInt` ref.
+                if emit_mir_expr(func, inner, slots, ctx)?.is_none() {
+                    return Ok(None);
+                }
+                let neg = ctx.fn_map.builtins.get("__aint_neg").copied().ok_or(
+                    WasmGcError::Validation(
+                        "bignum active but __aint_neg helper not registered".into(),
+                    ),
+                )?;
+                func.instruction(&Instruction::Call(neg));
             } else {
                 func.instruction(&Instruction::I64Const(0));
                 if emit_mir_expr(func, inner, slots, ctx)?.is_none() {

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -1,0 +1,793 @@
+//! bignum slice 1 — arbitrary-precision `Int` WAT helpers for wasm-gc.
+//!
+//! wasm-gc is the last backend still wrapping `i64`. VM and Rust are
+//! `Int = ℤ` via `aver-rt::AverInt`; wasm-gc emits WebAssembly GC
+//! directly and does not link aver-rt, so the small-int-optimized
+//! bignum lives here, IN the emitter, matching `aver-rt/src/int.rs`
+//! semantics EXACTLY.
+//!
+//! ## Representation (mirrors `AverInt`)
+//!
+//! ```text
+//! (struct $aint
+//!   (field $small (mut i64))                    ;; value when $magf == null
+//!   (field $magf  (mut (ref null (array i64))))  ;; magnitude limbs
+//!   (field $sign  (mut i32)))                    ;; -1 / 0 / +1, Big only
+//! ```
+//!
+//! - `$magf == null` → **Small**: value is `$small` (the i64 fast path).
+//! - `$magf != null` → **Big**: `$sign ∈ {-1,+1}`, `$magf` the
+//!   little-endian unsigned magnitude, canonical (no leading-zero
+//!   limbs, top limb non-zero).
+//!
+//! ### Limb radix (an internal detail, invisible to the ABI)
+//!
+//! The struct field type is `(array i64)`, but each limb carries only
+//! **32 bits** of magnitude (`0..2^32`). This is a deliberate
+//! implementation choice confined to these helpers: with 32-bit limbs a
+//! limb add `a+b+carry` and a limb multiply `a*b` both fit losslessly in
+//! a 64-bit lane, so carry/borrow propagation is exact with no
+//! add-with-carry primitive (wasm has none). The `$AverInt` struct shape
+//! is identical to the plan's — only the radix used inside decompose /
+//! recompose / arithmetic differs, and nothing outside this module ever
+//! observes a limb.
+//!
+//! ## Canonical invariant (non-negotiable)
+//!
+//! Any value that fits `i64` is ALWAYS Small. Every helper that can
+//! produce a Big funnels through the inlined normalize epilogue, which
+//! demotes an in-range magnitude back to Small — mirroring
+//! `AverInt::from_bigint`. Eq / Ord / (future) Hash depend on this.
+//!
+//! ## Single-function discipline (the trap)
+//!
+//! `compile_wat_helper` keeps only the FIRST function's body and
+//! discards the rest, AND does not rewrite call indices. So every helper
+//! is ONE function with NO `call` to any sibling — all limb routines are
+//! inlined. A stray `call` would be a silent miscompile only wasmtime
+//! catches.
+//!
+//! ## Overflow detection on the i64 fast path (no wasm flag)
+//!
+//! - ADD: `(a^s) & (b^s) < 0`, `s = a+b`.
+//! - SUB: `(a^b) & (a^d) < 0`, `d = a-b`.
+//! - MUL: round-trip-divide oracle `p == 0 || (a != 0 && p/a == b)`,
+//!   guarding `a == 0` and the `a == -1 && b == i64::MIN` `div_s` trap.
+//! - NEG: overflow only at `i64::MIN`.
+
+use wasm_encoder::Function;
+
+use super::super::WasmGcError;
+use super::super::types::TypeRegistry;
+use super::super::wat_helper;
+
+/// The `$mag` / `$aint` type declarations a bignum helper WAT needs, at
+/// the exact indices the user module's TypeRegistry recorded, so the
+/// spliced-in body's `struct.new $aint` / `array.* $mag` reference the
+/// right slots. `padding_types(mag_idx)` reserves `0..mag_idx`; the mag
+/// array lands at `mag_idx` and the struct at `mag_idx + 1`.
+fn aint_type_decls(registry: &TypeRegistry) -> Result<String, WasmGcError> {
+    let mag_idx = registry.aint_mag_array_idx.ok_or(WasmGcError::Validation(
+        "bignum helper needs the $AverInt magnitude array slot, but it wasn't allocated".into(),
+    ))?;
+    let struct_idx = registry.aint_struct_idx.ok_or(WasmGcError::Validation(
+        "bignum helper needs the $AverInt struct slot, but it wasn't allocated".into(),
+    ))?;
+    debug_assert_eq!(struct_idx, mag_idx + 1, "struct must sit right above mag");
+    let padding = wat_helper::padding_types(mag_idx);
+    Ok(format!(
+        "{padding}\
+         (type $mag (array (mut i64)))\n\
+         (type $aint (struct (field $small (mut i64)) \
+                             (field $magf (mut (ref null $mag))) \
+                             (field $sign (mut i32))))\n"
+    ))
+}
+
+/// Inlined WAT: decompose `$AverInt` operand local `$op` into a non-null
+/// 32-bit-limb magnitude array local `$opm` (little-endian, leading
+/// zeros possible) and a sign local `$ops` (-1/0/+1). A Small splits
+/// `|small|` into two 32-bit limbs; zero → sign 0 + empty magnitude.
+/// `|i64::MIN|` is recovered via `0 - small` (wrapping), giving the
+/// correct unsigned `2^63` whose low/high 32-bit halves are then split.
+fn decompose(op: &str, opm: &str, ops: &str, umag: &str) -> String {
+    // $umag is an i64 scratch holding |small| during the split.
+    format!(
+        r#"
+            (if (ref.is_null (struct.get $aint $magf (local.get ${op})))
+              (then
+                (if (i64.eqz (struct.get $aint $small (local.get ${op})))
+                  (then
+                    (local.set ${ops} (i32.const 0))
+                    (local.set ${opm} (array.new_default $mag (i32.const 0))))
+                  (else
+                    (local.set ${ops}
+                      (if (result i32) (i64.lt_s (struct.get $aint $small (local.get ${op})) (i64.const 0))
+                        (then (i32.const -1)) (else (i32.const 1))))
+                    (local.set ${umag}
+                      (if (result i64) (i32.lt_s (local.get ${ops}) (i32.const 0))
+                        (then (i64.sub (i64.const 0) (struct.get $aint $small (local.get ${op}))))
+                        (else (struct.get $aint $small (local.get ${op})))))
+                    (local.set ${opm} (array.new_default $mag (i32.const 2)))
+                    (array.set $mag (local.get ${opm}) (i32.const 0)
+                      (i64.and (local.get ${umag}) (i64.const 0xffffffff)))
+                    (array.set $mag (local.get ${opm}) (i32.const 1)
+                      (i64.shr_u (local.get ${umag}) (i64.const 32))))))
+              (else
+                (local.set ${opm} (struct.get $aint $magf (local.get ${op})))
+                (local.set ${ops} (struct.get $aint $sign (local.get ${op}))))) "#
+    )
+}
+
+/// Inlined WAT normalize epilogue. Takes a working 32-bit-limb magnitude
+/// array local `$rm` (leading zeros allowed) and a raw sign local `$rs`,
+/// leaves a canonical `$AverInt` on the stack. Scratch: `$rlen $i $hi
+/// $lo` (`$rlen $i` i32, `$hi $lo` i64) plus result-array local `$tmpm`.
+///
+/// Strips leading zeros; magnitude 0 → Small(0); a magnitude of ≤2 limbs
+/// whose 64-bit value fits the signed-i64 range for `$rs` → Small (incl.
+/// the lone `i64::MIN`); else a tight Big.
+fn normalize(rm: &str, rs: &str, rlen: &str, i: &str, lo: &str, hi: &str, tmpm: &str) -> String {
+    format!(
+        r#"
+            ;; strip leading zero limbs
+            (local.set ${rlen} (array.len (local.get ${rm})))
+            (block $strip_done (loop $strip
+              (br_if $strip_done (i32.eqz (local.get ${rlen})))
+              (br_if $strip_done
+                (i64.ne (array.get $mag (local.get ${rm}) (i32.sub (local.get ${rlen}) (i32.const 1))) (i64.const 0)))
+              (local.set ${rlen} (i32.sub (local.get ${rlen}) (i32.const 1)))
+              (br $strip)))
+            (if (result (ref null $aint)) (i32.eqz (local.get ${rlen}))
+              (then
+                (struct.new $aint (i64.const 0) (ref.null $mag) (i32.const 0)))
+              (else
+                (if (result (ref null $aint)) (i32.le_u (local.get ${rlen}) (i32.const 2))
+                  (then
+                    ;; reassemble ≤2 limbs into a 64-bit unsigned value
+                    (local.set ${lo} (i64.and (array.get $mag (local.get ${rm}) (i32.const 0)) (i64.const 0xffffffff)))
+                    (local.set ${hi}
+                      (if (result i64) (i32.eq (local.get ${rlen}) (i32.const 2))
+                        (then (i64.and (array.get $mag (local.get ${rm}) (i32.const 1)) (i64.const 0xffffffff)))
+                        (else (i64.const 0))))
+                    (local.set ${lo} (i64.or (local.get ${lo}) (i64.shl (local.get ${hi}) (i64.const 32))))
+                    ;; $lo now holds the full magnitude as an unsigned i64.
+                    (if (result (ref null $aint))
+                        (i64.eqz (i64.shr_u (local.get ${lo}) (i64.const 63)))
+                      (then
+                        ;; top bit clear → fits i64::MAX either sign → Small
+                        (struct.new $aint
+                          (if (result i64) (i32.lt_s (local.get ${rs}) (i32.const 0))
+                            (then (i64.sub (i64.const 0) (local.get ${lo}))) (else (local.get ${lo})))
+                          (ref.null $mag) (i32.const 0)))
+                      (else
+                        ;; top bit set: only -2^63 (i64::MIN) demotes.
+                        (if (result (ref null $aint))
+                            (i32.and (i32.lt_s (local.get ${rs}) (i32.const 0))
+                                     (i64.eq (local.get ${lo}) (i64.const 0x8000000000000000)))
+                          (then
+                            (struct.new $aint (i64.const 0x8000000000000000) (ref.null $mag) (i32.const 0)))
+                          (else
+                            {tight_big})))))
+                  (else
+                    {tight_big})))) "#,
+        tight_big = tight_big(rm, rs, rlen, i, tmpm),
+    )
+}
+
+/// Inlined WAT that copies the surviving `$rlen` limbs of `$rm` into a
+/// tight array `$tmpm` and builds a Big `$AverInt` (used by `normalize`
+/// for the genuinely-out-of-range case). `$i` is i32 scratch.
+fn tight_big(rm: &str, rs: &str, rlen: &str, i: &str, tmpm: &str) -> String {
+    format!(
+        r#"
+                        (local.set ${tmpm} (array.new_default $mag (local.get ${rlen})))
+                        (local.set ${i} (i32.const 0))
+                        (block $copy_done (loop $copy
+                          (br_if $copy_done (i32.ge_u (local.get ${i}) (local.get ${rlen})))
+                          (array.set $mag (local.get ${tmpm}) (local.get ${i})
+                            (array.get $mag (local.get ${rm}) (local.get ${i})))
+                          (local.set ${i} (i32.add (local.get ${i}) (i32.const 1)))
+                          (br $copy)))
+                        (struct.new $aint (i64.const 0) (local.get ${tmpm})
+                          (if (result i32) (i32.lt_s (local.get ${rs}) (i32.const 0)) (then (i32.const -1)) (else (i32.const 1)))) "#
+    )
+}
+
+/// Inlined unsigned-magnitude compare of arrays `$am` (stripped len
+/// `$alen`) and `$bm` (stripped len `$blen`) → -1/0/1 into i32 `$cmp`.
+/// i32 scratch `$j`.
+fn umag_cmp(am: &str, alen: &str, bm: &str, blen: &str, cmp: &str, j: &str) -> String {
+    format!(
+        r#"
+            (if (i32.ne (local.get ${alen}) (local.get ${blen}))
+              (then
+                (local.set ${cmp}
+                  (if (result i32) (i32.gt_u (local.get ${alen}) (local.get ${blen})) (then (i32.const 1)) (else (i32.const -1)))))
+              (else
+                (local.set ${cmp} (i32.const 0))
+                (local.set ${j} (local.get ${alen}))
+                (block $ucmp_done (loop $ucmp
+                  (br_if $ucmp_done (i32.eqz (local.get ${j})))
+                  (local.set ${j} (i32.sub (local.get ${j}) (i32.const 1)))
+                  (if (i64.ne (array.get $mag (local.get ${am}) (local.get ${j}))
+                              (array.get $mag (local.get ${bm}) (local.get ${j})))
+                    (then
+                      (local.set ${cmp}
+                        (if (result i32) (i64.gt_u (array.get $mag (local.get ${am}) (local.get ${j}))
+                                                   (array.get $mag (local.get ${bm}) (local.get ${j})))
+                          (then (i32.const 1)) (else (i32.const -1))))
+                      (br $ucmp_done)))
+                  (br $ucmp))))) "#
+    )
+}
+
+/// Type declarations for the bignum formatter, which references the
+/// `$string` array slot AS WELL AS `$mag` / `$aint`. The registry
+/// allocates `string_idx < mag_idx < struct_idx`, so we pad to each in
+/// turn: `padding_types(n)` injects `n` empty `(type (struct))` so the
+/// NEXT declared type lands at index `n`. Returns the full WAT prelude.
+fn aint_and_string_decls(registry: &TypeRegistry) -> Result<String, WasmGcError> {
+    let string_idx = registry
+        .string_array_type_idx
+        .ok_or(WasmGcError::Validation(
+            "bignum String.fromInt needs the String slot, but it wasn't allocated".into(),
+        ))?;
+    let mag_idx = registry.aint_mag_array_idx.ok_or(WasmGcError::Validation(
+        "bignum String.fromInt needs the $mag slot, but it wasn't allocated".into(),
+    ))?;
+    let struct_idx = registry.aint_struct_idx.ok_or(WasmGcError::Validation(
+        "bignum String.fromInt needs the $aint slot, but it wasn't allocated".into(),
+    ))?;
+    if !(string_idx < mag_idx && mag_idx + 1 == struct_idx) {
+        return Err(WasmGcError::Validation(format!(
+            "bignum String.fromInt expects string({string_idx}) < mag({mag_idx}) and \
+             struct({struct_idx}) == mag+1; layout invariant broken"
+        )));
+    }
+    let pad_to_string = wat_helper::padding_types(string_idx);
+    // After declaring $string we are at index string_idx+1; pad the gap
+    // up to mag_idx, then declare $mag and $aint.
+    let gap = wat_helper::padding_types(mag_idx - (string_idx + 1));
+    Ok(format!(
+        "{pad_to_string}\
+         (type $string (array (mut i8)))\n\
+         {gap}\
+         (type $mag (array (mut i64)))\n\
+         (type $aint (struct (field $small (mut i64)) \
+                             (field $magf (mut (ref null $mag))) \
+                             (field $sign (mut i32))))\n"
+    ))
+}
+
+/// `String.fromInt` under bignum — formats an `$AverInt` to a decimal
+/// `(ref null $string)`. Small reads `$small` and runs the same i64
+/// digit loop the scalar helper uses; Big repeatedly divides the 32-bit
+/// limb magnitude by 10 (the ONLY divmod in slice 1, and it is by a
+/// constant), collecting remainder digits low→high, then reverses them
+/// into the output array with a leading `-` for negative sign.
+pub(super) fn emit_string_from_aint(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_and_string_decls(registry)?;
+    let wat = format!(
+        r#"
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result (ref null $string))
+            (local $n i64) (local $abs i64) (local $copy i64)
+            (local $digits i32) (local $total i32) (local $i i32) (local $neg i32)
+            (local $arr (ref null $string))
+            (local $magc (ref null $mag)) (local $len i32) (local $li i32)
+            (local $cur i64) (local $rem i64) (local $q i64) (local $allzero i32)
+            (local $digbuf (ref null $string)) (local $dcount i32)
+            (if (result (ref null $string)) (ref.is_null (struct.get $aint $magf (local.get $a)))
+              (then
+                ;; ── Small: format $small as the scalar helper does ──
+                (local.set $n (struct.get $aint $small (local.get $a)))
+                (if (result (ref null $string)) (i64.eqz (local.get $n))
+                  (then (array.new $string (i32.const 48) (i32.const 1)))
+                  (else
+                    (local.set $neg (if (result i32) (i64.lt_s (local.get $n) (i64.const 0)) (then (i32.const 1)) (else (i32.const 0))))
+                    (local.set $abs (if (result i64) (local.get $neg) (then (i64.sub (i64.const 0) (local.get $n))) (else (local.get $n))))
+                    ;; count digits
+                    (local.set $copy (local.get $abs)) (local.set $digits (i32.const 0))
+                    (block $cd (loop $c
+                      (br_if $cd (i64.eqz (local.get $copy)))
+                      (local.set $digits (i32.add (local.get $digits) (i32.const 1)))
+                      (local.set $copy (i64.div_u (local.get $copy) (i64.const 10)))
+                      (br $c)))
+                    (local.set $total (i32.add (local.get $digits) (local.get $neg)))
+                    (local.set $arr (array.new_default $string (local.get $total)))
+                    (local.set $i (i32.sub (local.get $total) (i32.const 1)))
+                    (local.set $copy (local.get $abs))
+                    (block $fd (loop $f
+                      (br_if $fd (i32.lt_s (local.get $i) (local.get $neg)))
+                      (array.set $string (local.get $arr) (local.get $i)
+                        (i32.add (i32.const 48) (i32.wrap_i64 (i64.rem_u (local.get $copy) (i64.const 10)))))
+                      (local.set $copy (i64.div_u (local.get $copy) (i64.const 10)))
+                      (local.set $i (i32.sub (local.get $i) (i32.const 1)))
+                      (br $f)))
+                    (if (local.get $neg) (then (array.set $string (local.get $arr) (i32.const 0) (i32.const 45))))
+                    (local.get $arr))))
+              (else
+                ;; ── Big: divmod-by-10 over 32-bit limbs ──
+                (local.set $neg (if (result i32) (i32.lt_s (struct.get $aint $sign (local.get $a)) (i32.const 0)) (then (i32.const 1)) (else (i32.const 0))))
+                ;; work on a mutable copy of the magnitude
+                (local.set $len (array.len (struct.get $aint $magf (local.get $a))))
+                (local.set $magc (array.new_default $mag (local.get $len)))
+                (local.set $li (i32.const 0))
+                (block $cpd (loop $cp
+                  (br_if $cpd (i32.ge_u (local.get $li) (local.get $len)))
+                  (array.set $mag (local.get $magc) (local.get $li)
+                    (array.get $mag (struct.get $aint $magf (local.get $a)) (local.get $li)))
+                  (local.set $li (i32.add (local.get $li) (i32.const 1)))
+                  (br $cp)))
+                ;; collect digits low→high into $digbuf (max ~10 digits/limb*len; len*10 is safe)
+                (local.set $digbuf (array.new_default $string (i32.mul (local.get $len) (i32.const 10))))
+                (local.set $dcount (i32.const 0))
+                (block $dvd (loop $dv
+                  ;; rem = 0; for li=len-1 down to 0: cur=(rem<<32)|limb; q=cur/10; rem=cur%10; limb=q
+                  (local.set $rem (i64.const 0))
+                  (local.set $li (local.get $len))
+                  (block $dl (loop $d
+                    (br_if $dl (i32.eqz (local.get $li)))
+                    (local.set $li (i32.sub (local.get $li) (i32.const 1)))
+                    (local.set $cur (i64.or (i64.shl (local.get $rem) (i64.const 32))
+                                            (i64.and (array.get $mag (local.get $magc) (local.get $li)) (i64.const 0xffffffff))))
+                    (local.set $q (i64.div_u (local.get $cur) (i64.const 10)))
+                    (local.set $rem (i64.rem_u (local.get $cur) (i64.const 10)))
+                    (array.set $mag (local.get $magc) (local.get $li) (local.get $q))
+                    (br $d)))
+                  ;; emit digit = rem
+                  (array.set $string (local.get $digbuf) (local.get $dcount)
+                    (i32.add (i32.const 48) (i32.wrap_i64 (local.get $rem))))
+                  (local.set $dcount (i32.add (local.get $dcount) (i32.const 1)))
+                  ;; loop while magnitude is non-zero
+                  (local.set $allzero (i32.const 1))
+                  (local.set $li (i32.const 0))
+                  (block $zd (loop $z
+                    (br_if $zd (i32.ge_u (local.get $li) (local.get $len)))
+                    (if (i64.ne (array.get $mag (local.get $magc) (local.get $li)) (i64.const 0))
+                      (then (local.set $allzero (i32.const 0)) (br $zd)))
+                    (local.set $li (i32.add (local.get $li) (i32.const 1)))
+                    (br $z)))
+                  ;; exit when the magnitude has become all-zero; else loop.
+                  (br_if $dvd (local.get $allzero))
+                  (br $dv)))
+                ;; build output: [neg '-'] then digits reversed
+                (local.set $total (i32.add (local.get $dcount) (local.get $neg)))
+                (local.set $arr (array.new_default $string (local.get $total)))
+                (if (local.get $neg) (then (array.set $string (local.get $arr) (i32.const 0) (i32.const 45))))
+                (local.set $i (i32.const 0))
+                (block $od (loop $o
+                  (br_if $od (i32.ge_u (local.get $i) (local.get $dcount)))
+                  (array.set $string (local.get $arr)
+                    (i32.add (local.get $neg) (local.get $i))
+                    (array.get_u $string (local.get $digbuf) (i32.sub (i32.sub (local.get $dcount) (i32.const 1)) (local.get $i))))
+                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                  (br $o)))
+                (local.get $arr)))))
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_from_i64(n: i64) -> $AverInt` — canonical Small constructor.
+pub(super) fn emit_aint_from_i64(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(
+        r#"
+        (module
+          {decls}
+          (func (export "helper") (param $n i64) (result (ref null $aint))
+            (struct.new $aint (local.get $n) (ref.null $mag) (i32.const 0))))
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_neg(a) -> $AverInt`. Small fast path with `i64::MIN`
+/// promotion; Big flips the sign field (magnitude unchanged, stays
+/// canonical).
+pub(super) fn emit_aint_neg(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(
+        r#"
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result (ref null $aint))
+            (if (result (ref null $aint)) (ref.is_null (struct.get $aint $magf (local.get $a)))
+              (then
+                (if (result (ref null $aint))
+                    (i64.eq (struct.get $aint $small (local.get $a)) (i64.const 0x8000000000000000))
+                  (then
+                    ;; -(i64::MIN) = 2^63 → Big, positive, two 32-bit limbs
+                    ;; (low=0, high=0x80000000).
+                    (struct.new $aint (i64.const 0)
+                      (array.new_fixed $mag 2 (i64.const 0) (i64.const 0x80000000))
+                      (i32.const 1)))
+                  (else
+                    (struct.new $aint
+                      (i64.sub (i64.const 0) (struct.get $aint $small (local.get $a)))
+                      (ref.null $mag) (i32.const 0)))))
+              (else
+                (struct.new $aint (i64.const 0)
+                  (struct.get $aint $magf (local.get $a))
+                  (i32.sub (i32.const 0) (struct.get $aint $sign (local.get $a))))))))
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_eq(a, b) -> i32` (1/0). Leans on the canonical invariant:
+/// equal Small ↔ equal $small; equal Big ↔ same sign + same limbs; a
+/// Small and a Big are never equal.
+pub(super) fn emit_aint_eq(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(
+        r#"
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result i32)
+            (local $am (ref null $mag)) (local $bm (ref null $mag))
+            (local $i i32) (local $n i32) (local $eq i32)
+            (local.set $am (struct.get $aint $magf (local.get $a)))
+            (local.set $bm (struct.get $aint $magf (local.get $b)))
+            (if (result i32) (ref.is_null (local.get $am))
+              (then
+                (if (result i32) (ref.is_null (local.get $bm))
+                  (then (i64.eq (struct.get $aint $small (local.get $a)) (struct.get $aint $small (local.get $b))))
+                  (else (i32.const 0))))
+              (else
+                (if (result i32) (ref.is_null (local.get $bm))
+                  (then (i32.const 0))
+                  (else
+                    (if (result i32) (i32.ne (struct.get $aint $sign (local.get $a)) (struct.get $aint $sign (local.get $b)))
+                      (then (i32.const 0))
+                      (else
+                        (if (result i32) (i32.ne (array.len (local.get $am)) (array.len (local.get $bm)))
+                          (then (i32.const 0))
+                          (else
+                            (local.set $n (array.len (local.get $am)))
+                            (local.set $i (i32.const 0))
+                            (local.set $eq (i32.const 1))
+                            (block $done (loop $lp
+                              (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+                              (if (i64.ne (array.get $mag (local.get $am) (local.get $i))
+                                          (array.get $mag (local.get $bm) (local.get $i)))
+                                (then (local.set $eq (i32.const 0)) (br $done)))
+                              (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                              (br $lp)))
+                            (local.get $eq)))))))))))
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_cmp(a, b) -> i32` (-1/0/1). Sign first, then unsigned
+/// magnitude (flipped for two negatives). Mirrors `AverInt::cmp`.
+pub(super) fn emit_aint_cmp(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let decomp_a = decompose("a", "am", "as_", "umag");
+    let decomp_b = decompose("b", "bm", "bs", "umag");
+    let strip_a = strip("am", "alen", "sa", "la");
+    let strip_b = strip("bm", "blen", "sb", "lb");
+    let cmp = umag_cmp("am", "alen", "bm", "blen", "cmp", "j");
+    let wat = format!(
+        r#"
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result i32)
+            (local $am (ref null $mag)) (local $as_ i32)
+            (local $bm (ref null $mag)) (local $bs i32)
+            (local $alen i32) (local $blen i32)
+            (local $cmp i32) (local $j i32) (local $umag i64)
+            {decomp_a}
+            {decomp_b}
+            (if (result i32) (i32.ne (local.get $as_) (local.get $bs))
+              (then
+                (if (result i32) (i32.gt_s (local.get $as_) (local.get $bs)) (then (i32.const 1)) (else (i32.const -1))))
+              (else
+                (if (result i32) (i32.eqz (local.get $as_))
+                  (then (i32.const 0))
+                  (else
+                    {strip_a}
+                    {strip_b}
+                    {cmp}
+                    (if (result i32) (i32.lt_s (local.get $as_) (i32.const 0))
+                      (then (i32.sub (i32.const 0) (local.get $cmp)))
+                      (else (local.get $cmp)))))))))
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// Inlined leading-zero strip of array `$arr` into i32 len local `$len`,
+/// using unique block/loop label names `$bl`/`$lp`.
+fn strip(arr: &str, len: &str, bl: &str, lp: &str) -> String {
+    format!(
+        r#"
+            (local.set ${len} (array.len (local.get ${arr})))
+            (block ${bl} (loop ${lp}
+              (br_if ${bl} (i32.eqz (local.get ${len})))
+              (br_if ${bl} (i64.ne (array.get $mag (local.get ${arr}) (i32.sub (local.get ${len}) (i32.const 1))) (i64.const 0)))
+              (local.set ${len} (i32.sub (local.get ${len}) (i32.const 1)))
+              (br ${lp}))) "#
+    )
+}
+
+/// Inlined signed-magnitude combine. Operands are decomposed locals
+/// `(am, as_)` and `(bm, beff)` where `beff` is the EFFECTIVE sign of b
+/// (caller passes `bs` for add, the negation `-bs` for sub). Produces a
+/// working magnitude into `$rm` + raw sign into `$rs`, NOT normalized.
+///
+/// Assumes the caller has stripped `am`→`$alen`, `bm`→`$blen` and
+/// declared scratch `$rlen $i $carry $cmp $j $borrow $diff` with the
+/// types named below. 32-bit limbs make carry/borrow exact.
+fn signed_combine() -> String {
+    let cmp = umag_cmp("am", "alen", "bm", "blen", "cmp", "j");
+    format!(
+        r#"
+            ;; signs "agree" when one is zero, or the two non-zero signs match.
+            (if (i32.or (i32.eqz (local.get $as_))
+                  (i32.or (i32.eqz (local.get $beff)) (i32.eq (local.get $as_) (local.get $beff))))
+              (then
+                ;; ── magnitude ADD ── rlen = max(alen,blen)+1
+                (local.set $rlen (i32.add (i32.const 1)
+                  (if (result i32) (i32.gt_u (local.get $alen) (local.get $blen)) (then (local.get $alen)) (else (local.get $blen)))))
+                (local.set $rm (array.new_default $mag (local.get $rlen)))
+                (local.set $i (i32.const 0))
+                (local.set $carry (i64.const 0))
+                (block $add_done (loop $add_lp
+                  (br_if $add_done (i32.ge_u (local.get $i) (local.get $rlen)))
+                  (local.set $carry (i64.add (local.get $carry)
+                    (i64.add
+                      (if (result i64) (i32.lt_u (local.get $i) (local.get $alen)) (then (array.get $mag (local.get $am) (local.get $i))) (else (i64.const 0)))
+                      (if (result i64) (i32.lt_u (local.get $i) (local.get $blen)) (then (array.get $mag (local.get $bm) (local.get $i))) (else (i64.const 0))))))
+                  (array.set $mag (local.get $rm) (local.get $i) (i64.and (local.get $carry) (i64.const 0xffffffff)))
+                  (local.set $carry (i64.shr_u (local.get $carry) (i64.const 32)))
+                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                  (br $add_lp)))
+                (local.set $rs (if (result i32) (i32.eqz (local.get $as_)) (then (local.get $beff)) (else (local.get $as_)))))
+              (else
+                ;; ── magnitude SUBTRACT (differing signs) ── larger - smaller
+                {cmp}
+                (if (i32.eqz (local.get $cmp))
+                  (then
+                    (local.set $rm (array.new_default $mag (i32.const 0)))
+                    (local.set $rs (i32.const 0)))
+                  (else
+                    ;; result sign = sign of the larger magnitude operand
+                    (local.set $rs (if (result i32) (i32.gt_s (local.get $cmp) (i32.const 0)) (then (local.get $as_)) (else (local.get $beff))))
+                    (local.set $rlen (if (result i32) (i32.gt_u (local.get $alen) (local.get $blen)) (then (local.get $alen)) (else (local.get $blen))))
+                    (local.set $rm (array.new_default $mag (local.get $rlen)))
+                    (local.set $i (i32.const 0))
+                    (local.set $borrow (i64.const 0))
+                    (block $sub_done (loop $sub_lp
+                      (br_if $sub_done (i32.ge_u (local.get $i) (local.get $rlen)))
+                      ;; diff = larger_limb - smaller_limb - borrow, in 64 bits.
+                      ;; "larger" is am if cmp>0 else bm.
+                      (local.set $diff (i64.sub
+                        (i64.sub
+                          (if (result i64) (i32.gt_s (local.get $cmp) (i32.const 0))
+                            (then (if (result i64) (i32.lt_u (local.get $i) (local.get $alen)) (then (array.get $mag (local.get $am) (local.get $i))) (else (i64.const 0))))
+                            (else (if (result i64) (i32.lt_u (local.get $i) (local.get $blen)) (then (array.get $mag (local.get $bm) (local.get $i))) (else (i64.const 0)))))
+                          (if (result i64) (i32.gt_s (local.get $cmp) (i32.const 0))
+                            (then (if (result i64) (i32.lt_u (local.get $i) (local.get $blen)) (then (array.get $mag (local.get $bm) (local.get $i))) (else (i64.const 0))))
+                            (else (if (result i64) (i32.lt_u (local.get $i) (local.get $alen)) (then (array.get $mag (local.get $am) (local.get $i))) (else (i64.const 0))))))
+                        (local.get $borrow)))
+                      ;; if diff < 0 (as signed) add 2^32 and set borrow=1
+                      (if (i64.lt_s (local.get $diff) (i64.const 0))
+                        (then
+                          (local.set $diff (i64.add (local.get $diff) (i64.const 0x100000000)))
+                          (local.set $borrow (i64.const 1)))
+                        (else (local.set $borrow (i64.const 0))))
+                      (array.set $mag (local.get $rm) (local.get $i) (i64.and (local.get $diff) (i64.const 0xffffffff)))
+                      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                      (br $sub_lp)))))))
+    "#
+    )
+}
+
+/// Common locals declaration shared by add/sub: decomposed operands,
+/// lengths, carry/borrow scratch, and normalize scratch.
+fn arith_locals() -> &'static str {
+    r#"
+            (local $am (ref null $mag)) (local $as_ i32)
+            (local $bm (ref null $mag)) (local $bs i32) (local $beff i32)
+            (local $alen i32) (local $blen i32) (local $rlen i32)
+            (local $rm (ref null $mag)) (local $rs i32)
+            (local $i i32) (local $j i32) (local $cmp i32)
+            (local $carry i64) (local $borrow i64) (local $diff i64) (local $umag i64)
+            (local $lo i64) (local $hi i64) (local $tmpm (ref null $mag)) "#
+}
+
+/// `__aint_add(a, b) -> $AverInt`. i64 fast path with `(a^s)&(b^s)<0`
+/// overflow detection; on overflow OR either operand Big, decompose +
+/// signed-magnitude add + normalize.
+pub(super) fn emit_aint_add(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    emit_aint_addsub(registry, false)
+}
+
+/// `__aint_sub(a, b) -> $AverInt`. i64 fast path with `(a^b)&(a^d)<0`
+/// overflow detection; slow path negates b's effective sign.
+pub(super) fn emit_aint_sub(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    emit_aint_addsub(registry, true)
+}
+
+fn emit_aint_addsub(registry: &TypeRegistry, is_sub: bool) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let locals = arith_locals();
+    let decomp_a = decompose("a", "am", "as_", "umag");
+    let decomp_b = decompose("b", "bm", "bs", "umag");
+    let strip_a = strip("am", "alen", "sa", "la");
+    let strip_b = strip("bm", "blen", "sb", "lb");
+    let combine = signed_combine();
+    let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    // i64 fast-path: both Small.
+    let (fast_op, overflow_check) = if is_sub {
+        (
+            "(i64.sub (struct.get $aint $small (local.get $a)) (struct.get $aint $small (local.get $b)))",
+            // (a^b) & (a^d) < 0, d = result
+            "(i64.lt_s (i64.and (i64.xor (struct.get $aint $small (local.get $a)) (struct.get $aint $small (local.get $b))) (i64.xor (struct.get $aint $small (local.get $a)) (local.get $r))) (i64.const 0))",
+        )
+    } else {
+        (
+            "(i64.add (struct.get $aint $small (local.get $a)) (struct.get $aint $small (local.get $b)))",
+            // (a^s) & (b^s) < 0, s = result
+            "(i64.lt_s (i64.and (i64.xor (struct.get $aint $small (local.get $a)) (local.get $r)) (i64.xor (struct.get $aint $small (local.get $b)) (local.get $r))) (i64.const 0))",
+        )
+    };
+    let beff_set = if is_sub {
+        "(local.set $beff (i32.sub (i32.const 0) (local.get $bs)))"
+    } else {
+        "(local.set $beff (local.get $bs))"
+    };
+    let wat = format!(
+        r#"
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result (ref null $aint))
+            (local $r i64)
+            {locals}
+            ;; fast path: both Small.
+            (if (result (ref null $aint))
+                (i32.and (ref.is_null (struct.get $aint $magf (local.get $a)))
+                         (ref.is_null (struct.get $aint $magf (local.get $b))))
+              (then
+                (local.set $r {fast_op})
+                (if (result (ref null $aint)) {overflow_check}
+                  (then
+                    ;; overflow → slow path
+                    {decomp_a}
+                    {decomp_b}
+                    {beff_set}
+                    {strip_a}
+                    {strip_b}
+                    {combine}
+                    {norm})
+                  (else
+                    (struct.new $aint (local.get $r) (ref.null $mag) (i32.const 0)))))
+              (else
+                ;; at least one Big → slow path
+                {decomp_a}
+                {decomp_b}
+                {beff_set}
+                {strip_a}
+                {strip_b}
+                {combine}
+                {norm}))))
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_mul(a, b) -> $AverInt`. i64 fast path with the round-trip-
+/// divide overflow oracle (`p == 0 || (a != 0 && p/a == b)`), guarding
+/// `a == 0` and the `a == -1 && b == i64::MIN` `div_s` trap. Slow path:
+/// schoolbook 32-bit-limb magnitude multiply, sign = product of signs.
+pub(super) fn emit_aint_mul(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let locals = arith_locals();
+    let decomp_a = decompose("a", "am", "as_", "umag");
+    let decomp_b = decompose("b", "bm", "bs", "umag");
+    let strip_a = strip("am", "alen", "sa", "la");
+    let strip_b = strip("bm", "blen", "sb", "lb");
+    let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    let wat = format!(
+        r#"
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result (ref null $aint))
+            (local $r i64) (local $av i64) (local $bv i64)
+            (local $k i32) (local $prod i64) (local $ok i32)
+            {locals}
+            (if (result (ref null $aint))
+                (i32.and (ref.is_null (struct.get $aint $magf (local.get $a)))
+                         (ref.is_null (struct.get $aint $magf (local.get $b))))
+              (then
+                (local.set $av (struct.get $aint $small (local.get $a)))
+                (local.set $bv (struct.get $aint $small (local.get $b)))
+                (local.set $r (i64.mul (local.get $av) (local.get $bv)))
+                ;; overflow oracle (mirrors i64::checked_mul): NO overflow
+                ;; iff a == 0 (product genuinely 0), OR — a != 0 AND it is
+                ;; not the `a == -1 && b == i64::MIN` div_s trap edge (that
+                ;; edge IS an overflow) AND the round-trip `r / a == b`.
+                ;;
+                ;; CRUCIAL: wasm `i32.and`/`i32.or` are NOT short-circuiting
+                ;; — both arms evaluate eagerly. A flat boolean expression
+                ;; would run `i64.div_s` on the trap edge and TRAP. So we
+                ;; compute `$ok` with lazy `if` control flow, never reaching
+                ;; the divide unless the divisor is safe.
+                (if (i64.eqz (local.get $av))
+                  (then (local.set $ok (i32.const 1)))
+                  (else
+                    (if (i32.and (i64.eq (local.get $av) (i64.const -1))
+                                 (i64.eq (local.get $bv) (i64.const 0x8000000000000000)))
+                      (then (local.set $ok (i32.const 0)))  ;; trap edge → overflow
+                      (else
+                        (local.set $ok (i64.eq (i64.div_s (local.get $r) (local.get $av)) (local.get $bv)))))))
+                (if (result (ref null $aint)) (local.get $ok)
+                  (then
+                    ;; no overflow → Small result
+                    (struct.new $aint (local.get $r) (ref.null $mag) (i32.const 0)))
+                  (else
+                    ;; overflow → slow path
+                    {decomp_a} {decomp_b} {strip_a} {strip_b}
+                    {mul_body}
+                    {norm})))
+              (else
+                {decomp_a} {decomp_b} {strip_a} {strip_b}
+                {mul_body}
+                {norm}))))
+    "#,
+        mul_body = mul_magnitude(),
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// Inlined schoolbook 32-bit-limb magnitude multiply. Reads stripped
+/// `am`/`$alen`, `bm`/`$blen`; writes the product magnitude into `$rm`
+/// (len `$alen+$blen`) and the result sign into `$rs` (= as_ * bs, with
+/// 0 when either is zero). Scratch i32 `$i $j $k`, i64 `$carry $prod`.
+fn mul_magnitude() -> String {
+    r#"
+            ;; result sign: 0 if either operand zero, else product of signs.
+            (local.set $rs (i32.mul (local.get $as_) (local.get $bs)))
+            (local.set $rlen (i32.add (local.get $alen) (local.get $blen)))
+            (if (i32.eqz (local.get $rlen)) (then (local.set $rlen (i32.const 1))))
+            (local.set $rm (array.new_default $mag (local.get $rlen)))
+            (local.set $i (i32.const 0))
+            (block $mi_done (loop $mi
+              (br_if $mi_done (i32.ge_u (local.get $i) (local.get $alen)))
+              (local.set $carry (i64.const 0))
+              (local.set $j (i32.const 0))
+              (block $mj_done (loop $mj
+                (br_if $mj_done (i32.ge_u (local.get $j) (local.get $blen)))
+                (local.set $k (i32.add (local.get $i) (local.get $j)))
+                ;; prod = am[i]*bm[j] + rm[k] + carry  (fits in 64 bits:
+                ;; (2^32-1)^2 + 2*(2^32-1) < 2^64)
+                (local.set $prod (i64.add
+                  (i64.add
+                    (i64.mul (array.get $mag (local.get $am) (local.get $i))
+                             (array.get $mag (local.get $bm) (local.get $j)))
+                    (array.get $mag (local.get $rm) (local.get $k)))
+                  (local.get $carry)))
+                (array.set $mag (local.get $rm) (local.get $k) (i64.and (local.get $prod) (i64.const 0xffffffff)))
+                (local.set $carry (i64.shr_u (local.get $prod) (i64.const 32)))
+                (local.set $j (i32.add (local.get $j) (i32.const 1)))
+                (br $mj)))
+              ;; ripple the final carry up from rm[i+blen], masking each
+              ;; limb to 32 bits so no lane is left holding > 2^32-1.
+              (local.set $k (i32.add (local.get $i) (local.get $blen)))
+              (block $mc_done (loop $mc
+                (br_if $mc_done (i64.eqz (local.get $carry)))
+                (local.set $prod (i64.add (array.get $mag (local.get $rm) (local.get $k)) (local.get $carry)))
+                (array.set $mag (local.get $rm) (local.get $k) (i64.and (local.get $prod) (i64.const 0xffffffff)))
+                (local.set $carry (i64.shr_u (local.get $prod) (i64.const 32)))
+                (local.set $k (i32.add (local.get $k) (i32.const 1)))
+                (br $mc)))
+              (local.set $i (i32.add (local.get $i) (i32.const 1)))
+              (br $mi)))
+    "#
+    .to_string()
+}

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -395,7 +395,9 @@ pub(super) fn emit_aint_neg(registry: &TypeRegistry) -> Result<Function, WasmGcE
         (module
           {decls}
           (func (export "helper") (param $a (ref null $aint)) (result (ref null $aint))
-            (if (result (ref null $aint)) (ref.is_null (struct.get $aint $magf (local.get $a)))
+            (local $m (ref null $mag))
+            (local.set $m (struct.get $aint $magf (local.get $a)))
+            (if (result (ref null $aint)) (ref.is_null (local.get $m))
               (then
                 (if (result (ref null $aint))
                     (i64.eq (struct.get $aint $small (local.get $a)) (i64.const 0x8000000000000000))
@@ -410,9 +412,26 @@ pub(super) fn emit_aint_neg(registry: &TypeRegistry) -> Result<Function, WasmGcE
                       (i64.sub (i64.const 0) (struct.get $aint $small (local.get $a)))
                       (ref.null $mag) (i32.const 0)))))
               (else
-                (struct.new $aint (i64.const 0)
-                  (struct.get $aint $magf (local.get $a))
-                  (i32.sub (i32.const 0) (struct.get $aint $sign (local.get $a))))))))
+                ;; Big. Negation keeps the magnitude and flips the sign, and the
+                ;; result stays a canonical Big EXCEPT for +2^63 (the smallest
+                ;; Big, = i64::MAX + 1): -(2^63) = i64::MIN re-enters i64 range
+                ;; and MUST demote to Small, or `eq` would report it unequal to
+                ;; the same value reached as a Small. +2^63's canonical limbs
+                ;; are [0, 0x80000000] (len 2); every other Big negation is
+                ;; still a canonical Big, so a plain sign flip is correct there.
+                (if (result (ref null $aint))
+                    (i32.and
+                      (i32.eq (struct.get $aint $sign (local.get $a)) (i32.const 1))
+                      (i32.and (i32.eq (array.len (local.get $m)) (i32.const 2))
+                        (i32.and
+                          (i64.eqz (array.get $mag (local.get $m) (i32.const 0)))
+                          (i64.eq (array.get $mag (local.get $m) (i32.const 1)) (i64.const 0x80000000)))))
+                  (then
+                    (struct.new $aint (i64.const 0x8000000000000000) (ref.null $mag) (i32.const 0)))
+                  (else
+                    (struct.new $aint (i64.const 0)
+                      (local.get $m)
+                      (i32.sub (i32.const 0) (struct.get $aint $sign (local.get $a))))))))))
     "#
     );
     wat_helper::compile_wat_helper(&wat)

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -268,120 +268,14 @@ fn aint_and_string_decls(registry: &TypeRegistry) -> Result<String, WasmGcError>
 /// into the output array with a leading `-` for negative sign.
 pub(super) fn emit_string_from_aint(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_and_string_decls(registry)?;
-    let wat = format!(
-        r#"
-        (module
-          {decls}
-          (func (export "helper") (param $a (ref null $aint)) (result (ref null $string))
-            (local $n i64) (local $abs i64) (local $copy i64)
-            (local $digits i32) (local $total i32) (local $i i32) (local $neg i32)
-            (local $arr (ref null $string))
-            (local $magc (ref null $mag)) (local $len i32) (local $li i32)
-            (local $cur i64) (local $rem i64) (local $q i64) (local $allzero i32)
-            (local $digbuf (ref null $string)) (local $dcount i32)
-            (if (result (ref null $string)) (ref.is_null (struct.get $aint $magf (local.get $a)))
-              (then
-                ;; ── Small: format $small as the scalar helper does ──
-                (local.set $n (struct.get $aint $small (local.get $a)))
-                (if (result (ref null $string)) (i64.eqz (local.get $n))
-                  (then (array.new $string (i32.const 48) (i32.const 1)))
-                  (else
-                    (local.set $neg (if (result i32) (i64.lt_s (local.get $n) (i64.const 0)) (then (i32.const 1)) (else (i32.const 0))))
-                    (local.set $abs (if (result i64) (local.get $neg) (then (i64.sub (i64.const 0) (local.get $n))) (else (local.get $n))))
-                    ;; count digits
-                    (local.set $copy (local.get $abs)) (local.set $digits (i32.const 0))
-                    (block $cd (loop $c
-                      (br_if $cd (i64.eqz (local.get $copy)))
-                      (local.set $digits (i32.add (local.get $digits) (i32.const 1)))
-                      (local.set $copy (i64.div_u (local.get $copy) (i64.const 10)))
-                      (br $c)))
-                    (local.set $total (i32.add (local.get $digits) (local.get $neg)))
-                    (local.set $arr (array.new_default $string (local.get $total)))
-                    (local.set $i (i32.sub (local.get $total) (i32.const 1)))
-                    (local.set $copy (local.get $abs))
-                    (block $fd (loop $f
-                      (br_if $fd (i32.lt_s (local.get $i) (local.get $neg)))
-                      (array.set $string (local.get $arr) (local.get $i)
-                        (i32.add (i32.const 48) (i32.wrap_i64 (i64.rem_u (local.get $copy) (i64.const 10)))))
-                      (local.set $copy (i64.div_u (local.get $copy) (i64.const 10)))
-                      (local.set $i (i32.sub (local.get $i) (i32.const 1)))
-                      (br $f)))
-                    (if (local.get $neg) (then (array.set $string (local.get $arr) (i32.const 0) (i32.const 45))))
-                    (local.get $arr))))
-              (else
-                ;; ── Big: divmod-by-10 over 32-bit limbs ──
-                (local.set $neg (if (result i32) (i32.lt_s (struct.get $aint $sign (local.get $a)) (i32.const 0)) (then (i32.const 1)) (else (i32.const 0))))
-                ;; work on a mutable copy of the magnitude
-                (local.set $len (array.len (struct.get $aint $magf (local.get $a))))
-                (local.set $magc (array.new_default $mag (local.get $len)))
-                (local.set $li (i32.const 0))
-                (block $cpd (loop $cp
-                  (br_if $cpd (i32.ge_u (local.get $li) (local.get $len)))
-                  (array.set $mag (local.get $magc) (local.get $li)
-                    (array.get $mag (struct.get $aint $magf (local.get $a)) (local.get $li)))
-                  (local.set $li (i32.add (local.get $li) (i32.const 1)))
-                  (br $cp)))
-                ;; collect digits low→high into $digbuf (max ~10 digits/limb*len; len*10 is safe)
-                (local.set $digbuf (array.new_default $string (i32.mul (local.get $len) (i32.const 10))))
-                (local.set $dcount (i32.const 0))
-                (block $dvd (loop $dv
-                  ;; rem = 0; for li=len-1 down to 0: cur=(rem<<32)|limb; q=cur/10; rem=cur%10; limb=q
-                  (local.set $rem (i64.const 0))
-                  (local.set $li (local.get $len))
-                  (block $dl (loop $d
-                    (br_if $dl (i32.eqz (local.get $li)))
-                    (local.set $li (i32.sub (local.get $li) (i32.const 1)))
-                    (local.set $cur (i64.or (i64.shl (local.get $rem) (i64.const 32))
-                                            (i64.and (array.get $mag (local.get $magc) (local.get $li)) (i64.const 0xffffffff))))
-                    (local.set $q (i64.div_u (local.get $cur) (i64.const 10)))
-                    (local.set $rem (i64.rem_u (local.get $cur) (i64.const 10)))
-                    (array.set $mag (local.get $magc) (local.get $li) (local.get $q))
-                    (br $d)))
-                  ;; emit digit = rem
-                  (array.set $string (local.get $digbuf) (local.get $dcount)
-                    (i32.add (i32.const 48) (i32.wrap_i64 (local.get $rem))))
-                  (local.set $dcount (i32.add (local.get $dcount) (i32.const 1)))
-                  ;; loop while magnitude is non-zero
-                  (local.set $allzero (i32.const 1))
-                  (local.set $li (i32.const 0))
-                  (block $zd (loop $z
-                    (br_if $zd (i32.ge_u (local.get $li) (local.get $len)))
-                    (if (i64.ne (array.get $mag (local.get $magc) (local.get $li)) (i64.const 0))
-                      (then (local.set $allzero (i32.const 0)) (br $zd)))
-                    (local.set $li (i32.add (local.get $li) (i32.const 1)))
-                    (br $z)))
-                  ;; exit when the magnitude has become all-zero; else loop.
-                  (br_if $dvd (local.get $allzero))
-                  (br $dv)))
-                ;; build output: [neg '-'] then digits reversed
-                (local.set $total (i32.add (local.get $dcount) (local.get $neg)))
-                (local.set $arr (array.new_default $string (local.get $total)))
-                (if (local.get $neg) (then (array.set $string (local.get $arr) (i32.const 0) (i32.const 45))))
-                (local.set $i (i32.const 0))
-                (block $od (loop $o
-                  (br_if $od (i32.ge_u (local.get $i) (local.get $dcount)))
-                  (array.set $string (local.get $arr)
-                    (i32.add (local.get $neg) (local.get $i))
-                    (array.get_u $string (local.get $digbuf) (i32.sub (i32.sub (local.get $dcount) (i32.const 1)) (local.get $i))))
-                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
-                  (br $o)))
-                (local.get $arr)))))
-    "#
-    );
+    let wat = format!(include_str!("wat/string_from_aint.wat"), decls = decls);
     wat_helper::compile_wat_helper(&wat)
 }
 
 /// `__aint_from_i64(n: i64) -> $AverInt` — canonical Small constructor.
 pub(super) fn emit_aint_from_i64(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
-    let wat = format!(
-        r#"
-        (module
-          {decls}
-          (func (export "helper") (param $n i64) (result (ref null $aint))
-            (struct.new $aint (local.get $n) (ref.null $mag) (i32.const 0))))
-    "#
-    );
+    let wat = format!(include_str!("wat/from_i64.wat"), decls = decls);
     wat_helper::compile_wat_helper(&wat)
 }
 
@@ -390,50 +284,7 @@ pub(super) fn emit_aint_from_i64(registry: &TypeRegistry) -> Result<Function, Wa
 /// canonical).
 pub(super) fn emit_aint_neg(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
-    let wat = format!(
-        r#"
-        (module
-          {decls}
-          (func (export "helper") (param $a (ref null $aint)) (result (ref null $aint))
-            (local $m (ref null $mag))
-            (local.set $m (struct.get $aint $magf (local.get $a)))
-            (if (result (ref null $aint)) (ref.is_null (local.get $m))
-              (then
-                (if (result (ref null $aint))
-                    (i64.eq (struct.get $aint $small (local.get $a)) (i64.const 0x8000000000000000))
-                  (then
-                    ;; -(i64::MIN) = 2^63 → Big, positive, two 32-bit limbs
-                    ;; (low=0, high=0x80000000).
-                    (struct.new $aint (i64.const 0)
-                      (array.new_fixed $mag 2 (i64.const 0) (i64.const 0x80000000))
-                      (i32.const 1)))
-                  (else
-                    (struct.new $aint
-                      (i64.sub (i64.const 0) (struct.get $aint $small (local.get $a)))
-                      (ref.null $mag) (i32.const 0)))))
-              (else
-                ;; Big. Negation keeps the magnitude and flips the sign, and the
-                ;; result stays a canonical Big EXCEPT for +2^63 (the smallest
-                ;; Big, = i64::MAX + 1): -(2^63) = i64::MIN re-enters i64 range
-                ;; and MUST demote to Small, or `eq` would report it unequal to
-                ;; the same value reached as a Small. +2^63's canonical limbs
-                ;; are [0, 0x80000000] (len 2); every other Big negation is
-                ;; still a canonical Big, so a plain sign flip is correct there.
-                (if (result (ref null $aint))
-                    (i32.and
-                      (i32.eq (struct.get $aint $sign (local.get $a)) (i32.const 1))
-                      (i32.and (i32.eq (array.len (local.get $m)) (i32.const 2))
-                        (i32.and
-                          (i64.eqz (array.get $mag (local.get $m) (i32.const 0)))
-                          (i64.eq (array.get $mag (local.get $m) (i32.const 1)) (i64.const 0x80000000)))))
-                  (then
-                    (struct.new $aint (i64.const 0x8000000000000000) (ref.null $mag) (i32.const 0)))
-                  (else
-                    (struct.new $aint (i64.const 0)
-                      (local.get $m)
-                      (i32.sub (i32.const 0) (struct.get $aint $sign (local.get $a))))))))))
-    "#
-    );
+    let wat = format!(include_str!("wat/neg.wat"), decls = decls);
     wat_helper::compile_wat_helper(&wat)
 }
 
@@ -442,43 +293,7 @@ pub(super) fn emit_aint_neg(registry: &TypeRegistry) -> Result<Function, WasmGcE
 /// Small and a Big are never equal.
 pub(super) fn emit_aint_eq(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
-    let wat = format!(
-        r#"
-        (module
-          {decls}
-          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result i32)
-            (local $am (ref null $mag)) (local $bm (ref null $mag))
-            (local $i i32) (local $n i32) (local $eq i32)
-            (local.set $am (struct.get $aint $magf (local.get $a)))
-            (local.set $bm (struct.get $aint $magf (local.get $b)))
-            (if (result i32) (ref.is_null (local.get $am))
-              (then
-                (if (result i32) (ref.is_null (local.get $bm))
-                  (then (i64.eq (struct.get $aint $small (local.get $a)) (struct.get $aint $small (local.get $b))))
-                  (else (i32.const 0))))
-              (else
-                (if (result i32) (ref.is_null (local.get $bm))
-                  (then (i32.const 0))
-                  (else
-                    (if (result i32) (i32.ne (struct.get $aint $sign (local.get $a)) (struct.get $aint $sign (local.get $b)))
-                      (then (i32.const 0))
-                      (else
-                        (if (result i32) (i32.ne (array.len (local.get $am)) (array.len (local.get $bm)))
-                          (then (i32.const 0))
-                          (else
-                            (local.set $n (array.len (local.get $am)))
-                            (local.set $i (i32.const 0))
-                            (local.set $eq (i32.const 1))
-                            (block $done (loop $lp
-                              (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
-                              (if (i64.ne (array.get $mag (local.get $am) (local.get $i))
-                                          (array.get $mag (local.get $bm) (local.get $i)))
-                                (then (local.set $eq (i32.const 0)) (br $done)))
-                              (local.set $i (i32.add (local.get $i) (i32.const 1)))
-                              (br $lp)))
-                            (local.get $eq)))))))))))
-    "#
-    );
+    let wat = format!(include_str!("wat/eq.wat"), decls = decls);
     wat_helper::compile_wat_helper(&wat)
 }
 
@@ -492,30 +307,13 @@ pub(super) fn emit_aint_cmp(registry: &TypeRegistry) -> Result<Function, WasmGcE
     let strip_b = strip("bm", "blen", "sb", "lb");
     let cmp = umag_cmp("am", "alen", "bm", "blen", "cmp", "j");
     let wat = format!(
-        r#"
-        (module
-          {decls}
-          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result i32)
-            (local $am (ref null $mag)) (local $as_ i32)
-            (local $bm (ref null $mag)) (local $bs i32)
-            (local $alen i32) (local $blen i32)
-            (local $cmp i32) (local $j i32) (local $umag i64)
-            {decomp_a}
-            {decomp_b}
-            (if (result i32) (i32.ne (local.get $as_) (local.get $bs))
-              (then
-                (if (result i32) (i32.gt_s (local.get $as_) (local.get $bs)) (then (i32.const 1)) (else (i32.const -1))))
-              (else
-                (if (result i32) (i32.eqz (local.get $as_))
-                  (then (i32.const 0))
-                  (else
-                    {strip_a}
-                    {strip_b}
-                    {cmp}
-                    (if (result i32) (i32.lt_s (local.get $as_) (i32.const 0))
-                      (then (i32.sub (i32.const 0) (local.get $cmp)))
-                      (else (local.get $cmp)))))))))
-    "#
+        include_str!("wat/cmp.wat"),
+        decls = decls,
+        decomp_a = decomp_a,
+        decomp_b = decomp_b,
+        strip_a = strip_a,
+        strip_b = strip_b,
+        cmp = cmp,
     );
     wat_helper::compile_wat_helper(&wat)
 }
@@ -662,40 +460,18 @@ fn emit_aint_addsub(registry: &TypeRegistry, is_sub: bool) -> Result<Function, W
         "(local.set $beff (local.get $bs))"
     };
     let wat = format!(
-        r#"
-        (module
-          {decls}
-          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result (ref null $aint))
-            (local $r i64)
-            {locals}
-            ;; fast path: both Small.
-            (if (result (ref null $aint))
-                (i32.and (ref.is_null (struct.get $aint $magf (local.get $a)))
-                         (ref.is_null (struct.get $aint $magf (local.get $b))))
-              (then
-                (local.set $r {fast_op})
-                (if (result (ref null $aint)) {overflow_check}
-                  (then
-                    ;; overflow → slow path
-                    {decomp_a}
-                    {decomp_b}
-                    {beff_set}
-                    {strip_a}
-                    {strip_b}
-                    {combine}
-                    {norm})
-                  (else
-                    (struct.new $aint (local.get $r) (ref.null $mag) (i32.const 0)))))
-              (else
-                ;; at least one Big → slow path
-                {decomp_a}
-                {decomp_b}
-                {beff_set}
-                {strip_a}
-                {strip_b}
-                {combine}
-                {norm}))))
-    "#
+        include_str!("wat/addsub.wat"),
+        decls = decls,
+        locals = locals,
+        decomp_a = decomp_a,
+        decomp_b = decomp_b,
+        beff_set = beff_set,
+        strip_a = strip_a,
+        strip_b = strip_b,
+        combine = combine,
+        norm = norm,
+        fast_op = fast_op,
+        overflow_check = overflow_check,
     );
     wat_helper::compile_wat_helper(&wat)
 }
@@ -713,52 +489,14 @@ pub(super) fn emit_aint_mul(registry: &TypeRegistry) -> Result<Function, WasmGcE
     let strip_b = strip("bm", "blen", "sb", "lb");
     let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
     let wat = format!(
-        r#"
-        (module
-          {decls}
-          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result (ref null $aint))
-            (local $r i64) (local $av i64) (local $bv i64)
-            (local $k i32) (local $prod i64) (local $ok i32)
-            {locals}
-            (if (result (ref null $aint))
-                (i32.and (ref.is_null (struct.get $aint $magf (local.get $a)))
-                         (ref.is_null (struct.get $aint $magf (local.get $b))))
-              (then
-                (local.set $av (struct.get $aint $small (local.get $a)))
-                (local.set $bv (struct.get $aint $small (local.get $b)))
-                (local.set $r (i64.mul (local.get $av) (local.get $bv)))
-                ;; overflow oracle (mirrors i64::checked_mul): NO overflow
-                ;; iff a == 0 (product genuinely 0), OR — a != 0 AND it is
-                ;; not the `a == -1 && b == i64::MIN` div_s trap edge (that
-                ;; edge IS an overflow) AND the round-trip `r / a == b`.
-                ;;
-                ;; CRUCIAL: wasm `i32.and`/`i32.or` are NOT short-circuiting
-                ;; — both arms evaluate eagerly. A flat boolean expression
-                ;; would run `i64.div_s` on the trap edge and TRAP. So we
-                ;; compute `$ok` with lazy `if` control flow, never reaching
-                ;; the divide unless the divisor is safe.
-                (if (i64.eqz (local.get $av))
-                  (then (local.set $ok (i32.const 1)))
-                  (else
-                    (if (i32.and (i64.eq (local.get $av) (i64.const -1))
-                                 (i64.eq (local.get $bv) (i64.const 0x8000000000000000)))
-                      (then (local.set $ok (i32.const 0)))  ;; trap edge → overflow
-                      (else
-                        (local.set $ok (i64.eq (i64.div_s (local.get $r) (local.get $av)) (local.get $bv)))))))
-                (if (result (ref null $aint)) (local.get $ok)
-                  (then
-                    ;; no overflow → Small result
-                    (struct.new $aint (local.get $r) (ref.null $mag) (i32.const 0)))
-                  (else
-                    ;; overflow → slow path
-                    {decomp_a} {decomp_b} {strip_a} {strip_b}
-                    {mul_body}
-                    {norm})))
-              (else
-                {decomp_a} {decomp_b} {strip_a} {strip_b}
-                {mul_body}
-                {norm}))))
-    "#,
+        include_str!("wat/mul.wat"),
+        decls = decls,
+        locals = locals,
+        decomp_a = decomp_a,
+        decomp_b = decomp_b,
+        strip_a = strip_a,
+        strip_b = strip_b,
+        norm = norm,
         mul_body = mul_magnitude(),
     );
     wat_helper::compile_wat_helper(&wat)
@@ -809,4 +547,58 @@ fn mul_magnitude() -> String {
               (br $mi)))
     "#
     .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `TypeRegistry` with the bignum slots wired to a self-consistent
+    /// layout (`string=0 < mag=1`, `struct=mag+1=2`) — the layout
+    /// invariant both `aint_type_decls` and `aint_and_string_decls`
+    /// require. Built from an empty program so no parsing/resolution
+    /// machinery is needed, then the four bignum/String index fields are
+    /// overwritten directly (they are `pub(super)`, visible here).
+    fn bignum_registry() -> TypeRegistry {
+        let mut registry = TypeRegistry::build_with_handler(&[], &[], false);
+        registry.bignum = true;
+        registry.string_array_type_idx = Some(0);
+        registry.aint_mag_array_idx = Some(1);
+        registry.aint_struct_idx = Some(2);
+        registry
+    }
+
+    /// PARSE GUARD — the whole point of moving the WAT bodies into
+    /// `.wat` files. Every leaf helper's template is formatted and run
+    /// through `wat::parse_str` (inside `compile_wat_helper`). A stray
+    /// `)`/`(` in any `.wat` file — the exact bug class hand-balancing
+    /// parens in `r#"…"#` invited — fails HERE at `cargo test`, instead
+    /// of only when a program happens to exercise that op in wasmtime.
+    #[test]
+    fn every_bignum_helper_wat_parses() {
+        let registry = bignum_registry();
+
+        // Each leaf helper emits a full `(module … (func "helper" …))`;
+        // `compile_wat_helper` parses it, so `Ok` ⇒ the WAT is
+        // syntactically valid and the locals/body extracted cleanly.
+        let cases: &[(&str, fn(&TypeRegistry) -> Result<Function, WasmGcError>)] = &[
+            ("emit_aint_from_i64", emit_aint_from_i64),
+            ("emit_aint_neg", emit_aint_neg),
+            ("emit_aint_eq", emit_aint_eq),
+            ("emit_aint_cmp", emit_aint_cmp),
+            ("emit_aint_add", emit_aint_add),
+            ("emit_aint_sub", emit_aint_sub),
+            ("emit_aint_mul", emit_aint_mul),
+            ("emit_string_from_aint", emit_string_from_aint),
+        ];
+
+        for (name, emit) in cases {
+            let result = emit(&registry);
+            assert!(
+                result.is_ok(),
+                "bignum helper `{name}` failed to emit/parse its WAT: {:?}",
+                result.err()
+            );
+        }
+    }
 }

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -68,6 +68,8 @@ use super::WasmGcError;
 use super::types::TypeRegistry;
 use super::wat_helper;
 
+mod bignum;
+
 /// Curated set of pure-side builtins phase 3c+ implements. Adding a
 /// new builtin: extend this enum + `from_dotted` + `signature` +
 /// `emit_helper_body`.
@@ -143,6 +145,25 @@ pub(super) enum BuiltinName {
     /// Caller guards `b == 0`; the helper assumes `b != 0` (and would
     /// `i64.div_s`-trap on that or the `i64::MIN / -1` overflow).
     IntDivEuclid,
+    // ── bignum slice 1 — arbitrary-precision Int helpers ─────────────
+    // Each is a self-contained WAT fn over the `$AverInt` struct ref;
+    // registered only under the `AVER_WASMGC_BIGNUM` flag. See
+    // `bignum.rs` for the representation + semantics.
+    /// `__aint_from_i64(i64) -> $AverInt` — canonical Small constructor.
+    AintFromI64,
+    /// `__aint_add(a, b) -> $AverInt` — ℤ add (never wraps).
+    AintAdd,
+    /// `__aint_sub(a, b) -> $AverInt` — ℤ sub (never wraps).
+    AintSub,
+    /// `__aint_mul(a, b) -> $AverInt` — ℤ mul (never wraps); the C0 law
+    /// `a*a >= 0` holds even where i64 would wrap.
+    AintMul,
+    /// `__aint_neg(a) -> $AverInt` — ℤ negate (`-i64::MIN` promotes).
+    AintNeg,
+    /// `__aint_cmp(a, b) -> i32` (-1/0/1) — total order over ℤ.
+    AintCmp,
+    /// `__aint_eq(a, b) -> i32` (1/0) — equality leaning on canonical form.
+    AintEq,
 }
 
 impl BuiltinName {
@@ -201,11 +222,22 @@ impl BuiltinName {
             Self::StringReplace => "String.replace",
             Self::IntModEuclid => "__int_mod_euclid",
             Self::IntDivEuclid => "__int_div_euclid",
+            Self::AintFromI64 => "__aint_from_i64",
+            Self::AintAdd => "__aint_add",
+            Self::AintSub => "__aint_sub",
+            Self::AintMul => "__aint_mul",
+            Self::AintNeg => "__aint_neg",
+            Self::AintCmp => "__aint_cmp",
+            Self::AintEq => "__aint_eq",
         }
     }
 
     pub(super) fn params(self, registry: &TypeRegistry) -> Result<Vec<ValType>, WasmGcError> {
         match self {
+            // bignum slice 1 — `String.fromInt` takes the `$AverInt` ref
+            // (and formats Big via divmod-by-10) when bignum is active;
+            // otherwise the scalar i64.
+            Self::StringFromInt if registry.bignum => Ok(vec![aint_ref_ty(registry)?]),
             Self::StringFromInt => Ok(vec![ValType::I64]),
             Self::StringLength | Self::StringByteLength => Ok(vec![string_ref_ty(registry)?]),
             Self::StringConcatN => Ok(vec![string_array_ref_ty(registry)?]),
@@ -235,6 +267,11 @@ impl BuiltinName {
                 string_ref_ty(registry)?,
             ]),
             Self::IntModEuclid | Self::IntDivEuclid => Ok(vec![ValType::I64, ValType::I64]),
+            Self::AintFromI64 => Ok(vec![ValType::I64]),
+            Self::AintAdd | Self::AintSub | Self::AintMul | Self::AintCmp | Self::AintEq => {
+                Ok(vec![aint_ref_ty(registry)?, aint_ref_ty(registry)?])
+            }
+            Self::AintNeg => Ok(vec![aint_ref_ty(registry)?]),
         }
     }
 
@@ -264,6 +301,10 @@ impl BuiltinName {
             Self::ByteToHex => Ok(vec![result_ref_ty(registry, "Result<String,String>")?]),
             Self::StringReplace => Ok(vec![string_ref_ty(registry)?]),
             Self::IntModEuclid | Self::IntDivEuclid => Ok(vec![ValType::I64]),
+            Self::AintFromI64 | Self::AintAdd | Self::AintSub | Self::AintMul | Self::AintNeg => {
+                Ok(vec![aint_ref_ty(registry)?])
+            }
+            Self::AintCmp | Self::AintEq => Ok(vec![ValType::I32]),
         }
     }
 
@@ -272,6 +313,7 @@ impl BuiltinName {
     /// `emit_helper_bodies`.
     pub(super) fn emit_helper_body(self, registry: &TypeRegistry) -> Result<Function, WasmGcError> {
         match self {
+            Self::StringFromInt if registry.bignum => bignum::emit_string_from_aint(registry),
             Self::StringFromInt => emit_string_from_int(registry),
             Self::StringLength => emit_string_length(registry),
             Self::StringByteLength => emit_string_byte_length(registry),
@@ -298,6 +340,13 @@ impl BuiltinName {
             Self::StringReplace => emit_string_replace(registry),
             Self::IntModEuclid => emit_int_mod_euclid(),
             Self::IntDivEuclid => emit_int_div_euclid(),
+            Self::AintFromI64 => bignum::emit_aint_from_i64(registry),
+            Self::AintAdd => bignum::emit_aint_add(registry),
+            Self::AintSub => bignum::emit_aint_sub(registry),
+            Self::AintMul => bignum::emit_aint_mul(registry),
+            Self::AintNeg => bignum::emit_aint_neg(registry),
+            Self::AintCmp => bignum::emit_aint_cmp(registry),
+            Self::AintEq => bignum::emit_aint_eq(registry),
         }
     }
 }
@@ -354,6 +403,11 @@ impl BuiltinRegistry {
         }
         Ok(())
     }
+}
+
+/// `(ref null $AverInt)` — bignum slice 1 carrier ref.
+fn aint_ref_ty(registry: &TypeRegistry) -> Result<ValType, WasmGcError> {
+    super::types::aint_ref_ty(registry)
 }
 
 /// `(ref null $string_array)` — shared String repr.

--- a/src/codegen/wasm_gc/builtins/wat/addsub.wat
+++ b/src/codegen/wasm_gc/builtins/wat/addsub.wat
@@ -1,0 +1,34 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result (ref null $aint))
+            (local $r i64)
+            {locals}
+            ;; fast path: both Small.
+            (if (result (ref null $aint))
+                (i32.and (ref.is_null (struct.get $aint $magf (local.get $a)))
+                         (ref.is_null (struct.get $aint $magf (local.get $b))))
+              (then
+                (local.set $r {fast_op})
+                (if (result (ref null $aint)) {overflow_check}
+                  (then
+                    ;; overflow → slow path
+                    {decomp_a}
+                    {decomp_b}
+                    {beff_set}
+                    {strip_a}
+                    {strip_b}
+                    {combine}
+                    {norm})
+                  (else
+                    (struct.new $aint (local.get $r) (ref.null $mag) (i32.const 0)))))
+              (else
+                ;; at least one Big → slow path
+                {decomp_a}
+                {decomp_b}
+                {beff_set}
+                {strip_a}
+                {strip_b}
+                {combine}
+                {norm}))))
+    

--- a/src/codegen/wasm_gc/builtins/wat/cmp.wat
+++ b/src/codegen/wasm_gc/builtins/wat/cmp.wat
@@ -1,0 +1,24 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result i32)
+            (local $am (ref null $mag)) (local $as_ i32)
+            (local $bm (ref null $mag)) (local $bs i32)
+            (local $alen i32) (local $blen i32)
+            (local $cmp i32) (local $j i32) (local $umag i64)
+            {decomp_a}
+            {decomp_b}
+            (if (result i32) (i32.ne (local.get $as_) (local.get $bs))
+              (then
+                (if (result i32) (i32.gt_s (local.get $as_) (local.get $bs)) (then (i32.const 1)) (else (i32.const -1))))
+              (else
+                (if (result i32) (i32.eqz (local.get $as_))
+                  (then (i32.const 0))
+                  (else
+                    {strip_a}
+                    {strip_b}
+                    {cmp}
+                    (if (result i32) (i32.lt_s (local.get $as_) (i32.const 0))
+                      (then (i32.sub (i32.const 0) (local.get $cmp)))
+                      (else (local.get $cmp)))))))))
+    

--- a/src/codegen/wasm_gc/builtins/wat/eq.wat
+++ b/src/codegen/wasm_gc/builtins/wat/eq.wat
@@ -1,0 +1,35 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result i32)
+            (local $am (ref null $mag)) (local $bm (ref null $mag))
+            (local $i i32) (local $n i32) (local $eq i32)
+            (local.set $am (struct.get $aint $magf (local.get $a)))
+            (local.set $bm (struct.get $aint $magf (local.get $b)))
+            (if (result i32) (ref.is_null (local.get $am))
+              (then
+                (if (result i32) (ref.is_null (local.get $bm))
+                  (then (i64.eq (struct.get $aint $small (local.get $a)) (struct.get $aint $small (local.get $b))))
+                  (else (i32.const 0))))
+              (else
+                (if (result i32) (ref.is_null (local.get $bm))
+                  (then (i32.const 0))
+                  (else
+                    (if (result i32) (i32.ne (struct.get $aint $sign (local.get $a)) (struct.get $aint $sign (local.get $b)))
+                      (then (i32.const 0))
+                      (else
+                        (if (result i32) (i32.ne (array.len (local.get $am)) (array.len (local.get $bm)))
+                          (then (i32.const 0))
+                          (else
+                            (local.set $n (array.len (local.get $am)))
+                            (local.set $i (i32.const 0))
+                            (local.set $eq (i32.const 1))
+                            (block $done (loop $lp
+                              (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+                              (if (i64.ne (array.get $mag (local.get $am) (local.get $i))
+                                          (array.get $mag (local.get $bm) (local.get $i)))
+                                (then (local.set $eq (i32.const 0)) (br $done)))
+                              (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                              (br $lp)))
+                            (local.get $eq)))))))))))
+    

--- a/src/codegen/wasm_gc/builtins/wat/from_i64.wat
+++ b/src/codegen/wasm_gc/builtins/wat/from_i64.wat
@@ -1,0 +1,6 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $n i64) (result (ref null $aint))
+            (struct.new $aint (local.get $n) (ref.null $mag) (i32.const 0))))
+    

--- a/src/codegen/wasm_gc/builtins/wat/mul.wat
+++ b/src/codegen/wasm_gc/builtins/wat/mul.wat
@@ -1,0 +1,46 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result (ref null $aint))
+            (local $r i64) (local $av i64) (local $bv i64)
+            (local $k i32) (local $prod i64) (local $ok i32)
+            {locals}
+            (if (result (ref null $aint))
+                (i32.and (ref.is_null (struct.get $aint $magf (local.get $a)))
+                         (ref.is_null (struct.get $aint $magf (local.get $b))))
+              (then
+                (local.set $av (struct.get $aint $small (local.get $a)))
+                (local.set $bv (struct.get $aint $small (local.get $b)))
+                (local.set $r (i64.mul (local.get $av) (local.get $bv)))
+                ;; overflow oracle (mirrors i64::checked_mul): NO overflow
+                ;; iff a == 0 (product genuinely 0), OR — a != 0 AND it is
+                ;; not the `a == -1 && b == i64::MIN` div_s trap edge (that
+                ;; edge IS an overflow) AND the round-trip `r / a == b`.
+                ;;
+                ;; CRUCIAL: wasm `i32.and`/`i32.or` are NOT short-circuiting
+                ;; — both arms evaluate eagerly. A flat boolean expression
+                ;; would run `i64.div_s` on the trap edge and TRAP. So we
+                ;; compute `$ok` with lazy `if` control flow, never reaching
+                ;; the divide unless the divisor is safe.
+                (if (i64.eqz (local.get $av))
+                  (then (local.set $ok (i32.const 1)))
+                  (else
+                    (if (i32.and (i64.eq (local.get $av) (i64.const -1))
+                                 (i64.eq (local.get $bv) (i64.const 0x8000000000000000)))
+                      (then (local.set $ok (i32.const 0)))  ;; trap edge → overflow
+                      (else
+                        (local.set $ok (i64.eq (i64.div_s (local.get $r) (local.get $av)) (local.get $bv)))))))
+                (if (result (ref null $aint)) (local.get $ok)
+                  (then
+                    ;; no overflow → Small result
+                    (struct.new $aint (local.get $r) (ref.null $mag) (i32.const 0)))
+                  (else
+                    ;; overflow → slow path
+                    {decomp_a} {decomp_b} {strip_a} {strip_b}
+                    {mul_body}
+                    {norm})))
+              (else
+                {decomp_a} {decomp_b} {strip_a} {strip_b}
+                {mul_body}
+                {norm}))))
+    

--- a/src/codegen/wasm_gc/builtins/wat/neg.wat
+++ b/src/codegen/wasm_gc/builtins/wat/neg.wat
@@ -1,0 +1,42 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result (ref null $aint))
+            (local $m (ref null $mag))
+            (local.set $m (struct.get $aint $magf (local.get $a)))
+            (if (result (ref null $aint)) (ref.is_null (local.get $m))
+              (then
+                (if (result (ref null $aint))
+                    (i64.eq (struct.get $aint $small (local.get $a)) (i64.const 0x8000000000000000))
+                  (then
+                    ;; -(i64::MIN) = 2^63 → Big, positive, two 32-bit limbs
+                    ;; (low=0, high=0x80000000).
+                    (struct.new $aint (i64.const 0)
+                      (array.new_fixed $mag 2 (i64.const 0) (i64.const 0x80000000))
+                      (i32.const 1)))
+                  (else
+                    (struct.new $aint
+                      (i64.sub (i64.const 0) (struct.get $aint $small (local.get $a)))
+                      (ref.null $mag) (i32.const 0)))))
+              (else
+                ;; Big. Negation keeps the magnitude and flips the sign, and the
+                ;; result stays a canonical Big EXCEPT for +2^63 (the smallest
+                ;; Big, = i64::MAX + 1): -(2^63) = i64::MIN re-enters i64 range
+                ;; and MUST demote to Small, or `eq` would report it unequal to
+                ;; the same value reached as a Small. +2^63's canonical limbs
+                ;; are [0, 0x80000000] (len 2); every other Big negation is
+                ;; still a canonical Big, so a plain sign flip is correct there.
+                (if (result (ref null $aint))
+                    (i32.and
+                      (i32.eq (struct.get $aint $sign (local.get $a)) (i32.const 1))
+                      (i32.and (i32.eq (array.len (local.get $m)) (i32.const 2))
+                        (i32.and
+                          (i64.eqz (array.get $mag (local.get $m) (i32.const 0)))
+                          (i64.eq (array.get $mag (local.get $m) (i32.const 1)) (i64.const 0x80000000)))))
+                  (then
+                    (struct.new $aint (i64.const 0x8000000000000000) (ref.null $mag) (i32.const 0)))
+                  (else
+                    (struct.new $aint (i64.const 0)
+                      (local.get $m)
+                      (i32.sub (i32.const 0) (struct.get $aint $sign (local.get $a))))))))))
+    

--- a/src/codegen/wasm_gc/builtins/wat/string_from_aint.wat
+++ b/src/codegen/wasm_gc/builtins/wat/string_from_aint.wat
@@ -1,0 +1,98 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result (ref null $string))
+            (local $n i64) (local $abs i64) (local $copy i64)
+            (local $digits i32) (local $total i32) (local $i i32) (local $neg i32)
+            (local $arr (ref null $string))
+            (local $magc (ref null $mag)) (local $len i32) (local $li i32)
+            (local $cur i64) (local $rem i64) (local $q i64) (local $allzero i32)
+            (local $digbuf (ref null $string)) (local $dcount i32)
+            (if (result (ref null $string)) (ref.is_null (struct.get $aint $magf (local.get $a)))
+              (then
+                ;; ── Small: format $small as the scalar helper does ──
+                (local.set $n (struct.get $aint $small (local.get $a)))
+                (if (result (ref null $string)) (i64.eqz (local.get $n))
+                  (then (array.new $string (i32.const 48) (i32.const 1)))
+                  (else
+                    (local.set $neg (if (result i32) (i64.lt_s (local.get $n) (i64.const 0)) (then (i32.const 1)) (else (i32.const 0))))
+                    (local.set $abs (if (result i64) (local.get $neg) (then (i64.sub (i64.const 0) (local.get $n))) (else (local.get $n))))
+                    ;; count digits
+                    (local.set $copy (local.get $abs)) (local.set $digits (i32.const 0))
+                    (block $cd (loop $c
+                      (br_if $cd (i64.eqz (local.get $copy)))
+                      (local.set $digits (i32.add (local.get $digits) (i32.const 1)))
+                      (local.set $copy (i64.div_u (local.get $copy) (i64.const 10)))
+                      (br $c)))
+                    (local.set $total (i32.add (local.get $digits) (local.get $neg)))
+                    (local.set $arr (array.new_default $string (local.get $total)))
+                    (local.set $i (i32.sub (local.get $total) (i32.const 1)))
+                    (local.set $copy (local.get $abs))
+                    (block $fd (loop $f
+                      (br_if $fd (i32.lt_s (local.get $i) (local.get $neg)))
+                      (array.set $string (local.get $arr) (local.get $i)
+                        (i32.add (i32.const 48) (i32.wrap_i64 (i64.rem_u (local.get $copy) (i64.const 10)))))
+                      (local.set $copy (i64.div_u (local.get $copy) (i64.const 10)))
+                      (local.set $i (i32.sub (local.get $i) (i32.const 1)))
+                      (br $f)))
+                    (if (local.get $neg) (then (array.set $string (local.get $arr) (i32.const 0) (i32.const 45))))
+                    (local.get $arr))))
+              (else
+                ;; ── Big: divmod-by-10 over 32-bit limbs ──
+                (local.set $neg (if (result i32) (i32.lt_s (struct.get $aint $sign (local.get $a)) (i32.const 0)) (then (i32.const 1)) (else (i32.const 0))))
+                ;; work on a mutable copy of the magnitude
+                (local.set $len (array.len (struct.get $aint $magf (local.get $a))))
+                (local.set $magc (array.new_default $mag (local.get $len)))
+                (local.set $li (i32.const 0))
+                (block $cpd (loop $cp
+                  (br_if $cpd (i32.ge_u (local.get $li) (local.get $len)))
+                  (array.set $mag (local.get $magc) (local.get $li)
+                    (array.get $mag (struct.get $aint $magf (local.get $a)) (local.get $li)))
+                  (local.set $li (i32.add (local.get $li) (i32.const 1)))
+                  (br $cp)))
+                ;; collect digits low→high into $digbuf (max ~10 digits/limb*len; len*10 is safe)
+                (local.set $digbuf (array.new_default $string (i32.mul (local.get $len) (i32.const 10))))
+                (local.set $dcount (i32.const 0))
+                (block $dvd (loop $dv
+                  ;; rem = 0; for li=len-1 down to 0: cur=(rem<<32)|limb; q=cur/10; rem=cur%10; limb=q
+                  (local.set $rem (i64.const 0))
+                  (local.set $li (local.get $len))
+                  (block $dl (loop $d
+                    (br_if $dl (i32.eqz (local.get $li)))
+                    (local.set $li (i32.sub (local.get $li) (i32.const 1)))
+                    (local.set $cur (i64.or (i64.shl (local.get $rem) (i64.const 32))
+                                            (i64.and (array.get $mag (local.get $magc) (local.get $li)) (i64.const 0xffffffff))))
+                    (local.set $q (i64.div_u (local.get $cur) (i64.const 10)))
+                    (local.set $rem (i64.rem_u (local.get $cur) (i64.const 10)))
+                    (array.set $mag (local.get $magc) (local.get $li) (local.get $q))
+                    (br $d)))
+                  ;; emit digit = rem
+                  (array.set $string (local.get $digbuf) (local.get $dcount)
+                    (i32.add (i32.const 48) (i32.wrap_i64 (local.get $rem))))
+                  (local.set $dcount (i32.add (local.get $dcount) (i32.const 1)))
+                  ;; loop while magnitude is non-zero
+                  (local.set $allzero (i32.const 1))
+                  (local.set $li (i32.const 0))
+                  (block $zd (loop $z
+                    (br_if $zd (i32.ge_u (local.get $li) (local.get $len)))
+                    (if (i64.ne (array.get $mag (local.get $magc) (local.get $li)) (i64.const 0))
+                      (then (local.set $allzero (i32.const 0)) (br $zd)))
+                    (local.set $li (i32.add (local.get $li) (i32.const 1)))
+                    (br $z)))
+                  ;; exit when the magnitude has become all-zero; else loop.
+                  (br_if $dvd (local.get $allzero))
+                  (br $dv)))
+                ;; build output: [neg '-'] then digits reversed
+                (local.set $total (i32.add (local.get $dcount) (local.get $neg)))
+                (local.set $arr (array.new_default $string (local.get $total)))
+                (if (local.get $neg) (then (array.set $string (local.get $arr) (i32.const 0) (i32.const 45))))
+                (local.set $i (i32.const 0))
+                (block $od (loop $o
+                  (br_if $od (i32.ge_u (local.get $i) (local.get $dcount)))
+                  (array.set $string (local.get $arr)
+                    (i32.add (local.get $neg) (local.get $i))
+                    (array.get_u $string (local.get $digbuf) (i32.sub (i32.sub (local.get $dcount) (i32.const 1)) (local.get $i))))
+                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                  (br $o)))
+                (local.get $arr)))))
+    

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -191,6 +191,24 @@ pub(super) fn emit_module_with(
             &symbol_table,
         );
     }
+    // bignum slice 1 — when the opt-in `$AverInt` representation is
+    // active, register the full arithmetic prelude. Registration is
+    // unconditional (not per-op-discovered) because the literal /
+    // BinOp / Neg re-point sites all assume these fn indices exist;
+    // `wasm-opt -Oz` strips any helper a given program never reaches.
+    if registry.bignum {
+        for b in [
+            BuiltinName::AintFromI64,
+            BuiltinName::AintAdd,
+            BuiltinName::AintSub,
+            BuiltinName::AintMul,
+            BuiltinName::AintNeg,
+            BuiltinName::AintCmp,
+            BuiltinName::AintEq,
+        ] {
+            builtin_registry.register(b);
+        }
+    }
     // Sweep nominal element types of every registered List / Vector
     // and key types of every registered Map. The list/vec helper
     // bodies dispatch nominal element eq/hash via `Call(__eq_<X>)`
@@ -4319,6 +4337,51 @@ fn emit_user_types(
                 element_type: wasm_encoder::StorageType::I8,
                 mutable: true,
             }),
+        ));
+    }
+
+    // bignum slice 1 — `$AverInt` carrier + its `(array i64)` limb
+    // magnitude. Emitted only when the registry allocated them (opt-in
+    // flag + reachable Int arithmetic). The magnitude array slot sits
+    // one below the struct slot so the struct's `$mag` field references
+    // an already-defined idx (a single rec group makes forward refs
+    // legal too, but this keeps the layout obvious).
+    if let (Some(mag_idx), Some(struct_idx)) =
+        (registry.aint_mag_array_idx, registry.aint_struct_idx)
+    {
+        use wasm_encoder::{HeapType, RefType, StorageType, ValType};
+        // (array (mut i64)) — little-endian unsigned u64 limbs.
+        entries.push((
+            mag_idx,
+            mk_array(wasm_encoder::FieldType {
+                element_type: StorageType::Val(ValType::I64),
+                mutable: true,
+            }),
+        ));
+        // (struct (field $small i64)
+        //         (field $mag (ref null (array i64)))
+        //         (field $sign i32))
+        // Mutable fields so a helper can renormalize in place when it
+        // demotes a Big to Small without a fresh allocation.
+        entries.push((
+            struct_idx,
+            mk_struct(vec![
+                wasm_encoder::FieldType {
+                    element_type: StorageType::Val(ValType::I64),
+                    mutable: true,
+                },
+                wasm_encoder::FieldType {
+                    element_type: StorageType::Val(ValType::Ref(RefType {
+                        nullable: true,
+                        heap_type: HeapType::Concrete(mag_idx),
+                    })),
+                    mutable: true,
+                },
+                wasm_encoder::FieldType {
+                    element_type: StorageType::Val(ValType::I32),
+                    mutable: true,
+                },
+            ]),
         ));
     }
 

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -138,6 +138,26 @@ pub(super) struct TypeRegistry {
     /// declared. The runtime allocates the array lazily on first
     /// `Tcp.connect` call via `array.new_default` against this idx.
     pub(super) tcp_pool_type_idx: Option<u32>,
+    /// bignum slice 1 — opt-in arbitrary-precision `Int`. `true` when
+    /// the `AVER_WASMGC_BIGNUM` env flag is set AND any Int arithmetic
+    /// is reachable (so pure-String/Float/effect-only programs carry
+    /// zero bignum bytes). When set, `Int` lowers to `(ref null
+    /// $AverInt)` everywhere instead of the scalar `i64`, and `*` / `+`
+    /// / `-` / neg / cmp / eq route through the limb-arithmetic WAT
+    /// helpers rather than the wrapping `i64.*` opcodes.
+    pub(super) bignum: bool,
+    /// bignum slice 1 — wasm type idx for the `$AverInt` struct
+    /// `(struct (field $small i64) (field $mag (ref null (array i64)))
+    /// (field $sign i32))`. `Some` iff `bignum` is set. `$mag == null`
+    /// → Small (value in `$small`, the i64 fast path); non-null `$mag`
+    /// → Big (little-endian unsigned u64 limb magnitude + `$sign ∈
+    /// {-1,0,+1}`). Mirrors `aver-rt/src/int.rs` `AverInt`.
+    pub(super) aint_struct_idx: Option<u32>,
+    /// bignum slice 1 — wasm type idx for the `(array (mut i64))` limb
+    /// magnitude array referenced by `$AverInt.$mag`. `Some` iff
+    /// `bignum` is set; sits one slot below `aint_struct_idx` so the
+    /// struct can reference it without a forward edge.
+    pub(super) aint_mag_array_idx: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -304,6 +324,26 @@ impl TypeRegistry {
             let pool_idx = next_idx;
             next_idx += 1;
             (Some(slot_idx), Some(pool_idx))
+        } else {
+            (None, None)
+        };
+
+        // bignum slice 1 — `$AverInt` + `(array i64)` magnitude slots.
+        // Gated on the opt-in `AVER_WASMGC_BIGNUM` env flag AND "any Int
+        // arithmetic is reachable" so pure-String/Float/effect-only
+        // programs (and the 245B hello-worker) carry ZERO bignum bytes.
+        // The magnitude array slot is allocated first so the struct can
+        // reference it without a forward edge (a single rec group makes
+        // this safe, but keeping the array lower mirrors the other
+        // collection slots and reads cleaner).
+        let bignum_flag = std::env::var_os("AVER_WASMGC_BIGNUM").is_some();
+        let bignum = bignum_flag && resolved_fn_defs.iter().any(fn_uses_int_arithmetic);
+        let (aint_mag_array_idx, aint_struct_idx) = if bignum {
+            let mag_idx = next_idx;
+            next_idx += 1;
+            let struct_idx = next_idx;
+            next_idx += 1;
+            (Some(mag_idx), Some(struct_idx))
         } else {
             (None, None)
         };
@@ -915,6 +955,9 @@ impl TypeRegistry {
             non_newtypable_keys,
             tcp_slot_type_idx,
             tcp_pool_type_idx,
+            bignum,
+            aint_struct_idx,
+            aint_mag_array_idx,
         }
     }
 
@@ -1400,6 +1443,66 @@ fn fn_body_calls_int_div(fd: &crate::ir::hir::ResolvedFnDef) -> bool {
     fn_body_calls_builtin(fd, "Int.div")
 }
 
+/// bignum slice 1 — "any Int arithmetic reachable" gate. True iff the
+/// fn signature mentions `Int` (param or return) OR the body contains
+/// an arithmetic `BinOp` / `Neg` / Int literal. Used to keep the
+/// `$AverInt` slots out of pure-String/Float/effect-only programs even
+/// when the `AVER_WASMGC_BIGNUM` flag is set. Deliberately broad (an
+/// Int param is enough): the cost of a false positive is two unused
+/// type slots that `wasm-opt -Oz` would strip anyway; a false negative
+/// would be a miscompile, so we err toward inclusion.
+fn fn_uses_int_arithmetic(fd: &crate::ir::hir::ResolvedFnDef) -> bool {
+    use crate::ir::hir::{ResolvedExpr, ResolvedFnBody, ResolvedStmt};
+    if fd
+        .return_type
+        .display()
+        .split(|c: char| !c.is_alphanumeric())
+        .any(|t| t == "Int")
+    {
+        return true;
+    }
+    if fd.params.iter().any(|(_, t)| {
+        t.display()
+            .split(|c: char| !c.is_alphanumeric())
+            .any(|tok| tok == "Int")
+    }) {
+        return true;
+    }
+    fn walk(e: &ResolvedExpr) -> bool {
+        use crate::ast::Literal;
+        match e {
+            ResolvedExpr::Literal(Literal::Int(_)) => true,
+            ResolvedExpr::Neg(_) => true,
+            ResolvedExpr::BinOp(op, l, r) => {
+                use crate::ast::BinOp;
+                matches!(op, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div)
+                    || walk(&l.node)
+                    || walk(&r.node)
+            }
+            ResolvedExpr::Call(_, args) | ResolvedExpr::Ctor(_, args) => {
+                args.iter().any(|a| walk(&a.node))
+            }
+            ResolvedExpr::Match { subject, arms } => {
+                walk(&subject.node) || arms.iter().any(|a| walk(&a.body.node))
+            }
+            ResolvedExpr::TailCall { args, .. } => args.iter().any(|a| walk(&a.node)),
+            ResolvedExpr::Attr(o, _) | ResolvedExpr::ErrorProp(o) => walk(&o.node),
+            ResolvedExpr::List(xs)
+            | ResolvedExpr::Tuple(xs)
+            | ResolvedExpr::IndependentProduct(xs, _) => xs.iter().any(|x| walk(&x.node)),
+            ResolvedExpr::RecordCreate { fields, .. } => fields.iter().any(|(_, e)| walk(&e.node)),
+            ResolvedExpr::RecordUpdate { base, updates, .. } => {
+                walk(&base.node) || updates.iter().any(|(_, e)| walk(&e.node))
+            }
+            _ => false,
+        }
+    }
+    let ResolvedFnBody::Block(stmts) = fd.body.as_ref();
+    stmts.iter().any(|stmt| match stmt {
+        ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => walk(&e.node),
+    })
+}
+
 fn collect_string_literals_in_fn(
     fd: &crate::ir::hir::ResolvedFnDef,
     out: &mut Vec<Vec<u8>>,
@@ -1512,6 +1615,16 @@ pub(super) fn aver_to_wasm(
     registry: Option<&TypeRegistry>,
 ) -> Result<Option<ValType>, WasmGcError> {
     let trimmed = type_str.trim();
+    // bignum slice 1 — under the opt-in flag, `Int` is the `$AverInt`
+    // struct ref everywhere (signatures, locals, etc.), NOT the scalar
+    // `i64`. Intercept before `primitive_to_wasm` so the ref shape wins.
+    // Float / Bool keep their scalar lowering.
+    if trimmed == "Int"
+        && let Some(reg) = registry
+        && reg.bignum
+    {
+        return Ok(Some(aint_ref_ty(reg)?));
+    }
     if let Some(v) = primitive_to_wasm(trimmed) {
         return Ok(Some(v));
     }
@@ -1743,6 +1856,17 @@ pub(super) fn struct_ref(type_idx: u32) -> ValType {
         nullable: true,
         heap_type: HeapType::Concrete(type_idx),
     })
+}
+
+/// bignum slice 1 — `(ref null $AverInt)` ValType for the carrier
+/// struct. Errors if the registry has no `$AverInt` slot (i.e. bignum
+/// is off but a site asked for it), which is a wiring bug, not a user
+/// error.
+pub(super) fn aint_ref_ty(registry: &TypeRegistry) -> Result<ValType, WasmGcError> {
+    let idx = registry.aint_struct_idx.ok_or(WasmGcError::Validation(
+        "Int reachable under bignum but no $AverInt type slot was allocated".into(),
+    ))?;
+    Ok(struct_ref(idx))
 }
 
 /// Result-list shape for a wasm function signature derived from an

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -1494,7 +1494,22 @@ fn fn_uses_int_arithmetic(fd: &crate::ir::hir::ResolvedFnDef) -> bool {
             ResolvedExpr::RecordUpdate { base, updates, .. } => {
                 walk(&base.node) || updates.iter().any(|(_, e)| walk(&e.node))
             }
-            _ => false,
+            // Arithmetic hidden inside a `{...}` interpolation or a Map
+            // literal must still flip the gate — string interpolation is the
+            // idiomatic way to render an Int, and a missed arm lowers the
+            // WHOLE module's Int as wrapping i64 (a silent miscompile, not an
+            // error). The remaining arms are genuine leaves; enumerated
+            // explicitly (no `_` wildcard) so a future `ResolvedExpr` variant
+            // fails the build rather than silently defaulting the gate off.
+            ResolvedExpr::InterpolatedStr(parts) => parts.iter().any(|p| {
+                matches!(p, crate::ir::hir::ResolvedStrPart::Parsed(inner) if walk(&inner.node))
+            }),
+            ResolvedExpr::MapLiteral(pairs) => {
+                pairs.iter().any(|(k, v)| walk(&k.node) || walk(&v.node))
+            }
+            ResolvedExpr::Literal(_)
+            | ResolvedExpr::Ident(_)
+            | ResolvedExpr::Resolved { .. } => false,
         }
     }
     let ResolvedFnBody::Block(stmts) = fd.body.as_ref();

--- a/src/codegen/wasm_gc/wat_helper.rs
+++ b/src/codegen/wasm_gc/wat_helper.rs
@@ -65,8 +65,12 @@ pub(in crate::codegen::wasm_gc) fn padding_types(n: u32) -> String {
 pub(in crate::codegen::wasm_gc) fn compile_wat_helper(
     wat_source: &str,
 ) -> Result<Function, WasmGcError> {
-    let module_bytes = wat::parse_str(wat_source)
-        .map_err(|e| WasmGcError::Validation(format!("wat parse: {e}")))?;
+    let module_bytes = wat::parse_str(wat_source).map_err(|e| {
+        if std::env::var_os("AVER_WASMGC_DUMP_WAT").is_some() {
+            eprintln!("--- WAT parse failed ---\n{wat_source}\n--- end WAT ---");
+        }
+        WasmGcError::Validation(format!("wat parse: {e}"))
+    })?;
 
     let mut found_locals: Option<Vec<ValType>> = None;
     let mut found_body: Option<Vec<u8>> = None;

--- a/tests/cross_backend_proptest.rs
+++ b/tests/cross_backend_proptest.rs
@@ -384,6 +384,74 @@ fn wrap_program(expr: &str) -> String {
     )
 }
 
+// ─── Equality-class regression (canonical-invariant) ────────────────────────
+//
+// The differential proptest above compares RENDERED output
+// (`String.fromInt` / interpolation), so it structurally CANNOT catch a
+// canonical-invariant violation: a value stored as Big when it should be
+// Small (or vice-versa) renders to the same decimal string, yet
+// `__aint_eq` — which short-circuits "a Small and a Big are never equal"
+// — would report two equal values UNEQUAL. The only observable that
+// distinguishes them is `==`. This focused test runs programs whose
+// correctness shows ONLY through `==`, flag-on (`AVER_WASMGC_BIGNUM=1`)
+// wasm-gc, and asserts the Bool output matches the VM (`Int = ℤ`).
+//
+// Coverage:
+//   1. both sides reach i64::MIN by DIFFERENT routes (neg-demote vs
+//      sub-demote) — the neg→Small(i64::MIN) demotion just fixed;
+//   2. double negation round-trips +2^63 (Big) → i64::MIN (Small) → +2^63;
+//   3. a Big that cancels back into i64-range must demote to Small so it
+//      compares equal to the natively-Small literal.
+
+/// Render a Bool via `String.fromBool` (Console.print needs a String) so
+/// the program's only observable is the `==` result.
+fn eq_program(expr: &str) -> String {
+    wrap_program(&format!("String.fromBool({})", expr))
+}
+
+#[test]
+fn cross_int_equality_canonical_invariant_vm_vs_wasm_gc() {
+    // (expr, expected) — expected is the ℤ truth the VM computes.
+    let cases: &[(&str, &str)] = &[
+        // i64::MIN reached two ways: neg of +2^63 vs (0 - i64::MAX) - 1.
+        (
+            "((-(9223372036854775807 + 1)) == ((0 - 9223372036854775807) - 1))",
+            "true",
+        ),
+        // double-neg: +2^63 (Big) → i64::MIN (Small) → +2^63 (Big).
+        (
+            "((-(-(9223372036854775807 + 1))) == (9223372036854775807 + 1))",
+            "true",
+        ),
+        // Big cancelling back into i64 range must demote to Small.
+        (
+            "(((9223372036854775807 * 2) - 9223372036854775807) == 9223372036854775807)",
+            "true",
+        ),
+        // Negative control: a genuine Big is NOT equal to a Small.
+        (
+            "((9223372036854775807 + 1) == 9223372036854775807)",
+            "false",
+        ),
+    ];
+
+    for (expr, expected) in cases {
+        let source = eq_program(expr);
+        let vm = run_vm("cross-eq-vm", &source).expect("VM must accept equality program");
+        let wg = run_wasm_gc_bignum("cross-eq-wg", &source)
+            .expect("wasm-gc (bignum) must accept equality program");
+        assert_eq!(
+            vm, *expected,
+            "VM disagreed with the expected ℤ truth on `{expr}`",
+        );
+        assert_eq!(
+            wg, vm,
+            "wasm-gc (bignum) diverged from VM on canonical-invariant case `{expr}`:\n\
+             VM = {vm}, wasm-gc = {wg}",
+        );
+    }
+}
+
 // ─── Properties ────────────────────────────────────────────────────────────
 
 proptest! {

--- a/tests/cross_backend_proptest.rs
+++ b/tests/cross_backend_proptest.rs
@@ -101,6 +101,34 @@ fn run_wasm_gc(prefix: &str, source: &str) -> Result<String, String> {
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
+/// Like `run_wasm_gc`, but with the opt-in `AVER_WASMGC_BIGNUM=1` flag
+/// set so `Int` lowers to the arbitrary-precision `$AverInt` carrier
+/// (bignum slice 1). This is the differential oracle for add/sub/mul/
+/// neg/cmp/eq: with the flag on, wasm-gc must agree with the VM
+/// (Int = ℤ) on EVERY input, including the i64-overflow ones the
+/// generator produces.
+fn run_wasm_gc_bignum(prefix: &str, source: &str) -> Result<String, String> {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let path = temp_module(prefix, source);
+    let out = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .env("AVER_WASMGC_BIGNUM", "1")
+        .arg("run")
+        .arg(&path)
+        .arg("--wasm-gc")
+        .output()
+        .expect("expected `aver run --wasm-gc` (bignum) to execute");
+    cleanup(&path);
+    if !out.status.success() {
+        return Err(format!(
+            "wasm-gc (bignum) run failed:\n{}",
+            format_output(&out)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
 /// Compile `source` to a Rust project via `aver compile --target rust`,
 /// `cargo build` it (a REAL build — the AverInt arithmetic + clone cascade
 /// must type-check + borrow-check), then run the binary and return trimmed
@@ -215,6 +243,44 @@ fn int_expr(max_depth: u32) -> BoxedStrategy<String> {
             (bool_expr(1), inner.clone(), inner.clone()).prop_map(|(c, t, f)| {
                 format!("(match {}\n    true -> {}\n    false -> {})", c, t, f)
             }),
+        ]
+    })
+    .boxed()
+}
+
+/// Depth-bounded Int expression whose LEAVES deliberately include the
+/// i64 boundary values (`i64::MIN`, `i64::MAX`, `0`, `±1`, and
+/// large-near-overflow magnitudes), so the bignum differential oracle
+/// exercises the overflow → Big promotion, the `MIN`/`-1` mul trap edge,
+/// the `-i64::MIN` neg promotion, and the canonical demote-on-cancel
+/// paths — not just random mid-range arithmetic. Mirrors `int_expr`'s
+/// recursion otherwise.
+fn int_boundary_expr(max_depth: u32) -> BoxedStrategy<String> {
+    // Note literals at/over i64::MIN can't be written directly (the
+    // lexer rejects `9223372036854775808`), so `i64::MIN` is built as
+    // `(0 - 9223372036854775807 - 1)`. Negative leaves are parenthesised.
+    let leaf = prop_oneof![
+        (-1_000_000i64..=1_000_000i64).prop_map(|n| if n < 0 {
+            format!("({})", n)
+        } else {
+            n.to_string()
+        }),
+        Just("9223372036854775807".to_string()), // i64::MAX
+        Just("(0 - 9223372036854775807 - 1)".to_string()), // i64::MIN
+        Just("0".to_string()),
+        Just("1".to_string()),
+        Just("(-1)".to_string()),
+        Just("3037000500".to_string()), // ~sqrt(i64::MAX), squares overflow
+        Just("(-3037000500)".to_string()),
+        Just("4611686018427387904".to_string()), // 2^62
+        Just("(-4611686018427387904)".to_string()),
+    ];
+    leaf.prop_recursive(max_depth, 24, 4, |inner| {
+        prop_oneof![
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("({} + {})", a, b)),
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("({} - {})", a, b)),
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("({} * {})", a, b)),
+            inner.clone().prop_map(|a| format!("(-{})", a)),
         ]
     })
     .boxed()
@@ -338,17 +404,22 @@ proptest! {
     /// (associativity, ordering of side effects inside a chain of
     /// BinOps, …).
     ///
-    /// IGNORED while the Int = ℤ migration is VM-only: the VM now uses
-    /// arbitrary-precision integers (no wrapping), while wasm-gc (and the
-    /// Rust codegen) still wrap on i64 overflow. On the overflow inputs this
-    /// generator produces, the backends therefore diverge by design. Re-enable
-    /// once wasm-gc carries the same bignum `Int` semantics.
+    /// bignum slice 1 — RE-ENABLED. wasm-gc now carries the same
+    /// arbitrary-precision `Int = ℤ` semantics as the VM under the opt-in
+    /// `AVER_WASMGC_BIGNUM` flag (`$AverInt` carrier; add/sub/mul/neg/cmp/
+    /// eq as limb helpers). The differential oracle therefore holds on
+    /// every input — INCLUDING the i64-overflow ones this generator
+    /// produces — which is the whole point: where the wrapping backend
+    /// returned a wrapped-negative i64 (`a*a` at i64::MAX printed `1`),
+    /// the bignum backend now prints the exact ℤ value the VM prints.
+    /// The leaves include i64::MIN/MAX, 0, ±1, and large-near-overflow
+    /// magnitudes so the Big-promotion + mul-trap-edge + neg-promotion
+    /// + canonical-demote paths are all hit.
     #[test]
-    #[ignore = "Int=Z migration is VM-only; wasm-gc still wraps on overflow (intentional WIP divergence)"]
-    fn cross_int_arithmetic_vm_vs_wasm_gc(expr in int_expr(3)) {
+    fn cross_int_arithmetic_vm_vs_wasm_gc(expr in int_boundary_expr(3)) {
         let source = wrap_program(&format!("String.fromInt({})", expr));
         let vm = run_vm("cross-bp-int-vm", &source);
-        let wg = run_wasm_gc("cross-bp-int-wg", &source);
+        let wg = run_wasm_gc_bignum("cross-bp-int-wg", &source);
         match (&vm, &wg) {
             // Both backends accept the program — outputs must match.
             (Ok(v), Ok(w)) => prop_assert_eq!(

--- a/tests/cross_backend_proptest.rs
+++ b/tests/cross_backend_proptest.rs
@@ -446,6 +446,40 @@ proptest! {
         }
     }
 
+    /// THE SAME Int-arithmetic differential, but the value is rendered
+    /// through `"{...}"` string interpolation instead of
+    /// `String.fromInt(...)`. Interpolation is the idiomatic way to print
+    /// an Int, and it is a DISTINCT reachability path: the bignum gate
+    /// (`fn_uses_int_arithmetic`) must descend into interpolation parts, or
+    /// a program whose ONLY arithmetic lives inside a `{...}` lowers the
+    /// whole module's Int as wrapping i64 — a silent miscompile the
+    /// `String.fromInt` variant above structurally cannot catch (that call
+    /// keeps the gate on). Regression for that gate hole.
+    #[test]
+    fn cross_int_arithmetic_via_interpolation_vm_vs_wasm_gc(expr in int_boundary_expr(3)) {
+        let source = wrap_program(&format!("\"{{{}}}\"", expr));
+        let vm = run_vm("cross-bp-interp-vm", &source);
+        let wg = run_wasm_gc_bignum("cross-bp-interp-wg", &source);
+        match (&vm, &wg) {
+            (Ok(v), Ok(w)) => prop_assert_eq!(
+                v, w,
+                "VM vs wasm-gc diverged (interpolation render) on source:\n{}\nVM:\n{}\nwasm-gc:\n{}",
+                source, v, w
+            ),
+            (Err(_), Err(_)) => {}
+            (Ok(v), Err(e)) => prop_assert!(
+                false,
+                "VM accepted but wasm-gc rejected (interpolation) on source:\n{}\nVM stdout:\n{}\nwasm-gc error:\n{}",
+                source, v, e
+            ),
+            (Err(e), Ok(w)) => prop_assert!(
+                false,
+                "wasm-gc accepted but VM rejected (interpolation) on source:\n{}\nVM error:\n{}\nwasm-gc stdout:\n{}",
+                source, e, w
+            ),
+        }
+    }
+
     /// String concatenation + `String.fromInt` / `fromFloat` /
     /// `fromBool` projections must round-trip identically across
     /// backends. Covers the lowering of `+` over `AverStr` against


### PR DESCRIPTION
First slice of making the wasm-gc backend faithful to `Int = ℤ` (the VM and the Rust backend already are). wasm-gc emits WebAssembly GC directly and does not link `aver-rt`, so the small-int-optimized bignum is implemented in the emitter, matching `aver_rt::AverInt` and the VM exactly.

**Entirely behind the opt-in `AVER_WASMGC_BIGNUM` flag — the default path is byte-for-byte unchanged** (verified: a pure-String program compiles to a byte-identical module flag-on vs flag-off; zero bignum bytes, so the tiny-wasm/edge story survives). Nothing ships to users until the default flip (a later slice).

## Scope (slice 1)
Representation + `add`/`sub`/`mul`/`neg`/`cmp`/`eq`. A nullable struct ref `(ref null $AverInt)` = `(struct $small:i64, $mag:(array i64)?, $sign:i32)`: null `$mag` → Small (the i64 fast path), non-null → Big (little-endian limb magnitude + sign). Canonical invariant enforced everywhere (any i64-fitting value is always Small, so Eq/Ord can rely on it). Each arithmetic op is a self-contained WAT helper (limb routines inlined to avoid the `compile_wat_helper`-keeps-first-fn constraint). Overflow detection without a hardware flag: ADD/SUB via sign-bit tests, MUL via a round-trip-divide oracle (guarded at `a==0`, `a==-1 && b==i64::MIN`), NEG at `i64::MIN`.

Deferred to later slices (a flagged program using these falls back or errors cleanly — never a silent miscompile): Euclidean `Int.div`/`mod` (slice 2), decimal literal parsing of values > i64 and `Int`/`Float` exactness (slice 3), the default flip (slice 4).

## Verification (two-phase — cargo-green is necessary but not sufficient)
- **Phase 2 (wasmtime, the real gate):** `a * a` at `a = i64::MAX` prints the exact `85070591730234615847396907784232501249` under `aver run --wasm-gc` (flag on), matching the VM — the wrapping backend printed `1`.
- The previously-`#[ignore]`d `cross_int_arithmetic_vm_vs_wasm_gc` differential proptest is re-enabled with a boundary-heavy generator (i64::MIN/MAX, 0, ±1, near-overflow) and green at 500 cases.
- Boundary cases checked directly vs the VM: `MIN*MIN`, `±1 * MIN` (the `div_s` trap edge), `-i64::MIN` promotion, cross-sign mul, demote-on-cancel (`MAX*2 - MAX == MAX`).
- `cargo test wasm_gc_spec` 37/37, `cross_backend_proptest` 5/5; `cargo fmt --check` and `cargo clippy --features wasm,wasip2 -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)