### PR TITLE
the-method: self-persist decompositions; add 10 for open TIP laws

### DIFF
--- a/.claude/skills/the-method/the-method-loop.js
+++ b/.claude/skills/the-method/the-method-loop.js
@@ -3,7 +3,7 @@ export const meta = {
   description: 'The Method: an agent proposes helper lemmas -> aver tests -> Lean/Z3 judges -> refine, with an independent verify gate. Closes open Aver proof laws on any Aver project.',
   phases: [
     { title: 'Method', detail: 'one agent per open task: propose helper lemmas, test with aver, refine until Lean closes or budget out' },
-    { title: 'Verify', detail: "independent re-verify of each self-reported closure (fresh dir) — the proposer's own verdict is not trusted" },
+    { title: 'Verify', detail: "independent re-verify of each self-reported closure (fresh dir) — the proposer's own verdict is not trusted; on success the verified decomposition is PERSISTED to decomposed/ so it is recoverable, never re-guessed" },
   ],
 }
 
@@ -41,6 +41,10 @@ const RESULT_SCHEMA = {
 
 const FIND_AVER = 'Locate the aver binary: try ./target/release/aver, then ./target/debug/aver, then `aver` on PATH; if none exists, run `cargo build --bin aver` first.'
 const SAFETY = 'SAFETY: READ-ONLY on the project. Do ALL edits on COPIES under /tmp. Never run state-changing git commands and never modify project files.'
+// The verify gate is the ONE agent allowed a single project write: persisting the verified
+// decomposition to decomposed/ so wins are durable on disk during the run (not scraped from a
+// possibly-truncated result), and so re-runs replay instead of re-guessing.
+const VERIFY_SAFETY = 'SAFETY: do ALL proof/verification work on COPIES under /tmp. The ONLY project-file write you may make is creating/overwriting the single decomposed entry described below. Never run state-changing git commands; never touch any other project file.'
 
 const METHOD_PROMPT = (t) => `You ARE "The Method": close an OPEN Aver proof obligation by proposing auxiliary helper lemmas, testing them with the Aver toolchain, and refining on failure. You propose; the Lean kernel / Z3 judges.
 
@@ -68,10 +72,11 @@ Return: task="${t}"; closed (bool); attempts used; helperLaws = the WINNING set 
 // INDEPENDENT agent re-checks each claimed closure from scratch before we count it.
 const VERIFY_SCHEMA = {
   type: 'object', additionalProperties: false,
-  required: ['verified', 'note'],
+  required: ['verified', 'note', 'persistedPath'],
   properties: {
     verified: { type: 'boolean', description: 'true ONLY if you yourself observed "universal":true with "sorries":0 on the augmented task' },
     note: { type: 'string', description: '1-2 sentences: observed universal/sorries values, or why it failed' },
+    persistedPath: { type: 'string', description: 'project-relative path of the decomposed/ entry you wrote and re-confirmed (empty string if verified=false or the persist step failed)' },
   },
 }
 
@@ -86,8 +91,13 @@ Steps:
 3. Run: <aver> proof <scratch> --discover -o <freshdir> ; then <aver> proof <scratch> --check --check-json --backend lean -o <freshdir>.
 4. verified = true ONLY if the check output contains "universal":true AND "sorries":0. Retry once on a transient lake error.
 5. Sanity: confirm the BASE task (no helpers) is still OPEN ("universal":true ABSENT).
-${SAFETY}
-Return: verified (bool), note.`
+6. PERSIST (only if verified) — make the win durable and recoverable so it is never re-guessed:
+   - Destination = the target path with its "/tip/" segment replaced by "/decomposed/" (e.g. proof-corpus/tip/prod/prop_38.av -> proof-corpus/decomposed/prod/prop_38.av; proof-corpus/tip/isaplanner/prop_76.av -> proof-corpus/decomposed/isaplanner/prop_76.av). If the path has no "/tip/" segment, use proof-corpus/decomposed/<basename>. Create parent dirs if needed.
+   - Convention (read one existing decomposed/ entry + its base to match it EXACTLY): the entry is the base file with the helper laws (and any helper "fn" definitions they introduce) spliced in BEFORE the target "verify ... law" block — same module name, same functions, nothing else changed.
+   - Write your verified augmented .av to that destination, then re-run the closing sequence ON THE WRITTEN FILE and confirm it still shows "universal":true,"sorries":0. Set persistedPath to that project-relative path.
+   - If verified=false, or the write or re-check fails, set persistedPath="".
+${VERIFY_SAFETY}
+Return: verified (bool), note, persistedPath.`
 
 phase('Method')
 // pipeline: each task is proposed, then (if self-reported closed) independently verified — no
@@ -99,7 +109,7 @@ const results = (await pipeline(
     if (!r) return { task: t, closed: false, verified: false, attempts: 0, helperLaws: [], finalError: 'agent died', summary: '' }
     if (!r.closed) return { ...r, verified: false }
     return agent(VERIFY_PROMPT(r.task, r.helperLaws), { label: `verify:${r.task}`, phase: 'Verify', schema: VERIFY_SCHEMA, agentType: 'general-purpose' })
-      .then((v) => ({ ...r, verified: !!(v && v.verified), verifyNote: v ? v.note : 'verifier died' }))
+      .then((v) => ({ ...r, verified: !!(v && v.verified), verifyNote: v ? v.note : 'verifier died', persistedPath: v ? (v.persistedPath || '') : '' }))
   },
 )).filter(Boolean)
 
@@ -109,11 +119,16 @@ for (const r of results) {
 }
 const verifiedClosed = results.filter((r) => r.closed && r.verified)
 const overReported = results.filter((r) => r.closed && !r.verified)
-log(`The Method: ${verifiedClosed.length}/${results.length} verified-closed${overReported.length ? ` (${overReported.length} self-reported but failed verification)` : ''}`)
+const persisted = verifiedClosed.filter((r) => r.persistedPath)
+log(`The Method: ${verifiedClosed.length}/${results.length} verified-closed${overReported.length ? ` (${overReported.length} self-reported but failed verification)` : ''}; ${persisted.length} persisted to decomposed/`)
+const notPersisted = verifiedClosed.filter((r) => !r.persistedPath)
+if (notPersisted.length) log(`WARNING: ${notPersisted.length} verified win(s) NOT persisted: ${notPersisted.map((r) => r.task).join(', ')}`)
 return {
   verifiedClosed: verifiedClosed.length,
   selfReported: results.filter((r) => r.closed).length,
   total: results.length,
-  winners: verifiedClosed.map((r) => ({ task: r.task, helperLaws: r.helperLaws })),
+  persistedCount: persisted.length,
+  persistedPaths: persisted.map((r) => r.persistedPath),
+  winners: verifiedClosed.map((r) => ({ task: r.task, helperLaws: r.helperLaws, persistedPath: r.persistedPath || '' })),
   results,
 }

--- a/proof-corpus/decomposed/isaplanner/prop_52.av
+++ b/proof-corpus/decomposed/isaplanner/prop_52.av
@@ -1,0 +1,50 @@
+module Prop52
+    intent =
+        "TIP isaplanner prop_52: count n xs = count n (rev xs)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match eqNat(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+fn rev(x: List<Nat>) -> List<Nat>
+    match x
+        [] -> []
+        [y, ..xs] -> List.concat(rev(xs), [y])
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+verify plus law plusComm
+    given a: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given b: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(a, b) => plus(b, a)
+
+verify count law countHomo
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    given ys: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    count(n, List.concat(xs, ys)) => plus(count(n, xs), count(n, ys))
+
+verify count law countRev
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.Z]]
+    count(n, xs) => count(n, rev(xs))

--- a/proof-corpus/decomposed/isaplanner/prop_62.av
+++ b/proof-corpus/decomposed/isaplanner/prop_62.av
@@ -1,0 +1,31 @@
+module Prop62
+    intent =
+        "TIP isaplanner prop_62: if xs is non-empty then last(cons x xs) = last(xs)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn last(x: List<Nat>) -> Nat
+    match x
+        [] -> Nat.Z
+        [y, ..z] -> match z
+            [] -> y
+            [x2, ..x3] -> last(z)
+
+fn isCons(xs: List<Nat>) -> Bool
+    match xs
+        [] -> false
+        [y, ..z] -> true
+
+verify last law lastSnoc
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    last(List.concat(xs, [x])) => x
+
+verify last law lastConsNonEmpty
+    given xs: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.Z]]
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    when isCons(xs)
+    last(List.concat([x], xs)) => last(xs)

--- a/proof-corpus/decomposed/isaplanner/prop_76.av
+++ b/proof-corpus/decomposed/isaplanner/prop_76.av
@@ -1,0 +1,60 @@
+module Prop76
+    intent =
+        "TIP isaplanner prop_76: n != m => count n (xs ++ [m]) = count n xs."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn natEq(x: Nat, y: Nat) -> Bool
+    ? "Recursive structural equality on Peano Nat."
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> natEq(x2, y2)
+
+verify natEq
+    natEq(Nat.Z, Nat.Z) => true
+    natEq(Nat.Z, Nat.S(Nat.Z)) => false
+    natEq(Nat.S(Nat.Z), Nat.S(Nat.Z)) => true
+
+fn plus(x: Nat, y: Nat) -> Nat
+    ? "Peano addition."
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    ? "Count occurrences of x in the list y."
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match natEq(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+verify plus law plusRightZero
+    given a: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(a, Nat.Z) => a
+
+verify count law countHomo
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z], []]
+    given ys: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    count(n, List.concat(xs, ys)) => plus(count(n, xs), count(n, ys))
+
+verify count law countSingletonNeq
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given m: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    when Bool.not(natEq(n, m))
+    count(n, [m]) => Nat.Z
+
+verify count law countAppendSingleton
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given m: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    when Bool.not(natEq(n, m))
+    count(n, List.concat(xs, [m])) => count(n, xs)

--- a/proof-corpus/decomposed/isaplanner/prop_85.av
+++ b/proof-corpus/decomposed/isaplanner/prop_85.av
@@ -1,0 +1,65 @@
+module Prop85
+    intent =
+        "TIP isaplanner prop_85: if len xs = len ys then zip (rev xs) (rev ys) = rev (zip xs ys). Monomorphized to List<Int> with pairs as Tuple<Int, Int>."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn natEq(a: Nat, b: Nat) -> Bool
+    match a
+        Nat.Z -> match b
+            Nat.Z -> true
+            Nat.S(y) -> false
+        Nat.S(x) -> match b
+            Nat.Z -> false
+            Nat.S(y) -> natEq(x, y)
+
+fn len(xs: List<Int>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(len(ys))
+
+fn appendInt(xs: List<Int>, ys: List<Int>) -> List<Int>
+    match xs
+        [] -> ys
+        [z, ..zs] -> List.concat([z], appendInt(zs, ys))
+
+fn appendPair(xs: List<Tuple<Int, Int>>, ys: List<Tuple<Int, Int>>) -> List<Tuple<Int, Int>>
+    match xs
+        [] -> ys
+        [z, ..zs] -> List.concat([z], appendPair(zs, ys))
+
+fn rev(xs: List<Int>) -> List<Int>
+    match xs
+        [] -> []
+        [y, ..ys] -> appendInt(rev(ys), [y])
+
+fn revPair(xs: List<Tuple<Int, Int>>) -> List<Tuple<Int, Int>>
+    match xs
+        [] -> []
+        [y, ..ys] -> appendPair(revPair(ys), [y])
+
+fn zip(xs: List<Int>, ys: List<Int>) -> List<Tuple<Int, Int>>
+    match xs
+        [] -> []
+        [z, ..x2] -> match ys
+            [] -> []
+            [x3, ..x4] -> List.concat([(z, x3)], zip(x2, x4))
+
+verify appendInt law appendIntNilR
+    given xs: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    appendInt(xs, []) => xs
+
+verify appendInt law appendIntAssoc
+    given xs: List<Int> = [[], [1], [1, 2]]
+    given ys: List<Int> = [[], [4], [4, 5]]
+    given zs: List<Int> = [[], [7], [7, 8]]
+    appendInt(appendInt(xs, ys), zs) => appendInt(xs, appendInt(ys, zs))
+
+verify zip law zipRev
+    given xs: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given ys: List<Int> = [[], [4], [4, 5], [4, 5, 6]]
+    when natEq(len(xs), len(ys))
+    zip(rev(xs), rev(ys)) => revPair(zip(xs, ys))

--- a/proof-corpus/decomposed/prod/lemma_14.av
+++ b/proof-corpus/decomposed/prod/lemma_14.av
@@ -1,0 +1,38 @@
+module Lemma14
+    intent =
+        "TIP prod lemma_14: even(length(w ++ z)) = even(length(w ++ (x :: y :: z)))."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(xs: List<Int>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(length(ys))
+
+fn even(x: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(y) -> match y
+            Nat.Z -> false
+            Nat.S(z) -> even(z)
+
+verify length law lengthAppendTwo
+    given w: List<Int> = [[1], [1, 2], [1, 2, 3], [4, 5]]
+    given x: Int = [0, 5, 9, 2]
+    given y: Int = [0, 7, 1, 4]
+    given z: List<Int> = [[3], [3, 4], [5, 6, 7], [8]]
+    length(List.concat(w, List.concat([x, y], z))) => Nat.S(Nat.S(length(List.concat(w, z))))
+
+verify even law evenSuccSucc
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    even(Nat.S(Nat.S(n))) => even(n)
+
+verify even law evenLengthAppendTwo
+    given w: List<Int> = [[1], [1, 2], [1, 2, 3], [4, 5]]
+    given x: Int = [0, 5, 9, 2]
+    given y: Int = [0, 7, 1, 4]
+    given z: List<Int> = [[3], [3, 4], [5, 6, 7], [8]]
+    even(length(List.concat(w, z))) => even(length(List.concat(w, List.concat([x, y], z))))

--- a/proof-corpus/decomposed/prod/prop_06.av
+++ b/proof-corpus/decomposed/prod/prop_06.av
@@ -1,0 +1,50 @@
+module Prop06
+    intent =
+        "TIP prod prop_06: length (rev (x ++ y)) = length x + length y."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(xs: List<Int>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(length(ys))
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn append(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..ys] -> append(rev(ys), [y])
+
+verify length law lengthIsLen
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    length(x) => List.len(x)
+
+verify rev law revIsReverse
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    rev(x) => List.reverse(x)
+
+verify length law lengthAppend
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[], [2], [4, 5]]
+    length(append(x, y)) => plus(length(x), length(y))
+
+verify length law lengthRev
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    length(rev(x)) => length(x)
+
+verify length law revAppendLength
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[], [2], [4, 5]]
+    length(rev(append(x, y))) => plus(length(x), length(y))

--- a/proof-corpus/decomposed/prod/prop_17.av
+++ b/proof-corpus/decomposed/prod/prop_17.av
@@ -1,0 +1,23 @@
+module Prop17
+    intent =
+        "TIP prod prop_17: rev(rev(x ++ y)) = rev(rev(x)) ++ rev(rev(y))."
+    effects []
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..xs] -> List.concat(rev(xs), [y])
+
+verify rev law revDist
+    given x: List<Int> = [[1], [1, 2], [1, 2, 3]]
+    given y: List<Int> = [[4], [4, 5], [4, 5, 6]]
+    rev(List.concat(x, y)) => List.concat(rev(y), rev(x))
+
+verify rev law revInvolution
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    rev(rev(x)) => x
+
+verify rev law revRevAppend
+    given x: List<Int> = [[1], [1, 2, 3], [2]]
+    given y: List<Int> = [[2], [4, 5], [3]]
+    rev(rev(List.concat(x, y))) => List.concat(rev(rev(x)), rev(rev(y)))

--- a/proof-corpus/decomposed/prod/prop_18.av
+++ b/proof-corpus/decomposed/prod/prop_18.av
@@ -1,0 +1,23 @@
+module Prop18
+    intent =
+        "TIP prod prop_18: rev (rev x ++ y) = rev y ++ x."
+    effects []
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..xs] -> List.concat(rev(xs), [y])
+
+verify rev law revDist
+    given x: List<Int> = [[1], [1, 2], [1, 2, 3]]
+    given y: List<Int> = [[4], [4, 5], [4, 5, 6]]
+    rev(List.concat(x, y)) => List.concat(rev(y), rev(x))
+
+verify rev law revInvolution
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    rev(rev(x)) => x
+
+verify rev law revAppendRev
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given y: List<Int> = [[], [4], [4, 5], [4, 5, 6]]
+    rev(List.concat(rev(x), y)) => List.concat(rev(y), x)

--- a/proof-corpus/decomposed/prod/prop_38.av
+++ b/proof-corpus/decomposed/prod/prop_38.av
@@ -1,0 +1,40 @@
+module Prop38
+    intent =
+        "TIP prod prop_38: elem x y || elem x z => elem x (y ++ z)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn barbar(x: Bool, y: Bool) -> Bool
+    match x
+        true -> true
+        false -> y
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> barbar(eqNat(x, z), elem(x, xs))
+
+verify elem law elemAppendHom
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: List<Nat> = [[Nat.Z], [], [Nat.S(Nat.Z), Nat.Z]]
+    given z: List<Nat> = [[Nat.Z], [Nat.Z], [Nat.S(Nat.Z)]]
+    elem(x, List.concat(y, z)) => barbar(elem(x, y), elem(x, z))
+
+verify elem law elemAppend
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: List<Nat> = [[Nat.Z], [], [Nat.S(Nat.Z)]]
+    given z: List<Nat> = [[Nat.Z], [Nat.Z], [Nat.S(Nat.Z)]]
+    when barbar(elem(x, y), elem(x, z))
+    elem(x, List.concat(y, z)) => true

--- a/proof-corpus/decomposed/prod/prop_48.av
+++ b/proof-corpus/decomposed/prod/prop_48.av
@@ -1,0 +1,41 @@
+module Prop48
+    intent =
+        "TIP prod prop_48: insertion sort preserves length (length (isort x) = length x)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(x: List<Nat>) -> Nat
+    match x
+        [] -> Nat.Z
+        [y, ..xs] -> Nat.S(length(xs))
+
+fn lessEq(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> lessEq(z, x2)
+
+fn insert(x: Nat, y: List<Nat>) -> List<Nat>
+    match y
+        [] -> [x]
+        [z, ..xs] -> match lessEq(x, z)
+            true -> List.concat([x], y)
+            false -> List.concat([z], insert(x, xs))
+
+fn isort(x: List<Nat>) -> List<Nat>
+    match x
+        [] -> []
+        [y, ..xs] -> insert(y, isort(xs))
+
+verify insert law insertPreservesLength
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given y: List<Nat> = [[], [Nat.S(Nat.Z)], [Nat.S(Nat.S(Nat.Z)), Nat.Z]]
+    length(insert(x, y)) => Nat.S(length(y))
+
+verify length law isortPreservesLength
+    given x: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.S(Nat.Z), Nat.Z, Nat.S(Nat.S(Nat.Z))]]
+    length(isort(x)) => length(x)


### PR DESCRIPTION
## What

Two changes from running `the-method` (an LLM proposes auxiliary helper laws; the Lean kernel certifies them) over open TIP / IsaPlanner laws.

1. **`the-method` now persists verified decompositions itself.** The independent verification step writes each re-verified closure to `proof-corpus/decomposed/` (mapping the `tip/` path segment to `decomposed/`) the moment it confirms it — so a closed proof is durable on disk as soon as it closes, rather than scraped from the run's final result, and a later run replays the committed decomposition instead of re-deriving it. Adds `persistedPath` to the verify output and a warning when a verified result fails to persist.

2. **10 new kernel-verified decompositions** for previously-open laws. Each entry splices the proposed helper laws before the target law.
   - isaplanner: `prop_52`, `prop_62`, `prop_76`, `prop_85`
   - prod: `lemma_14`, `prop_06`, `prop_17`, `prop_18`, `prop_38`, `prop_48`

## Verification

Each decomposition was checked with `aver proof <file> --discover` then `--check --check-json --backend lean` and reports `universal:true`, `sorries:0`, with axioms within `{propext, Quot.sound}`. The candidates were proposed by `the-method`; only those that survived an independent re-verification pass are included (the proposer self-reported more closures than survived the check).

## Scope

No Rust changes — only the `the-method` skill script and `.av` data under `proof-corpus/decomposed/`. The base, no-discovery `proof-corpus/tip/` results are unchanged; these are the with-method `decomposed/` corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
