### PR TITLE
lean: prove String-concat monoid identities + harden the min/max rung

### DIFF
--- a/examples/formal/string_concat_monoid.av
+++ b/examples/formal/string_concat_monoid.av
@@ -1,0 +1,40 @@
+module StringConcatMonoid
+    exposes [label]
+    intent =
+        "A label is assembled from string segments with `+`. Two structural"
+        "facts the assembler relies on, proved here as UNIVERSAL laws (every"
+        "string, not just sampled rows):"
+        "  - an absent/empty segment changes nothing (`s + \"\" = s`, `\"\" + s = s`),"
+        "    so optional segments can be left empty without a special case;"
+        "  - grouping does not matter (`(a + b) + c = a + (b + c)`), so segments"
+        "    can be concatenated in any nesting."
+        ""
+        "These are the monoid laws of String concatenation. They mention no"
+        "user function — `String +` is the only operation — so they are pure"
+        "builtin identities; Aver proves them in the Lean kernel via the"
+        "`String.append` monoid lemmas."
+    effects []
+
+fn label(a: String, b: String) -> String
+    ? "Join two label segments."
+    a + b
+
+verify label
+    label("user", "/42") => "user/42"
+    label("", "root")    => "root"
+
+verify label law rightIdentity
+    given a: String = ["", "user", "/42"]
+    given b: String = ["", "x", "yz"]
+    a + "" => a
+
+verify label law leftIdentity
+    given a: String = ["", "user", "/42"]
+    given b: String = ["", "x", "yz"]
+    "" + a => a
+
+verify label law associative
+    given a: String = ["", "user", "/42"]
+    given b: String = ["", "x", "yz"]
+    given c: String = ["", "q", "rs"]
+    (a + b) + c => a + (b + c)

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -890,6 +890,15 @@ fn emit_verify_law_forall_auto_proof_inner(
             // exactly where the cascade returned `None`.
             emit_string_length_additive_law(law, &proof_intro_names)
         })
+        .or_else(|| {
+            // Pure builtin String-concat monoid identities (`s + "" = s`,
+            // `"" + s = s`, `(a + b) + c = a + (b + c)`) — the
+            // no-`String.len`-wrapper sibling of the rung above. Same
+            // class (bare String equality, no user fn → BackendDispatch →
+            // Dafny proves, Lean used to sorry); last-in-cascade and
+            // shape-driven, so it cannot perturb any existing proof.
+            emit_string_append_monoid_law(law, &proof_intro_names)
+        })
 }
 
 /// Fixed core AC-ring lemma package for the `RingIdentity` rung —
@@ -1130,6 +1139,74 @@ fn law_expr_children_any(
     }
 }
 
+/// Pure builtin String-concat monoid identities: `s + "" = s`, `"" + s =
+/// s`, and `(a + b) + c = a + (b + c)`. Like [`emit_string_length_additive_law`]
+/// these mention no user fn (the law is a bare String equality), so every
+/// cone-anchored rung declines and the strategy stays `BackendDispatch` —
+/// Dafny's Z3 discharges them, the Lean side fell to a bare `sorry`. This
+/// is the no-`String.len`-wrapper sibling of that rung.
+///
+/// One unified tactic closes all three shapes: `String.add_eq_append`
+/// (prelude rfl lemma, demand-shipped because the tactic cites it)
+/// rewrites the custom `HAdd String` `+` to `++`, then the Lean-core
+/// `String.append_empty` / `String.empty_append` / `String.append_assoc`
+/// finish. The `| sorry` floor keeps it sound — a falsely-matched
+/// non-identity (e.g. an `Int` reassociation that slipped past the earlier
+/// arithmetic rungs) just fails the tactic and degrades to the same caught
+/// sorry, never a false close (`simp` is kernel-checked).
+fn emit_string_append_monoid_law(
+    law: &VerifyLaw,
+    proof_intro_names: &[String],
+) -> Option<AutoProof> {
+    if law.when.is_some() {
+        return None;
+    }
+    let fires = law_expr_has_empty_string_concat(&law.lhs)
+        || law_expr_has_empty_string_concat(&law.rhs)
+        || is_concat_reassociation(&law.lhs, &law.rhs);
+    if !fires {
+        return None;
+    }
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        proof_lines: intro_then(
+            proof_intro_names,
+            vec![
+                "first | (simp only [String.add_eq_append, String.append_empty, \
+                 String.empty_append, String.append_assoc]) | sorry"
+                    .to_string(),
+            ],
+        ),
+        replaces_theorem: false,
+    })
+}
+
+/// `e` contains a `BinOp(Add, x, y)` where `x` or `y` is the empty String
+/// literal `""` — the unambiguous String-`+` signal (`""` only types as a
+/// String, so the `+` is the custom `HAdd String`). Triggers the
+/// identity shapes of [`emit_string_append_monoid_law`].
+fn law_expr_has_empty_string_concat(e: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
+    use crate::ast::{BinOp, Expr, Literal};
+    let is_empty_str = |s: &crate::ast::Spanned<Expr>| matches!(&s.node, Expr::Literal(Literal::Str(t)) if t.is_empty());
+    let here =
+        matches!(&e.node, Expr::BinOp(BinOp::Add, l, r) if is_empty_str(l) || is_empty_str(r));
+    here || law_expr_children_any(e, law_expr_has_empty_string_concat)
+}
+
+/// `lhs` is `(_ + _) + _` and `rhs` is `_ + (_ + _)` — a `+` reassociation
+/// (the associativity shape). Operand types are not inspected: an `Int`
+/// reassociation is closed by the earlier arithmetic rungs and never
+/// reaches this last-in-cascade rung, so matching the shape alone is safe.
+fn is_concat_reassociation(
+    lhs: &crate::ast::Spanned<crate::ast::Expr>,
+    rhs: &crate::ast::Spanned<crate::ast::Expr>,
+) -> bool {
+    use crate::ast::{BinOp, Expr};
+    let left_nested = matches!(&lhs.node, Expr::BinOp(BinOp::Add, l, _) if matches!(l.node, Expr::BinOp(BinOp::Add, _, _)));
+    let right_nested = matches!(&rhs.node, Expr::BinOp(BinOp::Add, _, r) if matches!(r.node, Expr::BinOp(BinOp::Add, _, _)));
+    left_nested && right_nested
+}
+
 /// Try `simp [fn_names...] ; omega` for laws on Int-domain functions.
 ///
 /// Works when the function is a non-recursive match on Int args
@@ -1233,9 +1310,20 @@ fn emit_simp_omega_from_ir(
                 .cloned()
                 .chain(["Int.max_def".to_string(), "Int.min_def".to_string()])
                 .collect();
+            // `<;> omega` alone closes the unfolded min/max if-nest —
+            // `omega` case-splits the `Int.min_def`/`Int.max_def`
+            // conditionals itself, which the legacy `(try split) <;>
+            // simp_all` chain did NOT for a 3-way `min` nest: it left
+            // unsolved goals and, with no `first | … | sorry` wrapper,
+            // hard-failed the WHOLE module build (poisoning every other
+            // law in the file, not just this one). Try the clean `omega`
+            // form first, keep the legacy chain as a fallback so no
+            // min/max law that closed before can regress, and floor on
+            // `sorry` so a still-open case degrades to a caught sorry
+            // instead of an uncatchable build error.
+            let l = lemmas.join(", ");
             format!(
-                "simp only [{}] <;> (try split) <;> simp_all <;> omega",
-                lemmas.join(", ")
+                "first | (simp only [{l}] <;> omega) | (simp only [{l}] <;> (try split) <;> simp_all <;> omega) | sorry"
             )
         } else if has_when {
             format!("simp_all [{}] <;> omega", lean_names.join(", "))

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -26,6 +26,20 @@ fn proof_export_builds_log_line_length_when_lake_is_available() {
 }
 
 #[test]
+fn proof_export_builds_string_concat_monoid_when_lake_is_available() {
+    // Pure builtin String-concat monoid identities (`s + "" = s`,
+    // `"" + s = s`, `(a + b) + c = a + (b + c)`). The shape-driven
+    // `emit_string_append_monoid_law` rung closes all three as universals;
+    // Dafny's Z3 already proves them. Sorry budget 0 — revert the rung and
+    // each law regresses to a bare sorry.
+    assert_proof_builds_with_sorry_budget(
+        "examples/formal/string_concat_monoid.av",
+        "aver-proof-string-concat-monoid",
+        0,
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_fibonacci_when_dafny_is_available() {
     // `goldenApprox(n)` divides `Float.fromInt(fib(n + 1))` by
     // `Float.fromInt(fib(n))`. Float `/` lowers via the `FloatDiv`

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -581,3 +581,132 @@ fn proof_lean_proves_string_length_additivity_kernel_clean() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_proves_string_concat_monoid_kernel_clean() {
+    // Pure builtin String-concat monoid identities — `s + "" = s`,
+    // `"" + s = s`, `(a + b) + c = a + (b + c)`. Same class as the
+    // String-length-additivity rung but WITHOUT a `String.len` wrapper, so
+    // a separate shape-driven rung (`emit_string_append_monoid_law`) closes
+    // them: `String.add_eq_append` rewrites the custom `HAdd String` `+` to
+    // `++`, then the Lean-core `String.append_empty`/`empty_append`/
+    // `append_assoc` finish. Each currently fell to a bare `sorry`
+    // (BackendDispatch; Dafny's Z3 already proves them).
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean string-concat-monoid test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-strmonoid-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module StrMonoid\n    effects []\n\n\
+         fn cat2(a: String, b: String) -> String\n    a + b\n\n\
+         verify cat2 law rightId\n    given a: String = [\"\", \"x\"]\n    given b: String = [\"\", \"y\"]\n    a + \"\" => a\n\n\
+         verify cat2 law leftId\n    given a: String = [\"\", \"x\"]\n    given b: String = [\"\", \"y\"]\n    \"\" + a => a\n\n\
+         verify cat2 law assoc\n    given a: String = [\"\", \"x\"]\n    given b: String = [\"\", \"y\"]\n    (a + b) + a => a + (b + a)\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-strmonoid-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean = std::fs::read_to_string(out.join("StrMonoid.lean")).expect("read StrMonoid.lean");
+    assert!(
+        lean.contains(
+            "String.add_eq_append, String.append_empty, String.empty_append, String.append_assoc"
+        ),
+        "the String-concat-monoid laws must emit the append-monoid simp rung:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "all three String-concat monoid identities must kernel-prove as GENUINE \
+         universals (passed, 0 sorries, universal:true).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn proof_lean_min_associativity_closes_without_build_error() {
+    // The `Int.min`/`Int.max` LinearArithmetic rung used to emit a bare
+    // `simp only [..., Int.min_def, Int.max_def] <;> (try split) <;>
+    // simp_all <;> omega` with NO `first | … | sorry` wrapper. For a 3-way
+    // `min` nest that chain left unsolved goals and hard-failed the WHOLE
+    // module's Lean build (not just this law). The rung now tries a clean
+    // `<;> omega` (omega case-splits the unfolded ifs itself) first, keeps
+    // the legacy chain as a non-regressing fallback, and floors on `sorry`.
+    // So min-associativity now closes as a universal AND a failing min/max
+    // case can never crash the build. (Revert the rung change and this
+    // task becomes `universal: no` via a Lean build error.)
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean min-associativity test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-minassoc-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module MinAssoc\n    effects []\n\n\
+         fn minOf(a: Int, b: Int) -> Int\n    Int.min(a, b)\n\n\
+         verify minOf law associative\n    given a: Int = [0, 1, -3]\n    given b: Int = [0, 1, -3]\n    given c: Int = [0, 1, -3]\n    minOf(minOf(a, b), c) => minOf(a, minOf(b, c))\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-minassoc-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "Int.min 3-way associativity must kernel-prove as a universal (passed, 0 \
+         sorries, universal:true) — and crucially must NOT hard-fail the Lean build.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
Stacks on #577 (base branch `lean-string-length-additivity`) — the String-concat monoid rung is added right after the String-length-additivity rung from that PR. Retarget to `main` once #577 merges.

## What

Two more pure-builtin algebraic-identity universals now close in the Lean backend:

1. **String-concat monoid** — `s + "" = s`, `"" + s = s`, `(a + b) + c = a + (b + c)`.
2. **Int.min/Int.max rung hardening** — `Int.min` 3-way associativity now closes, and no min/max law can hard-fail the build.

## Why

Both classes are discharged by Dafny's Z3 today but the Lean backend either fell to a bare `sorry` (the String-concat identities mention no user function, so they stay `BackendDispatch`) or — worse — produced an uncatchable Lean build error.

## How

- **String monoid**: a shape-driven rung (`emit_string_append_monoid_law`), the no-`String.len`-wrapper sibling of the String-length-additivity rung, added last in the `law_auto` cascade so it fires only where the chain returned `None`. Closes all three with `simp only [String.add_eq_append, String.append_empty, String.empty_append, String.append_assoc]`. Cannot perturb any existing proof.
- **min/max**: the min/max `LinearArithmetic` rung had no `first | ... | sorry` wrapper, so a non-closing 3-way `min` nest hard-failed the whole module's build. It now tries a clean `<;> omega` first (omega case-splits the unfolded `Int.min_def`/`Int.max_def` conditionals itself), keeps the legacy `(try split) <;> simp_all <;> omega` chain as a non-regressing fallback, and floors on `sorry`.

## Verification

- New kernel-clean tests: the three String-concat monoid identities and `Int.min` 3-way associativity each prove as genuine universals (`universal:true`, 0 sorries).
- `examples/formal/string_concat_monoid.av` builds with a 0-sorry budget.
- Full `proof_spec` green (185 passed; the lone failure is the pre-existing flaky Dafny `json` test, which passes in isolation and is untouched by this Lean-only change).
- `cargo clippy --features wasm,wasip2 -- -D warnings` clean.
- Dafny path untouched (already proved these).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
