### PR TITLE
Enable nontrapping-float-to-int in the wasm-opt invocation

### DIFF
--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4900,6 +4900,12 @@ fn run_optimize_pipeline(wasm_file: &Path, mode: super::cli::WasmOptMode) -> Res
         .arg("--enable-tail-call")
         .arg("--enable-gc")
         .arg("--enable-reference-types")
+        // The bignum f64->Int helper emits `i64.trunc_sat_f64_u` (exact integer
+        // over the full f64 range); `--strip-target-features` above drops the
+        // feature section, so wasm-opt must be told this proposal is allowed or
+        // it rejects the input. Every wasm-gc target engine (Chrome 119+ / FF
+        // 120+ / Safari 18.2+ / wasmtime / Node 22+) supports it.
+        .arg("--enable-nontrapping-float-to-int")
         .arg(&stage1_file)
         .arg("-o")
         .arg(&optimized_file)

--- a/tests/wasm_gc_optimize_trunc_sat.rs
+++ b/tests/wasm_gc_optimize_trunc_sat.rs
@@ -1,0 +1,59 @@
+//! Regression: `aver compile --target wasm-gc --optimize` runs `wasm-opt` over
+//! the whole module. The bignum prelude carries an f64->Int helper that emits
+//! `i64.trunc_sat_f64_u` (the nontrapping-float-to-int proposal). The wasm-opt
+//! invocation passes `--strip-target-features` (dropping the feature section),
+//! so wasm-opt must be told the proposal is allowed via
+//! `--enable-nontrapping-float-to-int` — otherwise it rejects the input with
+//! "all used features should be allowed", failing the optimize step. That broke
+//! `rebuild_playground.py` and `release.py` step 4 for every Int-heavy game.
+//!
+//! Fixture: the shipped `examples/games/life.av` reliably carries the helper
+//! into a validate-before-DCE position (a trimmed synthetic program lets
+//! wasm-opt strip it first, so it doesn't reproduce). A clean `aver compile
+//! --optimize size` is the assertion — without the flag the command exits
+//! non-zero (it may leave a partial pre-optimize wasm, so the EXIT CODE, not
+//! file presence, is the signal).
+
+#![cfg(feature = "wasm")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn wasm_gc_optimize_handles_trunc_sat_from_bignum_prelude() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let life = repo_root.join("examples/games/life.av");
+    assert!(life.exists(), "fixture missing: {}", life.display());
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let out_dir = std::env::temp_dir().join(format!("aver-trunc-sat-{nanos}"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg(&life)
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--optimize")
+        .arg("size")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("aver compile executes");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let _ = std::fs::remove_dir_all(&out_dir);
+
+    assert!(
+        output.status.success(),
+        "`aver compile --target wasm-gc --optimize size examples/games/life.av` failed — \
+         likely wasm-opt rejecting `i64.trunc_sat_f64_u` because \
+         `--enable-nontrapping-float-to-int` is missing from the wasm-opt invocation.\n\
+         stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## What

`aver compile --target wasm-gc --optimize` (used by `rebuild_playground.py` and `release.py` step 4) failed wasm-opt validation for every Int-heavy game:

```
wasm-opt -Oz failed ... [wasm-validator error] unexpected false: all used features should be allowed, on
  (i64.trunc_sat_f64_u (f64.floor (local.get $2)))
```

## Root cause

The bignum prelude carries an f64→Int helper that emits `i64.trunc_sat_f64_u` (the nontrapping-float-to-int proposal). Aver's wasm-opt invocation (`src/main/commands.rs`) enables bulk-memory/multivalue/tail-call/gc/reference-types and passes `--strip-target-features` (dropping the feature section) — but **not** `--enable-nontrapping-float-to-int`, so wasm-opt rejects the input.

## Fix

Add `--enable-nontrapping-float-to-int` to the wasm-opt args. Every wasm-gc target engine (Chrome 119+ / Firefox 120+ / Safari 18.2+ / wasmtime / Node 22+) supports it.

## Validation

- `tools/website/rebuild_playground.py` now rebuilds all games; `tools/edge/app.av --preset cloudflare` still validates.
- Regression test `tests/wasm_gc_optimize_trunc_sat.rs` compiles `examples/games/life.av` with `--optimize size` and asserts it validates. Verified it **fails without this fix** (the exact `trunc_sat` rejection) and passes with it.
- `fmt --check` + both clippy `-D warnings` gates clean.

Pre-existing latent bug (predates the Int=ℤ literals work in #619/#620); surfaced when rebuilding the playground for the first time since the bignum f64 helper landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmEe9iaJ4yFf3fgmALCB26