### PR TITLE
Derive additive recursion conformance from the audited generic

### DIFF
--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -85,7 +85,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 58;
+pub const CERT_SCHEMA_VERSION: u32 = 59;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/cert/render_certificate.rs
+++ b/src/codegen/cert/render_certificate.rs
@@ -5,7 +5,7 @@ fn render_certificate(
 ) -> String {
     let mut s = String::new();
     s.push_str(
-        "import CertPrelude\nimport Module\nimport Schema\nimport Manifest\nimport V3DispatchCore\n",
+        "import CertPrelude\nimport Module\nimport Schema\nimport Manifest\nimport V3DispatchCore\nimport V3DischargeRecursion\n",
     );
     for r in model_roots {
         s.push_str(&format!("import {r}\n"));
@@ -18,6 +18,9 @@ fn render_certificate(
     );
     for c in &analysis.certs {
         match c.inner() {
+            Cert::Recursive { .. } if recursion_uses_audited_generic(c) => {
+                s.push_str(&render_recursion_semantic_bridge(c))
+            }
             Cert::Recursive { .. } | Cert::AccumulatorRecursive { .. } => {
                 s.push_str(&render_fueled_recursion_cert(c))
             }

--- a/src/codegen/cert/render_integer.rs
+++ b/src/codegen/cert/render_integer.rs
@@ -1,3 +1,4 @@
 include!("render_integer_fuel.rs");
+include!("render_recursion_bridge.rs");
 include!("render_integer_recursive.rs");
 include!("render_integer_accumulator.rs");

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -505,7 +505,7 @@ fn render_manifest_lean(
 fn render_final(analysis: &Analysis, model_info: &ModelInfo) -> String {
     let mut s = String::new();
     s.push_str(
-        "import Certificate\nimport Manifest\nimport Schema\nimport V3DischargeFieldProj\nimport V3DischargeConstruct\nimport V3DischargeVerbatim\nimport V3DischargeString\nimport V3DischargeIntDispatch\n\n\
+        "import Certificate\nimport Manifest\nimport Schema\nimport V3DischargeFieldProj\nimport V3DischargeConstruct\nimport V3DischargeVerbatim\nimport V3DischargeString\nimport V3DischargeIntDispatch\nimport V3DischargeRecursion\n\n\
          set_option maxRecDepth 1000000\n\
          set_option linter.unusedSimpArgs false\n\n\
          open AverCert AverCert.Schema\n\n",
@@ -582,6 +582,9 @@ fn render_final(analysis: &Analysis, model_info: &ModelInfo) -> String {
                     && adt_constructor_uses_model(c, model_info)
                 {
                     return render_adt_constructor_final_arm(c, model_info);
+                }
+                if recursion_uses_audited_generic(c) {
+                    return render_recursion_final_arm(c);
                 }
                 if let Cert::AdtConstructor {
                     name,
@@ -1142,6 +1145,8 @@ fn render_manifest(
             Cert::VariantDispatch { .. } | Cert::WidenedIntMatch { .. }
         ) {
             "V3Master.intDispatch_canonical_discharges".to_string()
+        } else if recursion_uses_audited_generic(c) {
+            "V3Master.recursion_claim_discharges".to_string()
         } else {
             let theorem_suffix = if policy == CertificationPolicy::SimulatesModelTotally {
                 "wasm_total"

--- a/src/codegen/cert/render_recursion_bridge.rs
+++ b/src/codegen/cert/render_recursion_bridge.rs
@@ -1,0 +1,202 @@
+/// The audited `V3Rec` generic covers the four unary descent-by-one shapes
+/// whose byte-role combinator is `Int.add`. Multiplication and the two-argument
+/// accumulator have different semantics/arity and deliberately retain their
+/// residual bespoke proofs until matching audited generics exist.
+fn recursion_uses_audited_generic(c: &Cert) -> bool {
+    matches!(
+        c.inner(),
+        Cert::Recursive {
+            combinator: Combinator::Add,
+            ..
+        }
+    )
+}
+
+fn recursion_shape_lean_value(c: &Cert) -> String {
+    let Cert::Recursive {
+        base_k,
+        rec_first,
+        other,
+        combinator: Combinator::Add,
+        ..
+    } = c.inner()
+    else {
+        unreachable!("only unary additive recursion has a V3Rec shape")
+    };
+    let step = match (*rec_first, *other) {
+        (false, BodyOperand::Input) => ".inputSecond".to_string(),
+        (false, BodyOperand::Const(k)) => {
+            format!(".constSecond ({})", lean_int_lit(k))
+        }
+        (true, BodyOperand::Input) => ".inputFirst".to_string(),
+        (true, BodyOperand::Const(k)) => {
+            format!(".constFirst ({})", lean_int_lit(k))
+        }
+    };
+    format!(
+        "({{ base := {}, step := {step} }} : V3Rec.RecShapeU)",
+        lean_int_lit(*base_k)
+    )
+}
+
+fn recursion_claim_lean_value(c: &Cert) -> String {
+    let Cert::Recursive {
+        name,
+        carrier,
+        box_idx,
+        add_idx,
+        sub_idx,
+        ..
+    } = c.inner()
+    else {
+        unreachable!("audited recursion claim is unary")
+    };
+    format!(
+        "({{ exportNameBytes := {}, exportName := {}, carrier := {carrier}, \
+         hostTable := {}, obligation := AverCert.{name}Ob }} : \
+         AverCert.AcceptedArtifact.RecursionClaim)",
+        render_byte_list(name.as_bytes()),
+        lean_str(name),
+        recursion_host_table_lean_value(*box_idx, *add_idx, *sub_idx),
+    )
+}
+
+/// Concrete byte/plan acceptance needed to instantiate the artifact-shaped
+/// audited discharge from `Final.lean`. This is data reconstruction only: the
+/// source-model residual lives exclusively in the semantic bridge below.
+fn recursion_claim_acceptance_proof(c: &Cert) -> String {
+    let Cert::Recursive {
+        self_idx,
+        code_idx,
+        type_idx,
+        carrier,
+        ..
+    } = c.inner()
+    else {
+        unreachable!("audited recursion acceptance is unary")
+    };
+    let plan = recursion_plan_from_cert(c).expect("audited recursion has a canonical plan");
+    let body = lower_expr_fragment_plan(&plan, *carrier)
+        .map(|ops| render_ops_value(&ops))
+        .expect("audited recursion plan lowers to WInstr");
+    let bytes = lower_expr_fragment_plan_code_entry_bytes(&plan, *carrier)
+        .expect("audited recursion plan lowers to exact code-entry bytes");
+    let bytes = render_byte_list(&bytes);
+    let binding = format!(
+        "({{ funcIdx := {self_idx}, codeIdx := {code_idx}, typeIdx := {type_idx}, \
+         codeEntry := {bytes} }} : AverCert.WasmSlice.FuncBinding)"
+    );
+    format!(
+        "⟨rfl, rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
+         ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
+    )
+}
+
+/// Option-(b) residual for one unary additive recursion obligation. The
+/// generated proof identifies the byte-derived parsed shape and relates the
+/// generated source model to the independent `V3Rec.evalRecU` evaluator in
+/// both domain directions. Fuel induction and Wasm execution stay in the
+/// sha-pinned `V3RecSpike` / `V3DischargeRecursion` wall.
+fn render_recursion_semantic_bridge(c: &Cert) -> String {
+    let Cert::Recursive {
+        name,
+        box_idx,
+        add_idx,
+        sub_idx,
+        ..
+    } = c.inner()
+    else {
+        unreachable!()
+    };
+    debug_assert!(recursion_uses_audited_generic(c));
+    let shape = recursion_shape_lean_value(c);
+    let claim = recursion_claim_lean_value(c);
+    let acceptance = recursion_claim_acceptance_proof(c);
+    format!(
+        r#"/-! ### {name} — option-(b) recursion semantic bridge -/
+
+theorem {name}_recursionClaimAccepted :
+    AverCert.AcceptedArtifact.recursionClaimAccepted
+      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen
+      AverCert.manifest {claim} := by
+  dsimp [AverCert.AcceptedArtifact.recursionClaimAccepted,
+    AverCert.AcceptedArtifact.recursionPlanForExport,
+    AverCert.AcceptedArtifact.recursionPlanAccepted]
+  exact {acceptance}
+
+theorem {name}_recursionSemanticBridge :
+    V3Master.recursionSemanticBridge {claim}
+      AverCert.Plans.{name}RecursionPlan := by
+  have hModelFuel : ∀ fuel n,
+      V3Rec.evalRecUFuel {shape} fuel n = {name}__fuel fuel n := by
+    intro fuel
+    induction fuel with
+    | zero => intro n; rfl
+    | succ fuel ih =>
+        intro n
+        simp only [V3Rec.evalRecUFuel, {name}__fuel]
+        split <;> simp_all [V3Rec.stepEval]
+  have hModel : ∀ n, V3Rec.evalRecU {shape} n = {name} n := by
+    intro n
+    simpa [V3Rec.evalRecU, {name}] using hModelFuel (n.natAbs + 1) n
+  refine ⟨{box_idx}, {add_idx}, {sub_idx}, {shape},
+    rfl, rfl, rfl, rfl, ?_, ?_, ?_⟩
+  · intro add sub mul stringEq stringConcat
+    simpa [AverCert.{name}Ob, CertModule.{name}Host]
+  · intro S ns vs hDom
+    rcases hDom with ⟨hRepr, hLen⟩
+    cases ns with
+    | nil => simp at hLen
+    | cons n ns =>
+        cases ns with
+        | nil =>
+            cases hRepr with
+            | cons hv htail =>
+                cases htail
+                refine ⟨n, _, rfl, hv, ?_⟩
+                intro w hw
+                simpa [AverCert.Schema.intRepr, hModel n] using hw
+        | cons _ _ => simp at hLen
+  · intro S n v hv
+    refine ⟨[n], ⟨ReprAll.cons hv ReprAll.nil, rfl⟩, ?_⟩
+    intro w hw
+    simpa [AverCert.Schema.intRepr, hModel n] using hw
+
+#print axioms {name}_recursionSemanticBridge
+"#
+    )
+}
+
+/// Per-obligation `Final.cert` arm. A singleton artifact view supplies the
+/// already byte-derived claim to `recursion_claim_discharges`; the only
+/// semantic premise is the generated option-(b) bridge above.
+fn render_recursion_final_arm(c: &Cert) -> String {
+    debug_assert!(recursion_uses_audited_generic(c));
+    let name = c.name();
+    let claim = recursion_claim_lean_value(c);
+    format!(
+        r#"let claim : AverCert.AcceptedArtifact.RecursionClaim := {claim}
+      let artifact : AverCert.AcceptedArtifact.ArtifactData :=
+        {{ modBytes := AverCert.ArtifactBytes.modBytes,
+          modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest,
+          symFragmentClaims := [], stringEqClaims := [], stringConcatClaims := [],
+          constructClaims := [], recursionClaims := [claim],
+          mutualRecursionClaims := [], verbatimClaims := [], intDispatchClaims := [],
+          fieldProjectionClaims := [], compositionMembers := [], compositionClaims := [],
+          closureFuel := 0,
+          closureClaim := {{ roots := [], helpers := [], admitted := [] }} }}
+      exact V3Master.recursion_claim_discharges artifact
+        (by
+          dsimp [AverCert.AcceptedArtifact.acceptedRecursionFragments,
+            AverCert.AcceptedArtifact.recursionClaimsAccepted,
+            AverCert.AcceptedArtifact.allClaims, artifact]
+          exact ⟨CertProofs.{name}_recursionClaimAccepted, trivial⟩)
+        claim (by simp [artifact])
+        (by
+          intro plan hPlan
+          dsimp [artifact, AverCert.AcceptedArtifact.recursionPlanForExport] at hPlan
+          injection hPlan with hPlan
+          subst plan
+          exact CertProofs.{name}_recursionSemanticBridge)"#
+    )
+}

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -161,10 +161,10 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
     );
     assert_eq!(
         manifest["schema_version"].as_u64(),
-        Some(58),
-        "construct option-(b) migration is certificate schema 58"
+        Some(59),
+        "recursion option-(b) migration is certificate schema 59"
     );
-    assert_eq!(aver::codegen::cert::CERT_SCHEMA_VERSION, 58);
+    assert_eq!(aver::codegen::cert::CERT_SCHEMA_VERSION, 59);
     let declared_uncertified = manifest["declaredUncertified"].as_array().unwrap();
     assert_eq!(
         declared_uncertified.len(),
@@ -755,7 +755,13 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             && final_lean.contains("(hSemantic := CertProofs.mkOp_constructSemanticBridge)"),
         "construct-with-model arm must use the audited discharge and emitted bridge:\n{final_lean}"
     );
-    for bespoke_name in ["addTwo", "sumFrom", "countDown"] {
+    assert!(
+        final_lean.contains("exportName := \"sumFrom\"")
+            && final_lean.contains("V3Master.recursion_claim_discharges artifact")
+            && final_lean.contains("CertProofs.sumFrom_recursionSemanticBridge"),
+        "unary additive recursion arm must use the audited discharge and emitted bridge:\n{final_lean}"
+    );
+    for bespoke_name in ["addTwo", "countDown"] {
         assert!(
             final_lean.contains(&format!("CertProofs.{bespoke_name}_")),
             "unmigrated arm changed during coexistence migration: {bespoke_name}\n{final_lean}"
@@ -781,8 +787,12 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             && !certificate.contains("gauge_wasm_certified")
             && !certificate.contains("gauge_simulates")
             && !certificate.contains("mkOp_wasm_certified")
-            && !certificate.contains("mkOp_simulates"),
-        "migrated leaf/dispatch/construct families must not emit bespoke simulations:\n{certificate}"
+            && !certificate.contains("mkOp_simulates")
+            && !certificate.contains("sumFrom_wasm_certified")
+            && !certificate.contains("sumFrom_wasm_total")
+            && !certificate.contains("sumFrom_simulates")
+            && !certificate.contains("sumFromHostRef"),
+        "migrated leaf/dispatch/construct/recursion families must not emit bespoke simulations or tripwires:\n{certificate}"
     );
     for dispatch_name in ["evalOp", "boxInt", "gauge"] {
         assert!(
@@ -797,6 +807,14 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             && certificate.contains("cases n")
             && certificate.contains("V3ConstructVerbatim.constructModelFields"),
         "construct-with-model must emit only its small source-model bridge:\n{certificate}"
+    );
+    assert!(
+        certificate.contains("theorem sumFrom_recursionSemanticBridge")
+            && certificate.contains("have hModelFuel")
+            && certificate.contains("V3Rec.evalRecUFuel")
+            && certificate.contains("⟨n, _, rfl, hv")
+            && certificate.contains("⟨[n], ⟨ReprAll.cons hv ReprAll.nil, rfl⟩"),
+        "recursion must emit both option-(b) model directions and no evaluator proof:\n{certificate}"
     );
     let user_name = manifest["certified"]
         .as_array()
@@ -815,6 +833,13 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
         .find(|entry| entry["name"] == "mkOp")
         .unwrap();
     assert_eq!(mk_op["theorem"], "V3Master.construct_canonical_discharges");
+    let sum_from = manifest["certified"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["name"] == "sumFrom")
+        .unwrap();
+    assert_eq!(sum_from["theorem"], "V3Master.recursion_claim_discharges");
     for (name, theorem) in [
         ("wrapItems", "V3Master.verbatim_canonical_discharges"),
         ("tagName", "V3Master.verbatim_canonical_discharges"),
@@ -865,6 +890,14 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
         ),
         "mixed generic/bespoke Final.cert changed axiom surface:\n{combined}"
     );
+    assert!(
+        combined.contains(
+            "'CertProofs.sumFrom_recursionSemanticBridge' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        ) && combined.contains(
+            "'V3Master.recursion_claim_discharges' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        ),
+        "recursion bridge/discharge changed axiom surface:\n{combined}"
+    );
 
     let typecheck = cert_dir.join("V3AcceptRealTypecheck.lean");
     std::fs::write(
@@ -909,7 +942,7 @@ example :
 }
 
 #[test]
-fn cert_verify_declines_hostile_leaf_dispatch_and_construct_models() {
+fn cert_verify_declines_hostile_leaf_dispatch_construct_and_recursion_models() {
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping hostile leaf-model test: `lake` not available");
         return;
@@ -999,6 +1032,32 @@ fn cert_verify_declines_hostile_leaf_dispatch_and_construct_models() {
     assert!(
         !ok && report.contains("DECLINED") && !report.contains("CERTIFIED"),
         "wrong generated construct model definition must fail its emitted bridge and be DECLINED:\n{report}"
+    );
+    let _ = std::fs::remove_dir_all(&tampered);
+
+    let tampered = temp_dir("certify-hostile-recursion-model-definition");
+    copy_dir_all(&out_dir, &tampered);
+    let model = tampered.join("cert/CertGoals.lean");
+    let source = std::fs::read_to_string(&model).unwrap();
+    let honest = "else (n + sumFrom__fuel fuel' (n - 1)))";
+    let hostile = "else (2 + sumFrom__fuel fuel' (n - 1)))";
+    let edited = source.replacen(honest, hostile, 1);
+    assert_ne!(
+        source, edited,
+        "recursion model definition changed; update the hostile-model regression"
+    );
+    std::fs::write(&model, edited).unwrap();
+    let manifest = std::fs::read_to_string(tampered.join("cert/Manifest.lean")).unwrap();
+    assert!(
+        manifest.contains("model := fun ns => sumFrom (ns.headD 0)"),
+        "recursion hostile regression must leave the manifest model reference untouched"
+    );
+
+    let (ok, report) =
+        verify_certificate(&tampered.join("cert_goals.wasm"), &tampered.join("cert"));
+    assert!(
+        !ok && report.contains("DECLINED") && !report.contains("CERTIFIED"),
+        "wrong generated recursion model definition must fail its emitted bridge and be DECLINED:\n{report}"
     );
     let _ = std::fs::remove_dir_all(&tampered);
 
@@ -1190,7 +1249,7 @@ fn certify_fueled_recursion_generality_lake_builds_kernel_clean() {
             .unwrap();
         assert_eq!(entry["policy"], "simulatesModelTotally");
         assert_eq!(entry["level"], "L3");
-        assert_eq!(entry["theorem"], format!("CertProofs.{name}_wasm_total"));
+        assert_eq!(entry["theorem"], "V3Master.recursion_claim_discharges");
         assert_eq!(entry["termination_witness"]["measure"]["kind"], "intNatAbs");
         assert_eq!(entry["termination_witness"]["measure"]["param_index"], 0);
         assert_eq!(entry["termination_witness"]["descent"], -1);
@@ -1230,27 +1289,48 @@ fn certify_fueled_recursion_generality_lake_builds_kernel_clean() {
         build.status.success(),
         "lake build of emitted recursion cert failed:\n{combined}"
     );
-    // Kernel-clean on every recognised shape, including the ones the previous
-    // templates could not express.
-    for name in ["sumFrom", "constPlus", "backward", "factorial", "countDown"] {
+    // The additive unary family now emits only the model bridge. Multiplication
+    // and the two-argument accumulator remain explicit L1 residuals because the
+    // audited generic intentionally has neither semantic shape.
+    let certificate = std::fs::read_to_string(cert_dir.join("Certificate.lean")).unwrap();
+    let final_lean = std::fs::read_to_string(cert_dir.join("Final.lean")).unwrap();
+    for name in ["sumFrom", "constPlus", "backward"] {
+        assert!(
+            combined.contains(&format!(
+                "'CertProofs.{name}_recursionSemanticBridge' depends on axioms: [propext, Classical.choice, Quot.sound]"
+            )),
+            "recursion bridge for {name} not kernel-clean:\n{combined}"
+        );
+        assert!(
+            certificate.contains(&format!("theorem {name}_recursionSemanticBridge"))
+                && !certificate.contains(&format!("{name}_wasm_certified"))
+                && !certificate.contains(&format!("{name}_wasm_total"))
+                && !certificate.contains(&format!("{name}_simulates"))
+                && !certificate.contains(&format!("{name}HostRef"))
+                && final_lean.contains("V3Master.recursion_claim_discharges artifact")
+                && final_lean.contains(&format!("CertProofs.{name}_recursionSemanticBridge")),
+            "migrated recursion emitted a bespoke proof/tripwire or missed the generic arm for {name}:\n{certificate}\n{final_lean}"
+        );
+    }
+    for name in ["factorial", "countDown"] {
         assert!(
             combined.contains(&format!(
                 "{name}_wasm_certified' depends on axioms: [propext, Classical.choice, Quot.sound]"
             )),
-            "recursion certificate for {name} not kernel-clean:\n{combined}"
-        );
-    }
-    for name in ["sumFrom", "constPlus", "backward"] {
-        assert!(
-            combined.contains(&format!(
-                "{name}_wasm_total' depends on axioms: [propext, Classical.choice, Quot.sound]"
-            )),
-            "total recursion certificate for {name} not kernel-clean:\n{combined}"
+            "residual recursion certificate for {name} not kernel-clean:\n{combined}"
         );
     }
     assert!(
         !combined.contains("factorial_wasm_total") && !combined.contains("countDown_wasm_total"),
         "out-of-scope recursion family was promoted:\n{combined}"
+    );
+    assert!(
+        combined.contains(
+            "'V3Master.recursion_claim_discharges' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        ) && combined.contains(
+            "'AverCert.Final.cert' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        ),
+        "audited recursion discharge/final theorem changed axiom surface:\n{combined}"
     );
     assert!(
         !combined.contains("sorryAx"),
@@ -2254,6 +2334,15 @@ fn certify_carrier_at_type_index_64_lake_builds_kernel_clean() {
         "fixture must pin the carrier exactly at the s33 boundary index 64; \
          adjust the fixture's variant count if the emitter's type layout changed"
     );
+    let sum_big = manifest["certified"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["name"] == "sumBig")
+        .unwrap();
+    assert_eq!(sum_big["policy"], "simulatesModelTotally");
+    assert_eq!(sum_big["level"], "L3");
+    assert_eq!(sum_big["theorem"], "V3Master.recursion_claim_discharges");
     let build = Command::new("lake")
         .current_dir(&cert_dir)
         .arg("build")
@@ -2270,7 +2359,11 @@ fn certify_carrier_at_type_index_64_lake_builds_kernel_clean() {
     );
     assert!(
         combined.contains(
-            "sumBig_wasm_certified' depends on axioms: [propext, Classical.choice, Quot.sound]"
+            "'CertProofs.sumBig_recursionSemanticBridge' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        ) && combined.contains(
+            "'V3Master.recursion_claim_discharges' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        ) && combined.contains(
+            "'AverCert.Final.cert' depends on axioms: [propext, Classical.choice, Quot.sound]"
         ),
         "boundary certificate not kernel-clean:\n{combined}"
     );

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -42,13 +42,12 @@
 //!       change `o.code`, so the code `rfl` still fails → DECLINED
 //!   (r) comment decoy: the active `sumToCode` mutated PLUS a full honest body in
 //!       a `/- … -/` block comment. Dead text; the code `rfl` fails → DECLINED
-//!   (s) code decouple: `manifest` points `code` at a decoy `wrongCode` that
-//!       always traps (making `holds` vacuous and trivially provable) while the
-//!       honest `sumToCode` is dead. Builds green; the code `rfl` binds `o.code`
-//!       to the bytes, not `wrongCode`, so it fails → DECLINED
-//!   (t) self decouple (vacuity): `manifest` sets `self` to a wrong index, so the
-//!       code-table lookup misses and `wFuncN` traps (vacuous, provable `holds`).
-//!       Builds green; the self `rfl` binds `o.self` to the byte index → DECLINED
+//!   (s) migrated-recursion code decouple: `sumTo`'s obligation points at a
+//!       decoy `wrongCode`; the generic `recursionClaimAccepted` byte binding
+//!       rejects it without any bespoke simulation-proof swap → DECLINED
+//!   (t) migrated-recursion self decouple: `sumTo`'s obligation uses a wrong
+//!       function index; the generic recursion claim binds it to the byte index
+//!       and fails closed without a bespoke proof → DECLINED
 //!   (u) String.eq helper shape: a byte-level mutation inside the exact
 //!       compiler-generated helper, with the wasm hash rebound, makes the
 //!       checker re-derive a different host table and the kernel witness fails
@@ -134,6 +133,23 @@ fn aver_command() -> Command {
 
 fn aver_verify(artifact: &Path, cert_dir: &Path) -> (bool, String) {
     aver_cert(&["verify"], artifact, cert_dir)
+}
+
+fn assert_certificate_target_builds(cert_dir: &Path, case: &str) {
+    let out = Command::new("lake")
+        .current_dir(cert_dir)
+        .args(["build", "Certificate"])
+        .output()
+        .expect("lake builds the isolated Certificate target");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.status.success(),
+        "vacuous proof must compile before the byte-binding tripwire ({case}):\n{combined}"
+    );
 }
 
 fn aver_cert(sub: &[&str], artifact: &Path, cert_dir: &Path) -> (bool, String) {
@@ -1159,13 +1175,11 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         );
     }
 
-    // (s) Code decouple: point the obligation's `code` at a decoy `wrongCode` that
-    //     always traps, so `holds` is vacuous and trivially provable, while the
-    //     honest `sumToCode` is left dead. The artifact-carried recursion claim
-    //     pins `obligation.code` to the plan-lowered body, so the decoupled
-    //     obligation now fails the cert's OWN build — an even earlier fail-closed
-    //     decline than the checker witness's code `rfl` (which remains exercised
-    //     by cases (p)/(q)/(r), whose nlocals-only mutations build green).
+    // (s) Migrated-recursion code decouple: point `sumTo`'s obligation at a
+    //     decoy `wrongCode`, leaving the byte-honest `sumToCode` dead. `sumTo`
+    //     deliberately has no bespoke `sumTo_simulates` proof now: the generic
+    //     recursion bridge's `recursionClaimAccepted` must bind the obligation's
+    //     code directly to the byte-derived plan and fail closed.
     {
         let dir = temp_dir("neg-s");
         copy_dir(&out_dir, &dir);
@@ -1188,11 +1202,6 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         );
         assert_ne!(msrc, decoupled, "manifest code field shape changed");
         std::fs::write(&man, decoupled).unwrap();
-        let vac = VACUOUS_SIMULATES.replace(
-            "@BODY@",
-            "simp only [sumToOb, CertModule.wrongCode, wFuncN, reduceCtorEq] at hrun",
-        );
-        replace_simulates(&cert, &vac);
         let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &cert);
         assert!(!ok, "code decouple must be DECLINED:\n{out}");
         assert!(
@@ -1205,12 +1214,10 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         );
     }
 
-    // (t) Self decouple (vacuity): set the obligation's `self` to a wrong index so
-    //     `code self` misses the table and `wFuncN` traps — `holds` is vacuous and
-    //     provable. The artifact-carried recursion claim pins
-    //     `binding.funcIdx = obligation.self` to the byte-derived function
-    //     binding, so the decoupled `self` now fails the cert's OWN build — an
-    //     even earlier fail-closed decline than the checker witness's self `rfl`.
+    // (t) Migrated-recursion self decouple: set `sumTo`'s obligation `self` to a
+    //     wrong index. The generic recursion bridge's `recursionClaimAccepted`
+    //     binds `obligation.self` to the byte-derived function index, so this
+    //     must fail closed without any bespoke simulation-proof replacement.
     {
         let dir = temp_dir("neg-t");
         copy_dir(&out_dir, &dir);
@@ -1220,12 +1227,6 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         let decoupled = msrc.replacen("self := 1,", "self := 999,", 1);
         assert_ne!(msrc, decoupled, "manifest self field shape changed");
         std::fs::write(&man, decoupled).unwrap();
-        let vac = VACUOUS_SIMULATES.replace(
-            "@BODY@",
-            "simp only [sumToOb, CertModule.sumToCode, wFuncN,\n      \
-             show (999 = 1) = False by decide, if_false, reduceCtorEq] at hrun",
-        );
-        replace_simulates(&cert, &vac);
         let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &cert);
         assert!(!ok, "self decouple must be DECLINED:\n{out}");
         assert!(
@@ -1340,6 +1341,60 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         assert!(
             !out.contains("CERTIFIED"),
             "true-codRepr cert credited (w):\n{out}"
+        );
+    }
+
+    // (x) Bespoke-recursion code decouple: unlike migrated `sumTo`, `countDown`
+    //     still has a schema-shaped simulation theorem. Point its obligation at
+    //     an always-trapping decoy and replace that theorem with a valid vacuous
+    //     proof. Build the `Certificate` target alone first, proving the swapped
+    //     theorem elaborates; then require full verification to fail only once
+    //     the artifact/checker byte binding is present.
+    {
+        let dir = temp_dir("neg-x-countdown-code");
+        copy_dir(&out_dir, &dir);
+        let cert = dir.join("cert");
+        let module = cert.join("Module.lean");
+        let src = std::fs::read_to_string(&module).unwrap();
+        let with_decoy = src.replacen(
+            "end CertModule",
+            "/-- decoy: always traps, so `holds` is vacuous. -/\n\
+             def wrongCode : CodeTbl := fun _ => none\nend CertModule",
+            1,
+        );
+        assert_ne!(src, with_decoy, "module end marker shape changed");
+        std::fs::write(&module, with_decoy).unwrap();
+
+        let manifest = cert.join("Manifest.lean");
+        let msrc = std::fs::read_to_string(&manifest).unwrap();
+        let decoupled = msrc.replacen(
+            "code := CertModule.countDownCode",
+            "code := CertModule.wrongCode",
+            1,
+        );
+        assert_ne!(msrc, decoupled, "countDown code field shape changed");
+        std::fs::write(&manifest, decoupled).unwrap();
+        replace_countdown_simulates(
+            &cert,
+            "theorem countDown_simulates : AverCert.Schema.Obligation.holds countDownOb := by\n  \
+             intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel ns vs w hrepr hrun\n  \
+             exfalso\n  \
+             cases fuel with\n  \
+             | zero => simp only [wFuncN, reduceCtorEq] at hrun\n  \
+             | succ f =>\n      \
+               simp only [countDownOb, CertModule.wrongCode, wFuncN, reduceCtorEq] at hrun",
+        );
+        assert_certificate_target_builds(&cert, "x");
+
+        let (ok, out) = aver_verify(&dir.join("certprobe2.wasm"), &cert);
+        assert!(!ok, "countDown code decouple must be DECLINED (x):\n{out}");
+        assert!(
+            out.contains("did not build") || out.contains("does not bind"),
+            "wrong reason (x):\n{out}"
+        );
+        assert!(
+            !out.contains("CERTIFIED"),
+            "countDown code decouple credited (x):\n{out}"
         );
     }
 
@@ -1580,44 +1635,6 @@ const HONEST_SUMTO_CODE: &str = "/-- Verbatim emitted body of `sumTo` (self-recu
     .ifElse [.i64Const 0, .call 7]\n              \
     [.localGet 0, .localGet 0, .i64Const 1, .call 7, .call 9, .call 1, .call 8] ]⟩\n  \
     else none";
-
-/// A vacuous replacement proof of `sumTo_simulates` (the emitted honest proof
-/// references the honest `sumToCode`/`self`, so a decoupled obligation needs its
-/// own proof to build green). `@BODY@` is filled with the `simp` that discharges
-/// the trapped `wFuncN`.
-const VACUOUS_SIMULATES: &str = "theorem sumTo_simulates : AverCert.Schema.Obligation.holds sumToOb := by\n  \
-    intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel ns vs w hrepr hrun\n  \
-    exfalso\n  \
-    cases fuel with\n  \
-    | zero => simp only [wFuncN, reduceCtorEq] at hrun\n  \
-    | succ f =>\n      @BODY@";
-
-/// Swap the emitted `sumTo_simulates` proof in `Certificate.lean` for a
-/// (vacuous) replacement, matching the exact emitted block.
-fn replace_simulates(cert_dir: &Path, replacement: &str) {
-    let c = cert_dir.join("Certificate.lean");
-    let src = std::fs::read_to_string(&c).unwrap();
-    let old = "theorem sumTo_simulates : AverCert.Schema.Obligation.holds sumToOb := by\n  \
-        intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel ns vs w hrepr hrun\n  \
-        simp only [sumToOb, AverCert.Schema.Obligation.holds] at hrun ⊢\n  \
-        obtain ⟨hrepr, harity⟩ := hrepr\n  \
-        cases hrepr with\n  \
-        | nil =>\n      \
-        simp at harity\n  \
-        | cons hv htail =>\n      \
-        rename_i n v ns vs\n      \
-        cases htail with\n      \
-        | nil =>\n          \
-        simpa [AverCert.Schema.intRepr] using sumTo_wasm_certified S.Repr S.car S.smallIntro S.smallElim S.bigElim\n            \
-        add sub hadd hsub fuel n v w hv hrun\n      \
-        | cons _ _ =>\n          \
-        simp at harity";
-    assert!(
-        src.contains(old),
-        "emitted sumTo_simulates block shape changed; update the test"
-    );
-    std::fs::write(&c, src.replacen(old, replacement, 1)).unwrap();
-}
 
 /// Partial-obligation counterpart used by the semantic-face isolation probes.
 /// `sumTo` is L3 now, so vacuity probes stay on `countDown` to reach the


### PR DESCRIPTION
Unary additive recursion is the first (partial) recursion migration onto the audited generic. Exports of that shape now discharge through `V3Master.recursion_claim_discharges` fed a per-obligation bridge that ties the source model to the plan-derived recursion evaluator: fuel induction proves `evalRecU shape n = model n`, and both the partial and total (L3) directions follow. The host-role indices and `parseRecShapeU` reduce by `rfl`.

- Migrated: `sumFrom`, `constPlus`, `backward`, `manytypes.sumBig` — all remain total/L3.
- **Not migrated (deliberate):** `factorial` (multiplicative) and `countDown` (two-argument accumulator) keep their existing bespoke discharge. The audited generic models only unary additive recursion; extending it to those shapes is a separate soundness-wall change, tracked as a follow-up before the final flip.
- Hostile recursion model (mutating the generated `sumFrom` definition) is declined.
- Coexistence preserved: obligation order from `analysis.certs`; mixed migrated/bespoke arms. Axioms unchanged (`propext, Classical.choice, Quot.sound`); schema 58 → 59.

Gates green locally: fmt, build (--features wasm), clippy (wasm,wasip2 -D warnings), 1022 lib tests, cert_certify_spec 13/13, cert_decode_spec 8/8, guard_iso 5/5; end-to-end manytypes(L3)/opteval/cert_goals/json/mutual CERTIFIED at unchanged counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)