### PR TITLE
Add generic rungs for common-factor cancellation and remainder absorption in Euclidean floor division

### DIFF
--- a/projects/k5_fdiv/leafprobe.av
+++ b/projects/k5_fdiv/leafprobe.av
@@ -1,0 +1,50 @@
+module LeafProbe
+    intent =
+        "Empirical probe for the two leaf laws of the sticky-plus decomposition"
+        "(trunc-sticky, Lemma 7.3.2 core): the common-positive-factor cancel and the"
+        "Euclidean remainder absorption on floorDiv. Both are content-blind claim"
+        "shapes over bare Int givens -- no power of two appears in either claim; the"
+        "pow2-ness of the K5 chain enters only through citations of the proven"
+        "homomorphism. This probe measures whether the CURRENT engine closes them"
+        "push-button (universal) or exactly which gap remains."
+    exposes [floorDiv]
+    effects []
+
+fn floorDiv(a: Int, d: Int) -> Int
+    ? "Euclidean floor division a / d (the floor of the exact quotient for d > 0); guarded to 0 at d = 0. Mirror of Domain.Round.floorDiv."
+    Result.withDefault(Int.div(a, d), 0)
+
+verify floorDiv
+    floorDiv(7, 2) => 3
+    floorDiv(0 - 7, 2) => 0 - 4
+    floorDiv(52, 8) => 6
+
+// Leaf K1/K5 of the sticky-plus chain: cancelling a common POSITIVE factor c
+// from dividend and divisor leaves the Euclidean floor unchanged:
+// floor(a*c / (d*c)) = floor(a / d) for 0 < c, 0 < d. Generic over the
+// dividend a and BOTH factors -- no power of two in the claim; in the K5
+// chain c and d are instantiated at powers of two via the proven pow2
+// homomorphism, but the law itself is content-blind.
+
+verify floorDiv law cancelCommonFactor
+    given a: Int = [13, 0 - 7, 52, 0]
+    given d: Int = [2, 3, 5]
+    given c: Int = [1, 2, 7]
+    when 0 < d
+    when 0 < c
+    floorDiv(a * c, d * c) => floorDiv(a, d)
+
+// Leaf K3 of the sticky-plus chain: the Euclidean floor absorbs a
+// sub-divisor remainder: floor((d*q + r) / d) = q for 0 <= r < d. This is
+// quotient uniqueness of Euclidean division, stated generically over the
+// quotient q (any sign), the divisor d and the remainder r. In the K5 chain
+// it fires at d = 2, r = the round-to-odd bit b in {0,1}.
+
+verify floorDiv law absorbRemainder
+    given q: Int = [3, 0 - 2, 0, 13]
+    given d: Int = [1, 2, 3, 5]
+    given r: Int = [0, 1, 2]
+    when 0 < d
+    when 0 <= r
+    when r < d
+    floorDiv(d * q + r, d) => q

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -3,6 +3,7 @@
 /// This module is intentionally isolated from `toplevel.rs` so all heuristic
 /// matching and proof-shape logic lives in one place.
 mod decimal;
+mod floor_arith;
 mod floor_window;
 mod frac_monotone_compose;
 mod frac_order_chain;
@@ -103,6 +104,14 @@ pub(in crate::codegen::lean) use recursive_mono::{
 /// `Int.ediv_ediv_of_nonneg`. Feeds the `omit_domain` statement driver, kept in
 /// lockstep with `emit_nested_floor_law`.
 pub(in crate::codegen::lean) use nested_floor::recognize_nested_floor;
+
+/// Content-blind Euclidean-floor arithmetic rungs — `floor (a * c) (d * c) =
+/// floor a d` (shared positive factor cancel) and `floor (d * q + r) d = q`
+/// (bounded-remainder absorption), closed in pure core. Both feed the
+/// `omit_domain` statement driver, kept in lockstep with their emits.
+pub(in crate::codegen::lean) use floor_arith::{
+    recognize_absorb_remainder, recognize_cancel_common_factor,
+};
 
 /// Content-blind homomorphism rung — the name-blind, shape-only recognizer for
 /// `subject(OP1(a, b)) = OP2(subject(a), subject(b))` (subject recursive, OP1 /
@@ -865,6 +874,23 @@ fn emit_verify_law_forall_auto_proof_inner(
     // rather than falling through to a `grind` that explodes on the divisor.
     if let Some(proof) =
         nested_floor::emit_nested_floor_law(vb, law, ctx, theorem_base, quant_params)
+    {
+        return Some(proof);
+    }
+
+    // Euclidean-floor arithmetic (`floor (a * c) (d * c) = floor a d` under
+    // positive divisor + factor; `floor (d * q + r) d = q` under `0 <= r < d`):
+    // closed in pure core by the shared-factor cancel / bounded-remainder absorb
+    // lemmas. Both are very specific product/linear-dividend shapes, so they
+    // never collide with the homomorphism / keystone arms below; tried first so
+    // each closes by its deterministic core skeleton rather than a `grind`.
+    if let Some(proof) =
+        floor_arith::emit_cancel_common_factor_law(vb, law, ctx, theorem_base, quant_params)
+    {
+        return Some(proof);
+    }
+    if let Some(proof) =
+        floor_arith::emit_absorb_remainder_law(vb, law, ctx, theorem_base, quant_params)
     {
         return Some(proof);
     }

--- a/src/codegen/lean/law_auto/floor_arith.rs
+++ b/src/codegen/lean/law_auto/floor_arith.rs
@@ -14,19 +14,22 @@
 //! fire on the K5 laws AND on a plain-integer floor-division fn in any other
 //! module (the cross-domain second witness that proves they are shape-only).
 //!
-//! Both peel each `floor a d` to the bare Euclidean quotient `a / d` (the
-//! positive-divisor zero-guard peel), then close by a CORE lemma:
-//! `Int.mul_ediv_mul_of_pos_left` cancels the shared positive factor, and
-//! `Int.add_mul_ediv_left` + `Int.ediv_eq_zero_of_lt` absorb the bounded
-//! remainder. The positivity / bound facts are read off the law's `when` guard.
+//! Both recognizers are ORIENTATION-TOLERANT: the shared factor may sit on
+//! either side of each product, and the divisor multiplicand on either side of
+//! `d * q`, independently. The emitted proof normalizes the written orientation
+//! to the core-lemma's canonical form with an explicit `Int.mul_comm` step, then
+//! closes by a CORE lemma: `Int.mul_ediv_mul_of_pos_left` cancels the shared
+//! positive factor, and `Int.add_mul_ediv_left` + `Int.ediv_eq_zero_of_lt`
+//! absorb the bounded remainder. The positivity / bound facts are read off the
+//! law's `when` guard.
 
 use super::AutoProof;
 use super::aver_name_to_lean;
 use super::shared::{
     clause_gives_nonneg, clause_gives_pos, clause_is_lt, expr_dotted_name, flatten_and, floor_call,
-    is_euclidean_floor_fn, render, same_atom,
+    is_euclidean_floor_fn, render,
 };
-use crate::ast::{BinOp, Expr, VerifyBlock, VerifyLaw};
+use crate::ast::{BinOp, Expr, Spanned, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 
 /// The shared `floor a d = a / d` peel lemma text (positive divisor), keyed to a
@@ -49,6 +52,19 @@ fn intro_names(law: &VerifyLaw) -> String {
         .join(" ")
 }
 
+/// In a two-operand product whose children render to `l_r` / `r_r`, find the one
+/// that equals `target`; return the OTHER child's render and whether `target`
+/// sat on the LEFT. Content-blind: keyed only on structural equality of renders.
+fn split_shared(l_r: &str, r_r: &str, target: &str) -> Option<(String, bool)> {
+    if l_r == target {
+        Some((r_r.to_string(), true))
+    } else if r_r == target {
+        Some((l_r.to_string(), false))
+    } else {
+        None
+    }
+}
+
 // ---------------------------------------------------------------------------
 // cancelCommonFactor: floor (a * c) (d * c) = floor a d   (0 < d, 0 < c)
 // ---------------------------------------------------------------------------
@@ -58,12 +74,21 @@ struct CancelShape {
     a: String,
     d: String,
     c: String,
+    /// The dividend / divisor products as WRITTEN (either operand order).
+    dividend: String,
+    divisor: String,
+    /// `true` when the shared factor `c` sits on the LEFT of that product
+    /// (`c * a` / `c * d`); the emitted proof commutes it to the right before
+    /// citing the core cancel lemma.
+    c_left_in_dividend: bool,
+    c_left_in_divisor: bool,
 }
 
 /// Recognize `floor (a * c) (d * c) = floor a d`, capturing the floor fn and the
-/// atoms `a` / `d` / the shared RIGHT factor `c` structurally. The factor is
-/// keyed on the right of both products (matching the core cancel lemma); a
-/// different orientation declines.
+/// atoms `a` / `d` / the shared factor `c` structurally. ORIENTATION-TOLERANT:
+/// the shared factor may sit on either side of each product independently; `a`
+/// and `d` are pinned by the reduced rhs. A genuine non-match (no shared factor)
+/// declines.
 fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape> {
     // rhs = floor(a, d)
     let Expr::FnCall(callee, args) = &law.rhs.node else {
@@ -73,9 +98,10 @@ fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape
     if args.len() != 2 {
         return None;
     }
-    let (a_r, d_r) = (&args[0], &args[1]);
+    let a_render = render(&args[0], ctx);
+    let d_render = render(&args[1], ctx);
 
-    // lhs = floor(a * c, d * c), same floor fn
+    // lhs = floor(<product>, <product>), same floor fn
     let (prod_a, prod_d) = floor_call(&law.lhs, &floor_src)?;
     let Expr::BinOp(BinOp::Mul, a_l, c_a) = &prod_a.node else {
         return None;
@@ -84,11 +110,16 @@ fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape
         return None;
     };
 
-    // Shared factor on the RIGHT of both products; the left factors are the
-    // dividend / divisor of the reduced rhs.
-    if !same_atom(c_a, c_d, ctx) || !same_atom(a_l, a_r, ctx) || !same_atom(d_l, d_r, ctx) {
+    // In the dividend, one side is `a` and the other is the shared factor `c`;
+    // in the divisor, one side is `d` and the other must be the SAME `c`.
+    let (c_from_a, a_left) =
+        split_shared(&render(a_l, ctx), &render(c_a, ctx), &a_render)?;
+    let (c_from_d, d_left) =
+        split_shared(&render(d_l, ctx), &render(c_d, ctx), &d_render)?;
+    if c_from_a != c_from_d {
         return None;
     }
+    let c_render = c_from_a;
 
     if !is_euclidean_floor_fn(&floor_src, ctx) {
         return None;
@@ -98,8 +129,6 @@ fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape
     let when = law.when.as_ref()?;
     let mut clauses = Vec::new();
     flatten_and(when, &mut clauses);
-    let d_render = render(d_r, ctx);
-    let c_render = render(c_a, ctx);
     let pos_d = clauses.iter().any(|cl| clause_gives_pos(cl, &d_render, ctx));
     let pos_c = clauses.iter().any(|cl| clause_gives_pos(cl, &c_render, ctx));
     if !pos_d || !pos_c {
@@ -108,9 +137,14 @@ fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape
 
     Some(CancelShape {
         floor_lean: aver_name_to_lean(&floor_src),
-        a: render(a_r, ctx),
+        a: a_render,
         d: d_render,
         c: c_render,
+        dividend: render(prod_a, ctx),
+        divisor: render(prod_d, ctx),
+        // shared factor is on the left iff `a` (resp. `d`) is on the right.
+        c_left_in_dividend: !a_left,
+        c_left_in_divisor: !d_left,
     })
 }
 
@@ -133,10 +167,29 @@ pub(super) fn emit_cancel_common_factor_law(
         a,
         d,
         c,
+        dividend,
+        divisor,
+        c_left_in_dividend,
+        c_left_in_divisor,
     } = recognize_cancel(law, ctx)?;
     let when = render(law.when.as_ref()?, ctx);
     let lhs = render(&law.lhs, ctx);
     let rhs = render(&law.rhs, ctx);
+
+    // `0 < divisor` proof follows the WRITTEN factor order of the divisor.
+    let hdc = if c_left_in_divisor {
+        "Int.mul_pos hc hd" // 0 < c * d
+    } else {
+        "Int.mul_pos hd hc" // 0 < d * c
+    };
+    // Commute the shared factor to the RIGHT (core lemma's canonical form).
+    let mut normalize = String::new();
+    if c_left_in_dividend {
+        normalize.push_str(&format!("\n  rw [Int.mul_comm {c} {a}]"));
+    }
+    if c_left_in_divisor {
+        normalize.push_str(&format!("\n  rw [Int.mul_comm {c} {d}]"));
+    }
 
     let text = format!(
         r#"{peel}
@@ -145,8 +198,8 @@ theorem {base} : ∀ {quant}, {when} = true -> {lhs} = {rhs} := by
   simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le, gt_iff_lt] at h_when
   have hd : 0 < {d} := by omega
   have hc : 0 < {c} := by omega
-  have hdc : 0 < {d} * {c} := Int.mul_pos hd hc
-  rw [{base}__floordiv_eq ({a} * {c}) ({d} * {c}) hdc, {base}__floordiv_eq {a} {d} hd]
+  have hdc : 0 < {divisor} := {hdc}
+  rw [{base}__floordiv_eq ({dividend}) ({divisor}) hdc, {base}__floordiv_eq {a} {d} hd]{normalize}
   exact Int.mul_ediv_mul_of_pos_left {a} {d} hc"#,
         peel = floordiv_eq_lemma(theorem_base, &floor),
         base = theorem_base,
@@ -170,14 +223,49 @@ struct AbsorbShape {
     d: String,
     q: String,
     r: String,
+    /// The dividend sum as WRITTEN.
+    dividend: String,
+    /// `true` when the divisor sits on the LEFT of the product (`d * q`); the
+    /// emitted proof commutes `q * d` to `d * q` first.
+    d_left_in_product: bool,
+    /// `true` when the remainder is written FIRST (`r + d * q`); otherwise the
+    /// product leads (`d * q + r`) and the proof reorders it with `omega`.
+    r_first: bool,
+}
+
+/// Split a sum into (product, remainder) whichever way it is written: the
+/// operand that is a `Mul` matching the divisor / quotient is the product, the
+/// other is the remainder.
+fn split_sum<'a>(
+    add_l: &'a Spanned<Expr>,
+    add_r: &'a Spanned<Expr>,
+    d_render: &str,
+    rhs_render: &str,
+    ctx: &CodegenContext,
+) -> Option<(bool, &'a Spanned<Expr>, bool)> {
+    // Returns (d_left_in_product, remainder, r_first).
+    for (prod, rem, r_first) in [(add_l, add_r, false), (add_r, add_l, true)] {
+        let Expr::BinOp(BinOp::Mul, x, y) = &prod.node else {
+            continue;
+        };
+        let (xr, yr) = (render(x, ctx), render(y, ctx));
+        // one factor is the divisor `d`, the other is the quotient `q` = rhs.
+        if xr == d_render && yr == rhs_render {
+            return Some((true, rem, r_first));
+        }
+        if yr == d_render && xr == rhs_render {
+            return Some((false, rem, r_first));
+        }
+    }
+    None
 }
 
 /// Recognize `floor (d * q + r) d = q`, capturing the floor fn, the divisor `d`,
-/// the quotient `q` and the remainder `r` structurally. Keyed on the divisor
-/// being the LEFT factor of the `d * q` product (matching the core absorb
-/// lemma); a different orientation declines.
+/// the quotient `q` and the remainder `r` structurally. ORIENTATION-TOLERANT:
+/// the divisor may sit on either side of the product (`d * q` or `q * d`) and the
+/// remainder on either side of the sum. A genuine non-match declines.
 fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape> {
-    // lhs = floor(d * q + r, d)
+    // lhs = floor(<sum>, d)
     let floor_src = {
         let Expr::FnCall(callee, _) = &law.lhs.node else {
             return None;
@@ -185,17 +273,15 @@ fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape
         expr_dotted_name(callee)?
     };
     let (dividend, d_l) = floor_call(&law.lhs, &floor_src)?;
-    let Expr::BinOp(BinOp::Add, prod, r_e) = &dividend.node else {
+    let Expr::BinOp(BinOp::Add, add_l, add_r) = &dividend.node else {
         return None;
     };
-    let Expr::BinOp(BinOp::Mul, d_m, q_e) = &prod.node else {
-        return None;
-    };
+    let d_render = render(d_l, ctx);
+    let q_render = render(&law.rhs, ctx);
 
-    // The product's left factor is the divisor; the rhs is the quotient.
-    if !same_atom(d_m, d_l, ctx) || !same_atom(q_e, &law.rhs, ctx) {
-        return None;
-    }
+    let (d_left_in_product, rem, r_first) =
+        split_sum(add_l, add_r, &d_render, &q_render, ctx)?;
+    let r_render = render(rem, ctx);
 
     if !is_euclidean_floor_fn(&floor_src, ctx) {
         return None;
@@ -205,8 +291,6 @@ fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape
     let when = law.when.as_ref()?;
     let mut clauses = Vec::new();
     flatten_and(when, &mut clauses);
-    let d_render = render(d_l, ctx);
-    let r_render = render(r_e, ctx);
     let pos_d = clauses.iter().any(|cl| clause_gives_pos(cl, &d_render, ctx));
     let nonneg_r = clauses
         .iter()
@@ -221,8 +305,11 @@ fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape
     Some(AbsorbShape {
         floor_lean: aver_name_to_lean(&floor_src),
         d: d_render,
-        q: render(q_e, ctx),
+        q: q_render,
         r: r_render,
+        dividend: render(dividend, ctx),
+        d_left_in_product,
+        r_first,
     })
 }
 
@@ -245,10 +332,26 @@ pub(super) fn emit_absorb_remainder_law(
         d,
         q,
         r,
+        dividend,
+        d_left_in_product,
+        r_first,
     } = recognize_absorb(law, ctx)?;
     let when = render(law.when.as_ref()?, ctx);
     let lhs = render(&law.lhs, ctx);
     let rhs = render(&law.rhs, ctx);
+
+    // Normalize to the core lemma's canonical dividend `r + d * q`.
+    let mut normalize = String::new();
+    if !d_left_in_product {
+        // commute `q * d` -> `d * q`
+        normalize.push_str(&format!("\n  rw [Int.mul_comm {q} {d}]"));
+    }
+    if !r_first {
+        // reorder `d * q + r` -> `r + d * q` (omega abstracts the product atom)
+        normalize.push_str(&format!(
+            "\n  rw [show {d} * {q} + {r} = {r} + {d} * {q} from by omega]"
+        ));
+    }
 
     let text = format!(
         r#"{peel}
@@ -258,8 +361,7 @@ theorem {base} : ∀ {quant}, {when} = true -> {lhs} = {rhs} := by
   have hd : 0 < {d} := by omega
   have h0 : 0 <= {r} := by omega
   have hr : {r} < {d} := by omega
-  rw [{base}__floordiv_eq ({d} * {q} + {r}) {d} hd]
-  rw [show {d} * {q} + {r} = {r} + {d} * {q} from by omega]
+  rw [{base}__floordiv_eq ({dividend}) {d} hd]{normalize}
   rw [Int.add_mul_ediv_left {r} {q} (by omega : {d} ≠ 0)]
   rw [Int.ediv_eq_zero_of_lt h0 hr]
   omega"#,

--- a/src/codegen/lean/law_auto/floor_arith.rs
+++ b/src/codegen/lean/law_auto/floor_arith.rs
@@ -1,0 +1,277 @@
+//! CONTENT-BLIND Euclidean-floor arithmetic rungs — two shape-only recognizers,
+//! siblings of the nested-floor collapse, closing in pure core (NO Mathlib, NO
+//! `native_decide`).
+//!
+//! ```text
+//!   floor (a * c) (d * c) = floor a d          (0 < d, 0 < c)      [cancelCommonFactor]
+//!   floor (d * q + r) d   = q                  (0 < d, 0 <= r, r < d) [absorbRemainder]
+//! ```
+//!
+//! `floor` is a Euclidean floor-division fn (body `withDefault (Int.div a d) 0`,
+//! recognized by SHAPE via [`is_euclidean_floor_fn`], never by name). Every atom
+//! is captured STRUCTURALLY from the law's AST — no `pow2` / `trunc` / `sticky` /
+//! K5 literal anywhere in the recognizer or the emitted proof, so the same rungs
+//! fire on the K5 laws AND on a plain-integer floor-division fn in any other
+//! module (the cross-domain second witness that proves they are shape-only).
+//!
+//! Both peel each `floor a d` to the bare Euclidean quotient `a / d` (the
+//! positive-divisor zero-guard peel), then close by a CORE lemma:
+//! `Int.mul_ediv_mul_of_pos_left` cancels the shared positive factor, and
+//! `Int.add_mul_ediv_left` + `Int.ediv_eq_zero_of_lt` absorb the bounded
+//! remainder. The positivity / bound facts are read off the law's `when` guard.
+
+use super::AutoProof;
+use super::aver_name_to_lean;
+use super::shared::{
+    clause_gives_nonneg, clause_gives_pos, clause_is_lt, expr_dotted_name, flatten_and, floor_call,
+    is_euclidean_floor_fn, render, same_atom,
+};
+use crate::ast::{BinOp, Expr, VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+/// The shared `floor a d = a / d` peel lemma text (positive divisor), keyed to a
+/// per-law unique base so two floor rungs in the same module never collide.
+fn floordiv_eq_lemma(base: &str, floor: &str) -> String {
+    format!(
+        r#"theorem {base}__floordiv_eq (a d : Int) (hd : 0 < d) : {floor} a d = a / d := by
+  have hne : ¬((d == 0) = true) := by simp only [beq_iff_eq]; omega
+  simp only [{floor}]
+  rw [if_neg hne]
+  simp only [Except.withDefault]"#
+    )
+}
+
+fn intro_names(law: &VerifyLaw) -> String {
+    law.givens
+        .iter()
+        .map(|g| aver_name_to_lean(&g.name))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ---------------------------------------------------------------------------
+// cancelCommonFactor: floor (a * c) (d * c) = floor a d   (0 < d, 0 < c)
+// ---------------------------------------------------------------------------
+
+struct CancelShape {
+    floor_lean: String,
+    a: String,
+    d: String,
+    c: String,
+}
+
+/// Recognize `floor (a * c) (d * c) = floor a d`, capturing the floor fn and the
+/// atoms `a` / `d` / the shared RIGHT factor `c` structurally. The factor is
+/// keyed on the right of both products (matching the core cancel lemma); a
+/// different orientation declines.
+fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape> {
+    // rhs = floor(a, d)
+    let Expr::FnCall(callee, args) = &law.rhs.node else {
+        return None;
+    };
+    let floor_src = expr_dotted_name(callee)?;
+    if args.len() != 2 {
+        return None;
+    }
+    let (a_r, d_r) = (&args[0], &args[1]);
+
+    // lhs = floor(a * c, d * c), same floor fn
+    let (prod_a, prod_d) = floor_call(&law.lhs, &floor_src)?;
+    let Expr::BinOp(BinOp::Mul, a_l, c_a) = &prod_a.node else {
+        return None;
+    };
+    let Expr::BinOp(BinOp::Mul, d_l, c_d) = &prod_d.node else {
+        return None;
+    };
+
+    // Shared factor on the RIGHT of both products; the left factors are the
+    // dividend / divisor of the reduced rhs.
+    if !same_atom(c_a, c_d, ctx) || !same_atom(a_l, a_r, ctx) || !same_atom(d_l, d_r, ctx) {
+        return None;
+    }
+
+    if !is_euclidean_floor_fn(&floor_src, ctx) {
+        return None;
+    }
+
+    // `when` must guarantee both the divisor and the shared factor positive.
+    let when = law.when.as_ref()?;
+    let mut clauses = Vec::new();
+    flatten_and(when, &mut clauses);
+    let d_render = render(d_r, ctx);
+    let c_render = render(c_a, ctx);
+    let pos_d = clauses.iter().any(|cl| clause_gives_pos(cl, &d_render, ctx));
+    let pos_c = clauses.iter().any(|cl| clause_gives_pos(cl, &c_render, ctx));
+    if !pos_d || !pos_c {
+        return None;
+    }
+
+    Some(CancelShape {
+        floor_lean: aver_name_to_lean(&floor_src),
+        a: render(a_r, ctx),
+        d: d_render,
+        c: c_render,
+    })
+}
+
+pub(in crate::codegen::lean) fn recognize_cancel_common_factor(
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> bool {
+    recognize_cancel(law, ctx).is_some()
+}
+
+pub(super) fn emit_cancel_common_factor_law(
+    _vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    theorem_base: &str,
+    quant_params: &str,
+) -> Option<AutoProof> {
+    let CancelShape {
+        floor_lean: floor,
+        a,
+        d,
+        c,
+    } = recognize_cancel(law, ctx)?;
+    let when = render(law.when.as_ref()?, ctx);
+    let lhs = render(&law.lhs, ctx);
+    let rhs = render(&law.rhs, ctx);
+
+    let text = format!(
+        r#"{peel}
+theorem {base} : ∀ {quant}, {when} = true -> {lhs} = {rhs} := by
+  intro {intro} h_when
+  simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le, gt_iff_lt] at h_when
+  have hd : 0 < {d} := by omega
+  have hc : 0 < {c} := by omega
+  have hdc : 0 < {d} * {c} := Int.mul_pos hd hc
+  rw [{base}__floordiv_eq ({a} * {c}) ({d} * {c}) hdc, {base}__floordiv_eq {a} {d} hd]
+  exact Int.mul_ediv_mul_of_pos_left {a} {d} hc"#,
+        peel = floordiv_eq_lemma(theorem_base, &floor),
+        base = theorem_base,
+        quant = quant_params,
+        intro = intro_names(law),
+    );
+
+    Some(AutoProof {
+        support_lines: text.lines().map(str::to_string).collect(),
+        body: crate::codegen::lean::tactic_ir::Tactic::raw(Vec::new()),
+        replaces_theorem: true,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// absorbRemainder: floor (d * q + r) d = q   (0 < d, 0 <= r, r < d)
+// ---------------------------------------------------------------------------
+
+struct AbsorbShape {
+    floor_lean: String,
+    d: String,
+    q: String,
+    r: String,
+}
+
+/// Recognize `floor (d * q + r) d = q`, capturing the floor fn, the divisor `d`,
+/// the quotient `q` and the remainder `r` structurally. Keyed on the divisor
+/// being the LEFT factor of the `d * q` product (matching the core absorb
+/// lemma); a different orientation declines.
+fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape> {
+    // lhs = floor(d * q + r, d)
+    let floor_src = {
+        let Expr::FnCall(callee, _) = &law.lhs.node else {
+            return None;
+        };
+        expr_dotted_name(callee)?
+    };
+    let (dividend, d_l) = floor_call(&law.lhs, &floor_src)?;
+    let Expr::BinOp(BinOp::Add, prod, r_e) = &dividend.node else {
+        return None;
+    };
+    let Expr::BinOp(BinOp::Mul, d_m, q_e) = &prod.node else {
+        return None;
+    };
+
+    // The product's left factor is the divisor; the rhs is the quotient.
+    if !same_atom(d_m, d_l, ctx) || !same_atom(q_e, &law.rhs, ctx) {
+        return None;
+    }
+
+    if !is_euclidean_floor_fn(&floor_src, ctx) {
+        return None;
+    }
+
+    // `when` must guarantee 0 < d, 0 <= r, and r < d.
+    let when = law.when.as_ref()?;
+    let mut clauses = Vec::new();
+    flatten_and(when, &mut clauses);
+    let d_render = render(d_l, ctx);
+    let r_render = render(r_e, ctx);
+    let pos_d = clauses.iter().any(|cl| clause_gives_pos(cl, &d_render, ctx));
+    let nonneg_r = clauses
+        .iter()
+        .any(|cl| clause_gives_nonneg(cl, &r_render, ctx));
+    let r_lt_d = clauses
+        .iter()
+        .any(|cl| clause_is_lt(cl, &r_render, &d_render, ctx));
+    if !pos_d || !nonneg_r || !r_lt_d {
+        return None;
+    }
+
+    Some(AbsorbShape {
+        floor_lean: aver_name_to_lean(&floor_src),
+        d: d_render,
+        q: render(q_e, ctx),
+        r: r_render,
+    })
+}
+
+pub(in crate::codegen::lean) fn recognize_absorb_remainder(
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> bool {
+    recognize_absorb(law, ctx).is_some()
+}
+
+pub(super) fn emit_absorb_remainder_law(
+    _vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    theorem_base: &str,
+    quant_params: &str,
+) -> Option<AutoProof> {
+    let AbsorbShape {
+        floor_lean: floor,
+        d,
+        q,
+        r,
+    } = recognize_absorb(law, ctx)?;
+    let when = render(law.when.as_ref()?, ctx);
+    let lhs = render(&law.lhs, ctx);
+    let rhs = render(&law.rhs, ctx);
+
+    let text = format!(
+        r#"{peel}
+theorem {base} : ∀ {quant}, {when} = true -> {lhs} = {rhs} := by
+  intro {intro} h_when
+  simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le, gt_iff_lt] at h_when
+  have hd : 0 < {d} := by omega
+  have h0 : 0 <= {r} := by omega
+  have hr : {r} < {d} := by omega
+  rw [{base}__floordiv_eq ({d} * {q} + {r}) {d} hd]
+  rw [show {d} * {q} + {r} = {r} + {d} * {q} from by omega]
+  rw [Int.add_mul_ediv_left {r} {q} (by omega : {d} ≠ 0)]
+  rw [Int.ediv_eq_zero_of_lt h0 hr]
+  omega"#,
+        peel = floordiv_eq_lemma(theorem_base, &floor),
+        base = theorem_base,
+        quant = quant_params,
+        intro = intro_names(law),
+    );
+
+    Some(AutoProof {
+        support_lines: text.lines().map(str::to_string).collect(),
+        body: crate::codegen::lean::tactic_ir::Tactic::raw(Vec::new()),
+        replaces_theorem: true,
+    })
+}

--- a/src/codegen/lean/law_auto/floor_arith.rs
+++ b/src/codegen/lean/law_auto/floor_arith.rs
@@ -112,10 +112,8 @@ fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape
 
     // In the dividend, one side is `a` and the other is the shared factor `c`;
     // in the divisor, one side is `d` and the other must be the SAME `c`.
-    let (c_from_a, a_left) =
-        split_shared(&render(a_l, ctx), &render(c_a, ctx), &a_render)?;
-    let (c_from_d, d_left) =
-        split_shared(&render(d_l, ctx), &render(c_d, ctx), &d_render)?;
+    let (c_from_a, a_left) = split_shared(&render(a_l, ctx), &render(c_a, ctx), &a_render)?;
+    let (c_from_d, d_left) = split_shared(&render(d_l, ctx), &render(c_d, ctx), &d_render)?;
     if c_from_a != c_from_d {
         return None;
     }
@@ -129,8 +127,12 @@ fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape
     let when = law.when.as_ref()?;
     let mut clauses = Vec::new();
     flatten_and(when, &mut clauses);
-    let pos_d = clauses.iter().any(|cl| clause_gives_pos(cl, &d_render, ctx));
-    let pos_c = clauses.iter().any(|cl| clause_gives_pos(cl, &c_render, ctx));
+    let pos_d = clauses
+        .iter()
+        .any(|cl| clause_gives_pos(cl, &d_render, ctx));
+    let pos_c = clauses
+        .iter()
+        .any(|cl| clause_gives_pos(cl, &c_render, ctx));
     if !pos_d || !pos_c {
         return None;
     }
@@ -279,8 +281,7 @@ fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape
     let d_render = render(d_l, ctx);
     let q_render = render(&law.rhs, ctx);
 
-    let (d_left_in_product, rem, r_first) =
-        split_sum(add_l, add_r, &d_render, &q_render, ctx)?;
+    let (d_left_in_product, rem, r_first) = split_sum(add_l, add_r, &d_render, &q_render, ctx)?;
     let r_render = render(rem, ctx);
 
     if !is_euclidean_floor_fn(&floor_src, ctx) {
@@ -291,7 +292,9 @@ fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape
     let when = law.when.as_ref()?;
     let mut clauses = Vec::new();
     flatten_and(when, &mut clauses);
-    let pos_d = clauses.iter().any(|cl| clause_gives_pos(cl, &d_render, ctx));
+    let pos_d = clauses
+        .iter()
+        .any(|cl| clause_gives_pos(cl, &d_render, ctx));
     let nonneg_r = clauses
         .iter()
         .any(|cl| clause_gives_nonneg(cl, &r_render, ctx));

--- a/src/codegen/lean/law_auto/nested_floor.rs
+++ b/src/codegen/lean/law_auto/nested_floor.rs
@@ -23,8 +23,11 @@
 
 use super::AutoProof;
 use super::aver_name_to_lean;
-use super::shared::{expr_dotted_name, find_fn_def_by_call_name};
-use crate::ast::{BinOp, Expr, Literal, Spanned, Stmt, VerifyBlock, VerifyLaw};
+use super::shared::{
+    clause_gives_pos, expr_dotted_name, flatten_and, floor_call, is_euclidean_floor_fn, render,
+    same_atom,
+};
+use crate::ast::{BinOp, Expr, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 
 struct NestedFloorShape {
@@ -34,92 +37,6 @@ struct NestedFloorShape {
     a: String,
     d: String,
     e: String,
-}
-
-fn render(e: &Spanned<Expr>, ctx: &CodegenContext) -> String {
-    super::super::expr::emit_expr_legacy(e, ctx, None)
-}
-
-fn same_atom(a: &Spanned<Expr>, b: &Spanned<Expr>, ctx: &CodegenContext) -> bool {
-    render(a, ctx) == render(b, ctx)
-}
-
-/// `floor(x, y)` — a 2-arg call to `floor_src`; returns `(x, y)`.
-fn floor_call<'a>(
-    e: &'a Spanned<Expr>,
-    floor_src: &str,
-) -> Option<(&'a Spanned<Expr>, &'a Spanned<Expr>)> {
-    let Expr::FnCall(callee, args) = &e.node else {
-        return None;
-    };
-    if expr_dotted_name(callee).as_deref() != Some(floor_src) || args.len() != 2 {
-        return None;
-    }
-    Some((&args[0], &args[1]))
-}
-
-/// Whether `fd_src` names a Euclidean floor-division fn: its body is
-/// `Result.withDefault(Int.div(a, d), 0)` over the two parameters. This is the
-/// definition-shape gate that makes the nested-floor identity TRUE — keyed on
-/// the body, never on the fn's name.
-fn is_euclidean_floor_fn(floor_src: &str, ctx: &CodegenContext) -> bool {
-    let Some(fd) = find_fn_def_by_call_name(ctx, floor_src) else {
-        return false;
-    };
-    if !fd.effects.is_empty() || fd.params.len() != 2 {
-        return false;
-    }
-    let [Stmt::Expr(body)] = fd.body.stmts() else {
-        return false;
-    };
-    // withDefault(Int.div(_, _), 0)
-    let Expr::FnCall(callee, args) = &body.node else {
-        return false;
-    };
-    if expr_dotted_name(callee).as_deref() != Some("Result.withDefault") || args.len() != 2 {
-        return false;
-    }
-    if !matches!(&args[1].node, Expr::Literal(Literal::Int(0))) {
-        return false;
-    }
-    let Expr::FnCall(div_callee, div_args) = &args[0].node else {
-        return false;
-    };
-    expr_dotted_name(div_callee).as_deref() == Some("Int.div") && div_args.len() == 2
-}
-
-/// Flatten a `Bool.and` / `&&` conjunction of `when` clauses.
-fn flatten_and<'a>(e: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) {
-    match &e.node {
-        Expr::FnCall(callee, args)
-            if expr_dotted_name(callee).as_deref() == Some("Bool.and") && args.len() == 2 =>
-        {
-            flatten_and(&args[0], out);
-            flatten_and(&args[1], out);
-        }
-        _ => out.push(e),
-    }
-}
-
-/// Whether `clause` guarantees `0 < x` for the atom rendered as `x_render`:
-/// `0 < x`, `x > 0`, `1 <= x`, `x >= 1` (any nonneg/≥1 literal bound).
-fn clause_gives_pos(clause: &Spanned<Expr>, x_render: &str, ctx: &CodegenContext) -> bool {
-    let Expr::BinOp(op, l, r) = &clause.node else {
-        return false;
-    };
-    let int_lit = |e: &Spanned<Expr>| match &e.node {
-        Expr::Literal(Literal::Int(n)) => Some(*n),
-        _ => None,
-    };
-    match op {
-        // c < x  (c >= 0)  ⟹  0 < x ;  x > c  (c >= 0)
-        BinOp::Lt => int_lit(l).is_some_and(|c| c >= 0) && render(r, ctx) == x_render,
-        BinOp::Gt => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 0),
-        // c <= x  (c >= 1)  ;  x >= c  (c >= 1)
-        BinOp::Lte => int_lit(l).is_some_and(|c| c >= 1) && render(r, ctx) == x_render,
-        BinOp::Gte => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 1),
-        _ => false,
-    }
 }
 
 /// Recognize the nested-floor collapse shape, capturing `floor` / `a` / `d` /

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -1,9 +1,137 @@
 use std::collections::BTreeSet;
 
 use super::super::expr::aver_name_to_lean;
-use crate::ast::{Expr, FnBody, FnDef, Spanned, Stmt, VerifyBlock, VerifyLaw};
+use crate::ast::{BinOp, Expr, FnBody, FnDef, Literal, Spanned, Stmt, VerifyBlock, VerifyLaw};
 use crate::ast_rewrite::rewrite_idents_scoped;
 use crate::codegen::CodegenContext;
+
+/// Render an Aver expression to its Lean surface form (the same emitter the
+/// theorem statements use), so recognizers can compare atoms structurally.
+pub(super) fn render(e: &Spanned<Expr>, ctx: &CodegenContext) -> String {
+    super::super::expr::emit_expr_legacy(e, ctx, None)
+}
+
+/// Whether two Aver expressions render to the same Lean surface form.
+pub(super) fn same_atom(a: &Spanned<Expr>, b: &Spanned<Expr>, ctx: &CodegenContext) -> bool {
+    render(a, ctx) == render(b, ctx)
+}
+
+/// `floor(x, y)` — a 2-arg call to `floor_src`; returns `(x, y)`.
+pub(super) fn floor_call<'a>(
+    e: &'a Spanned<Expr>,
+    floor_src: &str,
+) -> Option<(&'a Spanned<Expr>, &'a Spanned<Expr>)> {
+    let Expr::FnCall(callee, args) = &e.node else {
+        return None;
+    };
+    if expr_dotted_name(callee).as_deref() != Some(floor_src) || args.len() != 2 {
+        return None;
+    }
+    Some((&args[0], &args[1]))
+}
+
+/// Whether `fd_src` names a Euclidean floor-division fn: its body is
+/// `Result.withDefault(Int.div(a, d), 0)` over the two parameters. This is the
+/// definition-shape gate that makes the floor identities TRUE — keyed on the
+/// body, never on the fn's name. Shared by every floor-division rung.
+pub(super) fn is_euclidean_floor_fn(floor_src: &str, ctx: &CodegenContext) -> bool {
+    let Some(fd) = find_fn_def_by_call_name(ctx, floor_src) else {
+        return false;
+    };
+    if !fd.effects.is_empty() || fd.params.len() != 2 {
+        return false;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    // withDefault(Int.div(_, _), 0)
+    let Expr::FnCall(callee, args) = &body.node else {
+        return false;
+    };
+    if expr_dotted_name(callee).as_deref() != Some("Result.withDefault") || args.len() != 2 {
+        return false;
+    }
+    if !matches!(&args[1].node, Expr::Literal(Literal::Int(0))) {
+        return false;
+    }
+    let Expr::FnCall(div_callee, div_args) = &args[0].node else {
+        return false;
+    };
+    expr_dotted_name(div_callee).as_deref() == Some("Int.div") && div_args.len() == 2
+}
+
+/// Flatten a `Bool.and` / `&&` conjunction of `when` clauses.
+pub(super) fn flatten_and<'a>(e: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) {
+    match &e.node {
+        Expr::FnCall(callee, args)
+            if expr_dotted_name(callee).as_deref() == Some("Bool.and") && args.len() == 2 =>
+        {
+            flatten_and(&args[0], out);
+            flatten_and(&args[1], out);
+        }
+        _ => out.push(e),
+    }
+}
+
+/// Whether `clause` guarantees `0 < x` for the atom rendered as `x_render`:
+/// `0 < x`, `x > 0`, `1 <= x`, `x >= 1` (any nonneg/≥1 literal bound).
+pub(super) fn clause_gives_pos(clause: &Spanned<Expr>, x_render: &str, ctx: &CodegenContext) -> bool {
+    let Expr::BinOp(op, l, r) = &clause.node else {
+        return false;
+    };
+    let int_lit = |e: &Spanned<Expr>| match &e.node {
+        Expr::Literal(Literal::Int(n)) => Some(*n),
+        _ => None,
+    };
+    match op {
+        // c < x  (c >= 0)  ⟹  0 < x ;  x > c  (c >= 0)
+        BinOp::Lt => int_lit(l).is_some_and(|c| c >= 0) && render(r, ctx) == x_render,
+        BinOp::Gt => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 0),
+        // c <= x  (c >= 1)  ;  x >= c  (c >= 1)
+        BinOp::Lte => int_lit(l).is_some_and(|c| c >= 1) && render(r, ctx) == x_render,
+        BinOp::Gte => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 1),
+        _ => false,
+    }
+}
+
+/// Whether `clause` guarantees `0 <= x` for the atom rendered as `x_render`:
+/// `0 <= x`, `x >= 0`, and any strictly-positive bound (which implies `>= 0`).
+pub(super) fn clause_gives_nonneg(
+    clause: &Spanned<Expr>,
+    x_render: &str,
+    ctx: &CodegenContext,
+) -> bool {
+    if clause_gives_pos(clause, x_render, ctx) {
+        return true;
+    }
+    let Expr::BinOp(op, l, r) = &clause.node else {
+        return false;
+    };
+    let int_lit = |e: &Spanned<Expr>| match &e.node {
+        Expr::Literal(Literal::Int(n)) => Some(*n),
+        _ => None,
+    };
+    match op {
+        // c <= x  (c >= 0)  ;  x >= c  (c >= 0)
+        BinOp::Lte => int_lit(l).is_some_and(|c| c >= 0) && render(r, ctx) == x_render,
+        BinOp::Gte => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 0),
+        _ => false,
+    }
+}
+
+/// Whether `clause` is the strict upper bound `x < y` for atoms rendered as
+/// `x_render` / `y_render`.
+pub(super) fn clause_is_lt(
+    clause: &Spanned<Expr>,
+    x_render: &str,
+    y_render: &str,
+    ctx: &CodegenContext,
+) -> bool {
+    let Expr::BinOp(BinOp::Lt, l, r) = &clause.node else {
+        return false;
+    };
+    render(l, ctx) == x_render && render(r, ctx) == y_render
+}
 
 pub(super) fn body_terminal_expr(body: &FnBody) -> Option<&Spanned<Expr>> {
     match body.stmts() {

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -75,7 +75,11 @@ pub(super) fn flatten_and<'a>(e: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Ex
 
 /// Whether `clause` guarantees `0 < x` for the atom rendered as `x_render`:
 /// `0 < x`, `x > 0`, `1 <= x`, `x >= 1` (any nonneg/≥1 literal bound).
-pub(super) fn clause_gives_pos(clause: &Spanned<Expr>, x_render: &str, ctx: &CodegenContext) -> bool {
+pub(super) fn clause_gives_pos(
+    clause: &Spanned<Expr>,
+    x_render: &str,
+    ctx: &CodegenContext,
+) -> bool {
     let Expr::BinOp(op, l, r) = &clause.node else {
         return false;
     };

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -687,6 +687,13 @@ fn emit_verify_law_block(
             // universal form, so dropping the sampled domain keeps statement and
             // proof aligned.
             || super::law_auto::recognize_nested_floor(&law_for_auto_proof, ctx)
+            // Euclidean-floor arithmetic: shared positive-factor cancellation
+            // (`floor (a * c) (d * c) = floor a d`) and bounded-remainder
+            // absorption (`floor (d * q + r) d = q`), proven universally in pure
+            // core. Each emit replaces the theorem with the universal form, so
+            // dropping the sampled domain keeps statement and proof aligned.
+            || super::law_auto::recognize_cancel_common_factor(&law_for_auto_proof, ctx)
+            || super::law_auto::recognize_absorb_remainder(&law_for_auto_proof, ctx)
             // Rational-order chaining law (the reciprocal-magnitude composition,
             // Lemma 8.2.4): the conclusion is the Fraction order fact `isNonNeg
             // (minus (pow2Signed BIG) A)`, proven universally by chaining the

--- a/tests/fixtures/floor_arith_witness.av
+++ b/tests/fixtures/floor_arith_witness.av
@@ -37,3 +37,27 @@ verify quotFloor law soakRemainder
     when 0 <= rest
     when rest < den
     quotFloor(den * whole + rest, den) => whole
+
+// Same cancel shape, but COMMUTED: the shared factor k sits on the LEFT of the
+// dividend and the RIGHT of the divisor (independent orientations), the
+// positivity is spelled `k > 0` instead of `0 < k`, and the when-clauses are
+// reordered. Content-blind rungs must still close it universal.
+verify quotFloor law shrinkFactorCommuted
+    given num: Int = [11, 0 - 4, 30, 0]
+    given den: Int = [2, 3, 4]
+    given k: Int = [1, 5, 6]
+    when k > 0
+    when 0 < den
+    quotFloor(k * num, den * k) => quotFloor(num, den)
+
+// Same absorb shape, but COMMUTED: the divisor is the RIGHT factor of the
+// product (`whole * den`, i.e. q * d order) and the remainder is written FIRST
+// in the sum; positivity spelled `den > 0` with reordered when-clauses.
+verify quotFloor law soakRemainderCommuted
+    given whole: Int = [4, 0 - 3, 0, 9]
+    given den: Int = [1, 2, 4, 6]
+    given rest: Int = [0, 1, 3]
+    when den > 0
+    when rest < den
+    when 0 <= rest
+    quotFloor(rest + whole * den, den) => whole

--- a/tests/fixtures/floor_arith_witness.av
+++ b/tests/fixtures/floor_arith_witness.av
@@ -50,6 +50,20 @@ verify quotFloor law shrinkFactorCommuted
     when 0 < den
     quotFloor(k * num, den * k) => quotFloor(num, den)
 
+// Fourth cancel corner: the shared factor sits on the LEFT of the DIVISOR
+// product (`scale * base`), with the dividend in the plain right orientation
+// (`top * scale`). No prior witness spelled the divisor factor-first, so this
+// exercises the divisor-side `Int.mul_comm` normalization in isolation; the
+// content-blind cancel rung must still close it universal. Fresh variable
+// names keep the witness name-blind.
+verify quotFloor law shrinkFactorDivisorLeft
+    given top: Int = [11, 0 - 4, 30, 0]
+    given base: Int = [2, 3, 4]
+    given scale: Int = [1, 5, 6]
+    when 0 < base
+    when 0 < scale
+    quotFloor(top * scale, scale * base) => quotFloor(top, base)
+
 // Same absorb shape, but COMMUTED: the divisor is the RIGHT factor of the
 // product (`whole * den`, i.e. q * d order) and the remainder is written FIRST
 // in the sum; positivity spelled `den > 0` with reordered when-clauses.

--- a/tests/fixtures/floor_arith_witness.av
+++ b/tests/fixtures/floor_arith_witness.av
@@ -19,6 +19,7 @@ verify quotFloor
 
 // Shared positive factor cancels — same shape as cancelCommonFactor, distinct
 // fn and variable names.
+
 verify quotFloor law shrinkFactor
     given num: Int = [11, 0 - 4, 30, 0]
     given den: Int = [2, 3, 4]
@@ -29,6 +30,7 @@ verify quotFloor law shrinkFactor
 
 // Bounded remainder is absorbed — same shape as absorbRemainder, distinct fn
 // and variable names.
+
 verify quotFloor law soakRemainder
     given whole: Int = [4, 0 - 3, 0, 9]
     given den: Int = [1, 2, 4, 6]
@@ -42,6 +44,7 @@ verify quotFloor law soakRemainder
 // dividend and the RIGHT of the divisor (independent orientations), the
 // positivity is spelled `k > 0` instead of `0 < k`, and the when-clauses are
 // reordered. Content-blind rungs must still close it universal.
+
 verify quotFloor law shrinkFactorCommuted
     given num: Int = [11, 0 - 4, 30, 0]
     given den: Int = [2, 3, 4]
@@ -56,6 +59,7 @@ verify quotFloor law shrinkFactorCommuted
 // exercises the divisor-side `Int.mul_comm` normalization in isolation; the
 // content-blind cancel rung must still close it universal. Fresh variable
 // names keep the witness name-blind.
+
 verify quotFloor law shrinkFactorDivisorLeft
     given top: Int = [11, 0 - 4, 30, 0]
     given base: Int = [2, 3, 4]
@@ -67,6 +71,7 @@ verify quotFloor law shrinkFactorDivisorLeft
 // Same absorb shape, but COMMUTED: the divisor is the RIGHT factor of the
 // product (`whole * den`, i.e. q * d order) and the remainder is written FIRST
 // in the sum; positivity spelled `den > 0` with reordered when-clauses.
+
 verify quotFloor law soakRemainderCommuted
     given whole: Int = [4, 0 - 3, 0, 9]
     given den: Int = [1, 2, 4, 6]

--- a/tests/fixtures/floor_arith_witness.av
+++ b/tests/fixtures/floor_arith_witness.av
@@ -1,0 +1,39 @@
+module FloorArithWitness
+    intent =
+        "Second, cross-domain witness for the Euclidean-floor arithmetic rungs:"
+        "a DIFFERENTLY-NAMED floor-division fn (quotFloor, over num/den) in a"
+        "different module, carrying the SAME two claim shapes as the K5 leaf"
+        "probe. If the cancel / absorb rungs are truly content-blind (keyed on"
+        "shape, not on floorDiv / K5 names), both laws close universal here too."
+    exposes [quotFloor]
+    effects []
+
+fn quotFloor(num: Int, den: Int) -> Int
+    ? "Euclidean floor division num / den; guarded to 0 at den = 0."
+    Result.withDefault(Int.div(num, den), 0)
+
+verify quotFloor
+    quotFloor(9, 4) => 2
+    quotFloor(0 - 9, 4) => 0 - 3
+    quotFloor(100, 7) => 14
+
+// Shared positive factor cancels — same shape as cancelCommonFactor, distinct
+// fn and variable names.
+verify quotFloor law shrinkFactor
+    given num: Int = [11, 0 - 4, 30, 0]
+    given den: Int = [2, 3, 4]
+    given k: Int = [1, 5, 6]
+    when 0 < den
+    when 0 < k
+    quotFloor(num * k, den * k) => quotFloor(num, den)
+
+// Bounded remainder is absorbed — same shape as absorbRemainder, distinct fn
+// and variable names.
+verify quotFloor law soakRemainder
+    given whole: Int = [4, 0 - 3, 0, 9]
+    given den: Int = [1, 2, 4, 6]
+    given rest: Int = [0, 1, 3]
+    when 0 < den
+    when 0 <= rest
+    when rest < den
+    quotFloor(den * whole + rest, den) => whole

--- a/tests/proof_spec/floor_window.rs
+++ b/tests/proof_spec/floor_window.rs
@@ -127,6 +127,7 @@ fn proof_export_floor_arith_second_witness_universal() {
         "quotFloor_law_shrinkFactor",
         "quotFloor_law_soakRemainder",
         "quotFloor_law_shrinkFactorCommuted",
+        "quotFloor_law_shrinkFactorDivisorLeft",
         "quotFloor_law_soakRemainderCommuted",
     ] {
         assert!(
@@ -147,6 +148,13 @@ fn proof_export_floor_arith_second_witness_universal() {
     assert!(
         lean.contains("rw [Int.mul_comm whole den]"),
         "commuted absorb witness must normalize the divisor multiplicand with Int.mul_comm"
+    );
+    // The fourth cancel corner puts the shared factor on the LEFT of the DIVISOR
+    // product; its normalization commutes the divisor multiplicand (not the
+    // dividend), a path no other witness exercises.
+    assert!(
+        lean.contains("rw [Int.mul_comm scale base]"),
+        "divisor-left cancel witness must normalize the divisor factor with Int.mul_comm"
     );
     // No law theorem REACHES sorry (only `first | proof | sorry` fail-safe
     // floors are permitted, and these rungs emit none).
@@ -319,6 +327,59 @@ fn proof_floor_window_lean_closes_kernel_genuine() {
         (Some(4), Some(0)),
         "explicit law counts: exactly the four universal-classed law \
          theorems certified, none degraded to bounded-domain.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// Live Lean gate for the second, cross-domain witness
+/// (`tests/fixtures/floor_arith_witness.av`). The export-structure pin
+/// (`proof_export_floor_arith_second_witness_universal`) only asserts the
+/// `universal` law-class MARKERS, which the Rust classifier stamps when the
+/// rung FIRES — not when the Lean kernel accepts the proof. This gate builds
+/// the whole fixture with the toolchain and asserts all five witness laws
+/// close sorry-free AND earn kernel-genuine `universal` credit (`#print
+/// axioms` inside the whitelist, encoded by the `universal` summary flag —
+/// same contract as `proof_floor_window_lean_closes_kernel_genuine`). Covers
+/// every orientation corner of the cancel / absorb rungs, including the
+/// shared factor on the LEFT of the divisor product.
+#[test]
+fn proof_floor_arith_witness_lean_closes_kernel_genuine() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping floor-arith-witness proof test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-floor-arith-witness-lake");
+    let (summary, run) =
+        run_lean_check_json("tests/fixtures/floor_arith_witness.av", &output_dir, 0, &[]);
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "floor-arith witness laws must close sorry-free.\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "all five witness law theorems are stated universally and must be \
+         kernel-genuine (axioms within the whitelist).\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        (
+            summary["universal_laws"].as_u64(),
+            summary["bounded_laws"].as_u64(),
+        ),
+        (Some(5), Some(0)),
+        "explicit law counts: exactly the five universal-classed witness \
+         theorems certified (every cancel / absorb orientation corner), none \
+         degraded to bounded-domain.\n{}",
         format_output(&run)
     );
     let _ = std::fs::remove_dir_all(&output_dir);

--- a/tests/proof_spec/floor_window.rs
+++ b/tests/proof_spec/floor_window.rs
@@ -91,6 +91,59 @@ fn proof_export_floor_window_lean_structure() {
     let _ = std::fs::remove_dir_all(&output_dir);
 }
 
+/// Second, cross-domain WITNESS for the Euclidean-floor arithmetic rungs
+/// (`tests/fixtures/floor_arith_witness.av`). The cancel / absorb rungs are
+/// keyed only on the CLAIM SHAPE (`floor (a * c) (d * c) = floor a d`;
+/// `floor (d * q + r) d = q`), never on the K5 `floorDiv` name. This fixture
+/// states the SAME two shapes over a differently-named floor-division fn
+/// (`quotFloor`, over `num`/`den`) in a different module with different given
+/// names — if the rungs were name-blind, both laws close `universal` here too.
+/// Export-structure pin (no toolchain needed): asserts the `universal`
+/// law-class markers and no REACHED sorry.
+#[test]
+fn proof_export_floor_arith_second_witness_universal() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let output_dir = temp_output_dir("aver-proof-floor-arith-witness");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/floor_arith_witness.av")
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("aver proof should run");
+    assert!(run.status.success(), "{}", format_output(&run));
+    let lean = std::fs::read_to_string(output_dir.join("FloorArithWitness.lean"))
+        .expect("FloorArithWitness.lean must be emitted");
+
+    // Both cross-domain law theorems replace their bounded statements with the
+    // TRUE universal form and are classed `universal` — the rungs fired on a
+    // fn with no `floorDiv` / K5 name.
+    for base in ["quotFloor_law_shrinkFactor", "quotFloor_law_soakRemainder"] {
+        assert!(
+            lean.contains(&format!("-- aver:law-class {base} universal")),
+            "{base} must be classed universal (rung is name-blind); got:\n{lean}"
+        );
+    }
+    // The core lemmas the rungs cite are present, not a sampled `native_decide`
+    // fallback or a bounded statement.
+    assert!(lean.contains("Int.mul_ediv_mul_of_pos_left"));
+    assert!(lean.contains("Int.add_mul_ediv_left"));
+    // No law theorem REACHES sorry (only `first | proof | sorry` fail-safe
+    // floors are permitted, and these rungs emit none).
+    let reached_sorry: Vec<&str> = lean
+        .lines()
+        .filter(|l| l.contains("sorry") && !l.contains("| sorry"))
+        .collect();
+    assert!(
+        reached_sorry.is_empty(),
+        "the second-witness fixture must not REACH sorry; offending lines:\n{}",
+        reached_sorry.join("\n")
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
 /// Export-structure pin, Dafny side (no toolchain needed). Before the
 /// class existed the binary-exponent fn declined to an opaque
 /// `{:axiom}` and the significand law was omitted; the other three

--- a/tests/proof_spec/floor_window.rs
+++ b/tests/proof_spec/floor_window.rs
@@ -117,19 +117,37 @@ fn proof_export_floor_arith_second_witness_universal() {
     let lean = std::fs::read_to_string(output_dir.join("FloorArithWitness.lean"))
         .expect("FloorArithWitness.lean must be emitted");
 
-    // Both cross-domain law theorems replace their bounded statements with the
-    // TRUE universal form and are classed `universal` — the rungs fired on a
-    // fn with no `floorDiv` / K5 name.
-    for base in ["quotFloor_law_shrinkFactor", "quotFloor_law_soakRemainder"] {
+    // Every cross-domain law theorem replaces its bounded statement with the
+    // TRUE universal form and is classed `universal` — the rungs fired on a
+    // fn with no `floorDiv` / K5 name. The `Commuted` witnesses additionally
+    // pin the ORIENTATION-TOLERANT path: shared factor / divisor multiplicand
+    // written on the opposite side, an alternative positivity spelling
+    // (`k > 0`, `den > 0`) and reordered when-clauses.
+    for base in [
+        "quotFloor_law_shrinkFactor",
+        "quotFloor_law_soakRemainder",
+        "quotFloor_law_shrinkFactorCommuted",
+        "quotFloor_law_soakRemainderCommuted",
+    ] {
         assert!(
             lean.contains(&format!("-- aver:law-class {base} universal")),
-            "{base} must be classed universal (rung is name-blind); got:\n{lean}"
+            "{base} must be classed universal (rung is name- and orientation-blind); got:\n{lean}"
         );
     }
     // The core lemmas the rungs cite are present, not a sampled `native_decide`
     // fallback or a bounded statement.
     assert!(lean.contains("Int.mul_ediv_mul_of_pos_left"));
     assert!(lean.contains("Int.add_mul_ediv_left"));
+    // The commuted witnesses drive the `Int.mul_comm` normalization step that
+    // rewrites the written product into the core lemma's canonical operand order.
+    assert!(
+        lean.contains("rw [Int.mul_comm k num]"),
+        "commuted cancel witness must normalize the shared factor with Int.mul_comm"
+    );
+    assert!(
+        lean.contains("rw [Int.mul_comm whole den]"),
+        "commuted absorb witness must normalize the divisor multiplicand with Int.mul_comm"
+    );
     // No law theorem REACHES sorry (only `first | proof | sorry` fail-safe
     // floors are permitted, and these rungs emit none).
     let reached_sorry: Vec<&str> = lean


### PR DESCRIPTION
Two more leaf identities of the sticky-plus rounding decomposition now close in pure core, push-button, where the engine previously fell back to bounded-domain sample enumeration:

- `floor (a * c) (d * c) = floor a d` for `0 < d, 0 < c` (shared positive factor cancels)
- `floor (d * q + r) d = q` for `0 < d, 0 <= r < d` (bounded remainder is absorbed)

## What

Both are content-blind rungs keyed only on the claim shape, never on function or module names. The same definition-shape gate the nested-floor rung uses confirms the fn is a real Euclidean division (body `withDefault (Int.div a d) 0`), and every atom is captured structurally from the AST.

- Cancel identity closes by the core lemma `Int.mul_ediv_mul_of_pos_left`.
- Absorb identity closes by `Int.add_mul_ediv_left` plus `Int.ediv_eq_zero_of_lt`.
- No Mathlib, no `native_decide`; each theorem's axioms stay within `{propext, Quot.sound}`.

The floor-shape recognizer helpers the nested-floor rung introduced (the Euclidean-division gate, the when-clause flattening, the positivity reader) are hoisted into the shared module so both rungs reuse one copy instead of duplicating them.

## Genericity

Pinned by a second, cross-domain witness (`tests/fixtures/floor_arith_witness.av`): the same two shapes stated over a differently-named division fn in a different module with different variable names both close universal, asserted by a new proof-spec structure test.

## Gates

- `leafprobe.av` verifies, 0 failed
- Both laws `universal` on the Lean kernel, 0 sorries, axioms `{propext, Quot.sound}`
- `round.av` unchanged at 21 universal (no regression)
- `cargo test --lib` 904, `proof_spec` 191, `identity_guardrails` green
- clippy clean on the new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)