### PR TITLE
lean: unify the Peano comparison bridges (≤ / < / =) into one parameterized form

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -118,7 +118,7 @@ fn lean_nat_lift_support(
     law_uid: &str,
     extra_fns: &BTreeSet<String>,
 ) -> (Vec<String>, Vec<String>, BTreeSet<String>) {
-    use crate::codegen::proof_recognize::{NatArithKind, NatCompareKind};
+    use crate::codegen::proof_recognize::NatArithKind;
     let mut support = Vec::new();
     let mut simp_extra = Vec::new();
     let mut bridged_fns: BTreeSet<String> = BTreeSet::new();
@@ -226,25 +226,27 @@ fn lean_nat_lift_support(
     for op in compare {
         let f = aver_name_to_lean(&op.fn_name);
         bridged_fns.insert(f.clone());
-        match op.kind {
-            // `(le a b = true) = (a ≤ b)`: a Prop-equality (propext) so `simp only`
-            // rewrites the Bool goal `le _ _ = true` straight into `_ ≤ _` for omega.
-            NatCompareKind::Le => {
-                let name = format!("{law_uid}_{f}_isNatLe");
-                support.push(format!(
-                    "theorem {name} : ∀ a b, ({f} a b = true) = (a ≤ b) := by\n  intro a b\n  induction a generalizing b with\n  | zero => first | (simp [{f}]) | sorry\n  | succ k ih => cases b with\n    | zero => first | (simp [{f}]) | sorry\n    | succ w => first | (simp [{f}, ih]) | sorry"
-                ));
-                simp_extra.push(name);
-            }
-            // `<` matches its SECOND arg first, so the bridge inducts on `b`.
-            NatCompareKind::Lt => {
-                let name = format!("{law_uid}_{f}_isNatLt");
-                support.push(format!(
-                    "theorem {name} : ∀ a b, ({f} a b = true) = (a < b) := by\n  intro a b\n  induction b generalizing a with\n  | zero => cases a <;> first | (simp [{f}]) | sorry\n  | succ k ih => cases a <;> first | (simp [{f}, ih]) | sorry"
-                ));
-                simp_extra.push(name);
-            }
-        }
+        // ONE bridge for every recognized Peano Bool relation — `≤`, `<`, `=`
+        // (and any later `≥`/`>`/`≠`): the Prop-equality (propext)
+        // `(f a b = true) = (a R b)`, so `simp only` rewrites the Bool goal
+        // `f _ _ = true` straight into the Prop relation for `omega`. All three
+        // close by the SAME double-peel — induct on the argument the fn
+        // destructures first (its DRIVER: `b` for `<`, `a` for `≤`/`=`),
+        // case-split the other in both arms, `simp [f(, ih)]`. They differ only
+        // in the target relation and which arg drives, both read off the kind;
+        // the proof template is shared. Sound-by-floor: a misrecognized shape
+        // fails the bridge proof and lands on the `sorry`, never a false theorem.
+        let name = format!("{law_uid}_{f}_{}", op.kind.bridge_suffix());
+        let prop = op.kind.prop_op();
+        let (driver, passenger) = if op.kind.induct_on_second() {
+            ("b", "a")
+        } else {
+            ("a", "b")
+        };
+        support.push(format!(
+            "theorem {name} : ∀ a b, ({f} a b = true) = (a {prop} b) := by\n  intro a b\n  induction {driver} generalizing {passenger} with\n  | zero => cases {passenger} <;> first | (simp [{f}]) | sorry\n  | succ k ih => cases {passenger} <;> first | (simp [{f}, ih]) | sorry"
+        ));
+        simp_extra.push(name);
     }
 
     // `*` is nonlinear: `omega` treats `a*b` as an opaque atom, and core Lean has
@@ -2729,7 +2731,7 @@ fn emit_both_args_peeling_law(
         lean_nat_lift_support(law, ctx, &law_uid, &BTreeSet::new());
     let has_compare_bridge = bridge_names
         .iter()
-        .any(|n| n.ends_with("_isNatLe") || n.ends_with("_isNatLt"));
+        .any(|n| n.ends_with("_isNatLe") || n.ends_with("_isNatLt") || n.ends_with("_isNatEq"));
     let relational = !is_comm_assoc && law.givens.len() == 2 && has_compare_bridge;
     if !is_comm_assoc && !relational {
         return None;

--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -735,6 +735,38 @@ fn detect_nat_arith_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatArithKind>
 pub(crate) enum NatCompareKind {
     Le,
     Lt,
+    /// Canonical Peano decidable equality (`eq Z Z = true`, `eq (S a) (S b) =
+    /// eq a b`, mismatches `false`). Bridged to the Prop `a = b` via
+    /// `(eq a b = true) = (a = b)`.
+    Eq,
+}
+
+impl NatCompareKind {
+    /// The Lean Prop relation the bridge maps `f a b = true` onto.
+    pub(crate) fn prop_op(self) -> &'static str {
+        match self {
+            NatCompareKind::Le => "≤",
+            NatCompareKind::Lt => "<",
+            NatCompareKind::Eq => "=",
+        }
+    }
+
+    /// The bridge theorem's name suffix (kept distinct per relation so two
+    /// bridges in one law never collide, and the both-args rung can spot them).
+    pub(crate) fn bridge_suffix(self) -> &'static str {
+        match self {
+            NatCompareKind::Le => "isNatLe",
+            NatCompareKind::Lt => "isNatLt",
+            NatCompareKind::Eq => "isNatEq",
+        }
+    }
+
+    /// Whether the recursion drives on the SECOND argument. `<` destructures its
+    /// second arg first, so its bridge inducts on `b`; `≤` and `=` drive on `a`.
+    /// The bridge proof inducts on the driver and case-splits the passenger.
+    pub(crate) fn induct_on_second(self) -> bool {
+        matches!(self, NatCompareKind::Lt)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -835,6 +867,27 @@ fn detect_nat_compare_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatCompareK
         && rec_ok(r, q)
     {
         return Some(NatCompareKind::Lt);
+    }
+
+    // Eq: outer on p0; the succ arm matches `≤`'s recursion shape (inner on p1,
+    // `Base -> false`, `Succ(r) -> op(q, r)`), but the BASE arm — unlike `≤`/`<`,
+    // whose base is a bare bool — itself nests a match on p1 (`Z -> true`, `S ->
+    // false`). That second nesting is exactly Peano decidable equality.
+    if outer_on == p0.as_str()
+        && inner_on == p1.as_str()
+        && as_bool_lit(inner_base) == Some(false)
+        && rec_ok(q, r)
+        && let Expr::Match {
+            subject: base_subj,
+            arms: base_arms,
+            ..
+        } = &base_body.node
+        && ln(base_subj) == Some(p1.as_str())
+        && let Some((bb_base, _z, bb_succ)) = split_peano_match(base_arms, &peano)
+        && as_bool_lit(bb_base) == Some(true)
+        && as_bool_lit(bb_succ) == Some(false)
+    {
+        return Some(NatCompareKind::Eq);
     }
 
     None

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -314,6 +314,22 @@ fn lean_proves_relational_both_args_min_le_when_lake_is_available() {
     );
 }
 
+/// Leaf-reach: a relational both-args law whose subject IS the Peano equality
+/// fn — `(max a b == a) = (b <= a)` — now closes universally. Beyond the `<=`
+/// bridge the residual carries `eq … = true` over the recursion, which only
+/// `omega` can finish once `eq` is itself bridged to the Prop `a = b` via
+/// `(eq a b = true) = (a = b)`. The recognizer learns the Peano decidable-
+/// equality shape and the both-args rung now picks up that `_isNatEq` bridge
+/// alongside `_isNatLe`. Budget 0: fully proven. TIP isaplanner prop_24.
+#[test]
+fn lean_proves_relational_both_args_eq_bridge_when_lake_is_available() {
+    assert_proof_builds_with_sorry_budget(
+        "proof-corpus/tip/isaplanner/prop_24.av",
+        "aver-relational-eq-bridge",
+        0,
+    );
+}
+
 /// Leaf-reach: the Lean backend auto-proves an ACCUMULATOR-generalizing law —
 /// `qrev(xs, acc) = rev(xs) ++ acc`, where `qrev` recurses on `xs` while
 /// THREADING `acc` (fed `List.concat([h], acc)`). The IH must be `∀ acc,


### PR DESCRIPTION
The auto-prover bridges a user's Bool-valued Peano comparison to the Lean Prop relation it computes — `(f a b = true) = (a R b)` — so `omega` can take over. There were two hand-written bridges (`≤`, `<`), each with its own recognizer shape AND its own copy-pasted proof template.

This **adds the `=` relation** and **collapses all three onto one shared template**.

## Generalization
The three relations differ only in:
- the target Prop (`≤` / `<` / `=`), and
- which argument the fn destructures first (the DRIVER: `b` for `<`, `a` for `≤`/`=`).

Both are read off the recognized kind (`prop_op()` / `induct_on_second()`), and the proof is the same double-peel for every relation: induct on the driver, case-split the passenger in both arms, `simp [f(, ih)]`. **Adding `≥` / `>` / `≠` later is now just a recognizer shape + an enum variant — no new template.**

The unified template is a behavioral **superset** of the old per-relation ones. Verified no-regression: prop_65 (`≤`), prop_69 (`<`), prop_68, prop_24/33/34 (relational) all stay `universal: true, 0 sorries`.

## What it closes
The new `=` bridge closes **TIP isaplanner prop_24** — `(max a b == a) = (b ≤ a)`, the relational both-args law whose subject IS the equality fn. Its residual carried `eq … = true` over the recursion, which nothing could finish without bridging `eq` to the Prop `=`. (Completes the relational-both-args family started in #591, which closed prop_33/34.)

## Why a compiler recognizer, not a user law
The bridge's RHS is a **Lean-native relation on the user's own `Nat` ADT, which has no Aver source form** (Aver's built-in `≤`/`<` are `Int`-only) — the user literally cannot state it. It's the seam between the user's `le`/`eq` and the prover's `≤`/`=`, and it taps a complete decision procedure (`omega`). That's exactly where compiler recognition earns its keep — as opposed to the auxiliary lemmas a user *can* write (the Method's territory).

## Verification
- New test `lean_proves_relational_both_args_eq_bridge` (prop_24, sorry-budget 0); prop_24 was `sorries: 1` on main.
- proof_spec 174/0, workspace 2322/0, both `-D warnings` clippy gates clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)