### PR TITLE
lean: close Bool-valued Int comparison identities (and stop them crashing the build)

### DIFF
--- a/examples/formal/int_comparison_laws.av
+++ b/examples/formal/int_comparison_laws.av
@@ -1,0 +1,46 @@
+module IntComparisonLaws
+    exposes [sameKey, notBelow, comparable]
+    intent =
+        "Bool-valued integer comparison predicates a scheduler/sorter relies on,"
+        "with their defining algebraic laws proved UNIVERSALLY (every pair of"
+        "ints, not just sampled rows):"
+        "  - equality is symmetric (`sameKey a b = sameKey b a`),"
+        "  - `not (a < b)` is exactly `a >= b` (`notBelow a b = atLeast a b`),"
+        "  - `<=` is total (`(a <= b) || (b <= a) = true`)."
+        ""
+        "These are pure builtin facts about Int comparison — no user recursion."
+        "Dafny's Z3 discharges them; the Lean backend normalises the Bool"
+        "comparison wrappers (`==`/decide/`||`) to a linear-order goal `omega`"
+        "decides."
+    effects []
+
+fn sameKey(a: Int, b: Int) -> Bool
+    ? "Do two keys compare equal?"
+    a == b
+
+fn atLeast(a: Int, b: Int) -> Bool
+    ? "Is a at least b?"
+    a >= b
+
+fn notBelow(a: Int, b: Int) -> Bool
+    ? "Is a not strictly below b?"
+    Bool.not(a < b)
+
+fn comparable(a: Int, b: Int) -> Bool
+    ? "Are a and b comparable under `<=` (always true — `<=` is total)?"
+    Bool.or(a <= b, b <= a)
+
+verify sameKey law symmetric
+    given a: Int = [0, 1, -2, 5]
+    given b: Int = [0, 1, -2, 5]
+    sameKey(a, b) => sameKey(b, a)
+
+verify notBelow law isAtLeast
+    given a: Int = [0, 1, -2, 5]
+    given b: Int = [0, 1, -2, 5]
+    notBelow(a, b) => atLeast(a, b)
+
+verify comparable law totalOrder
+    given a: Int = [0, 1, -2, 5]
+    given b: Int = [0, 1, -2, 5]
+    comparable(a, b) => true

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -1353,6 +1353,26 @@ fn expr_is_empty_map(e: &crate::ast::Spanned<crate::ast::Expr>, ctx: &CodegenCon
 /// emit body of the legacy `emit_simp_omega_law` (kept as fallback
 /// for `BackendDispatch`) but sources `unfold_fns` / `wrapper_
 /// return` / `smart_guard` from `ProofIR.law_theorems[*].strategy`.
+/// Core (no-Mathlib) lemma package that normalises a Bool-valued Int
+/// comparison identity so `omega` can finish: `Bool.beq_comm` orders the
+/// `==`, `Bool.or_eq_true`/`Bool.and_eq_true`/`decide_eq_true_eq` strip the
+/// `= true` / `&&` / `||` Bool wrappers to the underlying decidable props,
+/// `decide_eq_decide` reduces `decide p = decide q` to `p ↔ q`, `← decide_not`
+/// turns `!decide p` into `decide ¬p`, and `ge_iff_le`/`gt_iff_lt` rewrite
+/// `≥`/`>` to `≤`/`<` — leaving a pure linear-order goal `omega` decides.
+/// Used only as a `first`-alternative after the sign-split in the
+/// `wrapper_return` arm of [`emit_simp_omega_from_ir`].
+const COMPARISON_NORMALIZERS: &[&str] = &[
+    "Bool.beq_comm",
+    "Bool.or_eq_true",
+    "Bool.and_eq_true",
+    "decide_eq_decide",
+    "decide_eq_true_eq",
+    "← decide_not",
+    "ge_iff_le",
+    "gt_iff_lt",
+];
+
 #[allow(clippy::too_many_arguments)]
 fn emit_simp_omega_from_ir(
     unfold_fns: &[String],
@@ -1412,11 +1432,29 @@ fn emit_simp_omega_from_ir(
             .chain(["Int.add_comm".to_string(), "Int.mul_comm".to_string()])
             .collect();
         let simp_args = simp_hyps.join(", ");
+        // The sign-split `by_cases … <;> simp [Int.add_comm, Int.mul_comm]`
+        // closes wrapper-return arithmetic identities, but a Bool-valued
+        // COMPARISON identity (`(a == b) = (b == a)`, `!(a < b) = (a >= b)`,
+        // `(a <= b) || (b <= a) = true`, `(a < b) = (b > a)`) leaves it with
+        // "simp made no progress" — and with no `first | … | sorry` wrapper
+        // that hard-failed the whole module build. After the `unfold`, try the
+        // sign-split FIRST (so every law that closed before is byte-identical),
+        // then a comparison-normalising `simp only [<COMPARISON_NORMALIZERS>]
+        // <;> omega` (which closes the Bool-comparison shapes Dafny's Z3 already
+        // proves), and floor on `sorry` so anything still open degrades to a
+        // caught sorry instead of an uncatchable build error. The comparison
+        // rung is inert when the sign-split already closed (it is never
+        // reached), and `simp`/`omega` are sound, so it can never close a false
+        // law.
+        let cmp = format!(
+            "simp only [{}] <;> omega",
+            COMPARISON_NORMALIZERS.join(", ")
+        );
         intro_then(
             intro_names,
             vec![
                 format!("unfold {}", lean_names.join(" ")),
-                format!("{by_cases_chain} <;> simp [{simp_args}]"),
+                format!("first | ({by_cases_chain} <;> simp [{simp_args}]) | ({cmp}) | sorry"),
             ],
         )
     } else {

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -54,6 +54,20 @@ fn proof_export_builds_empty_map_facts_when_lake_is_available() {
 }
 
 #[test]
+fn proof_export_builds_int_comparison_laws_when_lake_is_available() {
+    // Bool-valued Int comparison identities (equality symmetry, `!(a < b) =
+    // (a >= b)`, totality of `<=`). The `wrapper_return` arm's sign-split now
+    // falls through to a comparison normaliser + `sorry` floor, closing these
+    // as universals; Dafny's Z3 already proves them. Sorry budget 0 — revert
+    // and each hard-fails the Lean build.
+    assert_proof_builds_with_sorry_budget(
+        "examples/formal/int_comparison_laws.av",
+        "aver-proof-int-comparison-laws",
+        0,
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_fibonacci_when_dafny_is_available() {
     // `goldenApprox(n)` divides `Float.fromInt(fib(n + 1))` by
     // `Float.fromInt(fib(n))`. Float `/` lowers via the `FloatDiv`

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -840,3 +840,69 @@ fn proof_lean_proves_empty_map_facts_kernel_clean() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_proves_int_comparison_identities_kernel_clean() {
+    // Bool-valued Int comparison identities — equality symmetry
+    // (`(a == b) = (b == a)`), `!(a < b) = (a >= b)`, totality of `<=`
+    // (`(a <= b) || (b <= a) = true`). These route to the `wrapper_return`
+    // arm of `emit_simp_omega_from_ir`, whose sign-split `by_cases <;> simp`
+    // left them at "simp made no progress" — and with no `first | … | sorry`
+    // wrapper that hard-failed the whole module build. The arm now tries the
+    // sign-split first (unchanged for arithmetic laws), then a comparison
+    // normaliser (`COMPARISON_NORMALIZERS` + `omega`), then a `sorry` floor.
+    // (Revert and these become a Lean build error, not even a caught sorry.)
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean int-comparison test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-intcmp-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module IntCmp\n    effects []\n\n\
+         fn sameKey(a: Int, b: Int) -> Bool\n    a == b\n\n\
+         fn atLeast(a: Int, b: Int) -> Bool\n    a >= b\n\n\
+         fn notBelow(a: Int, b: Int) -> Bool\n    Bool.not(a < b)\n\n\
+         fn comparable(a: Int, b: Int) -> Bool\n    Bool.or(a <= b, b <= a)\n\n\
+         verify sameKey law symmetric\n    given a: Int = [0, 1, -2]\n    given b: Int = [0, 1, -2]\n    sameKey(a, b) => sameKey(b, a)\n\n\
+         verify notBelow law isAtLeast\n    given a: Int = [0, 1, -2]\n    given b: Int = [0, 1, -2]\n    notBelow(a, b) => atLeast(a, b)\n\n\
+         verify comparable law totalOrder\n    given a: Int = [0, 1, -2]\n    given b: Int = [0, 1, -2]\n    comparable(a, b) => true\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-intcmp-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "the three Int comparison identities must kernel-prove as GENUINE \
+         universals (passed, 0 sorries, universal:true) — and must NOT hard-fail \
+         the Lean build.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

The Lean backend now proves Bool-valued Int comparison identities universally — equality symmetry (`(a == b) = (b == a)`), `!(a < b) = (a >= b)`, totality of `<=` (`(a <= b) || (b <= a) = true`), and `(a < b) = (b > a)`.

## Why

These route to the `wrapper_return` arm of `emit_simp_omega_from_ir`, whose sign-split `by_cases … <;> simp [Int.add_comm, Int.mul_comm]` is designed for arithmetic and left a Bool-comparison goal at "simp made no progress". Worse, that arm had no `first | … | sorry` wrapper, so the failure was an **uncatchable Lean build error** that poisoned the whole module. Dafny's Z3 already proves all of them.

## How

After the `unfold`, the arm now does `first | (sign-split) | (comparison normaliser) | sorry`:
- the **sign-split runs first**, so every arithmetic `wrapper_return` law that closed before is byte-identical (no regression);
- the **comparison normaliser** `simp only [COMPARISON_NORMALIZERS] <;> omega` (`Bool.beq_comm`, `Bool.or_eq_true`, `Bool.and_eq_true`, `decide_eq_decide`, `decide_eq_true_eq`, `← decide_not`, `ge_iff_le`, `gt_iff_lt`) strips the Bool/`decide` wrappers to a linear-order goal `omega` decides;
- the **`sorry` floor** turns anything still open into a caught sorry, never a build error.

The comparison rung is inert once the sign-split has closed (it is never reached), and `simp`/`omega` are sound, so it can never close a false law.

## Verification

- New kernel-clean test: the three comparison identities prove as genuine universals (`universal:true`, 0 sorries).
- `examples/formal/int_comparison_laws.av` builds with a 0-sorry budget.
- Full `proof_spec` green (191 passed, 0 failed) — the modified arm is shared by all `wrapper_return` LinearArithmetic laws, and none regressed.
- `cargo clippy --features wasm,wasip2 -- -D warnings` clean; `cargo fmt --check` clean.
- Dafny path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
