### PR TITLE
the-method: capability-fence the conjecturer (split proposer/runner)

### DIFF
--- a/.claude/agents/the-method-proposer.md
+++ b/.claude/agents/the-method-proposer.md
@@ -1,0 +1,19 @@
+---
+name: the-method-proposer
+description: The Method conjecturer — proposes auxiliary Aver helper laws to unblock an OPEN Aver proof obligation. Read-only by design (no Bash, no toolchain, no access to any generated proof), so it physically cannot drift from conjecturing into tactic/prover debugging. Invoked by the the-method workflow.
+tools: Read, Glob
+---
+
+You are THE CONJECTURER in "The Method". Your one job: given an OPEN Aver `verify … law`, output the auxiliary Aver helper law(s) that would unblock it. You PROPOSE; a separate runner tests and the Lean kernel / Z3 judges. You never see the proof and never run anything — that is deliberate.
+
+Hard boundaries (these are enforced by your tool set, not just asked):
+- You have **Read and Glob only**. You cannot run `aver`, `lake`, `cargo`, or any command, and you cannot open generated `.lean`/`.dfy` files (they do not exist in your world, and you must not go looking).
+- Reason ONLY about **Aver**: the datatypes, the functions in the proof cone, the open law, and what TRUE, GENERAL auxiliary Aver law (a missing homomorphism / associativity / distributivity / an equation relating subterms of the goal) the proof needs. Never reason about Lean tactics, induction strategy, simp sets, fuel, goal state, or any prover internals — discharging the proof is the toolchain's job.
+- Do NOT merely restate the goal as a "helper". A helper must be a separate, independently-true Aver law about the functions involved.
+
+Method:
+- Read the target task to learn its datatypes, functions, and the exact open law.
+- If the project has a `decomposed/` directory of already-solved tasks, read one solved entry (and its base) to learn EXACTLY how helper laws — and any `fn` they introduce — are written as valid Aver. Rendering matters: how a constructor/operator is written changes how it elaborates. Valid Aver only: first-order, no closures.
+- When you are given the Aver-level outcome of previous attempts (which helper failed its bounded check, or "all helpers verified but the law is still open"), use it to propose a DIFFERENT or ADDITIONAL Aver law, or to fix a law's statement / sample domains. If "all helpers verified but still open", the missing piece is usually one more lemma a level deeper (build the ladder: propose the sub-lemma your failed helper itself needs) — NOT a tactic.
+
+Keep your reasoning short. Long, tactic-flavoured analysis means you have drifted out of your job; step back to the single question: "what true Aver law is missing?" Return your proposed helper law(s) as structured output.

--- a/.claude/agents/the-method-runner.md
+++ b/.claude/agents/the-method-runner.md
@@ -1,0 +1,24 @@
+---
+name: the-method-runner
+description: The Method proof-runner — mechanically splices a given set of helper laws into a /tmp copy of a task, runs the Aver toolchain once, and returns ONLY the Aver-level verdict (universal/sorries + which helper failed its bounded check). Never interprets or surfaces Lean/Dafny. Invoked by the the-method workflow.
+tools: Read, Write, Edit, Bash
+---
+
+You are THE RUNNER in "The Method". You are a MECHANICAL step, not a thinker: you are handed a task and a fixed list of helper laws, you splice and run, and you report the verdict. You do NOT propose laws, you do NOT refine, and you do NOT debug.
+
+Locate the aver binary: try `./target/release/aver`, then `./target/debug/aver`, then `aver` on PATH; if none exists, run `cargo build --bin aver` first.
+
+What to do (exactly once — no loop):
+1. Copy the target task to a fresh `/tmp` scratch `.av`.
+2. Splice the given helper laws (and any `fn` they introduce) in VERBATIM, BEFORE the target `verify … law` line. Order matters — appending at the end can fail to fire. Use the helper `source` strings exactly as given.
+3. Run, into a FRESH `/tmp` dir:
+   - `<aver> proof <scratch> --discover -o <dir>`
+   - `<aver> proof <scratch> --check --check-json --backend lean -o <dir>`
+   Retry once on a transient `lake` error.
+4. Read ONLY the `--check-json` summary line. `universal` and `sorries` come straight from it. `universal:true` with `sorries:0` ⟺ closed.
+
+Reporting — this is the important constraint:
+- Return ONLY Aver-level facts: the `universal` boolean, the `sorries` integer, whether every helper passed its own bounded check (from the discover/verify output), and a one-line note in Aver terms (e.g. "helper `revDist` failed its bounded check", or "all helpers verified, target law still open"). 
+- NEVER read, quote, summarise, or reason about the generated `.lean`/`.dfy` files, the Lean goal state, tactics, simp sets, or the proof residual. The proposer that consumes your verdict must stay Lean-free; leaking prover internals back to it is the exact failure this split exists to prevent. If asked to explain *why* in prover terms — don't; report the Aver-level verdict and stop.
+
+SAFETY: work only on `/tmp` copies. Never modify any project file and never run state-changing `git` commands.

--- a/.claude/agents/the-method-verifier.md
+++ b/.claude/agents/the-method-verifier.md
@@ -1,0 +1,25 @@
+---
+name: the-method-verifier
+description: The Method verify gate — independently re-verifies a claimed closure from scratch (the proposer/runner verdict is not trusted) and, on success, persists the verified decomposition to decomposed/. Restricted tools; exactly one sanctioned project write. Invoked by the the-method workflow.
+tools: Read, Write, Edit, Bash
+---
+
+You are THE VERIFY GATE in "The Method". An autonomous run's own "closed" claim is not trustworthy on its own — you re-check it from scratch, yourself, before it counts. You are also the ONE step allowed a single project-file write: persisting a verified decomposition so a win is durable and never re-guessed.
+
+Locate the aver binary: try `./target/release/aver`, then `./target/debug/aver`, then `aver` on PATH; build it if missing.
+
+Re-verify (do not trust any prior verdict):
+1. Copy the target task to a fresh `/tmp` scratch.
+2. Splice the candidate helper laws (and any `fn` they introduce) in VERBATIM, BEFORE the target `verify … law` line. Order and rendering matter.
+3. Run: `<aver> proof <scratch> --discover -o <freshdir>`; then `<aver> proof <scratch> --check --check-json --backend lean -o <freshdir>`. Retry once on a transient `lake` error.
+4. `verified = true` ONLY if you yourself observe `universal:true` AND `sorries:0`.
+5. Sanity: confirm the BASE task (no helpers) is still OPEN (`universal:true` ABSENT) — a helper that was never needed is not a win.
+
+Persist (only if verified):
+- Destination = the target path with its `/tip/` segment replaced by `/decomposed/` (e.g. `proof-corpus/tip/prod/prop_38.av` → `proof-corpus/decomposed/prod/prop_38.av`). If the path has no `/tip/` segment, use `proof-corpus/decomposed/<basename>`. Create parent dirs if needed.
+- Read one existing `decomposed/` entry + its base to match the convention EXACTLY: the entry is the base file with the helper laws (and their `fn` defs) spliced in BEFORE the target `verify … law` block — same module name, same functions, nothing else changed.
+- Write the verified augmented `.av` to that destination, then re-run the closing sequence ON THE WRITTEN FILE and confirm it still shows `universal:true`,`sorries:0`. Set `persistedPath` to that project-relative path. If verification, the write, or the re-check fails, set `persistedPath=""`.
+
+You may read the toolchain output to confirm the verdict, but your job is the Aver-level pass/fail and the persist — keep your reasoning to that; do not analyse Lean tactics or the proof residual.
+
+SAFETY: do ALL proof work on `/tmp` copies. The ONLY project-file write you may make is creating/overwriting that single `decomposed/` entry. Never run state-changing `git` commands; never touch any other project file.

--- a/.claude/skills/the-method/SKILL.md
+++ b/.claude/skills/the-method/SKILL.md
@@ -28,18 +28,27 @@ Workflow({ scriptPath: "<this-skill-dir>/the-method-loop.js", args: { tasks: ["p
 ```
 
 ## How it runs
-One autonomous agent per task (in parallel). Each agent:
-1. Reads the target task; if the project has example decompositions (e.g. a `decomposed/`
-   directory of solved tasks), learns the exact splice form from one of them.
-2. Proposes 1–3 true, general helper laws aimed at the open goal (not a restatement of it).
-3. Splices them into a `/tmp` copy — **before** the target `verify ... law` (order matters; rendering
-   matters too) — and runs `aver proof <scratch> --discover -o <dir>` then
-   `aver proof <scratch> --check --check-json --backend lean -o <dir>`; success ⟺ `"universal":true`.
-4. Refines on failure, up to `attempts` tries.
+The conjecturer and the prover are SEPARATE, capability-fenced agents — "the agent proposes, the
+kernel decides" is enforced structurally, not merely asked. One independent chain per task, run in
+parallel; within a chain, up to `attempts` propose→test rounds:
+1. **Conjecturer** (`the-method-proposer`, **Read+Glob only** — no toolchain, no Bash, cannot open
+   any generated `.lean`/`.dfy`): reads the target (and one `decomposed/` example, if present) and
+   proposes 1–3 true, general helper laws aimed at the open goal — never a restatement.
+2. **Runner** (`the-method-runner`): mechanically splices the laws into a `/tmp` copy — **before**
+   the target `verify ... law` (order + rendering matter) — runs `aver proof <scratch> --discover`
+   then `... --check --check-json --backend lean`, and returns **ONLY the Aver-level verdict**
+   (`universal`/`sorries`, which helper failed its bounded check). The Lean residual never crosses
+   back to the conjecturer.
+3. On failure the conjecturer refines against that Aver-level verdict; on `"universal":true` with
+   `"sorries":0` the chain closes.
 
-Then a **Verify** phase independently re-checks each claimed closure from scratch (a separate agent,
-a fresh dir) — a self-reported closure is not trusted on its own. Only verified closures are
-returned.
+Because the conjecturer physically cannot see the proof, it cannot drift from conjecturing into
+tactic/prover-internals debugging (the measured dominant cost sink). The optional `model` override
+applies to the conjecturer only; the runner and verify gate stay on the default model.
+
+Then a **Verify** phase (`the-method-verifier`) independently re-checks each claimed closure from
+scratch (a fresh dir) — a self-reported closure is not trusted on its own — and persists the
+verified decomposition to `decomposed/`. Only verified closures are returned.
 
 ## Output
 Per task: `closed`, `verified`, `attempts`, `helperLaws` ({name, source}), `summary`; plus a
@@ -51,5 +60,6 @@ Keep a proposed lemma set only if the augmented task still closes — never let 
 regress a proof that worked without it.
 
 ## Safety
-READ-ONLY on the project. All edits happen on `/tmp` scratch copies. The loop never runs
-state-changing `git` commands and never modifies project files.
+The conjecturer and runner are READ-ONLY on the project — all proof work happens on `/tmp` scratch
+copies. The ONLY sanctioned project-file write is the verify gate persisting a re-confirmed win to
+`decomposed/`. The loop never runs state-changing `git` commands and never modifies your source.

--- a/.claude/skills/the-method/the-method-loop.js
+++ b/.claude/skills/the-method/the-method-loop.js
@@ -1,82 +1,61 @@
 export const meta = {
   name: 'the-method',
-  description: 'The Method: an agent proposes helper lemmas -> aver tests -> Lean/Z3 judges -> refine, with an independent verify gate. Closes open Aver proof laws on any Aver project.',
+  description: 'The Method: a CONJECTURER agent proposes helper lemmas -> a separate RUNNER agent tests with aver -> Lean/Z3 judges -> refine, with an independent verify gate. The conjecturer is capability-fenced (read-only, no toolchain, never sees the proof) so it cannot drift into tactic/prover debugging. Closes open Aver proof laws on any Aver project.',
   phases: [
-    { title: 'Method', detail: 'one agent per open task: propose helper lemmas, test with aver, refine until Lean closes or budget out' },
-    { title: 'Verify', detail: "independent re-verify of each self-reported closure (fresh dir) — the proposer's own verdict is not trusted; on success the verified decomposition is PERSISTED to decomposed/ so it is recoverable, never re-guessed" },
+    { title: 'Method', detail: 'per open task: a read-only conjecturer proposes helper laws; a mechanical runner splices + tests with aver and returns ONLY the Aver-level verdict; refine until Lean closes or the attempt cap is hit' },
+    { title: 'Verify', detail: "independent re-verify of each self-reported closure (fresh dir) — the run's own verdict is not trusted; on success the verified decomposition is PERSISTED to decomposed/ so it is recoverable, never re-guessed" },
   ],
 }
 
-// Inputs (via Workflow `args`): either an array of task .av paths, or { tasks: [...], attempts? }.
+// Inputs (via Workflow `args`): either an array of task .av paths, or { tasks: [...], attempts? , model? }.
 // Paths are relative to the project root (the cwd the workflow runs in) or absolute.
 let a = typeof args === 'string'
   ? (() => { try { return JSON.parse(args) } catch { return args.trim() ? [args.trim()] : null } })()
   : args
 const TASKS = Array.isArray(a) ? a : (a && Array.isArray(a.tasks) ? a.tasks : [])
 const MAX_ATTEMPTS = (a && a.attempts) || 3
-const MODEL = (a && a.model) || undefined  // optional model override for the proposer (e.g. 'haiku','sonnet'); undefined = inherit
+const MODEL = (a && a.model) || undefined  // optional model override for the CONJECTURER only (e.g. 'haiku','sonnet'); undefined = inherit. Runner + verify gate stay default = trustworthy.
 if (!TASKS.length) {
   log('the-method: pass one or more Aver task .av paths as args, e.g. { tasks: ["path/to/task.av"] }')
   return { error: 'no tasks given' }
 }
-log(`The Method: ${TASKS.length} task(s), up to ${MAX_ATTEMPTS} attempts each${MODEL ? `, proposer model=${MODEL}` : ''}`)
+log(`The Method: ${TASKS.length} task(s), up to ${MAX_ATTEMPTS} attempts each${MODEL ? `, conjecturer model=${MODEL}` : ''}`)
 
-const RESULT_SCHEMA = {
+// ---- THE CAPABILITY FENCE ----------------------------------------------------------------------
+// The proposer/runner split is the fence: "agent proposes, kernel decides" made STRUCTURAL, not
+// asked. The conjecturer (`the-method-proposer`, tools: Read+Glob ONLY) physically cannot run the
+// toolchain or open a generated .lean/.dfy, so it cannot slide from conjecturing into debugging
+// tactics/the proof residual — the measured dominant cost sink (a "must close" model spiralling on
+// the Lean goal state). The runner (`the-method-runner`) does the mechanical splice+run and returns
+// ONLY an Aver-level verdict; the Lean residual never crosses back into the conjecturer's context.
+// See feedback_explain_residual_internal_only + project_tip_isaplanner_split (cost diagnosis).
+
+const LAWS_SCHEMA = {
   type: 'object', additionalProperties: false,
-  required: ['task', 'closed', 'attempts', 'helperLaws', 'finalError', 'summary'],
+  required: ['helperLaws', 'rationale'],
   properties: {
-    task: { type: 'string' },
-    closed: { type: 'boolean', description: 'true iff the augmented task reached "universal":true on Lean' },
-    attempts: { type: 'integer' },
     helperLaws: {
       type: 'array',
       items: {
         type: 'object', additionalProperties: false, required: ['name', 'source'],
-        properties: { name: { type: 'string' }, source: { type: 'string', description: 'the helper law as valid Aver source' } },
+        properties: { name: { type: 'string' }, source: { type: 'string', description: 'the helper law (plus any fn it introduces) as valid first-order Aver source' } },
       },
     },
-    finalError: { type: 'string', description: 'empty if closed, else short Lean error / reason it stayed open' },
-    summary: { type: 'string', description: '2-3 sentences: what was tried and why it did/did not work' },
+    rationale: { type: 'string', description: '1-2 sentences, Aver-level only: what these laws say and why the proof needs them' },
   },
 }
 
-const FIND_AVER = 'Locate the aver binary: try ./target/release/aver, then ./target/debug/aver, then `aver` on PATH; if none exists, run `cargo build --bin aver` first.'
-const SAFETY = 'SAFETY: READ-ONLY on the project. Do ALL edits on COPIES under /tmp. Never run state-changing git commands and never modify project files.'
-// The verify gate is the ONE agent allowed a single project write: persisting the verified
-// decomposition to decomposed/ so wins are durable on disk during the run (not scraped from a
-// possibly-truncated result), and so re-runs replay instead of re-guessing.
-const VERIFY_SAFETY = 'SAFETY: do ALL proof/verification work on COPIES under /tmp. The ONLY project-file write you may make is creating/overwriting the single decomposed entry described below. Never run state-changing git commands; never touch any other project file.'
+const RUN_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['universal', 'sorries', 'allHelpersVerified', 'note'],
+  properties: {
+    universal: { type: 'boolean', description: 'value of "universal" from the --check-json line' },
+    sorries: { type: 'integer', description: 'value of "sorries" from the --check-json line' },
+    allHelpersVerified: { type: 'boolean', description: 'true iff every spliced helper passed its own bounded check' },
+    note: { type: 'string', description: 'ONE line, AVER-LEVEL ONLY (which helper failed its bounded check, or "all helpers verified, target law still open"). NEVER quote Lean/Dafny, tactics, or the proof residual.' },
+  },
+}
 
-const METHOD_PROMPT = (t) => `You ARE "The Method": close an OPEN Aver proof obligation by proposing auxiliary helper lemmas, testing them with the Aver toolchain, and refining on failure. You propose; the Lean kernel / Z3 judges.
-
-YOU ARE A CONJECTURER, NOT A PROVER. Reason ONLY about Aver: the datatypes, the functions, the open law, and what auxiliary Aver law would unblock it. Do NOT open, read, or reason about the generated Lean/Dafny files; do NOT reason about Lean tactics, induction strategy, the proof residual / goal state, simp sets, fuel, or the Aver prover's internals — discharging the proof is the toolchain's job, not yours. Your ONLY output is the right Aver helper law(s). If an attempt does not close, propose a DIFFERENT or additional Aver LAW (or fix the law's statement / sample domains) — never try to debug or fix the proof itself. Keep your reasoning short: long tactic-level analysis means you have drifted out of your job and should step back to "what true Aver law is missing?".
-
-LADDER — do not restate, do not spiral. A helper law may itself need its OWN sub-lemmas before it proves; that is normal and EXPECTED, and supplying them is YOUR job. Canonical example: 'plus(x, y) = plus(y, x)' does NOT prove alone — it needs 'plus(x, Nat.Z) = x' and 'plus(x, Nat.S(y)) = Nat.S(plus(x, y))' proven FIRST, after which the auto-prover discharges commutativity by induction with those in scope. When a helper does not close, ask "what does THIS helper itself need?" and add that rung. This LADDERING (a finite chain of distinct true sub-laws) is the core of the job, and is NOT the spiraling the attempt-cap targets — spiraling is re-proposing cosmetic variants of the SAME law, or analyzing the prover. A 3-4 law ladder that closes beats giving up at attempt 1. Foundational ladders (Peano plus/mult laws, list append identity/associativity, rev involution) recur across tasks — reuse them.
-
-Prefer the ONE-SIDED homomorphism form. For a two-sided commute goal like 'f(g(x, y)) = f(g(y, x))' the auto-prover often stalls on the symmetric g(x,y)-versus-g(y,x) shape. State the rung that pushes ONE side through its homomorphism — e.g. 'f(g(x, y)) = f(op(h(x), h(y)))' — and let a separate commutativity rung for op finish; that is the shape the auto-prover closes. Do not fight the verbatim two-sided form.
-
-You are working inside an Aver project (the current working directory).
-- ${FIND_AVER}
-- TARGET task file (contains an OPEN "verify ... law"): ${t}  (relative to the project root, or absolute).
-
-${SAFETY}
-
-STEP 1 — understand the mechanism for THIS project:
-- Read the target task: its datatypes, functions, and the OPEN law.
-- If the project has example decompositions (e.g. a "decomposed/" directory of already-solved tasks), read one solved task plus its base to learn EXACTLY how helper laws are written into a .av. The closing command sequence is:
-    <aver> proof <scratch.av> --discover -o <dir>            (proves + commits the helper lemmas)
-    <aver> proof <scratch.av> --check --check-json --backend lean -o <dir>   (SAME dir; closed <=> output contains "universal":true)
-
-STEP 2 — the loop (HARD CAP: at most ${MAX_ATTEMPTS} attempts; stop the instant it closes). If it has NOT closed after ${MAX_ATTEMPTS} attempts, STOP immediately — return closed:false with your best helper set and ONE short line naming the likely missing PROVER capability (e.g. "needs congr", "needs cases on a 2nd list arg", "nonlinear arithmetic"). Do NOT keep proposing more variations, and do NOT analyze the prover's tactics/internals — spiraling past the cap is the dominant cost sink and never closes a prover-blocked goal.
-1. Propose the TRUE, GENERAL helper laws the proof needs — a missing homomorphism / associativity / distributivity / an equation relating subterms of the goal — INCLUDING the sub-lemmas any helper itself needs (the LADDER above: e.g. propose plus-Z and plus-succ alongside plus-comm). Do not artificially cap the count at one or two, and do not merely restate the goal.
-2. Copy the target to a fresh /tmp scratch and splice the helper laws in BEFORE the target "verify ... law" line. ORDER MATTERS (appending at the END can fail to fire); RENDERING MATTERS (how a constructor/operator is written changes how it elaborates). Valid Aver only: first-order, no closures.
-3. Run discover then check into a FRESH /tmp dir. Closed <=> "universal":true with "sorries":0.
-4. Retry once on a transient lake error. On failure, read the Lean error / see which helper failed, refine, try again.
-
-Return: task="${t}"; closed (bool); attempts used; helperLaws = the WINNING set [{name, source}] if closed (else your best attempt); finalError ("" if closed); summary (2-3 sentences).`
-
-// VERIFY GATE — an autonomous agent's self-reported `closed` is not trustworthy on its own. An
-// INDEPENDENT agent re-checks each claimed closure from scratch before we count it.
 const VERIFY_SCHEMA = {
   type: 'object', additionalProperties: false,
   required: ['verified', 'note', 'persistedPath'],
@@ -87,38 +66,76 @@ const VERIFY_SCHEMA = {
   },
 }
 
-const VERIFY_PROMPT = (t, helperLaws) => `INDEPENDENT verification gate. Do NOT trust any prior "closed" claim — verify from scratch yourself.
-You are in an Aver project. ${FIND_AVER}
+const PROPOSE_PROMPT = (t, attempt, history) => `Propose the Aver helper law(s) to unblock an OPEN proof obligation. You are the CONJECTURER (read-only; you cannot run anything or see any proof — that is by design).
+
+- TARGET task file (contains the OPEN "verify … law"): ${t}  (relative to the project root, or absolute).
+- Attempt ${attempt} of ${MAX_ATTEMPTS}.
+${history.length ? `- Aver-level outcome of previous attempt(s) (NO prover internals — use it to propose a DIFFERENT/ADDITIONAL law, fix a statement/sample domain, or ladder one level deeper):\n${JSON.stringify(history)}` : '- This is the first attempt.'}
+
+Read the target (its datatypes, functions, the open law). If a decomposed/ directory exists, read one solved entry + its base to learn EXACTLY how helper laws (and any fn they introduce) are written as valid Aver. Then return 1-3 TRUE, GENERAL helper laws about the task's OWN functions that the proof needs (a missing homomorphism / associativity / distributivity / an equation relating subterms of the goal) — do NOT restate the goal. Valid Aver only: first-order, no closures. Keep rationale short and Aver-level.`
+
+const RUN_PROMPT = (t, helperLaws) => `Mechanically test a fixed helper-law set against an Aver task and report ONLY the Aver-level verdict.
+- TARGET task: ${t}  (relative to the project root, or absolute).
+- helper laws to splice (JSON, verbatim): ${JSON.stringify(helperLaws)}
+
+Copy ${t} to a fresh /tmp scratch; splice the helpers (and any fn they introduce) in BEFORE the target "verify … law" line (order + rendering matter); run \`<aver> proof <scratch> --discover -o <dir>\` then \`<aver> proof <scratch> --check --check-json --backend lean -o <dir>\` (retry once on a transient lake error). Read ONLY the --check-json summary line. Return universal, sorries, allHelpersVerified, and a one-line AVER-LEVEL note. Do NOT read or reason about the generated Lean/Dafny, tactics, or the proof residual.`
+
+const VERIFY_PROMPT = (t, helperLaws) => `INDEPENDENT verification gate. Do NOT trust any prior "closed" claim — verify from scratch yourself, then persist if it holds.
 - TARGET (OPEN in baseline): ${t}
 - candidate helper laws (JSON): ${JSON.stringify(helperLaws)}
 
-Steps:
-1. Copy ${t} to a fresh /tmp scratch.
-2. Splice the helper laws in BEFORE the target "verify ... law" line (order and rendering matter — appending at the end can fail). Use the helper source strings verbatim.
-3. Run: <aver> proof <scratch> --discover -o <freshdir> ; then <aver> proof <scratch> --check --check-json --backend lean -o <freshdir>.
-4. verified = true ONLY if the check output contains "universal":true AND "sorries":0. Retry once on a transient lake error.
-5. Sanity: confirm the BASE task (no helpers) is still OPEN ("universal":true ABSENT).
-6. PERSIST (only if verified) — make the win durable and recoverable so it is never re-guessed:
-   - Destination = the target path with its "/tip/" segment replaced by "/decomposed/" (e.g. proof-corpus/tip/prod/prop_38.av -> proof-corpus/decomposed/prod/prop_38.av; proof-corpus/tip/isaplanner/prop_76.av -> proof-corpus/decomposed/isaplanner/prop_76.av). If the path has no "/tip/" segment, use proof-corpus/decomposed/<basename>. Create parent dirs if needed.
-   - Convention (read one existing decomposed/ entry + its base to match it EXACTLY): the entry is the base file with the helper laws (and any helper "fn" definitions they introduce) spliced in BEFORE the target "verify ... law" block — same module name, same functions, nothing else changed.
-   - Write your verified augmented .av to that destination, then re-run the closing sequence ON THE WRITTEN FILE and confirm it still shows "universal":true,"sorries":0. Set persistedPath to that project-relative path.
-   - If verified=false, or the write or re-check fails, set persistedPath="".
-${VERIFY_SAFETY}
-Return: verified (bool), note, persistedPath.`
+Copy ${t} to a fresh /tmp scratch; splice the helpers in BEFORE the target "verify … law" line (use the source strings verbatim; order + rendering matter); run \`<aver> proof <scratch> --discover -o <freshdir>\` then \`<aver> proof <scratch> --check --check-json --backend lean -o <freshdir>\` (retry once on a transient lake error). verified=true ONLY if the check output contains "universal":true AND "sorries":0. Confirm the BASE task (no helpers) is still OPEN. If verified, PERSIST: destination = the target path with its "/tip/" segment replaced by "/decomposed/" (no "/tip/" → proof-corpus/decomposed/<basename>); match an existing decomposed/ entry's convention EXACTLY (base file + spliced helpers/fns, nothing else); write it, re-run the closing sequence on the WRITTEN file, confirm "universal":true,"sorries":0, and set persistedPath. Else persistedPath="". Return verified, note, persistedPath.`
 
 phase('Method')
-// pipeline: each task is proposed, then (if self-reported closed) independently verified — no
-// barrier, so verification starts the moment an agent finishes.
-const results = (await pipeline(
-  TASKS,
-  (t) => agent(METHOD_PROMPT(t), { label: `method:${t}`, phase: 'Method', schema: RESULT_SCHEMA, agentType: 'general-purpose', model: MODEL }),
-  (r, t) => {
-    if (!r) return { task: t, closed: false, verified: false, attempts: 0, helperLaws: [], finalError: 'agent died', summary: '' }
-    if (!r.closed) return { ...r, verified: false }
-    return agent(VERIFY_PROMPT(r.task, r.helperLaws), { label: `verify:${r.task}`, phase: 'Verify', schema: VERIFY_SCHEMA, agentType: 'general-purpose' })
-      .then((v) => ({ ...r, verified: !!(v && v.verified), verifyNote: v ? v.note : 'verifier died', persistedPath: v ? (v.persistedPath || '') : '' }))
-  },
-)).filter(Boolean)
+
+// One independent chain per task, run concurrently. Within a chain the propose->run loop is
+// sequential (each attempt refines on the prior Aver-level verdict); on a close, the verify gate
+// runs. Wrapped in thunks so cross-task concurrency is preserved; phase is set explicitly on each
+// agent (parallel/await => avoid racing the global phase() cursor).
+async function runOneTask(t) {
+  const history = []
+  let won = null
+  let lastNote = ''
+  let attemptsUsed = 0
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    attemptsUsed = attempt
+    const prop = await agent(PROPOSE_PROMPT(t, attempt, history),
+      { label: `propose:${t}#${attempt}`, phase: 'Method', schema: LAWS_SCHEMA, agentType: 'the-method-proposer', model: MODEL })
+    if (!prop || !Array.isArray(prop.helperLaws) || !prop.helperLaws.length) {
+      lastNote = prop ? 'conjecturer returned no laws' : 'conjecturer died'
+      history.push({ laws: [], note: lastNote })
+      continue
+    }
+    const run = await agent(RUN_PROMPT(t, prop.helperLaws),
+      { label: `run:${t}#${attempt}`, phase: 'Method', schema: RUN_SCHEMA, agentType: 'the-method-runner' })
+    if (run && run.universal === true && run.sorries === 0) {
+      won = { helperLaws: prop.helperLaws, rationale: prop.rationale || '' }
+      lastNote = ''
+      break
+    }
+    lastNote = run ? run.note : 'runner died'
+    history.push({ laws: prop.helperLaws, note: lastNote, allHelpersVerified: run ? run.allHelpersVerified : false })
+  }
+
+  const base = { task: t, attempts: attemptsUsed }
+  if (!won) {
+    return { ...base, closed: false, verified: false, helperLaws: history.length ? (history[history.length - 1].laws || []) : [], finalError: lastNote || 'did not close within attempt cap', persistedPath: '' }
+  }
+  const v = await agent(VERIFY_PROMPT(t, won.helperLaws),
+    { label: `verify:${t}`, phase: 'Verify', schema: VERIFY_SCHEMA, agentType: 'the-method-verifier' })
+  return {
+    ...base,
+    closed: true,
+    helperLaws: won.helperLaws,
+    finalError: '',
+    summary: won.rationale,
+    verified: !!(v && v.verified),
+    verifyNote: v ? v.note : 'verifier died',
+    persistedPath: v ? (v.persistedPath || '') : '',
+  }
+}
+
+const results = (await parallel(TASKS.map((t) => () => runOneTask(t)))).filter(Boolean)
 
 for (const r of results) {
   const status = r.closed ? (r.verified ? 'CLOSED+VERIFIED' : 'self-CLOSED but VERIFY FAILED') : 'open'


### PR DESCRIPTION
## Problem

The Method's proposer was a single `general-purpose` agent with full tools — it could read the generated `.lean`, run `lake`, and search the web for tactics. "You are a conjecturer, not a prover" was prompt-intention with **nothing enforcing it**. The measured failure was exactly that: on a prover-blocked goal the model spiralled into debugging Lean tactics and the proof residual (the dominant token sink), because nothing physically stopped it.

## Fix — make it structural, not asked

Split the loop into capability-fenced roles (new custom agent types under `.claude/agents/`):

- **`the-method-proposer`** (`Read, Glob` only): the conjecturer. No Bash, no toolchain, cannot open any generated `.lean`/`.dfy`. It proposes Aver helper laws and nothing else — it *physically cannot* slide into tactic/residual debugging.
- **`the-method-runner`** (`Read, Write, Edit, Bash`): mechanically splices the proposed laws into a `/tmp` copy, runs `aver proof --discover` + `--check --check-json`, and returns **only the Aver-level verdict** (`universal`/`sorries`, which helper failed its bounded check). The Lean residual never crosses back to the conjecturer.
- **`the-method-verifier`** (`Read, Write, Edit, Bash`): the existing independent re-verify + persist-to-`decomposed/` gate, now its own restricted type.

One independent chain per task runs in parallel; within a chain the propose→run rounds refine against the Aver-level verdict only, up to the attempt cap. The optional `model` override now applies to the conjecturer alone; runner and verify gate stay on the default model.

## Scope / safety

- No Rust/codegen change — the `aver` toolchain and the proof corpus are untouched.
- `the-method-loop.js` rewritten to the split; `SKILL.md` updated to describe the fence.
- Statically validated (workflow script parses; agent files well-formed). Not yet live-run (invoking the workflow is an explicit, billed opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)