### PR TITLE
Represent the module as one big-Nat in the certificate kernel

### DIFF
--- a/src/codegen/cert/AcceptedArtifactCore.lean
+++ b/src/codegen/cert/AcceptedArtifactCore.lean
@@ -27,7 +27,8 @@ def exprFragmentNLocals (_plan : ExprFragmentRawPlan) : Nat := 1
     quantified rather than accepted as checker-rendered parameters. This is the
     v2-shaped API: raw artifact bytes + raw plan + schema obligation. -/
 def exprFragmentPlanAccepted
-    (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
     (carrier : Nat)
     (plan : ExprFragmentRawPlan)
@@ -36,7 +37,7 @@ def exprFragmentPlanAccepted
   obligation.carrier = carrier ∧
   ∃ body codeEntry binding,
     AverCert.ExprFragmentAccepted.accepted
-      wasmBytes exportNameBytes carrier plan body codeEntry binding ∧
+      modBytes modLen exportNameBytes carrier plan body codeEntry binding ∧
     obligation.self = binding.funcIdx ∧
     obligation.code binding.funcIdx =
       some { arity := plan.params.length,
@@ -47,7 +48,8 @@ def exprFragmentPlanAccepted
     accept it and produce the representation-level expr-fragment plan before
     the existing byte-origin predicate is allowed to run. -/
 def symFragmentPlanAccepted
-    (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
     (carrier : Nat)
     (hostTable : List (HostRole × Nat))
@@ -58,7 +60,7 @@ def symFragmentPlanAccepted
       hostTable structTable plan with
   | some exprPlan =>
       exprFragmentPlanAccepted
-        wasmBytes exportNameBytes exportName carrier exprPlan obligation
+        modBytes modLen exportNameBytes exportName carrier exprPlan obligation
   | none => False
 
 /-- One source-level symbolic fragment claim inside an artifact certificate.
@@ -78,10 +80,10 @@ structure SymFragmentClaim where
   obligation      : Obligation
 
 def symFragmentClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (claim : SymFragmentClaim) : Prop :=
   symFragmentPlanAccepted
-    wasmBytes
+    modBytes modLen
     claim.exportNameBytes
     claim.exportName
     claim.carrier
@@ -99,7 +101,8 @@ def stringConcatNLocals (_plan : StringConcatRawPlan) : Nat := 1
     lowerers rebuild both the semantic `WInstr` body and exact code-entry bytes,
     and the Wasm slicer binds those bytes to the exported function. -/
 def stringConcatPlanAccepted
-    (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
     (carrier resultTy containerTy concatFuncIdx : Nat)
     (symPlan : SymRawPlan)
@@ -115,14 +118,14 @@ def stringConcatPlanAccepted
       resultTy containerTy concatFuncIdx plan = some body ∧
     AverCert.PlanBytes.lowerStringConcatCodeEntry
       carrier resultTy containerTy concatFuncIdx plan = some codeEntry ∧
-    AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+    AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
     binding.codeEntry = codeEntry ∧
     obligation.self = binding.funcIdx ∧
     obligation.code binding.funcIdx =
       some { arity := 1, nlocals := stringConcatNLocals plan, body := body }
 
 def stringEqPlanAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
     (carrier stringTy stringEqFuncIdx : Nat)
@@ -138,8 +141,8 @@ def stringEqPlanAccepted
       AverCert.PlanLower.lowerStringEqBody stringTy stringEqFuncIdx plan = some body ∧
       AverCert.PlanBytes.lowerStringEqCodeEntry carrier stringTy stringEqFuncIdx plan =
         some codeEntry ∧
-      AverCert.WasmSlice.codeEntryForExport wasmBytes exportNameBytes = some codeEntry ∧
-      AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+      AverCert.WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+      AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
       binding.funcIdx = obligation.self ∧
       binding.codeEntry = codeEntry ∧
       obligation.code binding.funcIdx =
@@ -321,13 +324,13 @@ structure CompositionClaim where
   obligation      : Obligation
 
 def stringEqClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest)
     (claim : StringEqClaim) : Prop :=
   match stringEqPlanForExport claim.exportName manifest.stringEqPlans with
   | some plan =>
       stringEqPlanAccepted
-        wasmBytes
+        modBytes modLen
         claim.exportNameBytes
         claim.exportName
         claim.carrier
@@ -339,13 +342,13 @@ def stringEqClaimAccepted
   | none => False
 
 def stringConcatClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest)
     (claim : StringConcatClaim) : Prop :=
   match stringConcatPlanForExport claim.exportName manifest.stringConcatPlans with
   | some plan =>
       stringConcatPlanAccepted
-        wasmBytes
+        modBytes modLen
         claim.exportNameBytes
         claim.exportName
         claim.carrier
@@ -367,7 +370,7 @@ def isListConstructSymPlan (symPlan : SymRawPlan) : Bool :=
   | _ => false
 
 def constructPlanAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
     (carrier : Nat)
@@ -385,27 +388,27 @@ def constructPlanAccepted
     ∃ body codeEntry binding,
       AverCert.PlanLower.lowerConstructBody structIdx plan = some body ∧
       AverCert.PlanBytes.lowerConstructCodeEntry carrier structIdx plan = some codeEntry ∧
-      AverCert.WasmSlice.codeEntryForExport wasmBytes exportNameBytes = some codeEntry ∧
-      AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+      AverCert.WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+      AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
       binding.funcIdx = obligation.self ∧
       binding.codeEntry = codeEntry ∧
       (isListConstructSymPlan symPlan = false ∨
         AverCert.WasmSlice.listConstructStructTypeMatches
-          wasmBytes structIdx elemTy = true) ∧
+          modBytes modLen structIdx elemTy = true) ∧
       (isListConstructSymPlan symPlan = false ∨
         AverCert.WasmSlice.listConstructFuncTypeMatches
-          wasmBytes binding.typeIdx plan.arity structIdx elemTy = true) ∧
+          modBytes modLen binding.typeIdx plan.arity structIdx elemTy = true) ∧
       obligation.code binding.funcIdx =
         some { arity := plan.arity, nlocals := 1, body := body }
 
 def constructClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest)
     (claim : ConstructClaim) : Prop :=
   match constructPlanForExport claim.exportName manifest.constructPlans with
   | some plan =>
       constructPlanAccepted
-        wasmBytes
+        modBytes modLen
         claim.exportNameBytes
         claim.exportName
         claim.carrier
@@ -432,7 +435,8 @@ def recursionNLocals (_plan : RecursionRawPlan) : Nat := 1
     The self index is additionally tied to the obligation through
     `binding.funcIdx = obligation.self`. -/
 def recursionPlanAccepted
-    (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
     (carrier : Nat)
     (hostTable : List (HostRole × Nat))
@@ -444,13 +448,13 @@ def recursionPlanAccepted
     ∃ body codeEntry binding,
       AverCert.PlanLower.lowerRecursionBody carrier plan = some body ∧
       AverCert.PlanBytes.lowerRecursionCodeEntry carrier plan = some codeEntry ∧
-      AverCert.WasmSlice.codeEntryForExport wasmBytes exportNameBytes = some codeEntry ∧
-      AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+      AverCert.WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+      AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
       binding.funcIdx = obligation.self ∧
       binding.codeEntry = codeEntry ∧
       AverCert.PlanCheck.checkRecursionPlanShape binding.funcIdx hostTable plan = true ∧
       AverCert.WasmSlice.funcTypeMatches
-        wasmBytes binding.typeIdx plan.params.length carrier = true ∧
+        modBytes modLen binding.typeIdx plan.params.length carrier = true ∧
       obligation.code binding.funcIdx =
         some { arity := plan.params.length,
                nlocals := recursionNLocals plan, body := body }
@@ -466,13 +470,13 @@ def recursionPlanForExport
         recursionPlanForExport exportName rest
 
 def recursionClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest)
     (claim : RecursionClaim) : Prop :=
   match recursionPlanForExport claim.exportName manifest.recursionPlans with
   | some plan =>
       recursionPlanAccepted
-        wasmBytes
+        modBytes modLen
         claim.exportNameBytes
         claim.exportName
         claim.carrier
@@ -497,7 +501,8 @@ def mutualNLocals (_plan : MutualRawPlan) : Nat := 1
     `obligation.code binding.funcIdx` picks this member's arm out of the shared
     multi-arm code table. -/
 def mutualPlanAccepted
-    (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
     (carrier : Nat)
     (memberSet : List Nat)
@@ -510,13 +515,13 @@ def mutualPlanAccepted
     ∃ body codeEntry binding,
       AverCert.PlanLower.lowerMutualBody carrier plan = some body ∧
       AverCert.PlanBytes.lowerMutualCodeEntry carrier plan = some codeEntry ∧
-      AverCert.WasmSlice.codeEntryForExport wasmBytes exportNameBytes = some codeEntry ∧
-      AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+      AverCert.WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+      AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
       binding.funcIdx = obligation.self ∧
       binding.codeEntry = codeEntry ∧
       AverCert.PlanCheck.checkMutualPlanShape memberSet hostTable plan = true ∧
       AverCert.WasmSlice.funcTypeMatches
-        wasmBytes binding.typeIdx plan.params.length carrier = true ∧
+        modBytes modLen binding.typeIdx plan.params.length carrier = true ∧
       obligation.code binding.funcIdx =
         some { arity := plan.params.length,
                nlocals := mutualNLocals plan, body := body }
@@ -532,13 +537,13 @@ def mutualPlanForExport
         mutualPlanForExport exportName rest
 
 def mutualRecursionClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest)
     (claim : MutualRecursionClaim) : Prop :=
   match mutualPlanForExport claim.exportName manifest.mutualPlans with
   | some plan =>
       mutualPlanAccepted
-        wasmBytes
+        modBytes modLen
         claim.exportNameBytes
         claim.exportName
         claim.carrier
@@ -553,9 +558,9 @@ def mutualRecursionClaimAccepted
     exact contents of passive data segment `dataIdx` recovered from the module's
     data section. Every other leaf trivially satisfies the binding. -/
 def verbatimLeafPayloadBound
-    (wasmBytes : AverCert.WasmSlice.ByteSeq) : VerbatimLeaf → Bool
+    (modBytes modLen : Nat) : VerbatimLeaf → Bool
   | .arrayNewData _ dataIdx bytes =>
-      match AverCert.WasmSlice.dataSegmentBytes wasmBytes dataIdx with
+      match AverCert.WasmSlice.dataSegmentBytes modBytes modLen dataIdx with
       | some contents => contents == bytes
       | none => false
   | _ => true
@@ -566,10 +571,11 @@ def verbatimLeafPayloadBound
     payload substitution keeps the code entry byte-identical while changing what
     the plan (hence the model) claims. -/
 def verbatimPayloadsBound
-    (wasmBytes : AverCert.WasmSlice.ByteSeq) : VerbatimDispatch → Bool
-  | .leaf l => verbatimLeafPayloadBound wasmBytes l
+    (modBytes modLen : Nat) : VerbatimDispatch → Bool
+  | .leaf l => verbatimLeafPayloadBound modBytes modLen l
   | .test _ hit rest =>
-      verbatimLeafPayloadBound wasmBytes hit && verbatimPayloadsBound wasmBytes rest
+      verbatimLeafPayloadBound modBytes modLen hit &&
+        verbatimPayloadsBound modBytes modLen rest
 
 /-- Canonical locals count declared by `lowerVerbatimLocalsBytes`: projecting
     plans declare the field scratch, scrutinee, and carrier locals; all other
@@ -594,7 +600,8 @@ def verbatimNLocals (plan : VerbatimRawPlan) : Nat :=
     byte-equality gate. The member index is tied to the obligation through
     `binding.funcIdx = obligation.self`. -/
 def verbatimPlanAccepted
-    (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
     (carrier : Nat)
     (plan : VerbatimRawPlan)
@@ -604,13 +611,13 @@ def verbatimPlanAccepted
     AverCert.PlanCheck.checkVerbatimRawPlan plan = true ∧
     ∃ codeEntry binding,
       AverCert.PlanBytes.lowerVerbatimCodeEntry carrier plan = some codeEntry ∧
-      AverCert.WasmSlice.codeEntryForExport wasmBytes exportNameBytes = some codeEntry ∧
-      AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+      AverCert.WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+      AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
       binding.funcIdx = obligation.self ∧
       binding.codeEntry = codeEntry ∧
       AverCert.WasmSlice.verbatimFuncTypeMatches
-        wasmBytes binding.typeIdx plan.resultSig = true ∧
-      verbatimPayloadsBound wasmBytes plan.body = true ∧
+        modBytes modLen binding.typeIdx plan.resultSig = true ∧
+      verbatimPayloadsBound modBytes modLen plan.body = true ∧
       obligation.code binding.funcIdx =
         some { arity := 1, nlocals := verbatimNLocals plan,
                body := AverCert.PlanLower.lowerVerbatimBody plan }
@@ -626,13 +633,13 @@ def verbatimPlanForExport
         verbatimPlanForExport exportName rest
 
 def verbatimClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest)
     (claim : VerbatimClaim) : Prop :=
   match verbatimPlanForExport claim.exportName manifest.verbatimPlans with
   | some plan =>
       verbatimPlanAccepted
-        wasmBytes
+        modBytes modLen
         claim.exportNameBytes
         claim.exportName
         claim.carrier
@@ -707,7 +714,8 @@ def intDispatchCanonicalHost
     artifact claim a 0-locals table whose body traps on its first `local.set`,
     making the partial-correctness obligation vacuously true. -/
 def intDispatchPlanAccepted
-    (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String)
     (carrier : Nat)
     (hostTable : List (HostRole × Nat))
@@ -722,12 +730,12 @@ def intDispatchPlanAccepted
       AverCert.PlanLower.lowerIntDispatchBody hostTable plan = some body ∧
       AverCert.PlanBytes.lowerIntDispatchCodeEntry carrier hostTable plan =
         some codeEntry ∧
-      AverCert.WasmSlice.codeEntryForExport wasmBytes exportNameBytes = some codeEntry ∧
-      AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+      AverCert.WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+      AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
       binding.funcIdx = obligation.self ∧
       binding.codeEntry = codeEntry ∧
       AverCert.WasmSlice.verbatimFuncTypeMatches
-        wasmBytes binding.typeIdx (.refNull carrier) = true ∧
+        modBytes modLen binding.typeIdx (.refNull carrier) = true ∧
       obligation.code binding.funcIdx =
         some { arity := 1,
                nlocals := AverCert.PlanCheck.intDispatchArmCount plan.body + 2,
@@ -744,13 +752,13 @@ def intDispatchPlanForExport
         intDispatchPlanForExport exportName rest
 
 def intDispatchClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest)
     (claim : IntDispatchClaim) : Prop :=
   match intDispatchPlanForExport claim.exportName manifest.intDispatchPlans with
   | some plan =>
       intDispatchPlanAccepted
-        wasmBytes
+        modBytes modLen
         claim.exportNameBytes
         claim.exportName
         claim.carrier
@@ -773,7 +781,8 @@ def fieldProjectionPlanForExport
     checker-derived struct index/count/result reference to the selected module
     field and to the exported unary function signature. -/
 def fieldProjectionPlanAccepted
-    (wasmBytes exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
     (exportName : String) (carrier structIdx fieldCount : Nat)
     (resultTy : FieldProjectionResultTy)
     (plan : FieldProjectionRawPlan) (obligation : Obligation) : Prop :=
@@ -784,23 +793,23 @@ def fieldProjectionPlanAccepted
     AverCert.PlanLower.lowerFieldProjectionBody structIdx fieldCount plan = some body ∧
     AverCert.PlanBytes.lowerFieldProjectionCodeEntry
       carrier structIdx fieldCount resultTy plan = some codeEntry ∧
-    AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+    AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
     binding.codeEntry = codeEntry ∧
     AverCert.WasmSlice.projectionStructTypeMatches
-      wasmBytes structIdx fieldCount plan.fieldIdx resultTy = true ∧
+      modBytes modLen structIdx fieldCount plan.fieldIdx resultTy = true ∧
     AverCert.WasmSlice.projectionFuncTypeMatches
-      wasmBytes binding.typeIdx structIdx resultTy = true ∧
+      modBytes modLen binding.typeIdx structIdx resultTy = true ∧
     obligation.self = binding.funcIdx ∧
     obligation.code binding.funcIdx =
       some { arity := 1, nlocals := 3, body := body }
 
 def fieldProjectionClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest)
     (claim : FieldProjectionClaim) : Prop :=
   match fieldProjectionPlanForExport claim.exportName manifest.fieldProjectionPlans with
   | some plan =>
-      fieldProjectionPlanAccepted wasmBytes claim.exportNameBytes claim.exportName
+      fieldProjectionPlanAccepted modBytes modLen claim.exportNameBytes claim.exportName
         claim.carrier claim.structIdx claim.fieldCount claim.resultTy plan claim.obligation
   | none => False
 
@@ -810,19 +819,19 @@ def fieldProjectionClaimAccepted
 def compositionNLocals (_plan : CompositionRawPlan) : Nat := 1
 
 def compositionMemberBinding
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (member : CompositionMemberClaim) : Option (String × Nat) :=
-  match AverCert.WasmSlice.funcBindingForExport wasmBytes member.exportNameBytes with
+  match AverCert.WasmSlice.funcBindingForExport modBytes modLen member.exportNameBytes with
   | some binding => some (member.exportName, binding.funcIdx)
   | none => none
 
 def compositionFuncTable
-    (wasmBytes : AverCert.WasmSlice.ByteSeq) :
+    (modBytes modLen : Nat) :
     List CompositionMemberClaim → Option (List (String × Nat))
   | [] => some []
   | member :: rest =>
-      match compositionMemberBinding wasmBytes member,
-            compositionFuncTable wasmBytes rest with
+      match compositionMemberBinding modBytes modLen member,
+            compositionFuncTable modBytes modLen rest with
       | some binding, some bindings => some (binding :: bindings)
       | _, _ => none
 
@@ -834,7 +843,7 @@ def compositionMemberForName
       else compositionMemberForName name rest
 
 def compositionMemberPlanAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (carrier : Nat)
     (hostTable : List (HostRole × Nat))
     (funcTable : List (String × Nat))
@@ -845,15 +854,15 @@ def compositionMemberPlanAccepted
     AverCert.PlanLower.lowerCompositionBody hostTable funcTable member.plan = some body ∧
     AverCert.PlanBytes.lowerCompositionCodeEntry carrier hostTable funcTable member.plan =
       some codeEntry ∧
-    AverCert.WasmSlice.codeEntryForExport wasmBytes member.exportNameBytes = some codeEntry ∧
-    AverCert.WasmSlice.funcBindingForExport wasmBytes member.exportNameBytes = some binding ∧
+    AverCert.WasmSlice.codeEntryForExport modBytes modLen member.exportNameBytes = some codeEntry ∧
+    AverCert.WasmSlice.funcBindingForExport modBytes modLen member.exportNameBytes = some binding ∧
     binding.codeEntry = codeEntry ∧
-    AverCert.WasmSlice.funcTypeMatches wasmBytes binding.typeIdx 1 carrier = true ∧
+    AverCert.WasmSlice.funcTypeMatches modBytes modLen binding.typeIdx 1 carrier = true ∧
     obligation.code binding.funcIdx =
       some { arity := 1, nlocals := compositionNLocals member.plan, body := body }
 
 def compositionNamedMembersAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (carrier : Nat)
     (hostTable : List (HostRole × Nat))
     (funcTable : List (String × Nat))
@@ -864,9 +873,9 @@ def compositionNamedMembersAccepted
       match compositionMemberForName name members with
       | some member =>
           compositionMemberPlanAccepted
-            wasmBytes carrier hostTable funcTable obligation member ∧
+            modBytes modLen carrier hostTable funcTable obligation member ∧
           compositionNamedMembersAccepted
-            wasmBytes carrier hostTable funcTable obligation members rest
+            modBytes modLen carrier hostTable funcTable obligation members rest
       | none => False
 
 def compositionPlanCallees (plan : CompositionRawPlan) : List String :=
@@ -954,129 +963,129 @@ def compositionClosureBound
      | none => false)
 
 def compositionClaimAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (members : List CompositionMemberClaim)
     (claim : CompositionClaim) : Prop :=
   claim.obligation.export_ = claim.exportName ∧
   claim.obligation.carrier = claim.carrier ∧
   AverCert.PlanCheck.checkCompositionHostTable claim.hostTable = true ∧
   claim.obligation.host = intDispatchCanonicalHost claim.carrier claim.hostTable ∧
-  match compositionFuncTable wasmBytes members with
+  match compositionFuncTable modBytes modLen members with
   | some funcTable =>
       compositionClosureBound claim.exportName claim.memberNames members funcTable = true ∧
       (match AverCert.PlanLower.compositionFuncIdx? funcTable claim.exportName with
        | some rootIdx => claim.obligation.self = rootIdx
        | none => False) ∧
-      compositionNamedMembersAccepted wasmBytes claim.carrier claim.hostTable
+      compositionNamedMembersAccepted modBytes modLen claim.carrier claim.hostTable
         funcTable claim.obligation members claim.memberNames
   | none => False
 
 /-- Aggregate source-level symbolic fragment acceptance for one artifact's
     source claim list. -/
 def symFragmentClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq) :
+    (modBytes modLen : Nat) :
     List SymFragmentClaim → Prop
   | [] => True
   | claim :: rest =>
-      symFragmentClaimAccepted wasmBytes claim ∧
-      symFragmentClaimsAccepted wasmBytes rest
+      symFragmentClaimAccepted modBytes modLen claim ∧
+      symFragmentClaimsAccepted modBytes modLen rest
 
 /-- Aggregate source-level String.concat witness acceptance for one artifact's
     string claim list. -/
 def stringConcatClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest) :
     List StringConcatClaim → Prop
   | [] => True
   | claim :: rest =>
-      stringConcatClaimAccepted wasmBytes manifest claim ∧
-      stringConcatClaimsAccepted wasmBytes manifest rest
+      stringConcatClaimAccepted modBytes modLen manifest claim ∧
+      stringConcatClaimsAccepted modBytes modLen manifest rest
 
 /-- Aggregate source-level String.eq witness acceptance for one artifact's
     string equality claim list. -/
 def stringEqClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest) :
     List StringEqClaim → Prop
   | [] => True
   | claim :: rest =>
-      stringEqClaimAccepted wasmBytes manifest claim ∧
-      stringEqClaimsAccepted wasmBytes manifest rest
+      stringEqClaimAccepted modBytes modLen manifest claim ∧
+      stringEqClaimsAccepted modBytes modLen manifest rest
 
 /-- Aggregate source-level constructor witness acceptance for one artifact's
     constructor claim list. -/
 def constructClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest) :
     List ConstructClaim → Prop
   | [] => True
   | claim :: rest =>
-      constructClaimAccepted wasmBytes manifest claim ∧
-      constructClaimsAccepted wasmBytes manifest rest
+      constructClaimAccepted modBytes modLen manifest claim ∧
+      constructClaimsAccepted modBytes modLen manifest rest
 
 /-- Aggregate fuel-recursion witness acceptance for one artifact's recursion
     claim list. -/
 def recursionClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest) :
     List RecursionClaim → Prop
   | [] => True
   | claim :: rest =>
-      recursionClaimAccepted wasmBytes manifest claim ∧
-      recursionClaimsAccepted wasmBytes manifest rest
+      recursionClaimAccepted modBytes modLen manifest claim ∧
+      recursionClaimsAccepted modBytes modLen manifest rest
 
 /-- Aggregate mutual-recursion witness acceptance for one artifact's mutual
     claim list. -/
 def mutualRecursionClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest) :
     List MutualRecursionClaim → Prop
   | [] => True
   | claim :: rest =>
-      mutualRecursionClaimAccepted wasmBytes manifest claim ∧
-      mutualRecursionClaimsAccepted wasmBytes manifest rest
+      mutualRecursionClaimAccepted modBytes modLen manifest claim ∧
+      mutualRecursionClaimsAccepted modBytes modLen manifest rest
 
 /-- Aggregate verbatim `ref.test`-dispatch acceptance for one artifact's verbatim
     claim list. -/
 def verbatimClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest) :
     List VerbatimClaim → Prop
   | [] => True
   | claim :: rest =>
-      verbatimClaimAccepted wasmBytes manifest claim ∧
-      verbatimClaimsAccepted wasmBytes manifest rest
+      verbatimClaimAccepted modBytes modLen manifest claim ∧
+      verbatimClaimsAccepted modBytes modLen manifest rest
 
 /-- Aggregate Int-face `ref.test`-dispatch acceptance for one artifact's
     int-dispatch claim list. -/
 def intDispatchClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest) :
     List IntDispatchClaim → Prop
   | [] => True
   | claim :: rest =>
-      intDispatchClaimAccepted wasmBytes manifest claim ∧
-      intDispatchClaimsAccepted wasmBytes manifest rest
+      intDispatchClaimAccepted modBytes modLen manifest claim ∧
+      intDispatchClaimsAccepted modBytes modLen manifest rest
 
 def fieldProjectionClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (manifest : AverCert.Schema.Manifest) :
     List FieldProjectionClaim → Prop
   | [] => True
   | claim :: rest =>
-      fieldProjectionClaimAccepted wasmBytes manifest claim ∧
-      fieldProjectionClaimsAccepted wasmBytes manifest rest
+      fieldProjectionClaimAccepted modBytes modLen manifest claim ∧
+      fieldProjectionClaimsAccepted modBytes modLen manifest rest
 
 /-- Aggregate composition-root acceptance. All roots share the artifact-wide
     unique member table, while each root independently re-derives its reachable
     closure and pins every reachable body into its own shared `CodeTbl`. -/
 def compositionClaimsAccepted
-    (wasmBytes : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
     (members : List CompositionMemberClaim) : List CompositionClaim → Prop
   | [] => True
   | claim :: rest =>
-      compositionClaimAccepted wasmBytes members claim ∧
-      compositionClaimsAccepted wasmBytes members rest
+      compositionClaimAccepted modBytes modLen members claim ∧
+      compositionClaimsAccepted modBytes modLen members rest
 
 /-- Every name claimed as a reachable member across all composition roots. Each
     claim's `memberNames` is pinned to its root's byte-derived reachable closure
@@ -1351,7 +1360,8 @@ def constructClaimSymPlanPairs
     the audited source encoder. Ordinary legacy obligations are still pinned by
     the verifier witness outside this artifact-level wrapper. -/
 structure ArtifactData where
-  wasmBytes          : AverCert.WasmSlice.ByteSeq
+  modBytes           : Nat
+  modLen             : Nat
   manifest           : AverCert.Schema.Manifest
   symFragmentClaims  : List SymFragmentClaim
   stringEqClaims     : List StringEqClaim
@@ -1394,36 +1404,36 @@ def manifestObligationExportsUnique (artifact : ArtifactData) : Bool :=
   stringListNodup names
 
 def acceptedSymFragments (artifact : ArtifactData) : Prop :=
-  symFragmentClaimsAccepted artifact.wasmBytes artifact.symFragmentClaims
+  symFragmentClaimsAccepted artifact.modBytes artifact.modLen artifact.symFragmentClaims
 
 def acceptedStringConcatFragments (artifact : ArtifactData) : Prop :=
   stringConcatClaimsAccepted
-    artifact.wasmBytes
+    artifact.modBytes artifact.modLen
     artifact.manifest
     artifact.stringConcatClaims
 
 def acceptedStringEqFragments (artifact : ArtifactData) : Prop :=
   stringEqClaimsAccepted
-    artifact.wasmBytes
+    artifact.modBytes artifact.modLen
     artifact.manifest
     artifact.stringEqClaims
 
 def acceptedConstructFragments (artifact : ArtifactData) : Prop :=
   constructClaimsAccepted
-    artifact.wasmBytes
+    artifact.modBytes artifact.modLen
     artifact.manifest
     artifact.constructClaims ∧
   (constructClaimExportNames artifact.constructClaims).Nodup
 
 def acceptedRecursionFragments (artifact : ArtifactData) : Prop :=
   recursionClaimsAccepted
-    artifact.wasmBytes
+    artifact.modBytes artifact.modLen
     artifact.manifest
     artifact.recursionClaims
 
 def acceptedMutualRecursionFragments (artifact : ArtifactData) : Prop :=
   mutualRecursionClaimsAccepted
-    artifact.wasmBytes
+    artifact.modBytes artifact.modLen
     artifact.manifest
     artifact.mutualRecursionClaims ∧
   mutualClaimsFormClosedSccs
@@ -1432,19 +1442,19 @@ def acceptedMutualRecursionFragments (artifact : ArtifactData) : Prop :=
 
 def acceptedVerbatimFragments (artifact : ArtifactData) : Prop :=
   verbatimClaimsAccepted
-    artifact.wasmBytes
+    artifact.modBytes artifact.modLen
     artifact.manifest
     artifact.verbatimClaims
 
 def acceptedIntDispatchFragments (artifact : ArtifactData) : Prop :=
   intDispatchClaimsAccepted
-    artifact.wasmBytes
+    artifact.modBytes artifact.modLen
     artifact.manifest
     artifact.intDispatchClaims
 
 def acceptedFieldProjectionFragments (artifact : ArtifactData) : Prop :=
   fieldProjectionClaimsAccepted
-    artifact.wasmBytes
+    artifact.modBytes artifact.modLen
     artifact.manifest
     artifact.fieldProjectionClaims
 
@@ -1456,7 +1466,8 @@ def acceptedFieldProjectionFragments (artifact : ArtifactData) : Prop :=
     composition claims present or not. -/
 def acceptedCompositionFragments (artifact : ArtifactData) : Prop :=
   compositionClaimsAccepted
-    artifact.wasmBytes artifact.compositionMembers artifact.compositionClaims ∧
+    artifact.modBytes artifact.modLen
+      artifact.compositionMembers artifact.compositionClaims ∧
   compositionMembersCovered
     artifact.compositionMembers artifact.compositionClaims = true ∧
   manifestObligationsClaimed artifact = true ∧

--- a/src/codegen/cert/ExprFragmentAccepted.lean
+++ b/src/codegen/cert/ExprFragmentAccepted.lean
@@ -14,7 +14,8 @@ open AverCert.Schema
 open CertPrelude
 
 def accepted
-    (wasmBytes exportName : AverCert.WasmSlice.ByteSeq)
+    (modBytes modLen : Nat)
+    (exportName : AverCert.WasmSlice.ByteSeq)
     (carrier : Nat)
     (plan : ExprFragmentRawPlan)
     (body : List WInstr)
@@ -23,7 +24,7 @@ def accepted
   AverCert.PlanCheck.checkExprFragmentRawPlan plan = true ∧
   AverCert.PlanLower.lowerExprFragmentBody carrier plan = some body ∧
   AverCert.PlanBytes.lowerExprFragmentCodeEntry carrier plan = some codeEntry ∧
-  AverCert.WasmSlice.funcBindingForExport wasmBytes exportName = some binding ∧
+  AverCert.WasmSlice.funcBindingForExport modBytes modLen exportName = some binding ∧
   binding.codeEntry = codeEntry
 
 end AverCert.ExprFragmentAccepted

--- a/src/codegen/cert/WasmSlice.lean
+++ b/src/codegen/cert/WasmSlice.lean
@@ -6,6 +6,7 @@
 -- section and code section.
 -- Unsupported import kinds decline.
 import SchemaCore
+import CertDecode
 
 namespace AverCert.WasmSlice
 
@@ -16,6 +17,45 @@ structure FuncBinding where
   codeIdx : Nat
   typeIdx : Nat
   codeEntry : ByteSeq
+
+/-! ### Whole-module byte cursor
+
+The Wasm module is one little-endian `Nat` plus its explicit byte length.  This
+is the same byte model and the same shift/mask discipline as
+`tools/certkit/prelude/CertDecode.lean`: reading uses `&&& 0xff`, advancing uses
+`>>> 8`, and skipping a framed payload uses one `>>> (8 * size)`.  The length is
+soundness-relevant because high trailing `0x00` bytes are not represented by the
+numeral.
+
+Only whole-module navigation uses this cursor.  Export names, selected type
+entries, data payloads, and code entries cross back to `ByteSeq`; those objects
+are small and remain the byte-exact certificate surface. -/
+
+abbrev takeNatBytes := CertDecode.takeBytes
+
+@[inline] def readNatUleb32 := CertDecode.readU
+
+def readNatS33 (bytes len : Nat) : Option (Int × Nat × Nat) :=
+  match CertDecode.sleb 5 0 0 bytes len with
+  | some (v, bytes', len') =>
+      if -(Int.ofNat (2 ^ 32)) ≤ v ∧ v < Int.ofNat (2 ^ 32) then
+        some (v, bytes', len')
+      else
+        none
+  | none => none
+
+/-- Validate and remove the exact eight-byte Wasm header. -/
+def stripHeader (modBytes modLen : Nat) : Option (Nat × Nat) :=
+  if 8 ≤ modLen ∧ (modBytes &&& 0xffffffffffffffff) = 0x000000016d736100 then
+    some (modBytes >>> 64, modLen - 8)
+  else
+    none
+
+def findSectionPayload (target modBytes modLen : Nat) : Option (Nat × Nat) :=
+  match stripHeader modBytes modLen with
+  | some (sections, sectionsLen) =>
+      CertDecode.findSecPayload target 64 sections sectionsLen
+  | none => none
 
 def takeN : Nat → ByteSeq → Option (ByteSeq × ByteSeq)
   | 0, xs => some ([], xs)
@@ -49,31 +89,6 @@ def readUleb32 (bytes : ByteSeq) : Option (Nat × ByteSeq) :=
 def readNameBytes (bytes : ByteSeq) : Option (ByteSeq × ByteSeq) :=
   match readUleb32 bytes with
   | some (len, rest) => takeN len rest
-  | none => none
-
-def stripHeader : ByteSeq → Option ByteSeq
-  | 0x00 :: 0x61 :: 0x73 :: 0x6d :: 0x01 :: 0x00 :: 0x00 :: 0x00 :: rest =>
-      some rest
-  | _ => none
-
-def findSectionPayloadFuel : Nat → Nat → ByteSeq → Option ByteSeq
-  | 0, _, _ => none
-  | _fuel + 1, _target, [] => none
-  | fuel + 1, target, id :: rest =>
-      match readUleb32 rest with
-      | some (size, afterSize) =>
-          match takeN size afterSize with
-          | some (payload, remaining) =>
-              if id = target then
-                some payload
-              else
-                findSectionPayloadFuel fuel target remaining
-          | none => none
-      | none => none
-
-def findSectionPayload (target : Nat) (wasmBytes : ByteSeq) : Option ByteSeq :=
-  match stripHeader wasmBytes with
-  | some sections => findSectionPayloadFuel (sections.length + 1) target sections
   | none => none
 
 /-- Signed LEB128 reader (s33 heap-type indices in value types). -/
@@ -286,18 +301,152 @@ def walkRecTypesFuel (check : ByteSeq → Bool) (target : Nat) :
           | some (r2, acc') => walkRecTypesFuel check target fuel rem (base + 1) r2 acc'
           | none => none
 
+/-! The matching whole-module walkers use the shared big-`Nat` cursor.  They
+parse every declared subtype, but materialize only the selected subtype as a
+small `ByteSeq` for the existing signature checker. -/
+
+def skipValTypeNat (bytes len : Nat) : Option (Nat × Nat) :=
+  if len = 0 then none else
+    let b := bytes &&& 0xff
+    let rest := bytes >>> 8
+    let restLen := len - 1
+    if b = 0x63 ∨ b = 0x64 then
+      match readNatS33 rest restLen with
+      | some (_, rest', restLen') => some (rest', restLen')
+      | none => none
+    else if (0x7b ≤ b ∧ b ≤ 0x7f) ∨ (0x69 ≤ b ∧ b ≤ 0x73) then
+      some (rest, restLen)
+    else
+      none
+
+def skipValTypesNatFuel : Nat → Nat → Nat → Nat → Option (Nat × Nat)
+  | 0, _, _, _ => none
+  | _fuel + 1, 0, bytes, len => some (bytes, len)
+  | fuel + 1, count + 1, bytes, len =>
+      match skipValTypeNat bytes len with
+      | some (rest, restLen) => skipValTypesNatFuel fuel count rest restLen
+      | none => none
+
+def skipFieldTypeNat (bytes len : Nat) : Option (Nat × Nat) :=
+  if len = 0 then none else
+    let b := bytes &&& 0xff
+    let storage? :=
+      if b = 0x78 ∨ b = 0x77 then some (bytes >>> 8, len - 1)
+      else skipValTypeNat bytes len
+    match storage? with
+    | some (afterStorage, storageLen) =>
+        if storageLen = 0 then none else
+          let mutability := afterStorage &&& 0xff
+          if mutability = 0x00 ∨ mutability = 0x01 then
+            some (afterStorage >>> 8, storageLen - 1)
+          else
+            none
+    | none => none
+
+def skipFieldTypesNatFuel : Nat → Nat → Nat → Nat → Option (Nat × Nat)
+  | 0, _, _, _ => none
+  | _fuel + 1, 0, bytes, len => some (bytes, len)
+  | fuel + 1, count + 1, bytes, len =>
+      match skipFieldTypeNat bytes len with
+      | some (rest, restLen) => skipFieldTypesNatFuel fuel count rest restLen
+      | none => none
+
+def skipCompTypeNat (bytes len : Nat) : Option (Nat × Nat) :=
+  if len = 0 then none else
+    let tag := bytes &&& 0xff
+    let rest := bytes >>> 8
+    let restLen := len - 1
+    if tag = 0x60 then
+      match readNatUleb32 rest restLen with
+      | some (np, params, paramsLen) =>
+          match skipValTypesNatFuel (np + 1) np params paramsLen with
+          | some (afterParams, afterParamsLen) =>
+              match readNatUleb32 afterParams afterParamsLen with
+              | some (nr, results, resultsLen) =>
+                  skipValTypesNatFuel (nr + 1) nr results resultsLen
+              | none => none
+          | none => none
+      | none => none
+    else if tag = 0x5f then
+      match readNatUleb32 rest restLen with
+      | some (nf, fields, fieldsLen) =>
+          skipFieldTypesNatFuel (nf + 1) nf fields fieldsLen
+      | none => none
+    else if tag = 0x5e then
+      skipFieldTypeNat rest restLen
+    else
+      none
+
+def skipNatUlebsFuel : Nat → Nat → Nat → Nat → Option (Nat × Nat)
+  | 0, _, _, _ => none
+  | _fuel + 1, 0, bytes, len => some (bytes, len)
+  | fuel + 1, count + 1, bytes, len =>
+      match readNatUleb32 bytes len with
+      | some (_, rest, restLen) => skipNatUlebsFuel fuel count rest restLen
+      | none => none
+
+def skipSubTypeNat (bytes len : Nat) : Option (Nat × Nat) :=
+  if len = 0 then none else
+    let b := bytes &&& 0xff
+    if b = 0x50 ∨ b = 0x4f then
+      match readNatUleb32 (bytes >>> 8) (len - 1) with
+      | some (ns, supertypes, supertypesLen) =>
+          match skipNatUlebsFuel (ns + 1) ns supertypes supertypesLen with
+          | some (comp, compLen) => skipCompTypeNat comp compLen
+          | none => none
+      | none => none
+    else
+      skipCompTypeNat bytes len
+
+def walkSubtypesNatFuel (check : ByteSeq → Bool) (target : Nat) :
+    Nat → Nat → Nat → Nat → Nat → Bool → Option (Nat × Nat × Bool)
+  | 0, _, _, _, _, _ => none
+  | _fuel + 1, 0, _base, bytes, len, acc => some (bytes, len, acc)
+  | fuel + 1, count + 1, base, bytes, len, acc =>
+      match skipSubTypeNat bytes len with
+      | some (rest, restLen) =>
+          let consumed := len - restLen
+          let acc' := if base = target then check (takeNatBytes consumed bytes) else acc
+          walkSubtypesNatFuel check target fuel count (base + 1) rest restLen acc'
+      | none => none
+
+def walkRecTypesNatFuel (check : ByteSeq → Bool) (target : Nat) :
+    Nat → Nat → Nat → Nat → Nat → Bool → Option (Nat × Nat × Bool)
+  | 0, _, _, _, _, _ => none
+  | _fuel + 1, 0, _base, bytes, len, acc => some (bytes, len, acc)
+  | fuel + 1, remaining + 1, base, bytes, len, acc =>
+      if len = 0 then none else
+        let b := bytes &&& 0xff
+        if b = 0x4e then
+          match readNatUleb32 (bytes >>> 8) (len - 1) with
+          | some (count, subtypes, subtypesLen) =>
+              match walkSubtypesNatFuel check target (count + 1) count base
+                  subtypes subtypesLen acc with
+              | some (rest, restLen, acc') =>
+                  walkRecTypesNatFuel check target fuel remaining (base + count)
+                    rest restLen acc'
+              | none => none
+          | none => none
+        else
+          match walkSubtypesNatFuel check target 2 1 base bytes len acc with
+          | some (rest, restLen, acc') =>
+              walkRecTypesNatFuel check target fuel remaining (base + 1)
+                rest restLen acc'
+          | none => none
+
 /-- Whether the module's type section is well-formed AND its entry `typeIdx`
     satisfies `check`. The whole rectype vector is parsed and required to consume
     the section payload EXACTLY (no trailing bytes past the last rectype), so a
     valid target entry followed by garbage is rejected, not silently accepted. -/
 def typeSectionMatches (check : ByteSeq → Bool)
-    (wasmBytes : ByteSeq) (typeIdx : Nat) : Bool :=
-  match findSectionPayload 0x01 wasmBytes with
-  | some payload =>
-      match readUleb32 payload with
-      | some (count, rest) =>
-          match walkRecTypesFuel check typeIdx (count + 1) count 0 rest false with
-          | some ([], acc) => acc
+    (modBytes modLen typeIdx : Nat) : Bool :=
+  match findSectionPayload 0x01 modBytes modLen with
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (count, rest, restLen) =>
+          match walkRecTypesNatFuel check typeIdx (count + 1) count 0
+              rest restLen false with
+          | some (_, 0, acc) => acc
           | _ => false
       | none => false
   | none => false
@@ -307,8 +456,8 @@ def typeSectionMatches (check : ByteSeq → Bool)
     This binds a claimed function binding's declared signature to the plan's
     params/result without trusting either, and (via `typeSectionMatches`) requires
     the whole type section to be well-formed and exactly consumed. -/
-def funcTypeMatches (wasmBytes : ByteSeq) (typeIdx arity carrier : Nat) : Bool :=
-  typeSectionMatches (checkCanonicalFuncType arity carrier) wasmBytes typeIdx
+def funcTypeMatches (modBytes modLen typeIdx arity carrier : Nat) : Bool :=
+  typeSectionMatches (checkCanonicalFuncType arity carrier) modBytes modLen typeIdx
 
 /-- Whether the head of `bytes` is EXACTLY the certified verbatim dispatch
     function type for `resultSig`: one nullable concrete nominal-root parameter
@@ -344,9 +493,9 @@ def checkVerbatimFuncType (resultSig : AverCert.Schema.VerbatimResultSig)
 
 /-- Whether the module's byte-derived type-section entry `typeIdx` exactly
     matches the verbatim plan's declared result-signature variant. -/
-def verbatimFuncTypeMatches (wasmBytes : ByteSeq) (typeIdx : Nat)
+def verbatimFuncTypeMatches (modBytes modLen typeIdx : Nat)
     (resultSig : AverCert.Schema.VerbatimResultSig) : Bool :=
-  typeSectionMatches (checkVerbatimFuncType resultSig) wasmBytes typeIdx
+  typeSectionMatches (checkVerbatimFuncType resultSig) modBytes modLen typeIdx
 
 /-! ### Bare field-projection type binding -/
 
@@ -396,11 +545,11 @@ def checkProjectionStructType
   | _ => false
 
 def projectionStructTypeMatches
-    (wasmBytes : ByteSeq) (structIdx fieldCount fieldIdx : Nat)
+    (modBytes modLen structIdx fieldCount fieldIdx : Nat)
     (resultTy : AverCert.Schema.FieldProjectionResultTy) : Bool :=
   typeSectionMatches
     (checkProjectionStructType fieldCount fieldIdx resultTy)
-    wasmBytes structIdx
+    modBytes modLen structIdx
 
 def checkProjectionFuncType
     (structIdx : Nat)
@@ -420,9 +569,9 @@ def checkProjectionFuncType
   | _ => false
 
 def projectionFuncTypeMatches
-    (wasmBytes : ByteSeq) (typeIdx structIdx : Nat)
+    (modBytes modLen typeIdx structIdx : Nat)
     (resultTy : AverCert.Schema.FieldProjectionResultTy) : Bool :=
-  typeSectionMatches (checkProjectionFuncType structIdx resultTy) wasmBytes typeIdx
+  typeSectionMatches (checkProjectionFuncType structIdx resultTy) modBytes modLen typeIdx
 
 /-! ### List-constructor type binding -/
 
@@ -458,9 +607,9 @@ def checkListConstructStructType
   | _ => false
 
 def listConstructStructTypeMatches
-    (wasmBytes : ByteSeq) (structIdx : Nat)
+    (modBytes modLen structIdx : Nat)
     (elemTy : AverCert.Schema.ConstructValType) : Bool :=
-  typeSectionMatches (checkListConstructStructType structIdx elemTy) wasmBytes structIdx
+  typeSectionMatches (checkListConstructStructType structIdx elemTy) modBytes modLen structIdx
 
 def checkListConstructFuncType
     (arity structIdx : Nat) (elemTy : AverCert.Schema.ConstructValType) : ByteSeq → Bool
@@ -488,9 +637,10 @@ def checkListConstructFuncType
   | _ => false
 
 def listConstructFuncTypeMatches
-    (wasmBytes : ByteSeq) (typeIdx arity structIdx : Nat)
+    (modBytes modLen typeIdx arity structIdx : Nat)
     (elemTy : AverCert.Schema.ConstructValType) : Bool :=
-  typeSectionMatches (checkListConstructFuncType arity structIdx elemTy) wasmBytes typeIdx
+  typeSectionMatches (checkListConstructFuncType arity structIdx elemTy)
+    modBytes modLen typeIdx
 
 /-! ### Passive data-section navigation
 
@@ -504,206 +654,204 @@ fail-closes. -/
 
 /-- Read one passive data segment (`0x01 <vec byte>`), returning its byte
     contents and the remaining bytes; any other flag fail-closes. -/
-def readPassiveDataSegment : ByteSeq → Option (ByteSeq × ByteSeq)
-  | 0x01 :: rest =>
-      match readUleb32 rest with
-      | some (len, afterLen) => takeN len afterLen
-      | none => none
-  | _ => none
-
-/-- Walk ALL `remaining` passive data segments, recording the contents of the one
-    at absolute index `target`. Returns the tail after the last segment and the
-    recorded contents; the caller requires the tail to be EMPTY, so a segment
-    followed by garbage or a count that overshoots the payload declines. -/
-def walkDataSegmentsFuel (target : Nat) :
-    Nat → Nat → Nat → ByteSeq → Option ByteSeq → Option (ByteSeq × Option ByteSeq)
-  | 0, _, _, _, _ => none
-  | _fuel + 1, 0, _cur, bytes, found => some (bytes, found)
-  | fuel + 1, rem + 1, cur, bytes, found =>
-      match readPassiveDataSegment bytes with
-      | some (contents, rest) =>
-          let found := if cur = target then some contents else found
-          walkDataSegmentsFuel target fuel rem (cur + 1) rest found
-      | none => none
-
-/-- The exact byte contents of passive data segment `dataIdx`, recovered from the
-    module's data section (id 11). The WHOLE segment vector is parsed and required
-    to consume the section payload EXACTLY (no trailing bytes), so a valid target
-    segment followed by garbage — or a declared count that does not match the
-    bytes — declines. `none` if the section is absent, `dataIdx` is out of range,
-    or any segment on the way is not passive. -/
-def dataSegmentBytes (wasmBytes : ByteSeq) (dataIdx : Nat) : Option ByteSeq :=
-  match findSectionPayload 0x0b wasmBytes with
-  | some payload =>
-      match readUleb32 payload with
-      | some (count, rest) =>
-          if dataIdx < count then
-            match walkDataSegmentsFuel dataIdx (count + 1) count 0 rest none with
-            | some ([], found) => found
-            | _ => none
-          else none
-      | none => none
-  | none => none
-
-def readImportFuncFlag (bytes : ByteSeq) : Option (Bool × ByteSeq) :=
-  match readNameBytes bytes with
-  | some (_, rest1) =>
-      match readNameBytes rest1 with
-      | some (_, rest2) =>
-          match readByte rest2 with
-          | some (kind, rest3) =>
-              if kind = 0x00 then
-                match readUleb32 rest3 with
-                | some (_, rest4) => some (true, rest4)
-                | none => none
-              else
-                none
-          | none => none
-      | none => none
-  | none => none
-
-def countFuncImportsFuel : Nat → Nat → ByteSeq → Nat → Option Nat
-  | 0, _, _, _ => none
-  | _fuel + 1, 0, _bytes, acc => some acc
-  | fuel + 1, count + 1, bytes, acc =>
-      match readImportFuncFlag bytes with
-      | some (isFunc, rest) =>
-          countFuncImportsFuel fuel count rest (if isFunc then acc + 1 else acc)
-      | none => none
-
-def importedFuncCount (wasmBytes : ByteSeq) : Option Nat :=
-  match findSectionPayload 0x02 wasmBytes with
-  | none => some 0
-  | some payload =>
-      match readUleb32 payload with
-      | some (count, rest) => countFuncImportsFuel (count + 1) count rest 0
-      | none => none
-
-def readExportEntry (bytes : ByteSeq) :
-    Option (ByteSeq × Nat × Nat × ByteSeq) :=
-  match readNameBytes bytes with
-  | some (name, rest1) =>
-      match readByte rest1 with
-      | some (kind, rest2) =>
-          match readUleb32 rest2 with
-          | some (idx, rest3) => some (name, kind, idx, rest3)
-          | none => none
-      | none => none
-  | none => none
-
-def findExportFuncIndexFuel : Nat → Nat → ByteSeq → ByteSeq → Option Nat
-  | 0, _, _, _ => none
-  | _fuel + 1, 0, _bytes, _targetName => none
-  | fuel + 1, count + 1, bytes, targetName =>
-      match readExportEntry bytes with
-      | some (name, kind, idx, rest) =>
-          if kind = 0x00 then
-            if name = targetName then
-              some idx
+def walkDataSegmentsNatFuel (target : Nat) :
+    Nat → Nat → Nat → Nat → Nat → Option ByteSeq → Option ByteSeq
+  | 0, _, _, _, _, _ => none
+  | _fuel + 1, 0, _current, _bytes, len, found =>
+      if len = 0 then found else none
+  | fuel + 1, remaining + 1, current, bytes, len, found =>
+      if len = 0 ∨ (bytes &&& 0xff) != 0x01 then none else
+        match readNatUleb32 (bytes >>> 8) (len - 1) with
+        | none => none
+        | some (size, contents, contentsLen) =>
+            if size ≤ contentsLen then
+              let found' :=
+                if current = target then some (takeNatBytes size contents) else found
+              walkDataSegmentsNatFuel target fuel remaining (current + 1)
+                (contents >>> (8 * size)) (contentsLen - size) found'
             else
-              findExportFuncIndexFuel fuel count rest targetName
-          else
-            findExportFuncIndexFuel fuel count rest targetName
-      | none => none
+              none
 
-def exportFuncIndex (wasmBytes targetName : ByteSeq) : Option Nat :=
-  match findSectionPayload 0x07 wasmBytes with
-  | some payload =>
-      match readUleb32 payload with
-      | some (count, rest) =>
-          findExportFuncIndexFuel (count + 1) count rest targetName
-      | none => none
-  | none => none
-
-def readCodeEntry (bytes : ByteSeq) : Option (ByteSeq × ByteSeq) :=
-  match readUleb32 bytes with
-  | some (size, afterSize) =>
-      let prefixLen := bytes.length - afterSize.length
-      let lenBytes := bytes.take prefixLen
-      match takeN size afterSize with
-      | some (body, rest) => some (lenBytes ++ body, rest)
-      | none => none
-  | none => none
-
-def codeEntryByCodeIndexFuel : Nat → Nat → ByteSeq → Option ByteSeq
-  | 0, _, _ => none
-  | _fuel + 1, _idx, [] => none
-  | fuel + 1, idx, bytes =>
-      match readCodeEntry bytes with
-      | some (entry, rest) =>
-          if idx = 0 then
-            some entry
-          else
-            codeEntryByCodeIndexFuel fuel (idx - 1) rest
-      | none => none
-
-def codeEntryByCodeIndex (wasmBytes : ByteSeq) (codeIdx : Nat) : Option ByteSeq :=
-  match findSectionPayload 0x0a wasmBytes with
-  | some payload =>
-      match readUleb32 payload with
-      | some (count, rest) =>
-          if codeIdx < count then
-            codeEntryByCodeIndexFuel (count + 1) codeIdx rest
+/-- Exact selected passive data payload.  The full declared vector must parse
+    and exhaust the section payload. -/
+def dataSegmentBytes (modBytes modLen dataIdx : Nat) : Option ByteSeq :=
+  match findSectionPayload 0x0b modBytes modLen with
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (count, rest, restLen) =>
+          if dataIdx < count then
+            walkDataSegmentsNatFuel dataIdx (count + 1) count 0 rest restLen none
           else
             none
       | none => none
   | none => none
 
-def typeIndexByCodeIndexFuel : Nat → Nat → Nat → ByteSeq → Option Nat
-  | 0, _, _, _ => none
-  | _fuel + 1, _idx, 0, _bytes => none
-  | fuel + 1, idx, count + 1, bytes =>
-      match readUleb32 bytes with
-      | some (typeIdx, rest) =>
-          if idx = 0 then
-            some typeIdx
-          else
-            typeIndexByCodeIndexFuel fuel (idx - 1) count rest
-      | none => none
-
-def typeIndexByCodeIndex (wasmBytes : ByteSeq) (codeIdx : Nat) : Option Nat :=
-  match findSectionPayload 0x03 wasmBytes with
-  | some payload =>
-      match readUleb32 payload with
-      | some (count, rest) =>
-          if codeIdx < count then
-            typeIndexByCodeIndexFuel (count + 1) codeIdx count rest
-          else
-            none
-      | none => none
-  | none => none
-
-def codeEntryByFuncIndex (wasmBytes : ByteSeq) (funcIdx : Nat) : Option ByteSeq :=
-  match importedFuncCount wasmBytes with
-  | some imported =>
-      if imported ≤ funcIdx then
-        codeEntryByCodeIndex wasmBytes (funcIdx - imported)
+def skipNatName (bytes len : Nat) : Option (Nat × Nat) :=
+  match readNatUleb32 bytes len with
+  | some (nameLen, name, nameAndRestLen) =>
+      if nameLen ≤ nameAndRestLen then
+        some (name >>> (8 * nameLen), nameAndRestLen - nameLen)
       else
         none
   | none => none
 
-def funcBindingByFuncIndex (wasmBytes : ByteSeq) (funcIdx : Nat) : Option FuncBinding :=
-  match importedFuncCount wasmBytes with
+def readImportFuncNat (bytes len : Nat) : Option (Nat × Nat) :=
+  match skipNatName bytes len with
+  | some (afterModule, afterModuleLen) =>
+      match skipNatName afterModule afterModuleLen with
+      | some (afterName, afterNameLen) =>
+          if afterNameLen = 0 ∨ (afterName &&& 0xff) != 0x00 then none else
+            match readNatUleb32 (afterName >>> 8) (afterNameLen - 1) with
+            | some (_, rest, restLen) => some (rest, restLen)
+            | none => none
+      | none => none
+  | none => none
+
+def countFuncImportsNatFuel : Nat → Nat → Nat → Nat → Nat → Option Nat
+  | 0, _, _, _, _ => none
+  | _fuel + 1, 0, _bytes, len, count =>
+      if len = 0 then some count else none
+  | fuel + 1, remaining + 1, bytes, len, count =>
+      match readImportFuncNat bytes len with
+      | some (rest, restLen) =>
+          countFuncImportsNatFuel fuel remaining rest restLen (count + 1)
+      | none => none
+
+def importedFuncCount (modBytes modLen : Nat) : Option Nat :=
+  match findSectionPayload 0x02 modBytes modLen with
+  | none => some 0
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (count, rest, restLen) =>
+          countFuncImportsNatFuel (count + 1) count rest restLen 0
+      | none => none
+
+def readExportEntryNat (bytes len : Nat) :
+    Option (ByteSeq × Nat × Nat × Nat × Nat) :=
+  match readNatUleb32 bytes len with
+  | some (nameLen, nameBytes, nameAndRestLen) =>
+      if nameLen ≤ nameAndRestLen then
+        let name := takeNatBytes nameLen nameBytes
+        let afterName := nameBytes >>> (8 * nameLen)
+        let afterNameLen := nameAndRestLen - nameLen
+        if afterNameLen = 0 then none else
+          let kind := afterName &&& 0xff
+          match readNatUleb32 (afterName >>> 8) (afterNameLen - 1) with
+          | some (idx, rest, restLen) => some (name, kind, idx, rest, restLen)
+          | none => none
+      else
+        none
+  | none => none
+
+def findExportFuncIndexNatFuel (targetName : ByteSeq) :
+    Nat → Nat → Nat → Nat → Option Nat → Option Nat
+  | 0, _, _, _, _ => none
+  | _fuel + 1, 0, _bytes, len, found =>
+      if len = 0 then found else none
+  | fuel + 1, remaining + 1, bytes, len, found =>
+      match readExportEntryNat bytes len with
+      | some (name, kind, idx, rest, restLen) =>
+          let found' :=
+            if kind = 0x00 ∧ name = targetName ∧ found.isNone then some idx else found
+          findExportFuncIndexNatFuel targetName fuel remaining rest restLen found'
+      | none => none
+
+def exportFuncIndex (modBytes modLen : Nat) (targetName : ByteSeq) : Option Nat :=
+  match findSectionPayload 0x07 modBytes modLen with
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (count, rest, restLen) =>
+          findExportFuncIndexNatFuel targetName (count + 1) count rest restLen none
+      | none => none
+  | none => none
+
+def codeEntryByCodeIndexNatFuel (target : Nat) :
+    Nat → Nat → Nat → Nat → Nat → Option ByteSeq → Option ByteSeq
+  | 0, _, _, _, _, _ => none
+  | _fuel + 1, 0, _current, _bytes, len, found =>
+      if len = 0 then found else none
+  | fuel + 1, remaining + 1, current, bytes, len, found =>
+      match readNatUleb32 bytes len with
+      | some (size, body, bodyAndRestLen) =>
+          if size ≤ bodyAndRestLen then
+            let prefixLen := len - bodyAndRestLen
+            let found' :=
+              if current = target then some (takeNatBytes (prefixLen + size) bytes) else found
+            codeEntryByCodeIndexNatFuel target fuel remaining (current + 1)
+              (body >>> (8 * size)) (bodyAndRestLen - size) found'
+          else
+            none
+      | none => none
+
+def codeEntryByCodeIndex (modBytes modLen codeIdx : Nat) : Option ByteSeq :=
+  match findSectionPayload 0x0a modBytes modLen with
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (count, rest, restLen) =>
+          if codeIdx < count then
+            codeEntryByCodeIndexNatFuel codeIdx (count + 1) count 0 rest restLen none
+          else
+            none
+      | none => none
+  | none => none
+
+def typeIndexByCodeIndexNatFuel (target : Nat) :
+    Nat → Nat → Nat → Nat → Nat → Option Nat → Option Nat
+  | 0, _, _, _, _, _ => none
+  | _fuel + 1, 0, _current, _bytes, len, found =>
+      if len = 0 then found else none
+  | fuel + 1, remaining + 1, current, bytes, len, found =>
+      match readNatUleb32 bytes len with
+      | some (typeIdx, rest, restLen) =>
+          let found' := if current = target then some typeIdx else found
+          typeIndexByCodeIndexNatFuel target fuel remaining (current + 1)
+            rest restLen found'
+      | none => none
+
+def typeIndexByCodeIndex (modBytes modLen codeIdx : Nat) : Option Nat :=
+  match findSectionPayload 0x03 modBytes modLen with
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (count, rest, restLen) =>
+          if codeIdx < count then
+            typeIndexByCodeIndexNatFuel codeIdx (count + 1) count 0 rest restLen none
+          else
+            none
+      | none => none
+  | none => none
+
+def codeEntryByFuncIndex (modBytes modLen funcIdx : Nat) : Option ByteSeq :=
+  match importedFuncCount modBytes modLen with
+  | some imported =>
+      if imported ≤ funcIdx then
+        codeEntryByCodeIndex modBytes modLen (funcIdx - imported)
+      else
+        none
+  | none => none
+
+def funcBindingByFuncIndex (modBytes modLen funcIdx : Nat) : Option FuncBinding :=
+  match importedFuncCount modBytes modLen with
   | some imported =>
       if imported ≤ funcIdx then
         let codeIdx := funcIdx - imported
-        match typeIndexByCodeIndex wasmBytes codeIdx,
-              codeEntryByCodeIndex wasmBytes codeIdx with
+        match typeIndexByCodeIndex modBytes modLen codeIdx,
+              codeEntryByCodeIndex modBytes modLen codeIdx with
         | some typeIdx, some codeEntry =>
-            some { funcIdx := funcIdx, codeIdx := codeIdx, typeIdx := typeIdx, codeEntry := codeEntry }
+            some { funcIdx := funcIdx, codeIdx := codeIdx,
+                   typeIdx := typeIdx, codeEntry := codeEntry }
         | _, _ => none
       else
         none
   | none => none
 
-def codeEntryForExport (wasmBytes targetName : ByteSeq) : Option ByteSeq :=
-  match exportFuncIndex wasmBytes targetName with
-  | some funcIdx => codeEntryByFuncIndex wasmBytes funcIdx
+def codeEntryForExport (modBytes modLen : Nat) (targetName : ByteSeq) : Option ByteSeq :=
+  match exportFuncIndex modBytes modLen targetName with
+  | some funcIdx => codeEntryByFuncIndex modBytes modLen funcIdx
   | none => none
 
-def funcBindingForExport (wasmBytes targetName : ByteSeq) : Option FuncBinding :=
-  match exportFuncIndex wasmBytes targetName with
-  | some funcIdx => funcBindingByFuncIndex wasmBytes funcIdx
+def funcBindingForExport (modBytes modLen : Nat) (targetName : ByteSeq) : Option FuncBinding :=
+  match exportFuncIndex modBytes modLen targetName with
+  | some funcIdx => funcBindingByFuncIndex modBytes modLen funcIdx
   | none => none
 
 end AverCert.WasmSlice

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -39,6 +39,7 @@ use std::path::Path;
 /// The Stage-A semantics prelude, single source of truth, embedded so the
 /// emitter is self-contained.
 pub const CERT_PRELUDE: &str = include_str!("../../../tools/certkit/prelude/CertPrelude.lean");
+pub const CERT_DECODE: &str = include_str!("../../../tools/certkit/prelude/CertDecode.lean");
 pub const LEAN_TOOLCHAIN: &str = include_str!("../../../tools/certkit/prelude/lean-toolchain");
 
 /// The audited statement schema, single source of truth, embedded so both the
@@ -65,7 +66,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 45;
+pub const CERT_SCHEMA_VERSION: u32 = 46;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";
@@ -102,6 +103,9 @@ pub fn audited_schema_core_sha() -> String {
 }
 pub fn audited_prelude_sha() -> String {
     sha256_hex(CERT_PRELUDE.as_bytes())
+}
+pub fn audited_decode_sha() -> String {
+    sha256_hex(CERT_DECODE.as_bytes())
 }
 pub fn audited_plan_check_sha() -> String {
     sha256_hex(CERT_PLAN_CHECK.as_bytes())

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -523,6 +523,7 @@ fn render_final(analysis: &Analysis) -> String {
 
 fn render_lakefile(model_roots: &[String]) -> String {
     let mut roots = vec!["`CertPrelude".to_string(), "`Contracts".to_string()];
+    roots.push("`CertDecode".to_string());
     for r in model_roots {
         roots.push(format!("`{r}"));
     }
@@ -553,6 +554,7 @@ struct ManifestHashes<'a> {
     schema: &'a str,
     schema_core: &'a str,
     prelude: &'a str,
+    decode: &'a str,
     plan_check: &'a str,
     plan_lower: &'a str,
     plan_bytes: &'a str,
@@ -589,6 +591,10 @@ fn render_manifest(
     s.push_str(&format!(
         "  \"prelude_sha256\": \"{}\",\n",
         hashes.prelude
+    ));
+    s.push_str(&format!(
+        "  \"cert_decode_sha256\": \"{}\",\n",
+        hashes.decode
     ));
     s.push_str(&format!(
         "  \"plan_check_sha256\": \"{}\",\n",

--- a/src/codegen/cert/render_project.rs
+++ b/src/codegen/cert/render_project.rs
@@ -14,6 +14,7 @@ pub fn write_project(
 
     // Copy in the semantics prelude + toolchain (single source of truth).
     write(&cert_dir, "CertPrelude.lean", CERT_PRELUDE)?;
+    write(&cert_dir, "CertDecode.lean", CERT_DECODE)?;
     write(&cert_dir, "lean-toolchain", LEAN_TOOLCHAIN)?;
 
     // Copy the model files (AverCommon + <Module>.lean) verbatim.
@@ -106,6 +107,7 @@ pub fn write_project(
     let schema_sha = sha256_hex(CERT_SCHEMA.as_bytes());
     let schema_core_sha = sha256_hex(CERT_SCHEMA_CORE.as_bytes());
     let prelude_sha = sha256_hex(CERT_PRELUDE.as_bytes());
+    let decode_sha = sha256_hex(CERT_DECODE.as_bytes());
     let plan_check_sha = sha256_hex(CERT_PLAN_CHECK.as_bytes());
     let plan_lower_sha = sha256_hex(CERT_PLAN_LOWER.as_bytes());
     let plan_bytes_sha = sha256_hex(CERT_PLAN_BYTES.as_bytes());
@@ -117,6 +119,7 @@ pub fn write_project(
         schema: &schema_sha,
         schema_core: &schema_core_sha,
         prelude: &prelude_sha,
+        decode: &decode_sha,
         plan_check: &plan_check_sha,
         plan_lower: &plan_lower_sha,
         plan_bytes: &plan_bytes_sha,
@@ -300,15 +303,15 @@ fn render_expr_fragment_plans(
                some {code_entry_bytes} := rfl\n\n\
              /-- The audited Lean-side Wasm slicer finds `{name}`'s exact code-entry bytes\n\
                  inside the emitted module bytes by export name. -/\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {code_entry_bytes} := rfl\n\n\
              /-- The audited Lean-side Wasm slicer binds `{name}` to its function\n\
                  index, defined-code index, type index and code-entry bytes. -/\n\
-             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {func_binding} := rfl\n\n\
              /-- The audited Lean-side expr-fragment acceptance predicate aggregates\n\
                  plan checking, semantic lowering, byte lowering and byte-origin binding. -/\n\
-             example : AverCert.ExprFragmentAccepted.accepted AverCert.ArtifactBytes.wasmBytes\n  \
+             example : AverCert.ExprFragmentAccepted.accepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen\n  \
                {export_name_bytes} {carrier} {name}Plan\n  \
                {lowered_body}\n  \
                {code_entry_bytes}\n  \
@@ -355,10 +358,10 @@ fn render_expr_fragment_plans(
                AverCert.PlanLower.lowerFieldProjectionBody {struct_idx} {field_count} {name}FieldProjectionPlan := rfl\n\n\
              example : AverCert.PlanBytes.lowerFieldProjectionCodeEntry {carrier} {struct_idx} {field_count} {result_ty_lean} {name}FieldProjectionPlan =\n  \
                some {code_entry} := rfl\n\n\
-             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {binding} := rfl\n\n\
-             example : AverCert.WasmSlice.projectionStructTypeMatches AverCert.ArtifactBytes.wasmBytes {struct_idx} {field_count} {field_idx} {result_ty_lean} = true := rfl\n\n\
-             example : AverCert.WasmSlice.projectionFuncTypeMatches AverCert.ArtifactBytes.wasmBytes {type_idx} {struct_idx} {result_ty_lean} = true := rfl\n\n",
+             example : AverCert.WasmSlice.projectionStructTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {struct_idx} {field_count} {field_idx} {result_ty_lean} = true := rfl\n\n\
+             example : AverCert.WasmSlice.projectionFuncTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {type_idx} {struct_idx} {result_ty_lean} = true := rfl\n\n",
             plan_value = field_projection_plan_lean_value(&plan),
             field_idx = plan.field_idx,
         ));
@@ -399,10 +402,10 @@ fn render_expr_fragment_plans(
             format!(
                 "/-- The byte-derived list struct binds `{name}`'s element representation. -/\n\
                  theorem {name}ConstructStructTypeMatches :\n  \
-                   AverCert.WasmSlice.listConstructStructTypeMatches AverCert.ArtifactBytes.wasmBytes {struct_idx} ({elem_ty}) = true := rfl\n\n\
+                   AverCert.WasmSlice.listConstructStructTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {struct_idx} ({elem_ty}) = true := rfl\n\n\
                  /-- The byte-derived exported signature binds `{name}`'s element representation. -/\n\
                  theorem {name}ConstructFuncTypeMatches :\n  \
-                   AverCert.WasmSlice.listConstructFuncTypeMatches AverCert.ArtifactBytes.wasmBytes {type_idx} {name}ConstructPlan.arity {struct_idx} ({elem_ty}) = true := rfl\n\n"
+                   AverCert.WasmSlice.listConstructFuncTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {type_idx} {name}ConstructPlan.arity {struct_idx} ({elem_ty}) = true := rfl\n\n"
             )
         } else {
             String::new()
@@ -442,11 +445,11 @@ fn render_expr_fragment_plans(
                some {code_entry_bytes} := rfl\n\n\
              /-- The audited Lean-side Wasm slicer finds `{name}`'s exact constructor\n\
                  code-entry bytes inside the emitted module bytes by export name. -/\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {code_entry_bytes} := rfl\n\n\
              /-- The audited Lean-side Wasm slicer binds `{name}` to its function\n\
                  index, defined-code index, type index and code-entry bytes. -/\n\
-             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {func_binding} := rfl\n\n\
              {type_match_pins}",
             sym_plan_value = sym_plan_lean_value(&sym_plan),
@@ -509,11 +512,11 @@ fn render_expr_fragment_plans(
                some {code_entry_bytes} := rfl\n\n\
              /-- The audited Lean-side Wasm slicer finds `{name}`'s exact code-entry bytes\n\
                  inside the emitted module bytes by export name. -/\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {code_entry_bytes} := rfl\n\n\
              /-- The audited Lean-side Wasm slicer binds `{name}` to its function\n\
                  index, defined-code index, type index and code-entry bytes. -/\n\
-             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {func_binding} := rfl\n\n\
              \n",
             sym_plan_value = sym_plan_lean_value(&sym_plan),
@@ -570,11 +573,11 @@ fn render_expr_fragment_plans(
                some {code_entry_bytes} := rfl\n\n\
              /-- The audited Lean-side Wasm slicer finds `{name}`'s exact code-entry bytes\n\
                  inside the emitted module bytes by export name. -/\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {code_entry_bytes} := rfl\n\n\
              /-- The audited Lean-side Wasm slicer binds `{name}` to its function\n\
                  index, defined-code index, type index and code-entry bytes. -/\n\
-             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {func_binding} := rfl\n\n\
              \n",
             sym_plan_value = sym_plan_lean_value(&sym_plan),
@@ -626,7 +629,7 @@ fn render_expr_fragment_plans(
              example : AverCert.PlanCheck.checkRecursionPlanShape {self_idx} {host_table} {name}RecursionPlan = true := rfl\n\n\
              /-- The declared function type of `{name}` is the canonical certified\n\
                  signature over the Int carrier. -/\n\
-             example : AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.wasmBytes {type_idx} {arity} {carrier} = true := rfl\n\n\
+             example : AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {type_idx} {arity} {carrier} = true := rfl\n\n\
              /-- The audited recursion lowerer maps `{name}`'s plan to the exact `Module.lean` body. -/\n\
              example : (CertModule.{name}Code {self_idx}).map (fun c => c.body) =\n  \
                AverCert.PlanLower.lowerRecursionBody {carrier} {name}RecursionPlan := rfl\n\n\
@@ -634,7 +637,7 @@ fn render_expr_fragment_plans(
              example : AverCert.PlanBytes.lowerRecursionCodeEntry {carrier} {name}RecursionPlan =\n  \
                some {code_entry_bytes} := rfl\n\n\
              /-- The Wasm slicer finds `{name}`'s exact code-entry bytes by export name. -/\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {code_entry_bytes} := rfl\n\n",
             plan_value = recursion_plan_lean_value(&plan),
         ));
@@ -677,7 +680,7 @@ fn render_expr_fragment_plans(
              example : AverCert.PlanCheck.checkMutualPlanShape {member_set} {host_table} {name}MutualPlan = true := rfl\n\n\
              /-- The declared function type of `{name}` is the canonical certified\n\
                  signature over the Int carrier. -/\n\
-             example : AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.wasmBytes {type_idx} 1 {carrier} = true := rfl\n\n\
+             example : AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {type_idx} 1 {carrier} = true := rfl\n\n\
              /-- The audited mutual lowerer maps `{name}`'s plan to its arm of the shared\n\
                  `{primary}Code` table (the exact `Module.lean` body). -/\n\
              example : (CertModule.{primary}Code {self_idx}).map (fun c => c.body) =\n  \
@@ -686,7 +689,7 @@ fn render_expr_fragment_plans(
              example : AverCert.PlanBytes.lowerMutualCodeEntry {carrier} {name}MutualPlan =\n  \
                some {code_entry_bytes} := rfl\n\n\
              /-- The Wasm slicer finds `{name}`'s exact code-entry bytes by export name. -/\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {code_entry_bytes} := rfl\n\n",
             plan_value = mutual_plan_lean_value(&plan),
         ));
@@ -726,7 +729,7 @@ fn render_expr_fragment_plans(
              example : AverCert.PlanBytes.lowerVerbatimCodeEntry {carrier} {name}VerbatimPlan =\n  \
                some {code_entry_bytes} := rfl\n\n\
              /-- The Wasm slicer finds `{name}`'s exact code-entry bytes by export name. -/\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {code_entry_bytes} := rfl\n\n",
             plan_value = verbatim_plan_lean_value(&plan),
         ));
@@ -777,7 +780,7 @@ fn render_expr_fragment_plans(
              example : AverCert.PlanBytes.lowerIntDispatchCodeEntry {carrier} {host_table} {name}IntDispatchPlan =\n  \
                some {code_entry_bytes} := rfl\n\n\
              /-- The Wasm slicer finds `{name}`'s exact code-entry bytes by export name. -/\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {code_entry_bytes} := rfl\n\n",
             plan_value = int_dispatch_plan_lean_value(&plan),
         ));
@@ -819,7 +822,7 @@ fn render_expr_fragment_plans(
                some {body} := rfl\n\n\
              example : AverCert.PlanBytes.lowerCompositionCodeEntry {carrier} {host_table} {func_table} {name}CompositionPlan =\n  \
                some {code_entry} := rfl\n\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {export_name_bytes} =\n  \
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} =\n  \
                some {code_entry} := rfl\n\n",
             name = entry.name,
             plan_value = composition_plan_lean_value(&plan),
@@ -1607,7 +1610,7 @@ fn render_artifact(
          def compositionClaims : List AverCert.AcceptedArtifact.CompositionClaim := {composition_claims_list}\n\n\
          {mutual_scc_closure_pins}\
          def data : AverCert.AcceptedArtifact.ArtifactData :=\n  \
-           ({{ wasmBytes := AverCert.ArtifactBytes.wasmBytes, manifest := AverCert.manifest, symFragmentClaims := symFragmentClaims, stringEqClaims := stringEqClaims, stringConcatClaims := stringConcatClaims, constructClaims := constructClaims, recursionClaims := recursionClaims, mutualRecursionClaims := mutualRecursionClaims, verbatimClaims := verbatimClaims, intDispatchClaims := intDispatchClaims, fieldProjectionClaims := fieldProjectionClaims, compositionMembers := compositionMembers, compositionClaims := compositionClaims }} : AverCert.AcceptedArtifact.ArtifactData)\n\n\
+           ({{ modBytes := AverCert.ArtifactBytes.modBytes, modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest, symFragmentClaims := symFragmentClaims, stringEqClaims := stringEqClaims, stringConcatClaims := stringConcatClaims, constructClaims := constructClaims, recursionClaims := recursionClaims, mutualRecursionClaims := mutualRecursionClaims, verbatimClaims := verbatimClaims, intDispatchClaims := intDispatchClaims, fieldProjectionClaims := fieldProjectionClaims, compositionMembers := compositionMembers, compositionClaims := compositionClaims }} : AverCert.AcceptedArtifact.ArtifactData)\n\n\
          def acceptedWithFinal\n\
              (finalCert : AverCert.Schema.Holds AverCert.manifest) :\n\
              AverCert.AcceptedArtifact.accepted data := by\n\
@@ -1680,16 +1683,30 @@ fn render_byte_list(bytes: &[u8]) -> String {
 
 pub fn render_artifact_bytes_lean(wasm_bytes: &[u8]) -> String {
     format!(
-        "-- Exact Wasm module bytes as Lean data.\n\
+        "-- Exact Wasm module as a little-endian Lean Nat plus byte length.\n\
          -- `aver cert verify` regenerates this file from the artifact it reads;\n\
          -- a cert-supplied file with this name is ignored.\n\
          import WasmSlice\n\n\
          set_option maxRecDepth 200000\n\n\
          namespace AverCert.ArtifactBytes\n\n\
-         def wasmBytes : AverCert.WasmSlice.ByteSeq := {}\n\n\
+         def modBytes : Nat := {}\n\n\
+         def modLen : Nat := {}\n\n\
          end AverCert.ArtifactBytes\n",
-        render_byte_list(wasm_bytes)
+        render_byte_nat(wasm_bytes),
+        wasm_bytes.len()
     )
+}
+
+fn render_byte_nat(bytes: &[u8]) -> String {
+    if bytes.is_empty() {
+        return "0".to_string();
+    }
+    let mut numeral = String::with_capacity(2 + bytes.len() * 2);
+    numeral.push_str("0x");
+    for byte in bytes.iter().rev() {
+        numeral.push_str(&format!("{byte:02x}"));
+    }
+    numeral
 }
 
 fn write(dir: &Path, name: &str, content: &str) -> Result<(), String> {

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -105,7 +105,7 @@ const WITNESS_THEOREM: &str = "AverCertChecker.accepted";
 /// audited trusted computing base (taken from this binary) plus the checker's
 /// own build config and witness. A cert shipping files by these names has them
 /// ignored.
-const CHECKER_OWNED: [&str; 13] = [
+const CHECKER_OWNED: [&str; 14] = [
     "Schema.lean",
     "SchemaCore.lean",
     "PlanCheck.lean",
@@ -116,6 +116,7 @@ const CHECKER_OWNED: [&str; 13] = [
     "AcceptedArtifact.lean",
     "AcceptedArtifactCore.lean",
     "ArtifactBytes.lean",
+    "CertDecode.lean",
     "CertPrelude.lean",
     "lakefile.lean",
     "CheckerWitness.lean",
@@ -123,7 +124,7 @@ const CHECKER_OWNED: [&str; 13] = [
 
 /// Audited modules whose exact bytes are shared by every certificate build.
 /// ArtifactBytes and certificate/model modules are deliberately absent.
-const STATIC_PRELUDE_ROOTS: [&str; 10] = [
+const STATIC_PRELUDE_ROOTS: [&str; 11] = [
     "SchemaCore",
     "Schema",
     "PlanCheck",
@@ -133,12 +134,14 @@ const STATIC_PRELUDE_ROOTS: [&str; 10] = [
     "ExprFragmentAccepted",
     "AcceptedArtifactCore",
     "AcceptedArtifact",
+    "CertDecode",
     "CertPrelude",
 ];
 
 /// Static roots whose complete import graph is artifact-independent.
-const PRISTINE_PRELUDE_ROOTS: [&str; 8] = [
+const PRISTINE_PRELUDE_ROOTS: [&str; 9] = [
     "CertPrelude",
+    "CertDecode",
     "WasmSlice",
     "SchemaCore",
     "PlanCheck",
@@ -457,6 +460,13 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
     if prelude_pin != audited_prelude {
         return Err(format!(
             "prelude hash mismatch: certificate pins {prelude_pin}, checker expects {audited_prelude}"
+        ));
+    }
+    let decode_pin = manifest_str(&manifest, "cert_decode_sha256")?;
+    let audited_decode = cert::audited_decode_sha();
+    if decode_pin != audited_decode {
+        return Err(format!(
+            "cert-decode hash mismatch: certificate pins {decode_pin}, checker expects {audited_decode}"
         ));
     }
     let plan_check_pin = manifest_str(&manifest, "plan_check_sha256")?;
@@ -1272,6 +1282,7 @@ fn static_prelude_files() -> Vec<(String, Vec<u8>)> {
             cert::CERT_ACCEPTED_ARTIFACT_CORE.as_bytes().to_vec(),
         ),
         ("CertPrelude.lean", cert::CERT_PRELUDE.as_bytes().to_vec()),
+        ("CertDecode.lean", cert::CERT_DECODE.as_bytes().to_vec()),
         (
             "ExprFragmentAccepted.lean",
             cert::CERT_EXPR_FRAGMENT_ACCEPTED.as_bytes().to_vec(),
@@ -1890,7 +1901,7 @@ fn lean_expr_fragment_wasm_slice_pins(rederived: &[cert::RederivedObligation]) -
         let export_name_bytes = lean_byte_list(r.name.as_bytes());
         out.push_str(&format!(
             "-- `{}`: checker-read module bytes expose this exact code-entry.\n\
-             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.wasmBytes {} = some ({}) := rfl\n",
+             example : AverCert.WasmSlice.codeEntryForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {} = some ({}) := rfl\n",
             r.name, export_name_bytes, bytes
         ));
     }
@@ -1918,7 +1929,7 @@ fn lean_expr_fragment_func_binding_pins(rederived: &[cert::RederivedObligation])
         );
         out.push_str(&format!(
             "-- `{}`: checker-read module bytes expose this exact function binding.\n\
-             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes {} = some {} := rfl\n",
+             example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {} = some {} := rfl\n",
             r.name, export_name_bytes, binding
         ));
     }
@@ -1946,7 +1957,7 @@ fn lean_expr_fragment_accepted_pins(rederived: &[cert::RederivedObligation]) -> 
         );
         out.push_str(&format!(
             "-- `{}`: one aggregate expr-fragment acceptance check.\n\
-             example : AverCert.ExprFragmentAccepted.accepted AverCert.ArtifactBytes.wasmBytes {} {} ({}) ({}) ({}) {} := by dsimp [AverCert.ExprFragmentAccepted.accepted]; exact ⟨rfl, rfl, rfl, rfl, rfl⟩\n",
+             example : AverCert.ExprFragmentAccepted.accepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {} {} ({}) ({}) ({}) {} := by dsimp [AverCert.ExprFragmentAccepted.accepted]; exact ⟨rfl, rfl, rfl, rfl, rfl⟩\n",
             r.name, export_name_bytes, r.carrier, plan, body, bytes, binding
         ));
     }
@@ -2532,7 +2543,7 @@ fn lean_artifact_data_literal(
     composition_claims: &str,
 ) -> String {
     format!(
-        "({{ wasmBytes := AverCert.ArtifactBytes.wasmBytes, manifest := AverCert.manifest, \
+        "({{ modBytes := AverCert.ArtifactBytes.modBytes, modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest, \
          symFragmentClaims := ({sym_claims} : List AverCert.AcceptedArtifact.SymFragmentClaim), \
          stringEqClaims := ({string_eq_claims} : List AverCert.AcceptedArtifact.StringEqClaim), \
          stringConcatClaims := ({string_claims} : List AverCert.AcceptedArtifact.StringConcatClaim), \

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -64,6 +64,7 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
     )
     .expect("manifest is valid JSON");
     let expected_schema_core_sha = aver::codegen::cert::audited_schema_core_sha();
+    let expected_decode_sha = aver::codegen::cert::audited_decode_sha();
     let expected_plan_check_sha = aver::codegen::cert::audited_plan_check_sha();
     let expected_plan_lower_sha = aver::codegen::cert::audited_plan_lower_sha();
     let expected_plan_bytes_sha = aver::codegen::cert::audited_plan_bytes_sha();
@@ -77,6 +78,11 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
         manifest["schema_core_sha256"].as_str(),
         Some(expected_schema_core_sha.as_str()),
         "manifest should pin the checker-owned SchemaCore.lean"
+    );
+    assert_eq!(
+        manifest["cert_decode_sha256"].as_str(),
+        Some(expected_decode_sha.as_str()),
+        "manifest should pin the checker-owned CertDecode.lean"
     );
     assert_eq!(
         manifest["plan_check_sha256"].as_str(),

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -545,8 +545,8 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
 
     // The artifact-carried data root is useful metadata, not authority. Since
     // the recursion exports carry byte-origin plan claims, an `Artifact.lean`
-    // whose `data` points at empty bytes can no longer even prove its own
-    // claims (`codeEntryForExport [] … = some …` has no `rfl`), so the tamper
+    // whose `data` points at zero module bytes can no longer even prove its own
+    // claims (`codeEntryForExport 0 modLen … = some …` has no `rfl`), so the tamper
     // dies at the cert's own build — before the checker's `AverCert.Artifact.data`
     // reconstruction pin, which remains the authority for claim-free certs.
     {
@@ -555,8 +555,8 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         let artifact = dir.join("cert").join("Artifact.lean");
         let src = std::fs::read_to_string(&artifact).unwrap();
         let corrupted = src.replacen(
-            "wasmBytes := AverCert.ArtifactBytes.wasmBytes",
-            "wasmBytes := []",
+            "modBytes := AverCert.ArtifactBytes.modBytes",
+            "modBytes := 0",
             1,
         );
         assert_ne!(src, corrupted, "Artifact.lean data shape changed");
@@ -1239,6 +1239,213 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     let _ = std::fs::remove_dir_all(&out_dir);
 }
 
+/// A valid custom section pads a real module to the 130,460-byte scale where
+/// the old monolithic `List Nat` pin exhausted default heartbeats. The big-Nat
+/// pin must close, while a one-byte-flipped expected entry must fail `rfl`.
+#[test]
+fn big_nat_code_entry_pin_closes_at_130kb_and_flipped_byte_fails() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping big-Nat scale regression: `lake` not available");
+        return;
+    }
+
+    fn read_uleb(bytes: &[u8], cursor: &mut usize) -> usize {
+        let mut value = 0usize;
+        let mut shift = 0usize;
+        loop {
+            let byte = bytes[*cursor];
+            *cursor += 1;
+            value |= usize::from(byte & 0x7f) << shift;
+            if byte < 0x80 {
+                return value;
+            }
+            shift += 7;
+        }
+    }
+
+    fn write_uleb(mut value: usize) -> Vec<u8> {
+        let mut out = Vec::new();
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            out.push(byte);
+            if value == 0 {
+                return out;
+            }
+        }
+    }
+
+    fn section_start(bytes: &[u8], target: u8) -> usize {
+        let mut cursor = 8usize;
+        while cursor < bytes.len() {
+            let start = cursor;
+            let id = bytes[cursor];
+            cursor += 1;
+            let size = read_uleb(bytes, &mut cursor);
+            if id == target {
+                return start;
+            }
+            cursor += size;
+        }
+        panic!("section {target} not found");
+    }
+
+    fn section_payload(bytes: &[u8], target: u8) -> (usize, usize) {
+        let mut cursor = section_start(bytes, target) + 1;
+        let size = read_uleb(bytes, &mut cursor);
+        (cursor, size)
+    }
+
+    fn render_list(bytes: &[u8]) -> String {
+        format!(
+            "[{}]",
+            bytes
+                .iter()
+                .map(u8::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+
+    let (out_dir, wasm_path, cert) = compile_cert_goals("cert-bignat-scale");
+    let original = std::fs::read(&wasm_path).unwrap();
+    let code_start = section_start(&original, 10);
+
+    const TARGET_LEN: usize = 130_460;
+    let custom_payload_len = TARGET_LEN - original.len() - 4;
+    let mut custom_payload = vec![0u8; custom_payload_len];
+    custom_payload[..4].copy_from_slice(&[3, b'p', b'a', b'd']);
+    let custom_size = write_uleb(custom_payload.len());
+    assert_eq!(custom_size.len(), 3, "scale fixture framing assumption");
+
+    let mut padded = Vec::with_capacity(TARGET_LEN);
+    padded.extend_from_slice(&original[..code_start]);
+    padded.push(0);
+    padded.extend_from_slice(&custom_size);
+    padded.extend_from_slice(&custom_payload);
+    padded.extend_from_slice(&original[code_start..]);
+    assert_eq!(padded.len(), TARGET_LEN);
+    for payload in wasmparser::Parser::new(0).parse_all(&padded) {
+        payload.expect("130KB custom-section-padded artifact must parse");
+    }
+    std::fs::write(out_dir.join("cert_goals_padded.wasm"), &padded).unwrap();
+
+    let mut imported_funcs = 0u32;
+    let mut add_two_func = None;
+    for payload in wasmparser::Parser::new(0).parse_all(&padded) {
+        match payload.expect("padded artifact must parse") {
+            wasmparser::Payload::ImportSection(reader) => {
+                for group in reader {
+                    for import in group.expect("import group must parse") {
+                        let (_, import) = import.expect("import must parse");
+                        if matches!(import.ty, wasmparser::TypeRef::Func(_)) {
+                            imported_funcs += 1;
+                        }
+                    }
+                }
+            }
+            wasmparser::Payload::ExportSection(reader) => {
+                for export in reader {
+                    let export = export.expect("export must parse");
+                    if export.name == "addTwo" && export.kind == wasmparser::ExternalKind::Func {
+                        add_two_func = Some(export.index);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    let code_idx = add_two_func
+        .expect("addTwo export")
+        .checked_sub(imported_funcs)
+        .expect("addTwo is defined") as usize;
+    let (code_payload, _) = section_payload(&padded, 10);
+    let mut cursor = code_payload;
+    let count = read_uleb(&padded, &mut cursor);
+    assert!(code_idx < count);
+    let mut code_entry = Vec::new();
+    for current in 0..count {
+        let entry_start = cursor;
+        let size = read_uleb(&padded, &mut cursor);
+        let entry_end = cursor + size;
+        if current == code_idx {
+            code_entry.extend_from_slice(&padded[entry_start..entry_end]);
+        }
+        cursor = entry_end;
+    }
+    assert!(!code_entry.is_empty());
+
+    let artifact_defs = aver::codegen::cert::render_artifact_bytes_lean(&padded)
+        .replace("AverCert.ArtifactBytes", "LargeBytes");
+    let positive = format!(
+        "{artifact_defs}\n\
+         theorem largePin : AverCert.WasmSlice.codeEntryForExport LargeBytes.modBytes LargeBytes.modLen [97, 100, 100, 84, 119, 111] = some {} := rfl\n\
+         #print axioms largePin\n",
+        render_list(&code_entry)
+    );
+    std::fs::write(cert.join("LargePin.lean"), positive).unwrap();
+    let prebuild = Command::new("lake")
+        .current_dir(&cert)
+        .args(["build", "WasmSlice"])
+        .output()
+        .expect("build audited WasmSlice dependency");
+    assert!(
+        prebuild.status.success(),
+        "WasmSlice dependency must build:\n{}{}",
+        String::from_utf8_lossy(&prebuild.stdout),
+        String::from_utf8_lossy(&prebuild.stderr)
+    );
+    let started = std::time::Instant::now();
+    let large_pin = Command::new("lake")
+        .current_dir(&cert)
+        .args([
+            "env",
+            "lean",
+            "-o",
+            ".lake/build/lib/lean/LargePin.olean",
+            "LargePin.lean",
+        ])
+        .output()
+        .expect("elaborate 130KB big-Nat pin");
+    let elapsed = started.elapsed();
+    assert!(
+        large_pin.status.success(),
+        "130KB big-Nat code-entry pin must close (elapsed {elapsed:?}):\n{}{}",
+        String::from_utf8_lossy(&large_pin.stdout),
+        String::from_utf8_lossy(&large_pin.stderr)
+    );
+    eprintln!("130KB big-Nat code-entry pin closed in {elapsed:?}");
+
+    let mut flipped = code_entry.clone();
+    flipped[0] ^= 1;
+    let negative = format!(
+        "import LargePin\n\
+         set_option maxRecDepth 200000\n\
+         example : AverCert.WasmSlice.codeEntryForExport LargeBytes.modBytes LargeBytes.modLen [97, 100, 100, 84, 119, 111] = some {} := rfl\n",
+        render_list(&flipped)
+    );
+    std::fs::write(cert.join("LargePinBad.lean"), negative).unwrap();
+    let bad_pin = Command::new("lake")
+        .current_dir(&cert)
+        .args(["env", "lean", "LargePinBad.lean"])
+        .output()
+        .expect("elaborate flipped-byte negative control");
+    let bad_output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&bad_pin.stdout),
+        String::from_utf8_lossy(&bad_pin.stderr)
+    );
+    assert!(
+        !bad_pin.status.success() && bad_output.contains("rfl"),
+        "one-byte-flipped expected code entry must fail rfl:\n{bad_output}"
+    );
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
 /// The byte-honest sumTo obligation face emitted for certprobe2 (the standard
 /// integer-class form), and the two panel face-vacuity mutations of it.
 const SUMTO_FACE: &str = "Dom := List Int, Cod := Int,\n    \
@@ -1468,7 +1675,7 @@ fn cert_verify_declines_tampered_expr_fragment_sidecar() {
         artifact_bytes_decoy_dir
             .join("cert")
             .join("ArtifactBytes.lean"),
-        "namespace AverCert.ArtifactBytes\n\ndef wasmBytes : List Nat := []\n\nend AverCert.ArtifactBytes\n",
+        "namespace AverCert.ArtifactBytes\n\ndef modBytes : Nat := 0\ndef modLen : Nat := 0\n\nend AverCert.ArtifactBytes\n",
     )
     .unwrap();
     let (ok, out) = aver_verify(
@@ -1797,7 +2004,7 @@ fn cert_verify_declines_tampered_expr_fragment_sidecar() {
         !ok,
         "tampered Lean WasmSlice byte-origin pin must be DECLINED:\n{out}"
     );
-    // A false `rfl` over the full `ArtifactBytes.wasmBytes` literal can fail
+    // A false `rfl` over the full `ArtifactBytes.modBytes` numeral can fail
     // either as a normal `WasmSlice.codeEntryForExport` type mismatch or as a
     // Lean stack overflow while reducing the huge byte list. Both are
     // fail-closed build failures for this untrusted emitted audit example.
@@ -3021,7 +3228,7 @@ theorem claimObligationsInManifest_append
 
 def acceptedCompositionWithoutClaimCoverage
     (artifact : AcceptedArtifact.ArtifactData) : Prop :=
-  AcceptedArtifact.compositionClaimsAccepted artifact.wasmBytes
+  AcceptedArtifact.compositionClaimsAccepted artifact.modBytes artifact.modLen
       artifact.compositionMembers artifact.compositionClaims ∧
     AcceptedArtifact.compositionMembersCovered artifact.compositionMembers
       artifact.compositionClaims = true ∧
@@ -3072,14 +3279,14 @@ example : AcceptedArtifact.manifestObligationsClaimed unclaimedArtifact = false 
 example : AcceptedArtifact.manifestObligationExportsUnique unclaimedArtifact = true := rfl
 
 example : ∀ nameBytes,
-    WasmSlice.funcBindingForExport unclaimedArtifact.wasmBytes nameBytes =
-      WasmSlice.funcBindingForExport Artifact.data.wasmBytes nameBytes := by
+    WasmSlice.funcBindingForExport unclaimedArtifact.modBytes unclaimedArtifact.modLen nameBytes =
+      WasmSlice.funcBindingForExport Artifact.data.modBytes Artifact.data.modLen nameBytes := by
   intro nameBytes
   rfl
 
 example : ∀ nameBytes,
-    WasmSlice.codeEntryForExport unclaimedArtifact.wasmBytes nameBytes =
-      WasmSlice.codeEntryForExport Artifact.data.wasmBytes nameBytes := by
+    WasmSlice.codeEntryForExport unclaimedArtifact.modBytes unclaimedArtifact.modLen nameBytes =
+      WasmSlice.codeEntryForExport Artifact.data.modBytes Artifact.data.modLen nameBytes := by
   intro nameBytes
   rfl
 
@@ -3170,7 +3377,7 @@ theorem duplicateFinal : Schema.Holds duplicateManifest := by
 
 def acceptedCompositionWithoutUniqueExports
     (artifact : AcceptedArtifact.ArtifactData) : Prop :=
-  AcceptedArtifact.compositionClaimsAccepted artifact.wasmBytes
+  AcceptedArtifact.compositionClaimsAccepted artifact.modBytes artifact.modLen
       artifact.compositionMembers artifact.compositionClaims ∧
     AcceptedArtifact.compositionMembersCovered artifact.compositionMembers
       artifact.compositionClaims = true ∧
@@ -3201,14 +3408,14 @@ example : AcceptedArtifact.manifestObligationsClaimed duplicateArtifact = true :
 example : AcceptedArtifact.manifestObligationExportsUnique duplicateArtifact = false := rfl
 
 example : ∀ nameBytes,
-    WasmSlice.funcBindingForExport duplicateArtifact.wasmBytes nameBytes =
-      WasmSlice.funcBindingForExport Artifact.data.wasmBytes nameBytes := by
+    WasmSlice.funcBindingForExport duplicateArtifact.modBytes duplicateArtifact.modLen nameBytes =
+      WasmSlice.funcBindingForExport Artifact.data.modBytes Artifact.data.modLen nameBytes := by
   intro nameBytes
   rfl
 
 example : ∀ nameBytes,
-    WasmSlice.codeEntryForExport duplicateArtifact.wasmBytes nameBytes =
-      WasmSlice.codeEntryForExport Artifact.data.wasmBytes nameBytes := by
+    WasmSlice.codeEntryForExport duplicateArtifact.modBytes duplicateArtifact.modLen nameBytes =
+      WasmSlice.codeEntryForExport Artifact.data.modBytes Artifact.data.modLen nameBytes := by
   intro nameBytes
   rfl
 
@@ -3321,11 +3528,11 @@ example : weakBytes AverCert.Plans.quadCompositionPlan =
   AverCert.PlanBytes.lowerCompositionCodeEntry 2 hosts funcs AverCert.Plans.quadCompositionPlan := rfl
 
 -- Wasm export binding, code-entry equality, and exact unary carrier signature.
-example : (AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes [113,117,97,100]).map
+example : (AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen [113,117,97,100]).map
     (fun b => (b.funcIdx, b.codeEntry)) = some (2,
       (AverCert.PlanBytes.lowerCompositionCodeEntry 2 hosts funcs AverCert.Plans.quadCompositionPlan).get!) := rfl
-example : AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.wasmBytes 5 1 2 = true := rfl
-example : AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.wasmBytes 5 2 2 = false := rfl
+example : AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 5 1 2 = true := rfl
+example : AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 5 2 2 = false := rfl
 def weakSignature (_ _ _ : Nat) : Bool := true
 example : weakSignature 5 2 2 = true := rfl
 
@@ -3477,7 +3684,7 @@ def nameBytes : List Nat := [112,97,105,114,70,115,116]
 -- which never demonstrated acceptance against all remaining guards.
 
 -- (d) BYTE-EQUALITY GATE dropped (`binding.codeEntry = codeEntry`).
-def fpAccept_dropBytes (wasmBytes exportNameBytes : ByteSeq)
+def fpAccept_dropBytes (modBytes modLen : Nat) (exportNameBytes : ByteSeq)
     (exportName : String) (carrier structIdx fieldCount : Nat)
     (resultTy : FieldProjectionResultTy)
     (plan : FieldProjectionRawPlan) (obligation : Obligation) : Prop :=
@@ -3486,14 +3693,14 @@ def fpAccept_dropBytes (wasmBytes exportNameBytes : ByteSeq)
   ∃ body codeEntry binding,
     AverCert.PlanLower.lowerFieldProjectionBody structIdx fieldCount plan = some body ∧
     AverCert.PlanBytes.lowerFieldProjectionCodeEntry carrier structIdx fieldCount resultTy plan = some codeEntry ∧
-    funcBindingForExport wasmBytes exportNameBytes = some binding ∧
-    projectionStructTypeMatches wasmBytes structIdx fieldCount plan.fieldIdx resultTy = true ∧
-    projectionFuncTypeMatches wasmBytes binding.typeIdx structIdx resultTy = true ∧
+    funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
+    projectionStructTypeMatches modBytes modLen structIdx fieldCount plan.fieldIdx resultTy = true ∧
+    projectionFuncTypeMatches modBytes modLen binding.typeIdx structIdx resultTy = true ∧
     obligation.self = binding.funcIdx ∧
     obligation.code binding.funcIdx = some { arity := 1, nlocals := 3, body := body }
 
 -- (e) STRUCT SELECTED-FIELD-TYPE dropped (`projectionStructTypeMatches`).
-def fpAccept_dropStruct (wasmBytes exportNameBytes : ByteSeq)
+def fpAccept_dropStruct (modBytes modLen : Nat) (exportNameBytes : ByteSeq)
     (exportName : String) (carrier structIdx fieldCount : Nat)
     (resultTy : FieldProjectionResultTy)
     (plan : FieldProjectionRawPlan) (obligation : Obligation) : Prop :=
@@ -3502,9 +3709,9 @@ def fpAccept_dropStruct (wasmBytes exportNameBytes : ByteSeq)
   ∃ body codeEntry binding,
     AverCert.PlanLower.lowerFieldProjectionBody structIdx fieldCount plan = some body ∧
     AverCert.PlanBytes.lowerFieldProjectionCodeEntry carrier structIdx fieldCount resultTy plan = some codeEntry ∧
-    funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+    funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
     binding.codeEntry = codeEntry ∧
-    projectionFuncTypeMatches wasmBytes binding.typeIdx structIdx resultTy = true ∧
+    projectionFuncTypeMatches modBytes modLen binding.typeIdx structIdx resultTy = true ∧
     obligation.self = binding.funcIdx ∧
     obligation.code binding.funcIdx = some { arity := 1, nlocals := 3, body := body }
 
@@ -3519,7 +3726,8 @@ def badBodyOb : Obligation := { AverCert.pairFstOb with code := badBodyCode }
 -- (0x64) at module offset 31. The code section and the func-type entry are
 -- byte-unchanged, so (d) and (f) still pass; only (e) reads the mutated struct
 -- field type.
-def structMut : ByteSeq := AverCert.ArtifactBytes.wasmBytes.set 31 100
+def structMut : Nat :=
+  AverCert.ArtifactBytes.modBytes + (1 <<< (8 * 31))
 
 -- Obligation export-name and carrier binds.
 def weakExport (_ _ : String) : Bool := true
@@ -3559,12 +3767,12 @@ example : weakLower badProfile = AverCert.PlanLower.lowerFieldProjectionBody 3 2
 -- complicit obligation (`badBodyOb`) supplying the wrong-field body, the
 -- code-table conjunct (h) is neutralized, leaving (d) as the sole guard on the
 -- field index: the wrong-field claim is ACCEPTED once (d) is dropped...
-example : fpAccept_dropBytes AverCert.ArtifactBytes.wasmBytes nameBytes "pairFst"
+example : fpAccept_dropBytes AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen nameBytes "pairFst"
     2 3 2 (.nullableRef 2) badField badBodyOb :=
   ⟨rfl, rfl, rfl, _, _, _, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 -- ...and the shipped predicate rejects it at exactly (d): the honest module
 -- code entry differs from the wrong-field canonical bytes.
-example : (funcBindingForExport AverCert.ArtifactBytes.wasmBytes nameBytes).map (fun b => b.codeEntry) ≠
+example : (funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen nameBytes).map (fun b => b.codeEntry) ≠
   AverCert.PlanBytes.lowerFieldProjectionCodeEntry 2 3 2 (.nullableRef 2) badField := by decide
 -- FIELD-INDEX defense-in-depth: (h) is a redundant-but-defensive sibling. When
 -- the obligation is the HONEST byte-derived one, its code table pins the field-0
@@ -3579,12 +3787,12 @@ example : AverCert.PlanBytes.lowerFieldProjectionCodeEntry 2 3 2 (.nullableRef 2
 
 -- Export-name/function-binding guard.
 def weakBinding (_ : List Nat) :=
-  AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes
+  AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen
     [112,97,105,114,70,115,116]
-example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes
+example : AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen
     [109,105,115,115,105,110,103] = none := rfl
 example : weakBinding [109,105,115,115,105,110,103] =
-  AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.wasmBytes
+  AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen
     [112,97,105,114,70,115,116] := rfl
 
 -- STRUCT SELECTED-FIELD-TYPE (e) — genuine predicate-level isolation. This guard
@@ -3595,37 +3803,37 @@ example : weakBinding [109,105,115,115,105,110,103] =
 -- section and func-type entry byte-identical. The honest claim is ACCEPTED once
 -- (e) is dropped (the byte gate (d) and signature (f) still pass over the
 -- mutated module because neither reads the struct's field types)...
-example : fpAccept_dropStruct structMut nameBytes "pairFst"
+example : fpAccept_dropStruct structMut AverCert.ArtifactBytes.modLen nameBytes "pairFst"
     2 3 2 (.nullableRef 2) honest AverCert.pairFstOb :=
   ⟨rfl, rfl, rfl, _, _, _, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 -- ...and the shipped predicate rejects the mutated module at exactly (e):
-example : AverCert.WasmSlice.projectionStructTypeMatches structMut 3 2 0 (.nullableRef 2) = false := rfl
+example : AverCert.WasmSlice.projectionStructTypeMatches structMut AverCert.ArtifactBytes.modLen 3 2 0 (.nullableRef 2) = false := rfl
 -- The siblings (d) byte gate and (f) signature are provably BLIND to the struct
 -- field-type mutation (they read the code and func-type sections):
-example : (funcBindingForExport structMut nameBytes).map (fun b => b.codeEntry) =
-  (funcBindingForExport AverCert.ArtifactBytes.wasmBytes nameBytes).map (fun b => b.codeEntry) := rfl
-example : AverCert.WasmSlice.projectionFuncTypeMatches structMut 6 3 (.nullableRef 2) = true := rfl
+example : (funcBindingForExport structMut AverCert.ArtifactBytes.modLen nameBytes).map (fun b => b.codeEntry) =
+  (funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen nameBytes).map (fun b => b.codeEntry) := rfl
+example : AverCert.WasmSlice.projectionFuncTypeMatches structMut AverCert.ArtifactBytes.modLen 6 3 (.nullableRef 2) = true := rfl
 -- The prior claim-data struct checks remain (structIdx / count / result ref) —
 -- these are also caught by the byte gate / signature, so this is the guard's
 -- redundant-but-defensive cross-check surface.
 example : AverCert.WasmSlice.projectionStructTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 3 2 0 (.nullableRef 2) = true := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 3 2 0 (.nullableRef 2) = true := rfl
 example : AverCert.WasmSlice.projectionStructTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 4 2 0 (.nullableRef 2) = false := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 4 2 0 (.nullableRef 2) = false := rfl
 example : AverCert.WasmSlice.projectionStructTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 3 3 0 (.nullableRef 2) = false := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 3 3 0 (.nullableRef 2) = false := rfl
 example : AverCert.WasmSlice.projectionStructTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 3 2 0 (.nullableRef 1) = false := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 3 2 0 (.nullableRef 1) = false := rfl
 
 -- The exported function must be unary over the claimed struct and return the
 -- selected byte-derived reference type.
 def weakSignature (_ _ : Nat) (_ : FieldProjectionResultTy) : Bool := true
 example : AverCert.WasmSlice.projectionFuncTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 6 3 (.nullableRef 2) = true := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 6 3 (.nullableRef 2) = true := rfl
 example : AverCert.WasmSlice.projectionFuncTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 6 4 (.nullableRef 2) = false := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 6 4 (.nullableRef 2) = false := rfl
 example : AverCert.WasmSlice.projectionFuncTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 6 3 (.nullableRef 1) = false := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 6 3 (.nullableRef 1) = false := rfl
 example : weakSignature 6 4 (.nullableRef 2) = true := rfl
 example : weakSignature 6 3 (.nullableRef 1) = true := rfl
 
@@ -4717,6 +4925,7 @@ fn verbatim_kernel_guards_are_isolating() {
     lean.push_str("import Schema\nimport PlanCheck\nimport PlanBytes\nimport WasmSlice\nimport AcceptedArtifact\n\n");
     lean.push_str("open AverCert\nopen AverCert.Schema\n");
     lean.push_str("set_option maxRecDepth 100000\n\n");
+    lean.push_str("def packLE : List Nat → Nat | [] => 0 | b :: bs => b + (packLE bs <<< 8)\n\n");
     // Minimal modules: header, type section, then a shared func/export/code/data
     // tail. `f` is func 0 of type 0; code entry `[2, 0, 11]`; data segment 0 is
     // "alpha" (passive). Only the type section differs between the two.
@@ -4728,18 +4937,18 @@ fn verbatim_kernel_guards_are_isolating() {
     lean.push_str("def binaryMod : List Nat := hdr ++ binaryType ++ tailSecs\n");
     lean.push_str("def nameF : List Nat := [102]\n\n");
     // SIGNATURE isolation: the byte-equality gate's inputs are identical...
-    lean.push_str("example : WasmSlice.funcBindingForExport unaryMod nameF = WasmSlice.funcBindingForExport binaryMod nameF := rfl\n");
-    lean.push_str("example : WasmSlice.codeEntryForExport unaryMod nameF = WasmSlice.codeEntryForExport binaryMod nameF := rfl\n");
+    lean.push_str("example : WasmSlice.funcBindingForExport (packLE unaryMod) unaryMod.length nameF = WasmSlice.funcBindingForExport (packLE binaryMod) binaryMod.length nameF := rfl\n");
+    lean.push_str("example : WasmSlice.codeEntryForExport (packLE unaryMod) unaryMod.length nameF = WasmSlice.codeEntryForExport (packLE binaryMod) binaryMod.length nameF := rfl\n");
     // ...and only the signature guard tells unary from binary.
     lean.push_str(
-        "example : WasmSlice.verbatimFuncTypeMatches unaryMod 0 (.refNull 5) = true := rfl\n",
+        "example : WasmSlice.verbatimFuncTypeMatches (packLE unaryMod) unaryMod.length 0 (.refNull 5) = true := rfl\n",
     );
     lean.push_str(
-        "example : WasmSlice.verbatimFuncTypeMatches binaryMod 0 (.refNull 5) = false := rfl\n\n",
+        "example : WasmSlice.verbatimFuncTypeMatches (packLE binaryMod) binaryMod.length 0 (.refNull 5) = false := rfl\n\n",
     );
     // PAYLOAD isolation: segment 0 is "alpha".
     lean.push_str(
-        "example : WasmSlice.dataSegmentBytes unaryMod 0 = some [97, 108, 112, 104, 97] := rfl\n",
+        "example : WasmSlice.dataSegmentBytes (packLE unaryMod) unaryMod.length 0 = some [97, 108, 112, 104, 97] := rfl\n",
     );
     lean.push_str("def planAlpha : VerbatimRawPlan := { profile := \"verbatim-plan-v1\", scrutineeLocal := 1, fieldLocal := 0, resultSig := .refNull 5, body := .leaf (.arrayNewData 5 0 [97, 108, 112, 104, 97]) }\n");
     lean.push_str("def planAlphB : VerbatimRawPlan := { profile := \"verbatim-plan-v1\", scrutineeLocal := 1, fieldLocal := 0, resultSig := .refNull 5, body := .leaf (.arrayNewData 5 0 [97, 108, 112, 104, 98]) }\n");
@@ -4749,9 +4958,9 @@ fn verbatim_kernel_guards_are_isolating() {
     lean.push_str("example : PlanBytes.lowerVerbatimCodeEntry 7 planAlpha = PlanBytes.lowerVerbatimCodeEntry 7 planAlphB := rfl\n");
     // ...so only `verbatimPayloadsBound` rejects the equal-length collision.
     lean.push_str(
-        "example : AcceptedArtifact.verbatimPayloadsBound unaryMod planAlpha.body = true := rfl\n",
+        "example : AcceptedArtifact.verbatimPayloadsBound (packLE unaryMod) unaryMod.length planAlpha.body = true := rfl\n",
     );
-    lean.push_str("example : AcceptedArtifact.verbatimPayloadsBound unaryMod planAlphB.body = false := rfl\n\n");
+    lean.push_str("example : AcceptedArtifact.verbatimPayloadsBound (packLE unaryMod) unaryMod.length planAlphB.body = false := rfl\n\n");
     // FIX 2(c): an out-of-range payload element is rejected up front.
     lean.push_str("example : PlanCheck.checkVerbatimRawPlan { profile := \"verbatim-plan-v1\", scrutineeLocal := 1, fieldLocal := 0, resultSig := .refNull 5, body := .leaf (.arrayNewData 5 0 [256]) } = false := rfl\n\n");
 
@@ -4770,10 +4979,10 @@ fn verbatim_kernel_guards_are_isolating() {
     lean.push_str(
         "def nonNullMod : List Nat := hdr ++ [1, 8, 1, 96, 1, 99, 4, 1, 100, 5] ++ tailSecs\n",
     );
-    lean.push_str("example : WasmSlice.funcBindingForExport nonNullMod nameF = WasmSlice.funcBindingForExport unaryMod nameF := rfl\n");
-    lean.push_str("example : WasmSlice.codeEntryForExport nonNullMod nameF = WasmSlice.codeEntryForExport unaryMod nameF := rfl\n");
+    lean.push_str("example : WasmSlice.funcBindingForExport (packLE nonNullMod) nonNullMod.length nameF = WasmSlice.funcBindingForExport (packLE unaryMod) unaryMod.length nameF := rfl\n");
+    lean.push_str("example : WasmSlice.codeEntryForExport (packLE nonNullMod) nonNullMod.length nameF = WasmSlice.codeEntryForExport (packLE unaryMod) unaryMod.length nameF := rfl\n");
     lean.push_str(
-        "example : WasmSlice.verbatimFuncTypeMatches nonNullMod 0 (.refNull 5) = false := rfl\n\n",
+        "example : WasmSlice.verbatimFuncTypeMatches (packLE nonNullMod) nonNullMod.length 0 (.refNull 5) = false := rfl\n\n",
     );
 
     // ABSTRACT-PARAM isolation: after `0x63` a NEGATIVE s33 heap type encodes an
@@ -4790,10 +4999,10 @@ fn verbatim_kernel_guards_are_isolating() {
     lean.push_str(
         "def abstractParamMod : List Nat := hdr ++ [1, 8, 1, 96, 1, 99, 109, 1, 99, 5] ++ tailSecs\n",
     );
-    lean.push_str("example : WasmSlice.funcBindingForExport abstractParamMod nameF = WasmSlice.funcBindingForExport unaryMod nameF := rfl\n");
-    lean.push_str("example : WasmSlice.codeEntryForExport abstractParamMod nameF = WasmSlice.codeEntryForExport unaryMod nameF := rfl\n");
+    lean.push_str("example : WasmSlice.funcBindingForExport (packLE abstractParamMod) abstractParamMod.length nameF = WasmSlice.funcBindingForExport (packLE unaryMod) unaryMod.length nameF := rfl\n");
+    lean.push_str("example : WasmSlice.codeEntryForExport (packLE abstractParamMod) abstractParamMod.length nameF = WasmSlice.codeEntryForExport (packLE unaryMod) unaryMod.length nameF := rfl\n");
     lean.push_str(
-        "example : WasmSlice.verbatimFuncTypeMatches abstractParamMod 0 (.refNull 5) = false := rfl\n\n",
+        "example : WasmSlice.verbatimFuncTypeMatches (packLE abstractParamMod) abstractParamMod.length 0 (.refNull 5) = false := rfl\n\n",
     );
 
     // PARSER STRICTNESS isolation (re-review FIX 3): the type-section and
@@ -4804,23 +5013,23 @@ fn verbatim_kernel_guards_are_isolating() {
     // Type section: a trailing `0xff` after the one valid func type.
     lean.push_str("def trailingTypeMod : List Nat := hdr ++ [1, 9, 1, 96, 1, 99, 4, 1, 99, 5, 255] ++ tailSecs\n");
     lean.push_str(
-        "example : WasmSlice.verbatimFuncTypeMatches trailingTypeMod 0 (.refNull 5) = false := rfl\n",
+        "example : WasmSlice.verbatimFuncTypeMatches (packLE trailingTypeMod) trailingTypeMod.length 0 (.refNull 5) = false := rfl\n",
     );
     // Type section: count claims 2 rectypes but only 1 is present.
     lean.push_str("def countMismatchTypeMod : List Nat := hdr ++ [1, 8, 2, 96, 1, 99, 4, 1, 99, 5] ++ tailSecs\n");
     lean.push_str(
-        "example : WasmSlice.verbatimFuncTypeMatches countMismatchTypeMod 0 (.refNull 5) = false := rfl\n",
+        "example : WasmSlice.verbatimFuncTypeMatches (packLE countMismatchTypeMod) countMismatchTypeMod.length 0 (.refNull 5) = false := rfl\n",
     );
     // Data section: a trailing `0xff` after the one valid segment.
     lean.push_str(
         "def dataTrailMod : List Nat := hdr ++ [11, 9, 1, 1, 5, 97, 108, 112, 104, 97, 255]\n",
     );
-    lean.push_str("example : WasmSlice.dataSegmentBytes dataTrailMod 0 = none := rfl\n");
+    lean.push_str("example : WasmSlice.dataSegmentBytes (packLE dataTrailMod) dataTrailMod.length 0 = none := rfl\n");
     // Data section: count claims 2 segments but only 1 is present.
     lean.push_str(
         "def dataCountMismatchMod : List Nat := hdr ++ [11, 8, 2, 1, 5, 97, 108, 112, 104, 97]\n",
     );
-    lean.push_str("example : WasmSlice.dataSegmentBytes dataCountMismatchMod 0 = none := rfl\n");
+    lean.push_str("example : WasmSlice.dataSegmentBytes (packLE dataCountMismatchMod) dataCountMismatchMod.length 0 = none := rfl\n");
     // Over-wide (6-byte) unsigned LEB32 exceeds the u32 width cap and declines.
     lean.push_str("example : WasmSlice.readUleb32 [128, 128, 128, 128, 128, 0] = none := rfl\n");
     lean.push_str("example : WasmSlice.readS33 [128, 128, 128, 128, 128, 0] = none := rfl\n");
@@ -4875,45 +5084,46 @@ def isoOb : Obligation :=
     model := fun _ => () }
 
 def weakVerbatimPlanAcceptedWithoutResultSig
-    (wasmBytes exportNameBytes : WasmSlice.ByteSeq) (exportName : String)
+    (modBytes modLen : Nat) (exportNameBytes : WasmSlice.ByteSeq) (exportName : String)
     (carrier : Nat) (plan : VerbatimRawPlan) (obligation : Obligation) : Prop :=
   obligation.export_ = exportName ∧
     obligation.carrier = carrier ∧
     PlanCheck.checkVerbatimRawPlan plan = true ∧
     ∃ codeEntry binding,
       PlanBytes.lowerVerbatimCodeEntry carrier plan = some codeEntry ∧
-      WasmSlice.codeEntryForExport wasmBytes exportNameBytes = some codeEntry ∧
-      WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+      WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+      WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
       binding.funcIdx = obligation.self ∧
       binding.codeEntry = codeEntry ∧
-      AcceptedArtifact.verbatimPayloadsBound wasmBytes plan.body = true ∧
+      AcceptedArtifact.verbatimPayloadsBound modBytes modLen plan.body = true ∧
       obligation.code binding.funcIdx =
         some { arity := 1, nlocals := AcceptedArtifact.verbatimNLocals plan,
                body := PlanLower.lowerVerbatimBody plan }
 
-example : WasmSlice.verbatimFuncTypeMatches isoF64Mod 0 .f64Scalar = true := rfl
-example : WasmSlice.verbatimFuncTypeMatches isoF64Mod 0 (.refNull 5) = false := rfl
-example : WasmSlice.verbatimFuncTypeMatches isoRefMod 0 (.refNull 5) = true := rfl
-example : WasmSlice.verbatimFuncTypeMatches isoRefMod 0 .f64Scalar = false := rfl
+example : WasmSlice.verbatimFuncTypeMatches (packLE isoF64Mod) isoF64Mod.length 0 .f64Scalar = true := rfl
+example : WasmSlice.verbatimFuncTypeMatches (packLE isoF64Mod) isoF64Mod.length 0 (.refNull 5) = false := rfl
+example : WasmSlice.verbatimFuncTypeMatches (packLE isoRefMod) isoRefMod.length 0 (.refNull 5) = true := rfl
+example : WasmSlice.verbatimFuncTypeMatches (packLE isoRefMod) isoRefMod.length 0 .f64Scalar = false := rfl
 
 example : weakVerbatimPlanAcceptedWithoutResultSig
-    isoRefMod isoNameF "f" 7 isoF64Plan isoOb := by
+    (packLE isoRefMod) isoRefMod.length isoNameF "f" 7 isoF64Plan isoOb := by
   refine ⟨rfl, rfl, rfl, ⟨_, _, rfl, rfl, rfl, rfl, rfl, rfl, ?_⟩⟩
-  simp [isoOb, isoCode, AcceptedArtifact.verbatimNLocals, isoF64Plan,
+  simp [packLE, isoRefMod, isoHdr, isoRefType, isoTail, isoOb, isoCode,
+    AcceptedArtifact.verbatimNLocals, isoF64Plan,
     PlanCheck.dispatchHasProjection]
   rfl
 
 example : ¬ AcceptedArtifact.verbatimPlanAccepted
-    isoRefMod isoNameF "f" 7 isoF64Plan isoOb := by
+    (packLE isoRefMod) isoRefMod.length isoNameF "f" 7 isoF64Plan isoOb := by
   intro h
   rcases h with ⟨_, _, _, ⟨_, binding, _, _, hbinding, _, _, hsig, _, _⟩⟩
-  have known : WasmSlice.funcBindingForExport isoRefMod isoNameF =
+  have known : WasmSlice.funcBindingForExport (packLE isoRefMod) isoRefMod.length isoNameF =
       some isoExpectedBinding := by rfl
   rw [known] at hbinding
   injection hbinding with hb
   subst binding
-  change WasmSlice.verbatimFuncTypeMatches isoRefMod 0 .f64Scalar = true at hsig
-  have cross : WasmSlice.verbatimFuncTypeMatches isoRefMod 0 .f64Scalar = false := rfl
+  change WasmSlice.verbatimFuncTypeMatches (packLE isoRefMod) isoRefMod.length 0 .f64Scalar = true at hsig
+  have cross : WasmSlice.verbatimFuncTypeMatches (packLE isoRefMod) isoRefMod.length 0 .f64Scalar = false := rfl
   rw [cross] at hsig
   contradiction
 "#,
@@ -5401,18 +5611,18 @@ example : sourceAccepted honestPrependSym permutedPrepend = false := rfl
 -- struct and the exported signature. A coherent symbolic relabel cannot turn
 -- the fixture's concrete `(ref null 39)` element into another byte type.
 example : AverCert.WasmSlice.listConstructStructTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 28 (.nullableRef 39) = true := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 28 (.nullableRef 39) = true := rfl
 example : AverCert.WasmSlice.listConstructFuncTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 63 1 28 (.nullableRef 39) = true := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 63 1 28 (.nullableRef 39) = true := rfl
 example : AverCert.WasmSlice.listConstructStructTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 28 .eqref = false := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 28 .eqref = false := rfl
 example : AverCert.WasmSlice.listConstructFuncTypeMatches
-    AverCert.ArtifactBytes.wasmBytes 63 1 28 .eqref = false := rfl
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen 63 1 28 .eqref = false := rfl
 
 -- CountAttack: predicate-level copy of constructPlanAccepted dropping ONLY
 -- `plan.fields.length = fieldCount`.
 def constructDropCount
-    (wasmBytes exportNameBytes : ByteSeq) (exportName : String)
+    (modBytes modLen : Nat) (exportNameBytes : ByteSeq) (exportName : String)
     (carrier structIdx : Nat) (elemTy : ConstructValType)
     (symPlan : SymRawPlan) (plan : ConstructRawPlan) (obligation : Obligation) : Prop :=
   obligation.export_ = exportName ∧ obligation.carrier = carrier ∧
@@ -5422,21 +5632,21 @@ def constructDropCount
   ∃ body codeEntry binding,
     AverCert.PlanLower.lowerConstructBody structIdx plan = some body ∧
     AverCert.PlanBytes.lowerConstructCodeEntry carrier structIdx plan = some codeEntry ∧
-    AverCert.WasmSlice.codeEntryForExport wasmBytes exportNameBytes = some codeEntry ∧
-    AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+    AverCert.WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+    AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
     binding.funcIdx = obligation.self ∧ binding.codeEntry = codeEntry ∧
-    AverCert.WasmSlice.listConstructStructTypeMatches wasmBytes structIdx elemTy = true ∧
+    AverCert.WasmSlice.listConstructStructTypeMatches modBytes modLen structIdx elemTy = true ∧
     AverCert.WasmSlice.listConstructFuncTypeMatches
-      wasmBytes binding.typeIdx plan.arity structIdx elemTy = true ∧
+      modBytes modLen binding.typeIdx plan.arity structIdx elemTy = true ∧
     obligation.code binding.funcIdx = some { arity := plan.arity, nlocals := 1, body := body }
-example : constructDropCount AverCert.ArtifactBytes.wasmBytes honestClaim.exportNameBytes
+example : constructDropCount AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen honestClaim.exportNameBytes
     honestClaim.exportName honestClaim.carrier honestClaim.structIdx honestClaim.elemTy
     honestClaim.symPlan honestSingleton honestClaim.obligation :=
   ⟨rfl, rfl, rfl, rfl, rfl, _, _, _, rfl, rfl, rfl, rfl, rfl, rfl,
     AverCert.Plans.singletonJsonEntriesConstructStructTypeMatches,
     AverCert.Plans.singletonJsonEntriesConstructFuncTypeMatches, rfl⟩
 example : ¬ AverCert.AcceptedArtifact.constructPlanAccepted
-    AverCert.ArtifactBytes.wasmBytes honestClaim.exportNameBytes honestClaim.exportName
+    AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen honestClaim.exportNameBytes honestClaim.exportName
     honestClaim.carrier honestClaim.structIdx 3 honestClaim.elemTy honestClaim.symPlan
     honestSingleton honestClaim.obligation := by
   intro h
@@ -5445,9 +5655,13 @@ example : ¬ AverCert.AcceptedArtifact.constructPlanAccepted
 
 -- ByteAttack: predicate-level copy dropping ONLY the exact code-entry gate
 -- (`codeEntryForExport` plus the same equality repeated in FuncBinding).
-def tamperedBytes := AverCert.ArtifactBytes.wasmBytes.set __BYTE_OFFSET__ 24
+def tamperedBytes :=
+  let shift := 8 * __BYTE_OFFSET__
+  AverCert.ArtifactBytes.modBytes -
+      (((AverCert.ArtifactBytes.modBytes >>> shift) &&& 0xff) <<< shift) +
+    (24 <<< shift)
 def constructDropByteExact
-    (wasmBytes exportNameBytes : ByteSeq) (exportName : String)
+    (modBytes modLen : Nat) (exportNameBytes : ByteSeq) (exportName : String)
     (carrier structIdx fieldCount : Nat) (elemTy : ConstructValType)
     (symPlan : SymRawPlan) (plan : ConstructRawPlan) (obligation : Obligation) : Prop :=
   obligation.export_ = exportName ∧ obligation.carrier = carrier ∧
@@ -5457,26 +5671,26 @@ def constructDropByteExact
   ∃ body codeEntry binding,
     AverCert.PlanLower.lowerConstructBody structIdx plan = some body ∧
     AverCert.PlanBytes.lowerConstructCodeEntry carrier structIdx plan = some codeEntry ∧
-    AverCert.WasmSlice.funcBindingForExport wasmBytes exportNameBytes = some binding ∧
+    AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
     binding.funcIdx = obligation.self ∧
-    AverCert.WasmSlice.listConstructStructTypeMatches wasmBytes structIdx elemTy = true ∧
+    AverCert.WasmSlice.listConstructStructTypeMatches modBytes modLen structIdx elemTy = true ∧
     AverCert.WasmSlice.listConstructFuncTypeMatches
-      wasmBytes binding.typeIdx plan.arity structIdx elemTy = true ∧
+      modBytes modLen binding.typeIdx plan.arity structIdx elemTy = true ∧
     obligation.code binding.funcIdx = some { arity := plan.arity, nlocals := 1, body := body }
-example : constructDropByteExact tamperedBytes honestClaim.exportNameBytes honestClaim.exportName
+example : constructDropByteExact tamperedBytes AverCert.ArtifactBytes.modLen honestClaim.exportNameBytes honestClaim.exportName
     honestClaim.carrier honestClaim.structIdx honestClaim.fieldCount honestClaim.elemTy
     honestClaim.symPlan honestSingleton honestClaim.obligation :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl, _, _, _, rfl, rfl, rfl, rfl,
     AverCert.Plans.singletonJsonEntriesConstructStructTypeMatches,
     AverCert.Plans.singletonJsonEntriesConstructFuncTypeMatches, rfl⟩
-example : ¬ AverCert.AcceptedArtifact.constructPlanAccepted tamperedBytes
+example : ¬ AverCert.AcceptedArtifact.constructPlanAccepted tamperedBytes AverCert.ArtifactBytes.modLen
     honestClaim.exportNameBytes honestClaim.exportName honestClaim.carrier honestClaim.structIdx
     honestClaim.fieldCount honestClaim.elemTy honestClaim.symPlan honestSingleton
     honestClaim.obligation := by
   intro h
   rcases h with ⟨_, _, _, _, _, _, _, _, _, _, hlower, hexact, _⟩
   exact (by decide :
-    AverCert.WasmSlice.codeEntryForExport tamperedBytes honestClaim.exportNameBytes ≠
+    AverCert.WasmSlice.codeEntryForExport tamperedBytes AverCert.ArtifactBytes.modLen honestClaim.exportNameBytes ≠
       AverCert.PlanBytes.lowerConstructCodeEntry honestClaim.carrier honestClaim.structIdx
         honestSingleton) (hexact.trans hlower.symm)
 
@@ -5501,7 +5715,7 @@ example : localsAccepted zeroCode = false := rfl
 def orphanPlans : List (String × ConstructRawPlan) :=
   AverCert.manifest.constructPlans ++ [("orphan", honestSingleton)]
 def constructFamilyDropNames (manifest : Manifest) (claims : List AverCert.AcceptedArtifact.ConstructClaim) : Prop :=
-  AverCert.AcceptedArtifact.constructClaimsAccepted AverCert.ArtifactBytes.wasmBytes manifest claims ∧
+  AverCert.AcceptedArtifact.constructClaimsAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen manifest claims ∧
   (AverCert.AcceptedArtifact.constructClaimExportNames claims).Nodup
 def orphanManifest : Manifest := { AverCert.manifest with constructPlans := orphanPlans }
 example : constructFamilyDropNames orphanManifest AverCert.Artifact.constructClaims := by
@@ -5522,7 +5736,7 @@ def dupPlans := [(honestClaim.exportName, honestSingleton),
   (honestClaim.exportName, permutedPrepend)]
 def dupManifest : Manifest := { AverCert.manifest with constructPlans := dupPlans }
 def constructFamilyDropNodup (manifest : Manifest) (claims : List AverCert.AcceptedArtifact.ConstructClaim) : Prop :=
-  AverCert.AcceptedArtifact.constructClaimsAccepted AverCert.ArtifactBytes.wasmBytes manifest claims ∧
+  AverCert.AcceptedArtifact.constructClaimsAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen manifest claims ∧
   AverCert.AcceptedArtifact.constructClaimExportNames claims =
     AverCert.AcceptedArtifact.constructManifestPlanNames manifest
 example : constructFamilyDropNodup dupManifest dupClaims := by
@@ -5570,6 +5784,7 @@ fn int_dispatch_kernel_guards_are_isolating() {
     );
     lean.push_str("open AverCert\nopen AverCert.Schema\nopen CertPrelude\n");
     lean.push_str("set_option maxRecDepth 100000\n\n");
+    lean.push_str("def packLE : List Nat → Nat | [] => 0 | b :: bs => b + (packLE bs <<< 8)\n\n");
     // Minimal modules: header, type section, then a shared func/export/code
     // tail. `f` is func 0 of type 0; code entry `[2, 0, 11]`. Only the type
     // section differs between the two: type 0 is one nominal-root ref ->
@@ -5590,14 +5805,14 @@ fn int_dispatch_kernel_guards_are_isolating() {
     lean.push_str("def binaryMod : List Nat := hdr ++ binaryType ++ tailSecs\n");
     lean.push_str("def nameF : List Nat := [102]\n\n");
     // SIGNATURE isolation: the byte-equality gate's inputs are identical...
-    lean.push_str("example : WasmSlice.funcBindingForExport unaryMod nameF = WasmSlice.funcBindingForExport binaryMod nameF := rfl\n");
-    lean.push_str("example : WasmSlice.codeEntryForExport unaryMod nameF = WasmSlice.codeEntryForExport binaryMod nameF := rfl\n");
+    lean.push_str("example : WasmSlice.funcBindingForExport (packLE unaryMod) unaryMod.length nameF = WasmSlice.funcBindingForExport (packLE binaryMod) binaryMod.length nameF := rfl\n");
+    lean.push_str("example : WasmSlice.codeEntryForExport (packLE unaryMod) unaryMod.length nameF = WasmSlice.codeEntryForExport (packLE binaryMod) binaryMod.length nameF := rfl\n");
     // ...and only the signature guard tells unary from binary.
     lean.push_str(
-        "example : WasmSlice.verbatimFuncTypeMatches unaryMod 0 (.refNull 5) = true := rfl\n",
+        "example : WasmSlice.verbatimFuncTypeMatches (packLE unaryMod) unaryMod.length 0 (.refNull 5) = true := rfl\n",
     );
     lean.push_str(
-        "example : WasmSlice.verbatimFuncTypeMatches binaryMod 0 (.refNull 5) = false := rfl\n\n",
+        "example : WasmSlice.verbatimFuncTypeMatches (packLE binaryMod) binaryMod.length 0 (.refNull 5) = false := rfl\n\n",
     );
     // HOST-TABLE DISTINCTNESS isolation: two plans differing ONLY in the arm's
     // host ROLE.

--- a/tools/certkit/prelude/CertDecode.lean
+++ b/tools/certkit/prelude/CertDecode.lean
@@ -99,8 +99,10 @@ def walkIds : Nat → Nat → Nat → Option (List Nat)
             | none => none
             | some tl => some (id :: tl)
 
-/-- Body suffix `(n, len)` of the first section with id = target, else none. -/
-def findSec (target : Nat) : Nat → Nat → Nat → Option (Nat × Nat)
+/-- First target section as `(payload bytes, payload size, suffix length at the
+    payload start)`. This is the single bounds-checked section-frame walker
+    shared by the format-B decoder and the certificate Wasm slicer. -/
+def findSecFrame (target : Nat) : Nat → Nat → Nat → Option (Nat × Nat × Nat)
   | 0,      _, _   => none
   | fuel+1, n, len =>
       if len == 0 then none else
@@ -109,8 +111,19 @@ def findSec (target : Nat) : Nat → Nat → Nat → Option (Nat × Nat)
         match readU n1 (len-1) with
         | none => none
         | some (size, n2, len2) =>
-            if id == target then some (n2, len2)
-            else findSec target fuel (n2 >>> (8*size)) (len2 - size)
+            if size ≤ len2 then
+              if id == target then some (n2, size, len2)
+              else findSecFrame target fuel (n2 >>> (8*size)) (len2 - size)
+            else none
+
+/-- Body suffix `(n, len)` of the first section with id = target, else none.
+    Kept as the format-B decoder API; framing is delegated to `findSecFrame`. -/
+def findSec (target fuel n len : Nat) : Option (Nat × Nat) :=
+  (findSecFrame target fuel n len).map (fun p => (p.1, p.2.2))
+
+/-- Exact `(payload bytes, payload size)` of the first target section. -/
+def findSecPayload (target fuel n len : Nat) : Option (Nat × Nat) :=
+  (findSecFrame target fuel n len).map (fun p => (p.1, p.2.1))
 
 /- ===================================================================== -/
 /-  Type section (arity per type index, struct field counts, carrier)     -/


### PR DESCRIPTION
## Summary
- The kernel navigates the wasm module as one little-endian `Nat` plus an explicit byte length instead of a `List Nat`: reading a byte is a mask, skipping a section is one GMP shift, and the giant cons-literal elaboration cost disappears. The design was de-risked by a dedicated spike proving the identical proposition kernel-clean at scales where the list path fails closed with a deterministic timeout.
- The section walker is shared with the in-kernel decoder (`CertDecode.lean`), which becomes an explicitly checker-owned, sha-pinned audited file — one byte model for both directions instead of two parallel slicers.
- Export names, code entries, data payloads, and extracted type entries stay `List Nat`, so the certified byte-equality propositions are textually unchanged and every small parser with its strictness guarantees (s33 bounds, verbatim signature checks, projection/constructor type binding, exact section exhaustion) is untouched.
- The byte length is the one new soundness obligation (trailing zero bytes vanish in a numeral): it is threaded and pinned through every module-facing predicate, and the verifier derives it from the hash-checked raw module rather than trusting manifest metadata.
- Both proof emitters (certify-side renderer and verify-side witness) emit the new representation. Certificate schema bumps to 46.

## Performance
- End-to-end `aver cert verify`: json 30.7KB — ~109s → ~38s; cert_goals 10.2KB — ~133s → ~41s (independently reproduced by the integrator: 40.8s, CERTIFIED, exit 0).
- New regression: a real module padded to 130,460 bytes closes its code-entry pin in ~26s at default heartbeats, where the list path deterministically timed out; a negative control flips one expected byte and the pin fails, proving non-vacuity.

## Testing
- `cargo fmt --check`, `cargo build --bin aver --features wasm`, `cargo clippy --features wasm,wasip2 -- -D warnings`
- `cargo test -p aver-lang --features wasm --lib` (1020 passed)
- `cert_certify_spec` (11, corpus lake builds), `cert_decode_spec` (2)
- Targeted verify: parser-strictness and manifest guard-isolation tests, plus the new large-module regression; full verify suite in CI
- End-to-end certify+verify on cert_goals and json, both CERTIFIED

🤖 Generated with [Claude Code](https://claude.com/claude-code)