### PR TITLE
Account the whole module interface and isolate certified closures

### DIFF
--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -25,6 +25,7 @@ jobs:
         include:
           - suite: cert_certify_spec
           - suite: cert_decode_spec
+          - suite: cert_whole_module_guard_iso
           - suite: cert_verify_spec
             partition: 1/4
           - suite: cert_verify_spec

--- a/docs/certification.md
+++ b/docs/certification.md
@@ -34,6 +34,24 @@ exactly one canonical local, and binds the whole host builder extensionally to
 the strict byte-derived singleton `add` table. The independently read Int model
 and the existing callee-by-callee simulation proof remain unchanged.
 
+## Whole-module coverage
+
+Artifact acceptance now accounts for the module's complete byte-derived
+interface. Every export of every kind is either a claimed obligation export or
+appears in `declaredUncertified`; every import is listed exactly in
+`capabilities` and must belong to the kernel's wasm-gc effect capability
+registry; and `start` records whether section 8 exists and, when it does, its
+function index. The audited closure fold starts from all certified exports,
+walks every transitive direct call (including runtime helper bodies and nested
+control flow), rejects reachable imports and dynamic calls, and rejects global,
+table, linear-memory, atomic, `data.drop`, and `elem.drop` operations in that
+closure. Shared-memory declarations are rejected as a module-level channel.
+
+This is an isolation claim about certified closures, not a behavioral claim
+about `declaredUncertified` exports. Their names and reasons make the remaining
+surface explicit; the certificate does not say that those exports are correct,
+safe, effect-free, or otherwise certified.
+
 > Architecture direction: new certificate work should follow
 > [plan-first canonical lowering](certification-architecture.md). Expression
 > fragments no longer emit or accept trace sidecars; their plan sidecars are
@@ -132,7 +150,7 @@ Per certified export, the certificate proves, from the schema's fixed statement 
 - **Simulation**: for every input tuple in the class, running the body read back from the module bytes under the fragment semantics — with the named runtime contracts as hypotheses — returns exactly the encoding of the function's Lean model applied to those inputs. This is partial correctness: the theorem is conditional on the run returning a value, so a trap or fuel exhaustion makes no claim — the executable anti-vacuity guards below are what witness that certified bodies actually run. Recursive bodies, including two-argument accumulator recursion, are handled by a fuel-indexed interpreter plus a fuel-stability companion theorem.
 - **Law transfer**: laws proven about the model compose with simulation into statements about the bytes themselves.
 
-All of it is bundled behind **one final theorem** per certificate, `AverCert.Final.cert : Schema.Holds manifest`. The fixed, audited `SchemaCore.lean` contains the dependency-closed statement schema, while the thin `Schema.lean` shim adds the artifact-specific module-hash conjunct; `manifest` is a literal describing this artifact (hash, exports, contracts, profile, ABI, and artifact-level certificate root). The schema states each obligation over a typed source **domain** and **codomain** with explicit representation relations (`Dom`, `Cod`, `domRepr`, `codRepr`, `model`), so the same schema covers integer, projection and ADT classes. Certificates are bound to their schema version (`schema_version` in the manifest, currently 40): a checker refuses a certificate from a different schema generation with an explicit unsupported-version message rather than a misleading downstream error, so regenerate certificates with the toolchain that will verify them. A consumer never reads proof scripts; they check the final theorem's name and type, the artifact certificate root, the manifest literal, and the schema-core/schema/prelude/plan-check/plan-lower/plan-bytes/wasm-slice/expr-fragment-accepted/accepted-artifact-core/accepted-artifact hashes. If statement approval required inspecting arbitrary Lean syntax, the compiler bug would just move into a certificate-auditor bug — the schema exists so that it can't.
+All of it is bundled behind **one final theorem** per certificate, `AverCert.Final.cert : Schema.Holds manifest`. The fixed, audited `SchemaCore.lean` contains the dependency-closed statement schema, while the thin `Schema.lean` shim adds the artifact-specific module-hash conjunct; `manifest` is a literal describing this artifact (hash, exports, contracts, profile, ABI, and artifact-level certificate root). The schema states each obligation over a typed source **domain** and **codomain** with explicit representation relations (`Dom`, `Cod`, `domRepr`, `codRepr`, `model`), so the same schema covers integer, projection and ADT classes. Certificates are bound to their schema version (`schema_version` in the manifest, currently 49): a checker refuses a certificate from a different schema generation with an explicit unsupported-version message rather than a misleading downstream error, so regenerate certificates with the toolchain that will verify them. A consumer never reads proof scripts; they check the final theorem's name and type, the artifact certificate root, the manifest literal, and the schema-core/schema/prelude/plan-check/plan-lower/plan-bytes/wasm-slice/expr-fragment-accepted/accepted-artifact-core/accepted-artifact hashes. If statement approval required inspecting arbitrary Lean syntax, the compiler bug would just move into a certificate-auditor bug — the schema exists so that it can't.
 
 Anti-vacuity is enforced separately: executable guard `example`s must compute each certified function on at least one concrete input (these use `native_decide` and are deliberately **outside** the proof credit). The final theorems' axioms are collected by the kernel and must be exactly the whitelist `[propext, Classical.choice, Quot.sound]` — a smuggled `axiom`, `sorryAx` (an admitted goal) or `ofReduceBool` (native-code trust) fails verification.
 
@@ -195,7 +213,7 @@ declined fail-closed and appear only in `source_level_only`.
 - The elaboration-executes-code token scan on cert data files is a raised bar, not a proof; the structural fix is the in-kernel decode path.
 - `--certify` conflicts with `--optimize`: the certificate binds the exact emitted bytes.
 
-As of schema 45, the `cert_goals` matrix has **23 certified exports and 0
+As of schema 49, the `cert_goals` matrix has **23 certified exports and 0
 plan-less certified exports**. The JSON fixture has **12 certified exports and
 0 plan-less certified exports**.
 

--- a/src/codegen/cert/AcceptedArtifactCore.lean
+++ b/src/codegen/cert/AcceptedArtifactCore.lean
@@ -1362,6 +1362,15 @@ def constructClaimSymPlanPairs
     (claims : List ConstructClaim) : List (String × SymRawPlan) :=
   claims.map (fun c => (c.exportName, c.symPlan))
 
+/-- Exact whole-module direct-call closure claimed by the producer and
+    independently recomputed from the artifact bytes. `roots` are precisely the
+    certified obligation function indices; every other admitted member is
+    explicitly classified as a helper. -/
+structure ClosureClaim where
+  roots    : List Nat
+  helpers  : List Nat
+  admitted : List Nat
+
 /-- The checker-facing artifact data currently accepted by the Lean bridge.
     `symFragmentClaims` is the source-level expression surface. There is no
     artifact-level raw `ExprFragmentClaim`; representation plans are derived by
@@ -1382,6 +1391,8 @@ structure ArtifactData where
   fieldProjectionClaims : List FieldProjectionClaim
   compositionMembers : List CompositionMemberClaim
   compositionClaims  : List CompositionClaim
+  closureFuel        : Nat
+  closureClaim       : ClosureClaim
 
 def claimObligationExports (artifact : ArtifactData) : List String :=
   artifact.symFragmentClaims.map (fun c => c.obligation.export_) ++
@@ -1410,6 +1421,109 @@ def manifestObligationsClaimed (artifact : ArtifactData) : Bool :=
 def manifestObligationExportsUnique (artifact : ArtifactData) : Bool :=
   let names := artifact.manifest.obligations.map (fun o => o.export_)
   stringListNodup names
+
+/-! ### Whole-module interface accounting and certified-closure isolation -/
+
+def stringBytes (s : String) : AverCert.WasmSlice.ByteSeq :=
+  s.toList.map Char.toNat
+
+def byteSeqMem (needle : AverCert.WasmSlice.ByteSeq) :
+    List AverCert.WasmSlice.ByteSeq → Bool
+  | [] => false
+  | x :: xs => needle == x || byteSeqMem needle xs
+
+def byteSeqListNodup : List AverCert.WasmSlice.ByteSeq → Bool
+  | [] => true
+  | x :: xs => !byteSeqMem x xs && byteSeqListNodup xs
+
+def certifiedExportEntries
+    (manifest : AverCert.Schema.Manifest) : List AverCert.WasmSlice.ExportEntry :=
+  manifest.obligations.map (fun obligation =>
+    { name := stringBytes obligation.export_, kind := 0, idx := obligation.self })
+
+def declaredUncertifiedNames
+    (manifest : AverCert.Schema.Manifest) : List AverCert.WasmSlice.ByteSeq :=
+  manifest.subject.declaredUncertified.map (fun entry => stringBytes entry.1)
+
+def exportEntryMem (needle : AverCert.WasmSlice.ExportEntry) :
+    List AverCert.WasmSlice.ExportEntry → Bool
+  | [] => false
+  | entry :: rest =>
+      (needle.name == entry.name && needle.kind == entry.kind && needle.idx == entry.idx) ||
+        exportEntryMem needle rest
+
+def exportAccounted
+    (certified : List AverCert.WasmSlice.ExportEntry)
+    (declared : List AverCert.WasmSlice.ByteSeq)
+    (entry : AverCert.WasmSlice.ExportEntry) : Bool :=
+  exportEntryMem entry certified || byteSeqMem entry.name declared
+
+/-- Every byte-derived module export is classified exactly once: either the
+    function/name/index of a claimed obligation or an explicit uncertified
+    declaration. Both declaration lists are duplicate-free, disjoint and have
+    no phantom names absent from the export section. -/
+def exportsAccounted (artifact : ArtifactData) : Bool :=
+  match AverCert.WasmSlice.enumExports artifact.modBytes artifact.modLen with
+  | none => false
+  | some actual =>
+      let certified := certifiedExportEntries artifact.manifest
+      let declared := declaredUncertifiedNames artifact.manifest
+      let actualNames := actual.map (fun entry => entry.name)
+      let certifiedNames := certified.map (fun entry => entry.name)
+      byteSeqListNodup actualNames &&
+      byteSeqListNodup certifiedNames &&
+      byteSeqListNodup declared &&
+      certifiedNames.all (fun name => !byteSeqMem name declared) &&
+      actual.all (exportAccounted certified declared) &&
+      certified.all (fun entry => exportEntryMem entry actual) &&
+      declared.all (fun name => byteSeqMem name actualNames)
+
+def capabilityBytes (capability : String × String) :
+    AverCert.WasmSlice.ByteSeq × AverCert.WasmSlice.ByteSeq :=
+  (stringBytes capability.1, stringBytes capability.2)
+
+/-- The manifest capability list is exact (including import order), contains no
+    duplicates, and is a subset of the kernel registry minted from the wasm-gc
+    effect import mapping. Non-effect and forged imports therefore fail here. -/
+def importsWithinCapabilities (artifact : ArtifactData) : Bool :=
+  let declared := artifact.manifest.subject.capabilities
+  stringListNodup (declared.map (fun capability => capability.1 ++ "." ++ capability.2)) &&
+  declared.all (fun capability => AverCert.Schema.CAPABILITY_REGISTRY.contains capability) &&
+  match AverCert.WasmSlice.enumImportNames artifact.modBytes artifact.modLen with
+  | some actual => actual == declared.map capabilityBytes
+  | none => false
+
+/-- The manifest declares absence/presence and, when present, the exact start
+    function index read from section 8. -/
+def startAccounted (artifact : ArtifactData) : Bool :=
+  AverCert.WasmSlice.startFuncIndex artifact.modBytes artifact.modLen ==
+    some artifact.manifest.subject.start
+
+/-- One union closure over all certified roots. Closure of a union is the union
+    of each root's closure, while scanning shared helpers only once. The exact
+    admitted set is partitioned into certified roots and helpers; imports and
+    rejected opcodes make `closureFold` return `none`. Shared memory is rejected
+    as a declaration-level hidden channel. -/
+def closureIsolation (artifact : ArtifactData) : Bool :=
+  let claim := artifact.closureClaim
+  let certified := artifact.manifest.obligations.map (fun obligation => obligation.self)
+  AverCert.WasmSlice.natListNodup claim.roots &&
+  AverCert.WasmSlice.natListNodup claim.helpers &&
+  AverCert.WasmSlice.natListNodup claim.admitted &&
+  AverCert.WasmSlice.natSetEq claim.roots certified &&
+  claim.roots.all (fun root => !AverCert.WasmSlice.natMem root claim.helpers) &&
+  AverCert.WasmSlice.natSetEq claim.admitted (claim.roots ++ claim.helpers) &&
+  AverCert.WasmSlice.noSharedMemory artifact.modBytes artifact.modLen &&
+  match AverCert.WasmSlice.closureFold artifact.modBytes artifact.modLen
+      artifact.closureFuel claim.roots [] with
+  | some actual => AverCert.WasmSlice.natSetEq actual claim.admitted
+  | none => false
+
+def acceptedWholeModule (artifact : ArtifactData) : Prop :=
+  exportsAccounted artifact = true ∧
+  importsWithinCapabilities artifact = true ∧
+  startAccounted artifact = true ∧
+  closureIsolation artifact = true
 
 def acceptedSymFragments (artifact : ArtifactData) : Prop :=
   symFragmentClaimsAccepted artifact.modBytes artifact.modLen artifact.symFragmentClaims
@@ -1491,7 +1605,8 @@ def acceptedFragments (artifact : ArtifactData) : Prop :=
   acceptedVerbatimFragments artifact ∧
   acceptedIntDispatchFragments artifact ∧
   acceptedFieldProjectionFragments artifact ∧
-  acceptedCompositionFragments artifact
+  acceptedCompositionFragments artifact ∧
+  acceptedWholeModule artifact
 
 def expectedArtifactRoot : String :=
   "AverCert.Artifact.certificate"

--- a/src/codegen/cert/SchemaCore.lean
+++ b/src/codegen/cert/SchemaCore.lean
@@ -8,16 +8,89 @@ import CertPrelude
 namespace AverCert.Schema
 open CertPrelude
 
-/-- What the artifact is: its pinned hash, the emitted-fragment profile, the
-    runtime ABI, the artifact-level theorem root, the certified export names,
-    and the named runtime contracts every certificate is conditional on. Pure
-    data, mirrored in `cert-manifest.json`. -/
+/-- The finite host-capability registry, minted from wasm-gc's exhaustive
+    `EffectName.import_pair` mapping.  Artifact manifests may declare only
+    pairs in this kernel-owned list; the Wasm import section is independently
+    enumerated and must match the declaration exactly. -/
+def CAPABILITY_REGISTRY : List (String × String) := [
+  ("aver", "console_print"),
+  ("aver", "console_error"),
+  ("aver", "console_warn"),
+  ("aver", "time_unix_ms"),
+  ("aver", "request_method"),
+  ("aver", "request_url"),
+  ("aver", "request_query"),
+  ("aver", "request_body"),
+  ("aver", "request_headers_load"),
+  ("aver", "response_text"),
+  ("aver", "response_set_header"),
+  ("aver", "http_send"),
+  ("aver", "http_add_request_header"),
+  ("aver", "http_clear_request_headers"),
+  ("aver", "env_get"),
+  ("aver", "env_set"),
+  ("aver", "console_read_line"),
+  ("aver", "args_len"),
+  ("aver", "args_get"),
+  ("aver", "random_float"),
+  ("aver", "random_int"),
+  ("aver", "time_sleep"),
+  ("aver", "time_now"),
+  ("aver", "float_sin"),
+  ("aver", "float_cos"),
+  ("aver", "float_atan2"),
+  ("aver", "float_pow"),
+  ("aver", "terminal_enable_raw_mode"),
+  ("aver", "terminal_disable_raw_mode"),
+  ("aver", "terminal_clear"),
+  ("aver", "terminal_move_to"),
+  ("aver", "terminal_print"),
+  ("aver", "terminal_set_color"),
+  ("aver", "terminal_reset_color"),
+  ("aver", "terminal_read_key"),
+  ("aver", "terminal_size"),
+  ("aver", "terminal_hide_cursor"),
+  ("aver", "terminal_show_cursor"),
+  ("aver", "terminal_flush"),
+  ("aver", "disk_read_text"),
+  ("aver", "disk_write_text"),
+  ("aver", "disk_append_text"),
+  ("aver", "disk_exists"),
+  ("aver", "disk_delete"),
+  ("aver", "disk_delete_dir"),
+  ("aver", "disk_list_dir"),
+  ("aver", "disk_make_dir"),
+  ("aver", "tcp_connect"),
+  ("aver", "tcp_write_line"),
+  ("aver", "tcp_read_line"),
+  ("aver", "tcp_close"),
+  ("aver", "tcp_send"),
+  ("aver", "tcp_ping"),
+  ("aver", "http_get"),
+  ("aver", "http_head"),
+  ("aver", "http_delete"),
+  ("aver", "http_post"),
+  ("aver", "http_put"),
+  ("aver", "http_patch"),
+  ("aver", "record_enter_group"),
+  ("aver", "record_set_branch"),
+  ("aver", "record_exit_group")
+]
+
+/-- What the artifact is: its pinned hash, emitted-fragment profile, runtime
+    ABI, artifact theorem root, the certified and explicitly uncertified export
+    names, the exact effect-import capability surface, byte-derived start
+    status, and the runtime contracts every certificate is conditional on.
+    Pure data, mirrored in `cert-manifest.json`. -/
 structure Subject where
   artifactHash : String
   profile      : String
   abi          : String
   artifactRoot : String
   exports      : List String
+  declaredUncertified : List (String × String)
+  capabilities : List (String × String)
+  start        : Option Nat
   contracts    : List String
 
 /-- The certification policy attached to a certified export. Partial simulation

--- a/src/codegen/cert/WasmSlice.lean
+++ b/src/codegen/cert/WasmSlice.lean
@@ -726,6 +726,112 @@ def importedFuncCount (modBytes modLen : Nat) : Option Nat :=
           countFuncImportsNatFuel (count + 1) count rest restLen 0
       | none => none
 
+/-! ### Whole-module interface enumeration
+
+These folds retain the names that the older binding slicer intentionally
+discarded.  They consume each section exactly and return `none` on malformed or
+unsupported descriptors, so the artifact envelope fails closed. -/
+
+structure ExportEntry where
+  name : ByteSeq
+  kind : Nat
+  idx  : Nat
+deriving Repr, DecidableEq
+
+def readNatName (bytes len : Nat) : Option (ByteSeq × Nat × Nat) :=
+  match readNatUleb32 bytes len with
+  | some (nameLen, nameBytes, nameAndRestLen) =>
+      if nameLen ≤ nameAndRestLen then
+        some (takeNatBytes nameLen nameBytes,
+          nameBytes >>> (8 * nameLen), nameAndRestLen - nameLen)
+      else none
+  | none => none
+
+def skipLimitsNat (bytes len : Nat) : Option (Nat × Nat) :=
+  match readNatUleb32 bytes len with
+  | some (flags, afterFlags, afterFlagsLen) =>
+      if flags < 16 then
+        match readNatUleb32 afterFlags afterFlagsLen with
+        | some (_, afterMin, afterMinLen) =>
+            let afterMax? :=
+              if (flags &&& 0x01) != 0 then readNatUleb32 afterMin afterMinLen
+              else some (0, afterMin, afterMinLen)
+            match afterMax? with
+            | some (_, afterMax, afterMaxLen) =>
+                if (flags &&& 0x08) != 0 then
+                  match readNatUleb32 afterMax afterMaxLen with
+                  | some (_, rest, restLen) => some (rest, restLen)
+                  | none => none
+                else some (afterMax, afterMaxLen)
+            | none => none
+        | none => none
+      else none
+  | none => none
+
+def skipImportDescNat (bytes len : Nat) : Option (Nat × Nat) :=
+  if len = 0 then none else
+    let kind := bytes &&& 0xff
+    let rest := bytes >>> 8
+    let restLen := len - 1
+    if kind = 0x00 then
+      match readNatUleb32 rest restLen with
+      | some (_, tail, tailLen) => some (tail, tailLen)
+      | none => none
+    else if kind = 0x01 then
+      match skipValTypeNat rest restLen with
+      | some (limits, limitsLen) => skipLimitsNat limits limitsLen
+      | none => none
+    else if kind = 0x02 then
+      skipLimitsNat rest restLen
+    else if kind = 0x03 then
+      match skipValTypeNat rest restLen with
+      | some (mutability, mutabilityLen) =>
+          if mutabilityLen = 0 then none else
+            let m := mutability &&& 0xff
+            if m = 0 ∨ m = 1 then some (mutability >>> 8, mutabilityLen - 1)
+            else none
+      | none => none
+    else if kind = 0x04 then
+      if restLen = 0 ∨ (rest &&& 0xff) != 0 then none else
+        match readNatUleb32 (rest >>> 8) (restLen - 1) with
+        | some (_, tail, tailLen) => some (tail, tailLen)
+        | none => none
+    else none
+
+def readImportNamePairNat (bytes len : Nat) :
+    Option ((ByteSeq × ByteSeq) × Nat × Nat) :=
+  match readNatName bytes len with
+  | some (moduleName, afterModule, afterModuleLen) =>
+      match readNatName afterModule afterModuleLen with
+      | some (fieldName, descriptor, descriptorLen) =>
+          match skipImportDescNat descriptor descriptorLen with
+          | some (rest, restLen) => some ((moduleName, fieldName), rest, restLen)
+          | none => none
+      | none => none
+  | none => none
+
+def enumImportNamesNatFuel :
+    Nat → Nat → Nat → Nat → List (ByteSeq × ByteSeq) →
+      Option (List (ByteSeq × ByteSeq))
+  | 0, _, _, _, _ => none
+  | _fuel + 1, 0, _bytes, len, acc =>
+      if len = 0 then some acc.reverse else none
+  | fuel + 1, remaining + 1, bytes, len, acc =>
+      match readImportNamePairNat bytes len with
+      | some (pair, rest, restLen) =>
+          enumImportNamesNatFuel fuel remaining rest restLen (pair :: acc)
+      | none => none
+
+def enumImportNames (modBytes modLen : Nat) :
+    Option (List (ByteSeq × ByteSeq)) :=
+  match findSectionPayload 0x02 modBytes modLen with
+  | none => some []
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (count, rest, restLen) =>
+          enumImportNamesNatFuel (count + 1) count rest restLen []
+      | none => none
+
 def readExportEntryNat (bytes len : Nat) :
     Option (ByteSeq × Nat × Nat × Nat × Nat) :=
   match readNatUleb32 bytes len with
@@ -742,6 +848,38 @@ def readExportEntryNat (bytes len : Nat) :
       else
         none
   | none => none
+
+def enumExportsNatFuel :
+    Nat → Nat → Nat → Nat → List ExportEntry → Option (List ExportEntry)
+  | 0, _, _, _, _ => none
+  | _fuel + 1, 0, _bytes, len, acc =>
+      if len = 0 then some acc.reverse else none
+  | fuel + 1, remaining + 1, bytes, len, acc =>
+      match readExportEntryNat bytes len with
+      | some (name, kind, idx, rest, restLen) =>
+          enumExportsNatFuel fuel remaining rest restLen
+            ({ name := name, kind := kind, idx := idx } :: acc)
+      | none => none
+
+def enumExports (modBytes modLen : Nat) : Option (List ExportEntry) :=
+  match findSectionPayload 0x07 modBytes modLen with
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (count, rest, restLen) =>
+          enumExportsNatFuel (count + 1) count rest restLen []
+      | none => none
+  | none => none
+
+/-- `some none` means no start section; `some (some idx)` is the exact function
+    index encoded by section 8.  A present payload must contain one u32 and no
+    trailing bytes. -/
+def startFuncIndex (modBytes modLen : Nat) : Option (Option Nat) :=
+  match findSectionPayload 0x08 modBytes modLen with
+  | none => some none
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (idx, _, 0) => some (some idx)
+      | _ => none
 
 def findExportFuncIndexNatFuel (targetName : ByteSeq) :
     Nat → Nat → Nat → Nat → Option Nat → Option Nat
@@ -853,5 +991,221 @@ def funcBindingForExport (modBytes modLen : Nat) (targetName : ByteSeq) : Option
   match exportFuncIndex modBytes modLen targetName with
   | some funcIdx => funcBindingByFuncIndex modBytes modLen funcIdx
   | none => none
+
+/-! ### Certified direct-call closure and rejected-channel scan
+
+The scanner deliberately recognizes only immediate layouts needed by the
+validated wasm-gc certified profile.  Structured control is linear in the code
+bytes (`block`/`loop`/`if`, branches, `else`, `end`), so instructions in every
+nested body are visited.  Direct `call`/`return_call` targets are collected;
+dynamic calls, globals, tables, linear memory, atomics, SIMD, segment drops and
+every unknown prefix fail closed.  Generated witnesses disclose a raised
+`maxRecDepth`; this is an elaborator reduction limit only and does not change
+the proposition or admitted axioms. -/
+
+def skipSignedLebBytes : Nat → ByteSeq → Option ByteSeq
+  | 0, _ => none
+  | _fuel + 1, [] => none
+  | fuel + 1, b :: rest =>
+      if b < 256 then
+        if b < 128 then some rest else skipSignedLebBytes fuel rest
+      else none
+
+def skipBlockType : ByteSeq → Option ByteSeq
+  | [] => none
+  | b :: rest =>
+      if b = 0x40 ∨ (0x7b ≤ b ∧ b ≤ 0x7f) then some rest
+      else if b = 0x63 ∨ b = 0x64 then skipSignedLebBytes 5 rest
+      else skipSignedLebBytes 5 (b :: rest)
+
+def skipLocalGroups : Nat → ByteSeq → Option ByteSeq
+  | 0, bytes => some bytes
+  | groups + 1, bytes =>
+      match readUleb32 bytes with
+      | some (_, afterCount) =>
+          match skipValType afterCount with
+          | some rest => skipLocalGroups groups rest
+          | none => none
+      | none => none
+
+def skipTwoUlebs (bytes : ByteSeq) : Option ByteSeq :=
+  match readUleb32 bytes with
+  | some (_, rest) =>
+      match readUleb32 rest with
+      | some (_, tail) => some tail
+      | none => none
+  | none => none
+
+def skipGcImmediate (sub : Nat) (bytes : ByteSeq) : Option ByteSeq :=
+  if sub = 0x00 ∨ sub = 0x01 ∨ sub = 0x06 ∨ sub = 0x07 ∨
+      sub = 0x0b ∨ sub = 0x0c ∨ sub = 0x0d ∨ sub = 0x0e ∨ sub = 0x10 then
+    match readUleb32 bytes with
+    | some (_, rest) => some rest
+    | none => none
+  else if sub = 0x02 ∨ sub = 0x03 ∨ sub = 0x04 ∨ sub = 0x05 ∨
+      sub = 0x08 ∨ sub = 0x09 ∨ sub = 0x0a ∨ sub = 0x11 ∨
+      sub = 0x12 ∨ sub = 0x13 then
+    skipTwoUlebs bytes
+  else if sub = 0x0f ∨ sub = 0x1a ∨ sub = 0x1b ∨
+      sub = 0x1c ∨ sub = 0x1d ∨ sub = 0x1e then
+    some bytes
+  else if sub = 0x14 ∨ sub = 0x15 ∨ sub = 0x16 ∨ sub = 0x17 then
+    skipSignedLebBytes 5 bytes
+  else none
+
+/-- Full-body instruction scan for direct callees.  Rejected opcodes return
+    `none`, which also makes reachable imports fail when closure expansion asks
+    `codeEntryByFuncIndex` for a body that does not exist. -/
+def scanClosureInstrs : Nat → ByteSeq → Option (List Nat)
+  | 0, _ => none
+  | _fuel + 1, [] => some []
+  | fuel + 1, op :: bytes =>
+      let next (rest : ByteSeq) := scanClosureInstrs fuel rest
+      let oneUleb := fun () =>
+        match readUleb32 bytes with
+        | some (_, rest) => next rest
+        | none => none
+      if op = 0x10 ∨ op = 0x12 then
+        match readUleb32 bytes with
+        | some (callee, rest) =>
+            (next rest).map (fun calls => callee :: calls)
+        | none => none
+      else if op = 0x02 ∨ op = 0x03 ∨ op = 0x04 then
+        match skipBlockType bytes with
+        | some rest => next rest
+        | none => none
+      else if op = 0x0c ∨ op = 0x0d ∨ op = 0x20 ∨ op = 0x21 ∨ op = 0x22 then
+        oneUleb ()
+      else if op = 0x0e then
+        match readUleb32 bytes with
+        | some (count, rest) =>
+            match skipUlebsFuel (count + 2) (count + 1) rest with
+            | some tail => next tail
+            | none => none
+        | none => none
+      else if op = 0x1c then
+        match readUleb32 bytes with
+        | some (count, rest) =>
+            match skipValTypesFuel (count + 1) count rest with
+            | some tail => next tail
+            | none => none
+        | none => none
+      else if op = 0x41 ∨ op = 0xd0 then
+        match skipSignedLebBytes 5 bytes with
+        | some rest => next rest
+        | none => none
+      else if op = 0x42 then
+        match skipSignedLebBytes 10 bytes with
+        | some rest => next rest
+        | none => none
+      else if op = 0x43 then
+        match takeN 4 bytes with
+        | some (_, rest) => next rest
+        | none => none
+      else if op = 0x44 then
+        match takeN 8 bytes with
+        | some (_, rest) => next rest
+        | none => none
+      else if op = 0xfb then
+        match readUleb32 bytes with
+        | some (sub, rest) =>
+            match skipGcImmediate sub rest with
+            | some tail => next tail
+            | none => none
+        | none => none
+      else if op = 0xfc then
+        match readUleb32 bytes with
+        | some (sub, rest) => if sub ≤ 7 then next rest else none
+        | none => none
+      else if op = 0x00 ∨ op = 0x01 ∨ op = 0x05 ∨ op = 0x0b ∨
+          op = 0x0f ∨ op = 0x1a ∨ op = 0x1b ∨ op = 0xd1 ∨ op = 0xd3 ∨
+          (0x45 ≤ op ∧ op ≤ 0xc4) then
+        next bytes
+      else none
+
+def scanClosureCodeEntry (entry : ByteSeq) : Option (List Nat) :=
+  match readUleb32 entry with
+  | some (_, body) =>
+      match readUleb32 body with
+      | some (localGroups, afterGroupCount) =>
+          match skipLocalGroups localGroups afterGroupCount with
+          | some instrs => scanClosureInstrs (instrs.length + 1) instrs
+          | none => none
+      | none => none
+  | none => none
+
+def scanClosureBody (modBytes modLen funcIdx : Nat) : Option (List Nat) :=
+  match codeEntryByFuncIndex modBytes modLen funcIdx with
+  | some entry => scanClosureCodeEntry entry
+  | none => none
+
+def natMem (x : Nat) : List Nat → Bool
+  | [] => false
+  | y :: ys => x == y || natMem x ys
+
+def natSubset : List Nat → List Nat → Bool
+  | [], _ => true
+  | x :: xs, ys => natMem x ys && natSubset xs ys
+
+def natSetEq (xs ys : List Nat) : Bool :=
+  natSubset xs ys && natSubset ys xs
+
+def natListNodup : List Nat → Bool
+  | [] => true
+  | x :: xs => !natMem x xs && natListNodup xs
+
+/-- Fuel-bounded transitive direct-call closure, using the spike-proven
+    worklist/seen fold over the big-Nat module representation. -/
+def closureFold (modBytes modLen : Nat) :
+    Nat → List Nat → List Nat → Option (List Nat)
+  | 0, [], seen => some seen
+  | 0, _ :: _, _ => none
+  | _fuel + 1, [], seen => some seen
+  | fuel + 1, func :: work, seen =>
+      if natMem func seen then
+        closureFold modBytes modLen fuel work seen
+      else
+        match scanClosureBody modBytes modLen func with
+        | some callees =>
+            closureFold modBytes modLen fuel (callees ++ work) (func :: seen)
+        | none => none
+
+def memoryLimitsUnshared : Nat → Nat → Nat → Option (Nat × Nat)
+  | 0, bytes, len => some (bytes, len)
+  | count + 1, bytes, len =>
+      match readNatUleb32 bytes len with
+      | some (flags, afterFlags, afterFlagsLen) =>
+          if flags < 16 ∧ (flags &&& 0x02) = 0 then
+            match readNatUleb32 afterFlags afterFlagsLen with
+            | some (_, afterMin, afterMinLen) =>
+                let afterMax? :=
+                  if (flags &&& 0x01) != 0 then readNatUleb32 afterMin afterMinLen
+                  else some (0, afterMin, afterMinLen)
+                match afterMax? with
+                | some (_, afterMax, afterMaxLen) =>
+                    if (flags &&& 0x08) != 0 then
+                      match readNatUleb32 afterMax afterMaxLen with
+                      | some (_, tail, tailLen) =>
+                          memoryLimitsUnshared count tail tailLen
+                      | none => none
+                    else memoryLimitsUnshared count afterMax afterMaxLen
+                | none => none
+            | none => none
+          else none
+      | none => none
+
+/-- Shared linear memory is a module-level hidden channel even if the current
+    bodies contain no atomic opcode, so the strict profile rejects the
+    declaration itself. -/
+def noSharedMemory (modBytes modLen : Nat) : Bool :=
+  match findSectionPayload 0x05 modBytes modLen with
+  | none => true
+  | some (payload, payloadLen) =>
+      match readNatUleb32 payload payloadLen with
+      | some (count, rest, restLen) =>
+          match memoryLimitsUnshared count rest restLen with
+          | some (_, 0) => true
+          | _ => false
+      | none => false
 
 end AverCert.WasmSlice

--- a/src/codegen/cert/analysis.rs
+++ b/src/codegen/cert/analysis.rs
@@ -2,6 +2,7 @@
 pub struct Analysis {
     certs: Vec<Cert>,
     declined: Vec<(String, String)>,
+    module_envelope: ModuleEnvelopeFacts,
     carrier: Option<u32>,
     contracts: Vec<String>,
     /// The strict byte-derived host-role table (S1 criteria: carrier-binop
@@ -121,10 +122,16 @@ pub fn analyze_with_fragment_plans(
 
     // Named runtime contracts actually consumed by the certified functions.
     let contracts = runtime_contracts_for_certs(&certs);
+    let certified = certs
+        .iter()
+        .map(|cert| (cert.name().to_string(), cert.self_idx()))
+        .collect::<Vec<_>>();
+    let module_envelope = collect_module_envelope_facts(wasm_bytes, &certified)?;
 
     Ok(Analysis {
         certs,
         declined,
+        module_envelope,
         carrier,
         contracts,
         frag_host_table,

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -66,7 +66,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 48;
+pub const CERT_SCHEMA_VERSION: u32 = 49;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";
@@ -149,6 +149,7 @@ include!("construct_plan_defs.rs");
 include!("field_projection_plan_defs.rs");
 include!("cert_methods.rs");
 include!("analysis.rs");
+include!("module_envelope.rs");
 include!("rederive.rs");
 include!("disasm.rs");
 include!("classification.rs");

--- a/src/codegen/cert/module_envelope.rs
+++ b/src/codegen/cert/module_envelope.rs
@@ -1,0 +1,212 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModuleExportFact {
+    pub name: String,
+    pub kind: u8,
+    pub index: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClosureClaimFact {
+    pub roots: Vec<u32>,
+    pub helpers: Vec<u32>,
+    pub admitted: Vec<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModuleEnvelopeFacts {
+    pub exports: Vec<ModuleExportFact>,
+    pub capabilities: Vec<(String, String)>,
+    pub start: Option<u32>,
+    pub closure_fuel: u32,
+    pub closure: ClosureClaimFact,
+}
+
+impl ModuleEnvelopeFacts {
+    pub(crate) fn declared_uncertified(
+        &self,
+        certified_names: impl IntoIterator<Item = String>,
+        declined: &[(String, String)],
+    ) -> Vec<(String, String)> {
+        let certified = certified_names.into_iter().collect::<BTreeSet<_>>();
+        let reasons = declined
+            .iter()
+            .cloned()
+            .collect::<BTreeMap<String, String>>();
+        self.exports
+            .iter()
+            .filter(|export| !certified.contains(&export.name))
+            .map(|export| {
+                let reason = reasons.get(&export.name).cloned().unwrap_or_else(|| {
+                    "module export is outside the claimed certification obligations".to_string()
+                });
+                (export.name.clone(), reason)
+            })
+            .collect()
+    }
+}
+
+fn external_kind_byte(kind: wasmparser::ExternalKind) -> u8 {
+    match kind {
+        wasmparser::ExternalKind::Func => 0,
+        wasmparser::ExternalKind::Table => 1,
+        wasmparser::ExternalKind::Memory => 2,
+        wasmparser::ExternalKind::Global => 3,
+        wasmparser::ExternalKind::Tag => 4,
+        wasmparser::ExternalKind::FuncExact => 5,
+    }
+}
+
+/// Re-derive the whole-module interface and direct-call graph from the exact
+/// validated bytes.  Rust renders this summary twice (producer and verifier),
+/// but it is not authority: the audited Lean folds independently enumerate the
+/// sections and recompute the closure from `ArtifactBytes.modBytes`.
+pub fn collect_module_envelope_facts(
+    wasm_bytes: &[u8],
+    certified: &[(String, u32)],
+) -> Result<ModuleEnvelopeFacts, String> {
+    use wasmparser::{Operator, Parser, Payload, TypeRef};
+
+    wasmparser::Validator::new()
+        .validate_all(wasm_bytes)
+        .map_err(|e| format!("wasm module failed validation: {e}"))?;
+
+    let registry = crate::codegen::wasm_gc::effects::capability_registry()
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let mut exports = Vec::new();
+    let mut capabilities = Vec::new();
+    let mut start = None;
+    let mut imported_funcs = 0u32;
+    let mut defined_funcs = 0u32;
+    let mut calls_by_func = BTreeMap::<u32, Vec<u32>>::new();
+
+    for payload in Parser::new(0).parse_all(wasm_bytes) {
+        match payload.map_err(|e| format!("wasm parse: {e}"))? {
+            Payload::ImportSection(reader) => {
+                for group in reader {
+                    let group = group.map_err(|e| format!("import read: {e}"))?;
+                    for import in group {
+                        let (_, import) = import.map_err(|e| format!("import read: {e}"))?;
+                        let pair = (import.module.to_string(), import.name.to_string());
+                        if !registry.contains(&(import.module, import.name)) {
+                            return Err(format!(
+                                "module import `{}.{}` is outside the wasm-gc effect capability registry",
+                                import.module, import.name
+                            ));
+                        }
+                        capabilities.push(pair);
+                        if matches!(import.ty, TypeRef::Func(_)) {
+                            imported_funcs += 1;
+                        }
+                    }
+                }
+            }
+            Payload::FunctionSection(reader) => {
+                defined_funcs = reader.count();
+            }
+            Payload::ExportSection(reader) => {
+                for export in reader {
+                    let export = export.map_err(|e| format!("export read: {e}"))?;
+                    exports.push(ModuleExportFact {
+                        name: export.name.to_string(),
+                        kind: external_kind_byte(export.kind),
+                        index: export.index,
+                    });
+                }
+            }
+            Payload::StartSection { func, .. } => {
+                start = Some(func);
+            }
+            Payload::CodeSectionEntry(body) => {
+                let func_idx = imported_funcs + calls_by_func.len() as u32;
+                let mut calls = Vec::new();
+                let mut operators = body
+                    .get_operators_reader()
+                    .map_err(|e| format!("operators read: {e}"))?;
+                while !operators.eof() {
+                    match operators
+                        .read()
+                        .map_err(|e| format!("operator read: {e}"))?
+                    {
+                        Operator::Call { function_index }
+                        | Operator::ReturnCall { function_index } => calls.push(function_index),
+                        _ => {}
+                    }
+                }
+                calls_by_func.insert(func_idx, calls);
+            }
+            _ => {}
+        }
+    }
+
+    if calls_by_func.len() != defined_funcs as usize {
+        return Err(format!(
+            "function/code section count mismatch: {defined_funcs} declarations, {} bodies",
+            calls_by_func.len()
+        ));
+    }
+
+    let mut roots = certified.iter().map(|(_, idx)| *idx).collect::<Vec<_>>();
+    roots.sort_unstable();
+    roots.dedup();
+    let root_set = roots.iter().copied().collect::<BTreeSet<_>>();
+    let mut reached = BTreeSet::new();
+    let mut work = VecDeque::from(roots.clone());
+    while let Some(func) = work.pop_front() {
+        if !reached.insert(func) {
+            continue;
+        }
+        if let Some(callees) = calls_by_func.get(&func) {
+            work.extend(callees.iter().copied());
+        }
+    }
+    let admitted = reached.iter().copied().collect::<Vec<_>>();
+    let helpers = admitted
+        .iter()
+        .copied()
+        .filter(|idx| !root_set.contains(idx))
+        .collect::<Vec<_>>();
+    // `closureFold` spends one unit for every worklist pop, including duplicate
+    // edges to an already-seen helper. Exact reachable vertices alone are not
+    // enough fuel for arithmetic-heavy modules where many roots share helpers.
+    let reachable_edges = reached
+        .iter()
+        .filter_map(|func| calls_by_func.get(func))
+        .try_fold(0u32, |count, calls| count.checked_add(calls.len() as u32))
+        .ok_or_else(|| "closure edge count overflows u32".to_string())?;
+    let closure_fuel = (roots.len() as u32)
+        .checked_add(reachable_edges)
+        .and_then(|n| n.checked_add(1))
+        .ok_or_else(|| "closure fuel overflows u32".to_string())?;
+
+    Ok(ModuleEnvelopeFacts {
+        exports,
+        capabilities,
+        start,
+        closure_fuel,
+        closure: ClosureClaimFact {
+            roots,
+            helpers,
+            admitted,
+        },
+    })
+}
+
+#[cfg(test)]
+mod module_envelope_tests {
+    #[test]
+    fn audited_kernel_capability_registry_tracks_effect_import_pairs() {
+        let registry = crate::codegen::wasm_gc::effects::capability_registry();
+        let unique = registry.iter().copied().collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(registry.len(), unique.len(), "effect import pairs must be unique");
+        for (module, field) in registry {
+            let lean_entry = format!("(\"{module}\", \"{field}\")");
+            assert!(
+                super::CERT_SCHEMA_CORE.contains(&lean_entry),
+                "SchemaCore.CAPABILITY_REGISTRY is missing {module}.{field}"
+            );
+        }
+    }
+}

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -273,6 +273,25 @@ fn render_manifest_lean(
         .map(|c| lean_str(c))
         .collect::<Vec<_>>()
         .join(", ");
+    let declared_uncertified = analysis
+        .module_envelope
+        .declared_uncertified(analysis.certified_names(), &analysis.declined)
+        .iter()
+        .map(|(name, reason)| format!("({}, {})", lean_str(name), lean_str(reason)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let capabilities = analysis
+        .module_envelope
+        .capabilities
+        .iter()
+        .map(|(module, field)| format!("({}, {})", lean_str(module), lean_str(field)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let start = analysis
+        .module_envelope
+        .start
+        .map(|idx| format!("some {idx}"))
+        .unwrap_or_else(|| "none".to_string());
     let obligations = analysis
         .certs
         .iter()
@@ -465,6 +484,9 @@ fn render_manifest_lean(
          abi := \"{RUNTIME_ABI}\",\n        \
          artifactRoot := \"{ARTIFACT_CERTIFICATE_ROOT}\",\n        \
          exports := [{exports}],\n        \
+         declaredUncertified := [{declared_uncertified}],\n        \
+         capabilities := [{capabilities}],\n        \
+         start := {start},\n        \
          contracts := [{contracts}] }},\n    \
          symFragmentPlans := [{sym_fragment_plans}],\n    \
          stringEqPlans := [{string_eq_plans}],\n    \
@@ -669,6 +691,47 @@ fn render_manifest(
         s.push_str("\n  ");
     }
     s.push_str("],\n");
+    let declared_uncertified = analysis
+        .module_envelope
+        .declared_uncertified(analysis.certified_names(), &analysis.declined);
+    s.push_str("  \"declaredUncertified\": [");
+    for (i, (name, reason)) in declared_uncertified.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!(
+            "\n    {{\"name\": {}, \"reason\": {}}}",
+            json_str(name),
+            json_str(reason)
+        ));
+    }
+    if !declared_uncertified.is_empty() {
+        s.push_str("\n  ");
+    }
+    s.push_str("],\n");
+    s.push_str("  \"capabilities\": [");
+    for (i, (module, field)) in analysis.module_envelope.capabilities.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!(
+            "\n    {{\"module\": {}, \"name\": {}}}",
+            json_str(module),
+            json_str(field)
+        ));
+    }
+    if !analysis.module_envelope.capabilities.is_empty() {
+        s.push_str("\n  ");
+    }
+    s.push_str("],\n");
+    match analysis.module_envelope.start {
+        Some(index) => s.push_str(&format!(
+            "  \"start\": {{\"present\": true, \"function_index\": {index}}},\n"
+        )),
+        None => s.push_str(
+            "  \"start\": {\"present\": false, \"function_index\": null},\n",
+        ),
+    }
     s.push_str("  \"certified\": [");
     for (i, c) in analysis.certs.iter().enumerate() {
         if i > 0 {

--- a/src/codegen/cert/render_project.rs
+++ b/src/codegen/cert/render_project.rs
@@ -1469,9 +1469,25 @@ fn render_artifact(
         host_table_lean,
         struct_table_lean,
     );
+    let nat_list = |values: &[u32]| {
+        format!(
+            "[{}]",
+            values
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    let closure_claim = format!(
+        "({{ roots := {}, helpers := {}, admitted := {} }} : AverCert.AcceptedArtifact.ClosureClaim)",
+        nat_list(&analysis.module_envelope.closure.roots),
+        nat_list(&analysis.module_envelope.closure.helpers),
+        nat_list(&analysis.module_envelope.closure.admitted),
+    );
     let fragment_proof = format!(
         concat!(
-            "  dsimp [data, symFragmentClaims, stringEqClaims, stringConcatClaims, constructClaims, recursionClaims, mutualRecursionClaims, verbatimClaims, intDispatchClaims, fieldProjectionClaims, compositionMembers, compositionClaims, AverCert.AcceptedArtifact.accepted,\n",
+            "  dsimp [data, closureClaim, symFragmentClaims, stringEqClaims, stringConcatClaims, constructClaims, recursionClaims, mutualRecursionClaims, verbatimClaims, intDispatchClaims, fieldProjectionClaims, compositionMembers, compositionClaims, AverCert.AcceptedArtifact.accepted,\n",
             "    AverCert.AcceptedArtifact.subjectMatchesArtifactRoot,\n",
             "    AverCert.AcceptedArtifact.expectedArtifactRoot,\n",
             "    AverCert.AcceptedArtifact.fragmentClaimObligationsInManifest,\n",
@@ -1513,6 +1529,7 @@ fn render_artifact(
             "    AverCert.AcceptedArtifact.acceptedIntDispatchFragments,\n",
             "    AverCert.AcceptedArtifact.acceptedFieldProjectionFragments,\n",
             "    AverCert.AcceptedArtifact.acceptedCompositionFragments,\n",
+            "    AverCert.AcceptedArtifact.acceptedWholeModule,\n",
             "    AverCert.AcceptedArtifact.symFragmentClaimsAccepted,\n",
             "    AverCert.AcceptedArtifact.symFragmentClaimAccepted,\n",
             "    AverCert.AcceptedArtifact.symFragmentPlanAccepted,\n",
@@ -1570,7 +1587,7 @@ fn render_artifact(
             "    AverCert.AcceptedArtifact.intDispatchCanonicalSlots,\n",
             "    AverCert.AcceptedArtifact.exprFragmentPlanAccepted,\n",
             "    AverCert.ExprFragmentAccepted.accepted]\n",
-            "  exact ⟨finalCert, ⟨rfl, ⟨{obligation_proof}, ⟨⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩, ⟨{sym_proof}, ⟨{string_eq_proof}, ⟨{string_proof}, ⟨{construct_proof}, ⟨{recursion_proof}, ⟨⟨{mutual_proof}, rfl⟩, ⟨{verbatim_proof}, ⟨{int_dispatch_proof}, ⟨{field_projection_proof}, {composition_proof}⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩\n"
+            "  exact ⟨finalCert, ⟨rfl, ⟨{obligation_proof}, ⟨⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩, ⟨{sym_proof}, ⟨{string_eq_proof}, ⟨{string_proof}, ⟨{construct_proof}, ⟨{recursion_proof}, ⟨⟨{mutual_proof}, rfl⟩, ⟨{verbatim_proof}, ⟨{int_dispatch_proof}, ⟨{field_projection_proof}, ⟨{composition_proof}, ⟨rfl, rfl, rfl, rfl⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩\n"
         ),
         obligation_proof = claims.obligation_proof,
         sym_proof = claims.sym_proof,
@@ -1594,6 +1611,8 @@ fn render_artifact(
          import Final\n\
          import Manifest\n\
          import Plans\n\n\
+         -- The whole-module big-Nat closure fold is kernel reduction. This\n\
+         -- explicit depth budget affects kernel reduction limits only, not soundness or axioms.\n\
          set_option maxRecDepth 200000\n\
          set_option linter.unusedSimpArgs false\n\n\
          namespace AverCert.Artifact\n\n\
@@ -1608,9 +1627,10 @@ fn render_artifact(
          def fieldProjectionClaims : List AverCert.AcceptedArtifact.FieldProjectionClaim := {field_projection_claims_list}\n\n\
          def compositionMembers : List AverCert.AcceptedArtifact.CompositionMemberClaim := {composition_members_list}\n\n\
          def compositionClaims : List AverCert.AcceptedArtifact.CompositionClaim := {composition_claims_list}\n\n\
+         def closureClaim : AverCert.AcceptedArtifact.ClosureClaim := {closure_claim}\n\n\
          {mutual_scc_closure_pins}\
          def data : AverCert.AcceptedArtifact.ArtifactData :=\n  \
-           ({{ modBytes := AverCert.ArtifactBytes.modBytes, modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest, symFragmentClaims := symFragmentClaims, stringEqClaims := stringEqClaims, stringConcatClaims := stringConcatClaims, constructClaims := constructClaims, recursionClaims := recursionClaims, mutualRecursionClaims := mutualRecursionClaims, verbatimClaims := verbatimClaims, intDispatchClaims := intDispatchClaims, fieldProjectionClaims := fieldProjectionClaims, compositionMembers := compositionMembers, compositionClaims := compositionClaims }} : AverCert.AcceptedArtifact.ArtifactData)\n\n\
+           ({{ modBytes := AverCert.ArtifactBytes.modBytes, modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest, symFragmentClaims := symFragmentClaims, stringEqClaims := stringEqClaims, stringConcatClaims := stringConcatClaims, constructClaims := constructClaims, recursionClaims := recursionClaims, mutualRecursionClaims := mutualRecursionClaims, verbatimClaims := verbatimClaims, intDispatchClaims := intDispatchClaims, fieldProjectionClaims := fieldProjectionClaims, compositionMembers := compositionMembers, compositionClaims := compositionClaims, closureFuel := {closure_fuel}, closureClaim := closureClaim }} : AverCert.AcceptedArtifact.ArtifactData)\n\n\
          def acceptedWithFinal\n\
              (finalCert : AverCert.Schema.Holds AverCert.manifest) :\n\
              AverCert.AcceptedArtifact.accepted data := by\n\
@@ -1629,6 +1649,8 @@ fn render_artifact(
         field_projection_claims_list = claims.field_projection_claims,
         composition_members_list = claims.composition_members,
         composition_claims_list = claims.composition_claims,
+        closure_claim = closure_claim,
+        closure_fuel = analysis.module_envelope.closure_fuel,
         mutual_scc_closure_pins = render_mutual_scc_closure_pins(analysis),
         fragment_proof = fragment_proof
     )

--- a/src/codegen/wasm_gc/effects.rs
+++ b/src/codegen/wasm_gc/effects.rs
@@ -182,6 +182,71 @@ pub(super) enum EffectName {
 }
 
 impl EffectName {
+    const ALL: &[Self] = &[
+        Self::ConsolePrint,
+        Self::ConsoleError,
+        Self::ConsoleWarn,
+        Self::TimeUnixMs,
+        Self::RequestMethod,
+        Self::RequestUrl,
+        Self::RequestQuery,
+        Self::RequestBody,
+        Self::RequestHeadersLoad,
+        Self::ResponseText,
+        Self::ResponseSetHeader,
+        Self::HttpSend,
+        Self::HttpAddRequestHeader,
+        Self::HttpClearRequestHeaders,
+        Self::EnvGet,
+        Self::EnvSet,
+        Self::ConsoleReadLine,
+        Self::ArgsLen,
+        Self::ArgsGet,
+        Self::RandomFloat,
+        Self::RandomInt,
+        Self::TimeSleep,
+        Self::TimeNow,
+        Self::FloatSin,
+        Self::FloatCos,
+        Self::FloatAtan2,
+        Self::FloatPow,
+        Self::TerminalEnableRawMode,
+        Self::TerminalDisableRawMode,
+        Self::TerminalClear,
+        Self::TerminalMoveTo,
+        Self::TerminalPrint,
+        Self::TerminalSetColor,
+        Self::TerminalResetColor,
+        Self::TerminalReadKey,
+        Self::TerminalSize,
+        Self::TerminalHideCursor,
+        Self::TerminalShowCursor,
+        Self::TerminalFlush,
+        Self::DiskReadText,
+        Self::DiskWriteText,
+        Self::DiskAppendText,
+        Self::DiskExists,
+        Self::DiskDelete,
+        Self::DiskDeleteDir,
+        Self::DiskListDir,
+        Self::DiskMakeDir,
+        Self::TcpConnect,
+        Self::TcpWriteLine,
+        Self::TcpReadLine,
+        Self::TcpClose,
+        Self::TcpSend,
+        Self::TcpPing,
+        Self::HttpGet,
+        Self::HttpHead,
+        Self::HttpDelete,
+        Self::HttpPost,
+        Self::HttpPut,
+        Self::HttpPatch,
+        Self::RecordEnterGroup,
+        Self::RecordSetBranch,
+        Self::RecordExitGroup,
+    ];
+
     pub(super) fn from_dotted(s: &str) -> Option<Self> {
         match s {
             "Console.print" => Some(Self::ConsolePrint),
@@ -614,6 +679,17 @@ impl EffectName {
             Self::RecordEnterGroup | Self::RecordSetBranch | Self::RecordExitGroup => Ok(vec![]),
         }
     }
+}
+
+/// The certification capability registry is minted from the same exhaustive
+/// effect-name list and `import_pair` mapping used by wasm-gc emission.  This
+/// keeps certificate interface accounting synchronized with the actual host
+/// import ABI instead of maintaining a second Rust-side registry.
+pub(crate) fn capability_registry() -> Vec<(&'static str, &'static str)> {
+    EffectName::ALL
+        .iter()
+        .map(|effect| effect.import_pair())
+        .collect()
 }
 
 fn result_ref_ty(registry: &TypeRegistry, canonical: &str) -> Result<ValType, WasmGcError> {

--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -57,7 +57,7 @@ use crate::ir::AnalysisResult;
 
 mod body;
 mod builtins;
-mod effects;
+pub(crate) mod effects;
 mod flatten;
 mod lists;
 mod maps;

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -237,6 +237,9 @@ struct Candidates {
     /// binding against the proven manifest; the final byte-binding and report
     /// use the byte-derived list.
     contracts: Vec<String>,
+    declared_uncertified: Vec<(String, String)>,
+    capabilities: Vec<(String, String)>,
+    start: Option<u32>,
     profile: String,
     abi: String,
 }
@@ -340,6 +343,19 @@ fn gate_candidate(kind: &str, s: &str) -> Result<(), String> {
     }
 }
 
+fn exact_object_fields(value: &Value, context: &str, expected: &[&str]) -> Result<(), String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| format!("cert-manifest.json `{context}` is not an object"))?;
+    if object.len() != expected.len() || expected.iter().any(|key| !object.contains_key(*key)) {
+        return Err(format!(
+            "cert-manifest.json `{context}` must contain exactly fields {}",
+            expected.join(", ")
+        ));
+    }
+    Ok(())
+}
+
 /// Pull the report candidates from the untrusted JSON and charset-gate each one
 /// on its decoded value. Nothing here is trusted yet — the witness `rfl`s below
 /// are what bind these to the kernel-proven manifest.
@@ -399,7 +415,7 @@ fn read_candidates(m: &Value) -> Result<Candidates, String> {
                 })?;
                 if kind != "intNatAbs" {
                     return Err(format!(
-                        "cert-manifest.json certified export `{name}` uses unsupported termination measure `{kind}`; schema 48 admits only `intNatAbs`"
+                        "cert-manifest.json certified export `{name}` uses unsupported termination measure `{kind}`; schema 49 admits only `intNatAbs`"
                     ));
                 }
                 let param_idx = measure
@@ -456,11 +472,83 @@ fn read_candidates(m: &Value) -> Result<Candidates, String> {
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    let declared_uncertified = m
+        .get("declaredUncertified")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            "cert-manifest.json is missing array field `declaredUncertified`".to_string()
+        })?
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| {
+            exact_object_fields(
+                entry,
+                &format!("declaredUncertified[{index}]"),
+                &["name", "reason"],
+            )?;
+            let name = entry.get("name").and_then(Value::as_str).ok_or_else(|| {
+                format!("cert-manifest.json `declaredUncertified[{index}].name` is not a string")
+            })?;
+            let reason = entry.get("reason").and_then(Value::as_str).ok_or_else(|| {
+                format!("cert-manifest.json `declaredUncertified[{index}].reason` is not a string")
+            })?;
+            Ok((name.to_string(), reason.to_string()))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let capabilities = m
+        .get("capabilities")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "cert-manifest.json is missing array field `capabilities`".to_string())?
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| {
+            exact_object_fields(
+                entry,
+                &format!("capabilities[{index}]"),
+                &["module", "name"],
+            )?;
+            let module = entry.get("module").and_then(Value::as_str).ok_or_else(|| {
+                format!("cert-manifest.json `capabilities[{index}].module` is not a string")
+            })?;
+            let name = entry.get("name").and_then(Value::as_str).ok_or_else(|| {
+                format!("cert-manifest.json `capabilities[{index}].name` is not a string")
+            })?;
+            Ok((module.to_string(), name.to_string()))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let start_value = m
+        .get("start")
+        .ok_or_else(|| "cert-manifest.json is missing object field `start`".to_string())?;
+    exact_object_fields(start_value, "start", &["present", "function_index"])?;
+    let present = start_value
+        .get("present")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| "cert-manifest.json `start.present` is not a boolean".to_string())?;
+    let start = match (present, start_value.get("function_index")) {
+        (false, Some(Value::Null)) => None,
+        (true, Some(value)) => value
+            .as_u64()
+            .and_then(|index| u32::try_from(index).ok())
+            .map(Some)
+            .ok_or_else(|| {
+                "cert-manifest.json present `start.function_index` is not a u32".to_string()
+            })?,
+        (false, _) => {
+            return Err(
+                "cert-manifest.json absent start must use null `function_index`".to_string(),
+            );
+        }
+        (true, None) => unreachable!("exact_object_fields checked function_index"),
+    };
+
     let cands = Candidates {
         names,
         policies,
         termination_witnesses,
         contracts,
+        declared_uncertified,
+        capabilities,
+        start,
         profile,
         abi,
     };
@@ -469,6 +557,14 @@ fn read_candidates(m: &Value) -> Result<Candidates, String> {
     }
     for c in &cands.contracts {
         gate_candidate("runtime contract", c)?;
+    }
+    for (name, reason) in &cands.declared_uncertified {
+        gate_candidate("declared-uncertified export name", name)?;
+        gate_candidate("declared-uncertified reason", reason)?;
+    }
+    for (module, name) in &cands.capabilities {
+        gate_candidate("capability module", module)?;
+        gate_candidate("capability name", name)?;
     }
     gate_candidate("profile", &cands.profile)?;
     gate_candidate("abi", &cands.abi)?;
@@ -676,6 +772,18 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
     for r in &rederived {
         gate_candidate("re-derived export name", &r.name)?;
     }
+    let certified_bindings = rederived
+        .iter()
+        .map(|obligation| (obligation.name.clone(), obligation.self_idx))
+        .collect::<Vec<_>>();
+    let module_envelope = cert::collect_module_envelope_facts(&bytes, &certified_bindings)?;
+    for export in &module_envelope.exports {
+        gate_candidate("byte-derived module export name", &export.name)?;
+    }
+    for (module, name) in &module_envelope.capabilities {
+        gate_candidate("byte-derived capability module", module)?;
+        gate_candidate("byte-derived capability name", name)?;
+    }
 
     // 3. Assemble a checker-owned build. The audited schema + prelude come from
     //    THIS binary, never from the cert; the cert supplies only per-artifact
@@ -723,6 +831,7 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
         &derived_contracts,
         &host_table_lean,
         &struct_table_lean,
+        &module_envelope,
     );
     std::fs::write(build.path.join("CheckerWitness.lean"), &witness)
         .map_err(|e| format!("cannot write checker witness: {e}"))?;
@@ -1628,6 +1737,15 @@ fn lean_str_list(items: &[String]) -> String {
     let inner = items
         .iter()
         .map(|s| format!("\"{s}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{inner}]")
+}
+
+fn lean_string_pair_list(items: &[(String, String)]) -> String {
+    let inner = items
+        .iter()
+        .map(|(left, right)| format!("(\"{left}\", \"{right}\")"))
         .collect::<Vec<_>>()
         .join(", ");
     format!("[{inner}]")
@@ -2635,7 +2753,14 @@ fn lean_artifact_data_literal(
     field_projection_claims: &str,
     composition_members: &str,
     composition_claims: &str,
+    module_envelope: &cert::ModuleEnvelopeFacts,
 ) -> String {
+    let roots = lean_nat_list(module_envelope.closure.roots.iter().copied());
+    let helpers = lean_nat_list(module_envelope.closure.helpers.iter().copied());
+    let admitted = lean_nat_list(module_envelope.closure.admitted.iter().copied());
+    let closure_claim = format!(
+        "({{ roots := {roots}, helpers := {helpers}, admitted := {admitted} }} : AverCert.AcceptedArtifact.ClosureClaim)"
+    );
     format!(
         "({{ modBytes := AverCert.ArtifactBytes.modBytes, modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest, \
          symFragmentClaims := ({sym_claims} : List AverCert.AcceptedArtifact.SymFragmentClaim), \
@@ -2648,8 +2773,10 @@ fn lean_artifact_data_literal(
          intDispatchClaims := ({int_dispatch_claims} : List AverCert.AcceptedArtifact.IntDispatchClaim), \
          fieldProjectionClaims := ({field_projection_claims} : List AverCert.AcceptedArtifact.FieldProjectionClaim), \
          compositionMembers := ({composition_members} : List AverCert.AcceptedArtifact.CompositionMemberClaim), \
-         compositionClaims := ({composition_claims} : List AverCert.AcceptedArtifact.CompositionClaim) }} : \
-         AverCert.AcceptedArtifact.ArtifactData)"
+         compositionClaims := ({composition_claims} : List AverCert.AcceptedArtifact.CompositionClaim), \
+         closureFuel := {closure_fuel}, closureClaim := {closure_claim} }} : \
+         AverCert.AcceptedArtifact.ArtifactData)",
+        closure_fuel = module_envelope.closure_fuel
     )
 }
 
@@ -2670,6 +2797,7 @@ fn lean_fragment_acceptance_proof_block(
             "{indent}  AverCert.AcceptedArtifact.acceptedIntDispatchFragments,\n",
             "{indent}  AverCert.AcceptedArtifact.acceptedFieldProjectionFragments,\n",
             "{indent}  AverCert.AcceptedArtifact.acceptedCompositionFragments,\n",
+            "{indent}  AverCert.AcceptedArtifact.acceptedWholeModule,\n",
             "{indent}  AverCert.AcceptedArtifact.symFragmentClaimsAccepted,\n",
             "{indent}  AverCert.AcceptedArtifact.symFragmentClaimAccepted,\n",
             "{indent}  AverCert.AcceptedArtifact.symFragmentPlanAccepted,\n",
@@ -2725,7 +2853,7 @@ fn lean_fragment_acceptance_proof_block(
             "{indent}  AverCert.AcceptedArtifact.fieldProjectionPlanAccepted,\n",
             "{indent}  AverCert.AcceptedArtifact.exprFragmentPlanAccepted,\n",
             "{indent}  AverCert.ExprFragmentAccepted.accepted]\n",
-            "{indent}exact ⟨{sym_proof}, ⟨{string_eq_proof}, ⟨{string_proof}, ⟨{construct_proof}, ⟨{recursion_proof}, ⟨⟨{mutual_proof}, rfl⟩, ⟨{verbatim_proof}, ⟨{int_dispatch_proof}, ⟨{field_projection_proof}, {composition_proof}⟩⟩⟩⟩⟩⟩⟩⟩⟩\n"
+            "{indent}exact ⟨{sym_proof}, ⟨{string_eq_proof}, ⟨{string_proof}, ⟨{construct_proof}, ⟨{recursion_proof}, ⟨⟨{mutual_proof}, rfl⟩, ⟨{verbatim_proof}, ⟨{int_dispatch_proof}, ⟨{field_projection_proof}, ⟨{composition_proof}, ⟨rfl, rfl, rfl, rfl⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩\n"
         ),
         indent = indent,
         sym_proof = witness.sym_proof,
@@ -2745,6 +2873,7 @@ fn lean_expr_fragment_obligation_acceptance_pins(
     rederived: &[cert::RederivedObligation],
     host_table_lean: &str,
     struct_table_lean: &str,
+    module_envelope: &cert::ModuleEnvelopeFacts,
 ) -> String {
     let witness = lean_expr_fragment_artifact_claims(rederived, host_table_lean, struct_table_lean);
     let proof_block = lean_fragment_acceptance_proof_block(&witness, "  ");
@@ -2760,6 +2889,7 @@ fn lean_expr_fragment_obligation_acceptance_pins(
         &witness.field_projection_claims,
         &witness.composition_members,
         &witness.composition_claims,
+        module_envelope,
     );
     format!(
         concat!(
@@ -2778,6 +2908,7 @@ fn lean_accepted_artifact_witness(
     rederived: &[cert::RederivedObligation],
     host_table_lean: &str,
     struct_table_lean: &str,
+    module_envelope: &cert::ModuleEnvelopeFacts,
 ) -> String {
     let witness = lean_expr_fragment_artifact_claims(rederived, host_table_lean, struct_table_lean);
     let artifact = lean_artifact_data_literal(
@@ -2792,6 +2923,7 @@ fn lean_accepted_artifact_witness(
         &witness.field_projection_claims,
         &witness.composition_members,
         &witness.composition_claims,
+        module_envelope,
     );
     let checker_proof = format!(
         concat!(
@@ -2837,6 +2969,7 @@ fn lean_accepted_artifact_witness(
             "    AverCert.AcceptedArtifact.acceptedIntDispatchFragments,\n",
             "    AverCert.AcceptedArtifact.acceptedFieldProjectionFragments,\n",
             "    AverCert.AcceptedArtifact.acceptedCompositionFragments,\n",
+            "    AverCert.AcceptedArtifact.acceptedWholeModule,\n",
             "    AverCert.AcceptedArtifact.symFragmentClaimsAccepted,\n",
             "    AverCert.AcceptedArtifact.symFragmentClaimAccepted,\n",
             "    AverCert.AcceptedArtifact.symFragmentPlanAccepted,\n",
@@ -2892,7 +3025,7 @@ fn lean_accepted_artifact_witness(
             "    AverCert.AcceptedArtifact.intDispatchCanonicalSlots,\n",
             "    AverCert.AcceptedArtifact.exprFragmentPlanAccepted,\n",
             "    AverCert.ExprFragmentAccepted.accepted]\n",
-            "  exact ⟨{final_witness}, ⟨rfl, ⟨{obligation_proof}, ⟨⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩, ⟨{sym_proof}, ⟨{string_eq_proof}, ⟨{string_proof}, ⟨{construct_proof}, ⟨{recursion_proof}, ⟨⟨{mutual_proof}, rfl⟩, ⟨{verbatim_proof}, ⟨{int_dispatch_proof}, ⟨{field_projection_proof}, {composition_proof}⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩\n"
+            "  exact ⟨{final_witness}, ⟨rfl, ⟨{obligation_proof}, ⟨⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩, ⟨{sym_proof}, ⟨{string_eq_proof}, ⟨{string_proof}, ⟨{construct_proof}, ⟨{recursion_proof}, ⟨⟨{mutual_proof}, rfl⟩, ⟨{verbatim_proof}, ⟨{int_dispatch_proof}, ⟨{field_projection_proof}, ⟨{composition_proof}, ⟨rfl, rfl, rfl, rfl⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩⟩\n"
         ),
         final_witness = FINAL_WITNESS_THEOREM,
         obligation_proof = witness.obligation_proof,
@@ -2942,6 +3075,7 @@ fn checker_witness(
     derived_contracts: &[String],
     host_table_lean: &str,
     struct_table_lean: &str,
+    module_envelope: &cert::ModuleEnvelopeFacts,
 ) -> String {
     // Count is the JSON-claimed number of certified exports, verified by `rfl`
     // against `obligations.length` (so a JSON claiming more or fewer than the
@@ -2954,6 +3088,27 @@ fn checker_witness(
     let names = lean_str_list(&rederived_names);
     let json_contracts = lean_str_list(&cands.contracts);
     let byte_contracts = lean_str_list(derived_contracts);
+    let json_declared_uncertified = lean_string_pair_list(&cands.declared_uncertified);
+    let certified_name_set = rederived_names
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    let byte_declared_names = module_envelope
+        .exports
+        .iter()
+        .filter(|export| !certified_name_set.contains(&export.name))
+        .map(|export| export.name.clone())
+        .collect::<Vec<_>>();
+    let byte_declared_names = lean_str_list(&byte_declared_names);
+    let json_capabilities = lean_string_pair_list(&cands.capabilities);
+    let byte_capabilities = lean_string_pair_list(&module_envelope.capabilities);
+    let json_start = cands
+        .start
+        .map(|index| format!("some {index}"))
+        .unwrap_or_else(|| "none".to_string());
+    let byte_start = module_envelope
+        .start
+        .map(|index| format!("some {index}"))
+        .unwrap_or_else(|| "none".to_string());
     let profile = &cands.profile;
     let abi = &cands.abi;
     let artifact_root = cert::ARTIFACT_CERTIFICATE_ROOT;
@@ -3021,9 +3176,14 @@ fn checker_witness(
         rederived,
         host_table_lean,
         struct_table_lean,
+        module_envelope,
     );
-    let accepted_artifact_witness =
-        lean_accepted_artifact_witness(rederived, host_table_lean, struct_table_lean);
+    let accepted_artifact_witness = lean_accepted_artifact_witness(
+        rederived,
+        host_table_lean,
+        struct_table_lean,
+        module_envelope,
+    );
     // Semantic-face bindings: pin each obligation's typed `Dom`/`Cod`/`domRepr`/
     // `codRepr` to the STANDARD form its BYTE-derived class implies, and prove
     // every domain is inhabited. These are the faces the schema-v3 checker did
@@ -3052,6 +3212,8 @@ fn checker_witness(
          import Final\n\
          import Artifact\n\
          open CertPrelude AverCert.Schema\n\
+         -- Whole-module closure checking reduces the embedded big-Nat bytes.\n\
+         -- This explicit depth budget changes only kernel reduction limits.\n\
          set_option maxRecDepth 200000\n\
          set_option linter.unusedSimpArgs false\n\
          set_option linter.unusedVariables false\n\n\
@@ -3064,6 +3226,16 @@ fn checker_witness(
          -- byte-bound body cannot be relabelled under a different export name.\n\
          example : AverCert.manifest.obligations.map (fun o => o.export_) = {names} := rfl\n\
          example : AverCert.manifest.subject.exports = {names} := rfl\n\
+         -- Whole-module interface declarations: JSON is pinned to the Lean\n\
+         -- manifest, while names/import pairs/start status are independently\n\
+         -- re-derived from the exact artifact bytes. Reasons are display-only;\n\
+         -- the security-relevant uncertified name set is byte-bound below.\n\
+         example : AverCert.manifest.subject.declaredUncertified = {json_declared_uncertified} := rfl\n\
+         example : AverCert.manifest.subject.declaredUncertified.map (fun entry => entry.1) = {byte_declared_names} := rfl\n\
+         example : AverCert.manifest.subject.capabilities = {json_capabilities} := rfl\n\
+         example : AverCert.manifest.subject.capabilities = {byte_capabilities} := rfl\n\
+         example : AverCert.manifest.subject.start = {json_start} := rfl\n\
+         example : AverCert.manifest.subject.start = {byte_start} := rfl\n\
          -- Contracts: the JSON candidate must match the proven manifest, and\n\
          -- the proven manifest must also match the BYTE-DERIVED contract list.\n\
          -- JSON-only padding and manifest+JSON deletion are therefore both\n\

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -124,6 +124,34 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
         Some(aver::codegen::cert::ARTIFACT_CERTIFICATE_ROOT),
         "manifest should expose the artifact-level certificate root"
     );
+    assert_eq!(
+        manifest["schema_version"].as_u64(),
+        Some(u64::from(aver::codegen::cert::CERT_SCHEMA_VERSION))
+    );
+    let declared_uncertified = manifest["declaredUncertified"].as_array().unwrap();
+    assert_eq!(
+        declared_uncertified.len(),
+        13,
+        "all 36 module exports must be certified or explicitly declared"
+    );
+    assert!(declared_uncertified.iter().all(|entry| {
+        entry.as_object().is_some_and(|object| {
+            object.len() == 2
+                && object
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some()
+                && object
+                    .get("reason")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some()
+        })
+    }));
+    assert_eq!(manifest["capabilities"], serde_json::json!([]));
+    assert_eq!(
+        manifest["start"],
+        serde_json::json!({"present": false, "function_index": null})
+    );
 
     let actual: BTreeMap<String, String> = manifest["certified"]
         .as_array()

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -3334,7 +3334,9 @@ example : ∀ nameBytes,
 
 example : ¬ AcceptedArtifact.accepted unclaimedArtifact := by
   intro h
-  rcases h with ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hclaimed, _⟩
+  rcases h with ⟨_, _, _, _, hfragments⟩
+  rcases hfragments with ⟨_, _, _, _, _, _, _, _, _, hcomposition, _⟩
+  have hclaimed := hcomposition.2.2.1
   change false = true at hclaimed
   contradiction
 
@@ -3342,7 +3344,8 @@ example : acceptedWithoutClaimCoverage unclaimedArtifact := by
   rcases Artifact.certificate with
     ⟨_, hsubject, hobs, hmatch, hsym, hstringEq, hstringConcat, hconstruct,
       hrecursion, hmutual, hverbatim, hintDispatch, hfieldProjection,
-      hcomposition, hmembersCovered, _, _⟩
+      hcompositionAccepted, _⟩
+  rcases hcompositionAccepted with ⟨hcomposition, hmembersCovered, _, _⟩
   refine ⟨unclaimedFinal, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · exact hsubject
   · simpa [unclaimedArtifact, unclaimedManifest,
@@ -3463,7 +3466,9 @@ example : ∀ nameBytes,
 
 example : ¬ AcceptedArtifact.accepted duplicateArtifact := by
   intro h
-  rcases h with ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hunique⟩
+  rcases h with ⟨_, _, _, _, hfragments⟩
+  rcases hfragments with ⟨_, _, _, _, _, _, _, _, _, hcomposition, _⟩
+  have hunique := hcomposition.2.2.2
   change false = true at hunique
   contradiction
 
@@ -3471,7 +3476,8 @@ example : acceptedWithoutUniqueExports duplicateArtifact := by
   rcases Artifact.certificate with
     ⟨_, hsubject, hobs, hmatch, hsym, hstringEq, hstringConcat, hconstruct,
       hrecursion, hmutual, hverbatim, hintDispatch, hfieldProjection,
-      hcomposition, hmembersCovered, _, _⟩
+      hcompositionAccepted, _⟩
+  rcases hcompositionAccepted with ⟨hcomposition, hmembersCovered, _, _⟩
   refine ⟨duplicateFinal, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · exact hsubject
   · simpa [duplicateArtifact, duplicateManifest,

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -1781,6 +1781,7 @@ fn cert_verify_declines_tampered_expr_fragment_sidecar() {
         out.contains("fragmentClaimObligationsInManifest")
             || out.contains("manifest.obligations).contains")
             || out.contains("closureIsolation")
+            || out.contains("closureClaim")
             || out.contains("AverCert.Artifact.certificate")
             || out.contains("Artifact.lean"),
         "wrong reason for missing manifest obligation:\n{out}"

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -1780,6 +1780,7 @@ fn cert_verify_declines_tampered_expr_fragment_sidecar() {
     assert!(
         out.contains("fragmentClaimObligationsInManifest")
             || out.contains("manifest.obligations).contains")
+            || out.contains("closureIsolation")
             || out.contains("AverCert.Artifact.certificate")
             || out.contains("Artifact.lean"),
         "wrong reason for missing manifest obligation:\n{out}"
@@ -4744,7 +4745,7 @@ fn mutual_scc_kernel_guards_are_isolating() {
     lean.push_str("example : mutualMembersFormClosedSccs [(1, 2, [1, 2, 3, 4]), (2, 1, [1, 2, 3, 4]), (3, 4, [1, 2, 3, 4]), (4, 3, [1, 2, 3, 4])] = false := rfl\n\n");
     // FIX B: the REAL acceptance conjunct rejects a dangling group; shape passes.
     lean.push_str("def dummyOb (nm : String) (s : Nat) : Obligation :=\n  { export_ := nm, policy := .simulatesModel, carrier := 2, code := fun _ => none,\n    host := fun _ _ _ _ _ => fun _ => none, self := s, Dom := Unit, Cod := Unit,\n    domRepr := fun _ _ _ => True, codRepr := fun _ _ _ => True, model := fun _ => () }\n\n");
-    lean.push_str("def manifestS : Manifest :=\n  { subject := { artifactHash := \"\", profile := \"\", abi := \"\", artifactRoot := \"\", exports := [], contracts := [] },\n    symFragmentPlans := [], stringEqPlans := [], stringConcatPlans := [], constructPlans := [],\n    exprFragmentPlans := [], recursionPlans := [], mutualPlans := [(\"a\", honestPlan)], compositionPlans := [], verbatimPlans := [], intDispatchPlans := [], fieldProjectionPlans := [], obligations := [] }\n\n");
+    lean.push_str("def manifestS : Manifest :=\n  { subject := { artifactHash := \"\", profile := \"\", abi := \"\", artifactRoot := \"\", exports := [], declaredUncertified := [], capabilities := [], start := none, contracts := [] },\n    symFragmentPlans := [], stringEqPlans := [], stringConcatPlans := [], constructPlans := [],\n    exprFragmentPlans := [], recursionPlans := [], mutualPlans := [(\"a\", honestPlan)], compositionPlans := [], verbatimPlans := [], intDispatchPlans := [], fieldProjectionPlans := [], obligations := [] }\n\n");
     lean.push_str("def claimsS : List MutualRecursionClaim :=\n  [ { exportNameBytes := [], exportName := \"a\", carrier := 2, memberSet := [1, 2],\n      hostTable := [(.box, 7), (.sub, 9)], obligation := dummyOb \"a\" 1 } ]\n\n");
     lean.push_str("example : AverCert.PlanCheck.checkMutualPlanShape [1, 2] [(.box, 7), (.sub, 9)] honestPlan = true := rfl\n");
     lean.push_str("example : mutualClaimEdges manifestS claimsS = some [(1, 2, [1, 2])] := rfl\n");

--- a/tests/cert_whole_module_guard_iso.rs
+++ b/tests/cert_whole_module_guard_iso.rs
@@ -1,0 +1,327 @@
+#![cfg(feature = "wasm")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    dir.push(format!("aver-{prefix}-{nanos}"));
+    dir
+}
+
+fn aver_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver"));
+    command.env(
+        "AVER_CERT_PRELUDE_CACHE",
+        std::env::temp_dir().join("aver-cert-prelude-store"),
+    );
+    command
+}
+
+fn assert_manifest_decode_declines(wasm: &std::path::Path, cert: &std::path::Path, expected: &str) {
+    let output = aver_command()
+        .arg("cert")
+        .arg("verify")
+        .arg(wasm)
+        .arg(cert)
+        .output()
+        .expect("run verifier for strict manifest decode");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !output.status.success(),
+        "malformed manifest verified:\n{combined}"
+    );
+    assert!(
+        combined.contains(expected),
+        "wrong strict-decode error, expected `{expected}`:\n{combined}"
+    );
+}
+
+fn section_offset_after_export(bytes: &[u8]) -> usize {
+    fn read_uleb(bytes: &[u8], cursor: &mut usize) -> usize {
+        let mut value = 0usize;
+        let mut shift = 0usize;
+        loop {
+            let byte = bytes[*cursor];
+            *cursor += 1;
+            value |= usize::from(byte & 0x7f) << shift;
+            if byte & 0x80 == 0 {
+                return value;
+            }
+            shift += 7;
+        }
+    }
+
+    let mut cursor = 8usize;
+    while cursor < bytes.len() {
+        let id = bytes[cursor];
+        cursor += 1;
+        let size = read_uleb(bytes, &mut cursor);
+        cursor += size;
+        if id == 7 {
+            return cursor;
+        }
+    }
+    panic!("compiler-produced module has no export section")
+}
+
+fn certified_opcode_offsets(bytes: &[u8]) -> (usize, u32, usize) {
+    let mut imported_funcs = 0u32;
+    let mut json_int = None;
+    let mut json_entry_key = None;
+    let mut code_ordinal = 0u32;
+    let mut call = None;
+    let mut local_get = None;
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        match payload.expect("compiler-produced json wasm must parse") {
+            wasmparser::Payload::ImportSection(reader) => {
+                for group in reader {
+                    for import in group.expect("import group must parse") {
+                        let (_, import) = import.expect("import must parse");
+                        if matches!(import.ty, wasmparser::TypeRef::Func(_)) {
+                            imported_funcs += 1;
+                        }
+                    }
+                }
+            }
+            wasmparser::Payload::ExportSection(reader) => {
+                for export in reader {
+                    let export = export.expect("export must parse");
+                    if export.kind != wasmparser::ExternalKind::Func {
+                        continue;
+                    }
+                    match export.name {
+                        "jsonInt" => json_int = Some(export.index),
+                        "jsonEntryKey" => json_entry_key = Some(export.index),
+                        _ => {}
+                    }
+                }
+            }
+            wasmparser::Payload::CodeSectionEntry(body) => {
+                let func_idx = imported_funcs + code_ordinal;
+                if Some(func_idx) == json_int || Some(func_idx) == json_entry_key {
+                    let mut operators = body.get_operators_reader().unwrap();
+                    while !operators.eof() {
+                        let opcode_offset = operators.original_position();
+                        match operators.read().expect("operator must parse") {
+                            wasmparser::Operator::Call { function_index }
+                                if Some(func_idx) == json_int && call.is_none() =>
+                            {
+                                call = Some((opcode_offset + 1, function_index));
+                            }
+                            wasmparser::Operator::LocalGet { .. }
+                                if Some(func_idx) == json_entry_key && local_get.is_none() =>
+                            {
+                                local_get = Some(opcode_offset);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                code_ordinal += 1;
+            }
+            _ => {}
+        }
+    }
+    let (call_offset, call_target) = call.expect("jsonInt must directly call its box helper");
+    assert!(call_target < 127, "GuardIso uses a one-byte call target");
+    let local_get_offset = local_get.expect("jsonEntryKey must contain local.get");
+    assert_eq!(bytes[local_get_offset], 0x20);
+    (call_offset, call_target, local_get_offset)
+}
+
+/// Five hostile artifacts leave all sibling conjuncts true, fail exactly their
+/// named whole-module guard, and pass the literal one-conjunct-weakened copy.
+#[test]
+fn whole_module_guards_are_isolated_and_weaken_confirmed() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping whole-module GuardIso test: `lake` not available");
+        return;
+    }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("cert-whole-module-guard-iso");
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("examples/data/json.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("compile json fixture for whole-module GuardIso");
+    assert!(
+        compile.status.success(),
+        "json compile failed for whole-module GuardIso:\n{}{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let cert = out_dir.join("cert");
+    let build = Command::new("lake")
+        .current_dir(&cert)
+        .arg("build")
+        .output()
+        .expect("build json certificate before whole-module GuardIso");
+    assert!(
+        build.status.success(),
+        "json certificate failed before whole-module GuardIso:\n{}{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    // The three new JSON fields are required and their nested objects have an
+    // exact shape; malformed candidates decline before any Lean build.
+    let manifest_path = cert.join("cert-manifest.json");
+    let honest_manifest: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+    let wasm_path = out_dir.join("json.wasm");
+    let mut malformed = honest_manifest.clone();
+    malformed
+        .as_object_mut()
+        .unwrap()
+        .remove("declaredUncertified");
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&malformed).unwrap(),
+    )
+    .unwrap();
+    assert_manifest_decode_declines(
+        &wasm_path,
+        &cert,
+        "missing array field `declaredUncertified`",
+    );
+
+    let mut malformed = honest_manifest.clone();
+    malformed["capabilities"][0]["extra"] = serde_json::json!(true);
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&malformed).unwrap(),
+    )
+    .unwrap();
+    assert_manifest_decode_declines(
+        &wasm_path,
+        &cert,
+        "must contain exactly fields module, name",
+    );
+
+    let mut malformed = honest_manifest.clone();
+    malformed["start"]["function_index"] = serde_json::json!(0);
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&malformed).unwrap(),
+    )
+    .unwrap();
+    assert_manifest_decode_declines(&wasm_path, &cert, "absent start must use null");
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&honest_manifest).unwrap(),
+    )
+    .unwrap();
+
+    let wasm = std::fs::read(&wasm_path).unwrap();
+    let start_insert_offset = section_offset_after_export(&wasm);
+    let (call_offset, call_target, local_get_offset) = certified_opcode_offsets(&wasm);
+    let capability_offset = wasm
+        .windows(b"console_print".len())
+        .position(|window| window == b"console_print")
+        .expect("json wasm must import aver.console_print");
+    assert_eq!(wasm[capability_offset], b'c');
+    assert_eq!(wasm[call_offset], call_target as u8);
+    let lean = format!(
+        r#"import Artifact
+
+open CertPrelude AverCert AverCert.Schema
+set_option maxRecDepth 300000
+
+def withoutExports (artifact : AcceptedArtifact.ArtifactData) : Prop :=
+  AcceptedArtifact.importsWithinCapabilities artifact = true ∧
+  AcceptedArtifact.startAccounted artifact = true ∧
+  AcceptedArtifact.closureIsolation artifact = true
+def withoutCapabilities (artifact : AcceptedArtifact.ArtifactData) : Prop :=
+  AcceptedArtifact.exportsAccounted artifact = true ∧
+  AcceptedArtifact.startAccounted artifact = true ∧
+  AcceptedArtifact.closureIsolation artifact = true
+def withoutStart (artifact : AcceptedArtifact.ArtifactData) : Prop :=
+  AcceptedArtifact.exportsAccounted artifact = true ∧
+  AcceptedArtifact.importsWithinCapabilities artifact = true ∧
+  AcceptedArtifact.closureIsolation artifact = true
+def withoutClosure (artifact : AcceptedArtifact.ArtifactData) : Prop :=
+  AcceptedArtifact.exportsAccounted artifact = true ∧
+  AcceptedArtifact.importsWithinCapabilities artifact = true ∧
+  AcceptedArtifact.startAccounted artifact = true
+
+-- (a) Existing byte-derived export removed only from the declaration.
+def missingExportManifest : Manifest :=
+  {{ manifest with subject :=
+      {{ manifest.subject with
+         declaredUncertified := manifest.subject.declaredUncertified.tail }} }}
+def missingExportArtifact : AcceptedArtifact.ArtifactData :=
+  {{ Artifact.data with manifest := missingExportManifest }}
+example : AcceptedArtifact.exportsAccounted missingExportArtifact = false := rfl
+example : withoutExports missingExportArtifact := ⟨rfl, rfl, rfl⟩
+
+-- (b) Actual console import is outside the declared capability set.
+def unknownCapabilityManifest : Manifest :=
+  {{ manifest with subject :=
+      {{ manifest.subject with capabilities := [("aver", "xonsole_print")] }} }}
+def unknownCapabilityBytes : Nat := ArtifactBytes.modBytes +
+  (21 <<< (8 * {capability_offset}))
+def unknownCapabilityArtifact : AcceptedArtifact.ArtifactData :=
+  {{ Artifact.data with manifest := unknownCapabilityManifest, modBytes := unknownCapabilityBytes }}
+example : CAPABILITY_REGISTRY.contains ("aver", "xonsole_print") = false := rfl
+example : AcceptedArtifact.importsWithinCapabilities unknownCapabilityArtifact = false := rfl
+example : withoutCapabilities unknownCapabilityArtifact := ⟨rfl, rfl, rfl⟩
+
+-- (c) Insert `start 0` after exports while the manifest declares absent.
+def startSectionBytes : Nat :=
+  (ArtifactBytes.modBytes &&& ((1 <<< (8 * {start_insert_offset})) - 1)) +
+  (0x0108 <<< (8 * {start_insert_offset})) +
+  ((ArtifactBytes.modBytes >>> (8 * {start_insert_offset})) <<<
+    (8 * ({start_insert_offset} + 3)))
+def undeclaredStartArtifact : AcceptedArtifact.ArtifactData :=
+  {{ Artifact.data with modBytes := startSectionBytes, modLen := ArtifactBytes.modLen + 3 }}
+example : AcceptedArtifact.startAccounted undeclaredStartArtifact = false := rfl
+example : withoutStart undeclaredStartArtifact := ⟨rfl, rfl, rfl⟩
+
+-- (d) Spike negative control: jsonInt's call leaves the admitted closure.
+def escapedCallBytes : Nat := ArtifactBytes.modBytes +
+  (1 <<< (8 * {call_offset}))
+def escapedCallArtifact : AcceptedArtifact.ArtifactData :=
+  {{ Artifact.data with modBytes := escapedCallBytes }}
+example : AcceptedArtifact.closureIsolation escapedCallArtifact = false := rfl
+example : withoutClosure escapedCallArtifact := ⟨rfl, rfl, rfl⟩
+
+-- (e) `local.get` (0x20) -> `global.get` (0x23) in a certified root.
+def globalReadBytes : Nat := ArtifactBytes.modBytes +
+  (3 <<< (8 * {local_get_offset}))
+def globalReadArtifact : AcceptedArtifact.ArtifactData :=
+  {{ Artifact.data with modBytes := globalReadBytes }}
+example : AcceptedArtifact.closureIsolation globalReadArtifact = false := rfl
+example : withoutClosure globalReadArtifact := ⟨rfl, rfl, rfl⟩
+"#
+    );
+    std::fs::write(cert.join("GuardIso.lean"), lean).unwrap();
+    let check = Command::new("lake")
+        .current_dir(&cert)
+        .arg("env")
+        .arg("lean")
+        .arg("GuardIso.lean")
+        .output()
+        .expect("run whole-module GuardIso");
+    assert!(
+        check.status.success(),
+        "whole-module GuardIso failed:\n{}{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+    let _ = std::fs::remove_dir_all(out_dir);
+}


### PR DESCRIPTION
## Summary
- Adds four artifact-wide kernel conjuncts: export accounting (every module export is a claimed obligation or explicitly `declaredUncertified`), capability accounting (every import appears in the manifest capability list, bound to a kernel registry minted from the effect registry), byte-derived start-section declaration, and certified-closure isolation — the transitive direct-call closure of all certified exports, recomputed in-kernel from the module bytes with helper control flow walked, may contain only certified-or-helper functions and no `call_indirect`, global/table access, linear-memory access, atomics, segment drops, or reachable imports. Shared-memory declarations are rejected as a hidden channel.
- The closure claim carries no free data: roots equal the byte-pinned obligation function indices, the admitted set is exactly roots plus helpers (nodup, set-equal), and the fold fail-closes on any rejected opcode. Closures fold as one union over all roots, scanning shared helpers once.
- The json example now ships a fully accounted interface: 12 certified, 85 declared-uncertified exports, the `aver.console_print` capability, start absent — and stays CERTIFIED end to end, as do cert_goals (23) and mutual (2, total level).
- Guard isolation per conjunct with one-conjunct-weakened copies: undeclared export, unknown import, undeclared start, a call-target escaping the closure, and a global read smuggled into a certified body each fail exactly at their conjunct. Strict manifest decoding rejects missing/extra/inconsistent fields.
- Docs gain a whole-module coverage section stating what is accounted and what is not claimed (behavior of declared-uncertified exports). Certificate schema bumps to 49.

## Cost note
End-to-end json verify rises from ~40s to ~71s — the whole-module closure recomputation over 196 functions is the added kernel work. Within the sharded CI budget.

## Testing
- fmt, clippy (wasm,wasip2), lib (1022), cert_certify_spec (11), cert_decode_spec (2)
- New whole-module guard-isolation suite + all existing manifest/termination/parser guards
- End-to-end certify+verify: json, cert_goals, mutual — all CERTIFIED

🤖 Generated with [Claude Code](https://claude.com/claude-code)