### PR TITLE
ir/mir: box Int counters whose recurrence has a growing self-tail-call path (C0 soundness)

### DIFF
--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -841,17 +841,44 @@ struct Recurrence {
 /// guard) — the conservative decline.
 fn recurrence_for_param(f: &MirFn, param_slot: LocalId, i: usize) -> Option<Recurrence> {
     let (guard_k, guard_kind) = guard_literal_for(&f.body.node, param_slot)?;
-    let mut recur: Option<Recurrence> = None;
-    find_self_tailcall_recurrence(
+
+    // Inspect EVERY self-tail-call's arg at index `i` — not just the first.
+    // A counter is a provably-bounded recurrence only when ALL of its
+    // self-recurrence paths advance it by the SAME single monotone
+    // `counter - step` decrement toward the equality guard. If any path is
+    // missing, grows the counter (`n + lit`), uses a different/opposite
+    // step, or is a non-`counter`-based expression, the param is NOT a
+    // bounded counter — DECLINE (box). Only checking the first path
+    // under-approximates the interval (a SECOND, growing self-tail-call
+    // leaks the counter out of `i64` range — the multi-tail-call soundness
+    // hole). Fail-closed: boxing costs speed, a missed bound never
+    // correctness.
+    //
+    // `walk_self_tailcall_steps` returns `false` the moment it sees any
+    // self-tail-call whose arg at `i` is NOT the agreed decrement step.
+    let mut step: Option<i128> = None;
+    let mut saw_self_tail = false;
+    let all_same_decrement = walk_self_tailcall_steps(
         &f.body.node,
         f.fn_id,
         param_slot,
         i,
-        guard_k,
-        guard_kind,
-        &mut recur,
+        &mut step,
+        &mut saw_self_tail,
     );
-    recur
+
+    // No self-tail-call at this index, or some path was not the agreed
+    // monotone decrement ⇒ no provably-bounded recurrence. Decline.
+    if !saw_self_tail || !all_same_decrement {
+        return None;
+    }
+    let step = step?;
+
+    Some(Recurrence {
+        guard_k,
+        step,
+        guard_kind,
+    })
 }
 
 /// Walk for a `Match`/`IfThenElse` that guards the counter against a
@@ -922,36 +949,50 @@ fn guard_literal_for(e: &MirExpr, counter: LocalId) -> Option<(i128, GuardKind)>
     }
 }
 
-/// Find a self-`TailCall` and check whether its arg at index `i` is a
-/// monotone `counter - step` (decrement of a positive literal). Records the
-/// [`Recurrence`] on the first match.
-fn find_self_tailcall_recurrence(
+/// Walk `e` and validate the arg at index `i` of EVERY self-`TailCall` to
+/// `self_fn`. Each such arg MUST be the monotone `counter - step` decrement
+/// (a positive literal `step`), and every path must agree on the SAME
+/// `step` — the first one seen pins it (recorded in `step`). `saw_self_tail`
+/// is set when at least one self-tail-call carries an arg at `i`.
+///
+/// Returns `false` (and stops contributing) the moment any self-tail-call's
+/// arg at `i` is NOT the agreed decrement — a growing `counter + lit`, a
+/// different/opposite step, or a non-`counter`-based expr. A `false` result
+/// means the param is not a provably-bounded counter and must box
+/// (fail-closed). A self-tail-call with too few args (no slot `i`) is
+/// skipped: the param at `i` does not participate in that call.
+fn walk_self_tailcall_steps(
     e: &MirExpr,
     self_fn: FnId,
     counter: LocalId,
     i: usize,
-    guard_k: i128,
-    guard_kind: GuardKind,
-    out: &mut Option<Recurrence>,
-) {
-    if out.is_some() {
-        return;
-    }
+    step: &mut Option<i128>,
+    saw_self_tail: &mut bool,
+) -> bool {
+    let mut ok = true;
     if let MirExpr::TailCall(tc) = e
         && tc.node.target == self_fn
         && let Some(arg) = tc.node.args.get(i)
-        && let Some(step) = decrement_step(&arg.node, counter)
     {
-        *out = Some(Recurrence {
-            guard_k,
-            step,
-            guard_kind,
-        });
-        return;
+        *saw_self_tail = true;
+        match decrement_step(&arg.node, counter) {
+            // First decrement path pins the step; later paths must match it.
+            Some(s) => match *step {
+                None => *step = Some(s),
+                Some(prev) if prev != s => ok = false,
+                Some(_) => {}
+            },
+            // Not a `counter - lit` decrement (a growth path, a different
+            // shape, or not counter-based) ⇒ unbounded recurrence.
+            None => ok = false,
+        }
     }
     visit_children(e, &mut |c| {
-        find_self_tailcall_recurrence(c, self_fn, counter, i, guard_k, guard_kind, out)
+        if !walk_self_tailcall_steps(c, self_fn, counter, i, step, saw_self_tail) {
+            ok = false;
+        }
     });
+    ok
 }
 
 /// If `e` is `counter - K` (a positive literal `K`), return `K`. The only
@@ -2061,6 +2102,48 @@ fn main() -> Int
         assert!(
             f.param_is_bare(0),
             "a ≥2-literal-arm bounded counter stays bare (dispatch path emits `== Ki64`)"
+        );
+    }
+
+    /// Multi-tail-call soundness hole: a counter with TWO self-tail-call
+    /// paths at the same index — one decrements (`n - 1`), one GROWS (`n +
+    /// 1_000_000_000_000_000_000`). The pre-fix recurrence recognizer
+    /// stopped at the FIRST (decrement) path and seeded the param's interval
+    /// from the decrement alone, marking it bare; at runtime the growth path
+    /// drove `n` out of `i64` range and the emitted native `i64` op
+    /// (`n + n`) silently wrapped in release (the C0 bug — caught only by the
+    /// `overflow-checks` panic in dev). The fix requires EVERY self-tail-call
+    /// arg at the index to be the SAME monotone decrement; a second growing
+    /// path makes the recurrence unbounded ⇒ the param must BOX (fail-closed).
+    #[test]
+    fn multi_tailcall_growing_path_demotes_to_boxed() {
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn loopit(n: Int, phase: Int) -> Int
+    match n
+        0 -> n + n
+        _ -> match phase
+            0 -> n + n
+            5000 -> loopit(n - 1, phase)
+            _ -> loopit(n + 1000000000000000000, phase - 1)
+
+fn main() -> Int
+    loopit(8, 5)
+"#;
+        let (program, facts) = facts_for(src);
+        let f = facts
+            .for_fn(fn_id_by_name(&program, "loopit"))
+            .expect("loopit facts");
+        // The counter `n` has a SECOND, growing self-tail-call path, so it is
+        // NOT a provably-bounded counter — it must box. Pre-fix this asserted
+        // `param_is_bare(0) == true` (the soundness hole): the recognizer saw
+        // only the `n - 1` path.
+        assert!(
+            !f.param_is_bare(0),
+            "a counter with a growing second self-tail-call path is unbounded → must box"
         );
     }
 }

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -405,6 +405,49 @@ fn main() -> Unit
     );
 }
 
+/// Multi-tail-call Int-unboxing soundness hole (the C0 bug): a counter `n`
+/// with TWO self-tail-call paths — one decrements (`n - 1`), one GROWS
+/// (`n + 1_000_000_000_000_000_000`). The pre-fix recurrence recognizer saw
+/// only the first (decrement) path, under-approximated `n`'s interval, and
+/// marked it bare → the Rust backend emitted native `i64` for `n`, so at
+/// runtime the growth path drove `n` past `i64::MAX` and `n + n` silently
+/// WRAPPED in release (a panic in dev under `overflow-checks`). The fix
+/// boxes `n` (every self-tail-call must be the SAME monotone decrement, else
+/// the recurrence is unbounded). Build+run the emitted Rust and assert it
+/// equals the VM's arbitrary-precision `10000000000000000016` — a wrongly
+/// bare counter would diverge (wrap) or panic.
+#[test]
+fn rust_multi_tailcall_growing_counter_matches_vm() {
+    let src = r#"module MultiTail
+    intent = "two self-tail-call paths: one decrements, one grows — counter must box"
+    depends []
+    effects [Console.print]
+
+fn loopit(n: Int, phase: Int) -> Int
+    ? "phase 5000 decrements n; any other non-zero phase grows n past i64 range"
+    match n
+        0 -> n + n
+        _ -> match phase
+            0 -> n + n
+            5000 -> loopit(n - 1, phase)
+            _ -> loopit(n + 1000000000000000000, phase - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(loopit(8, 5)))
+"#;
+    let vm = run_vm_inline("multitail", src).expect("vm run");
+    let rust = build_run_rust_inline("multitail", src).expect("rust build+run");
+    assert_eq!(
+        vm, "10000000000000000016",
+        "VM computes the arbitrary-precision (no-wrap) value"
+    );
+    assert_eq!(
+        rust, vm,
+        "Rust diverged from VM — the multi-tail-call counter was wrongly unboxed to i64 and wrapped/panicked"
+    );
+}
+
 /// The own_param perf win on the RUST backend, verified end-to-end: a
 /// linearly-threaded Vector param the pass proves uniquely owned must (a)
 /// build+run to the same result as the VM, and (b) emit the OWNED-by-value


### PR DESCRIPTION
## What

The Int unboxing analysis (`bare_i64.rs`) certified a recursion parameter as a bare `i64` counter when it had **multiple** self-tail-call paths but only the **first** was a monotone `counter - step` decrement. A second path that *grows* the counter (`n + 1_000_000_000_000_000_000`) was ignored, so the parameter's range was under-approximated, marked bare, and emitted as a native `i64` op that wrapped once the growth path drove it past `i64` range.

This was a shipped wrong-value on the Rust backend (the unboxing landed in #534): the value silently wrapped in release; in dev the generated `overflow-checks = true` profile turned it into a panic, which is how it surfaced.

## Fix

`recurrence_for_param` now inspects **every** self-tail-call's arg at the parameter index via the new `walk_self_tailcall_steps`. A parameter is a provably-bounded counter only when *all* of its self-recurrence paths advance it by the *same* single monotone `counter - step` decrement toward the equality guard. Any path that is missing, grows the counter, uses a different/opposite step, or is not counter-based ⇒ the recurrence is unbounded ⇒ the parameter **boxes** (fail-closed). Boxing costs speed; a missed bound never costs correctness.

Not over-conservative: two identical `n - 1` paths still stay bare. Mixed decrements that could overshoot the equality guard correctly box.

## Witness (`loopit(8, 5)`, one `n - 1` path + one `n + 1e18` path)

| | before | after |
|---|---|---|
| Rust signature | `mut n: i64` | `mut n: aver_rt::AverInt` |
| VM | `10000000000000000016` | `10000000000000000016` |
| Rust | panic (overflow trip-wire) | `10000000000000000016` ✓ |

Wins preserved (verified): `countdown(mut n: i64)` and `factorial`'s `mut n: i64` loop counter stay bare.

## Tests

- Unit `multi_tailcall_growing_path_demotes_to_boxed` — asserts the counter is **not** bare. Verified it fails against the pre-fix first-path-only recognizer.
- Integration `rust_multi_tailcall_growing_counter_matches_vm` — build+run the witness, Rust stdout == VM (ungated, normal CI).
- #519 unreachable-guard reachability tests + `cross_int_arithmetic_vm_vs_rust` differential intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)