### PR TITLE
Thread ref.null heap types and derive strict sub host role

### DIFF
--- a/src/codegen/cert/analysis.rs
+++ b/src/codegen/cert/analysis.rs
@@ -458,4 +458,164 @@ fn addTwo(x: Int) -> Int
             "a mul-first body must not compete for the add role"
         );
     }
+
+    fn compile_probe_bytes(src: &str) -> Vec<u8> {
+        let mut items = crate::source::parse_source(src).expect("probe source parses");
+        let pipeline = crate::ir::pipeline::run(
+            &mut items,
+            crate::ir::PipelineConfig {
+                typecheck: Some(crate::ir::TypecheckMode::Full { base_dir: None }),
+                ..Default::default()
+            },
+        );
+        assert!(
+            pipeline
+                .typecheck
+                .as_ref()
+                .is_none_or(|tc| tc.errors.is_empty()),
+            "probe source should typecheck"
+        );
+        crate::codegen::wasm_gc::compile_to_wasm_gc_with_handler_and_cert_plans(&items, None, None)
+            .expect("probe compiles to wasm-gc")
+            .bytes
+    }
+
+    /// The verbatim-widened fixture's `_ -> []` default arm lowers to a
+    /// `ref.null` of the `List` struct type. Disassembly must thread that
+    /// heap-type index through `Op::RefNull` (not drop it, as the old unit
+    /// variant did) so the S2 grammar can re-lower the empty-list default
+    /// byte-exactly. The index must equal the module's List struct type — the
+    /// same concrete type the function's `List<Int>` result references.
+    #[test]
+    fn ref_null_threads_default_arm_heap_type() {
+        let bytes = compile_probe_bytes(include_str!(
+            "../../../tools/certkit/fixtures/verbatimwiden.av"
+        ));
+        let (user_fns, _box_idx, _set, _carrier, _roles, _table) =
+            disassemble(&bytes).expect("disassemble");
+        let wrap_items = user_fns
+            .iter()
+            .find(|f| f.name == "wrapItems")
+            .expect("wrapItems user fn");
+        // `wrapItems` returns `List<Int>`, i.e. a concrete `(ref null $list)`.
+        let Some(TyKind::Ref(list_idx)) = wrap_items.result else {
+            panic!("wrapItems should return a concrete list ref");
+        };
+        let ref_null_hty = wrap_items
+            .ops
+            .iter()
+            .find_map(|op| match op {
+                Op::RefNull(hty) => Some(*hty),
+                _ => None,
+            })
+            .expect("wrapItems `[]` default arm should lower to a ref.null");
+        assert_eq!(
+            ref_null_hty,
+            Some(list_idx),
+            "ref.null must carry the List struct heap-type index (the `[]` \
+             default's type), not drop it"
+        );
+    }
+
+    /// Mirror of `frag_host_table_binds_add_to_the_cited_callee` for the strict
+    /// `sub` binding: a straight-line integer subtraction body cites box + sub,
+    /// and the strict table must bind `sub` to EXACTLY that cited callee (never
+    /// by index order). `x - 2` lowers to `sub(x, box(2))` — the compiler does
+    /// not rewrite it as add-with-negated-constant, so it genuinely cites sub.
+    #[test]
+    fn frag_host_table_binds_sub_to_the_cited_callee() {
+        let bytes = compile_probe_bytes(
+            r#"
+module SubRoleProbe
+    intent = "host sub role probe"
+    depends []
+    exposes [subTwo]
+
+fn subTwo(x: Int) -> Int
+    ? "Straight-line integer subtraction."
+    x - 2
+"#,
+        );
+        let (user_fns, box_idx, _set, _carrier, _roles, host_table) =
+            disassemble(&bytes).expect("disassemble");
+        let sub_two = user_fns
+            .iter()
+            .find(|f| f.name == "subTwo")
+            .expect("subTwo user fn");
+        let [cited_box, cited_sub] = sub_two.calls.as_slice() else {
+            panic!("subTwo should cite exactly box + sub, got {:?}", sub_two.calls);
+        };
+        assert_eq!(host_table.box_idx, Some(box_idx));
+        assert_eq!(host_table.box_idx, Some(*cited_box));
+        assert_eq!(
+            host_table.sub_idx,
+            Some(*cited_sub),
+            "the strict host-role table must bind `sub` to the callee the \
+             emitted body cites"
+        );
+    }
+
+    /// Synthetic-module template for the `sub` role-table derivation tests: an
+    /// optional decoy function plus the exact carrier-binop `sub` helper (its
+    /// first i64 arithmetic op is `i64.sub`) and the named box export the
+    /// disassembler requires. Parallel to `role_table_module` (which emits an
+    /// `add`-shaped helper); kept separate so the `add` tests' index
+    /// assertions are unaffected.
+    fn role_table_module_sub(decoy: &str) -> Vec<u8> {
+        wat::parse_str(format!(
+            r#"(module
+  (type $mag (array (mut i64)))
+  (type $c (struct (field i64) (field (ref null $mag)) (field i32)))
+  (type $bin (func (param (ref null $c)) (param (ref null $c)) (result (ref null $c))))
+  (type $box (func (param i64) (result (ref null $c))))
+  {decoy}
+  (func $box (type $box)
+    local.get 0 ref.null $mag i32.const 0 struct.new $c)
+  (func $sub (type $bin)
+    i64.const 1 i64.const 2 i64.sub drop local.get 0)
+  (export "__rt_aint_from_i64" (func $box))
+)"#
+        ))
+        .expect("role-table-sub module WAT parses")
+    }
+
+    /// If more than one candidate matches the strict carrier-binop signature +
+    /// `i64.sub`-first body shape, the `sub` role stays UNBOUND (fail-closed) —
+    /// the table never guesses by index order. Mirrors the `add` ambiguity test.
+    #[test]
+    fn frag_host_table_declines_ambiguous_sub_candidates() {
+        let bytes = role_table_module_sub(
+            r#"(func $decoy (type $bin)
+    i64.const 3 i64.const 4 i64.sub drop local.get 1)"#,
+        );
+        let (_fns, box_idx, _set, _carrier, _roles, host_table) =
+            disassemble(&bytes).expect("disassemble");
+        assert_eq!(host_table.box_idx, Some(box_idx));
+        assert_eq!(
+            host_table.sub_idx, None,
+            "two byte-shape-identical sub candidates must leave the role \
+             unbound (fail-closed), never bound by index order"
+        );
+    }
+
+    /// An `add`-first body must not compete for the `sub` role even though it
+    /// contains an `i64.sub`: `first arith == sub` keeps it out of sub
+    /// candidacy, so the genuine `i64.sub`-first helper (idx 2) binds alone.
+    /// Mirrors `frag_host_table_excludes_mul_first_bodies` for the add role.
+    #[test]
+    fn frag_host_table_excludes_add_first_bodies_from_sub() {
+        let bytes = role_table_module_sub(
+            r#"(func $decoy (type $bin)
+    i64.const 3 i64.const 4 i64.add drop
+    i64.const 3 i64.const 4 i64.sub drop
+    local.get 1)"#,
+        );
+        let (_fns, _box_idx, _set, _carrier, _roles, host_table) =
+            disassemble(&bytes).expect("disassemble");
+        assert_eq!(
+            host_table.sub_idx,
+            Some(2),
+            "an add-first body must not compete for the sub role"
+        );
+    }
 }

--- a/src/codegen/cert/classify_basic.rs
+++ b/src/codegen/cert/classify_basic.rs
@@ -48,7 +48,7 @@ fn nr_adt_constructor(
     for op in prefix {
         match op {
             LocalGet(i) if (*i as usize) < f.arity => fields.push(ConstructorField::Local(*i)),
-            RefNull => fields.push(ConstructorField::Null),
+            RefNull(_) => fields.push(ConstructorField::Null),
             _ => return None,
         }
     }

--- a/src/codegen/cert/classify_structural.rs
+++ b/src/codegen/cert/classify_structural.rs
@@ -98,7 +98,7 @@ fn normalize_local_hops(ops: &[Op]) -> Vec<Op> {
                         | Op::I64Const(..)
                         | Op::I32Const(..)
                         | Op::F64Const(..)
-                        | Op::RefNull
+                        | Op::RefNull(_)
                         | Op::ArrayNewData { .. }
                 )
                 && matches!((&out[j + 1], &out[j + 2]), (Op::LocalSet(a), Op::LocalGet(b)) if a == b)

--- a/src/codegen/cert/classify_verbatim.rs
+++ b/src/codegen/cert/classify_verbatim.rs
@@ -1,6 +1,6 @@
 fn verbatim_default_from_ops(ops: &[Op]) -> Option<VerbatimDefault> {
     match ops {
-        [Op::RefNull] => Some(VerbatimDefault::Null),
+        [Op::RefNull(_)] => Some(VerbatimDefault::Null),
         [Op::F64Const(bits)] => Some(VerbatimDefault::F64Bits(*bits)),
         [
             Op::I32Const(0),

--- a/src/codegen/cert/core_wasm.rs
+++ b/src/codegen/cert/core_wasm.rs
@@ -65,7 +65,14 @@ enum Op {
     /// recognizer can see the container construction; functions that use it in
     /// any shape other than the contracted concat beachhead are still declined.
     ArrayNewFixed(u32, u32),
-    RefNull,
+    /// `ref.null <heap>` carrying the disassembled heap type. `Some(idx)` is a
+    /// concrete module type index (e.g. the List struct a widened match's `[]`
+    /// default nulls); `None` is any abstract heap type (func/extern/none/…),
+    /// which is not re-lowerable by the plan grammar and so is a fail-closed
+    /// form. Every classifier ignores the payload (matches `RefNull(_)`), so
+    /// null-default recognition is unchanged; the index is threaded purely for
+    /// byte-exact re-lowering in the S2 control-flow grammar.
+    RefNull(Option<u32>),
     RefIsNull,
     I64Eq,
     I64LeS,

--- a/src/codegen/cert/disasm_module.rs
+++ b/src/codegen/cert/disasm_module.rs
@@ -219,7 +219,7 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
                                 Op::Other
                             }
                         }
-                        Operator::RefNull { .. } => Op::RefNull,
+                        Operator::RefNull { hty } => Op::RefNull(heap_type_index(hty)),
                         Operator::RefIsNull => Op::RefIsNull,
                         Operator::I64Eq => Op::I64Eq,
                         Operator::I64LeS => Op::I64LeS,
@@ -356,7 +356,10 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
     // contain `i64.add`, but its fast path multiplies first). If the module
     // does not determine a UNIQUE candidate, the role stays unbound (`None`)
     // and every plan citing it declines fail-closed — never guess by index
-    // order. `box` is the exported `__rt_aint_from_i64`, exact by name.
+    // order. `box` is the exported `__rt_aint_from_i64`, exact by name. `sub`
+    // is derived exactly like `add` (same carrier-binop signature, but
+    // `i64.sub`-first with its own uniqueness check); it is carried here as an
+    // S2 prerequisite and NOT yet surfaced to Lean (see `FragHostTable::lean_value`).
     let frag_host_table = {
         let is_carrier_binop = |def_idx: usize| -> bool {
             let Some(c) = carrier else {
@@ -371,20 +374,26 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
             params.as_slice() == [TyKind::Ref(c), TyKind::Ref(c)]
                 && *result == Some(TyKind::Ref(c))
         };
-        let add_candidates: Vec<u32> = code_entries
-            .iter()
-            .enumerate()
-            .filter(|(def_idx, entry)| {
-                entry.first_arith_strict == Some(FirstI64Arith::Add) && is_carrier_binop(*def_idx)
-            })
-            .map(|(def_idx, _)| num_imported_funcs + def_idx as u32)
-            .collect();
-        FragHostTable {
-            box_idx: Some(box_idx),
-            add_idx: match add_candidates.as_slice() {
+        let strict_binop_candidates = |arith: FirstI64Arith| -> Vec<u32> {
+            code_entries
+                .iter()
+                .enumerate()
+                .filter(|(def_idx, entry)| {
+                    entry.first_arith_strict == Some(arith) && is_carrier_binop(*def_idx)
+                })
+                .map(|(def_idx, _)| num_imported_funcs + def_idx as u32)
+                .collect()
+        };
+        let unique = |candidates: Vec<u32>| -> Option<u32> {
+            match candidates.as_slice() {
                 [only] => Some(*only),
                 _ => None,
-            },
+            }
+        };
+        FragHostTable {
+            box_idx: Some(box_idx),
+            add_idx: unique(strict_binop_candidates(FirstI64Arith::Add)),
+            sub_idx: unique(strict_binop_candidates(FirstI64Arith::Sub)),
         }
     };
 

--- a/src/codegen/cert/expr_fragment_defs.rs
+++ b/src/codegen/cert/expr_fragment_defs.rs
@@ -156,6 +156,12 @@ impl FragHostRole {
 pub(crate) struct FragHostTable {
     pub(crate) box_idx: Option<u32>,
     pub(crate) add_idx: Option<u32>,
+    /// The strict `sub` binding (byte-derived exactly like `add`: carrier-binop
+    /// signature + `i64.sub`-first + uniqueness, fail-closed to `None`).
+    /// Carried Rust-side as an S2 prerequisite but NOT yet part of the Lean
+    /// grammar: it is deliberately absent from `lean_value()` and `lookup()`
+    /// until the S2 control-flow leg extends the `HostRole` enum.
+    pub(crate) sub_idx: Option<u32>,
 }
 
 impl FragHostTable {
@@ -176,6 +182,10 @@ impl FragHostTable {
         if let Some(idx) = self.add_idx {
             entries.push(format!("(.add, {idx})"));
         }
+        // `sub_idx` is deliberately NOT rendered: the Lean `HostRole` grammar
+        // gains `.sub` only in the S2 control-flow leg. Emitting it now would
+        // change the audited artifact/claim surface, so `sub` stays invisible
+        // to Lean even though it is derived and carried Rust-side.
         format!("[{}]", entries.join(", "))
     }
 
@@ -187,6 +197,7 @@ impl FragHostTable {
         FragHostTable {
             box_idx: Some(0),
             add_idx: Some(0),
+            sub_idx: Some(0),
         }
     }
 }

--- a/src/codegen/cert/render_code_instrs.rs
+++ b/src/codegen/cert/render_code_instrs.rs
@@ -53,7 +53,11 @@ fn render_simple_op(op: &Op) -> Option<String> {
             type_idx, bytes, ..
         } => format!(".arrayNewData {type_idx} {}", render_nat_list(bytes)),
         Op::ArrayNewFixed(t, n) => format!(".arrayNewFixed {t} {n}"),
-        Op::RefNull => ".refNull".to_string(),
+        // The heap-type payload is deliberately NOT rendered: Lean's
+        // `CoreInstr.refNull` is a unit constructor, so emitting the index
+        // would change the audited artifact bytes. The index is carried only
+        // for Rust-side re-lowering in the S2 grammar leg.
+        Op::RefNull(_) => ".refNull".to_string(),
         Op::RefIsNull => ".refIsNull".to_string(),
         Op::I64Eq => ".i64Eq".to_string(),
         Op::I64LeS => ".i64LeS".to_string(),

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -3029,6 +3029,9 @@ pub(super) fn emit_module_with(
     let fragment_host_table = crate::codegen::cert::FragHostTable {
         box_idx: registry.aint_from_i64_fn_idx,
         add_idx: builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintAdd),
+        // `sub` mirrors `add` for parity with the byte-derived table, but is
+        // not yet consumed by any plan encoding (S2 prerequisite only).
+        sub_idx: builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintSub),
     };
     for (i, _fd) in fn_defs.iter().enumerate() {
         let self_wasm_idx = import_count + 1 + (i as u32);


### PR DESCRIPTION
Disassembler fidelity prerequisites for the ADT-match plan family. Op::RefNull now carries the concrete heap-type index (abstract heap types map to a fail-closed form), so null default arms can later be re-lowered byte-exactly; all classifier decisions are unchanged and the Lean-facing instruction rendering stays byte-identical. The strict host-role table gains a sub entry derived exactly like add (carrier-binop signature, sub-first body arithmetic, uniqueness, fail-closed on ambiguity), deliberately not yet rendered to Lean. Four new regressions; zero classification changes — all pinned counters hold.