### PR TITLE
fix(vm): list-concat fed back through recursion silently dropped middle elements

### DIFF
--- a/aver-memory/src/lists.rs
+++ b/aver-memory/src/lists.rs
@@ -244,10 +244,22 @@ impl<T: ArenaTypes> Arena<T> {
                     ..
                 } => {
                     let (head, tail) = self.list_uncons(head_segment)?;
-                    return Some((
-                        head,
-                        self.push_list_segments_rc(tail, Rc::clone(&rest), start),
-                    ));
+                    if rights.is_empty() {
+                        return Some((
+                            head,
+                            self.push_list_segments_rc(tail, Rc::clone(&rest), start),
+                        ));
+                    }
+                    // This Segments node was reached down the left spine of a
+                    // Concat, so right-siblings were accumulated in `rights`
+                    // (in reverse order). They must follow this node's own
+                    // remaining segments — the Flat/Prepend arms fold `rights`
+                    // in the same way; omitting it here silently drops every
+                    // element to the right of the Segments node.
+                    let mut parts: Vec<NanValue> = rest[start..].to_vec();
+                    rights.reverse();
+                    parts.extend(rights);
+                    return Some((head, self.push_list_segments(tail, parts)));
                 }
             }
         }

--- a/tests/vm_spec.rs
+++ b/tests/vm_spec.rs
@@ -1538,6 +1538,41 @@ fn vm_list_prepend() {
     );
 }
 
+/// Regression: recursively feeding `List.concat(tail, [head])` back through a
+/// function used to silently drop the MIDDLE elements of the list, because
+/// `Arena::list_uncons`'s `Segments` arm returned without folding in the
+/// right-siblings accumulated while descending a `Concat` left spine. Moving
+/// the head to the back `length` times must return the original list, not a
+/// first-and-last-only stub (`[1,2,3]` came back as `[1,3]`).
+#[test]
+fn vm_recursive_concat_tail_preserves_middle_elements() {
+    let src = "\
+type Nat\n    Z\n    S(Nat)\n\n\
+fn cyc(n: Nat, y: List<Int>) -> List<Int>\n\
+\x20   match n\n\
+\x20       Nat.Z -> y\n\
+\x20       Nat.S(z) -> match y\n\
+\x20           [] -> []\n\
+\x20           [h, ..t] -> cyc(z, List.concat(t, [h]))\n\n\
+fn main() -> List<Int>\n\
+\x20   cyc(Nat.S(Nat.S(Nat.S(Nat.S(Nat.S(Nat.Z))))), [1, 2, 3, 4, 5])\n";
+    let (result, arena) = vm_run_with_arena(src);
+    assert!(result.is_list());
+    let got: Vec<i64> = (0..arena.list_len(result.arena_index()))
+        .map(|i| {
+            arena
+                .list_get(result.arena_index(), i)
+                .unwrap()
+                .as_int(&arena)
+        })
+        .collect();
+    assert_eq!(
+        got,
+        vec![1, 2, 3, 4, 5],
+        "full rotation must restore the list"
+    );
+}
+
 #[test]
 fn vm_result_with_default() {
     let src = "fn main() -> Int\n    Result.withDefault(Result.Err(0), 42)\n";


### PR DESCRIPTION
## The bug (VM-only correctness)
A recursive move-head-to-back — `[h, ..t] -> f(List.concat(t, [h]))` — silently dropped every element between the first and last once the list had been concatenated enough times:
- `[1,2,3]` rotated by its length → `[1,3]`
- `[1,2,3,4,5]` → `[1,5]`

Single (non-recursive) `concat(tail,[head])` on a fresh list was fine; only feeding the concat result back through recursion corrupted it. **Silent wrong answers** — and it would poison proof literalization (which pins the expected side to VM ground truth), so a verified program could disagree with its own runtime.

## Root cause
The VM stores lists as a segment/concat **rope** (what gives `List.concat` its O(1) cost). `Arena::list_uncons` descends the left spine of a `Concat`, accumulating each right-sibling into `rights` to visit once the left side drains. The `Flat` and `Prepend` arms fold `rights` back in — but the **`Segments` arm did not**, so every element to the right of that `Segments` node (the elements added by the later concats) was discarded. Hence "keep first + last, drop the middle."

## Fix
The `Segments` arm now folds `rights` like its siblings: append the node's remaining segments plus the reversed right-siblings. Narrow and perf-safe — the common single-segment uncons keeps its fast `Rc`-clone path; only an uncons that actually descended a `Concat` spine does the extra fold.

## Differential (this is VM-only)
| backend | before |
|---|---|
| **VM** | wrong (`[1,3]`, `[1,5]`) |
| wasm-gc | correct |
| rust | correct |

After the fix the VM matches wasm-gc and rust.

## Verification
- Repro passes on the VM (full rotation restores the list).
- Regression test `vm_recursive_concat_tail_preserves_middle_elements` is **load-bearing**: it FAILS without the fix (`[1,5]` vs `[1,2,3,4,5]`).
- `cargo test --workspace` 2320/0; `cargo test -p aver-lang --features wasm,wasip2` 2561/0.
- `cargo clippy -p aver-lang --lib --bin aver -- -D warnings` and the `--features wasm,wasip2` variant both clean; `cargo fmt` touches only the two changed files.

## How it was found
Triaging the TIP `rotate` tasks (prop_21/prop_32) that the Method couldn't close — they were exposing this bug, not a missing lemma. (Two of those tasks were mislabeled "corpus bug"; they're real once the VM is correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)