### PR TITLE
Add the durable-promise state machine demo

### DIFF
--- a/projects/durable_promise/README.md
+++ b/projects/durable_promise/README.md
@@ -1,0 +1,117 @@
+# durable_promise
+
+The core of a durable-promise state machine, modeled in pure Aver and shipped with a
+machine-checked certificate: every safety law below is proven **universal on the Lean 4
+kernel**, and the same model runs.
+
+## What is modeled
+
+A durable promise is a cell that starts `Pending` and moves **exactly once** to a settled
+state. It is the smallest honest slice of a durable-execution promise machine — the state
+ADT and its pure transitions, with no effects, no server, no persistence layer.
+
+```
+type PromiseState
+    Pending
+    Resolved(Int)      // carries the resolved value
+    Rejected(Int)      // carries the rejection error
+    TimedOut
+
+record Promise
+    state: PromiseState
+    timeoutAt: Int      // absolute deadline
+```
+
+Time never enters as an ambient clock — only as a `now: Int` argument, the same discipline
+the reference spec uses.
+
+Three pure transitions plus a projection:
+
+- `observe(p, now)` — the timeout **projection**. A `Pending` promise whose deadline has
+  passed (`now >= timeoutAt`) is *viewed* as `TimedOut`; everything else is returned
+  unchanged. This is the read-time view applied *before* any writer acts, so observation
+  happens before persistence.
+- `resolve(p, now, value)` / `reject(p, now, error)` — settle a still-`Pending` promise.
+  Both project the timeout first (call `observe`) and only then write, which is what makes a
+  settled promise absorbing and an expired one impossible to resurrect.
+
+The value slot is modeled the way the existing Aver corpus models payloads: it lives inside
+the state variant (`Resolved(Int)` / `Rejected(Int)`), so `Pending` and `TimedOut` carry no
+value by construction rather than by a nullable field.
+
+## What is PROVEN vs sample-verified
+
+**All 8 law theorems are proven universal on the Lean kernel** (`aver proof --backend lean
+--check` reports `"universal":true, "sorries":0, "universal_laws":8, "bounded_laws":0`).
+Nothing here is sample-only. Every theorem's `#print axioms` set is exactly the three
+standard Lean foundational axioms — no `sorryAx`:
+
+```
+{ Classical.choice, Quot.sound, propext }
+```
+
+The 8 theorems cover the 5 safety themes:
+
+| # | Theme | Law(s) | Lean statement (∀-closed) |
+|---|-------|--------|---------------------------|
+| 1 | Settled is absorbing | `observe.settledIsIdentity`, `resolve.settledIsIdentity`, `reject.settledIsIdentity` | `isSettled p = true → op(p, …) = p` |
+| 2 | No double-settle | `resolve.alwaysSettles` (helper), `resolve.noDoubleSettle` | `resolve (resolve p n1 v1) n2 v2 = resolve p n1 v1` |
+| 3 | Projection is idempotent | `observe.idempotent` | `observe (observe p now) now = observe p now` |
+| 4 | Timeout is monotone | `observe.timeoutMonotone` | `isTimedOut (observe p now1) && now2 >= now1 → isTimedOut (observe p now2)` |
+| 5 | No resurrection | `resolve.noResurrection` | `isTimedOut (observe p now) → resolve (observe p now) now v = observe p now` |
+
+The `noDoubleSettle` law states more than "the value is preserved": it proves the *entire*
+promise (state and value) is unchanged by a second settle — so the first value is kept, as a
+corollary. The `alwaysSettles` helper (`resolve` never leaves a promise `Pending`) is the
+lemma that makes it go through. `noResurrection` is discharged by the kernel citing
+`observe.idempotent` automatically (`grind [observe_law_idempotent]`) — laws-as-lemmas
+composition, no manual wiring.
+
+The `verify` blocks in `domain/promise.av` are a separate, independent check: they evaluate
+each law on concrete samples with Aver's own evaluator (no Lean), which catches a false claim
+before any proof is attempted. They are a cross-check, not the proof — the proof is the
+universal `∀` theorem.
+
+### How each theorem closes (from the generated Lean)
+
+The three unconditional laws close with a direct `grind` over the definitions; the five
+`when`-guarded laws close with `simp only [<defs>, Bool.and_eq_true, decide_eq_true_eq] <;>
+grind`. The emitter wraps each guarded proof in a `first | <tactic> | … | sorry` portfolio
+whose final `sorry` is a never-taken floor: if any theorem had actually closed through it, its
+axiom set would contain `sorryAx` and the manifest tier would not be `universal`. It does not —
+`proof_manifest.json` records all 8 as `"tier":"universal"` with the clean 3-axiom set.
+
+## Reproduce
+
+From the repository root (build the repo binary first: `cargo build --bin aver`):
+
+```
+# 1. Sample-check every function and law (Aver evaluator, no Lean):
+aver verify projects/durable_promise/domain/promise.av
+
+# 2. Export to Lean 4 and run the kernel check (rm the output dir first):
+rm -rf out
+aver proof projects/durable_promise/domain/promise.av --backend lean --check --check-json
+
+#    Expected tail:
+#    {"backend":"lean", … ,"passed":true,"sorries":0,"universal":true,"universal_laws":8}
+#    Per-law axioms + tiers are written to out/proof_manifest.json.
+
+# 3. Run the demo:
+aver run projects/durable_promise/main.av --module-root projects/durable_promise
+```
+
+Demo output:
+
+```
+start          : Pending(deadline=10)
+resolve @5     : Resolved(42)
+resolve @6     : Resolved(42)  (first value kept)
+observe @12    : TimedOut(deadline=10)  (timeout projected)
+resolve @12    : TimedOut(deadline=10)  (no resurrection)
+```
+
+## Files
+
+- `domain/promise.av` — the state machine: ADT, transitions, and the 8 law theorems.
+- `main.av` — the runnable demo above.

--- a/projects/durable_promise/domain/promise.av
+++ b/projects/durable_promise/domain/promise.av
@@ -1,0 +1,166 @@
+module Promise
+    intent =
+        "The CORE of a durable-promise state machine, modeled in pure Aver and stated"
+        "so its safety laws can be machine-checked. A durable promise is a cell that"
+        "starts Pending and moves EXACTLY ONCE to a settled state: Resolved(value),"
+        "Rejected(error), or TimedOut. Time enters only as a `now: Int` argument, never"
+        "as an ambient clock. observe(p, now) is the timeout PROJECTION: a Pending"
+        "promise whose deadline has passed is VIEWED as TimedOut before any writer acts"
+        "on it, so observation happens before persistence. resolve and reject project"
+        "the timeout first and only then settle, which is what makes a settled promise"
+        "absorbing and an expired promise impossible to resurrect."
+    exposes [PromiseState, Promise, pending, observe, resolve, reject, isPending, isSettled, isTimedOut]
+    effects []
+
+type PromiseState
+    Pending
+    Resolved(Int)
+    Rejected(Int)
+    TimedOut
+
+record Promise
+    state: PromiseState
+    timeoutAt: Int
+
+fn pending(deadline: Int) -> Promise
+    ? "A fresh Pending promise that will expire once now reaches `deadline`."
+    Promise(state = PromiseState.Pending, timeoutAt = deadline)
+
+fn isPending(p: Promise) -> Bool
+    ? "True while the promise is still awaiting a settle or a timeout."
+    match p.state
+        PromiseState.Pending -> true
+        _ -> false
+
+verify isPending
+    isPending(pending(10)) => true
+    isPending(Promise(state = PromiseState.Resolved(7), timeoutAt = 10)) => false
+    isPending(Promise(state = PromiseState.TimedOut, timeoutAt = 10)) => false
+
+fn isSettled(p: Promise) -> Bool
+    ? "True once the promise has left Pending: Resolved, Rejected, or TimedOut."
+    match p.state
+        PromiseState.Pending -> false
+        _ -> true
+
+verify isSettled
+    isSettled(pending(10)) => false
+    isSettled(Promise(state = PromiseState.Rejected(1), timeoutAt = 10)) => true
+    isSettled(Promise(state = PromiseState.TimedOut, timeoutAt = 10)) => true
+
+fn isTimedOut(p: Promise) -> Bool
+    ? "True exactly when the promise has been projected to TimedOut."
+    match p.state
+        PromiseState.TimedOut -> true
+        _ -> false
+
+verify isTimedOut
+    isTimedOut(Promise(state = PromiseState.TimedOut, timeoutAt = 10)) => true
+    isTimedOut(pending(10)) => false
+
+fn observe(p: Promise, now: Int) -> Promise
+    ? "Timeout projection: a Pending promise whose deadline has passed (now >= timeoutAt) is viewed as TimedOut. Every other promise is returned unchanged. This is the read-time view applied before any settle is persisted."
+    match p.state
+        PromiseState.Pending -> match now >= p.timeoutAt
+            true -> Promise(state = PromiseState.TimedOut, timeoutAt = p.timeoutAt)
+            false -> p
+        _ -> p
+
+verify observe
+    observe(pending(10), 5) => pending(10)
+    observe(pending(10), 10) => Promise(state = PromiseState.TimedOut, timeoutAt = 10)
+    observe(pending(10), 15) => Promise(state = PromiseState.TimedOut, timeoutAt = 10)
+    observe(Promise(state = PromiseState.Resolved(3), timeoutAt = 10), 99) => Promise(state = PromiseState.Resolved(3), timeoutAt = 10)
+
+fn resolve(p: Promise, now: Int, value: Int) -> Promise
+    ? "Settle a promise successfully with `value`. The timeout is projected first, so resolve only writes when the promise is genuinely still Pending at `now`; on any already-settled or expired promise it is the identity."
+    match observe(p, now).state
+        PromiseState.Pending -> Promise(state = PromiseState.Resolved(value), timeoutAt = p.timeoutAt)
+        _ -> observe(p, now)
+
+verify resolve
+    resolve(pending(10), 5, 42) => Promise(state = PromiseState.Resolved(42), timeoutAt = 10)
+    resolve(pending(10), 15, 42) => Promise(state = PromiseState.TimedOut, timeoutAt = 10)
+    resolve(Promise(state = PromiseState.Resolved(1), timeoutAt = 10), 5, 42) => Promise(state = PromiseState.Resolved(1), timeoutAt = 10)
+
+fn reject(p: Promise, now: Int, error: Int) -> Promise
+    ? "Settle a promise with a failure `error`. Mirror of resolve: projects the timeout first, writes only on a still-Pending promise, otherwise identity."
+    match observe(p, now).state
+        PromiseState.Pending -> Promise(state = PromiseState.Rejected(error), timeoutAt = p.timeoutAt)
+        _ -> observe(p, now)
+
+verify reject
+    reject(pending(10), 5, 9) => Promise(state = PromiseState.Rejected(9), timeoutAt = 10)
+    reject(pending(10), 15, 9) => Promise(state = PromiseState.TimedOut, timeoutAt = 10)
+    reject(Promise(state = PromiseState.TimedOut, timeoutAt = 10), 5, 9) => Promise(state = PromiseState.TimedOut, timeoutAt = 10)
+
+// --- Safety laws (stated for machine-checking) ---
+
+// THEME 1 - Settled is absorbing: once a promise is not Pending, observing or
+// settling it again is the identity. Stated once per settling operation.
+
+verify observe law settledIsIdentity
+    given p: Promise = [Promise(state = PromiseState.Resolved(7), timeoutAt = 10), Promise(state = PromiseState.Rejected(2), timeoutAt = 3), Promise(state = PromiseState.TimedOut, timeoutAt = 4)]
+    given now: Int = [0, 4, 11]
+    when isSettled(p)
+    observe(p, now) => p
+
+verify resolve law settledIsIdentity
+    given p: Promise = [Promise(state = PromiseState.Resolved(7), timeoutAt = 10), Promise(state = PromiseState.Rejected(2), timeoutAt = 3), Promise(state = PromiseState.TimedOut, timeoutAt = 4)]
+    given now: Int = [0, 4, 11]
+    given value: Int = [1, 5]
+    when isSettled(p)
+    resolve(p, now, value) => p
+
+verify reject law settledIsIdentity
+    given p: Promise = [Promise(state = PromiseState.Resolved(7), timeoutAt = 10), Promise(state = PromiseState.Rejected(2), timeoutAt = 3), Promise(state = PromiseState.TimedOut, timeoutAt = 4)]
+    given now: Int = [0, 4, 11]
+    given error: Int = [1, 5]
+    when isSettled(p)
+    reject(p, now, error) => p
+
+// THEME 2 - No double-settle. A settle always leaves the promise in a settled
+// state (helper), so a second settle is absorbed and the FIRST outcome (its whole
+// state, value included) is preserved.
+
+verify resolve law alwaysSettles
+    given p: Promise = [Promise(state = PromiseState.Pending, timeoutAt = 10), Promise(state = PromiseState.Resolved(7), timeoutAt = 10), Promise(state = PromiseState.Rejected(2), timeoutAt = 3), Promise(state = PromiseState.TimedOut, timeoutAt = 4)]
+    given now: Int = [0, 4, 11]
+    given value: Int = [1, 5]
+    isPending(resolve(p, now, value)) => false
+
+verify resolve law noDoubleSettle
+    given p: Promise = [Promise(state = PromiseState.Pending, timeoutAt = 10), Promise(state = PromiseState.Resolved(7), timeoutAt = 10), Promise(state = PromiseState.TimedOut, timeoutAt = 4)]
+    given now1: Int = [0, 11]
+    given now2: Int = [0, 11]
+    given v1: Int = [1, 5]
+    given v2: Int = [2, 9]
+    resolve(resolve(p, now1, v1), now2, v2) => resolve(p, now1, v1)
+
+// THEME 3 - Timeout projection is idempotent.
+
+verify observe law idempotent
+    given p: Promise = [Promise(state = PromiseState.Pending, timeoutAt = 10), Promise(state = PromiseState.Resolved(7), timeoutAt = 10), Promise(state = PromiseState.TimedOut, timeoutAt = 4)]
+    given now: Int = [0, 4, 11]
+    observe(observe(p, now), now) => observe(p, now)
+
+// THEME 4 - Timeout is monotone: an expired view under now1 stays expired under
+// any later now2 >= now1.
+
+verify observe law timeoutMonotone
+    given p: Promise = [Promise(state = PromiseState.Pending, timeoutAt = 10), Promise(state = PromiseState.TimedOut, timeoutAt = 4)]
+    given now1: Int = [0, 10, 11]
+    given now2: Int = [0, 10, 11]
+    when isTimedOut(observe(p, now1))
+    when now2 >= now1
+    isTimedOut(observe(p, now2)) => true
+
+// THEME 5 - No resurrection: settling an already-expired promise does not
+// un-expire it.
+
+verify resolve law noResurrection
+    given p: Promise = [Promise(state = PromiseState.Pending, timeoutAt = 10), Promise(state = PromiseState.TimedOut, timeoutAt = 4)]
+    given now: Int = [0, 10, 11]
+    given value: Int = [1, 5]
+    when isTimedOut(observe(p, now))
+    resolve(observe(p, now), now, value) => observe(p, now)

--- a/projects/durable_promise/main.av
+++ b/projects/durable_promise/main.av
@@ -1,0 +1,44 @@
+module Main
+    intent =
+        "Runnable demo for the durable-promise state machine core. Prints a handful"
+        "of transitions so a reader can watch the projection principle and the"
+        "absorbing/no-resurrection behaviour that the laws in domain/promise.av prove"
+        "universal on the Lean kernel."
+    depends [Domain.Promise]
+    effects [Console]
+
+fn describe(p: Promise) -> String
+    ? "One-line rendering of a promise for the demo output."
+    match p.state
+        PromiseState.Pending -> "Pending(deadline={p.timeoutAt})"
+        PromiseState.Resolved(v) -> "Resolved({v})"
+        PromiseState.Rejected(e) -> "Rejected({e})"
+        PromiseState.TimedOut -> "TimedOut(deadline={p.timeoutAt})"
+
+verify describe
+    describe(Domain.Promise.pending(10)) => "Pending(deadline=10)"
+    describe(Promise(state = PromiseState.Resolved(42), timeoutAt = 10)) => "Resolved(42)"
+    describe(Promise(state = PromiseState.TimedOut, timeoutAt = 10)) => "TimedOut(deadline=10)"
+
+fn main() -> Unit
+    ? "Walks a promise through resolve, timeout projection, and no-resurrection."
+    ! [Console.print]
+    p0 = Domain.Promise.pending(10)
+    Console.print("start          : {describe(p0)}")
+
+    // Resolve before the deadline: writes the value.
+    p1 = Domain.Promise.resolve(p0, 5, 42)
+    Console.print("resolve @5     : {describe(p1)}")
+
+    // Second settle is absorbed; the first value survives (no double-settle).
+    p2 = Domain.Promise.resolve(p1, 6, 99)
+    Console.print("resolve @6     : {describe(p2)}  (first value kept)")
+
+    // A different promise that is never settled and then observed past its deadline.
+    q0 = Domain.Promise.pending(10)
+    q1 = Domain.Promise.observe(q0, 12)
+    Console.print("observe @12    : {describe(q1)}  (timeout projected)")
+
+    // Trying to resolve the expired promise does NOT un-expire it.
+    q2 = Domain.Promise.resolve(q1, 12, 7)
+    Console.print("resolve @12    : {describe(q2)}  (no resurrection)")


### PR DESCRIPTION
## What

projects/durable_promise: a minimal durable-promise state machine in pure Aver — Pending/Resolved/Rejected/TimedOut, pure transitions, timeout as a projection (observation before persistence), time entering only as an argument. Runnable demo plus eight safety laws stated exactly (settled-is-absorbing for each operation, no-double-settle preserving the first value, idempotent and monotone timeout projection, no-resurrection).

## Why it earns its place

All eight laws are universal on the Lean kernel (axioms within the whitelist, zero sorries) AND verify push-button on Dafny/Z3 — the same spec judged by two independent kernels. One law closes by auto-citing another (the engine's laws-as-lemmas composition, no manual wiring). The quickstart merged in #636 points here as the five-minute follow-up: add a law, and the checker tells you what is missing — that path was replayed end-to-end in review, including proving a fresh law universal.

## Gates

Lean: 8 universal / 0 sorries; Dafny: 8 verified / 0 errors / 0 timeouts. Runnable via aver run from the project directory (README documents the module-root requirement).