### PR TITLE
Emit nominal roots for sum types in the wasm-gc backend

### DIFF
--- a/src/codegen/cert/AcceptedArtifactCore.lean
+++ b/src/codegen/cert/AcceptedArtifactCore.lean
@@ -583,11 +583,12 @@ def verbatimNLocals (plan : VerbatimRawPlan) : Nat :=
     bound to the exported function by name. There are no host/self calls to tie,
     so the code entry is nearly the whole binding — but the code entry alone does
     NOT determine the export's meaning: it omits the function SIGNATURE (a second
-    `eqref` parameter leaves the locals + body bytes identical) and the
+    nominal-root parameter leaves the locals + body bytes identical) and the
     `array.new_data` PAYLOAD CONTENTS (only the segment index and length are
     encoded). Two further conjuncts close both holes in-kernel:
-    `verbatimFuncTypeMatches` forces the byte-derived type-section entry to be the
-    unary ref-null or f64 signature declared by `plan.resultSig`, and `verbatimPayloadsBound`
+    `verbatimFuncTypeMatches` forces the byte-derived type-section entry to have
+    one nullable concrete root parameter and the ref-null or f64 result declared
+    by `plan.resultSig`, and `verbatimPayloadsBound`
     forces every literal's claimed bytes to equal the byte-pinned data segment. A
     body byte-noisier than the canonical dispatch lowering still fails the
     byte-equality gate. The member index is tied to the obligation through
@@ -693,10 +694,10 @@ def intDispatchCanonicalHost
     the exported function by name. The dispatch structure (tags, arm constants,
     operand order, roles) is pinned entirely by the byte-equality gate: every
     plan field reaches the lowered bytes. The code entry omits the function
-    SIGNATURE (a second `eqref` parameter leaves the locals + body bytes
+    SIGNATURE (a second nominal-root parameter leaves the locals + body bytes
     identical), so `verbatimFuncTypeMatches` additionally forces the
-    byte-derived type-section entry to be the unary
-    `[eqref] → [(ref null carrier)]` signature — the same shape check the
+    byte-derived type-section entry to be the unary nominal-ref →
+    `[(ref null carrier)]` signature — the same shape check the
     verbatim family uses, here with the Int carrier as the result heap type.
     The function index is tied to the obligation through
     `binding.funcIdx = obligation.self`, and the obligation's code table must

--- a/src/codegen/cert/WasmSlice.lean
+++ b/src/codegen/cert/WasmSlice.lean
@@ -303,26 +303,30 @@ def funcTypeMatches (wasmBytes : ByteSeq) (typeIdx arity carrier : Nat) : Bool :
   typeSectionMatches (checkCanonicalFuncType arity carrier) wasmBytes typeIdx
 
 /-- Whether the head of `bytes` is EXACTLY the certified verbatim dispatch
-    function type for `resultSig`: `[eqref] → [(ref null heapTy)]` for a
-    `.refNull heapTy` plan, or `[eqref] → [f64]` for `.f64Scalar`. The result
+    function type for `resultSig`: one nullable concrete nominal-root parameter
+    followed by `[(ref null heapTy)]` for a `.refNull heapTy` plan, or `[f64]`
+    for `.f64Scalar`. The result
     bytes are parsed from the type section and must match the plan variant
     exactly; accepting f64 never loosens the nullable-reference branch. -/
 def checkVerbatimFuncType (resultSig : AverCert.Schema.VerbatimResultSig)
     (bytes : ByteSeq) : Bool :=
   match bytes with
-  | 0x60 :: 0x01 :: 0x6d :: rest =>
-      match readUleb32 rest with
-      | some (nr, r1) =>
-          if nr = 1 then
-            match resultSig, r1 with
-            | .refNull resultHeapTy, 0x63 :: r2 =>
-                match readS33 r2 with
-                | some (idx, _) => idx == Int.ofNat resultHeapTy
-                | none => false
-            | .f64Scalar, 0x7c :: _ => true
-            | _, _ => false
-          else
-            false
+  | 0x60 :: 0x01 :: 0x63 :: rootBytes =>
+      match readS33 rootBytes with
+      | some (_, rest) =>
+          match readUleb32 rest with
+          | some (nr, r1) =>
+              if nr = 1 then
+                match resultSig, r1 with
+                | .refNull resultHeapTy, 0x63 :: r2 =>
+                    match readS33 r2 with
+                    | some (idx, _) => idx == Int.ofNat resultHeapTy
+                    | none => false
+                | .f64Scalar, 0x7c :: _ => true
+                | _, _ => false
+              else
+                false
+          | none => false
       | none => false
   | _ => false
 

--- a/src/codegen/cert/WasmSlice.lean
+++ b/src/codegen/cert/WasmSlice.lean
@@ -307,13 +307,17 @@ def funcTypeMatches (wasmBytes : ByteSeq) (typeIdx arity carrier : Nat) : Bool :
     followed by `[(ref null heapTy)]` for a `.refNull heapTy` plan, or `[f64]`
     for `.f64Scalar`. The result
     bytes are parsed from the type section and must match the plan variant
-    exactly; accepting f64 never loosens the nullable-reference branch. -/
+    exactly; accepting f64 never loosens the nullable-reference branch. The
+    parameter's s33 heap type must be non-negative: a negative s33 after `0x63`
+    encodes an abstract heap type (e.g. long-form `eqref` as `0x63 0x6D`), not
+    a concrete nominal root, so it fail-closes. -/
 def checkVerbatimFuncType (resultSig : AverCert.Schema.VerbatimResultSig)
     (bytes : ByteSeq) : Bool :=
   match bytes with
   | 0x60 :: 0x01 :: 0x63 :: rootBytes =>
       match readS33 rootBytes with
-      | some (_, rest) =>
+      | some (rootIdx, rest) =>
+          if rootIdx < 0 then false else
           match readUleb32 rest with
           | some (nr, r1) =>
               if nr = 1 then

--- a/src/codegen/cert/classify_basic.rs
+++ b/src/codegen/cert/classify_basic.rs
@@ -166,14 +166,14 @@ fn nr_ref_dispatch_match(
         }
         let miss_ops = node_ops(miss_arm);
         // Typed admission (belt for the legacy route, mirroring the verbatim
-        // widened match): exactly one user ADT (eqref) value in — a
+        // widened match): exactly one nominal sum-root value in — a
         // two-parameter dispatch keeps a byte-identical code entry, so a unary
         // obligation must not be certified for a binary export — and exactly
         // one nullable Int-carrier reference out (the plan path additionally
-        // pins the exact `[eqref] -> [(ref null) carrier]` signature
+        // pins the exact unary concrete-ref -> nullable-carrier signature
         // in-kernel).
         if matches!(miss_ops.as_slice(), [Op::I64Const(0), Op::Call(b)] if *b == box_idx)
-            && matches!(f.params.as_slice(), [TyKind::Eqref])
+            && matches!(f.params.as_slice(), [TyKind::Ref { nullable: true, .. }])
             && matches!(f.results.as_slice(),
                 [TyKind::Ref { nullable: true, idx }] if *idx == carrier)
         {
@@ -188,13 +188,13 @@ fn nr_ref_dispatch_match(
                 ops: strip_trailing_end(&f.ops).to_vec(),
             });
         }
-        // Typed admission: exactly one user ADT (eqref) value in — a two-parameter
+        // Typed admission: exactly one nominal sum-root value in — a two-parameter
         // dispatch keeps a byte-identical code entry, so a unary obligation must
         // not be certified for a binary export — and exactly one result of the
         // kind the default implies (a nullable ref here; the plan path additionally
-        // pins the exact `[eqref] -> [(ref null) resultHeapTy]` signature in-kernel).
+        // pins the exact unary concrete-ref -> nullable-result signature in-kernel).
         if f.calls.is_empty()
-            && matches!(f.params.as_slice(), [TyKind::Eqref])
+            && matches!(f.params.as_slice(), [TyKind::Ref { nullable: true, .. }])
             && let Some(default) = verbatim_default_from_ops(&miss_ops)
             && verbatim_results_ok(&f.results, &default)
         {

--- a/src/codegen/cert/classify_variant_dispatch.rs
+++ b/src/codegen/cert/classify_variant_dispatch.rs
@@ -12,13 +12,11 @@ fn nr_variant_dispatch(
     host_roles: &std::collections::HashMap<u32, HostRole>,
 ) -> Option<Cert> {
     let carrier = carrier?;
-    // Typed admission: the byte signature must be exactly "one user ADT value
-    // in, one Int carrier out" — the claim-shape as the bytes declare it, not
-    // a bare parameter count. The COMPLETE result vector must be exactly one
-    // NULLABLE carrier reference (the exact `ref null` form the certified
-    // `[eqref] -> [(ref null) carrier]` signature promises; the plan path
-    // additionally pins it in-kernel).
-    if f.params.as_slice() != [TyKind::Eqref]
+    // Typed admission: the byte signature must be exactly one nullable,
+    // concrete nominal sum-root reference in and one Int carrier out. Full
+    // wasm validation has already proved that every tested constructor is a
+    // subtype of that parameter root.
+    if !matches!(f.params.as_slice(), [TyKind::Ref { nullable: true, .. }])
         || !matches!(f.results.as_slice(),
             [TyKind::Ref { nullable: true, idx }] if *idx == carrier)
     {

--- a/src/codegen/cert/classify_verbatim.rs
+++ b/src/codegen/cert/classify_verbatim.rs
@@ -3,7 +3,7 @@
 /// returns `f64`, and every reference-producing
 /// default (`ref.null`, `array.new_data`) — like the field-projection hit of a
 /// widened match — returns a NULLABLE reference (`ref null`, the exact form the
-/// certified `[eqref] -> [(ref null) resultHeapTy]` signature promises). A
+/// certified unary nominal-ref -> nullable-result signature promises). A
 /// zero-result, two-result, non-nullable-reference, or scalar-integer signature
 /// is declined. The plan-backed path is additionally pinned in-kernel to the
 /// exact disjoint result-signature variant by `verbatimFuncTypeMatches`.
@@ -52,13 +52,13 @@ fn nr_verbatim_variant_dispatch(
     carrier: Option<u32>,
 ) -> Option<Cert> {
     let carrier = carrier?;
-    // Typed admission: the byte signature must be exactly "one user ADT (eqref)
-    // value in". Without this a two-parameter dispatch keeps a byte-identical code
+    // Typed admission: the byte signature must be exactly one nullable concrete
+    // nominal sum-root value in. Without this a two-parameter dispatch keeps a byte-identical code
     // entry (the extra param is overwritten by `local.set`), so a unary obligation
     // would be certified for a binary export. The result type is left to the plan
     // path: the declared ref-null or f64 result variant is additionally pinned
     // in-kernel by `verbatimFuncTypeMatches`.
-    let [TyKind::Eqref] = f.params.as_slice() else {
+    let [TyKind::Ref { nullable: true, .. }] = f.params.as_slice() else {
         return None;
     };
     if !f.calls.is_empty() {

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -65,7 +65,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 41;
+pub const CERT_SCHEMA_VERSION: u32 = 43;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/wasm_gc/maps.rs
+++ b/src/codegen/wasm_gc/maps.rs
@@ -1014,8 +1014,9 @@ fn emit_box_key(f: &mut Function, k_aver: &str, registry: &TypeRegistry) {
 /// Heap type used by `Map.remove` for `ref.null` in the keys-array
 /// store-back. Concrete idx for K kinds with their own struct type
 /// (primitive K boxes, String, record, carrier, List, Vector); abstract
-/// Eq for sum K (whose wasm rep is eqref since variants share no
-/// concrete struct type).
+/// Heap type of the `ref.null` written into a cleared key slot, per
+/// K kind. Matches the keys array element type exactly (a sum K uses
+/// its nominal root struct).
 fn key_storage_null_heap(k_aver: &str, registry: &TypeRegistry) -> HeapType {
     if let Some(box_idx) = registry.primitive_key_box_idx(k_aver) {
         return HeapType::Concrete(box_idx);
@@ -1046,8 +1047,11 @@ fn key_storage_null_heap(k_aver: &str, registry: &TypeRegistry) -> HeapType {
     if let Some(slots) = registry.map_slots(k_aver) {
         return HeapType::Concrete(slots.map);
     }
-    // Sum K — eqref. ref.null of abstract Eq is a subtype of every
-    // concrete variant ref, so the array.set typechecks.
+    // Sum K — the nominal root struct the keys array declares as its
+    // element heap type, so the array.set typechecks.
+    if let Some(root) = registry.sum_root_type_idx(k_aver) {
+        return HeapType::Concrete(root);
+    }
     HeapType::Abstract {
         shared: false,
         ty: wasm_encoder::AbstractHeapType::Eq,
@@ -2826,7 +2830,7 @@ fn emit_map_remove(
     // keys[i] = null. Heap type matches the keys array element ref —
     // see `key_storage_null_heap` for the per-K-kind table (primitive
     // box / String / record / carrier / List / Vector concrete idx,
-    // abstract Eq for sum K).
+    // nominal root for sum K).
     let null_heap = key_storage_null_heap(k_aver, registry);
     f.instruction(&Instruction::LocalGet(4));
     f.instruction(&Instruction::LocalGet(7));

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -4649,6 +4649,20 @@ fn emit_user_types(
     // per-collection iteration order no longer matches insertion
     // order.
     let mut entries: Vec<(u32, SubType)> = Vec::new();
+    let mk_sub_struct = |fields: Vec<wasm_encoder::FieldType>,
+                         is_final: bool,
+                         supertype_idx: Option<u32>| SubType {
+        is_final,
+        supertype_idx,
+        composite_type: CompositeType {
+            inner: CompositeInnerType::Struct(StructType {
+                fields: fields.into_boxed_slice(),
+            }),
+            shared: false,
+            descriptor: None,
+            describes: None,
+        },
+    };
     let mk_struct = |fields: Vec<wasm_encoder::FieldType>| SubType {
         is_final: true,
         supertype_idx: None,
@@ -4689,6 +4703,16 @@ fn emit_user_types(
                 variants,
                 ..
             }) => {
+                let root_idx =
+                    registry
+                        .sum_root_type_idx(parent)
+                        .ok_or(WasmGcError::Validation(format!(
+                            "sum `{parent}` root not registered"
+                        )))?;
+                // Empty, non-final nominal carrier. It precedes all variants
+                // by registry construction and shares this rec group with all
+                // user types, so recursive payload graphs remain valid.
+                entries.push((root_idx, mk_sub_struct(Vec::new(), false, None)));
                 for v in variants {
                     let mut fields = Vec::new();
                     for ty in &v.fields {
@@ -4717,7 +4741,7 @@ fn emit_user_types(
                                 "variant `{parent}.{}` not registered",
                                 v.name
                             )))?;
-                    entries.push((info.type_idx, mk_struct(fields)));
+                    entries.push((info.type_idx, mk_sub_struct(fields, true, Some(root_idx))));
                 }
             }
             _ => {}

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -14,10 +14,9 @@
 //!    the right struct.
 //!
 //! Variants (`type Shape = Circle(Float) | Rect(Float, Float)`) get
-//! one struct type per constructor, with the parent-type name as the
-//! abstract carrier. Phase-3 keeps it simple: each constructor stands
-//! alone (no subtyping yet — pattern matching dispatches via tag-by-
-//! struct-type comparison through `ref.test`).
+//! one empty non-final root struct for the sum plus one final struct
+//! subtype per constructor. Pattern matching dispatches through
+//! `ref.test` against those concrete constructor types.
 
 use std::collections::HashMap;
 
@@ -39,6 +38,9 @@ use crate::ast::{TopLevel, TypeDef};
 pub(super) struct TypeRegistry {
     /// `record_name → type_idx` for product (record) types.
     pub(super) records: HashMap<String, u32>,
+    /// `sum_name → type_idx` for the empty, non-final nominal root
+    /// struct shared by every constructor of that sum.
+    pub(super) sum_roots: HashMap<String, u32>,
     /// `variant_constructor_name → (parent_type_name, type_idx, fields)`.
     /// `fields` are the type strings of the constructor's positional
     /// fields (Aver variants use positional fields, not named ones).
@@ -260,6 +262,7 @@ impl TypeRegistry {
         // unchanged.
         let handler_active = _handler_active;
         let mut records = HashMap::new();
+        let mut sum_roots = HashMap::new();
         let mut variants: HashMap<String, Vec<VariantInfo>> = HashMap::new();
         let mut record_fields = HashMap::new();
         let mut next_idx: u32 = 0;
@@ -273,6 +276,12 @@ impl TypeRegistry {
                 TopLevel::TypeDef(TypeDef::Sum {
                     name, variants: vs, ..
                 }) => {
+                    // Reserve the nominal root before every constructor.
+                    // `emit_user_types` preserves these indices inside one
+                    // explicit rec group, so the supertype is declared before
+                    // its subtypes while recursive sum payloads remain legal.
+                    sum_roots.insert(name.clone(), next_idx);
+                    next_idx += 1;
                     for v in vs {
                         variants
                             .entry(v.name.clone())
@@ -998,6 +1007,7 @@ impl TypeRegistry {
 
         Self {
             records,
+            sum_roots,
             variants,
             record_fields,
             vector_types,
@@ -1266,6 +1276,14 @@ impl TypeRegistry {
             return Some(idx);
         }
         None
+    }
+
+    pub(super) fn sum_root_type_idx(&self, name: &str) -> Option<u32> {
+        if let Some(idx) = self.sum_roots.get(name).copied() {
+            return Some(idx);
+        }
+        let bare = name.rsplit_once('.').map_or(name, |(_, b)| b);
+        self.sum_roots.get(bare).copied()
     }
 
     /// Look up a variant by bare name. Returns the first registered
@@ -1876,31 +1894,13 @@ pub(super) fn aver_to_wasm(
         if let Some(idx) = reg.record_type_idx(trimmed) {
             return Ok(Some(struct_ref(idx)));
         }
-        // Sum type by parent name — represented as the abstract `eq`
-        // ref so any variant subtype lands in the same slot. Each
-        // variant constructor's type idx still emits a concrete
-        // struct.new; the parent ref shape is what params/locals
-        // declare.
-        // Variant parent match: tolerate "Types.Tile" coming in from
-        // a canonicalised type stamp when the discovery walker
-        // registered the variants under bare "Tile" (Iron — A3).
-        let trimmed_bare = trimmed.rsplit_once('.').map_or(trimmed, |(_, b)| b);
-        if reg
-            .variants
-            .values()
-            .flat_map(|v| v.iter())
-            .any(|v| v.parent == trimmed || v.parent == trimmed_bare)
-        {
-            // Phase-3a: use `(ref null eq)` as the carrier — every
-            // wasm-gc struct is a subtype of `eq`. Real subtype
-            // hierarchies (where pattern matching tests `ref.test`
-            // against concrete struct types) lands in phase 3b.
+        // Sum type by parent name — use its nominal root struct as the
+        // carrier. Constructors still allocate their concrete variant
+        // structs, all declared as subtypes of this root.
+        if let Some(root_idx) = reg.sum_root_type_idx(trimmed) {
             return Ok(Some(ValType::Ref(RefType {
                 nullable: true,
-                heap_type: HeapType::Abstract {
-                    shared: false,
-                    ty: AbstractHeapType::Eq,
-                },
+                heap_type: HeapType::Concrete(root_idx),
             })));
         }
     }

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -332,7 +332,7 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
         "construct SymPlan should remain outside the expr-fragment encoder:\n{plans_lean}"
     );
     assert!(
-        plans_lean.contains("lowerConstructCodeEntry 18 0 mkOpConstructPlan =\n  some [10, 1, 1, 99, 18, 32, 0, 251, 0, 0, 11] := rfl"),
+        plans_lean.contains("lowerConstructCodeEntry 23 1 mkOpConstructPlan =\n  some [10, 1, 1, 99, 23, 32, 0, 251, 0, 1, 11] := rfl"),
         "mkOp construct plan should lower to the exact code-entry bytes:\n{plans_lean}"
     );
     let mkop_entry = manifest["certified"]
@@ -1478,8 +1478,9 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
     }
 }
 
-/// The s33 heap-type boundary: 62 user variant structs push the Int carrier to
-/// wasm type index 64, the first index whose signed s33 encoding (`c0 00`)
+/// The s33 heap-type boundary: 16 nominal sum roots plus 46 user variant
+/// structs push the Int carrier to wasm type index 64, the first index whose
+/// signed s33 encoding (`c0 00`)
 /// differs from unsigned LEB (`40`). The recursion plan claim binds the
 /// carrier index inside local declarations, the value-if block type and the
 /// declared function type, so a lowerer that emitted unsigned LEB would fail

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -4500,6 +4500,26 @@ fn verbatim_kernel_guards_are_isolating() {
         "example : WasmSlice.verbatimFuncTypeMatches nonNullMod 0 (.refNull 5) = false := rfl\n\n",
     );
 
+    // ABSTRACT-PARAM isolation: after `0x63` a NEGATIVE s33 heap type encodes an
+    // abstract heap type (long-form eqref is `0x63 0x6D`, s33 -19), not a concrete
+    // nominal root, so the signature guard fail-closes. The module differs from
+    // `unaryMod` only in that param byte (`4 -> 109`), so the byte-derived binding
+    // and code entry are IDENTICAL — only `checkVerbatimFuncType` tells them apart.
+    lean.push_str(
+        "example : WasmSlice.checkVerbatimFuncType (.refNull 5) [96, 1, 99, 109, 1, 99, 5] = false := rfl\n",
+    );
+    lean.push_str(
+        "example : WasmSlice.checkVerbatimFuncType .f64Scalar [96, 1, 99, 109, 1, 124] = false := rfl\n",
+    );
+    lean.push_str(
+        "def abstractParamMod : List Nat := hdr ++ [1, 8, 1, 96, 1, 99, 109, 1, 99, 5] ++ tailSecs\n",
+    );
+    lean.push_str("example : WasmSlice.funcBindingForExport abstractParamMod nameF = WasmSlice.funcBindingForExport unaryMod nameF := rfl\n");
+    lean.push_str("example : WasmSlice.codeEntryForExport abstractParamMod nameF = WasmSlice.codeEntryForExport unaryMod nameF := rfl\n");
+    lean.push_str(
+        "example : WasmSlice.verbatimFuncTypeMatches abstractParamMod 0 (.refNull 5) = false := rfl\n\n",
+    );
+
     // PARSER STRICTNESS isolation (re-review FIX 3): the type-section and
     // data-section walkers parse EVERY declared entry/segment and require EXACT
     // payload exhaustion, so a valid entry followed by trailing bytes, or a count

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -1367,10 +1367,10 @@ fn cert_verify_declines_tampered_array_new_data_operands() {
     copy_dir(&out_dir, &dir);
     let w = dir.join("json.wasm");
     let mut bytes = std::fs::read(&w).unwrap();
-    // i32.const 0; i32.const 0; array.new_data type16 seg11 (the empty string
+    // i32.const 0; i32.const 0; array.new_data type19 seg11 (the empty string
     // literal). Changing the length operand to 1 violates the decoder's
     // fail-closed data-segment guard while keeping the module parseable.
-    let pat = [0x41, 0x00, 0x41, 0x00, 0xfb, 0x09, 0x10, 0x0b];
+    let pat = [0x41, 0x00, 0x41, 0x00, 0xfb, 0x09, 0x13, 0x0b];
     let mut hits = 0usize;
     for i in 0..bytes.len().saturating_sub(pat.len()) {
         if bytes[i..].starts_with(&pat) {
@@ -1761,8 +1761,8 @@ fn cert_verify_declines_tampered_expr_fragment_sidecar() {
     let lean_bytes_tamper_cert = lean_bytes_tamper_dir.join("cert");
     let plans_lean = lean_bytes_tamper_cert.join("Plans.lean");
     let plans_text = std::fs::read_to_string(&plans_lean).unwrap();
-    let honest_bytes = "some [10, 1, 1, 99, 18, 32, 0, 32, 1, 160, 11]";
-    let tampered_bytes = "some [10, 1, 1, 99, 18, 32, 0, 32, 1, 161, 11]";
+    let honest_bytes = "some [10, 1, 1, 99, 23, 32, 0, 32, 1, 160, 11]";
+    let tampered_bytes = "some [10, 1, 1, 99, 23, 32, 0, 32, 1, 161, 11]";
     assert!(
         plans_text.contains(honest_bytes),
         "Plans.lean floatAddGoal byte pin changed"
@@ -4114,10 +4114,10 @@ fn cert_verify_declines_tampered_verbatim_plan() {
     }
 
     let honest = std::fs::read_to_string(cert.join("Plans.lean")).unwrap();
-    // (a) wrong `ref.test` type index: `wrapItems` tests struct type 0 -> 1.
-    // (b) swapped dispatch cascade: `tagName` tests tags 2 <-> 3.
+    // (a) wrong `ref.test` type index: `wrapItems` tests struct type 1 -> 2.
+    // (b) swapped dispatch cascade: `tagName` tests tags 4 <-> 5.
     // (c) wrong `array.new_data` data-segment index: `tagName`'s "alpha" 0 -> 9.
-    // (d) wrong `ref.null` result heap type: `wrapItems` 8 -> 18.
+    // (d) wrong `ref.null` result heap type: `wrapItems` 10 -> 18.
     // (e) equal-length payload collision: `tagName`'s "alpha" -> "alphb" (same
     //     length, same data index). The code-entry lowering pins only the payload
     //     LENGTH, so every byte-equality pin stays green; ONLY the acceptance
@@ -4127,28 +4127,28 @@ fn cert_verify_declines_tampered_verbatim_plan() {
     let tampers: [(&str, &str, &str); 5] = [
         (
             "ref.test type index",
-            ".test 0 (.project 0 0) (.leaf (.refNull))",
-            ".test 1 (.project 0 0) (.leaf (.refNull))",
+            ".test 1 (.project 1 0) (.leaf (.refNull))",
+            ".test 2 (.project 1 0) (.leaf (.refNull))",
         ),
         (
             "swapped dispatch cascade",
-            ".test 2 (.arrayNewData 5 0 [97, 108, 112, 104, 97]) (.test 3",
-            ".test 3 (.arrayNewData 5 0 [97, 108, 112, 104, 97]) (.test 2",
+            ".test 4 (.arrayNewData 7 0 [97, 108, 112, 104, 97]) (.test 5",
+            ".test 5 (.arrayNewData 7 0 [97, 108, 112, 104, 97]) (.test 4",
         ),
         (
             "array.new_data data index",
-            ".arrayNewData 5 0 [97, 108, 112, 104, 97]",
-            ".arrayNewData 5 9 [97, 108, 112, 104, 97]",
+            ".arrayNewData 7 0 [97, 108, 112, 104, 97]",
+            ".arrayNewData 7 9 [97, 108, 112, 104, 97]",
         ),
         (
             "ref.null heap type",
-            "resultSig := .refNull 8",
+            "resultSig := .refNull 10",
             "resultSig := .refNull 18",
         ),
         (
             "equal-length payload collision",
-            ".arrayNewData 5 0 [97, 108, 112, 104, 97]",
-            ".arrayNewData 5 0 [97, 108, 112, 104, 98]",
+            ".arrayNewData 7 0 [97, 108, 112, 104, 97]",
+            ".arrayNewData 7 0 [97, 108, 112, 104, 98]",
         ),
     ];
     for (label, from, to) in tampers {
@@ -4172,24 +4172,24 @@ fn cert_verify_declines_tampered_verbatim_plan() {
     // Guard-isolation: prove in-kernel that each vector diverges the lowered
     // code-entry bytes (so the byte-equality gate — the whole binding — catches
     // it), mirroring the spike's four `by decide` vectors on the real plans.
-    // carrier 7; `wrapItems` result heap 8, `tagName` string-array type 5.
+    // carrier 9; `wrapItems` result heap 10, `tagName` string-array type 7.
     let mut lean = String::new();
     lean.push_str("import Schema\nimport PlanCheck\nimport PlanLower\nimport PlanBytes\n\n");
     lean.push_str("open AverCert.Schema\nopen AverCert.PlanBytes\n\n");
-    lean.push_str("def honestWrap : VerbatimRawPlan := { profile := \"verbatim-plan-v1\", scrutineeLocal := 2, fieldLocal := 1, resultSig := .refNull 8, body := .test 0 (.project 0 0) (.leaf (.refNull)) }\n");
-    lean.push_str("def honestTag : VerbatimRawPlan := { profile := \"verbatim-plan-v1\", scrutineeLocal := 1, fieldLocal := 0, resultSig := .refNull 5, body := .test 2 (.arrayNewData 5 0 [97, 108, 112, 104, 97]) (.test 3 (.arrayNewData 5 1 [98, 101, 116, 97]) (.leaf (.arrayNewData 5 2 [103, 97, 109, 109, 97]))) }\n\n");
+    lean.push_str("def honestWrap : VerbatimRawPlan := { profile := \"verbatim-plan-v1\", scrutineeLocal := 2, fieldLocal := 1, resultSig := .refNull 10, body := .test 1 (.project 1 0) (.leaf (.refNull)) }\n");
+    lean.push_str("def honestTag : VerbatimRawPlan := { profile := \"verbatim-plan-v1\", scrutineeLocal := 1, fieldLocal := 0, resultSig := .refNull 7, body := .test 4 (.arrayNewData 7 0 [97, 108, 112, 104, 97]) (.test 5 (.arrayNewData 7 1 [98, 101, 116, 97]) (.leaf (.arrayNewData 7 2 [103, 97, 109, 109, 97]))) }\n\n");
     lean.push_str("example : AverCert.PlanCheck.checkVerbatimRawPlan honestWrap = true := rfl\n");
     lean.push_str("example : AverCert.PlanCheck.checkVerbatimRawPlan honestTag = true := rfl\n\n");
-    lean.push_str("def tamper1 : VerbatimRawPlan := { honestWrap with body := .test 1 (.project 0 0) (.leaf (.refNull)) }\n");
-    lean.push_str("example : lowerVerbatimCodeEntry 7 tamper1 ≠ lowerVerbatimCodeEntry 7 honestWrap := by decide\n");
-    lean.push_str("def tamper2 : VerbatimRawPlan := { honestTag with body := .test 3 (.arrayNewData 5 0 [97, 108, 112, 104, 97]) (.test 2 (.arrayNewData 5 1 [98, 101, 116, 97]) (.leaf (.arrayNewData 5 2 [103, 97, 109, 109, 97]))) }\n");
-    lean.push_str("example : lowerVerbatimCodeEntry 7 tamper2 ≠ lowerVerbatimCodeEntry 7 honestTag := by decide\n");
-    lean.push_str("def tamper3 : VerbatimRawPlan := { honestTag with body := .test 2 (.arrayNewData 5 9 [97, 108, 112, 104, 97]) (.test 3 (.arrayNewData 5 1 [98, 101, 116, 97]) (.leaf (.arrayNewData 5 2 [103, 97, 109, 109, 97]))) }\n");
-    lean.push_str("example : lowerVerbatimCodeEntry 7 tamper3 ≠ lowerVerbatimCodeEntry 7 honestTag := by decide\n");
+    lean.push_str("def tamper1 : VerbatimRawPlan := { honestWrap with body := .test 2 (.project 1 0) (.leaf (.refNull)) }\n");
+    lean.push_str("example : lowerVerbatimCodeEntry 9 tamper1 ≠ lowerVerbatimCodeEntry 9 honestWrap := by decide\n");
+    lean.push_str("def tamper2 : VerbatimRawPlan := { honestTag with body := .test 5 (.arrayNewData 7 0 [97, 108, 112, 104, 97]) (.test 4 (.arrayNewData 7 1 [98, 101, 116, 97]) (.leaf (.arrayNewData 7 2 [103, 97, 109, 109, 97]))) }\n");
+    lean.push_str("example : lowerVerbatimCodeEntry 9 tamper2 ≠ lowerVerbatimCodeEntry 9 honestTag := by decide\n");
+    lean.push_str("def tamper3 : VerbatimRawPlan := { honestTag with body := .test 4 (.arrayNewData 7 9 [97, 108, 112, 104, 97]) (.test 5 (.arrayNewData 7 1 [98, 101, 116, 97]) (.leaf (.arrayNewData 7 2 [103, 97, 109, 109, 97]))) }\n");
+    lean.push_str("example : lowerVerbatimCodeEntry 9 tamper3 ≠ lowerVerbatimCodeEntry 9 honestTag := by decide\n");
     lean.push_str(
         "def tamper4 : VerbatimRawPlan := { honestWrap with resultSig := .refNull 18 }\n",
     );
-    lean.push_str("example : lowerVerbatimCodeEntry 7 tamper4 ≠ lowerVerbatimCodeEntry 7 honestWrap := by decide\n");
+    lean.push_str("example : lowerVerbatimCodeEntry 9 tamper4 ≠ lowerVerbatimCodeEntry 9 honestWrap := by decide\n");
 
     let honest_build = Command::new("lake")
         .arg("build")
@@ -4269,7 +4269,7 @@ fn cert_verify_scalar_f64_verbatim_fixture_and_tampers() {
     let plans = std::fs::read_to_string(cert.join("Plans.lean")).unwrap();
     assert!(
         plans.contains(
-            "def floatOrZeroVerbatimPlan : VerbatimRawPlan := { profile := \"verbatim-plan-v1\", scrutineeLocal := 2, fieldLocal := 1, resultSig := .f64Scalar, body := .test 0 (.project 0 0) (.leaf (.f64Bits 0)) }"
+            "def floatOrZeroVerbatimPlan : VerbatimRawPlan := { profile := \"verbatim-plan-v1\", scrutineeLocal := 2, fieldLocal := 1, resultSig := .f64Scalar, body := .test 1 (.project 1 0) (.leaf (.f64Bits 0)) }"
         ),
         "floatOrZero plan must pin the scalar-f64 result and zero default"
     );
@@ -4376,7 +4376,7 @@ fn cert_verify_scalar_f64_verbatim_fixture_and_tampers() {
         copy_dir(&out_dir, &dir);
         let tampered_wasm = dir.join("f64verbatim.wasm");
         let range = type_section_range.expect("type section must exist");
-        let signature = [0x60, 0x01, 0x6d, 0x01, 0x7c];
+        let signature = [0x60, 0x01, 0x63, 0x00, 0x01, 0x7c];
         let matches = honest_bytes[range.clone()]
             .windows(signature.len())
             .enumerate()
@@ -4385,7 +4385,7 @@ fn cert_verify_scalar_f64_verbatim_fixture_and_tampers() {
         assert_eq!(
             matches.len(),
             1,
-            "floatOrZero's eqref -> f64 signature must be unique"
+            "floatOrZero's nominal-root-ref -> f64 signature must be unique"
         );
         let mut bytes = honest_bytes.clone();
         bytes[matches[0] + signature.len() - 1] = 0x63;
@@ -4418,7 +4418,7 @@ fn cert_verify_scalar_f64_verbatim_fixture_and_tampers() {
 /// nothing else moves).
 ///
 /// SIGNATURE guard: two minimal modules identical in every section EXCEPT the
-/// type section (the second appends a second `eqref` parameter). The
+/// type section (the second appends a second nominal-root parameter). The
 /// func/export/code/data sections — hence the byte-derived `FuncBinding` and code
 /// entry the byte-equality gate reads — are byte-for-byte identical, so the two
 /// sibling conjuncts (`funcBindingForExport`, `codeEntryForExport`) return the
@@ -4445,8 +4445,8 @@ fn verbatim_kernel_guards_are_isolating() {
     // tail. `f` is func 0 of type 0; code entry `[2, 0, 11]`; data segment 0 is
     // "alpha" (passive). Only the type section differs between the two.
     lean.push_str("def hdr : List Nat := [0, 97, 115, 109, 1, 0, 0, 0]\n");
-    lean.push_str("def unaryType : List Nat := [1, 7, 1, 96, 1, 109, 1, 99, 5]\n");
-    lean.push_str("def binaryType : List Nat := [1, 8, 1, 96, 2, 109, 109, 1, 99, 5]\n");
+    lean.push_str("def unaryType : List Nat := [1, 8, 1, 96, 1, 99, 4, 1, 99, 5]\n");
+    lean.push_str("def binaryType : List Nat := [1, 10, 1, 96, 2, 99, 4, 99, 4, 1, 99, 5]\n");
     lean.push_str("def tailSecs : List Nat := [3, 2, 1, 0, 7, 5, 1, 1, 102, 0, 0, 10, 4, 1, 2, 0, 11, 11, 8, 1, 1, 5, 97, 108, 112, 104, 97]\n");
     lean.push_str("def unaryMod : List Nat := hdr ++ unaryType ++ tailSecs\n");
     lean.push_str("def binaryMod : List Nat := hdr ++ binaryType ++ tailSecs\n");
@@ -4480,19 +4480,19 @@ fn verbatim_kernel_guards_are_isolating() {
     lean.push_str("example : PlanCheck.checkVerbatimRawPlan { profile := \"verbatim-plan-v1\", scrutineeLocal := 1, fieldLocal := 0, resultSig := .refNull 5, body := .leaf (.arrayNewData 5 0 [256]) } = false := rfl\n\n");
 
     // NULLABILITY isolation (re-review FIX 2): the certified verbatim signature is
-    // `[eqref] -> [(ref null resultHeapTy)]` — the `0x63` nullable form the
+    // one nominal-root ref -> `[(ref null resultHeapTy)]` — the `0x63` nullable form the
     // `ref.null` default requires. A non-null `0x64` result is rejected. The only
     // byte differing between `unaryMod` and `nonNullMod` is `0x63 -> 0x64`, so the
     // byte-derived binding and code entry are IDENTICAL (the reftype is never in
     // the code entry) — only `checkVerbatimFuncType` tells them apart.
     lean.push_str(
-        "example : WasmSlice.checkVerbatimFuncType (.refNull 5) [96, 1, 109, 1, 99, 5] = true := rfl\n",
+        "example : WasmSlice.checkVerbatimFuncType (.refNull 5) [96, 1, 99, 4, 1, 99, 5] = true := rfl\n",
     );
     lean.push_str(
-        "example : WasmSlice.checkVerbatimFuncType (.refNull 5) [96, 1, 109, 1, 100, 5] = false := rfl\n",
+        "example : WasmSlice.checkVerbatimFuncType (.refNull 5) [96, 1, 99, 4, 1, 100, 5] = false := rfl\n",
     );
     lean.push_str(
-        "def nonNullMod : List Nat := hdr ++ [1, 7, 1, 96, 1, 109, 1, 100, 5] ++ tailSecs\n",
+        "def nonNullMod : List Nat := hdr ++ [1, 8, 1, 96, 1, 99, 4, 1, 100, 5] ++ tailSecs\n",
     );
     lean.push_str("example : WasmSlice.funcBindingForExport nonNullMod nameF = WasmSlice.funcBindingForExport unaryMod nameF := rfl\n");
     lean.push_str("example : WasmSlice.codeEntryForExport nonNullMod nameF = WasmSlice.codeEntryForExport unaryMod nameF := rfl\n");
@@ -4506,12 +4506,12 @@ fn verbatim_kernel_guards_are_isolating() {
     // that does not match the bytes, declines — and an over-wide LEB is rejected
     // by the width cap. The honest single-entry sections still match.
     // Type section: a trailing `0xff` after the one valid func type.
-    lean.push_str("def trailingTypeMod : List Nat := hdr ++ [1, 8, 1, 96, 1, 109, 1, 99, 5, 255] ++ tailSecs\n");
+    lean.push_str("def trailingTypeMod : List Nat := hdr ++ [1, 9, 1, 96, 1, 99, 4, 1, 99, 5, 255] ++ tailSecs\n");
     lean.push_str(
         "example : WasmSlice.verbatimFuncTypeMatches trailingTypeMod 0 (.refNull 5) = false := rfl\n",
     );
     // Type section: count claims 2 rectypes but only 1 is present.
-    lean.push_str("def countMismatchTypeMod : List Nat := hdr ++ [1, 7, 2, 96, 1, 109, 1, 99, 5] ++ tailSecs\n");
+    lean.push_str("def countMismatchTypeMod : List Nat := hdr ++ [1, 8, 2, 96, 1, 99, 4, 1, 99, 5] ++ tailSecs\n");
     lean.push_str(
         "example : WasmSlice.verbatimFuncTypeMatches countMismatchTypeMod 0 (.refNull 5) = false := rfl\n",
     );
@@ -4538,8 +4538,8 @@ fn verbatim_kernel_guards_are_isolating() {
     lean.push_str(
         r#"
 def isoHdr : List Nat := [0, 97, 115, 109, 1, 0, 0, 0]
-def isoF64Type : List Nat := [1, 6, 1, 96, 1, 109, 1, 124]
-def isoRefType : List Nat := [1, 7, 1, 96, 1, 109, 1, 99, 5]
+def isoF64Type : List Nat := [1, 7, 1, 96, 1, 99, 4, 1, 124]
+def isoRefType : List Nat := [1, 8, 1, 96, 1, 99, 4, 1, 99, 5]
 def isoTail : List Nat :=
   [3, 2, 1, 0, 7, 5, 1, 1, 102, 0, 0,
    10, 24, 1, 22, 2, 1, 109, 1, 99, 7, 32, 0, 33, 1, 32, 1,
@@ -4715,8 +4715,8 @@ fn cert_verify_declines_tampered_int_dispatch_plan() {
     );
 
     let honest = std::fs::read_to_string(cert.join("Plans.lean")).unwrap();
-    // (a) wrong `ref.test` tag: `boxInt` tests struct type 0 -> 1.
-    // (b) swapped dispatch cascade: `gauge` tests tags 3 <-> 4.
+    // (a) wrong `ref.test` tag: `boxInt` tests struct type 1 -> 2.
+    // (b) swapped dispatch cascade: `gauge` tests tags 5 <-> 6.
     // (c) role swap: `gauge`'s Lo arm combinator `sub` -> `add`. The role table
     //     maps roles to DISTINCT indices, so the swap changes the host call
     //     byte — the exact discrimination `hostTableIndicesDistinct` protects.
@@ -4728,13 +4728,13 @@ fn cert_verify_declines_tampered_int_dispatch_plan() {
     let tampers: [(&str, &str, &str); 7] = [
         (
             "ref.test tag",
-            ".test 0 (.proj) (.default (0))",
             ".test 1 (.proj) (.default (0))",
+            ".test 2 (.proj) (.default (0))",
         ),
         (
             "swapped dispatch cascade",
-            ".test 3 (.hostOp .sub (0) true) (.test 4",
-            ".test 4 (.hostOp .sub (0) true) (.test 3",
+            ".test 5 (.hostOp .sub (0) true) (.test 6",
+            ".test 6 (.hostOp .sub (0) true) (.test 5",
         ),
         (
             "host role swap",
@@ -4850,8 +4850,8 @@ fn cert_verify_declines_tampered_int_dispatch_plan() {
         copy_dir(&out_dir, &dir);
         let module = dir.join("cert").join("Module.lean");
         let src = std::fs::read_to_string(&module).unwrap();
-        let from = "def boxIntHost : HostTbl := fun fn =>\n  if fn = 7 then some (1, boxRef 9)\n  else none";
-        let to = "def boxIntHost : HostTbl := fun fn =>\n  if fn = 7 then some (1, fun args => match args with | [WVal.i64v 0] => boxRef 9 args | _ => none)\n  else none";
+        let from = "def boxIntHost : HostTbl := fun fn =>\n  if fn = 7 then some (1, boxRef 11)\n  else none";
+        let to = "def boxIntHost : HostTbl := fun fn =>\n  if fn = 7 then some (1, fun args => match args with | [WVal.i64v 0] => boxRef 11 args | _ => none)\n  else none";
         assert!(
             src.contains(from),
             "boxIntHost shape changed; update the test"
@@ -4865,36 +4865,36 @@ fn cert_verify_declines_tampered_int_dispatch_plan() {
     // Guard-isolation: prove in-kernel that each byte-reaching vector diverges
     // the lowered code-entry bytes (so the byte-equality gate catches it), and
     // that the profile vector — which the lowering is provably BLIND to — is
-    // rejected exactly by the structural checker. carrier 9; role table
+    // rejected exactly by the structural checker. carrier 11; role table
     // box 7 / add 8 / sub 9 (the fixture's byte-derived table).
     let mut lean = String::new();
     lean.push_str("import Schema\nimport PlanCheck\nimport PlanLower\nimport PlanBytes\n\n");
     lean.push_str("open AverCert.Schema\nopen AverCert.PlanBytes\n\n");
     lean.push_str("def tbl : List (HostRole × Nat) := [(.box, 7), (.add, 8), (.sub, 9)]\n");
-    lean.push_str("def honestBox : IntDispatchRawPlan := { profile := \"int-dispatch-v1\", body := .test 0 (.proj) (.default (0)) }\n");
-    lean.push_str("def honestGauge : IntDispatchRawPlan := { profile := \"int-dispatch-v1\", body := .test 3 (.hostOp .sub (0) true) (.test 4 (.hostOp .add (9) false) (.test 5 (.proj) (.default (7)))) }\n\n");
+    lean.push_str("def honestBox : IntDispatchRawPlan := { profile := \"int-dispatch-v1\", body := .test 1 (.proj) (.default (0)) }\n");
+    lean.push_str("def honestGauge : IntDispatchRawPlan := { profile := \"int-dispatch-v1\", body := .test 5 (.hostOp .sub (0) true) (.test 6 (.hostOp .add (9) false) (.test 7 (.proj) (.default (7)))) }\n\n");
     lean.push_str("example : AverCert.PlanCheck.checkIntDispatchRawPlan honestBox = true := rfl\n");
     lean.push_str(
         "example : AverCert.PlanCheck.checkIntDispatchRawPlan honestGauge = true := rfl\n\n",
     );
-    lean.push_str("def tamper1 : IntDispatchRawPlan := { honestBox with body := .test 1 (.proj) (.default (0)) }\n");
-    lean.push_str("example : lowerIntDispatchCodeEntry 9 tbl tamper1 ≠ lowerIntDispatchCodeEntry 9 tbl honestBox := by decide\n");
-    lean.push_str("def tamper2 : IntDispatchRawPlan := { honestGauge with body := .test 4 (.hostOp .sub (0) true) (.test 3 (.hostOp .add (9) false) (.test 5 (.proj) (.default (7)))) }\n");
-    lean.push_str("example : lowerIntDispatchCodeEntry 9 tbl tamper2 ≠ lowerIntDispatchCodeEntry 9 tbl honestGauge := by decide\n");
-    lean.push_str("def tamper3 : IntDispatchRawPlan := { honestGauge with body := .test 3 (.hostOp .add (0) true) (.test 4 (.hostOp .add (9) false) (.test 5 (.proj) (.default (7)))) }\n");
-    lean.push_str("example : lowerIntDispatchCodeEntry 9 tbl tamper3 ≠ lowerIntDispatchCodeEntry 9 tbl honestGauge := by decide\n");
-    lean.push_str("def tamper4 : IntDispatchRawPlan := { honestGauge with body := .test 3 (.hostOp .sub (0) true) (.test 4 (.hostOp .add (8) false) (.test 5 (.proj) (.default (7)))) }\n");
-    lean.push_str("example : lowerIntDispatchCodeEntry 9 tbl tamper4 ≠ lowerIntDispatchCodeEntry 9 tbl honestGauge := by decide\n");
-    lean.push_str("def tamper5 : IntDispatchRawPlan := { honestGauge with body := .test 3 (.hostOp .sub (0) true) (.test 4 (.hostOp .add (9) true) (.test 5 (.proj) (.default (7)))) }\n");
-    lean.push_str("example : lowerIntDispatchCodeEntry 9 tbl tamper5 ≠ lowerIntDispatchCodeEntry 9 tbl honestGauge := by decide\n");
-    lean.push_str("def tamper6 : IntDispatchRawPlan := { honestGauge with body := .test 3 (.hostOp .sub (0) true) (.test 4 (.hostOp .add (9) false) (.test 5 (.proj) (.default (8)))) }\n");
-    lean.push_str("example : lowerIntDispatchCodeEntry 9 tbl tamper6 ≠ lowerIntDispatchCodeEntry 9 tbl honestGauge := by decide\n");
+    lean.push_str("def tamper1 : IntDispatchRawPlan := { honestBox with body := .test 2 (.proj) (.default (0)) }\n");
+    lean.push_str("example : lowerIntDispatchCodeEntry 11 tbl tamper1 ≠ lowerIntDispatchCodeEntry 11 tbl honestBox := by decide\n");
+    lean.push_str("def tamper2 : IntDispatchRawPlan := { honestGauge with body := .test 6 (.hostOp .sub (0) true) (.test 5 (.hostOp .add (9) false) (.test 7 (.proj) (.default (7)))) }\n");
+    lean.push_str("example : lowerIntDispatchCodeEntry 11 tbl tamper2 ≠ lowerIntDispatchCodeEntry 11 tbl honestGauge := by decide\n");
+    lean.push_str("def tamper3 : IntDispatchRawPlan := { honestGauge with body := .test 5 (.hostOp .add (0) true) (.test 6 (.hostOp .add (9) false) (.test 7 (.proj) (.default (7)))) }\n");
+    lean.push_str("example : lowerIntDispatchCodeEntry 11 tbl tamper3 ≠ lowerIntDispatchCodeEntry 11 tbl honestGauge := by decide\n");
+    lean.push_str("def tamper4 : IntDispatchRawPlan := { honestGauge with body := .test 5 (.hostOp .sub (0) true) (.test 6 (.hostOp .add (8) false) (.test 7 (.proj) (.default (7)))) }\n");
+    lean.push_str("example : lowerIntDispatchCodeEntry 11 tbl tamper4 ≠ lowerIntDispatchCodeEntry 11 tbl honestGauge := by decide\n");
+    lean.push_str("def tamper5 : IntDispatchRawPlan := { honestGauge with body := .test 5 (.hostOp .sub (0) true) (.test 6 (.hostOp .add (9) true) (.test 7 (.proj) (.default (7)))) }\n");
+    lean.push_str("example : lowerIntDispatchCodeEntry 11 tbl tamper5 ≠ lowerIntDispatchCodeEntry 11 tbl honestGauge := by decide\n");
+    lean.push_str("def tamper6 : IntDispatchRawPlan := { honestGauge with body := .test 5 (.hostOp .sub (0) true) (.test 6 (.hostOp .add (9) false) (.test 7 (.proj) (.default (8)))) }\n");
+    lean.push_str("example : lowerIntDispatchCodeEntry 11 tbl tamper6 ≠ lowerIntDispatchCodeEntry 11 tbl honestGauge := by decide\n");
     // Profile vector: the lowering is BLIND to the profile string, so the byte
     // gate alone would accept it — only the structural checker rejects it.
     lean.push_str(
         "def tamper7 : IntDispatchRawPlan := { honestBox with profile := \"int-dispatch-v2\" }\n",
     );
-    lean.push_str("example : lowerIntDispatchCodeEntry 9 tbl tamper7 = lowerIntDispatchCodeEntry 9 tbl honestBox := rfl\n");
+    lean.push_str("example : lowerIntDispatchCodeEntry 11 tbl tamper7 = lowerIntDispatchCodeEntry 11 tbl honestBox := rfl\n");
     lean.push_str("example : AverCert.PlanCheck.checkIntDispatchRawPlan tamper7 = false := rfl\n");
 
     let honest_build = Command::new("lake")
@@ -4927,7 +4927,7 @@ fn cert_verify_declines_tampered_int_dispatch_plan() {
 ///
 /// SIGNATURE guard (`verbatimFuncTypeMatches … carrier`, reused with the Int
 /// carrier as the result heap type): two minimal modules identical in every
-/// section EXCEPT the type section (the second appends a second `eqref`
+/// section EXCEPT the type section (the second appends a second nominal-root
 /// parameter). The func/export/code sections — hence the byte-derived
 /// `FuncBinding` and code entry the byte-equality gate reads — are
 /// byte-for-byte identical, so the two sibling conjuncts
@@ -5094,15 +5094,15 @@ example : sourceAccepted honestPrependSym permutedPrepend = false := rfl
 
 -- TypeAttack: the claimed element representation is read from both the list
 -- struct and the exported signature. A coherent symbolic relabel cannot turn
--- the fixture's concrete `(ref null 36)` element into another byte type.
+-- the fixture's concrete `(ref null 39)` element into another byte type.
 example : AverCert.WasmSlice.listConstructStructTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 25 (.nullableRef 36) = true := rfl
+    AverCert.ArtifactBytes.wasmBytes 28 (.nullableRef 39) = true := rfl
 example : AverCert.WasmSlice.listConstructFuncTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 60 1 25 (.nullableRef 36) = true := rfl
+    AverCert.ArtifactBytes.wasmBytes 63 1 28 (.nullableRef 39) = true := rfl
 example : AverCert.WasmSlice.listConstructStructTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 25 .eqref = false := rfl
+    AverCert.ArtifactBytes.wasmBytes 28 .eqref = false := rfl
 example : AverCert.WasmSlice.listConstructFuncTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 60 1 25 .eqref = false := rfl
+    AverCert.ArtifactBytes.wasmBytes 63 1 28 .eqref = false := rfl
 
 -- CountAttack: predicate-level copy of constructPlanAccepted dropping ONLY
 -- `plan.fields.length = fieldCount`.
@@ -5267,8 +5267,8 @@ fn int_dispatch_kernel_guards_are_isolating() {
     lean.push_str("set_option maxRecDepth 100000\n\n");
     // Minimal modules: header, type section, then a shared func/export/code
     // tail. `f` is func 0 of type 0; code entry `[2, 0, 11]`. Only the type
-    // section differs between the two: type 0 is `[eqref] -> [(ref null 5)]`
-    // vs `[eqref, eqref] -> [(ref null 5)]` (5 standing for the carrier).
+    // section differs between the two: type 0 is one nominal-root ref ->
+    // `[(ref null 5)]` vs two nominal-root refs -> `[(ref null 5)]`.
     // NOTE: these hand-built modules have a result-bearing signature with a
     // body returning nothing, so they would FAIL the wasmparser `validate_all`
     // chokepoint — they demonstrate slicer/guard DISCRIMINATION only, not
@@ -5276,8 +5276,8 @@ fn int_dispatch_kernel_guards_are_isolating() {
     // `cert_verify_declines_tampered_int_dispatch_plan` close the end-to-end
     // gap on a real validated artifact.
     lean.push_str("def hdr : List Nat := [0, 97, 115, 109, 1, 0, 0, 0]\n");
-    lean.push_str("def unaryType : List Nat := [1, 7, 1, 96, 1, 109, 1, 99, 5]\n");
-    lean.push_str("def binaryType : List Nat := [1, 8, 1, 96, 2, 109, 109, 1, 99, 5]\n");
+    lean.push_str("def unaryType : List Nat := [1, 8, 1, 96, 1, 99, 4, 1, 99, 5]\n");
+    lean.push_str("def binaryType : List Nat := [1, 10, 1, 96, 2, 99, 4, 99, 4, 1, 99, 5]\n");
     lean.push_str(
         "def tailSecs : List Nat := [3, 2, 1, 0, 7, 5, 1, 1, 102, 0, 0, 10, 4, 1, 2, 0, 11]\n",
     );
@@ -5341,21 +5341,21 @@ fn int_dispatch_kernel_guards_are_isolating() {
         "  | none => none\n\n",
     ));
     // The permuted (plan, table) pair lowers BYTE-IDENTICALLY...
-    lean.push_str("example : PlanBytes.lowerIntDispatchCodeEntry 9 permTbl permGauge = PlanBytes.lowerIntDispatchCodeEntry 9 honestTbl honestGauge := rfl\n");
+    lean.push_str("example : PlanBytes.lowerIntDispatchCodeEntry 11 permTbl permGauge = PlanBytes.lowerIntDispatchCodeEntry 11 honestTbl honestGauge := rfl\n");
     // ...and every sibling guard is blind to the permutation...
     lean.push_str("example : PlanCheck.checkIntDispatchRawPlan permGauge = true := rfl\n");
     lean.push_str("example : PlanCheck.hostTableIndicesDistinct permTbl = true := rfl\n");
     // ...the honest tables close the equality by `rfl` (whole-builder defeq,
     // incl. the box-only widened match)...
-    lean.push_str("example : AverCert.gaugeOb.host = AcceptedArtifact.intDispatchCanonicalHost 9 honestTbl := rfl\n");
-    lean.push_str("example : AverCert.boxIntOb.host = AcceptedArtifact.intDispatchCanonicalHost 9 [(.box, 7)] := rfl\n");
+    lean.push_str("example : AverCert.gaugeOb.host = AcceptedArtifact.intDispatchCanonicalHost 11 honestTbl := rfl\n");
+    lean.push_str("example : AverCert.boxIntOb.host = AcceptedArtifact.intDispatchCanonicalHost 11 [(.box, 7)] := rfl\n");
     // ...and ONLY the equality conjunct rejects the permuted table: the honest
     // obligation wires index 8 to the add slot, the permuted canonical wires it
     // to sub, and `hostBuilderProbe` exhibits the divergence.
     lean.push_str("example : hostBuilderProbe AverCert.gaugeOb.host 8 [] = some 1 := rfl\n");
-    lean.push_str("example : hostBuilderProbe (AcceptedArtifact.intDispatchCanonicalHost 9 permTbl) 8 [] = some 2 := rfl\n");
+    lean.push_str("example : hostBuilderProbe (AcceptedArtifact.intDispatchCanonicalHost 11 permTbl) 8 [] = some 2 := rfl\n");
     lean.push_str(concat!(
-        "example : AverCert.gaugeOb.host ≠ AcceptedArtifact.intDispatchCanonicalHost 9 permTbl := by\n",
+        "example : AverCert.gaugeOb.host ≠ AcceptedArtifact.intDispatchCanonicalHost 11 permTbl := by\n",
         "  intro h\n",
         "  have honest : hostBuilderProbe AverCert.gaugeOb.host 8 [] = some 1 := rfl\n",
         "  rw [h] at honest\n",
@@ -5373,18 +5373,18 @@ fn int_dispatch_kernel_guards_are_isolating() {
         "  fun _ _ _ _ _ => fun fn =>\n",
         "    if fn = 7 then\n",
         "      some (1, fun args => match args with\n",
-        "        | [WVal.i64v 0] => CertPrelude.boxRef 9 args\n",
+        "        | [WVal.i64v 0] => CertPrelude.boxRef 11 args\n",
         "        | _ => none)\n",
         "    else none\n",
     ));
     // At the probe point the sneaky builder is indistinguishable from canonical...
-    lean.push_str("example : hostBuilderProbe sneakyBoxHost 7 [.i64v 0] = hostBuilderProbe (AcceptedArtifact.intDispatchCanonicalHost 9 [(.box, 7)]) 7 [.i64v 0] := rfl\n");
+    lean.push_str("example : hostBuilderProbe sneakyBoxHost 7 [.i64v 0] = hostBuilderProbe (AcceptedArtifact.intDispatchCanonicalHost 11 [(.box, 7)]) 7 [.i64v 0] := rfl\n");
     // ...but it traps on a real constant where canonical boxes it...
     lean.push_str("example : hostBuilderProbe sneakyBoxHost 7 [.i64v 7] = none := rfl\n");
-    lean.push_str("example : hostBuilderProbe (AcceptedArtifact.intDispatchCanonicalHost 9 [(.box, 7)]) 7 [.i64v 7] = some 1007 := rfl\n");
+    lean.push_str("example : hostBuilderProbe (AcceptedArtifact.intDispatchCanonicalHost 11 [(.box, 7)]) 7 [.i64v 7] = some 1007 := rfl\n");
     // ...so the extensional equality rejects it.
     lean.push_str(concat!(
-        "example : sneakyBoxHost ≠ AcceptedArtifact.intDispatchCanonicalHost 9 [(.box, 7)] := by\n",
+        "example : sneakyBoxHost ≠ AcceptedArtifact.intDispatchCanonicalHost 11 [(.box, 7)] := by\n",
         "  intro h\n",
         "  have sneaky : hostBuilderProbe sneakyBoxHost 7 [.i64v 7] = none := rfl\n",
         "  rw [h] at sneaky\n",

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -167,3 +167,89 @@ fn wasm_gc_codegen_emits_valid_module_for_every_single_file_example() {
         compiled
     );
 }
+
+#[test]
+fn json_sum_uses_nominal_root_in_variants_tuple_and_dispatch() {
+    use wasmparser::{CompositeInnerType, Operator, Parser as WasmParser, Payload, StorageType};
+
+    let source = fs::read_to_string(examples_dir().join("data/json.av")).unwrap();
+    let items = parse_pipeline(&source).unwrap();
+    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None).unwrap();
+    wasmparser::Validator::new().validate_all(&bytes).unwrap();
+
+    let mut types = Vec::new();
+    let mut dispatch_targets = Vec::new();
+    for payload in WasmParser::new(0).parse_all(&bytes) {
+        match payload.unwrap() {
+            Payload::TypeSection(reader) => {
+                for group in reader {
+                    types.extend(group.unwrap().into_types());
+                }
+            }
+            Payload::CodeSectionEntry(body) => {
+                let mut ops = body.get_operators_reader().unwrap();
+                while !ops.eof() {
+                    match ops.read().unwrap() {
+                        Operator::RefTestNonNull { hty }
+                        | Operator::RefTestNullable { hty }
+                        | Operator::RefCastNonNull { hty }
+                        | Operator::RefCastNullable { hty } => {
+                            if let wasmparser::HeapType::Concrete(idx)
+                            | wasmparser::HeapType::Exact(idx) = hty
+                                && let Some(idx) = idx.as_module_index()
+                            {
+                                dispatch_targets.push(idx);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let root = &types[0];
+    assert!(!root.is_final, "Json root must be non-final");
+    assert!(
+        root.supertype_idx.is_none(),
+        "Json root must have no parent"
+    );
+    assert!(matches!(
+        &root.composite_type.inner,
+        CompositeInnerType::Struct(st) if st.fields.is_empty()
+    ));
+    for variant in &types[1..=6] {
+        assert!(variant.is_final, "Json variants remain final");
+        assert_eq!(
+            variant.supertype_idx.and_then(|idx| idx.as_module_index()),
+            Some(0),
+            "every Json variant must subtype the Json root"
+        );
+    }
+
+    let tuple_holds_json_root = types.iter().any(|sub| {
+        let CompositeInnerType::Struct(st) = &sub.composite_type.inner else {
+            return false;
+        };
+        if st.fields.len() != 2 {
+            return false;
+        }
+        matches!(
+            st.fields[1].element_type,
+            StorageType::Val(wasmparser::ValType::Ref(rt))
+                if rt.is_nullable()
+                    && matches!(rt.heap_type(), wasmparser::HeapType::Concrete(idx)
+                        if idx.as_module_index() == Some(0))
+        )
+    });
+    assert!(
+        tuple_holds_json_root,
+        "Tuple<String, Json> field 1 must be `(ref null $Json)`, not eqref"
+    );
+    assert!(!dispatch_targets.is_empty());
+    assert!(
+        dispatch_targets.iter().all(|idx| *idx != 0),
+        "specific pattern tests/casts must target concrete variants, not the sum root"
+    );
+}

--- a/tools/certkit/fixtures/manytypes.av
+++ b/tools/certkit/fixtures/manytypes.av
@@ -1,9 +1,9 @@
 module ManyTypes
     intent =
-        "Boundary probe: 62 user variant structs push the Int carrier to wasm"
+        "Boundary probe: 16 nominal sum roots plus 46 variant structs push the Int carrier to wasm"
         "type index 64, the first index whose s33 heap-type encoding differs"
         "from unsigned LEB (c0 00, not 40)."
-    exposes [T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, sumBig]
+    exposes [T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, sumBig]
 
 type T0
   A0(Int)
@@ -82,32 +82,6 @@ type T14
 
 type T15
   A15(Int)
-  B15(Int)
-  C15(Int)
-
-type T16
-  A16(Int)
-  B16(Int)
-  C16(Int)
-
-type T17
-  A17(Int)
-  B17(Int)
-  C17(Int)
-
-type T18
-  A18(Int)
-  B18(Int)
-  C18(Int)
-
-type T19
-  A19(Int)
-  B19(Int)
-  C19(Int)
-
-type T20
-  A20(Int)
-  B20(Int)
 
 fn sumBig(n: Int) -> Int
   ? "Sum 1..n, plain recursion, over a big type section."


### PR DESCRIPTION
## Summary
- Each sum type declares an empty non-final root struct in the same rec group as its constructors; every constructor struct is emitted as a final subtype of that root.
- Sum-typed parameters, locals, and struct fields use a concrete nullable reference to the root instead of the abstract `eqref`, so container payloads keep their source type family in the binary's type section (e.g. `Tuple<String, Json>` field 1 is now `(ref null $Json)`).
- The certificate kernel (`checkVerbatimFuncType`) and the Rust classifiers follow the new signature shape: one nullable concrete root parameter instead of `eqref`. Full wasm validation establishes the variant-to-root subtype relationship.
- Certificate schema bumps to 43.

## Measurements
- Allocation sites and hot-path instruction lines are unchanged across all eight example games and the JSON example; optimized module size grows 0–1.1% (type section only).
- Aggregate compile time across the games is unchanged (1.177s main vs branch); runtime harness deltas are within noise.

## Testing
- `cargo fmt --check`, `cargo build --bin aver --features wasm`, `cargo clippy --features wasm,wasip2 -- -D warnings`
- `cargo test -p aver-lang --features wasm --lib` (1019 passed)
- `wasm_gc_codegen_regression` (72 examples compiled/validated, new JSON nominal-root regression)
- `cert_certify_spec` (11), `cert_decode_spec` (2), `cert_verify_spec` (29)
- Explicit `wasm-tools validate` on all example games and JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)