### PR TITLE
Print only kernel-pinned facts on the trusted certificate report

### DIFF
--- a/aver-cert/src/verifier.rs
+++ b/aver-cert/src/verifier.rs
@@ -82,6 +82,7 @@ struct CertifiedExport {
     name: String,
     policy: String,
     face: String,
+    manifest_face: String,
 }
 
 struct TrustedReport {
@@ -339,6 +340,7 @@ fn trusted_check(
             name: candidate.name.clone(),
             policy: candidate.policy.clone(),
             face: report_face(candidate),
+            manifest_face: manifest_face(candidate),
         })
         .collect();
     Ok(TrustedReport {
@@ -350,6 +352,12 @@ fn trusted_check(
     })
 }
 
+/// The per-export line printed under a CERTIFIED/CHECKED verdict. Everything
+/// on it must be kernel-pinned: the class is rfl-bound to
+/// `StandardFace.reportEntries` by the checker witness (like the name, policy,
+/// and termination). The manifest's `dom`/`cod` strings are NOT pinned by any
+/// witness line, so they must never appear here — `explain` shows them,
+/// explicitly labeled as manifest-declared.
 fn report_face(candidate: &CertifiedCandidate) -> String {
     let label = match candidate.class.as_str() {
         "expr-fragment-v1" => "expression fragment",
@@ -365,8 +373,12 @@ fn report_face(candidate: &CertifiedCandidate) -> String {
         "cross-function-composition" => "cross-function composition",
         other => other,
     };
+    format!("class: {label}")
+}
+
+fn manifest_face(candidate: &CertifiedCandidate) -> String {
     format!(
-        "class: {label}  |  certificate face: Dom {}, Cod {}",
+        "manifest face (declared, not kernel-pinned): Dom {}, Cod {}",
         display_safe(&candidate.dom),
         display_safe(&candidate.cod)
     )
@@ -1032,6 +1044,7 @@ pub fn explain(artifact: &Path, cert_dir: &Path) -> Result<Explanation, String> 
         println!("  {}", export.name.bold());
         println!("    policy: {}", export.policy);
         println!("    {}", export.face);
+        println!("    {}", export.manifest_face);
     }
     if !report.contracts.is_empty() {
         println!("\n{}", "Runtime contracts".yellow().bold());
@@ -1065,6 +1078,24 @@ pub fn explain(artifact: &Path, cert_dir: &Path) -> Result<Explanation, String> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn report_face_prints_only_kernel_pinned_facts() {
+        let candidate = CertifiedCandidate {
+            name: "addOne".to_string(),
+            class: "expr-fragment-v1".to_string(),
+            policy: "simulatesModel".to_string(),
+            policy_lean: ".simulatesModel",
+            termination_lean: "none".to_string(),
+            dom: "List Int".to_string(),
+            cod: "Int".to_string(),
+        };
+        assert_eq!(report_face(&candidate), "class: expression fragment");
+        assert_eq!(
+            manifest_face(&candidate),
+            "manifest face (declared, not kernel-pinned): Dom List Int, Cod Int"
+        );
+    }
 
     #[test]
     fn module_names_are_plain() {

--- a/docs/certification.md
+++ b/docs/certification.md
@@ -154,7 +154,10 @@ embedded-wall identity, report candidates, declared uncertified exports,
 capabilities, and other envelope metadata. It does not contain an
 authoritative plan AST. During verification, the checker requires its report
 view to agree with the Lean manifest and the class/order derived by
-`StandardFace.lean`.
+`StandardFace.lean`. The manifest's `dom`/`cod` strings are display-only and
+are not pinned by the checker witness, so the CERTIFIED/CHECKED report prints
+only the pinned class; `aver cert explain` shows the declared face, explicitly
+labeled as manifest-declared.
 
 The manifest's `format.wall_id` selects one exact soundness wall embedded in
 the verifier. Files from the certificate package cannot replace the wall,

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -2569,6 +2569,102 @@ fn empty_cert_is_admission_only_and_exits_nonzero() {
     let _ = std::fs::remove_dir_all(&out_dir);
 }
 
+/// The manifest `dom`/`cod` strings are declared display metadata: no
+/// checker-witness line pins them, so editing them cannot fail verification.
+/// Precisely because they are unpinned, the trusted CHECKED/CERTIFIED report
+/// must never echo them. Sentinels planted in `cert-manifest.json` must leave
+/// the trusted check green, stay out of the complete trusted report output,
+/// and surface in `explain` only on the line explicitly labeled as
+/// manifest-declared and not kernel-pinned.
+#[test]
+fn unpinned_manifest_dom_cod_never_reach_the_trusted_report() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping unpinned manifest-face report test: `lake` not available");
+        return;
+    }
+
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("cert-unpinned-manifest-face");
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/certprobe.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("aver compile --certify runs");
+    assert!(
+        compile.status.success(),
+        "compile --certify failed:\n{}{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let wasm = out_dir.join("certprobe.wasm");
+    let cert = out_dir.join("cert");
+
+    // Sentinels that cannot collide with any real report text. They stay
+    // printable ASCII on purpose: the charset gate must keep admitting them so
+    // the test exercises the report boundary, not the input gate.
+    const DOM_SENTINEL: &str = "TAMPERED_DOM_SENTINEL";
+    const COD_SENTINEL: &str = "TAMPERED_COD_SENTINEL";
+    let mf = cert.join("cert-manifest.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    let certified = manifest["certified"].as_array_mut().unwrap();
+    assert!(
+        !certified.is_empty(),
+        "fixture must certify at least one export"
+    );
+    for entry in certified.iter_mut() {
+        entry["dom"] = serde_json::Value::String(DOM_SENTINEL.into());
+        entry["cod"] = serde_json::Value::String(COD_SENTINEL.into());
+    }
+    std::fs::write(&mf, serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+
+    // Unpinned by design: only the JSON display strings changed, so the same
+    // trusted check the tamper cases use must still pass.
+    let (ok, report) = aver_check(&wasm, &cert);
+    assert!(
+        ok,
+        "editing the unpinned dom/cod strings must not fail the trusted check:\n{report}"
+    );
+    assert!(
+        report.contains("CHECKED") && report.contains("addTwo") && report.contains("class: "),
+        "trusted report lost its verdict or kernel-pinned face line:\n{report}"
+    );
+    // The complete end-to-end trusted output — verdict, summary, and every
+    // per-export face line — must never echo the unpinned manifest strings.
+    assert!(
+        !report.contains(DOM_SENTINEL) && !report.contains(COD_SENTINEL),
+        "trusted report echoed an unpinned manifest dom/cod string:\n{report}"
+    );
+
+    // `explain` shows the declared face, but only under the explicit
+    // manifest-declared label; the sentinels must never leak anywhere else.
+    let (ok, explain) = aver_cert(&["explain"], &wasm, &cert);
+    assert!(
+        ok,
+        "explain must accept the certificate with edited dom/cod:\n{explain}"
+    );
+    assert!(
+        explain.contains(DOM_SENTINEL) && explain.contains(COD_SENTINEL),
+        "explain must still show the declared manifest face:\n{explain}"
+    );
+    for line in explain.lines() {
+        if line.contains(DOM_SENTINEL) || line.contains(COD_SENTINEL) {
+            assert!(
+                line.contains("manifest face (declared, not kernel-pinned)"),
+                "dom/cod escaped the labeled manifest-face line:\n{line}\n\nfull explain output:\n{explain}"
+            );
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
 /// An ADT class carries its witness body in `Module.lean` exactly like the
 /// integer classes: mutating the emitted `greetCode` (field-projection witness)
 /// so it no longer decodes from the bytes still builds green, but the checker


### PR DESCRIPTION
## Problem

The per-export line printed under a `CERTIFIED`/`CHECKED` verdict included the manifest's `dom`/`cod` strings taken verbatim from `cert-manifest.json`. The checker witness pins the export names, (name, class) report entries, policies, terminations, contracts, declared-uncertified list, capabilities, start, host tables, profile, and abi — but not `dom`/`cod`. A certificate author could therefore edit those two strings freely without failing verification, and the trusted report would display a face the kernel never checked (e.g. claim `Dom String, Cod String` for an export whose kernel-checked face is `Int -> Int`). The exit-code verdict was never affected.

## Fix

- The trusted report line now prints only kernel-pinned facts: the export name, policy, and the class label (rfl-bound to `StandardFace.reportEntries` by the checker witness).
- `aver cert explain` still shows the declared face, explicitly labeled: `manifest face (declared, not kernel-pinned): Dom …, Cod …`.
- `docs/certification.md` states the boundary explicitly.
- Manifest parsing and the printable-ASCII gating of `dom`/`cod` are unchanged.

Verified empirically: tampering `dom`/`cod` in a certified package's manifest leaves the verdict unchanged (they are display-only by design) and the lie no longer appears on the trusted line — only in `explain`, labeled as unpinned.

A kernel-derived face report (a `StandardFace` rendering of `Dom`/`Cod` pinned like the class) is deliberately deferred to a future wall revision, since any wall edit invalidates existing certificates.

## Tests

- New unit test `report_face_prints_only_kernel_pinned_facts`.
- `cargo test -p aver-cert --features verify`: 20 passed.
- `cargo clippy -p aver-cert --all-features`: clean.
- The only stdout assertion on the report line (`tests/cert_verify_spec.rs:2058`) matches the new format.