### PR TITLE
proof-corpus: two new Method decompositions (prod prop_22, prop_23)

### DIFF
--- a/proof-corpus/decomposed/prod/prop_22.av
+++ b/proof-corpus/decomposed/prod/prop_22.av
@@ -1,0 +1,50 @@
+module Prop22
+    intent =
+        "TIP prod prop_22: even(length(x ++ y)) = even(length(y ++ x))."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(xs: List<Int>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(length(ys))
+
+fn even(x: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(y) -> match y
+            Nat.Z -> false
+            Nat.S(z) -> even(z)
+
+fn append(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+verify plus law plusComm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, y) => plus(y, x)
+
+verify length law lengthAppendHomo
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given y: List<Int> = [[], [9], [8, 7], [5, 6, 7]]
+    length(append(x, y)) => plus(length(x), length(y))
+
+verify even law evenPlusComm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    even(plus(x, y)) => even(plus(y, x))
+
+verify even law evenLengthAppendComm
+    given x: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given y: List<Int> = [[], [9], [8, 7], [5, 6, 7]]
+    even(length(append(x, y))) => even(length(append(y, x)))

--- a/proof-corpus/decomposed/prod/prop_23.av
+++ b/proof-corpus/decomposed/prod/prop_23.av
@@ -1,0 +1,54 @@
+module Prop23
+    intent =
+        "TIP prod prop_23: half(length(x ++ y)) = half(length(y ++ x))."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn length(xs: List<Int>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(length(ys))
+
+fn half(x: Nat) -> Nat
+    match x
+        Nat.Z -> Nat.Z
+        Nat.S(y) -> match y
+            Nat.Z -> Nat.Z
+            Nat.S(z) -> Nat.S(half(z))
+
+fn append(x: List<Int>, y: List<Int>) -> List<Int>
+    match x
+        [] -> y
+        [z, ..xs] -> List.concat([z], append(xs, y))
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+verify plus law plusZeroRight
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, Nat.Z) => x
+
+verify plus law plusSuccRight
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    plus(x, Nat.S(y)) => Nat.S(plus(x, y))
+
+verify plus law plusComm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    plus(x, y) => plus(y, x)
+
+verify length law lengthAppend
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[], [2], [4, 5]]
+    length(append(x, y)) => plus(length(y), length(x))
+
+verify half law halfLengthAppendComm
+    given x: List<Int> = [[], [1], [1, 2, 3]]
+    given y: List<Int> = [[1], [2, 3], []]
+    half(length(append(x, y))) => half(length(append(y, x)))


### PR DESCRIPTION
Ran **the Method** (proposer → runner → verifier) across the **100** non-decomposed, non-auto-proved first-order TIP tasks (the 8 higher-order `isaplanner-mono` excluded — inexpressible, a missing function abstraction not a missing lemma).

## Result
| outcome | count |
|---|---|
| already auto-proved (baseline) | 62 |
| **newly closed by the Method** | **2** |
| open — Method found no closing decomposition | 36 |

So of the ~38 genuinely-open first-order tasks, the Method closed **2**, both kernel-genuine (independently re-checked `universal: true, sorries: 0` on Lean):

- **prod/prop_22** — `plusComm`, `lengthAppendHomo`, `evenPlusComm`, `evenLengthAppendComm`
- **prod/prop_23** — `plusZeroRight`, `plusSuccRight`, `plusComm`, `lengthAppend`, `halfLengthAppendComm`

The proposer supplied exactly the leaps the auto-prover lacked (plus-commutativity, length-append homomorphism, even/half-respects-commute); the verifier re-derived from scratch before persisting, so no false credit. The 36 it could not close stay out of the corpus.

Honest read: a modest but real frontier gain, and a measured data point on the Method's current reach (2/38 open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)