### PR TITLE
Fix the mobile output view: no dead editor space, board above controls

### DIFF
--- a/tools/website/playground/app.js
+++ b/tools/website/playground/app.js
@@ -180,6 +180,9 @@ function setMobileView(view) {
     ws.dataset.mobileView = view;
     const flip = document.querySelector("[data-mobile-flip]");
     if (flip) flip.textContent = view === "editor" ? "\u25a6 Output" : "\u270e Code";
+    // The terminal sizes itself to its box; kick a resize so it reclaims
+    // the space the editor just released (or gave back).
+    window.dispatchEvent(new Event("resize"));
 }
 document.querySelector("[data-mobile-flip]")?.addEventListener("click", () => {
     const ws = document.querySelector(".workspace");

--- a/tools/website/playground/styles.css
+++ b/tools/website/playground/styles.css
@@ -1450,7 +1450,17 @@ body {
     .workspace[data-mobile-view="editor"] .editor-pane { max-height: none; flex: 1; }
     .workspace[data-mobile-view="output"] .editor-tabs { display: none; }
     .workspace[data-mobile-view="output"] .editor-wrap { display: none; }
-    .workspace[data-mobile-view="output"] .editor-pane { max-height: none; }
+    /* With its content hidden the pane must stop stretching (base rule is
+       flex: 1) or it leaves a dead hole and crushes the terminal below. */
+    .workspace[data-mobile-view="output"] .editor-pane {
+        flex: 0 0 auto;
+        max-height: none;
+    }
+    .workspace[data-mobile-view="output"] .output-pane { flex: 1 1 auto; }
+    /* Board on top, thumbs at the bottom. */
+    .workspace[data-mobile-view="output"] .terminal-wrap { order: 1; }
+    .workspace[data-mobile-view="output"] .console-wrap { order: 2; }
+    .workspace[data-mobile-view="output"] .output-pane .touch-controls { order: 3; }
     .output-pane {
         min-width: 0;
         min-height: 200px;


### PR DESCRIPTION
Follow-up to #665, from a live phone screenshot: the collapsed editor pane kept its base `flex: 1`, leaving a dead dark region that crushed the game terminal at the bottom (the frame's header row was clipped), and the touch controls sat above the board. The collapsed pane now shrinks to its toolbar, the output pane takes the freed space, the board renders above the controls, and flipping views dispatches a resize so the terminal reclaims its box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)