### PR TITLE
proof(lean): discovery do-no-harm — try the pre-discovery proof first

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1620,6 +1620,12 @@ fn emit_list_induction(
     let discovered_simp = discovered_simp_entries(ctx, discovered);
     let siblings = earlier_law_lemmas(vb, law, ctx);
     let fast_simp = fastpath_simp_entries(ctx, discovered, &siblings);
+    // The pre-discovery arm simp set (law defs + recognizer rev rules), BEFORE
+    // the committed discovered lemmas join. The do-no-harm fallback ladder
+    // below inducts over THIS set so a law already universal without discovery
+    // keeps proving even if a committed lemma would simp-loop the augmented
+    // arms into a `sorry` (the net-negative feedback bug).
+    let simp_list_plain = simp_defs.iter().cloned().collect::<Vec<_>>().join(", ");
     simp_defs.extend(discovered_simp.iter().cloned());
     let simp_list = simp_defs.into_iter().collect::<Vec<_>>().join(", ");
     let target_lean = &intro_names[target_idx];
@@ -1683,6 +1689,11 @@ fn emit_list_induction(
         "List.cons_append, List.singleton_append, List.nil_append".to_string()
     } else {
         format!("{simp_list}, List.cons_append, List.singleton_append, List.nil_append")
+    };
+    let split_set_plain = if simp_list_plain.is_empty() {
+        "List.cons_append, List.singleton_append, List.nil_append".to_string()
+    } else {
+        format!("{simp_list_plain}, List.cons_append, List.singleton_append, List.nil_append")
     };
 
     // Each arm closes fully or admits `sorry` — and crucially BUILDS either
@@ -1909,6 +1920,23 @@ fn emit_list_induction(
             .collect();
 
         proof_lines.push("  first".to_string());
+        // DO-NO-HARM (Houdini accept). Try the EXACT pre-discovery proof FIRST:
+        // induct over `simp_list_plain` (NO committed discovered lemmas) with NO
+        // `sorry`, so an open arm THROWS and `first` moves on. A law already
+        // universal before discovery closes here and `first` stops — the
+        // discovered-lemma tactics below are reached ONLY when the pre-discovery
+        // proof cannot close. So a committed lemma can only ever ADD a proof,
+        // never demote a working one into a `sorry` (the net-negative feedback
+        // bug: e.g. the reversed `← (++)=append` rule simp-looping rev's
+        // `revRev` ladder). Gated on a non-empty `discovered_simp` so a
+        // sibling-only feedback emit (część A) stays byte-identical to before.
+        if !discovered_simp.is_empty() {
+            let (nil_plain, cons_plain) =
+                mk_arms(&simp_list_plain, &split_set_plain, bridge_set.as_deref(), None, false);
+            proof_lines.push(format!("  | (induction {} with", target_lean));
+            proof_lines.push(format!("     {nil_plain}"));
+            proof_lines.push(format!("     {cons_plain})"));
+        }
         proof_lines.push(format!(
             "  | (simp only [{}] <;> omega)",
             fast_lemmas.join(", ")

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -98,6 +98,101 @@ fn discovered_lemmas_close_length_homomorphism_law_when_lake_is_available() {
     let _ = std::fs::remove_dir_all(&out);
 }
 
+/// DO-NO-HARM (Houdini accept) — the INVERSE of the feedback-loop win above.
+/// `rev (rev x) = x` already closes `universal:true` WITHOUT discovery (the rev
+/// anti-homomorphism recognizer emits its own aux lemma). But `--discover` over
+/// this cone commits a REVERSED unfold rule (`(x ++ y) = append x y`), which the
+/// feedback path used to inject into the induction ARMS — where, mixed with
+/// `append`'s own def, it simp-loops the working ladder into a `sorry`
+/// (`universal:true → false`: the net-negative feedback bug). The fix tries the
+/// EXACT pre-discovery proof FIRST (a no-`sorry` plain ladder that throws on an
+/// open arm), so a committed lemma can only ever ADD a proof, never demote one.
+/// This test pins that property: a law universal before discovery STAYS
+/// universal after committing lemmas. (Complements the length-homomorphism test
+/// — there discovery MUST move false→true; here it MUST NOT move true→false.)
+#[test]
+fn discovery_does_not_demote_an_already_universal_law_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping do-no-harm test: `lake` not available");
+        return;
+    }
+    let source = "module RevRev\n    intent =\n        \"rev (rev x) = x — already universal via the rev anti-homomorphism recognizer\"\n    effects []\n\n\
+         fn append(x: List<Int>, y: List<Int>) -> List<Int>\n    match x\n        [] -> y\n        [z, ..xs] -> List.concat([z], append(xs, y))\n\n\
+         fn rev(x: List<Int>) -> List<Int>\n    match x\n        [] -> []\n        [y, ..xs] -> append(rev(xs), [y])\n\n\
+         verify rev law revRev\n    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]\n    rev(rev(x)) => x\n";
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-donoharm-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join("m.av"), source).expect("write m.av");
+    let out = temp_output_dir("aver-donoharm-out");
+
+    let check = |label: &str| -> (bool, u64, String) {
+        let run = Command::new(aver_bin)
+            .arg("proof")
+            .arg(src.join("m.av"))
+            .arg("--backend")
+            .arg("lean")
+            .arg("-o")
+            .arg(&out)
+            .arg("--check")
+            .arg("--check-json")
+            .output()
+            .unwrap_or_else(|e| panic!("{label}: aver proof failed to run: {e}"));
+        let json_line = run
+            .stdout
+            .split(|&b| b == b'\n')
+            .rev()
+            .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+            .unwrap_or_else(|| panic!("{label}: no JSON line:\n{}", format_output(&run)))
+            .to_string();
+        let summary: serde_json::Value = serde_json::from_str(&json_line)
+            .unwrap_or_else(|e| panic!("{label}: bad JSON ({e}):\n{json_line}"));
+        (
+            summary["universal"].as_bool().unwrap_or(false),
+            summary["sorries"].as_u64().unwrap_or(u64::MAX),
+            format_output(&run),
+        )
+    };
+
+    // 1. Baseline: the law is universal WITHOUT discovery. If this ever flips,
+    //    the fixture stopped exercising do-no-harm (the recognizer changed) —
+    //    fix the fixture, not by relaxing the post-discovery assertion.
+    let (universal_before, sorries_before, output_before) = check("baseline");
+    assert!(
+        universal_before && sorries_before == 0,
+        "fixture is NOT universal without discovery — it no longer exercises do-no-harm:\n{output_before}"
+    );
+
+    // 2. Discover + commit into the same output dir (commits the reversed
+    //    `(x ++ y) = append x y` unfold rule that used to poison the arms).
+    let discover = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--discover")
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("expected `aver proof --discover` to run");
+    let committed = std::fs::read_to_string(out.join("DiscoveredLemmas.lean")).unwrap_or_default();
+    assert!(
+        !committed.trim().is_empty() && committed.contains("theorem"),
+        "discovery committed no lemmas — the fixture no longer pins the feedback path:\n--- discover output ---\n{}",
+        format_output(&discover)
+    );
+
+    // 3. DO-NO-HARM: the SAME check, now replaying the committed lemmas, MUST
+    //    stay universal with zero sorries. A regression here is the
+    //    net-negative feedback bug (a committed lemma demoting a working proof).
+    let (universal_after, sorries_after, output_after) = check("with-discovery");
+    assert!(
+        universal_after && sorries_after == 0,
+        "committed discovered lemmas DEMOTED an already-universal law (do-no-harm violated):\n{output_after}"
+    );
+
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
 /// THE FEEDBACK LOOP, część A — an already-proved EARLIER user `verify … law`
 /// feeds a later law's proof, with NO `--discover` step at all. The file holds
 /// two laws over `length`: `lengthHomo` (the homomorphism `length (append xs


### PR DESCRIPTION
## What

The `--discover` feedback loop is **net-negative today**: re-pinning a committed lemma into the induction arms can simp-loop a working ladder into a `sorry`, demoting an already-universal law (`universal:true → false`). This is the master-plan #3 deal-breaker ("back-propagation net-negative without a do-no-harm guard").

## Reproduced regression

On `prod/prop_10` (rev's `revRev`, `rev (rev x) = x`) and `prod/lemma_09`: discovery commits the reversed unfold rule `(x ++ y) = append x y`, the feedback path injects it into the arm simp set, and mixed with `append`'s own def it ping-pongs to a no-progress loop — the arm falls through to `| sorry`, even though the rev anti-homomorphism recognizer **already proved the law without discovery**.

| law | before fix (replay) | after fix |
|---|---|---|
| `prop_10` revRev | `universal:false`, 1 sorry | `universal:true`, 0 sorry |
| `lemma_09` revAppendCons | (same demotion) | `universal:true` |

## Fix — Houdini do-no-harm, in the tactic (no inline judge, kernel-blind)

The literal Houdini guard ("keep the re-pin only if the judge still closes") needs an inline Lean call = a warm-lake dependency, which the plan has inverted. Instead this implements do-no-harm **in the tactic structure**: in the list-induction feedback emit, try the **exact pre-discovery proof first** as the leading `first` alternative — induct over `simp_list_plain` (the arm set *before* the committed lemmas join) with **no `sorry`**, so an open arm throws and `first` moves on to the discovered-lemma tactics.

A law already universal before discovery closes here and `first` stops; the committed lemmas are reached **only** when the pre-discovery proof cannot close. So a committed lemma can only ever **add** a proof, never demote a working one. Gated on a non-empty `discovered_simp`, so a sibling-only feedback emit (część A) stays byte-identical.

Carries **no warm-lake dependency** and unblocks #4 / #9.

## Scope

The list-induction path, where both documented regressions live (`prop_10`/`lemma_09` are rev/append). The generic structural path shares the mechanism but is not a documented net-negative; left untouched.

## Verify

- 23/23 discover + lemmas tests (discovery wins preserved: rle/sparse roundtrip, length/flatten/words homomorphisms)
- `proof_spec` 178/0; lib `codegen::lean` 86/0, `lemma_discovery` 32/0; clippy clean
- New permanent guard `discovery_does_not_demote_an_already_universal_law` — the inverse of the length-homomorphism win test (discovery MUST NOT move true→false)
- Full-corpus net-effect sweep (160 tip tasks, discover→commit→replay vs baseline) running; **0 demotions** observed so far across the completed tasks

🤖 Co-authored with Claude Opus 4.8
