### PR TITLE
auto-prover: bridge-free structural sibling rung for stranded S(S)-shaped laws

### DIFF
--- a/proof-corpus/tip_with_decompose_sweep.sh
+++ b/proof-corpus/tip_with_decompose_sweep.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# WITH-DECOMPOSE union sweep: a TIP task is CLOSED iff its base file proves
+# universal no-discovery OR a decomposed/<suite>/<name>.av entry proves
+# universal self-contained (same #print-axioms kernel-genuine bar, NO --discover).
+set -u
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+AVER="${AVER:-$ROOT/../target/debug/aver}"
+OUT="${OUT:-$HOME/aver-tip-with-decompose-after-structrung.txt}"
+: > "$OUT"
+echo "# WITH-DECOMPOSE union sweep  aver: $AVER  HEAD: $(cd "$ROOT/.." && git rev-parse --short HEAD)" >> "$OUT"
+prove_lean() {
+  local f="$1" out json
+  for attempt in 1 2; do
+    out="$(mktemp -d)"
+    json="$("$AVER" proof "$f" --backend lean --check --check-json -o "$out" 2>/dev/null | grep '"passed"' | tail -1)"
+    rm -rf "$out"
+    printf '%s' "$json" | grep -q '"universal":true' && { echo universal; return; }
+  done
+  echo open
+}
+sweep_dir() {
+  local suite="$1" label="$2" n=0 base=0 viadec=0 closed=0
+  echo "== $label ==" >> "$OUT"
+  for f in $(find "$ROOT/tip/$suite" -name '*.av' | sort); do
+    n=$((n + 1)); name="$(basename "$f")"; dec="$ROOT/decomposed/$suite/$name"
+    r="$(prove_lean "$f")"
+    if [ "$r" = universal ]; then base=$((base+1)); closed=$((closed+1)); printf '%-16s %s\n' base-universal "$name" >> "$OUT"
+    elif [ -f "$dec" ]; then
+      d="$(prove_lean "$dec")"
+      if [ "$d" = universal ]; then viadec=$((viadec+1)); closed=$((closed+1)); printf '%-16s %s\n' via-decompose "$name" >> "$OUT"
+      else printf '%-16s %s (decomposed present but OPEN)\n' open "$name" >> "$OUT"; fi
+    else printf '%-16s %s\n' open "$name" >> "$OUT"; fi
+  done
+  echo "-- $label: $closed / $n  (base $base + via-decompose $viadec) --" >> "$OUT"
+  echo "$label: $closed / $n  (base $base + decompose $viadec)"
+}
+a="$(sweep_dir isaplanner isaplanner)"; b="$(sweep_dir prod prod)"
+{ echo "=== SUMMARY (with decompose) ==="; echo "$a"; echo "$b"; } | tee -a "$OUT"
+echo "saved -> $OUT"

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -2314,6 +2314,23 @@ fn emit_list_induction(
             proof_lines.push(format!("     {nil_plain}"));
             proof_lines.push(format!("     {cons_plain})"));
         }
+        // Structural-only rung (bridge-free), tried BEFORE the bridged rungs
+        // below: the sibling laws ALONE, closed by `; done`. The bridge +
+        // commute-normalizer rungs rewrite a user fn to its builtin (`plus →
+        // +`) and a `S (S y)` literal to a numeral (`+ 2`) / reorder the `+`s —
+        // which strands an `S (S)`-shaped sibling law (`even ((n+1)+1) = even
+        // n`, `length (w ++ (x::y::z)) = ((length (w ++ z) + 1) + 1)`) so it no
+        // longer matches, and `omega` — blind to the opaque user fn (`even`) —
+        // then cannot finish. Trying the siblings WITHOUT the arithmetic
+        // canonicalization lets the pure structural rewrite close by `rfl`
+        // (prod lemma_14/lemma_16's `even`-shift targets). Gated on non-empty
+        // siblings; `; done` throws on any leftover, so this is strictly
+        // additive — a non-closing goal falls straight through to the rungs
+        // below, and the bare-sibling set is a subset of `fast_lemmas` already
+        // run there, so it adds no new simp-loop surface.
+        if !fast_simp.is_empty() {
+            proof_lines.push(format!("  | (simp only [{}]; done)", fast_simp.join(", ")));
+        }
         proof_lines.push(format!(
             "  | (simp only [{}] <;> omega)",
             fast_lemmas.join(", ")
@@ -2854,6 +2871,18 @@ fn emit_simple_induction(
             fast_lemmas.extend(COMMUTE_NORMALIZERS.iter().map(|s| s.to_string()));
         }
         proof_lines.push("  first".to_string());
+        // Structural-only rung (bridge-free), tried BEFORE the bridged rung
+        // below — see `emit_list_induction` for the full rationale. The `plus →
+        // +` bridge plus `Nat.add_comm` rewrite a `S (S y)` literal to a numeral
+        // and reorder the `+`s, stranding an `S (S)`-shaped sibling law (`even
+        // ((n+1)+1) = even n`) so it no longer matches and `omega` (blind to the
+        // opaque `even`) cannot finish. Trying the siblings alone lets the pure
+        // structural rewrite close by `rfl` (prod lemma_16's `even`-plus-shift).
+        // Gated on non-empty siblings; `; done` throws on a leftover, so it is
+        // strictly additive (falls through to the bridged rung below).
+        if !fast_simp.is_empty() {
+            proof_lines.push(format!("  | (simp only [{}]; done)", fast_simp.join(", ")));
+        }
         proof_lines.push(format!(
             "  | (simp only [{}] <;> omega)",
             fast_lemmas.join(", ")

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -326,6 +326,12 @@ fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
         "proof-corpus/decomposed/prod/prop_02.av",
         "proof-corpus/decomposed/prod/prop_19.av",
         "proof-corpus/decomposed/prod/prop_34.av",
+        // bridge-free structural rung: the `even`-shift targets whose sibling
+        // laws are `S (S)`-shaped and were stranded by the `plus → +` / commute
+        // normalizers in the bridged simp set (now closed by a leading
+        // structural-only rung).
+        "proof-corpus/decomposed/prod/lemma_14.av",
+        "proof-corpus/decomposed/prod/lemma_16.av",
     ];
     for task in tasks {
         let out = temp_output_dir(&format!(


### PR DESCRIPTION
## What

A law whose target closes by a pure structural rewrite through its sibling laws was being defeated by its own fast-path simp set. Example: `even (plus x (S (S y))) = even (plus x y)`, provable by `plusSuccRight` (twice) + `evenSuccSucc`. The fast path bundled those sibling laws together with the arithmetic canonicalization bridge (`plus a b = a + b`) and the commute normalizers (`Nat.add_comm` …). Those rewrite `plus` to `+` and the `S (S y)` literal to the numeral `+ 2` / reorder the summands — after which the `S (S)`-shaped sibling laws no longer match, and `omega` (blind to the opaque recursive `even`) cannot finish. The goal fell through to a `sorry`.

## Fix

Add a leading, bridge-free, normalizer-free `simp only [<siblings>]; done` rung in **both** the list-induction and Nat-induction emitters, tried before the bridged rungs. It lets the pure structural rewrite close by `rfl` when the bridge would otherwise interfere.

Safety:
- Gated on a non-empty sibling set.
- `; done` throws on any leftover goal, so the rung is **strictly additive** — a non-closing goal falls straight through to the existing rungs (cannot demote a working proof).
- The bare-sibling set is already a subset of the bridged set run immediately below it, so this adds **no new simp-loop surface**.

## Results (Lean, kernel-genuine, no discovery)

- Closes the two `even`-shift decompositions that previously carried a `sorry` without active discovery: prod `lemma_14`, `lemma_16`. Both are now pinned in the decomposed-stay-universal regression test.
- **No-discovery corpus byte-for-byte unchanged** (the rung never fires without sibling laws): isaplanner 46/78, prod 22/74 = 68/152.
- With-decompose union: 105 → 107/152.
- Full `cargo test` green, `cargo fmt --check` clean, `cargo clippy --features wasm,wasip2` clean.

Investigated alongside `prop_06`, whose remaining `sorry` is a different, deeper gap (the `rev = List.reverse` bridge needs an `append = ++` lemma to discharge `append (t.reverse) [h] = t.reverse ++ [h]`); left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)