### PR TITLE
Bound s33 parsing to the wasm spec in the certificate kernel

### DIFF
--- a/src/codegen/cert/WasmSlice.lean
+++ b/src/codegen/cert/WasmSlice.lean
@@ -92,8 +92,16 @@ def readSlebFuel : Nat → Nat → Int → ByteSeq → Option (Int × ByteSeq)
       else
         none
 
+/-- Read a spec-bounded s33: at most five bytes and in the signed 33-bit range
+    `-(2^32) ≤ v < 2^32`; the range check closes the final byte's unused bits. -/
 def readS33 (bytes : ByteSeq) : Option (Int × ByteSeq) :=
-  readSlebFuel 6 0 0 bytes
+  match readSlebFuel 5 0 0 bytes with
+  | some (v, rest) =>
+      if -(Int.ofNat (2 ^ 32)) ≤ v ∧ v < Int.ofNat (2 ^ 32) then
+        some (v, rest)
+      else
+        none
+  | none => none
 
 /-! ### Type-section navigation
 

--- a/src/codegen/cert/disasm_hosts.rs
+++ b/src/codegen/cert/disasm_hosts.rs
@@ -239,9 +239,9 @@ fn resolve_data_ops(ops: Vec<Op>, data_segments: &[Option<Vec<u8>>]) -> Vec<Op> 
 
 fn heap_type_index(hty: wasmparser::HeapType) -> Option<u32> {
     match hty {
-        wasmparser::HeapType::Concrete(idx) | wasmparser::HeapType::Exact(idx) => {
-            idx.as_module_index()
-        }
+        wasmparser::HeapType::Concrete(idx) => idx.as_module_index(),
+        // Kernel parity: exact references are not plain 0x63 s33 refs.
+        wasmparser::HeapType::Exact(_) => None,
         wasmparser::HeapType::Abstract { .. } => None,
     }
 }

--- a/src/codegen/cert/disasm_module.rs
+++ b/src/codegen/cert/disasm_module.rs
@@ -86,6 +86,8 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
                                                 ty: wasmparser::AbstractHeapType::Eq,
                                                 ..
                                             } => TyKind::Eqref,
+                                            // Kernel parity: exact references are not plain 0x63 s33 refs.
+                                            wasmparser::HeapType::Exact(_) => TyKind::Other,
                                             _ => TyKind::Other,
                                         },
                                     },

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -65,7 +65,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 43;
+pub const CERT_SCHEMA_VERSION: u32 = 44;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -4547,6 +4547,15 @@ fn verbatim_kernel_guards_are_isolating() {
     lean.push_str("example : WasmSlice.dataSegmentBytes dataCountMismatchMod 0 = none := rfl\n");
     // Over-wide (6-byte) unsigned LEB32 exceeds the u32 width cap and declines.
     lean.push_str("example : WasmSlice.readUleb32 [128, 128, 128, 128, 128, 0] = none := rfl\n");
+    lean.push_str("example : WasmSlice.readS33 [128, 128, 128, 128, 128, 0] = none := rfl\n");
+    lean.push_str(
+        "example : WasmSlice.readS33 [255, 255, 255, 255, 15] = some (4294967295, []) := rfl\n",
+    );
+    lean.push_str("example : WasmSlice.readS33 [128, 128, 128, 128, 16] = none := rfl\n");
+    lean.push_str(
+        "example : WasmSlice.readS33 [128, 128, 128, 128, 112] = some (-4294967296, []) := rfl\n",
+    );
+    lean.push_str("example : WasmSlice.readS33 [128, 128, 128, 128, 96] = none := rfl\n");
 
     // F64 RESULT-KIND isolation. These two tiny modules have identical
     // func/export/code sections and differ only in the byte-derived type result:


### PR DESCRIPTION
## Summary
- `readS33` now reads at most five bytes (the wasm spec bound for s33) and requires `-(2^32) <= v < 2^32`; the range check also closes the final byte's unused-bit freedom. Previously six-byte encodings and out-of-range values were accepted (not an admission bypass — full wasm validation rejects such modules before certification — but the kernel parser should be strict on its own).
- Boundary rfl vectors join the parser-strictness examples: six-byte rejection, both range limits accepted at exactly five bytes, one-past-limit rejected on both sides.
- The disassembler no longer folds exact references into concrete type indices (`heap_type_index` returns `None` for `HeapType::Exact`), keeping classifier admission no wider than the kernel gate, which rejects the exact-reference prefix as a negative s33. Currently unreachable under the validator configuration; defense in depth.
- Certificate schema bumps to 44.

Both items were flagged as non-blocking hardening follow-ups in the cross-vendor review of #701.

## Testing
- `cargo fmt --check`, `cargo build --bin aver --features wasm`, `cargo clippy --features wasm,wasip2 -- -D warnings`
- `cargo test -p aver-lang --features wasm --lib` (1019 passed)
- `cert_verify_spec verbatim_kernel_guards_are_isolating` (Lean kernel elaborates all new vectors)
- `cert_certify_spec` (11 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)