### PR TITLE
wasm-gc: Int = ℤ by default — the arc closes (slice 4, the flip)

### DIFF
--- a/src/codegen/wasm_gc/body/builtins_wasip2.rs
+++ b/src/codegen/wasm_gc/body/builtins_wasip2.rs
@@ -35,11 +35,14 @@ fn emit_aint_arg_as_i64_wasip2(
 ) -> Result<(), WasmGcError> {
     emit_mir_expr(func, arg, slots, ctx)?;
     if ctx.registry.bignum {
-        let to_sat = ctx.fn_map.builtins.get("__aint_to_i64_sat").copied().ok_or(
-            WasmGcError::Validation(
+        let to_sat = ctx
+            .fn_map
+            .builtins
+            .get("__aint_to_i64_sat")
+            .copied()
+            .ok_or(WasmGcError::Validation(
                 "bignum active but __aint_to_i64_sat helper not registered".into(),
-            ),
-        )?;
+            ))?;
         func.instruction(&Instruction::Call(to_sat));
     }
     Ok(())
@@ -53,11 +56,14 @@ fn lift_i64_result_to_aint_wasip2(
     ctx: &EmitCtx<'_>,
 ) -> Result<(), WasmGcError> {
     if ctx.registry.bignum {
-        let from_i64 = ctx.fn_map.builtins.get("__aint_from_i64").copied().ok_or(
-            WasmGcError::Validation(
-                "bignum active but __aint_from_i64 helper not registered".into(),
-            ),
-        )?;
+        let from_i64 =
+            ctx.fn_map
+                .builtins
+                .get("__aint_from_i64")
+                .copied()
+                .ok_or(WasmGcError::Validation(
+                    "bignum active but __aint_from_i64 helper not registered".into(),
+                ))?;
         func.instruction(&Instruction::Call(from_i64));
     }
     Ok(())

--- a/src/codegen/wasm_gc/body/builtins_wasip2.rs
+++ b/src/codegen/wasm_gc/body/builtins_wasip2.rs
@@ -23,10 +23,13 @@ use super::super::WasmGcError;
 use super::from_mir::emit_mir_expr;
 use super::{EmitCtx, SlotTable};
 
-/// `Int = ℤ`: emit an `Int` effect ARGUMENT and saturate-lower it from the
+/// `Int = ℤ`: emit an `Int` effect ARGUMENT and CHECKED-lower it from the
 /// `$AverInt` carrier to a raw i64 — the wasip2 effect lowerings (random
-/// bounds, sleep ms) compute on i64. A no-op passthrough when no Int is
-/// reachable (the arg is already i64).
+/// bounds, sleep ms, port) compute on i64. An out-of-i64 Big TRAPS
+/// (`__aint_to_i64_checked`) rather than saturating, so an out-of-range
+/// effect arg REJECTS on wasm-gc exactly as the VM's host services' checked
+/// `to_i64()` errors. A no-op passthrough when no Int is reachable (the arg
+/// is already i64).
 fn emit_aint_arg_as_i64_wasip2(
     func: &mut wasm_encoder::Function,
     arg: &Spanned<MirExpr>,
@@ -35,15 +38,15 @@ fn emit_aint_arg_as_i64_wasip2(
 ) -> Result<(), WasmGcError> {
     emit_mir_expr(func, arg, slots, ctx)?;
     if ctx.registry.bignum {
-        let to_sat = ctx
+        let to_checked = ctx
             .fn_map
             .builtins
-            .get("__aint_to_i64_sat")
+            .get("__aint_to_i64_checked")
             .copied()
             .ok_or(WasmGcError::Validation(
-                "bignum active but __aint_to_i64_sat helper not registered".into(),
+                "bignum active but __aint_to_i64_checked helper not registered".into(),
             ))?;
-        func.instruction(&Instruction::Call(to_sat));
+        func.instruction(&Instruction::Call(to_checked));
     }
     Ok(())
 }

--- a/src/codegen/wasm_gc/body/builtins_wasip2.rs
+++ b/src/codegen/wasm_gc/body/builtins_wasip2.rs
@@ -23,6 +23,46 @@ use super::super::WasmGcError;
 use super::from_mir::emit_mir_expr;
 use super::{EmitCtx, SlotTable};
 
+/// `Int = ℤ`: emit an `Int` effect ARGUMENT and saturate-lower it from the
+/// `$AverInt` carrier to a raw i64 — the wasip2 effect lowerings (random
+/// bounds, sleep ms) compute on i64. A no-op passthrough when no Int is
+/// reachable (the arg is already i64).
+fn emit_aint_arg_as_i64_wasip2(
+    func: &mut wasm_encoder::Function,
+    arg: &Spanned<MirExpr>,
+    slots: &SlotTable,
+    ctx: &EmitCtx<'_>,
+) -> Result<(), WasmGcError> {
+    emit_mir_expr(func, arg, slots, ctx)?;
+    if ctx.registry.bignum {
+        let to_sat = ctx.fn_map.builtins.get("__aint_to_i64_sat").copied().ok_or(
+            WasmGcError::Validation(
+                "bignum active but __aint_to_i64_sat helper not registered".into(),
+            ),
+        )?;
+        func.instruction(&Instruction::Call(to_sat));
+    }
+    Ok(())
+}
+
+/// `Int = ℤ`: lift the raw i64 result of an `Int`-returning wasip2 effect
+/// (`Random.int`, `Time.unixMs`) into the `$AverInt` carrier. No-op when
+/// no Int is reachable.
+fn lift_i64_result_to_aint_wasip2(
+    func: &mut wasm_encoder::Function,
+    ctx: &EmitCtx<'_>,
+) -> Result<(), WasmGcError> {
+    if ctx.registry.bignum {
+        let from_i64 = ctx.fn_map.builtins.get("__aint_from_i64").copied().ok_or(
+            WasmGcError::Validation(
+                "bignum active but __aint_from_i64 helper not registered".into(),
+            ),
+        )?;
+        func.instruction(&Instruction::Call(from_i64));
+    }
+    Ok(())
+}
+
 /// Phase 1.2b1.5 — call-site lowering for `Console.print` /
 /// `Console.error` / `Console.warn` on `--target wasip2`.
 ///
@@ -378,6 +418,8 @@ pub(super) fn emit_time_unix_ms_wasip2(
     func.instruction(&Instruction::I64Const(1_000_000));
     func.instruction(&Instruction::I64DivU);
     func.instruction(&Instruction::I64Add);
+    // `Int = ℤ`: `Time.unixMs() -> Int` — lift the i64 epoch ms to $aint.
+    lift_i64_result_to_aint_wasip2(func, ctx)?;
     Ok(())
 }
 
@@ -500,7 +542,8 @@ pub(super) fn emit_time_sleep_wasip2(
             "Time.sleep on wasip2: __rt_time_sleep fn idx missing — helper not allocated".into(),
         )
     })?;
-    emit_mir_expr(func, &args[0], slots, ctx)?; // ms: i64
+    // `Int = ℤ`: `ms` is the `$AverInt` carrier — saturate-lower to i64.
+    emit_aint_arg_as_i64_wasip2(func, &args[0], slots, ctx)?; // ms: i64
     func.instruction(&Instruction::Call(sleep_fn));
     Ok(())
 }
@@ -559,7 +602,8 @@ pub(super) fn emit_tcp_ping_wasip2(
         WasmGcError::Validation("Tcp.ping on wasip2: __rt_tcp_ping fn idx missing".into())
     })?;
     emit_mir_expr(func, &args[0], slots, ctx)?;
-    emit_mir_expr(func, &args[1], slots, ctx)?;
+    // `Int = ℤ`: the `port` is the `$AverInt` carrier — saturate-lower to i64.
+    emit_aint_arg_as_i64_wasip2(func, &args[1], slots, ctx)?;
     func.instruction(&Instruction::Call(ping_fn));
     Ok(())
 }
@@ -588,7 +632,8 @@ pub(super) fn emit_tcp_send_wasip2(
         WasmGcError::Validation("Tcp.send on wasip2: __rt_tcp_send fn idx missing".into())
     })?;
     emit_mir_expr(func, &args[0], slots, ctx)?;
-    emit_mir_expr(func, &args[1], slots, ctx)?;
+    // `Int = ℤ`: the `port` is the `$AverInt` carrier — saturate-lower to i64.
+    emit_aint_arg_as_i64_wasip2(func, &args[1], slots, ctx)?;
     emit_mir_expr(func, &args[2], slots, ctx)?;
     func.instruction(&Instruction::Call(send_fn));
     Ok(())
@@ -706,7 +751,8 @@ pub(super) fn emit_tcp_connect_wasip2(
         )
     })?;
     emit_mir_expr(func, &args[0], slots, ctx)?; // host: ref string
-    emit_mir_expr(func, &args[1], slots, ctx)?; // port: i64
+    // `Int = ℤ`: the `port` is the `$AverInt` carrier — saturate-lower to i64.
+    emit_aint_arg_as_i64_wasip2(func, &args[1], slots, ctx)?; // port: i64
     func.instruction(&Instruction::Call(connect_fn));
     Ok(())
 }
@@ -784,17 +830,20 @@ pub(super) fn emit_random_int_wasip2(
     //   push min_scratch
     //   push (get-random-u64() % (max - min + 1))
     //   i64.add
-    emit_mir_expr(func, &args[0], slots, ctx)?; // min: i64
+    // `Int = ℤ`: the host ABI is i64 — saturate-lower the `$AverInt`
+    // min/max bounds before the i64 arithmetic, then lift the i64 result.
+    emit_aint_arg_as_i64_wasip2(func, &args[0], slots, ctx)?; // min: i64
     func.instruction(&Instruction::LocalSet(min_scratch));
     func.instruction(&Instruction::LocalGet(min_scratch));
     func.instruction(&Instruction::Call(rand_fn)); // u64 -> i64 representation
-    emit_mir_expr(func, &args[1], slots, ctx)?; // max
+    emit_aint_arg_as_i64_wasip2(func, &args[1], slots, ctx)?; // max
     func.instruction(&Instruction::LocalGet(min_scratch));
     func.instruction(&Instruction::I64Sub);
     func.instruction(&Instruction::I64Const(1));
     func.instruction(&Instruction::I64Add);
     func.instruction(&Instruction::I64RemU); // modulo unsigned
     func.instruction(&Instruction::I64Add);
+    lift_i64_result_to_aint_wasip2(func, ctx)?;
     Ok(())
 }
 

--- a/src/codegen/wasm_gc/body/eq_helpers.rs
+++ b/src/codegen/wasm_gc/body/eq_helpers.rs
@@ -713,16 +713,19 @@ fn emit_inner_eq_dispatch(
         inner.to_string()
     };
     match resolved.as_str() {
-        // bignum slice 4 (eq+hash gap) — a GENUINE `Int` payload lowers to
-        // `$aint` under bignum → `__aint_eq` (an `i64.eq` on a ref is
-        // invalid wasm and wrong across Small/Big). A newtype-erased Int
-        // (`resolved == "Int"` but `inner != "Int"`) stays a scalar i64 →
-        // `i64.eq`. Both byte-identical flag-off.
-        "Int" if inner.trim() == "Int" => {
-            super::super::lists::emit_aint_field_eq(f, registry)?;
-        }
+        // `Int = ℤ` — an `Int` payload lowers to the `$aint` ref under
+        // bignum, so it compares via `__aint_eq` (an `i64.eq` on a ref is
+        // invalid wasm and wrong across the Small/Big boundary). This
+        // holds for BOTH a genuine `Int` field (`inner == "Int"`) AND a
+        // newtype-erased Int (`Box(v: Int)` → "Box" resolves to "Int"):
+        // the erased field's wasm representation is still `$aint`, not a
+        // scalar i64. Off-path (no Int reachable) both fall to `i64.eq`.
         "Int" => {
-            f.instruction(&Instruction::I64Eq);
+            // `emit_aint_field_eq` itself branches on `registry.bignum`
+            // (→ `__aint_eq` under ℤ, → `i64.eq` when no Int is reachable),
+            // so this single call is correct for both a genuine and an
+            // erased Int field.
+            super::super::lists::emit_aint_field_eq(f, registry)?;
         }
         "Bool" => {
             f.instruction(&Instruction::I32Eq);

--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -22,10 +22,10 @@ pub(crate) enum MirBuiltinEmit {
     Produced(bool),
 }
 
-/// bignum slice 2 — look up a registered `__aint_*` helper fn idx,
-/// erroring (not silently miscompiling) when the prelude wasn't
-/// registered. Registration is unconditional under the flag
-/// (`module.rs`), so a miss is a real wiring bug.
+/// Look up a registered `__aint_*` helper fn idx, erroring (not silently
+/// miscompiling) when the prelude wasn't registered. Registration is
+/// unconditional whenever Int arithmetic is reachable (`module.rs`), so a
+/// miss is a real wiring bug.
 fn aint_helper(ctx: &EmitCtx<'_>, name: &str) -> Result<u32, WasmGcError> {
     ctx.fn_map
         .builtins
@@ -34,6 +34,46 @@ fn aint_helper(ctx: &EmitCtx<'_>, name: &str) -> Result<u32, WasmGcError> {
         .ok_or(WasmGcError::Validation(format!(
             "bignum active but {name} helper not registered"
         )))
+}
+
+/// `Int = ℤ`: lift a raw i64 sitting on the wasm stack into the canonical
+/// Small `$AverInt` carrier (`call $__aint_from_i64`). Used at every
+/// Int-RETURNING builtin whose helper computes an i64 internally — a
+/// length / count / codepoint (`List.len`, `Map.len`, `Vector.len`,
+/// `String.len` / `byteLength`, `Char.toCode`) or an effect import return
+/// (`Random.int`, `Time.unixMs`) — so the value matches the `(ref null
+/// $AverInt)` shape every other Int site expects. A no-op when `bignum`
+/// is off (no Int reachable), where these builtins keep their scalar i64.
+pub(crate) fn lift_i64_result_to_aint(
+    func: &mut Function,
+    ctx: &EmitCtx<'_>,
+) -> Result<(), WasmGcError> {
+    if ctx.registry.bignum {
+        let from_i64 = aint_helper(ctx, "__aint_from_i64")?;
+        func.instruction(&Instruction::Call(from_i64));
+    }
+    Ok(())
+}
+
+/// `Int = ℤ`: emit an Int builtin ARGUMENT and saturate-lower it from the
+/// `$AverInt` carrier to a raw i64, for an i64-typed builtin slot whose
+/// receiving helper clamps out-of-range counts/indices (`List.take` /
+/// `List.drop` counts, `String.charAt` / `String.slice` indices). A no-op
+/// passthrough when `bignum` is off (the arg is already i64).
+fn emit_aint_arg_as_i64_sat(
+    func: &mut Function,
+    arg: &Spanned<MirExpr>,
+    slots: &SlotTable,
+    ctx: &EmitCtx<'_>,
+) -> Result<bool, WasmGcError> {
+    if emit_mir_expr(func, arg, slots, ctx)?.is_none() {
+        return Ok(false);
+    }
+    if ctx.registry.bignum {
+        let to_sat = aint_helper(ctx, "__aint_to_i64_sat")?;
+        func.instruction(&Instruction::Call(to_sat));
+    }
+    Ok(true)
 }
 
 /// bignum slice 3 — emit a `Vector`/`List` index expression and leave a
@@ -384,6 +424,8 @@ pub(crate) fn emit_mir_native_scalar_builtin(
                     ))?;
             arg!(0);
             func.instruction(&Instruction::Call(len_idx));
+            // `String.length` returns `Int` — lift the raw i64 count.
+            lift_i64_result_to_aint(func, ctx)?;
         }
         // `String.split` / `String.join` ride the singleton (T=String)
         // `string_split_ops`, not `fn_map.builtins`.
@@ -1228,6 +1270,13 @@ pub(crate) fn emit_mir_map_builtin(
     };
     emit_args!();
     func.instruction(&Instruction::Call(target));
+    // `Map.len` returns `Int`; its helper computes a raw i64, so lift it
+    // into the `$AverInt` carrier. (`keys` / `values` / `entries` return
+    // Lists, `get` an `Option<V>`, `has` a Bool, `set` / `remove` a Map —
+    // none are Int.)
+    if method == "len" {
+        lift_i64_result_to_aint(func, ctx)?;
+    }
     Ok(MirBuiltinEmit::Produced(true))
 }
 
@@ -1303,8 +1352,30 @@ pub(crate) fn emit_mir_list_builtin(
                     _ => unreachable!("outer match restricts dotted"),
                 }
             };
-            emit_args!();
+            // `List.take` / `List.drop` take an i64 COUNT as their second
+            // arg; under `Int = ℤ` that arg is an `$AverInt` ref, so it
+            // must be saturate-lowered (a Big count just clamps to
+            // all/none, which the helper's `i >= n` loop guard handles).
+            // The other 2-arg ops (`concat` second arg = List, `contains`
+            // = element) carry no Int count, so they ride `emit_args!`.
+            if matches!(dotted, "List.take" | "List.drop") {
+                if emit_mir_expr(func, &args[0], slots, ctx)?.is_none() {
+                    return Ok(MirBuiltinEmit::Fallback);
+                }
+                if !emit_aint_arg_as_i64_sat(func, &args[1], slots, ctx)? {
+                    return Ok(MirBuiltinEmit::Fallback);
+                }
+            } else {
+                emit_args!();
+            }
             func.instruction(&Instruction::Call(fn_idx));
+            // `List.len` / `List.length` return `Int`; the helper computes
+            // a raw i64, so lift it into the `$AverInt` carrier. (`reverse`
+            // / `concat` / `take` / `drop` / `contains` return a List or
+            // Bool — no lift.)
+            if matches!(dotted, "List.len" | "List.length") {
+                lift_i64_result_to_aint(func, ctx)?;
+            }
         }
         "List.zip" if args.len() == 2 => {
             let la_aver = aver_type_str_of(&args[0]);
@@ -1420,6 +1491,9 @@ pub(crate) fn emit_mir_vector_builtin(
             }
             func.instruction(&Instruction::ArrayLen);
             func.instruction(&Instruction::I64ExtendI32U);
+            // `Vector.len` returns `Int` — lift the i64 length into the
+            // `$AverInt` carrier.
+            lift_i64_result_to_aint(func, ctx)?;
         }
         "Vector.new" if args.len() == 2 => {
             let elem_aver = aver_type_str_of(&args[1]);

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -123,6 +123,10 @@ fn registered_builtin_int_arg_positions(dotted: &str) -> &'static [usize] {
         "Char.fromCode" => &[0],
         "String.charAt" => &[1],
         "String.slice" => &[1, 2],
+        // `Byte.toHex(Int) -> Result<String,String>` — a byte value
+        // 0..255 in an i64 slot; saturate-lower (the helper's range check
+        // rejects out-of-byte values exactly as a Big would over-saturate).
+        "Byte.toHex" => &[0],
         _ => &[],
     }
 }

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -588,13 +588,15 @@ pub(crate) fn emit_mir_expr(
                                 return Ok(None);
                             }
                             if ctx.registry.bignum && int_args.contains(&i) {
-                                let to_sat =
-                                    ctx.fn_map.builtins.get("__aint_to_i64_sat").copied().ok_or(
-                                        WasmGcError::Validation(
-                                            "bignum active but __aint_to_i64_sat helper not registered"
-                                                .into(),
-                                        ),
-                                    )?;
+                                let to_sat = ctx
+                                    .fn_map
+                                    .builtins
+                                    .get("__aint_to_i64_sat")
+                                    .copied()
+                                    .ok_or(WasmGcError::Validation(
+                                        "bignum active but __aint_to_i64_sat helper not registered"
+                                            .into(),
+                                    ))?;
                                 func.instruction(&Instruction::Call(to_sat));
                             }
                         }
@@ -1059,11 +1061,14 @@ pub(crate) fn emit_mir_args_then_call_lowering_int(
             return Ok(None);
         }
         if ctx.registry.bignum && int_arg_positions.contains(&i) {
-            let to_sat = ctx.fn_map.builtins.get("__aint_to_i64_sat").copied().ok_or(
-                WasmGcError::Validation(
+            let to_sat = ctx
+                .fn_map
+                .builtins
+                .get("__aint_to_i64_sat")
+                .copied()
+                .ok_or(WasmGcError::Validation(
                     "bignum active but __aint_to_i64_sat helper not registered".into(),
-                ),
-            )?;
+                ))?;
             func.instruction(&Instruction::Call(to_sat));
         }
     }

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -99,6 +99,18 @@ pub(super) use strings::*;
 
 pub use coverage::{CoverageReport, coverage_report};
 
+/// `Int = ℤ`: registered `fn_map.builtins` helpers whose Aver return type
+/// is `Int` but whose wasm helper computes a raw scalar i64 (a byte / code
+/// count), so the result must be lifted into the `$AverInt` carrier. Kept
+/// narrow: only the helpers that ride the generic `fn_map.builtins`
+/// dispatch path. Int-returning builtins lowered by a dedicated emitter
+/// (`List.len` / `Map.len` / `Vector.len` / `String.length` / the `Int.*`
+/// / `Float.*` bridges) lift at their own site and are NOT listed here, so
+/// nothing double-wraps.
+fn registered_builtin_returns_raw_int(dotted: &str) -> bool {
+    matches!(dotted, "String.len" | "String.byteLength" | "Char.toCode")
+}
+
 /// Lower `mir_fn.body` into `func`, mirroring [`super::emit_fn_body`]
 /// byte-for-byte. Returns `Ok(Some(extra_locals))` on full coverage,
 /// `Ok(None)` when any node falls outside the supported subset — the
@@ -594,6 +606,14 @@ pub(crate) fn emit_mir_expr(
                                 .is_none()
                             {
                                 return Ok(None);
+                            }
+                            // `Int = ℤ`: a registered helper that returns
+                            // `Int` (`String.len`, `String.byteLength`,
+                            // `Char.toCode`) computes a raw i64; lift it
+                            // into the `$AverInt` carrier so the value
+                            // matches the ref shape every Int site expects.
+                            if registered_builtin_returns_raw_int(dotted) {
+                                lift_i64_result_to_aint(func, ctx)?;
                             }
                             Ok(Some(aver_type_str_of(expr).trim() != "Unit"))
                         }

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -111,6 +111,48 @@ fn registered_builtin_returns_raw_int(dotted: &str) -> bool {
     matches!(dotted, "String.len" | "String.byteLength" | "Char.toCode")
 }
 
+/// `Int = ℤ`: zero-based argument positions a registered `fn_map.builtins`
+/// helper takes as a raw i64 but which the surface signature types as
+/// `Int` (a char code or a string index/length). Under ℤ those args arrive
+/// as `$AverInt` refs and must be saturate-lowered to i64 before the call.
+/// `Char.fromCode`'s out-of-u32 / negative → `Option.None`, and a string
+/// index past the length → empty/None, so a saturated i64::MAX/MIN
+/// reproduces the VM's clamping. Empty for every other registered builtin.
+fn registered_builtin_int_arg_positions(dotted: &str) -> &'static [usize] {
+    match dotted {
+        "Char.fromCode" => &[0],
+        "String.charAt" => &[1],
+        "String.slice" => &[1, 2],
+        _ => &[],
+    }
+}
+
+/// `Int = ℤ`: the HOST-ABI effect-boundary stays i64 (no bignum crosses
+/// the wire). Zero-based positions an AverBridge effect IMPORT takes as an
+/// `Int` (a machine-range index / bound / ms / status). Under ℤ those args
+/// arrive as `$AverInt` refs and must be saturate-lowered to i64 before
+/// the host call. Empty for effects with no Int arg.
+fn effect_int_arg_positions(dotted: &str) -> &'static [usize] {
+    match dotted {
+        "Random.int" => &[0, 1],
+        "Time.sleep" => &[0],
+        "Response.text" => &[0],
+        // Network port / server bind port / terminal coordinates.
+        "Tcp.send" | "Tcp.ping" | "Tcp.connect" => &[1],
+        "HttpServer.listen" | "HttpServer.listenWith" => &[0],
+        "Terminal.moveTo" => &[0, 1],
+        _ => &[],
+    }
+}
+
+/// `Int = ℤ`: AverBridge effect imports whose RESULT is an `Int` returned
+/// as i64 from the host (`Random.int`, `Time.unixMs`). The incoming i64 is
+/// lifted to a Small `$AverInt` so the value matches the ref shape Aver
+/// uses for Int everywhere off the wire.
+fn effect_returns_int(dotted: &str) -> bool {
+    matches!(dotted, "Random.int" | "Time.unixMs")
+}
+
 /// Lower `mir_fn.body` into `func`, mirroring [`super::emit_fn_body`]
 /// byte-for-byte. Returns `Ok(Some(extra_locals))` on full coverage,
 /// `Ok(None)` when any node falls outside the supported subset — the
@@ -532,13 +574,31 @@ pub(crate) fn emit_mir_expr(
                     // lowerings are handled by `emit_mir_wasip2_effect`
                     // above; this branch serves only the AverBridge target.)
                     if let Some(&effect_idx) = ctx.fn_map.effects.get(dotted) {
-                        for arg in &call.args {
+                        // `Int = ℤ`: the host ABI stays i64 — lower any
+                        // `Int` arg (`$AverInt` ref) to i64 before the call,
+                        // and lift an `Int` result (i64 from the host) back
+                        // into the carrier after. No bignum crosses the wire.
+                        let int_args = effect_int_arg_positions(dotted);
+                        for (i, arg) in call.args.iter().enumerate() {
                             if emit_mir_expr(func, arg, slots, ctx)?.is_none() {
                                 return Ok(None);
+                            }
+                            if ctx.registry.bignum && int_args.contains(&i) {
+                                let to_sat =
+                                    ctx.fn_map.builtins.get("__aint_to_i64_sat").copied().ok_or(
+                                        WasmGcError::Validation(
+                                            "bignum active but __aint_to_i64_sat helper not registered"
+                                                .into(),
+                                        ),
+                                    )?;
+                                func.instruction(&Instruction::Call(to_sat));
                             }
                         }
                         emit_caller_fn_idx(func, ctx)?;
                         func.instruction(&Instruction::Call(effect_idx));
+                        if effect_returns_int(dotted) {
+                            lift_i64_result_to_aint(func, ctx)?;
+                        }
                         return Ok(Some(aver_type_str_of(expr).trim() != "Unit"));
                     }
                     // Native scalar builtins (Float / Int / Bool) lower to
@@ -602,8 +662,15 @@ pub(crate) fn emit_mir_expr(
                     }
                     match ctx.fn_map.builtins.get(dotted) {
                         Some(&wasm_idx) => {
-                            if emit_mir_args_then_call(func, &call.args, slots, ctx, wasm_idx)?
-                                .is_none()
+                            // `Int = ℤ`: a registered helper that takes an
+                            // `Int` ARGUMENT in an i64-typed slot (a char
+                            // code / string index) needs that arg
+                            // saturate-lowered from `$AverInt` to i64.
+                            let int_args = registered_builtin_int_arg_positions(dotted);
+                            if emit_mir_args_then_call_lowering_int(
+                                func, &call.args, slots, ctx, wasm_idx, int_args,
+                            )?
+                            .is_none()
                             {
                                 return Ok(None);
                             }
@@ -621,6 +688,40 @@ pub(crate) fn emit_mir_expr(
                     }
                 }
                 MirCallee::Intrinsic(intr) => {
+                    // `Int = ℤ`: the const-fold pass rewrites a
+                    // `Result.withDefault(Int.div/mod(a, k), _)` over a
+                    // constant nonzero `k` into a bare `IntDivEuclid` /
+                    // `IntModEuclid` intrinsic (no Result, no `b == 0`
+                    // guard — `k ∉ {0,-1}` for div, `k != 0` for mod is
+                    // already proven). Under bignum `a`/`k` are `$AverInt`
+                    // refs, so route to the Euclidean `__aint_divmod`
+                    // helper (a `want_mod` flag selects div vs mod) instead
+                    // of the i64 `__int_{div,mod}_euclid` — which would
+                    // mix an i64 helper with ref operands (invalid wasm)
+                    // and silently truncate a Big.
+                    use crate::ir::hir::BuiltinIntrinsic;
+                    if ctx.registry.bignum
+                        && matches!(
+                            intr,
+                            BuiltinIntrinsic::IntDivEuclid | BuiltinIntrinsic::IntModEuclid
+                        )
+                        && call.args.len() == 2
+                    {
+                        let is_mod = matches!(intr, BuiltinIntrinsic::IntModEuclid);
+                        let divmod = ctx.fn_map.builtins.get("__aint_divmod").copied().ok_or(
+                            WasmGcError::Validation(
+                                "bignum active but __aint_divmod helper not registered".into(),
+                            ),
+                        )?;
+                        if emit_mir_expr(func, &call.args[0], slots, ctx)?.is_none()
+                            || emit_mir_expr(func, &call.args[1], slots, ctx)?.is_none()
+                        {
+                            return Ok(None);
+                        }
+                        func.instruction(&Instruction::I32Const(if is_mod { 1 } else { 0 }));
+                        func.instruction(&Instruction::Call(divmod));
+                        return Ok(Some(true));
+                    }
                     // Mirror of `emit_expr`'s `Intrinsic` arm: route the
                     // bare intrinsic name through the registered-builtin
                     // fast path. (Buffer intrinsics aren't produced on the
@@ -932,9 +1033,34 @@ pub(crate) fn emit_mir_args_then_call(
     ctx: &EmitCtx<'_>,
     wasm_idx: u32,
 ) -> Result<Option<()>, WasmGcError> {
-    for arg in args {
+    emit_mir_args_then_call_lowering_int(func, args, slots, ctx, wasm_idx, &[])
+}
+
+/// As [`emit_mir_args_then_call`], but `int_arg_positions` lists the
+/// zero-based args the helper takes as a raw i64 in an `Int`-typed slot
+/// (`Char.fromCode` code, `String.charAt`/`slice` indices). Under `Int =
+/// ℤ` those args arrive as `$AverInt` refs, so they are saturate-lowered
+/// to i64 (`__aint_to_i64_sat`) right after emission. A no-op for the
+/// common empty-positions case (every other builtin).
+pub(crate) fn emit_mir_args_then_call_lowering_int(
+    func: &mut Function,
+    args: &[Spanned<MirExpr>],
+    slots: &SlotTable,
+    ctx: &EmitCtx<'_>,
+    wasm_idx: u32,
+    int_arg_positions: &[usize],
+) -> Result<Option<()>, WasmGcError> {
+    for (i, arg) in args.iter().enumerate() {
         if emit_mir_expr(func, arg, slots, ctx)?.is_none() {
             return Ok(None);
+        }
+        if ctx.registry.bignum && int_arg_positions.contains(&i) {
+            let to_sat = ctx.fn_map.builtins.get("__aint_to_i64_sat").copied().ok_or(
+                WasmGcError::Validation(
+                    "bignum active but __aint_to_i64_sat helper not registered".into(),
+                ),
+            )?;
+            func.instruction(&Instruction::Call(to_sat));
         }
     }
     func.instruction(&Instruction::Call(wasm_idx));

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -133,9 +133,12 @@ fn registered_builtin_int_arg_positions(dotted: &str) -> &'static [usize] {
 
 /// `Int = ℤ`: the HOST-ABI effect-boundary stays i64 (no bignum crosses
 /// the wire). Zero-based positions an AverBridge effect IMPORT takes as an
-/// `Int` (a machine-range index / bound / ms / status). Under ℤ those args
-/// arrive as `$AverInt` refs and must be saturate-lowered to i64 before
-/// the host call. Empty for effects with no Int arg.
+/// `Int` (a machine-range bound / ms / port / coordinate). Under ℤ those
+/// args arrive as `$AverInt` refs and must be CHECKED-lowered to i64
+/// (`__aint_to_i64_checked`, which TRAPS on an out-of-i64 Big) before the
+/// host call — mirroring the VM host services' checked `to_i64()`, which
+/// ERRORS rather than saturating an out-of-range effect arg. Empty for
+/// effects with no Int arg.
 fn effect_int_arg_positions(dotted: &str) -> &'static [usize] {
     match dotted {
         "Random.int" => &[0, 1],
@@ -588,16 +591,24 @@ pub(crate) fn emit_mir_expr(
                                 return Ok(None);
                             }
                             if ctx.registry.bignum && int_args.contains(&i) {
-                                let to_sat = ctx
+                                // CHECKED (not saturating): an out-of-i64 Int
+                                // crossing the host effect boundary must
+                                // REJECT — the VM's host services do a checked
+                                // `to_i64()` and ERROR, so wasm-gc TRAPS rather
+                                // than silently saturating to i64::MAX/MIN (a
+                                // `Time.sleep(2^63)` saturated to a
+                                // ~292-million-year hang) and proceeding.
+                                let to_checked = ctx
                                     .fn_map
                                     .builtins
-                                    .get("__aint_to_i64_sat")
+                                    .get("__aint_to_i64_checked")
                                     .copied()
                                     .ok_or(WasmGcError::Validation(
-                                        "bignum active but __aint_to_i64_sat helper not registered"
+                                        "bignum active but __aint_to_i64_checked helper not \
+                                         registered"
                                             .into(),
                                     ))?;
-                                func.instruction(&Instruction::Call(to_sat));
+                                func.instruction(&Instruction::Call(to_checked));
                             }
                         }
                         emit_caller_fn_idx(func, ctx)?;

--- a/src/codegen/wasm_gc/body/hash_helpers.rs
+++ b/src/codegen/wasm_gc/body/hash_helpers.rs
@@ -642,15 +642,15 @@ fn emit_inner_hash_dispatch(
         inner.to_string()
     };
     match resolved.as_str() {
-        // bignum slice 4 (eq+hash gap) — a GENUINE `Int` payload lowers to
-        // `$aint` under bignum → `__aint_hash` (agrees with `__aint_eq`,
-        // and an `i32.wrap_i64` on a ref is invalid wasm). A newtype-erased
-        // Int stays a scalar i64 → wrap. Byte-identical flag-off.
-        "Int" if inner.trim() == "Int" => {
-            super::super::lists::emit_aint_field_hash(f, registry)?;
-        }
+        // `Int = ℤ` — an `Int` payload lowers to the `$aint` ref under
+        // bignum → `__aint_hash` (agrees with `__aint_eq`; an
+        // `i32.wrap_i64` on a ref is invalid wasm). This holds for BOTH a
+        // genuine `Int` field and a newtype-erased Int (`Box(v: Int)`):
+        // the erased field's wasm representation is still `$aint`.
+        // `emit_aint_field_hash` itself falls to `i32.wrap_i64` when no
+        // Int is reachable (bignum off).
         "Int" => {
-            f.instruction(&Instruction::I32WrapI64);
+            super::super::lists::emit_aint_field_hash(f, registry)?;
         }
         "Bool" => {} // already i32
         "Float" => {

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -440,6 +440,23 @@ pub(super) fn emit_aint_to_i64_sat(registry: &TypeRegistry) -> Result<Function, 
     wat_helper::compile_wat_helper(&wat)
 }
 
+/// `__aint_to_i64_checked(a) -> i64` — CHECKED Int→i64 lowering for an Int
+/// argument crossing the HOST EFFECT boundary (a `Random` bound,
+/// `Time.sleep` ms, a network port, a `Terminal` coordinate). A Small
+/// passes its `$small` through; a Big TRAPS (`unreachable`), since a
+/// canonical Big is by definition outside i64 range. This mirrors the VM
+/// host services' checked `AverInt::to_i64()` — which ERRORS on an out-of-
+/// i64 effect arg — so an out-of-range effect arg REJECTS on wasm-gc
+/// instead of silently saturating to i64::MAX/MIN and proceeding (e.g.
+/// `Time.sleep(2^63)` would otherwise saturate to a ~292-million-year
+/// hang). Self-contained: no inter-helper `call`, so
+/// `compile_wat_helper`'s single-function discipline holds.
+pub(super) fn emit_aint_to_i64_checked(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(include_str!("wat/to_i64_checked.wat"), decls = decls);
+    wat_helper::compile_wat_helper(&wat)
+}
+
 /// `__aint_neg(a) -> $AverInt`. Small fast path with `i64::MIN`
 /// promotion; Big flips the sign field (magnitude unchanged, stays
 /// canonical).

--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -427,6 +427,19 @@ pub(super) fn emit_aint_to_index(registry: &TypeRegistry) -> Result<Function, Wa
     wat_helper::compile_wat_helper(&wat)
 }
 
+/// `__aint_to_i64_sat(a) -> i64` — saturating Int→i64 lowering for an Int
+/// ARGUMENT into an i64-typed builtin slot. A Small passes its `$small`
+/// through; a positive Big saturates to i64::MAX, a negative Big to
+/// i64::MIN. Used where an out-of-i64 magnitude only needs to clamp to
+/// "all"/"none" (`List.take`/`drop` counts) or past-end (`String.charAt`/
+/// `slice` indices, `Char.fromCode`), which the receiving helper already
+/// handles as a saturated boundary.
+pub(super) fn emit_aint_to_i64_sat(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(include_str!("wat/to_i64_sat.wat"), decls = decls);
+    wat_helper::compile_wat_helper(&wat)
+}
+
 /// `__aint_neg(a) -> $AverInt`. Small fast path with `i64::MIN`
 /// promotion; Big flips the sign field (magnitude unchanged, stays
 /// canonical).

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -189,6 +189,14 @@ pub(super) enum BuiltinName {
     /// which the receiving helper already treats as clamp-to-all/none or
     /// an out-of-range char index. slice 4 (flip).
     AintToI64Sat,
+    /// `__aint_to_i64_checked(a) -> i64` — CHECKED Int→i64 lowering for an
+    /// Int argument crossing the HOST EFFECT boundary (`Random` bounds,
+    /// `Time.sleep` ms, a network port, a `Terminal` coordinate). A Small
+    /// passes through; a Big TRAPS (`unreachable`), since a canonical Big
+    /// is outside i64 range — mirroring the VM host services' checked
+    /// `AverInt::to_i64()`, which ERRORS rather than saturating an out-of-
+    /// range effect arg. slice 4 (flip).
+    AintToI64Checked,
 }
 
 impl BuiltinName {
@@ -261,6 +269,7 @@ impl BuiltinName {
             Self::AintFromF64 => "__aint_from_f64",
             Self::AintToIndex => "__aint_to_index",
             Self::AintToI64Sat => "__aint_to_i64_sat",
+            Self::AintToI64Checked => "__aint_to_i64_checked",
         }
     }
 
@@ -310,7 +319,7 @@ impl BuiltinName {
                 aint_ref_ty(registry)?,
                 ValType::I32,
             ]),
-            Self::AintToF64 | Self::AintToIndex | Self::AintToI64Sat => {
+            Self::AintToF64 | Self::AintToIndex | Self::AintToI64Sat | Self::AintToI64Checked => {
                 Ok(vec![aint_ref_ty(registry)?])
             }
             Self::AintFromF64 => Ok(vec![ValType::F64]),
@@ -355,7 +364,7 @@ impl BuiltinName {
                 Ok(vec![ValType::I32])
             }
             Self::AintToF64 => Ok(vec![ValType::F64]),
-            Self::AintToI64Sat => Ok(vec![ValType::I64]),
+            Self::AintToI64Sat | Self::AintToI64Checked => Ok(vec![ValType::I64]),
         }
     }
 
@@ -406,6 +415,7 @@ impl BuiltinName {
             Self::AintFromF64 => bignum::emit_aint_from_f64(registry),
             Self::AintToIndex => bignum::emit_aint_to_index(registry),
             Self::AintToI64Sat => bignum::emit_aint_to_i64_sat(registry),
+            Self::AintToI64Checked => bignum::emit_aint_to_i64_checked(registry),
         }
     }
 }

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -182,6 +182,13 @@ pub(super) enum BuiltinName {
     /// `__aint_to_index(a) -> i32` — Vector/List index extraction; Big →
     /// OOB sentinel `-1`. slice 3.
     AintToIndex,
+    /// `__aint_to_i64_sat(a) -> i64` — saturating Int→i64 lowering for an
+    /// Int ARGUMENT into an i64-typed builtin slot (`List.take`/`drop`
+    /// counts, `String.charAt`/`slice` indices, `Char.fromCode`). A Small
+    /// passes through; a Big saturates by sign to i64::MAX / i64::MIN,
+    /// which the receiving helper already treats as clamp-to-all/none or
+    /// an out-of-range char index. slice 4 (flip).
+    AintToI64Sat,
 }
 
 impl BuiltinName {
@@ -253,6 +260,7 @@ impl BuiltinName {
             Self::AintToF64 => "__aint_to_f64",
             Self::AintFromF64 => "__aint_from_f64",
             Self::AintToIndex => "__aint_to_index",
+            Self::AintToI64Sat => "__aint_to_i64_sat",
         }
     }
 
@@ -302,7 +310,9 @@ impl BuiltinName {
                 aint_ref_ty(registry)?,
                 ValType::I32,
             ]),
-            Self::AintToF64 | Self::AintToIndex => Ok(vec![aint_ref_ty(registry)?]),
+            Self::AintToF64 | Self::AintToIndex | Self::AintToI64Sat => {
+                Ok(vec![aint_ref_ty(registry)?])
+            }
             Self::AintFromF64 => Ok(vec![ValType::F64]),
         }
     }
@@ -345,6 +355,7 @@ impl BuiltinName {
                 Ok(vec![ValType::I32])
             }
             Self::AintToF64 => Ok(vec![ValType::F64]),
+            Self::AintToI64Sat => Ok(vec![ValType::I64]),
         }
     }
 
@@ -394,6 +405,7 @@ impl BuiltinName {
             Self::AintToF64 => bignum::emit_aint_to_f64(registry),
             Self::AintFromF64 => bignum::emit_aint_from_f64(registry),
             Self::AintToIndex => bignum::emit_aint_to_index(registry),
+            Self::AintToI64Sat => bignum::emit_aint_to_i64_sat(registry),
         }
     }
 }

--- a/src/codegen/wasm_gc/builtins/wat/to_i64_checked.wat
+++ b/src/codegen/wasm_gc/builtins/wat/to_i64_checked.wat
@@ -1,0 +1,17 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result i64)
+            ;; Checked `$AverInt` -> i64 for an Int argument crossing the
+            ;; HOST EFFECT boundary (a Random bound, Time.sleep ms, a
+            ;; network port, a Terminal coordinate). The host ABI is i64;
+            ;; the VM's host services do a checked `AverInt::to_i64()` and
+            ;; ERROR when the value does not fit i64. Mirror that: a Small
+            ;; passes its $small through unchanged; a Big is BY DEFINITION
+            ;; of the canonical form outside i64 range, so it TRAPS
+            ;; (`unreachable`) — the program rejects on wasm-gc exactly as
+            ;; the VM rejects, instead of silently saturating an out-of-
+            ;; range effect arg to i64::MAX/MIN and proceeding.
+            (if (result i64) (ref.is_null (struct.get $aint $magf (local.get $a)))
+              (then (struct.get $aint $small (local.get $a)))
+              (else (unreachable)))))

--- a/src/codegen/wasm_gc/builtins/wat/to_i64_sat.wat
+++ b/src/codegen/wasm_gc/builtins/wat/to_i64_sat.wat
@@ -1,0 +1,18 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $a (ref null $aint)) (result i64)
+            ;; Saturating `$AverInt` -> i64. A Small passes its $small
+            ;; through unchanged. A Big saturates by sign: a positive Big
+            ;; (necessarily > i64::MAX) -> i64::MAX, a negative Big
+            ;; (< i64::MIN) -> i64::MIN. Used to lower an Int argument into
+            ;; an i64-typed builtin slot where out-of-i64 magnitudes only
+            ;; need to be clamped to "all"/"none" (List.take / List.drop
+            ;; counts) or a String char index past the string length, which
+            ;; the receiving helper already treats as out of range.
+            (if (result i64) (ref.is_null (struct.get $aint $magf (local.get $a)))
+              (then (struct.get $aint $small (local.get $a)))
+              (else
+                (if (result i64) (i32.gt_s (struct.get $aint $sign (local.get $a)) (i32.const 0))
+                  (then (i64.const 0x7fffffffffffffff))
+                  (else (i64.const 0x8000000000000000)))))))

--- a/src/codegen/wasm_gc/lists.rs
+++ b/src/codegen/wasm_gc/lists.rs
@@ -2634,15 +2634,12 @@ fn emit_sum_inline_hash(
                 field_ty.trim().to_string()
             };
             match resolved.as_str() {
-                // A GENUINE `Int` field lowers to `$aint` under bignum →
-                // `__aint_hash`; a newtype-erased Int (`resolved == "Int"`
-                // but `field_ty != "Int"`) stays a scalar i64 → wrap. Both
-                // are byte-identical flag-off.
-                "Int" if field_ty.trim() == "Int" => {
-                    emit_aint_field_hash(f, registry)?;
-                }
+                // `Int = ℤ` — an `Int` field lowers to `$aint` under
+                // bignum, so both a genuine and a newtype-erased
+                // (`Box(v: Int)`) Int field hash via `__aint_hash`. The
+                // helper falls to `i32.wrap_i64` when no Int is reachable.
                 "Int" => {
-                    f.instruction(&Instruction::I32WrapI64);
+                    emit_aint_field_hash(f, registry)?;
                 }
                 "Bool" => {} // already i32
                 "Float" => {
@@ -2717,14 +2714,11 @@ fn emit_record_inline_hash(
             field_type.trim().to_string()
         };
         match resolved.as_str() {
-            // Genuine `Int` field → `$aint` under bignum → `__aint_hash`;
-            // newtype-erased Int stays scalar i64 → wrap. Byte-identical
-            // flag-off.
-            "Int" if field_type.trim() == "Int" => {
-                emit_aint_field_hash(f, registry)?;
-            }
+            // `Int = ℤ` — both a genuine and a newtype-erased Int field
+            // lower to `$aint` and hash via `__aint_hash` (the helper falls
+            // to `i32.wrap_i64` when no Int is reachable).
             "Int" => {
-                f.instruction(&Instruction::I32WrapI64);
+                emit_aint_field_hash(f, registry)?;
             }
             "Bool" => {} // already i32
             "Float" => {

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -6279,9 +6279,11 @@ fn emit_factory_terminal_size_make(
     // `Terminal.Size` fields are the `$AverInt` carrier — lift each.
     let lift = |f: &mut Function| -> Result<(), WasmGcError> {
         if registry.bignum {
-            let from_i64 = registry.aint_from_i64_fn_idx.ok_or(WasmGcError::Validation(
-                "bignum Terminal.Size factory needs the __aint_from_i64 fn idx".into(),
-            ))?;
+            let from_i64 = registry
+                .aint_from_i64_fn_idx
+                .ok_or(WasmGcError::Validation(
+                    "bignum Terminal.Size factory needs the __aint_from_i64 fn idx".into(),
+                ))?;
             f.instruction(&Instruction::Call(from_i64));
         }
         Ok(())
@@ -6464,9 +6466,11 @@ fn emit_factory_tcp_connection_make(
     // `Tcp.Connection.port` field is the `$AverInt` carrier — lift it.
     f.instruction(&Instruction::LocalGet(2));
     if registry.bignum {
-        let from_i64 = registry.aint_from_i64_fn_idx.ok_or(WasmGcError::Validation(
-            "bignum Tcp.Connection factory needs the __aint_from_i64 fn idx".into(),
-        ))?;
+        let from_i64 = registry
+            .aint_from_i64_fn_idx
+            .ok_or(WasmGcError::Validation(
+                "bignum Tcp.Connection factory needs the __aint_from_i64 fn idx".into(),
+            ))?;
         f.instruction(&Instruction::Call(from_i64));
     }
     f.instruction(&Instruction::StructNew(rec_idx));
@@ -6547,9 +6551,11 @@ fn emit_factory_http_response_make(
     // under bignum — lift it to a Small before `struct.new`.
     f.instruction(&Instruction::LocalGet(0));
     if registry.bignum {
-        let from_i64 = registry.aint_from_i64_fn_idx.ok_or(WasmGcError::Validation(
-            "bignum HttpResponse factory needs the __aint_from_i64 fn idx".into(),
-        ))?;
+        let from_i64 = registry
+            .aint_from_i64_fn_idx
+            .ok_or(WasmGcError::Validation(
+                "bignum HttpResponse factory needs the __aint_from_i64 fn idx".into(),
+            ))?;
         f.instruction(&Instruction::Call(from_i64));
     }
     f.instruction(&Instruction::LocalGet(1));

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -876,6 +876,8 @@ pub(super) fn emit_module_with(
     if registry.bignum {
         registry.aint_eq_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintEq);
         registry.aint_hash_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintHash);
+        registry.aint_from_i64_fn_idx =
+            builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintFromI64);
     }
 
     // 6) Map helper fn types (per-K hash + eq, per-(K,V) empty/set/get/len).
@@ -2380,6 +2382,13 @@ pub(super) fn emit_module_with(
             exports.export("__rt_string_to_lm", ExportKind::Func, b.to_lm_fn);
             exports.export("__rt_memory_pages", ExportKind::Func, b.pages_fn);
             exports.export("__rt_memory_grow", ExportKind::Func, b.grow_fn);
+            // `Int = ℤ`: `Int` entry params are the `$AverInt` carrier, so
+            // the host (`aver run --wasm-gc --expr`, record/replay) needs a
+            // way to build one from a machine-range i64 it parsed. Re-export
+            // the canonical Small constructor under a stable bridge name.
+            if let Some(idx) = registry.aint_from_i64_fn_idx {
+                exports.export("__rt_aint_from_i64", ExportKind::Func, idx);
+            }
         }
         exports.export("memory", ExportKind::Memory, 0);
     } else if cabi_realloc.is_some() {
@@ -6262,8 +6271,21 @@ fn emit_factory_terminal_size_make(
         .expect("checked at allocation");
     let mut f = Function::new([]);
     // params (width: i64, height: i64) → struct in declaration order.
+    // `Int = ℤ`: the host passes width/height as i64, but both
+    // `Terminal.Size` fields are the `$AverInt` carrier — lift each.
+    let lift = |f: &mut Function| -> Result<(), WasmGcError> {
+        if registry.bignum {
+            let from_i64 = registry.aint_from_i64_fn_idx.ok_or(WasmGcError::Validation(
+                "bignum Terminal.Size factory needs the __aint_from_i64 fn idx".into(),
+            ))?;
+            f.instruction(&Instruction::Call(from_i64));
+        }
+        Ok(())
+    };
     f.instruction(&Instruction::LocalGet(0));
+    lift(&mut f)?;
     f.instruction(&Instruction::LocalGet(1));
+    lift(&mut f)?;
     f.instruction(&Instruction::StructNew(rec_idx));
     f.instruction(&Instruction::End);
     Ok(f)
@@ -6508,7 +6530,16 @@ fn emit_factory_http_response_make(
         .record_type_idx("HttpResponse")
         .expect("checked at allocation");
     let mut f = Function::new([]);
+    // `Int = ℤ`: the host passes the HTTP `status` as i64 (the ABI stays
+    // i64), but the `HttpResponse.status` field is the `$AverInt` carrier
+    // under bignum — lift it to a Small before `struct.new`.
     f.instruction(&Instruction::LocalGet(0));
+    if registry.bignum {
+        let from_i64 = registry.aint_from_i64_fn_idx.ok_or(WasmGcError::Validation(
+            "bignum HttpResponse factory needs the __aint_from_i64 fn idx".into(),
+        ))?;
+        f.instruction(&Instruction::Call(from_i64));
+    }
     f.instruction(&Instruction::LocalGet(1));
     f.instruction(&Instruction::LocalGet(2));
     f.instruction(&Instruction::StructNew(rec_idx));

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -223,6 +223,12 @@ pub(super) fn emit_module_with(
             // i64-typed builtin slot (`List.take`/`drop` counts,
             // `String.charAt`/`slice` indices, `Char.fromCode`).
             BuiltinName::AintToI64Sat,
+            // CHECKED Int→i64 lowering for an Int argument crossing the
+            // host EFFECT boundary (`Random` bounds, `Time.sleep` ms, a
+            // network port, a `Terminal` coordinate). A Big TRAPS instead
+            // of saturating, so an out-of-range effect arg rejects on
+            // wasm-gc exactly as the VM's checked `to_i64()` errors.
+            BuiltinName::AintToI64Checked,
         ] {
             builtin_registry.register(b);
         }
@@ -878,8 +884,8 @@ pub(super) fn emit_module_with(
         registry.aint_hash_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintHash);
         registry.aint_from_i64_fn_idx =
             builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintFromI64);
-        registry.aint_to_i64_sat_fn_idx =
-            builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintToI64Sat);
+        registry.aint_to_i64_checked_fn_idx =
+            builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintToI64Checked);
     }
 
     // 6) Map helper fn types (per-K hash + eq, per-(K,V) empty/set/get/len).
@@ -2643,7 +2649,7 @@ pub(super) fn emit_module_with(
             headers_map_type_idx: map_slots.map,
             list_string_type_idx: list_string_idx,
             option_list_string_type_idx: opt_list_string_idx,
-            aint_to_i64_sat_fn_idx: registry.aint_to_i64_sat_fn_idx,
+            aint_to_i64_checked_fn_idx: registry.aint_to_i64_checked_fn_idx,
         };
         let helpers = super::wasip2_http_server::ServerHandlerHelperFns {
             cabi_realloc_fn: cabi,

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -1637,6 +1637,7 @@ pub(super) fn emit_module_with(
             headers_map_type_idx: map_slots.map,
             list_string_type_idx: list_string_idx,
             option_list_string_type_idx: opt_list_string_idx,
+            aint_from_i64_fn_idx: registry.aint_from_i64_fn_idx,
         })
     } else {
         None

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -878,6 +878,8 @@ pub(super) fn emit_module_with(
         registry.aint_hash_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintHash);
         registry.aint_from_i64_fn_idx =
             builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintFromI64);
+        registry.aint_to_i64_sat_fn_idx =
+            builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintToI64Sat);
     }
 
     // 6) Map helper fn types (per-K hash + eq, per-(K,V) empty/set/get/len).
@@ -2641,6 +2643,7 @@ pub(super) fn emit_module_with(
             headers_map_type_idx: map_slots.map,
             list_string_type_idx: list_string_idx,
             option_list_string_type_idx: opt_list_string_idx,
+            aint_to_i64_sat_fn_idx: registry.aint_to_i64_sat_fn_idx,
         };
         let helpers = super::wasip2_http_server::ServerHandlerHelperFns {
             cabi_realloc_fn: cabi,

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -219,6 +219,10 @@ pub(super) fn emit_module_with(
             BuiltinName::AintToF64,
             BuiltinName::AintFromF64,
             BuiltinName::AintToIndex,
+            // Saturating Int→i64 lowering for an Int ARGUMENT into an
+            // i64-typed builtin slot (`List.take`/`drop` counts,
+            // `String.charAt`/`slice` indices, `Char.fromCode`).
+            BuiltinName::AintToI64Sat,
         ] {
             builtin_registry.register(b);
         }

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -6456,7 +6456,15 @@ fn emit_factory_tcp_connection_make(
     let mut f = Function::new([]);
     f.instruction(&Instruction::LocalGet(0));
     f.instruction(&Instruction::LocalGet(1));
+    // `Int = ℤ`: the host passes `port` as i64 (machine-range), but the
+    // `Tcp.Connection.port` field is the `$AverInt` carrier — lift it.
     f.instruction(&Instruction::LocalGet(2));
+    if registry.bignum {
+        let from_i64 = registry.aint_from_i64_fn_idx.ok_or(WasmGcError::Validation(
+            "bignum Tcp.Connection factory needs the __aint_from_i64 fn idx".into(),
+        ))?;
+        f.instruction(&Instruction::Call(from_i64));
+    }
     f.instruction(&Instruction::StructNew(rec_idx));
     f.instruction(&Instruction::End);
     Ok(f)

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -180,6 +180,11 @@ pub(super) struct TypeRegistry {
     /// `Int` field (HTTP status, terminal rows/cols) as i64 from the host
     /// and must lift it to the `$AverInt` carrier before `struct.new`.
     pub(super) aint_from_i64_fn_idx: Option<u32>,
+    /// wasm fn idx of `__aint_to_i64_sat`, recorded alongside
+    /// `aint_from_i64_fn_idx`. `Some` iff `bignum`. Used by the
+    /// `--handler` proxy synthesis to saturate-lower the user's
+    /// `HttpResponse.status` `$AverInt` field to i64 before `set-status-code`.
+    pub(super) aint_to_i64_sat_fn_idx: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -986,6 +991,7 @@ impl TypeRegistry {
             aint_eq_fn_idx: None,
             aint_hash_fn_idx: None,
             aint_from_i64_fn_idx: None,
+            aint_to_i64_sat_fn_idx: None,
         }
     }
 

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -173,6 +173,13 @@ pub(super) struct TypeRegistry {
     /// folds limbs+sign); the inline `i32.wrap_i64` over a raw value is
     /// invalid on a ref and collision-collapses every Big to one bucket.
     pub(super) aint_hash_fn_idx: Option<u32>,
+    /// wasm fn idx of the `__aint_from_i64` canonical Small constructor,
+    /// recorded alongside `aint_eq_fn_idx`. `Some` iff `bignum`. Used by
+    /// the host-ABI record FACTORIES (`__rt_record_http_response_make`,
+    /// `__rt_record_terminal_size_make`) which receive a machine-range
+    /// `Int` field (HTTP status, terminal rows/cols) as i64 from the host
+    /// and must lift it to the `$AverInt` carrier before `struct.new`.
+    pub(super) aint_from_i64_fn_idx: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -974,9 +981,11 @@ impl TypeRegistry {
             aint_struct_idx,
             aint_mag_array_idx,
             // Set by `module.rs` after `BuiltinRegistry::assign_slots`,
-            // once the `__aint_eq` / `__aint_hash` fn indices are known.
+            // once the `__aint_eq` / `__aint_hash` / `__aint_from_i64`
+            // fn indices are known.
             aint_eq_fn_idx: None,
             aint_hash_fn_idx: None,
+            aint_from_i64_fn_idx: None,
         }
     }
 

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -138,13 +138,14 @@ pub(super) struct TypeRegistry {
     /// declared. The runtime allocates the array lazily on first
     /// `Tcp.connect` call via `array.new_default` against this idx.
     pub(super) tcp_pool_type_idx: Option<u32>,
-    /// bignum slice 1 — opt-in arbitrary-precision `Int`. `true` when
-    /// the `AVER_WASMGC_BIGNUM` env flag is set AND any Int arithmetic
-    /// is reachable (so pure-String/Float/effect-only programs carry
-    /// zero bignum bytes). When set, `Int` lowers to `(ref null
-    /// $AverInt)` everywhere instead of the scalar `i64`, and `*` / `+`
-    /// / `-` / neg / cmp / eq route through the limb-arithmetic WAT
-    /// helpers rather than the wrapping `i64.*` opcodes.
+    /// Arbitrary-precision `Int` (`Int = ℤ`, the only wasm-gc Int
+    /// semantics). `true` when any Int arithmetic is reachable — a SIZE
+    /// reachability gate, NOT a semantics flag (so pure-String/Float/
+    /// effect-only programs carry zero bignum bytes). When set, `Int`
+    /// lowers to `(ref null $AverInt)` everywhere instead of the scalar
+    /// `i64`, and `*` / `+` / `-` / neg / cmp / eq route through the
+    /// limb-arithmetic WAT helpers rather than the wrapping `i64.*`
+    /// opcodes.
     pub(super) bignum: bool,
     /// bignum slice 1 — wasm type idx for the `$AverInt` struct
     /// `(struct (field $small i64) (field $mag (ref null (array i64)))
@@ -342,16 +343,16 @@ impl TypeRegistry {
             (None, None)
         };
 
-        // bignum slice 1 — `$AverInt` + `(array i64)` magnitude slots.
-        // Gated on the opt-in `AVER_WASMGC_BIGNUM` env flag AND "any Int
-        // arithmetic is reachable" so pure-String/Float/effect-only
-        // programs (and the 245B hello-worker) carry ZERO bignum bytes.
-        // The magnitude array slot is allocated first so the struct can
-        // reference it without a forward edge (a single rec group makes
-        // this safe, but keeping the array lower mirrors the other
-        // collection slots and reads cleaner).
-        let bignum_flag = std::env::var_os("AVER_WASMGC_BIGNUM").is_some();
-        let bignum = bignum_flag && resolved_fn_defs.iter().any(fn_uses_int_arithmetic);
+        // `$AverInt` + `(array i64)` magnitude slots. `Int = ℤ` is now
+        // the only wasm-gc semantics (no flag), so this is governed purely
+        // by the "any Int arithmetic reachable" REACHABILITY gate: it is a
+        // SIZE optimization, not a semantics switch. Pure-String/Float/
+        // effect-only programs (and the 245B hello-worker) carry ZERO
+        // bignum bytes. The magnitude array slot is allocated first so the
+        // struct can reference it without a forward edge (a single rec
+        // group makes this safe, but keeping the array lower mirrors the
+        // other collection slots and reads cleaner).
+        let bignum = resolved_fn_defs.iter().any(fn_uses_int_arithmetic);
         let (aint_mag_array_idx, aint_struct_idx) = if bignum {
             let mag_idx = next_idx;
             next_idx += 1;
@@ -1461,14 +1462,14 @@ fn fn_body_calls_int_div(fd: &crate::ir::hir::ResolvedFnDef) -> bool {
     fn_body_calls_builtin(fd, "Int.div")
 }
 
-/// bignum slice 1 — "any Int arithmetic reachable" gate. True iff the
-/// fn signature mentions `Int` (param or return) OR the body contains
-/// an arithmetic `BinOp` / `Neg` / Int literal. Used to keep the
-/// `$AverInt` slots out of pure-String/Float/effect-only programs even
-/// when the `AVER_WASMGC_BIGNUM` flag is set. Deliberately broad (an
-/// Int param is enough): the cost of a false positive is two unused
-/// type slots that `wasm-opt -Oz` would strip anyway; a false negative
-/// would be a miscompile, so we err toward inclusion.
+/// "any Int arithmetic reachable" gate. True iff the fn signature
+/// mentions `Int` (param or return) OR the body contains an arithmetic
+/// `BinOp` / `Neg` / Int literal. Used to keep the `$AverInt` slots out
+/// of pure-String/Float/effect-only programs (a SIZE optimization — the
+/// semantics are always `Int = ℤ`). Deliberately broad (an Int param is
+/// enough): the cost of a false positive is two unused type slots that
+/// `wasm-opt -Oz` would strip anyway; a false negative would be a
+/// miscompile, so we err toward inclusion.
 /// Builtins whose signature mentions `Int` (produce OR consume one), so a
 /// call to any of them must flip the bignum gate even in a module with no
 /// Int literal / arithmetic of its own. Kept in sync with the surface
@@ -1706,10 +1707,10 @@ pub(super) fn aver_to_wasm(
     registry: Option<&TypeRegistry>,
 ) -> Result<Option<ValType>, WasmGcError> {
     let trimmed = type_str.trim();
-    // bignum slice 1 — under the opt-in flag, `Int` is the `$AverInt`
-    // struct ref everywhere (signatures, locals, etc.), NOT the scalar
-    // `i64`. Intercept before `primitive_to_wasm` so the ref shape wins.
-    // Float / Bool keep their scalar lowering.
+    // `Int = ℤ`: `Int` is the `$AverInt` struct ref everywhere
+    // (signatures, locals, etc.) whenever Int arithmetic is reachable,
+    // NOT the scalar `i64`. Intercept before `primitive_to_wasm` so the
+    // ref shape wins. Float / Bool keep their scalar lowering.
     if trimmed == "Int"
         && let Some(reg) = registry
         && reg.bignum
@@ -1726,8 +1727,14 @@ pub(super) fn aver_to_wasm(
         // Newtype optimization — a single-field record / single-variant
         // sum of a primitive lowers to the underlying primitive
         // everywhere. Saves an allocation per wrap and a struct.get
-        // per unwrap.
+        // per unwrap. `Int = ℤ`: an erased Int field is the `$AverInt`
+        // ref, NOT scalar i64 — recurse so the bignum interception above
+        // applies (otherwise an erased `Box(v: Int)` lowers to i64 while
+        // its stored/compared value is a ref → wasm-validation mismatch).
         if let Some(underlying) = reg.newtype_underlying(trimmed) {
+            if underlying.trim() == "Int" && reg.bignum {
+                return Ok(Some(aint_ref_ty(reg)?));
+            }
             return Ok(primitive_to_wasm(underlying));
         }
         if let Some(idx) = reg.record_type_idx(trimmed) {

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -180,11 +180,13 @@ pub(super) struct TypeRegistry {
     /// `Int` field (HTTP status, terminal rows/cols) as i64 from the host
     /// and must lift it to the `$AverInt` carrier before `struct.new`.
     pub(super) aint_from_i64_fn_idx: Option<u32>,
-    /// wasm fn idx of `__aint_to_i64_sat`, recorded alongside
-    /// `aint_from_i64_fn_idx`. `Some` iff `bignum`. Used by the
-    /// `--handler` proxy synthesis to saturate-lower the user's
-    /// `HttpResponse.status` `$AverInt` field to i64 before `set-status-code`.
-    pub(super) aint_to_i64_sat_fn_idx: Option<u32>,
+    /// wasm fn idx of `__aint_to_i64_checked` (TRAPS on an out-of-i64 Big).
+    /// `Some` iff `bignum`. Used by the `--handler` proxy synthesis to
+    /// CHECKED-lower the user's `HttpResponse.status` `$AverInt` field to
+    /// i64 before `set-status-code` — the VM rejects an out-of-range status
+    /// (`HttpResponse.status is out of range`), so an out-of-range status
+    /// TRAPS here rather than saturating into a wrong in-range code.
+    pub(super) aint_to_i64_checked_fn_idx: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -991,7 +993,7 @@ impl TypeRegistry {
             aint_eq_fn_idx: None,
             aint_hash_fn_idx: None,
             aint_from_i64_fn_idx: None,
-            aint_to_i64_sat_fn_idx: None,
+            aint_to_i64_checked_fn_idx: None,
         }
     }
 

--- a/src/codegen/wasm_gc/wasip2_http.rs
+++ b/src/codegen/wasm_gc/wasip2_http.rs
@@ -80,6 +80,11 @@ pub(super) struct HttpGetIndices {
     /// `Map.get` over the headers map; consumed via `struct.get`
     /// to extract tag (offset 0) + payload (offset 1).
     pub option_list_string_type_idx: u32,
+    /// `Int = ℤ`: wasm fn idx of `__aint_from_i64`, `Some` iff bignum.
+    /// The `HttpResponse.status` field is the `$AverInt` carrier, so the
+    /// inline u16→i64-widened status is lifted through this before the
+    /// `struct.new HttpResponse`.
+    pub aint_from_i64_fn_idx: Option<u32>,
 }
 
 /// Bundle of wasm fn indices the body references via `Call(idx)`.
@@ -1935,6 +1940,11 @@ pub(super) fn emit_http_get(indices: &HttpGetIndices, h: &HttpGetHelperFns) -> F
     // status: i64 — wasi returned u16 zero-extended in i32; widen.
     f.instruction(&Instruction::LocalGet(l_in_buf));
     f.instruction(&Instruction::I64ExtendI32U);
+    // `Int = ℤ`: the `HttpResponse.status` field is the `$AverInt`
+    // carrier — lift the widened i64 before `struct.new`.
+    if let Some(from_i64) = indices.aint_from_i64_fn_idx {
+        f.instruction(&Instruction::Call(from_i64));
+    }
 
     // body: ref string (l_arr, populated above).
     f.instruction(&Instruction::LocalGet(l_arr));

--- a/src/codegen/wasm_gc/wasip2_http_server.rs
+++ b/src/codegen/wasm_gc/wasip2_http_server.rs
@@ -105,11 +105,14 @@ pub(super) struct ServerHandlerIndices {
     /// `Map.get` when probing for an existing entry during the
     /// request-headers build.
     pub option_list_string_type_idx: u32,
-    /// `Int = ℤ`: wasm fn idx of `__aint_to_i64_sat`, `Some` iff bignum.
-    /// The user `HttpResponse.status` field is the `$AverInt` carrier, so
-    /// reading it for `set-status-code` first saturate-lowers to i64 (then
-    /// `i32.wrap`) instead of an `i32.wrap` on the ref.
-    pub aint_to_i64_sat_fn_idx: Option<u32>,
+    /// `Int = ℤ`: wasm fn idx of `__aint_to_i64_checked` (TRAPS on an
+    /// out-of-i64 Big), `Some` iff bignum. The user `HttpResponse.status`
+    /// field is the `$AverInt` carrier and flows OUT to the host; reading it
+    /// for `set-status-code` CHECKED-lowers to i64 (then `i32.wrap`) so an
+    /// out-of-range status REJECTS, mirroring the VM (`HttpResponse.status
+    /// is out of range`), instead of an `i32.wrap` saturating a Big into a
+    /// wrong in-range code.
+    pub aint_to_i64_checked_fn_idx: Option<u32>,
 }
 
 /// Bundle of wasm fn indices the body references via `Call(idx)`.
@@ -1059,10 +1062,12 @@ pub(super) fn emit_aver_http_handle(
         struct_type_index: resp_idx,
         field_index: 0, // status: i64 (scalar) or $AverInt ref (bignum)
     });
-    // `Int = ℤ`: the status field is the `$AverInt` carrier — saturate-
-    // lower to i64 before the `i32.wrap` (a status fits well within i32).
-    if let Some(to_sat) = indices.aint_to_i64_sat_fn_idx {
-        f.instruction(&Instruction::Call(to_sat));
+    // `Int = ℤ`: the status field is the `$AverInt` carrier flowing OUT to
+    // the host — CHECKED-lower to i64 before the `i32.wrap` so an out-of-
+    // i64 status TRAPS (the VM rejects it: `HttpResponse.status is out of
+    // range`) instead of saturating a Big into a wrong in-range code.
+    if let Some(to_checked) = indices.aint_to_i64_checked_fn_idx {
+        f.instruction(&Instruction::Call(to_checked));
     }
     f.instruction(&Instruction::I32WrapI64);
     f.instruction(&Instruction::LocalSet(l_ob_off)); // reuse i32 scratch for status

--- a/src/codegen/wasm_gc/wasip2_http_server.rs
+++ b/src/codegen/wasm_gc/wasip2_http_server.rs
@@ -105,6 +105,11 @@ pub(super) struct ServerHandlerIndices {
     /// `Map.get` when probing for an existing entry during the
     /// request-headers build.
     pub option_list_string_type_idx: u32,
+    /// `Int = ℤ`: wasm fn idx of `__aint_to_i64_sat`, `Some` iff bignum.
+    /// The user `HttpResponse.status` field is the `$AverInt` carrier, so
+    /// reading it for `set-status-code` first saturate-lowers to i64 (then
+    /// `i32.wrap`) instead of an `i32.wrap` on the ref.
+    pub aint_to_i64_sat_fn_idx: Option<u32>,
 }
 
 /// Bundle of wasm fn indices the body references via `Call(idx)`.
@@ -1052,8 +1057,13 @@ pub(super) fn emit_aver_http_handle(
     f.instruction(&Instruction::LocalGet(l_resp_struct));
     f.instruction(&Instruction::StructGet {
         struct_type_index: resp_idx,
-        field_index: 0, // status: i64
+        field_index: 0, // status: i64 (scalar) or $AverInt ref (bignum)
     });
+    // `Int = ℤ`: the status field is the `$AverInt` carrier — saturate-
+    // lower to i64 before the `i32.wrap` (a status fits well within i32).
+    if let Some(to_sat) = indices.aint_to_i64_sat_fn_idx {
+        f.instruction(&Instruction::Call(to_sat));
+    }
     f.instruction(&Instruction::I32WrapI64);
     f.instruction(&Instruction::LocalSet(l_ob_off)); // reuse i32 scratch for status
 

--- a/src/runtime/wasm_gc/decode.rs
+++ b/src/runtime/wasm_gc/decode.rs
@@ -168,7 +168,7 @@ pub(super) fn encode_entry_args_for_wasm_gc(
                             .map_err(|e| {
                                 format!("wasm-gc entry arg #{}: __rt_aint_from_i64: {e:#}", idx + 1)
                             })?;
-                        out_aint[0].clone()
+                        out_aint[0]
                     }
                     None => Val::I64(i),
                 }

--- a/src/runtime/wasm_gc/decode.rs
+++ b/src/runtime/wasm_gc/decode.rs
@@ -75,6 +75,30 @@ pub(crate) fn decode_val_typed(
         (Type::Unit, _) => Ok(JsonValue::Null),
         (Type::Int, Val::I64(n)) => Ok(JsonValue::Int(*n)),
         (Type::Int, Val::I32(n)) => Ok(JsonValue::Int(*n as i64)),
+        // `Int = ℤ`: `Int` lowers to the `(ref null $AverInt)` carrier, so
+        // `main () -> Int` returns a struct ref. Read the Small value out
+        // of `$small` (field 0) when `$magf` (field 1) is null. A Big
+        // result has no i64-range representation in the replay trace
+        // format (`JsonValue::Int(i64)`), the same limit the VM hits when
+        // recording — surface it as a clear error rather than truncating.
+        (Type::Int, Val::AnyRef(Some(_))) => {
+            let (_tag, fields) = read_struct(store, val)?;
+            if fields.len() < 2 {
+                return Err(format!(
+                    "Int carrier struct expected >= 2 fields, got {}",
+                    fields.len()
+                ));
+            }
+            match &fields[1] {
+                Val::AnyRef(None) => match &fields[0] {
+                    Val::I64(n) => Ok(JsonValue::Int(*n)),
+                    other => Err(format!("Int carrier $small was not i64: {other:?}")),
+                },
+                _ => Err("Int main return is a Big value, which exceeds the \
+                          i64 replay-trace format"
+                    .to_string()),
+            }
+        }
         (Type::Float, Val::F64(b)) => Ok(JsonValue::Float(f64::from_bits(*b))),
         (Type::Float, Val::F32(b)) => Ok(JsonValue::Float(f32::from_bits(*b) as f64)),
         (Type::Bool, Val::I32(n)) => Ok(JsonValue::Bool(*n != 0)),
@@ -122,16 +146,33 @@ pub(super) fn encode_entry_args_for_wasm_gc(
     let mut out = Vec::with_capacity(args.len());
     for (idx, value) in args.iter().enumerate() {
         let val = match value {
-            Value::Int(n) => match n.to_i64() {
-                Some(i) => Val::I64(i),
-                None => {
-                    return Err(format!(
+            Value::Int(n) => {
+                let i = n.to_i64().ok_or_else(|| {
+                    format!(
                         "wasm-gc entry arg #{}: Int value out of 64-bit range \
-                         (the wasm-gc backend uses 64-bit integers)",
+                         (the host ABI passes Int entry args as i64)",
                         idx + 1
-                    ));
+                    )
+                })?;
+                // `Int = ℤ`: an `Int` entry param is the `$AverInt`
+                // carrier. When the module exports the bridge constructor
+                // (`__rt_aint_from_i64`, present whenever Int is reachable),
+                // build the carrier from the i64; otherwise the param is a
+                // plain scalar i64 (no Int arithmetic reachable) and the raw
+                // value goes through unchanged.
+                match instance.get_func(&mut *store, "__rt_aint_from_i64") {
+                    Some(from_i64) => {
+                        let mut out_aint = [Val::AnyRef(None)];
+                        from_i64
+                            .call(&mut *store, &[Val::I64(i)], &mut out_aint)
+                            .map_err(|e| {
+                                format!("wasm-gc entry arg #{}: __rt_aint_from_i64: {e:#}", idx + 1)
+                            })?;
+                        out_aint[0].clone()
+                    }
+                    None => Val::I64(i),
                 }
-            },
+            }
             Value::Float(f) => Val::F64(f.to_bits()),
             Value::Bool(b) => Val::I32(if *b { 1 } else { 0 }),
             Value::Unit => continue, // Unit-typed param: no slot.

--- a/tests/cross_backend_proptest.rs
+++ b/tests/cross_backend_proptest.rs
@@ -83,6 +83,12 @@ fn run_vm(prefix: &str, source: &str) -> Result<String, String> {
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
+/// Run `source` on the wasm-gc backend. `Int = ℤ` is now the ONLY
+/// wasm-gc Int semantics (the `AVER_WASMGC_BIGNUM` flag was removed in
+/// the slice-4 flip), so this is also the differential oracle for
+/// add/sub/mul/neg/cmp/eq/div-mod/conversions: wasm-gc must agree with
+/// the VM on EVERY input, including the i64-overflow ones the
+/// generators produce.
 fn run_wasm_gc(prefix: &str, source: &str) -> Result<String, String> {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let aver_bin = env!("CARGO_BIN_EXE_aver");
@@ -97,34 +103,6 @@ fn run_wasm_gc(prefix: &str, source: &str) -> Result<String, String> {
     cleanup(&path);
     if !out.status.success() {
         return Err(format!("wasm-gc run failed:\n{}", format_output(&out)));
-    }
-    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
-}
-
-/// Like `run_wasm_gc`, but with the opt-in `AVER_WASMGC_BIGNUM=1` flag
-/// set so `Int` lowers to the arbitrary-precision `$AverInt` carrier
-/// (bignum slice 1). This is the differential oracle for add/sub/mul/
-/// neg/cmp/eq: with the flag on, wasm-gc must agree with the VM
-/// (Int = ℤ) on EVERY input, including the i64-overflow ones the
-/// generator produces.
-fn run_wasm_gc_bignum(prefix: &str, source: &str) -> Result<String, String> {
-    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
-    let path = temp_module(prefix, source);
-    let out = Command::new(aver_bin)
-        .current_dir(&repo_root)
-        .env("AVER_WASMGC_BIGNUM", "1")
-        .arg("run")
-        .arg(&path)
-        .arg("--wasm-gc")
-        .output()
-        .expect("expected `aver run --wasm-gc` (bignum) to execute");
-    cleanup(&path);
-    if !out.status.success() {
-        return Err(format!(
-            "wasm-gc (bignum) run failed:\n{}",
-            format_output(&out)
-        ));
     }
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
@@ -423,8 +401,8 @@ fn wrap_program(expr: &str) -> String {
 // `__aint_eq` — which short-circuits "a Small and a Big are never equal"
 // — would report two equal values UNEQUAL. The only observable that
 // distinguishes them is `==`. This focused test runs programs whose
-// correctness shows ONLY through `==`, flag-on (`AVER_WASMGC_BIGNUM=1`)
-// wasm-gc, and asserts the Bool output matches the VM (`Int = ℤ`).
+// correctness shows ONLY through `==` on the wasm-gc backend
+// (`Int = ℤ` by default), and asserts the Bool output matches the VM.
 //
 // Coverage:
 //   1. both sides reach i64::MIN by DIFFERENT routes (neg-demote vs
@@ -468,7 +446,7 @@ fn cross_int_equality_canonical_invariant_vm_vs_wasm_gc() {
     for (expr, expected) in cases {
         let source = eq_program(expr);
         let vm = run_vm("cross-eq-vm", &source).expect("VM must accept equality program");
-        let wg = run_wasm_gc_bignum("cross-eq-wg", &source)
+        let wg = run_wasm_gc("cross-eq-wg", &source)
             .expect("wasm-gc (bignum) must accept equality program");
         assert_eq!(
             vm, *expected,
@@ -491,8 +469,8 @@ fn cross_int_equality_canonical_invariant_vm_vs_wasm_gc() {
 // equal Big reached a DIFFERENT way would miss its entry). These cases route
 // every such site through `__aint_eq` / `__aint_hash`. Each builds Big values
 // by ARITHMETIC (`i64::MAX + 1`, `a*2`) — literals past i64 are lexer-rejected
-// — and the differential asserts flag-on (`AVER_WASMGC_BIGNUM=1`) wasm-gc
-// matches the VM (Int = ℤ) exactly. The decisive observable is a Big key/field
+// — and the differential asserts the wasm-gc backend (`Int = ℤ` by default)
+// matches the VM exactly. The decisive observable is a Big key/field
 // reached two ways: a string render can't tell a hit from a miss, but
 // `Map.get` / `Map.has` / `==` can.
 //
@@ -550,7 +528,7 @@ fn cross_int_eqhash_map_big_keys_vm_vs_wasm_gc() {
         Console.print(String.fromInt(Option.withDefault(Map.get(m5, bigAgain), 0 - 1)))\n";
     let source = map_int_program("Int", body);
     let vm = run_vm("cross-eqhash-map-vm", &source).expect("VM must accept Map<Int,Int> program");
-    let wg = run_wasm_gc_bignum("cross-eqhash-map-wg", &source)
+    let wg = run_wasm_gc("cross-eqhash-map-wg", &source)
         .expect("wasm-gc (bignum) must accept Map<Int,Int> with Big keys");
     assert_eq!(
         wg, vm,
@@ -576,7 +554,7 @@ fn cross_int_eqhash_set_big_dedup_vm_vs_wasm_gc() {
         Console.print(String.fromBool(Map.has(s3, (big * 2))))\n";
     let source = map_int_program("Bool", body);
     let vm = run_vm("cross-eqhash-set-vm", &source).expect("VM must accept Map<Int,Bool> program");
-    let wg = run_wasm_gc_bignum("cross-eqhash-set-wg", &source)
+    let wg = run_wasm_gc("cross-eqhash-set-wg", &source)
         .expect("wasm-gc (bignum) must accept Set-of-Int with Big members");
     assert_eq!(
         wg, vm,
@@ -619,7 +597,7 @@ fn cross_int_eqhash_record_sum_big_field_vm_vs_wasm_gc() {
              Console.print(String.fromBool(w1 == w4))\n"
         .to_string();
     let vm = run_vm("cross-eqhash-rec-vm", &source).expect("VM must accept record/sum eq program");
-    let wg = run_wasm_gc_bignum("cross-eqhash-rec-wg", &source)
+    let wg = run_wasm_gc("cross-eqhash-rec-wg", &source)
         .expect("wasm-gc (bignum) must accept record/sum eq with a Big Int field");
     assert_eq!(
         wg, vm,
@@ -730,7 +708,7 @@ fn cross_int_euclidean_divmod_vm_vs_wasm_gc() {
     let source = divmod_harness(lines.trim_end());
 
     let vm = run_vm("cross-divmod-vm", &source).expect("VM must accept the divmod harness");
-    let wg = run_wasm_gc_bignum("cross-divmod-wg", &source)
+    let wg = run_wasm_gc("cross-divmod-wg", &source)
         .expect("wasm-gc (bignum) must accept the divmod harness");
 
     // 1. The two backends agree byte-for-byte on every rendered line.
@@ -797,7 +775,7 @@ fn cross_int_big_operand_divmod_vm_vs_wasm_gc() {
     let source = divmod_harness(&body);
 
     let vm = run_vm("cross-bigdm-vm", &source).expect("VM must accept the big divmod program");
-    let wg = run_wasm_gc_bignum("cross-bigdm-wg", &source)
+    let wg = run_wasm_gc("cross-bigdm-wg", &source)
         .expect("wasm-gc (bignum) must accept the big divmod program");
 
     assert_eq!(
@@ -820,8 +798,8 @@ fn cross_int_big_operand_divmod_vm_vs_wasm_gc() {
 // These cover the three slice-3 conversions whose wasm-gc lowering used to be
 // i64-only (`Int.fromString` wrapping past i64), saturating
 // (`Int.fromFloat`/`Float.fromInt` outside i64), or wrong (an `I32WrapI64`
-// of a Big `Vector` index into a wrong in-range slot). Under
-// `AVER_WASMGC_BIGNUM=1` they must match the VM (Int = ℤ) exactly. As with
+// of a Big `Vector` index into a wrong in-range slot). On the wasm-gc
+// backend (`Int = ℤ` by default) they must match the VM exactly. As with
 // the slice-1/2 focused tests, the render goes through BOTH `String.fromInt`
 // AND `"{...}"` interpolation where applicable so neither blind spot hides a
 // divergence.
@@ -875,7 +853,7 @@ fn cross_int_from_string_roundtrip_vm_vs_wasm_gc() {
     );
 
     let vm = run_vm("cross-fs-vm", &source).expect("VM must accept the fromString harness");
-    let wg = run_wasm_gc_bignum("cross-fs-wg", &source)
+    let wg = run_wasm_gc("cross-fs-wg", &source)
         .expect("wasm-gc (bignum) must accept the fromString harness");
     assert_eq!(
         vm, wg,
@@ -941,7 +919,7 @@ fn cross_int_float_exactness_vm_vs_wasm_gc() {
     let source = format!("module Tmp\n\nfn main()\n    ! [Console.print]\n{body}\n");
 
     let vm = run_vm("cross-flt-vm", &source).expect("VM must accept the float-exactness harness");
-    let wg = run_wasm_gc_bignum("cross-flt-wg", &source)
+    let wg = run_wasm_gc("cross-flt-wg", &source)
         .expect("wasm-gc (bignum) must accept the float-exactness harness");
     assert_eq!(
         vm, wg,
@@ -1038,7 +1016,7 @@ fn cross_float_from_int_rounding_vm_vs_wasm_gc() {
 
     let vm =
         run_vm("cross-flt-round-vm", &source).expect("VM must accept the float-rounding harness");
-    let wg = run_wasm_gc_bignum("cross-flt-round-wg", &source)
+    let wg = run_wasm_gc("cross-flt-round-wg", &source)
         .expect("wasm-gc (bignum) must accept the float-rounding harness");
     assert_eq!(
         vm, wg,
@@ -1095,7 +1073,7 @@ fn cross_big_vector_index_oob_vm_vs_wasm_gc() {
     );
 
     let vm = run_vm("cross-bigidx-vm", &source).expect("VM must accept the big-index harness");
-    let wg = run_wasm_gc_bignum("cross-bigidx-wg", &source)
+    let wg = run_wasm_gc("cross-bigidx-wg", &source)
         .expect("wasm-gc (bignum) must accept the big-index harness");
     assert_eq!(
         vm, wg,
@@ -1131,14 +1109,14 @@ proptest! {
     /// (associativity, ordering of side effects inside a chain of
     /// BinOps, …).
     ///
-    /// bignum slice 1 — RE-ENABLED. wasm-gc now carries the same
-    /// arbitrary-precision `Int = ℤ` semantics as the VM under the opt-in
-    /// `AVER_WASMGC_BIGNUM` flag (`$AverInt` carrier; add/sub/mul/neg/cmp/
-    /// eq as limb helpers). The differential oracle therefore holds on
-    /// every input — INCLUDING the i64-overflow ones this generator
-    /// produces — which is the whole point: where the wrapping backend
-    /// returned a wrapped-negative i64 (`a*a` at i64::MAX printed `1`),
-    /// the bignum backend now prints the exact ℤ value the VM prints.
+    /// wasm-gc now carries the same arbitrary-precision `Int = ℤ`
+    /// semantics as the VM BY DEFAULT (`$AverInt` carrier; add/sub/mul/
+    /// neg/cmp/eq as limb helpers — no flag). The differential oracle
+    /// therefore holds on every input — INCLUDING the i64-overflow ones
+    /// this generator produces — which is the whole point: where the
+    /// old wrapping backend returned a wrapped-negative i64 (`a*a` at
+    /// i64::MAX printed `1`), the bignum backend now prints the exact ℤ
+    /// value the VM prints.
     /// The leaves include i64::MIN/MAX, 0, ±1, and large-near-overflow
     /// magnitudes so the Big-promotion + mul-trap-edge + neg-promotion
     /// + canonical-demote paths are all hit.
@@ -1146,7 +1124,7 @@ proptest! {
     fn cross_int_arithmetic_vm_vs_wasm_gc(expr in int_boundary_expr(3)) {
         let source = wrap_program(&format!("String.fromInt({})", expr));
         let vm = run_vm("cross-bp-int-vm", &source);
-        let wg = run_wasm_gc_bignum("cross-bp-int-wg", &source);
+        let wg = run_wasm_gc("cross-bp-int-wg", &source);
         match (&vm, &wg) {
             // Both backends accept the program — outputs must match.
             (Ok(v), Ok(w)) => prop_assert_eq!(
@@ -1186,7 +1164,7 @@ proptest! {
     fn cross_int_arithmetic_via_interpolation_vm_vs_wasm_gc(expr in int_boundary_expr(3)) {
         let source = wrap_program(&format!("\"{{{}}}\"", expr));
         let vm = run_vm("cross-bp-interp-vm", &source);
-        let wg = run_wasm_gc_bignum("cross-bp-interp-wg", &source);
+        let wg = run_wasm_gc("cross-bp-interp-wg", &source);
         match (&vm, &wg) {
             (Ok(v), Ok(w)) => prop_assert_eq!(
                 v, w,

--- a/tests/wasm_gc_capture_output.rs
+++ b/tests/wasm_gc_capture_output.rs
@@ -80,10 +80,11 @@ fn wasm_gc_console_print_writes_to_capture_buffer() {
 }
 
 // Boxed `match Int.div`/`match Int.mod` Err arms carry the VM's exact message
-// strings (`src/types/int.rs`): `"division by zero"` for both, `"division
-// overflow"` for `Int.div`'s `i64::MIN / -1` edge. Pin the wasm-gc captured
-// stdout to those byte-for-byte so the boxed Result construction can't drift
-// from the VM (the only path that produces these literals on wasm-gc).
+// strings (`src/types/int.rs`): `"division by zero"` for both. `Int = ℤ`:
+// `Int.div`'s `i64::MIN / -1` is NO LONGER an overflow Err — it is the valid
+// Big `+2^63` Ok (the slice-2 semantics: there is no i64 overflow over ℤ), so
+// that third case renders `ok`. Pin the wasm-gc captured stdout to those
+// byte-for-byte so the boxed Result construction can't drift from the VM.
 const DIV_MOD_ERR_SRC: &str = r#"module M
     intent =
         "boxed Int.div/mod Err messages"
@@ -141,10 +142,12 @@ fn wasm_gc_boxed_int_div_mod_err_messages_match_vm() {
     if let Err(e) = &run_res {
         panic!("wasm-gc run_in_process should succeed on boxed Int.div/mod, got: {e}");
     }
-    // Byte-for-byte identical to the VM's `src/types/int.rs` messages.
+    // Byte-for-byte identical to the VM. The first two are `Int.div`/`mod`
+    // by zero (still a genuine Err); the third is `Int.div(i64::MIN, -1)`,
+    // which over ℤ is the Ok Big `+2^63` → the `Result.Ok` arm renders `ok`.
     assert_eq!(
         stdout,
-        b"division by zero|division by zero|division overflow\n",
+        b"division by zero|division by zero|ok\n",
         "wasm-gc boxed Int.div/mod Err messages must match the VM verbatim; got {:?}",
         String::from_utf8_lossy(&stdout)
     );

--- a/tests/wasm_gc_effect_arg_overflow_regression.rs
+++ b/tests/wasm_gc_effect_arg_overflow_regression.rs
@@ -1,0 +1,170 @@
+//! Regression: under `Int = ℤ`, an out-of-i64 `Int` passed as an i64-typed
+//! HOST EFFECT argument must REJECT on wasm-gc, matching the VM.
+//!
+//! The bug (confirmed in wasmtime on the bignum default-flip branch): an
+//! out-of-i64 Big Int passed as an i64-typed effect argument silently
+//! SATURATED on wasm-gc and proceeded, where the VM raises a runtime error.
+//! `effect_int_arg_positions` lowered the Int args of host effects via
+//! `__aint_to_i64_sat` (`2^63 -> i64::MAX`) BEFORE the host call, for
+//! `Random.int` bounds, `Time.sleep` ms, `Tcp.*` ports, `HttpServer.*`
+//! bind ports, and `Terminal.moveTo` coordinates. The VM's host services do
+//! a CHECKED `to_i64()` and ERROR instead (e.g. `Random.int: bounds must
+//! fit a 64-bit integer`). Worst case: `Time.sleep(2^63)` saturated to
+//! i64::MAX ms (a ~292-million-year hang) where the VM errors.
+//!
+//! The fix replaces the saturating lower at the EFFECT-arg boundary ONLY
+//! with `__aint_to_i64_checked`, which TRAPS (`unreachable`) on an out-of-
+//! i64 Big. So an out-of-range effect arg now rejects on wasm-gc (a wasm
+//! trap → `run_in_process` returns `Err`) just as the VM errors. The
+//! SATURATING path stays in place for the PURE builtins where saturation
+//! MATCHES the VM (`String.charAt`/`slice` indices, `List.take`/`drop`
+//! counts, `Char.fromCode`) — this test pins that the pure-builtin
+//! saturation is NOT regressed.
+
+#![cfg(feature = "wasm")]
+
+use aver::ir::{NeutralAllocPolicy, PipelineConfig, TypecheckMode};
+
+/// Parse + typecheck + run a program through the in-process wasm-gc runtime,
+/// mirroring the CLI's `aver run --wasm-gc` pipeline (`try_run_wasm_gc` in
+/// `src/main/run_wasm_gc.rs`): the neutral alloc policy + the `analysis`
+/// facts must be threaded into `run_in_process`, otherwise codegen takes a
+/// different (analysis-less) path. Returns `Ok` with captured stdout on a
+/// clean run, or `Err(message)` when wasm execution traps / the backend
+/// rejects.
+fn run_wasm_gc(source: &str) -> Result<String, String> {
+    let mut lexer = aver::lexer::Lexer::new(source);
+    let tokens = lexer.tokenize().expect("lex");
+    let mut parser = aver::parser::Parser::new(tokens);
+    let mut items = parser.parse().expect("parse");
+    let neutral_policy = NeutralAllocPolicy;
+    let result = aver::ir::pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            alloc_policy: Some(&neutral_policy),
+            run_interp_lower: false,
+            run_buffer_build: false,
+            ..Default::default()
+        },
+    );
+
+    let (run_res, stdout, _stderr) = aver::services::console::capture_output(|| {
+        aver::runtime::wasm_gc::run_in_process(
+            &items,
+            result.analysis.as_ref(),
+            aver::runtime::wasm_gc::RunConfig {
+                program_args: Vec::new(),
+                entry_info: None,
+                mode: aver::runtime::wasm_gc::EffectMode::Normal,
+            },
+        )
+    });
+
+    run_res
+        .map(|_| String::from_utf8_lossy(&stdout).into_owned())
+        .map_err(|e| e.to_string())
+}
+
+/// `9223372036854775807 + 1` builds `2^63` (the first value past i64::MAX)
+/// by arithmetic, so the `$AverInt` carrier holds a Big. Passing it as the
+/// `Random.int` upper bound (an i64-typed effect arg) must TRAP on wasm-gc
+/// — the VM errors with `Random.int: bounds must fit a 64-bit integer`.
+#[test]
+fn out_of_i64_random_bound_traps_on_wasm_gc() {
+    let src = r#"module M
+    intent =
+        "out-of-i64 Random.int bound rejects"
+    effects [Random, Console]
+
+fn main() -> Unit
+    ! [Random.int, Console.print]
+    big = 9223372036854775807 + 1
+    n = Random.int(1, big)
+    Console.print("n = {n}")
+"#;
+    let res = run_wasm_gc(src);
+    assert!(
+        res.is_err(),
+        "an out-of-i64 Random.int upper bound must REJECT on wasm-gc (matching the VM's \
+         checked-bounds error), but the run succeeded with stdout: {res:?}"
+    );
+}
+
+/// `Time.sleep(2^63)` must TRAP on wasm-gc, not saturate to i64::MAX ms (a
+/// ~292-million-year hang). The VM errors (`Time.sleep: ms must fit a
+/// 64-bit integer`). The test would HANG, not just fail, on the unfixed
+/// saturating lowering — so a clean (fast) `Err` is the regression guard.
+#[test]
+fn out_of_i64_sleep_ms_traps_on_wasm_gc() {
+    let src = r#"module M
+    intent =
+        "out-of-i64 Time.sleep ms rejects (no 292-million-year hang)"
+    effects [Time, Console]
+
+fn main() -> Unit
+    ! [Time.sleep, Console.print]
+    big = 9223372036854775807 + 1
+    _ = Time.sleep(big)
+    Console.print("woke up")
+"#;
+    let res = run_wasm_gc(src);
+    assert!(
+        res.is_err(),
+        "Time.sleep(2^63) must TRAP on wasm-gc (terminate with an error), not saturate to \
+         i64::MAX ms and hang; run returned: {res:?}"
+    );
+}
+
+/// IN-RANGE effect args STILL WORK: a small `Random.int` bound and a small
+/// `Time.sleep` lower fine through the checked helper (a Small passes its
+/// `$small` through), so the program runs to completion and prints.
+#[test]
+fn in_range_effect_args_still_run_on_wasm_gc() {
+    let src = r#"module M
+    intent =
+        "in-range effect args still run"
+    effects [Random, Time, Console]
+
+fn main() -> Unit
+    ! [Random.int, Time.sleep, Console.print]
+    n = Random.int(1, 6)
+    _ = Time.sleep(1)
+    Console.print("done")
+"#;
+    let out = run_wasm_gc(src).expect("in-range effect args must run cleanly on wasm-gc");
+    assert_eq!(
+        out, "done\n",
+        "a normal program with small Random.int / Time.sleep args must run to completion; \
+         got stdout {out:?}"
+    );
+}
+
+/// PURE-builtin saturation is UNCHANGED: `String.charAt` with an out-of-i64
+/// index past the string end must SATURATE to `Option.None` on wasm-gc (the
+/// VM's clamp), NOT trap. This pins that the fix touched only the EFFECT-arg
+/// boundary and left the saturating `__aint_to_i64_sat` path intact for the
+/// pure builtins where saturation matches the VM.
+#[test]
+fn pure_builtin_out_of_i64_index_still_saturates_on_wasm_gc() {
+    let src = r#"module M
+    intent =
+        "pure-builtin out-of-i64 index saturates to None (unchanged)"
+    effects [Console]
+
+fn main() -> Unit
+    ! [Console.print]
+    big = 9223372036854775807 + 1
+    c = String.charAt("hello", big)
+    match c
+        Option.Some(ch) -> Console.print("got {ch}")
+        Option.None -> Console.print("none")
+"#;
+    let out = run_wasm_gc(src)
+        .expect("String.charAt with an out-of-range index must SATURATE to None, not trap");
+    assert_eq!(
+        out, "none\n",
+        "an out-of-i64 String.charAt index must saturate past the string end to Option.None \
+         (the VM's clamp), matching the pure-builtin saturating path; got stdout {out:?}"
+    );
+}

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -71,11 +71,49 @@ fn run_int(source: &str) -> i64 {
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap_or_else(|e| panic!("instantiate failed: {e}"));
+    call_main_aint(&mut store, &instance)
+}
+
+/// Call the `main` export and extract its `Int` return. `Int = ℤ`:
+/// `main` now returns a `(ref null $AverInt)` carrier, not a scalar
+/// `i64`. Every program in this spec returns a value that fits i64 (a
+/// length, a small arithmetic result), so it is always the Small
+/// representation (`$magf == null`); read field 0 (`$small`). A Big
+/// result would need the limb-array decode, which these in-range tests
+/// never produce.
+fn call_main_aint(store: &mut wasmtime::Store<()>, instance: &wasmtime::Instance) -> i64 {
     let main = instance
-        .get_typed_func::<(), i64>(&mut store, "main")
-        .unwrap_or_else(|e| panic!("main: () -> Int export missing: {e}"));
-    main.call(&mut store, ())
-        .unwrap_or_else(|e| panic!("main trapped: {e}"))
+        .get_func(&mut *store, "main")
+        .unwrap_or_else(|| panic!("main export missing"));
+    let mut results = [wasmtime::Val::I32(0)];
+    main.call(&mut *store, &[], &mut results)
+        .unwrap_or_else(|e| panic!("main trapped: {e}"));
+    extract_aint_small(store, &results[0])
+}
+
+/// Read the Small (`$small`, field 0) i64 out of an `$AverInt` carrier
+/// returned by `main`. Asserts the value is in the Small representation
+/// (the spec programs are all in-range); a non-null `$magf` (field 1)
+/// would mean a Big result this helper does not decode.
+fn extract_aint_small(store: &mut wasmtime::Store<()>, val: &wasmtime::Val) -> i64 {
+    let anyref = match val {
+        wasmtime::Val::AnyRef(Some(a)) => *a,
+        wasmtime::Val::AnyRef(None) => panic!("main returned a null Int carrier"),
+        other => panic!("main returned a non-ref value: {other:?}"),
+    };
+    let structref = anyref
+        .as_struct(&mut *store)
+        .expect("anyref→struct query")
+        .expect("Int carrier is not a struct");
+    let mag = structref.field(&mut *store, 1).expect("read $magf field");
+    match mag {
+        wasmtime::Val::AnyRef(None) => {}
+        _ => panic!("main returned a Big Int; this spec only covers Small results"),
+    }
+    match structref.field(&mut *store, 0).expect("read $small field") {
+        wasmtime::Val::I64(v) => v,
+        other => panic!("$small field was not an i64: {other:?}"),
+    }
 }
 
 /// Walk the module's import section and register a default-value stub
@@ -191,11 +229,7 @@ fn run_int_multi(entry_src: &str, dep_sources: &[(&str, &str)]) -> i64 {
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap_or_else(|e| panic!("instantiate failed: {e}"));
-    let main = instance
-        .get_typed_func::<(), i64>(&mut store, "main")
-        .unwrap_or_else(|e| panic!("main: () -> Int export missing: {e}"));
-    main.call(&mut store, ())
-        .unwrap_or_else(|e| panic!("main trapped: {e}"))
+    call_main_aint(&mut store, &instance)
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -1097,25 +1131,30 @@ fn main() -> Int
     );
 }
 
-// `i64::MIN / -1` is guarded out before `i64.div_s` traps, surfacing as Err.
+// `Int = ℤ`: `i64::MIN / -1` is NOT an overflow Err — over ℤ it is the
+// valid Ok Big `+2^63 = i64::MAX + 1`. The slice-2 semantics deleted the
+// old wrapping/trap guard. To keep the assert in `run_int`'s Small range
+// while exercising the Big quotient, subtract `i64::MAX`: `(+2^63) -
+// i64::MAX == 1`, which demotes back to a Small the harness can read. A
+// wrong (wrapping) quotient would not land on exactly 1.
 #[test]
-fn boxed_int_div_err_overflow() {
+fn boxed_int_div_min_over_neg_one_is_big_ok() {
     assert_eq!(
         run_int(
             r#"module Tmp
-    intent = "boxed Int.div Err (overflow)"
+    intent = "boxed Int.div i64::MIN / -1 = Ok Big +2^63"
     depends []
 
 fn sd(a: Int, b: Int) -> Int
     match Int.div(a, b)
-        Result.Ok(v)  -> v
-        Result.Err(_) -> 0 - 1
+        Result.Ok(v)  -> v - 9223372036854775807
+        Result.Err(_) -> 0 - 999
 
 fn main() -> Int
     sd(0 - 9223372036854775807 - 1, 0 - 1)
 "#
         ),
-        -1
+        1
     );
 }
 


### PR DESCRIPTION
The milestone. `Int = ℤ` (arbitrary precision) is now the **unconditional default** on the wasm-gc backend — the `AVER_WASMGC_BIGNUM` flag is removed. This closes the whole arc: **VM + Rust + wasm-gc all `Int = ℤ`**, no backend wraps i64. `a*a` at `i64::MAX` prints the exact `85070591730234615847396907784232501249` on `aver run --wasm-gc` with no flag — the C0 law the wrapping backend broke (it printed `1`) is now honest everywhere.

Builds on slices 1-3 (#521/#524/#526) + the eq+hash completion (#528), all of which shipped the bignum path behind the flag. This PR flips the default and closes every representation gap the flip exposes.

## Flag removal
`registry.bignum` is now governed purely by the `fn_uses_int_arithmetic` reachability gate (a SIZE optimization — pure-non-Int programs carry zero bignum bytes — never a semantics knob, per the Int-semantics decision). The env read is gone; the old i64-wrapping branches are removed (one path). The cross-backend differential now runs `Int = ℤ` by default.

## Gaps the flip exposed, now fixed
- **Int-returning builtins** lifted to the `$aint` carrier: `List.len`, `Map.len`, `Vector.len`, `String.len`/`byteLength`, `Char.toCode`, and the `Random.int`/`Time.unixMs` effect returns (these returned raw i64, breaking `String.fromInt(Map.len(...))`).
- **Int-arg-consuming builtins** saturate-lowered (`$aint → i64`) via a new `__aint_to_i64_sat` helper: `List.take`/`drop` counts, `Char.fromCode`, `String.charAt`/`slice`, and effect ports/ms/status args.
- **Newtype-over-Int erasure** (`record UserId { v: Int }`): the erased field is now the `$aint` ref everywhere it's read/compared/hashed/stored (was assumed scalar i64 → wasm validation failure).
- **const-fold euclid intrinsic**: `Result.withDefault(Int.div/mod(a, k), _)` routed the i64 `__int_div_euclid` against `$aint` operands — a silent miscompile, now routed to `__aint_divmod`.
- **Host-ABI record factories** (`HttpResponse.status`, `Terminal.Size`, `Tcp.Connection.port`) + the wasip2 effect ABI + record/replay decode lift the i64 Int field to `$aint`.

## Verification (no flag)
- `cargo test --features wasm,wasip2`: **2441 passed, 0 failed** (76 suites — wasm_gc, wasip2, record/replay, the 60-example corpus compile+validate, the 70 differential-MIR).
- The VM-vs-wasm-gc cross-backend differential (now default) at **2000 cases: 16 passed, 0 failed** (~26 min).
- Every Int bench scenario + json/fibonacci runs identically VM vs wasm-gc; big-int const-fold division round-trips exactly.
- `cargo fmt --check` + `cargo clippy --features wasm,wasip2 -- -D warnings` clean.

## Size (`--target wasm-gc --optimize size`) — the honest tradeoff
| Program | i64-wrap (before) | Int = ℤ (after) | Δ |
|---|---|---|---|
| hello-worker (pure String) | 451 B | 451 B | **0** — the discovery gate holds; zero bignum bytes |
| calculator (Int) | 1230 B | 3264 B | +2034 B |
| factorial (Int) | 626 B | 4996 B | +4370 B |

Non-Int programs stay tiny (the 245B-class edge story survives). Int-using programs pay the bignum prelude (~2–4.4 KB). Full size recovery for provably-bounded Int code is the future no-overflow/unboxing-for-wasm analysis (the same one already shipped for Rust speed) — a follow-up, not this PR.

## Deferred (orthogonal to Int = ℤ, pre-existing, not touched)
Two purely-Float wasm-gc bugs the panels noted — `Float.round` half-to-even (VM = half-away-from-zero) and `String.fromFloat` trap on floats ≥ 2^63 — were already broken before this slice and are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)