### PR TITLE
ci: wasm cross-backend differential proptests — 2000 nightly, 64 per-PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Nightly deep sweep against main with the heavy proptest budget: the
+  # WASM job's cross-backend differential runs 2000 cases nightly but a
+  # 64-case smoke per-PR (see its `PROPTEST_CASES` below). Mirrors the
+  # fuzz / proof / rust-codegen nightlies (cron 03:00 UTC). Manual runs
+  # via workflow_dispatch also get the full 2000-case sweep.
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -91,9 +99,23 @@ jobs:
         # `#![cfg(feature = "wasip2")]` test file at 0 tests, so the
         # wasip2 codegen / component-model surface went unchecked by the
         # gate. Enable both (they share `wasm-compile`) so the wasip2_*
-        # suites run. Same proptest budget as the Check & Test job.
+        # suites run.
+        #
+        # Proptest budget — split per-PR vs nightly. The wasm-feature
+        # proptests include the cross-backend DIFFERENTIAL sweeps
+        # (`tests/cross_backend_proptest.rs`), which spawn `aver run` twice
+        # per case (VM + wasm-gc) and JIT each module in wasmtime —
+        # ~0.5-1.5s/case, vs microseconds for the in-process proptests in
+        # the Check & Test job. At 2000 cases that is ~30 min, too slow for
+        # every PR. So: a 64-case SMOKE per-PR, and the full 2000-case
+        # sweep NIGHTLY (and on workflow_dispatch). The deterministic
+        # differentials (sign matrices, the Euclidean law, canonical-eq,
+        # interpolation render) run at ANY case count, so they stay the
+        # real per-PR net; the 2000-case sweep is the broad randomized
+        # net, alongside the fuzz nightly's `fuzz_parity_vm_vs_wasm_gc`
+        # in-process differential.
         env:
-          PROPTEST_CASES: '2000'
+          PROPTEST_CASES: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '2000' || '64' }}
         run: cargo test -p aver-lang --features wasm,wasip2
 
   wasm_release_build:


### PR DESCRIPTION
The `WASM` job's `Test (wasm + wasip2)` step takes ~30 minutes — ~97% of it is the cross-backend differential proptests (`tests/cross_backend_proptest.rs`), which spawn `aver run` twice per case (VM + wasm-gc) and JIT each module in wasmtime (~0.5–1.5s/case). At `PROPTEST_CASES=2000` that dominates every PR's wait.

This splits the budget the same way `fuzz.yml` / `rust-codegen.yml` / `proof.yml` already split their heavy work:
- **Per-PR (and push): a 64-case smoke** — the `wasm` job drops from ~30 min to ~6–8 min.
- **Nightly (cron 03:00 UTC) and `workflow_dispatch`: the full 2000-case sweep.**

The deterministic differentials (sign matrices, the Euclidean `q*b+r==a, 0<=r<|b|` law, the canonical-invariant `==` checks, the interpolation render) run at **any** case count, so they stay the per-PR safety net. The 2000-case random sweep is the broad net — and the fuzz nightly already carries `fuzz_parity_vm_vs_wasm_gc`, an in-process VM↔wasm-gc differential, so wasm-gc has nightly randomized coverage from two angles.

The in-process proptests in the `Check & Test` job stay at 2000 (microseconds per case; they've caught real bugs at that budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)