### PR TITLE
proof: close multiplicative accumulator-generalizing laws through the generic driver

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -3663,11 +3663,26 @@ fn emit_list_induction(
         // at the predecessor; for a threaded accumulator (`qrev`'s `acc`) no
         // split is needed (the IH applies at `h::acc` directly). The ladder is
         // the same sound first|simp|omega|split|sorry chain.
+        // Monoid-AC rung for a multiplicative accumulator (`prodTR(xs, acc) =>
+        // acc * prodSpec xs`): after the IH the residual is `(acc * h) * p = acc
+        // * (h * p)`, pure `Int.*` associativity/commutativity that `omega`
+        // (linear only) cannot decide. The core `Int.mul_*` lemmas form simp's
+        // permutative AC normal form (no Mathlib, no loop); a non-multiplicative
+        // law just fails the rung (the `; done` throws) and falls through, so it
+        // is strictly additive. `acc`/`Int.one_mul` cancel the wrapper's neutral.
+        let mul_ac_set = if simp_list.is_empty() {
+            "Int.mul_assoc, Int.mul_comm, Int.mul_left_comm, Int.mul_one, Int.one_mul".to_string()
+        } else {
+            format!(
+                "{simp_list}, Int.mul_assoc, Int.mul_comm, Int.mul_left_comm, Int.mul_one, Int.one_mul"
+            )
+        };
         let ladder = |s: &str| -> String {
             format!(
-                "first | ({s} [{d}]; done) | ({s} [{d}]; omega) | (simp only [{sp}]; split <;> simp_all [{d}] <;> omega) | sorry",
+                "first | ({s} [{d}]; done) | ({s} [{d}]; omega) | ({s} [{ac}]; done) | (simp only [{sp}]; split <;> simp_all [{d}] <;> omega) | sorry",
                 d = simp_list,
-                sp = split_set
+                sp = split_set,
+                ac = mul_ac_set
             )
         };
         let wrap = |arm: &str| -> String {
@@ -4404,6 +4419,45 @@ fn emit_simple_induction(
         ))
     };
 
+    // Multiplicative monoid-AC rung — a Nat accumulator fold (`factTR(n, acc) =>
+    // mul (factSpec n) acc`) leaves, after the IH, a nonlinear residual `mul
+    // (factSpec m) (mul (m+1) acc) = mul (mul (m+1) (factSpec m)) acc` that
+    // `omega` (linear) cannot decide. Close it by the core `Nat.mul_*` AC normal
+    // form after bridging `mul`/`plus` to the builtins. The bridged fns' OWN defs
+    // are DROPPED (unfolding `mul`'s def alongside its proven `= *` bridge strands
+    // the goal), and the broad `Nat.mul_*` set `lean_nat_lift_support` bundles is
+    // narrowed to the AC lemmas only (its `succ_mul` / `mul_add` directions fight
+    // the AC normal form). Fires only when a Nat `*` bridge is in scope; sound and
+    // additive — a non-multiplicative arm fails the `; done` and falls through.
+    let mul_ac_arm: Option<(String, String)> = if arith_bridges.iter().any(|b| b == "Nat.mul_assoc")
+    {
+        let bridge_thms = arith_bridges.iter().filter(|b| b.starts_with(&law_uid));
+        // `law_simp_defs` may `_root_.`-prefix an entry-module fn; `bridged_fns`
+        // holds the bare lean name, so strip the prefix before testing membership
+        // (otherwise the bridged `mul`/`plus` def survives and fights its bridge).
+        let mut acset: Vec<String> = law_simp_defs(ctx, vb, law)
+            .into_iter()
+            .filter(|d| !bridged_fns.contains(d.trim_start_matches("_root_.")))
+            .collect();
+        acset.extend(bridge_thms.cloned());
+        for lemma in [
+            "Nat.mul_assoc",
+            "Nat.mul_comm",
+            "Nat.mul_left_comm",
+            "Nat.mul_one",
+            "Nat.one_mul",
+        ] {
+            acset.push(lemma.to_string());
+        }
+        let set = acset.join(", ");
+        Some((
+            format!(" | (simp [{set}]; done)"),
+            format!(" | (simp_all [{set}]; done)"),
+        ))
+    } else {
+        None
+    };
+
     let mut arm_lines: Vec<String> = Vec::new();
     for variant in variants {
         let lean_variant = match &peano {
@@ -4430,8 +4484,12 @@ fn emit_simple_induction(
                     .as_ref()
                     .map(|(leaf, _)| leaf.as_str())
                     .unwrap_or_default();
+                let mul_ac = mul_ac_arm
+                    .as_ref()
+                    .map(|(leaf, _)| leaf.as_str())
+                    .unwrap_or_default();
                 arm_lines.push(format!(
-                    "| {v}{b} => first | (simp [{d}]; done) | (simp [{d}]; omega){bridge}{comm} | sorry",
+                    "| {v}{b} => first | (simp [{d}]; done) | (simp [{d}]; omega){bridge}{comm}{mul_ac} | sorry",
                     v = lean_variant,
                     b = binders,
                     d = simp_list
@@ -4459,8 +4517,12 @@ fn emit_simple_induction(
                     .as_ref()
                     .map(|(_, rec)| rec.as_str())
                     .unwrap_or_default();
+                let mul_ac = mul_ac_arm
+                    .as_ref()
+                    .map(|(_, rec)| rec.as_str())
+                    .unwrap_or_default();
                 arm_lines.push(format!(
-                    "| {v} {b} {ih} => first | (simp_all [{d}]; done) | (simp_all [{d}]; omega){bridge}{comm} | sorry",
+                    "| {v} {b} {ih} => first | (simp_all [{d}]; done) | (simp_all [{d}]; omega){bridge}{comm}{mul_ac} | sorry",
                     v = lean_variant,
                     b = field_binders.join(" "),
                     ih = ih_names.join(" "),

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -567,6 +567,55 @@ fn dafny_omits_user_adt_accumulator_generalizing_without_error() {
     );
 }
 
+/// MULTIPLICATIVE accumulator-generalization over a `List<Int>` (`prodTR(xs,
+/// acc) => acc * prodSpec xs`). After the IH the residual is `(acc * h) * p =
+/// acc * (h * p)` — pure `Int.*` associativity/commutativity that `omega`
+/// (linear only) cannot decide. The generalizing closer must inject the core
+/// `Int.mul_*` AC lemmas.
+#[test]
+fn lean_proves_multiplicative_list_accumulator_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping list-mul accumulator test: `lake` not available");
+        return;
+    }
+    let source = "module ListProdAcc\n    intent = \"list multiplicative accumulator-generalization\"\n    effects []\n\n\
+        fn prodTR(xs: List<Int>, acc: Int) -> Int\n    match xs\n        [] -> acc\n        [h, ..t] -> prodTR(t, acc * h)\n\n\
+        fn prodSpec(xs: List<Int>) -> Int\n    match xs\n        [] -> 1\n        [h, ..t] -> h * prodSpec(t)\n\n\
+        verify prodTR law accGeneralizes\n    given xs: List<Int> = [[], [2], [2, 3], [4, 5, 6]]\n    given acc: Int = [1, 2, 3]\n    prodTR(xs, acc) => acc * prodSpec(xs)\n";
+    let summary = proof_check_summary(source, "lean", "aver-listprodacc");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "the multiplicative List accumulator-generalization must close via the Int.mul AC closer\n{summary}"
+    );
+}
+
+/// MULTIPLICATIVE accumulator-generalization over a user Peano `Nat`
+/// (`factTR(n, acc) => mul(factSpec n, acc)`). The closer must drop the bridged
+/// user `mul`/`plus` defs (unfolding them alongside their `= *`/`= +` bridges
+/// strands the goal) and close the nonlinear residual by the core `Nat.mul_*`
+/// AC normal form — the multiplicative twin of the additive Nat win.
+#[test]
+fn lean_proves_multiplicative_nat_accumulator_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping nat-mul accumulator test: `lake` not available");
+        return;
+    }
+    let source = "module FactAccGen\n    intent = \"nat multiplicative accumulator-generalization\"\n    effects []\n\n\
+        type Nat\n    Z\n    S(Nat)\n\n\
+        fn plus(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> y\n        Nat.S(z) -> Nat.S(plus(z, y))\n\n\
+        fn mul(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> Nat.Z\n        Nat.S(z) -> plus(y, mul(z, y))\n\n\
+        fn factTR(n: Nat, acc: Nat) -> Nat\n    match n\n        Nat.Z -> acc\n        Nat.S(m) -> factTR(m, mul(n, acc))\n\n\
+        fn factSpec(n: Nat) -> Nat\n    match n\n        Nat.Z -> Nat.S(Nat.Z)\n        Nat.S(m) -> mul(n, factSpec(m))\n\n\
+        verify factTR law accGeneralizes\n    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z)), Nat.S(Nat.S(Nat.S(Nat.Z)))]\n    given acc: Nat = [Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]\n    factTR(n, acc) => mul(factSpec(n), acc)\n";
+    let summary = proof_check_summary(source, "lean", "aver-factaccgen");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "the multiplicative Nat accumulator-generalization must close via the dropped-def + Nat.mul AC closer\n{summary}"
+    );
+}
+
 /// A law whose verified fn body propagates errors with `?` must still collect
 /// the `?`-wrapped calls into its unfold set. `sumSafe`'s body is
 /// `x = safe(a)?; y = safe(b)?; Ok(x + y)` — every call hides behind `?`


### PR DESCRIPTION
## What

Gap 3 (#609) taught the generic Lean driver to prove **additive** accumulator-generalizing laws over user ADTs (`triTR(n, acc) = plus(triSpec n, acc)`). This extends the closer to the **multiplicative** corners — both `List<Int>` with builtin `*` and a user Peano `mul` — so a tail-recursive product's loop equals its direct recurrence plus the threaded accumulator and proves kernel-clean through the generic driver instead of a hand-written proof. Together with #609 the generic driver now covers all four corners of the accumulator-fold grid `{List, Nat} × {Add, Mul}`.

After the inductive hypothesis the residual is nonlinear (`(acc * h) * p = acc * (h * p)`), which `omega` (linear only) cannot decide. Two closer rungs, **both additive** — a non-multiplicative arm fails the `; done` and falls through, so no existing proof changes:

1. **List generalizing ladder** (`emit_list_induction`) gains an `Int.mul_assoc / mul_comm / mul_left_comm / mul_one / one_mul` rung — simp's permutative AC normal form, no Mathlib, no loop.

2. **User-ADT arm ladder** (`emit_simple_induction`) gains a `Nat.mul_*` AC rung that **drops the bridged `mul` / `plus` defs** (unfolding a fn's def alongside its proven `= *` / `= +` bridge strands the goal) and narrows the broad `Nat.mul_*` set to the AC lemmas only (the `succ_mul` / `mul_add` directions fight the AC normal form).

## Soundness

Fail-safe: both rungs are `simp [...]; done`, so they close only true goals (simp is sound) and a residual they can't close still degrades to the honest `sorry` that `#print axioms` denies credit for. The rungs run after the existing ones, so a law that already closed is untouched.

## Validation

| Gate | Result |
|---|---|
| Lean prod corpus | **35 universal / 3 partial** — unchanged |
| `proof_spec` | **180 / 0** (+ List and Nat multiplicative corner laws) |
| Dafny corpus | unchanged — this diff is Lean-only |
| `clippy --lib -D warnings`, `cargo fmt --all` | clean |

Both new corner proofs are kernel-clean (`[propext, Quot.sound]`).

## Next

This is the enabling capability; the payoff is the follow-up that decomposes the accumulator-fold wrapper fixtures into the now-provable helper laws and removes the bespoke wrapper-over-recursion emitters (`emit_peano_nat_fold`, `emit_list_fold`, `emit_tailrec_fixed_base_fold_law`, `emit_wrapper_over_recursion_law` + detectors), which the generic driver now subsumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193JLEireejXusNFkk1HeHi
