### PR TITLE
lean: prove relational both-args laws (generalize induction + bridge the comparison)

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -2703,13 +2703,37 @@ fn emit_both_args_peeling_law(
     if intro_names.len() != law.givens.len() {
         return None;
     }
-    // The law must be a genuine commutativity / associativity of THIS fn over
-    // its givens — not merely some 2-/3-given law that happens to mention a
-    // both-args-peeling fn. A `minus(plus(n,m),n)=m` or a `n ≤ m+n` keeps its
-    // existing bridge proof; this generalizing template fires only on
-    // `f a b = f b a` / `f (f a b) c = f a (f b c)`.
+    // Two shapes fire this generalizing template. (1) A genuine commutativity /
+    // associativity of THIS fn over its givens (`f a b = f b a` / `f (f a b) c =
+    // f a (f b c)`). (2) A 2-given RELATIONAL law that pairs a both-args-peeling
+    // fn with a comparison — `eq (max a b) a = lessEq b a` (prop_24/33/34): the
+    // proof needs the SAME `induction g1 generalizing g2 with … cases g2` double
+    // peel, plus the comparison fn's `(le a b = true) = (a ≤ b)` bridge so the
+    // residual lands in arithmetic `omega` decides. A `minus(plus(n,m),n)=m`
+    // (no comparison) matches NEITHER and keeps its existing bridge proof.
     let given_names: Vec<String> = law.givens.iter().map(|g| g.name.clone()).collect();
-    crate::codegen::proof_recognize::recognize_binary_law_shape(law, &vb.fn_name, &given_names)?;
+    let is_comm_assoc =
+        crate::codegen::proof_recognize::recognize_binary_law_shape(law, &vb.fn_name, &given_names)
+            .is_some();
+
+    // Comparison bridges in the law's cone (`lessEq`/`le`/`lt` → builtin `≤`/`<`),
+    // proved as self-contained support theorems. Their presence is what makes the
+    // relational shape closable; an arithmetic-only law has none and falls
+    // through to the single-carrier emitter unchanged.
+    let law_uid = format!(
+        "{}_{}",
+        aver_name_to_lean(&vb.fn_name),
+        aver_name_to_lean(&law.name)
+    );
+    let (bridge_support, bridge_names, _bridged) =
+        lean_nat_lift_support(law, ctx, &law_uid, &BTreeSet::new());
+    let has_compare_bridge = bridge_names
+        .iter()
+        .any(|n| n.ends_with("_isNatLe") || n.ends_with("_isNatLt"));
+    let relational = !is_comm_assoc && law.givens.len() == 2 && has_compare_bridge;
+    if !is_comm_assoc && !relational {
+        return None;
+    }
 
     let simp_list = law_simp_defs(ctx, vb, law)
         .into_iter()
@@ -2724,8 +2748,26 @@ fn emit_both_args_peeling_law(
         .iter()
         .map(|g| format!("cases {g} <;> "))
         .collect::<String>();
+    // RELATIONAL only: an additive rung that adds the comparison bridges to the
+    // arm `simp_all` and finishes with `omega`. Keeping the comparison fn's def
+    // AND its `= true ↔ ≤` bridge in one `simp_all` is fine (the bridge is a
+    // Prop-equality, not a recursive unfold, so it does not loop), then `omega`
+    // discharges the `≤`/`=` residual. Runs only after the bare `; done`/`; omega`
+    // rungs fail, ends in `omega`, so it throws on a leftover and degrades to the
+    // honest `sorry` — purely additive, sound, can only ADD closures. The
+    // comm/assoc path keeps an empty rung and is byte-identical to before.
+    let bridge_rung = if relational {
+        let all_simp = if bridge_names.is_empty() {
+            simp_list.clone()
+        } else {
+            format!("{simp_list}, {}", bridge_names.join(", "))
+        };
+        format!(" | ({cases_prefix}simp_all [{all_simp}] <;> omega)")
+    } else {
+        String::new()
+    };
     let ladder = format!(
-        "first | ({cases_prefix}simp_all [{simp_list}]; done) | ({cases_prefix}simp_all [{simp_list}]; omega) | sorry"
+        "first | ({cases_prefix}simp_all [{simp_list}]; done) | ({cases_prefix}simp_all [{simp_list}]; omega){bridge_rung} | sorry"
     );
 
     let proof_lines = vec![
@@ -2736,7 +2778,11 @@ fn emit_both_args_peeling_law(
     ];
 
     Some(AutoProof {
-        support_lines: Vec::new(),
+        support_lines: if relational {
+            bridge_support
+        } else {
+            Vec::new()
+        },
         body: crate::codegen::lean::tactic_ir::Tactic::raw(proof_lines),
         replaces_theorem: false,
     })

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -297,6 +297,23 @@ fn lean_escapes_user_max_min_collision_when_lake_is_available() {
     );
 }
 
+/// Leaf-reach: a RELATIONAL both-args law — `(min a b == b) = (b <= a)` — now
+/// closes as a genuine universal. The subject `eq` peels both args, so the proof
+/// needs `induction a generalizing b with … cases b`, and the residual only
+/// clears once the comparison fn's `(le a b = true) = (a ≤ b)` bridge rewrites
+/// it into arithmetic `omega` decides. The both-args-peeling emit used to fire
+/// only for commutativity/associativity (no comparison) and left this on a
+/// `sorry`; it now also handles the relational-with-comparison shape. Budget 0:
+/// fully proven. TIP isaplanner prop_34 (prop_33 is the symmetric `<=` variant).
+#[test]
+fn lean_proves_relational_both_args_min_le_when_lake_is_available() {
+    assert_proof_builds_with_sorry_budget(
+        "proof-corpus/tip/isaplanner/prop_34.av",
+        "aver-relational-both-args",
+        0,
+    );
+}
+
 /// Leaf-reach: the Lean backend auto-proves an ACCUMULATOR-generalizing law —
 /// `qrev(xs, acc) = rev(xs) ++ acc`, where `qrev` recurses on `xs` while
 /// THREADING `acc` (fed `List.concat([h], acc)`). The IH must be `∀ acc,


### PR DESCRIPTION
## What
Teaches the Lean auto-prover to close **relational** both-args laws — `(min a b == b) = (b <= a)` and friends — by generalizing the induction over the second argument and bridging the comparison into arithmetic.

The both-args-peeling emitter already proved commutativity / associativity via `induction g1 generalizing g2 with … cases g2`. This extends it to a two-given both-args law that is *not* comm/assoc but whose cone has a comparison fn: it emits the same double-induction plus an additive rung that adds the comparison's `(le a b = true) = (a ≤ b)` bridge to the arm `simp_all` and finishes with `omega`. Sound-by-floor (ends in `sorry`), and the comm/assoc path stays byte-identical (no bridge rung, no support lemmas).

## Result
- **prop_33** and **prop_34** (TIP isaplanner) now close as genuine universals (`universal: true, 0 sorries`), independently re-checked.
- Regression test `lean_proves_relational_both_args_min_le_when_lake_is_available` — **fails without this change** (prop_34 sorries 1).
- No regression: the comm/assoc both-args tasks (prop_31/32) stay universal; `cargo test --workspace` and `proof_spec` (173/0) green; both `-D warnings` clippy gates clean.

## Honest scope note
This started as the "LUKA2" item from the failure triage (lift a guard so generalizing-induction and sibling-arm-injection can combine). On investigation that framing was **stale**: the generalizing + sibling-arm-injection combination is already implemented, and the validating tasks are single-law files with no siblings to inject — so the guard-lift is a no-op for them. Their real blockers, measured:
- **prop_24/33/34** — Nat relational `eq(max/min …) = le/lessEq`: needed the double-induction + comparison bridge above. prop_33/34 close; **prop_24** (the `max` variant) additionally needs an equality bridge `(eq a b = true) = (a = b)` the prover doesn't yet emit — a clean follow-up.
- **prop_56/63/72/74/81/83/84, prod/prop_08** — list/zip laws needing auxiliary lemmas (`len(rev)`, take/drop-over-append, zip distribution) not present in the single-law files: the Method's territory, not a compiler-emit fix.

So this lands the real, sound, evidence-backed subset (2 tasks) rather than the mislabeled 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)