### PR TITLE
wasm-gc: native i64 for bounded multi-field records via 2-arg smart constructors

### DIFF
--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -591,6 +591,569 @@ pub fn carrier_interval_table(
     table
 }
 
+/// ETAP-2 multi-field carrier-`i64`: derive, per `(record-type, Int-field)`
+/// pair in scope, the constant interval a MULTI-ARG smart constructor's guard
+/// proves over that field. This generalizes [`carrier_interval_table`] from
+/// the single-`value`-field carrier TYPE to a multi-field record whose 2+-arg
+/// smart constructor bounds each field independently.
+///
+/// The recognized shape is:
+/// ```text
+/// record Coord { x: Int, y: Int }                 // 2+ Int fields
+/// fn coord(x: Int, y: Int) -> Result<Coord, String>
+///     match <guard conjunction over x, y>
+///         true  -> Result.Ok(Coord(x = x, y = y)) // param p_j -> field f_i
+///         false -> Result.Err("...")
+/// ```
+/// The Ok-branch `RecordCreate` maps each constructor PARAM to a record FIELD
+/// (`Coord(x = x, y = y)`). For each field, the guard is split on its
+/// `Bool.and` tree and only the leaf comparisons mentioning that field's bound
+/// param ALONE are kept (a cross-field condition like `x + y <= 50` mentions
+/// two params and is DROPPED — conservative/sound: a narrower per-field bound
+/// is always a valid over-approximation). Running [`interval_of_invariant`]
+/// over those single-var leaves yields the field's interval.
+///
+/// **Fail-closed.** A field with no proven single-var `fits_i64` bound is
+/// OMITTED (the field stays boxed `$AverInt`). A non-`Int` field, a param that
+/// the Ok branch does not bind one-to-one to a field, or an unrecognized guard
+/// all decline. The single-field path ([`carrier_interval_table`]) is
+/// untouched — this table is ADDITIVE and keyed by `(record, field)`.
+///
+/// Returns a map keyed by `(bare record name, field name)`.
+pub fn field_carrier_interval_table(
+    inputs: &ProofLowerInputs,
+) -> HashMap<(String, String), (crate::ir::interval::Interval, bool)> {
+    let mut table = HashMap::new();
+
+    let entry_typedefs = inputs.entry_items.iter().filter_map(|item| match item {
+        TopLevel::TypeDef(td) => Some((None::<&str>, td)),
+        _ => None,
+    });
+    let module_typedefs = inputs.dep_modules.iter().flat_map(|m| {
+        m.type_defs
+            .iter()
+            .map(move |td| (Some(m.prefix.as_str()), td))
+    });
+
+    for (module_prefix, td) in entry_typedefs.chain(module_typedefs) {
+        let TypeDef::Product { name, fields, .. } = td else {
+            continue;
+        };
+        // Single-field products are the existing carrier-TYPE path; skip them
+        // here so the two tables never both claim the same record.
+        if fields.len() < 2 {
+            continue;
+        }
+        // Every field must be a plain `Int` for the multi-field i64 erasure;
+        // a record mixing Int and non-Int fields keeps its non-Int fields
+        // boxed (only the Int fields with a proven bound become eligible).
+        let Some((ctor, ctor_prefix)) =
+            find_multi_field_smart_ctor(name, fields, inputs, module_prefix)
+        else {
+            continue;
+        };
+        // Map record FIELD name -> the constructor PARAM name that feeds it,
+        // read from the Ok-branch `RecordCreate`.
+        let field_to_param = match ctor_field_param_map(ctor, name, fields) {
+            Some(m) => m,
+            None => continue,
+        };
+        let guard = ctor_guard_predicate(ctor);
+        let Some(guard) = guard else { continue };
+        for (fname, ftype) in fields {
+            if ftype.trim() != "Int" {
+                continue;
+            }
+            let Some(param) = field_to_param.get(fname) else {
+                continue;
+            };
+            // Project the guard onto single-variable leaves mentioning ONLY
+            // this param. A cross-field leaf (two distinct params) is dropped.
+            let resolved_guard = inputs.resolve_expr(guard, ctor_prefix);
+            let leaves =
+                crate::codegen::common::flatten_bool_and_conjuncts_resolved(&resolved_guard);
+            let single_var: Vec<_> = leaves
+                .into_iter()
+                .filter(|leaf| resolved_leaf_mentions_only(leaf, param))
+                .collect();
+            if single_var.is_empty() {
+                continue;
+            }
+            // Rebuild a conjunction predicate over the kept leaves and run the
+            // SAME interval recognizer the single-field path uses.
+            let conj = rebuild_bool_and(single_var);
+            let invariant = Predicate {
+                free_vars: vec![(param.clone(), QuantifierType::Plain("Int".to_string()))],
+                expr: conj,
+            };
+            let (interval, interval_known) = crate::ir::interval::interval_of_invariant(&invariant);
+            if !interval_known {
+                continue;
+            }
+            // Same collision discipline as the type-keyed table: on a
+            // same-`(record, field)` collision across modules, intersect to
+            // the tighter common bound (fail-closed).
+            table
+                .entry((name.clone(), fname.clone()))
+                .and_modify(|(iv, known): &mut (crate::ir::interval::Interval, bool)| {
+                    *iv = iv.intersect(interval);
+                    *known = true;
+                })
+                .or_insert((interval, true));
+        }
+    }
+
+    table
+}
+
+/// Find the single recognized multi-arg smart constructor for `record_name`:
+/// a pure fn `mk(p1, ..., pN) -> Result<Rec, String>` whose body is a single
+/// two-arm `true -> Result.Ok(Rec(...)) | false -> Result.Err(_)` match. The
+/// param count must be >= 2 (a one-arg ctor is the single-field carrier path).
+/// Returns the `&FnDef` plus the module scope it was found in.
+fn find_multi_field_smart_ctor<'a>(
+    record_name: &str,
+    fields: &[(String, String)],
+    inputs: &ProofLowerInputs<'a>,
+    record_scope: Option<&str>,
+) -> Option<(&'a FnDef, Option<&'a str>)> {
+    let entry_fns = inputs.entry_items.iter().filter_map(|item| match item {
+        TopLevel::FnDef(fd) => Some((None::<&str>, fd)),
+        _ => None,
+    });
+    let module_fns = inputs.dep_modules.iter().flat_map(|m| {
+        m.fn_defs
+            .iter()
+            .map(move |fd| (Some(m.prefix.as_str()), fd))
+    });
+    for (scope, fd) in entry_fns.chain(module_fns) {
+        // The constructor lives in the same module as the record (opaque
+        // refinement is single-module); skip a same-named fn in another scope.
+        if scope != record_scope {
+            continue;
+        }
+        if !fd.return_type.starts_with("Result<") {
+            continue;
+        }
+        if !fd.return_type[7..].starts_with(record_name) {
+            continue;
+        }
+        if fd.params.len() < 2 {
+            continue;
+        }
+        let stmts = fd.body.stmts();
+        if stmts.len() != 1 {
+            continue;
+        }
+        let crate::ast::Stmt::Expr(body_expr) = &stmts[0] else {
+            continue;
+        };
+        let Expr::Match { arms, .. } = &body_expr.node else {
+            continue;
+        };
+        if !is_multi_field_ok_err_match(arms, record_name, fields) {
+            continue;
+        }
+        return Some((fd, scope));
+    }
+    None
+}
+
+/// True iff `arms` is the canonical multi-field smart-ctor shape:
+/// `true -> Result.Ok(Rec(f_i = p_j, ...))` covering EVERY field, and
+/// `false -> Result.Err(_)`.
+fn is_multi_field_ok_err_match(
+    arms: &[crate::ast::MatchArm],
+    record_name: &str,
+    fields: &[(String, String)],
+) -> bool {
+    if arms.len() != 2 {
+        return false;
+    }
+    let mut true_ok = false;
+    let mut false_err = false;
+    for arm in arms {
+        match &arm.pattern {
+            crate::ast::Pattern::Literal(Literal::Bool(true)) => {
+                if multi_field_ok_constructor(&arm.body, record_name, fields).is_some() {
+                    true_ok = true;
+                }
+            }
+            crate::ast::Pattern::Literal(Literal::Bool(false)) => {
+                if multi_field_is_err_constructor(&arm.body) {
+                    false_err = true;
+                }
+            }
+            _ => return false,
+        }
+    }
+    true_ok && false_err
+}
+
+/// Local mirror of `common::is_err_constructor` (which is private): the arm
+/// body is `Result.Err(_)`.
+fn multi_field_is_err_constructor(expr: &Spanned<Expr>) -> bool {
+    match &expr.node {
+        Expr::Constructor(name, Some(_)) => name == "Result.Err",
+        Expr::FnCall(callee, args) if args.len() == 1 => {
+            matches!(expr_to_dotted_name(&callee.node), Some(name) if name == "Result.Err")
+        }
+        _ => false,
+    }
+}
+
+/// Inspect a `Result.Ok(Rec(f_i = p_j, ...))` arm body and return the
+/// field-name -> param-name map when every field is set to a bare identifier.
+/// `None` if the body is not the expected `Result.Ok` of a `RecordCreate` of
+/// `record_name` covering exactly the declared fields with identifier values.
+fn multi_field_ok_constructor(
+    expr: &Spanned<Expr>,
+    record_name: &str,
+    fields: &[(String, String)],
+) -> Option<HashMap<String, String>> {
+    let (ctor_name, ctor_arg_node) = match &expr.node {
+        Expr::Constructor(name, Some(arg)) => (name.clone(), &arg.node),
+        Expr::FnCall(callee, args) if args.len() == 1 => {
+            let name = expr_to_dotted_name(&callee.node)?;
+            (name, &args[0].node)
+        }
+        _ => return None,
+    };
+    if ctor_name != "Result.Ok" {
+        return None;
+    }
+    let (t, create_fields) = match ctor_arg_node {
+        Expr::RecordCreate { type_name, fields } => (type_name.as_str(), fields),
+        _ => return None,
+    };
+    if t != record_name || create_fields.len() != fields.len() {
+        return None;
+    }
+    let mut map = HashMap::new();
+    for (fname, fvalue) in create_fields {
+        let param = match &fvalue.node {
+            Expr::Ident(n) | Expr::Resolved { name: n, .. } => n.clone(),
+            _ => return None,
+        };
+        map.insert(fname.clone(), param);
+    }
+    // Every declared field must be assigned by the Ok branch.
+    if fields.iter().any(|(fname, _)| !map.contains_key(fname)) {
+        return None;
+    }
+    Some(map)
+}
+
+/// The field -> param map of the smart constructor's Ok branch (the
+/// `true -> Result.Ok(Rec(...))` arm). Walks the body's single match.
+fn ctor_field_param_map(
+    fd: &FnDef,
+    record_name: &str,
+    fields: &[(String, String)],
+) -> Option<HashMap<String, String>> {
+    let stmts = fd.body.stmts();
+    let crate::ast::Stmt::Expr(body_expr) = stmts.first()? else {
+        return None;
+    };
+    let Expr::Match { arms, .. } = &body_expr.node else {
+        return None;
+    };
+    for arm in arms {
+        if matches!(
+            &arm.pattern,
+            crate::ast::Pattern::Literal(Literal::Bool(true))
+        ) {
+            return multi_field_ok_constructor(&arm.body, record_name, fields);
+        }
+    }
+    None
+}
+
+/// The smart constructor's guard predicate (the `Match` subject the Ok/Err
+/// arms branch on).
+fn ctor_guard_predicate(fd: &FnDef) -> Option<&Spanned<Expr>> {
+    let stmts = fd.body.stmts();
+    let crate::ast::Stmt::Expr(body_expr) = stmts.first()? else {
+        return None;
+    };
+    let Expr::Match { subject, .. } = &body_expr.node else {
+        return None;
+    };
+    Some(subject)
+}
+
+/// True iff every identifier leaf mentioned in `leaf` is `param` (so the leaf
+/// is a SINGLE-VARIABLE condition over that one param). A leaf naming two
+/// distinct params (a cross-field condition like `x + y <= 50`) returns false
+/// and is dropped by the caller — conservative/sound per-field projection.
+fn resolved_leaf_mentions_only(leaf: &Spanned<crate::ir::hir::ResolvedExpr>, param: &str) -> bool {
+    let mut only = true;
+    let mut saw = false;
+    collect_resolved_idents(leaf, &mut |name| {
+        if name == param {
+            saw = true;
+        } else {
+            only = false;
+        }
+    });
+    only && saw
+}
+
+/// Walk a resolved expression, invoking `f` for every identifier leaf
+/// (`Ident` / `Resolved`).
+fn collect_resolved_idents(e: &Spanned<crate::ir::hir::ResolvedExpr>, f: &mut impl FnMut(&str)) {
+    use crate::ir::hir::ResolvedExpr;
+    match &e.node {
+        ResolvedExpr::Ident(n) | ResolvedExpr::Resolved { name: n, .. } => f(n),
+        ResolvedExpr::BinOp(_, l, r) => {
+            collect_resolved_idents(l, f);
+            collect_resolved_idents(r, f);
+        }
+        ResolvedExpr::Neg(i) => collect_resolved_idents(i, f),
+        ResolvedExpr::Call(_, args) => {
+            for a in args {
+                collect_resolved_idents(a, f);
+            }
+        }
+        ResolvedExpr::Attr(o, _) => collect_resolved_idents(o, f),
+        _ => {}
+    }
+}
+
+/// Rebuild a `Bool.and` conjunction over the kept single-variable leaves.
+/// A single leaf returns itself; >1 fold into nested `Bool.and(...)` calls,
+/// matching the shape [`interval_of_invariant`] recognizes.
+fn rebuild_bool_and(
+    mut leaves: Vec<Spanned<crate::ir::hir::ResolvedExpr>>,
+) -> Spanned<crate::ir::hir::ResolvedExpr> {
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr};
+    let mut acc = leaves.remove(0);
+    for leaf in leaves {
+        let line = acc.line;
+        acc = Spanned::new(
+            ResolvedExpr::Call(
+                ResolvedCallee::Builtin("Bool.and".to_string()),
+                vec![acc, leaf],
+            ),
+            line,
+        );
+    }
+    acc
+}
+
+/// ETAP-2 multi-field carrier-`i64`: the per-`(record, field)` ELIGIBLE map —
+/// [`field_carrier_interval_table`] tightened the same way the single-field
+/// path tightens its proven-bound set. An entry survives only when its bound
+/// is recognized AND `fits_i64` AND the owning record is NOT demoted by either
+/// whole-program scan ([`multi_field_record_demotions`]):
+///   - the record is constructed UNGATED (a bare `RecordCreate` outside its
+///     own smart-ctor whose args are not all in-bounds literals) — that bypass
+///     could store an out-of-`i64` value the construct bridge would TRAP on;
+///   - the record (or a record reaching it) is used as a `Map` KEY — the
+///     Map-key codegen was not updated for the i64-erased fields.
+///
+/// A demoted record keeps EVERY field boxed (the whole struct stays the
+/// pre-slice all-`$AverInt` layout). wasm-gc only; the Rust path passes the
+/// empty default and never erases a field.
+///
+/// Returns a map keyed by `(bare record name, field name)`; an empty map
+/// reproduces the pre-slice all-`$AverInt` multi-field record byte-for-byte.
+pub fn field_carrier_eligible_intervals(
+    inputs: &ProofLowerInputs,
+    resolved_map_keys: &[crate::ast::Type],
+) -> HashMap<(String, String), (crate::ir::interval::Interval, bool)> {
+    let table = field_carrier_interval_table(inputs);
+    if table.is_empty() {
+        return table;
+    }
+    // Proven-bound candidates: bound recognized AND `fits_i64`. The set of
+    // RECORD names with at least one such field drives the demotion scans
+    // (a demotion is per-record — a record constructed ungated / used as a
+    // Map key keeps ALL its fields boxed).
+    let record_candidates: HashSet<String> = table
+        .iter()
+        .filter(|(_, (iv, known))| *known && iv.fits_i64())
+        .map(|((rec, _), _)| rec.clone())
+        .collect();
+    if std::env::var("AVER_CARRIER_I64_SKIP_DEMOTION").is_ok() {
+        return table
+            .into_iter()
+            .filter(|((rec, _), (iv, known))| {
+                *known && iv.fits_i64() && record_candidates.contains(rec)
+            })
+            .collect();
+    }
+    let demoted_records =
+        multi_field_record_demotions(inputs, &record_candidates, &table, resolved_map_keys);
+    table
+        .into_iter()
+        .filter(|((rec, _), (iv, known))| {
+            *known
+                && iv.fits_i64()
+                && record_candidates.contains(rec)
+                && !demoted_records.contains(rec)
+        })
+        .collect()
+}
+
+/// ETAP-2 multi-field carrier-`i64`: the RECORD-level fail-closed demotion
+/// scan — the multi-field generalization of [`carrier_eligibility_demotions`].
+/// A multi-field bounded record is demoted (every field kept boxed) when:
+///   - **Scan 1 (ungated construction).** A `RecordCreate` / `RecordUpdate` of
+///     the record in a fn OTHER than its recognized multi-arg smart constructor
+///     can smuggle an out-of-`i64` value past the per-field gate (the construct
+///     bridge `__aint_to_i64_checked` would TRAP). SAFE only when every field
+///     argument is a constant literal provably inside that field's proven
+///     interval; any non-literal / out-of-range field argument demotes.
+///   - **Scan 2 (Map-key usage).** The record — directly or transitively as a
+///     field of a record/Option/List/Tuple used as a Map KEY — reaches a
+///     `Map<K, V>` key position; the Map-key codegen still expects the boxed
+///     struct. Driven by the inference-complete resolved Map-key types, with
+///     the textual annotation scan as a cheap backstop. Both reuse the SAME
+///     `carriers_reachable_from` / `collect_map_key_carriers` closures the
+///     single-field path uses.
+///
+/// Fail-closed: a trip can only ever SHRINK the eligible set.
+fn multi_field_record_demotions(
+    inputs: &ProofLowerInputs,
+    candidates: &HashSet<String>,
+    field_intervals: &HashMap<(String, String), (crate::ir::interval::Interval, bool)>,
+    resolved_map_keys: &[crate::ast::Type],
+) -> HashSet<String> {
+    let mut demoted: HashSet<String> = HashSet::new();
+    if candidates.is_empty() {
+        return demoted;
+    }
+
+    // Map each candidate record to its recognized multi-arg smart-ctor fn name
+    // (the only construct site that gates the fields). A record with no
+    // recognizable smart-ctor never reached `field_carrier_interval_table`, so
+    // every candidate has one — but resolve defensively and demote on failure.
+    let mut ctor_fn_of: HashMap<String, String> = HashMap::new();
+    let record_defs = collect_product_defs(inputs);
+    for name in candidates {
+        let Some((fields, scope)) = record_defs.get(name) else {
+            demoted.insert(name.clone());
+            continue;
+        };
+        match find_multi_field_smart_ctor(name, fields, inputs, *scope) {
+            Some((ctor, _)) => {
+                ctor_fn_of.insert(name.clone(), ctor.name.clone());
+            }
+            None => {
+                demoted.insert(name.clone());
+            }
+        }
+    }
+
+    // ---- Scan 1: ungated construction --------------------------------------
+    let all_fn_defs = inputs
+        .entry_items
+        .iter()
+        .filter_map(|it| match it {
+            TopLevel::FnDef(fd) => Some(fd),
+            _ => None,
+        })
+        .chain(inputs.dep_modules.iter().flat_map(|m| m.fn_defs.iter()));
+    for fd in all_fn_defs {
+        for stmt in fd.body.stmts() {
+            let expr = match stmt {
+                crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => e,
+            };
+            carrier_walk_expr(expr, &mut |e| {
+                let (type_name, create_fields): (&String, &[(String, Spanned<Expr>)]) = match e {
+                    Expr::RecordCreate { type_name, fields } => (type_name, fields),
+                    Expr::RecordUpdate {
+                        type_name, updates, ..
+                    } => (type_name, updates),
+                    _ => return,
+                };
+                if !candidates.contains(type_name) {
+                    return;
+                }
+                // The construct inside the record's own smart-ctor is gated.
+                if ctor_fn_of.get(type_name) == Some(&fd.name) {
+                    return;
+                }
+                // Outside the smart-ctor: safe iff EVERY provided field value is
+                // a constant literal inside that field's proven interval (an
+                // in-bounds literal cannot smuggle an out-of-bound value past
+                // the gate). A `RecordUpdate` that omits a bounded field copies
+                // it from the (already-gated) base, which is safe too.
+                let all_safe = create_fields.iter().all(|(fname, value)| {
+                    match field_intervals.get(&(type_name.clone(), fname.clone())) {
+                        // A non-bounded field (no eligible interval) is stored
+                        // boxed regardless, so it can't smuggle an i64-overflow.
+                        None => true,
+                        Some((iv, true)) => literal_in_interval(value, *iv),
+                        Some((_, false)) => false,
+                    }
+                });
+                if !all_safe {
+                    demoted.insert(type_name.clone());
+                }
+            });
+        }
+    }
+
+    // ---- Scan 2: Map-key usage (direct + transitive) -----------------------
+    let record_fields = collect_record_fields(inputs);
+    for key in resolved_map_keys {
+        carriers_reachable_from(
+            key,
+            candidates,
+            &record_fields,
+            &mut HashSet::new(),
+            &mut demoted,
+        );
+    }
+    for ty_str in all_type_annotations(inputs) {
+        let ty = crate::types::parse_type_str(&ty_str);
+        collect_map_key_carriers(&ty, candidates, &record_fields, &mut demoted);
+    }
+
+    demoted
+}
+
+/// A candidate record's declarations as the demotion scan needs them: its
+/// `(field, type)` list plus the module scope it was found in (`None` = entry).
+type ProductDef<'a> = (&'a [(String, String)], Option<&'a str>);
+
+/// Bare `Product` type name → its [`ProductDef`]. Lets the demotion scan
+/// re-locate a candidate record's field declarations + smart constructor.
+fn collect_product_defs<'a>(inputs: &ProofLowerInputs<'a>) -> HashMap<String, ProductDef<'a>> {
+    let mut out: HashMap<String, ProductDef<'a>> = HashMap::new();
+    for item in inputs.entry_items {
+        if let TopLevel::TypeDef(TypeDef::Product { name, fields, .. }) = item {
+            out.entry(name.clone()).or_insert((fields.as_slice(), None));
+        }
+    }
+    for m in inputs.dep_modules {
+        for td in &m.type_defs {
+            if let TypeDef::Product { name, fields, .. } = td {
+                out.entry(name.clone())
+                    .or_insert((fields.as_slice(), Some(m.prefix.as_str())));
+            }
+        }
+    }
+    out
+}
+
+/// A `RecordCreate`/`RecordUpdate` field value is a constant integer literal
+/// (`5` or `-5`) provably within the proven interval `iv`. Any other shape
+/// (a param, a call, arithmetic) is not a provable constant ⇒ `false`.
+fn literal_in_interval(value: &Spanned<Expr>, iv: crate::ir::interval::Interval) -> bool {
+    let k: i128 = match &value.node {
+        Expr::Literal(Literal::Int(n)) => *n as i128,
+        Expr::Neg(inner) => match &inner.node {
+            Expr::Literal(Literal::Int(n)) => -(*n as i128),
+            _ => return false,
+        },
+        _ => return false,
+    };
+    iv.contains_point(k)
+}
+
 /// ETAP-2 carrier-`i64` SLICE 2b FOLLOW-UP: the fail-closed eligibility
 /// tightening. The bare carrier interval ([`carrier_interval_table`]) proves
 /// only that the smart-constructor's invariant `fits_i64`; it does NOT prove

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -944,23 +944,33 @@ fn rebuild_bool_and(
 /// ETAP-2 multi-field carrier-`i64`: the per-`(record, field)` ELIGIBLE map —
 /// [`field_carrier_interval_table`] tightened the same way the single-field
 /// path tightens its proven-bound set. An entry survives only when its bound
-/// is recognized AND `fits_i64` AND the owning record is NOT demoted by either
+/// is recognized AND `fits_i64` AND the owning record is NOT demoted by any
 /// whole-program scan ([`multi_field_record_demotions`]):
 ///   - the record is constructed UNGATED (a bare `RecordCreate` outside its
 ///     own smart-ctor whose args are not all in-bounds literals) — that bypass
 ///     could store an out-of-`i64` value the construct bridge would TRAP on;
 ///   - the record (or a record reaching it) is used as a `Map` KEY — the
-///     Map-key codegen was not updated for the i64-erased fields.
+///     Map-key codegen was not updated for the i64-erased fields;
+///   - the record (or a record reaching it) is used as a `Map` VALUE or as a
+///     `List` / `Vector` / `Tuple` element — those containers store the
+///     element/value in a backing array (or a heterogeneous tuple struct)
+///     whose slot is the boxed `$AverInt` record ref, so an i64-erased field
+///     of such an element fails wasm validation (`expected (ref null $type),
+///     found i64`). The whole record stays boxed in those container positions,
+///     matching the VM + the boxed wasm-gc path. (`Option` / `Result` payloads
+///     are NOT demoted: they hold the element as an inline struct ref, where an
+///     i64-erased field is fine — so the smart-ctor boundary
+///     `coord(...) -> Result<Coord, String>` keeps the native-i64 win.)
 ///
 /// A demoted record keeps EVERY field boxed (the whole struct stays the
 /// pre-slice all-`$AverInt` layout). wasm-gc only; the Rust path passes the
-/// empty default and never erases a field.
+/// empty registry and never erases a field.
 ///
 /// Returns a map keyed by `(bare record name, field name)`; an empty map
 /// reproduces the pre-slice all-`$AverInt` multi-field record byte-for-byte.
 pub fn field_carrier_eligible_intervals(
     inputs: &ProofLowerInputs,
-    resolved_map_keys: &[crate::ast::Type],
+    instantiations: &crate::ir::mir::InstantiationRegistry,
 ) -> HashMap<(String, String), (crate::ir::interval::Interval, bool)> {
     let table = field_carrier_interval_table(inputs);
     if table.is_empty() {
@@ -984,7 +994,7 @@ pub fn field_carrier_eligible_intervals(
             .collect();
     }
     let demoted_records =
-        multi_field_record_demotions(inputs, &record_candidates, &table, resolved_map_keys);
+        multi_field_record_demotions(inputs, &record_candidates, &table, instantiations);
     table
         .into_iter()
         .filter(|((rec, _), (iv, known))| {
@@ -1012,13 +1022,27 @@ pub fn field_carrier_eligible_intervals(
 ///     the textual annotation scan as a cheap backstop. Both reuse the SAME
 ///     `carriers_reachable_from` / `collect_map_key_carriers` closures the
 ///     single-field path uses.
+///   - **Scan 3 (container value / element usage).** The record — directly or
+///     transitively — reaches a `Map` VALUE, a `List` / `Vector` element, or a
+///     `Tuple` element. Those containers store the element/value in a backing
+///     array (or a heterogeneous tuple struct) whose slot is the boxed
+///     `$AverInt` record ref (`(ref null $Record)`); an i64-erased field of
+///     such an element then meets that boxed slot, failing wasm validation
+///     (`expected (ref null $type), found i64`). Demoting keeps the whole
+///     record boxed, which the boxed wasm-gc path + the VM agree on. `Option` /
+///     `Result` payloads are EXCLUDED — they hold the element as an inline
+///     struct ref where the i64-erased field is fine, so the smart-ctor
+///     boundary `coord(...) -> Result<Coord, String>` keeps the native-i64 win.
+///     Driven by the inference-complete instantiation registry (every `Map`,
+///     `List`, `Vector`, `Tuple` the program uses), reusing the same
+///     `carriers_reachable_from` closure.
 ///
 /// Fail-closed: a trip can only ever SHRINK the eligible set.
 fn multi_field_record_demotions(
     inputs: &ProofLowerInputs,
     candidates: &HashSet<String>,
     field_intervals: &HashMap<(String, String), (crate::ir::interval::Interval, bool)>,
-    resolved_map_keys: &[crate::ast::Type],
+    instantiations: &crate::ir::mir::InstantiationRegistry,
 ) -> HashSet<String> {
     let mut demoted: HashSet<String> = HashSet::new();
     if candidates.is_empty() {
@@ -1098,7 +1122,7 @@ fn multi_field_record_demotions(
 
     // ---- Scan 2: Map-key usage (direct + transitive) -----------------------
     let record_fields = collect_record_fields(inputs);
-    for key in resolved_map_keys {
+    for (key, _value) in &instantiations.maps {
         carriers_reachable_from(
             key,
             candidates,
@@ -1110,6 +1134,48 @@ fn multi_field_record_demotions(
     for ty_str in all_type_annotations(inputs) {
         let ty = crate::types::parse_type_str(&ty_str);
         collect_map_key_carriers(&ty, candidates, &record_fields, &mut demoted);
+    }
+
+    // ---- Scan 3: container value / element usage (direct + transitive) -----
+    // A multi-field carrier reachable from a `Map` VALUE, a `List` / `Vector`
+    // element, or a `Tuple` element keeps all its fields BOXED: those
+    // containers store their element/value in a backing ARRAY (`List`/`Vector`/
+    // `Map`-values) or a heterogeneous tuple struct whose slot type is the
+    // record's BOXED ref shape (`(ref null $type)`). An i64-erased field of
+    // such an element then meets that boxed slot and fails wasm validation
+    // (`expected (ref null $type), found i64`). Demoting keeps the whole record
+    // boxed — what the VM + the boxed wasm-gc path agree on.
+    //
+    // `Option` / `Result` payloads are DELIBERATELY excluded: those hold the
+    // element as an inline struct REF (the i64 fields stay inside the `$Coord`
+    // struct, which the Option/Result slot holds as `(ref $Coord)`), so an
+    // i64-erased field is fine there. Excluding them keeps the native-i64 win
+    // for the common smart-ctor boundary `coord(...) -> Result<Coord, String>`,
+    // which only ever wraps-then-immediately-unwraps the record — that pattern
+    // compiles clean WITHOUT demotion, and demoting it would needlessly box
+    // every multi-field carrier (its own constructor returns a `Result`).
+    //
+    // Driven by the inference-complete instantiation registry (the same
+    // typed-MIR source Scan 2's map keys come from), so a carrier used as a
+    // container element via a local binding OR pure inference (no annotation
+    // anywhere) is still demoted. Reuses `carriers_reachable_from`, which
+    // transitively chases record fields + nested containers.
+    let demote_from = |ty: &crate::ast::Type, demoted: &mut HashSet<String>| {
+        carriers_reachable_from(ty, candidates, &record_fields, &mut HashSet::new(), demoted);
+    };
+    for (_key, value) in &instantiations.maps {
+        demote_from(value, &mut demoted);
+    }
+    for elem in &instantiations.lists {
+        demote_from(elem, &mut demoted);
+    }
+    for elem in &instantiations.vectors {
+        demote_from(elem, &mut demoted);
+    }
+    for elems in &instantiations.tuples {
+        for elem in elems {
+            demote_from(elem, &mut demoted);
+        }
     }
 
     demoted

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -1336,17 +1336,36 @@ fn mir_arith_leaves_raw_compatible(e: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
     }
 }
 
-/// ETAP-2 carrier-`i64`: is `e` a `.value` `Project` whose BASE renders a
-/// native `i64` carrier value? Such a read renders as a raw native `i64` (the
-/// project bridge is skipped) — a genuine raw anchor like an `Unbox`. Two base
-/// shapes qualify, mirroring `FnBareFacts::carrier_project_interval`:
-///   - `Local(bare_carrier_slot)` — a bare carrier param/local (#551);
-///   - a NESTED carrier-field read — a `Project` whose result type is an
-///     eligible carrier (`rec.coord` in `rec.coord.value`); #550 erased that
-///     carrier field to a native `i64`, so the inner `struct.get` yields i64
-///     and the outer `.value` is identity.
+/// ETAP-2 carrier-`i64`: is `e` a `Project` that reads a native `i64` carrier
+/// value directly (the project bridge is skipped) — a genuine raw anchor like
+/// an `Unbox`? Three shapes qualify, mirroring
+/// `FnBareFacts::carrier_project_interval`:
+///   - a `.value` read whose base is a `Local(bare_carrier_slot)` — a bare
+///     carrier param/local (#551);
+///   - a `.value` read whose base is a NESTED carrier-field read (a `Project`
+///     whose result type is an eligible carrier, `rec.coord` in
+///     `rec.coord.value`); #550 erased that carrier field to a native `i64`;
+///   - a DIRECT bounded-field read `Project(rec, "x")` where `rec`'s stamped
+///     type is a bounded multi-field record and `(record, "x")` is an eligible
+///     field (#550 stored that field as a native `i64`, so the `struct.get`
+///     yields i64). This is the multi-field generalization.
 fn mir_is_bare_carrier_project(e: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
-    matches!(e, MirExpr::Project(p) if mir_base_renders_carrier_i64_raw(&p.node.base, ctx))
+    let MirExpr::Project(p) = e else {
+        return false;
+    };
+    mir_base_renders_carrier_i64_raw(&p.node.base, ctx)
+        || mir_is_field_carrier_read(&p.node.base, &p.node.field, ctx)
+}
+
+/// ETAP-2 multi-field carrier-`i64`: is `Project(base, field)` a DIRECT
+/// bounded-field read whose `(record, field)` is eligible? `base`'s stamped
+/// type names a bounded multi-field record and `(record, field)` is in the
+/// registry's eligible-field set — #550 stored that field as a native `i64`,
+/// so the `struct.get` reads raw i64. Fail-closed: any other base type / field
+/// is not eligible (the field is boxed, the read yields an `$AverInt`).
+fn mir_is_field_carrier_read(base: &Spanned<MirExpr>, field: &str, ctx: &EmitCtx<'_>) -> bool {
+    let record = aver_type_str_of(base);
+    ctx.registry.is_eligible_carrier_field(&record, field)
 }
 
 /// ETAP-2 carrier-`i64`: does `base` render a native `i64` carrier value (so a

--- a/src/codegen/wasm_gc/body/from_mir/records.rs
+++ b/src/codegen/wasm_gc/body/from_mir/records.rs
@@ -88,6 +88,17 @@ pub(crate) fn emit_mir_record_create(
         if emit_mir_record_field_value(func, &provided.value, decl_ty, slots, ctx)?.is_none() {
             return Ok(None);
         }
+        // ETAP-2 multi-field carrier-`i64`: an eligible bounded Int field is
+        // stored as a native `i64`, but the rewrite boxes every `RecordCreate`
+        // field value (`rewrite_boxed`), so the value just emitted is an
+        // `$AverInt`. Narrow it to the i64 the field slot holds via the
+        // construct bridge (`__aint_to_i64_checked`, which can never trap — the
+        // smart-ctor bound proves the fit). The bridge is a no-op when bignum is
+        // off (`Int` is already a scalar i64). Mirrors the single-field carrier
+        // construct bridge, per eligible field.
+        if ctx.registry.is_eligible_carrier_field(type_name, decl_name) {
+            emit_carrier_construct_bridge(func, ctx)?;
+        }
     }
     func.instruction(&Instruction::StructNew(type_idx));
     Ok(Some(()))
@@ -125,6 +136,13 @@ pub(crate) fn emit_mir_record_update(
             {
                 return Ok(None);
             }
+            // ETAP-2 multi-field carrier-`i64`: an OVERRIDE of an eligible
+            // bounded field is a boxed `$AverInt` (the rewrite boxes every
+            // update value) but the field slot is a native `i64` — narrow it via
+            // the construct bridge, exactly like `emit_mir_record_create`.
+            if ctx.registry.is_eligible_carrier_field(type_name, decl_name) {
+                emit_carrier_construct_bridge(func, ctx)?;
+            }
         } else {
             let field_idx = ctx
                 .registry
@@ -135,6 +153,10 @@ pub(crate) fn emit_mir_record_update(
             if emit_mir_expr(func, base, slots, ctx)?.is_none() {
                 return Ok(None);
             }
+            // A COPIED-from-base eligible field is already a native `i64` in the
+            // base struct, so the `struct.get` yields the i64 the new field slot
+            // expects — no bridge needed (the boxed `struct.get` of an
+            // `$AverInt` field stays `$AverInt`, also matching its slot).
             func.instruction(&Instruction::StructGet {
                 struct_type_index: type_idx,
                 field_index: field_idx,

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -282,6 +282,49 @@ pub(super) fn emit_module_with(
         .collect();
     registry.set_eligible_carriers(eligible_carriers);
 
+    // ETAP-2 multi-field carrier-`i64`: the per-`(record, field)` eligible
+    // table — a `Coord { x: Int, y: Int }` whose 2-arg smart ctor bounds each
+    // field. Each eligible field erases to a native `i64` struct field (the
+    // size lever, identical to the single-field-leaf composition). Computed
+    // here so the storage erasure (`record_struct_type` reads the registry's
+    // eligible-field set) AND the body-emit bridges (construct / direct-read)
+    // key off ONE table. Empty under `AVER_NO_CARRIER_I64=1` (the differential
+    // baseline) and on any program with no bounded multi-field record.
+    let field_carrier_intervals: crate::ir::mir::bare_i64::FieldCarrierIntervals =
+        if std::env::var("AVER_NO_CARRIER_I64").is_ok() {
+            crate::ir::mir::bare_i64::FieldCarrierIntervals::new()
+        } else {
+            let inputs = crate::codegen::proof_lower::ProofLowerInputs {
+                entry_items: items,
+                dep_modules: &[],
+                module_prefixes: &std::collections::HashSet::new(),
+                recursive_fns: &std::collections::HashSet::new(),
+                symbol_table: &symbol_table,
+                program_shape: None,
+            };
+            // The inference-complete resolved Map-key types (same source the
+            // single-field demotion scan uses) drive the multi-field Map-key
+            // demotion: a bounded record used as a Map KEY keeps all its fields
+            // boxed.
+            let resolved_map_keys: Vec<crate::ast::Type> =
+                crate::ir::mir::discover_instantiations(&optimized_mir)
+                    .maps
+                    .into_iter()
+                    .map(|(k, _v)| k)
+                    .collect();
+            crate::codegen::proof_lower::field_carrier_eligible_intervals(
+                &inputs,
+                &resolved_map_keys,
+            )
+        };
+    let eligible_carrier_fields: std::collections::HashSet<(String, String)> =
+        field_carrier_intervals
+            .iter()
+            .filter(|(_, (iv, known))| *known && iv.fits_i64())
+            .map(|((rec, field), _)| (rec.clone(), field.clone()))
+            .collect();
+    registry.set_eligible_carrier_fields(eligible_carrier_fields);
+
     let mir_program: crate::ir::mir::MirProgram = {
         // Reuse the `optimized` MIR built above for carrier-eligibility
         // Map-key discovery — the box/unbox boundary rewrite is the only
@@ -312,6 +355,7 @@ pub(super) fn emit_module_with(
             optimized,
             &boxed,
             &bare_carrier_intervals,
+            &field_carrier_intervals,
         )
     };
 
@@ -4512,7 +4556,7 @@ fn emit_user_types(
     for item in items {
         match item {
             TopLevel::TypeDef(TypeDef::Product { name, fields, .. }) => {
-                let st = record_struct_type(fields, registry)?;
+                let st = record_struct_type(name, fields, registry)?;
                 let idx = registry
                     .record_type_idx(name)
                     .ok_or(WasmGcError::Validation(format!(
@@ -4943,7 +4987,7 @@ fn emit_user_types(
             .record_fields
             .get(record.aver_name)
             .expect("builtin record registered without fields");
-        let st = super::types::record_struct_type(fields, registry)?;
+        let st = super::types::record_struct_type(record.aver_name, fields, registry)?;
         let idx = registry
             .record_type_idx(record.aver_name)
             .ok_or(WasmGcError::Validation(format!(

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -302,20 +302,14 @@ pub(super) fn emit_module_with(
                 symbol_table: &symbol_table,
                 program_shape: None,
             };
-            // The inference-complete resolved Map-key types (same source the
-            // single-field demotion scan uses) drive the multi-field Map-key
-            // demotion: a bounded record used as a Map KEY keeps all its fields
-            // boxed.
-            let resolved_map_keys: Vec<crate::ast::Type> =
-                crate::ir::mir::discover_instantiations(&optimized_mir)
-                    .maps
-                    .into_iter()
-                    .map(|(k, _v)| k)
-                    .collect();
-            crate::codegen::proof_lower::field_carrier_eligible_intervals(
-                &inputs,
-                &resolved_map_keys,
-            )
+            // The inference-complete instantiation registry (every `Map`,
+            // `List`, `Vector`, `Tuple`, `Option`, `Result` the program uses)
+            // drives the multi-field demotion: a bounded record used as a Map
+            // KEY, a Map VALUE, or any container element keeps all its fields
+            // boxed (its container-element/value codegen stores the boxed
+            // `$AverInt` record, so an i64-erased field fails wasm validation).
+            let instantiations = crate::ir::mir::discover_instantiations(&optimized_mir);
+            crate::codegen::proof_lower::field_carrier_eligible_intervals(&inputs, &instantiations)
         };
     let eligible_carrier_fields: std::collections::HashSet<(String, String)> =
         field_carrier_intervals

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -143,6 +143,17 @@ pub(super) struct TypeRegistry {
     /// invariant lands here. Built from
     /// [`crate::codegen::proof_lower::carrier_interval_table`].
     pub(super) eligible_carriers: std::collections::HashSet<String>,
+    /// ETAP-2 multi-field carrier-`i64`: the eligible `(record, field)` pairs
+    /// whose proven smart-constructor bound `fits_i64`. For a pair in this set,
+    /// the record's wasm STRUCT FIELD lowers to a native `i64` (instead of the
+    /// `$AverInt` ref), and the field read / record construct bridge the i64
+    /// boundary the same way the single-field carrier does. A multi-field record
+    /// can have a MIX: one bounded Int field → i64, another unbounded field →
+    /// boxed. Built from
+    /// [`crate::codegen::proof_lower::field_carrier_eligible_intervals`] (already
+    /// demotion-tightened); EMPTY (the default) reproduces the all-`$AverInt`
+    /// multi-field record layout byte-for-byte.
+    pub(super) eligible_carrier_fields: std::collections::HashSet<(String, String)>,
     /// Phase 4 (0.20) — `(struct (mut i32 socket) (mut i32 in_stream)
     /// (mut i32 out_stream) (mut i32 in_use))` slot type for an entry
     /// in the TCP connection pool. `None` when no `Tcp.*` effect is
@@ -1004,6 +1015,11 @@ impl TypeRegistry {
             // doesn't have. Empty here ⇒ no carrier erases to `i64` until
             // the codegen entry opts in.
             eligible_carriers: std::collections::HashSet::new(),
+            // ETAP-2 multi-field carrier-`i64`: populated post-build by
+            // `module.rs` (`set_eligible_carrier_fields`) from the multi-field
+            // carrier table. Empty here ⇒ no record field erases to `i64` until
+            // the codegen entry opts in.
+            eligible_carrier_fields: std::collections::HashSet::new(),
             tcp_slot_type_idx,
             tcp_pool_type_idx,
             bignum,
@@ -1308,6 +1324,32 @@ impl TypeRegistry {
         }
         let bare = type_name.rsplit_once('.').map_or(type_name, |(_, b)| b);
         self.eligible_carriers.contains(bare.trim())
+    }
+
+    /// ETAP-2 multi-field carrier-`i64`: install the eligible `(record, field)`
+    /// pairs whose proven bound `fits_i64`. Called once by the wasm-gc codegen
+    /// entry after it derives + demotion-tightens the multi-field carrier table.
+    /// Keyed by bare record name + field name (`("Coord", "x")`).
+    pub(super) fn set_eligible_carrier_fields(
+        &mut self,
+        fields: std::collections::HashSet<(String, String)>,
+    ) {
+        self.eligible_carrier_fields = fields;
+    }
+
+    /// ETAP-2 multi-field carrier-`i64`: is `(record_name, field)` a bounded
+    /// record field whose storage should be a native `i64`? `record_name` may
+    /// be bare or `Module.`-qualified; the field name is exact.
+    pub(super) fn is_eligible_carrier_field(&self, record_name: &str, field: &str) -> bool {
+        if self.eligible_carrier_fields.is_empty() {
+            return false;
+        }
+        let bare = record_name
+            .rsplit_once('.')
+            .map_or(record_name, |(_, b)| b)
+            .trim();
+        self.eligible_carrier_fields
+            .contains(&(bare.to_string(), field.to_string()))
     }
 
     pub(super) fn newtype_underlying(&self, type_name: &str) -> Option<&str> {
@@ -2154,14 +2196,24 @@ pub(super) fn fn_sig_key(params: &[ValType], results: &[ValType]) -> String {
 /// declared field, mutable=false (Aver records are immutable; `update`
 /// returns a fresh struct via `struct.new`).
 pub(super) fn record_struct_type(
+    record_name: &str,
     fields: &[(String, String)],
     registry: &TypeRegistry,
 ) -> Result<StructType, WasmGcError> {
     let mut out = Vec::with_capacity(fields.len());
-    for (_, ty) in fields {
-        let val_ty = aver_to_wasm(ty, Some(registry))?.ok_or(WasmGcError::Validation(format!(
-            "record field of type {ty} has no wasm representation"
-        )))?;
+    for (fname, ty) in fields {
+        // ETAP-2 multi-field carrier-`i64`: a bounded Int field of a recognized
+        // multi-arg smart-ctor record erases to a native `i64` (the storage size
+        // lever — identical to the single-field-leaf composition). Every other
+        // field keeps its default lowering, so a MIXED record (one bounded Int
+        // → i64, one unbounded → boxed `$AverInt`) lowers each field correctly.
+        let val_ty = if registry.is_eligible_carrier_field(record_name, fname) {
+            ValType::I64
+        } else {
+            aver_to_wasm(ty, Some(registry))?.ok_or(WasmGcError::Validation(format!(
+                "record field of type {ty} has no wasm representation"
+            )))?
+        };
         out.push(FieldType {
             element_type: StorageType::Val(val_ty),
             mutable: false,

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -57,6 +57,19 @@ use super::super::program::{LocalId, MirFn, MirProgram};
 /// reproduces the pre-slice all-`Int` behavior byte-for-byte.
 pub type CarrierIntervals = HashMap<String, (Interval, bool)>;
 
+/// ETAP-2 multi-field carrier-`i64` — per-`(record-type, field)` proven bound,
+/// keyed by the bare record name + field name. Built by
+/// [`crate::codegen::proof_lower::field_carrier_eligible_intervals`] (already
+/// tightened through the same demotion scans as the single-field set) and
+/// threaded into [`analyze`] alongside [`CarrierIntervals`]. Lets
+/// [`FnBareFacts::carrier_project_interval`] recognize a DIRECT bounded-field
+/// read — `Project(rec, "x")` where `rec`'s stamped type is a bounded record
+/// and field `x` is eligible — as a raw i64 leaf carrying `x`'s bound (#550
+/// stored the field as a native `i64`, so the `struct.get` yields i64). An
+/// EMPTY table (the default at every non-wasm-gc call site — the VM facts path,
+/// the Rust backend, tests) reproduces the pre-slice all-`Int` behavior.
+pub type FieldCarrierIntervals = HashMap<(String, String), (Interval, bool)>;
+
 /// The proven interval for a carrier whose Aver type name is `ty`, returned
 /// ONLY when the table holds a recognized bound (`interval_known`) that
 /// `fits_i64`. Any other case (`ty` not a carrier, an unrecognized invariant
@@ -192,6 +205,16 @@ pub struct FnBareFacts {
     /// backend / whenever no eligible carrier is in scope — the byte-identical
     /// default (the nested form then never fires, only the `Local`-base form).
     pub carrier_types: CarrierIntervals,
+    /// ETAP-2 multi-field carrier-`i64` (wasm-gc only): the eligible
+    /// `(record, field)` bound table. Lets `carrier_project_interval` recognize
+    /// a DIRECT bounded-field read — `Project(rec, "x")` where `rec`'s stamped
+    /// type is a bounded record and `(record, "x")` is eligible — as a raw i64
+    /// leaf carrying `x`'s proven bound. The #550 storage erasure stored that
+    /// field as a native `i64`, so the `struct.get` yields i64 and the read is a
+    /// bare leaf for the surrounding arithmetic. EMPTY on the Rust backend /
+    /// whenever no bounded multi-field record is in scope — the byte-identical
+    /// default (the direct-field form then never fires).
+    pub field_carrier_intervals: FieldCarrierIntervals,
 }
 
 impl FnBareFacts {
@@ -242,6 +265,15 @@ impl FnBareFacts {
         {
             return Some(iv);
         }
+        // Multi-field direct bounded-field read: `Project(rec, "x")` where
+        // `rec`'s stamped type is a bounded record and `(record, "x")` is an
+        // eligible field. The #550 storage erasure stored `x` as a native `i64`,
+        // so the `struct.get` yields raw i64 — a bare leaf carrying `x`'s proven
+        // bound. (The base `rec` is a `Coord` struct ref, NOT itself an eligible
+        // carrier, so this does not overlap the single-field `.value` paths.)
+        if let Some(iv) = self.field_carrier_field_interval(&p.node.base, &p.node.field) {
+            return Some(iv);
+        }
         // Nested carrier-field read: the base is any expression whose stamped
         // type is an eligible carrier (a field read, or transitively a field of
         // a field). The #550 storage erasure made that carrier a native `i64`,
@@ -249,6 +281,26 @@ impl FnBareFacts {
         // if the base has no stamped type, or the type is not an eligible
         // carrier, decline (boxed).
         self.base_renders_eligible_carrier(&p.node.base)
+    }
+
+    /// ETAP-2 multi-field carrier-`i64`: the proven interval of field `field`
+    /// read off `base`, when `base`'s stamped type is a bounded record and
+    /// `(record, field)` is an eligible bounded field. #550 stored that field
+    /// as a native `i64`, so the `struct.get` reads raw i64 directly — a bare
+    /// leaf. `None` when `base` has no stamped record type, or the
+    /// `(record, field)` pair is not eligible / not `fits_i64` — fail-closed.
+    fn field_carrier_field_interval(
+        &self,
+        base: &Spanned<MirExpr>,
+        field: &str,
+    ) -> Option<Interval> {
+        let name = base.ty().and_then(Type::named_name)?;
+        let bare = name.rsplit_once('.').map_or(name, |(_, b)| b);
+        let (iv, known) = self
+            .field_carrier_intervals
+            .get(&(bare.to_string(), field.to_string()))
+            .copied()?;
+        (known && iv.fits_i64()).then_some(iv)
     }
 
     /// The proven interval of `base` when it renders an eligible carrier value
@@ -389,6 +441,19 @@ impl BareI64Facts {
 /// fragment (callers unseen) bails to all-`Boxed`, exactly like
 /// `own_param`.
 pub fn analyze(program: &MirProgram, carrier: &CarrierIntervals) -> BareI64Facts {
+    analyze_with_fields(program, carrier, &FieldCarrierIntervals::new())
+}
+
+/// [`analyze`] plus the multi-field carrier table (`field_carrier`): the
+/// wasm-gc entry threads the eligible `(record, field)` bounds so a DIRECT
+/// bounded-field read renders as a raw i64 leaf. Every other caller goes
+/// through [`analyze`] (empty field table) and keeps the byte-identical
+/// pre-slice behavior.
+pub fn analyze_with_fields(
+    program: &MirProgram,
+    carrier: &CarrierIntervals,
+    field_carrier: &FieldCarrierIntervals,
+) -> BareI64Facts {
     // Diagnostic / bench-differential escape hatch: skip the analysis so a
     // run keeps the conservative all-Boxed baseline.
     if std::env::var("AVER_NO_BARE_I64").is_ok() {
@@ -409,12 +474,14 @@ pub fn analyze(program: &MirProgram, carrier: &CarrierIntervals) -> BareI64Facts
     }
 
     // The minimal cross-frame summary: which params are bare, whether the
-    // return is bare.
-    let summary = compute_summary(program, &int_params, carrier);
+    // return is bare. The field table only adds NEW bare leaves (a direct
+    // bounded-field read), which the body pass reads via the per-fn facts; the
+    // cross-frame param/return summary keys off `carrier` exactly as before.
+    let summary = compute_summary(program, &int_params, carrier, field_carrier);
 
     let mut fns: HashMap<FnId, FnBareFacts> = HashMap::new();
     for (id, f) in program.iter() {
-        fns.insert(*id, analyze_fn(f, &summary, carrier));
+        fns.insert(*id, analyze_fn(f, &summary, carrier, field_carrier));
     }
 
     BareI64Facts { fns }
@@ -463,6 +530,7 @@ fn compute_summary(
     program: &MirProgram,
     int_params: &HashMap<FnId, Vec<bool>>,
     carrier: &CarrierIntervals,
+    field_carrier: &FieldCarrierIntervals,
 ) -> Summary {
     // Address-taken fns (name appears as a `FnValue`) have callers we
     // cannot attribute — pin all their params/return boxed.
@@ -610,7 +678,7 @@ fn compute_summary(
                 bare_return: bare_return.clone(),
                 bare_param_intervals: bare_param_intervals.clone(),
             };
-            let facts = analyze_fn(f, &tmp, carrier);
+            let facts = analyze_fn(f, &tmp, carrier, field_carrier);
             if !facts.bare_return && bare_return.insert(*id, false) != Some(false) {
                 changed = true;
             }
@@ -658,7 +726,7 @@ fn compute_summary(
             bare_param_intervals: bare_param_intervals.clone(),
         };
         for (_caller, f) in program.iter() {
-            let facts = analyze_fn(f, &tmp, carrier);
+            let facts = analyze_fn(f, &tmp, carrier, field_carrier);
             let mut demote: Vec<FnId> = Vec::new();
             collect_let_bound_boxed_returns(&f.body.node, &facts, &bare_return, &mut demote);
             for target in demote {
@@ -1700,7 +1768,12 @@ fn literal_interval(arg: &MirExpr) -> Option<Interval> {
 /// `summary` (which params/returns are bare). The body walk derives an
 /// interval per slot (bottom-up over the `Let` chain), an escape predicate
 /// (a single use-flow scan), and combines them via `raw_i64_eligible`.
-fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBareFacts {
+fn analyze_fn(
+    f: &MirFn,
+    summary: &Summary,
+    carrier: &CarrierIntervals,
+    field_carrier: &FieldCarrierIntervals,
+) -> FnBareFacts {
     let mut facts = FnBareFacts::default();
 
     // 1. Range: seed param intervals from the summary. A bare param is
@@ -1766,6 +1839,13 @@ fn analyze_fn(f: &MirFn, summary: &Summary, carrier: &CarrierIntervals) -> FnBar
     // `rec.coord` is stamped an eligible carrier). EMPTY on the Rust backend /
     // no-eligible-carrier baseline, so the nested form never fires there.
     facts.carrier_types = carrier.clone();
+    // ETAP-2 multi-field carrier-`i64`: the eligible `(record, field)` bound
+    // table powers the DIRECT bounded-field recognition (`Project(rec, "x")`
+    // whose `rec` is a bounded record and `(record, "x")` is eligible). EMPTY
+    // on the Rust backend / no-eligible-record baseline, so the direct-field
+    // form never fires there. Set BEFORE the let-chain walk so a field read
+    // bound to a slot is recognized as a bare leaf.
+    facts.field_carrier_intervals = field_carrier.clone();
 
     // 2. Walk the body's `Let` chain, deriving an interval (+ worst-join
     //    op class) for each bound slot. The carrier-projection facts let the
@@ -3476,6 +3556,172 @@ fn main() -> Int
             produced_interval(&program, "spin", 0),
             None,
             "the unguarded decrement counter must widen to None, not hang"
+        );
+    }
+
+    // ---- multi-field carrier bound attribution -----------------------------
+
+    /// Build the per-`(record, field)` carrier-interval table for `src`
+    /// through the same multi-field derivation the codegen entry uses.
+    fn field_table_for(
+        src: &str,
+    ) -> HashMap<(String, String), (crate::ir::interval::Interval, bool)> {
+        let mut items = parse_source(src).expect("parse");
+        let cfg = crate::ir::pipeline::PipelineConfig {
+            typecheck: Some(crate::ir::pipeline::TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        };
+        let result = crate::ir::pipeline::run(&mut items, cfg);
+        let empty_prefixes: HashSet<String> = HashSet::new();
+        let empty_recursive: HashSet<crate::ir::FnId> = HashSet::new();
+        let inputs = crate::codegen::proof_lower::ProofLowerInputs {
+            entry_items: &items,
+            dep_modules: &[],
+            module_prefixes: &empty_prefixes,
+            recursive_fns: &empty_recursive,
+            symbol_table: &result.symbol_table,
+            program_shape: None,
+        };
+        crate::codegen::proof_lower::field_carrier_interval_table(&inputs)
+    }
+
+    #[test]
+    fn field_carrier_per_field_intervals() {
+        // A 2-arg smart ctor bounding each field independently → each field
+        // gets its own proven interval.
+        let src = r#"
+module Toy
+    intent = "t"
+    depends []
+
+record Coord
+    x: Int
+    y: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(Bool.and(x >= 0, x <= 100), Bool.and(y >= 0, y <= 200))
+        true  -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("err")
+
+fn main() -> Int
+    match coord(1, 2)
+        Result.Ok(c)  -> c.x
+        Result.Err(_) -> 0
+"#;
+        let table = field_table_for(src);
+        let (ix, kx) = table
+            .get(&("Coord".to_string(), "x".to_string()))
+            .copied()
+            .expect("x field bound");
+        let (iy, ky) = table
+            .get(&("Coord".to_string(), "y".to_string()))
+            .copied()
+            .expect("y field bound");
+        assert!(kx && ky, "both fields recognized");
+        use crate::ir::interval::Bound;
+        assert_eq!(ix.lo, Bound::Finite(0));
+        assert_eq!(ix.hi, Bound::Finite(100));
+        assert_eq!(iy.lo, Bound::Finite(0));
+        assert_eq!(iy.hi, Bound::Finite(200));
+    }
+
+    #[test]
+    fn field_carrier_cross_field_condition_dropped() {
+        // A cross-field leaf (`x + y <= 50`) mentions two params; it is dropped
+        // from each field's projection, so each field keeps only its own
+        // single-variable bound. The bound is a sound over-approximation.
+        let src = r#"
+module Toy
+    intent = "t"
+    depends []
+
+record Coord
+    x: Int
+    y: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(Bool.and(x >= 0, x <= 100), Bool.and(y >= 0, x + y <= 50))
+        true  -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("err")
+
+fn main() -> Int
+    0
+"#;
+        let table = field_table_for(src);
+        // x keeps its single-var [0, 100] (the cross-field `x + y <= 50` drops).
+        let (ix, kx) = table
+            .get(&("Coord".to_string(), "x".to_string()))
+            .copied()
+            .expect("x field bound");
+        assert!(kx);
+        use crate::ir::interval::Bound;
+        assert_eq!(ix.lo, Bound::Finite(0));
+        assert_eq!(ix.hi, Bound::Finite(100));
+        // y has only `y >= 0` as a single-var leaf (the upper bound was the
+        // dropped cross-field condition) → no fits_i64 upper bound, so the
+        // interval is recognized-but-unbounded-above; it is NOT eligible.
+        let y = table.get(&("Coord".to_string(), "y".to_string())).copied();
+        if let Some((iy, ky)) = y {
+            assert!(
+                !(ky && iy.fits_i64()),
+                "y with only a lower bound must not be a fits_i64 eligible field"
+            );
+        }
+    }
+
+    #[test]
+    fn field_carrier_only_one_field_bounded() {
+        // A mixed record: one field gated, the other not mentioned in the
+        // guard at all. Only the gated field gets a bound.
+        let src = r#"
+module Toy
+    intent = "t"
+    depends []
+
+record Coord
+    x: Int
+    y: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(x >= 0, x <= 100)
+        true  -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("err")
+
+fn main() -> Int
+    0
+"#;
+        let table = field_table_for(src);
+        assert!(
+            table.contains_key(&("Coord".to_string(), "x".to_string())),
+            "the gated field x is bounded"
+        );
+        let y = table.get(&("Coord".to_string(), "y".to_string())).copied();
+        assert!(
+            y.is_none_or(|(iv, k)| !(k && iv.fits_i64())),
+            "the ungated field y must not be an eligible bounded field"
+        );
+    }
+
+    #[test]
+    fn field_carrier_mis_fire_no_smart_ctor() {
+        // A plain 2-field record with NO smart constructor → no bound is
+        // attributed to any field (the table is empty for it).
+        let src = r#"
+module Toy
+    intent = "t"
+    depends []
+
+record Coord
+    x: Int
+    y: Int
+
+fn main() -> Int
+    Coord(x = 1, y = 2).x
+"#;
+        let table = field_table_for(src);
+        assert!(
+            !table.contains_key(&("Coord".to_string(), "x".to_string())),
+            "a record with no smart ctor attributes no field bound"
         );
     }
 }

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -71,7 +71,8 @@ pub fn rewrite_for_rust(
     // Rust; only the carrier-projection leaf is suppressed — pass an EMPTY
     // carrier table so `carrier_interval` declines every carrier.
     let empty = super::bare_i64::CarrierIntervals::new();
-    rewrite(program, boxed_signature_fns, &empty)
+    let empty_fields = super::bare_i64::FieldCarrierIntervals::new();
+    rewrite(program, boxed_signature_fns, &empty, &empty_fields)
 }
 
 /// ETAP-2 SLICE 2b: the wasm-gc entry. Identical body to
@@ -90,8 +91,9 @@ pub fn rewrite_for_wasm_gc(
     program: MirProgram,
     boxed_signature_fns: &std::collections::HashSet<crate::ir::FnId>,
     carrier: &super::bare_i64::CarrierIntervals,
+    field_carrier: &super::bare_i64::FieldCarrierIntervals,
 ) -> MirProgram {
-    rewrite(program, boxed_signature_fns, carrier)
+    rewrite(program, boxed_signature_fns, carrier, field_carrier)
 }
 
 /// The shared rewrite both public entries delegate to. Target-agnostic:
@@ -103,9 +105,10 @@ fn rewrite(
     program: MirProgram,
     boxed_signature_fns: &std::collections::HashSet<crate::ir::FnId>,
     carrier: &super::bare_i64::CarrierIntervals,
+    field_carrier: &super::bare_i64::FieldCarrierIntervals,
 ) -> MirProgram {
     let mut program = program;
-    let facts = super::bare_i64::analyze(&program, carrier);
+    let facts = super::bare_i64::analyze_with_fields(&program, carrier, field_carrier);
     // Collect ids first to avoid borrowing `program.fns` while mutating it.
     let ids: Vec<crate::ir::FnId> = program.fns.keys().copied().collect();
     for id in ids {

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -2477,3 +2477,164 @@ fn main() -> Unit
         off_raw.len(),
     );
 }
+
+// ===========================================================================
+// Multi-field carrier as a CONTAINER value / element (HOLE #3, fail-closed
+// demotion). A bounded `record Coord { x: Int, y: Int }` whose 2-arg smart
+// ctor erases each field to native i64 is stored in a `Map` VALUE, a `List`
+// / `Vector` element, or a `Tuple` element. Those containers hold the
+// element/value in a backing array (or a heterogeneous tuple struct) whose
+// slot is the BOXED `$AverInt` record ref — and the record's eq / hash
+// helper then reads an i64-erased field and passes it to the boxed `$AverInt`
+// eq / hash, failing wasm validation (`expected (ref null $type), found i64`).
+// The container scan demotes the record (all fields boxed) so it compiles
+// clean and matches the VM. (`Option` / `Result` payloads are EXCLUDED — they
+// hold the element as an inline struct ref where an i64-erased field is fine,
+// so the smart-ctor boundary `coord(...) -> Result<Coord, String>` keeps the
+// native-i64 win — covered by the per-position tests below.)
+//
+// Each test pairs the FIX (default build: VM == wasm-gc, clean compile) with
+// the REVERT (`AVER_CARRIER_I64_SKIP_DEMOTION=1` restores the un-tightened
+// eligibility ⇒ the validation failure returns). The field square reads back
+// `2^40 * 2^40 = 2^80`, far past i64::MAX, so the demoted (boxed) record must
+// keep the value EXACT.
+// ===========================================================================
+
+/// Shared body for the container-element demotion tests: a `Coord { x, y }`
+/// bounded `0 .. 2^40`, stored via `$store` and read back via `$read` which
+/// squares `g.x` (overshooting i64). `$store` / `$read` are the per-container
+/// fn pair; the rest is identical.
+fn multi_field_container_src(store_fn: &str, read_fn: &str) -> String {
+    format!(
+        r#"module M
+    intent = "multi-field carrier as container element"
+    effects [Console]
+
+record Coord
+    x: Int
+    y: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(Bool.and(x >= 0, x <= 1099511627776), Bool.and(y >= 0, y <= 1099511627776))
+        true  -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<Coord, String>) -> Coord
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Coord(x = 0, y = 0)
+
+{store_fn}
+
+{read_fn}
+
+fn main() -> Unit
+    ! [Console.print]
+    c = unwrap(coord(1099511627776, 0))
+    Console.print("{{readSquare(store(c))}}")
+"#
+    )
+}
+
+/// Assert a container-element program (FIX) compiles clean + VM == wasm-gc,
+/// and (REVERT) with the demotion scan disabled the i64-erased field in the
+/// container element fails wasm validation.
+fn assert_container_demotes_and_reverts(prefix: &str, src: &str) {
+    // FIX: the container scan demotes Coord to boxed ⇒ compiles clean AND
+    // VM == wasm-gc at the exact 2^80 bignum.
+    let out = assert_vm_wasm_identical(prefix, src);
+    assert_eq!(out, "1208925819614629174706176");
+
+    // REVERT: scan disabled ⇒ the i64-erased field in the container element's
+    // record eq / hash helper meets the boxed `$AverInt` helper ⇒ wasm
+    // validation fails (the hole returns).
+    let (ok, msg) = run_wasm_skip_demotion(&format!("{prefix}-revert"), src);
+    assert!(
+        !ok,
+        "{prefix} revert: with the container scan disabled an i64-erased \
+         multi-field carrier in a container element must fail wasm validation \
+         (the hole returns), but the run succeeded:\n{msg}"
+    );
+    assert!(
+        msg.contains("validation failed") || msg.contains("type mismatch"),
+        "{prefix} revert: expected a wasm validation / type-mismatch error from \
+         the i64-erased container element, got:\n{msg}"
+    );
+}
+
+/// HOLE #3 — a multi-field carrier as a `Map` VALUE.
+#[test]
+fn multi_field_as_map_value_demotes_to_boxed() {
+    let src = multi_field_container_src(
+        "fn store(c: Coord) -> Map<String, Coord>\n    Map.set({}, \"k\", c)",
+        "fn readSquare(m: Map<String, Coord>) -> Int\n    match Map.get(m, \"k\")\n        Option.Some(g) -> g.x * g.x\n        Option.None    -> 0",
+    );
+    assert_container_demotes_and_reverts("mf-map-value", &src);
+}
+
+/// HOLE #3 — a multi-field carrier as a `List` element.
+#[test]
+fn multi_field_as_list_element_demotes_to_boxed() {
+    let src = multi_field_container_src(
+        "fn store(c: Coord) -> List<Coord>\n    [c]",
+        "fn readSquare(xs: List<Coord>) -> Int\n    match xs\n        [g, ..rest] -> g.x * g.x\n        []          -> 0",
+    );
+    assert_container_demotes_and_reverts("mf-list-element", &src);
+}
+
+/// HOLE #3 — a multi-field carrier as a `Vector` element.
+#[test]
+fn multi_field_as_vector_element_demotes_to_boxed() {
+    let src = multi_field_container_src(
+        "fn store(c: Coord) -> Vector<Coord>\n    Vector.new(1, c)",
+        "fn readSquare(v: Vector<Coord>) -> Int\n    match Vector.get(v, 0)\n        Option.Some(g) -> g.x * g.x\n        Option.None    -> 0",
+    );
+    assert_container_demotes_and_reverts("mf-vector-element", &src);
+}
+
+/// HOLE #3 — a multi-field carrier as a `Tuple` element.
+#[test]
+fn multi_field_as_tuple_element_demotes_to_boxed() {
+    let src = multi_field_container_src(
+        "fn store(c: Coord) -> Tuple<Coord, Int>\n    (c, 0)",
+        "fn readSquare(t: Tuple<Coord, Int>) -> Int\n    match t\n        (g, _) -> g.x * g.x",
+    );
+    assert_container_demotes_and_reverts("mf-tuple-element", &src);
+}
+
+/// HOLE #3 boundary — a multi-field carrier as an `Option` / `Result` payload
+/// is NOT demoted: the payload holds an inline struct ref where an i64-erased
+/// field is fine, so the native-i64 win is preserved (the program compiles
+/// clean + matches the VM WITHOUT demotion). This guards against the scan
+/// over-demoting the common smart-ctor boundary `coord -> Result<Coord, _>`.
+#[test]
+fn multi_field_as_option_result_payload_stays_native() {
+    let option_src = multi_field_container_src(
+        "fn store(c: Coord) -> Option<Coord>\n    Option.Some(c)",
+        "fn readSquare(o: Option<Coord>) -> Int\n    match o\n        Option.Some(g) -> g.x * g.x\n        Option.None    -> 0",
+    );
+    // FIX path: VM == wasm-gc, compiles clean.
+    let out = assert_vm_wasm_identical("mf-option-payload", &option_src);
+    assert_eq!(out, "1208925819614629174706176");
+    // The Option payload is NOT a demotion hazard: even with the scan disabled
+    // it compiles clean (the inline struct ref holds the i64 fields fine).
+    let (ok, _msg) = run_wasm_skip_demotion("mf-option-payload-noskip", &option_src);
+    assert!(
+        ok,
+        "an Option payload of a multi-field carrier must compile clean with OR \
+         without the demotion scan — it is not a container-element hazard"
+    );
+
+    let result_src = multi_field_container_src(
+        "fn store(c: Coord) -> Result<Coord, String>\n    Result.Ok(c)",
+        "fn readSquare(r: Result<Coord, String>) -> Int\n    match r\n        Result.Ok(g)  -> g.x * g.x\n        Result.Err(_) -> 0",
+    );
+    let out = assert_vm_wasm_identical("mf-result-payload", &result_src);
+    assert_eq!(out, "1208925819614629174706176");
+    let (ok, _msg) = run_wasm_skip_demotion("mf-result-payload-noskip", &result_src);
+    assert!(
+        ok,
+        "a Result payload of a multi-field carrier must compile clean with OR \
+         without the demotion scan — it is not a container-element hazard"
+    );
+}

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -1452,6 +1452,37 @@ fn compile_wasm_bytes(prefix: &str, source: &str, no_carrier: bool) -> Vec<u8> {
     bytes
 }
 
+/// Like [`compile_wasm_bytes`] but runs the `--optimize size` pipeline
+/// (`wasm-metadce` → `wasm-opt -Oz`), which DCEs the unreachable boxed-`$AverInt`
+/// arithmetic prelude. The size WIN of the carrier-`i64` path only shows after
+/// DCE — an un-optimized module carries the whole bignum prelude in both builds.
+/// Returns `None` when the `wasm-opt` toolchain is absent (the size assertion
+/// then degrades to "not larger" so CI without `wasm-opt` still passes).
+fn compile_wasm_bytes_optimized(prefix: &str, source: &str, no_carrier: bool) -> Option<Vec<u8>> {
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = temp_module(prefix, source);
+    let out_dir = path.parent().expect("temp module has parent").join("out");
+    let mut cmd = Command::new(aver_bin);
+    cmd.current_dir(&repo_root)
+        .arg("compile")
+        .arg(&path)
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--optimize")
+        .arg("size")
+        .arg("-o")
+        .arg(&out_dir);
+    if no_carrier {
+        cmd.env("AVER_NO_CARRIER_I64", "1");
+    }
+    let out = cmd.output().expect("aver compile executes");
+    let wasm = out_dir.join("main.wasm");
+    let bytes = std::fs::read(&wasm).ok();
+    cleanup(&path);
+    if out.status.success() { bytes } else { None }
+}
+
 // ---------------------------------------------------------------------------
 // Eligibility-tightening (fail-closed) regressions.
 //
@@ -2089,4 +2120,360 @@ fn main() -> Unit
     // the sum is 0. VM is ground truth; the whole module must compile clean.
     let out = assert_vm_wasm_identical("bare-ip-call", src);
     assert_eq!(out, "0");
+}
+
+// ===========================================================================
+// Multi-field carrier-`i64`: a `record Coord { x: Int, y: Int }` plus a 2-arg
+// smart constructor gating BOTH fields → each Int field stored as native i64.
+// The source stays `c.x : Int` (no `.value`). VM is ground truth; every case
+// must match wasm-gc AND compile clean.
+// ===========================================================================
+
+/// A `Coord { x: Int, y: Int }` with a 2-arg smart ctor bounding each field.
+/// `c.x + c.dx` reads native i64 fields and adds raw. VM == wasm-gc, revert
+/// agrees (representation-only).
+#[test]
+fn multi_field_native_arithmetic_matches_vm_and_reverts() {
+    let src = r#"module M
+    intent = "multi-field carrier-i64 native arithmetic"
+    effects [Console]
+
+record Coord
+    x: Int
+    y: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(Bool.and(x >= 0, x <= 1000), Bool.and(y >= 0, y <= 1000))
+        true  -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("oob")
+
+fn manhattan(c: Coord) -> Int
+    c.x + c.y
+
+fn main() -> Unit
+    ! [Console.print]
+    match coord(30, 12)
+        Result.Ok(c)  -> Console.print("{manhattan(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("mf-native", src);
+    assert_eq!(out, "42");
+    assert_carrier_revert_agrees("mf-native", src, &out);
+}
+
+/// WIDE-BOUND per-field overflow: a field bounded `0 .. 2^40` whose squared
+/// value (`c.x * c.x` = up to 2^80) leaves `i64`, so the multiply MUST stay
+/// boxed (full `$aint` precision), matching the VM. A raw `i64.mul` would
+/// wrap. This is the load-bearing soundness case for the multi-field read.
+#[test]
+fn multi_field_wide_bound_square_stays_boxed_matches_vm() {
+    let src = r#"module M
+    intent = "multi-field carrier-i64 wide-bound overflow stays boxed"
+    effects [Console]
+
+record Wide
+    x: Int
+    y: Int
+
+fn wide(x: Int, y: Int) -> Result<Wide, String>
+    match Bool.and(Bool.and(x >= 0, x <= 1099511627776), Bool.and(y >= 0, y <= 1099511627776))
+        true  -> Result.Ok(Wide(x = x, y = y))
+        false -> Result.Err("oob")
+
+fn square(c: Wide) -> Int
+    c.x * c.x
+
+fn main() -> Unit
+    ! [Console.print]
+    match wide(1000000000, 0)
+        Result.Ok(c)  -> Console.print("{square(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    // 1e9 squared = 1e18, which fits i64; but the field bound 2^40 makes the
+    // PRODUCT bound 2^80 (> i64), so the analysis keeps the multiply boxed.
+    // The VM computes the exact 1000000000000000000; wasm-gc must match.
+    let out = assert_vm_wasm_identical("mf-wide-square", src);
+    assert_eq!(out, "1000000000000000000");
+    assert_carrier_revert_agrees("mf-wide-square", src, &out);
+}
+
+/// A wide-bound field whose square genuinely EXCEEDS i64 must still match the
+/// VM (boxed bignum). `2^40 * 2^40 = 2^80`, far past i64::MAX — a raw multiply
+/// would wrap to a wrong value.
+#[test]
+fn multi_field_wide_bound_true_overflow_matches_vm() {
+    let src = r#"module M
+    intent = "multi-field carrier-i64 true overflow stays boxed"
+    effects [Console]
+
+record Wide
+    x: Int
+    y: Int
+
+fn wide(x: Int, y: Int) -> Result<Wide, String>
+    match Bool.and(Bool.and(x >= 0, x <= 1099511627776), Bool.and(y >= 0, y <= 1099511627776))
+        true  -> Result.Ok(Wide(x = x, y = y))
+        false -> Result.Err("oob")
+
+fn square(c: Wide) -> Int
+    c.x * c.x
+
+fn main() -> Unit
+    ! [Console.print]
+    match wide(1099511627776, 0)
+        Result.Ok(c)  -> Console.print("{square(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    // 2^40 squared = 2^80 = 1208925819614629174706176, way past i64::MAX.
+    let out = assert_vm_wasm_identical("mf-true-overflow", src);
+    assert_eq!(out, "1208925819614629174706176");
+}
+
+/// MIXED record: one field gated/bounded (→ native i64), the other NOT
+/// mentioned in the guard (→ boxed `$AverInt`). Both reads must match the VM,
+/// and the whole module compiles clean (the boxed field stays the ref shape).
+#[test]
+fn multi_field_mixed_bounded_and_unbounded_matches_vm() {
+    let src = r#"module M
+    intent = "multi-field carrier-i64 mixed bounded/unbounded fields"
+    effects [Console]
+
+record Mixed
+    x: Int
+    y: Int
+
+fn mixed(x: Int, y: Int) -> Result<Mixed, String>
+    match Bool.and(x >= 0, x <= 100)
+        true  -> Result.Ok(Mixed(x = x, y = y))
+        false -> Result.Err("oob")
+
+fn combine(c: Mixed) -> Int
+    c.x + c.y
+
+fn bigY() -> Int
+    5000000000 * 5000000000
+
+fn main() -> Unit
+    ! [Console.print]
+    match mixed(7, bigY())
+        Result.Ok(c)  -> Console.print("{combine(c)}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    // x = 7 (bounded → i64), y = 5e9 * 5e9 = 2.5e19 (unbounded → boxed bignum,
+    // it exceeds i64::MAX ~9.2e18). The sum is boxed (y escapes i64), exact on
+    // both backends. The literals stay in i64 range; the PRODUCT overflows.
+    let out = assert_vm_wasm_identical("mf-mixed", src);
+    assert_eq!(out, "25000000000000000007");
+    assert_carrier_revert_agrees("mf-mixed", src, &out);
+}
+
+/// MIS-FIRE negative: a plain 2-field record with NO smart constructor. The
+/// fields must NOT be erased to i64 (no proven bound) — they stay boxed. The
+/// program still runs correctly and compiles clean; this guards against the
+/// recognizer firing on an unguarded record.
+#[test]
+fn multi_field_no_smart_ctor_keeps_fields_boxed_matches_vm() {
+    let src = r#"module M
+    intent = "multi-field plain record (no smart ctor) stays boxed"
+    effects [Console]
+
+record Plain
+    x: Int
+    y: Int
+
+fn combine(c: Plain) -> Int
+    c.x + c.y
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{combine(Plain(x = 5, y = 37))}")
+"#;
+    let out = assert_vm_wasm_identical("mf-misfire", src);
+    assert_eq!(out, "42");
+    assert_carrier_revert_agrees("mf-misfire", src, &out);
+}
+
+/// UNGATED / OUT-OF-RANGE construction demotes: the record has a smart ctor,
+/// but a SECOND fn constructs it ungated with an out-of-range / non-literal
+/// value. The record must fall back to all-boxed (every field stays
+/// `$AverInt`), or the construct bridge would TRAP on the out-of-range value.
+/// The program runs correctly and compiles clean.
+#[test]
+fn multi_field_ungated_construction_demotes_matches_vm() {
+    let src = r#"module M
+    intent = "multi-field ungated construction demotes to boxed"
+    effects [Console]
+
+record Coord
+    x: Int
+    y: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(Bool.and(x >= 0, x <= 100), Bool.and(y >= 0, y <= 100))
+        true  -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("oob")
+
+fn raw(n: Int) -> Coord
+    Coord(x = n, y = n)
+
+fn combine(c: Coord) -> Int
+    c.x + c.y
+
+fn bigN() -> Int
+    5000000000 * 5000000000
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{combine(raw(bigN()))}")
+"#;
+    // `raw` constructs Coord ungated with 2.5e19 (> i64::MAX); the record is
+    // demoted to all-boxed, so the bignum field stays exact (no trap, no wrap).
+    let out = assert_vm_wasm_identical("mf-ungated", src);
+    assert_eq!(out, "50000000000000000000");
+    assert_carrier_revert_agrees("mf-ungated", src, &out);
+}
+
+/// NESTED bounded record field read: `state.head.x` where `head : Coord` and
+/// `Coord.x` is a bounded i64 field. The struct.get chain reads the inner i64.
+/// VM == wasm-gc.
+#[test]
+fn multi_field_nested_read_matches_vm_and_reverts() {
+    let src = r#"module M
+    intent = "multi-field nested bounded field read"
+    effects [Console]
+
+record Coord
+    x: Int
+    y: Int
+
+record State
+    head: Coord
+    score: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(Bool.and(x >= 0, x <= 1000), Bool.and(y >= 0, y <= 1000))
+        true  -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("oob")
+
+fn headX(s: State) -> Int
+    s.head.x + s.head.y
+
+fn main() -> Unit
+    ! [Console.print]
+    match coord(11, 31)
+        Result.Ok(c)  -> Console.print("{headX(State(head = c, score = 0))}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("mf-nested", src);
+    assert_eq!(out, "42");
+    assert_carrier_revert_agrees("mf-nested", src, &out);
+}
+
+/// A bounded multi-field read flowing into a STRINGIFY sink (interpolation
+/// embed) — the raw i64 must be boxed at the embed boundary (the $aint decimal
+/// formatter takes an $AverInt ref). Compiles clean + matches the VM.
+#[test]
+fn multi_field_read_into_stringify_sink_matches_vm() {
+    let src = r#"module M
+    intent = "multi-field bounded read into a stringify sink"
+    effects [Console]
+
+record Coord
+    x: Int
+    y: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(Bool.and(x >= 0, x <= 1000), Bool.and(y >= 0, y <= 1000))
+        true  -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("oob")
+
+fn main() -> Unit
+    ! [Console.print]
+    match coord(40, 2)
+        Result.Ok(c)  -> Console.print("x={c.x} y={c.y}")
+        Result.Err(_) -> Console.print("err")
+"#;
+    let out = assert_vm_wasm_identical("mf-stringify", src);
+    assert_eq!(out, "x=40 y=2");
+    assert_carrier_revert_agrees("mf-stringify", src, &out);
+}
+
+/// SIZE PROOF for the multi-field win: a `Coord { x: Int, y: Int }` snake-shaped
+/// model (clean source, NO `.value`) whose 2-arg smart ctor bounds both fields.
+/// Every field read is native i64 and the arithmetic runs `i64.add/sub`, so the
+/// boxed `$AverInt` arithmetic prelude DCEs. The carrier-ON build must be
+/// STRICTLY SMALLER than the boxed baseline (`AVER_NO_CARRIER_I64=1`), and the
+/// `Coord` struct lowers to `(struct (field i64) (field i64))` — byte-identical
+/// to the single-field-leaf `Coord { x: Axis, y: Axis }` composition. VM ==
+/// wasm-gc both ways is covered by `assert_vm_wasm_identical`.
+#[test]
+fn multi_field_snake_size_drops_vs_boxed() {
+    let src = r#"module M
+    intent = "multi-field snake size: native field arithmetic"
+    effects [Console]
+
+record Coord
+    x: Int
+    y: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(Bool.and(x >= 0, x <= 1000), Bool.and(y >= 0, y <= 1000))
+        true  -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("oob")
+
+fn unwrap(r: Result<Coord, String>) -> Coord
+    match r
+        Result.Ok(c)  -> c
+        Result.Err(_) -> Coord(x = 0, y = 0)
+
+fn mk(x: Int, y: Int) -> Coord
+    unwrap(coord(x, y))
+
+fn sumX(a: Coord, b: Coord) -> Int
+    a.x + b.x
+
+fn sumY(a: Coord, b: Coord) -> Int
+    a.y + b.y
+
+fn diff(a: Coord, b: Coord) -> Int
+    (a.x - b.x) + (a.y - b.y)
+
+fn main() -> Unit
+    ! [Console.print]
+    p = mk(5, 7)
+    q = mk(1, 2)
+    Console.print("{sumX(p, q)} {sumY(p, q)} {diff(p, q)}")
+"#;
+    // Representation-only erasure: identical output both ways.
+    let out = assert_vm_wasm_identical("mf-snake-size", src);
+    assert_eq!(out, "6 9 9");
+    assert_carrier_revert_agrees("mf-snake-size", src, &out);
+
+    // The size WIN materializes after `--optimize size` (DCE drops the now-
+    // unreachable boxed-`$AverInt` arith prelude). Measured locally: carrier-ON
+    // ~1953 B vs carrier-OFF(boxed) ~6254 B (~31%) — byte-equal to the
+    // single-field-leaf `Coord { x: Axis, y: Axis }` composition (~1940 B).
+    if let (Some(on), Some(off)) = (
+        compile_wasm_bytes_optimized("mf-snake-on", src, false),
+        compile_wasm_bytes_optimized("mf-snake-off", src, true),
+    ) {
+        assert!(
+            on.len() < off.len(),
+            "multi-field carrier-i64 must SHRINK the optimized module — native field \
+             arithmetic DCEs the boxed arith prelude. carrier-ON={} bytes, \
+             carrier-OFF(boxed)={} bytes",
+            on.len(),
+            off.len(),
+        );
+    }
+    // Un-optimized, the carrier-ON build must at least NOT GROW the module
+    // (the storage erasure + native ops never add bytes; the prelude is shared).
+    let on_raw = compile_wasm_bytes("mf-snake-on-raw", src, false);
+    let off_raw = compile_wasm_bytes("mf-snake-off-raw", src, true);
+    assert!(
+        on_raw.len() <= off_raw.len() + 16,
+        "carrier-ON un-optimized must not meaningfully grow the module: ON={} OFF={}",
+        on_raw.len(),
+        off_raw.len(),
+    );
 }


### PR DESCRIPTION
## What

Extends bounded carriers from single-field (`record C { value: Int }`) to **multi-field** records: `record Coord { x: Int, y: Int }` with a 2+-arg smart constructor `coord(x, y) -> Result<Coord, String>` gating both fields → each Int field is stored as native `i64` and `c.x` reads native `i64`. The source stays natural — `c.x : Int`, no `.value`, no single-field-leaf indirection. This is the ergonomic model for migrating record-threaded code (games) to native arithmetic.

## How

- **Bound attribution:** recognize a 2+-arg smart constructor whose Ok branch is `Rec(f = p, ...)`; map each FIELD to its PARAM via the `RecordCreate` — **not by position**, so a swapped `Coord(x = y, y = x)` attributes correctly (field `x` gets the bound of the value it actually holds). Split the guard conjunction per param, keeping only single-variable leaves (a cross-field `x + y <= 50` is dropped — conservative, a narrower per-field bound is always a sound over-approximation), and run the #511 interval analysis per field. Fail-closed: a field with no proven single-var `fits_i64` bound, a field not bound to a bare param, or a complex guard/body all decline (the field stays boxed `$AverInt`).
- **Per-field eligibility** `(record, field) → interval`, filtered through the same demotion scans as single-field carriers (ungated construction, Map-key). Eligible fields lower to `i64` in the record struct; `Project(rec, field)` of an eligible field is a raw `i64` leaf fed into the #543 interval fixpoint (overflow stays boxed); construction bridges per field. wasm-gc only (the Rust backend keeps carriers as structs). Additive — the single-field path is untouched.

## Soundness

Same fixpoint: a field bounded `0..2^40` doing `c.x * c.x` (= 2^80) stays boxed and exact, VM == wasm-gc. The attribution follows the actual construction, so a field's bound is the bound on the value it actually holds. Storage is **byte-identical** to the single-field-leaf composition (`Coord{x:Int,y:Int}` → `(struct (field i64) (field i64))`; a mixed record → `(field i64) (field (ref null $AverInt))`). The new raw field-read source flows into the `$AverInt` sink chokepoints already closed in #552 → auto-boxed (verified by compile-checks into every sink). A plain record with no smart constructor stays fully boxed (mis-fire negative).

## Tests

+8 differential (each VM == wasm-gc AND compile-clean): native `c.x + c.dx`, wide-bound per-field overflow, mixed eligible/non-eligible fields, the mis-fire negative, ungated-construction demotion, nested field read, field read into each `$AverInt` sink. +4 bound-attribution unit tests (per-field intervals, cross-field dropped, only-one-field-bounded, no-smart-ctor). Carrier differential 47, cross-backend proptest + stress, wasip2 `pool_wraparound`, `cargo test` default 2293, fmt + clippy clean. The #550/#551/#552 single-field probes still pass.

## Measured

A `Coord{x,y}` snake model: **1953 B (on) vs 6254 B (boxed)** — the same proportional win and byte-identical storage as the single-field-leaf version (within 13 B), now with the natural `c.x` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
