### PR TITLE
Lean auto-proofs: _root_-qualify entry-module fn names so user fns can shadow the Lean stdlib

### DIFF
--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -31,8 +31,35 @@ pub(super) fn law_simp_defs(
 ) -> BTreeSet<String> {
     law_simp_source_names(ctx, vb, law)
         .into_iter()
-        .map(|name| aver_name_to_lean(&name))
+        .map(|name| {
+            let rendered = aver_name_to_lean(&name);
+            // Entry-module fns are emitted at the Lean root, so a user fn whose
+            // name shadows a stdlib symbol (e.g. `insert` vs the `Insert.insert`
+            // class method) makes a bare `simp only [insert]` error ("proposition
+            // expected") — the equation compiler can't pick the user def.
+            // `_root_.insert` always resolves to it and is a no-op otherwise.
+            // Dep-module fns are NOT at root: they live under their module
+            // namespace (`Lib.qrev`) and reach the consumer via `open Lib`, so a
+            // `_root_.` prefix would FAIL to resolve. Leave those bare — `open`
+            // resolves them exactly as before this change.
+            if is_dep_module_fn(ctx, &name) {
+                rendered
+            } else {
+                format!("_root_.{rendered}")
+            }
+        })
         .collect()
+}
+
+/// A simp-set name belongs to a dependency module iff its `FnDef` lives in
+/// one of `ctx.modules` (which holds dep modules only — entry-module fns sit
+/// in `ctx.fn_defs`). Mirrors `find_fn_def`'s dep-first resolution: on a
+/// bare-name collision between an entry and a dep fn, the dep classification
+/// wins, matching which def the bare reference actually resolves to.
+fn is_dep_module_fn(ctx: &CodegenContext, source_name: &str) -> bool {
+    ctx.modules
+        .iter()
+        .any(|m| m.fn_defs.iter().any(|fd| fd.name == source_name))
 }
 
 pub(super) fn law_simp_source_names(

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -1353,11 +1353,11 @@ verify mirror law involutive
     assert!(lean.contains("  induction t with"));
     assert!(
         lean.contains(
-            "  | leaf f0 => first | (simp [mirror]; done) | (simp [mirror]; omega) | sorry"
+            "  | leaf f0 => first | (simp [_root_.mirror]; done) | (simp [_root_.mirror]; omega) | sorry"
         )
     );
     assert!(lean.contains(
-            "  | node f0 f1 ih0 ih1 => first | (simp_all [mirror]; done) | (simp_all [mirror]; omega) | sorry"
+            "  | node f0 f1 ih0 ih1 => first | (simp_all [_root_.mirror]; done) | (simp_all [_root_.mirror]; omega) | sorry"
         ));
     assert!(!lean.contains(
             "-- universal theorem mirror_law_involutive omitted: sampled law shape is not auto-proved yet"


### PR DESCRIPTION
Fixes a user function whose name shadows a Lean stdlib symbol (e.g. a user `insert` vs the `Insert.insert` class method): a bare `simp only [insert]` in an auto-proof errored with "proposition expected" — the equation compiler could not pick the user def — so the law stayed unproven.

## Fix

In `law_simp_defs`, qualify each simp-set entry by where its definition lives:

- **Entry-module fns** are emitted at the Lean root → prefix with `_root_.`, which always resolves to the user def and is a no-op for non-clashing names.
- **Dependency-module fns** are NOT at root — they live under their module namespace (`Lib.qrev`) and reach a consumer via `open Lib`, so a `_root_.` prefix would fail to resolve. Those are left bare (resolved by `open`, byte-identical to before).

The classification mirrors `find_fn_def`'s dep-first resolution, so a bare-name collision between an entry and a dep fn is treated the same way the bare reference itself resolves.

## Result

Newly kernel-universal: `tip/prod/lemma_18` — `length (insert x y) = S (length y)`.

A blanket `_root_.` (prefixing dep fns too) was tried first and **broke cross-module proofs** — `_root_.Lib.qrev` does not resolve under `open Lib`. This module-aware version leaves dep references untouched. Verified locally with the **full** `proof_spec` suite (176 tests, incl. the cross-file dep-law tests) plus the lib suite (882) — both green; `cargo fmt --check` and `cargo clippy --features wasm,wasip2` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)