### PR TITLE
Pin the catch pairs under the thumbs

### DIFF
--- a/tools/website/playground/app.js
+++ b/tools/website/playground/app.js
@@ -4121,6 +4121,7 @@ async function loadGameSourcesAsTabs(gameName) {
 // Each game declares its own button groups. "grid:arrows" and "grid:wasd"
 // are special layout types; everything else is a flow layout.
 
+const GAME_TOUCH_SPREAD = new Set(["eggcatch"]);
 const GAME_TOUCH = {
     life: [
         { label: "Cursor", layout: "grid:arrows", keys: [
@@ -4139,17 +4140,19 @@ const GAME_TOUCH = {
         ]},
     ],
     eggcatch: [
-        { label: "Left", keys: [
+        { label: "Left", layout: "col", keys: [
             { key: "q", text: "Q \u2196" }, { key: "a", text: "A \u2199" },
-        ]},
-        { label: "Right", keys: [
-            { key: "p", text: "P \u2197" }, { key: "l", text: "L \u2198" },
         ]},
         { label: "Mode", keys: [
             { key: "1", text: "A" }, { key: "2", text: "B" },
             { key: "esc", text: "Esc" },
         ]},
+        { label: "Right", layout: "col", keys: [
+            { key: "p", text: "P \u2197" }, { key: "l", text: "L \u2198" },
+        ]},
     ],
+    // Container modifier: catch pairs pinned to the screen edges.
+    // (read by buildTouchControls via GAME_TOUCH_SPREAD)
     snake: [
         { label: "Direction", layout: "grid:arrows", keys: [
             { key: "up", text: "↑" }, { key: "left", text: "←" },
@@ -4235,6 +4238,7 @@ function buildTouchControls(gameName) {
         return;
     }
     container.style.display = "flex";
+    container.classList.toggle("spread", GAME_TOUCH_SPREAD.has(gameName));
     for (const group of config) {
         const div = document.createElement("div");
         div.className = "touch-group";
@@ -4249,6 +4253,8 @@ function buildTouchControls(gameName) {
             wrap.className = "touch-grid arrows";
         } else if (group.layout === "grid:wasd") {
             wrap.className = "touch-grid wasd";
+        } else if (group.layout === "col") {
+            wrap.className = "touch-actions col";
         } else {
             wrap.className = "touch-actions";
         }

--- a/tools/website/playground/styles.css
+++ b/tools/website/playground/styles.css
@@ -1421,6 +1421,19 @@ body {
     max-width: 144px;
 }
 
+/* Vertical thumb stack (e.g. the egg-catch catch pairs): up above down,
+   matching the chute geometry under each thumb. */
+.touch-actions.col {
+    flex-direction: column;
+    flex-wrap: nowrap;
+}
+
+/* Spread layout: first group hugs the left edge, last the right — the
+   catch pairs sit exactly under the thumbs of a two-handed grip. */
+.touch-controls.spread {
+    justify-content: space-between;
+}
+
 
 /* ── Responsive ──────────────────────────────────────────────────── */
 


### PR DESCRIPTION
From live phone play: the touch controls sat in one centered row, so the left/right catch pairs were nowhere near the thumbs of a two-handed grip. The pairs are now vertical stacks (up above down, matching the chute geometry) pinned to the screen edges via a spread container layout, with the mode buttons between them. Generic mechanism (a `col` group layout and a per-game spread flag), other games untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)