### PR TITLE
proof: prove single-list conditional laws universally via a try-universal probe

### DIFF
--- a/proof-corpus/decomposed/handwritten/all_zero_sum.av
+++ b/proof-corpus/decomposed/handwritten/all_zero_sum.av
@@ -1,0 +1,35 @@
+module AllZeroSum
+    intent =
+        "Single-list conditional: when every element of a list is zero, its per-element sum is zero."
+    effects []
+
+type Nat
+    Z
+    S(Nat)
+
+fn plus(x: Nat, y: Nat) -> Nat
+    match x
+        Nat.Z -> y
+        Nat.S(z) -> Nat.S(plus(z, y))
+
+fn allZero(xs: List<Nat>) -> Bool
+    match xs
+        [] -> true
+        [h, ..t] -> match h
+            Nat.Z -> allZero(t)
+            Nat.S(z) -> false
+
+fn sumList(xs: List<Nat>) -> Nat
+    match xs
+        [] -> Nat.Z
+        [h, ..t] -> plus(h, sumList(t))
+
+verify sumList law sumCons
+    given h: Nat = [Nat.Z, Nat.S(Nat.Z)]
+    given t: List<Nat> = [[], [Nat.Z], [Nat.S(Nat.Z)]]
+    sumList(List.concat([h], t)) => plus(h, sumList(t))
+
+verify sumList law sumAllZero
+    given xs: List<Nat> = [[], [Nat.Z], [Nat.Z, Nat.Z]]
+    when allZero(xs)
+    sumList(xs) => Nat.Z

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1884,9 +1884,17 @@ pub(in crate::codegen::lean) fn recognize_conditional_inductive_generic(
         .enumerate()
         .filter(|(i, g)| *i != target_idx && g.type_name.trim().starts_with("List<"))
         .count();
-    if other_lists != 1 {
+    // The two-list (exactly one partner) shape is the proven binary recursion —
+    // always attempted universally (unchanged). The single-list shape (zero
+    // partners — sortedness, json roundtrips, the per-element-fold-with-Bool-fold
+    // premise) is the Gap-1 SPECULATIVE case: too diverse to classify statically
+    // (the generic portfolio closes some and `sorry`s others), so it is admitted
+    // only under the speculative probe / commit driver — try-universal, fall back
+    // to the bounded sampled statement. More than one partner declines outright.
+    if other_lists > 1 {
         return false;
     }
+    let single_list = other_lists == 0;
     // Exclusive with the bespoke arms (they run first; keep the `omit_domain`
     // gate single-valued so the statement driver and the emit agree).
     if recognize_conditional_comparison_bridge(law, ctx)
@@ -1902,7 +1910,29 @@ pub(in crate::codegen::lean) fn recognize_conditional_inductive_generic(
     // would `sorry`; declining keeps such a law on its sound bounded fallback.
     // This is the principle made structural: the generic driver proves a
     // conditional law THROUGH its Aver helper laws, never by guessing.
-    !earlier_law_lemmas(vb, law, ctx).is_empty()
+    if earlier_law_lemmas(vb, law, ctx).is_empty() {
+        return false;
+    }
+    if single_list {
+        // Class-1 recursion-incompatibility: a cone fn that DECREMENTS a co-given
+        // (a non-target given) synchronously with the list — `drop`/`take` over a
+        // free `Nat` (`prop_39`'s `elem(x, drop(y, z))`) — is not closed by plain
+        // induction on the target list (the cons IH lands at the wrong
+        // predecessor of the co-given), so it keeps its sound bounded fallback.
+        if law_recurses_on_cogiven(law, ctx, target_idx) {
+            return false;
+        }
+        // SPECULATIVE: a single-list conditional is admitted only under an active
+        // probe pass (admit all, to measure which close) or a commit that
+        // recorded THIS `fn.law` as one that closed universally. The default
+        // state admits nothing, so single-list conditionals stay byte-identical
+        // to their pre-mechanism bounded fallback.
+        let id = format!("{}.{}", vb.fn_name, law.name);
+        if !super::super::tactic_ir::speculative::admits(&id) {
+            return false;
+        }
+    }
+    true
 }
 
 /// Close a conditional inductive law GENERICALLY: list induction on the
@@ -1975,6 +2005,23 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
     } else {
         format!("intro {} h_when", after.join(" "))
     };
+    // The `sorry` floor. Under the speculative PROBE pass it carries an
+    // `AVERSPEC_SORRY:<fn.law>` trace so a non-closing single-list portfolio is
+    // observable in the build log (Lean's `first` never runs the floor's trace
+    // when an earlier branch closes). Both induction arms share the floor: if
+    // EITHER arm falls through, the law did not close universally.
+    let floor = if super::super::tactic_ir::speculative::probing() && others.is_empty() {
+        // Record HERE (not at the recognizer's `admits`): the probe sink must
+        // hold only laws that actually emit this trace floor. A single-list
+        // candidate the recognizer admits but whose `∀`-theorem is then suppressed
+        // (`skip_universal` — e.g. a singleton-domain const-RHS law) emits no
+        // floor, never traces, and so must NOT be counted "closed".
+        let id = format!("{}.{}", vb.fn_name, law.name);
+        super::super::tactic_ir::speculative::record_probed(&id);
+        format!("    | (trace \"AVERSPEC_SORRY:{id}\"; sorry)")
+    } else {
+        "    | sorry".to_string()
+    };
     let mut body = vec![format!("  intro {}", before.join(" "))];
     body.extend([
         format!("  induction {target} with"),
@@ -1984,7 +2031,7 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         "    first".to_string(),
         format!("    | ({case_other}simp_all [{with_append}] <;> done)"),
         format!("    | (simp_all [{defs_pool}] <;> done)"),
-        "    | sorry".to_string(),
+        floor.clone(),
         "  | cons hd tl ih =>".to_string(),
         format!("    {arm_intro}"),
         format!("    {norm}"),
@@ -1996,7 +2043,12 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         format!("    | (simp only [{with_append}] <;> simp_all [{defs_pool}, h_when] <;> done)"),
         format!("    | (split <;> simp_all [{defs_pool}, h_when] <;> done)"),
         format!("    | (simp_all [{defs_pool}, h_when] <;> done)"),
-        "    | sorry".to_string(),
+        // Single-list per-element-fold shape (`when allZ(xs) -> sumN(xs) => Z`):
+        // the cons-head premise (`allZ (hd :: tl)` unfolds to a match on `hd`)
+        // needs the head split before the conditional IH applies. Fail-closed for
+        // a non-inductive head (`cases hd` on an `Int` fails, `first` advances).
+        format!("    | (cases hd <;> simp_all [{defs_pool}, h_when] <;> done)"),
+        floor,
     ]);
     Some(AutoProof {
         support_lines: Vec::new(),
@@ -2383,6 +2435,71 @@ fn find_list_induction_target(law: &VerifyLaw) -> Option<usize> {
     law.givens
         .iter()
         .position(|given| given.type_name.trim().starts_with("List<"))
+}
+
+/// Whether the law applies some fn that DECREMENTS a CO-GIVEN (a given other than
+/// the list induction `target_idx`) at the parameter position that fn recurses
+/// on — the drop/take-over-a-free-`Nat` shape. In `elem(x, drop(y, z))` the cone
+/// fn `drop` recurses by decrementing its first parameter (the `Nat` `y`, a
+/// co-given) in lockstep with peeling the list `z`; plain induction on the target
+/// list `z` does not track `y`'s decrement, so the cons IH lands at the wrong
+/// predecessor and the generic portfolio cannot close it. Such a single-list
+/// conditional must keep its sound bounded fallback rather than be admitted
+/// speculatively. Scans `lhs`, `rhs`, and the `when` premise; conservative
+/// (`param_decremented_in_recursion` only fires on the clean succ-binder shape).
+fn law_recurses_on_cogiven(law: &VerifyLaw, ctx: &CodegenContext, target_idx: usize) -> bool {
+    use crate::ast::Expr;
+    let cogivens: BTreeSet<&str> = law
+        .givens
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != target_idx)
+        .map(|(_, g)| g.name.as_str())
+        .collect();
+    fn scan(
+        expr: &crate::ast::Spanned<Expr>,
+        cogivens: &BTreeSet<&str>,
+        ctx: &CodegenContext,
+    ) -> bool {
+        match &expr.node {
+            Expr::FnCall(callee, args) => {
+                if let Some(name) = super::shared::expr_dotted_name(callee)
+                    && let Some(fd) =
+                        ctx.fn_def_by_name(&name, ctx.active_module_scope().as_deref())
+                {
+                    for (i, arg) in args.iter().enumerate() {
+                        let arg_is_cogiven = matches!(
+                            &arg.node,
+                            Expr::Ident(n) | Expr::Resolved { name: n, .. } if cogivens.contains(n.as_str())
+                        );
+                        if arg_is_cogiven
+                            && crate::codegen::recursion::detect::param_decremented_in_recursion(
+                                fd, i,
+                            )
+                        {
+                            return true;
+                        }
+                    }
+                }
+                args.iter().any(|a| scan(a, cogivens, ctx)) || scan(callee, cogivens, ctx)
+            }
+            Expr::Attr(e, _) | Expr::Neg(e) | Expr::ErrorProp(e) => scan(e, cogivens, ctx),
+            Expr::BinOp(_, l, r) => scan(l, cogivens, ctx) || scan(r, cogivens, ctx),
+            Expr::Constructor(_, payload) => {
+                payload.as_ref().is_some_and(|e| scan(e, cogivens, ctx))
+            }
+            Expr::List(es) | Expr::Tuple(es) => es.iter().any(|e| scan(e, cogivens, ctx)),
+            Expr::Match { subject, arms } => {
+                scan(subject, cogivens, ctx)
+                    || arms.iter().any(|arm| scan(&arm.body, cogivens, ctx))
+            }
+            _ => false,
+        }
+    }
+    [Some(&law.lhs), Some(&law.rhs), law.when.as_ref()]
+        .into_iter()
+        .flatten()
+        .any(|e| scan(e, &cogivens, ctx))
 }
 
 /// Which map query a fold-homomorphism law inspects on the map built by the

--- a/src/codegen/lean/tactic_ir.rs
+++ b/src/codegen/lean/tactic_ir.rs
@@ -487,6 +487,145 @@ pub mod minimize {
     }
 }
 
+/// The speculative-universal driver state — the "try-universal,
+/// fall-back-to-sampled" mechanism for SINGLE-LIST conditional laws (the Gap-1
+/// statement-form decision layer; analog of [`minimize`] but choosing the
+/// theorem's STATEMENT FORM, not collapsing a tactic portfolio).
+///
+/// A single-list `when`-law (zero partner lists — sortedness, the
+/// per-element-fold-with-Bool-fold-premise shape, json roundtrips) cannot be
+/// statically classified as "the generic conditional driver will close it
+/// universally": the shapes are too diverse. So the decision is made
+/// EMPIRICALLY by a probe build, exactly as `--minimize` learns the winning
+/// branch from one instrumented build:
+///   - [`begin_probe`] makes [`admits`] return `true` for EVERY such law (so the
+///     probe emit states each universally, floored with an `AVERSPEC_SORRY:<id>`
+///     trace) and records the admitted `fn.law` ids in a sink.
+///   - one `lake build` runs; a law whose portfolio fell through to the trace
+///     floor (didn't close) surfaces its id in the build log (see
+///     [`parse_failures`]).
+///   - [`set_committed`] is then given `probed − failures` (the laws that
+///     CLOSED). In the committed (Off) mode [`admits`] returns `true` only for
+///     that set, so the re-emit states the closed laws universally and the rest
+///     fall back to their sound bounded sampled-domain statement.
+///
+/// `COMMITTED` PERSISTS across the commit re-emit, any `--minimize` re-emit, and
+/// the final `--check` build (the recognizer is the single source of truth for
+/// the statement form, the `omit_domain` driver, the class marker, AND the proof
+/// emit — all keyed on [`admits`], so they always agree). The default state
+/// (`Off` + `COMMITTED = None`) admits nothing, leaving single-list conditionals
+/// on their current bounded fallback — byte-identical to before this mechanism.
+pub mod speculative {
+    use std::cell::RefCell;
+    use std::collections::HashSet;
+
+    #[derive(Clone, PartialEq)]
+    enum Mode {
+        Off,
+        Probe,
+    }
+
+    thread_local! {
+        // (mode, committed `fn.law` ids admitted in Off mode, probe sink).
+        static STATE: RefCell<(Mode, Option<HashSet<String>>, HashSet<String>)> =
+            RefCell::new((Mode::Off, None, HashSet::new()));
+    }
+
+    /// Enter the probe pass: [`admits`] returns `true` for every single-list
+    /// candidate (and records it), so the emit states each universally with an
+    /// `AVERSPEC_SORRY` trace floor. Clears the probe sink.
+    pub fn begin_probe() {
+        STATE.with(|s| {
+            let mut st = s.borrow_mut();
+            st.0 = Mode::Probe;
+            st.2 = HashSet::new();
+        });
+    }
+
+    /// Commit the empirically-determined set of laws that CLOSED universally:
+    /// switch to Off mode where [`admits`] returns `true` only for `closed`.
+    /// Persists through subsequent re-emits and the `--check` build.
+    pub fn set_committed(closed: HashSet<String>) {
+        STATE.with(|s| {
+            let mut st = s.borrow_mut();
+            st.0 = Mode::Off;
+            st.1 = Some(closed);
+        });
+    }
+
+    /// Full reset to the default (admit nothing) — the fail-safe path and the
+    /// no-candidate skip both restore byte-identical baseline emission.
+    pub fn clear() {
+        STATE.with(|s| *s.borrow_mut() = (Mode::Off, None, HashSet::new()));
+    }
+
+    /// Whether a single-list speculative law with this `fn.law` id should be
+    /// stated universally. In probe mode: always. In Off mode: only if it is in
+    /// the committed-closed set (`None` ⇒ admit nothing). Pure — does NOT record;
+    /// the probe sink is populated at the floor-emission site (see
+    /// [`record_probed`]) so it counts only laws that actually emit a trace floor.
+    pub fn admits(id: &str) -> bool {
+        STATE.with(|s| {
+            let st = s.borrow();
+            match st.0 {
+                Mode::Probe => true,
+                Mode::Off => st.1.as_ref().is_some_and(|set| set.contains(id)),
+            }
+        })
+    }
+
+    /// Whether a probe pass is active — the emit reads this to floor each
+    /// speculative portfolio with the `AVERSPEC_SORRY:<id>` trace instead of a
+    /// bare `sorry`, so a non-closing law is observable in the build log.
+    pub fn probing() -> bool {
+        STATE.with(|s| s.borrow().0 == Mode::Probe)
+    }
+
+    /// Record that this law actually EMITTED an `AVERSPEC_SORRY` trace floor in
+    /// the probe — i.e. its universal `∀`-theorem was emitted (not suppressed by
+    /// `skip_universal`) and can surface a failure. `closed = probed_ids −
+    /// parse_failures`, so the sink must hold exactly the laws that can trace,
+    /// never one whose theorem was dropped (which would never trace and be
+    /// miscounted "closed"). Called only under [`probing`].
+    pub fn record_probed(id: &str) {
+        STATE.with(|s| {
+            s.borrow_mut().2.insert(id.to_string());
+        });
+    }
+
+    /// The `fn.law` ids that emitted a probe trace floor (single-list candidates
+    /// whose universal `∀`-theorem was actually emitted). `closed = probed_ids −
+    /// parse_failures`.
+    pub fn probed_ids() -> HashSet<String> {
+        STATE.with(|s| s.borrow().2.clone())
+    }
+
+    /// Parse the `fn.law` ids whose speculative portfolio fell through to its
+    /// `AVERSPEC_SORRY:<id>` trace floor (did NOT close) from a `lake build` log.
+    /// `first` commits to the leftmost closing branch and never runs a later
+    /// branch's trace, so the marker surfaces IFF the portfolio reached its
+    /// sorry floor — a direct "this law did not close", no warning-location
+    /// mapping or separate `#print axioms` run required.
+    pub fn parse_failures(build_output: &str) -> HashSet<String> {
+        const MARKER: &str = "AVERSPEC_SORRY:";
+        let mut failed = HashSet::new();
+        for line in build_output.lines() {
+            let Some(pos) = line.find(MARKER) else {
+                continue;
+            };
+            let rest = &line[pos + MARKER.len()..];
+            let id: String = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '.')
+                .collect();
+            if !id.is_empty() {
+                failed.insert(id);
+            }
+        }
+        failed
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -645,6 +784,55 @@ mod tests {
             minimized.render(),
             vec!["intro a b".to_string(), "the_winner <;> omega".to_string()]
         );
+    }
+
+    #[test]
+    fn speculative_parse_failures_reads_fn_law_ids() {
+        // A single-list portfolio that fell through to its floor traces
+        // `AVERSPEC_SORRY:<fn.law>`; one that closed never runs the floor's
+        // trace, so its id is absent. The id allows dots and underscores.
+        let log = "\
+info: F.lean:50:5: AVERSPEC_SORRY:parseArrayElems.renderJsonListElemsRoundtrip
+info: F.lean:62:5: AVERSPEC_SORRY:parseObjFields.renderJsonEntriesFieldsRoundtrip
+warning: declaration uses 'sorry'
+";
+        let failed = super::speculative::parse_failures(log);
+        assert!(failed.contains("parseArrayElems.renderJsonListElemsRoundtrip"));
+        assert!(failed.contains("parseObjFields.renderJsonEntriesFieldsRoundtrip"));
+        assert_eq!(failed.len(), 2);
+        // A closed law (no trace) is not reported failed.
+        assert!(!failed.contains("sumList.sumAllZero"));
+    }
+
+    #[test]
+    fn speculative_admits_only_committed_in_off_mode() {
+        use super::speculative;
+        // Default: admit nothing (single-list conditionals stay on their bounded
+        // fallback — byte-identical to before the mechanism).
+        speculative::clear();
+        assert!(!speculative::admits("f.law"));
+        assert!(!speculative::probing());
+        // Probe: admit everything; the sink is populated by `record_probed` at
+        // the floor-emission site (not by `admits`), so it holds only laws that
+        // actually emitted a trace floor.
+        speculative::begin_probe();
+        assert!(speculative::probing());
+        assert!(speculative::admits("f.law"));
+        assert!(speculative::admits("g.other"));
+        assert!(speculative::probed_ids().is_empty());
+        speculative::record_probed("f.law");
+        speculative::record_probed("g.other");
+        assert!(speculative::probed_ids().contains("f.law"));
+        assert!(speculative::probed_ids().contains("g.other"));
+        // Commit: admit only the closed set, in Off mode.
+        let mut closed = std::collections::HashSet::new();
+        closed.insert("f.law".to_string());
+        speculative::set_committed(closed);
+        assert!(!speculative::probing());
+        assert!(speculative::admits("f.law"));
+        assert!(!speculative::admits("g.other"));
+        speculative::clear();
+        assert!(!speculative::admits("f.law"));
     }
 
     #[test]

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5130,6 +5130,13 @@ pub(super) fn cmd_proof(
             // evaluation path to go vacuous through).
             ctx.sample_expected = collect_verify_ground_truth(file, &module_root);
             cmd_proof_lean(file, output_dir, &mut ctx, verify_mode);
+            // Speculative-universal: a SINGLE-LIST conditional law cannot be
+            // statically classified as universal-closeable, so try each
+            // universally in one probe build and re-emit with the ones that
+            // CLOSED stated universally and the rest on their bounded fallback
+            // (try-universal, fall-back-to-sampled — analog of `--minimize` for
+            // the statement form). No-op when the file has no such candidate.
+            run_lean_speculative(file, output_dir, &mut ctx, verify_mode);
             // `--minimize`: learn each portfolio's winning branch from one
             // instrumented build, then re-emit collapsed (fail-safe — restores
             // the normal proof if the collapsed project does not build).
@@ -7219,6 +7226,137 @@ fn cmd_proof_lean(
 
     let build_hint = format!("cd {} && lake build", output_dir);
     write_codegen_output(file, output_dir, "Lean 4", &build_hint, &output);
+}
+
+/// Speculative-universal (Lean): the "try-universal, fall-back-to-sampled"
+/// statement-form decision for SINGLE-LIST conditional laws (Gap 1). A single
+/// list given with a `when` premise is too diverse to classify statically — the
+/// generic conditional driver closes some (sortedness, the per-element-fold
+/// shape) and `sorry`s others (the json roundtrips, whose conclusion is a
+/// String/parse equation the list-induction portfolio cannot peel). So the
+/// decision is made EMPIRICALLY, exactly as `--minimize` learns a portfolio's
+/// winning branch from one instrumented build:
+///
+/// 1. PROBE — state EVERY single-list candidate universally (floored with an
+///    `AVERSPEC_SORRY:<fn.law>` trace) and run one `lake build`. A candidate
+///    whose portfolio fell through to the floor surfaces its id in the log (it
+///    did not close). The bounded sample cross-checks still pass, so the probe
+///    build always succeeds (a `sorry` is a warning).
+/// 2. COMMIT — re-emit with the laws that CLOSED (`probed − failed`) stated
+///    universally and the rest reverted to their sound bounded sampled-domain
+///    statement.
+///
+/// No-op when the file has no single-list candidate (the probe emit records
+/// none — the byte-identical baseline is restored without a build, so the
+/// decomposed corpus pays nothing). Fail-safe: if the committed project does not
+/// build, the bounded baseline is restored. `lake`'s content-addressed cache
+/// keeps the probe + commit builds cheap.
+fn run_lean_speculative(
+    file: &str,
+    output_dir: &str,
+    ctx: &mut codegen::CodegenContext,
+    verify_mode: &super::cli::ProofVerifyMode,
+) {
+    use aver::ast::{TopLevel, VerifyKind};
+    use aver::codegen::lean::tactic_ir::speculative;
+    use std::process::Command;
+
+    // Cheap necessary-condition pre-filter: the speculative path only fires for a
+    // `when`-law with EXACTLY ONE `List<_>` given (the single-list shape —
+    // `other_lists == 0`). With no such law in the file the probe would admit
+    // nothing, so skip the extra emits + build entirely and leave the baseline
+    // untouched (a true no-op — the decomposed corpus pays nothing).
+    let has_single_list_candidate = ctx.items.iter().any(|item| {
+        let TopLevel::Verify(vb) = item else {
+            return false;
+        };
+        let VerifyKind::Law(law) = &vb.kind else {
+            return false;
+        };
+        law.when.is_some()
+            && law
+                .givens
+                .iter()
+                .filter(|g| g.type_name.trim().starts_with("List<"))
+                .count()
+                == 1
+    });
+    if !has_single_list_candidate {
+        return;
+    }
+
+    let lake_ok = Command::new("lake")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !lake_ok {
+        // Leave the baseline (already on disk) untouched.
+        return;
+    }
+    let build = |dir: &str| -> (bool, String) {
+        match Command::new("lake").arg("build").current_dir(dir).output() {
+            Ok(o) => (
+                o.status.success(),
+                format!(
+                    "{}{}",
+                    String::from_utf8_lossy(&o.stdout),
+                    String::from_utf8_lossy(&o.stderr)
+                ),
+            ),
+            Err(_) => (false, String::new()),
+        }
+    };
+
+    // 1) PROBE emit — single-list conditionals stated universally with trace floors.
+    speculative::begin_probe();
+    cmd_proof_lean(file, output_dir, ctx, verify_mode);
+    let probed = speculative::probed_ids();
+    if probed.is_empty() {
+        // No single-list candidate — restore the byte-identical baseline (no
+        // build needed; the probe emit only differs on single-list laws).
+        speculative::clear();
+        cmd_proof_lean(file, output_dir, ctx, verify_mode);
+        return;
+    }
+
+    let (probe_ok, probe_out) = build(output_dir);
+    if !probe_ok {
+        // A `sorry` is only a warning, so the probe build succeeds even when
+        // every candidate fails to close — a HARD failure means a speculative
+        // statement did not elaborate, and the per-law verdict can't be trusted.
+        // Restore the bounded baseline rather than commit a guess.
+        speculative::clear();
+        cmd_proof_lean(file, output_dir, ctx, verify_mode);
+        return;
+    }
+    let failed = speculative::parse_failures(&probe_out);
+    let closed: std::collections::HashSet<String> = probed.difference(&failed).cloned().collect();
+
+    // 2) COMMIT re-emit — the laws that closed go universal, the rest fall back.
+    speculative::set_committed(closed.clone());
+    cmd_proof_lean(file, output_dir, ctx, verify_mode);
+
+    // 3) FAIL-SAFE verify — the committed project must still build.
+    let (commit_ok, _) = build(output_dir);
+    if !commit_ok {
+        speculative::clear();
+        cmd_proof_lean(file, output_dir, ctx, verify_mode);
+        eprintln!(
+            "{}",
+            "speculative-universal: committed proof did not build — restored the bounded baseline"
+                .yellow()
+        );
+    } else if !closed.is_empty() {
+        println!(
+            "{}",
+            format!(
+                "speculative-universal: proved {} single-list conditional law(s) universally",
+                closed.len()
+            )
+            .green()
+        );
+    }
 }
 
 /// `--minimize` (Lean): collapse each emitted `first | … | sorry` portfolio to

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -1162,6 +1162,71 @@ fn proof_lean_proves_list_prod_kernel_clean_universal() {
 }
 
 #[test]
+fn proof_lean_speculative_proves_single_list_conditional_universal() {
+    // Gap-1 speculative-universal mechanism: a SINGLE-LIST conditional law
+    // (`when allZero(xs) -> sumList(xs) = Z`) cannot be statically classified as
+    // universal-closeable (the generic conditional driver closes some single-list
+    // shapes and `sorry`s others), so the probe states it universally, learns
+    // from ONE instrumented build that it CLOSES — the `cases hd` rung splits the
+    // per-element premise (`allZero (hd :: tl)`) so the conditional IH applies —
+    // and commits it as a genuine universal. Result is `universal:true`, 0
+    // sorries, `#print axioms` clean of `sorryAx`. The helper `sumCons` is the
+    // homomorphism the conditional law decomposes through. Regression guard for
+    // the whole single-list conditional try-universal-fall-back-to-sampled path.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping lean speculative-universal test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let out = temp_output_dir("aver-speculative-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg("proof-corpus/decomposed/handwritten/all_zero_sum.av")
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean = std::fs::read_to_string(out.join("AllZeroSum.lean")).expect("read AllZeroSum.lean");
+    // The conditional law must be COMMITTED as a universal-classed theorem (no
+    // sampled-domain disjunction premises) — the probe promoted it after the
+    // build proved it closes.
+    assert!(
+        lean.contains("-- aver:law-class sumList_law_sumAllZero universal"),
+        "sumAllZero must be committed as a universal-classed conditional:\n{lean}"
+    );
+    // The committed proof must carry neither the probe's transient trace floor
+    // nor a reachable sorry.
+    assert!(
+        !lean.contains("AVERSPEC_SORRY"),
+        "the committed proof must not carry the probe's trace floor:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["universal"].as_bool(),
+        ),
+        (Some(true), Some(0), Some(true)),
+        "the single-list conditional must kernel-prove as a GENUINE universal \
+         (passed, 0 sorries, universal:true).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
 fn proof_lean_proves_nat_tri_kernel_clean_universal() {
     // Nat + Add corner of the accumulator-fold grid: a tail-recursive
     // triangular-sum equals its recurrence. The Peano-`Nat` driver fixes the


### PR DESCRIPTION
## Co i dlaczego

A conditional `verify ... law` over a **single list** (no partner — sortedness, the per-element fold under a Bool-fold premise) can't be classified statically as one the generic conditional driver will close universally: some close, others (the json round-trips, whose conclusion is a parse/string equation the list-induction portfolio can't peel) don't. Stating them all universally regresses the non-closing ones to an honest `sorry`; leaving them all bounded forgoes the ones that do close.

This decides it **empirically**, the way `--minimize` learns a portfolio's winning branch from one build: state every single-list candidate universally with a sorry floor that traces its `fn.law` identity, run one `lake build`, then re-emit with the laws that **closed** stated universally and the rest reverted to their sound bounded sampled statement.

The recognizer stays the single source of truth (statement form, domain-omission, class marker, proof emit all key on it), so the probe and the commit agree, and a false "closed" verdict degrades to a **caught** failure (`#print axioms` sees the sorry → not credited universal) rather than a false universal credit.

## Zmiany

- `tactic_ir.rs` — a `speculative` thread-local (probe / committed set), sibling of the `minimize` pass
- `induction.rs` — single-list relaxation of `recognize_conditional_inductive_generic`, gated on the probe **and** a recursion-compatibility check (a cone fn that decrements a co-given in lockstep with the list — `drop`/`take` over a free `Nat` — keeps its bounded fallback); a cons-head split rung that closes the per-element-fold-under-premise shape
- `commands.rs` — `run_lean_speculative` orchestration: cheap pre-filter (a file with no single-list `when`-law pays nothing) → probe → build → commit closed-as-universal / rest bounded → fail-safe restore
- `all_zero_sum.av` demo + a kernel-clean regression test + 2 unit tests

## Walidacja (zero regresji)

| sweep | wynik |
|---|---|
| Lean prod | 35 FULL, 3 PARTIAL (prop_42/43/44, pre-existing) — unchanged |
| Lean isaplanner | prop_60 PARTIAL pre-existing; **bonus: `lastConsNonEmpty` bounded→universal** |
| json | sorries:0, passed:true (probe reverts the 2 round-trips to bounded) — unchanged |
| proof_spec | **187/0** (186 baseline + the new test) |
| Dafny | PASS=24 — unchanged (Lean-only) |
| clippy `--lib` + `--features wasm,wasip2` · fmt | clean |

Demo + bonus win verified `#print axioms` = `[propext, Quot.sound]` (kernel-clean, no `sorryAx`/`ofReduceBool`).

**Adversarial panel** (3 axes — soundness / out-of-corpus regression / orchestration — with per-finding refutation): one minor reporting over-count found **and fixed** (probe-sink recording moved to the trace-floor emission site so it counts only laws that actually emit a floor); everything else refuted. Zero soundness/regression defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdSMXQ2vHRw29C8YY5hVqW
