### PR TITLE
Move the proof arms onto a shared recognition substrate

### DIFF
--- a/projects/k5_fdiv/probe.av
+++ b/projects/k5_fdiv/probe.av
@@ -1,0 +1,29 @@
+module Probe
+    intent = "compute"
+    depends [Domain.Rational, Domain.Kernel, Domain.Remainder]
+    effects [Console]
+
+fn p1of(p0: Fraction, d: Fraction, sd2: Fraction) -> Fraction
+    ? "p1"
+    Domain.Rational.minus(p0, Domain.Rational.times(Domain.Remainder.firstQuotientDigit(p0, sd2), d))
+fn ph1of(p0: Fraction, d: Fraction, sd2: Fraction) -> Fraction
+    ? "ph1"
+    Domain.Kernel.truncFrac(p1of(p0, d, sd2), 32)
+fn q1of(p0: Fraction, d: Fraction, sd2: Fraction) -> Fraction
+    ? "q1"
+    Domain.Kernel.awayFrac(Domain.Rational.times(sd2, ph1of(p0, d, sd2)), 24)
+fn sep(p0: Fraction, d: Fraction, sd2: Fraction) -> Bool
+    ? "check"
+    Domain.Kernel.fracExpo(q1of(p0,d,sd2)) <= Domain.Kernel.fracExpo(Domain.Remainder.firstQuotientDigit(p0, sd2)) - 23
+fn show(tag: String, p0: Fraction, d: Fraction, sd2: Fraction) -> Unit
+    ? "p"
+    ! [Console.print]
+    q1 = q1of(p0, d, sd2)
+    Console.print("{tag}: eq0={Domain.Kernel.fracExpo(Domain.Remainder.firstQuotientDigit(p0, sd2))} q1top={q1.top} eq1={Domain.Kernel.fracExpo(q1)} sep={sep(p0,d,sd2)}")
+fn main() -> Unit
+    ? "run"
+    ! [Console.print]
+    show("A", Domain.Rational.Fraction(top = 5, bottom = 4), Domain.Rational.Fraction(top = 4, bottom = 5), Domain.Rational.Fraction(top = 5, bottom = 4))
+    show("B", Domain.Rational.Fraction(top = 7, bottom = 3), Domain.Rational.Fraction(top = 5, bottom = 2), Domain.Rational.Fraction(top = 2, bottom = 5))
+    show("C", Domain.Rational.Fraction(top = 9, bottom = 7), Domain.Rational.Fraction(top = 3, bottom = 2), Domain.Rational.Fraction(top = 2, bottom = 3))
+    show("D", Domain.Rational.Fraction(top = 11, bottom = 8), Domain.Rational.Fraction(top = 13, bottom = 7), Domain.Rational.Fraction(top = 7, bottom = 13))

--- a/src/codegen/lean/law_auto/container_induction.rs
+++ b/src/codegen/lean/law_auto/container_induction.rs
@@ -221,12 +221,12 @@ fn recognize(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenContext) -> Option<
     if let (Expr::FnCall(rc, ra), Expr::FnCall(lc, la)) = (&law.rhs.node, &law.lhs.node)
         && shared::expr_dotted_name(rc).as_deref() == Some(pair.f_src.as_str())
         && ra.len() == 1
-        && is_ident(&ra[0], t_name)
+        && shared::is_ident(&ra[0], t_name)
         && shared::expr_dotted_name(lc).as_deref() == Some(pair.f_src.as_str())
         && la.len() == 1
         && let Expr::FnCall(gc, ga) = &la[0].node
         && ga.len() == 1
-        && is_ident(&ga[0], t_name)
+        && shared::is_ident(&ga[0], t_name)
         && let Some(g_src) = shared::expr_dotted_name(gc)
         && g_src != pair.f_src
     {
@@ -292,7 +292,7 @@ fn recognize_pair(f_src: &str, ctx: &CodegenContext) -> Option<Pair> {
     let Expr::Match { subject, arms } = &f_body.node else {
         return None;
     };
-    if !is_ident(subject, t_param) {
+    if !shared::is_ident(subject, t_param) {
         return None;
     }
     if arms.len() != 2 {
@@ -352,32 +352,11 @@ fn node_arm_sibling(arms: &[crate::ast::MatchArm], ctx: &CodegenContext) -> Opti
             continue;
         }
         let field = &binders[0];
-        if let Some(name) = call_on_binder(&arm.body, field, ctx) {
+        if let Some(name) = shared::call_on_binder(&arm.body, field, ctx) {
             return Some(name);
         }
     }
     None
-}
-
-/// Deepest user-fn call `h(<field>)` (single arg the given binder) anywhere in
-/// `expr` — the walker `f`'s node arm applies its sibling to the child list,
-/// possibly under a constructor / list-op wrapper (`Node(reverse(fList kids))`).
-fn call_on_binder(expr: &Spanned<Expr>, field: &str, ctx: &CodegenContext) -> Option<String> {
-    let mut found: Option<String> = None;
-    fn walk(e: &Spanned<Expr>, field: &str, ctx: &CodegenContext, found: &mut Option<String>) {
-        if let Some((name, args)) = as_call(&e.node)
-            && args.len() == 1
-            && is_ident(&args[0], field)
-            && shared::find_fn_def(ctx, &name).is_some()
-        {
-            *found = Some(name);
-        }
-        for child in child_exprs(e) {
-            walk(child, field, ctx, found);
-        }
-    }
-    walk(expr, field, ctx, &mut found);
-    found
 }
 
 /// Whether `g`'s node arm applies `List.reverse` to a call to `glist` — the
@@ -398,7 +377,7 @@ fn node_arm_injects_reverse(g_fd: &FnDef, glist_src: &str, ctx: &CodegenContext)
         {
             return true;
         }
-        child_exprs(e)
+        shared::child_exprs(e)
             .into_iter()
             .any(|c| find_reverse_of(c, glist))
     }
@@ -420,7 +399,7 @@ fn is_list_walker(fd: &FnDef, adt: &str, f_src: &str) -> bool {
     let Expr::Match { subject, arms } = &body.node else {
         return false;
     };
-    if !is_ident(subject, param) || arms.len() != 2 {
+    if !shared::is_ident(subject, param) || arms.len() != 2 {
         return false;
     }
     // Canonical order: `[]` first, `[x, ..rest]` second (matches the `case3/case4`
@@ -437,26 +416,12 @@ fn is_list_walker(fd: &FnDef, adt: &str, f_src: &str) -> bool {
             Pattern::EmptyList => saw_nil = true,
             Pattern::Cons(head, _tail) => {
                 // The cons arm applies `f` to the head element.
-                cons_calls_f = calls_fn_on_ident(&arm.body, f_src, head);
+                cons_calls_f = shared::calls_fn_on_ident(&arm.body, f_src, head);
             }
             _ => return false,
         }
     }
     saw_nil && cons_calls_f
-}
-
-/// Whether `expr` contains a call `f(<ident>)` (single-arg, the given binder).
-fn calls_fn_on_ident(expr: &Spanned<Expr>, f_src: &str, ident: &str) -> bool {
-    if let Expr::FnCall(callee, args) = &expr.node
-        && args.len() == 1
-        && is_ident(&args[0], ident)
-        && shared::expr_dotted_name(callee).as_deref() == Some(f_src)
-    {
-        return true;
-    }
-    child_exprs(expr)
-        .into_iter()
-        .any(|c| calls_fn_on_ident(c, f_src, ident))
 }
 
 /// The `Int` literal of a numeric list-walker's `[]` base arm.
@@ -482,7 +447,7 @@ fn mutual_scc(f_src: &str, ctx: &CodegenContext) -> BTreeSet<String> {
         let mut seen = BTreeSet::new();
         let mut stack = vec![start.to_string()];
         while let Some(cur) = stack.pop() {
-            for callee in direct_user_calls(&cur, ctx) {
+            for callee in shared::direct_user_calls(&cur, ctx) {
                 if seen.insert(callee.clone()) {
                     stack.push(callee);
                 }
@@ -497,32 +462,6 @@ fn mutual_scc(f_src: &str, ctx: &CodegenContext) -> BTreeSet<String> {
         .cloned()
         .chain(std::iter::once(f_src.to_string()))
         .collect()
-}
-
-/// Direct callees of `src` that are user fn defs (by source name).
-fn direct_user_calls(src: &str, ctx: &CodegenContext) -> BTreeSet<String> {
-    let mut out = BTreeSet::new();
-    let Some(fd) = shared::find_fn_def(ctx, src) else {
-        return out;
-    };
-    fn walk(e: &Spanned<Expr>, ctx: &CodegenContext, out: &mut BTreeSet<String>) {
-        if let Some((name, _)) = as_call(&e.node)
-            && let Some(fd) = shared::find_fn_def(ctx, &name)
-        {
-            out.insert(fd.name.clone());
-        }
-        for c in child_exprs(e) {
-            walk(c, ctx, out);
-        }
-    }
-    for stmt in fd.body.stmts() {
-        match stmt {
-            crate::ast::Stmt::Expr(e) | crate::ast::Stmt::Binding(_, _, e) => {
-                walk(e, ctx, &mut out)
-            }
-        }
-    }
-    out
 }
 
 fn find_sum_variants<'a>(ctx: &'a CodegenContext, name: &str) -> Option<&'a Vec<TypeVariant>> {
@@ -564,55 +503,12 @@ fn is_dep_module_fn(ctx: &CodegenContext, source_name: &str) -> bool {
         .any(|m| m.fn_defs.iter().any(|fd| fd.name == source_name))
 }
 
-fn is_ident(expr: &Spanned<Expr>, name: &str) -> bool {
-    matches!(&expr.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == name)
-}
-
 /// `expr` is a single-arg call `callee(<ident>)` with `callee` = `fn_src`.
 fn is_call_on(expr: &Spanned<Expr>, fn_src: &str, ident: &str) -> bool {
     let Expr::FnCall(callee, args) = &expr.node else {
         return false;
     };
     args.len() == 1
-        && is_ident(&args[0], ident)
+        && shared::is_ident(&args[0], ident)
         && shared::expr_dotted_name(callee).as_deref() == Some(fn_src)
-}
-
-/// Callee source-name and args of a call, seeing through the TCO rewrite: a
-/// tail-position self/peer call is an `Expr::TailCall` (the TCO pass runs before
-/// law_auto), not an `Expr::FnCall`. Every walker that detects a call must treat
-/// it as one, or the recognizer under-computes the mutual SCC (silently admitting
-/// a >2-fn SCC) and misses a pair whose node-arm call sits in tail position. Same
-/// precedent as `induction/mod.rs` and `proof_recognize.rs`.
-fn as_call(e: &Expr) -> Option<(String, &[Spanned<Expr>])> {
-    match e {
-        Expr::FnCall(callee, args) => Some((shared::expr_dotted_name(callee)?, args.as_slice())),
-        Expr::TailCall(tc) => Some((tc.target.clone(), tc.args.as_slice())),
-        _ => None,
-    }
-}
-
-/// Immediate sub-expressions to recurse through when scanning a fn body — enough
-/// for the pure walker shapes this arm recognizes.
-fn child_exprs(e: &Spanned<Expr>) -> Vec<&Spanned<Expr>> {
-    match &e.node {
-        Expr::FnCall(callee, args) => {
-            let mut v = vec![callee.as_ref()];
-            v.extend(args.iter());
-            v
-        }
-        Expr::BinOp(_, l, r) => vec![l.as_ref(), r.as_ref()],
-        Expr::Neg(inner) | Expr::ErrorProp(inner) => vec![inner.as_ref()],
-        Expr::Attr(base, _) => vec![base.as_ref()],
-        Expr::Constructor(_, Some(inner)) => vec![inner.as_ref()],
-        Expr::Match { subject, arms } => {
-            let mut v = vec![subject.as_ref()];
-            v.extend(arms.iter().map(|a| a.body.as_ref()));
-            v
-        }
-        Expr::List(items) | Expr::Tuple(items) => items.iter().collect(),
-        // Post-TCO: a tail-position call's args are the sub-exprs to keep scanning.
-        Expr::TailCall(tc) => tc.args.iter().collect(),
-        _ => Vec::new(),
-    }
 }

--- a/src/codegen/lean/law_auto/frac_monotone_compose.rs
+++ b/src/codegen/lean/law_auto/frac_monotone_compose.rs
@@ -36,35 +36,9 @@
 
 use super::AutoProof;
 use super::aver_name_to_lean;
-use super::shared::{expr_dotted_name, find_fn_def_by_call_name};
+use super::shared::{self, expr_dotted_name, find_fn_def_by_call_name};
 use crate::ast::{BinOp, Expr, FnDef, Literal, Spanned, Stmt, VerifyBlock, VerifyKind, VerifyLaw};
 use crate::codegen::CodegenContext;
-
-/// `(short_callee_name, args)` when `expr` is a function call, matched on the
-/// last dotted component so a qualified `Domain.Rational.minus` matches `minus`.
-fn as_call(expr: &Spanned<Expr>) -> Option<(String, &[Spanned<Expr>])> {
-    let Expr::FnCall(callee, args) = &expr.node else {
-        return None;
-    };
-    let dotted = expr_dotted_name(callee)?;
-    let short = dotted.rsplit('.').next().unwrap_or(&dotted).to_string();
-    Some((short, args.as_slice()))
-}
-
-/// A call to the named primitive (by SHORT name) with exactly `n` args,
-/// returning `(dotted_name, args)`.
-fn call_named<'a>(
-    expr: &'a Spanned<Expr>,
-    name: &str,
-    n: usize,
-) -> Option<(String, &'a [Spanned<Expr>])> {
-    let (short, args) = as_call(expr)?;
-    let Expr::FnCall(callee, _) = &expr.node else {
-        return None;
-    };
-    let dotted = expr_dotted_name(callee)?;
-    (short == name && args.len() == n).then_some((dotted, args))
-}
 
 /// Deep-clone `e`, replacing any free `Ident`/`Resolved` named in `map`.
 fn substitute(
@@ -153,8 +127,8 @@ struct RatOps {
 /// Read the rational-op Lean names from the `isNonNeg`/`minus` heads of a
 /// conclusion body `isNonNeg (minus …)`.
 fn rat_ops_from_body(body: &Spanned<Expr>) -> Option<RatOps> {
-    let (isnonneg, nn_args) = call_named(body, "isNonNeg", 1)?;
-    let (minus, _) = call_named(&nn_args[0], "minus", 2)?;
+    let (isnonneg, nn_args) = shared::call_named_with_dotted(body, "isNonNeg", 1)?;
+    let (minus, _) = shared::call_named_with_dotted(&nn_args[0], "minus", 2)?;
     let prefix = minus.rsplit_once('.').map(|(p, _)| p.to_string())?;
     Some(RatOps {
         isnonneg: aver_name_to_lean(&isnonneg),
@@ -239,7 +213,7 @@ fn find_recursive_positivity(
         if !matches!(&r.node, Expr::Literal(Literal::Int(_))) {
             continue;
         }
-        let Some((callee, _)) = as_call(l) else {
+        let Some((callee, _)) = shared::short_call_name_args(l) else {
             continue;
         };
         if callee != short {
@@ -321,7 +295,7 @@ fn recognize_frac_positivity_shape(
     let body = subject_body(&subject_src, ctx)?;
     // Body `Bool.and(C1, C2)` with each a strict positivity of the SAME `F`'s
     // numerator / denominator.
-    let (_, and_args) = call_named(body, "and", 2)?;
+    let (_, and_args) = shared::call_named_with_dotted(body, "and", 2)?;
     let f1 = pos_comparison_fn(&and_args[0])?;
     let f2 = pos_comparison_fn(&and_args[1])?;
     if f1 != f2 {
@@ -427,10 +401,10 @@ fn recognize_frac_geone_shape(
     let body = subject_body(&subject_src, ctx)?;
     // Body `isNonNeg(minus(F(k), oneFraction()))`.
     let ops = rat_ops_from_body(body)?;
-    let (_, nn_args) = call_named(body, "isNonNeg", 1)?;
-    let (_, m_args) = call_named(&nn_args[0], "minus", 2)?;
-    let (sgn_short, f_args) = as_call(&m_args[0])?;
-    if f_args.len() != 1 || call_named(&m_args[1], "oneFraction", 0).is_none() {
+    let (_, nn_args) = shared::call_named_with_dotted(body, "isNonNeg", 1)?;
+    let (_, m_args) = shared::call_named_with_dotted(&nn_args[0], "minus", 2)?;
+    let (sgn_short, f_args) = shared::short_call_name_args(&m_args[0])?;
+    if f_args.len() != 1 || shared::call_named_with_dotted(&m_args[1], "oneFraction", 0).is_none() {
         return None;
     }
     let Expr::FnCall(sgn_callee, _) = &m_args[0].node else {
@@ -442,13 +416,16 @@ fn recognize_frac_geone_shape(
         return None;
     }
     let _ = sgn_short;
-    // Premise must be `arg >= 0` (the nonnegative-exponent guard that kills the
-    // negative arm). Compare to the subject's call argument.
-    let when = law.when.as_ref()?;
-    let Expr::BinOp(BinOp::Gte, _, r) = &when.node else {
+    // Premise must be a single nonnegative-exponent guard. Shared collection
+    // canonicalizes `arg >= 0` and `0 <= arg` to the same `0 <= arg` shape.
+    let clauses = shared::collect_when_clauses(law.when.as_ref()?);
+    let [when] = clauses.as_slice() else {
         return None;
     };
-    if !matches!(&r.node, Expr::Literal(Literal::Int(0))) {
+    let Expr::BinOp(BinOp::Lte, l, _) = &when.node else {
+        return None;
+    };
+    if !matches!(&l.node, Expr::Literal(Literal::Int(0))) {
         return None;
     }
     let (g, recpos) = find_recursive_positivity(vb, law, ctx)?;
@@ -544,10 +521,10 @@ struct FracMonotone {
 /// Match a homomorphism body `sameValue(F(a + b), times(F(a), F(b)))` over the
 /// SAME fn `F` (basename `sgn_short`).
 fn is_homomorphism_body(body: &Spanned<Expr>, sgn_short: &str) -> bool {
-    let Some((_, sv_args)) = call_named(body, "sameValue", 2) else {
+    let Some((_, sv_args)) = shared::call_named_with_dotted(body, "sameValue", 2) else {
         return false;
     };
-    let Some((f0, f0_args)) = as_call(&sv_args[0]) else {
+    let Some((f0, f0_args)) = shared::short_call_name_args(&sv_args[0]) else {
         return false;
     };
     if f0 != sgn_short || f0_args.len() != 1 {
@@ -556,16 +533,16 @@ fn is_homomorphism_body(body: &Spanned<Expr>, sgn_short: &str) -> bool {
     if !matches!(&f0_args[0].node, Expr::BinOp(BinOp::Add, _, _)) {
         return false;
     }
-    let Some((_, t_args)) = call_named(&sv_args[1], "times", 2) else {
+    let Some((_, t_args)) = shared::call_named_with_dotted(&sv_args[1], "times", 2) else {
         return false;
     };
-    matches!(as_call(&t_args[0]), Some((s, a)) if s == sgn_short && a.len() == 1)
-        && matches!(as_call(&t_args[1]), Some((s, a)) if s == sgn_short && a.len() == 1)
+    matches!(shared::short_call_name_args(&t_args[0]), Some((s, a)) if s == sgn_short && a.len() == 1)
+        && matches!(shared::short_call_name_args(&t_args[1]), Some((s, a)) if s == sgn_short && a.len() == 1)
 }
 
 /// Match a positivity body `Bool.and(F(_).x > 0, F(_).y > 0)` over `sgn_short`.
 fn is_positivity_body(body: &Spanned<Expr>, sgn_short: &str) -> bool {
-    let Some((_, and_args)) = call_named(body, "and", 2) else {
+    let Some((_, and_args)) = shared::call_named_with_dotted(body, "and", 2) else {
         return false;
     };
     let same = |c: &Spanned<Expr>| {
@@ -579,14 +556,14 @@ fn is_positivity_body(body: &Spanned<Expr>, sgn_short: &str) -> bool {
 
 /// Match a `>= 1` body `isNonNeg(minus(F(_), oneFraction()))` over `sgn_short`.
 fn is_geone_body(body: &Spanned<Expr>, sgn_short: &str) -> bool {
-    let Some((_, nn_args)) = call_named(body, "isNonNeg", 1) else {
+    let Some((_, nn_args)) = shared::call_named_with_dotted(body, "isNonNeg", 1) else {
         return false;
     };
-    let Some((_, m_args)) = call_named(&nn_args[0], "minus", 2) else {
+    let Some((_, m_args)) = shared::call_named_with_dotted(&nn_args[0], "minus", 2) else {
         return false;
     };
-    matches!(as_call(&m_args[0]), Some((s, a)) if s == sgn_short && a.len() == 1)
-        && call_named(&m_args[1], "oneFraction", 0).is_some()
+    matches!(shared::short_call_name_args(&m_args[0]), Some((s, a)) if s == sgn_short && a.len() == 1)
+        && shared::call_named_with_dotted(&m_args[1], "oneFraction", 0).is_some()
 }
 
 fn recognize_frac_monotone_shape(
@@ -612,10 +589,10 @@ fn recognize_frac_monotone_shape(
     let body = subject_body(&subject_src, ctx)?;
     // Body `isNonNeg(minus(F(HI), F(LO)))` over a single `Fraction`-valued `F`.
     let ops = rat_ops_from_body(body)?;
-    let (_, nn_args) = call_named(body, "isNonNeg", 1)?;
-    let (_, m_args) = call_named(&nn_args[0], "minus", 2)?;
-    let (sgn_hi, hi_args) = as_call(&m_args[0])?;
-    let (sgn_lo, lo_args) = as_call(&m_args[1])?;
+    let (_, nn_args) = shared::call_named_with_dotted(body, "isNonNeg", 1)?;
+    let (_, m_args) = shared::call_named_with_dotted(&nn_args[0], "minus", 2)?;
+    let (sgn_hi, hi_args) = shared::short_call_name_args(&m_args[0])?;
+    let (sgn_lo, lo_args) = shared::short_call_name_args(&m_args[1])?;
     if hi_args.len() != 1 || lo_args.len() != 1 || sgn_hi != sgn_lo {
         return None;
     }
@@ -649,12 +626,14 @@ fn recognize_frac_monotone_shape(
     let lo = substitute(&lo_args[0], &map);
 
     // Premise must establish `LO <= HI` (small side `LO`, big side `HI`).
-    let when = law.when.as_ref()?;
+    let clauses = shared::collect_when_clauses(law.when.as_ref()?);
+    let [when] = clauses.as_slice() else {
+        return None;
+    };
     let render = |e: &Spanned<Expr>| super::super::expr::emit_expr_legacy(e, ctx, None);
     let (lo_lean, hi_lean) = (render(&lo), render(&hi));
     let premise_ok = match &when.node {
         Expr::BinOp(BinOp::Lte, l, r) => render(l) == lo_lean && render(r) == hi_lean,
-        Expr::BinOp(BinOp::Gte, l, r) => render(l) == hi_lean && render(r) == lo_lean,
         _ => false,
     };
     if !premise_ok {

--- a/src/codegen/lean/law_auto/frac_order_chain.rs
+++ b/src/codegen/lean/law_auto/frac_order_chain.rs
@@ -66,7 +66,7 @@
 
 use super::AutoProof;
 use super::aver_name_to_lean;
-use super::shared::{expr_dotted_name, find_fn_def_by_call_name};
+use super::shared::{self, expr_dotted_name, find_fn_def_by_call_name};
 use crate::ast::{Expr, FnDef, Spanned, Stmt, VerifyBlock, VerifyKind, VerifyLaw};
 use crate::codegen::CodegenContext;
 
@@ -111,57 +111,6 @@ pub(super) struct FracOrderChain {
     /// The cited monotonicity pool law as `(module_prefix, theorem_base)` — the
     /// cross-file admission keys on it so the dep theorem is emitted.
     cited_deps: Vec<(String, String)>,
-}
-
-/// `(short_callee_name, args)` when `expr` is a function call. The short name
-/// is the last dotted component, so a qualified `Domain.Rational.minus` call
-/// matches the primitive `minus` — keyed on the rational ALGEBRA primitive.
-fn as_call(expr: &Spanned<Expr>) -> Option<(String, &[Spanned<Expr>])> {
-    let Expr::FnCall(callee, args) = &expr.node else {
-        return None;
-    };
-    let dotted = expr_dotted_name(callee)?;
-    let short = dotted.rsplit('.').next().unwrap_or(&dotted).to_string();
-    Some((short, args.as_slice()))
-}
-
-/// A call to the named primitive (matched on its SHORT name) with exactly `n`
-/// args, returning the args.
-fn call_named<'a>(expr: &'a Spanned<Expr>, name: &str, n: usize) -> Option<&'a [Spanned<Expr>]> {
-    let (short, args) = as_call(expr)?;
-    (short == name && args.len() == n).then_some(args)
-}
-
-/// Collect the dotted names of every `FnCall` reachable in `e`.
-fn collect_fncall_names(e: &Expr, out: &mut Vec<String>) {
-    match e {
-        Expr::FnCall(callee, args) => {
-            if let Some(n) = expr_dotted_name(callee) {
-                out.push(n);
-            }
-            for a in args {
-                collect_fncall_names(&a.node, out);
-            }
-        }
-        Expr::BinOp(_, a, b) => {
-            collect_fncall_names(&a.node, out);
-            collect_fncall_names(&b.node, out);
-        }
-        Expr::Neg(a) => collect_fncall_names(&a.node, out),
-        Expr::Attr(b, _) => collect_fncall_names(&b.node, out),
-        Expr::RecordCreate { fields, .. } => {
-            for (_, v) in fields {
-                collect_fncall_names(&v.node, out);
-            }
-        }
-        Expr::Match { subject, arms } => {
-            collect_fncall_names(&subject.node, out);
-            for arm in arms {
-                collect_fncall_names(&arm.body.node, out);
-            }
-        }
-        _ => {}
-    }
 }
 
 /// Deep-clone `e`, replacing any free `Ident`/`Resolved` named in `map` by the
@@ -223,7 +172,7 @@ fn signed_pow2_pow(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
     let recursive = crate::codegen::lean::recursive_pure_fn_names(ctx);
     let mut called: Vec<String> = Vec::new();
     for arm in arms {
-        collect_fncall_names(&arm.body.node, &mut called);
+        shared::collect_fncall_names(&arm.body.node, &mut called);
     }
     let mut pows: Vec<String> = called
         .into_iter()
@@ -261,12 +210,12 @@ fn body_matches_monotone(ctx: &CodegenContext, subj_src: &str, sgn_short: &str) 
         return false;
     };
     let is_sgn = |e: &Spanned<Expr>| -> bool {
-        matches!(as_call(e), Some((s, a)) if s == sgn_short && a.len() == 1)
+        matches!(shared::short_call_name_args(e), Some((s, a)) if s == sgn_short && a.len() == 1)
     };
-    let Some(nn) = call_named(body, "isNonNeg", 1) else {
+    let Some(nn) = shared::call_named(body, "isNonNeg", 1) else {
         return false;
     };
-    let Some(m) = call_named(&nn[0], "minus", 2) else {
+    let Some(m) = shared::call_named(&nn[0], "minus", 2) else {
         return false;
     };
     is_sgn(&m[0]) && is_sgn(&m[1])
@@ -330,14 +279,14 @@ pub(super) fn recognize_frac_order_chain_shape(
     let [Stmt::Expr(body)] = subj_fd.body.stmts() else {
         return None;
     };
-    let nn = call_named(body, "isNonNeg", 1)?;
+    let nn = shared::call_named(body, "isNonNeg", 1)?;
     // `isNonNeg` / `minus` Lean names (qualified), derived from the conclusion
     // heads — name-blind on the rational order primitives.
     let Expr::FnCall(isnonneg_callee, _) = &body.node else {
         return None;
     };
     let isnonneg = aver_name_to_lean(&expr_dotted_name(isnonneg_callee)?);
-    let m = call_named(&nn[0], "minus", 2)?;
+    let m = shared::call_named(&nn[0], "minus", 2)?;
     let Expr::FnCall(minus_callee, _) = &nn[0].node else {
         return None;
     };
@@ -348,7 +297,7 @@ pub(super) fn recognize_frac_order_chain_shape(
     let rat_prefix = minus.rsplit_once('.').map(|(p, _)| p.to_string())?;
     let times = format!("{rat_prefix}.times");
     let samevalue = format!("{rat_prefix}.sameValue");
-    let (sgn_short, hi_args) = as_call(&m[0])?;
+    let (sgn_short, hi_args) = shared::short_call_name_args(&m[0])?;
     if hi_args.len() != 1 {
         return None;
     }
@@ -376,8 +325,7 @@ pub(super) fn recognize_frac_order_chain_shape(
 
     // Premises: flatten the left-nested `Bool.and` tree.
     let when = law.when.as_ref()?;
-    let mut conj: Vec<&Spanned<Expr>> = Vec::new();
-    flatten_and(when, &mut conj);
+    let conj = shared::collect_when_clauses(when);
     // h1 (scale-by-2 bound), h2 (envelope lessThan), hsd2 (M.bottom != 0),
     // placement (<=/>=). Exactly four conjuncts.
     if conj.len() != 4 {
@@ -395,9 +343,9 @@ pub(super) fn recognize_frac_order_chain_shape(
 
     for c in &conj {
         // h1: isNonNeg (minus (times K M) A).
-        if let Some(nn1) = call_named(c, "isNonNeg", 1)
-            && let Some(m1) = call_named(&nn1[0], "minus", 2)
-            && let Some(t1) = call_named(&m1[0], "times", 2)
+        if let Some(nn1) = shared::call_named(c, "isNonNeg", 1)
+            && let Some(m1) = shared::call_named(&nn1[0], "minus", 2)
+            && let Some(t1) = shared::call_named(&m1[0], "times", 2)
             && render(&m1[1]) == a_lean
         {
             let k_str = render(&t1[0]);
@@ -411,8 +359,8 @@ pub(super) fn recognize_frac_order_chain_shape(
             continue;
         }
         // h2: lessThan (M, sgn SMALL).
-        if let Some(lt) = call_named(c, "lessThan", 2)
-            && let Some((s, sa)) = as_call(&lt[1])
+        if let Some(lt) = shared::call_named(c, "lessThan", 2)
+            && let Some((s, sa)) = shared::short_call_name_args(&lt[1])
             && s == sgn_short
             && sa.len() == 1
         {
@@ -470,16 +418,6 @@ pub(super) fn recognize_frac_order_chain_shape(
         mono_thm: mono.theorem_lean,
         cited_deps: vec![(mono.prefix, mono.theorem_base)],
     })
-}
-
-/// Flatten a left-nested `Bool.and(Bool.and(…), w)` `when` tree into conjuncts.
-fn flatten_and<'a>(expr: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) {
-    if let Some(args) = call_named(expr, "and", 2) {
-        flatten_and(&args[0], out);
-        flatten_and(&args[1], out);
-    } else {
-        out.push(expr);
-    }
 }
 
 /// Statement-builder hook: whether the chaining emit will close this law

--- a/src/codegen/lean/law_auto/frac_order_transitivity.rs
+++ b/src/codegen/lean/law_auto/frac_order_transitivity.rs
@@ -55,56 +55,13 @@
 
 use super::AutoProof;
 use super::aver_name_to_lean;
-use super::shared::{expr_dotted_name, find_fn_def_by_call_name};
+use super::shared::{self, expr_dotted_name, find_fn_def_by_call_name};
 use crate::ast::{BinOp, Expr, FnDef, Literal, Spanned, Stmt, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 
-/// `(short_callee_name, args)` when `expr` is a function call. The short name is
-/// the last dotted component, so a qualified `Domain.Rational.lessThan` call
-/// matches the primitive `lessThan` — keyed on the rational ALGEBRA primitive.
-fn as_call(expr: &Spanned<Expr>) -> Option<(String, &[Spanned<Expr>])> {
-    let Expr::FnCall(callee, args) = &expr.node else {
-        return None;
-    };
-    let dotted = expr_dotted_name(callee)?;
-    let short = dotted.rsplit('.').next().unwrap_or(&dotted).to_string();
-    Some((short, args.as_slice()))
-}
-
-/// A call to the named primitive (matched on its SHORT name) with exactly `n`
-/// args, returning the args.
-fn call_named<'a>(expr: &'a Spanned<Expr>, name: &str, n: usize) -> Option<&'a [Spanned<Expr>]> {
-    let (short, args) = as_call(expr)?;
-    (short == name && args.len() == n).then_some(args)
-}
-
-/// A call whose callee's dotted SOURCE name is EXACTLY `qual` (module-qualified,
-/// not short-name) with `n` args. Matching premises against the subject's own
-/// qualified primitives stops a same-short-named primitive from another module
-/// being conflated into the chain.
-fn call_qualified<'a>(
-    expr: &'a Spanned<Expr>,
-    qual: &str,
-    n: usize,
-) -> Option<&'a [Spanned<Expr>]> {
-    let Expr::FnCall(callee, args) = &expr.node else {
-        return None;
-    };
-    (expr_dotted_name(callee).as_deref() == Some(qual) && args.len() == n)
-        .then_some(args.as_slice())
-}
-
-/// The name of a bare identifier / resolved-slot reference.
-fn ident_name(e: &Spanned<Expr>) -> Option<&str> {
-    match &e.node {
-        Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.as_str()),
-        _ => None,
-    }
-}
-
 /// `param.field` record projection.
 fn is_field(e: &Spanned<Expr>, param: &str, field: &str) -> bool {
-    matches!(&e.node, Expr::Attr(base, f) if f == field && ident_name(base) == Some(param))
+    matches!(&e.node, Expr::Attr(base, f) if f == field && shared::ident_name(base) == Some(param))
 }
 
 /// `l * r`.
@@ -214,16 +171,6 @@ fn validate_order_primitives(
         return None;
     }
     Some(())
-}
-
-/// Flatten a left-nested `Bool.and(Bool.and(…), w)` `when` tree into conjuncts.
-fn flatten_and<'a>(expr: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) {
-    if let Some(args) = call_named(expr, "and", 2) {
-        flatten_and(&args[0], out);
-        flatten_and(&args[1], out);
-    } else {
-        out.push(expr);
-    }
 }
 
 /// Deep-clone `e`, replacing any free `Ident`/`Resolved` named in `map` by the
@@ -422,7 +369,7 @@ pub(super) fn recognize_frac_order_transitivity_shape(
     let [Stmt::Expr(body)] = subj_fd.body.stmts() else {
         return None;
     };
-    let lt = call_named(body, "lessThan", 2)?;
+    let lt = shared::call_named(body, "lessThan", 2)?;
     let Expr::FnCall(lt_callee, _) = &body.node else {
         return None;
     };
@@ -466,12 +413,11 @@ pub(super) fn recognize_frac_order_transitivity_shape(
 
     // Collect order edges from the flattened premises.
     let when = law.when.as_ref()?;
-    let mut conj: Vec<&Spanned<Expr>> = Vec::new();
-    flatten_and(when, &mut conj);
+    let conj = shared::collect_when_clauses(when);
     let n_conj = conj.len();
     let mut edges: Vec<Edge> = Vec::new();
     for (i, c) in conj.iter().enumerate() {
-        if let Some(a) = call_qualified(c, &lessthan_src, 2) {
+        if let Some(a) = shared::call_qualified(c, &lessthan_src, 2) {
             edges.push(Edge {
                 left: render(&a[0]),
                 right: render(&a[1]),
@@ -479,8 +425,8 @@ pub(super) fn recognize_frac_order_transitivity_shape(
                 strict: true,
                 conj_idx: i,
             });
-        } else if let Some(nn) = call_qualified(c, &isnonneg_src, 1)
-            && let Some(m) = call_qualified(&nn[0], &minus_src, 2)
+        } else if let Some(nn) = shared::call_qualified(c, &isnonneg_src, 1)
+            && let Some(m) = shared::call_qualified(&nn[0], &minus_src, 2)
         {
             // `isNonNeg (minus Y X)` means `X <= Y`: non-strict edge `X → Y`.
             edges.push(Edge {

--- a/src/codegen/lean/law_auto/induction/keystone.rs
+++ b/src/codegen/lean/law_auto/induction/keystone.rs
@@ -714,6 +714,9 @@ pub(super) fn signed_pow2_shape(fd: &crate::ast::FnDef, int_pow: &str) -> bool {
 }
 
 /// Collect the dotted names of every `FnCall` in `e` (recursively).
+// Private duplicate of shared::collect_fncall_names, kept during the substrate
+// wave because keystone's citation collection is byte-golden-pinned; migrating
+// it is banked for the next wave — extend shared.rs, not this copy.
 fn collect_fncall_names(e: &crate::ast::Expr, out: &mut Vec<String>) {
     use crate::ast::Expr;
     match e {

--- a/src/codegen/lean/law_auto/interval_mono.rs
+++ b/src/codegen/lean/law_auto/interval_mono.rs
@@ -37,7 +37,7 @@
 
 use super::AutoProof;
 use super::aver_name_to_lean;
-use super::shared::{expr_dotted_name, find_fn_def_by_call_name};
+use super::shared::{self, expr_dotted_name, find_fn_def_by_call_name};
 use crate::ast::{Expr, Spanned, Stmt, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 
@@ -59,56 +59,17 @@ pub(super) struct IntervalMono {
     subject: String,
 }
 
-/// `(short_callee_name, args)` when `expr` is a function call, else `None`.
-/// The short name is the last dotted component, so a qualified
-/// `Domain.Rational.minus` call matches the primitive `minus` — the rung
-/// keys on the rational ALGEBRA primitive, never on the law/figure name.
-fn as_call(expr: &Spanned<Expr>) -> Option<(String, &[Spanned<Expr>])> {
-    let Expr::FnCall(callee, args) = &expr.node else {
-        return None;
-    };
-    let dotted = expr_dotted_name(callee)?;
-    let short = dotted.rsplit('.').next().unwrap_or(&dotted).to_string();
-    Some((short, args.as_slice()))
-}
-
-/// A call to the named primitive with exactly `n` args.
-fn call_named<'a>(expr: &'a Spanned<Expr>, name: &str, n: usize) -> Option<&'a [Spanned<Expr>]> {
-    let (short, args) = as_call(expr)?;
-    (short == name && args.len() == n).then_some(args)
-}
-
-/// The bare identifier this expr names (an ident / resolved binding), else
-/// `None`. Used to pin a sub-expression to a given variable.
-fn ident_of(expr: &Spanned<Expr>) -> Option<String> {
-    match &expr.node {
-        Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.clone()),
-        _ => None,
-    }
-}
-
 /// `absFraction (minus (times <X> <Y>) (oneFraction))` ⇒ `(X_ident, Y_ident)`.
 /// The shared magnitude shape of the claim and both endpoint premises.
 fn match_abs_magnitude(expr: &Spanned<Expr>) -> Option<(String, String)> {
-    let abs_args = call_named(expr, "absFraction", 1)?;
-    let minus_args = call_named(&abs_args[0], "minus", 2)?;
-    let times_args = call_named(&minus_args[0], "times", 2)?;
+    let abs_args = shared::call_named(expr, "absFraction", 1)?;
+    let minus_args = shared::call_named(&abs_args[0], "minus", 2)?;
+    let times_args = shared::call_named(&minus_args[0], "times", 2)?;
     // second minus operand must be `oneFraction()` (0-arg call)
-    call_named(&minus_args[1], "oneFraction", 0)?;
-    let x = ident_of(&times_args[0])?;
-    let y = ident_of(&times_args[1])?;
+    shared::call_named(&minus_args[1], "oneFraction", 0)?;
+    let x = shared::ident_name(&times_args[0])?.to_string();
+    let y = shared::ident_name(&times_args[1])?.to_string();
     Some((x, y))
-}
-
-/// Flatten a left-nested `Bool.and(Bool.and(…), w)` `when` tree into its
-/// atomic conjuncts.
-fn flatten_and<'a>(expr: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) {
-    if let Some(args) = call_named(expr, "and", 2) {
-        flatten_and(&args[0], out);
-        flatten_and(&args[1], out);
-    } else {
-        out.push(expr);
-    }
 }
 
 /// Recognize the interval-monotonicity shape. Pure / name-blind on the law
@@ -145,9 +106,9 @@ pub(super) fn recognize_interval_monotonicity_shape(
         .next()
         .unwrap_or(&subject_src)
         .to_string();
-    let d = ident_of(&claim_args[0])?;
-    let v = ident_of(&claim_args[1])?;
-    let e = ident_of(&claim_args[2])?;
+    let d = shared::ident_name(&claim_args[0])?.to_string();
+    let v = shared::ident_name(&claim_args[1])?.to_string();
+    let e = shared::ident_name(&claim_args[2])?.to_string();
 
     // Subject body must be the magnitude bound `lessThan (absFraction
     // (minus (times p0 p1) oneFraction)) p2` over its three params — this
@@ -160,35 +121,34 @@ pub(super) fn recognize_interval_monotonicity_shape(
     let [Stmt::Expr(body)] = subj_fd.body.stmts() else {
         return None;
     };
-    let lt_args = call_named(body, "lessThan", 2)?;
+    let lt_args = shared::call_named(body, "lessThan", 2)?;
     let (mx, my) = match_abs_magnitude(&lt_args[0])?;
     let p0 = &subj_fd.params[0].0;
     let p1 = &subj_fd.params[1].0;
     let p2 = &subj_fd.params[2].0;
-    if &mx != p0 || &my != p1 || ident_of(&lt_args[1]).as_deref() != Some(p2.as_str()) {
+    if &mx != p0 || &my != p1 || shared::ident_name(&lt_args[1]) != Some(p2.as_str()) {
         return None;
     }
 
     // Six `when` conjuncts, matched to the six expected shapes.
     let when = law.when.as_ref()?;
-    let mut conj: Vec<&Spanned<Expr>> = Vec::new();
-    flatten_and(when, &mut conj);
+    let conj = shared::collect_when_clauses(when);
     if conj.len() != 6 {
         return None;
     }
 
     // A `subject(arg0, v, e)` endpoint premise ⇒ arg0 ident.
     let subject_endpoint = |c: &Spanned<Expr>| -> Option<String> {
-        let (short, args) = as_call(c)?;
+        let (short, args) = shared::short_call_name_args(c)?;
         if short != subject_short || args.len() != 3 {
             return None;
         }
-        if ident_of(&args[1]).as_deref() != Some(v.as_str())
-            || ident_of(&args[2]).as_deref() != Some(e.as_str())
+        if shared::ident_name(&args[1]) != Some(v.as_str())
+            || shared::ident_name(&args[2]) != Some(e.as_str())
         {
             return None;
         }
-        ident_of(&args[0])
+        shared::ident_name(&args[0]).map(str::to_string)
     };
 
     // Pass 1: bind lo/hi from the `isNonNeg(minus …)` pins and check the
@@ -199,20 +159,20 @@ pub(super) fn recognize_interval_monotonicity_shape(
     let mut saw_v_nonneg = false;
     let mut saw_guard = false;
     for c in &conj {
-        if let Some(args) = call_named(c, "isNonNeg", 1) {
-            if let Some(margs) = call_named(&args[0], "minus", 2) {
-                let a0 = ident_of(&margs[0]);
-                let a1 = ident_of(&margs[1]);
-                if a0.as_deref() == Some(d.as_str()) {
-                    lo = a1.or(lo); // minus(d, lo) ⇒ lo ≤ d
-                } else if a1.as_deref() == Some(d.as_str()) {
-                    hi = a0.or(hi); // minus(hi, d) ⇒ d ≤ hi
+        if let Some(args) = shared::call_named(c, "isNonNeg", 1) {
+            if let Some(margs) = shared::call_named(&args[0], "minus", 2) {
+                let a0 = shared::ident_name(&margs[0]);
+                let a1 = shared::ident_name(&margs[1]);
+                if a0 == Some(d.as_str()) {
+                    lo = a1.map(str::to_string).or(lo); // minus(d, lo) ⇒ lo ≤ d
+                } else if a1 == Some(d.as_str()) {
+                    hi = a0.map(str::to_string).or(hi); // minus(hi, d) ⇒ d ≤ hi
                 } else {
                     return None;
                 }
                 continue;
             }
-            if ident_of(&args[0]).as_deref() == Some(v.as_str()) {
+            if shared::ident_name(&args[0]) == Some(v.as_str()) {
                 saw_v_nonneg = true;
                 continue;
             }

--- a/src/codegen/lean/law_auto/monotone_reflect.rs
+++ b/src/codegen/lean/law_auto/monotone_reflect.rs
@@ -18,6 +18,10 @@ use super::{AutoProof, aver_name_to_lean};
 use crate::ast::{BinOp, Expr, FnDef, Literal, Spanned, Stmt, VerifyBlock, VerifyKind, VerifyLaw};
 use crate::codegen::CodegenContext;
 
+// Private copy kept off the shared substrate on purpose: this rung predates
+// the shared walkers and its recognition is TailCall-blind by construction
+// (measured inert on the corpus). Migrating it is banked for the next
+// substrate wave; do not extend this copy — extend shared.rs instead.
 fn as_call(expr: &Spanned<Expr>) -> Option<(String, &[Spanned<Expr>])> {
     let Expr::FnCall(callee, args) = &expr.node else {
         return None;

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -166,6 +166,45 @@ pub(super) fn child_exprs(e: &Spanned<Expr>) -> Vec<&Spanned<Expr>> {
     }
 }
 
+/// Collect dotted/source names of call sites using the legacy law-auto call-scan
+/// shape, with `TailCall` treated as a call site after TCO.
+pub(super) fn collect_fncall_names(e: &Expr, out: &mut Vec<String>) {
+    match e {
+        Expr::FnCall(callee, args) => {
+            if let Some(n) = expr_dotted_name(callee) {
+                out.push(n);
+            }
+            for a in args {
+                collect_fncall_names(&a.node, out);
+            }
+        }
+        Expr::TailCall(tc) => {
+            out.push(tc.target.clone());
+            for a in &tc.args {
+                collect_fncall_names(&a.node, out);
+            }
+        }
+        Expr::BinOp(_, a, b) => {
+            collect_fncall_names(&a.node, out);
+            collect_fncall_names(&b.node, out);
+        }
+        Expr::Neg(a) => collect_fncall_names(&a.node, out),
+        Expr::Attr(b, _) => collect_fncall_names(&b.node, out),
+        Expr::RecordCreate { fields, .. } => {
+            for (_, v) in fields {
+                collect_fncall_names(&v.node, out);
+            }
+        }
+        Expr::Match { subject, arms } => {
+            collect_fncall_names(&subject.node, out);
+            for arm in arms {
+                collect_fncall_names(&arm.body.node, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Deepest user-fn call `h(<field>)` (single arg the given binder) anywhere in
 /// `expr`; wrappers around the call are traversed through [`child_exprs`].
 pub(super) fn call_on_binder(

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -80,6 +80,156 @@ pub(super) fn flatten_and(e: &Spanned<Expr>, out: &mut Vec<Spanned<Expr>>) {
     }
 }
 
+pub(super) fn collect_when_clauses(e: &Spanned<Expr>) -> Vec<Spanned<Expr>> {
+    let mut out = Vec::new();
+    flatten_and(e, &mut out);
+    out
+}
+
+/// Callee source-name and args of a call, seeing through the TCO rewrite: a
+/// tail-position self/peer call is an `Expr::TailCall` after the proof pipeline
+/// runs, not an `Expr::FnCall`.
+pub(super) fn call_name_args(e: &Spanned<Expr>) -> Option<(String, &[Spanned<Expr>])> {
+    match &e.node {
+        Expr::FnCall(callee, args) => Some((expr_dotted_name(callee)?, args.as_slice())),
+        Expr::TailCall(tc) => Some((tc.target.clone(), tc.args.as_slice())),
+        _ => None,
+    }
+}
+
+pub(super) fn short_call_name_args(e: &Spanned<Expr>) -> Option<(String, &[Spanned<Expr>])> {
+    let (dotted, args) = call_name_args(e)?;
+    let short = dotted.rsplit('.').next().unwrap_or(&dotted).to_string();
+    Some((short, args))
+}
+
+pub(super) fn call_named<'a>(
+    expr: &'a Spanned<Expr>,
+    name: &str,
+    n: usize,
+) -> Option<&'a [Spanned<Expr>]> {
+    let (short, args) = short_call_name_args(expr)?;
+    (short == name && args.len() == n).then_some(args)
+}
+
+pub(super) fn call_named_with_dotted<'a>(
+    expr: &'a Spanned<Expr>,
+    name: &str,
+    n: usize,
+) -> Option<(String, &'a [Spanned<Expr>])> {
+    let (dotted, args) = call_name_args(expr)?;
+    let short = dotted.rsplit('.').next().unwrap_or(&dotted);
+    (short == name && args.len() == n).then_some((dotted, args))
+}
+
+pub(super) fn call_qualified<'a>(
+    expr: &'a Spanned<Expr>,
+    qual: &str,
+    n: usize,
+) -> Option<&'a [Spanned<Expr>]> {
+    let (dotted, args) = call_name_args(expr)?;
+    (dotted == qual && args.len() == n).then_some(args)
+}
+
+pub(super) fn ident_name(expr: &Spanned<Expr>) -> Option<&str> {
+    match &expr.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.as_str()),
+        _ => None,
+    }
+}
+
+pub(super) fn is_ident(expr: &Spanned<Expr>, name: &str) -> bool {
+    ident_name(expr) == Some(name)
+}
+
+/// Immediate sub-expressions used by law-auto source-AST scans. This mirrors
+/// the pre-existing pure recognizer walkers while making tail-call args visible.
+pub(super) fn child_exprs(e: &Spanned<Expr>) -> Vec<&Spanned<Expr>> {
+    match &e.node {
+        Expr::FnCall(callee, args) => {
+            let mut v = vec![callee.as_ref()];
+            v.extend(args.iter());
+            v
+        }
+        Expr::BinOp(_, l, r) => vec![l.as_ref(), r.as_ref()],
+        Expr::Neg(inner) | Expr::ErrorProp(inner) => vec![inner.as_ref()],
+        Expr::Attr(base, _) => vec![base.as_ref()],
+        Expr::Constructor(_, Some(inner)) => vec![inner.as_ref()],
+        Expr::Match { subject, arms } => {
+            let mut v = vec![subject.as_ref()];
+            v.extend(arms.iter().map(|a| a.body.as_ref()));
+            v
+        }
+        Expr::List(items) | Expr::Tuple(items) => items.iter().collect(),
+        Expr::TailCall(tc) => tc.args.iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Deepest user-fn call `h(<field>)` (single arg the given binder) anywhere in
+/// `expr`; wrappers around the call are traversed through [`child_exprs`].
+pub(super) fn call_on_binder(
+    expr: &Spanned<Expr>,
+    field: &str,
+    ctx: &CodegenContext,
+) -> Option<String> {
+    let mut found: Option<String> = None;
+    fn walk(e: &Spanned<Expr>, field: &str, ctx: &CodegenContext, found: &mut Option<String>) {
+        if let Some((name, args)) = call_name_args(e)
+            && args.len() == 1
+            && is_ident(&args[0], field)
+            && find_fn_def(ctx, &name).is_some()
+        {
+            *found = Some(name);
+        }
+        for child in child_exprs(e) {
+            walk(child, field, ctx, found);
+        }
+    }
+    walk(expr, field, ctx, &mut found);
+    found
+}
+
+/// Whether `expr` contains a call `fn_src(<ident>)` (single arg, the given
+/// binder), seeing through post-TCO `TailCall` nodes.
+pub(super) fn calls_fn_on_ident(expr: &Spanned<Expr>, fn_src: &str, ident: &str) -> bool {
+    if let Some((name, args)) = call_name_args(expr)
+        && args.len() == 1
+        && is_ident(&args[0], ident)
+        && name == fn_src
+    {
+        return true;
+    }
+    child_exprs(expr)
+        .into_iter()
+        .any(|c| calls_fn_on_ident(c, fn_src, ident))
+}
+
+/// Direct callees of `src` that are user fn defs (by source name), treating
+/// `TailCall` as a call site so mutual SCC recognition sees post-TCO bodies.
+pub(super) fn direct_user_calls(src: &str, ctx: &CodegenContext) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let Some(fd) = find_fn_def(ctx, src) else {
+        return out;
+    };
+    fn walk(e: &Spanned<Expr>, ctx: &CodegenContext, out: &mut BTreeSet<String>) {
+        if let Some((name, _)) = call_name_args(e)
+            && let Some(fd) = find_fn_def(ctx, &name)
+        {
+            out.insert(fd.name.clone());
+        }
+        for c in child_exprs(e) {
+            walk(c, ctx, out);
+        }
+    }
+    for stmt in fd.body.stmts() {
+        match stmt {
+            Stmt::Expr(e) | Stmt::Binding(_, _, e) => walk(e, ctx, &mut out),
+        }
+    }
+    out
+}
+
 /// Whether `clause` guarantees `0 < x` for the atom rendered as `x_render`:
 /// `0 < x`, `x > 0`, `1 <= x`, `x >= 1` (any nonneg/≥1 literal bound).
 /// Clauses arrive canonicalized by [`flatten_and`], so `x > 0` / `x >= 1`

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -1,3 +1,13 @@
+//! Shared recognition helpers for the law_auto proof arms.
+//!
+//! These live in the Lean codegen layer (not `analysis::shape`) because they
+//! render through `emit_expr_legacy`/`aver_name_to_lean` and take a
+//! `CodegenContext` — they are recognition-plus-rendering, not pre-codegen
+//! analysis. Contract: every walker here is TailCall-aware (the TCO pass
+//! rewrites peer calls before law_auto runs), so arms built on this module
+//! see post-TCO bodies uniformly; a walker that ignored `Expr::TailCall`
+//! reintroduces the recognition blindness fixed for the container arm.
+
 use std::collections::BTreeSet;
 
 use super::super::expr::aver_name_to_lean;

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -205,6 +205,43 @@ pub(super) fn collect_fncall_names(e: &Expr, out: &mut Vec<String>) {
     }
 }
 
+fn short_call_tree_children(e: &Spanned<Expr>) -> Vec<&Spanned<Expr>> {
+    match &e.node {
+        Expr::FnCall(_, args) => args.iter().collect(),
+        Expr::TailCall(tc) => tc.args.iter().collect(),
+        Expr::Attr(b, _) | Expr::Neg(b) => vec![b.as_ref()],
+        Expr::BinOp(_, l, r) => vec![l.as_ref(), r.as_ref()],
+        Expr::Constructor(_, Some(inner)) => vec![inner.as_ref()],
+        _ => Vec::new(),
+    }
+}
+
+/// Collect short callee names through the legacy triangle-style call tree,
+/// treating post-TCO `TailCall` nodes as call sites.
+pub(super) fn collect_short_callees(expr: &Spanned<Expr>, out: &mut BTreeSet<String>) {
+    if let Some((short, _)) = short_call_name_args(expr) {
+        out.insert(short);
+    }
+    for child in short_call_tree_children(expr) {
+        collect_short_callees(child, out);
+    }
+}
+
+/// Search the legacy triangle-style call tree, invoking `f` at each call site.
+pub(super) fn find_map_short_call_tree<T, F>(expr: &Spanned<Expr>, f: &mut F) -> Option<T>
+where
+    F: FnMut(&str, &[Spanned<Expr>]) -> Option<T>,
+{
+    if let Some((short, args)) = short_call_name_args(expr)
+        && let Some(found) = f(&short, args)
+    {
+        return Some(found);
+    }
+    short_call_tree_children(expr)
+        .into_iter()
+        .find_map(|child| find_map_short_call_tree(child, f))
+}
+
 /// Deepest user-fn call `h(<field>)` (single arg the given binder) anywhere in
 /// `expr`; wrappers around the call are traversed through [`child_exprs`].
 pub(super) fn call_on_binder(

--- a/src/codegen/lean/law_auto/transparent_chain.rs
+++ b/src/codegen/lean/law_auto/transparent_chain.rs
@@ -159,8 +159,7 @@ fn recognize_transparent_chain_shape(
         return None;
     }
 
-    let mut conjuncts = Vec::new();
-    shared::flatten_and(law.when.as_ref()?, &mut conjuncts);
+    let conjuncts = shared::collect_when_clauses(law.when.as_ref()?);
     if conjuncts.is_empty() {
         return None;
     }
@@ -168,11 +167,8 @@ fn recognize_transparent_chain_shape(
     let mut unfolds = Vec::new();
     let mut visited = BTreeSet::new();
     let mut stats = FragmentStats::default();
-    for conjunct in conjuncts {
-        let Expr::FnCall(callee, args) = &conjunct.node else {
-            return None;
-        };
-        let call_name = shared::expr_dotted_name(callee)?;
+    for conjunct in &conjuncts {
+        let (call_name, args) = shared::call_name_args(conjunct)?;
         if !has_citable_pool_law_for_call(vb, &call_name, ctx) {
             return None;
         }
@@ -252,34 +248,28 @@ fn premise_bool(
     owner_scope: Option<&str>,
     state: &mut CollectState<'_>,
 ) -> bool {
+    if let Some(args) = shared::call_qualified(expr, "Bool.and", 2) {
+        return premise_bool(&args[0], ctx, owner_scope, state)
+            && premise_bool(&args[1], ctx, owner_scope, state);
+    }
+    if let Some((name, args)) = shared::call_name_args(expr) {
+        for arg in args {
+            if !premise_term(arg, ctx, owner_scope, state) {
+                return false;
+            }
+        }
+        let Some(resolved) = resolve_fn_for_call(ctx, &name, owner_scope) else {
+            return false;
+        };
+        if resolved.fd.return_type.trim() != "Bool" {
+            return false;
+        }
+        return collect_transparent_premise_fn(ctx, resolved, state).is_some();
+    }
     match &expr.node {
         Expr::Literal(Literal::Bool(_)) => true,
         Expr::BinOp(op, l, r) if comparison_op(*op) => {
             premise_term(l, ctx, owner_scope, state) && premise_term(r, ctx, owner_scope, state)
-        }
-        Expr::FnCall(callee, args)
-            if shared::expr_dotted_name(callee).as_deref() == Some("Bool.and")
-                && args.len() == 2 =>
-        {
-            premise_bool(&args[0], ctx, owner_scope, state)
-                && premise_bool(&args[1], ctx, owner_scope, state)
-        }
-        Expr::FnCall(callee, args) => {
-            let Some(name) = shared::expr_dotted_name(callee) else {
-                return false;
-            };
-            for arg in args {
-                if !premise_term(arg, ctx, owner_scope, state) {
-                    return false;
-                }
-            }
-            let Some(resolved) = resolve_fn_for_call(ctx, &name, owner_scope) else {
-                return false;
-            };
-            if resolved.fd.return_type.trim() != "Bool" {
-                return false;
-            }
-            collect_transparent_premise_fn(ctx, resolved, state).is_some()
         }
         Expr::Match { subject, arms } => {
             if !premise_bool(subject, ctx, owner_scope, state) {
@@ -314,6 +304,20 @@ fn premise_term(
     owner_scope: Option<&str>,
     state: &mut CollectState<'_>,
 ) -> bool {
+    if let Some((name, args)) = shared::call_name_args(expr) {
+        for arg in args {
+            if !premise_term(arg, ctx, owner_scope, state) {
+                return false;
+            }
+        }
+        let Some(resolved) = resolve_fn_for_call(ctx, &name, owner_scope) else {
+            return false;
+        };
+        if resolved.fd.return_type.trim() != "Int" {
+            return false;
+        }
+        return collect_transparent_premise_fn(ctx, resolved, state).is_some();
+    }
     match &expr.node {
         Expr::Literal(Literal::Int(_)) => true,
         Expr::Ident(_) | Expr::Resolved { .. } => true,
@@ -324,23 +328,6 @@ fn premise_term(
         Expr::BinOp(BinOp::Mul, l, r) => {
             (int_literal(l) && premise_term(r, ctx, owner_scope, state))
                 || (int_literal(r) && premise_term(l, ctx, owner_scope, state))
-        }
-        Expr::FnCall(callee, args) => {
-            let Some(name) = shared::expr_dotted_name(callee) else {
-                return false;
-            };
-            for arg in args {
-                if !premise_term(arg, ctx, owner_scope, state) {
-                    return false;
-                }
-            }
-            let Some(resolved) = resolve_fn_for_call(ctx, &name, owner_scope) else {
-                return false;
-            };
-            if resolved.fd.return_type.trim() != "Int" {
-                return false;
-            }
-            collect_transparent_premise_fn(ctx, resolved, state).is_some()
         }
         Expr::Match { subject, arms } => {
             if !premise_bool(subject, ctx, owner_scope, state) {

--- a/src/codegen/lean/law_auto/triangle_sum.rs
+++ b/src/codegen/lean/law_auto/triangle_sum.rs
@@ -40,7 +40,7 @@
 use super::AutoProof;
 use super::aver_name_to_lean;
 use super::shared::{
-    expr_dotted_name, find_fn_def, find_fn_def_by_call_name, law_simp_source_names,
+    self, expr_dotted_name, find_fn_def, find_fn_def_by_call_name, law_simp_source_names,
 };
 use crate::ast::{Expr, Spanned, Stmt, VerifyBlock, VerifyKind, VerifyLaw};
 use crate::codegen::CodegenContext;
@@ -412,42 +412,6 @@ pub(super) struct TriangleSum {
     cited_deps: Vec<(String, String)>,
 }
 
-/// `(short_callee_name, args)` when `expr` is a function call, else `None`.
-fn as_call(expr: &Spanned<Expr>) -> Option<(String, &[Spanned<Expr>])> {
-    let Expr::FnCall(callee, args) = &expr.node else {
-        return None;
-    };
-    let dotted = expr_dotted_name(callee)?;
-    let short = dotted.rsplit('.').next().unwrap_or(&dotted).to_string();
-    Some((short, args.as_slice()))
-}
-
-/// A call to the named primitive (short name) with exactly `n` args.
-fn call_named<'a>(expr: &'a Spanned<Expr>, name: &str, n: usize) -> Option<&'a [Spanned<Expr>]> {
-    let (short, args) = as_call(expr)?;
-    (short == name && args.len() == n).then_some(args)
-}
-
-/// The bare identifier this expr names (an ident / resolved binding), else
-/// `None`.
-fn ident_of(expr: &Spanned<Expr>) -> Option<String> {
-    match &expr.node {
-        Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n.clone()),
-        _ => None,
-    }
-}
-
-/// Flatten a left-nested `Bool.and(Bool.and(…), w)` `when` tree into its
-/// atomic conjuncts.
-fn flatten_and<'a>(expr: &'a Spanned<Expr>, out: &mut Vec<&'a Spanned<Expr>>) {
-    if let Some(args) = call_named(expr, "and", 2) {
-        flatten_and(&args[0], out);
-        flatten_and(&args[1], out);
-    } else {
-        out.push(expr);
-    }
-}
-
 /// `<var>.<field> != 0` ⇒ `(var, field)`.
 fn nonzero_guard(expr: &Spanned<Expr>) -> Option<(String, String)> {
     let Expr::BinOp(crate::ast::BinOp::Neq, l, r) = &expr.node else {
@@ -459,29 +423,7 @@ fn nonzero_guard(expr: &Spanned<Expr>) -> Option<(String, String)> {
     let Expr::Attr(base, field) = &l.node else {
         return None;
     };
-    Some((ident_of(base)?, field.clone()))
-}
-
-/// The transitive set of short callee names reached from a fn body (one fn
-/// level; recurses through the cone via `seen`).
-fn collect_short_callees(expr: &Spanned<Expr>, out: &mut std::collections::BTreeSet<String>) {
-    match &expr.node {
-        Expr::FnCall(callee, args) => {
-            if let Some(d) = expr_dotted_name(callee) {
-                out.insert(d.rsplit('.').next().unwrap_or(&d).to_string());
-            }
-            for a in args {
-                collect_short_callees(a, out);
-            }
-        }
-        Expr::Attr(b, _) | Expr::Neg(b) => collect_short_callees(b, out),
-        Expr::BinOp(_, l, r) => {
-            collect_short_callees(l, out);
-            collect_short_callees(r, out);
-        }
-        Expr::Constructor(_, Some(inner)) => collect_short_callees(inner, out),
-        _ => {}
-    }
+    Some((shared::ident_name(base)?.to_string(), field.clone()))
 }
 
 /// Whether `fn_name`'s def is a rounding-error bound law subject: a `Bool`
@@ -498,17 +440,17 @@ fn bound_law_kind(ctx: &CodegenContext, fn_name: &str) -> Option<(bool, String)>
     let [Stmt::Expr(body)] = fd.body.stmts() else {
         return None;
     };
-    let lt = call_named(body, "lessThan", 2)?;
-    let abs = call_named(&lt[0], "absFraction", 1)?;
+    let lt = shared::call_named(body, "lessThan", 2)?;
+    let abs = shared::call_named(&lt[0], "absFraction", 1)?;
     // RHS must be a pow2Signed ulp.
-    call_named(&lt[1], "pow2Signed", 1)?;
-    let (efn_short, _) = as_call(&abs[0])?;
+    shared::call_named(&lt[1], "pow2Signed", 1)?;
+    let (efn_short, _) = shared::short_call_name_args(&abs[0])?;
     let efd = find_fn_def_by_call_name(ctx, &efn_short)?;
     let [Stmt::Expr(ebody)] = efd.body.stmts() else {
         return None;
     };
     let mut callees = std::collections::BTreeSet::new();
-    collect_short_callees(ebody, &mut callees);
+    shared::collect_short_callees(ebody, &mut callees);
     if callees.contains("awayFrac") {
         Some((true, efn_short))
     } else if callees.contains("truncFrac") {
@@ -569,24 +511,16 @@ fn extract_precision(
     cone: &std::collections::BTreeSet<String>,
 ) -> Option<i64> {
     fn walk(expr: &Spanned<Expr>) -> Option<i64> {
-        if let Expr::FnCall(callee, args) = &expr.node
-            && let Some(d) = expr_dotted_name(callee)
-        {
-            let short = d.rsplit('.').next().unwrap_or(&d);
+        shared::find_map_short_call_tree(expr, &mut |short, args| {
             if matches!(short, "awayFrac" | "truncFrac" | "compFrac")
                 && args.len() == 2
                 && let Expr::Literal(crate::ast::Literal::Int(k)) = &args[1].node
             {
-                return Some(*k);
+                Some(*k)
+            } else {
+                None
             }
-        }
-        match &expr.node {
-            Expr::FnCall(_, args) => args.iter().find_map(walk),
-            Expr::Attr(b, _) | Expr::Neg(b) => walk(b),
-            Expr::BinOp(_, l, r) => walk(l).or_else(|| walk(r)),
-            Expr::Constructor(_, Some(inner)) => walk(inner),
-            _ => None,
-        }
+        })
     }
     for name in cone {
         if let Some(fd) = find_fn_def(ctx, name) {
@@ -629,9 +563,9 @@ pub(super) fn recognize_triangle_sum_shape(
     // error bound). The `when` analysis below confirms the prior-error premise
     // bounds `absFraction (prior d sd)` by `eps`, pinning these roles to the
     // law structure rather than to the names a figure happens to choose.
-    let d = ident_of(&claim_args[0])?;
-    let sd = ident_of(&claim_args[1])?;
-    let eps = ident_of(&claim_args[2])?;
+    let d = shared::ident_name(&claim_args[0])?.to_string();
+    let sd = shared::ident_name(&claim_args[1])?.to_string();
+    let eps = shared::ident_name(&claim_args[2])?.to_string();
     // The three roles must be three DISTINCT givens (so the discharged
     // statement quantifies over exactly the law's givens, name-blind).
     let roles: std::collections::BTreeSet<&str> = [d.as_str(), sd.as_str(), eps.as_str()]
@@ -652,13 +586,12 @@ pub(super) fn recognize_triangle_sum_shape(
     let [Stmt::Expr(sbody)] = subj_fd.body.stmts() else {
         return None;
     };
-    let lt = call_named(sbody, "lessThan", 2)?;
-    call_named(&lt[0], "absFraction", 1)?;
+    let lt = shared::call_named(sbody, "lessThan", 2)?;
+    shared::call_named(&lt[0], "absFraction", 1)?;
 
     // `when`: four `<d|sd>.<top|bottom> != 0` guards + one prior-error bound.
     let when = law.when.as_ref()?;
-    let mut conj: Vec<&Spanned<Expr>> = Vec::new();
-    flatten_and(when, &mut conj);
+    let conj = shared::collect_when_clauses(when);
     if conj.len() != 5 {
         return None;
     }
@@ -674,13 +607,13 @@ pub(super) fn recognize_triangle_sum_shape(
         // The prior call's two arguments must be the `d`/`sd` roles in order
         // and its bound the `eps` role — this is what pins the discovered
         // roles to the law structure (name-blind).
-        if let Some(pa) = call_named(c, "lessThan", 2)
-            && let Some(abs) = call_named(&pa[0], "absFraction", 1)
-            && let Some((pfn, pargs)) = as_call(&abs[0])
+        if let Some(pa) = shared::call_named(c, "lessThan", 2)
+            && let Some(abs) = shared::call_named(&pa[0], "absFraction", 1)
+            && let Some((pfn, pargs)) = shared::short_call_name_args(&abs[0])
             && pargs.len() == 2
-            && ident_of(&pargs[0]).as_deref() == Some(d.as_str())
-            && ident_of(&pargs[1]).as_deref() == Some(sd.as_str())
-            && ident_of(&pa[1]).as_deref() == Some(eps.as_str())
+            && shared::ident_name(&pargs[0]) == Some(d.as_str())
+            && shared::ident_name(&pargs[1]) == Some(sd.as_str())
+            && shared::ident_name(&pa[1]) == Some(eps.as_str())
         {
             prior = Some(pfn);
             continue;

--- a/tests/fixtures/frac_monotone_geone_flip/domain/fprep.av
+++ b/tests/fixtures/frac_monotone_geone_flip/domain/fprep.av
@@ -1,0 +1,31 @@
+module Fprep
+    intent =
+        "Fixture for the frac_monotone ge-one canonicalized when-clause flip."
+    depends [Domain.Rational]
+    exposes [pow2, pow2Signed, pow2SignedAtLeastOne]
+    effects []
+
+fn pow2(n: Int) -> Int
+    ? "Two to the n for n >= 0, clamped to one for nonpositive n."
+    match n <= 0
+        true -> 1
+        false -> 2 * pow2(n - 1)
+
+verify pow2 law positive
+    given k: Int = [0, 1, 4]
+    pow2(k) >= 1 holds
+
+fn pow2Signed(k: Int) -> Fraction
+    ? "The exact rational 2^k for any integer k."
+    match k < 0
+        true -> Domain.Rational.Fraction(top = 1, bottom = pow2(0 - k))
+        false -> Domain.Rational.Fraction(top = pow2(k), bottom = 1)
+
+fn pow2SignedAtLeastOne(k: Int) -> Bool
+    ? "The signed power of two is at least one for nonnegative exponents."
+    Domain.Rational.isNonNeg(Domain.Rational.minus(pow2Signed(k), Domain.Rational.oneFraction()))
+
+verify pow2SignedAtLeastOne law geOneFlip
+    given k: Int = [0, 1, 4]
+    when 0 <= k
+    pow2SignedAtLeastOne(k) holds

--- a/tests/fixtures/frac_monotone_geone_flip/domain/rational.av
+++ b/tests/fixtures/frac_monotone_geone_flip/domain/rational.av
@@ -1,0 +1,29 @@
+module Rational
+    intent =
+        "Minimal exact-rational surface for the frac_monotone ge-one flip fixture."
+    exposes [Fraction, oneFraction, times, minus, sameValue, isNonNeg]
+    effects []
+
+record Fraction
+    top: Int
+    bottom: Int
+
+fn oneFraction() -> Fraction
+    ? "The exact rational one."
+    Fraction(top = 1, bottom = 1)
+
+fn times(a: Fraction, b: Fraction) -> Fraction
+    ? "Non-normalizing rational multiplication."
+    Fraction(top = a.top * b.top, bottom = a.bottom * b.bottom)
+
+fn minus(a: Fraction, b: Fraction) -> Fraction
+    ? "Non-normalizing rational subtraction."
+    Fraction(top = a.top * b.bottom - b.top * a.bottom, bottom = a.bottom * b.bottom)
+
+fn sameValue(a: Fraction, b: Fraction) -> Bool
+    ? "Cross-multiplication equality."
+    a.top * b.bottom == b.top * a.bottom
+
+fn isNonNeg(a: Fraction) -> Bool
+    ? "Sign-robust nonnegative rational order."
+    a.top * a.bottom >= 0

--- a/tests/proof_spec/builds.rs
+++ b/tests/proof_spec/builds.rs
@@ -163,6 +163,76 @@ fn proof_export_builds_map_set_nonempty_when_lake_is_available() {
 }
 
 #[test]
+fn proof_export_builds_frac_monotone_geone_flip_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping frac-monotone ge-one flip proof test: `lake` not available");
+        return;
+    }
+
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let output_dir = temp_output_dir("aver-proof-frac-geone-flip");
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/frac_monotone_geone_flip/domain/fprep.av")
+        .arg("--module-root")
+        .arg("tests/fixtures/frac_monotone_geone_flip")
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&output_dir)
+        .arg("--check")
+        .arg("--check-json")
+        .arg("--sorry-budget")
+        .arg("0")
+        .output()
+        .expect("expected frac-monotone ge-one flip proof to run");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        (
+            summary["universal"].as_bool(),
+            summary["universal_laws"].as_u64(),
+            summary["bounded_laws"].as_u64(),
+        ),
+        (Some(true), Some(2), Some(0)),
+        "recursive positivity plus flipped ge-one should both be universal.\n{}",
+        format_output(&run)
+    );
+
+    let lean = std::fs::read_to_string(output_dir.join("Fprep.lean"))
+        .expect("expected generated Fprep.lean");
+    assert!(
+        lean.contains("-- aver:law-class pow2SignedAtLeastOne_law_geOneFlip universal"),
+        "geOneFlip must be classified universal after canonicalizing `when 0 <= k`.\n{lean}"
+    );
+    assert!(
+        lean.contains("-- when (0 <= k)"),
+        "fixture must preserve the flipped source spelling in emitted comments.\n{lean}"
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+#[test]
 fn proof_dafny_verifies_fibonacci_when_dafny_is_available() {
     // `goldenApprox(n)` divides `Float.fromInt(fib(n + 1))` by
     // `Float.fromInt(fib(n))`. Float `/` lowers via the `FloatDiv`


### PR DESCRIPTION
## What

Seven law_auto arm families (container induction, transparent chain, frac-order transitivity, frac-order chain, interval mono, triangle sum, frac monotone compose) drop their private AST walkers and when-clause collectors for one shared, TailCall-aware, canonicalizing module in law_auto/shared.rs — the layer choice is documented in the module head (the helpers render through the Lean emitter, so they belong to codegen, not pre-codegen analysis). Four private flatten_and copies and the container arm's three private walkers are deleted outright. One sanctioned behavior change rides along: frac_monotone_compose's one-sided Gte match now goes through the #642 canonicalizer, with a flip fixture (both spellings universal). Two private copies outside the seven (monotone_reflect, keystone) stay behind explicit anchor comments with the banked migration reason.

## Why

Every arm born off-substrate re-inherited the same bug class: the TailCall blindness fixed for the container arm in #641 recurred as four canonicalization-bypassing clause collectors in #642's audit. The substrate ends that class systemically — new arms start on shared walkers whose TailCall-awareness is the module contract.

## Review evidence (implementer died before its gate battery; the panel re-measured everything from scratch)

- Behavior preservation measured the hard way: 130 emission runs byte-identical main-vs-branch (all 12 K5 domain modules, 17 fixtures, 108 examples, both binaries deterministic).
- Deletion audit with before/after counts per helper family; the exact CI clippy on both feature sets clean, no dead-code, all new helpers consumed.
- proof_spec: full suite green except one pre-existing load-induced Dafny flake, diagnosed and reproduced as environment-dependent on BOTH main and branch (passes in isolation on both).
- Panel notes recorded: the shared walkers' uniform TailCall-awareness technically widens recognition beyond the seven arms' old private copies — provably inert on the corpus and the intended substrate contract.

## Gates

lib green, proof_spec container_induction 7/7 + floor_window 9/9 + builds/lean_kernel serialized, byte-golden, clippy default and wasm,wasip2, fmt; commit-per-arm granularity for selective revert.