### PR TITLE
Admit laws-as-lemmas by citation closure over emission topology

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -35,6 +35,8 @@ use sampled::emit_guarded_domain_law;
 /// the `(module_prefix, theorem_base)` dep-law theorems some consumer law
 /// admits, so the emitter writes ONLY those into the build.
 pub(crate) use induction::admitted_dep_law_theorems;
+#[cfg(debug_assertions)]
+pub(crate) use induction::dep_theorem_order_keys;
 
 /// `emit_verify_law_block` reads this to decide whether a `when`-law's theorem
 /// statement should drop its sampled-domain disjunctions (`omit_domain`) and be

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -544,6 +544,106 @@ fn dep_law_admissible(
     }
 }
 
+/// Name-blind citation-closure over the acyclic module DAG. Admits every
+/// dep-module law theorem some consumer law's proof CITES whose subject fn sits
+/// OUTSIDE that consumer's call cone — the citations the structural
+/// `dep_law_admissible` cone gate above cannot reach. The citation edges of each
+/// rung are read from its shape-keyed `cited_deps` recognizer (`cited` below),
+/// unioned in one dispatcher; scanning EVERY entry and dep-module law as a
+/// consumer closes over multi-hop chains (a dep law cited by another dep law is
+/// itself scanned), so this subsumes the per-family manual injection loops that
+/// used to hand-list one rung's citations each.
+///
+/// Subject to the emission-topology guard: a dep-module theorem is admissible
+/// only when it is emitted strictly BEFORE the citing law — an earlier module,
+/// or the same module at an earlier source line (`order`, keyed on the same
+/// `(module_index, source_line)` the emit iterates in). FAIL-CLOSED: a citation
+/// to a later-emitted theorem is dropped, so the citing proof then fails to
+/// compile and earns no universal credit, exactly as an unmet forward
+/// dependency should. A cited pair the recognizer resolved that is not a tracked
+/// dep-module law theorem (absent from `order`) is trusted as the recognizer
+/// reported it.
+///
+/// Empty when there are no dep modules (single-file path) → byte-identical to
+/// the pre-feature output.
+fn cited_closure_dep_laws(
+    ctx: &CodegenContext,
+    admitted: &mut std::collections::HashSet<(String, String)>,
+) {
+    use crate::ast::{TopLevel, VerifyKind};
+    use crate::codegen::lean::toplevel::{law_as_lemma_statement, law_theorem_base};
+    use std::collections::HashMap;
+    // Emit order ranks dep modules by their index in `ctx.modules` and laws
+    // within a module by source line; entry laws are emitted AFTER every module,
+    // so they rank last (ENTRY_RANK) and may cite any dep.
+    const ENTRY_RANK: usize = usize::MAX;
+
+    // Every dep-module law theorem → its `(module_index, source_line)` emit-order
+    // key, under both spellings of its base a consumer might key on (the
+    // canonical `<fn>_law_<name>` and the law-as-lemma rewrite base the emit
+    // admission uses). The topology guard compares against this.
+    let mut order: HashMap<(String, String), (usize, usize)> = HashMap::new();
+    for (mi, module) in ctx.modules.iter().enumerate() {
+        ctx.with_module_scope(Some(module.prefix.as_str()), || {
+            for vb in &module.verify_laws {
+                let VerifyKind::Law(law) = &vb.kind else {
+                    continue;
+                };
+                let key = (mi, vb.line);
+                let canonical = law_theorem_base(vb, law, ctx);
+                order
+                    .entry((module.prefix.clone(), canonical))
+                    .or_insert(key);
+                if let Some((rewrite, _)) = law_as_lemma_statement(vb, law, ctx) {
+                    order.entry((module.prefix.clone(), rewrite)).or_insert(key);
+                }
+            }
+        });
+    }
+    if order.is_empty() {
+        return;
+    }
+
+    // The citation edges of one consumer law: the union of every rung's shape-
+    // keyed `cited_deps` recognizer. Each names the dep-module theorems that
+    // rung's proof cites whose subject fn is outside the consumer's call cone.
+    // Adding a rung — or folding a per-family injection loop into the closure —
+    // means adding it here: one dispatcher, not a new injection loop. Pure: the
+    // recognizers key on the claim's AST shape, never emit.
+    fn cited(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenContext) -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        out.extend(super::triangle_sum_cited_deps(vb, law, ctx));
+        out
+    }
+
+    let mut admit =
+        |scope: Option<&str>, vb: &VerifyBlock, law: &VerifyLaw, consumer_key: (usize, usize)| {
+            for dep in ctx.with_module_scope(scope, || cited(vb, law, ctx)) {
+                // Fail-closed on a provably-later dep-module theorem; trust the
+                // recognizer for anything not tracked in `order`.
+                if order.get(&dep).is_none_or(|k| *k < consumer_key) {
+                    admitted.insert(dep);
+                }
+            }
+        };
+
+    for item in &ctx.items {
+        let TopLevel::Verify(vb) = item else { continue };
+        let VerifyKind::Law(law) = &vb.kind else {
+            continue;
+        };
+        admit(None, vb, law, (ENTRY_RANK, vb.line));
+    }
+    for (mi, module) in ctx.modules.iter().enumerate() {
+        for vb in &module.verify_laws {
+            let VerifyKind::Law(law) = &vb.kind else {
+                continue;
+            };
+            admit(Some(module.prefix.as_str()), vb, law, (mi, vb.line));
+        }
+    }
+}
+
 /// Program-wide set of `(module_prefix, theorem_base)` dep-law theorems
 /// that SOME consumer law admits into its pool — the EMIT-side gate. A
 /// dep law is emitted into the build ONLY if it is in this set; an
@@ -629,22 +729,15 @@ pub(crate) fn admitted_dep_law_theorems(
         }
     }
 
-    // Triangle-sum consumers: the rung CITES two rounding bound universals
-    // (`awayFracErrorBound` / `truncFracErrorBound`) whose statements mention
-    // dep fns OUTSIDE the consumer law's cone (the consumer never calls the
-    // bound predicate itself), so the structural `dep_law_admissible` gate above
-    // does not reach them. The rung knows exactly which bound laws it cites, so
-    // admit those directly — keyed on the SAME recognizer the emit uses, so the
-    // cited theorem is emitted iff the proof that cites it is.
-    for item in &ctx.items {
-        let TopLevel::Verify(vb) = item else { continue };
-        let VerifyKind::Law(law) = &vb.kind else {
-            continue;
-        };
-        for dep in super::triangle_sum_cited_deps(vb, law, ctx) {
-            admitted.insert(dep);
-        }
-    }
+    // Generic citation-closure: admit every dep-module law theorem a consumer
+    // law's rung CITES whose subject fn is outside the consumer's cone —
+    // topology-guarded, over every entry and dep-module law. Replaces the
+    // per-family manual dep injections; the triangle-sum rounding bounds
+    // (`awayFracErrorBound` / `truncFracErrorBound`) used to be hand-listed here
+    // because their subject fns sit OUTSIDE the consumer law's cone, so the
+    // structural `dep_law_admissible` gate above never reaches them. See
+    // `cited_closure_dep_laws`.
+    cited_closure_dep_laws(ctx, &mut admitted);
 
     // Rational-order chaining consumers: the rung CITES the signed power-of-two
     // monotonicity + homomorphism pool laws (whose subject fns are NOT in the

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -613,6 +613,10 @@ fn cited_closure_dep_laws(
     fn cited(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenContext) -> Vec<(String, String)> {
         let mut out = Vec::new();
         out.extend(super::triangle_sum_cited_deps(vb, law, ctx));
+        out.extend(super::frac_order_chain_cited_deps(vb, law, ctx));
+        out.extend(super::frac_monotone_compose_cited_deps(vb, law, ctx));
+        out.extend(super::monotone_reflect_cited_deps(vb, law, ctx));
+        out.extend(keystone::keystone_dep_bridge_cites(vb, law, ctx));
         out
     }
 
@@ -738,100 +742,6 @@ pub(crate) fn admitted_dep_law_theorems(
     // structural `dep_law_admissible` gate above never reaches them. See
     // `cited_closure_dep_laws`.
     cited_closure_dep_laws(ctx, &mut admitted);
-
-    // Rational-order chaining consumers: the rung CITES the signed power-of-two
-    // monotonicity + homomorphism pool laws (whose subject fns are NOT in the
-    // consumer law's call cone — the consumer only calls `pow2Signed`, never the
-    // monotonicity/homomorphism predicate), so the structural gate above does
-    // not reach them. The rung knows exactly which laws it cites, so admit them
-    // directly — keyed on the SAME recognizer the emit uses, so the cited
-    // theorem is emitted iff the proof that cites it is.
-    for item in &ctx.items {
-        let TopLevel::Verify(vb) = item else { continue };
-        let VerifyKind::Law(law) = &vb.kind else {
-            continue;
-        };
-        for dep in super::frac_order_chain_cited_deps(vb, law, ctx) {
-            admitted.insert(dep);
-        }
-    }
-
-    // Exact-rational monotonicity / at-least-one / positivity laws: each CITES
-    // its module's homomorphism / positivity / `>= 1` / recursive-positivity
-    // sibling laws (whose subject fns are NOT in its call cone), so the structural
-    // gate does not reach them. A dependency export must carry the whole citation
-    // chain for the monotonicity theorem to close, so admit them directly — run
-    // under the dep module's scope so the recognizers resolve its fns and laws.
-    for module in &ctx.modules {
-        ctx.with_module_scope(Some(module.prefix.as_str()), || {
-            for vb in &module.verify_laws {
-                let VerifyKind::Law(law) = &vb.kind else {
-                    continue;
-                };
-                for dep in super::frac_monotone_compose_cited_deps(vb, law, ctx) {
-                    admitted.insert(dep);
-                }
-            }
-        });
-    }
-
-    // Strict-order reflection consumers: the rung CITES monotonicity and
-    // denominator-positivity sibling laws that are not necessarily in the
-    // consumer's call cone. Denominator-positivity itself cites the broader
-    // positivity law. Admit exactly those discovered dependencies under the dep
-    // module's scope, keyed on the same recognizers as the emitter. Entry laws
-    // can also cite an exposed dependency bridge theorem directly (for example a
-    // magnitude-bracket law over a dep's unary Fraction cone), so scan them too.
-    for item in &ctx.items {
-        let TopLevel::Verify(vb) = item else { continue };
-        let VerifyKind::Law(law) = &vb.kind else {
-            continue;
-        };
-        for dep in super::monotone_reflect_cited_deps(vb, law, ctx) {
-            admitted.insert(dep);
-        }
-    }
-    for module in &ctx.modules {
-        ctx.with_module_scope(Some(module.prefix.as_str()), || {
-            for vb in &module.verify_laws {
-                let VerifyKind::Law(law) = &vb.kind else {
-                    continue;
-                };
-                for dep in super::monotone_reflect_cited_deps(vb, law, ctx) {
-                    admitted.insert(dep);
-                }
-            }
-        });
-    }
-
-    // Keystone finite-domain composition consumers: the keystone's `grind`
-    // cites a dependency conditional-bridge law (`nonNegOfPositive`) to discharge
-    // a cited interval law's nonneg premise from the supplier's positivity
-    // conjunct. The bridge's hypothesis fn is reachable only through a cited
-    // supplier, so the structural gate above does not reach it; the keystone
-    // names it directly, keyed on the SAME recognizer the emit cites, so the dep
-    // theorem is emitted iff the proof that cites it is.
-    for item in &ctx.items {
-        let TopLevel::Verify(vb) = item else { continue };
-        let VerifyKind::Law(law) = &vb.kind else {
-            continue;
-        };
-        for dep in keystone::keystone_dep_bridge_cites(vb, law, ctx) {
-            admitted.insert(dep);
-        }
-    }
-    for module in &ctx.modules {
-        ctx.with_module_scope(Some(module.prefix.as_str()), || {
-            for vb in &module.verify_laws {
-                let VerifyKind::Law(law) = &vb.kind else {
-                    continue;
-                };
-                for dep in keystone::keystone_dep_bridge_cites(vb, law, ctx) {
-                    admitted.insert(dep);
-                }
-            }
-        });
-    }
 
     admitted
 }

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -564,6 +564,28 @@ fn dep_law_admissible(
 /// dep-module law theorem (absent from `order`) is trusted as the recognizer
 /// reported it.
 ///
+/// SCANNING ALL CONSUMERS IS SAFE (panel NOTE, chose: document over gating).
+/// The consumer loop scans EVERY entry and dep-module law, including a dep-module
+/// law that no other law admits and that is therefore itself never emitted. It
+/// deliberately does NOT gate the consumer on membership in `admitted`, for two
+/// reasons:
+///   1. Multi-hop closure in a single pass. A dep `D` cited by dep `C` cited by
+///      the entry must be admitted even though, at the moment `C` is scanned, `C`
+///      may not yet be in `admitted` (scan order is source order, not dependency
+///      order). Gating on `admitted` would drop such chains unless the whole scan
+///      were re-run to a fixpoint — real added complexity to remove a bounded,
+///      already-safe over-approximation.
+///   2. Over-admission is fail-closed and sound. The set only ever GROWS, so no
+///      genuinely-needed citation is lost. An extra admitted dep theorem is
+///      emitted under the same `first | <tactic> | sorry` floor as any law: if it
+///      proves it contributes zero sorries; if it does not, its caught `sorry`
+///      counts against the PROGRAM-WIDE sorry budget and trips `passed:false`. So
+///      the worst case of scanning a never-emitted consumer is a spurious build
+///      FAILURE, never false universal credit — credit still rides only on each
+///      cited theorem's own kernel certificate. (In the K5 corpus the admitted
+///      set is byte-identical to the pre-closure per-family injections, so this
+///      over-approximation is empty in practice.)
+///
 /// Empty when there are no dep modules (single-file path) → byte-identical to
 /// the pre-feature output.
 fn cited_closure_dep_laws(
@@ -571,35 +593,15 @@ fn cited_closure_dep_laws(
     admitted: &mut std::collections::HashSet<(String, String)>,
 ) {
     use crate::ast::{TopLevel, VerifyKind};
-    use crate::codegen::lean::toplevel::{law_as_lemma_statement, law_theorem_base};
-    use std::collections::HashMap;
     // Emit order ranks dep modules by their index in `ctx.modules` and laws
     // within a module by source line; entry laws are emitted AFTER every module,
     // so they rank last (ENTRY_RANK) and may cite any dep.
     const ENTRY_RANK: usize = usize::MAX;
 
-    // Every dep-module law theorem → its `(module_index, source_line)` emit-order
-    // key, under both spellings of its base a consumer might key on (the
-    // canonical `<fn>_law_<name>` and the law-as-lemma rewrite base the emit
-    // admission uses). The topology guard compares against this.
-    let mut order: HashMap<(String, String), (usize, usize)> = HashMap::new();
-    for (mi, module) in ctx.modules.iter().enumerate() {
-        ctx.with_module_scope(Some(module.prefix.as_str()), || {
-            for vb in &module.verify_laws {
-                let VerifyKind::Law(law) = &vb.kind else {
-                    continue;
-                };
-                let key = (mi, vb.line);
-                let canonical = law_theorem_base(vb, law, ctx);
-                order
-                    .entry((module.prefix.clone(), canonical))
-                    .or_insert(key);
-                if let Some((rewrite, _)) = law_as_lemma_statement(vb, law, ctx) {
-                    order.entry((module.prefix.clone(), rewrite)).or_insert(key);
-                }
-            }
-        });
-    }
+    // The `(module_prefix, theorem_base)` → `(module_index, source_line)` emit
+    // order map every cited dep is looked up against by the topology guard.
+    // Shared with the emit gate's `debug_assert` via `dep_theorem_order_keys`.
+    let order = dep_theorem_emit_order(ctx);
     if order.is_empty() {
         return;
     }
@@ -652,11 +654,71 @@ fn cited_closure_dep_laws(
 /// totally orders every law theorem. A citation is admissible only when the
 /// cited theorem is emitted strictly BEFORE the citing law: an earlier module,
 /// or the same module at an earlier source line. FAIL-CLOSED on a provably-
-/// later citation (a forward reference the kernel would reject). A dep the
-/// recognizer resolved that is not a tracked dep-module theorem (`None`) is
-/// trusted as reported.
+/// later citation (a forward reference the kernel would reject).
+///
+/// The `None` branch (a cited dep absent from the order map) is trusted as
+/// reported. This is sound ONLY under the subset invariant `dep_theorem_emit_order`
+/// documents: every REAL dep-module law theorem is a key of the order map, so a
+/// `None` lookup can only mean the recognizer resolved a citation to something
+/// that is NOT a tracked dep-module theorem (an `AverCommon`/import name the emit
+/// gate never emits and never topology-orders). Were that invariant to break, a
+/// genuinely later-emitted dep theorem could read as `None` and be trusted —
+/// fail-OPEN. The emit gate's `debug_assert` (see `dep_theorem_order_keys`) is
+/// the tripwire for exactly that drift.
 fn topology_admits(dep_order: Option<&(usize, usize)>, consumer_order: (usize, usize)) -> bool {
     dep_order.is_none_or(|dep| *dep < consumer_order)
+}
+
+/// Every dep-module law theorem → its `(module_index, source_line)` emit-order
+/// key, under BOTH base spellings a consumer might key on: the canonical
+/// `law_theorem_base` (`<fn>_law_<name>` or `<fn>_eq_<spec>`) and, when the law
+/// states as a plain rewrite, the `law_as_lemma_statement` base. Built per module
+/// under that module's own scope over `module.verify_laws` — the SAME two fns,
+/// scope, and law set the `transpile` dep-law emit gate computes each law's emit
+/// key from.
+///
+/// SUBSET INVARIANT: because both are computed the same way, every key the emit
+/// gate can produce for a dep-module law is a key of this map. `topology_admits`'
+/// `None` branch relies on it (a real dep theorem is never absent here), and the
+/// emit gate's `debug_assert` checks it.
+fn dep_theorem_emit_order(
+    ctx: &CodegenContext,
+) -> std::collections::HashMap<(String, String), (usize, usize)> {
+    use crate::ast::VerifyKind;
+    use crate::codegen::lean::toplevel::{law_as_lemma_statement, law_theorem_base};
+    let mut order: std::collections::HashMap<(String, String), (usize, usize)> =
+        std::collections::HashMap::new();
+    for (mi, module) in ctx.modules.iter().enumerate() {
+        ctx.with_module_scope(Some(module.prefix.as_str()), || {
+            for vb in &module.verify_laws {
+                let VerifyKind::Law(law) = &vb.kind else {
+                    continue;
+                };
+                let key = (mi, vb.line);
+                let canonical = law_theorem_base(vb, law, ctx);
+                order
+                    .entry((module.prefix.clone(), canonical))
+                    .or_insert(key);
+                if let Some((rewrite, _)) = law_as_lemma_statement(vb, law, ctx) {
+                    order.entry((module.prefix.clone(), rewrite)).or_insert(key);
+                }
+            }
+        });
+    }
+    order
+}
+
+/// The keyset of `dep_theorem_emit_order`: the `(module_prefix, theorem_base)`
+/// keys the emission-topology guard tracks. Exposed so the `transpile` dep-law
+/// emit gate can `debug_assert` the subset invariant — that every dep-module law
+/// it is about to consider is one the topology guard could see — which is what
+/// keeps `topology_admits`' `None`-is-trusted branch fail-CLOSED rather than
+/// fail-open. Debug-only consumer; computed once per emit pass.
+#[cfg(debug_assertions)]
+pub(crate) fn dep_theorem_order_keys(
+    ctx: &CodegenContext,
+) -> std::collections::HashSet<(String, String)> {
+    dep_theorem_emit_order(ctx).into_keys().collect()
 }
 
 /// Program-wide set of `(module_prefix, theorem_base)` dep-law theorems

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -623,9 +623,7 @@ fn cited_closure_dep_laws(
     let mut admit =
         |scope: Option<&str>, vb: &VerifyBlock, law: &VerifyLaw, consumer_key: (usize, usize)| {
             for dep in ctx.with_module_scope(scope, || cited(vb, law, ctx)) {
-                // Fail-closed on a provably-later dep-module theorem; trust the
-                // recognizer for anything not tracked in `order`.
-                if order.get(&dep).is_none_or(|k| *k < consumer_key) {
+                if topology_admits(order.get(&dep), consumer_key) {
                     admitted.insert(dep);
                 }
             }
@@ -646,6 +644,19 @@ fn cited_closure_dep_laws(
             admit(Some(module.prefix.as_str()), vb, law, (mi, vb.line));
         }
     }
+}
+
+/// Emission-topology guard for a cited dep-module theorem. Emit order is dep
+/// modules in `ctx.modules` order, laws within a module in source order, and
+/// entry laws after every module — so an `(module_index, source_line)` key
+/// totally orders every law theorem. A citation is admissible only when the
+/// cited theorem is emitted strictly BEFORE the citing law: an earlier module,
+/// or the same module at an earlier source line. FAIL-CLOSED on a provably-
+/// later citation (a forward reference the kernel would reject). A dep the
+/// recognizer resolved that is not a tracked dep-module theorem (`None`) is
+/// trusted as reported.
+fn topology_admits(dep_order: Option<&(usize, usize)>, consumer_order: (usize, usize)) -> bool {
+    dep_order.is_none_or(|dep| *dep < consumer_order)
 }
 
 /// Program-wide set of `(module_prefix, theorem_base)` dep-law theorems
@@ -5043,5 +5054,38 @@ fn collect_simp_idents(line: &str, set: &mut BTreeSet<String>) {
             }
         }
         rest = &after[close + 1..];
+    }
+}
+
+#[cfg(test)]
+mod topology_tests {
+    use super::topology_admits;
+
+    // The emission-topology guard the citation-closure applies to every cited
+    // dep-module theorem. Order key is `(module_index, source_line)`; entry laws
+    // rank after every module (`usize::MAX`).
+    #[test]
+    fn cited_dep_admissible_only_when_emitted_before_consumer() {
+        const ENTRY: usize = usize::MAX;
+
+        // POSITIVE — the frac_monotone_compose.rs:716 class the old cone missed:
+        // an entry law citing a dep-module pool law (earlier module) is admitted.
+        assert!(topology_admits(Some(&(0, 40)), (ENTRY, 10)));
+        // Same module, cited sibling theorem at an EARLIER source line -> admitted
+        // (the in-module monotonicity/positivity sibling chain).
+        assert!(topology_admits(Some(&(2, 15)), (2, 80)));
+        // Strictly earlier module dominates the line -> admitted.
+        assert!(topology_admits(Some(&(1, 9999)), (3, 5)));
+        // A dep the recognizer resolved but that is not tracked -> trusted.
+        assert!(topology_admits(None, (2, 30)));
+
+        // NEGATIVE (fail-closed) — a citation to a theorem emitted AFTER the
+        // consumer is refused, so the forward reference never reaches the kernel:
+        // same module, cited law LATER in source than the consumer.
+        assert!(!topology_admits(Some(&(2, 90)), (2, 30)));
+        // A strictly LATER module.
+        assert!(!topology_admits(Some(&(4, 1)), (3, 500)));
+        // Self (same module and line): a law cannot cite itself as an earlier lemma.
+        assert!(!topology_admits(Some(&(2, 30)), (2, 30)));
     }
 }

--- a/src/codegen/lean/law_auto/triangle_sum.rs
+++ b/src/codegen/lean/law_auto/triangle_sum.rs
@@ -487,11 +487,16 @@ fn find_rounding_bound_law(ctx: &CodegenContext, want_away: bool) -> Option<Roun
             if kind != want_away {
                 continue;
             }
-            let base = format!(
-                "{}_law_{}",
-                aver_name_to_lean(&vb.fn_name),
-                aver_name_to_lean(&law.name)
-            );
+            // The dependency theorem's base name, via the SAME canonical fn the
+            // emit gate and citation-closure `order` map key on (under the
+            // candidate module's own scope, exactly as `order` is built). Using
+            // `law_theorem_base` picks up its `canonical_spec_ref` arm, so a
+            // bound law stated as an equational spec keys as `<fn>_eq_<spec>`
+            // rather than the raw `<fn>_law_<name>`; the four other cited-dep
+            // families already route through the canonical fns.
+            let base = ctx.with_module_scope(Some(module.prefix.as_str()), || {
+                crate::codegen::lean::toplevel::law_theorem_base(vb, law, ctx)
+            });
             return Some(RoundingBoundLaw {
                 prefix: module.prefix.clone(),
                 theorem_base: base.clone(),

--- a/src/codegen/lean/transpile.rs
+++ b/src/codegen/lean/transpile.rs
@@ -395,6 +395,11 @@ pub(super) fn transpile_unified(
     } else {
         std::collections::HashSet::new()
     };
+    // Subset-invariant tripwire (see `topology_admits`): every dep-module law's
+    // emit key must be a key the citation-closure's topology order tracks — the
+    // premise that keeps its `None`-is-trusted branch fail-closed. Debug-only.
+    #[cfg(debug_assertions)]
+    let dep_theorem_order_keys = super::law_auto::dep_theorem_order_keys(ctx);
 
     for module in &ctx.modules {
         let mut body_sections: Vec<String> = Vec::new();
@@ -465,6 +470,18 @@ pub(super) fn transpile_unified(
                     let base = toplevel::law_as_lemma_statement(vb, law_ref, ctx)
                         .map(|(base, _)| base)
                         .unwrap_or_else(|| toplevel::law_theorem_base(vb, law_ref, ctx));
+                    // This emit key is computed from the SAME two fns under the
+                    // SAME scope as the topology order map — so it must be one of
+                    // that map's keys. If it is not, the emit-key and order-key
+                    // computations have drifted and `topology_admits`' `None`
+                    // branch could silently fail open.
+                    debug_assert!(
+                        dep_theorem_order_keys.contains(&(module.prefix.clone(), base.clone())),
+                        "dep-law emit key {:?} is absent from the citation-closure topology \
+                         order map; the fail-closed forward-reference guard would degrade to \
+                         fail-open",
+                        (module.prefix.clone(), base.clone())
+                    );
                     if !admitted_dep_laws.contains(&(module.prefix.clone(), base)) {
                         continue;
                     }

--- a/tests/fixtures/citation_closure_forward_ref/forward/domain/frac.av
+++ b/tests/fixtures/citation_closure_forward_ref/forward/domain/frac.av
@@ -1,0 +1,31 @@
+module Frac
+    intent =
+        "Dep module: the geone law's cited positivity sibling sits LATER in source, so the citation would be a forward reference the emission-topology guard must refuse."
+    depends [Domain.Rational]
+    exposes [pow2, pow2Signed, pow2SignedAtLeastOne]
+    effects []
+
+fn pow2(n: Int) -> Int
+    ? "Two to the n for n >= 0, clamped to one for nonpositive n."
+    match n <= 0
+        true -> 1
+        false -> 2 * pow2(n - 1)
+
+fn pow2Signed(k: Int) -> Fraction
+    ? "The exact rational 2^k for any integer k."
+    match k < 0
+        true -> Domain.Rational.Fraction(top = 1, bottom = pow2(0 - k))
+        false -> Domain.Rational.Fraction(top = pow2(k), bottom = 1)
+
+fn pow2SignedAtLeastOne(k: Int) -> Bool
+    ? "The signed power of two is at least one for nonnegative exponents."
+    Domain.Rational.isNonNeg(Domain.Rational.minus(pow2Signed(k), Domain.Rational.oneFraction()))
+
+verify pow2SignedAtLeastOne law geOneFlip
+    given k: Int = [0, 1, 4]
+    when 0 <= k
+    pow2SignedAtLeastOne(k) holds
+
+verify pow2 law positive
+    given k: Int = [0, 1, 4]
+    pow2(k) >= 1 holds

--- a/tests/fixtures/citation_closure_forward_ref/forward/domain/rational.av
+++ b/tests/fixtures/citation_closure_forward_ref/forward/domain/rational.av
@@ -1,0 +1,29 @@
+module Rational
+    intent =
+        "Minimal exact-rational surface for the citation-closure topology fixture."
+    exposes [Fraction, oneFraction, times, minus, sameValue, isNonNeg]
+    effects []
+
+record Fraction
+    top: Int
+    bottom: Int
+
+fn oneFraction() -> Fraction
+    ? "The exact rational one."
+    Fraction(top = 1, bottom = 1)
+
+fn times(a: Fraction, b: Fraction) -> Fraction
+    ? "Non-normalizing rational multiplication."
+    Fraction(top = a.top * b.top, bottom = a.bottom * b.bottom)
+
+fn minus(a: Fraction, b: Fraction) -> Fraction
+    ? "Non-normalizing rational subtraction."
+    Fraction(top = a.top * b.bottom - b.top * a.bottom, bottom = a.bottom * b.bottom)
+
+fn sameValue(a: Fraction, b: Fraction) -> Bool
+    ? "Cross-multiplication equality."
+    a.top * b.bottom == b.top * a.bottom
+
+fn isNonNeg(a: Fraction) -> Bool
+    ? "Sign-robust nonnegative rational order."
+    a.top * a.bottom >= 0

--- a/tests/fixtures/citation_closure_forward_ref/forward/main.av
+++ b/tests/fixtures/citation_closure_forward_ref/forward/main.av
@@ -1,0 +1,14 @@
+module Main
+    intent =
+        "Entry that leans on the dep module's at-least-one fact."
+    depends [Domain.Frac, Domain.Rational]
+    effects []
+
+fn atLeastOne(k: Int) -> Bool
+    ? "Wrapper over the dep at-least-one fact."
+    Domain.Frac.pow2SignedAtLeastOne(k)
+
+verify atLeastOne law wrap
+    given k: Int = [0, 1, 4]
+    when 0 <= k
+    atLeastOne(k) holds

--- a/tests/fixtures/citation_closure_forward_ref/inorder/domain/frac.av
+++ b/tests/fixtures/citation_closure_forward_ref/inorder/domain/frac.av
@@ -1,0 +1,31 @@
+module Frac
+    intent =
+        "Dep module: the geone law's cited positivity sibling is emitted BEFORE it."
+    depends [Domain.Rational]
+    exposes [pow2, pow2Signed, pow2SignedAtLeastOne]
+    effects []
+
+fn pow2(n: Int) -> Int
+    ? "Two to the n for n >= 0, clamped to one for nonpositive n."
+    match n <= 0
+        true -> 1
+        false -> 2 * pow2(n - 1)
+
+verify pow2 law positive
+    given k: Int = [0, 1, 4]
+    pow2(k) >= 1 holds
+
+fn pow2Signed(k: Int) -> Fraction
+    ? "The exact rational 2^k for any integer k."
+    match k < 0
+        true -> Domain.Rational.Fraction(top = 1, bottom = pow2(0 - k))
+        false -> Domain.Rational.Fraction(top = pow2(k), bottom = 1)
+
+fn pow2SignedAtLeastOne(k: Int) -> Bool
+    ? "The signed power of two is at least one for nonnegative exponents."
+    Domain.Rational.isNonNeg(Domain.Rational.minus(pow2Signed(k), Domain.Rational.oneFraction()))
+
+verify pow2SignedAtLeastOne law geOneFlip
+    given k: Int = [0, 1, 4]
+    when 0 <= k
+    pow2SignedAtLeastOne(k) holds

--- a/tests/fixtures/citation_closure_forward_ref/inorder/domain/rational.av
+++ b/tests/fixtures/citation_closure_forward_ref/inorder/domain/rational.av
@@ -1,0 +1,29 @@
+module Rational
+    intent =
+        "Minimal exact-rational surface for the citation-closure topology fixture."
+    exposes [Fraction, oneFraction, times, minus, sameValue, isNonNeg]
+    effects []
+
+record Fraction
+    top: Int
+    bottom: Int
+
+fn oneFraction() -> Fraction
+    ? "The exact rational one."
+    Fraction(top = 1, bottom = 1)
+
+fn times(a: Fraction, b: Fraction) -> Fraction
+    ? "Non-normalizing rational multiplication."
+    Fraction(top = a.top * b.top, bottom = a.bottom * b.bottom)
+
+fn minus(a: Fraction, b: Fraction) -> Fraction
+    ? "Non-normalizing rational subtraction."
+    Fraction(top = a.top * b.bottom - b.top * a.bottom, bottom = a.bottom * b.bottom)
+
+fn sameValue(a: Fraction, b: Fraction) -> Bool
+    ? "Cross-multiplication equality."
+    a.top * b.bottom == b.top * a.bottom
+
+fn isNonNeg(a: Fraction) -> Bool
+    ? "Sign-robust nonnegative rational order."
+    a.top * a.bottom >= 0

--- a/tests/fixtures/citation_closure_forward_ref/inorder/main.av
+++ b/tests/fixtures/citation_closure_forward_ref/inorder/main.av
@@ -1,0 +1,14 @@
+module Main
+    intent =
+        "Entry that leans on the dep module's at-least-one fact."
+    depends [Domain.Frac, Domain.Rational]
+    effects []
+
+fn atLeastOne(k: Int) -> Bool
+    ? "Wrapper over the dep at-least-one fact."
+    Domain.Frac.pow2SignedAtLeastOne(k)
+
+verify atLeastOne law wrap
+    given k: Int = [0, 1, 4]
+    when 0 <= k
+    atLeastOne(k) holds

--- a/tests/proof_spec/cross_file.rs
+++ b/tests/proof_spec/cross_file.rs
@@ -629,3 +629,124 @@ fn cross_file_uncited_unproven_dep_law_no_sorry_inflation() {
         format_output(&run)
     );
 }
+
+// ---------------------------------------------------------------------------
+// EMISSION-TOPOLOGY GUARD (end-to-end). The citation-closure admits a cited
+// dep-module theorem only when it is emitted strictly BEFORE the citing law
+// (`topology_admits`). The pure comparator has a unit test in
+// `induction::topology_tests`; this drives the guarantee through the WHOLE
+// pipeline so a regression that keeps the comparator correct but breaks the
+// wiring (or the recognizer's own forward-sibling decline) is still caught.
+//
+// Two dep-module fixtures are byte-identical except for the source order of a
+// geone law and the recursive-positivity sibling it cites:
+//   * `inorder` — the sibling is emitted first: the citation is backward, so
+//     the geone law proves universally and genuinely cites `pow2_law_positive`.
+//   * `forward` — the sibling is emitted LATER: the citation would be a forward
+//     reference the kernel rejects, so it is refused. The geone law degrades to
+//     its pre-closure tier (no universal theorem, no citation), no forward
+//     reference reaches the `.lean`, and the build stays green.
+// The JSON summary is identical for both; the guarantee lives in the emitted
+// dep `.lean`, so the assertions read it back.
+// ---------------------------------------------------------------------------
+
+/// Run a `citation_closure_forward_ref` variant end-to-end and return the JSON
+/// summary, the raw `Output`, and the generated `Domain/Frac.lean`.
+fn run_forward_ref_variant(variant: &str) -> (serde_json::Value, std::process::Output, String) {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root = format!("tests/fixtures/citation_closure_forward_ref/{variant}");
+    let output_dir = temp_output_dir(&format!("aver-citation-closure-{variant}"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg(format!("{root}/main.av"))
+        .arg("--module-root")
+        .arg(&root)
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&output_dir)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected citation-closure topology fixture to run");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with('{')))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)))
+        .to_string();
+    let summary: serde_json::Value =
+        serde_json::from_str(&json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    let frac = std::fs::read_to_string(output_dir.join("Domain/Frac.lean"))
+        .expect("expected generated Domain/Frac.lean");
+    let _ = std::fs::remove_dir_all(&output_dir);
+    (summary, run, frac)
+}
+
+#[test]
+fn cross_file_forward_citation_is_refused_end_to_end() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping citation-closure topology end-to-end test: `lake` not available");
+        return;
+    }
+
+    // BASELINE (`inorder`): the cited sibling is emitted first, so the geone
+    // law proves universally and genuinely cites `pow2_law_positive` — AFTER
+    // that theorem's own definition (a backward reference). This is what makes
+    // the forward case's refusal non-vacuous: the citation edge really exists.
+    let (base_summary, base_run, base_frac) = run_forward_ref_variant("inorder");
+    assert_eq!(
+        (
+            base_summary["passed"].as_bool(),
+            base_summary["build_errors"].as_u64(),
+        ),
+        (Some(true), Some(0)),
+        "the in-order baseline must build green\n{}",
+        format_output(&base_run)
+    );
+    assert!(
+        base_frac.contains("-- aver:law-class pow2SignedAtLeastOne_law_geOneFlip universal"),
+        "baseline: the geone law must prove universally when its cited sibling \
+         is emitted first\nDomain/Frac.lean:\n{base_frac}"
+    );
+    let base_def = base_frac
+        .find("theorem pow2_law_positive ")
+        .expect("baseline: the positivity sibling theorem must be emitted");
+    let base_cite = base_frac
+        .find("have h := pow2_law_positive")
+        .expect("baseline: the geone proof must cite the positivity sibling");
+    assert!(
+        base_def < base_cite,
+        "baseline: the citation must be a BACKWARD reference — the sibling is \
+         defined before it is cited\nDomain/Frac.lean:\n{base_frac}"
+    );
+
+    // GUARANTEE (`forward`): the identical program with the cited sibling
+    // emitted LATER. The forward citation is refused — the geone law degrades
+    // to its pre-closure tier (no universal theorem, no citation), NO forward
+    // reference reaches `Frac.lean`, and the build stays green (never red).
+    let (fwd_summary, fwd_run, fwd_frac) = run_forward_ref_variant("forward");
+    assert_eq!(
+        (
+            fwd_summary["passed"].as_bool(),
+            fwd_summary["build_errors"].as_u64(),
+        ),
+        (Some(true), Some(0)),
+        "the forward-citation fixture must NOT produce a red build\n{}",
+        format_output(&fwd_run)
+    );
+    assert!(
+        !fwd_frac.contains("-- aver:law-class pow2SignedAtLeastOne_law_geOneFlip universal"),
+        "forward: the geone law must degrade to its pre-closure tier (lose its \
+         universal theorem) when its citation would be a forward reference\n\
+         Domain/Frac.lean:\n{fwd_frac}"
+    );
+    assert!(
+        !fwd_frac.contains("have h := pow2_law_positive"),
+        "forward: NO forward reference to the later-emitted sibling may appear \
+         in the emitted proof\nDomain/Frac.lean:\n{fwd_frac}"
+    );
+}


### PR DESCRIPTION
## What

The laws-as-lemmas admission set was call-cone reachability patched by per-family manual injections (one comment read plainly: 'the structural admission gate never reaches them'). Admission is now a generic citation closure over the emission topology — module order is dependency-topological and law order is source order, so a strict (module, line) comparison gives exactly the order the transpiler emits in. The five citing families ride one dispatcher; the manual injection loops are deleted.

## Fail-closed by construction and by fixture

A citation whose target sits later in emission topology is dropped (no dep theorem emitted, no forward reference, consumer stays at its pre-closure tier) — pinned end-to-end by a forward-ref fixture, not just at the comparator. The one family that hand-built its citation key now uses the canonical spelling, closing a silent-drift channel; the guard's trusted branch rests on a named subset invariant with a debug assertion at the emit gate. Tier laundering is impossible on this path: the closure changes which theorems are emitted, never how they are proved or credited, and a sorry-floored dep taints every citer through the per-declaration axioms whitelist.

## Review evidence

The panel re-derived the topology argument from the module loader through the transpile loop, verified the K5 triangle citation edge is real and backward, and measured the whole K5 corpus byte-identical main-vs-branch (15/15 module emissions). The deliberate generalization (all recognizers scan both entry and dep-module laws — a strict superset of the old per-family scans) is documented with its fail-closed rationale.

## Gates

lib 933; proof_spec cross_file 8/8 (incl. the forward-ref fixture) + lean_kernel/check_gates/floor_window/container_induction/builds serialized across the two rounds; byte-golden; guardrails; clippy default and wasm,wasip2; fmt; K5 pins byte-identical (round/remainder/recip/estimate/fprep).