### PR TITLE
proof-corpus: re-derive prod prop_02 + prop_06 SOUND (no builtin bridge)

### DIFF
--- a/proof-corpus/decomposed/prod/prop_02.av
+++ b/proof-corpus/decomposed/prod/prop_02.av
@@ -1,0 +1,33 @@
+module Prop02
+    intent =
+        "TIP prod prop_02: length(x ++ y) = length(y ++ x)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(x: List<Int>) -> Nat
+    match x
+        [] -> Nat.Z
+        [y, ..xs] -> Nat.S(length(xs))
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+verify length law lengthConcatHomo
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[], [2], [4, 5]]
+    length(List.concat(x, y)) => plus(length(x), length(y))
+
+verify plus law plusComm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, y) => plus(y, x)
+
+verify length law lengthConcatComm
+    given x: List<Int> = [[1], [2, 3], [1, 2, 3]]
+    given y: List<Int> = [[4], [5], [4, 5]]
+    length(List.concat(x, y)) => length(List.concat(y, x))

--- a/proof-corpus/decomposed/prod/prop_06.av
+++ b/proof-corpus/decomposed/prod/prop_06.av
@@ -1,0 +1,47 @@
+module Prop06
+    intent =
+        "TIP prod prop_06: length (rev (x ++ y)) = length x + length y."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(xs: List<Int>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(length(ys))
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn append(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..ys] -> append(rev(ys), [y])
+
+verify plus law plusSuccRight
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, Nat.S(y)) => Nat.S(plus(x, y))
+
+verify length law lengthAppend
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[], [2], [4, 5]]
+    length(append(x, y)) => plus(length(x), length(y))
+
+verify length law lengthRev
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    length(rev(x)) => length(x)
+
+verify length law revAppendLength
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[], [2], [4, 5]]
+    length(rev(append(x, y))) => plus(length(x), length(y))

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -323,8 +323,11 @@ fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
         "proof-corpus/decomposed/prod/prop_31.av",
         // decomposition-reach chunk #2 (deterministic spread over fresh open pool).
         "proof-corpus/decomposed/isaplanner/prop_55.av",
-        // (prod/prop_02 removed: it closed only via the Aver-false `length => List.len`
-        //  Nat-vs-Int bridge, now correctly a type error — see the checker fix.)
+        // prop_02/prop_06 re-derived SOUND (pure Nat=Nat homomorphisms — no Aver-false
+        // builtin bridge) after the checker now rejects `length => List.len`; both pass
+        // `aver verify` AND `--check` universal.
+        "proof-corpus/decomposed/prod/prop_02.av",
+        "proof-corpus/decomposed/prod/prop_06.av",
         "proof-corpus/decomposed/prod/prop_19.av",
         "proof-corpus/decomposed/prod/prop_34.av",
         // bridge-free structural rung: the `even`-shift targets whose sibling


### PR DESCRIPTION
Follow-up to #573. After the checker now rejects the Aver-false `length => List.len` (Nat-vs-Int) bridge, the fenced The Method (sonnet conjecturer, full verify-sieve harness) found **sound, well-typed, self-contained** decompositions for both props it had to drop — **pure `Nat=Nat` homomorphisms, no builtin bridge at all**. This answers the open question directly: the builtin bridge was never needed; the right helpers are plain length-homomorphisms the conjecturer writes itself.

- **prop_02** (`length(x ++ y) = length(y ++ x)`): `lengthConcatHomo` + `plusComm`.
- **prop_06** (`length(rev(x ++ y)) = length x + length y`): `lengthAppend` + `lengthRev` + `plusSuccRight` (the per-law feedback laddered in `plusSuccRight` on attempt 2 — the conjecturer-feedback loop working).

Each independently confirmed by **both** `aver verify` (27/27, 30/30, zero violations) **and** `aver proof --check` (`universal:true`, `sorries:0`); base task still OPEN (helpers genuinely needed). Re-pinned in `decomposed_tip_tasks_stay_universal` (passes). They replace the unsound bridge entries removed in #573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)