### PR TITLE
site: drop eyebrow kickers and two-tone hero headings

### DIFF
--- a/tools/website/grandfather.html
+++ b/tools/website/grandfather.html
@@ -18,14 +18,6 @@
         .grandfather-page { max-width: 48rem; margin: 0 auto; padding: 0 1.5rem; }
 
         .grandfather-hero { padding: 3rem 0 1.2rem; }
-        .grandfather-hero .eyebrow {
-            color: var(--accent);
-            font-family: var(--font-mono);
-            font-size: 0.78rem;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            margin-bottom: 0.7rem;
-        }
         .grandfather-hero h1 {
             font-size: clamp(2rem, 4vw, 2.8rem);
             font-weight: 790;
@@ -34,7 +26,6 @@
             margin-bottom: 0.95rem;
             max-width: 18ch;
         }
-        .grandfather-hero h1 .accent { color: var(--accent); opacity: 0.92; }
         .grandfather-hero .subhead {
             color: var(--muted);
             font-size: 1.125rem;
@@ -247,8 +238,7 @@
 <main class="grandfather-page">
 
     <header class="grandfather-hero">
-        <div class="eyebrow">Notes</div>
-        <h1>Finding Aver's <span class="accent">grandfather</span></h1>
+        <h1>Finding Aver's grandfather</h1>
         <div class="tldr-box">
             <div class="tldr-label">TL;DR</div>
             <p class="subhead">I found a more than 30-year-old grandfather of my language and when I tried to implement its core paper in Aver just for fun - I've found a bug hiding in the paper's presentation for 30 years.</p>

--- a/tools/website/index.html
+++ b/tools/website/index.html
@@ -49,7 +49,7 @@
 <section class="hero">
     <div class="hero-text">
         <p class="hero-thesis">Code is cheap to generate. Expensive to trust.</p>
-        <h1>The AI-native language where code <span>explains itself.</span></h1>
+        <h1>The AI-native language where code explains itself.</h1>
         <p class="hero-sub">Aver is a language where every function carries its intent, side effects are visible in the type system, and tests are executable specs next to the code. The optimization target is the reviewer, not the generator.</p>
         <div class="hero-meta">
             <span class="hero-meta-item">Three backends: VM, Rust, standalone WASM.</span>

--- a/tools/website/oracle.html
+++ b/tools/website/oracle.html
@@ -11,14 +11,6 @@
         .oracle-page { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
 
         .oracle-hero { padding: 3rem 0 1.5rem; }
-        .oracle-hero .eyebrow {
-            color: var(--accent);
-            font-family: var(--font-mono);
-            font-size: 0.78rem;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            margin-bottom: 0.7rem;
-        }
         .oracle-hero h1 {
             font-size: clamp(2rem, 4vw, 3rem);
             font-weight: 790;
@@ -27,7 +19,6 @@
             margin-bottom: 0.95rem;
             max-width: 18ch;
         }
-        .oracle-hero h1 .accent { color: var(--accent); opacity: 0.92; }
         .oracle-hero .subhead {
             color: var(--muted);
             font-size: 1.05rem;
@@ -178,8 +169,7 @@
 <main class="oracle-page">
 
     <header class="oracle-hero">
-        <div class="eyebrow">Oracle &middot; the randomness paradox</div>
-        <h1>One <code>verify</code> block. Four tools. <span class="accent">Two verdicts.</span></h1>
+        <h1>One <code>verify</code> block. Four tools. Two verdicts.</h1>
         <p class="subhead">A 30-line example: <code>aver verify</code> passes, <code>aver verify --hostile</code> fails, and both proof backends reject it on identical source &mdash; tracing the path from sampled effects through adversarial profiles to universal proof.</p>
     </header>
 

--- a/tools/website/style.css
+++ b/tools/website/style.css
@@ -115,11 +115,6 @@ body { overflow-x: hidden; }
     max-width: 13.5ch;
 }
 
-.hero h1 span {
-    color: var(--accent);
-    opacity: 0.92;
-}
-
 .hero-thesis {
     display: block;
     font-size: 0.92rem;


### PR DESCRIPTION
Cosmetic de-AI-ification of the marketing pages — no wording changes.

- Remove the small uppercase mono "eyebrow" kicker labels above the **oracle** and **grandfather** hero headings (and their `.eyebrow` CSS).
- Unwrap the accent-coloured `<span>` inside all three hero `<h1>`s (index, oracle, grandfather) so each headline renders in a single colour instead of the two-tone accent-word treatment. Drop the now-dead hero-`h1`-accent / `.hero h1 span` CSS.

Headline wording is unchanged. averlang.dev auto-deploys from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)