### PR TITLE
proof: Peano driver works under any name (lift type positions to builtin Nat), not just `Nat`

### DIFF
--- a/proof-corpus/handwritten/peano_aliased_spec.av
+++ b/proof-corpus/handwritten/peano_aliased_spec.av
@@ -1,0 +1,34 @@
+module PeanoAliased
+    intent = "A Peano natural named other than Nat (Num/Zero/Succ) still proves the tail-recursive factorial = recurrence — the driver type is lifted to builtin Nat by shape, not by name."
+    effects []
+
+type Num
+    Zero
+    Succ(Num)
+
+fn add(x: Num, y: Num) -> Num
+    match x
+        Num.Zero -> y
+        Num.Succ(z) -> Num.Succ(add(z, y))
+
+fn mul(x: Num, y: Num) -> Num
+    match x
+        Num.Zero -> Num.Zero
+        Num.Succ(z) -> add(y, mul(z, y))
+
+fn factTR(n: Num, acc: Num) -> Num
+    match n
+        Num.Zero -> acc
+        Num.Succ(m) -> factTR(m, mul(n, acc))
+
+fn factFold(n: Num) -> Num
+    factTR(n, Num.Succ(Num.Zero))
+
+fn factSpec(n: Num) -> Num
+    match n
+        Num.Zero -> Num.Succ(Num.Zero)
+        Num.Succ(m) -> mul(n, factSpec(m))
+
+verify factFold law equalsSpec
+    given n: Num = [Num.Zero, Num.Succ(Num.Zero), Num.Succ(Num.Succ(Num.Zero))]
+    factFold(n) => factSpec(n)

--- a/src/codegen/lean/transpile.rs
+++ b/src/codegen/lean/transpile.rs
@@ -242,6 +242,16 @@ pub(super) fn transpile_unified(
         .collect();
     let recursive_names = recursive_pure_fn_names(ctx);
     let recursive_types = recursive_type_names(ctx);
+    // Lift every canonical Peano ADT's type annotations to builtin `Nat` for
+    // this emit, matching the value/pattern lift — so a Peano type named other
+    // than `Nat` is fully consistent (its binders' types agree with the `Nat`
+    // literals its values lift to). The guard clears the set when this returns.
+    let _peano_guard = crate::codegen::lean::types::scope_canonical_peano(
+        crate::codegen::proof_recognize::collect_peano_types(ctx)
+            .into_iter()
+            .map(|p| p.type_name)
+            .collect(),
+    );
     // Pure-fn param types + every type def's field types feed the
     // entries-measure emission scan: an entries-list spelling
     // (`Map<K, T>` / `List<Tuple<K, T>>`) may appear only in fn

--- a/src/codegen/lean/types.rs
+++ b/src/codegen/lean/types.rs
@@ -1,5 +1,41 @@
 /// Aver type → Lean 4 type string mapping.
 use crate::types::Type;
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+thread_local! {
+    /// Type names of the canonical Peano ADTs in the program currently being
+    /// transpiled to Lean. A canonical Peano type (`T { Zero; Succ(T) }`,
+    /// shape-detected by `detect_canonical_peano` — any name, not just `Nat`)
+    /// is lifted to Lean's builtin `Nat`: its VALUES and PATTERNS already lift
+    /// (`Zero`→`0`, `Succ e`→`e + 1`), so its TYPE annotations must lift to
+    /// `Nat` too — otherwise a `T`-typed binder is matched against `Nat`
+    /// literals and the proof is ill-typed. Populated once per
+    /// `transpile_unified`; empty outside it, so a stray `type_to_lean` keeps
+    /// the prior (no-lift) behavior.
+    static CANONICAL_PEANO: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+}
+
+/// Mark `names` as the canonical-Peano types to lift to `Nat` for the lifetime
+/// of the returned guard. The guard clears the set on drop, so a `type_to_lean`
+/// call outside the transpile scope never sees stale lift state.
+pub(crate) fn scope_canonical_peano(names: HashSet<String>) -> CanonicalPeanoGuard {
+    CANONICAL_PEANO.with(|s| *s.borrow_mut() = names);
+    CanonicalPeanoGuard
+}
+
+pub(crate) struct CanonicalPeanoGuard;
+
+impl Drop for CanonicalPeanoGuard {
+    fn drop(&mut self) {
+        CANONICAL_PEANO.with(|s| s.borrow_mut().clear());
+    }
+}
+
+fn is_canonical_peano(name: &str) -> bool {
+    let bare = name.rsplit('.').next().unwrap_or(name);
+    CANONICAL_PEANO.with(|s| s.borrow().contains(bare))
+}
 
 /// Convert an Aver `Type` to a Lean 4 type string.
 pub fn type_to_lean(ty: &Type) -> String {
@@ -47,7 +83,13 @@ pub fn type_to_lean(ty: &Type) -> String {
         // information. Identity-sensitive routing happens at the
         // call layer (see `backend_named_type_key`).
         Type::Named { name, .. } => {
-            if name.contains('.') {
+            if is_canonical_peano(name) {
+                // Lifted to builtin `Nat` (consistent with the value/pattern
+                // lift in `expr.rs`/`pattern.rs`), so any-named Peano ADT — not
+                // just one literally called `Nat` — gets the builtin-`Nat`
+                // proof machinery (`omega`, `Nat.*`).
+                "Nat".to_string()
+            } else if name.contains('.') {
                 name.replace('.', "_")
             } else {
                 name.clone()

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -183,6 +183,18 @@ fn proof_dafny_verifies_nat_tri_when_dafny_is_available() {
 }
 
 #[test]
+fn proof_dafny_verifies_aliased_peano_when_dafny_is_available() {
+    // A Peano natural named other than `Nat` (`Num`). Dafny names the datatype
+    // directly (no builtin-`Nat` lift needed), so the factorial support stack
+    // verifies over `Num` exactly as over `Nat`. Pairs with the Lean
+    // `proof_lean_lifts_aliased_peano_type_to_nat_and_proves_universal` guard.
+    assert_dafny_verifies(
+        "proof-corpus/handwritten/peano_aliased_spec.av",
+        "aver-dafny-peano-aliased",
+    );
+}
+
+#[test]
 fn proof_dafny_verifies_list_length_fold_when_dafny_is_available() {
     // Stage 8c of #232: `ProofStrategy::MatchDispatcherFold` — two
     // structural list folds (`1 + length(t)` vs `length(t) + 1`)

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -1216,3 +1216,62 @@ fn proof_lean_proves_nat_tri_kernel_clean_universal() {
     );
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_lifts_aliased_peano_type_to_nat_and_proves_universal() {
+    // A Peano natural named other than `Nat` (`Num` with `Zero`/`Succ`) must
+    // get the builtin-`Nat` treatment by SHAPE, not by name: its values lift
+    // (`Zero`→`0`, `Succ e`→`e + 1`) AND its type annotations lift (`Num`→
+    // `Nat`), so the factorial wrapper-over-recursion law closes kernel-clean.
+    // Regression guard: before the type-annotation lift, the binder type
+    // (`Num`) disagreed with the lifted `Nat` literals and the proof failed.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean aliased-peano test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let out = temp_output_dir("aver-peano-aliased-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg("proof-corpus/handwritten/peano_aliased_spec.av")
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean =
+        std::fs::read_to_string(out.join("PeanoAliased.lean")).expect("read PeanoAliased.lean");
+    // The `Num` driver must be lifted to builtin `Nat` in TYPE position too:
+    // the `def` binders read `: Nat`, never `: Num` (a `: Num` binder would
+    // disagree with the lifted `Nat` literals in the bodies).
+    assert!(
+        lean.contains("def factTR (n : Nat)")
+            && lean.contains("def factSpec (n : Nat)")
+            && !lean.contains("(n : Num)"),
+        "the aliased Peano type `Num` must lift to builtin `Nat` in type \
+         annotations (def binders should read `: Nat`, not `: Num`):\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "a non-`Nat`-named Peano factorial must kernel-prove as a GENUINE \
+         universal (passed, 0 sorries, universal:true).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

Follow-up to #596. #596 made the accumulator-fold ↔ recurrence strategy total across the **combine** axis (Add/Mul). Post-merge probing found the **driver** axis still carried a hidden constraint: the Peano-`Nat` driver only worked on Lean for a user type **literally named `Nat`**. A structurally-identical Peano type named `Num` failed (`sorry`).

## Root cause

A canonical Peano type (`T { Zero; Succ(T) }`, detected by **shape** via `detect_canonical_peano`) already had its **values/patterns** lifted to Lean's builtin `Nat` (`Zero`→`0`, `Succ e`→`e + 1`) for any name — but its **type annotations** were *not* lifted. For a type named `Nat` the annotation coincided with builtin `Nat`; for `Num` the binder type (`Num`) disagreed with the `Nat` literals its values became → ill-typed lemma → `sorry`. (Dafny was already name-agnostic — it names the datatype directly.)

## Fix

Complete the lift: `type_to_lean`'s `Named` arm maps a canonical-Peano type name to `Nat`. The set of such names is collected once per `transpile_unified` (reusing `collect_peano_types`, the same source the value-lift uses) and cleared by an RAII guard on return, so a `type_to_lean` call outside the transpile scope keeps the prior no-lift behavior. Lean-only.

## Verification
- Renamed Peano probes (factorial + triangular-sum over `Num`/`Zero`/`Succ`) now prove `universal: yes`, `#print axioms = [propext, Quot.sound]`; before the fix they `sorry`'d.
- No regression: `Nat`-named baselines (`sum_acc`, `fact_acc`, `nat_tri`, `list_prod`) stay green; full `proof_spec` suite; both clippy gates (incl. `--features wasm,wasip2`).
- New corpus `peano_aliased_spec.av` + tests pinning the type-annotation lift and a kernel-clean universal on both backends.

Still out of scope (the eventual general form): arbitrary recursive-ADT drivers (trees) and user monoids not a recognized builtin `+`/`*` (min/max/gcd) — need monoid laws proved on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)