### PR TITLE
lean: prove empty-map facts (Map.get/has/len on the empty map)

### DIFF
--- a/examples/formal/empty_map_facts.av
+++ b/examples/formal/empty_map_facts.av
@@ -1,0 +1,41 @@
+module EmptyMapFacts
+    exposes [lookup, contains, size]
+    intent =
+        "A freshly-created registry (an empty Map) has no entries. Three facts a"
+        "caller relies on before populating it, proved here as UNIVERSAL laws:"
+        "  - a lookup misses for every key (`Map.get(empty, k) = None`),"
+        "  - membership is false for every key (`Map.has(empty, k) = false`),"
+        "  - the size is zero (`Map.len(empty) = 0`)."
+        ""
+        "These are pure builtin facts about the empty map — no user recursion."
+        "Dafny's Z3 discharges them directly; the Lean backend proves them by"
+        "reducing the `AverMap` accessor on the empty entry list."
+    effects []
+
+fn emptyRegistry() -> Map<String, Int>
+    ? "A fresh, empty registry."
+    {}
+
+fn lookup(k: String) -> Option<Int>
+    ? "Look a key up in the fresh registry."
+    Map.get(emptyRegistry(), k)
+
+fn contains(k: String) -> Bool
+    ? "Is a key present in the fresh registry?"
+    Map.has(emptyRegistry(), k)
+
+fn size(ignored: Int) -> Int
+    ? "Number of entries in the fresh registry (always zero)."
+    Map.len(emptyRegistry())
+
+verify lookup law emptyHasNoEntries
+    given k: String = ["a", "x", "key"]
+    Map.get(emptyRegistry(), k) => Option.None
+
+verify contains law emptyContainsNothing
+    given k: String = ["a", "x", "key"]
+    Map.has(emptyRegistry(), k) => false
+
+verify size law emptyHasZeroSize
+    given ignored: Int = [0, 1]
+    Map.len(emptyRegistry()) => 0

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -858,6 +858,19 @@ fn emit_verify_law_forall_auto_proof_inner(
             })
         })
         .or_else(|| {
+            // Pure builtin empty-map facts (`Map.get(empty, k) = None`,
+            // `Map.has(empty, k) = false`, `Map.len(empty) = 0`). Placed
+            // BEFORE the prelude rung: such a law is stated through its
+            // subject fn (`getE(k) => None`), so `SimpOverPreludeLemmas`
+            // claims it but its minimal `simp [cone, Int.add_sub_cancel]`
+            // can't reduce the `AverMap.*` accessor and parks it on a sorry.
+            // This rung's bounded `simp only [cone, AverMap.*, []-lemmas]`
+            // closes it. The recognizer is empty-map-precise (the accessor's
+            // map arg must be a `{}` literal or a const fn returning `{}`),
+            // so it never steals a Map law the prelude rung could close.
+            emit_map_empty_fact_law(vb, law, ctx, &proof_intro_names)
+        })
+        .or_else(|| {
             // IR-pinned `RingIdentity` — rendered (like the prelude
             // rung below) after every legacy ad-hoc fallback, so it
             // fires only where the chain used to fall through. The
@@ -1205,6 +1218,130 @@ fn is_concat_reassociation(
     let left_nested = matches!(&lhs.node, Expr::BinOp(BinOp::Add, l, _) if matches!(l.node, Expr::BinOp(BinOp::Add, _, _)));
     let right_nested = matches!(&rhs.node, Expr::BinOp(BinOp::Add, _, r) if matches!(r.node, Expr::BinOp(BinOp::Add, _, _)));
     left_nested && right_nested
+}
+
+/// Pure builtin empty-map facts: `Map.get(empty, k) = None`,
+/// `Map.has(empty, k) = false`, `Map.len(empty) = 0`. The subject fn body
+/// reduces to a `Map.get`/`has`/`len` over a provably empty map; Dafny's Z3
+/// discharges these, but the Lean generic grind rung can't reduce the
+/// `AverMap.*` accessor on `[]` and parks the law on a caught sorry.
+///
+/// This rung unfolds the law's cone (subject fn + the empty-map source fn)
+/// together with the accessor defs and the `[]` lemmas, which collapses the
+/// goal: `AverMap.get [] k = none`, `AverMap.has [] k = false` (via
+/// `List.any_nil`), `((AverMap.len []) : Int) = 0` (via `List.length_nil` +
+/// `Int.ofNat_zero`). One unified `simp only` set closes any of the three;
+/// the `| sorry` floor keeps it sound — a Map law whose argument is NOT
+/// empty simply fails the `; done` and degrades to the same caught sorry it
+/// had before. Last-in-cascade and shape-driven, so it cannot perturb an
+/// existing proof (a Map law another rung already owns is handled earlier).
+fn emit_map_empty_fact_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    proof_intro_names: &[String],
+) -> Option<AutoProof> {
+    if law.when.is_some() || !subject_fn_accesses_empty_map(vb, ctx) {
+        return None;
+    }
+    let mut simp_set: Vec<String> = shared::law_simp_defs(ctx, vb, law).into_iter().collect();
+    simp_set.extend(
+        [
+            "AverMap.get",
+            "AverMap.has",
+            "AverMap.len",
+            "List.any_nil",
+            "List.length_nil",
+            "Int.ofNat_zero",
+        ]
+        .iter()
+        .map(|s| s.to_string()),
+    );
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        proof_lines: intro_then(
+            proof_intro_names,
+            vec![format!(
+                "first | (simp only [{}] ; done) | sorry",
+                simp_set.join(", ")
+            )],
+        ),
+        replaces_theorem: false,
+    })
+}
+
+/// True when the law's subject fn body accesses a PROVABLY EMPTY map via
+/// `Map.get`/`Map.has`/`Map.len` — the precise trigger for
+/// [`emit_map_empty_fact_law`]. Requiring emptiness (not just any Map
+/// accessor) keeps the rung from stealing a non-empty Map law the prelude
+/// rung might close.
+fn subject_fn_accesses_empty_map(vb: &VerifyBlock, ctx: &CodegenContext) -> bool {
+    let Some(fd) = ctx.fn_def_by_name(&vb.fn_name, None) else {
+        return false;
+    };
+    fd.body.stmts().iter().any(|stmt| {
+        let e = match stmt {
+            crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => e,
+        };
+        expr_accesses_empty_map(e, ctx)
+    })
+}
+
+/// `e` contains a `Map.get`/`Map.has`/`Map.len` call whose map argument is a
+/// provably empty map (see [`expr_is_empty_map`]), at any depth.
+fn expr_accesses_empty_map(
+    e: &crate::ast::Spanned<crate::ast::Expr>,
+    ctx: &CodegenContext,
+) -> bool {
+    use crate::ast::Expr;
+    if let Expr::FnCall(callee, args) = &e.node
+        && !args.is_empty()
+        && matches!(
+            crate::codegen::common::expr_to_dotted_name(&callee.node).as_deref(),
+            Some("Map.get") | Some("Map.has") | Some("Map.len")
+        )
+        && expr_is_empty_map(&args[0], ctx)
+    {
+        return true;
+    }
+    // Recurse into the compound `Expr` variants a law subject's body holds.
+    match &e.node {
+        Expr::Attr(o, _) => expr_accesses_empty_map(o, ctx),
+        Expr::FnCall(c, args) => {
+            expr_accesses_empty_map(c, ctx) || args.iter().any(|a| expr_accesses_empty_map(a, ctx))
+        }
+        Expr::BinOp(_, l, r) => expr_accesses_empty_map(l, ctx) || expr_accesses_empty_map(r, ctx),
+        Expr::Neg(i) | Expr::ErrorProp(i) => expr_accesses_empty_map(i, ctx),
+        Expr::Match { subject, arms } => {
+            expr_accesses_empty_map(subject, ctx)
+                || arms.iter().any(|a| expr_accesses_empty_map(&a.body, ctx))
+        }
+        Expr::Constructor(_, Some(inner)) => expr_accesses_empty_map(inner, ctx),
+        Expr::List(xs) | Expr::Tuple(xs) | Expr::IndependentProduct(xs, _) => {
+            xs.iter().any(|x| expr_accesses_empty_map(x, ctx))
+        }
+        _ => false,
+    }
+}
+
+/// A provably empty map: the `{}` literal, or a zero-arg call to a user fn
+/// whose body is exactly `{}`.
+fn expr_is_empty_map(e: &crate::ast::Spanned<crate::ast::Expr>, ctx: &CodegenContext) -> bool {
+    use crate::ast::{Expr, Stmt};
+    match &e.node {
+        Expr::MapLiteral(entries) => entries.is_empty(),
+        Expr::FnCall(callee, args) if args.is_empty() => {
+            crate::codegen::common::expr_to_dotted_name(&callee.node)
+                .and_then(|n| ctx.fn_def_by_name(&n, None))
+                .is_some_and(|fd| {
+                    let stmts = fd.body.stmts();
+                    stmts.len() == 1
+                        && matches!(&stmts[0],
+                            Stmt::Expr(b) if matches!(&b.node, Expr::MapLiteral(es) if es.is_empty()))
+                })
+        }
+        _ => false,
+    }
 }
 
 /// Try `simp [fn_names...] ; omega` for laws on Int-domain functions.

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -40,6 +40,20 @@ fn proof_export_builds_string_concat_monoid_when_lake_is_available() {
 }
 
 #[test]
+fn proof_export_builds_empty_map_facts_when_lake_is_available() {
+    // Pure builtin empty-map facts (`Map.get(empty, k) = None`,
+    // `Map.has(empty, k) = false`, `Map.len(empty) = 0`). The empty-map-precise
+    // `emit_map_empty_fact_law` rung closes all three as universals; Dafny's Z3
+    // already proves them. Sorry budget 0 — revert the rung and each regresses
+    // to a caught sorry.
+    assert_proof_builds_with_sorry_budget(
+        "examples/formal/empty_map_facts.av",
+        "aver-proof-empty-map-facts",
+        0,
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_fibonacci_when_dafny_is_available() {
     // `goldenApprox(n)` divides `Float.fromInt(fib(n + 1))` by
     // `Float.fromInt(fib(n))`. Float `/` lowers via the `FloatDiv`

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -771,3 +771,72 @@ fn proof_lean_int_abs_lowers_int_honest_so_nesting_builds() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_proves_empty_map_facts_kernel_clean() {
+    // Pure builtin empty-map facts — `Map.get(empty, k) = None`,
+    // `Map.has(empty, k) = false`, `Map.len(empty) = 0`. Each is stated
+    // through its subject fn (`lookup(k) => None`), so `SimpOverPreludeLemmas`
+    // claims it but its minimal `simp [cone, Int.add_sub_cancel]` can't reduce
+    // the `AverMap.*` accessor and parks it on a sorry. The empty-map-precise
+    // `emit_map_empty_fact_law` rung (before the prelude rung) closes it with
+    // a bounded `simp only [cone, AverMap.get/has/len, []-lemmas]`. Dafny's Z3
+    // already proves these.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean empty-map-facts test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-emptymap-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module EmptyMap\n    effects []\n\n\
+         fn emptyM() -> Map<String, Int>\n    {}\n\n\
+         fn lookup(k: String) -> Option<Int>\n    Map.get(emptyM(), k)\n\n\
+         fn contains(k: String) -> Bool\n    Map.has(emptyM(), k)\n\n\
+         fn size(ignored: Int) -> Int\n    Map.len(emptyM())\n\n\
+         verify lookup law getEmptyNone\n    given k: String = [\"a\", \"b\"]\n    Map.get(emptyM(), k) => Option.None\n\n\
+         verify contains law hasEmptyFalse\n    given k: String = [\"a\", \"b\"]\n    Map.has(emptyM(), k) => false\n\n\
+         verify size law lenEmptyZero\n    given ignored: Int = [0, 1]\n    Map.len(emptyM()) => 0\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-emptymap-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean = std::fs::read_to_string(out.join("EmptyMap.lean")).expect("read EmptyMap.lean");
+    assert!(
+        lean.contains("AverMap.get, AverMap.has, AverMap.len"),
+        "the empty-map-fact rung must emit the AverMap accessor simp set:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "all three empty-map facts (get/has/len) must kernel-prove as GENUINE \
+         universals (passed, 0 sorries, universal:true).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

The Lean backend now proves the pure builtin empty-map facts universally: `Map.get(empty, k) = None`, `Map.has(empty, k) = false`, `Map.len(empty) = 0`.

## Why

Each is stated through its subject fn (`lookup(k) => None`), so `SimpOverPreludeLemmas` claimed it — but its minimal `simp [cone, Int.add_sub_cancel]` set can't reduce the `AverMap.*` accessor on the empty entry list, so the law parked on a caught sorry. Dafny's Z3 discharges all three.

## How

A new shape-driven rung `emit_map_empty_fact_law`, placed **before** the prelude rung so it claims these laws first. It is empty-map-precise: it fires only when the subject fn accesses a provably empty map (a `{}` literal, or a const fn whose body is `{}`) via `Map.get`/`has`/`len` — so it never steals a non-empty Map law the prelude rung could close. It closes the goal with a **bounded** `simp only [cone, AverMap.get, AverMap.has, AverMap.len, List.any_nil, List.length_nil, Int.ofNat_zero]` (bounded — no full-`simp` loop risk), with a `| sorry` floor.

## Verification

- New kernel-clean test: all three empty-map facts prove as genuine universals (`universal:true`, 0 sorries).
- `examples/formal/empty_map_facts.av` builds with a 0-sorry budget.
- Full `proof_spec` green (188 passed, 0 failed) — the Map rung sits before the prelude rung, and no existing Map/prelude law regressed.
- `cargo clippy --features wasm,wasip2 -- -D warnings` clean; `cargo fmt --check` clean.
- Dafny path untouched (already proved these).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
