### PR TITLE
Canonicalize when-comparators before proof recognition

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -651,6 +651,27 @@ pub fn swap_comparison_operands_op(op: &crate::ast::BinOp) -> Option<crate::ast:
     }
 }
 
+/// Canonicalize a `when`-clause comparison to a single normal direction:
+/// rewrite `a > b` to `b < a` and `a >= b` to `b <= a` by swapping the
+/// operands. This is a pure operand swap, NEVER a negation — a strict
+/// bound stays strict (`Gt -> Lt`) and a nonstrict bound stays nonstrict
+/// (`Gte -> Lte`), so it can never turn a semantically-load-bearing `r < d`
+/// into `r <= d`. Any expression that is not a `>`/`>=` comparison
+/// (already-canonical `<`/`<=`, `==`/`!=`, or a non-comparison predicate)
+/// is returned unchanged, so canonical-direction clauses round-trip
+/// byte-identically. This is a lowering-privilege normalization internal to
+/// proof RECOGNITION only: the emitted theorem/lemma still renders the
+/// user's original `when` surface form, so nothing user-visible is flipped.
+pub fn canonicalize_comparison(e: &Spanned<Expr>) -> Spanned<Expr> {
+    if let Expr::BinOp(op, l, r) = &e.node
+        && matches!(op, crate::ast::BinOp::Gt | crate::ast::BinOp::Gte)
+        && let Some(swapped) = swap_comparison_operands_op(op)
+    {
+        return Spanned::new(Expr::BinOp(swapped, r.clone(), l.clone()), e.line);
+    }
+    e.clone()
+}
+
 /// Structural equality on Aver predicate expressions with commutator
 /// relaxation: at every `BinOp` comparator node, allow the operands +
 /// operator to be swapped. Both `a >= 0` and `0 <= a` compare equal,
@@ -2991,6 +3012,36 @@ mod tests {
             rhs,
             sample_guards: Vec::new(),
         }
+    }
+
+    #[test]
+    fn canonicalize_comparison_swaps_operands_never_negates() {
+        use crate::ast::BinOp;
+        let a = || bsb(Expr::Ident("a".to_string()));
+        let b = || bsb(Expr::Ident("b".to_string()));
+        let binop = |op, l: Box<Spanned<Expr>>, r: Box<Spanned<Expr>>| sb(Expr::BinOp(op, l, r));
+
+        // `a > b` canonicalizes to `b < a` — operands swapped, STILL strict.
+        let canon_gt = canonicalize_comparison(&binop(BinOp::Gt, a(), b()));
+        assert_eq!(canon_gt.node, binop(BinOp::Lt, b(), a()).node);
+        // `a >= b` canonicalizes to `b <= a` — operands swapped, STILL nonstrict.
+        let canon_gte = canonicalize_comparison(&binop(BinOp::Gte, a(), b()));
+        assert_eq!(canon_gte.node, binop(BinOp::Lte, b(), a()).node);
+
+        // Strictness is NEVER crossed: a strict `>` never becomes a nonstrict
+        // `<=`, and a nonstrict `>=` never becomes a strict `<`. (A `r < d`
+        // upper bound whose strictness is load-bearing stays strict.)
+        assert!(!matches!(&canon_gt.node, Expr::BinOp(BinOp::Lte, ..)));
+        assert!(!matches!(&canon_gte.node, Expr::BinOp(BinOp::Lt, ..)));
+
+        // Already-canonical / symmetric / non-comparison clauses pass through
+        // BYTE-identically (no swap), so canonical-direction laws are untouched.
+        for op in [BinOp::Lt, BinOp::Lte, BinOp::Eq, BinOp::Neq] {
+            let clause = binop(op, a(), b());
+            assert_eq!(canonicalize_comparison(&clause).node, clause.node);
+        }
+        let call = sb(Expr::FnCall(a(), vec![sb(Expr::Ident("x".to_string()))]));
+        assert_eq!(canonicalize_comparison(&call).node, call.node);
     }
 
     #[test]

--- a/src/codegen/dafny/lemmas.rs
+++ b/src/codegen/dafny/lemmas.rs
@@ -407,7 +407,12 @@ fn floor_call<'a>(
     Some((&args[0], &args[1]))
 }
 
-fn flatten_and<'a>(e: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) {
+/// Flatten a `Bool.and` conjunction of `when` clauses, canonicalizing every
+/// leaf comparison (`a > b` -> `b < a`, `a >= b` -> `b <= a`) so the Dafny
+/// recognizers below only match `Lt`/`Lte` — the direction-blind counterpart
+/// of the Lean `law_auto::shared::flatten_and` choke point. Recognition-only:
+/// the emitted `requires` still renders `law.when` verbatim.
+fn flatten_and(e: &Spanned<Expr>, out: &mut Vec<Spanned<Expr>>) {
     match &e.node {
         Expr::FnCall(callee, args)
             if expr_dotted_name(callee).as_deref() == Some("Bool.and") && args.len() == 2 =>
@@ -415,7 +420,7 @@ fn flatten_and<'a>(e: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) {
             flatten_and(&args[0], out);
             flatten_and(&args[1], out);
         }
-        _ => out.push(e),
+        _ => out.push(crate::codegen::common::canonicalize_comparison(e)),
     }
 }
 
@@ -427,11 +432,10 @@ fn clause_gives_pos(clause: &Spanned<Expr>, x_render: &str, ctx: &CodegenContext
         Expr::Literal(Literal::Int(n)) => Some(*n),
         _ => None,
     };
+    // `flatten_and` canonicalizes `x > c` / `x >= c` to `c < x` / `c <= x`.
     match op {
         BinOp::Lt => int_lit(l).is_some_and(|c| c >= 0) && render(r, ctx) == x_render,
-        BinOp::Gt => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 0),
         BinOp::Lte => int_lit(l).is_some_and(|c| c >= 1) && render(r, ctx) == x_render,
-        BinOp::Gte => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 1),
         _ => false,
     }
 }
@@ -447,9 +451,9 @@ fn clause_gives_nonneg(clause: &Spanned<Expr>, x_render: &str, ctx: &CodegenCont
         Expr::Literal(Literal::Int(n)) => Some(*n),
         _ => None,
     };
+    // `flatten_and` canonicalizes `x >= c` to `c <= x`.
     match op {
         BinOp::Lte => int_lit(l).is_some_and(|c| c >= 0) && render(r, ctx) == x_render,
-        BinOp::Gte => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 0),
         _ => false,
     }
 }

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -60,8 +60,15 @@ pub(super) fn is_euclidean_floor_fn(floor_src: &str, ctx: &CodegenContext) -> bo
     expr_dotted_name(div_callee).as_deref() == Some("Int.div") && div_args.len() == 2
 }
 
-/// Flatten a `Bool.and` / `&&` conjunction of `when` clauses.
-pub(super) fn flatten_and<'a>(e: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) {
+/// Flatten a `Bool.and` / `&&` conjunction of `when` clauses, canonicalizing
+/// every leaf comparison to one normal direction (`a > b` -> `b < a`,
+/// `a >= b` -> `b <= a`; see [`crate::codegen::common::canonicalize_comparison`]).
+/// This is the ONE choke point before the recognition arms below see the
+/// clauses: because the operands are pre-swapped here, the arms only ever
+/// match `Lt`/`Lte`, so they no longer hand-enumerate the `Gt`/`Gte`
+/// direction. Recognition-only — the emitters render `law.when` verbatim, so
+/// the user's original surface direction is preserved in the emitted proof.
+pub(super) fn flatten_and(e: &Spanned<Expr>, out: &mut Vec<Spanned<Expr>>) {
     match &e.node {
         Expr::FnCall(callee, args)
             if expr_dotted_name(callee).as_deref() == Some("Bool.and") && args.len() == 2 =>
@@ -69,12 +76,15 @@ pub(super) fn flatten_and<'a>(e: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Ex
             flatten_and(&args[0], out);
             flatten_and(&args[1], out);
         }
-        _ => out.push(e),
+        _ => out.push(crate::codegen::common::canonicalize_comparison(e)),
     }
 }
 
 /// Whether `clause` guarantees `0 < x` for the atom rendered as `x_render`:
 /// `0 < x`, `x > 0`, `1 <= x`, `x >= 1` (any nonneg/≥1 literal bound).
+/// Clauses arrive canonicalized by [`flatten_and`], so `x > 0` / `x >= 1`
+/// have already been swapped to `0 < x` / `1 <= x` — only the `Lt`/`Lte`
+/// forms need matching.
 pub(super) fn clause_gives_pos(
     clause: &Spanned<Expr>,
     x_render: &str,
@@ -88,12 +98,10 @@ pub(super) fn clause_gives_pos(
         _ => None,
     };
     match op {
-        // c < x  (c >= 0)  ⟹  0 < x ;  x > c  (c >= 0)
+        // c < x  (c >= 0)  ⟹  0 < x   (also matches canonicalized `x > c`)
         BinOp::Lt => int_lit(l).is_some_and(|c| c >= 0) && render(r, ctx) == x_render,
-        BinOp::Gt => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 0),
-        // c <= x  (c >= 1)  ;  x >= c  (c >= 1)
+        // c <= x  (c >= 1)          (also matches canonicalized `x >= c`)
         BinOp::Lte => int_lit(l).is_some_and(|c| c >= 1) && render(r, ctx) == x_render,
-        BinOp::Gte => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 1),
         _ => false,
     }
 }
@@ -116,15 +124,15 @@ pub(super) fn clause_gives_nonneg(
         _ => None,
     };
     match op {
-        // c <= x  (c >= 0)  ;  x >= c  (c >= 0)
+        // c <= x  (c >= 0)          (also matches canonicalized `x >= c`)
         BinOp::Lte => int_lit(l).is_some_and(|c| c >= 0) && render(r, ctx) == x_render,
-        BinOp::Gte => render(l, ctx) == x_render && int_lit(r).is_some_and(|c| c >= 0),
         _ => false,
     }
 }
 
 /// Whether `clause` is the strict upper bound `x < y` for atoms rendered as
-/// `x_render` / `y_render`.
+/// `x_render` / `y_render`. Clauses are canonicalized by [`flatten_and`], so a
+/// user-written `y > x` arrives here already swapped to `x < y` and matches.
 pub(super) fn clause_is_lt(
     clause: &Spanned<Expr>,
     x_render: &str,

--- a/tests/fixtures/floor_arith_witness.av
+++ b/tests/fixtures/floor_arith_witness.av
@@ -80,3 +80,33 @@ verify quotFloor law soakRemainderCommuted
     when rest < den
     when 0 <= rest
     quotFloor(rest + whole * den, den) => whole
+
+// The measured flip: the strict remainder bound is written `den > rest`
+// (the divisor-first `Gt` direction) instead of `rest < den`. Semantically
+// identical, but before comparator canonicalization the absorb rung matched
+// only the `Lt` spelling, so this exact flip dropped the law from universal
+// to bounded. The rung now canonicalizes the operand order internally and
+// closes it universal, spelling untouched in the emitted statement.
+
+verify quotFloor law soakRemainderUpperFlip
+    given whole: Int = [4, 0 - 3, 0, 9]
+    given den: Int = [1, 2, 4, 6]
+    given rest: Int = [0, 1, 3]
+    when 0 < den
+    when 0 <= rest
+    when den > rest
+    quotFloor(den * whole + rest, den) => whole
+
+// Ge<->Le twin of soakRemainder: the positivity and non-negativity are
+// spelled with `>=` (`den >= 1`, `rest >= 0`) rather than the `<`/`<=`
+// forms its twin uses. Canonicalization rewrites `x >= c` to `c <= x`, so
+// the same absorb rung recognizes both spellings identically.
+
+verify quotFloor law soakRemainderGeTwin
+    given whole: Int = [4, 0 - 3, 0, 9]
+    given den: Int = [1, 2, 4, 6]
+    given rest: Int = [0, 1, 3]
+    when den >= 1
+    when rest >= 0
+    when rest < den
+    quotFloor(den * whole + rest, den) => whole

--- a/tests/proof_spec/floor_window.rs
+++ b/tests/proof_spec/floor_window.rs
@@ -129,6 +129,12 @@ fn proof_export_floor_arith_second_witness_universal() {
         "quotFloor_law_shrinkFactorCommuted",
         "quotFloor_law_shrinkFactorDivisorLeft",
         "quotFloor_law_soakRemainderCommuted",
+        // Comparator-canonicalization witnesses: the strict remainder bound
+        // written divisor-first (`den > rest`) and the positivity/nonneg
+        // bounds spelled with `>=` must both close universal — the rung
+        // canonicalizes the operand order before recognition.
+        "quotFloor_law_soakRemainderUpperFlip",
+        "quotFloor_law_soakRemainderGeTwin",
     ] {
         assert!(
             lean.contains(&format!("-- aver:law-class {base} universal")),
@@ -349,7 +355,7 @@ fn proof_floor_window_lean_closes_kernel_genuine() {
 /// (`proof_export_floor_arith_second_witness_universal`) only asserts the
 /// `universal` law-class MARKERS, which the Rust classifier stamps when the
 /// rung FIRES — not when the Lean kernel accepts the proof. This gate builds
-/// the whole fixture with the toolchain and asserts all five witness laws
+/// the whole fixture with the toolchain and asserts all seven witness laws
 /// close sorry-free AND earn kernel-genuine `universal` credit (`#print
 /// axioms` inside the whitelist, encoded by the `universal` summary flag —
 /// same contract as `proof_floor_window_lean_closes_kernel_genuine`). Covers
@@ -379,7 +385,7 @@ fn proof_floor_arith_witness_lean_closes_kernel_genuine() {
     assert_eq!(
         summary["universal"].as_bool(),
         Some(true),
-        "all five witness law theorems are stated universally and must be \
+        "all seven witness law theorems are stated universally and must be \
          kernel-genuine (axioms within the whitelist).\n{}",
         format_output(&run)
     );
@@ -388,10 +394,11 @@ fn proof_floor_arith_witness_lean_closes_kernel_genuine() {
             summary["universal_laws"].as_u64(),
             summary["bounded_laws"].as_u64(),
         ),
-        (Some(5), Some(0)),
-        "explicit law counts: exactly the five universal-classed witness \
-         theorems certified (every cancel / absorb orientation corner), none \
-         degraded to bounded-domain.\n{}",
+        (Some(7), Some(0)),
+        "explicit law counts: exactly the seven universal-classed witness \
+         theorems certified (every cancel / absorb orientation corner plus \
+         the two comparator-canonicalization spellings), none degraded to \
+         bounded-domain.\n{}",
         format_output(&run)
     );
     let _ = std::fs::remove_dir_all(&output_dir);


### PR DESCRIPTION
## What

A measured hole: rewriting a law guard from 'r < d' to the semantically identical 'd > r' dropped floorDiv.absorbRemainder from universal to bounded (round.av 24 -> 23 universal) — recognition arms hand-enumerated operand orders and clause collection matched only the Lt/Le spellings. Comparisons in when-conjuncts are now canonicalized by pure operand swap (Gt->Lt, Ge->Le; strictness preserved, never negation) at the clause-collection choke points on both backends, and the arms that hand-matched flipped spellings are removed as exactly subsumed (re-proven empirically: the commuted witnesses still close universal on both kernels).

Canonical form is internal only: theorem statements and Dafny requires render the author's original spelling verbatim, and no diagnostic asks anyone to flip a comparison — direction is lowering privilege, not user intent.

## Verification

The original kill-fast replayed on the fixed binary: the 'd > r' spelling now closes universal (round.av 24/24, zero bounded, before/after in-thread). Adversarial panel: soundness GO (swap-only confirmed — no negation, no strictness change; subsumption of removed arms re-proven; no canonical-form leaks into --explain, emitted Lean, or Dafny requires; witness Dafny run 276 verified / 0 errors; 30/30 deterministic exports). Named follow-up (banked, out of scope): four arm families keep private clause collectors that bypass the choke points — harmless today (their conjuncts are fn-call shapes or direction-agnostic matches) and queued under the shared-recognition-substrate refactor.

## Gates

lib 928, proof_spec floor_window 9/9 and check_gates 19/19 serialized, fmt, clippy default and wasm,wasip2; K5 pins re-run (round 24/0 both spellings, remainder/recip unchanged).