### PR TITLE
Stub missing effect imports in the playground host

### DIFF
--- a/tools/website/playground/wasm_host.js
+++ b/tools/website/playground/wasm_host.js
@@ -299,6 +299,26 @@ export class AverBrowserHost {
         return live;
     }
 
+    /// Any `aver.*` import a module declares but this host does not implement
+    /// (e.g. `Disk.*` — the playground has no filesystem) gets a stub that only
+    /// fails IF THE PROGRAM CALLS IT, instead of failing the whole
+    /// instantiation with a LinkError. Code paths that never touch the effect
+    /// keep working; an unsupported call site surfaces an honest error.
+    withMissingEffectStubs(imports) {
+        imports.aver = new Proxy(imports.aver, {
+            get: (target, prop) => {
+                if (prop in target) return target[prop];
+                if (typeof prop !== "string") return undefined;
+                return () => {
+                    throw new Error(
+                        `effect import \`aver.${prop}\` is not available in the playground`,
+                    );
+                };
+            },
+        });
+        return imports;
+    }
+
     createImports() {
         // Every effect import declares a trailing `caller_fn:
         // any_ref` param now (see `effects.rs::params`). Each
@@ -309,7 +329,7 @@ export class AverBrowserHost {
         // the trailing arg — JS just lets the extra value drop on
         // the floor.
         const dec = (callerIdx) => this.averToJs(callerIdx);
-        return {
+        const imports = {
             aver: {
                 args_len: (callerIdx) =>
                     this.recordOrDispatch(
@@ -631,6 +651,7 @@ export class AverBrowserHost {
                 },
             },
         };
+        return this.withMissingEffectStubs(imports);
     }
 
     /// Decode a `Result<String, String>` marker JSON into the wasm-gc


### PR DESCRIPTION
Egg Catch died at instantiation on the live playground: its shell's replay path imports `aver.disk_read_text`, which the browser host does not implement, so `WebAssembly.instantiate` failed with a LinkError and the game reported "Game ended." immediately.

The host's `aver` import namespace is now wrapped in a Proxy: implemented effects pass through untouched; any missing import resolves to a stub that throws an honest `effect import aver.X is not available in the playground` only when the program actually calls it. Interactive play never touches Disk, so the game runs; a replay-from-file invocation would surface the unsupported effect at its call site instead of killing the module. Verified under Node: existing imports intact, stub throws on call, and the failure mode at instantiation is gone (the remaining Node error is its missing wasm-gc support, absent on Chrome 119+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)