### PR TITLE
typecheck: propagate expected element type into List.concat args

### DIFF
--- a/src/types/checker/infer/expr.rs
+++ b/src/types/checker/infer/expr.rs
@@ -389,6 +389,31 @@ impl TypeChecker {
                         Some(expected_map)
                     }
 
+                    // List.concat(a, b) — when an argument is an empty-list
+                    // literal `[]`, push the expected List<T> into both args so
+                    // the empty list adopts the concrete element type (e.g.
+                    // `List.concat([], [])` from cartesian law-case expansion of
+                    // `[]`-bearing givens would otherwise leave the result
+                    // List<Var>). Only the empty-list case is intercepted; a
+                    // genuine element mismatch between non-empty lists falls
+                    // through to normal concat inference, which reports a precise
+                    // "list element types differ" error.
+                    ("List.concat", 2, Type::List(_))
+                        if args
+                            .iter()
+                            .any(|a| matches!(&a.node, Expr::List(elems) if elems.is_empty())) =>
+                    {
+                        let left_ty = self.infer_type_with_expected(&args[0], Some(expected));
+                        let right_ty = self.infer_type_with_expected(&args[1], Some(expected));
+                        if self.compatible(&left_ty, expected)
+                            && self.compatible(&right_ty, expected)
+                        {
+                            Some(expected.clone())
+                        } else {
+                            None
+                        }
+                    }
+
                     // Option.None — accidentally written as zero-arg call.
                     ("Option.None", 0, Type::Option(_)) => Some(expected.clone()),
 


### PR DESCRIPTION
## What

A `given` sample's declared list type was dropped when a `verify` law case is cartesian-expanded, so an empty-list `[]` argument to `List.concat` inferred a polymorphic element type. When both arguments are empty (`List.concat([], [])`, produced by some cartesian cases), the call's element type could not be recovered and the result failed to match a concrete `List<T>` downstream (`expected List<Nat>, got List<T>`).

This adds a `List.concat` arm to the checker's bidirectional `try_infer_with_expected` path — mirroring the existing `Map.fromList` / `Vector.fromList` / `Option.Some` arms — so an expected `List<T>` is pushed into both arguments and the empty-list literal adopts it.

## Soundness

The arm only fires when the expected type is a list, and it still checks each argument against the expected type and reports a mismatch — a genuinely wrong element type is still rejected (verified: `List.concat([1], [Nat.Z])` under `List<Nat>` still errors `Int` vs `Nat`). It does not loosen `Var` unification.

## Verification

- **Repro**: a law whose two `given … : List<Nat>` each contain `[]`, used through `List.concat`, errored before and typechecks + proves (`universal:true, sorries:0`) after.
- **Regression**: the full corpus (160 files) typechecks with 0 type errors; a `[]`-first case (`prop_01`) is unchanged.
- `cargo test --lib`: 923 passed, 0 failed.
- `cargo clippy --features wasm,wasip2`: no new warnings from the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
