### PR TITLE
proof: prove additive user-ADT accumulator-generalizing laws on Dafny

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -1722,6 +1722,162 @@ fn ctx_type_is_recursive_sum(ctx: &CodegenContext, type_name: &str) -> bool {
         })
 }
 
+/// The user fn an accumulator fold COMBINES with — the head of the threaded
+/// accumulator argument in its single self-call (`plus` of `triTR(m, plus(n,
+/// acc))`, `mul` of `factTR(m, mul(n, acc))`). `None` for a non-fold or a
+/// non-`FnCall` accumulator step (a builtin `+`/`*` step lowers to a `BinOp`,
+/// not a user fn, and the List corner needs no algebraic helpers).
+fn accfold_combine_fn(fd: &FnDef) -> Option<String> {
+    use crate::ast::Expr;
+    use crate::codegen::recursion::detect::{
+        call_matches, collect_calls_from_body, param_threaded_in_recursion,
+    };
+    let acc_idx = (0..fd.params.len()).find(|&i| param_threaded_in_recursion(fd, i))?;
+    let calls: Vec<Vec<&Spanned<Expr>>> = collect_calls_from_body(fd.body.as_ref())
+        .into_iter()
+        .filter(|(name, _)| call_matches(name, &fd.name))
+        .map(|(_, args)| args)
+        .collect();
+    let acc_arg = calls.first()?.get(acc_idx).copied()?;
+    let Expr::FnCall(callee, _) = &acc_arg.node else {
+        return None;
+    };
+    expr_to_dotted_name(&callee.node)
+}
+
+/// `e` is `fn(arg0, arg1, …)` with each arg the bare ident named in `arg_names`.
+fn call_args_are_idents(e: &Spanned<Expr>, fn_name: &str, arg_names: &[&str]) -> bool {
+    let Expr::FnCall(callee, args) = &e.node else {
+        return false;
+    };
+    expr_to_dotted_name(&callee.node).as_deref() == Some(fn_name)
+        && args.len() == arg_names.len()
+        && args.iter().zip(arg_names).all(
+            |(a, n)| matches!(&a.node, Expr::Ident(x) | Expr::Resolved { name: x, .. } if x == n),
+        )
+}
+
+/// `true` iff `vb` is a commutativity law for `combine`: `combine(a, b) =>
+/// combine(b, a)` over two givens, no premise.
+fn law_is_commutativity(vb: &VerifyBlock, combine: &str) -> bool {
+    let crate::ast::VerifyKind::Law(law) = &vb.kind else {
+        return false;
+    };
+    if law.givens.len() != 2 || law.when.is_some() {
+        return false;
+    }
+    let a = law.givens[0].name.as_str();
+    let b = law.givens[1].name.as_str();
+    (call_args_are_idents(&law.lhs, combine, &[a, b])
+        && call_args_are_idents(&law.rhs, combine, &[b, a]))
+        || (call_args_are_idents(&law.lhs, combine, &[b, a])
+            && call_args_are_idents(&law.rhs, combine, &[a, b]))
+}
+
+/// `true` iff `vb` is an associativity law for `combine`: `combine(combine(a,
+/// b), c) => combine(a, combine(b, c))` over three givens, no premise (either
+/// nesting may be on the lhs).
+fn law_is_associativity(vb: &VerifyBlock, combine: &str) -> bool {
+    let crate::ast::VerifyKind::Law(law) = &vb.kind else {
+        return false;
+    };
+    if law.givens.len() != 3 || law.when.is_some() {
+        return false;
+    }
+    let a = law.givens[0].name.as_str();
+    let b = law.givens[1].name.as_str();
+    let c = law.givens[2].name.as_str();
+    // `combine(combine(a, b), c)` — outer call, inner first arg.
+    let nested = |e: &Spanned<Expr>| -> bool {
+        let Expr::FnCall(callee, args) = &e.node else {
+            return false;
+        };
+        expr_to_dotted_name(&callee.node).as_deref() == Some(combine)
+            && args.len() == 2
+            && call_args_are_idents(&args[0], combine, &[a, b])
+            && matches!(&args[1].node, Expr::Ident(x) | Expr::Resolved { name: x, .. } if x == c)
+    };
+    // `combine(a, combine(b, c))` — outer call, inner second arg.
+    let flat = |e: &Spanned<Expr>| -> bool {
+        let Expr::FnCall(callee, args) = &e.node else {
+            return false;
+        };
+        expr_to_dotted_name(&callee.node).as_deref() == Some(combine)
+            && args.len() == 2
+            && matches!(&args[0].node, Expr::Ident(x) | Expr::Resolved { name: x, .. } if x == a)
+            && call_args_are_idents(&args[1], combine, &[b, c])
+    };
+    (nested(&law.lhs) && flat(&law.rhs)) || (nested(&law.rhs) && flat(&law.lhs))
+}
+
+/// `true` iff a Nat accumulator-generalizing law verified ON `verified_fn` can
+/// CLOSE its universal on Dafny. Unlike Lean (which bridges the user monoid fn
+/// to builtin `Nat` arithmetic that Z3 knows is associative/commutative), Dafny
+/// sees the user `plus` / `mul` over the ADT as opaque, so the datatype-induction
+/// proof only discharges when the file ALSO provides commutativity AND
+/// associativity laws for the fold's combine fn — which the generic driver
+/// proves and cites. Absent those helpers the universal would ERROR (Dafny
+/// cannot sorry), so it must stay sample-only. The List corner never reaches
+/// here (its accumulator combine is a builtin `BinOp`, so `accfold_combine_fn`
+/// is `None`, and list folds are excluded from `accumulator_fold_fn_names`).
+pub fn nat_accfold_self_closeable(ctx: &CodegenContext, verified_fn: &str) -> bool {
+    if !accumulator_fold_fn_names(ctx).contains(verified_fn) {
+        return false;
+    }
+    let Some(fd) = ctx.fn_def_by_name(verified_fn, ctx.active_module_scope().as_deref()) else {
+        return false;
+    };
+    let Some(combine) = accfold_combine_fn(fd) else {
+        return false;
+    };
+    // Restrict to an ADDITIVE monoid combine (`plus`: base arm returns the 2nd
+    // param). Its commutativity / associativity prove generically by structural
+    // induction, so comm+assoc helpers are SUFFICIENT to close the accGen. A
+    // multiplicative combine (`mul`: base arm returns the zero constructor) also
+    // needs distributivity — comm+assoc alone do not even prove there — so it
+    // stays sample-only rather than ungating into a Z3 error.
+    if !ctx
+        .fn_def_by_name(&combine, ctx.active_module_scope().as_deref())
+        .is_some_and(combine_is_additive_monoid)
+    {
+        return false;
+    }
+    let laws = || {
+        ctx.items
+            .iter()
+            .filter_map(|i| match i {
+                TopLevel::Verify(vb) => Some(vb),
+                _ => None,
+            })
+            .chain(ctx.modules.iter().flat_map(|m| m.verify_laws.iter()))
+    };
+    let has_comm = laws().any(|vb| law_is_commutativity(vb, &combine));
+    let has_assoc = laws().any(|vb| law_is_associativity(vb, &combine));
+    has_comm && has_assoc
+}
+
+/// `true` iff `fd` is a 2-param ADDITIVE-monoid fn — some base (nullary-
+/// constructor) match arm returns the second parameter unchanged (`plus`'s
+/// `Z -> y`). A multiplicative monoid's base arm returns the zero constructor
+/// (`mul`'s `Z -> Z`) instead, so it fails this test.
+fn combine_is_additive_monoid(fd: &FnDef) -> bool {
+    use crate::ast::{Expr, Pattern, Stmt};
+    if fd.params.len() != 2 {
+        return false;
+    }
+    let second = fd.params[1].0.as_str();
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    let Expr::Match { arms, .. } = &body.node else {
+        return false;
+    };
+    arms.iter().any(|arm| {
+        matches!(&arm.pattern, Pattern::Constructor(_, binders) if binders.is_empty())
+            && matches!(&arm.body.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == second)
+    })
+}
+
 /// `true` iff `law`'s lhs/rhs calls a recursive accumulator-threading fn OTHER
 /// than `verified_fn` — the foreign-fold hazard (see
 /// [`accumulator_fold_fn_names`]). Such a law can't close by simple induction
@@ -1744,15 +1900,27 @@ pub fn law_calls_foreign_accumulator_fold(
     law_calls_unclassified_fn(law, &foreign)
 }
 
-/// `true` iff `law`'s lhs/rhs calls ANY recursive accumulator-threading fold,
-/// the verified fn INCLUDED. Dafny consults this (not the foreign-only variant):
-/// it lacks the `induction … generalizing acc` emit the Lean backend gained, so
-/// even a law verified ON the fold cannot close its universal there — it stays
-/// sample-only, exactly as it did when the fold was unclassified. Excluding the
-/// verified fn (as Lean does) would let Dafny ATTEMPT an empty-body universal
-/// lemma that Z3 rejects, turning a clean omission into a hard verify error.
-pub fn law_calls_any_accumulator_fold(ctx: &CodegenContext, law: &crate::ast::VerifyLaw) -> bool {
-    law_calls_unclassified_fn(law, &accumulator_fold_fn_names(ctx))
+/// Dafny's bound-vs-attempt decision for a law touching an accumulator fold,
+/// now that the Dafny backend HAS a datatype-induction generalizing emit. Bound
+/// (sample-only) when:
+///   * the law references a FOREIGN fold (needs that fold's own decomposition
+///     lemma, never available — the `fac(x) => qfac(x, 1)` shape), OR
+///   * the law is verified ON a Nat fold whose universal cannot close here
+///     (`nat_accfold_self_closeable` is false — no commutativity / associativity
+///     helper laws for the combine fn, which Z3 needs over the opaque ADT).
+///
+/// A self-fold WITH those helpers is NOT bound: the datatype-induction hint plus
+/// the cited algebra discharge it as a real universal. The List corner is never
+/// in `accumulator_fold_fn_names`, so its accumulator law always attempts (and
+/// closes — builtin `Int` arithmetic needs no helper).
+pub fn dafny_should_bound_accumulator_fold(
+    ctx: &CodegenContext,
+    law: &crate::ast::VerifyLaw,
+    verified_fn: &str,
+) -> bool {
+    law_calls_foreign_accumulator_fold(ctx, law, verified_fn)
+        || (accumulator_fold_fn_names(ctx).contains(verified_fn)
+            && !nat_accfold_self_closeable(ctx, verified_fn))
 }
 
 /// Issue #128: is the law's RHS independent of every given identifier?

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -1820,7 +1820,11 @@ fn law_is_associativity(vb: &VerifyBlock, combine: &str) -> bool {
 /// cannot sorry), so it must stay sample-only. The List corner never reaches
 /// here (its accumulator combine is a builtin `BinOp`, so `accfold_combine_fn`
 /// is `None`, and list folds are excluded from `accumulator_fold_fn_names`).
-pub fn nat_accfold_self_closeable(ctx: &CodegenContext, verified_fn: &str) -> bool {
+pub fn nat_accfold_self_closeable(
+    ctx: &CodegenContext,
+    verified_fn: &str,
+    accgen_law_name: &str,
+) -> bool {
     if !accumulator_fold_fn_names(ctx).contains(verified_fn) {
         return false;
     }
@@ -1842,17 +1846,26 @@ pub fn nat_accfold_self_closeable(ctx: &CodegenContext, verified_fn: &str) -> bo
     {
         return false;
     }
-    let laws = || {
-        ctx.items
-            .iter()
-            .filter_map(|i| match i {
-                TopLevel::Verify(vb) => Some(vb),
-                _ => None,
-            })
-            .chain(ctx.modules.iter().flat_map(|m| m.verify_laws.iter()))
-    };
-    let has_comm = laws().any(|vb| law_is_commutativity(vb, &combine));
-    let has_assoc = laws().any(|vb| law_is_associativity(vb, &combine));
+    // Only count comm/assoc helpers the citation engine will actually hoist into
+    // the proof: laws EARLIER in source than the accGen block in THIS module
+    // (`eligible_cites` is earlier-in-source, same-module). A helper declared
+    // after the accGen — or in a dependency — is present but un-citable, so
+    // ungating on it would emit a body missing the algebra it needs and Dafny
+    // would error instead of cleanly omitting.
+    let citable: Vec<&VerifyBlock> = ctx
+        .items
+        .iter()
+        .filter_map(|i| match i {
+            TopLevel::Verify(vb) => Some(vb),
+            _ => None,
+        })
+        .take_while(|vb| {
+            !matches!(&vb.kind, VerifyKind::Law(l)
+                if vb.fn_name == verified_fn && l.name == accgen_law_name)
+        })
+        .collect();
+    let has_comm = citable.iter().any(|vb| law_is_commutativity(vb, &combine));
+    let has_assoc = citable.iter().any(|vb| law_is_associativity(vb, &combine));
     has_comm && has_assoc
 }
 
@@ -1920,7 +1933,7 @@ pub fn dafny_should_bound_accumulator_fold(
 ) -> bool {
     law_calls_foreign_accumulator_fold(ctx, law, verified_fn)
         || (accumulator_fold_fn_names(ctx).contains(verified_fn)
-            && !nat_accfold_self_closeable(ctx, verified_fn))
+            && !nat_accfold_self_closeable(ctx, verified_fn, &law.name))
 }
 
 /// Issue #128: is the law's RHS independent of every given identifier?

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -881,6 +881,83 @@ fn dafny_threaded_accumulator_arg(
     Some(rendered)
 }
 
+/// Datatype-induction inductive hint for a law over a recursive USER ADT
+/// (`triTR(n, acc) => plus(triSpec(n), acc)`), the Dafny counterpart of Lean's
+/// `induction <n> generalizing acc`. Mirrors the verified fn's own `match` on
+/// the driver given: each constructor arm that contains a self-call recurses the
+/// LEMMA at that self-call's arguments (so the recursion lands on the field
+/// predecessor while the accumulator is threaded exactly as the fold feeds it).
+/// The cited commutativity/associativity laws (hoisted as `forall` facts above)
+/// then discharge the residual. Returns the `match … { … }` body lines, or
+/// `None` when the fn does not match the given or an arm is not a constructor
+/// pattern. The lemma's params are the law givens in the fn's parameter order
+/// (the law's lhs is `fn(givens…)`), so the self-call args render directly.
+fn dafny_datatype_inductive_hint(
+    fd: &FnDef,
+    given_name: &str,
+    lemma_name: &str,
+    ctx: &CodegenContext,
+) -> Option<Vec<String>> {
+    use crate::codegen::recursion::detect::{call_matches, collect_calls_from_expr};
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return None;
+    };
+    if !matches!(&subject.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == given_name)
+    {
+        return None;
+    }
+    let given_dafny = aver_name_to_dafny(given_name);
+    let mut lines = vec![format!("  match {} {{", given_dafny)];
+    for arm in arms {
+        let Pattern::Constructor(cname, binders) = &arm.pattern else {
+            return None;
+        };
+        let short = cname.rsplit('.').next().unwrap_or(cname);
+        let binder_str = if binders.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "({})",
+                binders
+                    .iter()
+                    .map(|b| aver_name_to_dafny(b))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        };
+        // Recurse the lemma at each self-call's arguments (the predecessor driver
+        // plus the threaded accumulator), rendered in the lemma's binders.
+        let mut calls = Vec::new();
+        collect_calls_from_expr(&arm.body, &mut calls);
+        let recs: Vec<String> = calls
+            .iter()
+            .filter(|(n, _)| call_matches(n, &fd.name))
+            .map(|(_, args)| {
+                let rendered: Vec<String> = args
+                    .iter()
+                    .map(|x| emit_expr_legacy(x, ctx, None))
+                    .collect();
+                format!("{}({});", lemma_name, rendered.join(", "))
+            })
+            .collect();
+        if recs.is_empty() {
+            lines.push(format!("    case {}{} =>", short, binder_str));
+        } else {
+            lines.push(format!(
+                "    case {}{} => {}",
+                short,
+                binder_str,
+                recs.join(" ")
+            ));
+        }
+    }
+    lines.push("  }".to_string());
+    Some(lines)
+}
+
 /// (`y` -> `y[1..]`) when guarding a conditional list lemma's recursive call.
 /// String-literal aware: an occurrence INSIDE a `"…"` literal (where the same
 /// spelling is just text, e.g. a premise comparing against `"y"`) is left
@@ -1263,12 +1340,11 @@ fn sample_seed_lemma_available(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenC
     let unclassified = crate::codegen::common::unclassified_fn_names(ctx);
     // Accumulator-fold reference — kept in sync with the universal-lemma gate in
     // `emit_verify_law` so the seed never references a lemma that gate omitted.
-    // Dafny gates ANY fold reference (the verified fn included): it has no
-    // `induction … generalizing acc` emit, so even a law verified ON the fold
-    // stays sample-only here.
+    // A foreign fold, or a self-fold whose universal can't close here (no
+    // algebra helpers for its combine fn), stays sample-only.
     if singleton_const_rhs
         || crate::codegen::common::law_calls_unclassified_fn(law, &unclassified)
-        || crate::codegen::common::law_calls_any_accumulator_fold(ctx, law)
+        || crate::codegen::common::dafny_should_bound_accumulator_fold(ctx, law, &vb.fn_name)
     {
         return false;
     }
@@ -2820,15 +2896,16 @@ pub fn emit_verify_law(
 
     let unclassified = crate::codegen::common::unclassified_fn_names(ctx);
     let calls_fuel_bounded = crate::codegen::common::law_calls_unclassified_fn(law, &unclassified);
-    // An accumulator-fold reference (the verified fn INCLUDED — see
-    // `law_calls_any_accumulator_fold`). Dafny has no `induction … generalizing
-    // acc` emit, so neither a `fac(x) => qfac(x, 1)` reference NOR a law verified
-    // ON the fold can close its universal here; both stay sample-only, exactly as
-    // they did when the fold was unclassified. The wrapper-over-recursion and
-    // tail-rec-fixed-base strategies have already returned their own support stack
-    // above, so they never reach this gate.
-    let calls_acc_fold = crate::codegen::common::law_calls_any_accumulator_fold(ctx, law);
-    if singleton_const_rhs || calls_fuel_bounded || calls_acc_fold {
+    // An accumulator-fold reference that can't close here: a FOREIGN fold (`fac(x)
+    // => qfac(x, 1)` needs `qfac`'s own decomposition lemma), or a Nat self-fold
+    // whose combine fn has no commutativity/associativity helper laws (Z3 can't
+    // derive ADT algebra). A self-fold WITH those helpers attempts and closes via
+    // the datatype-induction hint. The wrapper-over-recursion and tail-rec-fixed-
+    // base strategies have already returned their own support stack above, so they
+    // never reach this gate.
+    let bound_acc_fold =
+        crate::codegen::common::dafny_should_bound_accumulator_fold(ctx, law, &vb.fn_name);
+    if singleton_const_rhs || calls_fuel_bounded || bound_acc_fold {
         let reason = if singleton_const_rhs {
             "singleton-domain givens with constant RHS"
         } else if calls_fuel_bounded {
@@ -3454,6 +3531,24 @@ pub fn emit_verify_law(
                 }
             }
             lines.push("  }".to_string());
+        }
+    } else if law.when.is_none()
+        && crate::codegen::common::accumulator_fold_fn_names(ctx).contains(&vb.fn_name)
+        && let Some(fd) = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref())
+    {
+        // User-ADT accumulator-generalization (`triTR(n, acc) => plus(triSpec(n),
+        // acc)`). The gate only reaches here when this self-fold is closeable
+        // (`dafny_should_bound_accumulator_fold` is false — its combine fn has the
+        // commutativity/associativity helpers), so emit the datatype-induction
+        // hint mirroring the fold's `match` on its driver given. The cited algebra
+        // (forall-hoisted above) discharges the residual.
+        let lemma_name = format!("{}_{}", fn_name, law_name);
+        if let Some(hint) = law
+            .givens
+            .iter()
+            .find_map(|g| dafny_datatype_inductive_hint(fd, &g.name, &lemma_name, ctx))
+        {
+            lines.extend(hint);
         }
     } else if law
         .when

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -881,6 +881,25 @@ fn dafny_threaded_accumulator_arg(
     Some(rendered)
 }
 
+/// The law given the fold structurally recurses on — its `match` subject mapped
+/// back to a law given. `None` when the fn body isn't a single match on a given.
+fn datatype_driver_given_name(fd: &FnDef, law: &VerifyLaw) -> Option<String> {
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { subject, .. } = &body.node else {
+        return None;
+    };
+    let subj = match &subject.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => n,
+        _ => return None,
+    };
+    law.givens
+        .iter()
+        .find(|g| &g.name == subj)
+        .map(|g| g.name.clone())
+}
+
 /// Datatype-induction inductive hint for a law over a recursive USER ADT
 /// (`triTR(n, acc) => plus(triSpec(n), acc)`), the Dafny counterpart of Lean's
 /// `induction <n> generalizing acc`. Mirrors the verified fn's own `match` on
@@ -896,6 +915,7 @@ fn dafny_datatype_inductive_hint(
     fd: &FnDef,
     given_name: &str,
     lemma_name: &str,
+    law: &VerifyLaw,
     ctx: &CodegenContext,
 ) -> Option<Vec<String>> {
     use crate::codegen::recursion::detect::{call_matches, collect_calls_from_expr};
@@ -909,6 +929,31 @@ fn dafny_datatype_inductive_hint(
     {
         return None;
     }
+    // The lemma's params are the law givens in DECLARED order, but the fn's
+    // self-call passes its args in FN-PARAM order — which the law's lhs call
+    // binds to givens positionally. Build, for each lemma param (given), the
+    // fn-param index it occupies, so the recursive lemma call's args are
+    // reordered to the lemma signature regardless of how the law declared its
+    // givens vs the fn's parameter order. Declines (omit, safe) if the lhs is not
+    // a plain `fn(given, …)` call covering every given.
+    let ident_of = |e: &Spanned<Expr>| -> Option<String> {
+        match &e.node {
+            Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.clone()),
+            _ => None,
+        }
+    };
+    let Expr::FnCall(_, lhs_args) = &law.lhs.node else {
+        return None;
+    };
+    let lhs_idents: Vec<String> = lhs_args.iter().filter_map(ident_of).collect();
+    if lhs_idents.len() != lhs_args.len() {
+        return None;
+    }
+    let given_to_fn_pos: Vec<usize> = law
+        .givens
+        .iter()
+        .map(|g| lhs_idents.iter().position(|n| n == &g.name))
+        .collect::<Option<Vec<usize>>>()?;
     let given_dafny = aver_name_to_dafny(given_name);
     let mut lines = vec![format!("  match {} {{", given_dafny)];
     for arm in arms {
@@ -929,18 +974,18 @@ fn dafny_datatype_inductive_hint(
             )
         };
         // Recurse the lemma at each self-call's arguments (the predecessor driver
-        // plus the threaded accumulator), rendered in the lemma's binders.
+        // plus the threaded accumulator), reordered to the lemma's given order.
         let mut calls = Vec::new();
         collect_calls_from_expr(&arm.body, &mut calls);
         let recs: Vec<String> = calls
             .iter()
             .filter(|(n, _)| call_matches(n, &fd.name))
-            .map(|(_, args)| {
-                let rendered: Vec<String> = args
+            .filter_map(|(_, args)| {
+                let rendered: Vec<String> = given_to_fn_pos
                     .iter()
-                    .map(|x| emit_expr_legacy(x, ctx, None))
-                    .collect();
-                format!("{}({});", lemma_name, rendered.join(", "))
+                    .map(|&i| args.get(i).map(|x| emit_expr_legacy(x, ctx, None)))
+                    .collect::<Option<Vec<String>>>()?;
+                Some(format!("{}({});", lemma_name, rendered.join(", ")))
             })
             .collect();
         if recs.is_empty() {
@@ -3319,6 +3364,19 @@ pub fn emit_verify_law(
     }
 
     lines.push(format!("  ensures {} == {}", lhs, rhs));
+    // Datatype accumulator-generalization: the structurally-shrinking driver
+    // given may not be the lemma's FIRST param (givens can be declared in any
+    // order), so Dafny's default lexicographic measure — which tries params
+    // left-to-right and would hit the GROWING accumulator first — fails. Pin the
+    // measure to the driver. (The datatype-induction hint below recurses on its
+    // field predecessor, which decreases this driver.)
+    if law.when.is_none()
+        && crate::codegen::common::accumulator_fold_fn_names(ctx).contains(&vb.fn_name)
+        && let Some(fd) = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref())
+        && let Some(driver) = datatype_driver_given_name(fd, law)
+    {
+        lines.push(format!("  decreases {}", aver_name_to_dafny(&driver)));
+    }
     lines.push("{".to_string());
 
     // Earlier sibling laws eligible to be cited into this proof — shared by the
@@ -3546,7 +3604,7 @@ pub fn emit_verify_law(
         if let Some(hint) = law
             .givens
             .iter()
-            .find_map(|g| dafny_datatype_inductive_hint(fd, &g.name, &lemma_name, ctx))
+            .find_map(|g| dafny_datatype_inductive_hint(fd, &g.name, &lemma_name, law, ctx))
         {
             lines.extend(hint);
         }

--- a/tests/proof_spec/dafny_inline.rs
+++ b/tests/proof_spec/dafny_inline.rs
@@ -157,3 +157,27 @@ fn proof_dafny_accumulator_hint_handles_mangled_cons_binder() {
         "aver-dafny-uhead-acc",
     );
 }
+
+#[test]
+fn proof_dafny_proves_nat_additive_accumulator_via_algebra_helpers() {
+    // User-ADT accumulator-generalization on Dafny (`triTR(n, acc) =>
+    // plus(triSpec(n), acc)`): the datatype-induction hint mirrors the fold's
+    // `match` on its driver and recurses at the threaded accumulator, while the
+    // file's commutativity/associativity helper laws for `plus` (which prove
+    // generically) supply the algebra Z3 cannot derive over the opaque ADT. The
+    // smart gate only ungates this self-fold because those additive helpers are
+    // present.
+    assert_dafny_proves_inline(
+        "module NatTriAccGen\n    effects []\n\n\
+         type Nat\n    Z\n    S(Nat)\n\n\
+         fn plus(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> y\n        Nat.S(z) -> Nat.S(plus(z, y))\n\n\
+         fn triTR(n: Nat, acc: Nat) -> Nat\n    match n\n        Nat.Z -> acc\n        Nat.S(m) -> triTR(m, plus(n, acc))\n\n\
+         fn triSpec(n: Nat) -> Nat\n    match n\n        Nat.Z -> Nat.Z\n        Nat.S(m) -> plus(n, triSpec(m))\n\n\
+         verify plus law plusZeroR\n    given x: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]\n    plus(x, Nat.Z) => x\n\n\
+         verify plus law plusSuccR\n    given x: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given y: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    plus(x, Nat.S(y)) => Nat.S(plus(x, y))\n\n\
+         verify plus law plusComm\n    given a: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given b: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    plus(a, b) => plus(b, a)\n\n\
+         verify plus law plusAssoc\n    given a: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given b: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given c: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    plus(plus(a, b), c) => plus(a, plus(b, c))\n\n\
+         verify triTR law accGeneralizes\n    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]\n    given acc: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    triTR(n, acc) => plus(triSpec(n), acc)\n",
+        "aver-dafny-nat-tri-accgen",
+    );
+}

--- a/tests/proof_spec/dafny_inline.rs
+++ b/tests/proof_spec/dafny_inline.rs
@@ -181,3 +181,52 @@ fn proof_dafny_proves_nat_additive_accumulator_via_algebra_helpers() {
         "aver-dafny-nat-tri-accgen",
     );
 }
+
+#[test]
+fn proof_dafny_nat_accumulator_is_given_order_independent() {
+    // The datatype-induction hint reorders the recursive lemma call to the
+    // lemma's given order and pins `decreases` to the driver, so the additive
+    // accumulator law closes even when the accumulator given is declared BEFORE
+    // the driver — not a hard verify error from a wrong-instance / non-
+    // terminating recursive call.
+    assert_dafny_proves_inline(
+        "module NatTriOrder\n    effects []\n\n\
+         type Nat\n    Z\n    S(Nat)\n\n\
+         fn plus(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> y\n        Nat.S(z) -> Nat.S(plus(z, y))\n\n\
+         fn triTR(n: Nat, acc: Nat) -> Nat\n    match n\n        Nat.Z -> acc\n        Nat.S(m) -> triTR(m, plus(n, acc))\n\n\
+         fn triSpec(n: Nat) -> Nat\n    match n\n        Nat.Z -> Nat.Z\n        Nat.S(m) -> plus(n, triSpec(m))\n\n\
+         verify plus law plusZeroR\n    given x: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    plus(x, Nat.Z) => x\n\n\
+         verify plus law plusSuccR\n    given x: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given y: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    plus(x, Nat.S(y)) => Nat.S(plus(x, y))\n\n\
+         verify plus law plusComm\n    given a: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given b: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    plus(a, b) => plus(b, a)\n\n\
+         verify plus law plusAssoc\n    given a: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given b: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given c: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    plus(plus(a, b), c) => plus(a, plus(b, c))\n\n\
+         verify triTR law accGen\n    given acc: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given n: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]\n    triTR(n, acc) => plus(triSpec(n), acc)\n",
+        "aver-dafny-nat-accgen-order",
+    );
+}
+
+#[test]
+fn proof_dafny_nat_accumulator_omits_when_algebra_helpers_not_citable() {
+    // The gate ungates a Nat accumulator-generalization only when its
+    // commutativity/associativity helpers are CITABLE — earlier in source. With
+    // the helpers declared AFTER the accGen law (the citation engine cannot hoist
+    // them) the universal must stay sample-only — a clean omission, never a hard
+    // verify error from a body missing the algebra it needs.
+    if Command::new("dafny").arg("--version").output().is_err() {
+        eprintln!("skipping dafny accgen-order omit test: `dafny` not available");
+        return;
+    }
+    let source = "module NatTriAcAfter\n    effects []\n\n\
+         type Nat\n    Z\n    S(Nat)\n\n\
+         fn plus(x: Nat, y: Nat) -> Nat\n    match x\n        Nat.Z -> y\n        Nat.S(z) -> Nat.S(plus(z, y))\n\n\
+         fn triTR(n: Nat, acc: Nat) -> Nat\n    match n\n        Nat.Z -> acc\n        Nat.S(m) -> triTR(m, plus(n, acc))\n\n\
+         fn triSpec(n: Nat) -> Nat\n    match n\n        Nat.Z -> Nat.Z\n        Nat.S(m) -> plus(n, triSpec(m))\n\n\
+         verify triTR law accGen\n    given n: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given acc: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    triTR(n, acc) => plus(triSpec(n), acc)\n\n\
+         verify plus law plusComm\n    given a: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given b: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    plus(a, b) => plus(b, a)\n\n\
+         verify plus law plusAssoc\n    given a: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given b: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    given c: Nat = [Nat.Z, Nat.S(Nat.Z)]\n    plus(plus(a, b), c) => plus(a, plus(b, c))\n";
+    let summary = crate::lemmas::proof_check_summary(source, "dafny", "aver-dafny-acafter");
+    assert_eq!(
+        summary["errors"].as_u64(),
+        Some(0),
+        "a Nat accumulator law whose algebra helpers are declared after it must OMIT, not error\n{summary}"
+    );
+}

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -460,7 +460,7 @@ fn lean_proves_accumulator_generalizing_nat_when_lake_is_available() {
 /// Run `aver proof --backend <backend> --check --check-json` on one inline
 /// module and return the parsed summary. Shared by the ordering / over-bound /
 /// cross-backend regression guards below.
-fn proof_check_summary(source: &str, backend: &str, prefix: &str) -> serde_json::Value {
+pub(crate) fn proof_check_summary(source: &str, backend: &str, prefix: &str) -> serde_json::Value {
     let aver_bin = env!("CARGO_BIN_EXE_aver");
     let src = temp_output_dir(&format!("{prefix}-src"));
     std::fs::create_dir_all(&src).expect("src dir");


### PR DESCRIPTION
## What

The Dafny backend gained **list** accumulator-generalization in #611; this extends it to a user Peano **`Nat`** driver — `triTR(n, acc) => plus(triSpec(n), acc)` — so the generic driver proves the additive accumulator decomposition instead of the bespoke wrapper-over-recursion support stack.

## How

1. **Datatype-induction inductive hint** (`dafny_datatype_inductive_hint`) that mirrors the fold's `match` on its driver given and recurses the lemma at each self-call's arguments — the field predecessor plus the **threaded** accumulator — the Dafny counterpart of Lean's `induction generalizing acc`.

2. **Smart bound-vs-attempt gate** (`dafny_should_bound_accumulator_fold`). Z3 sees the user `plus` over the ADT as opaque, so the datatype proof only discharges when the file also provides **commutativity AND associativity** helper laws for the combine fn (which the generic driver proves and cites via the `forall` hoist). Absent those — or for a **multiplicative** combine, which also needs distributivity — the universal stays **sample-only rather than erroring** (Dafny cannot `sorry`). A bare accumulator law with no helpers still omits, so the Gap-3 omission guard is preserved.

3. The combine-fn / commutativity / associativity **shape recognizers** the gate keys on, plus the additive-monoid check that scopes it.

## Soundness

Fail-safe: Dafny/Z3 re-verifies every emitted lemma, so a wrong hint errors (caught by the harness) — never a false proof. The gate only ever moves a law between *attempt* (errors if it can't close) and *omit* (sample-only); the cited algebra laws are themselves proven, not assumed.

## Scope

Restricted to the **additive** monoid. A multiplicative combine (`mul`) needs distributivity helpers beyond comm+assoc — and those helper laws don't even prove generically on Dafny without their own chain — so a `mul`-fold gracefully **omits** rather than ungating into an error. Closing the multiplicative Nat corner on Dafny is a follow-up (a deeper algebra decomposition).

## Validation

| Gate | Result |
|---|---|
| Dafny prod corpus | **24 passing** — unchanged, fail set identical |
| `proof_spec` | **183 / 0** (+ an additive Nat accumulator-generalization Dafny test) |
| `clippy --lib -D warnings` + `--features wasm,wasip2`, `cargo fmt --all` | clean |
| Lean | unaffected |

## Next

With list + additive-Nat accumulator-generalization on both backends, the additive accumulator-fold wrapper fixtures (`sum_acc`, `nat_tri`) can be decomposed and their bespoke wrapper-over-recursion emitters retired in favour of the generic driver. The multiplicative corners (`list_prod` closes on Dafny via builtin `Int`; `fact_acc` needs the deeper `mul` algebra) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193JLEireejXusNFkk1HeHi
