### PR TITLE
codegen(lean): lower *.len builtins as Int, not Nat (type-honest translation)

### DIFF
--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -94,7 +94,12 @@ pub fn emit_builtin_call(
         ByteFromHex => format!("AverByte.fromHex {}", p(&a[0])),
 
         // ---- String ----
-        StringLen => format!("{}.length", p(&a[0])),
+        // `*.len` builtins return Aver `Int` (= ℤ), so their Lean lowering must
+        // produce an `Int`, not a bare Lean `Nat`: dropping to `Nat` silently
+        // changes the type (a spurious `Nat = Nat` proof for a `Nat`-vs-`Int`
+        // law) AND mis-computes `Int` arithmetic (`len x - 5` is ≥0-truncated in
+        // `Nat` but can be negative in `Int`). Wrap each as `Int.ofNat`.
+        StringLen => format!("(Int.ofNat {}.length)", p(&a[0])),
         StringCharAt => format!("String.charAtAv {} {}", p(&a[0]), p(&a[1])),
         StringChars => format!("String.charsAv {}", p(&a[0])),
         StringSlice => format!("String.sliceAv {} {} {}", p(&a[0]), p(&a[1]), p(&a[2])),
@@ -117,7 +122,7 @@ pub fn emit_builtin_call(
         // ---- List ----
         ListLen => {
             let subj = emit_list_length_subject(&args[0], ctx);
-            format!("{}.length", subj)
+            format!("(Int.ofNat {}.length)", subj)
         }
         ListHead => format!("{}.head?", p(&a[0])),
         ListTail => format!("{}.tail?", p(&a[0])),
@@ -152,7 +157,7 @@ pub fn emit_builtin_call(
             p(&a[1]),
             p(&a[2])
         ),
-        VectorLen => format!("{}.size", p(&a[0])),
+        VectorLen => format!("(Int.ofNat {}.size)", p(&a[0])),
         VectorFromList => format!("{}.toArray", p(&a[0])),
         ListFromVector => format!("{}.toList", p(&a[0])),
 
@@ -164,7 +169,7 @@ pub fn emit_builtin_call(
         MapKeys => format!("AverMap.keys {}", p(&a[0])),
         MapValues => format!("AverMap.values {}", p(&a[0])),
         MapEntries => format!("AverMap.entries {}", p(&a[0])),
-        MapLen => format!("AverMap.len {}", p(&a[0])),
+        MapLen => format!("(Int.ofNat (AverMap.len {}))", p(&a[0])),
         MapFromList => format!("AverMap.fromList {}", p(&a[0])),
     };
     Some(result)
@@ -252,6 +257,9 @@ mod tests {
         )
         .expect("List.len should be emitted");
 
-        assert_eq!(emitted, "(([] : List Unit)).length");
+        // `List.len` returns Aver `Int`, so the Lean lowering is `Int.ofNat`-wrapped
+        // (a bare Lean `Nat` would silently change the type); the empty-list subject
+        // still carries its `: List Unit` annotation.
+        assert_eq!(emitted, "(Int.ofNat (([] : List Unit)).length)");
     }
 }

--- a/src/codegen/lean/law_auto/suffix_roundtrip.rs
+++ b/src/codegen/lean/law_auto/suffix_roundtrip.rs
@@ -870,6 +870,14 @@ pub(super) fn emit_string_escape_roundtrip_law(
             proof_lines.push(format!("     {line}"));
         }
     }
+    // The law goal carries `Int.ofNat (…).length` (builtins lower `*.len` as
+    // `Int.ofNat`), while `hpos` is stated via the `(… : Int)` coercion (`↑·` /
+    // `Nat.cast`). These are propositionally equal but NOT defeq, so the implicit
+    // `rfl` after `rw [hpos]` cannot bridge them and the goal falls to a spurious
+    // `sorry`. Normalize `Int.ofNat n → ↑n` so both sides match; `try` keeps it a
+    // no-op for laws where `rw [hpos]` already closed by rfl (no mismatch), so it
+    // can only ADD closures, never demote one. `Int.ofNat_eq_natCast` is core-Lean.
+    proof_lines.push("     try simp only [Int.ofNat_eq_natCast]".to_string());
     proof_lines.push("     done)".to_string());
     proof_lines.push("  | sorry".to_string());
 


### PR DESCRIPTION
Follow-up (b1) to #573/#574. The `*.len` builtins return Aver `Int` (= ℤ) but the Lean lowering emitted a bare Lean `Nat` (`xs.length` / `Array.size` / `AverMap.len`). That silently changed the type at the Aver→Lean boundary:
- it let a `Nat`-vs-`Int` law prove a spurious `Nat = Nat` (the translation-validation hole behind the now-rejected `length => List.len` bridge), and
- it mis-computes `Int` arithmetic on a length (`List.len x - 5` is ≥0-truncated in Lean `Nat` but can be negative in Aver `Int`).

Fix: wrap each as `Int.ofNat (…)` so an Aver-`Int`-returning builtin maps to a Lean `Int` — `List.len`, `String.len`, `Vector.len`, `Map.len`. Makes `universal:true` a faithful certificate; defense-in-depth complement to the checker rejecting type-mismatched laws (#573).

**Zero proof regression** (measured): no-discovery corpus unchanged — isaplanner 46/78, prod 22/74 — because `omega` is cast-aware, so length comparisons/arithmetic (e.g. `prop_68: len(delete n xs) ≤ len xs`) still close through the `Int.ofNat` wrapper. Builtins unit test updated to the Int-wrapped form; `fmt`/`clippy --features wasm,wasip2` clean.

(Deliberately NOT doing "b2", an internal Nat↔List.length recognizer: the user-Peano `Nat` is a benchmark artifact, not Aver-native — Aver's native integer is `Int` — and the sound path via plain Nat homomorphisms already works, so b2 would be optimizing for the benchmark, not the language.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)