### PR TITLE
wasm-gc: native i64 arithmetic on carrier values read from record fields

### DIFF
--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -1053,10 +1053,11 @@ pub(crate) fn emit_mir_expr(
                 // native `i64.add` instead of two `__aint_from_i64` lifts plus
                 // a boxed limb-add.
                 let produced = emit_mir_expr(func, &proj.base, slots, ctx)?;
-                let bare_carrier_read = matches!(
-                    &proj.base.node,
-                    MirExpr::Local(local) if ctx.slot_is_bare_carrier(local.node.slot.0)
-                );
+                // The base renders a native `i64` (so the `.value` read is
+                // identity → raw i64, skip the project bridge) when it is a BARE
+                // carrier slot (#551) OR a NESTED carrier-field read (#550 erased
+                // the carrier field to i64, so the inner `struct.get` yields i64).
+                let bare_carrier_read = mir_base_renders_carrier_i64_raw(&proj.base, ctx);
                 if produced.is_some()
                     && ctx.registry.is_eligible_carrier(&record_name)
                     && !bare_carrier_read
@@ -1335,18 +1336,33 @@ fn mir_arith_leaves_raw_compatible(e: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
     }
 }
 
-/// ETAP-2 carrier-`i64`: is `e` a `Project(Local(bare_carrier_slot), _)`?
-/// Such a `.value` read renders as a raw native `i64` (the project bridge is
-/// skipped) — a genuine raw anchor like an `Unbox`.
+/// ETAP-2 carrier-`i64`: is `e` a `.value` `Project` whose BASE renders a
+/// native `i64` carrier value? Such a read renders as a raw native `i64` (the
+/// project bridge is skipped) — a genuine raw anchor like an `Unbox`. Two base
+/// shapes qualify, mirroring `FnBareFacts::carrier_project_interval`:
+///   - `Local(bare_carrier_slot)` — a bare carrier param/local (#551);
+///   - a NESTED carrier-field read — a `Project` whose result type is an
+///     eligible carrier (`rec.coord` in `rec.coord.value`); #550 erased that
+///     carrier field to a native `i64`, so the inner `struct.get` yields i64
+///     and the outer `.value` is identity.
 fn mir_is_bare_carrier_project(e: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
-    matches!(
-        e,
-        MirExpr::Project(p)
-            if matches!(
-                &p.node.base.node,
-                MirExpr::Local(local) if ctx.slot_is_bare_carrier(local.node.slot.0)
-            )
-    )
+    matches!(e, MirExpr::Project(p) if mir_base_renders_carrier_i64_raw(&p.node.base, ctx))
+}
+
+/// ETAP-2 carrier-`i64`: does `base` render a native `i64` carrier value (so a
+/// `.value` `Project` over it is identity → raw i64, skipping the project
+/// bridge)? True for a BARE carrier slot (`Local`, #551) or a NESTED
+/// carrier-field read (a `Project` whose stamped type is an eligible carrier,
+/// #550 erased the field to i64). Fail-closed: any other base is NOT a raw
+/// carrier read (the bridge runs, lifting the i64 to `$AverInt`).
+fn mir_base_renders_carrier_i64_raw(base: &Spanned<MirExpr>, ctx: &EmitCtx<'_>) -> bool {
+    match &base.node {
+        MirExpr::Local(local) => ctx.slot_is_bare_carrier(local.node.slot.0),
+        // A carrier-typed field read: its result type is the eligible carrier,
+        // which #550 stored as a native `i64`, so the field read yields i64.
+        MirExpr::Project(_) => ctx.registry.is_eligible_carrier(&aver_type_str_of(base)),
+        _ => false,
+    }
 }
 
 /// The `Add`/`Sub`/`Mul`/`Neg` tree `e` contains at least one genuine raw
@@ -1479,19 +1495,15 @@ pub(crate) fn emit_mir_int_raw(
         MirExpr::Unbox(_) | MirExpr::Call(_) | MirExpr::TailCall(_) => {
             emit_mir_expr(func, e, slots, ctx)
         }
-        // ETAP-2 carrier-`i64`: a `Project(Local(bare_carrier), "value")`
-        // reads the carrier's native i64 — the main emitter's `Project` arm
-        // skips the project bridge for a bare carrier slot, leaving the raw
-        // i64 on the stack. A non-bare-carrier `Project` reaching here would
-        // push an `$AverInt` (project bridge) where an i64 is expected, so
-        // guard: only delegate when the base is a bare carrier slot, else
-        // fall back (`Ok(None)`) — fail-closed.
-        MirExpr::Project(p) => {
-            let bare_carrier = matches!(
-                &p.node.base.node,
-                MirExpr::Local(local) if ctx.slot_is_bare_carrier(local.node.slot.0)
-            );
-            if bare_carrier {
+        // ETAP-2 carrier-`i64`: a `.value` `Project` over a native-i64 carrier
+        // base (a bare carrier slot, or a nested carrier-field read) reads the
+        // carrier's native i64 — the main emitter's `Project` arm skips the
+        // project bridge, leaving the raw i64 on the stack. Any other `Project`
+        // reaching here would push an `$AverInt` (project bridge) where an i64
+        // is expected, so guard on `mir_is_bare_carrier_project`, else fall back
+        // (`Ok(None)`) — fail-closed.
+        MirExpr::Project(_) => {
+            if mir_is_bare_carrier_project(&e.node, ctx) {
                 emit_mir_expr(func, e, slots, ctx)
             } else {
                 Ok(None)

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -181,6 +181,17 @@ pub struct FnBareFacts {
     /// backend (it keeps the carrier struct) and whenever no eligible carrier
     /// is in scope — the byte-identical default.
     pub carrier_slots: HashMap<LocalId, Interval>,
+    /// ETAP-2 carrier-`i64` (wasm-gc only): the eligible-carrier type table
+    /// (`bare type name → (proven interval, recognized)`), restricted to the
+    /// registry's eligible set. Lets `carrier_project_interval` recognize a
+    /// NESTED carrier-field read — `Project(Project(rec, "coord"), "value")`,
+    /// where the inner `rec.coord` is stamped an eligible carrier type — as a
+    /// raw i64 leaf carrying `coord`'s proven bound. The #550 storage erasure
+    /// already made the carrier field a native `i64`, so the inner field read
+    /// yields i64 and the outer `.value` is identity. EMPTY on the Rust
+    /// backend / whenever no eligible carrier is in scope — the byte-identical
+    /// default (the nested form then never fires, only the `Local`-base form).
+    pub carrier_types: CarrierIntervals,
 }
 
 impl FnBareFacts {
@@ -205,20 +216,58 @@ impl FnBareFacts {
         fact.interval
     }
 
-    /// ETAP-2 carrier-`i64`: the proven interval of a `Project(Local(slot),
-    /// _)` whose base `slot` holds a BARE carrier (wasm storage IS i64). The
-    /// `.value` read is a native i64 carrying the carrier's smart-constructor
-    /// bound, so it is a bare leaf for the surrounding arithmetic. `None` for
-    /// any non-carrier base — the conservative decline (boxed `$AverInt`
-    /// project bridge).
+    /// ETAP-2 carrier-`i64`: the proven interval of a `.value` `Project` whose
+    /// BASE renders an eligible carrier value (wasm storage IS i64). Two base
+    /// shapes qualify, both reading a native i64:
+    ///   - a `Local` in `carrier_slots` — a bare carrier PARAM/local (the #551
+    ///     param-level form);
+    ///   - a NESTED carrier-field read — a `Project` whose result `ty()` is an
+    ///     eligible carrier type (`carrier_types`), e.g. `rec.coord` in
+    ///     `rec.coord.value`. The #550 storage erasure made `coord` a native
+    ///     `i64` field, so the inner `struct.get` yields i64 and the outer
+    ///     `.value` is identity. The general field-of-field-of-… case is
+    ///     covered: ANY base whose `ty()` is an eligible carrier renders i64.
+    ///
+    /// In both cases the `.value` read is a native i64 carrying the carrier's
+    /// smart-constructor bound, a bare leaf for the surrounding arithmetic.
+    /// `None` for any other base — the conservative, fail-closed decline (the
+    /// boxed `$AverInt` project bridge runs).
     pub fn carrier_project_interval(&self, e: &MirExpr) -> Option<Interval> {
         let MirExpr::Project(p) = e else {
             return None;
         };
-        let MirExpr::Local(local) = &p.node.base.node else {
+        // Param/local bare carrier slot (#551).
+        if let MirExpr::Local(local) = &p.node.base.node
+            && let Some(iv) = self.carrier_slots.get(&local.node.slot).copied()
+        {
+            return Some(iv);
+        }
+        // Nested carrier-field read: the base is any expression whose stamped
+        // type is an eligible carrier (a field read, or transitively a field of
+        // a field). The #550 storage erasure made that carrier a native `i64`,
+        // so the base renders raw i64 and its `.value` is identity. Fail-closed:
+        // if the base has no stamped type, or the type is not an eligible
+        // carrier, decline (boxed).
+        self.base_renders_eligible_carrier(&p.node.base)
+    }
+
+    /// The proven interval of `base` when it renders an eligible carrier value
+    /// as a native `i64` — i.e. `base.ty()` is an eligible carrier type held in
+    /// `carrier_types`. This is the NESTED-field recognition: a carrier-typed
+    /// field read (`rec.coord`) was erased to an i64 field by #550, so reading
+    /// its `.value` is identity over that i64. We additionally require `base`
+    /// to be a `Project` so the recognition matches EXACTLY the i64-rendering
+    /// positions the wasm-gc emitter skips the project bridge for (a carrier
+    /// field read); a carrier-typed `Local`/`Call`/etc. base is NOT recognized
+    /// here (those go through `carrier_slots` or stay boxed) — fail-closed.
+    fn base_renders_eligible_carrier(&self, base: &Spanned<MirExpr>) -> Option<Interval> {
+        if !matches!(base.node, MirExpr::Project(_)) {
             return None;
-        };
-        self.carrier_slots.get(&local.node.slot).copied()
+        }
+        let name = base.ty().and_then(Type::named_name)?;
+        let bare = name.rsplit_once('.').map_or(name, |(_, b)| b);
+        let (iv, known) = self.carrier_types.get(bare).copied()?;
+        (known && iv.fits_i64()).then_some(iv)
     }
 
     /// ETAP-2 carrier-`i64`: does `e` read a bare carrier's i64 `.value`
@@ -1189,9 +1238,9 @@ fn caller_env(f: &MirFn, cells: &[Interval], floors: &[Interval]) -> HashMap<Loc
 fn eval_interval_pub(e: &MirExpr, env: &HashMap<LocalId, Interval>) -> Interval {
     let mut worst = Interval::point(0);
     // The recurrence back-edge args are `counter - step` over Int counters; a
-    // carrier `.value` projection never appears here, so the carrier-slot map
-    // is empty (a `Project` evaluates to `unbounded()`, the safe decline).
-    let no_carriers: HashMap<LocalId, Interval> = HashMap::new();
+    // carrier `.value` projection never appears here, so the carrier facts are
+    // empty (a `Project` evaluates to `unbounded()`, the safe decline).
+    let no_carriers = FnBareFacts::default();
     let iv = eval_interval(e, env, &mut worst, &no_carriers);
     worst.hull(iv)
 }
@@ -1712,17 +1761,18 @@ fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBar
     // can recognize a bare carrier's `.value` read. (Set before the combine so
     // `tail_value_is_bare` / `expr_is_bare_i64` see them via `&facts`.)
     facts.carrier_slots = carrier_slots;
+    // The eligible-carrier type table powers the NESTED carrier-field
+    // recognition (`Project(Project(rec, "coord"), "value")` whose inner
+    // `rec.coord` is stamped an eligible carrier). EMPTY on the Rust backend /
+    // no-eligible-carrier baseline, so the nested form never fires there.
+    facts.carrier_types = carrier.clone();
 
     // 2. Walk the body's `Let` chain, deriving an interval (+ worst-join
     //    op class) for each bound slot. The carrier-projection facts let the
-    //    walk read a bare carrier's `.value` as its proven i64 interval.
+    //    walk read a bare carrier's `.value` (param-level OR nested field) as
+    //    its proven i64 interval.
     let mut op_classes: HashMap<LocalId, OpClass> = HashMap::new();
-    walk_let_chain(
-        &f.body.node,
-        &mut intervals,
-        &mut op_classes,
-        &facts.carrier_slots,
-    );
+    walk_let_chain(&f.body.node, &mut intervals, &mut op_classes, &facts);
 
     // 3. Escape: a single use-flow scan. A slot escapes if any use-site is
     //    a general-Int context.
@@ -1786,25 +1836,26 @@ fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBar
 
 /// Walk the `Let` chain, recording each bound slot's interval and worst-
 /// join op class. `env` holds param + already-bound intervals and is grown
-/// in place; branches recurse so nested bindings are seen. `carrier_slots`
-/// lets a bare carrier's `.value` read (`Project`) contribute its proven
-/// interval to an arithmetic binding.
+/// in place; branches recurse so nested bindings are seen. `facts` carries
+/// the carrier-projection facts (`carrier_slots` + `carrier_types`) so a bare
+/// carrier's `.value` read (`Project`, param-level OR nested field) contributes
+/// its proven interval to an arithmetic binding.
 fn walk_let_chain(
     e: &MirExpr,
     env: &mut HashMap<LocalId, Interval>,
     op_classes: &mut HashMap<LocalId, OpClass>,
-    carrier_slots: &HashMap<LocalId, Interval>,
+    facts: &FnBareFacts,
 ) {
     match e {
         MirExpr::Let(l) => {
             let mut worst = Interval::point(0);
-            let iv = eval_interval(&l.node.value.node, env, &mut worst, carrier_slots);
+            let iv = eval_interval(&l.node.value.node, env, &mut worst, facts);
             env.insert(l.node.binding, iv);
             // The binding's op class is the worst-join over its value
             // expression (so a transient out-of-i64 intermediate demotes).
             op_classes.insert(l.node.binding, OpClass::of_interval(worst.hull(iv)));
-            walk_let_chain(&l.node.value.node, env, op_classes, carrier_slots);
-            walk_let_chain(&l.node.body.node, env, op_classes, carrier_slots);
+            walk_let_chain(&l.node.value.node, env, op_classes, facts);
+            walk_let_chain(&l.node.body.node, env, op_classes, facts);
         }
         // A `match subject { y -> … }` Ident-binding arm ALIASES the subject:
         // the binder `y` carries the subject's interval. Without this, a
@@ -1816,8 +1867,8 @@ fn walk_let_chain(
         // the current `env` (the subject is already in scope).
         MirExpr::Match(m) => {
             let mut worst = Interval::point(0);
-            let subj_iv = eval_interval(&m.node.subject.node, env, &mut worst, carrier_slots);
-            walk_let_chain(&m.node.subject.node, env, op_classes, carrier_slots);
+            let subj_iv = eval_interval(&m.node.subject.node, env, &mut worst, facts);
+            walk_let_chain(&m.node.subject.node, env, op_classes, facts);
             for arm in &m.node.arms {
                 if let MirPattern::Bind(slot, _) = &arm.pattern {
                     // Alias: the binder takes the subject's interval + op
@@ -1827,28 +1878,28 @@ fn walk_let_chain(
                         .entry(*slot)
                         .or_insert_with(|| OpClass::of_interval(subj_iv));
                 }
-                walk_let_chain(&arm.body.node, env, op_classes, carrier_slots);
+                walk_let_chain(&arm.body.node, env, op_classes, facts);
             }
         }
         _ => {
-            visit_children(e, &mut |c| {
-                walk_let_chain(c, env, op_classes, carrier_slots)
-            });
+            visit_children(e, &mut |c| walk_let_chain(c, env, op_classes, facts));
         }
     }
 }
 
 /// Abstractly evaluate a MIR expression to its interval, joining each
 /// arithmetic node into `worst` (so a transient out-of-i64 intermediate
-/// demotes the binding). Unknown shapes evaluate to `unbounded()`.
-/// `carrier_slots` maps a bare carrier slot to its proven `fits_i64` bound, so
-/// a `Project(Local(carrier_slot), _)` (`c.value`) evaluates to that bound
-/// rather than `unbounded()` — the carrier-projection leaf.
+/// demotes the binding). Unknown shapes evaluate to `unbounded()`. `facts`
+/// carries the carrier-projection facts so a `.value` read over a bare carrier
+/// — a param/local (`carrier_slots`) OR a nested carrier-field read
+/// (`Project(Project(..))` whose inner type is an eligible carrier) — evaluates
+/// to the carrier's proven bound rather than `unbounded()`, the
+/// carrier-projection leaf.
 fn eval_interval(
     e: &MirExpr,
     env: &HashMap<LocalId, Interval>,
     worst: &mut Interval,
-    carrier_slots: &HashMap<LocalId, Interval>,
+    facts: &FnBareFacts,
 ) -> Interval {
     match e {
         MirExpr::Literal(l) => match l.node {
@@ -1859,23 +1910,20 @@ fn eval_interval(
             .get(&local.node.slot)
             .copied()
             .unwrap_or_else(Interval::unbounded),
-        // ETAP-2 carrier-`i64`: `c.value` over a bare carrier slot reads the
-        // native i64 with the carrier's proven bound.
-        MirExpr::Project(p) => match &p.node.base.node {
-            MirExpr::Local(local) => carrier_slots
-                .get(&local.node.slot)
-                .copied()
-                .unwrap_or_else(Interval::unbounded),
-            _ => Interval::unbounded(),
-        },
+        // ETAP-2 carrier-`i64`: `c.value` over a bare carrier (param/local or a
+        // nested carrier field) reads the native i64 with the carrier's proven
+        // bound; any other `Project` declines to `unbounded()`.
+        MirExpr::Project(_) => facts
+            .carrier_project_interval(e)
+            .unwrap_or_else(Interval::unbounded),
         MirExpr::Neg(inner) => {
-            let r = Interval::point(0).sub(eval_interval(&inner.node, env, worst, carrier_slots));
+            let r = Interval::point(0).sub(eval_interval(&inner.node, env, worst, facts));
             *worst = worst.hull(r);
             r
         }
         MirExpr::BinOp(b) => {
-            let l = eval_interval(&b.node.lhs.node, env, worst, carrier_slots);
-            let r = eval_interval(&b.node.rhs.node, env, worst, carrier_slots);
+            let l = eval_interval(&b.node.lhs.node, env, worst, facts);
+            let r = eval_interval(&b.node.rhs.node, env, worst, facts);
             let result = match b.node.op {
                 BinOp::Add => l.add(r),
                 BinOp::Sub => l.sub(r),
@@ -2387,6 +2435,185 @@ fn main() -> Int
         }
     }
 
+    /// NESTED carrier-FIELD source: `Holder { c: IntRange }` whose `nestedAdd`
+    /// reads `h.c.value + h.c.value` (a `Project(Project(..))`). The base
+    /// `h.c` is stamped the eligible carrier `IntRange`, so the analysis treats
+    /// each nested `.value` as a raw i64 leaf at the `[0,100]` bound and the sum
+    /// stays OverflowFree (bare); a wide `0..2^40` carrier's `c.value * c.value`
+    /// overflows i64 and DECLINES (boxed) — the same fixpoint, fed the nested
+    /// leaf. With the carrier table OFF, the nested form never fires.
+    const NESTED_CARRIER_SRC: &str = r#"
+module Toy
+    intent = "t"
+    depends []
+
+record IntRange
+    value: Int
+
+record Holder
+    c: IntRange
+
+record Wide
+    value: Int
+
+record WideHolder
+    c: Wide
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("err")
+
+fn fromWide(n: Int) -> Result<Wide, String>
+    match Bool.and(n >= 0, n <= 1099511627776)
+        true  -> Result.Ok(Wide(value = n))
+        false -> Result.Err("err")
+
+fn nestedAdd(h: Holder) -> Int
+    h.c.value + h.c.value
+
+fn nestedWideMul(h: WideHolder) -> Int
+    h.c.value * h.c.value
+
+fn main() -> Int
+    0
+"#;
+
+    fn nested_carrier_facts(carrier_on: bool) -> (MirProgram, BareI64Facts) {
+        let mut items = parse_source(NESTED_CARRIER_SRC).expect("parse");
+        let cfg = crate::ir::pipeline::PipelineConfig {
+            typecheck: Some(crate::ir::pipeline::TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        };
+        let result = crate::ir::pipeline::run(&mut items, cfg);
+        assert!(
+            result
+                .typecheck
+                .as_ref()
+                .is_none_or(|t| t.errors.is_empty()),
+            "typecheck errors: {:?}",
+            result.typecheck.map(|t| t.errors)
+        );
+        let carrier = if carrier_on {
+            carrier_table_for(&items, &result.symbol_table)
+        } else {
+            CarrierIntervals::new()
+        };
+        let mir_items = result.resolved_items.clone();
+        let program = optimize(lower_program(&mir_items));
+        let facts = analyze(&program, &carrier);
+        (program, facts)
+    }
+
+    /// Find the `Project(Project(..), _)` nested-field read inside `e` and
+    /// query the carrier-projection recognizer on it.
+    fn find_nested_project_interval(e: &MirExpr, facts: &FnBareFacts) -> Option<Interval> {
+        if let MirExpr::Project(p) = e
+            && matches!(p.node.base.node, MirExpr::Project(_))
+            && let Some(iv) = facts.carrier_project_interval(e)
+        {
+            return Some(iv);
+        }
+        let mut found = None;
+        visit_children(e, &mut |c| {
+            if found.is_none() {
+                found = find_nested_project_interval(c, facts);
+            }
+        });
+        found
+    }
+
+    #[test]
+    fn nested_carrier_field_in_range_is_bare_leaf() {
+        // The carrier table is ON: the nested `h.c.value` read is recognized as
+        // a raw i64 leaf carrying the carrier's proven `[0,100]` bound, so the
+        // `+` over it is OverflowFree (the binding goes bare).
+        let (program, facts) = nested_carrier_facts(true);
+        let id = fn_id_by_name(&program, "nestedAdd");
+        let f = facts.for_fn(id).expect("nestedAdd facts");
+        let pf = program.fn_by_id(id).expect("mir fn");
+        let iv = find_nested_project_interval(&pf.body.node, f)
+            .expect("the nested h.c.value read is recognized as a carrier projection");
+        assert_eq!(
+            iv,
+            Interval::between(0, 100),
+            "the nested-field read carries the carrier's proven [0,100] bound"
+        );
+        // The whole `h.c.value + h.c.value` tree is a bare i64 expression.
+        let sum =
+            find_carrier_sum(&pf.body.node).expect("the body contains the `c.value + c.value` add");
+        assert!(
+            f.expr_is_bare_i64(sum),
+            "in-range nested-field sum is bare-i64 eligible (OverflowFree)"
+        );
+    }
+
+    #[test]
+    fn nested_carrier_field_off_table_declines() {
+        // With the carrier table EMPTY, the nested form never fires — the read
+        // is not recognized as a carrier projection (fail-closed → boxed).
+        let (program, facts) = nested_carrier_facts(false);
+        let id = fn_id_by_name(&program, "nestedAdd");
+        let f = facts.for_fn(id).expect("nestedAdd facts");
+        let pf = program.fn_by_id(id).expect("mir fn");
+        assert!(
+            find_nested_project_interval(&pf.body.node, f).is_none(),
+            "with the carrier table empty, a nested-field read is NOT a carrier projection"
+        );
+    }
+
+    #[test]
+    fn nested_carrier_field_wide_mul_declines() {
+        // A wide `0..2^40` nested-field carrier: `h.c.value * h.c.value` reaches
+        // up to 2^80, which overflows i64. Even though each nested read IS a
+        // recognized carrier projection, the PRODUCT leaves i64, so the compound
+        // declines to boxed — the same C0 gate as the param-level form.
+        let (program, facts) = nested_carrier_facts(true);
+        let id = fn_id_by_name(&program, "nestedWideMul");
+        let f = facts.for_fn(id).expect("nestedWideMul facts");
+        let pf = program.fn_by_id(id).expect("mir fn");
+        // The nested leaf IS recognized (carries the wide bound) …
+        let iv = find_nested_project_interval(&pf.body.node, f)
+            .expect("the nested wide read is still a recognized carrier projection");
+        assert!(iv.fits_i64(), "the [0,2^40] carrier bound itself fits i64");
+        // … but the `*` product does NOT, so the compound is NOT bare-i64.
+        let mul = find_carrier_sum(&pf.body.node)
+            .expect("the body contains the `c.value * c.value` multiply");
+        assert!(
+            !f.expr_is_bare_i64(mul),
+            "the wide-bound nested-field multiply overflows i64 and stays boxed"
+        );
+    }
+
+    /// Find the `Add`/`Mul` `BinOp` whose operands are nested-field carrier
+    /// reads (the `c.value + c.value` / `c.value * c.value` body). Manual
+    /// recursion over the tail-bearing node shapes (the body is a single arith
+    /// node, possibly wrapped in `Return`/`Let`/`Match`), returning a borrowed
+    /// reference (so it cannot route through the `visit_children` closure).
+    fn find_carrier_sum(e: &MirExpr) -> Option<&MirExpr> {
+        match e {
+            MirExpr::BinOp(b)
+                if matches!(b.node.op, BinOp::Add | BinOp::Mul)
+                    && matches!(b.node.lhs.node, MirExpr::Project(_))
+                    && matches!(b.node.rhs.node, MirExpr::Project(_)) =>
+            {
+                Some(e)
+            }
+            MirExpr::Return(inner) | MirExpr::Box(inner) | MirExpr::Unbox(inner) => {
+                find_carrier_sum(&inner.node)
+            }
+            MirExpr::Let(l) => {
+                find_carrier_sum(&l.node.value.node).or_else(|| find_carrier_sum(&l.node.body.node))
+            }
+            MirExpr::Match(m) => m
+                .node
+                .arms
+                .iter()
+                .find_map(|a| find_carrier_sum(&a.body.node)),
+            _ => None,
+        }
+    }
+
     #[test]
     fn countdown_counter_is_bare() {
         let src = r#"
@@ -2555,7 +2782,7 @@ fn main() -> List<Int>
         }));
 
         let mut worst = Interval::point(0);
-        let no_carriers: HashMap<LocalId, Interval> = HashMap::new();
+        let no_carriers = FnBareFacts::default();
         let result = eval_interval(&sub, &env, &mut worst, &no_carriers);
         // The final value cancels back into [0, 10] (fits i64) …
         assert!(result.fits_i64(), "final value cancels back into range");

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -698,6 +698,354 @@ fn main() -> Unit
 }
 
 // ---------------------------------------------------------------------------
+// NESTED carrier-FIELD reads (`rec.c.value`) — the record-threaded GAMES win.
+//
+// A `.value` read whose base is itself a carrier-typed RECORD FIELD —
+// `Project(Project(rec, "c"), "value")` — renders raw native `i64` on wasm-gc:
+// #550 erased the carrier field `c` to an i64 field, so the inner `struct.get`
+// yields i64 and the outer `.value` is identity. Before this slice the read
+// routed through the boxed `$AverInt` project bridge (the base was a `Project`,
+// not a bare-carrier `Local`), so a state-record-threaded game got ZERO arith
+// win. Now the nested read is a raw i64 leaf fed into the SAME interval
+// fixpoint as a param-level read: in-range arithmetic goes native, an
+// out-of-`i64` op stays boxed. The VM (full ℤ) is the oracle.
+
+/// The core nested-field shape: a record `{ c: Carrier }` with `rec.c.value +
+/// rec.c.value`. Each `rec.c.value` reads the i64 carrier field directly and
+/// the sum runs as a native `i64.add`. VM == wasm-gc, compiles clean, reverts.
+#[test]
+fn nested_carrier_field_add_matches_vm() {
+    let src = r#"module M
+    intent = "nested carrier-field read add"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+record Holder
+    c: IntRange
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<IntRange, String>) -> IntRange
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> IntRange(value = 0)
+
+fn ir(n: Int) -> IntRange
+    unwrap(fromInt(n))
+
+fn doubled(h: Holder) -> Int
+    h.c.value + h.c.value
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{doubled(Holder(c = ir(21)))}")
+"#;
+    let out = assert_vm_wasm_identical("nested-field-add", src);
+    assert_eq!(out, "42");
+    assert_carrier_revert_agrees("nested-field-add", src, &out);
+}
+
+/// The SNAKE shape — a GameState-like record holding bounded-carrier coords +
+/// a delta, with `state.x.value + state.dx.value` style nested-field
+/// arithmetic (the canonical record-threaded game move). Both nested reads are
+/// raw i64; the add is native. VM == wasm-gc, compiles clean, reverts.
+#[test]
+fn nested_carrier_field_snake_move_matches_vm() {
+    let src = r#"module M
+    intent = "snake-shaped nested carrier-field arithmetic"
+    effects [Console]
+
+record Coord
+    value: Int
+
+record GameState
+    x: Coord
+    y: Coord
+    dx: Coord
+    dy: Coord
+    score: Coord
+
+fn coordOf(n: Int) -> Result<Coord, String>
+    match Bool.and(n >= 0, n <= 1000)
+        true  -> Result.Ok(Coord(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<Coord, String>) -> Coord
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Coord(value = 0)
+
+fn coord(n: Int) -> Coord
+    unwrap(coordOf(n))
+
+fn nextX(s: GameState) -> Int
+    s.x.value + s.dx.value
+
+fn nextY(s: GameState) -> Int
+    s.y.value + s.dy.value
+
+fn bumpedScore(s: GameState) -> Int
+    s.score.value + 1
+
+fn atFood(s: GameState, fx: Coord, fy: Coord) -> Bool
+    Bool.and(s.x.value == fx.value, s.y.value == fy.value)
+
+fn main() -> Unit
+    ! [Console.print]
+    s = GameState(x = coord(5), y = coord(7), dx = coord(1), dy = coord(2), score = coord(3))
+    Console.print("{nextX(s)} {nextY(s)} {bumpedScore(s)} {atFood(s, coord(5), coord(7))} {atFood(s, coord(6), coord(7))}")
+"#;
+    let out = assert_vm_wasm_identical("nested-field-snake", src);
+    assert_eq!(out, "6 9 4 true false");
+    assert_carrier_revert_agrees("nested-field-snake", src, &out);
+}
+
+/// Nested-field read flowing into each `$AverInt`-typed SINK. A bare-returning
+/// fn whose body is a nested-field arith (`h.c.value + h.c.value`, kept native)
+/// feeds its raw `i64` result into: `String.fromInt`, a `Map` value, an
+/// independent-product (bang-group) element, and a no-bind `match` subject.
+/// Each sink slot is `$AverInt`, so the rewrite must box the raw result at the
+/// boundary (the same chokepoints #551 closed) — the new raw SOURCE flows into
+/// the SAME sinks. VM == wasm-gc, and the WHOLE module compiles clean.
+#[test]
+fn nested_carrier_field_into_sinks_box_at_boundary() {
+    let src = r#"module M
+    intent = "nested carrier-field result into $AverInt sinks"
+    effects [Console]
+
+record IntRange
+    value: Int
+
+record Holder
+    c: IntRange
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true  -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<IntRange, String>) -> IntRange
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> IntRange(value = 0)
+
+fn ir(n: Int) -> IntRange
+    unwrap(fromInt(n))
+
+fn dbl(h: Holder) -> Int
+    h.c.value + h.c.value
+
+fn toStr(h: Holder) -> String
+    String.fromInt(dbl(h))
+
+fn intoMap(h: Holder) -> Int
+    m = Map.set({}, "k", dbl(h))
+    Option.withDefault(Map.get(m, "k"), 0)
+
+fn intoProduct(h: Holder) -> Int
+    match (dbl(h), dbl(h))!
+        (a, b) -> a + b
+
+fn classify(h: Holder) -> Int
+    match dbl(h)
+        0  -> 1
+        20 -> 2
+        _  -> 3
+
+fn main() -> Unit
+    ! [Console.print]
+    h = Holder(c = ir(10))
+    Console.print("{toStr(h)} {intoMap(h)} {intoProduct(h)} {classify(h)}")
+"#;
+    let out = assert_vm_wasm_identical("nested-field-sinks", src);
+    assert_eq!(out, "20 20 40 2");
+    assert_carrier_revert_agrees("nested-field-sinks", src, &out);
+}
+
+/// WIDE-BOUND NESTED-FIELD OVERFLOW (the C0 soundness probe for the new raw
+/// source). A record holds a `0..2^40` carrier; `rec.c.value * rec.c.value` =
+/// up to `2^80`, which OVERFLOWS `i64`. The interval fixpoint must read the
+/// nested-field `.value` at the carrier's PROVEN `[0, 2^40]` bound and DEMOTE
+/// the multiply to boxed (the project bridge runs, the `*` is the
+/// full-precision `__aint_mul`) — a raw `i64.mul` would WRAP silently. The VM
+/// keeps full ℤ; an equal wasm-gc result proves the analysis bounded the
+/// nested-field read correctly and did NOT emit a wrapping native op.
+#[test]
+fn nested_carrier_field_wide_bound_mul_stays_boxed_match_vm() {
+    let src = r#"module M
+    intent = "nested carrier-field wide-bound multiply overflow"
+    effects [Console]
+
+record Wide
+    value: Int
+
+record Holder
+    c: Wide
+
+fn fromWide(n: Int) -> Result<Wide, String>
+    match Bool.and(n >= 0, n <= 1099511627776)
+        true  -> Result.Ok(Wide(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<Wide, String>) -> Wide
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Wide(value = 0)
+
+fn wide(n: Int) -> Wide
+    unwrap(fromWide(n))
+
+fn square(h: Holder) -> Int
+    h.c.value * h.c.value
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{square(Holder(c = wide(1099511627776)))}")
+"#;
+    // (2^40)^2 = 2^80, far beyond i64::MAX. The nested-field `.value` reads carry
+    // the [0, 2^40] bound, so the fixpoint demotes the multiply to boxed and the
+    // VM's exact bignum is reproduced.
+    let out = assert_vm_wasm_identical("nested-field-wide-overflow", src);
+    assert_eq!(out, "1208925819614629174706176");
+}
+
+/// SIZE PROOF for the record-threaded win: a snake-shaped GameState whose
+/// coords + score are bounded opaque carriers held in a record, with native
+/// nested-field arithmetic across moves. With the carrier path ON (default)
+/// the `.value` reads are raw i64 and the add/sub/mul/cmp run native, so the
+/// boxed `$AverInt` arithmetic prelude DCEs; with it OFF (`AVER_NO_CARRIER_I64=1`)
+/// each read lifts through the project bridge into a boxed limb-op. The ON
+/// build must be NO LARGER than the boxed baseline (and strictly smaller here,
+/// since the boxed-arith helpers are no longer reachable). VM == wasm-gc both
+/// ways is covered by `assert_vm_wasm_identical`; this test reports the bytes.
+#[test]
+fn nested_carrier_field_snake_size_drops_vs_boxed() {
+    let src = r#"module M
+    intent = "record-threaded snake size: native carrier-field arithmetic"
+    effects [Console]
+
+record Coord
+    value: Int
+
+record GameState
+    x: Coord
+    y: Coord
+    dx: Coord
+    dy: Coord
+    score: Coord
+
+fn coordOf(n: Int) -> Result<Coord, String>
+    match Bool.and(n >= 0, n <= 1000)
+        true  -> Result.Ok(Coord(value = n))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<Coord, String>) -> Coord
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Coord(value = 0)
+
+fn coord(n: Int) -> Coord
+    unwrap(coordOf(n))
+
+fn nextX(s: GameState) -> Int
+    s.x.value + s.dx.value
+
+fn nextY(s: GameState) -> Int
+    s.y.value + s.dy.value
+
+fn manhattan(s: GameState, fx: Coord, fy: Coord) -> Int
+    (fx.value - s.x.value) + (fy.value - s.y.value)
+
+fn areaScaled(s: GameState) -> Int
+    s.x.value * s.dx.value
+
+fn atFood(s: GameState, fx: Coord, fy: Coord) -> Bool
+    Bool.and(s.x.value == fx.value, s.y.value == fy.value)
+
+fn aheadOf(s: GameState, fx: Coord) -> Bool
+    s.x.value < fx.value
+
+fn bumpScore(s: GameState) -> Int
+    s.score.value + 1
+
+fn main() -> Unit
+    ! [Console.print]
+    s = GameState(x = coord(5), y = coord(7), dx = coord(1), dy = coord(2), score = coord(3))
+    fx = coord(8)
+    fy = coord(7)
+    Console.print("{nextX(s)} {nextY(s)} {manhattan(s, fx, fy)} {areaScaled(s)} {atFood(s, fx, fy)} {aheadOf(s, fx)} {bumpScore(s)}")
+"#;
+    // Behavior is identical both ways (representation-only erasure).
+    let out = assert_vm_wasm_identical("nested-snake-size", src);
+    assert_eq!(out, "6 9 3 5 false true 4");
+    assert_carrier_revert_agrees("nested-snake-size", src, &out);
+
+    let on = compile_wasm_bytes("nested-snake-on", src, false);
+    let off = compile_wasm_bytes("nested-snake-off", src, true);
+    assert!(
+        on.len() <= off.len(),
+        "record-threaded carrier-i64 must not GROW the module — native nested-field \
+         arithmetic should DCE the boxed arith prelude. carrier-ON={} bytes, \
+         carrier-OFF(boxed)={} bytes",
+        on.len(),
+        off.len(),
+    );
+    // The boxed `$AverInt` arithmetic helpers (`__aint_add` / `__aint_mul` /
+    // `__aint_sub`) must be UNREACHABLE in the carrier-ON build — every nested
+    // read went native. The WAT-token probe tolerates `wasm-tools` being absent
+    // (both counts 0 ⇒ the assertion is vacuous). With it present the carrier-ON
+    // boxed-arith footprint must sit STRICTLY below the boxed baseline.
+    let on_boxed_arith = carrier_boxed_arith_token_count("nested-snake-on-wat", src, false);
+    let off_boxed_arith = carrier_boxed_arith_token_count("nested-snake-off-wat", src, true);
+    if off_boxed_arith > 0 {
+        assert!(
+            on_boxed_arith < off_boxed_arith,
+            "the carrier-ON build must reach FEWER boxed-arith helpers than the boxed \
+             baseline (the native nested-field path DCEs them): ON={on_boxed_arith}, \
+             OFF={off_boxed_arith}",
+        );
+    }
+}
+
+/// Count `call $__aint_{add,sub,mul}` tokens in the WAT disassembly of
+/// `source`'s wasm-gc output — a probe for how much BOXED Int arithmetic
+/// survives. `no_carrier` forces the all-`$aint` baseline. Returns 0 (vacuous)
+/// when `wasm-tools` is absent.
+fn carrier_boxed_arith_token_count(prefix: &str, source: &str, no_carrier: bool) -> usize {
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = temp_module(prefix, source);
+    let out_dir = path.parent().expect("temp module has parent").join("out");
+    let mut cmd = Command::new(aver_bin);
+    cmd.current_dir(&repo_root)
+        .arg("compile")
+        .arg(&path)
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("-o")
+        .arg(&out_dir);
+    if no_carrier {
+        cmd.env("AVER_NO_CARRIER_I64", "1");
+    }
+    let out = cmd.output().expect("aver compile executes");
+    assert!(
+        out.status.success(),
+        "{prefix}: wasm-gc compile failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let wat = wasm_tools_print(&out_dir.join("main.wasm"));
+    cleanup(&path);
+    wat.match_indices("__aint_add").count()
+        + wat.match_indices("__aint_sub").count()
+        + wat.match_indices("__aint_mul").count()
+}
+
+// ---------------------------------------------------------------------------
 // BARE-i64 carrier RESULT → `$AverInt`-typed SINK boundaries.
 //
 // A native-`i64` carrier-arithmetic result (a `bare_return` fn whose body is


### PR DESCRIPTION
## What

Extends carrier raw-i64 arithmetic (#551, which covered carrier **parameters/locals**) to carrier values read from **record fields** — `state.coord.value`. A record-threaded program (carriers held in a state record — the idiomatic game shape) now does native `i64` arithmetic on those fields instead of routing every operation through `$AverInt`. This is the slice that makes record-threaded games shrink.

## Soundness

Same interval fixpoint as #551: a nested carrier-field read carries the carrier's proven bound, and every op is gated on `fits_i64` of its result — an overflowing op stays boxed (a wide-bound `field.value * field.value` over `[0,2^40]` reaches 2^80, stays boxed, exact, VM == wasm-gc). Recognition is **fail-closed**: a `.value` `Project` renders raw ONLY when the base's stamped type is an eligible carrier (the post-demotion `eligible_carriers` set); analysis and emit gate on the **same** check, so a non-carrier field read — or a carrier that was demoted (e.g. used as a Map key) — stays boxed in both. wasm-gc only (the Rust backend keeps carriers as structs). The new raw source flows into the `$AverInt` sink chokepoints already closed in #551, so it auto-boxes at every boundary.

## Measured

A record-threaded snake-shaped program (coords + score as bounded carriers in a `GameState` record, native field arithmetic), `--optimize size`: **2269 B (carrier on) vs 8453 B (boxed) — 73% reduction**. The WAT confirms the step fn returns `i64` with a raw `i64.add` and no project bridge; the boxed-arith prelude DCEs.

## Tests

+5 differential cases (each VM == wasm-gc AND full-module compile-clean): nested field add, the snake move pattern, a nested read into each of 4 `$AverInt` sinks, and the wide-bound nested-field overflow probe (stays boxed). Carrier differential 38, cross-backend proptest + stress, wasip2 `pool_wraparound`, `cargo test` default 0 failed, `fmt --check` + clippy (`--lib --bin aver`, default and `wasm,wasip2`) clean. The #551 param-level + wide-overflow probes still pass.

## Follow-ups (out of scope)

The remaining levers for fully-native games: a lean i64 formatter so `String.fromInt(score)` drops the bignum formatter; migrating the example games' sources to bounded carriers; and i64 Map-keys for board-state keyed by Int (the hardest, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
