### PR TITLE
wasm-gc: bignum-aware Int eq+hash for Map/Set keys, record/sum fields, container payloads

### DIFF
--- a/src/codegen/wasm_gc/body/eq_helpers.rs
+++ b/src/codegen/wasm_gc/body/eq_helpers.rs
@@ -713,6 +713,14 @@ fn emit_inner_eq_dispatch(
         inner.to_string()
     };
     match resolved.as_str() {
+        // bignum slice 4 (eq+hash gap) — a GENUINE `Int` payload lowers to
+        // `$aint` under bignum → `__aint_eq` (an `i64.eq` on a ref is
+        // invalid wasm and wrong across Small/Big). A newtype-erased Int
+        // (`resolved == "Int"` but `inner != "Int"`) stays a scalar i64 →
+        // `i64.eq`. Both byte-identical flag-off.
+        "Int" if inner.trim() == "Int" => {
+            super::super::lists::emit_aint_field_eq(f, registry)?;
+        }
         "Int" => {
             f.instruction(&Instruction::I64Eq);
         }

--- a/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
+++ b/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
@@ -701,8 +701,36 @@ pub(crate) fn emit_mir_int_cascade(
     if emit_mir_expr(func, subject, slots, ctx)?.is_none() {
         return Ok(None);
     }
-    func.instruction(&Instruction::I64Const(*pat_lit));
-    func.instruction(&Instruction::I64Eq);
+    // bignum slice 4 (eq+hash gap) — under the flag the subject is an
+    // `$aint` ref, so the literal must be lifted to a Small `$aint`
+    // (`__aint_from_i64`) and compared with `__aint_eq`. The flag-off path
+    // stays the byte-identical `i64.const` + `i64.eq`. Without this, an
+    // Int-literal `match` (`match n { 0 -> …, _ -> … }`) emits an `i64.eq`
+    // on a struct ref — invalid wasm.
+    if ctx.registry.bignum {
+        let from_i64 =
+            ctx.fn_map
+                .builtins
+                .get("__aint_from_i64")
+                .copied()
+                .ok_or(WasmGcError::Validation(
+                    "bignum active but __aint_from_i64 helper not registered".into(),
+                ))?;
+        let eq = ctx
+            .fn_map
+            .builtins
+            .get("__aint_eq")
+            .copied()
+            .ok_or(WasmGcError::Validation(
+                "bignum active but __aint_eq helper not registered".into(),
+            ))?;
+        func.instruction(&Instruction::I64Const(*pat_lit));
+        func.instruction(&Instruction::Call(from_i64));
+        func.instruction(&Instruction::Call(eq));
+    } else {
+        func.instruction(&Instruction::I64Const(*pat_lit));
+        func.instruction(&Instruction::I64Eq);
+    }
     func.instruction(&Instruction::If(block_ty));
     if emit_mir_expr(func, body, slots, ctx)?.is_none() {
         return Ok(None);

--- a/src/codegen/wasm_gc/body/hash_helpers.rs
+++ b/src/codegen/wasm_gc/body/hash_helpers.rs
@@ -642,6 +642,13 @@ fn emit_inner_hash_dispatch(
         inner.to_string()
     };
     match resolved.as_str() {
+        // bignum slice 4 (eq+hash gap) — a GENUINE `Int` payload lowers to
+        // `$aint` under bignum → `__aint_hash` (agrees with `__aint_eq`,
+        // and an `i32.wrap_i64` on a ref is invalid wasm). A newtype-erased
+        // Int stays a scalar i64 → wrap. Byte-identical flag-off.
+        "Int" if inner.trim() == "Int" => {
+            super::super::lists::emit_aint_field_hash(f, registry)?;
+        }
         "Int" => {
             f.instruction(&Instruction::I32WrapI64);
         }

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -454,6 +454,25 @@ pub(super) fn emit_aint_eq(registry: &TypeRegistry) -> Result<Function, WasmGcEr
     wat_helper::compile_wat_helper(&wat)
 }
 
+/// `__aint_hash(a) -> i32`. Equal `$AverInt` values MUST hash equal —
+/// the Eq/Hash agreement Map/Set keys and record/sum fields rely on. A
+/// Small folds its i64 `$small` to i32 (`s ^ (s >>> 32)`, then wrap); a
+/// Big DJB2-folds its 32-bit limb magnitude and mixes the sign. The
+/// canonical invariant guarantees a Small and a Big are never equal, so
+/// the two schemes need not agree across the boundary — only equal
+/// Smalls (same `$small`) and equal Bigs (same sign + same limbs) must
+/// collide, which they do. Self-contained: no inter-helper `call`, so
+/// `compile_wat_helper`'s single-function discipline holds. Unlike the
+/// slice-3 `$small`-field projection (where every Big collapses to
+/// `$small == 0` and all Big keys collide into one bucket), this gives
+/// Big keys a real distribution — relevant for `Map<Int, V>` / `Set<Int>`
+/// holding many distinct Big keys.
+pub(super) fn emit_aint_hash(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(include_str!("wat/hash.wat"), decls = decls);
+    wat_helper::compile_wat_helper(&wat)
+}
+
 /// `__aint_cmp(a, b) -> i32` (-1/0/1). Sign first, then unsigned
 /// magnitude (flipped for two negatives). Mirrors `AverInt::cmp`.
 pub(super) fn emit_aint_cmp(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
@@ -823,6 +842,7 @@ mod tests {
             ("emit_aint_neg", emit_aint_neg),
             ("emit_aint_abs", emit_aint_abs),
             ("emit_aint_eq", emit_aint_eq),
+            ("emit_aint_hash", emit_aint_hash),
             ("emit_aint_cmp", emit_aint_cmp),
             ("emit_aint_add", emit_aint_add),
             ("emit_aint_sub", emit_aint_sub),
@@ -885,6 +905,13 @@ mod validation_guard {
             // builder, the ±inf saturating Float path) is exactly the class
             // the parse-only guard cannot catch, so validate the full module.
             ("__aint_from_string", render_from_string(&registry)),
+            // slice 4 (eq+hash gap) — `__aint_hash` has a limb-fold loop +
+            // a Small/Big branch returning i32 on both arms; validate the
+            // full module so a stack-type slip fails at `cargo test`.
+            (
+                "__aint_hash",
+                render_simple(&registry, include_str!("wat/hash.wat")),
+            ),
             (
                 "__aint_to_f64",
                 render_simple(&registry, include_str!("wat/to_f64.wat")),

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -170,6 +170,10 @@ pub(super) enum BuiltinName {
     AintCmp,
     /// `__aint_eq(a, b) -> i32` (1/0) — equality leaning on canonical form.
     AintEq,
+    /// `__aint_hash(a) -> i32` — value hash agreeing with `__aint_eq`
+    /// (equal values hash equal). Map/Set Int keys + record/sum Int
+    /// fields under bignum. slice 4 (eq+hash gap).
+    AintHash,
     // ── bignum slice 3 — decimal parse / Float bridges / index ─────────
     /// `__aint_to_f64(a) -> f64` — `Float.fromInt` (±inf saturation). slice 3.
     AintToF64,
@@ -245,6 +249,7 @@ impl BuiltinName {
             Self::AintDivmod => "__aint_divmod",
             Self::AintCmp => "__aint_cmp",
             Self::AintEq => "__aint_eq",
+            Self::AintHash => "__aint_hash",
             Self::AintToF64 => "__aint_to_f64",
             Self::AintFromF64 => "__aint_from_f64",
             Self::AintToIndex => "__aint_to_index",
@@ -290,7 +295,7 @@ impl BuiltinName {
             Self::AintAdd | Self::AintSub | Self::AintMul | Self::AintCmp | Self::AintEq => {
                 Ok(vec![aint_ref_ty(registry)?, aint_ref_ty(registry)?])
             }
-            Self::AintNeg | Self::AintAbs => Ok(vec![aint_ref_ty(registry)?]),
+            Self::AintNeg | Self::AintAbs | Self::AintHash => Ok(vec![aint_ref_ty(registry)?]),
             // `want_mod` selects modulo (≠0) vs division (0).
             Self::AintDivmod => Ok(vec![
                 aint_ref_ty(registry)?,
@@ -336,7 +341,9 @@ impl BuiltinName {
             | Self::AintAbs
             | Self::AintDivmod
             | Self::AintFromF64 => Ok(vec![aint_ref_ty(registry)?]),
-            Self::AintCmp | Self::AintEq | Self::AintToIndex => Ok(vec![ValType::I32]),
+            Self::AintCmp | Self::AintEq | Self::AintHash | Self::AintToIndex => {
+                Ok(vec![ValType::I32])
+            }
             Self::AintToF64 => Ok(vec![ValType::F64]),
         }
     }
@@ -383,6 +390,7 @@ impl BuiltinName {
             Self::AintDivmod => bignum::emit_aint_divmod(registry),
             Self::AintCmp => bignum::emit_aint_cmp(registry),
             Self::AintEq => bignum::emit_aint_eq(registry),
+            Self::AintHash => bignum::emit_aint_hash(registry),
             Self::AintToF64 => bignum::emit_aint_to_f64(registry),
             Self::AintFromF64 => bignum::emit_aint_from_f64(registry),
             Self::AintToIndex => bignum::emit_aint_to_index(registry),

--- a/src/codegen/wasm_gc/builtins/wat/hash.wat
+++ b/src/codegen/wasm_gc/builtins/wat/hash.wat
@@ -1,0 +1,38 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result i32)
+            (local $m (ref null $mag))
+            (local $i i32) (local $n i32) (local $h i32) (local $s i64) (local $limb i64)
+            (local.set $m (struct.get $aint $magf (local.get $a)))
+            (if (result i32) (ref.is_null (local.get $m))
+              (then
+                ;; Small — fold the i64 `$small` to i32: (s ^ (s >>> 32)),
+                ;; then wrap. Distributes both halves of the 64-bit value.
+                (local.set $s (struct.get $aint $small (local.get $a)))
+                (i32.wrap_i64 (i64.xor (local.get $s) (i64.shr_u (local.get $s) (i64.const 32)))))
+              (else
+                ;; Big — DJB2-style fold over the 32-bit limb magnitude,
+                ;; then mix the sign in. The canonical invariant guarantees
+                ;; a Big never equals a Small, so the two schemes need not
+                ;; agree; equal Bigs share sign + limbs ⇒ same hash.
+                (local.set $h (i32.const 5381))
+                (local.set $n (array.len (local.get $m)))
+                (local.set $i (i32.const 0))
+                (block $done (loop $lp
+                  (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+                  (local.set $limb (array.get $mag (local.get $m) (local.get $i)))
+                  ;; h = h * 33 + low32(limb)
+                  (local.set $h (i32.add
+                    (i32.add (i32.shl (local.get $h) (i32.const 5)) (local.get $h))
+                    (i32.wrap_i64 (local.get $limb))))
+                  ;; h = h * 33 + high32(limb)
+                  (local.set $h (i32.add
+                    (i32.add (i32.shl (local.get $h) (i32.const 5)) (local.get $h))
+                    (i32.wrap_i64 (i64.shr_u (local.get $limb) (i64.const 32)))))
+                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                  (br $lp)))
+                ;; mix sign (-1 / +1; Big is never zero-magnitude canonical)
+                (i32.add
+                  (i32.add (i32.shl (local.get $h) (i32.const 5)) (local.get $h))
+                  (struct.get $aint $sign (local.get $a)))))))

--- a/src/codegen/wasm_gc/lists.rs
+++ b/src/codegen/wasm_gc/lists.rs
@@ -721,23 +721,58 @@ fn emit_int_elem_eq(
     Ok(())
 }
 
-/// bignum slice 3 — mix an Int element into a List / Vector HASH. The
-/// element must already be on the stack (an i64 flag-off, a `(ref null
-/// $aint)` flag-on). Flag-off keeps the byte-identical `i32.wrap_i64`;
-/// flag-on reads the `$small` field and wraps it. The hash is only ever
-/// used to bucket within the same wasm module (never compared
-/// cross-backend), so any deterministic projection is sound — `eq`
-/// disambiguates collisions, and a Big's `$small` is a stable constant.
+/// bignum slice 3 / slice 4 — mix an Int element into a List / Vector
+/// HASH. The element must already be on the stack (an i64 flag-off, a
+/// `(ref null $aint)` flag-on). Flag-off keeps the byte-identical
+/// `i32.wrap_i64`; flag-on routes through `__aint_hash` (slice 4),
+/// matching every other structural Int-hash site and giving Big elements
+/// a real distribution. (Slice 3 originally read just the `$small`
+/// field, which is correct — `eq` disambiguates — but collapsed every
+/// Big to one bucket; `__aint_hash` removes that pathology uniformly.)
 fn emit_int_elem_hash(f: &mut Function, registry: &TypeRegistry) -> Result<(), WasmGcError> {
+    emit_aint_field_hash(f, registry)
+}
+
+/// bignum slice 4 (eq+hash gap) — emit Int EQUALITY for a structural
+/// site (record/sum field, Map key, Map value, carrier payload) that
+/// already has two operands on the stack. Flag-off keeps the
+/// byte-identical `i64.eq`; flag-on routes through `__aint_eq` (the fn
+/// idx now recorded on the registry by `module.rs`) so two `$aint` refs
+/// compare by value across the Small/Big boundary. An `i64.eq` on a
+/// `$AverInt` ref is invalid wasm — the gap this closes for
+/// `Map<Int,V>` keys / `Set<Int>` / record-and-sum Int fields, the
+/// sibling of the slice-3 `List`/`Vector` fix.
+pub(super) fn emit_aint_field_eq(
+    f: &mut Function,
+    registry: &TypeRegistry,
+) -> Result<(), WasmGcError> {
     if registry.bignum {
-        let aint_idx = registry.aint_struct_idx.ok_or(WasmGcError::Validation(
-            "bignum active but no $AverInt struct slot for the list/vec hash element".into(),
+        let eq = registry.aint_eq_fn_idx.ok_or(WasmGcError::Validation(
+            "bignum active but __aint_eq fn idx wasn't recorded on the registry".into(),
         ))?;
-        f.instruction(&Instruction::StructGet {
-            struct_type_index: aint_idx,
-            field_index: 0,
-        });
-        f.instruction(&Instruction::I32WrapI64);
+        f.instruction(&Instruction::Call(eq));
+    } else {
+        f.instruction(&Instruction::I64Eq);
+    }
+    Ok(())
+}
+
+/// bignum slice 4 (eq+hash gap) — emit Int HASH for a structural site
+/// whose single Int operand is already on the stack (an i64 flag-off, a
+/// `(ref null $aint)` flag-on). Flag-off keeps the byte-identical
+/// `i32.wrap_i64`; flag-on routes through `__aint_hash`, which agrees
+/// with `__aint_eq` (equal values hash equal) AND gives Big keys a real
+/// distribution instead of collapsing every Big to `$small == 0`. An
+/// `i32.wrap_i64` on a `$AverInt` ref is invalid wasm.
+pub(super) fn emit_aint_field_hash(
+    f: &mut Function,
+    registry: &TypeRegistry,
+) -> Result<(), WasmGcError> {
+    if registry.bignum {
+        let h = registry.aint_hash_fn_idx.ok_or(WasmGcError::Validation(
+            "bignum active but __aint_hash fn idx wasn't recorded on the registry".into(),
+        ))?;
+        f.instruction(&Instruction::Call(h));
     } else {
         f.instruction(&Instruction::I32WrapI64);
     }
@@ -1922,7 +1957,7 @@ pub(super) fn emit_record_eq_inline(
         // emit per-field eq → i32
         match field_ty.trim() {
             "Int" => {
-                f.instruction(&Instruction::I64Eq);
+                emit_aint_field_eq(f, registry)?;
             }
             "Bool" => {
                 f.instruction(&Instruction::I32Eq);
@@ -2038,7 +2073,7 @@ pub(super) fn emit_sum_eq_inline(
                 });
                 match field_ty.trim() {
                     "Int" => {
-                        f.instruction(&Instruction::I64Eq);
+                        emit_aint_field_eq(f, registry)?;
                     }
                     "Bool" => {
                         f.instruction(&Instruction::I32Eq);
@@ -2599,6 +2634,13 @@ fn emit_sum_inline_hash(
                 field_ty.trim().to_string()
             };
             match resolved.as_str() {
+                // A GENUINE `Int` field lowers to `$aint` under bignum →
+                // `__aint_hash`; a newtype-erased Int (`resolved == "Int"`
+                // but `field_ty != "Int"`) stays a scalar i64 → wrap. Both
+                // are byte-identical flag-off.
+                "Int" if field_ty.trim() == "Int" => {
+                    emit_aint_field_hash(f, registry)?;
+                }
                 "Int" => {
                     f.instruction(&Instruction::I32WrapI64);
                 }
@@ -2675,6 +2717,12 @@ fn emit_record_inline_hash(
             field_type.trim().to_string()
         };
         match resolved.as_str() {
+            // Genuine `Int` field → `$aint` under bignum → `__aint_hash`;
+            // newtype-erased Int stays scalar i64 → wrap. Byte-identical
+            // flag-off.
+            "Int" if field_type.trim() == "Int" => {
+                emit_aint_field_hash(f, registry)?;
+            }
             "Int" => {
                 f.instruction(&Instruction::I32WrapI64);
             }

--- a/src/codegen/wasm_gc/maps.rs
+++ b/src/codegen/wasm_gc/maps.rs
@@ -766,7 +766,7 @@ fn emit_hash_for(
         return emit_hash_record(k_aver, registry, string_key_helpers, all_key_helpers);
     }
     if super::types::TypeRegistry::is_primitive_map_key(k_aver) {
-        return emit_hash_primitive(k_aver);
+        return emit_hash_primitive(k_aver, registry);
     }
     if registry
         .variants
@@ -817,7 +817,7 @@ fn emit_eq_for(
         return emit_eq_record(k_aver, registry, string_key_helpers, all_key_helpers);
     }
     if super::types::TypeRegistry::is_primitive_map_key(k_aver) {
-        return emit_eq_primitive(k_aver);
+        return emit_eq_primitive(k_aver, registry);
     }
     if registry
         .variants
@@ -859,15 +859,18 @@ fn emit_eq_for(
 /// primitives (callers don't have to box just to compute a hash).
 /// Map's keys array stores boxed refs, but `hash` runs on the raw
 /// value the user passed in.
-fn emit_hash_primitive(k_aver: &str) -> Result<Function, WasmGcError> {
+fn emit_hash_primitive(k_aver: &str, registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let mut f = Function::new([]);
     f.instruction(&Instruction::LocalGet(0));
     match k_aver {
         "Int" => {
-            // i32.wrap_i64 — keeps low 32 bits. Cheap, distributes
-            // poorly for tightly-clustered Int domains; bench
-            // scenarios don't stress this.
-            f.instruction(&Instruction::I32WrapI64);
+            // Flag-off: `i32.wrap_i64` — keeps low 32 bits. Cheap,
+            // distributes poorly for tightly-clustered Int domains; bench
+            // scenarios don't stress this. Flag-on (bignum): the key is an
+            // `$aint` ref, so route through `__aint_hash` (an
+            // `i32.wrap_i64` on a ref is invalid wasm, and all Big keys
+            // would otherwise collapse into one bucket).
+            super::lists::emit_aint_field_hash(&mut f, registry)?;
         }
         "Float" => {
             f.instruction(&Instruction::I64ReinterpretF64);
@@ -889,14 +892,23 @@ fn emit_hash_primitive(k_aver: &str) -> Result<Function, WasmGcError> {
 
 /// `eq : (K_raw, K_raw) -> i32` for primitive K. Native eq
 /// instruction per K kind.
-fn emit_eq_primitive(k_aver: &str) -> Result<Function, WasmGcError> {
+fn emit_eq_primitive(k_aver: &str, registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let mut f = Function::new([]);
     f.instruction(&Instruction::LocalGet(0));
     f.instruction(&Instruction::LocalGet(1));
     match k_aver {
-        "Int" => f.instruction(&Instruction::I64Eq),
-        "Float" => f.instruction(&Instruction::F64Eq),
-        "Bool" => f.instruction(&Instruction::I32Eq),
+        // Flag-on (bignum): keys are `$aint` refs → `__aint_eq` (an
+        // `i64.eq` on a ref is invalid wasm and wrong across Small/Big).
+        // Flag-off: byte-identical `i64.eq`.
+        "Int" => {
+            super::lists::emit_aint_field_eq(&mut f, registry)?;
+        }
+        "Float" => {
+            f.instruction(&Instruction::F64Eq);
+        }
+        "Bool" => {
+            f.instruction(&Instruction::I32Eq);
+        }
         _ => panic!(
             "internal compiler error: emit_eq_primitive called with \
              non-primitive K = `{k_aver}`; caller must dispatch to \
@@ -1877,8 +1889,9 @@ fn emit_hash_record(
         // emit field hash → i32
         match field_ty.trim() {
             "Int" => {
-                // i64 → low 32 bits
-                f.instruction(&Instruction::I32WrapI64);
+                // Flag-off: i64 → low 32 bits. Flag-on (bignum): the field
+                // is an `$aint` ref → `__aint_hash`.
+                super::lists::emit_aint_field_hash(&mut f, registry)?;
             }
             "Bool" => {
                 // already i32
@@ -1975,14 +1988,21 @@ fn emit_eq_record(
             field_index: i as u32,
         });
         match field_ty.trim() {
-            "Int" => f.instruction(&Instruction::I64Eq),
-            "Bool" => f.instruction(&Instruction::I32Eq),
-            "Float" => f.instruction(&Instruction::F64Eq),
+            // Flag-on (bignum): `$aint` ref → `__aint_eq`. Flag-off: `i64.eq`.
+            "Int" => {
+                super::lists::emit_aint_field_eq(&mut f, registry)?;
+            }
+            "Bool" => {
+                f.instruction(&Instruction::I32Eq);
+            }
+            "Float" => {
+                f.instruction(&Instruction::F64Eq);
+            }
             "String" => {
                 let helpers = string_key_helpers.ok_or(WasmGcError::Validation(
                     "eq_record: String field needs String key helpers".into(),
                 ))?;
-                f.instruction(&Instruction::Call(helpers.eq))
+                f.instruction(&Instruction::Call(helpers.eq));
             }
             other => {
                 let lookup_key = if other.starts_with("List<") || other.starts_with("Vector<") {
@@ -2006,7 +2026,7 @@ fn emit_eq_record(
                         .ok_or(WasmGcError::Validation(format!(
                             "eq_record: field `{other}` has no key helpers"
                         )))?;
-                    f.instruction(&Instruction::Call(inner.eq))
+                    f.instruction(&Instruction::Call(inner.eq));
                 } else {
                     return Err(WasmGcError::Unimplemented(
                         "phase 3c — record-key field type not in \
@@ -2355,7 +2375,7 @@ fn emit_map_eq(
     // if v_a != v_b → return 0
     f.instruction(&Instruction::LocalGet(10));
     f.instruction(&Instruction::LocalGet(11));
-    emit_v_eq(&mut f, v_aver, v_helpers)?;
+    emit_v_eq(&mut f, v_aver, v_helpers, registry)?;
     f.instruction(&Instruction::I32Eqz);
     f.instruction(&Instruction::If(BlockType::Empty));
     f.instruction(&Instruction::I32Const(0));
@@ -2381,10 +2401,12 @@ fn emit_v_eq(
     f: &mut Function,
     v_aver: &str,
     v_helpers: Option<KeyHelpers>,
+    registry: &TypeRegistry,
 ) -> Result<(), WasmGcError> {
     match v_aver.trim() {
+        // Flag-on (bignum): `$aint` ref → `__aint_eq`. Flag-off: `i64.eq`.
         "Int" => {
-            f.instruction(&Instruction::I64Eq);
+            super::lists::emit_aint_field_eq(f, registry)?;
         }
         "Bool" => {
             f.instruction(&Instruction::I32Eq);
@@ -2408,10 +2430,12 @@ fn emit_v_hash(
     f: &mut Function,
     v_aver: &str,
     v_helpers: Option<KeyHelpers>,
+    registry: &TypeRegistry,
 ) -> Result<(), WasmGcError> {
     match v_aver.trim() {
+        // Flag-on (bignum): `$aint` ref → `__aint_hash`. Flag-off: wrap.
         "Int" => {
-            f.instruction(&Instruction::I32WrapI64);
+            super::lists::emit_aint_field_hash(f, registry)?;
         }
         "Bool" => {} // already i32
         "Float" => {
@@ -2518,7 +2542,7 @@ fn emit_map_hash(
     f.instruction(&Instruction::LocalGet(5));
     f.instruction(&Instruction::LocalGet(3));
     f.instruction(&Instruction::ArrayGet(slots.values_array));
-    emit_v_hash(&mut f, v_aver, v_helpers)?;
+    emit_v_hash(&mut f, v_aver, v_helpers, registry)?;
     f.instruction(&Instruction::I32Add);
     f.instruction(&Instruction::LocalSet(8));
     // h ^= entry_h
@@ -3001,8 +3025,9 @@ fn emit_hash_sum(
             });
             let field_ty_trim = field_ty.trim();
             match field_ty_trim {
+                // Flag-on (bignum): `$aint` ref → `__aint_hash`. Flag-off: wrap.
                 "Int" => {
-                    f.instruction(&Instruction::I32WrapI64);
+                    super::lists::emit_aint_field_hash(&mut f, registry)?;
                 }
                 "Bool" => {}
                 "Float" => {
@@ -3102,14 +3127,21 @@ fn emit_eq_sum(
                 });
                 let field_ty_trim = field_ty.trim();
                 match field_ty_trim {
-                    "Int" => f.instruction(&Instruction::I64Eq),
-                    "Bool" => f.instruction(&Instruction::I32Eq),
-                    "Float" => f.instruction(&Instruction::F64Eq),
+                    // Flag-on (bignum): `$aint` ref → `__aint_eq`. Flag-off: `i64.eq`.
+                    "Int" => {
+                        super::lists::emit_aint_field_eq(&mut f, registry)?;
+                    }
+                    "Bool" => {
+                        f.instruction(&Instruction::I32Eq);
+                    }
+                    "Float" => {
+                        f.instruction(&Instruction::F64Eq);
+                    }
                     "String" => {
                         let helpers = string_key_helpers.ok_or(WasmGcError::Validation(
                             "eq_sum: String field needs String key helpers".into(),
                         ))?;
-                        f.instruction(&Instruction::Call(helpers.eq))
+                        f.instruction(&Instruction::Call(helpers.eq));
                     }
                     _ => {
                         // Compound field — proxy to per-type eq helper.
@@ -3123,7 +3155,7 @@ fn emit_eq_sum(
                                      type `{field_ty_trim}` of `{parent_name}`"
                                 ))
                             })?;
-                        f.instruction(&Instruction::Call(helpers.eq))
+                        f.instruction(&Instruction::Call(helpers.eq));
                     }
                 };
                 if i > 0 {

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -139,7 +139,7 @@ pub(super) fn emit_module_with(
     let symbol_table = view.symbol_table;
     let resolved_fn_defs = view.resolved_fn_defs;
 
-    let registry =
+    let mut registry =
         TypeRegistry::build_with_handler(items, &resolved_fn_defs, handler_name.is_some());
 
     // Lower the post-link resolved fns to MIR and run the shared
@@ -207,6 +207,11 @@ pub(super) fn emit_module_with(
             BuiltinName::AintDivmod,
             BuiltinName::AintCmp,
             BuiltinName::AintEq,
+            // slice 4 (eq+hash gap) — value hash agreeing with `__aint_eq`,
+            // for Map/Set Int keys and record/sum Int fields (the inline
+            // `i32.wrap_i64` over a raw value is invalid on an `$aint` ref,
+            // and collision-collapses every Big to one bucket).
+            BuiltinName::AintHash,
             // slice 3 — decimal parse / Float bridges / index extraction.
             // Registered alongside the arithmetic prelude so the conversion
             // + index re-point sites can assume the fn indices exist; -Oz
@@ -856,6 +861,17 @@ pub(super) fn emit_module_with(
         let p = name.params(&registry)?;
         let r = name.results(&registry)?;
         types.ty().function(p, r);
+    }
+    // bignum slice 4 (eq+hash gap) — record the `__aint_eq` / `__aint_hash`
+    // fn indices on the registry now that `assign_slots` has run, so every
+    // Int eq+hash emitter (Map keys/values, Set members, record/sum fields,
+    // carrier payloads — all of which already receive `&registry`) can route
+    // through them without threading two extra `Option<u32>` params through
+    // a dozen helper functions across maps.rs / lists.rs / eq_helpers.rs /
+    // hash_helpers.rs. `Some` iff `bignum`.
+    if registry.bignum {
+        registry.aint_eq_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintEq);
+        registry.aint_hash_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintHash);
     }
 
     // 6) Map helper fn types (per-K hash + eq, per-(K,V) empty/set/get/len).

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -158,6 +158,20 @@ pub(super) struct TypeRegistry {
     /// `bignum` is set; sits one slot below `aint_struct_idx` so the
     /// struct can reference it without a forward edge.
     pub(super) aint_mag_array_idx: Option<u32>,
+    /// bignum slice 4 (eq+hash gap) — wasm fn idx of the `__aint_eq`
+    /// helper, set by `module.rs` once `BuiltinRegistry::assign_slots`
+    /// runs. `Some` iff `bignum`. Every Int-eq site (Map keys, Set
+    /// members, record/sum fields, carrier payloads) routes through this
+    /// instead of an `i64.eq` on a `$AverInt` ref (which is invalid wasm
+    /// and wrong across the Small/Big boundary). Threaded via the
+    /// registry (already passed to every emitter) rather than per-fn args.
+    pub(super) aint_eq_fn_idx: Option<u32>,
+    /// bignum slice 4 (eq+hash gap) — wasm fn idx of the `__aint_hash`
+    /// helper, set alongside `aint_eq_fn_idx`. `Some` iff `bignum`.
+    /// Equal `$AverInt` values hash equal (Small folds `$small`, Big
+    /// folds limbs+sign); the inline `i32.wrap_i64` over a raw value is
+    /// invalid on a ref and collision-collapses every Big to one bucket.
+    pub(super) aint_hash_fn_idx: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -958,6 +972,10 @@ impl TypeRegistry {
             bignum,
             aint_struct_idx,
             aint_mag_array_idx,
+            // Set by `module.rs` after `BuiltinRegistry::assign_slots`,
+            // once the `__aint_eq` / `__aint_hash` fn indices are known.
+            aint_eq_fn_idx: None,
+            aint_hash_fn_idx: None,
         }
     }
 

--- a/tests/cross_backend_proptest.rs
+++ b/tests/cross_backend_proptest.rs
@@ -482,6 +482,152 @@ fn cross_int_equality_canonical_invariant_vm_vs_wasm_gc() {
     }
 }
 
+// ─── Int eq+hash gap: Map / Set / record / sum (slice 4) ────────────────────
+//
+// Slice 3 fixed List/Vector element eq+hash under bignum, but Map-with-Int-
+// keys, Set-of-Int (modelled as `Map<Int, Bool>`), and record/sum `==` with
+// an Int field still emitted `i64.eq` / `i32.wrap_i64` on an `$aint` REF —
+// invalid wasm AND semantically wrong for Big Int (a Big key looked up by an
+// equal Big reached a DIFFERENT way would miss its entry). These cases route
+// every such site through `__aint_eq` / `__aint_hash`. Each builds Big values
+// by ARITHMETIC (`i64::MAX + 1`, `a*2`) — literals past i64 are lexer-rejected
+// — and the differential asserts flag-on (`AVER_WASMGC_BIGNUM=1`) wasm-gc
+// matches the VM (Int = ℤ) exactly. The decisive observable is a Big key/field
+// reached two ways: a string render can't tell a hit from a miss, but
+// `Map.get` / `Map.has` / `==` can.
+//
+// NOTE (out of slice-4 scope, documented honestly): `Map.len` / `List.len`
+// return a raw i64 under bignum (an Int-returning builtin not lifted to
+// `$aint`), and bare `List<Int>` literals don't register their instantiation
+// under the flag. Both are PRE-EXISTING slice-1/3 representation gaps
+// independent of eq+hash; these tests therefore avoid `.len` + `String.fromInt`
+// and `List<Int>` literals. They are NOT regressions of this change.
+
+/// Empty `Map<Int, V>` builder (the `{}` literal needs a type annotation,
+/// which a binding can't carry — so a tiny typed helper fn supplies it).
+fn map_int_program(v_ty: &str, body: &str) -> String {
+    format!(
+        "module Tmp\n\
+         \n\
+         fn emptyM() -> Map<Int, {v_ty}>\n    \
+             {{}}\n\
+         \n\
+         fn main()\n    \
+             ! [Console.print]\n\
+         {body}"
+    )
+}
+
+#[test]
+fn cross_int_eqhash_map_big_keys_vm_vs_wasm_gc() {
+    // Two distinct Big keys + a Small key; a Big key reached via a SECOND
+    // computation (`bigAgain`, which equals `big` by ℤ arithmetic) must hit
+    // the SAME entry — overwriting it, not adding one (Eq/Hash agreement
+    // across the Small/Big boundary). Then `Map.remove` a Big key and read
+    // ONLY the post-remove map.
+    //
+    // We never read a pre-`Map.remove` map after the remove: wasm-gc's
+    // `Map.remove` rewrites the keys array in place (a PRE-EXISTING aliasing
+    // bug, reproducible flag-OFF too, unrelated to bignum eq+hash), so doing
+    // so would test that bug rather than this fix.
+    let body = "    \
+        big = (9223372036854775807 + 1)\n    \
+        big2 = (big * 2)\n    \
+        small = 42\n    \
+        bigAgain = ((9223372036854775807 * 2) - 9223372036854775807 + 1)\n    \
+        m1 = Map.set(emptyM(), big, 100)\n    \
+        m2 = Map.set(m1, big2, 200)\n    \
+        m3 = Map.set(m2, small, 300)\n    \
+        m4 = Map.set(m3, bigAgain, 101)\n    \
+        Console.print(String.fromInt(Option.withDefault(Map.get(m4, big), 0 - 1)))\n    \
+        Console.print(String.fromInt(Option.withDefault(Map.get(m4, big2), 0 - 1)))\n    \
+        Console.print(String.fromInt(Option.withDefault(Map.get(m4, small), 0 - 1)))\n    \
+        Console.print(String.fromInt(Option.withDefault(Map.get(m4, bigAgain), 0 - 1)))\n    \
+        Console.print(String.fromBool(Map.has(m4, big2)))\n    \
+        m5 = Map.remove(m4, big2)\n    \
+        Console.print(String.fromBool(Map.has(m5, big2)))\n    \
+        Console.print(String.fromInt(Option.withDefault(Map.get(m5, big), 0 - 1)))\n    \
+        Console.print(String.fromInt(Option.withDefault(Map.get(m5, bigAgain), 0 - 1)))\n";
+    let source = map_int_program("Int", body);
+    let vm = run_vm("cross-eqhash-map-vm", &source).expect("VM must accept Map<Int,Int> program");
+    let wg = run_wasm_gc_bignum("cross-eqhash-map-wg", &source)
+        .expect("wasm-gc (bignum) must accept Map<Int,Int> with Big keys");
+    assert_eq!(
+        wg, vm,
+        "VM vs wasm-gc (bignum) diverged on Map<Int,Int> with Big keys \
+         (get/has/overwrite/remove):\nVM:\n{vm}\nwasm-gc:\n{wg}"
+    );
+}
+
+#[test]
+fn cross_int_eqhash_set_big_dedup_vm_vs_wasm_gc() {
+    // Set-of-Int as `Map<Int, Bool>`: an equal-Big-via-two-paths must
+    // collapse to one membership entry; non-members miss.
+    let body = "    \
+        big = (9223372036854775807 + 1)\n    \
+        bigSame = ((9223372036854775807 * 2) - 9223372036854775807 + 1)\n    \
+        s1 = Map.set(emptyM(), big, true)\n    \
+        s2 = Map.set(s1, bigSame, true)\n    \
+        s3 = Map.set(s2, 7, true)\n    \
+        Console.print(String.fromBool(Map.has(s3, big)))\n    \
+        Console.print(String.fromBool(Map.has(s3, bigSame)))\n    \
+        Console.print(String.fromBool(Map.has(s3, 7)))\n    \
+        Console.print(String.fromBool(Map.has(s3, 8)))\n    \
+        Console.print(String.fromBool(Map.has(s3, (big * 2))))\n";
+    let source = map_int_program("Bool", body);
+    let vm = run_vm("cross-eqhash-set-vm", &source).expect("VM must accept Map<Int,Bool> program");
+    let wg = run_wasm_gc_bignum("cross-eqhash-set-wg", &source)
+        .expect("wasm-gc (bignum) must accept Set-of-Int with Big members");
+    assert_eq!(
+        wg, vm,
+        "VM vs wasm-gc (bignum) diverged on Set-of-Int (Map<Int,Bool>) Big dedup:\n\
+         VM:\n{vm}\nwasm-gc:\n{wg}"
+    );
+}
+
+#[test]
+fn cross_int_eqhash_record_sum_big_field_vm_vs_wasm_gc() {
+    // record `==` and sum `==` with a Big Int field: equal Big fields → true,
+    // differing → false, Small-vs-Big → false, different variant → false.
+    let source = "module Tmp\n\
+         \n\
+         record Point\n    \
+             x: Int\n    \
+             y: Int\n\
+         \n\
+         type Wrap\n    \
+             W(Int)\n    \
+             V(Int)\n\
+         \n\
+         fn main()\n    \
+             ! [Console.print]\n    \
+             big = (9223372036854775807 + 1)\n    \
+             bigSame = ((9223372036854775807 * 2) - 9223372036854775807 + 1)\n    \
+             p1 = Point(x = big, y = 5)\n    \
+             p2 = Point(x = bigSame, y = 5)\n    \
+             p3 = Point(x = big, y = 6)\n    \
+             p4 = Point(x = 42, y = 5)\n    \
+             Console.print(String.fromBool(p1 == p2))\n    \
+             Console.print(String.fromBool(p1 == p3))\n    \
+             Console.print(String.fromBool(p1 == p4))\n    \
+             w1 = Wrap.W(big)\n    \
+             w2 = Wrap.W(bigSame)\n    \
+             w3 = Wrap.W(42)\n    \
+             w4 = Wrap.V(big)\n    \
+             Console.print(String.fromBool(w1 == w2))\n    \
+             Console.print(String.fromBool(w1 == w3))\n    \
+             Console.print(String.fromBool(w1 == w4))\n"
+        .to_string();
+    let vm = run_vm("cross-eqhash-rec-vm", &source).expect("VM must accept record/sum eq program");
+    let wg = run_wasm_gc_bignum("cross-eqhash-rec-wg", &source)
+        .expect("wasm-gc (bignum) must accept record/sum eq with a Big Int field");
+    assert_eq!(
+        wg, vm,
+        "VM vs wasm-gc (bignum) diverged on record/sum `==` with a Big Int field:\n\
+         VM:\n{vm}\nwasm-gc:\n{wg}"
+    );
+}
+
 // ─── Euclidean divmod (slice 2) ─────────────────────────────────────────────
 //
 // `Int.div` / `Int.mod` return `Result<Int, String>` with EUCLIDEAN


### PR DESCRIPTION
Closes the Int **eq + hash** gap in the wasm-gc bignum backend — the last representation-completeness item before the default flip. Builds on slices 1-3 (#521/#524/#526). **Behind the opt-in `AVER_WASMGC_BIGNUM` flag; the default path is byte-unchanged** (flag-off emits `i64.eq` / `i32.wrap_i64`, no `$aint` allocated).

## The gap
Slice 3 fixed `List`/`Vector` element eq+hash, but `Map<Int,_>` keys, `Set<Int>`, `record`/`sum` `==` with an `Int` field, and `Option`/`Result`/`Tuple` Int payloads still emitted `i64.eq` / an i64 hash on an `$aint` ref — wrong (and invalid wasm) for a Big `Int` under the flag. Confirmed: with the fix stashed, `Map<Int,V>` fails wasm validation `expected i64, found (ref null $aint)`.

## What changed
- New `wat/hash.wat` (`__aint_hash`): Small folds its i64 `$small`; Big DJB2-folds its 32-bit limbs + sign. One self-contained WAT fn. (Slice 3's `$small`-projection hash collapsed every Big to bucket 0 — O(n) for Big-keyed maps; this distributes them. Consistent with `__aint_eq` by the canonical invariant: a Small and an equal Big can't coexist.)
- Every Int eq+hash site routed through `__aint_eq` / `__aint_hash` under the flag: Map keys + values (`maps.rs`), record/sum field eq+hash (`lists.rs`), Option/Result/Tuple payloads (`body/eq_helpers.rs`, `body/hash_helpers.rs`). The two helper fn-indices live on `TypeRegistry`.
- Fixed a latent slice-1 invalid-wasm bug: Int-literal `match` cascades emitted `i64.const`/`i64.eq` on an `$aint` subject (`body/from_mir/pattern_match.rs`).

## Verification (two-phase)
- **Phase 2 (wasmtime, vs VM):** `Map<Int,Int>` with Big keys — get/has correct, a Big key reached via different arithmetic hits the SAME entry, overwrite + remove of a Big key correct; `Set` dedup of equal-Big-via-two-paths; record/sum `==` with Big fields (equal→true, differing→false, Small-vs-Big→false). List/Vector<Int> Big regression clean.
- New permanent differential tests; `cross_backend_proptest` 16/16 (incl. the 2000-case differential); `wasm_gc` 49/49; lib 916/916; `cargo fmt --check` + `cargo clippy --features wasm,wasip2 -- -D warnings` clean.

## Known pre-flip gaps (separate, NOT this PR — fold into the flip)
`Map.len`/`List.len` still return raw i64 under bignum (Int-returning builtin not lifted); bare `List<Int>` literals don't register their instantiation under the flag; wasm-gc `Map.remove` has a pre-existing in-place-rewrite aliasing bug (reproduces flag-off). Flagged so the slice-4 flip closes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)