### PR TITLE
wasm-gc: decimal Int.fromString/String.fromInt + exact Int<->Float + Big-safe index, on bignum (slice 3)

### DIFF
--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -36,6 +36,59 @@ fn aint_helper(ctx: &EmitCtx<'_>, name: &str) -> Result<u32, WasmGcError> {
         )))
 }
 
+/// bignum slice 3 — emit a `Vector`/`List` index expression and leave a
+/// signed i32 on the stack such that `idx >= 0 (signed)` AND
+/// `idx < len (unsigned)` is the in-bounds predicate. Under the flag the
+/// `$AverInt` index goes through `__aint_to_index` (Big or out-of-range →
+/// the sentinel `-1`, which fails BOTH halves of that predicate, so a Big
+/// index reads out-of-bounds — the VM's `Option.None` — instead of being
+/// `I32WrapI64`-truncated into a wrong slot). Flag-off it is the byte-
+/// identical `I32WrapI64`; the caller still guards the lower bound on the
+/// raw i64 (`index >= 0`), so off-path behaviour is unchanged.
+fn emit_index_i32(
+    func: &mut Function,
+    index: &Spanned<MirExpr>,
+    slots: &SlotTable,
+    ctx: &EmitCtx<'_>,
+) -> Result<bool, WasmGcError> {
+    if emit_mir_expr(func, index, slots, ctx)?.is_none() {
+        return Ok(false);
+    }
+    if ctx.registry.bignum {
+        let to_index = aint_helper(ctx, "__aint_to_index")?;
+        func.instruction(&Instruction::Call(to_index));
+    } else {
+        func.instruction(&Instruction::I32WrapI64);
+    }
+    Ok(true)
+}
+
+/// bignum slice 3 — emit the lower-bound half of an index bounds-check:
+/// flag-off keeps the raw i64 `index >= 0`; flag-on tests the extracted
+/// i32 `idx >= 0` (signed), since `__aint_to_index` already collapses a
+/// negative / Big / too-large index to the `-1` sentinel.
+fn emit_index_nonneg(
+    func: &mut Function,
+    index: &Spanned<MirExpr>,
+    slots: &SlotTable,
+    ctx: &EmitCtx<'_>,
+) -> Result<bool, WasmGcError> {
+    if ctx.registry.bignum {
+        if !emit_index_i32(func, index, slots, ctx)? {
+            return Ok(false);
+        }
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::I32GeS);
+    } else {
+        if emit_mir_expr(func, index, slots, ctx)?.is_none() {
+            return Ok(false);
+        }
+        func.instruction(&Instruction::I64Const(0));
+        func.instruction(&Instruction::I64GeS);
+    }
+    Ok(true)
+}
+
 /// bignum slice 2 — the `(ref null $AverInt)` block-type for `if`/`else`
 /// arms that yield an `Int` under the flag (e.g. the `Int.min`/`max`
 /// select).
@@ -151,6 +204,40 @@ pub(crate) fn emit_mir_native_scalar_builtin(
     }
     let i64_block = wasm_encoder::BlockType::Result(ValType::I64);
     match dotted {
+        // bignum slice 3 — Int <-> Float bridges over `$AverInt`. The
+        // scalar `F64ConvertI64S` / saturating `I64TruncF64S` are WRONG for
+        // values outside i64 (the plan flags this), so under the flag these
+        // route through the limb helpers that match `aver-rt`'s `to_f64`
+        // (±inf saturation) and `from_f64_trunc` (non-finite → 0, huge
+        // finite → exact Big). The i64-scalar arms below stay for flag-off.
+        "Float.fromInt" if args.len() == 1 && ctx.registry.bignum => {
+            let to_f64 = aint_helper(ctx, "__aint_to_f64")?;
+            arg!(0);
+            func.instruction(&Instruction::Call(to_f64));
+        }
+        "Int.fromFloat" if args.len() == 1 && ctx.registry.bignum => {
+            let from_f64 = aint_helper(ctx, "__aint_from_f64")?;
+            arg!(0);
+            func.instruction(&Instruction::Call(from_f64));
+        }
+        "Float.floor" if args.len() == 1 && ctx.registry.bignum => {
+            let from_f64 = aint_helper(ctx, "__aint_from_f64")?;
+            arg!(0);
+            func.instruction(&Instruction::F64Floor);
+            func.instruction(&Instruction::Call(from_f64));
+        }
+        "Float.ceil" if args.len() == 1 && ctx.registry.bignum => {
+            let from_f64 = aint_helper(ctx, "__aint_from_f64")?;
+            arg!(0);
+            func.instruction(&Instruction::F64Ceil);
+            func.instruction(&Instruction::Call(from_f64));
+        }
+        "Float.round" if args.len() == 1 && ctx.registry.bignum => {
+            let from_f64 = aint_helper(ctx, "__aint_from_f64")?;
+            arg!(0);
+            func.instruction(&Instruction::F64Nearest);
+            func.instruction(&Instruction::Call(from_f64));
+        }
         "Float.fromInt" if args.len() == 1 => {
             arg!(0);
             func.instruction(&Instruction::F64ConvertI64S);
@@ -410,19 +497,31 @@ pub(crate) fn emit_mir_option_with_default(
                     format!("Vector.get: element type `{element}` has no wasm representation"),
                 ))?;
             let block_ty = wasm_encoder::BlockType::Result(elem_val);
-            e!(index);
-            func.instruction(&Instruction::I64Const(0));
-            func.instruction(&Instruction::I64GeS);
-            e!(index);
-            func.instruction(&Instruction::I32WrapI64);
+            // bignum slice 3 — index extraction routes through
+            // `__aint_to_index` (Big → OOB), see `emit_index_i32`.
+            macro_rules! idx_nonneg {
+                () => {
+                    if !emit_index_nonneg(func, index, slots, ctx)? {
+                        return Ok(MirBuiltinEmit::Fallback);
+                    }
+                };
+            }
+            macro_rules! idx_i32 {
+                () => {
+                    if !emit_index_i32(func, index, slots, ctx)? {
+                        return Ok(MirBuiltinEmit::Fallback);
+                    }
+                };
+            }
+            idx_nonneg!();
+            idx_i32!();
             e!(vector);
             func.instruction(&Instruction::ArrayLen);
             func.instruction(&Instruction::I32LtU);
             func.instruction(&Instruction::I32And);
             func.instruction(&Instruction::If(block_ty));
             e!(vector);
-            e!(index);
-            func.instruction(&Instruction::I32WrapI64);
+            idx_i32!();
             func.instruction(&Instruction::ArrayGet(vec_idx));
             func.instruction(&Instruction::Else);
             e!(default);
@@ -539,23 +638,34 @@ fn emit_mir_vector_set_or_default(
             }
         };
     }
+    // bignum slice 3 — index extraction through `__aint_to_index`.
+    macro_rules! idx_nonneg {
+        () => {
+            if !emit_index_nonneg(func, index, slots, ctx)? {
+                return Ok(MirBuiltinEmit::Fallback);
+            }
+        };
+    }
+    macro_rules! idx_i32 {
+        () => {
+            if !emit_index_i32(func, index, slots, ctx)? {
+                return Ok(MirBuiltinEmit::Fallback);
+            }
+        };
+    }
 
     // Fast path: dead, non-aliased binding → mutate the engine array in
     // place and return the same handle. No scratch, no allocation.
     if mir_arg_uniquely_owned(vector, ctx) {
-        e!(index);
-        func.instruction(&Instruction::I64Const(0));
-        func.instruction(&Instruction::I64GeS);
-        e!(index);
-        func.instruction(&Instruction::I32WrapI64);
+        idx_nonneg!();
+        idx_i32!();
         e!(vector);
         func.instruction(&Instruction::ArrayLen);
         func.instruction(&Instruction::I32LtU);
         func.instruction(&Instruction::I32And);
         func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
         e!(vector);
-        e!(index);
-        func.instruction(&Instruction::I32WrapI64);
+        idx_i32!();
         e!(value);
         func.instruction(&Instruction::ArraySet(vec_idx));
         func.instruction(&Instruction::End);
@@ -593,19 +703,15 @@ fn emit_mir_vector_set_or_default(
         array_type_index_src: vec_idx,
     });
 
-    e!(index);
-    func.instruction(&Instruction::I64Const(0));
-    func.instruction(&Instruction::I64GeS);
-    e!(index);
-    func.instruction(&Instruction::I32WrapI64);
+    idx_nonneg!();
+    idx_i32!();
     func.instruction(&Instruction::LocalGet(scratch));
     func.instruction(&Instruction::ArrayLen);
     func.instruction(&Instruction::I32LtU);
     func.instruction(&Instruction::I32And);
     func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
     func.instruction(&Instruction::LocalGet(scratch));
-    e!(index);
-    func.instruction(&Instruction::I32WrapI64);
+    idx_i32!();
     e!(value);
     func.instruction(&Instruction::ArraySet(vec_idx));
     func.instruction(&Instruction::End);
@@ -1328,14 +1434,18 @@ pub(crate) fn emit_mir_vector_builtin(
                         "Vector.new: instantiation `{canonical}` was not registered"
                     )))?;
             // wasm `array.new` pops [value, size:i32]; Aver pushes size
-            // (i64) then fill, so emit fill, then size, then wrap.
+            // (i64) then fill, so emit fill, then size, then narrow to i32.
+            // Under bignum the size is a `$AverInt` ref, narrowed via
+            // `__aint_to_index` (a Big / negative size → the `-1` sentinel,
+            // i.e. a 0xffffffff length that `array.new` rejects — the VM
+            // likewise can't materialise an out-of-i32 vector); flag-off
+            // keeps the byte-identical `I32WrapI64`.
             if emit_mir_expr(func, &args[1], slots, ctx)?.is_none() {
                 return Ok(MirBuiltinEmit::Fallback);
             }
-            if emit_mir_expr(func, &args[0], slots, ctx)?.is_none() {
+            if !emit_index_i32(func, &args[0], slots, ctx)? {
                 return Ok(MirBuiltinEmit::Fallback);
             }
-            func.instruction(&Instruction::I32WrapI64);
             func.instruction(&Instruction::ArrayNew(vec_idx));
         }
         "Vector.get" if args.len() == 2 => {
@@ -1404,11 +1514,23 @@ pub(crate) fn emit_mir_vector_get_boxed(
             }
         };
     }
-    e!(index);
-    func.instruction(&Instruction::I64Const(0));
-    func.instruction(&Instruction::I64GeS);
-    e!(index);
-    func.instruction(&Instruction::I32WrapI64);
+    // bignum slice 3 — index extraction through `__aint_to_index`.
+    macro_rules! idx_nonneg {
+        () => {
+            if !emit_index_nonneg(func, index, slots, ctx)? {
+                return Ok(MirBuiltinEmit::Fallback);
+            }
+        };
+    }
+    macro_rules! idx_i32 {
+        () => {
+            if !emit_index_i32(func, index, slots, ctx)? {
+                return Ok(MirBuiltinEmit::Fallback);
+            }
+        };
+    }
+    idx_nonneg!();
+    idx_i32!();
     e!(vector);
     func.instruction(&Instruction::ArrayLen);
     func.instruction(&Instruction::I32LtU);
@@ -1416,8 +1538,7 @@ pub(crate) fn emit_mir_vector_get_boxed(
     func.instruction(&Instruction::If(block_ty));
     func.instruction(&Instruction::I32Const(1));
     e!(vector);
-    e!(index);
-    func.instruction(&Instruction::I32WrapI64);
+    idx_i32!();
     func.instruction(&Instruction::ArrayGet(vec_idx));
     func.instruction(&Instruction::StructNew(opt_idx));
     func.instruction(&Instruction::Else);
@@ -1466,20 +1587,31 @@ pub(crate) fn emit_mir_vector_set_boxed(
             }
         };
     }
+    // bignum slice 3 — index extraction through `__aint_to_index`.
+    macro_rules! idx_nonneg {
+        () => {
+            if !emit_index_nonneg(func, index, slots, ctx)? {
+                return Ok(MirBuiltinEmit::Fallback);
+            }
+        };
+    }
+    macro_rules! idx_i32 {
+        () => {
+            if !emit_index_i32(func, index, slots, ctx)? {
+                return Ok(MirBuiltinEmit::Fallback);
+            }
+        };
+    }
     if mir_arg_uniquely_owned(vector, ctx) {
-        e!(index);
-        func.instruction(&Instruction::I64Const(0));
-        func.instruction(&Instruction::I64GeS);
-        e!(index);
-        func.instruction(&Instruction::I32WrapI64);
+        idx_nonneg!();
+        idx_i32!();
         e!(vector);
         func.instruction(&Instruction::ArrayLen);
         func.instruction(&Instruction::I32LtU);
         func.instruction(&Instruction::I32And);
         func.instruction(&Instruction::If(block_ty));
         e!(vector);
-        e!(index);
-        func.instruction(&Instruction::I32WrapI64);
+        idx_i32!();
         e!(value);
         func.instruction(&Instruction::ArraySet(vec_idx));
         func.instruction(&Instruction::I32Const(1));
@@ -1505,11 +1637,8 @@ pub(crate) fn emit_mir_vector_set_boxed(
                  (slot-pre-pass missed this site)"
             ))
         })?;
-    e!(index);
-    func.instruction(&Instruction::I64Const(0));
-    func.instruction(&Instruction::I64GeS);
-    e!(index);
-    func.instruction(&Instruction::I32WrapI64);
+    idx_nonneg!();
+    idx_i32!();
     e!(vector);
     func.instruction(&Instruction::ArrayLen);
     func.instruction(&Instruction::I32LtU);
@@ -1530,8 +1659,7 @@ pub(crate) fn emit_mir_vector_set_boxed(
         array_type_index_src: vec_idx,
     });
     func.instruction(&Instruction::LocalGet(scratch));
-    e!(index);
-    func.instruction(&Instruction::I32WrapI64);
+    idx_i32!();
     e!(value);
     func.instruction(&Instruction::ArraySet(vec_idx));
     func.instruction(&Instruction::I32Const(1));

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -279,12 +279,13 @@ fn aint_string_result_decls(registry: &TypeRegistry) -> Result<String, WasmGcErr
     let struct_idx = registry.aint_struct_idx.ok_or(WasmGcError::Validation(
         "bignum Int.fromString needs the $aint slot, but it wasn't allocated".into(),
     ))?;
-    let result_idx = registry
-        .result_type_idx("Result<Int,String>")
-        .ok_or(WasmGcError::Validation(
-            "bignum Int.fromString needs the Result<Int,String> slot, but it wasn't allocated"
-                .into(),
-        ))?;
+    let result_idx =
+        registry
+            .result_type_idx("Result<Int,String>")
+            .ok_or(WasmGcError::Validation(
+                "bignum Int.fromString needs the Result<Int,String> slot, but it wasn't allocated"
+                    .into(),
+            ))?;
     if !(string_idx < mag_idx && mag_idx + 1 == struct_idx && struct_idx < result_idx) {
         return Err(WasmGcError::Validation(format!(
             "bignum Int.fromString expects string({string_idx}) < mag({mag_idx}), \
@@ -879,9 +880,15 @@ mod validation_guard {
             // builder, the ±inf saturating Float path) is exactly the class
             // the parse-only guard cannot catch, so validate the full module.
             ("__aint_from_string", render_from_string(&registry)),
-            ("__aint_to_f64", render_simple(&registry, include_str!("wat/to_f64.wat"))),
+            (
+                "__aint_to_f64",
+                render_simple(&registry, include_str!("wat/to_f64.wat")),
+            ),
             ("__aint_from_f64", render_from_f64(&registry)),
-            ("__aint_to_index", render_simple(&registry, include_str!("wat/to_index.wat"))),
+            (
+                "__aint_to_index",
+                render_simple(&registry, include_str!("wat/to_index.wat")),
+            ),
         ];
 
         for (name, wat) in modules {

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -260,6 +260,114 @@ fn aint_and_string_decls(registry: &TypeRegistry) -> Result<String, WasmGcError>
     ))
 }
 
+/// Type declarations for the bignum `Int.fromString` parser, which
+/// references `$string`, `$mag`, `$aint` AND the `Result<Int,String>`
+/// carrier struct (ok field is the `$aint` ref under bignum, err field
+/// `$string`). The registry allocates `string_idx < mag_idx < struct_idx`
+/// (struct = mag+1), and the result slot lands above all three (after any
+/// intervening vector/list types). Pads each gap in turn so every named
+/// type lands at the user module's exact idx.
+fn aint_string_result_decls(registry: &TypeRegistry) -> Result<String, WasmGcError> {
+    let string_idx = registry
+        .string_array_type_idx
+        .ok_or(WasmGcError::Validation(
+            "bignum Int.fromString needs the String slot, but it wasn't allocated".into(),
+        ))?;
+    let mag_idx = registry.aint_mag_array_idx.ok_or(WasmGcError::Validation(
+        "bignum Int.fromString needs the $mag slot, but it wasn't allocated".into(),
+    ))?;
+    let struct_idx = registry.aint_struct_idx.ok_or(WasmGcError::Validation(
+        "bignum Int.fromString needs the $aint slot, but it wasn't allocated".into(),
+    ))?;
+    let result_idx = registry
+        .result_type_idx("Result<Int,String>")
+        .ok_or(WasmGcError::Validation(
+            "bignum Int.fromString needs the Result<Int,String> slot, but it wasn't allocated"
+                .into(),
+        ))?;
+    if !(string_idx < mag_idx && mag_idx + 1 == struct_idx && struct_idx < result_idx) {
+        return Err(WasmGcError::Validation(format!(
+            "bignum Int.fromString expects string({string_idx}) < mag({mag_idx}), \
+             struct({struct_idx}) == mag+1, and result({result_idx}) > struct; \
+             layout invariant broken"
+        )));
+    }
+    let pad_to_string = wat_helper::padding_types(string_idx);
+    // After `$string` at string_idx we are at string_idx+1; pad to mag_idx,
+    // declare `$mag` + `$aint`, then pad to result_idx and declare `$result`.
+    let gap_to_mag = wat_helper::padding_types(mag_idx - (string_idx + 1));
+    let gap_to_result = wat_helper::padding_types(result_idx - (struct_idx + 1));
+    Ok(format!(
+        "{pad_to_string}\
+         (type $string (array (mut i8)))\n\
+         {gap_to_mag}\
+         (type $mag (array (mut i64)))\n\
+         (type $aint (struct (field $small (mut i64)) \
+                             (field $magf (mut (ref null $mag))) \
+                             (field $sign (mut i32))))\n\
+         {gap_to_result}\
+         (type $result (struct (field (mut i32)) (field (mut (ref null $aint))) \
+                               (field (mut (ref null $string)))))\n"
+    ))
+}
+
+/// Inlined WAT that builds the VM-identical `Cannot parse '<s>' as Int`
+/// error message into a fresh `$string` and leaves an `Err`
+/// `(ref null $result)` on the stack. Mirrors `AverInt::from_str`'s
+/// rejection wrapped by `Int::from_string` (`src/types/int.rs`). Reuses
+/// the helper's `$len`/`$i`/`$err` locals; the prefix is `Cannot parse '`
+/// (14 bytes) and the suffix `' as Int` (8 bytes).
+fn from_string_err_build() -> String {
+    // ASCII for "Cannot parse '" then the original string then "' as Int".
+    let prefix: [u8; 14] = *b"Cannot parse '";
+    let suffix: [u8; 8] = *b"' as Int";
+    let mut set_prefix = String::new();
+    for (i, b) in prefix.iter().enumerate() {
+        set_prefix.push_str(&format!(
+            "(array.set $string (local.get $err) (i32.const {i}) (i32.const {b}))\n"
+        ));
+    }
+    let mut set_suffix = String::new();
+    for (k, b) in suffix.iter().enumerate() {
+        // suffix byte k lands at index 14 + len + k.
+        set_suffix.push_str(&format!(
+            "(array.set $string (local.get $err) (i32.add (i32.const {pos}) (local.get $len)) (i32.const {b}))\n",
+            pos = 14 + k
+        ));
+    }
+    format!(
+        r#"
+            (local.set $err (array.new_default $string (i32.add (local.get $len) (i32.const 22))))
+            {set_prefix}
+            ;; copy the original string into err[14..14+len]
+            (array.copy $string $string (local.get $err) (i32.const 14)
+              (local.get $s) (i32.const 0) (local.get $len))
+            {set_suffix}
+            (struct.new $result (i32.const 0) (ref.null $aint) (local.get $err))
+        "#
+    )
+}
+
+/// `Int.fromString(s) -> Result<Int, String>` under bignum. Accumulates
+/// decimal digits into a 32-bit-limb magnitude (`mag = mag*10 + digit`)
+/// then normalizes to a canonical `$AverInt`, so a 38-digit string parses
+/// to the EXACT value (not the wrapped-i64 the scalar helper produces).
+/// Acceptance matches the VM (`AverInt::from_str`): one optional leading
+/// `+`/`-`, then `≥1` ASCII digit, no whitespace/garbage; on any
+/// rejection returns `Err("Cannot parse '<s>' as Int")` byte-identically.
+pub(super) fn emit_aint_from_string(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_string_result_decls(registry)?;
+    let err_build = from_string_err_build();
+    let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    let wat = format!(
+        include_str!("wat/from_string.wat"),
+        decls = decls,
+        err_build = err_build,
+        norm = norm,
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
 /// `String.fromInt` under bignum — formats an `$AverInt` to a decimal
 /// `(ref null $string)`. Small reads `$small` and runs the same i64
 /// digit loop the scalar helper uses; Big repeatedly divides the 32-bit
@@ -276,6 +384,40 @@ pub(super) fn emit_string_from_aint(registry: &TypeRegistry) -> Result<Function,
 pub(super) fn emit_aint_from_i64(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
     let wat = format!(include_str!("wat/from_i64.wat"), decls = decls);
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_to_f64(a) -> f64` — `Float.fromInt` under bignum. Small is an
+/// exact `i64→f64` round; Big runs a Horner accumulation over the limbs
+/// (`acc = acc*2^32 + limb`, high→low) that saturates to `±inf` for
+/// magnitudes past f64 range, mirroring `AverInt::to_f64`
+/// (`aver-rt/src/int.rs`).
+pub(super) fn emit_aint_to_f64(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(include_str!("wat/to_f64.wat"), decls = decls);
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_from_f64(f) -> $AverInt` — `Int.fromFloat` under bignum.
+/// Non-finite → `0`; an in-`i64`-range truncated value stays Small; an
+/// out-of-range finite magnitude is built EXACTLY from the IEEE-754
+/// mantissa/exponent (a pure left shift, since `|t| >= 2^63` forces a
+/// non-negative exponent), matching `AverInt::from_f64_trunc`.
+pub(super) fn emit_aint_from_f64(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    let wat = format!(include_str!("wat/from_f64.wat"), decls = decls, norm = norm);
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_to_index(a) -> i32` — extract a wasm array index from an
+/// `$AverInt`. A Small in `[0, 2^31)` passes through; a negative /
+/// `>= 2^31` Small or ANY Big returns the OOB sentinel `-1`, so a Big
+/// index bounds-checks as out-of-range (the VM's `Option.None`) instead
+/// of being `I32WrapI64`-truncated into a wrong in-range slot.
+pub(super) fn emit_aint_to_index(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(include_str!("wat/to_index.wat"), decls = decls);
     wat_helper::compile_wat_helper(&wat)
 }
 
@@ -647,6 +789,13 @@ mod tests {
         registry.string_array_type_idx = Some(0);
         registry.aint_mag_array_idx = Some(1);
         registry.aint_struct_idx = Some(2);
+        // `Int.fromString` (slice 3) carries a `Result<Int,String>` whose
+        // ok field is the `$aint` ref. Register it just above the struct
+        // slot so `aint_string_result_decls` finds a valid layout.
+        registry
+            .result_types
+            .insert("Result<Int,String>".to_string(), 3);
+        registry.result_order.push("Result<Int,String>".to_string());
         registry
     }
 
@@ -674,6 +823,10 @@ mod tests {
             ("emit_aint_mul", emit_aint_mul),
             ("emit_aint_divmod", emit_aint_divmod),
             ("emit_string_from_aint", emit_string_from_aint),
+            ("emit_aint_from_string", emit_aint_from_string),
+            ("emit_aint_to_f64", emit_aint_to_f64),
+            ("emit_aint_from_f64", emit_aint_from_f64),
+            ("emit_aint_to_index", emit_aint_to_index),
         ];
 
         for (name, emit) in cases {
@@ -721,6 +874,14 @@ mod validation_guard {
                 "__aint_neg",
                 render_simple(&registry, include_str!("wat/neg.wat")),
             ),
+            // slice 3 — decimal parse / Float bridges / index extraction.
+            // Their control flow (limb-accumulate loops, the error-message
+            // builder, the ±inf saturating Float path) is exactly the class
+            // the parse-only guard cannot catch, so validate the full module.
+            ("__aint_from_string", render_from_string(&registry)),
+            ("__aint_to_f64", render_simple(&registry, include_str!("wat/to_f64.wat"))),
+            ("__aint_from_f64", render_from_f64(&registry)),
+            ("__aint_to_index", render_simple(&registry, include_str!("wat/to_index.wat"))),
         ];
 
         for (name, wat) in modules {
@@ -737,6 +898,24 @@ mod validation_guard {
     fn render_simple(registry: &TypeRegistry, template: &str) -> String {
         let decls = aint_type_decls(registry).unwrap();
         template.replace("{decls}", &decls)
+    }
+
+    fn render_from_string(registry: &TypeRegistry) -> String {
+        let decls = aint_string_result_decls(registry).unwrap();
+        let err_build = from_string_err_build();
+        let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+        format!(
+            include_str!("wat/from_string.wat"),
+            decls = decls,
+            err_build = err_build,
+            norm = norm,
+        )
+    }
+
+    fn render_from_f64(registry: &TypeRegistry) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+        format!(include_str!("wat/from_f64.wat"), decls = decls, norm = norm)
     }
 
     fn render_divmod(registry: &TypeRegistry) -> String {

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -389,10 +389,15 @@ pub(super) fn emit_aint_from_i64(registry: &TypeRegistry) -> Result<Function, Wa
 }
 
 /// `__aint_to_f64(a) -> f64` — `Float.fromInt` under bignum. Small is an
-/// exact `i64→f64` round; Big runs a Horner accumulation over the limbs
-/// (`acc = acc*2^32 + limb`, high→low) that saturates to `±inf` for
-/// magnitudes past f64 range, mirroring `AverInt::to_f64`
-/// (`aver-rt/src/int.rs`).
+/// exact `i64→f64` round; Big is CORRECTLY ROUNDED (round-to-nearest-even,
+/// bit-identical to `num_bigint::BigInt::to_f64`) via the sticky-jam
+/// technique: reduce the magnitude to its top 64 significant bits `M` with
+/// shift `s = sigbits - 64`, OR every dropped lower bit into a sticky bit,
+/// jam sticky into `M`'s LSB, `f64.convert_i64_u(M)`, then multiply by the
+/// EXACT power of two `2^s` (saturating to `±inf` for magnitudes past f64
+/// range). A naive high→low Horner accumulation (`acc = acc*2^32 + limb`)
+/// double-rounds and drifts 1 ULP on ~10% of >=3-limb magnitudes — the
+/// sticky-jam single-rounds, matching `AverInt::to_f64` (`aver-rt/src/int.rs`).
 pub(super) fn emit_aint_to_f64(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
     let wat = format!(include_str!("wat/to_f64.wat"), decls = decls);

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -170,6 +170,14 @@ pub(super) enum BuiltinName {
     AintCmp,
     /// `__aint_eq(a, b) -> i32` (1/0) — equality leaning on canonical form.
     AintEq,
+    // ── bignum slice 3 — decimal parse / Float bridges / index ─────────
+    /// `__aint_to_f64(a) -> f64` — `Float.fromInt` (±inf saturation). slice 3.
+    AintToF64,
+    /// `__aint_from_f64(f) -> $AverInt` — `Int.fromFloat` (exact Big). slice 3.
+    AintFromF64,
+    /// `__aint_to_index(a) -> i32` — Vector/List index extraction; Big →
+    /// OOB sentinel `-1`. slice 3.
+    AintToIndex,
 }
 
 impl BuiltinName {
@@ -237,6 +245,9 @@ impl BuiltinName {
             Self::AintDivmod => "__aint_divmod",
             Self::AintCmp => "__aint_cmp",
             Self::AintEq => "__aint_eq",
+            Self::AintToF64 => "__aint_to_f64",
+            Self::AintFromF64 => "__aint_from_f64",
+            Self::AintToIndex => "__aint_to_index",
         }
     }
 
@@ -286,6 +297,8 @@ impl BuiltinName {
                 aint_ref_ty(registry)?,
                 ValType::I32,
             ]),
+            Self::AintToF64 | Self::AintToIndex => Ok(vec![aint_ref_ty(registry)?]),
+            Self::AintFromF64 => Ok(vec![ValType::F64]),
         }
     }
 
@@ -321,8 +334,10 @@ impl BuiltinName {
             | Self::AintMul
             | Self::AintNeg
             | Self::AintAbs
-            | Self::AintDivmod => Ok(vec![aint_ref_ty(registry)?]),
-            Self::AintCmp | Self::AintEq => Ok(vec![ValType::I32]),
+            | Self::AintDivmod
+            | Self::AintFromF64 => Ok(vec![aint_ref_ty(registry)?]),
+            Self::AintCmp | Self::AintEq | Self::AintToIndex => Ok(vec![ValType::I32]),
+            Self::AintToF64 => Ok(vec![ValType::F64]),
         }
     }
 
@@ -342,6 +357,7 @@ impl BuiltinName {
             Self::StringToUpper => emit_string_case(registry, true),
             Self::StringToLower => emit_string_case(registry, false),
             Self::StringTrim => emit_string_trim(registry),
+            Self::IntFromString if registry.bignum => bignum::emit_aint_from_string(registry),
             Self::IntFromString => emit_int_from_string(registry),
             Self::FloatFromString => emit_float_from_string(registry),
             Self::StringFromFloat => emit_string_from_float(registry),
@@ -367,6 +383,9 @@ impl BuiltinName {
             Self::AintDivmod => bignum::emit_aint_divmod(registry),
             Self::AintCmp => bignum::emit_aint_cmp(registry),
             Self::AintEq => bignum::emit_aint_eq(registry),
+            Self::AintToF64 => bignum::emit_aint_to_f64(registry),
+            Self::AintFromF64 => bignum::emit_aint_from_f64(registry),
+            Self::AintToIndex => bignum::emit_aint_to_index(registry),
         }
     }
 }

--- a/src/codegen/wasm_gc/builtins/wat/from_f64.wat
+++ b/src/codegen/wasm_gc/builtins/wat/from_f64.wat
@@ -1,0 +1,71 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $f f64) (result (ref null $aint))
+            (local $t f64) (local $bits i64)
+            (local $exp i64) (local $mant i64)
+            (local $word i32) (local $bit i64)
+            (local $low64 i64) (local $high i64)
+            (local $rm (ref null $mag)) (local $mlen i32)
+            ;; normalize epilogue scratch
+            (local $rs i32) (local $rlen i32) (local $i i32) (local $lo i64) (local $hi i64)
+            (local $tmpm (ref null $mag))
+
+            ;; Non-finite (NaN / ±inf) → 0, matching `from_f64_trunc`.
+            (if (result (ref null $aint))
+                (i32.eqz (f64.eq (local.get $f) (local.get $f)))
+              (then (struct.new $aint (i64.const 0) (ref.null $mag) (i32.const 0)))
+              (else
+                ;; abs(f) == +inf ?  (NaN already handled above)
+                (if (result (ref null $aint))
+                    (f64.eq (f64.abs (local.get $f)) (f64.const inf))
+                  (then (struct.new $aint (i64.const 0) (ref.null $mag) (i32.const 0)))
+                  (else
+                    ;; truncate toward zero.
+                    (local.set $t (f64.trunc (local.get $f)))
+                    ;; In i64 range?  -2^63 <= t < 2^63  → Small via trunc_s
+                    ;; (won't trap given the bounds check).
+                    (if (result (ref null $aint))
+                        (i32.and
+                          (f64.ge (local.get $t) (f64.const -9223372036854775808))
+                          (f64.lt (local.get $t) (f64.const 9223372036854775808)))
+                      (then
+                        (struct.new $aint (i64.trunc_f64_s (local.get $t)) (ref.null $mag) (i32.const 0)))
+                      (else
+                        ;; Out of i64 range but finite — build the EXACT Big.
+                        ;; Decompose |t| = mantissa * 2^exp (IEEE-754 binary64):
+                        ;;   bits  = reinterpret(|t|)
+                        ;;   mant  = (bits & 2^52-1) | 2^52   (53-bit, normal)
+                        ;;   exp   = ((bits>>52)&0x7ff) - 1075
+                        ;; |t| >= 2^63 here so exp >= 11 (>0): a pure left shift.
+                        (local.set $bits (i64.reinterpret_f64 (f64.abs (local.get $t))))
+                        (local.set $mant (i64.or
+                          (i64.and (local.get $bits) (i64.const 0xfffffffffffff))
+                          (i64.const 0x10000000000000)))
+                        (local.set $exp (i64.sub
+                          (i64.and (i64.shr_u (local.get $bits) (i64.const 52)) (i64.const 0x7ff))
+                          (i64.const 1075)))
+                        ;; word = exp / 32, bit = exp % 32
+                        (local.set $word (i32.wrap_i64 (i64.div_u (local.get $exp) (i64.const 32))))
+                        (local.set $bit (i64.rem_u (local.get $exp) (i64.const 32)))
+                        ;; shifted = mant << bit, spanning up to 3 limbs from $word.
+                        ;;   low64 = (mant << bit) mod 2^64
+                        ;;   high  = mant >> (64 - bit)   (the bits past bit 63),
+                        ;;           or 0 when bit == 0.
+                        (local.set $low64 (i64.shl (local.get $mant) (local.get $bit)))
+                        (local.set $high (if (result i64) (i64.eqz (local.get $bit))
+                          (then (i64.const 0))
+                          (else (i64.shr_u (local.get $mant) (i64.sub (i64.const 64) (local.get $bit))))))
+                        ;; magnitude: $word + 3 limbs (the shifted mantissa) is
+                        ;; enough; normalize strips the trailing zeros.
+                        (local.set $mlen (i32.add (local.get $word) (i32.const 3)))
+                        (local.set $rm (array.new_default $mag (local.get $mlen)))
+                        (array.set $mag (local.get $rm) (local.get $word)
+                          (i64.and (local.get $low64) (i64.const 0xffffffff)))
+                        (array.set $mag (local.get $rm) (i32.add (local.get $word) (i32.const 1))
+                          (i64.and (i64.shr_u (local.get $low64) (i64.const 32)) (i64.const 0xffffffff)))
+                        (array.set $mag (local.get $rm) (i32.add (local.get $word) (i32.const 2))
+                          (i64.and (local.get $high) (i64.const 0xffffffff)))
+                        ;; sign from the ORIGINAL float (negative → -1).
+                        (local.set $rs (if (result i32) (f64.lt (local.get $f) (f64.const 0)) (then (i32.const -1)) (else (i32.const 1))))
+                        {norm}))))))))

--- a/src/codegen/wasm_gc/builtins/wat/from_string.wat
+++ b/src/codegen/wasm_gc/builtins/wat/from_string.wat
@@ -1,0 +1,82 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $s (ref null $string)) (result (ref null $result))
+            (local $len i32) (local $idx i32) (local $start i32)
+            (local $negative i32) (local $saw_digit i32)
+            (local $ch i32) (local $digit i64)
+            (local $rm (ref null $mag)) (local $mlen i32)
+            (local $i i32) (local $carry i64) (local $cur i64)
+            (local $err (ref null $string))
+            ;; normalize epilogue scratch
+            (local $rs i32) (local $rlen i32) (local $lo i64) (local $hi i64)
+            (local $tmpm (ref null $mag))
+
+            (local.set $len (array.len (local.get $s)))
+
+            ;; Empty input → Err.
+            (if (i32.eqz (local.get $len))
+              (then
+                {err_build}
+                return))
+
+            ;; Optional single leading '+' / '-'.
+            (local.set $start (i32.const 0))
+            (local.set $ch (array.get_u $string (local.get $s) (i32.const 0)))
+            (if (i32.eq (local.get $ch) (i32.const 0x2D))
+              (then
+                (local.set $negative (i32.const 1))
+                (local.set $start (i32.const 1)))
+              (else
+                (if (i32.eq (local.get $ch) (i32.const 0x2B))
+                  (then (local.set $start (i32.const 1))))))
+
+            ;; Magnitude accumulator: ceil(len/8)+2 limbs holds any decimal
+            ;; (each 32-bit limb absorbs >9 decimal digits; len/8+2 is a
+            ;; safe over-estimate). 32-bit-in-i64 limbs keep mul*10+digit
+            ;; exact (max limb value < 2^32, so limb*10+9 < 2^36 < 2^64).
+            (local.set $mlen (i32.add (i32.div_u (local.get $len) (i32.const 8)) (i32.const 2)))
+            (local.set $rm (array.new_default $mag (local.get $mlen)))
+
+            (local.set $idx (local.get $start))
+            (block $loop_done (loop $loop
+              (br_if $loop_done (i32.ge_u (local.get $idx) (local.get $len)))
+              (local.set $ch (array.get_u $string (local.get $s) (local.get $idx)))
+              ;; Reject any non-digit byte → Err.
+              (if (i32.or (i32.lt_u (local.get $ch) (i32.const 0x30))
+                          (i32.gt_u (local.get $ch) (i32.const 0x39)))
+                (then
+                  {err_build}
+                  return))
+              (local.set $saw_digit (i32.const 1))
+              (local.set $digit (i64.extend_i32_u (i32.sub (local.get $ch) (i32.const 0x30))))
+              ;; rm = rm*10 + digit  (little-endian limb multiply-add)
+              (local.set $carry (local.get $digit))
+              (local.set $i (i32.const 0))
+              (block $ma_done (loop $ma
+                (br_if $ma_done (i32.ge_u (local.get $i) (local.get $mlen)))
+                (local.set $cur (i64.add
+                  (i64.mul (array.get $mag (local.get $rm) (local.get $i)) (i64.const 10))
+                  (local.get $carry)))
+                (array.set $mag (local.get $rm) (local.get $i) (i64.and (local.get $cur) (i64.const 0xffffffff)))
+                (local.set $carry (i64.shr_u (local.get $cur) (i64.const 32)))
+                (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                (br $ma)))
+              (local.set $idx (i32.add (local.get $idx) (i32.const 1)))
+              (br $loop)))
+
+            ;; No digit consumed (empty, lone '+'/'-') → Err.
+            (if (i32.eqz (local.get $saw_digit))
+              (then
+                {err_build}
+                return))
+
+            ;; Sign for normalize: -1 if negative else +1 (normalize maps a
+            ;; zero magnitude to canonical Small(0) regardless of sign).
+            (local.set $rs (if (result i32) (local.get $negative) (then (i32.const -1)) (else (i32.const 1))))
+
+            ;; tag 1 (Ok), ok = normalized $aint, null err.
+            (i32.const 1)
+            {norm}
+            (ref.null $string)
+            (struct.new $result)))

--- a/src/codegen/wasm_gc/builtins/wat/to_f64.wat
+++ b/src/codegen/wasm_gc/builtins/wat/to_f64.wat
@@ -1,0 +1,34 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result f64)
+            (local $m (ref null $mag)) (local $len i32) (local $i i32)
+            (local $acc f64) (local $limb f64)
+            (local.set $m (struct.get $aint $magf (local.get $a)))
+            (if (result f64) (ref.is_null (local.get $m))
+              (then
+                ;; Small — exact i64→f64 (round-to-nearest, as the VM's `n as f64`).
+                (f64.convert_i64_s (struct.get $aint $small (local.get $a))))
+              (else
+                ;; Big — Horner over limbs high→low: acc = acc*2^32 + limb.
+                ;; Magnitudes beyond f64 range overflow to +inf naturally
+                ;; (IEEE), matching `BigInt::to_f64`'s ±inf saturation. The
+                ;; top 53 significant bits drive the mantissa; lower limbs add
+                ;; below the ULP and round to nearest. Sign applied last.
+                (local.set $len (array.len (local.get $m)))
+                (local.set $acc (f64.const 0))
+                (local.set $i (local.get $len))
+                (block $done (loop $lp
+                  (br_if $done (i32.eqz (local.get $i)))
+                  (local.set $i (i32.sub (local.get $i) (i32.const 1)))
+                  ;; limb is an unsigned 32-bit value held in an i64 lane.
+                  (local.set $limb (f64.convert_i64_u
+                    (i64.and (array.get $mag (local.get $m) (local.get $i)) (i64.const 0xffffffff))))
+                  ;; acc = acc * 2^32 + limb
+                  (local.set $acc (f64.add
+                    (f64.mul (local.get $acc) (f64.const 4294967296))
+                    (local.get $limb)))
+                  (br $lp)))
+                (if (result f64) (i32.lt_s (struct.get $aint $sign (local.get $a)) (i32.const 0))
+                  (then (f64.neg (local.get $acc)))
+                  (else (local.get $acc)))))))

--- a/src/codegen/wasm_gc/builtins/wat/to_f64.wat
+++ b/src/codegen/wasm_gc/builtins/wat/to_f64.wat
@@ -2,33 +2,110 @@
         (module
           {decls}
           (func (export "helper") (param $a (ref null $aint)) (result f64)
-            (local $m (ref null $mag)) (local $len i32) (local $i i32)
-            (local $acc f64) (local $limb f64)
+            (local $m (ref null $mag)) (local $len i32)
+            (local $toplimb i64) (local $topbits i32) (local $sigbits i32)
+            (local $s i32) (local $word i32) (local $bit i64)
+            (local $l0 i64) (local $l1 i64) (local $l2 i64)
+            (local $mreg i64) (local $sticky i32) (local $i i32)
+            (local $v0 f64) (local $pow f64)
             (local.set $m (struct.get $aint $magf (local.get $a)))
             (if (result f64) (ref.is_null (local.get $m))
               (then
                 ;; Small — exact i64→f64 (round-to-nearest, as the VM's `n as f64`).
                 (f64.convert_i64_s (struct.get $aint $small (local.get $a))))
               (else
-                ;; Big — Horner over limbs high→low: acc = acc*2^32 + limb.
-                ;; Magnitudes beyond f64 range overflow to +inf naturally
-                ;; (IEEE), matching `BigInt::to_f64`'s ±inf saturation. The
-                ;; top 53 significant bits drive the mantissa; lower limbs add
-                ;; below the ULP and round to nearest. Sign applied last.
+                ;; Big — correctly-rounded |mag|→f64 via the sticky-jam technique,
+                ;; then apply the sign. `$magf` is the canonical little-endian
+                ;; 32-bit-limb magnitude (top limb non-zero, length >= 1), so the
+                ;; significant bit count `sigbits >= 1`.
+                ;;
+                ;; Reduce the magnitude to its TOP 64 significant bits `mreg`,
+                ;; with shift exponent `s = sigbits - 64` (clamped at 0), so the
+                ;; true magnitude = mreg*2^s + dropped, where `dropped` is the
+                ;; bits below position `s`. `sticky` = (dropped != 0). Jamming
+                ;; sticky into mreg's LSB makes `f64.convert_i64_u(mreg)`'s
+                ;; round-to-nearest-even break half-way ties in the correct
+                ;; direction (the true value sits above the 64-bit mreg when
+                ;; dropped != 0); when dropped == 0 the conversion is exact.
+                ;; Finally multiply by 2^s (an EXACT power of two in f64 — the
+                ;; multiply introduces NO rounding except saturation to +inf for
+                ;; magnitudes past f64 range, which matches `BigInt::to_f64`).
                 (local.set $len (array.len (local.get $m)))
-                (local.set $acc (f64.const 0))
-                (local.set $i (local.get $len))
-                (block $done (loop $lp
-                  (br_if $done (i32.eqz (local.get $i)))
-                  (local.set $i (i32.sub (local.get $i) (i32.const 1)))
-                  ;; limb is an unsigned 32-bit value held in an i64 lane.
-                  (local.set $limb (f64.convert_i64_u
-                    (i64.and (array.get $mag (local.get $m) (local.get $i)) (i64.const 0xffffffff))))
-                  ;; acc = acc * 2^32 + limb
-                  (local.set $acc (f64.add
-                    (f64.mul (local.get $acc) (f64.const 4294967296))
-                    (local.get $limb)))
-                  (br $lp)))
+                ;; significant bits of the top (non-zero) limb: 32 - clz32.
+                (local.set $toplimb
+                  (i64.and (array.get $mag (local.get $m) (i32.sub (local.get $len) (i32.const 1)))
+                           (i64.const 0xffffffff)))
+                (local.set $topbits
+                  (i32.sub (i32.const 32) (i32.clz (i32.wrap_i64 (local.get $toplimb)))))
+                (local.set $sigbits
+                  (i32.add (i32.mul (i32.sub (local.get $len) (i32.const 1)) (i32.const 32))
+                           (local.get $topbits)))
+                ;; s = max(0, sigbits - 64)
+                (local.set $s
+                  (if (result i32) (i32.gt_s (local.get $sigbits) (i32.const 64))
+                    (then (i32.sub (local.get $sigbits) (i32.const 64)))
+                    (else (i32.const 0))))
+                ;; word = s / 32, bit = s % 32: the boundary limb + sub-limb offset.
+                (local.set $word (i32.div_u (local.get $s) (i32.const 32)))
+                (local.set $bit (i64.extend_i32_u (i32.rem_u (local.get $s) (i32.const 32))))
+                ;; Read the three limbs that hold the top 64 bits: limbs
+                ;; word, word+1, word+2 (64 bits + offset bit spans <= 3 limbs).
+                ;; Out-of-range limb indices read as 0.
+                (local.set $l0
+                  (if (result i64) (i32.lt_u (local.get $word) (local.get $len))
+                    (then (i64.and (array.get $mag (local.get $m) (local.get $word)) (i64.const 0xffffffff)))
+                    (else (i64.const 0))))
+                (local.set $l1
+                  (if (result i64) (i32.lt_u (i32.add (local.get $word) (i32.const 1)) (local.get $len))
+                    (then (i64.and (array.get $mag (local.get $m) (i32.add (local.get $word) (i32.const 1))) (i64.const 0xffffffff)))
+                    (else (i64.const 0))))
+                (local.set $l2
+                  (if (result i64) (i32.lt_u (i32.add (local.get $word) (i32.const 2)) (local.get $len))
+                    (then (i64.and (array.get $mag (local.get $m) (i32.add (local.get $word) (i32.const 2))) (i64.const 0xffffffff)))
+                    (else (i64.const 0))))
+                ;; mreg = bits [s, s+64) = combine(l0,l1,l2) >> bit, as a u64.
+                ;;   term0 = l0 >> bit               (bit in [0,31])
+                ;;   term1 = l1 << (32 - bit)        (shift in [1,32])
+                ;;   term2 = l2 << (64 - bit), but 0 when bit == 0 (would be a
+                ;;           no-op shift-by-64 == shift-by-0 otherwise).
+                (local.set $mreg
+                  (i64.or
+                    (i64.or
+                      (i64.shr_u (local.get $l0) (local.get $bit))
+                      (i64.shl (local.get $l1) (i64.sub (i64.const 32) (local.get $bit))))
+                    (if (result i64) (i64.eqz (local.get $bit))
+                      (then (i64.const 0))
+                      (else (i64.shl (local.get $l2) (i64.sub (i64.const 64) (local.get $bit)))))))
+                ;; sticky = (dropped != 0), dropped = bits [0, s):
+                ;;   - every limb at index < word non-zero, plus
+                ;;   - the low `bit` bits of limb `word`.
+                (local.set $sticky (i32.const 0))
+                (if (i64.ne
+                      (i64.and (local.get $l0)
+                               (i64.sub (i64.shl (i64.const 1) (local.get $bit)) (i64.const 1)))
+                      (i64.const 0))
+                  (then (local.set $sticky (i32.const 1))))
+                (local.set $i (i32.const 0))
+                (block $sdone (loop $slp
+                  (br_if $sdone (i32.ge_u (local.get $i) (local.get $word)))
+                  (if (i64.ne (array.get $mag (local.get $m) (local.get $i)) (i64.const 0))
+                    (then (local.set $sticky (i32.const 1))))
+                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                  (br $slp)))
+                ;; Jam sticky into mreg's LSB, convert (rounds at bit 53,
+                ;; round-to-nearest-even — correct for a <= 64-bit value).
+                (local.set $v0
+                  (f64.convert_i64_u (i64.or (local.get $mreg) (i64.extend_i32_u (local.get $sticky)))))
+                ;; pow = 2^s as an EXACT f64. For s <= 1023 build it from the
+                ;; biased exponent field (s + 1023) << 52; for s >= 1024 it is
+                ;; +inf, so v0 * inf = inf (correct saturation; v0 > 0 always).
+                (local.set $pow
+                  (if (result f64) (i32.le_s (local.get $s) (i32.const 1023))
+                    (then (f64.reinterpret_i64
+                            (i64.shl (i64.add (i64.extend_i32_u (local.get $s)) (i64.const 1023))
+                                     (i64.const 52))))
+                    (else (f64.const inf))))
+                ;; result = (mreg jammed → f64) * 2^s, with the sign applied.
                 (if (result f64) (i32.lt_s (struct.get $aint $sign (local.get $a)) (i32.const 0))
-                  (then (f64.neg (local.get $acc)))
-                  (else (local.get $acc)))))))
+                  (then (f64.neg (f64.mul (local.get $v0) (local.get $pow))))
+                  (else (f64.mul (local.get $v0) (local.get $pow))))))))

--- a/src/codegen/wasm_gc/builtins/wat/to_index.wat
+++ b/src/codegen/wasm_gc/builtins/wat/to_index.wat
@@ -1,0 +1,23 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result i32)
+            (local $n i64)
+            ;; A Big index is necessarily out of bounds (no engine array spans
+            ;; 2^31 entries), so it maps to the OOB sentinel -1. A Small index
+            ;; in [0, 2^31) passes through as its i32 value; a negative or
+            ;; >= 2^31 Small is likewise -1. The caller bounds-checks
+            ;; `idx >= 0 (signed)` AND `idx < len (unsigned)`; -1 fails BOTH
+            ;; (signed: -1 < 0; unsigned: 0xffffffff >= len), so a Big or
+            ;; out-of-range index yields the VM's `Option.None` / bounds miss,
+            ;; never a wrapped in-range access.
+            (if (result i32) (ref.is_null (struct.get $aint $magf (local.get $a)))
+              (then
+                (local.set $n (struct.get $aint $small (local.get $a)))
+                (if (result i32)
+                    (i32.and
+                      (i64.ge_s (local.get $n) (i64.const 0))
+                      (i64.lt_s (local.get $n) (i64.const 0x80000000)))
+                  (then (i32.wrap_i64 (local.get $n)))
+                  (else (i32.const -1))))
+              (else (i32.const -1)))))

--- a/src/codegen/wasm_gc/lists.rs
+++ b/src/codegen/wasm_gc/lists.rs
@@ -560,6 +560,9 @@ impl ListHelperRegistry {
         string_eq_fn_idx: Option<u32>,
         eq_helper_fn_idx: &std::collections::HashMap<String, u32>,
         hash_helper_fn_idx: &std::collections::HashMap<String, u32>,
+        // bignum slice 3 — `__aint_eq` fn idx, `Some` under the flag, so the
+        // Int-element eq sites in contains/eq route through it.
+        aint_eq_fn_idx: Option<u32>,
     ) -> Result<(), WasmGcError> {
         for canonical in &self.list_order {
             // Order MUST match `assign_slots` and
@@ -581,6 +584,7 @@ impl ListHelperRegistry {
                     kind.clone(),
                     string_eq_fn_idx,
                     eq_helper_fn_idx,
+                    aint_eq_fn_idx,
                 )?);
                 if let (Some(eq_fn), Some(_hash_fn)) = (ops.eq, ops.hash) {
                     codes.function(&emit_list_eq(
@@ -590,6 +594,7 @@ impl ListHelperRegistry {
                         string_eq_fn_idx,
                         eq_fn,
                         eq_helper_fn_idx,
+                        aint_eq_fn_idx,
                     )?);
                     codes.function(&emit_list_hash(
                         canonical,
@@ -615,6 +620,7 @@ impl ListHelperRegistry {
                     kind.clone(),
                     string_eq_fn_idx,
                     eq_helper_fn_idx,
+                    aint_eq_fn_idx,
                 )?);
                 codes.function(&emit_vec_hash(
                     canonical,
@@ -690,6 +696,52 @@ enum ListEqKind {
     /// the canonical (whitespace-free) so the body emitter can look
     /// it up in the helper idx map at emit time.
     CarrierEq(String),
+}
+
+/// bignum slice 3 — emit Int-element EQUALITY for a List / Vector
+/// helper. Flag-off keeps the byte-identical `i64.eq`; flag-on (the
+/// `$AverInt` representation) routes through `__aint_eq` so two `$aint`
+/// refs compare by value across the Small/Big boundary instead of an
+/// `i64.eq` on a struct ref (which fails wasm validation outright — a
+/// latent slice-1/2 gap for every `Vector<Int>` / `List<Int>` program).
+/// `aint_eq_fn_idx` is `Some` exactly when `registry.bignum`.
+fn emit_int_elem_eq(
+    f: &mut Function,
+    registry: &TypeRegistry,
+    aint_eq_fn_idx: Option<u32>,
+) -> Result<(), WasmGcError> {
+    if registry.bignum {
+        let eq = aint_eq_fn_idx.ok_or(WasmGcError::Validation(
+            "bignum active but __aint_eq fn idx wasn't threaded into the list/vec eq helper".into(),
+        ))?;
+        f.instruction(&Instruction::Call(eq));
+    } else {
+        f.instruction(&Instruction::I64Eq);
+    }
+    Ok(())
+}
+
+/// bignum slice 3 — mix an Int element into a List / Vector HASH. The
+/// element must already be on the stack (an i64 flag-off, a `(ref null
+/// $aint)` flag-on). Flag-off keeps the byte-identical `i32.wrap_i64`;
+/// flag-on reads the `$small` field and wraps it. The hash is only ever
+/// used to bucket within the same wasm module (never compared
+/// cross-backend), so any deterministic projection is sound — `eq`
+/// disambiguates collisions, and a Big's `$small` is a stable constant.
+fn emit_int_elem_hash(f: &mut Function, registry: &TypeRegistry) -> Result<(), WasmGcError> {
+    if registry.bignum {
+        let aint_idx = registry.aint_struct_idx.ok_or(WasmGcError::Validation(
+            "bignum active but no $AverInt struct slot for the list/vec hash element".into(),
+        ))?;
+        f.instruction(&Instruction::StructGet {
+            struct_type_index: aint_idx,
+            field_index: 0,
+        });
+        f.instruction(&Instruction::I32WrapI64);
+    } else {
+        f.instruction(&Instruction::I32WrapI64);
+    }
+    Ok(())
 }
 
 fn list_eq_kind(elem: &str, registry: &TypeRegistry) -> Option<ListEqKind> {
@@ -1673,6 +1725,7 @@ fn emit_list_contains(
     kind: ListEqKind,
     string_eq_fn_idx: Option<u32>,
     eq_helper_fn_idx: &std::collections::HashMap<String, u32>,
+    aint_eq_fn_idx: Option<u32>,
 ) -> Result<Function, WasmGcError> {
     let list_idx = list_idx_of(canonical, registry)?;
     let list_ref = ValType::Ref(RefType {
@@ -1778,14 +1831,18 @@ fn emit_list_contains(
             });
             f.instruction(&Instruction::LocalGet(1));
             match &kind {
-                ListEqKind::I64 => f.instruction(&Instruction::I64Eq),
-                ListEqKind::F64 => f.instruction(&Instruction::F64Eq),
-                ListEqKind::I32 => f.instruction(&Instruction::I32Eq),
+                ListEqKind::I64 => emit_int_elem_eq(&mut f, registry, aint_eq_fn_idx)?,
+                ListEqKind::F64 => {
+                    f.instruction(&Instruction::F64Eq);
+                }
+                ListEqKind::I32 => {
+                    f.instruction(&Instruction::I32Eq);
+                }
                 ListEqKind::StringEq => {
                     let eq_fn = string_eq_fn_idx.ok_or(WasmGcError::Validation(
                         "List.contains over String/Char needs __wasmgc_string_eq registered".into(),
                     ))?;
-                    f.instruction(&Instruction::Call(eq_fn))
+                    f.instruction(&Instruction::Call(eq_fn));
                 }
                 ListEqKind::RecordEq(_) | ListEqKind::SumEq(_) | ListEqKind::CarrierEq(_) => {
                     unreachable!(
@@ -2214,6 +2271,7 @@ fn emit_list_eq(
     string_eq_fn_idx: Option<u32>,
     self_fn_idx: u32,
     eq_helper_fn_idx: &std::collections::HashMap<String, u32>,
+    aint_eq_fn_idx: Option<u32>,
 ) -> Result<Function, WasmGcError> {
     let list_idx = list_idx_of(canonical, registry)?;
     // params: 0 = la, 1 = lb. No locals — short body.
@@ -2246,7 +2304,7 @@ fn emit_list_eq(
     });
     match &kind {
         ListEqKind::I64 => {
-            f.instruction(&Instruction::I64Eq);
+            emit_int_elem_eq(&mut f, registry, aint_eq_fn_idx)?;
         }
         ListEqKind::F64 => {
             f.instruction(&Instruction::F64Eq);
@@ -2385,7 +2443,7 @@ fn emit_list_hash(
     let _ = elem;
     match &kind {
         ListEqKind::I64 => {
-            f.instruction(&Instruction::I32WrapI64);
+            emit_int_elem_hash(&mut f, registry)?;
         }
         ListEqKind::I32 => {} // bool — already i32
         ListEqKind::F64 => {
@@ -2658,6 +2716,7 @@ fn emit_vec_eq(
     kind: ListEqKind,
     string_eq_fn_idx: Option<u32>,
     eq_helper_fn_idx: &std::collections::HashMap<String, u32>,
+    aint_eq_fn_idx: Option<u32>,
 ) -> Result<Function, WasmGcError> {
     let (vec_idx, _) = vec_idx_of_pair(canonical, registry)?;
     // params: 0=va, 1=vb. locals: 2=len, 3=i.
@@ -2690,7 +2749,7 @@ fn emit_vec_eq(
     f.instruction(&Instruction::ArrayGet(vec_idx));
     match &kind {
         ListEqKind::I64 => {
-            f.instruction(&Instruction::I64Eq);
+            emit_int_elem_eq(&mut f, registry, aint_eq_fn_idx)?;
         }
         ListEqKind::F64 => {
             f.instruction(&Instruction::F64Eq);
@@ -2803,7 +2862,7 @@ fn emit_vec_hash(
     let _ = elem;
     match &kind {
         ListEqKind::I64 => {
-            f.instruction(&Instruction::I32WrapI64);
+            emit_int_elem_hash(&mut f, registry)?;
         }
         ListEqKind::I32 => {} // bool — already i32
         ListEqKind::F64 => {

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -207,6 +207,13 @@ pub(super) fn emit_module_with(
             BuiltinName::AintDivmod,
             BuiltinName::AintCmp,
             BuiltinName::AintEq,
+            // slice 3 — decimal parse / Float bridges / index extraction.
+            // Registered alongside the arithmetic prelude so the conversion
+            // + index re-point sites can assume the fn indices exist; -Oz
+            // strips the unused ones.
+            BuiltinName::AintToF64,
+            BuiltinName::AintFromF64,
+            BuiltinName::AintToIndex,
         ] {
             builtin_registry.register(b);
         }
@@ -2294,6 +2301,16 @@ pub(super) fn emit_module_with(
             eq_helpers_lookup.insert(canonical.clone(), h.eq);
         }
     }
+    // bignum slice 3 — capture the `__aint_eq` fn idx before
+    // `builtin_idx_lookup` is moved into `fn_map`, so the list/vec Int-
+    // element eq sites can route through it (an `i64.eq` on a `$AverInt`
+    // ref is invalid wasm — a latent slice-1/2 gap for any `Vector<Int>`
+    // / `List<Int>`).
+    let aint_eq_fn_idx = if registry.bignum {
+        builtin_idx_lookup.get("__aint_eq").copied()
+    } else {
+        None
+    };
     let fn_map = FnMap {
         by_id,
         builtins: builtin_idx_lookup,
@@ -2861,6 +2878,7 @@ pub(super) fn emit_module_with(
         string_eq_fn_idx,
         &eq_helper_fn_idx_map,
         &hash_helper_fn_idx_map,
+        aint_eq_fn_idx,
     )?;
 
     // Per-(record/sum) `__eq_<TypeName>` helper bodies — emit after

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -1451,6 +1451,50 @@ fn fn_body_calls_int_div(fd: &crate::ir::hir::ResolvedFnDef) -> bool {
 /// Int param is enough): the cost of a false positive is two unused
 /// type slots that `wasm-opt -Oz` would strip anyway; a false negative
 /// would be a miscompile, so we err toward inclusion.
+/// Builtins whose signature mentions `Int` (produce OR consume one), so a
+/// call to any of them must flip the bignum gate even in a module with no
+/// Int literal / arithmetic of its own. Kept in sync with the surface
+/// builtins that the wasm-gc backend lowers with an `Int` ValType on either
+/// side. Deliberately generous — a stray match is two stripped type slots,
+/// a miss is a wrapping-i64 miscompile of a `ℤ` value.
+fn builtin_touches_int(name: &str) -> bool {
+    matches!(
+        name,
+        // Int producers / consumers.
+        "Int.fromString"
+            | "Int.fromFloat"
+            | "Int.abs"
+            | "Int.min"
+            | "Int.max"
+            | "Int.div"
+            | "Int.mod"
+            | "Int.toFloat"
+            // Float/Int bridges.
+            | "Float.fromInt"
+            | "Float.floor"
+            | "Float.ceil"
+            | "Float.round"
+            // String <-> Int.
+            | "String.fromInt"
+            | "String.len"
+            | "String.length"
+            | "String.byteLength"
+            | "String.charAt"
+            // Char codepoints are Int.
+            | "Char.toCode"
+            | "Char.fromCode"
+            // Indexed collection ops carry an `Int` index / length.
+            | "Vector.len"
+            | "Vector.get"
+            | "Vector.set"
+            | "Vector.new"
+            | "List.len"
+            // Effect builtins returning Int.
+            | "Random.int"
+            | "Time.unixMs"
+    )
+}
+
 fn fn_uses_int_arithmetic(fd: &crate::ir::hir::ResolvedFnDef) -> bool {
     use crate::ir::hir::{ResolvedExpr, ResolvedFnBody, ResolvedStmt};
     if fd
@@ -1479,9 +1523,23 @@ fn fn_uses_int_arithmetic(fd: &crate::ir::hir::ResolvedFnDef) -> bool {
                     || walk(&l.node)
                     || walk(&r.node)
             }
-            ResolvedExpr::Call(_, args) | ResolvedExpr::Ctor(_, args) => {
-                args.iter().any(|a| walk(&a.node))
+            ResolvedExpr::Call(callee, args) => {
+                // A builtin that PRODUCES or CONSUMES an `Int` flips the gate
+                // even when the program has no Int literal / arithmetic of its
+                // own — e.g. a module whose only Int touch is
+                // `Int.fromString(s)` (returns `Result<Int,String>`) or
+                // `Int.fromFloat(f)`. Without this the `$AverInt` slots stay
+                // unallocated and the Int-producing helper silently lowers
+                // through the wrapping-i64 scalar path (a 38-digit string would
+                // parse to a wrapped value). Mirrors the "err toward inclusion"
+                // policy: a false positive is two stripped slots, a miss is a
+                // miscompile.
+                use crate::ir::hir::ResolvedCallee;
+                let int_builtin = matches!(callee,
+                    ResolvedCallee::Builtin(name) if builtin_touches_int(name));
+                int_builtin || args.iter().any(|a| walk(&a.node))
             }
+            ResolvedExpr::Ctor(_, args) => args.iter().any(|a| walk(&a.node)),
             ResolvedExpr::Match { subject, arms } => {
                 walk(&subject.node) || arms.iter().any(|a| walk(&a.body.node))
             }

--- a/tests/cross_backend_proptest.rs
+++ b/tests/cross_backend_proptest.rs
@@ -812,6 +812,107 @@ fn cross_int_float_exactness_vm_vs_wasm_gc() {
 }
 
 #[test]
+fn cross_float_from_int_rounding_vm_vs_wasm_gc() {
+    // `Float.fromInt` (Big → f64) must be CORRECTLY ROUNDED (round-to-nearest-
+    // even), bit-identical to the VM's `AverInt::to_f64` (which funnels through
+    // `num_bigint::BigInt::to_f64`). The earlier exactness test
+    // (`cross_int_float_exactness_vm_vs_wasm_gc`) only fed `Float.fromInt`
+    // EXACTLY-representable Bigs (2^63, 1e27-class), so it never exercised the
+    // rounding boundary. A high→low Horner accumulation (`acc = acc*2^32 + limb`
+    // in f64) double-rounds, diverging by 1 ULP on ~10% of >=3-limb magnitudes;
+    // this test feeds NON-representable >=3-limb Bigs (>= ~2^85) and asserts the
+    // round-trip `Int.fromFloat(Float.fromInt(big)) == big` matches the VM
+    // exactly. It FAILS on the pre-fix Horner helper and PASSES after the
+    // sticky-jam top-64-bits conversion (confirmed empirically in wasmtime).
+    //
+    // Inputs: the three cross-vendor counterexamples, plus a deterministic
+    // spread of >=3-limb magnitudes (both signs) including near-power-of-two
+    // and bit-53 tie/round boundary shapes, so the rounding decision is
+    // exercised in both directions (round up, round down, exact, tie-to-even).
+    let mut cases: Vec<String> = vec![
+        // Confirmed off-by-1-ULP counterexamples from two cross-vendor panels.
+        "38693363567040072931711122".to_string(),
+        "1842425632053114986489719067".to_string(),
+        "1204155011761264803879351098619922060".to_string(),
+        // Negative variants (sign applied after the correctly-rounded magnitude).
+        "-38693363567040072931711122".to_string(),
+        "-1204155011761264803879351098619922060".to_string(),
+        // Near power-of-two +/- 1 (>= 3 limbs): 2^85, 2^96, 2^127, 2^200.
+        "38685626227668133590597632".to_string(), // 2^85 (exact)
+        "38685626227668133590597631".to_string(), // 2^85 - 1
+        "79228162514264337593543950336".to_string(), // 2^96 (exact)
+        "79228162514264337593543950337".to_string(), // 2^96 + 1
+        "170141183460469231731687303715884105728".to_string(), // 2^127
+        "170141183460469231731687303715884105727".to_string(), // 2^127 - 1
+        // bit-53 tie/round boundary: ((2^53 + k) << s) and +/- a low bit, so
+        // round-to-nearest-even is forced both ways across the dropped bits.
+        "77371252455336267181195264".to_string(), // (2^53) << 33, exact
+        "77371252455336267181195265".to_string(), // + 1 (sticky -> round up?)
+        "77371252455336275771129856".to_string(), // (2^53) << 33 + 2^32 (half -> tie-even)
+        "77371252455336284361064448".to_string(), // (2^53 + 1) << 33
+        "618970019642690137449562112".to_string(), // (2^53) << 36
+        "618970019642690137449562113".to_string(), // + 1
+        // A long magnitude (>= 6 limbs) so the multi-limb sticky OR is hit.
+        "12345678901234567890123456789012345678901234567890".to_string(),
+        "-12345678901234567890123456789012345678901234567890".to_string(),
+    ];
+    // A deterministic LCG spread of >=3-limb magnitudes, both signs, so the
+    // 1-ULP divergence (which the Horner helper hit on ~10% of inputs) is very
+    // likely to be tripped by at least one case if the fix ever regresses.
+    let mut state: u128 = 0x9E37_79B9_7F4A_7C15;
+    for _ in 0..40 {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let hi = (state >> 64) as u64;
+        let lo = state as u64;
+        // 96..160-bit magnitude (>= 3 32-bit limbs), top bit forced set.
+        let mag = ((hi as u128) << 64) | (lo as u128) | (1u128 << 95);
+        let sign = if state & 1 == 0 { "" } else { "-" };
+        cases.push(format!("{sign}{mag}"));
+    }
+
+    // Render each through the round-trip `Int.fromFloat(Float.fromInt(big))`
+    // (the observable both panels used — avoids the unrelated huge-magnitude
+    // `String.fromFloat` trap). The VM is the ℤ oracle.
+    let body: String = cases
+        .iter()
+        .map(|c| format!("    Console.print(rt(\"{c}\"))"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let source = format!(
+        "module Tmp\n\n\
+         fn rt(s: String) -> String\n    \
+             match Int.fromString(s)\n        \
+                 Result.Ok(n) -> String.fromInt(Int.fromFloat(Float.fromInt(n)))\n        \
+                 Result.Err(e) -> e\n\
+         \n\
+         fn main()\n    ! [Console.print]\n{body}\n"
+    );
+
+    let vm =
+        run_vm("cross-flt-round-vm", &source).expect("VM must accept the float-rounding harness");
+    let wg = run_wasm_gc_bignum("cross-flt-round-wg", &source)
+        .expect("wasm-gc (bignum) must accept the float-rounding harness");
+    assert_eq!(
+        vm, wg,
+        "VM vs wasm-gc (bignum) diverged on Float.fromInt(Big) correct rounding \
+         (the round-trip Int.fromFloat(Float.fromInt(big)) drifted by >= 1 ULP)"
+    );
+    // Sanity: the corpus actually exercised >=3-limb Bigs (none collapsed to a
+    // trivially-agreeing Small) — every line is a long decimal, not "0".
+    assert_eq!(
+        vm.lines().count(),
+        cases.len(),
+        "line count mismatch (a case failed to render)"
+    );
+    assert!(
+        vm.lines().all(|l| l.trim_start_matches('-').len() > 18),
+        "expected every round-trip to render a past-i64 (>18 digit) magnitude"
+    );
+}
+
+#[test]
 fn cross_big_vector_index_oob_vm_vs_wasm_gc() {
     // A Big `Int` index into a `Vector` is necessarily out of bounds, so it
     // must behave as the VM's `Option.None` — NOT an `I32WrapI64`-truncated

--- a/tests/cross_backend_proptest.rs
+++ b/tests/cross_backend_proptest.rs
@@ -234,6 +234,17 @@ fn int_expr(max_depth: u32) -> BoxedStrategy<String> {
             (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("({} * {})", a, b)),
             // Unary minus — first-class `Expr::Neg` post-A1.
             inner.clone().prop_map(|a| format!("(-{})", a)),
+            // Euclidean `Int.div` / `Int.mod` (`Result<Int,String>`),
+            // rendered through the `Result` match so the generator stays
+            // Int-typed; `Int.abs` / `Int.min` / `Int.max` are Int directly.
+            // These exercise the slice-2 divmod + abs/min/max paths in the
+            // differential fuzz (the in-repo generator previously emitted
+            // only `+ - * neg`, so CI never fuzzed them).
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| int_div_mod_expr("div", &a, &b)),
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| int_div_mod_expr("mod", &a, &b)),
+            inner.clone().prop_map(|a| format!("Int.abs({})", a)),
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("Int.min({}, {})", a, b)),
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("Int.max({}, {})", a, b)),
             // `match` on a Bool with two Int arms. Forces backends to
             // agree on branch-typed evaluation and value plumbing
             // through arms (the wasm-gc `if` ↔ VM jump-table split).
@@ -246,6 +257,16 @@ fn int_expr(max_depth: u32) -> BoxedStrategy<String> {
         ]
     })
     .boxed()
+}
+
+/// Render `Int.div(a, b)` / `Int.mod(a, b)` as an Int-typed expression by
+/// unwrapping the `Result<Int,String>` through an inline `match`. The
+/// divide-by-zero `Err` arm yields `0` so the expression is total (the
+/// differential still compares the Ok values, and both backends agree on
+/// the `0` fallback for `b == 0`). Wrapped in parens so it drops into any
+/// expression position.
+fn int_div_mod_expr(op: &str, a: &str, b: &str) -> String {
+    format!("(match Int.{op}({a}, {b})\n    Result.Ok(__q) -> __q\n    Result.Err(__e) -> 0)")
 }
 
 /// Depth-bounded Int expression whose LEAVES deliberately include the
@@ -281,6 +302,15 @@ fn int_boundary_expr(max_depth: u32) -> BoxedStrategy<String> {
             (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("({} - {})", a, b)),
             (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("({} * {})", a, b)),
             inner.clone().prop_map(|a| format!("(-{})", a)),
+            // Euclidean div/mod (through the `Result` match) + abs/min/max,
+            // at the i64-boundary leaves — exercises the slice-2 limb long
+            // division + the `MIN/-1` no-overflow edge + abs/min/max across
+            // the Small/Big boundary under the bignum differential oracle.
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| int_div_mod_expr("div", &a, &b)),
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| int_div_mod_expr("mod", &a, &b)),
+            inner.clone().prop_map(|a| format!("Int.abs({})", a)),
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("Int.min({}, {})", a, b)),
+            (inner.clone(), inner.clone()).prop_map(|(a, b)| format!("Int.max({}, {})", a, b)),
         ]
     })
     .boxed()
@@ -635,6 +665,201 @@ fn cross_int_big_operand_divmod_vm_vs_wasm_gc() {
         assert_eq!(
             got, expected,
             "VM ℤ truth wrong for `{expr}`: got {got}, expected {expected}"
+        );
+    }
+}
+
+// ─── Decimal parse/format + Int<->Float/index exactness (slice 3) ───────────
+//
+// These cover the three slice-3 conversions whose wasm-gc lowering used to be
+// i64-only (`Int.fromString` wrapping past i64), saturating
+// (`Int.fromFloat`/`Float.fromInt` outside i64), or wrong (an `I32WrapI64`
+// of a Big `Vector` index into a wrong in-range slot). Under
+// `AVER_WASMGC_BIGNUM=1` they must match the VM (Int = ℤ) exactly. As with
+// the slice-1/2 focused tests, the render goes through BOTH `String.fromInt`
+// AND `"{...}"` interpolation where applicable so neither blind spot hides a
+// divergence.
+
+#[test]
+fn cross_int_from_string_roundtrip_vm_vs_wasm_gc() {
+    // `String.fromInt(Int.fromString(s)) == s` for magnitudes well past i64
+    // (both signs), plus invalid-input error-message parity. The 38-digit
+    // value is `i64::MAX * i64::MAX` — the headline acceptance.
+    let ok_cases: &[&str] = &[
+        "0",
+        "1",
+        "-1",
+        "9223372036854775807",                     // i64::MAX
+        "9223372036854775808",                     // i64::MAX + 1 (Big)
+        "-9223372036854775808",                    // i64::MIN
+        "-9223372036854775809",                    // i64::MIN - 1 (Big)
+        "85070591730234615847396907784232501249",  // i64::MAX^2 (38 digits)
+        "-85070591730234615847396907784232501249", // negative, Big
+        "170141183460469231731687303715884105728", // 2^127 (39 digits)
+    ];
+    // Helpers do the `Result` match (an inline `match` inside a call arg
+    // doesn't parse); `main` just prints. `fs` reformats the parse, `rt`
+    // observes the round-trip equality `fromInt(fromString(s)) == orig` via
+    // `==` (an Int mis-stored as Small/Big still `String.fromInt`-renders the
+    // same decimal, so the explicit `==` is the real canonical-invariant check).
+    let mut lines = String::new();
+    for s in ok_cases {
+        lines.push_str(&format!("    Console.print(fs(\"{s}\"))\n"));
+        lines.push_str(&format!("    Console.print(rt(\"{s}\", \"{s}\"))\n"));
+    }
+    // Invalid-input → `Err` message parity (must be byte-identical to the VM).
+    let bad_cases: &[&str] = &[" 5", "5 ", "", "-", "+", "0x10", "1.5", "--5", "abc", "12a"];
+    for s in bad_cases {
+        lines.push_str(&format!("    Console.print(fs(\"{s}\"))\n"));
+    }
+    let source = format!(
+        "module Tmp\n\n\
+         fn fs(s: String) -> String\n    \
+             match Int.fromString(s)\n        \
+                 Result.Ok(n) -> String.fromInt(n)\n        \
+                 Result.Err(e) -> e\n\
+         \n\
+         fn rt(s: String, orig: String) -> String\n    \
+             match Int.fromString(s)\n        \
+                 Result.Ok(n) -> String.fromBool(String.fromInt(n) == orig)\n        \
+                 Result.Err(e) -> e\n\
+         \n\
+         fn main()\n    ! [Console.print]\n{}\n",
+        lines.trim_end()
+    );
+
+    let vm = run_vm("cross-fs-vm", &source).expect("VM must accept the fromString harness");
+    let wg = run_wasm_gc_bignum("cross-fs-wg", &source)
+        .expect("wasm-gc (bignum) must accept the fromString harness");
+    assert_eq!(
+        vm, wg,
+        "VM vs wasm-gc (bignum) diverged on Int.fromString parse/format/error parity"
+    );
+    // The round-trip-equality lines (every other line in the Ok block) must
+    // all be `true` on the VM ℤ oracle — proof the corpus actually exercised
+    // past-i64 round-trips rather than trivially agreeing.
+    let rt_true = vm.lines().filter(|l| *l == "true").count();
+    assert_eq!(
+        rt_true,
+        ok_cases.len(),
+        "expected one `true` round-trip line per Ok case (got {rt_true}); \
+         a past-i64 round-trip silently failed"
+    );
+}
+
+#[test]
+fn cross_int_float_exactness_vm_vs_wasm_gc() {
+    // `Float.fromInt` (±inf saturation) and `Int.fromFloat` (exact Big /
+    // non-finite → 0) must match the VM. Big values are built by arithmetic
+    // (the lexer rejects > i64 literals — a separate follow-up). The
+    // observables avoid `String.fromFloat` on huge magnitudes (a pre-existing
+    // wasm-gc trap, unrelated to slice 3): we render Bool comparisons and
+    // the exact Int round-trip via `String.fromInt`.
+    let cases: &[(&str, &str)] = &[
+        // Float.fromInt(Big) compared against a Float threshold (observable
+        // without String.fromFloat): 2^63 > 1e9.
+        (
+            "String.fromBool(Float.fromInt(9223372036854775807 + 1) > 1000000000.0)",
+            "true",
+        ),
+        // Round-trip: Int.fromFloat(Float.fromInt(2^63)) == 2^63 exactly.
+        (
+            "String.fromInt(Int.fromFloat(Float.fromInt(9223372036854775807 + 1)))",
+            "9223372036854775808",
+        ),
+        // Negative Big round-trip.
+        (
+            "String.fromInt(Int.fromFloat(Float.fromInt(0 - (9223372036854775807 + 1))))",
+            "-9223372036854775808",
+        ),
+        // Int.fromFloat of a huge finite float (1e27, built by Float mult) is
+        // an EXACT Big — matches the VM's BigInt::from_f64 rounding.
+        (
+            "String.fromInt(Int.fromFloat(1000000000.0 * 1000000000.0 * 1000000000.0))",
+            "1000000000000000013287555072",
+        ),
+        // Int.fromFloat of a Small-range float stays Small.
+        ("String.fromInt(Int.fromFloat(42.9))", "42"),
+        ("String.fromInt(Int.fromFloat(-42.9))", "-42"),
+        // Float.fromInt of a Small round-trips.
+        (
+            "String.fromBool(Int.fromFloat(Float.fromInt(123456789)) == 123456789)",
+            "true",
+        ),
+    ];
+    let body: String = cases
+        .iter()
+        .map(|(expr, _)| format!("    Console.print({expr})"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let source = format!("module Tmp\n\nfn main()\n    ! [Console.print]\n{body}\n");
+
+    let vm = run_vm("cross-flt-vm", &source).expect("VM must accept the float-exactness harness");
+    let wg = run_wasm_gc_bignum("cross-flt-wg", &source)
+        .expect("wasm-gc (bignum) must accept the float-exactness harness");
+    assert_eq!(
+        vm, wg,
+        "VM vs wasm-gc (bignum) diverged on Int<->Float exactness"
+    );
+    let vm_lines: Vec<&str> = vm.lines().collect();
+    assert_eq!(vm_lines.len(), cases.len(), "line count mismatch");
+    for ((expr, expected), got) in cases.iter().zip(vm_lines.iter()) {
+        assert_eq!(
+            got, expected,
+            "VM ℤ truth wrong for `{expr}`: got {got}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn cross_big_vector_index_oob_vm_vs_wasm_gc() {
+    // A Big `Int` index into a `Vector` is necessarily out of bounds, so it
+    // must behave as the VM's `Option.None` — NOT an `I32WrapI64`-truncated
+    // in-range access. Covers Vector.get (boxed) + the negative-index lower
+    // bound. The index is built by arithmetic so it overflows i64 into a Big.
+    // (index-expr, expected). The helper `vg` does the bounds-checked
+    // `Vector.get` + `Option` match (a 3-element vector of `7`s).
+    let cases: &[(&str, &str)] = &[
+        // Big positive index → None.
+        ("9223372036854775807 + 1", "none"),
+        // Big negative index → None.
+        ("0 - (9223372036854775807 + 1)", "none"),
+        // Plain negative index → None.
+        ("0 - 1", "none"),
+        // In-range index still works (the fix must not break valid access).
+        ("1", "7"),
+        // An index that would WRAP to an in-range i32 if truncated
+        // (`2^32 + 1` `I32WrapI64`s to `1`) must still be None.
+        ("4294967296 + 1", "none"),
+    ];
+    let body: String = cases
+        .iter()
+        .map(|(expr, _)| format!("    Console.print(vg({expr}))"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let source = format!(
+        "module Tmp\n\n\
+         fn vg(i: Int) -> String\n    \
+             match Vector.get(Vector.new(3, 7), i)\n        \
+                 Option.Some(x) -> String.fromInt(x)\n        \
+                 Option.None -> \"none\"\n\
+         \n\
+         fn main()\n    ! [Console.print]\n{body}\n"
+    );
+
+    let vm = run_vm("cross-bigidx-vm", &source).expect("VM must accept the big-index harness");
+    let wg = run_wasm_gc_bignum("cross-bigidx-wg", &source)
+        .expect("wasm-gc (bignum) must accept the big-index harness");
+    assert_eq!(
+        vm, wg,
+        "VM vs wasm-gc (bignum) diverged on Big-Vector-index out-of-bounds"
+    );
+    let vm_lines: Vec<&str> = vm.lines().collect();
+    assert_eq!(vm_lines.len(), cases.len(), "line count mismatch");
+    for ((expr, expected), got) in cases.iter().zip(vm_lines.iter()) {
+        assert_eq!(
+            got, expected,
+            "VM ℤ truth wrong for index `{expr}`: got {got}, expected {expected}"
         );
     }
 }


### PR DESCRIPTION
Slice 3 of making the wasm-gc backend faithful to `Int = ℤ`. Builds on slice 1 (#521, arithmetic) + slice 2 (#524, Euclidean div/mod). Still **entirely behind the opt-in `AVER_WASMGC_BIGNUM` flag — the default path is byte-identical** (calculator / lists / hello wasm SHA-256 match a base build).

## Scope — decimal parse/format + Int↔Float / index exactness
- **`Int.fromString`** (`wat/from_string.wat`): limb-accumulating decimal parse (`acc = acc*10 + digit`) — a 38-digit string now round-trips to the exact `$AverInt`. Invalid-input `Result.Err` message matches the VM byte-for-byte.
- **`Float.fromInt` / `Int.fromFloat`** (`wat/to_f64.wat`, `wat/from_f64.wat`): exact, replacing the saturating `I64TruncF64S` / `F64ConvertI64S` (wrong outside i64). `Int.fromFloat`: non-finite→0, in-range→Small, huge-finite→exact Big from the IEEE mantissa/exponent. `Float.fromInt`: Horner over limbs, ±inf saturation. Also re-points `Float.floor/ceil/round`.
- **`Vector` index** (`wat/to_index.wat`): a Big (or out-of-`[0, 2^31)`) Int index → out-of-bounds (`Option.None`), not a wrapped in-range access. All 5 index sites (get/set boxed, set-or-default, fused get-literal, `Vector.new` size) re-pointed off `I32WrapI64`.
- Gate fix: a `fromString`-only / `fromFloat`-only module now activates the bignum slots (was silently lowering through the wrapping-i64 scalar parse).

## Latent slice-1/2 bug fixed
`List<Int>` / `Vector<Int>` element **eq** emitted `i64.eq` and **hash** `i32.wrap_i64` on an `$AverInt` ref → invalid wasm; every such program failed validation under the flag. Now eq → `__aint_eq`, hash → the `$small` field.

## Known gap (pre-flip, NOT in slice 3)
Map-with-Int-keys, record/sum-with-Int-field eq, and Set still use `i64.eq` / i64-hash under the flag — they would mis-handle Big Int. This is a slice-1/2 completion item (thread `__aint_eq`/`__aint_cmp` + a new `__aint_hash` across the eq/hash registries) to close **before the slice-4 default flip**. Flagged here so it isn't forgotten; it does not affect the default path or slice 3's deliverables.

## Verification (two-phase — cargo-green is necessary but not sufficient)
- **Phase 2 (wasmtime):** `Int.fromString("85070591730234615847396907784232501249")` equals `9223372036854775807 * 9223372036854775807` on both backends; `String.fromInt(Int.fromString(s)) == s` for several >i64 magnitudes both signs; invalid-input error parity. `Int.fromFloat(1e27)` = exact `1000000000000000013287555072`; `Int.fromFloat(Float.fromInt(2^63))` round-trips to `9223372036854775808`. Big positive/negative + wrap-to-in-range Vector indices → `Option.None`; in-range index returns the element.
- New permanent differential tests (fromString round-trip + error parity, fromFloat/toFloat exactness, big-index OOB); the random int generator now also emits `Int.div/mod/abs/min/max`; both WAT guard tests (parse + full-validator) extended to the new helpers.
- `cargo test` wasm_gc green; `cargo fmt --check` + `cargo clippy --features wasm,wasip2 -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)