### PR TITLE
style(rust): rustfmt the do-no-harm mk_arms call (fix CI Format gate)

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1931,8 +1931,13 @@ fn emit_list_induction(
         // `revRev` ladder). Gated on a non-empty `discovered_simp` so a
         // sibling-only feedback emit (część A) stays byte-identical to before.
         if !discovered_simp.is_empty() {
-            let (nil_plain, cons_plain) =
-                mk_arms(&simp_list_plain, &split_set_plain, bridge_set.as_deref(), None, false);
+            let (nil_plain, cons_plain) = mk_arms(
+                &simp_list_plain,
+                &split_set_plain,
+                bridge_set.as_deref(),
+                None,
+                false,
+            );
             proof_lines.push(format!("  | (induction {} with", target_lean));
             proof_lines.push(format!("     {nil_plain}"));
             proof_lines.push(format!("     {cons_plain})"));


### PR DESCRIPTION
Pure formatting fix: the do-no-harm `mk_arms` call in `emit_list_induction` exceeded the line width after #544; rustfmt wants it multi-line. No behavior change. Recovers the red `Format` step on `main`.

`cargo fmt --check` clean locally.