### PR TITLE
Fix wasm-gc handler wrapper reading carrier HttpResponse.status as i64

### DIFF
--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -7096,12 +7096,29 @@ fn emit_handler_wrapper(
     f.instruction(&Instruction::Call(user_handler_wasm_idx));
     f.instruction(&Instruction::LocalSet(6));
 
-    // status = resp.status (i64)
+    // status = resp.status — under `Int = ℤ` the `HttpResponse.status` field is
+    // the `$AverInt` carrier (the factory lifts the host's i64 to a Small via
+    // `__aint_from_i64`), so lower it back to i64 before storing into the i64
+    // local the `Response.text` host import consumes. Mirror of
+    // `emit_factory_http_response_make`; saturating is safe — a status code
+    // always fits i64. Without this the wrapper stores a `(ref null $aint)` into
+    // an i64 local and the module fails wasm validation.
     f.instruction(&Instruction::LocalGet(6));
     f.instruction(&Instruction::StructGet {
         struct_type_index: resp_idx,
         field_index: 0,
     });
+    if registry.bignum {
+        let to_i64 =
+            fn_map
+                .builtins
+                .get("__aint_to_i64_sat")
+                .copied()
+                .ok_or(WasmGcError::Validation(
+                    "bignum aver_http_handle wrapper needs the __aint_to_i64_sat helper".into(),
+                ))?;
+        f.instruction(&Instruction::Call(to_i64));
+    }
     f.instruction(&Instruction::LocalSet(7));
     // resp_body = resp.body
     f.instruction(&Instruction::LocalGet(6));

--- a/tests/wasm_gc_handler_carrier.rs
+++ b/tests/wasm_gc_handler_carrier.rs
@@ -1,0 +1,79 @@
+//! Regression: the synthesized `aver_http_handle` wrapper (`--handler X` /
+//! `--preset cloudflare`) reads `HttpResponse.status` and hands it to the
+//! `Response.text` host import as an i64. Under `Int = ℤ` the status field is
+//! the `$AverInt` carrier (the HttpResponse factory lifts the host's i64 to a
+//! Small), so the wrapper must lower it back to i64 before the i64 local —
+//! exactly mirroring the factory. It didn't, so it stored a `(ref null $aint)`
+//! into an i64 local and the whole module failed wasm validation.
+//!
+//! A status LITERAL (`status = 200`) is itself Int arithmetic, so it flips the
+//! bignum gate on — meaning this hit EVERY Cloudflare-handler program, not just
+//! arithmetic-heavy ones. The backend validates the module internally before
+//! writing it, so a successful `aver compile` is the assertion: it would error
+//! (no `.wasm` written) without the fix.
+
+#![cfg(feature = "wasm")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn cloudflare_handler_with_bignum_status_validates() {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("aver-handler-carrier-{nanos}"));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let src = dir.join("app.av");
+    std::fs::write(
+        &src,
+        r#"module HandlerApp
+    intent = "Minimal Cloudflare handler exercising the aver_http_handle wrapper."
+    exposes [handler]
+
+fn handler(req: HttpRequest) -> HttpResponse
+    ? "Always 200 with a tiny body. The status literal flips the bignum gate, so HttpResponse.status is the $AverInt carrier the wrapper must lower."
+    HttpResponse(
+        status = 200,
+        body = "hi",
+        headers = { "content-type" => ["text/plain"] },
+    )
+"#,
+    )
+    .expect("write handler source");
+
+    let out_dir = dir.join("out");
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+        .arg("compile")
+        .arg(&src)
+        .arg("--preset")
+        .arg("cloudflare")
+        .arg("--handler")
+        .arg("handler")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("aver compile executes");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let wasm_written = std::fs::read_dir(&out_dir)
+        .map(|rd| {
+            rd.filter_map(Result::ok)
+                .any(|e| e.path().extension().is_some_and(|x| x == "wasm"))
+        })
+        .unwrap_or(false);
+
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        output.status.success() && wasm_written,
+        "Cloudflare handler wrapper failed to compile/validate — likely a \
+         `type mismatch: expected i64, found (ref null $type)` from reading the \
+         $AverInt-carrier HttpResponse.status into an i64 local without lowering.\n\
+         stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## What

`aver compile tools/edge/app.av --preset cloudflare` (a `release.py verify` gate) failed wasm-gc validation:

```
wasm-gc: validation failed — type mismatch: expected i64, found (ref null $type)
```

## Root cause

Under `Int` = ℤ, `HttpResponse.status` is the `$AverInt` carrier — the response factory lifts the host's i64 status to a `Small` via `__aint_from_i64` before `struct.new`. The synthesized `aver_http_handle` wrapper (`--handler X` / `--preset cloudflare`) read the field straight back into an **i64 local** to hand to the `Response.text` host import, so it stored a `(ref null $aint)` into an i64 local and the whole module failed validation.

A status literal (`status = 200`) is itself Int arithmetic, so the bignum gate is on for essentially every handler — this hit **every** Cloudflare-handler program, not just arithmetic-heavy ones.

## Fix

In `emit_handler_wrapper`, lower the carrier back to i64 with `__aint_to_i64_sat` when `registry.bignum`, mirroring the factory's lift. Saturating is safe — an HTTP status always fits i64. When bignum is off the field is a bare i64 and the path is unchanged.

## Validation

- `tools/edge/app.av --preset cloudflare` now compiles and `wasm-tools validate --features all` passes.
- New regression test `tests/wasm_gc_handler_carrier.rs` compiles a minimal handler with `--preset cloudflare` and asserts the module validates. Verified it **fails without this fix** (the exact `expected i64, found (ref null $type)` mismatch) and passes with it.
- `wasm_gc_perslot_int_unboxing_differential` + `compile_spec` still green; `fmt --check` and `clippy -D warnings` clean.

Pre-existing bug, independent of (and reviewable separately from) the arbitrary-precision integer literals work in #619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmEe9iaJ4yFf3fgmALCB26
