### PR TITLE
fix(vm): bignum Value::int in terminal-off stub + gate terminal-off on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings && cargo clippy -p aver-lang --lib --bin aver -- -D warnings
 
+      - name: Compile gate — terminal-off feature set
+        # The default build has `terminal` on, so `#[cfg(not(feature =
+        # "terminal"))]` branches (the playground/wasm32 and fuzz-mutator
+        # stubs) never compile in the normal gates — a whole class of
+        # regression that only surfaced in the nightly Fuzz job (which
+        # builds aver-lang with `terminal` off). The Int=ℤ migration hit
+        # exactly this: a `Value::Int(<raw i64>)` in the terminal-off
+        # `Terminal.Size` stub broke 7/8 fuzz targets while every PR
+        # stayed green. Checking the fuzz mutator manifest reproduces the
+        # exact terminal-off feature resolution (aver-lang with
+        # `default-features = false, features = ["runtime"]`) in ~17s, so
+        # this class now gates on PRs instead of the morning after.
+        run: cargo check --manifest-path fuzz/mutator/Cargo.toml
+
       - name: Test
         # Iron — Stage 4: CI exercises proptest sweeps at 2 000 cases
         # per property instead of the 256-case default. The matcher

--- a/src/vm/builtin.rs
+++ b/src/vm/builtin.rs
@@ -402,8 +402,8 @@ impl VmBuiltin {
                 let rec = Value::Record {
                     type_name: "Terminal.Size".to_string(),
                     fields: Arc::from(vec![
-                        ("width".to_string(), Value::Int(80)),
-                        ("height".to_string(), Value::Int(24)),
+                        ("width".to_string(), Value::int(80)),
+                        ("height".to_string(), Value::int(24)),
                     ]),
                 };
                 Some(Ok(NanValue::from_value(&rec, arena)))


### PR DESCRIPTION
Unbreaks the nightly **Fuzz** job (red on `main`, run [27745834612](https://github.com/jasisz/aver/actions/runs/27745834612)) **and** closes the CI blind spot that let it through. Two commits.

## 1. The fix
7 of 8 fuzz targets failed to build with `error[E0308]: expected AverInt, found integer` at `src/vm/builtin.rs:405-406`.

**Root cause:** the Int=ℤ migration changed `Value::Int` to wrap an `AverInt`, but the `Terminal.Size` fallback gated on `#[cfg(not(feature = "terminal"))]` — compiled only in the playground/wasm32 and fuzz-mutator builds (crossterm can't compile there) — still passed raw i64 literals. Default CI builds with `terminal` **on**, so that branch is never compiled there. Only the nightly Fuzz job builds aver-lang with `terminal` off (for the custom AST mutator), so it was the first to hit it. Every target that links the mutator failed; `replay_codec`, the only one that doesn't, stayed green.

Use the `Value::int(n)` convenience constructor, matching every other i64-literal call site. A sweep confirms this was the **only** `Value::Int(<raw i64>)` the migration missed (remaining hits are `JsonValue::Int`, the replay representation, still a plain i64).

## 2. The gate (the "razem" part)
The whole reason a 2-line type error reached `main`: the default build compiles `terminal` **on**, so `#[cfg(not(feature = "terminal"))]` stubs never type-check in any per-PR gate. Added a fast (~17s) **Compile gate — terminal-off feature set** step to Check & Test that runs `cargo check --manifest-path fuzz/mutator/Cargo.toml` — which pulls aver-lang with `default-features = false, features = ["runtime"]`, the exact terminal-off resolution the nightly Fuzz uses. This class of regression now fails on the PR instead of the next morning's cron.

## Verification
- default build (`terminal` on) compiles; full Check & Test + WASM + Proof green (first commit)
- the fuzz mutator build — the exact failing config — compiles clean (~17s locally)
- the new gate step runs and passes in this PR's CI (proving it both works and is satisfied by the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)