### PR TITLE
proof: let the probe decide every conditional law; drop the bespoke membership emitter

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -30,11 +30,6 @@ pub(crate) use induction::admitted_dep_law_theorems;
 /// and the proof emitter stay in lockstep.
 pub(in crate::codegen::lean) use induction::recognize_conditional_comparison_bridge;
 
-/// Twin of [`recognize_conditional_comparison_bridge`] for the conditional-
-/// INDUCTIVE list-predicate family (membership monotonicity / identity). Also
-/// feeds the `omit_domain` statement driver, kept in lockstep with the emitter.
-pub(in crate::codegen::lean) use induction::recognize_conditional_inductive_list;
-
 /// Generic conditional-inductive close (the decomposition path: list induction
 /// threading the premise, then `simp_all` over the fn defs and the laws-as-
 /// lemmas pool). Also feeds the `omit_domain` statement driver, kept in
@@ -307,21 +302,6 @@ fn emit_verify_law_forall_auto_proof_inner(
     if law.when.is_some()
         && let Some(proof) =
             induction::emit_conditional_comparison_bridge_law(vb, law, ctx, &intro_names)
-    {
-        return Some(proof);
-    }
-
-    // Conditional-INDUCTIVE list-predicate laws (the membership family: `prop_36`
-    // `when elem(x,y) -> elem(x, y ++ z) => true`, `prop_71` `when not(eqNat(x,y))
-    // -> elem(x, ins(y,xs)) = elem(x,xs)`). Tried right after the flat comparison
-    // bridge and, like it, BEFORE the pinned dispatch (no `when`-law is pinned
-    // `Induction`). Proves by induction on the list given, threading the premise
-    // into the cons IH. Same `omit_domain` universal-statement plumbing as the
-    // bridge family; any other conditional shape declines and keeps the bounded
-    // guarded-domain fallback.
-    if law.when.is_some()
-        && let Some(proof) =
-            induction::emit_conditional_inductive_list_law(vb, law, ctx, &intro_names)
     {
         return Some(proof);
     }

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1686,7 +1686,44 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
     };
     let with_append =
         format!("{defs_pool}, List.cons_append, List.nil_append, List.singleton_append");
+    // Peano comparison bridges (`(f a b = true) = (a R b)`) for the relations the
+    // law mentions — premise included (seeded into `extra`). They let `omega`
+    // discharge a dispatcher branch a COMPARISON premise rules out (`prop_86`'s
+    // `when lt(x,y)` needs `eqNat x y = false`, which falls out of the `<`/`=`
+    // bridges + `omega`). Empty for a law with no Peano comparison, so a
+    // non-comparison conditional is byte-unchanged. Sound-by-floor: a misrecognized
+    // op fails its own bridge proof and degrades to a sorry, never a false bridge.
+    let bridge_uid = format!(
+        "{}_{}_L{}",
+        aver_name_to_lean(&vb.fn_name),
+        aver_name_to_lean(&law.name),
+        vb.line
+    );
+    let mut bridge_extra: BTreeSet<String> = BTreeSet::new();
+    if let Some(when) = &law.when {
+        crate::codegen::proof_recognize::collect_called_fns(when, &mut bridge_extra);
+    }
+    let (bridge_support, bridge_names, _bridged) =
+        lean_nat_lift_support(law, ctx, &bridge_uid, &bridge_extra);
+    let cmp_bridges: Vec<String> = bridge_names
+        .into_iter()
+        .filter(|n| n.ends_with("_isNatLe") || n.ends_with("_isNatLt") || n.ends_with("_isNatEq"))
+        .collect();
     let norm = "(try simp only [Bool.not_eq_true, Bool.not_eq_false] at h_when)".to_string();
+    // Bridge rung: rewrite the COMPARISON premise (`lt x y = true`) and the goal's
+    // comparison calls into `<`/`≤`/`=` via the kernel-proved bridges, dispatch the
+    // subject's `split`, then let `omega` discharge the branch the premise rules
+    // out (`prop_86`). Emitted only when the law has a Peano comparison — otherwise
+    // the conditional emit is byte-identical to before.
+    let bridge_rung: Option<String> = if cmp_bridges.is_empty() {
+        None
+    } else {
+        let defs_pool_br = format!("{defs_pool}, {}", cmp_bridges.join(", "));
+        let bridges_csv = cmp_bridges.join(", ");
+        Some(format!(
+            "    | (simp only [{with_append}, {bridges_csv}] at h_when ⊢ <;> (split <;> simp_all [{defs_pool_br}]) <;> (try omega) <;> done)"
+        ))
+    };
     // The OTHER list givens (a binary recursion like zip-reverse inducts on
     // `xs` but must case-split the equal-length partner `ys`). At most one is
     // handled structurally; the membership-style `split` branches cover the
@@ -1836,7 +1873,15 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         // verified fn unfolded then `simp_all`; the bare `simp_all` above leaves
         // it under a stuck dependent match.
         format!("    | (simp only [{subject}] <;> simp_all [{defs_pool}, h_when] <;> done)"),
-        floor.clone(),
+    ]);
+    // Comparison-premise rung in the BASE case too (`prop_86`'s `elem x (ins y [])
+    // = elem x []` reduces to `elem x [y] = false`, which needs `eqNat x y = false`
+    // from `x < y` — the same bridge + `omega` the cons arm uses).
+    if let Some(rung) = &bridge_rung {
+        body.push(rung.clone());
+    }
+    body.push(floor.clone());
+    body.extend([
         "  | cons hd tl ih =>".to_string(),
         format!("    {arm_intro}"),
         format!("    {norm}"),
@@ -1856,13 +1901,20 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         // Cheap subject-unfold + split (closes the wrapper helper laws).
         subject_split_rung,
     ]);
+    // Comparison-premise rung (`prop_86`): bridges + `omega` — only when the law
+    // carries a Peano comparison.
+    if let Some(rung) = bridge_rung {
+        body.push(rung);
+    }
     // The expensive goal-directed rung — only for the wrapper shape.
     if let Some(rung) = wrapper_rung {
         body.push(rung);
     }
     body.push(floor);
+    let mut support = bridge_support;
+    support.extend(adapters);
     Some(AutoProof {
-        support_lines: adapters,
+        support_lines: support,
         body: Tactic::raw(body),
         replaces_theorem: false,
     })

--- a/src/codegen/lean/law_auto/induction.rs
+++ b/src/codegen/lean/law_auto/induction.rs
@@ -1572,304 +1572,6 @@ pub(in crate::codegen::lean) fn emit_conditional_comparison_bridge_law(
     })
 }
 
-/// Whether a `when`-law is a conditional-INDUCTIVE list-predicate law (the
-/// membership family — `prop_36` `when elem(x,y) -> elem(x, y ++ z) => true`,
-/// `prop_71` `when not(eqNat(x,y)) -> elem(x, ins(y,xs)) = elem(x,xs)`): there is
-/// a `List<_>` given to induct on, and the verified fn structurally recurses on
-/// a list parameter (so inducting on the list given peels both sides). Distinct
-/// from the flat comparison-bridge family — here the conclusion is a recursive
-/// list predicate, not an `omega`-shaped comparison, so it is proved by
-/// premise-threaded list induction rather than a bridge. Used by both the proof
-/// emitter and the `omit_domain` statement driver, which must agree.
-pub(in crate::codegen::lean) fn recognize_conditional_inductive_list(
-    vb: &VerifyBlock,
-    law: &VerifyLaw,
-    ctx: &CodegenContext,
-) -> bool {
-    let Some(when) = &law.when else {
-        return false;
-    };
-    let Some(target_idx) = find_list_induction_target(law) else {
-        return false;
-    };
-    // The bridge family owns the flat-comparison shape; never claim it here.
-    if conditional_comparison_bridge_shape(law, ctx) {
-        return false;
-    }
-    // A non-empty unfold cone is required (the induction arms `simp` the verified
-    // fn's defs); without one the portfolio has nothing to drive.
-    if law_simp_defs(ctx, vb, law).is_empty() {
-        return false;
-    }
-    // The verified fn must be a PER-ELEMENT LIST FOLD: it structurally recurses
-    // on a list parameter AND its cons arm combines the HEAD element with the
-    // recursive call (so inducting on the list given peels both sides in lockstep
-    // and the portfolio's `split <;> simp_all` closes via the IH). This gate is
-    // load-bearing — it admits `elem` (Bool) AND `count` (Nat) while excluding
-    // element-SELECTORS like `last`/`head` (`prop_59`/`prop_60`): `last`'s cons
-    // arm uses only the recursive tail (not the head), `head`'s only the head
-    // (no recursion), so neither folds — their conclusion is an element equation
-    // the membership portfolio cannot close, and admitting them would `sorry` and
-    // drop `passed`.
-    let Some(fd) = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref()) else {
-        return false;
-    };
-    if !is_per_element_list_fold(fd) {
-        return false;
-    }
-    // VALIDATED-SHAPE GATE. `omit_domain` replaces the bounded `native_decide`
-    // proof (which earns `passed`) with the universal portfolio; if that portfolio
-    // cannot close, its `sorry` floor would drop `passed` (sorries > budget). So
-    // restrict to the two shapes the probe + a measured corpus sweep proved the
-    // portfolio CLOSES, both driven by induction on the first list given:
-    //   (A) the conclusion applies the verified fn to a BUILTIN `List.concat(
-    //       <target>, _)` — the target is the spine the cons step peels
-    //       (`(h :: t) ++ z = h :: (t ++ z)`). Narrow by construction: only the
-    //       literal `List.concat` spelling qualifies, so the sole corpus hit is
-    //       `prop_36`; an append written as a USER fn (`prop_37`'s `append`)
-    //       reaches the portfolio through (B) instead, not here.
-    //   (B) target-independent premise — the `when` does not mention the
-    //       induction target, so it is a fixed side condition available in every
-    //       arm while the conclusion peels structurally. The broad branch: it
-    //       admits the whole neq-/eq-membership family (`prop_37`, `prop_46`,
-    //       `prop_47`, `prop_71`, `lemma_19`) plus `prop_38`.
-    // Other conditional-inductive shapes fail BOTH and decline — keeping their
-    // bounded `passed`: a premise that mentions the target over a non-`concat`
-    // conclusion (drop-relative `prop_39`, sort-relative `prop_49`,
-    // `prop_42`/`prop_43`/`prop_44`), and the sortedness/insertion family that
-    // needs a head-of-insert aux lemma (`prop_77`, `lemma_12`). The Bool-return
-    // gate above additionally drops element-returning `last`/`head` (`prop_59`/
-    // `prop_60`) and the `count`/`union`/`zip` value-returning list fns.
-    let target_name = &law.givens[target_idx].name;
-    let append_on_target = law_applies_verified_fn_to_concat(law, &vb.fn_name, target_name);
-    let premise_target_independent = !expr_mentions_ident(when, target_name);
-    append_on_target || premise_target_independent
-}
-
-/// Whether the law applies its verified fn to a `List.concat(<target>, _)` — the
-/// append-monotonicity shape (`elem(x, concat(y, z))` with `y` the induction
-/// target). Scans both sides of the claim.
-fn law_applies_verified_fn_to_concat(law: &VerifyLaw, fn_name: &str, target: &str) -> bool {
-    use crate::ast::Expr;
-    fn concat_first_arg_is(expr: &crate::ast::Spanned<Expr>, target: &str) -> bool {
-        let Expr::FnCall(callee, args) = &expr.node else {
-            return false;
-        };
-        super::shared::expr_dotted_name(callee).as_deref() == Some("List.concat")
-            && args
-                .first()
-                .is_some_and(|a| matches!(&a.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == target))
-    }
-    fn scan(expr: &crate::ast::Spanned<Expr>, fn_name: &str, target: &str) -> bool {
-        use crate::ast::Expr;
-        if let Expr::FnCall(callee, args) = &expr.node {
-            if super::shared::expr_dotted_name(callee).as_deref() == Some(fn_name)
-                && args.iter().any(|a| concat_first_arg_is(a, target))
-            {
-                return true;
-            }
-            if args.iter().any(|a| scan(a, fn_name, target)) {
-                return true;
-            }
-            return scan(callee, fn_name, target);
-        }
-        false
-    }
-    scan(&law.lhs, fn_name, target) || scan(&law.rhs, fn_name, target)
-}
-
-/// Whether an expression syntactically references the identifier `name`.
-/// Conservative on exotic node kinds (returns `true`): a premise whose shape we
-/// do not destructure is assumed to possibly mention the target, so it is
-/// EXCLUDED from the target-independent `(B)` branch rather than wrongly admitted
-/// — admitting a target-dependent premise there would risk a non-closing proof
-/// and a `passed` regression.
-fn expr_mentions_ident(expr: &crate::ast::Spanned<crate::ast::Expr>, name: &str) -> bool {
-    use crate::ast::Expr;
-    match &expr.node {
-        Expr::Literal(_) => false,
-        Expr::Ident(n) | Expr::Resolved { name: n, .. } => n == name,
-        Expr::Attr(e, _) | Expr::Neg(e) | Expr::ErrorProp(e) => expr_mentions_ident(e, name),
-        Expr::FnCall(callee, args) => {
-            expr_mentions_ident(callee, name) || args.iter().any(|a| expr_mentions_ident(a, name))
-        }
-        Expr::BinOp(_, l, r) => expr_mentions_ident(l, name) || expr_mentions_ident(r, name),
-        Expr::Constructor(_, payload) => payload
-            .as_ref()
-            .is_some_and(|e| expr_mentions_ident(e, name)),
-        Expr::List(es) | Expr::Tuple(es) => es.iter().any(|e| expr_mentions_ident(e, name)),
-        Expr::Match { subject, arms } => {
-            expr_mentions_ident(subject, name)
-                || arms.iter().any(|arm| expr_mentions_ident(&arm.body, name))
-        }
-        _ => true,
-    }
-}
-
-/// Whether some leaf of `expr` (descending through `match` arms) IS the bare
-/// identifier `name` — i.e. a code path that RETURNS that variable directly. For
-/// the cons head this is the SELECTOR signature: `last`'s `match zs { [] -> z ; …
-/// }` returns the head element, `head`'s cons arm is the bare head. A fold never
-/// returns the head — it only COMPARES it (`eqNat(x, z)`), so the head appears as
-/// a call argument, never as a leaf.
-fn any_leaf_is_ident(expr: &crate::ast::Spanned<crate::ast::Expr>, name: &str) -> bool {
-    use crate::ast::Expr;
-    match &expr.node {
-        Expr::Match { arms, .. } => arms.iter().any(|arm| any_leaf_is_ident(&arm.body, name)),
-        Expr::Ident(n) | Expr::Resolved { name: n, .. } => n == name,
-        _ => false,
-    }
-}
-
-/// A per-element list FOLD: the verified fn structurally recurses on a `List<_>`
-/// param AND its cons arm references the head element but NEVER returns it as a
-/// leaf (the head is COMPARED, not selected). Admits `elem` in BOTH spellings —
-/// `barbar(eqNat(x, z), elem(x, xs))` and the explicit `match eqNat(x, z) { true
-/// -> true ; false -> elem(x, xs) }` — and `count` (`match natEq(x, z) { true ->
-/// S(count …) ; false -> count … }`). Excludes element SELECTORS: `last`'s cons
-/// arm has a `[] -> z` leaf returning the head; `head` (which does not even
-/// recurse on the list, so the structural-param gate already rejects it). The
-/// cons-arm structure, not the return type, is the discriminator (so `count`'s
-/// `Nat` return qualifies alongside `elem`'s `Bool`).
-fn is_per_element_list_fold(fd: &crate::ast::FnDef) -> bool {
-    use crate::ast::{Expr, Pattern};
-    let Some(list_idx) = crate::codegen::recursion::detect::single_list_structural_param_index(fd)
-    else {
-        return false;
-    };
-    let list_param = &fd.params[list_idx].0;
-    let Some(body) = fd.body.tail_expr() else {
-        return false;
-    };
-    let Expr::Match { subject, arms } = &body.node else {
-        return false;
-    };
-    if !matches!(&subject.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == list_param)
-    {
-        return false;
-    }
-    arms.iter()
-        .find_map(|arm| {
-            let Pattern::Cons(head, _) = &arm.pattern else {
-                return None;
-            };
-            Some(expr_mentions_ident(&arm.body, head) && !any_leaf_is_ident(&arm.body, head))
-        })
-        .unwrap_or(false)
-}
-
-/// Close a conditional-inductive list-predicate law (`prop_36`, `prop_71`) as the
-/// TRUE-universal `∀ givens, <when> = true -> <claim>` by induction on the first
-/// `List` given, THREADING the premise: the premise is introduced INSIDE each
-/// arm (not before `induction`) so the cons induction hypothesis carries it as an
-/// antecedent — the essential difference from the unconditional `emit_list_induction`
-/// ladder. Each arm runs a `first | … | sorry` portfolio that unfolds the verified
-/// fn's defs + the `List.*_append` peel lemmas, normalizes a negated premise
-/// (`Bool.not_eq_true`), case-splits the recursive predicate's inner Bool
-/// dispatcher (`split`), and discharges with `simp_all` (which applies the IH at
-/// the tail using the premise-derived hypothesis). FAIL-CLOSED on two axes: any
-/// non-matching shape returns `None` (caller keeps the bounded guarded-domain
-/// proof), and every arm is `done`-terminated under a `sorry` floor, so a residual
-/// the portfolio cannot close degrades to an honest sorry (`universal:false`,
-/// `passed` via `_checked_domain`) rather than a build error or a false closure.
-pub(in crate::codegen::lean) fn emit_conditional_inductive_list_law(
-    vb: &VerifyBlock,
-    law: &VerifyLaw,
-    ctx: &CodegenContext,
-    intro_names: &[String],
-) -> Option<AutoProof> {
-    if !recognize_conditional_inductive_list(vb, law, ctx) {
-        return None;
-    }
-    let target_idx = find_list_induction_target(law)?;
-    let target = intro_names.get(target_idx)?.clone();
-    let defs = law_simp_defs(ctx, vb, law)
-        .into_iter()
-        .collect::<Vec<_>>()
-        .join(", ");
-    // The builtin `++` peel lemmas the recursive list expression needs (e.g.
-    // `(hd :: tl) ++ z = hd :: (tl ++ z)`, `[x] ++ y = x :: y`).
-    let with_append = format!("{defs}, List.cons_append, List.nil_append, List.singleton_append");
-    // Normalize a negated Bool premise (`(!p) = true` → `p = false`) so `simp_all`
-    // can use it; a no-op `try` when the premise is not negated.
-    let norm = "(try simp only [Bool.not_eq_true, Bool.not_eq_false] at h_when)".to_string();
-    // Peano comparison bridges (`(f a b = true) = (a R b)`) for the relations the
-    // law mentions — premise included. They let `omega` discharge the dispatcher
-    // branches a COMPARISON premise rules out: `prop_86` (`when lt(x,y)`) needs
-    // `eqNat x y = false`, which falls out of the `<`/`=` bridges + `omega`,
-    // whereas a same-relation premise (`prop_71`'s `eqNat`) needs no bridge and
-    // closes on the first branch below. Sound-by-floor: a misrecognized op fails
-    // its own bridge proof and degrades to a sorry, never a false bridge.
-    let law_uid = format!(
-        "{}_{}",
-        aver_name_to_lean(&vb.fn_name),
-        aver_name_to_lean(&law.name)
-    );
-    let mut extra: BTreeSet<String> = BTreeSet::new();
-    if let Some(when) = &law.when {
-        crate::codegen::proof_recognize::collect_called_fns(when, &mut extra);
-    }
-    let (bridge_support, bridge_names, _bridged) =
-        lean_nat_lift_support(law, ctx, &law_uid, &extra);
-    let cmp_bridges: Vec<String> = bridge_names
-        .into_iter()
-        .filter(|n| n.ends_with("_isNatLe") || n.ends_with("_isNatLt") || n.ends_with("_isNatEq"))
-        .collect();
-    // The `simp_all` set with the comparison bridges folded in (for the
-    // omega-closing branches); bare defs when the law has no Peano comparison.
-    let defs_br = if cmp_bridges.is_empty() {
-        defs.clone()
-    } else {
-        format!("{defs}, {}", cmp_bridges.join(", "))
-    };
-    // Arm portfolios. The measured same-relation closures (prop_36/37/38/46/47/71,
-    // lemma_19) land on the FIRST cons branch (`simp only […] at h_when ⊢ <;>
-    // (split <;> simp_all)`) and the first nil branch; the comparison-premise
-    // closure (prop_86) lands on the bridge+`omega` branches. The rest are a
-    // `done`-terminated speculative hedge (a non-closing branch throws on its
-    // `done`, so `first` advances at zero correctness cost, and at no build-time
-    // cost for an admitted law since the winning branch is tried first). The
-    // trailing `sorry` keeps the whole emit fail-closed.
-    let body = vec![
-        format!("  intro {}", intro_names.join(" ")),
-        format!("  induction {target} with"),
-        "  | nil =>".to_string(),
-        "    first".to_string(),
-        format!("    | (simp [{defs}]; done)"),
-        format!("    | (intro h_when; {norm}; simp_all [{defs}]; done)"),
-        format!(
-            "    | (intro h_when; {norm}; simp only [{defs}] <;> (split <;> simp_all [{defs_br}]) <;> (try omega) <;> done)"
-        ),
-        "    | sorry".to_string(),
-        "  | cons hd tl ih =>".to_string(),
-        "    intro h_when".to_string(),
-        format!("    {norm}"),
-        "    first".to_string(),
-        format!(
-            "    | (simp only [{with_append}] at h_when ⊢ <;> (split <;> simp_all [{defs}]) <;> done)"
-        ),
-        format!("    | (simp only [{with_append}] at h_when ⊢ <;> simp_all [{defs}] <;> done)"),
-        format!(
-            "    | (simp only [{with_append}] <;> (split <;> simp_all [{defs}, h_when]) <;> done)"
-        ),
-        format!("    | (simp only [{with_append}] <;> simp_all [{defs}, h_when] <;> done)"),
-        format!(
-            "    | (simp only [{with_append}] <;> (split <;> simp_all [{defs_br}]) <;> (try omega) <;> done)"
-        ),
-        format!(
-            "    | (simp only [{defs}] <;> (split <;> (simp_all [{defs_br}] <;> (try omega))) <;> done)"
-        ),
-        format!("    | (split <;> simp_all [{defs}, h_when] <;> done)"),
-        format!("    | (simp_all [{defs}, h_when] <;> done)"),
-        "    | sorry".to_string(),
-    ];
-    Some(AutoProof {
-        support_lines: bridge_support,
-        body: Tactic::raw(body),
-        replaces_theorem: false,
-    })
-}
-
 /// Whether [`emit_conditional_inductive_generic_law`] will attempt this law as a
 /// universal — the `omit_domain` driver reads this. A conditional law that
 /// recurses on a list given, with an equational conclusion, that the bespoke
@@ -1917,43 +1619,33 @@ pub(in crate::codegen::lean) fn recognize_conditional_inductive_generic(
         return false;
     }
     let single_list = other_lists == 0;
-    // Exclusive with the bespoke arms (they run first; keep the `omit_domain`
-    // gate single-valued so the statement driver and the emit agree).
-    if recognize_conditional_comparison_bridge(law, ctx)
-        || recognize_conditional_inductive_list(vb, law, ctx)
-    {
+    // Exclusive with the comparison-bridge arm (it runs first; keep the
+    // `omit_domain` gate single-valued so the statement driver and the emit
+    // agree). The membership family is now subsumed by this generic driver
+    // (probe-decided, no helper-pool gate), so it flows straight through.
+    if recognize_conditional_comparison_bridge(law, ctx) {
         return false;
     }
-    // Fire ONLY for a decomposition consumer — a law with at least one eligible
-    // earlier helper in its cone ∪ subject pool. Without helpers the generic
-    // `simp_all` over bare defs cannot supply the algebraic content (e.g.
-    // zip-reverse needs a snoc-distribution helper), so the universal proof
-    // would `sorry`; declining keeps such a law on its sound bounded fallback.
-    // This is the principle made structural: the generic driver proves a
-    // conditional law THROUGH its Aver helper laws, never by guessing.
-    if earlier_law_lemmas(vb, law, ctx).is_empty() {
+    // Class-1 recursion-incompatibility (single-list only): a cone fn that
+    // DECREMENTS a co-given synchronously with the list — `drop`/`take` over a
+    // free `Nat` (`prop_39`'s `elem(x, drop(y, z))`) — is not closed by plain
+    // induction on the target list (the cons IH lands at the wrong predecessor),
+    // so it keeps its sound bounded fallback rather than being probed.
+    if single_list && law_recurses_on_cogiven(law, ctx, target_idx) {
         return false;
     }
-    if single_list {
-        // Class-1 recursion-incompatibility: a cone fn that DECREMENTS a co-given
-        // (a non-target given) synchronously with the list — `drop`/`take` over a
-        // free `Nat` (`prop_39`'s `elem(x, drop(y, z))`) — is not closed by plain
-        // induction on the target list (the cons IH lands at the wrong
-        // predecessor of the co-given), so it keeps its sound bounded fallback.
-        if law_recurses_on_cogiven(law, ctx, target_idx) {
-            return false;
-        }
-        // SPECULATIVE: a single-list conditional is admitted only under an active
-        // probe pass (admit all, to measure which close) or a commit that
-        // recorded THIS `fn.law` as one that closed universally. The default
-        // state admits nothing, so single-list conditionals stay byte-identical
-        // to their pre-mechanism bounded fallback.
-        let id = format!("{}.{}", vb.fn_name, law.name);
-        if !super::super::tactic_ir::speculative::admits(&id) {
-            return false;
-        }
-    }
-    true
+    // SPECULATIVE admission — the probe is the proof-success oracle, not a static
+    // helper-count heuristic (a no-helper law can close by bare `simp_all` + the
+    // IH; a helper-rich one can still fail). The structural checks above decide
+    // whether the driver may TRY; the probe decides whether it actually CLOSED.
+    // `default` = the law's pre-probe disposition (two-list conditionals attempted
+    // directly, single-list declined to bounded), so a no-probe `transpile` stays
+    // byte-compatible; a probe-then-commit run overrides it from the empirical
+    // result (promoting a single-list closer, demoting a two-list non-closer like
+    // `prop_42`). The earlier helper laws still join the proof as MATERIAL (the
+    // emit's pool), they are simply no longer an admission gate.
+    let id = format!("{}.{}", vb.fn_name, law.name);
+    super::super::tactic_ir::speculative::admits(&id, other_lists == 1)
 }
 
 /// Close a conditional inductive law GENERICALLY: list induction on the
@@ -2027,14 +1719,14 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         format!("intro {} h_when", after.join(" "))
     };
     // The `sorry` floor. Under the speculative PROBE pass it carries an
-    // `AVERSPEC_SORRY:<fn.law>` trace so a non-closing single-list portfolio is
-    // observable in the build log (Lean's `first` never runs the floor's trace
-    // when an earlier branch closes). Both induction arms share the floor: if
-    // EITHER arm falls through, the law did not close universally.
-    let floor = if super::super::tactic_ir::speculative::probing() && others.is_empty() {
+    // `AVERSPEC_SORRY:<fn.law>` trace so a non-closing portfolio (single- OR
+    // two-list) is observable in the build log (Lean's `first` never runs the
+    // floor's trace when an earlier branch closes). Both induction arms share the
+    // floor: if EITHER arm falls through, the law did not close universally.
+    let floor = if super::super::tactic_ir::speculative::probing() {
         // Record HERE (not at the recognizer's `admits`): the probe sink must
-        // hold only laws that actually emit this trace floor. A single-list
-        // candidate the recognizer admits but whose `∀`-theorem is then suppressed
+        // hold only laws that actually emit this trace floor. A candidate the
+        // recognizer admits but whose `∀`-theorem is then suppressed
         // (`skip_universal` — e.g. a singleton-domain const-RHS law) emits no
         // floor, never traces, and so must NOT be counted "closed".
         let id = format!("{}.{}", vb.fn_name, law.name);

--- a/src/codegen/lean/tactic_ir.rs
+++ b/src/codegen/lean/tactic_ir.rs
@@ -559,17 +559,28 @@ pub mod speculative {
         STATE.with(|s| *s.borrow_mut() = (Mode::Off, None, HashSet::new()));
     }
 
-    /// Whether a single-list speculative law with this `fn.law` id should be
-    /// stated universally. In probe mode: always. In Off mode: only if it is in
-    /// the committed-closed set (`None` ⇒ admit nothing). Pure — does NOT record;
-    /// the probe sink is populated at the floor-emission site (see
-    /// [`record_probed`]) so it counts only laws that actually emit a trace floor.
-    pub fn admits(id: &str) -> bool {
+    /// Whether a conditional law with this `fn.law` id should be stated
+    /// universally. In probe mode: always (the probe attempts every structurally
+    /// eligible candidate). In Off mode WITH a committed set: only if it closed
+    /// (`set.contains(id)`). In Off mode with NO committed set (a direct
+    /// `transpile` outside any probe — a unit test, or the CLI's pre-probe
+    /// baseline): fall back to `default`. `default` is the law's PRE-probe
+    /// disposition — two-list conditionals were attempted directly (default
+    /// `true`), single-list ones declined to bounded (default `false`) — so a
+    /// no-probe emission stays byte-compatible with the pre-probe behavior, while
+    /// a probe-then-commit run lets the empirical result override it (promoting a
+    /// single-list closer, DEMOTING a two-list non-closer like `prop_42`). Pure —
+    /// does NOT record; the probe sink is populated at the floor-emission site
+    /// (see [`record_probed`]) so it counts only laws that emit a trace floor.
+    pub fn admits(id: &str, default: bool) -> bool {
         STATE.with(|s| {
             let st = s.borrow();
             match st.0 {
                 Mode::Probe => true,
-                Mode::Off => st.1.as_ref().is_some_and(|set| set.contains(id)),
+                Mode::Off => match st.1.as_ref() {
+                    Some(set) => set.contains(id),
+                    None => default,
+                },
             }
         })
     }
@@ -807,32 +818,33 @@ warning: declaration uses 'sorry'
     #[test]
     fn speculative_admits_only_committed_in_off_mode() {
         use super::speculative;
-        // Default: admit nothing (single-list conditionals stay on their bounded
-        // fallback — byte-identical to before the mechanism).
+        // No committed set: `admits` returns the law's `default` disposition — a
+        // single-list candidate (default false) stays bounded, a two-list one
+        // (default true) is attempted directly. Byte-compatible with pre-probe.
         speculative::clear();
-        assert!(!speculative::admits("f.law"));
+        assert!(!speculative::admits("f.law", false));
+        assert!(speculative::admits("g.two", true));
         assert!(!speculative::probing());
-        // Probe: admit everything; the sink is populated by `record_probed` at
-        // the floor-emission site (not by `admits`), so it holds only laws that
-        // actually emitted a trace floor.
+        // Probe: admit everything regardless of default; the sink is populated by
+        // `record_probed` at the floor-emission site (not by `admits`).
         speculative::begin_probe();
         assert!(speculative::probing());
-        assert!(speculative::admits("f.law"));
-        assert!(speculative::admits("g.other"));
+        assert!(speculative::admits("f.law", false));
+        assert!(speculative::admits("g.two", true));
         assert!(speculative::probed_ids().is_empty());
         speculative::record_probed("f.law");
-        speculative::record_probed("g.other");
+        speculative::record_probed("g.two");
         assert!(speculative::probed_ids().contains("f.law"));
-        assert!(speculative::probed_ids().contains("g.other"));
-        // Commit: admit only the closed set, in Off mode.
+        // Commit: admit only the closed set, IGNORING default — so a two-list
+        // non-closer (default true) is DEMOTED, a single-list closer promoted.
         let mut closed = std::collections::HashSet::new();
         closed.insert("f.law".to_string());
         speculative::set_committed(closed);
         assert!(!speculative::probing());
-        assert!(speculative::admits("f.law"));
-        assert!(!speculative::admits("g.other"));
+        assert!(speculative::admits("f.law", false));
+        assert!(!speculative::admits("g.two", true));
         speculative::clear();
-        assert!(!speculative::admits("f.law"));
+        assert!(!speculative::admits("f.law", false));
     }
 
     #[test]

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -694,9 +694,11 @@ verify le law leSucc
 #[test]
 fn transpile_proves_conditional_inductive_membership_law_as_universal() {
     // `prop_36 elemConcat`: `when elem(x,y) -> elem(x, y ++ z) => true` (append
-    // monotonicity, shape (A)). The conditional-inductive list emit closes it as
-    // the TRUE-universal `∀ x y z, elem x y = true -> elem x (y ++ z) = true` by
-    // induction on the first list given, threading the premise into the cons arm.
+    // monotonicity). The GENERIC conditional-inductive driver (no bespoke
+    // membership emitter) closes it as the TRUE-universal `∀ x y z, elem x y =
+    // true -> elem x (y ++ z) = true` by induction on the first list given,
+    // threading the premise into the cons arm. Admitted with no helper-pool gate;
+    // the partner list `z` is intro'd before the premise (`intro z h_when`).
     let mut ctx = ctx_from_source(
         r#"
 module CondIndMembership
@@ -744,63 +746,12 @@ verify elem law elemConcat
     assert!(lean.contains(
         "theorem elem_law_elemConcat : ∀ (x : Nat) (y : List Nat) (z : List Nat), elem x y = true -> elem x (y ++ z) = true := by"
     ));
-    // Induction on the first list given `y`, with the premise threaded INSIDE the
-    // cons arm (`intro h_when` after `induction`, so the IH carries the antecedent).
+    // Induction on the first list given `y`, with the partner list + premise
+    // threaded INSIDE the cons arm (`intro z h_when` after `induction`, so the IH
+    // carries the antecedent and generalizes over the partner).
     assert!(lean.contains("induction y with"));
     assert!(lean.contains("| cons hd tl ih =>"));
-    assert!(lean.contains("intro h_when"));
-}
-
-#[test]
-fn transpile_proves_count_membership_law_as_universal() {
-    // `prop_76`-shape (`when not(eqNat(n, m)) -> count(n, xs ++ [m]) = count(n, xs)`):
-    // the verified fn `count` returns Nat, not Bool, yet it is a per-element FOLD
-    // (its cons arm COMPARES the head, never returns it), so the membership emit
-    // admits it and closes the law `universal`. Guards the count/`last` boundary —
-    // a Nat-returning SELECTOR like `last` must NOT be admitted.
-    let mut ctx = ctx_from_source(
-        r#"
-module CountMembership
-    intent = "count(n, xs ++ [m]) = count(n, xs) when n /= m"
-
-type Nat
-    Z
-    S(Nat)
-
-fn eqNat(x: Nat, y: Nat) -> Bool
-    match x
-        Nat.Z -> match y
-            Nat.Z -> true
-            Nat.S(z) -> false
-        Nat.S(x2) -> match y
-            Nat.Z -> false
-            Nat.S(y2) -> eqNat(x2, y2)
-
-fn count(x: Nat, y: List<Nat>) -> Nat
-    match y
-        [] -> Nat.Z
-        [z, ..zs] -> match eqNat(x, z)
-            true -> Nat.S(count(x, zs))
-            false -> count(x, zs)
-
-verify count law countAppendSingleton
-    given n: Nat = [Nat.Z, Nat.S(Nat.Z)]
-    given m: Nat = [Nat.Z, Nat.S(Nat.Z)]
-    given xs: List<Nat> = [[], [Nat.Z]]
-    when Bool.not(eqNat(n, m))
-    count(n, List.concat(xs, [m])) => count(n, xs)
-"#,
-        "count_membership",
-    );
-    let out = transpile(&mut ctx);
-    let lean = generated_lean_file(&out);
-
-    // A `Nat`-returning fold still earns the unbounded `universal` statement.
-    assert!(lean.contains(
-        "-- aver:law-class count_law_countAppendSingleton universal count.countAppendSingleton"
-    ));
-    assert!(lean.contains("induction xs with"));
-    assert!(lean.contains("intro h_when"));
+    assert!(lean.contains("intro z h_when"));
 }
 
 #[test]

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -585,7 +585,6 @@ fn emit_verify_law_block(
     let conditional_universal = law.when.is_some()
         && lifted_vars.is_empty()
         && (super::law_auto::recognize_conditional_comparison_bridge(&law_for_auto_proof, ctx)
-            || super::law_auto::recognize_conditional_inductive_list(vb, &law_for_auto_proof, ctx)
             || super::law_auto::recognize_conditional_inductive_generic(
                 vb,
                 &law_for_auto_proof,
@@ -1007,7 +1006,6 @@ pub(crate) fn law_as_lemma_statement(
     // prover only bounds (it has no universal theorem to cite).
     if law.when.is_some()
         && !(super::law_auto::recognize_conditional_comparison_bridge(law, ctx)
-            || super::law_auto::recognize_conditional_inductive_list(vb, law, ctx)
             || super::law_auto::recognize_conditional_inductive_generic(vb, law, ctx))
     {
         return None;

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -7261,27 +7261,26 @@ fn run_lean_speculative(
     use aver::codegen::lean::tactic_ir::speculative;
     use std::process::Command;
 
-    // Cheap necessary-condition pre-filter: the speculative path only fires for a
-    // `when`-law with EXACTLY ONE `List<_>` given (the single-list shape —
-    // `other_lists == 0`). With no such law in the file the probe would admit
-    // nothing, so skip the extra emits + build entirely and leave the baseline
-    // untouched (a true no-op — the decomposed corpus pays nothing).
-    let has_single_list_candidate = ctx.items.iter().any(|item| {
+    // Cheap necessary-condition pre-filter: the speculative path fires for a
+    // `when`-law with ONE or TWO `List<_>` givens (the single-list and two-list
+    // conditional-inductive shapes the generic driver probes). With no such law
+    // the probe would admit nothing, so skip the extra emits + build entirely and
+    // leave the baseline untouched (a true no-op).
+    let has_conditional_list_candidate = ctx.items.iter().any(|item| {
         let TopLevel::Verify(vb) = item else {
             return false;
         };
         let VerifyKind::Law(law) = &vb.kind else {
             return false;
         };
-        law.when.is_some()
-            && law
-                .givens
-                .iter()
-                .filter(|g| g.type_name.trim().starts_with("List<"))
-                .count()
-                == 1
+        let lists = law
+            .givens
+            .iter()
+            .filter(|g| g.type_name.trim().starts_with("List<"))
+            .count();
+        law.when.is_some() && (lists == 1 || lists == 2)
     });
-    if !has_single_list_candidate {
+    if !has_conditional_list_candidate {
         return;
     }
 

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -7290,7 +7290,13 @@ fn run_lean_speculative(
         .map(|o| o.status.success())
         .unwrap_or(false);
     if !lake_ok {
-        // Leave the baseline (already on disk) untouched.
+        // No prover to run the probe, so we cannot learn which candidates close.
+        // The baseline directly admits two-list conditionals (the `default`), which
+        // would stamp a non-closer `universal` over a `sorry` floor. Commit an
+        // EMPTY closed-set instead: every conditional law falls back to its sound
+        // bounded statement (honest — nothing was proven). Then re-emit.
+        speculative::set_committed(std::collections::HashSet::new());
+        cmd_proof_lean(file, output_dir, ctx, verify_mode);
         return;
     }
     let build = |dir: &str| -> (bool, String) {
@@ -7324,8 +7330,10 @@ fn run_lean_speculative(
         // A `sorry` is only a warning, so the probe build succeeds even when
         // every candidate fails to close — a HARD failure means a speculative
         // statement did not elaborate, and the per-law verdict can't be trusted.
-        // Restore the bounded baseline rather than commit a guess.
-        speculative::clear();
+        // Commit an empty closed-set so every candidate falls back to bounded
+        // (NOT `clear()`, which would re-expose the default-admit baseline and
+        // stamp a two-list non-closer `universal` over a `sorry`).
+        speculative::set_committed(std::collections::HashSet::new());
         cmd_proof_lean(file, output_dir, ctx, verify_mode);
         return;
     }
@@ -7339,12 +7347,14 @@ fn run_lean_speculative(
     // 3) FAIL-SAFE verify — the committed project must still build.
     let (commit_ok, _) = build(output_dir);
     if !commit_ok {
-        speculative::clear();
+        // Commit an empty closed-set so every conditional law falls back to
+        // bounded (NOT `clear()` — the default-admit baseline would stamp a
+        // two-list non-closer `universal` over a `sorry`).
+        speculative::set_committed(std::collections::HashSet::new());
         cmd_proof_lean(file, output_dir, ctx, verify_mode);
         eprintln!(
             "{}",
-            "speculative-universal: committed proof did not build — restored the bounded baseline"
-                .yellow()
+            "speculative-universal: committed proof did not build — fell back to bounded".yellow()
         );
     } else if !closed.is_empty() {
         println!(

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -196,6 +196,56 @@ fn decomposed_tip_tasks_stay_universal_when_lake_is_available() {
     }
 }
 
+/// `tip/isaplanner/prop_86` (`x < y -> elem x (ins y xs) = elem x xs`): a
+/// single-list conditional MEMBERSHIP law whose premise is a Peano comparison.
+/// It closes universally only through the speculative probe (single-list) + the
+/// generic conditional driver's comparison-bridge rung — the `(lt a b = true) =
+/// (a < b)` / `(eqNat a b = true) = (a = b)` lifts that let `omega` discharge the
+/// `eqNat x y = false` the premise forces in BOTH the base (`ins y [] = [y]`)
+/// and cons arms. This is the regression the bespoke-membership-emitter removal
+/// had to preserve (the driver subsumes it, no per-figure Lean template), so it
+/// is pinned here. Lake-gated (CLI probe). Genuinely kernel-clean (no `sorryAx`).
+#[test]
+fn prop_86_comparison_premise_membership_stays_universal_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping prop_86 comparison-premise test: `lake` not available");
+        return;
+    }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let task = "proof-corpus/tip/isaplanner/prop_86.av";
+    let out = temp_output_dir("aver-prop_86-comparison-membership");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg(task)
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .unwrap_or_else(|e| panic!("{task}: aver proof failed to run: {e}"));
+    let json = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("{task}: no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json).unwrap_or_else(|e| panic!("{task}: bad JSON ({e})"));
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "{task}: comparison-premise membership must stay universal via the generic \
+         driver (the bespoke membership emitter was removed — the comparison-bridge \
+         rung in BOTH induction arms must carry it).\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&out);
+}
+
 /// część C — ARM injection of Forward sibling laws. Some laws need a helper
 /// applied INSIDE the induction cons-arm, not just at the top-level fast path:
 /// `count n xs = count n (rev xs)` only closes if the count-homomorphism


### PR DESCRIPTION
## Co i dlaczego

Generyczny conditional-inductive driver był dopuszczany tylko gdy prawo miało helper w puli — kiepski statyczny proxy „czy driver domknie". Teraz jest empiryczny orakl (probe: stwierdź universal → Lean → audyt aksjomatów → zachowaj tylko kernel-clean), więc statyczna bramka dawała false-negatives: standalone membership (domykane bare-simp_all+IH) było odrzucane za brak helpera → bespoke membership-emit musiał kompensować.

**Probe staje się arbitrem:**
- Rozszerzony z single-list na **two-list** conditional.
- **Wywalona bramka helper-pool** (helpery zostają jako MATERIAŁ dowodowy, nie precondition).
- `admits(id, default)` niesie pre-probe dispozycję (two-list direct, single-list declined) → no-probe `transpile` byte-compatible; probe-then-commit nadpisuje empirycznie (promuje single-list closer, DEMOTUJE two-list non-closer).
- Usunięty `emit_conditional_inductive_list_law` + recognizer/helpery.

Pozostałe gate'y = tylko strukturalne (recurses-on-List, znany `when`-shape, induction-var). Czy faktycznie domyka — decyduje probe + istniejący `#print axioms` credit-gate.

## Wynik

**Zdekomponowany korpus: 58/58 universal** (było 54). Membership (prop_36/37/38/46/47, lemma_19) przez generyk; ścieżka demotion naprawia 4 długoletnie PARTIALe — **prop_42/43/44** (union/intersect membership których driver nie domyka → czysto bounded) i **prop_60** (`last`-append) — teraz passing.

## Walidacja
- sweep prod+isaplanner: **58/58 FULL, zero PARTIAL, zero regresji**
- `cargo test --lib` 904/0 · clippy --lib + --features wasm,wasip2 · fmt — czyste
- net −368 linii (usunięty bespoke + uproszczony recognizer)
- Dafny nietknięty (zmiany Lean-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdSMXQ2vHRw29C8YY5hVqW