### PR TITLE
wasm-gc: thread per-slot Int representation seam (slice 2a, no behavior change)

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -222,6 +222,13 @@ pub(super) struct EmitCtx<'a> {
     /// reads this; an out-of-range slot is `false` (not aliased → fast
     /// path sound).
     pub(super) aliased_slots: &'a [bool],
+    /// Per-slot / per-param Int representation for the current fn (ETAP-2
+    /// SLICE 2a). Sourced from `MirFn::repr` (mirror of `aliased_slots`).
+    /// Default-empty on the un-rewritten wasm-gc MIR, so `slot_is_bare` /
+    /// `param_is_bare` / `bare_return` all answer "boxed" — the per-slot
+    /// unboxing seam is installed but inert until 2b wires the rewrite.
+    #[allow(dead_code)]
+    pub(super) repr: &'a crate::ir::mir::MirFnRepr,
     /// Param name → resolved aver type. Used by `CallLowerCtx` for
     /// local-name recognition; the typed-AST refactor (Step 3) made
     /// the *type* portion redundant for emit, but the param list is

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -185,7 +185,10 @@ pub(crate) fn emit_fn_body_via_mir(
     caller_fn_collector: &std::cell::RefCell<CallerFnCollector>,
     wasip2_lowering: Option<&Wasip2Lowering>,
 ) -> Result<Option<Vec<ValType>>, WasmGcError> {
-    let slots = SlotTable::build_for_fn(rfd, registry, fn_map)?;
+    // ETAP-2 SLICE 2a: pass the per-slot Int repr (mirror of the alias
+    // facts). Default-empty on the un-rewritten wasm-gc MIR, so every slot
+    // stays boxed.
+    let slots = SlotTable::build_for_fn(rfd, registry, fn_map, &mir_fn.repr)?;
     let return_type_str = rfd.return_type.display();
 
     // Precollect every `let`-bound name (mirror of `emit_fn_body`) so
@@ -216,6 +219,10 @@ pub(crate) fn emit_fn_body_via_mir(
         // its gate off MIR rather than the AST `FnResolution`. Identical
         // bits to the resolver table today; the home is what changes.
         aliased_slots: mir_fn.aliased_slots.as_slice(),
+        // ETAP-2 SLICE 2a: per-slot Int repr rides the MIR fn (mirror of
+        // `aliased_slots`). Default-empty today (no wasm-gc rewrite is
+        // wired), so every slot stays boxed.
+        repr: &mir_fn.repr,
         params: &rfd.params,
         binding_names: &binding_names,
         effect_idx_lookup,
@@ -1040,6 +1047,11 @@ pub(crate) fn emit_mir_expr(
         // consumes the shared, un-rewritten MIR, so these never appear here.
         // `Ok(None)` (outside the supported subset) is the defensive, never-
         // hit fallback; it keeps wasm-gc behavior untouched (slice 2 territory).
+        //
+        // TODO(2b): lower per-slot (bare -> scalar i64; Box -> __aint_from_i64;
+        // Unbox -> __aint_to_i64_checked). Slice 2a installs the repr seam but
+        // wires no rewrite, so `mir_fn.repr` stays default-empty and these
+        // nodes never reach the emitter — the `Ok(None)` arm remains dead.
         MirExpr::Box(_) | MirExpr::Unbox(_) => Ok(None),
     }
 }

--- a/src/codegen/wasm_gc/body/slots.rs
+++ b/src/codegen/wasm_gc/body/slots.rs
@@ -109,6 +109,7 @@ impl SlotTable {
         fd: &ResolvedFnDef,
         registry: &TypeRegistry,
         _fn_map: &FnMap,
+        repr: &crate::ir::mir::MirFnRepr,
     ) -> Result<Self, WasmGcError> {
         // Read the per-slot Aver type table the resolver built post-
         // typecheck (`FnResolution.local_slot_types`) and translate
@@ -116,10 +117,27 @@ impl SlotTable {
         // truth for slot indices ↔ types — every backend that needs
         // typed locals consumes the same table instead of re-walking
         // patterns.
+        // ETAP-2 SLICE 2a: per-slot Int unboxing seam. When a slot is
+        // tagged bare (`repr.bare_slots`) AND its Aver type is `Int`, the
+        // slot would carry a scalar `i64` local instead of the `$AverInt`
+        // ref. GATED OFF in 2a (`ENABLE_BARE_SLOTS == false`) so every slot
+        // falls through to `aver_to_wasm` (→ `$AverInt`); the branch is
+        // present, type-checks, and keys directly off the `by_slot` index
+        // (`LocalId(i)`, which the audit established is 1:1 with the
+        // resolver slot and the wasm local index). 2b flips the gate.
+        const ENABLE_BARE_SLOTS: bool = false;
         let mut by_slot: Vec<ValType> = Vec::new();
         if let Some(resolution) = fd.resolution.as_ref() {
-            for ty in resolution.local_slot_types.iter() {
+            for (i, ty) in resolution.local_slot_types.iter().enumerate() {
                 let aver_str = ty.display();
+                if ENABLE_BARE_SLOTS
+                    && aver_str.trim() == "Int"
+                    && repr.slot_is_bare(crate::ir::mir::LocalId(i as u32))
+                {
+                    // 2b: bare Int slot → raw scalar i64 local.
+                    by_slot.push(ValType::I64);
+                    continue;
+                }
                 // `Unit` (and any other type without a wasm
                 // representation) still occupies a slot index in the
                 // resolver's `local_slots` map — pushing an `i32`

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -93,7 +93,9 @@ use super::body::{FnEntry, FnMap, emit_fn_body_via_mir};
 use super::builtins::{BuiltinName, BuiltinRegistry};
 use super::effects::{EffectName, EffectRegistry};
 use super::maps::MapHelperRegistry;
-use super::types::{TypeRegistry, param_types, record_struct_type, return_results};
+use super::types::{
+    TypeRegistry, param_types_with_repr, record_struct_type, return_results_with_repr,
+};
 use super::wasip2_helpers::{
     CabiReallocIndices, ConsoleReadLineIndices, DecodeListStringIndices, DiskExistsIndices,
     DiskListDirIndices, DiskReadTextIndices, DiskSimplePathOpIndices, DiskWriteTextIndices,
@@ -803,10 +805,23 @@ pub(super) fn emit_module_with(
 
     // 4) One fn type per user fn. `fn_type_indices[i]` is the wasm
     //    type idx for the i-th user fn (in declaration order).
+    // ETAP-2 SLICE 2a: source the per-fn Int repr from the MIR fn so the
+    // functype here, the `SlotTable` params-prefix, and the
+    // `call_indirect` `fn_sig_key` all read the SAME repr (the invariant
+    // they must agree on byte-for-byte). On the un-rewritten wasm-gc MIR
+    // every repr is default-empty, so `*_with_repr` emits the boxed
+    // signature `param_types` / `return_results` already produced — and
+    // the gate (`ENABLE_BARE_SLOTS`) is off besides. `fn_defs[i]` is
+    // position-aligned with `resolved_fn_defs[i]`.
+    let default_repr = crate::ir::mir::MirFnRepr::default();
     let mut fn_type_indices: Vec<u32> = Vec::with_capacity(fn_defs.len());
-    for fd in &fn_defs {
-        let params = param_types(&fd.params, Some(&registry))?;
-        let results = return_results(&fd.return_type, Some(&registry))?;
+    for (i, fd) in fn_defs.iter().enumerate() {
+        let repr = mir_program
+            .fn_by_id(resolved_fn_defs[i].fn_id)
+            .map(|mf| &mf.repr)
+            .unwrap_or(&default_repr);
+        let params = param_types_with_repr(&fd.params, Some(&registry), &repr.bare_params)?;
+        let results = return_results_with_repr(&fd.return_type, Some(&registry), repr.bare_return)?;
         types.ty().function(params, results);
         fn_type_indices.push(next_type_idx);
         next_type_idx += 1;

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -1984,6 +1984,16 @@ pub(super) fn aint_ref_ty(registry: &TypeRegistry) -> Result<ValType, WasmGcErro
     Ok(struct_ref(idx))
 }
 
+/// ETAP-2 SLICE 2a: when a per-param / per-return bare bit is set AND the
+/// Aver type is `Int`, the wasm signature would carry a scalar `i64` in
+/// place of the `$AverInt` ref. GATED OFF in 2a (`ENABLE_BARE_SLOTS ==
+/// false`) so the `*_with_repr` variants produce exactly the boxed
+/// signature `return_results` / `param_types` already emit. This keeps the
+/// functype registered in `module.rs`, the `SlotTable` params-prefix, and
+/// the `call_indirect` `fn_sig_key` on one repr-aware path so they agree
+/// byte-for-byte; 2b flips the gate.
+const ENABLE_BARE_SLOTS: bool = false;
+
 /// Result-list shape for a wasm function signature derived from an
 /// Aver return type.
 pub(super) fn return_results(
@@ -1993,6 +2003,21 @@ pub(super) fn return_results(
     Ok(aver_to_wasm(type_str, registry)?.into_iter().collect())
 }
 
+/// Repr-aware variant of [`return_results`]. In 2a `bare_return` is always
+/// `false` (the wasm-gc MIR is un-rewritten ⇒ `MirFnRepr` default-empty)
+/// AND the gate is off, so this delegates to `return_results`.
+pub(super) fn return_results_with_repr(
+    type_str: &str,
+    registry: Option<&TypeRegistry>,
+    bare_return: bool,
+) -> Result<Vec<ValType>, WasmGcError> {
+    if ENABLE_BARE_SLOTS && bare_return && type_str.trim() == "Int" {
+        // 2b: bare Int return → scalar i64 result.
+        return Ok(vec![ValType::I64]);
+    }
+    return_results(type_str, registry)
+}
+
 /// Param-list shape for a wasm function signature.
 pub(super) fn param_types(
     params: &[(String, String)],
@@ -2000,6 +2025,39 @@ pub(super) fn param_types(
 ) -> Result<Vec<ValType>, WasmGcError> {
     let mut out = Vec::with_capacity(params.len());
     for (_, ty) in params {
+        if let Some(v) = aver_to_wasm(ty, registry)? {
+            out.push(v);
+        }
+    }
+    Ok(out)
+}
+
+/// Repr-aware variant of [`param_types`]. `bare_params[i]` flags the i-th
+/// param as scalar `i64`. In 2a `bare_params` is empty AND the gate is off,
+/// so every param funnels through `aver_to_wasm` (→ `$AverInt`).
+pub(super) fn param_types_with_repr(
+    params: &[(String, String)],
+    registry: Option<&TypeRegistry>,
+    bare_params: &[bool],
+) -> Result<Vec<ValType>, WasmGcError> {
+    // Fast path / 2a path: no param renders bare (gate off, or
+    // `bare_params` empty), so the signature is exactly what `param_types`
+    // already emits — keep it as the single boxed source of truth.
+    let any_bare = ENABLE_BARE_SLOTS
+        && params
+            .iter()
+            .enumerate()
+            .any(|(i, (_, ty))| bare_params.get(i).copied().unwrap_or(false) && ty.trim() == "Int");
+    if !any_bare {
+        return param_types(params, registry);
+    }
+    let mut out = Vec::with_capacity(params.len());
+    for (i, (_, ty)) in params.iter().enumerate() {
+        if bare_params.get(i).copied().unwrap_or(false) && ty.trim() == "Int" {
+            // 2b: bare Int param → scalar i64 in the signature.
+            out.push(ValType::I64);
+            continue;
+        }
         if let Some(v) = aver_to_wasm(ty, registry)? {
             out.push(v);
         }


### PR DESCRIPTION
## What

First slice of per-slot Int unboxing on the wasm-gc backend — the size-recovery epic. **Pure plumbing, zero behavior change.**

Installs the representation-aware typing seam so a future slot can lower to a scalar `i64` instead of the boxed `$AverInt`:
- `EmitCtx` carries `repr: &MirFnRepr` (sourced like `aliased_slots`).
- `SlotTable::build_for_fn` takes the repr and has a bare-Int → `ValType::I64` branch.
- `param_types` / `return_results` gain repr-aware variants; the functype registration, the SlotTable params-prefix, and the `call_indirect` functype dedup key all move onto the same repr-aware path so they agree byte-for-byte.

All of it is **gated off** (`ENABLE_BARE_SLOTS = false`) and fed the **default-empty** `MirFnRepr` (the wasm-gc MIR is not yet rewritten — that's slice 2b), so every slot stays `$AverInt` and the emitted wasm is byte-for-byte identical to today. This de-globalizes Int representation from the module-wide `registry.bignum` bool to a per-slot decision that currently answers "boxed" everywhere.

The `MirExpr::Box`/`Unbox` arm stays `Ok(None)` with a `TODO(2b)`.

## Why this slice

`rewrite_for_wasm_gc` + flipping the gate + lowering Box/Unbox (`bare → i64`, `Box → __aint_from_i64`, `Unbox → checked to_i64`) are the C0-bearing changes; landing them together in 2b under the mandatory cross-vendor panel keeps 2a a trivially-safe refactor. wasm-gc has **no overflow trip-wire** (i64 ops wrap silently, unlike Rust dev `overflow-checks`), so the safe-by-construction split matters.

## Verification

- **Byte-identical `.wasm`** — the acceptance criterion (a pure refactor cannot miscompile): 12 corpus programs (String/Int/Map/record/Float/interpolation) sha256-identical before/after, plus an independent 4-program before/after diff (fib/map_build/map_lookup/match_dispatch) — all identical.
- Full suite green; `cargo test --features wasm` VM-vs-wasm-gc differentials pass (`cross_backend_proptest` 16, `cross_backend_stress` 22); clippy clean (default + `wasm,wasip2`, no const-condition lint from the gated branch); fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)