### PR TITLE
Derive construct-with-model conformance from the audited generic

### DIFF
--- a/src/codegen/cert/V3DischargeConstruct.lean
+++ b/src/codegen/cert/V3DischargeConstruct.lean
@@ -136,6 +136,67 @@ private theorem construct_run_succ_eq_one
   rw [hFuel, hOne]
   simp [wRunF]
 
+/-- Per-obligation option-(b) discharge for a concrete model-bearing
+constructor export. The checked plan, canonical lowering, and code binding are
+data; `hSemantic` is the intentionally residual bridge from the named source
+model to the exact plan-derived constructed value. -/
+theorem construct_canonical_discharges
+    (exportName : String) (carrier structIdx self : Nat)
+    (plan : ConstructRawPlan) (code : CodeTbl)
+    (host :
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (List WVal → Option WVal) →
+      (Nat → List WVal → Option WVal) → HostTbl)
+    (Dom Cod : Type)
+    (domRepr : CarrierSpec carrier → Dom → List WVal → Prop)
+    (codRepr : CarrierSpec carrier → Cod → WVal → Prop)
+    (model : Dom → Cod)
+    (hCheck : AverCert.PlanCheck.checkConstructRawPlan plan = true)
+    (body : List WInstr)
+    (hLow : AverCert.PlanLower.lowerConstructBody structIdx plan = some body)
+    (hCode : code self = some
+      { arity := plan.arity, nlocals := 1, body := body })
+    (hSemantic : ∀ (S : CarrierSpec carrier) (x : Dom) (args : List WVal),
+      domRepr S x args →
+      args.length = plan.arity ∧
+      codRepr S (model x)
+        (.structv structIdx
+          (V3ConstructVerbatim.constructModelFields
+            (args ++ List.replicate 1 .null) plan.fields))) :
+    Obligation.holds
+      ({ export_ := exportName
+         policy := .simulatesModel
+         carrier := carrier
+         code := code
+         host := host
+         self := self
+         Dom := Dom
+         Cod := Cod
+         domRepr := domRepr
+         codRepr := codRepr
+         model := model } : Obligation) := by
+  intro S add sub mul stringEq stringConcat
+    _hAdd _hSub _hMul _hStringEq _hStringConcat fuel x args w hDom hRun
+  rcases hSemantic S x args hDom with ⟨hLen, hCod⟩
+  cases fuel with
+  | zero => simp [wFuncN] at hRun
+  | succ fuel =>
+      have hCall := V3ConstructVerbatim.generic_construct_certified
+        structIdx plan code (host add sub mul stringEq stringConcat) self 1
+        hCheck body hLow hCode args hLen
+      have hFuel := construct_run_succ_eq_one
+        structIdx plan code (host add sub mul stringEq stringConcat) self
+        hCheck body hLow hCode fuel args hLen
+      rw [hFuel, hCall] at hRun
+      have hw :
+          .structv structIdx
+            (V3ConstructVerbatim.constructModelFields
+              (args ++ List.replicate 1 .null) plan.fields) = w :=
+        Option.some.inj hRun
+      simpa [← hw] using hCod
+
 /-- Canonical option-(c) leaf bridge for a unary verbatim constructor pack. -/
 theorem constructUnary_canonical_discharges
     (exportName : String) (carrier structIdx self : Nat)
@@ -297,6 +358,7 @@ theorem construct_discharges
 end V3Master
 
 #print axioms V3Master.construct_accepted_call
+#print axioms V3Master.construct_canonical_discharges
 #print axioms V3Master.constructUnary_canonical_discharges
 #print axioms V3Master.constructBinary_canonical_discharges
 #print axioms V3Master.construct_claim_discharges

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -85,7 +85,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 57;
+pub const CERT_SCHEMA_VERSION: u32 = 58;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/cert/render_adt_constructor.rs
+++ b/src/codegen/cert/render_adt_constructor.rs
@@ -1,8 +1,11 @@
-fn render_adt_constructor_cert(c: &Cert, model_info: &ModelInfo) -> String {
+/// Option-(b) residual for one model-bearing ADT constructor. The generated
+/// theorem relates the named source model to the plan-derived constructed
+/// value; byte lowering, host simulation and fuel reasoning live in the
+/// audited `V3ConstructVerbatim` / `V3DischargeConstruct` wall.
+fn render_adt_constructor_semantic_bridge(c: &Cert, model_info: &ModelInfo) -> String {
     let c = c.inner();
     let Cert::AdtConstructor {
         name,
-        self_idx,
         carrier,
         struct_idx,
         ..
@@ -11,40 +14,75 @@ fn render_adt_constructor_cert(c: &Cert, model_info: &ModelInfo) -> String {
         unreachable!()
     };
     debug_assert!(adt_constructor_uses_model(c, model_info));
-    let sig = model_info.fns.get(name);
-    let _ = sig
-        .and_then(|s| model_info.inductives.get(&s.ret))
-        .and_then(|i| i.ctors.first());
+    let sig = model_info
+        .fns
+        .get(name)
+        .expect("model-bearing ADT constructor has a source signature");
+    let ret = &sig.ret;
+
     format!(
-        r#"/-! ### {name} — ADT constructor certificate (carrier type {carrier}) -/
+        r#"/-! ### {name} — option-(b) constructor semantic bridge -/
 
-theorem {name}_wasm_certified (host : HostTbl) :
-    ∀ (v : WVal), wFuncN {name}Code host 1 {self_idx} [v] = some (.structv {struct_idx} [v]) := by
-  intro v
-  simp [wFuncN, {name}Code, wRunF, popArgs, initLocals]
+theorem {name}_constructSemanticBridge :
+    ∀ (S : CarrierSpec {carrier}) (n : Int) (args : List WVal),
+      (∃ v, args = [v] ∧ AverCert.Schema.intRepr S n v) →
+      args.length = AverCert.Plans.{name}ConstructPlan.arity ∧
+      {ret}Repr S ({name} n)
+        (.structv {struct_idx}
+          (V3ConstructVerbatim.constructModelFields
+            (args ++ List.replicate 1 .null)
+            AverCert.Plans.{name}ConstructPlan.fields)) := by
+  intro S n args hDom
+  obtain ⟨v, rfl, hv⟩ := hDom
+  constructor
+  · rfl
+  · cases n <;>
+      simpa [{name}, AverCert.Plans.{name}ConstructPlan,
+        V3ConstructVerbatim.constructModelFields,
+        V3ConstructVerbatim.constructModelField, {ret}Repr,
+        AverCert.Schema.intRepr] using hv
 
-#print axioms {name}_wasm_certified
-
--- Executable tripwire: run the constructor on an Int 7 and decode field 0 of the
--- built struct back to `some 7`. Unlike a bare `= none` (which a TRAP also
--- satisfies), this forces the emitted body to genuinely pack its argument.
-example :
-    ((wFuncN {name}Code {name}Host 1 {self_idx} [carrierSmall {carrier} 7]).bind
-      (fun r => match r with
-        | .structv _ (f :: _) => carrierToInt f
-        | _ => none))
-      = some 7 := by native_decide
-
-theorem {name}_simulates : AverCert.Schema.Obligation.holds {name}Ob := by
-  intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel n vs w hrepr hrun
-  simp only [{name}Ob, AverCert.Schema.Obligation.holds] at hrun ⊢
-  obtain ⟨v, rfl, hv⟩ := hrepr
-  cases fuel with
-  | zero => simp [wFuncN] at hrun
-  | succ f =>
-      simp [wFuncN, wRunF, {name}Code, popArgs, initLocals] at hrun
-      subst hrun
-      exact ⟨v, rfl, by simpa [AverCert.Schema.intRepr] using hv⟩
+#print axioms {name}_constructSemanticBridge
 "#
+    )
+}
+
+/// The option-(b) final arm for one model-bearing ADT constructor. All byte
+/// and plan facts reduce from emitted data; the only non-canonical argument is
+/// the generated source-model semantic bridge in `Certificate.lean`.
+fn render_adt_constructor_final_arm(c: &Cert, model_info: &ModelInfo) -> String {
+    let c = c.inner();
+    let Cert::AdtConstructor {
+        name,
+        self_idx,
+        carrier,
+        struct_idx,
+        ops,
+        ..
+    } = c
+    else {
+        unreachable!()
+    };
+    debug_assert!(adt_constructor_uses_model(c, model_info));
+    let sig = model_info
+        .fns
+        .get(name)
+        .expect("model-bearing ADT constructor has a source signature");
+    let ret = &sig.ret;
+    let body = render_ops_value(ops);
+
+    format!(
+        "exact V3Master.construct_canonical_discharges \
+         (exportName := \"{name}\") (carrier := {carrier}) \
+         (structIdx := {struct_idx}) (self := {self_idx}) \
+         (plan := AverCert.Plans.{name}ConstructPlan) \
+         (code := CertModule.{name}Code) \
+         (host := fun _ _ _ _ _ => CertModule.{name}Host) \
+         (Dom := Int) (Cod := {ret}) \
+         (domRepr := fun S n args => ∃ v, args = [v] ∧ AverCert.Schema.intRepr S n v) \
+         (codRepr := fun S x w => {ret}Repr S x w) (model := {name}) \
+         (hCheck := by rfl) (body := {body}) \
+         (hLow := by rfl) (hCode := by rfl) \
+         (hSemantic := CertProofs.{name}_constructSemanticBridge)"
     )
 }

--- a/src/codegen/cert/render_certificate.rs
+++ b/src/codegen/cert/render_certificate.rs
@@ -22,10 +22,11 @@ fn render_certificate(
                 s.push_str(&render_fueled_recursion_cert(c))
             }
             Cert::AdtConstructor { .. } if adt_constructor_uses_model(c, model_info) => {
-                s.push_str(&render_adt_constructor_cert(c, model_info))
+                s.push_str(&render_adt_constructor_semantic_bridge(c, model_info))
             }
             // Verbatim constructor packs are option-(c) leaves discharged in
-            // `Final.cert`; model-bearing constructors keep their bespoke arm.
+            // `Final.cert`; model-bearing constructors emit only their option-(b)
+            // source-model bridge above.
             Cert::AdtConstructor { .. } => {}
             // The field-projection family is discharged in `Final.cert` by the
             // audited v3 generic plus its canonical option-(c) leaf bridge.

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -39,19 +39,9 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
         );
     }
     match c.inner() {
-        Cert::AdtConstructor {
-            struct_idx,
-            field_count,
-            ..
-        } if adt_constructor_uses_model(c, model_info) => {
+        Cert::AdtConstructor { .. } if adt_constructor_uses_model(c, model_info) => {
             let sig = model_info.fns.get(name);
             let ret = sig.map(|s| s.ret.as_str()).unwrap_or("Unit");
-            let ctor = sig
-                .and_then(|s| model_info.inductives.get(&s.ret))
-                .and_then(|i| i.ctors.first())
-                .map(|c| c.name.as_str())
-                .unwrap_or("mk");
-            let _ = (struct_idx, field_count);
             format!(
                 "abbrev {name}Ob : Schema.Obligation :=\n  \
                  {{ export_ := \"{name}\", policy := .simulatesModel, carrier := {carrier},\n    \
@@ -59,7 +49,7 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
                  Dom := Int, Cod := {ret},\n    \
                  domRepr := fun S n vs => ∃ v, vs = [v] ∧ intRepr S n v,\n    \
                  codRepr := fun S x w => {ret}Repr S x w,\n    \
-                 model := fun n => {ret}.{ctor} n }}\n\n",
+                 model := {name} }}\n\n",
                 carrier = c.carrier(),
                 host = c.host_expr(),
                 self_idx = c.self_idx(),
@@ -587,6 +577,11 @@ fn render_final(analysis: &Analysis, model_info: &ModelInfo) -> String {
                         model_info,
                         analysis.frag_host_table,
                     );
+                }
+                if matches!(c.inner(), Cert::AdtConstructor { .. })
+                    && adt_constructor_uses_model(c, model_info)
+                {
+                    return render_adt_constructor_final_arm(c, model_info);
                 }
                 if let Cert::AdtConstructor {
                     name,
@@ -1121,6 +1116,10 @@ fn render_manifest(
             "V3Master.fieldProjection_direct_canonical_discharges".to_string()
         } else if matches!(c.inner(), Cert::FieldProjection { .. }) {
             "V3Master.fieldProjection_canonical_discharges".to_string()
+        } else if matches!(c.inner(), Cert::AdtConstructor { .. })
+            && adt_constructor_uses_model(c, model_info)
+        {
+            "V3Master.construct_canonical_discharges".to_string()
         } else if let Cert::AdtConstructor { arity, .. } = c.inner()
             && !adt_constructor_uses_model(c, model_info)
         {

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -161,10 +161,10 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
     );
     assert_eq!(
         manifest["schema_version"].as_u64(),
-        Some(57),
-        "dispatch option-(b) migration is certificate schema 57"
+        Some(58),
+        "construct option-(b) migration is certificate schema 58"
     );
-    assert_eq!(aver::codegen::cert::CERT_SCHEMA_VERSION, 57);
+    assert_eq!(aver::codegen::cert::CERT_SCHEMA_VERSION, 58);
     let declared_uncertified = manifest["declaredUncertified"].as_array().unwrap();
     assert_eq!(
         declared_uncertified.len(),
@@ -750,7 +750,12 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             "dispatch arm must use the audited generic: {dispatch_name}\n{final_lean}"
         );
     }
-    for bespoke_name in ["addTwo", "sumFrom", "countDown", "mkOp"] {
+    assert!(
+        final_lean.contains("V3Master.construct_canonical_discharges (exportName := \"mkOp\")")
+            && final_lean.contains("(hSemantic := CertProofs.mkOp_constructSemanticBridge)"),
+        "construct-with-model arm must use the audited discharge and emitted bridge:\n{final_lean}"
+    );
+    for bespoke_name in ["addTwo", "sumFrom", "countDown"] {
         assert!(
             final_lean.contains(&format!("CertProofs.{bespoke_name}_")),
             "unmigrated arm changed during coexistence migration: {bespoke_name}\n{final_lean}"
@@ -774,8 +779,10 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             && !certificate.contains("boxInt_wasm_certified")
             && !certificate.contains("boxInt_simulates")
             && !certificate.contains("gauge_wasm_certified")
-            && !certificate.contains("gauge_simulates"),
-        "migrated leaf/dispatch families must not emit bespoke simulations:\n{certificate}"
+            && !certificate.contains("gauge_simulates")
+            && !certificate.contains("mkOp_wasm_certified")
+            && !certificate.contains("mkOp_simulates"),
+        "migrated leaf/dispatch/construct families must not emit bespoke simulations:\n{certificate}"
     );
     for dispatch_name in ["evalOp", "boxInt", "gauge"] {
         assert!(
@@ -785,6 +792,12 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             "dispatch must emit its option-(b) source-model bridge: {dispatch_name}\n{certificate}"
         );
     }
+    assert!(
+        certificate.contains("theorem mkOp_constructSemanticBridge")
+            && certificate.contains("cases n")
+            && certificate.contains("V3ConstructVerbatim.constructModelFields"),
+        "construct-with-model must emit only its small source-model bridge:\n{certificate}"
+    );
     let user_name = manifest["certified"]
         .as_array()
         .unwrap()
@@ -795,6 +808,13 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
         user_name["theorem"],
         "V3Master.fieldProjection_direct_canonical_discharges"
     );
+    let mk_op = manifest["certified"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["name"] == "mkOp")
+        .unwrap();
+    assert_eq!(mk_op["theorem"], "V3Master.construct_canonical_discharges");
     for (name, theorem) in [
         ("wrapItems", "V3Master.verbatim_canonical_discharges"),
         ("tagName", "V3Master.verbatim_canonical_discharges"),
@@ -889,7 +909,7 @@ example :
 }
 
 #[test]
-fn cert_verify_declines_hostile_leaf_and_dispatch_models() {
+fn cert_verify_declines_hostile_leaf_dispatch_and_construct_models() {
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping hostile leaf-model test: `lake` not available");
         return;
@@ -955,6 +975,32 @@ fn cert_verify_declines_hostile_leaf_and_dispatch_models() {
         );
         let _ = std::fs::remove_dir_all(&tampered);
     }
+
+    let tampered = temp_dir("certify-hostile-construct-model-definition");
+    copy_dir_all(&out_dir, &tampered);
+    let model = tampered.join("cert/CertGoals.lean");
+    let source = std::fs::read_to_string(&model).unwrap();
+    let honest = "def mkOp (n : Int) : Op :=\n  Op.add n";
+    let hostile = "def mkOp (n : Int) : Op :=\n  Op.neg n";
+    let edited = source.replacen(honest, hostile, 1);
+    assert_ne!(
+        source, edited,
+        "construct model definition changed; update the hostile-model regression"
+    );
+    std::fs::write(&model, edited).unwrap();
+    let manifest = std::fs::read_to_string(tampered.join("cert/Manifest.lean")).unwrap();
+    assert!(
+        manifest.contains("model := mkOp }"),
+        "construct hostile regression must leave the manifest model reference untouched"
+    );
+
+    let (ok, report) =
+        verify_certificate(&tampered.join("cert_goals.wasm"), &tampered.join("cert"));
+    assert!(
+        !ok && report.contains("DECLINED") && !report.contains("CERTIFIED"),
+        "wrong generated construct model definition must fail its emitted bridge and be DECLINED:\n{report}"
+    );
+    let _ = std::fs::remove_dir_all(&tampered);
 
     let _ = std::fs::remove_dir_all(&out_dir);
 }
@@ -2025,6 +2071,38 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
                 )
             })
             .collect::<Vec<_>>();
+        let model_construct_entries = manifest["certified"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|entry| {
+                entry["class"] == "adt-constructor"
+                    && entry["theorem"] == "V3Master.construct_canonical_discharges"
+            })
+            .collect::<Vec<_>>();
+        if !model_construct_entries.is_empty() {
+            let final_lean =
+                std::fs::read_to_string(cert_dir.join("Final.lean")).expect("Final.lean exists");
+            let certificate = std::fs::read_to_string(cert_dir.join("Certificate.lean"))
+                .expect("Certificate.lean exists");
+            for entry in &model_construct_entries {
+                let name = entry["name"].as_str().unwrap();
+                assert!(
+                    final_lean.contains(&format!(
+                        "V3Master.construct_canonical_discharges (exportName := \"{name}\")"
+                    )) && final_lean.contains(&format!(
+                        "(hSemantic := CertProofs.{name}_constructSemanticBridge)"
+                    )),
+                    "construct-with-model Final.cert arm must pass the audited discharge and bridge for {name}:\n{final_lean}"
+                );
+                assert!(
+                    certificate.contains(&format!("theorem {name}_constructSemanticBridge"))
+                        && !certificate.contains(&format!("{name}_wasm_certified"))
+                        && !certificate.contains(&format!("{name}_simulates")),
+                    "construct-with-model must emit only its option-(b) bridge for {name}:\n{certificate}"
+                );
+            }
+        }
         if !dispatch_entries.is_empty() {
             let final_lean =
                 std::fs::read_to_string(cert_dir.join("Final.lean")).expect("Final.lean exists");
@@ -2097,12 +2175,32 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
             !combined.contains("sorryAx"),
             "ADT certificate leaked sorryAx for {input}:\n{combined}"
         );
-        if prefix == "tuple-proj" || !dispatch_entries.is_empty() {
+        if !model_construct_entries.is_empty() {
+            assert!(
+                combined.contains(
+                    "'V3Master.construct_canonical_discharges' depends on axioms: [propext, Classical.choice, Quot.sound]"
+                ),
+                "audited construct discharge changed axiom surface:\n{combined}"
+            );
+            for entry in &model_construct_entries {
+                let name = entry["name"].as_str().unwrap();
+                assert!(
+                    combined.contains(&format!(
+                        "'CertProofs.{name}_constructSemanticBridge' depends on axioms: [propext, Quot.sound]"
+                    )),
+                    "construct source-model bridge changed axiom surface for {name}:\n{combined}"
+                );
+            }
+        }
+        if prefix == "tuple-proj"
+            || !dispatch_entries.is_empty()
+            || !model_construct_entries.is_empty()
+        {
             assert!(
                 combined.contains(
                     "'AverCert.Final.cert' depends on axioms: [propext, Classical.choice, Quot.sound]"
                 ),
-                "generic field-projection/dispatch holds proofs changed axiom surface:\n{combined}"
+                "generic field-projection/dispatch/construct holds proofs changed axiom surface:\n{combined}"
             );
         }
 


### PR DESCRIPTION
Model-bearing ADT constructors are the second option-b migration (after dispatch). An export whose model is a user source function constructing a user inductive now discharges through the audited generic construct theorem, fed a small per-obligation semantic bridge the compiler emits: a cases-on-source proof that the named model's representation equals the plan-derived constructed value. Byte lowering, host simulation and fuel reasoning stay in the sha-pinned wall.

- `opteval::mk` and `cert_goals::mkOp` migrate; JSON's verbatim constructors keep their canonical leaf discharge.
- A hostile model (mutating the generated `mkOp` definition to a different constructor) is declined — the bridge proof no longer reduces.
- Coexistence preserved: `cert_goals` stays 23 exports in original order at mixed L1/L3 with construct + migrated leaves/dispatch + un-migrated recursion/mutual/composition arms.
- Axioms unchanged (`propext, Classical.choice, Quot.sound`); certificate schema 57 → 58.

Gates green locally: fmt, build (--features wasm), clippy (wasm,wasip2 -D warnings), 1022 lib tests, cert_certify_spec 13/13, cert_decode_spec 8/8, guard_iso 5/5; end-to-end manytypes/opteval/cert_goals/json/mutual CERTIFIED at unchanged counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)