### PR TITLE
lean: finish induction arms by splitting nested conditionals before omega (count-sort family)

### DIFF
--- a/proof-corpus/decomposed/prod/prop_50.av
+++ b/proof-corpus/decomposed/prod/prop_50.av
@@ -1,0 +1,54 @@
+module Prop50
+    intent =
+        "TIP prod prop_50 (isaplanner #53): count x (isort y) = count x y, decomposed via count-insert permutation invariance."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..xs] -> match eqNat(x, z)
+            true -> Nat.S(count(x, xs))
+            false -> count(x, xs)
+
+fn lessEq(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> lessEq(z, x2)
+
+fn insert(x: Nat, y: List<Nat>) -> List<Nat>
+    match y
+        [] -> [x]
+        [z, ..xs] -> match lessEq(x, z)
+            true -> List.concat([x], y)
+            false -> List.concat([z], insert(x, xs))
+
+fn isort(x: List<Nat>) -> List<Nat>
+    match x
+        [] -> []
+        [y, ..xs] -> insert(y, isort(xs))
+
+verify count law countInsertPerm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given z: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given ys: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    count(x, insert(z, ys)) => count(x, List.concat([z], ys))
+
+verify count law countIsort
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given y: List<Nat> = [[], [Nat.S(Nat.Z)], [Nat.S(Nat.Z), Nat.Z]]
+    count(x, isort(y)) => count(x, y)

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1648,8 +1648,20 @@ fn wrap_with_fun_induction_rung(
     // is discharged by a PROVEN `_refl` lemma carried in `simp_defs`, never by an
     // in-closer induction. All tactics here (`simp_all`/`omega`) terminate and
     // are sound, so the rung is purely additive and adds no axioms.
+    // Last alternative: after `simp_all` normalizes, exhaust the goal's nested
+    // `if`/`match` branch points with `repeat' split` before `omega`. The cheaper
+    // rungs leave an unsplit `if <userBool> then …` (e.g. `if eqNat x z then …`)
+    // that `omega` treats as an opaque atom and cannot relate across the two
+    // sides; splitting every conditional first collapses each branch to concrete
+    // arithmetic `omega` closes. `repeat' split` is core Lean (Mathlib's
+    // `split_ifs` is unavailable here); it creates no new conditionals and halts
+    // when none remain, so it is bounded by the finitely-many `if`s already
+    // present, and the trailing `omega` throws on any non-arithmetic leftover —
+    // the rung stays sound-by-floor and falls through to `sorry`. Gated LAST so
+    // the cheaper `simp_all` rungs fire first. Closes the count-over-insert
+    // family (count/insert/sort branching on `eqNat`/`lessEq`).
     let closer = format!(
-        "first | (simp_all {defs}; done) | (simp_all {defs}; omega) | (simp_all {defs} <;> omega)"
+        "first | (simp_all {defs}; done) | (simp_all {defs}; omega) | (simp_all {defs} <;> omega) | (simp_all {defs} <;> (repeat' split) <;> omega)"
     );
     let mut out = vec![intro_line, "  first".to_string()];
     for t in targets {

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -330,6 +330,24 @@ fn lean_proves_relational_both_args_eq_bridge_when_lake_is_available() {
     );
 }
 
+/// Leaf-reach: the `fun_induction` closer now exhausts nested conditionals with
+/// `repeat' split` before `omega`. The count-over-insert lemma
+/// `count(x, insert(z, ys)) = count(x, [z] ++ ys)` (the irreducible leaf of the
+/// insertion-sort count-preservation family) leaves `if eqNat … then …` branches
+/// that the bare `simp_all; omega` rungs leave opaque to `omega`; splitting every
+/// conditional first collapses each to concrete arithmetic. With the leaf proven,
+/// the headline `count(x, isort y) = count(x, y)` closes too — both laws of this
+/// decomposed task are universal. Budget 0. (Removing the `repeat' split` rung
+/// reintroduces the leaf's `sorry`.)
+#[test]
+fn lean_proves_count_insert_split_rung_when_lake_is_available() {
+    assert_proof_builds_with_sorry_budget(
+        "proof-corpus/decomposed/prod/prop_50.av",
+        "aver-count-insert-split",
+        0,
+    );
+}
+
 /// Leaf-reach: the Lean backend auto-proves an ACCUMULATOR-generalizing law —
 /// `qrev(xs, acc) = rev(xs) ++ acc`, where `qrev` recurses on `xs` while
 /// THREADING `acc` (fed `List.concat([h], acc)`). The IH must be `∀ acc,


### PR DESCRIPTION
Found by a multi-approach research pass (6 distinct tactics, each lake-verified) into why the count-insertion-sort family stays open.

## The gap
The `fun_induction` closer proved a law by `simp_all [defs]` then `omega`. When the function branches on a **user Bool comparison** (`eqNat`/`lessEq`), `simp_all` leaves nested `if eqNat x z then …` terms that **`omega` treats as opaque atoms** — it loses the correlation between the two sides and can't close. The split/`fun_induction` machinery was already in the portfolio; the closer just stopped one step short.

## The fix (one rung)
Add a final alternative to the closer: `simp_all [defs] <;> (repeat' split) <;> omega`. Splitting every conditional first collapses each branch to concrete arithmetic `omega` decides.

- `repeat' split` is **core Lean** (`split_ifs` is Mathlib, unavailable here); it creates no new `if`s and halts when none remain → **bounded** by the finitely-many conditionals already present (~0.7s, no loop/explosion).
- Gated **LAST** so the three cheaper `simp_all` rungs fire first (no regression).
- Ends in `omega` (throws on non-arithmetic leftovers) → **sound-by-floor**, falls through to `sorry`, can only add closures. Axioms `[propext, Quot.sound]`.

## What it closes
The irreducible leaf `count(x, insert(z, ys)) = count(x, [z] ++ ys)` now proves kernel-genuine, and with it `count(x, isort y) = count(x, y)`. Adds `decomposed/prod/prop_50.av` (both laws universal) + a regression test (removing the rung reintroduces the `sorry`). The same rung lifts to the rest of the count/sort/filter family (prop_53/77/78) — natural follow-up decompositions.

## How it was found
Both flat and multi-level Method runs closed **0** of this hard tail; dissecting one leaf (`count`-over-`insert`) showed the wall is the auto-prover's leaf-reach (omega-opaque conditionals), not decomposition depth. A research pass then lake-tested 6 approaches — `grind`, `(repeat' split)`, simp-lemmas, reformulation, fun-induction closers, generalize — **all six closed it**; `(repeat' split)` is the cheapest, core-only, cleanest-axiom rung.

## Verification
- `decomposed/prod/prop_50.av`: `universal: true, sorries: 0` (2 laws).
- proof_spec 175/0 (new test + no-regression on the fun_induction tasks); workspace 2323/0; both `-D warnings` clippy gates clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)