### PR TITLE
proof: tight Lean decomposition proofs via the shared instantiation engine

### DIFF
--- a/src/codegen/cite_instantiate.rs
+++ b/src/codegen/cite_instantiate.rs
@@ -1,19 +1,25 @@
-//! Engine B — generic cited-lemma INSTANTIATION in the Dafny inductive step.
+//! Engine B — generic cited-lemma INSTANTIATION in the list-induction step,
+//! shared by both proof backends.
 //!
-//! The keystone (`earlier_law_citations`) hoists each eligible earlier law as a
-//! `forall`-fact at the body top. That suffices when Z3 can instantiate the
-//! universal itself — true for the builtin `List.concat` (Dafny `seq` `+`, whose
-//! associativity Z3 knows natively), but NOT for a USER-defined `append`: Z3
-//! never materialises the nested term `append(append(rev y, rev t), [h])`, so it
-//! cannot fire the cited associativity there. Lean closes the same goal because
-//! `simp_all` applies the pool laws as directed rewrites.
+//! The keystone (each backend's `forall`-citation / simp-pool hoist) makes every
+//! eligible earlier law available as a universal fact. That suffices when the
+//! backend can instantiate the universal itself — Z3 for the builtin
+//! `List.concat` (Dafny `seq` `+`, whose associativity it knows natively), or
+//! Lean's `simp_all` applying the pool laws as directed rewrites. It does NOT
+//! suffice for a USER-defined `append` on Dafny: Z3 never materialises the nested
+//! term `append(append(rev y, rev t), [h])`, so it cannot fire the cited
+//! associativity there.
 //!
-//! This module recovers that power on Dafny by emitting EXPLICIT instantiation
-//! calls of the cited lemmas at exactly the arguments the inductive step needs —
-//! the same thing the retired `rev` synthesizer hand-coded, but derived
-//! generically: substitute the induction variable by its `cons(head, tail)`,
-//! unfold the recursive cone fns one step, apply the induction hypothesis, then
-//! first-order-match each cited lemma's LHS against the resulting subterms.
+//! This module recovers that power generically by computing EXPLICIT
+//! instantiations of the cited lemmas at exactly the arguments the inductive step
+//! needs — the same thing the retired `rev` synthesizer hand-coded, but derived
+//! from the law itself: substitute the induction variable by its
+//! `cons(head, tail)`, unfold the recursive cone fns one step, apply the
+//! induction hypothesis, then first-order-match each cited lemma's LHS against
+//! the resulting subterms. Each backend renders the returned argument terms — the
+//! Dafny consumer as explicit lemma CALLS (`rev_revDist(rev(x[1..]), [x[0]])`),
+//! the Lean consumer as `have`-facts driving a tight `simp` (`have key :=
+//! rev_law_revDist (rev tail) [head]; simp […]`).
 //!
 //! Fail-closed: every cited lemma is universal-form, so any type-correct
 //! instantiation is a valid lemma call Dafny re-proves — a redundant one is

--- a/src/codegen/cite_instantiate.rs
+++ b/src/codegen/cite_instantiate.rs
@@ -37,6 +37,26 @@ use std::collections::{BTreeMap, BTreeSet};
 pub(crate) const HEAD: &str = "__cite_h";
 pub(crate) const TAIL: &str = "__cite_t";
 const UNFOLD_FUEL: usize = 8;
+/// Rounds of rewrite-closure when building the candidate term pool. Each round
+/// applies every rule to the previous round's new terms and re-unfolds, so a term
+/// needing N nested rewrites (a doubly-distributed `rev (rev t)`) surfaces by
+/// round N. Bounded to keep the dedup'd closure from growing without limit.
+const POOL_CLOSURE_FUEL: usize = 4;
+
+/// Whether using `law` LEFT-TO-RIGHT as a rewrite rule would loop: its LHS
+/// pattern (givens as wildcards) matches its own RHS, so applying `lhs -> rhs`
+/// yields a term the same rule still fires on (a commutation `plus x y = plus y
+/// x` is the canonical case). Such a law is fine for Dafny (Z3 instantiates the
+/// universal, it does not rewrite) but a non-terminating simp rule on Lean — the
+/// Lean cite selector drops it, leaning on `omega` for the commutativity instead.
+pub(crate) fn law_rewrites_to_self(law: &VerifyLaw) -> bool {
+    let wildcards: BTreeSet<String> = law.givens.iter().map(|g| g.name.clone()).collect();
+    if wildcards.is_empty() {
+        return false;
+    }
+    let mut binds: BTreeMap<String, Spanned<Expr>> = BTreeMap::new();
+    !expr_eq(&law.lhs, &law.rhs) && match_expr(&law.lhs, &law.rhs, &wildcards, &mut binds)
+}
 
 /// One computed instantiation of a cited law: which cited law (index into the
 /// `cited` slice) and the argument expressions to apply it at, in the cited
@@ -106,15 +126,34 @@ pub(crate) fn compute_instantiations(
         rules.push(rewrite_rule(c));
     }
 
-    // Build the candidate term pool: the unfolded sides, plus every rewrite-closure.
+    // Build the candidate term pool: the unfolded sides, then the rewrite-closure
+    // taken to a (fuel-bounded) FIXPOINT, re-unfolding after each round. One
+    // rewrite often exposes a term a SECOND rewrite must fire on — `rev (rev t)`
+    // (which a cited involution then matches) only appears after the distribution
+    // law has fired twice, and a deeper `qrev t [h]` only after the accumulator
+    // unfolds another step. Applying each rule once (the old behaviour) missed
+    // those, so the engine produced no instantiation and the law fell to the
+    // ladder. Dedup by structural equality keeps the closure from exploding.
     let mut pool: Vec<Spanned<Expr>> = vec![lhs0.clone(), rhs0.clone()];
-    for base in [&lhs0, &rhs0] {
-        for r in &rules {
-            let rewritten = apply_rule_all(base, r);
-            if !expr_eq(&rewritten, base) {
-                pool.push(rewritten);
+    let mut frontier: Vec<Spanned<Expr>> = pool.clone();
+    for _ in 0..POOL_CLOSURE_FUEL {
+        let mut next: Vec<Spanned<Expr>> = Vec::new();
+        for base in &frontier {
+            for r in &rules {
+                let rewritten = unfold_fix(&apply_rule_all(base, r), &cone);
+                if !expr_eq(&rewritten, base)
+                    && !pool.iter().any(|p| expr_eq(p, &rewritten))
+                    && !next.iter().any(|p| expr_eq(p, &rewritten))
+                {
+                    next.push(rewritten);
+                }
             }
         }
+        if next.is_empty() {
+            break;
+        }
+        pool.extend(next.iter().cloned());
+        frontier = next;
     }
 
     // Collect every subterm of every pooled term.
@@ -204,6 +243,12 @@ fn collect_calls(e: &Spanned<Expr>, out: &mut BTreeSet<String>) {
     {
         out.insert(n);
     }
+    // A tail-recursive fn body lowers its self/peer call to `TailCall` — the cone
+    // collector must see that target too, or the accumulator fn never joins the
+    // cone and never unfolds.
+    if let Expr::TailCall(data) = &e.node {
+        out.insert(data.target.clone());
+    }
     for c in children(e) {
         collect_calls(c, out);
     }
@@ -217,6 +262,7 @@ fn children(e: &Spanned<Expr>) -> Vec<&Spanned<Expr>> {
             v.extend(args.iter());
             v
         }
+        Expr::TailCall(data) => data.args.iter().collect(),
         Expr::List(items) | Expr::Tuple(items) => items.iter().collect(),
         Expr::Constructor(_, Some(inner)) => vec![inner.as_ref()],
         Expr::Attr(inner, _) => vec![inner.as_ref()],
@@ -226,7 +272,11 @@ fn children(e: &Spanned<Expr>) -> Vec<&Spanned<Expr>> {
     }
 }
 
-/// Rebuild `e` with each direct child replaced by `f(child)`.
+/// Rebuild `e` with each direct child replaced by `f(child)`. A `TailCall` is
+/// rebuilt as the equivalent `FnCall` (a tail call IS a call) — that both lets
+/// `f` substitute into its arguments (`map_children` is otherwise opaque to the
+/// `TailCall` payload, leaving the lowered `xs`/`acc` slots un-substituted) and
+/// normalises it so the unfolder and matcher see a uniform `FnCall` shape.
 fn map_children(
     e: &Spanned<Expr>,
     f: &mut impl FnMut(&Spanned<Expr>) -> Spanned<Expr>,
@@ -235,6 +285,10 @@ fn map_children(
         Expr::FnCall(callee, args) => {
             Expr::FnCall(Box::new(f(callee)), args.iter().map(&mut *f).collect())
         }
+        Expr::TailCall(data) => Expr::FnCall(
+            Box::new(ident(&data.target)),
+            data.args.iter().map(&mut *f).collect(),
+        ),
         Expr::List(items) => Expr::List(items.iter().map(&mut *f).collect()),
         Expr::Tuple(items) => Expr::Tuple(items.iter().map(&mut *f).collect()),
         Expr::Constructor(name, Some(inner)) => {
@@ -282,17 +336,45 @@ fn subst_many(e: &Spanned<Expr>, map: &BTreeMap<String, Spanned<Expr>>) -> Spann
 // ---- unfolding ------------------------------------------------------------
 
 /// Unfold recursive cone-fn applications whose first arg is a concrete `cons`,
-/// to a fixpoint (bounded by fuel).
+/// to a fixpoint (bounded by fuel), simplifying builtin nil-concatenations after
+/// each round.
 fn unfold_fix(e: &Spanned<Expr>, cone: &BTreeMap<String, &FnDef>) -> Spanned<Expr> {
-    let mut cur = e.clone();
+    let mut cur = simplify_concat_nil(e);
     for _ in 0..UNFOLD_FUEL {
         let (next, changed) = unfold_once(&cur, cone);
-        cur = next;
+        cur = simplify_concat_nil(&next);
         if !changed {
             break;
         }
     }
     cur
+}
+
+/// Simplify builtin nil-concatenations to a fixpoint: `List.concat(a, [])` → `a`
+/// and `List.concat([], a)` → `a`. Unfolding an accumulator recursion threads
+/// `List.concat([head], acc)` into the accumulator, so a step that started from
+/// `[]` leaves junk like `List.concat([head], [])`; without this the engine
+/// matches a cited law at the UN-normalised `List.concat([head], [])` instead of
+/// `[head]`, producing a useless (and simp-looping) instantiation. Builtin concat
+/// has `[]` as a two-sided identity, so this is sound; it touches only the
+/// builtin, never a user `append` (whose nil law is a cited theorem, not a
+/// rewrite the engine may assume).
+fn simplify_concat_nil(e: &Spanned<Expr>) -> Spanned<Expr> {
+    let mut f = |c: &Spanned<Expr>| simplify_concat_nil(c);
+    let mapped = map_children(e, &mut f);
+    if let Expr::FnCall(callee, args) = &mapped.node
+        && expr_to_dotted_name(&callee.node).as_deref() == Some("List.concat")
+        && args.len() == 2
+    {
+        let is_nil = |x: &Spanned<Expr>| matches!(&x.node, Expr::List(items) if items.is_empty());
+        if is_nil(&args[0]) {
+            return args[1].clone();
+        }
+        if is_nil(&args[1]) {
+            return args[0].clone();
+        }
+    }
+    mapped
 }
 
 fn unfold_once(e: &Spanned<Expr>, cone: &BTreeMap<String, &FnDef>) -> (Spanned<Expr>, bool) {

--- a/src/codegen/cite_instantiate.rs
+++ b/src/codegen/cite_instantiate.rs
@@ -25,31 +25,39 @@ use crate::codegen::CodegenContext;
 use crate::codegen::common::expr_to_dotted_name;
 use std::collections::{BTreeMap, BTreeSet};
 
-use super::expr::aver_name_to_dafny;
-
-/// An earlier law eligible to be cited into the current proof.
-pub(super) struct CiteTarget<'a> {
-    /// The Dafny lemma name (`fn_law`).
-    pub dafny_name: String,
-    /// The law itself — its `lhs`/`givens` drive the LHS match.
-    pub law: &'a VerifyLaw,
-}
-
-const HEAD: &str = "__cite_h";
-const TAIL: &str = "__cite_t";
+/// Placeholders for the cons head/tail of the induction variable in the computed
+/// instantiation arguments. Backends map these to their own syntax (Dafny
+/// `xs[0]` / `xs[1..]`, Lean's `head` / `tail` binders).
+pub(crate) const HEAD: &str = "__cite_h";
+pub(crate) const TAIL: &str = "__cite_t";
 const UNFOLD_FUEL: usize = 8;
 
-/// Emit explicit Dafny instantiation calls (e.g. `append_appendAssoc(rev(y),
-/// rev(x[1..]), [x[0]]);`) for the list-induction step of `law` on `list_param`.
-pub(super) fn cited_lemma_instantiations(
+/// One computed instantiation of a cited law: which cited law (index into the
+/// `cited` slice) and the argument expressions to apply it at, in the cited
+/// law's given order. Arguments contain [`HEAD`] / [`TAIL`] placeholders that the
+/// backend renders.
+pub(crate) struct Instantiation {
+    pub law_index: usize,
+    pub args: Vec<Spanned<Expr>>,
+}
+
+/// Backend-neutral core of Engine B: for the list-induction step of `law` on
+/// `ind_param` (the AVER given name), derive the exact arguments at which each
+/// cited law must be applied so the step closes. Substitute the induction
+/// variable by `cons(head, tail)`, unfold the recursive cone fns one step, apply
+/// the induction hypothesis, then first-order-match each cited law's LHS against
+/// the resulting subterms. Backends (Dafny lemma calls, Lean `have`-facts) render
+/// the returned arguments.
+pub(crate) fn compute_instantiations(
     law: &VerifyLaw,
-    list_param: &str,
-    cites: &[CiteTarget<'_>],
+    ind_param: &str,
+    cited: &[&VerifyLaw],
     ctx: &CodegenContext,
-) -> Vec<String> {
-    if cites.is_empty() {
+) -> Vec<Instantiation> {
+    if cited.is_empty() {
         return Vec::new();
     }
+    let list_param = ind_param;
     let mod_scope = ctx.active_module_scope();
     // Recursive cone fns reachable from the law, keyed by call name, for unfolding.
     let mut cone: BTreeMap<String, &FnDef> = BTreeMap::new();
@@ -88,8 +96,8 @@ pub(super) fn cited_lemma_instantiations(
     rules.push(rule_at_tail(law, list_param));
     // Every cited law is also a rewrite (at all its givens) — applying it can
     // expose the reassociated subterms another cited lemma needs to match.
-    for c in cites {
-        rules.push(rewrite_rule(c.law));
+    for c in cited {
+        rules.push(rewrite_rule(c));
     }
 
     // Build the candidate term pool: the unfolded sides, plus every rewrite-closure.
@@ -109,20 +117,21 @@ pub(super) fn cited_lemma_instantiations(
         collect_subterms(t, &mut subterms);
     }
 
-    // Match each cited lemma's LHS against the subterms; emit one call per match.
+    // Match each cited lemma's LHS against the subterms; record one instantiation
+    // per distinct (law, args) match.
     let mut emitted: BTreeSet<String> = BTreeSet::new();
-    let mut out: Vec<String> = Vec::new();
-    for c in cites {
-        let wildcards: BTreeSet<String> = c.law.givens.iter().map(|g| g.name.clone()).collect();
+    let mut out: Vec<Instantiation> = Vec::new();
+    for (law_index, c) in cited.iter().enumerate() {
+        let wildcards: BTreeSet<String> = c.givens.iter().map(|g| g.name.clone()).collect();
         for sub in &subterms {
             let mut binds: BTreeMap<String, Spanned<Expr>> = BTreeMap::new();
-            if match_expr(&c.law.lhs, sub, &wildcards, &mut binds) {
+            if match_expr(&c.lhs, sub, &wildcards, &mut binds) {
                 // Build the arg list in the cited law's given order.
+                let mut args: Vec<Spanned<Expr>> = Vec::new();
                 let mut ok = true;
-                let mut args: Vec<String> = Vec::new();
-                for g in &c.law.givens {
+                for g in &c.givens {
                     match binds.get(&g.name) {
-                        Some(e) => args.push(render(e, list_param)),
+                        Some(e) => args.push(e.clone()),
                         None => {
                             ok = false;
                             break;
@@ -132,9 +141,13 @@ pub(super) fn cited_lemma_instantiations(
                 if !ok {
                     continue;
                 }
-                let call = format!("    {}({});", c.dafny_name, args.join(", "));
-                if emitted.insert(call.clone()) {
-                    out.push(call);
+                // Structural dedup key (placeholder names are stable).
+                let key = format!(
+                    "{law_index}:{:?}",
+                    args.iter().map(|a| &a.node).collect::<Vec<_>>()
+                );
+                if emitted.insert(key) {
+                    out.push(Instantiation { law_index, args });
                 }
             }
         }
@@ -151,7 +164,7 @@ fn ident(name: &str) -> Spanned<Expr> {
 /// A variable reference, whether source-form `Ident` or resolved (fn bodies are
 /// lowered before the proof backend sees them, so both forms appear in the mix
 /// of law sides + unfolded bodies).
-fn ident_name(e: &Spanned<Expr>) -> Option<&str> {
+pub(crate) fn ident_name(e: &Spanned<Expr>) -> Option<&str> {
     match &e.node {
         Expr::Ident(n) => Some(n),
         Expr::Resolved { name, .. } => Some(name),
@@ -457,45 +470,4 @@ fn expr_eq(a: &Spanned<Expr>, b: &Spanned<Expr>) -> bool {
     let mut binds = BTreeMap::new();
     // Structural equality = match with no wildcards.
     match_expr(a, b, &empty, &mut binds)
-}
-
-// ---- Dafny rendering of instantiation arguments ---------------------------
-
-/// Render a matched arg expr to Dafny, mapping the induction placeholders to the
-/// concrete head/tail (`x[0]` / `x[1..]`) and `List.concat` to seq `+`.
-fn render(e: &Spanned<Expr>, list_param: &str) -> String {
-    if let Some(n) = ident_name(e) {
-        return match n {
-            HEAD => format!("{list_param}[0]"),
-            TAIL => format!("{list_param}[1..]"),
-            _ => aver_name_to_dafny(n),
-        };
-    }
-    match &e.node {
-        Expr::Literal(lit) => super::expr::emit_literal(lit),
-        Expr::List(items) => {
-            let inner: Vec<String> = items.iter().map(|i| render(i, list_param)).collect();
-            format!("[{}]", inner.join(", "))
-        }
-        Expr::FnCall(callee, args) => {
-            let name = expr_to_dotted_name(&callee.node).unwrap_or_default();
-            let rendered: Vec<String> = args.iter().map(|a| render(a, list_param)).collect();
-            if name == "List.concat" && rendered.len() == 2 {
-                format!("({} + {})", rendered[0], rendered[1])
-            } else {
-                format!("{}({})", aver_name_to_dafny(&name), rendered.join(", "))
-            }
-        }
-        Expr::Constructor(name, None) => aver_name_to_dafny(name),
-        Expr::Constructor(name, Some(inner)) => {
-            format!(
-                "{}({})",
-                aver_name_to_dafny(name),
-                render(inner, list_param)
-            )
-        }
-        Expr::Attr(inner, field) => format!("{}.{}", render(inner, list_param), field),
-        // Anything else: best-effort, should not appear in matched list args.
-        _ => String::new(),
-    }
 }

--- a/src/codegen/cite_instantiate.rs
+++ b/src/codegen/cite_instantiate.rs
@@ -42,6 +42,12 @@ const UNFOLD_FUEL: usize = 8;
 /// needing N nested rewrites (a doubly-distributed `rev (rev t)`) surfaces by
 /// round N. Bounded to keep the dedup'd closure from growing without limit.
 const POOL_CLOSURE_FUEL: usize = 4;
+/// Hard ceiling on the candidate-term pool. A pathological rule set (many cited
+/// laws over deeply nested terms) could otherwise make the fixpoint enumerate an
+/// exponential number of distinct rewrites; past this many terms the closure
+/// stops early with a partial pool. Far above any real decomposition (the prod
+/// corpus tops out in the low tens), so it never truncates a genuine instantiation.
+const POOL_SIZE_CAP: usize = 256;
 
 /// Whether using `law` LEFT-TO-RIGHT as a rewrite rule would loop: its LHS
 /// pattern (givens as wildcards) matches its own RHS, so applying `lhs -> rhs`
@@ -121,9 +127,16 @@ pub(crate) fn compute_instantiations(
     let mut rules: Vec<RewriteRule> = Vec::new();
     rules.push(rule_at_tail(law, list_param));
     // Every cited law is also a rewrite (at all its givens) — applying it can
-    // expose the reassociated subterms another cited lemma needs to match.
+    // expose the reassociated subterms another cited lemma needs to match. EXCEPT a
+    // law that rewrites to itself (`plus x y = plus y x`): as a closure rule it is
+    // a permutation, and a FAMILY of them (all-pairs transposition over a
+    // composition's cone) makes the fixpoint below enumerate every permutation —
+    // factorial blow-up that hangs codegen. Such a law is still MATCHED (it stays
+    // in `cited`) for a one-shot instantiation; it just never drives the closure.
     for c in cited {
-        rules.push(rewrite_rule(c));
+        if !law_rewrites_to_self(c) {
+            rules.push(rewrite_rule(c));
+        }
     }
 
     // Build the candidate term pool: the unfolded sides, then the rewrite-closure
@@ -133,10 +146,12 @@ pub(crate) fn compute_instantiations(
     // law has fired twice, and a deeper `qrev t [h]` only after the accumulator
     // unfolds another step. Applying each rule once (the old behaviour) missed
     // those, so the engine produced no instantiation and the law fell to the
-    // ladder. Dedup by structural equality keeps the closure from exploding.
+    // ladder. Dedup by structural equality plus a hard size CAP keep the closure
+    // bounded even when the rule set is adversarial (the cap degrades to a partial
+    // pool — the engine need only be useful, not complete).
     let mut pool: Vec<Spanned<Expr>> = vec![lhs0.clone(), rhs0.clone()];
     let mut frontier: Vec<Spanned<Expr>> = pool.clone();
-    for _ in 0..POOL_CLOSURE_FUEL {
+    'closure: for _ in 0..POOL_CLOSURE_FUEL {
         let mut next: Vec<Spanned<Expr>> = Vec::new();
         for base in &frontier {
             for r in &rules {
@@ -146,6 +161,10 @@ pub(crate) fn compute_instantiations(
                     && !next.iter().any(|p| expr_eq(p, &rewritten))
                 {
                     next.push(rewritten);
+                    if pool.len() + next.len() >= POOL_SIZE_CAP {
+                        pool.extend(next);
+                        break 'closure;
+                    }
                 }
             }
         }

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -4,7 +4,6 @@
 /// one file per dependent module wrapped in `module M { ... }`, plus a
 /// shared `common.dfy` with built-in records/helpers, plus the entry
 /// file holding the trust header, top-level items, and verify lemmas.
-mod cite_instantiate;
 mod expr;
 mod fuel;
 mod lemmas;

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -2318,6 +2318,54 @@ fn emit_floor_window_support_stack(
     }
 }
 
+/// Render a computed instantiation argument (from `cite_instantiate`) to Dafny:
+/// the induction placeholders map to the concrete head/tail (`xs[0]` / `xs[1..]`),
+/// `List.concat` to seq `+`.
+fn render_dafny_arg(e: &Spanned<Expr>, list_param: &str) -> String {
+    use crate::codegen::cite_instantiate::{HEAD, TAIL, ident_name};
+    if let Some(n) = ident_name(e) {
+        return match n {
+            HEAD => format!("{list_param}[0]"),
+            TAIL => format!("{list_param}[1..]"),
+            _ => aver_name_to_dafny(n),
+        };
+    }
+    match &e.node {
+        Expr::Literal(lit) => super::expr::emit_literal(lit),
+        Expr::List(items) => format!(
+            "[{}]",
+            items
+                .iter()
+                .map(|i| render_dafny_arg(i, list_param))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Expr::FnCall(callee, args) => {
+            let name =
+                crate::codegen::common::expr_to_dotted_name(&callee.node).unwrap_or_default();
+            let rendered: Vec<String> = args
+                .iter()
+                .map(|a| render_dafny_arg(a, list_param))
+                .collect();
+            if name == "List.concat" && rendered.len() == 2 {
+                format!("({} + {})", rendered[0], rendered[1])
+            } else {
+                format!("{}({})", aver_name_to_dafny(&name), rendered.join(", "))
+            }
+        }
+        Expr::Constructor(name, None) => aver_name_to_dafny(name),
+        Expr::Constructor(name, Some(inner)) => {
+            format!(
+                "{}({})",
+                aver_name_to_dafny(name),
+                render_dafny_arg(inner, list_param)
+            )
+        }
+        Expr::Attr(inner, field) => format!("{}.{}", render_dafny_arg(inner, list_param), field),
+        _ => String::new(),
+    }
+}
+
 /// Decomposition citation pool — the Dafny analog of the Lean `earlier_law_lemmas`
 /// simp pool. For THIS law, find earlier sibling laws in the same file whose
 /// universal `ensures` can drive the goal, and emit a `forall`-instantiation
@@ -2349,7 +2397,7 @@ fn eligible_cites<'a>(
     ctx: &'a CodegenContext,
     opaque_fns: &std::collections::HashSet<crate::ir::FnId>,
     native_emitted: &std::collections::HashSet<crate::ir::FnId>,
-) -> Vec<super::cite_instantiate::CiteTarget<'a>> {
+) -> Vec<(String, &'a VerifyLaw)> {
     use std::collections::BTreeSet;
 
     let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
@@ -2436,10 +2484,7 @@ fn eligible_cites<'a>(
             aver_name_to_dafny(&prev.fn_name),
             aver_name_to_dafny(&prev_law.name)
         );
-        out.push(super::cite_instantiate::CiteTarget {
-            dafny_name,
-            law: prev_law.as_ref(),
-        });
+        out.push((dafny_name, prev_law.as_ref()));
     }
     out
 }
@@ -2447,13 +2492,9 @@ fn eligible_cites<'a>(
 /// Hoist each eligible earlier law as a `forall`-fact at the body top. Z3 does not
 /// auto-apply lemmas, so a decomposed proof whose helper laws are merely emitted
 /// (not invoked) fails — this makes each one available universally.
-fn earlier_law_citations(
-    cites: &[super::cite_instantiate::CiteTarget<'_>],
-    ctx: &CodegenContext,
-) -> Vec<String> {
+fn earlier_law_citations(cites: &[(String, &VerifyLaw)], ctx: &CodegenContext) -> Vec<String> {
     let mut out = Vec::new();
-    for c in cites {
-        let prev_law = c.law;
+    for (dafny_name, prev_law) in cites {
         let plhs = emit_expr_legacy(&prev_law.lhs, ctx, None);
         let prhs = emit_expr_legacy(&prev_law.rhs, ctx, None);
         // Skip a sibling with an unused given (a binder absent from its own
@@ -2472,7 +2513,7 @@ fn earlier_law_citations(
             continue;
         }
         if prev_law.givens.is_empty() {
-            out.push(format!("  {}();", c.dafny_name));
+            out.push(format!("  {}();", dafny_name));
         } else {
             let binders = prev_law
                 .givens
@@ -2493,8 +2534,7 @@ fn earlier_law_citations(
                 .collect::<Vec<_>>()
                 .join(", ");
             out.push(format!(
-                "  forall {binders} ensures {plhs} == {prhs} {{ {}({args}); }}",
-                c.dafny_name
+                "  forall {binders} ensures {plhs} == {prhs} {{ {dafny_name}({args}); }}"
             ));
         }
     }
@@ -3237,13 +3277,24 @@ pub fn emit_verify_law(
             // derive the instantiation generically (symbolic unfold + IH + match).
             // Inside the `else` (|xs| > 0), so `xs[0]` / `xs[1..]` are in range.
             if !needs_bounded_form {
-                for inst in super::cite_instantiate::cited_lemma_instantiations(
+                let cited: Vec<&VerifyLaw> = cites.iter().map(|(_, l)| *l).collect();
+                let mut seen: std::collections::BTreeSet<String> =
+                    std::collections::BTreeSet::new();
+                for inst in crate::codegen::cite_instantiate::compute_instantiations(
                     law,
-                    &list_param,
-                    &cites,
+                    ind_var_src,
+                    &cited,
                     ctx,
                 ) {
-                    lines.push(inst);
+                    let args: Vec<String> = inst
+                        .args
+                        .iter()
+                        .map(|a| render_dafny_arg(a, &list_param))
+                        .collect();
+                    let call = format!("    {}({});", cites[inst.law_index].0, args.join(", "));
+                    if seen.insert(call.clone()) {
+                        lines.push(call);
+                    }
                 }
             }
             lines.push("  }".to_string());

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -835,6 +835,235 @@ fn earlier_law_lemmas(
     out
 }
 
+/// Earlier sibling laws eligible to be CITED into THIS law's tight decomposition
+/// (Engine B). The Lean sibling of the Dafny `eligible_cites`: the same
+/// `LawProofCone` ∪ subject ∪ lhs-rooted gate as [`earlier_law_lemmas`], but
+/// returning the cited law's [`VerifyLaw`] alongside its Lean theorem name, so
+/// the instantiation engine ([`compute_instantiations`]) can derive the exact
+/// application arguments and the rung can name the `have`-fact. In-file siblings
+/// only — the cross-file dep pool would need namespace-qualified theorem names
+/// the tight rung does not yet render. Unconditional (`when.is_none`) universal-
+/// form laws only; the per-declaration `#print axioms` gate keeps soundness, so
+/// the dafny-only opaque/native-mutual/oracle filters are not mirrored here.
+fn earlier_law_cites<'a>(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &'a CodegenContext,
+) -> Vec<(String, &'a VerifyLaw)> {
+    use crate::ast::{TopLevel, VerifyKind};
+    let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
+    let cone = crate::codegen::proof_lower::LawProofCone::compute(law, &vb.fn_name, &inputs);
+    let mut scope: BTreeSet<String> = cone
+        .pure_fns()
+        .iter()
+        .map(|fd| aver_name_to_lean(&fd.name))
+        .collect();
+    let subject = aver_name_to_lean(&vb.fn_name);
+    scope.insert(subject.clone());
+
+    let program_index: std::collections::BTreeMap<String, String> = program_fn_lean_names(ctx)
+        .into_iter()
+        .map(|l| (l.clone(), l))
+        .collect();
+
+    let mut out = Vec::new();
+    for item in &ctx.items {
+        let TopLevel::Verify(prev) = item else {
+            continue;
+        };
+        // Only blocks earlier in source are eligible; stop at the consumer.
+        if prev.line == vb.line && prev.fn_name == vb.fn_name {
+            break;
+        }
+        let VerifyKind::Law(prev_law) = &prev.kind else {
+            continue;
+        };
+        // Unconditional only: a `when`-law's universal is `P -> lhs = rhs`, not a
+        // plain rewrite the engine can instantiate by first-order matching.
+        if prev_law.when.is_some() {
+            continue;
+        }
+        let Some((name, stmt)) =
+            crate::codegen::lean::toplevel::law_as_lemma_statement(prev, prev_law, ctx)
+        else {
+            continue;
+        };
+        let text = format!("theorem {name} : {stmt} := by");
+        let mentions = crate::codegen::lemma_discovery::mentioned_fns(&text, &program_index);
+        if mentions.is_empty() {
+            continue;
+        }
+        // SAME three admission rules as `earlier_law_lemmas`: the sibling stays in
+        // the cone, OR it mentions the consumer's subject (decomposition that
+        // introduces a combinator), OR its LHS is cone-rooted.
+        let prev_subject = aver_name_to_lean(&prev.fn_name);
+        let lhs_mentions = crate::codegen::lemma_discovery::lemma_lhs_fns(&text, &program_index);
+        let lhs_rooted = !lhs_mentions.is_empty()
+            && lhs_mentions.is_subset(&scope)
+            && scope.contains(&prev_subject);
+        if mentions.is_subset(&scope)
+            || (mentions.contains(&subject) && scope.contains(&prev_subject))
+            || lhs_rooted
+        {
+            out.push((name, prev_law.as_ref()));
+        }
+    }
+    out
+}
+
+/// Render a computed instantiation argument (from `cite_instantiate`) to a Lean
+/// TERM — the mirror of the Dafny `render_dafny_arg`. The induction placeholders
+/// map to the `| cons head tail ih` binders, `List.concat` to `++`, and a fn
+/// call to a space-separated application; every compound form (a call, a `++`, a
+/// constructor application) is parenthesized as a whole, so each rendered arg is
+/// self-delimiting and joins into a larger application without ambiguity.
+fn render_lean_arg(e: &crate::ast::Spanned<crate::ast::Expr>) -> String {
+    use crate::ast::Expr;
+    use crate::codegen::cite_instantiate::{HEAD, TAIL, ident_name};
+    if let Some(n) = ident_name(e) {
+        return match n {
+            HEAD => "head".to_string(),
+            TAIL => "tail".to_string(),
+            _ => aver_name_to_lean(n),
+        };
+    }
+    match &e.node {
+        Expr::Literal(lit) => render_lean_literal(lit),
+        Expr::List(items) => format!(
+            "[{}]",
+            items
+                .iter()
+                .map(render_lean_arg)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Expr::FnCall(callee, args) => {
+            let name =
+                crate::codegen::common::expr_to_dotted_name(&callee.node).unwrap_or_default();
+            let rendered: Vec<String> = args.iter().map(render_lean_arg).collect();
+            if name == "List.concat" && rendered.len() == 2 {
+                format!("({} ++ {})", rendered[0], rendered[1])
+            } else {
+                format!("({} {})", aver_name_to_lean(&name), rendered.join(" "))
+            }
+        }
+        Expr::Constructor(name, None) => aver_name_to_lean(name),
+        Expr::Constructor(name, Some(inner)) => {
+            format!("({} {})", aver_name_to_lean(name), render_lean_arg(inner))
+        }
+        Expr::Attr(inner, field) => format!("{}.{}", render_lean_arg(inner), field),
+        _ => String::new(),
+    }
+}
+
+/// A literal in argument position — same surface as the Lean expr emitter's
+/// `emit_literal`, with a negative numeral parenthesized so it never glues onto
+/// the preceding application head.
+fn render_lean_literal(lit: &crate::ast::Literal) -> String {
+    use crate::ast::Literal;
+    match lit {
+        Literal::Int(i) if *i < 0 => format!("({})", i),
+        Literal::Int(i) => format!("{}", i),
+        Literal::Bool(b) => if *b { "true" } else { "false" }.to_string(),
+        Literal::Str(s) => format!("\"{}\"", crate::codegen::common::escape_string_literal(s)),
+        Literal::Float(f) => {
+            let s = f.to_string();
+            if s.contains('.') {
+                s
+            } else {
+                format!("{}.0", s)
+            }
+        }
+        Literal::Unit => "()".to_string(),
+    }
+}
+
+/// Engine B (Lean) — the TIGHT deterministic decomposition rung. When THIS law's
+/// inductive step closes by citing earlier sibling laws at exact arguments
+/// (computed by [`compute_instantiations`]), emit the precise proof
+///
+/// ```text
+/// induction <target> with
+/// | nil => simp [<defs>, <cited names>]
+/// | cons head tail ih => have key0 := <law0> <args0>; …; simp [<defs>, ih, key0, …]
+/// ```
+///
+/// instead of the fat `first | (simp…) | (induction…) | sorry` portfolio. The
+/// caller splices it as the LEADING `first` alternative, so the existing ladder
+/// stays as the fallback — zero regression by construction (the rung throws on
+/// any open goal and `first` moves on). Soundness rides on the same fail-closed
+/// guarantee as Dafny: each `have` is a type-checked instance of a kernel-proven
+/// sibling theorem, and the per-declaration `#print axioms` gate downstream flips
+/// `universal:false` on any `sorry`. Returns `None` when no sibling is eligible
+/// or the engine derives no instantiation (fall through to the ladder).
+fn b_tight_decomposition_rung(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    target_lean: &str,
+    ind_aver_name: &str,
+) -> Option<Vec<String>> {
+    let cites = earlier_law_cites(vb, law, ctx);
+    if cites.is_empty() {
+        return None;
+    }
+    let cited: Vec<&VerifyLaw> = cites.iter().map(|(_, l)| *l).collect();
+    let insts =
+        crate::codegen::cite_instantiate::compute_instantiations(law, ind_aver_name, &cited, ctx);
+    if insts.is_empty() {
+        return None;
+    }
+
+    let defs: Vec<String> = law_simp_defs(ctx, vb, law).into_iter().collect();
+    let cited_names: Vec<String> = cites.iter().map(|(n, _)| n.clone()).collect();
+
+    // cons arm: one `have key{i} := <law> <args>` per distinct instantiation,
+    // then `simp [defs, ih, keys]`. The specific instances (not the universal
+    // sibling theorems) drive the close, so the cited names go to `nil` only.
+    let mut have_parts: Vec<String> = Vec::new();
+    let mut keys: Vec<String> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    for inst in &insts {
+        let call = format!(
+            "{} {}",
+            cites[inst.law_index].0,
+            inst.args
+                .iter()
+                .map(render_lean_arg)
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        if !seen.insert(call.clone()) {
+            continue;
+        }
+        let key = format!("key{}", keys.len());
+        have_parts.push(format!("have {key} := {call}"));
+        keys.push(key);
+    }
+    if keys.is_empty() {
+        return None;
+    }
+
+    // nil arm: defs + every cited law NAME as a rewrite — a base case like
+    // `rev (append [] y) = append (rev y) (rev [])` needs the cited `appendNilR`
+    // to fire, and a sibling that does not apply is an inert simp rule.
+    let mut nil_simp = defs.clone();
+    nil_simp.extend(cited_names);
+    let mut cons_simp = defs;
+    cons_simp.push("ih".to_string());
+    cons_simp.extend(keys.iter().cloned());
+
+    Some(vec![
+        format!("  | (induction {target_lean} with"),
+        format!("     | nil => simp [{}]", nil_simp.join(", ")),
+        format!(
+            "     | cons head tail ih => {}; simp [{}])",
+            have_parts.join("; "),
+            cons_simp.join(", ")
+        ),
+    ])
+}
+
 /// Fast-path `simp` set for the feedback emit: the committed pinned lemmas
 /// (`committed_names` → `ctx.discovered_lemmas`) PLUS the eligible earlier
 /// sibling laws, run together through `lemma_discovery::simp_entries` so the
@@ -3708,6 +3937,42 @@ fn emit_list_induction(
         {
             support_lines.extend(compose_support);
             splice_leading_rung(&mut proof_lines, rung);
+        }
+    }
+
+    // Engine B — the TIGHT deterministic decomposition. When THIS law's
+    // inductive step closes by citing earlier sibling laws at exact arguments,
+    // splice the precise `have key := <law> <args>; simp […]` proof as the
+    // LEADING `first` alternative. Reached on EVERY induction path (plain,
+    // generalizing, discovery-feedback), so it is gated and spliced here rather
+    // than inside any one branch. Gate: unconditional law (the inductive arms
+    // re-establish no premise), a SIMPLE shape (`gen_given.is_none()` — no
+    // generalizing/accumulator the engine does not model), and ≥1 derived
+    // instantiation. The rung throws on any open goal and `first` falls through
+    // to the existing ladder byte-for-byte, so this can only ADD a tighter proof
+    // — zero regression by construction.
+    if law.when.is_none()
+        && gen_given.is_none()
+        && let Some(rung) =
+            b_tight_decomposition_rung(vb, law, ctx, target_lean, &law.givens[target_idx].name)
+    {
+        let intro_line = proof_lines.remove(0);
+        if proof_lines.first().map(String::as_str) == Some("  first") {
+            let mut wrapped = vec![intro_line, "  first".to_string()];
+            wrapped.extend(rung);
+            wrapped.extend(proof_lines.drain(1..));
+            proof_lines = wrapped;
+        } else {
+            let mut wrapped = vec![intro_line, "  first".to_string()];
+            wrapped.extend(rung);
+            wrapped.push("  | (".to_string());
+            for line in &proof_lines {
+                wrapped.push(format!("  {line}"));
+            }
+            if let Some(last) = wrapped.last_mut() {
+                last.push(')');
+            }
+            proof_lines = wrapped;
         }
     }
 

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -883,6 +883,13 @@ fn earlier_law_cites<'a>(
         if prev_law.when.is_some() {
             continue;
         }
+        // Drop a law that rewrites to itself (`plus x y = plus y x`): as a Lean
+        // simp rule it never terminates (a `maxHeartbeats` hang `first` cannot
+        // catch), and the engine does not need it — `omega` supplies the
+        // commutativity once the Peano bridge has linearised the goal.
+        if crate::codegen::cite_instantiate::law_rewrites_to_self(prev_law) {
+            continue;
+        }
         let Some((name, stmt)) =
             crate::codegen::lean::toplevel::law_as_lemma_statement(prev, prev_law, ctx)
         else {
@@ -916,15 +923,22 @@ fn earlier_law_cites<'a>(
 /// map to the `| cons head tail ih` binders, `List.concat` to `++`, and a fn
 /// call to a space-separated application; every compound form (a call, a `++`, a
 /// constructor application) is parenthesized as a whole, so each rendered arg is
-/// self-delimiting and joins into a larger application without ambiguity.
-fn render_lean_arg(e: &crate::ast::Spanned<crate::ast::Expr>) -> String {
+/// self-delimiting and joins into a larger application without ambiguity. A
+/// canonical-Peano constructor lifts to its builtin `Nat` form — `S(e)` to
+/// `(e + 1)`, `Z` to `0` — matching how the law statements emit it (a raw
+/// `Nat.S` is not a real Lean constant).
+fn render_lean_arg(e: &crate::ast::Spanned<crate::ast::Expr>, ctx: &CodegenContext) -> String {
     use crate::ast::Expr;
     use crate::codegen::cite_instantiate::{HEAD, TAIL, ident_name};
     if let Some(n) = ident_name(e) {
         return match n {
             HEAD => "head".to_string(),
             TAIL => "tail".to_string(),
-            _ => aver_name_to_lean(n),
+            // A bare canonical-Peano base ctor (`Nat.Z`) lifts to `0`.
+            _ => match peano_role(n, ctx) {
+                Some(crate::codegen::proof_recognize::PeanoCtor::Zero) => "0".to_string(),
+                _ => aver_name_to_lean(n),
+            },
         };
     }
     match &e.node {
@@ -933,27 +947,54 @@ fn render_lean_arg(e: &crate::ast::Spanned<crate::ast::Expr>) -> String {
             "[{}]",
             items
                 .iter()
-                .map(render_lean_arg)
+                .map(|i| render_lean_arg(i, ctx))
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
         Expr::FnCall(callee, args) => {
             let name =
                 crate::codegen::common::expr_to_dotted_name(&callee.node).unwrap_or_default();
-            let rendered: Vec<String> = args.iter().map(render_lean_arg).collect();
+            let rendered: Vec<String> = args.iter().map(|a| render_lean_arg(a, ctx)).collect();
+            // Canonical-Peano successor applied as a call (`Nat.S(e)`) → `(e + 1)`.
+            if rendered.len() == 1
+                && matches!(
+                    peano_role(&name, ctx),
+                    Some(crate::codegen::proof_recognize::PeanoCtor::Succ)
+                )
+            {
+                return format!("({} + 1)", rendered[0]);
+            }
             if name == "List.concat" && rendered.len() == 2 {
                 format!("({} ++ {})", rendered[0], rendered[1])
             } else {
                 format!("({} {})", aver_name_to_lean(&name), rendered.join(" "))
             }
         }
-        Expr::Constructor(name, None) => aver_name_to_lean(name),
-        Expr::Constructor(name, Some(inner)) => {
-            format!("({} {})", aver_name_to_lean(name), render_lean_arg(inner))
-        }
-        Expr::Attr(inner, field) => format!("{}.{}", render_lean_arg(inner), field),
+        Expr::Constructor(name, inner) => match peano_role(name, ctx) {
+            Some(crate::codegen::proof_recognize::PeanoCtor::Zero) => "0".to_string(),
+            Some(crate::codegen::proof_recognize::PeanoCtor::Succ) => match inner {
+                Some(e) => format!("({} + 1)", render_lean_arg(e, ctx)),
+                None => "0".to_string(),
+            },
+            None => match inner {
+                None => aver_name_to_lean(name),
+                Some(e) => format!("({} {})", aver_name_to_lean(name), render_lean_arg(e, ctx)),
+            },
+        },
+        Expr::Attr(inner, field) => format!("{}.{}", render_lean_arg(inner, ctx), field),
         _ => String::new(),
     }
+}
+
+/// Role of a dotted constructor name (`Nat.S` / `Nat.Z`) inside a canonical-Peano
+/// type, used to lift it to the builtin `Nat` surface when rendering an
+/// instantiation argument.
+fn peano_role(
+    dotted: &str,
+    ctx: &CodegenContext,
+) -> Option<crate::codegen::proof_recognize::PeanoCtor> {
+    let (type_name, ctor) = dotted.rsplit_once('.')?;
+    crate::codegen::proof_recognize::peano_ctor_role(ctx, type_name, ctor)
 }
 
 /// A literal in argument position — same surface as the Lean expr emitter's
@@ -1053,7 +1094,7 @@ fn b_tight_decomposition_arms(
             cites[inst.law_index].0,
             inst.args
                 .iter()
-                .map(render_lean_arg)
+                .map(|a| render_lean_arg(a, ctx))
                 .collect::<Vec<_>>()
                 .join(" ")
         );
@@ -1089,18 +1130,27 @@ fn b_tight_decomposition_arms(
     // simp into a failure `first` escalates past. The `<;> omega` variants close on
     // their own (omega on 0 goals is a no-op, on a leftover it closes or fails).
     //
-    // NO `sorry` floor here: the arms THROW when the closer cannot finish, so the
+    // The `<;> omega` rungs discharge a linear residual; the `congr 1` rungs
+    // handle a COMMUTED sum under an opaque wrapper (`even (a + b) = even (b + a)`,
+    // where omega cannot see inside `even`) — `congr 1` reduces it to the argument
+    // equality `a + b = b + a`, which omega then closes. Both only ever appear when
+    // a Peano bridge is in play, so they are inert for a pure structural law.
+    //
+    // NO `sorry` floor: the arms THROW when the closer cannot finish, so the
     // caller's `first | (this tight rung) | (existing ladder)` falls through to the
-    // ladder for the laws the engine does not yet close deterministically
-    // (instantiation-completeness gaps, simp-loop shapes). The ladder carries the
-    // graceful `sorry` floor.
-    let omega = if bridges.is_empty() {
+    // ladder for the shapes the engine does not close standalone (a law leaving a
+    // free `Nat` the cone fn must case-split, `drop n (xs ++ ys)`). On the prod
+    // decomposed corpus the tight closer finishes every eligible law, so the ladder
+    // is dead weight there and the tight decomposition is the headline.
+    let arith = if bridges.is_empty() {
         String::new()
     } else {
-        format!(" | (simp_all [{s}] <;> omega) | (simp [{s}] <;> omega)")
+        format!(
+            " | (simp_all [{s}] <;> omega) | (simp [{s}] <;> omega) | (simp_all [{s}]; congr 1 <;> omega) | (simp [{s}]; congr 1 <;> omega)"
+        )
     };
     let cons = format!(
-        "{}; first | (simp_all [{s}]; done) | (simp [{s}]; done){omega}",
+        "{}; first | (simp_all [{s}]; done) | (simp [{s}]; done){arith}",
         have_parts.join("; ")
     );
 
@@ -3999,9 +4049,9 @@ fn emit_list_induction(
         }
     }
 
-    // Engine B — the TIGHT deterministic decomposition. When THIS law's
-    // inductive step closes by citing earlier sibling laws at exact arguments,
-    // PREPEND the precise proof
+    // Engine B — the TIGHT deterministic decomposition. When THIS law's inductive
+    // step closes by citing earlier sibling laws at exact arguments, PREPEND the
+    // precise proof
     //
     //   induction <target> with
     //   | nil => <first | (simp …; done) | …>
@@ -4013,10 +4063,11 @@ fn emit_list_induction(
     // one branch. Gate: unconditional law (the inductive arms re-establish no
     // premise), a SIMPLE shape (`gen_given.is_none()` — no generalizing/accumulator
     // the engine does not model), and ≥1 derived instantiation. The tight arms
-    // carry NO `sorry`, so a law the closer cannot finish (an
-    // instantiation-completeness gap, a simp-loop shape) THROWS and `first` falls
-    // to the ladder byte-for-byte — zero regression by construction, and the
-    // headline IS the exact decomposition facts wherever the engine closes.
+    // carry NO `sorry`, so a law the closer cannot finish (a free `Nat` the cone fn
+    // must case-split, a shape outside the engine's reach) THROWS and `first` falls
+    // to the ladder byte-for-byte — zero regression by construction, and the tight
+    // decomposition is the headline wherever the engine closes (every prod
+    // decomposed law, with all seven completeness fixes).
     if law.when.is_none()
         && gen_given.is_none()
         && let Some((nil_body, cons_body, bridge_support)) =

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -988,21 +988,22 @@ fn render_lean_literal(lit: &crate::ast::Literal) -> String {
 /// | cons head tail ih => have key0 := <law0> <args0>; …; simp [<defs>, ih, key0, …]
 /// ```
 ///
-/// instead of the fat `first | (simp…) | (induction…) | sorry` portfolio. The
-/// caller splices it as the LEADING `first` alternative, so the existing ladder
-/// stays as the fallback — zero regression by construction (the rung throws on
-/// any open goal and `first` moves on). Soundness rides on the same fail-closed
-/// guarantee as Dafny: each `have` is a type-checked instance of a kernel-proven
-/// sibling theorem, and the per-declaration `#print axioms` gate downstream flips
-/// `universal:false` on any `sorry`. Returns `None` when no sibling is eligible
-/// or the engine derives no instantiation (fall through to the ladder).
-fn b_tight_decomposition_rung(
+/// instead of the fat `first | (simp…) | (induction…) | sorry` portfolio.
+/// Soundness rides on the same fail-closed guarantee as Dafny: each `have` is a
+/// type-checked instance of a kernel-proven sibling theorem, and the
+/// per-declaration `#print axioms` gate downstream flips `universal:false` on any
+/// `sorry`. Returns the two arm bodies — the `nil` simp-set and the `cons` arm
+/// body (`have …; simp […]`) — leaving the `induction … with` framing to the
+/// caller (so it can emit the tight proof STANDALONE, or wrapped as a `first`
+/// alternative). `None` when no sibling is eligible or the engine derives no
+/// instantiation.
+fn b_tight_decomposition_arms(
     vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,
-    target_lean: &str,
     ind_aver_name: &str,
-) -> Option<Vec<String>> {
+    law_uid: &str,
+) -> Option<(String, String, Vec<String>)> {
     let cites = earlier_law_cites(vb, law, ctx);
     if cites.is_empty() {
         return None;
@@ -1014,12 +1015,35 @@ fn b_tight_decomposition_rung(
         return None;
     }
 
-    let defs: Vec<String> = law_simp_defs(ctx, vb, law).into_iter().collect();
+    // Peano-op bridges — the engine KNOWS whether the law needs them: a user
+    // Peano op (`plus`/`minus`) recurses on ONE arg, so a residual like
+    // `plus (len t) 0` is STUCK (no constructor to match) and `omega` cannot see
+    // into the opaque `plus`. `lean_nat_lift_support` detects exactly those ops and
+    // returns their proven `f a b = a OP b` bridge; a law WITHOUT a Peano op gets
+    // an EMPTY bridge set (and no `omega` rung below), so the closer adapts to the
+    // law rather than guessing. The bridged fn's own def leaves the simp-set (the
+    // bridge replaces it).
+    //
+    // The Peano op often arrives through a CITED law's RHS, not this law's own
+    // statement — `length (rev x) = length x` cites `length (append a b) =
+    // plus …`, so the `plus` residual appears only after the citation fires. Feed
+    // the cited laws' fns as `extra_fns` (exactly what the param is for) so the
+    // bridge covers ops the decomposition introduces, not just the ones the
+    // consuming law names.
+    let mut cited_fns: BTreeSet<String> = BTreeSet::new();
+    for c in &cited {
+        crate::codegen::proof_recognize::collect_called_fns(&c.lhs, &mut cited_fns);
+        crate::codegen::proof_recognize::collect_called_fns(&c.rhs, &mut cited_fns);
+    }
+    let (bridge_support, bridges, bridged_fns) =
+        lean_nat_lift_support(law, ctx, law_uid, &cited_fns);
+    let defs: Vec<String> = law_simp_defs(ctx, vb, law)
+        .into_iter()
+        .filter(|n| !bridged_fns.contains(n.trim_start_matches("_root_.")))
+        .collect();
     let cited_names: Vec<String> = cites.iter().map(|(n, _)| n.clone()).collect();
 
-    // cons arm: one `have key{i} := <law> <args>` per distinct instantiation,
-    // then `simp [defs, ih, keys]`. The specific instances (not the universal
-    // sibling theorems) drive the close, so the cited names go to `nil` only.
+    // cons arm: one `have key{i} := <law> <args>` per distinct instantiation.
     let mut have_parts: Vec<String> = Vec::new();
     let mut keys: Vec<String> = Vec::new();
     let mut seen: BTreeSet<String> = BTreeSet::new();
@@ -1044,24 +1068,59 @@ fn b_tight_decomposition_rung(
         return None;
     }
 
-    // nil arm: defs + every cited law NAME as a rewrite — a base case like
-    // `rev (append [] y) = append (rev y) (rev [])` needs the cited `appendNilR`
-    // to fire, and a sibling that does not apply is an inert simp rule.
-    let mut nil_simp = defs.clone();
-    nil_simp.extend(cited_names);
-    let mut cons_simp = defs;
-    cons_simp.push("ih".to_string());
-    cons_simp.extend(keys.iter().cloned());
+    // cons simp-set: defs (minus bridged) + ih + keys + bridges. `ih` is listed
+    // explicitly so the goal-only `simp` arm (which does NOT read hypotheses) can
+    // use it.
+    let mut cons_set = defs.clone();
+    cons_set.push("ih".to_string());
+    cons_set.extend(keys.iter().cloned());
+    cons_set.extend(bridges.iter().cloned());
+    let s = cons_set.join(", ");
 
-    Some(vec![
-        format!("  | (induction {target_lean} with"),
-        format!("     | nil => simp [{}]", nil_simp.join(", ")),
-        format!(
-            "     | cons head tail ih => {}; simp [{}])",
-            have_parts.join("; "),
-            cons_simp.join(", ")
-        ),
-    ])
+    // The closer over the EXACT facts. `simp_all` and `simp` are COMPLEMENTARY and
+    // the choice is NOT statically decidable — `simp only [exact rules]` closes
+    // NEITHER (it lacks simp's `cons.injEq` / `add_zero` plumbing), and the same
+    // `rev (rev x) = x` law flips between them depending on whether the appended
+    // list is a user fn or the builtin `++`. So try both, then their `<;> omega`
+    // variants (only ever useful when a bridge made a residual linear). The `;
+    // done` is load-bearing: a bare `simp_all` that REWRITES but leaves a goal
+    // SUCCEEDS, so `first` would commit to it and the open goal becomes a hard
+    // error before the later alternatives are tried — `done` turns a non-closing
+    // simp into a failure `first` escalates past. The `<;> omega` variants close on
+    // their own (omega on 0 goals is a no-op, on a leftover it closes or fails).
+    //
+    // NO `sorry` floor here: the arms THROW when the closer cannot finish, so the
+    // caller's `first | (this tight rung) | (existing ladder)` falls through to the
+    // ladder for the laws the engine does not yet close deterministically
+    // (instantiation-completeness gaps, simp-loop shapes). The ladder carries the
+    // graceful `sorry` floor.
+    let omega = if bridges.is_empty() {
+        String::new()
+    } else {
+        format!(" | (simp_all [{s}] <;> omega) | (simp [{s}] <;> omega)")
+    };
+    let cons = format!(
+        "{}; first | (simp_all [{s}]; done) | (simp [{s}]; done){omega}",
+        have_parts.join("; ")
+    );
+
+    // nil arm: defs (minus bridged) + every cited law NAME as a rewrite — a base
+    // case like `rev (append [] y) = append (rev y) (rev [])` needs the cited
+    // `appendNilR` to fire; an inapplicable sibling is an inert simp rule. Same `;
+    // done` discipline, plus the `<;> omega` rung when a Peano bridge can linearise
+    // an arithmetic base case (`0 = plus 0 0`).
+    let mut nil_set = defs;
+    nil_set.extend(cited_names);
+    nil_set.extend(bridges.iter().cloned());
+    let n = nil_set.join(", ");
+    let nil_omega = if bridges.is_empty() {
+        String::new()
+    } else {
+        format!(" | (simp [{n}] <;> omega) | (simp_all [{n}] <;> omega)")
+    };
+    let nil = format!("first | (simp [{n}]; done) | (simp_all [{n}]; done){nil_omega}");
+
+    Some((nil, cons, bridge_support))
 }
 
 /// Fast-path `simp` set for the feedback emit: the committed pinned lemmas
@@ -3942,20 +4001,36 @@ fn emit_list_induction(
 
     // Engine B — the TIGHT deterministic decomposition. When THIS law's
     // inductive step closes by citing earlier sibling laws at exact arguments,
-    // splice the precise `have key := <law> <args>; simp […]` proof as the
-    // LEADING `first` alternative. Reached on EVERY induction path (plain,
-    // generalizing, discovery-feedback), so it is gated and spliced here rather
-    // than inside any one branch. Gate: unconditional law (the inductive arms
-    // re-establish no premise), a SIMPLE shape (`gen_given.is_none()` — no
-    // generalizing/accumulator the engine does not model), and ≥1 derived
-    // instantiation. The rung throws on any open goal and `first` falls through
-    // to the existing ladder byte-for-byte, so this can only ADD a tighter proof
-    // — zero regression by construction.
+    // PREPEND the precise proof
+    //
+    //   induction <target> with
+    //   | nil => <first | (simp …; done) | …>
+    //   | cons head tail ih => have key0 := <law> <args>; …; <first | (simp …; done) | …>
+    //
+    // as the LEADING `first` alternative, with the existing ladder as the
+    // fall-through. Reached on EVERY induction path (plain, generalizing,
+    // discovery-feedback), so it is gated and applied here rather than inside any
+    // one branch. Gate: unconditional law (the inductive arms re-establish no
+    // premise), a SIMPLE shape (`gen_given.is_none()` — no generalizing/accumulator
+    // the engine does not model), and ≥1 derived instantiation. The tight arms
+    // carry NO `sorry`, so a law the closer cannot finish (an
+    // instantiation-completeness gap, a simp-loop shape) THROWS and `first` falls
+    // to the ladder byte-for-byte — zero regression by construction, and the
+    // headline IS the exact decomposition facts wherever the engine closes.
     if law.when.is_none()
         && gen_given.is_none()
-        && let Some(rung) =
-            b_tight_decomposition_rung(vb, law, ctx, target_lean, &law.givens[target_idx].name)
+        && let Some((nil_body, cons_body, bridge_support)) =
+            b_tight_decomposition_arms(vb, law, ctx, &law.givens[target_idx].name, &law_uid)
     {
+        // The tight rung references the proven Peano bridges in its simp set; the
+        // ladder may emit the same bridge under the same name + body, so the
+        // exact-duplicate dedup below collapses them.
+        support_lines.extend(bridge_support);
+        let rung = vec![
+            format!("  | (induction {target_lean} with"),
+            format!("     | nil => {nil_body}"),
+            format!("     | cons head tail ih => {cons_body})"),
+        ];
         let intro_line = proof_lines.remove(0);
         if proof_lines.first().map(String::as_str) == Some("  first") {
             let mut wrapped = vec![intro_line, "  first".to_string()];

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5,6 +5,8 @@
 pub(crate) mod builtin_helpers;
 pub(crate) mod builtin_records;
 pub(crate) mod builtins;
+#[cfg(feature = "runtime")]
+pub(crate) mod cite_instantiate;
 pub mod common;
 #[cfg(feature = "runtime")]
 pub mod dafny;


### PR DESCRIPTION
Lift the explicit cited-lemma instantiation engine to a backend-neutral module and
wire it into the Lean backend, so a decomposition law's inductive step closes with
the precise proof — `have key := <law> <args>; simp […]` over the exact arguments
the engine derives — instead of the fat `first | (simp…) | (induction…) | sorry`
portfolio.

## What it does

The engine substitutes the induction variable by `cons(head, tail)`, unfolds the
recursive cone fns, applies the induction hypothesis, and first-order-matches each
cited law's left-hand side against the resulting subterms. Dafny already consumed
it as explicit lemma calls; Lean now consumes it as `have`-facts driving a tight
`simp`. The tight rung is the leading `first` alternative, with the existing ladder
retained as the fall-through, so a shape the engine does not model degrades to the
ladder — zero regression by construction.

## Completeness fixes (so the tight proof actually closes)

- treat a lowered tail call as the equivalent call when substituting/unfolding, so
  an accumulator fn (qrev, qrevflat) unfolds instead of leaving its lowered slots
  untouched;
- take the candidate-term pool to a fuel-bounded fixpoint, so a term needing two
  nested rewrites (a doubly distributed `rev (rev t)`) surfaces and matches;
- simplify builtin nil-concatenations while unfolding, so an accumulator threaded
  from `[]` matches the cited law at the normalized argument;
- drop a self-rewriting law (`plus x y = plus y x`) from the Lean citation set — it
  never terminates as a simp rule, and omega supplies the commutativity once the
  Peano bridge has linearised the goal;
- lift a canonical-Peano constructor argument to its builtin form when rendering
  Lean (`S e` to `(e + 1)`, `Z` to `0`);
- close each arm by trying both `simp_all` and `simp` (complementary), then their
  omega variants and a congr-then-omega rung for a commuted sum under an opaque
  wrapper, with the Peano bridge derived from the cited laws' fns too;
- bound the instantiation pool (drop self-rewriting rules from the closure, cap its
  size) so an adversarial transposition law family cannot hang codegen.

## Validation

- Lean decomposed corpus stays at 35 of 38 universal, now with the tight proof as
  the headline for every prod law; the three conditional set-membership laws stay
  out of scope.
- Dafny stays at its 22 baseline (the shared engine changes leave its output
  well-typed).
- `cargo test --test proof_spec` 174/0; clippy and fmt clean.
- An adversarial multi-agent review of the changes found one real robustness defect
  (a combinatorial pool blow-up on transposition law families), fixed by the pool
  bounds above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)