### PR TITLE
Promote int-countdown mutual recursion to the total policy

### DIFF
--- a/docs/certification.md
+++ b/docs/certification.md
@@ -168,11 +168,15 @@ Parameterized List construction uses the same plan-backed constructor bridge as 
 
 The manifest always declares its level. A certificate never silently claims more than its level supports.
 
-For the current L3 descent-by-one family, the checked witness is `Int.natAbs`
-of the recursive input and the total theorem runs the byte-pinned body with
-`n.natAbs + 1` fuel. “Total” here means that this run returns a value related to
-the source model, rather than only describing a value if execution happens to
-return. The statement remains conditional on the named `hAddTot` and `hSubTot`
+For the current L3 descent-by-one families (single additive recursion and
+integer-countdown mutual SCCs), the checked witness is `Int.natAbs` of the
+recursive input and the total theorem runs the byte-pinned body with
+`n.natAbs + 1` fuel. A mutual SCC gets one conjunction theorem over all members
+and promotion is atomic: if any member leaves the closed countdown vocabulary,
+no member is promoted. Budget-heuristic mutual groups remain partial. “Total”
+here means that this run returns a value related to the source model, rather
+than only describing a value if execution happens to return. The statement
+remains conditional on the named `hAddTot` and `hSubTot`
 host contracts: `Int.add` and `Int.sub` must themselves be total on represented
 values. Those helper bodies are still assumed at L3; proving them is the L2
 ratchet. L3 makes no time, memory, or other resource-bound claim.

--- a/src/codegen/cert/AcceptedArtifactCore.lean
+++ b/src/codegen/cert/AcceptedArtifactCore.lean
@@ -516,6 +516,10 @@ def mutualPlanAccepted
   obligation.export_ = exportName ∧
     obligation.carrier = carrier ∧
     AverCert.PlanCheck.checkMutualRawPlan plan = true ∧
+    (match obligation.policy, obligation.termination? with
+     | .simulatesModel, none => true
+     | .simulatesModelTotally, some witness => AverCert.Schema.checkTermMutual plan witness
+     | _, _ => false) = true ∧
     ∃ body codeEntry binding,
       AverCert.PlanLower.lowerMutualBody carrier plan = some body ∧
       AverCert.PlanBytes.lowerMutualCodeEntry carrier plan = some codeEntry ∧

--- a/src/codegen/cert/SchemaCore.lean
+++ b/src/codegen/cert/SchemaCore.lean
@@ -336,6 +336,37 @@ structure MutualRawPlan where
   body    : FragBlock
 deriving Repr
 
+/-- Kernel decision procedure for one member of a promoted integer-countdown
+    mutual SCC. The floor/measure checks are identical to `checkTerm`; the only
+    intentional shape difference is that the byte-pinned recursive edge is a
+    tail call to another member rather than a non-tail self call. SCC closure
+    and target membership remain separate artifact-acceptance guards. -/
+def checkTermMutual (plan : MutualRawPlan) (witness : TerminationWitness) : Bool :=
+  match witness.measure with
+  | .intNatAbs paramIdx =>
+      plan.profile == "mutual-plan-v1" &&
+      plan.params == [.intCarrier] &&
+      plan.result == .intCarrier &&
+      paramIdx == 0 &&
+      witness.descent == (-1 : Int) &&
+      match checkTermStep? paramIdx plan.body with
+      | some step =>
+          step.nodes.any fun node =>
+            match node.kind with
+            | .selfCall true _ [descentId] =>
+                match step.nodes[descentId]? with
+                | some { kind := .hostCall .sub _ [inputId, boxedOneId], .. } =>
+                    match step.nodes[inputId]?, step.nodes[boxedOneId]? with
+                    | some { kind := .local localIdx, .. },
+                      some { kind := .hostCall .box _ [oneId], .. } =>
+                        match step.nodes[oneId]? with
+                        | some { kind := .constI64 1, .. } => localIdx == paramIdx
+                        | _ => false
+                    | _, _ => false
+                | _ => false
+            | _ => false
+      | none => false
+
 /-- A composition member carries only its semantic-free byte SHAPE. A chain
     names callee exports; numeric Wasm indices are resolved from those exports'
     byte-derived `FuncBinding`s by the acceptance predicate and are never plan

--- a/src/codegen/cert/cert_defs.rs
+++ b/src/codegen/cert/cert_defs.rs
@@ -29,7 +29,7 @@ impl CertificationPolicy {
     }
 }
 
-/// Closed v47 measure vocabulary. New variants require a schema bump and a
+/// Closed v48 measure vocabulary. New variants require a schema bump and a
 /// corresponding in-kernel `checkTerm` branch; unknown JSON measures never
 /// fall back to this one.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/codegen/cert/cert_methods.rs
+++ b/src/codegen/cert/cert_methods.rs
@@ -1,3 +1,31 @@
+/// Promotion is an SCC property, never a per-export guess. The classifier only
+/// constructs `MutualRecursion` for the exact `n ≤ 0` / `g (n - 1)` grammar;
+/// this final fail-closed check additionally requires one closed simple cycle
+/// in the shared SCC value carried by every member. Thus a malformed or mixed
+/// group yields no witness for any of its obligations.
+fn mutual_scc_total_eligible(scc: &[MutualMember]) -> bool {
+    if scc.len() < 2
+        || scc
+            .iter()
+            .any(|member| scc.iter().filter(|m| m.self_idx == member.self_idx).count() != 1)
+    {
+        return false;
+    }
+    let start = scc[0].self_idx;
+    let mut current = start;
+    let mut visited = std::collections::HashSet::with_capacity(scc.len());
+    for _ in 0..scc.len() {
+        if !visited.insert(current) {
+            return false;
+        }
+        let Some(member) = scc.iter().find(|m| m.self_idx == current) else {
+            return false;
+        };
+        current = member.cross_idx;
+    }
+    current == start && visited.len() == scc.len()
+}
+
 impl Cert {
     fn inner(&self) -> &Cert {
         match self {
@@ -6,10 +34,10 @@ impl Cert {
         }
     }
 
-    /// The only v47 total family: unary `n - 1` recursion whose combinator uses
-    /// `Int.add`. Multiplicative recursion would require a frozen `mul`
-    /// totality contract, and accumulator/mutual/budget families are not part
-    /// of this leg, so all of them remain partial.
+    /// The v48 total families: unary `n - 1` recursion whose combinator uses
+    /// `Int.add`, and complete integer-countdown mutual SCCs. Multiplicative
+    /// recursion would require a frozen `mul` totality contract; accumulator
+    /// and budget-heuristic families remain partial.
     fn termination_witness(&self) -> Option<TerminationWitness> {
         match self.inner() {
             Cert::Recursive {
@@ -19,6 +47,12 @@ impl Cert {
                 measure: TerminationMeasure::IntNatAbs { param_idx: 0 },
                 descent: -1,
             }),
+            Cert::MutualRecursion { scc, .. } if mutual_scc_total_eligible(scc) => {
+                Some(TerminationWitness {
+                    measure: TerminationMeasure::IntNatAbs { param_idx: 0 },
+                    descent: -1,
+                })
+            }
             _ => None,
         }
     }

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -66,7 +66,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 47;
+pub const CERT_SCHEMA_VERSION: u32 = 48;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/cert/mutual_plan_defs.rs
+++ b/src/codegen/cert/mutual_plan_defs.rs
@@ -212,4 +212,20 @@ mod mutual_plan_gate_tests {
             "a member the canonical plan cannot reproduce must not carry a claim"
         );
     }
+
+    #[test]
+    fn mutual_total_promotion_is_atomic_per_scc() {
+        for position in 0..2 {
+            let mut cert = mutual_cert(position, vec![Vec::new(), Vec::new()]);
+            let Cert::MutualRecursion { scc, .. } = &mut cert else {
+                unreachable!()
+            };
+            // One member no longer belongs to the closed descent cycle. Even
+            // when inspecting the untouched sibling export, the shared SCC
+            // fails eligibility and no per-member witness can be attached.
+            scc[0].cross_idx = 99;
+            assert_eq!(cert.termination_witness(), None);
+            assert_eq!(cert.policy(), CertificationPolicy::SimulatesModel);
+        }
+    }
 }

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -198,7 +198,7 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
         // primary member (`scc[0]`); the model is this member's own function.
         Cert::MutualRecursion { scc, .. } => format!(
             "abbrev {name}Ob : Schema.Obligation :=\n  \
-             {{ export_ := \"{name}\", policy := .simulatesModel, carrier := {carrier},\n    \
+             {{ export_ := \"{name}\", policy := {policy}, termination? := {termination}, carrier := {carrier},\n    \
              code := CertModule.{primary}Code, host := {host}, self := {self_idx},\n    \
              Dom := List Int, Cod := Int,\n    \
              domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = 1,\n    \
@@ -208,6 +208,10 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
             carrier = c.carrier(),
             host = c.host_expr(),
             self_idx = c.self_idx(),
+            policy = c.policy().lean_value(),
+            termination = c
+                .termination_witness()
+                .map_or_else(|| "none".to_string(), |w| format!("some {}", w.lean_value())),
         ),
         _ => format!(
             "abbrev {name}Ob : Schema.Obligation :=\n  \

--- a/src/codegen/cert/render_mutual.rs
+++ b/src/codegen/cert/render_mutual.rs
@@ -51,6 +51,53 @@ fn mutual_sim_member_block(
     )
 }
 
+/// Forward-progress mirror of `mutual_sim_member_block`. The cross call is
+/// supplied by the matching conjunction IH, while sub-totality supplies the
+/// concrete descended carrier value. There is no arithmetic combinator in the
+/// mutual countdown family, so add-totality is intentionally unused here.
+fn mutual_total_member_block(
+    primary: &str,
+    c_ty: u32,
+    m: &MutualMember,
+    cross_ih: &str,
+) -> String {
+    let base_lit = lean_int_lit(m.base_k);
+    let mn = &m.name;
+    format!(
+        r#"      · intro n v hv hbound
+        rcases hcar n v hv with ⟨s, sg, rfl⟩ | ⟨s, lty, les, sg, rfl⟩
+        · have hs := hsmall_elim n s sg hv; subst hs
+          by_cases hle : s ≤ (0 : Int)
+          · refine ⟨carrierSmall {c_ty} {base_lit}, ?_, ?_⟩
+            · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32,
+                popArgs, initLocals, hle]
+            · rw [{mn}_base s hle]; exact hsmall_intro {base_lit}
+          · obtain ⟨vd, hsub⟩ := hSubTot s 1 _ (carrierSmall {c_ty} 1) hv (hsmall_intro 1)
+            have hrd : Repr (s - 1) vd := hSub s 1 _ _ vd hv (hsmall_intro 1) hsub
+            obtain ⟨vr, hrec, hrr⟩ := {cross_ih} (s - 1) vd hrd (by omega)
+            refine ⟨vr, ?_, ?_⟩
+            · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32,
+                popArgs, initLocals, hle, hsub, hrec]
+            · rw [{mn}_step s hle]; exact hrr
+        · obtain ⟨hsign, hne⟩ := hbig n s lty les sg hv
+          by_cases hlt : sg < (0 : Int)
+          · have hn0 : n ≤ 0 := by have := hsign.mp hlt; omega
+            refine ⟨carrierSmall {c_ty} {base_lit}, ?_, ?_⟩
+            · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32,
+                popArgs, initLocals, hlt]
+            · rw [{mn}_base n hn0]; exact hsmall_intro {base_lit}
+          · have hn0 : ¬ n ≤ 0 := by
+              intro hle; have : ¬ n < 0 := fun h => hlt (hsign.mpr h); omega
+            obtain ⟨vd, hsub⟩ := hSubTot n 1 _ (carrierSmall {c_ty} 1) hv (hsmall_intro 1)
+            have hrd : Repr (n - 1) vd := hSub n 1 _ _ vd hv (hsmall_intro 1) hsub
+            obtain ⟨vr, hrec, hrr⟩ := {cross_ih} (n - 1) vd hrd (by omega)
+            refine ⟨vr, ?_, ?_⟩
+            · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32,
+                popArgs, initLocals, hlt, hsub, hrec]
+            · rw [{mn}_step n hn0]; exact hrr"#,
+    )
+}
+
 /// The certificate block for a mutually-recursive SCC. Emitted ONCE, by the
 /// primary (lowest-`self_idx`) member; the shared block proves ONE conjunction
 /// `induction fuel` over all members (`{primary}_mutual_sim`), each cross-call
@@ -231,6 +278,132 @@ theorem {primary}_mutual_sim
 "#,
     ));
 
+    // ---- total correctness over the same conjunction induction -------------
+    let total_aux_conj = scc
+        .iter()
+        .map(|m| {
+            format!(
+                "      (∀ n v, Repr n v → n.natAbs < fuel →\n        ∃ w, wFuncN {primary}Code ({primary}Host sub) fuel {self_idx} [v] = some w ∧ Repr ({m} n) w)",
+                self_idx = m.self_idx,
+                m = m.name,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ∧\n");
+    let total_member_blocks = scc
+        .iter()
+        .enumerate()
+        .map(|(p, m)| {
+            mutual_total_member_block(
+                primary,
+                c_ty,
+                m,
+                &format!("ih{}", cross_pos[p]),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let total_conj = scc
+        .iter()
+        .map(|m| {
+            format!(
+                "    (∀ n v, Repr n v →\n      ∃ w, wFuncN {primary}Code ({primary}Host sub) (n.natAbs + 1) {self_idx} [v] = some w ∧ Repr ({m} n) w)",
+                self_idx = m.self_idx,
+                m = m.name,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ∧\n");
+    let total_fixed_blocks = (0..k)
+        .map(|p| {
+            let proj = conjunct_proj(p, k);
+            format!(
+                "  · intro n v hv\n    exact ({primary}_mutual_total_aux Repr hcar hsmall_intro hsmall_elim hbig sub hSub hSubTot (n.natAbs + 1)){proj} n v hv (by omega)"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    s.push_str(&format!(
+        r#"/-- Fuel-parametric progress for every member of the byte-closed integer
+    countdown SCC, proved by one conjunction induction. -/
+theorem {primary}_mutual_total_aux
+    (Repr : Int → WVal → Prop)
+    (hcar : ∀ n v, Repr n v →
+      (∃ s sg, v = .structv {c_ty} [.i64v s, .null, .i32v sg]) ∨
+      (∃ s lty les sg, v = .structv {c_ty} [.i64v s, .arr lty les, .i32v sg]))
+    (hsmall_intro : ∀ k : Int, Repr k (carrierSmall {c_ty} k))
+    (hsmall_elim : ∀ n s sg, Repr n (.structv {c_ty} [.i64v s, .null, .i32v sg]) → s = n)
+    (hbig : ∀ n s lty les sg,
+      Repr n (.structv {c_ty} [.i64v s, .arr lty les, .i32v sg]) → ((sg < 0) ↔ (n < 0)) ∧ n ≠ 0)
+    (sub : List WVal → Option WVal)
+    (hSub : ∀ a b va vb w, Repr a va → Repr b vb → sub [va, vb] = some w → Repr (a - b) w)
+    (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
+    ∀ (fuel : Nat),
+{total_aux_conj} := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      refine ⟨{holes}⟩ <;> · intro n v hv hbound; omega
+  | succ fuel ih =>
+      obtain ⟨{ih_names}⟩ := ih
+      refine ⟨{holes}⟩
+{total_member_blocks}
+
+#print axioms {primary}_mutual_total_aux
+
+/-- TOTAL correctness of the SCC at the fuel selected by each member's checked
+    `intNatAbs` witness. The statement is a conjunction, so no member can be
+    promoted independently of its cross-call hypotheses. -/
+theorem {primary}_mutual_total
+    (Repr : Int → WVal → Prop)
+    (hcar : ∀ n v, Repr n v →
+      (∃ s sg, v = .structv {c_ty} [.i64v s, .null, .i32v sg]) ∨
+      (∃ s lty les sg, v = .structv {c_ty} [.i64v s, .arr lty les, .i32v sg]))
+    (hsmall_intro : ∀ k : Int, Repr k (carrierSmall {c_ty} k))
+    (hsmall_elim : ∀ n s sg, Repr n (.structv {c_ty} [.i64v s, .null, .i32v sg]) → s = n)
+    (hbig : ∀ n s lty les sg,
+      Repr n (.structv {c_ty} [.i64v s, .arr lty les, .i32v sg]) → ((sg < 0) ↔ (n < 0)) ∧ n ≠ 0)
+    (sub : List WVal → Option WVal)
+    (hSub : ∀ a b va vb w, Repr a va → Repr b vb → sub [va, vb] = some w → Repr (a - b) w)
+    (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
+{total_conj} := by
+  refine ⟨{holes}⟩
+{total_fixed_blocks}
+
+#print axioms {primary}_mutual_total
+
+"#,
+    ));
+
+    // Stable per-export theorem names used by the JSON report.
+    for (p, m) in scc.iter().enumerate() {
+        let proj = conjunct_proj(p, k);
+        let mn = &m.name;
+        s.push_str(&format!(
+            r#"theorem {mn}_wasm_total
+    (Repr : Int → WVal → Prop)
+    (hcar : ∀ n v, Repr n v →
+      (∃ s sg, v = .structv {c_ty} [.i64v s, .null, .i32v sg]) ∨
+      (∃ s lty les sg, v = .structv {c_ty} [.i64v s, .arr lty les, .i32v sg]))
+    (hsmall_intro : ∀ k : Int, Repr k (carrierSmall {c_ty} k))
+    (hsmall_elim : ∀ n s sg, Repr n (.structv {c_ty} [.i64v s, .null, .i32v sg]) → s = n)
+    (hbig : ∀ n s lty les sg,
+      Repr n (.structv {c_ty} [.i64v s, .arr lty les, .i32v sg]) → ((sg < 0) ↔ (n < 0)) ∧ n ≠ 0)
+    (sub : List WVal → Option WVal)
+    (hSub : ∀ a b va vb w, Repr a va → Repr b vb → sub [va, vb] = some w → Repr (a - b) w)
+    (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
+    ∀ n v, Repr n v →
+      ∃ w, wFuncN {primary}Code ({primary}Host sub) (n.natAbs + 1) {self_idx} [v] = some w ∧
+        Repr ({mn} n) w :=
+  ({primary}_mutual_total Repr hcar hsmall_intro hsmall_elim hbig sub hSub hSubTot){proj}
+
+#print axioms {mn}_wasm_total
+
+"#,
+            self_idx = m.self_idx,
+        ));
+    }
+
     // ---- anti-vacuity: the emitted bodies actually RUN -----------------------
     s.push_str(&format!(
         "-- anti-vacuity: the emitted bodies actually RUN on concrete inputs.\n\
@@ -274,6 +447,18 @@ theorem {mn}_simulates : AverCert.Schema.Obligation.holds {mn}Ob := by
             sub hsub fuel){proj} n v w hv hrun
       | cons _ _ =>
           simp at harity
+"#,
+        ));
+        s.push_str(&format!(
+            r#"
+theorem {mn}_simulates_total : AverCert.Schema.Obligation.holdsTotal {mn}Ob := by
+  intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat
+    hAddTot hSubTot n v hv
+  refine ⟨[n], ?_, ?_⟩
+  · exact ⟨ReprAll.cons hv ReprAll.nil, rfl⟩
+  · simpa [{mn}Ob, AverCert.Schema.intRepr] using
+      {mn}_wasm_total S.Repr S.car S.smallIntro S.smallElim S.bigElim
+        sub hsub hSubTot n v hv
 "#,
         ));
     }

--- a/src/codegen/cert/render_project.rs
+++ b/src/codegen/cert/render_project.rs
@@ -1130,7 +1130,7 @@ fn render_artifact_expr_fragment_claims(
                     export_name = lean_str(name),
                 ));
                 mutual_proofs.push(format!(
-                    "⟨rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
+                    "⟨rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
                      ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
                 ));
             }

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -399,7 +399,7 @@ fn read_candidates(m: &Value) -> Result<Candidates, String> {
                 })?;
                 if kind != "intNatAbs" {
                     return Err(format!(
-                        "cert-manifest.json certified export `{name}` uses unsupported termination measure `{kind}`; schema 47 admits only `intNatAbs`"
+                        "cert-manifest.json certified export `{name}` uses unsupported termination measure `{kind}`; schema 48 admits only `intNatAbs`"
                     ));
                 }
                 let param_idx = measure
@@ -2145,7 +2145,7 @@ fn lean_expr_fragment_artifact_claims(
                 carrier = r.carrier,
             ));
             mutual_proofs.push(format!(
-                "⟨rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
+                "⟨rfl, rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
                  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
             ));
             continue;

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -781,6 +781,14 @@ fn certify_mutual_recursion_scc_lake_builds_kernel_clean() {
                 "expected {name} certified for {fixture}, got {certified:?}"
             );
         }
+        for entry in manifest["certified"].as_array().unwrap() {
+            if exports.contains(&entry["name"].as_str().unwrap()) {
+                assert_eq!(entry["policy"], "simulatesModelTotally");
+                assert_eq!(entry["level"], "L3");
+                assert_eq!(entry["termination_witness"]["measure"]["kind"], "intNatAbs");
+                assert_eq!(entry["termination_witness"]["descent"], -1);
+            }
+        }
 
         let build = Command::new("lake")
             .current_dir(&cert_dir)
@@ -803,6 +811,12 @@ fn certify_mutual_recursion_scc_lake_builds_kernel_clean() {
                 "{primary}_mutual_sim' depends on axioms: [propext, Classical.choice, Quot.sound]"
             )),
             "mutual certificate for {fixture} not kernel-clean:\n{combined}"
+        );
+        assert!(
+            combined.contains(&format!(
+                "{primary}_mutual_total' depends on axioms: [propext, Classical.choice, Quot.sound]"
+            )),
+            "mutual total certificate for {fixture} not kernel-clean:\n{combined}"
         );
         assert!(
             !combined.contains("sorryAx"),

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -4297,6 +4297,65 @@ fn recursion_termination_witness_guard_is_isolating() {
     let _ = std::fs::remove_dir_all(&out_dir);
 }
 
+/// Mutual L3 GuardIso: changing the witness on only one SCC obligation reaches
+/// the mutual termination conjunct, and deleting just that conjunct accepts the
+/// otherwise byte-identical hostile claim.
+#[test]
+fn mutual_termination_witness_guard_is_isolating() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping mutual termination-witness GuardIso: `lake` not available");
+        return;
+    }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("cert-mutual-termination-guard-iso");
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/mutual.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("compile mutual fixture for termination GuardIso");
+    assert!(
+        compile.status.success(),
+        "mutual compile failed for termination GuardIso:\n{}{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let cert = out_dir.join("cert");
+    let build = Command::new("lake")
+        .current_dir(&cert)
+        .arg("build")
+        .output()
+        .expect("build mutual certificate before termination GuardIso");
+    assert!(
+        build.status.success(),
+        "honest mutual certificate must build"
+    );
+    std::fs::write(
+        cert.join("GuardIso.lean"),
+        include_str!("fixtures/cert_mutual_termination_guard_iso.lean"),
+    )
+    .unwrap();
+    let check = Command::new("lake")
+        .current_dir(&cert)
+        .arg("env")
+        .arg("lean")
+        .arg("GuardIso.lean")
+        .output()
+        .expect("run mutual termination GuardIso");
+    assert!(
+        check.status.success(),
+        "mutual termination GuardIso failed:\n{}{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
 /// The JSON policy/witness is only a candidate: supported-but-wrong data must
 /// disagree with verifier byte re-derivation in the checker-authored Lean
 /// witness, while an unknown measure or missing total witness declines during

--- a/tests/fixtures/cert_mutual_termination_guard_iso.lean
+++ b/tests/fixtures/cert_mutual_termination_guard_iso.lean
@@ -1,0 +1,92 @@
+import Artifact
+
+open CertPrelude AverCert AverCert.Schema
+
+def honestMutualWitness : TerminationWitness :=
+  { measure := .intNatAbs 0, descent := -1 }
+def wrongMutualWitness : TerminationWitness :=
+  { measure := .intNatAbs 0, descent := 1 }
+
+def wrongEvenOb : Obligation :=
+  { AverCert.isEvenOb with termination? := some wrongMutualWitness }
+
+-- Literal `mutualPlanAccepted` copy with only its termination conjunct removed.
+def mutualPlanAcceptedWithoutCheckTerm
+    (modBytes modLen : Nat)
+    (exportNameBytes : AverCert.WasmSlice.ByteSeq)
+    (exportName : String)
+    (carrier : Nat)
+    (memberSet : List Nat)
+    (hostTable : List (HostRole × Nat))
+    (plan : MutualRawPlan)
+    (obligation : Obligation) : Prop :=
+  obligation.export_ = exportName ∧
+    obligation.carrier = carrier ∧
+    AverCert.PlanCheck.checkMutualRawPlan plan = true ∧
+    ∃ body codeEntry binding,
+      AverCert.PlanLower.lowerMutualBody carrier plan = some body ∧
+      AverCert.PlanBytes.lowerMutualCodeEntry carrier plan = some codeEntry ∧
+      AverCert.WasmSlice.codeEntryForExport modBytes modLen exportNameBytes = some codeEntry ∧
+      AverCert.WasmSlice.funcBindingForExport modBytes modLen exportNameBytes = some binding ∧
+      binding.funcIdx = obligation.self ∧
+      binding.codeEntry = codeEntry ∧
+      AverCert.PlanCheck.checkMutualPlanShape memberSet hostTable plan = true ∧
+      AverCert.WasmSlice.funcTypeMatches
+        modBytes modLen binding.typeIdx plan.params.length carrier = true ∧
+      obligation.code binding.funcIdx =
+        some { arity := plan.params.length,
+               nlocals := AverCert.AcceptedArtifact.mutualNLocals plan, body := body }
+
+abbrev mutualModBytes := AverCert.ArtifactBytes.modBytes
+abbrev mutualModLen := AverCert.ArtifactBytes.modLen
+abbrev evenNameBytes : AverCert.WasmSlice.ByteSeq := [105, 115, 69, 118, 101, 110]
+abbrev mutualHostTable : List (HostRole × Nat) := [(.box, 7), (.sub, 9)]
+abbrev mutualMemberSet : List Nat := [1, 2]
+abbrev evenPlan := AverCert.Plans.isEvenMutualPlan
+
+-- Both honest members carry the same accepted measure; one hostile member
+-- fails at the termination decision while the sibling remains unchanged.
+example : checkTermMutual evenPlan honestMutualWitness = true := rfl
+example : checkTermMutual AverCert.Plans.isOddMutualPlan honestMutualWitness = true := rfl
+example : checkTermMutual evenPlan wrongMutualWitness = false := rfl
+example : wrongEvenOb.termination? ≠ AverCert.isOddOb.termination? := by decide
+
+theorem honestMutualAccepted : AverCert.AcceptedArtifact.mutualPlanAccepted
+    mutualModBytes mutualModLen evenNameBytes "isEven" 2 mutualMemberSet
+    mutualHostTable evenPlan AverCert.isEvenOb := by
+  have hfrags : AverCert.AcceptedArtifact.acceptedFragments AverCert.Artifact.data :=
+    AverCert.Artifact.certificate.2.2.2.2
+  have hmutual : AverCert.AcceptedArtifact.acceptedMutualRecursionFragments AverCert.Artifact.data :=
+    hfrags.2.2.2.2.2.1
+  simpa [AverCert.AcceptedArtifact.acceptedMutualRecursionFragments,
+    AverCert.AcceptedArtifact.mutualRecursionClaimsAccepted,
+    AverCert.AcceptedArtifact.mutualRecursionClaimAccepted,
+    AverCert.AcceptedArtifact.mutualPlanForExport,
+    AverCert.Artifact.data, AverCert.Artifact.mutualRecursionClaims,
+    AverCert.manifest, evenPlan, mutualModBytes, mutualModLen, evenNameBytes,
+    mutualHostTable, mutualMemberSet] using hmutual.1.1
+
+theorem weakenedMutualAccepts : mutualPlanAcceptedWithoutCheckTerm
+    mutualModBytes mutualModLen evenNameBytes "isEven" 2 mutualMemberSet
+    mutualHostTable evenPlan wrongEvenOb := by
+  rcases honestMutualAccepted with ⟨hexport, hcarrier, hraw, _hterm, hrest⟩
+  exact ⟨hexport, hcarrier, hraw, by simpa [wrongEvenOb] using hrest⟩
+
+-- The shipped predicate rejects exactly at the one conjunct omitted above.
+example : ¬ AverCert.AcceptedArtifact.mutualPlanAccepted
+    mutualModBytes mutualModLen evenNameBytes "isEven" 2 mutualMemberSet
+    mutualHostTable evenPlan wrongEvenOb := by
+  intro h
+  rcases h with ⟨_, _, _, hterm, _⟩
+  contradiction
+
+-- Witness mutation cannot alter byte-derived bindings, and only one member was
+-- made hostile: the other obligation remains the honest total obligation.
+example : wrongEvenOb.self = AverCert.isEvenOb.self ∧
+    wrongEvenOb.carrier = AverCert.isEvenOb.carrier ∧
+    wrongEvenOb.code = AverCert.isEvenOb.code ∧
+    wrongEvenOb.host = AverCert.isEvenOb.host := by
+  exact ⟨rfl, rfl, rfl, rfl⟩
+example : AverCert.isOddOb.policy = .simulatesModelTotally ∧
+    AverCert.isOddOb.termination? = some honestMutualWitness := by
+  exact ⟨rfl, rfl⟩


### PR DESCRIPTION
## Summary
- Extends the termination-witness machinery from #706 to mutual-recursion groups: every member of an int-countdown group carries a witness checked in-kernel against the byte-pinned plan body (tail call to the next member, sub-by-boxed-one descent), and the group certifies bounded total correctness as a conjunction over one fuel induction, mirroring the single-recursion template.
- Promotion is per-group and fail-closed; mixed promotion within a group is impossible by construction (decline test included). Budget-heuristic fuelized groups do not promote.
- Both proof emitters handle the mutual-total obligations; strict manifest decoding follows the #706 pattern.
- Guard isolation: a wrong witness on one member fails exactly at the termination check while the one-conjunct-weakened copy accepts, with the other member's honest total claim unaffected.
- Certificate schema bumps to 48.

## End-to-end
- mutual.av: 2 certified exports, level L3 (isEven, isOdd both total), verify 13.2s
- mutual3.av: 3 certified exports, level L3 (rotA/rotB/rotC), verify 11.5s
- json.av: 12 certified, all partial-level, CERTIFIED, verify 40.5s — no scanner promoted

## Testing
- fmt, clippy (wasm,wasip2), lib tests (1021), cert_certify_spec (11), cert_decode_spec (2)
- New mutual guard-isolation + re-run of #706 termination guards and parser strictness guards; full verify suite in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)