### PR TITLE
fix(wasm-gc): hash/eq a newtype-erased Map value as its carrier, not the struct

### DIFF
--- a/src/codegen/wasm_gc/maps.rs
+++ b/src/codegen/wasm_gc/maps.rs
@@ -769,6 +769,19 @@ fn emit_hash_for(
     if k_aver == "String" {
         return emit_hash_string(registry);
     }
+    // A newtype-erased value record — a `Map<_, V>` whose `V` is a
+    // single-primitive-field record — reaches its hash helper as the
+    // bare carrier, not the `$V` struct: `aver_to_wasm(V)` and the
+    // `values_array` element are both `aver_to_wasm(under)`. Hash it as
+    // the underlying primitive. Routing through `emit_hash_record` would
+    // `struct.get` the unerased struct and diverge from the erased
+    // signature (the `map_keyed_by_record_with_record_value` validation
+    // bug). Map keys are never erased (`newtype_underlying` returns
+    // `None` for `non_newtypable_keys`), so this fires only for value
+    // records — exactly where `aver_to_wasm` erases.
+    if let Some(under) = registry.newtype_underlying(k_aver) {
+        return emit_hash_for(under, registry, string_key_helpers, all_key_helpers);
+    }
     if registry.record_type_idx(k_aver).is_some() {
         return emit_hash_record(k_aver, registry, string_key_helpers, all_key_helpers);
     }
@@ -819,6 +832,16 @@ fn emit_eq_for(
 ) -> Result<Function, WasmGcError> {
     if k_aver == "String" {
         return emit_eq_string(registry);
+    }
+    // Mirror of the newtype-erasure guard in `emit_hash_for`: a
+    // newtype-erased value record reaches its eq helper as two bare
+    // carriers (`aver_to_wasm(V) == aver_to_wasm(under)`), so compare
+    // them as the underlying primitive instead of `struct.get`-ing the
+    // unerased `$V` struct (which would diverge from the erased
+    // signature). Keys are never erased, so this fires only for value
+    // records.
+    if let Some(under) = registry.newtype_underlying(k_aver) {
+        return emit_eq_for(under, registry, string_key_helpers, all_key_helpers);
     }
     if registry.record_type_idx(k_aver).is_some() {
         return emit_eq_record(k_aver, registry, string_key_helpers, all_key_helpers);

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -3866,3 +3866,104 @@ fn main() -> Unit
         );
     }
 }
+
+// ── Map value that is a newtype-erased record ────────────────────────
+//
+// A `Map<K, V>` whose VALUE `V` is a single-primitive-field record is
+// newtype-erased: `aver_to_wasm(V)` and the `values_array` element are
+// the underlying carrier (`$aint` for Int), and the force-registered
+// per-V hash/eq helper SIGNATURE follows. The helper BODY used to
+// `struct.get` the unerased `$V` struct, diverging from the erased
+// signature → wasm validation failure
+// (`map_keyed_by_record_with_record_value`). The body must hash/eq the
+// carrier directly. Keys are never erased; multi-field record values
+// keep the struct path. These pin the fix on the three shapes.
+
+#[test]
+fn map_newtype_int_value_helper_matches_erased_signature() {
+    let src = r#"module M
+    intent = "newtype Int record map value — erased hash/eq helper"
+    effects [Console]
+
+record K
+    a: Int
+
+record V
+    b: Int
+
+fn lookup(m: Map<K, V>, k: K) -> Int
+    match Map.get(m, k)
+        Option.Some(v) -> v.b
+        Option.None -> 0 - 1
+
+fn main() -> Unit
+    ! [Console.print]
+    m = Map.set(Map.set({}, K(a = 1), V(b = 9)), K(a = 2), V(b = 8))
+    Console.print("{lookup(m, K(a = 1))},{lookup(m, K(a = 2))},{lookup(m, K(a = 3))}")
+"#;
+    // The bug was a pure validation failure on the V helper — the
+    // clean-compile assert is the load-bearing one; value parity pins
+    // that key hash/eq (a hit, a second key, a miss) still agree.
+    assert_compiles_clean_wasm_gc("map-newtype-int-value", src);
+    let out = assert_vm_wasm_identical("map-newtype-int-value", src);
+    assert_eq!(out, "9,8,-1");
+}
+
+#[test]
+fn map_newtype_float_value_helper_matches_erased_signature() {
+    let src = r#"module M
+    intent = "newtype Float record map value — erased hash/eq helper"
+    effects [Console]
+
+record K
+    a: Int
+
+record V
+    f: Float
+
+fn lookup(m: Map<K, V>, k: K) -> Float
+    match Map.get(m, k)
+        Option.Some(v) -> v.f
+        Option.None -> 0.0
+
+fn main() -> Unit
+    ! [Console.print]
+    m = Map.set({}, K(a = 1), V(f = 9.5))
+    Console.print("{lookup(m, K(a = 1))}")
+"#;
+    assert_compiles_clean_wasm_gc("map-newtype-float-value", src);
+    let out = assert_vm_wasm_identical("map-newtype-float-value", src);
+    assert_eq!(out, "9.5");
+}
+
+#[test]
+fn map_multifield_record_value_keeps_struct_path() {
+    // A multi-field record value is NOT newtype-erased — `aver_to_wasm`
+    // returns the `$V` struct ref, the helper signature and body agree,
+    // and the fix's guard does not fire. Pins that the unchanged path
+    // still compiles clean and round-trips.
+    let src = r#"module M
+    intent = "multi-field record map value — unerased struct path"
+    effects [Console]
+
+record K
+    a: Int
+
+record V
+    x: Int
+    y: Int
+
+fn lookup(m: Map<K, V>, k: K) -> Int
+    match Map.get(m, k)
+        Option.Some(v) -> v.x + v.y
+        Option.None -> 0 - 1
+
+fn main() -> Unit
+    ! [Console.print]
+    m = Map.set({}, K(a = 1), V(x = 3, y = 7))
+    Console.print("{lookup(m, K(a = 1))}")
+"#;
+    assert_compiles_clean_wasm_gc("map-multifield-value", src);
+    let out = assert_vm_wasm_identical("map-multifield-value", src);
+    assert_eq!(out, "10");
+}


### PR DESCRIPTION
First of the re-validated wasm-gc ledger bugs (`map_keyed_by_record_with_record_value`) — the one flagged as a live carrier-i64 soundness/validity hole, so it leads by the soundness-outranks-cosmetic rule.

## The bug
A `Map<K, V>` whose **value** `V` is a single-primitive-field record (`record V { b: Int }`) is newtype-erased: `aver_to_wasm(V)` and the `values_array` element become the underlying carrier (`$aint` for Int under bignum), and the force-registered per-V hash/eq helper **signature** follows. But the helper **body** went through `emit_hash_record`/`emit_eq_record`, which `struct.get` the unerased `$V` struct. Signature and body disagree → wasm validation failure (`type mismatch: expected (ref null $type), found (ref null $type)`), even for an empty `Map<Int,V>` that only calls `Map.len` (helpers are emitted unconditionally).

## The fix
Guard `emit_hash_for`/`emit_eq_for` on the **same** `newtype_underlying` predicate `aver_to_wasm` keys off. When the value record is erased, the helper receives the bare carrier, so hash/eq it as the underlying primitive — recursing through `emit_hash_for`/`emit_eq_for`, which routes `Int → __aint_hash/__aint_eq`, `Float`/`Bool` inline. Because the guard **is** the erasure check, signature and body can no longer diverge.

- **Keys** are never erased (`newtype_underlying` returns `None` for `non_newtypable_keys`) → unchanged.
- **Multi-field record values** aren't single-field → fall through to the struct path → unchanged.
- **i64-eligible carrier values** are never force-registered → never reach here.

## Verification
- New carrier-differential regressions: Int + Float newtype values (the fix) and a multi-field value (pins the unchanged struct path), each asserting a **clean wasm-gc compile** AND **VM↔wasm-gc value parity**.
- carrier_i64 differential 75/75; wasm_gc spec + codegen_regression + differential_mir + games (37) all green; fmt + clippy clean.

## Found adjacent, NOT fixed here
A newtype value over `String` is **not** erased (String isn't a wasm-gc primitive), so it stays a real record and hits a distinct `hash_record: String field needs String key helpers` gap. Separate bug, tracked apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)