### PR TITLE
Pin the locals count in every plan family's acceptance predicate

### DIFF
--- a/src/codegen/cert/AcceptedArtifactCore.lean
+++ b/src/codegen/cert/AcceptedArtifactCore.lean
@@ -17,30 +17,15 @@ namespace AverCert.AcceptedArtifact
 open AverCert.Schema
 open CertPrelude
 
-def exprFragmentObligationAccepted
-    (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
-    (exportName : String)
-    (carrier : Nat)
-    (plan : ExprFragmentRawPlan)
-    (body : List WInstr)
-    (codeEntry : List Nat)
-    (binding : AverCert.WasmSlice.FuncBinding)
-    (obligation : Obligation) : Prop :=
-  AverCert.ExprFragmentAccepted.accepted
-      wasmBytes exportNameBytes carrier plan body codeEntry binding ∧
-  obligation.export_ = exportName ∧
-  obligation.carrier = carrier ∧
-  obligation.self = binding.funcIdx ∧
-  ∃ nlocals,
-    obligation.code binding.funcIdx =
-      some { arity := plan.params.length, nlocals := nlocals, body := body }
+/-- Canonical locals count declared by `lowerExprFragmentBodyBytes`: every
+    accepted expression fragment has one carrier scratch local. -/
+def exprFragmentNLocals (_plan : ExprFragmentRawPlan) : Nat := 1
 
-/-- Artifact-level acceptance for one expression-fragment export. Unlike
-    `exprFragmentObligationAccepted`, this does not accept checker-rendered
-    intermediate values as parameters. The body, canonical code-entry bytes, and
-    function binding are witnesses to the audited Lean predicate
-    `ExprFragmentAccepted.accepted`. This is the v2-shaped API: raw artifact
-    bytes + raw plan + schema obligation. -/
+/-- Artifact-level acceptance for one expression-fragment export. The body,
+    canonical code-entry bytes, and function binding are witnesses to the
+    audited Lean predicate `ExprFragmentAccepted.accepted`, existentially
+    quantified rather than accepted as checker-rendered parameters. This is the
+    v2-shaped API: raw artifact bytes + raw plan + schema obligation. -/
 def exprFragmentPlanAccepted
     (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
@@ -53,9 +38,9 @@ def exprFragmentPlanAccepted
     AverCert.ExprFragmentAccepted.accepted
       wasmBytes exportNameBytes carrier plan body codeEntry binding ∧
     obligation.self = binding.funcIdx ∧
-    ∃ nlocals,
-      obligation.code binding.funcIdx =
-        some { arity := plan.params.length, nlocals := nlocals, body := body }
+    obligation.code binding.funcIdx =
+      some { arity := plan.params.length,
+             nlocals := exprFragmentNLocals plan, body := body }
 
 /-- Artifact-level acceptance for one source-level symbolic fragment export.
     The source plan is still untrusted data: the audited checker/encoder must
@@ -105,6 +90,10 @@ def symFragmentClaimAccepted
     claim.plan
     claim.obligation
 
+/-- Canonical locals count declared by `lowerStringConcatBodyBytes`: the
+    concatenation lowering always declares one carrier scratch local. -/
+def stringConcatNLocals (_plan : StringConcatRawPlan) : Nat := 1
+
 /-- Artifact-level acceptance for one String.concat export. The raw plan carries
     source-level chunks plus the encoder's data-index binding; the audited Lean
     lowerers rebuild both the semantic `WInstr` body and exact code-entry bytes,
@@ -129,9 +118,8 @@ def stringConcatPlanAccepted
     AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
     binding.codeEntry = codeEntry ∧
     obligation.self = binding.funcIdx ∧
-    ∃ nlocals,
-      obligation.code binding.funcIdx =
-        some { arity := 1, nlocals := nlocals, body := body }
+    obligation.code binding.funcIdx =
+      some { arity := 1, nlocals := stringConcatNLocals plan, body := body }
 
 def stringEqPlanAccepted
     (wasmBytes : AverCert.WasmSlice.ByteSeq)
@@ -374,6 +362,10 @@ def constructClaimAccepted
         claim.obligation
   | none => False
 
+/-- Canonical locals count declared by `lowerRecursionBodyBytes`: every
+    accepted fuel-recursion shape has one carrier scratch local. -/
+def recursionNLocals (_plan : RecursionRawPlan) : Nat := 1
+
 /-- Artifact-level acceptance for one fuel-recursion export. The
     `RecursionRawPlan` is checked (generic block typing AND the
     context-sensitive fuel-recursion grammar: every `selfCall` must target the
@@ -404,9 +396,9 @@ def recursionPlanAccepted
       AverCert.PlanCheck.checkRecursionPlanShape binding.funcIdx hostTable plan = true ∧
       AverCert.WasmSlice.funcTypeMatches
         wasmBytes binding.typeIdx plan.params.length carrier = true ∧
-      ∃ nlocals,
-        obligation.code binding.funcIdx =
-          some { arity := plan.params.length, nlocals := nlocals, body := body }
+      obligation.code binding.funcIdx =
+        some { arity := plan.params.length,
+               nlocals := recursionNLocals plan, body := body }
 
 def recursionPlanForExport
     (exportName : String) : List (String × RecursionRawPlan) →
@@ -433,6 +425,10 @@ def recursionClaimAccepted
         plan
         claim.obligation
   | none => False
+
+/-- Canonical locals count declared by `lowerMutualBodyBytes`: every accepted
+    mutual-recursion member shape has one carrier scratch local. -/
+def mutualNLocals (_plan : MutualRawPlan) : Nat := 1
 
 /-- Artifact-level acceptance for one mutual-recursion member export. The
     `MutualRawPlan` is checked (generic block typing AND the context-sensitive
@@ -466,9 +462,9 @@ def mutualPlanAccepted
       AverCert.PlanCheck.checkMutualPlanShape memberSet hostTable plan = true ∧
       AverCert.WasmSlice.funcTypeMatches
         wasmBytes binding.typeIdx plan.params.length carrier = true ∧
-      ∃ nlocals,
-        obligation.code binding.funcIdx =
-          some { arity := plan.params.length, nlocals := nlocals, body := body }
+      obligation.code binding.funcIdx =
+        some { arity := plan.params.length,
+               nlocals := mutualNLocals plan, body := body }
 
 def mutualPlanForExport
     (exportName : String) : List (String × MutualRawPlan) →
@@ -520,6 +516,12 @@ def verbatimPayloadsBound
   | .test _ hit rest =>
       verbatimLeafPayloadBound wasmBytes hit && verbatimPayloadsBound wasmBytes rest
 
+/-- Canonical locals count declared by `lowerVerbatimLocalsBytes`: projecting
+    plans declare the field scratch, scrutinee, and carrier locals; all other
+    plans declare only the scrutinee and carrier locals. -/
+def verbatimNLocals (plan : VerbatimRawPlan) : Nat :=
+  if AverCert.PlanCheck.dispatchHasProjection plan.body then 3 else 2
+
 /-- Artifact-level acceptance for one verbatim `ref.test`-dispatch export. The
     `VerbatimRawPlan` is checked structurally (`checkVerbatimRawPlan`), lowered to
     the match `WInstr` body and its exact code-entry bytes, and those bytes are
@@ -553,10 +555,9 @@ def verbatimPlanAccepted
       AverCert.WasmSlice.verbatimFuncTypeMatches
         wasmBytes binding.typeIdx plan.resultHeapTy = true ∧
       verbatimPayloadsBound wasmBytes plan.body = true ∧
-      ∃ nlocals,
-        obligation.code binding.funcIdx =
-          some { arity := 1, nlocals := nlocals,
-                 body := AverCert.PlanLower.lowerVerbatimBody plan }
+      obligation.code binding.funcIdx =
+        some { arity := 1, nlocals := verbatimNLocals plan,
+               body := AverCert.PlanLower.lowerVerbatimBody plan }
 
 def verbatimPlanForExport
     (exportName : String) : List (String × VerbatimRawPlan) →

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -65,7 +65,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 36;
+pub const CERT_SCHEMA_VERSION: u32 = 37;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/cert/render_project.rs
+++ b/src/codegen/cert/render_project.rs
@@ -792,7 +792,7 @@ fn render_artifact_expr_fragment_claims(
                 );
                 let proof = format!(
                     "⟨rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨⟨rfl, rfl, rfl, rfl, rfl⟩, rfl, ⟨_, rfl⟩⟩⟩⟩"
+                     ⟨⟨rfl, rfl, rfl, rfl, rfl⟩, rfl, rfl⟩⟩⟩"
                 );
                 if expr_fragment_source_plan(source_plan, plan).is_some() {
                     sym_claims.push(format!(
@@ -842,7 +842,7 @@ fn render_artifact_expr_fragment_claims(
                 ));
                 string_proofs.push(format!(
                     "⟨rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, ⟨_, rfl⟩⟩⟩⟩"
+                     ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
                 ));
             }
             Cert::StringEqVerbatimMatch {
@@ -956,7 +956,7 @@ fn render_artifact_expr_fragment_claims(
                 ));
                 recursion_proofs.push(format!(
                     "⟨rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, ⟨_, rfl⟩⟩⟩⟩"
+                     ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
                 ));
             }
             Cert::MutualRecursion {
@@ -995,7 +995,7 @@ fn render_artifact_expr_fragment_claims(
                 ));
                 mutual_proofs.push(format!(
                     "⟨rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, ⟨_, rfl⟩⟩⟩⟩"
+                     ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
                 ));
             }
             Cert::VerbatimWidenedMatch {
@@ -1017,10 +1017,11 @@ fn render_artifact_expr_fragment_claims(
                 ));
                 // The code entry, signature and payload conjuncts are the binding
                 // (no host/self calls), so the witness is anonymous for the code
-                // entry, binding and nlocals — each pinned by `rfl` (the two extra
-                // `rfl`s discharge the byte-derived signature and payload binds).
+                // entry and binding; the final `rfl` pins the canonical locals
+                // count (the two preceding `rfl`s discharge the byte-derived
+                // signature and payload binds).
                 verbatim_proofs.push(
-                    "⟨rfl, rfl, rfl, ⟨_, _, rfl, rfl, rfl, rfl, rfl, rfl, rfl, ⟨_, rfl⟩⟩⟩"
+                    "⟨rfl, rfl, rfl, ⟨_, _, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩"
                         .to_string(),
                 );
             }

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -2002,7 +2002,7 @@ fn lean_expr_fragment_artifact_claims(
             ));
             mutual_proofs.push(format!(
                 "⟨rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
-                 ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, ⟨_, rfl⟩⟩⟩⟩"
+                 ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
             ));
             continue;
         }
@@ -2029,7 +2029,7 @@ fn lean_expr_fragment_artifact_claims(
             ));
             recursion_proofs.push(format!(
                 "⟨rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
-                 ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, ⟨_, rfl⟩⟩⟩⟩"
+                 ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
             ));
             continue;
         }
@@ -2113,7 +2113,7 @@ fn lean_expr_fragment_artifact_claims(
             ));
             string_proofs.push(format!(
                 "⟨rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
-                 ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, ⟨_, rfl⟩⟩⟩⟩"
+                 ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
             ));
             continue;
         }
@@ -2155,10 +2155,11 @@ fn lean_expr_fragment_artifact_claims(
             ));
             // The code entry, signature and payload conjuncts are the binding (no
             // host/self calls), so the witness is anonymous for the code entry,
-            // binding and nlocals — each pinned by `rfl` (the two extra `rfl`s
-            // discharge the byte-derived signature and payload binds).
+            // binding; the final `rfl` pins the canonical locals count (the two
+            // preceding `rfl`s discharge the byte-derived signature and payload
+            // binds).
             verbatim_proofs.push(
-                "⟨rfl, rfl, rfl, ⟨_, _, rfl, rfl, rfl, rfl, rfl, rfl, rfl, ⟨_, rfl⟩⟩⟩".to_string(),
+                "⟨rfl, rfl, rfl, ⟨_, _, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩".to_string(),
             );
             continue;
         }
@@ -2201,7 +2202,7 @@ fn lean_expr_fragment_artifact_claims(
         );
         let proof = format!(
             "⟨rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
-             ⟨⟨rfl, rfl, rfl, rfl, rfl⟩, rfl, ⟨_, rfl⟩⟩⟩⟩"
+             ⟨⟨rfl, rfl, rfl, rfl, rfl⟩, rfl, rfl⟩⟩⟩"
         );
         if let Some(sym_plan) = r.fragment_sym_plan_lean.as_ref() {
             sym_claims.push(format!(

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -167,6 +167,36 @@ fn aver_verify_clean_cache(artifact: &Path, cert_dir: &Path) -> (bool, String) {
     (out.status.success(), combined)
 }
 
+fn set_named_code_nlocals_to_zero(
+    module: &Path,
+    export_name: &str,
+    arity: u32,
+    canonical_nlocals: u32,
+) {
+    let src = std::fs::read_to_string(module).unwrap();
+    let def_marker = format!("def {export_name}Code : CodeTbl");
+    let start = src
+        .find(&def_marker)
+        .unwrap_or_else(|| panic!("{export_name} code table should exist"));
+    let end = start
+        + src[start..]
+            .find("\n\n/-- Runtime host wiring")
+            .unwrap_or_else(|| panic!("{export_name} code table should have a bounded definition"));
+    let header = format!("some ⟨{arity}, {canonical_nlocals},");
+    let zero_header = format!("some ⟨{arity}, 0,");
+    let code_def = &src[start..end];
+    assert!(
+        code_def.contains(&header),
+        "{export_name} canonical locals-count header changed; update the test"
+    );
+    let zeroed = code_def.replacen(&header, &zero_header, 1);
+    let mut tampered = String::with_capacity(src.len());
+    tampered.push_str(&src[..start]);
+    tampered.push_str(&zeroed);
+    tampered.push_str(&src[end..]);
+    std::fs::write(module, tampered).unwrap();
+}
+
 fn compile_cert_goals(prefix: &str) -> (PathBuf, PathBuf, PathBuf) {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir(prefix);
@@ -955,12 +985,14 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
             !ok,
             "a body that does not re-derive must be DECLINED:\n{out}"
         );
-        // Caught by the kernel witness (the code binding), AFTER the cert built
-        // green — not by lake build or a hash binding.
-        assert!(out.contains("does not bind"), "wrong reason (p):\n{out}");
+        // The acceptance predicate now pins the locals count exactly, so this
+        // mutation can trip either the shipped artifact's own acceptance `rfl`
+        // during the lake build ("did not build") or the later checker-witness
+        // code binding ("does not bind"). Both are the same fail-closed
+        // decline; the earlier stage is the stronger constraint.
         assert!(
-            !out.contains("did not build"),
-            "case (p) must build green and be caught by the witness:\n{out}"
+            out.contains("does not bind") || out.contains("did not build"),
+            "wrong reason (p):\n{out}"
         );
         assert!(
             !out.contains("CERTIFIED"),
@@ -986,7 +1018,14 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         std::fs::write(&m, planted).unwrap();
         let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
         assert!(!ok, "shadow decoy must be DECLINED:\n{out}");
-        assert!(out.contains("does not bind"), "wrong reason (q):\n{out}");
+        // The locals-count mutation can trip the shipped artifact's own
+        // acceptance `rfl` at lake build ("did not build") or the later
+        // checker-witness code binding ("does not bind") — the shadow decoy
+        // fools neither stage.
+        assert!(
+            out.contains("does not bind") || out.contains("did not build"),
+            "wrong reason (q):\n{out}"
+        );
         assert!(
             !out.contains("CERTIFIED"),
             "shadow decoy credited (q):\n{out}"
@@ -1008,7 +1047,12 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         std::fs::write(&m, planted).unwrap();
         let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &dir.join("cert"));
         assert!(!ok, "comment decoy must be DECLINED:\n{out}");
-        assert!(out.contains("does not bind"), "wrong reason (r):\n{out}");
+        // Same stage-agnostic decline as (q): the locals-count pin can trip at
+        // the artifact's own lake build or at the checker witness.
+        assert!(
+            out.contains("does not bind") || out.contains("did not build"),
+            "wrong reason (r):\n{out}"
+        );
         assert!(
             !out.contains("CERTIFIED"),
             "comment decoy credited (r):\n{out}"
@@ -1402,6 +1446,21 @@ fn cert_verify_declines_tampered_expr_fragment_sidecar() {
     let cert = out_dir.join("cert");
     let (ok, report) = aver_verify(&wasm, &cert);
     assert!(ok, "expected clean goals certificate to verify:\n{report}");
+
+    // Honest bytes and plan, but the standalone obligation code table claims
+    // zero locals. The expr-fragment acceptance path must pin the one carrier
+    // scratch local declared by the canonical byte lowering.
+    {
+        let dir = temp_dir("cert-expr-zero-locals");
+        copy_dir(&out_dir, &dir);
+        set_named_code_nlocals_to_zero(&dir.join("cert/Module.lean"), "addTwo", 1, 1);
+        let (ok, report) = aver_verify(&dir.join("cert_goals.wasm"), &dir.join("cert"));
+        assert!(
+            !ok,
+            "expr-fragment zero-locals code must be DECLINED:\n{report}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     let artifact_bytes_decoy_dir = temp_dir("cert-expr-artifact-bytes-decoy");
     copy_dir(&out_dir, &artifact_bytes_decoy_dir);
@@ -2248,6 +2307,20 @@ fn cert_verify_declines_tampered_string_concat_helper_shape() {
         ok,
         "expected clean stringconcat certificate to verify:\n{report}"
     );
+
+    // Honest bytes and plan, zero locals in the obligation only: String.concat
+    // canonically declares one carrier scratch local.
+    {
+        let dir = temp_dir("cert-stringconcat-zero-locals");
+        copy_dir(&out_dir, &dir);
+        set_named_code_nlocals_to_zero(&dir.join("cert/Module.lean"), "shout", 1, 1);
+        let (ok, report) = aver_verify(&dir.join("stringconcat.wasm"), &dir.join("cert"));
+        assert!(
+            !ok,
+            "String.concat zero-locals code must be DECLINED:\n{report}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
     assert!(
         report.contains("2 certified exports"),
         "stringconcat should certify shout plus bump:\n{report}"
@@ -2666,10 +2739,14 @@ fn adt_witness_body_mutation_is_declined() {
 
     let (ok, out) = aver_verify(&out_dir.join("user_record.wasm"), &out_dir.join("cert"));
     assert!(!ok, "mutated ADT witness body must be DECLINED:\n{out}");
-    assert!(out.contains("does not bind"), "wrong reason:\n{out}");
+    // The acceptance predicate now pins the locals count exactly, so this
+    // mutation can trip either the shipped artifact's own acceptance `rfl`
+    // during the lake build ("did not build") or the later checker-witness
+    // code binding ("does not bind"). Both are the same fail-closed decline;
+    // the earlier stage is the stronger constraint.
     assert!(
-        !out.contains("did not build"),
-        "must build green and be caught by the witness:\n{out}"
+        out.contains("does not bind") || out.contains("did not build"),
+        "wrong reason:\n{out}"
     );
     assert!(
         !out.contains("CERTIFIED"),
@@ -3051,6 +3128,20 @@ fn cert_verify_declines_tampered_recursion_plan() {
     let (ok, report) = aver_verify(&wasm, &cert);
     assert!(ok, "honest recursion certificate should verify:\n{report}");
 
+    // Honest bytes and plan, zero locals in the obligation only: recursion
+    // canonically declares one carrier scratch local.
+    {
+        let dir = temp_dir("cert-recursion-zero-locals");
+        copy_dir(&out_dir, &dir);
+        set_named_code_nlocals_to_zero(&dir.join("cert/Module.lean"), "sumFrom", 1, 1);
+        let (ok, report) = aver_verify(&dir.join("recgen.wasm"), &dir.join("cert"));
+        assert!(
+            !ok,
+            "recursion zero-locals code must be DECLINED:\n{report}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     let honest = std::fs::read_to_string(cert.join("Plans.lean")).unwrap();
     // (a) descent role/target swap: `sub(n, box 1)` becomes `add(n, box 1)`, so
     //     the descent computes `n + 1` instead of `n - 1` (byte `10 0c -> 10 0b`).
@@ -3144,6 +3235,17 @@ fn cert_verify_declines_tampered_mutual_plan() {
     let cert = out_dir.join("cert");
     let (ok, report) = aver_verify(&wasm, &cert);
     assert!(ok, "honest mutual certificate should verify:\n{report}");
+
+    // Honest bytes and plan, zero locals in the obligation only: every mutual
+    // member canonically declares one carrier scratch local.
+    {
+        let dir = temp_dir("cert-mutual-zero-locals");
+        copy_dir(&out_dir, &dir);
+        set_named_code_nlocals_to_zero(&dir.join("cert/Module.lean"), "isEven", 1, 1);
+        let (ok, report) = aver_verify(&dir.join("mutual.wasm"), &dir.join("cert"));
+        assert!(!ok, "mutual zero-locals code must be DECLINED:\n{report}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     let honest = std::fs::read_to_string(cert.join("Plans.lean")).unwrap();
     // (a) member-call retargeted OUTSIDE the byte-derived SCC set ({1, 2}): the
@@ -3501,6 +3603,17 @@ fn cert_verify_declines_tampered_verbatim_plan() {
     let cert = out_dir.join("cert");
     let (ok, report) = aver_verify(&wasm, &cert);
     assert!(ok, "honest verbatim certificate should verify:\n{report}");
+
+    // Honest bytes and plan, zero locals in the obligation only. `wrapItems`
+    // projects a field, so its canonical verbatim layout has three locals.
+    {
+        let dir = temp_dir("cert-verbatim-zero-locals");
+        copy_dir(&out_dir, &dir);
+        set_named_code_nlocals_to_zero(&dir.join("cert/Module.lean"), "wrapItems", 1, 3);
+        let (ok, report) = aver_verify(&dir.join("verbatimgen.wasm"), &dir.join("cert"));
+        assert!(!ok, "verbatim zero-locals code must be DECLINED:\n{report}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     let honest = std::fs::read_to_string(cert.join("Plans.lean")).unwrap();
     // (a) wrong `ref.test` type index: `wrapItems` tests struct type 0 -> 1.


### PR DESCRIPTION
Applies uniformly the binding that PR #693 introduced for integer dispatch: the six remaining plan-family acceptance predicates (expression-fragment obligation and plan, string concatenation, recursion, mutual recursion, verbatim) bound the obligation's locals count through an unconstrained existential. Nothing related it to the locals vector the canonical byte lowering declares, so an obligation claiming zero locals against honest bytes satisfied the predicate while its body could not run — making the partial-correctness obligation vacuously true for the standalone kernel predicate. The shipped verifier was unaffected (the checker rederives the honest count and pins it).

## Change

- Each predicate now requires the exact canonical count derived from the plan or claim data already bound by the byte-equality gate (e.g. verbatim: three locals with a projection, two without; recursion/mutual: one carrier scratch local; string concatenation and expression fragments: the count their lowering declares).
- Witnesses discharge the pinned conjunct by rfl; the existential witness tuples are gone.
- Certificate schema version 36 -> 37.

## Tests

- Six new end-to-end tamper vectors: a zero-locals obligation with honest everything else is DECLINED, one per family.
- Two existing mutation tests asserted the decline was caught specifically by the checker witness; the pinned count now trips the artifact's own acceptance rfl during the lake build (an earlier, stronger stage), so those assertions accept either stage. The decline itself remains unconditionally asserted.
- Full gates green: lib 1015, cert_certify_spec 11, cert_decode_spec 2, cert_verify_spec 24; fmt and scoped clippy clean.
- Pins unchanged: json (12 certified, 76 source-level-only); cert_goals bridge 21 plan-backed / 2 legacy.