### PR TITLE
Fix the release build: cfg-gate the topology tripwire block

### DIFF
--- a/src/codegen/lean/transpile.rs
+++ b/src/codegen/lean/transpile.rs
@@ -475,13 +475,19 @@ pub(super) fn transpile_unified(
                     // that map's keys. If it is not, the emit-key and order-key
                     // computations have drifted and `topology_admits`' `None`
                     // branch could silently fail open.
-                    debug_assert!(
-                        dep_theorem_order_keys.contains(&(module.prefix.clone(), base.clone())),
-                        "dep-law emit key {:?} is absent from the citation-closure topology \
-                         order map; the fail-closed forward-reference guard would degrade to \
-                         fail-open",
-                        (module.prefix.clone(), base.clone())
-                    );
+                    // A cfg block, not a bare `debug_assert!`: the macro's body is
+                    // type-checked in release builds too, where the cfg-gated
+                    // `dep_theorem_order_keys` binding above does not exist.
+                    #[cfg(debug_assertions)]
+                    {
+                        debug_assert!(
+                            dep_theorem_order_keys.contains(&(module.prefix.clone(), base.clone())),
+                            "dep-law emit key {:?} is absent from the citation-closure \
+                             topology order map; the fail-closed forward-reference guard \
+                             would degrade to fail-open",
+                            (module.prefix.clone(), base.clone())
+                        );
+                    }
                     if !admitted_dep_laws.contains(&(module.prefix.clone(), base)) {
                         continue;
                     }


### PR DESCRIPTION
Main has been red for release-profile builds since #647: the topology tripwire bound its helper under cfg(debug_assertions) but asserted through debug_assert!, whose body is type-checked in release too — E0425 in Bench Gate, WASM release, and all Fuzz nightly targets, while every debug-profile check stayed green. The assert now sits inside a cfg block that release compilation removes entirely.

Verified locally in BOTH profiles (the per-PR CI runs debug only — release evidence is local by necessity): cargo check --release clean, debug build + lib 933 green, clippy default and wasm,wasip2, fmt. Debug behavior unchanged.