### PR TITLE
Restore the honest-failure floor of the proof checker

### DIFF
--- a/docs/dafny.md
+++ b/docs/dafny.md
@@ -188,7 +188,7 @@ lemma fib_fibSpec(n: int)
 
 ## Limitations
 
-- **No verify cases**: Z3 times out on deep computations like `fib(12) == 144`
+- **No verify cases**: Z3 times out on deep computations like `fib(12) == 144`. Dafny's own `errors` total is blind to per-lemma timeouts, so `--check-json` carries a separate additive `timeouts` field (count of `… timed out after N seconds` lines) alongside `errors`; a consumer accounting for failing laws must read both. `timeouts` is informational — it does not change `passed` or the exit code (the timed-out run still fails via Dafny's exit status)
 - **Constructor collisions**: if a user type defines variants named `Ok`/`Err`, Dafny may report ambiguity errors
 - **Opaque builtins**: `IntToString`, `FloatFromString`, `CharToCode` etc. are declared without bodies — Z3 knows their signatures but can't reason about their implementation
 - **Complex laws**: laws involving indirect recursion, accumulator patterns, or multi-function chains may not be provable by Z3 alone

--- a/docs/lean.md
+++ b/docs/lean.md
@@ -185,6 +185,12 @@ summary line. Fields of the Lean summary:
   verify-on-domain still passes; this is deliberately the lenient gate)
 - `sorries` — residual `sorry` count across the build output
   (`--sorry-budget N` tolerates up to N)
+- `build_errors` — count of HARD lake/lean build errors (source-located
+  `error: file.lean:L:C: …` diagnostics), distinct from `sorries`. A
+  degraded proof arm should always fall to a caught `sorry`; a non-zero
+  `build_errors` means a tactic escaped the `first | … | sorry` floor and
+  `sorries` alone would read as an honest-looking result. Informational
+  only — it does not change `passed` or the exit code
 - `universal` — `true` only when EVERY law theorem in the export is
   kernel-genuine: its `#print axioms` stays inside
   `{propext, Classical.choice, Quot.sound}` (so `native_decide` and

--- a/src/codegen/lean/law_auto/induction/floor_bound.rs
+++ b/src/codegen/lean/law_auto/induction/floor_bound.rs
@@ -2496,6 +2496,9 @@ pub(super) fn emit_rational_floor_family(
                     }
                 }
             }
+            // Same `h_when` naming contract as inequality.rs: the guard is in
+            // scope under the name `h_when` so the prelude conjunction-split arm
+            // in `aver_int_order` can read it by name (one-level split only).
             let close = format!(
                 "simp only [{defs}, Bool.and_eq_true, Bool.or_eq_true, ge_iff_le, gt_iff_lt, decide_eq_true_eq, beq_iff_eq] at h_when ⊢ <;> aver_int_order"
             );

--- a/src/codegen/lean/law_auto/inequality.rs
+++ b/src/codegen/lean/law_auto/inequality.rs
@@ -65,6 +65,10 @@ pub(super) fn emit_nonlinear_nonneg_law(
     // closes the goal from leaving `aver_int_order` running on no goals.
     let (intro_names, branch) = if law.when.is_some() {
         let mut names = givens;
+        // Naming contract: the guard MUST be introduced as `h_when`. The
+        // prelude's conjunction-split arm in `aver_int_order` reads it by that
+        // exact name (`And.left h_when` / `And.right h_when`) and peels one
+        // level only; rename it and that arm silently no-ops (see prelude.rs).
         names.push("h_when".to_string());
         (
             names,

--- a/src/codegen/lean/prelude.rs
+++ b/src/codegen/lean/prelude.rs
@@ -949,10 +949,20 @@ that is NOT derivable when the law carries no `0 ≤ a` guard. Trying
 contraction's `s²` bound) its shared-right-factor unification fails fast (the
 two right factors differ), so `mul_le_mul` still takes them — and any genuine
 `0 ≤ b` leaf there is closed by the early `omega` rung from that family's
-`0 ≤ e ≤ b` guards. The `mul_le_mul` arm is locally heartbeat-capped because
-bad metavariable product searches can otherwise escape the outer proof floor as
-a deterministic `whnf` timeout; a timeout in that arm should be just another
-failed `first` alternative.
+`0 ≤ e ≤ b` guards. The `mul_le_mul` arm is NOT heartbeat-capped: a
+deterministic `whnf` timeout is a HARD, uncatchable failure of a `first`
+portfolio at the tactic level — it aborts `lake build` rather than falling
+through to the next `first` alternative. `set_option maxHeartbeats … in` only
+takes effect at the COMMAND level, never inside a `first | …` tactic
+alternative (measured 2026-07-02 across three controlled builds under Lean
+4.31: the inline wrapper changed nothing). So this timeout class is not
+containable here. What actually keeps this arm from diverging in practice is
+the narrower conjunction split below (keyed to the named `h_when` guard rather
+than an anonymous `_ ∧ _` match, so it no longer feeds spurious metavariable
+products into the product rungs), not any cap. When a timeout does occur its
+class is surfaced truthfully by the `--check-json` `build_errors` field; the
+named follow-up is driver-level re-emission of the offending law WITHOUT this
+arm (a tactic-level cap cannot do it).
 
 The MULTIPLY-BY-POSITIVE rungs (`mul_lt_mul_of_pos_left` / `_right` for a strict
 product order `m*a < m*b` / `a*m < b*m`, and `mul_le_mul_of_nonneg_left` for the
@@ -967,7 +977,17 @@ composition step. Placed last so their strict (`<`) conclusion never shadows a
 `<=`/`0 <=`/`0 <` goal the earlier rungs own (a strict-conclusion lemma cannot
 unify with a non-strict goal, but keeping them last also keeps the common
 nonneg/positivity search shallow and the output byte-identical for corpora that
-never hit a multiplied-form goal). -/
+never hit a multiplied-form goal).
+
+The final arm splits a named guard conjunction and recurses. It reads the
+hypothesis LITERALLY named `h_when` — the order-law emitters
+(`law_auto/inequality.rs`, `law_auto/induction/floor_bound.rs`) intro the guard
+under exactly that name and `simp … at h_when ⊢` — takes `And.left`/`And.right`,
+and recurses. This is a NAMING CONTRACT: any new order-law emitter that renames
+the guard makes this arm silently no-op (no `h_when` in context), and the goal
+falls to `sorry`. It also peels ONE level only (measured): a right-nested guard
+of three-plus conjuncts (`A ∧ (B ∧ C)`) yields `h_when_left := A` /
+`h_when_right := B ∧ C`, leaving the inner conjunction bundled. -/
 syntax "aver_int_order" : tactic
 macro_rules
   | `(tactic| aver_int_order) => `(tactic|
@@ -978,8 +998,7 @@ macro_rules
         | (apply Int.mul_nonneg <;> aver_int_order)
         | (apply Int.mul_pos <;> aver_int_order)
         | (apply Int.mul_le_mul_of_nonneg_right <;> aver_int_order)
-        | (set_option maxHeartbeats 50000 in
-           apply Int.mul_le_mul <;> aver_int_order)
+        | (apply Int.mul_le_mul <;> aver_int_order)
         | (apply Int.mul_lt_mul_of_pos_left <;> aver_int_order)
         | (apply Int.mul_lt_mul_of_pos_right <;> aver_int_order)
         | (apply Int.mul_le_mul_of_nonneg_left <;> aver_int_order)

--- a/src/codegen/lean/prelude.rs
+++ b/src/codegen/lean/prelude.rs
@@ -943,14 +943,16 @@ conclusions `0 < _` / `0 ≤ _` never unify, so neither shadows the other). The
 `mul_le_mul_of_nonneg_right` rung sits BEFORE
 `mul_le_mul`, and that order is load-bearing for performance: `mul_le_mul`
 would also unify with `a*c ≤ b*c` (taking `d := c`) but spawns a `0 ≤ b` leaf
-that is NOT derivable when the law carries no `0 ≤ a` guard, and the three
-product rungs then thrash on that atomic leaf with metavariable products until
-the heartbeat limit. Trying `mul_le_mul_of_nonneg_right` first closes such a
-goal directly from `a ≤ b` / `0 ≤ c` and never spawns `0 ≤ b`; on the squared
-shapes (`e*e ≤ b*b`, the contraction's `s²` bound) its shared-right-factor
-unification fails fast (the two right factors differ), so `mul_le_mul` still
-takes them — and any genuine `0 ≤ b` leaf there is closed by the early `omega`
-rung from that family's `0 ≤ e ≤ b` guards.
+that is NOT derivable when the law carries no `0 ≤ a` guard. Trying
+`mul_le_mul_of_nonneg_right` first closes such a goal directly from `a ≤ b` /
+`0 ≤ c` and never spawns `0 ≤ b`; on the squared shapes (`e*e ≤ b*b`, the
+contraction's `s²` bound) its shared-right-factor unification fails fast (the
+two right factors differ), so `mul_le_mul` still takes them — and any genuine
+`0 ≤ b` leaf there is closed by the early `omega` rung from that family's
+`0 ≤ e ≤ b` guards. The `mul_le_mul` arm is locally heartbeat-capped because
+bad metavariable product searches can otherwise escape the outer proof floor as
+a deterministic `whnf` timeout; a timeout in that arm should be just another
+failed `first` alternative.
 
 The MULTIPLY-BY-POSITIVE rungs (`mul_lt_mul_of_pos_left` / `_right` for a strict
 product order `m*a < m*b` / `a*m < b*m`, and `mul_le_mul_of_nonneg_left` for the
@@ -976,11 +978,15 @@ macro_rules
         | (apply Int.mul_nonneg <;> aver_int_order)
         | (apply Int.mul_pos <;> aver_int_order)
         | (apply Int.mul_le_mul_of_nonneg_right <;> aver_int_order)
-        | (apply Int.mul_le_mul <;> aver_int_order)
+        | (set_option maxHeartbeats 50000 in
+           apply Int.mul_le_mul <;> aver_int_order)
         | (apply Int.mul_lt_mul_of_pos_left <;> aver_int_order)
         | (apply Int.mul_lt_mul_of_pos_right <;> aver_int_order)
         | (apply Int.mul_le_mul_of_nonneg_left <;> aver_int_order)
-        | (obtain ⟨hl, hr⟩ := ‹_ ∧ _›; aver_int_order))"#;
+        | (have h_when_left := And.left h_when
+           have h_when_right := And.right h_when
+           clear h_when
+           aver_int_order))"#;
 
 #[cfg(test)]
 pub(super) fn generate_prelude() -> String {

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -603,10 +603,13 @@ pub(super) enum Commands {
         #[arg(long, requires = "check")]
         sorry_budget: Option<usize>,
         /// `--check` only: emit a structured JSON summary
-        /// (`{backend, errors, sorries, budget, passed}`) to stdout
-        /// instead of streaming the verifier's raw output. Exit
-        /// codes unchanged: 0 within budget, 1 over, 2 on harness
-        /// failure.
+        /// (`{backend, errors, sorries, budget, passed, ...}`) to stdout
+        /// instead of streaming the verifier's raw output. Additive
+        /// telemetry fields: Lean carries `build_errors` (hard lake/lean
+        /// errors distinct from sorries), Dafny carries `timeouts`
+        /// (per-lemma timeouts the `errors` count is blind to); both are
+        /// informational and never change exit codes. Exit codes
+        /// unchanged: 0 within budget, 1 over, 2 on harness failure.
         #[arg(long, requires = "check")]
         check_json: bool,
         /// `--check` only (Lean-only): for each law that does NOT close

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5700,6 +5700,19 @@ fn run_proof_check(
         }
     };
 
+    // Additive check-json telemetry, per backend — informational only, NEVER
+    // folded into `passed` or the exit code (the floor still degrades to a
+    // caught `sorry` / the budgets still gate). `build_errors` surfaces a hard
+    // Lean error that `sorries` hides; `timeouts` surfaces Dafny timeouts the
+    // `errors` count is blind to.
+    let (lean_build_errors, dafny_timeouts): (Option<usize>, Option<usize>) = match backend {
+        super::cli::ProofBackend::Lean => (
+            Some(count_lean_build_errors(&stderr) + count_lean_build_errors(&stdout)),
+            None,
+        ),
+        super::cli::ProofBackend::Dafny => (None, Some(count_dafny_timeouts(&stdout))),
+    };
+
     if model_panic_hits > 0 {
         eprintln!(
             "{}",
@@ -5873,8 +5886,14 @@ fn run_proof_check(
         if let Some(e) = errors {
             obj.insert("errors".into(), e.into());
         }
+        if let Some(t) = dafny_timeouts {
+            obj.insert("timeouts".into(), t.into());
+        }
         if let Some(s) = sorries {
             obj.insert("sorries".into(), s.into());
+        }
+        if let Some(be) = lean_build_errors {
+            obj.insert("build_errors".into(), be.into());
         }
         if let Some(a) = axioms {
             obj.insert("axioms".into(), a.into());
@@ -6440,6 +6459,42 @@ fn count_dafny_omitted_universals(dir: &str) -> usize {
 fn count_lean_sorries(s: &str) -> usize {
     s.lines()
         .filter(|l| l.contains("declaration uses") && l.contains("sorry"))
+        .count()
+}
+
+/// Count HARD Lean/lake build errors in captured verifier output — the
+/// source-located `error: <file>.lean:L:C: …` diagnostics that abort the
+/// build, DISTINCT from `sorry` (a non-fatal warning counted by
+/// `count_lean_sorries`). A degraded proof arm should always fall to a caught
+/// `sorry`; a hard error here means a tactic escaped the `first | … | sorry`
+/// floor (measured: `assumption` on a metavariable conjunction goal, a
+/// deterministic `whnf` heartbeat timeout), which `sorries` alone hides. Lake's
+/// cascade lines (`error: Lean exited with code 1`, `error: build failed`)
+/// carry no `.lean:` source location and are not counted, so one failing
+/// theorem reads as one hard error, not three. Purely telemetry: never gates
+/// `passed` or the exit code.
+fn count_lean_build_errors(s: &str) -> usize {
+    s.lines()
+        .filter(|l| {
+            let l = l.trim_start();
+            l.starts_with("error:") && l.contains(".lean:")
+        })
+        .count()
+}
+
+/// Count Dafny per-lemma verification timeouts in captured verifier output.
+/// The `errors` count from `parse_dafny_error_count` mirrors only Dafny's
+/// "N errors" total and is BLIND to timeouts (measured on k5_fdiv round.av:
+/// 2 errors reported while 12 additional laws timed out), so a consumer
+/// reading `errors` alone under-counts failing laws. Each timed-out lemma
+/// prints one `Verification of '…' timed out after N seconds` line; the
+/// summary "N time outs" line uses "time outs" (with a space) and is not
+/// matched, so it is not double-counted. Purely telemetry: never gates
+/// `passed` or the exit code.
+fn count_dafny_timeouts(stdout: &str) -> usize {
+    stdout
+        .lines()
+        .filter(|l| l.contains("timed out after"))
         .count()
 }
 
@@ -9296,6 +9351,75 @@ mod tests {
             "both glyphs counted, unrelated lines ignored"
         );
         assert_eq!(super::count_lean_sorries("Build completed successfully"), 0);
+    }
+
+    #[test]
+    fn count_lean_build_errors_counts_hard_errors_not_cascade_or_sorries() {
+        // Verbatim captured pre-fix output of probe_a.av (the DEFECT-1 file):
+        // one source-located hard error escaped the sorry floor while the
+        // check-json line reported only `sorries:1`. The counter must see the
+        // ONE real Lean error, ignore the `sorry` warning, and ignore lake's
+        // cascade lines (`Lean exited with code 1`, `build failed`) that carry
+        // no `.lean:` location — otherwise one failure would read as three.
+        let probe_a = "\
+warning: SosProbeA.lean:65:49: This simp argument is unused:
+error: SosProbeA.lean:100:113: Tactic `assumption` failed
+warning: SosProbeA.lean:175:8: declaration uses `sorry`
+error: Lean exited with code 1
+Some required targets logged failures:
+- SosProbeA
+error: build failed";
+        assert_eq!(super::count_lean_build_errors(probe_a), 1);
+        // The genuine sorry warning is NOT a build error.
+        assert_eq!(super::count_lean_sorries(probe_a), 1);
+        // A deterministic whnf timeout (probe_b2's DEFECT-2 shape) is also a
+        // hard, source-located error.
+        let probe_b2 = "error: SosProbeB2.lean:69:0: (deterministic) timeout at 'whnf', maximum number of heartbeats (200000)";
+        assert_eq!(super::count_lean_build_errors(probe_b2), 1);
+        // A clean build has zero.
+        assert_eq!(
+            super::count_lean_build_errors("Build completed successfully"),
+            0
+        );
+    }
+
+    #[test]
+    fn count_dafny_timeouts_counts_timed_out_lemmas_not_summary() {
+        // Verbatim captured lines from the k5_fdiv round.av Dafny run
+        // (prompts/probe-artifacts/dafny-parity/.../run2.log): 12 lemmas timed
+        // out while `errors` reported only 2. Each timeout is one
+        // `timed out after` line; the "N time outs" summary (space) and the two
+        // postcondition errors must NOT be counted as timeouts.
+        let run2 = "\
+Round.dfy(244,26): Error: Verification of 'floorDiv_dividesPow2Multiple' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(278,26): Error: Verification of 'floorDiv_nestedFloorCollapse' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(340,26): Error: Verification of 'floorDiv_absorbRemainder' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(470,74): Error: Verification of 'truncErrorMagnitudeNonneg_nonneg' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(492,0): Error: a postcondition could not be proved on this return path
+Round.dfy(491,33): Related location: this is the postcondition that could not be proved
+Round.dfy(520,81): Error: Verification of 'truncErrorReconstructs_reconstructsValue' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(554,0): Error: a postcondition could not be proved on this return path
+Round.dfy(553,32): Related location: this is the postcondition that could not be proved
+Round.dfy(582,58): Error: Verification of 'truncErrorSameSign_signCondition' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(737,50): Error: Verification of 'truncComposes_composesToInner' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(768,72): Error: Verification of 'awayTruncComposes_composesToInner' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(799,76): Error: Verification of 'truncStickyComposes_composesThroughSticky' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(830,78): Error: Verification of 'awayErrorReconstructs_reconstructsValue' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(861,53): Error: Verification of 'awayErrorBound_strictBound' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+Round.dfy(923,57): Error: Verification of 'stickyErrorBound_strictBound' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+
+Dafny program verifier finished with 158 verified, 2 errors, 12 time outs";
+        assert_eq!(super::count_dafny_timeouts(run2), 12);
+        // The `errors` parser still reports 2 on the same capture — the two are
+        // orthogonal counts.
+        assert_eq!(super::parse_dafny_error_count(run2), Some(2));
+        // A clean run has zero timeouts.
+        assert_eq!(
+            super::count_dafny_timeouts(
+                "Dafny program verifier finished with 8 verified, 0 errors"
+            ),
+            0
+        );
     }
 
     fn empty_codegen_ctx() -> CodegenContext {

--- a/tests/fixtures/failsoft_sos_probe_a.av
+++ b/tests/fixtures/failsoft_sos_probe_a.av
@@ -1,0 +1,65 @@
+module SosProbeA
+    intent =
+        "SOS-certificate probe A. A hand-supplied sum-of-squares certificate for"
+        "the AM-GM style inequality a*a + b*b >= 2*a*b, split into the two NSPI"
+        "obligations: the ring identity f - g == sigma (amgmId) and the certificate"
+        "nonnegativity 0 <= sigma (amgmCertNonneg, sosGuardedComb). The target law"
+        "amgm is stated WITHOUT the certificate in its body: it closes only if the"
+        "checkers compose the pool lemmas. amgm as-written is also the negative"
+        "control: its witness square (a-b)^2 is not syntactically present."
+    exposes [amgmId, amgmCertNonneg, sosGuardedComb, amgm]
+    effects []
+
+fn amgmId(a: Int, b: Int) -> Bool
+    ? "Certificate identity: f - g equals the hand-chosen square (a-b)^2."
+    a * a + b * b - 2 * a * b == (a - b) * (a - b)
+
+verify amgmId
+    amgmId(1, 2) => true
+    amgmId(-3, 5) => true
+
+verify amgmId law universal
+    given a: Int = [-7, -1, 0, 1, 9]
+    given b: Int = [-4, 0, 2, 8]
+    amgmId(a, b) holds
+
+fn amgmCertNonneg(a: Int, b: Int) -> Bool
+    ? "Certificate nonnegativity: the hand-chosen square is nonnegative."
+    (a - b) * (a - b) >= 0
+
+verify amgmCertNonneg
+    amgmCertNonneg(1, 2) => true
+    amgmCertNonneg(-3, 5) => true
+
+verify amgmCertNonneg law universal
+    given a: Int = [-7, -1, 0, 1, 9]
+    given b: Int = [-4, 0, 2, 8]
+    amgmCertNonneg(a, b) holds
+
+fn sosGuardedComb(a: Int, b: Int, g: Int) -> Bool
+    ? "sigma_0 + sigma_1 * g_1 with hand-chosen squares and premise g >= 0."
+    (a - b) * (a - b) + g * ((a + b) * (a + b)) >= 0
+
+verify sosGuardedComb
+    sosGuardedComb(1, 2, 3) => true
+    sosGuardedComb(-3, 5, 0) => true
+
+verify sosGuardedComb law guarded
+    given a: Int = [-7, -1, 0, 1, 9]
+    given b: Int = [-4, 0, 2, 8]
+    given g: Int = [0, 1, 5]
+    when g >= 0
+    sosGuardedComb(a, b, g) holds
+
+fn amgm(a: Int, b: Int) -> Bool
+    ? "Target inequality; the witness square is NOT syntactically present."
+    a * a + b * b >= 2 * a * b
+
+verify amgm
+    amgm(1, 2) => true
+    amgm(-3, 5) => true
+
+verify amgm law universal
+    given a: Int = [-7, -1, 0, 1, 9]
+    given b: Int = [-4, 0, 2, 8]
+    amgm(a, b) holds

--- a/tests/fixtures/failsoft_sos_probe_b2.av
+++ b/tests/fixtures/failsoft_sos_probe_b2.av
@@ -1,0 +1,40 @@
+module SosProbeB2
+    intent =
+        "Boundary variant of probe B: same cleared |a| <= p*b shape but with"
+        "NON-strict premises p*b - a >= 0 and p*b + a >= 0. nsCert is the pure"
+        "product-of-premises certificate step; nsTarget is the composed target"
+        "without the certificate in its body."
+    exposes [nsCert, nsTarget]
+    effects []
+
+fn nsCert(a: Int, p: Int, b: Int) -> Bool
+    ? "Certificate positivity, non-strict: product of the cleared premises >= 0."
+    (p * b - a) * (p * b + a) >= 0
+
+verify nsCert
+    nsCert(1, 2, 3) => true
+    nsCert(0, 1, 1) => true
+
+verify nsCert law guarded
+    given a: Int = [-6, -1, 0, 2, 5]
+    given p: Int = [1, 2, 4]
+    given b: Int = [1, 3]
+    when p * b - a >= 0
+    when p * b + a >= 0
+    nsCert(a, p, b) holds
+
+fn nsTarget(a: Int, p: Int, b: Int) -> Bool
+    ? "Target, non-strict: a*a <= (p*b)*(p*b) without the certificate in the body."
+    a * a <= (p * b) * (p * b)
+
+verify nsTarget
+    nsTarget(1, 2, 3) => true
+    nsTarget(0, 1, 1) => true
+
+verify nsTarget law guarded
+    given a: Int = [-6, -1, 0, 2, 5]
+    given p: Int = [1, 2, 4]
+    given b: Int = [1, 3]
+    when p * b - a >= 0
+    when p * b + a >= 0
+    nsTarget(a, p, b) holds

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -82,6 +82,31 @@ fn proof_export_builds_int_abs_laws_when_lake_is_available() {
 }
 
 #[test]
+fn proof_export_failsoft_sos_probe_a_degrades_to_sorry_when_lake_is_available() {
+    // Regression for the fail-soft floor: the guarded nonlinear nonnegativity
+    // certificate can leave the fragment, but it must degrade to a counted
+    // `sorry`, never a hard Lean build error from inside the tactic portfolio.
+    assert_proof_builds_with_sorry_budget(
+        "tests/fixtures/failsoft_sos_probe_a.av",
+        "aver-proof-failsoft-sos-a",
+        2,
+    );
+}
+
+#[test]
+fn proof_export_failsoft_sos_probe_b2_degrades_to_sorry_when_lake_is_available() {
+    // Regression for the fail-soft floor: this non-strict product certificate
+    // used to hit a deterministic whnf heartbeat timeout in `aver_int_order`.
+    // The risky arm must be locally bounded and fall through to a counted
+    // `sorry`, not abort `lake build`.
+    assert_proof_builds_with_sorry_budget(
+        "tests/fixtures/failsoft_sos_probe_b2.av",
+        "aver-proof-failsoft-sos-b2",
+        1,
+    );
+}
+
+#[test]
 fn proof_export_builds_validated_wrapper_when_lake_is_available() {
     // Genericity guard for the validated-wrapper arm: a synthetic, non-K5
     // error-checking division wrapper whose correctness law

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -97,8 +97,13 @@ fn proof_export_failsoft_sos_probe_a_degrades_to_sorry_when_lake_is_available() 
 fn proof_export_failsoft_sos_probe_b2_degrades_to_sorry_when_lake_is_available() {
     // Regression for the fail-soft floor: this non-strict product certificate
     // used to hit a deterministic whnf heartbeat timeout in `aver_int_order`.
-    // The risky arm must be locally bounded and fall through to a counted
-    // `sorry`, not abort `lake build`.
+    // The divergence source was the anonymous `_ ∧ _` conjunction split, now
+    // narrowed to the named `h_when` guard, so the `mul_le_mul` arm no longer
+    // feeds spurious metavariable products; the goal falls through to a counted
+    // `sorry` instead of aborting `lake build`. NOTE: the whnf-timeout class is
+    // NOT catchable at tactic level (a tactic-level `maxHeartbeats` cap is
+    // inert — see prelude.rs); this test passes because the divergence source
+    // is gone, not because the arm is bounded.
     assert_proof_builds_with_sorry_budget(
         "tests/fixtures/failsoft_sos_probe_b2.av",
         "aver-proof-failsoft-sos-b2",


### PR DESCRIPTION
## What

Three measured defects let the proof pipeline escalate or mask failures instead of degrading honestly:

1. **A generated proof could hard-fail the build.** The nonlinear order portfolio destructured when-premises through an anonymous conjunction lookup whose failure escaped the `first | … | sorry` floor (captured: `Tactic 'assumption' failed … goal ?m ∧ ?m`). The arm now destructures the named `h_when` hypothesis with plain `And.left`/`And.right`, which fail cleanly inside the portfolio — strictly narrower, no new proof closes because of it. Regression fixtures pin both captured shapes: the build now succeeds with honest sorries instead of erroring.
2. **A deterministic whnf timeout in the same portfolio killed the build.** Measured across three controlled builds: a tactic-level `set_option maxHeartbeats` wrapper is inert in this toolchain, so this class is NOT containable at the tactic level. The inert wrapper and its false comment are removed and replaced with the measured truth; the timeout class is surfaced by the new telemetry, and driver-level re-emission without the offending arm is the named follow-up.
3. **check-json masked failures.** New additive fields: `build_errors` (hard Lean build errors, distinct from sorries) and Dafny `timeouts` (parsed from verifier output — previously 12 timed-out laws were invisible next to `errors: 2`). Exit-code semantics unchanged; parsers unit-tested against the captured logs; docs updated with the exact counting scope.

## Gates

cargo test --lib 911, proof_spec 194 (incl. two new fail-soft regressions), identity_guardrails 2, clippy -D warnings (default and wasm,wasip2), fmt. K5 pins re-attested: round.av 24 universal / estimate.av 8 / fprep.av 16, all 0 sorries, with `build_errors:0` visible end-to-end. Reviewed by a four-lens adversarial panel; its blocker (the inert heartbeat cap) is resolved by the honest re-bank in this PR.