### PR TITLE
Harden Lean subprocesses and rebalance certificate CI

### DIFF
--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -6,17 +6,19 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   cert-kernel:
-    # One job per certification suite, and the long verify suite is further
-    # sharded across four runners (tests are independent; each spawns its own
-    # kernel build), so wall-clock is bounded by the slowest single test rather
-    # than the whole suite. Shared toolchain setup is duplicated per matrix leg
-    # but runs in parallel.
-    name: Cert Kernel (${{ matrix.suite }}${{ matrix.partition && format(' {0}', matrix.partition) || '' }})
+    # The two sequential verify monster tests get dedicated runners. The
+    # complement is slice-partitioned, so each verify test is selected exactly
+    # once. The one certify monster test is isolated from its complement.
+    name: Cert Kernel (${{ matrix.suite }}${{ matrix.lane && format(' {0}', matrix.lane) || '' }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -24,15 +26,50 @@ jobs:
       matrix:
         include:
           - suite: cert_certify_spec
+            lane: hostile-models
+            mode: nextest
+            filter: 'test(=cert_verify_declines_hostile_expr_leaf_dispatch_construct_recursion_and_mutual_models)'
+            partition: 1/1
+          - suite: cert_certify_spec
+            lane: rest
+            mode: nextest
+            filter: 'not test(=cert_verify_declines_hostile_expr_leaf_dispatch_construct_recursion_and_mutual_models)'
+            partition: 1/1
           - suite: cert_decode_spec
+            lane: ''
+            mode: cargo
           - suite: cert_whole_module_guard_iso
+            lane: ''
+            mode: cargo
           - suite: cert_verify_spec
+            lane: tripwires
+            mode: nextest
+            filter: 'test(=cert_verify_accepts_and_tripwires_fail_closed)'
+            partition: 1/1
+          - suite: cert_verify_spec
+            lane: plans-authority
+            mode: nextest
+            filter: 'test(=cert_verify_uses_plans_lean_as_the_only_plan_data)'
+            partition: 1/1
+          - suite: cert_verify_spec
+            lane: rest-1/4
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(=cert_verify_uses_plans_lean_as_the_only_plan_data))'
             partition: 1/4
           - suite: cert_verify_spec
+            lane: rest-2/4
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(=cert_verify_uses_plans_lean_as_the_only_plan_data))'
             partition: 2/4
           - suite: cert_verify_spec
+            lane: rest-3/4
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(=cert_verify_uses_plans_lean_as_the_only_plan_data))'
             partition: 3/4
           - suite: cert_verify_spec
+            lane: rest-4/4
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(=cert_verify_uses_plans_lean_as_the_only_plan_data))'
             partition: 4/4
     env:
       CARGO_BUILD_JOBS: '2'
@@ -72,14 +109,15 @@ jobs:
           sudo mv /tmp/wasm-tools-1.246.2-x86_64-linux/wasm-tools /usr/local/bin/wasm-tools
           wasm-tools --version
 
-      - name: Verify `lake` reachable
+      - name: Verify pinned `lake` reachable
         run: |
+          toolchain="$(tr -d '\r\n' < aver-cert/assets/wall/current/lean-toolchain)"
           for attempt in 1 2 3 4 5 6; do
-            if lake --version; then exit 0; fi
-            echo "::warning::lake/toolchain fetch failed (attempt ${attempt}/6); retrying in 15s"
+            if elan run --install "$toolchain" lake --version; then exit 0; fi
+            echo "::warning::pinned lake/toolchain fetch failed (attempt ${attempt}/6); retrying in 15s"
             sleep 15
           done
-          echo "::error::lake unreachable after 6 attempts (toolchain download)"
+          echo "::error::pinned lake unreachable after 6 attempts (toolchain download)"
           exit 1
 
       - name: Cache prebuilt prelude store
@@ -90,22 +128,32 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/aver-cert-prelude-store
-          key: prelude-store-${{ runner.os }}-${{ hashFiles('aver-cert/assets/wall/current/**', 'aver-cert/src/verifier.rs') }}
+          key: prelude-store-${{ runner.os }}-${{ hashFiles('aver-cert/assets/wall/current/**', 'aver-cert/src/verifier.rs', 'aver-cert/src/prelude_cache.rs', 'aver-cert/src/lean_process.rs') }}
 
       - name: Install nextest
-        if: matrix.partition != ''
+        if: matrix.mode == 'nextest'
         uses: taiki-e/install-action@nextest
 
       - name: Build standalone certificate verifier
         run: cargo build -p aver-cert --bin aver-cert
 
+      - name: Verify hostile Lean search paths are isolated
+        if: matrix.suite == 'cert_decode_spec'
+        env:
+          AVER_CERT_REQUIRE_PINNED_LEAN: '1'
+        run: >-
+          cargo test -p aver-cert --lib --features verify
+          lean_process::tests::hostile_lean_path_olean_is_not_visible -- --exact
+
       - name: Run certification suite
-        if: matrix.partition == ''
+        if: matrix.mode == 'cargo'
         run: cargo test -p aver-lang --features wasm --test ${{ matrix.suite }}
 
-      - name: Run certification suite shard
-        # The verify tests are independent (each builds its own temp cert
-        # project), so count-partitioning across runners is safe; every test
-        # runs in exactly one shard.
-        if: matrix.partition != ''
-        run: cargo nextest run -p aver-lang --features wasm --test ${{ matrix.suite }} --partition count:${{ matrix.partition }}
+      - name: Run certification suite lane
+        # Filtering happens before slice partitioning. Each exact monster-test
+        # filter and its suite-specific complement are disjoint and exhaustive.
+        if: matrix.mode == 'nextest'
+        run: >-
+          cargo nextest run -p aver-lang --features wasm --test ${{ matrix.suite }}
+          -E '${{ matrix.filter }}'
+          --partition slice:${{ matrix.partition }}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ cargo install aver-cert
 independent certificate verifier used by `aver cert`; keep both executables in
 the same directory or on `PATH`. The verifier starts its own public version
 line at `0.1.0` rather than sharing the `aver-lang` version, and checks
-certificates with the pinned Lean 4.32 toolchain.
+certificates with the pinned Lean 4.32 toolchain. Certificate verification
+requires a standard Elan installation at `$ELAN_HOME/bin/elan` (or
+`$HOME/.elan/bin/elan` when `ELAN_HOME` is unset); the verifier deliberately
+does not resolve its trusted Lean subprocesses through `PATH`.
 
 Then try it with a tiny file:
 

--- a/aver-cert/README.md
+++ b/aver-cert/README.md
@@ -15,8 +15,10 @@ cargo install aver-cert
 ```
 
 Verification uses the checker-pinned `leanprover/lean4:v4.32.0` toolchain.
-`lake`, `lean`, and `leanchecker` must therefore be available through the Lean
-toolchain manager.
+It requires a standard Elan installation at `$ELAN_HOME/bin/elan` (or
+`$HOME/.elan/bin/elan` when `ELAN_HOME` is unset). The verifier invokes that
+canonical executable directly and deliberately does not resolve its trusted
+`lake`, `lean`, or `leanchecker` subprocesses through `PATH`.
 
 ## Commands
 

--- a/aver-cert/src/cache.rs
+++ b/aver-cert/src/cache.rs
@@ -14,7 +14,9 @@ use std::path::{Path, PathBuf};
 use sha2::{Digest, Sha256};
 
 const CACHE_ENV: &str = "AVER_CERT_DATA_CACHE";
-const CACHE_LAYOUT_VERSION: &str = "v1";
+// Do not reuse outputs produced before Lean subprocesses had a cleared,
+// exact-toolchain environment.
+const CACHE_LAYOUT_VERSION: &str = "v2-hermetic-env";
 
 pub(crate) struct KeyMaterial<'a> {
     pub schema_version: u64,

--- a/aver-cert/src/lean_process.rs
+++ b/aver-cert/src/lean_process.rs
@@ -1,0 +1,366 @@
+//! Hermetic subprocess boundary for the checker-owned Lean toolchain.
+//!
+//! Lake's `env` command prepends project/toolchain search paths to ambient
+//! `LEAN_PATH` and `LEAN_SRC_PATH`; it does not replace them. Every verifier
+//! subprocess therefore starts from an empty environment. The Elan home is the
+//! explicit bootstrap trust anchor: its canonical `bin/elan` is selected once,
+//! invoked by absolute path, and told to run the exact embedded toolchain.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+pub(crate) struct LeanRunner {
+    elan: PathBuf,
+    elan_home: PathBuf,
+    toolchain: String,
+    system_environment: Vec<(&'static str, OsString)>,
+}
+
+impl LeanRunner {
+    pub(crate) fn new(toolchain: &str) -> Result<Self, String> {
+        Self::with_environment(toolchain, |name| std::env::var_os(name))
+    }
+
+    fn with_environment(
+        toolchain: &str,
+        environment: impl Fn(&str) -> Option<OsString>,
+    ) -> Result<Self, String> {
+        let toolchain = toolchain.trim();
+        if toolchain.is_empty() || toolchain.chars().any(char::is_whitespace) {
+            return Err("embedded Lean toolchain name is empty or malformed".to_string());
+        }
+
+        #[cfg(windows)]
+        let user_home =
+            nonempty(environment("USERPROFILE")).or_else(|| nonempty(environment("HOME")));
+        #[cfg(not(windows))]
+        let user_home = nonempty(environment("HOME"));
+        let elan_home = nonempty(environment("ELAN_HOME"))
+            .map(PathBuf::from)
+            .or_else(|| user_home.map(|home| PathBuf::from(home).join(".elan")))
+            .ok_or_else(|| {
+                "cannot resolve the pinned Lean toolchain: set ELAN_HOME or HOME".to_string()
+            })?;
+        let elan_home = std::fs::canonicalize(&elan_home).map_err(|error| {
+            format!(
+                "cannot resolve trusted Elan home {}: {error}",
+                elan_home.display()
+            )
+        })?;
+        let elan_name = format!("elan{}", std::env::consts::EXE_SUFFIX);
+        let elan = elan_home.join("bin").join(elan_name);
+        let elan = std::fs::canonicalize(&elan).map_err(|error| {
+            format!(
+                "cannot resolve trusted Elan executable {}: {error}; install Elan there or set ELAN_HOME",
+                elan.display()
+            )
+        })?;
+        if !elan.is_file() {
+            return Err(format!(
+                "trusted Elan executable is not a regular file: {}",
+                elan.display()
+            ));
+        }
+
+        let system_environment = Vec::new();
+
+        #[cfg(windows)]
+        let mut system_environment = system_environment;
+        #[cfg(windows)]
+        {
+            copy_if_present(&mut system_environment, "SYSTEMROOT", &environment);
+            copy_if_present(&mut system_environment, "WINDIR", &environment);
+        }
+
+        Ok(Self {
+            elan,
+            elan_home,
+            toolchain: toolchain.to_string(),
+            system_environment,
+        })
+    }
+
+    pub(crate) fn run_lake(&self, work_dir: &Path, arguments: &[&str]) -> Result<Output, String> {
+        let work_dir = std::fs::canonicalize(work_dir).map_err(|error| {
+            format!(
+                "cannot resolve checker-owned Lean work dir {}: {error}",
+                work_dir.display()
+            )
+        })?;
+        let temp_dir = work_dir.join(format!(
+            ".aver-cert-tmp-{}-{}",
+            std::process::id(),
+            unique_nanos()
+        ));
+        let mut builder = std::fs::DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        builder.create(&temp_dir).map_err(|error| {
+            format!(
+                "cannot create checker-owned Lean temp dir {}: {error}",
+                temp_dir.display()
+            )
+        })?;
+
+        let output = self
+            .lake_command(&work_dir, &temp_dir, arguments)
+            .output()
+            .map_err(|error| format!("could not start trusted Elan: {error}"));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        output
+    }
+
+    fn lake_command(&self, work_dir: &Path, temp_dir: &Path, arguments: &[&str]) -> Command {
+        let mut command = Command::new(&self.elan);
+        command.env_clear();
+        command
+            .env("ELAN_HOME", &self.elan_home)
+            // Lake 4.32 reads its toolchain-local artifact cache by default.
+            // Disable every implicit Lake cache; Aver caches are explicit,
+            // content-addressed, and validated separately.
+            .env("LAKE_ARTIFACT_CACHE", "0")
+            .env("LAKE_RESTORE_ARTIFACTS", "0")
+            .env("LAKE_NO_CACHE", "1")
+            .env("LAKE_CACHE_DIR", "");
+        for (name, value) in &self.system_environment {
+            command.env(name, value);
+        }
+
+        // Never inherit an attacker-selected temp root. Both production callers
+        // pass a newly created checker-owned project directory here.
+        command
+            .env("TMPDIR", temp_dir)
+            .env("TMP", temp_dir)
+            .env("TEMP", temp_dir)
+            .current_dir(work_dir)
+            .arg("run")
+            .arg("--install")
+            .arg(&self.toolchain)
+            .arg("lake")
+            .args(arguments);
+        command
+    }
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+
+#[cfg(windows)]
+fn copy_if_present(
+    destination: &mut Vec<(&'static str, OsString)>,
+    name: &'static str,
+    environment: &impl Fn(&str) -> Option<OsString>,
+) {
+    if let Some(value) = nonempty(environment(name)) {
+        destination.push((name, value));
+    }
+}
+
+fn nonempty(value: Option<OsString>) -> Option<OsString> {
+    value.filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wall;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    fn command_environment(command: &Command) -> BTreeMap<String, OsString> {
+        command
+            .get_envs()
+            .filter_map(|(name, value)| {
+                value.map(|value| (name.to_string_lossy().into_owned(), value.to_os_string()))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn command_whitelists_only_toolchain_bootstrap_and_checker_temp() {
+        let runner = LeanRunner {
+            elan: PathBuf::from("/trusted/elan/bin/elan"),
+            elan_home: PathBuf::from("/trusted/elan"),
+            toolchain: wall::LEAN_TOOLCHAIN.trim().to_string(),
+            system_environment: Vec::new(),
+        };
+        let command = runner.lake_command(
+            Path::new("/checker/build"),
+            Path::new("/checker/temp"),
+            &["env", "lean"],
+        );
+
+        assert_eq!(command.get_program(), "/trusted/elan/bin/elan");
+        assert_eq!(
+            command
+                .get_args()
+                .map(|argument| argument.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            [
+                "run",
+                "--install",
+                wall::LEAN_TOOLCHAIN.trim(),
+                "lake",
+                "env",
+                "lean"
+            ]
+        );
+
+        let environment = command_environment(&command);
+        for forbidden in [
+            "LEAN_PATH",
+            "LEAN_SRC_PATH",
+            "LEAN_SYSROOT",
+            "ELAN_TOOLCHAIN",
+            "PATH",
+            "HOME",
+            "LAKE_HOME",
+            "LAKE_OVERRIDE_LEAN",
+        ] {
+            assert!(
+                !environment.contains_key(forbidden),
+                "forwarded {forbidden}"
+            );
+        }
+        assert_eq!(environment.get("ELAN_HOME").unwrap(), "/trusted/elan");
+        assert_eq!(environment.get("LAKE_ARTIFACT_CACHE").unwrap(), "0");
+        assert_eq!(environment.get("LAKE_RESTORE_ARTIFACTS").unwrap(), "0");
+        assert_eq!(environment.get("LAKE_NO_CACHE").unwrap(), "1");
+        assert_eq!(environment.get("LAKE_CACHE_DIR").unwrap(), "");
+        for temp in ["TMPDIR", "TMP", "TEMP"] {
+            assert_eq!(environment.get(temp).unwrap(), "/checker/temp");
+        }
+    }
+
+    struct TestTree(PathBuf);
+
+    impl TestTree {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "aver-cert-lean-env-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|duration| duration.as_nanos())
+                    .unwrap_or(0)
+            ));
+            std::fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestTree {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn report(output: &std::process::Output) -> String {
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+
+    /// Lean 4.32's `lake env` keeps inherited LEAN_PATH entries live after its
+    /// own package paths. Prove the baseline can import a valid ambient olean,
+    /// then prove the production environment boundary makes it unreachable.
+    #[test]
+    fn hostile_lean_path_olean_is_not_visible() {
+        let toolchain = wall::LEAN_TOOLCHAIN.trim();
+        let available = Command::new("elan")
+            .args(["run", "--install", toolchain, "lake", "--version"])
+            .output();
+        if !matches!(available, Ok(output) if output.status.success()) {
+            assert!(
+                std::env::var_os("AVER_CERT_REQUIRE_PINNED_LEAN").is_none(),
+                "pinned Elan toolchain is required for this security gate"
+            );
+            eprintln!("skipping hostile LEAN_PATH test: pinned Elan toolchain unavailable");
+            return;
+        }
+
+        let tree = TestTree::new();
+        let ambient = tree.0.join("ambient");
+        let consumer = tree.0.join("consumer");
+        std::fs::create_dir(&ambient).unwrap();
+        std::fs::create_dir(&consumer).unwrap();
+        for directory in [&ambient, &consumer] {
+            std::fs::write(directory.join("lean-toolchain"), wall::LEAN_TOOLCHAIN).unwrap();
+            std::fs::write(
+                directory.join("lakefile.lean"),
+                "import Lake\nopen Lake DSL\npackage «envprobe» where\n",
+            )
+            .unwrap();
+        }
+        std::fs::write(
+            ambient.join("CertPrelude.lean"),
+            "def ambientMarker : Nat := 666\n",
+        )
+        .unwrap();
+
+        let runner = LeanRunner::new(wall::LEAN_TOOLCHAIN).unwrap();
+        let built = runner
+            .run_lake(
+                &ambient,
+                &["env", "lean", "-o", "CertPrelude.olean", "CertPrelude.lean"],
+            )
+            .unwrap();
+        assert!(
+            built.status.success(),
+            "shadow olean build failed:\n{}",
+            report(&built)
+        );
+        std::fs::remove_file(ambient.join("CertPrelude.lean")).unwrap();
+        assert!(ambient.join("CertPrelude.olean").is_file());
+
+        std::fs::write(
+            consumer.join("Probe.lean"),
+            "import CertPrelude\n\ndef observed : Nat := ambientMarker\n",
+        )
+        .unwrap();
+
+        let baseline = Command::new("elan")
+            .current_dir(&consumer)
+            .env("LEAN_PATH", &ambient)
+            .args(["run", toolchain, "lake", "env", "lean", "Probe.lean"])
+            .output()
+            .unwrap();
+        assert!(
+            baseline.status.success(),
+            "Lean 4.32 baseline did not retain ambient LEAN_PATH:\n{}",
+            report(&baseline)
+        );
+
+        let hostile = |name: &str| match name {
+            "LEAN_PATH" | "LEAN_SRC_PATH" => Some(ambient.as_os_str().to_os_string()),
+            "ELAN_TOOLCHAIN" => Some(OsString::from("leanprover/lean4:v4.31.0")),
+            _ => std::env::var_os(name),
+        };
+        let hardened = LeanRunner::with_environment(wall::LEAN_TOOLCHAIN, hostile)
+            .unwrap()
+            .run_lake(&consumer, &["env", "lean", "Probe.lean"])
+            .unwrap();
+        let hardened_report = report(&hardened);
+        assert!(
+            !hardened.status.success(),
+            "hostile ambient olean crossed the cleared environment:\n{hardened_report}"
+        );
+        assert!(
+            hardened_report.contains("CertPrelude")
+                && (hardened_report.contains("unknown module")
+                    || hardened_report.contains("not found")),
+            "hardened failure was not the missing hostile module:\n{hardened_report}"
+        );
+    }
+}

--- a/aver-cert/src/lib.rs
+++ b/aver-cert/src/lib.rs
@@ -18,6 +18,8 @@ pub use engine::*;
 #[cfg(feature = "verify")]
 mod cache;
 #[cfg(feature = "verify")]
+mod lean_process;
+#[cfg(feature = "verify")]
 mod prelude_cache;
 #[cfg(feature = "verify")]
 mod verifier;

--- a/aver-cert/src/main.rs
+++ b/aver-cert/src/main.rs
@@ -43,9 +43,38 @@ enum Command {
     },
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum Route {
+    StrictVerify {
+        artifact: PathBuf,
+        cert_dir: PathBuf,
+    },
+    TrustedOleanCheck {
+        artifact: PathBuf,
+        cert_dir: PathBuf,
+    },
+    StrictExplain {
+        artifact: PathBuf,
+        cert_dir: PathBuf,
+    },
+}
+
+impl Command {
+    fn into_route(self) -> Route {
+        match self {
+            Self::Verify { artifact, cert_dir } => Route::StrictVerify { artifact, cert_dir },
+            Self::Check { artifact, cert_dir } => Route::TrustedOleanCheck { artifact, cert_dir },
+            Self::Explain { artifact, cert_dir } | Self::Inspect { artifact, cert_dir } => {
+                Route::StrictExplain { artifact, cert_dir }
+            }
+        }
+    }
+}
+
 fn main() -> ExitCode {
-    match Cli::parse().command {
-        Command::Verify { artifact, cert_dir } => match aver_cert::verify(&artifact, &cert_dir) {
+    match Cli::parse().command.into_route() {
+        Route::StrictVerify { artifact, cert_dir } => match aver_cert::verify(&artifact, &cert_dir)
+        {
             Ok(Verdict::Certified { summary, faces }) => {
                 println!("{} {}", "CERTIFIED".green().bold(), summary);
                 println!("  {}", aver_cert::ARTIFACT_DECODE_LINE);
@@ -69,33 +98,35 @@ fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
-        Command::Check { artifact, cert_dir } => match aver_cert::check(&artifact, &cert_dir) {
-            Ok(CheckVerdict::Checked { summary, faces }) => {
-                println!("{} {}", "CHECKED".cyan().bold(), summary);
-                println!(
-                    "  trusted-olean developer preflight; fresh-environment replay was skipped"
-                );
-                for face in faces {
-                    println!("  {face}");
+        Route::TrustedOleanCheck { artifact, cert_dir } => {
+            match aver_cert::check(&artifact, &cert_dir) {
+                Ok(CheckVerdict::Checked { summary, faces }) => {
+                    println!("{} {}", "CHECKED".cyan().bold(), summary);
+                    println!(
+                        "  trusted-olean developer preflight; fresh-environment replay was skipped"
+                    );
+                    for face in faces {
+                        println!("  {face}");
+                    }
+                    ExitCode::SUCCESS
                 }
-                ExitCode::SUCCESS
+                Ok(CheckVerdict::NoExports(summary)) => {
+                    eprintln!(
+                        "{} {}",
+                        "NO CHECKED EXPORTS (developer preflight only, no behavioral claims)"
+                            .yellow()
+                            .bold(),
+                        summary
+                    );
+                    ExitCode::FAILURE
+                }
+                Err(reason) => {
+                    eprintln!("{} {}", "CHECK FAILED".red().bold(), reason);
+                    ExitCode::FAILURE
+                }
             }
-            Ok(CheckVerdict::NoExports(summary)) => {
-                eprintln!(
-                    "{} {}",
-                    "NO CHECKED EXPORTS (developer preflight only, no behavioral claims)"
-                        .yellow()
-                        .bold(),
-                    summary
-                );
-                ExitCode::FAILURE
-            }
-            Err(reason) => {
-                eprintln!("{} {}", "CHECK FAILED".red().bold(), reason);
-                ExitCode::FAILURE
-            }
-        },
-        Command::Explain { artifact, cert_dir } | Command::Inspect { artifact, cert_dir } => {
+        }
+        Route::StrictExplain { artifact, cert_dir } => {
             match aver_cert::explain(&artifact, &cert_dir) {
                 Ok(Explanation::Certified) => ExitCode::SUCCESS,
                 Ok(Explanation::NoExports) => ExitCode::FAILURE,
@@ -105,5 +136,25 @@ fn main() -> ExitCode {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_route(subcommand: &str) -> Route {
+        Cli::try_parse_from(["aver-cert", subcommand, "app.wasm", "out/cert"])
+            .expect("certificate command should parse")
+            .command
+            .into_route()
+    }
+
+    #[test]
+    fn explain_and_inspect_share_the_same_strict_route() {
+        let explain = parse_route("explain");
+        let inspect = parse_route("inspect");
+        assert_eq!(explain, inspect);
+        assert!(matches!(explain, Route::StrictExplain { .. }));
     }
 }

--- a/aver-cert/src/prelude_cache.rs
+++ b/aver-cert/src/prelude_cache.rs
@@ -10,14 +10,14 @@
 //! `.olean` outputs and Lake traces. With no environment variable, the strict
 //! path uses no prelude cache.
 
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
 use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
 
+use crate::lean_process::LeanRunner;
 use crate::wall::Wall;
 
 const CACHE_ENV: &str = "AVER_CERT_PRELUDE_CACHE";
+const CACHE_LAYOUT_VERSION: &str = "v2-hermetic-env";
 
 pub(crate) struct PristineWallCache {
     entry: Option<PathBuf>,
@@ -25,7 +25,7 @@ pub(crate) struct PristineWallCache {
 }
 
 impl PristineWallCache {
-    pub(crate) fn prepare(build_dir: &Path, wall: &Wall) -> Self {
+    pub(crate) fn prepare(build_dir: &Path, wall: &Wall, lean: &LeanRunner) -> Self {
         let Some(store) = cache_store() else {
             return Self::disabled();
         };
@@ -38,7 +38,7 @@ impl PristineWallCache {
             Err(()) => {
                 let _ = std::fs::remove_dir_all(build_dir.join(".lake"));
                 let _ = std::fs::remove_dir_all(&entry);
-                populate(&store, &entry, &key, &files).is_ok()
+                populate(&store, &entry, &key, &files, lean).is_ok()
                     && try_reuse(&entry, build_dir, &key).is_ok()
             }
         };
@@ -128,6 +128,7 @@ fn checker_lakefile(roots: &[&str]) -> String {
 /// lakefile binds the pristine root set, and `lean-toolchain` binds Lean.
 fn static_wall_key(files: &[(String, Vec<u8>)]) -> String {
     let mut hasher = Sha256::new();
+    hasher.update(CACHE_LAYOUT_VERSION.as_bytes());
     for (name, bytes) in files {
         hasher.update((name.len() as u64).to_be_bytes());
         hasher.update(name.as_bytes());
@@ -137,7 +138,13 @@ fn static_wall_key(files: &[(String, Vec<u8>)]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-fn populate(store: &Path, entry: &Path, key: &str, files: &[(String, Vec<u8>)]) -> Result<(), ()> {
+fn populate(
+    store: &Path,
+    entry: &Path,
+    key: &str,
+    files: &[(String, Vec<u8>)],
+    lean: &LeanRunner,
+) -> Result<(), ()> {
     std::fs::create_dir_all(store).map_err(|_| ())?;
     let temp = store.join(format!("tmp-{}-{}", std::process::id(), unique_nanos()));
     std::fs::create_dir(&temp).map_err(|_| ())?;
@@ -146,11 +153,7 @@ fn populate(store: &Path, entry: &Path, key: &str, files: &[(String, Vec<u8>)]) 
         for (name, bytes) in files {
             std::fs::write(temp.join(name), bytes).map_err(|_| ())?;
         }
-        let built = Command::new("lake")
-            .current_dir(&temp)
-            .arg("build")
-            .output()
-            .map_err(|_| ())?;
+        let built = lean.run_lake(&temp, &["build"]).map_err(|_| ())?;
         if !built.status.success() || !temp.join(".lake").is_dir() {
             return Err(());
         }

--- a/aver-cert/src/verifier.rs
+++ b/aver-cert/src/verifier.rs
@@ -7,13 +7,13 @@
 //! termination witness, host table, and runtime contracts.
 
 use crate::cache::{ArtifactBuildCache, KeyMaterial as ArtifactCacheKeyMaterial};
+use crate::lean_process::LeanRunner;
 use crate::prelude_cache::PristineWallCache;
 use crate::{format, wall};
 use colored::Colorize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 const AXIOM_WHITELIST: [&str; 3] = ["propext", "Classical.choice", "Quot.sound"];
 const CHECKED_ROOT: &str = "AverCertChecker.checked";
@@ -265,6 +265,7 @@ fn trusted_check(
 
     let candidates = read_candidates(&manifest)?;
     let build = assemble_build(cert_dir, &bytes, selected_wall)?;
+    let lean = LeanRunner::new(selected_wall.toolchain)?;
     let cache_pins = [("wasm_sha256", pinned_hash), ("wall_id", wall_id)];
     let mut cache = ArtifactBuildCache::prepare(
         &build.path,
@@ -278,17 +279,17 @@ fn trusted_check(
     let mut wall_cache = if data_cache_hit {
         PristineWallCache::disabled()
     } else {
-        PristineWallCache::prepare(&build.path, selected_wall)
+        PristineWallCache::prepare(&build.path, selected_wall, &lean)
     };
 
-    let mut data_build = run_lake(&build.path, &["build"])?;
+    let mut data_build = run_lake(&lean, &build.path, &["build"])?;
     if !data_build.status.success() && (data_cache_hit || wall_cache.was_seeded()) {
         if data_cache_hit {
             cache.invalidate(&build.path);
         } else {
             wall_cache.clear_build(&build.path);
         }
-        data_build = run_lake(&build.path, &["build"])?;
+        data_build = run_lake(&lean, &build.path, &["build"])?;
         if data_build.status.success() && wall_cache.was_seeded() {
             wall_cache.evict();
         }
@@ -305,6 +306,7 @@ fn trusted_check(
     std::fs::write(build.path.join("CheckerWitness.lean"), witness)
         .map_err(|error| format!("cannot write checker witness: {error}"))?;
     let elaborated = run_lake(
+        &lean,
         &build.path,
         &[
             "env",
@@ -321,7 +323,7 @@ fn trusted_check(
         ));
     }
     if let Some(replay_args) = kernel_replay_args(replay_mode) {
-        let replayed = run_lake(&build.path, replay_args)?;
+        let replayed = run_lake(&lean, &build.path, replay_args)?;
         if !replayed.status.success() {
             return Err(format!(
                 "certificate failed fresh-environment kernel replay:\n{}",
@@ -913,14 +915,52 @@ struct BuildDir {
 
 impl BuildDir {
     fn new() -> Result<Self, String> {
-        let path = std::env::temp_dir().join(format!(
+        let path = checker_temp_root()?.join(format!(
             "aver-cert-check-{}-{}",
             std::process::id(),
             unique_nanos()
         ));
-        std::fs::create_dir(&path)
+        let mut builder = std::fs::DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        builder
+            .create(&path)
             .map_err(|error| format!("cannot create checker build dir: {error}"))?;
         Ok(Self { path })
+    }
+}
+
+fn checker_temp_root() -> Result<PathBuf, String> {
+    #[cfg(unix)]
+    {
+        Ok(PathBuf::from("/tmp"))
+    }
+    #[cfg(windows)]
+    {
+        let home = std::env::var_os("USERPROFILE")
+            .or_else(|| std::env::var_os("HOME"))
+            .ok_or_else(|| {
+                "cannot select checker temp root: USERPROFILE/HOME is not set".to_string()
+            })?;
+        let root = PathBuf::from(home)
+            .join("AppData")
+            .join("Local")
+            .join("Temp");
+        std::fs::create_dir_all(&root)
+            .map_err(|error| format!("cannot create checker temp root: {error}"))?;
+        Ok(root)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let home = std::env::var_os("HOME")
+            .ok_or_else(|| "cannot select checker temp root: HOME is not set".to_string())?;
+        let root = PathBuf::from(home).join(".aver-cert-tmp");
+        std::fs::create_dir_all(&root)
+            .map_err(|error| format!("cannot create checker temp root: {error}"))?;
+        Ok(root)
     }
 }
 
@@ -942,17 +982,13 @@ struct LakeOut {
     combined: String,
 }
 
-fn run_lake(build_dir: &Path, arguments: &[&str]) -> Result<LakeOut, String> {
-    let output = Command::new("lake")
-        .current_dir(build_dir)
-        .args(arguments)
-        .output()
-        .map_err(|error| {
-            format!(
-                "could not run `lake {}`: {error} (is Lean/lake installed?)",
-                arguments.join(" ")
-            )
-        })?;
+fn run_lake(lean: &LeanRunner, build_dir: &Path, arguments: &[&str]) -> Result<LakeOut, String> {
+    let output = lean.run_lake(build_dir, arguments).map_err(|error| {
+        format!(
+            "could not run pinned `elan run … lake {}`: {error} (is Elan installed?)",
+            arguments.join(" ")
+        )
+    })?;
     Ok(LakeOut {
         status: output.status,
         combined: format!(

--- a/docs/certification.md
+++ b/docs/certification.md
@@ -162,6 +162,11 @@ axiom closure.
 `leanchecker --fresh` protects the final replay from declarations retained in
 the preceding elaboration environment. It is part of the same Lean toolchain,
 not a separately implemented or independently distributed kernel checker.
+The canonical Elan installation directory is a local trust anchor. Every Lake,
+Lean, and leanchecker subprocess otherwise starts with a cleared environment,
+an exact toolchain argument, disabled implicit Lake caches, and checker-owned
+temporary paths; ambient Lean/Lake search paths and toolchain overrides are not
+forwarded.
 
 Some source meaning cannot be reconstructed from WebAssembly alone. In
 particular, ADT domain/representation and model declarations remain explicit

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -2464,18 +2464,9 @@ fn empty_cert_is_admission_only_and_exits_nonzero() {
         "empty cert preflight must not emit a certification verdict:\n{check_out}"
     );
 
-    // `explain` / `inspect` share verify's fail-closed exit contract: an
-    // admission-only cert (zero certified exports) must not exit green or show a
-    // green CERTIFIED header from either subcommand.
-    for sub in [["explain"], ["inspect"]] {
-        let (ok_e, out_e) = aver_cert(&sub, &out_dir.join("certempty.wasm"), &out_dir.join("cert"));
-        assert!(!ok_e, "empty cert `{}` must exit nonzero:\n{out_e}", sub[0]);
-        assert!(
-            out_e.contains("NO CERTIFIED EXPORTS") && !out_e.contains("\u{1b}[32m"),
-            "empty cert `{}` must report admission-only, not green CERTIFIED:\n{out_e}",
-            sub[0]
-        );
-    }
+    // `explain` and its `inspect` alias normalize to the same strict route in
+    // the standalone verifier. That routing contract has a cheap binary unit
+    // test; do not repeat two full fresh-environment replays here.
 
     // A5 report-line injection (the BANK verbatim attack), Manifest + JSON:
     // stash the fabricated `AVERCERT-EXPORT\tstealAllFunds` report line in the


### PR DESCRIPTION
## Summary

- route every verifier/prelude subprocess through one cleared Lean environment
- invoke canonical Elan by absolute path with the embedded Lean 4.32 toolchain, disable implicit Lake caches, and use checker-owned temporary directories
- add a negative Lean 4.32 test proving an ambient valid `CertPrelude.olean` is visible to ordinary `lake env lean` but invisible to the verifier runner
- split the three slow certificate outliers into dedicated nextest lanes, balance the remaining verify suite with slice partitions, and cancel superseded runs
- replace two duplicate full `explain`/`inspect` replays with a cheap routing unit test

## Security boundary

`LEAN_PATH`, `LEAN_SRC_PATH`, `ELAN_TOOLCHAIN`, all ambient `LEAN_*`/`LAKE_*`, `PATH`, `HOME`, and ambient temp variables are no longer forwarded. The canonical Elan home remains the explicit local bootstrap trust anchor. Both Aver cache layouts are bumped so outputs made before this boundary are not reused.

## Validation

- `cargo fmt --all -- --check`
- both repository clippy gates with `-D warnings`
- `cargo test -p aver-cert --all-features`: 49 passed
- hostile `.olean` regression: passed and required in the cert workflow
- full poisoned-parent CLI smoke: passed with `LEAN_PATH`, `LEAN_SRC_PATH`, `ELAN_TOOLCHAIN=v4.31`, and `TMPDIR` set hostile
- representative mixed strict+check smoke: cold 149.52 s, warm 126.98 s (22.54 s / 15.1% saved)
- `cargo test --workspace`: all reached suites passed; the two generated-project tests blocked by sandbox DNS passed 2/2 when rerun with network
- matrix audit: verify 34 = 2 dedicated + 32 split 8/8/8/8; certify 13 = 1 dedicated + 12 complement
