### PR TITLE
Reuse a prebuilt audited prelude in the certification test harness

### DIFF
--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -12,12 +12,12 @@ env:
 jobs:
   cert-kernel:
     # One job per certification suite so the long verify suite (each test does a
-    # clean-cache lake kernel build by design) no longer serializes behind the
+    # fresh checker-owned lake kernel build) no longer serializes behind the
     # fast certify/decode suites, and each suite fails independently. Shared
     # toolchain setup is duplicated per matrix leg but runs in parallel.
     name: Cert Kernel (${{ matrix.suite }})
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -34,9 +34,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cache Lean toolchain
-        # The certification tests build every cert project from a clean lake
-        # cache by design (the verifier must not trust caches); the toolchain
-        # download itself is the only cacheable part.
+        # The verifier's production default remains a clean Lake build. Tests
+        # may copy an exact-byte-keyed pristine prelude cache into fresh builds;
+        # the Lean toolchain download is cached separately here.
         uses: actions/cache@v4
         with:
           path: ~/.elan

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -85,6 +85,7 @@ use std::process::Command;
 use aver::codegen::cert;
 use colored::Colorize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 /// Kernel axioms a certificate is allowed to depend on. Anything else — most
 /// importantly `sorryAx` (an admitted goal) or `ofReduceBool` (native-code
@@ -115,6 +116,24 @@ const CHECKER_OWNED: [&str; 11] = [
     "lakefile.lean",
     "CheckerWitness.lean",
 ];
+
+/// Audited modules whose exact bytes are shared by every certificate build.
+/// ArtifactBytes and certificate/model modules are deliberately absent.
+const STATIC_PRELUDE_ROOTS: [&str; 8] = [
+    "Schema",
+    "PlanCheck",
+    "PlanLower",
+    "PlanBytes",
+    "WasmSlice",
+    "ExprFragmentAccepted",
+    "AcceptedArtifact",
+    "CertPrelude",
+];
+
+/// Static roots whose imports are also entirely static. Schema imports the
+/// artifact-specific Module, so it and its dependants must be rebuilt after
+/// the pristine cache is copied into an artifact build.
+const PRISTINE_PRELUDE_ROOTS: [&str; 2] = ["CertPrelude", "WasmSlice"];
 
 /// Maximum length (bytes) of a JSON-supplied string spliced into the witness.
 const MAX_CANDIDATE_LEN: usize = 200;
@@ -537,9 +556,17 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
     //    / srcDir / `.lake` cache are never read.
     let build = assemble_build(cert_dir, &bytes)?;
 
+    // Test harness opt-in only. Production verification remains a fresh build
+    // with no `.lake`; cache failures silently retain that clean-cache path.
+    let reused_prelude = reuse_prebuilt_prelude(&build.path);
+
     // 4. The assembled project must build under the pinned toolchain, from a
     //    clean cache (the fresh dir has no `.lake`).
-    let b = run_lake(&build.path, &["build"])?;
+    let mut b = run_lake(&build.path, &["build"])?;
+    if reused_prelude && !b.status.success() {
+        let _ = std::fs::remove_dir_all(build.path.join(".lake"));
+        b = run_lake(&build.path, &["build"])?;
+    }
     if !b.status.success() {
         return Err(format!(
             "certificate did not build (lake build failed):\n{}",
@@ -574,7 +601,20 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
     );
     std::fs::write(build.path.join("CheckerWitness.lean"), &witness)
         .map_err(|e| format!("cannot write checker witness: {e}"))?;
-    let w = run_lake(&build.path, &["env", "lean", "CheckerWitness.lean"])?;
+    let mut w = run_lake(&build.path, &["env", "lean", "CheckerWitness.lean"])?;
+    if reused_prelude && !w.status.success() {
+        // A corrupt or stale test cache must not turn a clean success into a
+        // decline. Rebuild from scratch and ask the unchanged witness again.
+        let _ = std::fs::remove_dir_all(build.path.join(".lake"));
+        let clean = run_lake(&build.path, &["build"])?;
+        if !clean.status.success() {
+            return Err(format!(
+                "certificate did not build (lake build failed):\n{}",
+                tail(&clean.combined, 20)
+            ));
+        }
+        w = run_lake(&build.path, &["env", "lean", "CheckerWitness.lean"])?;
+    }
     if !w.status.success() {
         // The verdict is this exit code, not any parsed line. The lake output is
         // shown to the human to name which face failed (hash, a report binding,
@@ -1175,35 +1215,24 @@ fn assemble_build(cert_dir: &Path, wasm_bytes: &[u8]) -> Result<BuildDir, String
     }
 
     // Audited trusted computing base from THIS binary (not the cert).
-    write(&build.path, "Schema.lean", cert::CERT_SCHEMA)?;
-    write(&build.path, "PlanCheck.lean", cert::CERT_PLAN_CHECK)?;
-    write(&build.path, "PlanLower.lean", cert::CERT_PLAN_LOWER)?;
-    write(&build.path, "PlanBytes.lean", cert::CERT_PLAN_BYTES)?;
-    write(&build.path, "WasmSlice.lean", cert::CERT_WASM_SLICE)?;
-    write(
-        &build.path,
-        "ExprFragmentAccepted.lean",
-        cert::CERT_EXPR_FRAGMENT_ACCEPTED,
-    )?;
-    write(
-        &build.path,
-        "AcceptedArtifact.lean",
-        cert::CERT_ACCEPTED_ARTIFACT,
-    )?;
+    for (name, bytes) in static_prelude_files() {
+        if name == "lakefile.lean" {
+            continue;
+        }
+        std::fs::write(build.path.join(&name), bytes)
+            .map_err(|e| format!("cannot stage {name}: {e}"))?;
+    }
     write(
         &build.path,
         "ArtifactBytes.lean",
         &cert::render_artifact_bytes_lean(wasm_bytes),
     )?;
-    write(&build.path, "CertPrelude.lean", cert::CERT_PRELUDE)?;
-    write(&build.path, "lean-toolchain", cert::LEAN_TOOLCHAIN)?;
-    roots.push("Schema".to_string());
-    roots.push("PlanCheck".to_string());
-    roots.push("PlanLower".to_string());
-    roots.push("PlanBytes".to_string());
-    roots.push("WasmSlice".to_string());
-    roots.push("ExprFragmentAccepted".to_string());
-    roots.push("AcceptedArtifact".to_string());
+    // Preserve the production lakefile's historical root order exactly.
+    roots.extend(
+        STATIC_PRELUDE_ROOTS[..STATIC_PRELUDE_ROOTS.len() - 1]
+            .iter()
+            .map(|root| (*root).to_string()),
+    );
     roots.push("ArtifactBytes".to_string());
     roots.push("CertPrelude".to_string());
 
@@ -1211,6 +1240,125 @@ fn assemble_build(cert_dir: &Path, wasm_bytes: &[u8]) -> Result<BuildDir, String
     // (gated) files actually present.
     write(&build.path, "lakefile.lean", &checker_lakefile(&roots))?;
     Ok(build)
+}
+
+/// Exact, artifact-independent files used to build the reusable prelude. The
+/// returned sequence is filename-sorted so both staging and keying are stable.
+fn static_prelude_files() -> Vec<(String, Vec<u8>)> {
+    let static_lakefile = checker_lakefile(
+        &PRISTINE_PRELUDE_ROOTS
+            .iter()
+            .map(|root| (*root).to_string())
+            .collect::<Vec<_>>(),
+    );
+    let mut files = vec![
+        (
+            "AcceptedArtifact.lean",
+            cert::CERT_ACCEPTED_ARTIFACT.as_bytes().to_vec(),
+        ),
+        ("CertPrelude.lean", cert::CERT_PRELUDE.as_bytes().to_vec()),
+        (
+            "ExprFragmentAccepted.lean",
+            cert::CERT_EXPR_FRAGMENT_ACCEPTED.as_bytes().to_vec(),
+        ),
+        ("PlanBytes.lean", cert::CERT_PLAN_BYTES.as_bytes().to_vec()),
+        ("PlanCheck.lean", cert::CERT_PLAN_CHECK.as_bytes().to_vec()),
+        ("PlanLower.lean", cert::CERT_PLAN_LOWER.as_bytes().to_vec()),
+        ("Schema.lean", cert::CERT_SCHEMA.as_bytes().to_vec()),
+        ("WasmSlice.lean", cert::CERT_WASM_SLICE.as_bytes().to_vec()),
+        ("lakefile.lean", static_lakefile.into_bytes()),
+        ("lean-toolchain", cert::LEAN_TOOLCHAIN.as_bytes().to_vec()),
+    ]
+    .into_iter()
+    .map(|(name, bytes)| (name.to_string(), bytes))
+    .collect::<Vec<_>>();
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files
+}
+
+/// SHA-256 of the unambiguous, filename-sorted `(filename, exact bytes)`
+/// sequence. Length prefixes prevent different pairs from sharing a framing.
+fn static_prelude_key(files: &[(String, Vec<u8>)]) -> String {
+    let mut hasher = Sha256::new();
+    for (name, bytes) in files {
+        hasher.update((name.len() as u64).to_be_bytes());
+        hasher.update(name.as_bytes());
+        hasher.update((bytes.len() as u64).to_be_bytes());
+        hasher.update(bytes);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Reuse a pristine prelude-only Lake build when the certification test
+/// harness opts in. Every failure returns silently to the fresh-cache build.
+fn reuse_prebuilt_prelude(build_dir: &Path) -> bool {
+    let Some(store) = std::env::var_os("AVER_CERT_PRELUDE_CACHE").map(PathBuf::from) else {
+        return false;
+    };
+    try_reuse_prebuilt_prelude(&store, build_dir).is_ok()
+}
+
+fn try_reuse_prebuilt_prelude(store: &Path, build_dir: &Path) -> Result<(), ()> {
+    let files = static_prelude_files();
+    let key = static_prelude_key(&files);
+    let entry = store.join(key);
+    let cached_lake = entry.join(".lake");
+
+    if !cached_lake.is_dir() {
+        populate_prebuilt_prelude(store, &entry, &files)?;
+    }
+    if !cached_lake.is_dir() {
+        return Err(());
+    }
+
+    let destination = build_dir.join(".lake");
+    if let Err(()) = copy_tree(&cached_lake, &destination) {
+        let _ = std::fs::remove_dir_all(destination);
+        return Err(());
+    }
+    Ok(())
+}
+
+/// Build only the artifact-independent files, then atomically publish the
+/// whole pristine project directory. Thus no artifact data can enter a store
+/// entry, and concurrent builders either publish or consume the winner.
+fn populate_prebuilt_prelude(
+    store: &Path,
+    entry: &Path,
+    files: &[(String, Vec<u8>)],
+) -> Result<(), ()> {
+    std::fs::create_dir_all(store).map_err(|_| ())?;
+    let temp = store.join(format!("tmp-{}-{}", std::process::id(), unique_nanos()));
+    let pristine = StoreBuildDir::new(temp)?;
+    for (name, bytes) in files {
+        std::fs::write(pristine.path.join(name), bytes).map_err(|_| ())?;
+    }
+
+    let built = run_lake(&pristine.path, &["build"]).map_err(|_| ())?;
+    if !built.status.success() || !pristine.path.join(".lake").is_dir() {
+        return Err(());
+    }
+
+    match std::fs::rename(&pristine.path, entry) {
+        Ok(()) => pristine.keep(),
+        Err(_) if entry.join(".lake").is_dir() => {}
+        Err(_) => return Err(()),
+    }
+    Ok(())
+}
+
+fn copy_tree(source: &Path, destination: &Path) -> Result<(), ()> {
+    std::fs::create_dir(destination).map_err(|_| ())?;
+    for entry in std::fs::read_dir(source).map_err(|_| ())? {
+        let entry = entry.map_err(|_| ())?;
+        let destination_entry = destination.join(entry.file_name());
+        if entry.file_type().map_err(|_| ())?.is_dir() {
+            copy_tree(&entry.path(), &destination_entry)?;
+        } else {
+            std::fs::copy(entry.path(), destination_entry).map_err(|_| ())?;
+        }
+    }
+    Ok(())
 }
 
 /// A cert data file must be named `<Ident>.lean` where `<Ident>` matches
@@ -2427,12 +2575,11 @@ struct BuildDir {
 
 impl BuildDir {
     fn new() -> Result<BuildDir, String> {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let path =
-            std::env::temp_dir().join(format!("aver-certverify-{}-{nanos}", std::process::id()));
+        let path = std::env::temp_dir().join(format!(
+            "aver-certverify-{}-{}",
+            std::process::id(),
+            unique_nanos()
+        ));
         std::fs::create_dir_all(&path).map_err(|e| format!("create checker build dir: {e}"))?;
         Ok(BuildDir { path })
     }
@@ -2442,6 +2589,40 @@ impl Drop for BuildDir {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.path);
     }
+}
+
+struct StoreBuildDir {
+    path: PathBuf,
+    remove_on_drop: std::cell::Cell<bool>,
+}
+
+impl StoreBuildDir {
+    fn new(path: PathBuf) -> Result<Self, ()> {
+        std::fs::create_dir(&path).map_err(|_| ())?;
+        Ok(Self {
+            path,
+            remove_on_drop: std::cell::Cell::new(true),
+        })
+    }
+
+    fn keep(&self) {
+        self.remove_on_drop.set(false);
+    }
+}
+
+impl Drop for StoreBuildDir {
+    fn drop(&mut self) {
+        if self.remove_on_drop.get() {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
 }
 
 fn write(dir: &Path, name: &str, content: &str) -> Result<(), String> {

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -23,6 +23,15 @@ fn temp_dir(prefix: &str) -> PathBuf {
     d
 }
 
+fn aver_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver"));
+    command.env(
+        "AVER_CERT_PRELUDE_CACHE",
+        std::env::temp_dir().join("aver-cert-prelude-store"),
+    );
+    command
+}
+
 #[test]
 fn certify_goal_matrix_manifest_tracks_current_surface() {
     // This fixture is the dashboard for "how much do we certify now?". Larger
@@ -31,9 +40,7 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
     // goal becomes certifiable, move it from `expected_backlog` into `expected`.
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify-goals");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
-
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/cert_goals.av")
@@ -472,9 +479,8 @@ fn certify_straight_line_fixture_lake_builds_kernel_clean() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/certprobe.av")
@@ -543,9 +549,8 @@ fn certify_declines_overflowing_multiplication_recursion() {
     // No `lake` needed: this is a pure emitter fail-closed check.
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify-recdecline");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/recdecline.av")
@@ -602,9 +607,8 @@ fn certify_fueled_recursion_generality_lake_builds_kernel_clean() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify-recgen");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/recgen.av")
@@ -684,7 +688,6 @@ fn certify_mutual_recursion_scc_lake_builds_kernel_clean() {
     }
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
     // A two-member SCC (`isEven`/`isOdd`) and a three-member cycle
     // (`rotA -> rotB -> rotC -> rotA`), so the ONE shared conjunction proof — its
@@ -706,7 +709,7 @@ fn certify_mutual_recursion_scc_lake_builds_kernel_clean() {
 
     for (fixture, exports, primary) in cases {
         let out_dir = temp_dir("certify-mutual");
-        let compile = Command::new(aver_bin)
+        let compile = aver_command()
             .current_dir(&repo_root)
             .arg("compile")
             .arg(fixture)
@@ -783,9 +786,8 @@ fn certify_verbatim_variant_dispatch_lake_builds_kernel_clean() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify-strdispatch");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/strdispatch.av")
@@ -859,9 +861,8 @@ fn certify_string_eq_host_contract_lake_builds_kernel_clean() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify-stringeq");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/stringeq.av")
@@ -1020,9 +1021,8 @@ fn certify_string_concat_host_contract_lake_builds_kernel_clean() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify-stringconcat");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/stringconcat.av")
@@ -1238,9 +1238,8 @@ fn certify_composition_fixture_lake_builds_kernel_clean() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify-compose");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/compose.av")
@@ -1329,7 +1328,6 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
     }
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
     let cases = [
         (
@@ -1373,7 +1371,7 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
 
     for (input, prefix, expected) in cases {
         let out_dir = temp_dir(prefix);
-        let compile = Command::new(aver_bin)
+        let compile = aver_command()
             .current_dir(&repo_root)
             .arg("compile")
             .arg(input)
@@ -1447,9 +1445,8 @@ fn certify_carrier_at_type_index_64_lake_builds_kernel_clean() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify-manytypes");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/manytypes.av")

--- a/tests/cert_decode_spec.rs
+++ b/tests/cert_decode_spec.rs
@@ -124,6 +124,15 @@ fn temp_dir(prefix: &str) -> PathBuf {
     d
 }
 
+fn aver_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver"));
+    command.env(
+        "AVER_CERT_PRELUDE_CACHE",
+        std::env::temp_dir().join("aver-cert-prelude-store"),
+    );
+    command
+}
+
 /// Copy the decoder prelude sources into a fresh temp dir and `lake build` them
 /// (the witnesses import the resulting `.olean`s).
 fn build_prelude() -> PathBuf {
@@ -155,7 +164,7 @@ fn build_prelude() -> PathBuf {
 }
 
 fn compile_wasm_at(repo: &Path, av_path: &Path, name: &str, out: &Path) -> Vec<u8> {
-    let c = Command::new(env!("CARGO_BIN_EXE_aver"))
+    let c = aver_command()
         .current_dir(repo)
         .arg("compile")
         .arg(av_path)
@@ -176,7 +185,7 @@ fn compile_wasm_at(repo: &Path, av_path: &Path, name: &str, out: &Path) -> Vec<u
 /// Emit the certificate for a fixture and return its model `.lean` files, which
 /// `rederive_obligations` reads to recover the recursion combinator operator.
 fn model_lean_files(repo: &Path, av_path: &Path, out: &Path) -> Vec<(String, String)> {
-    let c = Command::new(env!("CARGO_BIN_EXE_aver"))
+    let c = aver_command()
         .current_dir(repo)
         .arg("compile")
         .arg(av_path)

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -119,12 +119,21 @@ fn copy_dir(src: &Path, dst: &Path) {
     }
 }
 
+fn aver_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver"));
+    command.env(
+        "AVER_CERT_PRELUDE_CACHE",
+        std::env::temp_dir().join("aver-cert-prelude-store"),
+    );
+    command
+}
+
 fn aver_verify(artifact: &Path, cert_dir: &Path) -> (bool, String) {
     aver_cert(&["verify"], artifact, cert_dir)
 }
 
 fn aver_cert(sub: &[&str], artifact: &Path, cert_dir: &Path) -> (bool, String) {
-    let out = Command::new(env!("CARGO_BIN_EXE_aver"))
+    let out = aver_command()
         .arg("cert")
         .args(sub)
         .arg(artifact)
@@ -139,10 +148,29 @@ fn aver_cert(sub: &[&str], artifact: &Path, cert_dir: &Path) -> (bool, String) {
     (out.status.success(), combined)
 }
 
+fn aver_verify_clean_cache(artifact: &Path, cert_dir: &Path) -> (bool, String) {
+    // Clean-cache litmus for the production verifier path: keep exactly this
+    // positive end-to-end verification independent of the test-only store.
+    let out = aver_command()
+        .env_remove("AVER_CERT_PRELUDE_CACHE")
+        .arg("cert")
+        .arg("verify")
+        .arg(artifact)
+        .arg(cert_dir)
+        .output()
+        .expect("aver cert verify runs");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), combined)
+}
+
 fn compile_cert_goals(prefix: &str) -> (PathBuf, PathBuf, PathBuf) {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir(prefix);
-    let compile = Command::new(env!("CARGO_BIN_EXE_aver"))
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/cert_goals.av")
@@ -267,10 +295,9 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certverify");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
     // Emit the recursive fixture's certificate.
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/certprobe2.av")
@@ -290,10 +317,9 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     let wasm = out_dir.join("certprobe2.wasm");
     let cert = out_dir.join("cert");
 
-    // Happy path: the freshly emitted certificate verifies end to end. The
-    // checker builds in its OWN fresh temp dir, so nothing here is cached for
-    // the tamper cases below.
-    let (ok, report) = aver_verify(&wasm, &cert);
+    // Happy path: the freshly emitted certificate verifies end to end through
+    // the production clean-cache path. Tamper cases below use the test store.
+    let (ok, report) = aver_verify_clean_cache(&wasm, &cert);
     assert!(ok, "expected clean certificate to verify, got:\n{report}");
     assert!(report.contains("CERTIFIED"), "missing CERTIFIED:\n{report}");
     assert!(
@@ -616,7 +642,7 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         let dir = temp_dir("neg-e");
         copy_dir(&out_dir, &dir);
         let foreign_out = temp_dir("neg-e-foreign");
-        let fc = Command::new(aver_bin)
+        let fc = aver_command()
             .current_dir(&repo_root)
             .arg("compile")
             .arg("tools/certkit/fixtures/certprobe.av")
@@ -659,7 +685,7 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     //      witness hash face exercised now that claim-covered certs die earlier.
     {
         let empty_out = temp_dir("neg-e2-empty");
-        let ec = Command::new(aver_bin)
+        let ec = aver_command()
             .current_dir(&repo_root)
             .arg("compile")
             .arg("tools/certkit/fixtures/certempty.av")
@@ -1243,9 +1269,8 @@ fn cert_verify_declines_tampered_array_new_data_operands() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-json-data");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("examples/data/json.av")
@@ -1347,9 +1372,8 @@ fn cert_verify_declines_tampered_expr_fragment_sidecar() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-expr-sidecar");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/cert_goals.av")
@@ -2023,9 +2047,8 @@ fn cert_verify_declines_tampered_string_eq_helper_shape() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-stringeq");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/stringeq.av")
@@ -2192,9 +2215,8 @@ fn cert_verify_declines_tampered_string_concat_helper_shape() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-stringconcat");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/stringconcat.av")
@@ -2467,9 +2489,8 @@ fn empty_cert_is_admission_only_and_exits_nonzero() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certempty");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/certempty.av")
@@ -2608,9 +2629,8 @@ fn adt_witness_body_mutation_is_declined() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-adt-mut");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("examples/core/user_record.av")
@@ -2661,9 +2681,8 @@ fn variant_dispatch_body_mutation_is_declined() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-vd-mut");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/signalgauge.av")
@@ -2720,9 +2739,8 @@ fn composition_callee_mutation_is_declined() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-compose-mut");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/compose.av")
@@ -2784,9 +2802,8 @@ fn cert_verify_declines_flipped_field_projection_sidecar() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-proj-sidecar");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/cert_goals.av")
@@ -2894,9 +2911,8 @@ fn cert_verify_declines_relabeled_projection_source_types() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-proj-relabel");
-    let aver_bin = env!("CARGO_BIN_EXE_aver");
 
-    let compile = Command::new(aver_bin)
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/cert_goals.av")
@@ -2996,7 +3012,7 @@ fn cert_verify_declines_tampered_recursion_plan() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-recursion-plan");
-    let compile = Command::new(env!("CARGO_BIN_EXE_aver"))
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/recgen.av")
@@ -3090,7 +3106,7 @@ fn cert_verify_declines_tampered_mutual_plan() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("cert-mutual-plan");
-    let compile = Command::new(env!("CARGO_BIN_EXE_aver"))
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/mutual.av")
@@ -3259,7 +3275,7 @@ fn cert_verify_declines_broken_mutual_scc_membership() {
 
     for (fixture, vectors) in cases {
         let out_dir = temp_dir("cert-mutual-scc");
-        let compile = Command::new(env!("CARGO_BIN_EXE_aver"))
+        let compile = aver_command()
             .current_dir(&repo_root)
             .arg("compile")
             .arg(fixture)
@@ -3384,7 +3400,7 @@ fn mutual_scc_kernel_guards_are_isolating() {
     );
 
     let out_dir = temp_dir("cert-mutual-guard-iso");
-    let compile = Command::new(env!("CARGO_BIN_EXE_aver"))
+    let compile = aver_command()
         .current_dir(&repo_root)
         .arg("compile")
         .arg("tools/certkit/fixtures/mutual.av")


### PR DESCRIPTION
The 20-test certification verify suite takes more than 42 minutes in CI and has twice exceeded its 45-minute timeout because every verifier invocation starts with an empty Lake cache.

This adds an AVER_CERT_PRELUDE_CACHE test-harness opt-in. Entries are SHA-256 keyed by the exact filename/byte sequence of the audited static files, prelude-only lakefile, and lean-toolchain. Misses build a pristine static-only project and publish it with an atomic rename; hits recursively copy .lake into each fresh checker-owned build. All cache I/O and cached build/witness failures fall back silently to a clean build. With the variable unset, the production path and lakefile root order are unchanged. Artifact data is never published to the store. Because Schema imports artifact-specific Module, the pristine build safely prebuilds only the dependency-closed CertPrelude and WasmSlice roots; Lake rebuilds Schema and its downstream modules for each artifact.

Local debug litmus on certprobe:
- cold clean path: 36.81s
- empty-store miss and successful population: 31.28s
- populated-store hit: 26.33s
- warm production path without the variable: 26.17s
- one-byte Final.lean corruption with the cache present: declined (15.92s)
- repeated key: 777abe4e0645cf0e4940ea65453381db83fe83e59fc6d7d78cc4acd4371f1d99
- corrupted cached CertPrelude.olean: verification succeeded through clean fallback

Verification:
- cargo build --bin aver --features wasm
- cargo fmt --all -- --check
- cargo clippy --bin aver --features wasm,wasip2 -- -D warnings
- cert_certify_spec: 11 passed
- three named cert_verify_spec filters passed

The repository-wide clippy command remains blocked by 31 pre-existing unused_braces errors in generated self-host code; the aver binary target passes with warnings denied. The CI job timeout is raised from 45 to 60 minutes as a safety margin.