### PR TITLE
proof: add the holds claim form, reserve the Bool family, harden the Dafny premise slicer

### DIFF
--- a/editors/keywords.json
+++ b/editors/keywords.json
@@ -2,7 +2,7 @@
   "_note": "Source of truth for Aver editor grammars. Edit here, then run `python3 editors/sync.py --write` to regenerate sublime/vscode/highlight.js. CI/release blocks if these are out of sync (see `editors/sync.py --check`).",
 
   "declaration": ["type", "record", "module", "depends", "exposes", "opaque"],
-  "control": ["fn", "match", "verify", "decision", "law", "given", "when", "effects", "trace"],
+  "control": ["fn", "match", "verify", "decision", "law", "given", "when", "holds", "effects", "trace"],
   "header_field": ["intent", "reason", "date", "chosen", "rejected", "impacts", "author"],
 
   "constants": ["true", "false", "Unit"],

--- a/editors/sublime/Aver.sublime-syntax
+++ b/editors/sublime/Aver.sublime-syntax
@@ -91,7 +91,7 @@ contexts:
   keywords:
     - match: '\b(depends|exposes|module|opaque|record|type)\b'
       scope: keyword.declaration.aver
-    - match: '\b(decision|effects|verify|given|match|trace|when|law|fn)\b'
+    - match: '\b(decision|effects|verify|given|match|trace|when|law|holds|fn)\b'
       scope: keyword.control.aver
     - match: '^(\s*)(intent|reason|date|chosen|rejected|impacts|author|needs)(:)'
       captures:

--- a/editors/vscode/syntaxes/aver.tmLanguage.json
+++ b/editors/vscode/syntaxes/aver.tmLanguage.json
@@ -70,7 +70,7 @@
       }
     },
     "keywords": {
-      "match": "\\b(decision|rejected|depends|effects|exposes|impacts|author|chosen|intent|module|opaque|reason|record|verify|given|match|trace|date|type|when|law|fn)\\b",
+      "match": "\\b(decision|rejected|depends|effects|exposes|impacts|author|chosen|intent|module|opaque|reason|record|verify|given|match|trace|date|type|when|law|holds|fn)\\b",
       "name": "keyword.other.aver"
     },
     "effect-annotation": {

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -818,6 +818,9 @@ fn when_is_peano_comparison(when: &Spanned<Expr>, ctx: &CodegenContext) -> bool 
 /// (a substring flanked by identifier chars `[A-Za-z0-9_]` is left untouched).
 /// Used to slice a `when` premise's induction-target reference to its tail
 /// (`y` -> `y[1..]`) when guarding a conditional list lemma's recursive call.
+/// String-literal aware: an occurrence INSIDE a `"…"` literal (where the same
+/// spelling is just text, e.g. a premise comparing against `"y"`) is left
+/// untouched — slicing it would corrupt the literal.
 fn replace_ident_word(s: &str, word: &str, repl: &str) -> String {
     if word.is_empty() {
         return s.to_string();
@@ -827,7 +830,29 @@ fn replace_ident_word(s: &str, word: &str, repl: &str) -> String {
     let wlen = word.chars().count();
     let mut out = String::new();
     let mut i = 0;
+    let mut in_string = false;
     while i < chars.len() {
+        // Copy string literals verbatim, honoring `\"` / `\\` escapes, so a
+        // matching identifier spelled inside a literal is never sliced.
+        if in_string {
+            out.push(chars[i]);
+            if chars[i] == '\\' && i + 1 < chars.len() {
+                out.push(chars[i + 1]);
+                i += 2;
+                continue;
+            }
+            if chars[i] == '"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if chars[i] == '"' {
+            in_string = true;
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
         let matches_here = i + wlen <= chars.len()
             && chars[i..i + wlen].iter().collect::<String>() == word
             && (i == 0 || !is_ident(chars[i - 1]))
@@ -3071,5 +3096,36 @@ pub fn emit_verify_law(
         lines.join("\n")
     } else {
         format!("{}\n{}", op_lemma_defs.join("\n"), lines.join("\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::replace_ident_word;
+
+    #[test]
+    fn replace_ident_word_slices_whole_words_but_not_substrings() {
+        // Whole-word identity is sliced; a substring (`yy`) and a dotted member
+        // (`y.len`) keep their `y` untouched on the wrong boundary.
+        assert_eq!(
+            replace_ident_word("elem(x, y)", "y", "y[1..]"),
+            "elem(x, y[1..])"
+        );
+        assert_eq!(replace_ident_word("yy && y", "y", "y[1..]"), "yy && y[1..]");
+    }
+
+    #[test]
+    fn replace_ident_word_leaves_string_literals_untouched() {
+        // The target spelled INSIDE a `"…"` literal must NOT be sliced — that
+        // would corrupt the literal. The bare occurrence still is.
+        assert_eq!(
+            replace_ident_word("tag(y) == \"y\"", "y", "y[1..]"),
+            "tag(y[1..]) == \"y\""
+        );
+        // Escaped quote inside the literal does not end the string early.
+        assert_eq!(
+            replace_ident_word("f(y) || s == \"a\\\"y\\\"b\"", "y", "y[1..]"),
+            "f(y[1..]) || s == \"a\\\"y\\\"b\""
+        );
     }
 }

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -690,12 +690,15 @@ const LEAN_RESERVED: &[&str] = &[
     // "invalid simp theorem"), and the proof can't reference the user fn.
     // Escaping to `max'`/`and'`/`insert'`/… sidesteps it. (Other stdlib names
     // like `length`/`take`/`drop` are reached as METHODS `xs.length` and don't
-    // collide as bare identifiers.)
+    // collide as bare identifiers.) The full Bool family `and`/`or`/`not`/`xor`
+    // all resolve against `_root_.<op> : Bool -> Bool -> Bool`.
     "and",
     "insert",
     "max",
     "min",
+    "not",
     "or",
+    "xor",
     "mutual",
     "namespace",
     "noncomputable",
@@ -744,6 +747,12 @@ mod tests {
         // `fn max`/`min` doesn't collide with the typeclass-dispatched form.
         assert_eq!(aver_name_to_lean("max"), "max'");
         assert_eq!(aver_name_to_lean("min"), "min'");
+        // The full Bool family collides with `_root_.and`/`or`/`not`/`xor`
+        // (each `Bool -> Bool -> Bool`); a bare reference is "ambiguous term".
+        assert_eq!(aver_name_to_lean("and"), "and'");
+        assert_eq!(aver_name_to_lean("or"), "or'");
+        assert_eq!(aver_name_to_lean("not"), "not'");
+        assert_eq!(aver_name_to_lean("xor"), "xor'");
     }
 
     #[test]

--- a/src/parser/blocks.rs
+++ b/src/parser/blocks.rs
@@ -391,9 +391,18 @@ impl Parser {
                 let law_start_line = self.current().line;
                 let law_start_col = self.current().col;
                 let mut left = self.parse_expr()?;
-                self.expect_exact(&TokenKind::FatArrow)?;
-                self.skip_formatting();
-                let mut right = self.parse_expr()?;
+                // Claim form: `lhs => rhs` (Yields — an operational equation) OR
+                // `P holds` (Holds — the Bool predicate `P` is true, sugar for
+                // `P => true`). Both lower to the same `lhs`/`rhs` pair, so the
+                // downstream case-expansion and codegen are unchanged.
+                let mut right = if self.current_ident_is("holds") {
+                    self.advance(); // holds
+                    Spanned::bare(Expr::Literal(Literal::Bool(true)))
+                } else {
+                    self.expect_exact(&TokenKind::FatArrow)?;
+                    self.skip_formatting();
+                    self.parse_expr()?
+                };
 
                 // Substitute locals into the single assertion.
                 for (name, value) in &law_locals {

--- a/tests/parser_spec.rs
+++ b/tests/parser_spec.rs
@@ -978,6 +978,36 @@ verify max law ordered
 }
 
 #[test]
+fn verify_law_parses_holds_claim_as_predicate_true() {
+    // `P holds` is sugar for `P => true`: the rhs lowers to the Bool literal
+    // `true` and the lhs is the predicate, so downstream case-expansion and
+    // codegen see the same `lhs`/`rhs` pair as the explicit `=> true` form.
+    let src = r#"
+verify max law sane
+    given a: Int = [1, 2]
+    given b: Int = [1, 2]
+    max(a, b) >= b holds
+"#;
+    let items = parse(src);
+    let TopLevel::Verify(vb) = &items[0] else {
+        panic!("expected Verify");
+    };
+    let VerifyKind::Law(law) = &vb.kind else {
+        panic!("expected law verify");
+    };
+    assert!(
+        matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true))),
+        "`holds` rhs must be the implicit `true`: {:?}",
+        law.rhs.node
+    );
+    assert!(
+        matches!(&law.lhs.node, Expr::BinOp(BinOp::Gte, _, _)),
+        "`holds` lhs is the predicate: {:?}",
+        law.lhs.node
+    );
+}
+
+#[test]
 fn verify_law_requires_given_lines() {
     let src = r#"
 verify add law commutative


### PR DESCRIPTION
Three small proof-surface and codegen fixes (the carried-forward polish items).

- **`P holds`** is now a valid law claim — sugar for `P => true` (the Bool predicate `P` is true). It lowers to the same `lhs`/`rhs` pair, so case-expansion and codegen are unchanged, and `=> true` still parses. `holds` is added to the editor / TextMate / Sublime highlight lists.

- **`not` and `xor`** join the Lean reserved-word set. A user `fn not` / `fn xor` emitted a bare `def not` / `def xor` that resolves ambiguously against `_root_.not` / `_root_.xor` (`ambiguous term`), exactly like `and` / `or` before; they are now escaped to `not'` / `xor'`. (Confirmed: a `not`/`xor` law went `passed:false` → `universal:true` after the fix.)

- The Dafny `when`-premise slicer (`replace_ident_word`, which rewrites a list given `y` → `y[1..]` for a guarded recursive call) is now **string-literal aware**: a matching identifier spelled inside a `"…"` literal is left untouched rather than corrupting the literal.

Verification: `cargo clippy --features wasm,wasip2` clean; `parser_spec` 106/0; new parser, reserved-word, and slicer unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oM6Phxqd5XXwxrqSNHvG2