### PR TITLE
Graduate single-function string-position skip scanners to native definitions

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -1807,14 +1807,49 @@ fn emit_verify_law_forall_auto_proof_inner(
             if defs.is_empty() {
                 return None;
             }
+            // A GRADUATED string-position scanner (native `def` with a
+            // `termination_by`) in the def cone makes a blind `simp [<fn>]`
+            // heartbeat-abort on the well-founded equation lemmas — a HARD
+            // `isDefEq` timeout that `first | … | sorry` does NOT catch. Drive
+            // the scanner's own `.induct` instead (`fun_induction` closes the
+            // progress-shaped universals graduation unlocks) and DROP the
+            // blind-simp fallback for this case, so a non-closing split
+            // degrades to the honest `sorry` floor rather than aborting the
+            // build. A non-scanner cone keeps the byte-identical simp floor.
+            let scope = ctx.active_module_scope();
+            let cone_has_scanner = shared::law_simp_source_names(ctx, vb, law)
+                .iter()
+                .filter_map(|n| {
+                    ctx.fn_def_by_name(n, scope.as_deref())
+                        .or_else(|| ctx.fn_def_by_name(n, None))
+                })
+                .any(|fd| {
+                    crate::codegen::lean::toplevel::fuel::detect_simple_string_pos_skip_literal(fd)
+                        .is_some()
+                });
+            let tactic_line = if cone_has_scanner {
+                let targets =
+                    induction::find_fun_induction_targets(vb, law, ctx, &proof_intro_names);
+                let mut arms: Vec<String> = targets
+                    .iter()
+                    .map(|t| {
+                        format!(
+                            "(fun_induction {} {} <;> simp_all <;> omega)",
+                            t.fn_lean,
+                            t.args.join(" ")
+                        )
+                    })
+                    .collect();
+                arms.push("sorry".to_string());
+                format!("first | {}", arms.join(" | "))
+            } else {
+                format!("first | (simp [{}] <;> done) | sorry", defs.join(", "))
+            };
             Some(AutoProof {
                 support_lines: Vec::new(),
                 body: crate::codegen::lean::tactic_ir::Tactic::raw(intro_then(
                     &proof_intro_names,
-                    vec![format!(
-                        "first | (simp [{}] <;> done) | sorry",
-                        defs.join(", ")
-                    )],
+                    vec![tactic_line],
                 )),
                 replaces_theorem: false,
             })

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -2755,10 +2755,10 @@ fn emit_map_fold_homomorphism(
 /// IH — no arg choice, no `generalizing`, no tail `cases`. It CLOSES only when
 /// the recursion key is a FREE VARIABLE; on a composite scrutinee it abstracts
 /// the term and loses the IH, so we require every argument to be a bare given.
-struct FunInductionTarget {
-    fn_lean: String,
+pub(super) struct FunInductionTarget {
+    pub(super) fn_lean: String,
     /// Goal-argument Lean names (the intro names), in call order.
-    args: Vec<String>,
+    pub(super) args: Vec<String>,
 }
 
 /// Whether a fn's body case-splits with a `match` — the condition under which
@@ -2806,7 +2806,7 @@ fn fn_body_has_match(fd: &crate::ast::FnDef) -> bool {
 /// <existing ladder>` arms. Each `fun_induction` either CLOSES the goal or
 /// FAILS (no theorem / goal mismatch / non-closing closer), falling to the next
 /// arm and ultimately to today's ladder — it can only ADD closures.
-fn find_fun_induction_targets(
+pub(super) fn find_fun_induction_targets(
     vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -15,7 +15,7 @@ mod shared;
 pub mod tactic_ir;
 #[cfg(test)]
 mod tests;
-mod toplevel;
+pub(in crate::codegen::lean) mod toplevel;
 mod transpile;
 mod types;
 pub mod untranslate;

--- a/src/codegen/lean/prelude.rs
+++ b/src/codegen/lean/prelude.rs
@@ -176,6 +176,29 @@ theorem String.charAt_none_of_ge (s : String) (pos : Int) (h0 : 0 ≤ pos) (h : 
   have hn : ¬ pos < 0 := by omega
   simp [String.charAtAv, hn, List.getElem?_eq_none, h]"#;
 
+/// `String.charAtAv s pos = some c` forces `pos` into `[0, s.length)`.
+/// The termination witness for the graduated native string-position
+/// SKIP scanner: `decreasing_by` reads the outer match's `charAtAv …
+/// = some c` equation and this lemma turns it into `pos.toNat <
+/// s.toList.length`, which `omega` uses to discharge the strict
+/// decrease of the `s.toList.length - pos.toNat` measure. Sibling of
+/// `charAt_eq_of_lt` / `charAt_none_of_ge`; core-only (no `by_contra`
+/// / `push_neg`, neither of which is in the emitted prelude).
+const LEAN_PRELUDE_STRING_CHARAT_SOME_BOUNDS: &str = r#"/-- `String.charAtAv` returning `some` pins the position in bounds. -/
+theorem String.charAt_some_bounds (s : String) (pos : Int) (c : String)
+    (h : String.charAtAv s pos = some c) :
+    0 ≤ pos ∧ pos.toNat < s.toList.length := by
+  unfold String.charAtAv at h
+  by_cases hneg : pos < 0
+  · simp [hneg] at h
+  · simp only [hneg, if_false] at h
+    refine ⟨by omega, ?_⟩
+    rcases Nat.lt_or_ge pos.toNat s.toList.length with hlt | hge
+    · exact hlt
+    · exfalso
+      rw [List.getElem?_eq_none hge] at h
+      simp at h"#;
+
 /// Decimal-digit facts over the `NumericParse` prelude — reopened
 /// `AverDigits` namespace, demand-driven like the String spec lemmas.
 /// `natDigits_head_ne_zero` (a canonical decimal render never starts
@@ -1116,6 +1139,9 @@ fn generate_string_helpers_prelude(body: &str, include_all_helpers: bool) -> Str
     }
     if include_all_helpers || body.contains("String.charAt_none_of_ge") {
         parts.push(LEAN_PRELUDE_STRING_CHARAT_NONE_OF_GE.to_string());
+    }
+    if include_all_helpers || body.contains("String.charAt_some_bounds") {
+        parts.push(LEAN_PRELUDE_STRING_CHARAT_SOME_BOUNDS.to_string());
     }
     parts.join("\n\n")
 }

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -2732,6 +2732,113 @@ fn walk(s: String, pos: Int) -> Int
 }
 
 #[test]
+fn proof_mode_declines_graduation_for_non_unit_advance_arm() {
+    // FAIL-CLOSED graduation: a skip scanner whose inner char-match mixes the
+    // exact `self(s, pos + 1)` advance with a NON-unit `self(s, pos + 2)` arm
+    // must stay FUELED, not graduate — a native `def` cannot sorry-floor a
+    // `decreasing_by`, so a step shape the recognizer cannot affirmatively
+    // classify must never reach native emission. The upstream StringPosAdvance
+    // classifier admits `pos + k` for any k >= 1, so this shape reaches the
+    // gate; before the fix the `pos + 2` arm fell through the detector's
+    // `_ => {}` and the sibling `pos + 1` arm graduated the whole fn. A fuel
+    // wrapper always builds.
+    let source = r#"module NonUnitAdvance
+    intent = "mixed advance skip scanner"
+    effects []
+
+fn skipMixed(s: String, pos: Int) -> Int
+    match String.charAt(s, pos)
+        Option.None -> pos
+        Option.Some(c) -> match c
+            " " -> skipMixed(s, pos + 1)
+            "x" -> skipMixed(s, pos + 2)
+            _ -> pos
+"#;
+    let mut ctx = ctx_from_source(source, "non_unit_advance");
+    let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
+    let lean = generated_lean_file(&out);
+
+    assert!(
+        lean.contains("def skipMixed__fuel"),
+        "the mixed-advance scanner must stay fueled:\n{lean}"
+    );
+    assert!(
+        !lean.contains("String.charAt_some_bounds")
+            && !lean.contains("termination_by (s.toList.length - pos.toNat)"),
+        "the mixed-advance scanner must NOT graduate to a native def:\n{lean}"
+    );
+}
+
+#[test]
+fn graduation_gate_declines_unclassifiable_arms() {
+    // Direct fail-closed net on the graduation recognizer. The upstream
+    // classifier rejects some of these shapes to `partial def`, so the gate
+    // is exercised in isolation: a self-call arm that is NOT the exact
+    // `self(s, pos + 1)` advance, or an outer arm that is not the exact
+    // charAt none/some pair, must make `detect_simple_string_pos_skip_literal`
+    // decline — anything it accepts is emitted as a native `def` whose
+    // `decreasing_by` cannot be sorry-floored.
+    use crate::codegen::lean::toplevel::fuel::detect_simple_string_pos_skip_literal;
+    fn fd_named<'a>(ctx: &'a CodegenContext, name: &str) -> &'a FnDef {
+        ctx.fn_defs
+            .iter()
+            .find(|fd| fd.name == name)
+            .unwrap_or_else(|| panic!("fn {name} not found"))
+    }
+
+    // Positive control: the canonical uniform `pos + 1` skip shape graduates.
+    let good = ctx_from_source(
+        "module GateGood\n    effects []\n\n\
+         fn skipWs(s: String, pos: Int) -> Int\n    match String.charAt(s, pos)\n        Option.None -> pos\n        Option.Some(c) -> match c\n            \" \" -> skipWs(s, pos + 1)\n            _ -> pos\n",
+        "gate_good",
+    );
+    assert!(
+        detect_simple_string_pos_skip_literal(fd_named(&good, "skipWs")).is_some(),
+        "the canonical uniform pos+1 skipper must still be recognized"
+    );
+
+    // BLOCKER 1 (:691): a non-advancing `self(s, pos)` arm alongside a real
+    // `self(s, pos + 1)` arm — `decreasing_by` would fail on the non-advancing
+    // call, so decline.
+    let non_adv = ctx_from_source(
+        "module GateNonAdv\n    effects []\n\n\
+         fn skipMixed(s: String, pos: Int) -> Int\n    match String.charAt(s, pos)\n        Option.None -> pos\n        Option.Some(c) -> match c\n            \" \" -> skipMixed(s, pos + 1)\n            \"x\" -> skipMixed(s, pos)\n            _ -> pos\n",
+        "gate_non_adv",
+    );
+    assert!(
+        detect_simple_string_pos_skip_literal(fd_named(&non_adv, "skipMixed")).is_none(),
+        "a non-advancing self-call arm must decline graduation"
+    );
+
+    // BLOCKER 1 (:691): the advance routed through a helper `self(s, bump(pos))`
+    // — an opaque step `decreasing_by` cannot discharge, so decline.
+    let helper = ctx_from_source(
+        "module GateHelper\n    effects []\n\n\
+         fn bump(pos: Int) -> Int\n    pos + 1\n\n\
+         fn skipMixed(s: String, pos: Int) -> Int\n    match String.charAt(s, pos)\n        Option.None -> pos\n        Option.Some(c) -> match c\n            \" \" -> skipMixed(s, pos + 1)\n            \"x\" -> skipMixed(s, bump(pos))\n            _ -> pos\n",
+        "gate_helper",
+    );
+    assert!(
+        detect_simple_string_pos_skip_literal(fd_named(&helper, "skipMixed")).is_none(),
+        "a helper-routed advance arm must decline graduation"
+    );
+
+    // BLOCKER 2 (:621): an outer catch-all `_` on the charAt Option. The native
+    // emitter cannot name a `= some c` discriminant off a wildcard, so a
+    // graduated def would hard-error — the outer match must be exactly the
+    // none/some pair.
+    let outer_wild = ctx_from_source(
+        "module GateOuterWild\n    effects []\n\n\
+         fn skipR(s: String, pos: Int) -> Int\n    match String.charAt(s, pos)\n        Option.None -> pos\n        Option.Some(c) -> match c\n            \" \" -> skipR(s, pos + 1)\n            _ -> pos\n        _ -> pos\n",
+        "gate_outer_wild",
+    );
+    assert!(
+        detect_simple_string_pos_skip_literal(fd_named(&outer_wild, "skipR")).is_none(),
+        "an outer wildcard on the charAt Option must decline graduation"
+    );
+}
+
+#[test]
 fn proof_mode_accepts_mutual_int_countdown_recursion() {
     let mut ctx = empty_ctx();
     let even = FnDef {

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -2664,9 +2664,16 @@ fn proof_mode_accepts_single_string_pos_advance_recursion() {
 }
 
 #[test]
-fn proof_mode_emits_stability_lemma_for_simple_string_pos_skipper() {
+fn proof_mode_graduates_simple_string_pos_skipper_to_native() {
+    // The simple string-position SKIP shape (skipWs family) graduates to a
+    // native fuel-free `def` with a `termination_by` measure, so Lean derives
+    // a real `.induct`. This SUBSUMES the #643 single-fn fuel-stability lemma:
+    // the graduated shape has no `__fuel` wrapper and no `_stable` lemma
+    // (native `.induct` is strictly stronger). The stability-lemma emission
+    // path is now unreachable for single fns — see the `walk`-shape decline
+    // test below, which pins that a NON-skip string-position fn stays fueled.
     let source = r#"module FuelStable
-    intent = "simple string-position fuel stability"
+    intent = "simple string-position graduation"
     effects []
 
 fn skipSpaces(s: String, pos: Int) -> Int
@@ -2680,13 +2687,26 @@ fn skipSpaces(s: String, pos: Int) -> Int
     let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
     let lean = generated_lean_file(&out);
 
-    assert!(lean.contains("def skipSpaces__fuel"));
     assert!(
-        lean.contains("theorem skipSpaces__fuel_stable :"),
-        "expected simple string-position skipper to get a stability lemma:\n{lean}"
+        lean.contains("def skipSpaces (s : String) (pos : Int) : Int :="),
+        "expected native fuel-free skipSpaces def:\n{lean}"
     );
-    assert!(lean.contains("averStringPosFuel s pos 1 ≤ fuel"));
-    assert!(lean.contains("skipSpaces__fuel fuel s pos = skipSpaces s pos"));
+    assert!(
+        lean.contains("termination_by (s.toList.length - pos.toNat)"),
+        "expected the StringLenMinusPos measure as termination_by:\n{lean}"
+    );
+    assert!(
+        lean.contains("String.charAt_some_bounds"),
+        "decreasing_by must cite the prelude bounds lemma:\n{lean}"
+    );
+    assert!(
+        !lean.contains("def skipSpaces__fuel"),
+        "graduated skipper must NOT emit a fuel wrapper:\n{lean}"
+    );
+    assert!(
+        !lean.contains("skipSpaces__fuel_stable"),
+        "graduated skipper must NOT emit the fuel-stability lemma (subsumed by native):\n{lean}"
+    );
 }
 
 #[test]
@@ -3067,7 +3087,12 @@ fn json_example_uses_total_defs_and_domain_guarded_laws_in_proof_mode() {
     let lean = generated_lean_file(&out);
 
     assert!(!lean.contains("partial def"));
-    assert!(lean.contains("def skipWs__fuel"));
+    // skipWs is a single simple-skip scanner: it graduates to a native
+    // fuel-free `def` with a `termination_by` measure (real `.induct`).
+    assert!(lean.contains("def skipWs (s : String) (pos : Int) : Int :="));
+    assert!(lean.contains("termination_by (s.toList.length - pos.toNat)"));
+    assert!(!lean.contains("def skipWs__fuel"));
+    // parseValue sits in a mutual parser clique — mutual groups stay fueled.
     assert!(lean.contains("def parseValue__fuel"));
     assert!(lean.contains("def toString' (j : Json) : String :="));
     assert!(

--- a/src/codegen/lean/toplevel/fn_def.rs
+++ b/src/codegen/lean/toplevel/fn_def.rs
@@ -255,8 +255,10 @@ pub fn emit_fn_def_proof(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
             })
         )
     {
-        if detect_simple_string_pos_skip_literal(fd).is_some() {
-            return Some(emit_native_string_pos_skip_fn(fd, ctx));
+        if detect_simple_string_pos_skip_literal(fd).is_some()
+            && let Some(native) = emit_native_string_pos_skip_fn(fd, ctx)
+        {
+            return Some(native);
         }
         return Some(emit_fuelized_string_pos_fn(fd, ctx));
     }
@@ -336,7 +338,7 @@ pub fn emit_fn_def_proof(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
 /// Result: a real `<fn>.induct`, which the `fun_induction` law rung
 /// (unavailable to the fuel wrapper's non-recursive `.induct`) uses to
 /// close universal progress laws.
-fn emit_native_string_pos_skip_fn(fd: &FnDef, ctx: &CodegenContext) -> String {
+fn emit_native_string_pos_skip_fn(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
     let fn_name = aver_name_to_lean(&fd.name);
     let params = emit_fn_params(&fd.params);
     let ret_type = if fd.return_type.is_empty() {
@@ -355,6 +357,17 @@ fn emit_native_string_pos_skip_fn(fd: &FnDef, ctx: &CodegenContext) -> String {
     // Native self-calls (no fuel rewrite); Lean's wf compiler handles the
     // recursion once `termination_by`/`decreasing_by` are supplied.
     let body_str = emit_fn_body_for(fd, body, ctx);
+    // FAIL-CLOSED: the `decreasing_by` reads `charAtAv s pos = some c` off a
+    // named discriminant, so the sole outer `match String.charAtAv` must be
+    // renamed to `match hc_scan : String.charAtAv`. Verify the substitution
+    // target occurs EXACTLY once before injecting: zero occurrences (no-op
+    // rename) or several (only the first renamed) both yield a native def
+    // whose `decreasing_by` cannot see the bound and hard-errors. On any
+    // other count, decline graduation and let the caller stay fueled — a
+    // fuel wrapper always builds, a mis-injected native def does not.
+    if body_str.matches("match String.charAtAv").count() != 1 {
+        return None;
+    }
     // Name the sole outer `charAtAv` discriminant so its `= some c`
     // equation reaches `decreasing_by`.
     let body_named = body_str.replacen(
@@ -380,7 +393,7 @@ fn emit_native_string_pos_skip_fn(fd: &FnDef, ctx: &CodegenContext) -> String {
         s, pos
     ));
     lines.push("    omega)".to_string());
-    lines.join("\n")
+    Some(lines.join("\n"))
 }
 
 pub(super) fn lower_pure_question_bang_for_emit(fd: &FnDef) -> Option<FnDef> {

--- a/src/codegen/lean/toplevel/fn_def.rs
+++ b/src/codegen/lean/toplevel/fn_def.rs
@@ -2,7 +2,8 @@ use std::collections::HashSet;
 
 use super::expr::aver_name_to_lean;
 use super::fuel::{
-    contract_lex_params_rank, emit_fuelized_int_ascending_fn, emit_fuelized_int_countdown_fn,
+    contract_lex_params_rank, detect_simple_string_pos_skip_literal,
+    emit_fuelized_int_ascending_fn, emit_fuelized_int_countdown_fn,
     emit_fuelized_mutual_int_countdown_group, emit_fuelized_mutual_sizeof_group,
     emit_fuelized_mutual_string_pos_group, emit_fuelized_string_pos_fn,
     emit_nat_linear_recurrence_fn, emit_native_guarded_int_countdown_fn,
@@ -234,6 +235,18 @@ pub fn emit_fn_def_proof(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
     // StringPosAdvance — `Fuel { StringLenMinusPos { string, pos } }`.
     // Lean's emit reads the params from fd.params directly so the
     // contract just acts as the dispatch signal.
+    //
+    // GRADUATION: the simple SKIP shape (`match charAtAv s pos { none =>
+    // pos; some c => match c { <lit> => self(s, pos+1) …; _ => pos } }`,
+    // recognized by `detect_simple_string_pos_skip_literal`) emits a
+    // native fuel-free `def` with `termination_by (s.length - pos)` so
+    // Lean derives a real `<fn>.induct` for the `fun_induction` law rung.
+    // The tight recognizer IS the fail-closed floor: it fires only where
+    // every self-call sits under the outer `charAtAv s pos = some`
+    // guard, which forces `pos.toNat < s.length` — the exact fact the
+    // `decreasing_by` needs. Any other string-position shape (unbounded
+    // advance, carried-param scanner, mutual clique) keeps the fuel
+    // wrapper, since a native `def` cannot sorry-floor its termination.
     if let Some(contract) = crate::codegen::common::find_fn_contract_for_fn(ctx, fd)
         && matches!(
             contract.recursion,
@@ -242,6 +255,9 @@ pub fn emit_fn_def_proof(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
             })
         )
     {
+        if detect_simple_string_pos_skip_literal(fd).is_some() {
+            return Some(emit_native_string_pos_skip_fn(fd, ctx));
+        }
         return Some(emit_fuelized_string_pos_fn(fd, ctx));
     }
 
@@ -297,6 +313,74 @@ pub fn emit_fn_def_proof(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
     }
 
     Some(lines.join("\n"))
+}
+
+/// Native (fuel-free) emission for a graduated single-fn string-position
+/// SKIP scanner (the skipWs shape). Gated upstream by
+/// [`detect_simple_string_pos_skip_literal`], so the whole body is
+/// `match charAtAv s pos { none => pos; some c => match c { <lit> =>
+/// self(s, pos+1) …; _ => pos } }` and every recursive call sits under
+/// the outer `charAtAv s pos = some c` guard on the SAME `(s, pos)`.
+///
+/// Two moves make Lean accept the native def:
+///  1. The outer `charAtAv` match is named (`match hc_scan : …`). Lean
+///     drops the discriminant equation under a plain `match`, so
+///     `decreasing_by` would otherwise not see `charAtAv s pos = some c`.
+///     The general match emitter only names Ident/Attr subjects (not the
+///     `charAtAv` FnCall), so we inject the binder on the sole outer
+///     `match String.charAtAv` line here.
+///  2. `decreasing_by` cites the prelude's `String.charAt_some_bounds`
+///     to turn that equation into `pos.toNat < s.toList.length`, then
+///     `omega` closes the strict decrease of `s.toList.length - pos.toNat`.
+///
+/// Result: a real `<fn>.induct`, which the `fun_induction` law rung
+/// (unavailable to the fuel wrapper's non-recursive `.induct`) uses to
+/// close universal progress laws.
+fn emit_native_string_pos_skip_fn(fd: &FnDef, ctx: &CodegenContext) -> String {
+    let fn_name = aver_name_to_lean(&fd.name);
+    let params = emit_fn_params(&fd.params);
+    let ret_type = if fd.return_type.is_empty() {
+        "Unit".to_string()
+    } else {
+        type_annotation_to_lean(&fd.return_type)
+    };
+    let s = aver_name_to_lean(&fd.params[0].0);
+    let pos = aver_name_to_lean(&fd.params[1].0);
+
+    let lowered = lower_pure_question_bang_for_emit(fd);
+    let body = lowered
+        .as_ref()
+        .map(|lowered_fd| lowered_fd.body.as_ref())
+        .unwrap_or(fd.body.as_ref());
+    // Native self-calls (no fuel rewrite); Lean's wf compiler handles the
+    // recursion once `termination_by`/`decreasing_by` are supplied.
+    let body_str = emit_fn_body_for(fd, body, ctx);
+    // Name the sole outer `charAtAv` discriminant so its `= some c`
+    // equation reaches `decreasing_by`.
+    let body_named = body_str.replacen(
+        "match String.charAtAv",
+        "match hc_scan : String.charAtAv",
+        1,
+    );
+
+    let mut lines = Vec::new();
+    if let Some(desc) = &fd.desc {
+        lines.push(format!("/-- {} -/", sanitize_doc(desc)));
+    }
+    lines.push(format!("def {} {} : {} :=", fn_name, params, ret_type));
+    lines.push(body_named);
+    lines.push(format!(
+        "termination_by ({}.toList.length - {}.toNat)",
+        s, pos
+    ));
+    lines.push("decreasing_by".to_string());
+    lines.push("  all_goals (".to_string());
+    lines.push(format!(
+        "    obtain ⟨h0, hlt⟩ := String.charAt_some_bounds {} {} _ hc_scan",
+        s, pos
+    ));
+    lines.push("    omega)".to_string());
+    lines.join("\n")
 }
 
 pub(super) fn lower_pure_question_bang_for_emit(fd: &FnDef) -> Option<FnDef> {

--- a/src/codegen/lean/toplevel/fuel.rs
+++ b/src/codegen/lean/toplevel/fuel.rs
@@ -603,30 +603,37 @@ pub(in crate::codegen::lean) fn detect_simple_string_pos_skip_literal(
         return None;
     }
 
+    // FAIL-CLOSED: the outer match must be EXACTLY the `charAtAv s pos`
+    // none/some pair — `Option.None -> pos` (terminal exit) and
+    // `Option.Some(c) -> <inner char match>` (the recursion). Every other
+    // outer arm declines graduation so the fn stays fueled:
+    //   * a catch-all `_` (BLOCKER 2): the native emitter names the sole
+    //     outer discriminant (`match hc_scan : charAtAv …`) so
+    //     `decreasing_by` can read `charAtAv s pos = some c`. A wildcard
+    //     arm produces no `= some c` equation, so the graduated def
+    //     hard-errors on its termination proof — a native def cannot
+    //     sorry-floor termination, so this must never be emitted.
+    //   * a `None` arm returning anything but `pos`, or an unexpected extra
+    //     constructor — not the graduating skip shape.
     let mut saw_none_exit = false;
     let mut recursive_literal = None;
     let mut saw_fallback_exit = false;
     for arm in arms {
         match &arm.pattern {
             Pattern::Constructor(name, fields) if name == "Option.None" && fields.is_empty() => {
-                saw_none_exit = expr_is_ident(&arm.body, pos_name);
+                if !expr_is_ident(&arm.body, pos_name) {
+                    return None;
+                }
+                saw_none_exit = true;
             }
             Pattern::Constructor(name, fields) if name == "Option.Some" && fields.len() == 1 => {
-                let lit = detect_inner_char_match_literal(
+                let (lit, fallback) = detect_inner_char_match_literal(
                     &arm.body, &fields[0], &fd.name, s_name, pos_name,
                 )?;
-                recursive_literal = Some(lit.0);
-                saw_fallback_exit = lit.1;
+                recursive_literal = Some(lit);
+                saw_fallback_exit = fallback;
             }
-            Pattern::Wildcard => {
-                if let Some((lit, fallback)) =
-                    detect_inner_char_match_literal(&arm.body, "", &fd.name, s_name, pos_name)
-                {
-                    recursive_literal = Some(lit);
-                    saw_fallback_exit = fallback;
-                }
-            }
-            _ => {}
+            _ => return None,
         }
     }
 
@@ -680,15 +687,32 @@ fn detect_inner_char_match_literal(
     let mut fallback_exit = false;
     for arm in arms {
         match &arm.pattern {
+            // An advancing arm: EXACTLY `self(s, pos + 1)` under the
+            // `charAtAv s pos = some c` guard — the only recursive step
+            // whose strict decrease of `s.length - pos` the native
+            // `decreasing_by` can close.
             Pattern::Literal(Literal::Str(lit))
                 if expr_is_self_pos_plus_one_tailcall(&arm.body, fn_name, s_name, pos_name) =>
             {
                 recursive_literal = Some(lit.clone());
             }
+            // The catch-all terminal exit `_ -> pos`.
             Pattern::Wildcard if expr_is_ident(&arm.body, pos_name) => {
                 fallback_exit = true;
             }
-            _ => {}
+            // FAIL-CLOSED: every remaining arm must be a TERMINAL,
+            // non-recursive arm (no self-call anywhere in its body). An arm
+            // carrying a self-call that is NOT the exact `self(s, pos + 1)`
+            // advance — a non-advancing `self(s, pos)`, a non-unit
+            // `self(s, pos + 2)`, or an advance routed through a helper
+            // `self(s, f(pos))` — graduates a native def whose
+            // `decreasing_by` cannot close (or silently changes the proven
+            // step shape), so it is unclassifiable: decline and stay fueled.
+            _ => {
+                if expr_contains_self_call(&arm.body, fn_name) {
+                    return None;
+                }
+            }
         }
     }
     recursive_literal.map(|lit| (lit, fallback_exit))
@@ -753,6 +777,66 @@ fn expr_is_pos_plus_one(expr: &Spanned<Expr>, pos_name: &str) -> bool {
         ) if expr_is_ident(left, pos_name)
             && matches!(&right.node, Expr::Literal(Literal::Int(1)))
     )
+}
+
+/// True iff `expr` (recursively) contains a call whose target is the
+/// recursive fn itself (`fn_name`). Covers post-TCO `TailCall`s — whose
+/// target the generic `recursion::expr_references_ident` walker skips,
+/// checking only its args — and both `Ident` and resolver-`Resolved`
+/// `FnCall` callees. Used by [`detect_inner_char_match_literal`] to
+/// reject an inner-match arm carrying a self-call that is NOT the exact
+/// `self(s, pos + 1)` advance: such an arm graduates a native def whose
+/// `decreasing_by` cannot close, so the fn must stay fueled. No existing
+/// helper reports TailCall targets, so this focused walker is the
+/// smallest fail-closed check.
+fn expr_contains_self_call(expr: &Spanned<Expr>, fn_name: &str) -> bool {
+    match &expr.node {
+        Expr::TailCall(data) => {
+            data.target == fn_name
+                || data
+                    .args
+                    .iter()
+                    .any(|a| expr_contains_self_call(a, fn_name))
+        }
+        Expr::FnCall(callee, args) => {
+            matches!(&callee.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == fn_name)
+                || expr_contains_self_call(callee, fn_name)
+                || args.iter().any(|a| expr_contains_self_call(a, fn_name))
+        }
+        Expr::Attr(obj, _) => expr_contains_self_call(obj, fn_name),
+        Expr::BinOp(_, l, r) => {
+            expr_contains_self_call(l, fn_name) || expr_contains_self_call(r, fn_name)
+        }
+        Expr::Neg(inner) | Expr::ErrorProp(inner) => expr_contains_self_call(inner, fn_name),
+        Expr::Match { subject, arms } => {
+            expr_contains_self_call(subject, fn_name)
+                || arms
+                    .iter()
+                    .any(|a| expr_contains_self_call(&a.body, fn_name))
+        }
+        Expr::Constructor(_, inner) => inner
+            .as_deref()
+            .is_some_and(|e| expr_contains_self_call(e, fn_name)),
+        Expr::InterpolatedStr(parts) => parts
+            .iter()
+            .any(|p| matches!(p, StrPart::Parsed(e) if expr_contains_self_call(e, fn_name))),
+        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
+            items.iter().any(|i| expr_contains_self_call(i, fn_name))
+        }
+        Expr::MapLiteral(entries) => entries.iter().any(|(k, v)| {
+            expr_contains_self_call(k, fn_name) || expr_contains_self_call(v, fn_name)
+        }),
+        Expr::RecordCreate { fields, .. } => fields
+            .iter()
+            .any(|(_, v)| expr_contains_self_call(v, fn_name)),
+        Expr::RecordUpdate { base, updates, .. } => {
+            expr_contains_self_call(base, fn_name)
+                || updates
+                    .iter()
+                    .any(|(_, v)| expr_contains_self_call(v, fn_name))
+        }
+        Expr::Literal(_) | Expr::Ident(_) | Expr::Resolved { .. } => false,
+    }
 }
 
 fn strip_match_eq_binders(body: String) -> String {

--- a/src/codegen/lean/toplevel/fuel.rs
+++ b/src/codegen/lean/toplevel/fuel.rs
@@ -585,7 +585,9 @@ fn emit_simple_string_pos_stability_lemma(
     ))
 }
 
-fn detect_simple_string_pos_skip_literal(fd: &FnDef) -> Option<String> {
+pub(in crate::codegen::lean) fn detect_simple_string_pos_skip_literal(
+    fd: &FnDef,
+) -> Option<String> {
     if fd.params.len() != 2 {
         return None;
     }
@@ -706,7 +708,18 @@ fn is_string_char_at(expr: &Spanned<Expr>, s_name: &str, pos_name: &str) -> bool
 }
 
 fn expr_is_ident(expr: &Spanned<Expr>, name: &str) -> bool {
-    matches!(&expr.node, Expr::Ident(n) if n == name)
+    // Accept both raw `Ident` (pre-resolution, e.g. the recursion
+    // classifier) and the resolver's `Resolved { name, .. }` slot form
+    // (fn bodies at proof-emit time are resolved in place). Without the
+    // `Resolved` arm this shape detection silently declines on every
+    // emit-time body — the reason the graduation gate and the #643
+    // stability gate previously depended on the string `_from_body`
+    // fallback.
+    match &expr.node {
+        Expr::Ident(n) => n == name,
+        Expr::Resolved { name: n, .. } => n == name,
+        _ => false,
+    }
 }
 
 fn expr_is_self_pos_plus_one_tailcall(
@@ -719,6 +732,7 @@ fn expr_is_self_pos_plus_one_tailcall(
         Expr::TailCall(data) => (&data.target, &data.args),
         Expr::FnCall(callee, args) => match &callee.node {
             Expr::Ident(name) => (name, args),
+            Expr::Resolved { name, .. } => (name, args),
             _ => return false,
         },
         _ => return false,

--- a/src/codegen/lean/toplevel/mod.rs
+++ b/src/codegen/lean/toplevel/mod.rs
@@ -1,6 +1,6 @@
 /// Top-level Aver items → Lean 4 items (defs, inductives, structures, examples).
 mod fn_def;
-mod fuel;
+pub(in crate::codegen::lean) mod fuel;
 mod lex_list;
 mod render;
 mod type_def;

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -1601,3 +1601,85 @@ fn proof_lean_multi_literal_string_pos_skipper_graduates_native_kernel_clean() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_mixed_advance_skipper_stays_fueled_stability_lemma_kernel_clean() {
+    // Divergence pin: after the graduation gate was tightened to a fail-closed
+    // recognizer, a skip scanner mixing the exact `self(s, pos + 1)` advance
+    // with a NON-unit `self(s, pos + 2)` arm no longer graduates — a native
+    // `def` cannot sorry-floor its `decreasing_by`, so an unclassifiable step
+    // shape must never reach native emission — and stays FUELED. The #643
+    // fuel-stability gate is deliberately looser than graduation (it
+    // re-recognizes the fueled body from its emitted text), so a `__fuel`
+    // wrapper AND its `_stable` lemma are still emitted here even though
+    // graduation declined. The build MUST stay kernel-clean: it succeeds with
+    // NO hard error and NO false theorem (`model_panicked: false`). The
+    // `_stable` skeleton is pos+1-uniform, so on the mixed step it degrades to
+    // its designed fail-soft `sorry` floor (uncited by any law, so no universal
+    // credit is tainted); under `--sorry-budget 1` the check passes.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping mixed-advance fueled-stability test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-mixed-advance-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        "module MixedAdvance\n    effects []\n\n\
+         fn skipMixed(s: String, pos: Int) -> Int\n    match String.charAt(s, pos)\n        Option.None -> pos\n        Option.Some(c) -> match c\n            \" \" -> skipMixed(s, pos + 1)\n            \"x\" -> skipMixed(s, pos + 2)\n            _ -> pos\n\n\
+         verify skipMixed\n    skipMixed(\"\", 0) => 0\n    skipMixed(\"  a\", 0) => 2\n",
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-mixed-advance-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .arg("--sorry-budget")
+        .arg("1")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean =
+        std::fs::read_to_string(out.join("MixedAdvance.lean")).expect("read MixedAdvance.lean");
+    // Fueled, NOT graduated: a `__fuel` wrapper + `_stable` lemma, and no native
+    // `def` termination_by / bounds-lemma citation.
+    assert!(
+        lean.contains("def skipMixed__fuel") && lean.contains("theorem skipMixed__fuel_stable"),
+        "the mixed-advance skipper must stay fueled with a stability lemma:\n{lean}"
+    );
+    assert!(
+        !lean.contains("String.charAt_some_bounds")
+            && !lean.contains("termination_by (s.toList.length - pos.toNat)"),
+        "the mixed-advance skipper must NOT graduate to a native def:\n{lean}"
+    );
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with("{")))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    // Kernel-clean in the soundness sense: build succeeds (no hard error), no
+    // model panic (no vacuous/false certification). The single `sorry` is the
+    // uncited `_stable` fail-soft floor, absorbed by the budget.
+    assert_eq!(
+        (
+            summary["build_errors"].as_u64(),
+            summary["model_panicked"].as_bool(),
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+        ),
+        (Some(0), Some(false), Some(true), Some(1)),
+        "the fueled mixed-advance skipper must build clean with only the fail-soft _stable sorry.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -1516,29 +1516,35 @@ verify ledgerWithinCeiling law nonstrictChainWitness
 }
 
 #[test]
-fn proof_lean_multi_literal_string_pos_skipper_stability_lemma_kernel_clean() {
-    // Regression net for the fuel-stability lemma on a MULTI-literal string-position
-    // skipper — the json `skipWs` shape (four whitespace chars all recursing to
-    // `self(s, pos+1)`, rankBudget 1). The first synthesized skeleton only handled a
-    // single skip literal and hard-failed this shape with `unsolved goals` (`case neg`
-    // could not close the residual `match … skipWs__fuel fuel …  = match … skipWs__fuel
-    // measure' …`). The robust skeleton is literal-COUNT agnostic, so the lemma must
-    // kernel-prove with NO sorry, and the whole project must build clean.
+fn proof_lean_multi_literal_string_pos_skipper_graduates_native_kernel_clean() {
+    // Graduation kernel net for the MULTI-literal string-position skipper — the
+    // json `skipWs` shape (four whitespace chars all recursing to `self(s,
+    // pos+1)`, rankBudget 1). It now emits as a native fuel-free `def` with a
+    // `termination_by (s.length - pos)` measure whose `decreasing_by` cites the
+    // prelude `String.charAt_some_bounds`. Because Lean derives a real
+    // `skipWs.induct`, a genuine UNIVERSAL progress law `∀ s pos, skipWs s pos
+    // >= pos` closes through the `fun_induction` rung. All of it must kernel-
+    // prove with NO sorry and NO hard build error (the well-founded `def` cannot
+    // sorry-floor its termination, so a failed `decreasing_by` would be a hard
+    // error here — this test is the floor). Replaces the pre-graduation
+    // fuel-stability-lemma net: the `__fuel` wrapper and its `_stable` lemma are
+    // gone (native `.induct` is strictly stronger).
     if Command::new("lake").arg("--version").output().is_err() {
-        eprintln!("skipping multi-literal skipper stability test: `lake` not available");
+        eprintln!("skipping multi-literal skipper graduation test: `lake` not available");
         return;
     }
     let aver_bin = env!("CARGO_BIN_EXE_aver");
-    let src = temp_output_dir("aver-skipws-stable-src");
+    let src = temp_output_dir("aver-skipws-native-src");
     std::fs::create_dir_all(&src).expect("create src dir");
     std::fs::write(
         src.join("m.av"),
-        "module SkipWsFuel\n    effects []\n\n\
+        "module SkipWsNative\n    effects []\n\n\
          fn skipWs(s: String, pos: Int) -> Int\n    match String.charAt(s, pos)\n        Option.None -> pos\n        Option.Some(c) -> match c\n            \" \" -> skipWs(s, pos + 1)\n            \"\\t\" -> skipWs(s, pos + 1)\n            \"\\n\" -> skipWs(s, pos + 1)\n            \"\\r\" -> skipWs(s, pos + 1)\n            _ -> pos\n\n\
-         verify skipWs\n    skipWs(\"\", 0) => 0\n    skipWs(\"  abc\", 0) => 2\n    skipWs(\"\\tabc\", 0) => 1\n",
+         verify skipWs\n    skipWs(\"\", 0) => 0\n    skipWs(\"  abc\", 0) => 2\n    skipWs(\"\\tabc\", 0) => 1\n\n\
+         verify skipWs law progress\n    given s: String = [\"\", \"  x\"]\n    given pos: Int = [0, 1]\n    skipWs(s, pos) >= pos holds\n",
     )
     .expect("write m.av");
-    let out = temp_output_dir("aver-skipws-stable-out");
+    let out = temp_output_dir("aver-skipws-native-out");
     let run = Command::new(aver_bin)
         .arg("proof")
         .arg(src.join("m.av"))
@@ -1552,16 +1558,23 @@ fn proof_lean_multi_literal_string_pos_skipper_stability_lemma_kernel_clean() {
         .arg("0")
         .output()
         .expect("expected `aver proof --check --check-json` to run");
-    let lean = std::fs::read_to_string(out.join("SkipWsFuel.lean")).expect("read SkipWsFuel.lean");
-    // The stability lemma must be emitted (the multi-literal skip shape is gated in)
-    // and floored fail-soft (`first | (…) | sorry`).
+    let lean =
+        std::fs::read_to_string(out.join("SkipWsNative.lean")).expect("read SkipWsNative.lean");
+    // Native fuel-free graduation: a real `def` + `termination_by`, NO fuel
+    // wrapper, NO stability lemma.
     assert!(
-        lean.contains("theorem skipWs__fuel_stable :"),
-        "the multi-literal string-position skipper must get a stability lemma:\n{lean}"
+        lean.contains("def skipWs (s : String) (pos : Int) : Int :=")
+            && lean.contains("termination_by (s.toList.length - pos.toNat)"),
+        "the multi-literal skipper must graduate to a native def:\n{lean}"
     );
     assert!(
-        lean.contains("  first\n") && lean.contains("\n  | sorry"),
-        "the stability lemma must be floored `first | (…) | sorry`:\n{lean}"
+        !lean.contains("def skipWs__fuel") && !lean.contains("skipWs__fuel_stable"),
+        "graduated skipper must NOT emit a fuel wrapper or stability lemma:\n{lean}"
+    );
+    // The universal progress law closes on the derived `.induct`.
+    assert!(
+        lean.contains("skipWs_law_progress universal") && lean.contains("fun_induction skipWs"),
+        "the universal progress law must close via the fun_induction rung:\n{lean}"
     );
     let json_line = run
         .stdout
@@ -1571,18 +1584,18 @@ fn proof_lean_multi_literal_string_pos_skipper_stability_lemma_kernel_clean() {
         .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
     let summary: serde_json::Value =
         serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
-    // passed + zero sorries together certify: the lemma did NOT fall to its sorry
-    // floor (`sorries == 0`) and `lake build` genuinely closed it (`passed`), i.e.
-    // the robust skeleton kernel-proves the multi-literal case — no `unsolved goals`.
+    // passed + zero sorries + zero build errors + universal:true certify the
+    // native `def` termination discharged, the universal law closed on
+    // `.induct`, and nothing fell to a sorry floor or aborted the build.
     assert_eq!(
         (
             summary["passed"].as_bool(),
             summary["sorries"].as_u64(),
             summary["build_errors"].as_u64(),
+            summary["universal"].as_bool(),
         ),
-        (Some(true), Some(0), Some(0)),
-        "the multi-literal skipper stability lemma must kernel-prove with no sorry and \
-         no hard build error.\n{}",
+        (Some(true), Some(0), Some(0), Some(true)),
+        "the graduated skipper + universal progress law must kernel-prove clean.\n{}",
         format_output(&run)
     );
     let _ = std::fs::remove_dir_all(&src);


### PR DESCRIPTION
## What

The termination classifier already computes the descent measure for skip-style string scanners, yet the emitter always wrapped them in fuel, so Lean never derived a usable induction principle and ~1.7k LOC of bespoke roundtrip families compensate downstream. Simple single-function skip scanners now emit as native defs with the classifier's measure (termination_by + a new demand-driven core prelude bounds lemma), which makes the existing functional-induction rung fire: a genuine universal progress law closes on the kernel where the fuelized form was stuck. Mutual parser cliques stay fueled by design (governed by the banked group-stability walls).

## Safety of the gate

A native def cannot sorry-floor its termination, so the graduation gate is fail-closed: every match arm must be affirmatively classified (guarded unit-advance self-call or terminal), the outer match must be exactly the charAt some/none pair, and the discriminant-binder injection asserts it applied exactly once — anything else stays fueled. The adversarial panel confirmed the first draft's gate was fail-open with a reachable hard error (a redundant-wildcard scanner failed the whole build) and two latent modes; all are foreclosed and pinned by hostile fixtures (mixed advance, non-advancing, helper-routed, wildcard — each declines and builds).

## Measured along the way

- IntAscending scanners do NOT graduate (banked with an omega counterexample: the equality guard yields disequality, not a bound) — they stay fueled, honestly.
- A soundness-floor gap found and fixed: blind simp over a well-founded def's equation lemmas hard-aborts past the sorry floor; law cones containing a graduated scanner now drive .induct instead.
- The #643 stability-lemma emission survives for shapes that fail the tightened gate, pinned by a new divergence fixture; the fully-subsumed 71-LOC single-fn path plus ~1.6k LOC of roundtrip families are named for follow-up deletion, not touched here.

## Gates

lib 932; proof_spec lean_kernel 24 / check_gates 19 / floor_window 15 / container_induction 7, serialized; byte-golden; guardrails; clippy both feature sets; fmt; json.av baseline held verbatim (19 bounded / 10 universal) with its whitespace skipper now native; K5 round.av byte-identical to main.