### PR TITLE
fix(wasm-gc): clear the remaining bug ledger (6 codegen bugs)

### DIFF
--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -242,6 +242,40 @@ pub(crate) fn emit_mir_native_scalar_builtin(
             }
         };
     }
+    // Ties-away-from-zero rounding (matches the VM's `f64::round`). wasm has
+    // only `F64Nearest` (ties-to-even), so emit it inline as
+    // `t = trunc(x); select(t + copysign(1, x), t, |x - t| >= 0.5)`. The
+    // half-test is EXACT — there is deliberately NO `+0.5` pre-round, which
+    // would double-round a predecessor-of-half like `0.49999999999999994`
+    // UP to 1 and is absorbed into a no-op for large odd integers in
+    // `[2^52, 2^53)`; both are inputs `F64Nearest` and `floor(|x|+0.5)` get
+    // wrong. `x` (`args[$i]`) is re-emitted (the existing `Int.abs`/`min`/
+    // `max` arms re-emit args the same way) — safe because `Float.round`'s
+    // argument is a pure scalar. Leaves the rounded `f64` on the stack.
+    macro_rules! round_ties_away {
+        ($i:expr) => {{
+            // val1 = trunc(x) + copysign(1.0, x)
+            arg!($i);
+            func.instruction(&Instruction::F64Trunc);
+            func.instruction(&Instruction::F64Const((1.0f64).into()));
+            arg!($i);
+            func.instruction(&Instruction::F64Copysign);
+            func.instruction(&Instruction::F64Add);
+            // val2 = trunc(x)
+            arg!($i);
+            func.instruction(&Instruction::F64Trunc);
+            // cond = |x - trunc(x)| >= 0.5
+            arg!($i);
+            arg!($i);
+            func.instruction(&Instruction::F64Trunc);
+            func.instruction(&Instruction::F64Sub);
+            func.instruction(&Instruction::F64Abs);
+            func.instruction(&Instruction::F64Const((0.5f64).into()));
+            func.instruction(&Instruction::F64Ge);
+            // select val1 (round away) if |frac| >= 0.5 else val2 (trunc)
+            func.instruction(&Instruction::Select);
+        }};
+    }
     let i64_block = wasm_encoder::BlockType::Result(ValType::I64);
     match dotted {
         // bignum slice 3 — Int <-> Float bridges over `$AverInt`. The
@@ -274,8 +308,7 @@ pub(crate) fn emit_mir_native_scalar_builtin(
         }
         "Float.round" if args.len() == 1 && ctx.registry.bignum => {
             let from_f64 = aint_helper(ctx, "__aint_from_f64")?;
-            arg!(0);
-            func.instruction(&Instruction::F64Nearest);
+            round_ties_away!(0);
             func.instruction(&Instruction::Call(from_f64));
         }
         "Float.fromInt" if args.len() == 1 => {
@@ -297,8 +330,7 @@ pub(crate) fn emit_mir_native_scalar_builtin(
             func.instruction(&Instruction::I64TruncF64S);
         }
         "Float.round" if args.len() == 1 => {
-            arg!(0);
-            func.instruction(&Instruction::F64Nearest);
+            round_ties_away!(0);
             func.instruction(&Instruction::I64TruncF64S);
         }
         "Float.abs" if args.len() == 1 => {

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -1224,14 +1224,26 @@ pub(crate) fn emit_mir_expr(
             // per entry. Canonical from the first entry's K/V stamped
             // types, or the sole registered `Map<K,V>` when empty.
             let canonical: String = if entries.is_empty() {
-                if ctx.registry.map_order.len() == 1 {
+                // Empty `{}` carries no entry types, but the type checker
+                // stamped the whole literal with its expected `Map<K, V>`
+                // (the empty-MapLiteral arm in `types/checker/infer/expr.rs`
+                // adopts `expected`). Consult that stamp first — canonicalised
+                // the same way the non-empty branch builds it from entry types
+                // — so multiple registered instantiations resolve
+                // unambiguously. Fall back to the lone-instantiation shortcut
+                // only when the stamp is not a registered `Map<K, V>`.
+                let stamped = aver_type_canonical(expr, ctx.return_type, ctx.registry);
+                if ctx.registry.map_order.contains(&stamped) {
+                    stamped
+                } else if ctx.registry.map_order.len() == 1 {
                     ctx.registry.map_order[0].clone()
                 } else {
-                    return Err(WasmGcError::Validation(
+                    return Err(WasmGcError::Validation(format!(
                         "empty MapLiteral: cannot resolve Map<K,V> instantiation \
-                         without context (multiple instantiations registered)"
-                            .into(),
-                    ));
+                         (stamped `{stamped}` not registered; {} instantiations \
+                         available)",
+                        ctx.registry.map_order.len()
+                    )));
                 }
             } else {
                 let k_aver = aver_type_str_of(&entries[0].0);

--- a/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
+++ b/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
@@ -226,6 +226,40 @@ pub(crate) fn emit_mir_match(
             }
             Ok(Some(produces))
         }
+        "Unit" => {
+            // A `Unit` subject (`match u { _ -> body }` / `match u { x -> body
+            // }`) is irrefutable: `Unit` has a single inhabitant, so the first
+            // arm always fires. There is no tag to test and no branch block,
+            // and the subject carries no wasm value (`aver_to_wasm("Unit") ==
+            // None`).
+            //
+            // Take the shortcut — emit ONLY the arm body — only for a PURE
+            // subject (a slot read, field projection, or literal). Emitting
+            // such a subject would `local.get` the i32 PLACEHOLDER slot the
+            // `SlotTable` reserves for a `Unit` local and leave a stray value
+            // on the stack; a pure read has no effects, so skipping it is both
+            // required for validity and behaviour-preserving. An EFFECTFUL
+            // `Unit` subject (e.g. a `Unit`-returning call used directly as the
+            // subject) is deliberately left to the `_ => Ok(None)` fallback
+            // below — a LOUD trap stub — rather than silently dropping its
+            // effect: that shape is degenerate (a `Unit` call's result is
+            // already discarded), has no corpus precedent, and keeping it loud
+            // avoids a silent VM↔wasm-gc divergence. Without this branch even
+            // the pure case falls through to the trap. No branch block ⇒ the
+            // body inherits `result_raw` directly, like `emit_mir_tuple_match`.
+            if matches!(
+                m.subject.node,
+                MirExpr::Local(_) | MirExpr::Project(_) | MirExpr::Literal(_)
+            ) {
+                ctx.int_result_raw.set(result_raw);
+                if emit_mir_expr(func, &m.arms[0].body, slots, ctx)?.is_none() {
+                    return Ok(None);
+                }
+                Ok(Some(produces))
+            } else {
+                Ok(None)
+            }
+        }
         // Non-primitive subjects (sum/record/etc.) fall back.
         _ => Ok(None),
     }

--- a/src/codegen/wasm_gc/body/from_mir/records.rs
+++ b/src/codegen/wasm_gc/body/from_mir/records.rs
@@ -115,6 +115,33 @@ pub(crate) fn emit_mir_record_update(
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<Option<()>, WasmGcError> {
+    // Mirror `emit_mir_record_create`'s newtype short-circuit: a record with
+    // a single primitive field is newtype-erased to the bare underlying value
+    // (Int->i64, Float->f64, Bool->i32), so an UPDATE must also emit the bare
+    // value with NO struct ops. Without this, `RecordUpdate` would
+    // `struct.get`/`struct.new` the erased wrapper and push a `(ref $type)`
+    // where the surrounding flow expects the unwrapped primitive -> wasm-gc
+    // validation error (`type mismatch: expected i64, found (ref $type)`).
+    if ctx.registry.newtype_underlying(type_name).is_some() {
+        let produced = if let Some(override_field) = updates.first() {
+            // The newtype's only field is overridden: emit the override value
+            // directly. The rewrite boxes update values, so an eligible carrier
+            // field's value is an `$AverInt` that must be narrowed to the i64
+            // the carrier holds — exactly like `emit_mir_record_create`'s
+            // single-field carrier construct bridge.
+            let p = emit_mir_expr(func, &override_field.value, slots, ctx)?;
+            if p.is_some() && ctx.registry.is_eligible_carrier(type_name) {
+                emit_carrier_construct_bridge(func, ctx)?;
+            }
+            p
+        } else {
+            // No override for the single field: re-emit the base, which already
+            // evaluates to the bare erased value (no bridge — a carrier base is
+            // already the native `i64`, matching the copied-from-base case).
+            emit_mir_expr(func, base, slots, ctx)?
+        };
+        return Ok(produced.map(|_| ()));
+    }
     let type_idx = ctx
         .registry
         .record_type_idx(type_name)

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -1930,7 +1930,27 @@ fn emit_string_from_float(registry: &TypeRegistry) -> Result<Function, WasmGcErr
 
             local.get $abs_val
             f64.floor
-            i64.trunc_f64_s
+            ;; Integer-part conversion. `$abs_val` is `f64.abs(val)`, so it is
+            ;; always >= 0, and the digit loop below is fully UNSIGNED
+            ;; (`i64.div_u`/`i64.rem_u`, plus a sign-agnostic `i64.eqz`).
+            ;; Use the non-trapping SATURATING UNSIGNED truncation rather than
+            ;; the trapping signed `i64.trunc_f64_s`: the signed variant traps
+            ;; for `floor(abs_val) >= 2^63` (~9.22e18) and had no overflow
+            ;; guard (the fractional loop below already bails at
+            ;; `9.2233720368547758e18`; the integer path never did), so e.g.
+            ;; `String.fromFloat(1e19)` trapped on wasm-gc.
+            ;;
+            ;; `i64.trunc_sat_f64_u` renders the EXACT integer over the full
+            ;; u64 range `[0, 2^64)`, matching the VM's Rust shortest-roundtrip
+            ;; formatting for every magnitude whose exact f64
+            ;; integer equals its own shortest decimal — all `|f| < 2^53`, plus
+            ;; whole values like `1e19`/`1.8e19` up to `2^64`. For
+            ;; `|f| >= 2^64` it saturates to `u64::MAX` instead of trapping
+            ;; (best-effort, non-trapping, mirroring the fractional bail). The
+            ;; remaining exact-vs-shortest divergence above `2^53` (e.g.
+            ;; `9223372036854775000.0` -> `9223372036854774784`) needs a full
+            ;; Ryu/Grisu in WAT and is intentionally left to a future change.
+            i64.trunc_sat_f64_u
             local.set $int_part
 
             i32.const 21 local.set $pos

--- a/src/codegen/wasm_gc/maps.rs
+++ b/src/codegen/wasm_gc/maps.rs
@@ -199,6 +199,29 @@ impl MapHelperRegistry {
             if v_aver_trim == "String" {
                 needs_string = true;
             }
+            // A value record / sum V is NOT newtype-erased when its
+            // single field is `String` (String is not a wasm-gc
+            // primitive), so it routes through `emit_hash_record` /
+            // `emit_eq_record`, whose String-field arm needs the
+            // String key helper. Mirror the K check above for V so a
+            // direct `String` field of the value record force-
+            // registers `String` even when K has none.
+            if let Some(fs) = registry.record_fields.get(v_aver_trim) {
+                needs_string |= fs.iter().any(|(_, t)| t.trim() == "String");
+            }
+            if registry
+                .variants
+                .values()
+                .flat_map(|v| v.iter())
+                .any(|v| v.parent == v_aver_trim)
+            {
+                needs_string |= registry
+                    .variants
+                    .values()
+                    .flat_map(|vs| vs.iter())
+                    .filter(|v| v.parent == v_aver_trim)
+                    .any(|v| v.fields.iter().any(|t| t.trim() == "String"));
+            }
             if needs_string && k_seen.insert("String".into()) {
                 k_names.push("String".into());
             }

--- a/tests/wasm_gc_carrier_i64_differential.rs
+++ b/tests/wasm_gc_carrier_i64_differential.rs
@@ -3967,3 +3967,184 @@ fn main() -> Unit
     let out = assert_vm_wasm_identical("map-multifield-value", src);
     assert_eq!(out, "10");
 }
+
+// ── wasm-gc bug-ledger tail (docs/wasm-gc-known-issues.md) ───────────
+//
+// Six pre-existing wasm-gc codegen bugs, all re-validated as still
+// reproducing on main post-carrier-i64 and fixed together. Parked here
+// to reuse the VM↔wasm-gc differential harness (several are not
+// carrier-specific). Each asserts VM↔wasm-gc value parity; the
+// validation-failure ones also assert a clean full-module compile.
+
+#[test]
+fn ledger_match_on_unit_emits_body_not_trap_stub() {
+    // A `match` on a Unit subject fell through subject-type dispatch to a
+    // whole-fn `unreachable` trap stub. The pure-subject case now emits
+    // the (irrefutable) first arm. (Effectful Unit subjects deliberately
+    // still fall back — out of scope, kept loud, not silently dropped.)
+    let src = r#"module M
+    intent = "match on unit subject"
+    effects [Console]
+
+fn classify(u: Unit) -> Int
+    match u
+        _ -> 42
+
+fn label(u: Unit) -> String
+    match u
+        x -> "bound"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{classify(Unit)},{label(Unit)}")
+"#;
+    let out = assert_vm_wasm_identical("ledger-match-unit", src);
+    assert_eq!(out, "42,bound");
+}
+
+#[test]
+fn ledger_empty_map_literal_resolves_via_stamp_with_multiple_instantiations() {
+    // An empty `{}` only resolved the canonical `Map<K,V>` when exactly
+    // one instantiation was registered; with two it hard-errored instead
+    // of consulting the stamped expected type. (Type-agnostic; a record
+    // value just happens to register two instantiations.)
+    let src = r#"module M
+    intent = "two empty-map instantiations"
+    effects [Console]
+
+record Pt
+    x: Int
+    y: Int
+
+record Line
+    a: Int
+    b: Int
+
+fn buildPt() -> Map<String, Pt>
+    Map.set({}, "p", Pt(x = 5, y = 7))
+
+fn buildLine() -> Map<String, Line>
+    Map.set({}, "l", Line(a = 1, b = 2))
+
+fn ptX(k: String) -> Int
+    match Map.get(buildPt(), k)
+        Option.Some(p) -> p.x
+        Option.None -> 0 - 1
+
+fn lineA(k: String) -> Int
+    match Map.get(buildLine(), k)
+        Option.Some(l) -> l.a
+        Option.None -> 0 - 1
+
+fn main() -> Unit
+    ! [Console.print]
+    px = ptX("p")
+    la = lineA("l")
+    Console.print("{px},{la}")
+"#;
+    assert_compiles_clean_wasm_gc("ledger-empty-map-multi", src);
+    let out = assert_vm_wasm_identical("ledger-empty-map-multi", src);
+    assert_eq!(out, "5,1");
+}
+
+#[test]
+fn ledger_float_round_is_ties_away_not_ties_to_even() {
+    // wasm-gc emitted `F64Nearest` (IEEE ties-to-even); the VM uses Rust
+    // `f64::round` (ties-away). The fix emits an EXACT ties-away sequence
+    // (`trunc + |frac|>=0.5 select`). The adversarial cases are the point:
+    // a naive `floor(|x|+0.5)` double-rounds `0.49999999999999994` up to 1
+    // and absorbs `+0.5` into a no-op for large odd integers — both pinned
+    // here so that simplification can never silently come back.
+    let src = r#"module M
+    intent = "float round ties-away"
+    effects [Console]
+
+fn r(f: Float) -> Int
+    Float.round(f)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{r(2.5)},{r(0.0 - 2.5)},{r(0.5)},{r(0.0 - 0.5)},{r(1.5)},{r(0.49999999999999994)},{r(8256582647594471.0)}")
+"#;
+    let out = assert_vm_wasm_identical("ledger-float-round", src);
+    // 2.5->3, -2.5->-3, 0.5->1, -0.5->-1, 1.5->2, 0.4999..94->0 (NOT 1),
+    // 8256582647594471->itself (NOT +1).
+    assert_eq!(out, "3,-3,1,-1,2,0,8256582647594471");
+}
+
+#[test]
+fn ledger_string_from_float_no_trap_past_2_pow_63() {
+    // The integer-part conversion used the trapping `i64.trunc_f64_s` with
+    // no overflow guard, so `String.fromFloat(1e19)` trapped. Now uses
+    // saturating unsigned truncation, rendering the exact integer across
+    // the full u64 range.
+    let src = r#"module M
+    intent = "string from float past 2^63"
+    effects [Console]
+
+fn s(f: Float) -> String
+    String.fromFloat(f)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{s(10000000000000000000.0)}|{s(18000000000000000000.0)}")
+"#;
+    let out = assert_vm_wasm_identical("ledger-string-from-float", src);
+    assert_eq!(out, "10000000000000000000|18000000000000000000");
+}
+
+#[test]
+fn ledger_record_update_on_newtype_record() {
+    // `RecordUpdate` on a newtype (single-primitive-field) record lacked
+    // the create-side newtype short-circuit, emitting `struct.get`/
+    // `struct.new` against the erased wrapper → validation failure.
+    let src = r#"module M
+    intent = "record update on newtype"
+    effects [Console]
+
+record Wrapper
+    val: Int
+
+fn bump(w: Wrapper) -> Wrapper
+    Wrapper.update(w, val = w.val + 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{bump(Wrapper(val = 41)).val}")
+"#;
+    assert_compiles_clean_wasm_gc("ledger-record-update-newtype", src);
+    let out = assert_vm_wasm_identical("ledger-record-update-newtype", src);
+    assert_eq!(out, "42");
+}
+
+#[test]
+fn ledger_map_value_record_with_string_field() {
+    // A Map value record with a `String` field is NOT newtype-erased
+    // (String is not a wasm-gc primitive), so it routes through
+    // `emit_hash_record`/`emit_eq_record`, whose String-field arm needs
+    // the String key helper force-registered. It used to hard-error
+    // "String field needs String key helpers".
+    let src = r#"module M
+    intent = "map value record with String field"
+    effects [Console]
+
+record K
+    a: Int
+
+record V
+    s: String
+
+fn lookup(m: Map<K, V>, k: K) -> String
+    match Map.get(m, k)
+        Option.Some(v) -> v.s
+        Option.None -> "none"
+
+fn main() -> Unit
+    ! [Console.print]
+    m = Map.set({}, K(a = 1), V(s = "hi"))
+    Console.print("{lookup(m, K(a = 1))},{lookup(m, K(a = 2))}")
+"#;
+    assert_compiles_clean_wasm_gc("ledger-map-string-value", src);
+    let out = assert_vm_wasm_identical("ledger-map-string-value", src);
+    assert_eq!(out, "hi,none");
+}


### PR DESCRIPTION
Clears the tail of the wasm-gc bug ledger (`docs/wasm-gc-known-issues.md`). Re-validated on main post-carrier-i64 — all six still reproduced. Each fix was designed + adversarially reviewed by independent agents, then verified VM↔wasm-gc here. Two of the agents' first drafts were caught and reworked (see below).

| bug | failure mode | fix |
|---|---|---|
| `match_on_unit` | trap stub | emit the irrefutable first arm — **purity-gated** |
| `record_as_map_value` | validation | empty `{}` consults the stamped expected type |
| `float_round` | silent wrong value | **exact** ties-away `trunc + |frac|>=0.5 select` |
| `string_from_float` | trap | saturating-unsigned truncation |
| `record_update` | validation | newtype short-circuit (mirror create) |
| String-field map value | validation | force-register the String key helper for V |

## Two reworks vs the agents' first drafts
- **float_round**: the proposed `copysign(floor(|x|+0.5), x)` was **WRONG** (review caught it) — it double-rounds `0.49999999999999994` up to 1 and absorbs `+0.5` into a no-op for large odd integers in `[2^52,2^53)`. The witness only tested exact halves, which would have hidden it. Replaced with the exact `trunc(x); select(t + copysign(1,x), t, |x - t| >= 0.5)` (no `+0.5` pre-round). The regression pins both adversarial cases.
- **match_on_unit**: the first draft silently dropped effects for an effectful Unit-call subject. Gated on subject purity so only pure subjects (slot/projection/literal) take the shortcut; an effectful Unit subject still falls back loudly rather than diverging from the VM.

## Honest residuals (documented in code)
- `string_from_float`: `|f| >= 2^64` now saturates to `u64::MAX` instead of trapping (mirrors the fractional-loop bail); the pre-existing exact-vs-shortest divergence above `2^53` is unchanged. Both need Ryu/Grisu in WAT.
- `record_update`: a carrier field updated past its proven bound (within i64) is not re-validated — intentional and **matches the VM** (update never re-runs the smart ctor on either backend).

## Verification
- All six witnesses pass VM↔wasm-gc, including float_round's adversarial cases.
- carrier_i64 differential **81/81**; wasm_gc spec + codegen_regression + differential_mir + games (37) all green; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)