### PR TITLE
proof-corpus: fix two mis-encoded isaplanner tasks (prop_70, prop_82)

### DIFF
--- a/proof-corpus/tip/isaplanner/prop_70.av
+++ b/proof-corpus/tip/isaplanner/prop_70.av
@@ -17,4 +17,5 @@ fn le(x: Nat, y: Nat) -> Bool
 verify le law leSucc
     given m: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
     given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
-    le(m, n) => le(m, Nat.S(n))
+    when le(m, n)
+    le(m, Nat.S(n)) => true

--- a/proof-corpus/tip/isaplanner/prop_82.av
+++ b/proof-corpus/tip/isaplanner/prop_82.av
@@ -1,1 +1,35 @@
 module Prop82
+    intent =
+        "TIP isaplanner prop_82: take n (zip xs ys) = zip (take n xs) (take n ys)."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn zip(x: List<Int>, y: List<Int>) -> List<Tuple<Int, Int>>
+    match x
+        [] -> []
+        [z, ..x2] -> match y
+            [] -> []
+            [x3, ..x4] -> List.concat([(z, x3)], zip(x2, x4))
+
+fn take(n: Nat, xs: List<Int>) -> List<Int>
+    match n
+        Nat.Z -> []
+        Nat.S(z) -> match xs
+            [] -> []
+            [x2, ..x3] -> List.concat([x2], take(z, x3))
+
+fn takePairs(n: Nat, xs: List<Tuple<Int, Int>>) -> List<Tuple<Int, Int>>
+    match n
+        Nat.Z -> []
+        Nat.S(z) -> match xs
+            [] -> []
+            [x2, ..x3] -> List.concat([x2], takePairs(z, x3))
+
+verify zip law takeZip
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Int> = [[], [1], [1, 2, 3]]
+    given ys: List<Int> = [[], [4], [4, 5]]
+    takePairs(n, zip(xs, ys)) => zip(take(n, xs), take(n, ys))


### PR DESCRIPTION
Two TIP isaplanner corpus tasks weren't honest benchmarks. Found while triaging the tasks the Method couldn't close.

## prop_70 — implication written as an equality
Intent: "m ≤ n **implies** m ≤ S(n)". It was encoded as `le(m, n) => le(m, S(n))` — Aver's `=>` asserts the two Booleans are **equal**, which is false whenever `le(m,n)` is false (it verified only 7/9 of its own samples, and the prover correctly refused it).

Fix: encode the implication faithfully with a premise —
```
when le(m, n)
le(m, Nat.S(n)) => true
```
Now verifies (the 3 premise-false samples skip) and `aver proof --check` reports an honest **bounded** result (`passed: true, universal: false, 0 sorries`) instead of a false universal.

## prop_82 — empty stub
The file was `module Prop82` and nothing else — no functions, no law, contributing nothing. Filled with the actual TIP task `take n (zip xs ys) = zip (take n xs) (take n ys)` (with `take` monomorphized for the element list and the pair list). Verifies **27/27** and lands as an honest **open** task (1 sorry), like the rest of the unproven corpus.

## Not changed (triage had mislabeled them "corpus bug")
- **prop_21 / prop_32** (`rotate (length x) …`): not corpus bugs — they were exposing the VM list-concat element-loss bug fixed in **#589**. They verify correctly now (9/9, 4/4) and need no change.
- **lemma_12** (`sorted y => sorted (insert x y)`): already verifies 9/9; a genuinely hard open task, not a mis-encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)