### PR TITLE
wasm-gc: Euclidean Int.div/mod + abs/min/max on bignum, behind the opt-in flag (slice 2)

### DIFF
--- a/src/codegen/wasm_gc/body/emit.rs
+++ b/src/codegen/wasm_gc/body/emit.rs
@@ -23,6 +23,26 @@ pub(super) fn emit_default_value(
     registry: &TypeRegistry,
 ) -> Result<(), WasmGcError> {
     match aver_ty.trim() {
+        // bignum slice 1/2 — under the opt-in flag, the default `Int` is
+        // the canonical `$AverInt` Small(0) struct ref, not the scalar
+        // `i64` zero. Used as the ok-field placeholder of `Result.Err`
+        // carriers (e.g. `Int.div`/`Int.mod`'s `Result<Int,String>`),
+        // where the field type is now `(ref null $aint)`.
+        "Int" if registry.bignum => {
+            let aint_idx = registry.aint_struct_idx.ok_or(WasmGcError::Validation(
+                "bignum default Int needs the $AverInt struct slot, but it wasn't allocated".into(),
+            ))?;
+            let mag_idx = registry.aint_mag_array_idx.ok_or(WasmGcError::Validation(
+                "bignum default Int needs the $mag array slot, but it wasn't allocated".into(),
+            ))?;
+            func.instruction(&Instruction::I64Const(0));
+            func.instruction(&Instruction::RefNull(wasm_encoder::HeapType::Concrete(
+                mag_idx,
+            )));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::StructNew(aint_idx));
+            Ok(())
+        }
         "Int" => {
             func.instruction(&Instruction::I64Const(0));
             Ok(())

--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -22,6 +22,32 @@ pub(crate) enum MirBuiltinEmit {
     Produced(bool),
 }
 
+/// bignum slice 2 — look up a registered `__aint_*` helper fn idx,
+/// erroring (not silently miscompiling) when the prelude wasn't
+/// registered. Registration is unconditional under the flag
+/// (`module.rs`), so a miss is a real wiring bug.
+fn aint_helper(ctx: &EmitCtx<'_>, name: &str) -> Result<u32, WasmGcError> {
+    ctx.fn_map
+        .builtins
+        .get(name)
+        .copied()
+        .ok_or(WasmGcError::Validation(format!(
+            "bignum active but {name} helper not registered"
+        )))
+}
+
+/// bignum slice 2 — the `(ref null $AverInt)` block-type for `if`/`else`
+/// arms that yield an `Int` under the flag (e.g. the `Int.min`/`max`
+/// select).
+fn aint_block_ty(ctx: &EmitCtx<'_>) -> Result<wasm_encoder::BlockType, WasmGcError> {
+    let idx = ctx.registry.aint_struct_idx.ok_or(WasmGcError::Validation(
+        "bignum active but no $AverInt struct slot was allocated".into(),
+    ))?;
+    Ok(wasm_encoder::BlockType::Result(
+        crate::codegen::wasm_gc::types::struct_ref(idx),
+    ))
+}
+
 /// `--target wasip2` effect lowering — the MIR analogue of the
 /// `ctx.wasip2_lowering.is_some()` block in `emit_dotted_builtin`
 /// (builtins.rs). On wasip2 every Console / Args / Env / Time / Random
@@ -168,6 +194,47 @@ pub(crate) fn emit_mir_native_scalar_builtin(
         }
         "Float.pi" if args.is_empty() => {
             func.instruction(&Instruction::F64Const(std::f64::consts::PI.into()));
+        }
+        // bignum slice 2 — `Int.abs` / `Int.min` / `Int.max` over
+        // `$AverInt` refs route through the limb helpers (`__aint_abs`,
+        // `__aint_cmp`) so they're correct across the Small/Big boundary
+        // and both signs (incl. `|i64::MIN| = +2^63`). The i64-scalar arms
+        // below stay for the default (flag-off) path.
+        "Int.abs" if args.len() == 1 && ctx.registry.bignum => {
+            let abs_idx = aint_helper(ctx, "__aint_abs")?;
+            arg!(0);
+            func.instruction(&Instruction::Call(abs_idx));
+        }
+        "Int.min" if args.len() == 2 && ctx.registry.bignum => {
+            // a if cmp(a, b) <= 0 else b  (mirrors `AverInt::min_ref`); both
+            // args are pure builtin args, re-emitted per branch.
+            let cmp_idx = aint_helper(ctx, "__aint_cmp")?;
+            let aint_block = aint_block_ty(ctx)?;
+            arg!(0);
+            arg!(1);
+            func.instruction(&Instruction::Call(cmp_idx));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::I32LeS);
+            func.instruction(&Instruction::If(aint_block));
+            arg!(0);
+            func.instruction(&Instruction::Else);
+            arg!(1);
+            func.instruction(&Instruction::End);
+        }
+        "Int.max" if args.len() == 2 && ctx.registry.bignum => {
+            // a if cmp(a, b) >= 0 else b  (mirrors `AverInt::max_ref`).
+            let cmp_idx = aint_helper(ctx, "__aint_cmp")?;
+            let aint_block = aint_block_ty(ctx)?;
+            arg!(0);
+            arg!(1);
+            func.instruction(&Instruction::Call(cmp_idx));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::I32GeS);
+            func.instruction(&Instruction::If(aint_block));
+            arg!(0);
+            func.instruction(&Instruction::Else);
+            arg!(1);
+            func.instruction(&Instruction::End);
         }
         "Int.abs" if args.len() == 1 => {
             arg!(0);
@@ -604,6 +671,16 @@ pub(crate) fn emit_mir_int_div_mod_boxed(
             .ok_or(WasmGcError::Validation(
                 "boxed Int.div/mod requires the `Result<Int,String>` slot to be registered".into(),
             ))?;
+    // bignum slice 2 — under the opt-in `$AverInt` representation, `a`/`b`
+    // are struct refs (not i64). Route through the single Euclidean
+    // `__aint_divmod` helper (a `want_mod` flag selects div vs mod), test
+    // `b == 0` on the struct, and DROP the `i64::MIN / -1` overflow guard:
+    // over ℤ that quotient is `+2^63`, a valid `Result.Ok` (a Big), not an
+    // error — matching the VM (`src/types/int.rs`) and `aver-rt`.
+    if ctx.registry.bignum {
+        return emit_mir_aint_div_mod_boxed(func, is_div, a, b, slots, ctx, res_idx);
+    }
+
     let helper_name = if is_div {
         "__int_div_euclid"
     } else {
@@ -674,6 +751,92 @@ pub(crate) fn emit_mir_int_div_mod_boxed(
     Ok(MirBuiltinEmit::Produced(true))
 }
 
+/// bignum slice 2 — the `$AverInt` analogue of `emit_mir_int_div_mod_boxed`.
+/// `a`/`b` are `(ref null $aint)` struct refs; the carrier
+/// `Result<Int,String>`'s ok field (field 1) is therefore an `$AverInt`
+/// ref, not i64. Builds the same tagged struct the VM produces:
+/// `b == 0` → `Err("division by zero")`, else `Ok(__aint_divmod(a, b, m))`
+/// with `m = 0` for `div`, `1` for `mod`. There is NO overflow branch —
+/// over ℤ `i64::MIN / -1` is the valid Big `+2^63`.
+fn emit_mir_aint_div_mod_boxed(
+    func: &mut Function,
+    is_div: bool,
+    a: &Spanned<MirExpr>,
+    b: &Spanned<MirExpr>,
+    slots: &SlotTable,
+    ctx: &EmitCtx<'_>,
+    res_idx: u32,
+) -> Result<MirBuiltinEmit, WasmGcError> {
+    let aint_idx = ctx.registry.aint_struct_idx.ok_or(WasmGcError::Validation(
+        "bignum Int.div/mod requires the $AverInt struct slot to be registered".into(),
+    ))?;
+    let divmod_idx =
+        ctx.fn_map
+            .builtins
+            .get("__aint_divmod")
+            .copied()
+            .ok_or(WasmGcError::Validation(
+                "bignum Int.div/mod requires the __aint_divmod helper to be registered".into(),
+            ))?;
+
+    macro_rules! e {
+        ($x:expr) => {
+            if emit_mir_expr(func, $x, slots, ctx)?.is_none() {
+                return Ok(MirBuiltinEmit::Fallback);
+            }
+        };
+    }
+
+    let res_block = wasm_encoder::BlockType::Result(ValType::Ref(wasm_encoder::RefType {
+        nullable: true,
+        heap_type: wasm_encoder::HeapType::Concrete(res_idx),
+    }));
+
+    // `Result.Err("division by zero")` — tag 0, an `$AverInt`-typed ok
+    // placeholder (default Int = Small(0)), the message string.
+    macro_rules! emit_err {
+        () => {{
+            func.instruction(&Instruction::I32Const(0));
+            emit_default_value(func, "Int", ctx.registry)?;
+            emit_string_literal_bytes(func, b"division by zero", ctx)?;
+            func.instruction(&Instruction::StructNew(res_idx));
+        }};
+    }
+    // `Result.Ok(__aint_divmod(a, b, want_mod))` — tag 1, the result, null err.
+    macro_rules! emit_ok {
+        () => {{
+            func.instruction(&Instruction::I32Const(1));
+            e!(a);
+            e!(b);
+            func.instruction(&Instruction::I32Const(if is_div { 0 } else { 1 }));
+            func.instruction(&Instruction::Call(divmod_idx));
+            emit_default_value(func, "String", ctx.registry)?;
+            func.instruction(&Instruction::StructNew(res_idx));
+        }};
+    }
+
+    // if b == 0 (canonical zero is Small(0): `$magf == null && $small == 0`)
+    e!(b);
+    func.instruction(&Instruction::StructGet {
+        struct_type_index: aint_idx,
+        field_index: 1,
+    });
+    func.instruction(&Instruction::RefIsNull);
+    e!(b);
+    func.instruction(&Instruction::StructGet {
+        struct_type_index: aint_idx,
+        field_index: 0,
+    });
+    func.instruction(&Instruction::I64Eqz);
+    func.instruction(&Instruction::I32And);
+    func.instruction(&Instruction::If(res_block));
+    emit_err!();
+    func.instruction(&Instruction::Else);
+    emit_ok!();
+    func.instruction(&Instruction::End);
+    Ok(MirBuiltinEmit::Produced(true))
+}
+
 /// Full mirror of `emit_result_with_default`. Two shapes:
 ///
 /// 1. **Fused** `Result.withDefault(Int.mod(a, b), default)` — `Int.mod`
@@ -718,6 +881,48 @@ pub(crate) fn emit_mir_result_with_default(
             let is_mod = inner_dotted == "Int.mod";
             let a = &inner.args[0];
             let b = &inner.args[1];
+            // bignum slice 2 — fold through the Euclidean `__aint_divmod`
+            // helper over `$AverInt` refs. `b == 0` is tested on the struct
+            // (canonical zero is Small(0)) and routes to `default`; there is
+            // no `i64::MIN / -1` trap edge (that quotient is a valid Big).
+            if ctx.registry.bignum {
+                let aint_idx = ctx.registry.aint_struct_idx.ok_or(WasmGcError::Validation(
+                    "bignum Result.withDefault(Int.div/mod) needs the $AverInt slot".into(),
+                ))?;
+                let divmod_idx = ctx.fn_map.builtins.get("__aint_divmod").copied().ok_or(
+                    WasmGcError::Validation(
+                        "bignum Result.withDefault(Int.div/mod) needs the __aint_divmod helper"
+                            .into(),
+                    ),
+                )?;
+                let block_ty = wasm_encoder::BlockType::Result(
+                    crate::codegen::wasm_gc::types::struct_ref(aint_idx),
+                );
+                // if b == 0 (`$magf == null && $small == 0`) -> default,
+                // else __aint_divmod(a, b, want_mod)
+                e!(b);
+                func.instruction(&Instruction::StructGet {
+                    struct_type_index: aint_idx,
+                    field_index: 1,
+                });
+                func.instruction(&Instruction::RefIsNull);
+                e!(b);
+                func.instruction(&Instruction::StructGet {
+                    struct_type_index: aint_idx,
+                    field_index: 0,
+                });
+                func.instruction(&Instruction::I64Eqz);
+                func.instruction(&Instruction::I32And);
+                func.instruction(&Instruction::If(block_ty));
+                e!(default);
+                func.instruction(&Instruction::Else);
+                e!(a);
+                e!(b);
+                func.instruction(&Instruction::I32Const(if is_mod { 1 } else { 0 }));
+                func.instruction(&Instruction::Call(divmod_idx));
+                func.instruction(&Instruction::End);
+                return Ok(MirBuiltinEmit::Produced(true));
+            }
             // Both fold through a Euclidean helper so the result matches the
             // VM/Rust `checked_{rem,div}_euclid`: `mod` lands in `[0,|b|)`,
             // `div` floors. The `b == 0` guard below routes divide-by-zero to

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -288,6 +288,15 @@ pub(super) fn emit_aint_neg(registry: &TypeRegistry) -> Result<Function, WasmGcE
     wat_helper::compile_wat_helper(&wat)
 }
 
+/// `__aint_abs(a) -> $AverInt` (slice 2). `|a|` over ℤ: a non-negative
+/// value is unchanged; `|i64::MIN|` promotes to the Big `+2^63`; a
+/// negative Big flips its sign field to `+1`. Mirrors `AverInt::abs`.
+pub(super) fn emit_aint_abs(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(include_str!("wat/abs.wat"), decls = decls);
+    wat_helper::compile_wat_helper(&wat)
+}
+
 /// `__aint_eq(a, b) -> i32` (1/0). Leans on the canonical invariant:
 /// equal Small ↔ equal $small; equal Big ↔ same sign + same limbs; a
 /// Small and a Big are never equal.
@@ -502,6 +511,72 @@ pub(super) fn emit_aint_mul(registry: &TypeRegistry) -> Result<Function, WasmGcE
     wat_helper::compile_wat_helper(&wat)
 }
 
+/// Locals for the divmod helper: decomposed operands + lengths, the
+/// long-division working set (quotient `$qm`, working remainder `$rwm`
+/// stripped to `$rwlen`, the bit/word/offset cursor), borrow/carry
+/// scratch, the Euclidean-adjust output `$rwout`, and the normalize
+/// scratch (`$rm $rs $rlen $lo $hi $tmpm`) shared by both result epilogues.
+fn divmod_locals() -> &'static str {
+    r#"
+            (local $am (ref null $mag)) (local $as_ i32)
+            (local $bm (ref null $mag)) (local $bs i32)
+            (local $alen i32) (local $blen i32)
+            (local $qm (ref null $mag)) (local $rwm (ref null $mag)) (local $rwlen i32)
+            (local $rwout (ref null $mag)) (local $rm (ref null $mag)) (local $rs i32) (local $rlen i32)
+            (local $bit i32) (local $word i32) (local $off i32)
+            (local $i i32) (local $j i32) (local $cmp i32) (local $negadj i32)
+            (local $carry i64) (local $acc i64) (local $borrow i64) (local $diff i64) (local $umag i64)
+            (local $lo i64) (local $hi i64) (local $tmpm (ref null $mag)) "#
+}
+
+/// `__aint_divmod(a, b, want_mod) -> $AverInt`. Euclidean division
+/// (`want_mod == 0`) or modulo (`want_mod != 0`), matching
+/// `aver-rt::AverInt::{div,rem}_euclid` and the VM EXACTLY: the
+/// remainder is always in `[0, |b|)`. The b == 0 partiality is handled
+/// by the caller BEFORE this helper (the boxed `Int.div`/`Int.mod`
+/// lowering), so this assumes `b != 0`.
+///
+/// Fast path: both operands Small AND not the `i64::MIN / -1` overflow
+/// (whose ℤ quotient `+2^63` is a Big) — reuse the same i64 Euclidean
+/// arithmetic the wrapping backend emits (`i64.div_s`/`i64.rem_s` plus
+/// the rem<0 lift). Slow path: decompose, run unsigned shift-subtract
+/// long division of the magnitudes to a truncating quotient+remainder,
+/// then apply the sign rules + the Euclidean adjustment and normalize.
+///
+/// Euclidean lift (derived from `euclid_div_rem`): when the dividend is
+/// negative and the truncating remainder is nonzero, the quotient's
+/// magnitude is `|trunc_q| + 1` (sign = `as_ * bs`, unchanged) and the
+/// remainder is `|b| - trunc_rem` (always non-negative). Otherwise the
+/// truncating quotient/remainder magnitudes pass through with sign
+/// `as_ * bs` / `as_` respectively. Both results renormalize.
+pub(super) fn emit_aint_divmod(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let locals = divmod_locals();
+    let decomp_a = decompose("a", "am", "as_", "umag");
+    let decomp_b = decompose("b", "bm", "bs", "umag");
+    let strip_a = strip("am", "alen", "sa", "la");
+    let strip_b = strip("bm", "blen", "sb", "lb");
+    // r vs |b| during long division: $rwm (stripped $rwlen) ⋛ $bm ($blen).
+    let cmp_r_b = umag_cmp("rwm", "rwlen", "bm", "blen", "cmp", "j");
+    // Two normalize epilogues, one per result branch; they're in disjoint
+    // `if` arms so reusing the same scratch locals is safe.
+    let norm_q = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    let norm_r = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    let wat = format!(
+        include_str!("wat/divmod.wat"),
+        decls = decls,
+        locals = locals,
+        decomp_a = decomp_a,
+        decomp_b = decomp_b,
+        strip_a = strip_a,
+        strip_b = strip_b,
+        cmp_r_b = cmp_r_b,
+        norm_q = norm_q,
+        norm_r = norm_r,
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
 /// Inlined schoolbook 32-bit-limb magnitude multiply. Reads stripped
 /// `am`/`$alen`, `bm`/`$blen`; writes the product magnitude into `$rm`
 /// (len `$alen+$blen`) and the result sign into `$rs` (= as_ * bs, with
@@ -560,6 +635,13 @@ mod tests {
     /// machinery is needed, then the four bignum/String index fields are
     /// overwritten directly (they are `pub(super)`, visible here).
     fn bignum_registry() -> TypeRegistry {
+        bignum_registry_for_validation()
+    }
+
+    /// Same self-consistent bignum layout, re-exported to the
+    /// `validation_guard` sibling module so its full-validate test renders
+    /// helpers against an identical type section.
+    pub(super) fn bignum_registry_for_validation() -> TypeRegistry {
         let mut registry = TypeRegistry::build_with_handler(&[], &[], false);
         registry.bignum = true;
         registry.string_array_type_idx = Some(0);
@@ -584,11 +666,13 @@ mod tests {
         let cases: &[(&str, fn(&TypeRegistry) -> Result<Function, WasmGcError>)] = &[
             ("emit_aint_from_i64", emit_aint_from_i64),
             ("emit_aint_neg", emit_aint_neg),
+            ("emit_aint_abs", emit_aint_abs),
             ("emit_aint_eq", emit_aint_eq),
             ("emit_aint_cmp", emit_aint_cmp),
             ("emit_aint_add", emit_aint_add),
             ("emit_aint_sub", emit_aint_sub),
             ("emit_aint_mul", emit_aint_mul),
+            ("emit_aint_divmod", emit_aint_divmod),
             ("emit_string_from_aint", emit_string_from_aint),
         ];
 
@@ -600,5 +684,82 @@ mod tests {
                 result.err()
             );
         }
+    }
+}
+
+/// VALIDATION guard — stronger than `every_bignum_helper_wat_parses`.
+/// The parse guard only runs `wat::parse_str` (syntax), so it accepts a
+/// helper whose control flow type-checks WRONG — e.g. an
+/// `(if (result (ref null $aint)) …)` whose arms leave nothing on the
+/// stack, or a branch with a mismatched value type. Those are *validation*
+/// errors wasmtime raises at instantiation, the exact class slice 2's
+/// divmod hit twice (spurious result annotations; a stale length local).
+/// Here every leaf helper's rendered module is run through the full
+/// `wasmparser` validator (GC + tail-call features on), so a stack-type
+/// bug in any `.wat` fails at `cargo test`, not only when a program
+/// happens to divide in wasmtime.
+#[cfg(test)]
+mod validation_guard {
+    use super::tests::bignum_registry_for_validation;
+    use super::*;
+
+    /// Validate the divmod + abs helpers (the slice-2 additions whose
+    /// control flow is non-trivial) by rendering their full WAT module and
+    /// running the binary validator. Renders via the same generators the
+    /// emitter uses.
+    #[test]
+    fn slice2_helper_modules_validate() {
+        let registry = bignum_registry_for_validation();
+
+        let modules: Vec<(&str, String)> = vec![
+            ("__aint_divmod", render_divmod(&registry)),
+            (
+                "__aint_abs",
+                render_simple(&registry, include_str!("wat/abs.wat")),
+            ),
+            (
+                "__aint_neg",
+                render_simple(&registry, include_str!("wat/neg.wat")),
+            ),
+        ];
+
+        for (name, wat) in modules {
+            let bytes = wat::parse_str(&wat)
+                .unwrap_or_else(|e| panic!("helper `{name}` failed to parse: {e}"));
+            let mut validator =
+                wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all());
+            validator
+                .validate_all(&bytes)
+                .unwrap_or_else(|e| panic!("helper `{name}` failed to VALIDATE: {e}"));
+        }
+    }
+
+    fn render_simple(registry: &TypeRegistry, template: &str) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        template.replace("{decls}", &decls)
+    }
+
+    fn render_divmod(registry: &TypeRegistry) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        let locals = divmod_locals();
+        let decomp_a = decompose("a", "am", "as_", "umag");
+        let decomp_b = decompose("b", "bm", "bs", "umag");
+        let strip_a = strip("am", "alen", "sa", "la");
+        let strip_b = strip("bm", "blen", "sb", "lb");
+        let cmp_r_b = umag_cmp("rwm", "rwlen", "bm", "blen", "cmp", "j");
+        let norm_q = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+        let norm_r = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+        format!(
+            include_str!("wat/divmod.wat"),
+            decls = decls,
+            locals = locals,
+            decomp_a = decomp_a,
+            decomp_b = decomp_b,
+            strip_a = strip_a,
+            strip_b = strip_b,
+            cmp_r_b = cmp_r_b,
+            norm_q = norm_q,
+            norm_r = norm_r,
+        )
     }
 }

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -160,6 +160,12 @@ pub(super) enum BuiltinName {
     AintMul,
     /// `__aint_neg(a) -> $AverInt` — ℤ negate (`-i64::MIN` promotes).
     AintNeg,
+    /// `__aint_abs(a) -> $AverInt` — ℤ abs (`|i64::MIN|` promotes). slice 2.
+    AintAbs,
+    /// `__aint_divmod(a, b, want_mod) -> $AverInt` — Euclidean division
+    /// (`want_mod == 0`) or modulo (`want_mod != 0`); remainder always in
+    /// `[0, |b|)`. Caller guards `b == 0`. slice 2.
+    AintDivmod,
     /// `__aint_cmp(a, b) -> i32` (-1/0/1) — total order over ℤ.
     AintCmp,
     /// `__aint_eq(a, b) -> i32` (1/0) — equality leaning on canonical form.
@@ -227,6 +233,8 @@ impl BuiltinName {
             Self::AintSub => "__aint_sub",
             Self::AintMul => "__aint_mul",
             Self::AintNeg => "__aint_neg",
+            Self::AintAbs => "__aint_abs",
+            Self::AintDivmod => "__aint_divmod",
             Self::AintCmp => "__aint_cmp",
             Self::AintEq => "__aint_eq",
         }
@@ -271,7 +279,13 @@ impl BuiltinName {
             Self::AintAdd | Self::AintSub | Self::AintMul | Self::AintCmp | Self::AintEq => {
                 Ok(vec![aint_ref_ty(registry)?, aint_ref_ty(registry)?])
             }
-            Self::AintNeg => Ok(vec![aint_ref_ty(registry)?]),
+            Self::AintNeg | Self::AintAbs => Ok(vec![aint_ref_ty(registry)?]),
+            // `want_mod` selects modulo (≠0) vs division (0).
+            Self::AintDivmod => Ok(vec![
+                aint_ref_ty(registry)?,
+                aint_ref_ty(registry)?,
+                ValType::I32,
+            ]),
         }
     }
 
@@ -301,9 +315,13 @@ impl BuiltinName {
             Self::ByteToHex => Ok(vec![result_ref_ty(registry, "Result<String,String>")?]),
             Self::StringReplace => Ok(vec![string_ref_ty(registry)?]),
             Self::IntModEuclid | Self::IntDivEuclid => Ok(vec![ValType::I64]),
-            Self::AintFromI64 | Self::AintAdd | Self::AintSub | Self::AintMul | Self::AintNeg => {
-                Ok(vec![aint_ref_ty(registry)?])
-            }
+            Self::AintFromI64
+            | Self::AintAdd
+            | Self::AintSub
+            | Self::AintMul
+            | Self::AintNeg
+            | Self::AintAbs
+            | Self::AintDivmod => Ok(vec![aint_ref_ty(registry)?]),
             Self::AintCmp | Self::AintEq => Ok(vec![ValType::I32]),
         }
     }
@@ -345,6 +363,8 @@ impl BuiltinName {
             Self::AintSub => bignum::emit_aint_sub(registry),
             Self::AintMul => bignum::emit_aint_mul(registry),
             Self::AintNeg => bignum::emit_aint_neg(registry),
+            Self::AintAbs => bignum::emit_aint_abs(registry),
+            Self::AintDivmod => bignum::emit_aint_divmod(registry),
             Self::AintCmp => bignum::emit_aint_cmp(registry),
             Self::AintEq => bignum::emit_aint_eq(registry),
         }

--- a/src/codegen/wasm_gc/builtins/wat/abs.wat
+++ b/src/codegen/wasm_gc/builtins/wat/abs.wat
@@ -1,0 +1,31 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result (ref null $aint))
+            (local $m (ref null $mag))
+            (local.set $m (struct.get $aint $magf (local.get $a)))
+            (if (result (ref null $aint)) (ref.is_null (local.get $m))
+              (then
+                ;; Small. Non-negative → unchanged. i64::MIN → +2^63 (Big,
+                ;; two 32-bit limbs low=0 high=0x80000000). Other negatives →
+                ;; the negated value still fits i64 (stays Small).
+                (if (result (ref null $aint)) (i64.ge_s (struct.get $aint $small (local.get $a)) (i64.const 0))
+                  (then (local.get $a))
+                  (else
+                    (if (result (ref null $aint))
+                        (i64.eq (struct.get $aint $small (local.get $a)) (i64.const 0x8000000000000000))
+                      (then
+                        (struct.new $aint (i64.const 0)
+                          (array.new_fixed $mag 2 (i64.const 0) (i64.const 0x80000000))
+                          (i32.const 1)))
+                      (else
+                        (struct.new $aint
+                          (i64.sub (i64.const 0) (struct.get $aint $small (local.get $a)))
+                          (ref.null $mag) (i32.const 0)))))))
+              (else
+                ;; Big. |a| keeps the magnitude with sign +1 (a Big is never
+                ;; in i64 range, so its magnitude stays a canonical Big — no
+                ;; demote needed; the only Big that could demote under negate
+                ;; is +2^63, and that is already positive here).
+                (struct.new $aint (i64.const 0) (local.get $m) (i32.const 1))))))
+

--- a/src/codegen/wasm_gc/builtins/wat/divmod.wat
+++ b/src/codegen/wasm_gc/builtins/wat/divmod.wat
@@ -1,0 +1,199 @@
+
+        (module
+          {decls}
+          (func (export "helper")
+              (param $a (ref null $aint)) (param $b (ref null $aint)) (param $want_mod i32)
+              (result (ref null $aint))
+            (local $sa i64) (local $sb i64) (local $sq i64) (local $sr i64)
+            {locals}
+            ;; ── fast path: both Small AND not the i64::MIN / -1 overflow ──
+            ;; (`i64.div_s` traps on MIN/-1; over ℤ that quotient is +2^63,
+            ;; a Big, so it must take the limb path). Caller guarantees b != 0.
+            (if (result (ref null $aint))
+                (i32.and
+                  (i32.and (ref.is_null (struct.get $aint $magf (local.get $a)))
+                           (ref.is_null (struct.get $aint $magf (local.get $b))))
+                  (i32.eqz
+                    (i32.and
+                      (i64.eq (struct.get $aint $small (local.get $a)) (i64.const 0x8000000000000000))
+                      (i64.eq (struct.get $aint $small (local.get $b)) (i64.const -1)))))
+              (then
+                (local.set $sa (struct.get $aint $small (local.get $a)))
+                (local.set $sb (struct.get $aint $small (local.get $b)))
+                ;; Euclidean rem: q = a rem_s b; if q<0, q += |b|.
+                (local.set $sr (i64.rem_s (local.get $sa) (local.get $sb)))
+                (if (i64.lt_s (local.get $sr) (i64.const 0))
+                  (then
+                    (local.set $sr (i64.add (local.get $sr)
+                      (if (result i64) (i64.lt_s (local.get $sb) (i64.const 0))
+                        (then (i64.sub (i64.const 0) (local.get $sb)))
+                        (else (local.get $sb)))))))
+                (if (result (ref null $aint)) (local.get $want_mod)
+                  (then
+                    (struct.new $aint (local.get $sr) (ref.null $mag) (i32.const 0)))
+                  (else
+                    ;; Euclidean quotient: trunc q, step toward -inf when rem<0.
+                    (local.set $sq (i64.div_s (local.get $sa) (local.get $sb)))
+                    (local.set $sr (i64.rem_s (local.get $sa) (local.get $sb)))
+                    (if (i64.lt_s (local.get $sr) (i64.const 0))
+                      (then
+                        (local.set $sq
+                          (if (result i64) (i64.gt_s (local.get $sb) (i64.const 0))
+                            (then (i64.sub (local.get $sq) (i64.const 1)))
+                            (else (i64.add (local.get $sq) (i64.const 1)))))))
+                    (struct.new $aint (local.get $sq) (ref.null $mag) (i32.const 0)))))
+              (else
+                ;; ── slow path: limb long division ──
+                {decomp_a}
+                {decomp_b}
+                {strip_a}
+                {strip_b}
+                ;; Unsigned long division of |a| (am, alen) by |b| (bm, blen),
+                ;; shift-subtract, MSB-to-LSB over the bit width of |a|. Produces
+                ;; unsigned quotient magnitude $qm (len $alen) and remainder
+                ;; magnitude held in $rwm (len $blen+1, working) → stripped len $rwlen.
+                (local.set $qm (array.new_default $mag (if (result i32) (i32.eqz (local.get $alen)) (then (i32.const 1)) (else (local.get $alen)))))
+                (local.set $rwm (array.new_default $mag (i32.add (local.get $blen) (i32.const 1))))
+                (local.set $rwlen (i32.const 0))
+                ;; bit index counts from alen*32-1 downto 0.
+                (local.set $bit (i32.sub (i32.mul (local.get $alen) (i32.const 32)) (i32.const 1)))
+                (block $bits_done (loop $bits
+                  (br_if $bits_done (i32.lt_s (local.get $bit) (i32.const 0)))
+                  ;; r <<= 1  (shift the working remainder magnitude left by one bit)
+                  (local.set $carry (i64.const 0))
+                  (local.set $i (i32.const 0))
+                  (block $shl_done (loop $shl
+                    (br_if $shl_done (i32.ge_u (local.get $i) (i32.add (local.get $blen) (i32.const 1))))
+                    (local.set $acc (i64.or
+                      (i64.and (i64.shl (array.get $mag (local.get $rwm) (local.get $i)) (i64.const 1)) (i64.const 0xffffffff))
+                      (local.get $carry)))
+                    (local.set $carry (i64.shr_u (array.get $mag (local.get $rwm) (local.get $i)) (i64.const 31)))
+                    (array.set $mag (local.get $rwm) (local.get $i) (local.get $acc))
+                    (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                    (br $shl)))
+                  ;; r |= bit_(bit) of |a|
+                  (local.set $word (i32.div_u (local.get $bit) (i32.const 32)))
+                  (local.set $off (i32.rem_u (local.get $bit) (i32.const 32)))
+                  (if (i64.ne
+                        (i64.and (i64.shr_u (array.get $mag (local.get $am) (local.get $word)) (i64.extend_i32_u (local.get $off))) (i64.const 1))
+                        (i64.const 0))
+                    (then
+                      (array.set $mag (local.get $rwm) (i32.const 0)
+                        (i64.or (array.get $mag (local.get $rwm) (i32.const 0)) (i64.const 1)))))
+                  ;; recompute stripped working-remainder length $rwlen
+                  (local.set $rwlen (i32.add (local.get $blen) (i32.const 1)))
+                  (block $rstrip_done (loop $rstrip
+                    (br_if $rstrip_done (i32.eqz (local.get $rwlen)))
+                    (br_if $rstrip_done (i64.ne (array.get $mag (local.get $rwm) (i32.sub (local.get $rwlen) (i32.const 1))) (i64.const 0)))
+                    (local.set $rwlen (i32.sub (local.get $rwlen) (i32.const 1)))
+                    (br $rstrip)))
+                  ;; if r >= |b|: r -= |b|; set quotient bit.
+                  {cmp_r_b}
+                  (if (i32.ge_s (local.get $cmp) (i32.const 0))
+                    (then
+                      ;; r -= |b|  (borrow subtract, r >= |b| guaranteed)
+                      (local.set $borrow (i64.const 0))
+                      (local.set $i (i32.const 0))
+                      (block $rsub_done (loop $rsub
+                        (br_if $rsub_done (i32.ge_u (local.get $i) (i32.add (local.get $blen) (i32.const 1))))
+                        (local.set $diff (i64.sub
+                          (i64.sub
+                            (array.get $mag (local.get $rwm) (local.get $i))
+                            (if (result i64) (i32.lt_u (local.get $i) (local.get $blen)) (then (array.get $mag (local.get $bm) (local.get $i))) (else (i64.const 0))))
+                          (local.get $borrow)))
+                        (if (i64.lt_s (local.get $diff) (i64.const 0))
+                          (then
+                            (local.set $diff (i64.add (local.get $diff) (i64.const 0x100000000)))
+                            (local.set $borrow (i64.const 1)))
+                          (else (local.set $borrow (i64.const 0))))
+                        (array.set $mag (local.get $rwm) (local.get $i) (i64.and (local.get $diff) (i64.const 0xffffffff)))
+                        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                        (br $rsub)))
+                      ;; set quotient bit (bit) — word/off computed above.
+                      (array.set $mag (local.get $qm) (local.get $word)
+                        (i64.or (array.get $mag (local.get $qm) (local.get $word))
+                          (i64.shl (i64.const 1) (i64.extend_i32_u (local.get $off)))))))
+                  (local.set $bit (i32.sub (local.get $bit) (i32.const 1)))
+                  (br $bits)))
+                ;; $rwm now holds the unsigned truncating remainder magnitude;
+                ;; $qm the unsigned truncating quotient. Re-strip $rwm to its
+                ;; canonical length $rwlen — the in-loop $rwlen reflects the
+                ;; PRE-subtract remainder of the last bit, so it is stale here.
+                (local.set $rwlen (i32.add (local.get $blen) (i32.const 1)))
+                (block $rwfin_done (loop $rwfin
+                  (br_if $rwfin_done (i32.eqz (local.get $rwlen)))
+                  (br_if $rwfin_done (i64.ne (array.get $mag (local.get $rwm) (i32.sub (local.get $rwlen) (i32.const 1))) (i64.const 0)))
+                  (local.set $rwlen (i32.sub (local.get $rwlen) (i32.const 1)))
+                  (br $rwfin)))
+                ;;
+                ;; Result signs: trunc-q sign = as_ * bs (0 if either 0);
+                ;; trunc-r sign follows the dividend (as_), 0 if rem is 0.
+                ;; Euclidean lift (dividend negative & remainder nonzero):
+                ;;   quotient magnitude += 1 (sign unchanged = as_ * bs);
+                ;;   remainder = |b| - rwm, sign +.
+                ;;
+                ;; Result signs: trunc-q sign = as_ * bs (0 if either 0);
+                ;; trunc-r sign follows the dividend (as_), 0 if rem is 0.
+                ;; Euclidean lift (dividend negative & remainder nonzero):
+                ;;   quotient magnitude += 1 (sign unchanged = as_ * bs);
+                ;;   remainder = |b| - rwm, sign +.
+                (local.set $negadj
+                  (i32.and (i32.lt_s (local.get $as_) (i32.const 0)) (i32.ne (local.get $rwlen) (i32.const 0))))
+                (if (result (ref null $aint)) (local.get $want_mod)
+                  (then
+                    ;; ── remainder ──
+                    (if (local.get $negadj)
+                      (then
+                        ;; rwout = |b| - rwm  (rwm < |b|, so a clean borrow subtract)
+                        (local.set $rwout (array.new_default $mag (local.get $blen)))
+                        (local.set $borrow (i64.const 0))
+                        (local.set $i (i32.const 0))
+                        (block $rfin_done (loop $rfin
+                          (br_if $rfin_done (i32.ge_u (local.get $i) (local.get $blen)))
+                          (local.set $diff (i64.sub
+                            (i64.sub
+                              (array.get $mag (local.get $bm) (local.get $i))
+                              (if (result i64) (i32.lt_u (local.get $i) (local.get $rwlen)) (then (array.get $mag (local.get $rwm) (local.get $i))) (else (i64.const 0))))
+                            (local.get $borrow)))
+                          (if (i64.lt_s (local.get $diff) (i64.const 0))
+                            (then
+                              (local.set $diff (i64.add (local.get $diff) (i64.const 0x100000000)))
+                              (local.set $borrow (i64.const 1)))
+                            (else (local.set $borrow (i64.const 0))))
+                          (array.set $mag (local.get $rwout) (local.get $i) (i64.and (local.get $diff) (i64.const 0xffffffff)))
+                          (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                          (br $rfin)))
+                        (local.set $rm (local.get $rwout)))
+                      (else
+                        ;; trunc remainder magnitude as-is; sign +.
+                        (local.set $rm (local.get $rwm))))
+                    (local.set $rs (i32.const 1))
+                    {norm_r})
+                  (else
+                    ;; ── quotient ──
+                    (local.set $rs (i32.mul (local.get $as_) (local.get $bs)))
+                    (if (local.get $negadj)
+                      (then
+                        ;; quotient magnitude += 1 (ripple carry; grow by one limb
+                        ;; so a top-limb carry has room).
+                        (local.set $rwout (array.new_default $mag (i32.add (local.get $alen) (i32.const 1))))
+                        (local.set $i (i32.const 0))
+                        (block $qcp_done (loop $qcp
+                          (br_if $qcp_done (i32.ge_u (local.get $i) (local.get $alen)))
+                          (array.set $mag (local.get $rwout) (local.get $i) (array.get $mag (local.get $qm) (local.get $i)))
+                          (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                          (br $qcp)))
+                        (local.set $carry (i64.const 1))
+                        (local.set $i (i32.const 0))
+                        (block $qinc_done (loop $qinc
+                          (br_if $qinc_done (i64.eqz (local.get $carry)))
+                          (local.set $acc (i64.add (array.get $mag (local.get $rwout) (local.get $i)) (local.get $carry)))
+                          (array.set $mag (local.get $rwout) (local.get $i) (i64.and (local.get $acc) (i64.const 0xffffffff)))
+                          (local.set $carry (i64.shr_u (local.get $acc) (i64.const 32)))
+                          (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                          (br $qinc)))
+                        (local.set $rm (local.get $rwout)))
+                      (else
+                        (local.set $rm (local.get $qm))))
+                    {norm_q}))))))
+

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -203,6 +203,8 @@ pub(super) fn emit_module_with(
             BuiltinName::AintSub,
             BuiltinName::AintMul,
             BuiltinName::AintNeg,
+            BuiltinName::AintAbs,
+            BuiltinName::AintDivmod,
             BuiltinName::AintCmp,
             BuiltinName::AintEq,
         ] {

--- a/tests/cross_backend_proptest.rs
+++ b/tests/cross_backend_proptest.rs
@@ -452,6 +452,193 @@ fn cross_int_equality_canonical_invariant_vm_vs_wasm_gc() {
     }
 }
 
+// ─── Euclidean divmod (slice 2) ─────────────────────────────────────────────
+//
+// `Int.div` / `Int.mod` return `Result<Int, String>` with EUCLIDEAN
+// semantics (remainder always in `[0, |b|)`), matching the VM
+// (`src/types/int.rs`) and `aver-rt` exactly. Under bignum there is NO
+// `i64::MIN / -1` overflow — that quotient is the valid Big `+2^63`.
+//
+// The differential proptest compares RENDERED stdout, so it is blind to
+// two slice-1 bug classes; both are covered explicitly below:
+//   - render via BOTH `String.fromInt` AND `"{...}"` interpolation;
+//   - assert the law `(a/b)*b + (a%b) == a` and `0 <= (a%b) < |b|`
+//     through `==` (flag-on wasm-gc must equal the VM ℤ truth `true`),
+//     which a string render cannot distinguish from a canonical-invariant
+//     violation.
+
+/// The full sign/boundary matrix of operands for the Euclidean law. Each
+/// is a *parenthesised Int expression* (so it drops straight into a call
+/// arg). Includes i64::MIN/MAX, 0, ±1, near-sqrt(MAX) (squares overflow),
+/// 2^62, and Big values built by arithmetic (`a*a`, `±2^63`).
+fn divmod_operands() -> Vec<&'static str> {
+    // One representative per sign/boundary class. Kept to 11 so the
+    // generated `main` (11×11 pairs × 3 prints) stays well under the VM's
+    // single-function stack budget — the Big magnitudes are exercised by
+    // `cross_int_big_operand_divmod_vm_vs_wasm_gc` and the sweep below.
+    vec![
+        "0",
+        "1",
+        "(0 - 1)",
+        "7",
+        "(0 - 7)",
+        "9223372036854775807",             // i64::MAX
+        "((0 - 9223372036854775807) - 1)", // i64::MIN
+        "(9223372036854775807 + 1)",       // +2^63 (Big)
+        "(0 - (9223372036854775807 + 1))", // -2^63 (Big)
+        "3037000500",
+        "(0 - 3037000500)",
+    ]
+}
+
+/// `Int.div(a,b)` rendered as a String via a Result-unwrapping helper.
+/// `b == 0` renders the `Result.Err` message, so divide-by-zero is part
+/// of the differential (both backends must produce the same message).
+fn divmod_harness(body_lines: &str) -> String {
+    // `law` asserts the Euclidean contract `(q*b + r == a) && (0 <= r < |b|)`
+    // through `==` / `<` (NOT a string render), so a value mis-stored as
+    // Small-vs-Big — invisible to `String.fromInt` — fails it. The
+    // conjunction is spelled with `Bool.and` + a helper (Aver's parser
+    // rejects deeply nested inline `match` in this position).
+    format!(
+        "module Tmp\n\
+         \n\
+         fn dv(a: Int, b: Int) -> String\n    \
+             match Int.div(a, b)\n        \
+                 Result.Ok(q) -> String.fromInt(q)\n        \
+                 Result.Err(e) -> e\n\
+         \n\
+         fn md(a: Int, b: Int) -> String\n    \
+             match Int.mod(a, b)\n        \
+                 Result.Ok(r) -> String.fromInt(r)\n        \
+                 Result.Err(e) -> e\n\
+         \n\
+         fn lawq(a: Int, b: Int, q: Int) -> Bool\n    \
+             match Int.mod(a, b)\n        \
+                 Result.Ok(r) -> Bool.and(((q * b) + r) == a, Bool.and((0 - 1) < r, r < Int.abs(b)))\n        \
+                 Result.Err(_) -> false\n\
+         \n\
+         fn law(a: Int, b: Int) -> Bool\n    \
+             match Int.div(a, b)\n        \
+                 Result.Ok(q) -> lawq(a, b, q)\n        \
+                 Result.Err(_) -> true\n\
+         \n\
+         fn main()\n    \
+             ! [Console.print]\n\
+         {body_lines}\n"
+    )
+}
+
+#[test]
+fn cross_int_euclidean_divmod_vm_vs_wasm_gc() {
+    let ops = divmod_operands();
+    // Build one program that prints, for every (a, b) pair:
+    //   - div rendered via String.fromInt
+    //   - mod rendered via "{...}" interpolation (the slice-1 render blind
+    //     spot — a distinct reachability path)
+    //   - the Euclidean law `(q*b + r == a) && (0 <= r < |b|)` via `==`
+    //     (the canonical-invariant blind spot — only `==` distinguishes a
+    //     mis-stored Small/Big)
+    let mut lines = String::new();
+    let mut pair_count = 0usize;
+    for a in &ops {
+        for b in &ops {
+            lines.push_str(&format!("    Console.print(dv({a}, {b}))\n"));
+            lines.push_str(&format!("    Console.print(\"{{md({a}, {b})}}\")\n"));
+            lines.push_str(&format!(
+                "    Console.print(String.fromBool(law({a}, {b})))\n"
+            ));
+            pair_count += 1;
+        }
+    }
+    let source = divmod_harness(lines.trim_end());
+
+    let vm = run_vm("cross-divmod-vm", &source).expect("VM must accept the divmod harness");
+    let wg = run_wasm_gc_bignum("cross-divmod-wg", &source)
+        .expect("wasm-gc (bignum) must accept the divmod harness");
+
+    // 1. The two backends agree byte-for-byte on every rendered line.
+    assert_eq!(
+        vm, wg,
+        "VM vs wasm-gc (bignum) diverged on the Euclidean divmod matrix \
+         ({pair_count} pairs, div+mod+law per pair)"
+    );
+
+    // 2. Every `law(...)` line is `true` on the VM (the ℤ oracle). The law
+    //    lines are every third line; assert none is `false`, so the matrix
+    //    actually exercised the law rather than trivially agreeing on a
+    //    shared bug.
+    let law_lines: Vec<&str> = vm.lines().skip(2).step_by(3).collect();
+    assert_eq!(
+        law_lines.len(),
+        pair_count,
+        "expected one law line per pair"
+    );
+    assert!(
+        law_lines.iter().all(|l| *l == "true"),
+        "the Euclidean law `q*b + r == a, 0 <= r < |b|` failed on the VM ℤ \
+         oracle for some pair (first offending around index {:?})",
+        law_lines.iter().position(|l| *l != "true")
+    );
+}
+
+#[test]
+fn cross_int_big_operand_divmod_vm_vs_wasm_gc() {
+    // Big-operand divmod specifically exercises the limb long division
+    // (the i64 fast path can't reach these). `(a*a)/a == a`, `(a*a)%a == 0`
+    // for a near i64::MAX, plus a Big dividend over a Small divisor (both
+    // signs). Rendered via String.fromInt; the VM truth is asserted inline.
+    let cases: &[(&str, &str)] = &[
+        // (program-expr, expected ℤ stdout)
+        (
+            "dv(9223372036854775807 * 9223372036854775807, 9223372036854775807)",
+            "9223372036854775807",
+        ),
+        (
+            "md(9223372036854775807 * 9223372036854775807, 9223372036854775807)",
+            "0",
+        ),
+        ("dv(3037000500 * 3037000500, 3037000500)", "3037000500"),
+        ("md(3037000500 * 3037000500, 3037000500)", "0"),
+        // Big dividend, Small divisor, exactly divisible (i64::MAX*7 % 7 == 0).
+        ("md(9223372036854775807 * 7, 7)", "0"),
+        ("dv(9223372036854775807 * 7, 7)", "9223372036854775807"),
+        // Negative Big dividend, Small divisor — Euclidean remainder is
+        // non-negative; exact divisibility keeps it 0 (the slice-2 stale-
+        // length bug produced a spurious +7 here).
+        ("md((0 - 9223372036854775807) * 7, 7)", "0"),
+        (
+            "dv((0 - 9223372036854775807) * 7, 7)",
+            "-9223372036854775807",
+        ),
+    ];
+
+    let body: String = cases
+        .iter()
+        .map(|(expr, _)| format!("    Console.print({expr})"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let source = divmod_harness(&body);
+
+    let vm = run_vm("cross-bigdm-vm", &source).expect("VM must accept the big divmod program");
+    let wg = run_wasm_gc_bignum("cross-bigdm-wg", &source)
+        .expect("wasm-gc (bignum) must accept the big divmod program");
+
+    assert_eq!(
+        vm, wg,
+        "VM vs wasm-gc (bignum) diverged on Big-operand divmod"
+    );
+
+    let vm_lines: Vec<&str> = vm.lines().collect();
+    assert_eq!(vm_lines.len(), cases.len(), "line count mismatch");
+    for ((expr, expected), got) in cases.iter().zip(vm_lines.iter()) {
+        assert_eq!(
+            got, expected,
+            "VM ℤ truth wrong for `{expr}`: got {got}, expected {expected}"
+        );
+    }
+}
+
 // ─── Properties ────────────────────────────────────────────────────────────
 
 proptest! {


### PR DESCRIPTION
Slice 2 of making the wasm-gc backend faithful to `Int = ℤ`. Builds on slice 1 (#521, representation + add/sub/mul/neg/cmp/eq). Still **entirely behind the opt-in `AVER_WASMGC_BIGNUM` flag — the default path (i64 wrapping, current `Int.div`/`mod` Result behavior, host ABI i64) is byte-unchanged.**

## Scope
Euclidean `Int.div` / `Int.mod` (remainder always in `[0, |b|)`, matching `aver_rt::AverInt` and the VM exactly) + `Int.abs` / `Int.min` / `Int.max`.

- New WAT helper `wat/divmod.wat` (`__aint_divmod(a, b, want_mod)`): Small fast path reuses i64 Euclidean arithmetic; the slow path is unsigned shift-subtract long division → truncating quotient/remainder → sign rules + the Euclidean lift → normalize. One self-contained fn (the `compile_wat_helper`-keeps-first-fn discipline), limb routines spliced from the slice-1 generators.
- New `wat/abs.wat` (`abs(i64::MIN) = +2^63`, a Big, not an overflow). `min`/`max` route through the slice-1 `cmp` helper.
- `Int.div`/`Int.mod` keep returning `Result<Int, String>`: `b == 0` → `Err("division by zero")` (exact VM message). The `i64::MIN / -1` overflow→Err is **dropped on the bignum path** — it is now `Ok(+2^63)`, a valid value.

Deferred (later slices, a flagged program using them falls back or errors cleanly): decimal parse/format of `> i64` literals + `Int`/`Float` exactness (slice 3), the default flip (slice 4).

## Verification (two-phase — cargo-green is necessary but not sufficient)
- **Phase 2 (wasmtime, the real gate):** a 481-case full-sign-matrix div/mod sweep (i64::MIN/MAX, 0, ±1, ±2^63, big squares) is byte-identical VM vs flag-on wasm-gc; an independent Python arbitrary-precision oracle confirmed `q*b + r == a` and `0 <= r < |b|` on all non-zero-divisor cases (0 mismatches). `i64::MIN / -1 = 9223372036854775808`; `abs(i64::MIN) = 9223372036854775808`; `b == 0` → `division by zero` on both backends; Big÷Big with multi-limb divisors confirmed.
- Permanent differential tests added: `cross_int_euclidean_divmod_vm_vs_wasm_gc` (renders div via `String.fromInt`, mod via `"{...}"` interpolation, asserts the law via `==`/`<` — covering the two render-blind-spots slice 1 was bitten by) and `cross_int_big_operand_divmod_vm_vs_wasm_gc`.
- A new `slice2_helper_modules_validate` test runs the rendered helper modules through the full wasmparser validator (catches stack-type bugs the parse-only guard misses).
- `cargo test` (lib 916 + wasm_gc) green; `cargo fmt --check` + `cargo clippy --features wasm,wasip2 -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)