### PR TITLE
codegen(lean): lower *.len via (… : Int) coercion matching the prelude + correct Natural's intent

### DIFF
--- a/examples/refinement/natural/natural.av
+++ b/examples/refinement/natural/natural.av
@@ -2,22 +2,21 @@ module Natural
     exposes [fromInt, toInt, add, mul]
     exposes opaque [Natural]
     intent =
-        "Refinement-via-opaque, sound-proof variant. Aver has no"
-        "refinement types and no value-level contracts; instead, an"
-        "opaque record with a validating constructor pins the `Int"
-        ">= 0` invariant inside the defining module."
+        "Refinement-via-opaque: Aver has no refinement types in the"
+        "type system (proof-only is the ceiling), so an opaque record"
+        "with a validating constructor pins the `Int >= 0` invariant"
+        "inside the defining module — the non-negativity fact that"
+        "Aver's single `Int = ℤ` does not itself carry in the type."
         ""
-        "All arithmetic operations return Result<Nat, String> and"
-        "route through fromInt internally. This loses the 'closed"
-        "under +' shorthand (the caller has to thread the Result"
-        "through every call site) but gains soundness against Aver"
-        "Int's i64 wrap-around: `add(Natural(value = i64::MAX),"
-        "Natural(value = 1))` returns Err, not a silent overflow that"
-        "produces a Nat with value < 0. A naive `add(a, b) ="
-        "Natural(value = a.value + b.value)` is fully provable for"
-        "unbounded ints in Lean / Dafny / Z3 but wrong on the Aver"
-        "runtime — the gap between a mathematical proof and the"
-        "VM's actual semantics. This variant closes that gap."
+        "Operations route their raw Int result through `fromInt`, so"
+        "the `>= 0` invariant is maintained by construction. For `add`"
+        "and `mul` the result is always Ok — a sum/product of"
+        "non-negatives is non-negative; the Result shape is the"
+        "general refinement-maintenance pattern (load-bearing only for"
+        "an operation that could leave the non-negatives, e.g. a"
+        "subtraction). NOTE: Aver `Int` is arbitrary-precision (ℤ), so"
+        "there is NO overflow/wrap-around to guard against — the value"
+        "here is purely the `>= 0` refinement, not overflow-safety."
     effects []
 
 record Natural
@@ -44,9 +43,9 @@ verify toInt
     toInt(Natural(value = 5)) => 5
 
 fn add(a: Natural, b: Natural) -> Result<Natural, String>
-    ? "Sum of two Nats — overflow-safe. Routes the raw Int sum"
-      "through fromInt so wrap-around (i64::MAX + 1 = i64::MIN)"
-      "surfaces as Err instead of a Nat with value < 0."
+    ? "Sum of two Nats. Routes the raw Int sum through fromInt to"
+      "maintain the `>= 0` invariant by construction; for two Nats"
+      "the sum is always non-negative, so this is always Ok."
     fromInt(a.value + b.value)
 
 verify add
@@ -61,7 +60,9 @@ verify add law commutative
     add(Natural(value = a), Natural(value = b)) => add(Natural(value = b), Natural(value = a))
 
 fn mul(a: Natural, b: Natural) -> Result<Natural, String>
-    ? "Product of two Nats — overflow-safe via fromInt."
+    ? "Product of two Nats — routes through fromInt to maintain the"
+      "`>= 0` invariant (always Ok: a product of non-negatives is"
+      "non-negative)."
     fromInt(a.value * b.value)
 
 verify mul

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -98,8 +98,14 @@ pub fn emit_builtin_call(
         // produce an `Int`, not a bare Lean `Nat`: dropping to `Nat` silently
         // changes the type (a spurious `Nat = Nat` proof for a `Nat`-vs-`Int`
         // law) AND mis-computes `Int` arithmetic (`len x - 5` is ≥0-truncated in
-        // `Nat` but can be negative in `Int`). Wrap each as `Int.ofNat`.
-        StringLen => format!("(Int.ofNat {}.length)", p(&a[0])),
+        // `Nat` but can be negative in `Int`). Cast to `Int` via the ascription
+        // `(… : Int)`, which elaborates to the `Nat.cast`/`↑` coercion — the SAME
+        // form the hand-written prelude lemmas use (`(s.length : Int)` in
+        // String.slice_full etc.). Using `Int.ofNat` instead would be a distinct,
+        // non-defeq term (`Int.ofNat n` ≠ `↑n` reducibly in Lean 4.31), clashing
+        // with the prelude at any rfl-terminal step; matching `↑` avoids that
+        // class entirely. `omega` is cast-aware, so length arithmetic still closes.
+        StringLen => format!("({}.length : Int)", p(&a[0])),
         StringCharAt => format!("String.charAtAv {} {}", p(&a[0]), p(&a[1])),
         StringChars => format!("String.charsAv {}", p(&a[0])),
         StringSlice => format!("String.sliceAv {} {} {}", p(&a[0]), p(&a[1]), p(&a[2])),
@@ -122,7 +128,7 @@ pub fn emit_builtin_call(
         // ---- List ----
         ListLen => {
             let subj = emit_list_length_subject(&args[0], ctx);
-            format!("(Int.ofNat {}.length)", subj)
+            format!("({}.length : Int)", subj)
         }
         ListHead => format!("{}.head?", p(&a[0])),
         ListTail => format!("{}.tail?", p(&a[0])),
@@ -157,7 +163,7 @@ pub fn emit_builtin_call(
             p(&a[1]),
             p(&a[2])
         ),
-        VectorLen => format!("(Int.ofNat {}.size)", p(&a[0])),
+        VectorLen => format!("({}.size : Int)", p(&a[0])),
         VectorFromList => format!("{}.toArray", p(&a[0])),
         ListFromVector => format!("{}.toList", p(&a[0])),
 
@@ -169,7 +175,7 @@ pub fn emit_builtin_call(
         MapKeys => format!("AverMap.keys {}", p(&a[0])),
         MapValues => format!("AverMap.values {}", p(&a[0])),
         MapEntries => format!("AverMap.entries {}", p(&a[0])),
-        MapLen => format!("(Int.ofNat (AverMap.len {}))", p(&a[0])),
+        MapLen => format!("((AverMap.len {}) : Int)", p(&a[0])),
         MapFromList => format!("AverMap.fromList {}", p(&a[0])),
     };
     Some(result)
@@ -257,9 +263,9 @@ mod tests {
         )
         .expect("List.len should be emitted");
 
-        // `List.len` returns Aver `Int`, so the Lean lowering is `Int.ofNat`-wrapped
-        // (a bare Lean `Nat` would silently change the type); the empty-list subject
-        // still carries its `: List Unit` annotation.
-        assert_eq!(emitted, "(Int.ofNat (([] : List Unit)).length)");
+        // `List.len` returns Aver `Int`, so the Lean lowering casts to `Int` via the
+        // `(… : Int)` ascription (the `↑`/Nat.cast form the prelude uses), not a bare
+        // Lean `Nat`; the empty-list subject still carries its `: List Unit` annotation.
+        assert_eq!(emitted, "((([] : List Unit)).length : Int)");
     }
 }

--- a/src/codegen/lean/law_auto/suffix_roundtrip.rs
+++ b/src/codegen/lean/law_auto/suffix_roundtrip.rs
@@ -870,14 +870,6 @@ pub(super) fn emit_string_escape_roundtrip_law(
             proof_lines.push(format!("     {line}"));
         }
     }
-    // The law goal carries `Int.ofNat (…).length` (builtins lower `*.len` as
-    // `Int.ofNat`), while `hpos` is stated via the `(… : Int)` coercion (`↑·` /
-    // `Nat.cast`). These are propositionally equal but NOT defeq, so the implicit
-    // `rfl` after `rw [hpos]` cannot bridge them and the goal falls to a spurious
-    // `sorry`. Normalize `Int.ofNat n → ↑n` so both sides match; `try` keeps it a
-    // no-op for laws where `rw [hpos]` already closed by rfl (no mismatch), so it
-    // can only ADD closures, never demote one. `Int.ofNat_eq_natCast` is core-Lean.
-    proof_lines.push("     try simp only [Int.ofNat_eq_natCast]".to_string());
     proof_lines.push("     done)".to_string());
     proof_lines.push("  | sorry".to_string());
 


### PR DESCRIPTION
Two cleanups following the B1 / Nat discussion.

**(b) `*.len` lowering → the `↑`/Nat.cast coercion (root fix, supersedes the #575 band-aid).** B1 lowered `*.len` as `Int.ofNat (…)` — type-honest, but a DISTINCT non-defeq term from the `↑`/`Nat.cast` coercion the hand-written prelude lemmas use (`(s.length : Int)`). That inconsistency caused the escape/JSON regression and needed a `simp only [Int.ofNat_eq_natCast]` band-aid in the suffix-roundtrip glue. Fix: emit `({}.length : Int)` so the builtin uses the **same** `↑` form as the prelude → syntactically identical at every join → escape/JSON close by the existing rfl → **band-aid reverted**. `omega` is cast-aware over `↑`, so length arithmetic still closes. This eliminates the Int.ofNat-vs-↑ clash CLASS at the source (the preventive "generalization") rather than spreading a normalization patch.

**(a) `examples/refinement/natural/natural.av` intent corrected.** It justified Result-threading by "i64 wrap-around" — but Int=ℤ has no overflow. Reframed (intent + add/mul docs) as a pure `Int >= 0` non-negativity refinement; add/mul of two Naturals are always Ok. Docs only.

**Verified:** full proof_spec green (escape/JSON/roundtrip + Dafny-json all pass with the band-aid removed); no-discovery corpus unchanged (isaplanner 46/78, prod 22/74); builtins unit test updated to `: Int`; fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)