### PR TITLE
examples: write Bool-predicate laws with the holds claim form

### DIFF
--- a/examples/data/quicksort.av
+++ b/examples/data/quicksort.av
@@ -20,7 +20,7 @@ verify sort
 
 verify sort law resultOrdered
     given xs: List<Int> = [[], [1], [2, 1], [3, 1, 2], [5, 1, 5, 2, 3], [9, 4, 7, 1, 3, 8, 2]]
-    isOrdered(sort(xs)) => true
+    isOrdered(sort(xs)) holds
 
 verify sort law lengthPreserved
     given xs: List<Int> = [[], [1], [2, 1], [3, 1, 2], [5, 1, 5, 2, 3], [9, 4, 7, 1, 3, 8, 2]]

--- a/examples/data/rational.av
+++ b/examples/data/rational.av
@@ -31,17 +31,17 @@ verify plus
 verify plus law commutative
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 0, bottom = 1), Fraction(top = 5, bottom = -3)]
     given b: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 0, bottom = 1), Fraction(top = 5, bottom = -3)]
-    sameValue(plus(a, b), plus(b, a)) => true
+    sameValue(plus(a, b), plus(b, a)) holds
 
 verify plus law associative
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 5, bottom = -3)]
     given b: Fraction = [Fraction(top = 0, bottom = 1), Fraction(top = 2, bottom = 5), Fraction(top = -1, bottom = 2)]
     given c: Fraction = [Fraction(top = 1, bottom = 1), Fraction(top = -2, bottom = -7), Fraction(top = 3, bottom = 8)]
-    sameValue(plus(plus(a, b), c), plus(a, plus(b, c))) => true
+    sameValue(plus(plus(a, b), c), plus(a, plus(b, c))) holds
 
 verify plus law zeroIsNeutral
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 0, bottom = 1), Fraction(top = 5, bottom = -3)]
-    sameValue(plus(a, zeroFraction()), a) => true
+    sameValue(plus(a, zeroFraction()), a) holds
 
 fn times(a: Fraction, b: Fraction) -> Fraction
     ? "Fraction multiplication without normalization: (ac)/(bd)."
@@ -54,27 +54,27 @@ verify times
 verify times law commutative
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 0, bottom = 1), Fraction(top = 5, bottom = -3)]
     given b: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 0, bottom = 1), Fraction(top = 5, bottom = -3)]
-    sameValue(times(a, b), times(b, a)) => true
+    sameValue(times(a, b), times(b, a)) holds
 
 verify times law associative
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 5, bottom = -3)]
     given b: Fraction = [Fraction(top = 0, bottom = 1), Fraction(top = 2, bottom = 5), Fraction(top = -1, bottom = 2)]
     given c: Fraction = [Fraction(top = 1, bottom = 1), Fraction(top = -2, bottom = -7), Fraction(top = 3, bottom = 8)]
-    sameValue(times(times(a, b), c), times(a, times(b, c))) => true
+    sameValue(times(times(a, b), c), times(a, times(b, c))) holds
 
 verify times law distributesOverPlus
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 5, bottom = -3)]
     given b: Fraction = [Fraction(top = 0, bottom = 1), Fraction(top = 2, bottom = 5), Fraction(top = -1, bottom = 2)]
     given c: Fraction = [Fraction(top = 1, bottom = 1), Fraction(top = -2, bottom = -7), Fraction(top = 3, bottom = 8)]
-    sameValue(times(a, plus(b, c)), plus(times(a, b), times(a, c))) => true
+    sameValue(times(a, plus(b, c)), plus(times(a, b), times(a, c))) holds
 
 verify times law oneIsNeutral
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 0, bottom = 1), Fraction(top = 5, bottom = -3)]
-    sameValue(times(a, oneFraction()), a) => true
+    sameValue(times(a, oneFraction()), a) holds
 
 verify times law zeroAbsorbs
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 0, bottom = 1), Fraction(top = 5, bottom = -3)]
-    sameValue(times(a, zeroFraction()), zeroFraction()) => true
+    sameValue(times(a, zeroFraction()), zeroFraction()) holds
 
 fn negate(a: Fraction) -> Fraction
     ? "Fraction negation: flips the numerator sign, keeps the denominator."
@@ -82,7 +82,7 @@ fn negate(a: Fraction) -> Fraction
 
 verify negate law involutive
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 0, bottom = 1), Fraction(top = 5, bottom = -3)]
-    sameValue(negate(negate(a)), a) => true
+    sameValue(negate(negate(a)), a) holds
 
 fn minus(a: Fraction, b: Fraction) -> Fraction
     ? "Fraction subtraction without normalization: a/b - c/d = (ad - cb)/(bd)."
@@ -91,7 +91,7 @@ fn minus(a: Fraction, b: Fraction) -> Fraction
 verify minus law equalsPlusNegate
     given a: Fraction = [Fraction(top = 1, bottom = 2), Fraction(top = -3, bottom = 4), Fraction(top = 5, bottom = -3)]
     given b: Fraction = [Fraction(top = 0, bottom = 1), Fraction(top = 2, bottom = 5), Fraction(top = -1, bottom = 2)]
-    sameValue(minus(a, b), plus(a, negate(b))) => true
+    sameValue(minus(a, b), plus(a, negate(b))) holds
 
 fn sameValue(a: Fraction, b: Fraction) -> Bool
     ? "Cross-multiplication equality: a/b equals c/d exactly when ad == cb."

--- a/examples/formal/int_abs_laws.av
+++ b/examples/formal/int_abs_laws.av
@@ -28,7 +28,7 @@ verify magnitude law idempotent
 
 verify magnitude law nonNegative
     given x: Int = [0, 3, -5, 7]
-    Int.abs(x) >= 0 => true
+    Int.abs(x) >= 0 holds
 
 verify scaledMagnitude law multiplicative
     given x: Int = [0, 3, -5]

--- a/examples/formal/int_comparison_laws.av
+++ b/examples/formal/int_comparison_laws.av
@@ -43,4 +43,4 @@ verify notBelow law isAtLeast
 verify comparable law totalOrder
     given a: Int = [0, 1, -2, 5]
     given b: Int = [0, 1, -2, 5]
-    comparable(a, b) => true
+    comparable(a, b) holds

--- a/examples/formal/law_auto.av
+++ b/examples/formal/law_auto.av
@@ -86,7 +86,7 @@ fn incCount(counts: Map<String, Int>, word: String) -> Map<String, Int>
 verify incCount law keyPresent
     given counts: Map<String, Int> = [{}, {"a" => 1}, {"x" => 2, "y" => 4}]
     given word: String = ["a", "z", "new"]
-    Map.has(incCount(counts, word), word) => true
+    Map.has(incCount(counts, word), word) holds
 
 verify incCount law existingKeyIncrements
     given counts: Map<String, Int> = [{"a" => 1}, {"a" => 5, "x" => 2}]

--- a/examples/formal/map_set_nonempty.av
+++ b/examples/formal/map_set_nonempty.av
@@ -20,4 +20,4 @@ verify sizeAfterInsert law nonEmptyAfterInsert
     given reg: Map<String, Int> = [{}, {"a" => 1}, {"a" => 1, "b" => 2}]
     given k: String = ["x", "a"]
     given v: Int = [7]
-    Map.len(Map.set(reg, k, v)) >= 1 => true
+    Map.len(Map.set(reg, k, v)) >= 1 holds

--- a/examples/formal/randomness_paradox.av
+++ b/examples/formal/randomness_paradox.av
@@ -18,7 +18,7 @@ fn twoFloatsDistinct() -> Bool
 
 verify twoFloatsDistinct law alwaysDistinct
     given rnd: Random.float = [distinctStub]
-    twoFloatsDistinct() => true
+    twoFloatsDistinct() holds
 
 fn main() -> Unit
     ! [Console.print]


### PR DESCRIPTION
Follow-on to #604 (which added the `holds` claim). A law asserting a Bool predicate is universally true reads better as `P holds` than `P => true`.

Converts the **law claims** in the formal and data showcase examples:
- `comparable(a, b) holds` (total order)
- `Int.abs(x) >= 0 holds`
- `Map.len(Map.set(reg, k, v)) >= 1 holds`
- the rational ring laws — `sameValue(plus(a,b), plus(b,a)) holds`, … (commutativity / associativity / neutrality / distributivity / involution)
- `isOrdered(sort(xs)) holds`
- `Map.has(incCount(counts, word), word) holds`
- `twoFloatsDistinct() holds`

**Left as-is:** concrete sample CASES (`f(input) => true`, where `holds` is not the claim form — it parses only as a law claim) and the upstream TIP corpus (byte-for-byte from the benchmark).

Each converted law still type-checks and proves (`holds` lowers to the same `lhs => true` pair): `check examples/data` 20/20, `rational` closes on Dafny, `int_abs_laws` stays `universal_laws: 3` on Lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oM6Phxqd5XXwxrqSNHvG2