### PR TITLE
lean: close the Int.abs identity laws (idempotence, multiplicativity, non-negativity)

### DIFF
--- a/examples/formal/int_abs_laws.av
+++ b/examples/formal/int_abs_laws.av
@@ -1,0 +1,36 @@
+module IntAbsLaws
+    exposes [magnitude, scaledMagnitude]
+    intent =
+        "`Int.abs` is a magnitude: its three defining algebraic laws, proved"
+        "UNIVERSALLY (every int, not just sampled rows):"
+        "  - idempotence — taking the magnitude of a magnitude changes nothing"
+        "    (`Int.abs(Int.abs x) = Int.abs x`),"
+        "  - multiplicativity — magnitude distributes over a product"
+        "    (`Int.abs(x*y) = Int.abs x * Int.abs y`),"
+        "  - non-negativity — a magnitude is never negative (`Int.abs x >= 0`)."
+        ""
+        "These are pure builtin facts. `Int.abs : Int -> Int` lowers Int-honestly"
+        "to `((x : Int).natAbs : Int)`, so the Lean proofs are about the Nat.cast"
+        "of a natAbs; Dafny's Z3 discharges them too."
+    effects []
+
+fn magnitude(x: Int) -> Int
+    ? "The magnitude (absolute value) of x."
+    Int.abs(x)
+
+fn scaledMagnitude(x: Int, y: Int) -> Int
+    ? "The magnitude of a product."
+    Int.abs(x * y)
+
+verify magnitude law idempotent
+    given x: Int = [0, 3, -5, 7]
+    Int.abs(Int.abs(x)) => Int.abs(x)
+
+verify magnitude law nonNegative
+    given x: Int = [0, 3, -5, 7]
+    Int.abs(x) >= 0 => true
+
+verify scaledMagnitude law multiplicative
+    given x: Int = [0, 3, -5]
+    given y: Int = [0, 2, -4]
+    Int.abs(x * y) => Int.abs(x) * Int.abs(y)

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -793,6 +793,18 @@ fn emit_verify_law_forall_auto_proof_inner(
             None
         })
         .or_else(|| {
+            // Pure builtin `Int.abs` identities (`Int.abs(Int.abs x) =
+            // Int.abs x`, `Int.abs(x*y) = Int.abs x * Int.abs y`,
+            // `Int.abs x >= 0 = true`). Placed BEFORE the LinearArithmetic
+            // rung: idempotence/non-negativity otherwise route there and its
+            // `simp only [cone] <;> omega` can't see through the `Int.natAbs`
+            // cast (and, with no sorry floor, hard-fails the build), while the
+            // `*`-distribution law falls through to a bare sorry. Dafny's Z3
+            // proves all three. Shape-driven on `Int.abs` in the law sides, so
+            // it leaves every non-abs LinearArithmetic law untouched.
+            emit_int_abs_identity_law(law, &proof_intro_names)
+        })
+        .or_else(|| {
             // IR-pinned SimpOmegaUnfold takes precedence over the
             // legacy detection here — the lowerer already ran the
             // same shape check and captured `unfold_fns`,
@@ -1218,6 +1230,45 @@ fn is_concat_reassociation(
     let left_nested = matches!(&lhs.node, Expr::BinOp(BinOp::Add, l, _) if matches!(l.node, Expr::BinOp(BinOp::Add, _, _)));
     let right_nested = matches!(&rhs.node, Expr::BinOp(BinOp::Add, _, r) if matches!(r.node, Expr::BinOp(BinOp::Add, _, _)));
     left_nested && right_nested
+}
+
+/// Pure builtin `Int.abs` identities — idempotence (`Int.abs(Int.abs x) =
+/// Int.abs x`), multiplicativity (`Int.abs(x*y) = Int.abs x * Int.abs y`),
+/// and non-negativity (`Int.abs x >= 0 = true`). `Int.abs` lowers to the
+/// Int-honest `((… : Int).natAbs : Int)`, so these are facts about the
+/// `Nat.cast` of a `natAbs`; the cone is already inlined in the goal, so no
+/// def unfold is needed. One tactic closes all three: `Int.natAbs_natCast`
+/// collapses `(↑n).natAbs = n` (idempotence), `Int.natAbs_mul` +
+/// `Int.natCast_mul` push the product through the cast (multiplicativity),
+/// and the full-`simp` fallback discharges the Bool `… >= 0 = true` wrapper
+/// (non-negativity). The `| sorry` floor keeps it sound — `simp`/`omega` are
+/// kernel-checked, so it can never close a false law.
+fn emit_int_abs_identity_law(law: &VerifyLaw, proof_intro_names: &[String]) -> Option<AutoProof> {
+    if law.when.is_some() || !(law_expr_calls_int_abs(&law.lhs) || law_expr_calls_int_abs(&law.rhs))
+    {
+        return None;
+    }
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        proof_lines: intro_then(
+            proof_intro_names,
+            vec![
+                "first | (simp only [Int.natAbs_natCast, Int.natAbs_mul, Int.natCast_mul] <;> omega) \
+                 | (simp [Int.natAbs_natCast, Int.natAbs_mul, Int.natCast_mul]) | sorry"
+                    .to_string(),
+            ],
+        ),
+        replaces_theorem: false,
+    })
+}
+
+/// `e` contains an `Int.abs(...)` builtin call at any depth — the trigger
+/// for [`emit_int_abs_identity_law`].
+fn law_expr_calls_int_abs(e: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
+    use crate::ast::Expr;
+    let here = matches!(&e.node, Expr::FnCall(callee, _)
+        if crate::codegen::common::expr_to_dotted_name(&callee.node).as_deref() == Some("Int.abs"));
+    here || law_expr_children_any(e, law_expr_calls_int_abs)
 }
 
 /// Pure builtin empty-map facts: `Map.get(empty, k) = None`,

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -68,6 +68,20 @@ fn proof_export_builds_int_comparison_laws_when_lake_is_available() {
 }
 
 #[test]
+fn proof_export_builds_int_abs_laws_when_lake_is_available() {
+    // Pure builtin `Int.abs` identities (idempotence, multiplicativity,
+    // non-negativity). The `emit_int_abs_identity_law` rung closes all three
+    // as universals via the natAbs/cast lemmas; Dafny's Z3 already proves
+    // them. Sorry budget 0 — revert and idempotence/non-neg hard-fail the
+    // build and multiplicativity sorries.
+    assert_proof_builds_with_sorry_budget(
+        "examples/formal/int_abs_laws.av",
+        "aver-proof-int-abs-laws",
+        0,
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_fibonacci_when_dafny_is_available() {
     // `goldenApprox(n)` divides `Float.fromInt(fib(n + 1))` by
     // `Float.fromInt(fib(n))`. Float `/` lowers via the `FloatDiv`

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -906,3 +906,72 @@ fn proof_lean_proves_int_comparison_identities_kernel_clean() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_proves_int_abs_identities_kernel_clean() {
+    // Pure builtin `Int.abs` identities — idempotence
+    // (`Int.abs(Int.abs x) = Int.abs x`), multiplicativity
+    // (`Int.abs(x*y) = Int.abs x * Int.abs y`), and non-negativity
+    // (`Int.abs x >= 0 = true`). `Int.abs` lowers Int-honestly to
+    // `((… : Int).natAbs : Int)`; the `emit_int_abs_identity_law` rung
+    // (before the LinearArithmetic rung) closes all three with
+    // `Int.natAbs_natCast` / `Int.natAbs_mul` / `Int.natCast_mul`
+    // (+ a full-`simp` fallback for the Bool `>= 0` wrapper), `sorry`-floored.
+    // Before this rung they hard-failed the build (idempotence/non-neg) or
+    // sorried (multiplicativity). Dafny's Z3 proves all three.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean int-abs-identities test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-absid-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module AbsId\n    effects []\n\n\
+         fn magnitude(x: Int) -> Int\n    Int.abs(x)\n\n\
+         fn scaledMagnitude(x: Int, y: Int) -> Int\n    Int.abs(x * y)\n\n\
+         verify magnitude law idempotent\n    given x: Int = [0, 3, -5]\n    Int.abs(Int.abs(x)) => Int.abs(x)\n\n\
+         verify magnitude law nonNegative\n    given x: Int = [0, 3, -5]\n    Int.abs(x) >= 0 => true\n\n\
+         verify scaledMagnitude law multiplicative\n    given x: Int = [0, 3, -5]\n    given y: Int = [0, 2, -4]\n    Int.abs(x * y) => Int.abs(x) * Int.abs(y)\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-absid-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean = std::fs::read_to_string(out.join("AbsId.lean")).expect("read AbsId.lean");
+    assert!(
+        lean.contains("Int.natAbs_natCast, Int.natAbs_mul, Int.natCast_mul"),
+        "the Int.abs identity rung must emit the natAbs/cast lemma set:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "the three Int.abs identities must kernel-prove as GENUINE universals \
+         (passed, 0 sorries, universal:true).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

The Lean backend now proves the three `Int.abs` identity laws universally — idempotence (`Int.abs(Int.abs x) = Int.abs x`), multiplicativity (`Int.abs(x*y) = Int.abs x * Int.abs y`), and non-negativity (`Int.abs x >= 0 = true`).

## Why

Follow-up to the Int-honest `Int.abs` lowering (#580, which fixed nesting/type-honesty but did not close these laws). On Lean they did not close: idempotence and non-negativity route to the LinearArithmetic plain arm, whose `simp only [cone] <;> omega` can't see through the `Int.natAbs` cast and — with no `sorry` floor — hard-failed the build; multiplicativity fell through to a bare `sorry`. Dafny's Z3 proves all three.

## How

A shape-driven rung `emit_int_abs_identity_law`, placed **before** the LinearArithmetic rung so it claims all three (`Int.abs` lowers Int-honestly to `((… : Int).natAbs : Int)`, so the goal is already inlined — no cone unfold needed). Recognised by `Int.abs` appearing in the law sides, so it leaves every non-abs LinearArithmetic law untouched. One tactic closes all three:

```
first | (simp only [Int.natAbs_natCast, Int.natAbs_mul, Int.natCast_mul] <;> omega)
      | (simp [Int.natAbs_natCast, Int.natAbs_mul, Int.natCast_mul])
      | sorry
```

`Int.natAbs_natCast` collapses `(↑n).natAbs = n` (idempotence), `Int.natAbs_mul` + `Int.natCast_mul` push the product through the cast (multiplicativity), the full-`simp` fallback discharges the Bool `>= 0 = true` wrapper (non-negativity), and the `sorry` floor keeps it sound (`simp`/`omega` are kernel-checked, so it can never close a false law).

## Verification

- New kernel-clean test: all three identities prove as genuine universals (`universal:true`, 0 sorries; `#print axioms = [propext]` in isolation).
- `examples/formal/int_abs_laws.av` builds with a 0-sorry budget.
- Full `proof_spec` green (193 passed, 0 failed) — the rung is before LinearArithmetic and no non-abs law regressed.
- `cargo clippy --features wasm,wasip2 -- -D warnings` clean; `cargo fmt --check` clean.
- Dafny path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
