### PR TITLE
One-command stack: Dockerfile, quickstart, and honest constraints

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+target*
+out
+prompts
+.claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+FROM --platform=linux/amd64 rust:1.95.0-bookworm AS builder
+
+ARG LEAN_TOOLCHAIN=leanprover/lean4:v4.31.0
+ARG DAFNY_VERSION=4.11.0
+
+ENV ELAN_HOME=/opt/elan
+ENV PATH=/opt/elan/bin:/opt/dafny:$PATH
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl git unzip; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    curl -sSfL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 \
+        https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+        | sh -s -- -y --default-toolchain "${LEAN_TOOLCHAIN}"; \
+    lean --version; \
+    lake --version
+
+RUN set -eux; \
+    curl -fSL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 \
+        -o /tmp/dafny.zip \
+        "https://github.com/dafny-lang/dafny/releases/download/v${DAFNY_VERSION}/dafny-${DAFNY_VERSION}-x64-ubuntu-22.04.zip"; \
+    unzip -q /tmp/dafny.zip -d /opt/dafny-install; \
+    dafny_dir="$(dirname "$(find /opt/dafny-install -name dafny -type f | head -n 1)")"; \
+    ln -s "${dafny_dir}" /opt/dafny; \
+    chmod +x /opt/dafny/dafny || true; \
+    dafny --version; \
+    rm -f /tmp/dafny.zip
+
+WORKDIR /work
+
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY aver-memory ./aver-memory
+COPY aver-rt ./aver-rt
+COPY aver-lsp ./aver-lsp
+COPY src ./src
+
+RUN cargo build --bin aver
+
+FROM --platform=linux/amd64 debian:bookworm-slim AS runtime
+
+ENV ELAN_HOME=/opt/elan
+ENV PATH=/opt/elan/bin:/opt/dafny:/usr/local/bin:$PATH
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates; \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work
+
+COPY --from=builder /opt/elan /opt/elan
+COPY --from=builder /opt/dafny-install /opt/dafny-install
+COPY --from=builder /opt/dafny /opt/dafny
+COPY --from=builder /work/target/debug/aver /usr/local/bin/aver
+COPY examples/core/hello.av ./examples/core/hello.av
+COPY examples/formal/string_concat_monoid.av ./examples/formal/string_concat_monoid.av
+
+RUN set -eux; \
+    lean --version; \
+    lake --version; \
+    dafny --version; \
+    aver run examples/core/hello.av; \
+    rm -rf /tmp/aver-proof-smoke-build; \
+    aver proof examples/formal/string_concat_monoid.av --backend lean --check -o /tmp/aver-proof-smoke-build
+
+CMD ["sh", "-lc", "aver run examples/core/hello.av && rm -rf /tmp/aver-proof-smoke-run && aver proof examples/formal/string_concat_monoid.av --backend lean --check -o /tmp/aver-proof-smoke-run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY --from=builder /opt/dafny-install /opt/dafny-install
 COPY --from=builder /opt/dafny /opt/dafny
 COPY --from=builder /work/target/debug/aver /usr/local/bin/aver
 COPY examples/core/hello.av ./examples/core/hello.av
-COPY examples/formal/string_concat_monoid.av ./examples/formal/string_concat_monoid.av
+COPY examples/formal/validated_wrapper_law.av ./examples/formal/validated_wrapper_law.av
 
 RUN set -eux; \
     lean --version; \
@@ -64,6 +64,6 @@ RUN set -eux; \
     dafny --version; \
     aver run examples/core/hello.av; \
     rm -rf /tmp/aver-proof-smoke-build; \
-    aver proof examples/formal/string_concat_monoid.av --backend lean --check -o /tmp/aver-proof-smoke-build
+    aver proof examples/formal/validated_wrapper_law.av --backend lean --check -o /tmp/aver-proof-smoke-build
 
-CMD ["sh", "-lc", "aver run examples/core/hello.av && rm -rf /tmp/aver-proof-smoke-run && aver proof examples/formal/string_concat_monoid.av --backend lean --check -o /tmp/aver-proof-smoke-run"]
+CMD ["sh", "-lc", "aver run examples/core/hello.av && rm -rf /tmp/aver-proof-smoke-run && aver proof examples/formal/validated_wrapper_law.av --backend lean --check -o /tmp/aver-proof-smoke-run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY aver-memory ./aver-memory
 COPY aver-rt ./aver-rt
 COPY aver-lsp ./aver-lsp
 COPY src ./src
+COPY benches ./benches
 
 RUN cargo build --bin aver
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG LEAN_TOOLCHAIN=leanprover/lean4:v4.31.0
 ARG DAFNY_VERSION=4.11.0
 
 ENV ELAN_HOME=/opt/elan
-ENV PATH=/opt/elan/bin:/opt/dafny:$PATH
+ENV PATH=/opt/elan/bin:/opt/dafny:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN set -eux; \
     apt-get update; \
@@ -43,7 +43,7 @@ RUN cargo build --bin aver
 FROM --platform=linux/amd64 debian:bookworm-slim AS runtime
 
 ENV ELAN_HOME=/opt/elan
-ENV PATH=/opt/elan/bin:/opt/dafny:/usr/local/bin:$PATH
+ENV PATH=/opt/elan/bin:/opt/dafny:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN set -eux; \
     apt-get update; \
@@ -67,4 +67,4 @@ RUN set -eux; \
     rm -rf /tmp/aver-proof-smoke-build; \
     aver proof examples/formal/validated_wrapper_law.av --backend lean --check -o /tmp/aver-proof-smoke-build
 
-CMD ["sh", "-lc", "aver run examples/core/hello.av && rm -rf /tmp/aver-proof-smoke-run && aver proof examples/formal/validated_wrapper_law.av --backend lean --check -o /tmp/aver-proof-smoke-run"]
+CMD ["sh", "-c", "aver run examples/core/hello.av && rm -rf /tmp/aver-proof-smoke-run && aver proof examples/formal/validated_wrapper_law.av --backend lean --check -o /tmp/aver-proof-smoke-run"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Read the [Aver Manifesto](https://jasisz.github.io/aver-language/) for the longe
 
 ## Quickstart
 
+### Docker
+
+```bash
+docker build -t aver-one-command . && docker run --rm aver-one-command
+```
+
+This builds `aver`, runs `examples/core/hello.av`, and checks one Lean law from `examples/formal`. See [docs/quickstart.md](docs/quickstart.md).
+
 ### Install from crates.io
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,57 @@
+# Quickstart
+
+From a clean checkout with Docker available, run:
+
+```bash
+docker build -t aver-one-command . && docker run --rm aver-one-command
+```
+
+That one command builds a local image and then runs the image's default smoke test. The Dockerfile also runs the same smoke test while building the image, so the build fails before producing a usable image if either step regresses.
+
+The image pins:
+
+- Rust `1.95.0`
+- Lean toolchain `leanprover/lean4:v4.31.0`
+- Dafny `4.11.0`
+
+The Rust build is a debug build. That keeps the local quickstart bounded; release LTO is intentionally left out of this Docker path.
+
+## What It Runs
+
+The smoke test runs:
+
+```bash
+aver run examples/core/hello.av
+aver proof examples/formal/validated_wrapper_law.av --backend lean --check -o /tmp/aver-proof-smoke-run
+```
+
+The first command executes the hello example on the Aver VM.
+
+The second command exports `examples/formal/validated_wrapper_law.av` to Lean and asks `lake build` to re-check the generated theorem on the Lean kernel. The checked law is `checkedDiv.returnsCore`: when the divisor is nonzero, the error-checking wrapper returns `Result.Ok(coreDiv(a, b))`. The check is strict: the default budgets allow no Lean build errors and no residual `sorry`.
+
+## Five-Minute Follow-Up
+
+The durable-promise demo is not on `main` yet. If it has not been merged, inspect it from the `demo-durable-promise` branch:
+
+```bash
+git fetch origin demo-durable-promise
+git switch demo-durable-promise
+```
+
+The demo path on that branch is:
+
+```text
+projects/durable_promise/main.av
+```
+
+Add one `verify ... law ...` block to the demo, then ask the proof checker to show the missing proof obligation:
+
+```bash
+aver proof projects/durable_promise/main.av --backend lean --check --explain -o /tmp/aver-durable-proof
+```
+
+If the law does not close universally, `--explain` records the residual open goal in the generated proof manifest.
+
+## CI
+
+No Docker CI job is wired for this quickstart. The image downloads and materializes three toolchains, including Lean and Dafny, and is kept as a manual verification path unless a later CI environment can show it adds less than 10 minutes with no flake risk.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,11 +8,15 @@ docker build -t aver-one-command . && docker run --rm aver-one-command
 
 That one command builds a local image and then runs the image's default smoke test. The Dockerfile also runs the same smoke test while building the image, so the build fails before producing a usable image if either step regresses.
 
+Expected first-build cost on a native `linux/amd64` host is roughly 10-20 minutes and 1-2 GB of downloads for Docker base layers, Rust crates, Lean, and Dafny. Later builds are much smaller when Docker and Cargo caches are warm.
+
+Apple Silicon warning: this image is currently `linux/amd64` only because Dafny `4.11.0` publishes the Ubuntu x64 asset used here, but not a Linux ARM64 asset. Docker Desktop runs the image under qemu on Apple Silicon; expect the first build to take roughly 30-60 minutes and the default smoke-test run to take a few minutes under full emulation.
+
 The image pins:
 
 - Rust `1.95.0`
 - Lean toolchain `leanprover/lean4:v4.31.0`
-- Dafny `4.11.0`
+- Dafny `4.11.0` (`dafny-4.11.0-x64-ubuntu-22.04.zip`)
 
 The Rust build is a debug build. That keeps the local quickstart bounded; release LTO is intentionally left out of this Docker path.
 
@@ -36,6 +40,7 @@ The durable-promise demo is not on `main` yet. If it has not been merged, inspec
 ```bash
 git fetch origin demo-durable-promise
 git switch demo-durable-promise
+cd projects/durable_promise
 ```
 
 The demo path on that branch is:
@@ -47,7 +52,7 @@ projects/durable_promise/main.av
 Add one `verify ... law ...` block to the demo, then ask the proof checker to show the missing proof obligation:
 
 ```bash
-aver proof projects/durable_promise/main.av --backend lean --check --explain -o /tmp/aver-durable-proof
+aver proof main.av --backend lean --check --explain -o /tmp/aver-durable-proof
 ```
 
 If the law does not close universally, `--explain` records the residual open goal in the generated proof manifest.


### PR DESCRIPTION
## What

A cold outsider gets from zero to a kernel-verified proof and a running program in one command: `docker build -t aver-one-command . && docker run --rm aver-one-command`. The image pins Rust 1.95, the Lean toolchain the generated projects require (v4.31.0), and Dafny 4.11.0; the in-image smoke runs a program and proves a law on the Lean kernel. docs/quickstart.md documents the command, expected time and download size, the Apple-Silicon emulation caveat (Dafny publishes no linux-arm64 asset for 4.11.0 — fact-checked against the release), and a five-minute follow-up (add a law to the durable-promise demo; replayed verbatim in review, including proving a fresh law universal).

## Review evidence (docker daemon unavailable on the dev machine — verified by proxy, stated plainly)

- The exact builder COPY set was extracted to a scratch directory and built with the pinned cargo version: exit 0 (round 1 caught a deterministic manifest failure — missing benches/ — now fixed, plus .dockerignore: build context drops from ~9.9 GB of git+target to ~61 MB).
- The runtime CMD was switched off a login shell: on Debian, /etc/profile resets root's PATH and would have dropped elan and Dafny at run time while build-time smoke passed — a mechanism-level catch, now also exercised at build time via the same non-login shell.
- Both smoke commands replayed green natively on the pinned toolchains; base image tags and toolchain releases verified to exist; the generated lake project needs no network at container runtime.

The first full in-image build will be executed by the first user with a working docker daemon; the PR says so instead of pretending otherwise.