### PR TITLE
Re-derive certified bodies from the module bytes on cert verify

### DIFF
--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -19,8 +19,10 @@
 //! the shape present in the hashed bytes.
 //!
 //! `aver cert verify` re-runs this same audited pipeline on the hash-verified
-//! bytes (`rederive_code_defs`) and confirms the cert's `Module.lean` states
-//! exactly those bodies — so the WInstr data is re-derived from the bytes, not
+//! bytes (`rederive_obligations`) and pins the re-derived `code`/`host`/`self`/
+//! `carrier` values into its checker-authored witness with `rfl` against the
+//! proven `manifest.obligations` — so the `WInstr` data the kernel theorem
+//! actually reasons about is forced to equal what the bytes decode to, not
 //! merely trusted. This is trusted via inspection of the disassembler, not by an
 //! in-kernel wasm decode proof (a full kernel decoder is a deferred residual).
 
@@ -230,24 +232,46 @@ pub fn analyze(wasm_bytes: &[u8]) -> Result<Analysis, String> {
     })
 }
 
-/// Re-derive the certified `{name}Code` definitions straight from the module
-/// bytes, using the SAME audited `disassemble` → `classify` → `render_code_def`
-/// pipeline the emitter uses. Returns `(export_name, code_def_text)` for every
-/// user function that classifies into a certified template; the text is
-/// byte-identical to the block `render_module` embeds in the cert's
-/// `Module.lean`. A checker holding the hash-verified bytes can therefore
-/// confirm that each certified body actually decodes from those bytes, rather
-/// than trusting the (attacker-editable) `WInstr` data in `Module.lean`.
+/// A certified obligation re-derived straight from the module bytes: the
+/// `CodeTbl` body value, the fully-expanded host-builder value, the self
+/// function index and the carrier type index — every one a pure function of the
+/// hash-verified bytes, via the SAME audited `disassemble` → `classify` pipeline
+/// the emitter uses. `aver cert verify` splices these into its checker-authored
+/// witness and pins each with `rfl` against the matching `manifest.obligations`
+/// projection, so an obligation whose `code`/`host`/`self`/`carrier` diverge
+/// from the bytes (a fabricated or vacuous body) fails the kernel witness.
 ///
-/// This is trusted by inspection of the Aver disassembler (the consumer's own
-/// binary), not by a kernel decode proof; a full in-kernel wasm decoder is a
-/// deferred residual.
-pub fn rederive_code_defs(wasm_bytes: &[u8]) -> Result<Vec<(String, String)>, String> {
+/// Trusted by inspection of the Aver disassembler (the consumer's own binary),
+/// not by an in-kernel wasm decode proof; a full kernel decoder is a deferred
+/// residual.
+pub struct RederivedObligation {
+    pub name: String,
+    /// The `fun fn => ...` `CodeTbl` value (`render_code_value`).
+    pub code: String,
+    /// The fully-expanded host builder value (`render_host_value`).
+    pub host: String,
+    /// `Obligation.self`: the self function index in the module.
+    pub self_idx: u32,
+    /// `Obligation.carrier`: the Int carrier struct type index.
+    pub carrier: u32,
+}
+
+/// Re-derive one [`RederivedObligation`] per user function that classifies into
+/// a certified template, in module (obligation) order. The order and length
+/// match `render_manifest_lean`'s `obligations` list, so the checker's
+/// list-equality `rfl`s bind position for position.
+pub fn rederive_obligations(wasm_bytes: &[u8]) -> Result<Vec<RederivedObligation>, String> {
     let (user_fns, box_idx, user_idx_set, carrier) = disassemble(wasm_bytes)?;
     let mut out = Vec::new();
     for f in &user_fns {
         if let Ok(c) = classify(f, box_idx, carrier, &user_idx_set) {
-            out.push((c.name().to_string(), render_code_def(&c)));
+            out.push(RederivedObligation {
+                name: c.name().to_string(),
+                code: render_code_value(&c),
+                host: render_host_value(&c),
+                self_idx: c.self_idx(),
+                carrier: c.carrier(),
+            });
         }
     }
     Ok(out)
@@ -760,9 +784,28 @@ fn render_host_def(c: &Cert) -> String {
 }
 
 fn render_code_def(c: &Cert) -> String {
+    let doc = match c {
+        Cert::StraightLine { .. } => "straight-line add-constant",
+        Cert::Recursive { .. } => "self-recursive",
+    };
+    format!(
+        "/-- Verbatim emitted body of `{name}` ({doc}). -/\n\
+         def {name}Code : CodeTbl := {value}\n",
+        name = c.name(),
+        value = render_code_value(c),
+    )
+}
+
+/// The `CodeTbl` VALUE (the `fun fn => ...` lambda, no `def` wrapper) a
+/// certified body decodes to. This is the term the checker splices, verbatim,
+/// into `CheckerWitness.lean` and pins with `rfl` against
+/// `manifest.obligations.map (·.code)`, so a `{name}Code` def in the cert's
+/// `Module.lean` that diverges from the bytes fails the kernel witness. Kept
+/// byte-identical to the RHS `render_code_def` emits so the emitted `Module.lean`
+/// is unchanged.
+fn render_code_value(c: &Cert) -> String {
     match c {
         Cert::StraightLine {
-            name,
             self_idx,
             nlocals,
             k,
@@ -770,22 +813,20 @@ fn render_code_def(c: &Cert) -> String {
             add_idx,
             ..
         } => format!(
-            "/-- Verbatim emitted body of `{name}` (straight-line add-constant). -/\n\
-             def {name}Code : CodeTbl := fun fn =>\n  \
+            "fun fn =>\n  \
              if fn = {self_idx} then some ⟨1, {nlocals}, \
-             [.localGet 0, .i64Const ({k}), .call {box_idx}, .call {add_idx}]⟩ else none\n",
+             [.localGet 0, .i64Const ({k}), .call {box_idx}, .call {add_idx}]⟩ else none",
         ),
         Cert::Recursive {
-            name,
             self_idx,
             nlocals,
             carrier,
             box_idx,
             add_idx,
             sub_idx,
+            ..
         } => format!(
-            "/-- Verbatim emitted body of `{name}` (self-recursive). -/\n\
-             def {name}Code : CodeTbl := fun fn =>\n  \
+            "fun fn =>\n  \
              if fn = {self_idx} then some ⟨1, {nlocals},\n    \
              [ .localGet 0, .localSet 1,\n      \
              .localGet 1, .structGet {carrier} 1, .refIsNull,\n      \
@@ -793,7 +834,41 @@ fn render_code_def(c: &Cert) -> String {
              [.localGet 1, .structGet {carrier} 2, .i32Const 0, .i32LtS],\n      \
              .ifElse [.i64Const 0, .call {box_idx}]\n              \
              [.localGet 0, .localGet 0, .i64Const 1, .call {box_idx}, .call {sub_idx}, \
-             .call {self_idx}, .call {add_idx}] ]⟩\n  else none\n",
+             .call {self_idx}, .call {add_idx}] ]⟩\n  else none",
+        ),
+    }
+}
+
+/// The `Obligation.host` builder VALUE for a certified body, FULLY EXPANDED to
+/// the box/add/sub wiring on the byte-derived indices — deliberately NOT a
+/// reference to `CertModule.{name}Host` (which an attacker edits). The checker
+/// splices this and pins it with `rfl` against `manifest.obligations.map
+/// (·.host)`, so a nerfed host (e.g. `fun _ _ _ => none`, which would make
+/// `holds` vacuous even with an honest `code`) fails the kernel witness.
+/// Definitionally equal to the honest `render_host_def` builder.
+fn render_host_value(c: &Cert) -> String {
+    match c {
+        Cert::StraightLine {
+            carrier,
+            box_idx,
+            add_idx,
+            ..
+        } => format!(
+            "fun add _ => fun fn =>\n    \
+             if fn = {box_idx} then some (1, boxRef {carrier})\n    \
+             else if fn = {add_idx} then some (2, add)\n    else none",
+        ),
+        Cert::Recursive {
+            carrier,
+            box_idx,
+            add_idx,
+            sub_idx,
+            ..
+        } => format!(
+            "fun add sub => fun fn =>\n    \
+             if fn = {box_idx} then some (1, boxRef {carrier})\n    \
+             else if fn = {add_idx} then some (2, add)\n    \
+             else if fn = {sub_idx} then some (2, sub)\n    else none",
         ),
     }
 }

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -16,8 +16,13 @@
 //! matched against the two structural templates, and re-rendered as
 //! `CertPrelude.WInstr` data. A function whose real emitted body does not match
 //! a template is declined — so the `WInstr` data in `Module.lean` is exactly
-//! the shape present in the hashed bytes. Checker-side re-derivation of the
-//! body from the bytes (avercheck) is Stage C and deliberately not built here.
+//! the shape present in the hashed bytes.
+//!
+//! `aver cert verify` re-runs this same audited pipeline on the hash-verified
+//! bytes (`rederive_code_defs`) and confirms the cert's `Module.lean` states
+//! exactly those bodies — so the WInstr data is re-derived from the bytes, not
+//! merely trusted. This is trusted via inspection of the disassembler, not by an
+//! in-kernel wasm decode proof (a full kernel decoder is a deferred residual).
 
 use sha2::{Digest, Sha256};
 use std::path::Path;
@@ -223,6 +228,29 @@ pub fn analyze(wasm_bytes: &[u8]) -> Result<Analysis, String> {
         carrier,
         contracts,
     })
+}
+
+/// Re-derive the certified `{name}Code` definitions straight from the module
+/// bytes, using the SAME audited `disassemble` → `classify` → `render_code_def`
+/// pipeline the emitter uses. Returns `(export_name, code_def_text)` for every
+/// user function that classifies into a certified template; the text is
+/// byte-identical to the block `render_module` embeds in the cert's
+/// `Module.lean`. A checker holding the hash-verified bytes can therefore
+/// confirm that each certified body actually decodes from those bytes, rather
+/// than trusting the (attacker-editable) `WInstr` data in `Module.lean`.
+///
+/// This is trusted by inspection of the Aver disassembler (the consumer's own
+/// binary), not by a kernel decode proof; a full in-kernel wasm decoder is a
+/// deferred residual.
+pub fn rederive_code_defs(wasm_bytes: &[u8]) -> Result<Vec<(String, String)>, String> {
+    let (user_fns, box_idx, user_idx_set, carrier) = disassemble(wasm_bytes)?;
+    let mut out = Vec::new();
+    for f in &user_fns {
+        if let Ok(c) = classify(f, box_idx, carrier, &user_idx_set) {
+            out.push((c.name().to_string(), render_code_def(&c)));
+        }
+    }
+    Ok(out)
 }
 
 // ---- disassembly ---------------------------------------------------------

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -24,19 +24,26 @@
 //! (stdout is shown to a human inside error messages only — a display channel,
 //! never a trust channel.) `explain` renders that same trusted report.
 //!
-//! After the witness checks, the certified bodies are RE-DERIVED from the
-//! hash-verified artifact bytes by the audited Aver disassembler
-//! (`cert::rederive_code_defs`) and compared, byte for byte, against the
-//! `{name}Code` definitions in the cert's `Module.lean` (read here independently
-//! as attacker-editable text). The kernel witness proves "some Lean-encoded body
-//! simulates the model and the bytes hash to S"; it does NOT prove that body
-//! actually DECODES from those bytes. So a hostile producer could ship `WInstr`
-//! data unrelated to the real bytes with a vacuously-true `holds`. Re-deriving
-//! the bodies from the bytes and matching them against `Module.lean` closes that
-//! bytes-vs-data divergence for every certified export (missing / diverging /
-//! disassembler-declined -> DECLINED). This is trusted via inspection of the
-//! disassembler, not an in-kernel wasm decode proof; a full kernel decoder is a
-//! deferred residual.
+//! The bytes-vs-data divergence is closed INSIDE that same kernel witness. A
+//! bare `Holds manifest` proof only says "some Lean-encoded body simulates the
+//! model and the bytes hash to S"; it does NOT say that body DECODES from those
+//! bytes, so a hostile producer could ship `WInstr` data unrelated to the real
+//! bytes with a vacuously-true `holds`. To close that, the checker re-derives
+//! each obligation's `code`, `host`, `self` and `carrier` from the hash-verified
+//! bytes with the audited Aver disassembler (`cert::rederive_obligations`) and
+//! splices those values, fully expanded, into the witness — then pins them with
+//! `rfl` against `manifest.obligations.map (·.code / ·.host / ·.self / ·.carrier)`.
+//! Those are EXACTLY the fields `Obligation.holds` reasons about
+//! (`wFuncN o.code (o.host add sub) fuel o.self`), so a fabricated body, a
+//! decoupled `code`/`self`/`carrier`, or a nerfed `host` (which would make
+//! `holds` vacuous) all diverge from the bytes and fail a `rfl` — the file does
+//! not check and verify declines. The spliced terms are the checker's own
+//! rendering over the bytes, never attacker text, and are fully expanded so they
+//! do not reference the cert's `CertModule.*` defs (which an attacker edits).
+//! `Module.lean` is never read as text for comparison. This is trusted via
+//! inspection of the disassembler, not an in-kernel wasm decode proof; a full
+//! kernel decoder is a deferred residual, and `model` (not byte-re-derivable for
+//! a recursive reference function) remains a read declaration.
 //!
 //! Two input gates run before anything is elaborated:
 //!   * A cert data file whose name is not a plain `Foo.lean` Lean-module
@@ -85,11 +92,13 @@ const CHECKER_OWNED: [&str; 4] = [
 /// Maximum length (bytes) of a JSON-supplied string spliced into the witness.
 const MAX_CANDIDATE_LEN: usize = 200;
 
-/// Emitted on a CERTIFIED verdict once the certified bodies have been re-derived
-/// from the hash-verified module bytes and matched against the cert's
-/// `Module.lean`. This is an orthogonal guarantee, trusted via the audited Aver
-/// disassembler (not a kernel decode proof); it does not change the cert level.
-const ARTIFACT_DECODE_LINE: &str = "artifact-decode: bytes re-derive to the certified bodies (L1.5, trusted via the audited disassembler)";
+/// Emitted on a CERTIFIED verdict: every obligation's code/host/self/carrier was
+/// re-derived from the hash-verified module bytes and pinned to the proven
+/// manifest by `rfl` inside the kernel witness (so the certified `holds` is a
+/// statement about what the bytes actually decode to). Trusted via the audited
+/// Aver disassembler, not an in-kernel wasm decode proof; it does not change the
+/// cert level.
+const ARTIFACT_DECODE_LINE: &str = "artifact-decode: obligations' code/host/self/carrier are kernel-pinned (rfl) to what the bytes decode to (trusted via the audited disassembler)";
 
 /// Tokens that make Lean ELABORATION execute code. The scan is a substring
 /// match on raw cert data-file text (see the module doc: a deliberately brittle
@@ -309,6 +318,15 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
     //    decoded value so it is safe to splice as a Lean literal below.
     let cands = read_candidates(&manifest)?;
 
+    // 2b. Re-derive the certified obligations (code/host/self/carrier) straight
+    //     from the hash-verified artifact bytes with the audited disassembler.
+    //     These are spliced into the checker witness below and pinned with `rfl`
+    //     against `manifest.obligations`, so the kernel theorem is forced to
+    //     reason about exactly what the bytes decode to. If disassembly fails
+    //     outright (not a wasm module, no box helper), decline here — before the
+    //     witness — fail-closed.
+    let rederived = cert::rederive_obligations(&bytes)?;
+
     // 3. Assemble a checker-owned build. The audited schema + prelude come from
     //    THIS binary, never from the cert; the cert supplies only per-artifact
     //    DATA (Module/Manifest/Certificate/Final + the model modules). Each data
@@ -328,34 +346,28 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
     }
 
     // 5. Kernel witness authored BY THE CHECKER (never shipped in the cert):
-    //    the sha binding, the report-candidate bindings, the final-theorem type
-    //    ascription, and the axiom-whitelist check (see `checker_witness`).
-    let witness = checker_witness(&actual, &cands);
+    //    the sha binding, the report-candidate bindings, the artifact-decode
+    //    bindings (code/host/self/carrier of every obligation pinned to the
+    //    bytes-derived values with `rfl`), the final-theorem type ascription,
+    //    and the axiom-whitelist check (see `checker_witness`).
+    let witness = checker_witness(&actual, &cands, &rederived);
     std::fs::write(build.path.join("CheckerWitness.lean"), &witness)
         .map_err(|e| format!("cannot write checker witness: {e}"))?;
     let w = run_lake(&build.path, &["env", "lean", "CheckerWitness.lean"])?;
     if !w.status.success() {
         // The verdict is this exit code, not any parsed line. The lake output is
         // shown to the human to name which face failed (hash, a report binding,
-        // the `Holds manifest` type, or a non-whitelisted axiom).
+        // an artifact-decode binding, the `Holds manifest` type, or a
+        // non-whitelisted axiom).
         return Err(format!(
             "certificate does not bind to this artifact: the checker's kernel witness \
              (hash binding, certified-export/contract/profile/abi bindings against the \
-             proven manifest, final-theorem type `Holds manifest`, and the axiom \
-             whitelist) did not check:\n{}",
+             proven manifest, the artifact-decode bindings that pin each obligation's \
+             code/host/self/carrier to what the bytes decode to, the final-theorem type \
+             `Holds manifest`, and the axiom whitelist) did not check:\n{}",
             tail(&w.combined, 30)
         ));
     }
-
-    // 5b. Re-derive the certified bodies from the hash-verified artifact bytes
-    //     with the audited disassembler and confirm the cert's `Module.lean`
-    //     states exactly those bodies. The kernel witness proves "some Lean body
-    //     simulates the model and the bytes hash to S"; it does NOT prove that
-    //     the Lean `WInstr` data actually DECODES from those bytes. A hostile
-    //     producer could ship `WInstr` data unrelated to the real bytes with a
-    //     vacuously-true `holds`. Re-deriving from the bytes and comparing to the
-    //     (attacker-editable) `Module.lean` text catches that mismatch.
-    rederive_bodies(&bytes, cert_dir, &cands.names)?;
 
     // 6. The witness checked, so every candidate is kernel-confirmed equal to
     //    the proven manifest. Build the report from those candidates; the count
@@ -371,44 +383,6 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
         abi: cands.abi,
         artifact_hash: actual,
     })
-}
-
-/// Re-derive the certified `{name}Code` bodies from the hash-verified artifact
-/// bytes using the audited disassembler, and require the cert's `Module.lean`
-/// to state each one verbatim. `Module.lean` is read INDEPENDENTLY here as
-/// attacker-editable text (the same file the build consumed) purely to compare
-/// against the re-derivation from the bytes — the point is to catch it lying.
-///
-/// For every kernel-certified export: if the disassembler declines the export
-/// (its real bytes fall outside the certified fragment) or the re-derived
-/// definition is not present verbatim in `Module.lean`, the certificate is
-/// DECLINED. Trusted by inspection of the Aver disassembler (the consumer's own
-/// binary), not by an in-kernel decode proof (a deferred residual).
-fn rederive_bodies(bytes: &[u8], cert_dir: &Path, certified: &[String]) -> Result<(), String> {
-    let derived = cert::rederive_code_defs(bytes)?;
-    let module_path = cert_dir.join("Module.lean");
-    let module_text = std::fs::read_to_string(&module_path)
-        .map_err(|e| format!("cannot read {}: {e}", module_path.display()))?;
-    for name in certified {
-        let def = derived
-            .iter()
-            .find(|(n, _)| n == name)
-            .map(|(_, d)| d.as_str())
-            .ok_or_else(|| {
-                format!(
-                    "artifact bytes do not re-derive the certified body of `{name}`: the \
-                     audited disassembler did not classify this export into a certified template"
-                )
-            })?;
-        if !module_text.contains(def) {
-            return Err(format!(
-                "artifact bytes do not re-derive the certified body of `{name}`: the \
-                 `{name}Code` definition in the certificate's Module.lean is not what the \
-                 hash-verified module bytes decode to"
-            ));
-        }
-    }
-    Ok(())
 }
 
 /// Populate a fresh, checker-owned build directory: the cert's DATA-only Lean
@@ -517,18 +491,40 @@ fn lean_str_list(items: &[String]) -> String {
     format!("[{inner}]")
 }
 
+/// A Lean list literal of raw (possibly multi-line) expression terms. Each item
+/// is a term the checker itself rendered from the hash-verified bytes (a code or
+/// host value), never attacker text, so splicing it verbatim is safe.
+fn lean_expr_list<'a>(items: impl Iterator<Item = &'a str>) -> String {
+    let inner = items.collect::<Vec<_>>().join(",\n   ");
+    format!("[ {inner} ]")
+}
+
+/// A Lean list literal of `Nat` literals (obligation self / carrier indices).
+fn lean_nat_list(items: impl Iterator<Item = u32>) -> String {
+    let inner = items.map(|n| n.to_string()).collect::<Vec<_>>().join(", ");
+    format!("[{inner}]")
+}
+
 /// The Lean file the checker authors at verify time. `sha` is what the checker
 /// computed from the artifact bytes; `cands` are the charset-gated JSON report
 /// candidates. Every claim is a `rfl` against `AverCert.manifest` (or the final
 /// theorem's type / the kernel axiom collector), so a lying JSON, a rebound
 /// hash, a weakened theorem, or a smuggled axiom all make this file fail to
 /// check — and THAT (the process exit code) is the only verdict channel.
-fn checker_witness(sha: &str, cands: &Candidates) -> String {
+fn checker_witness(
+    sha: &str,
+    cands: &Candidates,
+    rederived: &[cert::RederivedObligation],
+) -> String {
     let n = cands.names.len();
     let names = lean_str_list(&cands.names);
     let contracts = lean_str_list(&cands.contracts);
     let profile = &cands.profile;
     let abi = &cands.abi;
+    let codes = lean_expr_list(rederived.iter().map(|r| r.code.as_str()));
+    let hosts = lean_expr_list(rederived.iter().map(|r| r.host.as_str()));
+    let selfs = lean_nat_list(rederived.iter().map(|r| r.self_idx));
+    let carriers = lean_nat_list(rederived.iter().map(|r| r.carrier));
     let whitelist = AXIOM_WHITELIST
         .iter()
         .map(|a| format!("`{a}"))
@@ -540,7 +536,8 @@ fn checker_witness(sha: &str, cands: &Candidates) -> String {
          import Schema\n\
          import Module\n\
          import Manifest\n\
-         import Final\n\n\
+         import Final\n\
+         open CertPrelude\n\n\
          -- Count (the verdict bit): the kernel confirms EXACTLY this many\n\
          -- obligations. A JSON claiming more or fewer fails this `rfl`.\n\
          example : AverCert.manifest.obligations.length = {n} := rfl\n\
@@ -554,6 +551,20 @@ fn checker_witness(sha: &str, cands: &Candidates) -> String {
          -- Hash binding: the sha the checker computed from the artifact bytes.\n\
          example : AverCert.manifest.subject.artifactHash = \"{sha}\" := rfl\n\
          example : CertModule.wasmSha256 = \"{sha}\" := rfl\n\n\
+         -- Artifact-decode bindings: the CODE, HOST, SELF and CARRIER of every\n\
+         -- obligation are pinned, position for position, to the values the\n\
+         -- audited disassembler re-derived from the hash-verified bytes. These\n\
+         -- are EXACTLY the fields `Obligation.holds` reasons about\n\
+         -- (`wFuncN o.code (o.host add sub) fuel o.self`), so a fabricated body,\n\
+         -- a decoupled `code`/`self`/`carrier`, or a nerfed `host` that would\n\
+         -- make `holds` vacuous all diverge from the bytes and fail a `rfl`. The\n\
+         -- spliced terms come from the checker's own audited renderer over the\n\
+         -- bytes, never from attacker text, and are fully expanded (they do NOT\n\
+         -- reference the cert's `CertModule.*` defs, which an attacker edits).\n\
+         example : AverCert.manifest.obligations.map (fun o => o.code) =\n  {codes} := rfl\n\
+         example : AverCert.manifest.obligations.map (fun o => o.host) =\n  {hosts} := rfl\n\
+         example : AverCert.manifest.obligations.map (fun o => o.self) = {selfs} := rfl\n\
+         example : AverCert.manifest.obligations.map (fun o => o.carrier) = {carriers} := rfl\n\n\
          -- Statement: force the final theorem's TYPE by ascription (no text match).\n\
          def {WITNESS_THEOREM} : AverCert.Schema.Holds AverCert.manifest := AverCert.Final.cert\n\n\
          -- Axiom whitelist, enforced by the kernel's own axiom collector over the\n\

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -98,7 +98,7 @@ const MAX_CANDIDATE_LEN: usize = 200;
 /// statement about what the bytes actually decode to). Trusted via the audited
 /// Aver disassembler, not an in-kernel wasm decode proof; it does not change the
 /// cert level.
-const ARTIFACT_DECODE_LINE: &str = "artifact-decode: obligations' code/host/self/carrier are kernel-pinned (rfl) to what the bytes decode to (trusted via the audited disassembler)";
+const ARTIFACT_DECODE_LINE: &str = "artifact-decode: each obligation's export name and its code/host/self/carrier are kernel-pinned (rfl) to what the bytes decode to (trusted via the audited disassembler)";
 
 /// Tokens that make Lean ELABORATION execute code. The scan is a substring
 /// match on raw cert data-file text (see the module doc: a deliberately brittle
@@ -152,6 +152,9 @@ struct TrustedReport {
 /// only the kernel witness (via `rfl` against `AverCert.manifest`) makes them
 /// trustworthy.
 struct Candidates {
+    /// Certified export names as CLAIMED by the JSON. Used only for the count
+    /// binding (`obligations.length`, verified by `rfl`); the export NAMES the
+    /// obligations are pinned to come from the bytes, not from here.
     names: Vec<String>,
     contracts: Vec<String>,
     profile: String,
@@ -232,6 +235,11 @@ fn read_candidates(m: &Value) -> Result<Candidates, String> {
     let profile = manifest_str(m, "profile")?.to_string();
     let abi = manifest_str(m, "abi")?.to_string();
 
+    // The JSON export names are read ONLY for the count binding
+    // (`obligations.length`, verified by `rfl`). The export NAMES the
+    // obligations are actually pinned to are re-derived from the module's
+    // export section (see the witness), so a producer cannot relabel a
+    // byte-bound body under a different export name.
     let names = m
         .get("certified")
         .and_then(Value::as_array)
@@ -327,6 +335,13 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
     //     witness — fail-closed.
     let rederived = cert::rederive_obligations(&bytes)?;
 
+    // The re-derived export names come from the module's export section, which a
+    // hostile producer controls via the bytes; gate them exactly like the JSON
+    // candidates before they are spliced as Lean string literals in the witness.
+    for r in &rederived {
+        gate_candidate("re-derived export name", &r.name)?;
+    }
+
     // 3. Assemble a checker-owned build. The audited schema + prelude come from
     //    THIS binary, never from the cert; the cert supplies only per-artifact
     //    DATA (Module/Manifest/Certificate/Final + the model modules). Each data
@@ -369,14 +384,14 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
         ));
     }
 
-    // 6. The witness checked, so every candidate is kernel-confirmed equal to
-    //    the proven manifest. Build the report from those candidates; the count
-    //    is exactly the kernel-confirmed obligation count.
+    // 6. The witness checked, so every binding is kernel-confirmed against the
+    //    proven manifest. Build the report from the BYTE-DERIVED export names
+    //    (kernel-pinned to `manifest.obligations.map (·.export_)`), not the JSON;
+    //    the count is exactly the kernel-confirmed obligation count.
     Ok(TrustedReport {
-        exports: cands
-            .names
+        exports: rederived
             .iter()
-            .map(|n| (n.clone(), "simulatesModel".to_string()))
+            .map(|r| (r.name.clone(), "simulatesModel".to_string()))
             .collect(),
         contracts: cands.contracts,
         profile: cands.profile,
@@ -516,8 +531,15 @@ fn checker_witness(
     cands: &Candidates,
     rederived: &[cert::RederivedObligation],
 ) -> String {
+    // Count is the JSON-claimed number of certified exports, verified by `rfl`
+    // against `obligations.length` (so a JSON claiming more or fewer than the
+    // manifest fails closed, unchanged from before). The export NAMES the
+    // obligations are pinned to come from the BYTES (the re-derived export
+    // section), never the JSON, so a producer cannot relabel a byte-bound body
+    // as a different (uncertified) export.
     let n = cands.names.len();
-    let names = lean_str_list(&cands.names);
+    let rederived_names: Vec<String> = rederived.iter().map(|r| r.name.clone()).collect();
+    let names = lean_str_list(&rederived_names);
     let contracts = lean_str_list(&cands.contracts);
     let profile = &cands.profile;
     let abi = &cands.abi;
@@ -542,7 +564,9 @@ fn checker_witness(
          -- obligations. A JSON claiming more or fewer fails this `rfl`.\n\
          example : AverCert.manifest.obligations.length = {n} := rfl\n\
          -- Names: the obligation export list and the subject export list both\n\
-         -- equal the JSON-supplied candidates, or a `rfl` fails.\n\
+         -- equal the BYTE-DERIVED export names (from the module's export\n\
+         -- section, re-derived by the disassembler), or a `rfl` fails — so a\n\
+         -- byte-bound body cannot be relabelled under a different export name.\n\
          example : AverCert.manifest.obligations.map (fun o => o.export_) = {names} := rfl\n\
          example : AverCert.manifest.subject.exports = {names} := rfl\n\
          example : AverCert.manifest.subject.contracts = {contracts} := rfl\n\

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -24,6 +24,20 @@
 //! (stdout is shown to a human inside error messages only — a display channel,
 //! never a trust channel.) `explain` renders that same trusted report.
 //!
+//! After the witness checks, the certified bodies are RE-DERIVED from the
+//! hash-verified artifact bytes by the audited Aver disassembler
+//! (`cert::rederive_code_defs`) and compared, byte for byte, against the
+//! `{name}Code` definitions in the cert's `Module.lean` (read here independently
+//! as attacker-editable text). The kernel witness proves "some Lean-encoded body
+//! simulates the model and the bytes hash to S"; it does NOT prove that body
+//! actually DECODES from those bytes. So a hostile producer could ship `WInstr`
+//! data unrelated to the real bytes with a vacuously-true `holds`. Re-deriving
+//! the bodies from the bytes and matching them against `Module.lean` closes that
+//! bytes-vs-data divergence for every certified export (missing / diverging /
+//! disassembler-declined -> DECLINED). This is trusted via inspection of the
+//! disassembler, not an in-kernel wasm decode proof; a full kernel decoder is a
+//! deferred residual.
+//!
 //! Two input gates run before anything is elaborated:
 //!   * A cert data file whose name is not a plain `Foo.lean` Lean-module
 //!     identifier is DECLINED — otherwise a name with a comma/space/newline
@@ -70,6 +84,12 @@ const CHECKER_OWNED: [&str; 4] = [
 
 /// Maximum length (bytes) of a JSON-supplied string spliced into the witness.
 const MAX_CANDIDATE_LEN: usize = 200;
+
+/// Emitted on a CERTIFIED verdict once the certified bodies have been re-derived
+/// from the hash-verified module bytes and matched against the cert's
+/// `Module.lean`. This is an orthogonal guarantee, trusted via the audited Aver
+/// disassembler (not a kernel decode proof); it does not change the cert level.
+const ARTIFACT_DECODE_LINE: &str = "artifact-decode: bytes re-derive to the certified bodies (L1.5, trusted via the audited disassembler)";
 
 /// Tokens that make Lean ELABORATION execute code. The scan is a substring
 /// match on raw cert data-file text (see the module doc: a deliberately brittle
@@ -133,6 +153,7 @@ pub(super) fn cmd_cert_verify(artifact: &str, cert_dir: &str) {
     match verify(Path::new(artifact), Path::new(cert_dir)) {
         Ok(Verdict::Certified(summary)) => {
             println!("{} {}", "CERTIFIED".green().bold(), summary);
+            println!("  {ARTIFACT_DECODE_LINE}");
         }
         Ok(Verdict::NoExports(summary)) => {
             // Fail-closed: a trust tool must not exit green for a cert that
@@ -326,6 +347,16 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
         ));
     }
 
+    // 5b. Re-derive the certified bodies from the hash-verified artifact bytes
+    //     with the audited disassembler and confirm the cert's `Module.lean`
+    //     states exactly those bodies. The kernel witness proves "some Lean body
+    //     simulates the model and the bytes hash to S"; it does NOT prove that
+    //     the Lean `WInstr` data actually DECODES from those bytes. A hostile
+    //     producer could ship `WInstr` data unrelated to the real bytes with a
+    //     vacuously-true `holds`. Re-deriving from the bytes and comparing to the
+    //     (attacker-editable) `Module.lean` text catches that mismatch.
+    rederive_bodies(&bytes, cert_dir, &cands.names)?;
+
     // 6. The witness checked, so every candidate is kernel-confirmed equal to
     //    the proven manifest. Build the report from those candidates; the count
     //    is exactly the kernel-confirmed obligation count.
@@ -340,6 +371,44 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
         abi: cands.abi,
         artifact_hash: actual,
     })
+}
+
+/// Re-derive the certified `{name}Code` bodies from the hash-verified artifact
+/// bytes using the audited disassembler, and require the cert's `Module.lean`
+/// to state each one verbatim. `Module.lean` is read INDEPENDENTLY here as
+/// attacker-editable text (the same file the build consumed) purely to compare
+/// against the re-derivation from the bytes — the point is to catch it lying.
+///
+/// For every kernel-certified export: if the disassembler declines the export
+/// (its real bytes fall outside the certified fragment) or the re-derived
+/// definition is not present verbatim in `Module.lean`, the certificate is
+/// DECLINED. Trusted by inspection of the Aver disassembler (the consumer's own
+/// binary), not by an in-kernel decode proof (a deferred residual).
+fn rederive_bodies(bytes: &[u8], cert_dir: &Path, certified: &[String]) -> Result<(), String> {
+    let derived = cert::rederive_code_defs(bytes)?;
+    let module_path = cert_dir.join("Module.lean");
+    let module_text = std::fs::read_to_string(&module_path)
+        .map_err(|e| format!("cannot read {}: {e}", module_path.display()))?;
+    for name in certified {
+        let def = derived
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, d)| d.as_str())
+            .ok_or_else(|| {
+                format!(
+                    "artifact bytes do not re-derive the certified body of `{name}`: the \
+                     audited disassembler did not classify this export into a certified template"
+                )
+            })?;
+        if !module_text.contains(def) {
+            return Err(format!(
+                "artifact bytes do not re-derive the certified body of `{name}`: the \
+                 `{name}Code` definition in the certificate's Module.lean is not what the \
+                 hash-verified module bytes decode to"
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Populate a fresh, checker-owned build directory: the cert's DATA-only Lean
@@ -595,6 +664,7 @@ fn explain(artifact: &Path, cert_dir: &Path) -> Result<(), String> {
         );
     } else {
         println!("\n{}", "CERTIFIED".green().bold());
+        println!("  {ARTIFACT_DECODE_LINE}");
     }
     for (name, policy) in &report.exports {
         println!("  {}  [{}]", name.cyan().bold(), cert::CERT_LEVEL);

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -647,12 +647,44 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         );
     }
 
+    // (u) Export-name relabel: keep the byte-bound honest body/self/carrier, but
+    //     relabel the obligation (and the JSON) to a DIFFERENT export name the
+    //     module also exports (`countDown`). The certified export names are now
+    //     re-derived from the module's export section and pinned by `rfl`, so the
+    //     label no longer matches the export table → DECLINED. Without this bind,
+    //     a producer could advertise a byte-bound body under the name of an
+    //     uncertified export the consumer then calls.
+    {
+        let dir = temp_dir("neg-u");
+        copy_dir(&out_dir, &dir);
+        let man = dir.join("cert").join("Manifest.lean");
+        let mt = std::fs::read_to_string(&man)
+            .unwrap()
+            .replace("export_ := \"sumTo\"", "export_ := \"countDown\"")
+            .replace("exports := [\"sumTo\"]", "exports := [\"countDown\"]");
+        std::fs::write(&man, mt).unwrap();
+        let mf = dir.join("cert").join("cert-manifest.json");
+        let mut m: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+        for c in m["certified"].as_array_mut().unwrap() {
+            if c["name"] == serde_json::json!("sumTo") {
+                c["name"] = serde_json::json!("countDown");
+            }
+        }
+        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "export-name relabel must be DECLINED (u):\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (u):\n{out}");
+        assert!(!out.contains("CERTIFIED"), "relabel credited (u):\n{out}");
+    }
+
     let _ = std::fs::remove_dir_all(&out_dir);
 }
 
 /// The byte-honest `sumToCode` body for certprobe2, used verbatim as a decoy in
 /// the shadow/comment cases (planting the honest TEXT must not change `o.code`).
-const HONEST_SUMTO_CODE: &str = "def sumToCode : CodeTbl := fun fn =>\n  \
+const HONEST_SUMTO_CODE: &str = "/-- Verbatim emitted body of `sumTo` (self-recursive). -/\n\
+    def sumToCode : CodeTbl := fun fn =>\n  \
     if fn = 1 then some ⟨1, 1,\n    \
     [ .localGet 0, .localSet 1,\n      \
     .localGet 1, .structGet 2 1, .refIsNull,\n      \

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -32,9 +32,23 @@
 //!   (n) A7 filename gate: a cert file whose name is not a Lean module
 //!       identifier → DECLINED (no lakefile-root injection)
 //!   (o) A8 token scan: a data file carrying `#eval` → DECLINED (brittle wall)
-//!   (p) C2 bytes-vs-data: a `Module.lean` body that builds green and passes the
-//!       kernel witness but does NOT decode from the bytes → DECLINED by
-//!       re-derivation from the hash-verified bytes (would be CERTIFIED without)
+//!   (p) bytes-vs-data, body divergence: a `Module.lean` `sumToCode` whose
+//!       locals count is bumped 1→2. It still builds green AND passes the old
+//!       report bindings, but the checker pins `manifest.obligations.map (·.code)`
+//!       to the bytes-derived lambda with `rfl`, so the diverging body fails the
+//!       kernel witness → DECLINED ("does not bind"), never CERTIFIED
+//!   (q) shadow decoy: the active `sumToCode` mutated (locals 1→2) PLUS a full
+//!       honest body re-planted in a `namespace Shadow`. The decoy text does not
+//!       change `o.code`, so the code `rfl` still fails → DECLINED
+//!   (r) comment decoy: the active `sumToCode` mutated PLUS a full honest body in
+//!       a `/- … -/` block comment. Dead text; the code `rfl` fails → DECLINED
+//!   (s) code decouple: `manifest` points `code` at a decoy `wrongCode` that
+//!       always traps (making `holds` vacuous and trivially provable) while the
+//!       honest `sumToCode` is dead. Builds green; the code `rfl` binds `o.code`
+//!       to the bytes, not `wrongCode`, so it fails → DECLINED
+//!   (t) self decouple (vacuity): `manifest` sets `self` to a wrong index, so the
+//!       code-table lookup misses and `wFuncN` traps (vacuous, provable `holds`).
+//!       Builds green; the self `rfl` binds `o.self` to the byte index → DECLINED
 //! plus a separate empty-cert test: zero certified exports must NOT print the
 //! green path and must exit nonzero, and the A5 report-line injection payload
 //! (in the manifest and/or JSON) is rejected by the charset gate.
@@ -151,10 +165,11 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         report.contains("1 certified export"),
         "expected exactly one certified export:\n{report}"
     );
-    // The certified bodies were re-derived from the hash-verified bytes and
-    // matched against Module.lean: the CERTIFIED report names that guarantee.
+    // Each obligation's code/host/self/carrier was pinned to the bytes-derived
+    // values by `rfl` inside the kernel witness: the CERTIFIED report names that
+    // guarantee (artifact-decode).
     assert!(
-        report.contains("artifact-decode: bytes re-derive to the certified bodies"),
+        report.contains("artifact-decode:") && report.contains("kernel-pinned"),
         "missing artifact-decode line on the happy path:\n{report}"
     );
 
@@ -217,14 +232,29 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         );
     }
 
-    // (e) A1 hash rebind: replace the artifact with arbitrary bytes and edit
-    //     ONLY `wasm_sha256` in the JSON to match. The fast JSON pre-check now
-    //     passes; the kernel witness rejects it because the theorems talk about
-    //     the ORIGINAL hash, not the checker-computed one.
+    // (e) A1 hash rebind: replace the artifact with a DIFFERENT but genuine cert
+    //     module (certprobe's wasm) and edit ONLY `wasm_sha256` in the JSON to
+    //     match it. The fast JSON pre-check passes and the swapped module still
+    //     disassembles, so the checker reaches the kernel witness — which rejects
+    //     it because the theorems (and `CertModule.wasmSha256`) talk about the
+    //     ORIGINAL hash, not the checker-computed one.
     {
         let dir = temp_dir("neg-e");
         copy_dir(&out_dir, &dir);
-        let foreign = b"\x00\xde\xad\xbe\xef arbitrary not-a-wasm bytes".to_vec();
+        let foreign_out = temp_dir("neg-e-foreign");
+        let fc = Command::new(aver_bin)
+            .current_dir(&repo_root)
+            .arg("compile")
+            .arg("tools/certkit/fixtures/certprobe.av")
+            .arg("--target")
+            .arg("wasm-gc")
+            .arg("--certify")
+            .arg("-o")
+            .arg(&foreign_out)
+            .output()
+            .expect("aver compile --certify runs");
+        assert!(fc.status.success(), "foreign fixture compile failed");
+        let foreign = std::fs::read(foreign_out.join("certprobe.wasm")).unwrap();
         std::fs::write(dir.join("certprobe2.wasm"), &foreign).unwrap();
         let sha = aver::codegen::cert::sha256_hex(&foreign);
         let mf = dir.join("cert").join("cert-manifest.json");
@@ -233,6 +263,7 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         m["wasm_sha256"] = serde_json::Value::String(sha);
         std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
         let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        let _ = std::fs::remove_dir_all(&foreign_out);
         assert!(!ok, "A1 hash rebind must fail:\n{out}");
         assert!(out.contains("does not bind"), "wrong reason (e):\n{out}");
         // The witness names the exact face the kernel rejected.
@@ -455,16 +486,16 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         );
     }
 
-    // (p) C2 bytes-vs-data divergence: a Module.lean whose `sumToCode` body does
-    //     NOT decode from the real bytes. The locals count in the CodeTbl entry
-    //     is bumped 1 -> 2 (an extra, unused local), which the recursive proof
-    //     tolerates: the cert still `lake build`s AND passes the kernel witness
-    //     (hash, count, names, `Holds manifest`, axioms all check). Only the
-    //     re-derivation from the hash-verified bytes catches that the declared
-    //     body diverges from what the bytes decode to. The wasm bytes are
-    //     untouched, so the hash stays consistent — the mismatch is purely in the
-    //     attacker-editable Lean data. Without re-derivation this cert would be
-    //     CERTIFIED green (the vacuity/divergence residual C2); with it, DECLINED.
+    // (p) bytes-vs-data divergence: a Module.lean whose `sumToCode` body does NOT
+    //     decode from the real bytes. The locals count in the CodeTbl entry is
+    //     bumped 1 -> 2 (an extra, unused local), which the recursive proof
+    //     tolerates: the cert still `lake build`s AND passes the old report
+    //     bindings (hash, count, names). The checker now splices the bytes-derived
+    //     code lambda into the witness and pins `manifest.obligations.map (·.code)`
+    //     to it with `rfl`; the bumped body (locals 2) is not the byte-derived one
+    //     (locals 1), so the kernel witness fails: DECLINED, never CERTIFIED. The
+    //     wasm bytes are untouched, so the hash stays consistent — the mismatch is
+    //     purely in the attacker-editable Lean data.
     {
         let dir = temp_dir("neg-p");
         copy_dir(&out_dir, &dir);
@@ -479,15 +510,12 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
             !ok,
             "a body that does not re-derive must be DECLINED:\n{out}"
         );
+        // Caught by the kernel witness (the code binding), AFTER the cert built
+        // green — not by lake build or a hash binding.
+        assert!(out.contains("does not bind"), "wrong reason (p):\n{out}");
         assert!(
-            out.contains("do not re-derive the certified body of `sumTo`"),
-            "wrong reason (p): expected the re-derivation mismatch:\n{out}"
-        );
-        // The mismatch is caught by re-derivation, AFTER the cert built and the
-        // kernel witness passed — not by lake build or a hash/witness binding.
-        assert!(
-            !out.contains("did not build") && !out.contains("does not bind"),
-            "case (p) must be caught by re-derivation, not the build/witness:\n{out}"
+            !out.contains("did not build"),
+            "case (p) must build green and be caught by the witness:\n{out}"
         );
         assert!(
             !out.contains("CERTIFIED"),
@@ -495,7 +523,171 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         );
     }
 
+    // (q) Shadow decoy (the reproduced bypass): mutate the ACTIVE `sumToCode`
+    //     (locals 1→2) and re-plant a byte-identical honest body in a
+    //     `namespace Shadow`. The old substring check matched the honest text in
+    //     `Shadow` and passed; the code `rfl` pins `o.code` — which is the active,
+    //     mutated `CertModule.sumToCode`, not the shadow — so it fails: DECLINED.
+    {
+        let dir = temp_dir("neg-q");
+        copy_dir(&out_dir, &dir);
+        let m = dir.join("cert").join("Module.lean");
+        let src = std::fs::read_to_string(&m).unwrap();
+        let mutated = src.replacen("some ⟨1, 1,", "some ⟨1, 2,", 1);
+        assert_ne!(src, mutated, "fixture recursive body shape changed");
+        let shadow = format!("namespace Shadow\n{HONEST_SUMTO_CODE}\nend Shadow\n\nend CertModule");
+        let planted = mutated.replacen("end CertModule", &shadow, 1);
+        assert_ne!(mutated, planted, "shadow decoy not planted");
+        std::fs::write(&m, planted).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "shadow decoy must be DECLINED:\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (q):\n{out}");
+        assert!(
+            !out.contains("CERTIFIED"),
+            "shadow decoy credited (q):\n{out}"
+        );
+    }
+
+    // (r) Comment decoy: mutate the active `sumToCode` and re-plant a byte-honest
+    //     body inside a `/- … -/` block comment. Dead text; `o.code` is still the
+    //     mutated active def, so the code `rfl` fails: DECLINED.
+    {
+        let dir = temp_dir("neg-r");
+        copy_dir(&out_dir, &dir);
+        let m = dir.join("cert").join("Module.lean");
+        let src = std::fs::read_to_string(&m).unwrap();
+        let mutated = src.replacen("some ⟨1, 1,", "some ⟨1, 2,", 1);
+        assert_ne!(src, mutated, "fixture recursive body shape changed");
+        let comment = format!("/- honest decoy:\n{HONEST_SUMTO_CODE}\n-/\n\nend CertModule");
+        let planted = mutated.replacen("end CertModule", &comment, 1);
+        std::fs::write(&m, planted).unwrap();
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(!ok, "comment decoy must be DECLINED:\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (r):\n{out}");
+        assert!(
+            !out.contains("CERTIFIED"),
+            "comment decoy credited (r):\n{out}"
+        );
+    }
+
+    // (s) Code decouple: point the obligation's `code` at a decoy `wrongCode` that
+    //     always traps, so `holds` is vacuous and trivially provable, while the
+    //     honest `sumToCode` is left dead. The cert builds green (the vacuous proof
+    //     replaces the honest one). The code `rfl` binds `o.code` to the
+    //     bytes-derived lambda, not `wrongCode`, so the witness fails: DECLINED.
+    {
+        let dir = temp_dir("neg-s");
+        copy_dir(&out_dir, &dir);
+        let cert = dir.join("cert");
+        let m = cert.join("Module.lean");
+        let src = std::fs::read_to_string(&m).unwrap();
+        let with_decoy = src.replacen(
+            "end CertModule",
+            "/-- decoy: always traps, so `holds` is vacuous. -/\n\
+             def wrongCode : CodeTbl := fun _ => none\nend CertModule",
+            1,
+        );
+        std::fs::write(&m, with_decoy).unwrap();
+        let man = cert.join("Manifest.lean");
+        let msrc = std::fs::read_to_string(&man).unwrap();
+        let decoupled = msrc.replacen(
+            "code := CertModule.sumToCode",
+            "code := CertModule.wrongCode",
+            1,
+        );
+        assert_ne!(msrc, decoupled, "manifest code field shape changed");
+        std::fs::write(&man, decoupled).unwrap();
+        let vac = VACUOUS_SIMULATES.replace(
+            "@BODY@",
+            "simp only [sumToOb, CertModule.wrongCode, wFuncN, reduceCtorEq] at hrun",
+        );
+        replace_simulates(&cert, &vac);
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &cert);
+        assert!(!ok, "code decouple must be DECLINED:\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (s):\n{out}");
+        assert!(
+            !out.contains("did not build"),
+            "case (s) must build green and be caught by the witness:\n{out}"
+        );
+        assert!(
+            !out.contains("CERTIFIED"),
+            "code decouple credited (s):\n{out}"
+        );
+    }
+
+    // (t) Self decouple (vacuity): set the obligation's `self` to a wrong index so
+    //     `code self` misses the table and `wFuncN` traps — `holds` is vacuous and
+    //     provable. Builds green; the self `rfl` binds `o.self` to the byte index,
+    //     so the witness fails: DECLINED.
+    {
+        let dir = temp_dir("neg-t");
+        copy_dir(&out_dir, &dir);
+        let cert = dir.join("cert");
+        let man = cert.join("Manifest.lean");
+        let msrc = std::fs::read_to_string(&man).unwrap();
+        let decoupled = msrc.replacen("self := 1,", "self := 999,", 1);
+        assert_ne!(msrc, decoupled, "manifest self field shape changed");
+        std::fs::write(&man, decoupled).unwrap();
+        let vac = VACUOUS_SIMULATES.replace(
+            "@BODY@",
+            "simp only [sumToOb, CertModule.sumToCode, wFuncN,\n      \
+             show (999 = 1) = False by decide, if_false, reduceCtorEq] at hrun",
+        );
+        replace_simulates(&cert, &vac);
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &cert);
+        assert!(!ok, "self decouple must be DECLINED:\n{out}");
+        assert!(out.contains("does not bind"), "wrong reason (t):\n{out}");
+        assert!(
+            !out.contains("did not build"),
+            "case (t) must build green and be caught by the witness:\n{out}"
+        );
+        assert!(
+            !out.contains("CERTIFIED"),
+            "self decouple credited (t):\n{out}"
+        );
+    }
+
     let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// The byte-honest `sumToCode` body for certprobe2, used verbatim as a decoy in
+/// the shadow/comment cases (planting the honest TEXT must not change `o.code`).
+const HONEST_SUMTO_CODE: &str = "def sumToCode : CodeTbl := fun fn =>\n  \
+    if fn = 1 then some ⟨1, 1,\n    \
+    [ .localGet 0, .localSet 1,\n      \
+    .localGet 1, .structGet 2 1, .refIsNull,\n      \
+    .ifElse [.localGet 1, .structGet 2 0, .i64Const 0, .i64LeS]\n              \
+    [.localGet 1, .structGet 2 2, .i32Const 0, .i32LtS],\n      \
+    .ifElse [.i64Const 0, .call 7]\n              \
+    [.localGet 0, .localGet 0, .i64Const 1, .call 7, .call 9, .call 1, .call 8] ]⟩\n  \
+    else none";
+
+/// A vacuous replacement proof of `sumTo_simulates` (the emitted honest proof
+/// references the honest `sumToCode`/`self`, so a decoupled obligation needs its
+/// own proof to build green). `@BODY@` is filled with the `simp` that discharges
+/// the trapped `wFuncN`.
+const VACUOUS_SIMULATES: &str = "theorem sumTo_simulates : AverCert.Schema.Obligation.holds sumToOb := by\n  \
+    intro S add sub hadd hsub fuel n v w hv hrun\n  \
+    exfalso\n  \
+    cases fuel with\n  \
+    | zero => simp only [wFuncN, reduceCtorEq] at hrun\n  \
+    | succ f =>\n      @BODY@";
+
+/// Swap the emitted `sumTo_simulates` proof in `Certificate.lean` for a
+/// (vacuous) replacement, matching the exact emitted block.
+fn replace_simulates(cert_dir: &Path, replacement: &str) {
+    let c = cert_dir.join("Certificate.lean");
+    let src = std::fs::read_to_string(&c).unwrap();
+    let old = "theorem sumTo_simulates : AverCert.Schema.Obligation.holds sumToOb := by\n  \
+        intro S add sub hadd hsub fuel n v w hv hrun\n  \
+        simp only [sumToOb, AverCert.Schema.Obligation.holds] at hrun ⊢\n  \
+        exact sumTo_wasm_certified S.Repr S.car S.smallIntro S.smallElim S.bigElim\n    \
+        add sub hadd hsub fuel n v w hv hrun";
+    assert!(
+        src.contains(old),
+        "emitted sumTo_simulates block shape changed; update the test"
+    );
+    std::fs::write(&c, src.replacen(old, replacement, 1)).unwrap();
 }
 
 /// A cert with zero certified exports is an admission, not a certification: it

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -32,6 +32,9 @@
 //!   (n) A7 filename gate: a cert file whose name is not a Lean module
 //!       identifier → DECLINED (no lakefile-root injection)
 //!   (o) A8 token scan: a data file carrying `#eval` → DECLINED (brittle wall)
+//!   (p) C2 bytes-vs-data: a `Module.lean` body that builds green and passes the
+//!       kernel witness but does NOT decode from the bytes → DECLINED by
+//!       re-derivation from the hash-verified bytes (would be CERTIFIED without)
 //! plus a separate empty-cert test: zero certified exports must NOT print the
 //! green path and must exit nonzero, and the A5 report-line injection payload
 //! (in the manifest and/or JSON) is rejected by the charset gate.
@@ -147,6 +150,12 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     assert!(
         report.contains("1 certified export"),
         "expected exactly one certified export:\n{report}"
+    );
+    // The certified bodies were re-derived from the hash-verified bytes and
+    // matched against Module.lean: the CERTIFIED report names that guarantee.
+    assert!(
+        report.contains("artifact-decode: bytes re-derive to the certified bodies"),
+        "missing artifact-decode line on the happy path:\n{report}"
     );
 
     // (a) One flipped wasm byte → hash mismatch, before any build.
@@ -443,6 +452,46 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         assert!(
             out.contains("execute code") && out.contains("#eval"),
             "wrong reason (o):\n{out}"
+        );
+    }
+
+    // (p) C2 bytes-vs-data divergence: a Module.lean whose `sumToCode` body does
+    //     NOT decode from the real bytes. The locals count in the CodeTbl entry
+    //     is bumped 1 -> 2 (an extra, unused local), which the recursive proof
+    //     tolerates: the cert still `lake build`s AND passes the kernel witness
+    //     (hash, count, names, `Holds manifest`, axioms all check). Only the
+    //     re-derivation from the hash-verified bytes catches that the declared
+    //     body diverges from what the bytes decode to. The wasm bytes are
+    //     untouched, so the hash stays consistent — the mismatch is purely in the
+    //     attacker-editable Lean data. Without re-derivation this cert would be
+    //     CERTIFIED green (the vacuity/divergence residual C2); with it, DECLINED.
+    {
+        let dir = temp_dir("neg-p");
+        copy_dir(&out_dir, &dir);
+        let m = dir.join("cert").join("Module.lean");
+        let src = std::fs::read_to_string(&m).unwrap();
+        let corrupted = src.replacen("some ⟨1, 1,", "some ⟨1, 2,", 1);
+        assert_ne!(src, corrupted, "fixture recursive body shape changed");
+        std::fs::write(&m, corrupted).unwrap();
+        // wasm bytes are untouched: the hash still matches the pinned value.
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+        assert!(
+            !ok,
+            "a body that does not re-derive must be DECLINED:\n{out}"
+        );
+        assert!(
+            out.contains("do not re-derive the certified body of `sumTo`"),
+            "wrong reason (p): expected the re-derivation mismatch:\n{out}"
+        );
+        // The mismatch is caught by re-derivation, AFTER the cert built and the
+        // kernel witness passed — not by lake build or a hash/witness binding.
+        assert!(
+            !out.contains("did not build") && !out.contains("does not bind"),
+            "case (p) must be caught by re-derivation, not the build/witness:\n{out}"
+        );
+        assert!(
+            !out.contains("CERTIFIED"),
+            "a diverging body must never be credited (p):\n{out}"
         );
     }
 


### PR DESCRIPTION
Closes the bytes↔data gap on the consumer side. `aver cert verify` now re-derives each certified obligation's `code`, `host`, `self`, `carrier` and export name from the hash-verified `app.wasm` bytes (with the audited disassembler) and pins them, fully expanded, by `rfl` inside the checker-authored witness — the same discipline as the report/axiom bindings. These are exactly the fields `Obligation.holds` reasons about, so:

- a fabricated body, a decoupled `code`/`self`/`carrier`, or a nerfed `host` that would make `holds` vacuous all diverge from the bytes and fail a `rfl`;
- a byte-bound body cannot be relabelled under a different (uncertified) export name;
- the certified count stays JSON-claimed and `rfl`-verified against `obligations.length`, so an over/under-claiming JSON still fails closed.

The verdict remains the witness process exit code (no lake/lean text is parsed). `CERT_LEVEL` is unchanged (L1); trust in the re-derivation rests on inspection of the audited disassembler (the consumer's own binary), not an in-kernel wasm decode proof — a full kernel decoder stays a deferred residual, stated honestly in the `artifact-decode` line.

Regressions (all build green + pass the kernel witness, so each is caught purely by the byte-binding, not the build): body divergence, shadow-namespace decoy, block-comment decoy, code-decouple, self-decouple vacuity, and export-name relabel.

Tests: `cargo test --features wasm --test cert_verify_spec --test cert_certify_spec` (verify tripwires a–u + golden emission). Build, fmt, clippy(--bin aver) clean.