### PR TITLE
Verify on a fast witness path with a per-artifact build cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,9 @@ use clap::Parser as ClapParser;
 #[cfg(feature = "wasm-compile")]
 #[path = "main/cert_cmd.rs"]
 mod cert_cmd;
+#[cfg(feature = "wasm-compile")]
+#[path = "main/cert_data_cache.rs"]
+mod cert_data_cache;
 #[path = "main/cli.rs"]
 mod cli;
 #[path = "main/commands.rs"]

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -965,10 +965,12 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
                     .to_string(),
             );
         }
+        // The data project itself failed to build, so the diagnostic witness
+        // cannot even import its modules — the real reason lives in the BUILD
+        // output, which is what the decline must carry.
         return Err(format!(
-            "certificate did not build (lake build failed); the diagnostic checker witness \
-             also declined:\n{}",
-            tail(&diagnostic.combined, 30)
+            "certificate did not build (lake build failed):\n{}",
+            tail(&b.combined, 30)
         ));
     }
     artifact_cache.publish(&build.path);

--- a/src/main/cert_cmd.rs
+++ b/src/main/cert_cmd.rs
@@ -9,9 +9,10 @@
 //! `AcceptedArtifactCore.lean` / `AcceptedArtifact.lean` / `CertPrelude.lean`
 //! this binary embeds, regenerates
 //! `ArtifactBytes.lean` from the artifact bytes it read, copies the cert's
-//! DATA-only Lean files, authors its own `lakefile.lean`, and builds with a
-//! clean cache. It then writes a `CheckerWitness.lean` — which the checker, not
-//! the cert, authors — that:
+//! DATA-only Lean files, and authors its own `lakefile.lean`. Artifact-specific
+//! Lake outputs may come from the content-addressed user cache, but sources are
+//! always staged afresh and `lake build` still runs. It then writes a
+//! `CheckerWitness.lean` — which the checker, not the cert, authors — that:
 //!   * binds the sha256 the checker computed from the artifact bytes to the
 //!     hashes the kernel-checked theorems talk about (`rfl`);
 //!   * binds the certified-export names, contracts, profile and ABI the
@@ -86,6 +87,8 @@ use colored::Colorize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use crate::cert_data_cache::{ArtifactBuildCache, KeyMaterial as ArtifactCacheKeyMaterial};
+
 /// Kernel axioms a certificate is allowed to depend on. Anything else — most
 /// importantly `sorryAx` (an admitted goal) or `ofReduceBool` (native-code
 /// trust) — fails the check. Spliced into the witness as `Name` literals and
@@ -97,6 +100,15 @@ const AXIOM_WHITELIST: [&str; 3] = ["propext", "Classical.choice", "Quot.sound"]
 /// artifact-carried acceptance root used for the axiom audit.
 const FINAL_WITNESS_THEOREM: &str = "AverCertChecker.final";
 const WITNESS_THEOREM: &str = "AverCertChecker.accepted";
+
+/// The normal verifier authors only the trust-bearing witness. If that witness
+/// declines, verification automatically authors the diagnostic superset, whose
+/// two expensive mirror proofs localize the failing accepted-artifact conjunct.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WitnessMode {
+    Fast,
+    Diagnostic,
+}
 
 /// Lean source files the checker owns and never copies from the cert: the
 /// audited trusted computing base (taken from this binary) plus the checker's
@@ -877,38 +889,97 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
     //    / srcDir / `.lake` cache are never read.
     let build = assemble_build(cert_dir, &bytes)?;
 
-    // Test harness opt-in only. Production verification remains a fresh build
-    // with no `.lake`; cache failures silently retain that clean-cache path.
-    reuse_prebuilt_prelude(&build.path);
+    // The artifact DATA cache is content-addressed by the complete manifest hash
+    // wall, schema version, toolchain, and exact staged build sources. It stores
+    // only Lake outputs. A hit is therefore a build hint, never a verdict: Lake
+    // still checks the freshly staged source dependency traces, and the checker
+    // re-authors/runs the witness (including the Artifact.data rfl pin,
+    // Artifact.certificate type ascription, and axiom audit) below. Accidental
+    // stale or poisoned output either fails integrity, makes Lake rebuild/fail,
+    // or makes that fresh witness fail; none of those paths can report certified.
+    let cache_pins = [
+        ("wasm_sha256", pinned),
+        ("schema_sha256", schema_pin),
+        ("schema_core_sha256", schema_core_pin),
+        ("prelude_sha256", prelude_pin),
+        ("cert_decode_sha256", decode_pin),
+        ("plan_check_sha256", plan_check_pin),
+        ("plan_lower_sha256", plan_lower_pin),
+        ("plan_bytes_sha256", plan_bytes_pin),
+        ("wasm_slice_sha256", wasm_slice_pin),
+        ("expr_fragment_accepted_sha256", expr_fragment_accepted_pin),
+        ("accepted_artifact_sha256", accepted_artifact_pin),
+        ("accepted_artifact_core_sha256", accepted_artifact_core_pin),
+    ];
+    let mut artifact_cache = ArtifactBuildCache::prepare(
+        &build.path,
+        &ArtifactCacheKeyMaterial {
+            schema_version,
+            pinned_sha256: &cache_pins,
+            toolchain_version: cert::LEAN_TOOLCHAIN.trim(),
+        },
+    );
 
-    // 4. The assembled project must build under the pinned toolchain, from a
-    //    clean cache (the fresh dir has no `.lake`).
-    let b = run_lake(&build.path, &["build"])?;
+    // A whole DATA-cache hit already contains the pristine prelude. On a miss,
+    // retain the existing env-gated prelude seed before building the DATA roots.
+    if !artifact_cache.was_hit() {
+        reuse_prebuilt_prelude(&build.path);
+    }
+
+    // Byte-derived inputs used by both witness variants. They are computed
+    // before Lake so even a build decline can be followed by the required
+    // diagnostic-witness attempt.
+    let host_table_lean = cert::byte_derived_frag_host_table_lean(&bytes)?;
+    let struct_table_lean = cert::frag_struct_table_lean_from_entries(
+        rederived
+            .iter()
+            .flat_map(|r| r.fragment_struct_entries.iter()),
+    )?;
+
+    // 4. The assembled project must build under the pinned toolchain. If a
+    //    validated cache entry nevertheless breaks Lake, discard it and retry
+    //    once from freshly staged sources (optionally with only the pristine
+    //    prelude seed). The clean retry is authoritative.
+    let mut b = run_lake(&build.path, &["build"])?;
+    if !b.status.success() && artifact_cache.was_hit() {
+        artifact_cache.invalidate(&build.path);
+        reuse_prebuilt_prelude(&build.path);
+        b = run_lake(&build.path, &["build"])?;
+    }
     if !b.status.success() {
+        let diagnostic = author_and_run_checker_witness(
+            &build.path,
+            &actual,
+            &cands,
+            &rederived,
+            &derived_contracts,
+            &host_table_lean,
+            &struct_table_lean,
+            &module_envelope,
+            WitnessMode::Diagnostic,
+        )?;
+        if diagnostic.status.success() {
+            return Err(
+                "internal verifier error: lake build failed but the diagnostic checker witness \
+                 succeeded; verification failed closed"
+                    .to_string(),
+            );
+        }
         return Err(format!(
-            "certificate did not build (lake build failed):\n{}",
-            tail(&b.combined, 20)
+            "certificate did not build (lake build failed); the diagnostic checker witness \
+             also declined:\n{}",
+            tail(&diagnostic.combined, 30)
         ));
     }
+    artifact_cache.publish(&build.path);
 
     // 5. Kernel witness authored BY THE CHECKER (never shipped in the cert):
     //    the sha binding, the report-candidate bindings, the artifact-decode /
     //    checked-plan bindings (kernel-decoded non-expression code/carrier/struct,
     //    canonical expression plans, and Rust-derived host/self), the final-theorem type
     //    ascription, and the axiom-whitelist check (see `checker_witness`).
-    // Byte-derived host-role table: source-plan encoding in the witness and
-    // artifact claims always runs against these indices, never plan-supplied
-    // ones.
-    let host_table_lean = cert::byte_derived_frag_host_table_lean(&bytes)?;
-    // Byte-derived struct table: the consistent union of every checked
-    // projection sidecar's per-export entries (each pinned by canonical
-    // code-entry byte equality against this module's bytes).
-    let struct_table_lean = cert::frag_struct_table_lean_from_entries(
-        rederived
-            .iter()
-            .flat_map(|r| r.fragment_struct_entries.iter()),
-    )?;
-    let witness = checker_witness(
+    let w = author_and_run_checker_witness(
+        &build.path,
         &actual,
         &cands,
         &rederived,
@@ -916,24 +987,46 @@ fn trusted_check(artifact: &Path, cert_dir: &Path) -> Result<TrustedReport, Stri
         &host_table_lean,
         &struct_table_lean,
         &module_envelope,
-    );
-    std::fs::write(build.path.join("CheckerWitness.lean"), &witness)
-        .map_err(|e| format!("cannot write checker witness: {e}"))?;
-    let w = run_lake(&build.path, &["env", "lean", "CheckerWitness.lean"])?;
+        WitnessMode::Fast,
+    )?;
     if !w.status.success() {
+        // The fast witness deliberately omits two redundant but useful mirror
+        // proofs. Re-author the diagnostic superset on every decline so callers
+        // retain the existing per-conjunct Lean errors. The diagnostic result is
+        // never allowed to upgrade the verdict: if the superset unexpectedly
+        // succeeds after the fast witness failed, the checker reports an internal
+        // inconsistency and fails closed.
+        let diagnostic = author_and_run_checker_witness(
+            &build.path,
+            &actual,
+            &cands,
+            &rederived,
+            &derived_contracts,
+            &host_table_lean,
+            &struct_table_lean,
+            &module_envelope,
+            WitnessMode::Diagnostic,
+        )?;
+        if diagnostic.status.success() {
+            return Err(
+                "internal verifier error: the fast checker witness failed but its diagnostic \
+                 superset succeeded; verification failed closed"
+                    .to_string(),
+            );
+        }
         // The verdict is this exit code, not any parsed line. The lake output is
         // shown to the human to name which face failed (hash, a report binding,
         // an artifact-decode / checked-plan binding, the `Holds manifest` type,
         // or a non-whitelisted axiom).
         return Err(format!(
-            "certificate does not bind to this artifact: the checker's kernel witness \
+            "certificate does not bind to this artifact: the checker's diagnostic kernel witness \
              (hash binding, certified-export/contract/profile/abi bindings against the \
              proven manifest, the artifact-root binding, the artifact-decode / checked-plan bindings for \
              kernel-decoded code/carrier/struct facts plus pinned host/self, the semantic-face \
              bindings that pin each obligation's Dom/Cod/domRepr/codRepr to the standard \
              form of its class and prove every domain is inhabited, the final-theorem type \
              `Holds manifest`, and the axiom whitelist) did not check:\n{}",
-            tail(&w.combined, 30)
+            tail(&diagnostic.combined, 30)
         ));
     }
 
@@ -2985,6 +3078,7 @@ fn lean_accepted_artifact_witness(
     host_table_lean: &str,
     struct_table_lean: &str,
     module_envelope: &cert::ModuleEnvelopeFacts,
+    mode: WitnessMode,
 ) -> String {
     let witness = lean_expr_fragment_artifact_claims(rederived, host_table_lean, struct_table_lean);
     let artifact = lean_artifact_data_literal(
@@ -3001,7 +3095,7 @@ fn lean_accepted_artifact_witness(
         &witness.composition_claims,
         module_envelope,
     );
-    let checker_proof = format!(
+    let checker_proof = (mode == WitnessMode::Diagnostic).then(|| format!(
         concat!(
             "  dsimp [AverCert.AcceptedArtifact.accepted,\n",
             "    AverCert.AcceptedArtifact.subjectMatchesArtifactRoot,\n",
@@ -3128,17 +3222,26 @@ fn lean_accepted_artifact_witness(
         int_dispatch_proof = witness.int_dispatch_proof,
         field_projection_proof = witness.field_projection_proof,
         composition_proof = witness.composition_proof
-    );
+    ));
+    let diagnostic_mirror = checker_proof.map_or_else(String::new, |checker_proof| {
+        format!(
+            concat!(
+                "-- Checker-owned mirror proof kept as a narrow diagnostic. The axiom\n",
+                "-- audit below is rooted at the artifact-carried proof, after the data\n",
+                "-- pin above has checked.\n",
+                "example : AverCert.AcceptedArtifact.accepted {artifact} := by\n",
+                "{checker_proof}\n\n"
+            ),
+            artifact = artifact,
+            checker_proof = checker_proof
+        )
+    });
     format!(
         concat!(
             "-- Artifact-carried data pin: the cert-supplied `Artifact.lean` data\n",
             "-- must be exactly the checker-reconstructed artifact literal.\n",
             "example : AverCert.Artifact.data = {artifact} := rfl\n\n",
-            "-- Checker-owned mirror proof kept as a narrow diagnostic. The axiom\n",
-            "-- audit below is rooted at the artifact-carried proof, after the data\n",
-            "-- pin above has checked.\n",
-            "example : AverCert.AcceptedArtifact.accepted {artifact} := by\n",
-            "{checker_proof}\n\n",
+            "{diagnostic_mirror}",
             "-- Whole-artifact acceptance root carried by the artifact itself. The\n",
             "-- checker only accepts it after the data pin and final-theorem\n",
             "-- ascription above have checked.\n",
@@ -3147,7 +3250,7 @@ fn lean_accepted_artifact_witness(
         ),
         witness_theorem = WITNESS_THEOREM,
         artifact = artifact,
-        checker_proof = checker_proof
+        diagnostic_mirror = diagnostic_mirror
     )
 }
 
@@ -3157,6 +3260,7 @@ fn lean_accepted_artifact_witness(
 /// theorem's type / the kernel axiom collector), so a lying JSON, a rebound
 /// hash, a weakened theorem, or a smuggled axiom all make this file fail to
 /// check — and THAT (the process exit code) is the only verdict channel.
+#[allow(clippy::too_many_arguments)]
 fn checker_witness(
     sha: &str,
     cands: &Candidates,
@@ -3165,6 +3269,7 @@ fn checker_witness(
     host_table_lean: &str,
     struct_table_lean: &str,
     module_envelope: &cert::ModuleEnvelopeFacts,
+    mode: WitnessMode,
 ) -> String {
     // Count is the JSON-claimed number of certified exports, verified by `rfl`
     // against `obligations.length` (so a JSON claiming more or fewer than the
@@ -3283,17 +3388,22 @@ fn checker_witness(
     let expr_fragment_wasm_slice_pins = lean_expr_fragment_wasm_slice_pins(rederived);
     let expr_fragment_func_binding_pins = lean_expr_fragment_func_binding_pins(rederived);
     let expr_fragment_accepted_pins = lean_expr_fragment_accepted_pins(rederived);
-    let expr_fragment_obligation_acceptance_pins = lean_expr_fragment_obligation_acceptance_pins(
-        rederived,
-        host_table_lean,
-        struct_table_lean,
-        module_envelope,
-    );
+    let expr_fragment_obligation_acceptance_pins = if mode == WitnessMode::Diagnostic {
+        lean_expr_fragment_obligation_acceptance_pins(
+            rederived,
+            host_table_lean,
+            struct_table_lean,
+            module_envelope,
+        )
+    } else {
+        String::new()
+    };
     let accepted_artifact_witness = lean_accepted_artifact_witness(
         rederived,
         host_table_lean,
         struct_table_lean,
         module_envelope,
+        mode,
     );
     // Semantic-face bindings: pin each obligation's typed `Dom`/`Cod`/`domRepr`/
     // `codRepr` to the STANDARD form its BYTE-derived class implies, and prove
@@ -3530,6 +3640,41 @@ fn checker_witness(
 /// is indexed into `manifest.obligations` so the block is robust to an
 /// obligation count that diverges from the manifest. Empty when there are no
 /// certified obligations.
+#[allow(clippy::too_many_arguments)]
+fn author_and_run_checker_witness(
+    build_dir: &Path,
+    sha: &str,
+    cands: &Candidates,
+    rederived: &[cert::RederivedObligation],
+    derived_contracts: &[String],
+    host_table_lean: &str,
+    struct_table_lean: &str,
+    module_envelope: &cert::ModuleEnvelopeFacts,
+    mode: WitnessMode,
+) -> Result<LakeOut, String> {
+    let witness = checker_witness(
+        sha,
+        cands,
+        rederived,
+        derived_contracts,
+        host_table_lean,
+        struct_table_lean,
+        module_envelope,
+        mode,
+    );
+    std::fs::write(build_dir.join("CheckerWitness.lean"), witness).map_err(|e| {
+        format!(
+            "cannot write {} checker witness: {e}",
+            if mode == WitnessMode::Diagnostic {
+                "diagnostic"
+            } else {
+                "fast"
+            }
+        )
+    })?;
+    run_lake(build_dir, &["env", "lean", "CheckerWitness.lean"])
+}
+
 fn face_bindings(rederived: &[cert::RederivedObligation]) -> String {
     let mut s = String::new();
     for (i, r) in rederived.iter().enumerate() {

--- a/src/main/cert_data_cache.rs
+++ b/src/main/cert_data_cache.rs
@@ -1,0 +1,367 @@
+//! Content-addressed Lake build-output cache for artifact-specific cert DATA.
+//!
+//! Entries contain only `.lake` plus an integrity manifest. Source inputs are
+//! always staged afresh by `cert_cmd`; `lake build` still runs on every verify,
+//! and the checker witness is never cached.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+const CACHE_ENV: &str = "AVER_CERT_DATA_CACHE";
+const CACHE_LAYOUT_VERSION: &str = "v1";
+
+pub(crate) struct KeyMaterial<'a> {
+    pub schema_version: u64,
+    pub pinned_sha256: &'a [(&'a str, &'a str)],
+    pub toolchain_version: &'a str,
+}
+
+/// A prepared cache lookup. Cache I/O is deliberately best-effort: failure to
+/// read, validate, or publish an entry leaves verification on the fresh build.
+pub(crate) struct ArtifactBuildCache {
+    entry: Option<PathBuf>,
+    hit: bool,
+}
+
+impl ArtifactBuildCache {
+    pub(crate) fn prepare(build_dir: &Path, material: &KeyMaterial<'_>) -> Self {
+        let Some(store) = cache_store() else {
+            return Self {
+                entry: None,
+                hit: false,
+            };
+        };
+        let Ok(key) = artifact_cache_key(build_dir, material) else {
+            return Self {
+                entry: None,
+                hit: false,
+            };
+        };
+        let entry = store.join(CACHE_LAYOUT_VERSION).join(key);
+        let hit = try_reuse(&entry, build_dir).is_ok();
+        Self {
+            entry: Some(entry),
+            hit,
+        }
+    }
+
+    pub(crate) fn was_hit(&self) -> bool {
+        self.hit
+    }
+
+    /// Remove an entry that made `lake build` fail so the caller can retry from
+    /// freshly staged sources (optionally seeded only by the pristine prelude).
+    pub(crate) fn invalidate(&mut self, build_dir: &Path) {
+        if let Some(entry) = &self.entry {
+            let _ = std::fs::remove_dir_all(entry);
+        }
+        let _ = std::fs::remove_dir_all(build_dir.join(".lake"));
+        self.hit = false;
+    }
+
+    pub(crate) fn publish(&self, build_dir: &Path) {
+        if self.hit {
+            return;
+        }
+        let Some(entry) = &self.entry else {
+            return;
+        };
+        let _ = try_publish(entry, build_dir);
+    }
+}
+
+/// `AVER_CERT_DATA_CACHE=0|off|false` opts out. Any other explicit value is a
+/// cache directory (useful for hermetic tests); otherwise use the OS user cache
+/// location. Failure to identify a user cache directory disables the hint.
+fn cache_store() -> Option<PathBuf> {
+    if let Some(value) = std::env::var_os(CACHE_ENV) {
+        let text = value.to_string_lossy();
+        if text.is_empty()
+            || text == "0"
+            || text.eq_ignore_ascii_case("off")
+            || text.eq_ignore_ascii_case("false")
+        {
+            return None;
+        }
+        return Some(PathBuf::from(value));
+    }
+
+    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+        return Some(PathBuf::from(xdg).join("aver").join("cert-data"));
+    }
+    #[cfg(target_os = "macos")]
+    if let Some(home) = std::env::var_os("HOME") {
+        return Some(
+            PathBuf::from(home)
+                .join("Library")
+                .join("Caches")
+                .join("aver")
+                .join("cert-data"),
+        );
+    }
+    #[cfg(target_os = "windows")]
+    if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+        return Some(PathBuf::from(local).join("aver").join("cert-data"));
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    if let Some(home) = std::env::var_os("HOME") {
+        return Some(
+            PathBuf::from(home)
+                .join(".cache")
+                .join("aver")
+                .join("cert-data"),
+        );
+    }
+    None
+}
+
+/// Hash all inputs that can affect artifact DATA build products. The explicit
+/// manifest wall is included even though the exact freshly staged source tree
+/// is also hashed: schema version, artifact sha, every audited-file sha, and
+/// toolchain version are visible, independently framed invalidators. The source
+/// tree then covers ArtifactBytes plus every certificate/model DATA file, so a
+/// DATA edit that leaves the JSON pins untouched still cannot reuse an entry.
+fn artifact_cache_key(build_dir: &Path, material: &KeyMaterial<'_>) -> Result<String, ()> {
+    let mut hasher = Sha256::new();
+    hash_part(&mut hasher, b"layout", CACHE_LAYOUT_VERSION.as_bytes());
+    hash_part(
+        &mut hasher,
+        b"schema_version",
+        material.schema_version.to_string().as_bytes(),
+    );
+
+    let mut pins = material.pinned_sha256.to_vec();
+    pins.sort_by_key(|(name, _)| *name);
+    for (name, value) in pins {
+        hash_part(&mut hasher, name.as_bytes(), value.as_bytes());
+    }
+    hash_part(
+        &mut hasher,
+        b"toolchain_version",
+        material.toolchain_version.as_bytes(),
+    );
+
+    for (name, bytes) in staged_source_files(build_dir)? {
+        hash_part(&mut hasher, name.as_bytes(), &bytes);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn hash_part(hasher: &mut Sha256, name: &[u8], bytes: &[u8]) {
+    hasher.update((name.len() as u64).to_be_bytes());
+    hasher.update(name);
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+}
+
+fn staged_source_files(build_dir: &Path) -> Result<Vec<(String, Vec<u8>)>, ()> {
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(build_dir).map_err(|_| ())? {
+        let entry = entry.map_err(|_| ())?;
+        if !entry.file_type().map_err(|_| ())?.is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_str().ok_or(())?.to_string();
+        if name == "CheckerWitness.lean" {
+            continue;
+        }
+        files.push((name, std::fs::read(entry.path()).map_err(|_| ())?));
+    }
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(files)
+}
+
+fn try_reuse(entry: &Path, build_dir: &Path) -> Result<(), ()> {
+    let cached_lake = entry.join(".lake");
+    if !cached_lake.is_dir() {
+        return Err(());
+    }
+    if verify_integrity(entry, &cached_lake).is_err() {
+        let _ = std::fs::remove_dir_all(entry);
+        return Err(());
+    }
+
+    let destination = build_dir.join(".lake");
+    let _ = std::fs::remove_dir_all(&destination);
+    if copy_tree(&cached_lake, &destination).is_err()
+        || verify_integrity(entry, &destination).is_err()
+    {
+        let _ = std::fs::remove_dir_all(destination);
+        let _ = std::fs::remove_dir_all(entry);
+        return Err(());
+    }
+    Ok(())
+}
+
+fn try_publish(entry: &Path, build_dir: &Path) -> Result<(), ()> {
+    let lake = build_dir.join(".lake");
+    if !lake.is_dir() {
+        return Err(());
+    }
+    let parent = entry.parent().ok_or(())?;
+    std::fs::create_dir_all(parent).map_err(|_| ())?;
+    let temp = parent.join(format!("tmp-{}-{}", std::process::id(), unique_nanos()));
+    std::fs::create_dir(&temp).map_err(|_| ())?;
+    let result = (|| {
+        copy_tree(&lake, &temp.join(".lake"))?;
+        write_integrity(&temp)?;
+        match std::fs::rename(&temp, entry) {
+            Ok(()) => Ok(()),
+            Err(_) if entry.join(".lake").is_dir() => Ok(()),
+            Err(_) => Err(()),
+        }
+    })();
+    let _ = std::fs::remove_dir_all(temp);
+    result
+}
+
+fn copy_tree(source: &Path, destination: &Path) -> Result<(), ()> {
+    std::fs::create_dir(destination).map_err(|_| ())?;
+    for entry in std::fs::read_dir(source).map_err(|_| ())? {
+        let entry = entry.map_err(|_| ())?;
+        let destination_entry = destination.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|_| ())?;
+        if file_type.is_dir() {
+            copy_tree(&entry.path(), &destination_entry)?;
+        } else if file_type.is_file() {
+            std::fs::copy(entry.path(), destination_entry).map_err(|_| ())?;
+        } else {
+            return Err(());
+        }
+    }
+    Ok(())
+}
+
+fn write_integrity(entry: &Path) -> Result<(), ()> {
+    let mut manifest = String::new();
+    for (path, hash) in lake_tree_hashes(&entry.join(".lake"))? {
+        manifest.push_str(&hash);
+        manifest.push_str("  ");
+        manifest.push_str(&path);
+        manifest.push('\n');
+    }
+    std::fs::write(entry.join("manifest.sha256"), manifest).map_err(|_| ())
+}
+
+fn verify_integrity(entry: &Path, lake: &Path) -> Result<(), ()> {
+    let manifest = std::fs::read_to_string(entry.join("manifest.sha256")).map_err(|_| ())?;
+    let mut expected = Vec::new();
+    for line in manifest.lines() {
+        let (hash, path) = line.split_once("  ").ok_or(())?;
+        if hash.len() != 64 || !hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(());
+        }
+        let relative = Path::new(path);
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        {
+            return Err(());
+        }
+        expected.push((path.to_string(), hash.to_ascii_lowercase()));
+    }
+    expected.sort();
+    if expected != lake_tree_hashes(lake)? {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn lake_tree_hashes(root: &Path) -> Result<Vec<(String, String)>, ()> {
+    fn visit(root: &Path, dir: &Path, hashes: &mut Vec<(String, String)>) -> Result<(), ()> {
+        for entry in std::fs::read_dir(dir).map_err(|_| ())? {
+            let entry = entry.map_err(|_| ())?;
+            let file_type = entry.file_type().map_err(|_| ())?;
+            if file_type.is_dir() {
+                visit(root, &entry.path(), hashes)?;
+            } else if file_type.is_file() {
+                let path = entry.path();
+                let relative = path.strip_prefix(root).map_err(|_| ())?;
+                let relative = relative
+                    .to_str()
+                    .ok_or(())?
+                    .replace(std::path::MAIN_SEPARATOR, "/");
+                if relative.contains(['\n', '\r']) {
+                    return Err(());
+                }
+                let bytes = std::fs::read(path).map_err(|_| ())?;
+                hashes.push((relative, format!("{:x}", Sha256::digest(bytes))));
+            } else {
+                return Err(());
+            }
+        }
+        Ok(())
+    }
+
+    let mut hashes = Vec::new();
+    visit(root, root, &mut hashes)?;
+    hashes.sort();
+    Ok(hashes)
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_invalidates_every_explicit_input_and_staged_source() {
+        let dir = std::env::temp_dir().join(format!(
+            "aver-cert-data-cache-key-{}-{}",
+            std::process::id(),
+            unique_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("Artifact.lean"), "def artifact := 1\n").unwrap();
+        let pins = [("wasm_sha256", "aa"), ("schema_sha256", "bb")];
+        let material = KeyMaterial {
+            schema_version: 50,
+            pinned_sha256: &pins,
+            toolchain_version: "leanprover/lean4:v4.31.0",
+        };
+        let baseline = artifact_cache_key(&dir, &material).unwrap();
+
+        let changed_schema = KeyMaterial {
+            schema_version: 51,
+            ..material
+        };
+        assert_ne!(baseline, artifact_cache_key(&dir, &changed_schema).unwrap());
+
+        for index in 0..pins.len() {
+            let mut changed = pins;
+            changed[index].1 = "changed";
+            assert_ne!(
+                baseline,
+                artifact_cache_key(
+                    &dir,
+                    &KeyMaterial {
+                        pinned_sha256: &changed,
+                        ..material
+                    }
+                )
+                .unwrap()
+            );
+        }
+
+        let changed_toolchain = KeyMaterial {
+            toolchain_version: "leanprover/lean4:v4.32.0",
+            ..material
+        };
+        assert_ne!(
+            baseline,
+            artifact_cache_key(&dir, &changed_toolchain).unwrap()
+        );
+
+        std::fs::write(dir.join("Artifact.lean"), "def artifact := 2\n").unwrap();
+        assert_ne!(baseline, artifact_cache_key(&dir, &material).unwrap());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -29,6 +29,10 @@ fn aver_command() -> Command {
         "AVER_CERT_PRELUDE_CACHE",
         std::env::temp_dir().join("aver-cert-prelude-store"),
     );
+    command.env(
+        "AVER_CERT_DATA_CACHE",
+        std::env::temp_dir().join("aver-cert-data-store"),
+    );
     command
 }
 

--- a/tests/cert_decode_spec.rs
+++ b/tests/cert_decode_spec.rs
@@ -160,6 +160,10 @@ fn aver_command() -> Command {
         "AVER_CERT_PRELUDE_CACHE",
         std::env::temp_dir().join("aver-cert-prelude-store"),
     );
+    command.env(
+        "AVER_CERT_DATA_CACHE",
+        std::env::temp_dir().join("aver-cert-data-store"),
+    );
     command
 }
 

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -125,6 +125,10 @@ fn aver_command() -> Command {
         "AVER_CERT_PRELUDE_CACHE",
         std::env::temp_dir().join("aver-cert-prelude-store"),
     );
+    command.env(
+        "AVER_CERT_DATA_CACHE",
+        std::env::temp_dir().join("aver-cert-data-store"),
+    );
     command
 }
 
@@ -153,6 +157,7 @@ fn aver_verify_clean_cache(artifact: &Path, cert_dir: &Path) -> (bool, String) {
     // positive end-to-end verification independent of the test-only store.
     let out = aver_command()
         .env_remove("AVER_CERT_PRELUDE_CACHE")
+        .env("AVER_CERT_DATA_CACHE", "0")
         .arg("cert")
         .arg("verify")
         .arg(artifact)
@@ -165,6 +170,101 @@ fn aver_verify_clean_cache(artifact: &Path, cert_dir: &Path) -> (bool, String) {
         String::from_utf8_lossy(&out.stderr)
     );
     (out.status.success(), combined)
+}
+
+fn find_named_file(root: &Path, name: &str) -> Option<PathBuf> {
+    for entry in std::fs::read_dir(root).ok()? {
+        let entry = entry.ok()?;
+        let path = entry.path();
+        if entry.file_type().ok()?.is_dir() {
+            if let Some(found) = find_named_file(&path, name) {
+                return Some(found);
+            }
+        } else if entry.file_name() == name {
+            return Some(path);
+        }
+    }
+    None
+}
+
+#[test]
+fn cert_verify_rebuilds_after_cached_olean_corruption() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping cert DATA-cache corruption test: `lake` not available");
+        return;
+    }
+
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("cert-data-cache-corruption-artifact");
+    let cache_dir = temp_dir("cert-data-cache-corruption-store");
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/mutual.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("compile mutual fixture for DATA-cache corruption test");
+    assert!(
+        compile.status.success(),
+        "compile --certify failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let verify = || {
+        Command::new(env!("CARGO_BIN_EXE_aver"))
+            .env(
+                "AVER_CERT_PRELUDE_CACHE",
+                std::env::temp_dir().join("aver-cert-prelude-store"),
+            )
+            .env("AVER_CERT_DATA_CACHE", &cache_dir)
+            .arg("cert")
+            .arg("verify")
+            .arg(out_dir.join("mutual.wasm"))
+            .arg(out_dir.join("cert"))
+            .output()
+            .expect("verify mutual fixture with isolated DATA cache")
+    };
+    let first = verify();
+    assert!(
+        first.status.success(),
+        "initial cached verify failed:\n{}{}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let artifact_olean = find_named_file(&cache_dir, "Artifact.olean")
+        .expect("successful verify should publish cached Artifact.olean");
+    let mut corrupted = std::fs::read(&artifact_olean).unwrap();
+    assert!(!corrupted.is_empty(), "Artifact.olean must not be empty");
+    corrupted[0] ^= 0xff;
+    std::fs::write(&artifact_olean, &corrupted).unwrap();
+
+    let second = verify();
+    let second_report = format!(
+        "{}{}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert!(
+        second.status.success(),
+        "corrupt cached olean must be rejected and rebuilt (or fail closed):\n{second_report}"
+    );
+    assert!(
+        second_report.contains("CERTIFIED"),
+        "rebuilt verification did not produce the normal verdict:\n{second_report}"
+    );
+    assert_ne!(
+        std::fs::read(&artifact_olean).unwrap(),
+        corrupted,
+        "corrupted Artifact.olean survived integrity validation"
+    );
+
+    let _ = std::fs::remove_dir_all(out_dir);
+    let _ = std::fs::remove_dir_all(cache_dir);
 }
 
 fn set_named_code_nlocals_to_zero(
@@ -4431,6 +4531,12 @@ fn cert_verify_declines_tampered_termination_manifest() {
             report.contains(expected),
             "{label}: wrong decline reason, expected `{expected}`:\n{report}"
         );
+        if label == "wrong descent" {
+            assert!(
+                report.contains("diagnostic kernel witness"),
+                "witness decline must surface the diagnostic rerun:\n{report}"
+            );
+        }
         let _ = std::fs::remove_dir_all(dir);
     }
     let _ = std::fs::remove_dir_all(out_dir);

--- a/tests/cert_whole_module_guard_iso.rs
+++ b/tests/cert_whole_module_guard_iso.rs
@@ -19,6 +19,10 @@ fn aver_command() -> Command {
         "AVER_CERT_PRELUDE_CACHE",
         std::env::temp_dir().join("aver-cert-prelude-store"),
     );
+    command.env(
+        "AVER_CERT_DATA_CACHE",
+        std::env::temp_dir().join("aver-cert-data-store"),
+    );
     command
 }
 


### PR DESCRIPTION
## Summary
- Two-phase verify: the fast path drops the two diagnostic re-proofs of the acceptance predicate that duplicated the artifact-carried theorem (~27s of every verify); a failing fast path automatically re-runs with the full diagnostic witness and surfaces its output as the decline report, keeping per-conjunct failure reasons legible. The fast-path trust chain is unchanged and fail-closed: the data pin, the type ascription to the artifact-carried proof, and the kernel axiom audit. A fast-path failure with a diagnostic-path success is reported as an internal error, fail-closed.
- Per-artifact build cache for the certificate data project, keyed by the manifest's pinned hashes, the toolchain version, and the exact staged source bytes — any divergence forces a rebuild. The witness is still authored and kernel-checked on every verify; a corrupted cache entry makes the build or witness fail, never falsely succeed (pinned by an invalidation test that corrupts a cached olean).
- End-to-end tamper flow confirms the diagnostic re-run reports a legible per-conjunct reason (14.2s decline).

## Timing (json example)
- Warm re-verify: ~89s → **15.6s**. The remaining floor is the trust-bearing witness check itself; the follow-up pass splits it into shared opaque proof bundles (design consulted and banked).

## Testing
- fmt, clippy (wasm,wasip2), lib with wasm features, full cert_certify_spec, cert_decode_spec (incl. clean-store rerun), cert_whole_module_guard_iso, cache-invalidation and decline-reason tests
- End-to-end timing matrix on json, cert_goals, mutual — all CERTIFIED

🤖 Generated with [Claude Code](https://claude.com/claude-code)