### PR TITLE
Emit a proven fuel-stability lemma for simple string-position fuel wrappers

### DIFF
--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -2664,6 +2664,54 @@ fn proof_mode_accepts_single_string_pos_advance_recursion() {
 }
 
 #[test]
+fn proof_mode_emits_stability_lemma_for_simple_string_pos_skipper() {
+    let source = r#"module FuelStable
+    intent = "simple string-position fuel stability"
+    effects []
+
+fn skipSpaces(s: String, pos: Int) -> Int
+    match String.charAt(s, pos)
+        Option.None -> pos
+        Option.Some(c) -> match c
+            " " -> skipSpaces(s, pos + 1)
+            _ -> pos
+"#;
+    let mut ctx = ctx_from_source(source, "fuel_stable");
+    let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
+    let lean = generated_lean_file(&out);
+
+    assert!(lean.contains("def skipSpaces__fuel"));
+    assert!(
+        lean.contains("theorem skipSpaces__fuel_stable :"),
+        "expected simple string-position skipper to get a stability lemma:\n{lean}"
+    );
+    assert!(lean.contains("averStringPosFuel s pos 1 ≤ fuel"));
+    assert!(lean.contains("skipSpaces__fuel fuel s pos = skipSpaces s pos"));
+}
+
+#[test]
+fn proof_mode_declines_stability_lemma_for_non_skip_string_pos_shape() {
+    let source = r#"module FuelStableDecline
+    intent = "string-position recursion outside the stability shape"
+    effects []
+
+fn walk(s: String, pos: Int) -> Int
+    match String.charAt(s, pos)
+        Option.None -> pos
+        Option.Some(_) -> walk(s, pos + 1)
+"#;
+    let mut ctx = ctx_from_source(source, "fuel_stable_decline");
+    let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
+    let lean = generated_lean_file(&out);
+
+    assert!(lean.contains("def walk__fuel"));
+    assert!(
+        !lean.contains("walk__fuel_stable"),
+        "out-of-shape string-position recursion must not get an unprobed stability lemma:\n{lean}"
+    );
+}
+
+#[test]
 fn proof_mode_accepts_mutual_int_countdown_recursion() {
     let mut ctx = empty_ctx();
     let even = FnDef {

--- a/src/codegen/lean/toplevel/fuel.rs
+++ b/src/codegen/lean/toplevel/fuel.rs
@@ -333,6 +333,9 @@ pub(super) fn emit_fuelized_string_pos_fn(fd: &FnDef, ctx: &CodegenContext) -> S
         emit_string_pos_scan_lemma(fd, &helper_name, ctx)
             .map(|lemma| vec![String::new(), lemma])
             .unwrap_or_default(),
+        emit_simple_string_pos_stability_lemma(fd, &helper_name, 1, &body)
+            .map(|lemma| vec![String::new(), lemma])
+            .unwrap_or_default(),
     ]
     .into_iter()
     .flatten()
@@ -481,6 +484,240 @@ theorem {lemma_name} :
       simp only [{helper_name}, hch]
       rw [hpos]"#
     ))
+}
+
+fn emit_simple_string_pos_stability_lemma(
+    fd: &FnDef,
+    helper_name: &str,
+    rank_budget: usize,
+    emitted_body: &str,
+) -> Option<String> {
+    let literal = detect_simple_string_pos_skip_literal(fd)
+        .or_else(|| detect_simple_string_pos_skip_literal_from_body(fd, helper_name, emitted_body))?;
+    let fn_name = aver_name_to_lean(&fd.name);
+    let s = aver_name_to_lean(&fd.params.first()?.0);
+    let pos = aver_name_to_lean(&fd.params.get(1)?.0);
+    let params = emit_fn_params(&fd.params);
+    let args = emit_fn_param_names(&fd.params);
+    let binders = if params.is_empty() {
+        String::new()
+    } else {
+        format!(" {params}")
+    };
+    let lit = format!(
+        "\"{}\"",
+        crate::codegen::common::escape_string_literal(&literal)
+    );
+    let lemma_name = format!("{helper_name}_stable");
+
+    Some(format!(
+        r#"theorem {lemma_name} :
+    ∀ (fuel : Nat){binders},
+      averStringPosFuel {s} {pos} {rank_budget} ≤ fuel →
+      {helper_name} fuel {args} = {fn_name} {args} := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro {args} h
+      unfold averStringPosFuel at h
+      omega
+  | succ fuel ih =>
+      intro {args} h
+      unfold {fn_name}
+      have hmeasure_pos : 0 < averStringPosFuel {s} {pos} {rank_budget} := by
+        unfold averStringPosFuel
+        omega
+      cases hmeasure : averStringPosFuel {s} {pos} {rank_budget} with
+      | zero =>
+          omega
+      | succ measure' =>
+          by_cases hneg : {pos} < 0
+          · have hchar : String.charAtAv {s} {pos} = none := by
+              unfold String.charAtAv
+              simp [hneg]
+            simp [{helper_name}, hchar]
+          · have h0 : 0 ≤ {pos} := by omega
+            by_cases hlt : {pos}.toNat < {s}.toList.length
+            · have hchar := String.charAt_eq_of_lt {s} {pos} h0 hlt
+              by_cases hmatch : Char.toString ({s}.toList[{pos}.toNat]) = {lit}
+              · simp only [{helper_name}, hchar]
+                rw [hmatch]
+                have hnext_measure : averStringPosFuel {s} ({pos} + 1) {rank_budget} = measure' := by
+                  unfold averStringPosFuel at h hmeasure ⊢
+                  omega
+                have hleft : {helper_name} fuel {s} ({pos} + 1) = {fn_name} {s} ({pos} + 1) := by
+                  apply ih
+                  rw [hnext_measure]
+                  unfold averStringPosFuel at h hmeasure
+                  omega
+                unfold {fn_name} at hleft
+                rw [hnext_measure] at hleft
+                simpa using hleft
+              · have hmatch2 : ¬ String.singleton {s}.toList[{pos}.toNat] = {lit} := by
+                  simpa [Char.toString] using hmatch
+                simp [{helper_name}, hchar, hmatch2]
+            · have hchar := String.charAt_none_of_ge {s} {pos} h0 (by omega)
+              simp [{helper_name}, hchar]"#
+    ))
+}
+
+fn detect_simple_string_pos_skip_literal(fd: &FnDef) -> Option<String> {
+    if fd.params.len() != 2 {
+        return None;
+    }
+    let s_name = &fd.params[0].0;
+    let pos_name = &fd.params[1].0;
+    let [Stmt::Expr(expr)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { subject, arms } = &expr.node else {
+        return None;
+    };
+    if !is_string_char_at(subject.as_ref(), s_name, pos_name) {
+        return None;
+    }
+
+    let mut saw_none_exit = false;
+    let mut recursive_literal = None;
+    let mut saw_fallback_exit = false;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::Constructor(name, fields) if name == "Option.None" && fields.is_empty() => {
+                saw_none_exit = expr_is_ident(&arm.body, pos_name);
+            }
+            Pattern::Constructor(name, fields) if name == "Option.Some" && fields.len() == 1 => {
+                let lit = detect_inner_char_match_literal(
+                    &arm.body,
+                    &fields[0],
+                    &fd.name,
+                    s_name,
+                    pos_name,
+                )?;
+                recursive_literal = Some(lit.0);
+                saw_fallback_exit = lit.1;
+            }
+            Pattern::Wildcard => {
+                if let Some((lit, fallback)) =
+                    detect_inner_char_match_literal(&arm.body, "", &fd.name, s_name, pos_name)
+                {
+                    recursive_literal = Some(lit);
+                    saw_fallback_exit = fallback;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    match (saw_none_exit, saw_fallback_exit, recursive_literal) {
+        (true, true, Some(lit)) => Some(lit),
+        _ => None,
+    }
+}
+
+fn detect_simple_string_pos_skip_literal_from_body(
+    fd: &FnDef,
+    helper_name: &str,
+    body: &str,
+) -> Option<String> {
+    let s_name = aver_name_to_lean(&fd.params.first()?.0);
+    let pos_name = aver_name_to_lean(&fd.params.get(1)?.0);
+    let recursive_suffix = format!("=> {helper_name} {STRING_POS_FUEL_VAR} {s_name} ({pos_name} + 1)");
+    let none_exit = format!("| .none => {pos_name}");
+    let fallback_exit = format!("| _ => {pos_name}");
+    if !body.lines().any(|line| line.trim() == none_exit)
+        || !body.lines().any(|line| line.trim() == fallback_exit)
+    {
+        return None;
+    }
+    body.lines().find_map(|line| {
+        let trimmed = line.trim();
+        if !trimmed.ends_with(&recursive_suffix) {
+            return None;
+        }
+        let rest = trimmed.strip_prefix("| \"")?;
+        let end = rest.find("\" =>")?;
+        Some(rest[..end].to_string())
+    })
+}
+
+fn detect_inner_char_match_literal(
+    expr: &Spanned<Expr>,
+    binding: &str,
+    fn_name: &str,
+    s_name: &str,
+    pos_name: &str,
+) -> Option<(String, bool)> {
+    let Expr::Match { subject, arms } = &expr.node else {
+        return None;
+    };
+    if !binding.is_empty() && !expr_is_ident(subject, binding) {
+        return None;
+    }
+    let mut recursive_literal = None;
+    let mut fallback_exit = false;
+    for arm in arms {
+        match &arm.pattern {
+            Pattern::Literal(Literal::Str(lit)) => {
+                if expr_is_self_pos_plus_one_tailcall(&arm.body, fn_name, s_name, pos_name) {
+                    recursive_literal = Some(lit.clone());
+                }
+            }
+            Pattern::Wildcard if expr_is_ident(&arm.body, pos_name) => {
+                fallback_exit = true;
+            }
+            _ => {}
+        }
+    }
+    recursive_literal.map(|lit| (lit, fallback_exit))
+}
+
+fn is_string_char_at(expr: &Spanned<Expr>, s_name: &str, pos_name: &str) -> bool {
+    let Expr::FnCall(callee, args) = &expr.node else {
+        return false;
+    };
+    if args.len() != 2 || !expr_is_ident(&args[0], s_name) || !expr_is_ident(&args[1], pos_name) {
+        return false;
+    }
+    let Expr::Attr(base, method) = &callee.node else {
+        return false;
+    };
+    method == "charAt" && expr_is_ident(base, "String")
+}
+
+fn expr_is_ident(expr: &Spanned<Expr>, name: &str) -> bool {
+    matches!(&expr.node, Expr::Ident(n) if n == name)
+}
+
+fn expr_is_self_pos_plus_one_tailcall(
+    expr: &Spanned<Expr>,
+    fn_name: &str,
+    s_name: &str,
+    pos_name: &str,
+) -> bool {
+    let (target, args) = match &expr.node {
+        Expr::TailCall(data) => (&data.target, &data.args),
+        Expr::FnCall(callee, args) => match &callee.node {
+            Expr::Ident(name) => (name, args),
+            _ => return false,
+        },
+        _ => return false,
+    };
+    target == fn_name
+        && args.len() == 2
+        && expr_is_ident(&args[0], s_name)
+        && expr_is_pos_plus_one(&args[1], pos_name)
+}
+
+fn expr_is_pos_plus_one(expr: &Spanned<Expr>, pos_name: &str) -> bool {
+    matches!(
+        &expr.node,
+        Expr::BinOp(
+            BinOp::Add,
+            left,
+            right
+        ) if expr_is_ident(left, pos_name)
+            && matches!(&right.node, Expr::Literal(Literal::Int(1)))
+    )
 }
 
 fn strip_match_eq_binders(body: String) -> String {

--- a/src/codegen/lean/toplevel/fuel.rs
+++ b/src/codegen/lean/toplevel/fuel.rs
@@ -492,8 +492,9 @@ fn emit_simple_string_pos_stability_lemma(
     rank_budget: usize,
     emitted_body: &str,
 ) -> Option<String> {
-    let literal = detect_simple_string_pos_skip_literal(fd)
-        .or_else(|| detect_simple_string_pos_skip_literal_from_body(fd, helper_name, emitted_body))?;
+    let literal = detect_simple_string_pos_skip_literal(fd).or_else(|| {
+        detect_simple_string_pos_skip_literal_from_body(fd, helper_name, emitted_body)
+    })?;
     let fn_name = aver_name_to_lean(&fd.name);
     let s = aver_name_to_lean(&fd.params.first()?.0);
     let pos = aver_name_to_lean(&fd.params.get(1)?.0);
@@ -587,11 +588,7 @@ fn detect_simple_string_pos_skip_literal(fd: &FnDef) -> Option<String> {
             }
             Pattern::Constructor(name, fields) if name == "Option.Some" && fields.len() == 1 => {
                 let lit = detect_inner_char_match_literal(
-                    &arm.body,
-                    &fields[0],
-                    &fd.name,
-                    s_name,
-                    pos_name,
+                    &arm.body, &fields[0], &fd.name, s_name, pos_name,
                 )?;
                 recursive_literal = Some(lit.0);
                 saw_fallback_exit = lit.1;
@@ -621,7 +618,8 @@ fn detect_simple_string_pos_skip_literal_from_body(
 ) -> Option<String> {
     let s_name = aver_name_to_lean(&fd.params.first()?.0);
     let pos_name = aver_name_to_lean(&fd.params.get(1)?.0);
-    let recursive_suffix = format!("=> {helper_name} {STRING_POS_FUEL_VAR} {s_name} ({pos_name} + 1)");
+    let recursive_suffix =
+        format!("=> {helper_name} {STRING_POS_FUEL_VAR} {s_name} ({pos_name} + 1)");
     let none_exit = format!("| .none => {pos_name}");
     let fallback_exit = format!("| _ => {pos_name}");
     if !body.lines().any(|line| line.trim() == none_exit)

--- a/src/codegen/lean/toplevel/fuel.rs
+++ b/src/codegen/lean/toplevel/fuel.rs
@@ -486,13 +486,42 @@ theorem {lemma_name} :
     ))
 }
 
+/// Companion stability lemma for a simple string-position fuel SKIPPER —
+/// `<fn>__fuel fuel s pos = <fn> s pos` whenever `fuel` meets the wrapper's
+/// initial `averStringPosFuel s pos rank` budget. Gated to the skip shape
+/// (`match charAt with none => pos | some c => match c with <lit> => self(s,
+/// pos+1) … | _ => pos`) by [`detect_simple_string_pos_skip_literal`]; the
+/// literal itself is only the shape witness — the proof is literal-COUNT
+/// agnostic (handles single- and multi-literal skippers like json's four-way
+/// `skipWs` uniformly), so the detected literal value is discarded.
+///
+/// The recursive branch never case-splits on the character: once
+/// `charAt = some c` is fixed, both `<fn>__fuel (fuel+1)` and the wrapper's
+/// `<fn>__fuel (measure'+1)` unfold to the SAME inner `match Char.toString c`
+/// whose only difference is the recursive fuel argument (`fuel` vs `measure'`),
+/// and one `simp only [<fn>__fuel, hchar, hleft]` closes it by rewriting that
+/// argument — independent of how many literal arms recurse.
+///
+/// FAIL-SOFT: the whole proof is wrapped in `first | (<skeleton>) | sorry`
+/// (mirroring the off-probe floor of
+/// [`crate::codegen::lean::law_auto::transparent_chain`]). A gated shape the
+/// skeleton cannot close degrades to a non-fatal `declaration uses 'sorry'`
+/// warning instead of a hard `unsolved goals` build error. The lemma is not
+/// cited by any law, so its own `sorry` never enters another law's
+/// `#print axioms` set — universal credit for laws that do not reference it is
+/// untouched. A bare `sorry` (not the `AVERSPEC_SORRY:<id>` trace) is used
+/// deliberately: the trace exists so `speculative::parse_failures` can demote a
+/// non-closing conditional LAW to bounded, and this support lemma has no law
+/// tier to demote and no `speculative::admits` consumer.
 fn emit_simple_string_pos_stability_lemma(
     fd: &FnDef,
     helper_name: &str,
     rank_budget: usize,
     emitted_body: &str,
 ) -> Option<String> {
-    let literal = detect_simple_string_pos_skip_literal(fd).or_else(|| {
+    // Gate only: the detected literal is the shape witness; the robust proof
+    // below is literal-agnostic, so the value is discarded.
+    detect_simple_string_pos_skip_literal(fd).or_else(|| {
         detect_simple_string_pos_skip_literal_from_body(fd, helper_name, emitted_body)
     })?;
     let fn_name = aver_name_to_lean(&fd.name);
@@ -505,10 +534,6 @@ fn emit_simple_string_pos_stability_lemma(
     } else {
         format!(" {params}")
     };
-    let lit = format!(
-        "\"{}\"",
-        crate::codegen::common::escape_string_literal(&literal)
-    );
     let lemma_name = format!("{helper_name}_stable");
 
     Some(format!(
@@ -516,49 +541,47 @@ fn emit_simple_string_pos_stability_lemma(
     ∀ (fuel : Nat){binders},
       averStringPosFuel {s} {pos} {rank_budget} ≤ fuel →
       {helper_name} fuel {args} = {fn_name} {args} := by
-  intro fuel
-  induction fuel with
-  | zero =>
-      intro {args} h
-      unfold averStringPosFuel at h
-      omega
-  | succ fuel ih =>
-      intro {args} h
-      unfold {fn_name}
-      have hmeasure_pos : 0 < averStringPosFuel {s} {pos} {rank_budget} := by
-        unfold averStringPosFuel
-        omega
-      cases hmeasure : averStringPosFuel {s} {pos} {rank_budget} with
-      | zero =>
-          omega
-      | succ measure' =>
-          by_cases hneg : {pos} < 0
-          · have hchar : String.charAtAv {s} {pos} = none := by
-              unfold String.charAtAv
-              simp [hneg]
-            simp [{helper_name}, hchar]
-          · have h0 : 0 ≤ {pos} := by omega
-            by_cases hlt : {pos}.toNat < {s}.toList.length
-            · have hchar := String.charAt_eq_of_lt {s} {pos} h0 hlt
-              by_cases hmatch : Char.toString ({s}.toList[{pos}.toNat]) = {lit}
-              · simp only [{helper_name}, hchar]
-                rw [hmatch]
-                have hnext_measure : averStringPosFuel {s} ({pos} + 1) {rank_budget} = measure' := by
-                  unfold averStringPosFuel at h hmeasure ⊢
-                  omega
-                have hleft : {helper_name} fuel {s} ({pos} + 1) = {fn_name} {s} ({pos} + 1) := by
-                  apply ih
-                  rw [hnext_measure]
-                  unfold averStringPosFuel at h hmeasure
-                  omega
-                unfold {fn_name} at hleft
-                rw [hnext_measure] at hleft
-                simpa using hleft
-              · have hmatch2 : ¬ String.singleton {s}.toList[{pos}.toNat] = {lit} := by
-                  simpa [Char.toString] using hmatch
-                simp [{helper_name}, hchar, hmatch2]
-            · have hchar := String.charAt_none_of_ge {s} {pos} h0 (by omega)
-              simp [{helper_name}, hchar]"#
+  first
+  | (intro fuel
+     induction fuel with
+     | zero =>
+         intro {args} h
+         unfold averStringPosFuel at h
+         omega
+     | succ fuel ih =>
+         intro {args} h
+         unfold {fn_name}
+         have hmeasure_pos : 0 < averStringPosFuel {s} {pos} {rank_budget} := by
+           unfold averStringPosFuel
+           omega
+         cases hmeasure : averStringPosFuel {s} {pos} {rank_budget} with
+         | zero =>
+             omega
+         | succ measure' =>
+             by_cases hneg : {pos} < 0
+             · have hchar : String.charAtAv {s} {pos} = none := by
+                 unfold String.charAtAv
+                 simp [hneg]
+               simp [{helper_name}, hchar]
+             · have h0 : 0 ≤ {pos} := by omega
+               by_cases hlt : {pos}.toNat < {s}.toList.length
+               · have hchar := String.charAt_eq_of_lt {s} {pos} h0 hlt
+                 have hnext_measure : averStringPosFuel {s} ({pos} + 1) {rank_budget} = measure' := by
+                   unfold averStringPosFuel at h hmeasure ⊢
+                   omega
+                 have hleft : {helper_name} fuel {s} ({pos} + 1) = {helper_name} measure' {s} ({pos} + 1) := by
+                   have hstep : {helper_name} fuel {s} ({pos} + 1) = {fn_name} {s} ({pos} + 1) := by
+                     apply ih
+                     rw [hnext_measure]
+                     unfold averStringPosFuel at h hmeasure
+                     omega
+                   rw [hstep]
+                   unfold {fn_name}
+                   rw [hnext_measure]
+                 simp only [{helper_name}, hchar, hleft]
+               · have hchar := String.charAt_none_of_ge {s} {pos} h0 (by omega)
+                 simp [{helper_name}, hchar])
+  | sorry"#
     ))
 }
 
@@ -655,10 +678,10 @@ fn detect_inner_char_match_literal(
     let mut fallback_exit = false;
     for arm in arms {
         match &arm.pattern {
-            Pattern::Literal(Literal::Str(lit)) => {
-                if expr_is_self_pos_plus_one_tailcall(&arm.body, fn_name, s_name, pos_name) {
-                    recursive_literal = Some(lit.clone());
-                }
+            Pattern::Literal(Literal::Str(lit))
+                if expr_is_self_pos_plus_one_tailcall(&arm.body, fn_name, s_name, pos_name) =>
+            {
+                recursive_literal = Some(lit.clone());
             }
             Pattern::Wildcard if expr_is_ident(&arm.body, pos_name) => {
                 fallback_exit = true;

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -1514,3 +1514,77 @@ verify ledgerWithinCeiling law nonstrictChainWitness
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_multi_literal_string_pos_skipper_stability_lemma_kernel_clean() {
+    // Regression net for the fuel-stability lemma on a MULTI-literal string-position
+    // skipper — the json `skipWs` shape (four whitespace chars all recursing to
+    // `self(s, pos+1)`, rankBudget 1). The first synthesized skeleton only handled a
+    // single skip literal and hard-failed this shape with `unsolved goals` (`case neg`
+    // could not close the residual `match … skipWs__fuel fuel …  = match … skipWs__fuel
+    // measure' …`). The robust skeleton is literal-COUNT agnostic, so the lemma must
+    // kernel-prove with NO sorry, and the whole project must build clean.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping multi-literal skipper stability test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-skipws-stable-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module SkipWsFuel\n    effects []\n\n\
+         fn skipWs(s: String, pos: Int) -> Int\n    match String.charAt(s, pos)\n        Option.None -> pos\n        Option.Some(c) -> match c\n            \" \" -> skipWs(s, pos + 1)\n            \"\\t\" -> skipWs(s, pos + 1)\n            \"\\n\" -> skipWs(s, pos + 1)\n            \"\\r\" -> skipWs(s, pos + 1)\n            _ -> pos\n\n\
+         verify skipWs\n    skipWs(\"\", 0) => 0\n    skipWs(\"  abc\", 0) => 2\n    skipWs(\"\\tabc\", 0) => 1\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-skipws-stable-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .arg("--sorry-budget")
+        .arg("0")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean = std::fs::read_to_string(out.join("SkipWsFuel.lean")).expect("read SkipWsFuel.lean");
+    // The stability lemma must be emitted (the multi-literal skip shape is gated in)
+    // and floored fail-soft (`first | (…) | sorry`).
+    assert!(
+        lean.contains("theorem skipWs__fuel_stable :"),
+        "the multi-literal string-position skipper must get a stability lemma:\n{lean}"
+    );
+    assert!(
+        lean.contains("  first\n") && lean.contains("\n  | sorry"),
+        "the stability lemma must be floored `first | (…) | sorry`:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    // passed + zero sorries together certify: the lemma did NOT fall to its sorry
+    // floor (`sorries == 0`) and `lake build` genuinely closed it (`passed`), i.e.
+    // the robust skeleton kernel-proves the multi-literal case — no `unsolved goals`.
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["build_errors"].as_u64(),
+        ),
+        (Some(true), Some(0), Some(0)),
+        "the multi-literal skipper stability lemma must kernel-prove with no sorry and \
+         no hard build error.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## What

Functions the termination classifier cannot grade natively are emitted as fuelized wrappers, which block useful induction: nothing connects fn__fuel k to the plain fn. Every simple string-position fuel wrapper now gets an emitted, kernel-proven stability lemma 'measure <= k -> fn__fuel k s pos = fn s pos', keyed on the stored fuel-metric shape (name-blind). The proof skeleton is literal-agnostic (one simp rewrite of the recursive fuel argument once the scrutinee character is fixed), so multi-branch skippers like the JSON corpus's four-way whitespace scanner are covered, and the whole proof sits under a fail-soft floor: an unprovable instance degrades to a caught sorry instead of a build error, and a support lemma's floor cannot poison any law's axioms (cited by no law; verified empirically).

## Measured trail

The hand kill-fast proved the lemma class core-clean before any emitter code. The first emitter draft regressed examples/data/json.av to a hard build error (caught by the build_errors check-json field the same window shipped in #632); the fix round robustified the skeleton — smaller than the original, deleting per-literal reasoning — and restored the corpus baseline verbatim: passed true, 19 bounded / 10 universal, 0 build errors, 0 sorries, with the lemma now proving inside.

The mutual-clique case (the JSON parser's recursive group — the eventual consumer for productwise laws) is measured and banked, NOT shipped: a per-function stability lemma structurally lacks the sibling induction hypothesis, so the group form must be stated simultaneously over the whole clique. That is the named follow-up leg.

## Gates

lib 929; proof_spec lean_kernel + check_gates serialized 42/42 including the new kernel-clean multi-literal fixture and the emit/decline unit pair; clippy default and wasm,wasip2; fmt; forced-failure floor test (sorryAx caught, lake exits 0).