### PR TITLE
proof: close conditional inductive laws through Aver helper laws and a generic driver

### DIFF
--- a/proof-corpus/decomposed/isaplanner/prop_85.av
+++ b/proof-corpus/decomposed/isaplanner/prop_85.av
@@ -48,15 +48,22 @@ fn zip(xs: List<Int>, ys: List<Int>) -> List<Tuple<Int, Int>>
             [] -> []
             [x3, ..x4] -> List.concat([(z, x3)], zip(x2, x4))
 
-verify appendInt law appendIntNilR
-    given xs: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
-    appendInt(xs, []) => xs
+verify len law lenSnocSucc
+    given a: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    given x: Int = [9, 5]
+    len(appendInt(a, [x])) => Nat.S(len(a))
 
-verify appendInt law appendIntAssoc
-    given xs: List<Int> = [[], [1], [1, 2]]
-    given ys: List<Int> = [[], [4], [4, 5]]
-    given zs: List<Int> = [[], [7], [7, 8]]
-    appendInt(appendInt(xs, ys), zs) => appendInt(xs, appendInt(ys, zs))
+verify len law lenRevPreserved
+    given xs: List<Int> = [[], [1], [1, 2], [1, 2, 3]]
+    len(rev(xs)) => len(xs)
+
+verify zip law zipSnocDistribution
+    given as: List<Int> = [[], [1], [1, 2]]
+    given bs: List<Int> = [[], [4], [4, 5]]
+    given x: Int = [7, 8]
+    given y: Int = [9, 0]
+    when natEq(len(as), len(bs))
+    zip(appendInt(as, [x]), appendInt(bs, [y])) => appendPair(zip(as, bs), [(x, y)])
 
 verify zip law zipRev
     given xs: List<Int> = [[], [1], [1, 2], [1, 2, 3]]

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -40,10 +40,11 @@ pub(in crate::codegen::lean) use induction::recognize_conditional_inductive_list
 /// Also feeds the `omit_domain` statement driver, kept in lockstep with the emit.
 pub(in crate::codegen::lean) use induction::recognize_conditional_sortedness_law;
 
-/// The zip-reverse length-equality figure (`prop_85`), absorbed from the
-/// `when`-universal lane onto the main path. Also feeds the `omit_domain`
-/// statement driver, kept in lockstep with the emit.
-pub(in crate::codegen::lean) use induction::recognize_conditional_zip_rev_law;
+/// Generic conditional-inductive close (the decomposition path: list induction
+/// threading the premise, then `simp_all` over the fn defs and the laws-as-
+/// lemmas pool). Also feeds the `omit_domain` statement driver, kept in
+/// lockstep with the emit.
+pub(in crate::codegen::lean) use induction::recognize_conditional_inductive_generic;
 
 /// `aver proof --explain` residual probe: turn an emitted main law theorem's
 /// source lines into a normalization-only twin so Lean reports its residual
@@ -341,13 +342,16 @@ fn emit_verify_law_forall_auto_proof_inner(
         return Some(proof);
     }
 
-    // Zip-reverse under equal lengths (`prop_85`: `when natEq(len xs, len ys)
-    // -> zip(rev xs, rev ys) => revPair(zip xs ys)`). Absorbed from the
-    // `when`-universal lane: the validated proof carries a snoc-distribution
-    // aux lemma the bare list IH cannot supply, like the sortedness family
-    // above. Same `omit_domain` plumbing; declines any other shape.
+    // Generic conditional-inductive close: any `when`-law that recurses on a
+    // list given with an equational conclusion, proved by list induction +
+    // premise threading + `simp_all` over the fn defs AND the laws-as-lemmas
+    // pool (earlier `verify ... law` helper blocks). This is the DECOMPOSITION
+    // path — a figure's algebraic content (e.g. zip-reverse's snoc-distribution)
+    // lives as Aver helper laws, not a hardcoded Lean template. Tried last among
+    // the conditional arms; the bespoke recognizers above decline into it.
     if law.when.is_some()
-        && let Some(proof) = induction::emit_conditional_zip_rev_law(vb, law, ctx, &intro_names)
+        && let Some(proof) =
+            induction::emit_conditional_inductive_generic_law(vb, law, ctx, &intro_names)
     {
         return Some(proof);
     }

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -40,6 +40,11 @@ pub(in crate::codegen::lean) use induction::recognize_conditional_inductive_list
 /// Also feeds the `omit_domain` statement driver, kept in lockstep with the emit.
 pub(in crate::codegen::lean) use induction::recognize_conditional_sortedness_law;
 
+/// The zip-reverse length-equality figure (`prop_85`), absorbed from the
+/// `when`-universal lane onto the main path. Also feeds the `omit_domain`
+/// statement driver, kept in lockstep with the emit.
+pub(in crate::codegen::lean) use induction::recognize_conditional_zip_rev_law;
+
 /// `aver proof --explain` residual probe: turn an emitted main law theorem's
 /// source lines into a normalization-only twin so Lean reports its residual
 /// (`unsolved goals`). Re-exported up to `codegen::lean` for the `--check`
@@ -332,6 +337,17 @@ fn emit_verify_law_forall_auto_proof_inner(
     // supply. Same `omit_domain` plumbing.
     if law.when.is_some()
         && let Some(proof) = induction::emit_conditional_sortedness_law(vb, law, ctx, &intro_names)
+    {
+        return Some(proof);
+    }
+
+    // Zip-reverse under equal lengths (`prop_85`: `when natEq(len xs, len ys)
+    // -> zip(rev xs, rev ys) => revPair(zip xs ys)`). Absorbed from the
+    // `when`-universal lane: the validated proof carries a snoc-distribution
+    // aux lemma the bare list IH cannot supply, like the sortedness family
+    // above. Same `omit_domain` plumbing; declines any other shape.
+    if law.when.is_some()
+        && let Some(proof) = induction::emit_conditional_zip_rev_law(vb, law, ctx, &intro_names)
     {
         return Some(proof);
     }

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1242,18 +1242,20 @@ pub(in crate::codegen::lean) fn recognize_conditional_inductive_list(
     if law_simp_defs(ctx, vb, law).is_empty() {
         return false;
     }
-    // The verified fn must be a Bool list PREDICATE that structurally recurses on
-    // a list parameter (so inducting on the list given peels both sides in
-    // lockstep). The Bool-return gate is load-bearing: an element-returning list
-    // fn (`last`/`head` — `prop_59`/`prop_60`) also recurses on a list and can
-    // pass (A)/(B), but its conclusion is an element equation the membership
-    // portfolio cannot close, so admitting it would `sorry` and drop `passed`.
+    // The verified fn must be a PER-ELEMENT LIST FOLD: it structurally recurses
+    // on a list parameter AND its cons arm combines the HEAD element with the
+    // recursive call (so inducting on the list given peels both sides in lockstep
+    // and the portfolio's `split <;> simp_all` closes via the IH). This gate is
+    // load-bearing — it admits `elem` (Bool) AND `count` (Nat) while excluding
+    // element-SELECTORS like `last`/`head` (`prop_59`/`prop_60`): `last`'s cons
+    // arm uses only the recursive tail (not the head), `head`'s only the head
+    // (no recursion), so neither folds — their conclusion is an element equation
+    // the membership portfolio cannot close, and admitting them would `sorry` and
+    // drop `passed`.
     let Some(fd) = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref()) else {
         return false;
     };
-    if fd.return_type.trim() != "Bool"
-        || crate::codegen::recursion::detect::single_list_structural_param_index(fd).is_none()
-    {
+    if !is_per_element_list_fold(fd) {
         return false;
     }
     // VALIDATED-SHAPE GATE. `omit_domain` replaces the bounded `native_decide`
@@ -1337,8 +1339,64 @@ fn expr_mentions_ident(expr: &crate::ast::Spanned<crate::ast::Expr>, name: &str)
             .as_ref()
             .is_some_and(|e| expr_mentions_ident(e, name)),
         Expr::List(es) | Expr::Tuple(es) => es.iter().any(|e| expr_mentions_ident(e, name)),
+        Expr::Match { subject, arms } => {
+            expr_mentions_ident(subject, name)
+                || arms.iter().any(|arm| expr_mentions_ident(&arm.body, name))
+        }
         _ => true,
     }
+}
+
+/// Whether some leaf of `expr` (descending through `match` arms) IS the bare
+/// identifier `name` — i.e. a code path that RETURNS that variable directly. For
+/// the cons head this is the SELECTOR signature: `last`'s `match zs { [] -> z ; …
+/// }` returns the head element, `head`'s cons arm is the bare head. A fold never
+/// returns the head — it only COMPARES it (`eqNat(x, z)`), so the head appears as
+/// a call argument, never as a leaf.
+fn any_leaf_is_ident(expr: &crate::ast::Spanned<crate::ast::Expr>, name: &str) -> bool {
+    use crate::ast::Expr;
+    match &expr.node {
+        Expr::Match { arms, .. } => arms.iter().any(|arm| any_leaf_is_ident(&arm.body, name)),
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => n == name,
+        _ => false,
+    }
+}
+
+/// A per-element list FOLD: the verified fn structurally recurses on a `List<_>`
+/// param AND its cons arm references the head element but NEVER returns it as a
+/// leaf (the head is COMPARED, not selected). Admits `elem` in BOTH spellings —
+/// `barbar(eqNat(x, z), elem(x, xs))` and the explicit `match eqNat(x, z) { true
+/// -> true ; false -> elem(x, xs) }` — and `count` (`match natEq(x, z) { true ->
+/// S(count …) ; false -> count … }`). Excludes element SELECTORS: `last`'s cons
+/// arm has a `[] -> z` leaf returning the head; `head` (which does not even
+/// recurse on the list, so the structural-param gate already rejects it). The
+/// cons-arm structure, not the return type, is the discriminator (so `count`'s
+/// `Nat` return qualifies alongside `elem`'s `Bool`).
+fn is_per_element_list_fold(fd: &crate::ast::FnDef) -> bool {
+    use crate::ast::{Expr, Pattern};
+    let Some(list_idx) = crate::codegen::recursion::detect::single_list_structural_param_index(fd)
+    else {
+        return false;
+    };
+    let list_param = &fd.params[list_idx].0;
+    let Some(body) = fd.body.tail_expr() else {
+        return false;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return false;
+    };
+    if !matches!(&subject.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == list_param)
+    {
+        return false;
+    }
+    arms.iter()
+        .find_map(|arm| {
+            let Pattern::Cons(head, _) = &arm.pattern else {
+                return None;
+            };
+            Some(expr_mentions_ident(&arm.body, head) && !any_leaf_is_ident(&arm.body, head))
+        })
+        .unwrap_or(false)
 }
 
 /// Close a conditional-inductive list-predicate law (`prop_36`, `prop_71`) as the

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1781,6 +1781,64 @@ theorem {sort_cons} : ∀ (z : Nat) (l : List Nat),
     })
 }
 
+/// Whether [`emit_conditional_zip_rev_law`] will close this law universally —
+/// the `omit_domain` statement driver reads this, kept in lockstep with the
+/// emit. The recognizer is the lane's validated `ZipRevLenEq` classifier,
+/// borrowed by the main path during the `when`-universal lane's retirement.
+pub(in crate::codegen::lean) fn recognize_conditional_zip_rev_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> bool {
+    crate::codegen::lean::universal_lane::is_zip_rev_bridge(vb, law, ctx)
+}
+
+/// Close the zip-reverse length-equality law (`prop_85`:
+/// `when natEq(len xs, len ys) -> zip(rev xs, rev ys) => revPair(zip xs ys)`)
+/// as the TRUE-universal `∀ xs ys, len xs = len ys -> …`. Reuses the lane's
+/// validated proof — the `=`-bridge over Peano `Nat`, append/rev length
+/// homomorphisms, the `len ys = 0 → ys = []` inversion, and the
+/// snoc-distribution aux lemma — then the main induction on `xs`, threading
+/// the length premise through the generalized `ys`. The support lemmas are
+/// `<fn>_<law>`-scoped (no `_law_`, so the `#print axioms` credit audit never
+/// mistakes one for the creditable theorem). FAIL-CLOSED: declines any other
+/// shape (`None`), so the caller keeps the bounded proof.
+pub(in crate::codegen::lean) fn emit_conditional_zip_rev_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    _intro_names: &[String],
+) -> Option<AutoProof> {
+    let prefix = format!(
+        "{}_{}",
+        aver_name_to_lean(&vb.fn_name),
+        aver_name_to_lean(&law.name)
+    );
+    let (supports, body) =
+        crate::codegen::lean::universal_lane::zip_rev_universal_proof(vb, law, ctx, &prefix)?;
+    // The lane emits the body at base indentation (its renderer adds the
+    // leading two spaces); the main-path `AutoProof` body carries its own
+    // two-space base indent, so re-indent here (empty lines stay empty).
+    let body_lines: Vec<String> = body
+        .lines()
+        .map(|l| {
+            if l.is_empty() {
+                String::new()
+            } else {
+                format!("  {l}")
+            }
+        })
+        .collect();
+    // ONE `support_lines` element (newlines embedded): `emit_verify_law_block`
+    // de-duplicates support lines line-by-line, which would silently drop the
+    // proof's repeated lines and corrupt the multi-lemma block.
+    Some(AutoProof {
+        support_lines: vec![supports.join("\n")],
+        body: Tactic::raw(body_lines),
+        replaces_theorem: false,
+    })
+}
+
 /// `discovered` carries the lemma names of an IR-pinned
 /// `ProofStrategy::SimpOverLemmas` (the discovery feedback loop): the emits
 /// below add them to the law's simp sets, embed their texts (first user

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1511,6 +1511,163 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_list_law(
     })
 }
 
+/// Whether [`emit_conditional_inductive_generic_law`] will attempt this law as a
+/// universal — the `omit_domain` driver reads this. A conditional law that
+/// recurses on a list given, with an equational conclusion, that the bespoke
+/// conditional recognizers (comparison/membership/sortedness) all decline. This
+/// is the DECOMPOSITION path: the figure's algebraic content lives as earlier
+/// `verify ... law` helper blocks (the laws-as-lemmas pool), and a GENERIC list
+/// induction + premise threading + `simp_all` over the fn defs AND those pool
+/// lemmas closes it — no per-figure Lean template.
+pub(in crate::codegen::lean) fn recognize_conditional_inductive_generic(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> bool {
+    if law.when.is_none() {
+        return false;
+    }
+    // Equational conclusion (`lhs => rhs`), lhs a fn-call — not a `holds`/Bool
+    // claim (those are the membership family's territory).
+    if !matches!(&law.lhs.node, crate::ast::Expr::FnCall(..)) {
+        return false;
+    }
+    let Some(target_idx) = find_list_induction_target(law) else {
+        return false;
+    };
+    // The binary-recursion shape: induct on one list, case-split EXACTLY ONE
+    // partner list (the length-linked pair, like zip-reverse's `xs`/`ys` or the
+    // snoc-distribution's `as`/`bs`). A single-list conditional law (zero
+    // partners — e.g. json's `parse(render items)` roundtrips) is NOT reliably
+    // closed by this generic `simp_all` portfolio, so it stays on its sound
+    // bounded fallback rather than committing to a universal it would `sorry`.
+    let other_lists = law
+        .givens
+        .iter()
+        .enumerate()
+        .filter(|(i, g)| *i != target_idx && g.type_name.trim().starts_with("List<"))
+        .count();
+    if other_lists != 1 {
+        return false;
+    }
+    // Exclusive with the bespoke arms (they run first; keep the `omit_domain`
+    // gate single-valued so the statement driver and the emit agree).
+    if recognize_conditional_comparison_bridge(law, ctx)
+        || recognize_conditional_inductive_list(vb, law, ctx)
+        || recognize_conditional_sortedness_law(vb, law, ctx)
+    {
+        return false;
+    }
+    // Fire ONLY for a decomposition consumer — a law with at least one eligible
+    // earlier helper in its cone ∪ subject pool. Without helpers the generic
+    // `simp_all` over bare defs cannot supply the algebraic content (e.g.
+    // zip-reverse needs a snoc-distribution helper), so the universal proof
+    // would `sorry`; declining keeps such a law on its sound bounded fallback.
+    // This is the principle made structural: the generic driver proves a
+    // conditional law THROUGH its Aver helper laws, never by guessing.
+    !earlier_law_lemmas(vb, law, ctx).is_empty()
+}
+
+/// Close a conditional inductive law GENERICALLY: list induction on the
+/// recursive given, the premise threaded into each arm, and `simp_all` over the
+/// fn defs PLUS the eligible earlier sibling laws (the laws-as-lemmas pool). The
+/// algebraic content a figure needs (`zip` over append-singleton, length
+/// homomorphisms, …) is supplied by Aver helper `verify ... law` blocks in the
+/// same module, NOT a hardcoded Lean template. FAIL-CLOSED: the portfolio ends
+/// in `sorry`, so a law this generic driver cannot close degrades to a residual
+/// the audit catches; it never fabricates a proof.
+pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    intro_names: &[String],
+) -> Option<AutoProof> {
+    if !recognize_conditional_inductive_generic(vb, law, ctx) {
+        return None;
+    }
+    let target_idx = find_list_induction_target(law)?;
+    let target = intro_names.get(target_idx)?.clone();
+    let defs = law_simp_defs(ctx, vb, law)
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join(", ");
+    // The laws-as-lemmas pool: earlier sibling laws eligible for this proof's
+    // cone ∪ subject. Their NAMES join the induction-arm `simp_all` set (the
+    // membership emit only feeds them to its flat fast path; a conditional
+    // INDUCTIVE consumer like zip-reverse needs them INSIDE the cons arm).
+    let pool_names: Vec<String> = earlier_law_lemmas(vb, law, ctx)
+        .iter()
+        .map(|l| l.name.clone())
+        .collect();
+    let defs_pool = if pool_names.is_empty() {
+        defs.clone()
+    } else {
+        format!("{defs}, {}", pool_names.join(", "))
+    };
+    let with_append =
+        format!("{defs_pool}, List.cons_append, List.nil_append, List.singleton_append");
+    let norm = "(try simp only [Bool.not_eq_true, Bool.not_eq_false] at h_when)".to_string();
+    // The OTHER list givens (a binary recursion like zip-reverse inducts on
+    // `xs` but must case-split the equal-length partner `ys`). At most one is
+    // handled structurally; the membership-style `split` branches cover the
+    // single-list and goal-driven cases.
+    let others: Vec<String> = law
+        .givens
+        .iter()
+        .enumerate()
+        .filter(|(i, g)| *i != target_idx && g.type_name.trim().starts_with("List<"))
+        .map(|(_, g)| aver_name_to_lean(&g.name))
+        .collect();
+    let case_other = if others.len() == 1 {
+        format!("cases {} <;> ", others[0])
+    } else {
+        String::new()
+    };
+    // Induct on the target ONLY; the partner list, scalars, AND the premise stay
+    // universally quantified (intro'd inside each arm) so the IH generalizes over
+    // them — a binary recursion like zip-reverse needs `ys` to vary with `xs`'s
+    // structure. `intro` the givens that PRECEDE the target (fixed parameters),
+    // then re-intro the rest per arm.
+    // Intro the givens UP TO AND INCLUDING the target (so `induction {target}`
+    // sees it in scope), induct, then re-intro the rest + premise per arm so the
+    // IH generalizes over them.
+    let before: Vec<String> = intro_names.iter().take(target_idx + 1).cloned().collect();
+    let after: Vec<String> = intro_names.iter().skip(target_idx + 1).cloned().collect();
+    let arm_intro = if after.is_empty() {
+        "intro h_when".to_string()
+    } else {
+        format!("intro {} h_when", after.join(" "))
+    };
+    let mut body = vec![format!("  intro {}", before.join(" "))];
+    body.extend([
+        format!("  induction {target} with"),
+        "  | nil =>".to_string(),
+        format!("    {arm_intro}"),
+        format!("    {norm}"),
+        "    first".to_string(),
+        format!("    | ({case_other}simp_all [{with_append}] <;> done)"),
+        format!("    | (simp_all [{defs_pool}] <;> done)"),
+        "    | sorry".to_string(),
+        "  | cons hd tl ih =>".to_string(),
+        format!("    {arm_intro}"),
+        format!("    {norm}"),
+        "    first".to_string(),
+        format!("    | ({case_other}simp_all [{with_append}] <;> done)"),
+        format!(
+            "    | ({case_other}simp only [{with_append}] at h_when ⊢ <;> (split <;> simp_all [{defs_pool}]) <;> done)"
+        ),
+        format!("    | (simp only [{with_append}] <;> simp_all [{defs_pool}, h_when] <;> done)"),
+        format!("    | (split <;> simp_all [{defs_pool}, h_when] <;> done)"),
+        format!("    | (simp_all [{defs_pool}, h_when] <;> done)"),
+        "    | sorry".to_string(),
+    ]);
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        body: Tactic::raw(body),
+        replaces_theorem: false,
+    })
+}
+
 /// The four fns of a recognized sortedness-of-insert law, by SOURCE name.
 struct SortednessPlan {
     /// The verified sorted-insertion fn (`insort`/`insert`).
@@ -1777,64 +1934,6 @@ theorem {sort_cons} : ∀ (z : Nat) (l : List Nat),
     Some(AutoProof {
         support_lines,
         body: Tactic::raw(body),
-        replaces_theorem: false,
-    })
-}
-
-/// Whether [`emit_conditional_zip_rev_law`] will close this law universally —
-/// the `omit_domain` statement driver reads this, kept in lockstep with the
-/// emit. The recognizer is the lane's validated `ZipRevLenEq` classifier,
-/// borrowed by the main path during the `when`-universal lane's retirement.
-pub(in crate::codegen::lean) fn recognize_conditional_zip_rev_law(
-    vb: &VerifyBlock,
-    law: &VerifyLaw,
-    ctx: &CodegenContext,
-) -> bool {
-    crate::codegen::lean::universal_lane::is_zip_rev_bridge(vb, law, ctx)
-}
-
-/// Close the zip-reverse length-equality law (`prop_85`:
-/// `when natEq(len xs, len ys) -> zip(rev xs, rev ys) => revPair(zip xs ys)`)
-/// as the TRUE-universal `∀ xs ys, len xs = len ys -> …`. Reuses the lane's
-/// validated proof — the `=`-bridge over Peano `Nat`, append/rev length
-/// homomorphisms, the `len ys = 0 → ys = []` inversion, and the
-/// snoc-distribution aux lemma — then the main induction on `xs`, threading
-/// the length premise through the generalized `ys`. The support lemmas are
-/// `<fn>_<law>`-scoped (no `_law_`, so the `#print axioms` credit audit never
-/// mistakes one for the creditable theorem). FAIL-CLOSED: declines any other
-/// shape (`None`), so the caller keeps the bounded proof.
-pub(in crate::codegen::lean) fn emit_conditional_zip_rev_law(
-    vb: &VerifyBlock,
-    law: &VerifyLaw,
-    ctx: &CodegenContext,
-    _intro_names: &[String],
-) -> Option<AutoProof> {
-    let prefix = format!(
-        "{}_{}",
-        aver_name_to_lean(&vb.fn_name),
-        aver_name_to_lean(&law.name)
-    );
-    let (supports, body) =
-        crate::codegen::lean::universal_lane::zip_rev_universal_proof(vb, law, ctx, &prefix)?;
-    // The lane emits the body at base indentation (its renderer adds the
-    // leading two spaces); the main-path `AutoProof` body carries its own
-    // two-space base indent, so re-indent here (empty lines stay empty).
-    let body_lines: Vec<String> = body
-        .lines()
-        .map(|l| {
-            if l.is_empty() {
-                String::new()
-            } else {
-                format!("  {l}")
-            }
-        })
-        .collect();
-    // ONE `support_lines` element (newlines embedded): `emit_verify_law_block`
-    // de-duplicates support lines line-by-line, which would silently drop the
-    // proof's repeated lines and corrupt the multi-lemma block.
-    Some(AutoProof {
-        support_lines: vec![supports.join("\n")],
-        body: Tactic::raw(body_lines),
         replaces_theorem: false,
     })
 }

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -752,6 +752,58 @@ verify elem law elemConcat
 }
 
 #[test]
+fn transpile_proves_count_membership_law_as_universal() {
+    // `prop_76`-shape (`when not(eqNat(n, m)) -> count(n, xs ++ [m]) = count(n, xs)`):
+    // the verified fn `count` returns Nat, not Bool, yet it is a per-element FOLD
+    // (its cons arm COMPARES the head, never returns it), so the membership emit
+    // admits it and closes the law `universal`. Guards the count/`last` boundary —
+    // a Nat-returning SELECTOR like `last` must NOT be admitted.
+    let mut ctx = ctx_from_source(
+        r#"
+module CountMembership
+    intent = "count(n, xs ++ [m]) = count(n, xs) when n /= m"
+
+type Nat
+    Z
+    S(Nat)
+
+fn eqNat(x: Nat, y: Nat) -> Bool
+    match x
+        Nat.Z -> match y
+            Nat.Z -> true
+            Nat.S(z) -> false
+        Nat.S(x2) -> match y
+            Nat.Z -> false
+            Nat.S(y2) -> eqNat(x2, y2)
+
+fn count(x: Nat, y: List<Nat>) -> Nat
+    match y
+        [] -> Nat.Z
+        [z, ..zs] -> match eqNat(x, z)
+            true -> Nat.S(count(x, zs))
+            false -> count(x, zs)
+
+verify count law countAppendSingleton
+    given n: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given m: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given xs: List<Nat> = [[], [Nat.Z]]
+    when Bool.not(eqNat(n, m))
+    count(n, List.concat(xs, [m])) => count(n, xs)
+"#,
+        "count_membership",
+    );
+    let out = transpile(&mut ctx);
+    let lean = generated_lean_file(&out);
+
+    // A `Nat`-returning fold still earns the unbounded `universal` statement.
+    assert!(lean.contains(
+        "-- aver:law-class count_law_countAppendSingleton universal count.countAppendSingleton"
+    ));
+    assert!(lean.contains("induction xs with"));
+    assert!(lean.contains("intro h_when"));
+}
+
+#[test]
 fn transpile_proves_sortedness_of_insertion_law_as_universal() {
     // `prop_77 sortedInsort`: `when sorted(xs) -> sorted(insort(x, xs)) => true`.
     // Closes as the TRUE-universal `∀ x xs, sorted xs = true -> sorted (insort x xs)

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -870,6 +870,87 @@ verify insort law sortedInsort
 }
 
 #[test]
+fn transpile_proves_zip_rev_law_as_universal() {
+    // `prop_85 zipRev`: `when natEq(len xs, len ys) -> zip(rev xs, rev ys) =>
+    // revPair(zip xs ys)`. Absorbed from the `when`-universal lane onto the main
+    // path: closes as the TRUE-universal `∀ xs ys, len xs = len ys -> …` by
+    // reusing the lane's validated proof — the `=`-bridge over Peano `Nat`, the
+    // append/rev length homomorphisms, the `len ys = 0 → ys = []` inversion, and
+    // the snoc-distribution aux lemma the bare list IH cannot supply.
+    let mut ctx = ctx_from_source(
+        r#"
+module ZipRev
+    intent = "if len xs = len ys then zip (rev xs) (rev ys) = revPair (zip xs ys)"
+
+type Nat
+    Z
+    S(Nat)
+
+fn natEq(a: Nat, b: Nat) -> Bool
+    match a
+        Nat.Z -> match b
+            Nat.Z -> true
+            Nat.S(y) -> false
+        Nat.S(x) -> match b
+            Nat.Z -> false
+            Nat.S(y) -> natEq(x, y)
+
+fn len(xs: List<Int>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [y, ..ys] -> Nat.S(len(ys))
+
+fn appendInt(xs: List<Int>, ys: List<Int>) -> List<Int>
+    match xs
+        [] -> ys
+        [z, ..zs] -> List.concat([z], appendInt(zs, ys))
+
+fn appendPair(xs: List<Tuple<Int, Int>>, ys: List<Tuple<Int, Int>>) -> List<Tuple<Int, Int>>
+    match xs
+        [] -> ys
+        [z, ..zs] -> List.concat([z], appendPair(zs, ys))
+
+fn rev(xs: List<Int>) -> List<Int>
+    match xs
+        [] -> []
+        [y, ..ys] -> appendInt(rev(ys), [y])
+
+fn revPair(xs: List<Tuple<Int, Int>>) -> List<Tuple<Int, Int>>
+    match xs
+        [] -> []
+        [y, ..ys] -> appendPair(revPair(ys), [y])
+
+fn zip(xs: List<Int>, ys: List<Int>) -> List<Tuple<Int, Int>>
+    match xs
+        [] -> []
+        [z, ..x2] -> match ys
+            [] -> []
+            [x3, ..x4] -> List.concat([(z, x3)], zip(x2, x4))
+
+verify zip law zipRev
+    given xs: List<Int> = [[], [1], [1, 2]]
+    given ys: List<Int> = [[], [4], [4, 5]]
+    when natEq(len(xs), len(ys))
+    zip(rev(xs), rev(ys)) => revPair(zip(xs, ys))
+"#,
+        "zip_rev",
+    );
+    let out = transpile(&mut ctx);
+    let lean = generated_lean_file(&out);
+
+    // Classed `universal` (sampled-domain disjunctions dropped).
+    assert!(lean.contains("-- aver:law-class zip_law_zipRev universal zip.zipRev"));
+    // The TRUE-universal conditional statement.
+    assert!(lean.contains(
+        "theorem zip_law_zipRev : ∀ (xs : List Int) (ys : List Int), natEq (len xs) (len ys) = true -> zip (rev xs) (rev ys) = revPair (zip xs ys) := by"
+    ));
+    // The snoc-distribution aux lemma, `<fn>_<law>`-scoped (no `_law_` so the
+    // `#print axioms` credit audit never mistakes it for the main theorem).
+    assert!(lean.contains("theorem zip_zipRev_snoc (x y : Int) : ∀ (as bs : List Int),"));
+    assert!(lean.contains("theorem zip_zipRev_bridge_eq"));
+}
+
+#[test]
 fn transpile_auto_proves_simp_normalized_canonical_spec_law_in_auto_mode() {
     let mut ctx = ctx_from_source(
         r#"

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -870,13 +870,13 @@ verify insort law sortedInsort
 }
 
 #[test]
-fn transpile_proves_zip_rev_law_as_universal() {
-    // `prop_85 zipRev`: `when natEq(len xs, len ys) -> zip(rev xs, rev ys) =>
-    // revPair(zip xs ys)`. Absorbed from the `when`-universal lane onto the main
-    // path: closes as the TRUE-universal `∀ xs ys, len xs = len ys -> …` by
-    // reusing the lane's validated proof — the `=`-bridge over Peano `Nat`, the
-    // append/rev length homomorphisms, the `len ys = 0 → ys = []` inversion, and
-    // the snoc-distribution aux lemma the bare list IH cannot supply.
+fn transpile_proves_zip_rev_via_generic_decomposition() {
+    // `prop_85 zipRev` closes through the DECOMPOSITION path, NOT a hardcoded
+    // Lean template: a `zipSnocDistribution` helper `verify ... law` supplies the
+    // algebraic content, and the GENERIC conditional-inductive driver proves
+    // zipRev by list induction + `simp_all` over the fn defs AND that earlier
+    // helper (the laws-as-lemmas pool). The premise `when` law is cited as the
+    // conditional rewrite `… = true -> …`.
     let mut ctx = ctx_from_source(
         r#"
 module ZipRev
@@ -927,6 +927,19 @@ fn zip(xs: List<Int>, ys: List<Int>) -> List<Tuple<Int, Int>>
             [] -> []
             [x3, ..x4] -> List.concat([(z, x3)], zip(x2, x4))
 
+verify len law lenSnocSucc
+    given a: List<Int> = [[], [1], [1, 2]]
+    given x: Int = [9]
+    len(appendInt(a, [x])) => Nat.S(len(a))
+
+verify zip law zipSnocDistribution
+    given as: List<Int> = [[], [1]]
+    given bs: List<Int> = [[], [4]]
+    given x: Int = [7]
+    given y: Int = [9]
+    when natEq(len(as), len(bs))
+    zip(appendInt(as, [x]), appendInt(bs, [y])) => appendPair(zip(as, bs), [(x, y)])
+
 verify zip law zipRev
     given xs: List<Int> = [[], [1], [1, 2]]
     given ys: List<Int> = [[], [4], [4, 5]]
@@ -938,16 +951,17 @@ verify zip law zipRev
     let out = transpile(&mut ctx);
     let lean = generated_lean_file(&out);
 
-    // Classed `universal` (sampled-domain disjunctions dropped).
+    // zipRev is classed `universal` and proved by the GENERIC driver: list
+    // induction threading the premise, with the snoc-distribution HELPER LAW
+    // cited from the pool inside the proof's `simp_all` set.
     assert!(lean.contains("-- aver:law-class zip_law_zipRev universal zip.zipRev"));
-    // The TRUE-universal conditional statement.
     assert!(lean.contains(
         "theorem zip_law_zipRev : ∀ (xs : List Int) (ys : List Int), natEq (len xs) (len ys) = true -> zip (rev xs) (rev ys) = revPair (zip xs ys) := by"
     ));
-    // The snoc-distribution aux lemma, `<fn>_<law>`-scoped (no `_law_` so the
-    // `#print axioms` credit audit never mistakes it for the main theorem).
-    assert!(lean.contains("theorem zip_zipRev_snoc (x y : Int) : ∀ (as bs : List Int),"));
-    assert!(lean.contains("theorem zip_zipRev_bridge_eq"));
+    assert!(lean.contains("induction xs with"));
+    assert!(lean.contains("zip_law_zipSnocDistribution"));
+    // No hardcoded per-figure template (the old `zip_rev_supports_body` path).
+    assert!(!lean.contains("zip_zipRev_snoc"));
 }
 
 #[test]

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -573,7 +573,8 @@ fn emit_verify_law_block(
         && lifted_vars.is_empty()
         && (super::law_auto::recognize_conditional_comparison_bridge(&law_for_auto_proof, ctx)
             || super::law_auto::recognize_conditional_inductive_list(vb, &law_for_auto_proof, ctx)
-            || super::law_auto::recognize_conditional_sortedness_law(vb, &law_for_auto_proof, ctx));
+            || super::law_auto::recognize_conditional_sortedness_law(vb, &law_for_auto_proof, ctx)
+            || super::law_auto::recognize_conditional_zip_rev_law(vb, &law_for_auto_proof, ctx));
     if !quant_params.is_empty() && !skip_universal {
         lines.extend(emit_verify_law_support_theorems(
             vb,

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -574,7 +574,11 @@ fn emit_verify_law_block(
         && (super::law_auto::recognize_conditional_comparison_bridge(&law_for_auto_proof, ctx)
             || super::law_auto::recognize_conditional_inductive_list(vb, &law_for_auto_proof, ctx)
             || super::law_auto::recognize_conditional_sortedness_law(vb, &law_for_auto_proof, ctx)
-            || super::law_auto::recognize_conditional_zip_rev_law(vb, &law_for_auto_proof, ctx));
+            || super::law_auto::recognize_conditional_inductive_generic(
+                vb,
+                &law_for_auto_proof,
+                ctx,
+            ));
     if !quant_params.is_empty() && !skip_universal {
         lines.extend(emit_verify_law_support_theorems(
             vb,
@@ -984,7 +988,18 @@ pub(crate) fn law_as_lemma_statement(
     law: &VerifyLaw,
     ctx: &CodegenContext,
 ) -> Option<(String, String)> {
-    if law.when.is_some() {
+    // A `when`-premise law is citable as a CONDITIONAL rewrite (`P = true ->
+    // lhs = rhs`) — but only once it is proven universally, which the
+    // conditional recognizers gate. Before #599 no `when`-law was ever
+    // universal, so the pool declined them wholesale; now a proven conditional
+    // law is a sound conditional simp lemma. Decline a `when`-law the auto-
+    // prover only bounds (it has no universal theorem to cite).
+    if law.when.is_some()
+        && !(super::law_auto::recognize_conditional_comparison_bridge(law, ctx)
+            || super::law_auto::recognize_conditional_inductive_list(vb, law, ctx)
+            || super::law_auto::recognize_conditional_sortedness_law(vb, law, ctx)
+            || super::law_auto::recognize_conditional_inductive_generic(vb, law, ctx))
+    {
         return None;
     }
     if crate::codegen::common::law_lhs_has_trace_projection(&law.lhs) {
@@ -1070,7 +1085,15 @@ pub(crate) fn law_as_lemma_statement(
     }
     let lhs = emit_expr_legacy(&law_lhs, ctx, None);
     let rhs = emit_expr_legacy(&law_rhs, ctx, None);
-    Some((theorem_base, format!("{lhs} = {rhs}")))
+    // A `when`-law is cited as the conditional rewrite the auto-prover proved:
+    // `<premise> = true -> lhs = rhs`, matching the `omit_domain` theorem.
+    match &law.when {
+        Some(when) => {
+            let premise = emit_expr_legacy(when, ctx, None);
+            Some((theorem_base, format!("{premise} = true -> {lhs} = {rhs}")))
+        }
+        None => Some((theorem_base, format!("{lhs} = {rhs}"))),
+    }
 }
 
 #[derive(Clone)]

--- a/src/codegen/lean/universal_lane/bridge.rs
+++ b/src/codegen/lean/universal_lane/bridge.rs
@@ -956,6 +956,215 @@ pub(super) fn classify_bridge_law(
     }
 }
 
+/// The validated zip-rev (`ZipRevLenEq`) proof, factored out of
+/// [`render_bridge_law`] so the SAME proof text backs both the lane twin
+/// and the main-path conditional emit. All fn-name params are already
+/// Lean-mangled; `prefix` scopes the six support-lemma names (the lane
+/// passes its `_universal` theorem, the main path its `<fn>_<law>` base);
+/// `sab` is the test-only sabotage suffix (`""` on the main path). The
+/// body is emitted at base indentation — each caller adds its own.
+#[allow(clippy::too_many_arguments)]
+fn zip_rev_supports_body(
+    eq: &str,
+    len: &str,
+    zip: &str,
+    rev: &str,
+    revp: &str,
+    app: &str,
+    appp: &str,
+    a_ty: &str,
+    xs: &str,
+    ys: &str,
+    prefix: &str,
+    sab: &str,
+) -> (Vec<String>, String) {
+    let supports = vec![
+        format!(
+            r#"private theorem {prefix}_bridge_eq : ∀ (a b : Nat), _root_.{eq} a b = true → a = b := by
+  intro a
+  induction a with
+  | zero =>
+    intro b h
+    cases b with
+    | zero => rfl
+    | succ y => simp [_root_.{eq}] at h
+  | succ x ih =>
+    intro b h
+    cases b with
+    | zero => simp [_root_.{eq}] at h
+    | succ y =>
+      have hx := ih y (by simpa [_root_.{eq}] using h)
+      omega
+"#
+        ),
+        format!(
+            r#"private theorem {prefix}_bridge_refl : ∀ (a : Nat), _root_.{eq} a a = true := by
+  intro a
+  induction a with
+  | zero => rfl
+  | succ x ih => simpa [_root_.{eq}] using ih
+"#
+        ),
+        // Measure homomorphism over append — the premise-stepping
+        // arithmetic below rides on it.
+        format!(
+            r#"private theorem {prefix}_len_append : ∀ (xs ys : List {a_ty}),
+    _root_.{len} (_root_.{app} xs ys) = _root_.{len} xs + _root_.{len} ys := by
+  intro xs
+  induction xs with
+  | nil => intro ys; simp [_root_.{app}, _root_.{len}]
+  | cons z zs ih =>
+    intro ys
+    simp only [_root_.{app}, List.singleton_append, _root_.{len}, ih]
+    omega
+"#
+        ),
+        format!(
+            r#"private theorem {prefix}_len_rev : ∀ (xs : List {a_ty}), _root_.{len} (_root_.{rev} xs) = _root_.{len} xs := by
+  intro xs
+  induction xs with
+  | nil => simp [_root_.{rev}]
+  | cons y ys ih =>
+    simp only [_root_.{rev}, {prefix}_len_append, _root_.{len}, ih]
+"#
+        ),
+        // Premise-driven shape inversion of the non-induction
+        // variable: `len ys = 0 → ys = []`.
+        format!(
+            r#"private theorem {prefix}_len_zero : ∀ (ys : List {a_ty}), _root_.{len} ys = 0 → ys = [] := by
+  intro ys h
+  cases ys with
+  | nil => rfl
+  | cons y ys =>
+    simp only [_root_.{len}] at h
+    exact absurd h (by omega)
+"#
+        ),
+        // The snoc-distribution aux lemma (zip over append-singleton
+        // under length equality) — emitted from the validated template,
+        // never as a sorry. Its own premise threads by per-step
+        // stepping and vacuous discharge.
+        format!(
+            r#"private theorem {prefix}_snoc (x y : {a_ty}) : ∀ (as bs : List {a_ty}),
+    _root_.{len} as = _root_.{len} bs →
+    _root_.{zip} (_root_.{app} as [x]) (_root_.{app} bs [y])
+      = _root_.{appp} (_root_.{zip} as bs) [(x, y)] := by
+  intro as
+  induction as with
+  | nil =>
+    intro bs h
+    have hb : bs = [] := {prefix}_len_zero bs (by simp only [_root_.{len}] at h; omega)
+    subst hb
+    simp [_root_.{app}, _root_.{zip}, _root_.{appp}]
+  | cons a as ih =>
+    intro bs h
+    cases bs with
+    | nil =>
+      simp only [_root_.{len}] at h
+      exact absurd h (by omega)
+    | cons b bs =>
+      have h' : _root_.{len} as = _root_.{len} bs := by simp only [_root_.{len}] at h; omega
+      simp only [_root_.{app}, List.singleton_append, _root_.{zip}, _root_.{appp}, ih bs h']
+"#
+        ),
+    ];
+    let body = format!(
+        r#"intro {xs}{sab}
+induction {xs} with
+| nil =>
+  intro {ys} h
+  have h0 : _root_.{len} {ys} = 0 := by
+    have hh := {prefix}_bridge_eq (_root_.{len} []) (_root_.{len} {ys}) h
+    simp only [_root_.{len}] at hh
+    omega
+  have hy : {ys} = [] := {prefix}_len_zero {ys} h0
+  subst hy
+  simp [_root_.{rev}, _root_.{zip}, _root_.{revp}]
+| cons z x2 ih =>
+  intro {ys} h
+  cases {ys} with
+  | nil =>
+    have hh := {prefix}_bridge_eq (_root_.{len} (z :: x2)) (_root_.{len} []) h
+    simp only [_root_.{len}] at hh
+    exact absurd hh (by omega)
+  | cons y x4 =>
+    have hlen : _root_.{len} x2 = _root_.{len} x4 := by
+      have hh := {prefix}_bridge_eq (_root_.{len} (z :: x2)) (_root_.{len} (y :: x4)) h
+      simp only [_root_.{len}] at hh
+      omega
+    have hrevlen : _root_.{len} (_root_.{rev} x2) = _root_.{len} (_root_.{rev} x4) := by
+      rw [{prefix}_len_rev, {prefix}_len_rev]; exact hlen
+    have hih : _root_.{zip} (_root_.{rev} x2) (_root_.{rev} x4) = _root_.{revp} (_root_.{zip} x2 x4) := by
+      apply ih
+      rw [hlen]
+      exact {prefix}_bridge_refl (_root_.{len} x4)
+    calc _root_.{zip} (_root_.{rev} (z :: x2)) (_root_.{rev} (y :: x4))
+        = _root_.{zip} (_root_.{app} (_root_.{rev} x2) [z]) (_root_.{app} (_root_.{rev} x4) [y]) := by
+          simp only [_root_.{rev}]
+      _ = _root_.{appp} (_root_.{zip} (_root_.{rev} x2) (_root_.{rev} x4)) [(z, y)] :=
+          {prefix}_snoc z y (_root_.{rev} x2) (_root_.{rev} x4) hrevlen
+      _ = _root_.{appp} (_root_.{revp} (_root_.{zip} x2 x4)) [(z, y)] := by rw [hih]
+      _ = _root_.{revp} (_root_.{zip} (z :: x2) (y :: x4)) := by
+          simp only [_root_.{zip}, _root_.{revp}, List.singleton_append]"#
+    );
+    (supports, body)
+}
+
+/// True iff `law` is the zip-rev length-equality figure. The main-path
+/// `omit_domain` driver reads this to flip the law-class marker to
+/// `universal` for exactly this shape.
+pub(in crate::codegen::lean) fn is_zip_rev_bridge(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> bool {
+    matches!(
+        classify_bridge_law(vb, law, ctx),
+        Some(BridgePlan::ZipRevLenEq { .. })
+    )
+}
+
+/// Build the zip-rev universal proof (support lemmas + body) for the MAIN
+/// path, `prefix`-scoping the support-lemma names so they never collide
+/// with the lane twin or carry the `_law_` substring the credit audit
+/// keys on. `None` for any non-zip-rev law.
+pub(in crate::codegen::lean) fn zip_rev_universal_proof(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    prefix: &str,
+) -> Option<(Vec<String>, String)> {
+    let Some(BridgePlan::ZipRevLenEq {
+        eq_fn,
+        len_fn,
+        zip_fn,
+        rev_fn,
+        rev_pair_fn,
+        append_fn,
+        append_pair_fn,
+        elem_ty,
+        xs,
+        ys,
+    }) = classify_bridge_law(vb, law, ctx)
+    else {
+        return None;
+    };
+    Some(zip_rev_supports_body(
+        &aver_name_to_lean(&eq_fn),
+        &aver_name_to_lean(&len_fn),
+        &aver_name_to_lean(&zip_fn),
+        &aver_name_to_lean(&rev_fn),
+        &aver_name_to_lean(&rev_pair_fn),
+        &aver_name_to_lean(&append_fn),
+        &aver_name_to_lean(&append_pair_fn),
+        &elem_ty,
+        &aver_name_to_lean(&xs),
+        &aver_name_to_lean(&ys),
+        prefix,
+        "",
+    ))
+}
+
 /// Render one bridge-premise lane law: the validated proof template
 /// for `plan`, support lemmas included, into a single hashed module.
 /// Statement built by the SAME `law_theorem_prop` as the manifest
@@ -1080,125 +1289,20 @@ pub(super) fn render_bridge_law(
             elem_ty,
             xs,
             ys,
-        } => {
-            let eq = aver_name_to_lean(eq_fn);
-            let len = aver_name_to_lean(len_fn);
-            let zip = aver_name_to_lean(zip_fn);
-            let rev = aver_name_to_lean(rev_fn);
-            let revp = aver_name_to_lean(rev_pair_fn);
-            let app = aver_name_to_lean(append_fn);
-            let appp = aver_name_to_lean(append_pair_fn);
-            let a_ty = elem_ty;
-            let xs = aver_name_to_lean(xs);
-            let ys = aver_name_to_lean(ys);
-            let supports = vec![
-                bridge_eq_lemma(&eq),
-                bridge_refl_lemma(&eq),
-                // Measure homomorphism over append — the premise-stepping
-                // arithmetic below rides on it.
-                format!(
-                    r#"private theorem {theorem}_len_append : ∀ (xs ys : List {a_ty}),
-    _root_.{len} (_root_.{app} xs ys) = _root_.{len} xs + _root_.{len} ys := by
-  intro xs
-  induction xs with
-  | nil => intro ys; simp [_root_.{app}, _root_.{len}]
-  | cons z zs ih =>
-    intro ys
-    simp only [_root_.{app}, List.singleton_append, _root_.{len}, ih]
-    omega
-"#
-                ),
-                format!(
-                    r#"private theorem {theorem}_len_rev : ∀ (xs : List {a_ty}), _root_.{len} (_root_.{rev} xs) = _root_.{len} xs := by
-  intro xs
-  induction xs with
-  | nil => simp [_root_.{rev}]
-  | cons y ys ih =>
-    simp only [_root_.{rev}, {theorem}_len_append, _root_.{len}, ih]
-"#
-                ),
-                // Premise-driven shape inversion of the non-induction
-                // variable: `len ys = 0 → ys = []`.
-                format!(
-                    r#"private theorem {theorem}_len_zero : ∀ (ys : List {a_ty}), _root_.{len} ys = 0 → ys = [] := by
-  intro ys h
-  cases ys with
-  | nil => rfl
-  | cons y ys =>
-    simp only [_root_.{len}] at h
-    exact absurd h (by omega)
-"#
-                ),
-                // The snoc-distribution aux lemma (zip over
-                // append-singleton under length equality) — emitted
-                // from the validated template, never as a sorry. Its
-                // own premise threads by per-step stepping (C) and
-                // vacuous discharge (D).
-                format!(
-                    r#"private theorem {theorem}_snoc (x y : {a_ty}) : ∀ (as bs : List {a_ty}),
-    _root_.{len} as = _root_.{len} bs →
-    _root_.{zip} (_root_.{app} as [x]) (_root_.{app} bs [y])
-      = _root_.{appp} (_root_.{zip} as bs) [(x, y)] := by
-  intro as
-  induction as with
-  | nil =>
-    intro bs h
-    have hb : bs = [] := {theorem}_len_zero bs (by simp only [_root_.{len}] at h; omega)
-    subst hb
-    simp [_root_.{app}, _root_.{zip}, _root_.{appp}]
-  | cons a as ih =>
-    intro bs h
-    cases bs with
-    | nil =>
-      simp only [_root_.{len}] at h
-      exact absurd h (by omega)
-    | cons b bs =>
-      have h' : _root_.{len} as = _root_.{len} bs := by simp only [_root_.{len}] at h; omega
-      simp only [_root_.{app}, List.singleton_append, _root_.{zip}, _root_.{appp}, ih bs h']
-"#
-                ),
-            ];
-            let body = format!(
-                r#"intro {xs}{sab}
-induction {xs} with
-| nil =>
-  intro {ys} h
-  have h0 : _root_.{len} {ys} = 0 := by
-    have hh := {theorem}_bridge_eq (_root_.{len} []) (_root_.{len} {ys}) h
-    simp only [_root_.{len}] at hh
-    omega
-  have hy : {ys} = [] := {theorem}_len_zero {ys} h0
-  subst hy
-  simp [_root_.{rev}, _root_.{zip}, _root_.{revp}]
-| cons z x2 ih =>
-  intro {ys} h
-  cases {ys} with
-  | nil =>
-    have hh := {theorem}_bridge_eq (_root_.{len} (z :: x2)) (_root_.{len} []) h
-    simp only [_root_.{len}] at hh
-    exact absurd hh (by omega)
-  | cons y x4 =>
-    have hlen : _root_.{len} x2 = _root_.{len} x4 := by
-      have hh := {theorem}_bridge_eq (_root_.{len} (z :: x2)) (_root_.{len} (y :: x4)) h
-      simp only [_root_.{len}] at hh
-      omega
-    have hrevlen : _root_.{len} (_root_.{rev} x2) = _root_.{len} (_root_.{rev} x4) := by
-      rw [{theorem}_len_rev, {theorem}_len_rev]; exact hlen
-    have hih : _root_.{zip} (_root_.{rev} x2) (_root_.{rev} x4) = _root_.{revp} (_root_.{zip} x2 x4) := by
-      apply ih
-      rw [hlen]
-      exact {theorem}_bridge_refl (_root_.{len} x4)
-    calc _root_.{zip} (_root_.{rev} (z :: x2)) (_root_.{rev} (y :: x4))
-        = _root_.{zip} (_root_.{app} (_root_.{rev} x2) [z]) (_root_.{app} (_root_.{rev} x4) [y]) := by
-          simp only [_root_.{rev}]
-      _ = _root_.{appp} (_root_.{zip} (_root_.{rev} x2) (_root_.{rev} x4)) [(z, y)] :=
-          {theorem}_snoc z y (_root_.{rev} x2) (_root_.{rev} x4) hrevlen
-      _ = _root_.{appp} (_root_.{revp} (_root_.{zip} x2 x4)) [(z, y)] := by rw [hih]
-      _ = _root_.{revp} (_root_.{zip} (z :: x2) (y :: x4)) := by
-          simp only [_root_.{zip}, _root_.{revp}, List.singleton_append]"#
-            );
-            (supports, body)
-        }
+        } => zip_rev_supports_body(
+            &aver_name_to_lean(eq_fn),
+            &aver_name_to_lean(len_fn),
+            &aver_name_to_lean(zip_fn),
+            &aver_name_to_lean(rev_fn),
+            &aver_name_to_lean(rev_pair_fn),
+            &aver_name_to_lean(append_fn),
+            &aver_name_to_lean(append_pair_fn),
+            elem_ty,
+            &aver_name_to_lean(xs),
+            &aver_name_to_lean(ys),
+            &theorem,
+            sab,
+        ),
         BridgePlan::EqElemInsert {
             eq_fn,
             elem_fn,

--- a/src/codegen/lean/universal_lane/bridge.rs
+++ b/src/codegen/lean/universal_lane/bridge.rs
@@ -1110,61 +1110,6 @@ induction {xs} with
     (supports, body)
 }
 
-/// True iff `law` is the zip-rev length-equality figure. The main-path
-/// `omit_domain` driver reads this to flip the law-class marker to
-/// `universal` for exactly this shape.
-pub(in crate::codegen::lean) fn is_zip_rev_bridge(
-    vb: &VerifyBlock,
-    law: &VerifyLaw,
-    ctx: &CodegenContext,
-) -> bool {
-    matches!(
-        classify_bridge_law(vb, law, ctx),
-        Some(BridgePlan::ZipRevLenEq { .. })
-    )
-}
-
-/// Build the zip-rev universal proof (support lemmas + body) for the MAIN
-/// path, `prefix`-scoping the support-lemma names so they never collide
-/// with the lane twin or carry the `_law_` substring the credit audit
-/// keys on. `None` for any non-zip-rev law.
-pub(in crate::codegen::lean) fn zip_rev_universal_proof(
-    vb: &VerifyBlock,
-    law: &VerifyLaw,
-    ctx: &CodegenContext,
-    prefix: &str,
-) -> Option<(Vec<String>, String)> {
-    let Some(BridgePlan::ZipRevLenEq {
-        eq_fn,
-        len_fn,
-        zip_fn,
-        rev_fn,
-        rev_pair_fn,
-        append_fn,
-        append_pair_fn,
-        elem_ty,
-        xs,
-        ys,
-    }) = classify_bridge_law(vb, law, ctx)
-    else {
-        return None;
-    };
-    Some(zip_rev_supports_body(
-        &aver_name_to_lean(&eq_fn),
-        &aver_name_to_lean(&len_fn),
-        &aver_name_to_lean(&zip_fn),
-        &aver_name_to_lean(&rev_fn),
-        &aver_name_to_lean(&rev_pair_fn),
-        &aver_name_to_lean(&append_fn),
-        &aver_name_to_lean(&append_pair_fn),
-        &elem_ty,
-        &aver_name_to_lean(&xs),
-        &aver_name_to_lean(&ys),
-        prefix,
-        "",
-    ))
-}
-
 /// Render one bridge-premise lane law: the validated proof template
 /// for `plan`, support lemmas included, into a single hashed module.
 /// Statement built by the SAME `law_theorem_prop` as the manifest

--- a/src/codegen/lean/universal_lane/mod.rs
+++ b/src/codegen/lean/universal_lane/mod.rs
@@ -125,12 +125,6 @@ mod shared;
 mod sign;
 
 use bridge::{classify_bridge_law, render_bridge_law};
-// The zip-rev figure's recognizer and proof builder are reused by the
-// main conditional-law path (the `when`-as-implication absorption) so the
-// figure is proved on the headline theorem, not only the off-headline
-// lane twin. The lane module owns the validated proof text; the main path
-// borrows it until the lane is retired.
-pub(in crate::codegen::lean) use bridge::{is_zip_rev_bridge, zip_rev_universal_proof};
 use consume::{HelperView, classify_consumption, render_consumption};
 use floor::{classify_floor_law, render_floor_law};
 use sign::{classify_lane_law, collect_pins, render_lane_law};

--- a/src/codegen/lean/universal_lane/mod.rs
+++ b/src/codegen/lean/universal_lane/mod.rs
@@ -125,6 +125,12 @@ mod shared;
 mod sign;
 
 use bridge::{classify_bridge_law, render_bridge_law};
+// The zip-rev figure's recognizer and proof builder are reused by the
+// main conditional-law path (the `when`-as-implication absorption) so the
+// figure is proved on the headline theorem, not only the off-headline
+// lane twin. The lane module owns the validated proof text; the main path
+// borrows it until the lane is retired.
+pub(in crate::codegen::lean) use bridge::{is_zip_rev_bridge, zip_rev_universal_proof};
 use consume::{HelperView, classify_consumption, render_consumption};
 use floor::{classify_floor_law, render_floor_law};
 use sign::{classify_lane_law, collect_pins, render_lane_law};

--- a/tests/proof_spec/check_gates.rs
+++ b/tests/proof_spec/check_gates.rs
@@ -76,19 +76,34 @@ fn proof_check_lean_universal_field_distinguishes_bounded_from_genuine() {
     // depends on `Lean.ofReduceBool` (the kernel trusting the compiler's
     // evaluation over the concrete domain), NOT the universal claim, so
     // `#print axioms` exposes it. `universal` must report `false` there while
-    // `passed` stays `true` — the exact split the field exists for. prop_85
-    // (zip/rev over a bounded sample domain) is the committed corpus instance.
+    // `passed` stays `true` — the exact split the field exists for. The
+    // `fac = qfac · 1` accumulator equivalence is the bounded-only instance:
+    // genuine induction needs an IH generalization over the accumulator the
+    // no-discovery auto-prover does not perform, so it falls back to the bounded
+    // sample proof. (This is the SAME law the Dafny sibling test pins as its
+    // omitted-universal instance — both flip together if the capability lands.)
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping lean universal-field test: `lake` not available");
         return;
     }
-    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-universal-bounded-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("facq.av"),
+        "module FacQ\n    effects []\n\n\
+         type Nat\n    Z\n    S(Nat)\n\n\
+         fn plus(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> y\n        Nat.S(z) -> Nat.S(plus(z, y))\n\n\
+         fn mult(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> Nat.Z\n        Nat.S(z) -> plus(y, mult(z, y))\n\n\
+         fn fac(x: Nat) -> Nat\n    match x\n        Nat.Z -> Nat.S(Nat.Z)\n        Nat.S(y) -> mult(x, fac(y))\n\n\
+         fn qfac(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> y\n        Nat.S(z) -> qfac(z, mult(x, y))\n\n\
+         verify fac law facQfac\n    given x: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    fac(x) => qfac(x, Nat.S(Nat.Z))\n",
+    )
+    .expect("write facq.av");
     let out = temp_output_dir("aver-universal-bounded-out");
     let run = Command::new(aver_bin)
-        .current_dir(&repo_root)
         .arg("proof")
-        .arg("proof-corpus/tip/isaplanner/prop_85.av")
+        .arg(src.join("facq.av"))
         .arg("--backend")
         .arg("lean")
         .arg("-o")
@@ -110,10 +125,11 @@ fn proof_check_lean_universal_field_distinguishes_bounded_from_genuine() {
         (Some(true), Some(false)),
         "a bounded `native_decide` proof must stay lenient on `passed` but report \
          `universal:false` (it depends on `Lean.ofReduceBool`, not the ∀-claim). \
-         If `universal` flipped to true, prop_85 now closes genuinely — celebrate \
-         and re-baseline this test.\n{}",
+         If `universal` flipped to true, the accumulator equivalence now closes \
+         genuinely — celebrate and re-baseline this test (and its Dafny sibling).\n{}",
         format_output(&run)
     );
+    let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
 

--- a/tests/proof_spec/when_lane.rs
+++ b/tests/proof_spec/when_lane.rs
@@ -380,13 +380,16 @@ fn proof_when_universal_lane_json_end_to_end() {
     let _ = std::fs::remove_dir_all(&output_dir);
 }
 
-/// Bridge-premise family, hard floor: TIP isaplanner prop_85 (zip-rev
-/// under the relational premise `natEq(len(xs), len(ys))`) closes
-/// GENUINELY through the quarantine lane — `when_universal == 1` keyed
-/// on per-declaration `#print axioms` evidence within the kernel
-/// whitelist — while the COUNTED summary stays byte-identical to
-/// main's (passed, 0 sorries, file-level universal:false). A sabotage
-/// run pins the iron guard on this family too.
+/// Bridge-premise family: TIP isaplanner prop_85 (zip-rev under the
+/// relational premise `natEq(len(xs), len(ys))`) now closes GENUINELY on
+/// the MAIN path — the figure was absorbed from the quarantine lane, so
+/// the counted build proves `zip_law_zipRev` universally (file-level
+/// `universal:true`). The lane STILL emits its off-headline twin
+/// transitionally (`when_universal == 1`, kept until the lane is retired),
+/// keyed on per-declaration `#print axioms` evidence within the kernel
+/// whitelist. A sabotage run breaks only the redundant lane twin: the
+/// counted summary stays byte-identical because the main proof is
+/// independent of the lane.
 #[test]
 fn proof_when_universal_lane_closes_tip_prop_85() {
     if Command::new("lake").arg("--version").output().is_err() {
@@ -409,14 +412,15 @@ fn proof_when_universal_lane_closes_tip_prop_85() {
     assert_eq!(normal["passed"].as_bool(), Some(true));
     assert_eq!(
         normal["universal"].as_bool(),
-        Some(false),
-        "file-level `universal` keeps counted-build semantics; the lane \
-         credit is per-law via when_universal"
+        Some(true),
+        "zip-rev was absorbed onto the main path: the counted build now \
+         proves zip_law_zipRev universally, so file-level `universal` is true"
     );
     assert_eq!(
         normal["when_universal"].as_u64(),
         Some(1),
-        "prop_85's zip.zipRev must close universally in the lane.\n{}",
+        "the lane still emits prop_85's off-headline twin transitionally \
+         (kept until the lane is retired).\n{}",
         format_output(&run)
     );
     // Per-law detail artifact: kernel-genuine evidence, quoted.

--- a/tests/proof_spec/when_lane.rs
+++ b/tests/proof_spec/when_lane.rs
@@ -381,15 +381,15 @@ fn proof_when_universal_lane_json_end_to_end() {
 }
 
 /// Bridge-premise family: TIP isaplanner prop_85 (zip-rev under the
-/// relational premise `natEq(len(xs), len(ys))`) now closes GENUINELY on
-/// the MAIN path — the figure was absorbed from the quarantine lane, so
-/// the counted build proves `zip_law_zipRev` universally (file-level
-/// `universal:true`). The lane STILL emits its off-headline twin
-/// transitionally (`when_universal == 1`, kept until the lane is retired),
-/// keyed on per-declaration `#print axioms` evidence within the kernel
-/// whitelist. A sabotage run breaks only the redundant lane twin: the
-/// counted summary stays byte-identical because the main proof is
-/// independent of the lane.
+/// relational premise `natEq(len(xs), len(ys))`). The BARE task carries no
+/// helper laws, so the counted build leaves `zip_law_zipRev` bounded
+/// (file-level `universal:false`) — the genuine universal proof lives in
+/// the decomposed corpus (helper laws + the generic conditional-inductive
+/// driver), a separate metric. The lane still emits its off-headline twin
+/// here (`when_universal == 1`, kept until the lane is retired), keyed on
+/// per-declaration `#print axioms` evidence within the kernel whitelist. A
+/// sabotage run breaks only that twin: the counted summary stays
+/// byte-identical because it never depended on the lane.
 #[test]
 fn proof_when_universal_lane_closes_tip_prop_85() {
     if Command::new("lake").arg("--version").output().is_err() {
@@ -412,15 +412,16 @@ fn proof_when_universal_lane_closes_tip_prop_85() {
     assert_eq!(normal["passed"].as_bool(), Some(true));
     assert_eq!(
         normal["universal"].as_bool(),
-        Some(true),
-        "zip-rev was absorbed onto the main path: the counted build now \
-         proves zip_law_zipRev universally, so file-level `universal` is true"
+        Some(false),
+        "the BARE task carries no helper laws, so the counted build leaves \
+         zip_law_zipRev bounded; the universal proof lives in the decomposed \
+         corpus (helper laws + the generic driver), a separate metric"
     );
     assert_eq!(
         normal["when_universal"].as_u64(),
         Some(1),
-        "the lane still emits prop_85's off-headline twin transitionally \
-         (kept until the lane is retired).\n{}",
+        "the lane still emits prop_85's off-headline twin (kept until the \
+         lane is retired).\n{}",
         format_output(&run)
     );
     // Per-law detail artifact: kernel-genuine evidence, quoted.


### PR DESCRIPTION
Conditional inductive laws now close on the **counted** build through Aver helper laws and a generic driver, replacing per-figure hand-written Lean.

### What lands

- **count under a disequality** (`count(n, xs ++ [m]) = count(n, xs)` when `n /= m`, TIP isaplanner prop_76 / lemma_21) — the membership recognizer admits a `Nat`-returning per-element fold.

- **The laws-as-lemmas pool admits `when`-premise laws.** A proven conditional law is cited as the conditional rewrite `<premise> = true -> lhs = rhs`. The pool declined every `when`-law before (none were universal); now a conditional law that closes universally is a sound conditional simp lemma for later laws in its cone.

- **A generic conditional-inductive driver.** It proves a conditional law by induction on the recursive list given, threads the premise into each arm, and closes with `simp_all` over the fn defs AND the eligible earlier helper laws. It fires only for the binary-recursion shape (one inducted list, one length-linked partner) with a non-empty helper pool — so a bare task, or a single-list roundtrip, keeps its sound bounded proof instead of committing to a universal it could not close.

- **The zip-reverse figure's bespoke emit is removed.** `prop_85` now closes through its decomposition (`proof-corpus/decomposed/isaplanner/prop_85.av`): the helper laws `len (append a [x]) = S (len a)`, `len (rev xs) = len xs`, and the zip snoc-distribution under equal lengths supply the algebraic steps; the generic driver assembles them. Kernel clean, axioms `[propext, Quot.sound]`.

### Why

A figure's algebraic content is expressible as an Aver law, so it belongs in the laws-as-lemmas pool (discovered/written once, reused), not hand-written into the Lean emitter. The conditional-proving work was the missing prerequisite: only once a `when`-law proves universally can it serve as a pool lemma.

Verification: `proof_spec` 184/0; `cargo clippy --features wasm,wasip2` clean; per-law `#print axioms` within the kernel whitelist; bare `tip/prop_85` stays bounded (no baseline regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oM6Phxqd5XXwxrqSNHvG2