### PR TITLE
proof: total accumulator-fold ↔ recurrence across driver × combine (4/4 grid cells)

### DIFF
--- a/proof-corpus/handwritten/list_prod_spec.av
+++ b/proof-corpus/handwritten/list_prod_spec.av
@@ -1,0 +1,20 @@
+module ListProd
+    intent = "List + Mul corner of the accumulator-fold grid: a tail-recursive product equals its recurrence."
+    effects []
+
+fn prodTR(xs: List<Int>, acc: Int) -> Int
+    match xs
+        [] -> acc
+        [h, ..t] -> prodTR(t, acc * h)
+
+fn prodFold(xs: List<Int>) -> Int
+    prodTR(xs, 1)
+
+fn prodSpec(xs: List<Int>) -> Int
+    match xs
+        [] -> 1
+        [h, ..t] -> h * prodSpec(t)
+
+verify prodFold law equalsSpec
+    given xs: List<Int> = [[], [2], [2, 3], [4, 5, 6]]
+    prodFold(xs) => prodSpec(xs)

--- a/proof-corpus/handwritten/nat_tri_spec.av
+++ b/proof-corpus/handwritten/nat_tri_spec.av
@@ -1,0 +1,29 @@
+module NatTri
+    intent = "Nat + Add corner of the accumulator-fold grid: a tail-recursive triangular-sum equals its recurrence."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn triTR(n: Nat, acc: Nat) -> Nat
+    match n
+        Nat.Z -> acc
+        Nat.S(m) -> triTR(m, plus(n, acc))
+
+fn triFold(n: Nat) -> Nat
+    triTR(n, Nat.Z)
+
+fn triSpec(n: Nat) -> Nat
+    match n
+        Nat.Z -> Nat.Z
+        Nat.S(m) -> plus(n, triSpec(m))
+
+verify triFold law equalsSpec
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z)), Nat.S(Nat.S(Nat.S(Nat.Z)))]
+    triFold(n) => triSpec(n)

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1749,9 +1749,11 @@ fn emit_wrapper_nat_support_stack(
     impl_dafny: &str,
     law_name_dafny: &str,
 ) -> Option<String> {
-    // Only the value-first multiplicative countdown is handled here; the
-    // additive twin is the `seq<int>` `sum_acc` path.
-    if combine_op != crate::ast::BinOp::Mul || !value_first {
+    // Value-first countdown over a Peano `Nat`, additive OR multiplicative.
+    // The `List`/`seq<int>` driver is the sibling stack; here the close is
+    // chosen by the combine op — additive rests on the `plus` monoid alone,
+    // multiplicative builds the `mul` monoid on top of it.
+    if !value_first || !matches!(combine_op, crate::ast::BinOp::Add | crate::ast::BinOp::Mul) {
         return None;
     }
 
@@ -1772,35 +1774,32 @@ fn emit_wrapper_nat_support_stack(
         .find(|v| v.fields.len() == 1 && v.fields[0].trim() == bare)?
         .name
         .clone();
-    let combine_fd = ctx.fn_def_by_name(combine_fn, ctx.active_module_scope().as_deref())?;
-    let plus = aver_name_to_dafny(&peano_additive_callee(combine_fd)?);
+    // The additive monoid: for a multiplicative combine (`mul`) it is the
+    // callee of `mul`'s succ arm (`S(z) -> plus(y, mul(z, y))`); for an
+    // additive combine the fn IS that monoid.
+    let plus = match combine_op {
+        crate::ast::BinOp::Mul => {
+            let combine_fd =
+                ctx.fn_def_by_name(combine_fn, ctx.active_module_scope().as_deref())?;
+            aver_name_to_dafny(&peano_additive_callee(combine_fd)?)
+        }
+        _ => aver_name_to_dafny(combine_fn),
+    };
 
     let t = bare.to_string();
-    let mul = aver_name_to_dafny(combine_fn);
     let inner = aver_name_to_dafny(inner_fn);
     let other = aver_name_to_dafny(other_fn);
     let wrap = aver_name_to_dafny(wrapper_fn);
     let zero = format!("{t}.{base}");
-    let one = format!("{t}.{succ}({t}.{base})");
     let main = format!("{impl_dafny}_{law_name_dafny}");
     let p = format!("{main}__"); // law-scoped helper-lemma prefix
 
-    // Names of the proved helper lemmas (`plus` monoid, then `mul` monoid).
-    let (pz, ps, pc, pa, psw) = (
+    // `plus` monoid helper-lemma names (shared by both combine ops).
+    let (pz, ps, pc, pa) = (
         format!("{p}plus_zero_r"),
         format!("{p}plus_succ_r"),
         format!("{p}plus_comm"),
         format!("{p}plus_assoc"),
-        format!("{p}plus_swap"),
-    );
-    let (om, mo, ma, mpd, mc, mz, msr) = (
-        format!("{p}one_mul"),
-        format!("{p}mul_one"),
-        format!("{p}mul_assoc"),
-        format!("{p}mul_plus_dist"),
-        format!("{p}mul_comm"),
-        format!("{p}mul_zero_r"),
-        format!("{p}mul_succ_r"),
     );
     let acc = format!("{inner}__acc");
 
@@ -1808,7 +1807,7 @@ fn emit_wrapper_nat_support_stack(
     lines.push(format!(
         "// Law: {wrapper_fn}.{law_name_dafny} — Peano-Nat wrapper-over-recursion support stack"
     ));
-    // ── plus monoid ──────────────────────────────────────────────────────
+    // ── plus monoid (shared) ─────────────────────────────────────────────
     lines.push(format!(
         "lemma {pz}(x: {t})\n  ensures {plus}(x, {zero}) == x\n  decreases x\n{{ match x case {base} => case {succ}(q) => {pz}(q); }}"
     ));
@@ -1821,38 +1820,67 @@ fn emit_wrapper_nat_support_stack(
     lines.push(format!(
         "lemma {pa}(a: {t}, b: {t}, c: {t})\n  ensures {plus}({plus}(a, b), c) == {plus}(a, {plus}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(q) => {pa}(q, b, c); }}"
     ));
-    lines.push(format!(
-        "lemma {psw}(a: {t}, b: {t}, c: {t})\n  ensures {plus}(a, {plus}(b, c)) == {plus}(b, {plus}(a, c))\n{{ {pa}(a, b, c); {pc}(a, b); {pa}(b, a, c); }}"
-    ));
-    // ── mul monoid ───────────────────────────────────────────────────────
-    lines.push(format!(
-        "lemma {mz}(b: {t})\n  ensures {mul}(b, {zero}) == {zero}\n  decreases b\n{{ match b case {base} => case {succ}(w) => {mz}(w); }}"
-    ));
-    lines.push(format!(
-        "lemma {om}(x: {t})\n  ensures {mul}({one}, x) == x\n{{ {pz}(x); }}"
-    ));
-    lines.push(format!(
-        "lemma {mo}(a: {t})\n  ensures {mul}(a, {one}) == a\n  decreases a\n{{ match a case {base} => case {succ}(z) => {mo}(z); assert {plus}({one}, z) == {t}.{succ}(z); }}"
-    ));
-    lines.push(format!(
-        "lemma {msr}(b: {t}, z: {t})\n  ensures {mul}(b, {t}.{succ}(z)) == {plus}(b, {mul}(b, z))\n  decreases b\n{{ match b case {base} => case {succ}(w) => {msr}(w, z); {psw}(z, w, {mul}(w, z)); }}"
-    ));
-    lines.push(format!(
-        "lemma {mpd}(a: {t}, b: {t}, c: {t})\n  ensures {mul}({plus}(a, b), c) == {plus}({mul}(a, c), {mul}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(z) => {mpd}(z, b, c); {pa}(c, {mul}(z, c), {mul}(b, c)); }}"
-    ));
-    lines.push(format!(
-        "lemma {ma}(a: {t}, b: {t}, c: {t})\n  ensures {mul}({mul}(a, b), c) == {mul}(a, {mul}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(z) => {ma}(z, b, c); {mpd}(b, {mul}(z, b), c); }}"
-    ));
-    lines.push(format!(
-        "lemma {mc}(a: {t}, b: {t})\n  ensures {mul}(a, b) == {mul}(b, a)\n  decreases a\n{{ match a case {base} => {mz}(b); case {succ}(z) => {mc}(z, b); {msr}(b, z); }}"
-    ));
-    // ── accumulator decomposition + main law ─────────────────────────────
-    lines.push(format!(
-        "lemma {acc}(n: {t}, a: {t})\n  ensures {inner}(n, a) == {mul}({inner}(n, {one}), a)\n  decreases n\n{{ match n case {base} => {om}(a); case {succ}(m) => {acc}(m, {mul}(n, a)); {acc}(m, {mul}(n, {one})); {mo}(n); {ma}({inner}(m, {one}), n, a); }}"
-    ));
-    lines.push(format!(
-        "lemma {{:fuel {wrap}, 5}} {{:fuel {other}, 5}} {{:fuel {inner}, 5}} {main}(n: {t})\n  ensures {wrap}(n) == {other}(n)\n  decreases n\n{{ match n case {base} => case {succ}(m) => {main}(m); {acc}(m, {mul}(n, {one})); {mo}(n); {mc}({other}(m), n); }}\n"
-    ));
+
+    match combine_op {
+        crate::ast::BinOp::Mul => {
+            // ── mul monoid (built on the plus monoid) ────────────────────
+            let mul = aver_name_to_dafny(combine_fn);
+            let one = format!("{t}.{succ}({t}.{base})");
+            let psw = format!("{p}plus_swap");
+            let (om, mo, ma, mpd, mc, mz, msr) = (
+                format!("{p}one_mul"),
+                format!("{p}mul_one"),
+                format!("{p}mul_assoc"),
+                format!("{p}mul_plus_dist"),
+                format!("{p}mul_comm"),
+                format!("{p}mul_zero_r"),
+                format!("{p}mul_succ_r"),
+            );
+            lines.push(format!(
+                "lemma {psw}(a: {t}, b: {t}, c: {t})\n  ensures {plus}(a, {plus}(b, c)) == {plus}(b, {plus}(a, c))\n{{ {pa}(a, b, c); {pc}(a, b); {pa}(b, a, c); }}"
+            ));
+            lines.push(format!(
+                "lemma {mz}(b: {t})\n  ensures {mul}(b, {zero}) == {zero}\n  decreases b\n{{ match b case {base} => case {succ}(w) => {mz}(w); }}"
+            ));
+            lines.push(format!(
+                "lemma {om}(x: {t})\n  ensures {mul}({one}, x) == x\n{{ {pz}(x); }}"
+            ));
+            lines.push(format!(
+                "lemma {mo}(a: {t})\n  ensures {mul}(a, {one}) == a\n  decreases a\n{{ match a case {base} => case {succ}(z) => {mo}(z); assert {plus}({one}, z) == {t}.{succ}(z); }}"
+            ));
+            lines.push(format!(
+                "lemma {msr}(b: {t}, z: {t})\n  ensures {mul}(b, {t}.{succ}(z)) == {plus}(b, {mul}(b, z))\n  decreases b\n{{ match b case {base} => case {succ}(w) => {msr}(w, z); {psw}(z, w, {mul}(w, z)); }}"
+            ));
+            lines.push(format!(
+                "lemma {mpd}(a: {t}, b: {t}, c: {t})\n  ensures {mul}({plus}(a, b), c) == {plus}({mul}(a, c), {mul}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(z) => {mpd}(z, b, c); {pa}(c, {mul}(z, c), {mul}(b, c)); }}"
+            ));
+            lines.push(format!(
+                "lemma {ma}(a: {t}, b: {t}, c: {t})\n  ensures {mul}({mul}(a, b), c) == {mul}(a, {mul}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(z) => {ma}(z, b, c); {mpd}(b, {mul}(z, b), c); }}"
+            ));
+            lines.push(format!(
+                "lemma {mc}(a: {t}, b: {t})\n  ensures {mul}(a, b) == {mul}(b, a)\n  decreases a\n{{ match a case {base} => {mz}(b); case {succ}(z) => {mc}(z, b); {msr}(b, z); }}"
+            ));
+            // ── accumulator decomposition + main law (multiplicative) ─────
+            lines.push(format!(
+                "lemma {acc}(n: {t}, a: {t})\n  ensures {inner}(n, a) == {mul}({inner}(n, {one}), a)\n  decreases n\n{{ match n case {base} => {om}(a); case {succ}(m) => {acc}(m, {mul}(n, a)); {acc}(m, {mul}(n, {one})); {mo}(n); {ma}({inner}(m, {one}), n, a); }}"
+            ));
+            lines.push(format!(
+                "lemma {{:fuel {wrap}, 5}} {{:fuel {other}, 5}} {{:fuel {inner}, 5}} {main}(n: {t})\n  ensures {wrap}(n) == {other}(n)\n  decreases n\n{{ match n case {base} => case {succ}(m) => {main}(m); {acc}(m, {mul}(n, {one})); {mo}(n); {mc}({other}(m), n); }}\n"
+            ));
+        }
+        _ => {
+            // ── accumulator decomposition + main law (additive) ──────────
+            // No `mul` monoid: the close rests on `plus` associativity and
+            // commutativity alone, and the neutral is `zero` (the additive
+            // identity). `inner n acc = plus (inner n zero) acc`.
+            lines.push(format!(
+                "lemma {acc}(n: {t}, a: {t})\n  ensures {inner}(n, a) == {plus}({inner}(n, {zero}), a)\n  decreases n\n{{ match n case {base} => case {succ}(m) => {acc}(m, {plus}(n, a)); {acc}(m, {plus}(n, {zero})); {pz}(n); {pa}({inner}(m, {zero}), n, a); }}"
+            ));
+            lines.push(format!(
+                "lemma {{:fuel {wrap}, 5}} {{:fuel {other}, 5}} {{:fuel {inner}, 5}} {main}(n: {t})\n  ensures {wrap}(n) == {other}(n)\n  decreases n\n{{ match n case {base} => case {succ}(m) => {main}(m); {acc}(m, {plus}(n, {zero})); {pz}(n); {pc}({other}(m), n); }}\n"
+            ));
+        }
+    }
     Some(lines.join("\n"))
 }
 

--- a/src/codegen/lean/law_auto/spec/wrapper_over_recursion.rs
+++ b/src/codegen/lean/law_auto/spec/wrapper_over_recursion.rs
@@ -76,6 +76,18 @@ fn emit_list_fold(
     };
     let acc_thm = format!("{inner_l}_acc");
 
+    // The decomposition residual is linear for `+`/`-` (omega closes it) but
+    // nonlinear for `*` — there the close is core-Lean Int multiplicative
+    // associativity/commutativity/identity (no Mathlib). The combine op picks
+    // the close independently of the `List` driver skeleton.
+    let (acc_close, main_close) = match combine_op {
+        BinOp::Mul => (
+            "simp [Int.one_mul, Int.mul_one, Int.mul_assoc, Int.mul_comm, Int.mul_left_comm]",
+            "simp [ih, Int.one_mul, Int.mul_one, Int.mul_assoc, Int.mul_comm, Int.mul_left_comm]",
+        ),
+        _ => ("omega", "omega"),
+    };
+
     let support_lines = vec![
         format!(
             "theorem {acc_thm} (xs : List Int) (a : Int) : {inner_l} xs a = a {op} {inner_l} xs {neutral} := by"
@@ -83,7 +95,7 @@ fn emit_list_fold(
         "  induction xs generalizing a with".to_string(),
         format!("  | nil => simp [{inner_l}]"),
         format!(
-            "  | cons h t ih => simp only [{inner_l}]; rw [ih (a {op} h), ih ({neutral} {op} h)]; omega"
+            "  | cons h t ih => simp only [{inner_l}]; rw [ih (a {op} h), ih ({neutral} {op} h)]; {acc_close}"
         ),
     ];
 
@@ -98,7 +110,7 @@ fn emit_list_fold(
         format!("    simp only [{wrapper_l}, {inner_l}, {other_l}]"),
         format!("    rw [{acc_thm} t ({neutral} {op} h)]"),
         format!("    simp only [{wrapper_l}] at ih"),
-        "    omega".to_string(),
+        format!("    {main_close}"),
     ];
 
     Some(AutoProof {
@@ -108,13 +120,14 @@ fn emit_list_fold(
     })
 }
 
-/// Peano-`Nat` countdown fold (`factTR`). The decomposition lemma
-/// `inner n acc = combine (inner n 1) acc` is proved by `induction n
+/// Peano-`Nat` countdown fold (`factTR` / `triTR`). The decomposition lemma
+/// `inner n acc = combine (inner n neutral) acc` is proved by `induction n
 /// generalizing acc`; the main law unfolds the wrapper's neutral, peels one
-/// step with the lemma, applies the IH, and closes the nonlinear residual via
-/// the bridged user monoid fn + the core `Nat.mul_*` lemmas. Only the
-/// multiplicative case is emitted here (the additive `List` twin already
-/// covers `+`); other ops decline so the law falls back to the generic ladder.
+/// step with the lemma, applies the IH, and closes the residual. The driver
+/// fixes the `Nat` skeleton; the combine op fixes the close and the neutral:
+/// multiplicative bridges the user monoid fn to `Nat.*` and closes with the
+/// core `Nat.mul_*` lemmas (neutral `1`), additive bridges to `+` and closes
+/// with `omega` (neutral `0`). Other ops decline to the generic ladder.
 #[allow(clippy::too_many_arguments)]
 fn emit_peano_nat_fold(
     vb: &VerifyBlock,
@@ -127,10 +140,10 @@ fn emit_peano_nat_fold(
     combine_fn: &str,
     value_first: bool,
 ) -> Option<AutoProof> {
-    if combine_op != BinOp::Mul {
+    if !matches!(combine_op, BinOp::Add | BinOp::Mul) {
         return None;
     }
-    let neutral = "1";
+    let neutral = if combine_op == BinOp::Mul { "1" } else { "0" };
     let combine_l = aver_name_to_lean(combine_fn);
     let acc_thm = format!("{inner_l}_acc");
     let law_uid = format!(
@@ -155,6 +168,21 @@ fn emit_peano_nat_fold(
     }
     let simp_set = simp_extra.join(", ");
 
+    // The decomposition + main residuals: a multiplicative close needs the core
+    // `Nat.mul_*` lemmas on top of the bridges already in `simp_set`; an
+    // additive residual is linear once `plus` is bridged to `+`, so `omega`
+    // finishes it. The combine op picks the close independently of the driver.
+    let (decomp_close, main_close) = match combine_op {
+        BinOp::Mul => (
+            format!("simp [{simp_set}]"),
+            format!("simp [{simp_set}, Nat.mul_comm]"),
+        ),
+        _ => (
+            format!("simp only [{simp_set}]; omega"),
+            format!("simp only [{simp_set}]; omega"),
+        ),
+    };
+
     // Render the step term in the SAME arg order the source wrote, so the
     // rewrite matches the def's actual `combine(...)` subterm.
     let combine_apply = |value: &str, other: &str| -> String {
@@ -175,7 +203,7 @@ fn emit_peano_nat_fold(
     support_lines.push("  induction n generalizing acc with".to_string());
     support_lines.push(format!("  | zero => simp [{inner_l}, {simp_set}]"));
     support_lines.push(format!(
-        "  | succ m ih => simp only [{inner_l}]; rw [ih ({succ_acc}), ih ({succ_one})]; simp [{simp_set}]"
+        "  | succ m ih => simp only [{inner_l}]; rw [ih ({succ_acc}), ih ({succ_one})]; {decomp_close}"
     ));
 
     // Main law: unfold the wrapper's neutral (`S(Z)` renders as `0 + 1`;
@@ -192,7 +220,7 @@ fn emit_peano_nat_fold(
         format!("    simp only [{inner_l}, {other_l}]"),
         format!("    rw [{acc_thm} m ({main_step})]"),
         "    rw [ih]".to_string(),
-        format!("    simp [{simp_set}, Nat.mul_comm]"),
+        format!("    {main_close}"),
     ];
 
     Some(AutoProof {

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -156,6 +156,33 @@ fn proof_export_builds_fact_acc_when_lake_is_available() {
 }
 
 #[test]
+fn proof_dafny_verifies_list_prod_when_dafny_is_available() {
+    // List + Mul corner of the accumulator-fold grid. Z3 knows `int` `*` is
+    // associative/commutative for free, so the `seq<int>` support stack closes
+    // with no extra monoid lemmas — but the strategy must still fire and emit
+    // the decomposition + main lemmas. Regression guard for the `List` driver
+    // under the multiplicative combine.
+    assert_dafny_verifies(
+        "proof-corpus/handwritten/list_prod_spec.av",
+        "aver-dafny-list-prod",
+    );
+}
+
+#[test]
+fn proof_dafny_verifies_nat_tri_when_dafny_is_available() {
+    // Nat + Add corner. The user `plus` is a function over the `Nat` datatype,
+    // so Z3 needs the `plus` monoid lemmas (zero/succ/comm/assoc) supplied by
+    // induction before the additive accumulator-decomposition + main lemmas —
+    // the additive sibling of the factorial support stack. Regression guard
+    // that the Peano-`Nat` support stack covers the additive combine, not just
+    // the multiplicative one.
+    assert_dafny_verifies(
+        "proof-corpus/handwritten/nat_tri_spec.av",
+        "aver-dafny-nat-tri",
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_list_length_fold_when_dafny_is_available() {
     // Stage 8c of #232: `ProofStrategy::MatchDispatcherFold` — two
     // structural list folds (`1 + length(t)` vs `length(t) + 1`)

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -1104,3 +1104,115 @@ fn proof_lean_proves_fact_acc_kernel_clean_universal() {
     );
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_proves_list_prod_kernel_clean_universal() {
+    // List + Mul corner of the accumulator-fold grid: a tail-recursive product
+    // equals its recurrence. The `List` driver fixes the induction skeleton;
+    // the `*` combine fixes the close — the linear `omega` of the additive
+    // `sum_acc` twin cannot discharge the nonlinear residual, so the emitter
+    // closes with the core `Int.mul_*` associativity/commutativity lemmas (no
+    // Mathlib). Regression guard that the close is chosen by the combine op,
+    // not hardcoded to the `List` driver's original additive `omega`.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean list-prod test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let out = temp_output_dir("aver-list-prod-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg("proof-corpus/handwritten/list_prod_spec.av")
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean = std::fs::read_to_string(out.join("ListProd.lean")).expect("read ListProd.lean");
+    assert!(
+        lean.contains("theorem prodTR_acc") && lean.contains("Int.mul_assoc"),
+        "the `prodTR_acc` decomposition lemma and the `Int.mul_*` multiplicative \
+         close must be emitted (the combine op picks the close):\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "tail-recursive product == its recurrence must kernel-prove as a \
+         GENUINE universal (passed, 0 sorries, universal:true).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn proof_lean_proves_nat_tri_kernel_clean_universal() {
+    // Nat + Add corner of the accumulator-fold grid: a tail-recursive
+    // triangular-sum equals its recurrence. The Peano-`Nat` driver fixes the
+    // induction skeleton; the `+` combine fixes the close — the `plus`→`+`
+    // bridge plus `omega` (no `Nat.mul_*` needed, unlike the factorial twin).
+    // `triTR` must emit as a terminating `def`. Regression guard that the
+    // Peano-`Nat` driver is no longer wired only alongside the multiplicative
+    // close.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean nat-tri test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let out = temp_output_dir("aver-nat-tri-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg("proof-corpus/handwritten/nat_tri_spec.av")
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean = std::fs::read_to_string(out.join("NatTri.lean")).expect("read NatTri.lean");
+    assert!(
+        lean.contains("theorem triTR_acc") && lean.contains("_plus_isNatAdd"),
+        "the `plus`→`+` bridge and the `triTR_acc` decomposition lemma must be \
+         emitted (the additive Peano-Nat path):\n{lean}"
+    );
+    assert!(
+        lean.contains("def triTR") && !lean.contains("partial def triTR"),
+        "triTR must emit as a terminating `def`, not `partial def`:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "tail-recursive triangular-sum == its recurrence must kernel-prove as a \
+         GENUINE universal (passed, 0 sorries, universal:true).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

PR #595 closed the tail-recursive factorial = recurrence (Peano-`Nat` × multiplicative). That was correct but **narrow**: the wrapper-over-recursion strategy's two axes — driver type (`List` vs Peano-`Nat`) and combine op (addition vs multiplication) — were entangled, so only the two *diagonal* grid cells closed. This makes the cross-product **total**.

### Grid (driver × combine), `universal: yes` / `0 sorries` on Lean **and** `0 errors, 0 axioms` on Dafny

| | Add | Mul |
|---|---|---|
| **List** | `sum_acc_spec` (pre-existing) | **`list_prod_spec` (new)** |
| **Nat** | **`nat_tri_spec` (new)** | `fact_acc_spec` (#595) |

The two off-diagonal cells failed before: a `List` product hit the additive `omega` close on a nonlinear residual; a Peano-`Nat` triangular sum hit the multiplicative-only guard → `sorry` (Lean) / asserted-unprovable universal (Dafny).

## How

Decouple the axes — the driver picks the decomposition lemma + induction skeleton, the combine op picks the close + neutral, independently:
- **Lean `List`**: multiplicative close = core `Int.mul_*` lemmas (no Mathlib); additive keeps `omega`.
- **Lean Peano-`Nat`**: drop the multiplicative-only guard; additive bridges `plus`→`+` + `omega` (neutral `0`), multiplicative keeps the `Nat.mul_*` close (neutral `1`).
- **Dafny Peano-`Nat`**: additive decomposition + main law on the shared `plus` monoid (the `seq<int>` driver already closes both via Z3 native `int` arithmetic).

## Verification
- All four cells: Lean `universal: yes`, `#print axioms = [propext, Quot.sound]`; Dafny `0 errors, 0 axioms`.
- **Revert-test (load-bearing):** with the emitter changes reverted, all three newly-passing cells fail (`nat_tri` Lean `1 sorry`, `nat_tri` Dafny `1 error`, `list_prod` Lean unsolved-`omega`).
- No regression: the two baselines stay green; full `proof_spec` suite; both clippy gates (incl. `--features wasm,wasip2`).
- New corpus: `proof-corpus/handwritten/{list_prod_spec,nat_tri_spec}.av`; new `proof_spec` tests pinning each cell universal.

Out of scope (flagged for later): arbitrary recursive-ADT drivers (trees) and user monoids not a recognized builtin `+`/`*` (min/max/gcd) — those need monoid laws proved on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)