### PR TITLE
proof-corpus: monomorphized renderings of the 8 higher-order isaplanner problems

### DIFF
--- a/proof-corpus/run.sh
+++ b/proof-corpus/run.sh
@@ -83,10 +83,13 @@ union=0
 total=0
 when_universal=0
 # `decomposed/` holds LLM helper-law-augmented copies of OPEN tip/ tasks (a
-# SEPARATE "loop reach" metric, see decomposed/README.md). Excluded here so the
-# baseline `coverage (union)` stays "what the engine proves UNAIDED on bare
-# tip/" — counting the augmented copies would double-count + inflate it.
-for f in $(find "$ROOT" -name '*.av' -not -path '*/decomposed/*' | sort); do
+# SEPARATE "loop reach" metric, see decomposed/README.md). `isaplanner-mono/`
+# holds monomorphized renderings of the 8 higher-order isaplanner problems Aver
+# cannot express natively (a SEPARATE asterisked metric, see
+# isaplanner-mono/README.md). Both are excluded here so the baseline
+# `coverage (union)` stays "what the engine proves UNAIDED on bare, natively
+# expressible tip/" — folding either in would inflate the headline.
+for f in $(find "$ROOT" -name '*.av' -not -path '*/decomposed/*' -not -path '*/isaplanner-mono/*' | sort); do
   [ -e "$f" ] || continue
   total=$((total + 1))
   lres=$(proves "$f" lean)

--- a/proof-corpus/tip/isaplanner-mono/README.md
+++ b/proof-corpus/tip/isaplanner-mono/README.md
@@ -1,0 +1,76 @@
+# isaplanner-mono — monomorphized renderings of the higher-order TIP problems
+
+The published IsaPlanner benchmark is 85 problems. Eight of them are
+**higher-order** — they pass a function as an argument:
+
+| prop | conjecture | higher-order fn |
+|------|------------|-----------------|
+| 12 | `drop n (map f xs) = map f (drop n xs)` | `map f` |
+| 14 | `filter p (xs ++ ys) = filter p xs ++ filter p ys` | `filter p` |
+| 35 | `dropWhile (λx. False) xs = xs` | `dropWhile` + λ |
+| 36 | `takeWhile (λx. True) xs = xs` | `takeWhile` + λ |
+| 41 | `take n (map f xs) = map f (take n xs)` | `map f` |
+| 43 | `takeWhile p xs ++ dropWhile p xs = xs` | `takeWhile`/`dropWhile p` |
+| 66 | `len (filter p xs) ≤ len xs` | `filter p` |
+| 73 | `rev (filter p xs) = filter p (rev xs)` | `filter p` |
+
+Aver is **first-order with no closures** (whole-program monomorphized — the
+property that buys exact effect footprints, provable `!`, etc.). The stdlib has
+no `List.map`/`filter`/`takeWhile`/`dropWhile`. So these 8 **cannot be written
+natively** — they are *inexpressible*, not unproven, and are absent from
+`../isaplanner/` (which holds the 77 natively-expressible standard problems +
+one extra, `prop_86`).
+
+This directory renders those 8 **the Aver way**: the function/predicate is
+*fixed to a concrete monomorphic instance*, turning the higher-order operator
+into an ordinary first-order recursive function.
+
+## The asterisk (read before quoting any number)
+
+A monomorphized rendering is a **strictly weaker statement** than the
+higher-order original: it loses the `∀`-over-function quantifier (one concrete
+`f`/`p` instead of all of them). It is **not** apples-to-apples with a
+higher-order prover that proves the full `∀ f. …`.
+
+It *is* the same **inductive problem**: in all 8, `f`/`p` is parametric — it is
+carried opaquely or cased on identically — so the induction is the same shape
+the higher-order proof would use. Whole-program monomorphization also means a
+real Aver program never has a generic `map f`; it has `mapSucc`, `filterZero`.
+So this is the *idiomatic* form, not a degraded one.
+
+**Non-degeneracy is required.** A constant `f = id` would collapse the problem
+(`map id xs = xs`) and prove nothing. Instances chosen here:
+
+- `map f` → `mapS` applies `Nat.S` (successor) — genuinely transforms each element.
+- `filter p` / `takeWhile p` / `dropWhile p` → predicate `isZ` (is-zero) — keeps a
+  proper, non-trivial sublist.
+- prop_35 / prop_36 are **faithful by construction**: their predicate *is* the
+  constant `False` / `True`, so `constFalse` / `constTrue` is the exact original,
+  no instance choice involved.
+
+This is a **separate, asterisked metric** — excluded from `run.sh`'s headline
+`coverage (union)` so it can never be conflated with the strict
+natively-expressible number.
+
+## Result (measured 2026-06-15, Lean kernel-genuine, no discovery)
+
+**6 / 8 universal:** prop_12, prop_14, prop_35, prop_36, prop_41, prop_43.
+
+Open: prop_66 (needs a `le`/`S` helper lemma), prop_73 (needs
+`filter (xs++ys) = filter xs ++ filter ys`, i.e. prop_14, as a helper to push
+`filter` through `rev`'s append). Both are exactly the cases a higher-order
+prover closes via **lemma discovery / theory exploration** — honestly open here
+in the no-discovery baseline.
+
+## Denominators (apples-to-apples with the published 85)
+
+- **Strict native:** 41 / 85 — Aver proves 41 standard problems; the 8
+  higher-order ones count as not-done because they are inexpressible.
+- **With this asterisk:** 47 / 85 — adding the 6 monomorphized closures.
+
+For comparison: IsaPlanner 47/85 (rippling + lemma discovery), Dafny 45/85 (Z3,
+prover-accepts). Aver's numbers are Lean kernel-genuine
+(`#print axioms ⊆ {propext, Classical.choice, Quot.sound}`) and discovery-free —
+a trust × no-discovery cell no published tool occupies. The asterisked 47
+landing on IsaPlanner's 47 is a coincidence of counts, **not** of statement
+strength: 6 of Aver's are the weaker fixed-instance form.

--- a/proof-corpus/tip/isaplanner-mono/prop_12.av
+++ b/proof-corpus/tip/isaplanner-mono/prop_12.av
@@ -1,0 +1,29 @@
+module Prop12Mono
+    intent =
+        "TIP isaplanner prop_12, monomorphized (Aver is first-order, no closures):"
+        "drop n (map f xs) = map f (drop n xs), with f FIXED to the concrete"
+        "non-degenerate successor (mapS applies Nat.S). Strictly weaker than the"
+        "higher-order original (loses the forall-over-f), but the induction is"
+        "identical: f is parametric and never participates in the recursion."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn mapS(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> List.concat([Nat.S(y)], mapS(ys))
+
+fn drop(n: Nat, xs: List<Nat>) -> List<Nat>
+    match n
+        Nat.Z -> xs
+        Nat.S(z) -> match xs
+            [] -> []
+            [x2, ..x3] -> drop(z, x3)
+
+verify drop law dropMapCommute
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z)), Nat.Z]]
+    drop(n, mapS(xs)) => mapS(drop(n, xs))

--- a/proof-corpus/tip/isaplanner-mono/prop_14.av
+++ b/proof-corpus/tip/isaplanner-mono/prop_14.av
@@ -1,0 +1,34 @@
+module Prop14Mono
+    intent =
+        "TIP isaplanner prop_14, monomorphized (Aver is first-order, no closures):"
+        "filter p (xs ++ ys) = filter p xs ++ filter p ys, with p FIXED to the"
+        "concrete non-degenerate is-zero predicate (filterZ keeps only Z). Strictly"
+        "weaker than the higher-order original (loses the forall-over-p); the"
+        "induction is identical, the proof cases on p(head) exactly as the HO one."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn isZ(n: Nat) -> Bool
+    match n
+        Nat.Z -> true
+        Nat.S(z) -> false
+
+fn filterZ(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> match isZ(y)
+            true -> List.concat([y], filterZ(ys))
+            false -> filterZ(ys)
+
+fn append(x: List<Nat>, y: List<Nat>) -> List<Nat>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+verify filterZ law filterAppendDistribute
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.Z]]
+    given ys: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z)], [Nat.Z, Nat.Z]]
+    filterZ(append(xs, ys)) => append(filterZ(xs), filterZ(ys))

--- a/proof-corpus/tip/isaplanner-mono/prop_35.av
+++ b/proof-corpus/tip/isaplanner-mono/prop_35.av
@@ -1,0 +1,25 @@
+module Prop35Mono
+    intent =
+        "TIP isaplanner prop_35, monomorphized (Aver is first-order, no closures):"
+        "dropWhile (\\x -> False) xs = xs. The original predicate IS the constant"
+        "False, so the concrete constFalse is a FAITHFUL rendering (no arbitrary"
+        "instance choice). dropWhileF never drops, so it returns the list unchanged."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn constFalse(n: Nat) -> Bool
+    false
+
+fn dropWhileF(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> match constFalse(y)
+            true -> dropWhileF(ys)
+            false -> xs
+
+verify dropWhileF law dropWhileFalseId
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]]
+    dropWhileF(xs) => xs

--- a/proof-corpus/tip/isaplanner-mono/prop_36.av
+++ b/proof-corpus/tip/isaplanner-mono/prop_36.av
@@ -1,0 +1,25 @@
+module Prop36Mono
+    intent =
+        "TIP isaplanner prop_36, monomorphized (Aver is first-order, no closures):"
+        "takeWhile (\\x -> True) xs = xs. The original predicate IS the constant"
+        "True, so the concrete constTrue is a FAITHFUL rendering (no arbitrary"
+        "instance choice). takeWhileT always keeps, so it returns the whole list."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn constTrue(n: Nat) -> Bool
+    true
+
+fn takeWhileT(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> match constTrue(y)
+            true -> List.concat([y], takeWhileT(ys))
+            false -> []
+
+verify takeWhileT law takeWhileTrueId
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]]
+    takeWhileT(xs) => xs

--- a/proof-corpus/tip/isaplanner-mono/prop_41.av
+++ b/proof-corpus/tip/isaplanner-mono/prop_41.av
@@ -1,0 +1,29 @@
+module Prop41Mono
+    intent =
+        "TIP isaplanner prop_41, monomorphized (Aver is first-order, no closures):"
+        "take n (map f xs) = map f (take n xs), with f FIXED to the concrete"
+        "non-degenerate successor (mapS applies Nat.S). Strictly weaker than the"
+        "higher-order original (loses the forall-over-f); the induction is"
+        "identical, f is parametric and never participates in the recursion."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn mapS(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> List.concat([Nat.S(y)], mapS(ys))
+
+fn take(n: Nat, xs: List<Nat>) -> List<Nat>
+    match n
+        Nat.Z -> []
+        Nat.S(z) -> match xs
+            [] -> []
+            [x2, ..x3] -> List.concat([x2], take(z, x3))
+
+verify take law takeMapCommute
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z)), Nat.Z]]
+    take(n, mapS(xs)) => mapS(take(n, xs))

--- a/proof-corpus/tip/isaplanner-mono/prop_43.av
+++ b/proof-corpus/tip/isaplanner-mono/prop_43.av
@@ -1,0 +1,40 @@
+module Prop43Mono
+    intent =
+        "TIP isaplanner prop_43, monomorphized (Aver is first-order, no closures):"
+        "takeWhile p xs ++ dropWhile p xs = xs, with p FIXED to the concrete"
+        "non-degenerate is-zero predicate. Strictly weaker than the higher-order"
+        "original (loses the forall-over-p); the induction is identical, both sides"
+        "case on p(head) exactly as the HO original does."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn isZ(n: Nat) -> Bool
+    match n
+        Nat.Z -> true
+        Nat.S(z) -> false
+
+fn takeWhileZ(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> match isZ(y)
+            true -> List.concat([y], takeWhileZ(ys))
+            false -> []
+
+fn dropWhileZ(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> match isZ(y)
+            true -> dropWhileZ(ys)
+            false -> xs
+
+fn append(x: List<Nat>, y: List<Nat>) -> List<Nat>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+verify takeWhileZ law takeDropWhileAppend
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.Z, Nat.S(Nat.Z), Nat.Z]]
+    append(takeWhileZ(xs), dropWhileZ(xs)) => xs

--- a/proof-corpus/tip/isaplanner-mono/prop_66.av
+++ b/proof-corpus/tip/isaplanner-mono/prop_66.av
@@ -1,0 +1,39 @@
+module Prop66Mono
+    intent =
+        "TIP isaplanner prop_66, monomorphized (Aver is first-order, no closures):"
+        "len (filter p xs) <= len xs, with p FIXED to the concrete non-degenerate"
+        "is-zero predicate. Strictly weaker than the higher-order original (loses"
+        "the forall-over-p); the induction is identical, casing on p(head)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn isZ(n: Nat) -> Bool
+    match n
+        Nat.Z -> true
+        Nat.S(z) -> false
+
+fn filterZ(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> match isZ(y)
+            true -> List.concat([y], filterZ(ys))
+            false -> filterZ(ys)
+
+fn len(xs: List<Nat>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(len(ys))
+
+fn le(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> le(z, x2)
+
+verify filterZ law filterLenLe
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z)), Nat.Z]]
+    le(len(filterZ(xs)), len(xs)) => true

--- a/proof-corpus/tip/isaplanner-mono/prop_73.av
+++ b/proof-corpus/tip/isaplanner-mono/prop_73.av
@@ -1,0 +1,32 @@
+module Prop73Mono
+    intent =
+        "TIP isaplanner prop_73, monomorphized (Aver is first-order, no closures):"
+        "rev (filter p xs) = filter p (rev xs), with p FIXED to the concrete"
+        "non-degenerate is-zero predicate. Strictly weaker than the higher-order"
+        "original (loses the forall-over-p); the induction is identical."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn isZ(n: Nat) -> Bool
+    match n
+        Nat.Z -> true
+        Nat.S(z) -> false
+
+fn filterZ(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> match isZ(y)
+            true -> List.concat([y], filterZ(ys))
+            false -> filterZ(ys)
+
+fn rev(xs: List<Nat>) -> List<Nat>
+    match xs
+        [] -> []
+        [y, ..ys] -> List.concat(rev(ys), [y])
+
+verify filterZ law filterRevCommute
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z)), Nat.Z]]
+    rev(filterZ(xs)) => filterZ(rev(xs))

--- a/proof-corpus/tip_split_sweep.sh
+++ b/proof-corpus/tip_split_sweep.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Per-task Lean-universal sweep over the TIP corpus, SPLIT by source suite
+# (isaplanner-78 vs prod-74). Mirrors run.sh's metric exactly: a task is
+# CLOSED iff `aver proof <f> --backend lean --check --check-json` reports
+# "universal":true (the #print-axioms-gated kernel-genuine signal).
+#
+# Lean-only on purpose: Lean elaboration has no wall-clock timeout, so a
+# heavy machine only makes this SLOW, never wrong (unlike Dafny/Z3). The
+# retry-once absorbs transient lake-lock failures. So the per-task verdicts
+# are trustworthy even under load.
+#
+# Output is PERSISTED (home dir, not /tmp) so "which tasks pass?" is forever
+# a grep, not a re-measurement.
+set -u
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+AVER="${AVER:-$ROOT/../target/debug/aver}"
+OUT="${OUT:-$HOME/aver-tip-split-sweep-2026-06-15.txt}"
+
+: > "$OUT"
+echo "# TIP per-task Lean-universal sweep (split isaplanner/prod)" >> "$OUT"
+echo "# aver: $AVER  HEAD: $(cd "$ROOT/.." && git rev-parse --short HEAD)" >> "$OUT"
+echo "" >> "$OUT"
+
+prove_lean() {
+  local f="$1" out json
+  for attempt in 1 2; do
+    out="$(mktemp -d)"
+    json="$("$AVER" proof "$f" --backend lean --check --check-json -o "$out" 2>/dev/null | grep '"passed"' | tail -1)"
+    rm -rf "$out"
+    printf '%s' "$json" | grep -q '"universal":true' && { echo universal; return; }
+  done
+  echo open
+}
+
+sweep_dir() {
+  local dir="$1" label="$2" n=0 closed=0
+  echo "== $label ==" >> "$OUT"
+  for f in $(find "$ROOT/$dir" -name '*.av' | sort); do
+    n=$((n + 1))
+    r="$(prove_lean "$f")"
+    [ "$r" = universal ] && closed=$((closed + 1))
+    printf '%-10s %s\n' "$r" "${f#"$ROOT/$dir/"}" >> "$OUT"
+  done
+  echo "-- $label: $closed / $n universal --" >> "$OUT"
+  echo "" >> "$OUT"
+  echo "$label: $closed / $n"
+}
+
+a="$(sweep_dir tip/isaplanner isaplanner)"
+b="$(sweep_dir tip/prod prod)"
+{
+  echo "=== SUMMARY ==="
+  echo "$a"
+  echo "$b"
+} | tee -a "$OUT"
+echo "saved -> $OUT"


### PR DESCRIPTION
The published IsaPlanner benchmark is 85 problems; 8 of them (12, 14, 35, 36, 41, 43, 66, 73) are **higher-order** — they pass a function as an argument (`map f`, `filter p`, `takeWhile/dropWhile p`, a lambda). Aver is first-order with no closures, so these are **inexpressible natively** and are absent from `tip/isaplanner/` (the 77 expressible standard problems + `prop_86`).

This adds `tip/isaplanner-mono/`: each of the 8 rendered **the Aver way** — the function/predicate fixed to a concrete non-degenerate instance (`map` → `Nat.S`; `filter`/`takeWhile`/`dropWhile` → is-zero; prop_35/36 use the constant predicate, which is the *faithful* original).

## The asterisk

A monomorphized rendering is a **strictly weaker statement** than the higher-order original (loses the `∀`-over-function), but the **same inductive problem** — `f`/`p` is parametric, carried/cased identically. Non-degenerate instances required (a constant `f = id` would collapse the problem and is rejected). Full rationale in `tip/isaplanner-mono/README.md`.

This is a **separate, asterisked metric**: `run.sh` excludes `isaplanner-mono/` from the headline coverage union (like `decomposed/`), so it can never be conflated with the strict natively-expressible number.

## Result (Lean kernel-genuine, no discovery)

**6/8 universal:** prop_12, prop_14, prop_35, prop_36, prop_41, prop_43.
Open: prop_66 (needs a `le`/`S` helper lemma), prop_73 (needs `filter (xs++ys)` distribution = prop_14, as a lemma) — exactly the lemma-discovery cases.

Denominators vs published 85: strict native **41/85**, with this asterisk **47/85** (IsaPlanner 47/85 via rippling+discovery; Dafny 45/85 via Z3). Aver's are kernel-genuine + discovery-free. The 47 coinciding with IsaPlanner's 47 is a coincidence of counts, not of statement strength.

All 8 pass `aver verify` (60/60 example cases). Adds `tip_split_sweep.sh`, the per-suite Lean-universal measurement tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)