### PR TITLE
Derive mutual-recursion conformance from the audited generic

### DIFF
--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -85,7 +85,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 60;
+pub const CERT_SCHEMA_VERSION: u32 = 61;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/cert/render_certificate.rs
+++ b/src/codegen/cert/render_certificate.rs
@@ -16,6 +16,14 @@ fn render_certificate(
          set_option maxRecDepth 1000000\n\n\
          namespace CertProofs\nopen CertPrelude CertModule AverCert AverCert.Schema\n\n",
     );
+    // Mutual option-(b) bridges share one concrete SCC/acceptance package.
+    // Emit those packages first so source/export order cannot create a forward
+    // reference when a non-primary member appears before its primary.
+    for c in &analysis.certs {
+        if matches!(c.inner(), Cert::MutualRecursion { .. }) {
+            s.push_str(&render_mutual_shared_bridge_data(c));
+        }
+    }
     for c in &analysis.certs {
         match c.inner() {
             Cert::Recursive { .. } | Cert::AccumulatorRecursive { .. }
@@ -52,7 +60,7 @@ fn render_certificate(
             | Cert::StringEqVerbatimMatch { .. }
             | Cert::StringConcatVerbatimMatch { .. } => {}
             Cert::Composition { .. } => s.push_str(&render_composition_cert(c)),
-            Cert::MutualRecursion { .. } => s.push_str(&render_mutual_recursion_cert(c)),
+            Cert::MutualRecursion { .. } => s.push_str(&render_mutual_semantic_bridge(c)),
             Cert::NonRecursive { .. } => unreachable!(),
         }
         s.push('\n');

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -591,6 +591,9 @@ fn render_final(analysis: &Analysis, model_info: &ModelInfo) -> String {
                 if recursion_uses_audited_generic(c) {
                     return render_recursion_final_arm(c);
                 }
+                if matches!(c.inner(), Cert::MutualRecursion { .. }) {
+                    return render_mutual_final_arm(c);
+                }
                 if let Cert::AdtConstructor {
                     name,
                     self_idx,
@@ -1153,6 +1156,8 @@ fn render_manifest(
             "V3Master.intDispatch_canonical_discharges".to_string()
         } else if recursion_uses_audited_generic(c) {
             "V3Master.recursion_claim_discharges".to_string()
+        } else if matches!(c.inner(), Cert::MutualRecursion { .. }) {
+            "V3Master.mutual_claim_discharges".to_string()
         } else {
             let theorem_suffix = if policy == CertificationPolicy::SimulatesModelTotally {
                 "wasm_total"

--- a/src/codegen/cert/render_model_support.rs
+++ b/src/codegen/cert/render_model_support.rs
@@ -264,18 +264,4 @@ fn conjunct_proj(pos: usize, k: usize) -> String {
     s
 }
 
-/// Evaluate the mutual model at `scc[pos]` on input `n` under partial-correctness
-/// semantics (`f n = if n ≤ 0 then base else cross (n-1)`) to obtain the
-/// anti-vacuity guard values. Terminates: `n` strictly descends to the base.
-fn eval_mutual(scc: &[MutualMember], pos: usize, n: i64) -> i64 {
-    if n <= 0 {
-        return scc[pos].base_k;
-    }
-    let cross_pos = scc
-        .iter()
-        .position(|m| m.self_idx == scc[pos].cross_idx)
-        .expect("mutual SCC cross target is a member");
-    eval_mutual(scc, cross_pos, n - 1)
-}
-
 // Mutual-recursion proof rendering lives in render_mutual.rs.

--- a/src/codegen/cert/render_mutual.rs
+++ b/src/codegen/cert/render_mutual.rs
@@ -1,475 +1,358 @@
-/// One conjunct's proof block inside `{primary}_mutual_sim`: the carrier-sign
-/// dispatch for member `m`, whose base arm boxes `m.base_k` and whose step arm
-/// tail-calls its cross target (self index `m.cross_idx`, model `cross_name`),
-/// discharged by the matching conjunct `cross_ih` of the fuel induction
-/// hypothesis. A verbatim port of the validated probe block, parameterised by
-/// name, carrier and the byte-derived indices/literals.
-fn mutual_sim_member_block(
-    primary: &str,
-    c_ty: u32,
-    m: &MutualMember,
-    cross_name: &str,
-    cross_ih: &str,
-) -> String {
-    let base_lit = lean_int_lit(m.base_k);
-    let cs = m.cross_idx;
-    let mn = &m.name;
-    format!(
-        r#"      · intro n v w hv hrun
-        rcases hcar n v hv with ⟨s, sg, rfl⟩ | ⟨s, lty, les, sg, rfl⟩
-        · have hs := hsmall_elim n s sg hv; subst hs
-          by_cases hle : s ≤ (0 : Int)
-          · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32, popArgs, initLocals, hle] at hrun
-            rw [{mn}_base s hle, ← hrun]; exact hsmall_intro {base_lit}
-          · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32, popArgs, initLocals, hle] at hrun
-            rcases hsub : sub [.structv {c_ty} [.i64v s, .null, .i32v sg], carrierSmall {c_ty} 1] with _ | vd
-            · simp [hsub] at hrun
-            · simp only [hsub] at hrun
-              have hrd : Repr (s - 1) vd := hSub s 1 _ _ vd hv (hsmall_intro 1) hsub
-              rcases hrec : wFuncN {primary}Code ({primary}Host sub) fuel {cs} [vd] with _ | vr
-              · simp [hrec] at hrun
-              · simp only [hrec] at hrun
-                have hrr : Repr ({cross_name} (s - 1)) vr := {cross_ih} (s - 1) vd vr hrd hrec
-                rw [{mn}_step s hle]; rw [Option.some.injEq] at hrun; rw [← hrun]; exact hrr
-        · obtain ⟨hsign, hne⟩ := hbig n s lty les sg hv
-          by_cases hlt : sg < (0 : Int)
-          · have hn0 : n ≤ 0 := by have := hsign.mp hlt; omega
-            simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32, popArgs, initLocals, hlt] at hrun
-            rw [{mn}_base n hn0, ← hrun]; exact hsmall_intro {base_lit}
-          · have hn0 : ¬ n ≤ 0 := by
-              intro hle; have : ¬ n < 0 := fun h => hlt (hsign.mpr h); omega
-            simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32, popArgs, initLocals, hlt] at hrun
-            rcases hsub : sub [.structv {c_ty} [.i64v s, .arr lty les, .i32v sg], carrierSmall {c_ty} 1] with _ | vd
-            · simp [hsub] at hrun
-            · simp only [hsub] at hrun
-              have hrd : Repr (n - 1) vd := hSub n 1 _ _ vd hv (hsmall_intro 1) hsub
-              rcases hrec : wFuncN {primary}Code ({primary}Host sub) fuel {cs} [vd] with _ | vr
-              · simp [hrec] at hrun
-              · simp only [hrec] at hrun
-                have hrr : Repr ({cross_name} (n - 1)) vr := {cross_ih} (n - 1) vd vr hrd hrec
-                rw [{mn}_step n hn0]; rw [Option.some.injEq] at hrun; rw [← hrun]; exact hrr"#,
-    )
-}
-
-/// Forward-progress mirror of `mutual_sim_member_block`. The cross call is
-/// supplied by the matching conjunction IH, while sub-totality supplies the
-/// concrete descended carrier value. There is no arithmetic combinator in the
-/// mutual countdown family, so add-totality is intentionally unused here.
-fn mutual_total_member_block(
-    primary: &str,
-    c_ty: u32,
-    m: &MutualMember,
-    cross_ih: &str,
-) -> String {
-    let base_lit = lean_int_lit(m.base_k);
-    let mn = &m.name;
-    format!(
-        r#"      · intro n v hv hbound
-        rcases hcar n v hv with ⟨s, sg, rfl⟩ | ⟨s, lty, les, sg, rfl⟩
-        · have hs := hsmall_elim n s sg hv; subst hs
-          by_cases hle : s ≤ (0 : Int)
-          · refine ⟨carrierSmall {c_ty} {base_lit}, ?_, ?_⟩
-            · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32,
-                popArgs, initLocals, hle]
-            · rw [{mn}_base s hle]; exact hsmall_intro {base_lit}
-          · obtain ⟨vd, hsub⟩ := hSubTot s 1 _ (carrierSmall {c_ty} 1) hv (hsmall_intro 1)
-            have hrd : Repr (s - 1) vd := hSub s 1 _ _ vd hv (hsmall_intro 1) hsub
-            obtain ⟨vr, hrec, hrr⟩ := {cross_ih} (s - 1) vd hrd (by omega)
-            refine ⟨vr, ?_, ?_⟩
-            · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32,
-                popArgs, initLocals, hle, hsub, hrec]
-            · rw [{mn}_step s hle]; exact hrr
-        · obtain ⟨hsign, hne⟩ := hbig n s lty les sg hv
-          by_cases hlt : sg < (0 : Int)
-          · have hn0 : n ≤ 0 := by have := hsign.mp hlt; omega
-            refine ⟨carrierSmall {c_ty} {base_lit}, ?_, ?_⟩
-            · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32,
-                popArgs, initLocals, hlt]
-            · rw [{mn}_base n hn0]; exact hsmall_intro {base_lit}
-          · have hn0 : ¬ n ≤ 0 := by
-              intro hle; have : ¬ n < 0 := fun h => hlt (hsign.mpr h); omega
-            obtain ⟨vd, hsub⟩ := hSubTot n 1 _ (carrierSmall {c_ty} 1) hv (hsmall_intro 1)
-            have hrd : Repr (n - 1) vd := hSub n 1 _ _ vd hv (hsmall_intro 1) hsub
-            obtain ⟨vr, hrec, hrr⟩ := {cross_ih} (n - 1) vd hrd (by omega)
-            refine ⟨vr, ?_, ?_⟩
-            · simp [wFuncN, wRunF, {primary}Code, {primary}Host, boxRef, b32,
-                popArgs, initLocals, hlt, hsub, hrec]
-            · rw [{mn}_step n hn0]; exact hrr"#,
-    )
-}
-
-/// The certificate block for a mutually-recursive SCC. Emitted ONCE, by the
-/// primary (lowest-`self_idx`) member; the shared block proves ONE conjunction
-/// `induction fuel` over all members (`{primary}_mutual_sim`), each cross-call
-/// discharged by the matching conjunct of the IH, on top of a conjunction
-/// fuel-irrelevance bridge and per-member base/step lemmas. Every member's
-/// obligation cites its conjunct. (Two-member SCC for now; the k>2 conjunction
-/// is a follow-up.)
-fn render_mutual_recursion_cert(c: &Cert) -> String {
+/// The concrete mutual claim fed to the audited generic discharge.  The SCC
+/// member set and host-role table are byte-derived data shared with the
+/// accepted-artifact witness.
+fn mutual_claim_lean_value(c: &Cert) -> String {
     let Cert::MutualRecursion {
+        name,
+        carrier,
+        box_idx,
+        sub_idx,
         scc,
+        ..
+    } = c.inner()
+    else {
+        unreachable!("audited mutual claim has a mutual-recursion shape")
+    };
+    format!(
+        "({{ exportNameBytes := {}, exportName := {}, carrier := {carrier}, \
+         memberSet := {}, hostTable := {}, obligation := AverCert.{name}Ob }} : \
+         AverCert.AcceptedArtifact.MutualRecursionClaim)",
+        render_byte_list(name.as_bytes()),
+        lean_str(name),
+        mutual_member_set_lean_value(scc),
+        mutual_host_table_lean_value(*box_idx, *sub_idx),
+    )
+}
+
+/// Concrete byte/plan acceptance for one member of the shared SCC.  This is
+/// data reconstruction only; source-model semantics lives in the bridge below.
+fn mutual_claim_acceptance_proof(c: &Cert) -> String {
+    let Cert::MutualRecursion {
         carrier,
         position,
+        scc,
+        ..
+    } = c.inner()
+    else {
+        unreachable!("audited mutual acceptance has a mutual-recursion shape")
+    };
+    let member = &scc[*position];
+    let plan = mutual_plan_from_cert(c).expect("audited mutual member has a canonical plan");
+    let body = lower_expr_fragment_plan(&plan, *carrier)
+        .map(|ops| render_ops_value(&ops))
+        .expect("audited mutual plan lowers to WInstr");
+    let bytes = lower_expr_fragment_plan_code_entry_bytes(&plan, *carrier)
+        .expect("audited mutual plan lowers to exact code-entry bytes");
+    let bytes = render_byte_list(&bytes);
+    let binding = format!(
+        "({{ funcIdx := {}, codeIdx := {}, typeIdx := {}, codeEntry := {bytes} }} : \
+         AverCert.WasmSlice.FuncBinding)",
+        member.self_idx, member.code_idx, member.type_idx,
+    );
+    format!(
+        "⟨rfl, rfl, rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
+         ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
+    )
+}
+
+/// Right-nested constructor for a conjunction of `count` reflexive facts.
+fn mutual_rfl_conjunction(count: usize) -> String {
+    debug_assert!(count >= 2);
+    (0..count - 2).fold("⟨rfl, rfl⟩".to_string(), |tail, _| {
+        format!("⟨rfl, {tail}⟩")
+    })
+}
+
+/// Exhaust a concrete `Fin k` by `Fin.cases`, closing each inhabited branch
+/// with `rfl`.  The final successor branch is `Fin 0` and closes by elimination.
+fn render_mutual_fin_rfl_cases(k: usize, initial_indent: &str) -> String {
+    debug_assert!(k >= 2);
+    let mut out = String::new();
+    let mut indent = initial_indent.to_string();
+    for _ in 0..k {
+        out.push_str(&format!("{indent}refine Fin.cases ?_ ?_ i\n"));
+        out.push_str(&format!("{indent}· rfl\n"));
+        out.push_str(&format!("{indent}· intro i\n"));
+        indent.push_str("  ");
+    }
+    out.push_str(&format!("{indent}exact Fin.elim0 i"));
+    out
+}
+
+/// Definitions shared by every option-(b) bridge in one SCC: concrete members,
+/// plans, raw edges, the audited `AdmittedScc`, claims, and byte acceptance.
+/// Emitted once by the primary (lowest-self-index) member.
+fn render_mutual_shared_bridge_data(c: &Cert) -> String {
+    let Cert::MutualRecursion {
+        position,
+        carrier,
+        box_idx,
+        sub_idx,
+        scc,
         ..
     } = c.inner()
     else {
         unreachable!()
     };
     if *position != 0 {
-        // The shared block is emitted once, by the primary member.
         return String::new();
     }
-    let k = scc.len();
-    let c_ty = *carrier;
     let primary = &scc[0].name;
-    // The SCC position of each member's cross-call target.
-    let cross_pos: Vec<usize> = scc
+    let k = scc.len();
+    let member_set = mutual_member_set_lean_value(scc);
+    let members = scc
         .iter()
-        .map(|m| {
-            scc.iter()
-                .position(|x| x.self_idx == m.cross_idx)
-                .expect("cross target is an SCC member")
+        .map(|member| {
+            let cross = scc
+                .iter()
+                .position(|candidate| candidate.self_idx == member.cross_idx)
+                .expect("mutual cross target is an SCC member");
+            format!(
+                "({{ self := {}, base := {}, cross := ⟨{cross}, by omega⟩ }} : \
+                 V3Mutual.MemberU {k})",
+                member.self_idx,
+                lean_int_lit(member.base_k),
+            )
         })
-        .collect();
-    let holes = std::iter::repeat_n("?_", k).collect::<Vec<_>>().join(", ");
-
-    let mut s = String::new();
-    s.push_str(&format!(
-        "/-! ### {primary} — mutual-recursive SCC certificate (carrier type {c_ty}) -/\n\n"
-    ));
-
-    // ---- model-side fuel bridge (conjunction; one cap-induction at R = 1) ----
-    let bridge_conj = scc
-        .iter()
-        .map(|m| format!("{m}__fuel k1 n = {m}__fuel k2 n", m = m.name))
         .collect::<Vec<_>>()
-        .join(" ∧ ");
-    let all_fuel = scc
+        .join(",\n    ");
+    let plans = scc
         .iter()
-        .map(|m| format!("{}__fuel", m.name))
+        .map(|member| format!("AverCert.Plans.{}MutualPlan", member.name))
         .collect::<Vec<_>>()
         .join(", ");
-    let hb_names = (0..k)
-        .map(|i| format!("hb{i}"))
+    let edges = scc
+        .iter()
+        .map(|member| format!("({}, {}, {member_set})", member.self_idx, member.cross_idx))
         .collect::<Vec<_>>()
         .join(", ");
-    let bridge_rewrites = scc
+    let claims = scc
         .iter()
-        .enumerate()
-        .map(|(p, m)| {
-            format!(
-                "        · simp only [{m}__fuel]; rw [if_neg hn, if_neg hn, hb{cp}]",
-                m = m.name,
-                cp = cross_pos[p],
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    s.push_str(&format!(
-        r#"-- model-side fuel bridge over the whole SCC (the cap-induction pattern at R = 1).
-theorem {primary}_fuel_irrel :
-    ∀ (t k1 k2 : Nat) (n : Int), n.natAbs < t → n.natAbs < k1 → n.natAbs < k2 →
-      {bridge_conj} := by
-  intro t
-  induction t with
-  | zero => intro k1 k2 n ht _ _; omega
-  | succ t ih =>
-      intro k1 k2 n ht h1 h2
-      cases k1 with
-      | zero => omega
-      | succ m1 =>
-      cases k2 with
-      | zero => omega
-      | succ m2 =>
-      by_cases hn : n ≤ 0
-      · refine ⟨{holes}⟩ <;> simp [{all_fuel}, hn]
-      · have hstep : (n - 1).natAbs < t := by
-          have h1n : (1 : Int) ≤ n := by omega
-          have h2n : (n - 1).natAbs = n.natAbs - 1 := by omega
-          omega
-        obtain ⟨{hb_names}⟩ := ih m1 m2 (n - 1) hstep (by omega) (by omega)
-        refine ⟨{holes}⟩
-{bridge_rewrites}
-
-"#,
-    ));
-
-    // ---- per-member base/step lemmas -----------------------------------------
-    for (p, m) in scc.iter().enumerate() {
-        let cn = &scc[cross_pos[p]].name;
-        let base_lit = lean_int_lit(m.base_k);
-        let proj = conjunct_proj(cross_pos[p], k);
-        let mn = &m.name;
-        s.push_str(&format!(
-            r#"theorem {mn}_base (n : Int) (hn : n ≤ 0) : {mn} n = {base_lit} := by
-  simp [{mn}, {mn}__fuel, hn]
-
-theorem {mn}_step (n : Int) (hn : ¬ n ≤ 0) : {mn} n = {cn} (n - 1) := by
-  simp only [{mn}, {mn}__fuel]
-  rw [if_neg hn]
-  show {cn}__fuel n.natAbs (n - 1) = {cn} (n - 1)
-  rw [{cn}]
-  exact ({primary}_fuel_irrel (n.natAbs + (n - 1).natAbs + 2) n.natAbs ((n - 1).natAbs + 1)
-    (n - 1) (by omega) (by omega) (by omega)){proj}
-
-"#,
-        ));
-    }
-
-    // ---- the conjunction simulation theorem (one `induction fuel`) -----------
-    let sim_conj = scc
-        .iter()
-        .map(|m| {
-            format!(
-                "      (∀ n v w, Repr n v →\n        wFuncN {primary}Code ({primary}Host sub) fuel {self_idx} [v] = some w → Repr ({m} n) w)",
-                self_idx = m.self_idx,
-                m = m.name,
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(" ∧\n");
-    let ih_names = (0..k)
-        .map(|i| format!("ih{i}"))
+        .map(|member| format!("{}_mutualClaim", member.name))
         .collect::<Vec<_>>()
         .join(", ");
-    let member_blocks = scc
+    let accepted = scc.iter().rev().fold("trivial".to_string(), |tail, member| {
+        format!("⟨{}_mutualClaimAccepted, {tail}⟩", member.name)
+    });
+    let lowered = render_mutual_fin_rfl_cases(k, "      ");
+
+    let mut out = format!(
+        r#"/-! ### {primary} — option-(b) mutual SCC data -/
+
+def {primary}_mutualMembers : Fin {k} → V3Mutual.MemberU {k} := fun i =>
+  [{members}].get i
+
+def {primary}_mutualPlans : Fin {k} → MutualRawPlan := fun i =>
+  [{plans}].get i
+
+def {primary}_mutualEdges : List (Nat × Nat × List Nat) :=
+  [{edges}]
+
+def {primary}_mutualScc : V3Mutual.AdmittedScc {k} {carrier} {box_idx} {sub_idx} :=
+  {{ members := {primary}_mutualMembers
+    plans := {primary}_mutualPlans
+    rawEdges := {primary}_mutualEdges
+    edgesBound := by decide
+    closed := by decide
+    checked := by decide
+    shaped := by decide
+    lowered := by
+      intro i
+{lowered} }}
+
+"#,
+    );
+    for member in scc {
+        let member_cert = Cert::MutualRecursion {
+            name: member.name.clone(),
+            self_idx: member.self_idx,
+            carrier: *carrier,
+            box_idx: *box_idx,
+            sub_idx: *sub_idx,
+            position: scc
+                .iter()
+                .position(|candidate| candidate.self_idx == member.self_idx)
+                .expect("member belongs to SCC"),
+            scc: scc.clone(),
+        };
+        let wrapped = Cert::NonRecursive {
+            inner: Box::new(member_cert),
+        };
+        let claim = mutual_claim_lean_value(&wrapped);
+        let acceptance = mutual_claim_acceptance_proof(&wrapped);
+        out.push_str(&format!(
+            r#"def {name}_mutualClaim : AverCert.AcceptedArtifact.MutualRecursionClaim :=
+  {claim}
+
+theorem {name}_mutualClaimAccepted :
+    AverCert.AcceptedArtifact.mutualRecursionClaimAccepted
+      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest
+      {name}_mutualClaim := by
+  dsimp [{name}_mutualClaim,
+    AverCert.AcceptedArtifact.mutualRecursionClaimAccepted,
+    AverCert.AcceptedArtifact.mutualPlanForExport,
+    AverCert.AcceptedArtifact.mutualPlanAccepted]
+  exact {acceptance}
+
+"#,
+            name = member.name,
+        ));
+    }
+    out.push_str(&format!(
+        r#"def {primary}_mutualClaims : List AverCert.AcceptedArtifact.MutualRecursionClaim :=
+  [{claims}]
+
+def {primary}_mutualArtifact : AverCert.AcceptedArtifact.ArtifactData :=
+  {{ modBytes := AverCert.ArtifactBytes.modBytes,
+    modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest,
+    symFragmentClaims := [], stringEqClaims := [], stringConcatClaims := [],
+    constructClaims := [], recursionClaims := [],
+    mutualRecursionClaims := {primary}_mutualClaims,
+    verbatimClaims := [], intDispatchClaims := [], fieldProjectionClaims := [],
+    compositionMembers := [], compositionClaims := [], closureFuel := 0,
+    closureClaim := {{ roots := [], helpers := [], admitted := [] }} }}
+
+theorem {primary}_mutualFragmentsAccepted :
+    AverCert.AcceptedArtifact.acceptedMutualRecursionFragments
+      {primary}_mutualArtifact := by
+  dsimp [AverCert.AcceptedArtifact.acceptedMutualRecursionFragments,
+    AverCert.AcceptedArtifact.mutualRecursionClaimsAccepted,
+    AverCert.AcceptedArtifact.allClaims,
+    AverCert.AcceptedArtifact.mutualClaimsFormClosedSccs,
+    AverCert.AcceptedArtifact.mutualClaimEdges,
+    AverCert.AcceptedArtifact.mutualClaimEdge,
+    AverCert.AcceptedArtifact.mutualPlanForExport,
+    AverCert.AcceptedArtifact.mutualPlanTarget,
+    AverCert.AcceptedArtifact.mutualMembersFormClosedSccs,
+    AverCert.AcceptedArtifact.followSccCycle,
+    AverCert.AcceptedArtifact.natEdgeLookup,
+    AverCert.AcceptedArtifact.natListNodup,
+    AverCert.AcceptedArtifact.natListSetEq,
+    {primary}_mutualArtifact, {primary}_mutualClaims]
+  exact ⟨{accepted}, rfl⟩
+
+"#,
+    ));
+    out
+}
+
+/// Option-(b) residual for one mutual export.  A simultaneous fuel induction
+/// relates every source member to the plan-derived k-generic evaluator; the
+/// selected member then supplies both domain directions required by
+/// `mutualSemanticBridge`.  Wasm execution and totality stay in the audited wall.
+fn render_mutual_semantic_bridge(c: &Cert) -> String {
+    let Cert::MutualRecursion {
+        name,
+        position,
+        box_idx,
+        sub_idx,
+        scc,
+        ..
+    } = c.inner()
+    else {
+        unreachable!()
+    };
+    let primary = &scc[0].name;
+    let k = scc.len();
+    let model_fuel = scc
         .iter()
         .enumerate()
-        .map(|(p, m)| {
-            mutual_sim_member_block(
-                primary,
-                c_ty,
-                m,
-                &scc[cross_pos[p]].name,
-                &format!("ih{}", cross_pos[p]),
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    s.push_str(&format!(
-        r#"/-- THE CERTIFICATE THEOREM: partial correctness of the VERBATIM emitted mutual
-    bodies against the generated models, for ALL n : ℤ, as ONE conjunction proven
-    by a single `induction fuel` (each cross-call discharged by the matching IH
-    conjunct). -/
-theorem {primary}_mutual_sim
-    (Repr : Int → WVal → Prop)
-    (hcar : ∀ n v, Repr n v →
-      (∃ s sg, v = .structv {c_ty} [.i64v s, .null, .i32v sg]) ∨
-      (∃ s lty les sg, v = .structv {c_ty} [.i64v s, .arr lty les, .i32v sg]))
-    (hsmall_intro : ∀ k : Int, Repr k (carrierSmall {c_ty} k))
-    (hsmall_elim : ∀ n s sg, Repr n (.structv {c_ty} [.i64v s, .null, .i32v sg]) → s = n)
-    (hbig : ∀ n s lty les sg,
-      Repr n (.structv {c_ty} [.i64v s, .arr lty les, .i32v sg]) → ((sg < 0) ↔ (n < 0)) ∧ n ≠ 0)
-    (sub : List WVal → Option WVal)
-    (hSub : ∀ a b va vb w, Repr a va → Repr b vb → sub [va, vb] = some w → Repr (a - b) w) :
-    ∀ (fuel : Nat),
-{sim_conj} := by
-  intro fuel
-  induction fuel with
-  | zero =>
-      refine ⟨{holes}⟩ <;> · intro n v w hv hrun; simp [wFuncN] at hrun
-  | succ fuel ih =>
-      obtain ⟨{ih_names}⟩ := ih
-      refine ⟨{holes}⟩
-{member_blocks}
-
-#print axioms {primary}_mutual_sim
-
-"#,
-    ));
-
-    // ---- total correctness over the same conjunction induction -------------
-    let total_aux_conj = scc
-        .iter()
-        .map(|m| {
+        .map(|(member_pos, member)| {
             format!(
-                "      (∀ n v, Repr n v → n.natAbs < fuel →\n        ∃ w, wFuncN {primary}Code ({primary}Host sub) fuel {self_idx} [v] = some w ∧ Repr ({m} n) w)",
-                self_idx = m.self_idx,
-                m = m.name,
+                "V3Mutual.evalMutualUFuel {primary}_mutualMembers fuel \
+                 ⟨{member_pos}, by omega⟩ n = {}__fuel fuel n",
+                member.name,
             )
         })
         .collect::<Vec<_>>()
-        .join(" ∧\n");
-    let total_member_blocks = scc
+        .join(" ∧\n      ");
+    let source_fuels = scc
         .iter()
-        .enumerate()
-        .map(|(p, m)| {
-            mutual_total_member_block(
-                primary,
-                c_ty,
-                m,
-                &format!("ih{}", cross_pos[p]),
-            )
-        })
+        .map(|member| format!("{}__fuel", member.name))
         .collect::<Vec<_>>()
-        .join("\n");
-    let total_conj = scc
-        .iter()
-        .map(|m| {
-            format!(
-                "    (∀ n v, Repr n v →\n      ∃ w, wFuncN {primary}Code ({primary}Host sub) (n.natAbs + 1) {self_idx} [v] = some w ∧ Repr ({m} n) w)",
-                self_idx = m.self_idx,
-                m = m.name,
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(" ∧\n");
-    let total_fixed_blocks = (0..k)
-        .map(|p| {
-            let proj = conjunct_proj(p, k);
-            format!(
-                "  · intro n v hv\n    exact ({primary}_mutual_total_aux Repr hcar hsmall_intro hsmall_elim hbig sub hSub hSubTot (n.natAbs + 1)){proj} n v hv (by omega)"
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    s.push_str(&format!(
-        r#"/-- Fuel-parametric progress for every member of the byte-closed integer
-    countdown SCC, proved by one conjunction induction. -/
-theorem {primary}_mutual_total_aux
-    (Repr : Int → WVal → Prop)
-    (hcar : ∀ n v, Repr n v →
-      (∃ s sg, v = .structv {c_ty} [.i64v s, .null, .i32v sg]) ∨
-      (∃ s lty les sg, v = .structv {c_ty} [.i64v s, .arr lty les, .i32v sg]))
-    (hsmall_intro : ∀ k : Int, Repr k (carrierSmall {c_ty} k))
-    (hsmall_elim : ∀ n s sg, Repr n (.structv {c_ty} [.i64v s, .null, .i32v sg]) → s = n)
-    (hbig : ∀ n s lty les sg,
-      Repr n (.structv {c_ty} [.i64v s, .arr lty les, .i32v sg]) → ((sg < 0) ↔ (n < 0)) ∧ n ≠ 0)
-    (sub : List WVal → Option WVal)
-    (hSub : ∀ a b va vb w, Repr a va → Repr b vb → sub [va, vb] = some w → Repr (a - b) w)
-    (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
-    ∀ (fuel : Nat),
-{total_aux_conj} := by
-  intro fuel
-  induction fuel with
-  | zero =>
-      refine ⟨{holes}⟩ <;> · intro n v hv hbound; omega
-  | succ fuel ih =>
-      obtain ⟨{ih_names}⟩ := ih
-      refine ⟨{holes}⟩
-{total_member_blocks}
+        .join(", ");
+    let zero = mutual_rfl_conjunction(k);
+    let projection = conjunct_proj(*position, k);
+    let fin_cases = render_mutual_fin_rfl_cases(k, "    ");
+    format!(
+        r#"/-! ### {name} — option-(b) mutual semantic bridge -/
 
-#print axioms {primary}_mutual_total_aux
+theorem {name}_mutualSemanticBridge :
+    V3Master.mutualSemanticBridge {primary}_mutualArtifact
+      {name}_mutualClaim AverCert.Plans.{name}MutualPlan := by
+  have hModelFuel : ∀ fuel n,
+      {model_fuel} := by
+    intro fuel
+    induction fuel with
+    | zero => intro n; exact {zero}
+    | succ fuel ih =>
+        intro n
+        simp only [V3Mutual.evalMutualUFuel, {source_fuels}]
+        split <;> simp_all [{primary}_mutualMembers]
+  have hModel : ∀ n,
+      V3Mutual.evalMutualU {primary}_mutualMembers
+        ⟨{position}, by omega⟩ n = {name} n := by
+    intro n
+    simpa [V3Mutual.evalMutualU, {name}] using
+      (hModelFuel (n.natAbs + 1) n){projection}
+  refine ⟨{k}, {box_idx}, {sub_idx}, {primary}_mutualScc,
+    ⟨{position}, by omega⟩, rfl, rfl, rfl, rfl, ?_, ?_, ?_, ?_⟩
+  · intro i _hi
+{fin_cases}
+  · intro add sub mul stringEq stringConcat
+    refine ⟨rfl, rfl, ?_⟩
+    intro i
+{fin_cases}
+  · intro S ns vs hDom
+    rcases hDom with ⟨hRepr, hLen⟩
+    cases hRepr with
+    | nil => simp at hLen
+    | cons hv htail =>
+        rename_i n v ns vs
+        cases htail with
+        | nil =>
+            refine ⟨n, v, rfl, hv, ?_⟩
+            intro w hw
+            change S.Repr (V3Mutual.evalMutualU {primary}_mutualMembers
+              ⟨{position}, by omega⟩ n) w at hw
+            rw [hModel n] at hw
+            simpa [{name}_mutualClaim, AverCert.{name}Ob,
+              AverCert.Schema.intRepr] using hw
+        | cons _ _ => simp at hLen
+  · intro S n v hv
+    refine ⟨[n], ⟨ReprAll.cons hv ReprAll.nil, rfl⟩, ?_⟩
+    intro w hw
+    change S.Repr (V3Mutual.evalMutualU {primary}_mutualMembers
+      ⟨{position}, by omega⟩ n) w at hw
+    rw [hModel n] at hw
+    simpa [{name}_mutualClaim, AverCert.{name}Ob,
+      AverCert.Schema.intRepr] using hw
 
-/-- TOTAL correctness of the SCC at the fuel selected by each member's checked
-    `intNatAbs` witness. The statement is a conjunction, so no member can be
-    promoted independently of its cross-call hypotheses. -/
-theorem {primary}_mutual_total
-    (Repr : Int → WVal → Prop)
-    (hcar : ∀ n v, Repr n v →
-      (∃ s sg, v = .structv {c_ty} [.i64v s, .null, .i32v sg]) ∨
-      (∃ s lty les sg, v = .structv {c_ty} [.i64v s, .arr lty les, .i32v sg]))
-    (hsmall_intro : ∀ k : Int, Repr k (carrierSmall {c_ty} k))
-    (hsmall_elim : ∀ n s sg, Repr n (.structv {c_ty} [.i64v s, .null, .i32v sg]) → s = n)
-    (hbig : ∀ n s lty les sg,
-      Repr n (.structv {c_ty} [.i64v s, .arr lty les, .i32v sg]) → ((sg < 0) ↔ (n < 0)) ∧ n ≠ 0)
-    (sub : List WVal → Option WVal)
-    (hSub : ∀ a b va vb w, Repr a va → Repr b vb → sub [va, vb] = some w → Repr (a - b) w)
-    (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
-{total_conj} := by
-  refine ⟨{holes}⟩
-{total_fixed_blocks}
-
-#print axioms {primary}_mutual_total
-
+#print axioms {name}_mutualSemanticBridge
 "#,
-    ));
+    )
+}
 
-    // Stable per-export theorem names used by the JSON report.
-    for (p, m) in scc.iter().enumerate() {
-        let proj = conjunct_proj(p, k);
-        let mn = &m.name;
-        s.push_str(&format!(
-            r#"theorem {mn}_wasm_total
-    (Repr : Int → WVal → Prop)
-    (hcar : ∀ n v, Repr n v →
-      (∃ s sg, v = .structv {c_ty} [.i64v s, .null, .i32v sg]) ∨
-      (∃ s lty les sg, v = .structv {c_ty} [.i64v s, .arr lty les, .i32v sg]))
-    (hsmall_intro : ∀ k : Int, Repr k (carrierSmall {c_ty} k))
-    (hsmall_elim : ∀ n s sg, Repr n (.structv {c_ty} [.i64v s, .null, .i32v sg]) → s = n)
-    (hbig : ∀ n s lty les sg,
-      Repr n (.structv {c_ty} [.i64v s, .arr lty les, .i32v sg]) → ((sg < 0) ↔ (n < 0)) ∧ n ≠ 0)
-    (sub : List WVal → Option WVal)
-    (hSub : ∀ a b va vb w, Repr a va → Repr b vb → sub [va, vb] = some w → Repr (a - b) w)
-    (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
-    ∀ n v, Repr n v →
-      ∃ w, wFuncN {primary}Code ({primary}Host sub) (n.natAbs + 1) {self_idx} [v] = some w ∧
-        Repr ({mn} n) w :=
-  ({primary}_mutual_total Repr hcar hsmall_intro hsmall_elim hbig sub hSub hSubTot){proj}
-
-#print axioms {mn}_wasm_total
-
-"#,
-            self_idx = m.self_idx,
-        ));
-    }
-
-    // ---- anti-vacuity: the emitted bodies actually RUN -----------------------
-    s.push_str(&format!(
-        "-- anti-vacuity: the emitted bodies actually RUN on concrete inputs.\n\
-         def {primary}HostRef : HostTbl := {primary}Host (subRef {c_ty})\n"
-    ));
-    for (p, m) in scc.iter().enumerate() {
-        for &input in &[4i64, 3, -1] {
-            let expected = eval_mutual(scc, p, input);
-            s.push_str(&format!(
-                "example :\n    \
-                 ((wFuncN {primary}Code {primary}HostRef 40 {self_idx} [carrierSmall {c_ty} {inp}]).bind carrierToInt)\n      \
-                 = some {exp} := by native_decide\n",
-                self_idx = m.self_idx,
-                inp = lean_int_lit(input),
-                exp = lean_int_lit128(expected as i128),
-            ));
-        }
-    }
-
-    // ---- per-member schema obligations (each cites its conjunct) -------------
-    for (p, m) in scc.iter().enumerate() {
-        let proj = conjunct_proj(p, k);
-        let mn = &m.name;
-        s.push_str(&format!(
-            r#"
-/-- Schema-shaped simulation obligation for `{mn}` (composed by the single final
-    theorem): the emitted mutual body simulates the model `{mn}` via the matching
-    conjunct of `{primary}_mutual_sim`. -/
-theorem {mn}_simulates : AverCert.Schema.Obligation.holds {mn}Ob := by
-  intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel ns vs w hrepr hrun
-  simp only [{mn}Ob, AverCert.Schema.Obligation.holds] at hrun ⊢
-  obtain ⟨hrepr, harity⟩ := hrepr
-  cases hrepr with
-  | nil =>
-      simp at harity
-  | cons hv htail =>
-      rename_i n v ns vs
-      cases htail with
-      | nil =>
-          simpa [AverCert.Schema.intRepr] using ({primary}_mutual_sim S.Repr S.car S.smallIntro S.smallElim S.bigElim
-            sub hsub fuel){proj} n v w hv hrun
-      | cons _ _ =>
-          simp at harity
-"#,
-        ));
-        s.push_str(&format!(
-            r#"
-theorem {mn}_simulates_total : AverCert.Schema.Obligation.holdsTotal {mn}Ob := by
-  intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat
-    hAddTot hSubTot x vs hDom
-  simp only [{mn}Ob] at hDom ⊢
-  obtain ⟨hrepr, harity⟩ := hDom
-  cases hrepr with
-  | nil => simp at harity
-  | cons hv htail =>
-      rename_i n v ns vs
-      cases htail with
-      | nil =>
-          refine ⟨n, v, [], rfl, hv, ?_⟩
-          simpa [{mn}Ob, AverCert.Schema.intRepr] using
-            {mn}_wasm_total S.Repr S.car S.smallIntro S.smallElim S.bigElim
-              sub hsub hSubTot n v hv
-      | cons _ _ => simp at harity
-"#,
-        ));
-    }
-
-    s
+/// Per-obligation `Final.cert` arm.  The SCC artifact supplies byte acceptance
+/// and closure; this export contributes only its option-(b) semantic bridge.
+fn render_mutual_final_arm(c: &Cert) -> String {
+    let Cert::MutualRecursion { name, scc, .. } = c.inner() else {
+        unreachable!()
+    };
+    let primary = &scc[0].name;
+    format!(
+        r#"exact V3Master.mutual_claim_discharges
+        CertProofs.{primary}_mutualArtifact
+        CertProofs.{primary}_mutualFragmentsAccepted
+        CertProofs.{name}_mutualClaim
+        (by simp [CertProofs.{primary}_mutualArtifact,
+          CertProofs.{primary}_mutualClaims])
+        (by
+          intro plan hPlan
+          dsimp [CertProofs.{primary}_mutualArtifact,
+            AverCert.AcceptedArtifact.mutualPlanForExport] at hPlan
+          injection hPlan with hPlan
+          subst plan
+          exact CertProofs.{name}_mutualSemanticBridge)"#,
+    )
 }

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -67,6 +67,23 @@ fn verify_certificate(wasm: &std::path::Path, cert_dir: &std::path::Path) -> (bo
     )
 }
 
+fn assert_certificate_target_builds(cert_dir: &std::path::Path, case: &str) {
+    let output = Command::new("lake")
+        .current_dir(cert_dir)
+        .args(["build", "Certificate"])
+        .output()
+        .expect("lake builds the isolated Certificate target");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "honest Certificate target must build before the hostile edit ({case}):\n{combined}"
+    );
+}
+
 fn lean_obligation_def<'a>(manifest_lean: &'a str, name: &str) -> &'a str {
     let marker = format!("abbrev {name}Ob : Schema.Obligation :=");
     let start = manifest_lean
@@ -171,10 +188,10 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
     );
     assert_eq!(
         manifest["schema_version"].as_u64(),
-        Some(60),
-        "multiplicative/accumulator recursion migration is certificate schema 60"
+        Some(61),
+        "mutual option-(b) migration is certificate schema 61"
     );
-    assert_eq!(aver::codegen::cert::CERT_SCHEMA_VERSION, 60);
+    assert_eq!(aver::codegen::cert::CERT_SCHEMA_VERSION, 61);
     let declared_uncertified = manifest["declaredUncertified"].as_array().unwrap();
     assert_eq!(
         declared_uncertified.len(),
@@ -784,6 +801,13 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             "recursion arm must use the audited discharge and emitted bridge: {recursion_name}\n{final_lean}"
         );
     }
+    for mutual_name in ["isEven", "isOdd"] {
+        assert!(
+            final_lean.contains("V3Master.mutual_claim_discharges")
+                && final_lean.contains(&format!("CertProofs.{mutual_name}_mutualSemanticBridge")),
+            "mutual arm must use the audited discharge and emitted bridge: {mutual_name}\n{final_lean}"
+        );
+    }
     for bespoke_name in ["addTwo"] {
         assert!(
             final_lean.contains(&format!("CertProofs.{bespoke_name}_")),
@@ -818,8 +842,15 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             && !certificate.contains("countDown_wasm_certified")
             && !certificate.contains("countDown_wasm_total")
             && !certificate.contains("countDown_simulates")
-            && !certificate.contains("countDownHostRef"),
-        "migrated leaf/dispatch/construct/recursion families must not emit bespoke simulations or tripwires:\n{certificate}"
+            && !certificate.contains("countDownHostRef")
+            && !certificate.contains("isEven_simulates")
+            && !certificate.contains("isOdd_simulates")
+            && !certificate.contains("isEven_wasm")
+            && !certificate.contains("isOdd_wasm")
+            && !certificate.contains("isEven_mutual_sim")
+            && !certificate.contains("isEven_mutual_total")
+            && !certificate.contains("isEvenHostRef"),
+        "migrated leaf/dispatch/construct/recursion/mutual families must not emit bespoke simulations or tripwires:\n{certificate}"
     );
     for dispatch_name in ["evalOp", "boxInt", "gauge"] {
         assert!(
@@ -852,6 +883,16 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             && certificate.contains("ReprAll.cons hvn (ReprAll.cons hvacc ReprAll.nil)"),
         "accumulator recursion must emit both arity-two option-(b) model directions:\n{certificate}"
     );
+    for mutual_name in ["isEven", "isOdd"] {
+        assert!(
+            certificate.contains(&format!("theorem {mutual_name}_mutualSemanticBridge"))
+                && certificate.contains("V3Mutual.evalMutualUFuel")
+                && certificate.contains("have hModelFuel")
+                && certificate.contains("refine ⟨n, v, rfl, hv")
+                && certificate.contains("⟨[n], ⟨ReprAll.cons hv ReprAll.nil, rfl⟩"),
+            "mutual export must emit both option-(b) model directions: {mutual_name}\n{certificate}"
+        );
+    }
     let user_name = manifest["certified"]
         .as_array()
         .unwrap()
@@ -883,6 +924,15 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
         .find(|entry| entry["name"] == "countDown")
         .unwrap();
     assert_eq!(count_down["theorem"], "V3Master.recursion_claim_discharges");
+    for name in ["isEven", "isOdd"] {
+        let entry = manifest["certified"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap();
+        assert_eq!(entry["theorem"], "V3Master.mutual_claim_discharges");
+    }
     for (name, theorem) in [
         ("wrapItems", "V3Master.verbatim_canonical_discharges"),
         ("tagName", "V3Master.verbatim_canonical_discharges"),
@@ -943,6 +993,16 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
         ),
         "recursion bridge/discharge changed axiom surface:\n{combined}"
     );
+    assert!(
+        combined.contains(
+            "'CertProofs.isEven_mutualSemanticBridge' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        ) && combined.contains(
+            "'CertProofs.isOdd_mutualSemanticBridge' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        ) && combined.contains(
+            "'V3Master.mutual_claim_discharges' depends on axioms: [propext, Classical.choice, Quot.sound]"
+        ),
+        "mutual bridge/discharge changed axiom surface:\n{combined}"
+    );
 
     let typecheck = cert_dir.join("V3AcceptRealTypecheck.lean");
     std::fs::write(
@@ -987,7 +1047,7 @@ example :
 }
 
 #[test]
-fn cert_verify_declines_hostile_leaf_dispatch_construct_and_recursion_models() {
+fn cert_verify_declines_hostile_leaf_dispatch_construct_recursion_and_mutual_models() {
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping hostile leaf-model test: `lake` not available");
         return;
@@ -1020,6 +1080,10 @@ fn cert_verify_declines_hostile_leaf_dispatch_construct_and_recursion_models() {
         clean_ok,
         "hostile-model baseline must first certify:\n{clean_report}"
     );
+    let build_green = temp_dir("certify-hostile-mutual-build-green");
+    copy_dir_all(&out_dir, &build_green);
+    assert_certificate_target_builds(&build_green.join("cert"), "mutual hostile-model baseline");
+    let _ = std::fs::remove_dir_all(&build_green);
 
     for (label, honest, hostile) in [
         (
@@ -1079,6 +1143,43 @@ fn cert_verify_declines_hostile_leaf_dispatch_construct_and_recursion_models() {
         "wrong generated construct model definition must fail its emitted bridge and be DECLINED:\n{report}"
     );
     let _ = std::fs::remove_dir_all(&tampered);
+
+    for (name, honest, hostile) in [
+        (
+            "isEven",
+            "else isOdd__fuel fuel' (n - 1))",
+            "else isOdd__fuel fuel' (n - 2))",
+        ),
+        (
+            "isOdd",
+            "else isEven__fuel fuel' (n - 1))",
+            "else isEven__fuel fuel' (n - 2))",
+        ),
+    ] {
+        let tampered = temp_dir(&format!("certify-hostile-{name}-model-definition"));
+        copy_dir_all(&out_dir, &tampered);
+        let model = tampered.join("cert/CertGoals.lean");
+        let source = std::fs::read_to_string(&model).unwrap();
+        let edited = source.replacen(honest, hostile, 1);
+        assert_ne!(
+            source, edited,
+            "{name} model definition changed; update the hostile-model regression"
+        );
+        std::fs::write(&model, edited).unwrap();
+        let manifest = std::fs::read_to_string(tampered.join("cert/Manifest.lean")).unwrap();
+        assert!(
+            manifest.contains(&format!("model := fun ns => {name} (ns.headD 0)")),
+            "{name} hostile regression must leave the manifest model reference untouched"
+        );
+
+        let (ok, report) =
+            verify_certificate(&tampered.join("cert_goals.wasm"), &tampered.join("cert"));
+        assert!(
+            !ok && report.contains("DECLINED") && !report.contains("CERTIFIED"),
+            "wrong generated {name} definition must fail the mutual semantic bridge and be DECLINED:\n{report}"
+        );
+        let _ = std::fs::remove_dir_all(&tampered);
+    }
 
     let tampered = temp_dir("certify-hostile-recursion-model-definition");
     copy_dir_all(&out_dir, &tampered);
@@ -1497,24 +1598,17 @@ fn certify_mutual_recursion_scc_lake_builds_kernel_clean() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
     // A two-member SCC (`isEven`/`isOdd`) and a three-member cycle
-    // (`rotA -> rotB -> rotC -> rotA`), so the ONE shared conjunction proof — its
-    // `induction fuel`, its k-way destructuring and its `.2.….1` conjunct
-    // projection — is exercised at both k = 2 and k = 3. `primary` is the
-    // lowest-`self_idx` member whose `{primary}_mutual_sim` carries the proof.
-    let cases: [(&str, &[&str], &str); 2] = [
-        (
-            "tools/certkit/fixtures/mutual.av",
-            &["isEven", "isOdd"],
-            "isEven",
-        ),
+    // (`rotA -> rotB -> rotC -> rotA`) exercise the plan-derived `AdmittedScc`
+    // and simultaneous source-fuel bridge at k = 2 and k = 3.
+    let cases: [(&str, &[&str]); 2] = [
+        ("tools/certkit/fixtures/mutual.av", &["isEven", "isOdd"]),
         (
             "tools/certkit/fixtures/mutual3.av",
             &["rotA", "rotB", "rotC"],
-            "rotA",
         ),
     ];
 
-    for (fixture, exports, primary) in cases {
+    for (fixture, exports) in cases {
         let out_dir = temp_dir("certify-mutual");
         let compile = aver_command()
             .current_dir(&repo_root)
@@ -1545,7 +1639,8 @@ fn certify_mutual_recursion_scc_lake_builds_kernel_clean() {
             .iter()
             .map(|c| c["name"].as_str().unwrap())
             .collect();
-        // Every member of the SCC is a certified export sharing one proof.
+        // Every member of the SCC is a certified export using the same audited
+        // SCC package and its own source-model bridge.
         for name in exports {
             assert!(
                 certified.contains(name),
@@ -1558,6 +1653,7 @@ fn certify_mutual_recursion_scc_lake_builds_kernel_clean() {
                 assert_eq!(entry["level"], "L3");
                 assert_eq!(entry["termination_witness"]["measure"]["kind"], "intNatAbs");
                 assert_eq!(entry["termination_witness"]["descent"], -1);
+                assert_eq!(entry["theorem"], "V3Master.mutual_claim_discharges");
             }
         }
 
@@ -1575,19 +1671,33 @@ fn certify_mutual_recursion_scc_lake_builds_kernel_clean() {
             build.status.success(),
             "lake build of emitted mutual cert {fixture} failed:\n{combined}"
         );
-        // The whole SCC shares ONE simulation proof, `{primary}_mutual_sim`,
-        // kernel-clean on the core whitelist.
+        let certificate = std::fs::read_to_string(cert_dir.join("Certificate.lean")).unwrap();
+        let final_lean = std::fs::read_to_string(cert_dir.join("Final.lean")).unwrap();
+        for name in exports {
+            assert!(
+                combined.contains(&format!(
+                    "'CertProofs.{name}_mutualSemanticBridge' depends on axioms: [propext, Classical.choice, Quot.sound]"
+                )),
+                "mutual bridge for {name} in {fixture} not kernel-clean:\n{combined}"
+            );
+            assert!(
+                certificate.contains(&format!("theorem {name}_mutualSemanticBridge"))
+                    && !certificate.contains(&format!("{name}_simulates"))
+                    && !certificate.contains(&format!("{name}_wasm"))
+                    && final_lean.contains("V3Master.mutual_claim_discharges")
+                    && final_lean.contains(&format!("CertProofs.{name}_mutualSemanticBridge")),
+                "migrated mutual export retained bespoke proof/tripwire emission: {name}\n{certificate}\n{final_lean}"
+            );
+        }
         assert!(
-            combined.contains(&format!(
-                "{primary}_mutual_sim' depends on axioms: [propext, Classical.choice, Quot.sound]"
-            )),
-            "mutual certificate for {fixture} not kernel-clean:\n{combined}"
+            !certificate.contains("native_decide"),
+            "generic mutual discharge must not emit a native-decide tripwire:\n{certificate}"
         );
         assert!(
-            combined.contains(&format!(
-                "{primary}_mutual_total' depends on axioms: [propext, Classical.choice, Quot.sound]"
-            )),
-            "mutual total certificate for {fixture} not kernel-clean:\n{combined}"
+            combined.contains(
+                "'AverCert.Final.cert' depends on axioms: [propext, Classical.choice, Quot.sound]"
+            ),
+            "mutual Final.cert changed axiom surface for {fixture}:\n{combined}"
         );
         assert!(
             !combined.contains("sorryAx"),

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -4457,6 +4457,16 @@ fn cert_verify_declines_tampered_mutual_plan() {
     let cert = out_dir.join("cert");
     let (ok, report) = aver_verify(&wasm, &cert);
     assert!(ok, "honest mutual certificate should verify:\n{report}");
+    let certificate = std::fs::read_to_string(cert.join("Certificate.lean")).unwrap();
+    assert!(
+        certificate.contains("theorem isEven_mutualSemanticBridge")
+            && certificate.contains("theorem isOdd_mutualSemanticBridge")
+            && !certificate.contains("isEven_simulates")
+            && !certificate.contains("isOdd_simulates")
+            && !certificate.contains("isEven_wasm")
+            && !certificate.contains("isOdd_wasm"),
+        "migrated mutual family must expose only option-(b) bridges:\n{certificate}"
+    );
 
     // Honest bytes and plan, zero locals in the obligation only: every mutual
     // member canonically declares one carrier scratch local.
@@ -4466,6 +4476,62 @@ fn cert_verify_declines_tampered_mutual_plan() {
         set_named_code_nlocals_to_zero(&dir.join("cert/Module.lean"), "isEven", 1, 1);
         let (ok, report) = aver_verify(&dir.join("mutual.wasm"), &dir.join("cert"));
         assert!(!ok, "mutual zero-locals code must be DECLINED:\n{report}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The migrated family has no bespoke simulation theorem to replace with a
+    // vacuous proof. Pointing the obligation at a trapping decoy must now fail
+    // directly in the generic mutual claim's byte/plan acceptance.
+    {
+        let dir = temp_dir("cert-mutual-code-decouple");
+        copy_dir(&out_dir, &dir);
+        let module = dir.join("cert/Module.lean");
+        let source = std::fs::read_to_string(&module).unwrap();
+        let edited = source.replacen(
+            "end CertModule",
+            "/-- decoy: always traps, so an unbound simulation would be vacuous. -/\n\
+             def wrongCode : CodeTbl := fun _ => none\nend CertModule",
+            1,
+        );
+        assert_ne!(source, edited, "mutual Module.lean end marker changed");
+        std::fs::write(&module, edited).unwrap();
+
+        let manifest = dir.join("cert/Manifest.lean");
+        let source = std::fs::read_to_string(&manifest).unwrap();
+        let edited = source.replacen(
+            "code := CertModule.isEvenCode",
+            "code := CertModule.wrongCode",
+            1,
+        );
+        assert_ne!(source, edited, "isEven obligation code field changed");
+        std::fs::write(&manifest, edited).unwrap();
+
+        let (ok, report) = aver_verify(&dir.join("mutual.wasm"), &dir.join("cert"));
+        assert!(
+            !ok && !report.contains("CERTIFIED"),
+            "mutual code decouple must be DECLINED by generic acceptance:\n{report}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Likewise the obligation's selected member is part of the generic claim;
+    // a wrong self index cannot be hidden behind a bespoke mutual proof.
+    {
+        let dir = temp_dir("cert-mutual-self-decouple");
+        copy_dir(&out_dir, &dir);
+        let manifest = dir.join("cert/Manifest.lean");
+        let source = std::fs::read_to_string(&manifest).unwrap();
+        let honest = "code := CertModule.isEvenCode, host := fun _ sub _ _ _ => CertModule.isEvenHost sub, self := 1,";
+        let hostile = "code := CertModule.isEvenCode, host := fun _ sub _ _ _ => CertModule.isEvenHost sub, self := 5,";
+        let edited = source.replacen(honest, hostile, 1);
+        assert_ne!(source, edited, "isEven obligation self field changed");
+        std::fs::write(&manifest, edited).unwrap();
+
+        let (ok, report) = aver_verify(&dir.join("mutual.wasm"), &dir.join("cert"));
+        assert!(
+            !ok && !report.contains("CERTIFIED"),
+            "mutual self decouple must be DECLINED by generic acceptance:\n{report}"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Mutual recursion (isEven/isOdd) migrates to option-b: the audited generic mutual discharge fed a per-obligation bridge (fuel induction tying the source mutual models to the plan-derived mutual evaluator, unfolding the real source definitions). Bespoke mutual proof emission removed. Hostile model declined with build-green-first isolation. Verified locally: mutual.av CERTIFIED (isEven/isOdd, L3), cert_goals.av 23 unchanged, cert_certify_spec 13/13, axioms [propext, Classical.choice, Quot.sound]. Full cert_verify_spec runs in CI. Schema 60 → 61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)