### PR TITLE
ir/mir: Int unboxing becomes a MIR rewrite with explicit Box/Unbox nodes (Rust migration, behavior-equivalent)

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -2019,7 +2019,7 @@ fn emit_mir_match_with(
     // ── 1. Single-arm irrefutable → `let` destructuring. ──
     // Mirror of `emit_match`'s first branch.
     if arms.len() == 1 && resolved_pattern_is_irrefutable(&arms[0].pattern) {
-        let mut subj_code = emit_mir_expr(&m.subject, emit_ctx)?;
+        let subj_code = emit_mir_expr(&m.subject, emit_ctx)?;
         // Int unboxing boundary (defect esc_match): a `match (n - 1) { x -> … }`
         // binds the subject to `x`. When the analysis marked the bound slot
         // BOXED (because `x` later escapes — `[x, x]`) but the subject renders

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -852,6 +852,8 @@ fn label_for(expr: &MirExpr) -> &'static str {
         MirExpr::IndependentProduct(_) => "IndependentProduct",
         MirExpr::Return(_) => "Return",
         MirExpr::FnValue(_) => "FnValue",
+        MirExpr::Box(_) => "Box",
+        MirExpr::Unbox(_) => "Unbox",
     }
 }
 
@@ -1449,6 +1451,25 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
         // refinement + module-path mangling) so the emit is byte-identical.
         // The VM does the same (`compile_ident` → `symbol_ref`).
         MirExpr::FnValue(name) => Some(emit_mir_static_ref(name, emit_ctx)),
+        // ETAP-2 representation boundaries (inserted by the
+        // `bare_i64::rewrite_for_rust` MIR->MIR pass). Codegen no longer
+        // DECIDES where a boundary goes — the rewrite already inserted it —
+        // it just lowers the node:
+        //   Box(x)   — x evaluates to a raw `i64`; box it into `AverInt`.
+        //   Unbox(x) — x evaluates to an `AverInt`; narrow to raw `i64`
+        //              via the checked `to_i64()` (the analysis proved the
+        //              value fits, so the `expect` never fires).
+        MirExpr::Box(inner) => {
+            let raw = emit_mir_expr(inner, emit_ctx)?;
+            Some(format!("aver_rt::AverInt::from_i64({})", raw))
+        }
+        MirExpr::Unbox(inner) => {
+            let boxed = emit_mir_expr(inner, emit_ctx)?;
+            Some(format!(
+                "{}.to_i64().expect(\"Int out of i64 range\")",
+                boxed
+            ))
+        }
         _ => None,
     }
 }
@@ -5440,6 +5461,7 @@ mod tests {
             body,
             local_count: 0,
             aliased_slots: std::sync::Arc::new(vec![]),
+            repr: crate::ir::mir::MirFnRepr::default(),
         }
     }
 

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -325,24 +325,6 @@ fn emit_bare_i64(expr: &Spanned<MirExpr>) -> Option<String> {
     }
 }
 
-/// Coerce an operand of a BOXED `AverInt` arithmetic op to an `AverInt`
-/// expression. A bare-`i64` operand whose boxed-path emission would be a
-/// raw `i64` (a bare `Local` or bare arithmetic tree) crosses the
-/// bare→`AverInt` boundary via `from_i64`. A literal is NOT converted: its
-/// boxed-path `code` is already `AverInt::from_i64(N)` (the correct boxed
-/// form), so wrapping it would double-box. A boxed / unanalyzable operand
-/// is left as the already-emitted `code`.
-fn boxed_int_operand(code: String, _expr: &Spanned<MirExpr>, _ctx: &MirEmitCtx<'_>) -> String {
-    // ETAP-2 SLICE 1: the bare->boxed boundary is now an EXPLICIT
-    // `MirExpr::Box` node the `bare_i64_rewrite` pass inserted, lowered by
-    // the `Box` arm of `emit_mir_expr`. Codegen no longer inserts the
-    // `from_i64` conversion here — it would double-box the value the rewrite
-    // already wrapped. This is now an identity pass (kept as a no-op so the
-    // many call sites need not all be deleted in one churn-heavy edit; the
-    // residual call sites are harmless and the next cleanup can inline it).
-    code
-}
-
 /// Per-fn borrow policy for the MIR walker — the slice of
 /// [`super::emit_ctx::EmitCtx`] the covered arms read, owned so a
 /// borrowing [`MirEmitCtx`] can be built from it. Recomputed per
@@ -977,12 +959,10 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                 // Mixed-representation boundary: this is the boxed
                 // `AverInt` arithmetic path, but ONE operand may be a bare
                 // `i64` (e.g. `acc * n` where `acc` stays boxed and `n`
-                // went bare). The `AverInt` method takes `&AverInt`, so a
-                // bare operand re-enters the boxed world via `from_i64`
-                // (the bare→AverInt escape edge). A boxed operand is left
-                // as-is.
-                let l = boxed_int_operand(l, &bop.lhs, emit_ctx);
-                let r = boxed_int_operand(r, &bop.rhs, emit_ctx);
+                // went bare). ETAP-2 SLICE 1: the bare→`AverInt` boundary is
+                // now an EXPLICIT `Box(n)` node the rewrite inserted, so
+                // `emit_mir_expr` already produced the `from_i64(n)` text for
+                // `l` / `r` — no codegen-side coercion here.
                 let method = match bop.op {
                     BinOp::Add => "add",
                     BinOp::Sub => "sub",
@@ -2047,11 +2027,11 @@ fn emit_mir_match_with(
         // bound `x` is the `AverInt` its later uses expect. A bare bound slot
         // keeps the raw subject. (Only the `Bind` arm carries a slot; a
         // wildcard / destructuring pattern is unaffected.)
-        if let MirPattern::Bind(slot, _) = &m.arms[0].pattern
-            && !emit_ctx.bare.is_bare(*slot)
-        {
-            subj_code = boxed_int_operand(subj_code, &m.subject, emit_ctx);
-        }
+        // ETAP-2 SLICE 1: the bind-crossing boundary is now an EXPLICIT
+        // `Box`/`Unbox` node the rewrite wrapped the subject in (it rewrites
+        // the subject in the binding's representation context). `subj_code`
+        // already carries the right representation — no codegen-side coercion.
+        let _ = &m.arms[0].pattern;
         let subj = mir_clone_arg(subj_code, &m.subject.node, emit_ctx);
         let codegen = emit_ctx.codegen?;
         let pat = emit_pattern(&arms[0].pattern, false, codegen);

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -332,19 +332,15 @@ fn emit_bare_i64(expr: &Spanned<MirExpr>) -> Option<String> {
 /// boxed-path `code` is already `AverInt::from_i64(N)` (the correct boxed
 /// form), so wrapping it would double-box. A boxed / unanalyzable operand
 /// is left as the already-emitted `code`.
-fn boxed_int_operand(code: String, expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> String {
-    // A standalone literal already emits as `AverInt::from_i64(N)` on the
-    // boxed path — never re-wrap it.
-    if matches!(&expr.node, MirExpr::Literal(_)) {
-        return code;
-    }
-    if mir_expr_is_bare_i64(expr, ctx)
-        && let Some(bare) = emit_bare_i64(expr)
-    {
-        format!("aver_rt::AverInt::from_i64({})", bare)
-    } else {
-        code
-    }
+fn boxed_int_operand(code: String, _expr: &Spanned<MirExpr>, _ctx: &MirEmitCtx<'_>) -> String {
+    // ETAP-2 SLICE 1: the bare->boxed boundary is now an EXPLICIT
+    // `MirExpr::Box` node the `bare_i64_rewrite` pass inserted, lowered by
+    // the `Box` arm of `emit_mir_expr`. Codegen no longer inserts the
+    // `from_i64` conversion here — it would double-box the value the rewrite
+    // already wrapped. This is now an identity pass (kept as a no-op so the
+    // many call sites need not all be deleted in one churn-heavy edit; the
+    // residual call sites are harmless and the next cleanup can inline it).
+    code
 }
 
 /// Per-fn borrow policy for the MIR walker — the slice of
@@ -1258,19 +1254,18 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             // result dropped. Mirror of HIR's discarded-`Stmt::Expr`
             // shape.
             let let_node = &spanned_let.node;
-            let value = emit_mir_expr(&let_node.value, emit_ctx)?;
-            // Int unboxing boundary (defect esc_match): when the binding slot
-            // is BOXED but its value renders bare `i64` (a bare `Local` /
-            // compound over a bare counter, e.g. `let x = n - 1`), the raw
-            // `i64` would be re-read later in an `AverInt` position (`[x, x]`
-            // aggregate) — a `rustc` E0308. The escape analysis already marked
-            // such a binding boxed; align codegen by boxing the value at the
-            // binding crossing with `from_i64`. A bare binding (its later uses
-            // are all bare-emittable) keeps the raw value untouched.
-            let value = if !emit_ctx.bare.is_bare(let_node.binding) {
-                boxed_int_operand(value, &let_node.value, emit_ctx)
+            // ETAP-2 SLICE 1: the binding-crossing representation BOUNDARY
+            // (defect esc_match — a raw value bound into a boxed slot) is now
+            // an EXPLICIT `Box`/`Unbox` node the `bare_i64_rewrite` pass
+            // wrapped the value in. Codegen lowers it via the `Box`/`Unbox`
+            // arms — no `from_i64` decision here. It still RENDERS a bare
+            // binding's value raw (representation): a `i64` binding takes a
+            // native `i64` literal / leaf / arithmetic.
+            let value = if emit_ctx.bare.is_bare(let_node.binding) {
+                emit_bare_i64(&let_node.value)
+                    .or_else(|| emit_mir_expr(&let_node.value, emit_ctx))?
             } else {
-                value
+                emit_mir_expr(&let_node.value, emit_ctx)?
             };
             let body = emit_mir_expr(&let_node.body, emit_ctx)?;
             if let_node.binding_name.is_empty() {
@@ -2505,16 +2500,11 @@ pub(super) fn emit_mir_fn_body(
         return Some(format!("    crate::cancel_checkpoint();\n    {}", tail));
     }
 
-    // Int unboxing boundary (defect Q5): a BOXED-return non-TCO fn whose tail
-    // value renders bare `i64` (e.g. `h() -> Int` returning the bare-returning
-    // call `g(2)`) would land a raw `i64` in the `AverInt` return — box every
-    // bare leaf with `from_i64` at the return crossing.
-    if !emit_ctx.bare.bare_return
-        && tail_renders_bare_i64(body, emit_ctx)
-        && let Some(tail) = emit_boxed_return_tail(body, emit_ctx)
-    {
-        return Some(format!("    crate::cancel_checkpoint();\n    {}", tail));
-    }
+    // ETAP-2 SLICE 1: the boxed-return tail boundary (defect Q5 / subj_ret)
+    // is now EXPLICIT — the `bare_i64_rewrite` pass already `Box`ed every
+    // bare leaf reaching a boxed return, and `emit_mir_expr` lowers those
+    // `Box` nodes. So the default emit below renders the boxed-return tail
+    // correctly without a codegen-side boxing pass.
 
     let mut code = emit_mir_expr(body, emit_ctx)?;
     // Return-position field access on a borrowed param → clone for
@@ -2562,116 +2552,6 @@ fn emit_bare_return_tail(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Optio
             None
         }
         _ => None,
-    }
-}
-
-/// Does the value in RETURN/tail position render as a bare `i64` at any
-/// reachable leaf? Mirrors the descent of [`emit_bare_return_tail`] /
-/// [`emit_boxed_return_tail`] but only inspects the leaf representation. A
-/// `Match`/`IfThenElse` is bare-leafed if ANY arm/branch tail is; a `Let`
-/// body inherits its final expr; a direct leaf is bare iff
-/// [`mir_expr_is_bare_i64`]. Used to decide whether a BOXED-return fn whose
-/// tail value emits bare needs the `from_i64` boundary conversion (defects
-/// Q5 / subj_ret: a bare `Local`/compound aliased into an `AverInt` return).
-fn tail_renders_bare_i64(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> bool {
-    match &expr.node {
-        // A standalone `Int` literal is NOT a bare-rendering leaf for the
-        // boxing decision: its normal boxed-path emit is already
-        // `AverInt::from_i64(N)` (the correct boxed form), so it needs no
-        // return conversion. Only a bare `Local` / compound / call result —
-        // which would render as raw `i64` — does. (Mirrors `boxed_int_operand`,
-        // which likewise leaves a literal untouched.)
-        MirExpr::Literal(_) => false,
-        _ if mir_expr_is_bare_i64(expr, ctx) => true,
-        // A call to a fn whose RETURN the analysis proved bare renders as a
-        // raw `i64` (its signature is `-> i64`). Consumed in a boxed-return
-        // position this is the Q5 mismatch.
-        MirExpr::Call(_) | MirExpr::TailCall(_) => mir_call_returns_bare(expr, ctx),
-        MirExpr::Match(m) => m
-            .node
-            .arms
-            .iter()
-            .any(|arm| tail_renders_bare_i64(&arm.body, ctx)),
-        MirExpr::IfThenElse(ite) => {
-            tail_renders_bare_i64(&ite.node.then_branch, ctx)
-                || tail_renders_bare_i64(&ite.node.else_branch, ctx)
-        }
-        MirExpr::Let(l) => tail_renders_bare_i64(&l.node.body, ctx),
-        MirExpr::Return(inner) => tail_renders_bare_i64(inner, ctx),
-        _ => false,
-    }
-}
-
-/// Is `expr` a `Call(Fn)` / outside-loop `TailCall` whose callee's RETURN
-/// the whole-program unboxing analysis proved bare (`bare_return`)? Such a
-/// call renders as raw `i64`; in a boxed-return position it needs the
-/// `from_i64` boundary conversion. `None` codegen ctx (coverage/test) has no
-/// facts → `false` (conservative).
-fn mir_call_returns_bare(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> bool {
-    let target = match &expr.node {
-        MirExpr::Call(c) => match c.node.callee {
-            MirCallee::Fn(t) => t,
-            _ => return false,
-        },
-        MirExpr::TailCall(tc) => tc.node.target,
-        _ => return false,
-    };
-    ctx.codegen
-        .and_then(|cg| cg.bare_i64.for_fn(target))
-        .is_some_and(|f| f.bare_return)
-}
-
-/// Emit a tail/return value as a boxed `AverInt`, converting every bare-`i64`
-/// leaf at the boundary with `from_i64`. The structural mirror of
-/// [`emit_bare_return_tail`], but for a fn whose declared return is the
-/// general `AverInt` while some tail leaf is a proven-bare value (a bare
-/// `Local` aliased from a bare param, or a bare-returning call result). This
-/// is the return-position counterpart of [`boxed_int_operand`]: it keeps the
-/// loop counter bare (no demotion, win preserved) and only coerces at the
-/// single return crossing.
-///
-/// A non-bare leaf is emitted via the normal value path (`emit_mir_value_return`
-/// without the bare branch) — it is already an `AverInt`, so it is left as-is.
-/// Returns `None` for any shape the descent can't render (the caller then
-/// falls back to the default emit).
-fn emit_boxed_return_tail(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<String> {
-    match &expr.node {
-        // A standalone `Int` literal already emits as `AverInt::from_i64(N)`
-        // on the normal boxed path — emit it there (re-boxing would double-box
-        // into `from_i64(Ni64)`). Mirrors the `tail_renders_bare_i64` skip.
-        MirExpr::Literal(_) => {
-            let code = emit_mir_expr(expr, ctx)?;
-            Some(mir_maybe_clone(code, &expr.node, ctx))
-        }
-        // A directly bare-eligible leaf (a bare `Local` / compound): box it.
-        _ if mir_expr_is_bare_i64(expr, ctx) => {
-            emit_bare_i64(expr).map(|bare| format!("aver_rt::AverInt::from_i64({})", bare))
-        }
-        // A call to a bare-return callee: its result is a raw `i64`; box it.
-        MirExpr::Call(_) | MirExpr::TailCall(_) if mir_call_returns_bare(expr, ctx) => {
-            let code = emit_mir_expr(expr, ctx)?;
-            Some(format!("aver_rt::AverInt::from_i64({})", code))
-        }
-        MirExpr::Match(m) => emit_mir_match_with(&m.node, ctx, &|arm_body, ctx| {
-            emit_boxed_return_tail(arm_body, ctx)
-        }),
-        MirExpr::IfThenElse(ite) => {
-            let (cond, then_src, else_src) = mir_if_cond_and_branches(&ite.node, ctx)?;
-            let then_b = emit_boxed_return_tail(then_src, ctx)?;
-            let else_b = emit_boxed_return_tail(else_src, ctx)?;
-            Some(format!(
-                "if {} {{ {} }} else {{ {} }}",
-                cond, then_b, else_b
-            ))
-        }
-        MirExpr::Return(inner) => emit_boxed_return_tail(inner, ctx),
-        // A non-bare leaf is already an `AverInt` — emit it through the
-        // normal value path (which itself never takes the bare branch here,
-        // since this fn's return is boxed).
-        _ => {
-            let code = emit_mir_expr(expr, ctx)?;
-            Some(mir_maybe_clone(code, &expr.node, ctx))
-        }
     }
 }
 
@@ -3068,19 +2948,11 @@ fn emit_mir_value_return(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Optio
     {
         return Some(bare);
     }
-    // Int unboxing boundary (defects Q5 / subj_ret): when the fn's return is
-    // BOXED (`!bare_return`) but a tail leaf renders bare `i64` — a bare
-    // `Local` aliased from a bare param, or a bare-returning call result —
-    // the raw `i64` would land in the `AverInt` return slot (`rustc` E0308).
-    // Box every bare leaf with `from_i64` at the return crossing, keeping the
-    // counter bare (no demotion). Only when the type is actually Int, which a
-    // bare-rendering leaf implies.
-    if !ctx.bare.bare_return
-        && tail_renders_bare_i64(expr, ctx)
-        && let Some(boxed) = emit_boxed_return_tail(expr, ctx)
-    {
-        return Some(boxed);
-    }
+    // ETAP-2 SLICE 1: the boxed-return tail boundary (defects Q5 / subj_ret)
+    // is now an EXPLICIT `Box` node the `bare_i64_rewrite` pass inserted
+    // around each bare leaf reaching a boxed return. `emit_mir_expr` lowers
+    // those `Box` nodes, so the default path renders the boxed return
+    // correctly without a codegen-side boxing pass.
     let code = emit_mir_expr(expr, ctx)?;
     Some(mir_maybe_clone(code, &expr.node, ctx))
 }
@@ -3099,25 +2971,21 @@ fn emit_mir_self_tco_continue(
 ) -> Option<String> {
     let mut arg_strs = Vec::with_capacity(args.len());
     for (i, a) in args.iter().enumerate() {
-        // Int unboxing: a bare param's rebind value must be bare `i64`
-        // (the loop variable is `mut p: i64`). A bare-eligible arg emits
-        // raw; a non-bare arg flowing into a bare param narrows via
-        // `to_i64` (rare). A boxed param keeps the clone path.
+        // ETAP-2 SLICE 1: the rebind-value representation boundary is now
+        // EXPLICIT — the `bare_i64_rewrite` pass already wrapped each
+        // self-tail-call arg for the self-fn's i-th param representation
+        // (`Box` for a raw arg into a boxed loop var, `Unbox` for a boxed
+        // arg into a bare `i64` loop var). Codegen renders the arg:
+        //   - bare param (`mut p: i64`): a raw leaf / compound / literal
+        //     renders bare via `emit_bare_i64`; an `Unbox`-wrapped boxed arg
+        //     falls through to `emit_mir_expr` (lowering `Unbox`).
+        //   - boxed param: `emit_mir_expr` (lowering any `Box` node), then
+        //     the clone policy.
         if ctx.bare.param_is_bare(i) {
-            let bare = if mir_expr_is_bare_i64(a, ctx) {
-                emit_bare_i64(a)
-            } else {
-                emit_mir_expr(a, ctx)
-                    .map(|c| format!("{}.to_i64().expect(\"Int out of i64 range\")", c))
-            };
-            arg_strs.push(bare?);
+            let rendered = emit_bare_i64(a).or_else(|| emit_mir_expr(a, ctx));
+            arg_strs.push(rendered?);
         } else {
-            // A BOXED rebind slot needs an `AverInt`. A bare-emittable arg
-            // (a bare compound `n + 1` / bare `Local`) renders raw `i64` on
-            // the default path, which would assign a bare value into the
-            // `AverInt` loop variable (`rustc` E0308). Convert at the
-            // boundary with `from_i64`, mirroring the named-call path.
-            let code = boxed_int_operand(emit_mir_expr(a, ctx)?, a, ctx);
+            let code = emit_mir_expr(a, ctx)?;
             arg_strs.push(mir_clone_arg(code, &a.node, ctx));
         }
     }
@@ -3657,41 +3525,28 @@ fn emit_named_call_to(
         Some(cg) => callee_borrow_mask(name, args.len(), cg),
         None => vec![false; args.len()],
     };
+    // ETAP-2 SLICE 1: the call-arg representation BOUNDARY (the `from_i64` /
+    // `to_i64` CONVERSION for a value whose representation differs from the
+    // param's) is now an EXPLICIT `Box`/`Unbox` node the `bare_i64_rewrite`
+    // pass inserted, lowered by `emit_mir_expr`. Codegen no longer decides
+    // those conversions here. It still RENDERS a bare-param arg raw — that
+    // is representation, not a boundary: a literal / bare leaf / bare
+    // arithmetic tree at a `i64` param emits its native `i64` form
+    // (`emit_bare_i64`), and an `Unbox`-wrapped boxed arg falls through to
+    // `emit_mir_expr` (which lowers the `Unbox`).
     let callee_bare = callee.and_then(|id| ctx.codegen.and_then(|cg| cg.bare_i64.for_fn(id)));
     let mut arg_strs = Vec::with_capacity(args.len());
     for (i, a) in args.iter().enumerate() {
-        // Int unboxing boundary: a bare callee param takes a raw `i64`.
         if callee_bare.is_some_and(|f| f.param_is_bare(i)) {
-            let bare_arg = if mir_expr_is_bare_i64(a, ctx) {
-                // The arg is itself bare — emit it raw.
-                emit_bare_i64(a)
-            } else {
-                // A boxed `AverInt` arg narrows to `i64` via the checked
-                // `to_i64` (rare by construction — the caller usually has
-                // a literal or a bare value here).
-                emit_mir_expr(a, ctx)
-                    .map(|c| format!("{}.to_i64().expect(\"Int out of i64 range\")", c))
-            };
-            if let Some(s) = bare_arg {
-                arg_strs.push(s);
-                continue;
-            }
-            // Could not render bare — bail to keep soundness (the boxed
-            // signature would then mismatch, but `for_fn` only marks a
-            // param bare when every caller can supply it, so this is
-            // effectively unreachable for well-formed facts).
-            return None;
+            // Bare `i64` param: render the arg in its raw form. A raw leaf /
+            // compound / literal renders via `emit_bare_i64`; anything else
+            // (an `Unbox` node the rewrite inserted for a genuinely-boxed
+            // arg) falls through to `emit_mir_expr`.
+            let rendered = emit_bare_i64(a).or_else(|| emit_mir_expr(a, ctx));
+            arg_strs.push(rendered?);
+            continue;
         }
-        // A BOXED callee param: the arg must be an `AverInt`. A bare-emittable
-        // arg (a bare `Local`, or an `Add`/`Sub`/`Mul` tree the analysis proved
-        // in-range) renders as raw `i64` on the default path, which would land
-        // a bare value in an `AverInt` slot (`rustc` E0308). Convert it at the
-        // boundary with `from_i64` — exactly the bare→boxed coercion
-        // `boxed_int_operand` performs for a boxed-arithmetic operand. A literal
-        // already emits as `AverInt::from_i64(N)` (handled inside
-        // `boxed_int_operand`), and a boxed / unanalyzable arg is left untouched.
         let code = emit_mir_expr(a, ctx)?;
-        let code = boxed_int_operand(code, a, ctx);
         let s = if borrow_mask.get(i).copied().unwrap_or(false) {
             mir_borrow_arg(code, &a.node, ctx)
         } else {

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -81,7 +81,13 @@ pub fn transpile(ctx: &mut CodegenContext) -> ProjectOutput {
     // the explicit boundary nodes; the body emitter below then lowers those
     // nodes trivially instead of deciding representation itself.
     if let Some(prog) = ctx.mir_program.take() {
-        ctx.mir_program = Some(crate::ir::mir::optimize::bare_i64_rewrite::rewrite_for_rust(prog));
+        // Mutual-TCO members are emitted with an unconditionally boxed
+        // (`AverInt`) trampoline signature regardless of the unboxing
+        // analysis, so the rewrite must not tag them bare (it would desync
+        // the boxed signature from a bare-rewritten body / caller).
+        let boxed = ctx.mutual_tco_members.clone();
+        ctx.mir_program =
+            Some(crate::ir::mir::optimize::bare_i64_rewrite::rewrite_for_rust(prog, &boxed));
     }
     let has_embedded_policy = ctx.policy.is_some();
     let has_runtime_policy = ctx.runtime_policy_from_env;

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -72,6 +72,17 @@ fn synthesize_rust_module_cascade(
 
 /// Transpile an Aver program to a Rust project.
 pub fn transpile(ctx: &mut CodegenContext) -> ProjectOutput {
+    // ETAP-2 SLICE 1: make Int representation EXPLICIT in the MIR the Rust
+    // backend codegens from. This runs ONLY here (the Rust entry) — the VM,
+    // wasm-gc, proof, Dafny and Lean backends never call `transpile`, so
+    // their `ctx.mir_program` keeps the all-`Int` representation and never
+    // sees a `Box`/`Unbox` node. The rewrite reuses the (already-computed)
+    // `bare_i64` range+escape analysis to tag each fn's `repr` and insert
+    // the explicit boundary nodes; the body emitter below then lowers those
+    // nodes trivially instead of deciding representation itself.
+    if let Some(prog) = ctx.mir_program.take() {
+        ctx.mir_program = Some(crate::ir::mir::optimize::bare_i64_rewrite::rewrite_for_rust(prog));
+    }
     let has_embedded_policy = ctx.policy.is_some();
     let has_runtime_policy = ctx.runtime_policy_from_env;
     let embedded_independence_cancel = ctx

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -1035,6 +1035,12 @@ pub(crate) fn emit_mir_expr(
             }
             None => Ok(None),
         },
+        // ETAP-2 Int-representation boundaries are inserted ONLY by the
+        // Rust-codegen-only `bare_i64_rewrite` pass — the wasm-gc backend
+        // consumes the shared, un-rewritten MIR, so these never appear here.
+        // `Ok(None)` (outside the supported subset) is the defensive, never-
+        // hit fallback; it keeps wasm-gc behavior untouched (slice 2 territory).
+        MirExpr::Box(_) | MirExpr::Unbox(_) => Ok(None),
     }
 }
 

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -5305,7 +5305,11 @@ fn collect_address_taken(mir_program: &crate::ir::mir::MirProgram) -> Vec<String
                 walk(&b.node.lhs.node, seen, order);
                 walk(&b.node.rhs.node, seen, order);
             }
-            MirExpr::Neg(inner) | MirExpr::Try(inner) | MirExpr::Return(inner) => {
+            MirExpr::Neg(inner)
+            | MirExpr::Try(inner)
+            | MirExpr::Return(inner)
+            | MirExpr::Box(inner)
+            | MirExpr::Unbox(inner) => {
                 walk(&inner.node, seen, order);
             }
             MirExpr::Match(m) => {
@@ -5421,9 +5425,11 @@ fn collect_call_indirect_sigs(
                 walk(&b.node.lhs.node, note);
                 walk(&b.node.rhs.node, note);
             }
-            MirExpr::Neg(inner) | MirExpr::Try(inner) | MirExpr::Return(inner) => {
-                walk(&inner.node, note)
-            }
+            MirExpr::Neg(inner)
+            | MirExpr::Try(inner)
+            | MirExpr::Return(inner)
+            | MirExpr::Box(inner)
+            | MirExpr::Unbox(inner) => walk(&inner.node, note),
             MirExpr::Match(m) => {
                 walk(&m.node.subject.node, note);
                 for arm in &m.node.arms {

--- a/src/ir/mir/dump.rs
+++ b/src/ir/mir/dump.rs
@@ -140,6 +140,18 @@ fn write_expr(f: &mut fmt::Formatter<'_>, expr: &Spanned<MirExpr>, indent: &str)
             write!(f, "return ")?;
             write_expr(f, inner, indent)
         }
+        // ETAP-2 representation boundaries (only present on the Rust
+        // codegen clone after `bare_i64::rewrite_for_rust`).
+        MirExpr::Box(inner) => {
+            write!(f, "box(")?;
+            write_expr(f, inner, indent)?;
+            write!(f, ")")
+        }
+        MirExpr::Unbox(inner) => {
+            write!(f, "unbox(")?;
+            write_expr(f, inner, indent)?;
+            write!(f, ")")
+        }
     }
 }
 

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -184,6 +184,30 @@ pub enum MirExpr {
     /// walker falls back to HIR if the name doesn't resolve (a genuinely
     /// unresolved ident — typecheck-rejected input).
     FnValue(String),
+    /// **Int-representation boundary (ETAP-2): raw `i64` → `Int`.** The
+    /// inner expression evaluates to a raw machine `i64` (a value the Int
+    /// "unboxing" analysis proved bare); `Box` wraps it back into the
+    /// arbitrary-precision `Int` (`aver_rt::AverInt`) at every escape (a
+    /// return-as-Int, a boxed-callee-param arg, an aggregate/record/map
+    /// store, a stringify, a boxed `Let` crossing, a boxed-arithmetic
+    /// operand).
+    ///
+    /// Inserted ONLY by the `bare_i64::rewrite_for_rust` MIR→MIR pass,
+    /// which runs LATE (after proof export + shape recognition) on a
+    /// per-target clone — so the VM / wasm-gc / proof MIR never contains
+    /// this node. Backends that may see it (the Rust codegen) lower it to
+    /// `aver_rt::AverInt::from_i64(<inner raw>)`; every other walker treats
+    /// it as a transparent pass-through to `inner` (it never appears on
+    /// their path, the arm exists only for exhaustiveness).
+    Box(std::boxed::Box<Spanned<MirExpr>>),
+    /// **Int-representation boundary (ETAP-2): `Int` → raw `i64`.** The dual
+    /// of [`MirExpr::Box`]: the inner expression evaluates to an `Int`
+    /// (`aver_rt::AverInt`) and `Unbox` narrows it to a raw machine `i64`
+    /// via the checked `to_i64()` (the analysis only marks a slot bare when
+    /// it provably fits `i64`, so the narrowing never loses information).
+    /// Inserted by the same rewrite; the Rust codegen lowers it to
+    /// `<inner boxed>.to_i64().expect(...)`.
+    Unbox(std::boxed::Box<Spanned<MirExpr>>),
 }
 
 /// `let binding = value; body`.

--- a/src/ir/mir/instantiations.rs
+++ b/src/ir/mir/instantiations.rs
@@ -444,7 +444,7 @@ mod tests {
                 body,
                 local_count: 0,
                 aliased_slots: std::sync::Arc::new(Vec::new()),
-                repr: super::program::MirFnRepr::default(),
+                repr: crate::ir::mir::MirFnRepr::default(),
             },
         );
         p

--- a/src/ir/mir/instantiations.rs
+++ b/src/ir/mir/instantiations.rs
@@ -222,7 +222,10 @@ impl Walker {
                 self.register_ty(spanned_proj.node.base.ty());
                 self.visit_expr(&spanned_proj.node.base.node);
             }
-            MirExpr::Try(inner) | MirExpr::Return(inner) => {
+            MirExpr::Try(inner)
+            | MirExpr::Return(inner)
+            | MirExpr::Box(inner)
+            | MirExpr::Unbox(inner) => {
                 self.register_ty(inner.ty());
                 self.visit_expr(&inner.node);
             }
@@ -441,6 +444,7 @@ mod tests {
                 body,
                 local_count: 0,
                 aliased_slots: std::sync::Arc::new(Vec::new()),
+                repr: super::program::MirFnRepr::default(),
             },
         );
         p

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -258,6 +258,10 @@ fn lower_fn(fd: &ResolvedFnDef, program: &mut MirProgram) -> Result<MirFn, SkipR
             .as_ref()
             .map(|r| r.aliased_slots.clone())
             .unwrap_or_default(),
+        // Int-representation tags stay empty at lowering: they are filled
+        // only by the late `bare_i64::rewrite_for_rust` pass on the Rust
+        // codegen clone. Everywhere else, every Int value is boxed.
+        repr: super::program::MirFnRepr::default(),
     })
 }
 

--- a/src/ir/mir/mod.rs
+++ b/src/ir/mir/mod.rs
@@ -94,5 +94,5 @@ pub use optimize::{
     BareI64Facts, FnBareFacts, Repr, ValueFact, algebraic_simplify, bool_match_to_if,
     branch_collapse, const_fold, dead_code, inline_nullary_literals, optimize,
 };
-pub use program::{LocalId, MirFn, MirParam, MirProgram};
+pub use program::{LocalId, MirFn, MirFnRepr, MirParam, MirProgram};
 pub use stats::{LowerStats, SkipReason};

--- a/src/ir/mir/optimize/algebraic.rs
+++ b/src/ir/mir/optimize/algebraic.rs
@@ -214,7 +214,10 @@ fn algebraic_walk_children(node: &mut MirExpr) {
             }
         }
         MirExpr::Project(spanned_proj) => algebraic_in_place(&mut spanned_proj.node.base),
-        MirExpr::Try(inner) | MirExpr::Return(inner) => algebraic_in_place(inner),
+        MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => algebraic_in_place(inner),
         MirExpr::List(items) | MirExpr::Tuple(items) => {
             for item in items {
                 algebraic_in_place(item);

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -1394,7 +1394,11 @@ fn visit_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {
             f(&b.node.lhs.node);
             f(&b.node.rhs.node);
         }
-        MirExpr::Neg(inner) | MirExpr::Try(inner) | MirExpr::Return(inner) => f(&inner.node),
+        MirExpr::Neg(inner)
+        | MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => f(&inner.node),
         MirExpr::Match(m) => {
             f(&m.node.subject.node);
             for arm in &m.node.arms {

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -1371,6 +1371,13 @@ pub fn type_is_int(ty: Option<&Type>) -> bool {
     matches!(ty, Some(Type::Int))
 }
 
+/// Test-only re-export of the immediate-children walk, so sibling-module
+/// tests (`bare_i64_rewrite`) can recurse without duplicating the match.
+#[cfg(test)]
+pub(crate) fn tests_visit_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {
+    visit_children(e, f)
+}
+
 /// Apply `f` to every immediate sub-expression of `e`. Kept in sync with
 /// the exhaustive walk in `own_param.rs` / `instantiations.rs`.
 fn visit_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -195,6 +195,42 @@ fn call_returns_raw(e: &MirExpr, ctx: &RewriteCtx<'_>) -> bool {
     ctx.all.for_fn(target).is_some_and(|f| f.bare_return)
 }
 
+/// Rewrite a `match` SUBJECT for the representation its binding aliases
+/// require. A `match subject { x -> … }` binds the subject to `x`, so `x`
+/// inherits the subject's representation. The analysis already set `x`'s
+/// repr (a binding that ESCAPES is boxed — defect esc_match `[x, x]`), so
+/// the subject must be rewritten to MATCH the binding: boxed when the
+/// binding is boxed (the raw subject is `Box`ed at the bind crossing), raw
+/// when the binding is bare. With no `Bind` arm (literal / ctor / wildcard
+/// patterns) the subject is an ordinary value position. When arms disagree
+/// (multiple bind arms with mixed reps — not produced by lowering), the
+/// safe choice is boxed.
+fn rewrite_match_subject(
+    subj: Spanned<MirExpr>,
+    arms: &[crate::ir::mir::MirMatchArm],
+    ctx: &RewriteCtx<'_>,
+) -> Spanned<MirExpr> {
+    use crate::ir::mir::MirPattern;
+    let bind_slots: Vec<LocalId> = arms
+        .iter()
+        .filter_map(|arm| match &arm.pattern {
+            MirPattern::Bind(slot, _) => Some(*slot),
+            _ => None,
+        })
+        .collect();
+    if bind_slots.is_empty() {
+        return rewrite_value(subj, ctx);
+    }
+    // Every bind slot aliases the same subject, so they share a repr in a
+    // well-formed program; require ALL bare to treat the subject raw.
+    let all_bare = bind_slots.iter().all(|s| ctx.facts.is_bare(*s));
+    if all_bare {
+        rewrite_raw(subj, ctx)
+    } else {
+        rewrite_boxed(subj, ctx)
+    }
+}
+
 /// Rewrite a value in TAIL/return position. `bare_return` is the enclosing
 /// fn's return representation: when bare, the tail is a raw context; when
 /// boxed, a boxed context (and the descent boxes a bare leaf — defects
@@ -204,15 +240,16 @@ fn rewrite_tail(e: Spanned<MirExpr>, bare_return: bool, ctx: &RewriteCtx<'_>) ->
     let line = e.line;
     match e.node {
         MirExpr::Match(mut m) => {
-            // Subject is an ordinary value position (handled by its own
-            // children rewrite); the arm bodies are tails.
+            // Subject is rewritten for the binding's representation (a bound
+            // subject aliases the binding — defect esc_match); the arm bodies
+            // are tails.
             let subj = std::mem::replace(
                 &mut m.node.subject,
                 std::boxed::Box::new(Spanned::bare(MirExpr::Literal(Spanned::bare(
                     Literal::Unit,
                 )))),
             );
-            m.node.subject = std::boxed::Box::new(rewrite_value(*subj, ctx));
+            m.node.subject = std::boxed::Box::new(rewrite_match_subject(*subj, &m.node.arms, ctx));
             for arm in &mut m.node.arms {
                 let body = std::mem::replace(
                     &mut arm.body,
@@ -473,7 +510,7 @@ fn rewrite_children_inner(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<
         }
         MirExpr::Match(mut m) => {
             let subj = take_box(&mut m.node.subject);
-            m.node.subject = std::boxed::Box::new(rewrite_value(subj, ctx));
+            m.node.subject = std::boxed::Box::new(rewrite_match_subject(subj, &m.node.arms, ctx));
             for arm in &mut m.node.arms {
                 let body = std::mem::replace(
                     &mut arm.body,

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -1,0 +1,697 @@
+//! ETAP-2 SLICE 1 — the Int-representation MIR→MIR rewrite.
+//!
+//! Turns the [`super::bare_i64`] range+escape ANALYSIS (a side table) into
+//! EXPLICIT representation in the MIR: it tags each fn's bare slots /
+//! params / return on [`MirFn::repr`](crate::ir::mir::MirFn) and inserts
+//! [`MirExpr::Box`] / [`MirExpr::Unbox`] boundary nodes at every position
+//! where a raw `i64` value crosses into an `Int` (`AverInt`) context or
+//! vice-versa. After this pass, the Rust backend lowers TRIVIALLY: a bare
+//! slot reads native `i64`, raw arithmetic stays raw, and a `Box`/`Unbox`
+//! node is the only place a boundary conversion is emitted — codegen no
+//! longer DECIDES where boundaries go, so the boundary-completeness bug
+//! class (PR #519) becomes structurally impossible.
+//!
+//! ## Where it runs
+//!
+//! LATE and Rust-codegen-ONLY. The shared `optimize()` pipeline (consumed
+//! by the VM, wasm-gc, proof, Dafny, Lean) does NOT run this — those keep
+//! the all-`Int` representation. The Rust backend applies it to a CLONE of
+//! the optimized MIR at the point it codegens. Running after proof export
+//! and shape recognition is mandatory: both key on the syntactic structure
+//! this rewrite rewrites.
+//!
+//! ## Equivalence to the prior side-table codegen
+//!
+//! The rewrite inserts a boundary node at EXACTLY the positions the old
+//! `from_mir.rs` inserted a conversion (the 5 sites: boxed-arithmetic
+//! operand, call-arg at a boxed/bare callee param, a boxed `Let` crossing,
+//! a boxed-return tail leaf), reusing the SAME [`FnBareFacts`] predicates
+//! (`is_bare`, `expr_is_bare_i64`, `param_is_bare`, `bare_return`). So the
+//! emitted Rust is behavior-equivalent: the conversions land in the same
+//! places, just decided ONCE here instead of re-derived per emit site.
+//!
+//! ## Fail-closed
+//!
+//! Pure function of the analysis output. A value is raw only where the
+//! analysis proved it `Bare`; a missing/unknown fact ⇒ boxed. A wrongly
+//! raw value would still fail to type-check in the emitted Rust (raw `i64`
+//! into an `AverInt` slot is `E0308`), the same backstop as before.
+
+use crate::ast::{BinOp, Literal, Spanned};
+use crate::ir::mir::program::LocalId;
+use crate::ir::mir::{
+    BareI64Facts, FnBareFacts, MirCallee, MirExpr, MirFn, MirFnRepr, MirProgram, MirStrPart,
+};
+
+/// Rewrite `program` so Int representation is explicit (ETAP-2). Runs the
+/// existing range+escape analysis, then for every fn populates `repr` and
+/// inserts `Box`/`Unbox` boundary nodes. Pure: returns a fresh program;
+/// the caller (the Rust backend) feeds it the clone it codegens from.
+pub fn rewrite_for_rust(mut program: MirProgram) -> MirProgram {
+    let facts = super::bare_i64::analyze(&program);
+    // Collect ids first to avoid borrowing `program.fns` while mutating it.
+    let ids: Vec<crate::ir::FnId> = program.fns.keys().copied().collect();
+    for id in ids {
+        let Some(fn_facts) = facts.for_fn(id).cloned() else {
+            continue;
+        };
+        if let Some(f) = program.fns.get_mut(&id) {
+            rewrite_fn(f, &fn_facts, &facts);
+        }
+    }
+    program
+}
+
+/// Populate `f.repr` from the analysis and insert the explicit boundary
+/// nodes throughout `f.body`.
+fn rewrite_fn(f: &mut MirFn, facts: &FnBareFacts, all: &BareI64Facts) {
+    // 1. Make the per-value representation explicit on the fn.
+    let mut bare_slots = std::collections::HashSet::new();
+    for (slot, fact) in &facts.values {
+        if fact.is_bare() {
+            bare_slots.insert(*slot);
+        }
+    }
+    f.repr = MirFnRepr {
+        bare_slots,
+        bare_params: facts.bare_params.clone(),
+        bare_return: facts.bare_return,
+    };
+
+    // 2. Insert boundary nodes. The body is in RETURN position: a bare
+    //    return fn expects its tail raw; a boxed return fn expects it
+    //    boxed (and a bare leaf there is `Box`ed — defect Q5 / subj_ret).
+    let ctx = RewriteCtx { facts, all };
+    let body = std::mem::replace(
+        &mut f.body,
+        Spanned::bare(MirExpr::Literal(Spanned::bare(Literal::Unit))),
+    );
+    f.body = rewrite_tail(body, facts.bare_return, &ctx);
+}
+
+struct RewriteCtx<'a> {
+    facts: &'a FnBareFacts,
+    all: &'a BareI64Facts,
+}
+
+/// Wrap `e` in a fresh `Box` node (raw i64 -> Int), preserving the span +
+/// the logical `Int` type stamp (a representation boundary keeps the value's
+/// logical type — only its machine representation changes — so downstream
+/// numeric-disambiguation reads still see `Int`).
+fn box_node(e: Spanned<MirExpr>) -> Spanned<MirExpr> {
+    let line = e.line;
+    let ty = e.ty().cloned();
+    let out = Spanned::new(MirExpr::Box(std::boxed::Box::new(e)), line);
+    if let Some(t) = ty {
+        out.set_ty(t);
+    }
+    out
+}
+
+/// Wrap `e` in a fresh `Unbox` node (Int -> raw i64), preserving the span +
+/// logical type stamp (see [`box_node`]).
+fn unbox_node(e: Spanned<MirExpr>) -> Spanned<MirExpr> {
+    let line = e.line;
+    let ty = e.ty().cloned();
+    let out = Spanned::new(MirExpr::Unbox(std::boxed::Box::new(e)), line);
+    if let Some(t) = ty {
+        out.set_ty(t);
+    }
+    out
+}
+
+/// Does `e` render as a raw `i64` value (a bare leaf or a whole-tree-bare
+/// `Add`/`Sub`/`Mul`/`Neg`)? Same gate the codegen `emit_bare_i64` path
+/// keys on — `FnBareFacts::expr_is_bare_i64`.
+fn renders_raw(e: &MirExpr, facts: &FnBareFacts) -> bool {
+    facts.expr_is_bare_i64(e)
+}
+
+/// Rewrite an expression appearing in a BOXED (`Int`/`AverInt`) context:
+/// every Int sub-value here must be an `AverInt`. A sub-expression that
+/// renders raw is wrapped in `Box`. This is the structural relocation of
+/// the codegen `boxed_int_operand` coercion + the boxed-return tail boxing.
+fn rewrite_boxed(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
+    // A standalone Int literal already lowers to `AverInt::from_i64(N)` on
+    // the boxed path — never wrap it (would double-box). Mirrors
+    // `boxed_int_operand`'s literal skip.
+    if matches!(&e.node, MirExpr::Literal(l) if matches!(l.node, Literal::Int(_))) {
+        return rewrite_children(e, ctx);
+    }
+    // A call to a bare-RETURN callee renders as raw `i64` (its signature is
+    // `-> i64`); in a boxed context it must be boxed (defect Q5).
+    if call_returns_raw(&e.node, ctx) {
+        let inner = rewrite_children(e, ctx);
+        return box_node(inner);
+    }
+    // A directly raw-rendering leaf / compound (a bare `Local`, or an
+    // in-range `Add`/`Sub`/`Mul`/`Neg` tree): box it. Its raw operands stay
+    // raw inside (rewrite_children leaves them — they are consumed by the
+    // native arithmetic that the Box wraps).
+    if renders_raw(&e.node, ctx.facts) {
+        return box_node(e);
+    }
+    // Otherwise it is already an `AverInt` — recurse so any nested boxed
+    // contexts (call args, aggregate elements, …) get their own boundaries.
+    rewrite_children(e, ctx)
+}
+
+/// Rewrite an expression appearing in a RAW (`i64`) context: the consumer
+/// expects a native `i64`. A sub-expression that is already raw stays; one
+/// that is a boxed `AverInt` is narrowed via `Unbox`. This is the
+/// relocation of the codegen call-arg `to_i64` coercion at a bare param.
+fn rewrite_raw(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
+    // A call to a bare-return callee is already raw `i64`.
+    if call_returns_raw(&e.node, ctx) {
+        return rewrite_children(e, ctx);
+    }
+    // A raw-rendering leaf / compound: stays raw, but recurse so a nested
+    // boxed operand inside an arithmetic tree is handled. (By construction
+    // a whole-tree-bare compound has only raw leaves, so this is a no-op,
+    // but recursing keeps the walk total.)
+    if renders_raw(&e.node, ctx.facts) {
+        return rewrite_children(e, ctx);
+    }
+    // A boxed `AverInt` value reaching a raw context: narrow it. (Rare by
+    // construction — the analysis only marks a param bare when every caller
+    // supplies a raw or literal value; this covers the residual `to_i64`
+    // call-arg path.)
+    let inner = rewrite_children(e, ctx);
+    unbox_node(inner)
+}
+
+/// Is `e` a `Call(Fn)` / `TailCall` whose callee's return the analysis
+/// proved bare (renders as raw `i64`)? Mirror of codegen's
+/// `mir_call_returns_bare`.
+fn call_returns_raw(e: &MirExpr, ctx: &RewriteCtx<'_>) -> bool {
+    let target = match e {
+        MirExpr::Call(c) => match c.node.callee {
+            MirCallee::Fn(t) => t,
+            _ => return false,
+        },
+        MirExpr::TailCall(tc) => tc.node.target,
+        _ => return false,
+    };
+    ctx.all.for_fn(target).is_some_and(|f| f.bare_return)
+}
+
+/// Rewrite a value in TAIL/return position. `bare_return` is the enclosing
+/// fn's return representation: when bare, the tail is a raw context; when
+/// boxed, a boxed context (and the descent boxes a bare leaf — defects
+/// Q5 / subj_ret). Match / IfThenElse / Let / Return recurse into their
+/// tail leaves so each arm/branch is handled in the right context.
+fn rewrite_tail(e: Spanned<MirExpr>, bare_return: bool, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
+    let line = e.line;
+    match e.node {
+        MirExpr::Match(mut m) => {
+            // Subject is an ordinary value position (handled by its own
+            // children rewrite); the arm bodies are tails.
+            let subj = std::mem::replace(
+                &mut m.node.subject,
+                std::boxed::Box::new(Spanned::bare(MirExpr::Literal(Spanned::bare(
+                    Literal::Unit,
+                )))),
+            );
+            m.node.subject = std::boxed::Box::new(rewrite_value(*subj, ctx));
+            for arm in &mut m.node.arms {
+                let body = std::mem::replace(
+                    &mut arm.body,
+                    Spanned::bare(MirExpr::Literal(Spanned::bare(Literal::Unit))),
+                );
+                arm.body = rewrite_tail(body, bare_return, ctx);
+            }
+            Spanned::new(MirExpr::Match(m), line)
+        }
+        MirExpr::IfThenElse(mut ite) => {
+            let cond = std::mem::replace(
+                &mut ite.node.cond,
+                std::boxed::Box::new(Spanned::bare(MirExpr::Literal(Spanned::bare(
+                    Literal::Bool(false),
+                )))),
+            );
+            ite.node.cond = std::boxed::Box::new(rewrite_value(*cond, ctx));
+            let then_b = std::mem::replace(
+                &mut ite.node.then_branch,
+                std::boxed::Box::new(Spanned::bare(MirExpr::Literal(Spanned::bare(
+                    Literal::Unit,
+                )))),
+            );
+            ite.node.then_branch = std::boxed::Box::new(rewrite_tail(*then_b, bare_return, ctx));
+            let else_b = std::mem::replace(
+                &mut ite.node.else_branch,
+                std::boxed::Box::new(Spanned::bare(MirExpr::Literal(Spanned::bare(
+                    Literal::Unit,
+                )))),
+            );
+            ite.node.else_branch = std::boxed::Box::new(rewrite_tail(*else_b, bare_return, ctx));
+            Spanned::new(MirExpr::IfThenElse(ite), line)
+        }
+        MirExpr::Let(mut l) => {
+            // The let VALUE is a value position (boxed unless its binding
+            // slot is bare); the let BODY is the tail.
+            let value = std::mem::replace(
+                &mut l.node.value,
+                std::boxed::Box::new(Spanned::bare(MirExpr::Literal(Spanned::bare(
+                    Literal::Unit,
+                )))),
+            );
+            l.node.value = std::boxed::Box::new(rewrite_let_value(*value, l.node.binding, ctx));
+            let body = std::mem::replace(
+                &mut l.node.body,
+                std::boxed::Box::new(Spanned::bare(MirExpr::Literal(Spanned::bare(
+                    Literal::Unit,
+                )))),
+            );
+            l.node.body = std::boxed::Box::new(rewrite_tail(*body, bare_return, ctx));
+            Spanned::new(MirExpr::Let(l), line)
+        }
+        MirExpr::Return(inner) => {
+            let r = rewrite_tail(*inner, bare_return, ctx);
+            Spanned::new(MirExpr::Return(std::boxed::Box::new(r)), line)
+        }
+        // A self-tail-call's value is the recurrence, not a base value — its
+        // args are handled by `rewrite_value` (call-arg boundaries).
+        other => {
+            let spanned = Spanned::new(other, line);
+            if bare_return {
+                rewrite_raw(spanned, ctx)
+            } else {
+                rewrite_boxed(spanned, ctx)
+            }
+        }
+    }
+}
+
+/// Rewrite the VALUE of a `Let` binding. The binding's representation is
+/// its slot repr: a bare binding wants a raw value, a boxed binding wants
+/// an `AverInt` (defect esc_match — a `let x = n - 1` whose `x` escapes is
+/// boxed, so the raw `n - 1` is `Box`ed at the crossing).
+fn rewrite_let_value(
+    e: Spanned<MirExpr>,
+    binding: LocalId,
+    ctx: &RewriteCtx<'_>,
+) -> Spanned<MirExpr> {
+    if ctx.facts.is_bare(binding) {
+        rewrite_raw(e, ctx)
+    } else {
+        rewrite_boxed(e, ctx)
+    }
+}
+
+/// Rewrite an expression in an ordinary VALUE position (not tail, not a
+/// specially-typed context). Defaults to a boxed context — the general Int
+/// world — except where the node itself imposes a raw sub-context
+/// (arithmetic over bare operands, a bare callee param). The per-node
+/// boundary logic lives in `rewrite_children`.
+fn rewrite_value(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
+    // A raw-rendering compound/leaf in a value position is itself raw; its
+    // CONSUMER (the parent) decides whether to box it. So here we only
+    // recurse into children (which place their own boundaries); the parent
+    // arm that produced this `rewrite_value` call already applied the
+    // boxed/raw wrapper if it needed one.
+    rewrite_children(e, ctx)
+}
+
+/// Recurse into the children of `e`, placing boundary nodes per-node:
+///
+/// - `BinOp` arithmetic over Int operands: a bare operand consumed by a
+///   BOXED `AverInt` op is `Box`ed (`boxed_int_operand`); a whole-tree-bare
+///   op keeps raw operands.
+/// - `Call(Fn)` / `TailCall`: each arg is rewritten in the callee's i-th
+///   param context (raw if the param is bare, boxed otherwise).
+/// - aggregates / records / maps / interpolation: each element is a boxed
+///   context (a general-Int store).
+/// - everything else: structural recursion in a value context.
+fn rewrite_children(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
+    // Preserve the node's type stamp across the rebuild: the codegen
+    // `int_arith` / numeric disambiguation reads `lhs.ty()` / `rhs.ty()`, so
+    // dropping the stamp here would silently flip an `acc * n` Int multiply
+    // onto the raw `*`-operator path (which `AverInt` has no impl for).
+    let ty = e.ty().cloned();
+    let out = rewrite_children_inner(e, ctx);
+    if let Some(t) = ty {
+        out.set_ty(t);
+    }
+    out
+}
+
+fn rewrite_children_inner(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
+    let line = e.line;
+    match e.node {
+        MirExpr::BinOp(mut b) => {
+            let op = b.node.op;
+            let int_arith = matches!(op, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div);
+            // Query whole-tree bareness on the ORIGINAL node before taking
+            // the operands apart (it inspects `b.node` verbatim).
+            let whole_raw =
+                int_arith && renders_raw(&MirExpr::BinOp(clone_binop_shell(&b)), ctx.facts);
+            let lhs = take_box(&mut b.node.lhs);
+            let rhs = take_box(&mut b.node.rhs);
+            // Whole-tree-bare arithmetic stays raw: keep operands raw.
+            if whole_raw {
+                b.node.lhs = std::boxed::Box::new(rewrite_raw(lhs, ctx));
+                b.node.rhs = std::boxed::Box::new(rewrite_raw(rhs, ctx));
+                return Spanned::new(MirExpr::BinOp(b), line);
+            }
+            if int_arith
+                && (super::bare_i64::type_is_int(operand_ty(&lhs))
+                    || super::bare_i64::type_is_int(operand_ty(&rhs)))
+            {
+                // Boxed `AverInt` arithmetic: each operand must be an
+                // `AverInt`. A raw operand is `Box`ed (`boxed_int_operand`).
+                b.node.lhs = std::boxed::Box::new(rewrite_boxed(lhs, ctx));
+                b.node.rhs = std::boxed::Box::new(rewrite_boxed(rhs, ctx));
+                return Spanned::new(MirExpr::BinOp(b), line);
+            }
+            // Comparison or non-Int op: a comparison between two raw
+            // operands stays raw (codegen emits `i64 == i64`); otherwise
+            // recurse as value positions.
+            if matches!(
+                op,
+                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
+            ) && renders_raw(&lhs.node, ctx.facts)
+                && renders_raw(&rhs.node, ctx.facts)
+            {
+                b.node.lhs = std::boxed::Box::new(rewrite_raw(lhs, ctx));
+                b.node.rhs = std::boxed::Box::new(rewrite_raw(rhs, ctx));
+                return Spanned::new(MirExpr::BinOp(b), line);
+            }
+            b.node.lhs = std::boxed::Box::new(rewrite_value(lhs, ctx));
+            b.node.rhs = std::boxed::Box::new(rewrite_value(rhs, ctx));
+            Spanned::new(MirExpr::BinOp(b), line)
+        }
+        MirExpr::Neg(inner) => {
+            // Negation over a bare operand renders boxed by codegen (the
+            // bare `Neg` path bails to `AverInt::neg`), so the operand is a
+            // boxed context.
+            let r = rewrite_boxed(*inner, ctx);
+            Spanned::new(MirExpr::Neg(std::boxed::Box::new(r)), line)
+        }
+        MirExpr::Call(mut c) => {
+            let callee = c.node.callee.clone();
+            let args = std::mem::take(&mut c.node.args);
+            c.node.args = rewrite_call_args(args, &callee, ctx);
+            Spanned::new(MirExpr::Call(c), line)
+        }
+        MirExpr::TailCall(mut tc) => {
+            let target = tc.node.target;
+            let callee = MirCallee::Fn(target);
+            let args = std::mem::take(&mut tc.node.args);
+            tc.node.args = rewrite_call_args(args, &callee, ctx);
+            Spanned::new(MirExpr::TailCall(tc), line)
+        }
+        MirExpr::List(items) => Spanned::new(MirExpr::List(rewrite_boxed_each(items, ctx)), line),
+        MirExpr::Tuple(items) => Spanned::new(MirExpr::Tuple(rewrite_boxed_each(items, ctx)), line),
+        MirExpr::MapLiteral(pairs) => {
+            let pairs = pairs
+                .into_iter()
+                .map(|(k, v)| (rewrite_boxed(k, ctx), rewrite_boxed(v, ctx)))
+                .collect();
+            Spanned::new(MirExpr::MapLiteral(pairs), line)
+        }
+        MirExpr::Construct(mut c) => {
+            let args = std::mem::take(&mut c.node.args);
+            c.node.args = rewrite_boxed_each(args, ctx);
+            Spanned::new(MirExpr::Construct(c), line)
+        }
+        MirExpr::RecordCreate(mut r) => {
+            for fld in &mut r.node.fields {
+                let v = std::mem::replace(
+                    &mut fld.value,
+                    Spanned::bare(MirExpr::Literal(Spanned::bare(Literal::Unit))),
+                );
+                fld.value = rewrite_boxed(v, ctx);
+            }
+            Spanned::new(MirExpr::RecordCreate(r), line)
+        }
+        MirExpr::RecordUpdate(mut u) => {
+            let base = take_box(&mut u.node.base);
+            u.node.base = std::boxed::Box::new(rewrite_value(base, ctx));
+            for fld in &mut u.node.updates {
+                let v = std::mem::replace(
+                    &mut fld.value,
+                    Spanned::bare(MirExpr::Literal(Spanned::bare(Literal::Unit))),
+                );
+                fld.value = rewrite_boxed(v, ctx);
+            }
+            Spanned::new(MirExpr::RecordUpdate(u), line)
+        }
+        MirExpr::InterpolatedStr(parts) => {
+            let parts = parts
+                .into_iter()
+                .map(|p| match p {
+                    MirStrPart::Expr(ex) => MirStrPart::Expr(rewrite_value(ex, ctx)),
+                    MirStrPart::Literal(s) => MirStrPart::Literal(s),
+                })
+                .collect();
+            Spanned::new(MirExpr::InterpolatedStr(parts), line)
+        }
+        MirExpr::IndependentProduct(mut ip) => {
+            let items = std::mem::take(&mut ip.node.items);
+            ip.node.items = items.into_iter().map(|it| rewrite_value(it, ctx)).collect();
+            Spanned::new(MirExpr::IndependentProduct(ip), line)
+        }
+        MirExpr::Project(mut p) => {
+            let base = take_box(&mut p.node.base);
+            p.node.base = std::boxed::Box::new(rewrite_value(base, ctx));
+            Spanned::new(MirExpr::Project(p), line)
+        }
+        MirExpr::Try(inner) => {
+            let r = rewrite_value(*inner, ctx);
+            Spanned::new(MirExpr::Try(std::boxed::Box::new(r)), line)
+        }
+        MirExpr::Return(inner) => {
+            let r = rewrite_value(*inner, ctx);
+            Spanned::new(MirExpr::Return(std::boxed::Box::new(r)), line)
+        }
+        MirExpr::Let(mut l) => {
+            let value = take_box(&mut l.node.value);
+            l.node.value = std::boxed::Box::new(rewrite_let_value(value, l.node.binding, ctx));
+            let body = take_box(&mut l.node.body);
+            l.node.body = std::boxed::Box::new(rewrite_value(body, ctx));
+            Spanned::new(MirExpr::Let(l), line)
+        }
+        MirExpr::Match(mut m) => {
+            let subj = take_box(&mut m.node.subject);
+            m.node.subject = std::boxed::Box::new(rewrite_value(subj, ctx));
+            for arm in &mut m.node.arms {
+                let body = std::mem::replace(
+                    &mut arm.body,
+                    Spanned::bare(MirExpr::Literal(Spanned::bare(Literal::Unit))),
+                );
+                arm.body = rewrite_value(body, ctx);
+            }
+            Spanned::new(MirExpr::Match(m), line)
+        }
+        MirExpr::IfThenElse(mut ite) => {
+            let cond = take_box(&mut ite.node.cond);
+            ite.node.cond = std::boxed::Box::new(rewrite_value(cond, ctx));
+            let then_b = take_box(&mut ite.node.then_branch);
+            ite.node.then_branch = std::boxed::Box::new(rewrite_value(then_b, ctx));
+            let else_b = take_box(&mut ite.node.else_branch);
+            ite.node.else_branch = std::boxed::Box::new(rewrite_value(else_b, ctx));
+            Spanned::new(MirExpr::IfThenElse(ite), line)
+        }
+        // Leaves + already-inserted boundary nodes: nothing to recurse.
+        node @ (MirExpr::Literal(_)
+        | MirExpr::Local(_)
+        | MirExpr::FnValue(_)
+        | MirExpr::Box(_)
+        | MirExpr::Unbox(_)) => Spanned::new(node, line),
+    }
+}
+
+/// Rewrite the args of a `Call(Fn)` / `TailCall`: each arg is rewritten in
+/// the callee's i-th param context — raw if the callee param is bare
+/// (`Unbox` a boxed arg, keep a raw one), boxed otherwise (`Box` a raw arg).
+/// A non-`Fn` callee (builtin / intrinsic / fn-value) treats every Int arg
+/// as a general-Int (boxed) context.
+fn rewrite_call_args(
+    args: Vec<Spanned<MirExpr>>,
+    callee: &MirCallee,
+    ctx: &RewriteCtx<'_>,
+) -> Vec<Spanned<MirExpr>> {
+    let callee_facts = match callee {
+        MirCallee::Fn(t) => ctx.all.for_fn(*t),
+        _ => None,
+    };
+    args.into_iter()
+        .enumerate()
+        .map(|(i, a)| {
+            if callee_facts.is_some_and(|f| f.param_is_bare(i)) {
+                rewrite_raw(a, ctx)
+            } else {
+                rewrite_boxed(a, ctx)
+            }
+        })
+        .collect()
+}
+
+fn rewrite_boxed_each(items: Vec<Spanned<MirExpr>>, ctx: &RewriteCtx<'_>) -> Vec<Spanned<MirExpr>> {
+    items.into_iter().map(|it| rewrite_boxed(it, ctx)).collect()
+}
+
+/// Take a boxed child out, leaving a Unit placeholder (immediately
+/// overwritten by the caller). Avoids cloning a whole subtree.
+fn take_box(slot: &mut std::boxed::Box<Spanned<MirExpr>>) -> Spanned<MirExpr> {
+    let placeholder = std::boxed::Box::new(Spanned::bare(MirExpr::Literal(Spanned::bare(
+        Literal::Unit,
+    ))));
+    *std::mem::replace(slot, placeholder)
+}
+
+/// The operand's type stamp (for the int-arith disambiguation, same as
+/// codegen reads `bop.lhs.ty()`).
+fn operand_ty(e: &Spanned<MirExpr>) -> Option<&crate::ast::Type> {
+    e.ty()
+}
+
+/// Build a throwaway `BinOp` shell (same op, cloned operands) used only to
+/// query `expr_is_bare_i64` on the WHOLE tree without consuming the real
+/// node. Cloning is cheap here (only fires for Int arithmetic nodes).
+fn clone_binop_shell(b: &Spanned<crate::ir::mir::MirBinOp>) -> Spanned<crate::ir::mir::MirBinOp> {
+    Spanned::new(
+        crate::ir::mir::MirBinOp {
+            op: b.node.op,
+            lhs: b.node.lhs.clone(),
+            rhs: b.node.rhs.clone(),
+        },
+        b.line,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::mir::{lower_program, optimize};
+    use crate::source::parse_source;
+
+    fn rewritten(src: &str) -> MirProgram {
+        let mut items = parse_source(src).expect("parse");
+        let cfg = crate::ir::pipeline::PipelineConfig {
+            typecheck: Some(crate::ir::pipeline::TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        };
+        let result = crate::ir::pipeline::run(&mut items, cfg);
+        assert!(
+            result
+                .typecheck
+                .as_ref()
+                .is_none_or(|t| t.errors.is_empty()),
+            "typecheck errors: {:?}",
+            result.typecheck.map(|t| t.errors)
+        );
+        let mir_items = result.resolved_items.clone();
+        let program = optimize(lower_program(&mir_items));
+        rewrite_for_rust(program)
+    }
+
+    fn fn_named<'a>(program: &'a MirProgram, name: &str) -> &'a MirFn {
+        program
+            .iter()
+            .find(|(_, f)| f.name == name)
+            .map(|(_, f)| f)
+            .unwrap_or_else(|| panic!("fn `{name}` not in program"))
+    }
+
+    /// Walk the body counting `Box` / `Unbox` boundary nodes.
+    fn count_boundaries(e: &MirExpr) -> (usize, usize) {
+        let mut boxes = 0;
+        let mut unboxes = 0;
+        count_rec(e, &mut boxes, &mut unboxes);
+        (boxes, unboxes)
+    }
+
+    fn count_rec(e: &MirExpr, boxes: &mut usize, unboxes: &mut usize) {
+        match e {
+            MirExpr::Box(_) => *boxes += 1,
+            MirExpr::Unbox(_) => *unboxes += 1,
+            _ => {}
+        }
+        super::super::bare_i64::tests_visit_children(e, &mut |c| count_rec(c, boxes, unboxes));
+    }
+
+    #[test]
+    fn countdown_repr_is_explicit_and_no_spurious_boundary() {
+        // The countdown counter is bare; its body is pure raw arithmetic
+        // toward a bare return, so NO boundary node is needed.
+        let src = r#"
+module Countdown
+    intent = "t"
+    depends []
+
+fn countdown(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> countdown(n - 1)
+
+fn main() -> Int
+    countdown(20000)
+"#;
+        let program = rewritten(src);
+        let f = fn_named(&program, "countdown");
+        assert!(f.repr.param_is_bare(0), "counter param tagged bare on MIR");
+        assert!(f.repr.bare_return, "bare return tagged on MIR");
+        let (boxes, unboxes) = count_boundaries(&f.body.node);
+        assert_eq!(
+            (boxes, unboxes),
+            (0, 0),
+            "an all-bare countdown needs no boundary node"
+        );
+    }
+
+    #[test]
+    fn factorial_boxes_bare_operand_at_mul() {
+        // `acc * n`: `acc` boxed, `n` bare. The rewrite must `Box(n)` at the
+        // boxed-multiply boundary (exactly one Box, no Unbox).
+        let src = r#"
+module Factorial
+    intent = "t"
+    depends []
+
+fn factorial(n: Int, acc: Int) -> Int
+    match n
+        0 -> acc
+        _ -> factorial(n - 1, acc * n)
+
+fn main() -> Int
+    factorial(10, 1)
+"#;
+        let program = rewritten(src);
+        let f = fn_named(&program, "factorial");
+        assert!(f.repr.param_is_bare(0), "n is bare on MIR");
+        assert!(!f.repr.param_is_bare(1), "acc stays boxed on MIR");
+        let (boxes, unboxes) = count_boundaries(&f.body.node);
+        assert_eq!(boxes, 1, "exactly the `Box(n)` at `acc * n`");
+        assert_eq!(unboxes, 0, "no Unbox needed");
+    }
+
+    #[test]
+    fn q5_bare_return_into_boxed_return_boxes_at_crossing() {
+        // Defect Q5: `g` has a bare return; `h` returns the call result as a
+        // boxed Int. The rewrite must `Box` the bare-returning call in `h`.
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn g(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> g(n - 1)
+
+fn h() -> Int
+    g(2)
+
+fn main() -> Int
+    h()
+"#;
+        let program = rewritten(src);
+        let g = fn_named(&program, "g");
+        assert!(g.repr.bare_return, "g keeps its bare return");
+        let h = fn_named(&program, "h");
+        assert!(!h.repr.bare_return, "h's return stays boxed");
+        let (boxes, _unboxes) = count_boundaries(&h.body.node);
+        assert!(boxes >= 1, "h boxes the bare-returning call result");
+    }
+}

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -47,16 +47,35 @@ use crate::ir::mir::{
 /// existing range+escape analysis, then for every fn populates `repr` and
 /// inserts `Box`/`Unbox` boundary nodes. Pure: returns a fresh program;
 /// the caller (the Rust backend) feeds it the clone it codegens from.
-pub fn rewrite_for_rust(mut program: MirProgram) -> MirProgram {
+///
+/// `boxed_signature_fns` lists fns the Rust backend emits with an
+/// unconditionally BOXED (`AverInt`) signature regardless of the analysis —
+/// today the mutual-TCO members, whose trampoline always returns `AverInt`.
+/// The analysis can still flag such a fn's return/params bare (a phantom the
+/// codegen overrides), so the rewrite must treat them as boxed everywhere:
+/// it leaves their `repr` empty (body stays all-`Int`) AND treats their
+/// params/return as boxed at every CALL site, so a caller neither raw-reads
+/// nor double-boxes a value the callee actually returns as `AverInt`.
+pub fn rewrite_for_rust(
+    program: MirProgram,
+    boxed_signature_fns: &std::collections::HashSet<crate::ir::FnId>,
+) -> MirProgram {
+    let mut program = program;
     let facts = super::bare_i64::analyze(&program);
     // Collect ids first to avoid borrowing `program.fns` while mutating it.
     let ids: Vec<crate::ir::FnId> = program.fns.keys().copied().collect();
     for id in ids {
+        // A boxed-signature fn (mutual-TCO member) keeps the all-`Int`
+        // default repr + un-rewritten body: codegen emits it boxed, so any
+        // bare tag would desync signature and body.
+        if boxed_signature_fns.contains(&id) {
+            continue;
+        }
         let Some(fn_facts) = facts.for_fn(id).cloned() else {
             continue;
         };
         if let Some(f) = program.fns.get_mut(&id) {
-            rewrite_fn(f, &fn_facts, &facts);
+            rewrite_fn(f, &fn_facts, &facts, boxed_signature_fns);
         }
     }
     program
@@ -64,7 +83,12 @@ pub fn rewrite_for_rust(mut program: MirProgram) -> MirProgram {
 
 /// Populate `f.repr` from the analysis and insert the explicit boundary
 /// nodes throughout `f.body`.
-fn rewrite_fn(f: &mut MirFn, facts: &FnBareFacts, all: &BareI64Facts) {
+fn rewrite_fn(
+    f: &mut MirFn,
+    facts: &FnBareFacts,
+    all: &BareI64Facts,
+    boxed_signature_fns: &std::collections::HashSet<crate::ir::FnId>,
+) {
     // 1. Make the per-value representation explicit on the fn.
     let mut bare_slots = std::collections::HashSet::new();
     for (slot, fact) in &facts.values {
@@ -81,7 +105,11 @@ fn rewrite_fn(f: &mut MirFn, facts: &FnBareFacts, all: &BareI64Facts) {
     // 2. Insert boundary nodes. The body is in RETURN position: a bare
     //    return fn expects its tail raw; a boxed return fn expects it
     //    boxed (and a bare leaf there is `Box`ed — defect Q5 / subj_ret).
-    let ctx = RewriteCtx { facts, all };
+    let ctx = RewriteCtx {
+        facts,
+        all,
+        boxed_signature_fns,
+    };
     let body = std::mem::replace(
         &mut f.body,
         Spanned::bare(MirExpr::Literal(Spanned::bare(Literal::Unit))),
@@ -92,6 +120,23 @@ fn rewrite_fn(f: &mut MirFn, facts: &FnBareFacts, all: &BareI64Facts) {
 struct RewriteCtx<'a> {
     facts: &'a FnBareFacts,
     all: &'a BareI64Facts,
+    /// Fns the Rust backend emits with an unconditionally boxed signature
+    /// (mutual-TCO members). A call to such a fn returns `AverInt` and takes
+    /// `AverInt` params regardless of the analysis flags — so `call_returns_raw`
+    /// and `rewrite_call_args` treat them as boxed.
+    boxed_signature_fns: &'a std::collections::HashSet<crate::ir::FnId>,
+}
+
+impl RewriteCtx<'_> {
+    /// The callee's per-fn facts, BUT only when the callee is emitted with
+    /// its analysis-derived signature. A boxed-signature fn (mutual-TCO
+    /// member) returns `None` here, so callers treat its params/return boxed.
+    fn callee_facts(&self, target: crate::ir::FnId) -> Option<&FnBareFacts> {
+        if self.boxed_signature_fns.contains(&target) {
+            return None;
+        }
+        self.all.for_fn(target)
+    }
 }
 
 /// Wrap `e` in a fresh `Box` node (raw i64 -> Int), preserving the span +
@@ -138,12 +183,17 @@ fn rewrite_boxed(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> 
     if matches!(&e.node, MirExpr::Literal(l) if matches!(l.node, Literal::Int(_))) {
         return rewrite_children(e, ctx);
     }
-    // A call to a bare-RETURN callee renders as raw `i64` (its signature is
-    // `-> i64`); in a boxed context it must be boxed (defect Q5).
-    if call_returns_raw(&e.node, ctx) {
-        let inner = rewrite_children(e, ctx);
-        return box_node(inner);
-    }
+    // NOTE: a bare-RETURN call is NOT boxed here. The prior side-table
+    // codegen only boxed a bare-returning call in RETURN-TAIL position
+    // (`emit_boxed_return_tail`); a call result in a non-tail boxed context
+    // (a `let` value, an arithmetic operand, an aggregate element) was left
+    // as-is, because the analysis's "unsafe return consumer" rule (C2)
+    // demotes a callee's `bare_return` whenever its result reaches such a
+    // position. Boxing it here would double-box a callee whose ACTUAL
+    // emitted signature is boxed anyway (e.g. a mutual-TCO member, which
+    // codegen always emits `-> AverInt` regardless of the analysis flag).
+    // The Q5 return-tail case is handled by `rewrite_boxed_tail`.
+    //
     // A directly raw-rendering leaf / compound (a bare `Local`, or an
     // in-range `Add`/`Sub`/`Mul`/`Neg` tree): box it. Its raw operands stay
     // raw inside (rewrite_children leaves them — they are consumed by the
@@ -156,26 +206,45 @@ fn rewrite_boxed(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> 
     rewrite_children(e, ctx)
 }
 
+/// Rewrite a value in a BOXED RETURN-TAIL position (a boxed-return fn's tail
+/// leaf). Same as [`rewrite_boxed`] PLUS the Q5 case: a bare-returning call
+/// in tail position renders as raw `i64`, so box it (`emit_boxed_return_tail`
+/// in the prior codegen). This is restricted to tail position because that
+/// is the only place the prior codegen boxed a bare-returning call.
+fn rewrite_boxed_tail(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
+    if matches!(&e.node, MirExpr::Literal(l) if matches!(l.node, Literal::Int(_))) {
+        return rewrite_children(e, ctx);
+    }
+    // Q5 / subj_ret: a bare-returning call in tail position is raw `i64`; box
+    // it at the return crossing.
+    if call_returns_raw(&e.node, ctx) {
+        let inner = rewrite_children(e, ctx);
+        return box_node(inner);
+    }
+    if renders_raw(&e.node, ctx.facts) {
+        return box_node(e);
+    }
+    rewrite_children(e, ctx)
+}
+
 /// Rewrite an expression appearing in a RAW (`i64`) context: the consumer
 /// expects a native `i64`. A sub-expression that is already raw stays; one
 /// that is a boxed `AverInt` is narrowed via `Unbox`. This is the
 /// relocation of the codegen call-arg `to_i64` coercion at a bare param.
 fn rewrite_raw(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
-    // A call to a bare-return callee is already raw `i64`.
-    if call_returns_raw(&e.node, ctx) {
-        return rewrite_children(e, ctx);
-    }
-    // A raw-rendering leaf / compound: stays raw, but recurse so a nested
-    // boxed operand inside an arithmetic tree is handled. (By construction
-    // a whole-tree-bare compound has only raw leaves, so this is a no-op,
-    // but recursing keeps the walk total.)
+    // A raw-rendering leaf / compound (a bare `Local`, an in-range
+    // `Add`/`Sub`/`Mul`/`Neg` tree, an Int literal): stays raw. Recurse so a
+    // nested boxed operand inside an arithmetic tree is handled (a no-op by
+    // construction — a whole-tree-bare compound has only raw leaves).
     if renders_raw(&e.node, ctx.facts) {
         return rewrite_children(e, ctx);
     }
-    // A boxed `AverInt` value reaching a raw context: narrow it. (Rare by
-    // construction — the analysis only marks a param bare when every caller
-    // supplies a raw or literal value; this covers the residual `to_i64`
-    // call-arg path.)
+    // Any other value reaching a raw context (`i64` param / return) is a
+    // boxed `AverInt` and must be narrowed via `Unbox` (the checked
+    // `to_i64`). This mirrors the prior codegen's bare-param call-arg path,
+    // which narrowed every non-`emit_bare_i64` arg — INCLUDING a call result
+    // — with `to_i64`, rather than trusting the (mutual-TCO-unreliable)
+    // `bare_return` flag.
     let inner = rewrite_children(e, ctx);
     unbox_node(inner)
 }
@@ -192,7 +261,7 @@ fn call_returns_raw(e: &MirExpr, ctx: &RewriteCtx<'_>) -> bool {
         MirExpr::TailCall(tc) => tc.node.target,
         _ => return false,
     };
-    ctx.all.for_fn(target).is_some_and(|f| f.bare_return)
+    ctx.callee_facts(target).is_some_and(|f| f.bare_return)
 }
 
 /// Rewrite a `match` SUBJECT for the representation its binding aliases
@@ -238,6 +307,7 @@ fn rewrite_match_subject(
 /// tail leaves so each arm/branch is handled in the right context.
 fn rewrite_tail(e: Spanned<MirExpr>, bare_return: bool, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
     let line = e.line;
+    let ty = e.ty().cloned();
     match e.node {
         MirExpr::Match(mut m) => {
             // Subject is rewritten for the binding's representation (a bound
@@ -306,14 +376,32 @@ fn rewrite_tail(e: Spanned<MirExpr>, bare_return: bool, ctx: &RewriteCtx<'_>) ->
             let r = rewrite_tail(*inner, bare_return, ctx);
             Spanned::new(MirExpr::Return(std::boxed::Box::new(r)), line)
         }
-        // A self-tail-call's value is the recurrence, not a base value — its
-        // args are handled by `rewrite_value` (call-arg boundaries).
+        // A (self / mutual) tail-call is the RECURRENCE, not a returned
+        // value: it transfers control, it does not cross a representation
+        // boundary in the caller's frame. Its ARGS are rewritten in the
+        // callee's per-param context (`rewrite_call_args`), but the call
+        // itself is never `Box`/`Unbox`ed. Treating it as a value (and
+        // unboxing it in a bare-return fn) was the spurious-`Unbox` bug.
+        MirExpr::TailCall(mut tc) => {
+            let target = tc.node.target;
+            let callee = MirCallee::Fn(target);
+            let args = std::mem::take(&mut tc.node.args);
+            tc.node.args = rewrite_call_args(args, &callee, ctx);
+            Spanned::new(MirExpr::TailCall(tc), line)
+        }
+        // A base-case value (a literal, a bare `Local`, an arithmetic tree,
+        // an ordinary `Call`): rewrite for the fn's return representation.
         other => {
             let spanned = Spanned::new(other, line);
+            if let Some(t) = ty {
+                spanned.set_ty(t);
+            }
             if bare_return {
                 rewrite_raw(spanned, ctx)
             } else {
-                rewrite_boxed(spanned, ctx)
+                // Boxed-return tail: the Q5 bare-returning-call boxing applies
+                // here (and only here — see `rewrite_boxed_tail`).
+                rewrite_boxed_tail(spanned, ctx)
             }
         }
     }
@@ -549,7 +637,7 @@ fn rewrite_call_args(
     ctx: &RewriteCtx<'_>,
 ) -> Vec<Spanned<MirExpr>> {
     let callee_facts = match callee {
-        MirCallee::Fn(t) => ctx.all.for_fn(*t),
+        MirCallee::Fn(t) => ctx.callee_facts(*t),
         _ => None,
     };
     args.into_iter()
@@ -620,7 +708,7 @@ mod tests {
         );
         let mir_items = result.resolved_items.clone();
         let program = optimize(lower_program(&mir_items));
-        rewrite_for_rust(program)
+        rewrite_for_rust(program, &std::collections::HashSet::new())
     }
 
     fn fn_named<'a>(program: &'a MirProgram, name: &str) -> &'a MirFn {

--- a/src/ir/mir/optimize/bool_match.rs
+++ b/src/ir/mir/optimize/bool_match.rs
@@ -156,7 +156,10 @@ fn bool_match_walk_children(node: &mut MirExpr) {
             }
         }
         MirExpr::Project(spanned_proj) => bool_match_in_place(&mut spanned_proj.node.base),
-        MirExpr::Try(inner) | MirExpr::Return(inner) => bool_match_in_place(inner),
+        MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => bool_match_in_place(inner),
         MirExpr::List(items) | MirExpr::Tuple(items) => {
             for item in items {
                 bool_match_in_place(item);

--- a/src/ir/mir/optimize/branch_collapse.rs
+++ b/src/ir/mir/optimize/branch_collapse.rs
@@ -119,7 +119,10 @@ fn branch_collapse_walk_children(node: &mut MirExpr) {
             }
         }
         MirExpr::Project(spanned_proj) => branch_collapse_in_place(&mut spanned_proj.node.base),
-        MirExpr::Try(inner) | MirExpr::Return(inner) => branch_collapse_in_place(inner),
+        MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => branch_collapse_in_place(inner),
         MirExpr::List(items) | MirExpr::Tuple(items) => {
             for item in items {
                 branch_collapse_in_place(item);

--- a/src/ir/mir/optimize/const_fold.rs
+++ b/src/ir/mir/optimize/const_fold.rs
@@ -143,6 +143,7 @@ fn walk_children(node: &mut MirExpr, builtins: &[String]) {
         MirExpr::Project(spanned_proj) => fold_in_place(&mut spanned_proj.node.base, builtins),
         MirExpr::Try(inner) => fold_in_place(inner, builtins),
         MirExpr::Return(inner) => fold_in_place(inner, builtins),
+        MirExpr::Box(inner) | MirExpr::Unbox(inner) => fold_in_place(inner, builtins),
         MirExpr::List(items) | MirExpr::Tuple(items) => {
             for item in items {
                 fold_in_place(item, builtins);

--- a/src/ir/mir/optimize/dead_code.rs
+++ b/src/ir/mir/optimize/dead_code.rs
@@ -107,6 +107,7 @@ fn dce_walk_children(node: &mut MirExpr) {
         MirExpr::Project(spanned_proj) => dce_in_place(&mut spanned_proj.node.base),
         MirExpr::Try(inner) => dce_in_place(inner),
         MirExpr::Return(inner) => dce_in_place(inner),
+        MirExpr::Box(inner) | MirExpr::Unbox(inner) => dce_in_place(inner),
         MirExpr::List(items) | MirExpr::Tuple(items) => {
             for item in items {
                 dce_in_place(item);
@@ -197,7 +198,10 @@ fn visit_locals(node: &MirExpr, visit: &mut impl FnMut(LocalId)) {
             }
         }
         MirExpr::Project(spanned_proj) => visit_locals(&spanned_proj.node.base.node, visit),
-        MirExpr::Try(inner) | MirExpr::Return(inner) => visit_locals(&inner.node, visit),
+        MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => visit_locals(&inner.node, visit),
         MirExpr::List(items) | MirExpr::Tuple(items) => {
             for item in items {
                 visit_locals(&item.node, visit);
@@ -283,6 +287,9 @@ pub(super) fn is_pure(expr: &Spanned<MirExpr>) -> bool {
                 && is_pure(&spanned_ite.node.then_branch)
                 && is_pure(&spanned_ite.node.else_branch)
         }
+        // A representation boundary is pure iff its inner value is — it is
+        // a pure `from_i64` / `to_i64` conversion over the inner result.
+        MirExpr::Box(inner) | MirExpr::Unbox(inner) => is_pure(inner),
         MirExpr::Call(_)
         | MirExpr::TailCall(_)
         | MirExpr::Try(_)

--- a/src/ir/mir/optimize/inline.rs
+++ b/src/ir/mir/optimize/inline.rs
@@ -123,7 +123,10 @@ fn inline_walk_children(node: &mut MirExpr, candidates: &HashMap<FnId, Literal>)
             }
         }
         MirExpr::Project(spanned_proj) => inline_in_place(&mut spanned_proj.node.base, candidates),
-        MirExpr::Try(inner) | MirExpr::Return(inner) => inline_in_place(inner, candidates),
+        MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => inline_in_place(inner, candidates),
         MirExpr::List(items) | MirExpr::Tuple(items) => {
             for item in items {
                 inline_in_place(item, candidates);
@@ -173,6 +176,7 @@ mod tests {
                 body: span(callee_body),
                 local_count: 0,
                 aliased_slots: std::sync::Arc::new(Vec::new()),
+                repr: crate::ir::mir::program::MirFnRepr::default(),
             },
         );
         p.fns.insert(
@@ -186,6 +190,7 @@ mod tests {
                 body: span(caller_body),
                 local_count: 0,
                 aliased_slots: std::sync::Arc::new(Vec::new()),
+                repr: crate::ir::mir::program::MirFnRepr::default(),
             },
         );
         p
@@ -227,6 +232,7 @@ mod tests {
                 body: span(MirExpr::Literal(span(Literal::Int(42)))),
                 local_count: 1,
                 aliased_slots: std::sync::Arc::new(Vec::new()),
+                repr: crate::ir::mir::program::MirFnRepr::default(),
             },
         );
         let caller_body_expr = MirExpr::Call(span(MirCall {
@@ -244,6 +250,7 @@ mod tests {
                 body: span(caller_body_expr),
                 local_count: 0,
                 aliased_slots: std::sync::Arc::new(Vec::new()),
+                repr: crate::ir::mir::program::MirFnRepr::default(),
             },
         );
         let inlined = inline_nullary_literals(p);

--- a/src/ir/mir/optimize/mod.rs
+++ b/src/ir/mir/optimize/mod.rs
@@ -47,6 +47,7 @@
 
 pub mod algebraic;
 pub mod bare_i64;
+pub mod bare_i64_rewrite;
 pub mod bool_match;
 pub mod branch_collapse;
 pub mod const_fold;

--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -763,7 +763,10 @@ fn scan_leaks(
                 out,
             );
         }
-        MirExpr::Return(inner) | MirExpr::Try(inner) => {
+        MirExpr::Return(inner)
+        | MirExpr::Try(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => {
             scan_leaks(&inner.node, prov, captures_param, builtins, out);
         }
 
@@ -1256,7 +1259,11 @@ fn visit_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {
             f(&b.node.lhs.node);
             f(&b.node.rhs.node);
         }
-        MirExpr::Neg(inner) | MirExpr::Try(inner) | MirExpr::Return(inner) => f(&inner.node),
+        MirExpr::Neg(inner)
+        | MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => f(&inner.node),
         MirExpr::Match(m) => {
             f(&m.node.subject.node);
             for arm in &m.node.arms {
@@ -1356,6 +1363,7 @@ mod tests {
                 body: span(MirExpr::Literal(span(Literal::Int(0)))),
                 local_count: 1,
                 aliased_slots: Arc::new(vec![true]),
+                repr: crate::ir::mir::program::MirFnRepr::default(),
             },
         );
         (p, id)

--- a/src/ir/mir/optimize/test_helpers.rs
+++ b/src/ir/mir/optimize/test_helpers.rs
@@ -29,6 +29,7 @@ pub(crate) fn one_fn_program(body: MirExpr) -> MirProgram {
             body: span(body),
             local_count: 0,
             aliased_slots: std::sync::Arc::new(Vec::new()),
+            repr: super::super::program::MirFnRepr::default(),
         },
     );
     p

--- a/src/ir/mir/program.rs
+++ b/src/ir/mir/program.rs
@@ -160,6 +160,50 @@ pub struct MirFn {
     /// out-of-range slot reads `false` (not aliased → fast path sound),
     /// matching the resolver tables.
     pub aliased_slots: std::sync::Arc<Vec<bool>>,
+    /// **Int-representation tags (ETAP-2).** Populated ONLY by the
+    /// `bare_i64::rewrite_for_rust` MIR->MIR pass on the per-target clone
+    /// the Rust backend codegens from; default-empty everywhere else (so
+    /// the VM / wasm-gc / proof MIR keep all-`Int` representation). When a
+    /// slot is in [`MirFnRepr::bare_slots`] it is a raw machine `i64` for
+    /// its whole lifetime (its reads render native `i64`, arithmetic over
+    /// raw slots stays raw); every crossing into an `Int` context is an
+    /// explicit [`super::expr::MirExpr::Box`] node the rewrite inserted.
+    /// This is the per-value representation tag made explicit ON the IR --
+    /// backends read it off the rewritten `MirFn` instead of re-deriving
+    /// from the `BareI64Facts` side table.
+    pub repr: MirFnRepr,
+}
+
+/// Per-fn Int-representation summary made explicit on the rewritten MIR
+/// (ETAP-2 SLICE 1). Default-empty ⇒ everything is the arbitrary-precision
+/// `Int` (`aver_rt::AverInt`), the fail-closed baseline. Populated only by
+/// `bare_i64::rewrite_for_rust`.
+#[derive(Debug, Clone, Default)]
+pub struct MirFnRepr {
+    /// Locals (params + let bindings + match aliases) the rewrite tagged as
+    /// raw machine `i64`. A read of such a slot renders as a native `i64`
+    /// ident; arithmetic over raw slots stays raw. A missing slot is `Int`
+    /// (boxed) -- fail-closed.
+    pub bare_slots: std::collections::HashSet<LocalId>,
+    /// Per-param representation, indexed by declaration order (same indexing
+    /// `aliased_slots` / `own_param` use): `true` ⟺ the param's Rust
+    /// signature type is bare `i64` (and every caller `Box`/`Unbox`es at the
+    /// boundary).
+    pub bare_params: Vec<bool>,
+    /// `true` ⟺ the fn's Rust return type is bare `i64`.
+    pub bare_return: bool,
+}
+
+impl MirFnRepr {
+    /// Is the value bound to `slot` represented as a raw machine `i64`?
+    pub fn slot_is_bare(&self, slot: LocalId) -> bool {
+        self.bare_slots.contains(&slot)
+    }
+
+    /// Is param index `i` bare in the Rust signature?
+    pub fn param_is_bare(&self, i: usize) -> bool {
+        self.bare_params.get(i).copied().unwrap_or(false)
+    }
 }
 
 /// One formal parameter. The `LocalId` is assigned at lowering

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -440,6 +440,14 @@ pub(super) fn compile_mir_expr(
             Ok(())
         }
 
+        // ETAP-2 representation boundaries are inserted only by the Rust
+        // codegen rewrite (`bare_i64::rewrite_for_rust`) on a per-target
+        // clone — the VM compiles the SHARED, un-rewritten MIR, so these
+        // never reach here. The VM models every Int as arbitrary-precision,
+        // so `Box`/`Unbox` are representation identities: compile the inner
+        // transparently (defensive — keeps the walker total).
+        MirExpr::Box(inner) | MirExpr::Unbox(inner) => compile_mir_expr(fc, inner),
+
         // ── Phase 4d: tail-call dispatch ────────────────────────
         MirExpr::TailCall(spanned_tail) => {
             let tc = &spanned_tail.node;
@@ -898,6 +906,8 @@ fn can_compile(expr: &Spanned<MirExpr>) -> bool {
         MirExpr::Project(p) => can_compile(&p.node.base),
         // Phase 4d additions:
         MirExpr::Try(inner) => can_compile(inner),
+        // ETAP-2 boundaries are Rust-codegen-only; never on the VM path.
+        MirExpr::Box(inner) | MirExpr::Unbox(inner) => can_compile(inner),
         MirExpr::TailCall(t) => t.node.args.iter().all(can_compile),
         // Phase 4f additions:
         MirExpr::List(items) => items.iter().all(can_compile),
@@ -1597,6 +1607,11 @@ fn contains_last_use_slot_mir(expr: &MirExpr, target: u32) -> bool {
         MirExpr::Neg(inner) => contains_last_use_slot_mir(&inner.node, target),
         MirExpr::Project(p) => contains_last_use_slot_mir(&p.node.base.node, target),
         MirExpr::Try(inner) => contains_last_use_slot_mir(&inner.node, target),
+        // ETAP-2 boundaries never appear on the VM path (the rewrite is
+        // Rust-codegen-only); recurse transparently for completeness.
+        MirExpr::Box(inner) | MirExpr::Unbox(inner) => {
+            contains_last_use_slot_mir(&inner.node, target)
+        }
         MirExpr::Construct(c) => c
             .node
             .args

--- a/tests/mir_phase2_model_spec.rs
+++ b/tests/mir_phase2_model_spec.rs
@@ -185,6 +185,7 @@ fn build_a_tiny_function_by_hand() {
         body,
         local_count: 1,
         aliased_slots: std::sync::Arc::new(Vec::new()),
+        repr: aver::ir::mir::MirFnRepr::default(),
     };
     let mut program = MirProgram::empty();
     program.fns.insert(f.fn_id, f);

--- a/tests/mir_phase2b_dump_spec.rs
+++ b/tests/mir_phase2b_dump_spec.rs
@@ -58,6 +58,7 @@ fn one_fn_dump_pins_skeleton() {
             body,
             local_count: 0,
             aliased_slots: std::sync::Arc::new(Vec::new()),
+            repr: aver::ir::mir::MirFnRepr::default(),
         },
     );
 
@@ -106,6 +107,7 @@ fn try_bind_via_let_composition_dump_shape() {
             body,
             local_count: 0,
             aliased_slots: std::sync::Arc::new(Vec::new()),
+            repr: aver::ir::mir::MirFnRepr::default(),
         },
     );
     let dump = format!("{program}");
@@ -163,6 +165,7 @@ fn match_dump_shape() {
             body,
             local_count: 0,
             aliased_slots: std::sync::Arc::new(Vec::new()),
+            repr: aver::ir::mir::MirFnRepr::default(),
         },
     );
     let dump = format!("{program}");
@@ -209,6 +212,7 @@ fn ctor_pattern_dump_uses_ctor_id() {
             body,
             local_count: 0,
             aliased_slots: std::sync::Arc::new(Vec::new()),
+            repr: aver::ir::mir::MirFnRepr::default(),
         },
     );
     let dump = format!("{program}");
@@ -240,6 +244,7 @@ fn effects_render_on_fn_header() {
             body,
             local_count: 0,
             aliased_slots: std::sync::Arc::new(Vec::new()),
+            repr: aver::ir::mir::MirFnRepr::default(),
         },
     );
     let dump = format!("{program}");
@@ -267,6 +272,7 @@ fn fns_render_in_fn_id_order() {
                 body: span(MirExpr::Literal(span(Literal::Int(raw as i64)))),
                 local_count: 0,
                 aliased_slots: std::sync::Arc::new(Vec::new()),
+                repr: aver::ir::mir::MirFnRepr::default(),
             },
         );
     }
@@ -301,6 +307,7 @@ fn let_dump_shape() {
             body,
             local_count: 0,
             aliased_slots: std::sync::Arc::new(Vec::new()),
+            repr: aver::ir::mir::MirFnRepr::default(),
         },
     );
     let dump = format!("{program}");


### PR DESCRIPTION
Foundation of etap 2 (size/speed-recovery via the unboxing analysis). **No shipped behavior changes** — this is a behavior-equivalent refactor that elevates the Int representation choice from a codegen-consumed side table into the MIR itself, so backends lower it trivially and the boundary-completeness bug class becomes structurally impossible. wasm-gc is untouched (slice 2 wires it to consume the same nodes → the wasm size recovery).

## Before / after
- **Before:** `bare_i64::analyze(&MirProgram) -> BareI64Facts` (a side table); the Rust codegen read `is_bare`/`expr_is_bare_i64` and DECIDED representation + inserted `from_i64`/`to_i64` boundary conversions in `from_mir.rs`. That "codegen must remember every boundary" design is exactly what caused the #519 boundary bugs (Q4/Q5/esc_match/marms).
- **After:** the same range+escape ANALYSIS is kept verbatim; only its MATERIALIZATION changes. A MIR→MIR rewrite (`ir/mir/optimize/bare_i64_rewrite.rs`) inserts explicit `MirExpr::Box` (raw i64 → Int) / `MirExpr::Unbox` (Int → raw i64) nodes + a per-fn `MirFnRepr` tag. The Rust codegen no longer decides representation — it lowers the nodes (`Box → AverInt::from_i64`, `Unbox → checked to_i64`, bare slots → native i64).

## Where it runs (and why)
Only in the Rust `transpile` entry, on a clone of the optimized MIR. The VM, wasm-gc, and proof (Lean/Dafny) backends consume the unmodified shared MIR and never see a `Box`/`Unbox` node or a bare tag — mandatory because proof export + shape recognition key on the syntactic structure the rewrite rewrites. `proof_spec` (176 tests) unchanged confirms proof is unaffected.

## Behavior-equivalence (the validation — Rust is already cross-vendor-verified, so equivalence proves the rewrite)
- `cross_int_arithmetic_vm_vs_rust` green (Rust computes Int = ℤ identically to the VM, incl. i64-overflow no-wrap).
- The five #519 boundary regressions (`rust_codegen_compiles_unbox_boundary_regressions`) cargo-check clean; `bump` → `9223372036854775808`.
- The unboxing SPEED win preserved: `countdown`/`factorial` still emit bare `i64` counters; `AVER_NO_BARE_I64=1` still forces the boxed variant.
- Every corpus example still compiles to buildable Rust; full default suite (77 binaries, 2246 tests) green; fmt + clippy (`-p aver-lang --lib --bin aver`, default and `--features wasm,wasip2`) clean.
- The emitted Rust is behavior-equivalent (not byte-identical): same conversions, decided once in the rewrite. One benign redundancy — a `from_i64(...)` wrapper on a discarded `main` result.

## A latent bug fixed
The migration surfaced (and fixed) a real inconsistency the side-table version hid by accident: the analysis can flag a mutual-TCO member's return bare (a phantom) while codegen emits those with a boxed trampoline. The rewrite threads `mutual_tco_members` (skip tagging them) + two placement rules (a tail-call is the recurrence, never boxed; bare-return boxing only in return-tail). Verified by the deep mutual/self-recursion differential.

Design note: `prompts/etap2-mir-rewrite.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)