### PR TITLE
Close conditional premise-chain laws by unfolding transparent arithmetic bodies

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -18,8 +18,8 @@ mod sampled;
 mod shared;
 mod spec;
 mod suffix_roundtrip;
-mod triangle_sum;
 mod transparent_chain;
+mod triangle_sum;
 
 use super::VerifyEmitMode;
 use super::expr::aver_name_to_lean;
@@ -938,6 +938,33 @@ fn emit_verify_law_forall_auto_proof_inner(
     // trigger — this arm emits that obtain-conjuncts-then-apply skeleton from the
     // shape (name-blind). Probe-gated like the keystone, so a plan whose
     // orchestration does not close falls back to its bounded sampled statement.
+    // Transparent arithmetic premise chain: every `when` conjunct is a call to
+    // an already-citable law predicate whose transitively-unfolded body lies in
+    // the linear-Int fragment {comparisons, +, -, literal·term, if/max}, and the
+    // goal (after unfolding the subject fn) is a single comparison in the same
+    // fragment. Closed in true-universal form by unfolding those bodies and
+    // `split at h_when <;> omega`.
+    //
+    // Placed BEFORE the two probe-gated generic drivers (multicite / keystone),
+    // by NECESSITY: the keystone's `simp only [...] <;> grind` over the pool
+    // CLAIMS this shape too but its `grind` cannot do the max/min split plus the
+    // linear chain, so it records the law's `AVERSPEC_SORRY` floor as a FAILURE —
+    // shadowing this arm and reverting the flip to bounded. This arm's recognizer
+    // is strictly narrower than the keystone's (a PURE-non-recursive subject and
+    // premise fns, all Int givens, the transparent-arithmetic fragment, exactly
+    // one premise-side split), and `omega` is complete on that fragment, so it can
+    // only claim shapes it provably closes — it never steals or regresses a
+    // keystone / multicite shape (those cite opaque `Fraction` / recursive cone
+    // fns this recognizer rejects) and cannot shadow the recursive Induction /
+    // FloorDivWindow rungs below. Probe-gated (`speculative::admits`) exactly like
+    // the keystone: a chain the probe cannot certify reverts to bounded.
+    if law.when.is_some()
+        && let Some(proof) =
+            transparent_chain::emit_transparent_chain_law(vb, law, ctx, &intro_names)
+    {
+        return Some(proof);
+    }
+
     if let Some(proof) = induction::emit_multicite_composition_law(vb, law, ctx, &intro_names) {
         return Some(proof);
     }
@@ -977,18 +1004,6 @@ fn emit_verify_law_forall_auto_proof_inner(
     if law.when.is_some()
         && let Some(proof) =
             interval_mono::emit_interval_monotonicity_law(vb, law, ctx, theorem_base)
-    {
-        return Some(proof);
-    }
-
-    // Transparent arithmetic premise chain: every `when` conjunct is a call to
-    // an already-citable law predicate whose body unfolds to linear Int
-    // arithmetic plus one premise-side max/min-style split. Deterministic and
-    // placed after existing deterministic composition rungs but before any
-    // bounded guarded-domain fallback.
-    if law.when.is_some()
-        && let Some(proof) =
-            transparent_chain::emit_transparent_chain_law(vb, law, ctx, &intro_names)
     {
         return Some(proof);
     }

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -19,6 +19,7 @@ mod shared;
 mod spec;
 mod suffix_roundtrip;
 mod triangle_sum;
+mod transparent_chain;
 
 use super::VerifyEmitMode;
 use super::expr::aver_name_to_lean;
@@ -141,6 +142,11 @@ pub(in crate::codegen::lean) use triangle_sum::recognize_triangle_sum;
 /// cites — unioned into the cross-file admission set so those dep theorems are
 /// emitted into the build.
 pub(in crate::codegen::lean) use triangle_sum::triangle_sum_cited_deps;
+
+/// Transparent arithmetic premise-chain arm: a `when` law whose premises cite
+/// already-citable transparent arithmetic predicates. Feeds the `omit_domain`
+/// statement driver, kept in lockstep with `emit_transparent_chain_law`.
+pub(in crate::codegen::lean) use transparent_chain::recognize_transparent_chain;
 
 // (Defined in this module.) The finite bounded-Int-domain recognizer — see
 // `recognize_finite_int_domain` — feeds the `omit_domain` statement driver so
@@ -971,6 +977,18 @@ fn emit_verify_law_forall_auto_proof_inner(
     if law.when.is_some()
         && let Some(proof) =
             interval_mono::emit_interval_monotonicity_law(vb, law, ctx, theorem_base)
+    {
+        return Some(proof);
+    }
+
+    // Transparent arithmetic premise chain: every `when` conjunct is a call to
+    // an already-citable law predicate whose body unfolds to linear Int
+    // arithmetic plus one premise-side max/min-style split. Deterministic and
+    // placed after existing deterministic composition rungs but before any
+    // bounded guarded-domain fallback.
+    if law.when.is_some()
+        && let Some(proof) =
+            transparent_chain::emit_transparent_chain_law(vb, law, ctx, &intro_names)
     {
         return Some(proof);
     }

--- a/src/codegen/lean/law_auto/transparent_chain.rs
+++ b/src/codegen/lean/law_auto/transparent_chain.rs
@@ -4,13 +4,33 @@
 //! whose premises are calls to already-citable law predicates, then unfolds only
 //! those predicate bodies plus their transparent non-recursive helpers. The
 //! body gate is shape-keyed, not name-keyed.
+//!
+//! Probe-gated exactly like the keystone (`induction::keystone`): both the
+//! statement recognizer ([`recognize_transparent_chain`], which feeds the
+//! `omit_domain` universal-statement driver) and the proof emit
+//! ([`emit_transparent_chain_law`]) key on
+//! [`tactic_ir::speculative::admits`], so a chain whose `omega` close the probe
+//! cannot certify REVERTS to the sound bounded sampled-domain statement instead
+//! of forcing a passing project red. Outside any probe (`admits` default
+//! `false`) the law stays bounded — byte-identical to before this arm.
+//!
+//! Named boundary: the citable-pool check resolves premises against EARLIER
+//! sibling laws in the entry module (`enclosing_verify_blocks`) or a dependency
+//! module's own law list. Under entry-only speculative probing a dependency
+//! module's `when`-law that is itself only probe-committable is not yet a stable
+//! citation, so the intended fixtures keep the cited pool laws in the SAME module
+//! as the chain law. Widening to freely cross-module pool citations is a
+//! separate change and deliberately out of scope here.
 
 use std::collections::BTreeSet;
 
 use super::super::expr::aver_name_to_lean;
-use super::{shared, AutoProof};
-use crate::ast::{BinOp, Expr, FnDef, Literal, Pattern, Spanned, VerifyBlock, VerifyKind, VerifyLaw};
+use super::{AutoProof, shared};
+use crate::ast::{
+    BinOp, Expr, FnDef, Literal, Pattern, Spanned, VerifyBlock, VerifyKind, VerifyLaw,
+};
 use crate::codegen::CodegenContext;
+use crate::codegen::lean::tactic_ir::speculative;
 
 struct TransparentChain {
     subject_lean: String,
@@ -39,7 +59,13 @@ pub(in crate::codegen::lean) fn recognize_transparent_chain(
     law: &VerifyLaw,
     ctx: &CodegenContext,
 ) -> bool {
-    recognize_transparent_chain_shape(vb, law, ctx).is_some()
+    if recognize_transparent_chain_shape(vb, law, ctx).is_none() {
+        return false;
+    }
+    // Probe-gated: the universal statement form (`omit_domain`) and the proof
+    // emit stay in lockstep because both consult `admits`. Default `false` keeps
+    // a non-probe transpile on the bounded fallback (keystone precedent).
+    speculative::admits(&law_id(vb, law), false)
 }
 
 pub(in crate::codegen::lean) fn emit_transparent_chain_law(
@@ -52,19 +78,41 @@ pub(in crate::codegen::lean) fn emit_transparent_chain_law(
         subject_lean,
         premise_unfolds,
     } = recognize_transparent_chain_shape(vb, law, ctx)?;
+    // Same gate as the statement recognizer: a chain the probe did not commit
+    // (or a plain transpile with no probe) declines here, so the caller falls
+    // through to the bounded guarded-domain fallback and the statement stays
+    // bounded.
+    let id = law_id(vb, law);
+    if !speculative::admits(&id, false) {
+        return None;
+    }
     let mut intros = intro_names.to_vec();
     intros.push("h_when".to_string());
     let premise_defs = premise_unfolds.join(" ");
+    // Fail-closed floor. Under the probe it carries the `AVERSPEC_SORRY:<id>`
+    // trace so a non-closing chain surfaces in the build log (and `record_probed`
+    // registers the id as one that emitted a floor); the committed re-emit then
+    // states only the closers universally. Off-probe it is a bare `sorry`.
+    let floor = if speculative::probing() {
+        speculative::record_probed(&id);
+        format!("(trace \"AVERSPEC_SORRY:{id}\"; sorry)")
+    } else {
+        "sorry".to_string()
+    };
     Some(AutoProof {
         support_lines: Vec::new(),
         body: crate::codegen::lean::tactic_ir::Tactic::raw(super::intro_then(
             &intros,
             vec![format!(
-                "first | (unfold {subject_lean}; unfold {premise_defs} at h_when; simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le] at h_when ⊢; split at h_when <;> omega) | sorry"
+                "first | (unfold {subject_lean}; unfold {premise_defs} at h_when; simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le] at h_when ⊢; split at h_when <;> omega) | {floor}"
             )],
         )),
         replaces_theorem: false,
     })
+}
+
+fn law_id(vb: &VerifyBlock, law: &VerifyLaw) -> String {
+    format!("{}.{}", vb.fn_name, law.name)
 }
 
 fn recognize_transparent_chain_shape(
@@ -99,10 +147,7 @@ fn recognize_transparent_chain_shape(
     if bare_basename(&subject_call) != vb.fn_name {
         return None;
     }
-    if subject_args
-        .iter()
-        .any(|arg| !plain_term(arg))
-    {
+    if subject_args.iter().any(|arg| !plain_term(arg)) {
         return None;
     }
     let subject = resolve_fn_for_call(ctx, &subject_call, ctx.active_module_scope().as_deref())?;
@@ -135,10 +180,7 @@ fn recognize_transparent_chain_shape(
         if cited.fd.return_type.trim() != "Bool" || !fn_is_pure_nonrecursive(ctx, &cited) {
             return None;
         }
-        if args
-            .iter()
-            .any(|arg| !plain_term(arg))
-        {
+        if args.iter().any(|arg| !plain_term(arg)) {
             return None;
         }
         let mut state = CollectState {
@@ -186,9 +228,7 @@ fn collect_transparent_premise_fn(
 fn plain_bool(expr: &Spanned<Expr>) -> bool {
     match &expr.node {
         Expr::Literal(Literal::Bool(_)) => true,
-        Expr::BinOp(op, l, r) if comparison_op(*op) => {
-            plain_term(l) && plain_term(r)
-        }
+        Expr::BinOp(op, l, r) if comparison_op(*op) => plain_term(l) && plain_term(r),
         _ => false,
     }
 }
@@ -330,7 +370,10 @@ fn premise_term(
 }
 
 fn comparison_op(op: BinOp) -> bool {
-    matches!(op, BinOp::Eq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte)
+    matches!(
+        op,
+        BinOp::Eq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
+    )
 }
 
 fn int_literal(expr: &Spanned<Expr>) -> bool {
@@ -358,16 +401,14 @@ fn resolve_fn_for_call<'a>(
     owner_scope: Option<&str>,
 ) -> Option<ResolvedFn<'a>> {
     if let Some((prefix, short)) = split_module_call(ctx, call_name) {
-        let fd = ctx
-            .fn_def_by_name(short, Some(prefix))
-            .or_else(|| {
-                ctx.modules
-                    .iter()
-                    .find(|m| m.prefix == prefix)?
-                    .fn_defs
-                    .iter()
-                    .find(|fd| fd.name == short)
-            })?;
+        let fd = ctx.fn_def_by_name(short, Some(prefix)).or_else(|| {
+            ctx.modules
+                .iter()
+                .find(|m| m.prefix == prefix)?
+                .fn_defs
+                .iter()
+                .find(|fd| fd.name == short)
+        })?;
         return Some(ResolvedFn {
             fd,
             scope: Some(prefix.to_string()),
@@ -398,7 +439,10 @@ fn resolve_fn_for_call<'a>(
     })
 }
 
-fn split_module_call<'a>(ctx: &'a CodegenContext, call_name: &'a str) -> Option<(&'a str, &'a str)> {
+fn split_module_call<'a>(
+    ctx: &'a CodegenContext,
+    call_name: &'a str,
+) -> Option<(&'a str, &'a str)> {
     ctx.modules
         .iter()
         .filter_map(|module| {
@@ -409,6 +453,16 @@ fn split_module_call<'a>(ctx: &'a CodegenContext, call_name: &'a str) -> Option<
         .max_by_key(|(prefix, _)| prefix.len())
 }
 
+/// Whether an EARLIER law block establishes the premise predicate `call_name` as
+/// a pool member — a `verify <fn> law <name>` whose `law_as_lemma_statement` is
+/// well-formed. This is a RECOGNITION gate (the arm only fires on premises that
+/// name a law-backed predicate), NOT a soundness dependency: the emitted proof
+/// never cites the pool law theorem — it `unfold`s the predicate fn's own body
+/// (definitional) and discharges the goal from the introduced premises `h_when`
+/// with `omega`, then the `#print axioms` whitelist + kernel recheck certify it.
+/// So a pool law that is itself only bounded (or, in principle, unproven) cannot
+/// lend false credit here; checking mere statement shape rather than
+/// proven-universal tier is therefore truthful for this arm.
 fn has_citable_pool_law_for_call(vb: &VerifyBlock, call_name: &str, ctx: &CodegenContext) -> bool {
     use crate::codegen::lean::toplevel::law_as_lemma_statement;
     if let Some((prefix, short)) = split_module_call(ctx, call_name)

--- a/src/codegen/lean/law_auto/transparent_chain.rs
+++ b/src/codegen/lean/law_auto/transparent_chain.rs
@@ -1,0 +1,480 @@
+//! Transparent arithmetic premise-chain close.
+//!
+//! This arm is deliberately syntax-discovery-only: it recognizes a `when` law
+//! whose premises are calls to already-citable law predicates, then unfolds only
+//! those predicate bodies plus their transparent non-recursive helpers. The
+//! body gate is shape-keyed, not name-keyed.
+
+use std::collections::BTreeSet;
+
+use super::super::expr::aver_name_to_lean;
+use super::{shared, AutoProof};
+use crate::ast::{BinOp, Expr, FnDef, Literal, Pattern, Spanned, VerifyBlock, VerifyKind, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+struct TransparentChain {
+    subject_lean: String,
+    premise_unfolds: Vec<String>,
+}
+
+struct ResolvedFn<'a> {
+    fd: &'a FnDef,
+    scope: Option<String>,
+    lean_name: String,
+}
+
+#[derive(Default)]
+struct FragmentStats {
+    premise_splits: usize,
+}
+
+struct CollectState<'a> {
+    visited: &'a mut BTreeSet<String>,
+    unfolds: &'a mut Vec<String>,
+    stats: &'a mut FragmentStats,
+}
+
+pub(in crate::codegen::lean) fn recognize_transparent_chain(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> bool {
+    recognize_transparent_chain_shape(vb, law, ctx).is_some()
+}
+
+pub(in crate::codegen::lean) fn emit_transparent_chain_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    intro_names: &[String],
+) -> Option<AutoProof> {
+    let TransparentChain {
+        subject_lean,
+        premise_unfolds,
+    } = recognize_transparent_chain_shape(vb, law, ctx)?;
+    let mut intros = intro_names.to_vec();
+    intros.push("h_when".to_string());
+    let premise_defs = premise_unfolds.join(" ");
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        body: crate::codegen::lean::tactic_ir::Tactic::raw(super::intro_then(
+            &intros,
+            vec![format!(
+                "first | (unfold {subject_lean}; unfold {premise_defs} at h_when; simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le] at h_when ⊢; split at h_when <;> omega) | sorry"
+            )],
+        )),
+        replaces_theorem: false,
+    })
+}
+
+fn recognize_transparent_chain_shape(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Option<TransparentChain> {
+    law.when.as_ref()?;
+    if law.givens.is_empty() || law.givens.iter().any(|g| g.type_name.trim() != "Int") {
+        return None;
+    }
+    if law.givens.iter().any(|g| {
+        crate::codegen::common::refinement_lift_for_given(
+            &g.name,
+            &g.type_name,
+            &law.lhs,
+            &law.rhs,
+            ctx,
+        )
+        .is_some()
+    }) {
+        return None;
+    }
+    if !matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true))) {
+        return None;
+    }
+
+    let Expr::FnCall(subject_callee, subject_args) = &law.lhs.node else {
+        return None;
+    };
+    let subject_call = shared::expr_dotted_name(subject_callee)?;
+    if bare_basename(&subject_call) != vb.fn_name {
+        return None;
+    }
+    if subject_args
+        .iter()
+        .any(|arg| !plain_term(arg))
+    {
+        return None;
+    }
+    let subject = resolve_fn_for_call(ctx, &subject_call, ctx.active_module_scope().as_deref())?;
+    if subject.fd.name != vb.fn_name || !fn_is_pure_nonrecursive(ctx, &subject) {
+        return None;
+    }
+    let subject_body = shared::body_terminal_expr(&subject.fd.body)?;
+    if !plain_bool(subject_body) {
+        return None;
+    }
+
+    let mut conjuncts = Vec::new();
+    shared::flatten_and(law.when.as_ref()?, &mut conjuncts);
+    if conjuncts.is_empty() {
+        return None;
+    }
+
+    let mut unfolds = Vec::new();
+    let mut visited = BTreeSet::new();
+    let mut stats = FragmentStats::default();
+    for conjunct in conjuncts {
+        let Expr::FnCall(callee, args) = &conjunct.node else {
+            return None;
+        };
+        let call_name = shared::expr_dotted_name(callee)?;
+        if !has_citable_pool_law_for_call(vb, &call_name, ctx) {
+            return None;
+        }
+        let cited = resolve_fn_for_call(ctx, &call_name, ctx.active_module_scope().as_deref())?;
+        if cited.fd.return_type.trim() != "Bool" || !fn_is_pure_nonrecursive(ctx, &cited) {
+            return None;
+        }
+        if args
+            .iter()
+            .any(|arg| !plain_term(arg))
+        {
+            return None;
+        }
+        let mut state = CollectState {
+            visited: &mut visited,
+            unfolds: &mut unfolds,
+            stats: &mut stats,
+        };
+        collect_transparent_premise_fn(ctx, cited, &mut state)?;
+    }
+
+    // The measured core tactic is `split at h_when <;> omega`; decline shapes
+    // with no premise-side split or several nested splits instead of guessing a
+    // different tactic.
+    if stats.premise_splits != 1 || unfolds.is_empty() {
+        return None;
+    }
+
+    Some(TransparentChain {
+        subject_lean: subject.lean_name,
+        premise_unfolds: unfolds,
+    })
+}
+
+fn collect_transparent_premise_fn(
+    ctx: &CodegenContext,
+    resolved: ResolvedFn<'_>,
+    state: &mut CollectState<'_>,
+) -> Option<()> {
+    let key = scoped_key(resolved.scope.as_deref(), &resolved.fd.name);
+    if !state.visited.insert(key) {
+        return Some(());
+    }
+    if !fn_is_pure_nonrecursive(ctx, &resolved) {
+        return None;
+    }
+    let body = shared::body_terminal_expr(&resolved.fd.body)?;
+    state.unfolds.push(resolved.lean_name.clone());
+    match resolved.fd.return_type.trim() {
+        "Bool" => premise_bool(body, ctx, resolved.scope.as_deref(), state).then_some(()),
+        "Int" => premise_term(body, ctx, resolved.scope.as_deref(), state).then_some(()),
+        _ => None,
+    }
+}
+
+fn plain_bool(expr: &Spanned<Expr>) -> bool {
+    match &expr.node {
+        Expr::Literal(Literal::Bool(_)) => true,
+        Expr::BinOp(op, l, r) if comparison_op(*op) => {
+            plain_term(l) && plain_term(r)
+        }
+        _ => false,
+    }
+}
+
+fn plain_term(expr: &Spanned<Expr>) -> bool {
+    match &expr.node {
+        Expr::Literal(Literal::Int(_)) => true,
+        Expr::Ident(_) | Expr::Resolved { .. } => true,
+        Expr::Neg(inner) => plain_term(inner),
+        Expr::BinOp(BinOp::Add | BinOp::Sub, l, r) => plain_term(l) && plain_term(r),
+        Expr::BinOp(BinOp::Mul, l, r) => {
+            (int_literal(l) && plain_term(r)) || (int_literal(r) && plain_term(l))
+        }
+        _ => false,
+    }
+}
+
+fn premise_bool(
+    expr: &Spanned<Expr>,
+    ctx: &CodegenContext,
+    owner_scope: Option<&str>,
+    state: &mut CollectState<'_>,
+) -> bool {
+    match &expr.node {
+        Expr::Literal(Literal::Bool(_)) => true,
+        Expr::BinOp(op, l, r) if comparison_op(*op) => {
+            premise_term(l, ctx, owner_scope, state) && premise_term(r, ctx, owner_scope, state)
+        }
+        Expr::FnCall(callee, args)
+            if shared::expr_dotted_name(callee).as_deref() == Some("Bool.and")
+                && args.len() == 2 =>
+        {
+            premise_bool(&args[0], ctx, owner_scope, state)
+                && premise_bool(&args[1], ctx, owner_scope, state)
+        }
+        Expr::FnCall(callee, args) => {
+            let Some(name) = shared::expr_dotted_name(callee) else {
+                return false;
+            };
+            for arg in args {
+                if !premise_term(arg, ctx, owner_scope, state) {
+                    return false;
+                }
+            }
+            let Some(resolved) = resolve_fn_for_call(ctx, &name, owner_scope) else {
+                return false;
+            };
+            if resolved.fd.return_type.trim() != "Bool" {
+                return false;
+            }
+            collect_transparent_premise_fn(ctx, resolved, state).is_some()
+        }
+        Expr::Match { subject, arms } => {
+            if !premise_bool(subject, ctx, owner_scope, state) {
+                return false;
+            }
+            let mut saw_true = false;
+            let mut saw_false = false;
+            for arm in arms {
+                match bool_pattern(&arm.pattern) {
+                    Some(true) => saw_true = true,
+                    Some(false) => saw_false = true,
+                    None => return false,
+                }
+                if !premise_bool(&arm.body, ctx, owner_scope, state) {
+                    return false;
+                }
+            }
+            if saw_true && saw_false {
+                state.stats.premise_splits += 1;
+                true
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn premise_term(
+    expr: &Spanned<Expr>,
+    ctx: &CodegenContext,
+    owner_scope: Option<&str>,
+    state: &mut CollectState<'_>,
+) -> bool {
+    match &expr.node {
+        Expr::Literal(Literal::Int(_)) => true,
+        Expr::Ident(_) | Expr::Resolved { .. } => true,
+        Expr::Neg(inner) => premise_term(inner, ctx, owner_scope, state),
+        Expr::BinOp(BinOp::Add | BinOp::Sub, l, r) => {
+            premise_term(l, ctx, owner_scope, state) && premise_term(r, ctx, owner_scope, state)
+        }
+        Expr::BinOp(BinOp::Mul, l, r) => {
+            (int_literal(l) && premise_term(r, ctx, owner_scope, state))
+                || (int_literal(r) && premise_term(l, ctx, owner_scope, state))
+        }
+        Expr::FnCall(callee, args) => {
+            let Some(name) = shared::expr_dotted_name(callee) else {
+                return false;
+            };
+            for arg in args {
+                if !premise_term(arg, ctx, owner_scope, state) {
+                    return false;
+                }
+            }
+            let Some(resolved) = resolve_fn_for_call(ctx, &name, owner_scope) else {
+                return false;
+            };
+            if resolved.fd.return_type.trim() != "Int" {
+                return false;
+            }
+            collect_transparent_premise_fn(ctx, resolved, state).is_some()
+        }
+        Expr::Match { subject, arms } => {
+            if !premise_bool(subject, ctx, owner_scope, state) {
+                return false;
+            }
+            let mut saw_true = false;
+            let mut saw_false = false;
+            for arm in arms {
+                match bool_pattern(&arm.pattern) {
+                    Some(true) => saw_true = true,
+                    Some(false) => saw_false = true,
+                    None => return false,
+                }
+                if !premise_term(&arm.body, ctx, owner_scope, state) {
+                    return false;
+                }
+            }
+            if saw_true && saw_false {
+                state.stats.premise_splits += 1;
+                true
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn comparison_op(op: BinOp) -> bool {
+    matches!(op, BinOp::Eq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte)
+}
+
+fn int_literal(expr: &Spanned<Expr>) -> bool {
+    matches!(&expr.node, Expr::Literal(Literal::Int(_)))
+}
+
+fn bool_pattern(pattern: &Pattern) -> Option<bool> {
+    match pattern {
+        Pattern::Literal(Literal::Bool(value)) => Some(*value),
+        _ => None,
+    }
+}
+
+fn fn_is_pure_nonrecursive(ctx: &CodegenContext, resolved: &ResolvedFn<'_>) -> bool {
+    if !resolved.fd.effects.is_empty() {
+        return false;
+    }
+    let recursive = super::super::recursive_pure_fn_names(ctx);
+    !recursive.contains(&resolved.fd.name)
+}
+
+fn resolve_fn_for_call<'a>(
+    ctx: &'a CodegenContext,
+    call_name: &str,
+    owner_scope: Option<&str>,
+) -> Option<ResolvedFn<'a>> {
+    if let Some((prefix, short)) = split_module_call(ctx, call_name) {
+        let fd = ctx
+            .fn_def_by_name(short, Some(prefix))
+            .or_else(|| {
+                ctx.modules
+                    .iter()
+                    .find(|m| m.prefix == prefix)?
+                    .fn_defs
+                    .iter()
+                    .find(|fd| fd.name == short)
+            })?;
+        return Some(ResolvedFn {
+            fd,
+            scope: Some(prefix.to_string()),
+            lean_name: aver_name_to_lean(&format!("{prefix}.{short}")),
+        });
+    }
+
+    if let Some(scope) = owner_scope
+        && let Some(module) = ctx.modules.iter().find(|m| m.prefix == scope)
+        && let Some(fd) = ctx
+            .fn_def_by_name(call_name, Some(scope))
+            .or_else(|| module.fn_defs.iter().find(|fd| fd.name == call_name))
+    {
+        return Some(ResolvedFn {
+            fd,
+            scope: Some(scope.to_string()),
+            lean_name: aver_name_to_lean(&format!("{scope}.{}", fd.name)),
+        });
+    }
+
+    let fd = ctx
+        .fn_def_by_name(call_name, None)
+        .or_else(|| ctx.fn_defs.iter().find(|fd| fd.name == call_name))?;
+    Some(ResolvedFn {
+        fd,
+        scope: None,
+        lean_name: aver_name_to_lean(&fd.name),
+    })
+}
+
+fn split_module_call<'a>(ctx: &'a CodegenContext, call_name: &'a str) -> Option<(&'a str, &'a str)> {
+    ctx.modules
+        .iter()
+        .filter_map(|module| {
+            call_name
+                .strip_prefix(&format!("{}.", module.prefix))
+                .map(|short| (module.prefix.as_str(), short))
+        })
+        .max_by_key(|(prefix, _)| prefix.len())
+}
+
+fn has_citable_pool_law_for_call(vb: &VerifyBlock, call_name: &str, ctx: &CodegenContext) -> bool {
+    use crate::codegen::lean::toplevel::law_as_lemma_statement;
+    if let Some((prefix, short)) = split_module_call(ctx, call_name)
+        && let Some(module) = ctx.modules.iter().find(|m| m.prefix == prefix)
+    {
+        return module.verify_laws.iter().any(|prev| {
+            if prev.fn_name != short {
+                return false;
+            }
+            let VerifyKind::Law(prev_law) = &prev.kind else {
+                return false;
+            };
+            ctx.with_module_scope(Some(prefix), || {
+                law_as_lemma_statement(prev, prev_law, ctx).is_some()
+            })
+        });
+    }
+
+    let short = bare_basename(call_name);
+    for prev in enclosing_verify_blocks(vb, ctx) {
+        if prev.line == vb.line && prev.fn_name == vb.fn_name {
+            break;
+        }
+        if prev.fn_name != short {
+            continue;
+        }
+        let VerifyKind::Law(prev_law) = &prev.kind else {
+            continue;
+        };
+        if law_as_lemma_statement(prev, prev_law, ctx).is_some() {
+            return true;
+        }
+    }
+    false
+}
+
+fn enclosing_verify_blocks<'a>(vb: &VerifyBlock, ctx: &'a CodegenContext) -> Vec<&'a VerifyBlock> {
+    use crate::ast::TopLevel;
+    for module in &ctx.modules {
+        if module
+            .verify_laws
+            .iter()
+            .any(|b| b.line == vb.line && b.fn_name == vb.fn_name)
+        {
+            return module.verify_laws.iter().collect();
+        }
+    }
+    ctx.items
+        .iter()
+        .filter_map(|item| match item {
+            TopLevel::Verify(block) => Some(block),
+            _ => None,
+        })
+        .collect()
+}
+
+fn scoped_key(scope: Option<&str>, name: &str) -> String {
+    match scope {
+        Some(scope) => format!("{scope}.{name}"),
+        None => name.to_string(),
+    }
+}
+
+fn bare_basename(name: &str) -> &str {
+    name.trim_start_matches("_root_.")
+        .rsplit('.')
+        .next()
+        .unwrap_or(name)
+}

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -646,6 +646,12 @@ fn emit_verify_law_block(
             // argument. The emit replaces the theorem with the `Prop`-hypothesis
             // universal form, so dropping the sampled domain keeps them aligned.
             || super::law_auto::recognize_interval_monotonicity(vb, &law_for_auto_proof, ctx)
+            // Transparent arithmetic premise chain: the `when` premise cites
+            // citable transparent arithmetic law predicates, and the proof
+            // unfolds those bodies before `split at h_when <;> omega`. The
+            // statement and proof share this recognizer so the sampled domain is
+            // dropped only for shapes the deterministic arm owns.
+            || super::law_auto::recognize_transparent_chain(vb, &law_for_auto_proof, ctx)
             // Exact-rational order facts about an opaque unary `Fraction` cone fn
             // `F` (the K5 signed power of two): its POSITIVITY (`F(k).top > 0 &&
             // F(k).bottom > 0`), its AT-LEAST-ONE (`when k >= 0 -> isNonNeg(minus(
@@ -1227,6 +1233,7 @@ pub(crate) fn law_as_lemma_statement(
             // interval-magnitude bound.
             || super::law_auto::recognize_finite_int_domain(vb, law, ctx)
             || super::law_auto::recognize_interval_monotonicity(vb, law, ctx)
+            || super::law_auto::recognize_transparent_chain(vb, law, ctx)
             || super::law_auto::recognize_validated_wrapper(vb, law, ctx)
             || pinned_when_universal)
     {

--- a/tests/fixtures/transparent_chain_h1.av
+++ b/tests/fixtures/transparent_chain_h1.av
@@ -1,0 +1,52 @@
+module TransparentChainH1
+    intent =
+        "Self-contained CI adaptation of the g1c-h1 probe: the sticky-plus"
+        "exponent-separation hypothesis 1 + e(q2+q3) < e(q1), discharged by"
+        "chaining two digit-separation citations and the sum-exponent window."
+        "The K5 dependency cone (Fraction magnitudes, pow2Signed) is replaced by"
+        "same-module pool laws so the whole chain lives in one entry module; the"
+        "transparent-arithmetic premise-chain arm must flip innerHypothesis from"
+        "bounded to universal."
+    effects []
+
+fn digitSeparation_8_2_1(eQ1: Int, eQ0: Int) -> Bool
+    ? "Lemma 8.2.1 (Digit Separation): e(q1) <= e(q0) - 23."
+    eQ0 - 23 - eQ1 >= 0
+
+verify digitSeparation_8_2_1 law firstImplication
+    given eQ0: Int = [25, 24, 23]
+    digitSeparation_8_2_1(eQ0 - 23, eQ0) holds
+
+fn maxInt(a: Int, b: Int) -> Int
+    ? "The larger of two integers -- the max(ex, ey) of Lemma 9.3.2."
+    match a >= b
+        true -> a
+        false -> b
+
+verify maxInt
+    maxInt(2, 3) => 3
+    maxInt(5, 1) => 5
+    maxInt(-2, -2) => -2
+
+fn sumExponentUpper_9_3_2(eSum: Int, ex: Int, ey: Int) -> Bool
+    ? "Lemma 9.3.2 (sum-exponent upper bound): e(x + y) <= 1 + max(ex, ey)."
+    eSum <= 1 + maxInt(ex, ey)
+
+verify sumExponentUpper_9_3_2 law section_9_3_2
+    given ex: Int = [2, 0, -1]
+    given ey: Int = [3, 0, -2]
+    sumExponentUpper_9_3_2(1 + ex, ex, ey) holds
+
+fn expSeparationInner(eQ1: Int, eQ2: Int, eQ3: Int, eSum: Int) -> Bool
+    ? "H1 inner hypothesis: 1 + e(q2+q3) < e(q1)."
+    1 + eSum < eQ1
+
+verify expSeparationInner law innerHypothesis
+    given eQ1: Int = [30, 25, 24]
+    given eQ2: Int = [5, 1, 0]
+    given eQ3: Int = [0 - 20, 0 - 23, 0 - 25]
+    given eSum: Int = [6, 2, 1]
+    when digitSeparation_8_2_1(eQ2, eQ1)
+    when digitSeparation_8_2_1(eQ3, eQ2)
+    when sumExponentUpper_9_3_2(eSum, eQ2, eQ3)
+    expSeparationInner(eQ1, eQ2, eQ3, eSum) holds

--- a/tests/fixtures/transparent_chain_not_implied.av
+++ b/tests/fixtures/transparent_chain_not_implied.av
@@ -1,0 +1,55 @@
+module TransparentChainNotImplied
+    intent =
+        "Regression for the probe-gating safety rail. `tightRoom` has the EXACT"
+        "shape the transparent-chain arm recognizes (a citable-predicate premise"
+        "chain with one peak split, all-Int givens), so the recognizer admits it"
+        "and the speculative probe attempts it universally -- but the chain does"
+        "NOT imply the conclusion (`5 + load < cap` needs load <= cap - 6, while"
+        "the premises only force load <= cap - 4), so `omega` cannot close it."
+        "The probe must observe the AVERSPEC_SORRY floor and REVERT this law to"
+        "its sound bounded sampled statement: the whole project stays passed,"
+        "never flipped red. The sibling universal laws confirm the arm still"
+        "fires where the chain IS implied."
+    effects []
+
+fn separated(a: Int, b: Int) -> Bool
+    ? "b sits at least the fixed threshold above a."
+    b - 5 - a >= 0
+
+verify separated law atThreshold
+    given b: Int = [30, 25, 24]
+    separated(b - 5, b) holds
+
+fn peakOf(x: Int, y: Int) -> Int
+    ? "The larger of two loads."
+    match x >= y
+        true -> x
+        false -> y
+
+verify peakOf
+    peakOf(2, 3) => 3
+    peakOf(5, 1) => 5
+    peakOf(-2, -2) => -2
+
+fn withinPeak(load: Int, x: Int, y: Int) -> Bool
+    ? "A combined load never exceeds one plus the larger contributing load."
+    load <= 1 + peakOf(x, y)
+
+verify withinPeak law peakBound
+    given x: Int = [5, 1, 0]
+    given y: Int = [3, 0, -2]
+    withinPeak(1 + x, x, y) holds
+
+fn tightRoom(cap: Int, mid: Int, low: Int, load: Int) -> Bool
+    ? "An OVER-STRONG headroom claim the premise chain does not force."
+    5 + load < cap
+
+verify tightRoom law capacityChain
+    given cap: Int = [30, 25, 24]
+    given mid: Int = [5, 1, 0]
+    given low: Int = [0 - 20, 0 - 23, 0 - 25]
+    given load: Int = [6, 2, 1]
+    when separated(mid, cap)
+    when separated(low, mid)
+    when withinPeak(load, mid, low)
+    tightRoom(cap, mid, low, load) holds

--- a/tests/fixtures/transparent_chain_witness.av
+++ b/tests/fixtures/transparent_chain_witness.av
@@ -1,0 +1,51 @@
+module TransparentChainWitness
+    intent =
+        "Cross-domain litmus for the transparent-arithmetic premise-chain arm:"
+        "the SAME chain shape as the K5 h1 hypothesis, but non-K5 vocabulary"
+        "(capacity / load / threshold) and all-different names. Two threshold"
+        "separations and a peak-load window chain to a headroom conclusion; the"
+        "arm must close it universally with ZERO engine changes, proving the"
+        "recognizer keys on claim SHAPE, not on names or domain constants."
+    effects []
+
+fn separated(a: Int, b: Int) -> Bool
+    ? "b sits at least the fixed threshold above a."
+    b - 5 - a >= 0
+
+verify separated law atThreshold
+    given b: Int = [30, 25, 24]
+    separated(b - 5, b) holds
+
+fn peakOf(x: Int, y: Int) -> Int
+    ? "The larger of two loads."
+    match x >= y
+        true -> x
+        false -> y
+
+verify peakOf
+    peakOf(2, 3) => 3
+    peakOf(5, 1) => 5
+    peakOf(-2, -2) => -2
+
+fn withinPeak(load: Int, x: Int, y: Int) -> Bool
+    ? "A combined load never exceeds one plus the larger contributing load."
+    load <= 1 + peakOf(x, y)
+
+verify withinPeak law peakBound
+    given x: Int = [5, 1, 0]
+    given y: Int = [3, 0, -2]
+    withinPeak(1 + x, x, y) holds
+
+fn roomToSpare(cap: Int, mid: Int, low: Int, load: Int) -> Bool
+    ? "Headroom: one more than the combined load still fits under the cap."
+    1 + load < cap
+
+verify roomToSpare law capacityChain
+    given cap: Int = [30, 25, 24]
+    given mid: Int = [5, 1, 0]
+    given low: Int = [0 - 20, 0 - 23, 0 - 25]
+    given load: Int = [6, 2, 1]
+    when separated(mid, cap)
+    when separated(low, mid)
+    when withinPeak(load, mid, low)
+    roomToSpare(cap, mid, low, load) holds

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -785,3 +785,149 @@ fn proof_bounded_laws_counts_distinct_part_named_laws_separately() {
     );
     let _ = std::fs::remove_dir_all(&output_dir);
 }
+
+/// Read the per-law `tier` for `law_id` (`fn.law`) from the emitted
+/// `proof_manifest.json`. `None` if the manifest or record is absent.
+fn manifest_law_tier(output_dir: &std::path::Path, law_id: &str) -> Option<String> {
+    let raw = std::fs::read_to_string(output_dir.join("proof_manifest.json")).ok()?;
+    let manifest: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    manifest["laws"].as_array()?.iter().find_map(|l| {
+        if l["law"].as_str()? == law_id {
+            Some(l["tier"].as_str()?.to_string())
+        } else {
+            None
+        }
+    })
+}
+
+#[test]
+fn proof_export_flips_transparent_chain_h1_to_universal_when_lake_is_available() {
+    // Acceptance (a) for the transparent-arithmetic premise-chain arm: the
+    // self-contained adaptation of the g1c-h1 probe (`1 + e(q2+q3) < e(q1)`,
+    // discharged by chaining two digit-separation citations and the sum-exponent
+    // window). The engine emits this `when`-law BOUNDED without the arm; the arm
+    // unfolds the three cited predicate bodies and closes `split at h_when <;>
+    // omega`, so the speculative probe commits it UNIVERSAL. Revert the arm (or
+    // its probe gate) and the chain law falls back to `bounded` — this asserts
+    // the flip AND the axiom whitelist.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping transparent-chain h1 test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-transparent-chain-h1");
+    let (summary, run) = run_lean_check_json(
+        "tests/fixtures/transparent_chain_h1.av",
+        &output_dir,
+        0,
+        &[],
+    );
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        manifest_law_tier(&output_dir, "expSeparationInner.innerHypothesis").as_deref(),
+        Some("universal"),
+        "the h1 premise chain must flip bounded -> universal via the arm.\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "the whole file (pool laws + flipped chain) must be kernel-genuine \
+         universal — no native_decide in a law theorem.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+#[test]
+fn proof_export_closes_transparent_chain_cross_domain_witness_when_lake_is_available() {
+    // D3 litmus: the SAME chain shape as the h1 hypothesis with all-different
+    // names and a non-K5 domain (capacity / load / threshold) closes UNIVERSALLY
+    // through the same arm with ZERO further engine changes — proving the
+    // recognizer keys on claim SHAPE, not on names or domain constants. A
+    // name-keyed regression would leave `roomToSpare.capacityChain` bounded here.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping transparent-chain witness test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-transparent-chain-witness");
+    let (summary, run) = run_lean_check_json(
+        "tests/fixtures/transparent_chain_witness.av",
+        &output_dir,
+        0,
+        &[],
+    );
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        manifest_law_tier(&output_dir, "roomToSpare.capacityChain").as_deref(),
+        Some("universal"),
+        "the cross-domain witness chain must close universal via the same arm.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+#[test]
+fn proof_probe_gating_reverts_not_implied_transparent_chain_to_bounded_when_lake_is_available() {
+    // Probe-gating safety rail (the green -> red repro turned regression):
+    // `tightRoom.capacityChain` has the EXACT shape the arm recognizes, so the
+    // recognizer admits it and the probe attempts it universally — but the
+    // premises do NOT imply the over-strong conclusion, so `omega` cannot close
+    // it. The probe must see the `AVERSPEC_SORRY` floor and REVERT the law to its
+    // sound bounded sampled statement, leaving the whole project `passed`. Remove
+    // the probe gate (force universal-or-sorry) and this law's universal theorem
+    // carries a sorry — `passed` flips false / `sorries` climbs — so this test
+    // fails loudly, exactly the red build the gate prevents.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping transparent-chain not-implied test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-transparent-chain-not-implied");
+    let (summary, run) = run_lean_check_json(
+        "tests/fixtures/transparent_chain_not_implied.av",
+        &output_dir,
+        0,
+        &[],
+    );
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "an in-shape but not-implied chain must revert to bounded and keep the \
+         project passing, never flip it red.\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        manifest_law_tier(&output_dir, "tightRoom.capacityChain").as_deref(),
+        Some("bounded"),
+        "the not-implied chain must land bounded, not universal.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}


### PR DESCRIPTION
## What

A new probe-gated Lean emission arm for when-laws whose premises cite earlier pool laws with transparent arithmetic bodies (linear integer arithmetic, comparisons, if/max). Instead of e-matching machinery, the arm unfolds the cited bodies definitionally and closes with a simp bridge and split <;> omega — measured on a real ladder-style law before any engine code was written; the emitted tactic reproduces the measured winning proof verbatim.

## Behavior

- A depth-3 conditional premise chain that previously fell to bounded-domain enumeration now closes universal (axioms [propext, Quot.sound]).
- Probe-gated like the existing speculative arms: when the chain is NOT actually implied, the probe records the failure and the law reverts to the bounded path — a passing project can never turn red because of this arm (regression fixture included: same shape, non-implied chain, lands bounded + passed).
- Cross-domain witness fixture (same shape, non-K5 vocabulary) closes universal via the same arm with no further engine changes — the recognizer is keyed on body shapes, never names.
- Placement: after all deterministic rungs, before the speculative keystone (measured necessary: the keystone's probe otherwise claims the shape, floor-fails on the max/min split, and shadows the flip; counterfactual verified in review). The recognizer is strictly narrower than the keystone's and omega is complete on its fragment.
- Known boundary documented at the module: dependency-module pool laws are not citable under entry-only probing.

## Gates

proof_spec 197 (194 + 3 new, live lake), lib 911, identity_guardrails 2, clippy -D warnings (default and wasm,wasip2), fmt. K5 pins re-attested independently by implementer and reviewer: round.av 24 / estimate.av 8 / fprep.av 16 universal, 0 sorries.