### PR TITLE
Derive expr-fragment and composition conformance from the audited generic

### DIFF
--- a/src/codegen/cert/V3DischargeComposition.lean
+++ b/src/codegen/cert/V3DischargeComposition.lean
@@ -194,9 +194,10 @@ private theorem compositionNamedMemberAccepted_of_mem
           · exact ⟨member, hLookup, hHead⟩
           · exact ih hTail hMem
 
-/-- Function-table lookup agrees with the byte-derived binding of a selected
-member. -/
-private theorem compositionFuncIdx_eq_binding
+/-- A member's function-table target is exactly its byte-derived export
+    binding.  Generated option-(b) bridges use this instead of re-evaluating
+    the whole artifact byte parser or pinning a second function table. -/
+theorem compositionFuncIdx_eq_binding
     (modBytes modLen : Nat) (members : List CompositionMemberClaim)
     (funcTable : List (String × Nat)) (name : String)
     (member : CompositionMemberClaim)
@@ -277,6 +278,46 @@ def compositionMemberDischarges (artifact : ArtifactData) : Prop :=
           (claim.obligation.host add sub mul stringEq stringConcat)
           models name)
 
+/-- Option-(b) per-obligation bridge. Unlike the artifact-wide legacy split
+    above, the source model selection and the member facts are existentially
+    tied in one bridge, so a generated bridge cannot prove facts for one model
+    function and discharge a root using another. -/
+def compositionClaimSemanticBridge
+    (artifact : ArtifactData) (claim : CompositionClaim)
+    (callees : List String) : Prop :=
+  claim.obligation.policy = .simulatesModel ∧
+  ∀ (S : CarrierSpec claim.obligation.carrier)
+    (add sub mul stringEq : List WVal → Option WVal)
+    (stringConcat : Nat → List WVal → Option WVal)
+    (hAdd : ∀ a b va vb w, S.Repr a va → S.Repr b vb →
+      add [va, vb] = some w → S.Repr (a + b) w)
+    (hSub : ∀ a b va vb w, S.Repr a va → S.Repr b vb →
+      sub [va, vb] = some w → S.Repr (a - b) w)
+    (hMul : ∀ a b va vb w, S.Repr a va → S.Repr b vb →
+      mul [va, vb] = some w → S.Repr (a * b) w)
+    (hStringEq : ∀ a b w, stringEq [a, b] = some w →
+      w = b32 (stringEqW a b))
+    (hStringConcat : ∀ resultTy parts c,
+      stringConcat resultTy [parts] = some c →
+        stringConcatW resultTy parts = some c)
+    (x : claim.obligation.Dom) (vs : List WVal),
+    claim.obligation.domRepr S x vs →
+    ∃ (n : Int) (v : WVal) (models : String → Int → Int)
+      (rootModel : Int → Int),
+      vs = [v] ∧ S.Repr n v ∧
+      (∀ input, rootModel input =
+        V3Composition.evalCompositionCalls models callees input) ∧
+      (∀ w, S.Repr (rootModel n) w →
+        claim.obligation.codRepr S (claim.obligation.model x) w) ∧
+      ∀ funcTable,
+        compositionFuncTable artifact.modBytes artifact.modLen
+            artifact.compositionMembers = some funcTable →
+        ∀ name ∈ callees,
+          Nonempty (V3Composition.MemberFact S artifact.compositionMembers
+            funcTable claim.obligation.code
+            (claim.obligation.host add sub mul stringEq stringConcat)
+            models name)
+
 theorem composition_claim_discharges
     (artifact : ArtifactData)
     (hAcc : acceptedCompositionFragments artifact)
@@ -348,6 +389,77 @@ theorem composition_claim_discharges
           apply hCod
           exact hCertified fuel n v w hv hRun
 
+/-- Per-obligation option-(b) composition discharge. Acceptance supplies the
+    byte-derived root and member table; the single semantic bridge supplies a
+    source model and member facts tied to that same model selection. -/
+theorem composition_claim_discharges_with_bridge
+    (artifact : ArtifactData)
+    (claim : CompositionClaim)
+    (hClaim : compositionClaimAccepted artifact.modBytes artifact.modLen
+      artifact.compositionMembers claim)
+    (hBridge : ∀ rootMember,
+      compositionMemberForName claim.exportName artifact.compositionMembers =
+          some rootMember →
+      ∀ callees, rootMember.plan.shape = .chain callees →
+        compositionClaimSemanticBridge artifact claim callees) :
+    obligationHolds claim.obligation := by
+  rcases hClaim with ⟨_hExport, hCarrier, _hHostCheck, hHost, hClaim⟩
+  cases hTable : compositionFuncTable artifact.modBytes artifact.modLen
+      artifact.compositionMembers with
+  | none => simp [hTable] at hClaim
+  | some funcTable =>
+      simp only [hTable] at hClaim
+      rcases hClaim with ⟨hClosure, hRootIdx, hNamed⟩
+      obtain ⟨rootMember, callees, hRootLookup, hShape, hRootMem⟩ :=
+        compositionClosureBound_root claim.exportName claim.memberNames
+          artifact.compositionMembers funcTable hClosure
+      obtain ⟨acceptedRoot, hAcceptedLookup, hRootAccepted⟩ :=
+        compositionNamedMemberAccepted_of_mem artifact.modBytes artifact.modLen
+          claim.carrier claim.hostTable funcTable claim.obligation
+          artifact.compositionMembers claim.memberNames hNamed
+          claim.exportName hRootMem
+      rw [hRootLookup] at hAcceptedLookup
+      have hRootEq : acceptedRoot = rootMember :=
+        (Option.some.inj hAcceptedLookup).symm
+      subst acceptedRoot
+      clear hClosure
+      rcases hRootAccepted with
+        ⟨hCheck, body, codeEntry, binding, hLower, _hCodeEntry,
+          _hExportCode, hBinding, _hBindingCode, _hType, hCode⟩
+      cases hTarget : AverCert.PlanLower.compositionFuncIdx?
+              funcTable claim.exportName with
+      | none => simp [hTarget] at hRootIdx
+      | some rootIdx =>
+          have hSelf : claim.obligation.self = rootIdx := by
+            simpa [hTarget] using hRootIdx
+          have hBindingIdx : binding.funcIdx = rootIdx := by
+            have hResolved := compositionFuncIdx_eq_binding
+              artifact.modBytes artifact.modLen artifact.compositionMembers
+              funcTable claim.exportName rootMember binding hTable
+              hRootLookup hBinding
+            rw [hTarget] at hResolved
+            exact (Option.some.inj hResolved).symm
+          have hCodeSelf : claim.obligation.code claim.obligation.self =
+              some ⟨1, compositionNLocals rootMember.plan, body⟩ := by
+            simpa [hSelf, ← hBindingIdx] using hCode
+          rcases hBridge rootMember hRootLookup callees hShape with
+            ⟨hPolicy, hModel⟩
+          rw [obligationHolds, hPolicy]
+          intro S add sub mul stringEq stringConcat
+            hAdd hSub hMul hStringEq hStringConcat fuel x vs w hDom hRun
+          rcases hModel S add sub mul stringEq stringConcat
+              hAdd hSub hMul hStringEq hStringConcat x vs hDom with
+            ⟨n, v, models, rootModel, rfl, hv, hRootModel, hCod, hMembers⟩
+          have hCertified := V3Composition.generic_composition_certified
+            S artifact.compositionMembers funcTable claim.obligation.code
+            (claim.obligation.host add sub mul stringEq stringConcat)
+            models rootModel claim.obligation.self claim.hostTable
+            rootMember.plan callees hShape hCheck body hLower hCodeSelf
+            (fun name hName => Classical.choice
+              (hMembers funcTable hTable name hName)) hRootModel
+          apply hCod
+          exact hCertified fuel n v w hv hRun
+
 theorem composition_discharges
     (artifact : ArtifactData)
     (hAcc : acceptedCompositionFragments artifact)
@@ -361,4 +473,5 @@ theorem composition_discharges
 end V3Master
 
 #print axioms V3Master.composition_claim_discharges
+#print axioms V3Master.composition_claim_discharges_with_bridge
 #print axioms V3Master.composition_discharges

--- a/src/codegen/cert/V3DischargeExprFragment.lean
+++ b/src/codegen/cert/V3DischargeExprFragment.lean
@@ -4,9 +4,12 @@ v3 master wiring — source expression-fragment discharge.
 Acceptance pins the audited SymRawPlan encoder, checked representation plan,
 canonical lowering, and exact code entry.  The independent obligation
 domain/model face and the plan-evaluator result stay explicit, following the
-established family-discharge pattern.  In particular, source integer inputs
-are materialised with `carrierSmall`, which is the exact comparison domain of
-`exprfragment_generic_certified`.
+established family-discharge pattern.  The bridge chooses the exact input
+values: comparison fragments use `carrierSmall`, Bool fragments use `b32`,
+and contracted integer fragments preserve arbitrary represented inputs.  For
+partial host contracts, the successful byte run is exposed only to rule out a
+missing host result; the audited generic still identifies the evaluator result
+with the byte result.
 -/
 import V3Master
 
@@ -32,19 +35,33 @@ private theorem allClaims_of_mem {Claim : Type u} (accept : Claim → Prop)
 
 /-- The semantic face not carried by `symFragmentPlanAccepted`.  It relates an
 arbitrary obligation-domain representation to the generic theorem's honest
-`carrierSmall` source arguments and pins the SymRawPlan-derived evaluator's
-result to the obligation's independently declared model/codomain relation. -/
+input values and pins the SymRawPlan-derived evaluator's result to the
+obligation's independently declared model/codomain relation. -/
 def exprFragmentSemanticBridge
     (claim : SymFragmentClaim) (plan : ExprFragmentRawPlan) : Prop :=
   claim.obligation.policy = .simulatesModel ∧
   ∀ (S : CarrierSpec claim.obligation.carrier)
     (add sub mul stringEq : List WVal → Option WVal)
     (stringConcat : Nat → List WVal → Option WVal)
-    (fuel : Nat) (x : claim.obligation.Dom) (vs : List WVal),
+    (hAdd : ∀ a b va vb w, S.Repr a va → S.Repr b vb →
+      add [va, vb] = some w → S.Repr (a + b) w)
+    (hSub : ∀ a b va vb w, S.Repr a va → S.Repr b vb →
+      sub [va, vb] = some w → S.Repr (a - b) w)
+    (hMul : ∀ a b va vb w, S.Repr a va → S.Repr b vb →
+      mul [va, vb] = some w → S.Repr (a * b) w)
+    (hStringEq : ∀ a b w, stringEq [a, b] = some w →
+      w = b32 (stringEqW a b))
+    (hStringConcat : ∀ resultTy parts c,
+      stringConcat resultTy [parts] = some c →
+        stringConcatW resultTy parts = some c)
+    (fuel : Nat) (x : claim.obligation.Dom) (vs : List WVal) (w : WVal),
     claim.obligation.domRepr S x vs →
-    ∃ (sourceArgs : List Int) (modelLocals : List WVal) (result : WVal),
-      vs = sourceArgs.map (carrierSmall claim.obligation.carrier) ∧
-      sourceArgs.length = plan.params.length ∧
+    wFuncN claim.obligation.code
+      (claim.obligation.host add sub mul stringEq stringConcat)
+      (fuel + 1) claim.obligation.self vs = some w →
+    ∃ (inputs : List WVal) (modelLocals : List WVal) (result : WVal),
+      vs = inputs ∧
+      inputs.length = plan.params.length ∧
       V3ExprFragmentGeneric.blockCallsOK
         (claim.obligation.host add sub mul stringEq stringConcat)
         (fun g => (claim.obligation.code g).map (fun c => c.arity))
@@ -57,7 +74,7 @@ def exprFragmentSemanticBridge
           (claim.obligation.host add sub mul stringEq stringConcat) fuel g args)
         claim.obligation.carrier claim.plan
         (initLocals ⟨plan.params.length, exprFragmentNLocals plan, []⟩
-          (sourceArgs.map (carrierSmall claim.obligation.carrier))) =
+          inputs) =
           some (.ok modelLocals [result]) ∧
       claim.obligation.codRepr S (claim.obligation.model x) result
 
@@ -107,17 +124,18 @@ theorem exprFragment_claim_discharges
         simpa [← hSelf] using hCode
       rw [obligationHolds, hPolicy]
       intro S add sub mul stringEq stringConcat
-        _hAdd _hSub _hMul _hStringEq _hStringConcat fuel x vs w hDom hRun
+        hAdd hSub hMul hStringEq hStringConcat fuel x vs w hDom hRun
       cases fuel with
       | zero => simp [wFuncN] at hRun
       | succ fuel =>
-          rcases hSemantic S add sub mul stringEq stringConcat fuel x vs hDom with
-            ⟨sourceArgs, modelLocals, result, rfl, hArity, hCalls, hEval, hCod⟩
+          rcases hSemantic S add sub mul stringEq stringConcat
+              hAdd hSub hMul hStringEq hStringConcat fuel x vs w hDom hRun with
+            ⟨inputs, modelLocals, result, rfl, hArity, hCalls, hEval, hCod⟩
           have hGeneric := V3ExprFragmentGeneric.exprfragment_generic_certified
             S claim.hostTable claim.structTable claim.obligation.code
             (claim.obligation.host add sub mul stringEq stringConcat)
             claim.plan plan hEncode hCheck body hLower claim.obligation.self
-            (exprFragmentNLocals plan) fuel hCodeSelf sourceArgs hArity hCalls
+            (exprFragmentNLocals plan) fuel hCodeSelf vs hArity hCalls
             modelLocals result hEval
           rw [hGeneric] at hRun
           have hResult : result = w := Option.some.inj hRun

--- a/src/codegen/cert/V3GenericCertified.lean
+++ b/src/codegen/cert/V3GenericCertified.lean
@@ -444,10 +444,11 @@ theorem mutualCorrect (fuel : Nat) : NodesCorrect fuel /\ BlockCorrect fuel := b
 
 /-! ## Audited-plan generic certificate
 
-The source inputs are deliberately materialised with `carrierSmall`; this is
-the domain exported range/comparison obligations quantify over.  No claim is
-made for an arbitrary `S.Repr` at a comparison boundary (the big-carrier
-eliminator intentionally does not provide enough information for that).
+The input values are supplied by the per-obligation semantic bridge.  This
+keeps the lowering theorem representation-polymorphic: comparison obligations
+may still choose the honest `carrierSmall` domain, while contracted integer
+operations may retain their stronger arbitrary-`S.Repr` domain and Bool
+fragments may use their canonical `b32` inputs.
 
 `evalSymRawPlan` begins at the checked source `SymRawPlan`, invokes the audited
 encoder, and evaluates the resulting structured plan.  Thus the theorem is
@@ -466,8 +467,8 @@ theorem exprfragment_generic_certified {C : Nat} (S : CarrierSpec C)
     (hlower : lowerBlock C plan.body = some instrs)
     (self nlocals fuel : Nat)
     (hself : code self = some ⟨plan.params.length, nlocals, instrs⟩)
-    (sourceArgs : List Int)
-    (hsourceArity : sourceArgs.length = plan.params.length)
+    (inputs : List WVal)
+    (hinputArity : inputs.length = plan.params.length)
     (hcalls : blockCallsOK host (fun g => (code g).map (fun c => c.arity))
       plan.body)
     (modelLocals : List WVal) (result : WVal)
@@ -475,17 +476,14 @@ theorem exprfragment_generic_certified {C : Nat} (S : CarrierSpec C)
       (fun g => (code g).map (fun c => c.arity))
       (fun g args => wFuncN code host fuel g args)
       C symPlan
-      (initLocals ⟨plan.params.length, nlocals, instrs⟩
-        (sourceArgs.map (carrierSmall C))) =
+      (initLocals ⟨plan.params.length, nlocals, instrs⟩ inputs) =
       some (.ok modelLocals [result])) :
-    wFuncN code host (fuel + 1) self
-      (sourceArgs.map (carrierSmall C)) = some result := by
+    wFuncN code host (fuel + 1) self inputs = some result := by
   have hevalBlock : runBlock host
       (fun g => (code g).map (fun c => c.arity))
       (fun g args => wFuncN code host fuel g args)
       C plan.body
-      (initLocals ⟨plan.params.length, nlocals, instrs⟩
-        (sourceArgs.map (carrierSmall C))) =
+      (initLocals ⟨plan.params.length, nlocals, instrs⟩ inputs) =
       some (.ok modelLocals [result]) := by
     simp only [evalSymRawPlan, hencode] at heval
     exact heval
@@ -493,15 +491,13 @@ theorem exprfragment_generic_certified {C : Nat} (S : CarrierSpec C)
       (fun g => (code g).map (fun (c : WCode) => c.arity))
       (fun g args => wFuncN code host fuel g args)
       maxFuel C plan.body
-      (initLocals ⟨plan.params.length, nlocals, instrs⟩
-        (sourceArgs.map (carrierSmall C))) =
+      (initLocals ⟨plan.params.length, nlocals, instrs⟩ inputs) =
       some (.ok modelLocals [result]) at hevalBlock
   have hwrun := (mutualCorrect maxFuel).2 host
     (fun g => (code g).map (fun (c : WCode) => c.arity))
     (fun g args => wFuncN code host fuel g args)
     C plan.body instrs hcalls hlower
-    (initLocals ⟨plan.params.length, nlocals, instrs⟩
-      (sourceArgs.map (carrierSmall C)))
+    (initLocals ⟨plan.params.length, nlocals, instrs⟩ inputs)
     (.ok modelLocals [result]) hevalBlock
   simp [wFuncN, hself, hwrun]
 

--- a/src/codegen/cert/mod.rs
+++ b/src/codegen/cert/mod.rs
@@ -85,7 +85,7 @@ pub const RUNTIME_ABI: &str = "aver-wasm-gc/0";
 /// Certification level of a v0 artifact certificate: conditional on the named
 /// runtime contracts (see the consult level naming L0/L1/L2/L3).
 pub const CERT_LEVEL: &str = "L1";
-pub const CERT_SCHEMA_VERSION: u32 = 60;
+pub const CERT_SCHEMA_VERSION: u32 = 61;
 pub const BOX_CONTRACT: &str = "__rt_aint_from_i64 (box i64 -> carrier)";
 pub const INT_ADD_CONTRACT: &str =
     "Int.add (carrier add = exact integer addition on represented values)";

--- a/src/codegen/cert/render.rs
+++ b/src/codegen/cert/render.rs
@@ -6,6 +6,7 @@ include!("render_composition.rs");
 include!("render_adt_constructor.rs");
 include!("render_adt.rs");
 include!("render_expr_fragment.rs");
+include!("render_expr_fragment_bridge.rs");
 include!("render_model_support.rs");
 include!("render_mutual.rs");
 include!("render_manifest.rs");

--- a/src/codegen/cert/render_certificate.rs
+++ b/src/codegen/cert/render_certificate.rs
@@ -5,7 +5,7 @@ fn render_certificate(
 ) -> String {
     let mut s = String::new();
     s.push_str(
-        "import CertPrelude\nimport Module\nimport Schema\nimport Manifest\nimport V3DispatchCore\nimport V3DischargeRecursion\n",
+        "import CertPrelude\nimport Module\nimport Schema\nimport Manifest\nimport V3DispatchCore\nimport V3DischargeComposition\nimport V3DischargeExprFragment\nimport V3DischargeRecursion\n",
     );
     for r in model_roots {
         s.push_str(&format!("import {r}\n"));
@@ -16,6 +16,8 @@ fn render_certificate(
          set_option maxRecDepth 1000000\n\n\
          namespace CertProofs\nopen CertPrelude CertModule AverCert AverCert.Schema\n\n",
     );
+    let struct_table_lean = emit_frag_struct_table_lean(analysis)
+        .expect("certified fragment struct table remains consistent");
     for c in &analysis.certs {
         match c.inner() {
             Cert::Recursive { .. } | Cert::AccumulatorRecursive { .. }
@@ -44,6 +46,13 @@ fn render_certificate(
                     analysis.frag_host_table,
                 ))
             }
+            Cert::ExprFragment { .. } if expr_fragment_uses_audited_generic(c) => {
+                s.push_str(&render_expr_fragment_semantic_bridge(
+                    c,
+                    analysis.frag_host_table,
+                    &struct_table_lean,
+                ))
+            }
             Cert::ExprFragment { .. } => s.push_str(&render_expr_fragment_cert(c)),
             // Verbatim and String families are discharged by their audited
             // canonical leaf bridges. Their plans/claims/data remain emitted.
@@ -51,7 +60,9 @@ fn render_certificate(
             | Cert::VerbatimVariantDispatch { .. }
             | Cert::StringEqVerbatimMatch { .. }
             | Cert::StringConcatVerbatimMatch { .. } => {}
-            Cert::Composition { .. } => s.push_str(&render_composition_cert(c)),
+            Cert::Composition { .. } => {
+                s.push_str(&render_composition_semantic_bridge(c, analysis))
+            }
             Cert::MutualRecursion { .. } => s.push_str(&render_mutual_recursion_cert(c)),
             Cert::NonRecursive { .. } => unreachable!(),
         }

--- a/src/codegen/cert/render_composition.rs
+++ b/src/codegen/cert/render_composition.rs
@@ -28,62 +28,122 @@ fn compose_topo_order(caller_idx: u32, closure: &[ClosureEntry]) -> Vec<u32> {
     order
 }
 
-/// Evaluate a closure entry's integer model on a concrete input (for the
-/// anti-vacuity `native_decide` guard values). Mirrors the leaf models exactly.
-fn compose_eval(idx: u32, x: i64, by_idx: &std::collections::HashMap<u32, &ClosureEntry>) -> i64 {
-    match by_idx.get(&idx).map(|e| &e.shape) {
-        Some(LeafShape::SelfSum { .. }) => x + x,
-        Some(LeafShape::Chain { calls }) => {
-            let mut acc = x;
-            for c in calls {
-                acc = compose_eval(*c, acc, by_idx);
-            }
-            acc
-        }
-        None => x,
-    }
+fn composition_member_claim_lean_value(entry: &ClosureEntry) -> String {
+    format!(
+        "({{ exportNameBytes := {}, exportName := {}, \
+         plan := AverCert.Plans.{}CompositionPlan }} : \
+         AverCert.AcceptedArtifact.CompositionMemberClaim)",
+        render_byte_list(entry.name.as_bytes()),
+        lean_str(&entry.name),
+        entry.name,
+    )
 }
 
-/// Longest chain of code-calls from `idx` down to a leaf (fuel budget for the
-/// `native_decide` guards: each level burns one unit in `wFuncN`).
-fn compose_depth(idx: u32, by_idx: &std::collections::HashMap<u32, &ClosureEntry>) -> usize {
-    match by_idx.get(&idx).map(|e| &e.shape) {
-        Some(LeafShape::Chain { calls }) => {
-            1 + calls
-                .iter()
-                .map(|c| compose_depth(*c, by_idx))
-                .max()
-                .unwrap_or(0)
-        }
-        _ => 1,
-    }
+fn composition_members_lean_value(closure: &[ClosureEntry]) -> String {
+    format!(
+        "[{}]",
+        closure
+            .iter()
+            .map(composition_member_claim_lean_value)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
-/// The cross-function composition certificate: a simulation lemma per closure
-/// entry over the caller's SHARED code table (callee lemmas first, the caller's
-/// `_wasm_certified` last), the anti-vacuity guards, and the schema obligation.
-/// Content-blind: the only per-function inputs are DATA (the closure entries,
-/// their call indices and model names), never a hand-tuned proof.
-fn render_composition_cert(c: &Cert) -> String {
+fn composition_claim_lean_value(c: &Cert, add_idx: u32) -> String {
+    let Cert::Composition {
+        name,
+        carrier,
+        closure,
+        ..
+    } = c.inner()
+    else {
+        unreachable!()
+    };
+    let member_names = closure
+        .iter()
+        .map(|entry| lean_str(&entry.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "({{ exportName := {}, carrier := {carrier}, hostTable := {}, \
+         memberNames := [{member_names}], obligation := AverCert.{name}Ob }} : \
+         AverCert.AcceptedArtifact.CompositionClaim)",
+        lean_str(name),
+        composition_host_table_lean_value(add_idx),
+    )
+}
+
+fn composition_claim_acceptance_proof(
+    c: &Cert,
+    strict: FragHostTable,
+) -> String {
+    let Cert::Composition {
+        carrier, closure, ..
+    } = c.inner()
+    else {
+        unreachable!()
+    };
+    let plans = composition_plans_from_cert(c, strict)
+        .expect("audited composition has byte-derived member plans");
+    let add_idx = strict
+        .add_idx
+        .expect("plan-backed composition has strict add host");
+    let funcs = composition_func_table(closure);
+    let mut named_proof = "trivial".to_string();
+    for (entry, plan) in plans.iter().rev() {
+        let body = render_ops_value(
+            &lower_composition_plan(plan, add_idx, &funcs)
+                .expect("composition member lowers against closure table"),
+        );
+        let code_entry = render_byte_list(
+            &composition_code_entry_bytes(plan, *carrier, add_idx, &funcs)
+                .expect("composition member byte-lowers against closure table"),
+        );
+        let binding = format!(
+            "({{ funcIdx := {}, codeIdx := {}, typeIdx := {}, codeEntry := {} }} : \
+             AverCert.WasmSlice.FuncBinding)",
+            entry.self_idx, entry.code_idx, entry.type_idx, code_entry
+        );
+        let member_proof = format!(
+            "⟨rfl, ⟨({body}), ({code_entry}), {binding}, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩"
+        );
+        named_proof = format!("⟨{member_proof}, {named_proof}⟩");
+    }
+    format!("⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, {named_proof}⟩⟩⟩⟩⟩⟩")
+}
+
+/// Option-(b) composition bridge. Root glue is discharged by the audited
+/// generic; generated lemmas remain only for the non-root member semantics
+/// that the generic deliberately consumes through `MemberFact`.
+fn render_composition_semantic_bridge(c: &Cert, analysis: &Analysis) -> String {
     let Cert::Composition {
         name,
         self_idx,
         carrier,
         closure,
         ..
-    } = c
+    } = c.inner()
     else {
         unreachable!()
     };
+    let add_idx = analysis
+        .frag_host_table
+        .add_idx
+        .expect("composition bridge has strict add host");
     let by_idx: std::collections::HashMap<u32, &ClosureEntry> =
         closure.iter().map(|e| (e.self_idx, e)).collect();
-    let lemma_name = |idx: u32| -> String {
-        if idx == *self_idx {
-            format!("{name}_wasm_certified")
-        } else {
-            format!("{name}__sim_{idx}")
-        }
+    let root = by_idx[self_idx];
+    let LeafShape::Chain { calls: root_calls } = &root.shape else {
+        unreachable!("composition root is a chain")
     };
+    let callees = root_calls
+        .iter()
+        .map(|idx| lean_str(&by_idx[idx].name))
+        .collect::<Vec<_>>();
+    let callees_lean = format!("[{}]", callees.join(", "));
+    let lemma_name = |idx: u32| -> String { format!("{name}__compositionMember_{idx}") };
+    let model_name = format!("{name}CompositionModel");
     let sig = |concl_model: &str| -> String {
         format!(
             "    (S : CarrierSpec {carrier}) (add sub : List WVal → Option WVal)\n\
@@ -95,15 +155,36 @@ fn render_composition_cert(c: &Cert) -> String {
     };
 
     let mut s = format!(
-        "/-! ### {name} — cross-function composition certificate (carrier type {carrier}) -/\n\n"
+        "/-! ### {name} — option-(b) composition semantic bridge (carrier type {carrier}) -/\n\n"
     );
+    s.push_str(&format!(
+        "def {model_name} (member : String) (x : Int) : Int :=\n  {}\n\n",
+        closure
+            .iter()
+            .map(|entry| format!(
+                "if member = {} then {} x else",
+                lean_str(&entry.name),
+                entry.name
+            ))
+            .chain(std::iter::once("x".to_string()))
+            .collect::<Vec<_>>()
+            .join(" ")
+    ));
+    let model_simp = closure
+        .iter()
+        .map(|entry| entry.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
 
     for idx in compose_topo_order(*self_idx, closure) {
+        if idx == *self_idx {
+            continue;
+        }
         let e = by_idx[&idx];
         let head = format!(
             "theorem {}\n{}",
             lemma_name(idx),
-            sig(&format!("{} x", e.name))
+            sig(&format!("{model_name} {} x", lean_str(&e.name)))
         )
         .replace("{IDX}", &idx.to_string());
         match &e.shape {
@@ -117,7 +198,7 @@ fn render_composition_cert(c: &Cert) -> String {
                      rcases hc : add [v, v] with _ | r <;>\n        \
                      simp [wFuncN, wRunF, {name}Code, {name}Host, boxRef, popArgs, initLocals, hc] at hrun\n      \
                      subst hrun\n      \
-                     exact hadd x x v v r hv hv hc\n\n",
+                     simpa [{model_name}, {model_simp}] using hadd x x v v r hv hv hc\n\n",
                     ename = e.name,
                 ));
             }
@@ -150,57 +231,169 @@ fn render_composition_cert(c: &Cert) -> String {
                         h = i + 1,
                         lem = lemma_name(*c_idx),
                     ));
-                    model_arg = format!("{} ({})", by_idx[c_idx].name, model_arg);
+                    model_arg = format!(
+                        "{model_name} {} ({model_arg})",
+                        lean_str(&by_idx[c_idx].name)
+                    );
                 }
-                body.push_str(&format!("      exact r{}\n\n", calls.len()));
+                body.push_str(&format!(
+                    "      simpa [{model_name}, {model_simp}] using r{}\n\n",
+                    calls.len()
+                ));
                 s.push_str(&format!(
-                    "-- {label} `{ename}`: unary user-call chain; cites each callee lemma.\n{head} := by\n  \
+                    "-- callee `{ename}`: unary user-call chain; cites each member lemma.\n{head} := by\n  \
                      intro fuel x v w hv hrun\n  \
                      cases fuel with\n  \
                      | zero => simp only [wFuncN, reduceCtorEq] at hrun\n  \
                      | succ f =>\n{body}",
                     ename = e.name,
-                    label = if idx == *self_idx { "caller" } else { "callee" },
                 ));
             }
         }
     }
 
-    s.push_str(&format!("#print axioms {name}_wasm_certified\n\n"));
-
-    // anti-vacuity guards: run the whole closure on concrete inputs.
-    let g_fuel = compose_depth(*self_idx, &by_idx) + 2;
-    let g3 = compose_eval(*self_idx, 3, &by_idx);
-    let gm5 = compose_eval(*self_idx, -5, &by_idx);
+    let members = composition_members_lean_value(closure);
+    let claim = composition_claim_lean_value(c, add_idx);
+    let acceptance = composition_claim_acceptance_proof(c, analysis.frag_host_table);
     s.push_str(&format!(
-        "-- anti-vacuity: the emitted closure actually RUNS on concrete inputs.\n\
-         def {name}HostRef : HostTbl := {name}Host (addRef {carrier}) (subRef {carrier})\n\
-         example :\n    \
-         ((wFuncN {name}Code {name}HostRef {g_fuel} {self_idx} [carrierSmall {carrier} 3]).bind carrierToInt) = some ({g3}) := by\n  \
-         native_decide\n\
-         example :\n    \
-         ((wFuncN {name}Code {name}HostRef {g_fuel} {self_idx} [carrierSmall {carrier} (-5)]).bind carrierToInt) = some ({gm5}) := by\n  \
-         native_decide\n\n"
+        "def {name}CompositionMembers : List AverCert.AcceptedArtifact.CompositionMemberClaim :=\n  \
+         {members}\n\n\
+         def {name}CompositionClaim : AverCert.AcceptedArtifact.CompositionClaim :=\n  \
+         {claim}\n\n\
+         theorem {name}_compositionClaimAccepted :\n    \
+         AverCert.AcceptedArtifact.compositionClaimAccepted\n      \
+         AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen\n      \
+         {name}CompositionMembers {name}CompositionClaim := by\n  \
+         dsimp [{name}CompositionMembers, {name}CompositionClaim,\n    \
+         AverCert.AcceptedArtifact.compositionClaimAccepted,\n    \
+         AverCert.AcceptedArtifact.compositionFuncTable,\n    \
+         AverCert.AcceptedArtifact.compositionMemberBinding,\n    \
+         AverCert.AcceptedArtifact.compositionNamedMembersAccepted,\n    \
+         AverCert.AcceptedArtifact.compositionMemberPlanAccepted,\n    \
+         AverCert.AcceptedArtifact.compositionMemberForName,\n    \
+         AverCert.AcceptedArtifact.compositionClosureBound,\n    \
+         AverCert.AcceptedArtifact.compositionEdges,\n    \
+         AverCert.AcceptedArtifact.compositionPlanCallees,\n    \
+         AverCert.AcceptedArtifact.compositionEdgesDescend,\n    \
+         AverCert.AcceptedArtifact.compositionReachClosure,\n    \
+         AverCert.AcceptedArtifact.compositionReachStep,\n    \
+         AverCert.AcceptedArtifact.compositionEdgeLookup,\n    \
+         AverCert.AcceptedArtifact.stringListNodup,\n    \
+         AverCert.AcceptedArtifact.stringListSetEq]\n  \
+         exact {acceptance}\n\n"
     ));
 
-    // the schema obligation: bridge the caller lemma to `Obligation.holds`.
+    let direct_callee = by_idx[root_calls
+        .first()
+        .expect("composition root has a direct callee")];
+    let direct_member = composition_member_claim_lean_value(direct_callee);
+    let direct_plan = composition_plan_for_entry(
+        direct_callee,
+        &closure
+            .iter()
+            .map(|entry| (entry.self_idx, entry.name.clone()))
+            .collect(),
+    )
+    .expect("direct composition member has a plan");
+    let funcs = composition_func_table(closure);
+    let direct_body = render_ops_value(
+        &lower_composition_plan(&direct_plan, add_idx, &funcs)
+            .expect("direct composition member lowers"),
+    );
+    let direct_code_entry = render_byte_list(
+        &composition_code_entry_bytes(&direct_plan, *carrier, add_idx, &funcs)
+            .expect("direct composition member byte-lowers"),
+    );
+    let direct_binding = format!(
+        "({{ funcIdx := {}, codeIdx := {}, typeIdx := {}, codeEntry := {} }} : \
+         AverCert.WasmSlice.FuncBinding)",
+        direct_callee.self_idx,
+        direct_callee.code_idx,
+        direct_callee.type_idx,
+        direct_code_entry,
+    );
     s.push_str(&format!(
-        "/-- Schema-shaped simulation obligation for `{name}` (composed by the single\n\
-        \x20   final theorem): the emitted body simulates `{name}` by citing its callees. -/\n\
-         theorem {name}_simulates : AverCert.Schema.Obligation.holds {name}Ob := by\n  \
-         intro S add sub mul stringEq stringConcat hadd hsub hmul hStringEq hStringConcat fuel ns vs w hrepr hrun\n  \
-         simp only [{name}Ob, AverCert.Schema.Obligation.holds] at hrun ⊢\n  \
-         obtain ⟨hrepr, harity⟩ := hrepr\n  \
-         cases hrepr with\n  \
-         | nil => simp at harity\n  \
-         | cons hv htail =>\n    \
-         rename_i n v ns vs\n    \
-         cases htail with\n    \
-         | nil =>\n      \
-         simpa [AverCert.Schema.intRepr] using\n        \
-         {name}_wasm_certified S add sub hadd hsub fuel n v w hv hrun\n    \
-         | cons _ _ => simp at harity\n"
+        "theorem {name}_compositionSemanticBridge :\n    \
+         V3Master.compositionClaimSemanticBridge\n      \
+         ({{ modBytes := AverCert.ArtifactBytes.modBytes,\n         \
+         modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest,\n         \
+         symFragmentClaims := [], stringEqClaims := [], stringConcatClaims := [],\n         \
+         constructClaims := [], recursionClaims := [], mutualRecursionClaims := [],\n         \
+         verbatimClaims := [], intDispatchClaims := [], fieldProjectionClaims := [],\n         \
+         compositionMembers := {name}CompositionMembers,\n         \
+         compositionClaims := [{name}CompositionClaim], closureFuel := 0,\n         \
+         closureClaim := {{ roots := [], helpers := [], admitted := [] }} }} :\n        \
+         AverCert.AcceptedArtifact.ArtifactData)\n      \
+         {name}CompositionClaim {callees_lean} := by\n  \
+         refine ⟨rfl, ?_⟩\n  \
+         intro S add sub mul stringEq stringConcat\n    \
+         hAdd hSub hMul hStringEq hStringConcat ns vs hDom\n  \
+         dsimp [{name}CompositionClaim, AverCert.{name}Ob] at ns vs hDom ⊢\n  \
+         rcases hDom with ⟨hRepr, hLen⟩\n  \
+         cases hRepr with\n  \
+         | nil => simp at hLen\n  \
+         | cons hv htail =>\n      \
+         rename_i n v ns' vs'\n      \
+         cases htail with\n      \
+         | cons _ _ => simp at hLen\n      \
+         | nil =>\n          \
+         refine ⟨n, v, {model_name}, {name}, rfl, hv, ?_, ?_, ?_⟩\n          \
+         · intro input\n            \
+         simp [{model_name}, V3Composition.evalCompositionCalls, {model_simp}]\n          \
+         · intro w hw\n            \
+         simpa [AverCert.Schema.intRepr] using hw\n          \
+         · intro funcTable hTable member hMember\n            \
+         have hMember' : member = {} := by simpa using hMember\n            \
+         subst member\n            \
+         exact ⟨⟨\n              \
+         {direct_member},\n              \
+         by rfl,\n              \
+         {},\n              \
+         V3Master.compositionFuncIdx_eq_binding\n                \
+         AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen\n                \
+         {name}CompositionMembers funcTable {} {direct_member}\n                \
+         {direct_binding} hTable (by rfl) (by rfl),\n              \
+         by simp [CertModule.{name}Host],\n              \
+         {direct_body},\n              \
+         by rfl,\n              \
+         {} S add sub hAdd hSub\n            \
+         ⟩⟩\n\n\
+         #print axioms {name}_compositionSemanticBridge\n",
+        lean_str(&direct_callee.name),
+        direct_callee.self_idx,
+        lean_str(&direct_callee.name),
+        lemma_name(direct_callee.self_idx),
     ));
 
     s
+}
+
+fn render_composition_final_arm(c: &Cert) -> String {
+    let name = c.name();
+    format!(
+        r#"change AverCert.{name}Ob.holds
+      let claim : AverCert.AcceptedArtifact.CompositionClaim :=
+        CertProofs.{name}CompositionClaim
+      let artifact : AverCert.AcceptedArtifact.ArtifactData :=
+        {{ modBytes := AverCert.ArtifactBytes.modBytes,
+          modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest,
+          symFragmentClaims := [], stringEqClaims := [], stringConcatClaims := [],
+          constructClaims := [], recursionClaims := [], mutualRecursionClaims := [],
+          verbatimClaims := [], intDispatchClaims := [], fieldProjectionClaims := [],
+          compositionMembers := CertProofs.{name}CompositionMembers,
+          compositionClaims := [claim], closureFuel := 0,
+          closureClaim := {{ roots := [], helpers := [], admitted := [] }} }}
+      exact V3Master.composition_claim_discharges_with_bridge artifact
+        claim (by simpa [artifact] using
+          CertProofs.{name}_compositionClaimAccepted)
+        (by
+          intro rootMember hRoot callees hShape
+          dsimp [artifact, claim, CertProofs.{name}CompositionClaim,
+            CertProofs.{name}CompositionMembers] at hRoot hShape
+          simp [AverCert.AcceptedArtifact.compositionMemberForName] at hRoot
+          subst rootMember
+          injection hShape with hShape
+          subst callees
+          exact CertProofs.{name}_compositionSemanticBridge)"#
+    )
 }

--- a/src/codegen/cert/render_expr_fragment.rs
+++ b/src/codegen/cert/render_expr_fragment.rs
@@ -1,4 +1,9 @@
 fn render_expr_fragment_cert(c: &Cert) -> String {
+    // Audited integer/Bool source fragments emit only their option-(b)
+    // semantic bridge in `Certificate.lean`.
+    if expr_fragment_uses_audited_generic(c) {
+        return String::new();
+    }
     if let Some(face) = c.int_add_face() {
         return render_expr_fragment_int_add_cert(c, face);
     }

--- a/src/codegen/cert/render_expr_fragment_bridge.rs
+++ b/src/codegen/cert/render_expr_fragment_bridge.rs
@@ -1,0 +1,354 @@
+/// Integer and Bool source fragments are within the audited symbolic fragment
+/// grammar. Float fragments are deliberately excluded: their bit-level source
+/// models remain bespoke because floating-point semantics are outside v3's
+/// integer/Bool model.
+fn expr_fragment_uses_audited_generic(c: &Cert) -> bool {
+    let Cert::ExprFragment {
+        source_plan: Some(source_plan),
+        plan,
+        ..
+    } = c.inner()
+    else {
+        return false;
+    };
+    source_plan
+        .params
+        .iter()
+        .all(|ty| matches!(ty, SymTy::Int | SymTy::Bool))
+        && matches!(source_plan.result, SymTy::Int | SymTy::Bool)
+        && plan
+            .params
+            .iter()
+            .all(|ty| matches!(ty, FragTy::IntCarrier | FragTy::BoolI32))
+        && matches!(plan.result, FragTy::IntCarrier | FragTy::BoolI32)
+}
+
+fn expr_fragment_source_model(c: &Cert) -> String {
+    debug_assert!(expr_fragment_uses_audited_generic(c));
+    match c.arity() {
+        1 => c.name().to_string(),
+        2 => format!("fun p => {} p.1 p.2", c.name()),
+        arity => panic!("unsupported generic expr-fragment source arity {arity}"),
+    }
+}
+
+fn expr_fragment_claim_lean_value(
+    c: &Cert,
+    host_table: FragHostTable,
+    struct_table_lean: &str,
+) -> String {
+    debug_assert!(expr_fragment_uses_audited_generic(c));
+    let name = c.name();
+    format!(
+        "({{ exportNameBytes := {}, exportName := {}, carrier := {}, \
+         hostTable := {}, structTable := {struct_table_lean}, \
+         plan := AverCert.Plans.{name}SymPlan, obligation := AverCert.{name}Ob }} : \
+         AverCert.AcceptedArtifact.SymFragmentClaim)",
+        render_byte_list(name.as_bytes()),
+        lean_str(name),
+        c.carrier(),
+        host_table.lean_value(),
+    )
+}
+
+/// Reconstruct the same byte/plan witness emitted as DATA in `Artifact.lean`.
+fn expr_fragment_claim_acceptance_proof(c: &Cert) -> String {
+    let Cert::ExprFragment {
+        carrier,
+        self_idx,
+        code_idx,
+        type_idx,
+        plan,
+        ..
+    } = c.inner()
+    else {
+        unreachable!()
+    };
+    let code_entry_bytes = lower_expr_fragment_plan_code_entry_bytes(plan, *carrier)
+        .expect("generic expr-fragment plan lowers to code-entry bytes");
+    let code_entry_bytes = render_byte_list(&code_entry_bytes);
+    let lowered_body = lower_expr_fragment_plan(plan, *carrier)
+        .map(|ops| render_ops_value(&ops))
+        .expect("generic expr-fragment plan lowers to WInstr body");
+    let binding = format!(
+        "({{ funcIdx := {self_idx}, codeIdx := {code_idx}, typeIdx := {type_idx}, \
+         codeEntry := {code_entry_bytes} }} : AverCert.WasmSlice.FuncBinding)"
+    );
+    format!(
+        "⟨rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {binding}, \
+         ⟨⟨rfl, rfl, rfl, rfl, rfl⟩, rfl, rfl⟩⟩⟩"
+    )
+}
+
+fn render_expr_fragment_semantic_bridge(
+    c: &Cert,
+    host_table: FragHostTable,
+    struct_table_lean: &str,
+) -> String {
+    debug_assert!(expr_fragment_uses_audited_generic(c));
+    if let Some(face) = c.int_add_face() {
+        return render_expr_fragment_int_add_semantic_bridge(
+            c,
+            face,
+            host_table,
+            struct_table_lean,
+        );
+    }
+    render_expr_fragment_int_bool_semantic_bridge(c, host_table, struct_table_lean)
+}
+
+fn render_expr_fragment_int_add_semantic_bridge(
+    c: &Cert,
+    face: FragIntAddFace,
+    host_table: FragHostTable,
+    struct_table_lean: &str,
+) -> String {
+    let name = c.name();
+    let carrier = c.carrier();
+    let k = lean_int_lit(face.k);
+    let claim = expr_fragment_claim_lean_value(c, host_table, struct_table_lean);
+    let acceptance = expr_fragment_claim_acceptance_proof(c);
+    let host_table_lean = host_table.lean_value();
+    format!(
+        r#"/-! ### {name} — option-(b) integer expr-fragment semantic bridge -/
+
+theorem {name}_exprFragmentClaimAccepted :
+    AverCert.AcceptedArtifact.symFragmentClaimAccepted
+      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {claim} := by
+  unfold AverCert.AcceptedArtifact.symFragmentClaimAccepted
+  exact {acceptance}
+
+theorem {name}_exprFragmentSemanticBridge :
+    V3Master.exprFragmentSemanticBridge {claim}
+      AverCert.Plans.{name}Plan := by
+  refine ⟨rfl, ?_⟩
+  intro S add sub mul stringEq stringConcat
+    hAdd hSub hMul hStringEq hStringConcat fuel ns vs out hDom hRun
+  dsimp [AverCert.{name}Ob] at ns vs hDom hRun ⊢
+  rcases hDom with ⟨hRepr, hLen⟩
+  cases hRepr with
+  | nil => simp at hLen
+  | cons hv htail =>
+      rename_i n v ns' vs'
+      cases htail with
+      | cons _ _ => simp at hLen
+      | nil =>
+          cases hc : add [v, carrierSmall {carrier} ({k})] with
+          | none =>
+              simp [wFuncN, wRunF, CertModule.{name}Code, CertModule.{name}Host,
+                boxRef, popArgs, initLocals, hc] at hRun
+          | some result =>
+              refine ⟨[v], [v, .null], result, rfl, rfl, ?_, ?_, ?_⟩
+              · simp [V3ExprFragmentGeneric.blockCallsOK,
+                  V3ExprFragmentGeneric.nodesCallsOK,
+                  V3ExprFragmentGeneric.kindCallsOK, AverCert.Plans.{name}Plan,
+                  CertModule.{name}Code, CertModule.{name}Host]
+              · simp only [V3ExprFragmentFull.evalSymRawPlan]
+                rw [show AverCert.PlanCheck.encodeSymRawPlanToExprFragmentRawPlan
+                  {host_table_lean} {struct_table_lean}
+                  AverCert.Plans.{name}SymPlan =
+                    some AverCert.Plans.{name}Plan by rfl]
+                simp [AverCert.Plans.{name}Plan,
+                  AverCert.PlanLower.maxFuel, V3ExprFragmentFull.runBlock,
+                  V3ExprFragmentFull.runBlockFuel,
+                  V3ExprFragmentFull.runNodesFuel,
+                  V3ExprFragmentFull.finishWith,
+                  AverCert.AcceptedArtifact.exprFragmentNLocals,
+                  CertModule.{name}Code, CertModule.{name}Host, boxRef,
+                  popArgs, initLocals, carrierSmall, hc] <;>
+                try simp_all [V3ExprFragmentFull.runBlockFuel,
+                  V3ExprFragmentFull.runNodesFuel,
+                  V3ExprFragmentFull.finishWith, PlanLower.popExpected,
+                  PlanLower.popExpectedAll, PlanLower.primInstr,
+                  V3ExprFragmentFull.runPrim, wRunF,
+                  AverCert.AcceptedArtifact.exprFragmentNLocals,
+                  CertModule.{name}Code, CertModule.{name}Host, boxRef,
+                  popArgs, initLocals, hc, carrierSmall, b32] <;>
+                try simp_all [V3ExprFragmentFull.runBlockFuel,
+                  V3ExprFragmentFull.runNodesFuel,
+                  V3ExprFragmentFull.finishWith, PlanLower.popExpected,
+                  PlanLower.popExpectedAll, PlanLower.primInstr,
+                  V3ExprFragmentFull.runPrim, wRunF,
+                  AverCert.AcceptedArtifact.exprFragmentNLocals,
+                  CertModule.{name}Code, CertModule.{name}Host, boxRef,
+                  popArgs, initLocals, hc, carrierSmall, b32]
+              · simpa [AverCert.Schema.intRepr, {name}] using
+                  hAdd n ({k}) v (carrierSmall {carrier} ({k})) result hv
+                    (S.smallIntro ({k})) hc
+
+#print axioms {name}_exprFragmentSemanticBridge
+"#
+    )
+}
+
+fn expr_fragment_bridge_eval_tactic(
+    plan: &ExprFragmentPlan,
+    name: &str,
+    host_table_lean: &str,
+    struct_table_lean: &str,
+    evalset: &str,
+) -> String {
+    let mut steps = plan
+        .params
+        .iter()
+        .enumerate()
+        .filter(|(_, ty)| **ty == FragTy::BoolI32)
+        .map(|(i, _)| format!("cases a{i}"))
+        .collect::<Vec<_>>();
+    let mut conds = Vec::new();
+    collect_expr_fragment_conditions(&plan.body, &|idx, _ty| format!("a{idx}"), &mut conds);
+    for (i, cond) in conds.iter().enumerate() {
+        steps.push(format!("by_cases h{i} : {cond}"));
+    }
+    let hints = if conds.is_empty() {
+        String::new()
+    } else {
+        format!(
+            ", {}",
+            (0..conds.len())
+                .map(|i| format!("h{i}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    let first = if steps.is_empty() {
+        format!("simp [{evalset}, carrierSmall, ge_iff_le]")
+    } else {
+        format!(
+            "{} <;> simp [{evalset}, carrierSmall, ge_iff_le{hints}]",
+            steps.join(" <;> ")
+        )
+    };
+    let normalize = "V3ExprFragmentFull.runBlockFuel, \
+        V3ExprFragmentFull.runNodesFuel, V3ExprFragmentFull.finishWith, \
+        PlanLower.popExpected, PlanLower.popExpectedAll, PlanLower.primInstr, \
+        V3ExprFragmentFull.runPrim, wRunF, \
+        AverCert.AcceptedArtifact.exprFragmentNLocals, carrierSmall, b32";
+    format!(
+        "    simp only [V3ExprFragmentFull.evalSymRawPlan]\n    \
+         rw [show AverCert.PlanCheck.encodeSymRawPlanToExprFragmentRawPlan\n      \
+         {host_table_lean} {struct_table_lean} AverCert.Plans.{name}SymPlan =\n      \
+         some AverCert.Plans.{name}Plan by rfl]\n    \
+         {first} <;>\n    try simp_all [{normalize}] <;>\n    \
+         try simp_all [{normalize}] <;>\n    try simp_all [{normalize}]"
+    )
+}
+
+fn render_expr_fragment_int_bool_semantic_bridge(
+    c: &Cert,
+    host_table: FragHostTable,
+    struct_table_lean: &str,
+) -> String {
+    let Cert::ExprFragment {
+        name,
+        carrier,
+        plan,
+        ..
+    } = c.inner()
+    else {
+        unreachable!()
+    };
+    debug_assert_eq!(plan.result, FragTy::BoolI32);
+    let claim = expr_fragment_claim_lean_value(c, host_table, struct_table_lean);
+    let acceptance = expr_fragment_claim_acceptance_proof(c);
+    let result = expr_fragment_wval_expr(plan, &|idx, _ty| format!("a{idx}"));
+    let input_values = plan
+        .params
+        .iter()
+        .enumerate()
+        .map(|(idx, ty)| match ty {
+            FragTy::IntCarrier => format!("carrierSmall {carrier} a{idx}"),
+            FragTy::BoolI32 => format!("b32 a{idx}"),
+            _ => unreachable!("generic integer/Bool fragment input"),
+        })
+        .collect::<Vec<_>>();
+    let inputs = format!("[{}]", input_values.join(", "));
+    let mut locals = input_values;
+    locals.push(".null".to_string());
+    let locals = format!("[{}]", locals.join(", "));
+    let (dom_name, unpack) = match plan.params.len() {
+        1 => ("a0", String::new()),
+        2 => ("p", "  rcases p with ⟨a0, a1⟩\n".to_string()),
+        arity => panic!("unsupported generic expr-fragment arity {arity}"),
+    };
+    let evalset = format!(
+        "AverCert.Plans.{name}Plan, AverCert.PlanLower.maxFuel, \
+         V3ExprFragmentFull.runBlock, V3ExprFragmentFull.runBlockFuel, \
+         V3ExprFragmentFull.runNodesFuel, V3ExprFragmentFull.finishWith, \
+         AverCert.AcceptedArtifact.exprFragmentNLocals, \
+         CertModule.{name}Code, CertModule.{name}Host, wFuncN, wRunF, f, b32, \
+         popArgs, initLocals, {name}"
+    );
+    let host_table_lean = host_table.lean_value();
+    let eval_tactic = expr_fragment_bridge_eval_tactic(
+        plan,
+        name,
+        &host_table_lean,
+        struct_table_lean,
+        &evalset,
+    );
+    format!(
+        r#"/-! ### {name} — option-(b) integer/Bool expr-fragment semantic bridge -/
+
+theorem {name}_exprFragmentClaimAccepted :
+    AverCert.AcceptedArtifact.symFragmentClaimAccepted
+      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {claim} := by
+  unfold AverCert.AcceptedArtifact.symFragmentClaimAccepted
+  exact {acceptance}
+
+theorem {name}_exprFragmentSemanticBridge :
+    V3Master.exprFragmentSemanticBridge {claim}
+      AverCert.Plans.{name}Plan := by
+  refine ⟨rfl, ?_⟩
+  intro S add sub mul stringEq stringConcat
+    hAdd hSub hMul hStringEq hStringConcat fuel {dom_name} vs out hDom hRun
+  dsimp [AverCert.{name}Ob] at {dom_name} vs hDom hRun ⊢
+{unpack}  subst vs
+  refine ⟨{inputs}, {locals}, {result}, rfl, rfl, ?_, ?_, ?_⟩
+  · simp [V3ExprFragmentGeneric.blockCallsOK,
+      V3ExprFragmentGeneric.nodesCallsOK, V3ExprFragmentGeneric.kindCallsOK,
+      AverCert.Plans.{name}Plan, CertModule.{name}Code, CertModule.{name}Host]
+  ·
+{eval_tactic}
+  · simp [{name}, AverCert.Schema.boolRepr, b32]
+
+#print axioms {name}_exprFragmentSemanticBridge
+"#
+    )
+}
+
+/// Per-obligation `Final.cert` arm. A singleton artifact view supplies the
+/// byte-derived source-plan claim; the generated theorem supplies only the
+/// source-model semantic residual.
+fn render_expr_fragment_final_arm(
+    c: &Cert,
+    host_table: FragHostTable,
+    struct_table_lean: &str,
+) -> String {
+    debug_assert!(expr_fragment_uses_audited_generic(c));
+    let name = c.name();
+    let claim = expr_fragment_claim_lean_value(c, host_table, struct_table_lean);
+    format!(
+        r#"let claim : AverCert.AcceptedArtifact.SymFragmentClaim := {claim}
+      let artifact : AverCert.AcceptedArtifact.ArtifactData :=
+        {{ modBytes := AverCert.ArtifactBytes.modBytes,
+          modLen := AverCert.ArtifactBytes.modLen, manifest := AverCert.manifest,
+          symFragmentClaims := [claim], stringEqClaims := [], stringConcatClaims := [],
+          constructClaims := [], recursionClaims := [], mutualRecursionClaims := [],
+          verbatimClaims := [], intDispatchClaims := [], fieldProjectionClaims := [],
+          compositionMembers := [], compositionClaims := [], closureFuel := 0,
+          closureClaim := {{ roots := [], helpers := [], admitted := [] }} }}
+      exact V3Master.exprFragment_claim_discharges artifact
+        (by
+          dsimp [AverCert.AcceptedArtifact.acceptedSymFragments,
+            AverCert.AcceptedArtifact.symFragmentClaimsAccepted,
+            AverCert.AcceptedArtifact.allClaims, artifact]
+          exact ⟨CertProofs.{name}_exprFragmentClaimAccepted, trivial⟩)
+        claim (by simp [artifact])
+        (by
+          intro plan hPlan
+          injection hPlan with hPlan
+          subst plan
+          exact CertProofs.{name}_exprFragmentSemanticBridge)"#
+    )
+}

--- a/src/codegen/cert/render_manifest.rs
+++ b/src/codegen/cert/render_manifest.rs
@@ -4,6 +4,7 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
     // SAME full-strength obligation the legacy straight-line class shipped:
     // any representation in, represented `n + k` out, under the add contract.
     if c.int_add_face().is_some() {
+        let host = c.host_expr();
         return format!(
             "abbrev {name}Ob : Schema.Obligation :=\n  \
              {{ export_ := \"{name}\", policy := .simulatesModel, carrier := {carrier},\n    \
@@ -11,11 +12,9 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
              Dom := List Int, Cod := Int,\n    \
              domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = {arity},\n    \
              codRepr := fun S n w => intRepr S n w,\n    \
-             model := {model} }}\n\n",
+             model := fun ns => {name} (ns.headD 0) }}\n\n",
             carrier = c.carrier(),
-            host = c.host_expr(),
             self_idx = c.self_idx(),
-            model = c.model_expr(),
             arity = c.arity(),
         );
     }
@@ -152,10 +151,15 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
                 | FragTy::Ref
                 | FragTy::AdtRef => "fun S v w => verbatimRepr S v w",
             };
-            let model =
+            let plan_model =
                 expr_fragment_value_expr(&plan.body, plan.body.result, &|idx, _ty| {
                     expr_fragment_dom_accessor("p", idx as usize, plan.params.len())
                 });
+            let model = if expr_fragment_uses_audited_generic(c) {
+                expr_fragment_source_model(c)
+            } else {
+                format!("fun p => {plan_model}")
+            };
             format!(
                 "abbrev {name}Ob : Schema.Obligation :=\n  \
                  {{ export_ := \"{name}\", policy := .simulatesModel, carrier := {carrier},\n    \
@@ -163,7 +167,7 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
                  Dom := {dom}, Cod := {cod},\n    \
                  domRepr := fun _S p vs => vs = {dom_repr},\n    \
                  codRepr := {cod_repr},\n    \
-                 model := fun p => {model} }}\n\n",
+                 model := {model} }}\n\n",
                 host = c.host_expr(),
                 self_idx = c.self_idx(),
             )
@@ -510,7 +514,7 @@ fn render_manifest_lean(
 fn render_final(analysis: &Analysis, model_info: &ModelInfo) -> String {
     let mut s = String::new();
     s.push_str(
-        "import Certificate\nimport Manifest\nimport Schema\nimport V3DischargeFieldProj\nimport V3DischargeConstruct\nimport V3DischargeVerbatim\nimport V3DischargeString\nimport V3DischargeIntDispatch\nimport V3DischargeRecursion\n\n\
+        "import Certificate\nimport Manifest\nimport Schema\nimport V3DischargeComposition\nimport V3DischargeExprFragment\nimport V3DischargeFieldProj\nimport V3DischargeConstruct\nimport V3DischargeVerbatim\nimport V3DischargeString\nimport V3DischargeIntDispatch\nimport V3DischargeRecursion\n\n\
          set_option maxRecDepth 1000000\n\
          set_option linter.unusedSimpArgs false\n\n\
          open AverCert AverCert.Schema\n\n",
@@ -539,10 +543,22 @@ fn render_final(analysis: &Analysis, model_info: &ModelInfo) -> String {
             .join(" | ");
         s.push_str(&format!("  rcases ho with {pattern}\n"));
         // Every resulting goal is closed by exactly one export's obligation.
+        let struct_table_lean = emit_frag_struct_table_lean(analysis)
+            .expect("certified fragment struct table remains consistent");
         let arms = analysis
             .certs
             .iter()
             .map(|c| {
+                if expr_fragment_uses_audited_generic(c) {
+                    return render_expr_fragment_final_arm(
+                        c,
+                        analysis.frag_host_table,
+                        &struct_table_lean,
+                    );
+                }
+                if matches!(c.inner(), Cert::Composition { .. }) {
+                    return render_composition_final_arm(c);
+                }
                 if let Some(face) = c.project_face() {
                     return format!(
                         "exact V3Master.fieldProjection_direct_canonical_discharges \
@@ -1121,7 +1137,11 @@ fn render_manifest(
             ),
             None => String::new(),
         };
-        let theorem = if c.project_face().is_some() {
+        let theorem = if matches!(c.inner(), Cert::Composition { .. }) {
+            "V3Master.composition_claim_discharges_with_bridge".to_string()
+        } else if expr_fragment_uses_audited_generic(c) {
+            "V3Master.exprFragment_claim_discharges".to_string()
+        } else if c.project_face().is_some() {
             "V3Master.fieldProjection_direct_canonical_discharges".to_string()
         } else if matches!(c.inner(), Cert::FieldProjection { .. }) {
             "V3Master.fieldProjection_canonical_discharges".to_string()

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -171,10 +171,10 @@ fn certify_goal_matrix_manifest_tracks_current_surface() {
     );
     assert_eq!(
         manifest["schema_version"].as_u64(),
-        Some(60),
-        "multiplicative/accumulator recursion migration is certificate schema 60"
+        Some(61),
+        "integer expr-fragment generic migration is certificate schema 61"
     );
-    assert_eq!(aver::codegen::cert::CERT_SCHEMA_VERSION, 60);
+    assert_eq!(aver::codegen::cert::CERT_SCHEMA_VERSION, 61);
     let declared_uncertified = manifest["declaredUncertified"].as_array().unwrap();
     assert_eq!(
         declared_uncertified.len(),
@@ -784,10 +784,34 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             "recursion arm must use the audited discharge and emitted bridge: {recursion_name}\n{final_lean}"
         );
     }
-    for bespoke_name in ["addTwo"] {
+    for expr_fragment_name in [
+        "addTwo",
+        "inAsciiDigit",
+        "intLessZero",
+        "intEqZero",
+        "boolAndGoal",
+    ] {
         assert!(
-            final_lean.contains(&format!("CertProofs.{bespoke_name}_")),
-            "unmigrated arm changed during coexistence migration: {bespoke_name}\n{final_lean}"
+            final_lean.contains("V3Master.exprFragment_claim_discharges artifact")
+                && final_lean.contains(&format!(
+                    "CertProofs.{expr_fragment_name}_exprFragmentSemanticBridge"
+                )),
+            "integer/Bool expr-fragment arm must use the audited generic and its option-(b) bridge: {expr_fragment_name}\n{final_lean}"
+        );
+    }
+    for composition_name in ["quad", "hex16"] {
+        assert!(
+            final_lean.contains("V3Master.composition_claim_discharges_with_bridge artifact")
+                && final_lean.contains(&format!(
+                    "CertProofs.{composition_name}_compositionSemanticBridge"
+                )),
+            "integer composition export must use the audited generic and its option-(b) bridge: {composition_name}\n{final_lean}"
+        );
+    }
+    for float_name in ["floatAddGoal", "floatMulAddGoal", "floatLeGoal"] {
+        assert!(
+            final_lean.contains(&format!("CertProofs.{float_name}_simulates")),
+            "float expr-fragment must remain bespoke because floats are outside the audited model: {float_name}\n{final_lean}"
         );
     }
     let certificate = std::fs::read_to_string(cert_dir.join("Certificate.lean"))
@@ -818,9 +842,63 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
             && !certificate.contains("countDown_wasm_certified")
             && !certificate.contains("countDown_wasm_total")
             && !certificate.contains("countDown_simulates")
-            && !certificate.contains("countDownHostRef"),
-        "migrated leaf/dispatch/construct/recursion families must not emit bespoke simulations or tripwires:\n{certificate}"
+            && !certificate.contains("countDownHostRef")
+            && !certificate.contains("addTwo_wasm_certified")
+            && !certificate.contains("addTwo_simulates")
+            && !certificate.contains("addTwoHostRef")
+            && !certificate.contains("quad_wasm_certified")
+            && !certificate.contains("quad_simulates")
+            && !certificate.contains("quadHostRef")
+            && !certificate.contains("hex16_wasm_certified")
+            && !certificate.contains("hex16_simulates")
+            && !certificate.contains("hex16HostRef")
+            && !certificate.contains("inAsciiDigit_wasm_certified")
+            && !certificate.contains("inAsciiDigit_simulates")
+            && !certificate.contains("inAsciiDigitHostRef")
+            && !certificate.contains("intLessZero_wasm_certified")
+            && !certificate.contains("intLessZero_simulates")
+            && !certificate.contains("intLessZeroHostRef")
+            && !certificate.contains("intEqZero_wasm_certified")
+            && !certificate.contains("intEqZero_simulates")
+            && !certificate.contains("intEqZeroHostRef")
+            && !certificate.contains("boolAndGoal_wasm_certified")
+            && !certificate.contains("boolAndGoal_simulates")
+            && !certificate.contains("boolAndGoalHostRef"),
+        "migrated leaf/dispatch/construct/recursion/integer expression families must not emit bespoke simulations or tripwires:\n{certificate}"
     );
+    for expr_fragment_name in [
+        "addTwo",
+        "inAsciiDigit",
+        "intLessZero",
+        "intEqZero",
+        "boolAndGoal",
+    ] {
+        assert!(
+            certificate.contains(&format!(
+                "theorem {expr_fragment_name}_exprFragmentClaimAccepted"
+            )) && certificate.contains(&format!(
+                "theorem {expr_fragment_name}_exprFragmentSemanticBridge"
+            )),
+            "integer/Bool expr-fragment must emit claim acceptance plus its small semantic bridge: {expr_fragment_name}\n{certificate}"
+        );
+    }
+    for composition_name in ["quad", "hex16"] {
+        assert!(
+            certificate.contains(&format!(
+                "theorem {composition_name}_compositionClaimAccepted"
+            )) && certificate.contains(&format!(
+                "theorem {composition_name}_compositionSemanticBridge"
+            )),
+            "integer composition must emit claim acceptance plus its small semantic bridge: {composition_name}\n{certificate}"
+        );
+    }
+    for float_name in ["floatAddGoal", "floatMulAddGoal", "floatLeGoal"] {
+        assert!(
+            certificate.contains(&format!("theorem {float_name}_wasm_certified"))
+                && certificate.contains(&format!("theorem {float_name}_simulates")),
+            "float proof must remain on the bespoke surface: {float_name}\n{certificate}"
+        );
+    }
     for dispatch_name in ["evalOp", "boxInt", "gauge"] {
         assert!(
             certificate.contains(&format!(
@@ -883,6 +961,33 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
         .find(|entry| entry["name"] == "countDown")
         .unwrap();
     assert_eq!(count_down["theorem"], "V3Master.recursion_claim_discharges");
+    for name in [
+        "addTwo",
+        "inAsciiDigit",
+        "intLessZero",
+        "intEqZero",
+        "boolAndGoal",
+    ] {
+        let entry = manifest["certified"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap();
+        assert_eq!(entry["theorem"], "V3Master.exprFragment_claim_discharges");
+    }
+    for name in ["quad", "hex16"] {
+        let entry = manifest["certified"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap();
+        assert_eq!(
+            entry["theorem"],
+            "V3Master.composition_claim_discharges_with_bridge"
+        );
+    }
     for (name, theorem) in [
         ("wrapItems", "V3Master.verbatim_canonical_discharges"),
         ("tagName", "V3Master.verbatim_canonical_discharges"),
@@ -943,6 +1048,22 @@ fn certify_goal_matrix_lands_v3_wall_kernel_clean() {
         ),
         "recursion bridge/discharge changed axiom surface:\n{combined}"
     );
+    for bridge in [
+        "addTwo_exprFragmentSemanticBridge",
+        "inAsciiDigit_exprFragmentSemanticBridge",
+        "intLessZero_exprFragmentSemanticBridge",
+        "intEqZero_exprFragmentSemanticBridge",
+        "boolAndGoal_exprFragmentSemanticBridge",
+        "quad_compositionSemanticBridge",
+        "hex16_compositionSemanticBridge",
+    ] {
+        assert!(
+            combined.contains(&format!(
+                "'CertProofs.{bridge}' depends on axioms: [propext, Classical.choice, Quot.sound]"
+            )),
+            "migrated integer/Bool bridge changed axiom surface: {bridge}\n{combined}"
+        );
+    }
 
     let typecheck = cert_dir.join("V3AcceptRealTypecheck.lean");
     std::fs::write(
@@ -987,7 +1108,7 @@ example :
 }
 
 #[test]
-fn cert_verify_declines_hostile_leaf_dispatch_construct_and_recursion_models() {
+fn cert_verify_declines_hostile_expr_leaf_dispatch_construct_and_recursion_models() {
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping hostile leaf-model test: `lake` not available");
         return;
@@ -1020,6 +1141,37 @@ fn cert_verify_declines_hostile_leaf_dispatch_construct_and_recursion_models() {
         clean_ok,
         "hostile-model baseline must first certify:\n{clean_report}"
     );
+
+    let tampered = temp_dir("certify-hostile-expr-fragment-model-definition");
+    copy_dir_all(&out_dir, &tampered);
+    let model = tampered.join("cert/CertGoals.lean");
+    let source = std::fs::read_to_string(&model).unwrap();
+    let honest = "def addTwo (x : Int) : Int :=\n  (x + 2)";
+    let hostile = "def addTwo (x : Int) : Int :=\n  (x + 3)";
+    let edited = source.replacen(honest, hostile, 1);
+    assert_ne!(
+        source, edited,
+        "expr-fragment model definition changed; update the hostile-model regression"
+    );
+    std::fs::write(&model, edited).unwrap();
+    assert_eq!(
+        std::fs::read(tampered.join("cert_goals.wasm")).unwrap(),
+        std::fs::read(&wasm).unwrap(),
+        "hostile expr-fragment check must isolate the mutation to generated source data"
+    );
+    let manifest = std::fs::read_to_string(tampered.join("cert/Manifest.lean")).unwrap();
+    assert!(
+        manifest.contains("model := fun ns => addTwo (ns.headD 0)"),
+        "expr-fragment hostile regression must leave the manifest model reference untouched"
+    );
+
+    let (ok, report) =
+        verify_certificate(&tampered.join("cert_goals.wasm"), &tampered.join("cert"));
+    assert!(
+        !ok && report.contains("DECLINED") && !report.contains("CERTIFIED"),
+        "wrong generated expr-fragment model definition must fail its emitted bridge and be DECLINED:\n{report}"
+    );
+    let _ = std::fs::remove_dir_all(&tampered);
 
     for (label, honest, hostile) in [
         (
@@ -1171,7 +1323,7 @@ fn certify_straight_line_fixture_lake_builds_kernel_clean() {
     // core whitelist and never `sorryAx`.
     assert!(
         combined.contains(
-            "addTwo_wasm_certified' depends on axioms: [propext, Classical.choice, Quot.sound]"
+            "addTwo_exprFragmentSemanticBridge' depends on axioms: [propext, Classical.choice, Quot.sound]"
         ),
         "certificate theorem not kernel-clean:\n{combined}"
     );
@@ -2179,7 +2331,7 @@ fn certify_composition_fixture_lake_builds_kernel_clean() {
     // stays on the core whitelist; no `sorryAx` leaks through the composition.
     assert!(
         combined.contains(
-            "quad_wasm_certified' depends on axioms: [propext, Classical.choice, Quot.sound]"
+            "quad_compositionSemanticBridge' depends on axioms: [propext, Classical.choice, Quot.sound]"
         ),
         "composition certificate theorem not kernel-clean:\n{combined}"
     );


### PR DESCRIPTION
Two families migrate to option-b in one branch: integer expr-fragment (addTwo, quad, hex16, inAsciiDigit, intLessZero, intEqZero, boolAndGoal) and composition (cross-function chains). Each discharges through its audited generic fed a per-obligation source-model bridge. Float goals stay bespoke by design (out-of-model). The composition migration also removes the old native_decide-guard machinery (compose_eval/compose_depth) in favour of the option-b bridge.

Merged with main (mutual family) — resolved so composition uses its new bridge and mutual uses its bridge; no family's coverage lost.

Verified locally: mutual.av (isEven/isOdd L3), compose.av (quad/hex16 L1, double source-level-only), cert_goals.av (23, mixed L1/L3) all CERTIFIED; cert_certify_spec 13/13; axioms [propext, Classical.choice, Quot.sound]; no sorry/admit/native_decide. Full cert_verify_spec runs in CI. Schema 60 → 62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)