### PR TITLE
Make cert verify a verified-report checker (no parsed-text trust channel)

### DIFF
--- a/src/codegen/cert/Schema.lean
+++ b/src/codegen/cert/Schema.lean
@@ -1,0 +1,84 @@
+-- AverCert statement schema (audited, fixed).
+--
+-- The single final certificate theorem is
+--   `AverCert.Final.cert : AverCert.Schema.Holds manifest`.
+-- A consumer trusts the certificate by checking THREE things: the theorem
+-- NAME, the manifest LITERAL, and the content hash of THIS file plus the
+-- semantics prelude. It never inspects the Lean syntax of the proof. Because
+-- `Holds` and its denotations live here and this file's hash is pinned in the
+-- checker, the meaning of the certificate cannot be weakened without changing
+-- a hash the checker rejects.
+import CertPrelude
+import Module
+
+namespace AverCert.Schema
+open CertPrelude
+
+/-- What the artifact is: its pinned hash, the emitted-fragment profile, the
+    runtime ABI, the certified export names, and the named runtime contracts
+    every certificate is conditional on. Pure data, mirrored in
+    `cert-manifest.json`. -/
+structure Subject where
+  artifactHash : String
+  profile      : String
+  abi          : String
+  exports      : List String
+  contracts    : List String
+
+/-- The certification policy attached to a certified export. v0 ships exactly
+    one constructor: the emitted body simulates the generated model. -/
+inductive Policy where
+  | simulatesModel
+
+/-- The representation-relation faces a simulation certificate is stated over
+    (the Int carrier `{i64 small, ref limbs, i32 sign}`). Bundled in the audited
+    schema so `Obligation.holds` is self-contained. -/
+structure CarrierSpec (C : Nat) where
+  Repr : Int → WVal → Prop
+  car : ∀ n v, Repr n v →
+    (∃ s sg, v = .structv C [.i64v s, .null, .i32v sg]) ∨
+    (∃ s lty les sg, v = .structv C [.i64v s, .arr lty les, .i32v sg])
+  smallIntro : ∀ k : Int, Repr k (carrierSmall C k)
+  smallElim : ∀ n s sg, Repr n (.structv C [.i64v s, .null, .i32v sg]) → s = n
+  bigElim : ∀ n s lty les sg,
+      Repr n (.structv C [.i64v s, .arr lty les, .i32v sg]) → ((sg < 0) ↔ (n < 0)) ∧ n ≠ 0
+
+/-- One certified export. `code`/`host`/`self` pin the emitted body and its
+    runtime wiring; `model` is the generated reference function the body is
+    proven to simulate. `aver cert verify` re-derives `code`, `self` and
+    `carrier` from the module bytes, so the obligation is bound to the artifact. -/
+structure Obligation where
+  export_ : String
+  policy  : Policy
+  carrier : Nat
+  code    : CodeTbl
+  host    : (List WVal → Option WVal) → (List WVal → Option WVal) → HostTbl
+  self    : Nat
+  model   : Int → Int
+
+/-- Denotation of `simulatesModel`: under any representation `S` and any host
+    add/sub contracts obeying the named integer laws, the emitted body run on a
+    representation of `n` yields a representation of `model n`. Partial
+    correctness — vacuous on trap or fuel exhaustion. -/
+def Obligation.holds (o : Obligation) : Prop :=
+  ∀ (S : CarrierSpec o.carrier)
+    (add sub : List WVal → Option WVal)
+    (_hadd : ∀ a b va vb w, S.Repr a va → S.Repr b vb → add [va, vb] = some w → S.Repr (a + b) w)
+    (_hsub : ∀ a b va vb w, S.Repr a va → S.Repr b vb → sub [va, vb] = some w → S.Repr (a - b) w)
+    (fuel : Nat) (n : Int) (v w : WVal),
+    S.Repr n v →
+    wFuncN o.code (o.host add sub) fuel o.self [v] = some w →
+    S.Repr (o.model n) w
+
+structure Manifest where
+  subject     : Subject
+  obligations : List Obligation
+
+/-- The single audited certificate proposition: the manifest's pinned hash is
+    the module hash, and every certified export carries `simulatesModel` and
+    genuinely simulates its model. -/
+def Holds (m : Manifest) : Prop :=
+  m.subject.artifactHash = CertModule.wasmSha256
+  ∧ ∀ o ∈ m.obligations, o.policy = Policy.simulatesModel ∧ o.holds
+
+end AverCert.Schema

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -27,6 +27,46 @@ use std::path::Path;
 const CERT_PRELUDE: &str = include_str!("../../../tools/certkit/prelude/CertPrelude.lean");
 const LEAN_TOOLCHAIN: &str = include_str!("../../../tools/certkit/prelude/lean-toolchain");
 
+/// The audited statement schema, single source of truth, embedded so both the
+/// emitter and the `aver cert verify` checker pin the exact same bytes. The
+/// consumer trusts the certificate by checking the final theorem NAME, the
+/// manifest LITERAL, and the hash of THIS file plus the prelude — never Lean
+/// proof syntax. Fixed content (no per-build parts) so its sha256 is known to
+/// the checker at compile time.
+pub const CERT_SCHEMA: &str = include_str!("Schema.lean");
+
+/// Emitted-fragment profile and runtime ABI identifiers recorded in the
+/// manifest. Stable strings the checker echoes; bumped when the certified
+/// fragment or the runtime import surface changes.
+pub const PROFILE_ID: &str = "AverUserProfile/v0";
+pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
+/// Certification level of a v0 artifact certificate: conditional on the named
+/// runtime contracts (see the consult level naming L0/L1/L2/L3).
+pub const CERT_LEVEL: &str = "L1";
+/// The one approved final-theorem statement line. `aver cert verify` confirms
+/// this exact line is present in `Final.lean` (name + `Holds manifest`), which
+/// is what pins the statement without matching arbitrary Lean syntax.
+pub const FINAL_THEOREM: &str = "AverCert.Final.cert";
+pub const FINAL_STATEMENT_LINE: &str =
+    "theorem AverCert.Final.cert : AverCert.Schema.Holds manifest";
+
+/// sha256 of a byte slice, lowercase hex.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    hex(&h.finalize())
+}
+
+/// The content hashes of the audited schema and semantics prelude as embedded
+/// in THIS binary — the checker's anchor: a cert whose on-disk `Schema.lean` /
+/// `CertPrelude.lean` do not hash to these is not the audited version.
+pub fn audited_schema_sha() -> String {
+    sha256_hex(CERT_SCHEMA.as_bytes())
+}
+pub fn audited_prelude_sha() -> String {
+    sha256_hex(CERT_PRELUDE.as_bytes())
+}
+
 /// A user function recovered from the emitted module.
 struct UserFn {
     name: String,
@@ -86,6 +126,31 @@ impl Cert {
     fn name(&self) -> &str {
         match self {
             Cert::StraightLine { name, .. } | Cert::Recursive { name, .. } => name,
+        }
+    }
+    fn self_idx(&self) -> u32 {
+        match self {
+            Cert::StraightLine { self_idx, .. } | Cert::Recursive { self_idx, .. } => *self_idx,
+        }
+    }
+    fn carrier(&self) -> u32 {
+        match self {
+            Cert::StraightLine { carrier, .. } | Cert::Recursive { carrier, .. } => *carrier,
+        }
+    }
+    /// The Lean expression for the model this export simulates.
+    fn model_expr(&self) -> String {
+        match self {
+            Cert::StraightLine { k, .. } => format!("fun n => n + ({k})"),
+            Cert::Recursive { name, .. } => name.clone(),
+        }
+    }
+    /// The Lean expression for the 2-arg host builder in `Obligation` shape
+    /// (`add → sub → HostTbl`); straight-line ignores `sub`.
+    fn host_expr(&self) -> String {
+        match self {
+            Cert::StraightLine { name, .. } => format!("fun add _ => CertModule.{name}Host add"),
+            Cert::Recursive { name, .. } => format!("CertModule.{name}Host"),
         }
     }
 }
@@ -548,15 +613,30 @@ pub fn write_project(
         "Module.lean",
         &render_module(analysis, wasm_name, &sha),
     )?;
+    // Audited statement schema (fixed) + generated manifest literal + the one
+    // final theorem that composes the per-export obligations.
+    write(&cert_dir, "Schema.lean", CERT_SCHEMA)?;
+    write(
+        &cert_dir,
+        "Manifest.lean",
+        &render_manifest_lean(analysis, &model_roots, &sha),
+    )?;
     write(
         &cert_dir,
         "Certificate.lean",
         &render_certificate(analysis, &model_roots),
     )?;
+    write(&cert_dir, "Final.lean", &render_final(analysis))?;
     write(&cert_dir, "lakefile.lean", &render_lakefile(&model_roots))?;
+
+    // Content hashes the checker re-verifies: the audited schema and the
+    // semantics prelude. Pinning these plus the final theorem name and the
+    // manifest literal is the whole trust story.
+    let schema_sha = sha256_hex(CERT_SCHEMA.as_bytes());
+    let prelude_sha = sha256_hex(CERT_PRELUDE.as_bytes());
     std::fs::write(
         cert_dir.join("cert-manifest.json"),
-        render_manifest(analysis, wasm_name, &sha),
+        render_manifest(analysis, wasm_name, &sha, &schema_sha, &prelude_sha),
     )
     .map_err(|e| format!("write manifest: {e}"))?;
     Ok(())
@@ -610,9 +690,45 @@ fn render_module(analysis: &Analysis, wasm_name: &str, sha: &str) -> String {
     for c in &analysis.certs {
         s.push_str(&render_code_def(c));
         s.push('\n');
+        s.push_str(&render_host_def(c));
+        s.push('\n');
     }
     s.push_str("end CertModule\n");
     s
+}
+
+/// The runtime host-contract wiring for a certified body, as data in
+/// `CertModule` so both the certificate proofs and the manifest reference the
+/// one definition.
+fn render_host_def(c: &Cert) -> String {
+    match c {
+        Cert::StraightLine {
+            name,
+            carrier,
+            box_idx,
+            add_idx,
+            ..
+        } => format!(
+            "/-- Runtime host wiring for `{name}` (box + add contracts). -/\n\
+             def {name}Host (add : List WVal → Option WVal) : HostTbl := fun fn =>\n  \
+             if fn = {box_idx} then some (1, boxRef {carrier})\n  \
+             else if fn = {add_idx} then some (2, add)\n  else none\n",
+        ),
+        Cert::Recursive {
+            name,
+            carrier,
+            box_idx,
+            add_idx,
+            sub_idx,
+            ..
+        } => format!(
+            "/-- Runtime host wiring for `{name}` (box + add + sub contracts). -/\n\
+             def {name}Host (add sub : List WVal → Option WVal) : HostTbl := fun fn =>\n  \
+             if fn = {box_idx} then some (1, boxRef {carrier})\n  \
+             else if fn = {add_idx} then some (2, add)\n  \
+             else if fn = {sub_idx} then some (2, sub)\n  else none\n",
+        ),
+    }
 }
 
 fn render_code_def(c: &Cert) -> String {
@@ -656,7 +772,7 @@ fn render_code_def(c: &Cert) -> String {
 
 fn render_certificate(analysis: &Analysis, model_roots: &[String]) -> String {
     let mut s = String::new();
-    s.push_str("import CertPrelude\nimport Module\n");
+    s.push_str("import CertPrelude\nimport Module\nimport Schema\nimport Manifest\n");
     for r in model_roots {
         s.push_str(&format!("import {r}\n"));
     }
@@ -664,7 +780,7 @@ fn render_certificate(analysis: &Analysis, model_roots: &[String]) -> String {
         "\nset_option linter.unusedSimpArgs false\n\
          set_option linter.unusedVariables false\n\
          set_option maxRecDepth 1000000\n\n\
-         namespace CertProofs\nopen CertPrelude CertModule\n\n",
+         namespace CertProofs\nopen CertPrelude CertModule AverCert\n\n",
     );
     for c in &analysis.certs {
         match c {
@@ -692,13 +808,9 @@ fn render_straightline_cert(c: &Cert) -> String {
     };
     let g1 = k + 3;
     let g2 = k - 5;
+    let _ = (box_idx, add_idx);
     format!(
         r#"/-! ### {name} — straight-line certificate (carrier type {carrier}) -/
-
-def {name}Host (add : List WVal → Option WVal) : HostTbl := fun fn =>
-  if fn = {box_idx} then some (1, boxRef {carrier})
-  else if fn = {add_idx} then some (2, add)
-  else none
 
 /-- The VERBATIM emitted body of `{name}` maps any representation of `n` to a
     representation of `n + {k}`, for ALL `n : ℤ`, under the named runtime
@@ -744,6 +856,20 @@ example :
 example :
     ((wFuncN {name}Code {name}HostRef 4 {self_idx} [carrierSmall {carrier} (-5)]).bind carrierToInt)
       = some ({g2}) := by native_decide
+
+/-- Schema-shaped simulation obligation for `{name}` (composed by the single
+    final theorem). Partial correctness over any fuel and representation. -/
+theorem {name}_simulates : AverCert.Schema.Obligation.holds {name}Ob := by
+  intro S add sub hadd hsub fuel n v w hv hrun
+  simp only [{name}Ob, AverCert.Schema.Obligation.holds] at hrun ⊢
+  cases fuel with
+  | zero => simp only [wFuncN, reduceCtorEq] at hrun
+  | succ f =>
+    rcases hc : add [v, carrierSmall {carrier} ({k})] with _ | r
+    · simp [wFuncN, wRunF, {name}Code, {name}Host, boxRef, popArgs, initLocals, hc] at hrun
+    · simp [wFuncN, wRunF, {name}Code, {name}Host, boxRef, popArgs, initLocals, hc] at hrun
+      subst hrun
+      exact hadd n ({k}) v (carrierSmall {carrier} ({k})) r hv (S.smallIntro ({k})) hc
 "#
     )
 }
@@ -762,14 +888,9 @@ fn render_recursive_cert(c: &Cert) -> String {
         unreachable!()
     };
     let g3 = eval_sumto(3);
+    let _ = (box_idx, add_idx, sub_idx);
     format!(
         r#"/-! ### {name} — self-recursive certificate (carrier type {carrier}) -/
-
-def {name}Host (add sub : List WVal → Option WVal) : HostTbl := fun fn =>
-  if fn = {box_idx} then some (1, boxRef {carrier})
-  else if fn = {add_idx} then some (2, add)
-  else if fn = {sub_idx} then some (2, sub)
-  else none
 
 -- model-side fuel bridge (the cap-induction pattern at R = 1).
 theorem {name}_fuel_irrel :
@@ -919,8 +1040,122 @@ example :
 example :
     ((wFuncN {name}Code {name}HostRef 20 {self_idx} [carrierSmall {carrier} (-4)]).bind carrierToInt)
       = some 0 := by native_decide
+
+/-- Schema-shaped simulation obligation for `{name}` (composed by the single
+    final theorem): the emitted recursive body simulates the model `{name}`. -/
+theorem {name}_simulates : AverCert.Schema.Obligation.holds {name}Ob := by
+  intro S add sub hadd hsub fuel n v w hv hrun
+  simp only [{name}Ob, AverCert.Schema.Obligation.holds] at hrun ⊢
+  exact {name}_wasm_certified S.Repr S.car S.smallIntro S.smallElim S.bigElim
+    add sub hadd hsub fuel n v w hv hrun
 "#
     )
+}
+
+/// The generated manifest literal, mirroring `cert-manifest.json`: the subject
+/// metadata plus one `Obligation` per certified export. This is the LITERAL the
+/// consumer pins.
+fn render_manifest_lean(analysis: &Analysis, model_roots: &[String], sha: &str) -> String {
+    let mut s = String::new();
+    s.push_str("import Schema\nimport Module\n");
+    for r in model_roots {
+        s.push_str(&format!("import {r}\n"));
+    }
+    s.push_str(
+        "\nset_option linter.unusedVariables false\n\n\
+         namespace AverCert\nopen AverCert.Schema CertPrelude\n\n",
+    );
+    // One obligation def per certified export.
+    for c in &analysis.certs {
+        let name = c.name();
+        s.push_str(&format!(
+            "abbrev {name}Ob : Schema.Obligation :=\n  \
+             {{ export_ := \"{name}\", policy := .simulatesModel, carrier := {carrier},\n    \
+             code := CertModule.{name}Code, host := {host}, self := {self_idx}, model := {model} }}\n\n",
+            carrier = c.carrier(),
+            host = c.host_expr(),
+            self_idx = c.self_idx(),
+            model = c.model_expr(),
+        ));
+    }
+    // Subject + manifest.
+    let exports = analysis
+        .certs
+        .iter()
+        .map(|c| format!("\"{}\"", c.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let contracts = analysis
+        .contracts
+        .iter()
+        .map(|c| lean_str(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let obligations = analysis
+        .certs
+        .iter()
+        .map(|c| format!("{}Ob", c.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    s.push_str(&format!(
+        "def manifest : Schema.Manifest :=\n  \
+         {{ subject :=\n      \
+         {{ artifactHash := \"{sha}\",\n        \
+         profile := \"{PROFILE_ID}\",\n        \
+         abi := \"{RUNTIME_ABI}\",\n        \
+         exports := [{exports}],\n        \
+         contracts := [{contracts}] }},\n    \
+         obligations := [{obligations}] }}\n\n\
+         end AverCert\n",
+    ));
+    s
+}
+
+/// The single final theorem: `AverCert.Final.cert : Holds manifest`, proved by
+/// composing the per-export `_simulates` obligations. No other final theorem is
+/// emitted; the checker pins this exact statement line.
+fn render_final(analysis: &Analysis) -> String {
+    let mut s = String::new();
+    s.push_str(
+        "import Certificate\nimport Manifest\nimport Schema\n\n\
+         set_option maxRecDepth 1000000\n\
+         set_option linter.unusedSimpArgs false\n\n\
+         open AverCert AverCert.Schema\n\n",
+    );
+    s.push_str(
+        "/-- THE single artifact certificate: the pinned module hash is this module's\n\
+        hash, and every certified export simulates its model under the named runtime\n\
+        contracts. Proof composes the per-export obligations; nothing else. -/\n",
+    );
+    s.push_str(&format!("{FINAL_STATEMENT_LINE} := by\n"));
+    if analysis.certs.is_empty() {
+        s.push_str(
+            "  refine ⟨rfl, ?_⟩\n  \
+             intro o ho\n  \
+             simp only [manifest, List.mem_nil_iff, List.not_mem_nil] at ho\n",
+        );
+    } else {
+        s.push_str("  refine ⟨rfl, ?_⟩\n  intro o ho\n");
+        s.push_str(
+            "  simp only [manifest, List.mem_cons, List.mem_singleton, List.mem_nil_iff,\n    \
+             List.not_mem_nil, or_false] at ho\n",
+        );
+        // `rcases` with one `rfl` per obligation, split on the disjunction.
+        let pattern = std::iter::repeat_n("rfl", analysis.certs.len())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        s.push_str(&format!("  rcases ho with {pattern}\n"));
+        // Every resulting goal is closed by exactly one export's obligation.
+        let arms = analysis
+            .certs
+            .iter()
+            .map(|c| format!("exact ⟨rfl, CertProofs.{}_simulates⟩", c.name()))
+            .collect::<Vec<_>>()
+            .join("\n    | ");
+        s.push_str(&format!("  all_goals\n    first\n    | {arms}\n"));
+    }
+    s.push_str(&format!("\n#print axioms {FINAL_THEOREM}\n"));
+    s
 }
 
 fn render_lakefile(model_roots: &[String]) -> String {
@@ -929,7 +1164,10 @@ fn render_lakefile(model_roots: &[String]) -> String {
         roots.push(format!("`{r}"));
     }
     roots.push("`Module".to_string());
+    roots.push("`Schema".to_string());
+    roots.push("`Manifest".to_string());
     roots.push("`Certificate".to_string());
+    roots.push("`Final".to_string());
     format!(
         "import Lake\nopen Lake DSL\n\npackage «avercert» where\n  version := v!\"0.1.0\"\n\n\
          @[default_target]\nlean_lib «AverCert» where\n  srcDir := \".\"\n  roots := #[{}]\n",
@@ -937,12 +1175,24 @@ fn render_lakefile(model_roots: &[String]) -> String {
     )
 }
 
-fn render_manifest(analysis: &Analysis, wasm_name: &str, sha: &str) -> String {
+fn render_manifest(
+    analysis: &Analysis,
+    wasm_name: &str,
+    sha: &str,
+    schema_sha: &str,
+    prelude_sha: &str,
+) -> String {
     let mut s = String::new();
     s.push_str("{\n");
     s.push_str("  \"schema_version\": 1,\n");
     s.push_str(&format!("  \"wasm\": \"{wasm_name}.wasm\",\n"));
     s.push_str(&format!("  \"wasm_sha256\": \"{sha}\",\n"));
+    s.push_str(&format!("  \"level\": \"{CERT_LEVEL}\",\n"));
+    s.push_str(&format!("  \"profile\": \"{PROFILE_ID}\",\n"));
+    s.push_str(&format!("  \"abi\": \"{RUNTIME_ABI}\",\n"));
+    s.push_str(&format!("  \"final_theorem\": \"{FINAL_THEOREM}\",\n"));
+    s.push_str(&format!("  \"schema_sha256\": \"{schema_sha}\",\n"));
+    s.push_str(&format!("  \"prelude_sha256\": \"{prelude_sha}\",\n"));
     if let Some(c) = analysis.carrier {
         s.push_str(&format!("  \"carrier_type_index\": {c},\n"));
     } else {
@@ -969,9 +1219,11 @@ fn render_manifest(analysis: &Analysis, wasm_name: &str, sha: &str) -> String {
             Cert::Recursive { .. } => "self-recursive",
         };
         s.push_str(&format!(
-            "\n    {{\"name\": {}, \"class\": \"{}\", \"theorem\": \"CertProofs.{}_wasm_certified\"}}",
+            "\n    {{\"name\": {}, \"class\": \"{}\", \"policy\": \"simulatesModel\", \
+             \"level\": \"{}\", \"theorem\": \"CertProofs.{}_wasm_certified\"}}",
             json_str(c.name()),
             kind,
+            CERT_LEVEL,
             c.name()
         ));
     }
@@ -995,6 +1247,22 @@ fn render_manifest(analysis: &Analysis, wasm_name: &str, sha: &str) -> String {
     }
     s.push_str("]\n}\n");
     s
+}
+
+/// A Lean string literal (escapes `"` and `\`); contract descriptions never
+/// contain control characters.
+fn lean_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
 }
 
 fn json_str(s: &str) -> String {

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -24,8 +24,8 @@ use std::path::Path;
 
 /// The Stage-A semantics prelude, single source of truth, embedded so the
 /// emitter is self-contained.
-const CERT_PRELUDE: &str = include_str!("../../../tools/certkit/prelude/CertPrelude.lean");
-const LEAN_TOOLCHAIN: &str = include_str!("../../../tools/certkit/prelude/lean-toolchain");
+pub const CERT_PRELUDE: &str = include_str!("../../../tools/certkit/prelude/CertPrelude.lean");
+pub const LEAN_TOOLCHAIN: &str = include_str!("../../../tools/certkit/prelude/lean-toolchain");
 
 /// The audited statement schema, single source of truth, embedded so both the
 /// emitter and the `aver cert verify` checker pin the exact same bytes. The

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use clap::Parser as ClapParser;
 
+#[path = "main/cert_cmd.rs"]
+mod cert_cmd;
 #[path = "main/cli.rs"]
 mod cli;
 #[path = "main/commands.rs"]
@@ -31,7 +33,7 @@ mod shared;
 #[path = "main/why_cmd.rs"]
 mod why_cmd;
 
-use cli::{Cli, Commands, CompilePolicyMode};
+use cli::{CertCommand, Cli, Commands, CompilePolicyMode};
 #[allow(unused_imports)]
 use cli::{CompileTarget, DeployPack, DeployPreset};
 
@@ -423,5 +425,14 @@ fn main() {
                 write_baseline.as_deref(),
             );
         }
+        Commands::Cert { cmd } => match cmd {
+            CertCommand::Verify { artifact, cert_dir } => {
+                cert_cmd::cmd_cert_verify(artifact, cert_dir);
+            }
+            CertCommand::Explain { artifact, cert_dir }
+            | CertCommand::Inspect { artifact, cert_dir } => {
+                cert_cmd::cmd_cert_explain(artifact, cert_dir);
+            }
+        },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser as ClapParser;
 
+#[cfg(feature = "wasm-compile")]
 #[path = "main/cert_cmd.rs"]
 mod cert_cmd;
 #[path = "main/cli.rs"]
@@ -33,7 +34,9 @@ mod shared;
 #[path = "main/why_cmd.rs"]
 mod why_cmd;
 
-use cli::{CertCommand, Cli, Commands, CompilePolicyMode};
+#[cfg(feature = "wasm-compile")]
+use cli::CertCommand;
+use cli::{Cli, Commands, CompilePolicyMode};
 #[allow(unused_imports)]
 use cli::{CompileTarget, DeployPack, DeployPreset};
 
@@ -425,14 +428,29 @@ fn main() {
                 write_baseline.as_deref(),
             );
         }
-        Commands::Cert { cmd } => match cmd {
-            CertCommand::Verify { artifact, cert_dir } => {
-                cert_cmd::cmd_cert_verify(artifact, cert_dir);
+        Commands::Cert { cmd } => {
+            #[cfg(feature = "wasm-compile")]
+            match cmd {
+                CertCommand::Verify { artifact, cert_dir } => {
+                    cert_cmd::cmd_cert_verify(artifact, cert_dir);
+                }
+                CertCommand::Explain { artifact, cert_dir }
+                | CertCommand::Inspect { artifact, cert_dir } => {
+                    cert_cmd::cmd_cert_explain(artifact, cert_dir);
+                }
             }
-            CertCommand::Explain { artifact, cert_dir }
-            | CertCommand::Inspect { artifact, cert_dir } => {
-                cert_cmd::cmd_cert_explain(artifact, cert_dir);
+            #[cfg(not(feature = "wasm-compile"))]
+            {
+                let _ = cmd;
+                use colored::Colorize;
+                eprintln!(
+                    "{}",
+                    "aver cert requires a wasm-enabled build (rebuild with: \
+                     cargo build --features wasm)"
+                        .red()
+                );
+                std::process::exit(1);
             }
-        },
+        }
     }
 }

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -1,11 +1,13 @@
 //! `aver cert verify|explain|inspect` — the consumer side of
 //! `aver compile --certify`.
 //!
-//! `verify` is a fail-closed checker: it confirms the artifact bytes hash to
-//! the pinned value, that the audited schema and semantics prelude on disk are
-//! the ones this binary embeds, that the cert `lake build`s, and that the ONE
-//! final theorem is present with its approved statement and stays kernel-clean.
-//! `explain`/`inspect` render the manifest as a human report without building.
+//! `verify` is a fail-closed checker: it confirms the audited schema and
+//! semantics prelude on disk are the ones this binary embeds, that the cert
+//! `lake build`s, and then — via a Lean witness the checker authors itself —
+//! that the hash it computed from the artifact bytes is the one the theorems
+//! are about and that the final theorem really has type `Holds manifest`,
+//! kernel-clean. `explain` renders the manifest as a human report without
+//! building.
 
 use std::path::Path;
 use std::process::Command;

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -19,10 +19,36 @@ use serde_json::Value;
 /// trust) — fails the check.
 const AXIOM_WHITELIST: [&str; 3] = ["propext", "Classical.choice", "Quot.sound"];
 
+/// The theorem the checker composes in its own witness file: it ascribes
+/// `AverCert.Final.cert` to the type `Holds manifest`, so reading its axioms
+/// transitively covers the final theorem without matching any text.
+const WITNESS_THEOREM: &str = "AverCertChecker.final";
+
+/// Outcome of a successful (fail-closed) verify pass.
+enum Verdict {
+    /// At least one export carries a behavioral certificate.
+    Certified(String),
+    /// The certificate built and stayed kernel-clean, but names zero certified
+    /// exports — an admission with no behavioral claims. Not the green path.
+    NoExports(String),
+}
+
 pub(super) fn cmd_cert_verify(artifact: &str, cert_dir: &str) {
     match verify(Path::new(artifact), Path::new(cert_dir)) {
-        Ok(summary) => {
+        Ok(Verdict::Certified(summary)) => {
             println!("{} {}", "CERTIFIED".green().bold(), summary);
+        }
+        Ok(Verdict::NoExports(summary)) => {
+            // Fail-closed: a trust tool must not exit green for a cert that
+            // makes no behavioral claims.
+            eprintln!(
+                "{} {}",
+                "NO CERTIFIED EXPORTS (admission only, no behavioral claims)"
+                    .yellow()
+                    .bold(),
+                summary
+            );
+            std::process::exit(1);
         }
         Err(reason) => {
             eprintln!("{} {}", "DECLINED".red().bold(), reason);
@@ -52,10 +78,12 @@ fn manifest_str<'a>(m: &'a Value, key: &str) -> Result<&'a str, String> {
         .ok_or_else(|| format!("cert-manifest.json is missing string field `{key}`"))
 }
 
-fn verify(artifact: &Path, cert_dir: &Path) -> Result<String, String> {
+fn verify(artifact: &Path, cert_dir: &Path) -> Result<Verdict, String> {
     let manifest = read_manifest(cert_dir)?;
 
-    // 1. Artifact identity: the bytes must hash to the pinned value.
+    // 1. Artifact identity (fast pre-check): the bytes must hash to the pinned
+    //    value. This is a convenience tripwire on the (attacker-editable) JSON;
+    //    the kernel witness in step 4 is what actually binds the hash.
     let bytes = std::fs::read(artifact)
         .map_err(|e| format!("cannot read artifact {}: {e}", artifact.display()))?;
     let actual = cert::sha256_hex(&bytes);
@@ -92,42 +120,69 @@ fn verify(artifact: &Path, cert_dir: &Path) -> Result<String, String> {
         ));
     }
 
-    // 4. The single final theorem must be present with its approved statement
-    //    (name + `Holds manifest`) — no arbitrary Lean syntax is matched, just
-    //    the one canonical line.
-    let final_src = std::fs::read_to_string(cert_dir.join("Final.lean"))
-        .map_err(|e| format!("cannot read Final.lean: {e}"))?;
-    if !final_src.contains(cert::FINAL_STATEMENT_LINE) {
+    // 4. Kernel witness authored BY THE CHECKER (never shipped in the cert):
+    //    (a) bind the sha256 the checker just computed from the artifact bytes
+    //        to the hashes the kernel-checked theorems talk about
+    //        (`manifest.subject.artifactHash` and `CertModule.wasmSha256`), by
+    //        splicing the computed hash in as a Lean literal and demanding `rfl`;
+    //    (b) force the final theorem's TYPE to `Holds manifest` by ascription,
+    //        so a comment-smuggled `: True := trivial` cannot pass.
+    //    Elaborating this file replaces both the old (bypassable) substring
+    //    check and the separate axiom read: `#print axioms` on the composed
+    //    witness transitively covers `Final.cert`.
+    let witness = checker_witness(&actual);
+    std::fs::write(cert_dir.join("CheckerWitness.lean"), &witness)
+        .map_err(|e| format!("cannot write checker witness: {e}"))?;
+    let w = run_lake(cert_dir, &["env", "lean", "CheckerWitness.lean"])?;
+    if !w.status.success() {
         return Err(format!(
-            "final theorem statement is not the approved shape; expected exactly:\n    {}",
-            cert::FINAL_STATEMENT_LINE
-        ));
-    }
-    if manifest_str(&manifest, "final_theorem")? != cert::FINAL_THEOREM {
-        return Err(format!(
-            "manifest names an unexpected final theorem (expected {})",
-            cert::FINAL_THEOREM
+            "certificate does not bind to this artifact: the checker's kernel witness \
+             (hash binding + final-theorem type `Holds manifest`) did not check:\n{}",
+            tail(&w.combined, 30)
         ));
     }
 
-    // 5. The final theorem must be kernel-clean: re-elaborate Final.lean and
-    //    read its `#print axioms` output (robust to a cached build), then
-    //    confirm the axiom set is within the whitelist.
-    let axioms = run_lake(cert_dir, &["env", "lean", "Final.lean"])?;
-    check_axioms(&axioms.combined)?;
+    // 5. The composed witness must be kernel-clean.
+    check_axioms(&w.combined, WITNESS_THEOREM)?;
 
     let n = manifest
         .get("certified")
         .and_then(Value::as_array)
         .map(|a| a.len())
         .unwrap_or(0);
-    Ok(format!(
+    let summary = format!(
         "{} ({} certified export{}, level {})",
         artifact.display(),
         n,
         if n == 1 { "" } else { "s" },
         manifest_str(&manifest, "level").unwrap_or("L1"),
-    ))
+    );
+    if n == 0 {
+        Ok(Verdict::NoExports(summary))
+    } else {
+        Ok(Verdict::Certified(summary))
+    }
+}
+
+/// The Lean file the checker authors at verify time to bind the artifact hash
+/// and the final theorem's type to the kernel. `sha` is what the checker
+/// computed from the artifact bytes — spliced in as a literal, not read from
+/// the (attacker-editable) manifest JSON.
+fn checker_witness(sha: &str) -> String {
+    format!(
+        "-- Authored by `aver cert verify`, NOT shipped in the certificate.\n\
+         import Schema\n\
+         import Module\n\
+         import Manifest\n\
+         import Final\n\n\
+         -- Binding: the sha256 the checker computed from the artifact bytes must\n\
+         -- equal the hashes the kernel-checked theorems are about.\n\
+         example : AverCert.manifest.subject.artifactHash = \"{sha}\" := rfl\n\
+         example : CertModule.wasmSha256 = \"{sha}\" := rfl\n\n\
+         -- Statement: force the final theorem's TYPE by ascription (no text match).\n\
+         def {WITNESS_THEOREM} : AverCert.Schema.Holds AverCert.manifest := AverCert.Final.cert\n\n\
+         #print axioms {WITNESS_THEOREM}\n"
+    )
 }
 
 /// A schema/prelude file must hash to the audited value baked into this binary
@@ -154,17 +209,16 @@ fn check_audited_file(
     Ok(())
 }
 
-/// Parse the `#print axioms AverCert.Final.cert` output and confirm the final
-/// theorem depends only on whitelisted kernel axioms.
-fn check_axioms(output: &str) -> Result<(), String> {
-    let needle = format!("'{}' ", cert::FINAL_THEOREM);
+/// Parse the `#print axioms <theorem>` output and confirm the theorem depends
+/// only on whitelisted kernel axioms.
+fn check_axioms(output: &str, theorem: &str) -> Result<(), String> {
+    let needle = format!("'{theorem}' ");
     let line = output
         .lines()
         .find(|l| l.contains(&needle))
         .ok_or_else(|| {
             format!(
-                "could not read the axiom dependencies of {} (no `#print axioms` output)",
-                cert::FINAL_THEOREM
+                "could not read the axiom dependencies of {theorem} (no `#print axioms` output)"
             )
         })?;
     if line.contains("does not depend on any axioms") {

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -1,18 +1,43 @@
 //! `aver cert verify|explain` — the consumer side of `aver compile --certify`.
 //!
-//! `verify` is a fail-closed checker. It does NOT trust the certificate's build
-//! configuration or its report: it assembles its OWN build in a fresh,
-//! checker-owned temp directory from the audited `Schema.lean` / `CertPrelude.lean`
-//! this binary embeds plus the cert's DATA-only Lean files, authors its own
-//! `lakefile.lean`, and builds with a clean cache. It then — via a Lean witness
-//! the checker authors itself — binds the hash it computed from the artifact
-//! bytes to the theorems, forces the final theorem's type to `Holds manifest`,
-//! and confirms kernel-cleanliness. The certified-export report (count, names,
-//! policies, contracts) is read back from the SAME `AverCert.manifest` literal
-//! the witness proved `Holds` about, so the report can never name an export the
-//! kernel did not see. `explain` renders that same trusted report (it therefore
-//! builds too); the untrusted JSON is consulted only for the DECLINED list,
-//! which carries no behavioral claim.
+//! `verify` is a fail-closed checker whose ONLY trust channel is the exit code
+//! of the Lean toolchain over files the checker itself authored. It assembles
+//! its OWN build in a fresh, checker-owned temp directory from the audited
+//! `Schema.lean` / `CertPrelude.lean` this binary embeds plus the cert's
+//! DATA-only Lean files, authors its own `lakefile.lean`, and builds with a
+//! clean cache. It then writes a `CheckerWitness.lean` — which the checker, not
+//! the cert, authors — that:
+//!   * binds the sha256 the checker computed from the artifact bytes to the
+//!     hashes the kernel-checked theorems talk about (`rfl`);
+//!   * binds the certified-export names, contracts, profile and ABI the
+//!     UNTRUSTED `cert-manifest.json` claims to the `AverCert.manifest` literal
+//!     the final theorem is about (`rfl`) — a lying JSON makes a `rfl` fail;
+//!   * forces the final theorem's TYPE to `Holds manifest` by ascription;
+//!   * runs the kernel's own axiom collector (`Lean.collectAxioms`) on that
+//!     ascribed constant and throws unless every axiom is on the whitelist
+//!     (full `Name` equality, not text) — a smuggled `axiom`, `sorryAx` or
+//!     `ofReduceBool` makes the file fail to check.
+//!
+//! NO byte of lake/lean stdout/stderr is ever parsed into a verdict or into a
+//! CERTIFIED report line: the verdict is the witness process exit code, and the
+//! report is built in Rust from the JSON candidates the kernel just confirmed.
+//! (stdout is shown to a human inside error messages only — a display channel,
+//! never a trust channel.) `explain` renders that same trusted report.
+//!
+//! Two input gates run before anything is elaborated:
+//!   * A cert data file whose name is not a plain `Foo.lean` Lean-module
+//!     identifier is DECLINED — otherwise a name with a comma/space/newline
+//!     could inject tokens into the checker-authored lakefile's `roots` array.
+//!   * Each cert data file's raw text is scanned for a blacklist of tokens that
+//!     make Lean elaboration run arbitrary code (`#eval`, `run_cmd`, `macro`,
+//!     `elab`, `initialize`, `unsafe`, `implemented_by`, `extern`, ...). This
+//!     is a DELIBERATELY BRITTLE wall, not a proof: because `lake build`
+//!     ELABORATES these files, a data file can in principle run code (including
+//!     overwriting an already-built `.olean` the kernel will not re-check).
+//!     Fully closing that class needs a verified checker / a bytes-to-data
+//!     decoder (residual C2); the token scan only raises the bar. An attacker
+//!     who finds a bypass of THIS scan has found a documented residual, not a
+//!     break of the hash / count / axiom bindings above.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -23,11 +48,12 @@ use serde_json::Value;
 
 /// Kernel axioms a certificate is allowed to depend on. Anything else — most
 /// importantly `sorryAx` (an admitted goal) or `ofReduceBool` (native-code
-/// trust) — fails the check.
+/// trust) — fails the check. Spliced into the witness as `Name` literals and
+/// compared by full-name equality by `Lean.collectAxioms`.
 const AXIOM_WHITELIST: [&str; 3] = ["propext", "Classical.choice", "Quot.sound"];
 
-/// The theorem the checker composes in its own witness file: it ascribes
-/// `AverCert.Final.cert` to the type `Holds manifest`, so reading its axioms
+/// The constant the checker composes in its own witness file: it ascribes
+/// `AverCert.Final.cert` to the type `Holds manifest`, so collecting its axioms
 /// transitively covers the final theorem without matching any text.
 const WITNESS_THEOREM: &str = "AverCertChecker.final";
 
@@ -42,6 +68,31 @@ const CHECKER_OWNED: [&str; 4] = [
     "CheckerWitness.lean",
 ];
 
+/// Maximum length (bytes) of a JSON-supplied string spliced into the witness.
+const MAX_CANDIDATE_LEN: usize = 200;
+
+/// Tokens that make Lean ELABORATION execute code. The scan is a substring
+/// match on raw cert data-file text (see the module doc: a deliberately brittle
+/// wall, not a proof). Kept as literals rather than a parser so the wall is
+/// obvious and auditable.
+const CODE_EXEC_TOKENS: [&str; 15] = [
+    "#eval",
+    "run_cmd",
+    "run_elab",
+    "initialize",
+    "builtin_initialize",
+    "macro",
+    "macro_rules",
+    "elab",
+    "elab_rules",
+    "syntax",
+    "notation",
+    "unsafe",
+    "implemented_by",
+    "extern",
+    "open Lean",
+];
+
 /// Outcome of a successful (fail-closed) verify pass.
 enum Verdict {
     /// At least one export carries a behavioral certificate.
@@ -51,8 +102,8 @@ enum Verdict {
     NoExports(String),
 }
 
-/// The certified side of the report, read back from the kernel-checked
-/// `AverCert.manifest` literal (NOT from the attacker-editable JSON).
+/// The certified side of the report, built from the JSON candidates the kernel
+/// witness confirmed equal to the proven `AverCert.manifest` literal.
 struct TrustedReport {
     /// One `(export name, policy)` per proven obligation.
     exports: Vec<(String, String)>,
@@ -60,6 +111,17 @@ struct TrustedReport {
     profile: String,
     abi: String,
     artifact_hash: String,
+}
+
+/// Untrusted strings pulled from `cert-manifest.json`, each already passed
+/// through the charset gate on its serde-DECODED value. They are candidates:
+/// only the kernel witness (via `rfl` against `AverCert.manifest`) makes them
+/// trustworthy.
+struct Candidates {
+    names: Vec<String>,
+    contracts: Vec<String>,
+    profile: String,
+    abi: String,
 }
 
 pub(super) fn cmd_cert_verify(artifact: &str, cert_dir: &str) {
@@ -107,6 +169,79 @@ fn manifest_str<'a>(m: &'a Value, key: &str) -> Result<&'a str, String> {
         .ok_or_else(|| format!("cert-manifest.json is missing string field `{key}`"))
 }
 
+/// True iff `s`, a serde-DECODED value, is printable ASCII with no `"` or `\`
+/// and at most `MAX_CANDIDATE_LEN` bytes. Splicing only such values into the
+/// Lean witness guarantees the spliced literal cannot break out of its string
+/// or inject a line (newlines and every other control char are rejected).
+fn charset_ok(s: &str) -> bool {
+    s.len() <= MAX_CANDIDATE_LEN
+        && s.bytes()
+            .all(|b| (0x20..=0x7e).contains(&b) && b != b'"' && b != b'\\')
+}
+
+fn gate_candidate(kind: &str, s: &str) -> Result<(), String> {
+    if charset_ok(s) {
+        Ok(())
+    } else {
+        Err(format!(
+            "certificate {kind} contains a value outside the allowed charset \
+             (printable ASCII, no quote or backslash, at most {MAX_CANDIDATE_LEN} bytes): {s:?}"
+        ))
+    }
+}
+
+/// Pull the report candidates from the untrusted JSON and charset-gate each one
+/// on its decoded value. Nothing here is trusted yet — the witness `rfl`s below
+/// are what bind these to the kernel-proven manifest.
+fn read_candidates(m: &Value) -> Result<Candidates, String> {
+    let profile = manifest_str(m, "profile")?.to_string();
+    let abi = manifest_str(m, "abi")?.to_string();
+
+    let names = m
+        .get("certified")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "cert-manifest.json is missing array field `certified`".to_string())?
+        .iter()
+        .map(|c| {
+            c.get("name")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    "cert-manifest.json `certified[]` entry is missing string field `name`"
+                        .to_string()
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let contracts = m
+        .get("runtime_contracts")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "cert-manifest.json is missing array field `runtime_contracts`".to_string())?
+        .iter()
+        .map(|c| {
+            c.as_str().map(str::to_string).ok_or_else(|| {
+                "cert-manifest.json `runtime_contracts[]` entry is not a string".to_string()
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let cands = Candidates {
+        names,
+        contracts,
+        profile,
+        abi,
+    };
+    for n in &cands.names {
+        gate_candidate("certified export name", n)?;
+    }
+    for c in &cands.contracts {
+        gate_candidate("runtime contract", c)?;
+    }
+    gate_candidate("profile", &cands.profile)?;
+    gate_candidate("abi", &cands.abi)?;
+    Ok(cands)
+}
+
 fn verify(artifact: &Path, cert_dir: &Path) -> Result<Verdict, String> {
     let report = trusted_check(artifact, cert_dir)?;
     let n = report.exports.len();
@@ -125,9 +260,9 @@ fn verify(artifact: &Path, cert_dir: &Path) -> Result<Verdict, String> {
 }
 
 /// The trusted core, shared by `verify` and `explain`: bind the artifact bytes
-/// to a checker-owned build of the cert's data, prove the final theorem is
-/// `Holds manifest` kernel-clean, and read the certified report back from that
-/// same manifest literal.
+/// and the JSON report candidates to a checker-owned build of the cert's data,
+/// prove the final theorem is `Holds manifest` and kernel-clean, and — only if
+/// the witness checks — build the report from those now-confirmed candidates.
 fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, String> {
     // 1. Artifact identity (fast pre-check): the bytes must hash to the pinned
     //    value. This is a convenience tripwire on the (attacker-editable) JSON;
@@ -144,15 +279,19 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
         ));
     }
 
-    // 2. Assemble a checker-owned build. The audited schema + prelude come from
+    // 2. Report candidates from the untrusted JSON, each charset-gated on its
+    //    decoded value so it is safe to splice as a Lean literal below.
+    let cands = read_candidates(&manifest)?;
+
+    // 3. Assemble a checker-owned build. The audited schema + prelude come from
     //    THIS binary, never from the cert; the cert supplies only per-artifact
-    //    DATA (Module/Manifest/Certificate/Final + the model modules). The cert's
-    //    own lakefile / srcDir / `.lake` cache are never read, so a build-tree
-    //    subversion (decoy `Holds := True` behind a redirected srcDir or a
-    //    poisoned olean cache) cannot take effect.
+    //    DATA (Module/Manifest/Certificate/Final + the model modules). Each data
+    //    file's name is gated (no lakefile-root injection) and its text scanned
+    //    for code-executing tokens before it is staged. The cert's own lakefile
+    //    / srcDir / `.lake` cache are never read.
     let build = assemble_build(cert_dir)?;
 
-    // 3. The assembled project must build under the pinned toolchain, from a
+    // 4. The assembled project must build under the pinned toolchain, from a
     //    clean cache (the fresh dir has no `.lake`).
     let b = run_lake(&build.path, &["build"])?;
     if !b.status.success() {
@@ -162,39 +301,45 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
         ));
     }
 
-    // 4. Kernel witness authored BY THE CHECKER (never shipped in the cert):
-    //    (a) bind the sha256 the checker just computed from the artifact bytes
-    //        to the hashes the kernel-checked theorems talk about, by splicing
-    //        the computed hash in as a Lean literal and demanding `rfl`;
-    //    (b) force the final theorem's TYPE to `Holds manifest` by ascription,
-    //        so a comment-smuggled `: True := trivial` cannot pass;
-    //    (c) print the certified report from the SAME `manifest` literal, so the
-    //        report cannot name an export the kernel did not vouch for.
-    let witness = checker_witness(&actual);
+    // 5. Kernel witness authored BY THE CHECKER (never shipped in the cert):
+    //    the sha binding, the report-candidate bindings, the final-theorem type
+    //    ascription, and the axiom-whitelist check (see `checker_witness`).
+    let witness = checker_witness(&actual, &cands);
     std::fs::write(build.path.join("CheckerWitness.lean"), &witness)
         .map_err(|e| format!("cannot write checker witness: {e}"))?;
     let w = run_lake(&build.path, &["env", "lean", "CheckerWitness.lean"])?;
     if !w.status.success() {
+        // The verdict is this exit code, not any parsed line. The lake output is
+        // shown to the human to name which face failed (hash, a report binding,
+        // the `Holds manifest` type, or a non-whitelisted axiom).
         return Err(format!(
             "certificate does not bind to this artifact: the checker's kernel witness \
-             (hash binding + final-theorem type `Holds manifest`) did not check:\n{}",
+             (hash binding, certified-export/contract/profile/abi bindings against the \
+             proven manifest, final-theorem type `Holds manifest`, and the axiom \
+             whitelist) did not check:\n{}",
             tail(&w.combined, 30)
         ));
     }
 
-    // 5. The composed witness must be kernel-clean.
-    check_axioms(&w.combined, WITNESS_THEOREM)?;
-
-    // 6. Read the certified report back from the proven manifest.
-    parse_report(&w.combined)
+    // 6. The witness checked, so every candidate is kernel-confirmed equal to
+    //    the proven manifest. Build the report from those candidates; the count
+    //    is exactly the kernel-confirmed obligation count.
+    Ok(TrustedReport {
+        exports: cands
+            .names
+            .iter()
+            .map(|n| (n.clone(), "simulatesModel".to_string()))
+            .collect(),
+        contracts: cands.contracts,
+        profile: cands.profile,
+        abi: cands.abi,
+        artifact_hash: actual,
+    })
 }
 
 /// Populate a fresh, checker-owned build directory: the cert's DATA-only Lean
-/// files, the audited schema/prelude/toolchain from THIS binary, and a
-/// checker-authored lakefile. Extra/unexpected Lean files the cert ships are
-/// copied in as inert extra roots (they cannot weaken the pinned `Holds`, whose
-/// meaning lives in the binary's `Schema.lean`); if they fail to compile the
-/// build fails closed.
+/// files (each name-gated and token-scanned), the audited schema/prelude/
+/// toolchain from THIS binary, and a checker-authored lakefile.
 fn assemble_build(cert_dir: &Path) -> Result<BuildDir, String> {
     let build = BuildDir::new()?;
 
@@ -211,11 +356,16 @@ fn assemble_build(cert_dir: &Path) -> Result<BuildDir, String> {
         if !name.ends_with(".lean") || CHECKER_OWNED.contains(&name.as_str()) {
             continue;
         }
+        // Gate the file NAME: it must be a plain `Foo.lean` module identifier,
+        // so it cannot inject tokens into the checker-authored lakefile roots.
+        let root = lean_module_root(&name)?;
         let content = std::fs::read(entry.path())
             .map_err(|e| format!("cannot read cert file {name}: {e}"))?;
+        // Scan the file TEXT for code-executing tokens before staging it.
+        scan_for_code_exec(&name, &content)?;
         std::fs::write(build.path.join(&name), &content)
             .map_err(|e| format!("cannot stage {name}: {e}"))?;
-        roots.push(name.trim_end_matches(".lean").to_string());
+        roots.push(root);
     }
 
     // Audited trusted computing base from THIS binary (not the cert).
@@ -226,14 +376,50 @@ fn assemble_build(cert_dir: &Path) -> Result<BuildDir, String> {
     roots.push("CertPrelude".to_string());
 
     // Checker-authored lakefile: fixed `srcDir := "."`, roots derived from the
-    // files actually present (content-blind).
+    // (gated) files actually present.
     write(&build.path, "lakefile.lean", &checker_lakefile(&roots))?;
     Ok(build)
 }
 
+/// A cert data file must be named `<Ident>.lean` where `<Ident>` matches
+/// `^[A-Za-z][A-Za-z0-9_]*$`; return that identifier (the lakefile root).
+/// Rejecting anything else keeps the checker-authored lakefile's `roots` array
+/// free of comma/space/newline injection from a hostile filename.
+fn lean_module_root(name: &str) -> Result<String, String> {
+    let stem = name.strip_suffix(".lean").ok_or_else(|| {
+        format!("cert file `{name}` is not a `.lean` file (rejected as a build root)")
+    })?;
+    let mut chars = stem.chars();
+    let ok = matches!(chars.next(), Some(c) if c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if stem.is_empty() || !ok {
+        return Err(format!(
+            "cert file name `{name}` is not a plain Lean module identifier \
+             (must match ^[A-Za-z][A-Za-z0-9_]*\\.lean$); rejected to keep the \
+             checker's lakefile roots uninjectable"
+        ));
+    }
+    Ok(stem.to_string())
+}
+
+/// Scan a cert data file's raw text for tokens that make Lean elaboration run
+/// arbitrary code. See the module doc: a deliberately brittle wall.
+fn scan_for_code_exec(name: &str, content: &[u8]) -> Result<(), String> {
+    let text = String::from_utf8_lossy(content);
+    for tok in CODE_EXEC_TOKENS {
+        if text.contains(tok) {
+            return Err(format!(
+                "cert data file `{name}` contains the token `{tok}`, which makes Lean \
+                 elaboration execute code; declined (elaboration-executes-code wall)"
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// The checker's own lakefile. Fixed structure; the root list is whatever Lean
-/// modules ended up in the build dir. `srcDir := "."` so no cert-supplied
-/// srcDir redirection is honored.
+/// modules ended up in the build dir (all name-gated). `srcDir := "."` so no
+/// cert-supplied srcDir redirection is honored.
 fn checker_lakefile(roots: &[String]) -> String {
     let list = roots
         .iter()
@@ -246,101 +432,68 @@ fn checker_lakefile(roots: &[String]) -> String {
     )
 }
 
+/// A Lean list literal of string literals. Every element has passed the charset
+/// gate (no `"` or `\`, no control chars), so raw splicing is safe.
+fn lean_str_list(items: &[String]) -> String {
+    let inner = items
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{inner}]")
+}
+
 /// The Lean file the checker authors at verify time. `sha` is what the checker
-/// computed from the artifact bytes — spliced in as a literal, not read from
-/// the (attacker-editable) manifest JSON. The trailing `#eval` prints the
-/// certified report from the SAME `manifest` literal the theorem is about.
-fn checker_witness(sha: &str) -> String {
+/// computed from the artifact bytes; `cands` are the charset-gated JSON report
+/// candidates. Every claim is a `rfl` against `AverCert.manifest` (or the final
+/// theorem's type / the kernel axiom collector), so a lying JSON, a rebound
+/// hash, a weakened theorem, or a smuggled axiom all make this file fail to
+/// check — and THAT (the process exit code) is the only verdict channel.
+fn checker_witness(sha: &str, cands: &Candidates) -> String {
+    let n = cands.names.len();
+    let names = lean_str_list(&cands.names);
+    let contracts = lean_str_list(&cands.contracts);
+    let profile = &cands.profile;
+    let abi = &cands.abi;
+    let whitelist = AXIOM_WHITELIST
+        .iter()
+        .map(|a| format!("`{a}"))
+        .collect::<Vec<_>>()
+        .join(", ");
     format!(
         "-- Authored by `aver cert verify`, NOT shipped in the certificate.\n\
+         import Lean\n\
          import Schema\n\
          import Module\n\
          import Manifest\n\
          import Final\n\n\
-         -- Binding: the sha256 the checker computed from the artifact bytes must\n\
-         -- equal the hashes the kernel-checked theorems are about.\n\
+         -- Count (the verdict bit): the kernel confirms EXACTLY this many\n\
+         -- obligations. A JSON claiming more or fewer fails this `rfl`.\n\
+         example : AverCert.manifest.obligations.length = {n} := rfl\n\
+         -- Names: the obligation export list and the subject export list both\n\
+         -- equal the JSON-supplied candidates, or a `rfl` fails.\n\
+         example : AverCert.manifest.obligations.map (fun o => o.export_) = {names} := rfl\n\
+         example : AverCert.manifest.subject.exports = {names} := rfl\n\
+         example : AverCert.manifest.subject.contracts = {contracts} := rfl\n\
+         example : AverCert.manifest.subject.profile = \"{profile}\" := rfl\n\
+         example : AverCert.manifest.subject.abi = \"{abi}\" := rfl\n\n\
+         -- Hash binding: the sha the checker computed from the artifact bytes.\n\
          example : AverCert.manifest.subject.artifactHash = \"{sha}\" := rfl\n\
          example : CertModule.wasmSha256 = \"{sha}\" := rfl\n\n\
          -- Statement: force the final theorem's TYPE by ascription (no text match).\n\
          def {WITNESS_THEOREM} : AverCert.Schema.Holds AverCert.manifest := AverCert.Final.cert\n\n\
-         #print axioms {WITNESS_THEOREM}\n\n\
-         -- Certified report, derived from the SAME manifest literal proven above.\n\
-         #eval (do\n  \
-         for o in AverCert.manifest.obligations do\n    \
-         let pol := match o.policy with | AverCert.Schema.Policy.simulatesModel => \"simulatesModel\"\n    \
-         IO.println (\"AVERCERT-EXPORT\\t\" ++ o.export_ ++ \"\\t\" ++ pol)\n  \
-         for c in AverCert.manifest.subject.contracts do\n    \
-         IO.println (\"AVERCERT-CONTRACT\\t\" ++ c)\n  \
-         IO.println (\"AVERCERT-SUBJECT\\t\" ++ AverCert.manifest.subject.profile ++ \"\\t\" ++ AverCert.manifest.subject.abi)\n  \
-         IO.println (\"AVERCERT-HASH\\t\" ++ AverCert.manifest.subject.artifactHash) : IO Unit)\n"
+         -- Axiom whitelist, enforced by the kernel's own axiom collector over the\n\
+         -- ascribed constant: full `Name` equality, not text. Any non-whitelisted\n\
+         -- axiom (a smuggled `axiom evil`, `sorryAx`, `ofReduceBool`, ...) makes\n\
+         -- this command throw, so the file does not check and verify declines.\n\
+         open Lean in\n\
+         run_cmd do\n  \
+         let allowed : List Name := [{whitelist}]\n  \
+         let axs \u{2190} collectAxioms `{WITNESS_THEOREM}\n  \
+         for a in axs do\n    \
+         unless allowed.contains a do\n      \
+         throwError s!\"non-whitelisted axiom: {{a}}\"\n"
     )
-}
-
-/// Parse the trusted report lines the witness `#eval` emitted.
-fn parse_report(output: &str) -> Result<TrustedReport, String> {
-    let mut exports = Vec::new();
-    let mut contracts = Vec::new();
-    let mut profile = String::new();
-    let mut abi = String::new();
-    let mut artifact_hash = String::new();
-    for line in output.lines() {
-        if let Some(rest) = line.strip_prefix("AVERCERT-EXPORT\t") {
-            let mut parts = rest.splitn(2, '\t');
-            let name = parts.next().unwrap_or("").to_string();
-            let policy = parts.next().unwrap_or("").to_string();
-            exports.push((name, policy));
-        } else if let Some(rest) = line.strip_prefix("AVERCERT-CONTRACT\t") {
-            contracts.push(rest.to_string());
-        } else if let Some(rest) = line.strip_prefix("AVERCERT-SUBJECT\t") {
-            let mut parts = rest.splitn(2, '\t');
-            profile = parts.next().unwrap_or("").to_string();
-            abi = parts.next().unwrap_or("").to_string();
-        } else if let Some(rest) = line.strip_prefix("AVERCERT-HASH\t") {
-            artifact_hash = rest.to_string();
-        }
-    }
-    if artifact_hash.is_empty() {
-        return Err(
-            "checker report missing (witness did not emit the manifest render)".to_string(),
-        );
-    }
-    Ok(TrustedReport {
-        exports,
-        contracts,
-        profile,
-        abi,
-        artifact_hash,
-    })
-}
-
-/// Parse the `#print axioms <theorem>` output and confirm the theorem depends
-/// only on whitelisted kernel axioms.
-fn check_axioms(output: &str, theorem: &str) -> Result<(), String> {
-    let needle = format!("'{theorem}' ");
-    let line = output
-        .lines()
-        .find(|l| l.contains(&needle))
-        .ok_or_else(|| {
-            format!(
-                "could not read the axiom dependencies of {theorem} (no `#print axioms` output)"
-            )
-        })?;
-    if line.contains("does not depend on any axioms") {
-        return Ok(());
-    }
-    let list = line
-        .split_once("depends on axioms:")
-        .map(|(_, rest)| rest.trim())
-        .ok_or_else(|| format!("unrecognized `#print axioms` output: {line}"))?;
-    let list = list.trim_start_matches('[').trim_end_matches(']');
-    for axiom in list.split(',').map(str::trim).filter(|a| !a.is_empty()) {
-        if !AXIOM_WHITELIST.contains(&axiom) {
-            return Err(format!(
-                "final theorem depends on non-whitelisted axiom `{axiom}` (kernel not clean)"
-            ));
-        }
-    }
-    Ok(())
 }
 
 /// A checker-owned temp build directory, removed on drop.
@@ -404,9 +557,18 @@ fn tail(s: &str, lines: usize) -> String {
     all[start..].join("\n")
 }
 
-/// Human-readable report. The CERTIFIED side is the trusted, kernel-derived
+/// Keep only printable ASCII for terminal display of UNTRUSTED strings (the
+/// declined list from the JSON), so a hostile cert cannot inject ANSI escapes
+/// or control characters into the report.
+fn display_safe(s: &str) -> String {
+    s.chars()
+        .map(|c| if (' '..='~').contains(&c) { c } else { '?' })
+        .collect()
+}
+
+/// Human-readable report. The CERTIFIED side is the trusted, kernel-confirmed
 /// report (so it builds); the DECLINED side is read from the untrusted JSON
-/// (declines carry no behavioral claim).
+/// (declines carry no behavioral claim) and sanitized for display.
 fn explain(artifact: &Path, cert_dir: &Path) -> Result<(), String> {
     let report = trusted_check(artifact, cert_dir)?;
 
@@ -434,7 +596,7 @@ fn explain(artifact: &Path, cert_dir: &Path) -> Result<(), String> {
         }
     }
 
-    // DECLINED: untrusted convenience only (no behavioral claim).
+    // DECLINED: untrusted convenience only (no behavioral claim), sanitized.
     let manifest = read_manifest(cert_dir)?;
     let declined = manifest
         .get("source_level_only")
@@ -446,8 +608,8 @@ fn explain(artifact: &Path, cert_dir: &Path) -> Result<(), String> {
         println!("  (none)");
     }
     for d in &declined {
-        let name = d.get("name").and_then(Value::as_str).unwrap_or("?");
-        let reason = d.get("reason").and_then(Value::as_str).unwrap_or("?");
+        let name = display_safe(d.get("name").and_then(Value::as_str).unwrap_or("?"));
+        let reason = display_safe(d.get("reason").and_then(Value::as_str).unwrap_or("?"));
         println!("  {name} — {reason}");
     }
     Ok(())

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -1,0 +1,288 @@
+//! `aver cert verify|explain|inspect` — the consumer side of
+//! `aver compile --certify`.
+//!
+//! `verify` is a fail-closed checker: it confirms the artifact bytes hash to
+//! the pinned value, that the audited schema and semantics prelude on disk are
+//! the ones this binary embeds, that the cert `lake build`s, and that the ONE
+//! final theorem is present with its approved statement and stays kernel-clean.
+//! `explain`/`inspect` render the manifest as a human report without building.
+
+use std::path::Path;
+use std::process::Command;
+
+use aver::codegen::cert;
+use colored::Colorize;
+use serde_json::Value;
+
+/// Kernel axioms a certificate is allowed to depend on. Anything else — most
+/// importantly `sorryAx` (an admitted goal) or `ofReduceBool` (native-code
+/// trust) — fails the check.
+const AXIOM_WHITELIST: [&str; 3] = ["propext", "Classical.choice", "Quot.sound"];
+
+pub(super) fn cmd_cert_verify(artifact: &str, cert_dir: &str) {
+    match verify(Path::new(artifact), Path::new(cert_dir)) {
+        Ok(summary) => {
+            println!("{} {}", "CERTIFIED".green().bold(), summary);
+        }
+        Err(reason) => {
+            eprintln!("{} {}", "DECLINED".red().bold(), reason);
+            std::process::exit(1);
+        }
+    }
+}
+
+pub(super) fn cmd_cert_explain(artifact: &str, cert_dir: &str) {
+    if let Err(e) = explain(Path::new(artifact), Path::new(cert_dir)) {
+        eprintln!("{} {}", "error:".red(), e);
+        std::process::exit(1);
+    }
+}
+
+/// Read + parse `cert-manifest.json` from the cert directory.
+fn read_manifest(cert_dir: &Path) -> Result<Value, String> {
+    let path = cert_dir.join("cert-manifest.json");
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    serde_json::from_str(&text).map_err(|e| format!("cert-manifest.json is not valid JSON: {e}"))
+}
+
+fn manifest_str<'a>(m: &'a Value, key: &str) -> Result<&'a str, String> {
+    m.get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("cert-manifest.json is missing string field `{key}`"))
+}
+
+fn verify(artifact: &Path, cert_dir: &Path) -> Result<String, String> {
+    let manifest = read_manifest(cert_dir)?;
+
+    // 1. Artifact identity: the bytes must hash to the pinned value.
+    let bytes = std::fs::read(artifact)
+        .map_err(|e| format!("cannot read artifact {}: {e}", artifact.display()))?;
+    let actual = cert::sha256_hex(&bytes);
+    let pinned = manifest_str(&manifest, "wasm_sha256")?;
+    if actual != pinned {
+        return Err(format!(
+            "artifact hash mismatch: {} hashes to {actual}, certificate pins {pinned}",
+            artifact.display()
+        ));
+    }
+
+    // 2. Audited trusted computing base: the on-disk schema and prelude must be
+    //    exactly the ones this binary embeds (anchor), AND agree with the hashes
+    //    the manifest records (self-consistency).
+    check_audited_file(
+        cert_dir,
+        "Schema.lean",
+        &cert::audited_schema_sha(),
+        manifest_str(&manifest, "schema_sha256")?,
+    )?;
+    check_audited_file(
+        cert_dir,
+        "CertPrelude.lean",
+        &cert::audited_prelude_sha(),
+        manifest_str(&manifest, "prelude_sha256")?,
+    )?;
+
+    // 3. The certificate project must build under the pinned toolchain.
+    let build = run_lake(cert_dir, &["build"])?;
+    if !build.status.success() {
+        return Err(format!(
+            "certificate did not build (lake build failed):\n{}",
+            tail(&build.combined, 20)
+        ));
+    }
+
+    // 4. The single final theorem must be present with its approved statement
+    //    (name + `Holds manifest`) — no arbitrary Lean syntax is matched, just
+    //    the one canonical line.
+    let final_src = std::fs::read_to_string(cert_dir.join("Final.lean"))
+        .map_err(|e| format!("cannot read Final.lean: {e}"))?;
+    if !final_src.contains(cert::FINAL_STATEMENT_LINE) {
+        return Err(format!(
+            "final theorem statement is not the approved shape; expected exactly:\n    {}",
+            cert::FINAL_STATEMENT_LINE
+        ));
+    }
+    if manifest_str(&manifest, "final_theorem")? != cert::FINAL_THEOREM {
+        return Err(format!(
+            "manifest names an unexpected final theorem (expected {})",
+            cert::FINAL_THEOREM
+        ));
+    }
+
+    // 5. The final theorem must be kernel-clean: re-elaborate Final.lean and
+    //    read its `#print axioms` output (robust to a cached build), then
+    //    confirm the axiom set is within the whitelist.
+    let axioms = run_lake(cert_dir, &["env", "lean", "Final.lean"])?;
+    check_axioms(&axioms.combined)?;
+
+    let n = manifest
+        .get("certified")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0);
+    Ok(format!(
+        "{} ({} certified export{}, level {})",
+        artifact.display(),
+        n,
+        if n == 1 { "" } else { "s" },
+        manifest_str(&manifest, "level").unwrap_or("L1"),
+    ))
+}
+
+/// A schema/prelude file must hash to the audited value baked into this binary
+/// and to the value the manifest recorded.
+fn check_audited_file(
+    cert_dir: &Path,
+    name: &str,
+    audited: &str,
+    recorded: &str,
+) -> Result<(), String> {
+    let path = cert_dir.join(name);
+    let bytes = std::fs::read(&path).map_err(|e| format!("cannot read {name}: {e}"))?;
+    let on_disk = cert::sha256_hex(&bytes);
+    if on_disk != audited {
+        return Err(format!(
+            "{name} is not the audited version: it hashes to {on_disk}, this checker expects {audited}"
+        ));
+    }
+    if on_disk != recorded {
+        return Err(format!(
+            "{name} content-hash does not match the manifest (disk {on_disk}, manifest {recorded})"
+        ));
+    }
+    Ok(())
+}
+
+/// Parse the `#print axioms AverCert.Final.cert` output and confirm the final
+/// theorem depends only on whitelisted kernel axioms.
+fn check_axioms(output: &str) -> Result<(), String> {
+    let needle = format!("'{}' ", cert::FINAL_THEOREM);
+    let line = output
+        .lines()
+        .find(|l| l.contains(&needle))
+        .ok_or_else(|| {
+            format!(
+                "could not read the axiom dependencies of {} (no `#print axioms` output)",
+                cert::FINAL_THEOREM
+            )
+        })?;
+    if line.contains("does not depend on any axioms") {
+        return Ok(());
+    }
+    let list = line
+        .split_once("depends on axioms:")
+        .map(|(_, rest)| rest.trim())
+        .ok_or_else(|| format!("unrecognized `#print axioms` output: {line}"))?;
+    let list = list.trim_start_matches('[').trim_end_matches(']');
+    for axiom in list.split(',').map(str::trim).filter(|a| !a.is_empty()) {
+        if !AXIOM_WHITELIST.contains(&axiom) {
+            return Err(format!(
+                "final theorem depends on non-whitelisted axiom `{axiom}` (kernel not clean)"
+            ));
+        }
+    }
+    Ok(())
+}
+
+struct LakeOut {
+    status: std::process::ExitStatus,
+    combined: String,
+}
+
+fn run_lake(cert_dir: &Path, args: &[&str]) -> Result<LakeOut, String> {
+    let out = Command::new("lake")
+        .current_dir(cert_dir)
+        .args(args)
+        .output()
+        .map_err(|e| {
+            format!(
+                "could not run `lake {}`: {e} (is Lean/lake installed?)",
+                args.join(" ")
+            )
+        })?;
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Ok(LakeOut {
+        status: out.status,
+        combined,
+    })
+}
+
+fn tail(s: &str, lines: usize) -> String {
+    let all: Vec<&str> = s.lines().collect();
+    let start = all.len().saturating_sub(lines);
+    all[start..].join("\n")
+}
+
+/// Human-readable report from the manifest alone (no build).
+fn explain(artifact: &Path, cert_dir: &Path) -> Result<(), String> {
+    let manifest = read_manifest(cert_dir)?;
+    let level = manifest_str(&manifest, "level").unwrap_or("L1");
+    let profile = manifest_str(&manifest, "profile").unwrap_or("?");
+    let abi = manifest_str(&manifest, "abi").unwrap_or("?");
+
+    println!("{}", "Artifact certificate".bold());
+    println!("  artifact: {}", artifact.display());
+    println!(
+        "  pinned sha256: {}",
+        manifest_str(&manifest, "wasm_sha256").unwrap_or("?")
+    );
+    println!("  profile: {profile}    abi: {abi}");
+
+    let contracts: Vec<&str> = manifest
+        .get("runtime_contracts")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+
+    let certified = manifest
+        .get("certified")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    println!("\n{}", "CERTIFIED".green().bold());
+    if certified.is_empty() {
+        println!("  (none)");
+    }
+    for c in &certified {
+        let name = c.get("name").and_then(Value::as_str).unwrap_or("?");
+        let policy = c
+            .get("policy")
+            .and_then(Value::as_str)
+            .unwrap_or("simulatesModel");
+        let lvl = c.get("level").and_then(Value::as_str).unwrap_or(level);
+        let class = c.get("class").and_then(Value::as_str).unwrap_or("");
+        println!("  {}  [{}]", name.cyan().bold(), lvl);
+        println!(
+            "    policy: {policy} ({class} body simulates its model under the named contracts)"
+        );
+        if contracts.is_empty() {
+            println!("    runtime-contracts: (none)");
+        } else {
+            println!("    runtime-contracts:");
+            for rc in &contracts {
+                println!("      - {rc}");
+            }
+        }
+    }
+
+    let declined = manifest
+        .get("source_level_only")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    println!("\n{}", "DECLINED".yellow().bold());
+    if declined.is_empty() {
+        println!("  (none)");
+    }
+    for d in &declined {
+        let name = d.get("name").and_then(Value::as_str).unwrap_or("?");
+        let reason = d.get("reason").and_then(Value::as_str).unwrap_or("?");
+        println!("  {name} — {reason}");
+    }
+    Ok(())
+}

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -75,10 +75,11 @@ const MAX_CANDIDATE_LEN: usize = 200;
 /// match on raw cert data-file text (see the module doc: a deliberately brittle
 /// wall, not a proof). Kept as literals rather than a parser so the wall is
 /// obvious and auditable.
-const CODE_EXEC_TOKENS: [&str; 15] = [
+const CODE_EXEC_TOKENS: [&str; 20] = [
     "#eval",
     "run_cmd",
     "run_elab",
+    "run_tac",
     "initialize",
     "builtin_initialize",
     "macro",
@@ -90,6 +91,10 @@ const CODE_EXEC_TOKENS: [&str; 15] = [
     "unsafe",
     "implemented_by",
     "extern",
+    "deriving",
+    "attribute",
+    "@[",
+    "«",
     "open Lean",
 ];
 
@@ -486,10 +491,12 @@ fn checker_witness(sha: &str, cands: &Candidates) -> String {
          -- ascribed constant: full `Name` equality, not text. Any non-whitelisted\n\
          -- axiom (a smuggled `axiom evil`, `sorryAx`, `ofReduceBool`, ...) makes\n\
          -- this command throw, so the file does not check and verify declines.\n\
+         -- `Lean.collectAxioms` / `Lean.Name` are fully qualified so a cert that\n\
+         -- ships a root-level `def collectAxioms` shadow cannot be resolved here.\n\
          open Lean in\n\
          run_cmd do\n  \
-         let allowed : List Name := [{whitelist}]\n  \
-         let axs \u{2190} collectAxioms `{WITNESS_THEOREM}\n  \
+         let allowed : List Lean.Name := [{whitelist}]\n  \
+         let axs \u{2190} Lean.collectAxioms `{WITNESS_THEOREM}\n  \
          for a in axs do\n    \
          unless allowed.contains a do\n      \
          throwError s!\"non-whitelisted axiom: {{a}}\"\n"
@@ -577,9 +584,17 @@ fn explain(artifact: &Path, cert_dir: &Path) -> Result<(), String> {
     println!("  pinned sha256: {}", report.artifact_hash);
     println!("  profile: {}    abi: {}", report.profile, report.abi);
 
-    println!("\n{}", "CERTIFIED".green().bold());
     if report.exports.is_empty() {
-        println!("  (none)");
+        // Fail-closed parity with `verify`: a trust tool must not show a green
+        // CERTIFIED header for a cert that makes no behavioral claims.
+        println!(
+            "\n{}",
+            "NO CERTIFIED EXPORTS (admission only, no behavioral claims)"
+                .yellow()
+                .bold()
+        );
+    } else {
+        println!("\n{}", "CERTIFIED".green().bold());
     }
     for (name, policy) in &report.exports {
         println!("  {}  [{}]", name.cyan().bold(), cert::CERT_LEVEL);
@@ -611,6 +626,12 @@ fn explain(artifact: &Path, cert_dir: &Path) -> Result<(), String> {
         let name = display_safe(d.get("name").and_then(Value::as_str).unwrap_or("?"));
         let reason = display_safe(d.get("reason").and_then(Value::as_str).unwrap_or("?"));
         println!("  {name} — {reason}");
+    }
+
+    // Same fail-closed exit contract as `verify`: an admission-only cert carries
+    // no behavioral claim, so `explain`/`inspect` must not exit green either.
+    if report.exports.is_empty() {
+        std::process::exit(1);
     }
     Ok(())
 }

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -1,15 +1,20 @@
-//! `aver cert verify|explain|inspect` — the consumer side of
-//! `aver compile --certify`.
+//! `aver cert verify|explain` — the consumer side of `aver compile --certify`.
 //!
-//! `verify` is a fail-closed checker: it confirms the audited schema and
-//! semantics prelude on disk are the ones this binary embeds, that the cert
-//! `lake build`s, and then — via a Lean witness the checker authors itself —
-//! that the hash it computed from the artifact bytes is the one the theorems
-//! are about and that the final theorem really has type `Holds manifest`,
-//! kernel-clean. `explain` renders the manifest as a human report without
-//! building.
+//! `verify` is a fail-closed checker. It does NOT trust the certificate's build
+//! configuration or its report: it assembles its OWN build in a fresh,
+//! checker-owned temp directory from the audited `Schema.lean` / `CertPrelude.lean`
+//! this binary embeds plus the cert's DATA-only Lean files, authors its own
+//! `lakefile.lean`, and builds with a clean cache. It then — via a Lean witness
+//! the checker authors itself — binds the hash it computed from the artifact
+//! bytes to the theorems, forces the final theorem's type to `Holds manifest`,
+//! and confirms kernel-cleanliness. The certified-export report (count, names,
+//! policies, contracts) is read back from the SAME `AverCert.manifest` literal
+//! the witness proved `Holds` about, so the report can never name an export the
+//! kernel did not see. `explain` renders that same trusted report (it therefore
+//! builds too); the untrusted JSON is consulted only for the DECLINED list,
+//! which carries no behavioral claim.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use aver::codegen::cert;
@@ -26,6 +31,17 @@ const AXIOM_WHITELIST: [&str; 3] = ["propext", "Classical.choice", "Quot.sound"]
 /// transitively covers the final theorem without matching any text.
 const WITNESS_THEOREM: &str = "AverCertChecker.final";
 
+/// Lean source files the checker owns and never copies from the cert: the
+/// audited trusted computing base (taken from this binary) plus the checker's
+/// own build config and witness. A cert shipping files by these names has them
+/// ignored.
+const CHECKER_OWNED: [&str; 4] = [
+    "Schema.lean",
+    "CertPrelude.lean",
+    "lakefile.lean",
+    "CheckerWitness.lean",
+];
+
 /// Outcome of a successful (fail-closed) verify pass.
 enum Verdict {
     /// At least one export carries a behavioral certificate.
@@ -33,6 +49,17 @@ enum Verdict {
     /// The certificate built and stayed kernel-clean, but names zero certified
     /// exports — an admission with no behavioral claims. Not the green path.
     NoExports(String),
+}
+
+/// The certified side of the report, read back from the kernel-checked
+/// `AverCert.manifest` literal (NOT from the attacker-editable JSON).
+struct TrustedReport {
+    /// One `(export name, policy)` per proven obligation.
+    exports: Vec<(String, String)>,
+    contracts: Vec<String>,
+    profile: String,
+    abi: String,
+    artifact_hash: String,
 }
 
 pub(super) fn cmd_cert_verify(artifact: &str, cert_dir: &str) {
@@ -81,14 +108,34 @@ fn manifest_str<'a>(m: &'a Value, key: &str) -> Result<&'a str, String> {
 }
 
 fn verify(artifact: &Path, cert_dir: &Path) -> Result<Verdict, String> {
-    let manifest = read_manifest(cert_dir)?;
+    let report = trusted_check(artifact, cert_dir)?;
+    let n = report.exports.len();
+    let summary = format!(
+        "{} ({} certified export{}, level {})",
+        artifact.display(),
+        n,
+        if n == 1 { "" } else { "s" },
+        cert::CERT_LEVEL,
+    );
+    if n == 0 {
+        Ok(Verdict::NoExports(summary))
+    } else {
+        Ok(Verdict::Certified(summary))
+    }
+}
 
+/// The trusted core, shared by `verify` and `explain`: bind the artifact bytes
+/// to a checker-owned build of the cert's data, prove the final theorem is
+/// `Holds manifest` kernel-clean, and read the certified report back from that
+/// same manifest literal.
+fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, String> {
     // 1. Artifact identity (fast pre-check): the bytes must hash to the pinned
     //    value. This is a convenience tripwire on the (attacker-editable) JSON;
-    //    the kernel witness in step 4 is what actually binds the hash.
+    //    the kernel witness below is what actually binds the hash.
     let bytes = std::fs::read(artifact)
         .map_err(|e| format!("cannot read artifact {}: {e}", artifact.display()))?;
     let actual = cert::sha256_hex(&bytes);
+    let manifest = read_manifest(cert_dir)?;
     let pinned = manifest_str(&manifest, "wasm_sha256")?;
     if actual != pinned {
         return Err(format!(
@@ -97,45 +144,36 @@ fn verify(artifact: &Path, cert_dir: &Path) -> Result<Verdict, String> {
         ));
     }
 
-    // 2. Audited trusted computing base: the on-disk schema and prelude must be
-    //    exactly the ones this binary embeds (anchor), AND agree with the hashes
-    //    the manifest records (self-consistency).
-    check_audited_file(
-        cert_dir,
-        "Schema.lean",
-        &cert::audited_schema_sha(),
-        manifest_str(&manifest, "schema_sha256")?,
-    )?;
-    check_audited_file(
-        cert_dir,
-        "CertPrelude.lean",
-        &cert::audited_prelude_sha(),
-        manifest_str(&manifest, "prelude_sha256")?,
-    )?;
+    // 2. Assemble a checker-owned build. The audited schema + prelude come from
+    //    THIS binary, never from the cert; the cert supplies only per-artifact
+    //    DATA (Module/Manifest/Certificate/Final + the model modules). The cert's
+    //    own lakefile / srcDir / `.lake` cache are never read, so a build-tree
+    //    subversion (decoy `Holds := True` behind a redirected srcDir or a
+    //    poisoned olean cache) cannot take effect.
+    let build = assemble_build(cert_dir)?;
 
-    // 3. The certificate project must build under the pinned toolchain.
-    let build = run_lake(cert_dir, &["build"])?;
-    if !build.status.success() {
+    // 3. The assembled project must build under the pinned toolchain, from a
+    //    clean cache (the fresh dir has no `.lake`).
+    let b = run_lake(&build.path, &["build"])?;
+    if !b.status.success() {
         return Err(format!(
             "certificate did not build (lake build failed):\n{}",
-            tail(&build.combined, 20)
+            tail(&b.combined, 20)
         ));
     }
 
     // 4. Kernel witness authored BY THE CHECKER (never shipped in the cert):
     //    (a) bind the sha256 the checker just computed from the artifact bytes
-    //        to the hashes the kernel-checked theorems talk about
-    //        (`manifest.subject.artifactHash` and `CertModule.wasmSha256`), by
-    //        splicing the computed hash in as a Lean literal and demanding `rfl`;
+    //        to the hashes the kernel-checked theorems talk about, by splicing
+    //        the computed hash in as a Lean literal and demanding `rfl`;
     //    (b) force the final theorem's TYPE to `Holds manifest` by ascription,
-    //        so a comment-smuggled `: True := trivial` cannot pass.
-    //    Elaborating this file replaces both the old (bypassable) substring
-    //    check and the separate axiom read: `#print axioms` on the composed
-    //    witness transitively covers `Final.cert`.
+    //        so a comment-smuggled `: True := trivial` cannot pass;
+    //    (c) print the certified report from the SAME `manifest` literal, so the
+    //        report cannot name an export the kernel did not vouch for.
     let witness = checker_witness(&actual);
-    std::fs::write(cert_dir.join("CheckerWitness.lean"), &witness)
+    std::fs::write(build.path.join("CheckerWitness.lean"), &witness)
         .map_err(|e| format!("cannot write checker witness: {e}"))?;
-    let w = run_lake(cert_dir, &["env", "lean", "CheckerWitness.lean"])?;
+    let w = run_lake(&build.path, &["env", "lean", "CheckerWitness.lean"])?;
     if !w.status.success() {
         return Err(format!(
             "certificate does not bind to this artifact: the checker's kernel witness \
@@ -147,29 +185,71 @@ fn verify(artifact: &Path, cert_dir: &Path) -> Result<Verdict, String> {
     // 5. The composed witness must be kernel-clean.
     check_axioms(&w.combined, WITNESS_THEOREM)?;
 
-    let n = manifest
-        .get("certified")
-        .and_then(Value::as_array)
-        .map(|a| a.len())
-        .unwrap_or(0);
-    let summary = format!(
-        "{} ({} certified export{}, level {})",
-        artifact.display(),
-        n,
-        if n == 1 { "" } else { "s" },
-        manifest_str(&manifest, "level").unwrap_or("L1"),
-    );
-    if n == 0 {
-        Ok(Verdict::NoExports(summary))
-    } else {
-        Ok(Verdict::Certified(summary))
-    }
+    // 6. Read the certified report back from the proven manifest.
+    parse_report(&w.combined)
 }
 
-/// The Lean file the checker authors at verify time to bind the artifact hash
-/// and the final theorem's type to the kernel. `sha` is what the checker
+/// Populate a fresh, checker-owned build directory: the cert's DATA-only Lean
+/// files, the audited schema/prelude/toolchain from THIS binary, and a
+/// checker-authored lakefile. Extra/unexpected Lean files the cert ships are
+/// copied in as inert extra roots (they cannot weaken the pinned `Holds`, whose
+/// meaning lives in the binary's `Schema.lean`); if they fail to compile the
+/// build fails closed.
+fn assemble_build(cert_dir: &Path) -> Result<BuildDir, String> {
+    let build = BuildDir::new()?;
+
+    // Copy the cert's data Lean files, collecting lakefile roots as we go.
+    let mut roots: Vec<String> = Vec::new();
+    let entries = std::fs::read_dir(cert_dir)
+        .map_err(|e| format!("cannot read cert dir {}: {e}", cert_dir.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("cert dir read: {e}"))?;
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue; // skip `.lake/` and any other subdirectory
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !name.ends_with(".lean") || CHECKER_OWNED.contains(&name.as_str()) {
+            continue;
+        }
+        let content = std::fs::read(entry.path())
+            .map_err(|e| format!("cannot read cert file {name}: {e}"))?;
+        std::fs::write(build.path.join(&name), &content)
+            .map_err(|e| format!("cannot stage {name}: {e}"))?;
+        roots.push(name.trim_end_matches(".lean").to_string());
+    }
+
+    // Audited trusted computing base from THIS binary (not the cert).
+    write(&build.path, "Schema.lean", cert::CERT_SCHEMA)?;
+    write(&build.path, "CertPrelude.lean", cert::CERT_PRELUDE)?;
+    write(&build.path, "lean-toolchain", cert::LEAN_TOOLCHAIN)?;
+    roots.push("Schema".to_string());
+    roots.push("CertPrelude".to_string());
+
+    // Checker-authored lakefile: fixed `srcDir := "."`, roots derived from the
+    // files actually present (content-blind).
+    write(&build.path, "lakefile.lean", &checker_lakefile(&roots))?;
+    Ok(build)
+}
+
+/// The checker's own lakefile. Fixed structure; the root list is whatever Lean
+/// modules ended up in the build dir. `srcDir := "."` so no cert-supplied
+/// srcDir redirection is honored.
+fn checker_lakefile(roots: &[String]) -> String {
+    let list = roots
+        .iter()
+        .map(|r| format!("`{r}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "import Lake\nopen Lake DSL\n\npackage «avercert» where\n  version := v!\"0.1.0\"\n\n\
+         @[default_target]\nlean_lib «AverCert» where\n  srcDir := \".\"\n  roots := #[{list}]\n"
+    )
+}
+
+/// The Lean file the checker authors at verify time. `sha` is what the checker
 /// computed from the artifact bytes — spliced in as a literal, not read from
-/// the (attacker-editable) manifest JSON.
+/// the (attacker-editable) manifest JSON. The trailing `#eval` prints the
+/// certified report from the SAME `manifest` literal the theorem is about.
 fn checker_witness(sha: &str) -> String {
     format!(
         "-- Authored by `aver cert verify`, NOT shipped in the certificate.\n\
@@ -183,32 +263,54 @@ fn checker_witness(sha: &str) -> String {
          example : CertModule.wasmSha256 = \"{sha}\" := rfl\n\n\
          -- Statement: force the final theorem's TYPE by ascription (no text match).\n\
          def {WITNESS_THEOREM} : AverCert.Schema.Holds AverCert.manifest := AverCert.Final.cert\n\n\
-         #print axioms {WITNESS_THEOREM}\n"
+         #print axioms {WITNESS_THEOREM}\n\n\
+         -- Certified report, derived from the SAME manifest literal proven above.\n\
+         #eval (do\n  \
+         for o in AverCert.manifest.obligations do\n    \
+         let pol := match o.policy with | AverCert.Schema.Policy.simulatesModel => \"simulatesModel\"\n    \
+         IO.println (\"AVERCERT-EXPORT\\t\" ++ o.export_ ++ \"\\t\" ++ pol)\n  \
+         for c in AverCert.manifest.subject.contracts do\n    \
+         IO.println (\"AVERCERT-CONTRACT\\t\" ++ c)\n  \
+         IO.println (\"AVERCERT-SUBJECT\\t\" ++ AverCert.manifest.subject.profile ++ \"\\t\" ++ AverCert.manifest.subject.abi)\n  \
+         IO.println (\"AVERCERT-HASH\\t\" ++ AverCert.manifest.subject.artifactHash) : IO Unit)\n"
     )
 }
 
-/// A schema/prelude file must hash to the audited value baked into this binary
-/// and to the value the manifest recorded.
-fn check_audited_file(
-    cert_dir: &Path,
-    name: &str,
-    audited: &str,
-    recorded: &str,
-) -> Result<(), String> {
-    let path = cert_dir.join(name);
-    let bytes = std::fs::read(&path).map_err(|e| format!("cannot read {name}: {e}"))?;
-    let on_disk = cert::sha256_hex(&bytes);
-    if on_disk != audited {
-        return Err(format!(
-            "{name} is not the audited version: it hashes to {on_disk}, this checker expects {audited}"
-        ));
+/// Parse the trusted report lines the witness `#eval` emitted.
+fn parse_report(output: &str) -> Result<TrustedReport, String> {
+    let mut exports = Vec::new();
+    let mut contracts = Vec::new();
+    let mut profile = String::new();
+    let mut abi = String::new();
+    let mut artifact_hash = String::new();
+    for line in output.lines() {
+        if let Some(rest) = line.strip_prefix("AVERCERT-EXPORT\t") {
+            let mut parts = rest.splitn(2, '\t');
+            let name = parts.next().unwrap_or("").to_string();
+            let policy = parts.next().unwrap_or("").to_string();
+            exports.push((name, policy));
+        } else if let Some(rest) = line.strip_prefix("AVERCERT-CONTRACT\t") {
+            contracts.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("AVERCERT-SUBJECT\t") {
+            let mut parts = rest.splitn(2, '\t');
+            profile = parts.next().unwrap_or("").to_string();
+            abi = parts.next().unwrap_or("").to_string();
+        } else if let Some(rest) = line.strip_prefix("AVERCERT-HASH\t") {
+            artifact_hash = rest.to_string();
+        }
     }
-    if on_disk != recorded {
-        return Err(format!(
-            "{name} content-hash does not match the manifest (disk {on_disk}, manifest {recorded})"
-        ));
+    if artifact_hash.is_empty() {
+        return Err(
+            "checker report missing (witness did not emit the manifest render)".to_string(),
+        );
     }
-    Ok(())
+    Ok(TrustedReport {
+        exports,
+        contracts,
+        profile,
+        abi,
+        artifact_hash,
+    })
 }
 
 /// Parse the `#print axioms <theorem>` output and confirm the theorem depends
@@ -241,14 +343,42 @@ fn check_axioms(output: &str, theorem: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// A checker-owned temp build directory, removed on drop.
+struct BuildDir {
+    path: PathBuf,
+}
+
+impl BuildDir {
+    fn new() -> Result<BuildDir, String> {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path =
+            std::env::temp_dir().join(format!("aver-certverify-{}-{nanos}", std::process::id()));
+        std::fs::create_dir_all(&path).map_err(|e| format!("create checker build dir: {e}"))?;
+        Ok(BuildDir { path })
+    }
+}
+
+impl Drop for BuildDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn write(dir: &Path, name: &str, content: &str) -> Result<(), String> {
+    std::fs::write(dir.join(name), content).map_err(|e| format!("write {name}: {e}"))
+}
+
 struct LakeOut {
     status: std::process::ExitStatus,
     combined: String,
 }
 
-fn run_lake(cert_dir: &Path, args: &[&str]) -> Result<LakeOut, String> {
+fn run_lake(build_dir: &Path, args: &[&str]) -> Result<LakeOut, String> {
     let out = Command::new("lake")
-        .current_dir(cert_dir)
+        .current_dir(build_dir)
         .args(args)
         .output()
         .map_err(|e| {
@@ -274,58 +404,38 @@ fn tail(s: &str, lines: usize) -> String {
     all[start..].join("\n")
 }
 
-/// Human-readable report from the manifest alone (no build).
+/// Human-readable report. The CERTIFIED side is the trusted, kernel-derived
+/// report (so it builds); the DECLINED side is read from the untrusted JSON
+/// (declines carry no behavioral claim).
 fn explain(artifact: &Path, cert_dir: &Path) -> Result<(), String> {
-    let manifest = read_manifest(cert_dir)?;
-    let level = manifest_str(&manifest, "level").unwrap_or("L1");
-    let profile = manifest_str(&manifest, "profile").unwrap_or("?");
-    let abi = manifest_str(&manifest, "abi").unwrap_or("?");
+    let report = trusted_check(artifact, cert_dir)?;
 
     println!("{}", "Artifact certificate".bold());
     println!("  artifact: {}", artifact.display());
-    println!(
-        "  pinned sha256: {}",
-        manifest_str(&manifest, "wasm_sha256").unwrap_or("?")
-    );
-    println!("  profile: {profile}    abi: {abi}");
+    println!("  pinned sha256: {}", report.artifact_hash);
+    println!("  profile: {}    abi: {}", report.profile, report.abi);
 
-    let contracts: Vec<&str> = manifest
-        .get("runtime_contracts")
-        .and_then(Value::as_array)
-        .map(|a| a.iter().filter_map(Value::as_str).collect())
-        .unwrap_or_default();
-
-    let certified = manifest
-        .get("certified")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
     println!("\n{}", "CERTIFIED".green().bold());
-    if certified.is_empty() {
+    if report.exports.is_empty() {
         println!("  (none)");
     }
-    for c in &certified {
-        let name = c.get("name").and_then(Value::as_str).unwrap_or("?");
-        let policy = c
-            .get("policy")
-            .and_then(Value::as_str)
-            .unwrap_or("simulatesModel");
-        let lvl = c.get("level").and_then(Value::as_str).unwrap_or(level);
-        let class = c.get("class").and_then(Value::as_str).unwrap_or("");
-        println!("  {}  [{}]", name.cyan().bold(), lvl);
+    for (name, policy) in &report.exports {
+        println!("  {}  [{}]", name.cyan().bold(), cert::CERT_LEVEL);
         println!(
-            "    policy: {policy} ({class} body simulates its model under the named contracts)"
+            "    policy: {policy} (emitted body simulates its model under the named contracts)"
         );
-        if contracts.is_empty() {
+        if report.contracts.is_empty() {
             println!("    runtime-contracts: (none)");
         } else {
             println!("    runtime-contracts:");
-            for rc in &contracts {
+            for rc in &report.contracts {
                 println!("      - {rc}");
             }
         }
     }
 
+    // DECLINED: untrusted convenience only (no behavioral claim).
+    let manifest = read_manifest(cert_dir)?;
     let declined = manifest
         .get("source_level_only")
         .and_then(Value::as_array)

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -718,6 +718,32 @@ pub(super) enum Commands {
         #[arg(long)]
         write_baseline: Option<String>,
     },
+    /// Inspect and verify an emitted artifact certificate (`cert/`) against its
+    /// wasm-gc module. Consumer side of `aver compile --certify`.
+    Cert {
+        #[command(subcommand)]
+        cmd: CertCommand,
+    },
+}
+
+/// Subcommands of `aver cert`.
+#[derive(Subcommand)]
+pub(super) enum CertCommand {
+    /// Full check: pinned artifact hash, `lake build`, the single final
+    /// theorem's name + kernel-clean axioms, and the audited schema/prelude
+    /// content hashes. Exit 0 on a valid certificate, 1 otherwise.
+    Verify {
+        /// The wasm-gc module the certificate is about.
+        artifact: String,
+        /// The emitted `cert/` directory.
+        cert_dir: String,
+    },
+    /// Human-readable report (no build): CERTIFIED exports with their policies
+    /// and runtime contracts, and DECLINED functions with reasons. Reads the
+    /// manifest only.
+    Explain { artifact: String, cert_dir: String },
+    /// Alias of `explain` (report without the lake build).
+    Inspect { artifact: String, cert_dir: String },
 }
 
 #[cfg(test)]

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -779,6 +779,20 @@ mod tests {
     }
 
     #[test]
+    fn cert_verify_parses_artifact_and_dir() {
+        let cli = Cli::parse_from(["aver", "cert", "verify", "app.wasm", "out/cert"]);
+        match cli.command {
+            Commands::Cert {
+                cmd: CertCommand::Verify { artifact, cert_dir },
+            } => {
+                assert_eq!(artifact, "app.wasm");
+                assert_eq!(cert_dir, "out/cert");
+            }
+            _ => panic!("expected cert verify command"),
+        }
+    }
+
+    #[test]
     fn verify_accepts_deps_flag() {
         let cli = Cli::parse_from(["aver", "verify", "examples/modules/app.av", "--deps"]);
         match cli.command {

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -490,6 +490,19 @@ fn empty_cert_is_admission_only_and_exits_nonzero() {
         "empty cert must not print the green CERTIFIED path:\n{out}"
     );
 
+    // `explain` / `inspect` share verify's fail-closed exit contract: an
+    // admission-only cert (zero certified exports) must not exit green or show a
+    // green CERTIFIED header from either subcommand.
+    for sub in [["explain"], ["inspect"]] {
+        let (ok_e, out_e) = aver_cert(&sub, &out_dir.join("certempty.wasm"), &out_dir.join("cert"));
+        assert!(!ok_e, "empty cert `{}` must exit nonzero:\n{out_e}", sub[0]);
+        assert!(
+            out_e.contains("NO CERTIFIED EXPORTS") && !out_e.contains("\u{1b}[32m"),
+            "empty cert `{}` must report admission-only, not green CERTIFIED:\n{out_e}",
+            sub[0]
+        );
+    }
+
     // A5 report-line injection (the BANK verbatim attack), Manifest + JSON:
     // stash the fabricated `AVERCERT-EXPORT\tstealAllFunds` report line in the
     // subject `contracts`, in BOTH the Lean manifest and (consistently) the

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -1,16 +1,27 @@
 //! Integration tests for `aver cert verify` — the tripwires ARE the product.
 //!
 //! Compiles a fixture with `--certify`, confirms `aver cert verify` accepts it
-//! end to end, then confirms it fails closed on each tampering class with the
-//! expected reason:
+//! end to end, then confirms it fails closed on each tampering class:
 //!   (a) one flipped wasm byte           → artifact hash mismatch
 //!   (b) a corrupted `Module.lean` body  → lake build failure
 //!   (c) a trivialized final theorem     → kernel witness rejects the type
-//!   (d) a tampered `Schema.lean`        → not the audited version
+//!   (d) a swapped `Schema.lean`         → IGNORED: the checker builds against
+//!       its own embedded audited schema, so a cert-supplied schema (weakened
+//!       or not) has no effect and the genuine cert still verifies
 //!   (e) A1 hash rebind: foreign bytes + a matching `wasm_sha256` in the JSON
 //!       → the kernel witness rejects the hash binding
 //!   (f) A2 comment smuggle: the approved statement in a comment plus a
 //!       `: True := trivial` theorem → the kernel witness rejects the type
+//!   (g) A3 build-tree subversion: a decoy `Holds := True` behind a redirected
+//!       `srcDir` plus a weak `trivial` final → the checker ignores the cert's
+//!       lakefile/srcDir and builds the final against the embedded schema, so
+//!       the weak proof fails closed
+//!   (h) A3 olean cache: a poisoned `.lake` cache shipped in the cert →
+//!       IGNORED: the checker builds in a fresh dir, so the genuine cert still
+//!       verifies (the shipped cache is never consumed)
+//!   (i) A4 report forgery: appending a fabricated certified export to ONLY
+//!       `cert-manifest.json` → the count and names come from the proven Lean
+//!       manifest, so the forged export never appears
 //! plus a separate empty-cert test: zero certified exports must NOT print the
 //! green path and must exit nonzero.
 //!
@@ -45,13 +56,17 @@ fn copy_dir(src: &Path, dst: &Path) {
 }
 
 fn aver_verify(artifact: &Path, cert_dir: &Path) -> (bool, String) {
+    aver_cert(&["verify"], artifact, cert_dir)
+}
+
+fn aver_cert(sub: &[&str], artifact: &Path, cert_dir: &Path) -> (bool, String) {
     let out = Command::new(env!("CARGO_BIN_EXE_aver"))
         .arg("cert")
-        .arg("verify")
+        .args(sub)
         .arg(artifact)
         .arg(cert_dir)
         .output()
-        .expect("aver cert verify runs");
+        .expect("aver cert runs");
     let combined = format!(
         "{}{}",
         String::from_utf8_lossy(&out.stdout),
@@ -59,6 +74,26 @@ fn aver_verify(artifact: &Path, cert_dir: &Path) -> (bool, String) {
     );
     (out.status.success(), combined)
 }
+
+/// A weakened schema whose `Holds` is trivially `True`. Used by the A3 decoy;
+/// it defines the same surface the data modules import so the decoy tree would
+/// build under the OLD (cert-controlled) build path.
+const WEAK_SCHEMA: &str = "import CertPrelude\nimport Module\n\
+namespace AverCert.Schema\nopen CertPrelude\n\
+structure Subject where\n  artifactHash : String\n  profile : String\n  abi : String\n  \
+exports : List String\n  contracts : List String\n\
+inductive Policy where\n  | simulatesModel\n\
+structure Obligation where\n  export_ : String\n  policy : Policy\n  carrier : Nat\n  \
+code : CodeTbl\n  host : (List WVal -> Option WVal) -> (List WVal -> Option WVal) -> HostTbl\n  \
+self : Nat\n  model : Int -> Int\n\
+def Obligation.holds (_o : Obligation) : Prop := True\n\
+structure Manifest where\n  subject : Subject\n  obligations : List Obligation\n\
+def Holds (_m : Manifest) : Prop := True\n\
+end AverCert.Schema\n";
+
+const WEAK_FINAL: &str = "import Certificate\nimport Manifest\nimport Schema\n\n\
+theorem AverCert.Final.cert : AverCert.Schema.Holds manifest := trivial\n\n\
+#print axioms AverCert.Final.cert\n";
 
 #[test]
 fn cert_verify_accepts_and_tripwires_fail_closed() {
@@ -92,11 +127,16 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     let wasm = out_dir.join("certprobe2.wasm");
     let cert = out_dir.join("cert");
 
-    // Happy path: the freshly emitted certificate verifies end to end. This
-    // also warms the `.lake` build cache the tamper cases below reuse.
+    // Happy path: the freshly emitted certificate verifies end to end. The
+    // checker builds in its OWN fresh temp dir, so nothing here is cached for
+    // the tamper cases below.
     let (ok, report) = aver_verify(&wasm, &cert);
     assert!(ok, "expected clean certificate to verify, got:\n{report}");
     assert!(report.contains("CERTIFIED"), "missing CERTIFIED:\n{report}");
+    assert!(
+        report.contains("1 certified export"),
+        "expected exactly one certified export:\n{report}"
+    );
 
     // (a) One flipped wasm byte → hash mismatch, before any build.
     {
@@ -126,9 +166,9 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         assert!(out.contains("did not build"), "wrong reason (b):\n{out}");
     }
 
-    // (c) A trivialized final theorem (same name, `: True := trivial`) → the
-    //     kernel witness ascribes `Final.cert` to `Holds manifest`, so `True`
-    //     is rejected.
+    // (c) A trivialized final theorem (same name, `: True := trivial`) → it
+    //     builds, but the kernel witness ascribes `Final.cert` to
+    //     `Holds manifest`, so `True` is rejected.
     {
         let dir = temp_dir("neg-c");
         copy_dir(&out_dir, &dir);
@@ -142,17 +182,19 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         assert!(out.contains("does not bind"), "wrong reason (c):\n{out}");
     }
 
-    // (d) A tampered Schema.lean → not the audited version.
+    // (d) A swapped Schema.lean is IGNORED: the checker builds against its own
+    //     embedded audited schema, never the cert's. Even a weakened schema in
+    //     the cert dir has no effect, so the genuine cert still verifies.
     {
         let dir = temp_dir("neg-d");
         copy_dir(&out_dir, &dir);
-        let s = dir.join("cert").join("Schema.lean");
-        let mut src = std::fs::read_to_string(&s).unwrap();
-        src.push_str("\n-- tampered\n");
-        std::fs::write(&s, src).unwrap();
+        std::fs::write(dir.join("cert").join("Schema.lean"), WEAK_SCHEMA).unwrap();
         let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "tampered Schema.lean must fail:\n{out}");
-        assert!(out.contains("audited version"), "wrong reason (d):\n{out}");
+        assert!(ok, "cert-supplied Schema.lean must be ignored:\n{out}");
+        assert!(
+            out.contains("CERTIFIED"),
+            "genuine cert should verify (d):\n{out}"
+        );
     }
 
     // (e) A1 hash rebind: replace the artifact with arbitrary bytes and edit
@@ -182,8 +224,8 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
 
     // (f) A2 comment smuggle: the approved statement line present only in a
     //     COMMENT, plus a `theorem AverCert.Final.cert : True := trivial`. The
-    //     deleted substring check would have passed; the kernel witness ascribes
-    //     `Final.cert` to `Holds manifest`, and `True ≠ Holds manifest`.
+    //     kernel witness ascribes `Final.cert` to `Holds manifest`, and
+    //     `True ≠ Holds manifest`.
     {
         let dir = temp_dir("neg-f");
         copy_dir(&out_dir, &dir);
@@ -197,6 +239,99 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         assert!(!ok, "A2 comment smuggle must fail:\n{out}");
         assert!(out.contains("does not bind"), "wrong reason (f):\n{out}");
         assert!(out.contains("Holds"), "witness not exercised (f):\n{out}");
+    }
+
+    // (g) A3 build-tree subversion: point the cert's lakefile `srcDir` at a
+    //     hidden decoy tree whose `Holds := True`, and weaken the final proof to
+    //     `trivial`. Under the OLD (cert-controlled) build this passed. The
+    //     checker now ignores the cert's lakefile/srcDir and builds `Final.lean`
+    //     against its OWN embedded schema, so `trivial` fails closed.
+    {
+        let dir = temp_dir("neg-g");
+        copy_dir(&out_dir, &dir);
+        let cert = dir.join("cert");
+        // Decoy build tree with a weakened schema, reached via srcDir redirect.
+        let hidden = cert.join("hidden");
+        copy_dir(&out_dir.join("cert"), &hidden);
+        std::fs::write(hidden.join("Schema.lean"), WEAK_SCHEMA).unwrap();
+        // The (visible) final proof only holds against the trivial `Holds`.
+        std::fs::write(cert.join("Final.lean"), WEAK_FINAL).unwrap();
+        // Redirect the cert's own lakefile at the decoy tree.
+        let lf = cert.join("lakefile.lean");
+        let src = std::fs::read_to_string(&lf).unwrap();
+        let redirected = src.replace("srcDir := \".\"", "srcDir := \"hidden\"");
+        assert_ne!(src, redirected, "lakefile srcDir shape changed");
+        std::fs::write(&lf, redirected).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &cert);
+        assert!(!ok, "A3 srcDir subversion must fail:\n{out}");
+        assert!(out.contains("did not build"), "wrong reason (g):\n{out}");
+    }
+
+    // (h) A3 olean cache: ship a poisoned `.lake` cache in the cert. The checker
+    //     builds in a fresh dir and never consumes it, so a genuine cert still
+    //     verifies (a checker that reused the cache would choke on the garbage).
+    {
+        let dir = temp_dir("neg-h");
+        copy_dir(&out_dir, &dir);
+        let lib = dir.join("cert").join(".lake").join("build").join("lib");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("Schema.olean"), b"GARBAGE-NOT-AN-OLEAN").unwrap();
+        std::fs::write(lib.join("Final.olean"), b"GARBAGE").unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(ok, "shipped .lake cache must be ignored:\n{out}");
+        assert!(
+            out.contains("CERTIFIED"),
+            "genuine cert should verify (h):\n{out}"
+        );
+    }
+
+    // (i) A4 report forgery: append a fabricated certified export to ONLY the
+    //     JSON. The count and names are read back from the kernel-proven Lean
+    //     manifest, so the forged export never appears in verify or explain.
+    {
+        let dir = temp_dir("neg-i");
+        copy_dir(&out_dir, &dir);
+        let mf = dir.join("cert").join("cert-manifest.json");
+        let json = std::fs::read_to_string(&mf).unwrap();
+        let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
+        m["certified"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "name": "withdrawAll",
+                "class": "straight-line",
+                "policy": "simulatesModel",
+                "level": "L1",
+                "theorem": "CertProofs.withdrawAll_wasm_certified"
+            }));
+        m["runtime_contracts"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::Value::String("FAKE contract injected".into()));
+        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+        // Every .lean and hash is byte-identical; only the JSON changed.
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(
+            ok,
+            "genuine cert with a padded JSON should still verify:\n{out}"
+        );
+        assert!(
+            out.contains("1 certified export") && !out.contains("2 certified"),
+            "count must come from the Lean manifest, not the JSON:\n{out}"
+        );
+        assert!(
+            !out.contains("withdrawAll"),
+            "forged export leaked (i):\n{out}"
+        );
+        let (_, exp) = aver_cert(
+            &["explain"],
+            &dir.join("certprobe2.wasm"),
+            &dir.join("cert"),
+        );
+        assert!(
+            !exp.contains("withdrawAll") && !exp.contains("FAKE contract"),
+            "explain rendered a forged export/contract (i):\n{exp}"
+        );
     }
 
     let _ = std::fs::remove_dir_all(&out_dir);
@@ -241,6 +376,25 @@ fn empty_cert_is_admission_only_and_exits_nonzero() {
     assert!(
         !out.contains("CERTIFIED /") && !out.contains("\u{1b}[32m"),
         "empty cert must not print the green CERTIFIED path:\n{out}"
+    );
+
+    // A4 empty-cert honesty: a JSON padded with a fabricated certified export
+    // cannot inflate the Lean-derived count off zero.
+    let mf = out_dir.join("cert").join("cert-manifest.json");
+    let json = std::fs::read_to_string(&mf).unwrap();
+    let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
+    m["certified"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "name": "withdrawAll", "policy": "simulatesModel", "level": "L1"
+        }));
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_verify(&out_dir.join("certempty.wasm"), &out_dir.join("cert"));
+    assert!(!ok, "padded empty cert must still exit nonzero:\n{out}");
+    assert!(
+        out.contains("NO CERTIFIED EXPORTS") && !out.contains("withdrawAll"),
+        "padded JSON must not inflate the empty-cert count:\n{out}"
     );
 
     let _ = std::fs::remove_dir_all(&out_dir);

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -1,12 +1,18 @@
 //! Integration tests for `aver cert verify` — the tripwires ARE the product.
 //!
 //! Compiles a fixture with `--certify`, confirms `aver cert verify` accepts it
-//! end to end, then confirms it fails closed on each of the four tampering
-//! classes with the expected reason:
+//! end to end, then confirms it fails closed on each tampering class with the
+//! expected reason:
 //!   (a) one flipped wasm byte           → artifact hash mismatch
 //!   (b) a corrupted `Module.lean` body  → lake build failure
-//!   (c) a trivialized final theorem     → not the approved statement
+//!   (c) a trivialized final theorem     → kernel witness rejects the type
 //!   (d) a tampered `Schema.lean`        → not the audited version
+//!   (e) A1 hash rebind: foreign bytes + a matching `wasm_sha256` in the JSON
+//!       → the kernel witness rejects the hash binding
+//!   (f) A2 comment smuggle: the approved statement in a comment plus a
+//!       `: True := trivial` theorem → the kernel witness rejects the type
+//! plus a separate empty-cert test: zero certified exports must NOT print the
+//! green path and must exit nonzero.
 //!
 //! Gated behind `wasm` (the `--certify` path needs the wasm-gc backend) and
 //! skipped when `lake` is unavailable, mirroring `cert_certify_spec.rs`.
@@ -121,7 +127,8 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     }
 
     // (c) A trivialized final theorem (same name, `: True := trivial`) → the
-    //     approved statement line is gone.
+    //     kernel witness ascribes `Final.cert` to `Holds manifest`, so `True`
+    //     is rejected.
     {
         let dir = temp_dir("neg-c");
         copy_dir(&out_dir, &dir);
@@ -132,7 +139,7 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         std::fs::write(&f, trivial).unwrap();
         let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
         assert!(!ok, "trivialized final theorem must fail:\n{out}");
-        assert!(out.contains("approved shape"), "wrong reason (c):\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (c):\n{out}");
     }
 
     // (d) A tampered Schema.lean → not the audited version.
@@ -147,6 +154,94 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         assert!(!ok, "tampered Schema.lean must fail:\n{out}");
         assert!(out.contains("audited version"), "wrong reason (d):\n{out}");
     }
+
+    // (e) A1 hash rebind: replace the artifact with arbitrary bytes and edit
+    //     ONLY `wasm_sha256` in the JSON to match. The fast JSON pre-check now
+    //     passes; the kernel witness rejects it because the theorems talk about
+    //     the ORIGINAL hash, not the checker-computed one.
+    {
+        let dir = temp_dir("neg-e");
+        copy_dir(&out_dir, &dir);
+        let foreign = b"\x00\xde\xad\xbe\xef arbitrary not-a-wasm bytes".to_vec();
+        std::fs::write(dir.join("certprobe2.wasm"), &foreign).unwrap();
+        let sha = aver::codegen::cert::sha256_hex(&foreign);
+        let mf = dir.join("cert").join("cert-manifest.json");
+        let json = std::fs::read_to_string(&mf).unwrap();
+        let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
+        m["wasm_sha256"] = serde_json::Value::String(sha);
+        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "A1 hash rebind must fail:\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (e):\n{out}");
+        // The witness names the exact face the kernel rejected.
+        assert!(
+            out.contains("artifactHash"),
+            "witness not exercised (e):\n{out}"
+        );
+    }
+
+    // (f) A2 comment smuggle: the approved statement line present only in a
+    //     COMMENT, plus a `theorem AverCert.Final.cert : True := trivial`. The
+    //     deleted substring check would have passed; the kernel witness ascribes
+    //     `Final.cert` to `Holds manifest`, and `True ≠ Holds manifest`.
+    {
+        let dir = temp_dir("neg-f");
+        copy_dir(&out_dir, &dir);
+        let f = dir.join("cert").join("Final.lean");
+        let smuggled = "import Certificate\nimport Manifest\nimport Schema\n\n\
+             -- theorem AverCert.Final.cert : AverCert.Schema.Holds manifest := by trivial\n\
+             theorem AverCert.Final.cert : True := trivial\n\n\
+             #print axioms AverCert.Final.cert\n";
+        std::fs::write(&f, smuggled).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "A2 comment smuggle must fail:\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (f):\n{out}");
+        assert!(out.contains("Holds"), "witness not exercised (f):\n{out}");
+    }
+
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// A cert with zero certified exports is an admission, not a certification: it
+/// must NOT print the green CERTIFIED path and must exit nonzero (fail-closed).
+#[test]
+fn empty_cert_is_admission_only_and_exits_nonzero() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping empty-cert test: `lake` not available");
+        return;
+    }
+
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("certempty");
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+
+    let compile = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/certempty.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("aver compile --certify runs");
+    assert!(
+        compile.status.success(),
+        "compile --certify failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let (ok, out) = aver_verify(&out_dir.join("certempty.wasm"), &out_dir.join("cert"));
+    assert!(!ok, "empty cert must exit nonzero:\n{out}");
+    assert!(
+        out.contains("NO CERTIFIED EXPORTS"),
+        "empty cert must be reported as admission-only:\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED /") && !out.contains("\u{1b}[32m"),
+        "empty cert must not print the green CERTIFIED path:\n{out}"
+    );
 
     let _ = std::fs::remove_dir_all(&out_dir);
 }

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -19,11 +19,22 @@
 //!   (h) A3 olean cache: a poisoned `.lake` cache shipped in the cert →
 //!       IGNORED: the checker builds in a fresh dir, so the genuine cert still
 //!       verifies (the shipped cache is never consumed)
-//!   (i) A4 report forgery: appending a fabricated certified export to ONLY
-//!       `cert-manifest.json` → the count and names come from the proven Lean
-//!       manifest, so the forged export never appears
+//!   (i) A4 report forgery: appending a fabricated certified export/contract to
+//!       ONLY `cert-manifest.json` → the report names/count/contracts are
+//!       candidates the kernel witness binds to the proven manifest with `rfl`,
+//!       so a lying JSON makes a binding fail and the cert is DECLINED
+//!   (j) drift, JSON claims one export MORE than the manifest → DECLINED
+//!   (k) drift, JSON claims one export FEWER than the manifest → DECLINED
+//!   (l) charset gate: a candidate name carrying a control char → DECLINED
+//!       before any splice into the witness
+//!   (m) evil axiom: `Final.cert` proved from a smuggled `axiom` → the witness
+//!       axiom collector throws on the non-whitelisted axiom
+//!   (n) A7 filename gate: a cert file whose name is not a Lean module
+//!       identifier → DECLINED (no lakefile-root injection)
+//!   (o) A8 token scan: a data file carrying `#eval` → DECLINED (brittle wall)
 //! plus a separate empty-cert test: zero certified exports must NOT print the
-//! green path and must exit nonzero.
+//! green path and must exit nonzero, and the A5 report-line injection payload
+//! (in the manifest and/or JSON) is rejected by the charset gate.
 //!
 //! Gated behind `wasm` (the `--certify` path needs the wasm-gc backend) and
 //! skipped when `lake` is unavailable, mirroring `cert_certify_spec.rs`.
@@ -285,9 +296,11 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         );
     }
 
-    // (i) A4 report forgery: append a fabricated certified export to ONLY the
-    //     JSON. The count and names are read back from the kernel-proven Lean
-    //     manifest, so the forged export never appears in verify or explain.
+    // (i) A4 report forgery: append a fabricated certified export + contract to
+    //     ONLY the JSON. The report names/count/contracts are now candidates the
+    //     kernel witness binds to the proven Lean manifest with `rfl`, so a JSON
+    //     that claims an export or contract the manifest does not have makes a
+    //     binding fail: the cert is DECLINED and the forged names never appear.
     {
         let dir = temp_dir("neg-i");
         copy_dir(&out_dir, &dir);
@@ -311,26 +324,125 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
         // Every .lean and hash is byte-identical; only the JSON changed.
         let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "padded JSON must be DECLINED, not credited:\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (i):\n{out}");
+        // The declined diagnostic echoes the rejected candidate; what matters is
+        // that the forged export is never CERTIFIED (credited).
         assert!(
-            ok,
-            "genuine cert with a padded JSON should still verify:\n{out}"
+            !out.contains("CERTIFIED"),
+            "forged export credited (i):\n{out}"
+        );
+    }
+
+    // (j) Drift, JSON claims MORE than the manifest: a second certified entry
+    //     whose name is charset-clean but absent from the obligations. The
+    //     `obligations.length = N` / export-name bindings fail closed.
+    {
+        let dir = temp_dir("neg-j");
+        copy_dir(&out_dir, &dir);
+        let mf = dir.join("cert").join("cert-manifest.json");
+        let mut m: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+        m["certified"].as_array_mut().unwrap().push(serde_json::json!({
+            "name": "phantom", "class": "straight-line", "policy": "simulatesModel", "level": "L1"
+        }));
+        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "JSON claiming an extra export must fail (j):\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (j):\n{out}");
+        assert!(
+            !out.contains("CERTIFIED"),
+            "phantom export credited (j):\n{out}"
+        );
+    }
+
+    // (k) Drift, JSON claims FEWER than the manifest: an empty `certified` while
+    //     the manifest still proves one obligation. `length = 0 := rfl` fails.
+    {
+        let dir = temp_dir("neg-k");
+        copy_dir(&out_dir, &dir);
+        let mf = dir.join("cert").join("cert-manifest.json");
+        let mut m: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+        m["certified"] = serde_json::Value::Array(vec![]);
+        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "JSON dropping a real export must fail (k):\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (k):\n{out}");
+    }
+
+    // (l) Charset gate: a certified name carrying a control character (decoded
+    //     from the JSON) is rejected before any splice, so it can never reach
+    //     the Lean witness.
+    {
+        let dir = temp_dir("neg-l");
+        copy_dir(&out_dir, &dir);
+        let mf = dir.join("cert").join("cert-manifest.json");
+        let mut m: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+        m["certified"][0]["name"] = serde_json::Value::String("sumTo\nevil := by rfl".into());
+        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "control char in a candidate must fail (l):\n{out}");
+        assert!(out.contains("charset"), "wrong reason (l):\n{out}");
+    }
+
+    // (m) Evil axiom: prove `Final.cert` from a smuggled `axiom evil`. The build
+    //     succeeds (an axiom is valid Lean), but the witness runs the kernel's
+    //     axiom collector over the ascribed constant and throws on `evil`.
+    {
+        let dir = temp_dir("neg-m");
+        copy_dir(&out_dir, &dir);
+        let f = dir.join("cert").join("Final.lean");
+        let evil = "import Certificate\nimport Manifest\nimport Schema\n\n\
+             open AverCert AverCert.Schema\n\n\
+             axiom evil : AverCert.Schema.Holds AverCert.manifest\n\
+             theorem AverCert.Final.cert : AverCert.Schema.Holds manifest := evil\n";
+        std::fs::write(&f, evil).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "axiom-backed final theorem must fail (m):\n{out}");
+        assert!(
+            out.contains("non-whitelisted axiom"),
+            "witness axiom collector not exercised (m):\n{out}"
+        );
+    }
+
+    // (n) A7 filename gate: a cert data file whose name is not a plain Lean
+    //     module identifier (a space here) is rejected before staging, so it
+    //     cannot inject tokens into the checker-authored lakefile roots.
+    {
+        let dir = temp_dir("neg-n");
+        copy_dir(&out_dir, &dir);
+        std::fs::write(
+            dir.join("cert").join("bad name.lean"),
+            "-- inert\ndef x : Nat := 0\n",
+        )
+        .unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "hostile cert file name must fail (n):\n{out}");
+        assert!(
+            out.contains("module identifier"),
+            "wrong reason (n):\n{out}"
+        );
+    }
+
+    // (o) A8 token scan: a cert data file carrying an elaboration-executes-code
+    //     token is rejected before it is staged (deliberately brittle wall).
+    {
+        let dir = temp_dir("neg-o");
+        copy_dir(&out_dir, &dir);
+        let c = dir.join("cert").join("Contracts.lean");
+        let mut src = std::fs::read_to_string(&c).unwrap();
+        src.push_str("\n#eval IO.println \"pwned\"\n");
+        std::fs::write(&c, src).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(
+            !ok,
+            "code-executing token in a data file must fail (o):\n{out}"
         );
         assert!(
-            out.contains("1 certified export") && !out.contains("2 certified"),
-            "count must come from the Lean manifest, not the JSON:\n{out}"
-        );
-        assert!(
-            !out.contains("withdrawAll"),
-            "forged export leaked (i):\n{out}"
-        );
-        let (_, exp) = aver_cert(
-            &["explain"],
-            &dir.join("certprobe2.wasm"),
-            &dir.join("cert"),
-        );
-        assert!(
-            !exp.contains("withdrawAll") && !exp.contains("FAKE contract"),
-            "explain rendered a forged export/contract (i):\n{exp}"
+            out.contains("execute code") && out.contains("#eval"),
+            "wrong reason (o):\n{out}"
         );
     }
 
@@ -378,8 +490,70 @@ fn empty_cert_is_admission_only_and_exits_nonzero() {
         "empty cert must not print the green CERTIFIED path:\n{out}"
     );
 
+    // A5 report-line injection (the BANK verbatim attack), Manifest + JSON:
+    // stash the fabricated `AVERCERT-EXPORT\tstealAllFunds` report line in the
+    // subject `contracts`, in BOTH the Lean manifest and (consistently) the
+    // JSON, over an empty obligations list. There is no report parser anymore,
+    // and the newline/tab in the candidate is rejected by the charset gate
+    // before any splice: DECLINED, and `stealAllFunds` is never credited.
+    {
+        let dir = temp_dir("certempty-a5");
+        copy_dir(&out_dir, &dir);
+        let man = dir.join("cert").join("Manifest.lean");
+        let src = std::fs::read_to_string(&man).unwrap();
+        let payload_lean = "[\"x\\nAVERCERT-EXPORT\\tstealAllFunds\\tsimulatesModel\"]";
+        let poisoned = src.replacen(
+            "contracts := []",
+            &format!("contracts := {payload_lean}"),
+            1,
+        );
+        assert_ne!(src, poisoned, "empty-cert manifest contracts shape changed");
+        std::fs::write(&man, poisoned).unwrap();
+        let mf = dir.join("cert").join("cert-manifest.json");
+        let mut m: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+        m["runtime_contracts"] = serde_json::Value::Array(vec![serde_json::Value::String(
+            "x\nAVERCERT-EXPORT\tstealAllFunds\tsimulatesModel".into(),
+        )]);
+        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certempty.wasm"), &dir.join("cert"));
+        assert!(!ok, "A5 injection payload must fail:\n{out}");
+        assert!(
+            out.contains("charset"),
+            "wrong reason (A5 manifest):\n{out}"
+        );
+        // The charset diagnostic echoes the rejected value; the property is that
+        // the payload is never CERTIFIED.
+        assert!(
+            !out.contains("CERTIFIED"),
+            "A5 payload credited an export:\n{out}"
+        );
+    }
+
+    // A5 JSON-only variant: the same payload only in the JSON (manifest left
+    // empty). Still DECLINED by the charset gate.
+    {
+        let dir = temp_dir("certempty-a5json");
+        copy_dir(&out_dir, &dir);
+        let mf = dir.join("cert").join("cert-manifest.json");
+        let mut m: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+        m["runtime_contracts"] = serde_json::Value::Array(vec![serde_json::Value::String(
+            "x\nAVERCERT-EXPORT\tstealAllFunds\tsimulatesModel".into(),
+        )]);
+        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certempty.wasm"), &dir.join("cert"));
+        assert!(!ok, "A5 JSON-only payload must fail:\n{out}");
+        assert!(out.contains("charset"), "wrong reason (A5 json):\n{out}");
+        assert!(
+            !out.contains("CERTIFIED"),
+            "A5 JSON-only payload credited an export:\n{out}"
+        );
+    }
+
     // A4 empty-cert honesty: a JSON padded with a fabricated certified export
-    // cannot inflate the Lean-derived count off zero.
+    // now fails the kernel binding (the count is `obligations.length = N` by
+    // rfl, and the empty manifest proves zero), so it is DECLINED, not credited.
     let mf = out_dir.join("cert").join("cert-manifest.json");
     let json = std::fs::read_to_string(&mf).unwrap();
     let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -393,8 +567,8 @@ fn empty_cert_is_admission_only_and_exits_nonzero() {
     let (ok, out) = aver_verify(&out_dir.join("certempty.wasm"), &out_dir.join("cert"));
     assert!(!ok, "padded empty cert must still exit nonzero:\n{out}");
     assert!(
-        out.contains("NO CERTIFIED EXPORTS") && !out.contains("withdrawAll"),
-        "padded JSON must not inflate the empty-cert count:\n{out}"
+        out.contains("does not bind") && !out.contains("CERTIFIED"),
+        "padded JSON must be DECLINED, not credited:\n{out}"
     );
 
     let _ = std::fs::remove_dir_all(&out_dir);

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -1,0 +1,152 @@
+//! Integration tests for `aver cert verify` — the tripwires ARE the product.
+//!
+//! Compiles a fixture with `--certify`, confirms `aver cert verify` accepts it
+//! end to end, then confirms it fails closed on each of the four tampering
+//! classes with the expected reason:
+//!   (a) one flipped wasm byte           → artifact hash mismatch
+//!   (b) a corrupted `Module.lean` body  → lake build failure
+//!   (c) a trivialized final theorem     → not the approved statement
+//!   (d) a tampered `Schema.lean`        → not the audited version
+//!
+//! Gated behind `wasm` (the `--certify` path needs the wasm-gc backend) and
+//! skipped when `lake` is unavailable, mirroring `cert_certify_spec.rs`.
+#![cfg(feature = "wasm")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let mut d = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    d.push(format!("aver-{prefix}-{nanos}"));
+    d
+}
+
+fn copy_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let to = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir(&entry.path(), &to);
+        } else {
+            std::fs::copy(entry.path(), &to).unwrap();
+        }
+    }
+}
+
+fn aver_verify(artifact: &Path, cert_dir: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .arg("cert")
+        .arg("verify")
+        .arg(artifact)
+        .arg(cert_dir)
+        .output()
+        .expect("aver cert verify runs");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), combined)
+}
+
+#[test]
+fn cert_verify_accepts_and_tripwires_fail_closed() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping cert verify test: `lake` not available");
+        return;
+    }
+
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("certverify");
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+
+    // Emit the recursive fixture's certificate.
+    let compile = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/certprobe2.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("aver compile --certify runs");
+    assert!(
+        compile.status.success(),
+        "compile --certify failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let wasm = out_dir.join("certprobe2.wasm");
+    let cert = out_dir.join("cert");
+
+    // Happy path: the freshly emitted certificate verifies end to end. This
+    // also warms the `.lake` build cache the tamper cases below reuse.
+    let (ok, report) = aver_verify(&wasm, &cert);
+    assert!(ok, "expected clean certificate to verify, got:\n{report}");
+    assert!(report.contains("CERTIFIED"), "missing CERTIFIED:\n{report}");
+
+    // (a) One flipped wasm byte → hash mismatch, before any build.
+    {
+        let dir = temp_dir("neg-a");
+        copy_dir(&out_dir, &dir);
+        let w = dir.join("certprobe2.wasm");
+        let mut bytes = std::fs::read(&w).unwrap();
+        let mid = bytes.len() / 2;
+        bytes[mid] ^= 0x01;
+        std::fs::write(&w, &bytes).unwrap();
+        let (ok, out) = aver_verify(&w, &dir.join("cert"));
+        assert!(!ok, "flipped wasm byte must fail:\n{out}");
+        assert!(out.contains("hash mismatch"), "wrong reason (a):\n{out}");
+    }
+
+    // (b) A corrupted Module.lean instruction → lake build failure.
+    {
+        let dir = temp_dir("neg-b");
+        copy_dir(&out_dir, &dir);
+        let m = dir.join("cert").join("Module.lean");
+        let src = std::fs::read_to_string(&m).unwrap();
+        let corrupted = src.replacen(".i64Const 0, .i64LeS", ".i64Const 999, .i64LeS", 1);
+        assert_ne!(src, corrupted, "fixture body shape changed");
+        std::fs::write(&m, corrupted).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "corrupted Module.lean must fail:\n{out}");
+        assert!(out.contains("did not build"), "wrong reason (b):\n{out}");
+    }
+
+    // (c) A trivialized final theorem (same name, `: True := trivial`) → the
+    //     approved statement line is gone.
+    {
+        let dir = temp_dir("neg-c");
+        copy_dir(&out_dir, &dir);
+        let f = dir.join("cert").join("Final.lean");
+        let trivial = "import Certificate\nimport Manifest\nimport Schema\n\n\
+             theorem AverCert.Final.cert : True := trivial\n\n\
+             #print axioms AverCert.Final.cert\n";
+        std::fs::write(&f, trivial).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "trivialized final theorem must fail:\n{out}");
+        assert!(out.contains("approved shape"), "wrong reason (c):\n{out}");
+    }
+
+    // (d) A tampered Schema.lean → not the audited version.
+    {
+        let dir = temp_dir("neg-d");
+        copy_dir(&out_dir, &dir);
+        let s = dir.join("cert").join("Schema.lean");
+        let mut src = std::fs::read_to_string(&s).unwrap();
+        src.push_str("\n-- tampered\n");
+        std::fs::write(&s, src).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "tampered Schema.lean must fail:\n{out}");
+        assert!(out.contains("audited version"), "wrong reason (d):\n{out}");
+    }
+
+    let _ = std::fs::remove_dir_all(&out_dir);
+}

--- a/tools/certkit/fixtures/certempty.av
+++ b/tools/certkit/fixtures/certempty.av
@@ -1,0 +1,12 @@
+module CertEmpty
+    intent =
+        "Probe with no certifiable exports: the only function is outside the"
+        "single-argument certified fragment, so nothing is certified."
+    exposes [addPair]
+
+fn addPair(a: Int, b: Int) -> Int
+    ? "Two-argument add; declined by the Stage-B single-argument templates."
+    a + b
+
+verify addPair
+    addPair(1, 2) => 3


### PR DESCRIPTION
Rewrites the consumer-side `aver cert verify` so its verdict and its CERTIFIED report come solely from the exit code of `lake env lean` over a checker-authored `CheckerWitness.lean` — no byte of lake/lean stdout is parsed into a verdict or a report line.

- The certified-export names, subject exports, runtime contracts, profile and ABI are taken as charset-gated candidates from the untrusted `cert-manifest.json` and bound to the kernel-checked `AverCert.manifest` literal by `rfl`; a lying JSON fails a binding and the certificate is DECLINED.
- The certified count is exactly `obligations.length` confirmed by `rfl` (N=0 → NO CERTIFIED EXPORTS, exit 1; N≥1 required for CERTIFIED).
- The axiom whitelist is enforced structurally by the kernel's own `Lean.collectAxioms` over the ascribed final theorem (full `Name` equality), not by parsing `#print axioms` text.
- Two pre-elaboration input gates: cert data filenames must be plain Lean-module identifiers (kills lakefile-root injection), and each data file is scanned for elaboration-executes-code tokens (a deliberately brittle wall).
- `explain`/`inspect` share verify's fail-closed exit contract for admission-only certs.

Deletes the previous `parse_report` / `check_axioms` / `#eval` report channel. Known residual, tracked separately: the checker does not yet re-derive the instruction bodies from the wasm bytes at verify time (the bytes↔data bridge / audited re-disassembler).

Tests: `cargo test --features wasm --test cert_verify_spec` (owns-build tripwires A1–A4, empty-cert, happy-path, plus report-injection / JSON drift / charset / evil-axiom / filename / token cases). Build, fmt, clippy(--bin aver) clean.