### PR TITLE
fix(test): category-comment the Type::Named match in native-termination measure (identity guardrail)

### DIFF
--- a/src/codegen/lean/toplevel/fuel.rs
+++ b/src/codegen/lean/toplevel/fuel.rs
@@ -889,6 +889,10 @@ fn emit_native_termination_measure(fd: &FnDef, ctx: &CodegenContext) -> Option<S
             // try native here instead of conservatively forcing a fuel wrapper,
             // which would tax every law touching the predicate with
             // fuel-congruence. SINGLE-carrier only (see above).
+            // backend-link-stage: name-keyed recursive-type-def lookup (same as
+            // the fuel path's `recursive_types`); the measure only needs WHETHER
+            // this Named type is recursive, not its `id`, so the bare-name match
+            // is sufficient here.
             crate::types::Type::Named { name: tname, .. }
                 if single_sizeof_param
                     && ctx


### PR DESCRIPTION
#547 tripped the Epic #180 identity guardrail: its native-termination measure matches `Type::Named { name, .. }` (bare destructure ignoring `id`) without a category comment. The lookup is name-keyed by design (same as the fuel path's `recursive_types`) — the measure only needs WHETHER the type is recursive, not its `id`. Add the `backend-link-stage` category comment. Full `cargo test` green locally.