### PR TITLE
proof(lean): native termination for single-carrier structural recursive-ADT/Map SCCs (dissolve fuel-congruence)

### DIFF
--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -3219,10 +3219,20 @@ fn grok_s_language_example_uses_total_ranked_sizeof_mutual_recursion() {
     let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
     let lean = generated_lean_file(&out);
     assert!(lean.contains("mutual"));
-    assert!(lean.contains("def eval__fuel"));
     assert!(lean.contains("def parseListItems__fuel"));
     assert!(!lean.contains("partial def eval"));
-    assert!(!lean.contains("termination_by (sizeOf e,"));
+    // The `eval` SCC stays FUEL: it has MULTI-`Sexpr`-carrier members
+    // (`evalOpWithPair(_, leftExpr: Sexpr, rightExpr: Sexpr, _)`). Multi-carrier
+    // ADT sum measures are native-closable for some shapes but not all (a
+    // red-black-tree SCC's `decreasing_by` fails), so multi-carrier ADT stays
+    // on fuel — only SINGLE-carrier structural ADT goes native.
+    assert!(lean.contains("def eval__fuel"));
+    assert!(lean.contains("def evalOpWithPair__fuel"));
+    // The SINGLE-carrier structural `Sexpr` fns (`toString'`, `validSymbolNames`)
+    // DO emit native `termination_by (sizeOf e, _)` now (no fuel) — structural
+    // recursion on the ADT, Lean's own termination check accepts it.
+    assert!(lean.contains("termination_by (sizeOf e,"));
+    assert!(!lean.contains("def toString'__fuel"));
     assert!(lean.contains("-- when validSymbolNames e"));
     assert!(!lean.contains("private theorem toString'_law_parseRoundtrip_aux"));
     assert!(

--- a/src/codegen/lean/toplevel/fuel.rs
+++ b/src/codegen/lean/toplevel/fuel.rs
@@ -839,6 +839,14 @@ fn emit_native_termination_measure(fd: &FnDef, ctx: &CodegenContext) -> Option<S
     if indices.is_empty() {
         return None;
     }
+    // SINGLE-carrier only for the recursive-ADT arm. Multi-carrier ADT sum
+    // measures (`sizeOf f + sizeOf g`) are native-CLOSABLE for some shapes
+    // (an `eval` SCC builds) but NOT all — a red-black-tree mutual SCC's
+    // `decreasing_by` does not close, hard-failing the build. So multi-carrier
+    // ADT stays on fuel pending a per-SCC closure check; lifting it blanket
+    // regressed `proof_export_lake_builds_red_black_tree`.
+    let single_sizeof_param = indices.len() == 1;
+
     // Pointer-eq scope so a same-bare-name twin never provides
     // these param types. Synthetic / mid-rewrite fns fall back to
     // on-demand resolve.
@@ -855,21 +863,47 @@ fn emit_native_termination_measure(fd: &FnDef, ctx: &CodegenContext) -> Option<S
         let (name, ty) = rfd.params.get(idx)?;
         let lean_name = aver_name_to_lean(name);
         match ty {
-            crate::types::Type::List(_) | crate::types::Type::Vector(_) => {
+            crate::types::Type::List(_)
+            | crate::types::Type::Vector(_)
+            // `Map` lowers to `List (k × v)` in the proof backend (AverMap is
+            // list-backed), so `sizeOf` measures it exactly like a List — e.g.
+            // a json-shaped `objectSafe(m: Map) = entriesSafe(Map.entries m)`
+            // delegates at the SAME `sizeOf m` and settles on the lex rank.
+            | crate::types::Type::Map(_, _) => {
                 // `sizeOf` instead of `.length` so the user measure
                 // matches what Lean's mutual-block wf elaboration
                 // generates internally — `decreasing_tactic` then
                 // closes the chain without `simp_wf` scrambling.
                 terms.push(format!("sizeOf {lean_name}"));
             }
-            // Skip Named ADTs and String: `sizeOf` decrease on a
-            // recursive ADT in a multi-arg measure (`step f` from
-            // `stepApp f arg`, measure `sizeOf f + sizeOf arg`)
-            // needs the strict-positivity fact `sizeOf arg ≥ 1`
-            // which omega doesn't get for free. Fall back to fuel
-            // for those SCCs — accumulator-pattern guard already
-            // filters them too, so the only effect here is a more
-            // conservative measure-existence gate.
+            // A recursive ADT param recurses STRUCTURALLY: its `sizeOf`
+            // strictly drops on every constructor sub-term, so it carries a
+            // native `sizeOf` measure exactly like a List — the same
+            // `(sizeOf, rank)` lex tuple the mutual block emits, with the
+            // robust `decreasing_by` closing the ADT-field decrease and the
+            // rank settling any same-`sizeOf` delegation (e.g. a Map-as-list
+            // `entries` identity hop in a json-shaped SCC). Restricted to the
+            // Proof side only, and the kernel's own termination check is the
+            // fail-closed backstop — if the measure is wrong for some SCC the
+            // build fails (that SCC stays open), never a false theorem. So we
+            // try native here instead of conservatively forcing a fuel wrapper,
+            // which would tax every law touching the predicate with
+            // fuel-congruence. SINGLE-carrier only (see above).
+            crate::types::Type::Named { name: tname, .. }
+                if single_sizeof_param
+                    && ctx
+                        .modules
+                        .iter()
+                        .flat_map(|m| m.type_defs.iter())
+                        .chain(ctx.type_defs.iter())
+                        .any(|td| {
+                            type_def_name(td) == tname.as_str() && is_recursive_type_def(td)
+                        }) =>
+            {
+                terms.push(format!("sizeOf {lean_name}"));
+            }
+            // String (parser position-recursion, not structural) and every
+            // other shape still decline to fuel.
             _ => return None,
         }
     }
@@ -943,9 +977,14 @@ pub(super) fn emit_native_mutual_sizeof_group(
         // Robust tactic chain — `decreasing_tactic` alone bottoms out
         // on simple shapes (BigInt) but Lean elaborator on multi-arg
         // mutual SCCs sometimes needs `simp_wf` to unfold sizeOf
-        // before omega can close the arithmetic on lengths.
+        // before omega can close the arithmetic on lengths. The
+        // `simp only [AverMap.entries, AverMap.fromList]` step unfolds the
+        // list-backed-Map identities so a `objectSafe(m)=entriesSafe(Map.entries m)`
+        // delegation's goal reduces `sizeOf (AverMap.entries m)` to `sizeOf m`
+        // (then the lex rank closes the same-size step); `AverMap.*` is always
+        // in scope via the imported prelude, and `try` no-ops where absent.
         lines.push(
-            "  decreasing_by all_goals (first | decreasing_tactic | (simp_wf; (try simp_all); first | omega | (constructor <;> first | rfl | omega)))"
+            "  decreasing_by all_goals (first | decreasing_tactic | (simp_wf; (try simp only [AverMap.entries, AverMap.fromList]); (try simp_all); first | omega | (constructor <;> first | rfl | omega)))"
                 .to_string(),
         );
         lines.push(String::new());

--- a/src/codegen/recursion/detect.rs
+++ b/src/codegen/recursion/detect.rs
@@ -1537,10 +1537,22 @@ fn expr_calls_into_set(expr: &Spanned<Expr>, names: &HashSet<String>) -> bool {
 }
 
 fn arg_is_non_growing(expr: &Spanned<Expr>) -> bool {
-    matches!(
-        &expr.node,
-        Expr::Ident(_) | Expr::Resolved { .. } | Expr::Literal(_) | Expr::Attr(..)
-    )
+    match &expr.node {
+        Expr::Ident(_) | Expr::Resolved { .. } | Expr::Literal(_) | Expr::Attr(..) => true,
+        // `Map.entries(x)` lowers to `x` (AverMap is list-backed; `entries` is
+        // the identity), so it is size-PRESERVING — non-growing exactly when
+        // its argument is. This lets a json-shaped delegation
+        // `objectSafe(m) = entriesSafe(Map.entries m)` read as the same-`sizeOf`
+        // lex step it actually is (the rank, not the size, decreases). Sound:
+        // a wrong size-claim only makes the SCC's native `termination_by` fail
+        // to elaborate (fall back to fuel), never a false theorem.
+        Expr::FnCall(callee, args) => {
+            expr_to_dotted_name(callee).as_deref() == Some("Map.entries")
+                && args.len() == 1
+                && arg_is_non_growing(&args[0])
+        }
+        _ => false,
+    }
 }
 
 pub(crate) fn supports_mutual_sizeof_ranked(

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -67,6 +67,78 @@ fn proof_lean_peano_lift_nat_arith_kernel_clean() {
 }
 
 #[test]
+fn proof_lean_mutual_recursive_adt_predicate_uses_native_termination_kernel_clean() {
+    // A mutual recursive-ADT predicate SCC (`treeOk : Tree -> Bool` +
+    // `treeListOk : List Tree -> Bool`) must emit as a NATIVE
+    // `termination_by (sizeOf, rank)` mutual block — NOT a fuel-wrapped
+    // `__fuel` def. Native emission keeps the predicate a CLEAN recursive def,
+    // so its cons-distribution law
+    //   `treeListOk (h :: t) = treeOk h && treeListOk t`
+    // closes as a one-step structural proof. Under the old conservative gate the
+    // SCC fell to fuel because a member has a recursive-ADT param (`t : Tree`),
+    // and the fuel WRAPPER makes the two sides of that law carry DIFFERENT fuel
+    // expressions — a gap no `simp`/`grind` bridges without a synthesized
+    // fuel-congruence lemma, so the law stayed bounded (`sorry`). Proof side is
+    // fail-closed: a wrong measure only makes Lean reject the `termination_by`
+    // (SCC stays open), never a false theorem — so trying native here is safe.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping native-termination ADT test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-native-adt-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module TreeSafe\n    effects []\n\n\
+         type Tree\n    Leaf(Bool)\n    Node(List<Tree>)\n\n\
+         fn treeOk(t: Tree) -> Bool\n    match t\n        Tree.Leaf(b) -> b\n        Tree.Node(kids) -> treeListOk(kids)\n\n\
+         fn treeListOk(ts: List<Tree>) -> Bool\n    match ts\n        [] -> true\n        [h, ..rest] -> match treeOk(h)\n            true -> treeListOk(rest)\n            false -> false\n\n\
+         verify treeListOk law consDistrib\n    given h: Tree = [Tree.Leaf(true), Tree.Leaf(false), Tree.Node([Tree.Leaf(true)])]\n    given t: List<Tree> = [[], [Tree.Leaf(true)], [Tree.Leaf(false), Tree.Leaf(true)]]\n    treeListOk(List.prepend(h, t)) => Bool.and(treeOk(h), treeListOk(t))\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-native-adt-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean = std::fs::read_to_string(out.join("TreeSafe.lean")).expect("read TreeSafe.lean");
+    assert!(
+        !lean.contains("__fuel") && lean.contains("termination_by (sizeOf"),
+        "the mutual recursive-ADT predicate must emit NATIVE `termination_by (sizeOf, _)` \
+         (no `__fuel` wrapper):\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "the cons-distribution law over the native (fuel-free) predicate must \
+         kernel-prove as a GENUINE universal:\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
 fn proof_lean_proves_peano_arith_identity_via_nat_lift_kernel_clean() {
     // Layer-2 of the Peano lift (#3): recognize the canonical `plus` (left-
     // recursive addition) and `minus` (truncated subtraction) and emit a


### PR DESCRIPTION
## What

A mutual recursive SCC with a recursive-ADT param (`j: Json`, `t: Tree`) or a `Map` param was conservatively **fuel-wrapped**, because `emit_native_termination_measure` bailed (`_ => return None`) on any non-List/Vector carrier.

Fuel-wrapping is what **forces fuel-congruence** onto every law touching the predicate: even the trivial distribution `safe(h::t) = safe_elem h && safe t` fails under fuel (the two sides carry **different** `__fuel` expressions; no `simp`/`grind` bridges that without a synthesized per-SCC fuel-congruence lemma — the json when-law hard-residue from `prove-master-plan`).

## Fix

Lift the gate for the **single-carrier structural** case: a lone recursive-ADT carrier (and `Map`, which lowers to `List (k×v)`) gets a native `sizeOf` measure, so the SCC emits a clean `termination_by (sizeOf, rank)` mutual block with **no fuel**.

- `AverMap.entries = id` is unfolded in `decreasing_by` so a `objectSafe(m) = entriesSafe(Map.entries m)` same-`sizeOf` delegation settles on the lex rank.
- `arg_is_non_growing` recognizes `Map.entries(x)` as size-preserving so the SCC isn't mis-flagged as a growing accumulator.

## Effect

Structural predicate laws over recursive ADTs become **trivial clean proofs** (`simp only [def]; cases`, `[propext, Quot.sound]`) — the **fuel-congruence hard-residue is dissolved for them, by eliminating fuel rather than building congruence machinery**. The json `jsonRoundtripSafe`/`jsonListRoundtripSafe`/… SCC now emits native (Layer-0 obstacle gone; the json when-laws stay bounded only on Layer-1 = the still-fuel-wrapped string-position parser — a separate problem).

## Safety (proof side is fail-closed)

A wrong measure makes Lean reject `termination_by` (that SCC stays open/bounded), **never a false theorem** — so the backend can try native here, unlike the Int-unboxing analysis (no backstop → stays conservative static). The boundary:

| recursion shape | termination | fuel? |
|---|---|---|
| structural ADT/List/Map/Nat — **single carrier** | native `sizeOf` | NO |
| structural ADT — **multi carrier** (`sizeOf f + sizeOf g`) | native for some, not all | YES (red-black-tree `decreasing_by` fails; blanket lift tried + reverted) |
| computed-arg interpreters (lambda `step`/`stepApp`) | no simple measure | YES (`scc_has_growing_accumulator`) |
| string-position parsers | recurse on `pos` | YES (future: `length−pos` measure) |

## Verify

- `proof_spec` 180/0; lib `codegen::lean` 86/0; clippy + fmt clean
- grok_s `toString'`/`validSymbolNames` → native; `eval` (multi-carrier) correctly stays fuel; parser stays fuel
- lambda computed-arg stays fuel
- New guard `proof_lean_mutual_recursive_adt_predicate_uses_native_termination_kernel_clean`: a mutual recursive-ADT predicate emits native termination and its cons-distribution law kernel-proves `universal` (false→true vs fuel)

🤖 Co-authored with Claude Opus 4.8
