### PR TITLE
Decline non-list parametrized constructors fail-closed

### DIFF
--- a/src/codegen/cert/AcceptedArtifactCore.lean
+++ b/src/codegen/cert/AcceptedArtifactCore.lean
@@ -366,6 +366,18 @@ def isListConstructSymPlan (symPlan : SymRawPlan) : Bool :=
   | .app1 "List" _ => true
   | _ => false
 
+/-- A parametrized constructor result may only be certified when it is the
+    recognized `List` cons shape (whose element type is byte-bound below).
+    Any other parametrized result (`.app1 _`/`.app2 _`) is declined
+    fail-closed until a per-shape type binding exists; monomorphic results
+    stay bound by the struct index in the code entry. -/
+def parametrizedConstructIsList (symPlan : SymRawPlan) : Bool :=
+  match symPlan.result with
+  | .app1 "List" _ => true
+  | .app1 _ _ => false
+  | .app2 _ _ _ => false
+  | _ => true
+
 def constructPlanAccepted
     (wasmBytes : AverCert.WasmSlice.ByteSeq)
     (exportNameBytes : AverCert.WasmSlice.ByteSeq)
@@ -395,6 +407,7 @@ def constructPlanAccepted
       (isListConstructSymPlan symPlan = false ∨
         AverCert.WasmSlice.listConstructFuncTypeMatches
           wasmBytes binding.typeIdx plan.arity structIdx elemTy = true) ∧
+      parametrizedConstructIsList symPlan = true ∧
       obligation.code binding.funcIdx =
         some { arity := plan.arity, nlocals := 1, body := body }
 

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -65,7 +65,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 41;
+pub const CERT_SCHEMA_VERSION: u32 = 42;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/cert/render_project.rs
+++ b/src/codegen/cert/render_project.rs
@@ -1041,7 +1041,7 @@ fn render_artifact_expr_fragment_claims(
                 construct_proofs.push(format!(
                     "⟨rfl, rfl, rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
                      ⟨rfl, rfl, rfl, rfl, rfl, rfl, {struct_type_proof}, \
-                     {func_type_proof}, rfl⟩⟩⟩"
+                     {func_type_proof}, by decide, rfl⟩⟩⟩"
                 ));
             }
             Cert::Recursive {

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -2203,7 +2203,7 @@ fn lean_expr_fragment_artifact_claims(
             construct_proofs.push(format!(
                 "⟨rfl, rfl, rfl, rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
                  ⟨rfl, rfl, rfl, rfl, rfl, rfl, {struct_type_proof}, \
-                 {func_type_proof}, rfl⟩⟩⟩"
+                 {func_type_proof}, by decide, rfl⟩⟩⟩"
             ));
             continue;
         }

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -5204,11 +5204,11 @@ example : constructFamilyDropNames orphanManifest AverCert.Artifact.constructCla
   · constructor
     · exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, _, _, _, rfl, rfl, rfl, rfl, rfl, rfl,
         Or.inr AverCert.Plans.singletonJsonEntriesConstructStructTypeMatches,
-        Or.inr AverCert.Plans.singletonJsonEntriesConstructFuncTypeMatches, rfl⟩
+        Or.inr AverCert.Plans.singletonJsonEntriesConstructFuncTypeMatches, by decide, rfl⟩
     · constructor
       · exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, _, _, _, rfl, rfl, rfl, rfl, rfl, rfl,
           Or.inr AverCert.Plans.prependJsonEntryConstructStructTypeMatches,
-          Or.inr AverCert.Plans.prependJsonEntryConstructFuncTypeMatches, rfl⟩
+          Or.inr AverCert.Plans.prependJsonEntryConstructFuncTypeMatches, by decide, rfl⟩
       · trivial
   · decide
 
@@ -5225,11 +5225,11 @@ example : constructFamilyDropNodup dupManifest dupClaims := by
   · constructor
     · exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, _, _, _, rfl, rfl, rfl, rfl, rfl, rfl,
         Or.inr AverCert.Plans.singletonJsonEntriesConstructStructTypeMatches,
-        Or.inr AverCert.Plans.singletonJsonEntriesConstructFuncTypeMatches, rfl⟩
+        Or.inr AverCert.Plans.singletonJsonEntriesConstructFuncTypeMatches, by decide, rfl⟩
     · constructor
       · exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, _, _, _, rfl, rfl, rfl, rfl, rfl, rfl,
           Or.inr AverCert.Plans.singletonJsonEntriesConstructStructTypeMatches,
-          Or.inr AverCert.Plans.singletonJsonEntriesConstructFuncTypeMatches, rfl⟩
+          Or.inr AverCert.Plans.singletonJsonEntriesConstructFuncTypeMatches, by decide, rfl⟩
       · trivial
   · decide
 example : ¬ (AverCert.AcceptedArtifact.constructClaimExportNames dupClaims).Nodup := by decide


### PR DESCRIPTION
Follow-up hardening to the list-cons leg (#697). The element-type binding that pins a list constructor's element type to the byte-derived type section was gated on the literal type name `List`; a future parametrized non-list constructor (any `.app1`/`.app2` result that is not `List<_>`) would skip that binding and certify via the struct index alone, reopening the round-1 relabel hole for that ADT if its field were erased.

## Change

- New guard `parametrizedConstructIsList`: a parametrized constructor result may only be certified when it is the recognized list cons shape (whose element type is byte-bound). Any other parametrized result is declined fail-closed until a per-shape binding exists.
- Monomorphic constructors are unaffected — they stay bound by the struct index carried in the code entry.
- Witness generators (both emitters) and the guard-iso test witnesses emit the matching `by decide` proof of the new conjunct.
- Certificate schema version 41 -> 42.

## Not exploitable today; this is fail-closed hardening

Verified: the only parametrized-result construct claims in the entire corpus are `.app1 "List"` (singletonJsonEntries, prependJsonEntry), which satisfy the new guard. No non-list parametrized constructor is certified anywhere, so nothing is dropped. Found by self-review during #697 and banked as probe-artifacts/construct-narrowing-nit; this closes it.

## Tests

fmt, debug build, scoped clippy -D warnings, lib 1019, cert_certify_spec 11, cert_decode_spec 2, cert_verify_spec 29; the honest json certificate still certifies 12 exports and cert_goals stays 23/0.

A guard-iso adversary for a non-list parametrized result was skipped for lack of a fixture supplying the byte witnesses (no such export exists); the fail-closed behavior follows by construction from the conjunct.