### PR TITLE
docs: reflect Int=ℤ — fix stale /-and-overflow claims + changelog the arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
-## 0.25.1 (unreleased)
+## 0.26.0 (unreleased)
+
+### Changed
+
+- **`Int` is now arbitrary-precision (ℤ) on every backend — VM, Rust, and wasm-gc.** Integer arithmetic no longer overflows or wraps: a result that exceeds 64 bits keeps going instead of silently truncating, so `Int` is the mathematical integer everywhere, matching what proofs and `verify` already assumed. This closes the last place a verified Aver program could disagree with its proof at runtime. Small values keep a native-integer fast path; only genuinely large magnitudes pay for big-integer storage.
+
+### Performance
+
+- **Bounded integers recover native speed and code size under the ℤ default.** A value the compiler can prove stays in a fixed range — an opaque or module-private record whose smart constructor bounds its field — is stored and computed as a native 64-bit integer rather than the big-integer representation on wasm-gc, comparisons against integer constants lower to a direct machine compare, and the big-integer runtime is shared across helpers instead of copied into each. Size-sensitive programs (the games corpus) shed most of the cost the ℤ default would otherwise add.
 
 ### Added
 

--- a/docs/dafny.md
+++ b/docs/dafny.md
@@ -58,7 +58,7 @@ A single `.dfy` file containing:
 | `match x: true → a, false → b` | `if x then a else b` |
 | `match n: 0 → base, _ → f(n-1)` | `if n == 0 then base else f(n-1)` |
 | `match xs: [] → a, [h,..t] → b` | `if \|xs\| == 0 then a else var h := xs[0]; var t := xs[1..]; b` |
-| `x / y` | `x / y` (Dafny flags unproved non-zero divisor) |
+| `Int.div(a, b)` / `Int.mod(a, b)` | `Result`-wrapped Euclidean div/mod (Dafny guards the zero divisor); integer `/` is a type error, `/` is Float-only (Dafny `real`) |
 | `verify f law name` | sample `method` + universal `lemma` |
 
 ## Termination

--- a/docs/diagnostics-slugs.md
+++ b/docs/diagnostics-slugs.md
@@ -21,7 +21,7 @@ Source of truth: `src/diagnostics/classify.rs` (classifier) and `src/checker/*.r
 | `unknown-ident` | error | A referenced name has no binding in scope. | Check spelling or add the missing import. |
 | `arity-mismatch` | error | Function or constructor called with the wrong number of args. | Adjust the number of arguments. |
 | `effect-violation` | error | A function calls an effect it doesn't declare in `! [...]`. | Add the missing effect to the function's `! [...]`. |
-| `int-div` | error | The `/` operator was used on two `Int`s. Integer division is partial (zero divisor, or `i64::MIN / -1` overflow), so it is a function, not an operator. | Use `Int.div(a, b) : Result<Int, String>`; handle with `match` or `Result.withDefault`. |
+| `int-div` | error | The `/` operator was used on two `Int`s. Integer division is partial (the divisor may be zero → `Result.Err`), so it is a function, not an operator. | Use `Int.div(a, b) : Result<Int, String>`; handle with `match` or `Result.withDefault`. |
 
 ## Intent / verify hygiene
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -35,7 +35,7 @@ Duplicate binding of the same name in the same scope is a type error.
 
 ## Operators
 
-Arithmetic: `+`, `-`, `*`, `/` — operands must match (`Int+Int`, `Float+Float`, `String+String`). No implicit promotion; use `Float.fromInt` / `Int.fromFloat` to convert.
+Arithmetic: `+`, `-`, `*` — operands must match (`Int+Int`, `Float+Float`, `String+String`). No implicit promotion; use `Float.fromInt` / `Int.fromFloat` to convert. The `/` operator is **Float-only**; integer `/` is a type error. For integers use `Int.div(a, b) : Result<Int, String>` (Euclidean; `b == 0` → `Result.Err`) and `Int.mod(a, b) : Result<Int, String>` — there is no integer `%`. `Int` is arbitrary-precision (ℤ): no overflow, no wraparound.
 Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`.
 Error propagation: `expr?` — unwraps `Result.Ok`, propagates `Result.Err` as a `RuntimeError`.
 Independent products: `(a, b)!` — product of independent computations. `(a, b)?!` — same, with Result unwrapping (all must succeed or first error propagates). Elements cannot reference each other; independence is structural. Composes recursively for fan-out parallelism. See [independence.md](independence.md).


### PR DESCRIPTION
Audit of all ~30 docs for Int=ℤ accuracy. Reference docs landed the migration cleanly; this fixes the residue and records the arc.

## Fixed (stale Int semantics)
- **`docs/language.md`** — `/` was shown as generic arithmetic with `Int+Int` operands, implying integer `/` is valid. It's a type error. Now: `/` is Float-only; integers use `Int.div`/`Int.mod : Result<Int,String>`; no `%`. Added that `Int` is arbitrary-precision (no overflow/wrap).
- **`docs/diagnostics-slugs.md`** — the `int-div` row justified partiality with the phantom `i64::MIN / -1` overflow (gone under ℤ). Now: partial only on a zero divisor.
- **`docs/dafny.md`** — mapping table showed bare integer `x / y`; replaced with the `Int.div`/`Int.mod` Result-wrapped Euclidean mapping.

## Changelog
The headline change of the cycle (**Int → ℤ**) and the bounded-integer native-speed/size recovery were unrecorded. Added concise `Changed` + `Performance` entries and bumped the unreleased section `0.25.1 → 0.26.0` (a breaking Int-semantics change is a minor, not a patch; codename TBD at release).

## Deliberately NOT changed
- Historical changelog entries (0.24 "Divide", 0.13, 0.12) — they were accurate at their versions, when Int was still i64. Editing them would falsify history.
- `docs/oracle.md` Int boundary set (`i64::MIN/MAX`) — that doc accurately describes the code (`hostile_values.rs` still emits those). Under ℤ they're the Small/Big seam (fine to keep) but the set misses beyond-i64 sentinels — a **code**-coverage gap tracked separately, not a doc fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)