### PR TITLE
Add an in-kernel certificate profile decoder with a cross-oracle differential

### DIFF
--- a/tests/cert_decode_spec.rs
+++ b/tests/cert_decode_spec.rs
@@ -1,18 +1,25 @@
 //! Integration tests for the in-kernel certificate profile decoder
 //! (`tools/certkit/prelude/CertDecode.lean`).
 //!
-//! The main test is a three-way decoder differential: for every certkit
-//! fixture it agrees, TERM FOR TERM, across the Lean kernel decoder
-//! (`CertDecode.decode…`, checked by `rfl`), the Rust
-//! `cert::rederive_obligations` (the certified-obligation oracle), and the
-//! Python byte-level `tools/certkit/decode_ref.py`.
-//! It compiles each fixture, emits a Lean witness pinning `decodeExports`,
-//! `decodeImports`, `decodeCarrier`, and per-function `decodeCode` to the oracle
-//! values, and lets `lake env lean` be the verdict — a divergence is a kernel
-//! `rfl` failure with a full repro, never a string compare (the lesson from the
-//! v1 substring checker). It also drives the 39-opcode coverage matrix (33
-//! opcodes exercised by fixture bodies plus 6 covered by a synthetic single-body
-//! probe) fail-closed.
+//! The main test is a decoder differential: for every certkit fixture the Lean
+//! kernel decoder (`CertDecode.decode…`, checked by `rfl`) agrees, TERM FOR
+//! TERM, with the Python byte-level oracle (`tools/certkit/decode_ref.py`) on
+//! every user-function body, the section walk, exports, imports and carrier —
+//! and, for the CERTIFIED obligations, additionally with the Rust
+//! `cert::rederive_obligations` (three oracles on those; two on the rest).
+//! It compiles each fixture, emits a Lean witness pinning `walkIds`,
+//! `decodeExports`, `decodeImports`, `decodeCarrier`, and per-function
+//! `decodeCode` to the oracle values, and lets `lake env lean` be the verdict —
+//! a divergence is a kernel `rfl` failure with a full repro, never a string
+//! compare (the lesson from the v1 substring checker). It also drives the
+//! 39-opcode coverage matrix (33 opcodes exercised by fixture bodies plus 6
+//! covered by a synthetic single-body probe) fail-closed.
+//!
+//! The certkit fixtures are all pure (no import section), so the import-section
+//! decode path (`decImportVec`, a non-zero function-index base) is exercised by
+//! an extra effectful module the test itself writes and compiles: its
+//! `Console.print` lowers to a real import, and the test asserts the decoded
+//! import list is non-empty so this coverage cannot silently regress.
 //!
 //! A second test performs the mutation suite M1–M6 on real bytes: a flip in a
 //! certified body changes the decode, a flip in a decoder-skipped section does
@@ -147,11 +154,11 @@ fn build_prelude() -> PathBuf {
     dst
 }
 
-fn compile_wasm(repo: &Path, fixture: &str, out: &Path) -> Vec<u8> {
+fn compile_wasm_at(repo: &Path, av_path: &Path, name: &str, out: &Path) -> Vec<u8> {
     let c = Command::new(env!("CARGO_BIN_EXE_aver"))
         .current_dir(repo)
         .arg("compile")
-        .arg(format!("tools/certkit/fixtures/{fixture}.av"))
+        .arg(av_path)
         .arg("--target")
         .arg("wasm-gc")
         .arg("-o")
@@ -160,11 +167,34 @@ fn compile_wasm(repo: &Path, fixture: &str, out: &Path) -> Vec<u8> {
         .expect("aver compile runs");
     assert!(
         c.status.success(),
-        "compile {fixture} failed:\n{}",
+        "compile {name} failed:\n{}",
         String::from_utf8_lossy(&c.stderr)
     );
-    std::fs::read(out.join(format!("{fixture}.wasm"))).unwrap()
+    std::fs::read(out.join(format!("{name}.wasm"))).unwrap()
 }
+
+/// An effectful module the test writes itself: `Console.print` lowers to a real
+/// wasm import, so this is the one module in the differential whose import
+/// section is non-empty and whose function-index base is non-zero.
+const IMPORTS_FIXTURE_NAME: &str = "certimports";
+const IMPORTS_FIXTURE_SRC: &str = r#"module CertImports
+    intent =
+        "Import-section witness for the certificate decoder differential."
+    exposes [double]
+    effects [Console]
+
+fn double(x: Int) -> Int
+    ? "Doubles an integer."
+    x + x
+
+verify double
+    double(2) => 4
+    double(-3) => -6
+
+fn main()
+    ! [Console.print]
+    Console.print("{double(21)}")
+"#;
 
 /// The Python byte-level decoder oracle for a module.
 fn oracle_json(repo: &Path, wasm: &Path) -> serde_json::Value {
@@ -287,10 +317,34 @@ fn cert_decode_three_way_differential_and_coverage() {
 
     let mut covered: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
 
-    for &fixture in FIXTURES {
-        let bytes = compile_wasm(&repo, fixture, &out);
+    // Repo fixtures plus the test-authored effectful module (real emitter
+    // round-trip either way; the extra module is the import-section witness).
+    let imports_av = out.join(format!("{IMPORTS_FIXTURE_NAME}.av"));
+    std::fs::write(&imports_av, IMPORTS_FIXTURE_SRC).unwrap();
+    let mut modules: Vec<(String, PathBuf)> = FIXTURES
+        .iter()
+        .map(|f| {
+            (
+                f.to_string(),
+                repo.join(format!("tools/certkit/fixtures/{f}.av")),
+            )
+        })
+        .collect();
+    modules.push((IMPORTS_FIXTURE_NAME.to_string(), imports_av));
+
+    for (fixture, av_path) in &modules {
+        let bytes = compile_wasm_at(&repo, av_path, fixture, &out);
         let wasm_path = out.join(format!("{fixture}.wasm"));
         let oracle = oracle_json(&repo, &wasm_path);
+
+        // The import-section witness must actually witness something: a lowering
+        // change that drops the imports would make this coverage vacuous again.
+        if fixture.as_str() == IMPORTS_FIXTURE_NAME {
+            assert!(
+                !oracle["imports"].as_array().unwrap().is_empty(),
+                "{fixture}: expected a non-empty import section (effect lowering changed?)"
+            );
+        }
 
         // Rust oracle: certified obligations, cross-checked against the Python
         // oracle (carrier + export-name → self), then pinned to the Lean decoder
@@ -303,7 +357,20 @@ fn cert_decode_three_way_differential_and_coverage() {
         src.push_str(&format!("def bytesN : Nat := 0x{}\n", hex_le(&bytes)));
         src.push_str(&format!("def bytesLen : Nat := {}\n\n", bytes.len()));
 
-        // Section-level bindings (oracle: Python byte decoder).
+        // Section-level bindings (oracle: Python byte decoder). The `walkIds`
+        // binding walks the ENTIRE file (one entry per section), so a malformed
+        // section frame anywhere in the module fails the differential even in
+        // regions the targeted decoders skip.
+        let sections: Vec<String> = oracle["sections"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s.as_u64().unwrap().to_string())
+            .collect();
+        src.push_str(&format!(
+            "example : CertDecode.walkIds 64 (bytesN >>> 64) (bytesLen - 8) = some [{}] := rfl\n",
+            sections.join(", ")
+        ));
         src.push_str(&format!(
             "example : CertDecode.decodeExports bytesN bytesLen = some {} := rfl\n",
             exports_lit(&oracle["exports"])
@@ -508,7 +575,12 @@ fn cert_decode_mutations_fail_closed() {
     let out = temp_dir("cdec-mut-wasm");
     std::fs::create_dir_all(&out).unwrap();
 
-    let bytes = compile_wasm(&repo, "certprobe2", &out);
+    let bytes = compile_wasm_at(
+        &repo,
+        &repo.join("tools/certkit/fixtures/certprobe2.av"),
+        "certprobe2",
+        &out,
+    );
     let obligations = aver::codegen::cert::rederive_obligations(&bytes).unwrap();
     let sumto = obligations.iter().find(|o| o.name == "sumTo").unwrap();
     let self_idx = sumto.self_idx;

--- a/tests/cert_decode_spec.rs
+++ b/tests/cert_decode_spec.rs
@@ -385,6 +385,45 @@ fn cert_decode_three_way_differential_and_coverage() {
         }
     }
 
+    // Axiom footprint: the verdict path must stay on `[propext]` — no `sorryAx`,
+    // no `native_decide` / `ofReduceBool` escape hatch (brief constraint). Pin
+    // it as a regression on the richest fixture (certprobe2's nested body).
+    {
+        let bytes = std::fs::read(out.join("certprobe2.wasm")).unwrap();
+        let oracle = oracle_json(&repo, &out.join("certprobe2.wasm"));
+        let sumto = &oracle["funcs"].as_array().unwrap()[1];
+        let mut src = String::new();
+        src.push_str("import CertDecode\nopen CertPrelude\n\n");
+        src.push_str(&format!("def bytesN : Nat := 0x{}\n", hex_le(&bytes)));
+        src.push_str(&format!("def bytesLen : Nat := {}\n\n", bytes.len()));
+        src.push_str(&format!(
+            "theorem tCode : CertDecode.decodeCode bytesN bytesLen {} = some ⟨{}, {}, {}⟩ := rfl\n",
+            sumto["idx"].as_u64().unwrap(),
+            sumto["arity"].as_u64().unwrap(),
+            sumto["nlocals"].as_u64().unwrap(),
+            sumto["body"].as_str().unwrap()
+        ));
+        src.push_str("#print axioms tCode\n");
+        let (ok, report) = run_lean(&prelude, &src);
+        assert!(ok, "axiom-footprint witness failed to build:\n{report}");
+        assert!(
+            report.contains("propext"),
+            "axiom line missing propext:\n{report}"
+        );
+        for forbidden in [
+            "sorryAx",
+            "ofReduceBool",
+            "native",
+            "Classical.choice",
+            "Quot.sound",
+        ] {
+            assert!(
+                !report.contains(forbidden),
+                "verdict path carries a non-[propext] axiom `{forbidden}`:\n{report}"
+            );
+        }
+    }
+
     // Coverage matrix, fail-closed: every one of the 39 must be exercised.
     let missing: Vec<&str> = ALL_OPCODES
         .iter()

--- a/tests/cert_decode_spec.rs
+++ b/tests/cert_decode_spec.rs
@@ -1,0 +1,561 @@
+//! Integration tests for the in-kernel certificate profile decoder
+//! (`tools/certkit/prelude/CertDecode.lean`).
+//!
+//! The main test is a three-way decoder differential: for every certkit
+//! fixture it agrees, TERM FOR TERM, across
+//!   * the Lean kernel decoder (`CertDecode.decode…`, checked by `rfl`),
+//!   * the Rust `cert::rederive_obligations` (the certified-obligation oracle),
+//!   * the Python byte-level `tools/certkit/decode_ref.py`.
+//! It compiles each fixture, emits a Lean witness pinning `decodeExports`,
+//! `decodeImports`, `decodeCarrier`, and per-function `decodeCode` to the oracle
+//! values, and lets `lake env lean` be the verdict — a divergence is a kernel
+//! `rfl` failure with a full repro, never a string compare (the lesson from the
+//! v1 substring checker). It also drives the 39-opcode coverage matrix (33
+//! opcodes exercised by fixture bodies plus 6 covered by a synthetic single-body
+//! probe) fail-closed.
+//!
+//! A second test performs the mutation suite M1–M6 on real bytes: a flip in a
+//! certified body changes the decode, a flip in a decoder-skipped section does
+//! not, an export relabel changes the export map, and overlong LEB / truncation
+//! / out-of-function-space indices all decode to `none` (never a garbage
+//! success).
+//!
+//! Gated behind `wasm` (the wasm-gc backend) and skipped when `lake` or
+//! `python3` is unavailable, mirroring `cert_verify_spec.rs`.
+#![cfg(feature = "wasm")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const FIXTURES: &[&str] = &[
+    "certprobe",
+    "certprobe2",
+    "certkit_ops",
+    "certkit_zoo",
+    "certempty",
+];
+
+/// The 39 measured user-code opcode mnemonics (mirrors `diff_harness.py`).
+const ALL_OPCODES: &[&str] = &[
+    "array.new_data", "array.new_fixed", "call", "else", "end", "f64.add",
+    "f64.const", "f64.div", "f64.eq", "f64.ge", "f64.gt", "f64.le", "f64.lt",
+    "f64.mul", "f64.sub", "i32.and", "i32.const", "i32.eq", "i32.gt_s",
+    "i32.le_s", "i32.lt_s", "i64.const", "i64.eq", "i64.eqz", "i64.ge_s",
+    "i64.gt_s", "i64.le_s", "i64.lt_s", "if", "local.get", "local.set",
+    "ref.cast", "ref.is_null", "ref.null", "ref.test", "return", "return_call",
+    "struct.get", "struct.new",
+];
+
+/// The opcodes never surfaced by a certkit user-function body; the decoder's
+/// arm for each is exercised by a synthetic single-body probe instead.
+const SYNTH_OPCODES: &[&str] = &[
+    "i32.and", "i32.eq", "i64.eqz", "return", "ref.null", "array.new_fixed",
+];
+
+/// Raw bytes of the synthetic probe body and the term it must decode to. Covers
+/// exactly the six opcodes above (i32.and, i32.eq, i64.eqz, return, ref.null +
+/// heaptype, array.new_fixed) followed by the function `end`.
+const SYNTH_BYTES: &[u8] = &[
+    0x71, 0x46, 0x50, 0x0f, 0xd0, 0x70, 0xfb, 0x08, 0x02, 0x03, 0x0b,
+];
+const SYNTH_TERM: &str = "[.i32And, .i32Eq, .i64Eqz, .ret, .refNull, .arrayNewFixed 2 3]";
+
+// ---- environment ---------------------------------------------------------
+
+fn lake_available() -> bool {
+    Command::new("lake").arg("--version").output().is_ok()
+}
+
+fn python_available() -> bool {
+    Command::new("python3").arg("--version").output().is_ok()
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let mut d = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    d.push(format!("aver-{prefix}-{nanos}"));
+    d
+}
+
+/// Copy the decoder prelude sources into a fresh temp dir and `lake build` them
+/// (the witnesses import the resulting `.olean`s).
+fn build_prelude() -> PathBuf {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let src = repo.join("tools/certkit/prelude");
+    let dst = temp_dir("cdec-prelude");
+    std::fs::create_dir_all(&dst).unwrap();
+    for f in [
+        "CertPrelude.lean",
+        "CertDecode.lean",
+        "CertPreludeSanity.lean",
+        "lakefile.lean",
+        "lean-toolchain",
+    ] {
+        std::fs::copy(src.join(f), dst.join(f)).unwrap();
+    }
+    let o = Command::new("lake")
+        .arg("build")
+        .current_dir(&dst)
+        .output()
+        .expect("lake build runs");
+    assert!(
+        o.status.success(),
+        "lake build of the decoder prelude failed:\n{}{}",
+        String::from_utf8_lossy(&o.stdout),
+        String::from_utf8_lossy(&o.stderr)
+    );
+    dst
+}
+
+fn compile_wasm(repo: &Path, fixture: &str, out: &Path) -> Vec<u8> {
+    let c = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(repo)
+        .arg("compile")
+        .arg(format!("tools/certkit/fixtures/{fixture}.av"))
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("-o")
+        .arg(out)
+        .output()
+        .expect("aver compile runs");
+    assert!(
+        c.status.success(),
+        "compile {fixture} failed:\n{}",
+        String::from_utf8_lossy(&c.stderr)
+    );
+    std::fs::read(out.join(format!("{fixture}.wasm"))).unwrap()
+}
+
+/// The Python byte-level decoder oracle for a module.
+fn oracle_json(repo: &Path, wasm: &Path) -> serde_json::Value {
+    let o = Command::new("python3")
+        .current_dir(repo)
+        .arg("tools/certkit/decode_ref.py")
+        .arg("json")
+        .arg(wasm)
+        .output()
+        .expect("decode_ref.py runs");
+    assert!(
+        o.status.success(),
+        "decode_ref.py failed:\n{}",
+        String::from_utf8_lossy(&o.stderr)
+    );
+    serde_json::from_slice(&o.stdout).expect("decode_ref.py emits json")
+}
+
+// ---- Lean witness helpers ------------------------------------------------
+
+fn hex_le(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes.iter().rev() {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn lean_str(s: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn exports_lit(exports: &serde_json::Value) -> String {
+    let items: Vec<String> = exports
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| {
+            let name = e[0].as_str().unwrap();
+            let idx = e[1].as_u64().unwrap();
+            format!("({}, {})", lean_str(name), idx)
+        })
+        .collect();
+    format!("[{}]", items.join(", "))
+}
+
+fn imports_lit(imports: &serde_json::Value) -> String {
+    let items: Vec<String> = imports
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| format!("({}, {})", lean_str(e[0].as_str().unwrap()), lean_str(e[1].as_str().unwrap())))
+        .collect();
+    format!("[{}]", items.join(", "))
+}
+
+/// Extract the `⟨arity, nlocals, [body]⟩` `WCode` literal from a
+/// `rederive_obligations` `code` string (`fun fn => if fn = N then some ⟨…⟩
+/// else none`).
+fn wcode_from_rederive(code: &str) -> String {
+    let start = code.find("then some ").expect("rederive code shape") + "then some ".len();
+    let end = code.rfind(" else none").expect("rederive code shape");
+    code[start..end].trim().to_string()
+}
+
+/// Run `lake env lean` on a witness source in the prebuilt prelude dir. Returns
+/// (clean, combined-output). A divergence surfaces as a kernel error here.
+fn run_lean(prelude: &Path, src: &str) -> (bool, String) {
+    let file = prelude.join("DecodeWitness.lean");
+    std::fs::write(&file, src).unwrap();
+    let o = Command::new("lake")
+        .arg("env")
+        .arg("lean")
+        .arg("DecodeWitness.lean")
+        .current_dir(prelude)
+        .output()
+        .expect("lake env lean runs");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&o.stdout),
+        String::from_utf8_lossy(&o.stderr)
+    );
+    let _ = std::fs::remove_file(&file);
+    let clean = o.status.success() && !combined.contains("error");
+    (clean, combined)
+}
+
+// ---- main differential + coverage ---------------------------------------
+
+#[test]
+fn cert_decode_three_way_differential_and_coverage() {
+    if !lake_available() {
+        eprintln!("skipping cert decode test: `lake` not available");
+        return;
+    }
+    if !python_available() {
+        eprintln!("skipping cert decode test: `python3` not available");
+        return;
+    }
+
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let prelude = build_prelude();
+    let out = temp_dir("cdec-wasm");
+    std::fs::create_dir_all(&out).unwrap();
+
+    let mut covered: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    for &fixture in FIXTURES {
+        let bytes = compile_wasm(&repo, fixture, &out);
+        let wasm_path = out.join(format!("{fixture}.wasm"));
+        let oracle = oracle_json(&repo, &wasm_path);
+
+        // Rust oracle: certified obligations, cross-checked against the Python
+        // oracle (carrier + export-name → self), then pinned to the Lean decoder
+        // with rederive's exact rendered code strings.
+        let obligations = aver::codegen::cert::rederive_obligations(&bytes)
+            .expect("rederive succeeds on a compiled module");
+
+        let mut src = String::new();
+        src.push_str("import CertDecode\nopen CertPrelude\n\n");
+        src.push_str(&format!("def bytesN : Nat := 0x{}\n", hex_le(&bytes)));
+        src.push_str(&format!("def bytesLen : Nat := {}\n\n", bytes.len()));
+
+        // Section-level bindings (oracle: Python byte decoder).
+        src.push_str(&format!(
+            "example : CertDecode.decodeExports bytesN bytesLen = some {} := rfl\n",
+            exports_lit(&oracle["exports"])
+        ));
+        src.push_str(&format!(
+            "example : CertDecode.decodeImports bytesN bytesLen = some {} := rfl\n",
+            imports_lit(&oracle["imports"])
+        ));
+        if let Some(c) = oracle["carrier"].as_u64() {
+            src.push_str(&format!(
+                "example : CertDecode.decodeCarrier bytesN bytesLen = some {c} := rfl\n"
+            ));
+        }
+
+        // Per-function code bindings for EVERY user function (oracle: Python).
+        for f in oracle["funcs"].as_array().unwrap() {
+            let idx = f["idx"].as_u64().unwrap();
+            let arity = f["arity"].as_u64().unwrap();
+            let nlocals = f["nlocals"].as_u64().unwrap();
+            let body = f["body"].as_str().unwrap();
+            src.push_str(&format!(
+                "example : CertDecode.decodeCode bytesN bytesLen {idx} = some ⟨{arity}, {nlocals}, {body}⟩ := rfl\n"
+            ));
+            // opcode census for the coverage matrix.
+        }
+
+        // Certified obligations (oracle: Rust rederive) — the SAME rendered code
+        // strings the production witness pins, bound to the Lean decoder.
+        for o in &obligations {
+            // cross-check Rust vs Python: the carrier and the export → self map.
+            if let Some(c) = oracle["carrier"].as_u64() {
+                assert_eq!(
+                    o.carrier as u64, c,
+                    "{fixture}: rederive carrier {} != oracle carrier {c}",
+                    o.carrier
+                );
+            }
+            let mapped = oracle["exports"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|e| e[0].as_str() == Some(o.name.as_str()) && e[1].as_u64() == Some(o.self_idx as u64));
+            assert!(
+                mapped,
+                "{fixture}: rederive export {}→{} not in the decoded export map",
+                o.name, o.self_idx
+            );
+            src.push_str(&format!(
+                "example : CertDecode.decodeCode bytesN bytesLen {} = some {} := rfl\n",
+                o.self_idx,
+                wcode_from_rederive(&o.code)
+            ));
+        }
+
+        let (ok, report) = run_lean(&prelude, &src);
+        assert!(
+            ok,
+            "decoder differential DIVERGED on `{fixture}` (kernel rejected a binding):\n{report}"
+        );
+
+        for op in oracle["opcodes"].as_array().unwrap() {
+            covered.insert(op.as_str().unwrap().to_string());
+        }
+    }
+
+    // Synthetic single-body probe for the six opcodes no fixture body surfaces.
+    {
+        let mut src = String::new();
+        src.push_str("import CertDecode\nopen CertPrelude\n\n");
+        src.push_str(&format!("def synthN : Nat := 0x{}\n", hex_le(SYNTH_BYTES)));
+        src.push_str(&format!("def synthLen : Nat := {}\n\n", SYNTH_BYTES.len()));
+        src.push_str(&format!(
+            "example : CertDecode.decodeBodyBytes [] [] {} synthN synthLen = some {} := rfl\n",
+            SYNTH_BYTES.len(),
+            SYNTH_TERM
+        ));
+        let (ok, report) = run_lean(&prelude, &src);
+        assert!(ok, "synthetic opcode probe failed to decode:\n{report}");
+        for op in SYNTH_OPCODES {
+            covered.insert((*op).to_string());
+        }
+    }
+
+    // Coverage matrix, fail-closed: every one of the 39 must be exercised.
+    let missing: Vec<&str> = ALL_OPCODES
+        .iter()
+        .copied()
+        .filter(|op| !covered.contains(*op))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "opcode coverage FAIL — {} of 39 exercised, missing: {:?}",
+        covered.iter().filter(|c| ALL_OPCODES.contains(&c.as_str())).count(),
+        missing
+    );
+
+    let _ = std::fs::remove_dir_all(&out);
+    let _ = std::fs::remove_dir_all(&prelude);
+}
+
+// ---- mutation suite M1–M6 ------------------------------------------------
+
+/// Minimal section walk: returns (id, body_start, size) for each section.
+fn walk_sections(b: &[u8]) -> Vec<(u8, usize, usize)> {
+    let mut i = 8usize;
+    let mut secs = Vec::new();
+    while i < b.len() {
+        let id = b[i];
+        i += 1;
+        let (size, ni) = read_uleb(b, i);
+        secs.push((id, ni, size));
+        i = ni + size;
+    }
+    secs
+}
+
+fn read_uleb(b: &[u8], mut i: usize) -> (usize, usize) {
+    let mut r = 0usize;
+    let mut s = 0u32;
+    loop {
+        let x = b[i];
+        i += 1;
+        r |= ((x & 0x7f) as usize) << s;
+        if x & 0x80 == 0 {
+            break;
+        }
+        s += 7;
+    }
+    (r, i)
+}
+
+/// Offset of the funcidx byte of the export named `name` (single-byte index).
+fn export_funcidx_offset(b: &[u8], name: &str) -> usize {
+    let secs = walk_sections(b);
+    let (_, start, _) = *secs.iter().find(|s| s.0 == 7).unwrap();
+    let (cnt, mut i) = read_uleb(b, start);
+    for _ in 0..cnt {
+        let (nlen, ni) = read_uleb(b, i);
+        let this = std::str::from_utf8(&b[ni..ni + nlen]).unwrap_or("");
+        i = ni + nlen;
+        let _kind = b[i];
+        i += 1;
+        let idx_off = i;
+        let (_idx, ni2) = read_uleb(b, i);
+        i = ni2;
+        if this == name {
+            return idx_off;
+        }
+    }
+    panic!("export {name} not found");
+}
+
+#[test]
+fn cert_decode_mutations_fail_closed() {
+    if !lake_available() {
+        eprintln!("skipping cert decode mutation test: `lake` not available");
+        return;
+    }
+
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let prelude = build_prelude();
+    let out = temp_dir("cdec-mut-wasm");
+    std::fs::create_dir_all(&out).unwrap();
+
+    let bytes = compile_wasm(&repo, "certprobe2", &out);
+    let obligations = aver::codegen::cert::rederive_obligations(&bytes).unwrap();
+    let sumto = obligations.iter().find(|o| o.name == "sumTo").unwrap();
+    let self_idx = sumto.self_idx;
+    let orig_wcode = wcode_from_rederive(&sumto.code);
+
+    // helper: build a witness over an explicit byte array + a single example.
+    let witness = |b: &[u8], example: &str| -> String {
+        format!(
+            "import CertDecode\nopen CertPrelude\n\ndef bytesN : Nat := 0x{}\ndef bytesLen : Nat := {}\n\n{example}\n",
+            hex_le(b),
+            b.len()
+        )
+    };
+
+    // M1: flip a byte inside the certified body → the original decode no longer
+    // holds. Locate sumTo's body via the code section and flip its first opcode.
+    {
+        let secs = walk_sections(&bytes);
+        let (_, cstart, _) = *secs.iter().find(|s| s.0 == 10).unwrap();
+        let (_nf, mut i) = read_uleb(&bytes, cstart);
+        // skip entry 0 (defined idx 0), reach entry 1 (sumTo, defined idx 1).
+        let (sz0, ni) = read_uleb(&bytes, i);
+        i = ni + sz0;
+        let (_sz1, ni2) = read_uleb(&bytes, i);
+        i = ni2; // start of sumTo entry body: nloc groups ...
+        let (ng, ni3) = read_uleb(&bytes, i);
+        assert_eq!(ng, 1, "sumTo locals shape changed");
+        // one local group: count + ref valtype (0x63 + heaptype sleb)
+        let (_c, ni4) = read_uleb(&bytes, ni3);
+        let mut j = ni4;
+        assert!(bytes[j] == 0x63 || bytes[j] == 0x64);
+        j += 1;
+        let (_ht, jb) = read_uleb(&bytes, j); // heaptype (small, uleb == sleb)
+        let body0 = jb; // first opcode byte of the body (local.get)
+        assert_eq!(bytes[body0], 0x20, "sumTo body does not start with local.get");
+        let example = format!(
+            "example : CertDecode.decodeCode bytesN bytesLen {self_idx} = some {orig_wcode} := rfl"
+        );
+        // positive control: the binding holds on the un-mutated bytes …
+        let (ok0, r0) = run_lean(&prelude, &witness(&bytes, &example));
+        assert!(ok0, "M1 positive control: original binding must hold:\n{r0}");
+        let mut m = bytes.clone();
+        m[body0 + 1] ^= 0x04; // flip the local index operand
+        // … and fails only because of the body-byte flip.
+        let (ok, report) = run_lean(&prelude, &witness(&m, &example));
+        assert!(!ok, "M1: a body-byte flip must break the original decode:\n{report}");
+    }
+
+    // M2: flip a byte in a decoder-skipped section (memory, id 5) → the decoded
+    // obligations are unchanged.
+    {
+        let secs = walk_sections(&bytes);
+        let mem = secs.iter().find(|s| s.0 == 5).expect("memory section");
+        let off = mem.1 + mem.2 - 1; // last content byte of the memory section
+        let mut m = bytes.clone();
+        m[off] ^= 0x01;
+        assert_ne!(m, bytes);
+        let example = format!(
+            "example : CertDecode.decodeCode bytesN bytesLen {self_idx} = some {orig_wcode} := rfl\n\
+             example : CertDecode.decodeCarrier bytesN bytesLen = some {} := rfl",
+            sumto.carrier
+        );
+        let (ok, report) = run_lean(&prelude, &witness(&m, &example));
+        assert!(ok, "M2: a flip in a skipped section must leave the decode unchanged:\n{report}");
+    }
+
+    // M3: relabel sumTo's export funcidx → the decoded export map changes.
+    {
+        let off = export_funcidx_offset(&bytes, "sumTo");
+        assert_eq!(bytes[off], 1, "sumTo export funcidx shape changed");
+        let example =
+            "example : (CertDecode.decodeExports bytesN bytesLen).bind (fun m => m.lookup \"sumTo\") = some 1 := rfl"
+                .to_string();
+        // positive control: sumTo → 1 in the un-mutated export map …
+        let (ok0, r0) = run_lean(&prelude, &witness(&bytes, &example));
+        assert!(ok0, "M3 positive control: original export map must hold:\n{r0}");
+        let mut m = bytes.clone();
+        m[off] = 5; // relabel to another defined function index
+        // … and fails only because the funcidx was relabelled.
+        let (ok, report) = run_lean(&prelude, &witness(&m, &example));
+        assert!(!ok, "M3: an export relabel must change the decoded funcidx:\n{report}");
+    }
+
+    // M4: overlong LEB in a section size → the walk decodes to none. Rewrite the
+    // memory section's 1-byte size as an overlong two-byte encoding.
+    {
+        let secs = walk_sections(&bytes);
+        let mem = secs.iter().find(|s| s.0 == 5).expect("memory section");
+        // the size LEB sits just before the body start; find its extent.
+        let (_size, after) = read_uleb(&bytes, mem.1 - 1); // 1-byte size assumed
+        assert_eq!(after, mem.1, "memory section size is not a single byte");
+        let size_byte = bytes[mem.1 - 1];
+        assert!(size_byte < 0x80);
+        let mut m: Vec<u8> = bytes[..mem.1 - 1].to_vec();
+        m.push(size_byte | 0x80); // continuation set …
+        m.push(0x00); // … then a trailing zero → overlong (rejected)
+        m.extend_from_slice(&bytes[mem.1..]);
+        let example =
+            "example : CertDecode.decodeExports bytesN bytesLen = none := rfl".to_string();
+        let (ok, report) = run_lean(&prelude, &witness(&m, &example));
+        assert!(ok, "M4: an overlong size LEB must make the section walk fail closed:\n{report}");
+    }
+
+    // M5: truncation inside the code section → the body decodes to none, while
+    // the (earlier) export section still decodes.
+    {
+        let secs = walk_sections(&bytes);
+        let (_, cstart, _) = *secs.iter().find(|s| s.0 == 10).unwrap();
+        let (_nf, i) = read_uleb(&bytes, cstart);
+        let (sz0, ni) = read_uleb(&bytes, i);
+        let (_sz1, ni2) = read_uleb(&bytes, ni + sz0);
+        let cut = ni2 + 3; // 3 bytes into sumTo's entry, mid-body
+        let m = bytes[..cut].to_vec();
+        let example = format!(
+            "example : CertDecode.decodeCode bytesN bytesLen {self_idx} = none := rfl\n\
+             example : (CertDecode.decodeExports bytesN bytesLen).isSome = true := rfl"
+        );
+        let (ok, report) = run_lean(&prelude, &witness(&m, &example));
+        assert!(ok, "M5: a truncated code section must decode to none, exports intact:\n{report}");
+    }
+
+    // M6: a function index beyond the module's function space decodes to none
+    // (an export relabelled past the end never yields a garbage body).
+    {
+        let example =
+            "example : CertDecode.decodeCode bytesN bytesLen 100000 = none := rfl".to_string();
+        let (ok, report) = run_lean(&prelude, &witness(&bytes, &example));
+        assert!(ok, "M6: an out-of-function-space index must decode to none:\n{report}");
+    }
+
+    let _ = std::fs::remove_dir_all(&out);
+    let _ = std::fs::remove_dir_all(&prelude);
+}

--- a/tests/cert_decode_spec.rs
+++ b/tests/cert_decode_spec.rs
@@ -2,10 +2,10 @@
 //! (`tools/certkit/prelude/CertDecode.lean`).
 //!
 //! The main test is a three-way decoder differential: for every certkit
-//! fixture it agrees, TERM FOR TERM, across
-//!   * the Lean kernel decoder (`CertDecode.decode…`, checked by `rfl`),
-//!   * the Rust `cert::rederive_obligations` (the certified-obligation oracle),
-//!   * the Python byte-level `tools/certkit/decode_ref.py`.
+//! fixture it agrees, TERM FOR TERM, across the Lean kernel decoder
+//! (`CertDecode.decode…`, checked by `rfl`), the Rust
+//! `cert::rederive_obligations` (the certified-obligation oracle), and the
+//! Python byte-level `tools/certkit/decode_ref.py`.
 //! It compiles each fixture, emits a Lean witness pinning `decodeExports`,
 //! `decodeImports`, `decodeCarrier`, and per-function `decodeCode` to the oracle
 //! values, and lets `lake env lean` be the verdict — a divergence is a kernel
@@ -37,19 +37,56 @@ const FIXTURES: &[&str] = &[
 
 /// The 39 measured user-code opcode mnemonics (mirrors `diff_harness.py`).
 const ALL_OPCODES: &[&str] = &[
-    "array.new_data", "array.new_fixed", "call", "else", "end", "f64.add",
-    "f64.const", "f64.div", "f64.eq", "f64.ge", "f64.gt", "f64.le", "f64.lt",
-    "f64.mul", "f64.sub", "i32.and", "i32.const", "i32.eq", "i32.gt_s",
-    "i32.le_s", "i32.lt_s", "i64.const", "i64.eq", "i64.eqz", "i64.ge_s",
-    "i64.gt_s", "i64.le_s", "i64.lt_s", "if", "local.get", "local.set",
-    "ref.cast", "ref.is_null", "ref.null", "ref.test", "return", "return_call",
-    "struct.get", "struct.new",
+    "array.new_data",
+    "array.new_fixed",
+    "call",
+    "else",
+    "end",
+    "f64.add",
+    "f64.const",
+    "f64.div",
+    "f64.eq",
+    "f64.ge",
+    "f64.gt",
+    "f64.le",
+    "f64.lt",
+    "f64.mul",
+    "f64.sub",
+    "i32.and",
+    "i32.const",
+    "i32.eq",
+    "i32.gt_s",
+    "i32.le_s",
+    "i32.lt_s",
+    "i64.const",
+    "i64.eq",
+    "i64.eqz",
+    "i64.ge_s",
+    "i64.gt_s",
+    "i64.le_s",
+    "i64.lt_s",
+    "if",
+    "local.get",
+    "local.set",
+    "ref.cast",
+    "ref.is_null",
+    "ref.null",
+    "ref.test",
+    "return",
+    "return_call",
+    "struct.get",
+    "struct.new",
 ];
 
 /// The opcodes never surfaced by a certkit user-function body; the decoder's
 /// arm for each is exercised by a synthetic single-body probe instead.
 const SYNTH_OPCODES: &[&str] = &[
-    "i32.and", "i32.eq", "i64.eqz", "return", "ref.null", "array.new_fixed",
+    "i32.and",
+    "i32.eq",
+    "i64.eqz",
+    "return",
+    "ref.null",
+    "array.new_fixed",
 ];
 
 /// Raw bytes of the synthetic probe body and the term it must decode to. Covers
@@ -188,7 +225,13 @@ fn imports_lit(imports: &serde_json::Value) -> String {
         .as_array()
         .unwrap()
         .iter()
-        .map(|e| format!("({}, {})", lean_str(e[0].as_str().unwrap()), lean_str(e[1].as_str().unwrap())))
+        .map(|e| {
+            format!(
+                "({}, {})",
+                lean_str(e[0].as_str().unwrap()),
+                lean_str(e[1].as_str().unwrap())
+            )
+        })
         .collect();
     format!("[{}]", items.join(", "))
 }
@@ -298,11 +341,9 @@ fn cert_decode_three_way_differential_and_coverage() {
                     o.carrier
                 );
             }
-            let mapped = oracle["exports"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .any(|e| e[0].as_str() == Some(o.name.as_str()) && e[1].as_u64() == Some(o.self_idx as u64));
+            let mapped = oracle["exports"].as_array().unwrap().iter().any(|e| {
+                e[0].as_str() == Some(o.name.as_str()) && e[1].as_u64() == Some(o.self_idx as u64)
+            });
             assert!(
                 mapped,
                 "{fixture}: rederive export {}→{} not in the decoded export map",
@@ -353,7 +394,10 @@ fn cert_decode_three_way_differential_and_coverage() {
     assert!(
         missing.is_empty(),
         "opcode coverage FAIL — {} of 39 exercised, missing: {:?}",
-        covered.iter().filter(|c| ALL_OPCODES.contains(&c.as_str())).count(),
+        covered
+            .iter()
+            .filter(|c| ALL_OPCODES.contains(&c.as_str()))
+            .count(),
         missing
     );
 
@@ -460,18 +504,27 @@ fn cert_decode_mutations_fail_closed() {
         j += 1;
         let (_ht, jb) = read_uleb(&bytes, j); // heaptype (small, uleb == sleb)
         let body0 = jb; // first opcode byte of the body (local.get)
-        assert_eq!(bytes[body0], 0x20, "sumTo body does not start with local.get");
+        assert_eq!(
+            bytes[body0], 0x20,
+            "sumTo body does not start with local.get"
+        );
         let example = format!(
             "example : CertDecode.decodeCode bytesN bytesLen {self_idx} = some {orig_wcode} := rfl"
         );
         // positive control: the binding holds on the un-mutated bytes …
         let (ok0, r0) = run_lean(&prelude, &witness(&bytes, &example));
-        assert!(ok0, "M1 positive control: original binding must hold:\n{r0}");
+        assert!(
+            ok0,
+            "M1 positive control: original binding must hold:\n{r0}"
+        );
         let mut m = bytes.clone();
         m[body0 + 1] ^= 0x04; // flip the local index operand
         // … and fails only because of the body-byte flip.
         let (ok, report) = run_lean(&prelude, &witness(&m, &example));
-        assert!(!ok, "M1: a body-byte flip must break the original decode:\n{report}");
+        assert!(
+            !ok,
+            "M1: a body-byte flip must break the original decode:\n{report}"
+        );
     }
 
     // M2: flip a byte in a decoder-skipped section (memory, id 5) → the decoded
@@ -489,7 +542,10 @@ fn cert_decode_mutations_fail_closed() {
             sumto.carrier
         );
         let (ok, report) = run_lean(&prelude, &witness(&m, &example));
-        assert!(ok, "M2: a flip in a skipped section must leave the decode unchanged:\n{report}");
+        assert!(
+            ok,
+            "M2: a flip in a skipped section must leave the decode unchanged:\n{report}"
+        );
     }
 
     // M3: relabel sumTo's export funcidx → the decoded export map changes.
@@ -501,12 +557,18 @@ fn cert_decode_mutations_fail_closed() {
                 .to_string();
         // positive control: sumTo → 1 in the un-mutated export map …
         let (ok0, r0) = run_lean(&prelude, &witness(&bytes, &example));
-        assert!(ok0, "M3 positive control: original export map must hold:\n{r0}");
+        assert!(
+            ok0,
+            "M3 positive control: original export map must hold:\n{r0}"
+        );
         let mut m = bytes.clone();
         m[off] = 5; // relabel to another defined function index
         // … and fails only because the funcidx was relabelled.
         let (ok, report) = run_lean(&prelude, &witness(&m, &example));
-        assert!(!ok, "M3: an export relabel must change the decoded funcidx:\n{report}");
+        assert!(
+            !ok,
+            "M3: an export relabel must change the decoded funcidx:\n{report}"
+        );
     }
 
     // M4: overlong LEB in a section size → the walk decodes to none. Rewrite the
@@ -526,7 +588,10 @@ fn cert_decode_mutations_fail_closed() {
         let example =
             "example : CertDecode.decodeExports bytesN bytesLen = none := rfl".to_string();
         let (ok, report) = run_lean(&prelude, &witness(&m, &example));
-        assert!(ok, "M4: an overlong size LEB must make the section walk fail closed:\n{report}");
+        assert!(
+            ok,
+            "M4: an overlong size LEB must make the section walk fail closed:\n{report}"
+        );
     }
 
     // M5: truncation inside the code section → the body decodes to none, while
@@ -544,7 +609,10 @@ fn cert_decode_mutations_fail_closed() {
              example : (CertDecode.decodeExports bytesN bytesLen).isSome = true := rfl"
         );
         let (ok, report) = run_lean(&prelude, &witness(&m, &example));
-        assert!(ok, "M5: a truncated code section must decode to none, exports intact:\n{report}");
+        assert!(
+            ok,
+            "M5: a truncated code section must decode to none, exports intact:\n{report}"
+        );
     }
 
     // M6: a function index beyond the module's function space decodes to none
@@ -553,7 +621,10 @@ fn cert_decode_mutations_fail_closed() {
         let example =
             "example : CertDecode.decodeCode bytesN bytesLen 100000 = none := rfl".to_string();
         let (ok, report) = run_lean(&prelude, &witness(&bytes, &example));
-        assert!(ok, "M6: an out-of-function-space index must decode to none:\n{report}");
+        assert!(
+            ok,
+            "M6: an out-of-function-space index must decode to none:\n{report}"
+        );
     }
 
     let _ = std::fs::remove_dir_all(&out);

--- a/tools/certkit/decode_ref.py
+++ b/tools/certkit/decode_ref.py
@@ -394,6 +394,7 @@ def analyze(wasm_path):
         "exports": exports,
         "opcodes": sorted(opcodes),
         "funcs": funcs,
+        "sections": [s[0] for s in secs],
     }
 
 

--- a/tools/certkit/decode_ref.py
+++ b/tools/certkit/decode_ref.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Byte-level reference decoder for the AverUserProfile/v0 certificate profile.
+
+This is the Python leg of the three-way decoder differential: it decodes a
+compiled wasm-gc module DIRECTLY from its bytes (section walk, type section,
+import/function/export/data sections, and the 39-opcode user-code fragment)
+into the same pure data the in-kernel `CertDecode.lean` decoder and the Rust
+`cert::rederive_obligations` produce. `extract.py` (WAT-level) and this file
+(byte-level) are independent implementations of the same grammar, so `validate`
+cross-checks them; `json` emits the oracle the decoder witness/tests pin.
+
+Python stdlib only.
+"""
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+import wat        # noqa: E402
+import extract    # noqa: E402
+
+
+# ---- LEB128 --------------------------------------------------------------
+
+def uleb(b, i):
+    r = 0
+    s = 0
+    st = i
+    while True:
+        x = b[i]
+        i += 1
+        r |= (x & 0x7f) << s
+        if not (x & 0x80):
+            if i - st > 1 and x == 0:
+                raise ValueError("overlong LEB")
+            break
+        s += 7
+    return r, i
+
+
+def sleb(b, i):
+    r = 0
+    s = 0
+    while True:
+        x = b[i]
+        i += 1
+        r |= (x & 0x7f) << s
+        s += 7
+        if not (x & 0x80):
+            if s < 64 and (x & 0x40):
+                r |= -(1 << s)
+            break
+    return r, i
+
+
+def walk(b):
+    assert b[0:4] == b"\x00asm", "bad magic"
+    i = 8
+    secs = []
+    while i < len(b):
+        sid = b[i]
+        i += 1
+        sz, i = uleb(b, i)
+        secs.append((sid, i, sz))
+        i += sz
+    return secs
+
+
+def find(secs, sid):
+    xs = [s for s in secs if s[0] == sid]
+    return xs[0] if xs else None
+
+
+# ---- type section (arity, struct field counts, carrier) ------------------
+
+NUM_VT = {0x7f, 0x7e, 0x7d, 0x7c, 0x7b}
+
+
+def read_valtype(b, i):
+    v = b[i]
+    if v in NUM_VT:
+        return i + 1
+    if v in (0x63, 0x64):
+        _, i = sleb(b, i + 1)
+        return i
+    if 0x6a <= v <= 0x73:          # abstract-heap shorthand (eqref, anyref, ...)
+        return i + 1
+    raise ValueError(f"valtype {v:#x}")
+
+
+def read_storagetype(b, i):
+    v = b[i]
+    if v in (0x78, 0x77):          # packed i8 / i16
+        return i + 1
+    return read_valtype(b, i)
+
+
+def read_field(b, i):
+    v = b[i]
+    i = read_storagetype(b, i)
+    return v, i + 1                # storage first byte + skip mut byte
+
+
+def decode_types(b, secs):
+    ty = find(secs, 1)
+    arities = {}                   # typeidx -> param count (func types)
+    nfields = {}                   # typeidx -> field count (struct types)
+    carrier = None
+    if ty is None:
+        return arities, nfields, carrier
+    i = ty[1]
+    count, i = uleb(b, i)
+    tidx = 0
+
+    def comptype(i):
+        nonlocal tidx, carrier
+        v = b[i]
+        if v == 0x60:              # func
+            i += 1
+            np, i = uleb(b, i)
+            for _ in range(np):
+                i = read_valtype(b, i)
+            nr, i = uleb(b, i)
+            for _ in range(nr):
+                i = read_valtype(b, i)
+            arities[tidx] = np
+        elif v == 0x5f:            # struct
+            i += 1
+            nf, i = uleb(b, i)
+            fbs = []
+            for _ in range(nf):
+                sfb, i = read_field(b, i)
+                fbs.append(sfb)
+            nfields[tidx] = nf
+            if carrier is None and nf == 3 and fbs[0] == 0x7e and fbs[2] == 0x7f:
+                carrier = tidx
+        elif v == 0x5e:            # array
+            i += 1
+            _, i = read_field(b, i)
+        else:
+            raise ValueError(f"comptype {v:#x}")
+        tidx += 1
+        return i
+
+    def subtype(i):
+        v = b[i]
+        if v in (0x50, 0x4f):      # sub / sub final
+            i += 1
+            n, i = uleb(b, i)
+            for _ in range(n):
+                _, i = uleb(b, i)
+        return comptype(i)
+
+    for _ in range(count):
+        if b[i] == 0x4e:           # explicit rec group
+            i += 1
+            n, i = uleb(b, i)
+            for _ in range(n):
+                i = subtype(i)
+        else:
+            i = subtype(i)
+    return arities, nfields, carrier
+
+
+# ---- import / function / export / data sections --------------------------
+
+def decode_imports(b, secs):
+    imp = find(secs, 2)
+    out = []
+    nfunc = 0
+    if imp is None:
+        return out, 0
+    i = imp[1]
+    n, i = uleb(b, i)
+    for _ in range(n):
+        ml, i = uleb(b, i)
+        mod = b[i:i + ml].decode("latin1")
+        i += ml
+        nl, i = uleb(b, i)
+        nm = b[i:i + nl].decode("latin1")
+        i += nl
+        kind = b[i]
+        i += 1
+        if kind == 0:
+            _, i = uleb(b, i)
+            out.append((mod, nm))
+            nfunc += 1
+        else:
+            raise ValueError(f"non-function import kind {kind}")
+    return out, nfunc
+
+
+def decode_funcsec(b, secs):
+    fs = find(secs, 3)
+    out = []
+    if fs is None:
+        return out
+    i = fs[1]
+    n, i = uleb(b, i)
+    for _ in range(n):
+        t, i = uleb(b, i)
+        out.append(t)
+    return out
+
+
+def decode_exports(b, secs):
+    ex = find(secs, 7)
+    out = []
+    i = ex[1]
+    n, i = uleb(b, i)
+    for _ in range(n):
+        nl, i = uleb(b, i)
+        nm = b[i:i + nl].decode("latin1")
+        i += nl
+        kind = b[i]
+        i += 1
+        idx, i = uleb(b, i)
+        if kind == 0:
+            out.append((nm, idx))
+    return out
+
+
+def decode_data(b, secs):
+    d = find(secs, 11)
+    out = []
+    if d is None:
+        return out
+    i = d[1]
+    n, i = uleb(b, i)
+    for _ in range(n):
+        flag = b[i]
+        i += 1
+        if flag != 0x01:
+            raise ValueError(f"non-passive data flag {flag}")
+        cnt, i = uleb(b, i)
+        out.append(b[i:i + cnt])
+        i += cnt
+    return out
+
+
+# ---- body decode ---------------------------------------------------------
+
+def skip_blocktype(b, i):
+    bt = b[i]
+    if bt == 0x40 or bt in NUM_VT:
+        return i + 1
+    if bt in (0x63, 0x64):
+        _, i = sleb(b, i + 1)
+        return i
+    _, i = sleb(b, i)              # typeidx s33
+    return i
+
+
+SIMPLE = {
+    0x50: ".i64Eqz", 0x51: ".i64Eq", 0x57: ".i64LeS", 0x53: ".i64LtS",
+    0x59: ".i64GeS", 0x55: ".i64GtS", 0x46: ".i32Eq", 0x71: ".i32And",
+    0x48: ".i32LtS", 0x4c: ".i32LeS", 0x4a: ".i32GtS", 0xa0: ".f64Add",
+    0xa1: ".f64Sub", 0xa2: ".f64Mul", 0xa3: ".f64Div", 0x61: ".f64Eq",
+    0x63: ".f64Lt", 0x65: ".f64Le", 0x66: ".f64Ge", 0x64: ".f64Gt",
+    0xd1: ".refIsNull", 0x0f: ".ret",
+}
+
+
+def decode_block(b, i, end, nfields, data_segs, pend):
+    out = []
+    while i < end:
+        op = b[i]
+        i += 1
+        if op in (0x0b, 0x05):     # end / else — leave the terminator
+            return out, i - 1
+        if op == 0x04:             # if
+            i = skip_blocktype(b, i)
+            tb, i = decode_block(b, i, end, nfields, data_segs, pend)
+            eb = []
+            if b[i] == 0x05:
+                i += 1
+                eb, i = decode_block(b, i, end, nfields, data_segs, pend)
+            i += 1                 # closing end
+            out.append(f".ifElse [{', '.join(tb)}] [{', '.join(eb)}]")
+        elif op == 0x20:
+            v, i = uleb(b, i)
+            out.append(f".localGet {v}")
+        elif op == 0x21:
+            v, i = uleb(b, i)
+            out.append(f".localSet {v}")
+        elif op == 0x42:
+            v, i = sleb(b, i)
+            out.append(f".i64Const ({v})")
+        elif op == 0x41:
+            v, i = sleb(b, i)
+            out.append(f".i32Const ({v})")
+            pend.append(v)
+        elif op == 0x44:
+            bits = int.from_bytes(b[i:i + 8], "little")
+            i += 8
+            out.append(f".f64Const 0x{bits:016x}")
+        elif op == 0xd0:
+            _, i = sleb(b, i)
+            out.append(".refNull")
+        elif op == 0x10:
+            v, i = uleb(b, i)
+            out.append(f".call {v}")
+        elif op == 0x12:
+            v, i = uleb(b, i)
+            out.append(f".returnCall {v}")
+        elif op == 0xfb:
+            sub, i = uleb(b, i)
+            if sub == 0x00:
+                t, i = uleb(b, i)
+                out.append(f".structNew {t} {nfields.get(t, 0)}")
+            elif sub == 0x02:
+                t, i = uleb(b, i)
+                f, i = uleb(b, i)
+                out.append(f".structGet {t} {f}")
+            elif sub == 0x08:
+                t, i = uleb(b, i)
+                m, i = uleb(b, i)
+                out.append(f".arrayNewFixed {t} {m}")
+            elif sub == 0x09:
+                t, i = uleb(b, i)
+                seg, i = uleb(b, i)
+                length = pend[-1] if pend else 0
+                offset = pend[-2] if len(pend) >= 2 else 0
+                payload = data_segs[seg] if seg < len(data_segs) else b""
+                chunk = list(payload[offset:offset + length])
+                out.append(f".arrayNewData {t} [{', '.join(str(x) for x in chunk)}]")
+            elif sub in (0x14, 0x15):
+                h, i = sleb(b, i)
+                out.append(f".refTest {h}")
+            elif sub in (0x16, 0x17):
+                h, i = sleb(b, i)
+                out.append(f".refCast {h}")
+            else:
+                raise ValueError(f"gc subop {sub:#x}")
+        elif op in SIMPLE:
+            out.append(SIMPLE[op])
+        else:
+            raise ValueError(f"opcode {op:#x}")
+    return out, i
+
+
+def analyze(wasm_path):
+    b = open(wasm_path, "rb").read()
+    secs = walk(b)
+    w = wat.wat_of(wasm_path)
+    user = wat.user_functions(w)
+    bodies = wat.function_bodies(w)
+    arities, nfields, carrier = decode_types(b, secs)
+    imports, nimp = decode_imports(b, secs)
+    funcsec = decode_funcsec(b, secs)
+    exports = decode_exports(b, secs)
+    data_segs = decode_data(b, secs)
+
+    code = find(secs, 10)
+    j = code[1]
+    nf, j = uleb(b, j)
+    entries = []
+    for _ in range(nf):
+        esz, j = uleb(b, j)
+        bend = j + esz
+        k = j
+        ng, k = uleb(b, k)
+        nloc = 0
+        for _ in range(ng):
+            c, k = uleb(b, k)
+            t = b[k]
+            k += 1
+            if t in (0x63, 0x64):
+                _, k = sleb(b, k)
+            nloc += c
+        entries.append((k, bend, nloc))
+        j = bend
+
+    funcs = []
+    opcodes = set()
+    for name, fidx in sorted(user.items(), key=lambda kv: kv[1]):
+        di = fidx - nimp
+        bstart, bend, nloc = entries[di]
+        body, _ = decode_block(b, bstart, bend, nfields, data_segs, [])
+        tyidx = funcsec[di]
+        arity = arities.get(tyidx, 0)
+        funcs.append({
+            "name": name, "idx": fidx, "arity": arity, "nlocals": nloc,
+            "body": "[" + ", ".join(body) + "]",
+        })
+        for ln in bodies.get(fidx, {}).get("lines", []):
+            if ln.split():
+                opcodes.add(ln.split()[0])
+
+    return {
+        "carrier": carrier,
+        "imports": imports,
+        "exports": exports,
+        "opcodes": sorted(opcodes),
+        "funcs": funcs,
+    }
+
+
+# ---- CLI -----------------------------------------------------------------
+
+def _validate(paths):
+    ok_all = True
+    for path in paths:
+        r = analyze(path)
+        meta, arms = extract.extract(path)
+        exp = {}
+        for a in arms:
+            m = re.match(r"\s*\|\s*(\d+)\s*=>\s*some\s*⟨(\d+),\s*(\d+),\s*\[(.*)\]⟩", a)
+            exp[int(m.group(1))] = (int(m.group(2)), int(m.group(3)), "[" + m.group(4) + "]")
+        ok = True
+        for f in r["funcs"]:
+            if (f["arity"], f["nlocals"], f["body"]) != exp[f["idx"]]:
+                ok = False
+                print(f"  MISMATCH {os.path.basename(path)} fn{f['idx']} {f['name']}")
+        if r["carrier"] != meta["carrier"]:
+            ok = False
+            print(f"  CARRIER {r['carrier']} != {meta['carrier']} in {path}")
+        ok_all = ok_all and ok
+        print(f"{os.path.basename(path):20} carrier={r['carrier']} "
+              f"exports={len(r['exports'])} funcs={len(r['funcs'])} "
+              f"{'OK' if ok else 'FAIL'}")
+    return ok_all
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("usage: decode_ref.py {validate|json} <wasm>...", file=sys.stderr)
+        sys.exit(2)
+    mode = sys.argv[1]
+    if mode == "validate":
+        sys.exit(0 if _validate(sys.argv[2:]) else 1)
+    elif mode == "json":
+        print(json.dumps(analyze(sys.argv[2])))
+    else:
+        print(f"unknown mode {mode}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/certkit/prelude/CertDecode.lean
+++ b/tools/certkit/prelude/CertDecode.lean
@@ -1,0 +1,653 @@
+/-
+  CertDecode — checker-owned, in-kernel decoder for the AverUserProfile/v0
+  certificate profile. Given a wasm-gc module as a little-endian big-`Nat`
+  plus a byte length, it decodes the profile-relevant sections into PURE DATA
+  (`rfl`-comparable): the export map, the imported (module, name) list, the Int
+  carrier type index, and per-function `WCode` (arity from the type section,
+  nlocals from the locals declaration, body as `List CertPrelude.WInstr` — the
+  full 39-opcode fragment, if/else/end folded into `WInstr.ifElse`).
+
+  The result semantics mirror `src/codegen/cert/mod.rs::rederive_obligations`
+  and `tools/certkit/extract.py` so all three decoders agree term for term on
+  every certkit fixture (three-way differential).
+
+  Construction constraints (from the C2 kill-fast probes):
+  * All recursion is STRUCTURAL or on an explicit fuel `Nat`. There is no
+    well-founded recursion and no `partial def`, so every `decode…` reduces in
+    the kernel and a certificate witness closes by `rfl` (axioms `[propext]`).
+  * The byte representation is one little-endian big-`Nat` + a length. Reading a
+    byte is `n &&& 0xff`, advancing is `n >>> 8`, and skipping a section body of
+    `size` bytes is a single GMP-accelerated shift `n >>> (8 * size)`.
+
+  Scope is PROFILE-ONLY and REJECT-BY-DEFAULT. The type-section subset decoded
+  is exactly what the Aver wasm-gc compiler emits and the fixtures exercise:
+  rec groups, optional `sub`/`sub final` prefixes, `func`/`struct`/`array`
+  composite types, numeric valtypes (0x7b–0x7f), reference valtypes
+  (0x63/0x64 + heaptype), and the abstract-heap valtype shorthands (0x6a–0x73,
+  e.g. `eqref`). Anything outside this subset (a valtype/opcode the emitter does
+  not produce, an overlong LEB, a truncated section) decodes to `none` — never a
+  garbage success. Module admission is out of scope (that is a later item on the
+  same decoder); the certificate claim is about obligations, and skipped
+  sections are covered by the checker-side module hash.
+-/
+import CertPrelude
+open CertPrelude
+
+namespace CertDecode
+
+/-- ASCII/latin1 name bytes → `String` (defeq to the string literal under `rfl`,
+    so the certified export names are anchored, not weakened to byte lists). -/
+def mkName (ns : List Nat) : String := String.ofList (ns.map (fun n => Char.ofNat n))
+
+/-- Peel `count` bytes off the little-endian big-`Nat` into a `List Nat`. -/
+def takeBytes : Nat → Nat → List Nat
+  | 0,   _ => []
+  | k+1, n => (n &&& 0xff) :: takeBytes k (n >>> 8)
+
+/- ===================================================================== -/
+/-  LEB128                                                                -/
+/- ===================================================================== -/
+
+/-- Canonical unsigned LEB128 over `(n, len)`; overlong trailing-zero → none. -/
+def uleb : Nat → Nat → Nat → Nat → Nat → Option (Nat × Nat × Nat)
+  | 0,      _,   _,     _, _   => none
+  | fuel+1, acc, shift, n, len =>
+      if len == 0 then none else
+        let b   := n &&& 0xff
+        let n'  := n >>> 8
+        let acc' := acc + ((b &&& 0x7f) <<< shift)
+        if b < 128 then
+          if (shift != 0) && (b == 0) then none else some (acc', n', len-1)
+        else uleb fuel acc' (shift+7) n' (len-1)
+
+@[inline] def readU (n len : Nat) : Option (Nat × Nat × Nat) := uleb 5 0 0 n len
+
+/-- Signed LEB128 (i64/i32 const immediates, s33 heaptypes / typeidx). -/
+def sleb : Nat → Int → Nat → Nat → Nat → Option (Int × Nat × Nat)
+  | 0,      _,   _,     _, _   => none
+  | fuel+1, acc, shift, n, len =>
+      if len == 0 then none else
+        let b   := n &&& 0xff
+        let n'  := n >>> 8
+        let acc' := acc + (Int.ofNat (b &&& 0x7f)) * ((2 : Int) ^ shift)
+        if b < 128 then
+          let signed := if (b &&& 0x40) != 0 then acc' - ((2 : Int) ^ (shift+7)) else acc'
+          some (signed, n', len-1)
+        else sleb fuel acc' (shift+7) n' (len-1)
+
+@[inline] def readS (n len : Nat) : Option (Int × Nat × Nat) := sleb 10 0 0 n len
+
+/- ===================================================================== -/
+/-  Section walk                                                          -/
+/- ===================================================================== -/
+
+/-- Whole-file section id sequence (skip is one GMP shift per section). -/
+def walkIds : Nat → Nat → Nat → Option (List Nat)
+  | 0,      _, _   => none
+  | fuel+1, n, len =>
+      if len == 0 then some [] else
+        let id  := n &&& 0xff
+        let n1  := n >>> 8
+        match readU n1 (len-1) with
+        | none => none
+        | some (size, n2, len2) =>
+            match walkIds fuel (n2 >>> (8*size)) (len2 - size) with
+            | none => none
+            | some tl => some (id :: tl)
+
+/-- Body suffix `(n, len)` of the first section with id = target, else none. -/
+def findSec (target : Nat) : Nat → Nat → Nat → Option (Nat × Nat)
+  | 0,      _, _   => none
+  | fuel+1, n, len =>
+      if len == 0 then none else
+        let id  := n &&& 0xff
+        let n1  := n >>> 8
+        match readU n1 (len-1) with
+        | none => none
+        | some (size, n2, len2) =>
+            if id == target then some (n2, len2)
+            else findSec target fuel (n2 >>> (8*size)) (len2 - size)
+
+/- ===================================================================== -/
+/-  Type section (arity per type index, struct field counts, carrier)     -/
+/- ===================================================================== -/
+
+/-- Per-type-index arities (0 for non-func), struct field counts (0 for
+    non-struct), and the first Int-carrier struct index. -/
+structure TypeInfo where
+  arities : List Nat
+  nfields : List Nat
+  carrier : Option Nat
+
+/-- Consume one valtype, returning its leading byte (for carrier detection). -/
+def readValType (n len : Nat) : Option (Nat × Nat × Nat) :=
+  if len == 0 then none else
+    let v := n &&& 0xff
+    let n1 := n >>> 8
+    let len1 := len - 1
+    if v == 0x7f || v == 0x7e || v == 0x7d || v == 0x7c || v == 0x7b then some (v, n1, len1)
+    else if v == 0x63 || v == 0x64 then
+      match readS n1 len1 with            -- heaptype (s33)
+      | none => none
+      | some (_, n2, len2) => some (v, n2, len2)
+    else if decide (0x6a ≤ v ∧ v ≤ 0x73) then some (v, n1, len1)  -- abstract-heap shorthand
+    else none
+
+/-- Consume one storage type (packed i8/i16, or a valtype). -/
+def readStorageType (n len : Nat) : Option (Nat × Nat × Nat) :=
+  if len == 0 then none else
+    let v := n &&& 0xff
+    if v == 0x78 || v == 0x77 then some (v, n >>> 8, len - 1)
+    else readValType n len
+
+/-- Consume one struct/array field (storage type + mut byte); return leading
+    byte of the storage type. -/
+def readField (n len : Nat) : Option (Nat × Nat × Nat) :=
+  match readStorageType n len with
+  | none => none
+  | some (sfb, n1, len1) =>
+      if len1 == 0 then none else some (sfb, n1 >>> 8, len1 - 1)   -- drop mut byte
+
+/-- Read `k` fields, collecting their leading storage bytes. -/
+def readFields : Nat → Nat → Nat → Option (List Nat × Nat × Nat)
+  | 0,   n, len => some ([], n, len)
+  | k+1, n, len =>
+      match readField n len with
+      | none => none
+      | some (sfb, n1, len1) =>
+          match readFields k n1 len1 with
+          | none => none
+          | some (rest, n2, len2) => some (sfb :: rest, n2, len2)
+
+/-- Skip `p` valtypes (func params/results). -/
+def skipValTypes : Nat → Nat → Nat → Option (Nat × Nat)
+  | 0,   n, len => some (n, len)
+  | p+1, n, len =>
+      match readValType n len with
+      | none => none
+      | some (_, n1, len1) => skipValTypes p n1 len1
+
+/-- Skip `s` unsigned LEB values (e.g. a vec of supertype type indices). -/
+def skipUlebs : Nat → Nat → Nat → Option (Nat × Nat)
+  | 0,   n, len => some (n, len)
+  | s+1, n, len =>
+      match readU n len with
+      | none => none
+      | some (_, n1, len1) => skipUlebs s n1 len1
+
+/-- Decode one composite type at absolute type index `tidx`. -/
+def decComptype (tidx n len : Nat) : Option (Nat × Nat × Option Nat × Nat × Nat) :=
+  if len == 0 then none else
+    let c := n &&& 0xff
+    let n1 := n >>> 8
+    let len1 := len - 1
+    if c == 0x60 then            -- func
+      match readU n1 len1 with
+      | none => none
+      | some (np, n2, len2) =>
+          match skipValTypes np n2 len2 with
+          | none => none
+          | some (n3, len3) =>
+              match readU n3 len3 with
+              | none => none
+              | some (nr, n4, len4) =>
+                  match skipValTypes nr n4 len4 with
+                  | none => none
+                  | some (n5, len5) => some (np, 0, none, n5, len5)
+    else if c == 0x5f then       -- struct
+      match readU n1 len1 with
+      | none => none
+      | some (nf, n2, len2) =>
+          match readFields nf n2 len2 with
+          | none => none
+          | some (fbs, n3, len3) =>
+              let isCarrier :=
+                nf == 3 && (fbs[0]?).getD 0 == 0x7e && (fbs[2]?).getD 0 == 0x7f
+              some (0, nf, (if isCarrier then some tidx else none), n3, len3)
+    else if c == 0x5e then       -- array
+      match readField n1 len1 with
+      | none => none
+      | some (_, n2, len2) => some (0, 0, none, n2, len2)
+    else none
+
+/-- Decode one subtype at absolute type index `tidx`: its func arity (0 if not
+    func), struct field count (0 if not struct), and whether it is the carrier.
+    Handles an optional `sub` / `sub final` prefix (0x50 / 0x4f). -/
+def decOneSubtype (tidx n len : Nat) : Option (Nat × Nat × Option Nat × Nat × Nat) :=
+  if len == 0 then none else
+    let b0 := n &&& 0xff
+    if b0 == 0x50 || b0 == 0x4f then
+      match readU (n >>> 8) (len - 1) with        -- vec of supertype typeidx
+      | none => none
+      | some (nsup, n1, len1) =>
+          match skipUlebs nsup n1 len1 with
+          | none => none
+          | some (n2, len2) => decComptype tidx n2 len2
+    else decComptype tidx n len
+
+/-- Decode `k` subtypes in a rec group, threading the absolute type index. -/
+def decSubtypes : Nat → Nat → Nat → Nat → Option (List Nat × List Nat × Option Nat × Nat × Nat)
+  | 0,   _,    n, len => some ([], [], none, n, len)
+  | k+1, tidx, n, len =>
+      match decOneSubtype tidx n len with
+      | none => none
+      | some (ar, nf, car, n1, len1) =>
+          match decSubtypes k (tidx+1) n1 len1 with
+          | none => none
+          | some (ars, nfs, car2, n2, len2) =>
+              some (ar :: ars, nf :: nfs, car.orElse (fun _ => car2), n2, len2)
+
+/-- Decode `entries` rectype entries (each a rec group or a bare subtype). -/
+def decRecVec : Nat → Nat → Nat → Nat → Option (List Nat × List Nat × Option Nat × Nat × Nat)
+  | 0,   _,    n, len => some ([], [], none, n, len)
+  | e+1, tidx, n, len =>
+      if len == 0 then none else
+        let b0 := n &&& 0xff
+        if b0 == 0x4e then                 -- explicit rec group
+          match readU (n >>> 8) (len - 1) with
+          | none => none
+          | some (sc, n1, len1) =>
+              match decSubtypes sc tidx n1 len1 with
+              | none => none
+              | some (ars, nfs, car, n2, len2) =>
+                  match decRecVec e (tidx + sc) n2 len2 with
+                  | none => none
+                  | some (ars2, nfs2, car2, n3, len3) =>
+                      some (ars ++ ars2, nfs ++ nfs2, car.orElse (fun _ => car2), n3, len3)
+        else                               -- single implicit rec group
+          match decOneSubtype tidx n len with
+          | none => none
+          | some (ar, nf, car, n1, len1) =>
+              match decRecVec e (tidx+1) n1 len1 with
+              | none => none
+              | some (ars2, nfs2, car2, n2, len2) =>
+                  some (ar :: ars2, nf :: nfs2, car.orElse (fun _ => car2), n2, len2)
+
+def decodeTypes (n len : Nat) : Option TypeInfo :=
+  match findSec 1 64 (n >>> 64) (len - 8) with
+  | none => none
+  | some (tN, tLen) =>
+      match readU tN tLen with
+      | none => none
+      | some (cnt, n1, len1) =>
+          match decRecVec cnt 0 n1 len1 with
+          | none => none
+          | some (ars, nfs, car, _, _) => some ⟨ars, nfs, car⟩
+
+/-- The Int carrier struct type index. -/
+def decodeCarrier (n len : Nat) : Option Nat :=
+  match decodeTypes n len with
+  | some ti => ti.carrier
+  | none => none
+
+/- ===================================================================== -/
+/-  Function / import / export / data sections                            -/
+/- ===================================================================== -/
+
+/-- Read `k` type indices (function section entries). -/
+def decFuncVec : Nat → Nat → Nat → Option (List Nat × Nat × Nat)
+  | 0,   n, len => some ([], n, len)
+  | k+1, n, len =>
+      match readU n len with
+      | none => none
+      | some (t, n1, len1) =>
+          match decFuncVec k n1 len1 with
+          | none => none
+          | some (rest, n2, len2) => some (t :: rest, n2, len2)
+
+/-- Per-defined-function type index (function section). -/
+def decodeFuncTypes (n len : Nat) : Option (List Nat) :=
+  match findSec 3 64 (n >>> 64) (len - 8) with
+  | none => some []
+  | some (fN, fLen) =>
+      match readU fN fLen with
+      | none => none
+      | some (cnt, n1, len1) =>
+          match decFuncVec cnt n1 len1 with
+          | none => none
+          | some (ts, _, _) => some ts
+
+/-- Read `k` imports, keeping the (module, name) of each imported FUNCTION.
+    Non-function import kinds are outside the profile → reject (fail-closed). -/
+def decImportVec : Nat → Nat → Nat → Option (List (String × String) × Nat × Nat)
+  | 0,   n, len => some ([], n, len)
+  | k+1, n, len =>
+      match readU n len with                     -- module name length
+      | none => none
+      | some (ml, n1, len1) =>
+          let modName := mkName (takeBytes ml n1)
+          let n2 := n1 >>> (8*ml)
+          let len2 := len1 - ml
+          match readU n2 len2 with                -- import name length
+          | none => none
+          | some (nl, n3, len3) =>
+              let nm := mkName (takeBytes nl n3)
+              let n4 := n3 >>> (8*nl)
+              let len4 := len3 - nl
+              if len4 == 0 then none else
+                let kind := n4 &&& 0xff
+                let n5 := n4 >>> 8
+                let len5 := len4 - 1
+                if kind == 0 then                 -- func import: typeidx uleb
+                  match readU n5 len5 with
+                  | none => none
+                  | some (_, n6, len6) =>
+                      match decImportVec k n6 len6 with
+                      | none => none
+                      | some (rest, n7, len7) => some ((modName, nm) :: rest, n7, len7)
+                else none
+
+/-- Imported (module, name) list. Absent import section → no imports. -/
+def decodeImports (n len : Nat) : Option (List (String × String)) :=
+  match findSec 2 64 (n >>> 64) (len - 8) with
+  | none => some []
+  | some (iN, iLen) =>
+      match readU iN iLen with
+      | none => none
+      | some (cnt, n1, len1) =>
+          match decImportVec cnt n1 len1 with
+          | none => none
+          | some (imps, _, _) => some imps
+
+/-- Number of imported functions = the base offset for defined function indices. -/
+def funcImportBase (n len : Nat) : Option Nat :=
+  match decodeImports n len with
+  | some imps => some imps.length
+  | none => none
+
+/-- Export section: keep function exports (kind 0) as (name, funcidx). -/
+def decEntries : Nat → Nat → Nat → Option (List (String × Nat))
+  | 0,     _, _   => some []
+  | cnt+1, n, len =>
+      match readU n len with
+      | none => none
+      | some (nlen, n1, len1) =>
+          let name := takeBytes nlen n1
+          let n2   := n1 >>> (8*nlen)
+          let len2 := len1 - nlen
+          if len2 == 0 then none else
+            let kind := n2 &&& 0xff
+            let n3   := n2 >>> 8
+            match readU n3 (len2-1) with
+            | none => none
+            | some (idx, n4, len4) =>
+                match decEntries cnt n4 len4 with
+                | none => none
+                | some tl => if kind == 0 then some ((mkName name, idx) :: tl) else some tl
+
+def decodeExports (n len : Nat) : Option (List (String × Nat)) :=
+  match findSec 7 64 (n >>> 64) (len - 8) with
+  | none => none
+  | some (eN, eLen) =>
+      match readU eN eLen with
+      | none => none
+      | some (cnt, n1, len1) => decEntries cnt n1 len1
+
+/-- Read `k` (passive) data segments as byte lists. Non-passive flags are
+    outside the profile → reject (fail-closed). -/
+def decDataVec : Nat → Nat → Nat → Option (List (List Nat) × Nat × Nat)
+  | 0,   n, len => some ([], n, len)
+  | k+1, n, len =>
+      if len == 0 then none else
+        let flag := n &&& 0xff
+        let n1 := n >>> 8
+        let len1 := len - 1
+        if flag == 0x01 then
+          match readU n1 len1 with              -- byte count
+          | none => none
+          | some (bc, n2, len2) =>
+              let bytes := takeBytes bc n2
+              let n3 := n2 >>> (8*bc)
+              let len3 := len2 - bc
+              match decDataVec k n3 len3 with
+              | none => none
+              | some (rest, n4, len4) => some (bytes :: rest, n4, len4)
+        else none
+
+/-- Data segment payloads by segment index. Absent data section → no segments. -/
+def decodeData (n len : Nat) : Option (List (List Nat)) :=
+  match findSec 11 64 (n >>> 64) (len - 8) with
+  | none => some []
+  | some (dN, dLen) =>
+      match readU dN dLen with
+      | none => none
+      | some (cnt, n1, len1) =>
+          match decDataVec cnt n1 len1 with
+          | none => none
+          | some (segs, _, _) => some segs
+
+/- ===================================================================== -/
+/-  Code section: locals, instructions, nested if/else                    -/
+/- ===================================================================== -/
+
+/-- Skip `g` local-declaration groups; return the total declared local count
+    (handles wasm-gc ref valtypes 0x63/0x64 followed by a heaptype). -/
+def decLocals : Nat → Nat → Nat → Option (Nat × Nat × Nat)
+  | 0,   n, len => some (0, n, len)
+  | g+1, n, len =>
+      match readU n len with                      -- group count
+      | none => none
+      | some (c, n1, len1) =>
+          if len1 == 0 then none else
+            let t := n1 &&& 0xff
+            let n2 := n1 >>> 8
+            if t == 0x63 || t == 0x64 then
+              match readS n2 (len1-1) with          -- heaptype
+              | none => none
+              | some (_, n3, len3) =>
+                  match decLocals g n3 len3 with
+                  | none => none
+                  | some (m, n4, len4) => some (c + m, n4, len4)
+            else
+              match decLocals g n2 (len1-1) with
+              | none => none
+              | some (m, n4, len4) => some (c + m, n4, len4)
+
+/-- Consume an `if` blocktype (empty / numeric / ref+heaptype / typeidx s33). -/
+def skipBlockType (n len : Nat) : Option (Nat × Nat) :=
+  if len == 0 then none else
+    let b0 := n &&& 0xff
+    if b0 == 0x40 then some (n >>> 8, len - 1)
+    else if b0 == 0x7f || b0 == 0x7e || b0 == 0x7d || b0 == 0x7c || b0 == 0x7b then
+      some (n >>> 8, len - 1)
+    else if b0 == 0x63 || b0 == 0x64 then
+      match readS (n >>> 8) (len - 1) with
+      | none => none
+      | some (_, n1, len1) => some (n1, len1)
+    else
+      match readS n len with                       -- typeidx s33 blocktype
+      | none => none
+      | some (_, n1, len1) => some (n1, len1)
+
+/-- Decode one non-structured instruction. `pending` holds i32 const values
+    most-recent-first, so `array.new_data` resolves its (offset, length). -/
+def decInstr (nfields : List Nat) (segs : List (List Nat)) (pending : List Int)
+    (op n len : Nat) : Option (WInstr × List Int × Nat × Nat) :=
+  if op == 0x20 then (readU n len).map (fun p => (WInstr.localGet p.1, pending, p.2.1, p.2.2))
+  else if op == 0x21 then (readU n len).map (fun p => (WInstr.localSet p.1, pending, p.2.1, p.2.2))
+  else if op == 0x42 then (readS n len).map (fun p => (WInstr.i64Const p.1, pending, p.2.1, p.2.2))
+  else if op == 0x41 then (readS n len).map (fun p => (WInstr.i32Const p.1, p.1 :: pending, p.2.1, p.2.2))
+  else if op == 0x44 then
+    if len < 8 then none
+    else some (WInstr.f64Const (UInt64.ofNat (n &&& 0xffffffffffffffff)), pending, n >>> 64, len - 8)
+  else if op == 0xd0 then (readS n len).map (fun p => (WInstr.refNull, pending, p.2.1, p.2.2))
+  else if op == 0xd1 then some (WInstr.refIsNull, pending, n, len)
+  else if op == 0x10 then (readU n len).map (fun p => (WInstr.call p.1, pending, p.2.1, p.2.2))
+  else if op == 0x12 then (readU n len).map (fun p => (WInstr.returnCall p.1, pending, p.2.1, p.2.2))
+  else if op == 0x0f then some (WInstr.ret, pending, n, len)
+  -- integer / float scalar ops (single byte, no immediate)
+  else if op == 0x50 then some (WInstr.i64Eqz, pending, n, len)
+  else if op == 0x51 then some (WInstr.i64Eq, pending, n, len)
+  else if op == 0x57 then some (WInstr.i64LeS, pending, n, len)
+  else if op == 0x53 then some (WInstr.i64LtS, pending, n, len)
+  else if op == 0x59 then some (WInstr.i64GeS, pending, n, len)
+  else if op == 0x55 then some (WInstr.i64GtS, pending, n, len)
+  else if op == 0x46 then some (WInstr.i32Eq, pending, n, len)
+  else if op == 0x71 then some (WInstr.i32And, pending, n, len)
+  else if op == 0x48 then some (WInstr.i32LtS, pending, n, len)
+  else if op == 0x4c then some (WInstr.i32LeS, pending, n, len)
+  else if op == 0x4a then some (WInstr.i32GtS, pending, n, len)
+  else if op == 0xa0 then some (WInstr.f64Add, pending, n, len)
+  else if op == 0xa1 then some (WInstr.f64Sub, pending, n, len)
+  else if op == 0xa2 then some (WInstr.f64Mul, pending, n, len)
+  else if op == 0xa3 then some (WInstr.f64Div, pending, n, len)
+  else if op == 0x61 then some (WInstr.f64Eq, pending, n, len)
+  else if op == 0x63 then some (WInstr.f64Lt, pending, n, len)
+  else if op == 0x65 then some (WInstr.f64Le, pending, n, len)
+  else if op == 0x66 then some (WInstr.f64Ge, pending, n, len)
+  else if op == 0x64 then some (WInstr.f64Gt, pending, n, len)
+  -- wasm-gc prefixed opcodes (0xfb sub)
+  else if op == 0xfb then
+    match readU n len with
+    | none => none
+    | some (sub, n1, len1) =>
+        if sub == 0x00 then                          -- struct.new
+          (readU n1 len1).map (fun q =>
+            (WInstr.structNew q.1 ((nfields[q.1]?).getD 0), pending, q.2.1, q.2.2))
+        else if sub == 0x02 then                     -- struct.get
+          match readU n1 len1 with
+          | none => none
+          | some (ty, n2, len2) =>
+              (readU n2 len2).map (fun f => (WInstr.structGet ty f.1, pending, f.2.1, f.2.2))
+        else if sub == 0x08 then                     -- array.new_fixed
+          match readU n1 len1 with
+          | none => none
+          | some (ty, n2, len2) =>
+              (readU n2 len2).map (fun m => (WInstr.arrayNewFixed ty m.1, pending, m.2.1, m.2.2))
+        else if sub == 0x09 then                     -- array.new_data
+          match readU n1 len1 with
+          | none => none
+          | some (ty, n2, len2) =>
+              match readU n2 len2 with
+              | none => none
+              | some (seg, n3, len3) =>
+                  let length := (pending.headD 0).toNat
+                  let offset := ((pending.drop 1).headD 0).toNat
+                  let payload := (segs[seg]?).getD []
+                  let chunk := (payload.drop offset).take length
+                  some (WInstr.arrayNewData ty chunk, pending, n3, len3)
+        else if sub == 0x14 || sub == 0x15 then      -- ref.test
+          (readS n1 len1).map (fun h => (WInstr.refTest h.1.toNat, pending, h.2.1, h.2.2))
+        else if sub == 0x16 || sub == 0x17 then      -- ref.cast
+          (readS n1 len1).map (fun h => (WInstr.refCast h.1.toNat, pending, h.2.1, h.2.2))
+        else none
+  else none
+
+/-- Decode a block of instructions. Returns the folded instructions, the
+    threaded `pending` list, the new `(n, len)`, and a terminator tag
+    (0 = `end` 0x0b, 1 = `else` 0x05), both consumed. Fuel bounds the number of
+    instructions (body byte size is a safe bound). -/
+def decBlock (nfields : List Nat) (segs : List (List Nat)) :
+    Nat → List Int → Nat → Nat → Option (List WInstr × List Int × Nat × Nat × Nat)
+  | 0,      _,       _, _   => none
+  | fuel+1, pending, n, len =>
+      if len == 0 then none else
+        let op := n &&& 0xff
+        let n1 := n >>> 8
+        let len1 := len - 1
+        if op == 0x0b then some ([], pending, n1, len1, 0)
+        else if op == 0x05 then some ([], pending, n1, len1, 1)
+        else if op == 0x04 then
+          match skipBlockType n1 len1 with
+          | none => none
+          | some (n2, len2) =>
+              match decBlock nfields segs fuel pending n2 len2 with
+              | none => none
+              | some (thenB, pend1, n3, len3, t1) =>
+                  if t1 == 1 then
+                    match decBlock nfields segs fuel pend1 n3 len3 with
+                    | none => none
+                    | some (elseB, pend2, n4, len4, t2) =>
+                        if t2 == 0 then
+                          match decBlock nfields segs fuel pend2 n4 len4 with
+                          | none => none
+                          | some (rest, pend3, n5, len5, t3) =>
+                              some (WInstr.ifElse thenB elseB :: rest, pend3, n5, len5, t3)
+                        else none
+                  else if t1 == 0 then
+                    match decBlock nfields segs fuel pend1 n3 len3 with
+                    | none => none
+                    | some (rest, pend3, n5, len5, t3) =>
+                        some (WInstr.ifElse thenB [] :: rest, pend3, n5, len5, t3)
+                  else none
+        else
+          match decInstr nfields segs pending op n1 len1 with
+          | none => none
+          | some (ins, pending', n2, len2) =>
+              match decBlock nfields segs fuel pending' n2 len2 with
+              | none => none
+              | some (rest, pend3, n3, len3, t3) => some (ins :: rest, pend3, n3, len3, t3)
+
+/-- Decode a raw straight/nested body Nat (little-endian, ending in `end`).
+    Used by the coverage matrix's synthetic single-body probes. -/
+def decodeBodyBytes (nfields : List Nat) (segs : List (List Nat)) (fuel n len : Nat) :
+    Option (List WInstr) :=
+  match decBlock nfields segs fuel [] n len with
+  | none => none
+  | some (instrs, _, _, _, term) => if term == 0 then some instrs else none
+
+/- ===================================================================== -/
+/-  Per-function obligation decode                                        -/
+/- ===================================================================== -/
+
+/-- Skip `k` code-section entries (each: size prefix + `size` body bytes). -/
+def skipEntries : Nat → Nat → Nat → Option (Nat × Nat)
+  | 0,   n, len => some (n, len)
+  | k+1, n, len =>
+      match readU n len with
+      | none => none
+      | some (sz, n1, len1) => skipEntries k (n1 >>> (8*sz)) (len1 - sz)
+
+/-- Full `WCode` (arity from the type section, nlocals from the locals decl,
+    body from the code section) for the module function `funcidx`. -/
+def decodeCode (n len funcidx : Nat) : Option WCode :=
+  match decodeTypes n len with
+  | none => none
+  | some ti =>
+    match decodeData n len with
+    | none => none
+    | some segs =>
+      match funcImportBase n len with
+      | none => none
+      | some nimp =>
+        match decodeFuncTypes n len with
+        | none => none
+        | some ftys =>
+          match ftys[funcidx - nimp]? with
+          | none => none
+          | some tyidx =>
+            match ti.arities[tyidx]? with
+            | none => none
+            | some ar =>
+              match findSec 10 64 (n >>> 64) (len - 8) with
+              | none => none
+              | some (codeN, codeLen) =>
+                match readU codeN codeLen with          -- nfuncs
+                | none => none
+                | some (_nf, r0, l0) =>
+                  match skipEntries (funcidx - nimp) r0 l0 with
+                  | none => none
+                  | some (eN, eLen) =>
+                    match readU eN eLen with            -- this entry's size
+                    | none => none
+                    | some (esz, bN, bLen) =>
+                      match readU bN bLen with          -- nloc groups
+                      | none => none
+                      | some (ng, gN, gLen) =>
+                        match decLocals ng gN gLen with
+                        | none => none
+                        | some (nloc, bodyN, bodyLen) =>
+                          match decBlock ti.nfields segs esz [] bodyN bodyLen with
+                          | none => none
+                          | some (instrs, _, _, _, term) =>
+                              if term == 0 then some ⟨ar, nloc, instrs⟩ else none
+
+/-- The decoded body (`List WInstr`) of `funcidx`. -/
+def decodeBody (n len funcidx : Nat) : Option (List WInstr) :=
+  (decodeCode n len funcidx).map (·.body)
+
+/-- The decoded arity of `funcidx` (from the type section). -/
+def decodeArity (n len funcidx : Nat) : Option Nat :=
+  (decodeCode n len funcidx).map (·.arity)
+
+end CertDecode

--- a/tools/certkit/prelude/CertDecode.lean
+++ b/tools/certkit/prelude/CertDecode.lean
@@ -81,7 +81,11 @@ def sleb : Nat → Int → Nat → Nat → Nat → Option (Int × Nat × Nat)
 /-  Section walk                                                          -/
 /- ===================================================================== -/
 
-/-- Whole-file section id sequence (skip is one GMP shift per section). -/
+/-- Whole-file section id sequence (skip is one GMP shift per section). Not on
+    the targeted decode paths below, but pinned per fixture by the decoder
+    differential (`tests/cert_decode_spec.rs`) so a malformed section frame
+    anywhere in the module — including regions the targeted decoders skip —
+    fails the kernel witness. -/
 def walkIds : Nat → Nat → Nat → Option (List Nat)
   | 0,      _, _   => none
   | fuel+1, n, len =>

--- a/tools/certkit/prelude/lakefile.lean
+++ b/tools/certkit/prelude/lakefile.lean
@@ -7,4 +7,4 @@ package «certprelude» where
 @[default_target]
 lean_lib «CertPrelude» where
   srcDir := "."
-  roots := #[`CertPrelude, `CertPreludeSanity]
+  roots := #[`CertPrelude, `CertPreludeSanity, `CertDecode]


### PR DESCRIPTION
Adds `tools/certkit/prelude/CertDecode.lean`: a kernel-reducible (structural/fuel recursion, `rfl`-checkable, axiom base [propext]) decoder for the certified wasm-gc profile — LEB128, section walk, type/import/function/export/code/data sections, and full instruction bodies including nested if/else, GC opcodes and data-segment resolution.

Verification, all kernel-checked (never string compare):
- A decoder differential over every certkit fixture plus a test-authored effectful module (import-section coverage with a non-zero function index base): every user-function body, the whole-file section walk, exports, imports and carrier agree term for term with the Python byte-level oracle (`tools/certkit/decode_ref.py`, cross-validated against `extract.py`), and the certified obligations additionally agree with `cert::rederive_obligations` — the same rendered values the production witness pins.
- A fail-closed 39-opcode coverage matrix (33 from fixture bodies, 6 from a synthetic probe).
- A mutation suite on real bytes: body flip changes the decode, skipped-section flip does not, export relabel changes the map, and overlong LEB / truncation / out-of-range indices decode to none.

The verify path is untouched: this lands the decoder and its evidence; switching `aver cert verify` to bind through it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)