### PR TITLE
wasm-gc: factor shared bignum sub-routines into callable helpers

### DIFF
--- a/src/codegen/wasm_gc/builtins/bignum.rs
+++ b/src/codegen/wasm_gc/builtins/bignum.rs
@@ -84,13 +84,32 @@ fn aint_type_decls(registry: &TypeRegistry) -> Result<String, WasmGcError> {
     ))
 }
 
+/// Decompose `$AverInt` operand local `$op` into a non-null 32-bit-limb
+/// magnitude array local `$opm` (little-endian, leading zeros possible) and a
+/// sign local `$ops` (-1/0/+1). When the shared `__aint_decompose` sub-routine
+/// has a registered fn index, emits a `call` to it (its two results land into
+/// `$opm` / `$ops`); otherwise inlines the body. `$umag` is an i64 scratch the
+/// inline path uses.
+fn decompose(registry: &TypeRegistry, op: &str, opm: &str, ops: &str, umag: &str) -> String {
+    if let Some(idx) = registry.aint_decompose_fn_idx {
+        // `call` pushes `(mag, sign)`; pop sign then mag into the caller locals.
+        return format!(
+            r#"
+            (call {idx} (local.get ${op}))
+            (local.set ${ops})
+            (local.set ${opm}) "#
+        );
+    }
+    decompose_inline(op, opm, ops, umag)
+}
+
 /// Inlined WAT: decompose `$AverInt` operand local `$op` into a non-null
 /// 32-bit-limb magnitude array local `$opm` (little-endian, leading
 /// zeros possible) and a sign local `$ops` (-1/0/+1). A Small splits
 /// `|small|` into two 32-bit limbs; zero → sign 0 + empty magnitude.
 /// `|i64::MIN|` is recovered via `0 - small` (wrapping), giving the
 /// correct unsigned `2^63` whose low/high 32-bit halves are then split.
-fn decompose(op: &str, opm: &str, ops: &str, umag: &str) -> String {
+fn decompose_inline(op: &str, opm: &str, ops: &str, umag: &str) -> String {
     // $umag is an i64 scratch holding |small| during the split.
     format!(
         r#"
@@ -119,6 +138,19 @@ fn decompose(op: &str, opm: &str, ops: &str, umag: &str) -> String {
     )
 }
 
+/// Normalize epilogue. Takes a working 32-bit-limb magnitude array local
+/// `$rm` (leading zeros allowed) and a raw sign local `$rs`, leaves a
+/// canonical `$AverInt` on the stack. When the shared `__aint_normalize`
+/// sub-routine has a registered fn index, emits a `call` to it; otherwise
+/// inlines the body, whose scratch locals are the fixed `$rlen $i $lo $hi
+/// $tmpm` (declared by every caller's `arith_locals`/`divmod_locals`).
+fn normalize(registry: &TypeRegistry, rm: &str, rs: &str) -> String {
+    if let Some(idx) = registry.aint_normalize_fn_idx {
+        return format!("(call {idx} (local.get ${rm}) (local.get ${rs}))");
+    }
+    normalize_inline(rm, rs, "rlen", "i", "lo", "hi", "tmpm")
+}
+
 /// Inlined WAT normalize epilogue. Takes a working 32-bit-limb magnitude
 /// array local `$rm` (leading zeros allowed) and a raw sign local `$rs`,
 /// leaves a canonical `$AverInt` on the stack. Scratch: `$rlen $i $hi
@@ -127,7 +159,15 @@ fn decompose(op: &str, opm: &str, ops: &str, umag: &str) -> String {
 /// Strips leading zeros; magnitude 0 → Small(0); a magnitude of ≤2 limbs
 /// whose 64-bit value fits the signed-i64 range for `$rs` → Small (incl.
 /// the lone `i64::MIN`); else a tight Big.
-fn normalize(rm: &str, rs: &str, rlen: &str, i: &str, lo: &str, hi: &str, tmpm: &str) -> String {
+fn normalize_inline(
+    rm: &str,
+    rs: &str,
+    rlen: &str,
+    i: &str,
+    lo: &str,
+    hi: &str,
+    tmpm: &str,
+) -> String {
     format!(
         r#"
             ;; strip leading zero limbs
@@ -194,10 +234,31 @@ fn tight_big(rm: &str, rs: &str, rlen: &str, i: &str, tmpm: &str) -> String {
     )
 }
 
+/// Unsigned-magnitude compare of arrays `$am` (stripped len `$alen`) and
+/// `$bm` (stripped len `$blen`) → -1/0/1 into i32 `$cmp`. When the shared
+/// `__aint_umag_cmp` sub-routine has a registered fn index, emits a `call`
+/// to it; otherwise inlines the body (i32 scratch `$j`).
+fn umag_cmp(
+    registry: &TypeRegistry,
+    am: &str,
+    alen: &str,
+    bm: &str,
+    blen: &str,
+    cmp: &str,
+    j: &str,
+) -> String {
+    if let Some(idx) = registry.aint_umag_cmp_fn_idx {
+        return format!(
+            "(local.set ${cmp} (call {idx} (local.get ${am}) (local.get ${alen}) (local.get ${bm}) (local.get ${blen})))"
+        );
+    }
+    umag_cmp_inline(am, alen, bm, blen, cmp, j)
+}
+
 /// Inlined unsigned-magnitude compare of arrays `$am` (stripped len
 /// `$alen`) and `$bm` (stripped len `$blen`) → -1/0/1 into i32 `$cmp`.
 /// i32 scratch `$j`.
-fn umag_cmp(am: &str, alen: &str, bm: &str, blen: &str, cmp: &str, j: &str) -> String {
+fn umag_cmp_inline(am: &str, alen: &str, bm: &str, blen: &str, cmp: &str, j: &str) -> String {
     format!(
         r#"
             (if (i32.ne (local.get ${alen}) (local.get ${blen}))
@@ -359,10 +420,12 @@ fn from_string_err_build() -> String {
 pub(super) fn emit_aint_from_string(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_string_result_decls(registry)?;
     let err_build = from_string_err_build();
-    let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    let norm = normalize(registry, "rm", "rs");
+    let func_pad = func_pad(&[(registry.aint_normalize_fn_idx, NORMALIZE_SIG)]);
     let wat = format!(
         include_str!("wat/from_string.wat"),
         decls = decls,
+        func_pad = func_pad,
         err_build = err_build,
         norm = norm,
     );
@@ -378,6 +441,75 @@ pub(super) fn emit_aint_from_string(registry: &TypeRegistry) -> Result<Function,
 pub(super) fn emit_string_from_aint(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_and_string_decls(registry)?;
     let wat = format!(include_str!("wat/string_from_aint.wat"), decls = decls);
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// WAT signatures the shared sub-routines are `call`ed with, in `$`-typed
+/// WAT form. Must match the `params`/`results` declared in `builtins/mod.rs`,
+/// because the standalone helper module's placeholder `(func)` at each
+/// sub-routine's real index is type-checked against the `call`.
+const DECOMPOSE_SIG: &str = "(param (ref null $aint)) (result (ref null $mag) i32)";
+const NORMALIZE_SIG: &str = "(param (ref null $mag)) (param i32) (result (ref null $aint))";
+const STRIP_SIG: &str = "(param (ref null $mag)) (result i32)";
+const UMAG_CMP_SIG: &str =
+    "(param (ref null $mag)) (param i32) (param (ref null $mag)) (param i32) (result i32)";
+
+/// Build the function-index scaffolding a multi-helper bignum WAT needs so its
+/// `(call <real-idx>)` instructions validate in the standalone module. Only
+/// the shared sub-routines the helper actually `call`s contribute a stub; a
+/// `None` fn idx (bignum off, or a not-yet-factored sub-routine) is skipped —
+/// the generator inlined the body in that case, so no `call` was emitted.
+/// Returns the WAT fragment to splice right after `{decls}`. See
+/// `wat_helper::func_placeholders` for the index/relocation contract.
+fn func_pad(callees: &[(Option<u32>, &'static str)]) -> String {
+    let stubs: Vec<wat_helper::CalleeStub> = callees
+        .iter()
+        .filter_map(|(idx, sig)| idx.map(|abs_idx| wat_helper::CalleeStub { abs_idx, sig }))
+        .collect();
+    wat_helper::func_placeholders(&stubs)
+}
+
+/// `__aint_decompose(a) -> (mag, sign)` — shared sub-routine. Splits an
+/// `$AverInt` into a non-null 32-bit-limb magnitude (leading zeros possible)
+/// and a sign (-1/0/+1), leaving both on the stack `(mag, sign)`. The body is
+/// the same logic the inlined `decompose` generator emits, lifted into a
+/// callable function so add/sub/mul/divmod/cmp `call` it once instead of each
+/// carrying a private copy. A leaf (no inter-helper `call`).
+pub(super) fn emit_aint_decompose(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(include_str!("wat/decompose.wat"), decls = decls);
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_normalize(rm, rs) -> $AverInt` — shared sub-routine. Strips leading
+/// zeros from a working magnitude, demotes an in-range value to Small (incl.
+/// the lone `i64::MIN`) or builds a tight Big, leaving a canonical `$AverInt`.
+/// Same logic the inlined `normalize` epilogue emits; a leaf.
+pub(super) fn emit_aint_normalize(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(
+        include_str!("wat/normalize.wat"),
+        decls = decls,
+        tight_big = tight_big("rm", "rs", "rlen", "i", "tmpm"),
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_strip(arr) -> i32` — shared sub-routine. Count of limbs after
+/// dropping leading-zero limbs. Same logic the inlined `strip` generator
+/// emits; a leaf.
+pub(super) fn emit_aint_strip(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(include_str!("wat/strip.wat"), decls = decls);
+    wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__aint_umag_cmp(am, alen, bm, blen) -> i32` (-1/0/1) — shared sub-routine.
+/// Unsigned magnitude compare of two stripped limb arrays. Same logic the
+/// inlined `umag_cmp` generator emits; a leaf.
+pub(super) fn emit_aint_umag_cmp(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let decls = aint_type_decls(registry)?;
+    let wat = format!(include_str!("wat/umag_cmp.wat"), decls = decls);
     wat_helper::compile_wat_helper(&wat)
 }
 
@@ -411,8 +543,14 @@ pub(super) fn emit_aint_to_f64(registry: &TypeRegistry) -> Result<Function, Wasm
 /// non-negative exponent), matching `AverInt::from_f64_trunc`.
 pub(super) fn emit_aint_from_f64(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
-    let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
-    let wat = format!(include_str!("wat/from_f64.wat"), decls = decls, norm = norm);
+    let norm = normalize(registry, "rm", "rs");
+    let func_pad = func_pad(&[(registry.aint_normalize_fn_idx, NORMALIZE_SIG)]);
+    let wat = format!(
+        include_str!("wat/from_f64.wat"),
+        decls = decls,
+        func_pad = func_pad,
+        norm = norm
+    );
     wat_helper::compile_wat_helper(&wat)
 }
 
@@ -507,14 +645,20 @@ pub(super) fn emit_aint_hash(registry: &TypeRegistry) -> Result<Function, WasmGc
 /// magnitude (flipped for two negatives). Mirrors `AverInt::cmp`.
 pub(super) fn emit_aint_cmp(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
-    let decomp_a = decompose("a", "am", "as_", "umag");
-    let decomp_b = decompose("b", "bm", "bs", "umag");
-    let strip_a = strip("am", "alen", "sa", "la");
-    let strip_b = strip("bm", "blen", "sb", "lb");
-    let cmp = umag_cmp("am", "alen", "bm", "blen", "cmp", "j");
+    let decomp_a = decompose(registry, "a", "am", "as_", "umag");
+    let decomp_b = decompose(registry, "b", "bm", "bs", "umag");
+    let strip_a = strip(registry, "am", "alen", "sa", "la");
+    let strip_b = strip(registry, "bm", "blen", "sb", "lb");
+    let cmp = umag_cmp(registry, "am", "alen", "bm", "blen", "cmp", "j");
+    let func_pad = func_pad(&[
+        (registry.aint_decompose_fn_idx, DECOMPOSE_SIG),
+        (registry.aint_strip_fn_idx, STRIP_SIG),
+        (registry.aint_umag_cmp_fn_idx, UMAG_CMP_SIG),
+    ]);
     let wat = format!(
         include_str!("wat/cmp.wat"),
         decls = decls,
+        func_pad = func_pad,
         decomp_a = decomp_a,
         decomp_b = decomp_b,
         strip_a = strip_a,
@@ -524,9 +668,19 @@ pub(super) fn emit_aint_cmp(registry: &TypeRegistry) -> Result<Function, WasmGcE
     wat_helper::compile_wat_helper(&wat)
 }
 
+/// Leading-zero strip of array `$arr` into i32 len local `$len`. When the
+/// shared `__aint_strip` sub-routine has a registered fn index, emits a `call`
+/// to it; otherwise inlines a loop using unique block/loop labels `$bl`/`$lp`.
+fn strip(registry: &TypeRegistry, arr: &str, len: &str, bl: &str, lp: &str) -> String {
+    if let Some(idx) = registry.aint_strip_fn_idx {
+        return format!("(local.set ${len} (call {idx} (local.get ${arr})))");
+    }
+    strip_inline(arr, len, bl, lp)
+}
+
 /// Inlined leading-zero strip of array `$arr` into i32 len local `$len`,
 /// using unique block/loop label names `$bl`/`$lp`.
-fn strip(arr: &str, len: &str, bl: &str, lp: &str) -> String {
+fn strip_inline(arr: &str, len: &str, bl: &str, lp: &str) -> String {
     format!(
         r#"
             (local.set ${len} (array.len (local.get ${arr})))
@@ -546,8 +700,8 @@ fn strip(arr: &str, len: &str, bl: &str, lp: &str) -> String {
 /// Assumes the caller has stripped `am`→`$alen`, `bm`→`$blen` and
 /// declared scratch `$rlen $i $carry $cmp $j $borrow $diff` with the
 /// types named below. 32-bit limbs make carry/borrow exact.
-fn signed_combine() -> String {
-    let cmp = umag_cmp("am", "alen", "bm", "blen", "cmp", "j");
+fn signed_combine(registry: &TypeRegistry) -> String {
+    let cmp = umag_cmp(registry, "am", "alen", "bm", "blen", "cmp", "j");
     format!(
         r#"
             ;; signs "agree" when one is zero, or the two non-zero signs match.
@@ -640,12 +794,18 @@ pub(super) fn emit_aint_sub(registry: &TypeRegistry) -> Result<Function, WasmGcE
 fn emit_aint_addsub(registry: &TypeRegistry, is_sub: bool) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
     let locals = arith_locals();
-    let decomp_a = decompose("a", "am", "as_", "umag");
-    let decomp_b = decompose("b", "bm", "bs", "umag");
-    let strip_a = strip("am", "alen", "sa", "la");
-    let strip_b = strip("bm", "blen", "sb", "lb");
-    let combine = signed_combine();
-    let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    let decomp_a = decompose(registry, "a", "am", "as_", "umag");
+    let decomp_b = decompose(registry, "b", "bm", "bs", "umag");
+    let strip_a = strip(registry, "am", "alen", "sa", "la");
+    let strip_b = strip(registry, "bm", "blen", "sb", "lb");
+    let combine = signed_combine(registry);
+    let norm = normalize(registry, "rm", "rs");
+    let func_pad = func_pad(&[
+        (registry.aint_decompose_fn_idx, DECOMPOSE_SIG),
+        (registry.aint_strip_fn_idx, STRIP_SIG),
+        (registry.aint_umag_cmp_fn_idx, UMAG_CMP_SIG),
+        (registry.aint_normalize_fn_idx, NORMALIZE_SIG),
+    ]);
     // i64 fast-path: both Small.
     let (fast_op, overflow_check) = if is_sub {
         (
@@ -668,6 +828,7 @@ fn emit_aint_addsub(registry: &TypeRegistry, is_sub: bool) -> Result<Function, W
     let wat = format!(
         include_str!("wat/addsub.wat"),
         decls = decls,
+        func_pad = func_pad,
         locals = locals,
         decomp_a = decomp_a,
         decomp_b = decomp_b,
@@ -689,14 +850,20 @@ fn emit_aint_addsub(registry: &TypeRegistry, is_sub: bool) -> Result<Function, W
 pub(super) fn emit_aint_mul(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
     let locals = arith_locals();
-    let decomp_a = decompose("a", "am", "as_", "umag");
-    let decomp_b = decompose("b", "bm", "bs", "umag");
-    let strip_a = strip("am", "alen", "sa", "la");
-    let strip_b = strip("bm", "blen", "sb", "lb");
-    let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    let decomp_a = decompose(registry, "a", "am", "as_", "umag");
+    let decomp_b = decompose(registry, "b", "bm", "bs", "umag");
+    let strip_a = strip(registry, "am", "alen", "sa", "la");
+    let strip_b = strip(registry, "bm", "blen", "sb", "lb");
+    let norm = normalize(registry, "rm", "rs");
+    let func_pad = func_pad(&[
+        (registry.aint_decompose_fn_idx, DECOMPOSE_SIG),
+        (registry.aint_strip_fn_idx, STRIP_SIG),
+        (registry.aint_normalize_fn_idx, NORMALIZE_SIG),
+    ]);
     let wat = format!(
         include_str!("wat/mul.wat"),
         decls = decls,
+        func_pad = func_pad,
         locals = locals,
         decomp_a = decomp_a,
         decomp_b = decomp_b,
@@ -749,19 +916,26 @@ fn divmod_locals() -> &'static str {
 pub(super) fn emit_aint_divmod(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let decls = aint_type_decls(registry)?;
     let locals = divmod_locals();
-    let decomp_a = decompose("a", "am", "as_", "umag");
-    let decomp_b = decompose("b", "bm", "bs", "umag");
-    let strip_a = strip("am", "alen", "sa", "la");
-    let strip_b = strip("bm", "blen", "sb", "lb");
+    let decomp_a = decompose(registry, "a", "am", "as_", "umag");
+    let decomp_b = decompose(registry, "b", "bm", "bs", "umag");
+    let strip_a = strip(registry, "am", "alen", "sa", "la");
+    let strip_b = strip(registry, "bm", "blen", "sb", "lb");
     // r vs |b| during long division: $rwm (stripped $rwlen) ⋛ $bm ($blen).
-    let cmp_r_b = umag_cmp("rwm", "rwlen", "bm", "blen", "cmp", "j");
+    let cmp_r_b = umag_cmp(registry, "rwm", "rwlen", "bm", "blen", "cmp", "j");
     // Two normalize epilogues, one per result branch; they're in disjoint
     // `if` arms so reusing the same scratch locals is safe.
-    let norm_q = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
-    let norm_r = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+    let norm_q = normalize(registry, "rm", "rs");
+    let norm_r = normalize(registry, "rm", "rs");
+    let func_pad = func_pad(&[
+        (registry.aint_decompose_fn_idx, DECOMPOSE_SIG),
+        (registry.aint_strip_fn_idx, STRIP_SIG),
+        (registry.aint_umag_cmp_fn_idx, UMAG_CMP_SIG),
+        (registry.aint_normalize_fn_idx, NORMALIZE_SIG),
+    ]);
     let wat = format!(
         include_str!("wat/divmod.wat"),
         decls = decls,
+        func_pad = func_pad,
         locals = locals,
         decomp_a = decomp_a,
         decomp_b = decomp_b,
@@ -883,6 +1057,11 @@ mod tests {
             ("emit_aint_to_f64", emit_aint_to_f64),
             ("emit_aint_from_f64", emit_aint_from_f64),
             ("emit_aint_to_index", emit_aint_to_index),
+            // Shared sub-routines — their standalone modules must parse too.
+            ("emit_aint_decompose", emit_aint_decompose),
+            ("emit_aint_normalize", emit_aint_normalize),
+            ("emit_aint_strip", emit_aint_strip),
+            ("emit_aint_umag_cmp", emit_aint_umag_cmp),
         ];
 
         for (name, emit) in cases {
@@ -951,6 +1130,16 @@ mod validation_guard {
                 "__aint_to_index",
                 render_simple(&registry, include_str!("wat/to_index.wat")),
             ),
+            // Shared sub-routines (size dedup) — their standalone modules
+            // must VALIDATE: the demote-to-Small / build-Big branch
+            // (`__aint_normalize`) returns `(ref null $aint)` on every arm, the
+            // decompose splits return `(mag, sign)`, the strip/cmp return i32.
+            // A paren slip or stack-type mismatch fails here, not only when a
+            // program happens to hit the divide path in wasmtime.
+            ("__aint_decompose", render_decompose(&registry)),
+            ("__aint_normalize", render_normalize(&registry)),
+            ("__aint_strip", render_strip(&registry)),
+            ("__aint_umag_cmp", render_umag_cmp(&registry)),
         ];
 
         for (name, wat) in modules {
@@ -964,6 +1153,174 @@ mod validation_guard {
         }
     }
 
+    /// CALL-PATH validate — the arithmetic helpers rendered with the `call`
+    /// path ACTIVE. Setting the shared fn-index fields on the registry flips
+    /// each generator from inlining to emitting `(call <idx>)` plus the
+    /// `func_pad` placeholder scaffolding (`(func <sig> unreachable)` at each
+    /// callee's index). The resulting STANDALONE module — placeholders at
+    /// indices 0..=3 then the exported helper — is exactly what
+    /// `compile_wat_helper` parses, and it self-validates: the `call <idx>`
+    /// type-checks against the placeholder of matching signature. A wrong
+    /// call-index/signature, a `func_pad` slot at the wrong index, or a stack
+    /// mismatch in the `call` shim fails here — the bug class the inline-only
+    /// standalone guards above structurally cannot see.
+    #[test]
+    fn shared_subroutine_call_path_validates() {
+        let mut registry = bignum_registry_for_validation();
+        // Pick non-trivial indices so an off-by-one in `func_pad`'s padding (or
+        // in the lifted `call`'s LEB128 index) would mis-resolve and fail.
+        registry.aint_decompose_fn_idx = Some(7);
+        registry.aint_normalize_fn_idx = Some(8);
+        registry.aint_strip_fn_idx = Some(9);
+        registry.aint_umag_cmp_fn_idx = Some(10);
+
+        // Each helper's full standalone module text (decls + func_pad +
+        // exported helper), validated as a unit. `func_pad` declares placeholder
+        // funcs up to index 10 so every `(call 7..10)` resolves to a func of the
+        // right signature.
+        let modules: Vec<(&str, String)> = vec![
+            ("__aint_add", render_addsub(&registry, false)),
+            ("__aint_sub", render_addsub(&registry, true)),
+            ("__aint_mul", render_mul(&registry)),
+            ("__aint_divmod", render_divmod(&registry)),
+            ("__aint_cmp", render_cmp(&registry)),
+            ("__aint_from_string", render_from_string(&registry)),
+            ("__aint_from_f64", render_from_f64(&registry)),
+        ];
+        for (name, wat) in modules {
+            let bytes = wat::parse_str(&wat)
+                .unwrap_or_else(|e| panic!("call-path helper `{name}` failed to parse: {e}"));
+            let mut validator =
+                wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all());
+            validator
+                .validate_all(&bytes)
+                .unwrap_or_else(|e| panic!("call-path helper `{name}` failed to VALIDATE: {e}"));
+        }
+    }
+
+    fn render_addsub(registry: &TypeRegistry, is_sub: bool) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        let locals = arith_locals();
+        let decomp_a = decompose(registry, "a", "am", "as_", "umag");
+        let decomp_b = decompose(registry, "b", "bm", "bs", "umag");
+        let strip_a = strip(registry, "am", "alen", "sa", "la");
+        let strip_b = strip(registry, "bm", "blen", "sb", "lb");
+        let combine = signed_combine(registry);
+        let norm = normalize(registry, "rm", "rs");
+        let func_pad = func_pad(&[
+            (registry.aint_decompose_fn_idx, DECOMPOSE_SIG),
+            (registry.aint_strip_fn_idx, STRIP_SIG),
+            (registry.aint_umag_cmp_fn_idx, UMAG_CMP_SIG),
+            (registry.aint_normalize_fn_idx, NORMALIZE_SIG),
+        ]);
+        let (fast_op, overflow_check) = if is_sub {
+            (
+                "(i64.sub (struct.get $aint $small (local.get $a)) (struct.get $aint $small (local.get $b)))",
+                "(i64.lt_s (i64.and (i64.xor (struct.get $aint $small (local.get $a)) (struct.get $aint $small (local.get $b))) (i64.xor (struct.get $aint $small (local.get $a)) (local.get $r))) (i64.const 0))",
+            )
+        } else {
+            (
+                "(i64.add (struct.get $aint $small (local.get $a)) (struct.get $aint $small (local.get $b)))",
+                "(i64.lt_s (i64.and (i64.xor (struct.get $aint $small (local.get $a)) (local.get $r)) (i64.xor (struct.get $aint $small (local.get $b)) (local.get $r))) (i64.const 0))",
+            )
+        };
+        let beff_set = if is_sub {
+            "(local.set $beff (i32.sub (i32.const 0) (local.get $bs)))"
+        } else {
+            "(local.set $beff (local.get $bs))"
+        };
+        format!(
+            include_str!("wat/addsub.wat"),
+            decls = decls,
+            func_pad = func_pad,
+            locals = locals,
+            decomp_a = decomp_a,
+            decomp_b = decomp_b,
+            beff_set = beff_set,
+            strip_a = strip_a,
+            strip_b = strip_b,
+            combine = combine,
+            norm = norm,
+            fast_op = fast_op,
+            overflow_check = overflow_check,
+        )
+    }
+
+    fn render_mul(registry: &TypeRegistry) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        let locals = arith_locals();
+        let decomp_a = decompose(registry, "a", "am", "as_", "umag");
+        let decomp_b = decompose(registry, "b", "bm", "bs", "umag");
+        let strip_a = strip(registry, "am", "alen", "sa", "la");
+        let strip_b = strip(registry, "bm", "blen", "sb", "lb");
+        let norm = normalize(registry, "rm", "rs");
+        let func_pad = func_pad(&[
+            (registry.aint_decompose_fn_idx, DECOMPOSE_SIG),
+            (registry.aint_strip_fn_idx, STRIP_SIG),
+            (registry.aint_normalize_fn_idx, NORMALIZE_SIG),
+        ]);
+        format!(
+            include_str!("wat/mul.wat"),
+            decls = decls,
+            func_pad = func_pad,
+            locals = locals,
+            decomp_a = decomp_a,
+            decomp_b = decomp_b,
+            strip_a = strip_a,
+            strip_b = strip_b,
+            norm = norm,
+            mul_body = mul_magnitude(),
+        )
+    }
+
+    fn render_cmp(registry: &TypeRegistry) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        let decomp_a = decompose(registry, "a", "am", "as_", "umag");
+        let decomp_b = decompose(registry, "b", "bm", "bs", "umag");
+        let strip_a = strip(registry, "am", "alen", "sa", "la");
+        let strip_b = strip(registry, "bm", "blen", "sb", "lb");
+        let cmp = umag_cmp(registry, "am", "alen", "bm", "blen", "cmp", "j");
+        let func_pad = func_pad(&[
+            (registry.aint_decompose_fn_idx, DECOMPOSE_SIG),
+            (registry.aint_strip_fn_idx, STRIP_SIG),
+            (registry.aint_umag_cmp_fn_idx, UMAG_CMP_SIG),
+        ]);
+        format!(
+            include_str!("wat/cmp.wat"),
+            decls = decls,
+            func_pad = func_pad,
+            decomp_a = decomp_a,
+            decomp_b = decomp_b,
+            strip_a = strip_a,
+            strip_b = strip_b,
+            cmp = cmp,
+        )
+    }
+
+    fn render_decompose(registry: &TypeRegistry) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        format!(include_str!("wat/decompose.wat"), decls = decls)
+    }
+
+    fn render_normalize(registry: &TypeRegistry) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        format!(
+            include_str!("wat/normalize.wat"),
+            decls = decls,
+            tight_big = tight_big("rm", "rs", "rlen", "i", "tmpm"),
+        )
+    }
+
+    fn render_strip(registry: &TypeRegistry) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        format!(include_str!("wat/strip.wat"), decls = decls)
+    }
+
+    fn render_umag_cmp(registry: &TypeRegistry) -> String {
+        let decls = aint_type_decls(registry).unwrap();
+        format!(include_str!("wat/umag_cmp.wat"), decls = decls)
+    }
+
     fn render_simple(registry: &TypeRegistry, template: &str) -> String {
         let decls = aint_type_decls(registry).unwrap();
         template.replace("{decls}", &decls)
@@ -972,10 +1329,12 @@ mod validation_guard {
     fn render_from_string(registry: &TypeRegistry) -> String {
         let decls = aint_string_result_decls(registry).unwrap();
         let err_build = from_string_err_build();
-        let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+        let norm = normalize(registry, "rm", "rs");
+        let func_pad = func_pad(&[(registry.aint_normalize_fn_idx, NORMALIZE_SIG)]);
         format!(
             include_str!("wat/from_string.wat"),
             decls = decls,
+            func_pad = func_pad,
             err_build = err_build,
             norm = norm,
         )
@@ -983,23 +1342,36 @@ mod validation_guard {
 
     fn render_from_f64(registry: &TypeRegistry) -> String {
         let decls = aint_type_decls(registry).unwrap();
-        let norm = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
-        format!(include_str!("wat/from_f64.wat"), decls = decls, norm = norm)
+        let norm = normalize(registry, "rm", "rs");
+        let func_pad = func_pad(&[(registry.aint_normalize_fn_idx, NORMALIZE_SIG)]);
+        format!(
+            include_str!("wat/from_f64.wat"),
+            decls = decls,
+            func_pad = func_pad,
+            norm = norm
+        )
     }
 
     fn render_divmod(registry: &TypeRegistry) -> String {
         let decls = aint_type_decls(registry).unwrap();
         let locals = divmod_locals();
-        let decomp_a = decompose("a", "am", "as_", "umag");
-        let decomp_b = decompose("b", "bm", "bs", "umag");
-        let strip_a = strip("am", "alen", "sa", "la");
-        let strip_b = strip("bm", "blen", "sb", "lb");
-        let cmp_r_b = umag_cmp("rwm", "rwlen", "bm", "blen", "cmp", "j");
-        let norm_q = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
-        let norm_r = normalize("rm", "rs", "rlen", "i", "lo", "hi", "tmpm");
+        let decomp_a = decompose(registry, "a", "am", "as_", "umag");
+        let decomp_b = decompose(registry, "b", "bm", "bs", "umag");
+        let strip_a = strip(registry, "am", "alen", "sa", "la");
+        let strip_b = strip(registry, "bm", "blen", "sb", "lb");
+        let cmp_r_b = umag_cmp(registry, "rwm", "rwlen", "bm", "blen", "cmp", "j");
+        let norm_q = normalize(registry, "rm", "rs");
+        let norm_r = normalize(registry, "rm", "rs");
+        let func_pad = func_pad(&[
+            (registry.aint_decompose_fn_idx, DECOMPOSE_SIG),
+            (registry.aint_strip_fn_idx, STRIP_SIG),
+            (registry.aint_umag_cmp_fn_idx, UMAG_CMP_SIG),
+            (registry.aint_normalize_fn_idx, NORMALIZE_SIG),
+        ]);
         format!(
             include_str!("wat/divmod.wat"),
             decls = decls,
+            func_pad = func_pad,
             locals = locals,
             decomp_a = decomp_a,
             decomp_b = decomp_b,

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -211,6 +211,26 @@ pub(super) enum BuiltinName {
     /// `AverInt::to_i64()`, which ERRORS rather than saturating an out-of-
     /// range effect arg. slice 4 (flip).
     AintToI64Checked,
+    // ── bignum shared sub-routines (size dedup) ─────────────────────────
+    // These were TEXT-INLINED into every arithmetic helper because
+    // `compile_wat_helper` lifted one fn and could not relocate inter-helper
+    // `call`s. The lifter now pads the standalone helper WAT with
+    // function-index placeholders so a `call <real-idx>` validates and its
+    // body bytes transfer verbatim — letting the arithmetic helpers `call`
+    // these ONCE-emitted sub-routines instead of carrying a private copy.
+    // Registered (and slotted) BEFORE the arithmetic helpers that call them,
+    // so their fn indices are known when those helpers' WAT is rendered.
+    /// `__aint_decompose(a) -> (mag, sign)` — split an `$AverInt` into a
+    /// non-null 32-bit-limb magnitude (leading zeros possible) + sign.
+    AintDecompose,
+    /// `__aint_normalize(rm, rs) -> $AverInt` — strip + demote-to-Small /
+    /// build-tight-Big a working magnitude into a canonical `$AverInt`.
+    AintNormalize,
+    /// `__aint_strip(arr) -> i32` — count of limbs after leading zeros.
+    AintStrip,
+    /// `__aint_umag_cmp(am, alen, bm, blen) -> i32` (-1/0/1) — unsigned
+    /// magnitude compare of two stripped limb arrays.
+    AintUmagCmp,
 }
 
 impl BuiltinName {
@@ -285,6 +305,10 @@ impl BuiltinName {
             Self::AintToIndex => "__aint_to_index",
             Self::AintToI64Sat => "__aint_to_i64_sat",
             Self::AintToI64Checked => "__aint_to_i64_checked",
+            Self::AintDecompose => "__aint_decompose",
+            Self::AintNormalize => "__aint_normalize",
+            Self::AintStrip => "__aint_strip",
+            Self::AintUmagCmp => "__aint_umag_cmp",
         }
     }
 
@@ -341,6 +365,16 @@ impl BuiltinName {
                 Ok(vec![aint_ref_ty(registry)?])
             }
             Self::AintFromF64 => Ok(vec![ValType::F64]),
+            // Shared bignum sub-routines.
+            Self::AintDecompose => Ok(vec![aint_ref_ty(registry)?]),
+            Self::AintNormalize => Ok(vec![mag_ref_ty(registry)?, ValType::I32]),
+            Self::AintStrip => Ok(vec![mag_ref_ty(registry)?]),
+            Self::AintUmagCmp => Ok(vec![
+                mag_ref_ty(registry)?,
+                ValType::I32,
+                mag_ref_ty(registry)?,
+                ValType::I32,
+            ]),
         }
     }
 
@@ -383,6 +417,11 @@ impl BuiltinName {
             }
             Self::AintToF64 => Ok(vec![ValType::F64]),
             Self::AintToI64Sat | Self::AintToI64Checked => Ok(vec![ValType::I64]),
+            // Shared bignum sub-routines.
+            Self::AintDecompose => Ok(vec![mag_ref_ty(registry)?, ValType::I32]),
+            Self::AintNormalize => Ok(vec![aint_ref_ty(registry)?]),
+            Self::AintStrip => Ok(vec![ValType::I32]),
+            Self::AintUmagCmp => Ok(vec![ValType::I32]),
         }
     }
 
@@ -438,6 +477,10 @@ impl BuiltinName {
             Self::AintToIndex => bignum::emit_aint_to_index(registry),
             Self::AintToI64Sat => bignum::emit_aint_to_i64_sat(registry),
             Self::AintToI64Checked => bignum::emit_aint_to_i64_checked(registry),
+            Self::AintDecompose => bignum::emit_aint_decompose(registry),
+            Self::AintNormalize => bignum::emit_aint_normalize(registry),
+            Self::AintStrip => bignum::emit_aint_strip(registry),
+            Self::AintUmagCmp => bignum::emit_aint_umag_cmp(registry),
         }
     }
 }
@@ -499,6 +542,11 @@ impl BuiltinRegistry {
 /// `(ref null $AverInt)` — bignum slice 1 carrier ref.
 fn aint_ref_ty(registry: &TypeRegistry) -> Result<ValType, WasmGcError> {
     super::types::aint_ref_ty(registry)
+}
+
+/// `(ref null $mag)` — shared bignum sub-routine limb-array ref.
+fn mag_ref_ty(registry: &TypeRegistry) -> Result<ValType, WasmGcError> {
+    super::types::aint_mag_ref_ty(registry)
 }
 
 /// `(ref null $string_array)` — shared String repr.

--- a/src/codegen/wasm_gc/builtins/wat/addsub.wat
+++ b/src/codegen/wasm_gc/builtins/wat/addsub.wat
@@ -1,6 +1,7 @@
 
         (module
           {decls}
+          {func_pad}
           (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result (ref null $aint))
             (local $r i64)
             {locals}

--- a/src/codegen/wasm_gc/builtins/wat/cmp.wat
+++ b/src/codegen/wasm_gc/builtins/wat/cmp.wat
@@ -1,6 +1,7 @@
 
         (module
           {decls}
+          {func_pad}
           (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result i32)
             (local $am (ref null $mag)) (local $as_ i32)
             (local $bm (ref null $mag)) (local $bs i32)

--- a/src/codegen/wasm_gc/builtins/wat/decompose.wat
+++ b/src/codegen/wasm_gc/builtins/wat/decompose.wat
@@ -1,0 +1,29 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $op (ref null $aint)) (result (ref null $mag) i32)
+            (local $opm (ref null $mag)) (local $ops i32) (local $umag i64)
+            (if (ref.is_null (struct.get $aint $magf (local.get $op)))
+              (then
+                (if (i64.eqz (struct.get $aint $small (local.get $op)))
+                  (then
+                    (local.set $ops (i32.const 0))
+                    (local.set $opm (array.new_default $mag (i32.const 0))))
+                  (else
+                    (local.set $ops
+                      (if (result i32) (i64.lt_s (struct.get $aint $small (local.get $op)) (i64.const 0))
+                        (then (i32.const -1)) (else (i32.const 1))))
+                    (local.set $umag
+                      (if (result i64) (i32.lt_s (local.get $ops) (i32.const 0))
+                        (then (i64.sub (i64.const 0) (struct.get $aint $small (local.get $op))))
+                        (else (struct.get $aint $small (local.get $op)))))
+                    (local.set $opm (array.new_default $mag (i32.const 2)))
+                    (array.set $mag (local.get $opm) (i32.const 0)
+                      (i64.and (local.get $umag) (i64.const 0xffffffff)))
+                    (array.set $mag (local.get $opm) (i32.const 1)
+                      (i64.shr_u (local.get $umag) (i64.const 32))))))
+              (else
+                (local.set $opm (struct.get $aint $magf (local.get $op)))
+                (local.set $ops (struct.get $aint $sign (local.get $op)))))
+            (local.get $opm) (local.get $ops)))
+

--- a/src/codegen/wasm_gc/builtins/wat/divmod.wat
+++ b/src/codegen/wasm_gc/builtins/wat/divmod.wat
@@ -1,6 +1,7 @@
 
         (module
           {decls}
+          {func_pad}
           (func (export "helper")
               (param $a (ref null $aint)) (param $b (ref null $aint)) (param $want_mod i32)
               (result (ref null $aint))

--- a/src/codegen/wasm_gc/builtins/wat/from_f64.wat
+++ b/src/codegen/wasm_gc/builtins/wat/from_f64.wat
@@ -1,6 +1,7 @@
 
         (module
           {decls}
+          {func_pad}
           (func (export "helper") (param $f f64) (result (ref null $aint))
             (local $t f64) (local $bits i64)
             (local $exp i64) (local $mant i64)

--- a/src/codegen/wasm_gc/builtins/wat/from_string.wat
+++ b/src/codegen/wasm_gc/builtins/wat/from_string.wat
@@ -1,6 +1,7 @@
 
         (module
           {decls}
+          {func_pad}
           (func (export "helper") (param $s (ref null $string)) (result (ref null $result))
             (local $len i32) (local $idx i32) (local $start i32)
             (local $negative i32) (local $saw_digit i32)

--- a/src/codegen/wasm_gc/builtins/wat/mul.wat
+++ b/src/codegen/wasm_gc/builtins/wat/mul.wat
@@ -1,6 +1,7 @@
 
         (module
           {decls}
+          {func_pad}
           (func (export "helper") (param $a (ref null $aint)) (param $b (ref null $aint)) (result (ref null $aint))
             (local $r i64) (local $av i64) (local $bv i64)
             (local $k i32) (local $prod i64) (local $ok i32)

--- a/src/codegen/wasm_gc/builtins/wat/normalize.wat
+++ b/src/codegen/wasm_gc/builtins/wat/normalize.wat
@@ -1,0 +1,47 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $rm (ref null $mag)) (param $rs i32) (result (ref null $aint))
+            (local $rlen i32) (local $i i32) (local $lo i64) (local $hi i64) (local $tmpm (ref null $mag))
+            ;; strip leading zero limbs
+            (local.set $rlen (array.len (local.get $rm)))
+            (block $strip_done (loop $strip
+              (br_if $strip_done (i32.eqz (local.get $rlen)))
+              (br_if $strip_done
+                (i64.ne (array.get $mag (local.get $rm) (i32.sub (local.get $rlen) (i32.const 1))) (i64.const 0)))
+              (local.set $rlen (i32.sub (local.get $rlen) (i32.const 1)))
+              (br $strip)))
+            (if (result (ref null $aint)) (i32.eqz (local.get $rlen))
+              (then
+                (struct.new $aint (i64.const 0) (ref.null $mag) (i32.const 0)))
+              (else
+                (if (result (ref null $aint)) (i32.le_u (local.get $rlen) (i32.const 2))
+                  (then
+                    ;; reassemble <=2 limbs into a 64-bit unsigned value
+                    (local.set $lo (i64.and (array.get $mag (local.get $rm) (i32.const 0)) (i64.const 0xffffffff)))
+                    (local.set $hi
+                      (if (result i64) (i32.eq (local.get $rlen) (i32.const 2))
+                        (then (i64.and (array.get $mag (local.get $rm) (i32.const 1)) (i64.const 0xffffffff)))
+                        (else (i64.const 0))))
+                    (local.set $lo (i64.or (local.get $lo) (i64.shl (local.get $hi) (i64.const 32))))
+                    ;; $lo now holds the full magnitude as an unsigned i64.
+                    (if (result (ref null $aint))
+                        (i64.eqz (i64.shr_u (local.get $lo) (i64.const 63)))
+                      (then
+                        ;; top bit clear -> fits i64::MAX either sign -> Small
+                        (struct.new $aint
+                          (if (result i64) (i32.lt_s (local.get $rs) (i32.const 0))
+                            (then (i64.sub (i64.const 0) (local.get $lo))) (else (local.get $lo)))
+                          (ref.null $mag) (i32.const 0)))
+                      (else
+                        ;; top bit set: only -2^63 (i64::MIN) demotes.
+                        (if (result (ref null $aint))
+                            (i32.and (i32.lt_s (local.get $rs) (i32.const 0))
+                                     (i64.eq (local.get $lo) (i64.const 0x8000000000000000)))
+                          (then
+                            (struct.new $aint (i64.const 0x8000000000000000) (ref.null $mag) (i32.const 0)))
+                          (else
+                            {tight_big})))))
+                  (else
+                    {tight_big}))))))
+

--- a/src/codegen/wasm_gc/builtins/wat/strip.wat
+++ b/src/codegen/wasm_gc/builtins/wat/strip.wat
@@ -1,0 +1,13 @@
+
+        (module
+          {decls}
+          (func (export "helper") (param $arr (ref null $mag)) (result i32)
+            (local $len i32)
+            (local.set $len (array.len (local.get $arr)))
+            (block $bl (loop $lp
+              (br_if $bl (i32.eqz (local.get $len)))
+              (br_if $bl (i64.ne (array.get $mag (local.get $arr) (i32.sub (local.get $len) (i32.const 1))) (i64.const 0)))
+              (local.set $len (i32.sub (local.get $len) (i32.const 1)))
+              (br $lp)))
+            (local.get $len)))
+

--- a/src/codegen/wasm_gc/builtins/wat/umag_cmp.wat
+++ b/src/codegen/wasm_gc/builtins/wat/umag_cmp.wat
@@ -1,0 +1,28 @@
+
+        (module
+          {decls}
+          (func (export "helper")
+              (param $am (ref null $mag)) (param $alen i32)
+              (param $bm (ref null $mag)) (param $blen i32) (result i32)
+            (local $cmp i32) (local $j i32)
+            (if (i32.ne (local.get $alen) (local.get $blen))
+              (then
+                (local.set $cmp
+                  (if (result i32) (i32.gt_u (local.get $alen) (local.get $blen)) (then (i32.const 1)) (else (i32.const -1)))))
+              (else
+                (local.set $cmp (i32.const 0))
+                (local.set $j (local.get $alen))
+                (block $ucmp_done (loop $ucmp
+                  (br_if $ucmp_done (i32.eqz (local.get $j)))
+                  (local.set $j (i32.sub (local.get $j) (i32.const 1)))
+                  (if (i64.ne (array.get $mag (local.get $am) (local.get $j))
+                              (array.get $mag (local.get $bm) (local.get $j)))
+                    (then
+                      (local.set $cmp
+                        (if (result i32) (i64.gt_u (array.get $mag (local.get $am) (local.get $j))
+                                                   (array.get $mag (local.get $bm) (local.get $j)))
+                          (then (i32.const 1)) (else (i32.const -1))))
+                      (br $ucmp_done)))
+                  (br $ucmp)))))
+            (local.get $cmp)))
+

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -387,6 +387,13 @@ pub(super) fn emit_module_with(
     // `wasm-opt -Oz` strips any helper a given program never reaches.
     if registry.bignum {
         for b in [
+            // Shared sub-routines FIRST, so the arithmetic helpers that `call`
+            // them have a known fn index. `wasm-opt -Oz` DCEs any a given
+            // program never reaches.
+            BuiltinName::AintDecompose,
+            BuiltinName::AintNormalize,
+            BuiltinName::AintStrip,
+            BuiltinName::AintUmagCmp,
             BuiltinName::AintFromI64,
             BuiltinName::AintAdd,
             BuiltinName::AintSub,
@@ -1105,6 +1112,16 @@ pub(super) fn emit_module_with(
             builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintFromI64);
         registry.aint_to_i64_checked_fn_idx =
             builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintToI64Checked);
+        // Shared sub-routine fn indices — the arithmetic helpers' WAT renders a
+        // `call <idx>` to these instead of inlining the body. `Some` since they
+        // are registered unconditionally above when `bignum`.
+        registry.aint_decompose_fn_idx =
+            builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintDecompose);
+        registry.aint_normalize_fn_idx =
+            builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintNormalize);
+        registry.aint_strip_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintStrip);
+        registry.aint_umag_cmp_fn_idx =
+            builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintUmagCmp);
     }
 
     // 6) Map helper fn types (per-K hash + eq, per-(K,V) empty/set/get/len).

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -214,6 +214,16 @@ pub(super) struct TypeRegistry {
     /// (`HttpResponse.status is out of range`), so an out-of-range status
     /// TRAPS here rather than saturating into a wrong in-range code.
     pub(super) aint_to_i64_checked_fn_idx: Option<u32>,
+    /// bignum size dedup — wasm fn indices of the shared sub-routines the
+    /// arithmetic helpers `call` instead of inlining a private copy. Recorded
+    /// by `module.rs` once `BuiltinRegistry::assign_slots` runs (the
+    /// sub-routines are registered BEFORE the helpers that call them, so the
+    /// indices are known when each helper's WAT is rendered). `Some` iff
+    /// `bignum`. `None` falls each helper back to the inlined body.
+    pub(super) aint_decompose_fn_idx: Option<u32>,
+    pub(super) aint_normalize_fn_idx: Option<u32>,
+    pub(super) aint_strip_fn_idx: Option<u32>,
+    pub(super) aint_umag_cmp_fn_idx: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -1032,6 +1042,10 @@ impl TypeRegistry {
             aint_hash_fn_idx: None,
             aint_from_i64_fn_idx: None,
             aint_to_i64_checked_fn_idx: None,
+            aint_decompose_fn_idx: None,
+            aint_normalize_fn_idx: None,
+            aint_strip_fn_idx: None,
+            aint_umag_cmp_fn_idx: None,
         }
     }
 
@@ -2078,6 +2092,19 @@ pub(super) fn aint_ref_ty(registry: &TypeRegistry) -> Result<ValType, WasmGcErro
         "Int reachable under bignum but no $AverInt type slot was allocated".into(),
     ))?;
     Ok(struct_ref(idx))
+}
+
+/// bignum size dedup — `(ref null $mag)` ValType for the 32-bit-limb
+/// magnitude array. The shared `__aint_decompose` / `__aint_normalize` /
+/// `__aint_strip` / `__aint_umag_cmp` sub-routines take/return it.
+pub(super) fn aint_mag_ref_ty(registry: &TypeRegistry) -> Result<ValType, WasmGcError> {
+    let idx = registry.aint_mag_array_idx.ok_or(WasmGcError::Validation(
+        "bignum shared sub-routine needs the $mag array slot, but it wasn't allocated".into(),
+    ))?;
+    Ok(ValType::Ref(RefType {
+        nullable: true,
+        heap_type: HeapType::Concrete(idx),
+    }))
 }
 
 /// ETAP-2 SLICE 2a: when a per-param / per-return bare bit is set AND the

--- a/src/codegen/wasm_gc/wat_helper.rs
+++ b/src/codegen/wasm_gc/wat_helper.rs
@@ -47,6 +47,50 @@ pub(in crate::codegen::wasm_gc) fn padding_types(n: u32) -> String {
     s
 }
 
+/// A shared sub-routine a helper `call`s by its REAL user-module function
+/// index: `abs_idx` is that index, `sig` the WAT param/result signature it is
+/// `call`ed with (e.g. `"(param (ref null $aint)) (result (ref null $mag) i32)"`).
+pub(in crate::codegen::wasm_gc) struct CalleeStub {
+    pub abs_idx: u32,
+    pub sig: &'static str,
+}
+
+/// Build the function-index scaffolding a multi-helper WAT module needs so its
+/// `(call <abs_idx>)` instructions VALIDATE in the standalone module.
+///
+/// A helper WAT has no imported functions, so defined-function indices start
+/// at 0 and advance in definition order. To make `(call N)` (where `N` is a
+/// shared sub-routine's real user-module fn index) valid, the standalone
+/// module must declare a function at index `N` with a matching signature.
+/// This emits placeholder `(func)`s at indices `0..=max(abs_idx)`, giving each
+/// real-callee slot its true signature (so the `call` type-checks) and every
+/// filler slot a trivial `(func unreachable)`. The caller then appends the
+/// actual helper as `(func (export "helper") …)`, which lands at the NEXT
+/// index — `compile_wat_helper` lifts it by export name. The lifted body's
+/// `call N` bytes already encode the real index, so they transfer verbatim
+/// into the user module with NO relocation.
+///
+/// `unreachable` is a valid body for ANY result type (stack-polymorphic), so
+/// the placeholders satisfy the validator without fabricating return values.
+pub(in crate::codegen::wasm_gc) fn func_placeholders(callees: &[CalleeStub]) -> String {
+    let max_idx = match callees.iter().map(|c| c.abs_idx).max() {
+        Some(m) => m,
+        None => return String::new(),
+    };
+    let mut sig_at: std::collections::HashMap<u32, &'static str> = std::collections::HashMap::new();
+    for c in callees {
+        sig_at.insert(c.abs_idx, c.sig);
+    }
+    let mut s = String::with_capacity((max_idx as usize + 1) * 24);
+    for idx in 0..=max_idx {
+        match sig_at.get(&idx) {
+            Some(sig) => s.push_str(&format!("(func {sig} unreachable)\n")),
+            None => s.push_str("(func unreachable)\n"),
+        }
+    }
+    s
+}
+
 /// Compile a WAT helper template into a `wasm_encoder::Function` ready
 /// to be appended to the user module's code section.
 ///
@@ -72,15 +116,54 @@ pub(in crate::codegen::wasm_gc) fn compile_wat_helper(
         WasmGcError::Validation(format!("wat parse: {e}"))
     })?;
 
+    // The function index we want to lift. Historically a helper WAT held
+    // exactly one `(func)` and we lifted entry 0. To let a helper `call` a
+    // SHARED sub-routine (decompose / normalize / …) at that sub-routine's
+    // REAL user-module fn index, the helper WAT now pads its function-index
+    // space with placeholder `(func)`s so each `call <abs-idx>` validates in
+    // the standalone module — the called index already equals the user-module
+    // index, so the lifted body's `call` bytes transfer VERBATIM, no
+    // relocation. The real helper is the one exported `"helper"`; everything
+    // before it is scaffolding. Resolve that export to a function index and
+    // lift the matching code entry (falling back to entry 0 when no `"helper"`
+    // export exists, preserving the single-function helpers byte-for-byte).
+    let mut helper_fn_idx: Option<u32> = None;
+    for payload in Parser::new(0).parse_all(&module_bytes) {
+        let payload =
+            payload.map_err(|e| WasmGcError::Validation(format!("wasm parse helper: {e}")))?;
+        if let Payload::ExportSection(reader) = payload {
+            for export in reader {
+                let export =
+                    export.map_err(|e| WasmGcError::Validation(format!("export read: {e}")))?;
+                if export.name == "helper" && export.kind == wasmparser::ExternalKind::Func {
+                    helper_fn_idx = Some(export.index);
+                }
+            }
+        }
+    }
+
     let mut found_locals: Option<Vec<ValType>> = None;
     let mut found_body: Option<Vec<u8>> = None;
+    // Function index of the current code-section entry. A helper WAT has no
+    // imported functions, so defined-function indices start at 0 and advance
+    // per `CodeSectionEntry`.
+    let mut code_fn_idx: u32 = 0;
 
     for payload in Parser::new(0).parse_all(&module_bytes) {
         let payload =
             payload.map_err(|e| WasmGcError::Validation(format!("wasm parse helper: {e}")))?;
         if let Payload::CodeSectionEntry(body) = payload {
-            // Helper modules contain exactly one function — take the
-            // first one and stop.
+            let this_idx = code_fn_idx;
+            code_fn_idx += 1;
+            // Lift the `"helper"`-exported function when present, else the
+            // first function (the legacy single-`func` helper shape).
+            let want = match helper_fn_idx {
+                Some(idx) => this_idx == idx,
+                None => found_body.is_none(),
+            };
+            if !want {
+                continue;
+            }
             let mut locals: Vec<ValType> = Vec::new();
             let mut locals_reader = body
                 .get_locals_reader()
@@ -110,7 +193,9 @@ pub(in crate::codegen::wasm_gc) fn compile_wat_helper(
 
             found_locals = Some(locals);
             found_body = Some(expr_bytes);
-            break;
+            if helper_fn_idx.is_some() {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
## What

The hand-written bignum `$aint` helpers text-inlined their shared sub-routines (decompose, normalize, strip, umag_cmp) into **every** helper, because the WAT-lift kept only the first function and couldn't relocate `call` indices — ~3.8-4.9 KB of duplication binaryen `-Oz` cannot dedup (it does function-level DCE/inline, not identical-subsequence outlining). This factors those sub-routines into callable helpers registered once; add/sub/mul/divmod/cmp/from_string/from_f64 now `call` them instead of inlining. **Behavior-preserving — the bignum arithmetic is byte-identical.**

## How

- `compile_wat_helper` lifts the function named by `(func (export "helper"))` (resolving its index), falling back to entry 0 — single-function helpers stay byte-identical (a non-Int program compiles byte-for-byte to HEAD).
- A `func_placeholders` mechanism renders `(call <real-idx>)` where the index is the shared sub-routine's actual user-module function index (recorded on `TypeRegistry`, mirroring the existing `aint_eq_fn_idx` plumbing), and pads the standalone helper module with `unreachable` stubs at the lower indices so it validates — so the lifted `call` bytes transfer **verbatim, no relocation arithmetic**.

## Soundness (a wrong call-index = wrong bignum everywhere — the ℤ soundness core)

Exhaustive VM-vs-wasm-gc differential (31 cases): `+ - * div mod < == Neg abs min max String.fromInt Int↔Float` across small / big (2^200, 10^40) / negative / zero / i64::MIN-MAX / mixed Small-Big. The `a*a` at i64::MAX headline = exact `85070591730234615847396907784232501249`; cancel-to-Small, `imin/-1`, correctly-rounded `fromFloat` all match. `wasm-tools validate` passes; a new `shared_subroutine_call_path_validates` guard renders the call-path at non-trivial fn indices (caught a paren bug the inline-only guards missed).

## Measured

all-bignum-ops: **11722 → 6789 B (-4.9 KB)**; fractal-shaped (add+sub+mul+cmp): **8637 → 4850 B (-3.8 KB)**. normalize body: 10 → 1 copies. Recovered on every Int-heavy binary, `-Oz`-proof, stacks with the carrier work.

## Tests

Full `cargo test --features wasm` **2522/0** (proof_spec 180 + bignum parse/validate/call-path guards), carrier differential 66, cross-backend, perslot, default 0 failed, fmt + clippy clean. Non-Int byte-identical. `string_from_aint` (decimal formatter) left un-factored — a further additive opportunity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
