### PR TITLE
Derive field-projection conformance from the audited generic

### DIFF
--- a/src/codegen/cert/V3DischargeFieldProj.lean
+++ b/src/codegen/cert/V3DischargeFieldProj.lean
@@ -140,6 +140,116 @@ private theorem fieldProjection_run_succ_eq_one
       subst body
       simp [wFuncN, hCode, initLocals, wRunF]
 
+/-- Canonical option-(c) leaf bridge for one field projection.  The obligation
+face is fully canonical: a represented pair is lowered to a two-field struct,
+the result is represented verbatim, and the model is the checked plan's pair
+projection.  Artifact-specific callers supply only the reducible plan check and
+code-table binding; no per-obligation semantic proof remains. -/
+theorem fieldProjection_canonical_discharges
+    (exportName : String)
+    (carrier structIdx self : Nat)
+    (plan : FieldProjectionRawPlan)
+    (code : CodeTbl)
+    (host :
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (Nat → List WVal → Option WVal) → HostTbl)
+    (hCheck : AverCert.PlanCheck.checkFieldProjectionRawPlan 2 plan = true)
+    (hCode : code self = some {
+      arity := 1
+      nlocals := 3
+      body := [.localGet 0, .localSet 2, .localGet 2, .refCast structIdx,
+        .structGet structIdx plan.fieldIdx, .localSet 1, .localGet 1] }) :
+    Obligation.holds
+      ({ export_ := exportName
+         policy := .simulatesModel
+         carrier := carrier
+         code := code
+         host := host
+         self := self
+         Dom := WVal × WVal
+         Cod := WVal
+         domRepr := fun _ p vs => vs = [.structv structIdx [p.1, p.2]]
+         codRepr := fun S v w => verbatimRepr S v w
+         model := fun p => V3FieldProj.pairProjection plan.fieldIdx p.1 p.2 } :
+        Obligation) := by
+  intro S add sub mul stringEq stringConcat
+    _hAdd _hSub _hMul _hStringEq _hStringConcat fuel p vs w hDom hRun
+  rcases p with ⟨a, b⟩
+  subst vs
+  cases fuel with
+  | zero => simp [wFuncN] at hRun
+  | succ fuel =>
+      let body : List WInstr :=
+        [.localGet 0, .localSet 2, .localGet 2, .refCast structIdx,
+          .structGet structIdx plan.fieldIdx, .localSet 1, .localGet 1]
+      have hLow : AverCert.PlanLower.lowerFieldProjectionBody structIdx 2 plan =
+          some body := by
+        simp [body, AverCert.PlanLower.lowerFieldProjectionBody, hCheck]
+      have hCall := V3FieldProj.generic_field_projection_certified
+        structIdx plan code (host add sub mul stringEq stringConcat) self
+        hCheck body hLow hCode a b
+      have hFuel := fieldProjection_run_succ_eq_one
+        structIdx plan code (host add sub mul stringEq stringConcat) self
+        hCheck body hLow hCode fuel a b
+      rw [hFuel, hCall] at hRun
+      exact (Option.some.inj hRun).symm
+
+/-- Canonical option-(c) leaf bridge for the projection-faced expression
+fragment lowering.  This is the direct two-instruction sibling of
+`fieldProjection_canonical_discharges`: the checked fragment loads its sole
+struct argument and projects field zero or one without the legacy spill/cast
+spine. -/
+theorem fieldProjection_direct_canonical_discharges
+    (exportName : String)
+    (carrier structIdx self fieldIdx : Nat)
+    (code : CodeTbl)
+    (host :
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (Nat → List WVal → Option WVal) → HostTbl)
+    (hField : fieldIdx < 2)
+    (hCode : code self = some {
+      arity := 1
+      nlocals := 1
+      body := [.localGet 0, .structGet structIdx fieldIdx] }) :
+    Obligation.holds
+      ({ export_ := exportName
+         policy := .simulatesModel
+         carrier := carrier
+         code := code
+         host := host
+         self := self
+         Dom := WVal × WVal
+         Cod := WVal
+         domRepr := fun _ p vs => vs = [.structv structIdx [p.1, p.2]]
+         codRepr := fun S v w => verbatimRepr S v w
+         model := fun p => V3FieldProj.pairProjection fieldIdx p.1 p.2 } :
+        Obligation) := by
+  intro S add sub mul stringEq stringConcat
+    _hAdd _hSub _hMul _hStringEq _hStringConcat fuel p vs w hDom hRun
+  rcases p with ⟨a, b⟩
+  subst vs
+  cases fuel with
+  | zero => simp [wFuncN] at hRun
+  | succ fuel =>
+      cases fieldIdx with
+      | zero =>
+          simpa [V3FieldProj.pairProjection, verbatimRepr] using
+            (Option.some.inj (by
+              simpa [wFuncN, hCode, initLocals, wRunF] using hRun)).symm
+      | succ fieldIdx =>
+          cases fieldIdx with
+          | zero =>
+              simpa [V3FieldProj.pairProjection, verbatimRepr] using
+                (Option.some.inj (by
+                  simpa [wFuncN, hCode, initLocals, wRunF] using hRun)).symm
+          | succ fieldIdx => omega
+
 /-- One accepted claim discharges once its semantic face is tied to the checked
 projection plan.  This is the complete reusable per-claim proof shape. -/
 theorem fieldProjection_claim_discharges
@@ -221,4 +331,6 @@ end V3Master
 #print axioms V3Master.fieldProjection_accepted_call
 #print axioms V3Master.fieldProjection_claim_discharges
 #print axioms V3Master.fieldProjection_discharges
+#print axioms V3Master.fieldProjection_canonical_discharges
+#print axioms V3Master.fieldProjection_direct_canonical_discharges
 #print axioms V3Master.reprSpecOfCarrierSpec

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -85,7 +85,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 54;
+pub const CERT_SCHEMA_VERSION: u32 = 55;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/cert/rederive.rs
+++ b/src/codegen/cert/rederive.rs
@@ -261,7 +261,10 @@ pub enum ObligationFace {
     /// Field projection: `Dom := WVal × WVal`, `Cod := WVal`,
     /// `codRepr := verbatimRepr`,
     /// `domRepr := fun _ p vs => vs = [.structv struct_idx [p.1, p.2]]`.
-    Projection { struct_idx: u32 },
+    Projection {
+        struct_idx: u32,
+        field_idx: u32,
+    },
     /// Typed expression fragment: `Dom` is the product of all lifted wasm
     /// parameters, `Cod` is the lifted root type, and `domRepr` is the exact
     /// wasm argument vector reconstructed from the byte-derived parameter types.
@@ -298,14 +301,20 @@ impl ObligationFace {
         if let Some(face) = c.project_face() {
             return ObligationFace::Projection {
                 struct_idx: face.struct_idx,
+                field_idx: face.field_idx,
             };
         }
         match c.inner() {
             Cert::Recursive { .. }
             | Cert::AccumulatorRecursive { .. }
             | Cert::Composition { .. } => ObligationFace::IntList { arity: c.arity() },
-            Cert::FieldProjection { struct_idx, .. } => ObligationFace::Projection {
+            Cert::FieldProjection {
+                struct_idx,
+                field_idx,
+                ..
+            } => ObligationFace::Projection {
                 struct_idx: *struct_idx,
+                field_idx: *field_idx,
             },
             Cert::ExprFragment { plan, .. } => ObligationFace::ExprFragment {
                 params: plan.params.clone(),
@@ -415,7 +424,11 @@ impl ObligationFace {
                      intro o h\n  {reduce}\n  subst h; exact HEq.rfl\n"
                 ));
             }
-            ObligationFace::Projection { struct_idx } => {
+            ObligationFace::Projection {
+                struct_idx,
+                field_idx,
+            } => {
+                let projection = if *field_idx == 0 { "p.1" } else { "p.2" };
                 s.push_str(&format!(
                     "example : ({obl}[{idx}]?).map (fun o => o.Dom) = \
                      some (CertPrelude.WVal × CertPrelude.WVal) := rfl\n"
@@ -433,6 +446,12 @@ impl ObligationFace {
                      HEq o.domRepr (fun (_S : AverCert.Schema.CarrierSpec o.carrier) \
                      (p : CertPrelude.WVal × CertPrelude.WVal) (vs : List CertPrelude.WVal) =>\n      \
                      vs = [.structv {struct_idx} [p.1, p.2]]) := by\n  \
+                     intro o h\n  {reduce}\n  subst h; exact HEq.rfl\n"
+                ));
+                s.push_str(&format!(
+                    "example : ∀ o, {obl}[{idx}]? = some o →\n    \
+                     HEq o.model (fun (p : CertPrelude.WVal × CertPrelude.WVal) => \
+                     {projection}) := by\n  \
                      intro o h\n  {reduce}\n  subst h; exact HEq.rfl\n"
                 ));
             }

--- a/src/codegen/cert/render_adt.rs
+++ b/src/codegen/cert/render_adt.rs
@@ -64,27 +64,17 @@ theorem {name}_simulates : AverCert.Schema.Obligation.holds {name}Ob := by
     )
 }
 
-/// Which end of the `struct.new`/verbatim spine a certificate proves: packing
-/// arguments INTO a variant struct (the dual of) reading a field OUT of one.
-/// Both are one-step `cases fuel` proofs over `WVal`/`verbatimRepr` with no host,
-/// so [`render_struct_verbatim_cert`] emits them through one skeleton.
+/// The `struct.new`/verbatim shape proved by the constructor certificate.
 enum StructVerbatimShape<'a> {
     /// Verbatim constructor: wrap `arity` arguments into variant `struct_idx`.
     Pack {
         arity: usize,
         fields: &'a [ConstructorField],
     },
-    /// Field projection: read field `field_idx` (0 or 1) out of a two-field struct.
-    Project { field_idx: u32 },
 }
 
-/// The `struct.new`/verbatim certificate arm: a single one-step `cases fuel`
-/// proof over `WVal`/`verbatimRepr` (no host), shared by the verbatim
-/// constructor (packs its arguments into variant `struct_idx`) and the field
-/// projection (reads a field back out) — structural duals that pop the raw
-/// arguments, reduce the interpreter and close by `rfl`. The two ends differ
-/// only in the statement's argument shape, the executable tripwire and the
-/// obligation's argument destructuring.
+/// The `struct.new`/verbatim constructor certificate: a single one-step
+/// `cases fuel` proof over `WVal`/`verbatimRepr` with no host.
 fn render_struct_verbatim_cert(
     name: &str,
     self_idx: u32,
@@ -132,27 +122,6 @@ example :
                 format!("(.structv {struct_idx} {built})"),
                 intro,
                 destructure,
-                tripwire,
-            )
-        }
-        StructVerbatimShape::Project { field_idx } => {
-            let expected = if field_idx == 0 { "a" } else { "b" };
-            let forced = if field_idx == 0 { 7 } else { 9 };
-            let tripwire = format!(
-                r#"-- Executable tripwire: project the field from a concrete two-carrier struct and
--- decode it back. A trapping body yields `none`, so this forces a real read.
-example :
-    ((wFuncN {name}Code {name}Host 1 {self_idx}
-        [.structv {struct_idx} [carrierSmall {carrier} 7, carrierSmall {carrier} 9]]).bind carrierToInt)
-      = some {forced} := by native_decide"#
-            );
-            (
-                "field projection certificate".to_string(),
-                "(a b : WVal)".to_string(),
-                format!("[.structv {struct_idx} [a, b]]"),
-                expected.to_string(),
-                "intro a b".to_string(),
-                "  rcases p with ⟨a, b⟩\n".to_string(),
                 tripwire,
             )
         }

--- a/src/codegen/cert/render_certificate.rs
+++ b/src/codegen/cert/render_certificate.rs
@@ -20,22 +20,10 @@ fn render_certificate(
                 s.push_str(&render_fueled_recursion_cert(c))
             }
             Cert::AdtConstructor { .. } => s.push_str(&render_adt_constructor_cert(c, model_info)),
-            Cert::FieldProjection {
-                name,
-                self_idx,
-                carrier,
-                struct_idx,
-                field_idx,
-                ..
-            } => s.push_str(&render_struct_verbatim_cert(
-                name,
-                *self_idx,
-                *carrier,
-                *struct_idx,
-                StructVerbatimShape::Project {
-                    field_idx: *field_idx,
-                },
-            )),
+            // The field-projection family is discharged in `Final.cert` by the
+            // audited v3 generic plus its canonical option-(c) leaf bridge.
+            // Its plan, obligation and claim data remain emitted unchanged.
+            Cert::FieldProjection { .. } => {}
             Cert::WidenedIntMatch { .. } | Cert::VariantDispatch { .. } => {
                 s.push_str(&render_adt_match_cert(c, model_info))
             }

--- a/src/codegen/cert/render_expr_fragment.rs
+++ b/src/codegen/cert/render_expr_fragment.rs
@@ -2,20 +2,10 @@ fn render_expr_fragment_cert(c: &Cert) -> String {
     if let Some(face) = c.int_add_face() {
         return render_expr_fragment_int_add_cert(c, face);
     }
-    // The verbatim Project face over the plan-lowered body: the SAME theorem
-    // and closer the legacy field-projection class ships (`wFuncN` plays the
-    // identical `WInstr` body), so migrating the class changes recognition,
-    // not the proof shape.
-    if let Some(face) = c.project_face() {
-        return render_struct_verbatim_cert(
-            c.name(),
-            c.self_idx(),
-            c.carrier(),
-            face.struct_idx,
-            StructVerbatimShape::Project {
-                field_idx: face.field_idx,
-            },
-        );
+    // Projection-faced fragments are discharged in `Final.cert` through the
+    // audited direct-projection generic and emit no bespoke proof declarations.
+    if c.project_face().is_some() {
+        return String::new();
     }
     let c = c.inner();
     let Cert::ExprFragment {

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -515,7 +515,7 @@ fn render_manifest_lean(
 fn render_final(analysis: &Analysis) -> String {
     let mut s = String::new();
     s.push_str(
-        "import Certificate\nimport Manifest\nimport Schema\n\n\
+        "import Certificate\nimport Manifest\nimport Schema\nimport V3DischargeFieldProj\n\n\
          set_option maxRecDepth 1000000\n\
          set_option linter.unusedSimpArgs false\n\n\
          open AverCert AverCert.Schema\n\n",
@@ -548,6 +548,36 @@ fn render_final(analysis: &Analysis) -> String {
             .certs
             .iter()
             .map(|c| {
+                if let Some(face) = c.project_face() {
+                    return format!(
+                        "exact V3Master.fieldProjection_direct_canonical_discharges \
+                         \"{}\" {} {} {} {} CertModule.{}Code \
+                         (fun _ _ _ _ _ => CertModule.{}Host) (by decide) (by rfl)",
+                        c.name(),
+                        c.carrier(),
+                        face.struct_idx,
+                        c.self_idx(),
+                        face.field_idx,
+                        c.name(),
+                        c.name(),
+                    );
+                }
+                if let Cert::FieldProjection {
+                    name,
+                    self_idx,
+                    carrier,
+                    struct_idx,
+                    ..
+                } = c.inner()
+                {
+                    return format!(
+                        "exact V3Master.fieldProjection_canonical_discharges \
+                         \"{name}\" {carrier} {struct_idx} {self_idx} \
+                         AverCert.Plans.{name}FieldProjectionPlan \
+                         CertModule.{name}Code \
+                         (fun _ _ _ _ _ => CertModule.{name}Host) (by rfl) (by rfl)"
+                    );
+                }
                 let theorem = if c.policy() == CertificationPolicy::SimulatesModelTotally {
                     "simulates_total"
                 } else {
@@ -996,22 +1026,29 @@ fn render_manifest(
             ),
             None => String::new(),
         };
-        let theorem_suffix = if policy == CertificationPolicy::SimulatesModelTotally {
-            "wasm_total"
+        let theorem = if c.project_face().is_some() {
+            "V3Master.fieldProjection_direct_canonical_discharges".to_string()
+        } else if matches!(c.inner(), Cert::FieldProjection { .. }) {
+            "V3Master.fieldProjection_canonical_discharges".to_string()
         } else {
-            "wasm_certified"
+            let theorem_suffix = if policy == CertificationPolicy::SimulatesModelTotally {
+                "wasm_total"
+            } else {
+                "wasm_certified"
+            };
+            format!("CertProofs.{}_{theorem_suffix}", c.name())
         };
         s.push_str(&format!(
             "\n    {{\"name\": {}, \"class\": \"{}\", \"policy\": \"{}\", \
              \"level\": \"{}\", \"dom\": {}, \"cod\": {}, \
-             \"theorem\": \"CertProofs.{}_{theorem_suffix}\"{}{}}}",
+             \"theorem\": {}{}{}}}",
             json_str(c.name()),
             kind,
             policy.manifest_name(),
             policy.level(),
             json_str(&dom),
             json_str(&cod),
-            c.name(),
+            json_str(&theorem),
             termination_json,
             fragment_json,
         ));

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -692,6 +692,36 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
         );
     }
 
+    let final_lean =
+        std::fs::read_to_string(cert_dir.join("Final.lean")).expect("Final.lean exists");
+    assert!(
+        final_lean.contains("V3Master.fieldProjection_direct_canonical_discharges \"userName\""),
+        "coexistence projection arm must use the audited generic:\n{final_lean}"
+    );
+    for bespoke_name in ["addTwo", "sumFrom", "countDown", "mkOp", "evalOp"] {
+        assert!(
+            final_lean.contains(&format!("CertProofs.{bespoke_name}_")),
+            "non-projection arm changed during coexistence migration: {bespoke_name}\n{final_lean}"
+        );
+    }
+    let certificate = std::fs::read_to_string(cert_dir.join("Certificate.lean"))
+        .expect("Certificate.lean exists");
+    assert!(
+        !certificate.contains("userName_wasm_certified")
+            && !certificate.contains("userName_simulates"),
+        "projection-faced fragment must not emit bespoke proofs:\n{certificate}"
+    );
+    let user_name = manifest["certified"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["name"] == "userName")
+        .unwrap();
+    assert_eq!(
+        user_name["theorem"],
+        "V3Master.fieldProjection_direct_canonical_discharges"
+    );
+
     let started = std::time::Instant::now();
     let build = Command::new("lake")
         .current_dir(&cert_dir)
@@ -1740,11 +1770,40 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
             .iter()
             .map(|c| c["name"].as_str().unwrap())
             .collect();
-        for name in expected {
+        for &name in &expected {
             assert!(
                 certified.contains(&name),
                 "expected {name} certified for {input}, got {certified:?}"
             );
+        }
+        if prefix == "tuple-proj" {
+            let entries = manifest["certified"].as_array().unwrap();
+            for name in ["pairFst", "pairSnd"] {
+                let entry = entries.iter().find(|entry| entry["name"] == name).unwrap();
+                assert_eq!(
+                    entry["theorem"], "V3Master.fieldProjection_canonical_discharges",
+                    "projection metadata must name the audited generic leaf theorem"
+                );
+            }
+            let certificate = std::fs::read_to_string(cert_dir.join("Certificate.lean"))
+                .expect("Certificate.lean exists");
+            assert!(
+                !certificate.contains("pairFst_wasm_certified")
+                    && !certificate.contains("pairFst_simulates")
+                    && !certificate.contains("pairSnd_wasm_certified")
+                    && !certificate.contains("pairSnd_simulates"),
+                "field projections must not emit bespoke proofs:\n{certificate}"
+            );
+            let final_lean =
+                std::fs::read_to_string(cert_dir.join("Final.lean")).expect("Final.lean exists");
+            for name in ["pairFst", "pairSnd"] {
+                assert!(
+                    final_lean.contains(&format!(
+                        "V3Master.fieldProjection_canonical_discharges \"{name}\""
+                    )),
+                    "Final.cert must use the audited generic for {name}:\n{final_lean}"
+                );
+            }
         }
         let build = Command::new("lake")
             .current_dir(&cert_dir)
@@ -1764,6 +1823,14 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
             !combined.contains("sorryAx"),
             "ADT certificate leaked sorryAx for {input}:\n{combined}"
         );
+        if prefix == "tuple-proj" {
+            assert!(
+                combined.contains(
+                    "'AverCert.Final.cert' depends on axioms: [propext, Classical.choice, Quot.sound]"
+                ),
+                "generic field-projection holds proofs changed axiom surface:\n{combined}"
+            );
+        }
 
         let _ = std::fs::remove_dir_all(&out_dir);
     }


### PR DESCRIPTION
## Summary
- First family migrated off bespoke per-export proofs onto the audited v3 generic (landed in #716). Field-projection obligations: the model is face-pinned to its byte-derived projection (`HEq.rfl`), collapsing the semantic bridge to an audited generic lemma (option-c leaf, zero per-obligation proof); the per-obligation acceptance arm applies the audited `fieldProjection_discharges` instead of the generated proof; the bespoke projection proof emission is deleted.
- **Coexistence, no flag-day:** every other family keeps its generated proof unchanged. A mixed artifact proves each obligation through whichever path its family uses, in one acceptance proof. Verified end-to-end: `tupleproj.av` (pure projection) and `cert_goals.av` (projection + recursion + dispatch) both CERTIFIED at unchanged counts/levels.
- Certificate schema bumps to 55.

## Change surface
- `rederive.rs` — model face pin for the Projection obligation face.
- `render_manifest.rs` — the field-projection acceptance arm uses the generic discharge; other arms unchanged.
- `render_adt.rs` / `render_certificate.rs` / `render_expr_fragment.rs` — bespoke projection proof emission removed.
- `V3DischargeFieldProj.lean` — the leaf bridge/discharge (re-sha-pinned).
- `cert_certify_spec.rs` — assertions updated to the generic path.

## Testing
- fmt, build (wasm); end-to-end certify+verify tupleproj (2/L1) and cert_goals (23/mixed L1-L3, the coexistence case) — both CERTIFIED (the verdict includes the axiom-whitelist audit).
- CI runs the full cert suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)