### PR TITLE
proof-corpus: add verified prop_28 decomposition (revflat = qrevflat x [])

### DIFF
--- a/proof-corpus/decomposed/README.md
+++ b/proof-corpus/decomposed/README.md
@@ -62,6 +62,7 @@ All were OPEN even to Z3/Dafny.
 | `handwritten/qrev_rev.av` | `fastRev x = rev x` | OPEN (frontier) | accumulator-generalization: `qrev(xs,acc) = rev(xs)++acc` |
 | `isaplanner/prop_19.av` | `len(drop n xs) = len xs − n` | OPEN (frontier) | the generalized `len∘drop` law over `n` |
 | `prod/prop_27.av` | `rev x = qrev x []` | OPEN (frontier) | `qrev` spec `qrev(x,y) = rev(x)++y` |
+| `prod/prop_28.av` | `revflat x = qrevflat x []` | OPEN (frontier) | append↔concat bridge + append right-identity/associativity + the `qrevflat` accumulator spec `qrevflat(x,y) = append(revflat x, y)` |
 | `prod/prop_29.av` | `rev(qrev x []) = x` | OPEN (frontier) | qrev-spec + rev-append homomorphism + rev involution |
 | `prod/prop_30.av` | `rev(rev x ++ []) = x` | OPEN (frontier) | rev-snoc + rev involution |
 | `prod/prop_31.av` | `qrev(qrev x []) [] = x` | OPEN (frontier) | generalized `qrev` "master" law `qrev(qrev(x,y),[]) = qrev(y,x)` |

--- a/proof-corpus/decomposed/prod/prop_28.av
+++ b/proof-corpus/decomposed/prod/prop_28.av
@@ -1,0 +1,48 @@
+module Prop28
+    intent =
+        "TIP prod prop_28: revflat x = qrevflat x []."
+    effects []
+
+fn append(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+fn rev(x: List<Int>) -> List<Int>
+    match x
+        [] -> []
+        [y, ..xs] -> append(rev(xs), [y])
+
+fn qrevflat(x: List<List<Int>>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [xs, ..xss] -> qrevflat(xss, append(rev(xs), y))
+
+fn revflat(x: List<List<Int>>) -> List<Int>
+    match x
+        [] -> []
+        [xs, ..xss] -> append(revflat(xss), rev(xs))
+
+verify append law appendConcatBridge
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[], [9], [8, 7]]
+    append(x, y) => List.concat(x, y)
+
+verify append law appendRightId
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    append(x, []) => x
+
+verify append law appendAssoc
+    given a: List<Int> = [[], [1], [1, 2]]
+    given b: List<Int> = [[], [3], [4, 5]]
+    given c: List<Int> = [[], [6], [7, 8]]
+    append(append(a, b), c) => append(a, append(b, c))
+
+verify qrevflat law qrevflatSpec
+    given x: List<List<Int>> = [[], [[1]], [[1, 2], [3]], [[1], [2, 3]]]
+    given y: List<Int> = [[], [9], [8, 7]]
+    qrevflat(x, y) => append(revflat(x), y)
+
+verify revflat law revflatQrevflat
+    given x: List<List<Int>> = [[], [[1]], [[1, 2], [3]], [[1], [2, 3]]]
+    revflat(x) => qrevflat(x, [])

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -318,6 +318,7 @@ fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
         "proof-corpus/decomposed/handwritten/qrev_rev.av",
         "proof-corpus/decomposed/isaplanner/prop_19.av",
         "proof-corpus/decomposed/prod/prop_27.av",
+        "proof-corpus/decomposed/prod/prop_28.av",
         "proof-corpus/decomposed/prod/prop_29.av",
         "proof-corpus/decomposed/prod/prop_30.av",
         "proof-corpus/decomposed/prod/prop_31.av",


### PR DESCRIPTION
## What

Adds a verified helper-law decomposition for TIP `prod/prop_28` — `revflat x = qrevflat x []` — to `proof-corpus/decomposed/prod/`.

## Why

The bare task is OPEN to the unaided engine **and** to Z3/Dafny. It closes once the proof is decomposed into canonical helper laws.

## How

Four helper laws, each kernel-clean (`universal: true`, 0 sorries):
- `append(x, y) = List.concat(x, y)` (bridge to the builtin),
- `append(x, []) = x` (right identity),
- `append(append(a, b), c) = append(a, append(b, c))` (associativity),
- `qrevflat(x, y) = append(revflat x, y)` (the accumulator spec),

from which the target `revflat x = qrevflat x []` follows. The decomposition was produced by the helper-law loop and independently re-verified from scratch.

## Verification

- `aver proof --check` reports `universal: true`, 0 sorries on the whole file (re-confirmed on current `main`).
- Registered in the decomposed-corpus regression sweep (`decomposed_tip_tasks_stay_universal_when_lake_is_available`) and the README contents table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
