### PR TITLE
auto-prover gaps (congr / second-list cases / loop-safe orientation) + the-method cost cap

### DIFF
--- a/.claude/skills/the-method/the-method-loop.js
+++ b/.claude/skills/the-method/the-method-loop.js
@@ -13,7 +13,7 @@ let a = typeof args === 'string'
   ? (() => { try { return JSON.parse(args) } catch { return args.trim() ? [args.trim()] : null } })()
   : args
 const TASKS = Array.isArray(a) ? a : (a && Array.isArray(a.tasks) ? a.tasks : [])
-const MAX_ATTEMPTS = (a && a.attempts) || 4
+const MAX_ATTEMPTS = (a && a.attempts) || 3
 const MODEL = (a && a.model) || undefined  // optional model override for the proposer (e.g. 'haiku','sonnet'); undefined = inherit
 if (!TASKS.length) {
   log('the-method: pass one or more Aver task .av paths as args, e.g. { tasks: ["path/to/task.av"] }')
@@ -63,7 +63,7 @@ STEP 1 — understand the mechanism for THIS project:
     <aver> proof <scratch.av> --discover -o <dir>            (proves + commits the helper lemmas)
     <aver> proof <scratch.av> --check --check-json --backend lean -o <dir>   (SAME dir; closed <=> output contains "universal":true)
 
-STEP 2 — the loop (max ${MAX_ATTEMPTS} attempts; stop the instant it closes):
+STEP 2 — the loop (HARD CAP: at most ${MAX_ATTEMPTS} attempts; stop the instant it closes). If it has NOT closed after ${MAX_ATTEMPTS} attempts, STOP immediately — return closed:false with your best helper set and ONE short line naming the likely missing PROVER capability (e.g. "needs congr", "needs cases on a 2nd list arg", "nonlinear arithmetic"). Do NOT keep proposing more variations, and do NOT analyze the prover's tactics/internals — spiraling past the cap is the dominant cost sink and never closes a prover-blocked goal.
 1. Propose 1-3 TRUE, GENERAL helper laws about the task's OWN functions that the main proof needs — a missing homomorphism / associativity / distributivity / an equation relating subterms of the goal. Do NOT merely restate the goal.
 2. Copy the target to a fresh /tmp scratch and splice the helper laws in BEFORE the target "verify ... law" line. ORDER MATTERS (appending at the END can fail to fire); RENDERING MATTERS (how a constructor/operator is written changes how it elaborates). Valid Aver only: first-order, no closures.
 3. Run discover then check into a FRESH /tmp dir. Closed <=> "universal":true with "sorries":0.

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1630,6 +1630,21 @@ fn emit_list_induction(
     let simp_list = simp_defs.into_iter().collect::<Vec<_>>().join(", ");
     let target_lean = &intro_names[target_idx];
 
+    // SECOND list argument — a list-typed `given` OTHER than the induction
+    // target. A law like `last (xs ++ ys) = lastOfTwo xs ys` inducts on `xs`,
+    // but the subject's body matches the OTHER list (`lastOfTwo` matches `ys`),
+    // so the residual `last (h :: ys) = match ys with [] => h | _ => last ys`
+    // only closes after the second list is ALSO case-split. The induction
+    // ladder peels the target's `tail`; an additive `cases <second_list>` rung
+    // (run only after the existing arms fail, ending in `omega`) splits the
+    // second list too. First list-typed given that is not the target.
+    let second_list: Option<String> = law
+        .givens
+        .iter()
+        .enumerate()
+        .find(|(i, g)| *i != target_idx && g.type_name.trim_start().starts_with("List"))
+        .and_then(|(i, _)| intro_names.get(i).cloned());
+
     // Generalizing-induction target: a Peano `given` the verified fn decrements
     // SYNCHRONOUSLY with the list (the `n` of `take`/`drop`, which match `n`
     // then recurse on `(z, tail)`). Inducting on the list alone gives a cons IH
@@ -1778,10 +1793,44 @@ fn emit_list_induction(
         let split_extra_branch = cases_extra
             .map(|s| format!(" | (simp only [{s}]; split <;> simp_all [{s}] <;> omega)"))
             .unwrap_or_default();
+        // GAP #3 — case-split the SECOND list argument. The subject fn may match
+        // a DIFFERENT list than the induction target (`lastOfTwo` matches `ys`,
+        // not the recursed `xs`), leaving a residual `… = match ys with …` that
+        // no amount of `cases tail` peels. An additive `cases <second_list>`
+        // rung (and a `cases tail <;> cases <second_list>` twin for the cons arm,
+        // where BOTH lists drive the two-deep `last`/`butlast` shape) splits it.
+        // Runs only after the prior arms fail and ends in `<;> omega`, so a
+        // non-closing arm still degrades to the honest `sorry` — purely additive,
+        // sound (`cases`/`simp_all`/`omega` mint no axioms), can only ADD closures.
+        let second_cases_nil = second_list
+            .as_deref()
+            .map(|sl| format!(" | (cases {sl} <;> simp_all [{arm_simp}] <;> omega)"))
+            .unwrap_or_default();
+        let second_cases_cons = second_list
+            .as_deref()
+            .map(|sl| {
+                format!(
+                    " | (cases {sl} <;> simp_all [{arm_simp}] <;> omega) | (cases tail <;> cases {sl} <;> simp_all [{arm_simp}] <;> omega)"
+                )
+            })
+            .unwrap_or_default();
+        // GAP #1 — push a proved equality through a user-fn wrapper with `congr`.
+        // simp+omega cannot conclude `f a = f b` from a provable `a = b` when `f`
+        // is an opaque user fn (`half (length …) = half (length …)`): omega never
+        // sees inside `half`. `congr 1` reduces the goal to its argument equality
+        // `a = b`, which the SAME arm simp set + `omega` then discharges (the
+        // homomorphism/bridge rewrites having normalized `a` and `b` to the same
+        // linear-arith form). Runs only after the prior arms fail and every
+        // sub-goal ends in `omega`, so it throws on a leftover and degrades to
+        // `sorry` — additive and sound, can only ADD closures.
+        let congr_nil =
+            format!(" | (simp [{arm_simp}]; congr 1 <;> simp_all [{arm_simp}] <;> omega)");
+        let congr_cons =
+            format!(" | (simp_all [{arm_simp}]; congr 1 <;> simp_all [{arm_simp}] <;> omega)");
         let tail = if with_sorry { " | sorry" } else { "" };
         (
             format!(
-                "| nil => first | (simp [{arm_simp}]; done) | (simp [{arm_simp}]; omega){nil_bridge} | (simp only [{arm_split}]; split <;> simp_all [{arm_simp}]{split_bridge} <;> omega){tail}"
+                "| nil => first | (simp [{arm_simp}]; done) | (simp [{arm_simp}]; omega){nil_bridge} | (simp only [{arm_split}]; split <;> simp_all [{arm_simp}]{split_bridge} <;> omega){second_cases_nil}{congr_nil}{tail}"
             ),
             // Trailing `cases tail` branch: a fn whose body matches TWO levels
             // deep on the list (`last`/`butlast`: `match x | [] | y::z => match z
@@ -1795,7 +1844,7 @@ fn emit_list_induction(
             // non-closing arm still degrades to the honest `sorry`. Sound, so it
             // can only ADD closures.
             format!(
-                "| cons head tail ih => first | (simp_all [{arm_simp}]; done) | (simp_all [{arm_simp}]; omega){cons_bridge} | (simp only [{arm_split}]; split <;> simp_all [{arm_simp}]{split_bridge} <;> omega) | (cases tail <;> simp_all [{arm_simp}] <;> omega){cases_extra_branch}{split_extra_branch}{tail}"
+                "| cons head tail ih => first | (simp_all [{arm_simp}]; done) | (simp_all [{arm_simp}]; omega){cons_bridge} | (simp only [{arm_split}]; split <;> simp_all [{arm_simp}]{split_bridge} <;> omega) | (cases tail <;> simp_all [{arm_simp}] <;> omega){cases_extra_branch}{split_extra_branch}{second_cases_cons}{congr_cons}{tail}"
             ),
         )
     };

--- a/tests/proof_spec/check_gates.rs
+++ b/tests/proof_spec/check_gates.rs
@@ -980,14 +980,14 @@ fn run_check_json_for(out_tag: &str, corpus_av: &str, explain: bool) -> Option<s
 #[test]
 fn proof_check_explain_surfaces_open_goal_residual() {
     // `--explain` enabler for an agent proposer / "Lemma Calculation": for an
-    // OPEN inductive law (prop_49 butlast, which the auto-prover sorry-floors)
-    // the check-json must carry a per-`fn.law` `open_goals` entry whose text is
+    // OPEN inductive law (prop_53 count-over-sort, which the auto-prover
+    // sorry-floors) the check-json must carry a per-`fn.law` `open_goals` entry whose text is
     // the law's UNSOLVED GOAL with the inductive hypothesis (`ih`) in canonical
     // recursive form — exactly what an agent applies the IH against. The counted
     // verdict is unchanged (still not universal, still a sorry).
     let Some(summary) = run_check_json_for(
         "aver-explain-open-out",
-        "proof-corpus/tip/isaplanner/prop_49.av",
+        "proof-corpus/tip/isaplanner/prop_53.av",
         true,
     ) else {
         return;
@@ -997,7 +997,7 @@ fn proof_check_explain_surfaces_open_goal_residual() {
         .and_then(|g| g.as_object())
         .unwrap_or_else(|| panic!("--explain must emit an `open_goals` object:\n{summary}"));
     let residual = goals
-        .get("butlast.butlastConcatLaw")
+        .get("count.countSort")
         .and_then(|v| v.as_str())
         .unwrap_or_else(|| panic!("open_goals must be keyed by `fn.law` identity:\n{summary}"));
     assert!(
@@ -1005,7 +1005,7 @@ fn proof_check_explain_surfaces_open_goal_residual() {
         "the residual text must be non-empty:\n{residual}"
     );
     assert!(
-        residual.contains("ih :") && residual.contains("butlast (append tail ys)"),
+        residual.contains("ih :") && residual.contains("count n (sort tail)"),
         "the residual must carry the IH in canonical recursive form (the Lemma \
          Calculation input):\n{residual}"
     );
@@ -1018,7 +1018,7 @@ fn proof_check_without_explain_emits_no_open_goals_key() {
     // substring consumers (proof-corpus/run.sh, the --gate baseline diff).
     let Some(summary) = run_check_json_for(
         "aver-explain-noop-out",
-        "proof-corpus/tip/isaplanner/prop_49.av",
+        "proof-corpus/tip/isaplanner/prop_53.av",
         false,
     ) else {
         return;
@@ -1031,7 +1031,7 @@ fn proof_check_without_explain_emits_no_open_goals_key() {
     // reports WITH --explain (only the additive `open_goals` key may appear).
     let Some(with_explain) = run_check_json_for(
         "aver-explain-cmp-out",
-        "proof-corpus/tip/isaplanner/prop_49.av",
+        "proof-corpus/tip/isaplanner/prop_53.av",
         true,
     ) else {
         return;


### PR DESCRIPTION
From the cheap-model probe diagnosis: the **auto-prover** (not the proposer) was the real ceiling, and unclosable goals were the cost sink.

## Auto-prover (`induction.rs`)

Two **additive** list-induction rungs, gated AFTER the existing tactic arms and ending in `omega`, so they can only add closures and never mint a false universal (the `#print axioms` gate still excludes `sorryAx`):

1. **congr fallback** — reduces `f(a) = f(b)` to `a = b` (e.g. `half(length …) = half(length …)`) when `simp`+`omega` can't see through a user fn.
2. **cases on a second list argument** — a subject fn matching a list other than the induction target (e.g. `lastOfTwo` matching `ys`) left a residual no `cases tail` could peel; an additive `cases <second-list>` rung splits it.

**Result:** plain `--check` universal count 61 → 63 (`prop_61`, `prop_49` now close kernel-clean, axioms ⊆ `{propext, Quot.sound}`); zero regressions across the corpus and the decomposed-artifact suite. The `--explain` residual test is repointed off `prop_49` (closed by this change) to `prop_53` (count-over-sort, still open).

> A third change — a loop-safe simp-orientation guard — was **dropped** after it over-rejected a discovered lemma and regressed a decomposed artifact (`prop_55`). It will return with a decomposed-corpus regression test.

## the-method cost cap (skill)

On a goal unclosable by the current prover (not by a missing lemma), the proposer would spiral — many attempts and very large transcripts diagnosing the prover. Lower the default attempt cap to 3 and make it a hard stop: report the likely missing prover capability in one line and stop, rather than analyzing the prover's internals.

## Verification

- `cargo test --lib`: 924 passed; `proof_spec` decomposed-stay-universal + explain-residual tests pass.
- Spot-check: `prop_61`, `prop_49` → `universal:true` (new); `prop_01`, `prop_02` → `universal:true` (no regression).
- `cargo fmt --check` clean; `cargo clippy --features wasm,wasip2` no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
