### PR TITLE
wasm-gc: run native i64 arithmetic on provably-bounded carrier values

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -558,6 +558,18 @@ impl<'a> EmitCtx<'a> {
         self.repr.slot_is_bare(crate::ir::mir::LocalId(slot))
     }
 
+    /// ETAP-2 carrier-`i64`: does wasm local `slot` hold a BARE carrier whose
+    /// `.value` projection reads a raw native `i64` (the registry already
+    /// erased the carrier storage to i64, and the `bare_i64` analysis proved
+    /// the read flows only into native arithmetic / a raw return)? When set,
+    /// the `Project` emit SKIPS the `$AverInt` project bridge and yields the
+    /// i64 directly. Default `false` for slots outside the rewritten repr —
+    /// fail-closed (the project bridge runs, the `.value` lifts to `$AverInt`).
+    pub(super) fn slot_is_bare_carrier(&self, slot: u32) -> bool {
+        self.repr
+            .slot_is_bare_carrier(crate::ir::mir::LocalId(slot))
+    }
+
     /// ETAP-2 SLICE 2b: is param index `i` of the CALLEE `target` bare?
     /// Read from the callee's `MirFn::repr` (every fn's repr lives on the
     /// rewritten program). Default `false` (boxed) when the program is

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -1038,11 +1038,29 @@ pub(crate) fn emit_mir_expr(
             let record_name = aver_type_str_of(&proj.base);
             if ctx.registry.newtype_underlying(&record_name).is_some() {
                 // ETAP-2 carrier-`i64`: an eligible carrier's field read is
-                // still identity (emit the base), but the base is now a
-                // native `i64` and the projected `.value` is a plain `Int`,
-                // so lift it back into the `$AverInt` carrier.
+                // still identity (emit the base, which is a native `i64`).
+                //
+                // The default reads `.value` as a plain `Int`, so the i64 is
+                // lifted back into the `$AverInt` carrier via the project
+                // bridge. BUT when the base is a BARE carrier slot
+                // (`slot_is_bare_carrier`), the `bare_i64` rewrite proved the
+                // `.value` read flows ONLY into native i64 arithmetic / a raw
+                // return — and it left the surrounding context raw (or wrapped
+                // the read in an explicit `Box` where a boxed value is wanted).
+                // So in that case we SKIP the bridge and yield the raw i64; the
+                // `Box` node (if any) does the lift. This is the whole
+                // carrier-arithmetic size lever: `c.value + c.value` runs as a
+                // native `i64.add` instead of two `__aint_from_i64` lifts plus
+                // a boxed limb-add.
                 let produced = emit_mir_expr(func, &proj.base, slots, ctx)?;
-                if produced.is_some() && ctx.registry.is_eligible_carrier(&record_name) {
+                let bare_carrier_read = matches!(
+                    &proj.base.node,
+                    MirExpr::Local(local) if ctx.slot_is_bare_carrier(local.node.slot.0)
+                );
+                if produced.is_some()
+                    && ctx.registry.is_eligible_carrier(&record_name)
+                    && !bare_carrier_read
+                {
                     emit_carrier_project_bridge(func, ctx)?;
                 }
                 return Ok(produced.map(|_| aver_type_str_of(expr).trim() != "Unit"));
@@ -1260,6 +1278,9 @@ pub(crate) fn mir_renders_raw_i64(e: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
     match e {
         MirExpr::Local(local) => ctx.slot_is_bare(local.node.slot.0),
         MirExpr::Unbox(_) => true,
+        // ETAP-2 carrier-`i64`: a bare carrier's `.value` read is a genuine
+        // raw i64 (the project bridge is skipped), like an `Unbox`.
+        MirExpr::Project(_) => mir_is_bare_carrier_project(e, ctx),
         MirExpr::Box(_) => false,
         // A standalone `Int` literal is raw-COMPATIBLE (it can lower to an
         // `i64.const`), but on its own it is NOT proof of a raw context — its
@@ -1301,6 +1322,8 @@ fn mir_arith_leaves_raw_compatible(e: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
     match e {
         MirExpr::Local(local) => ctx.slot_is_bare(local.node.slot.0),
         MirExpr::Unbox(_) => true,
+        // ETAP-2 carrier-`i64`: a bare carrier's `.value` is a raw i64 leaf.
+        MirExpr::Project(_) => mir_is_bare_carrier_project(e, ctx),
         MirExpr::Literal(l) => matches!(l.node, Literal::Int(_)),
         MirExpr::Neg(inner) => mir_arith_leaves_raw_compatible(&inner.node, ctx),
         MirExpr::BinOp(b) => {
@@ -1312,6 +1335,20 @@ fn mir_arith_leaves_raw_compatible(e: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
     }
 }
 
+/// ETAP-2 carrier-`i64`: is `e` a `Project(Local(bare_carrier_slot), _)`?
+/// Such a `.value` read renders as a raw native `i64` (the project bridge is
+/// skipped) — a genuine raw anchor like an `Unbox`.
+fn mir_is_bare_carrier_project(e: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
+    matches!(
+        e,
+        MirExpr::Project(p)
+            if matches!(
+                &p.node.base.node,
+                MirExpr::Local(local) if ctx.slot_is_bare_carrier(local.node.slot.0)
+            )
+    )
+}
+
 /// The `Add`/`Sub`/`Mul`/`Neg` tree `e` contains at least one genuine raw
 /// VALUE (a bare `Local` or an `Unbox`) — not just literals. This anchors
 /// the tree to a bare slot's computation; a pure-literal tree has no anchor.
@@ -1319,6 +1356,9 @@ fn mir_has_raw_anchor(e: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
     match e {
         MirExpr::Local(local) => ctx.slot_is_bare(local.node.slot.0),
         MirExpr::Unbox(_) => true,
+        // ETAP-2 carrier-`i64`: a bare carrier's `.value` read is a genuine
+        // raw anchor (a real i64 value, not a literal).
+        MirExpr::Project(_) => mir_is_bare_carrier_project(e, ctx),
         MirExpr::Neg(inner) => mir_has_raw_anchor(&inner.node, ctx),
         MirExpr::BinOp(b) => {
             mir_has_raw_anchor(&b.node.lhs.node, ctx) || mir_has_raw_anchor(&b.node.rhs.node, ctx)
@@ -1438,6 +1478,24 @@ pub(crate) fn emit_mir_int_raw(
         // it; no result colour needed (the i64 comes from the callee sig).
         MirExpr::Unbox(_) | MirExpr::Call(_) | MirExpr::TailCall(_) => {
             emit_mir_expr(func, e, slots, ctx)
+        }
+        // ETAP-2 carrier-`i64`: a `Project(Local(bare_carrier), "value")`
+        // reads the carrier's native i64 — the main emitter's `Project` arm
+        // skips the project bridge for a bare carrier slot, leaving the raw
+        // i64 on the stack. A non-bare-carrier `Project` reaching here would
+        // push an `$AverInt` (project bridge) where an i64 is expected, so
+        // guard: only delegate when the base is a bare carrier slot, else
+        // fall back (`Ok(None)`) — fail-closed.
+        MirExpr::Project(p) => {
+            let bare_carrier = matches!(
+                &p.node.base.node,
+                MirExpr::Local(local) if ctx.slot_is_bare_carrier(local.node.slot.0)
+            );
+            if bare_carrier {
+                emit_mir_expr(func, e, slots, ctx)
+            } else {
+                Ok(None)
+            }
         }
         // A `Match` / `IfThenElse` / `Let` / `Return` whose tail is the raw
         // value: delegate to the main emitter WITH the raw result colour set,

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -266,6 +266,20 @@ pub(super) fn emit_module_with(
                 proven.difference(&demoted).cloned().collect()
             }
         };
+    // ETAP-2 carrier-`i64`: the per-slot raw-i64 carrier ARITHMETIC path (the
+    // `bare_i64` analysis + rewrite) must key off the SAME carrier set the
+    // registry's STORAGE erasure uses — `eligible_carriers`, i.e. the proven
+    // bound MINUS the fail-closed demotions (Map-key / bare-ctor) AND empty
+    // under `AVER_NO_CARRIER_I64=1`. Otherwise the analysis would flag a
+    // `.value` read raw (skip the project bridge) for a carrier the registry
+    // kept as `$AverInt` storage — reading an i64 from an `$AverInt` slot,
+    // a wasm validation error. So restrict the carrier table to the eligible
+    // names before threading it into the rewrite.
+    let bare_carrier_intervals: crate::ir::mir::bare_i64::CarrierIntervals = carrier_intervals
+        .iter()
+        .filter(|(name, _)| eligible_carriers.contains(name.as_str()))
+        .map(|(name, iv)| (name.clone(), *iv))
+        .collect();
     registry.set_eligible_carriers(eligible_carriers);
 
     let mir_program: crate::ir::mir::MirProgram = {
@@ -288,16 +302,16 @@ pub(super) fn emit_module_with(
         // fragment never goes bare.
         let boxed =
             crate::ir::mir::optimize::bare_i64_rewrite::mutual_recursion_box_set(&optimized);
-        // The per-carrier-type bound (`carrier_intervals`, hoisted above)
-        // also seeds the MIR rewrite's optional per-slot raw-i64 path. That
-        // path is gated OFF in this slice (`CARRIER_BARE_ELIGIBLE == false`),
-        // so it is inert here; the carrier-`i64` size lever lives entirely in
-        // the registry's `eligible_carriers` set + the construct / project
-        // box-bridges.
+        // The eligible-carrier bound (`bare_carrier_intervals`) seeds the MIR
+        // rewrite's per-slot raw-i64 carrier path (`CARRIER_BARE_ELIGIBLE ==
+        // true`): a bare carrier's `.value` reads native i64 and arithmetic
+        // over it runs as `i64.add/sub/mul` where the interval fixpoint proves
+        // the result fits i64. Restricted to the registry's eligible set above,
+        // so the analysis never goes raw for a carrier the storage kept boxed.
         crate::ir::mir::optimize::bare_i64_rewrite::rewrite_for_wasm_gc(
             optimized,
             &boxed,
-            &carrier_intervals,
+            &bare_carrier_intervals,
         )
     };
 

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -86,7 +86,7 @@ pub type CarrierIntervals = HashMap<String, (Interval, bool)>;
 /// integration below are all LIVE and tested; flipping this `const` to
 /// `true` (after the body-emit bridge lands) turns the slice on with no
 /// other change to this file.
-const CARRIER_BARE_ELIGIBLE: bool = false;
+const CARRIER_BARE_ELIGIBLE: bool = true;
 
 fn carrier_interval(ty: &str, carrier: &CarrierIntervals) -> Option<Interval> {
     if !CARRIER_BARE_ELIGIBLE {
@@ -171,6 +171,16 @@ pub struct FnBareFacts {
     pub bare_params: Vec<bool>,
     /// `true` ⟺ the fn's return type is emitted as a bare `i64`.
     pub bare_return: bool,
+    /// ETAP-2 carrier-`i64` (wasm-gc only): slots holding a bare carrier
+    /// value (an eligible refinement-via-opaque carrier whose wasm storage IS
+    /// a native `i64`) mapped to the carrier's PROVEN `fits_i64` interval.
+    /// A `Project(Local(slot), "value")` over such a slot reads the i64
+    /// directly (no `$AverInt` project bridge) and contributes the carrier's
+    /// interval to the surrounding arithmetic, so `c.value + c.value` over a
+    /// `[0,100]` carrier stays in the OverflowFree band. EMPTY on the Rust
+    /// backend (it keeps the carrier struct) and whenever no eligible carrier
+    /// is in scope — the byte-identical default.
+    pub carrier_slots: HashMap<LocalId, Interval>,
 }
 
 impl FnBareFacts {
@@ -193,6 +203,29 @@ impl FnBareFacts {
             return None;
         }
         fact.interval
+    }
+
+    /// ETAP-2 carrier-`i64`: the proven interval of a `Project(Local(slot),
+    /// _)` whose base `slot` holds a BARE carrier (wasm storage IS i64). The
+    /// `.value` read is a native i64 carrying the carrier's smart-constructor
+    /// bound, so it is a bare leaf for the surrounding arithmetic. `None` for
+    /// any non-carrier base — the conservative decline (boxed `$AverInt`
+    /// project bridge).
+    pub fn carrier_project_interval(&self, e: &MirExpr) -> Option<Interval> {
+        let MirExpr::Project(p) = e else {
+            return None;
+        };
+        let MirExpr::Local(local) = &p.node.base.node else {
+            return None;
+        };
+        self.carrier_slots.get(&local.node.slot).copied()
+    }
+
+    /// ETAP-2 carrier-`i64`: does `e` read a bare carrier's i64 `.value`
+    /// (`Project(Local(bare_carrier_slot), _)`)? Such a read renders raw i64
+    /// on wasm-gc (the project bridge is skipped), so it is a bare leaf.
+    pub fn is_carrier_project(&self, e: &MirExpr) -> bool {
+        self.carrier_project_interval(e).is_some()
     }
 
     /// Compute the result interval of an EXPRESSION TREE built only from
@@ -221,6 +254,9 @@ impl FnBareFacts {
                 _ => None,
             },
             MirExpr::Local(local) => self.bare_slot_interval(local.node.slot),
+            // ETAP-2 carrier-`i64`: a bare carrier's `.value` is a native i64
+            // leaf carrying the carrier's proven bound.
+            MirExpr::Project(_) => self.carrier_project_interval(e),
             MirExpr::Neg(inner) => {
                 let r = Interval::point(0).sub(self.bare_expr_interval(&inner.node)?);
                 r.fits_i64().then_some(r)
@@ -258,6 +294,8 @@ impl FnBareFacts {
             // `{N}i64` constant on a bare path the analysis already gated).
             MirExpr::Literal(l) => matches!(l.node, Literal::Int(_)),
             MirExpr::Local(local) => self.is_bare(local.node.slot),
+            // ETAP-2 carrier-`i64`: a bare carrier's `.value` reads raw i64.
+            MirExpr::Project(_) => self.is_carrier_project(e),
             // A compound: require the WHOLE-TREE result interval to fit i64.
             MirExpr::Neg(_) | MirExpr::BinOp(_) => self.bare_expr_interval(e).is_some_and(|iv| {
                 raw_i64_eligible(Some(iv), std::iter::once(&OpClass::OverflowFree))
@@ -1150,7 +1188,11 @@ fn caller_env(f: &MirFn, cells: &[Interval], floors: &[Interval]) -> HashMap<Loc
 /// intermediate widens the counter out of `i64` ⇒ `!fits_i64` ⇒ boxed.
 fn eval_interval_pub(e: &MirExpr, env: &HashMap<LocalId, Interval>) -> Interval {
     let mut worst = Interval::point(0);
-    let iv = eval_interval(e, env, &mut worst);
+    // The recurrence back-edge args are `counter - step` over Int counters; a
+    // carrier `.value` projection never appears here, so the carrier-slot map
+    // is empty (a `Project` evaluates to `unbounded()`, the safe decline).
+    let no_carriers: HashMap<LocalId, Interval> = HashMap::new();
+    let iv = eval_interval(e, env, &mut worst, &no_carriers);
     worst.hull(iv)
 }
 
@@ -1619,30 +1661,44 @@ fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBar
     //    falls back to the full-`i64` line (still sound — bare ⟹ confined to
     //    `i64` by construction); a boxed param is unbounded.
     //
-    //    ETAP-2 SLICE 0+1 — carrier params. A param whose annotated type is a
-    //    refinement-via-opaque carrier (`carrier_interval(&p.ty, carrier)` is
-    //    `Some`) is bare-eligible from its PROVEN smart-constructor bound,
-    //    INDEPENDENT of the recurrence rule that drives `summary.param_bare`
-    //    (a carrier param isn't Int-typed, so the cross-frame summary never
-    //    flags it). The carrier bound is sound by construction: the type is
-    //    opaque + the only constructor is the guarded smart constructor, so
-    //    every inhabitant provably lies in the interval. The eligibility is
-    //    not final here — the combine (step 4) still gates on `!escapes`, and
-    //    the signature `bare_params[i]` is set FROM that combine result below
-    //    (so a carrier stored into a record / Map / stringified — i.e. one
-    //    that escapes — keeps a boxed signature, the slice-2 boundary).
+    //    ETAP-2 carrier-`i64` — carrier params (wasm-gc only). A param whose
+    //    annotated type is a refinement-via-opaque carrier
+    //    (`carrier_interval(&p.ty, carrier)` is `Some`) has its wasm storage
+    //    ALREADY erased to a native `i64` (the registry's `eligible_carriers`
+    //    set, applied uniformly by `aver_to_wasm`), INDEPENDENT of this Int-
+    //    bareness analysis. So a carrier param is NOT an Int-bare slot — the
+    //    value `c` is the carrier (a record), never a raw Int operand — and we
+    //    deliberately do NOT mark it `bare_params` / `Repr::Bare`: a carrier
+    //    value flows to a carrier param with NO conversion (both are i64), so
+    //    flagging it bare would make the call site spuriously `Unbox` the i64.
+    //    What the carrier param DOES enable is a raw `.value` read: a
+    //    `Project(Local(carrier_slot), "value")` reads the i64 directly (no
+    //    `$AverInt` project bridge) and contributes the carrier's PROVEN bound
+    //    to the surrounding arithmetic. We record that bound in `carrier_slots`
+    //    so `bare_expr_interval` / `expr_is_bare_i64` treat the `.value` read
+    //    as a bare leaf — `c.value + c.value` over a `[0,100]` carrier then
+    //    stays OverflowFree, while `c.value * c.value` over a `[0,2^40]`
+    //    carrier overflows i64 and the compound declines (boxed) — the C0
+    //    soundness gate is the SAME interval fixpoint, just with a carrier-
+    //    projection leaf source. The bound is sound by construction: the type
+    //    is opaque + the only constructor is the guarded smart constructor, so
+    //    every inhabitant provably lies in the interval.
     let mut intervals: HashMap<LocalId, Interval> = HashMap::new();
     let mut bare_params = vec![false; f.params.len()];
-    let mut carrier_params = vec![false; f.params.len()];
+    let mut carrier_slots: HashMap<LocalId, Interval> = HashMap::new();
     for (i, p) in f.params.iter().enumerate() {
         let recurrence_bare = summary.param_bare(f.fn_id, i);
-        let carrier_iv = carrier_interval(&p.ty, carrier);
-        carrier_params[i] = carrier_iv.is_some();
         bare_params[i] = recurrence_bare;
-        let iv = if let Some(cv) = carrier_iv {
-            // Carrier param: seed from its proven (fits_i64) bound.
-            cv
-        } else if recurrence_bare {
+        if let Some(cv) = carrier_interval(&p.ty, carrier) {
+            // Carrier param: its `.value` reads raw i64 with this proven bound.
+            // The param value `c` itself stays a (boxed/struct) carrier slot —
+            // not an Int-bare slot — so its `intervals` entry is unbounded
+            // (it is never an arithmetic operand directly).
+            carrier_slots.insert(p.local, cv);
+            intervals.insert(p.local, Interval::unbounded());
+            continue;
+        }
+        let iv = if recurrence_bare {
             summary
                 .param_interval(f.fn_id, i)
                 .filter(|iv| iv.fits_i64())
@@ -1652,11 +1708,21 @@ fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBar
         };
         intervals.insert(p.local, iv);
     }
+    // Record the carrier-projection facts on the result so the rewrite + emit
+    // can recognize a bare carrier's `.value` read. (Set before the combine so
+    // `tail_value_is_bare` / `expr_is_bare_i64` see them via `&facts`.)
+    facts.carrier_slots = carrier_slots;
 
     // 2. Walk the body's `Let` chain, deriving an interval (+ worst-join
-    //    op class) for each bound slot.
+    //    op class) for each bound slot. The carrier-projection facts let the
+    //    walk read a bare carrier's `.value` as its proven i64 interval.
     let mut op_classes: HashMap<LocalId, OpClass> = HashMap::new();
-    walk_let_chain(&f.body.node, &mut intervals, &mut op_classes);
+    walk_let_chain(
+        &f.body.node,
+        &mut intervals,
+        &mut op_classes,
+        &facts.carrier_slots,
+    );
 
     // 3. Escape: a single use-flow scan. A slot escapes if any use-site is
     //    a general-Int context.
@@ -1689,11 +1755,12 @@ fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBar
     // Params absent from the Let walk still get a fact (their seed). Every
     // param is in `intervals`, so the combine above already inserted its
     // value fact — this `or_insert_with` is a backstop for any param the
-    // combine somehow skipped. A carrier param is bare iff its proven bound
-    // made it eligible (it was seeded into `intervals`, so the combine
-    // covered it); the recurrence path keeps its `summary` seed.
+    // combine somehow skipped. The recurrence path keeps its `summary` seed;
+    // a carrier param is NOT Int-bare (its `intervals` entry is unbounded), so
+    // the backstop boxes it — the value `c` is a carrier slot, only its
+    // `.value` read goes raw (via `carrier_slots`).
     for (i, p) in f.params.iter().enumerate() {
-        let seeded_bare = summary.param_bare(f.fn_id, i) || carrier_params[i];
+        let seeded_bare = summary.param_bare(f.fn_id, i);
         facts.values.entry(p.local).or_insert_with(|| {
             if seeded_bare {
                 ValueFact {
@@ -1707,21 +1774,6 @@ fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBar
             }
         });
     }
-
-    // Couple each CARRIER param's signature bit to the combine result: a
-    // carrier param is bare in the signature ONLY when its value repr came
-    // out `Bare` (proven bound `fits_i64`, OverflowFree ops, and — crucially
-    // — it does NOT escape into an aggregate / Map / stringify). This is the
-    // in-fn analogue of `compute_summary`'s condition B2 for Int counters:
-    // the signature never disagrees with the body repr, so wasm-gc/Rust
-    // never emit an `i64` param the body reads through an `$aint`/`AverInt`
-    // method. A non-carrier param keeps its recurrence-derived `bare_params`
-    // bit untouched.
-    for (i, p) in f.params.iter().enumerate() {
-        if carrier_params[i] {
-            bare_params[i] = facts.values.get(&p.local).is_some_and(|v| v.is_bare());
-        }
-    }
     facts.bare_params = bare_params;
 
     // 5. Return: bare iff the summary says so AND the body's tail value is
@@ -1734,22 +1786,25 @@ fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBar
 
 /// Walk the `Let` chain, recording each bound slot's interval and worst-
 /// join op class. `env` holds param + already-bound intervals and is grown
-/// in place; branches recurse so nested bindings are seen.
+/// in place; branches recurse so nested bindings are seen. `carrier_slots`
+/// lets a bare carrier's `.value` read (`Project`) contribute its proven
+/// interval to an arithmetic binding.
 fn walk_let_chain(
     e: &MirExpr,
     env: &mut HashMap<LocalId, Interval>,
     op_classes: &mut HashMap<LocalId, OpClass>,
+    carrier_slots: &HashMap<LocalId, Interval>,
 ) {
     match e {
         MirExpr::Let(l) => {
             let mut worst = Interval::point(0);
-            let iv = eval_interval(&l.node.value.node, env, &mut worst);
+            let iv = eval_interval(&l.node.value.node, env, &mut worst, carrier_slots);
             env.insert(l.node.binding, iv);
             // The binding's op class is the worst-join over its value
             // expression (so a transient out-of-i64 intermediate demotes).
             op_classes.insert(l.node.binding, OpClass::of_interval(worst.hull(iv)));
-            walk_let_chain(&l.node.value.node, env, op_classes);
-            walk_let_chain(&l.node.body.node, env, op_classes);
+            walk_let_chain(&l.node.value.node, env, op_classes, carrier_slots);
+            walk_let_chain(&l.node.body.node, env, op_classes, carrier_slots);
         }
         // A `match subject { y -> … }` Ident-binding arm ALIASES the subject:
         // the binder `y` carries the subject's interval. Without this, a
@@ -1761,8 +1816,8 @@ fn walk_let_chain(
         // the current `env` (the subject is already in scope).
         MirExpr::Match(m) => {
             let mut worst = Interval::point(0);
-            let subj_iv = eval_interval(&m.node.subject.node, env, &mut worst);
-            walk_let_chain(&m.node.subject.node, env, op_classes);
+            let subj_iv = eval_interval(&m.node.subject.node, env, &mut worst, carrier_slots);
+            walk_let_chain(&m.node.subject.node, env, op_classes, carrier_slots);
             for arm in &m.node.arms {
                 if let MirPattern::Bind(slot, _) = &arm.pattern {
                     // Alias: the binder takes the subject's interval + op
@@ -1772,11 +1827,13 @@ fn walk_let_chain(
                         .entry(*slot)
                         .or_insert_with(|| OpClass::of_interval(subj_iv));
                 }
-                walk_let_chain(&arm.body.node, env, op_classes);
+                walk_let_chain(&arm.body.node, env, op_classes, carrier_slots);
             }
         }
         _ => {
-            visit_children(e, &mut |c| walk_let_chain(c, env, op_classes));
+            visit_children(e, &mut |c| {
+                walk_let_chain(c, env, op_classes, carrier_slots)
+            });
         }
     }
 }
@@ -1784,7 +1841,15 @@ fn walk_let_chain(
 /// Abstractly evaluate a MIR expression to its interval, joining each
 /// arithmetic node into `worst` (so a transient out-of-i64 intermediate
 /// demotes the binding). Unknown shapes evaluate to `unbounded()`.
-fn eval_interval(e: &MirExpr, env: &HashMap<LocalId, Interval>, worst: &mut Interval) -> Interval {
+/// `carrier_slots` maps a bare carrier slot to its proven `fits_i64` bound, so
+/// a `Project(Local(carrier_slot), _)` (`c.value`) evaluates to that bound
+/// rather than `unbounded()` — the carrier-projection leaf.
+fn eval_interval(
+    e: &MirExpr,
+    env: &HashMap<LocalId, Interval>,
+    worst: &mut Interval,
+    carrier_slots: &HashMap<LocalId, Interval>,
+) -> Interval {
     match e {
         MirExpr::Literal(l) => match l.node {
             Literal::Int(k) => Interval::point(k as i128),
@@ -1794,14 +1859,23 @@ fn eval_interval(e: &MirExpr, env: &HashMap<LocalId, Interval>, worst: &mut Inte
             .get(&local.node.slot)
             .copied()
             .unwrap_or_else(Interval::unbounded),
+        // ETAP-2 carrier-`i64`: `c.value` over a bare carrier slot reads the
+        // native i64 with the carrier's proven bound.
+        MirExpr::Project(p) => match &p.node.base.node {
+            MirExpr::Local(local) => carrier_slots
+                .get(&local.node.slot)
+                .copied()
+                .unwrap_or_else(Interval::unbounded),
+            _ => Interval::unbounded(),
+        },
         MirExpr::Neg(inner) => {
-            let r = Interval::point(0).sub(eval_interval(&inner.node, env, worst));
+            let r = Interval::point(0).sub(eval_interval(&inner.node, env, worst, carrier_slots));
             *worst = worst.hull(r);
             r
         }
         MirExpr::BinOp(b) => {
-            let l = eval_interval(&b.node.lhs.node, env, worst);
-            let r = eval_interval(&b.node.rhs.node, env, worst);
+            let l = eval_interval(&b.node.lhs.node, env, worst, carrier_slots);
+            let r = eval_interval(&b.node.rhs.node, env, worst, carrier_slots);
             let result = match b.node.op {
                 BinOp::Add => l.add(r),
                 BinOp::Sub => l.sub(r),
@@ -1996,6 +2070,9 @@ fn tail_value_is_bare(e: &MirExpr, facts: &FnBareFacts, escaping: &HashSet<Local
         MirExpr::BinOp(b) if matches!(b.node.op, BinOp::Add | BinOp::Sub | BinOp::Mul) => {
             facts.expr_is_bare_i64(e)
         }
+        // ETAP-2 carrier-`i64`: a tail `c.value` over a bare carrier reads raw
+        // i64, so the fn may return bare i64 (skip the project bridge).
+        MirExpr::Project(_) => facts.is_carrier_project(e),
         _ => false,
     }
 }
@@ -2261,16 +2338,18 @@ fn main() -> Int
     }
 
     #[test]
-    fn carrier_seam_gated_off_keeps_param_boxed() {
-        // SHIPPED-SAFE invariant: while the codegen body-emit bridge is not
-        // in place (`CARRIER_BARE_ELIGIBLE == false`), a carrier param stays
-        // BOXED even when the table holds its proven bound — so the analysis
-        // never desyncs a carrier slot from the (still-boxed) signature and
-        // wasm-gc / Rust output is byte-identical to pre-slice. This test
-        // pins the gate; flip the `const` (with the body bridge) to enable.
+    fn carrier_seam_enabled_records_carrier_projection_slots() {
+        // The carrier-`i64` arithmetic seam is ON (`CARRIER_BARE_ELIGIBLE ==
+        // true`). A carrier param is NOT marked an Int-bare param/slot — the
+        // value `c` is the carrier (i64 STORAGE, never a raw Int operand), so
+        // flagging it bare would make a call site spuriously `Unbox` it. What
+        // the seam DOES is record the carrier param's slot in `carrier_slots`
+        // (with its proven bound) so a `c.value` read renders raw i64. Pin
+        // both: param NOT Int-bare, slot recorded as a carrier-projection
+        // source with the `[0,100]` bound.
         assert!(
-            !CARRIER_BARE_ELIGIBLE,
-            "this test pins the shipped-off carrier seam"
+            CARRIER_BARE_ELIGIBLE,
+            "this test pins the enabled carrier-arithmetic seam"
         );
         let (program, facts) = carrier_facts(true);
         for name in ["toInt", "doubled"] {
@@ -2278,7 +2357,32 @@ fn main() -> Int
             let f = facts.for_fn(id).expect("carrier facts");
             assert!(
                 !f.param_is_bare(0),
-                "with the seam gated off, `{name}`'s carrier param stays boxed"
+                "`{name}`'s carrier param is NOT an Int-bare param (no spurious \
+                 Unbox at the call site)"
+            );
+            let pf = program.fn_by_id(id).expect("mir fn");
+            let carrier_slot = pf.params[0].local;
+            assert_eq!(
+                f.carrier_slots.get(&carrier_slot).copied(),
+                Some(Interval::between(0, 100)),
+                "`{name}`'s carrier param is a carrier-projection source with the \
+                 proven [0,100] bound"
+            );
+        }
+    }
+
+    #[test]
+    fn carrier_off_table_records_no_carrier_slots() {
+        // With the carrier table EMPTY (the Rust backend / no-eligible-carrier
+        // baseline), no carrier-projection slot is recorded — the byte-
+        // identical pre-slice behavior.
+        let (program, facts) = carrier_facts(false);
+        for name in ["toInt", "doubled"] {
+            let id = fn_id_by_name(&program, name);
+            let f = facts.for_fn(id).expect("carrier facts");
+            assert!(
+                f.carrier_slots.is_empty(),
+                "with the carrier table empty, `{name}` records no carrier slot"
             );
         }
     }
@@ -2451,7 +2555,8 @@ fn main() -> List<Int>
         }));
 
         let mut worst = Interval::point(0);
-        let result = eval_interval(&sub, &env, &mut worst);
+        let no_carriers: HashMap<LocalId, Interval> = HashMap::new();
+        let result = eval_interval(&sub, &env, &mut worst, &no_carriers);
         // The final value cancels back into [0, 10] (fits i64) …
         assert!(result.fits_i64(), "final value cancels back into range");
         // … but the worst-join saw the transient `n + i64::MAX` (out of i64),

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -59,9 +59,19 @@ use crate::ir::mir::{
 pub fn rewrite_for_rust(
     program: MirProgram,
     boxed_signature_fns: &std::collections::HashSet<crate::ir::FnId>,
-    carrier: &super::bare_i64::CarrierIntervals,
+    _carrier: &super::bare_i64::CarrierIntervals,
 ) -> MirProgram {
-    rewrite(program, boxed_signature_fns, carrier)
+    // ETAP-2 carrier-`i64` is a WASM-GC-ONLY size lever: the wasm-gc registry
+    // erases an eligible carrier's storage to a native `i64` everywhere, so a
+    // carrier value IS an i64 and `c.value` can stay raw. The RUST backend
+    // keeps the carrier as a real struct (`IntRange { value: AverInt }`), so a
+    // raw-i64 carrier path would emit invalid Rust (a `.to_i64()` on a struct,
+    // an `i64` where the field is `AverInt`). The Int-recurrence bareness
+    // (countdown / factorial counters) is target-agnostic and stays on for
+    // Rust; only the carrier-projection leaf is suppressed — pass an EMPTY
+    // carrier table so `carrier_interval` declines every carrier.
+    let empty = super::bare_i64::CarrierIntervals::new();
+    rewrite(program, boxed_signature_fns, &empty)
 }
 
 /// ETAP-2 SLICE 2b: the wasm-gc entry. Identical body to
@@ -198,10 +208,17 @@ fn rewrite_fn(
             bare_slots.insert(*slot);
         }
     }
+    // ETAP-2 carrier-`i64`: carry the bare-carrier slots so the wasm-gc emit
+    // reads `c.value` as a raw i64 (skip the project bridge). A boxed-signature
+    // fn (mutual-TCO member) gets an empty `facts`, so its `carrier_slots` is
+    // empty too — its carrier reads stay boxed, matching the pinned signature.
+    let carrier_slots: std::collections::HashSet<LocalId> =
+        facts.carrier_slots.keys().copied().collect();
     f.repr = MirFnRepr {
         bare_slots,
         bare_params: facts.bare_params.clone(),
         bare_return: facts.bare_return,
+        carrier_slots,
     };
 
     // 2. Insert boundary nodes. The body is in RETURN position: a bare
@@ -685,17 +702,29 @@ fn rewrite_children_inner(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<
                 b.node.rhs = std::boxed::Box::new(rewrite_boxed(rhs, ctx));
                 return Spanned::new(MirExpr::BinOp(b), line);
             }
-            // Comparison or non-Int op: a comparison between two raw
-            // operands stays raw (codegen emits `i64 == i64`); otherwise
-            // recurse as value positions.
+            // Comparison: a comparison between two raw operands stays raw
+            // (codegen emits `i64 == i64`); otherwise BOTH operands must be
+            // boxed `$AverInt` (the boxed comparison helper). The MIXED case
+            // is the carrier-arithmetic crux: `s.x.value == fx.value` reads a
+            // carrier FIELD (`Project(Project(..))`, a boxed `$AverInt`) on one
+            // side and a bare carrier PARAM's `.value` (raw i64) on the other.
+            // Without boxing the raw side, codegen would compare an i64 against
+            // an `$AverInt` ref — a wasm VALIDATION error. So if EITHER operand
+            // is boxed, route BOTH through `rewrite_boxed` (a no-op on an
+            // already-boxed operand, a `Box` on a raw one).
             if matches!(
                 op,
                 BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
-            ) && renders_raw(&lhs.node, ctx.facts)
-                && renders_raw(&rhs.node, ctx.facts)
-            {
-                b.node.lhs = std::boxed::Box::new(rewrite_raw(lhs, ctx));
-                b.node.rhs = std::boxed::Box::new(rewrite_raw(rhs, ctx));
+            ) {
+                let both_raw =
+                    renders_raw(&lhs.node, ctx.facts) && renders_raw(&rhs.node, ctx.facts);
+                if both_raw {
+                    b.node.lhs = std::boxed::Box::new(rewrite_raw(lhs, ctx));
+                    b.node.rhs = std::boxed::Box::new(rewrite_raw(rhs, ctx));
+                } else {
+                    b.node.lhs = std::boxed::Box::new(rewrite_boxed(lhs, ctx));
+                    b.node.rhs = std::boxed::Box::new(rewrite_boxed(rhs, ctx));
+                }
                 return Spanned::new(MirExpr::BinOp(b), line);
             }
             b.node.lhs = std::boxed::Box::new(rewrite_value(lhs, ctx));

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -302,17 +302,27 @@ fn rewrite_boxed(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> 
     if matches!(&e.node, MirExpr::Literal(l) if matches!(l.node, Literal::Int(_))) {
         return rewrite_children(e, ctx);
     }
-    // NOTE: a bare-RETURN call is NOT boxed here. The prior side-table
-    // codegen only boxed a bare-returning call in RETURN-TAIL position
-    // (`emit_boxed_return_tail`); a call result in a non-tail boxed context
-    // (a `let` value, an arithmetic operand, an aggregate element) was left
-    // as-is, because the analysis's "unsafe return consumer" rule (C2)
-    // demotes a callee's `bare_return` whenever its result reaches such a
-    // position. Boxing it here would double-box a callee whose ACTUAL
-    // emitted signature is boxed anyway (e.g. a mutual-TCO member, which
-    // codegen always emits `-> AverInt` regardless of the analysis flag).
-    // The Q5 return-tail case is handled by `rewrite_boxed_tail`.
-    //
+    // A bare-RETURNING call whose result lands in THIS `$AverInt` sink is
+    // boxed (the Q5 rule, here extended from the return-tail to EVERY boxed
+    // context). The analysis's "unsafe return consumer" rule (C2) demotes a
+    // callee's `bare_return` in MOST non-tail boxed positions (an arithmetic
+    // operand, a boxed-param arg, an aggregate element), so for those the
+    // callee is already `-> $AverInt` and `call_returns_raw` reports false —
+    // this box is a no-op. But C2 deliberately WHITELISTS the stringify-safe
+    // sinks (`String.fromInt`, interpolation embeds): the callee STAYS
+    // `bare_return`, so its raw `i64` result flows unchanged into an
+    // `$AverInt`-typed builtin arg. On Rust that arg was coerced per-emit; on
+    // wasm-gc there is no per-call coercion, so the raw `i64` met an
+    // `$AverInt` ref slot — a wasm VALIDATION error (the carrier-arith bug:
+    // `String.fromInt(dbl(c))` with `dbl` bare-return). Boxing the call here
+    // closes the boundary while keeping `dbl`'s add native. A mutual-TCO
+    // member is NOT double-boxed: `call_returns_raw` reads `callee_facts`,
+    // which is `None` for a `boxed_signature_fn` (that callee already emits
+    // `-> $AverInt`), so it reports false and we leave it alone.
+    if call_returns_raw(&e.node, ctx) {
+        let inner = rewrite_children(e, ctx);
+        return box_node(inner);
+    }
     // A directly raw-rendering leaf / compound (a bare `Local`, or an
     // in-range `Add`/`Sub`/`Mul`/`Neg` tree): box it. Its raw operands stay
     // raw inside (rewrite_children leaves them — they are consumed by the
@@ -1060,5 +1070,45 @@ fn main() -> Int
         assert!(!h.repr.bare_return, "h's return stays boxed");
         let (boxes, _unboxes) = count_boundaries(&h.body.node);
         assert!(boxes >= 1, "h boxes the bare-returning call result");
+    }
+
+    #[test]
+    fn bare_return_call_into_string_from_int_arg_boxes_at_sink() {
+        // The carrier-arith bug class at the MIR level: `g` has a bare return
+        // (the analysis keeps the recurrence native); `s` feeds the bare-
+        // returning `g(2)` straight into `String.fromInt`, whose param slot is
+        // `$AverInt`. The rewrite MUST insert a `Box` at that builtin-arg
+        // boundary — without it the raw `i64` call result met a `ref null
+        // $type` slot, a wasm-gc validation failure (`verify --wasm-gc` masks
+        // it; only a full-module compile catches it). The box lands ONLY at
+        // the sink; `g`'s recurrence stays native (`g.repr.bare_return`).
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn g(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> g(n - 1)
+
+fn s() -> String
+    String.fromInt(g(2))
+
+fn main() -> String
+    s()
+"#;
+        let program = rewritten(src);
+        let g = fn_named(&program, "g");
+        assert!(
+            g.repr.bare_return,
+            "g's recurrence stays native (bare return preserved)"
+        );
+        let s = fn_named(&program, "s");
+        let (boxes, _unboxes) = count_boundaries(&s.body.node);
+        assert!(
+            boxes >= 1,
+            "the bare-returning g(2) feeding String.fromInt's $AverInt arg is boxed at the sink"
+        );
     }
 }

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -853,8 +853,18 @@ fn rewrite_children_inner(e: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<
             Spanned::new(MirExpr::InterpolatedStr(parts), line)
         }
         MirExpr::IndependentProduct(mut ip) => {
+            // `(a, b, c)!` builds a tuple `struct.new` whose Int element slots
+            // are `$AverInt` (`ref null $type`); `(a, b, c)?!` likewise builds
+            // the unwrapped-Ok tuple. Each element is therefore a BOXED context,
+            // exactly like a plain `Tuple` (the adjacent arm above). Routing the
+            // items through `rewrite_value` (children only) left a raw-rendering
+            // Int element — a bare-returning call (`countdown(3)`), inline bare
+            // arith, or a bare carrier `.value` (`dbl(c)`) — un-boxed, so the
+            // raw `i64` met the `$AverInt` tuple field: a wasm VALIDATION error
+            // on a VM-valid program (the 4th boundary-completeness hole). Box
+            // each element at the chokepoint, identical to `Tuple`.
             let items = std::mem::take(&mut ip.node.items);
-            ip.node.items = items.into_iter().map(|it| rewrite_value(it, ctx)).collect();
+            ip.node.items = rewrite_boxed_each(items, ctx);
             Spanned::new(MirExpr::IndependentProduct(ip), line)
         }
         MirExpr::Project(mut p) => {

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -476,9 +476,10 @@ fn call_returns_raw(e: &MirExpr, ctx: &RewriteCtx<'_>) -> bool {
 /// the subject must be rewritten to MATCH the binding: boxed when the
 /// binding is boxed (the raw subject is `Box`ed at the bind crossing), raw
 /// when the binding is bare. With no `Bind` arm (literal / ctor / wildcard
-/// patterns) the subject is an ordinary value position. When arms disagree
-/// (multiple bind arms with mixed reps — not produced by lowering), the
-/// safe choice is boxed.
+/// patterns) the subject is rewritten for the representation the wasm-gc
+/// match cascade reads off it (see [`rewrite_no_bind_subject`]). When bind
+/// arms disagree (multiple bind arms with mixed reps — not produced by
+/// lowering), the safe choice is boxed.
 fn rewrite_match_subject(
     subj: Spanned<MirExpr>,
     arms: &[crate::ir::mir::MirMatchArm],
@@ -493,12 +494,44 @@ fn rewrite_match_subject(
         })
         .collect();
     if bind_slots.is_empty() {
-        return rewrite_value(subj, ctx);
+        return rewrite_no_bind_subject(subj, ctx);
     }
     // Every bind slot aliases the same subject, so they share a repr in a
     // well-formed program; require ALL bare to treat the subject raw.
     let all_bare = bind_slots.iter().all(|s| ctx.facts.is_bare(*s));
     if all_bare {
+        rewrite_raw(subj, ctx)
+    } else {
+        rewrite_boxed(subj, ctx)
+    }
+}
+
+/// Rewrite a no-`Bind`-arm match subject (literal / ctor / wildcard arms,
+/// e.g. `match dbl(c) { 0 -> 1; _ -> 2 }`). The wasm-gc Int-match cascade
+/// types this subject by a single STRUCTURAL test — `mir_renders_raw_i64`:
+/// a subject that renders a raw `i64` keeps the native `i64.eq`/`i64.const`
+/// compare path; ANY other subject is typed `$AverInt` (a `ref null $type`)
+/// and compared with `__aint_eq`. So the rewrite must honor exactly that
+/// split:
+///
+///   - a subject that renders raw (a bare `Local`, a bare carrier `.value`,
+///     a whole-tree-bare arith) stays raw — `rewrite_raw` (so the native
+///     compare matches; this is the common bare-counter `match n { 0 -> … }`),
+///   - EVERY other subject must be an `$AverInt`, so it routes through the
+///     single boxing chokepoint `rewrite_boxed`, which boxes a bare-RETURNING
+///     call (the boundary-completeness hole: `match dbl(c) { 0 -> … }` /
+///     `match countdown(3) { 0 -> … }`, the callee returns raw `i64` but the
+///     cascade typed the subject `$AverInt` → a wasm VALIDATION error), boxes
+///     a Match/IfThenElse subject's raw-yielding arms, and is a no-op on an
+///     already-`$AverInt` subject.
+///
+/// Before this funnel the no-bind subject went through `rewrite_value`, which
+/// rewrites only children and never applied the `call_returns_raw`→`Box`
+/// rule, so a bare-returning-call subject leaked raw into the `$AverInt`
+/// position. The `renders_raw` guard keeps `rewrite_boxed` from boxing a
+/// genuinely-raw subject (which would needlessly force the boxed compare).
+fn rewrite_no_bind_subject(subj: Spanned<MirExpr>, ctx: &RewriteCtx<'_>) -> Spanned<MirExpr> {
+    if renders_raw(&subj.node, ctx.facts) {
         rewrite_raw(subj, ctx)
     } else {
         rewrite_boxed(subj, ctx)
@@ -1109,6 +1142,78 @@ fn main() -> String
         assert!(
             boxes >= 1,
             "the bare-returning g(2) feeding String.fromInt's $AverInt arg is boxed at the sink"
+        );
+    }
+
+    #[test]
+    fn bare_return_call_as_no_bind_match_subject_boxes_at_subject() {
+        // The 3rd hole of the bare-i64 → $AverInt class at the MIR level: `g`
+        // has a bare return; `r` uses `g(2)` as a NO-BIND match subject
+        // (literal/wildcard arms). The wasm-gc Int-match cascade types that
+        // subject `$AverInt` (a bare-returning call is not recognized raw), so
+        // the rewrite MUST box `g(2)` at the subject crossing — without it the
+        // raw `i64` met the `ref null $type` subject slot, a wasm validation
+        // failure. The box lands at the subject; `g`'s recurrence stays native.
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn g(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> g(n - 1)
+
+fn r() -> Int
+    match g(2)
+        0 -> 1
+        _ -> 2
+
+fn main() -> Int
+    r()
+"#;
+        let program = rewritten(src);
+        let g = fn_named(&program, "g");
+        assert!(
+            g.repr.bare_return,
+            "g's recurrence stays native (bare return preserved)"
+        );
+        let r = fn_named(&program, "r");
+        let (boxes, _unboxes) = count_boundaries(&r.body.node);
+        assert!(
+            boxes >= 1,
+            "the bare-returning g(2) used as a no-bind $AverInt match subject is boxed"
+        );
+    }
+
+    #[test]
+    fn bare_local_no_bind_match_subject_stays_raw() {
+        // The native-compare path must be preserved: a bare counter used as a
+        // no-bind match subject (`match n { 0 -> …; _ -> … }`, `n` bare) renders
+        // raw `i64`, so the wasm-gc cascade keeps the native `i64.eq` compare.
+        // The rewrite must NOT box it (no spurious boundary) — `countdown`'s own
+        // recurrence-decrementing match is exactly this shape.
+        let src = r#"
+module M
+    intent = "t"
+    depends []
+
+fn countdown(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> countdown(n - 1)
+
+fn main() -> Int
+    countdown(20000)
+"#;
+        let program = rewritten(src);
+        let f = fn_named(&program, "countdown");
+        assert!(f.repr.param_is_bare(0), "counter param is bare");
+        let (boxes, unboxes) = count_boundaries(&f.body.node);
+        assert_eq!(
+            (boxes, unboxes),
+            (0, 0),
+            "a bare-counter no-bind match subject stays raw — no boundary node"
         );
     }
 }

--- a/src/ir/mir/program.rs
+++ b/src/ir/mir/program.rs
@@ -192,12 +192,26 @@ pub struct MirFnRepr {
     pub bare_params: Vec<bool>,
     /// `true` ⟺ the fn's Rust return type is bare `i64`.
     pub bare_return: bool,
+    /// ETAP-2 carrier-`i64` (wasm-gc only): slots holding a BARE carrier value
+    /// — an eligible refinement-via-opaque carrier whose wasm storage IS a
+    /// native `i64`. A `Project(Local(slot), "value")` over such a slot reads
+    /// the i64 DIRECTLY (the codegen skips the `$AverInt` project bridge), so
+    /// the `.value` read is a raw-i64 leaf for the native arithmetic the
+    /// rewrite left raw. Empty on the Rust backend (carriers stay structs) and
+    /// whenever no eligible carrier is in scope — the byte-identical default.
+    pub carrier_slots: std::collections::HashSet<LocalId>,
 }
 
 impl MirFnRepr {
     /// Is the value bound to `slot` represented as a raw machine `i64`?
     pub fn slot_is_bare(&self, slot: LocalId) -> bool {
         self.bare_slots.contains(&slot)
+    }
+
+    /// ETAP-2 carrier-`i64`: does `slot` hold a bare carrier whose `.value`
+    /// read renders as a raw native `i64` (no project bridge)?
+    pub fn slot_is_bare_carrier(&self, slot: LocalId) -> bool {
+        self.carrier_slots.contains(&slot)
     }
 
     /// Is param index `i` bare in the Rust signature?

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -1512,3 +1512,140 @@ fn main() -> Unit
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Match-SUBJECT boundary completeness (the 3rd hole of the bare-i64 →
+// `$AverInt` class).
+//
+// The wasm-gc Int-match cascade types a no-`Bind`-arm subject by a single
+// structural test (`mir_renders_raw_i64`): a raw-rendering subject keeps the
+// native `i64.eq` compare, ANY other subject is typed `$AverInt` and compared
+// with `__aint_eq`. A bare-RETURNING call subject (`match dbl(c) { 0 -> … }`,
+// `match countdown(3) { 0 -> … }`) renders raw `i64` from the callee but is
+// NOT recognized raw by the cascade, so it was typed `$AverInt` — and the
+// `bare_i64_rewrite` routed the no-bind subject through `rewrite_value`
+// (children only), never boxing the bare-returning call. The raw `i64` met a
+// `ref null $type` subject slot → a wasm VALIDATION error on a VM-valid
+// program. Now the no-bind subject funnels through the boxing chokepoint.
+//
+// These are the FIRST match-scrutinee cases in the differential. Two flavors:
+//   - CARRIER: `match dbl(c) { … }` with `dbl` a bare carrier-arith call —
+//     vanishes with `AVER_NO_CARRIER_I64=1` (the #551 blocker).
+//   - BARE-i64: `match countdown(n) { … }` over a recurrence counter —
+//     vanishes with `AVER_NO_BARE_I64=1`, a PRE-EXISTING bare-i64 bug the
+//     same fix closes (carrier-arith plays no part).
+
+/// CARRIER flavor — a bare-returning carrier-arith call as a no-bind match
+/// SUBJECT (`match dbl(c) { 0 -> …; 100 -> …; _ -> … }`). The subject is
+/// typed `$AverInt` by the cascade, so the rewrite must box `dbl(c)`'s raw
+/// `i64` result at the subject boundary. VM == wasm-gc, and the whole module
+/// compiles clean.
+#[test]
+fn carrier_bare_call_as_match_subject_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result as no-bind Int match subject"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn classify(c: C) -> Int
+    match dbl(c)
+        0   -> 1
+        100 -> 2
+        _   -> 3
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(50)
+        Result.Ok(c)  -> Console.print("{classify(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-match-subject", src);
+    assert_eq!(out, "2");
+    assert_carrier_revert_agrees("carrier-match-subject", src, &out);
+}
+
+/// CARRIER flavor, BOOL-result variant — the no-bind match SUBJECT is the
+/// same bare-returning carrier-arith call, but each arm yields a `Bool`
+/// (`match dbl(c) { 100 -> true; _ -> false }`). The arm result type does NOT
+/// change the subject's `$AverInt` typing, so the subject-boundary box is
+/// still required; only the block result colour differs.
+#[test]
+fn carrier_bare_call_as_bool_match_subject_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result as no-bind subject, Bool arms"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn isHundred(c: C) -> Bool
+    match dbl(c)
+        100 -> true
+        _   -> false
+
+fn show(b: Bool) -> String
+    match b
+        true  -> "yes"
+        false -> "no"
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(50)
+        Result.Ok(c)  -> Console.print("{show(isHundred(c))}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-bool-match-subject", src);
+    assert_eq!(out, "yes");
+    assert_carrier_revert_agrees("carrier-bool-match-subject", src, &out);
+}
+
+/// BARE-i64 flavor (PRE-EXISTING, predates #551) — a bare-i64 recurrence
+/// counter as a no-bind match SUBJECT (`match countdown(n) { 0 -> …; _ -> … }`).
+/// `countdown` returns a native `i64` (bare return); the cascade typed the
+/// subject `$AverInt`, so the same subject-boundary box closes it. Carrier
+/// arith plays no part (no carrier here) — the program vanishes the bug only
+/// with `AVER_NO_BARE_I64=1`, never `AVER_NO_CARRIER_I64=1`. VM == wasm-gc and
+/// the module compiles clean.
+#[test]
+fn bare_recurrence_call_as_match_subject_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "bare-i64 recurrence result as no-bind Int match subject"
+    effects [Console]
+
+fn countdown(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> countdown(n - 1)
+
+fn run(n: Int) -> Int
+    match countdown(n)
+        0 -> 1
+        _ -> 2
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{run(3)} {run(0)}")
+"#;
+    // countdown(3) and countdown(0) both reach 0, so both pick the `0 -> 1`
+    // arm. VM is ground truth; the whole module must compile clean to wasm-gc.
+    let out = assert_vm_wasm_identical("bare-match-subject", src);
+    assert_eq!(out, "1 1");
+}

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -416,6 +416,237 @@ fn main() -> Unit
     );
 }
 
+// ---------------------------------------------------------------------------
+// Carrier ARITHMETIC differentials (the raw-i64 carrier path,
+// `CARRIER_BARE_ELIGIBLE == true`). A bare carrier's `.value` reads a native
+// `i64` and arithmetic over it runs as `i64.add/sub/mul` WHERE the interval
+// fixpoint proves the result fits `i64`; an operation that could leave `i64`
+// stays boxed (the project bridge runs, full `$aint` precision). The VM (full
+// ℤ) is the oracle: any divergence is a silent wrap.
+
+/// Carrier + carrier and carrier * literal: both run as native `i64` ops over
+/// a `[0,100]` carrier (the products fit `i64`). VM == wasm-gc.
+#[test]
+fn carrier_arith_add_and_mul_literal_match_vm() {
+    let src = r#"module M
+    intent = "carrier-i64 add + mul-literal arithmetic"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<IntRange, String>) -> IntRange
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> IntRange(value = 0)
+
+fn ir(n: Int) -> IntRange
+    unwrap(fromInt(n))
+
+fn sumPair(a: IntRange, b: IntRange) -> Int
+    a.value + b.value
+
+fn timesTen(c: IntRange) -> Int
+    c.value * 10
+
+fn doubled(c: IntRange) -> Int
+    c.value + c.value
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{sumPair(ir(30), ir(12))} {timesTen(ir(7))} {doubled(ir(20))}")
+"#;
+    let out = assert_vm_wasm_identical("carrier-arith-add-mul", src);
+    assert_eq!(out, "42 70 40");
+    assert_carrier_revert_agrees("carrier-arith-add-mul", src, &out);
+}
+
+/// Carrier COMPARISON `<` and `==`: a bare carrier's `.value` compares as a
+/// raw `i64.lt_s` / `i64.eq`. VM == wasm-gc.
+#[test]
+fn carrier_value_comparison_match_vm() {
+    let src = r#"module M
+    intent = "carrier-i64 value comparison"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<IntRange, String>) -> IntRange
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> IntRange(value = 0)
+
+fn ir(n: Int) -> IntRange
+    unwrap(fromInt(n))
+
+fn less(a: IntRange, b: IntRange) -> Bool
+    a.value < b.value
+
+fn eq(a: IntRange, b: IntRange) -> Bool
+    a.value == b.value
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{less(ir(3), ir(7))} {less(ir(7), ir(3))} {eq(ir(5), ir(5))} {eq(ir(5), ir(6))}")
+"#;
+    let out = assert_vm_wasm_identical("carrier-cmp", src);
+    assert_eq!(out, "true false true false");
+    assert_carrier_revert_agrees("carrier-cmp", src, &out);
+}
+
+/// MIXED-representation carrier comparison + arithmetic — the load-bearing
+/// snake shape. `s.x.value` reads a carrier FIELD (`Project(Project(..))`, a
+/// boxed `$AverInt` via the project bridge) while `fx.value` reads a bare
+/// carrier PARAM's `.value` (a raw i64). Comparing / subtracting one against
+/// the other must coerce both to the same representation (box the raw side) —
+/// without the fix, codegen compared an i64 against an `$AverInt` ref, a wasm
+/// validation error. VM == wasm-gc.
+#[test]
+fn carrier_mixed_field_and_param_value_match_vm() {
+    let src = r#"module M
+    intent = "carrier-i64 mixed field/param value comparison + subtraction"
+    effects [Console]
+
+record Coord
+    value: Int
+
+record State
+    x: Coord
+    y: Coord
+
+fn coordOf(n: Int) -> Result<Coord, String>
+    match Bool.and(n >= 0, n <= 1000)
+        true  -> Result.Ok(Coord(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<Coord, String>) -> Coord
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Coord(value = 0)
+
+fn coord(n: Int) -> Coord
+    unwrap(coordOf(n))
+
+fn atFood(s: State, fx: Coord, fy: Coord) -> Bool
+    Bool.and(s.x.value == fx.value, s.y.value == fy.value)
+
+fn manhattan(s: State, fx: Coord, fy: Coord) -> Int
+    (fx.value - s.x.value) + (fy.value - s.y.value)
+
+fn main() -> Unit
+    ! [Console.print]
+    s = State(x = coord(5), y = coord(5))
+    fx = coord(8)
+    fy = coord(5)
+    Console.print("{atFood(s, fx, fy)} {atFood(s, coord(5), coord(5))} {manhattan(s, fx, fy)}")
+"#;
+    let out = assert_vm_wasm_identical("carrier-mixed", src);
+    assert_eq!(out, "false true 3");
+    assert_carrier_revert_agrees("carrier-mixed", src, &out);
+}
+
+/// Carrier as a RECORD FIELD with arithmetic on the projected value, plus the
+/// SNAKE pattern — a record-update increment `score = state.score + 1` where
+/// `score` is a bounded carrier field. The `state.score.value + 1` runs as a
+/// native `i64.add` and the result is rewrapped into a fresh carrier field via
+/// the construct bridge. VM == wasm-gc.
+#[test]
+fn carrier_record_field_arithmetic_and_snake_pattern_match_vm() {
+    let src = r#"module M
+    intent = "carrier-i64 record field arithmetic + snake score increment"
+    effects [Console]
+
+record Coord
+    value: Int
+
+record State
+    score: Coord
+    x: Coord
+
+fn fromCoord(n: Int) -> Result<Coord, String>
+    match Bool.and(n >= 0, n <= 1000)
+        true  -> Result.Ok(Coord(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<Coord, String>) -> Coord
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Coord(value = 0)
+
+fn coord(n: Int) -> Coord
+    unwrap(fromCoord(n))
+
+fn bump(s: State) -> State
+    State(score = coord(s.score.value + 1), x = s.x)
+
+fn readScore(s: State) -> Int
+    s.score.value
+
+fn readX(s: State) -> Int
+    s.x.value
+
+fn main() -> Unit
+    ! [Console.print]
+    s = State(score = coord(41), x = coord(7))
+    s2 = bump(s)
+    Console.print("{readScore(s2)} {readX(s2)} {readScore(s)}")
+"#;
+    let out = assert_vm_wasm_identical("carrier-record-snake", src);
+    assert_eq!(out, "42 7 41");
+}
+
+/// WIDE-BOUND OVERFLOW (the load-bearing C0 soundness probe). A carrier
+/// bounded `0..2^40` doing `c.value * c.value` = up to `2^80`, which OVERFLOWS
+/// `i64`. The interval fixpoint must DEMOTE the multiply to boxed (the project
+/// bridge runs, the `*` is the full-precision `__aint_mul`) — a raw `i64.mul`
+/// would WRAP silently. The VM keeps full ℤ; an equal wasm-gc result proves
+/// the analysis did NOT emit a wrapping native op for an out-of-`i64` op.
+#[test]
+fn carrier_wide_bound_mul_overflow_stays_boxed_match_vm() {
+    let src = r#"module M
+    intent = "carrier-i64 wide-bound multiply overflow"
+    effects [Console]
+
+record Wide
+    value: Int
+
+fn fromWide(n: Int) -> Result<Wide, String>
+    match Bool.and(n >= 0, n <= 1099511627776)
+        true  -> Result.Ok(Wide(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<Wide, String>) -> Wide
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Wide(value = 0)
+
+fn wide(n: Int) -> Wide
+    unwrap(fromWide(n))
+
+fn square(c: Wide) -> Int
+    c.value * c.value
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{square(wide(1099511627776))}")
+"#;
+    // 2^40 = 1099511627776; (2^40)^2 = 2^80, far beyond i64::MAX. The VM
+    // computes the exact bignum; wasm-gc must match (stayed boxed, no wrap).
+    let out = assert_vm_wasm_identical("carrier-wide-overflow", src);
+    assert_eq!(out, "1208925819614629174706176");
+}
+
 /// Compile `source` to a wasm-gc `.wasm` and return its bytes. `no_carrier`
 /// forces the all-`$aint` baseline via `AVER_NO_CARRIER_I64=1`.
 fn compile_wasm_bytes(prefix: &str, source: &str, no_carrier: bool) -> Vec<u8> {

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -65,8 +65,57 @@ fn run(prefix: &str, source: &str, wasm_gc: bool, no_carrier: bool) -> (bool, St
     )
 }
 
+/// FULL-MODULE wasm-gc compile of `source` (carrier-`i64` ON). Returns
+/// `(success, combined stdout+stderr)`. The boundary-completeness class this
+/// guards (a bare-i64 carrier result meeting an `$AverInt`-typed sink) is a
+/// MODULE-level validation failure: it surfaces only when the WHOLE module
+/// is lowered, never under a per-case `verify --wasm-gc` (which wraps one fn
+/// in a thin harness and can't see the cross-fn boundary). `aver run
+/// --wasm-gc` exercises only the call graph `main` reaches, so a sink in an
+/// unreached fn slips through — `compile --target wasm-gc` lowers EVERY fn.
+fn compile_wasm_gc(prefix: &str, source: &str) -> (bool, String) {
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = temp_module(prefix, source);
+    let out_dir = path.parent().expect("temp module has parent").join("out");
+    let out = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg(&path)
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("aver compile executes");
+    cleanup(&path);
+    let mut combined = String::from_utf8_lossy(&out.stdout).to_string();
+    combined.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.success(), combined.trim().to_string())
+}
+
+/// Assert `source` compiles to a wasm-gc module CLEANLY — no validation
+/// error. The `compile` CLI prints a validation failure to stdout but STILL
+/// EXITS 0, so a success-status check alone is blind to this bug class; the
+/// assertion scans the combined output for the diagnostic substrings too.
+fn assert_compiles_clean_wasm_gc(prefix: &str, source: &str) {
+    let (ok, msg) = compile_wasm_gc(prefix, source);
+    assert!(
+        ok && !msg.contains("validation failed")
+            && !msg.contains("type mismatch")
+            && !msg.contains("error"),
+        "{prefix}: full-module wasm-gc compile was NOT clean — a carrier-i64 value \
+         reached an $AverInt-typed sink (builtin arg / field / map / aggregate / boxed \
+         param) without a Box at the boundary. `verify --wasm-gc` masks this; only a \
+         full-module compile catches it.\n{msg}"
+    );
+}
+
 /// VM == wasm-gc (carrier-`i64` ON). Divergence ⇒ a carrier value wrapped or
-/// a boundary bridge dropped precision.
+/// a boundary bridge dropped precision. ALSO asserts the WHOLE module
+/// compiles clean to wasm-gc (every fn lowered, not just `main`'s reachable
+/// graph) — the boundary-completeness gate `aver run` / `verify --wasm-gc`
+/// could not see.
 fn assert_vm_wasm_identical(prefix: &str, source: &str) -> String {
     let (vm_ok, vm_out) = run(prefix, source, false, false);
     let (wg_ok, wg_out) = run(prefix, source, true, false);
@@ -78,6 +127,7 @@ fn assert_vm_wasm_identical(prefix: &str, source: &str) -> String {
          boundary bridge lost precision where the VM kept the full $aint carrier.\n  \
          VM     = {vm_out:?}\n  wasm-gc= {wg_out:?}"
     );
+    assert_compiles_clean_wasm_gc(prefix, source);
     vm_out
 }
 
@@ -644,6 +694,382 @@ fn main() -> Unit
     // 2^40 = 1099511627776; (2^40)^2 = 2^80, far beyond i64::MAX. The VM
     // computes the exact bignum; wasm-gc must match (stayed boxed, no wrap).
     let out = assert_vm_wasm_identical("carrier-wide-overflow", src);
+    assert_eq!(out, "1208925819614629174706176");
+}
+
+// ---------------------------------------------------------------------------
+// BARE-i64 carrier RESULT → `$AverInt`-typed SINK boundaries.
+//
+// A native-`i64` carrier-arithmetic result (a `bare_return` fn whose body is
+// `c.value + c.value`, kept native because the interval fixpoint proved the
+// sum fits i64) flowing into an `$AverInt`-typed consume site must be BOXED
+// at the boundary (`__aint_from_i64`), or the raw `i64` meets a `ref null
+// $type` slot — a wasm-gc VALIDATION failure on a VM-valid program. The wasm
+// rewrite was missing this box for the call-result-into-`$AverInt`-sink path
+// (`String.fromInt` and every other boxed sink: a record `Int` field, a
+// `Map` value/key, a `Tuple`/`Option`/`Result` payload, a boxed user-fn
+// param). The interval analysis keeps the ADD native (`dbl`'s `bare_return`
+// stays true); the box lands only at the stringify/sink boundary, so the
+// size/speed win is preserved. Each witness must compile clean AND VM ==
+// wasm-gc (`assert_vm_wasm_identical` now also asserts a clean full-module
+// compile). The original panel witness `String.fromInt(dbl(c)) => "10"` is
+// the first case.
+
+/// The witness from the cross-vendor panel: a bare-returning carrier-arith
+/// call (`dbl(c) = c.value + c.value`) fed straight into `String.fromInt`,
+/// whose wasm slot is `$AverInt`. Before the fix this was a module-level
+/// validation error that `verify --wasm-gc` masked.
+#[test]
+fn carrier_bare_call_into_string_from_int_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result into String.fromInt"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn dblStr(c: C) -> String
+    String.fromInt(dbl(c))
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(5)
+        Result.Ok(c)  -> Console.print(dblStr(c))
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-fromint-call", src);
+    assert_eq!(out, "10");
+    assert_carrier_revert_agrees("carrier-fromint-call", src, &out);
+}
+
+/// String INTERPOLATION embed of a bare-returning carrier-arith call
+/// (`"v={dbl(c)}"`). The embed's decimal formatter takes an `$AverInt` ref;
+/// the analysis whitelists stringify as a safe `bare_return` consumer, so the
+/// call stays bare and must be boxed at the embed crossing.
+#[test]
+fn carrier_bare_call_into_interpolation_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result into interpolation embed"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn show(c: C) -> String
+    "v={dbl(c)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(5)
+        Result.Ok(c)  -> Console.print(show(c))
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-interp-call", src);
+    assert_eq!(out, "v=10");
+    assert_carrier_revert_agrees("carrier-interp-call", src, &out);
+}
+
+/// A bare-returning carrier-arith call result stored into a RECORD `Int`
+/// FIELD (`Box(n = dbl(c))`, field typed `$AverInt`).
+#[test]
+fn carrier_bare_call_into_record_field_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result into record Int field"
+    effects [Console]
+
+record C
+    value: Int
+
+record Holder
+    n: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn store(c: C) -> Holder
+    Holder(n = dbl(c))
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(5)
+        Result.Ok(c)  -> Console.print("{store(c).n}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-recfield-call", src);
+    assert_eq!(out, "10");
+    assert_carrier_revert_agrees("carrier-recfield-call", src, &out);
+}
+
+/// A bare-returning carrier-arith call result stored as a `Map<_, Int>` VALUE
+/// (`Map.set({}, "k", dbl(c))`, value typed `$AverInt`).
+#[test]
+fn carrier_bare_call_into_map_value_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result into Map Int value"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn build(c: C) -> Map<String, Int>
+    Map.set({}, "k", dbl(c))
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(5)
+        Result.Ok(c)  -> Console.print("{Option.withDefault(Map.get(build(c), "k"), 0)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-mapval-call", src);
+    assert_eq!(out, "10");
+    assert_carrier_revert_agrees("carrier-mapval-call", src, &out);
+}
+
+/// A bare-returning carrier-arith call result used as a `Map<Int, _>` KEY
+/// (`Map.set({}, dbl(c), "v")`, key typed `$AverInt`).
+#[test]
+fn carrier_bare_call_into_map_key_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result into Map Int key"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn build(c: C) -> Map<Int, String>
+    Map.set({}, dbl(c), "v")
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(5)
+        Result.Ok(c)  -> Console.print(Option.withDefault(Map.get(build(c), 10), "MISS"))
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-mapkey-call", src);
+    assert_eq!(out, "v");
+    assert_carrier_revert_agrees("carrier-mapkey-call", src, &out);
+}
+
+/// A bare-returning carrier-arith call result as a `Tuple<Int, _>` payload
+/// (`(dbl(c), "x")`, first element typed `$AverInt`).
+#[test]
+fn carrier_bare_call_into_tuple_payload_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result into Tuple Int payload"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn pair(c: C) -> Tuple<Int, String>
+    (dbl(c), "x")
+
+fn fst(t: Tuple<Int, String>) -> Int
+    match t
+        (a, _) -> a
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(5)
+        Result.Ok(c)  -> Console.print("{fst(pair(c))}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-tuple-call", src);
+    assert_eq!(out, "10");
+    assert_carrier_revert_agrees("carrier-tuple-call", src, &out);
+}
+
+/// A bare-returning carrier-arith call result as an `Option<Int>` payload
+/// (`Option.Some(dbl(c))`, payload typed `$AverInt`).
+#[test]
+fn carrier_bare_call_into_option_payload_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result into Option Int payload"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn opt(c: C) -> Option<Int>
+    Option.Some(dbl(c))
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(5)
+        Result.Ok(c)  -> Console.print("{Option.withDefault(opt(c), 0)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-option-call", src);
+    assert_eq!(out, "10");
+    assert_carrier_revert_agrees("carrier-option-call", src, &out);
+}
+
+/// A bare-returning carrier-arith call result as a `Result<Int, _>` payload
+/// (`Result.Ok(dbl(c))`, Ok payload typed `$AverInt`).
+#[test]
+fn carrier_bare_call_into_result_payload_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result into Result Int payload"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn coerce(n: Int) -> C
+    match mk(n)
+        Result.Ok(c)  -> c
+        Result.Err(_) -> C(value = 0)
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn res(c: C) -> Result<Int, String>
+    Result.Ok(dbl(c))
+
+fn main() -> Unit
+    ! [Console.print]
+    match res(coerce(5))
+        Result.Ok(v)  -> Console.print("{v}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-result-call", src);
+    assert_eq!(out, "10");
+    assert_carrier_revert_agrees("carrier-result-call", src, &out);
+}
+
+/// A bare-returning carrier-arith call result passed as an arg to a USER fn
+/// with a BOXED `Int` param (`addBoxed(dbl(c), 7)`, `x` is `$AverInt`
+/// because `x * 1000000000000` makes its product escape i64 ⇒ boxed param).
+#[test]
+fn carrier_bare_call_into_boxed_user_param_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result into boxed user-fn Int param"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn addBoxed(x: Int, y: Int) -> Int
+    x * 1000000000000 + y
+
+fn combine(c: C) -> Int
+    addBoxed(dbl(c), 7)
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(5)
+        Result.Ok(c)  -> Console.print("{combine(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-userparam-call", src);
+    assert_eq!(out, "10000000000007");
+    assert_carrier_revert_agrees("carrier-userparam-call", src, &out);
+}
+
+/// SOUNDNESS guard for the new boxing: a WIDE-bound carrier whose
+/// `c.value * c.value` OVERFLOWS i64, then stringified via `String.fromInt`.
+/// The interval fixpoint demotes the multiply to boxed (so `square`'s
+/// `bare_return` is false and the new Q5 box is a no-op there); the full
+/// `$aint` product must reach the formatter EXACT — a raw i64 would wrap.
+#[test]
+fn carrier_wide_overflow_into_string_from_int_stays_exact() {
+    let src = r#"module M
+    intent = "wide-bound carrier overflow into String.fromInt stays exact"
+    effects [Console]
+
+record Wide
+    value: Int
+
+fn fromWide(n: Int) -> Result<Wide, String>
+    match Bool.and(n >= 0, n <= 1099511627776)
+        true  -> Result.Ok(Wide(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<Wide, String>) -> Wide
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Wide(value = 0)
+
+fn wide(n: Int) -> Wide
+    unwrap(fromWide(n))
+
+fn square(c: Wide) -> Int
+    c.value * c.value
+
+fn squareStr(c: Wide) -> String
+    String.fromInt(square(c))
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(squareStr(wide(1099511627776)))
+"#;
+    let out = assert_vm_wasm_identical("carrier-wide-fromint", src);
     assert_eq!(out, "1208925819614629174706176");
 }
 

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -1649,3 +1649,96 @@ fn main() -> Unit
     let out = assert_vm_wasm_identical("bare-match-subject", src);
     assert_eq!(out, "1 1");
 }
+
+// ---------------------------------------------------------------------------
+// INDEPENDENT-PRODUCT (bang-group `!`) element boundary completeness (the 4th
+// hole of the bare-i64 → `$AverInt` class).
+//
+// `(a, b)!` builds a tuple `struct.new` whose Int element slots are typed
+// `$AverInt` (`ref null $type`), exactly like a plain `Tuple` literal. The
+// `bare_i64_rewrite` routed the product's elements through `rewrite_value`
+// (children only) instead of the `rewrite_boxed_each` chokepoint the adjacent
+// `Tuple` arm uses, so a raw-rendering Int element — a bare-returning call
+// (`countdown(3)`), inline bare arith, or a bare carrier `.value` (`dbl(c)`) —
+// stayed un-boxed: the raw `i64` met the `$AverInt` tuple field, a wasm
+// VALIDATION error on a VM-valid program. `verify --wasm-gc` masks it; only a
+// full-module compile (every fn lowered) catches it. Two flavors:
+//   - CARRIER: `(dbl(c), dbl(c))!` over a bare carrier-arith call — vanishes
+//     with `AVER_NO_CARRIER_I64=1` (the #551 carrier blocker).
+//   - BARE-i64: `(countdown(3), countdown(4))!` over recurrence counters —
+//     vanishes with `AVER_NO_BARE_I64=1`, a PRE-EXISTING bare-i64 bug the same
+//     fix closes (carrier-arith plays no part).
+
+/// CARRIER flavor — a bang-group product `(dbl(c), dbl(c))!` whose elements are
+/// bare-returning carrier-arith calls. Each Int element slot of the tuple is
+/// `$AverInt`, so the rewrite must box each `dbl(c)` raw `i64` result at the
+/// product-element boundary. VM == wasm-gc, and the whole module compiles clean.
+#[test]
+fn carrier_bare_call_in_independent_product_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "carrier arith result in independent-product (!) element"
+    effects [Console]
+
+record C
+    value: Int
+
+fn mk(n: Int) -> Result<C, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(C(value = n))
+        false -> Result.Err("oob")
+
+fn dbl(c: C) -> Int
+    c.value + c.value
+
+fn pair(c: C) -> Tuple<Int, Int>
+    (dbl(c), dbl(c))!
+
+fn sumPair(c: C) -> Int
+    match pair(c)
+        (a, b) -> a + b
+
+fn main() -> Unit
+    ! [Console.print]
+    match mk(5)
+        Result.Ok(c)  -> Console.print("{sumPair(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("carrier-ip-call", src);
+    assert_eq!(out, "20");
+    assert_carrier_revert_agrees("carrier-ip-call", src, &out);
+}
+
+/// BARE-i64 flavor (PRE-EXISTING, predates #551) — a bang-group product
+/// `(countdown(3), countdown(4))!` whose elements are bare-i64 recurrence
+/// calls. `countdown` returns a native `i64` (bare return); each tuple element
+/// slot is `$AverInt`, so the same product-element box closes it. Carrier
+/// arith plays no part (no carrier here) — the program vanishes the bug only
+/// with `AVER_NO_BARE_I64=1`, never `AVER_NO_CARRIER_I64=1`. VM == wasm-gc and
+/// the module compiles clean.
+#[test]
+fn bare_recurrence_call_in_independent_product_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "bare-i64 recurrence result in independent-product (!) element"
+    effects [Console]
+
+fn countdown(n: Int) -> Int
+    match n
+        0 -> 0
+        _ -> countdown(n - 1)
+
+fn pair() -> Tuple<Int, Int>
+    (countdown(3), countdown(4))!
+
+fn run() -> Int
+    match pair()
+        (a, b) -> a + b
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{run()}")
+"#;
+    // countdown(3) and countdown(4) both reach 0, so the tuple is (0, 0) and
+    // the sum is 0. VM is ground truth; the whole module must compile clean.
+    let out = assert_vm_wasm_identical("bare-ip-call", src);
+    assert_eq!(out, "0");
+}


### PR DESCRIPTION
## What

Runs **native `i64` arithmetic** on provably-bounded opaque-carrier values on the wasm-gc backend, instead of routing every carrier operation through the arbitrary-precision `$AverInt` representation. When a carrier's smart-constructor bound proves the value fits `i64`, its `.value` projection stays a raw `i64` and arithmetic on it lowers to `i64.add`/`sub`/`mul`/comparison — so a program whose Int work is confined to bounded carriers stops linking the bignum prelude.

This is the speed/size half of carrier-i64: #550 made carrier **storage** native `i64`; this makes carrier **arithmetic** native too.

## Soundness

Carrier `.value` is seeded into the existing guard-seeded interval fixpoint with the carrier's proven bound, and every operation is gated on `fits_i64` of its **result**, not merely on its operands being carriers. An operation whose result can leave `i64` stays boxed and runs in `$AverInt`. Verified: a carrier bounded `0..2^40` doing `c.value * c.value` (= 2^80) produces the exact `1208925819614629174706176` on **both** the VM and wasm-gc — the WAT shows that multiply stays boxed (`__aint_mul`, no `i64.mul`); the fixpoint demoted the overflowing op rather than emit a wrapping native one. The VM (full ℤ) is ground truth; wasm-gc `i64` wraps silently, so this gating is the whole correctness story.

Scoped to wasm-gc — the Rust backend keeps carriers as real structs, so the rewrite passes it an empty carrier table. The path is filtered by carrier **eligibility** (post-demotion), so a carrier the registry kept boxed never goes raw; `AVER_NO_CARRIER_I64=1` empties the set and restores the boxed representation.

## Tests

`tests/wasm_gc_carrier_i64_differential.rs` (+5 cases: carrier+carrier, carrier×literal, comparison `<`/`==`, mixed field/param, record-field + increment, and the wide-bound overflow probe). Full carrier differential 18/18, cross-backend proptest + stress, wasip2 `pool_wraparound` family, per-slot Int differential — all pass. `cargo test` default 2283/0; `fmt --check` clean; clippy `-D warnings` on lib + `aver` bin (default and `wasm,wasip2`) clean.

## Measured

Carrier-arithmetic probe: 1908 B vs 4041 B boxed (−53%). A coords/score-as-carrier-parameter snake variant: 2032 B vs 6339 B (−68%), VM == wasm-gc — the bignum prelude becomes unreachable once the arithmetic goes native.

## Honest caveat (follow-up)

The win lands on arithmetic over carrier **parameters/locals**. A nested carrier-**field** read (`state.coord.value` = `Project(Project(..))`) still routes through the boxed project bridge, so a record-threaded program that keeps its Ints in a state record doesn't benefit yet — extending the raw projection to nested carrier fields is the next slice (the one that makes the real `examples/games/snake.av` shrink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
