### PR TITLE
Derive dispatch-family conformance from the audited generic

### DIFF
--- a/src/codegen/cert/V3DischargeIntDispatch.lean
+++ b/src/codegen/cert/V3DischargeIntDispatch.lean
@@ -272,6 +272,78 @@ theorem intDispatch_claim_discharges
       exact hCod w (hGeneric S add sub mul stringEq stringConcat hAdd hSub
         fuel tag fields n w hCascade hRun)
 
+/-- Per-obligation option-(b) discharge for a concrete Int-dispatch export.
+The checked plan, canonical host table, lowering, and code binding are data;
+`hSemantic` is the intentionally residual source-model bridge emitted for the
+user function.  Unlike the option-(c) leaf theorems, the model is not replaced
+by a canonical evaluator: the bridge proves that the user's model agrees with
+the byte-derived `EvalCascade` on every represented source constructor. -/
+theorem intDispatch_canonical_discharges
+    (exportName : String)
+    (carrier self : Nat)
+    (plan : IntDispatchRawPlan)
+    (hostTable : List (HostRole × Nat))
+    (code : CodeTbl)
+    (host :
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (Nat → List WVal → Option WVal) → HostTbl)
+    (Dom : Type)
+    (domRepr : CarrierSpec carrier → Dom → List WVal → Prop)
+    (model : Dom → Int)
+    (hRaw : AverCert.PlanCheck.checkIntDispatchRawPlan plan = true)
+    (hDistinct : AverCert.PlanCheck.hostTableIndicesDistinct hostTable = true)
+    (hHost : ∀ add sub mul stringEq stringConcat,
+      host add sub mul stringEq stringConcat =
+        intDispatchCanonicalHost carrier hostTable
+          add sub mul stringEq stringConcat)
+    (hRoot : ∃ tyIdx leaf rest, plan.body = .test tyIdx leaf rest)
+    (body : List WInstr)
+    (hLow : AverCert.PlanLower.lowerIntDispatchBody hostTable plan = some body)
+    (hCode : code self = some {
+      arity := 1,
+      nlocals := AverCert.PlanCheck.intDispatchArmCount plan.body + 2,
+      body := body })
+    (hSemantic : ∀ (S : CarrierSpec carrier) (x : Dom) (vs : List WVal),
+      domRepr S x vs →
+      ∃ tag fields n,
+        vs = [.structv tag fields] ∧
+        V3Dispatch.EvalCascade S plan.body tag fields n ∧
+        ∀ w, S.Repr n w → intRepr S (model x) w) :
+    Obligation.holds
+      ({ export_ := exportName
+         policy := .simulatesModel
+         carrier := carrier
+         code := code
+         host := host
+         self := self
+         Dom := Dom
+         Cod := Int
+         domRepr := domRepr
+         codRepr := fun S n w => intRepr S n w
+         model := model } : Obligation) := by
+  intro S add sub mul stringEq stringConcat
+    hAdd hSub _hMul _hStringEq _hStringConcat fuel x vs w hDom hRun
+  rcases hSemantic S x vs hDom with
+    ⟨tag, fields, n, hVs, hCascade, hCod⟩
+  subst vs
+  cases fuel with
+  | zero => simp [wFuncN] at hRun
+  | succ fuel =>
+      have hSlots : V3Dispatch.HostSlots carrier
+          (host add sub mul stringEq stringConcat) hostTable add sub := by
+        rw [hHost]
+        exact canonicalHostSlots carrier add sub hostTable hDistinct
+      have hGeneric := V3Dispatch.generic_int_dispatch_certified
+        S plan code (host add sub mul stringEq stringConcat) self
+        hostTable add sub hSlots hAdd hSub
+        (intDispatchPinnedTypes plan.body)
+        (checkIntDispatchFamily_of_raw plan hRaw)
+        hRoot body hLow hCode
+      exact hCod w (hGeneric fuel tag fields n w hCascade hRun)
+
 /-- Complete family slice under the semantic/root bridge missing from current
 artifact acceptance. -/
 theorem intDispatch_discharges
@@ -290,4 +362,5 @@ end V3Master
 #print axioms V3Master.intDispatch_default_root_has_no_test
 #print axioms V3Master.intDispatch_accepted_call
 #print axioms V3Master.intDispatch_claim_discharges
+#print axioms V3Master.intDispatch_canonical_discharges
 #print axioms V3Master.intDispatch_discharges

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -85,7 +85,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 56;
+pub const CERT_SCHEMA_VERSION: u32 = 57;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/cert/render.rs
+++ b/src/codegen/cert/render.rs
@@ -3,6 +3,7 @@ include!("render_code.rs");
 include!("render_certificate.rs");
 include!("render_integer.rs");
 include!("render_composition.rs");
+include!("render_adt_constructor.rs");
 include!("render_adt.rs");
 include!("render_expr_fragment.rs");
 include!("render_model_support.rs");

--- a/src/codegen/cert/render_adt.rs
+++ b/src/codegen/cert/render_adt.rs
@@ -1,350 +1,378 @@
-fn render_adt_constructor_cert(c: &Cert, model_info: &ModelInfo) -> String {
-    let c = c.inner();
-    let Cert::AdtConstructor {
-        name,
-        self_idx,
-        carrier,
-        struct_idx,
-        ..
-    } = c
-    else {
-        unreachable!()
+/// Option-(b) residual for one model-bearing Int dispatch.  The generated
+/// theorem performs only source-ADT case analysis and builds the matching
+/// `EvalCascade`; byte lowering, host simulation and fuel reasoning live in
+/// the audited `V3DispatchCore` / `V3DischargeIntDispatch` wall.
+fn render_int_dispatch_semantic_bridge(
+    c: &Cert,
+    model_info: &ModelInfo,
+    strict: FragHostTable,
+) -> String {
+    let Some(plan) = int_dispatch_plan_from_cert(c, strict) else {
+        return format!(
+            "-- {}: no byte-matching int-dispatch plan\nexample : False := by decide\n",
+            c.name()
+        );
     };
-    debug_assert!(adt_constructor_uses_model(c, model_info));
-    let sig = model_info.fns.get(name);
-    let _ = sig
-        .and_then(|s| model_info.inductives.get(&s.ret))
-        .and_then(|i| i.ctors.first());
-    format!(
-        r#"/-! ### {name} — ADT constructor certificate (carrier type {carrier}) -/
-
-theorem {name}_wasm_certified (host : HostTbl) :
-    ∀ (v : WVal), wFuncN {name}Code host 1 {self_idx} [v] = some (.structv {struct_idx} [v]) := by
-  intro v
-  simp [wFuncN, {name}Code, wRunF, popArgs, initLocals]
-
-#print axioms {name}_wasm_certified
-
--- Executable tripwire: run the constructor on an Int 7 and decode field 0 of the
--- built struct back to `some 7`. Unlike a bare `= none` (which a TRAP also
--- satisfies), this forces the emitted body to genuinely pack its argument.
-example :
-    ((wFuncN {name}Code {name}Host 1 {self_idx} [carrierSmall {carrier} 7]).bind
-      (fun r => match r with
-        | .structv _ (f :: _) => carrierToInt f
-        | _ => none))
-      = some 7 := by native_decide
-
-theorem {name}_simulates : AverCert.Schema.Obligation.holds {name}Ob := by
-  intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel n vs w hrepr hrun
-  simp only [{name}Ob, AverCert.Schema.Obligation.holds] at hrun ⊢
-  obtain ⟨v, rfl, hv⟩ := hrepr
-  cases fuel with
-  | zero => simp [wFuncN] at hrun
-  | succ f =>
-      simp [wFuncN, wRunF, {name}Code, popArgs, initLocals] at hrun
-      subst hrun
-      exact ⟨v, rfl, by simpa [AverCert.Schema.intRepr] using hv⟩
-"#
-    )
-}
-
-/// The per-class ingredients of one ADT-match certificate: the pieces that
-/// differ between the fully-modelled variant dispatch and the widened Int match,
-/// spliced into ONE shared `cases o` skeleton by [`render_adt_match_cert`].
-struct AdtMatchPlan {
-    doc_title: String,
-    /// The theorem header up to (not including) the trailing ` :` — the binder
-    /// block differs (variant carries the add/sub host contracts, widened none).
-    header: String,
-    ty: String,
-    /// The domain-representation relation: the shared, faithful `{ty}Repr` when
-    /// every constructor is modelled, the per-function weak `{name}DomRepr` when
-    /// only one integer-payload variant is projected.
-    repr: String,
-    host_term: String,
-    host_ref_def: String,
-    /// The explicit per-constructor `cases o` arms, already joined.
-    cases: String,
-    guards: String,
-    /// The `_simulates` citation of `{name}_wasm_certified` (its argument list
-    /// differs by the host contracts).
-    sim_cite: String,
-}
-
-/// Leaf-polymorphic ADT variant-match certificate: ONE explicit `cases o` proof
-/// spine shared by the fully-modelled variant dispatch (every constructor
-/// faithfully represented, closing through the runtime add/sub contracts) and
-/// the widened Int match (one integer-payload constructor projected faithfully,
-/// every other constructor opaque and boxing the default). The walker emits the
-/// spine; each constructor closes with its OWN honest closer against its OWN
-/// honest domain representation, so neither faithfulness level is weakened to fit
-/// the other (the exact fold that a single shared `Repr` would have banned).
-fn render_adt_match_cert(c: &Cert, model_info: &ModelInfo) -> String {
-    let inner = c.inner();
-    let name = inner.name();
-    let self_idx = inner.self_idx();
-    let plan = match inner {
-        Cert::VariantDispatch { .. } => adt_match_variant_plan(inner, model_info),
-        Cert::WidenedIntMatch { .. } => adt_match_widened_plan(inner, model_info),
+    match c.inner() {
+        Cert::VariantDispatch { .. } => render_variant_dispatch_semantic_bridge(c, model_info, &plan),
+        Cert::WidenedIntMatch { .. } => render_widened_int_semantic_bridge(c, model_info, &plan),
         _ => unreachable!(),
-    };
-    let AdtMatchPlan {
-        doc_title,
-        header,
-        ty,
-        repr,
-        host_term,
-        host_ref_def,
-        cases,
-        guards,
-        sim_cite,
-    } = match plan {
-        Ok(p) => p,
-        Err(early) => return early,
-    };
-    format!(
-        r#"{doc_title}
-
-{header} :
-    ∀ (fuel : Nat) (o : {ty}) (v w : WVal), {repr} S o v →
-      wFuncN {name}Code {host_term} fuel {self_idx} [v] = some w →
-      S.Repr ({name} o) w := by
-  intro fuel
-  cases fuel with
-  | zero => intro o v w hv hrun; simp [wFuncN] at hrun
-  | succ f =>
-      intro o v w hv hrun
-      cases o with
-{cases}
-
-#print axioms {name}_wasm_certified
-
-{host_ref_def}
-{guards}
-
-theorem {name}_simulates : AverCert.Schema.Obligation.holds {name}Ob := by
-  intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel o vs w hrepr hrun
-  simp only [{name}Ob, AverCert.Schema.Obligation.holds] at hrun ⊢
-  obtain ⟨v, rfl, hv⟩ := hrepr
-  simpa [AverCert.Schema.intRepr] using {sim_cite}
-"#
-    )
+    }
 }
 
-/// The variant-dispatch plan: every constructor of a fully-modelled inductive is
-/// faithful (`{ty}Repr`); its arm is a payload projection, a payload/const host
-/// combination, or the terminal default. Closes through the add/sub contracts.
-fn adt_match_variant_plan(c: &Cert, model_info: &ModelInfo) -> Result<AdtMatchPlan, String> {
+fn render_variant_dispatch_semantic_bridge(
+    c: &Cert,
+    model_info: &ModelInfo,
+    plan: &IntDispatchRawPlan,
+) -> String {
     let Cert::VariantDispatch {
         name,
-        self_idx,
         carrier,
-        add_idx,
-        sub_idx,
         arms,
-        default_k,
         ..
-    } = c
+    } = c.inner()
     else {
         unreachable!()
     };
-    let ty = model_info
+    let Some(ty) = model_info
         .fns
         .get(name)
-        .and_then(|s| s.params.first())
-        .map(|s| s.as_str())
-        .unwrap_or("Op");
-    let repr = format!("{ty}Repr");
-    let host_ref = format!("{name}HostRef");
-    let Some(ind) = model_info.inductives.get(ty) else {
-        return Err(format!(
-            "-- {name}: no source inductive for {ty}\nexample : False := by decide\n"
-        ));
+        .and_then(|sig| sig.params.first())
+    else {
+        return format!(
+            "-- {name}: source model parameter type unavailable\nexample : False := by decide\n"
+        );
     };
-    let base = arms.iter().map(|(t, _)| *t).min().unwrap_or(0);
-    let arm_of_tag =
-        |tag: u32| -> Option<&ArmLeaf> { arms.iter().find(|(t, _)| *t == tag).map(|(_, l)| l) };
-    let simp_run = format!(
-        "simp [wFuncN, wRunF, {name}Code, {name}Host, boxRef, b32, popArgs, initLocals] at hrun"
-    );
+    let Some(ind) = model_info.inductives.get(ty) else {
+        return format!(
+            "-- {name}: source inductive `{ty}` unavailable\nexample : False := by decide\n"
+        );
+    };
+    let Some(base) = arms.iter().map(|(tag, _)| *tag).min() else {
+        return format!("-- {name}: empty dispatch\nexample : False := by decide\n");
+    };
 
     let mut cases = Vec::new();
-    let mut guards = Vec::new();
-    for (i, ctor) in ind.ctors.iter().enumerate() {
-        let tag = base + i as u32;
-        let cn = &ctor.name;
-        let payload = !ctor.fields.is_empty();
-        if arm_of_tag(tag).is_some() && !payload {
-            return Err(format!(
-                "-- {name}: variant tag mapping mismatch ({cn} is nullary but tag {tag} is dispatched)\nexample : False := by decide\n"
+    for (position, ctor) in ind.ctors.iter().enumerate() {
+        let tag = base + position as u32;
+        let binders = constructor_binders(ctor.fields.len());
+        if ctor.fields.is_empty() {
+            let source_value = format!("{name} (.{})", ctor.name);
+            let term = match render_eval_cascade_term(
+                &plan.body,
+                tag,
+                "[]",
+                &source_value,
+                None,
+            ) {
+                Ok(term) => term,
+                Err(error) => return render_dispatch_bridge_failure(name, &error),
+            };
+            cases.push(format!(
+                "  | {ctor} =>\n      subst v\n      refine ⟨{tag}, [], {source_value}, rfl, ?_, ?_⟩\n      · simpa [AverCert.Plans.{name}IntDispatchPlan, {name}, V3Dispatch.evalLeaf] using\n          ({term})\n      · intro w hw\n        simpa [AverCert.Schema.intRepr] using hw",
+                ctor = ctor.name,
+            ));
+        } else if ctor.fields.as_slice() == ["Int"] {
+            let source_value = format!("{name} (.{ctor} x)", ctor = ctor.name);
+            let term = match render_eval_cascade_term(
+                &plan.body,
+                tag,
+                "[cx]",
+                &source_value,
+                Some(("x", "cx", "hcx")),
+            ) {
+                Ok(term) => term,
+                Err(error) => return render_dispatch_bridge_failure(name, &error),
+            };
+            cases.push(format!(
+                "  | {ctor} x =>\n      obtain ⟨cx, rfl, hcx⟩ := hv\n      refine ⟨{tag}, [cx], {source_value}, rfl, ?_, ?_⟩\n      · simpa [AverCert.Plans.{name}IntDispatchPlan, {name}, V3Dispatch.evalLeaf] using\n          ({term})\n      · intro w hw\n        simpa [AverCert.Schema.intRepr] using hw",
+                ctor = ctor.name,
+            ));
+        } else {
+            cases.push(format!(
+                "  | {ctor}{binders} => simp [{ty}Repr] at hv",
+                ctor = ctor.name,
             ));
         }
-        match arm_of_tag(tag) {
-            Some(ArmLeaf::Proj) => {
-                cases.push(format!(
-                    "      | {cn} x =>\n          obtain ⟨cx, rfl, hcx⟩ := hv\n          {simp_run}\n          subst hrun\n          simpa [{name}] using hcx"
-                ));
-                guards.push(format!(
-                    "example : ((wFuncN {name}Code {host_ref} 4 {self_idx} [.structv {tag} [carrierSmall {carrier} 5]]).bind carrierToInt)\n    = some 5 := by native_decide"
-                ));
-            }
-            Some(ArmLeaf::HostOp {
-                role,
-                k,
-                const_first,
-            }) => {
-                let (hostfn, hyp) = match role {
-                    HostRole::Add => ("add", "hadd"),
-                    HostRole::Sub => ("sub", "hsub"),
-                    HostRole::StringEq | HostRole::StringConcat => unreachable!(),
-                };
-                let (operands, cite) = if *const_first {
-                    (
-                        format!("[carrierSmall {carrier} ({k}), cx]"),
-                        format!(
-                            "{hyp} ({k}) x (carrierSmall {carrier} ({k})) cx w' (S.smallIntro ({k})) hcx hs"
-                        ),
-                    )
-                } else {
-                    (
-                        format!("[cx, carrierSmall {carrier} ({k})]"),
-                        format!(
-                            "{hyp} x ({k}) cx (carrierSmall {carrier} ({k})) w' hcx (S.smallIntro ({k})) hs"
-                        ),
-                    )
-                };
-                cases.push(format!(
-                    "      | {cn} x =>\n          obtain ⟨cx, rfl, hcx⟩ := hv\n          {simp_run}\n          rcases hs : {hostfn} {operands} with _ | w' <;> simp [hs] at hrun\n          subst hrun\n          have := {cite}\n          simpa [{name}] using this"
-                ));
-                let sample = 5i64;
-                let expected = if *const_first {
-                    match role {
-                        HostRole::Add => k + sample,
-                        HostRole::Sub => k - sample,
-                        HostRole::StringEq | HostRole::StringConcat => unreachable!(),
-                    }
-                } else {
-                    match role {
-                        HostRole::Add => sample + k,
-                        HostRole::Sub => sample - k,
-                        HostRole::StringEq | HostRole::StringConcat => unreachable!(),
-                    }
-                };
-                guards.push(format!(
-                    "example : ((wFuncN {name}Code {host_ref} 4 {self_idx} [.structv {tag} [carrierSmall {carrier} {sample}]]).bind carrierToInt)\n    = some ({expected}) := by native_decide"
-                ));
-            }
-            None => {
-                if payload {
-                    cases.push(format!(
-                        "      | {cn} x =>\n          obtain ⟨cx, rfl, hcx⟩ := hv\n          {simp_run}\n          subst hrun\n          simpa [{name}] using S.smallIntro ({default_k})"
-                    ));
-                    guards.push(format!(
-                        "example : ((wFuncN {name}Code {host_ref} 4 {self_idx} [.structv {tag} [carrierSmall {carrier} 5]]).bind carrierToInt)\n    = some ({default_k}) := by native_decide"
-                    ));
-                } else {
-                    cases.push(format!(
-                        "      | {cn} =>\n          subst hv\n          {simp_run}\n          subst hrun\n          simpa [{name}] using S.smallIntro ({default_k})"
-                    ));
-                    guards.push(format!(
-                        "example : ((wFuncN {name}Code {host_ref} 4 {self_idx} [.structv {tag} []]).bind carrierToInt)\n    = some ({default_k}) := by native_decide"
-                    ));
-                }
-            }
-        }
     }
-    let add_ref = if add_idx.is_some() {
-        format!("(addRef {carrier})")
-    } else {
-        "(fun _ => none)".to_string()
-    };
-    let sub_ref = if sub_idx.is_some() {
-        format!("(subRef {carrier})")
-    } else {
-        "(fun _ => none)".to_string()
-    };
-    Ok(AdtMatchPlan {
-        doc_title: format!(
-            "/-! ### {name} — general variant dispatch certificate (carrier type {carrier}) -/"
-        ),
-        header: format!(
-            "theorem {name}_wasm_certified\n    (S : CarrierSpec {carrier})\n    (add sub : List WVal → Option WVal)\n    (hadd : ∀ a b va vb w, S.Repr a va → S.Repr b vb → add [va, vb] = some w → S.Repr (a + b) w)\n    (hsub : ∀ a b va vb w, S.Repr a va → S.Repr b vb → sub [va, vb] = some w → S.Repr (a - b) w)"
-        ),
-        ty: ty.to_string(),
-        repr,
-        host_term: format!("({name}Host add sub)"),
-        host_ref_def: format!("def {host_ref} : HostTbl := {name}Host {add_ref} {sub_ref}"),
-        cases: cases.join("\n"),
-        guards: guards.join("\n"),
-        sim_cite: format!("{name}_wasm_certified S add sub hadd hsub fuel o v w hv hrun"),
-    })
+
+    format!(
+        r#"/-! ### {name} — option-(b) Int-dispatch semantic bridge -/
+
+theorem {name}_intDispatchSemanticBridge :
+    ∀ (S : CarrierSpec {carrier}) (x : {ty}) (vs : List WVal),
+      (∃ v, vs = [v] ∧ {ty}Repr S x v) →
+      ∃ tag fields n,
+        vs = [.structv tag fields] ∧
+        V3Dispatch.EvalCascade S
+          AverCert.Plans.{name}IntDispatchPlan.body tag fields n ∧
+        ∀ w, S.Repr n w → AverCert.Schema.intRepr S ({name} x) w := by
+  intro S x vs hDom
+  obtain ⟨v, rfl, hv⟩ := hDom
+  cases x with
+{cases}
+
+#print axioms {name}_intDispatchSemanticBridge
+"#,
+        cases = cases.join("\n"),
+    )
 }
 
-/// The widened-match plan: the single integer-payload constructor is faithful
-/// (projects its carrier), every other constructor is opaque — represented only
-/// as "some struct of a different type" and boxing the default `0`. The honest
-/// per-function `{name}DomRepr` keeps the heterogeneous variants opaque instead
-/// of forcing them into an integer carrier they cannot inhabit.
-fn adt_match_widened_plan(c: &Cert, model_info: &ModelInfo) -> Result<AdtMatchPlan, String> {
+fn render_widened_int_semantic_bridge(
+    c: &Cert,
+    model_info: &ModelInfo,
+    plan: &IntDispatchRawPlan,
+) -> String {
     let Cert::WidenedIntMatch {
         name,
-        self_idx,
         carrier,
         hit_variant_idx,
         ..
-    } = c
+    } = c.inner()
     else {
         unreachable!()
     };
-    let Some((_ty, ind, hit_ctor)) = widened_match_info(c, model_info) else {
-        return Err(format!(
-            "-- {name}: widened match info unavailable\nexample : False := by decide\n"
-        ));
+    let Some((ty, ind, hit_ctor)) = widened_match_info(c, model_info) else {
+        return format!(
+            "-- {name}: widened source model information unavailable\nexample : False := by decide\n"
+        );
     };
-    let ty = model_info
-        .fns
-        .get(name)
-        .and_then(|s| s.params.first())
-        .cloned()
-        .unwrap_or_else(|| "Op".to_string());
-    let other_idx = if *hit_variant_idx == 0 { 1 } else { 0 };
 
     let mut cases = Vec::new();
     for ctor in &ind.ctors {
+        let binders = constructor_binders(ctor.fields.len());
+        let source_ctor = constructor_application(&ctor.name, ctor.fields.len());
+        let source_value = format!("{name} ({source_ctor})");
         if ctor.name == hit_ctor {
-            cases.push(format!(
-                "      | {cn} x =>\n          simp only [{name}DomRepr] at hv\n          obtain ⟨cx, rfl, hcx⟩ := hv\n          simp [wFuncN, wRunF, {name}Code, {name}Host, b32, popArgs, initLocals] at hrun\n          subst hrun\n          simpa [{name}] using hcx",
-                cn = ctor.name,
-            ));
-        } else {
-            let binders = match ctor.fields.len() {
-                0 => String::new(),
-                1 => " x".to_string(),
-                n => " _".repeat(n),
+            let term = match render_eval_cascade_term(
+                &plan.body,
+                *hit_variant_idx,
+                "[cx]",
+                &source_value,
+                Some(("x", "cx", "hcx")),
+            ) {
+                Ok(term) => term,
+                Err(error) => return render_dispatch_bridge_failure(name, &error),
             };
             cases.push(format!(
-                "      | {cn}{binders} =>\n          simp only [{name}DomRepr] at hv\n          obtain ⟨t, fs, rfl, hne⟩ := hv\n          simp [wFuncN, wRunF, {name}Code, {name}Host, boxRef, b32, popArgs, initLocals, hne] at hrun\n          subst hrun\n          simpa [{name}] using S.smallIntro 0",
-                cn = ctor.name,
+                "  | {ctor} x =>\n      obtain ⟨cx, rfl, hcx⟩ := hv\n      refine ⟨{hit_variant_idx}, [cx], {source_value}, rfl, ?_, ?_⟩\n      · simpa [AverCert.Plans.{name}IntDispatchPlan, {name}, V3Dispatch.evalLeaf] using\n          ({term})\n      · intro w hw\n        simpa [AverCert.Schema.intRepr] using hw",
+                ctor = ctor.name,
+            ));
+        } else {
+            let term = match render_widened_miss_term(
+                &plan.body,
+                *hit_variant_idx,
+                "tag",
+                "fields",
+                &source_value,
+            ) {
+                Ok(term) => term,
+                Err(error) => return render_dispatch_bridge_failure(name, &error),
+            };
+            cases.push(format!(
+                "  | {ctor}{binders} =>\n      obtain ⟨tag, fields, rfl, hne⟩ := hv\n      refine ⟨tag, fields, {source_value}, rfl, ?_, ?_⟩\n      · simpa [AverCert.Plans.{name}IntDispatchPlan, {name}, V3Dispatch.evalLeaf] using\n          ({term})\n      · intro w hw\n        simpa [AverCert.Schema.intRepr] using hw",
+                ctor = ctor.name,
             ));
         }
     }
-    let guards = format!(
-        "example :\n    ((wFuncN {name}Code {name}HostRef 4 {self_idx}\n        [.structv {hit_variant_idx} [carrierSmall {carrier} 42]]).bind carrierToInt)\n      = some 42 := by native_decide\nexample :\n    ((wFuncN {name}Code {name}HostRef 4 {self_idx}\n        [.structv {other_idx} []]).bind carrierToInt)\n      = some 0 := by native_decide"
+
+    format!(
+        r#"/-! ### {name} — option-(b) widened-Int semantic bridge -/
+
+theorem {name}_intDispatchSemanticBridge :
+    ∀ (S : CarrierSpec {carrier}) (x : {ty}) (vs : List WVal),
+      (∃ v, vs = [v] ∧ {name}DomRepr S x v) →
+      ∃ tag fields n,
+        vs = [.structv tag fields] ∧
+        V3Dispatch.EvalCascade S
+          AverCert.Plans.{name}IntDispatchPlan.body tag fields n ∧
+        ∀ w, S.Repr n w → AverCert.Schema.intRepr S ({name} x) w := by
+  intro S x vs hDom
+  obtain ⟨v, rfl, hv⟩ := hDom
+  cases x with
+{cases}
+
+#print axioms {name}_intDispatchSemanticBridge
+"#,
+        cases = cases.join("\n"),
+    )
+}
+
+fn render_eval_cascade_term(
+    cascade: &IntDispatchCascade,
+    tag: u32,
+    fields: &str,
+    result: &str,
+    payload: Option<(&str, &str, &str)>,
+) -> Result<String, String> {
+    match cascade {
+        IntDispatchCascade::Default(k) => Ok(format!(
+            "V3Dispatch.EvalCascade.default ({k}) {tag} {fields}"
+        )),
+        IntDispatchCascade::Test {
+            ty_idx,
+            hit,
+            rest,
+        } if *ty_idx == tag => {
+            let Some((x, cx, hcx)) = payload else {
+                return Err(format!(
+                    "dispatch tag {tag} selects a payload leaf for a non-payload constructor"
+                ));
+            };
+            Ok(format!(
+                "V3Dispatch.EvalCascade.hit {ty_idx} ({leaf}) ({rest}) {fields} {x} {cx} rfl {hcx}",
+                leaf = int_dispatch_leaf_lean_value(hit),
+                rest = int_dispatch_cascade_lean_value(rest),
+            ))
+        }
+        IntDispatchCascade::Test {
+            ty_idx,
+            hit,
+            rest,
+        } => {
+            let tail = render_eval_cascade_term(rest, tag, fields, result, payload)?;
+            Ok(format!(
+                "V3Dispatch.EvalCascade.miss {ty_idx} {tag} ({leaf}) ({rest}) {fields} ({result}) (by decide) ({tail})",
+                leaf = int_dispatch_leaf_lean_value(hit),
+                rest = int_dispatch_cascade_lean_value(rest),
+            ))
+        }
+    }
+}
+
+fn render_widened_miss_term(
+    cascade: &IntDispatchCascade,
+    hit_tag: u32,
+    tag: &str,
+    fields: &str,
+    result: &str,
+) -> Result<String, String> {
+    let IntDispatchCascade::Test {
+        ty_idx,
+        hit,
+        rest,
+    } = cascade
+    else {
+        return Err("widened plan has no test root".to_string());
+    };
+    if *ty_idx != hit_tag || !matches!(rest.as_ref(), IntDispatchCascade::Default(0)) {
+        return Err("widened plan is not one projected hit plus default zero".to_string());
+    }
+    Ok(format!(
+        "V3Dispatch.EvalCascade.miss {ty_idx} {tag} ({leaf}) ({rest}) {fields} ({result}) hne (V3Dispatch.EvalCascade.default (0) {tag} {fields})",
+        leaf = int_dispatch_leaf_lean_value(hit),
+        rest = int_dispatch_cascade_lean_value(rest),
+    ))
+}
+
+fn constructor_binders(field_count: usize) -> String {
+    match field_count {
+        0 => String::new(),
+        1 => " x".to_string(),
+        count => (0..count).map(|i| format!(" x{i}")).collect::<String>(),
+    }
+}
+
+fn constructor_application(name: &str, field_count: usize) -> String {
+    match field_count {
+        0 => format!(".{name}"),
+        1 => format!(".{name} x"),
+        count => format!(
+            ".{name} {}",
+            (0..count)
+                .map(|i| format!("x{i}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        ),
+    }
+}
+
+fn render_dispatch_bridge_failure(name: &str, error: &str) -> String {
+    format!("-- {name}: {error}\nexample : False := by decide\n")
+}
+
+/// The option-(b) final arm for one model-bearing Int dispatch.  All byte and
+/// host facts reduce from emitted data; the only non-canonical argument is the
+/// generated source-model semantic bridge in `Certificate.lean`.
+fn render_int_dispatch_final_arm(
+    c: &Cert,
+    model_info: &ModelInfo,
+    strict: FragHostTable,
+) -> String {
+    let plan = int_dispatch_plan_from_cert(c, strict)
+        .expect("certified Int dispatch must carry a byte-matching plan");
+    let hosts = int_dispatch_host_table_from_cert(c)
+        .expect("certified Int dispatch must carry a host-role table");
+    let IntDispatchCascade::Test {
+        ty_idx,
+        hit,
+        rest,
+    } = &plan.body
+    else {
+        unreachable!("classified Int dispatch always has a test root")
+    };
+    let root = format!(
+        "⟨{ty_idx}, ({}), ({}), rfl⟩",
+        int_dispatch_leaf_lean_value(hit),
+        int_dispatch_cascade_lean_value(rest),
     );
-    Ok(AdtMatchPlan {
-        doc_title: format!(
-            "/-! ### {name} — widened Int match certificate (carrier type {carrier}) -/"
-        ),
-        header: format!("theorem {name}_wasm_certified (S : CarrierSpec {carrier})"),
-        ty,
-        repr: format!("{name}DomRepr"),
-        host_term: format!("{name}Host"),
-        host_ref_def: format!(
-            "-- Executable tripwires: the projected variant reads its carrier, every other\n-- variant boxes the default `0`. A trapping body yields `none`, forcing a run.\ndef {name}HostRef : HostTbl := {name}Host"
-        ),
-        cases: cases.join("\n"),
-        guards,
-        sim_cite: format!("{name}_wasm_certified S fuel o v w hv hrun"),
-    })
+    let (name, carrier, self_idx, ops, dom, dom_repr) = match c.inner() {
+        Cert::VariantDispatch {
+            name,
+            carrier,
+            self_idx,
+            ops,
+            ..
+        } => {
+            let ty = model_info
+                .fns
+                .get(name)
+                .and_then(|sig| sig.params.first())
+                .expect("variant dispatch model parameter type");
+            (
+                name,
+                *carrier,
+                *self_idx,
+                ops,
+                ty.clone(),
+                format!("fun S o vs => ∃ v, vs = [v] ∧ {ty}Repr S o v"),
+            )
+        }
+        Cert::WidenedIntMatch {
+            name,
+            carrier,
+            self_idx,
+            ops,
+            ..
+        } => {
+            let ty = model_info
+                .fns
+                .get(name)
+                .and_then(|sig| sig.params.first())
+                .expect("widened dispatch model parameter type");
+            (
+                name,
+                *carrier,
+                *self_idx,
+                ops,
+                ty.clone(),
+                format!("fun S o vs => ∃ v, vs = [v] ∧ {name}DomRepr S o v"),
+            )
+        }
+        _ => unreachable!(),
+    };
+    let host_table = int_dispatch_host_table_lean_value(&hosts);
+    let host = c.host_expr();
+    let body = render_ops_value(ops);
+    format!(
+        "exact V3Master.intDispatch_canonical_discharges \
+         (exportName := \"{name}\") (carrier := {carrier}) (self := {self_idx}) \
+         (plan := AverCert.Plans.{name}IntDispatchPlan) \
+         (hostTable := {host_table}) (code := CertModule.{name}Code) \
+         (host := {host}) (Dom := {dom}) (domRepr := {dom_repr}) (model := {name}) \
+         (hRaw := by rfl) (hDistinct := by rfl) (hHost := by intros; rfl) \
+         (hRoot := by exact {root}) (body := {body}) \
+         (hLow := by rfl) (hCode := by rfl) \
+         (hSemantic := CertProofs.{name}_intDispatchSemanticBridge)"
+    )
 }

--- a/src/codegen/cert/render_adt_constructor.rs
+++ b/src/codegen/cert/render_adt_constructor.rs
@@ -1,0 +1,50 @@
+fn render_adt_constructor_cert(c: &Cert, model_info: &ModelInfo) -> String {
+    let c = c.inner();
+    let Cert::AdtConstructor {
+        name,
+        self_idx,
+        carrier,
+        struct_idx,
+        ..
+    } = c
+    else {
+        unreachable!()
+    };
+    debug_assert!(adt_constructor_uses_model(c, model_info));
+    let sig = model_info.fns.get(name);
+    let _ = sig
+        .and_then(|s| model_info.inductives.get(&s.ret))
+        .and_then(|i| i.ctors.first());
+    format!(
+        r#"/-! ### {name} — ADT constructor certificate (carrier type {carrier}) -/
+
+theorem {name}_wasm_certified (host : HostTbl) :
+    ∀ (v : WVal), wFuncN {name}Code host 1 {self_idx} [v] = some (.structv {struct_idx} [v]) := by
+  intro v
+  simp [wFuncN, {name}Code, wRunF, popArgs, initLocals]
+
+#print axioms {name}_wasm_certified
+
+-- Executable tripwire: run the constructor on an Int 7 and decode field 0 of the
+-- built struct back to `some 7`. Unlike a bare `= none` (which a TRAP also
+-- satisfies), this forces the emitted body to genuinely pack its argument.
+example :
+    ((wFuncN {name}Code {name}Host 1 {self_idx} [carrierSmall {carrier} 7]).bind
+      (fun r => match r with
+        | .structv _ (f :: _) => carrierToInt f
+        | _ => none))
+      = some 7 := by native_decide
+
+theorem {name}_simulates : AverCert.Schema.Obligation.holds {name}Ob := by
+  intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel n vs w hrepr hrun
+  simp only [{name}Ob, AverCert.Schema.Obligation.holds] at hrun ⊢
+  obtain ⟨v, rfl, hv⟩ := hrepr
+  cases fuel with
+  | zero => simp [wFuncN] at hrun
+  | succ f =>
+      simp [wFuncN, wRunF, {name}Code, popArgs, initLocals] at hrun
+      subst hrun
+      exact ⟨v, rfl, by simpa [AverCert.Schema.intRepr] using hv⟩
+"#
+    )
+}

--- a/src/codegen/cert/render_certificate.rs
+++ b/src/codegen/cert/render_certificate.rs
@@ -4,7 +4,9 @@ fn render_certificate(
     model_info: &ModelInfo,
 ) -> String {
     let mut s = String::new();
-    s.push_str("import CertPrelude\nimport Module\nimport Schema\nimport Manifest\n");
+    s.push_str(
+        "import CertPrelude\nimport Module\nimport Schema\nimport Manifest\nimport V3DispatchCore\n",
+    );
     for r in model_roots {
         s.push_str(&format!("import {r}\n"));
     }
@@ -30,7 +32,11 @@ fn render_certificate(
             // Its plan, obligation and claim data remain emitted unchanged.
             Cert::FieldProjection { .. } => {}
             Cert::WidenedIntMatch { .. } | Cert::VariantDispatch { .. } => {
-                s.push_str(&render_adt_match_cert(c, model_info))
+                s.push_str(&render_int_dispatch_semantic_bridge(
+                    c,
+                    model_info,
+                    analysis.frag_host_table,
+                ))
             }
             Cert::ExprFragment { .. } => s.push_str(&render_expr_fragment_cert(c)),
             // Verbatim and String families are discharged by their audited

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -510,12 +510,12 @@ fn render_manifest_lean(
 }
 
 /// The single final theorem: `AverCert.Final.cert : Holds manifest`, proved by
-/// composing the per-export `_simulates` obligations. No other final theorem is
-/// emitted; the checker pins this exact statement line.
+/// composing audited generic discharges with the residual bespoke families.
+/// No other final theorem is emitted; the checker pins this exact statement.
 fn render_final(analysis: &Analysis, model_info: &ModelInfo) -> String {
     let mut s = String::new();
     s.push_str(
-        "import Certificate\nimport Manifest\nimport Schema\nimport V3DischargeFieldProj\nimport V3DischargeConstruct\nimport V3DischargeVerbatim\nimport V3DischargeString\n\n\
+        "import Certificate\nimport Manifest\nimport Schema\nimport V3DischargeFieldProj\nimport V3DischargeConstruct\nimport V3DischargeVerbatim\nimport V3DischargeString\nimport V3DischargeIntDispatch\n\n\
          set_option maxRecDepth 1000000\n\
          set_option linter.unusedSimpArgs false\n\n\
          open AverCert AverCert.Schema\n\n",
@@ -576,6 +576,16 @@ fn render_final(analysis: &Analysis, model_info: &ModelInfo) -> String {
                          AverCert.Plans.{name}FieldProjectionPlan \
                         CertModule.{name}Code \
                          (fun _ _ _ _ _ => CertModule.{name}Host) (by rfl) (by rfl)"
+                    );
+                }
+                if matches!(
+                    c.inner(),
+                    Cert::VariantDispatch { .. } | Cert::WidenedIntMatch { .. }
+                ) {
+                    return render_int_dispatch_final_arm(
+                        c,
+                        model_info,
+                        analysis.frag_host_table,
                     );
                 }
                 if let Cert::AdtConstructor {
@@ -1128,6 +1138,11 @@ fn render_manifest(
             "V3Master.stringEq_canonical_discharges".to_string()
         } else if matches!(c.inner(), Cert::StringConcatVerbatimMatch { .. }) {
             "V3Master.stringConcat_canonical_discharges".to_string()
+        } else if matches!(
+            c.inner(),
+            Cert::VariantDispatch { .. } | Cert::WidenedIntMatch { .. }
+        ) {
+            "V3Master.intDispatch_canonical_discharges".to_string()
         } else {
             let theorem_suffix = if policy == CertificationPolicy::SimulatesModelTotally {
                 "wasm_total"

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -161,8 +161,10 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
     );
     assert_eq!(
         manifest["schema_version"].as_u64(),
-        Some(u64::from(aver::codegen::cert::CERT_SCHEMA_VERSION))
+        Some(57),
+        "dispatch option-(b) migration is certificate schema 57"
     );
+    assert_eq!(aver::codegen::cert::CERT_SCHEMA_VERSION, 57);
     let declared_uncertified = manifest["declaredUncertified"].as_array().unwrap();
     assert_eq!(
         declared_uncertified.len(),
@@ -740,10 +742,18 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             "migrated leaf arm must use the audited generic: {name}\n{final_lean}"
         );
     }
-    for bespoke_name in ["addTwo", "sumFrom", "countDown", "mkOp", "evalOp"] {
+    for dispatch_name in ["evalOp", "boxInt", "gauge"] {
+        assert!(
+            final_lean.contains(&format!(
+                "V3Master.intDispatch_canonical_discharges (exportName := \"{dispatch_name}\")"
+            )),
+            "dispatch arm must use the audited generic: {dispatch_name}\n{final_lean}"
+        );
+    }
+    for bespoke_name in ["addTwo", "sumFrom", "countDown", "mkOp"] {
         assert!(
             final_lean.contains(&format!("CertProofs.{bespoke_name}_")),
-            "non-projection arm changed during coexistence migration: {bespoke_name}\n{final_lean}"
+            "unmigrated arm changed during coexistence migration: {bespoke_name}\n{final_lean}"
         );
     }
     let certificate = std::fs::read_to_string(cert_dir.join("Certificate.lean"))
@@ -758,9 +768,23 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             && !certificate.contains("quoteOrSelf_wasm_certified")
             && !certificate.contains("quoteOrSelf_simulates")
             && !certificate.contains("shout_wasm_certified")
-            && !certificate.contains("shout_simulates"),
-        "migrated leaf families must not emit bespoke proofs:\n{certificate}"
+            && !certificate.contains("shout_simulates")
+            && !certificate.contains("evalOp_wasm_certified")
+            && !certificate.contains("evalOp_simulates")
+            && !certificate.contains("boxInt_wasm_certified")
+            && !certificate.contains("boxInt_simulates")
+            && !certificate.contains("gauge_wasm_certified")
+            && !certificate.contains("gauge_simulates"),
+        "migrated leaf/dispatch families must not emit bespoke simulations:\n{certificate}"
     );
+    for dispatch_name in ["evalOp", "boxInt", "gauge"] {
+        assert!(
+            certificate.contains(&format!(
+                "theorem {dispatch_name}_intDispatchSemanticBridge"
+            )),
+            "dispatch must emit its option-(b) source-model bridge: {dispatch_name}\n{certificate}"
+        );
+    }
     let user_name = manifest["certified"]
         .as_array()
         .unwrap()
@@ -784,6 +808,18 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             .find(|entry| entry["name"] == name)
             .unwrap();
         assert_eq!(entry["theorem"], theorem);
+    }
+    for name in ["evalOp", "boxInt", "gauge"] {
+        let entry = manifest["certified"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap();
+        assert_eq!(
+            entry["theorem"],
+            "V3Master.intDispatch_canonical_discharges"
+        );
     }
 
     let started = std::time::Instant::now();
@@ -853,7 +889,7 @@ example :
 }
 
 #[test]
-fn cert_verify_declines_hostile_verbatim_and_string_models() {
+fn cert_verify_declines_hostile_leaf_and_dispatch_models() {
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping hostile leaf-model test: `lake` not available");
         return;
@@ -898,6 +934,7 @@ fn cert_verify_declines_hostile_verbatim_and_string_models() {
             "model := quoteOrSelfModel }",
             "model := shoutModel }",
         ),
+        ("dispatch", "model := gauge }", "model := fun _ => 0 }"),
     ] {
         let tampered = temp_dir(&format!("certify-hostile-{label}-model"));
         copy_dir_all(&out_dir, &tampered);
@@ -914,7 +951,7 @@ fn cert_verify_declines_hostile_verbatim_and_string_models() {
             verify_certificate(&tampered.join("cert_goals.wasm"), &tampered.join("cert"));
         assert!(
             !ok && report.contains("DECLINED") && !report.contains("CERTIFIED"),
-            "wrong canonical {label} model must be DECLINED:\n{report}"
+            "wrong {label} model must make its emitted bridge fail and be DECLINED:\n{report}"
         );
         let _ = std::fs::remove_dir_all(&tampered);
     }
@@ -1930,6 +1967,11 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
             "signal-gauge",
             vec!["gauge"],
         ),
+        (
+            "tools/certkit/fixtures/intdispatchgen.av",
+            "int-dispatch-gen",
+            vec!["boxInt", "gauge"],
+        ),
         // Payload-first subtraction, constant-first addition, and payload
         // variants elided into the wildcard default.
         ("tools/certkit/fixtures/meter.av", "meter", vec!["readout"]),
@@ -1971,6 +2013,42 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
                 certified.contains(&name),
                 "expected {name} certified for {input}, got {certified:?}"
             );
+        }
+        let dispatch_entries = manifest["certified"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|entry| {
+                matches!(
+                    entry["class"].as_str(),
+                    Some("variant-dispatch" | "widened-int-match")
+                )
+            })
+            .collect::<Vec<_>>();
+        if !dispatch_entries.is_empty() {
+            let final_lean =
+                std::fs::read_to_string(cert_dir.join("Final.lean")).expect("Final.lean exists");
+            let certificate = std::fs::read_to_string(cert_dir.join("Certificate.lean"))
+                .expect("Certificate.lean exists");
+            for entry in &dispatch_entries {
+                let name = entry["name"].as_str().unwrap();
+                assert_eq!(
+                    entry["theorem"],
+                    "V3Master.intDispatch_canonical_discharges"
+                );
+                assert!(
+                    final_lean.contains(&format!(
+                        "V3Master.intDispatch_canonical_discharges (exportName := \"{name}\")"
+                    )) && final_lean.contains("(hRoot := by exact ⟨"),
+                    "dispatch Final.cert arm must pass the audited discharge and root witness for {name}:\n{final_lean}"
+                );
+                assert!(
+                    certificate.contains(&format!("theorem {name}_intDispatchSemanticBridge"))
+                        && !certificate.contains(&format!("{name}_wasm_certified"))
+                        && !certificate.contains(&format!("{name}_simulates")),
+                    "dispatch must emit only its option-(b) bridge for {name}:\n{certificate}"
+                );
+            }
         }
         if prefix == "tuple-proj" {
             let entries = manifest["certified"].as_array().unwrap();
@@ -2019,12 +2097,12 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
             !combined.contains("sorryAx"),
             "ADT certificate leaked sorryAx for {input}:\n{combined}"
         );
-        if prefix == "tuple-proj" {
+        if prefix == "tuple-proj" || !dispatch_entries.is_empty() {
             assert!(
                 combined.contains(
                     "'AverCert.Final.cert' depends on axioms: [propext, Classical.choice, Quot.sound]"
                 ),
-                "generic field-projection holds proofs changed axiom surface:\n{combined}"
+                "generic field-projection/dispatch holds proofs changed axiom surface:\n{combined}"
             );
         }
 


### PR DESCRIPTION
## Summary
- Migrates the dispatch families (variant-dispatch, widened-integer, integer-dispatch) — the **first model-bearing families** (option-b). Their model is the user's source function, so the semantic bridge (model = plan-derived cascade evaluator under codRepr) is discharged by a **small per-obligation proof** the compiler emits (cases-on-source, 32-60 lines / 1.7-3.5 KB), not a byte-forced face pin. The interpreter/fuel/byte reasoning that bespoke proofs carried now lives in the audited generic. Bespoke dispatch proof emission deleted.
- **Hostile-model tamper** (gauge's model → constant) is DECLINED — the emitted bridge genuinely constrains.
- **Coexistence** preserved: dispatch + migrated leaves + un-migrated recursion/mutual/composition all certify. Verified end-to-end: signalgauge/widenedmatch/intdispatchgen (dispatch), cert_goals (23 mixed), json (12/L1 — dispatch migrated + string/recursion).
- Certificate schema bumps to 57.

## Testing
- fmt, build (wasm); cert_certify_spec (13, incl. dispatch hostile decline), cert_decode_spec (8), cert_whole_module_guard_iso (5) — serial.
- End-to-end certify+verify: all fixtures CERTIFIED at unchanged counts/levels; hostile dispatch model → DECLINE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)