### PR TITLE
Certify bounded total correctness for unary integer descent recursion

### DIFF
--- a/docs/certification.md
+++ b/docs/certification.md
@@ -161,11 +161,21 @@ Parameterized List construction uses the same plan-backed constructor bridge as 
 | level | meaning |
 |---|---|
 | L0 | source-level verification only; no artifact claim |
-| **L1 (current)** | artifact claim, conditional on the named runtime contracts in the manifest |
+| L1 | partial-correctness artifact claim, conditional on the named runtime contracts in the manifest |
 | L2 | runtime contracts themselves proven against the shipped helper bodies |
-| L3 | additionally totality/resource bounds ("bounded total correctness on valid inputs") |
+| **L3 (current for promoted exports)** | total correctness: a represented valid input returns a represented model result at the fuel selected by a checked measure witness |
+| Future | resource bounds (not claimed by L3) |
 
 The manifest always declares its level. A certificate never silently claims more than its level supports.
+
+For the current L3 descent-by-one family, the checked witness is `Int.natAbs`
+of the recursive input and the total theorem runs the byte-pinned body with
+`n.natAbs + 1` fuel. “Total” here means that this run returns a value related to
+the source model, rather than only describing a value if execution happens to
+return. The statement remains conditional on the named `hAddTot` and `hSubTot`
+host contracts: `Int.add` and `Int.sub` must themselves be total on represented
+values. Those helper bodies are still assumed at L3; proving them is the L2
+ratchet. L3 makes no time, memory, or other resource-bound claim.
 
 ## Honest limits (v0)
 

--- a/src/codegen/cert/AcceptedArtifactCore.lean
+++ b/src/codegen/cert/AcceptedArtifactCore.lean
@@ -445,6 +445,10 @@ def recursionPlanAccepted
   obligation.export_ = exportName ∧
     obligation.carrier = carrier ∧
     AverCert.PlanCheck.checkRecursionRawPlan plan = true ∧
+    (match obligation.policy, obligation.termination? with
+     | .simulatesModel, none => true
+     | .simulatesModelTotally, some witness => AverCert.Schema.checkTerm plan witness
+     | _, _ => false) = true ∧
     ∃ body codeEntry binding,
       AverCert.PlanLower.lowerRecursionBody carrier plan = some body ∧
       AverCert.PlanBytes.lowerRecursionCodeEntry carrier plan = some codeEntry ∧

--- a/src/codegen/cert/Schema.lean
+++ b/src/codegen/cert/Schema.lean
@@ -10,8 +10,8 @@ import SchemaCore
 namespace AverCert.Schema
 
 /-- The single audited certificate proposition: the manifest's pinned hash is
-    the module hash, and every certified export carries `simulatesModel` and
-    genuinely simulates its model. -/
+    the module hash, and every certified export satisfies the partial or total
+    model-simulation denotation selected by its policy. -/
 def Holds (m : Manifest) : Prop :=
   m.subject.artifactHash = CertModule.wasmSha256 ∧ HoldsCore m
 

--- a/src/codegen/cert/SchemaCore.lean
+++ b/src/codegen/cert/SchemaCore.lean
@@ -20,10 +20,27 @@ structure Subject where
   exports      : List String
   contracts    : List String
 
-/-- The certification policy attached to a certified export. v0 ships exactly
-    one constructor: the emitted body simulates the generated model. -/
+/-- The certification policy attached to a certified export. Partial simulation
+    remains the default; the total preset additionally promises return at the
+    fuel selected by the checked termination witness. -/
 inductive Policy where
   | simulatesModel
+  | simulatesModelTotally
+
+/-- Closed measure vocabulary for the first total-correctness family. The
+    parameter index is claim data; `checkTerm` below accepts it only when the
+    byte-bound recursion plan descends that integer parameter by one. -/
+inductive Measure where
+  | intNatAbs (paramIdx : Nat)
+deriving Repr, DecidableEq
+
+/-- Non-canonical termination evidence attached to an obligation rather than
+    its byte-origin plan. Multiple measures may justify the same code bytes;
+    the kernel checks the selected measure against the pinned descent. -/
+structure TerminationWitness where
+  measure : Measure
+  descent : Int
+deriving Repr, DecidableEq
 
 /-- Value representation types admitted by the `expr-fragment-v1` plan grammar.
     This is the Lean-data mirror of the Rust `ExprFragmentPlan` sidecar: v1
@@ -226,6 +243,83 @@ structure RecursionRawPlan where
   result  : FragTy
   body    : FragBlock
 deriving Repr
+
+/-! ### Termination-witness checking
+
+`recursion-plan-v1` is separately checked and lowered byte-exactly by artifact
+acceptance. The helpers here inspect the same raw plan and confirm the one L3
+measure currently admitted: `Int.natAbs` of the sole parameter, guarded at
+`n ≤ 0`, with a recursive argument computed as `sub(n, box 1)`. -/
+
+def checkTermSmallFloor (paramIdx : Nat) (block : FragBlock) : Bool :=
+  match block.result, block.nodes with
+  | 3,
+      [{ id := 0, ty := .intCarrier, kind := .local localIdx },
+       { id := 1, ty := .i64, kind := .structGet 0 0 },
+       { id := 2, ty := .i64, kind := .constI64 0 },
+       { id := 3, ty := .boolI32, kind := .prim .i64LeS [1, 2] }] =>
+      localIdx == paramIdx
+  | _, _ => false
+
+def checkTermBigFloor (paramIdx : Nat) (block : FragBlock) : Bool :=
+  match block.result, block.nodes with
+  | 3,
+      [{ id := 0, ty := .intCarrier, kind := .local localIdx },
+       { id := 1, ty := .rawI32, kind := .structGet 2 0 },
+       { id := 2, ty := .boolI32, kind := .constBool false },
+       { id := 3, ty := .boolI32, kind := .prim .i32LtS [1, 2] }] =>
+      localIdx == paramIdx
+  | _, _ => false
+
+/-- The step arm selected by the canonical small/big carrier discriminator and
+    non-positive floor guard. Returning `none` rejects any different guard. -/
+def checkTermStep? (paramIdx : Nat) (body : FragBlock) : Option FragBlock :=
+  match body.result, body.nodes with
+  | 4,
+      [{ id := 0, ty := .intCarrier, kind := .local localIdx },
+       { id := 1, ty := .ref, kind := .structGet 1 0 },
+       { id := 2, ty := .boolI32, kind := .refIsNull 1 },
+       { id := 3, ty := .boolI32, kind := .ifElse 2 small big },
+       { id := 4, ty := .intCarrier, kind := .ifElse 3 _base step }] =>
+      if localIdx == paramIdx && checkTermSmallFloor paramIdx small &&
+          checkTermBigFloor paramIdx big then some step else none
+  | _, _ => none
+
+/-- Does one node in the step arm call self on exactly
+    `sub(local paramIdx, box(1))`? Node ids are followed within the same checked
+    ANF block; host indices and the self index remain byte-bound by the ordinary
+    recursion-plan acceptance predicate. -/
+def checkTermDescent (paramIdx : Nat) (step : FragBlock) : Bool :=
+  step.nodes.any fun node =>
+    match node.kind with
+    | .selfCall false _ [descentId] =>
+        match step.nodes[descentId]? with
+        | some { kind := .hostCall .sub _ [inputId, boxedOneId], .. } =>
+            match step.nodes[inputId]?, step.nodes[boxedOneId]? with
+            | some { kind := .local localIdx, .. },
+              some { kind := .hostCall .box _ [oneId], .. } =>
+                match step.nodes[oneId]? with
+                | some { kind := .constI64 1, .. } => localIdx == paramIdx
+                | _ => false
+            | _, _ => false
+        | _ => false
+    | _ => false
+
+/-- Kernel decision procedure for the promoted unary descent-by-one family.
+    It does not synthesise a measure: it checks the claimed `natAbs` parameter,
+    the `-1` descent, the non-positive floor guard, and the exact recursive
+    argument chain already pinned to the module bytes by the plan gate. -/
+def checkTerm (plan : RecursionRawPlan) (witness : TerminationWitness) : Bool :=
+  match witness.measure with
+  | .intNatAbs paramIdx =>
+      plan.profile == "recursion-plan-v1" &&
+      plan.params == [.intCarrier] &&
+      plan.result == .intCarrier &&
+      paramIdx == 0 &&
+      witness.descent == (-1 : Int) &&
+      match checkTermStep? paramIdx plan.body with
+      | some step => checkTermDescent paramIdx step
+      | none => false
 
 /-- Raw, untrusted mutual-recursion member plan. Like `RecursionRawPlan` it
     reuses the `expr-fragment` ANF grammar with a `selfCall` node and an
@@ -490,6 +584,7 @@ def verbatimRepr (_S : CarrierSpec C) (v : WVal) (w : WVal) : Prop := w = v
 structure Obligation where
   export_ : String
   policy  : Policy
+  termination? : Option TerminationWitness := none
   carrier : Nat
   code    : CodeTbl
   host    :
@@ -527,6 +622,30 @@ def Obligation.holds (o : Obligation) : Prop :=
     wFuncN o.code (o.host add sub mul stringEq stringConcat) fuel o.self vs = some w →
     o.codRepr S (o.model x) w
 
+/-- Denotation of `simulatesModelTotally`. In addition to the five existing
+    partial host laws it assumes that integer add and sub return on represented
+    operands. For every represented integer input, the body must return at
+    fuel `natAbs n + 1`; the domain witness connects that standard integer face
+    to the obligation's independently pinned model and representations. For the
+    promoted unary recursion obligations this unfolds to
+    `∃ w, run (natAbs n + 1) = some w ∧ Repr (f n) w`. -/
+def Obligation.holdsTotal (o : Obligation) : Prop :=
+  ∀ (S : CarrierSpec o.carrier)
+    (add sub mul stringEq : List WVal → Option WVal)
+    (stringConcat : Nat → List WVal → Option WVal)
+    (_hadd : ∀ a b va vb w, S.Repr a va → S.Repr b vb → add [va, vb] = some w → S.Repr (a + b) w)
+    (_hsub : ∀ a b va vb w, S.Repr a va → S.Repr b vb → sub [va, vb] = some w → S.Repr (a - b) w)
+    (_hmul : ∀ a b va vb w, S.Repr a va → S.Repr b vb → mul [va, vb] = some w → S.Repr (a * b) w)
+    (_hStringEq : ∀ a b w, stringEq [a, b] = some w → w = b32 (stringEqW a b))
+    (_hStringConcat : ∀ resultTy parts c, stringConcat resultTy [parts] = some c → stringConcatW resultTy parts = some c)
+    (_hAddTot : ∀ a b va vb, S.Repr a va → S.Repr b vb → ∃ w, add [va, vb] = some w)
+    (_hSubTot : ∀ a b va vb, S.Repr a va → S.Repr b vb → ∃ w, sub [va, vb] = some w)
+    (n : Int) (v : WVal), S.Repr n v →
+    ∃ x : o.Dom, o.domRepr S x [v] ∧
+      ∃ w, wFuncN o.code (o.host add sub mul stringEq stringConcat)
+          (n.natAbs + 1) o.self [v] = some w ∧
+        o.codRepr S (o.model x) w
+
 structure Manifest where
   subject     : Subject
   symFragmentPlans : List (String × SymRawPlan)
@@ -543,9 +662,11 @@ structure Manifest where
   obligations : List Obligation
 
 /-- The artifact-independent part of the audited certificate proposition:
-    every certified export carries `simulatesModel` and genuinely simulates
-    its model. -/
+    each export satisfies the denotation selected by its policy. -/
 def HoldsCore (m : Manifest) : Prop :=
-  ∀ o ∈ m.obligations, o.policy = Policy.simulatesModel ∧ o.holds
+  ∀ o ∈ m.obligations,
+    match o.policy with
+    | .simulatesModel => o.holds
+    | .simulatesModelTotally => o.holdsTotal
 
 end AverCert.Schema

--- a/src/codegen/cert/analysis.rs
+++ b/src/codegen/cert/analysis.rs
@@ -167,7 +167,13 @@ fn runtime_contracts_for_certs<'a>(certs: impl IntoIterator<Item = &'a Cert>) ->
     let mut has_sub = false;
     let mut has_string_eq = false;
     let mut has_string_concat = false;
+    let mut has_add_total = false;
+    let mut has_sub_total = false;
     for c in certs {
+        if c.policy() == CertificationPolicy::SimulatesModelTotally {
+            has_add_total = true;
+            has_sub_total = true;
+        }
         if c.int_add_face().is_some() {
             has_box = true;
             has_add = true;
@@ -237,6 +243,12 @@ fn runtime_contracts_for_certs<'a>(certs: impl IntoIterator<Item = &'a Cert>) ->
     }
     if has_string_concat {
         contracts.push(STRING_CONCAT_CONTRACT.to_string());
+    }
+    if has_add_total {
+        contracts.push(INT_ADD_TOTAL_CONTRACT.to_string());
+    }
+    if has_sub_total {
+        contracts.push(INT_SUB_TOTAL_CONTRACT.to_string());
     }
     contracts
 }

--- a/src/codegen/cert/cert_defs.rs
+++ b/src/codegen/cert/cert_defs.rs
@@ -1,3 +1,62 @@
+/// Policy presets carried by the Rust manifest schema and independently
+/// re-derived by `aver cert verify` from the classified artifact bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CertificationPolicy {
+    SimulatesModel,
+    SimulatesModelTotally,
+}
+
+impl CertificationPolicy {
+    pub fn manifest_name(self) -> &'static str {
+        match self {
+            Self::SimulatesModel => "simulatesModel",
+            Self::SimulatesModelTotally => "simulatesModelTotally",
+        }
+    }
+
+    pub fn lean_value(self) -> &'static str {
+        match self {
+            Self::SimulatesModel => ".simulatesModel",
+            Self::SimulatesModelTotally => ".simulatesModelTotally",
+        }
+    }
+
+    pub fn level(self) -> &'static str {
+        match self {
+            Self::SimulatesModel => "L1",
+            Self::SimulatesModelTotally => "L3",
+        }
+    }
+}
+
+/// Closed v47 measure vocabulary. New variants require a schema bump and a
+/// corresponding in-kernel `checkTerm` branch; unknown JSON measures never
+/// fall back to this one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TerminationMeasure {
+    IntNatAbs { param_idx: u32 },
+}
+
+/// Claim-axis termination data. It is deliberately absent from recursion
+/// plans and their hashes: the verifier re-derives this value from the admitted
+/// recursion family and pins it separately on the obligation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TerminationWitness {
+    pub measure: TerminationMeasure,
+    pub descent: i64,
+}
+
+impl TerminationWitness {
+    pub fn lean_value(self) -> String {
+        match self.measure {
+            TerminationMeasure::IntNatAbs { param_idx } => format!(
+                "({{ measure := .intNatAbs {param_idx}, descent := ({}) }} : AverCert.Schema.TerminationWitness)",
+                self.descent
+            ),
+        }
+    }
+}
+
 /// A certified function and the template holes extracted from its body.
 enum Cert {
     /// Generic non-recursive certificate. The inner shape still carries the

--- a/src/codegen/cert/cert_methods.rs
+++ b/src/codegen/cert/cert_methods.rs
@@ -6,6 +6,31 @@ impl Cert {
         }
     }
 
+    /// The only v47 total family: unary `n - 1` recursion whose combinator uses
+    /// `Int.add`. Multiplicative recursion would require a frozen `mul`
+    /// totality contract, and accumulator/mutual/budget families are not part
+    /// of this leg, so all of them remain partial.
+    fn termination_witness(&self) -> Option<TerminationWitness> {
+        match self.inner() {
+            Cert::Recursive {
+                combinator: Combinator::Add,
+                ..
+            } => Some(TerminationWitness {
+                measure: TerminationMeasure::IntNatAbs { param_idx: 0 },
+                descent: -1,
+            }),
+            _ => None,
+        }
+    }
+
+    fn policy(&self) -> CertificationPolicy {
+        if self.termination_witness().is_some() {
+            CertificationPolicy::SimulatesModelTotally
+        } else {
+            CertificationPolicy::SimulatesModel
+        }
+    }
+
     /// The straight-line integer face of a host-call expr fragment, when this
     /// cert is an `ExprFragment` whose plan is exactly `add(param0, box(k))`.
     /// Renderers branch on this to state the full-strength integer obligation

--- a/src/codegen/cert/classify_expr_fragment_sidecar_check.rs
+++ b/src/codegen/cert/classify_expr_fragment_sidecar_check.rs
@@ -65,6 +65,8 @@ pub fn check_expr_fragment_plan_sidecar(
         host: render_host_value(&cert),
         self_idx: cert.self_idx(),
         carrier: cert.carrier(),
+        policy: CertificationPolicy::SimulatesModel,
+        termination_witness: None,
         face: ObligationFace::of_cert(&cert),
         fragment_code_idx: match cert.inner() {
             Cert::ExprFragment { code_idx, .. } => Some(*code_idx),
@@ -222,6 +224,8 @@ pub fn check_sym_fragment_plan_sidecar(
         host: render_host_value(&cert),
         self_idx: cert.self_idx(),
         carrier: cert.carrier(),
+        policy: CertificationPolicy::SimulatesModel,
+        termination_witness: None,
         face: ObligationFace::of_cert(&cert),
         fragment_code_idx: match cert.inner() {
             Cert::ExprFragment { code_idx, .. } => Some(*code_idx),

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -66,12 +66,14 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 46;
+pub const CERT_SCHEMA_VERSION: u32 = 47;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";
 pub const INT_SUB_CONTRACT: &str =
     "Int.sub (carrier sub = exact integer subtraction on represented values)";
+pub const INT_ADD_TOTAL_CONTRACT: &str = "Int.add (carrier add = exact integer addition on represented values); total on represented values";
+pub const INT_SUB_TOTAL_CONTRACT: &str = "Int.sub (carrier sub = exact integer subtraction on represented values); total on represented values";
 pub const STRING_EQ_CONTRACT: &str =
     "String.eq (WVal byte-array equality; non-arrays compare false)";
 pub const STRING_CONCAT_CONTRACT: &str =

--- a/src/codegen/cert/rederive.rs
+++ b/src/codegen/cert/rederive.rs
@@ -25,6 +25,11 @@ pub struct RederivedObligation {
     pub self_idx: u32,
     /// `Obligation.carrier`: the Int carrier struct type index.
     pub carrier: u32,
+    /// Policy and witness independently re-derived from the byte-classified
+    /// recursion family. The checker pins both fields separately from the plan
+    /// hash and rejects producer-supplied promotion labels that disagree.
+    pub policy: CertificationPolicy,
+    pub termination_witness: Option<TerminationWitness>,
     /// The BYTE-derived typed face: which standard `Dom`/`Cod`/`domRepr`/`codRepr`
     /// forms the honest emitter renders for this class. `aver cert verify` pins
     /// these into its witness, so a manifest weakening the semantic face
@@ -585,6 +590,8 @@ fn rederive_certificate_inner(
             host: render_host_value(c),
             self_idx: c.self_idx(),
             carrier: c.carrier(),
+            policy: c.policy(),
+            termination_witness: c.termination_witness(),
             face: ObligationFace::of_cert(c),
             fragment_code_idx: match c.inner() {
                 Cert::ExprFragment { code_idx, .. } => Some(*code_idx),

--- a/src/codegen/cert/render_integer_accumulator.rs
+++ b/src/codegen/cert/render_integer_accumulator.rs
@@ -119,6 +119,7 @@ theorem {name}_base (n acc : Int) (hn : n ≤ 0) : {name} n acc = acc := by
                 rw [{name}_step n acc hn0, ← hrun]
                 exact ih (n - 1) (acc + n) vd va vr hrd hra hrec"#
         ),
+        total: String::new(),
         faithful_concl: format!(
             r#"    ∀ (fuel : Nat) (n acc : Int) (vn vacc w : WVal), Repr n vn → Repr acc vacc →
       wFuncN {name}Code ({name}Host add sub) fuel {self_idx} [vn, vacc] = some w →

--- a/src/codegen/cert/render_integer_fuel.rs
+++ b/src/codegen/cert/render_integer_fuel.rs
@@ -36,6 +36,9 @@ struct FuelPieces {
     concl: String,
     zero_body: String,
     succ_body: String,
+    /// Optional L3 theorem block. Empty for every family outside the promoted
+    /// unary add/sub descent-by-one class.
+    total: String,
     faithful_concl: String,
     faithful_body: String,
     guards: String,
@@ -64,6 +67,7 @@ fn render_fueled_recursion_cert(c: &Cert) -> String {
         concl,
         zero_body,
         succ_body,
+        total,
         faithful_concl,
         faithful_body,
         guards,
@@ -88,6 +92,8 @@ theorem {name}_wasm_certified
 {succ_body}
 
 #print axioms {name}_wasm_certified
+
+{total}
 
 /-- Consumer-facing composition: whatever the bytes return represents the model
     value `{name} {vars}` (faithfulness law ∘ simulation). -/

--- a/src/codegen/cert/render_integer_recursive.rs
+++ b/src/codegen/cert/render_integer_recursive.rs
@@ -54,7 +54,7 @@ fn recursive_fuel_pieces(c: &Cert) -> FuelPieces {
     // Per carrier arm: `input` names the model int (`s` small / `n` big) and
     // `input_wval` its byte form; produce the `add [..]` operand list and the
     // `hAdd ..` argument prefix (everything before the trailing `hadd`).
-    let combinator_arm = |input: &str, input_wval: &str| -> (String, String) {
+    let combinator_arm = |input: &str, input_wval: &str| -> (String, String, String) {
         let other_wval = match other {
             BodyOperand::Input => input_wval.to_string(),
             BodyOperand::Const(k) => format!("carrierSmall {carrier} {}", lean_int_lit(k)),
@@ -68,22 +68,112 @@ fn recursive_fuel_pieces(c: &Cert) -> FuelPieces {
             (
                 format!("[vr, {other_wval}]"),
                 format!("{rec_int} {} _ _ wa hrr {other_repr}", other_expr(input)),
+                format!("{rec_int} {} _ _ hrr {other_repr}", other_expr(input)),
             )
         } else {
             (
                 format!("[{other_wval}, vr]"),
                 format!("{} {rec_int} _ _ wa {other_repr} hrr", other_expr(input)),
+                format!("{} {rec_int} _ _ {other_repr} hrr", other_expr(input)),
             )
         }
     };
-    let (add_small, hadd_small) = combinator_arm(
+    let (add_small, hadd_small, hadd_tot_small) = combinator_arm(
         "s",
         &format!(".structv {carrier} [.i64v s, .null, .i32v sg]"),
     );
-    let (add_big, hadd_big) = combinator_arm(
+    let (add_big, hadd_big, hadd_tot_big) = combinator_arm(
         "n",
         &format!(".structv {carrier} [.i64v s, .arr lty les, .i32v sg]"),
     );
+    let total = if combinator == Combinator::Add {
+        let total_repr_hyps = recursion_repr_hyps(*carrier);
+        format!(
+            r#"/-- Fuel-parametric progress from the checked `natAbs` measure and
+    add/sub totality on represented values. -/
+theorem {name}_wasm_total_aux
+{total_repr_hyps}
+    (add sub : List WVal → Option WVal)
+    (hAdd : ∀ a b va vb w, Repr a va → Repr b vb → add [va, vb] = some w → Repr (a + b) w)
+    (hSub : ∀ a b va vb w, Repr a va → Repr b vb → sub [va, vb] = some w → Repr (a - b) w)
+    (hAddTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, add [va, vb] = some w)
+    (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
+    ∀ (fuel : Nat) (n : Int) (v : WVal), Repr n v → n.natAbs < fuel →
+      ∃ w, wFuncN {name}Code ({name}Host add sub) fuel {self_idx} [v] = some w ∧
+        Repr ({name} n) w := by
+  intro fuel
+  induction fuel with
+  | zero => intro n v hv hlt; omega
+  | succ fuel ih =>
+      intro n v hv hlt
+      rcases hcar n v hv with ⟨s, sg, rfl⟩ | ⟨s, lty, les, sg, rfl⟩
+      · have hs := hsmall_elim n s sg hv
+        subst hs
+        by_cases hle : s ≤ (0 : Int)
+        · refine ⟨carrierSmall {carrier} {base}, ?_, ?_⟩
+          · simp [wFuncN, wRunF, {name}Code, {name}Host, boxRef, b32,
+              popArgs, initLocals, hle]
+          · rw [{name}_base s hle]; exact hsmall_intro {base}
+        · obtain ⟨vd, hsub⟩ := hSubTot s 1 _ (carrierSmall {carrier} 1) hv (hsmall_intro 1)
+          have hrd : Repr (s - 1) vd := hSub s 1 _ _ vd hv (hsmall_intro 1) hsub
+          obtain ⟨vr, hrec, hrr⟩ := ih (s - 1) vd hrd (by omega)
+          obtain ⟨wa, hadd⟩ := hAddTot {hadd_tot_small}
+          refine ⟨wa, ?_, ?_⟩
+          · simp [wFuncN, wRunF, {name}Code, {name}Host, boxRef, b32,
+              popArgs, initLocals, hle, hsub, hrec, hadd]
+          · rw [{name}_step s hle]; exact hAdd {hadd_small} hadd
+      · obtain ⟨hsign, hne⟩ := hbig n s lty les sg hv
+        by_cases hlt2 : sg < (0 : Int)
+        · have hn0 : n ≤ 0 := by have := hsign.mp hlt2; omega
+          refine ⟨carrierSmall {carrier} {base}, ?_, ?_⟩
+          · simp [wFuncN, wRunF, {name}Code, {name}Host, boxRef, b32,
+              popArgs, initLocals, hlt2]
+          · rw [{name}_base n hn0]; exact hsmall_intro {base}
+        · have hn0 : ¬ n ≤ 0 := by
+            intro hle
+            have : ¬ n < 0 := fun h => hlt2 (hsign.mpr h)
+            omega
+          obtain ⟨vd, hsub⟩ := hSubTot n 1 _ (carrierSmall {carrier} 1) hv (hsmall_intro 1)
+          have hrd : Repr (n - 1) vd := hSub n 1 _ _ vd hv (hsmall_intro 1) hsub
+          obtain ⟨vr, hrec, hrr⟩ := ih (n - 1) vd hrd (by omega)
+          obtain ⟨wa, hadd⟩ := hAddTot {hadd_tot_big}
+          refine ⟨wa, ?_, ?_⟩
+          · simp [wFuncN, wRunF, {name}Code, {name}Host, boxRef, b32,
+              popArgs, initLocals, hlt2, hsub, hrec, hadd]
+          · rw [{name}_step n hn0]; exact hAdd {hadd_big} hadd
+
+#print axioms {name}_wasm_total_aux
+
+/-- TOTAL correctness at the fuel selected by the checked `intNatAbs` witness. -/
+theorem {name}_wasm_total
+{total_repr_hyps}
+    (add sub : List WVal → Option WVal)
+    (hAdd : ∀ a b va vb w, Repr a va → Repr b vb → add [va, vb] = some w → Repr (a + b) w)
+    (hSub : ∀ a b va vb w, Repr a va → Repr b vb → sub [va, vb] = some w → Repr (a - b) w)
+    (hAddTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, add [va, vb] = some w)
+    (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
+    ∀ (n : Int) (v : WVal), Repr n v →
+      ∃ w, wFuncN {name}Code ({name}Host add sub) (n.natAbs + 1) {self_idx} [v] = some w ∧
+        Repr ({name} n) w :=
+  fun n v hv =>
+    {name}_wasm_total_aux Repr hcar hsmall_intro hsmall_elim hbig add sub hAdd hSub
+      hAddTot hSubTot (n.natAbs + 1) n v hv (by omega)
+
+#print axioms {name}_wasm_total
+
+theorem {name}_simulates_total : AverCert.Schema.Obligation.holdsTotal {name}Ob := by
+  intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat
+    hAddTot hSubTot n v hv
+  refine ⟨[n], ?_, ?_⟩
+  · exact ⟨ReprAll.cons hv ReprAll.nil, rfl⟩
+  · simpa [{name}Ob, AverCert.Schema.intRepr] using
+      {name}_wasm_total S.Repr S.car S.smallIntro S.smallElim S.bigElim
+        add sub hadd hsub hAddTot hSubTot n v hv
+"#
+        )
+    } else {
+        String::new()
+    };
     FuelPieces {
         doc_kind: "self-recursive",
         cert_kind: "recursive",
@@ -189,6 +279,7 @@ theorem {name}_base (n : Int) (hn : n ≤ 0) : {name} n = {base} := by
                 rw [{name}_step n hn0, ← hrun]
                 exact {chyp} {hadd_big} hadd"#
         ),
+        total,
         faithful_concl: format!(
             r#"    ∀ (fuel : Nat) (n : Int) (v w : WVal), Repr n v →
       wFuncN {name}Code ({name}Host {cparam} sub) fuel {self_idx} [v] = some w →

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -211,7 +211,7 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
         ),
         _ => format!(
             "abbrev {name}Ob : Schema.Obligation :=\n  \
-             {{ export_ := \"{name}\", policy := .simulatesModel, carrier := {carrier},\n    \
+             {{ export_ := \"{name}\", policy := {policy}, termination? := {termination}, carrier := {carrier},\n    \
              code := CertModule.{name}Code, host := {host}, self := {self_idx},\n    \
              Dom := List Int, Cod := Int,\n    \
              domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = {arity},\n    \
@@ -222,6 +222,11 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
             self_idx = c.self_idx(),
             model = c.model_expr(),
             arity = c.arity(),
+            policy = c.policy().lean_value(),
+            termination = c
+                .termination_witness()
+                .map(|w| format!("some {}", w.lean_value()))
+                .unwrap_or_else(|| "none".to_string()),
         ),
     }
 }
@@ -512,7 +517,14 @@ fn render_final(analysis: &Analysis) -> String {
         let arms = analysis
             .certs
             .iter()
-            .map(|c| format!("exact ⟨rfl, CertProofs.{}_simulates⟩", c.name()))
+            .map(|c| {
+                let theorem = if c.policy() == CertificationPolicy::SimulatesModelTotally {
+                    "simulates_total"
+                } else {
+                    "simulates"
+                };
+                format!("exact CertProofs.{}_{theorem}", c.name())
+            })
             .collect::<Vec<_>>()
             .join("\n    | ");
         s.push_str(&format!("  all_goals\n    first\n    | {arms}\n"));
@@ -572,11 +584,24 @@ fn render_manifest(
     hashes: &ManifestHashes<'_>,
 ) -> String {
     let mut s = String::new();
+    let has_total = analysis
+        .certs
+        .iter()
+        .any(|c| c.policy() == CertificationPolicy::SimulatesModelTotally);
+    let has_partial = analysis
+        .certs
+        .iter()
+        .any(|c| c.policy() == CertificationPolicy::SimulatesModel);
+    let artifact_level = match (has_partial, has_total) {
+        (true, true) => "mixed L1/L3",
+        (false, true) => "L3",
+        _ => CERT_LEVEL,
+    };
     s.push_str("{\n");
     s.push_str(&format!("  \"schema_version\": {CERT_SCHEMA_VERSION},\n"));
     s.push_str(&format!("  \"wasm\": \"{wasm_name}.wasm\",\n"));
     s.push_str(&format!("  \"wasm_sha256\": \"{sha}\",\n"));
-    s.push_str(&format!("  \"level\": \"{CERT_LEVEL}\",\n"));
+    s.push_str(&format!("  \"level\": \"{artifact_level}\",\n"));
     s.push_str(&format!("  \"profile\": \"{PROFILE_ID}\",\n"));
     s.push_str(&format!("  \"abi\": \"{RUNTIME_ABI}\",\n"));
     s.push_str(&format!("  \"final_theorem\": \"{FINAL_THEOREM}\",\n"));
@@ -741,17 +766,34 @@ fn render_manifest(
             }
             _ => String::new(),
         };
+        let policy = c.policy();
+        let termination_json = match c.termination_witness() {
+            Some(TerminationWitness {
+                measure: TerminationMeasure::IntNatAbs { param_idx },
+                descent,
+            }) => format!(
+                ", \"termination_witness\": {{\"measure\": {{\"kind\": \"intNatAbs\", \"param_index\": {param_idx}}}, \"descent\": {descent}}}"
+            ),
+            None => String::new(),
+        };
+        let theorem_suffix = if policy == CertificationPolicy::SimulatesModelTotally {
+            "wasm_total"
+        } else {
+            "wasm_certified"
+        };
         s.push_str(&format!(
-            "\n    {{\"name\": {}, \"class\": \"{}\", \"policy\": \"simulatesModel\", \
+            "\n    {{\"name\": {}, \"class\": \"{}\", \"policy\": \"{}\", \
              \"level\": \"{}\", \"dom\": {}, \"cod\": {}, \
-             \"theorem\": \"CertProofs.{}_wasm_certified\"{}}}",
+             \"theorem\": \"CertProofs.{}_{theorem_suffix}\"{}{}}}",
             json_str(c.name()),
             kind,
-            CERT_LEVEL,
+            policy.manifest_name(),
+            policy.level(),
             json_str(&dom),
             json_str(&cod),
             c.name(),
-            fragment_json
+            termination_json,
+            fragment_json,
         ));
     }
     if !analysis.certs.is_empty() {

--- a/src/codegen/cert/render_project.rs
+++ b/src/codegen/cert/render_project.rs
@@ -1091,7 +1091,7 @@ fn render_artifact_expr_fragment_claims(
                     export_name = lean_str(name),
                 ));
                 recursion_proofs.push(format!(
-                    "⟨rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
+                    "⟨rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
                      ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
                 ));
             }

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -229,6 +229,10 @@ struct Candidates {
     /// binding (`obligations.length`, verified by `rfl`); the export NAMES the
     /// obligations are pinned to come from the bytes, not from here.
     names: Vec<String>,
+    /// Policy/witness claim axis decoded from JSON. The checker separately
+    /// pins these candidates to the Lean manifest and to byte re-derivation.
+    policies: Vec<cert::CertificationPolicy>,
+    termination_witnesses: Vec<Option<cert::TerminationWitness>>,
     /// Runtime contracts as CLAIMED by the JSON. Used only for the witness
     /// binding against the proven manifest; the final byte-binding and report
     /// use the byte-derived list.
@@ -348,21 +352,97 @@ fn read_candidates(m: &Value) -> Result<Candidates, String> {
     // obligations are actually pinned to are re-derived from the module's
     // export section (see the witness), so a producer cannot relabel a
     // byte-bound body under a different export name.
-    let names = m
+    let certified = m
         .get("certified")
         .and_then(Value::as_array)
-        .ok_or_else(|| "cert-manifest.json is missing array field `certified`".to_string())?
-        .iter()
-        .map(|c| {
-            c.get("name")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .ok_or_else(|| {
-                    "cert-manifest.json `certified[]` entry is missing string field `name`"
-                        .to_string()
+        .ok_or_else(|| "cert-manifest.json is missing array field `certified`".to_string())?;
+    let mut names = Vec::with_capacity(certified.len());
+    let mut policies = Vec::with_capacity(certified.len());
+    let mut termination_witnesses = Vec::with_capacity(certified.len());
+    for c in certified {
+        let name = c
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                "cert-manifest.json `certified[]` entry is missing string field `name`".to_string()
+            })?
+            .to_string();
+        let policy = match c.get("policy").and_then(Value::as_str) {
+            Some("simulatesModel") => cert::CertificationPolicy::SimulatesModel,
+            Some("simulatesModelTotally") => cert::CertificationPolicy::SimulatesModelTotally,
+            Some(other) => {
+                return Err(format!(
+                    "cert-manifest.json certified export `{name}` uses unsupported policy `{other}`"
+                ));
+            }
+            None => {
+                return Err(format!(
+                    "cert-manifest.json certified export `{name}` is missing string field `policy`"
+                ));
+            }
+        };
+        let termination_witness = match c.get("termination_witness") {
+            None => None,
+            Some(witness) => {
+                let measure = witness
+                    .get("measure")
+                    .and_then(Value::as_object)
+                    .ok_or_else(|| {
+                        format!(
+                            "cert-manifest.json certified export `{name}` has malformed termination witness measure"
+                        )
+                    })?;
+                let kind = measure.get("kind").and_then(Value::as_str).ok_or_else(|| {
+                    format!(
+                        "cert-manifest.json certified export `{name}` has no termination measure kind"
+                    )
+                })?;
+                if kind != "intNatAbs" {
+                    return Err(format!(
+                        "cert-manifest.json certified export `{name}` uses unsupported termination measure `{kind}`; schema 47 admits only `intNatAbs`"
+                    ));
+                }
+                let param_idx = measure
+                    .get("param_index")
+                    .and_then(Value::as_u64)
+                    .and_then(|n| u32::try_from(n).ok())
+                    .ok_or_else(|| {
+                        format!(
+                            "cert-manifest.json certified export `{name}` has invalid intNatAbs parameter index"
+                        )
+                    })?;
+                let descent = witness
+                    .get("descent")
+                    .and_then(Value::as_i64)
+                    .ok_or_else(|| {
+                        format!(
+                            "cert-manifest.json certified export `{name}` has invalid termination descent"
+                        )
+                    })?;
+                Some(cert::TerminationWitness {
+                    measure: cert::TerminationMeasure::IntNatAbs { param_idx },
+                    descent,
                 })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+            }
+        };
+        match (policy, termination_witness) {
+            (cert::CertificationPolicy::SimulatesModel, None)
+            | (cert::CertificationPolicy::SimulatesModelTotally, Some(_)) => {}
+            (cert::CertificationPolicy::SimulatesModel, Some(_)) => {
+                return Err(format!(
+                    "cert-manifest.json partial export `{name}` must not carry a termination witness"
+                ));
+            }
+            (cert::CertificationPolicy::SimulatesModelTotally, None) => {
+                return Err(format!(
+                    "cert-manifest.json total export `{name}` is missing `termination_witness`"
+                ));
+            }
+        }
+        names.push(name);
+        policies.push(policy);
+        termination_witnesses.push(termination_witness);
+    }
 
     let contracts = m
         .get("runtime_contracts")
@@ -378,6 +458,8 @@ fn read_candidates(m: &Value) -> Result<Candidates, String> {
 
     let cands = Candidates {
         names,
+        policies,
+        termination_witnesses,
         contracts,
         profile,
         abi,
@@ -396,12 +478,22 @@ fn read_candidates(m: &Value) -> Result<Candidates, String> {
 fn verify(artifact: &Path, cert_dir: &Path) -> Result<Verdict, String> {
     let report = trusted_check(artifact, cert_dir)?;
     let n = report.exports.len();
+    let has_total = report
+        .exports
+        .iter()
+        .any(|e| e.policy == "simulatesModelTotally");
+    let has_partial = report.exports.iter().any(|e| e.policy == "simulatesModel");
+    let level = match (has_partial, has_total) {
+        (true, true) => "mixed L1/L3",
+        (false, true) => "L3",
+        _ => "L1",
+    };
     let summary = format!(
         "{} ({} certified export{}, level {})",
         artifact.display(),
         n,
         if n == 1 { "" } else { "s" },
-        cert::CERT_LEVEL,
+        level,
     );
     if n == 0 {
         Ok(Verdict::NoExports(summary))
@@ -409,7 +501,7 @@ fn verify(artifact: &Path, cert_dir: &Path) -> Result<Verdict, String> {
         let faces = report
             .exports
             .iter()
-            .map(|e| format!("{}  {}", e.name, e.face))
+            .map(|e| format!("{}  policy: {}  {}", e.name, e.policy, e.face))
             .collect();
         Ok(Verdict::Certified { summary, faces })
     }
@@ -674,7 +766,7 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
                 .map(display_safe);
             CertifiedExport {
                 name: r.name.clone(),
-                policy: "simulatesModel".to_string(),
+                policy: r.policy.manifest_name().to_string(),
                 face: if r.string_eq_plan_lean.is_some() {
                     "class: verbatim string equality match  |  Dom: WVal  Cod: WVal  codRepr: verbatimRepr  (model is a read declaration; behaviour pinned by an interpreter tripwire)"
                         .to_string()
@@ -722,6 +814,8 @@ fn merge_runtime_contracts(legacy: Vec<String>, sidecar: Vec<String>) -> Vec<Str
         cert::INT_SUB_CONTRACT,
         cert::STRING_EQ_CONTRACT,
         cert::STRING_CONCAT_CONTRACT,
+        cert::INT_ADD_TOTAL_CONTRACT,
+        cert::INT_SUB_TOTAL_CONTRACT,
     ];
     canonical
         .iter()
@@ -2078,7 +2172,7 @@ fn lean_expr_fragment_artifact_claims(
                 carrier = r.carrier,
             ));
             recursion_proofs.push(format!(
-                "⟨rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
+                "⟨rfl, rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
                  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
             ));
             continue;
@@ -2867,6 +2961,45 @@ fn checker_witness(
     let hosts = lean_expr_list(rederived.iter().map(|r| r.host.as_str()));
     let selfs = lean_nat_list(rederived.iter().map(|r| r.self_idx));
     let carriers = lean_nat_list(rederived.iter().map(|r| r.carrier));
+    let json_policies = format!(
+        "[{}]",
+        cands
+            .policies
+            .iter()
+            .map(|p| p.lean_value())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let byte_policies = format!(
+        "[{}]",
+        rederived
+            .iter()
+            .map(|r| r.policy.lean_value())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let render_termination = |witness: Option<cert::TerminationWitness>| match witness {
+        Some(w) => format!("some {}", w.lean_value()),
+        None => "none".to_string(),
+    };
+    let json_terminations = format!(
+        "[{}]",
+        cands
+            .termination_witnesses
+            .iter()
+            .copied()
+            .map(render_termination)
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let byte_terminations = format!(
+        "[{}]",
+        rederived
+            .iter()
+            .map(|r| render_termination(r.termination_witness))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
     let expr_fragment_plans = lean_expr_fragment_plan_pairs(rederived);
     let sym_fragment_plans = lean_sym_fragment_plan_pairs(rederived);
     let string_eq_plans = lean_string_eq_plan_pairs(rederived);
@@ -2937,6 +3070,14 @@ fn checker_witness(
          -- declined; the final report uses only the byte-derived list.\n\
          example : AverCert.manifest.subject.contracts = {json_contracts} := rfl\n\
          example : AverCert.manifest.subject.contracts = {byte_contracts} := rfl\n\
+         -- Policy/witness axis: JSON is only a candidate; both lists must also
+         -- equal the policy and termination witness independently re-derived
+         -- from the byte-classified family. The witness remains outside every
+         -- plan hash.
+         example : AverCert.manifest.obligations.map (fun o => o.policy) = {json_policies} := rfl\n\
+         example : AverCert.manifest.obligations.map (fun o => o.policy) = {byte_policies} := rfl\n\
+         example : AverCert.manifest.obligations.map (fun o => o.termination?) = {json_terminations} := rfl\n\
+         example : AverCert.manifest.obligations.map (fun o => o.termination?) = {byte_terminations} := rfl\n\
          example : AverCert.manifest.subject.profile = \"{profile}\" := rfl\n\
          example : AverCert.manifest.subject.abi = \"{abi}\" := rfl\n\
          example : AverCert.manifest.subject.artifactRoot = \"{artifact_root}\" := rfl\n\n\
@@ -3230,12 +3371,19 @@ fn explain(artifact: &Path, cert_dir: &Path) -> Result<(), String> {
         println!("  {ARTIFACT_DECODE_LINE}");
     }
     for e in &report.exports {
-        println!("  {}  [{}]", e.name.cyan().bold(), cert::CERT_LEVEL);
+        let level = if e.policy == "simulatesModelTotally" {
+            "L3"
+        } else {
+            "L1"
+        };
+        println!("  {}  [{}]", e.name.cyan().bold(), level);
         println!("    {}", e.face);
-        println!(
-            "    policy: {} (emitted body simulates its model under the named contracts)",
-            e.policy
-        );
+        let policy_note = if e.policy == "simulatesModelTotally" {
+            "emitted body returns a represented model result at checked measure fuel, conditional on the named contracts"
+        } else {
+            "emitted body partially simulates its model under the named contracts"
+        };
+        println!("    policy: {} ({policy_note})", e.policy);
         if report.contracts.is_empty() {
             println!("    runtime-contracts: (none)");
         } else {

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -433,6 +433,8 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
             aver::codegen::cert::INT_SUB_CONTRACT,
             aver::codegen::cert::STRING_EQ_CONTRACT,
             aver::codegen::cert::STRING_CONCAT_CONTRACT,
+            aver::codegen::cert::INT_ADD_TOTAL_CONTRACT,
+            aver::codegen::cert::INT_SUB_TOTAL_CONTRACT,
         ],
         "goal matrix runtime contracts changed"
     );
@@ -636,6 +638,39 @@ fn certify_fueled_recursion_generality_lake_builds_kernel_clean() {
             "expected {name} certified, got {certified:?}"
         );
     }
+    let certified_entries = manifest["certified"].as_array().unwrap();
+    for name in ["sumFrom", "constPlus", "backward"] {
+        let entry = certified_entries
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap();
+        assert_eq!(entry["policy"], "simulatesModelTotally");
+        assert_eq!(entry["level"], "L3");
+        assert_eq!(entry["theorem"], format!("CertProofs.{name}_wasm_total"));
+        assert_eq!(entry["termination_witness"]["measure"]["kind"], "intNatAbs");
+        assert_eq!(entry["termination_witness"]["measure"]["param_index"], 0);
+        assert_eq!(entry["termination_witness"]["descent"], -1);
+    }
+    for name in ["factorial", "countDown"] {
+        let entry = certified_entries
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap();
+        assert_eq!(entry["policy"], "simulatesModel");
+        assert_eq!(entry["level"], "L1");
+        assert!(entry.get("termination_witness").is_none());
+    }
+    let contracts = manifest["runtime_contracts"].as_array().unwrap();
+    assert!(
+        contracts
+            .iter()
+            .any(|c| { c == aver::codegen::cert::INT_ADD_TOTAL_CONTRACT })
+    );
+    assert!(
+        contracts
+            .iter()
+            .any(|c| { c == aver::codegen::cert::INT_SUB_TOTAL_CONTRACT })
+    );
 
     let build = Command::new("lake")
         .current_dir(&cert_dir)
@@ -661,6 +696,18 @@ fn certify_fueled_recursion_generality_lake_builds_kernel_clean() {
             "recursion certificate for {name} not kernel-clean:\n{combined}"
         );
     }
+    for name in ["sumFrom", "constPlus", "backward"] {
+        assert!(
+            combined.contains(&format!(
+                "{name}_wasm_total' depends on axioms: [propext, Classical.choice, Quot.sound]"
+            )),
+            "total recursion certificate for {name} not kernel-clean:\n{combined}"
+        );
+    }
+    assert!(
+        !combined.contains("factorial_wasm_total") && !combined.contains("countDown_wasm_total"),
+        "out-of-scope recursion family was promoted:\n{combined}"
+    );
     assert!(
         !combined.contains("sorryAx"),
         "recursion certificate leaked sorryAx:\n{combined}"

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -1171,7 +1171,8 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         assert!(!out.contains("CERTIFIED"), "relabel credited (u):\n{out}");
     }
 
-    // (v) M1 semantic-face vacuity — `Dom := Empty`. Empty the sumTo obligation's
+    // (v) M1 semantic-face vacuity — `Dom := Empty`. Empty the still-partial
+    //     countDown obligation's
     //     domain so `holds` quantifies over no inhabitant, and swap in a vacuous
     //     `ns.elim` proof. It builds green AND passes the code/host/self/carrier
     //     bindings, but the witness proves `Nonempty o.Dom` over every obligation
@@ -1181,12 +1182,15 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         copy_dir(&out_dir, &dir);
         let man = dir.join("cert").join("Manifest.lean");
         let msrc = std::fs::read_to_string(&man).unwrap();
-        let edited = msrc.replacen(SUMTO_FACE, SUMTO_FACE_EMPTY_DOM, 1);
-        assert_ne!(msrc, edited, "sumToOb face shape changed; update the test");
+        let edited = msrc.replacen(COUNTDOWN_FACE, COUNTDOWN_FACE_EMPTY_DOM, 1);
+        assert_ne!(
+            msrc, edited,
+            "countDownOb face shape changed; update the test"
+        );
         std::fs::write(&man, edited).unwrap();
-        replace_simulates(
+        replace_countdown_simulates(
             &dir.join("cert"),
-            "theorem sumTo_simulates : AverCert.Schema.Obligation.holds sumToOb := by\n  \
+            "theorem countDown_simulates : AverCert.Schema.Obligation.holds countDownOb := by\n  \
              intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel ns vs w hrepr hrun\n  \
              exact ns.elim",
         );
@@ -1214,12 +1218,15 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         copy_dir(&out_dir, &dir);
         let man = dir.join("cert").join("Manifest.lean");
         let msrc = std::fs::read_to_string(&man).unwrap();
-        let edited = msrc.replacen(SUMTO_FACE, SUMTO_FACE_TRUE_CODREPR, 1);
-        assert_ne!(msrc, edited, "sumToOb face shape changed; update the test");
+        let edited = msrc.replacen(COUNTDOWN_FACE, COUNTDOWN_FACE_TRUE_CODREPR, 1);
+        assert_ne!(
+            msrc, edited,
+            "countDownOb face shape changed; update the test"
+        );
         std::fs::write(&man, edited).unwrap();
-        replace_simulates(
+        replace_countdown_simulates(
             &dir.join("cert"),
-            "theorem sumTo_simulates : AverCert.Schema.Obligation.holds sumToOb := by\n  \
+            "theorem countDown_simulates : AverCert.Schema.Obligation.holds countDownOb := by\n  \
              intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel ns vs w hrepr hrun\n  \
              trivial",
         );
@@ -1446,18 +1453,19 @@ fn big_nat_code_entry_pin_closes_at_130kb_and_flipped_byte_fails() {
     let _ = std::fs::remove_dir_all(out_dir);
 }
 
-/// The byte-honest sumTo obligation face emitted for certprobe2 (the standard
+/// The byte-honest, still-partial countDown obligation face emitted for
+/// certprobe2 (the standard
 /// integer-class form), and the two panel face-vacuity mutations of it.
-const SUMTO_FACE: &str = "Dom := List Int, Cod := Int,\n    \
-    domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = 1,\n    \
+const COUNTDOWN_FACE: &str = "Dom := List Int, Cod := Int,\n    \
+    domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = 2,\n    \
     codRepr := fun S n w => intRepr S n w,\n    \
-    model := fun ns => sumTo (ns.headD 0) }";
-const SUMTO_FACE_EMPTY_DOM: &str = "Dom := Empty, Cod := Int,\n    \
+    model := fun ns => countDown (ns.headD 0) ((ns.drop 1).headD 0) }";
+const COUNTDOWN_FACE_EMPTY_DOM: &str = "Dom := Empty, Cod := Int,\n    \
     domRepr := fun _ (e : Empty) _ => e.elim,\n    \
     codRepr := fun S n w => intRepr S n w,\n    \
     model := fun (e : Empty) => e.elim }";
-const SUMTO_FACE_TRUE_CODREPR: &str = "Dom := List Int, Cod := Int,\n    \
-    domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = 1,\n    \
+const COUNTDOWN_FACE_TRUE_CODREPR: &str = "Dom := List Int, Cod := Int,\n    \
+    domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = 2,\n    \
     codRepr := fun _ _ _ => True,\n    \
     model := fun _ => 999 }";
 
@@ -1507,6 +1515,39 @@ fn replace_simulates(cert_dir: &Path, replacement: &str) {
     assert!(
         src.contains(old),
         "emitted sumTo_simulates block shape changed; update the test"
+    );
+    std::fs::write(&c, src.replacen(old, replacement, 1)).unwrap();
+}
+
+/// Partial-obligation counterpart used by the semantic-face isolation probes.
+/// `sumTo` is L3 now, so vacuity probes stay on `countDown` to reach the
+/// verifier's typed-face pins rather than failing the total denotation earlier.
+fn replace_countdown_simulates(cert_dir: &Path, replacement: &str) {
+    let c = cert_dir.join("Certificate.lean");
+    let src = std::fs::read_to_string(&c).unwrap();
+    let old = "theorem countDown_simulates : AverCert.Schema.Obligation.holds countDownOb := by\n  \
+        intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel ns vs w hrepr hrun\n  \
+        simp only [countDownOb, AverCert.Schema.Obligation.holds] at hrun ⊢\n  \
+        obtain ⟨hrepr, harity⟩ := hrepr\n  \
+        cases hrepr with\n  \
+        | nil =>\n      \
+        simp at harity\n  \
+        | cons hvn htail =>\n      \
+        rename_i n vn ns1 vs1\n      \
+        cases htail with\n      \
+        | nil =>\n          \
+        simp at harity\n      \
+        | cons hvacc htail2 =>\n          \
+        rename_i acc vacc ns2 vs2\n          \
+        cases htail2 with\n          \
+        | nil =>\n              \
+        simpa [AverCert.Schema.intRepr] using countDown_wasm_certified S.Repr S.car S.smallIntro S.smallElim S.bigElim\n                \
+        add sub hadd hsub fuel n acc vn vacc w hvn hvacc hrun\n          \
+        | cons _ _ =>\n              \
+        simp at harity";
+    assert!(
+        src.contains(old),
+        "emitted countDown_simulates block shape changed; update the test"
     );
     std::fs::write(&c, src.replacen(old, replacement, 1)).unwrap();
 }
@@ -3273,7 +3314,7 @@ theorem unclaimedFinal : Schema.Holds unclaimedManifest := by
   rcases ho' with ho | rfl
   · exact Final.cert.2 o ho
   · have hadd := Final.cert.2 AverCert.addTwoOb (by simp [AverCert.manifest])
-    exact ⟨rfl, by simpa [unclaimedOb, Obligation.holds] using hadd.2⟩
+    simpa [unclaimedOb, Obligation.holds] using hadd
 
 example : AcceptedArtifact.manifestObligationsClaimed unclaimedArtifact = false := rfl
 example : AcceptedArtifact.manifestObligationExportsUnique unclaimedArtifact = true := rfl
@@ -3373,7 +3414,7 @@ theorem duplicateFinal : Schema.Holds duplicateManifest := by
   · exact Final.cert.2 o ho
   · simp only [List.mem_singleton] at ho
     subst o
-    exact ⟨rfl, duplicateObHolds⟩
+    exact duplicateObHolds
 
 def acceptedCompositionWithoutUniqueExports
     (artifact : AcceptedArtifact.ArtifactData) : Prop :=
@@ -4191,6 +4232,136 @@ fn cert_verify_declines_tampered_recursion_plan() {
     }
 
     let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// GuardIso for the L3 witness: hostile measure/descent claims keep the honest
+/// bytes and obligation bindings, fail exactly at `checkTerm`, and are accepted
+/// by a literal one-conjunct-weakened copy. Total policy without a witness also
+/// fails closed.
+#[test]
+fn recursion_termination_witness_guard_is_isolating() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping termination-witness GuardIso test: `lake` not available");
+        return;
+    }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("cert-recursion-termination-guard-iso");
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/recgen.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("compile recgen fixture for termination-witness GuardIso");
+    assert!(
+        compile.status.success(),
+        "recgen compile failed for termination-witness GuardIso:\n{}{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let cert = out_dir.join("cert");
+    let build = Command::new("lake")
+        .current_dir(&cert)
+        .arg("build")
+        .output()
+        .expect("build recgen certificate before termination-witness GuardIso");
+    assert!(
+        build.status.success(),
+        "recgen certificate failed before termination-witness GuardIso:\n{}{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+    std::fs::write(
+        cert.join("GuardIso.lean"),
+        include_str!("fixtures/cert_termination_guard_iso.lean"),
+    )
+    .unwrap();
+    let check = Command::new("lake")
+        .current_dir(&cert)
+        .arg("env")
+        .arg("lean")
+        .arg("GuardIso.lean")
+        .output()
+        .expect("run termination-witness GuardIso");
+    assert!(
+        check.status.success(),
+        "termination-witness GuardIso failed:\n{}{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// The JSON policy/witness is only a candidate: supported-but-wrong data must
+/// disagree with verifier byte re-derivation in the checker-authored Lean
+/// witness, while an unknown measure or missing total witness declines during
+/// strict manifest decoding.
+#[test]
+fn cert_verify_declines_tampered_termination_manifest() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping termination manifest round-trip test: `lake` not available");
+        return;
+    }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("cert-termination-manifest-roundtrip");
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/recgen.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("compile recgen fixture for termination manifest round-trip");
+    assert!(compile.status.success());
+    let wasm = out_dir.join("recgen.wasm");
+    let cert = out_dir.join("cert");
+    let (ok, report) = aver_verify(&wasm, &cert);
+    assert!(ok, "honest totality manifest should verify:\n{report}");
+
+    for (label, mutate, expected) in [
+        ("wrong descent", 0_u8, "does not bind"),
+        ("unknown measure", 1_u8, "unsupported termination measure"),
+        ("missing witness", 2_u8, "is missing `termination_witness`"),
+    ] {
+        let dir = temp_dir("cert-termination-manifest-tamper");
+        copy_dir(&out_dir, &dir);
+        let path = dir.join("cert/cert-manifest.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let entry = manifest["certified"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|entry| entry["name"] == "sumFrom")
+            .unwrap();
+        match mutate {
+            0 => entry["termination_witness"]["descent"] = serde_json::json!(1),
+            1 => entry["termination_witness"]["measure"]["kind"] = serde_json::json!("lex"),
+            2 => {
+                entry.as_object_mut().unwrap().remove("termination_witness");
+            }
+            _ => unreachable!(),
+        }
+        std::fs::write(&path, serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
+        let (ok, report) = aver_verify(&dir.join("recgen.wasm"), &dir.join("cert"));
+        assert!(
+            !ok,
+            "{label}: hostile totality manifest verified:\n{report}"
+        );
+        assert!(
+            report.contains(expected),
+            "{label}: wrong decline reason, expected `{expected}`:\n{report}"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+    let _ = std::fs::remove_dir_all(out_dir);
 }
 
 /// A tampered byte-first `mutual-plan-v1` plan is declined. Each vector mutates

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -2392,7 +2392,8 @@ fn cert_verify_declines_tampered_string_eq_helper_shape() {
         "stringeq should certify quoteOrSelf plus bump:\n{report}"
     );
     assert!(
-        report.contains("quoteOrSelf  class: verbatim string equality match"),
+        report
+            .contains("quoteOrSelf  policy: simulatesModel  class: verbatim string equality match"),
         "quoteOrSelf should report the byte-derived String.eq class:\n{report}"
     );
     let manifest: serde_json::Value = serde_json::from_str(

--- a/tests/fixtures/cert_termination_guard_iso.lean
+++ b/tests/fixtures/cert_termination_guard_iso.lean
@@ -1,0 +1,125 @@
+import Artifact
+
+open CertPrelude AverCert AverCert.Schema
+set_option linter.unnecessarySimpa false
+
+def honestWitness : TerminationWitness :=
+  { measure := .intNatAbs 0, descent := -1 }
+def wrongMeasureWitness : TerminationWitness :=
+  { measure := .intNatAbs 1, descent := -1 }
+def wrongDescentWitness : TerminationWitness :=
+  { measure := .intNatAbs 0, descent := 1 }
+
+def honestTotalOb : Obligation :=
+  { AverCert.sumFromOb with
+      policy := .simulatesModelTotally
+      termination? := some honestWitness }
+def wrongMeasureOb : Obligation :=
+  { honestTotalOb with termination? := some wrongMeasureWitness }
+def wrongDescentOb : Obligation :=
+  { honestTotalOb with termination? := some wrongDescentWitness }
+def missingWitnessOb : Obligation :=
+  { honestTotalOb with termination? := none }
+
+-- Literal `recursionPlanAccepted` copy with only its `checkTerm` conjunct removed.
+def recursionPlanAcceptedWithoutCheckTerm
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (exportName : String)
+    (carrier : Nat)
+    (hostTable : List (HostRole × Nat))
+    (plan : RecursionRawPlan)
+    (obligation : Obligation) : Prop :=
+  obligation.export_ = exportName ∧
+    obligation.carrier = carrier ∧
+    AverCert.PlanCheck.checkRecursionRawPlan plan = true ∧
+    ∃ body codeEntry binding,
+      AverCert.PlanLower.lowerRecursionBody carrier plan = some body ∧
+      AverCert.PlanBytes.lowerRecursionCodeEntry carrier plan = some codeEntry ∧
+      AverCert.WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+      AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
+      binding.funcIdx = obligation.self ∧
+      binding.codeEntry = codeEntry ∧
+      AverCert.PlanCheck.checkRecursionPlanShape binding.funcIdx hostTable plan = true ∧
+      AverCert.WasmSlice.funcTypeMatches
+        modBytes modLen binding.typeIdx plan.params.length carrier = true ∧
+      obligation.code binding.funcIdx =
+        some { arity := plan.params.length,
+               nlocals := AverCert.AcceptedArtifact.recursionNLocals plan, body := body }
+
+abbrev modBytes := AverCert.ArtifactBytes.modBytes
+abbrev modLen := AverCert.ArtifactBytes.modLen
+abbrev nameBytes : AverCert.WasmSlice.ByteSeq :=
+  [115, 117, 109, 70, 114, 111, 109]
+abbrev hostTable : List (HostRole × Nat) :=
+  [(.box, 10), (.add, 11), (.sub, 12)]
+abbrev plan := AverCert.Plans.sumFromRecursionPlan
+
+-- The honest witness passes; each hostile witness fails at `checkTerm` itself.
+example : checkTerm plan honestWitness = true := rfl
+example : checkTerm plan wrongMeasureWitness = false := rfl
+example : checkTerm plan wrongDescentWitness = false := rfl
+
+theorem honestAccepted : AverCert.AcceptedArtifact.recursionPlanAccepted
+    modBytes modLen nameBytes "sumFrom" 2 hostTable plan AverCert.sumFromOb := by
+  have hfrags : AverCert.AcceptedArtifact.acceptedFragments AverCert.Artifact.data :=
+    AverCert.Artifact.certificate.2.2.2.2
+  have hrec : AverCert.AcceptedArtifact.acceptedRecursionFragments AverCert.Artifact.data :=
+    hfrags.2.2.2.2.1
+  simpa [AverCert.AcceptedArtifact.acceptedRecursionFragments,
+    AverCert.AcceptedArtifact.recursionClaimsAccepted,
+    AverCert.AcceptedArtifact.recursionClaimAccepted,
+    AverCert.AcceptedArtifact.recursionPlanForExport,
+    AverCert.Artifact.data, AverCert.Artifact.recursionClaims,
+    AverCert.manifest, plan, modBytes, modLen, nameBytes, hostTable] using hrec.1
+
+theorem weakenedAccepts (obligation : Obligation)
+    (hfields : obligation.export_ = AverCert.sumFromOb.export_ ∧
+      obligation.carrier = AverCert.sumFromOb.carrier ∧
+      obligation.self = AverCert.sumFromOb.self ∧
+      obligation.code = AverCert.sumFromOb.code) :
+    recursionPlanAcceptedWithoutCheckTerm
+      modBytes modLen nameBytes "sumFrom" 2 hostTable plan obligation := by
+  rcases honestAccepted with ⟨hexport, hcarrier, hraw, _hterm, hrest⟩
+  rcases hfields with ⟨hexport', hcarrier', hself', hcode'⟩
+  refine ⟨?_, ?_, hraw, ?_⟩
+  · simpa [hexport'] using hexport
+  · simpa [hcarrier'] using hcarrier
+  · simpa [hself', hcode'] using hrest
+
+-- The one-conjunct-weakened copy accepts both hostile obligations.
+example : recursionPlanAcceptedWithoutCheckTerm
+    modBytes modLen nameBytes "sumFrom" 2 hostTable plan wrongMeasureOb :=
+  weakenedAccepts wrongMeasureOb ⟨rfl, rfl, rfl, rfl⟩
+example : recursionPlanAcceptedWithoutCheckTerm
+    modBytes modLen nameBytes "sumFrom" 2 hostTable plan wrongDescentOb :=
+  weakenedAccepts wrongDescentOb ⟨rfl, rfl, rfl, rfl⟩
+
+-- The real predicate rejects exactly where the weakened copy differs.
+example : ¬ AverCert.AcceptedArtifact.recursionPlanAccepted
+    modBytes modLen nameBytes "sumFrom" 2 hostTable plan wrongMeasureOb := by
+  intro h
+  rcases h with ⟨_, _, _, hterm, _⟩
+  contradiction
+example : ¬ AverCert.AcceptedArtifact.recursionPlanAccepted
+    modBytes modLen nameBytes "sumFrom" 2 hostTable plan wrongDescentOb := by
+  intro h
+  rcases h with ⟨_, _, _, hterm, _⟩
+  contradiction
+example : ¬ AverCert.AcceptedArtifact.recursionPlanAccepted
+    modBytes modLen nameBytes "sumFrom" 2 hostTable plan missingWitnessOb := by
+  intro h
+  rcases h with ⟨_, _, _, hterm, _⟩
+  contradiction
+
+-- Witness mutation cannot change any byte-derived obligation binding.
+example : honestTotalOb.self = wrongMeasureOb.self ∧
+    honestTotalOb.carrier = wrongMeasureOb.carrier ∧
+    honestTotalOb.code = wrongMeasureOb.code ∧
+    honestTotalOb.host = wrongMeasureOb.host := by
+  exact ⟨rfl, rfl, rfl, rfl⟩
+example : honestTotalOb.self = wrongDescentOb.self ∧
+    honestTotalOb.carrier = wrongDescentOb.carrier ∧
+    honestTotalOb.code = wrongDescentOb.code ∧
+    honestTotalOb.host = wrongDescentOb.host := by
+  exact ⟨rfl, rfl, rfl, rfl⟩


### PR DESCRIPTION
## Summary
- Obligations can carry a termination witness: a measure (vocabulary closed to the integer absolute-value measure) plus the byte-pinned descent, checked in-kernel by a decidable strict-decrease test. The witness lives on the obligation, not in the plan or its hash — many valid measures certify the same bytes.
- A new total policy's denotation upgrades the certified statement from partial correctness (if a run returns, the result represents the model) to bounded total correctness: for every represented input, the run at fuel `natAbs n + 1` returns a value representing the model, conditional on two new named host-totality contracts (add and sub return on represented operands). The denotation quantifies over every carrier spec, so the existential domain witness is forced at consumption.
- The single descent-by-one recursion family promotes and emits a `_wasm_total` theorem beside the partial one (mirrored template, renderer only). In the fueled-recursion fixture, three exports promote to total; the factorial shape stays partial (would need mul totality, outside the frozen add/sub interface), accumulator and mutual families stay partial, and no json string-position scanner promotes (json stays 12 certified, all partial-level, CERTIFIED end to end).
- Guard isolation: a wrong measure or wrong descent fails exactly at the termination check while a one-conjunct-weakened acceptance copy accepts; an unknown measure declines with the closed-vocabulary reason; a total policy without a witness declines during strict manifest decoding.
- Docs: the level table row for totality no longer claims resource bounds (marked future). Certificate schema bumps to 47.

## Testing
- `cargo fmt --check`, `cargo build --bin aver --features wasm`, `cargo clippy --features wasm,wasip2 -- -D warnings`
- `cargo test -p aver-lang --features wasm --lib` (1020 passed)
- `cert_certify_spec` (11, corpus lake builds), `cert_decode_spec` (2)
- New termination guard-isolation and manifest round-trip tests; existing manifest/parser guards re-run green
- End-to-end certify+verify: recgen (5 certified, mixed levels, 14.7s) and json (12 certified, 40.5s), both CERTIFIED

🤖 Generated with [Claude Code](https://claude.com/claude-code)