### PR TITLE
Derive floor-divisor positivity from the divisor's shape

### DIFF
--- a/src/codegen/lean/law_auto/floor_arith.rs
+++ b/src/codegen/lean/law_auto/floor_arith.rs
@@ -26,8 +26,8 @@
 use super::AutoProof;
 use super::aver_name_to_lean;
 use super::shared::{
-    clause_gives_nonneg, clause_gives_pos, clause_is_lt, expr_dotted_name, flatten_and, floor_call,
-    is_euclidean_floor_fn, render,
+    PositivityFact, clause_gives_nonneg, clause_is_lt, divisor_positivity, expr_dotted_name,
+    flatten_and, floor_call, is_euclidean_floor_fn, render,
 };
 use crate::ast::{BinOp, Expr, Spanned, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
@@ -52,6 +52,34 @@ fn intro_names(law: &VerifyLaw) -> String {
         .join(" ")
 }
 
+/// Parenthesize an atom render iff it is compound (contains whitespace), so it
+/// stays a single unit when spliced as a POSITIONAL lemma argument
+/// (`lemma (pow2 k) …`, not `lemma pow2 k …`). A no-op on every single-token
+/// atom the pre-L5 corpus emits (bare givens / literals), so the guarded K5 pins
+/// stay byte-identical; only the shape-derived multi-token divisors (`pow2 k`)
+/// gain the wrap they need to parse.
+fn atom_arg(render: &str) -> String {
+    if render.contains(char::is_whitespace) {
+        format!("({render})")
+    } else {
+        render.to_string()
+    }
+}
+
+/// The `(hypothesis-type-atom, proof-term)` for `0 < atom` from its shape fact.
+/// Ascribes `(atom : Int)` only when the atom is purely literal (else the
+/// numerals default to `Nat`); a guarded / pool-fn / mixed-product atom is
+/// already `Int`-anchored and stays bare, byte-identical to the pre-L5 `0 <
+/// {atom} := by omega`.
+fn pos_have(atom: &str, fact: &PositivityFact) -> (String, String) {
+    let ty = if fact.needs_int_ascription() {
+        format!("({atom} : Int)")
+    } else {
+        atom.to_string()
+    };
+    (ty, fact.lean_term())
+}
+
 /// In a two-operand product whose children render to `l_r` / `r_r`, find the one
 /// that equals `target`; return the OTHER child's render and whether `target`
 /// sat on the LEFT. Content-blind: keyed only on structural equality of renders.
@@ -74,6 +102,11 @@ struct CancelShape {
     a: String,
     d: String,
     c: String,
+    /// How `0 < d` / `0 < c` are discharged, derived from each atom's SHAPE
+    /// (`WhenGuard` -> `by omega` when the author's guard supplies it —
+    /// byte-identical to the pre-L5 emission).
+    d_fact: PositivityFact,
+    c_fact: PositivityFact,
     /// The dividend / divisor products as WRITTEN (either operand order).
     dividend: String,
     divisor: String,
@@ -89,7 +122,11 @@ struct CancelShape {
 /// the shared factor may sit on either side of each product independently; `a`
 /// and `d` are pinned by the reduced rhs. A genuine non-match (no shared factor)
 /// declines.
-fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape> {
+fn recognize_cancel(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Option<CancelShape> {
     // rhs = floor(a, d)
     let Expr::FnCall(callee, args) = &law.rhs.node else {
         return None;
@@ -118,30 +155,31 @@ fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape
         return None;
     }
     let c_render = c_from_a;
+    // The divisor atom exprs (for shape-derived positivity): `d` is whichever
+    // side of the divisor product matched the reduced-rhs divisor, `c` the other.
+    let (d_expr, c_expr): (&Spanned<Expr>, &Spanned<Expr>) =
+        if d_left { (d_l, c_d) } else { (c_d, d_l) };
 
     if !is_euclidean_floor_fn(&floor_src, ctx) {
         return None;
     }
 
-    // `when` must guarantee both the divisor and the shared factor positive.
+    // Both the divisor `d` and the shared factor `c` must be provably positive —
+    // from the author's `when` guard OR from each atom's AST shape. A guarded
+    // atom yields `by omega` (byte-identical to the pre-L5 emission).
     let when = law.when.as_ref()?;
     let mut clauses = Vec::new();
     flatten_and(when, &mut clauses);
-    let pos_d = clauses
-        .iter()
-        .any(|cl| clause_gives_pos(cl, &d_render, ctx));
-    let pos_c = clauses
-        .iter()
-        .any(|cl| clause_gives_pos(cl, &c_render, ctx));
-    if !pos_d || !pos_c {
-        return None;
-    }
+    let d_fact = divisor_positivity(d_expr, &clauses, ctx, vb.line)?;
+    let c_fact = divisor_positivity(c_expr, &clauses, ctx, vb.line)?;
 
     Some(CancelShape {
         floor_lean: aver_name_to_lean(&floor_src),
         a: a_render,
         d: d_render,
         c: c_render,
+        d_fact,
+        c_fact,
         dividend: render(prod_a, ctx),
         divisor: render(prod_d, ctx),
         // shared factor is on the left iff `a` (resp. `d`) is on the right.
@@ -151,14 +189,15 @@ fn recognize_cancel(law: &VerifyLaw, ctx: &CodegenContext) -> Option<CancelShape
 }
 
 pub(in crate::codegen::lean) fn recognize_cancel_common_factor(
+    vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,
 ) -> bool {
-    recognize_cancel(law, ctx).is_some()
+    recognize_cancel(vb, law, ctx).is_some()
 }
 
 pub(super) fn emit_cancel_common_factor_law(
-    _vb: &VerifyBlock,
+    vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,
     theorem_base: &str,
@@ -169,14 +208,18 @@ pub(super) fn emit_cancel_common_factor_law(
         a,
         d,
         c,
+        d_fact,
+        c_fact,
         dividend,
         divisor,
         c_left_in_dividend,
         c_left_in_divisor,
-    } = recognize_cancel(law, ctx)?;
+    } = recognize_cancel(vb, law, ctx)?;
     let when = render(law.when.as_ref()?, ctx);
     let lhs = render(&law.lhs, ctx);
     let rhs = render(&law.rhs, ctx);
+    let (d_ty, d_pos) = pos_have(&d, &d_fact);
+    let (c_ty, c_pos) = pos_have(&c, &c_fact);
 
     // `0 < divisor` proof follows the WRITTEN factor order of the divisor.
     let hdc = if c_left_in_divisor {
@@ -184,13 +227,23 @@ pub(super) fn emit_cancel_common_factor_law(
     } else {
         "Int.mul_pos hd hc" // 0 < d * c
     };
+    // The `Int.mul_pos hd hc` term is `Int` (its factor hyps are), so the `hdc`
+    // TYPE must match: ascribe the product when BOTH factors are purely literal
+    // (a degenerate cancel, but the numerals would otherwise default to `Nat`).
+    let divisor_ty = if d_fact.needs_int_ascription() && c_fact.needs_int_ascription() {
+        format!("({divisor} : Int)")
+    } else {
+        divisor.clone()
+    };
+    // Atoms spliced as POSITIONAL lemma args get the compound-only paren wrap.
+    let (aw, dw, cw) = (atom_arg(&a), atom_arg(&d), atom_arg(&c));
     // Commute the shared factor to the RIGHT (core lemma's canonical form).
     let mut normalize = String::new();
     if c_left_in_dividend {
-        normalize.push_str(&format!("\n  rw [Int.mul_comm {c} {a}]"));
+        normalize.push_str(&format!("\n  rw [Int.mul_comm {cw} {aw}]"));
     }
     if c_left_in_divisor {
-        normalize.push_str(&format!("\n  rw [Int.mul_comm {c} {d}]"));
+        normalize.push_str(&format!("\n  rw [Int.mul_comm {cw} {dw}]"));
     }
 
     let text = format!(
@@ -198,11 +251,11 @@ pub(super) fn emit_cancel_common_factor_law(
 theorem {base} : ∀ {quant}, {when} = true -> {lhs} = {rhs} := by
   intro {intro} h_when
   simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le, gt_iff_lt] at h_when
-  have hd : 0 < {d} := by omega
-  have hc : 0 < {c} := by omega
-  have hdc : 0 < {divisor} := {hdc}
-  rw [{base}__floordiv_eq ({dividend}) ({divisor}) hdc, {base}__floordiv_eq {a} {d} hd]{normalize}
-  exact Int.mul_ediv_mul_of_pos_left {a} {d} hc"#,
+  have hd : 0 < {d_ty} := {d_pos}
+  have hc : 0 < {c_ty} := {c_pos}
+  have hdc : 0 < {divisor_ty} := {hdc}
+  rw [{base}__floordiv_eq ({dividend}) ({divisor}) hdc, {base}__floordiv_eq {aw} {dw} hd]{normalize}
+  exact Int.mul_ediv_mul_of_pos_left {aw} {dw} hc"#,
         peel = floordiv_eq_lemma(theorem_base, &floor),
         base = theorem_base,
         quant = quant_params,
@@ -225,6 +278,10 @@ struct AbsorbShape {
     d: String,
     q: String,
     r: String,
+    /// How `0 < d` is discharged, derived from the divisor's SHAPE (`WhenGuard`
+    /// -> `by omega` when the author's guard supplies it — byte-identical to the
+    /// pre-L5 emission).
+    d_fact: PositivityFact,
     /// The dividend sum as WRITTEN.
     dividend: String,
     /// `true` when the divisor sits on the LEFT of the product (`d * q`); the
@@ -266,7 +323,11 @@ fn split_sum<'a>(
 /// the quotient `q` and the remainder `r` structurally. ORIENTATION-TOLERANT:
 /// the divisor may sit on either side of the product (`d * q` or `q * d`) and the
 /// remainder on either side of the sum. A genuine non-match declines.
-fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape> {
+fn recognize_absorb(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Option<AbsorbShape> {
     // lhs = floor(<sum>, d)
     let floor_src = {
         let Expr::FnCall(callee, _) = &law.lhs.node else {
@@ -288,20 +349,21 @@ fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape
         return None;
     }
 
-    // `when` must guarantee 0 < d, 0 <= r, and r < d.
+    // The remainder bounds `0 <= r` / `r < d` are genuinely author-supplied (no
+    // shape derives them), but the divisor positivity `0 < d` comes from the
+    // author's guard OR the divisor's AST shape — a guarded divisor yields
+    // `by omega`, byte-identical to the pre-L5 emission.
     let when = law.when.as_ref()?;
     let mut clauses = Vec::new();
     flatten_and(when, &mut clauses);
-    let pos_d = clauses
-        .iter()
-        .any(|cl| clause_gives_pos(cl, &d_render, ctx));
+    let d_fact = divisor_positivity(d_l, &clauses, ctx, vb.line)?;
     let nonneg_r = clauses
         .iter()
         .any(|cl| clause_gives_nonneg(cl, &r_render, ctx));
     let r_lt_d = clauses
         .iter()
         .any(|cl| clause_is_lt(cl, &r_render, &d_render, ctx));
-    if !pos_d || !nonneg_r || !r_lt_d {
+    if !nonneg_r || !r_lt_d {
         return None;
     }
 
@@ -310,6 +372,7 @@ fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape
         d: d_render,
         q: q_render,
         r: r_render,
+        d_fact,
         dividend: render(dividend, ctx),
         d_left_in_product,
         r_first,
@@ -317,14 +380,15 @@ fn recognize_absorb(law: &VerifyLaw, ctx: &CodegenContext) -> Option<AbsorbShape
 }
 
 pub(in crate::codegen::lean) fn recognize_absorb_remainder(
+    vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,
 ) -> bool {
-    recognize_absorb(law, ctx).is_some()
+    recognize_absorb(vb, law, ctx).is_some()
 }
 
 pub(super) fn emit_absorb_remainder_law(
-    _vb: &VerifyBlock,
+    vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,
     theorem_base: &str,
@@ -335,19 +399,23 @@ pub(super) fn emit_absorb_remainder_law(
         d,
         q,
         r,
+        d_fact,
         dividend,
         d_left_in_product,
         r_first,
-    } = recognize_absorb(law, ctx)?;
+    } = recognize_absorb(vb, law, ctx)?;
     let when = render(law.when.as_ref()?, ctx);
     let lhs = render(&law.lhs, ctx);
     let rhs = render(&law.rhs, ctx);
+    let (d_ty, d_pos) = pos_have(&d, &d_fact);
 
+    // Atoms spliced as POSITIONAL lemma args get the compound-only paren wrap.
+    let (dw, qw, ra) = (atom_arg(&d), atom_arg(&q), atom_arg(&r));
     // Normalize to the core lemma's canonical dividend `r + d * q`.
     let mut normalize = String::new();
     if !d_left_in_product {
         // commute `q * d` -> `d * q`
-        normalize.push_str(&format!("\n  rw [Int.mul_comm {q} {d}]"));
+        normalize.push_str(&format!("\n  rw [Int.mul_comm {qw} {dw}]"));
     }
     if !r_first {
         // reorder `d * q + r` -> `r + d * q` (omega abstracts the product atom)
@@ -361,11 +429,11 @@ pub(super) fn emit_absorb_remainder_law(
 theorem {base} : ∀ {quant}, {when} = true -> {lhs} = {rhs} := by
   intro {intro} h_when
   simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le, gt_iff_lt] at h_when
-  have hd : 0 < {d} := by omega
+  have hd : 0 < {d_ty} := {d_pos}
   have h0 : 0 <= {r} := by omega
   have hr : {r} < {d} := by omega
-  rw [{base}__floordiv_eq ({dividend}) {d} hd]{normalize}
-  rw [Int.add_mul_ediv_left {r} {q} (by omega : {d} ≠ 0)]
+  rw [{base}__floordiv_eq ({dividend}) {dw} hd]{normalize}
+  rw [Int.add_mul_ediv_left {ra} {qw} (by omega : {d_ty} ≠ 0)]
   rw [Int.ediv_eq_zero_of_lt h0 hr]
   omega"#,
         peel = floordiv_eq_lemma(theorem_base, &floor),

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -420,7 +420,20 @@ impl PositivityFact {
             PositivityFact::Decide => "by decide".to_string(),
             PositivityFact::WhenGuard => "by omega".to_string(),
             PositivityFact::CitedLaw { citation } => {
-                format!("by have hpos := {citation}; omega")
+                // `citation : (f arg >= B) = true` is a `Prop` equality
+                // (`(B <= f arg) = True` after `ge_iff_le`) that `omega` will not
+                // read. Normalize it to the bare `B <= f arg` fact first — the
+                // exact `[ge_iff_le, eq_iff_iff, iff_true]` chain
+                // `emit_recursive_positive_law` uses to discharge the same
+                // statement — THEN `omega` derives `0 < f arg`. Without the
+                // normalization `omega` silently ignores the hypothesis and only
+                // closes when other premises already imply positivity (the absorb
+                // arms), so the cancel arm — whose sole positivity source is this
+                // citation — would fail.
+                format!(
+                    "by have hpos := {citation}; \
+                     simp only [ge_iff_le, eq_iff_iff, iff_true] at hpos; omega"
+                )
             }
             PositivityFact::MulPos(l, r) => {
                 format!("Int.mul_pos ({}) ({})", l.lean_term(), r.lean_term())
@@ -523,12 +536,32 @@ fn citable_pool_blocks(ctx: &CodegenContext, before_line: usize) -> Vec<&VerifyB
     out
 }
 
-/// Whether `law` claims `f(binder) >= B` / `B <= f(binder)` with `B >= 1` (i.e.
-/// `0 < f`), for the fn whose short name is `f_short`. The `holds` law's rhs is
-/// `true`. Shape-keyed on the comparison form; the fn is discovered from the
-/// caller's atom, never hardcoded. `B >= 1` (not `>= 0`) is load-bearing: a
-/// `f >= 0` law gives only `0 <= f`, not the strict `0 < f` the divisor needs.
+/// Whether `law`'s EMITTED theorem is EXACTLY `∀ (v : T), (f v >= B) = true`
+/// (or the `B <= f v` twin) with `B >= 1` — the plain single-binder positivity
+/// form the citation term `f_law_name (arg)` consumes. STATEMENT-level, not
+/// merely recognizer-level: the citation applies exactly ONE argument to the
+/// theorem and hands the result straight to `omega`, so the theorem must carry
+/// no extra premise or binder. The fn is discovered from the caller's atom,
+/// never hardcoded. Fail-closed on anything else. Rejects, in particular:
+///   * a `when`-guarded law — its theorem gains a `<guard> = true ->` premise,
+///     so `f_law_name (arg)` is an implication `omega` cannot read;
+///   * a law with more than one given — `f_law_name (arg)` is then a partial
+///     application, still a `∀`, not the bare comparison;
+///   * a law whose fn argument is not the plain bound binder (`f(v + 1) >= B`) —
+///     citing at the caller's atom would yield a fact about the WRONG term.
+///
+/// `B >= 1` (not `>= 0`) is load-bearing: a `f >= 0` law gives only `0 <= f`,
+/// not the strict `0 < f` the divisor needs.
 fn law_claims_positive_over(law: &VerifyLaw, f_short: &str) -> bool {
+    // A `when` guard becomes a `... = true ->` premise on the emitted theorem.
+    if law.when.is_some() {
+        return false;
+    }
+    // The citation applies exactly ONE argument, so the theorem must bind
+    // exactly one `∀` variable for it to fully instantiate.
+    let [binder] = law.givens.as_slice() else {
+        return false;
+    };
     if !matches!(law.rhs.node, Expr::Literal(Literal::Bool(true))) {
         return false;
     }
@@ -536,15 +569,19 @@ fn law_claims_positive_over(law: &VerifyLaw, f_short: &str) -> bool {
         Expr::Literal(Literal::Int(n)) => Some(*n),
         _ => None,
     };
-    let is_f_call = |e: &Spanned<Expr>| -> bool {
+    // `f(v)` where `v` is EXACTLY the single bound binder, so substituting the
+    // caller's atom argument yields `(f arg >= B) = true` about THAT atom.
+    let is_f_of_binder = |e: &Spanned<Expr>| -> bool {
         matches!(call_name_args(e), Some((n, a))
-            if n.rsplit('.').next().unwrap_or(&n) == f_short && a.len() == 1)
+            if n.rsplit('.').next().unwrap_or(&n) == f_short
+                && a.len() == 1
+                && ident_name(&a[0]) == Some(binder.name.as_str()))
     };
     match &law.lhs.node {
         // f(binder) >= B
-        Expr::BinOp(BinOp::Gte, l, r) => is_f_call(l) && int_lit(r).is_some_and(|b| b >= 1),
+        Expr::BinOp(BinOp::Gte, l, r) => is_f_of_binder(l) && int_lit(r).is_some_and(|b| b >= 1),
         // B <= f(binder)
-        Expr::BinOp(BinOp::Lte, l, r) => int_lit(l).is_some_and(|b| b >= 1) && is_f_call(r),
+        Expr::BinOp(BinOp::Lte, l, r) => int_lit(l).is_some_and(|b| b >= 1) && is_f_of_binder(r),
         _ => false,
     }
 }

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -11,7 +11,10 @@
 use std::collections::BTreeSet;
 
 use super::super::expr::aver_name_to_lean;
-use crate::ast::{BinOp, Expr, FnBody, FnDef, Literal, Spanned, Stmt, VerifyBlock, VerifyLaw};
+use crate::ast::{
+    BinOp, Expr, FnBody, FnDef, Literal, Spanned, Stmt, TopLevel, VerifyBlock, VerifyKind,
+    VerifyLaw,
+};
 use crate::ast_rewrite::rewrite_idents_scoped;
 use crate::codegen::CodegenContext;
 
@@ -362,6 +365,186 @@ pub(super) fn clause_gives_nonneg(
     match op {
         // c <= x  (c >= 0)          (also matches canonicalized `x >= c`)
         BinOp::Lte => int_lit(l).is_some_and(|c| c >= 0) && render(r, ctx) == x_render,
+        _ => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Divisor-shape positivity (`0 < d`) discharge.
+//
+// The floor-family arms need `0 < d` for every divisor / factor atom. Rather
+// than force the author to spell a `when 0 < d` guard, derive the fact from the
+// atom's AST SHAPE: a positive `Int` literal (`decide`), a product of positives
+// (`Int.mul_pos` over recursively-derived factors), or a fn call `f(a)` with a
+// proven pool positivity law `f(_) >= 1` (CITE it — laws-as-lemmas, keyed on the
+// claim FORM not the fn's name). The author's guard stays the fallback and is
+// checked FIRST, so every pre-L5 guarded law emits byte-identically (`by omega`).
+// An atom no route covers yields `None`, and the arm declines exactly as before
+// (fail-closed).
+// ---------------------------------------------------------------------------
+
+/// How `0 < <atom>` is discharged for a divisor / factor atom, keyed on the
+/// atom's AST shape.
+pub(super) enum PositivityFact {
+    /// A positive `Int` literal: `by decide`.
+    Decide,
+    /// A product `x * y`: `Int.mul_pos` over the two factors' facts.
+    MulPos(Box<PositivityFact>, Box<PositivityFact>),
+    /// A fn call `f(a)` with a proven pool positivity law: cite it at `a`, then
+    /// `omega`. `citation` is the applied theorem term `<fn>_law_<name> (arg)`.
+    CitedLaw { citation: String },
+    /// The author's `when` guard already gives `0 < atom`: read it off `h_when`
+    /// with `omega` (byte-identical to the pre-L5 emission).
+    WhenGuard,
+}
+
+impl PositivityFact {
+    /// Whether the atom is built PURELY from literals (so `0 < atom` would
+    /// default its numerals to `Nat`), meaning the `have` needs an explicit
+    /// `(atom : Int)` ascription. A fact carrying any fn call / bound variable
+    /// (`CitedLaw`, `WhenGuard`, or a `MulPos` containing one) is already
+    /// `Int`-anchored, so it stays un-ascribed and byte-identical to pre-L5.
+    pub(super) fn needs_int_ascription(&self) -> bool {
+        match self {
+            PositivityFact::Decide => true,
+            PositivityFact::MulPos(l, r) => l.needs_int_ascription() && r.needs_int_ascription(),
+            PositivityFact::CitedLaw { .. } | PositivityFact::WhenGuard => false,
+        }
+    }
+
+    /// The Lean proof TERM of type `0 < <atom>`. Valid both as the RHS of a
+    /// `have h : 0 < atom := <term>` and as a bare argument to `Int.mul_pos`
+    /// (whose expected factor types fix any inner `by` goal).
+    pub(super) fn lean_term(&self) -> String {
+        match self {
+            PositivityFact::Decide => "by decide".to_string(),
+            PositivityFact::WhenGuard => "by omega".to_string(),
+            PositivityFact::CitedLaw { citation } => {
+                format!("by have hpos := {citation}; omega")
+            }
+            PositivityFact::MulPos(l, r) => {
+                format!("Int.mul_pos ({}) ({})", l.lean_term(), r.lean_term())
+            }
+        }
+    }
+}
+
+/// Derive `0 < atom` from the atom's AST shape, or `None` when no route covers
+/// it (the arm then declines, fail-closed). `clauses` are the law's
+/// canonicalized `when` conjuncts; `before_line` is the citing law's source
+/// line so a cited pool law is only accepted when it is emitted EARLIER (Lean
+/// forbids forward references).
+pub(super) fn divisor_positivity(
+    atom: &Spanned<Expr>,
+    clauses: &[Spanned<Expr>],
+    ctx: &CodegenContext,
+    before_line: usize,
+) -> Option<PositivityFact> {
+    // 1. Author guard FIRST — every pre-L5 guarded law keeps its exact emission.
+    let atom_render = render(atom, ctx);
+    if clauses
+        .iter()
+        .any(|cl| clause_gives_pos(cl, &atom_render, ctx))
+    {
+        return Some(PositivityFact::WhenGuard);
+    }
+    // 2. Positive Int literal.
+    if let Expr::Literal(Literal::Int(n)) = &atom.node {
+        return (*n > 0).then_some(PositivityFact::Decide);
+    }
+    // 3. Product of positives.
+    if let Expr::BinOp(BinOp::Mul, x, y) = &atom.node {
+        let fx = divisor_positivity(x, clauses, ctx, before_line)?;
+        let fy = divisor_positivity(y, clauses, ctx, before_line)?;
+        return Some(PositivityFact::MulPos(Box::new(fx), Box::new(fy)));
+    }
+    // 4. Fn call with a proven pool positivity law.
+    cited_positivity_law(atom, ctx, before_line)
+        .map(|citation| PositivityFact::CitedLaw { citation })
+}
+
+/// Find a pool positivity law about the SAME fn the atom calls, emitted earlier
+/// than `before_line` and proven universal; return the applied citation term
+/// `<fn>_law_<name> (arg)`. Shape-keyed on the claim form `f(binder) >= B`
+/// (`B >= 1`), never on the fn's name — the fn is discovered from the atom.
+fn cited_positivity_law(
+    atom: &Spanned<Expr>,
+    ctx: &CodegenContext,
+    before_line: usize,
+) -> Option<String> {
+    let (f_src, args) = call_name_args(atom)?;
+    if args.len() != 1 {
+        // The recursive-positivity pool law is unary (`f : Int -> Int`).
+        return None;
+    }
+    let f_short = f_src.rsplit('.').next().unwrap_or(&f_src);
+    for vb in citable_pool_blocks(ctx, before_line) {
+        let VerifyKind::Law(law) = &vb.kind else {
+            continue;
+        };
+        if vb.fn_name.rsplit('.').next().unwrap_or(&vb.fn_name) != f_short {
+            continue;
+        }
+        if !law_claims_positive_over(law, f_short) {
+            continue;
+        }
+        // Universality gate: the recursive-positivity arm closes this as the
+        // universal `∀ binder, (f binder >= B) = true`, so a citation at any
+        // argument typechecks and `omega` derives `0 < f arg` from it.
+        if !super::recursive_mono::recognize_recursive_positive(vb, law, ctx) {
+            continue;
+        }
+        let base = format!(
+            "{}_law_{}",
+            aver_name_to_lean(&vb.fn_name),
+            aver_name_to_lean(&law.name)
+        );
+        return Some(format!("{base} ({})", render(&args[0], ctx)));
+    }
+    None
+}
+
+/// Sibling verify-law blocks a law at `before_line` may cite: dependency-module
+/// laws (always emitted before the entry module) and EARLIER entry-module laws
+/// (source line strictly before the citing law). Ordering is enforced because
+/// Lean forbids forward references to the cited theorem.
+fn citable_pool_blocks(ctx: &CodegenContext, before_line: usize) -> Vec<&VerifyBlock> {
+    let mut out: Vec<&VerifyBlock> = Vec::new();
+    for module in &ctx.modules {
+        out.extend(module.verify_laws.iter());
+    }
+    for item in &ctx.items {
+        if let TopLevel::Verify(b) = item
+            && b.line < before_line
+        {
+            out.push(b);
+        }
+    }
+    out
+}
+
+/// Whether `law` claims `f(binder) >= B` / `B <= f(binder)` with `B >= 1` (i.e.
+/// `0 < f`), for the fn whose short name is `f_short`. The `holds` law's rhs is
+/// `true`. Shape-keyed on the comparison form; the fn is discovered from the
+/// caller's atom, never hardcoded. `B >= 1` (not `>= 0`) is load-bearing: a
+/// `f >= 0` law gives only `0 <= f`, not the strict `0 < f` the divisor needs.
+fn law_claims_positive_over(law: &VerifyLaw, f_short: &str) -> bool {
+    if !matches!(law.rhs.node, Expr::Literal(Literal::Bool(true))) {
+        return false;
+    }
+    let int_lit = |e: &Spanned<Expr>| match &e.node {
+        Expr::Literal(Literal::Int(n)) => Some(*n),
+        _ => None,
+    };
+    let is_f_call = |e: &Spanned<Expr>| -> bool {
+        matches!(call_name_args(e), Some((n, a))
+            if n.rsplit('.').next().unwrap_or(&n) == f_short && a.len() == 1)
+    };
+    match &law.lhs.node {
+        // f(binder) >= B
+        Expr::BinOp(BinOp::Gte, l, r) => is_f_call(l) && int_lit(r).is_some_and(|b| b >= 1),
+        // B <= f(binder)
+        Expr::BinOp(BinOp::Lte, l, r) => int_lit(l).is_some_and(|b| b >= 1) && is_f_call(r),
         _ => false,
     }
 }

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -698,8 +698,8 @@ fn emit_verify_law_block(
             // absorption (`floor (d * q + r) d = q`), proven universally in pure
             // core. Each emit replaces the theorem with the universal form, so
             // dropping the sampled domain keeps statement and proof aligned.
-            || super::law_auto::recognize_cancel_common_factor(&law_for_auto_proof, ctx)
-            || super::law_auto::recognize_absorb_remainder(&law_for_auto_proof, ctx)
+            || super::law_auto::recognize_cancel_common_factor(vb, &law_for_auto_proof, ctx)
+            || super::law_auto::recognize_absorb_remainder(vb, &law_for_auto_proof, ctx)
             // Rational-order chaining law (the reciprocal-magnitude composition,
             // Lemma 8.2.4): the conclusion is the Fraction order fact `isNonNeg
             // (minus (pow2Signed BIG) A)`, proven universally by chaining the

--- a/tests/fixtures/divisor_shape_positivity.av
+++ b/tests/fixtures/divisor_shape_positivity.av
@@ -61,3 +61,15 @@ verify floorDiv law absorbProduct
     when 0 <= r
     when r < 8 * pow2(k)
     floorDiv(8 * pow2(k) * q + r, 8 * pow2(k)) => q
+
+// CANCEL arm with a POOL-FN shared factor, NO positivity guard. The shared
+// factor `pow2(k)` cancels; its `0 < pow2(k)` is derived ONLY by CITING the
+// pool law (the `when 0 < k` guard bounds the exponent, not the divisor, so
+// omega has no other route to positivity here). This is the arm that actually
+// exercises the citation: unlike the absorb laws, no remainder bound implies
+// `0 < pow2(k)` for free, so a broken citation surfaces as a lake failure.
+verify floorDiv law cancelPow2
+    given a: Int = [8, 17, 0 - 5]
+    given k: Int = [1, 2, 3]
+    when 0 < k
+    floorDiv(a * pow2(k), 8 * pow2(k)) => floorDiv(a, 8)

--- a/tests/fixtures/divisor_shape_positivity.av
+++ b/tests/fixtures/divisor_shape_positivity.av
@@ -1,0 +1,63 @@
+module DivisorShapePositivity
+    intent =
+        "Divisor-shape positivity: the Euclidean-floor arithmetic rungs derive"
+        "0 < d from the DIVISOR'S AST SHAPE instead of a ritual `when 0 < d`"
+        "guard. A positive Int literal closes by `decide`; a product of positives"
+        "by `Int.mul_pos` over each factor; a fn call `f(a)` with a proven pool"
+        "positivity law `f(_) >= 1` by CITING it (laws-as-lemmas, keyed on the"
+        "claim FORM not the name). None of the three floor laws below spells the"
+        "positivity guard, yet all close universal; the pool law is stated FIRST"
+        "so its theorem is emitted before the citations."
+    exposes [pow2, floorDiv]
+    effects []
+
+// The pool positivity law. `pow2(k) >= 1` is proven universally by the recursive
+// positivity rung; the floor laws below CITE it for their pow2-shaped divisors.
+fn pow2(n: Int) -> Int
+    match n <= 0
+        true -> 1
+        false -> 2 * pow2(n - 1)
+
+verify pow2
+    pow2(0) => 1
+    pow2(3) => 8
+
+verify pow2 law positive
+    given k: Int = [0, 1, 3]
+    pow2(k) >= 1 holds
+
+// The Euclidean floor-division fn (recognized by SHAPE, never by name).
+fn floorDiv(a: Int, d: Int) -> Int
+    ? "Euclidean floor division a / d, guarded to 0 at d = 0."
+    Result.withDefault(Int.div(a, d), 0)
+
+verify floorDiv
+    floorDiv(52, 8) => 6
+
+// LITERAL divisor, NO positivity guard: `0 < 8` derived by `decide`.
+verify floorDiv law absorbLiteral
+    given q: Int = [4, 6, 0]
+    given r: Int = [0, 1, 7]
+    when 0 <= r
+    when r < 8
+    floorDiv(8 * q + r, 8) => q
+
+// POOL-FN divisor, NO positivity guard: `0 < pow2(k)` cited from `pow2 law
+// positive`. Deleting that pool law drops this law back to bounded.
+verify floorDiv law absorbPow2
+    given k: Int = [1, 2, 3]
+    given q: Int = [4, 6, 0]
+    given r: Int = [0, 1, 2]
+    when 0 <= r
+    when r < pow2(k)
+    floorDiv(pow2(k) * q + r, pow2(k)) => q
+
+// PRODUCT divisor, NO positivity guard: `0 < 8 * pow2(k)` derived by
+// `Int.mul_pos` over the literal factor (`decide`) and the pool-fn factor (cite).
+verify floorDiv law absorbProduct
+    given k: Int = [1, 2, 3]
+    given q: Int = [4, 6, 0]
+    given r: Int = [0, 1, 2]
+    when 0 <= r
+    when r < 8 * pow2(k)
+    floorDiv(8 * pow2(k) * q + r, 8 * pow2(k)) => q

--- a/tests/fixtures/divisor_shape_positivity_witness.av
+++ b/tests/fixtures/divisor_shape_positivity_witness.av
@@ -1,0 +1,50 @@
+module DivisorShapePositivityWitness
+    intent =
+        "Cross-domain, NAME-blind witness for divisor-shape positivity. A"
+        "DIFFERENTLY-named recursive positive fn `blk` and a differently-named"
+        "Euclidean floor fn `quot` (over `top`/`bot`) carry the SAME two claim"
+        "shapes as the primary fixture. If the positivity derivation keys on the"
+        "claim FORM and not on the `pow2` / `floorDiv` names, both floor laws"
+        "close universal here too: a literal divisor by `decide` and a `blk(k)`"
+        "divisor by CITING the discovered `blk` positivity pool law."
+    exposes [blk, quot]
+    effects []
+
+// A foreign recursive positive fn; its pool law is the positivity `blk(n) >= 1`.
+fn blk(n: Int) -> Int
+    match n <= 0
+        true -> 1
+        false -> 2 * blk(n - 1)
+
+verify blk
+    blk(0) => 1
+    blk(2) => 4
+
+verify blk law atLeastOne
+    given n: Int = [0, 1, 3]
+    blk(n) >= 1 holds
+
+// A foreign Euclidean floor-division fn (recognized by SHAPE, not by name).
+fn quot(top: Int, bot: Int) -> Int
+    ? "Euclidean floor division top / bot, guarded to 0 at bot = 0."
+    Result.withDefault(Int.div(top, bot), 0)
+
+verify quot
+    quot(50, 9) => 5
+
+// Literal divisor, no guard: `0 < 5` by `decide`.
+verify quot law soakLiteral
+    given whole: Int = [4, 6, 0]
+    given rest: Int = [0, 1, 4]
+    when 0 <= rest
+    when rest < 5
+    quot(5 * whole + rest, 5) => whole
+
+// Foreign pool-fn divisor, no guard: `0 < blk(k)` cited from `blk law atLeastOne`.
+verify quot law soakBlock
+    given k: Int = [1, 2, 3]
+    given whole: Int = [4, 6, 0]
+    given rest: Int = [0, 1, 2]
+    when 0 <= rest
+    when rest < blk(k)
+    quot(blk(k) * whole + rest, blk(k)) => whole

--- a/tests/proof_spec/floor_window.rs
+++ b/tests/proof_spec/floor_window.rs
@@ -453,9 +453,11 @@ fn proof_bigint_floor_div_graduation_dafny() {
 /// Divisor-shape positivity (`tests/fixtures/divisor_shape_positivity.av`): the
 /// Euclidean-floor arithmetic rungs derive `0 < d` from the DIVISOR'S AST SHAPE
 /// instead of a ritual `when 0 < d` guard. Export-structure pin (no toolchain):
-/// three floor laws with NO positivity guard close `universal`, each via its own
+/// four floor laws with NO positivity guard close `universal`, each via its own
 /// derivation route — a positive literal by `decide`, a pool-fn call by CITING
-/// the proven `pow2 law positive`, and a product by `Int.mul_pos` over the two.
+/// the proven `pow2 law positive`, a product by `Int.mul_pos` over the two, and
+/// a CANCEL law whose sole positivity source is that same citation (no remainder
+/// bound implies it for free, unlike the absorb arms).
 #[test]
 fn proof_export_divisor_shape_positivity_universal() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -479,26 +481,44 @@ fn proof_export_divisor_shape_positivity_universal() {
         "floorDiv_law_absorbLiteral",
         "floorDiv_law_absorbPow2",
         "floorDiv_law_absorbProduct",
+        "floorDiv_law_cancelPow2",
     ] {
         assert!(
             lean.contains(&format!("-- aver:law-class {base} universal")),
             "{base} must close universal via shape-derived positivity; got:\n{lean}"
         );
     }
-    // The three derivation routes each leave their fingerprint in the emitted
-    // `0 < d` proof: `decide` for the literal, a citation of the pool positivity
-    // theorem for the pow2 fn, and `Int.mul_pos` over both for the product.
+    // The derivation routes each leave their fingerprint in the emitted `0 < d`
+    // proof: `decide` for the literal, a citation of the pool positivity theorem
+    // (normalized off its Prop `= true` form so `omega` reads it) for the pow2
+    // fn, and `Int.mul_pos` over both for the product.
     assert!(
         lean.contains("have hd : 0 < (8 : Int) := by decide"),
         "literal divisor positivity must close by `decide`:\n{lean}"
     );
     assert!(
-        lean.contains("have hpos := pow2_law_positive (k); omega"),
-        "pow2 divisor positivity must CITE the pool positivity law:\n{lean}"
+        lean.contains(
+            "have hpos := pow2_law_positive (k); \
+             simp only [ge_iff_le, eq_iff_iff, iff_true] at hpos; omega"
+        ),
+        "pow2 divisor positivity must CITE the pool positivity law and normalize it:\n{lean}"
     );
     assert!(
-        lean.contains("Int.mul_pos (by decide) (by have hpos := pow2_law_positive (k); omega)"),
+        lean.contains(
+            "Int.mul_pos (by decide) (by have hpos := pow2_law_positive (k); \
+             simp only [ge_iff_le, eq_iff_iff, iff_true] at hpos; omega)"
+        ),
         "product divisor positivity must be `Int.mul_pos` over the literal and cited factors:\n{lean}"
+    );
+    // The CANCEL arm's `0 < pow2 k` has NO route but the citation — no remainder
+    // bound implies it for free — so this fingerprint is what actually detects a
+    // broken citation (the absorb arms would still close from their `when`).
+    assert!(
+        lean.contains(
+            "have hc : 0 < pow2 k := by have hpos := pow2_law_positive (k); \
+             simp only [ge_iff_le, eq_iff_iff, iff_true] at hpos; omega"
+        ),
+        "cancel divisor positivity must be discharged solely by the cited pool law:\n{lean}"
     );
     // No law theorem REACHES sorry (only `first | proof | sorry` fail-safe floors).
     let reached_sorry: Vec<&str> = lean
@@ -514,10 +534,13 @@ fn proof_export_divisor_shape_positivity_universal() {
 }
 
 /// Live Lean gate for the divisor-shape positivity fixture: the pool positivity
-/// law plus the three guard-free floor laws (literal / pool-fn / product
+/// law plus the four guard-free floor laws (literal / pool-fn / product / cancel
 /// divisors) all close sorry-free and earn kernel-genuine `universal` credit
-/// (`#print axioms` inside the whitelist). Deleting the pool law drops the pow2
-/// and product laws back to bounded (verified separately); here it is present.
+/// (`#print axioms` inside the whitelist). The cancel law is the load-bearing
+/// one: its `0 < pow2 k` comes ONLY from the cited pool law (no remainder bound
+/// masks a broken citation), so a regression in the citation surfaces here as a
+/// lake failure. Deleting the pool law drops the citing laws back to bounded
+/// (`proof_divisor_shape_pool_law_is_load_bearing`); here it is present.
 #[test]
 fn proof_divisor_shape_positivity_lean_closes_kernel_genuine() {
     if Command::new("lake").arg("--version").output().is_err() {
@@ -555,8 +578,8 @@ fn proof_divisor_shape_positivity_lean_closes_kernel_genuine() {
             summary["universal_laws"].as_u64(),
             summary["bounded_laws"].as_u64(),
         ),
-        (Some(4), Some(0)),
-        "exactly the four universal-classed law theorems certified, none bounded.\n{}",
+        (Some(5), Some(0)),
+        "exactly the five universal-classed law theorems certified, none bounded.\n{}",
         format_output(&run)
     );
     let _ = std::fs::remove_dir_all(&output_dir);
@@ -594,7 +617,10 @@ fn proof_export_divisor_shape_positivity_witness_universal() {
     // The cited theorem is the FOREIGN pool law (`blk_law_atLeastOne`), proving
     // the citation is discovered from the claim shape, not a hardcoded `pow2`.
     assert!(
-        lean.contains("have hpos := blk_law_atLeastOne (k); omega"),
+        lean.contains(
+            "have hpos := blk_law_atLeastOne (k); \
+             simp only [ge_iff_le, eq_iff_iff, iff_true] at hpos; omega"
+        ),
         "the foreign pool positivity law must be the cited one:\n{lean}"
     );
     let reached_sorry: Vec<&str> = lean
@@ -713,4 +739,97 @@ verify floorDiv law absorbBare
         "must NOT claim universal for an underivable divisor:\n{lean}"
     );
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The cited pool positivity law is LOAD-BEARING for the cancel arm, proven by a
+/// two-source revert. Both sources carry the identical guard-free cancel law
+/// `floorDiv(a*pow2(k), 8*pow2(k)) = floorDiv(a, 8)`, whose only positivity
+/// source is `0 < pow2 k`. WITH `pow2 law positive` in scope the divisor-shape
+/// rung derives that by CITING it and the law classes `universal`; DELETE just
+/// that one pool law (the fn and the cancel law untouched) and the same law
+/// declines to the sound `bounded-domain` sampled fallback. This is the
+/// mechanized form of the "delete the pool law" revert — the classification flip
+/// is what proves the citation, not a coincidence, carries the universality.
+/// Export-structure pin (no toolchain): the class is fixed at emit time.
+#[test]
+fn proof_divisor_shape_pool_law_is_load_bearing() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+
+    // Shared tail: the pow2 fn, a floor fn, and the guard-free cancel law whose
+    // shared factor is `pow2(k)`. The `when 0 < k` guard bounds the exponent,
+    // NOT the divisor, so `0 < pow2 k` has no route but a citation.
+    let tail = r#"
+fn pow2(n: Int) -> Int
+    match n <= 0
+        true -> 1
+        false -> 2 * pow2(n - 1)
+
+verify pow2
+    pow2(0) => 1
+    pow2(3) => 8
+POOL_LAW
+fn floorDiv(a: Int, d: Int) -> Int
+    ? "Euclidean floor division a / d, guarded to 0 at d = 0."
+    Result.withDefault(Int.div(a, d), 0)
+
+verify floorDiv
+    floorDiv(52, 8) => 6
+
+verify floorDiv law cancelPow2
+    given a: Int = [8, 17, 0 - 5]
+    given k: Int = [1, 2, 3]
+    when 0 < k
+    floorDiv(a * pow2(k), 8 * pow2(k)) => floorDiv(a, 8)
+"#;
+    let header = "module CancelRevert\n    intent = \"cancel revert\"\n    exposes [pow2, floorDiv]\n    effects []\n";
+    let pool_law =
+        "\nverify pow2 law positive\n    given k: Int = [0, 1, 3]\n    pow2(k) >= 1 holds\n";
+
+    let emit_class = |with_pool: bool| -> String {
+        let body = tail.replace("POOL_LAW", if with_pool { pool_law } else { "" });
+        let src = format!("{header}{body}");
+        let dir = temp_output_dir(if with_pool {
+            "aver-proof-cancel-revert-with"
+        } else {
+            "aver-proof-cancel-revert-without"
+        });
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let av = dir.join("cancel_revert.av");
+        std::fs::write(&av, &src).expect("write fixture");
+        let out_lean = dir.join("lean");
+        let run = Command::new(aver_bin)
+            .current_dir(&repo_root)
+            .arg("proof")
+            .arg(&av)
+            .arg("-o")
+            .arg(&out_lean)
+            .output()
+            .expect("aver proof should run");
+        assert!(run.status.success(), "{}", format_output(&run));
+        let lean = std::fs::read_to_string(out_lean.join("CancelRevert.lean")).expect("lean out");
+        let _ = std::fs::remove_dir_all(&dir);
+        lean.lines()
+            .find(|l| l.contains("-- aver:law-class floorDiv_law_cancelPow2 "))
+            .unwrap_or_else(|| panic!("no cancel law-class line:\n{lean}"))
+            .to_string()
+    };
+
+    // WITH the pool law: the citation discharges `0 < pow2 k` → universal.
+    let with_pool = emit_class(true);
+    assert!(
+        with_pool.contains("floorDiv_law_cancelPow2 universal"),
+        "with the pool law present the cancel law must class universal; got: {with_pool}"
+    );
+    // WITHOUT the pool law: nothing derives `0 < pow2 k` → the rung declines to
+    // the sound bounded sampled fallback (NOT a false universal).
+    let without_pool = emit_class(false);
+    assert!(
+        without_pool.contains("floorDiv_law_cancelPow2 bounded-domain"),
+        "deleting the pool law must drop the cancel law to bounded-domain; got: {without_pool}"
+    );
+    assert!(
+        !without_pool.contains("floorDiv_law_cancelPow2 universal"),
+        "deleting the pool law must NOT leave a false universal; got: {without_pool}"
+    );
 }

--- a/tests/proof_spec/floor_window.rs
+++ b/tests/proof_spec/floor_window.rs
@@ -449,3 +449,268 @@ fn proof_bigint_floor_div_graduation_dafny() {
         0,
     );
 }
+
+/// Divisor-shape positivity (`tests/fixtures/divisor_shape_positivity.av`): the
+/// Euclidean-floor arithmetic rungs derive `0 < d` from the DIVISOR'S AST SHAPE
+/// instead of a ritual `when 0 < d` guard. Export-structure pin (no toolchain):
+/// three floor laws with NO positivity guard close `universal`, each via its own
+/// derivation route — a positive literal by `decide`, a pool-fn call by CITING
+/// the proven `pow2 law positive`, and a product by `Int.mul_pos` over the two.
+#[test]
+fn proof_export_divisor_shape_positivity_universal() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let output_dir = temp_output_dir("aver-proof-divisor-shape");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/divisor_shape_positivity.av")
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("aver proof should run");
+    assert!(run.status.success(), "{}", format_output(&run));
+    let lean = std::fs::read_to_string(output_dir.join("DivisorShapePositivity.lean"))
+        .expect("DivisorShapePositivity.lean must be emitted");
+
+    // Every guard-free floor law closes universal — the positivity was derived
+    // from the divisor's shape, not read off a `when` clause.
+    for base in [
+        "floorDiv_law_absorbLiteral",
+        "floorDiv_law_absorbPow2",
+        "floorDiv_law_absorbProduct",
+    ] {
+        assert!(
+            lean.contains(&format!("-- aver:law-class {base} universal")),
+            "{base} must close universal via shape-derived positivity; got:\n{lean}"
+        );
+    }
+    // The three derivation routes each leave their fingerprint in the emitted
+    // `0 < d` proof: `decide` for the literal, a citation of the pool positivity
+    // theorem for the pow2 fn, and `Int.mul_pos` over both for the product.
+    assert!(
+        lean.contains("have hd : 0 < (8 : Int) := by decide"),
+        "literal divisor positivity must close by `decide`:\n{lean}"
+    );
+    assert!(
+        lean.contains("have hpos := pow2_law_positive (k); omega"),
+        "pow2 divisor positivity must CITE the pool positivity law:\n{lean}"
+    );
+    assert!(
+        lean.contains("Int.mul_pos (by decide) (by have hpos := pow2_law_positive (k); omega)"),
+        "product divisor positivity must be `Int.mul_pos` over the literal and cited factors:\n{lean}"
+    );
+    // No law theorem REACHES sorry (only `first | proof | sorry` fail-safe floors).
+    let reached_sorry: Vec<&str> = lean
+        .lines()
+        .filter(|l| l.contains("sorry") && !l.contains("| sorry"))
+        .collect();
+    assert!(
+        reached_sorry.is_empty(),
+        "divisor-shape fixture must not REACH sorry; offending lines:\n{}",
+        reached_sorry.join("\n")
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// Live Lean gate for the divisor-shape positivity fixture: the pool positivity
+/// law plus the three guard-free floor laws (literal / pool-fn / product
+/// divisors) all close sorry-free and earn kernel-genuine `universal` credit
+/// (`#print axioms` inside the whitelist). Deleting the pool law drops the pow2
+/// and product laws back to bounded (verified separately); here it is present.
+#[test]
+fn proof_divisor_shape_positivity_lean_closes_kernel_genuine() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping divisor-shape proof test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-divisor-shape-lake");
+    let (summary, run) = run_lean_check_json(
+        "tests/fixtures/divisor_shape_positivity.av",
+        &output_dir,
+        0,
+        &[],
+    );
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "divisor-shape laws must close sorry-free.\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "the pool law and all three shape-derived floor laws must be kernel-genuine \
+         universal (axioms within the whitelist).\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        (
+            summary["universal_laws"].as_u64(),
+            summary["bounded_laws"].as_u64(),
+        ),
+        (Some(4), Some(0)),
+        "exactly the four universal-classed law theorems certified, none bounded.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// Cross-domain, NAME- and DOMAIN-blind witness
+/// (`tests/fixtures/divisor_shape_positivity_witness.av`): a powers-of-THREE
+/// recursive fn `blk` and a differently-named floor fn `quot`, with the pool law
+/// spelled `1 <= blk(n)`. If the derivation keys on the claim SHAPE and not on
+/// `pow2` / `floorDiv` names or the power-of-two domain, the literal and cited
+/// floor laws close universal here too. Export-structure pin.
+#[test]
+fn proof_export_divisor_shape_positivity_witness_universal() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let output_dir = temp_output_dir("aver-proof-divisor-shape-witness");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/divisor_shape_positivity_witness.av")
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("aver proof should run");
+    assert!(run.status.success(), "{}", format_output(&run));
+    let lean = std::fs::read_to_string(output_dir.join("DivisorShapePositivityWitness.lean"))
+        .expect("DivisorShapePositivityWitness.lean must be emitted");
+
+    for base in ["quot_law_soakLiteral", "quot_law_soakBlock"] {
+        assert!(
+            lean.contains(&format!("-- aver:law-class {base} universal")),
+            "{base} must close universal (name- and domain-blind); got:\n{lean}"
+        );
+    }
+    // The cited theorem is the FOREIGN pool law (`blk_law_atLeastOne`), proving
+    // the citation is discovered from the claim shape, not a hardcoded `pow2`.
+    assert!(
+        lean.contains("have hpos := blk_law_atLeastOne (k); omega"),
+        "the foreign pool positivity law must be the cited one:\n{lean}"
+    );
+    let reached_sorry: Vec<&str> = lean
+        .lines()
+        .filter(|l| l.contains("sorry") && !l.contains("| sorry"))
+        .collect();
+    assert!(
+        reached_sorry.is_empty(),
+        "divisor-shape witness must not REACH sorry; offending lines:\n{}",
+        reached_sorry.join("\n")
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// Live Lean gate for the cross-domain witness: the foreign `blk` positivity
+/// pool law and the two guard-free `quot` floor laws close sorry-free and
+/// kernel-genuine universal — a differently named fn, so any `pow2` / `floorDiv`
+/// name leak in the derivation would break here.
+#[test]
+fn proof_divisor_shape_positivity_witness_lean_closes_kernel_genuine() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping divisor-shape witness proof test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-divisor-shape-witness-lake");
+    let (summary, run) = run_lean_check_json(
+        "tests/fixtures/divisor_shape_positivity_witness.av",
+        &output_dir,
+        0,
+        &[],
+    );
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "witness laws must close sorry-free.\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "the foreign pool law and both shape-derived floor laws must be \
+         kernel-genuine universal.\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        (
+            summary["universal_laws"].as_u64(),
+            summary["bounded_laws"].as_u64(),
+        ),
+        (Some(3), Some(0)),
+        "exactly three universal-classed witness law theorems, none bounded.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// The fail-closed boundary of divisor-shape positivity: an absorb law whose
+/// divisor is a BARE given with no `when 0 < d` guard and no derivable shape
+/// (not a literal, product, or pool-fn call) must DECLINE — the rung keeps its
+/// sound sampled fallback (`bounded-domain`), not a false universal. The law is
+/// genuinely false for `m <= 0`, so bounded is correct. Export pin, no toolchain.
+#[test]
+fn proof_divisor_shape_underivable_divisor_declines() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = r#"module UnderivableDivisor
+    intent =
+        "An absorb-remainder floor law whose divisor is an unguarded bare"
+        "variable: no shape derives its positivity, so the rung must decline."
+    exposes [floorDiv]
+    effects []
+
+fn floorDiv(a: Int, d: Int) -> Int
+    ? "Euclidean floor division a / d, guarded to 0 at d = 0."
+    Result.withDefault(Int.div(a, d), 0)
+
+verify floorDiv
+    floorDiv(52, 8) => 6
+
+verify floorDiv law absorbBare
+    given m: Int = [1, 2, 3]
+    given q: Int = [4, 6, 0]
+    given r: Int = [0, 1, 2]
+    when 0 <= r
+    when r < m
+    floorDiv(m * q + r, m) => q
+"#;
+    let dir = temp_output_dir("aver-proof-divisor-shape-underivable");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let av = dir.join("underivable.av");
+    std::fs::write(&av, src).expect("write fixture");
+    let out_lean = dir.join("lean");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg(&av)
+        .arg("-o")
+        .arg(&out_lean)
+        .output()
+        .expect("aver proof should run");
+    assert!(run.status.success(), "{}", format_output(&run));
+    let lean = std::fs::read_to_string(out_lean.join("UnderivableDivisor.lean")).expect("lean out");
+    // Declines to the sound bounded fallback, NOT a false universal.
+    assert!(
+        lean.contains("-- aver:law-class floorDiv_law_absorbBare bounded-domain"),
+        "an unguarded, shape-underivable divisor must decline to bounded-domain:\n{lean}"
+    );
+    assert!(
+        !lean.contains("-- aver:law-class floorDiv_law_absorbBare universal"),
+        "must NOT claim universal for an underivable divisor:\n{lean}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## What

Floor-division proof arms sourced '0 < d' exclusively from an author-written when-guard, so a law whose divisor is a literal, a product of known-positives, or a function with a proven positivity law in the pool declined if the ritual guard was missing. The arms now derive the fact from the divisor's AST shape — literal via decide, product via Int.mul_pos over recursively derived factors, function via CITING the pool's positivity law (shape-keyed on the claim form, name-blind) — with the when-guard as the unchanged fallback and a fail-closed decline when nothing derives. The derivation lives in the shared recognition substrate (#644).

## Semantics win

Authors stop writing 'when pow2(k) > 0' where the compiler can see it; when-guards go back to carrying domain knowledge only. Guarded laws are untouched: the whole K5 corpus emits byte-identical Lean (md5-verified against main in an isolated worktree).

## Review trail

The panel probed past the surface: absorb-shaped fixtures are structurally blind to citation breakage (their own premises already imply positivity), so it built a cancel-arm probe and confirmed two blockers — the citation term fed omega an unnormalized fact, and the citation gate was recognizer-level rather than statement-level. Both fixed; the fix round also empirically corrected the architect's prescribed normalization lemma (never fired — the fact is a Prop equality) using the measured set from the existing pattern. The cancel fixture and a committed two-source revert test (pool law present -> universal; deleted -> bounded) now pin exactly the class the original fixtures could not see.

## Gates

lib 930; proof_spec floor_window/lean_kernel/check_gates/byte-golden serialized 58/58 including six divisor-shape tests, the foreign-named witness, and the load-bearing revert; clippy both feature sets; fmt; K5 round.av byte-identical to main (0 CitedLaw uses in K5 — guarded fallback exact).