### PR TITLE
lean: prove Map.len(Map.set m k v) >= 1 (set yields a non-empty map)

### DIFF
--- a/examples/formal/map_set_nonempty.av
+++ b/examples/formal/map_set_nonempty.av
@@ -1,0 +1,23 @@
+module MapSetNonEmpty
+    exposes [sizeAfterInsert]
+    intent =
+        "Inserting into a registry (a Map) always leaves it non-empty — there is"
+        "at least the entry just written. Proved UNIVERSALLY: for every map, key,"
+        "and value, `Map.len(Map.set(reg, k, v)) >= 1`."
+        ""
+        "Unlike the empty-map facts, this is not a definitional unfold: `set`"
+        "recurses over the entry list, so the proof needs induction (its result"
+        "is a non-empty list whether the key was new or already present). The"
+        "Lean side carries that induction in a hand-proved prelude lemma"
+        "(`AverMap.len_set_ge_one`); Dafny's Z3 discharges it directly."
+    effects []
+
+fn sizeAfterInsert(reg: Map<String, Int>, k: String, v: Int) -> Int
+    ? "Number of entries after inserting (k, v) into reg."
+    Map.len(Map.set(reg, k, v))
+
+verify sizeAfterInsert law nonEmptyAfterInsert
+    given reg: Map<String, Int> = [{}, {"a" => 1}, {"a" => 1, "b" => 2}]
+    given k: String = ["x", "a"]
+    given v: Int = [7]
+    Map.len(Map.set(reg, k, v)) >= 1 => true

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -883,6 +883,15 @@ fn emit_verify_law_forall_auto_proof_inner(
             emit_map_empty_fact_law(vb, law, ctx, &proof_intro_names)
         })
         .or_else(|| {
+            // `Map.len(Map.set(m, k, v)) >= 1 => true` — `set` always yields a
+            // non-empty map. Unlike the empty-map facts this needs real
+            // induction (`set.go` length is `>= 1`), so it leans on the
+            // hand-proved prelude lemma `AverMap.len_set_ge_one` (stated in the
+            // exact lowered goal shape); the rung just `exact`s it. Shape-driven
+            // on the `Map.len(Map.set(…)) >= 1` lhs, so it claims nothing else.
+            emit_map_len_set_positive_law(law, &proof_intro_names)
+        })
+        .or_else(|| {
             // IR-pinned `RingIdentity` — rendered (like the prelude
             // rung below) after every legacy ad-hoc fallback, so it
             // fires only where the chain used to fall through. The
@@ -1393,6 +1402,48 @@ fn expr_is_empty_map(e: &crate::ast::Spanned<crate::ast::Expr>, ctx: &CodegenCon
         }
         _ => false,
     }
+}
+
+/// `Map.len(Map.set(m, k, v)) >= 1 => true` — `set` always yields a
+/// non-empty map. Unlike the empty-map facts this is not a definitional
+/// unfold: it needs induction on `m` (`set.go` length is `>= 1`). The
+/// hand-proved prelude lemma `AverMap.len_set_ge_one` carries that induction
+/// and is stated in the exact lowered goal shape, so the rung discharges the
+/// law with a bare `exact AverMap.len_set_ge_one _ _ _` (the placeholders
+/// unify the map/key/value from the goal). Citing the lemma demand-ships it.
+/// The `| sorry` floor keeps it sound.
+fn emit_map_len_set_positive_law(
+    law: &VerifyLaw,
+    proof_intro_names: &[String],
+) -> Option<AutoProof> {
+    if law.when.is_some() || !law_is_map_len_set_ge_one(law) {
+        return None;
+    }
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        proof_lines: intro_then(
+            proof_intro_names,
+            vec!["first | (exact AverMap.len_set_ge_one _ _ _) | sorry".to_string()],
+        ),
+        replaces_theorem: false,
+    })
+}
+
+/// True for a law whose lhs is `Map.len(Map.set(_, _, _)) >= 1` — the trigger
+/// for [`emit_map_len_set_positive_law`].
+fn law_is_map_len_set_ge_one(law: &VerifyLaw) -> bool {
+    use crate::ast::{BinOp, Expr, Literal};
+    let Expr::BinOp(BinOp::Gte, left, right) = &law.lhs.node else {
+        return false;
+    };
+    let is_one = matches!(&right.node, Expr::Literal(Literal::Int(1)));
+    let len_over_set = matches!(&left.node, Expr::FnCall(callee, args)
+        if crate::codegen::common::expr_to_dotted_name(&callee.node).as_deref() == Some("Map.len")
+            && args.len() == 1
+            && matches!(&args[0].node, Expr::FnCall(set_callee, _)
+                if crate::codegen::common::expr_to_dotted_name(&set_callee.node).as_deref()
+                    == Some("Map.set")));
+    is_one && len_over_set
 }
 
 /// Try `simp [fn_names...] ; omega` for laws on Int-domain functions.

--- a/src/codegen/lean/prelude.rs
+++ b/src/codegen/lean/prelude.rs
@@ -310,6 +310,31 @@ theorem has_set_self [DecidableEq α] (m : List (α × β)) (k : α) (v : β) :
     AverMap.has (AverMap.set m k v) k = true := by
   simpa [AverMap.has, AverMap.set] using any_set_go_self k v m"#;
 
+/// `Map.len(Map.set(m, k, v)) >= 1` — `set` always yields a non-empty map.
+/// `set.go` either appends `[(k, v)]` (the `nil` base) or rebuilds a `cons`
+/// (both branches of the `cons` step), so its length is `≥ 1` for every `m` —
+/// proved by induction on `m`. The public `len_set_ge_one` is stated in the
+/// exact lowered shape of the law goal (`((AverMap.len … : Int) >= 1) = true`)
+/// so the emitter can discharge it with a bare `exact AverMap.len_set_ge_one
+/// _ _ _`. This is the one empty-vs-non-empty Map fact that needs real
+/// induction rather than a definitional unfold.
+const AVER_MAP_PRELUDE_LEN_SET_GE_ONE: &str = r#"private theorem set_go_len_pos [DecidableEq α] (k : α) (v : β) :
+    ∀ (m : List (α × β)), 1 ≤ (AverMap.set.go k v m).length := by
+  intro m
+  induction m with
+  | nil =>
+      simp [AverMap.set.go]
+  | cons p tl ih =>
+      simp only [AverMap.set.go]
+      split <;> simp
+
+theorem len_set_ge_one [DecidableEq α] (m : List (α × β)) (k : α) (v : β) :
+    (((AverMap.len (AverMap.set m k v)) : Int) >= 1) = true := by
+  have h : 1 ≤ (AverMap.set m k v).length := by
+    simpa [AverMap.set] using set_go_len_pos k v m
+  simp only [AverMap.len]
+  exact eq_true (by omega)"#;
+
 const AVER_MAP_PRELUDE_GET_SET_SELF: &str = r#"private theorem get_set_go_self [DecidableEq α] (k : α) (v : β) :
     ∀ (m : List (α × β)), AverMap.get (AverMap.set.go k v m) k = some v := by
   intro m
@@ -1019,6 +1044,7 @@ fn generate_map_prelude(body: &str, include_all_helpers: bool) -> String {
     let mut parts = vec![AVER_MAP_PRELUDE_BASE.to_string()];
 
     let needs_has_set_self = include_all_helpers || body.contains("AverMap.has_set_self");
+    let needs_len_set_ge_one = include_all_helpers || body.contains("AverMap.len_set_ge_one");
     let needs_get_set_self = include_all_helpers || body.contains("AverMap.get_set_self");
     let needs_get_set_other = include_all_helpers
         || body.contains("AverMap.get_set_other")
@@ -1031,6 +1057,9 @@ fn generate_map_prelude(body: &str, include_all_helpers: bool) -> String {
 
     if needs_has_set_self {
         parts.push(AVER_MAP_PRELUDE_HAS_SET_SELF.to_string());
+    }
+    if needs_len_set_ge_one {
+        parts.push(AVER_MAP_PRELUDE_LEN_SET_GE_ONE.to_string());
     }
     if needs_get_set_self {
         parts.push(AVER_MAP_PRELUDE_GET_SET_SELF.to_string());

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -82,6 +82,19 @@ fn proof_export_builds_int_abs_laws_when_lake_is_available() {
 }
 
 #[test]
+fn proof_export_builds_map_set_nonempty_when_lake_is_available() {
+    // `Map.len(Map.set(m, k, v)) >= 1` — set yields a non-empty map. Needs
+    // induction (the hand-proved prelude lemma `AverMap.len_set_ge_one`); the
+    // `emit_map_len_set_positive_law` rung discharges it. Sorry budget 0 —
+    // revert and the law regresses to a bare sorry. Dafny's Z3 proves it.
+    assert_proof_builds_with_sorry_budget(
+        "examples/formal/map_set_nonempty.av",
+        "aver-proof-map-set-nonempty",
+        0,
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_fibonacci_when_dafny_is_available() {
     // `goldenApprox(n)` divides `Float.fromInt(fib(n + 1))` by
     // `Float.fromInt(fib(n))`. Float `/` lowers via the `FloatDiv`

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -975,3 +975,67 @@ fn proof_lean_proves_int_abs_identities_kernel_clean() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_proves_map_set_nonempty_kernel_clean() {
+    // `Map.len(Map.set(m, k, v)) >= 1 => true` — `set` always yields a
+    // non-empty map. Unlike the empty-map facts this needs real induction
+    // (`set.go` length is `>= 1`), carried by the hand-proved prelude lemma
+    // `AverMap.len_set_ge_one` (stated in the exact lowered goal shape and
+    // demand-shipped). The `emit_map_len_set_positive_law` rung discharges the
+    // law with `exact AverMap.len_set_ge_one _ _ _`. Was a bare sorry before.
+    // Dafny's Z3 proves it.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean map-set-nonempty test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-mapsetne-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module MapSetNE\n    effects []\n\n\
+         fn after(reg: Map<String, Int>, k: String, v: Int) -> Int\n    Map.len(Map.set(reg, k, v))\n\n\
+         verify after law nonEmpty\n    given reg: Map<String, Int> = [{}, {\"a\" => 1}]\n    given k: String = [\"x\", \"a\"]\n    given v: Int = [7]\n    Map.len(Map.set(reg, k, v)) >= 1 => true\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-mapsetne-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean = std::fs::read_to_string(out.join("MapSetNE.lean")).expect("read MapSetNE.lean");
+    assert!(
+        lean.contains("AverMap.len_set_ge_one"),
+        "the map-set-nonempty rung must cite the inductive prelude lemma \
+         `AverMap.len_set_ge_one`:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "Map.len(Map.set m k v) >= 1 must kernel-prove as a GENUINE universal \
+         (passed, 0 sorries, universal:true) via the inductive prelude lemma.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

The Lean backend now proves `Map.len(Map.set(m, k, v)) >= 1` universally — inserting into a map always leaves it non-empty.

## Why

The last pure-builtin Map fact from the gap sweep. Unlike the empty-map facts (`get/has/len` on `{}`, which are definitional unfolds), `set` recurses over the entry list, so this needs **real induction**: the result is a non-empty list whether the key was new or already present. Dafny's Z3 discharges it directly; the Lean side fell to a bare `sorry`.

## How

A hand-proved prelude lemma `AverMap.len_set_ge_one`, stated in the **exact lowered goal shape** (`((AverMap.len (AverMap.set …) : Int) >= 1) = true`), backed by an inductive helper `set_go_len_pos` (`1 <= (set.go k v m).length`, by induction on `m` — the nil base appends `[(k,v)]`, both cons branches rebuild a cons). It is demand-shipped (only when cited), like the existing `AverMap.has_set_self` / `get_set_self` lemmas.

The shape-driven rung `emit_map_len_set_positive_law` (recognising a `Map.len(Map.set(…)) >= 1` lhs) discharges the law with a bare `exact AverMap.len_set_ge_one _ _ _` (the placeholders unify the map/key/value from the goal), `| sorry`-floored.

## Verification

- New kernel-clean test: the law proves as a genuine universal (`universal:true`, 0 sorries) via the inductive lemma.
- `examples/formal/map_set_nonempty.av` builds with a 0-sorry budget.
- Full `proof_spec` green (195 passed, 0 failed).
- `cargo clippy --features wasm,wasip2 -- -D warnings` clean; `cargo fmt --check` clean.
- Dafny path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
