### PR TITLE
Name the failing law in proof --check output and align --explain attribution

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -17,6 +17,19 @@ There is no dedicated `Set` type — use `Map<T, Unit>` (see [Sets](#sets) below
 User-defined sum types: `type Shape` → `Shape.Circle(Float)`, `Shape.Rect(Float, Float)`
 User-defined product types: `record User` → `User(name = "Alice", age = 30)`, `u.name`
 
+Declare them with the type name on its own line and the members indented beneath — one variant per line for a sum type, one `field: Type` per line for a record:
+
+```aver
+type Shape           // sum type
+    Circle(Float)
+    Rect(Float, Float)
+    Point            // zero-arg variant — a bare singleton (Shape.Point)
+
+record User          // product type
+    name: String
+    age: Int
+```
+
 `Unit` means "no meaningful value". It is similar to `void`, but still a real type; diagnostics render the value as `()`. Effectful functions such as `Console.print` commonly return `Unit`.
 
 ## Bindings
@@ -36,6 +49,7 @@ Duplicate binding of the same name in the same scope is a type error.
 ## Operators
 
 Arithmetic: `+`, `-`, `*` — operands must match (`Int+Int`, `Float+Float`, `String+String`). No implicit promotion; use `Float.fromInt` / `Int.fromFloat` to convert. The `/` operator is **Float-only**; integer `/` is a type error. For integers use `Int.div(a, b) : Result<Int, String>` (Euclidean; `b == 0` → `Result.Err`) and `Int.mod(a, b) : Result<Int, String>` — there is no integer `%`. `Int` is arbitrary-precision (ℤ): no overflow, no wraparound.
+Unary minus negates a numeric expression: `-n` (equivalent to `0 - n`), and numeric literals may be written negative (`-3`, `-1.5`).
 Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`.
 Error propagation: `expr?` — unwraps `Result.Ok`, propagates `Result.Err` as a `RuntimeError`.
 Independent products: `(a, b)!` — product of independent computations. `(a, b)?!` — same, with Result unwrapping (all must succeed or first error propagates). Elements cannot reference each other; independence is structural. Composes recursively for fan-out parallelism. See [independence.md](independence.md).
@@ -300,9 +314,12 @@ Each module file must start with `module <Name>` and contain exactly one module 
 ```aver
 module Payments
     intent = "Processes transactions."
+    effects [Disk.readText]
     depends [Data.Fibonacci]
     exposes [charge]
 ```
+
+`effects [...]` declares the module's effect boundary — the union of the effects its functions may perform, in the same granular/namespace-shorthand form as function-level `! [...]`. It goes after `intent`. `aver check` warns when a module with functions omits it; a pure module declares `effects []` explicitly.
 
 ### Opaque types
 

--- a/docs/lean.md
+++ b/docs/lean.md
@@ -185,6 +185,13 @@ summary line. Fields of the Lean summary:
   verify-on-domain still passes; this is deliberately the lenient gate)
 - `sorries` — residual `sorry` count across the build output
   (`--sorry-budget N` tolerates up to N)
+- `sorry_laws` — the `fn.law` identities whose theorem carries a residual
+  `sorry` in the gate build (present only when `sorries > 0`). This is the
+  machine-readable "which law failed?" answer: the emitter maps each Lean
+  `declaration uses 'sorry'` warning back to its law through the
+  `-- aver:law-class` markers, so you no longer `lake build` the generated
+  project by hand and grep the warning's line number against the emitted
+  theorems
 - `build_errors` — count of HARD lake/lean build errors (source-located
   `error: file.lean:L:C: …` diagnostics), distinct from `sorries`. A
   degraded proof arm should always fall to a caught `sorry`; a non-zero
@@ -216,6 +223,20 @@ statement-class markers and the same `#print axioms` audit the `universal`
 bool keys on. A robust CI budget pins all four together:
 `sorries == X`, `universal == true`, `universal_laws == N`,
 `bounded_laws == M`.
+
+### Step zero: which law failed?
+
+When a check reports `sorries: N > 0`, the first question is *which* law — and
+the answer is already in the summary. Read `sorry_laws`: it names the failing
+`fn.law` identities directly, no manual `lake build` + grep. Add `--explain` to
+get each failing law's residual open goal inline under `open_goals` (keyed by
+the same identity). The residual probe is deliberately coarse, so on a file with
+both a proven and a failing law it can also surface a goal from the *proven*
+law; that borrowed goal is reported separately under `probe_of` and never in
+`open_goals`, so a healthy, already-proven law is never mistaken for the
+failure. Only after `sorry_laws` names the culprit should you reach for the
+`--emit-ir-after=law_lower` workflow (linked above) to understand *why* that
+specific law did not auto-prove.
 
 ## Law provenance (`-- aver:provenance`)
 

--- a/docs/lean.md
+++ b/docs/lean.md
@@ -229,12 +229,15 @@ bool keys on. A robust CI budget pins all four together:
 When a check reports `sorries: N > 0`, the first question is *which* law — and
 the answer is already in the summary. Read `sorry_laws`: it names the failing
 `fn.law` identities directly, no manual `lake build` + grep. Add `--explain` to
-get each failing law's residual open goal inline under `open_goals` (keyed by
-the same identity). The residual probe is deliberately coarse, so on a file with
-both a proven and a failing law it can also surface a goal from the *proven*
-law; that borrowed goal is reported separately under `probe_of` and never in
-`open_goals`, so a healthy, already-proven law is never mistaken for the
-failure. Only after `sorry_laws` names the culprit should you reach for the
+also get goal text where there is any to show: a failing law whose proof left a
+partial goal gets it inline under `open_goals` (keyed by the same identity),
+while a law that fails outright — its theorem is just a `sorry` — has no
+residual goal to print and is named in `sorry_laws` only. The residual probe is
+deliberately coarse, so on a file with both a proven and a failing law it can
+also surface a goal from the *proven* law; that borrowed goal is reported
+separately under `probe_of` and never in `open_goals`, so a healthy,
+already-proven law is never mistaken for the failure. Only after `sorry_laws`
+names the culprit should you reach for the
 `--emit-ir-after=law_lower` workflow (linked above) to understand *why* that
 specific law did not auto-prove.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,7 +55,7 @@ Add one `verify ... law ...` block to the demo, then ask the proof checker to sh
 aver proof main.av --backend lean --check-json --explain -o /tmp/aver-durable-proof
 ```
 
-If the law does not close universally, the check-json summary names it: `sorry_laws` lists the `fn.law` identities whose theorem carries the residual `sorry`, and `--explain` adds an `open_goals` object with each failing law's residual open goal (keyed by the same identity). The per-law `proof_manifest.json` also carries the residual on a law's `open_goal` field — but only for a law that earns a manifest entry; a law that fails outright (its theorem is just a `sorry`) is named in `sorry_laws`/`open_goals` instead, so read those for the "which law failed" answer.
+If the law does not close universally, the check-json summary names it: `sorry_laws` lists the `fn.law` identities whose theorem carries the residual `sorry` — that field is the authoritative "which law failed" answer. `--explain` additionally surfaces goal text where there is any to show: a failing law whose proof left a partial goal gets it under `open_goals` (keyed by the same identity); a law that fails outright (its theorem is just a `sorry`) has no residual goal to print, so it appears in `sorry_laws` only. Goals the coarse probe borrows from *proven* laws land under `probe_of`, never `open_goals`.
 
 ## CI
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,10 +52,10 @@ projects/durable_promise/main.av
 Add one `verify ... law ...` block to the demo, then ask the proof checker to show the missing proof obligation:
 
 ```bash
-aver proof main.av --backend lean --check --explain -o /tmp/aver-durable-proof
+aver proof main.av --backend lean --check-json --explain -o /tmp/aver-durable-proof
 ```
 
-If the law does not close universally, `--explain` records the residual open goal in the generated proof manifest.
+If the law does not close universally, the check-json summary names it: `sorry_laws` lists the `fn.law` identities whose theorem carries the residual `sorry`, and `--explain` adds an `open_goals` object with each failing law's residual open goal (keyed by the same identity). The per-law `proof_manifest.json` also carries the residual on a law's `open_goal` field — but only for a law that earns a manifest entry; a law that fails outright (its theorem is just a `sorry`) is named in `sorry_laws`/`open_goals` instead, so read those for the "which law failed" answer.
 
 ## CI
 

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -565,6 +565,12 @@ pub(super) enum Commands {
         fail_on_regression: bool,
     },
     /// Export pure Aver code to a proof/verification project
+    // `--check-json` is the machine-readable form of `--check` — a strictly
+    // richer form of the same gate — so it IMPLIES `--check`. The modifier
+    // flags below (`--explain`, `--sorry-budget`, …) therefore accept EITHER
+    // spelling: they require this `check_mode` group (satisfied by `--check`
+    // OR `--check-json`), not the bare `--check` flag.
+    #[command(group(clap::ArgGroup::new("check_mode").args(["check", "check_json"]).multiple(true)))]
     Proof {
         file: String,
         /// Output directory for the generated project
@@ -594,13 +600,13 @@ pub(super) enum Commands {
         /// don't yet have a closing strategy. N is a WHOLE-FILE total,
         /// not per-law: `--error-budget 2` passes a file with two
         /// independently-failing laws. Defaults to 0 (strict).
-        #[arg(long, requires = "check")]
+        #[arg(long, requires = "check_mode")]
         error_budget: Option<usize>,
         /// `--check` only: tolerate up to N residual Lean `sorry`s (and,
         /// on Dafny, `assume {:axiom}` trust-escapes). Symmetric to
         /// `--error-budget`. Like it, N is a WHOLE-FILE total, not
         /// per-law. Defaults to 0 (strict).
-        #[arg(long, requires = "check")]
+        #[arg(long, requires = "check_mode")]
         sorry_budget: Option<usize>,
         /// `--check` only: emit a structured JSON summary
         /// (`{backend, errors, sorries, budget, passed, ...}`) to stdout
@@ -610,7 +616,7 @@ pub(super) enum Commands {
         /// (per-lemma timeouts the `errors` count is blind to); both are
         /// informational and never change exit codes. Exit codes
         /// unchanged: 0 within budget, 1 over, 2 on harness failure.
-        #[arg(long, requires = "check")]
+        #[arg(long)]
         check_json: bool,
         /// `--check` only (Lean-only): for each law that does NOT close
         /// universally (a residual `sorry` / failed inductive arm), emit
@@ -625,7 +631,7 @@ pub(super) enum Commands {
         /// fail-soft (a probe failure never affects `passed` / exit code).
         /// With `--explain` absent, the check-json bytes and manifest are
         /// byte-identical to before (no new key, `open_goal` absent).
-        #[arg(long, requires = "check")]
+        #[arg(long, requires = "check_mode")]
         explain: bool,
         /// `--check` only (Lean-only): MINIMIZE each auto-proof. The emitter
         /// pins a deterministic `first | (tactic₁) | … | sorry` PORTFOLIO at
@@ -645,7 +651,7 @@ pub(super) enum Commands {
         /// to, so a law that only closes via its `sorry` floor collapses to a
         /// bare `sorry` (the honest gap is never silently dropped), and a law
         /// that closes for real loses its alternation and floor.
-        #[arg(long, requires = "check")]
+        #[arg(long, requires = "check_mode")]
         minimize: bool,
         /// Mathlib break-glass tier (Lean-only, opt-in). DEFAULT OFF: the
         /// generated proof is byte-identical to today — pure core, NO Mathlib
@@ -664,7 +670,7 @@ pub(super) enum Commands {
         /// axiom-cleanliness, whether the law needed the Mathlib import — `core`
         /// when a core arm closed it, `mathlib` only when the break-glass arm did
         /// (read from the build-log trace marker the break-glass arm emits).
-        #[arg(long, requires = "check")]
+        #[arg(long, requires = "check_mode")]
         allow_mathlib: bool,
         /// THE RATCHET. Compare the freshly recomputed per-law proof
         /// manifest against this committed baseline and exit non-zero on

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -595,22 +595,25 @@ pub(super) enum Commands {
         /// regressions on pinned `ProofStrategy` choices.
         #[arg(long)]
         check: bool,
-        /// `--check` only: tolerate up to N Dafny verification
+        /// Check mode (`--check`/`--check-json`) only: tolerate up to N Dafny
+        /// verification
         /// errors. Gates regressions upward for examples whose laws
         /// don't yet have a closing strategy. N is a WHOLE-FILE total,
         /// not per-law: `--error-budget 2` passes a file with two
         /// independently-failing laws. Defaults to 0 (strict).
         #[arg(long, requires = "check_mode")]
         error_budget: Option<usize>,
-        /// `--check` only: tolerate up to N residual Lean `sorry`s (and,
+        /// Check mode (`--check`/`--check-json`) only: tolerate up to N
+        /// residual Lean `sorry`s (and,
         /// on Dafny, `assume {:axiom}` trust-escapes). Symmetric to
         /// `--error-budget`. Like it, N is a WHOLE-FILE total, not
         /// per-law. Defaults to 0 (strict).
         #[arg(long, requires = "check_mode")]
         sorry_budget: Option<usize>,
-        /// `--check` only: emit a structured JSON summary
+        /// Emit a structured JSON summary
         /// (`{backend, errors, sorries, budget, passed, ...}`) to stdout
-        /// instead of streaming the verifier's raw output. Additive
+        /// instead of streaming the verifier's raw output. Implies check
+        /// mode, so it works without `--check`. Additive
         /// telemetry fields: Lean carries `build_errors` (hard lake/lean
         /// errors distinct from sorries), Dafny carries `timeouts`
         /// (per-lemma timeouts the `errors` count is blind to); both are
@@ -618,7 +621,8 @@ pub(super) enum Commands {
         /// unchanged: 0 within budget, 1 over, 2 on harness failure.
         #[arg(long)]
         check_json: bool,
-        /// `--check` only (Lean-only): for each law that does NOT close
+        /// Check mode (`--check`/`--check-json`) only, Lean-only: for each
+        /// law that does NOT close
         /// universally (a residual `sorry` / failed inductive arm), emit
         /// the law's UNSOLVED GOAL ("residual") text per law — into the
         /// per-law `proof_manifest.json` records (`open_goal`) and, with
@@ -633,7 +637,8 @@ pub(super) enum Commands {
         /// byte-identical to before (no new key, `open_goal` absent).
         #[arg(long, requires = "check_mode")]
         explain: bool,
-        /// `--check` only (Lean-only): MINIMIZE each auto-proof. The emitter
+        /// Check mode (`--check`/`--check-json`) only, Lean-only: MINIMIZE
+        /// each auto-proof. The emitter
         /// pins a deterministic `first | (tactic₁) | … | sorry` PORTFOLIO at
         /// every law (it cannot know statically which alternative will close);
         /// this rewrites each one to the single branch that actually closed,

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5265,10 +5265,11 @@ pub(super) fn cmd_proof(
         }
     }
 
-    // `--gate` / `--write-baseline` imply a verifier run (they recompute the
-    // current manifest), so run the check harness when EITHER is set even
-    // without an explicit `--check`.
-    if check || gate.is_some() || write_baseline.is_some() {
+    // `--check-json` is the machine-readable form of `--check` and IMPLIES it;
+    // `--gate` / `--write-baseline` also imply a verifier run (they recompute
+    // the current manifest). So run the check harness when ANY of these is set
+    // even without an explicit `--check`.
+    if check || check_json || gate.is_some() || write_baseline.is_some() {
         // For Dafny, hand the harness the real entry module filename so it
         // verifies the file that carries the verify-law lemmas (not an
         // arbitrary dependency module).
@@ -5753,6 +5754,20 @@ fn run_proof_check(
     };
     let universal: Option<bool> = lean_law_audit.as_ref().map(|a| a.universal);
 
+    // Which law(s) actually FAILED in the gate build (Lean only): map each
+    // `declaration uses 'sorry'` warning back to the `fn.law` identity of the
+    // theorem that carries it, via the emitted `-- aver:law-class` markers. This
+    // is the machine-readable answer to "which law failed?" — previously the user
+    // had to `lake build` the generated project by hand and grep the sorry
+    // warning's line number against the emitted theorems. Empty for a clean build
+    // or on Dafny. Also anchors `--explain`'s residual attribution below.
+    let sorry_laws: Vec<String> = match backend {
+        super::cli::ProofBackend::Lean if sorries.unwrap_or(0) > 0 => {
+            lean_sorry_laws(output_dir, &format!("{stdout}{stderr}"))
+        }
+        _ => Vec::new(),
+    };
+
     // Proof manifest (Lean only): the file-level audit's per-law records as one
     // byte-reproducible per-law table, written to `<out>/proof_manifest.json`.
     // This is the artifact `--gate` diffs against a committed baseline; it
@@ -5771,6 +5786,11 @@ fn run_proof_check(
         .as_ref()
         .map(|audit| build_proof_manifest(&audit.laws));
     let mut open_goals: std::collections::BTreeMap<String, String> =
+        std::collections::BTreeMap::new();
+    // `--explain` residuals borrowed from HEALTHY (proven) laws — see the
+    // attribution split below. Kept separate from `open_goals` so a proven law's
+    // probe artifact is never mistaken for the failing law.
+    let mut probe_of: std::collections::BTreeMap<String, String> =
         std::collections::BTreeMap::new();
     if explain
         && matches!(backend, super::cli::ProofBackend::Lean)
@@ -5798,6 +5818,33 @@ fn run_proof_check(
             .filter(|(label, _)| !closed_universal.contains(label.as_str()))
             .collect();
         open_goals = lean_residual_goals(output_dir, &open);
+        // Attribute residuals to the law that ACTUALLY failed. When the gate
+        // build has residual sorries the audit bailed on `sorries > 0`, so
+        // `closed_universal` above is empty and the coarse normalization-only
+        // probe runs over EVERY emitted law — including healthy, kernel-proven
+        // ones (a proven law still yields an "unsolved goals" residual once its
+        // closing tactics are stripped). Keying that borrowed residual as the
+        // failure is what sent the P4 cold-start report to "fix" a law that was
+        // already proven. So split by `sorry_laws` (the laws whose theorem truly
+        // carries the gate-build sorry): sorry-bearers are the genuine
+        // `open_goals`; a residual from a non-sorry law is probe context
+        // (`probe_of`), never presented as the failure. With no sorries the probe
+        // only ran over bounded laws, so keep every residual as `open_goals`
+        // (unchanged behavior — no `probe_of`).
+        if !sorry_laws.is_empty() {
+            let sorry_set: std::collections::HashSet<&str> =
+                sorry_laws.iter().map(String::as_str).collect();
+            let mut genuine: std::collections::BTreeMap<String, String> =
+                std::collections::BTreeMap::new();
+            for (law, goal) in std::mem::take(&mut open_goals) {
+                if sorry_set.contains(law.as_str()) {
+                    genuine.insert(law, goal);
+                } else {
+                    probe_of.insert(law, goal);
+                }
+            }
+            open_goals = genuine;
+        }
         for l in m.laws.iter_mut() {
             if let Some(goal) = open_goals.get(&l.law) {
                 l.open_goal = Some(goal.clone());
@@ -5952,6 +5999,21 @@ fn run_proof_check(
             // existing substring consumers of check-json are untouched.
             obj.insert("manifest".into(), PROOF_MANIFEST_FILE.into());
         }
+        // Which law(s) failed (Lean): the `fn.law` identities whose theorem
+        // carries the gate-build `sorry`. Answers "which law?" without a manual
+        // `lake build` + grep. Emitted only when non-empty (a clean build / Dafny
+        // adds no key), so the check-json bytes are unchanged on a pass.
+        if !sorry_laws.is_empty() {
+            obj.insert(
+                "sorry_laws".into(),
+                serde_json::Value::Array(
+                    sorry_laws
+                        .iter()
+                        .map(|l| serde_json::Value::String(l.clone()))
+                        .collect(),
+                ),
+            );
+        }
         // `--explain` ONLY: surface the per-law residuals inline so an agent
         // consumer reads them WITHOUT opening the sidecar. Keyed by `fn.law`
         // identity. Emitted only when `--explain` produced at least one residual
@@ -5963,6 +6025,17 @@ fn run_proof_check(
                 goals.insert(law.clone(), goal.clone().into());
             }
             obj.insert("open_goals".into(), serde_json::Value::Object(goals));
+        }
+        // `--explain` ONLY: residuals the coarse probe surfaced from HEALTHY
+        // (proven) laws while at least one OTHER law failed — probe context, kept
+        // out of `open_goals` so a proven law is never mistaken for the failure.
+        // Empty (no key) unless the split above moved a borrowed residual here.
+        if !probe_of.is_empty() {
+            let mut probes = serde_json::Map::new();
+            for (law, goal) in &probe_of {
+                probes.insert(law.clone(), goal.clone().into());
+            }
+            obj.insert("probe_of".into(), serde_json::Value::Object(probes));
         }
         obj.insert("budget".into(), budget.into());
         obj.insert("passed".into(), passed.into());
@@ -7068,6 +7141,106 @@ fn lean_universal_audit(dir: &str, sorries: usize) -> LeanLawAudit {
             laws: bounded_records,
         },
     }
+}
+
+/// Parse `<path>.lean:<line>` out of a Lean/lake diagnostic line, returning the
+/// file BASENAME and the 1-based line number. Tolerant of a leading `warning:`
+/// and a `././` / directory prefix on the path (`lake build` and `lake env lean`
+/// render the path differently). `None` if the line carries no `.lean:<digits>`.
+fn parse_lean_decl_location(line: &str) -> Option<(String, usize)> {
+    let idx = line.find(".lean:")?;
+    let before = &line[..idx];
+    let start = before
+        .rfind(|c: char| c == '/' || c.is_whitespace())
+        .map(|p| p + 1)
+        .unwrap_or(0);
+    let stem = &before[start..];
+    if stem.is_empty() {
+        return None;
+    }
+    let after = &line[idx + ".lean:".len()..];
+    let digits: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let ln = digits.parse::<usize>().ok()?;
+    Some((format!("{stem}.lean"), ln))
+}
+
+/// Map each `declaration uses 'sorry'` warning in a Lean `lake build` log to the
+/// `fn.law` identity of the enclosing law theorem, via the emitted
+/// `-- aver:law-class` markers. Returns the SORTED, DEDUPED set of law identities
+/// whose theorem carries a residual `sorry` in the GATE build — the answer to
+/// "which law failed?" that otherwise required a manual `lake build` + grep. The
+/// gate build's floor is a bare `sorry` (not the probe's `AVERSPEC_SORRY` trace),
+/// so the warning's `file:line` is the only signal: it points at the theorem's
+/// declaration line, so the enclosing theorem is the nearest one whose line is
+/// `<= the warning line`. Lean-only; empty when the build has no sorries or the
+/// emitted sources are unreadable.
+fn lean_sorry_laws(dir: &str, build_output: &str) -> Vec<String> {
+    let locations: Vec<(String, usize)> = build_output
+        .lines()
+        .filter(|l| l.contains("declaration uses") && l.contains("sorry"))
+        .filter_map(parse_lean_decl_location)
+        .collect();
+    if locations.is_empty() {
+        return Vec::new();
+    }
+    // Per emitted file: its top-level `theorem <name>` declarations as
+    // `(1-based line, name)`, plus the global `theorem -> fn.law` label map read
+    // off the class markers (same shape `emitted_main_law_theorems` reads).
+    let mut labels: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut file_thms: std::collections::HashMap<String, Vec<(usize, String)>> =
+        std::collections::HashMap::new();
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for entry in rd.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !name.ends_with(".lean") || name == "lakefile.lean" {
+                continue;
+            }
+            let Ok(contents) = std::fs::read_to_string(entry.path()) else {
+                continue;
+            };
+            let mut thms: Vec<(usize, String)> = Vec::new();
+            for (idx, line) in contents.lines().enumerate() {
+                if let Some(rest) = line.strip_prefix(lean_codegen::LAW_CLASS_MARKER_PREFIX) {
+                    let mut parts = rest.split_whitespace();
+                    if let (Some(thm), Some(_class)) = (parts.next(), parts.next())
+                        && let Some(label) = parts.next()
+                    {
+                        labels.insert(thm.to_string(), label.to_string());
+                    }
+                    continue;
+                }
+                if let Some(rest) = line.strip_prefix("theorem ") {
+                    let thm = rest
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or("")
+                        .trim_end_matches(':');
+                    if !thm.is_empty() {
+                        thms.push((idx + 1, thm.to_string())); // Lean lines are 1-based
+                    }
+                }
+            }
+            file_thms.insert(name, thms);
+        }
+    }
+    let mut out: Vec<String> = Vec::new();
+    for (file, warn_line) in &locations {
+        let Some(thms) = file_thms.get(file) else {
+            continue;
+        };
+        // Enclosing theorem = the nearest declaration at or above the warning
+        // line (the sorry warning is located at the theorem's own declaration).
+        if let Some((_, thm)) = thms
+            .iter()
+            .filter(|(tl, _)| tl <= warn_line)
+            .max_by_key(|(tl, _)| *tl)
+        {
+            out.push(manifest_label_for(thm, &labels));
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
 }
 
 /// Scan the emitted `.lean` sources for every MAIN law theorem (the universal
@@ -9737,6 +9910,27 @@ mod tests {
             "both glyphs counted, unrelated lines ignored"
         );
         assert_eq!(super::count_lean_sorries("Build completed successfully"), 0);
+    }
+
+    #[test]
+    fn parse_lean_decl_location_extracts_basename_and_line() {
+        // The gate-build sorry warning `lean_sorry_laws` keys on. Basename + line
+        // must survive a `warning:` prefix, a `././` build path prefix, and the
+        // backtick glyph — the line is mapped to the enclosing theorem by number.
+        assert_eq!(
+            super::parse_lean_decl_location(
+                "warning: Warehouse.lean:105:8: declaration uses `sorry`"
+            ),
+            Some(("Warehouse.lean".to_string(), 105))
+        );
+        assert_eq!(
+            super::parse_lean_decl_location(
+                "warning: ././Warehouse.lean:105:8: declaration uses 'sorry'"
+            ),
+            Some(("Warehouse.lean".to_string(), 105))
+        );
+        // A line with no `.lean:<digits>` is not a location.
+        assert_eq!(super::parse_lean_decl_location("error: build failed"), None);
     }
 
     #[test]

--- a/tests/fixtures/warehouse_failing_law.av
+++ b/tests/fixtures/warehouse_failing_law.av
@@ -1,0 +1,55 @@
+module Warehouse
+    intent =
+        "Tracks a stock level through explicit inventory moves."
+    effects [Console]
+    exposes [Move, moveDelta, totalDelta, applyAll]
+
+type Move
+    Receive(Int)
+    Ship(Int)
+
+fn moveDelta(m: Move) -> Int
+    ? "Signed stock change of a single move."
+    match m
+        Move.Receive(n) -> n
+        Move.Ship(n) -> 0 - n
+
+verify moveDelta
+    moveDelta(Move.Receive(5)) => 5
+    moveDelta(Move.Ship(3)) => -3
+
+fn totalDelta(moves: List<Move>) -> Int
+    ? "Signed stock change of a whole list of moves."
+    match moves
+        [] -> 0
+        [m, ..rest] -> moveDelta(m) + totalDelta(rest)
+
+verify totalDelta
+    totalDelta([]) => 0
+    totalDelta([Move.Receive(5), Move.Ship(3)]) => 2
+
+fn applyAll(stock: Int, moves: List<Move>) -> Int
+    ? "Applies moves in order to a starting stock level."
+    match moves
+        [] -> stock
+        [m, ..rest] -> applyAll(stock + moveDelta(m), rest)
+
+verify applyAll
+    applyAll(10, []) => 10
+    applyAll(10, [Move.Receive(5), Move.Ship(3)]) => 12
+
+verify applyAll law matchesTotalDelta
+    given stock: Int = -2..2
+    given moves: List<Move> = [[], [Move.Receive(1)], [Move.Ship(2), Move.Receive(3)]]
+    applyAll(stock, moves) => stock + totalDelta(moves)
+
+verify applyAll law appendHomomorphism
+    given stock: Int = -1..1
+    given a: List<Move> = [[], [Move.Receive(1)], [Move.Ship(2), Move.Receive(3)]]
+    given b: List<Move> = [[], [Move.Ship(4)]]
+    applyAll(applyAll(stock, a), b) => stock + totalDelta(List.concat(a, b))
+
+fn main() -> Unit
+    ! [Console.print]
+    stock = applyAll(10, [Move.Receive(5), Move.Ship(3)])
+    Console.print("Final stock: {stock}")

--- a/tests/proof_spec/check_gates.rs
+++ b/tests/proof_spec/check_gates.rs
@@ -1051,6 +1051,69 @@ fn proof_check_without_explain_emits_no_open_goals_key() {
 }
 
 #[test]
+fn proof_check_sorry_laws_names_failing_law_not_a_proven_one() {
+    // Regression for the P4 cold-start report. `warehouse_failing_law.av` has a
+    // HEALTHY law (`applyAll.matchesTotalDelta`, kernel-proven) alongside a
+    // FAILING one (`applyAll.appendHomomorphism`, an append-homomorphism the
+    // engine sorry-floors). The gate build reports `sorries:1`. The check-json
+    // must (1) NAME the failing law in `sorry_laws` — the answer the reporter had
+    // to reconstruct by hand with `lake build` + grep — and (2) under `--explain`
+    // NEVER key the proven law's residual as the open goal. In the report the
+    // coarse probe surfaced `applyAll.matchesTotalDelta`'s residual as the open
+    // goal, sending the reporter to "fix" a law that was already proven.
+    let Some(summary) = run_check_json_for(
+        "aver-warehouse-sorry-laws-out",
+        "tests/fixtures/warehouse_failing_law.av",
+        true,
+    ) else {
+        return;
+    };
+    assert_eq!(
+        summary.get("passed").and_then(|v| v.as_bool()),
+        Some(false),
+        "the failing law must not pass:\n{summary}"
+    );
+    assert_eq!(
+        summary.get("sorries").and_then(|v| v.as_u64()),
+        Some(1),
+        "exactly the one failing law sorries:\n{summary}"
+    );
+    // Fix 1: the failing law is NAMED — no manual `lake build` + grep.
+    let sorry_laws = summary
+        .get("sorry_laws")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| panic!("check-json must carry `sorry_laws` on a failure:\n{summary}"));
+    assert_eq!(
+        sorry_laws,
+        &vec![serde_json::Value::String(
+            "applyAll.appendHomomorphism".to_string()
+        )],
+        "`sorry_laws` must name exactly the failing law:\n{summary}"
+    );
+    // Fix 2: the proven law is NEVER keyed as an open goal; any goal surfaced in
+    // `open_goals` must be the actual failing law.
+    if let Some(open_goals) = summary.get("open_goals").and_then(|v| v.as_object()) {
+        assert!(
+            !open_goals.contains_key("applyAll.matchesTotalDelta"),
+            "the proven law must not be keyed as an open goal:\n{summary}"
+        );
+        for k in open_goals.keys() {
+            assert_eq!(
+                k, "applyAll.appendHomomorphism",
+                "open_goals may only key the failing law:\n{summary}"
+            );
+        }
+    }
+    // A residual borrowed from the proven law is probe context, never the failure.
+    if let Some(probe_of) = summary.get("probe_of").and_then(|v| v.as_object()) {
+        assert!(
+            !probe_of.contains_key("applyAll.appendHomomorphism"),
+            "the failing law is not probe context:\n{summary}"
+        );
+    }
+}
+
+#[test]
 fn verify_law_rejects_incompatible_sides_nat_vs_int() {
     // Regression: a `verify … law` body `LHS => RHS` asserts the two sides are
     // EQUAL, so they must have compatible types. A user `Nat`-returning fn equated


### PR DESCRIPTION
When a proof check fails, the summary now answers "which law failed" directly and never points at a healthy law.

- New check-json field `sorry_laws`: the `fn.law` identities whose theorem carries the residual `sorry`, mapped from the Lean `declaration uses 'sorry'` warnings back through the emitted law-class markers.
- Fixed `--explain` attribution: previously, on a file with both a proven and a failing law, the coarse residual probe could key a goal borrowed from the *proven* law into `open_goals`, blaming the wrong law. Residuals are now split — goals of sorry-bearing laws stay in `open_goals`, borrowed goals from proven laws move to a new `probe_of` field.
- `--check-json` now implies check mode, so it works standalone (previously it required `--check`); modifier flags (`--explain`, budgets, `--minimize`) accept either.
- Docs (`quickstart.md`, `lean.md`, `language.md`) updated to the measured behavior, including the case of a law that fails outright and therefore has no residual goal text; stale "`--check` only" help strings refreshed.

Adds a `warehouse_failing_law.av` fixture and a regression test pinning that `sorry_laws` names the failing law and never a proven one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BDYkTmTBhbKMmfMYPHZD7