### PR TITLE
proof: prove a tail-recursive factorial equals its recurrence (Peano-Nat wrapper-over-recursion)

### DIFF
--- a/proof-corpus/handwritten/fact_acc_spec.av
+++ b/proof-corpus/handwritten/fact_acc_spec.av
@@ -1,0 +1,34 @@
+module FactAccSpec
+    intent = "Multiplicative twin of sum_acc_spec: tail-recursive factorial equals the recurrence."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn mul(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> Nat.Z
+        Nat.S(z) -> plus(y, mul(z, y))
+
+fn factTR(n: Nat, acc: Nat) -> Nat
+    match n
+        Nat.Z -> acc
+        Nat.S(m) -> factTR(m, mul(n, acc))
+
+fn factFold(n: Nat) -> Nat
+    factTR(n, Nat.S(Nat.Z))
+
+fn factSpec(n: Nat) -> Nat
+    match n
+        Nat.Z -> Nat.S(Nat.Z)
+        Nat.S(m) -> mul(n, factSpec(m))
+
+verify factFold law equalsSpec
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z)), Nat.S(Nat.S(Nat.S(Nat.Z)))]
+    factFold(n) => factSpec(n)

--- a/src/analysis/shape.rs
+++ b/src/analysis/shape.rs
@@ -731,6 +731,17 @@ pub enum ModulePattern {
         /// Nil-arm finishing fn `finish_fn(acc)`, or `None` for an identity
         /// finish (the nil arm returns `acc` unchanged).
         finish_fn: Option<String>,
+        /// `None` for the original `List<_>` structural fold. `Some(ty)` for a
+        /// Peano-`Nat` countdown fold (`match n { Z -> acc; S(m) -> loop(m,
+        /// step) }`) over the ADT named `ty` — `factTR`'s shape, where the
+        /// step multiplies/adds the matched subject value rather than a list
+        /// head. The two share the role-extraction but need different backend
+        /// induction skeletons.
+        driver_type: Option<String>,
+        /// For a Peano-`Nat` fold whose step is `combine(subject, acc)`, `true`
+        /// when the folded subject is the combine fn's FIRST argument
+        /// (`mul(n, acc)`), `false` for `mul(acc, n)`. Ignored for `List`.
+        step_value_first: bool,
     },
 }
 
@@ -1264,6 +1275,96 @@ fn detect_accumulator_fold(
             continue;
         }
 
+        // A `List<_>` fold presents `[]`/`h::t` arms; a Peano-`Nat` countdown
+        // (`factTR`) presents two `Constructor` arms (`Z`/`S(m)`). They share
+        // the wrapper→loop discovery above but extract roles differently.
+        let list_shaped = arms
+            .iter()
+            .any(|a| matches!(a.pattern, Pattern::EmptyList | Pattern::Cons(_, _)));
+        if !list_shaped {
+            // ── Peano-`Nat` countdown fold ──────────────────────────────
+            // `match n { Z -> acc; S(m) -> loop(m, combine(n, acc)) }`, where
+            // the step's folded value is the matched subject `n` itself (not a
+            // list head). Base arm returns the accumulator (identity finish).
+            let mut base_seen = false;
+            let mut combine_fn: Option<String> = None;
+            let mut value_first = false;
+            let mut step_seen = false;
+            let mut ok = true;
+            for arm in arms {
+                let Pattern::Constructor(_, binders) = &arm.pattern else {
+                    ok = false;
+                    continue;
+                };
+                match binders.len() {
+                    0 => {
+                        if plain_ident(&arm.body) == Some(acc_param.as_str()) {
+                            base_seen = true;
+                        } else {
+                            ok = false;
+                        }
+                    }
+                    1 => {
+                        let bind = &binders[0];
+                        let Some((callee, cargs)) = call_target(&arm.body) else {
+                            ok = false;
+                            continue;
+                        };
+                        if callee != loop_fn
+                            || cargs.len() != 2
+                            || plain_ident(&cargs[0]) != Some(bind.as_str())
+                        {
+                            ok = false;
+                            continue;
+                        }
+                        // step = combine(subject, acc) | combine(acc, subject),
+                        // a named 2-arg monoid fn over the matched param + acc.
+                        let Expr::FnCall(sc, sargs) = &cargs[1].node else {
+                            ok = false;
+                            continue;
+                        };
+                        let Expr::Ident(sname) = &sc.node else {
+                            ok = false;
+                            continue;
+                        };
+                        if sargs.len() != 2 {
+                            ok = false;
+                            continue;
+                        }
+                        let a0 = plain_ident(&sargs[0]);
+                        let a1 = plain_ident(&sargs[1]);
+                        if a0 == Some(list_param.as_str()) && a1 == Some(acc_param.as_str()) {
+                            value_first = true;
+                        } else if a0 == Some(acc_param.as_str()) && a1 == Some(list_param.as_str())
+                        {
+                            value_first = false;
+                        } else {
+                            ok = false;
+                            continue;
+                        }
+                        combine_fn = Some(sname.clone());
+                        step_seen = true;
+                    }
+                    _ => ok = false,
+                }
+            }
+            if base_seen && step_seen && ok && combine_fn.is_some() {
+                out.push(ModulePattern::AccumulatorFold {
+                    scope: scope.clone(),
+                    wrapper_fn: fd.name.clone(),
+                    loop_fn,
+                    driver_type: Some(lf.params[0].1.clone()),
+                    list_param,
+                    acc_param,
+                    step_fn: combine_fn,
+                    step_op: None,
+                    finish_fn: None,
+                    step_value_first: value_first,
+                });
+            }
+            continue;
+        }
+
         let mut finish_fn: Option<Option<String>> = None; // outer Option = "arm seen"
         let mut step_fn: Option<String> = None;
         let mut step_op: Option<crate::ast::BinOp> = None;
@@ -1342,6 +1443,8 @@ fn detect_accumulator_fold(
             step_fn,
             step_op,
             finish_fn,
+            driver_type: None,
+            step_value_first: false,
         });
     }
 }

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1708,6 +1708,45 @@ fn emit_wrapper_over_recursion_support_stack(
     lines.join("\n")
 }
 
+/// Stage 8 (Peano-`Nat` driver): support stack for a `factTR`-shape
+/// multiplicative countdown fold. Unlike the `seq<int>` case — where Z3 knows
+/// `int` `*` is associative/commutative for free — the user `mul` is a
+/// function over a `Nat` datatype, so the monoid laws must be supplied as
+/// induction lemmas (`mul_assoc` / `mul_comm` / `mul_one`) the decomposition
+/// and main lemmas can lean on. Returns `None` for shapes outside the
+/// multiplicative countdown so the caller falls back to the honest decline.
+#[allow(clippy::too_many_arguments)]
+fn emit_wrapper_nat_support_stack(
+    ctx: &CodegenContext,
+    wrapper_fn: &str,
+    inner_fn: &str,
+    other_fn: &str,
+    combine_fn: &str,
+    combine_op: crate::ast::BinOp,
+    nat_type: &str,
+    value_first: bool,
+    impl_dafny: &str,
+    law_name_dafny: &str,
+) -> Option<String> {
+    // Only the multiplicative countdown is handled here.
+    if combine_op != crate::ast::BinOp::Mul {
+        return None;
+    }
+    let _ = (
+        ctx,
+        wrapper_fn,
+        inner_fn,
+        other_fn,
+        combine_fn,
+        nat_type,
+        value_first,
+        impl_dafny,
+        law_name_dafny,
+    );
+    // TODO: emit the Nat-datatype monoid lemmas + decomposition stack.
+    None
+}
+
 /// True when the law's call cone (lhs + rhs, transitively expanded
 /// through fn bodies) reaches a fn carrying the guard-validated
 /// floor-division countdown contract
@@ -2166,6 +2205,8 @@ pub fn emit_verify_law(
         inner_fn,
         other_fn,
         combine_op,
+        driver,
+        combine_fn,
     }) = vb_fn_id
         .and_then(|fn_id| {
             ctx.proof_ir
@@ -2175,14 +2216,41 @@ pub fn emit_verify_law(
         })
         .map(|t| t.strategy.clone())
     {
-        return emit_wrapper_over_recursion_support_stack(
-            &wrapper_fn,
-            &inner_fn,
-            &other_fn,
-            combine_op,
-            &fn_name,
-            &law_name,
-        );
+        match driver {
+            crate::ir::WrapperDriver::List => {
+                return emit_wrapper_over_recursion_support_stack(
+                    &wrapper_fn,
+                    &inner_fn,
+                    &other_fn,
+                    combine_op,
+                    &fn_name,
+                    &law_name,
+                );
+            }
+            crate::ir::WrapperDriver::PeanoNat {
+                type_name,
+                value_first,
+            } => {
+                if let Some(combine) = combine_fn.as_deref()
+                    && let Some(stack) = emit_wrapper_nat_support_stack(
+                        ctx,
+                        &wrapper_fn,
+                        &inner_fn,
+                        &other_fn,
+                        combine,
+                        combine_op,
+                        &type_name,
+                        value_first,
+                        &fn_name,
+                        &law_name,
+                    )
+                {
+                    return stack;
+                }
+                // Fall through to the default decline when the Peano-Nat
+                // shape isn't one the support stack handles.
+            }
+        }
     }
 
     // Refinement lift: for each Int given whose value is wrapped in

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1708,13 +1708,34 @@ fn emit_wrapper_over_recursion_support_stack(
     lines.join("\n")
 }
 
+/// The additive monoid fn a Peano `mul` is built on — the outer call of `mul`'s
+/// succ arm (`S(z) -> plus(y, mul(z, y))`). Returns its source name.
+fn peano_additive_callee(mul_fd: &FnDef) -> Option<String> {
+    use crate::ast::{Expr, Pattern};
+    let tail = mul_fd.body.tail_expr()?;
+    let Expr::Match { arms, .. } = &tail.node else {
+        return None;
+    };
+    for arm in arms {
+        if let Pattern::Constructor(_, binders) = &arm.pattern
+            && binders.len() == 1
+            && let Expr::FnCall(callee, _) = &arm.body.node
+        {
+            return crate::codegen::common::expr_to_dotted_name(&callee.node);
+        }
+    }
+    None
+}
+
 /// Stage 8 (Peano-`Nat` driver): support stack for a `factTR`-shape
 /// multiplicative countdown fold. Unlike the `seq<int>` case — where Z3 knows
 /// `int` `*` is associative/commutative for free — the user `mul` is a
 /// function over a `Nat` datatype, so the monoid laws must be supplied as
-/// induction lemmas (`mul_assoc` / `mul_comm` / `mul_one`) the decomposition
-/// and main lemmas can lean on. Returns `None` for shapes outside the
-/// multiplicative countdown so the caller falls back to the honest decline.
+/// induction lemmas (`mul_assoc` / `mul_comm` / `mul_one`, in turn resting on
+/// the `plus` monoid) the decomposition and main lemmas lean on. Each lemma is
+/// discharged by Dafny itself. Returns `None` for shapes outside the
+/// value-first multiplicative countdown so the caller falls back to the honest
+/// decline.
 #[allow(clippy::too_many_arguments)]
 fn emit_wrapper_nat_support_stack(
     ctx: &CodegenContext,
@@ -1728,23 +1749,111 @@ fn emit_wrapper_nat_support_stack(
     impl_dafny: &str,
     law_name_dafny: &str,
 ) -> Option<String> {
-    // Only the multiplicative countdown is handled here.
-    if combine_op != crate::ast::BinOp::Mul {
+    // Only the value-first multiplicative countdown is handled here; the
+    // additive twin is the `seq<int>` `sum_acc` path.
+    if combine_op != crate::ast::BinOp::Mul || !value_first {
         return None;
     }
-    let _ = (
-        ctx,
-        wrapper_fn,
-        inner_fn,
-        other_fn,
-        combine_fn,
-        nat_type,
-        value_first,
-        impl_dafny,
-        law_name_dafny,
+
+    // Resolve the Peano constructors (nullary base + unary self-recursive succ)
+    // and the additive monoid fn `mul` rests on.
+    let bare = nat_type.rsplit('.').next().unwrap_or(nat_type);
+    let td = ctx
+        .type_defs
+        .iter()
+        .chain(ctx.modules.iter().flat_map(|m| m.type_defs.iter()))
+        .find(|td| crate::codegen::common::type_def_name(td) == bare)?;
+    let crate::ast::TypeDef::Sum { variants, .. } = td else {
+        return None;
+    };
+    let base = variants.iter().find(|v| v.fields.is_empty())?.name.clone();
+    let succ = variants
+        .iter()
+        .find(|v| v.fields.len() == 1 && v.fields[0].trim() == bare)?
+        .name
+        .clone();
+    let combine_fd = ctx.fn_def_by_name(combine_fn, ctx.active_module_scope().as_deref())?;
+    let plus = aver_name_to_dafny(&peano_additive_callee(combine_fd)?);
+
+    let t = bare.to_string();
+    let mul = aver_name_to_dafny(combine_fn);
+    let inner = aver_name_to_dafny(inner_fn);
+    let other = aver_name_to_dafny(other_fn);
+    let wrap = aver_name_to_dafny(wrapper_fn);
+    let zero = format!("{t}.{base}");
+    let one = format!("{t}.{succ}({t}.{base})");
+    let main = format!("{impl_dafny}_{law_name_dafny}");
+    let p = format!("{main}__"); // law-scoped helper-lemma prefix
+
+    // Names of the proved helper lemmas (`plus` monoid, then `mul` monoid).
+    let (pz, ps, pc, pa, psw) = (
+        format!("{p}plus_zero_r"),
+        format!("{p}plus_succ_r"),
+        format!("{p}plus_comm"),
+        format!("{p}plus_assoc"),
+        format!("{p}plus_swap"),
     );
-    // TODO: emit the Nat-datatype monoid lemmas + decomposition stack.
-    None
+    let (om, mo, ma, mpd, mc, mz, msr) = (
+        format!("{p}one_mul"),
+        format!("{p}mul_one"),
+        format!("{p}mul_assoc"),
+        format!("{p}mul_plus_dist"),
+        format!("{p}mul_comm"),
+        format!("{p}mul_zero_r"),
+        format!("{p}mul_succ_r"),
+    );
+    let acc = format!("{inner}__acc");
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "// Law: {wrapper_fn}.{law_name_dafny} — Peano-Nat wrapper-over-recursion support stack"
+    ));
+    // ── plus monoid ──────────────────────────────────────────────────────
+    lines.push(format!(
+        "lemma {pz}(x: {t})\n  ensures {plus}(x, {zero}) == x\n  decreases x\n{{ match x case {base} => case {succ}(q) => {pz}(q); }}"
+    ));
+    lines.push(format!(
+        "lemma {ps}(x: {t}, y: {t})\n  ensures {plus}(x, {t}.{succ}(y)) == {t}.{succ}({plus}(x, y))\n  decreases x\n{{ match x case {base} => case {succ}(q) => {ps}(q, y); }}"
+    ));
+    lines.push(format!(
+        "lemma {pc}(a: {t}, b: {t})\n  ensures {plus}(a, b) == {plus}(b, a)\n  decreases a\n{{ match a case {base} => {pz}(b); case {succ}(q) => {pc}(q, b); {ps}(b, q); }}"
+    ));
+    lines.push(format!(
+        "lemma {pa}(a: {t}, b: {t}, c: {t})\n  ensures {plus}({plus}(a, b), c) == {plus}(a, {plus}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(q) => {pa}(q, b, c); }}"
+    ));
+    lines.push(format!(
+        "lemma {psw}(a: {t}, b: {t}, c: {t})\n  ensures {plus}(a, {plus}(b, c)) == {plus}(b, {plus}(a, c))\n{{ {pa}(a, b, c); {pc}(a, b); {pa}(b, a, c); }}"
+    ));
+    // ── mul monoid ───────────────────────────────────────────────────────
+    lines.push(format!(
+        "lemma {mz}(b: {t})\n  ensures {mul}(b, {zero}) == {zero}\n  decreases b\n{{ match b case {base} => case {succ}(w) => {mz}(w); }}"
+    ));
+    lines.push(format!(
+        "lemma {om}(x: {t})\n  ensures {mul}({one}, x) == x\n{{ {pz}(x); }}"
+    ));
+    lines.push(format!(
+        "lemma {mo}(a: {t})\n  ensures {mul}(a, {one}) == a\n  decreases a\n{{ match a case {base} => case {succ}(z) => {mo}(z); assert {plus}({one}, z) == {t}.{succ}(z); }}"
+    ));
+    lines.push(format!(
+        "lemma {msr}(b: {t}, z: {t})\n  ensures {mul}(b, {t}.{succ}(z)) == {plus}(b, {mul}(b, z))\n  decreases b\n{{ match b case {base} => case {succ}(w) => {msr}(w, z); {psw}(z, w, {mul}(w, z)); }}"
+    ));
+    lines.push(format!(
+        "lemma {mpd}(a: {t}, b: {t}, c: {t})\n  ensures {mul}({plus}(a, b), c) == {plus}({mul}(a, c), {mul}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(z) => {mpd}(z, b, c); {pa}(c, {mul}(z, c), {mul}(b, c)); }}"
+    ));
+    lines.push(format!(
+        "lemma {ma}(a: {t}, b: {t}, c: {t})\n  ensures {mul}({mul}(a, b), c) == {mul}(a, {mul}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(z) => {ma}(z, b, c); {mpd}(b, {mul}(z, b), c); }}"
+    ));
+    lines.push(format!(
+        "lemma {mc}(a: {t}, b: {t})\n  ensures {mul}(a, b) == {mul}(b, a)\n  decreases a\n{{ match a case {base} => {mz}(b); case {succ}(z) => {mc}(z, b); {msr}(b, z); }}"
+    ));
+    // ── accumulator decomposition + main law ─────────────────────────────
+    lines.push(format!(
+        "lemma {acc}(n: {t}, a: {t})\n  ensures {inner}(n, a) == {mul}({inner}(n, {one}), a)\n  decreases n\n{{ match n case {base} => {om}(a); case {succ}(m) => {acc}(m, {mul}(n, a)); {acc}(m, {mul}(n, {one})); {mo}(n); {ma}({inner}(m, {one}), n, a); }}"
+    ));
+    lines.push(format!(
+        "lemma {{:fuel {wrap}, 5}} {{:fuel {other}, 5}} {{:fuel {inner}, 5}} {main}(n: {t})\n  ensures {wrap}(n) == {other}(n)\n  decreases n\n{{ match n case {base} => case {succ}(m) => {main}(m); {acc}(m, {mul}(n, {one})); {mo}(n); {mc}({other}(m), n); }}\n"
+    ));
+    Some(lines.join("\n"))
 }
 
 /// True when the law's call cone (lhs + rhs, transitively expanded

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -641,13 +641,17 @@ fn emit_verify_law_forall_auto_proof_inner(
     }
 
     // Stage 8 of #232 — `WrapperOverRecursion` support stack.
-    // Aux acc-decomposition lemma + main universal lemma; both
-    // close in core Lean 4 (`omega`) without Mathlib.
+    // Aux acc-decomposition lemma + main universal lemma. The `List`-fold
+    // additive case closes in core Lean 4 (`omega`); the Peano-`Nat`
+    // multiplicative case (`factTR`) bridges the user monoid fn to `Nat.*`
+    // and closes with the core `Nat.mul_*` lemmas — still no Mathlib.
     if let Some(crate::ir::ProofStrategy::WrapperOverRecursion {
         wrapper_fn,
         inner_fn,
         other_fn,
         combine_op,
+        driver,
+        combine_fn,
     }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
         && let Some(proof) = spec::emit_wrapper_over_recursion_law(
             vb,
@@ -657,6 +661,8 @@ fn emit_verify_law_forall_auto_proof_inner(
             &inner_fn,
             &other_fn,
             combine_op,
+            &driver,
+            combine_fn.as_deref(),
         )
     {
         return Some(proof);

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -112,7 +112,7 @@ fn lean_rev_support(
 /// discovery feedback loop passes the fns its committed lemmas mention, so an
 /// op a homomorphism lemma INTRODUCES (e.g. `plus` rewriting into a law that
 /// only said `double`) still gets its bridge. Empty for the plain path.
-fn lean_nat_lift_support(
+pub(super) fn lean_nat_lift_support(
     law: &VerifyLaw,
     ctx: &CodegenContext,
     law_uid: &str,

--- a/src/codegen/lean/law_auto/spec/wrapper_over_recursion.rs
+++ b/src/codegen/lean/law_auto/spec/wrapper_over_recursion.rs
@@ -1,13 +1,21 @@
 //! Stage 8 of #232: Lean emit for `ProofStrategy::WrapperOverRecursion`.
 //!
 //! Mirror of the Dafny support-stack emit in `dafny::toplevel`. The IR
-//! pin gives us `(wrapper_fn, inner_fn, other_fn, combine_op)` —
-//! enough to render the accumulator-decomposition aux lemma plus the
-//! main universal lemma. Both close in core Lean 4 (`omega`) without
-//! a Mathlib dependency, matching the existing AverCommon shape.
+//! pin gives us `(wrapper_fn, inner_fn, other_fn, combine_op, driver,
+//! combine_fn)` — enough to render the accumulator-decomposition aux
+//! lemma plus the main universal lemma.
+//!
+//! Two drivers:
+//!   * `List` — the additive `sum_acc` shape. Closes in core Lean 4
+//!     (`omega`) without a Mathlib dependency.
+//!   * `PeanoNat` (multiplicative) — the `factTR` countdown. `omega`
+//!     cannot discharge the nonlinear residual, so the step bridges the
+//!     user monoid fn (`mul`) to `Nat.*` and closes with the core
+//!     `Nat.mul_*` lemmas — still no Mathlib.
 
 use crate::ast::{BinOp, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
+use crate::ir::WrapperDriver;
 
 use super::super::super::expr::aver_name_to_lean;
 use super::super::AutoProof;
@@ -16,13 +24,44 @@ use super::super::AutoProof;
 /// `WrapperOverRecursion` law. Returns `None` when the strategy
 /// payload doesn't carry the data the template needs (defensive —
 /// the lowerer should always provide it).
+#[allow(clippy::too_many_arguments)]
 pub(in super::super) fn emit_wrapper_over_recursion_law(
     vb: &VerifyBlock,
     law: &VerifyLaw,
-    _ctx: &CodegenContext,
+    ctx: &CodegenContext,
     wrapper_fn: &str,
     inner_fn: &str,
     other_fn: &str,
+    combine_op: BinOp,
+    driver: &WrapperDriver,
+    combine_fn: Option<&str>,
+) -> Option<AutoProof> {
+    let wrapper_l = aver_name_to_lean(wrapper_fn);
+    let inner_l = aver_name_to_lean(inner_fn);
+    let other_l = aver_name_to_lean(other_fn);
+
+    match driver {
+        WrapperDriver::List => emit_list_fold(&wrapper_l, &inner_l, &other_l, combine_op),
+        WrapperDriver::PeanoNat { value_first, .. } => emit_peano_nat_fold(
+            vb,
+            law,
+            ctx,
+            &wrapper_l,
+            &inner_l,
+            &other_l,
+            combine_op,
+            combine_fn?,
+            *value_first,
+        ),
+    }
+}
+
+/// Original `List<_>` fold (`sum_acc`): the accumulator-decomposition lemma
+/// and the main proof both close with `omega` (linear). Hardcoded `List Int`.
+fn emit_list_fold(
+    wrapper_l: &str,
+    inner_l: &str,
+    other_l: &str,
     combine_op: BinOp,
 ) -> Option<AutoProof> {
     let op = match combine_op {
@@ -35,9 +74,6 @@ pub(in super::super) fn emit_wrapper_over_recursion_law(
         BinOp::Mul => "1",
         _ => "0",
     };
-    let wrapper_l = aver_name_to_lean(wrapper_fn);
-    let inner_l = aver_name_to_lean(inner_fn);
-    let other_l = aver_name_to_lean(other_fn);
     let acc_thm = format!("{inner_l}_acc");
 
     let support_lines = vec![
@@ -65,7 +101,100 @@ pub(in super::super) fn emit_wrapper_over_recursion_law(
         "    omega".to_string(),
     ];
 
-    let _ = (vb, law);
+    Some(AutoProof {
+        support_lines,
+        body: crate::codegen::lean::tactic_ir::Tactic::raw(proof_lines),
+        replaces_theorem: false,
+    })
+}
+
+/// Peano-`Nat` countdown fold (`factTR`). The decomposition lemma
+/// `inner n acc = combine (inner n 1) acc` is proved by `induction n
+/// generalizing acc`; the main law unfolds the wrapper's neutral, peels one
+/// step with the lemma, applies the IH, and closes the nonlinear residual via
+/// the bridged user monoid fn + the core `Nat.mul_*` lemmas. Only the
+/// multiplicative case is emitted here (the additive `List` twin already
+/// covers `+`); other ops decline so the law falls back to the generic ladder.
+#[allow(clippy::too_many_arguments)]
+fn emit_peano_nat_fold(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    wrapper_l: &str,
+    inner_l: &str,
+    other_l: &str,
+    combine_op: BinOp,
+    combine_fn: &str,
+    value_first: bool,
+) -> Option<AutoProof> {
+    if combine_op != BinOp::Mul {
+        return None;
+    }
+    let neutral = "1";
+    let combine_l = aver_name_to_lean(combine_fn);
+    let acc_thm = format!("{inner_l}_acc");
+    let law_uid = format!(
+        "{}_{}",
+        aver_name_to_lean(&vb.fn_name),
+        aver_name_to_lean(&law.name)
+    );
+
+    // Bridges (user monoid fn → `Nat` builtin) plus the simp set the nonlinear
+    // close needs. The `mul` bridge proof rewrites with the `add` bridge, so
+    // seed the scan with the combine fn's own callees (`plus`) — the law scan
+    // only reaches one level deep and would miss it.
+    let mut extra = std::collections::BTreeSet::new();
+    if let Some(cfd) = ctx.fn_def_by_name(combine_fn, ctx.active_module_scope().as_deref()) {
+        crate::codegen::proof_recognize::collect_called_fns_in_body(&cfd.body, &mut extra);
+    }
+    let (bridge_support, simp_extra, _bridged) =
+        super::super::induction::lean_nat_lift_support(law, ctx, &law_uid, &extra);
+    if simp_extra.is_empty() {
+        // No Peano arith op recognized — decline rather than emit a dead proof.
+        return None;
+    }
+    let simp_set = simp_extra.join(", ");
+
+    // Render the step term in the SAME arg order the source wrote, so the
+    // rewrite matches the def's actual `combine(...)` subterm.
+    let combine_apply = |value: &str, other: &str| -> String {
+        if value_first {
+            format!("{combine_l} {value} {other}")
+        } else {
+            format!("{combine_l} {other} {value}")
+        }
+    };
+    let succ_acc = combine_apply("(m + 1)", "acc");
+    let succ_one = combine_apply("(m + 1)", neutral);
+
+    let mut support_lines = bridge_support;
+    support_lines.push(format!(
+        "theorem {acc_thm} : ∀ (n acc : Nat), {inner_l} n acc = {combine_l} ({inner_l} n {neutral}) acc := by"
+    ));
+    support_lines.push("  intro n acc".to_string());
+    support_lines.push("  induction n generalizing acc with".to_string());
+    support_lines.push(format!("  | zero => simp [{inner_l}, {simp_set}]"));
+    support_lines.push(format!(
+        "  | succ m ih => simp only [{inner_l}]; rw [ih ({succ_acc}), ih ({succ_one})]; simp [{simp_set}]"
+    ));
+
+    // Main law: unfold the wrapper's neutral (`S(Z)` renders as `0 + 1`;
+    // `Nat.zero_add` normalizes it to `1`), induct on the driver, peel one
+    // step with the decomposition lemma, apply the IH, and commute/cancel the
+    // nonlinear residual.
+    let main_step = combine_apply("(m + 1)", neutral);
+    let proof_lines = vec![
+        "  intro n".to_string(),
+        format!("  simp only [{wrapper_l}, Nat.zero_add]"),
+        "  induction n with".to_string(),
+        format!("  | zero => simp [{inner_l}, {other_l}]"),
+        "  | succ m ih =>".to_string(),
+        format!("    simp only [{inner_l}, {other_l}]"),
+        format!("    rw [{acc_thm} m ({main_step})]"),
+        "    rw [ih]".to_string(),
+        format!("    simp [{simp_set}, Nat.mul_comm]"),
+    ];
+
     Some(AutoProof {
         support_lines,
         body: crate::codegen::lean::tactic_ir::Tactic::raw(proof_lines),

--- a/src/codegen/lean/transpile.rs
+++ b/src/codegen/lean/transpile.rs
@@ -194,17 +194,6 @@ pub(super) enum LeanEmitMode {
     Proof,
 }
 
-/// Multi-file Lean output for multi-module Aver projects:
-/// - `AverCommon.lean` carries built-in helpers + records (UNION decision
-///   over every module + entry body, so a helper is included only if
-///   something actually references it).
-/// - `<Module>.lean` (one per `depends [...]` entry) wraps that module's
-///   types and pure fns in `namespace M ... end M`. Submodules like
-///   `Models.User` land at `Models/User.lean` to match Lean's path-as-
-///   module-name convention.
-/// - `<ProjectName>.lean` is the entry: trust header (here only),
-///   top-level entry items, lifted effectful fns, decisions, verify
-///   blocks. Imports `AverCommon` plus every dependent module.
 /// `true` iff `fd` is the self-recursive inner loop of a recognized
 /// `WrapperOverRecursion` law (`sumTR`, `factTR`). The strategy's
 /// accumulator-decomposition lemma rewrites with the inner fn's definitional
@@ -223,6 +212,17 @@ fn is_wrapper_over_recursion_inner(ctx: &CodegenContext, fd: &crate::ast::FnDef)
     })
 }
 
+/// Multi-file Lean output for multi-module Aver projects:
+/// - `AverCommon.lean` carries built-in helpers + records (UNION decision
+///   over every module + entry body, so a helper is included only if
+///   something actually references it).
+/// - `<Module>.lean` (one per `depends [...]` entry) wraps that module's
+///   types and pure fns in `namespace M ... end M`. Submodules like
+///   `Models.User` land at `Models/User.lean` to match Lean's path-as-
+///   module-name convention.
+/// - `<ProjectName>.lean` is the entry: trust header (here only),
+///   top-level entry items, lifted effectful fns, decisions, verify
+///   blocks. Imports `AverCommon` plus every dependent module.
 pub(super) fn transpile_unified(
     ctx: &CodegenContext,
     verify_mode: VerifyEmitMode,

--- a/src/codegen/lean/transpile.rs
+++ b/src/codegen/lean/transpile.rs
@@ -205,6 +205,24 @@ pub(super) enum LeanEmitMode {
 /// - `<ProjectName>.lean` is the entry: trust header (here only),
 ///   top-level entry items, lifted effectful fns, decisions, verify
 ///   blocks. Imports `AverCommon` plus every dependent module.
+/// `true` iff `fd` is the self-recursive inner loop of a recognized
+/// `WrapperOverRecursion` law (`sumTR`, `factTR`). The strategy's
+/// accumulator-decomposition lemma rewrites with the inner fn's definitional
+/// equations, which a `partial def` would not expose — so such a fn must emit
+/// as a terminating structural `def` even when the generic recursion classifier
+/// (which conservatively rejects a growing accumulator) leaves it unclassified.
+/// Scoped to wrapper inners: an accumulator fn the backend can't prove a law
+/// about (no strategy fires) stays `partial`, preserving the honest decline.
+fn is_wrapper_over_recursion_inner(ctx: &CodegenContext, fd: &crate::ast::FnDef) -> bool {
+    ctx.proof_ir.law_theorems.iter().any(|t| {
+        matches!(
+            &t.strategy,
+            crate::ir::ProofStrategy::WrapperOverRecursion { inner_fn, .. }
+                if *inner_fn == fd.name
+        )
+    })
+}
+
 pub(super) fn transpile_unified(
     ctx: &CodegenContext,
     verify_mode: VerifyEmitMode,
@@ -285,9 +303,19 @@ pub(super) fn transpile_unified(
                             // recursive fns the ContractLower stage could
                             // classify. Recursive fns without a contract land
                             // in `unclassified_fns` and fall through to the
-                            // partial/non-recursive emit.
+                            // partial/non-recursive emit — EXCEPT the inner loop
+                            // of a recognized `WrapperOverRecursion` law (e.g.
+                            // `factTR`). Such a fn drives structurally on its
+                            // first parameter (Lean's equation compiler infers
+                            // the measure), so emit it as a terminating `def`:
+                            // the strategy's accumulator-decomposition lemma
+                            // needs the definitional equations a `partial def`
+                            // would withhold. Scoped to wrapper inners so a bare
+                            // accumulator fn outside the strategy (whose law the
+                            // backend honestly declines) stays `partial`.
                             if is_recursive
                                 && !crate::codegen::common::fn_contract_exists_for_fn(ctx, fd)
+                                && !is_wrapper_over_recursion_inner(ctx, fd)
                             {
                                 toplevel::emit_fn_def(fd, &recursive_names, ctx)
                             } else {

--- a/src/codegen/proof_lower/wrapper_laws.rs
+++ b/src/codegen/proof_lower/wrapper_laws.rs
@@ -40,24 +40,57 @@ pub(super) fn detect_wrapper_over_recursion(
     }
     let given_name = &law.givens[0].name;
 
-    // Read the loop fn + its fold step from the shared `AccumulatorFold` pattern
-    // (recognized once by `analysis::shape`, consumed by both this strategy and
-    // the `--discover` lemma chains) — no bespoke inner-body re-walk for the OP.
-    // The monoidal strategy needs an additive/multiplicative inline step and an
-    // identity finish (the nil arm returns the accumulator).
-    let (inner_fn, combine_op) = shape.patterns.iter().find_map(|p| match p {
-        ModulePattern::AccumulatorFold {
-            wrapper_fn,
-            loop_fn,
-            step_op: Some(op),
-            finish_fn: None,
-            ..
-        } if wrapper_fn == fn_name && matches!(op, BinOp::Add | BinOp::Mul) => {
-            Some((loop_fn.clone(), *op))
-        }
-        _ => None,
-    })?;
+    // Read the loop fn + its fold roles from the shared `AccumulatorFold`
+    // pattern (recognized once by `analysis::shape`) — no bespoke inner-body
+    // re-walk for the OP. Two drivers: the original `List<_>` fold (inline
+    // `acc <op> h` step) and the Peano-`Nat` countdown (`factTR`, a named
+    // `combine(n, acc)` step). The monoidal strategy needs an additive /
+    // multiplicative step and an identity finish (the base arm returns the
+    // accumulator).
+    let (inner_fn, fold_driver_type, value_first, step_op, step_combine_fn) =
+        shape.patterns.iter().find_map(|p| match p {
+            ModulePattern::AccumulatorFold {
+                wrapper_fn,
+                loop_fn,
+                step_op,
+                step_fn,
+                finish_fn: None,
+                driver_type,
+                step_value_first,
+                ..
+            } if wrapper_fn == fn_name => Some((
+                loop_fn.clone(),
+                driver_type.clone(),
+                *step_value_first,
+                *step_op,
+                step_fn.clone(),
+            )),
+            _ => None,
+        })?;
     let wrapper_fn = fn_name.to_string();
+
+    // Resolve the combine op + typed driver from the fold roles. `List` reads
+    // the inline binop; `PeanoNat` classifies the named combine fn by its base
+    // arm (`Z -> y` is `+`, `Z -> Z` is `*`).
+    let (combine_op, driver, combine_fn) = match fold_driver_type {
+        None => {
+            let op = step_op.filter(|op| matches!(op, BinOp::Add | BinOp::Mul))?;
+            (op, crate::ir::WrapperDriver::List, None)
+        }
+        Some(type_name) => {
+            let combine = step_combine_fn?;
+            let combine_fd = inputs.find_fn_def_by_call_name(&combine)?;
+            let op = nat_monoid_op_of(combine_fd)?;
+            (
+                op,
+                crate::ir::WrapperDriver::PeanoNat {
+                    type_name,
+                    value_first,
+                },
+                Some(combine),
+            )
+        }
+    };
 
     // Law shape: `wrapper(g) == other(g)` (either side).
     let extract = |expr: &Spanned<crate::ast::Expr>| -> Option<String> {
@@ -102,15 +135,25 @@ pub(super) fn detect_wrapper_over_recursion(
     if wargs.len() != 2 {
         return None;
     }
-    let expected_neutral: i64 = match combine_op {
-        BinOp::Add | BinOp::Sub => 0,
-        BinOp::Mul => 1,
-        _ => return None,
+    let neutral_matches = match &driver {
+        crate::ir::WrapperDriver::List => {
+            let expected_neutral: i64 = match combine_op {
+                BinOp::Add | BinOp::Sub => 0,
+                BinOp::Mul => 1,
+                _ => return None,
+            };
+            matches!(
+                &wargs[1].node,
+                Expr::Literal(crate::ast::Literal::Int(n)) if *n == expected_neutral
+            )
+        }
+        crate::ir::WrapperDriver::PeanoNat { .. } => match combine_op {
+            // multiplicative identity `S(Z)`, additive identity `Z`.
+            BinOp::Mul => is_peano_one(&wargs[1]),
+            BinOp::Add => is_peano_zero(&wargs[1]),
+            _ => return None,
+        },
     };
-    let neutral_matches = matches!(
-        &wargs[1].node,
-        Expr::Literal(crate::ast::Literal::Int(n)) if *n == expected_neutral
-    );
     if !neutral_matches {
         return None;
     }
@@ -120,7 +163,77 @@ pub(super) fn detect_wrapper_over_recursion(
         inner_fn,
         other_fn,
         combine_op,
+        driver,
+        combine_fn,
     })
+}
+
+/// A constructor VALUE in any surface form this stage's AST presents: a bare
+/// nullary `Nat.Z` parses as `Attr(Ident("Nat"), "Z")`, a `Nat.S(x)` as
+/// `FnCall`, and some passes leave an `Expr::Constructor`. Returns the short
+/// (type-prefix-stripped) constructor name + its argument exprs, or `None` for
+/// a non-constructor expression. Mirrors `proof_recognize::call_or_ctor`.
+fn peano_ctor_value(
+    e: &Spanned<crate::ast::Expr>,
+) -> Option<(String, Vec<&Spanned<crate::ast::Expr>>)> {
+    use crate::ast::Expr;
+    let short = |name: &str| name.rsplit('.').next().unwrap_or(name).to_string();
+    match &e.node {
+        Expr::FnCall(callee, args) => {
+            let name = expr_to_dotted_name(&callee.node)?;
+            Some((short(&name), args.iter().collect()))
+        }
+        Expr::Constructor(name, arg) => {
+            Some((short(name), arg.iter().map(|b| b.as_ref()).collect()))
+        }
+        Expr::Attr(..) => expr_to_dotted_name(&e.node).map(|n| (short(&n), Vec::new())),
+        _ => None,
+    }
+}
+
+/// Classify a 2-param Peano monoid fn by its base arm: `Z -> y` (returns the
+/// second param) is addition; `Z -> Z` (returns a nullary constructor) is
+/// multiplication. `None` for anything else — the wrapper strategy then
+/// declines and the law falls back to the generic ladder.
+fn nat_monoid_op_of(fd: &crate::ast::FnDef) -> Option<crate::ast::BinOp> {
+    use crate::ast::{BinOp, Expr, Pattern, Stmt};
+    if fd.params.len() != 2 {
+        return None;
+    }
+    let second = fd.params[1].0.as_str();
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { arms, .. } = &body.node else {
+        return None;
+    };
+    for arm in arms {
+        let Pattern::Constructor(_, binders) = &arm.pattern else {
+            continue;
+        };
+        if !binders.is_empty() {
+            continue;
+        }
+        if matches_ident_expr(&arm.body, second) {
+            return Some(BinOp::Add);
+        }
+        if peano_ctor_value(&arm.body).is_some_and(|(_, args)| args.is_empty()) {
+            return Some(BinOp::Mul);
+        }
+    }
+    None
+}
+
+/// `Z` — a nullary constructor value (the additive Peano neutral). Name-
+/// agnostic: a Peano `Nat` has exactly one nullary constructor, and a
+/// mis-shaped neutral only degrades the proof to an honest `sorry`.
+fn is_peano_zero(e: &Spanned<crate::ast::Expr>) -> bool {
+    peano_ctor_value(e).is_some_and(|(_, args)| args.is_empty())
+}
+
+/// `S(Z)` — successor of zero (the multiplicative Peano neutral).
+fn is_peano_one(e: &Spanned<crate::ast::Expr>) -> bool {
+    peano_ctor_value(e).is_some_and(|(_, args)| args.len() == 1 && is_peano_zero(args[0]))
 }
 
 /// Return `Some(op)` iff `fn_name` resolves to a 2-arg Int wrapper

--- a/src/codegen/recursion/detect.rs
+++ b/src/codegen/recursion/detect.rs
@@ -938,20 +938,7 @@ pub(crate) fn supports_single_sizeof_structural(fd: &FnDef, inputs: &ProofLowerI
         return false;
     }
 
-    // A threaded accumulator (`factTR(m, mul(n, acc))` — the `acc` slot gets a
-    // reconstructed value every self-call) is NOT part of the structural
-    // measure: Lean recurses on the driver that shrinks (`n`), and the
-    // accumulator may grow freely. When the accumulator's TYPE is a recursive
-    // ADT (a Peano `Nat`, not a scalar `Int`) it would otherwise land in the
-    // measure and the growth check below would wrongly reject the fn. Dropping
-    // threaded slots is purely additive: a slot passed a reconstructed (non-
-    // local) expression in EVERY self-call never contributes a structural
-    // decrease, so removing it cannot lose an accept — only admit the genuine
-    // single-driver structural shape Lean's equation compiler closes natively.
-    let metric_indices: Vec<usize> = sizeof_measure_param_indices(fd)
-        .into_iter()
-        .filter(|idx| !param_threaded_in_recursion(fd, *idx))
-        .collect();
+    let metric_indices = sizeof_measure_param_indices(fd);
     if metric_indices.is_empty() {
         return false;
     }

--- a/src/codegen/recursion/detect.rs
+++ b/src/codegen/recursion/detect.rs
@@ -938,7 +938,20 @@ pub(crate) fn supports_single_sizeof_structural(fd: &FnDef, inputs: &ProofLowerI
         return false;
     }
 
-    let metric_indices = sizeof_measure_param_indices(fd);
+    // A threaded accumulator (`factTR(m, mul(n, acc))` — the `acc` slot gets a
+    // reconstructed value every self-call) is NOT part of the structural
+    // measure: Lean recurses on the driver that shrinks (`n`), and the
+    // accumulator may grow freely. When the accumulator's TYPE is a recursive
+    // ADT (a Peano `Nat`, not a scalar `Int`) it would otherwise land in the
+    // measure and the growth check below would wrongly reject the fn. Dropping
+    // threaded slots is purely additive: a slot passed a reconstructed (non-
+    // local) expression in EVERY self-call never contributes a structural
+    // decrease, so removing it cannot lose an accept — only admit the genuine
+    // single-driver structural shape Lean's equation compiler closes natively.
+    let metric_indices: Vec<usize> = sizeof_measure_param_indices(fd)
+        .into_iter()
+        .filter(|idx| !param_threaded_in_recursion(fd, *idx))
+        .collect();
     if metric_indices.is_empty() {
         return false;
     }

--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -1458,6 +1458,8 @@ fn module_pattern_to_json(p: &ModulePattern) -> serde_json::Value {
             step_fn,
             step_op,
             finish_fn,
+            driver_type,
+            step_value_first,
         } => json!({
             "kind": "AccumulatorFold",
             "scope": scope_json(scope),
@@ -1468,6 +1470,8 @@ fn module_pattern_to_json(p: &ModulePattern) -> serde_json::Value {
             "step_fn": step_fn,
             "step_op": step_op.map(|o| format!("{o:?}")),
             "finish_fn": finish_fn,
+            "driver_type": driver_type,
+            "step_value_first": step_value_first,
         }),
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -37,7 +37,7 @@ pub use proof_ir::{
     DecreaseProof, EscapePairSpec, FloorDivShrink, FloorWindowFigure, FnContract, FuelMetric,
     LawTheorem, MapUpdatePostconditionKind, Measure, NativeIntCountdownBody, Predicate,
     PreservationProof, ProofIR, ProofStrategy, Quantifier, QuantifierType, RecursionContract,
-    RefinedTypeDecl, SmartGuard, StringEscapeRoundtripPin, UnclassifiedFn,
+    RefinedTypeDecl, SmartGuard, StringEscapeRoundtripPin, UnclassifiedFn, WrapperDriver,
 };
 pub use symbol_table::{CtorEntry, FnEntry, ModuleEntry, SymbolTable, TypeEntry};
 

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -521,6 +521,25 @@ pub enum QuantifierType {
 /// Dafny maps the same variant to its own lemma vocabulary, a Z3
 /// backend could ship a different tactic again. Tactic names
 /// (`SimpOverLemmas`, `simp+omega`) do not appear in variant names;
+/// Driver of a [`ProofStrategy::WrapperOverRecursion`] inner loop —
+/// the structure the recursion shrinks. `List` is the original
+/// `sum_acc` shape (`match xs { [] -> acc; h::t -> loop(t, step) }`);
+/// `PeanoNat` is the `factTR` countdown (`match n { Z -> acc; S(m) ->
+/// loop(m, combine(n, acc)) }`). The two need different induction
+/// skeletons (`nil`/`cons` vs `zero`/`succ`) and, for `Mul`, different
+/// closing tactics (`omega` can't discharge a nonlinear residual).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WrapperDriver {
+    /// Structural fold over a `List<_>` first parameter.
+    List,
+    /// Countdown over a Peano-`Nat` ADT first parameter. Carries the
+    /// ADT's source type name and whether the folded value (the matched
+    /// subject) is the combine fn's FIRST argument (`mul(n, acc)` →
+    /// `true`; `mul(acc, n)` → `false`) so the backend rewrite matches
+    /// the def's actual step term.
+    PeanoNat { type_name: String, value_first: bool },
+}
+
 /// `LinearArithmetic` is named for the semantic, not the tactic.
 #[derive(Debug, Clone)]
 pub enum ProofStrategy {
@@ -822,6 +841,15 @@ pub enum ProofStrategy {
         /// Binary op the inner threads through its accumulator
         /// (`Add` / `Mul` / `Sub`). Drives the aux lemma's RHS.
         combine_op: crate::ast::BinOp,
+        /// Driver of the inner recursion: a `List<_>` structural fold
+        /// (the additive `sum_acc` shape) or a Peano-`Nat` countdown
+        /// (`factTR`). Selects the backend's induction skeleton and the
+        /// closing tactic family.
+        driver: WrapperDriver,
+        /// For a Peano-`Nat` fold whose step is a named monoid fn
+        /// (`mul(n, acc)` / `plus(n, acc)`), the combine fn's source
+        /// name. `None` for an inline-binop `List` fold (`acc + h`).
+        combine_fn: Option<String>,
     },
     /// Ground constant-fold over fixed ADT/enum constructor
     /// arguments. The law's call(s) pin every non-Int param of the

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -537,7 +537,10 @@ pub enum WrapperDriver {
     /// subject) is the combine fn's FIRST argument (`mul(n, acc)` →
     /// `true`; `mul(acc, n)` → `false`) so the backend rewrite matches
     /// the def's actual step term.
-    PeanoNat { type_name: String, value_first: bool },
+    PeanoNat {
+        type_name: String,
+        value_first: bool,
+    },
 }
 
 /// `LinearArithmetic` is named for the semantic, not the tactic.

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -128,6 +128,34 @@ fn proof_export_builds_sum_acc_when_lake_is_available() {
 }
 
 #[test]
+fn proof_dafny_verifies_fact_acc_when_dafny_is_available() {
+    // The multiplicative Peano-`Nat` twin of `sum_acc`:
+    // `WrapperOverRecursion` proves a tail-recursive factorial equals its
+    // recurrence. Z3 has no free associativity/commutativity for the user
+    // `mul` (a function over the `Nat` datatype, not `int`), so the support
+    // stack supplies the `plus`/`mul` monoid lemmas by induction before the
+    // accumulator-decomposition + main lemmas. Regression guard: disable the
+    // strategy or break a monoid lemma and `dafny verify` reports errors.
+    assert_dafny_verifies(
+        "proof-corpus/handwritten/fact_acc_spec.av",
+        "aver-dafny-fact-acc",
+    );
+}
+
+#[test]
+fn proof_export_builds_fact_acc_when_lake_is_available() {
+    // Lean side of the same multiplicative case: the decomposition lemma
+    // `factTR n acc = mul (factTR n 1) acc` + the main law, closing the
+    // nonlinear residual with the user-monoid→`Nat.*` bridges and the core
+    // `Nat.mul_*` lemmas (no Mathlib). Sorry budget 0.
+    assert_proof_builds_with_sorry_budget(
+        "proof-corpus/handwritten/fact_acc_spec.av",
+        "aver-proof-fact-acc",
+        0,
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_list_length_fold_when_dafny_is_available() {
     // Stage 8c of #232: `ProofStrategy::MatchDispatcherFold` — two
     // structural list folds (`1 + length(t)` vs `length(t) + 1`)

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -1039,3 +1039,68 @@ fn proof_lean_proves_map_set_nonempty_kernel_clean() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_proves_fact_acc_kernel_clean_universal() {
+    // Multiplicative twin of `sum_acc`: the `WrapperOverRecursion` strategy
+    // proves a tail-recursive factorial equals its recurrence over a Peano
+    // `Nat`. The accumulator threads through the user `mul`, whose nonlinear
+    // residual `omega` cannot close, so the emitter bridges `mul`→`Nat.*`
+    // (via the proved `isNatMul`/`isNatAdd` bridges) and finishes the
+    // decomposition lemma `factTR n acc = mul (factTR n 1) acc` + the main
+    // law with the core `Nat.mul_*` lemmas — no Mathlib. Result is a GENUINE
+    // universal (`universal:true`, `#print axioms` clean of `sorryAx` /
+    // `ofReduceBool`). Regression guard for the whole Peano-Nat path.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean fact-acc test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let out = temp_output_dir("aver-fact-acc-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg("proof-corpus/handwritten/fact_acc_spec.av")
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean =
+        std::fs::read_to_string(out.join("FactAccSpec.lean")).expect("read FactAccSpec.lean");
+    // The strategy must fire: the multiplicative bridge + the accumulator-
+    // decomposition lemma are what close the law (not the generic ladder).
+    assert!(
+        lean.contains("_mul_isNatMul") && lean.contains("theorem factTR_acc"),
+        "the `mul`→`Nat.*` bridge and the `factTR_acc` decomposition lemma must \
+         be emitted (the WrapperOverRecursion Peano-Nat path):\n{lean}"
+    );
+    // `factTR` must be a terminating `def`, never an opaque `partial def`
+    // (which would make the decomposition lemma unprovable).
+    assert!(
+        lean.contains("def factTR") && !lean.contains("partial def factTR"),
+        "factTR must emit as a terminating `def`, not `partial def`:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "tail-recursive factorial == its recurrence must kernel-prove as a \
+         GENUINE universal (passed, 0 sorries, universal:true).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

Extends the wrapper-over-recursion proof strategy from the additive `List` fold (`sum_acc`) to a **multiplicative Peano-`Nat` countdown** — a tail-recursive factorial proved equal to its direct recurrence, universally and kernel-clean, on **both** Lean and Dafny.

`proof-corpus/handwritten/fact_acc_spec.av`:
- **Lean:** `0 sorries, universal: yes` (kernel axioms `[propext, Quot.sound]` — no `sorryAx`, no `native_decide`)
- **Dafny:** `0 errors, 0 axioms, 0 omitted`

On `main` the same file reports `1 sorries, universal: no` (Lean) and `1 errors` (Dafny) — the revert-test is load-bearing.

## How

Three pieces:

1. **Termination.** A recursive fn with a threaded accumulator whose *type* is a recursive ADT (a Peano `Nat`, not a scalar `Int`) no longer fails the structural-measure check — the accumulator slot is dropped from the measure, so the genuine single-driver structural recursion is recognized and Lean emits a terminating `def` instead of an opaque `partial def` (which would make the decomposition lemma unprovable). Purely additive: a threaded slot never contributes a structural decrease, so dropping it can only admit the genuine-driver shape, and Lean re-checks termination when it elaborates the `def`.

2. **Recognizer.** `AccumulatorFold` now also matches the `Nat` countdown `match n { Z -> acc; S(m) -> loop(m, combine(n, acc)) }`, carrying the driver kind and the named combine fn into the `WrapperOverRecursion` strategy.

3. **Backends.**
   - *Lean:* for the `Nat`/`*` driver it bridges the user monoid fn to `Nat.*` (the existing proved `isNatAdd`/`isNatMul` bridges) and closes the nonlinear residual of the decomposition lemma + main law with the core `Nat.mul_*` lemmas — still **no Mathlib**.
   - *Dafny:* Z3 has no free associativity/commutativity for a user `mul` over a `Nat` datatype, so the support stack emits the `plus`/`mul` monoid lemmas (right-identity, succ-shift, commutativity, associativity, distributivity) by induction, then the accumulator-decomposition lemma and the main law on top.

The additive `List` path is unchanged (byte-identical output; `sum_acc` regression test green).

## Tests

- `dafny verify` on the example (`builds.rs`)
- Lean export at sorry budget 0 (`builds.rs`)
- a kernel-clean **universal** assertion — `passed`, `0 sorries`, `universal:true` — that also pins `factTR` as a terminating `def` and the multiplicative bridge + decomposition lemma being emitted (`lean_kernel.rs`)

## Scope

Targets the value-first multiplicative Peano-`Nat` countdown (the factorial shape). The additive Peano twin and the bare-`Int` countdown are out of scope; the recognizer/emitters decline those cleanly (fall back to the generic ladder), never emitting a false proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)