### PR TITLE
proof: close drop/take count-composition and tail-recursive exponentiation

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1884,6 +1884,154 @@ fn emit_wrapper_nat_support_stack(
     Some(lines.join("\n"))
 }
 
+/// TIP prop_35 (`exp x y = qexp x y one`): Dafny support stack for a
+/// `TailRecFixedBaseFold` — the tail-recursive-with-fixed-base shape. Reuses the
+/// `plus`/`mul` Peano monoid prelude, then the accumulator-decomposition lemma
+/// `qexp(x, n, a) == mul(qexp(x, n, one), a)` (the extra `x` is held fixed
+/// through the induction on `n`) and the main law `exp(x, n) == qexp(x, n, one)`.
+/// The combine multiplies the accumulator by the FIXED base `x` (not the matched
+/// subject). Returns `None` for shapes outside the multiplicative/additive Peano
+/// combine so the caller keeps the honest omitted decline.
+#[allow(clippy::too_many_arguments)]
+fn emit_tailrec_fixed_base_support_stack(
+    ctx: &CodegenContext,
+    spec_fn: &str,
+    loop_fn: &str,
+    combine_fn: &str,
+    combine_op: crate::ast::BinOp,
+    nat_type: &str,
+    impl_dafny: &str,
+    law_name_dafny: &str,
+) -> Option<String> {
+    if !matches!(combine_op, crate::ast::BinOp::Add | crate::ast::BinOp::Mul) {
+        return None;
+    }
+
+    // Peano constructors (nullary base + unary self-recursive succ) and the
+    // additive monoid fn the combine rests on.
+    let bare = nat_type.rsplit('.').next().unwrap_or(nat_type);
+    let td = ctx
+        .type_defs
+        .iter()
+        .chain(ctx.modules.iter().flat_map(|m| m.type_defs.iter()))
+        .find(|td| crate::codegen::common::type_def_name(td) == bare)?;
+    let crate::ast::TypeDef::Sum { variants, .. } = td else {
+        return None;
+    };
+    let base = variants.iter().find(|v| v.fields.is_empty())?.name.clone();
+    let succ = variants
+        .iter()
+        .find(|v| v.fields.len() == 1 && v.fields[0].trim() == bare)?
+        .name
+        .clone();
+    let plus = match combine_op {
+        crate::ast::BinOp::Mul => {
+            let combine_fd =
+                ctx.fn_def_by_name(combine_fn, ctx.active_module_scope().as_deref())?;
+            aver_name_to_dafny(&peano_additive_callee(combine_fd)?)
+        }
+        _ => aver_name_to_dafny(combine_fn),
+    };
+
+    let t = bare.to_string();
+    let spec = aver_name_to_dafny(spec_fn);
+    let loop_d = aver_name_to_dafny(loop_fn);
+    let zero = format!("{t}.{base}");
+    let main = format!("{impl_dafny}_{law_name_dafny}");
+    let p = format!("{main}__"); // law-scoped helper-lemma prefix
+    let acc = format!("{loop_d}__acc");
+
+    // `plus` monoid helper-lemma names (shared by both combine ops).
+    let (pz, ps, pc, pa) = (
+        format!("{p}plus_zero_r"),
+        format!("{p}plus_succ_r"),
+        format!("{p}plus_comm"),
+        format!("{p}plus_assoc"),
+    );
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "// Law: {spec_fn}.{law_name_dafny} — tail-recursive fixed-base fold support stack"
+    ));
+    // ── plus monoid (shared) ──
+    lines.push(format!(
+        "lemma {pz}(x: {t})\n  ensures {plus}(x, {zero}) == x\n  decreases x\n{{ match x case {base} => case {succ}(q) => {pz}(q); }}"
+    ));
+    lines.push(format!(
+        "lemma {ps}(x: {t}, y: {t})\n  ensures {plus}(x, {t}.{succ}(y)) == {t}.{succ}({plus}(x, y))\n  decreases x\n{{ match x case {base} => case {succ}(q) => {ps}(q, y); }}"
+    ));
+    lines.push(format!(
+        "lemma {pc}(a: {t}, b: {t})\n  ensures {plus}(a, b) == {plus}(b, a)\n  decreases a\n{{ match a case {base} => {pz}(b); case {succ}(q) => {pc}(q, b); {ps}(b, q); }}"
+    ));
+    lines.push(format!(
+        "lemma {pa}(a: {t}, b: {t}, c: {t})\n  ensures {plus}({plus}(a, b), c) == {plus}(a, {plus}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(q) => {pa}(q, b, c); }}"
+    ));
+
+    let one = format!("{t}.{succ}({t}.{base})");
+    match combine_op {
+        crate::ast::BinOp::Mul => {
+            // ── mul monoid (built on the plus monoid) ──
+            let mul = aver_name_to_dafny(combine_fn);
+            let psw = format!("{p}plus_swap");
+            let (om, mo, ma, mpd, mc, mz, msr) = (
+                format!("{p}one_mul"),
+                format!("{p}mul_one"),
+                format!("{p}mul_assoc"),
+                format!("{p}mul_plus_dist"),
+                format!("{p}mul_comm"),
+                format!("{p}mul_zero_r"),
+                format!("{p}mul_succ_r"),
+            );
+            lines.push(format!(
+                "lemma {psw}(a: {t}, b: {t}, c: {t})\n  ensures {plus}(a, {plus}(b, c)) == {plus}(b, {plus}(a, c))\n{{ {pa}(a, b, c); {pc}(a, b); {pa}(b, a, c); }}"
+            ));
+            lines.push(format!(
+                "lemma {mz}(b: {t})\n  ensures {mul}(b, {zero}) == {zero}\n  decreases b\n{{ match b case {base} => case {succ}(w) => {mz}(w); }}"
+            ));
+            lines.push(format!(
+                "lemma {om}(x: {t})\n  ensures {mul}({one}, x) == x\n{{ {pz}(x); }}"
+            ));
+            lines.push(format!(
+                "lemma {mo}(a: {t})\n  ensures {mul}(a, {one}) == a\n  decreases a\n{{ match a case {base} => case {succ}(z) => {mo}(z); assert {plus}({one}, z) == {t}.{succ}(z); }}"
+            ));
+            lines.push(format!(
+                "lemma {msr}(b: {t}, z: {t})\n  ensures {mul}(b, {t}.{succ}(z)) == {plus}(b, {mul}(b, z))\n  decreases b\n{{ match b case {base} => case {succ}(w) => {msr}(w, z); {psw}(z, w, {mul}(w, z)); }}"
+            ));
+            lines.push(format!(
+                "lemma {mpd}(a: {t}, b: {t}, c: {t})\n  ensures {mul}({plus}(a, b), c) == {plus}({mul}(a, c), {mul}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(z) => {mpd}(z, b, c); {pa}(c, {mul}(z, c), {mul}(b, c)); }}"
+            ));
+            lines.push(format!(
+                "lemma {ma}(a: {t}, b: {t}, c: {t})\n  ensures {mul}({mul}(a, b), c) == {mul}(a, {mul}(b, c))\n  decreases a\n{{ match a case {base} => case {succ}(z) => {ma}(z, b, c); {mpd}(b, {mul}(z, b), c); }}"
+            ));
+            lines.push(format!(
+                "lemma {mc}(a: {t}, b: {t})\n  ensures {mul}(a, b) == {mul}(b, a)\n  decreases a\n{{ match a case {base} => {mz}(b); case {succ}(z) => {mc}(z, b); {msr}(b, z); }}"
+            ));
+            // ── accumulator decomposition + main law (multiplicative) ──
+            // `x` is fixed through the induction on `n`; the combine is
+            // `mul(x, acc)` (fixed base × accumulator).
+            lines.push(format!(
+                "lemma {acc}(x: {t}, n: {t}, a: {t})\n  ensures {loop_d}(x, n, a) == {mul}({loop_d}(x, n, {one}), a)\n  decreases n\n{{ match n case {base} => {om}(a); case {succ}(m) => {acc}(x, m, {mul}(x, a)); {acc}(x, m, {mul}(x, {one})); {mo}(x); {ma}({loop_d}(x, m, {one}), x, a); }}"
+            ));
+            lines.push(format!(
+                "lemma {{:fuel {spec}, 5}} {{:fuel {loop_d}, 5}} {main}(x: {t}, n: {t})\n  ensures {spec}(x, n) == {loop_d}(x, n, {one})\n  decreases n\n{{ match n case {base} => case {succ}(m) => {main}(x, m); {acc}(x, m, {mul}(x, {one})); {mo}(x); {mc}({spec}(x, m), x); }}\n"
+            ));
+        }
+        _ => {
+            // ── accumulator decomposition + main law (additive) ──
+            // No `mul` monoid: the close rests on `plus` associativity and
+            // commutativity, neutral is `zero`. Combine is `plus(x, acc)`.
+            let plus_c = aver_name_to_dafny(combine_fn);
+            lines.push(format!(
+                "lemma {acc}(x: {t}, n: {t}, a: {t})\n  ensures {loop_d}(x, n, a) == {plus_c}({loop_d}(x, n, {zero}), a)\n  decreases n\n{{ match n case {base} => {pc}({zero}, a); {pz}(a); case {succ}(m) => {acc}(x, m, {plus_c}(x, a)); {acc}(x, m, {plus_c}(x, {zero})); {pz}(x); {pa}({loop_d}(x, m, {zero}), x, a); }}"
+            ));
+            lines.push(format!(
+                "lemma {{:fuel {spec}, 5}} {{:fuel {loop_d}, 5}} {main}(x: {t}, n: {t})\n  ensures {spec}(x, n) == {loop_d}(x, n, {zero})\n  decreases n\n{{ match n case {base} => case {succ}(m) => {main}(x, m); {acc}(x, m, {plus_c}(x, {zero})); {pz}(x); {pc}({spec}(x, m), x); }}\n"
+            ));
+        }
+    }
+    Some(lines.join("\n"))
+}
+
 /// True when the law's call cone (lhs + rhs, transitively expanded
 /// through fn bodies) reaches a fn carrying the guard-validated
 /// floor-division countdown contract
@@ -2208,6 +2356,40 @@ pub fn emit_verify_law(
     // closed by Dafny's `decreases`-driven induction either; the
     // `__fuel`-style wrapper hides the structural decrease. Sample
     // assertions still cover the declared domain.
+    // TIP prop_35 — `TailRecFixedBaseFold` (the `qexp` shape). The loop is
+    // rejected by the recursion classifier (a growing accumulator) so it lands
+    // in `unclassified_fns` and would trip the fuel gate below, but the strategy
+    // supplies its own complete Peano-monoid support stack that PROVES the
+    // universal. Emit it before the fuel gate (mirror of the Lean fuel-gate
+    // exception). Falls through only if the stack declines the shape.
+    if let Some(crate::ir::ProofStrategy::TailRecFixedBaseFold {
+        spec_fn,
+        loop_fn,
+        combine_fn,
+        combine_op,
+        type_name,
+    }) = vb_fn_id
+        .and_then(|fn_id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == fn_id && t.law_name == law.name)
+        })
+        .map(|t| t.strategy.clone())
+        && let Some(stack) = emit_tailrec_fixed_base_support_stack(
+            ctx,
+            &spec_fn,
+            &loop_fn,
+            &combine_fn,
+            combine_op,
+            &type_name,
+            &fn_name,
+            &law_name,
+        )
+    {
+        return stack;
+    }
+
     let unclassified = crate::codegen::common::unclassified_fn_names(ctx);
     let calls_fuel_bounded = crate::codegen::common::law_calls_unclassified_fn(law, &unclassified);
     if singleton_const_rhs || calls_fuel_bounded {
@@ -2389,6 +2571,9 @@ pub fn emit_verify_law(
             }
         }
     }
+    // (`TailRecFixedBaseFold` is dispatched earlier — before the fuel gate —
+    // since its `qexp` loop is classifier-rejected and would otherwise be
+    // omitted; see the early return above.)
 
     // Refinement lift: for each Int given whose value is wrapped in
     // a refinement record on either side (e.g. `IntRange(value = a)`),

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -326,6 +326,29 @@ fn emit_verify_law_forall_auto_proof_inner(
     {
         return Some(proof);
     }
+    // IR-pinned `TailRecFixedBaseFold` (TIP prop_35, `exp x y = qexp x y one`).
+    // Like `FloorDivWindow`, it renders its own TRUE-universal statement plus the
+    // accumulator-generalization support lemma (`replaces_theorem`); the caller's
+    // law-class marker classes it `universal`, fail-closed behind `#print axioms`.
+    if let Some(crate::ir::ProofStrategy::TailRecFixedBaseFold {
+        spec_fn,
+        loop_fn,
+        combine_fn,
+        combine_op,
+        ..
+    }) = law_strategy_for(ctx, &vb.fn_name, &law.name)
+        && let Some(proof) = spec::emit_tailrec_fixed_base_fold_law(
+            law,
+            ctx,
+            theorem_base,
+            &spec_fn,
+            &loop_fn,
+            &combine_fn,
+            combine_op,
+        )
+    {
+        return Some(proof);
+    }
     // IR-pinned strategies. The lowerer's decision wins over the
     // ad-hoc detection chain that follows; backend just renders the
     // tactic the IR selected. Each variant has a fixed Lean shape;

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1831,6 +1831,249 @@ fn zip_nil_helper(
     Some(NilHelper { text, name })
 }
 
+/// Bare given name a goal-argument `Expr` refers to (an `Ident`/`Resolved`),
+/// `None` for anything composite.
+fn given_ident_name(expr: &crate::ast::Spanned<crate::ast::Expr>) -> Option<&str> {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.as_str()),
+        _ => None,
+    }
+}
+
+/// A recognized **count-composition** law: `f(op(a, b), c) = f(a, f(b, c))`
+/// (in either orientation), where the verified fn `f` recurses on a `Nat` driver
+/// with a nested list `match` in its `S` arm (the take/drop shape), `op` is a
+/// recognized canonical Peano addition, `a`/`b` are `Nat` givens and `c` is the
+/// list given. The standard proof inducts on the INNER count `b` generalizing the
+/// list `c` (the outer count `a` fixed), unfolding `f` one step on both sides and
+/// chaining the IH at the peeled tail — which the family's existing rungs (driver
+/// = `a`, or `fun_induction`) do not produce. Returns the inner-count given's name
+/// and the list given's name.
+struct CountComposition {
+    /// Source name of the inner `Nat` count given to induct on (`b`).
+    inner_count: String,
+    /// Source name of the list given to generalize over (`c`).
+    list_given: String,
+}
+
+/// Recognize the count-composition shape on the law. The verified fn `f` must be
+/// a single-list-structural fn with a synchronously-decremented `Nat` driver, and
+/// the law's two sides must be `f(op(a, b), c)` and `f(a, f(b, c))` for a
+/// recognized Peano-addition `op` over bare `Nat`/list givens.
+fn recognize_count_composition(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Option<CountComposition> {
+    use crate::ast::Expr;
+    use crate::codegen::recursion::detect::{
+        param_decremented_in_recursion, single_list_structural_param_index,
+    };
+    if law.when.is_some() {
+        return None;
+    }
+    let fd = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref())?;
+    let list_idx = single_list_structural_param_index(fd)?;
+    // The fn must drive on a synchronously-decremented Nat param (the take/drop
+    // `n`), so its first arg is the count peeled in lockstep with the list.
+    if !fd.params.iter().enumerate().any(|(i, (_, ty))| {
+        i != list_idx
+            && (ty.trim() == "Nat"
+                || crate::codegen::proof_recognize::peano_type_named(ctx, ty.trim()).is_some())
+            && param_decremented_in_recursion(fd, i)
+    }) {
+        return None;
+    }
+
+    // The recognized Peano-addition fns in the law's cone (so we know `op` is a
+    // genuine `+`, bridged to builtin addition by `lean_nat_lift_support`).
+    let add_fns: BTreeSet<String> =
+        crate::codegen::proof_recognize::collect_nat_arith_ops_in_law(law, ctx)
+            .into_iter()
+            .filter(|op| op.kind == crate::codegen::proof_recognize::NatArithKind::Add)
+            .map(|op| op.fn_name)
+            .collect();
+    if add_fns.is_empty() {
+        return None;
+    }
+
+    // `f(op(a, b), c)`: the verified fn applied to a 2-arg add over two givens and
+    // a bare list given. Returns `(a, b, c)` as source names.
+    let composed = |side: &crate::ast::Spanned<Expr>| -> Option<(String, String, String)> {
+        let Expr::FnCall(callee, args) = &side.node else {
+            return None;
+        };
+        if super::shared::expr_dotted_name(callee).as_deref() != Some(vb.fn_name.as_str())
+            || args.len() != 2
+        {
+            return None;
+        }
+        let Expr::FnCall(op_callee, op_args) = &args[0].node else {
+            return None;
+        };
+        let op_name = super::shared::expr_dotted_name(op_callee)?;
+        if !add_fns.contains(&op_name) || op_args.len() != 2 {
+            return None;
+        }
+        let a = given_ident_name(&op_args[0])?.to_string();
+        let b = given_ident_name(&op_args[1])?.to_string();
+        let c = given_ident_name(&args[1])?.to_string();
+        Some((a, b, c))
+    };
+
+    // `f(a, f(b, c))`: the verified fn nested on a bare outer count, an inner
+    // verified-fn call on a second bare count and the same list. Returns
+    // `(a, b, c)` as source names.
+    let nested = |side: &crate::ast::Spanned<Expr>| -> Option<(String, String, String)> {
+        let Expr::FnCall(callee, args) = &side.node else {
+            return None;
+        };
+        if super::shared::expr_dotted_name(callee).as_deref() != Some(vb.fn_name.as_str())
+            || args.len() != 2
+        {
+            return None;
+        }
+        let a = given_ident_name(&args[0])?.to_string();
+        let Expr::FnCall(inner_callee, inner_args) = &args[1].node else {
+            return None;
+        };
+        if super::shared::expr_dotted_name(inner_callee).as_deref() != Some(vb.fn_name.as_str())
+            || inner_args.len() != 2
+        {
+            return None;
+        }
+        let b = given_ident_name(&inner_args[0])?.to_string();
+        let c = given_ident_name(&inner_args[1])?.to_string();
+        Some((a, b, c))
+    };
+
+    // Either orientation: one side composed, the other nested, with matching
+    // `(a, b, c)`. The inner count `b` (op's second arg = nested inner first arg)
+    // is the induction target; `c` is generalized.
+    let (composed_side, nested_side) = composed(&law.lhs)
+        .map(|c| (c, nested(&law.rhs)))
+        .or_else(|| composed(&law.rhs).map(|c| (c, nested(&law.lhs))))?;
+    let (ca, cb, cc) = composed_side;
+    let (na, nb, nc) = nested_side?;
+    if ca != na || cb != nb || cc != nc {
+        return None;
+    }
+    // `b` and `a` must be distinct Nat givens, `c` the list given.
+    let given_type = |name: &str| {
+        law.givens
+            .iter()
+            .find(|g| g.name == name)
+            .map(|g| g.type_name.trim().to_string())
+    };
+    let is_nat = |name: &str| -> bool {
+        given_type(name).is_some_and(|ty| {
+            ty == "Nat" || crate::codegen::proof_recognize::peano_type_named(ctx, &ty).is_some()
+        })
+    };
+    let is_list = |name: &str| -> bool {
+        given_type(name).is_some_and(|ty| ty.starts_with("List<") || ty == "List")
+    };
+    if ca == cb || !is_nat(&ca) || !is_nat(&cb) || !is_list(&cc) {
+        return None;
+    }
+    Some(CountComposition {
+        inner_count: cb,
+        list_given: cc,
+    })
+}
+
+/// ADDITIVE rung for the count-COMPOSITION family (`f(op(a,b), c) =
+/// f(a, f(b,c))`, the `drop`/`take` composition lemmas). Inducts on the INNER
+/// count `b` generalizing the list `c`, with a closer that bridges `op` to
+/// builtin `+`, unfolds `f` one step on both sides, peels the list, and chains
+/// the IH at the tail. The synchronous-driver rung (driver = the FIRST count `a`)
+/// and `fun_induction` both fall through to `sorry` on this shape — inducting on
+/// `a` peels `op(a,b)` and the outer `f`'s list at different rates, never lining
+/// the IH up — so this is the missing pivot. Returns
+/// `(support_helper_theorems, rung_alternative_lines)`: the rung is ONE
+/// parenthesized `first` alternative meant to LEAD the existing ladder. It
+/// carries NO `sorry` floor and every arm ends in `simp_all`/`simp only … <;>`
+/// (which THROW on an open goal), so the alternative either CLOSES the goal or
+/// FAILS and `first` falls through to the existing ladder byte-for-byte. All
+/// tactics (`induction`/`cases`/`simp_all`/`omega` + the kernel-proved
+/// `isNatAdd` bridge and the proved `nil`-helper) are sound, so it can only ever
+/// ADD closures; a non-closing law stays `universal:false` exactly as before.
+fn emit_count_composition_rung(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    intro_names: &[String],
+    law_uid: &str,
+) -> Option<(Vec<String>, Vec<String>)> {
+    let plan = recognize_count_composition(vb, law, ctx)?;
+    let driver = law
+        .givens
+        .iter()
+        .position(|g| g.name == plan.inner_count)
+        .and_then(|i| intro_names.get(i).cloned())?;
+    let list_intro = law
+        .givens
+        .iter()
+        .position(|g| g.name == plan.list_given)
+        .and_then(|i| intro_names.get(i).cloned())?;
+
+    // The kernel-proved `op a b = a + b` bridge (so `op a (k+1)` reduces — `op`
+    // recurses on its FIRST arg, which here is symbolic) and the `f _ [] = []`
+    // nil-helper. Both ride the same `lean_nat_lift_support` / `take_drop_nil_helper`
+    // the synchronous rung already emits; we re-derive their names and texts so
+    // this rung is self-contained (the caller dedups support lines).
+    let (arith_support, arith_bridges, _bridged) =
+        lean_nat_lift_support(law, ctx, law_uid, &BTreeSet::new());
+    let add_bridge = arith_bridges
+        .iter()
+        .find(|n| n.ends_with("_isNatAdd"))
+        .cloned()?;
+
+    // The `f _ [] = []` helper for the verified fn (same name the synchronous rung
+    // mints).
+    let mut support: Vec<String> = arith_support;
+    let mut nil_simp: Vec<String> = Vec::new();
+    if let Some(fd) = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref())
+        && let Some(h) = take_drop_nil_helper(fd, law_uid, ctx)
+    {
+        nil_simp.push(h.name.clone());
+        support.push(h.text);
+    }
+
+    // Arm simp sets. `base`: law defs (`_root_.`-prefixed) + the add bridge + the
+    // nil-helper. The `zero` arm closes by `cases c <;> simp_all [base]` (the
+    // bridge turns `op a 0` into `a + 0 = a`); the `succ` arm peels the list and
+    // chains the IH after rewriting `op a (k+1)` to `(a + k) + 1` (so `f` peels)
+    // — `simp only [bridge, Nat.add_succ, f-defs] at *` exposes the one-step
+    // unfolds, then `simp_all [base, ih]` lands the IH at the tail.
+    let mut base_set: BTreeSet<String> = law_simp_defs(ctx, vb, law);
+    base_set.insert(add_bridge.clone());
+    base_set.extend(nil_simp.iter().cloned());
+    let base = base_set.iter().cloned().collect::<Vec<_>>().join(", ");
+    // The `simp only` unfold set for the succ arm: the law's defs (so `f`'s
+    // equations fire) + the bridge + `Nat.add_succ` (reassociates `a + (k+1)` to
+    // `(a + k) + 1` so `f` recognizes the `_ + 1` driver).
+    let mut unfold_set: BTreeSet<String> = law_simp_defs(ctx, vb, law);
+    unfold_set.insert(add_bridge.clone());
+    unfold_set.insert("Nat.add_succ".to_string());
+    let unfold = unfold_set.iter().cloned().collect::<Vec<_>>().join(", ");
+    // The cons-arm `simp_all` set carries the IH too.
+    let mut cons_set = base_set.clone();
+    cons_set.insert("ih".to_string());
+    let cons = cons_set.iter().cloned().collect::<Vec<_>>().join(", ");
+
+    let rung = vec![
+        "  | (".to_string(),
+        format!("    induction {driver} generalizing {list_intro} with"),
+        format!("    | zero => cases {list_intro} <;> simp_all [{base}]"),
+        format!(
+            "    | succ k ih => cases {list_intro} <;> simp only [{unfold}] at * <;> simp_all [{cons}])"
+        ),
+    ];
+    Some((support, rung))
+}
+
 /// ADDITIVE rung for the SYNCHRONOUS take/drop/zip family. A law whose subject
 /// fn recurses synchronously on a `Nat` and a `List` (take/drop) — or threads two
 /// lists (zip) — closes by generalizing-induction on the DRIVER `Nat` while
@@ -2591,32 +2834,65 @@ fn emit_list_induction(
         // (the `fun_induction`-wrapped `first` chain, or the bare ladder). The
         // rung carries no `sorry` floor and throws on any open goal, so `first`
         // either takes its closure or falls through to the rest byte-for-byte.
-        if let Some((multivar_support, rung)) =
-            emit_synchronous_multivar_induction(vb, law, ctx, intro_names, &law_uid)
-        {
-            support_lines.extend(multivar_support);
+        // Splice a leading `first` alternative (a parenthesized rung block) in
+        // front of whatever ladder is in `proof_lines`. If the ladder is already
+        // a `first` chain the rung becomes its new first alternative; otherwise a
+        // fresh `first | (rung) | (existing body)` wrapper is built. The rung
+        // either CLOSES the goal or THROWS (no `sorry` floor), so `first` falls
+        // through byte-for-byte — purely additive.
+        let splice_leading_rung = |proof_lines: &mut Vec<String>, rung: Vec<String>| {
             let intro_line = proof_lines.remove(0);
-            // If the ladder is already a `first` chain (the `fun_induction` rung
-            // ran), splice the rung in as its new first alternative; otherwise
-            // build a fresh `first | (rung) | (existing body)` wrapper.
             if proof_lines.first().map(String::as_str) == Some("  first") {
                 let mut wrapped = vec![intro_line, "  first".to_string()];
                 wrapped.extend(rung);
-                wrapped.extend(proof_lines.into_iter().skip(1));
-                proof_lines = wrapped;
+                wrapped.extend(proof_lines.drain(1..));
+                *proof_lines = wrapped;
             } else {
                 let mut wrapped = vec![intro_line, "  first".to_string()];
                 wrapped.extend(rung);
                 wrapped.push("  | (".to_string());
-                for line in &proof_lines {
+                for line in proof_lines.iter() {
                     wrapped.push(format!("  {line}"));
                 }
                 if let Some(last) = wrapped.last_mut() {
                     last.push(')');
                 }
-                proof_lines = wrapped;
+                *proof_lines = wrapped;
             }
+        };
+
+        if let Some((multivar_support, rung)) =
+            emit_synchronous_multivar_induction(vb, law, ctx, intro_names, &law_uid)
+        {
+            support_lines.extend(multivar_support);
+            splice_leading_rung(&mut proof_lines, rung);
         }
+
+        // ADDITIVE count-COMPOSITION rung (`f(op(a,b), c) = f(a, f(b,c))`, the
+        // drop/take composition lemmas). Inducts on the INNER count generalizing
+        // the list — the pivot the synchronous-driver rung (driver = the FIRST
+        // count) and `fun_induction` both miss. Spliced LAST so it LEADS the
+        // `first` chain. Same additive contract: it closes or throws and falls
+        // through. The bridge/nil-helper support lines may duplicate the
+        // synchronous rung's; the renderer dedups support theorems by name.
+        if let Some((compose_support, rung)) =
+            emit_count_composition_rung(vb, law, ctx, intro_names, &law_uid)
+        {
+            support_lines.extend(compose_support);
+            splice_leading_rung(&mut proof_lines, rung);
+        }
+    }
+
+    // The leading rungs (synchronous-driver and count-composition) may each emit
+    // the SAME proved support theorem (the `isNatAdd` bridge, the `f _ [] = []`
+    // nil-helper). A verbatim-duplicate `theorem … := by …` block is a Lean
+    // re-declaration error in the single-theorem path (which extends support
+    // lines without dedup), so drop exact-duplicate support theorems here,
+    // preserving first-occurrence order. Identical text = identical declaration,
+    // so this never changes a proof.
+    {
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        support_lines.retain(|line| seen.insert(line.clone()));
     }
 
     Some(AutoProof {

--- a/src/codegen/lean/law_auto/spec/mod.rs
+++ b/src/codegen/lean/law_auto/spec/mod.rs
@@ -8,6 +8,7 @@ mod wrapper_over_recursion;
 pub(super) use linear_recurrence2::emit_second_order_linear_recurrence_spec_equivalence_law;
 pub(super) use match_dispatcher_fold::emit_match_dispatcher_fold_law;
 pub(super) use result_pipeline_chain::emit_result_pipeline_chain_law;
+pub(super) use wrapper_over_recursion::emit_tailrec_fixed_base_fold_law;
 pub(super) use wrapper_over_recursion::emit_wrapper_over_recursion_law;
 
 use crate::ast::{Expr, Spanned, VerifyBlock, VerifyLaw};

--- a/src/codegen/lean/law_auto/spec/wrapper_over_recursion.rs
+++ b/src/codegen/lean/law_auto/spec/wrapper_over_recursion.rs
@@ -56,6 +56,114 @@ pub(in super::super) fn emit_wrapper_over_recursion_law(
     }
 }
 
+/// TIP prop_35 (`exp x y = qexp x y one`): a tail-recursive fold with a FIXED
+/// base param. Renders a self-contained, TRUE-universal proof (`replaces_theorem`),
+/// mirroring `FloorDivWindow`'s emission style: the `isNatMul`/`isNatAdd` bridges,
+/// the accumulator-generalization lemma `loop x y z = combine (loop x y neutral) z`
+/// (induct on the driver, generalize the accumulator; the base param is held
+/// fixed), and the main law `spec x y = loop x y neutral` proved by induction on
+/// the driver, peeling one step with the lemma. The multiplicative residual closes
+/// via the bridge to core `Nat.mul_*` (no Mathlib); additive closes with `omega`.
+#[allow(clippy::too_many_arguments)]
+pub(in super::super) fn emit_tailrec_fixed_base_fold_law(
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    theorem_base: &str,
+    spec_fn: &str,
+    loop_fn: &str,
+    combine_fn: &str,
+    combine_op: BinOp,
+) -> Option<AutoProof> {
+    if !matches!(combine_op, BinOp::Add | BinOp::Mul) {
+        return None;
+    }
+    let spec_l = aver_name_to_lean(spec_fn);
+    let loop_l = aver_name_to_lean(loop_fn);
+    let combine_l = aver_name_to_lean(combine_fn);
+    let neutral = if combine_op == BinOp::Mul { "1" } else { "0" };
+    // The main theorem is named for `theorem_base` so the law-class marker
+    // (which keys credit on that name) finds it; support lemmas hang off the
+    // same base to stay collision-free across laws in one file.
+    let base = theorem_base.to_string();
+    let acc_thm = format!("{base}__acc");
+
+    // Bridges (user monoid fn → `Nat` builtin). The `mul` bridge proof rewrites
+    // with the `add` bridge, so seed the scan with the combine fn's own callees
+    // (`plus`) — the law scan only reaches one level deep and would miss it.
+    let mut extra = std::collections::BTreeSet::new();
+    if let Some(cfd) = ctx.fn_def_by_name(combine_fn, ctx.active_module_scope().as_deref()) {
+        crate::codegen::proof_recognize::collect_called_fns_in_body(&cfd.body, &mut extra);
+    }
+    let (bridge_support, simp_extra, _bridged) =
+        super::super::induction::lean_nat_lift_support(law, ctx, &base, &extra);
+    // Keep only the bridge THEOREM names (`{base}_*`); the shared support also
+    // bundles a broad `Nat.mul_*` rewrite set whose `succ_mul`/`mul_add`
+    // directions fight the AC normal form the residual needs. The bridges put
+    // both sides in `*` form; this emit supplies its own minimal close.
+    let bridges: Vec<String> = simp_extra
+        .into_iter()
+        .filter(|n| n.starts_with(&base))
+        .collect();
+    if bridges.is_empty() {
+        // No Peano arith op recognized — decline rather than emit a dead proof.
+        return None;
+    }
+    let bridge_set = bridges.join(", ");
+
+    // The decomposition + main residuals. Multiplicative: bridge both sides to
+    // `*`, then the residual is pure AC reassociation (`Nat.mul_assoc` +
+    // `Nat.mul_comm` normalize, `Nat.mul_one` cancels the neutral). Additive is
+    // linear once the combine is bridged to `+`, so `omega` finishes it.
+    let (decomp_close, main_close) = match combine_op {
+        BinOp::Mul => (
+            format!(
+                "simp [{bridge_set}, Nat.mul_assoc, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_one]"
+            ),
+            format!(
+                "simp [{bridge_set}, Nat.mul_assoc, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_one]"
+            ),
+        ),
+        _ => (
+            format!("simp only [{bridge_set}]; omega"),
+            format!("simp only [{bridge_set}]; omega"),
+        ),
+    };
+
+    let mut lines: Vec<String> = bridge_support;
+    // Accumulator-generalization lemma. `x` is universally bound but held FIXED
+    // through the induction; the recursion shrinks `y`, generalizing `z`.
+    lines.push(format!(
+        "theorem {acc_thm} : ∀ (x y z : Nat), {loop_l} x y z = {combine_l} ({loop_l} x y {neutral}) z := by"
+    ));
+    lines.push("  intro x y z".to_string());
+    lines.push("  induction y generalizing z with".to_string());
+    lines.push(format!("  | zero => simp [{loop_l}, {bridge_set}]"));
+    lines.push(format!(
+        "  | succ m ih => simp only [{loop_l}]; rw [ih ({combine_l} x z), ih ({combine_l} x {neutral})]; {decomp_close}"
+    ));
+
+    // Main law. Unfold the wrapper's inline neutral (`one` / `S(Z)` renders as
+    // `0 + 1`; `Nat.zero_add` normalizes it), induct on the driver, peel one
+    // step with the lemma, apply the IH, and close the residual.
+    lines.push(format!(
+        "theorem {base} : ∀ (x y : Nat), {spec_l} x y = {loop_l} x y {neutral} := by"
+    ));
+    lines.push("  intro x y".to_string());
+    lines.push("  induction y with".to_string());
+    lines.push(format!("  | zero => simp [{spec_l}, {loop_l}]"));
+    lines.push("  | succ m ih =>".to_string());
+    lines.push(format!("    simp only [{spec_l}, {loop_l}]"));
+    lines.push(format!("    rw [{acc_thm} x m ({combine_l} x {neutral})]"));
+    lines.push("    rw [ih]".to_string());
+    lines.push(format!("    {main_close}"));
+
+    Some(AutoProof {
+        support_lines: lines,
+        body: crate::codegen::lean::tactic_ir::Tactic::raw(Vec::new()),
+        replaces_theorem: true,
+    })
+}
+
 /// Original `List<_>` fold (`sum_acc`): the accumulator-decomposition lemma
 /// and the main proof both close with `omega` (linear). Hardcoded `List Int`.
 fn emit_list_fold(

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -534,13 +534,21 @@ fn emit_verify_law_block(
     // would drop the very theorems the strategy exists to close
     // (e.g. `parseEscape.escapeCodeRoundtrip`, whose `parseEscape`
     // is fuel-bounded), so the fuel gate does not apply.
+    // EXCEPTION — `TailRecFixedBaseFold`: the `qexp` loop is rejected by the
+    // recursion classifier (a growing accumulator), so it lands in
+    // `unclassified_fns` and trips the fuel gate. But the strategy re-emits the
+    // loop as a terminating structural `def` (see `transpile`) and supplies its
+    // OWN universal proof from the accumulator-decomposition lemma — there is no
+    // `__fuel` wrapper to drive. Skipping here would drop the very theorem the
+    // strategy exists to close, so the fuel gate does not apply.
     let unclassified = crate::codegen::common::unclassified_fn_names(ctx);
     let calls_fuel_bounded = crate::codegen::common::law_calls_unclassified_fn(law, &unclassified);
-    let pinned_finite_domain_cases = matches!(
+    let pinned_self_universal = matches!(
         pinned_law_strategy,
         Some(crate::ir::ProofStrategy::FiniteDomainCases { .. })
+            | Some(crate::ir::ProofStrategy::TailRecFixedBaseFold { .. })
     );
-    let skip_universal = singleton_const_rhs || (calls_fuel_bounded && !pinned_finite_domain_cases);
+    let skip_universal = singleton_const_rhs || (calls_fuel_bounded && !pinned_self_universal);
     if !quant_params.is_empty() && !skip_universal {
         lines.extend(emit_verify_law_support_theorems(
             vb,
@@ -573,9 +581,16 @@ fn emit_verify_law_block(
         // marker says `universal`. Credit stays fail-closed: the
         // `#print axioms` whitelist still decides, and a sorry'd or
         // native_decide'd proof can never be credited.
+        // Strategies that emit their OWN true-universal statement
+        // (`replaces_theorem`) and so must override the bounded-domain
+        // default class: `FloorDivWindow` and `TailRecFixedBaseFold`
+        // (the `qexp` tail-recursive-fold shape). Both render a genuine
+        // `∀ givens, ... = ...` theorem named `theorem_base` and route
+        // through the `emit_verify_law_forall_auto_proof` path below.
         let floor_window_universal = matches!(
             pinned_law_strategy,
             Some(crate::ir::ProofStrategy::FloorDivWindow { .. })
+                | Some(crate::ir::ProofStrategy::TailRecFixedBaseFold { .. })
         );
         // The marker carries a THIRD field: the `fn.law` identity label
         // (the SAME `format!("{fn}.{law}")` the when-universal lane keys on,

--- a/src/codegen/lean/transpile.rs
+++ b/src/codegen/lean/transpile.rs
@@ -208,6 +208,15 @@ fn is_wrapper_over_recursion_inner(ctx: &CodegenContext, fd: &crate::ast::FnDef)
             &t.strategy,
             crate::ir::ProofStrategy::WrapperOverRecursion { inner_fn, .. }
                 if *inner_fn == fd.name
+        ) || matches!(
+            &t.strategy,
+            // The `TailRecFixedBaseFold` loop (`qexp`) recurses on its DRIVER
+            // (2nd param); Lean's equation compiler still infers the structural
+            // measure across all params, so it must emit as a terminating `def`
+            // for the accumulator-decomposition lemma's `rw` to see its
+            // definitional equations — a `partial def` would withhold them.
+            crate::ir::ProofStrategy::TailRecFixedBaseFold { loop_fn, .. }
+                if *loop_fn == fd.name
         )
     })
 }

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -2229,6 +2229,17 @@ fn classify_law_strategy(
     {
         return s;
     }
+    // Tail-recursive fold with a FIXED base param (TIP prop_35,
+    // `exp x y = qexp x y one`). The 2-given inline-wrapper shape the
+    // `WrapperOverRecursion` recognizer can't reach: a 3-arg loop whose
+    // extra leading param is held fixed and whose combine multiplies the
+    // accumulator by that fixed param. Emits the accumulator-generalization
+    // lemma plus the main universal law.
+    if law.when.is_none()
+        && let Some(s) = detect_tailrec_fixed_base_fold(law, inputs)
+    {
+        return s;
+    }
     // Structural induction runs first — when any given binds a
     // recursive ADT, induction over its variants is the canonical
     // proof. Reflexive could also fire on `f(t) = f(t)` for `t: Tree`

--- a/src/codegen/proof_lower/wrapper_laws.rs
+++ b/src/codegen/proof_lower/wrapper_laws.rs
@@ -168,6 +168,245 @@ pub(super) fn detect_wrapper_over_recursion(
     })
 }
 
+/// TIP prop_35 (`exp x y = qexp x y one`): a tail-recursive fold with a FIXED
+/// base parameter. Detect the law `spec(x, y) == loop(x, y, neutral)` where the
+/// extra leading param `x` is threaded unchanged through both fns, the driver
+/// `y` is the structurally-shrinking Peano `Nat`, and the combine multiplies the
+/// accumulator by the fixed `x` (not by the matched subject). Distinct from
+/// `WrapperOverRecursion`: TWO givens, the wrapper call written inline (no
+/// separate non-recursive wrapper fn), a 3-arg loop, and combine-by-fixed-param.
+///
+/// `spec` must be `match y { Z -> neutral; S(n) -> combine(x, spec(x, n)) }`
+/// and `loop` `match y { Z -> z; S(n) -> loop(x, n, combine(x, z)) }`, with the
+/// inline neutral matching the combine op (`S(Z)` for `Mul`, `Z` for `Add`).
+pub(super) fn detect_tailrec_fixed_base_fold(
+    law: &crate::ast::VerifyLaw,
+    inputs: &ProofLowerInputs,
+) -> Option<crate::ir::ProofStrategy> {
+    use crate::ast::{Expr, Pattern, Stmt};
+
+    fn ident_name(e: &Spanned<Expr>) -> Option<&str> {
+        match &e.node {
+            Expr::Ident(n) => Some(n.as_str()),
+            Expr::Resolved { name, .. } => Some(name.as_str()),
+            _ => None,
+        }
+    }
+    // A 0-arg call (`one()` → `FnCall(one, [])`) or bare ctor value the law
+    // wrote inline as the loop's neutral accumulator argument.
+    let is_neutral_one = |e: &Spanned<Expr>| -> bool {
+        if is_peano_one(e) {
+            return true;
+        }
+        // `one()` resolves to a nullary fn whose body is `S(Z)`.
+        if let Expr::FnCall(c, a) = &e.node
+            && a.is_empty()
+            && let Some(name) = expr_to_dotted_name(&c.node)
+            && let Some(fd) = inputs.find_fn_def_by_call_name(&name)
+            && let Some(b) = body_terminal_expr(fd.body.as_ref())
+        {
+            return is_peano_one(b);
+        }
+        false
+    };
+    let is_neutral_zero = |e: &Spanned<Expr>| -> bool {
+        if is_peano_zero(e) {
+            return true;
+        }
+        if let Expr::FnCall(c, a) = &e.node
+            && a.is_empty()
+            && let Some(name) = expr_to_dotted_name(&c.node)
+            && let Some(fd) = inputs.find_fn_def_by_call_name(&name)
+            && let Some(b) = body_terminal_expr(fd.body.as_ref())
+        {
+            return is_peano_zero(b);
+        }
+        false
+    };
+
+    if law.givens.len() != 2 || law.when.is_some() {
+        return None;
+    }
+    let g0 = law.givens[0].name.as_str();
+    let g1 = law.givens[1].name.as_str();
+    let type_name = law.givens[1].type_name.clone();
+
+    // Law sides: `spec(x, y)` (2 args, both givens) and `loop(x, y, neutral)`
+    // (3 args, first two givens, third the inline neutral).
+    let as_spec = |e: &Spanned<Expr>| -> Option<String> {
+        let Expr::FnCall(c, a) = &e.node else {
+            return None;
+        };
+        if a.len() != 2 || ident_name(&a[0])? != g0 || ident_name(&a[1])? != g1 {
+            return None;
+        }
+        expr_to_dotted_name(&c.node)
+    };
+    fn as_loop<'e>(
+        e: &'e Spanned<Expr>,
+        g0: &str,
+        g1: &str,
+    ) -> Option<(String, &'e Spanned<Expr>)> {
+        let id = |x: &Spanned<Expr>| -> Option<String> {
+            match &x.node {
+                Expr::Ident(n) => Some(n.clone()),
+                Expr::Resolved { name, .. } => Some(name.clone()),
+                _ => None,
+            }
+        };
+        let Expr::FnCall(c, a) = &e.node else {
+            return None;
+        };
+        if a.len() != 3 || id(&a[0]).as_deref() != Some(g0) || id(&a[1]).as_deref() != Some(g1) {
+            return None;
+        }
+        Some((expr_to_dotted_name(&c.node)?, &a[2]))
+    }
+    let (spec_fn, loop_fn, neutral) = match (as_spec(&law.lhs), as_loop(&law.rhs, g0, g1)) {
+        (Some(s), Some((l, n))) => (s, l, n),
+        _ => match (as_spec(&law.rhs), as_loop(&law.lhs, g0, g1)) {
+            (Some(s), Some((l, n))) => (s, l, n),
+            _ => return None,
+        },
+    };
+    if spec_fn == loop_fn {
+        return None;
+    }
+
+    // The shared combine must be a Peano monoid fn; its op fixes the neutral.
+    let spec_fd = inputs.find_fn_def_by_call_name(&spec_fn)?;
+    let loop_fd = inputs.find_fn_def_by_call_name(&loop_fn)?;
+    if spec_fd.params.len() != 2 || loop_fd.params.len() != 3 {
+        return None;
+    }
+    let base_p = loop_fd.params[0].0.as_str();
+    let drv_p = loop_fd.params[1].0.as_str();
+    let acc_p = loop_fd.params[2].0.as_str();
+
+    // ── spec: match <drv> { Z -> neutral; S(n) -> combine(base, spec(base, n)) }
+    let spec_base = spec_fd.params[0].0.as_str();
+    let spec_drv = spec_fd.params[1].0.as_str();
+    let [Stmt::Expr(sbody)] = spec_fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { subject, arms } = &sbody.node else {
+        return None;
+    };
+    if ident_name(subject) != Some(spec_drv) || arms.len() != 2 {
+        return None;
+    }
+    let mut spec_combine: Option<String> = None;
+    for arm in arms {
+        let Pattern::Constructor(_, binders) = &arm.pattern else {
+            return None;
+        };
+        match binders.len() {
+            0 => {} // base arm returns the neutral; validated against the op below
+            1 => {
+                // S(n) -> combine(base, spec(base, n))
+                let Expr::FnCall(cc, cargs) = &arm.body.node else {
+                    return None;
+                };
+                let cname = expr_to_dotted_name(&cc.node)?;
+                if cargs.len() != 2 || ident_name(&cargs[0])? != spec_base {
+                    return None;
+                }
+                let Expr::FnCall(rc, rargs) = &cargs[1].node else {
+                    return None;
+                };
+                if expr_to_dotted_name(&rc.node)? != spec_fn
+                    || rargs.len() != 2
+                    || ident_name(&rargs[0])? != spec_base
+                    || ident_name(&rargs[1])? != binders[0].as_str()
+                {
+                    return None;
+                }
+                spec_combine = Some(cname);
+            }
+            _ => return None,
+        }
+    }
+    let spec_combine = spec_combine?;
+
+    // ── loop: match <drv> { Z -> acc; S(n) -> loop(base, n, combine(base, acc)) }
+    let [Stmt::Expr(lbody)] = loop_fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match {
+        subject: lsubj,
+        arms: larms,
+    } = &lbody.node
+    else {
+        return None;
+    };
+    if ident_name(lsubj) != Some(drv_p) || larms.len() != 2 {
+        return None;
+    }
+    let mut loop_combine: Option<String> = None;
+    for arm in larms {
+        let Pattern::Constructor(_, binders) = &arm.pattern else {
+            return None;
+        };
+        match binders.len() {
+            0 => {
+                if ident_name(&arm.body) != Some(acc_p) {
+                    return None;
+                }
+            }
+            1 => {
+                // S(n) -> loop(base, n, combine(base, acc))
+                let (callee, cargs) = match &arm.body.node {
+                    Expr::FnCall(c, a) => (expr_to_dotted_name(&c.node)?, a.clone()),
+                    Expr::TailCall(td) => (td.target.clone(), td.args.clone()),
+                    _ => return None,
+                };
+                if callee != loop_fn
+                    || cargs.len() != 3
+                    || ident_name(&cargs[0])? != base_p
+                    || ident_name(&cargs[1])? != binders[0].as_str()
+                {
+                    return None;
+                }
+                let Expr::FnCall(sc, sargs) = &cargs[2].node else {
+                    return None;
+                };
+                if expr_to_dotted_name(&sc.node)? != spec_combine
+                    || sargs.len() != 2
+                    || ident_name(&sargs[0])? != base_p
+                    || ident_name(&sargs[1])? != acc_p
+                {
+                    return None;
+                }
+                loop_combine = Some(expr_to_dotted_name(&sc.node)?);
+            }
+            _ => return None,
+        }
+    }
+    if loop_combine.as_deref() != Some(spec_combine.as_str()) {
+        return None;
+    }
+
+    // Classify the combine op + check the inline neutral matches it.
+    let combine_fd = inputs.find_fn_def_by_call_name(&spec_combine)?;
+    let combine_op = nat_monoid_op_of(combine_fd)?;
+    let neutral_ok = match combine_op {
+        crate::ast::BinOp::Mul => is_neutral_one(neutral),
+        crate::ast::BinOp::Add => is_neutral_zero(neutral),
+        _ => return None,
+    };
+    if !neutral_ok {
+        return None;
+    }
+
+    Some(crate::ir::ProofStrategy::TailRecFixedBaseFold {
+        spec_fn,
+        loop_fn,
+        combine_fn: spec_combine,
+        combine_op,
+        type_name,
+    })
+}
+
 /// A constructor VALUE in any surface form this stage's AST presents: a bare
 /// nullary `Nat.Z` parses as `Attr(Ident("Nat"), "Z")`, a `Nat.S(x)` as
 /// `FnCall`, and some passes leave an `Expr::Constructor`. Returns the short

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -854,6 +854,35 @@ pub enum ProofStrategy {
         /// name. `None` for an inline-binop `List` fold (`acc + h`).
         combine_fn: Option<String>,
     },
+    /// Tail-recursive fold with a FIXED base parameter — the `qexp`
+    /// shape (TIP prop_35). The law `spec(x, y) == loop(x, y, neutral)`
+    /// equates a 2-arg structural recurrence on the DRIVER `y`:
+    /// `spec(x, y) = match y { Z -> neutral; S n -> combine(x, spec(x, n)) }`
+    /// against a 3-arg tail-recursive form carrying an accumulator:
+    /// `loop(x, y, z) = match y { Z -> z; S n -> loop(x, n, combine(x, z)) }`.
+    /// Unlike `WrapperOverRecursion`, the extra param `x` is FIXED across
+    /// the recursion (the base), the combine multiplies the accumulator by
+    /// `x` (not by the matched subject), and the law binds TWO givens with
+    /// the wrapper call written inline (no separate wrapper fn). Backends
+    /// emit the accumulator-generalization lemma
+    /// `loop x y z = combine (loop x y neutral) z` (induct on `y`,
+    /// generalize `z`; `x` fixed) plus the main universal law; the
+    /// multiplicative algebra closes via the `isNatMul` bridge to core
+    /// `Nat.mul_*` (no Mathlib). Today: multiplicative (`Mul`, neutral
+    /// `S(Z)`) and additive (`Add`, neutral `Z`) Peano combines.
+    TailRecFixedBaseFold {
+        /// Source name of the direct recurrence the law's other side calls
+        /// (e.g. `"exp"`). Recurses on the driver, base param fixed.
+        spec_fn: String,
+        /// Source name of the 3-arg tail-recursive loop (e.g. `"qexp"`).
+        loop_fn: String,
+        /// Source name of the binary monoid combine fn (`mult` / `plus`).
+        combine_fn: String,
+        /// Combine op classified from the monoid fn's base arm.
+        combine_op: crate::ast::BinOp,
+        /// Source type name of the driving Peano `Nat` ADT.
+        type_name: String,
+    },
     /// Ground constant-fold over fixed ADT/enum constructor
     /// arguments. The law's call(s) pin every non-Int param of the
     /// verified fn to a constructor literal (`CellContent.Empty`,


### PR DESCRIPTION
Two executor extensions to the Lean/Dafny proof backend, each closing an open proof-corpus law universally with genuine kernel axioms (no Mathlib).

**1. drop/take count-composition** (`induction.rs`)
Adds an induction rung for laws `f(plus x y) z = f(x) (f(y) z)` where `f` recurses on a Nat driver with a nested list match (drop/take). The existing portfolio (induction on the outer count, fun_induction, induction on the list) leaves the succ step at `sorry` because the two sides consume the list at different rates. Inducting on the **inner** count generalizing the list, with the existing `isNatAdd` bridge handling the plus algebra, closes it. Closes `isaplanner/prop_56` (`drop n (drop m xs) = drop (n+m) xs`). Purely additive — the rung leads the portfolio and falls through unchanged on non-matching shapes.

**2. tail-recursive exponentiation = recurrence** (accumulator-fold extension)
Extends the accumulator-fold strategy to a three-argument tail-recursive form with a **fixed base** param and a multiply-by-base combine: `exp(x,y) = qexp(x,y,one())`. The emit proves `qexp(x,y,z) = mult(exp(x,y), z)` by induction on `y` generalizing `z`, then specializes to the neutral `one()`. Multiplicative algebra rides the existing `isNatMul` bridge to core `Nat.mul_*`. Closes `prod/prop_35` on **both** Lean and Dafny.

**Verification** (independently confirmed)
- `prop_56`, `prop_35` → `universal: yes`, `0 sorries`, axioms `[propext, Quot.sound]` (no `sorryAx`/`native_decide`); `prop_35` Dafny `0 errors, 0 axioms, 0 omitted`.
- `proof_spec`: 184 passed, 0 failed.
- `clippy --features wasm,wasip2 -- -D warnings`: clean. `fmt --check`: clean.
- Rebased onto and re-verified against #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AnpZpi5CvnfdMXnSV9U5B