### PR TITLE
proof: prove conditional comparison and membership laws universally in Lean

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -792,6 +792,28 @@ fn is_literal_div_shrink(expr: &Spanned<Expr>, param_name: &str) -> bool {
         )
 }
 
+/// Whether a `when` premise is a 2-arg call to a recognized canonical Peano
+/// comparison fn (`≤` / `<` / `=`). This is the exact condition under which the
+/// Nat-given lockstep-peel induction hint's recursive call satisfies its own
+/// `requires`: the comparison unfolds `f(S a, S b) == f(a, b)`, so the outer
+/// premise on the peeled-successor arguments reduces to the recursive premise.
+/// A non-comparison (or otherwise non-lockstep) premise is rejected, so the
+/// hint is never emitted where its recursion would violate a precondition.
+fn when_is_peano_comparison(when: &Spanned<Expr>, ctx: &CodegenContext) -> bool {
+    let Expr::FnCall(callee, args) = &when.node else {
+        return false;
+    };
+    if args.len() != 2 {
+        return false;
+    }
+    let Some(name) = crate::codegen::common::expr_to_dotted_name(&callee.node) else {
+        return false;
+    };
+    let mut names = std::collections::BTreeSet::new();
+    names.insert(name);
+    !crate::codegen::proof_recognize::collect_nat_compare_ops_for_names(&names, ctx).is_empty()
+}
+
 /// True when a self-recursive fn's termination cannot be justified by
 /// any `decreases` pattern this emitter recognizes AND no parameter
 /// offers Dafny's default lexicographic measure a structural ordering
@@ -2941,6 +2963,53 @@ pub fn emit_verify_law(
             }
             lines.push(format!("    {}({});", lemma_name, other_args.join(", ")));
             lines.push("  }".to_string());
+        }
+    } else if law
+        .when
+        .as_ref()
+        .is_some_and(|w| when_is_peano_comparison(w, ctx))
+        && !law.givens.is_empty()
+        && law.givens.iter().all(|g| {
+            crate::codegen::proof_recognize::peano_type_named(ctx, g.type_name.trim()).is_some()
+        })
+    {
+        // Conditional Peano-`Nat` comparison law (`prop_70 leSucc`:
+        // `requires le(m, n) ensures le(m, S n)`). Z3 cannot discharge the
+        // universal from `{}` + fuel alone (auto-`{:induction}` does not close
+        // it either — measured), so emit explicit structural induction on EVERY
+        // `Nat` given: peel each in lockstep and recurse on the all-predecessors
+        // tuple. The zero arms close from the `requires` + `le`-fuel; the
+        // all-succ arm's recursive call supplies the induction hypothesis (the
+        // `requires le(m', n')` it needs is exactly the unfolded outer
+        // `le(S m', S n')`). Sound by construction: Dafny re-checks the
+        // recursion and its termination, so a shape the lockstep peel does not
+        // actually prove stays an honest verify error, never a false lemma.
+        let lemma_name = format!("{}_{}", fn_name, law_name);
+        let peeled: Vec<String> = law
+            .givens
+            .iter()
+            .map(|g| format!("{}_p", aver_name_to_dafny(&g.name)))
+            .collect();
+        for (depth, g) in law.givens.iter().enumerate() {
+            let peano = crate::codegen::proof_recognize::peano_type_named(ctx, g.type_name.trim())
+                .expect("guarded by the all-Peano-given check above");
+            let pad = "  ".repeat(depth + 1);
+            lines.push(format!("{}match {} {{", pad, aver_name_to_dafny(&g.name)));
+            lines.push(format!("{}  case {} => {{}}", pad, peano.base_ctor));
+            lines.push(format!(
+                "{}  case {}({}) =>",
+                pad, peano.succ_ctor, peeled[depth]
+            ));
+        }
+        let inner_pad = "  ".repeat(law.givens.len() + 1);
+        lines.push(format!(
+            "{}{}({});",
+            inner_pad,
+            lemma_name,
+            peeled.join(", ")
+        ));
+        for depth in (0..law.givens.len()).rev() {
+            lines.push(format!("{}}}", "  ".repeat(depth + 1)));
         }
     }
 

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -23,6 +23,18 @@ use sampled::emit_guarded_domain_law;
 /// admits, so the emitter writes ONLY those into the build.
 pub(crate) use induction::admitted_dep_law_theorems;
 
+/// `emit_verify_law_block` reads this to decide whether a `when`-law's theorem
+/// statement should drop its sampled-domain disjunctions (`omit_domain`) and be
+/// emitted in TRUE-universal form — exactly when the conditional
+/// comparison-bridge emit will close it. Re-exported so the statement builder
+/// and the proof emitter stay in lockstep.
+pub(in crate::codegen::lean) use induction::recognize_conditional_comparison_bridge;
+
+/// Twin of [`recognize_conditional_comparison_bridge`] for the conditional-
+/// INDUCTIVE list-predicate family (membership monotonicity / identity). Also
+/// feeds the `omit_domain` statement driver, kept in lockstep with the emitter.
+pub(in crate::codegen::lean) use induction::recognize_conditional_inductive_list;
+
 /// `aver proof --explain` residual probe: turn an emitted main law theorem's
 /// source lines into a normalization-only twin so Lean reports its residual
 /// (`unsolved goals`). Re-exported up to `codegen::lean` for the `--check`
@@ -275,6 +287,38 @@ fn emit_verify_law_forall_auto_proof_inner(
         .map(|g| aver_name_to_lean(&g.name))
         .collect();
     let proof_intro_names = extend_intro_names_with_premises(law, &intro_names);
+
+    // Conditional comparison-bridge laws (the `prop_70 leSucc` family):
+    // `when <R1(..)> -> <R2(..)> = true` over canonical Peano relations
+    // (`≤`/`<`/`=`). Tried BEFORE the pinned-strategy dispatch because
+    // `classify_law_strategy` never pins `Induction` on a `when`-law (it routes
+    // them to `LinearArithmetic` / `BackendDispatch`), so this is the only point
+    // a conditional law reaches a genuine universal closer. For exactly this
+    // recognized shape `emit_verify_law_block` emits the unbounded
+    // `∀ givens, when = true -> claim` statement (see
+    // `recognize_conditional_comparison_bridge`); every other conditional shape
+    // declines here and falls through to the bounded guarded-domain proof.
+    if law.when.is_some()
+        && let Some(proof) =
+            induction::emit_conditional_comparison_bridge_law(vb, law, ctx, &intro_names)
+    {
+        return Some(proof);
+    }
+
+    // Conditional-INDUCTIVE list-predicate laws (the membership family: `prop_36`
+    // `when elem(x,y) -> elem(x, y ++ z) => true`, `prop_71` `when not(eqNat(x,y))
+    // -> elem(x, ins(y,xs)) = elem(x,xs)`). Tried right after the flat comparison
+    // bridge and, like it, BEFORE the pinned dispatch (no `when`-law is pinned
+    // `Induction`). Proves by induction on the list given, threading the premise
+    // into the cons IH. Same `omit_domain` universal-statement plumbing as the
+    // bridge family; any other conditional shape declines and keeps the bounded
+    // guarded-domain fallback.
+    if law.when.is_some()
+        && let Some(proof) =
+            induction::emit_conditional_inductive_list_law(vb, law, ctx, &intro_names)
+    {
+        return Some(proof);
+    }
 
     // Structural induction — IR-pinned `ProofStrategy::Induction`
     // wins first. The legacy chain ran induction at this position

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1059,6 +1059,362 @@ fn premise_intro_names(law: &VerifyLaw, intro_names: &[String]) -> Vec<String> {
     names
 }
 
+/// A linear `Nat` argument `omega` can reason about after the comparison
+/// bridges fire: a bare given/identifier, a Peano successor `Nat.S(x)` over
+/// another such term, the zero constructor `Nat.Z`, or a numeral. A non-`S`/`Z`
+/// CALL or any other term shape is rejected, so the conditional-bridge
+/// recognizer only matches goals that genuinely lower to linear arithmetic. A
+/// bare identifier is accepted regardless of its bound type — soundness rests on
+/// the SOLE caller, [`is_peano_compare_call`], gating these as the arguments of a
+/// recognized 2-arg Peano comparison fn (so they are `Nat` by that fn's
+/// signature); a misuse outside that gate would over-accept, but the proof's
+/// `sorry` floor + the `#print axioms` credit gate keep even that fail-closed.
+fn is_linear_nat_arg(expr: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
+    use crate::ast::{Expr, Literal};
+    match &expr.node {
+        Expr::Ident(_) | Expr::Resolved { .. } => true,
+        Expr::Literal(Literal::Int(_)) => true,
+        Expr::FnCall(callee, args) => match super::shared::expr_dotted_name(callee) {
+            Some(name) => match name.rsplit('.').next().unwrap_or(name.as_str()) {
+                "S" => args.len() == 1 && is_linear_nat_arg(&args[0]),
+                "Z" => args.is_empty(),
+                _ => false,
+            },
+            None => false,
+        },
+        _ => false,
+    }
+}
+
+/// A 2-arg call to a recognized canonical Peano comparison fn (`≤` / `<` / `=`)
+/// whose arguments are both linear `Nat` terms. Returns `true` when the
+/// expression is exactly that shape — the building block of the
+/// conditional-comparison-bridge recognizer.
+fn is_peano_compare_call(
+    expr: &crate::ast::Spanned<crate::ast::Expr>,
+    ctx: &CodegenContext,
+) -> bool {
+    use crate::ast::Expr;
+    let Expr::FnCall(callee, args) = &expr.node else {
+        return false;
+    };
+    if args.len() != 2 {
+        return false;
+    }
+    let Some(name) = super::shared::expr_dotted_name(callee) else {
+        return false;
+    };
+    let mut names = BTreeSet::new();
+    names.insert(name);
+    if crate::codegen::proof_recognize::collect_nat_compare_ops_for_names(&names, ctx).is_empty() {
+        return false;
+    }
+    is_linear_nat_arg(&args[0]) && is_linear_nat_arg(&args[1])
+}
+
+/// The EASY conditional-comparison shape (`prop_70 leSucc`): a `when` premise
+/// that is a canonical Peano Bool relation over linear `Nat` terms, and an
+/// atomic conclusion `<relation>(..) => true` that is another such relation.
+/// Bridging both sides to their Prop forms turns the law into a linear-`Nat`
+/// implication, which `omega` discharges. Deliberately narrow: a negated /
+/// compound premise, or a conclusion that is not a single comparison `= true`,
+/// is rejected so the law keeps the bounded guarded-domain fallback (the HARD
+/// conditional-inductive family — sortedness/insertion — is out of scope here).
+fn conditional_comparison_bridge_shape(law: &VerifyLaw, ctx: &CodegenContext) -> bool {
+    use crate::ast::{Expr, Literal};
+    let Some(when) = &law.when else {
+        return false;
+    };
+    // Conclusion is `<peano-compare>(..) => true` (the `=> true` / `holds`
+    // surface): rhs is the literal `true`, lhs a recognized comparison call.
+    if !matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true))) {
+        return false;
+    }
+    if !is_peano_compare_call(&law.lhs, ctx) {
+        return false;
+    }
+    // Premise is an un-negated recognized comparison call.
+    is_peano_compare_call(when, ctx)
+}
+
+/// Whether [`emit_conditional_comparison_bridge_law`] will close this law as a
+/// TRUE-universal conditional. The caller (`emit_verify_law_block`) reads this
+/// to decide whether to drop the sampled-domain disjunctions from the theorem
+/// statement (`omit_domain`), so the predicate must agree with the emit: it is
+/// exactly the recognizer, and the shape guarantees a comparison bridge exists
+/// (so the emit never declines for lack of one).
+pub(in crate::codegen::lean) fn recognize_conditional_comparison_bridge(
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> bool {
+    conditional_comparison_bridge_shape(law, ctx)
+}
+
+/// Close an EASY conditional comparison law (`prop_70 leSucc`) as the
+/// TRUE-universal `∀ givens, <when> = true -> <claim>`. Emits the canonical
+/// Peano comparison bridges (`(f a b = true) = (a R b)`) for every relation the
+/// law mentions — seeding the scan with the premise's fns, which
+/// `lean_nat_lift_support` (lhs/rhs only) would otherwise miss — then proves
+/// the goal by rewriting the premise hypothesis and the goal through those
+/// bridges and discharging the linear-`Nat` residual with `omega`.
+///
+/// FAIL-CLOSED on two axes: (1) any shape that is not the recognized
+/// pure-comparison conditional returns `None`, so the caller falls back to the
+/// bounded guarded-domain `native_decide` proof (still `passed`, not
+/// `universal`); (2) the proof body is floored with `sorry`, so a residual the
+/// bridges + `omega` cannot close degrades to an honest sorry (caught,
+/// `universal:false`) rather than a build error — the `_checked_domain`
+/// cross-check still earns `passed`. The bridge support theorems are themselves
+/// sound-by-floor (`lean_nat_lift_support`), so a misrecognized relation can
+/// never inject a false bridge.
+pub(in crate::codegen::lean) fn emit_conditional_comparison_bridge_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    intro_names: &[String],
+) -> Option<AutoProof> {
+    if !conditional_comparison_bridge_shape(law, ctx) {
+        return None;
+    }
+    // Law-scoped bridge name prefix, matching the other induction emits
+    // (`{fn}_{law}`). Deliberately NOT the `{fn}_law_{law}` theorem base: a
+    // `_law_` substring would make the audit's `is_main_law_theorem` mistake a
+    // bridge support theorem for a creditable main law theorem.
+    let law_uid = format!(
+        "{}_{}",
+        aver_name_to_lean(&vb.fn_name),
+        aver_name_to_lean(&law.name)
+    );
+    // `lean_nat_lift_support` scans `lhs`/`rhs` for ops; seed `extra_fns` with
+    // the premise's fns so a premise-only relation still gets a bridge.
+    let mut extra: BTreeSet<String> = BTreeSet::new();
+    if let Some(when) = &law.when {
+        crate::codegen::proof_recognize::collect_called_fns(when, &mut extra);
+    }
+    let (bridge_support, bridge_names, _bridged) =
+        lean_nat_lift_support(law, ctx, &law_uid, &extra);
+    let has_compare_bridge = bridge_names
+        .iter()
+        .any(|n| n.ends_with("_isNatLe") || n.ends_with("_isNatLt") || n.ends_with("_isNatEq"));
+    if !has_compare_bridge {
+        return None;
+    }
+    let bridges = bridge_names.join(", ");
+    // `intro <givens> h_when`; rewrite the premise hypothesis AND the goal
+    // through the Prop bridges, then `omega` over the linear residual. `<;>
+    // omega` (not `; omega`) so a `simp` that fully closes the goal does not
+    // leave `omega` with no goals.
+    let intro = format!("  intro {} h_when", intro_names.join(" "));
+    let close = format!("  first | (simp only [{bridges}] at h_when ⊢ <;> omega) | sorry");
+    Some(AutoProof {
+        support_lines: bridge_support,
+        body: Tactic::raw(vec![intro, close]),
+        replaces_theorem: false,
+    })
+}
+
+/// Whether a `when`-law is a conditional-INDUCTIVE list-predicate law (the
+/// membership family — `prop_36` `when elem(x,y) -> elem(x, y ++ z) => true`,
+/// `prop_71` `when not(eqNat(x,y)) -> elem(x, ins(y,xs)) = elem(x,xs)`): there is
+/// a `List<_>` given to induct on, and the verified fn structurally recurses on
+/// a list parameter (so inducting on the list given peels both sides). Distinct
+/// from the flat comparison-bridge family — here the conclusion is a recursive
+/// list predicate, not an `omega`-shaped comparison, so it is proved by
+/// premise-threaded list induction rather than a bridge. Used by both the proof
+/// emitter and the `omit_domain` statement driver, which must agree.
+pub(in crate::codegen::lean) fn recognize_conditional_inductive_list(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> bool {
+    let Some(when) = &law.when else {
+        return false;
+    };
+    let Some(target_idx) = find_list_induction_target(law) else {
+        return false;
+    };
+    // The bridge family owns the flat-comparison shape; never claim it here.
+    if conditional_comparison_bridge_shape(law, ctx) {
+        return false;
+    }
+    // A non-empty unfold cone is required (the induction arms `simp` the verified
+    // fn's defs); without one the portfolio has nothing to drive.
+    if law_simp_defs(ctx, vb, law).is_empty() {
+        return false;
+    }
+    // The verified fn must be a Bool list PREDICATE that structurally recurses on
+    // a list parameter (so inducting on the list given peels both sides in
+    // lockstep). The Bool-return gate is load-bearing: an element-returning list
+    // fn (`last`/`head` — `prop_59`/`prop_60`) also recurses on a list and can
+    // pass (A)/(B), but its conclusion is an element equation the membership
+    // portfolio cannot close, so admitting it would `sorry` and drop `passed`.
+    let Some(fd) = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref()) else {
+        return false;
+    };
+    if fd.return_type.trim() != "Bool"
+        || crate::codegen::recursion::detect::single_list_structural_param_index(fd).is_none()
+    {
+        return false;
+    }
+    // VALIDATED-SHAPE GATE. `omit_domain` replaces the bounded `native_decide`
+    // proof (which earns `passed`) with the universal portfolio; if that portfolio
+    // cannot close, its `sorry` floor would drop `passed` (sorries > budget). So
+    // restrict to the two shapes the probe + a measured corpus sweep proved the
+    // portfolio CLOSES, both driven by induction on the first list given:
+    //   (A) the conclusion applies the verified fn to a BUILTIN `List.concat(
+    //       <target>, _)` — the target is the spine the cons step peels
+    //       (`(h :: t) ++ z = h :: (t ++ z)`). Narrow by construction: only the
+    //       literal `List.concat` spelling qualifies, so the sole corpus hit is
+    //       `prop_36`; an append written as a USER fn (`prop_37`'s `append`)
+    //       reaches the portfolio through (B) instead, not here.
+    //   (B) target-independent premise — the `when` does not mention the
+    //       induction target, so it is a fixed side condition available in every
+    //       arm while the conclusion peels structurally. The broad branch: it
+    //       admits the whole neq-/eq-membership family (`prop_37`, `prop_46`,
+    //       `prop_47`, `prop_71`, `lemma_19`) plus `prop_38`.
+    // Other conditional-inductive shapes fail BOTH and decline — keeping their
+    // bounded `passed`: a premise that mentions the target over a non-`concat`
+    // conclusion (drop-relative `prop_39`, sort-relative `prop_49`,
+    // `prop_42`/`prop_43`/`prop_44`), and the sortedness/insertion family that
+    // needs a head-of-insert aux lemma (`prop_77`, `lemma_12`). The Bool-return
+    // gate above additionally drops element-returning `last`/`head` (`prop_59`/
+    // `prop_60`) and the `count`/`union`/`zip` value-returning list fns.
+    let target_name = &law.givens[target_idx].name;
+    let append_on_target = law_applies_verified_fn_to_concat(law, &vb.fn_name, target_name);
+    let premise_target_independent = !expr_mentions_ident(when, target_name);
+    append_on_target || premise_target_independent
+}
+
+/// Whether the law applies its verified fn to a `List.concat(<target>, _)` — the
+/// append-monotonicity shape (`elem(x, concat(y, z))` with `y` the induction
+/// target). Scans both sides of the claim.
+fn law_applies_verified_fn_to_concat(law: &VerifyLaw, fn_name: &str, target: &str) -> bool {
+    use crate::ast::Expr;
+    fn concat_first_arg_is(expr: &crate::ast::Spanned<Expr>, target: &str) -> bool {
+        let Expr::FnCall(callee, args) = &expr.node else {
+            return false;
+        };
+        super::shared::expr_dotted_name(callee).as_deref() == Some("List.concat")
+            && args
+                .first()
+                .is_some_and(|a| matches!(&a.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == target))
+    }
+    fn scan(expr: &crate::ast::Spanned<Expr>, fn_name: &str, target: &str) -> bool {
+        use crate::ast::Expr;
+        if let Expr::FnCall(callee, args) = &expr.node {
+            if super::shared::expr_dotted_name(callee).as_deref() == Some(fn_name)
+                && args.iter().any(|a| concat_first_arg_is(a, target))
+            {
+                return true;
+            }
+            if args.iter().any(|a| scan(a, fn_name, target)) {
+                return true;
+            }
+            return scan(callee, fn_name, target);
+        }
+        false
+    }
+    scan(&law.lhs, fn_name, target) || scan(&law.rhs, fn_name, target)
+}
+
+/// Whether an expression syntactically references the identifier `name`.
+/// Conservative on exotic node kinds (returns `true`): a premise whose shape we
+/// do not destructure is assumed to possibly mention the target, so it is
+/// EXCLUDED from the target-independent `(B)` branch rather than wrongly admitted
+/// — admitting a target-dependent premise there would risk a non-closing proof
+/// and a `passed` regression.
+fn expr_mentions_ident(expr: &crate::ast::Spanned<crate::ast::Expr>, name: &str) -> bool {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::Literal(_) => false,
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => n == name,
+        Expr::Attr(e, _) | Expr::Neg(e) | Expr::ErrorProp(e) => expr_mentions_ident(e, name),
+        Expr::FnCall(callee, args) => {
+            expr_mentions_ident(callee, name) || args.iter().any(|a| expr_mentions_ident(a, name))
+        }
+        Expr::BinOp(_, l, r) => expr_mentions_ident(l, name) || expr_mentions_ident(r, name),
+        Expr::Constructor(_, payload) => payload
+            .as_ref()
+            .is_some_and(|e| expr_mentions_ident(e, name)),
+        Expr::List(es) | Expr::Tuple(es) => es.iter().any(|e| expr_mentions_ident(e, name)),
+        _ => true,
+    }
+}
+
+/// Close a conditional-inductive list-predicate law (`prop_36`, `prop_71`) as the
+/// TRUE-universal `∀ givens, <when> = true -> <claim>` by induction on the first
+/// `List` given, THREADING the premise: the premise is introduced INSIDE each
+/// arm (not before `induction`) so the cons induction hypothesis carries it as an
+/// antecedent — the essential difference from the unconditional `emit_list_induction`
+/// ladder. Each arm runs a `first | … | sorry` portfolio that unfolds the verified
+/// fn's defs + the `List.*_append` peel lemmas, normalizes a negated premise
+/// (`Bool.not_eq_true`), case-splits the recursive predicate's inner Bool
+/// dispatcher (`split`), and discharges with `simp_all` (which applies the IH at
+/// the tail using the premise-derived hypothesis). FAIL-CLOSED on two axes: any
+/// non-matching shape returns `None` (caller keeps the bounded guarded-domain
+/// proof), and every arm is `done`-terminated under a `sorry` floor, so a residual
+/// the portfolio cannot close degrades to an honest sorry (`universal:false`,
+/// `passed` via `_checked_domain`) rather than a build error or a false closure.
+pub(in crate::codegen::lean) fn emit_conditional_inductive_list_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    intro_names: &[String],
+) -> Option<AutoProof> {
+    if !recognize_conditional_inductive_list(vb, law, ctx) {
+        return None;
+    }
+    let target_idx = find_list_induction_target(law)?;
+    let target = intro_names.get(target_idx)?.clone();
+    let defs = law_simp_defs(ctx, vb, law)
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join(", ");
+    // The builtin `++` peel lemmas the recursive list expression needs (e.g.
+    // `(hd :: tl) ++ z = hd :: (tl ++ z)`, `[x] ++ y = x :: y`).
+    let with_append = format!("{defs}, List.cons_append, List.nil_append, List.singleton_append");
+    // Normalize a negated Bool premise (`(!p) = true` → `p = false`) so `simp_all`
+    // can use it; a no-op `try` when the premise is not negated.
+    let norm = "(try simp only [Bool.not_eq_true, Bool.not_eq_false] at h_when)".to_string();
+    // Arm portfolios. Every measured corpus closure (prop_36/37/38/46/47/71,
+    // lemma_19) lands on the FIRST cons branch (`simp only […] at h_when ⊢ <;>
+    // (split <;> simp_all)`) and the first nil branch (`simp [defs]; done`); the
+    // remaining branches are a `done`-terminated speculative hedge for premise /
+    // dispatcher shape variants the family may grow into (a non-closing branch
+    // throws on its `done`, so `first` advances at zero correctness cost — and at
+    // no build-time cost for an admitted law, since the winning branch is tried
+    // first). The trailing `sorry` keeps the whole emit fail-closed.
+    let body = vec![
+        format!("  intro {}", intro_names.join(" ")),
+        format!("  induction {target} with"),
+        "  | nil =>".to_string(),
+        "    first".to_string(),
+        format!("    | (simp [{defs}]; done)"),
+        format!("    | (intro h_when; {norm}; simp_all [{defs}]; done)"),
+        "    | sorry".to_string(),
+        "  | cons hd tl ih =>".to_string(),
+        "    intro h_when".to_string(),
+        format!("    {norm}"),
+        "    first".to_string(),
+        format!(
+            "    | (simp only [{with_append}] at h_when ⊢ <;> (split <;> simp_all [{defs}]) <;> done)"
+        ),
+        format!("    | (simp only [{with_append}] at h_when ⊢ <;> simp_all [{defs}] <;> done)"),
+        format!(
+            "    | (simp only [{with_append}] <;> (split <;> simp_all [{defs}, h_when]) <;> done)"
+        ),
+        format!("    | (simp only [{with_append}] <;> simp_all [{defs}, h_when] <;> done)"),
+        format!("    | (split <;> simp_all [{defs}, h_when] <;> done)"),
+        format!("    | (simp_all [{defs}, h_when] <;> done)"),
+        "    | sorry".to_string(),
+    ];
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        body: Tactic::raw(body),
+        replaces_theorem: false,
+    })
+}
+
 /// `discovered` carries the lemma names of an IR-pinned
 /// `ProofStrategy::SimpOverLemmas` (the discovery feedback loop): the emits
 /// below add them to the law's simp sets, embed their texts (first user
@@ -1076,6 +1432,20 @@ pub(super) fn emit_structural_induction_law(
     _theorem_prop: &str,
     discovered: &[String],
 ) -> Option<AutoProof> {
+    // A `when` premise blocks the structural-induction routing below — the
+    // inductive arms re-establish no premise, which is the HARD
+    // conditional-inductive family (sortedness/insertion) tracked under its own
+    // brief (`prompts/conditional-inductive-executor.md`). The EASY conditional
+    // comparison-bridge family (`prop_70 leSucc`) is closed instead by
+    // `emit_conditional_comparison_bridge_law`, reached pin-independently in the
+    // early arm of `emit_verify_law_forall_auto_proof_inner` BEFORE this routing.
+    // This function is in fact never reached for a `when`-law today —
+    // `classify_law_strategy` never pins `Induction` on one, and `SimpOverLemmas`
+    // only re-pins an already-`Induction`-pinned law — so the structural path
+    // simply declines every conditional law. When the conditional-inductive
+    // strategy lands it will route HERE (induction on the list given, threading
+    // the premise); until then, decline so the caller keeps the bounded
+    // guarded-domain fallback.
     if law.when.is_some() {
         return None;
     }

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -643,6 +643,115 @@ verify clampNonNegative law clampNonNegativeSpec
 }
 
 #[test]
+fn transpile_proves_conditional_comparison_bridge_law_as_universal() {
+    // `prop_70 leSucc`: `when le(m, n) -> le(m, S n) => true`. The conditional
+    // comparison-bridge emit closes it as the TRUE-universal
+    // `∀ m n, le m n = true -> le m (n + 1) = true` — the sampled-domain
+    // disjunctions are dropped (`omit_domain`) so the law is classed `universal`,
+    // and the premise + goal are bridged to `≤` and discharged by `omega`.
+    let mut ctx = ctx_from_source(
+        r#"
+module CondCmpBridge
+    intent = "conditional comparison bridge: le(m,n) implies le(m, S n)"
+
+type Nat
+    Z
+    S(Nat)
+
+fn le(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> true
+        Nat.S(z) -> match y
+            Nat.Z -> false
+            Nat.S(x2) -> le(z, x2)
+
+verify le law leSucc
+    given m: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    when le(m, n)
+    le(m, Nat.S(n)) => true
+"#,
+        "cond_cmp_bridge",
+    );
+    let out = transpile(&mut ctx);
+    let lean = generated_lean_file(&out);
+
+    // Classed `universal`, NOT `bounded-domain`.
+    assert!(lean.contains("-- aver:law-class le_law_leSucc universal le.leSucc"));
+    // The TRUE-universal conditional statement: no `m = 0 ∨ …` sampled-domain
+    // premise, the `when` survives as the `= true ->` implication.
+    assert!(lean.contains(
+        "theorem le_law_leSucc : ∀ (m : Nat) (n : Nat), le m n = true -> le m (n + 1) = true := by"
+    ));
+    // Law-scoped `≤` bridge support theorem (uid `le_leSucc`, no `_law_` so the
+    // audit never mistakes it for a creditable main theorem).
+    assert!(lean.contains("theorem le_leSucc_le_isNatLe : ∀ a b, (le a b = true) = (a ≤ b) := by"));
+    // Premise introduced as `h_when`; bridged at hypothesis and goal, `omega` closes.
+    assert!(lean.contains("intro m n h_when"));
+    assert!(lean.contains("simp only [le_leSucc_le_isNatLe] at h_when ⊢ <;> omega"));
+}
+
+#[test]
+fn transpile_proves_conditional_inductive_membership_law_as_universal() {
+    // `prop_36 elemConcat`: `when elem(x,y) -> elem(x, y ++ z) => true` (append
+    // monotonicity, shape (A)). The conditional-inductive list emit closes it as
+    // the TRUE-universal `∀ x y z, elem x y = true -> elem x (y ++ z) = true` by
+    // induction on the first list given, threading the premise into the cons arm.
+    let mut ctx = ctx_from_source(
+        r#"
+module CondIndMembership
+    intent = "conditional inductive membership: elem x y implies elem x (y ++ z)"
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn barbar(x: Bool, y: Bool) -> Bool
+    match x
+        true -> true
+        false -> y
+
+fn elem(x: Nat, y: List<Nat>) -> Bool
+    match y
+        [] -> false
+        [z, ..xs] -> barbar(eqNat(x, z), elem(x, xs))
+
+verify elem law elemConcat
+    given x: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given y: List<Nat> = [[Nat.Z], [Nat.S(Nat.Z)]]
+    given z: List<Nat> = [[], [Nat.Z]]
+    when elem(x, y)
+    elem(x, List.concat(y, z)) => true
+"#,
+        "cond_ind_membership",
+    );
+    let out = transpile(&mut ctx);
+    let lean = generated_lean_file(&out);
+
+    // Classed `universal`, NOT `bounded-domain` (the sampled-domain disjunctions
+    // are dropped via `omit_domain`).
+    assert!(lean.contains("-- aver:law-class elem_law_elemConcat universal elem.elemConcat"));
+    // The TRUE-universal conditional statement (no `y = [..] ∨ …` domain premise).
+    assert!(lean.contains(
+        "theorem elem_law_elemConcat : ∀ (x : Nat) (y : List Nat) (z : List Nat), elem x y = true -> elem x (y ++ z) = true := by"
+    ));
+    // Induction on the first list given `y`, with the premise threaded INSIDE the
+    // cons arm (`intro h_when` after `induction`, so the IH carries the antecedent).
+    assert!(lean.contains("induction y with"));
+    assert!(lean.contains("| cons hd tl ih =>"));
+    assert!(lean.contains("intro h_when"));
+}
+
+#[test]
 fn transpile_auto_proves_simp_normalized_canonical_spec_law_in_auto_mode() {
     let mut ctx = ctx_from_source(
         r#"

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -549,6 +549,30 @@ fn emit_verify_law_block(
             | Some(crate::ir::ProofStrategy::TailRecFixedBaseFold { .. })
     );
     let skip_universal = singleton_const_rhs || (calls_fuel_bounded && !pinned_self_universal);
+    // Oracle v1: the auto-proof matchers compare law.lhs / law.rhs ASTs. For
+    // effectful laws the theorem statement has been rewritten to target the
+    // lifted fn (BranchPath.root() + oracle args injected); the matchers need to
+    // see the same rewritten form or they'll miss shapes like
+    // `pickOne(root, rnd) == pickOneSpec(root, rnd)` and fall back to `sorry`.
+    let law_for_auto_proof = crate::ast::VerifyLaw {
+        name: law.name.clone(),
+        givens: law.givens.clone(),
+        when: law.when.clone(),
+        lhs: law_lhs.clone(),
+        rhs: law_rhs.clone(),
+        sample_guards: law.sample_guards.clone(),
+    };
+    // A recognized EASY conditional comparison-bridge `when`-law (`prop_70
+    // leSucc`) is proven UNIVERSALLY by the dedicated bridge emit, so its
+    // theorem statement drops the sampled-domain disjunctions (`omit_domain`)
+    // and is classed `universal`. Restricted to non-refinement-lifted laws (the
+    // lifted path already drops the domain through the quantifier type and uses
+    // its own premise handling). Must agree with the proof emitter — both key on
+    // the same recognizer.
+    let conditional_universal = law.when.is_some()
+        && lifted_vars.is_empty()
+        && (super::law_auto::recognize_conditional_comparison_bridge(&law_for_auto_proof, ctx)
+            || super::law_auto::recognize_conditional_inductive_list(vb, &law_for_auto_proof, ctx));
     if !quant_params.is_empty() && !skip_universal {
         lines.extend(emit_verify_law_support_theorems(
             vb,
@@ -564,6 +588,7 @@ fn emit_verify_law_block(
             &rhs_template,
             when_template.as_deref(),
             &lifted_vars,
+            conditional_universal,
         );
         // Statement-class marker — the channel `aver proof --check`'s
         // `universal` metric keys on (see `LAW_CLASS_MARKER_PREFIX`).
@@ -611,21 +636,6 @@ fn emit_verify_law_block(
             vb.fn_name,
             law.name,
         ));
-        // Oracle v1: the auto-proof matchers compare law.lhs / law.rhs
-        // ASTs. For effectful laws the theorem statement has been
-        // rewritten to target the lifted fn (BranchPath.root() + oracle
-        // args injected); the matchers need to see the same rewritten
-        // form or they'll miss shapes like
-        // `pickOne(root, rnd) == pickOneSpec(root, rnd)` and fall back
-        // to `sorry`. Build a view of the law with the rewritten body.
-        let law_for_auto_proof = crate::ast::VerifyLaw {
-            name: law.name.clone(),
-            givens: law.givens.clone(),
-            when: law.when.clone(),
-            lhs: law_lhs.clone(),
-            rhs: law_rhs.clone(),
-            sample_guards: law.sample_guards.clone(),
-        };
         // (Removed: refinement_auto_proof — Aver-specific bypass.
         // Refinement-lifted laws now flow through law_auto via the
         // IR-pinned `ProofStrategy::LinearArithmetic { lifted: true }`.
@@ -1133,6 +1143,7 @@ fn law_with_sliced_domain(
     part
 }
 
+#[allow(clippy::too_many_arguments)]
 fn law_theorem_parts(
     law: &VerifyLaw,
     ctx: &CodegenContext,
@@ -1141,7 +1152,14 @@ fn law_theorem_parts(
     rhs_template: &str,
     when_template: Option<&str>,
     lifted_vars: &std::collections::HashMap<String, String>,
+    omit_domain: bool,
 ) -> Vec<LawTheoremPart> {
+    // `omit_domain` (a recognized conditional-comparison-bridge `when`-law)
+    // drops the sampled-domain disjunctions, so the statement is the
+    // TRUE-universal `∀ givens, when = true -> claim`. The resulting
+    // `bounded_domain = false` keeps the single-part path (no domain chunking —
+    // there is no large disjunction to split) and flips the law-class marker to
+    // `universal`.
     let (prop, bounded_domain) = law_theorem_prop(
         law,
         ctx,
@@ -1149,7 +1167,7 @@ fn law_theorem_parts(
         rhs_template,
         when_template,
         lifted_vars,
-        false,
+        omit_domain,
     );
     let single = || {
         vec![LawTheoremPart {


### PR DESCRIPTION
## What

A verify-law with a `when` premise was only sample-checked, never proven universally — the backend emitted a domain-bounded theorem (`passed`, not `universal`). Conditional laws now earn a genuine kernel-checked `universal: yes`.

**Comparison conditionals** (`isaplanner/prop_70`, `le(m,n) -> le(m, S n)`): bridge the premise and conclusion to their `<=`/`<`/`=` Prop relations, discharge the linear residual with `omega`. The recognized conditional is emitted in true-universal form `∀ givens, when = true -> claim` (sampled-domain disjunctions dropped → law-class marker `universal`). Dafny closes the same law with an explicit Nat-given structural-induction hint.

**Membership conditionals** (`prod/prop_36`, `isaplanner/prop_71`, `prod/prop_37`, `prod/prop_38`, `prod/prop_46`, `prod/prop_47`, `prod/lemma_19`): induction on the list given, threading the premise into the cons induction hypothesis, then a `simp`/`split`/`simp_all` portfolio. Restricted to a validated shape — the verified fn returns Bool and recurses on a list, and either the conclusion appends the target or the premise is independent of the target.

## Safety

Both routes are fail-closed:
- An unrecognized conditional keeps its bounded `native_decide` proof, so a non-closing match can never replace a passing proof with a `sorry`.
- Crediting stays behind the `#print axioms` whitelist (`propext`/`Classical.choice`/`Quot.sound`): a residual the tactics cannot close degrades to an honest `sorry` (`universal: false`), never a false universal. Verified on the kernel against deliberately-false laws.

## Verification

- New universal closures, all kernel-clean (`[propext, Quot.sound]`): `prop_70` (Lean + Dafny), `prop_36`, `prop_37`, `prop_38`, `prop_46`, `prop_47`, `prop_71`, `lemma_19`.
- Broad sweep of every `when`-law: zero `passed` regression.
- `tests/proof_spec` 184/0; `cargo clippy --features wasm,wasip2 --lib` clean; two new regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)