### PR TITLE
wasm-gc: box carrier-field reads at mutual-recursion and interpolation sinks

### DIFF
--- a/src/codegen/wasm_gc/body/from_mir/strings.rs
+++ b/src/codegen/wasm_gc/body/from_mir/strings.rs
@@ -70,6 +70,18 @@ pub(crate) fn emit_mir_interpolated_str(
                 match aver_ty.trim() {
                     "String" => { /* identity */ }
                     "Int" => {
+                        // ETAP-2 carrier-`i64`: a bare-carrier `.value` read
+                        // (or raw carrier arithmetic) leaves a native `i64` on
+                        // the stack — the project bridge was skipped because the
+                        // surrounding context is expected to box. `String.fromInt`
+                        // takes a boxed `$AverInt` ref, so this IS that context:
+                        // lift the raw `i64` to `$AverInt` (`__aint_from_i64`)
+                        // before the call, or the raw `i64` meets a `(ref null
+                        // $type)` slot (a wasm VALIDATION failure). Mirrors the
+                        // `from_mir.rs` boundary-box at the other `$AverInt` sinks.
+                        if ctx.registry.bignum && mir_renders_raw_i64(&inner.node, ctx) {
+                            emit_carrier_project_bridge(func, ctx)?;
+                        }
                         let to_string_idx =
                             ctx.fn_map.builtins.get("String.fromInt").copied().ok_or(
                                 WasmGcError::Validation(

--- a/src/ir/mir/optimize/bare_i64_rewrite.rs
+++ b/src/ir/mir/optimize/bare_i64_rewrite.rs
@@ -126,7 +126,28 @@ fn rewrite(
         // `AverInt` — a wasm VALIDATION error. The all-boxed facts make
         // `rewrite_boxed`/`rewrite_call_args` box that result.
         let fn_facts = if boxed_signature_fns.contains(&id) {
-            FnBareFacts::default()
+            // Empty `values` / `carrier_slots` / `bare_params` / `bare_return`
+            // (its own signature + slots stay boxed `AverInt`, matching the
+            // pinned mutual-TCO signature). BUT keep the TYPE-driven carrier
+            // recognition tables (`carrier_types` / `field_carrier_intervals`):
+            // a NESTED carrier-field read (`state.score.value`, base type a
+            // single-field carrier) or a DIRECT bounded multi-field read is
+            // recognized by the wasm-gc EMITTER structurally (registry-based,
+            // independent of this fn's boxed-signature override) — it reads the
+            // erased `i64` field directly and SKIPS the project bridge. So the
+            // rewrite must ALSO see those reads as raw and `Box` them into this
+            // fn's boxed (`$AverInt`) sinks (a `String.fromInt` arg, a returned
+            // `Result.Ok` embed). With fully-empty facts the rewrite missed the
+            // box and the raw `i64` met an `$AverInt` slot — a wasm VALIDATION
+            // failure on a mutual-TCO member that stringifies a carrier field
+            // (the snake `tick`/`tickMove` SCC stringifying `score.value`).
+            // These tables are global (same for every fn), so this never
+            // introduces bareness the analysis didn't already prove.
+            FnBareFacts {
+                carrier_types: carrier.clone(),
+                field_carrier_intervals: field_carrier.clone(),
+                ..FnBareFacts::default()
+            }
         } else {
             let Some(f) = facts.for_fn(id).cloned() else {
                 continue;

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -867,6 +867,62 @@ fn main() -> Unit
     assert_carrier_revert_agrees("nested-field-sinks", src, &out);
 }
 
+/// MUTUAL-RECURSION SCC member stringifying a nested carrier field — the
+/// snake `tick`/`tickMove`/`gameLoop` shape. `step`/`bounce`/`loopN` form a
+/// call cycle, so all three carry a PINNED boxed (`$AverInt`) signature and
+/// the rewrite forces each member's body all-boxed. The bug: the all-boxed
+/// override used FULLY-empty facts, dropping the carrier-recognition tables —
+/// so a nested carrier-field read (`h.c.value`, base type a single-field
+/// carrier) reached an `$AverInt` sink (`String.fromInt`) WITHOUT a `Box`,
+/// while the wasm-gc emitter (registry-based, independent of the override)
+/// still rendered it raw `i64`. The raw `i64` met the formatter's `(ref null
+/// $type)` slot — a wasm VALIDATION failure on a VM-valid program. The fix
+/// keeps the TYPE-driven carrier tables in the all-boxed facts so the rewrite
+/// boxes the field read at the sink. Without it, `compile --target wasm-gc`
+/// fails validation; with it, VM == wasm-gc.
+#[test]
+fn mutual_recursion_member_stringifies_carrier_field_boxes_at_boundary() {
+    let src = r#"module M
+    intent = "mutual-TCO member stringifies a nested carrier field"
+    effects [Console]
+
+record Score
+    value: Int
+
+record State
+    score: Score
+    fuel: Int
+
+fn fromInt(n: Int) -> Result<Score, String>
+    match Bool.and(n >= 0, n <= 1000000)
+        true  -> Result.Ok(Score(value = n))
+        false -> Result.Err("oob")
+
+fn sc(n: Int) -> Score
+    match fromInt(n)
+        Result.Ok(s)  -> s
+        Result.Err(_) -> Score(value = 0)
+
+fn step(s: State) -> String
+    match s.fuel == 0
+        true  -> "done: {String.fromInt(s.score.value)}"
+        false -> bounce(s)
+
+fn bounce(s: State) -> String
+    loopN(State(score = s.score, fuel = s.fuel - 1))
+
+fn loopN(s: State) -> String
+    step(s)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(step(State(score = sc(7), fuel = 3)))
+"#;
+    let out = assert_vm_wasm_identical("mutual-tco-carrier-stringify", src);
+    assert_eq!(out, "done: 7");
+    assert_carrier_revert_agrees("mutual-tco-carrier-stringify", src, &out);
+}
+
 /// WIDE-BOUND NESTED-FIELD OVERFLOW (the C0 soundness probe for the new raw
 /// source). A record holds a `0..2^40` carrier; `rec.c.value * rec.c.value` =
 /// up to `2^80`, which OVERFLOWS `i64`. The interval fixpoint must read the


### PR DESCRIPTION
## What

Two wasm-gc carrier-i64 boundary-completeness fixes (same class as the per-slot/field work): a raw `i64` carrier-field read reaching an `$AverInt` sink without a `Box` -> wasm validation failure.

- **Mutual-recursion member.** A boxed-signature mutual-TCO member used fully-empty bare facts, dropping the global type-driven carrier tables. The wasm-gc emitter still recognizes a carrier-field read structurally and emits a raw `i64`, but the rewrite then missed boxing it into a `String.fromInt` arg / `Result.Ok` embed. Fix: keep `carrier_types` / `field_carrier_intervals` (type-level, global) in the all-boxed facts so the rewrite boxes the read. It can only ADD a box, never introduce bareness the analysis did not prove.
- **String interpolation.** The `Int` arm of an interpolated string now boxes a raw-rendering carrier read before `String.fromInt`, mirroring every other `$AverInt` sink boundary.

Found by migrating a real game (a mutual-TCO tick loop stringifying a bounded score). Fail-loud (validation failure), not a silent wrong value.

## Tests

Revert-tested regression `mutual_recursion_member_stringifies_carrier_field_boxes_at_boundary`; carrier differential 59, full wasm-gc suite, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
