### PR TITLE
proof: close accumulator-generalizing laws on Dafny via a threaded inductive hint

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -817,6 +817,61 @@ fn when_is_peano_comparison(when: &Spanned<Expr>, ctx: &CodegenContext) -> bool 
 /// Replace every WHOLE-WORD occurrence of identifier `word` in `s` with `repl`
 /// (a substring flanked by identifier chars `[A-Za-z0-9_]` is left untouched).
 /// Used to slice a `when` premise's induction-target reference to its tail
+/// The Dafny-rendered THREADED accumulator argument for the inductive-hint
+/// self-call of a list-accumulator-fold lemma — the Dafny counterpart of Lean's
+/// `generalizing acc`. `fd` recurses via `match xs { [] -> _; [h, ..t] ->
+/// fd(t, <acc_arg>) }`; this renders `<acc_arg>` (e.g. `acc + h`) in the lemma's
+/// binders by re-expressing the cons head/tail binders as `<list>[0]` / `<list>
+/// [1..]`. With the recursive lemma call at this threaded value (not the
+/// unchanged param) the IH lands where the fold actually fed the accumulator, so
+/// Z3 closes `fd(xs, acc) == acc <op> spec(xs)`. Returns `None` (caller keeps the
+/// unchanged-arg fallback) unless `fd` is a single self-recursive list match
+/// whose accumulator given name matches a threaded param.
+fn dafny_threaded_accumulator_arg(
+    fd: &FnDef,
+    acc_given_name: &str,
+    list_param_name: &str,
+    list_dafny: &str,
+    ctx: &CodegenContext,
+) -> Option<String> {
+    use crate::codegen::recursion::detect::{
+        call_matches, collect_calls_from_body, param_threaded_in_recursion,
+    };
+    // The fn param the accumulator given binds to (by name), and it must be a
+    // threaded accumulator of THIS recursion.
+    let acc_idx = fd.params.iter().position(|(p, _)| p == acc_given_name)?;
+    if !param_threaded_in_recursion(fd, acc_idx) {
+        return None;
+    }
+    // The single self-call's accumulator argument (the threaded value).
+    let calls: Vec<Vec<&Spanned<Expr>>> = collect_calls_from_body(fd.body.as_ref())
+        .into_iter()
+        .filter(|(name, _)| call_matches(name, &fd.name))
+        .map(|(_, args)| args)
+        .collect();
+    let acc_arg = calls.first()?.get(acc_idx).copied()?;
+    // The list match's head/tail binders, to re-express in the lemma's terms.
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return None;
+    };
+    if !matches!(&subject.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == list_param_name)
+    {
+        return None;
+    }
+    let (head, tail) = arms.iter().find_map(|a| match &a.pattern {
+        Pattern::Cons(h, t) => Some((h.clone(), t.clone())),
+        _ => None,
+    })?;
+    let mut rendered = emit_expr_legacy(acc_arg, ctx, None);
+    rendered = replace_ident_word(&rendered, &head, &format!("{list_dafny}[0]"));
+    rendered = replace_ident_word(&rendered, &tail, &format!("{list_dafny}[1..]"));
+    rendered = replace_ident_word(&rendered, list_param_name, list_dafny);
+    Some(rendered)
+}
+
 /// (`y` -> `y[1..]`) when guarding a conditional list lemma's recursive call.
 /// String-literal aware: an occurrence INSIDE a `"…"` literal (where the same
 /// spelling is just text, e.g. a premise comparing against `"y"`) is left
@@ -3238,6 +3293,13 @@ pub fn emit_verify_law(
         if any_recursive {
             let list_param = aver_name_to_dafny(&law.givens[list_given_idx].name);
             let lemma_name = format!("{}_{}", fn_name, law_name);
+            // A THREADED accumulator given recurses at the value the fold feeds
+            // it (`acc + xs[0]`), not the unchanged param — the Dafny counterpart
+            // of Lean's `induction generalizing acc`. Without it the IH lands at
+            // the wrong accumulator and Z3 cannot close `fold(xs, acc) == acc <op>
+            // spec(xs)`. Falls back to the unchanged name for a non-accumulator
+            // given (the verified fn is the top fn of the law's lhs/rhs).
+            let verified_fd = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref());
             let other_args: Vec<String> = law
                 .givens
                 .iter()
@@ -3245,6 +3307,16 @@ pub fn emit_verify_law(
                 .map(|(i, g)| {
                     if i == list_given_idx {
                         format!("{}[1..]", list_param)
+                    } else if let Some(threaded) = verified_fd.and_then(|fd| {
+                        dafny_threaded_accumulator_arg(
+                            fd,
+                            &g.name,
+                            &law.givens[list_given_idx].name,
+                            &list_param,
+                            ctx,
+                        )
+                    }) {
+                        threaded
                     } else {
                         aver_name_to_dafny(&g.name)
                     }

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -865,10 +865,19 @@ fn dafny_threaded_accumulator_arg(
         Pattern::Cons(h, t) => Some((h.clone(), t.clone())),
         _ => None,
     })?;
-    let mut rendered = emit_expr_legacy(acc_arg, ctx, None);
-    rendered = replace_ident_word(&rendered, &head, &format!("{list_dafny}[0]"));
-    rendered = replace_ident_word(&rendered, &tail, &format!("{list_dafny}[1..]"));
-    rendered = replace_ident_word(&rendered, list_param_name, list_dafny);
+    // Substitute on the DAFNY-RENDERED binder names (`emit_expr_legacy` mangles
+    // a leading-underscore / reserved-word binder, so the source spelling would
+    // miss), in ONE pass so the cons head/tail rewrites cannot cascade into each
+    // other when a binder name collides with the list param. The list param, if
+    // the accumulator arg mentions it, already renders as `list_dafny` (the fn's
+    // list param shares the given's name — checked above), so no rewrite is
+    // needed for it.
+    let rendered = emit_expr_legacy(acc_arg, ctx, None);
+    let subs = vec![
+        (aver_name_to_dafny(&head), format!("{list_dafny}[0]")),
+        (aver_name_to_dafny(&tail), format!("{list_dafny}[1..]")),
+    ];
+    let rendered = replace_ident_words(&rendered, &subs);
     Some(rendered)
 }
 
@@ -916,6 +925,64 @@ fn replace_ident_word(s: &str, word: &str, repl: &str) -> String {
             out.push_str(repl);
             i += wlen;
         } else {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Single-pass whole-word identifier substitution: at each identifier boundary
+/// the FIRST matching `(from, to)` pair replaces the token, and the inserted
+/// text is NOT re-scanned — so substitutions cannot cascade into one another
+/// (mapping `h -> xs[0]` then `t -> xs[1..]` leaves an already-inserted `xs[0]`
+/// intact even when a binder name collides with the list param). String literals
+/// are copied verbatim. Used by `dafny_threaded_accumulator_arg`, where the cons
+/// head/tail binder spellings can otherwise collide on a sequential rewrite.
+fn replace_ident_words(s: &str, subs: &[(String, String)]) -> String {
+    let is_ident = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    let mut in_string = false;
+    while i < chars.len() {
+        if in_string {
+            out.push(chars[i]);
+            if chars[i] == '\\' && i + 1 < chars.len() {
+                out.push(chars[i + 1]);
+                i += 2;
+                continue;
+            }
+            if chars[i] == '"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if chars[i] == '"' {
+            in_string = true;
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        let at_boundary = i == 0 || !is_ident(chars[i - 1]);
+        let mut matched = false;
+        if at_boundary {
+            for (from, to) in subs {
+                let wlen = from.chars().count();
+                if wlen > 0
+                    && i + wlen <= chars.len()
+                    && chars[i..i + wlen].iter().collect::<String>() == *from
+                    && (i + wlen >= chars.len() || !is_ident(chars[i + wlen]))
+                {
+                    out.push_str(to);
+                    i += wlen;
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if !matched {
             out.push(chars[i]);
             i += 1;
         }

--- a/tests/proof_spec/dafny_inline.rs
+++ b/tests/proof_spec/dafny_inline.rs
@@ -140,3 +140,20 @@ fn proof_dafny_proves_list_accumulator_generalization() {
         "aver-dafny-sumacc-gen",
     );
 }
+
+#[test]
+fn proof_dafny_accumulator_hint_handles_mangled_cons_binder() {
+    // The threaded-accumulator render substitutes on the DAFNY-rendered binder
+    // name, in one pass — so a cons binder whose spelling Dafny mangles (a
+    // leading-underscore `_h` becomes `aver_h`) is still re-expressed as
+    // `xs[0]`, not left as an out-of-scope identifier. Without the fix the
+    // emitted recursive call references `aver_h` and Dafny reports an
+    // unresolved identifier.
+    assert_dafny_proves_inline(
+        "module UHeadAcc\n    effects []\n\n\
+         fn sumTR(xs: List<Int>, acc: Int) -> Int\n    match xs\n        [] -> acc\n        [_h, ..t] -> sumTR(t, acc + _h)\n\n\
+         fn sumSpec(xs: List<Int>) -> Int\n    match xs\n        [] -> 0\n        [h, ..t] -> h + sumSpec(t)\n\n\
+         verify sumTR law accGeneralizes\n    given xs: List<Int> = [[], [1], [1, 2]]\n    given acc: Int = [0, 5]\n    sumTR(xs, acc) => acc + sumSpec(xs)\n",
+        "aver-dafny-uhead-acc",
+    );
+}

--- a/tests/proof_spec/dafny_inline.rs
+++ b/tests/proof_spec/dafny_inline.rs
@@ -123,3 +123,20 @@ fn proof_dafny_cites_earlier_helper_law() {
         "aver-rev-cite",
     );
 }
+
+#[test]
+fn proof_dafny_proves_list_accumulator_generalization() {
+    // The Dafny counterpart of Lean's `induction ... generalizing acc`: the
+    // inductive-hint self-call for a THREADED accumulator must recurse at the
+    // value the fold feeds it (`acc + xs[0]`), not the unchanged param. With the
+    // self-call at the threaded accumulator, Z3 closes `sumTR(xs, acc) == acc +
+    // sumSpec(xs)` as a real universal (and the multiplicative twin over `*`,
+    // which Z3's nonlinear arithmetic discharges with the same threaded hint).
+    assert_dafny_proves_inline(
+        "module SumAccGen\n    effects []\n\n\
+         fn sumTR(xs: List<Int>, acc: Int) -> Int\n    match xs\n        [] -> acc\n        [h, ..t] -> sumTR(t, acc + h)\n\n\
+         fn sumSpec(xs: List<Int>) -> Int\n    match xs\n        [] -> 0\n        [h, ..t] -> h + sumSpec(t)\n\n\
+         verify sumTR law accGeneralizes\n    given xs: List<Int> = [[], [1], [1, 2, 3]]\n    given acc: Int = [0, 5]\n    sumTR(xs, acc) => acc + sumSpec(xs)\n",
+        "aver-dafny-sumacc-gen",
+    );
+}


### PR DESCRIPTION
## What

The Dafny inductive-hint self-call for a list-accumulator-fold lemma passed the accumulator parameter **unchanged**, so the induction hypothesis landed at the wrong accumulator and Z3 could not close `fold(xs, acc) == acc <op> spec(xs)`. This passes the **threaded** accumulator the fold actually feeds (`acc + xs[0]`, `[xs[0]] + acc`, …) at the recursive lemma call — the Dafny counterpart of Lean's `induction ... generalizing acc`.

The threaded argument is rendered from the verified fn's own recursive call: its cons head/tail binders are re-expressed in the lemma's terms (`xs[0]` / `xs[1..]`). Only a given that is a **threaded accumulator** of the verified fn (`param_threaded_in_recursion`) is rewritten; a non-accumulator given keeps the unchanged-parameter fallback, so the change is additive.

## Why

This is the Dafny half of the accumulator-fold work (#609 + #610 did the Lean half). Before it, a decomposed accumulator law verified directly on the fold (`qrev(x, y) == rev(x) ++ y`) errored on Dafny because the inductive hint was unsound-shaped; the bespoke wrapper-over-recursion support stack was the only thing that could prove the accumulator decomposition on Dafny.

## Validation

| Gate | Result |
|---|---|
| Dafny prod corpus | **22 → 24** — `qrev`-decomposition tasks prop_27 + prop_29 now close as genuine universals (`errors:0, omitted:0, axioms:0`); the fail set is a strict subset of baseline (zero new failures) |
| `proof_spec` | **181 / 0** (+ a Dafny accumulator-generalization test) |
| `clippy --lib -D warnings`, `cargo fmt --all` | clean |
| Lean | unaffected — this diff is Dafny-only |

The additive `*` corner closes too — Z3's nonlinear arithmetic discharges the threaded multiplicative hint.

## Next

This brings list accumulator-generalization to Dafny. The user-ADT (Peano `Nat`) corner still routes to sample-only on Dafny (no datatype-induction generalizing hint yet); closing it is the remaining step before the bespoke wrapper-over-recursion emitters can be removed in favour of the generic driver on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193JLEireejXusNFkk1HeHi
