### PR TITLE
proof-corpus: count preserved under insertion sort (prop_53)

### DIFF
--- a/proof-corpus/decomposed/isaplanner/prop_53.av
+++ b/proof-corpus/decomposed/isaplanner/prop_53.av
@@ -1,0 +1,54 @@
+module Prop53
+    intent =
+        "TIP isaplanner prop_53: count n xs = count n (sort xs), decomposed via count-insort permutation invariance."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..ys] -> match eqNat(x, z)
+            true -> Nat.S(count(x, ys))
+            false -> count(x, ys)
+
+fn leNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> leNat(z, x2)
+
+fn insort(x: Nat, y: List<Nat>) -> List<Nat>
+    match y
+        [] -> [x]
+        [z, ..xs] -> match leNat(x, z)
+            true -> List.concat([x], y)
+            false -> List.concat([z], insort(x, xs))
+
+fn sort(x: List<Nat>) -> List<Nat>
+    match x
+        [] -> []
+        [y, ..xs] -> insort(y, sort(xs))
+
+verify count law countInsortPerm
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given z: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given ys: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z), Nat.Z]]
+    count(x, insort(z, ys)) => count(x, List.concat([z], ys))
+
+verify count law countSort
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]
+    given xs: List<Nat> = [[], [Nat.S(Nat.Z)], [Nat.S(Nat.Z), Nat.Z, Nat.S(Nat.Z)]]
+    count(n, xs) => count(n, sort(xs))

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -144,6 +144,10 @@ fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
         // structural-only rung).
         "proof-corpus/decomposed/prod/lemma_14.av",
         "proof-corpus/decomposed/prod/lemma_16.av",
+        // count-preservation under insertion sort: the count-over-insort
+        // permutation leaf closes via the `repeat' split` rung, then the sort
+        // law follows. (prod/prop_50 is its twin, pinned by its own test.)
+        "proof-corpus/decomposed/isaplanner/prop_53.av",
     ];
     for task in tasks {
         let out = temp_output_dir(&format!(


### PR DESCRIPTION
Payoff of the conditional-splitting rung (#593): with the count-over-insort permutation leaf now provable, the count-preservation law closes.

- **isaplanner/prop_53** — `count(n, xs) = count(n, sort xs)`. Decomposed via the permutation helper `count(x, insort(z, ys)) = count(x, [z] ++ ys)` (closes through the `repeat' split` rung), then the sort law follows by induction. Both laws `universal: true, 0 sorries`. Twin of `prod/prop_50` (added in #593). Pinned in the decomposed-corpus test.

## Honestly out of scope
The **sorted-insort family** (prop_77 `sorted xs → sorted (insort x xs)`, prop_78 `sorted (sort xs)`) is left open. Its residual reasons about the ordering invariant `sorted` and the head of `insort` (order transitivity) — not the conditional arithmetic this rung handles. That's a separate leaf-reach, a future investigation, not a count law.

## Verification
proof_spec 175/0 (the decomposed-corpus test now includes prop_53). No compiler change — corpus + test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)