### PR TITLE
lean: prove String-length additivity universally

### DIFF
--- a/examples/formal/log_line_length.av
+++ b/examples/formal/log_line_length.av
@@ -1,0 +1,27 @@
+module LogLineLength
+    exposes [assembledLength]
+    intent =
+        "A log writer assembles each line from a fixed timestamp prefix and the"
+        "message body, then reserves exactly that many bytes in a fixed-size ring"
+        "buffer before the write. The reservation must equal the sum of the two"
+        "part lengths, or the buffer math under-reserves and truncates a line."
+        ""
+        "The `reservationIsExact` law states that the assembled length is the sum"
+        "of the part lengths — `String.len(a + b) = String.len(a) + String.len(b)`."
+        "It is a pure builtin identity (no user recursion), proved UNIVERSALLY:"
+        "Aver's `String +` is `String.append`, so the length distributes over the"
+        "concatenation for every prefix/body, not just the sampled rows."
+    effects []
+
+fn assembledLength(prefix: String, body: String) -> Int
+    ? "Byte length of the assembled log line (prefix followed by body)."
+    String.len(prefix + body)
+
+verify assembledLength
+    assembledLength("12:00 ", "boot ok") => 13
+    assembledLength("x", "")             => 1
+
+verify assembledLength law reservationIsExact
+    given prefix: String = ["", "12:00 ", "ERROR "]
+    given body: String = ["", "boot ok", "disk full"]
+    String.len(prefix + body) => String.len(prefix) + String.len(body)

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -866,18 +866,29 @@ fn emit_verify_law_forall_auto_proof_inner(
             emit_ring_identity_law(vb, law, ctx, &proof_intro_names)
         })
         .or_else(|| {
-            // IR-pinned `SimpOverPreludeLemmas` — DELIBERATELY the last
-            // rung, after every legacy ad-hoc fallback above: it must
-            // fire only where the chain used to return `None` and the
-            // caller emitted a bare-`sorry` universal. The simp set is
-            // kept minimal (cone + fuel + registry hits + the single
-            // baked-in `Int.add_sub_cancel` rewrite the archived
-            // hand-proofs needed) — a fat set risks a simp LOOP, and a
+            // IR-pinned `SimpOverPreludeLemmas` — after every legacy
+            // ad-hoc fallback above: it must fire only where the chain
+            // used to return `None` and the caller emitted a
+            // bare-`sorry` universal. The simp set is kept minimal
+            // (cone + fuel + registry hits + the single baked-in
+            // `Int.add_sub_cancel` rewrite the archived hand-proofs
+            // needed) — a fat set risks a simp LOOP, and a
             // maxHeartbeats blow-up is a build error `first` cannot
             // catch. `done` forces closure: simp succeeding but
             // leaving a residual goal must fall to the honest `sorry`,
             // never surface as an "unsolved goals" build error.
             emit_simp_over_prelude_lemmas_law(vb, law, ctx, &proof_intro_names)
+        })
+        .or_else(|| {
+            // Pure builtin String-length additivity (`String.len(a + b)
+            // = String.len(a) + String.len(b)`). The law statement is
+            // over builtins alone, so every cone-anchored rung above has
+            // already declined and the strategy stayed `BackendDispatch`
+            // — Dafny's Z3 already discharges the sequence-length axiom,
+            // and this is the Lean-only twin that closes it instead of a
+            // bare `sorry`. Shape-driven (not IR-pinned), so it fires
+            // exactly where the cascade returned `None`.
+            emit_string_length_additive_law(law, &proof_intro_names)
         })
 }
 
@@ -1026,6 +1037,97 @@ fn emit_simp_over_prelude_lemmas_law(
         ),
         replaces_theorem: false,
     })
+}
+
+/// Pure builtin String-length additivity: `String.len(a + b) =
+/// String.len(a) + String.len(b)` (and nested-concat / argument-swapped
+/// variants). The law statement mentions no user fn — its lhs calls
+/// builtins directly — so every cone-anchored rung declines: `Induction`
+/// needs a recursive-ADT given, and `SimpOverPreludeLemmas` anchors its
+/// unfold set on the subject fn appearing in the lhs. The strategy
+/// therefore stays `BackendDispatch`, where Dafny's Z3 already discharges
+/// the law via the sequence-length axiom (`|s + t| = |s| + |t|`) but the
+/// Lean side fell to a bare `sorry`. This Lean-only rung closes it
+/// without touching the IR strategy or the Dafny path.
+///
+/// Mechanism: Aver's `String +` is the custom `HAdd String` instance
+/// (`⟨String.append⟩`); the prelude `rfl` lemma `String.add_eq_append :
+/// s + t = s ++ t` (demand-shipped because the emitted tactic cites it)
+/// rewrites `+ → ++`, the Lean-core `@[simp] String.length_append`
+/// rewrites `(s ++ t).length → s.length + t.length`, and `omega` finishes
+/// over the `(… : Int)` length coercions (it is cast-aware). The honest
+/// `| sorry` floor means a non-additive law this happened to match simply
+/// fails the tactic and degrades to the same caught sorry it had before —
+/// the rung can never close a false law (`simp`/`omega` are sound).
+fn emit_string_length_additive_law(
+    law: &VerifyLaw,
+    proof_intro_names: &[String],
+) -> Option<AutoProof> {
+    if law.when.is_some() {
+        return None;
+    }
+    if !(law_expr_has_string_len_over_concat(&law.lhs)
+        || law_expr_has_string_len_over_concat(&law.rhs))
+    {
+        return None;
+    }
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        proof_lines: intro_then(
+            proof_intro_names,
+            vec![
+                "first | (simp only [String.add_eq_append, String.length_append] <;> omega) | sorry"
+                    .to_string(),
+            ],
+        ),
+        replaces_theorem: false,
+    })
+}
+
+/// True when `e` contains a `String.len(arg)` call whose `arg`
+/// syntactically involves a string `+` — the trigger shape for
+/// [`emit_string_length_additive_law`]. `String.len` takes a `String`, so
+/// an `Add` under it is necessarily the custom `HAdd String` concat (no
+/// type lookup needed). Walks both law sides so an argument-swapped law
+/// (`len(a) + len(b) => len(a + b)`) is recognised too.
+fn law_expr_has_string_len_over_concat(e: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
+    use crate::ast::Expr;
+    let here = matches!(&e.node, Expr::FnCall(callee, args)
+        if args.len() == 1
+            && crate::codegen::common::expr_to_dotted_name(&callee.node).as_deref()
+                == Some("String.len")
+            && expr_contains_add(&args[0]));
+    here || law_expr_children_any(e, law_expr_has_string_len_over_concat)
+}
+
+/// True when `e` contains a `BinOp(Add, …)` at any depth.
+fn expr_contains_add(e: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
+    use crate::ast::{BinOp, Expr};
+    matches!(&e.node, Expr::BinOp(BinOp::Add, _, _)) || law_expr_children_any(e, expr_contains_add)
+}
+
+/// `true` if `f` holds on any direct child sub-expression of `e`. Covers
+/// the compound `Expr` variants a `verify` law's lhs/rhs can hold;
+/// leaf/irrelevant variants short-circuit to `false`.
+fn law_expr_children_any(
+    e: &crate::ast::Spanned<crate::ast::Expr>,
+    f: fn(&crate::ast::Spanned<crate::ast::Expr>) -> bool,
+) -> bool {
+    use crate::ast::Expr;
+    match &e.node {
+        Expr::Attr(o, _) => f(o),
+        Expr::FnCall(c, args) => f(c) || args.iter().any(f),
+        Expr::BinOp(_, l, r) => f(l) || f(r),
+        Expr::Neg(i) | Expr::ErrorProp(i) => f(i),
+        Expr::Match { subject, arms } => f(subject) || arms.iter().any(|a| f(&a.body)),
+        Expr::Constructor(_, Some(inner)) => f(inner),
+        Expr::List(xs) | Expr::Tuple(xs) | Expr::IndependentProduct(xs, _) => xs.iter().any(f),
+        Expr::MapLiteral(kvs) => kvs.iter().any(|(k, v)| f(k) || f(v)),
+        Expr::RecordCreate { fields, .. } => fields.iter().any(|(_, v)| f(v)),
+        Expr::RecordUpdate { base, updates, .. } => f(base) || updates.iter().any(|(_, v)| f(v)),
+        Expr::TailCall(d) => d.args.iter().any(f),
+        _ => false,
+    }
 }
 
 /// Try `simp [fn_names...] ; omega` for laws on Int-domain functions.

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -11,6 +11,21 @@ fn proof_export_builds_fibonacci_when_lake_is_available() {
 }
 
 #[test]
+fn proof_export_builds_log_line_length_when_lake_is_available() {
+    // Pure builtin String-length additivity (`String.len(a + b) =
+    // String.len(a) + String.len(b)`) on a life-like log-line byte-budget
+    // example. The law mentions no user fn, so it stays `BackendDispatch`;
+    // the Lean-only `emit_string_length_additive_law` rung closes it as a
+    // universal. Sorry budget 0 — the rung must fully discharge it (revert
+    // the rung and this example regresses to a caught sorry).
+    assert_proof_builds_with_sorry_budget(
+        "examples/formal/log_line_length.av",
+        "aver-proof-log-line-length",
+        0,
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_fibonacci_when_dafny_is_available() {
     // `goldenApprox(n)` divides `Float.fromInt(fib(n + 1))` by
     // `Float.fromInt(fib(n))`. Float `/` lowers via the `FloatDiv`

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -509,3 +509,75 @@ fn proof_lean_proves_rev_antihomomorphism_kernel_clean() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_proves_string_length_additivity_kernel_clean() {
+    // Pure builtin String-length additivity: `String.len(a + b) =
+    // String.len(a) + String.len(b)`. The law mentions no user fn — its lhs
+    // calls builtins directly — so every cone-anchored rung declines
+    // (Induction needs a recursive-ADT given; SimpOverPreludeLemmas anchors
+    // its unfold set on the subject fn appearing in the lhs) and the IR
+    // strategy stays `BackendDispatch`. Dafny's Z3 already discharges the
+    // sequence-length axiom; the Lean side used to fall to a bare `sorry`.
+    // The shape-driven `emit_string_length_additive_law` rung now closes it:
+    // `String.add_eq_append` (rfl) rewrites the custom `HAdd String` `+` to
+    // `++`, the core `@[simp] String.length_append` distributes the length,
+    // and `omega` finishes over the `(… : Int)` coercions — a GENUINE
+    // universal (`universal:true`), not a bounded `native_decide`. (Revert
+    // the emitter and this law degrades to `universal:false` — the rung is
+    // load-bearing.)
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean string-length-additivity test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-strlen-add-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module StrLenAdd\n    effects []\n\n\
+         fn assembledLength(prefix: String, body: String) -> Int\n    String.len(prefix + body)\n\n\
+         verify assembledLength law reservationIsExact\n    given prefix: String = [\"\", \"12:00 \"]\n    given body: String = [\"\", \"boot ok\"]\n    String.len(prefix + body) => String.len(prefix) + String.len(body)\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-strlen-add-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    // The closer must be the string-length-additive rung, not a sorry.
+    let lean = std::fs::read_to_string(out.join("StrLenAdd.lean")).expect("read StrLenAdd.lean");
+    assert!(
+        lean.contains("simp only [String.add_eq_append, String.length_append] <;> omega"),
+        "the String-length-additive law must emit the `String.add_eq_append` + \
+         `String.length_append` + `omega` rung:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "String.len(a + b) = String.len(a) + String.len(b) must kernel-prove as a \
+         GENUINE universal (passed, 0 sorries, universal:true).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

The Lean backend now proves String-length additivity universally:
`String.len(a + b) = String.len(a) + String.len(b)` (and its nested-concat
and argument-swapped variants).

## Why

This law mentions no user function — its left side calls builtins
directly — so every cone-anchored law strategy declines and the strategy
stays `BackendDispatch`. Dafny's Z3 already discharges it (sequence-length
axiom), but the Lean backend had no emit rung for it and fell to a bare
`sorry`.

## How

A shape-driven emit rung is added as the last `.or_else` in the `law_auto`
cascade, so it fires only where the chain previously returned `None`
(BackendDispatch laws that became a bare-`sorry` universal); it cannot
perturb any existing proof. The tactic is
`simp only [String.add_eq_append, String.length_append] <;> omega` —
`String.add_eq_append` (rfl) rewrites the custom `HAdd String` `+` to
`++`, the Lean-core `@[simp] String.length_append` distributes the length,
and `omega` finishes over the `Int` length coercions.

## Verification

- New kernel-clean test proves the law as a genuine universal
  (`universal:true`, 0 sorries).
- Revert-test: without the rung the law degrades to `universal:false`
  (1 sorry) — the rung is load-bearing.
- Example `examples/formal/log_line_length.av` builds with a 0-sorry budget.
- Full `proof_spec` green; `cargo clippy --features wasm,wasip2` clean.
- Dafny path untouched (already proved this law).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
