### PR TITLE
proof: prove negated-premise comparison-bridge laws

### DIFF
--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1401,6 +1401,21 @@ fn is_peano_compare_call(
 /// compound premise, or a conclusion that is not a single comparison `= true`,
 /// is rejected so the law keeps the bounded guarded-domain fallback (the HARD
 /// conditional-inductive family — sortedness/insertion — is out of scope here).
+/// The inner comparison call of a NEGATED premise `Bool.not(<compare>)`, if the
+/// premise has that shape. `Bool.not` is the dotted builtin (not a prefix `not`).
+fn negated_compare_inner(
+    expr: &crate::ast::Spanned<crate::ast::Expr>,
+) -> Option<&crate::ast::Spanned<crate::ast::Expr>> {
+    use crate::ast::Expr;
+    let Expr::FnCall(callee, args) = &expr.node else {
+        return None;
+    };
+    if super::shared::expr_dotted_name(callee).as_deref() != Some("Bool.not") || args.len() != 1 {
+        return None;
+    }
+    Some(&args[0])
+}
+
 fn conditional_comparison_bridge_shape(law: &VerifyLaw, ctx: &CodegenContext) -> bool {
     use crate::ast::{Expr, Literal};
     let Some(when) = &law.when else {
@@ -1414,8 +1429,13 @@ fn conditional_comparison_bridge_shape(law: &VerifyLaw, ctx: &CodegenContext) ->
     if !is_peano_compare_call(&law.lhs, ctx) {
         return false;
     }
-    // Premise is an un-negated recognized comparison call.
-    is_peano_compare_call(when, ctx)
+    // Premise is a recognized comparison call, bare OR negated `Bool.not(...)`.
+    // The negated form (`le-totality`: `not(le a b) -> le b a`) bridges the
+    // premise via the FALSE bridge `(f a b = false) = (complement)`.
+    match negated_compare_inner(when) {
+        Some(inner) => is_peano_compare_call(inner, ctx),
+        None => is_peano_compare_call(when, ctx),
+    }
 }
 
 /// Whether [`emit_conditional_comparison_bridge_law`] will close this law as a
@@ -1481,14 +1501,50 @@ pub(in crate::codegen::lean) fn emit_conditional_comparison_bridge_law(
         return None;
     }
     let bridges = bridge_names.join(", ");
-    // `intro <givens> h_when`; rewrite the premise hypothesis AND the goal
-    // through the Prop bridges, then `omega` over the linear residual. `<;>
-    // omega` (not `; omega`) so a `simp` that fully closes the goal does not
-    // leave `omega` with no goals.
     let intro = format!("  intro {} h_when", intro_names.join(" "));
-    let close = format!("  first | (simp only [{bridges}] at h_when ⊢ <;> omega) | sorry");
+
+    // NEGATED premise (`when Bool.not(le a b)`): the bridge `(le a b = true) =
+    // (a ≤ b)` cannot rewrite `(!le a b) = true`. Emit the FALSE bridge `(f a b =
+    // false) = (complement)` for the premise's relation (the omega-ready negation
+    // of its true Prop), normalize the Bool negation (`Bool.not_eq_true'`), then
+    // bridge the goal + premise and discharge with `omega`. The false bridge is
+    // sound-by-floor like the true one (a misrecognized op fails its own induction
+    // and lands on `sorry`, never a false theorem).
+    let mut support = bridge_support;
+    let close = if let Some(inner) = law.when.as_ref().and_then(negated_compare_inner) {
+        let mut premise_fns: BTreeSet<String> = BTreeSet::new();
+        crate::codegen::proof_recognize::collect_called_fns(inner, &mut premise_fns);
+        let false_bridges: Vec<String> = crate::codegen::proof_recognize::collect_nat_compare_ops_for_names(
+            &premise_fns, ctx,
+        )
+        .into_iter()
+        .map(|op| {
+            let f = aver_name_to_lean(&op.fn_name);
+            let name = format!("{law_uid}_{f}_{}False", op.kind.bridge_suffix());
+            let false_prop = op.kind.false_prop();
+            let (driver, passenger) = if op.kind.induct_on_second() {
+                ("b", "a")
+            } else {
+                ("a", "b")
+            };
+            support.push(format!(
+                "theorem {name} : ∀ a b, ({f} a b = false) = ({false_prop}) := by\n  intro a b\n  induction {driver} generalizing {passenger} with\n  | zero => cases {passenger} <;> first | (simp [{f}]) | (simp [{f}]; omega) | sorry\n  | succ k ih => cases {passenger} <;> first | (simp [{f}, ih]) | (simp [{f}, ih]; omega) | sorry"
+            ));
+            name
+        })
+        .collect();
+        let false_set = false_bridges.join(", ");
+        format!(
+            "  first | (simp only [{bridges}] at ⊢; simp only [Bool.not_eq_true', {false_set}, {bridges}] at h_when; omega) | sorry"
+        )
+    } else {
+        // Un-negated premise: rewrite the premise hypothesis AND the goal through
+        // the Prop bridges, then `omega`. `<;> omega` (not `; omega`) so a `simp`
+        // that fully closes the goal does not leave `omega` with no goals.
+        format!("  first | (simp only [{bridges}] at h_when ⊢ <;> omega) | sorry")
+    };
     Some(AutoProof {
-        support_lines: bridge_support,
+        support_lines: support,
         body: Tactic::raw(vec![intro, close]),
         replaces_theorem: false,
     })

--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -549,6 +549,18 @@ impl NatCompareKind {
         }
     }
 
+    /// The Prop the FALSE bridge maps `f a b = false` onto — the complement of
+    /// `prop_op`, written in the `omega`-ready form: `¬(a ≤ b)` is `b < a`,
+    /// `¬(a < b)` is `b ≤ a`, `¬(a = b)` is `a ≠ b`. Used to bridge a NEGATED
+    /// premise (`when Bool.not(le a b)`) into a linear-`Nat` fact.
+    pub(crate) fn false_prop(self) -> &'static str {
+        match self {
+            NatCompareKind::Le => "b < a",
+            NatCompareKind::Lt => "b ≤ a",
+            NatCompareKind::Eq => "a ≠ b",
+        }
+    }
+
     /// The bridge theorem's name suffix (kept distinct per relation so two
     /// bridges in one law never collide, and the both-args rung can spot them).
     pub(crate) fn bridge_suffix(self) -> &'static str {

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -1637,3 +1637,27 @@ fn lean_escape_roundtrip_template_regression_degrades_to_caught_sorry_when_lake_
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+/// Negated-premise comparison bridge (`le-totality`: `when Bool.not(le a b)`
+/// -> `le b a => true`). The `(le a b = true) = (a ≤ b)` bridge cannot rewrite
+/// the negated hypothesis `(!le a b) = true`, so the emitter adds the FALSE
+/// bridge `(le a b = false) = (b < a)`, normalizes the Bool negation, and closes
+/// the linear residual with `omega`. Before this the negated premise was
+/// rejected and the law stayed bounded (`universal:false`).
+#[test]
+fn lean_proves_negated_premise_comparison_bridge_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping negated-premise bridge test: `lake` not available");
+        return;
+    }
+    let source = "module LeTotal\n    intent = \"not(le a b) implies le b a\"\n    effects []\n\n\
+        type Nat\n    Z\n    S(Nat)\n\n\
+        fn le(x: Nat, y: Nat) -> Bool\n    match x\n        Nat.Z -> true\n        Nat.S(z) -> match y\n            Nat.Z -> false\n            Nat.S(w) -> le(z, w)\n\n\
+        verify le law leTotality\n    given a: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]\n    given b: Nat = [Nat.Z, Nat.S(Nat.Z), Nat.S(Nat.S(Nat.Z))]\n    when Bool.not(le(a, b))\n    le(b, a) => true\n";
+    let summary = proof_check_summary(source, "lean", "aver-letotality");
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "the negated-premise comparison bridge must close le-totality as a universal\n{summary}"
+    );
+}


### PR DESCRIPTION
## What

A conditional law whose premise is a **negated** Peano comparison — `when Bool.not(le a b) -> le b a => true`, the totality of `<=` — was rejected by the comparison-bridge recognizer and stayed bounded. The bridge `(le a b = true) = (a <= b)` can't rewrite the negated hypothesis `(!le a b) = true`.

This emits the **false bridge** `(f a b = false) = (complement)` — the `omega`-ready negation of each relation's Prop (`<=` → `b < a`, `<` → `b <= a`, `=` → `a != b`) — alongside the existing true bridge. The closer normalizes the Bool negation (`Bool.not_eq_true'`), bridges both the goal and the premise, and discharges the linear residual with `omega`. The recognizer is extended to accept `when Bool.not(<compare>)` and the law drops its bounded-domain disjunctions (`omit_domain`).

## Soundness

Sound-by-floor, exactly like the true bridge: a misrecognized relation fails its own induction proof and lands on `sorry` (caught, `universal:false`), never a false theorem. The closer is also `sorry`-floored. Both `le`-totality and its `<` twin verify kernel-clean (`[propext, Quot.sound]`).

## Validation

| Gate | Result |
|---|---|
| Lean prod corpus | **35 universal / 3 partial** — unchanged |
| `proof_spec` | **186 / 0** (+ a negated-premise comparison-bridge test) |
| un-negated comparison laws (`prop_70` etc.) | unchanged |
| `clippy --lib -D warnings`, `cargo fmt --all` | clean |
| Dafny | unaffected — this diff is Lean-only |

## Next

The negated comparison premise is one of the helpers the sortedness / insertion family needs (`le a b = false -> le b a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193JLEireejXusNFkk1HeHi
