### PR TITLE
ir/mir: box Int compounds whose intermediate leaves i64 (compile-error fix)

### DIFF
--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -131,13 +131,22 @@ impl FnBareFacts {
     /// Compute the result interval of an EXPRESSION TREE built only from
     /// bare leaves (`Local`s the analysis proved `Bare`, `Int` literals) and
     /// `Add`/`Sub`/`Mul`/`Neg` nodes, using the saturating #511 interval
-    /// arithmetic. Returns `None` if any leaf is non-bare / unknown or the
-    /// node is an unsupported shape — the conservative decline.
+    /// arithmetic. Returns `None` if any leaf is non-bare / unknown, the node
+    /// is an unsupported shape, OR any INTERMEDIATE sub-result leaves `i64` —
+    /// the conservative decline.
     ///
     /// This is the SINGLE SOURCE OF TRUTH for "what interval does this
     /// inline compound evaluate to": both the analysis's `tail_value_is_bare`
     /// and the Rust backend's `mir_expr_is_bare_i64` route a compound through
     /// here, so neither can accept a tree whose result leaves `i64`.
+    ///
+    /// SOUNDNESS: gating only the WHOLE-TREE result is not enough — a
+    /// transient out-of-`i64` intermediate (`(n + i64::MAX) - i64::MAX`,
+    /// whose inner `Add` is `[MAX+1, …]` but whose final value narrows back
+    /// into range) would lower this node's raw-`i64` op and WRAP before the
+    /// enclosing op runs. So every node's result is checked against `i64`
+    /// here, mirroring `eval_interval`'s `worst`-join on the analysis side;
+    /// a single escaping sub-result declines the whole compound to boxed.
     pub fn bare_expr_interval(&self, e: &MirExpr) -> Option<Interval> {
         match e {
             MirExpr::Literal(l) => match l.node {
@@ -147,17 +156,18 @@ impl FnBareFacts {
             MirExpr::Local(local) => self.bare_slot_interval(local.node.slot),
             MirExpr::Neg(inner) => {
                 let r = Interval::point(0).sub(self.bare_expr_interval(&inner.node)?);
-                Some(r)
+                r.fits_i64().then_some(r)
             }
             MirExpr::BinOp(b) => {
                 let l = self.bare_expr_interval(&b.node.lhs.node)?;
                 let r = self.bare_expr_interval(&b.node.rhs.node)?;
-                match b.node.op {
-                    BinOp::Add => Some(l.add(r)),
-                    BinOp::Sub => Some(l.sub(r)),
-                    BinOp::Mul => Some(l.mul(r)),
-                    _ => None,
-                }
+                let result = match b.node.op {
+                    BinOp::Add => l.add(r),
+                    BinOp::Sub => l.sub(r),
+                    BinOp::Mul => l.mul(r),
+                    _ => return None,
+                };
+                result.fits_i64().then_some(result)
             }
             _ => None,
         }

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -448,6 +448,48 @@ fn main() -> Unit
     );
 }
 
+/// Transient intermediate-overflow Int-unboxing hole: a compound
+/// `(n + i64::MAX) - i64::MAX` over a bare counter `n`. The whole-tree result
+/// narrows back INTO `i64`, but the inner `n + i64::MAX` intermediate leaves
+/// `i64`. The pre-fix `bare_expr_interval` checked only the FINAL result
+/// interval, so the compound was marked bare and the Rust backend emitted a
+/// MIXED tree — the inner `add` boxed-then-`to_i64()` then a raw `i64` outer
+/// `.sub` — which does NOT compile (`E0599 no method 'sub' for i64`). This is
+/// fail-closed (a compile error, never a silent wrap), but a valid Aver
+/// program must still compile: the fix gates EVERY intermediate against `i64`
+/// (mirroring the analysis-side `eval_interval` worst-join), so the whole
+/// compound boxes. Build+run the emitted Rust and assert it builds and equals
+/// the VM's exact `1`.
+#[test]
+fn rust_transient_intermediate_overflow_compound_matches_vm() {
+    let src = r#"module IntermediateOverflow
+    intent = "a compound whose intermediate leaves i64 but final narrows back must box"
+    depends []
+    effects [Console.print]
+
+fn loopit(n: Int) -> Int
+    ? "base case adds then subtracts i64::MAX; the intermediate overflows i64"
+    match n
+        1 -> (n + 9223372036854775807) - 9223372036854775807
+        _ -> loopit(n - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(loopit(5)))
+"#;
+    let vm = run_vm_inline("intermediate_overflow", src).expect("vm run");
+    let rust = build_run_rust_inline("intermediate_overflow", src)
+        .expect("rust build+run (pre-fix: E0599 — the mixed bare/boxed compound did not compile)");
+    assert_eq!(
+        vm, "1",
+        "VM computes the exact value (the intermediate is ℤ, never wraps)"
+    );
+    assert_eq!(
+        rust, vm,
+        "Rust diverged from VM — the transient-overflow compound was wrongly kept bare"
+    );
+}
+
 /// The own_param perf win on the RUST backend, verified end-to-end: a
 /// linearly-threaded Vector param the pass proves uniquely owned must (a)
 /// build+run to the same result as the VM, and (b) emit the OWNED-by-value


### PR DESCRIPTION
## What

`bare_expr_interval` (the shared gate used by both the analysis's tail-value check and the Rust backend's per-expression bare check) computed only a compound's **final** result interval. A tree like `(n + i64::MAX) - i64::MAX` — whose inner `Add` is `[MAX+1, …]` (out of `i64`) but whose final value narrows back into range — was therefore certified bare.

The Rust backend then emitted a **mixed** tree: the inner `add` boxed-then-`to_i64()`, then a raw `i64` outer `.sub` — which does not compile:

```
error[E0599]: no method named `sub` found for type `i64`
```

This is fail-closed (the missing coercion is a compile error, never a silent wrap — `aver-rt` has no `i64`↔`AverInt` coercion), but a valid Aver program that runs fine on the VM must still compile on the Rust backend.

## Fix

Gate **every** intermediate sub-result against `i64` inside `bare_expr_interval`, mirroring the analysis-side `eval_interval` worst-join: a single escaping intermediate declines the whole compound to boxed. This makes `bare_expr_interval`'s doc-comment claim ("every intermediate stays OverflowFree") actually true.

Strictly more conservative, so no legitimately-bare tree is over-boxed: a tree is bare iff every native `i64` op stays in range, which is exactly "all sub-results fit `i64`."

## Verified

| program | VM | Rust (before) | Rust (after) |
|---|---|---|---|
| `(n + i64::MAX) - i64::MAX` over bare `n` | `1` | `E0599` (no compile) | `1` ✓ (compound boxes) |
| `(n + 10) - 3` over bare `n` | `8` | `8` (raw i64) | `8` ✓ (stays raw i64) |

The counter `n` itself stays bare `i64` in both cases — only the overflowing compound boxes.

## Tests

- Integration `rust_transient_intermediate_overflow_compound_matches_vm` — build+run the witness, assert it compiles and Rust stdout == VM. Fails pre-fix (E0599 → build error).
- Full suite + `cargo clippy --features wasm,wasip2` + `cargo fmt --check` clean.

## Context

This is the same defect class as the #511 slice-1 "intermediate narrows back" bug (caught by the same cross-vendor panel), re-appearing at the MIR-expression level. It surfaced while reviewing #538 (the multi-tail-call counter fix); independent code path, separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)