### PR TITLE
the-method: harden proposer + restore dropped TIP preconditions

### DIFF
--- a/.claude/skills/the-method/the-method-loop.js
+++ b/.claude/skills/the-method/the-method-loop.js
@@ -14,11 +14,12 @@ let a = typeof args === 'string'
   : args
 const TASKS = Array.isArray(a) ? a : (a && Array.isArray(a.tasks) ? a.tasks : [])
 const MAX_ATTEMPTS = (a && a.attempts) || 4
+const MODEL = (a && a.model) || undefined  // optional model override for the proposer (e.g. 'haiku','sonnet'); undefined = inherit
 if (!TASKS.length) {
   log('the-method: pass one or more Aver task .av paths as args, e.g. { tasks: ["path/to/task.av"] }')
   return { error: 'no tasks given' }
 }
-log(`The Method: ${TASKS.length} task(s), up to ${MAX_ATTEMPTS} attempts each`)
+log(`The Method: ${TASKS.length} task(s), up to ${MAX_ATTEMPTS} attempts each${MODEL ? `, proposer model=${MODEL}` : ''}`)
 
 const RESULT_SCHEMA = {
   type: 'object', additionalProperties: false,
@@ -47,6 +48,8 @@ const SAFETY = 'SAFETY: READ-ONLY on the project. Do ALL edits on COPIES under /
 const VERIFY_SAFETY = 'SAFETY: do ALL proof/verification work on COPIES under /tmp. The ONLY project-file write you may make is creating/overwriting the single decomposed entry described below. Never run state-changing git commands; never touch any other project file.'
 
 const METHOD_PROMPT = (t) => `You ARE "The Method": close an OPEN Aver proof obligation by proposing auxiliary helper lemmas, testing them with the Aver toolchain, and refining on failure. You propose; the Lean kernel / Z3 judges.
+
+YOU ARE A CONJECTURER, NOT A PROVER. Reason ONLY about Aver: the datatypes, the functions, the open law, and what auxiliary Aver law would unblock it. Do NOT open, read, or reason about the generated Lean/Dafny files; do NOT reason about Lean tactics, induction strategy, the proof residual / goal state, simp sets, fuel, or the Aver prover's internals — discharging the proof is the toolchain's job, not yours. Your ONLY output is the right Aver helper law(s). If an attempt does not close, propose a DIFFERENT or additional Aver LAW (or fix the law's statement / sample domains) — never try to debug or fix the proof itself. Keep your reasoning short: long tactic-level analysis means you have drifted out of your job and should step back to "what true Aver law is missing?".
 
 You are working inside an Aver project (the current working directory).
 - ${FIND_AVER}
@@ -104,7 +107,7 @@ phase('Method')
 // barrier, so verification starts the moment an agent finishes.
 const results = (await pipeline(
   TASKS,
-  (t) => agent(METHOD_PROMPT(t), { label: `method:${t}`, phase: 'Method', schema: RESULT_SCHEMA, agentType: 'general-purpose' }),
+  (t) => agent(METHOD_PROMPT(t), { label: `method:${t}`, phase: 'Method', schema: RESULT_SCHEMA, agentType: 'general-purpose', model: MODEL }),
   (r, t) => {
     if (!r) return { task: t, closed: false, verified: false, attempts: 0, helperLaws: [], finalError: 'agent died', summary: '' }
     if (!r.closed) return { ...r, verified: false }

--- a/proof-corpus/decomposed/isaplanner/prop_60.av
+++ b/proof-corpus/decomposed/isaplanner/prop_60.av
@@ -19,6 +19,17 @@ fn isCons(xs: List<Nat>) -> Bool
         [] -> false
         [y, ..z] -> true
 
+verify last law lastSnoc
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    last(List.concat(xs, [x])) => x
+
+verify last law lastConsNonEmpty
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.Z]]
+    when isCons(xs)
+    last(List.concat([x], xs)) => last(xs)
+
 verify last law lastAppend
     given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
     given ys: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z)], [Nat.Z, Nat.S(Nat.Z)]]

--- a/proof-corpus/decomposed/prod/prop_36.av
+++ b/proof-corpus/decomposed/prod/prop_36.av
@@ -1,0 +1,39 @@
+module Prop36
+    intent =
+        "TIP prod prop_36: elem x y => elem x (y ++ z)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn barbar(x: Bool, y: Bool) -> Bool
+    match x
+        true -> true
+        false -> y
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> barbar(eqNat(x, z), elem(x, xs))
+
+verify elem law barbarPreserveTrue
+    given x: Bool = [true, false]
+    given y: Bool = [true, false]
+    barbar(true, y) => true
+
+verify elem law elemConcat
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z)], [Nat.Z, Nat.S(Nat.Z)]]
+    given z: List<Nat> = [[], [Nat.S(Nat.Z)], [Nat.Z]]
+    when elem(x, y)
+    elem(x, List.concat(y, z)) => true

--- a/proof-corpus/tip/isaplanner/prop_48.av
+++ b/proof-corpus/tip/isaplanner/prop_48.av
@@ -21,6 +21,12 @@ fn butlast(xs: List<Nat>) -> List<Nat>
             [] -> []
             [x2, ..x3] -> List.concat([y], butlast(z))
 
+fn isCons(xs: List<Nat>) -> Bool
+    match xs
+        [] -> false
+        [y, ..z] -> true
+
 verify butlast law butlastLastAppend
     given xs: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]]
+    when isCons(xs)
     List.concat(butlast(xs), [last(xs)]) => xs

--- a/proof-corpus/tip/isaplanner/prop_59.av
+++ b/proof-corpus/tip/isaplanner/prop_59.av
@@ -19,7 +19,13 @@ fn appendNat(x: List<Nat>, y: List<Nat>) -> List<Nat>
         [] -> y
         [z, ..xs] -> List.concat([z], appendNat(xs, y))
 
+fn isNil(xs: List<Nat>) -> Bool
+    match xs
+        [] -> true
+        [y, ..z] -> false
+
 verify last law lastAppendNil
     given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z], [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]]
     given ys: List<Nat> = [[], [], [], []]
+    when isNil(ys)
     last(appendNat(xs, ys)) => last(xs)

--- a/proof-corpus/tip/isaplanner/prop_71.av
+++ b/proof-corpus/tip/isaplanner/prop_71.av
@@ -41,4 +41,5 @@ verify elem law insElem
     given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
     given y: Nat = [Nat.S(Nat.Z), Nat.Z, Nat.S(Nat.S(Nat.Z))]
     given xs: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    when Bool.not(eqNat(x, y))
     elem(x, ins(y, xs)) => elem(x, xs)


### PR DESCRIPTION
## What

Two independent changes, both from running `the-method` over open TIP / IsaPlanner laws.

1. **`the-method` proposer kept a conjecturer.** The proposer prompt now forbids reading the generated Lean/Dafny or reasoning about tactics, induction strategy, the proof residual, or the prover's internals — it proposes Aver helper laws, and when one does not close it proposes a different law rather than debugging the proof. In a recent run, agents that drifted into prover-internal reasoning produced transcripts ~10x larger; this keeps the proposer cheap and on task. Also adds an optional `model` override for the proposer agent (the verification gate stays on the default model).

2. **Restored 4 dropped TIP preconditions.** `prop_60`, `prop_48`, `prop_59`, `prop_71` carried their precondition only in the prose `intent` but dropped the guard from the `verify` law, leaving a universally-false statement that can never close. Restored the guard to match the original tip-org/benchmarks source (ys non-empty / xs non-empty / ys empty / x != y). Each stays open without discovery (still needs a lemma) but is now true rather than false — the base no-discovery count is unchanged.

3. **2 kernel-verified decompositions** found by `the-method`: isaplanner `prop_60` (last over append) and prod `prop_36` (elem over append). Both close with `universal: true`, `sorries: 0`, axioms within `{propext, Quot.sound}`.

## Verification

Each guarded base typechecks and stays `universal: false` (open, needs a lemma). Each decomposition was re-checked at its final path: `universal: true`, `sorries: 0`. Only candidates that survived an independent re-verification pass are included.

## Scope

No Rust changes — only the `the-method` skill script and `.av` data under `proof-corpus/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
