### PR TITLE
wasm-gc: lower bounded opaque-carrier Int fields to native i64

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -615,9 +615,16 @@ pub fn build_context(
     // representation facts from the optimized MIR. Read-only — never
     // mutates the program. Empty (all-`Boxed`) when there is no MIR
     // (defensive) or for fragments the analysis bails on.
+    //
+    // ETAP-2 SLICE 0+1: this facts path (the VM-side / general read) passes
+    // an EMPTY carrier table, so no carrier slot lowers here — byte-identical
+    // to the pre-slice behavior. Carrier lowering is opt-in at the two
+    // codegen-rewrite entries (`rewrite_for_rust` / `rewrite_for_wasm_gc`),
+    // which build the real table from the refinement-via-opaque inputs.
+    let empty_carrier = crate::ir::mir::bare_i64::CarrierIntervals::new();
     let bare_i64 = mir_program
         .as_ref()
-        .map(crate::ir::mir::bare_i64::analyze)
+        .map(|p| crate::ir::mir::bare_i64::analyze(p, &empty_carrier))
         .unwrap_or_default();
 
     let ctx = CodegenContext {

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -508,6 +508,509 @@ fn populate_refined_type_intervals(inputs: &ProofLowerInputs, ir: &mut ProofIR) 
     }
 }
 
+/// ETAP-2 SLICE 0+1: derive, per refinement-via-opaque type in scope, the
+/// constant interval its smart-constructor invariant proves over the
+/// carrier. The table is keyed by the opaque type's *bare* Aver name (e.g.
+/// `"IntRange"`). The bare-`i64` MIR pass matches a carrier
+/// parameter/local/return slot against this key — it extracts the bare name
+/// from the slot's `MirParam.ty` (which the lowerer fills with the Debug
+/// form `Named { id: …, name: "IntRange" }`, NOT the bare name; see
+/// `bare_named_type` in `bare_i64`) and seeds the slot with the proven bound.
+///
+/// The value is `interval_of_invariant(&predicate)` — byte-identical to the
+/// bound [`populate_refined_type_intervals`] persists on each
+/// `RefinedTypeDecl` (both build the same [`Predicate`] from
+/// [`refinement_info_for_in_scope`] + [`ProofLowerInputs::resolve_expr`] and
+/// run the same `interval` recognizer). No forked logic.
+///
+/// **Fail-closed.** A type whose invariant the recognizer does not
+/// understand returns `interval_known == false`; that entry is OMITTED from
+/// the table entirely, so the MIR pass never sees it and the carrier stays
+/// boxed. A carrier whose proven bound does not `fits_i64` is also kept
+/// (the table carries the raw `(Interval, bool)` so the seed site can apply
+/// `fits_i64` itself — see `carrier_interval` in `bare_i64`).
+pub fn carrier_interval_table(
+    inputs: &ProofLowerInputs,
+) -> HashMap<String, (crate::ir::interval::Interval, bool)> {
+    let mut table = HashMap::new();
+
+    let entry_typedefs = inputs.entry_items.iter().filter_map(|item| match item {
+        TopLevel::TypeDef(td) => Some((None::<&str>, td)),
+        _ => None,
+    });
+    let module_typedefs = inputs.dep_modules.iter().flat_map(|m| {
+        m.type_defs
+            .iter()
+            .map(move |td| (Some(m.prefix.as_str()), td))
+    });
+
+    for (module_prefix, td) in entry_typedefs.chain(module_typedefs) {
+        // Refinement-via-opaque is a single-carrier-field product; mirror the
+        // exact eligibility `populate_refined_types` applies so the keyed
+        // bound is the same fact the proof side carries.
+        let TypeDef::Product { name, fields, .. } = td else {
+            continue;
+        };
+        if fields.len() != 1 {
+            continue;
+        }
+        let Some(info) =
+            crate::codegen::common::refinement_info_for_in_scope(name, inputs, module_prefix)
+        else {
+            continue;
+        };
+        let invariant = Predicate {
+            free_vars: vec![(
+                info.param_name.to_string(),
+                QuantifierType::Plain(info.carrier_type.to_string()),
+            )],
+            expr: inputs.resolve_expr(info.predicate, module_prefix),
+        };
+        let (interval, interval_known) = crate::ir::interval::interval_of_invariant(&invariant);
+        // Fail-closed: an unrecognized invariant (`interval_known == false`)
+        // is OMITTED, so the carrier stays boxed.
+        if !interval_known {
+            continue;
+        }
+        // Key by the bare type name — the `MirParam.ty` string. Two modules
+        // may each declare a same-named carrier with different predicates;
+        // the bare name collides. Keep the FIRST (entry walks before deps),
+        // and on a same-name collision intersect to the tighter common bound
+        // (fail-closed: a narrower interval is always still a valid
+        // over-approximation of either inhabitant set, and a mismatch can
+        // only ever shrink eligibility, never wrongly widen it).
+        table
+            .entry(name.clone())
+            .and_modify(|(iv, known): &mut (crate::ir::interval::Interval, bool)| {
+                *iv = iv.intersect(interval);
+                *known = true;
+            })
+            .or_insert((interval, true));
+    }
+
+    table
+}
+
+/// ETAP-2 carrier-`i64` SLICE 2b FOLLOW-UP: the fail-closed eligibility
+/// tightening. The bare carrier interval ([`carrier_interval_table`]) proves
+/// only that the smart-constructor's invariant `fits_i64`; it does NOT prove
+/// that every value of the carrier type actually went through that gate, nor
+/// that the carrier's codegen is exercised only in positions the i64 erasure
+/// supports. This scan removes a carrier from the eligible set when either
+/// assumption is violated, so the carrier stays boxed (`$AverInt`) — the
+/// safe, pre-slice representation that the VM and the boxed wasm-gc path
+/// agree on.
+///
+/// Two whole-program scans, both fail-closed (a trip can only ever SHRINK the
+/// eligible set, never widen it):
+///
+/// 1. **Ungated construction (closes the bare-constructor bypass).** A bare
+///    record constructor `IntRange(value = n)` callable in the defining
+///    module bypasses the smart-ctor's `0 <= n <= 100` gate. With `n`
+///    overflowing `i64` the VM keeps full precision but the wasm-gc construct
+///    bridge `__aint_to_i64_checked` TRAPS. A carrier `RecordCreate`d outside
+///    its own recognized smart-constructor function is therefore ineligible —
+///    UNLESS the construct's carrier-field argument is a constant literal that
+///    provably lies inside the carrier's proven interval. Such a literal
+///    construct (`IntRange(value = 0)` against a `[0, 100]` bound) cannot
+///    smuggle an out-of-bound / i64-overflowing value past the gate, so it is
+///    SAFE and does not demote — that pattern is exactly the in-bounds Err
+///    fallback the slice's own carriers use (`unwrap`'s `IntRange(value = 0)`).
+///    A non-literal argument, or a literal OUTSIDE the interval, is ungated
+///    and DOES demote (this is the `mk(n) = IntRange(value = n)` bypass).
+///
+/// 2. **Map-key usage (closes the i64-erased Map-KEY codegen gap).** A
+///    carrier used as a `Map` KEY type — directly (`Map<IntRange, V>`) or
+///    transitively as a field of a record/type used as a key
+///    (`Map<Coord, V>` with `Coord { x: IntRange }`) — fails wasm validation,
+///    because the Map-key codegen was not updated for the i64-erased carrier.
+///    Such a carrier is ineligible (the boxed key path it used before still
+///    compiles). Map VALUES are unaffected and stay eligible.
+///
+///    The COMPLETE source of truth for which carriers are Map keys is
+///    `resolved_map_keys` — the resolved `Map<K, V>` key types harvested from
+///    the typed MIR (`ir::mir::discover_instantiations`). Because those types
+///    come from inference, a carrier used as a key reaches this scan whether
+///    its `Map` type was written as a fn-signature annotation, a LOCAL-BINDING
+///    annotation (`m: Map<IntRange, Int> = …`), or NO annotation at all
+///    (`m = Map.set({}, c, 5)`). A textual annotation scan cannot see the
+///    last two; the resolved key type can. The annotation scan is retained as
+///    a cheap fail-closed backstop only.
+///
+/// Returns the set of carrier type names (bare names, the same keys
+/// [`carrier_interval_table`] uses) to REMOVE from the eligible set. The
+/// caller subtracts this from the proven-bound set.
+///
+/// `resolved_map_keys`: every `Map<K, _>` key type the program instantiates,
+/// per the typed-MIR instantiation registry. This is the inference-complete
+/// Map-key signal that drives Scan 2.
+pub fn carrier_eligibility_demotions(
+    inputs: &ProofLowerInputs,
+    candidates: &HashSet<String>,
+    intervals: &HashMap<String, (crate::ir::interval::Interval, bool)>,
+    resolved_map_keys: &[crate::ast::Type],
+) -> HashSet<String> {
+    let mut demoted: HashSet<String> = HashSet::new();
+    if candidates.is_empty() {
+        return demoted;
+    }
+
+    // Map each candidate carrier to its recognized smart-constructor fn name.
+    // `refinement_info_for_in_scope` is THE source of truth for "the
+    // smart-ctor function" — the exact fn the interval recognizer keyed off.
+    // For the wasm-gc path `dep_modules` is empty (the program is flattened
+    // into `entry_items`), so the entry scope (`None`) resolves every
+    // carrier; we still consult dep scopes for generality.
+    let mut ctor_fn_of: HashMap<String, String> = HashMap::new();
+    for name in candidates {
+        if let Some(info) = crate::codegen::common::refinement_info_for_in_scope(name, inputs, None)
+        {
+            ctor_fn_of.insert(name.clone(), info.constructor_fn.to_string());
+        } else {
+            for m in inputs.dep_modules {
+                if let Some(info) = crate::codegen::common::refinement_info_for_in_scope(
+                    name,
+                    inputs,
+                    Some(m.prefix.as_str()),
+                ) {
+                    ctor_fn_of.insert(name.clone(), info.constructor_fn.to_string());
+                    break;
+                }
+            }
+        }
+    }
+
+    // ---- Scan 1: ungated construction --------------------------------------
+    // Walk every fn body in the program. A `RecordCreate { type_name }` whose
+    // `type_name` is a candidate carrier and which sits in a fn OTHER than
+    // that carrier's smart-constructor is an ungated construct ⇒ demote,
+    // UNLESS its carrier-field argument is a constant literal provably inside
+    // the carrier's proven interval (an in-bounds literal can't smuggle an
+    // out-of-bound value past the gate — fail-closed but not over-eager). If
+    // we can't cleanly identify the smart-ctor (no entry in `ctor_fn_of`),
+    // every non-literal-safe construct demotes — fail-closed.
+    let all_fn_defs = inputs
+        .entry_items
+        .iter()
+        .filter_map(|it| match it {
+            TopLevel::FnDef(fd) => Some(fd),
+            _ => None,
+        })
+        .chain(inputs.dep_modules.iter().flat_map(|m| m.fn_defs.iter()));
+    for fd in all_fn_defs {
+        for stmt in fd.body.stmts() {
+            let expr = match stmt {
+                crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => e,
+            };
+            carrier_walk_expr(expr, &mut |e| {
+                // Both a fresh construct (`RecordCreate`) and a record-update
+                // (`RecordUpdate`, which sets the carrier's only field to an
+                // arbitrary value) can smuggle a value past the smart-ctor
+                // gate; treat both the same.
+                let (type_name, fields): (&String, &[(String, Spanned<Expr>)]) = match e {
+                    Expr::RecordCreate { type_name, fields } => (type_name, fields),
+                    Expr::RecordUpdate {
+                        type_name, updates, ..
+                    } => (type_name, updates),
+                    _ => return,
+                };
+                if !candidates.contains(type_name) {
+                    return;
+                }
+                // The construct inside the carrier's own smart-ctor is the
+                // gated one — never demotes.
+                if ctor_fn_of.get(type_name) == Some(&fd.name) {
+                    return;
+                }
+                // Outside the smart-ctor: safe iff the (single) carrier field
+                // is a constant literal inside the proven interval.
+                let safe_literal = matches!(
+                    intervals.get(type_name),
+                    Some((iv, true)) if construct_arg_is_in_interval(fields, *iv)
+                );
+                if !safe_literal {
+                    demoted.insert(type_name.clone());
+                }
+            });
+        }
+    }
+
+    // ---- Scan 2: Map-key usage (direct + transitive) -----------------------
+    // Build, per record type, the set of carrier names reachable through its
+    // (transitive) fields, so a carrier nested inside a record used as a key
+    // is demoted too.
+    let record_fields = collect_record_fields(inputs);
+
+    // PRIMARY (complete) source of truth: the RESOLVED Map-key types harvested
+    // from the typed MIR (`discover_instantiations`). Every `Map<K, V>` the
+    // program actually instantiates is here — including ones whose key type is
+    // only known after INFERENCE (a local-binding `m: Map<…>` annotation that
+    // the textual scan never walks, or a fully inferred `m = Map.set({}, c,
+    // 5)` with no annotation at all). A textual annotation scan is
+    // fundamentally incomplete for these; the resolved key type is not. Demote
+    // every carrier reachable from each resolved key (directly, or
+    // transitively through a record / Option / List / Tuple field — the same
+    // `carriers_reachable_from` closure the annotation path uses).
+    for key in resolved_map_keys {
+        carriers_reachable_from(
+            key,
+            candidates,
+            &record_fields,
+            &mut HashSet::new(),
+            &mut demoted,
+        );
+    }
+
+    // BACKSTOP (cheap): the original textual scan over fn-param / fn-return /
+    // record-field annotations. Redundant with the resolved-IR path above for
+    // any Map the MIR sees, but kept so a Map type that appears ONLY in an
+    // annotation position the MIR instantiation walk doesn't reach (e.g. a
+    // signature whose body never constructs/uses the Map) still trips. It can
+    // only ever ADD to `demoted` (fail-closed).
+    for ty_str in all_type_annotations(inputs) {
+        let ty = crate::types::parse_type_str(&ty_str);
+        collect_map_key_carriers(&ty, candidates, &record_fields, &mut demoted);
+    }
+
+    demoted
+}
+
+/// A single-carrier-field `RecordCreate`'s field argument is a constant
+/// integer literal provably within the proven interval `iv`. Handles the
+/// bare literal `IntRange(value = 0)` and the negated literal
+/// `IntRange(value = -5)` (parsed as `Expr::Neg(Literal(Int))`). Any other
+/// shape (a parameter, a call, an arithmetic expression) is NOT a provable
+/// constant ⇒ returns `false` ⇒ the construct is treated as ungated.
+fn construct_arg_is_in_interval(
+    fields: &[(String, Spanned<Expr>)],
+    iv: crate::ir::interval::Interval,
+) -> bool {
+    // Refinement-via-opaque carriers are single-field products.
+    let [(_, value)] = fields else {
+        return false;
+    };
+    let k: i128 = match &value.node {
+        Expr::Literal(Literal::Int(n)) => *n as i128,
+        Expr::Neg(inner) => match &inner.node {
+            Expr::Literal(Literal::Int(n)) => -(*n as i128),
+            _ => return false,
+        },
+        _ => return false,
+    };
+    iv.contains_point(k)
+}
+
+/// Local AST visitor (the proof-lower module has no shared walker). Pre-order
+/// visit of every sub-expression. Mirrors `call_graph::walk_expr`.
+fn carrier_walk_expr(expr: &Spanned<Expr>, visit: &mut impl FnMut(&Expr)) {
+    visit(&expr.node);
+    match &expr.node {
+        Expr::FnCall(func, args) => {
+            carrier_walk_expr(func, visit);
+            for arg in args {
+                carrier_walk_expr(arg, visit);
+            }
+        }
+        Expr::TailCall(boxed) => {
+            for arg in &boxed.args {
+                carrier_walk_expr(arg, visit);
+            }
+        }
+        Expr::Attr(obj, _) => carrier_walk_expr(obj, visit),
+        Expr::BinOp(_, l, r) => {
+            carrier_walk_expr(l, visit);
+            carrier_walk_expr(r, visit);
+        }
+        Expr::Neg(inner) | Expr::ErrorProp(inner) => carrier_walk_expr(inner, visit),
+        Expr::Match { subject, arms, .. } => {
+            carrier_walk_expr(subject, visit);
+            for arm in arms {
+                carrier_walk_expr(&arm.body, visit);
+            }
+        }
+        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+            for item in items {
+                carrier_walk_expr(item, visit);
+            }
+        }
+        Expr::MapLiteral(entries) => {
+            for (k, v) in entries {
+                carrier_walk_expr(k, visit);
+                carrier_walk_expr(v, visit);
+            }
+        }
+        Expr::Constructor(_, maybe) => {
+            if let Some(inner) = maybe {
+                carrier_walk_expr(inner, visit);
+            }
+        }
+        Expr::InterpolatedStr(parts) => {
+            for part in parts {
+                if let crate::ast::StrPart::Parsed(e) = part {
+                    carrier_walk_expr(e, visit);
+                }
+            }
+        }
+        Expr::RecordCreate { fields, .. } => {
+            for (_, e) in fields {
+                carrier_walk_expr(e, visit);
+            }
+        }
+        Expr::RecordUpdate { base, updates, .. } => {
+            carrier_walk_expr(base, visit);
+            for (_, e) in updates {
+                carrier_walk_expr(e, visit);
+            }
+        }
+        Expr::Literal(_) | Expr::Ident(_) | Expr::Resolved { .. } => {}
+    }
+}
+
+/// Bare record-type name → its field type strings (`Product` types only).
+/// Used by Scan 2 to chase a carrier nested inside a record used as a Map
+/// key.
+fn collect_record_fields(inputs: &ProofLowerInputs) -> HashMap<String, Vec<String>> {
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    let entry_tds = inputs.entry_items.iter().filter_map(|it| match it {
+        TopLevel::TypeDef(td) => Some(td),
+        _ => None,
+    });
+    let dep_tds = inputs.dep_modules.iter().flat_map(|m| m.type_defs.iter());
+    for td in entry_tds.chain(dep_tds) {
+        if let TypeDef::Product { name, fields, .. } = td {
+            out.entry(name.clone())
+                .or_default()
+                .extend(fields.iter().map(|(_, ty)| ty.clone()));
+        }
+    }
+    out
+}
+
+/// Every type annotation string in the program: fn param types, fn return
+/// types, and record field types. A `Map<…>` anywhere here is a Map-key
+/// usage candidate for Scan 2.
+fn all_type_annotations(inputs: &ProofLowerInputs) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let push_fn = |fd: &FnDef, out: &mut Vec<String>| {
+        for (_, ty) in &fd.params {
+            out.push(ty.clone());
+        }
+        out.push(fd.return_type.clone());
+    };
+    for it in inputs.entry_items {
+        match it {
+            TopLevel::FnDef(fd) => push_fn(fd, &mut out),
+            TopLevel::TypeDef(TypeDef::Product { fields, .. }) => {
+                out.extend(fields.iter().map(|(_, ty)| ty.clone()));
+            }
+            _ => {}
+        }
+    }
+    for m in inputs.dep_modules {
+        for fd in &m.fn_defs {
+            push_fn(fd, &mut out);
+        }
+        for td in &m.type_defs {
+            if let TypeDef::Product { fields, .. } = td {
+                out.extend(fields.iter().map(|(_, ty)| ty.clone()));
+            }
+        }
+    }
+    out
+}
+
+/// Walk a parsed `Type`. For every `Map<K, _>` encountered, add every
+/// candidate carrier REACHABLE from `K` (directly, or transitively through a
+/// record's fields) to `demoted`. Recurses through every type constructor so
+/// a `Map` buried inside `List<Map<…>>`, a `Result`/`Option` payload, a
+/// tuple, etc. is still found.
+fn collect_map_key_carriers(
+    ty: &crate::ast::Type,
+    candidates: &HashSet<String>,
+    record_fields: &HashMap<String, Vec<String>>,
+    demoted: &mut HashSet<String>,
+) {
+    use crate::ast::Type;
+    match ty {
+        Type::Map(key, value) => {
+            carriers_reachable_from(key, candidates, record_fields, &mut HashSet::new(), demoted);
+            // The KEY is the hazard; recurse into both so a nested Map in
+            // either position is still inspected.
+            collect_map_key_carriers(key, candidates, record_fields, demoted);
+            collect_map_key_carriers(value, candidates, record_fields, demoted);
+        }
+        Type::Result(a, b) => {
+            collect_map_key_carriers(a, candidates, record_fields, demoted);
+            collect_map_key_carriers(b, candidates, record_fields, demoted);
+        }
+        Type::Option(a) | Type::List(a) | Type::Vector(a) => {
+            collect_map_key_carriers(a, candidates, record_fields, demoted);
+        }
+        Type::Tuple(items) => {
+            for t in items {
+                collect_map_key_carriers(t, candidates, record_fields, demoted);
+            }
+        }
+        Type::Fn(params, ret, _) => {
+            for p in params {
+                collect_map_key_carriers(p, candidates, record_fields, demoted);
+            }
+            collect_map_key_carriers(ret, candidates, record_fields, demoted);
+        }
+        _ => {}
+    }
+}
+
+/// Collect every candidate carrier reachable from a Map-KEY type `key`:
+/// `key` itself if it names a carrier, plus (transitively) any carrier among
+/// the fields of a record `key` names. `seen` guards self-referential
+/// records.
+fn carriers_reachable_from(
+    key: &crate::ast::Type,
+    candidates: &HashSet<String>,
+    record_fields: &HashMap<String, Vec<String>>,
+    seen: &mut HashSet<String>,
+    demoted: &mut HashSet<String>,
+) {
+    use crate::ast::Type;
+    let Some(name) = key.named_name() else {
+        // A Map key that is itself a container (`Map<List<Carrier>, V>`) —
+        // chase the inner element types too.
+        match key {
+            Type::Option(a) | Type::List(a) | Type::Vector(a) => {
+                carriers_reachable_from(a, candidates, record_fields, seen, demoted);
+            }
+            Type::Tuple(items) => {
+                for t in items {
+                    carriers_reachable_from(t, candidates, record_fields, seen, demoted);
+                }
+            }
+            Type::Map(k, v) => {
+                carriers_reachable_from(k, candidates, record_fields, seen, demoted);
+                carriers_reachable_from(v, candidates, record_fields, seen, demoted);
+            }
+            Type::Result(a, b) => {
+                carriers_reachable_from(a, candidates, record_fields, seen, demoted);
+                carriers_reachable_from(b, candidates, record_fields, seen, demoted);
+            }
+            _ => {}
+        }
+        return;
+    };
+    if !seen.insert(name.to_string()) {
+        return;
+    }
+    if candidates.contains(name) {
+        demoted.insert(name.to_string());
+    }
+    if let Some(fields) = record_fields.get(name) {
+        for field_ty in fields {
+            let parsed = crate::types::parse_type_str(field_ty);
+            carriers_reachable_from(&parsed, candidates, record_fields, seen, demoted);
+        }
+    }
+}
+
 /// Walk `analyze_plans(inputs)` and populate `ProofIR.fn_contracts`.
 ///
 /// Translation pass over the classifier output (`RecursionPlan`) —

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -86,8 +86,18 @@ pub fn transpile(ctx: &mut CodegenContext) -> ProjectOutput {
         // analysis, so the rewrite must not tag them bare (it would desync
         // the boxed signature from a bare-rewritten body / caller).
         let boxed = ctx.mutual_tco_members.clone();
-        ctx.mir_program =
-            Some(crate::ir::mir::optimize::bare_i64_rewrite::rewrite_for_rust(prog, &boxed));
+        // ETAP-2 SLICE 0+1: derive the per-carrier-type proven bound from the
+        // same refinement-via-opaque inputs the proof side reads, so a
+        // carrier function-slot can lower to native `i64`. An empty table
+        // (no opaque-bounded carrier in scope) keeps the all-`Int` behavior.
+        // Scoped so the immutable `&ctx` borrow ends before the assignment.
+        let carrier = {
+            let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
+            crate::codegen::proof_lower::carrier_interval_table(&inputs)
+        };
+        ctx.mir_program = Some(
+            crate::ir::mir::optimize::bare_i64_rewrite::rewrite_for_rust(prog, &boxed, &carrier),
+        );
     }
     let has_embedded_policy = ctx.policy.is_some();
     let has_runtime_policy = ctx.runtime_policy_from_env;

--- a/src/codegen/wasm_gc/body/eq_helpers.rs
+++ b/src/codegen/wasm_gc/body/eq_helpers.rs
@@ -92,6 +92,13 @@ impl EqHelperRegistry {
         if self.kinds.contains_key(type_name) {
             return;
         }
+        // ETAP-2 carrier-`i64`: an eligible carrier is `i64`-erased — no
+        // struct, no per-type `__eq_<Carrier>` helper (its eq inlines as raw
+        // `i64.eq` at the use site). A struct `__eq_` body over an `i64` is
+        // invalid wasm. Backstop covering every caller path.
+        if registry.is_eligible_carrier(type_name) {
+            return;
+        }
         // Skip nominal types whose fields contain unhandled shapes
         // (List/Map/Vector/Set inside fields — the inline eq emitter
         // covers Option/Result/Tuple via per-instantiation helpers
@@ -175,6 +182,16 @@ impl EqHelperRegistry {
             field_ty,
             "Int" | "Float" | "Bool" | "String" | "Unit" | "Byte" | "Char"
         ) {
+            return;
+        }
+        // ETAP-2 carrier-`i64`: an eligible carrier is erased to a native
+        // `i64`, so it has NO struct representation and needs NO per-type
+        // `__eq_<Carrier>` helper — its eq is the raw `i64.eq` inlined at the
+        // use site (the carrier-`i64` arms in the inline eq emitters). Treat
+        // it exactly like a primitive: register nothing. Registering a helper
+        // would emit a body that `struct.get`s a value that is actually an
+        // `i64` (the func-33 validation failure this guards).
+        if registry.is_eligible_carrier(field_ty) {
             return;
         }
         if registry.record_fields.contains_key(field_ty) {
@@ -705,6 +722,16 @@ fn emit_inner_eq_dispatch(
     string_eq_fn_idx: Option<u32>,
     helper_idx_map: &HashMap<String, u32>,
 ) -> Result<(), WasmGcError> {
+    // ETAP-2 carrier-`i64`: an eligible carrier field/payload is a NATIVE
+    // `i64` (erased to `i64`, not the `$AverInt` ref a plain `Int` field
+    // lowers to), so it compares with a raw `i64.eq` — NOT `__aint_eq`,
+    // which expects two refs and fails validation on a scalar `i64`. Check
+    // before the newtype resolution, which would fold the carrier into
+    // `Int` → `emit_aint_field_eq` → `__aint_eq`.
+    if registry.is_eligible_carrier(inner) {
+        f.instruction(&Instruction::I64Eq);
+        return Ok(());
+    }
     // Resolve newtypes — `Box(n: Int)` reaches here as "Box" but
     // its wasm representation is i64.
     let resolved: String = if let Some(under) = registry.newtype_underlying(inner) {

--- a/src/codegen/wasm_gc/body/from_mir/constructors.rs
+++ b/src/codegen/wasm_gc/body/from_mir/constructors.rs
@@ -22,7 +22,13 @@ pub(crate) fn emit_mir_constructor_with_args(
         )));
     }
     if ctx.registry.newtype_underlying(&info.parent).is_some() {
-        return Ok(emit_mir_expr(func, &args[0], slots, ctx)?.map(|_| ()));
+        let produced = emit_mir_expr(func, &args[0], slots, ctx)?;
+        // ETAP-2 carrier-`i64`: a single-variant single-`Int` carrier sum
+        // erases to `i64`; narrow the payload value at the construct boundary.
+        if produced.is_some() && ctx.registry.is_eligible_carrier(&info.parent) {
+            emit_carrier_construct_bridge(func, ctx)?;
+        }
+        return Ok(produced.map(|_| ()));
     }
     for arg in args {
         if emit_mir_expr(func, arg, slots, ctx)?.is_none() {

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -99,6 +99,56 @@ pub(super) use strings::*;
 
 pub use coverage::{CoverageReport, coverage_report};
 
+/// ETAP-2 carrier-`i64`: narrow the `$AverInt` Int VALUE on the stack down
+/// to the native `i64` the carrier slot/field holds. Emitted at the carrier
+/// CONSTRUCT boundary (the newtype-erased smart-constructor field value, an
+/// `$AverInt`, must land as `i64` in the carrier). Uses
+/// `__aint_to_i64_checked` — which TRAPS on an out-of-`i64` Big — but the
+/// carrier's proven smart-constructor bound `fits_i64`, so the trap is
+/// unreachable for any value that ever reaches a real carrier (opaque type +
+/// guarded constructor). A no-op when bignum is off (then `Int` is already a
+/// scalar i64 and the carrier field is too).
+pub(crate) fn emit_carrier_construct_bridge(
+    func: &mut Function,
+    ctx: &EmitCtx<'_>,
+) -> Result<(), WasmGcError> {
+    if ctx.registry.bignum {
+        let to_checked = ctx
+            .fn_map
+            .builtins
+            .get("__aint_to_i64_checked")
+            .copied()
+            .ok_or(WasmGcError::Validation(
+                "carrier-i64 construct needs __aint_to_i64_checked but it is not registered".into(),
+            ))?;
+        func.instruction(&Instruction::Call(to_checked));
+    }
+    Ok(())
+}
+
+/// ETAP-2 carrier-`i64`: lift the native `i64` a carrier slot/field holds
+/// back into the `$AverInt` carrier the surrounding `Int` context expects.
+/// Emitted at the carrier PROJECT boundary (`c.value` reads the i64 and the
+/// result is a plain `Int`). Uses `__aint_from_i64` (the canonical Small
+/// constructor — infallible). A no-op when bignum is off.
+pub(crate) fn emit_carrier_project_bridge(
+    func: &mut Function,
+    ctx: &EmitCtx<'_>,
+) -> Result<(), WasmGcError> {
+    if ctx.registry.bignum {
+        let from_i64 =
+            ctx.fn_map
+                .builtins
+                .get("__aint_from_i64")
+                .copied()
+                .ok_or(WasmGcError::Validation(
+                    "carrier-i64 project needs __aint_from_i64 but it is not registered".into(),
+                ))?;
+        func.instruction(&Instruction::Call(from_i64));
+    }
+    Ok(())
+}
+
 /// `Int = ℤ`: registered `fn_map.builtins` helpers whose Aver return type
 /// is `Int` but whose wasm helper computes a raw scalar i64 (a byte / code
 /// count), so the result must be lifted into the `$AverInt` carrier. Kept
@@ -987,8 +1037,15 @@ pub(crate) fn emit_mir_expr(
             let proj = &spanned_proj.node;
             let record_name = aver_type_str_of(&proj.base);
             if ctx.registry.newtype_underlying(&record_name).is_some() {
-                return Ok(emit_mir_expr(func, &proj.base, slots, ctx)?
-                    .map(|_| aver_type_str_of(expr).trim() != "Unit"));
+                // ETAP-2 carrier-`i64`: an eligible carrier's field read is
+                // still identity (emit the base), but the base is now a
+                // native `i64` and the projected `.value` is a plain `Int`,
+                // so lift it back into the `$AverInt` carrier.
+                let produced = emit_mir_expr(func, &proj.base, slots, ctx)?;
+                if produced.is_some() && ctx.registry.is_eligible_carrier(&record_name) {
+                    emit_carrier_project_bridge(func, ctx)?;
+                }
+                return Ok(produced.map(|_| aver_type_str_of(expr).trim() != "Unit"));
             }
             let (Some(type_idx), Some(field_idx)) = (
                 ctx.registry.record_type_idx(&record_name),

--- a/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
+++ b/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
@@ -1236,6 +1236,13 @@ pub(crate) fn emit_mir_single_variant_match(
         if emit_mir_expr(func, subject, slots, ctx)?.is_none() {
             return Ok(None);
         }
+        // ETAP-2 carrier-`i64`: an eligible carrier subject is a native
+        // `i64`, but the unwrapped binding has the underlying `Int` type
+        // (its slot is an `$AverInt` ref), so lift it back before the
+        // `local.set`. Skip when the binding is discarded (`_`, NO_SLOT).
+        if slot != NO_SLOT && ctx.registry.is_eligible_carrier(&info.parent) {
+            super::emit_carrier_project_bridge(func, ctx)?;
+        }
         if slot != NO_SLOT {
             func.instruction(&Instruction::LocalSet(slot));
         } else {
@@ -1403,6 +1410,12 @@ pub(crate) fn emit_mir_arm_body(
             let slot = bindings[0].0;
             if slot != NO_SLOT {
                 func.instruction(&Instruction::LocalGet(subject_scratch));
+                // ETAP-2 carrier-`i64`: the scratch holds the carrier's
+                // native `i64`; the unwrapped binding's slot is the
+                // underlying `$AverInt`, so lift before binding.
+                if ctx.registry.is_eligible_carrier(&info.parent) {
+                    super::emit_carrier_project_bridge(func, ctx)?;
+                }
                 func.instruction(&Instruction::LocalSet(slot));
             }
             return emit_mir_arm_body_value(func, &arm.body, result_raw, slots, ctx);

--- a/src/codegen/wasm_gc/body/from_mir/records.rs
+++ b/src/codegen/wasm_gc/body/from_mir/records.rs
@@ -54,7 +54,14 @@ pub(crate) fn emit_mir_record_create(
         let field = fields.first().ok_or(WasmGcError::Validation(format!(
             "newtype record `{type_name}` requires one field"
         )))?;
-        return Ok(emit_mir_expr(func, &field.value, slots, ctx)?.map(|_| ()));
+        let produced = emit_mir_expr(func, &field.value, slots, ctx)?;
+        // ETAP-2 carrier-`i64`: an eligible carrier construct is still
+        // identity, but the field value is a plain `Int` (`$AverInt`) and the
+        // carrier holds a native `i64`, so narrow it at the boundary.
+        if produced.is_some() && ctx.registry.is_eligible_carrier(type_name) {
+            emit_carrier_construct_bridge(func, ctx)?;
+        }
+        return Ok(produced.map(|_| ()));
     }
     let type_idx = ctx
         .registry

--- a/src/codegen/wasm_gc/body/hash_helpers.rs
+++ b/src/codegen/wasm_gc/body/hash_helpers.rs
@@ -78,6 +78,15 @@ impl HashHelperRegistry {
         if self.kinds.contains_key(type_name) {
             return;
         }
+        // ETAP-2 carrier-`i64`: an eligible carrier is `i64`-erased — it has
+        // no struct and needs no per-type `__hash_<Carrier>` helper (its hash
+        // inlines as raw `i32.wrap_i64` at every use site). A struct-shaped
+        // helper body over an `i64` value is invalid wasm. This is the
+        // backstop covering every caller path (seed, field walk, `==`
+        // discovery, nominal-in-type walk).
+        if registry.is_eligible_carrier(type_name) {
+            return;
+        }
         let mut seen = std::collections::HashSet::new();
         let resolvable = match kind {
             HashKind::Record => {
@@ -146,6 +155,12 @@ impl HashHelperRegistry {
             field_ty,
             "Int" | "Float" | "Bool" | "String" | "Unit" | "Byte" | "Char"
         ) {
+            return;
+        }
+        // ETAP-2 carrier-`i64`: an eligible carrier is `i64`-erased — no
+        // struct, no per-type `__hash_<Carrier>` helper; its hash is the raw
+        // `i32.wrap_i64` inlined at the use site. Treat like a primitive.
+        if registry.is_eligible_carrier(field_ty) {
             return;
         }
         if registry.record_fields.contains_key(field_ty) {
@@ -636,6 +651,14 @@ fn emit_inner_hash_dispatch(
     helper_idx_map: &HashMap<String, u32>,
     self_fn_idx: Option<u32>,
 ) -> Result<(), WasmGcError> {
+    // ETAP-2 carrier-`i64`: an eligible carrier field/payload is a native
+    // `i64`, so its hash is a raw `i32.wrap_i64` — NOT `__aint_hash` (a ref
+    // helper). Must agree with the carrier eq (`i64.eq`) so equal carriers
+    // hash equal. Check before the newtype resolution.
+    if registry.is_eligible_carrier(inner) {
+        f.instruction(&Instruction::I32WrapI64);
+        return Ok(());
+    }
     let resolved: String = if let Some(under) = registry.newtype_underlying(inner) {
         under.to_string()
     } else {

--- a/src/codegen/wasm_gc/lists.rs
+++ b/src/codegen/wasm_gc/lists.rs
@@ -696,6 +696,15 @@ enum ListEqKind {
     /// the canonical (whitespace-free) so the body emitter can look
     /// it up in the helper idx map at emit time.
     CarrierEq(String),
+    /// ETAP-2 carrier-`i64`: a refinement-via-opaque carrier whose
+    /// proven bound `fits_i64` and whose erasure is therefore a NATIVE
+    /// `i64` array/list element — NOT the boxed `$AverInt` ref a plain
+    /// `Int` element lowers to under bignum. Equality is a raw `i64.eq`
+    /// and hash a raw `i32.wrap_i64`, EXACTLY the bignum-off Int path, so
+    /// the element op matches the `(array i64)` / `(field i64)` storage
+    /// instead of calling the `$aint` ref helpers (`__aint_eq` /
+    /// `__aint_hash`) which would expect a ref and fail wasm validation.
+    CarrierI64,
 }
 
 /// bignum slice 3 — emit Int-element EQUALITY for a List / Vector
@@ -781,6 +790,16 @@ pub(super) fn emit_aint_field_hash(
 
 fn list_eq_kind(elem: &str, registry: &TypeRegistry) -> Option<ListEqKind> {
     let trimmed = elem.trim();
+    // ETAP-2 carrier-`i64`: an eligible carrier element is a NATIVE `i64`
+    // (the erasure produced `i64`, not `$AverInt`), so its element eq/hash
+    // must be the raw `i64.eq` / `i32.wrap_i64`, NOT the boxed `$aint`
+    // helper the plain-`Int` recursion below would pick. Check BEFORE the
+    // newtype recursion, which would otherwise fold the carrier into `Int`
+    // → `I64` → `emit_int_elem_eq` → `call $__aint_eq` (a ref helper that
+    // fails validation on a raw `i64` element).
+    if registry.is_eligible_carrier(trimmed) {
+        return Some(ListEqKind::CarrierI64);
+    }
     // Newtype-erased sum / record (single-variant single-field of a
     // primitive) gets its underlying primitive's eq instruction.
     if let Some(under) = registry.newtype_underlying(trimmed) {
@@ -1867,6 +1886,12 @@ fn emit_list_contains(
             f.instruction(&Instruction::LocalGet(1));
             match &kind {
                 ListEqKind::I64 => emit_int_elem_eq(&mut f, registry, aint_eq_fn_idx)?,
+                // ETAP-2 carrier-`i64`: raw `i64.eq` — the element is a native
+                // `i64`, NOT an `$AverInt` ref, so it does NOT route through
+                // `emit_int_elem_eq` (which calls `__aint_eq` under bignum).
+                ListEqKind::CarrierI64 => {
+                    f.instruction(&Instruction::I64Eq);
+                }
                 ListEqKind::F64 => {
                     f.instruction(&Instruction::F64Eq);
                 }
@@ -1955,6 +1980,17 @@ pub(super) fn emit_record_eq_inline(
             field_index: i as u32,
         });
         // emit per-field eq → i32
+        // ETAP-2 carrier-`i64`: an eligible carrier field is a native `i64`,
+        // so it compares with a raw `i64.eq`, NOT the `__aint_eq` ref helper
+        // (the plain-`Int` arm) nor a per-type `__eq_<Carrier>` (which a
+        // newtype carrier never gets). Check before the type-name match.
+        if registry.is_eligible_carrier(field_ty.trim()) {
+            f.instruction(&Instruction::I64Eq);
+            if i > 0 {
+                f.instruction(&Instruction::I32And);
+            }
+            continue;
+        }
         match field_ty.trim() {
             "Int" => {
                 emit_aint_field_eq(f, registry)?;
@@ -2071,6 +2107,15 @@ pub(super) fn emit_sum_eq_inline(
                     struct_type_index: v_idx,
                     field_index: i as u32,
                 });
+                // ETAP-2 carrier-`i64`: an eligible carrier sum-field is a
+                // native `i64` → raw `i64.eq`.
+                if registry.is_eligible_carrier(field_ty.trim()) {
+                    f.instruction(&Instruction::I64Eq);
+                    if i > 0 {
+                        f.instruction(&Instruction::I32And);
+                    }
+                    continue;
+                }
                 match field_ty.trim() {
                     "Int" => {
                         emit_aint_field_eq(f, registry)?;
@@ -2341,6 +2386,10 @@ fn emit_list_eq(
         ListEqKind::I64 => {
             emit_int_elem_eq(&mut f, registry, aint_eq_fn_idx)?;
         }
+        // ETAP-2 carrier-`i64`: raw `i64.eq` over native-`i64` elements.
+        ListEqKind::CarrierI64 => {
+            f.instruction(&Instruction::I64Eq);
+        }
         ListEqKind::F64 => {
             f.instruction(&Instruction::F64Eq);
         }
@@ -2479,6 +2528,13 @@ fn emit_list_hash(
     match &kind {
         ListEqKind::I64 => {
             emit_int_elem_hash(&mut f, registry)?;
+        }
+        // ETAP-2 carrier-`i64`: raw `i32.wrap_i64` over the native-`i64`
+        // element — the bignum-off Int hash, NOT `__aint_hash` (a ref
+        // helper). Equal carrier values hash equal because they ARE the
+        // same `i64`.
+        ListEqKind::CarrierI64 => {
+            f.instruction(&Instruction::I32WrapI64);
         }
         ListEqKind::I32 => {} // bool — already i32
         ListEqKind::F64 => {
@@ -2627,6 +2683,15 @@ fn emit_sum_inline_hash(
                 struct_type_index: v_idx,
                 field_index: i as u32,
             });
+            // ETAP-2 carrier-`i64`: an eligible carrier sum-field is a native
+            // `i64` → raw `i32.wrap_i64` (the bignum-off Int hash), matching
+            // its `i64.eq`.
+            if registry.is_eligible_carrier(field_ty.trim()) {
+                f.instruction(&Instruction::I32WrapI64);
+                f.instruction(&Instruction::I32Add);
+                f.instruction(&Instruction::LocalSet(elem_hash_local));
+                continue;
+            }
             let resolved: String = if let Some(under) = registry.newtype_underlying(field_ty.trim())
             {
                 under.to_string()
@@ -2708,6 +2773,14 @@ fn emit_record_inline_hash(
             struct_type_index: record_idx,
             field_index: i as u32,
         });
+        // ETAP-2 carrier-`i64`: an eligible carrier record-field is a native
+        // `i64` → raw `i32.wrap_i64`, matching its `i64.eq`.
+        if registry.is_eligible_carrier(field_type.trim()) {
+            f.instruction(&Instruction::I32WrapI64);
+            f.instruction(&Instruction::I32Add);
+            f.instruction(&Instruction::LocalSet(elem_hash_local));
+            continue;
+        }
         let resolved: String = if let Some(under) = registry.newtype_underlying(field_type.trim()) {
             under.to_string()
         } else {
@@ -2792,6 +2865,10 @@ fn emit_vec_eq(
     match &kind {
         ListEqKind::I64 => {
             emit_int_elem_eq(&mut f, registry, aint_eq_fn_idx)?;
+        }
+        // ETAP-2 carrier-`i64`: raw `i64.eq` over `(array i64)` elements.
+        ListEqKind::CarrierI64 => {
+            f.instruction(&Instruction::I64Eq);
         }
         ListEqKind::F64 => {
             f.instruction(&Instruction::F64Eq);
@@ -2905,6 +2982,10 @@ fn emit_vec_hash(
     match &kind {
         ListEqKind::I64 => {
             emit_int_elem_hash(&mut f, registry)?;
+        }
+        // ETAP-2 carrier-`i64`: raw `i32.wrap_i64` over `(array i64)` elems.
+        ListEqKind::CarrierI64 => {
+            f.instruction(&Instruction::I32WrapI64);
         }
         ListEqKind::I32 => {} // bool — already i32
         ListEqKind::F64 => {

--- a/src/codegen/wasm_gc/maps.rs
+++ b/src/codegen/wasm_gc/maps.rs
@@ -205,8 +205,15 @@ impl MapHelperRegistry {
             if k_seen.insert(k_aver.to_string()) {
                 k_names.push(k_aver.to_string());
             }
+            // ETAP-2 carrier-`i64`: an eligible carrier V is `i64`-erased —
+            // it behaves like a primitive V, so it needs NO pseudo-K
+            // `__hash_/__eq_<V>` helper (a struct-shaped body over an `i64` is
+            // invalid wasm). The Map's value eq/hash dispatches it inline as
+            // raw `i64.eq` / `i32.wrap_i64` (the `is_eligible_carrier` arms in
+            // the map value-dispatch sites).
             if !super::types::TypeRegistry::is_primitive_map_key(v_aver_trim)
                 && v_aver_trim != "String"
+                && !registry.is_eligible_carrier(v_aver_trim)
                 && k_seen.insert(v_aver_trim.to_string())
             {
                 k_names.push(v_aver_trim.to_string());
@@ -2403,6 +2410,13 @@ fn emit_v_eq(
     v_helpers: Option<KeyHelpers>,
     registry: &TypeRegistry,
 ) -> Result<(), WasmGcError> {
+    // ETAP-2 carrier-`i64`: an eligible carrier V is a native `i64` in the
+    // values array → raw `i64.eq`, NOT a `__eq_<V>` helper (which is never
+    // registered for it) nor `__aint_eq` (a ref helper).
+    if registry.is_eligible_carrier(v_aver.trim()) {
+        f.instruction(&Instruction::I64Eq);
+        return Ok(());
+    }
     match v_aver.trim() {
         // Flag-on (bignum): `$aint` ref → `__aint_eq`. Flag-off: `i64.eq`.
         "Int" => {
@@ -2432,6 +2446,12 @@ fn emit_v_hash(
     v_helpers: Option<KeyHelpers>,
     registry: &TypeRegistry,
 ) -> Result<(), WasmGcError> {
+    // ETAP-2 carrier-`i64`: an eligible carrier V is a native `i64` →
+    // raw `i32.wrap_i64`, matching its `i64.eq`.
+    if registry.is_eligible_carrier(v_aver.trim()) {
+        f.instruction(&Instruction::I32WrapI64);
+        return Ok(());
+    }
     match v_aver.trim() {
         // Flag-on (bignum): `$aint` ref → `__aint_hash`. Flag-off: wrap.
         "Int" => {

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -157,13 +157,123 @@ pub(super) fn emit_module_with(
     // value or a builtin/variant `FnValue` (no funcref-table slot),
     // for which it returns `None`. Such fns get a `unreachable`
     // trap-stub body (`emit_trap_stub_body`).
-    let mir_program: crate::ir::mir::MirProgram = {
+    // ETAP-2 carrier-`i64`: derive the per-carrier-type proven bound ONCE,
+    // up front. The wasm-gc input `items` is the already-FLATTENED program
+    // (`flatten_multimodule` inlined every dep into entry scope, mirroring
+    // this view's `SymbolTable::build(items, &[])`), so the carrier type +
+    // its smart constructor both live in `entry_items` and `dep_modules` is
+    // empty. The same table feeds (a) the MIR `bare_i64` rewrite (an
+    // optional per-slot raw-i64 perf path, gated off in this slice) AND (b)
+    // the type registry's `eligible_carriers` set, which is THE size lever:
+    // every eligible carrier erases to a native `i64` in `aver_to_wasm`. An
+    // empty table (no opaque-bounded carrier) keeps the pre-slice all-`Int`
+    // lowering byte-for-byte.
+    let carrier_intervals = {
+        let empty_prefixes: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let empty_recursive: std::collections::HashSet<crate::ir::FnId> =
+            std::collections::HashSet::new();
+        let inputs = crate::codegen::proof_lower::ProofLowerInputs {
+            entry_items: items,
+            dep_modules: &[],
+            module_prefixes: &empty_prefixes,
+            recursive_fns: &empty_recursive,
+            symbol_table: &symbol_table,
+            program_shape: None,
+        };
+        crate::codegen::proof_lower::carrier_interval_table(&inputs)
+    };
+    // The codegen size lever: a carrier whose proven bound is recognized AND
+    // `fits_i64` erases to native `i64` everywhere it appears (slots, record
+    // fields, Option/Result payloads, `Vector<Carrier>` elements). A bound
+    // too wide for `i64` (or an unrecognized invariant, already omitted from
+    // the table upstream) is excluded here, so the carrier stays `$AverInt`.
+    //
+    // `AVER_NO_CARRIER_I64=1` is the differential / size-measurement escape
+    // hatch: it forces the all-`$AverInt` carrier representation (empty
+    // eligible set), so a coords-heavy toy can be compiled both ways to
+    // measure the struct-field size win, and any divergence the carrier path
+    // introduces can be bisected against the boxed baseline.
+    // Lower + optimize the resolved fns to MIR ONCE, up front — the typed MIR
+    // is the RESOLVED-IR source of truth for Map-key types: every node carries
+    // an `Option<Type>` stamp, so `discover_instantiations` surfaces every
+    // `Map<K, V>` the program actually uses, including ones with NO textual
+    // annotation (a local-binding `m: Map<…>` whose annotation Scan 2's string
+    // walk never reaches, or a fully INFERRED `m = Map.set({}, c, 5)`). The
+    // box/unbox boundary rewrite (`rewrite_for_wasm_gc`) is layered on top of
+    // THIS same `optimized` value below — building it here avoids a second
+    // lower+optimize pass while making the inferred Map-key types available to
+    // the carrier-eligibility scan.
+    let optimized_mir: crate::ir::mir::MirProgram = {
         let mir_items: Vec<crate::ir::hir::ResolvedTopLevel> = resolved_fn_defs
             .iter()
             .cloned()
             .map(crate::ir::hir::ResolvedTopLevel::FnDef)
             .collect();
-        let optimized = crate::ir::mir::optimize(crate::ir::mir::lower_program(&mir_items));
+        crate::ir::mir::optimize(crate::ir::mir::lower_program(&mir_items))
+    };
+
+    let eligible_carriers: std::collections::HashSet<String> =
+        if std::env::var("AVER_NO_CARRIER_I64").is_ok() {
+            std::collections::HashSet::new()
+        } else {
+            // Proven-bound candidates: the carrier's invariant is recognized
+            // AND `fits_i64`. This is necessary but NOT sufficient — it does
+            // not prove every value went through the gate, nor that the
+            // carrier's codegen is only exercised in positions the i64
+            // erasure supports.
+            let proven: std::collections::HashSet<String> = carrier_intervals
+                .iter()
+                .filter(|(_, (iv, known))| *known && iv.fits_i64())
+                .map(|(name, _)| name.clone())
+                .collect();
+            // Fail-closed tightening (unless explicitly disabled for a
+            // revert-test): subtract carriers that are constructed ungated
+            // (bare ctor bypass) or used as a `Map` KEY (direct/transitive).
+            // Either trip keeps that carrier BOXED, matching the VM and the
+            // pre-slice boxed wasm-gc path. `AVER_CARRIER_I64_SKIP_DEMOTION=1`
+            // restores the un-tightened set so the regression revert-tests
+            // can show the hole returning (trap / validation error).
+            if std::env::var("AVER_CARRIER_I64_SKIP_DEMOTION").is_ok() {
+                proven
+            } else {
+                let inputs = crate::codegen::proof_lower::ProofLowerInputs {
+                    entry_items: items,
+                    dep_modules: &[],
+                    module_prefixes: &std::collections::HashSet::new(),
+                    recursive_fns: &std::collections::HashSet::new(),
+                    symbol_table: &symbol_table,
+                    program_shape: None,
+                };
+                // RESOLVED-IR Map-key types: the typed-MIR instantiation
+                // registry carries every `Map<K, V>` the program uses, keyed
+                // off inference, so a carrier used as a Map KEY via a local
+                // binding OR pure inference (no annotation anywhere) is still
+                // demoted. This is the complete source of truth; the textual
+                // annotation scan inside `carrier_eligibility_demotions` stays
+                // as a cheap backstop.
+                let resolved_map_keys: Vec<crate::ast::Type> =
+                    crate::ir::mir::discover_instantiations(&optimized_mir)
+                        .maps
+                        .into_iter()
+                        .map(|(k, _v)| k)
+                        .collect();
+                let demoted = crate::codegen::proof_lower::carrier_eligibility_demotions(
+                    &inputs,
+                    &proven,
+                    &carrier_intervals,
+                    &resolved_map_keys,
+                );
+                proven.difference(&demoted).cloned().collect()
+            }
+        };
+    registry.set_eligible_carriers(eligible_carriers);
+
+    let mir_program: crate::ir::mir::MirProgram = {
+        // Reuse the `optimized` MIR built above for carrier-eligibility
+        // Map-key discovery — the box/unbox boundary rewrite is the only
+        // step layered on top, and it does not change the type stamps the
+        // instantiation scan consumed.
+        let optimized = optimized_mir;
         // ETAP-2 SLICE 2b: make Int representation EXPLICIT for the wasm-gc
         // codegen. The rewrite tags each fn's bare slots / params / return on
         // `MirFn::repr` and inserts `Box`/`Unbox` boundary nodes; the body
@@ -178,7 +288,17 @@ pub(super) fn emit_module_with(
         // fragment never goes bare.
         let boxed =
             crate::ir::mir::optimize::bare_i64_rewrite::mutual_recursion_box_set(&optimized);
-        crate::ir::mir::optimize::bare_i64_rewrite::rewrite_for_wasm_gc(optimized, &boxed)
+        // The per-carrier-type bound (`carrier_intervals`, hoisted above)
+        // also seeds the MIR rewrite's optional per-slot raw-i64 path. That
+        // path is gated OFF in this slice (`CARRIER_BARE_ELIGIBLE == false`),
+        // so it is inert here; the carrier-`i64` size lever lives entirely in
+        // the registry's `eligible_carriers` set + the construct / project
+        // box-bridges.
+        crate::ir::mir::optimize::bare_i64_rewrite::rewrite_for_wasm_gc(
+            optimized,
+            &boxed,
+            &carrier_intervals,
+        )
     };
 
     // Lazy caller_fn name registry — populated during user-fn body
@@ -276,6 +396,14 @@ pub(super) fn emit_module_with(
         }
     }
     for name in &nominal_seed {
+        // ETAP-2 carrier-`i64`: an eligible carrier is `i64`-erased — it has
+        // no struct, so a per-type `__eq_/__hash_<Carrier>` helper would emit
+        // a body that `struct.get`s an `i64` (invalid wasm). Its eq/hash is
+        // the raw `i64.eq` / `i32.wrap_i64` inlined at every use site, so skip
+        // the helper registration entirely (mirrors `register_field_type`).
+        if registry.is_eligible_carrier(name) {
+            continue;
+        }
         if registry.record_fields.contains_key(name) {
             eq_helpers_registry.register_transitive(name, EqKind::Record, &registry);
             hash_helpers_registry.register_transitive(name, HashKind::Record, &registry);
@@ -4917,6 +5045,13 @@ fn register_nominal_in_type(
             let Some(key) = named_type_registry_key(symbol_table, t) else {
                 return;
             };
+            // ETAP-2 carrier-`i64`: an eligible carrier is `i64`-erased — no
+            // struct, no per-type helper (its eq/hash inlines raw at the use
+            // site). Skip so no `__eq_/__hash_<Carrier>` slot is allocated
+            // (a struct-shaped body over an `i64` is invalid wasm).
+            if type_registry.is_eligible_carrier(&key) {
+                return;
+            }
             if type_registry.record_fields.contains_key(&key) {
                 eq_helpers.register_transitive(&key, EqKind::Record, type_registry);
             } else if type_registry
@@ -5042,7 +5177,13 @@ fn discover_builtins_in_expr(
                 && matches!(t, AverType::Named { .. })
                 && let Some(key) = named_type_registry_key(symbol_table, t)
             {
-                if type_registry.record_fields.contains_key(&key) {
+                // ETAP-2 carrier-`i64`: a direct carrier `==` lowers via the
+                // project box-bridge (each side boxed to `$AverInt`, compared
+                // with `__aint_eq`) — NOT a struct `__eq_<Carrier>` helper. An
+                // eligible carrier is `i64`-erased and gets no such helper.
+                if type_registry.is_eligible_carrier(&key) {
+                    // no helper — handled inline
+                } else if type_registry.record_fields.contains_key(&key) {
                     eq_helpers.register_transitive(&key, EqKind::Record, type_registry);
                 } else if type_registry
                     .variants

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -127,6 +127,22 @@ pub(super) struct TypeRegistry {
     /// addressing layout uses `keys[i] == null` as the empty marker,
     /// which only works when keys are emitted as ref values.
     pub(super) non_newtypable_keys: std::collections::HashSet<String>,
+    /// ETAP-2 carrier-`i64`: refinement-via-opaque carrier types whose
+    /// proven smart-constructor bound `fits_i64`, keyed by bare Aver name
+    /// (e.g. `"IntRange"`). For a name in this set, the newtype erasure
+    /// produces a NATIVE `i64` (not the `$AverInt` ref) EVERYWHERE the
+    /// carrier appears — fn slots, record fields, Option/Result payloads,
+    /// `Vector<Carrier>` elements — because every shape routes through
+    /// `aver_to_wasm`. The carrier `IS` the `i64`; the two boundary
+    /// conversions (construct unboxes the `$AverInt` field value to `i64`
+    /// via `__aint_to_i64_checked` — which can never trap because the bound
+    /// proves the fit; projection boxes the `i64` back to `$AverInt` via
+    /// `__aint_from_i64`) live at the carrier construct / project emit
+    /// sites. EMPTY (the default) reproduces the all-`$aint` behavior
+    /// byte-for-byte; only an opaque carrier with a recognized, `fits_i64`
+    /// invariant lands here. Built from
+    /// [`crate::codegen::proof_lower::carrier_interval_table`].
+    pub(super) eligible_carriers: std::collections::HashSet<String>,
     /// Phase 4 (0.20) — `(struct (mut i32 socket) (mut i32 in_stream)
     /// (mut i32 out_stream) (mut i32 in_use))` slot type for an entry
     /// in the TCP connection pool. `None` when no `Tcp.*` effect is
@@ -982,6 +998,12 @@ impl TypeRegistry {
             string_literals,
             string_literal_idx,
             non_newtypable_keys,
+            // ETAP-2 carrier-`i64`: populated post-build by `module.rs`
+            // (`set_eligible_carriers`) from the refinement-via-opaque
+            // carrier table, which needs `ProofLowerInputs` this builder
+            // doesn't have. Empty here ⇒ no carrier erases to `i64` until
+            // the codegen entry opts in.
+            eligible_carriers: std::collections::HashSet::new(),
             tcp_slot_type_idx,
             tcp_pool_type_idx,
             bignum,
@@ -1267,6 +1289,27 @@ impl TypeRegistry {
     /// lowers to identity, `match obj { Foo.Foo(n) -> body }` binds `n`
     /// to the underlying `T` value with no `struct.get`. Same trick
     /// rustc uses for `struct UserId(u64)`.
+    /// ETAP-2 carrier-`i64`: install the set of refinement-via-opaque
+    /// carrier type names whose proven bound `fits_i64`. Called once by the
+    /// wasm-gc codegen entry after it derives the carrier interval table.
+    /// Keyed by bare Aver name (`"IntRange"`).
+    pub(super) fn set_eligible_carriers(&mut self, names: std::collections::HashSet<String>) {
+        self.eligible_carriers = names;
+    }
+
+    /// ETAP-2 carrier-`i64`: is `type_name` (bare or `Module.`-qualified) a
+    /// carrier whose erasure should be a native `i64`? A carrier in the
+    /// eligible set is ALSO a newtype (single-field opaque record of `Int`),
+    /// so `newtype_underlying` already returns `Some("Int")` for it — this
+    /// just decides whether that erasure becomes `i64` or stays `$AverInt`.
+    pub(super) fn is_eligible_carrier(&self, type_name: &str) -> bool {
+        if self.eligible_carriers.is_empty() {
+            return false;
+        }
+        let bare = type_name.rsplit_once('.').map_or(type_name, |(_, b)| b);
+        self.eligible_carriers.contains(bare.trim())
+    }
+
     pub(super) fn newtype_underlying(&self, type_name: &str) -> Option<&str> {
         // Suppress newtype optimisation when the type is used as a
         // `Map<K, *>` key. Map's open-addressing layout uses
@@ -1749,6 +1792,17 @@ pub(super) fn aver_to_wasm(
         // applies (otherwise an erased `Box(v: Int)` lowers to i64 while
         // its stored/compared value is a ref → wasm-validation mismatch).
         if let Some(underlying) = reg.newtype_underlying(trimmed) {
+            // ETAP-2 carrier-`i64`: an eligible carrier (opaque single-`Int`
+            // record whose smart-constructor bound `fits_i64`) erases to a
+            // NATIVE `i64` instead of the `$AverInt` ref — the size lever.
+            // This fires EVERYWHERE the carrier type-string reaches a
+            // ValType (fn slots, record fields, Option/Result payloads,
+            // `Vector<Carrier>` elements) because they all route here. The
+            // construct / project emit sites box-bridge the boundary to the
+            // surrounding `$AverInt` Int values.
+            if reg.is_eligible_carrier(trimmed) {
+                return Ok(Some(ValType::I64));
+            }
             if underlying.trim() == "Int" && reg.bignum {
                 return Ok(Some(aint_ref_ty(reg)?));
             }

--- a/src/ir/interval.rs
+++ b/src/ir/interval.rs
@@ -242,6 +242,18 @@ impl Interval {
         self.lo.fits_i64() && self.hi.fits_i64()
     }
 
+    /// `true` when the constant `k` provably lies within `[lo, hi]`. Used by
+    /// the carrier-`i64` eligibility tightening: a BARE record constructor
+    /// outside the smart-ctor whose carrier-field argument is a literal in
+    /// the proven interval is SAFE (it cannot smuggle an out-of-bound /
+    /// i64-overflowing value past the gate), so it does not demote the
+    /// carrier. A non-literal argument (or a literal outside the interval)
+    /// is ungated and DOES demote. `Bound::le` is module-private, so this
+    /// containment test must live here.
+    pub fn contains_point(self, k: i128) -> bool {
+        self.lo.le(Bound::Finite(k)) && Bound::Finite(k).le(self.hi)
+    }
+
     /// Standard interval widening ∇. An endpoint that moved OUTWARD between
     /// the previous iterate `self` and the next iterate `next` jumps to the
     /// matching infinity; a stable or inward-moving endpoint is kept (as the
@@ -1047,6 +1059,25 @@ mod tests {
         // [-2, 3] * [-2, 3] → min of {4,-6,-6,9} = -6, max = 9.
         let a = Interval::between(-2, 3);
         assert_eq!(a.mul(a), Interval::between(-6, 9));
+    }
+
+    #[test]
+    fn contains_point_respects_both_bounds_and_infinities() {
+        let band = Interval::between(0, 100);
+        // Endpoints inclusive, interior in, outside out.
+        assert!(band.contains_point(0));
+        assert!(band.contains_point(100));
+        assert!(band.contains_point(50));
+        assert!(!band.contains_point(-1));
+        assert!(!band.contains_point(101));
+        // One-sided bands: `n >= 0` contains every non-negative, no negative.
+        let ge0 = Interval::ge(0);
+        assert!(ge0.contains_point(0));
+        assert!(ge0.contains_point(i64::MAX as i128));
+        assert!(!ge0.contains_point(-1));
+        // The fully-unbounded interval contains everything.
+        assert!(Interval::unbounded().contains_point(i128::MIN));
+        assert!(Interval::unbounded().contains_point(i128::MAX));
     }
 
     // ── interval_of_invariant: 5 recognized shapes ─────────────────

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -47,6 +47,73 @@ use crate::ir::interval::{Interval, OpClass, raw_i64_eligible};
 use super::super::expr::{MirCallee, MirExpr, MirPattern};
 use super::super::program::{LocalId, MirFn, MirProgram};
 
+/// ETAP-2 SLICE 0+1 — per-carrier-type proven bound, keyed by the opaque
+/// type's bare Aver name (the `MirParam.ty` string). Built once by
+/// [`crate::codegen::proof_lower::carrier_interval_table`] and threaded into
+/// [`analyze`]. The `bool` is the `interval_known` bit from
+/// [`crate::ir::interval::interval_of_invariant`]: only a recognized,
+/// `fits_i64` bound makes a carrier slot bare-eligible. An EMPTY table
+/// (the default at every non-carrier call site — the VM facts path, tests)
+/// reproduces the pre-slice all-`Int` behavior byte-for-byte.
+pub type CarrierIntervals = HashMap<String, (Interval, bool)>;
+
+/// The proven interval for a carrier whose Aver type name is `ty`, returned
+/// ONLY when the table holds a recognized bound (`interval_known`) that
+/// `fits_i64`. Any other case (`ty` not a carrier, an unrecognized invariant
+/// omitted upstream, or a bound too wide for `i64`) yields `None` — the
+/// fail-closed decline that keeps the carrier boxed.
+///
+/// `ty` is a `MirParam.ty` string, which the lowerer fills with
+/// `format!("{:?}", Type)` — so a named carrier type renders as the Debug
+/// form `Named { id: Some(TypeId(N)), name: "IntRange" }`, NOT the bare
+/// `"IntRange"`. We extract the bare `name:` to match the table key (which
+/// is keyed by the bare type name from `populate_refined_types`).
+///
+/// ## Seam gate (`CARRIER_BARE_ELIGIBLE`)
+///
+/// This is the analysis half of carrier-`i64` lowering. The codegen half —
+/// flipping a bare-carrier function slot to a native `i64` on the wasm-gc /
+/// Rust backends — is NOT in place yet: a carrier is a refinement-via-opaque
+/// single-field record that the wasm-gc registry already *newtype-erases* to
+/// its underlying `Int` ref (`$aint`), and the body-emit path (`Project` of
+/// the carrier field, `RecordCreate` of the carrier, the smart-constructor
+/// `Result.Ok(IntRange(..))` boundary, and the same on Rust which does NOT
+/// erase the carrier at all) still expects that ref. Flagging a carrier slot
+/// bare in `MirFnRepr` therefore desyncs the body from the (still-boxed)
+/// signature and emits invalid wasm. So the seam ships GATED OFF — exactly
+/// the discipline 2a used (`ENABLE_BARE_SLOTS = false`) before 2b flipped it.
+/// The table, threading, name-extraction, escape-coupling and summary
+/// integration below are all LIVE and tested; flipping this `const` to
+/// `true` (after the body-emit bridge lands) turns the slice on with no
+/// other change to this file.
+const CARRIER_BARE_ELIGIBLE: bool = false;
+
+fn carrier_interval(ty: &str, carrier: &CarrierIntervals) -> Option<Interval> {
+    if !CARRIER_BARE_ELIGIBLE {
+        return None;
+    }
+    let bare = bare_named_type(ty)?;
+    let (iv, known) = carrier.get(bare).copied()?;
+    if known && iv.fits_i64() {
+        Some(iv)
+    } else {
+        None
+    }
+}
+
+/// Extract the bare type name from a `MirParam.ty` Debug string for a
+/// `Type::Named`. Returns the `name: "X"` payload as `X`, or `None` when the
+/// string is not a `Named { … }` Debug form (e.g. `"Int"`, `"Result(…)"`).
+/// The Debug format of `Type::Named { id, name }` is stable
+/// (`Named { id: …, name: "X" }`); we slice out the quoted `name:` field.
+fn bare_named_type(ty: &str) -> Option<&str> {
+    let rest = ty.strip_prefix("Named {")?;
+    let after = rest.split("name:").nth(1)?;
+    let start = after.find('"')? + 1;
+    let end = after[start..].find('"')? + start;
+    Some(&after[start..end])
+}
+
 /// Representation chosen for a value: a native machine `i64` or the
 /// default arbitrary-precision `AverInt`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -234,7 +301,7 @@ impl BareI64Facts {
 /// visible `MirCallee::Fn` / `MirTailCall` call graph. A dependency-module
 /// fragment (callers unseen) bails to all-`Boxed`, exactly like
 /// `own_param`.
-pub fn analyze(program: &MirProgram) -> BareI64Facts {
+pub fn analyze(program: &MirProgram, carrier: &CarrierIntervals) -> BareI64Facts {
     // Diagnostic / bench-differential escape hatch: skip the analysis so a
     // run keeps the conservative all-Boxed baseline.
     if std::env::var("AVER_NO_BARE_I64").is_ok() {
@@ -256,11 +323,11 @@ pub fn analyze(program: &MirProgram) -> BareI64Facts {
 
     // The minimal cross-frame summary: which params are bare, whether the
     // return is bare.
-    let summary = compute_summary(program, &int_params);
+    let summary = compute_summary(program, &int_params, carrier);
 
     let mut fns: HashMap<FnId, FnBareFacts> = HashMap::new();
     for (id, f) in program.iter() {
-        fns.insert(*id, analyze_fn(f, &summary));
+        fns.insert(*id, analyze_fn(f, &summary, carrier));
     }
 
     BareI64Facts { fns }
@@ -305,7 +372,11 @@ impl Summary {
     }
 }
 
-fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) -> Summary {
+fn compute_summary(
+    program: &MirProgram,
+    int_params: &HashMap<FnId, Vec<bool>>,
+    carrier: &CarrierIntervals,
+) -> Summary {
     // Address-taken fns (name appears as a `FnValue`) have callers we
     // cannot attribute — pin all their params/return boxed.
     let mut address_taken: HashSet<String> = HashSet::new();
@@ -452,7 +523,7 @@ fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) 
                 bare_return: bare_return.clone(),
                 bare_param_intervals: bare_param_intervals.clone(),
             };
-            let facts = analyze_fn(f, &tmp);
+            let facts = analyze_fn(f, &tmp, carrier);
             if !facts.bare_return && bare_return.insert(*id, false) != Some(false) {
                 changed = true;
             }
@@ -500,7 +571,7 @@ fn compute_summary(program: &MirProgram, int_params: &HashMap<FnId, Vec<bool>>) 
             bare_param_intervals: bare_param_intervals.clone(),
         };
         for (_caller, f) in program.iter() {
-            let facts = analyze_fn(f, &tmp);
+            let facts = analyze_fn(f, &tmp, carrier);
             let mut demote: Vec<FnId> = Vec::new();
             collect_let_bound_boxed_returns(&f.body.node, &facts, &bare_return, &mut demote);
             for target in demote {
@@ -1538,7 +1609,7 @@ fn literal_interval(arg: &MirExpr) -> Option<Interval> {
 /// `summary` (which params/returns are bare). The body walk derives an
 /// interval per slot (bottom-up over the `Let` chain), an escape predicate
 /// (a single use-flow scan), and combines them via `raw_i64_eligible`.
-fn analyze_fn(f: &MirFn, summary: &Summary) -> FnBareFacts {
+fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBareFacts {
     let mut facts = FnBareFacts::default();
 
     // 1. Range: seed param intervals from the summary. A bare param is
@@ -1547,12 +1618,31 @@ fn analyze_fn(f: &MirFn, summary: &Summary) -> FnBareFacts {
     //    stays in the OverflowFree band; a bare param with no tight interval
     //    falls back to the full-`i64` line (still sound — bare ⟹ confined to
     //    `i64` by construction); a boxed param is unbounded.
+    //
+    //    ETAP-2 SLICE 0+1 — carrier params. A param whose annotated type is a
+    //    refinement-via-opaque carrier (`carrier_interval(&p.ty, carrier)` is
+    //    `Some`) is bare-eligible from its PROVEN smart-constructor bound,
+    //    INDEPENDENT of the recurrence rule that drives `summary.param_bare`
+    //    (a carrier param isn't Int-typed, so the cross-frame summary never
+    //    flags it). The carrier bound is sound by construction: the type is
+    //    opaque + the only constructor is the guarded smart constructor, so
+    //    every inhabitant provably lies in the interval. The eligibility is
+    //    not final here — the combine (step 4) still gates on `!escapes`, and
+    //    the signature `bare_params[i]` is set FROM that combine result below
+    //    (so a carrier stored into a record / Map / stringified — i.e. one
+    //    that escapes — keeps a boxed signature, the slice-2 boundary).
     let mut intervals: HashMap<LocalId, Interval> = HashMap::new();
     let mut bare_params = vec![false; f.params.len()];
+    let mut carrier_params = vec![false; f.params.len()];
     for (i, p) in f.params.iter().enumerate() {
-        let is_bare = summary.param_bare(f.fn_id, i);
-        bare_params[i] = is_bare;
-        let iv = if is_bare {
+        let recurrence_bare = summary.param_bare(f.fn_id, i);
+        let carrier_iv = carrier_interval(&p.ty, carrier);
+        carrier_params[i] = carrier_iv.is_some();
+        bare_params[i] = recurrence_bare;
+        let iv = if let Some(cv) = carrier_iv {
+            // Carrier param: seed from its proven (fits_i64) bound.
+            cv
+        } else if recurrence_bare {
             summary
                 .param_interval(f.fn_id, i)
                 .filter(|iv| iv.fits_i64())
@@ -1562,7 +1652,6 @@ fn analyze_fn(f: &MirFn, summary: &Summary) -> FnBareFacts {
         };
         intervals.insert(p.local, iv);
     }
-    facts.bare_params = bare_params;
 
     // 2. Walk the body's `Let` chain, deriving an interval (+ worst-join
     //    op class) for each bound slot.
@@ -1597,11 +1686,16 @@ fn analyze_fn(f: &MirFn, summary: &Summary) -> FnBareFacts {
             },
         );
     }
-    // Params absent from the Let walk still get a fact (their seed).
+    // Params absent from the Let walk still get a fact (their seed). Every
+    // param is in `intervals`, so the combine above already inserted its
+    // value fact — this `or_insert_with` is a backstop for any param the
+    // combine somehow skipped. A carrier param is bare iff its proven bound
+    // made it eligible (it was seeded into `intervals`, so the combine
+    // covered it); the recurrence path keeps its `summary` seed.
     for (i, p) in f.params.iter().enumerate() {
-        let is_bare = summary.param_bare(f.fn_id, i);
+        let seeded_bare = summary.param_bare(f.fn_id, i) || carrier_params[i];
         facts.values.entry(p.local).or_insert_with(|| {
-            if is_bare {
+            if seeded_bare {
                 ValueFact {
                     interval: intervals.get(&p.local).copied(),
                     op_class: OpClass::OverflowFree,
@@ -1613,6 +1707,22 @@ fn analyze_fn(f: &MirFn, summary: &Summary) -> FnBareFacts {
             }
         });
     }
+
+    // Couple each CARRIER param's signature bit to the combine result: a
+    // carrier param is bare in the signature ONLY when its value repr came
+    // out `Bare` (proven bound `fits_i64`, OverflowFree ops, and — crucially
+    // — it does NOT escape into an aggregate / Map / stringify). This is the
+    // in-fn analogue of `compute_summary`'s condition B2 for Int counters:
+    // the signature never disagrees with the body repr, so wasm-gc/Rust
+    // never emit an `i64` param the body reads through an `$aint`/`AverInt`
+    // method. A non-carrier param keeps its recurrence-derived `bare_params`
+    // bit untouched.
+    for (i, p) in f.params.iter().enumerate() {
+        if carrier_params[i] {
+            bare_params[i] = facts.values.get(&p.local).is_some_and(|v| v.is_bare());
+        }
+    }
+    facts.bare_params = bare_params;
 
     // 5. Return: bare iff the summary says so AND the body's tail value is
     //    itself bare-eligible.
@@ -2009,6 +2119,13 @@ mod tests {
     use crate::source::parse_source;
 
     fn facts_for(src: &str) -> (MirProgram, BareI64Facts) {
+        facts_for_with_carrier(src, &CarrierIntervals::new())
+    }
+
+    /// Like [`facts_for`] but threads a caller-supplied carrier table —
+    /// used by the carrier-slot tests. The empty-table caller
+    /// ([`facts_for`]) reproduces the pre-slice behavior exactly.
+    fn facts_for_with_carrier(src: &str, carrier: &CarrierIntervals) -> (MirProgram, BareI64Facts) {
         let mut items = parse_source(src).expect("parse");
         let cfg = crate::ir::pipeline::PipelineConfig {
             typecheck: Some(crate::ir::pipeline::TypecheckMode::Full { base_dir: None }),
@@ -2025,8 +2142,29 @@ mod tests {
         );
         let mir_items: Vec<crate::ir::hir::ResolvedTopLevel> = result.resolved_items.clone();
         let program = optimize(lower_program(&mir_items));
-        let facts = analyze(&program);
+        let facts = analyze(&program, carrier);
         (program, facts)
+    }
+
+    /// Build the carrier-interval table for `src` through the same
+    /// refinement-via-opaque derivation the codegen entries use. Returns
+    /// the parsed items + symbol table the table borrows from, so the
+    /// caller can keep them alive while running `analyze`.
+    fn carrier_table_for(
+        items: &[crate::ast::TopLevel],
+        symbols: &crate::ir::SymbolTable,
+    ) -> CarrierIntervals {
+        let empty_prefixes: HashSet<String> = HashSet::new();
+        let empty_recursive: HashSet<crate::ir::FnId> = HashSet::new();
+        let inputs = crate::codegen::proof_lower::ProofLowerInputs {
+            entry_items: items,
+            dep_modules: &[],
+            module_prefixes: &empty_prefixes,
+            recursive_fns: &empty_recursive,
+            symbol_table: symbols,
+            program_shape: None,
+        };
+        crate::codegen::proof_lower::carrier_interval_table(&inputs)
     }
 
     fn fn_id_by_name<'a>(program: &'a MirProgram, name: &str) -> crate::ir::FnId {
@@ -2035,6 +2173,114 @@ mod tests {
             .find(|(_, f)| f.name == name)
             .map(|(id, _)| *id)
             .unwrap_or_else(|| panic!("fn `{name}` not in program"))
+    }
+
+    /// ETAP-2 SLICE 0+1 carrier-slot source. `carrier` seeds the bound;
+    /// the empty-carrier variant is the revert-test baseline.
+    const CARRIER_SRC: &str = r#"
+module Toy
+    intent = "t"
+    depends []
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("err")
+
+fn toInt(c: IntRange) -> Int
+    c.value
+
+fn doubled(c: IntRange) -> Int
+    c.value + c.value
+
+fn main() -> Int
+    match fromInt(50)
+        Result.Ok(c)  -> toInt(c) + doubled(c)
+        Result.Err(_) -> 0
+"#;
+
+    /// Drive `CARRIER_SRC` through the pipeline + carrier table; return the
+    /// MIR program + analysis facts.
+    fn carrier_facts(carrier_on: bool) -> (MirProgram, BareI64Facts) {
+        let mut items = parse_source(CARRIER_SRC).expect("parse");
+        let cfg = crate::ir::pipeline::PipelineConfig {
+            typecheck: Some(crate::ir::pipeline::TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        };
+        let result = crate::ir::pipeline::run(&mut items, cfg);
+        let carrier = if carrier_on {
+            carrier_table_for(&items, &result.symbol_table)
+        } else {
+            CarrierIntervals::new()
+        };
+        let mir_items = result.resolved_items.clone();
+        let program = optimize(lower_program(&mir_items));
+        let facts = analyze(&program, &carrier);
+        (program, facts)
+    }
+
+    #[test]
+    fn bare_named_type_extracts_name_from_debug() {
+        // The lowerer fills `MirParam.ty` with `format!("{:?}", Type)`, so a
+        // named carrier renders as the Debug form. Pin the extractor.
+        assert_eq!(
+            bare_named_type("Named { id: Some(TypeId(0)), name: \"IntRange\" }"),
+            Some("IntRange")
+        );
+        assert_eq!(
+            bare_named_type("Named { id: None, name: \"Natural\" }"),
+            Some("Natural")
+        );
+        // Non-Named (primitive / compound) debug strings decline.
+        assert_eq!(bare_named_type("Int"), None);
+        assert_eq!(
+            bare_named_type("Result(Named { id: None, name: \"X\" }, Str)"),
+            None
+        );
+    }
+
+    #[test]
+    fn carrier_interval_table_derives_proven_bound() {
+        // The table is keyed by the bare carrier type name and carries the
+        // exact `[0, 100]` bound the proof side persists — byte-identical
+        // derivation, fail-closed on an unrecognized invariant.
+        let mut items = parse_source(CARRIER_SRC).expect("parse");
+        let cfg = crate::ir::pipeline::PipelineConfig {
+            typecheck: Some(crate::ir::pipeline::TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        };
+        let result = crate::ir::pipeline::run(&mut items, cfg);
+        let table = carrier_table_for(&items, &result.symbol_table);
+        let (iv, known) = table.get("IntRange").copied().expect("IntRange in table");
+        assert!(known, "the [0,100] invariant is recognized");
+        assert!(iv.fits_i64(), "the carrier bound fits i64");
+        assert_eq!(iv, Interval::between(0, 100), "exact proven carrier bound");
+    }
+
+    #[test]
+    fn carrier_seam_gated_off_keeps_param_boxed() {
+        // SHIPPED-SAFE invariant: while the codegen body-emit bridge is not
+        // in place (`CARRIER_BARE_ELIGIBLE == false`), a carrier param stays
+        // BOXED even when the table holds its proven bound — so the analysis
+        // never desyncs a carrier slot from the (still-boxed) signature and
+        // wasm-gc / Rust output is byte-identical to pre-slice. This test
+        // pins the gate; flip the `const` (with the body bridge) to enable.
+        assert!(
+            !CARRIER_BARE_ELIGIBLE,
+            "this test pins the shipped-off carrier seam"
+        );
+        let (program, facts) = carrier_facts(true);
+        for name in ["toInt", "doubled"] {
+            let id = fn_id_by_name(&program, name);
+            let f = facts.for_fn(id).expect("carrier facts");
+            assert!(
+                !f.param_is_bare(0),
+                "with the seam gated off, `{name}`'s carrier param stays boxed"
+            );
+        }
     }
 
     #[test]

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -59,8 +59,9 @@ use crate::ir::mir::{
 pub fn rewrite_for_rust(
     program: MirProgram,
     boxed_signature_fns: &std::collections::HashSet<crate::ir::FnId>,
+    carrier: &super::bare_i64::CarrierIntervals,
 ) -> MirProgram {
-    rewrite(program, boxed_signature_fns)
+    rewrite(program, boxed_signature_fns, carrier)
 }
 
 /// ETAP-2 SLICE 2b: the wasm-gc entry. Identical body to
@@ -78,8 +79,9 @@ pub fn rewrite_for_rust(
 pub fn rewrite_for_wasm_gc(
     program: MirProgram,
     boxed_signature_fns: &std::collections::HashSet<crate::ir::FnId>,
+    carrier: &super::bare_i64::CarrierIntervals,
 ) -> MirProgram {
-    rewrite(program, boxed_signature_fns)
+    rewrite(program, boxed_signature_fns, carrier)
 }
 
 /// The shared rewrite both public entries delegate to. Target-agnostic:
@@ -90,9 +92,10 @@ pub fn rewrite_for_wasm_gc(
 fn rewrite(
     program: MirProgram,
     boxed_signature_fns: &std::collections::HashSet<crate::ir::FnId>,
+    carrier: &super::bare_i64::CarrierIntervals,
 ) -> MirProgram {
     let mut program = program;
-    let facts = super::bare_i64::analyze(&program);
+    let facts = super::bare_i64::analyze(&program, carrier);
     // Collect ids first to avoid borrowing `program.fns` while mutating it.
     let ids: Vec<crate::ir::FnId> = program.fns.keys().copied().collect();
     for id in ids {
@@ -914,7 +917,11 @@ mod tests {
         );
         let mir_items = result.resolved_items.clone();
         let program = optimize(lower_program(&mir_items));
-        rewrite_for_rust(program, &std::collections::HashSet::new())
+        rewrite_for_rust(
+            program,
+            &std::collections::HashSet::new(),
+            &super::super::bare_i64::CarrierIntervals::new(),
+        )
     }
 
     fn fn_named<'a>(program: &'a MirProgram, name: &str) -> &'a MirFn {

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -1,0 +1,857 @@
+//! ETAP-2 carrier-`i64` — refinement-via-opaque carrier types erased to a
+//! native `i64` on the wasm-gc backend.
+//!
+//! A carrier `record IntRange { value: Int } exposes opaque` whose
+//! smart-constructor proves a `fits_i64` bound erases to a native `i64`
+//! EVERYWHERE it appears: function slots, record/struct FIELDS, and
+//! `Vector<Carrier>` / `List<Carrier>` / `Map<_, Carrier>` elements. The VM
+//! keeps the full `$aint` carrier (a record holding ℤ), so VM output is the
+//! ground truth; every emitted carrier-`i64` program MUST produce identical
+//! output. A wrong-bare value would silently wrap on wasm-gc (no trip-wire),
+//! and a type desync fails wasm validation at compile time — so identical
+//! VM-vs-wasm-gc output is the soundness gate.
+//!
+//! The bound proves the value fits `i64` (opaque + guarded smart ctor), so
+//! the boundary conversions are sound: the construct narrows the `$AverInt`
+//! field value to `i64` via `__aint_to_i64_checked` (whose trap is
+//! unreachable for a real carrier value), the projection lifts the `i64`
+//! back to `$AverInt` via `__aint_from_i64`. Arithmetic over a projected
+//! carrier runs at full `$aint` precision, so a transient that overshoots
+//! `i64` and comes back (`(c + i64::MAX) - i64::MAX`) stays exact.
+
+#![cfg(feature = "wasm")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_module(prefix: &str, source: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("{prefix}-{nanos}"));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let path = dir.join("main.av");
+    std::fs::write(&path, source).expect("write temp module source");
+    path
+}
+
+fn cleanup(path: &std::path::Path) {
+    let _ = std::fs::remove_dir_all(path.parent().expect("temp module has parent"));
+}
+
+/// Run `source` on the VM (`wasm_gc = false`) or wasm-gc (`true`).
+/// `no_carrier` sets `AVER_NO_CARRIER_I64=1` so the wasm-gc backend keeps
+/// the all-`$aint` carrier representation — the differential / revert-test
+/// baseline.
+fn run(prefix: &str, source: &str, wasm_gc: bool, no_carrier: bool) -> (bool, String) {
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = temp_module(prefix, source);
+    let mut cmd = Command::new(aver_bin);
+    cmd.current_dir(&repo_root).arg("run").arg(&path);
+    if wasm_gc {
+        cmd.arg("--wasm-gc");
+    }
+    if no_carrier {
+        cmd.env("AVER_NO_CARRIER_I64", "1");
+    }
+    let out = cmd.output().expect("aver run executes");
+    cleanup(&path);
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+    )
+}
+
+/// VM == wasm-gc (carrier-`i64` ON). Divergence ⇒ a carrier value wrapped or
+/// a boundary bridge dropped precision.
+fn assert_vm_wasm_identical(prefix: &str, source: &str) -> String {
+    let (vm_ok, vm_out) = run(prefix, source, false, false);
+    let (wg_ok, wg_out) = run(prefix, source, true, false);
+    assert!(vm_ok, "{prefix}: VM run failed:\n{vm_out}");
+    assert!(wg_ok, "{prefix}: wasm-gc run failed:\n{wg_out}");
+    assert_eq!(
+        vm_out, wg_out,
+        "{prefix}: VM-vs-wasm-gc DIVERGENCE — a carrier-i64 value wrapped or a \
+         boundary bridge lost precision where the VM kept the full $aint carrier.\n  \
+         VM     = {vm_out:?}\n  wasm-gc= {wg_out:?}"
+    );
+    vm_out
+}
+
+/// REVERT-TEST: the same program with the carrier path forced OFF
+/// (`AVER_NO_CARRIER_I64=1`, all-`$aint`) must still match the VM AND the
+/// carrier-`i64` output. Equal-both-ways proves the carrier erasure changed
+/// the REPRESENTATION, never the observable result — the soundness invariant.
+fn assert_carrier_revert_agrees(prefix: &str, source: &str, expected: &str) {
+    let (wg_off_ok, wg_off_out) = run(prefix, source, true, true);
+    assert!(
+        wg_off_ok,
+        "{prefix}: wasm-gc (carrier OFF) run failed:\n{wg_off_out}"
+    );
+    assert_eq!(
+        wg_off_out, expected,
+        "{prefix}: the all-$aint baseline diverged from the carrier-i64 output — \
+         the carrier erasure must be representation-only.\n  carrier-off = {wg_off_out:?}\n  \
+         expected    = {expected:?}"
+    );
+}
+
+/// Milestone 1 — a carrier as a FUNCTION SLOT (param + projection + smart-ctor
+/// Result boundary). `toInt`/`doubled` take `(param i64)`; `fromInt`'s Ok
+/// payload is `i64`. The full chain must equal the VM, and the revert-test
+/// (all-$aint) must agree.
+#[test]
+fn carrier_function_slot_matches_vm_and_reverts() {
+    let src = r#"module M
+    intent = "carrier-i64 function slot"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn toInt(c: IntRange) -> Int
+    c.value
+
+fn doubled(c: IntRange) -> Int
+    c.value + c.value
+
+fn main() -> Unit
+    ! [Console.print]
+    match fromInt(50)
+        Result.Ok(c)  -> Console.print("{toInt(c) + doubled(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-fn-slot", src);
+    assert_eq!(out, "150");
+    assert_carrier_revert_agrees("carrier-fn-slot", src, &out);
+}
+
+/// Bound EDGES (0, 100) and a TRANSIENT that overshoots `i64::MAX` and comes
+/// back. The transient must stay EXACT: the projected carrier is boxed to
+/// `$aint` before the arithmetic, so `(c + i64::MAX) - i64::MAX == c` at full
+/// precision (a raw-i64 add would wrap). This is the load-bearing soundness
+/// case for the project bridge.
+#[test]
+fn carrier_bound_edges_and_transient_overflow_match_vm() {
+    let src = r#"module M
+    intent = "carrier-i64 edges + transient"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn transient(c: IntRange) -> Int
+    (c.value + 9223372036854775807) - 9223372036854775807
+
+fn show(label: String, r: Result<IntRange, String>) -> Unit
+    ! [Console.print]
+    match r
+        Result.Ok(c)  -> Console.print("{label}:{transient(c)}")
+        Result.Err(e) -> Console.print("{label}:ERR")
+
+fn main() -> Unit
+    ! [Console.print]
+    show("0", fromInt(0))
+    show("100", fromInt(100))
+    show("50", fromInt(50))
+    show("neg", fromInt(0 - 1))
+"#;
+    let out = assert_vm_wasm_identical("carrier-edges", src);
+    assert_eq!(out, "0:0\n100:100\n50:50\nneg:ERR");
+    assert_carrier_revert_agrees("carrier-edges", src, &out);
+}
+
+/// Milestone 2 — a carrier as a STRUCT FIELD: `record Coord { x: IntRange,
+/// y: IntRange }` lowers to `(struct (field i64) (field i64))`. Build /
+/// update / read coords. VM == wasm-gc, and the revert-test (all-$aint)
+/// agrees. The build/update/read path is representation-only, so the
+/// all-$aint baseline produces the same result.
+#[test]
+fn carrier_struct_field_matches_vm_and_reverts() {
+    let src = r#"module M
+    intent = "carrier-i64 struct field"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+record Coord
+    x: IntRange
+    y: IntRange
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<IntRange, String>) -> IntRange
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> IntRange(value = 0)
+
+fn ir(n: Int) -> IntRange
+    unwrap(fromInt(n))
+
+fn toInt(c: IntRange) -> Int
+    c.value
+
+fn mkCoord(a: IntRange, b: IntRange) -> Coord
+    Coord(x = a, y = b)
+
+fn moveX(p: Coord, nx: IntRange) -> Coord
+    Coord(x = nx, y = p.y)
+
+fn sumCoord(p: Coord) -> Int
+    toInt(p.x) + toInt(p.y)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{sumCoord(moveX(mkCoord(ir(10), ir(20)), ir(99)))}")
+"#;
+    let out = assert_vm_wasm_identical("carrier-struct-field", src);
+    assert_eq!(out, "119");
+    assert_carrier_revert_agrees("carrier-struct-field", src, &out);
+}
+
+/// Carrier-FIELD EQUALITY: a `Coord` with two carrier-`i64` fields compared
+/// via `==` routes through a raw `i64.eq` per field. VM == wasm-gc.
+///
+/// NB: the revert-test is intentionally OMITTED here. The all-`$aint`
+/// baseline (`AVER_NO_CARRIER_I64=1`) for a record whose fields are
+/// newtype-erased Int carriers TRAPS on wasm-gc with a `cast failure` — a
+/// PRE-EXISTING bug in the boxed record-eq path (the pristine pre-carrier
+/// HEAD traps identically), independent of this slice. The carrier-`i64`
+/// path's raw `i64.eq` per field actually AVOIDS that trap, so the
+/// carrier-ON differential is correct where the boxed baseline is broken.
+#[test]
+fn carrier_struct_field_equality_matches_vm() {
+    let src = r#"module M
+    intent = "carrier-i64 struct field equality"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+record Coord
+    x: IntRange
+    y: IntRange
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<IntRange, String>) -> IntRange
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> IntRange(value = 0)
+
+fn ir(n: Int) -> IntRange
+    unwrap(fromInt(n))
+
+fn mkCoord(a: IntRange, b: IntRange) -> Coord
+    Coord(x = a, y = b)
+
+fn sameCoord(a: Coord, b: Coord) -> Bool
+    a == b
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{sameCoord(mkCoord(ir(1), ir(2)), mkCoord(ir(1), ir(2)))} {sameCoord(mkCoord(ir(1), ir(2)), mkCoord(ir(1), ir(3)))}")
+"#;
+    let out = assert_vm_wasm_identical("carrier-struct-field-eq", src);
+    assert_eq!(out, "true false");
+}
+
+/// Milestone 3 (build/read) — a carrier as a `Vector` element / `Map`
+/// value. `Vector<IntRange>` is `(array i64)`; `Map<String, IntRange>`
+/// stores i64 values. Build / read through `Vector.get` / `Map.get`
+/// (carrier payload unwrapped from the returned `Option<IntRange>`). VM ==
+/// wasm-gc.
+///
+/// NB: the revert-test is OMITTED. The all-`$aint` baseline for a
+/// `Vector<newtype-carrier>` / `Map<_, newtype-carrier>` fails wasm
+/// validation even for plain build/read — a PRE-EXISTING bug in the boxed
+/// container path (the pristine pre-carrier HEAD fails identically), which
+/// the carrier-`i64` erasure happens to fix.
+#[test]
+fn carrier_in_containers_build_read_matches_vm() {
+    let src = r#"module M
+    intent = "carrier-i64 build/read in Vector/Map"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<IntRange, String>) -> IntRange
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> IntRange(value = 0)
+
+fn ir(n: Int) -> IntRange
+    unwrap(fromInt(n))
+
+fn setAt(v: Vector<IntRange>, i: Int, x: IntRange) -> Vector<IntRange>
+    Option.withDefault(Vector.set(v, i, x), v)
+
+fn buildVec() -> Vector<IntRange>
+    setAt(setAt(Vector.new(2, ir(0)), 0, ir(10)), 1, ir(20))
+
+fn vecAt(v: Vector<IntRange>, i: Int) -> Int
+    match Vector.get(v, i)
+        Option.Some(c) -> c.value
+        Option.None    -> 0 - 1
+
+fn mkMap() -> Map<String, IntRange>
+    Map.fromList([("a", ir(42)), ("b", ir(7))])
+
+fn mapGet(m: Map<String, IntRange>, k: String) -> Int
+    match Map.get(m, k)
+        Option.Some(c) -> c.value
+        Option.None    -> 0 - 1
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{vecAt(buildVec(), 0) + vecAt(buildVec(), 1)} {mapGet(mkMap(), "a")} {mapGet(mkMap(), "z")}")
+"#;
+    let out = assert_vm_wasm_identical("carrier-containers", src);
+    assert_eq!(out, "30 42 -1");
+}
+
+/// Milestone 3 (eq/hash) — `List.contains`, list `==`, and `Map ==` over a
+/// carrier element/value, each dispatched as a raw `i64.eq` / `i32.wrap_i64`.
+/// VM == wasm-gc.
+///
+/// NB: the revert-test is OMITTED. The all-`$aint` baseline for a
+/// `List<newtype-carrier>` / `Map<_, newtype-carrier>` `==`/`contains` fails
+/// wasm validation — a PRE-EXISTING bug in the boxed container-eq path (the
+/// pristine pre-carrier HEAD fails identically), independent of this slice.
+/// The carrier-`i64` raw-element dispatch is correct where the boxed
+/// baseline is broken.
+#[test]
+fn carrier_in_containers_eq_matches_vm() {
+    let src = r#"module M
+    intent = "carrier-i64 container eq/contains"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<IntRange, String>) -> IntRange
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> IntRange(value = 0)
+
+fn ir(n: Int) -> IntRange
+    unwrap(fromInt(n))
+
+fn mkList() -> List<IntRange>
+    [ir(1), ir(2), ir(3)]
+
+fn mkMap() -> Map<String, IntRange>
+    Map.fromList([("a", ir(42)), ("b", ir(7))])
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{List.contains(mkList(), ir(2))} {List.contains(mkList(), ir(9))} {mkList() == mkList()} {mkMap() == mkMap()}")
+"#;
+    let out = assert_vm_wasm_identical("carrier-containers-eq", src);
+    assert_eq!(out, "true false true true");
+}
+
+/// Byte-identity guard: a NON-carrier program (no opaque-bounded carrier in
+/// scope) must compile to a wasm-gc module that is byte-for-byte the SAME
+/// with the carrier path on (default) and off (`AVER_NO_CARRIER_I64=1`) —
+/// the carrier path only fires for eligible opaque types, so it is inert
+/// for ordinary code.
+#[test]
+fn non_carrier_program_byte_identical_carrier_on_off() {
+    let src = r#"module M
+    intent = "non-carrier program — carrier path must be inert"
+    effects [Console]
+
+record Point
+    x: Int
+    y: Int
+
+fn mk(a: Int, b: Int) -> Point
+    Point(x = a, y = b)
+
+fn sum(p: Point) -> Int
+    p.x + p.y
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{sum(mk(3, 4))}")
+"#;
+    let on = compile_wasm_bytes("noncarrier-on", src, false);
+    let off = compile_wasm_bytes("noncarrier-off", src, true);
+    assert_eq!(
+        on, off,
+        "a non-carrier program must produce byte-identical wasm-gc with the carrier path \
+         on vs off — the carrier erasure leaked into ordinary code"
+    );
+}
+
+/// Compile `source` to a wasm-gc `.wasm` and return its bytes. `no_carrier`
+/// forces the all-`$aint` baseline via `AVER_NO_CARRIER_I64=1`.
+fn compile_wasm_bytes(prefix: &str, source: &str, no_carrier: bool) -> Vec<u8> {
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = temp_module(prefix, source);
+    let out_dir = path.parent().expect("temp module has parent").join("out");
+    let mut cmd = Command::new(aver_bin);
+    cmd.current_dir(&repo_root)
+        .arg("compile")
+        .arg(&path)
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("-o")
+        .arg(&out_dir);
+    if no_carrier {
+        cmd.env("AVER_NO_CARRIER_I64", "1");
+    }
+    let out = cmd.output().expect("aver compile executes");
+    assert!(
+        out.status.success(),
+        "{prefix}: wasm-gc compile failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // The emitted file is named after the source file (`main.wasm`).
+    let wasm = out_dir.join("main.wasm");
+    let bytes = std::fs::read(&wasm).expect("read compiled wasm");
+    cleanup(&path);
+    bytes
+}
+
+// ---------------------------------------------------------------------------
+// Eligibility-tightening (fail-closed) regressions.
+//
+// Two soundness/completeness holes in the carrier-`i64` feature, closed by
+// removing a carrier from the eligible set (⇒ it stays boxed) whenever a
+// whole-program scan trips:
+//
+//   * HOLE #1 — a BARE record constructor outside the smart-ctor with a
+//     non-literal (or out-of-bound) argument bypasses the gate; an
+//     i64-overflowing value then TRAPS on the wasm-gc construct bridge while
+//     the VM keeps full precision. The bare ctor demotes the carrier.
+//
+//   * HOLE #2 — a carrier used as a `Map` KEY (direct or transitive) fails
+//     wasm validation because the Map-key codegen was not updated for the
+//     i64-erased carrier. Map-key usage demotes the carrier.
+//
+// Each test pairs the FIX (default build: VM == wasm-gc, no trap / clean
+// compile) with a REVERT (`AVER_CARRIER_I64_SKIP_DEMOTION=1` restores the
+// un-tightened eligibility ⇒ the hole returns: a trap / a validation error).
+
+/// Run `source` on wasm-gc with the eligibility-tightening scan DISABLED
+/// (`AVER_CARRIER_I64_SKIP_DEMOTION=1`) — the revert baseline that restores
+/// the pre-fix (un-tightened) behavior so a regression test can show the hole
+/// returning. Returns `(success, combined stdout+stderr)` (the holes surface
+/// as a trap or a validation error on stderr).
+fn run_wasm_skip_demotion(prefix: &str, source: &str) -> (bool, String) {
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = temp_module(prefix, source);
+    let out = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("run")
+        .arg(&path)
+        .arg("--wasm-gc")
+        .env("AVER_CARRIER_I64_SKIP_DEMOTION", "1")
+        .output()
+        .expect("aver run executes");
+    cleanup(&path);
+    let mut combined = String::from_utf8_lossy(&out.stdout).to_string();
+    combined.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.success(), combined.trim().to_string())
+}
+
+/// Count `i64` tokens in the WAT disassembly of `source`'s wasm-gc output —
+/// a representation probe. More erased carriers ⇒ more `i64`. `skip_demotion`
+/// restores the un-tightened eligibility (every proven carrier erased).
+fn carrier_i64_token_count(prefix: &str, source: &str, skip_demotion: bool) -> usize {
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = temp_module(prefix, source);
+    let out_dir = path.parent().expect("temp module has parent").join("out");
+    let mut cmd = Command::new(aver_bin);
+    cmd.current_dir(&repo_root)
+        .arg("compile")
+        .arg(&path)
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("-o")
+        .arg(&out_dir);
+    if skip_demotion {
+        cmd.env("AVER_CARRIER_I64_SKIP_DEMOTION", "1");
+    }
+    let out = cmd.output().expect("aver compile executes");
+    assert!(
+        out.status.success(),
+        "{prefix}: wasm-gc compile failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let wat = wasm_tools_print(&out_dir.join("main.wasm"));
+    cleanup(&path);
+    wat.match_indices("i64").count()
+}
+
+/// Disassemble a wasm module to WAT via the `wasm-tools` CLI. Skips the test
+/// (returns the raw bytes hex'd to a non-matching string) if the tool is
+/// absent — the count-based assertion below tolerates that by comparing two
+/// counts produced the same way.
+fn wasm_tools_print(wasm: &std::path::Path) -> String {
+    match Command::new("wasm-tools").arg("print").arg(wasm).output() {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
+        _ => String::new(),
+    }
+}
+
+/// HOLE #1 regression — the bare-constructor bypass (`mk(n) = IntRange(value
+/// = n)` with `n` unbounded, fed an i64-overflowing value). The ungated bare
+/// ctor demotes `IntRange` to boxed, so the wasm-gc result matches the VM's
+/// full-precision value with NO trap. The revert (scan disabled) keeps
+/// `IntRange` as i64 and the construct bridge `__aint_to_i64_checked` TRAPS.
+#[test]
+fn bare_construct_bypass_demotes_to_boxed() {
+    let src = r#"module M
+    intent = "carrier bypass via bare ctor beyond i64"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn mk(n: Int) -> IntRange
+    IntRange(value = n)
+
+fn toInt(c: IntRange) -> Int
+    c.value
+
+fn big() -> Int
+    4000000000 * 4000000000
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{toInt(mk(big()))}")
+"#;
+    // FIX: demoted to boxed ⇒ VM == wasm-gc, full precision, no trap.
+    let out = assert_vm_wasm_identical("bare-bypass", src);
+    assert_eq!(out, "16000000000000000000");
+
+    // REVERT: scan disabled ⇒ IntRange stays i64 ⇒ the construct bridge traps.
+    let (ok, msg) = run_wasm_skip_demotion("bare-bypass-revert", src);
+    assert!(
+        !ok,
+        "revert: with the ungated-construct scan disabled the bare-ctor bypass \
+         must TRAP on wasm-gc (the hole returns), but the run succeeded with:\n{msg}"
+    );
+    assert!(
+        msg.contains("trap") || msg.contains("unreachable"),
+        "revert: expected a wasm trap (the __aint_to_i64_checked bridge firing on \
+         the overflowing bare value), got:\n{msg}"
+    );
+}
+
+/// HOLE #2 regression — a carrier used as a `Map` KEY. The Map-key scan
+/// demotes `IntRange` to boxed, so the program compiles to wasm-gc via the
+/// boxed key path and matches the VM. The revert (scan disabled) keeps
+/// `IntRange` as i64 in the key position and wasm VALIDATION fails.
+#[test]
+fn carrier_as_map_key_demotes_to_boxed() {
+    let src = r#"module M
+    intent = "carrier as Map KEY"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<IntRange, String>) -> IntRange
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> IntRange(value = 0)
+
+fn ir(n: Int) -> IntRange
+    unwrap(fromInt(n))
+
+fn mkMap() -> Map<IntRange, String>
+    Map.fromList([(ir(5), "five"), (ir(7), "seven")])
+
+fn lookup(m: Map<IntRange, String>, k: IntRange) -> String
+    match Map.get(m, k)
+        Option.Some(v) -> v
+        Option.None    -> "MISS"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{lookup(mkMap(), ir(5))} {lookup(mkMap(), ir(7))} {lookup(mkMap(), ir(9))}")
+"#;
+    // FIX: demoted to boxed key ⇒ compiles clean AND VM == wasm-gc.
+    let out = assert_vm_wasm_identical("mapkey", src);
+    assert_eq!(out, "five seven MISS");
+
+    // REVERT: scan disabled ⇒ i64-erased Map KEY ⇒ wasm validation fails.
+    let (ok, msg) = run_wasm_skip_demotion("mapkey-revert", src);
+    assert!(
+        !ok,
+        "revert: with the Map-key scan disabled an i64-erased carrier KEY must \
+         fail wasm validation (the hole returns), but the run succeeded:\n{msg}"
+    );
+    assert!(
+        msg.contains("validation failed") || msg.contains("type mismatch"),
+        "revert: expected a wasm validation / type-mismatch error from the \
+         i64-erased Map key, got:\n{msg}"
+    );
+}
+
+/// HOLE #2 (completeness) — a carrier used as a `Map` KEY through a LOCAL
+/// BINDING annotation (`m: Map<IntRange, Int> = …`). The original Map-key scan
+/// only walked fn-param / fn-return / record-field annotation strings, so a
+/// binding-level `Map<…>` annotation was MISSED and the carrier wrongly stayed
+/// i64 → wasm validation failure on a VM-valid program. The resolved-IR scan
+/// (typed-MIR `Map<K, V>` instantiations) sees this Map and demotes the key.
+#[test]
+fn carrier_as_map_key_via_local_binding_demotes_to_boxed() {
+    let src = r#"module M
+    intent = "carrier as Map KEY via local binding annotation"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn use(c: IntRange) -> Int
+    m: Map<IntRange, Int> = Map.set({}, c, 5)
+    Option.withDefault(Map.get(m, c), 0)
+
+fn main() -> Unit
+    ! [Console.print]
+    match fromInt(7)
+        Result.Ok(c)  -> Console.print("{use(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    // FIX: the binding-annotated Map key demotes ⇒ boxed key path ⇒ compiles
+    // clean AND VM == wasm-gc.
+    let out = assert_vm_wasm_identical("mapkey-localbind", src);
+    assert_eq!(out, "5");
+
+    // REVERT: scan disabled ⇒ i64-erased Map KEY ⇒ wasm validation fails.
+    let (ok, msg) = run_wasm_skip_demotion("mapkey-localbind-revert", src);
+    assert!(
+        !ok,
+        "revert: with demotion disabled the i64-erased carrier KEY (local-binding \
+         annotation) must fail wasm validation, but the run succeeded:\n{msg}"
+    );
+    assert!(
+        msg.contains("validation failed") || msg.contains("type mismatch"),
+        "revert: expected a wasm validation / type-mismatch error from the \
+         i64-erased Map key, got:\n{msg}"
+    );
+}
+
+/// HOLE #2 (completeness) — a carrier used as a `Map` KEY reached ONLY through
+/// INFERENCE: `m = Map.set({}, c, 5)` with NO annotation anywhere. A textual
+/// annotation scan fundamentally cannot see this key type; the resolved typed
+/// MIR carries it. The resolved-IR scan demotes the key.
+#[test]
+fn carrier_as_map_key_fully_inferred_demotes_to_boxed() {
+    let src = r#"module M
+    intent = "carrier as Map KEY, fully inferred (no annotation)"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn use(c: IntRange) -> Int
+    m = Map.set({}, c, 5)
+    Option.withDefault(Map.get(m, c), 0)
+
+fn main() -> Unit
+    ! [Console.print]
+    match fromInt(7)
+        Result.Ok(c)  -> Console.print("{use(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    // FIX: the inferred Map key demotes ⇒ boxed key path ⇒ compiles clean AND
+    // VM == wasm-gc.
+    let out = assert_vm_wasm_identical("mapkey-inferred", src);
+    assert_eq!(out, "5");
+
+    // REVERT: scan disabled ⇒ i64-erased inferred Map KEY ⇒ wasm validation fails.
+    let (ok, msg) = run_wasm_skip_demotion("mapkey-inferred-revert", src);
+    assert!(
+        !ok,
+        "revert: with demotion disabled the i64-erased carrier KEY (fully inferred) \
+         must fail wasm validation, but the run succeeded:\n{msg}"
+    );
+    assert!(
+        msg.contains("validation failed") || msg.contains("type mismatch"),
+        "revert: expected a wasm validation / type-mismatch error from the \
+         i64-erased Map key, got:\n{msg}"
+    );
+}
+
+/// No-over-boxing CONTROL for the inferred-key fix — the SAME inference shape
+/// (`m = Map.set(…)`, no annotation) but the carrier sits in the Map VALUE
+/// position, not the key. A Map VALUE carrier is i64-supported, so it must
+/// STAY eligible: demoting it would be over-boxing. The `i64` footprint with
+/// demotion ON must EQUAL the footprint with demotion disabled — proof the
+/// resolved-IR scan demotes KEYS only, never values.
+#[test]
+fn carrier_as_inferred_map_value_stays_i64() {
+    let src = r#"module M
+    intent = "carrier as Map VALUE, fully inferred — must stay i64"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn use(c: IntRange) -> Int
+    m = Map.set({}, "k", c)
+    match Map.get(m, "k")
+        Option.Some(v) -> v.value
+        Option.None    -> 0
+
+fn main() -> Unit
+    ! [Console.print]
+    match fromInt(7)
+        Result.Ok(c)  -> Console.print("{use(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    // Behaviour: VM == wasm-gc (the value-carrier path is sound either way).
+    let out = assert_vm_wasm_identical("mapvalue-inferred", src);
+    assert_eq!(out, "7");
+
+    // Representation: demotion-ON must EQUAL demotion-disabled. If the scan
+    // over-reached and demoted the VALUE carrier, the i64 footprint would
+    // SHRINK below the un-tightened build.
+    let with_skip = carrier_i64_token_count("mapvalue-skip", src, true);
+    let default = carrier_i64_token_count("mapvalue-def", src, false);
+    if with_skip > 0 {
+        assert_eq!(
+            default, with_skip,
+            "over-boxing: a carrier used as a Map VALUE (not key) must STAY i64 — \
+             default={default}, skip-demotion={with_skip}. A smaller default count \
+             would mean the resolved-IR Map-key scan wrongly demoted a VALUE carrier."
+        );
+    }
+}
+
+/// Per-type granularity — a program with TWO carriers: `Tainted` is bare-
+/// constructed with an unbounded arg (⇒ demoted, boxed) while `Clean` is only
+/// ever smart-constructed (⇒ eligible, i64). The scan is per-type, not
+/// all-or-nothing: the default build's `i64` footprint sits STRICTLY between
+/// "both boxed" and "both i64", proving exactly one carrier was demoted.
+#[test]
+fn mixed_program_demotes_per_type() {
+    let src = r#"module M
+    intent = "two carriers: one bare-bypassed (boxed), one clean (i64)"
+    effects [Console]
+
+record Tainted
+    value: Int
+
+record Clean
+    value: Int
+
+fn fromTainted(n: Int) -> Result<Tainted, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(Tainted(value = n))
+        false -> Result.Err("oob")
+
+fn fromClean(n: Int) -> Result<Clean, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(Clean(value = n))
+        false -> Result.Err("oob")
+
+fn bareTainted(n: Int) -> Tainted
+    Tainted(value = n)
+
+fn unwrapC(r: Result<Clean, String>) -> Clean
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Clean(value = 0)
+
+fn tInt(c: Tainted) -> Int
+    c.value
+
+fn cInt(c: Clean) -> Int
+    c.value
+
+fn bigTainted() -> Int
+    tInt(bareTainted(4000000000 * 4000000000))
+
+fn cleanVal() -> Int
+    cInt(unwrapC(fromClean(50)))
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{bigTainted()} {cleanVal()}")
+"#;
+    // Behavior: Tainted boxed (full precision, no trap), Clean correct.
+    let out = assert_vm_wasm_identical("mixed", src);
+    assert_eq!(out, "16000000000000000000 50");
+
+    // Representation: per-type proof. `default` (Tainted boxed, Clean i64)
+    // must sit STRICTLY between `skip` (both i64) and the floor. If the scan
+    // were all-or-nothing, `default` would equal `skip`.
+    let with_skip = carrier_i64_token_count("mixed-skip", src, true);
+    let default = carrier_i64_token_count("mixed-def", src, false);
+    // `wasm-tools` absent ⇒ both counts are 0; the assertion below is then
+    // vacuously skipped (0 < 0 is false, so we only assert when we have data).
+    if with_skip > 0 {
+        assert!(
+            default < with_skip,
+            "per-type: demoting only `Tainted` must lower the i64 footprint below \
+             the both-eligible build — default={default}, skip-demotion={with_skip}. \
+             Equal counts would mean the scan boxed BOTH carriers (all-or-nothing)."
+        );
+    }
+}


### PR DESCRIPTION
## What

A user record that `exposes opaque` and is constructed only through a smart
constructor whose bound proves the carried `Int` fits `i64` now erases to a
native `i64` on the wasm-gc backend — in function slots, record fields,
`Option`/`Result` payloads, and `Vector`/`List`/`Map` elements — instead of
the boxed arbitrary-precision `Int`. The win is **memory**: an inline `i64`
in place of a heap-allocated `Int` object.

(This is the memory win, not a `.wasm` size win — the bignum prelude still
ships; reaching the lean `i64` formatter so the prelude drops is a separate
follow-up.)

## Soundness

Only carriers whose smart-constructor invariant is recognized **and** proves
the value fits `i64` are eligible. A fail-closed whole-program scan then
demotes (keeps boxed) any such carrier that could hold an out-of-range value
or reaches codegen the erasure doesn't support yet:

- **Ungated construction** — a bare constructor called outside the smart
  constructor bypasses the bound; demoted unless the field is a constant
  literal proven in range.
- **Map key** — directly, or transitively through a record/`Option`/`List`/
  `Tuple` field; the i64-erased key path isn't wired yet. Detection reads the
  typed MIR's resolved `Map<K,V>` instantiations, so it catches keys whose
  type is only known after inference (local-binding annotations and fully
  inferred maps), not just textual annotations. Map **values** stay eligible.

Either trip can only ever shrink the eligible set, never widen it.

## Tests

- `tests/wasm_gc_carrier_i64_differential.rs` (13): VM-vs-wasm-gc agreement at
  the bound edges, ungated-construction demotion, Map-key demotion via
  annotation / local-binding / full inference, Map-value-stays-i64 control,
  revert-tests (`AVER_CARRIER_I64_SKIP_DEMOTION` shows the hole returning),
  and byte-identity of non-carrier programs.
- cross-backend proptest 16/16 + stress 22/22, wasip2 `pool_wraparound`
  (effectful path), full default suite 0 failed, clippy clean on lib + `aver`
  bin (default and `wasm,wasip2`), `fmt --check` clean.

## Out of scope / parked

Pre-existing wasm-gc codegen gaps (measured on the base commit, VM = ground
truth), tracked in `docs/wasm-gc-known-issues.md`, **not** introduced here:
RecordUpdate on a single-field record fails wasm-gc validation
(`emit_mir_record_update` lacks the newtype short-circuit
`emit_mir_record_create` has) — a carrier used in a non-constant RecordUpdate
is already demoted to boxed, so this is not a carrier soundness hole;
`match` on a `Unit` subject traps; empty `{}` with more than one `Map`
instantiation fails to resolve; `Float.round` uses ties-to-even vs the VM's
ties-away; `String.fromFloat` traps for `|f| >= 2^63`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
