### PR TITLE
Enforce wall-clock timeouts on the certificate verifier's Lean steps

### DIFF
--- a/aver-cert/Cargo.toml
+++ b/aver-cert/Cargo.toml
@@ -48,4 +48,5 @@ wasm-encoder = { version = "0.248", optional = true }
 wasmparser = { version = "0.248", optional = true }
 
 [dev-dependencies]
+sha2 = "0.10"
 wat = "1"

--- a/aver-cert/README.md
+++ b/aver-cert/README.md
@@ -91,6 +91,11 @@ omits only the final fresh replay and therefore trusts the locally built or
 explicitly cached `.olean` graph. It still writes and elaborates a fresh
 checker-owned witness on every run, including the report pins and axiom guard.
 
+Every Lean toolchain step runs under a wall-clock limit (15 minutes per step
+by default), so no certificate can hang the verifier forever. On expiry the
+step's whole process tree is stopped and the certificate is not accepted.
+`AVER_CERT_PHASE_TIMEOUT_SECS=N` replaces the per-step limit.
+
 See the [certificate guide](../docs/certification.md) and
 [architecture](../docs/certification-architecture.md) for the guarantee and
 trust boundary.

--- a/aver-cert/src/lean_process.rs
+++ b/aver-cert/src/lean_process.rs
@@ -17,7 +17,39 @@ const PHASE_TIMEOUT_ENV: &str = "AVER_CERT_PHASE_TIMEOUT_SECS";
 /// Generous default: real certificate verifies take minutes per step, and the
 /// first run on a machine may also install the pinned toolchain.
 const DEFAULT_PHASE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+/// Upper bound for the override: one day per step. Far beyond any real
+/// verify, and it keeps every deadline computation trivially in range.
+const MAX_PHASE_TIMEOUT_SECS: u64 = 24 * 60 * 60;
+/// How long cleanup after a kill may itself take (reaping the child, waiting
+/// for the kill helper) before the cleanup is abandoned so the caller gets
+/// its fail-closed error promptly.
+const CLEANUP_LIMIT: Duration = Duration::from_secs(5);
 const WAIT_POLL: Duration = Duration::from_millis(50);
+
+/// Why a Lean toolchain step produced no usable output.
+#[derive(Debug)]
+pub(crate) enum LeanStepError {
+    /// The step exceeded the per-step wall-clock limit and its process tree
+    /// was stopped. Mandatory verifier steps fail closed on this; the prelude
+    /// cache downgrades it to a loud cache miss.
+    Timeout { phase: String, limit: Duration },
+    /// The step could not be started, observed, or staged.
+    Failed(String),
+}
+
+impl std::fmt::Display for LeanStepError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout { phase, limit } => write!(
+                formatter,
+                "the {phase} step exceeded its {}-second time limit and was stopped; \
+                 the certificate is not accepted (set {PHASE_TIMEOUT_ENV} to allow more time)",
+                limit.as_secs()
+            ),
+            Self::Failed(reason) => formatter.write_str(reason),
+        }
+    }
+}
 
 pub(crate) struct LeanRunner {
     elan: PathBuf,
@@ -98,12 +130,12 @@ impl LeanRunner {
         work_dir: &Path,
         phase: &str,
         arguments: &[&str],
-    ) -> Result<Output, String> {
+    ) -> Result<Output, LeanStepError> {
         let work_dir = std::fs::canonicalize(work_dir).map_err(|error| {
-            format!(
+            LeanStepError::Failed(format!(
                 "cannot resolve checker-owned Lean work dir {}: {error}",
                 work_dir.display()
-            )
+            ))
         })?;
         let temp_dir = work_dir.join(format!(
             ".aver-cert-tmp-{}-{}",
@@ -117,10 +149,10 @@ impl LeanRunner {
             builder.mode(0o700);
         }
         builder.create(&temp_dir).map_err(|error| {
-            format!(
+            LeanStepError::Failed(format!(
                 "cannot create checker-owned Lean temp dir {}: {error}",
                 temp_dir.display()
-            )
+            ))
         })?;
 
         let output = run_with_timeout(
@@ -169,23 +201,37 @@ fn phase_timeout(environment: &impl Fn(&str) -> Option<OsString>) -> Result<Dura
         return Ok(DEFAULT_PHASE_TIMEOUT);
     };
     let text = value.to_string_lossy();
-    text.trim()
+    let seconds = text
+        .trim()
         .parse::<u64>()
         .ok()
         .filter(|&seconds| seconds > 0)
-        .map(Duration::from_secs)
         .ok_or_else(|| {
             format!(
                 "{PHASE_TIMEOUT_ENV} must be a positive whole number of seconds, got `{}`",
                 text.trim()
             )
-        })
+        })?;
+    // Fail closed on absurd overrides instead of carrying an unbounded value
+    // into deadline arithmetic: past one day per step nothing legitimate is
+    // being configured.
+    if seconds > MAX_PHASE_TIMEOUT_SECS {
+        return Err(format!(
+            "{PHASE_TIMEOUT_ENV} must be at most {MAX_PHASE_TIMEOUT_SECS} seconds (one day), got `{}`",
+            text.trim()
+        ));
+    }
+    Ok(Duration::from_secs(seconds))
 }
 
 /// Run one verifier step to completion under a wall-clock limit. On expiry the
 /// step's entire process tree is killed and a fail-closed error naming the
 /// step is returned: a timed-out step can never contribute to a green verdict.
-fn run_with_timeout(mut command: Command, limit: Duration, phase: &str) -> Result<Output, String> {
+fn run_with_timeout(
+    mut command: Command,
+    limit: Duration,
+    phase: &str,
+) -> Result<Output, LeanStepError> {
     command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -198,14 +244,19 @@ fn run_with_timeout(mut command: Command, limit: Duration, phase: &str) -> Resul
         command.process_group(0);
     }
     let mut child = command.spawn().map_err(|error| {
-        format!("could not start the trusted Lean toolchain for the {phase} step: {error}")
+        LeanStepError::Failed(format!(
+            "could not start the trusted Lean toolchain for the {phase} step: {error}"
+        ))
     })?;
     let stdout = drain(child.stdout.take());
     let stderr = drain(child.stderr.take());
 
-    // The deadline covers both process exit and output drain: a runaway
+    // The limit covers both process exit and output drain: a runaway
     // descendant holding the output pipes open must not stall the verifier.
-    let deadline = Instant::now() + limit;
+    // Compare elapsed time against the limit instead of precomputing a
+    // deadline so no configured limit can overflow `Instant` arithmetic
+    // after the child has already been spawned.
+    let started = Instant::now();
     let mut status = None;
     let finished = loop {
         if status.is_none() {
@@ -213,27 +264,35 @@ fn run_with_timeout(mut command: Command, limit: Duration, phase: &str) -> Resul
                 Ok(exited) => exited,
                 Err(error) => {
                     kill_process_tree(&mut child);
-                    let _ = child.wait();
-                    return Err(format!("could not observe the {phase} step: {error}"));
+                    // Leave the drain threads detached: a survivor holding
+                    // the pipes open must not delay this error.
+                    drop(stdout);
+                    drop(stderr);
+                    return Err(LeanStepError::Failed(format!(
+                        "could not observe the {phase} step: {error}"
+                    )));
                 }
             };
         }
         match status {
             Some(status) if stdout.is_finished() && stderr.is_finished() => break Some(status),
-            _ if Instant::now() >= deadline => break None,
+            _ if started.elapsed() >= limit => break None,
             _ => std::thread::sleep(WAIT_POLL),
         }
     };
 
     let Some(status) = finished else {
         kill_process_tree(&mut child);
-        let _ = child.wait();
-        let _ = (join_drain(stdout), join_drain(stderr));
-        return Err(format!(
-            "the {phase} step exceeded its {}-second time limit and was stopped; \
-             the certificate is not accepted (set {PHASE_TIMEOUT_ENV} to allow more time)",
-            limit.as_secs()
-        ));
+        // Do not join the drain threads: if any process escaped the group
+        // kill and still holds a pipe open, joining would hang the verifier.
+        // The threads own nothing the caller needs, so leave them detached
+        // and report the timeout promptly.
+        drop(stdout);
+        drop(stderr);
+        return Err(LeanStepError::Timeout {
+            phase: phase.to_string(),
+            limit,
+        });
     };
     Ok(Output {
         status,
@@ -245,26 +304,50 @@ fn run_with_timeout(mut command: Command, limit: Duration, phase: &str) -> Resul
 /// Stop the child and every process it spawned. On Unix the child leads its
 /// own process group, so one group-wide SIGKILL reaches lake and its lean
 /// workers; on Windows `taskkill /T` walks the process tree.
+///
+/// Cleanup is itself bounded: the kill helper and the reap of the child each
+/// get [`CLEANUP_LIMIT`], and a cleanup that cannot finish in time is
+/// abandoned so the caller's fail-closed error is reported promptly instead
+/// of trading a hung step for a hung cleanup.
 fn kill_process_tree(child: &mut Child) {
     #[cfg(unix)]
-    {
-        let _ = Command::new("kill")
-            .args(["-KILL", "--", &format!("-{}", child.id())])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-    }
+    let killer = Command::new("kill")
+        .args(["-KILL", "--", &format!("-{}", child.id())])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
     #[cfg(windows)]
+    let killer = Command::new("taskkill")
+        .args(["/T", "/F", "/PID", &child.id().to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    if let Ok(mut killer) = killer
+        && reap_with_deadline(&mut killer, CLEANUP_LIMIT).is_none()
     {
-        let _ = Command::new("taskkill")
-            .args(["/T", "/F", "/PID", &child.id().to_string()])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
+        let _ = killer.kill();
+        let _ = killer.try_wait();
     }
     let _ = child.kill();
+    // Reap the child if it exits promptly; a child that ignores SIGKILL
+    // (unkillable kernel state) is abandoned rather than waited on forever.
+    let _ = reap_with_deadline(child, CLEANUP_LIMIT);
+}
+
+/// Poll `try_wait` until the process exits or the deadline passes. Returns
+/// `None` when the process is still running (or cannot be observed) so the
+/// caller can abandon it instead of blocking.
+fn reap_with_deadline(child: &mut Child, limit: Duration) -> Option<std::process::ExitStatus> {
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) if started.elapsed() < limit => std::thread::sleep(WAIT_POLL),
+            Ok(None) | Err(_) => return None,
+        }
+    }
 }
 
 fn drain(pipe: Option<impl std::io::Read + Send + 'static>) -> std::thread::JoinHandle<Vec<u8>> {
@@ -381,9 +464,13 @@ mod tests {
 
     impl TestTree {
         fn new() -> Self {
+            // The clock alone can collide across parallel test threads; the
+            // counter keeps every tree in this process unique.
+            static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
             let path = std::env::temp_dir().join(format!(
-                "aver-cert-lean-env-{}-{}",
+                "aver-cert-lean-env-{}-{}-{}",
                 std::process::id(),
+                NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|duration| duration.as_nanos())
@@ -531,11 +618,27 @@ mod tests {
         let overridden = runner_with_timeout_setting(Some("120")).unwrap();
         assert_eq!(overridden.phase_timeout, Duration::from_secs(120));
 
+        let at_cap = runner_with_timeout_setting(Some(&MAX_PHASE_TIMEOUT_SECS.to_string()))
+            .expect("the cap itself is a valid override");
+        assert_eq!(
+            at_cap.phase_timeout,
+            Duration::from_secs(MAX_PHASE_TIMEOUT_SECS)
+        );
+
         for invalid in ["0", "-5", "soon", "1.5"] {
             let Err(error) = runner_with_timeout_setting(Some(invalid)) else {
                 panic!("malformed timeout override `{invalid}` must fail closed");
             };
             assert!(error.contains(PHASE_TIMEOUT_ENV), "{error}");
+        }
+
+        let over_cap = (MAX_PHASE_TIMEOUT_SECS + 1).to_string();
+        for oversized in [over_cap.as_str(), &u64::MAX.to_string()] {
+            let Err(error) = runner_with_timeout_setting(Some(oversized)) else {
+                panic!("oversized timeout override `{oversized}` must fail closed");
+            };
+            assert!(error.contains(PHASE_TIMEOUT_ENV), "{error}");
+            assert!(error.contains("at most"), "{error}");
         }
     }
 
@@ -553,7 +656,8 @@ mod tests {
         ));
 
         let error = run_with_timeout(command, Duration::from_secs(1), "test probe")
-            .expect_err("a hung step must fail closed");
+            .expect_err("a hung step must fail closed")
+            .to_string();
         assert!(error.contains("test probe"), "{error}");
         assert!(error.contains("time limit"), "{error}");
         assert!(error.contains(PHASE_TIMEOUT_ENV), "{error}");

--- a/aver-cert/src/lean_process.rs
+++ b/aver-cert/src/lean_process.rs
@@ -8,13 +8,23 @@
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+/// Overrides the per-step wall-clock limit, in whole seconds, for every Lean
+/// toolchain subprocess on the verify/check path.
+const PHASE_TIMEOUT_ENV: &str = "AVER_CERT_PHASE_TIMEOUT_SECS";
+/// Generous default: real certificate verifies take minutes per step, and the
+/// first run on a machine may also install the pinned toolchain.
+const DEFAULT_PHASE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const WAIT_POLL: Duration = Duration::from_millis(50);
 
 pub(crate) struct LeanRunner {
     elan: PathBuf,
     elan_home: PathBuf,
     toolchain: String,
     system_environment: Vec<(&'static str, OsString)>,
+    phase_timeout: Duration,
 }
 
 impl LeanRunner {
@@ -30,6 +40,7 @@ impl LeanRunner {
         if toolchain.is_empty() || toolchain.chars().any(char::is_whitespace) {
             return Err("embedded Lean toolchain name is empty or malformed".to_string());
         }
+        let phase_timeout = phase_timeout(&environment)?;
 
         #[cfg(windows)]
         let user_home =
@@ -78,10 +89,16 @@ impl LeanRunner {
             elan_home,
             toolchain: toolchain.to_string(),
             system_environment,
+            phase_timeout,
         })
     }
 
-    pub(crate) fn run_lake(&self, work_dir: &Path, arguments: &[&str]) -> Result<Output, String> {
+    pub(crate) fn run_lake(
+        &self,
+        work_dir: &Path,
+        phase: &str,
+        arguments: &[&str],
+    ) -> Result<Output, String> {
         let work_dir = std::fs::canonicalize(work_dir).map_err(|error| {
             format!(
                 "cannot resolve checker-owned Lean work dir {}: {error}",
@@ -106,10 +123,11 @@ impl LeanRunner {
             )
         })?;
 
-        let output = self
-            .lake_command(&work_dir, &temp_dir, arguments)
-            .output()
-            .map_err(|error| format!("could not start trusted Elan: {error}"));
+        let output = run_with_timeout(
+            self.lake_command(&work_dir, &temp_dir, arguments),
+            self.phase_timeout,
+            phase,
+        );
         let _ = std::fs::remove_dir_all(&temp_dir);
         output
     }
@@ -144,6 +162,123 @@ impl LeanRunner {
             .args(arguments);
         command
     }
+}
+
+fn phase_timeout(environment: &impl Fn(&str) -> Option<OsString>) -> Result<Duration, String> {
+    let Some(value) = nonempty(environment(PHASE_TIMEOUT_ENV)) else {
+        return Ok(DEFAULT_PHASE_TIMEOUT);
+    };
+    let text = value.to_string_lossy();
+    text.trim()
+        .parse::<u64>()
+        .ok()
+        .filter(|&seconds| seconds > 0)
+        .map(Duration::from_secs)
+        .ok_or_else(|| {
+            format!(
+                "{PHASE_TIMEOUT_ENV} must be a positive whole number of seconds, got `{}`",
+                text.trim()
+            )
+        })
+}
+
+/// Run one verifier step to completion under a wall-clock limit. On expiry the
+/// step's entire process tree is killed and a fail-closed error naming the
+/// step is returned: a timed-out step can never contribute to a green verdict.
+fn run_with_timeout(mut command: Command, limit: Duration, phase: &str) -> Result<Output, String> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // A fresh process group lets the checker stop lake together with
+        // every lean worker it spawned using one group-wide signal.
+        command.process_group(0);
+    }
+    let mut child = command.spawn().map_err(|error| {
+        format!("could not start the trusted Lean toolchain for the {phase} step: {error}")
+    })?;
+    let stdout = drain(child.stdout.take());
+    let stderr = drain(child.stderr.take());
+
+    // The deadline covers both process exit and output drain: a runaway
+    // descendant holding the output pipes open must not stall the verifier.
+    let deadline = Instant::now() + limit;
+    let mut status = None;
+    let finished = loop {
+        if status.is_none() {
+            status = match child.try_wait() {
+                Ok(exited) => exited,
+                Err(error) => {
+                    kill_process_tree(&mut child);
+                    let _ = child.wait();
+                    return Err(format!("could not observe the {phase} step: {error}"));
+                }
+            };
+        }
+        match status {
+            Some(status) if stdout.is_finished() && stderr.is_finished() => break Some(status),
+            _ if Instant::now() >= deadline => break None,
+            _ => std::thread::sleep(WAIT_POLL),
+        }
+    };
+
+    let Some(status) = finished else {
+        kill_process_tree(&mut child);
+        let _ = child.wait();
+        let _ = (join_drain(stdout), join_drain(stderr));
+        return Err(format!(
+            "the {phase} step exceeded its {}-second time limit and was stopped; \
+             the certificate is not accepted (set {PHASE_TIMEOUT_ENV} to allow more time)",
+            limit.as_secs()
+        ));
+    };
+    Ok(Output {
+        status,
+        stdout: join_drain(stdout),
+        stderr: join_drain(stderr),
+    })
+}
+
+/// Stop the child and every process it spawned. On Unix the child leads its
+/// own process group, so one group-wide SIGKILL reaches lake and its lean
+/// workers; on Windows `taskkill /T` walks the process tree.
+fn kill_process_tree(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        let _ = Command::new("kill")
+            .args(["-KILL", "--", &format!("-{}", child.id())])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+    #[cfg(windows)]
+    {
+        let _ = Command::new("taskkill")
+            .args(["/T", "/F", "/PID", &child.id().to_string()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+    let _ = child.kill();
+}
+
+fn drain(pipe: Option<impl std::io::Read + Send + 'static>) -> std::thread::JoinHandle<Vec<u8>> {
+    std::thread::spawn(move || {
+        let mut buffer = Vec::new();
+        if let Some(mut pipe) = pipe {
+            let _ = pipe.read_to_end(&mut buffer);
+        }
+        buffer
+    })
+}
+
+fn join_drain(reader: std::thread::JoinHandle<Vec<u8>>) -> Vec<u8> {
+    reader.join().unwrap_or_default()
 }
 
 fn unique_nanos() -> u128 {
@@ -192,6 +327,7 @@ mod tests {
             elan_home: PathBuf::from("/trusted/elan"),
             toolchain: wall::LEAN_TOOLCHAIN.trim().to_string(),
             system_environment: Vec::new(),
+            phase_timeout: DEFAULT_PHASE_TIMEOUT,
         };
         let command = runner.lake_command(
             Path::new("/checker/build"),
@@ -313,6 +449,7 @@ mod tests {
         let built = runner
             .run_lake(
                 &ambient,
+                "shadow olean build",
                 &["env", "lean", "-o", "CertPrelude.olean", "CertPrelude.lean"],
             )
             .unwrap();
@@ -349,7 +486,7 @@ mod tests {
         };
         let hardened = LeanRunner::with_environment(wall::LEAN_TOOLCHAIN, hostile)
             .unwrap()
-            .run_lake(&consumer, &["env", "lean", "Probe.lean"])
+            .run_lake(&consumer, "hostile probe", &["env", "lean", "Probe.lean"])
             .unwrap();
         let hardened_report = report(&hardened);
         assert!(
@@ -361,6 +498,86 @@ mod tests {
                 && (hardened_report.contains("unknown module")
                     || hardened_report.contains("not found")),
             "hardened failure was not the missing hostile module:\n{hardened_report}"
+        );
+    }
+
+    fn runner_with_timeout_setting(value: Option<&str>) -> Result<LeanRunner, String> {
+        let tree = TestTree::new();
+        let elan_home = tree.0.join("elan");
+        std::fs::create_dir_all(elan_home.join("bin")).unwrap();
+        std::fs::write(
+            elan_home
+                .join("bin")
+                .join(format!("elan{}", std::env::consts::EXE_SUFFIX)),
+            b"placeholder",
+        )
+        .unwrap();
+
+        let elan_home = elan_home.into_os_string();
+        let timeout = value.map(OsString::from);
+        LeanRunner::with_environment(wall::LEAN_TOOLCHAIN, move |name| match name {
+            "ELAN_HOME" => Some(elan_home.clone()),
+            PHASE_TIMEOUT_ENV => timeout.clone(),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn phase_timeout_defaults_generously_and_validates_the_override() {
+        let default = runner_with_timeout_setting(None).unwrap();
+        assert_eq!(default.phase_timeout, DEFAULT_PHASE_TIMEOUT);
+        assert_eq!(default.phase_timeout, Duration::from_secs(900));
+
+        let overridden = runner_with_timeout_setting(Some("120")).unwrap();
+        assert_eq!(overridden.phase_timeout, Duration::from_secs(120));
+
+        for invalid in ["0", "-5", "soon", "1.5"] {
+            let Err(error) = runner_with_timeout_setting(Some(invalid)) else {
+                panic!("malformed timeout override `{invalid}` must fail closed");
+            };
+            assert!(error.contains(PHASE_TIMEOUT_ENV), "{error}");
+        }
+    }
+
+    /// The hang guard must kill the whole process group: lake spawns lean
+    /// workers, and killing only the direct child would leave them running.
+    #[cfg(unix)]
+    #[test]
+    fn expired_phase_kills_the_whole_process_group() {
+        let tree = TestTree::new();
+        let pid_file = tree.0.join("grandchild.pid");
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(format!(
+            "tail -f /dev/null & echo $! > '{}'; wait",
+            pid_file.display()
+        ));
+
+        let error = run_with_timeout(command, Duration::from_secs(1), "test probe")
+            .expect_err("a hung step must fail closed");
+        assert!(error.contains("test probe"), "{error}");
+        assert!(error.contains("time limit"), "{error}");
+        assert!(error.contains(PHASE_TIMEOUT_ENV), "{error}");
+
+        let grandchild =
+            std::fs::read_to_string(&pid_file).expect("grandchild pid recorded before the timeout");
+        let grandchild = grandchild.trim().to_string();
+        assert!(!grandchild.is_empty(), "grandchild pid file was empty");
+
+        let mut alive = true;
+        for _ in 0..100 {
+            let probe = Command::new("ps")
+                .args(["-p", &grandchild, "-o", "pid="])
+                .output()
+                .expect("ps runs");
+            if !probe.status.success() || String::from_utf8_lossy(&probe.stdout).trim().is_empty() {
+                alive = false;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            !alive,
+            "grandchild process {grandchild} survived the group kill"
         );
     }
 }

--- a/aver-cert/src/main.rs
+++ b/aver-cert/src/main.rs
@@ -9,7 +9,10 @@ use colored::Colorize;
 #[command(
     name = "aver-cert",
     version,
-    about = "Independent verifier for Aver artifact certificates"
+    about = "Independent verifier for Aver artifact certificates",
+    after_help = "Every Lean toolchain step runs under a wall-clock limit (900 seconds per \
+                  step by default). Set AVER_CERT_PHASE_TIMEOUT_SECS to change it; when a \
+                  step exceeds the limit it is stopped and the certificate is not accepted."
 )]
 struct Cli {
     #[command(subcommand)]

--- a/aver-cert/src/prelude_cache.rs
+++ b/aver-cert/src/prelude_cache.rs
@@ -153,7 +153,9 @@ fn populate(
         for (name, bytes) in files {
             std::fs::write(temp.join(name), bytes).map_err(|_| ())?;
         }
-        let built = lean.run_lake(&temp, &["build"]).map_err(|_| ())?;
+        let built = lean
+            .run_lake(&temp, "proof library cache build", &["build"])
+            .map_err(|_| ())?;
         if !built.status.success() || !temp.join(".lake").is_dir() {
             return Err(());
         }

--- a/aver-cert/src/prelude_cache.rs
+++ b/aver-cert/src/prelude_cache.rs
@@ -3,7 +3,10 @@
 //! The cache is only a build hint. Every path still stages each source, runs
 //! `lake build`, and authors a fresh witness; strict `verify` additionally
 //! finishes with `leanchecker --fresh`. Any cache failure removes the copied
-//! build tree so the verifier can retry from freshly staged sources.
+//! build tree so the verifier can retry from freshly staged sources. A cache
+//! build that times out or cannot run is reported as a warning and degrades
+//! to a plain cache miss: the mandatory proof build that follows has its own
+//! wall-clock limit, so the verify/check flow stays bounded and fail-closed.
 //!
 //! The configured directory is trusted local state. Its integrity manifest
 //! detects accidental corruption, not an active writer able to replace both
@@ -13,7 +16,7 @@
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
-use crate::lean_process::LeanRunner;
+use crate::lean_process::{LeanRunner, LeanStepError};
 use crate::wall::Wall;
 
 const CACHE_ENV: &str = "AVER_CERT_PRELUDE_CACHE";
@@ -153,9 +156,26 @@ fn populate(
         for (name, bytes) in files {
             std::fs::write(temp.join(name), bytes).map_err(|_| ())?;
         }
+        // A cache build that times out or cannot run must NOT fail
+        // verification: the cache is only a build hint, and skipping it is
+        // exactly a cache miss. Soundness is unaffected because the
+        // mandatory certificate proof build that follows re-does this work
+        // under its own wall-clock limit and fails closed on its own. But
+        // the fallback must be loud, not silent: name the step and say what
+        // happens next.
         let built = lean
             .run_lake(&temp, "proof library cache build", &["build"])
-            .map_err(|_| ())?;
+            .map_err(|error| match error {
+                LeanStepError::Timeout { limit, .. } => eprintln!(
+                    "warning: the proof library cache build exceeded its {}-second limit; \
+                     continuing without the cache",
+                    limit.as_secs()
+                ),
+                LeanStepError::Failed(reason) => eprintln!(
+                    "warning: the proof library cache build could not run; \
+                     continuing without the cache: {reason}"
+                ),
+            })?;
         if !built.status.success() || !temp.join(".lake").is_dir() {
             return Err(());
         }

--- a/aver-cert/src/verifier.rs
+++ b/aver-cert/src/verifier.rs
@@ -20,6 +20,8 @@ const CHECKED_ROOT: &str = "AverCertChecker.checked";
 const MAX_CANDIDATE_LEN: usize = 200;
 const TOOLCHAIN_ROOTS: [&str; 4] = ["Init", "Lake", "Lean", "Std"];
 const FRESH_REPLAY_ARGS: [&str; 4] = ["env", "leanchecker", "--fresh", "CheckerWitness"];
+/// User-facing name of the `lake build` step in timeout and failure messages.
+const PROOF_BUILD_PHASE: &str = "certificate proof build";
 
 /// Emitted on a green verdict. All trust-bearing byte facts and claim metadata
 /// are checked by the embedded Lean wall; Rust performs no parallel verdict
@@ -283,14 +285,14 @@ fn trusted_check(
         PristineWallCache::prepare(&build.path, selected_wall, &lean)
     };
 
-    let mut data_build = run_lake(&lean, &build.path, &["build"])?;
+    let mut data_build = run_lake(&lean, &build.path, PROOF_BUILD_PHASE, &["build"])?;
     if !data_build.status.success() && (data_cache_hit || wall_cache.was_seeded()) {
         if data_cache_hit {
             cache.invalidate(&build.path);
         } else {
             wall_cache.clear_build(&build.path);
         }
-        data_build = run_lake(&lean, &build.path, &["build"])?;
+        data_build = run_lake(&lean, &build.path, PROOF_BUILD_PHASE, &["build"])?;
         if data_build.status.success() && wall_cache.was_seeded() {
             wall_cache.evict();
         }
@@ -309,6 +311,7 @@ fn trusted_check(
     let elaborated = run_lake(
         &lean,
         &build.path,
+        "artifact witness check",
         &[
             "env",
             "lean",
@@ -324,7 +327,7 @@ fn trusted_check(
         ));
     }
     if let Some(replay_args) = kernel_replay_args(replay_mode) {
-        let replayed = run_lake(&lean, &build.path, replay_args)?;
+        let replayed = run_lake(&lean, &build.path, "final kernel replay", replay_args)?;
         if !replayed.status.success() {
             return Err(format!(
                 "certificate failed fresh-environment kernel replay:\n{}",
@@ -994,13 +997,13 @@ struct LakeOut {
     combined: String,
 }
 
-fn run_lake(lean: &LeanRunner, build_dir: &Path, arguments: &[&str]) -> Result<LakeOut, String> {
-    let output = lean.run_lake(build_dir, arguments).map_err(|error| {
-        format!(
-            "could not run pinned `elan run … lake {}`: {error} (is Elan installed?)",
-            arguments.join(" ")
-        )
-    })?;
+fn run_lake(
+    lean: &LeanRunner,
+    build_dir: &Path,
+    phase: &str,
+    arguments: &[&str],
+) -> Result<LakeOut, String> {
+    let output = lean.run_lake(build_dir, phase, arguments)?;
     Ok(LakeOut {
         status: output.status,
         combined: format!(

--- a/aver-cert/src/verifier.rs
+++ b/aver-cert/src/verifier.rs
@@ -1003,7 +1003,11 @@ fn run_lake(
     phase: &str,
     arguments: &[&str],
 ) -> Result<LakeOut, String> {
-    let output = lean.run_lake(build_dir, phase, arguments)?;
+    // Any step failure — including a timeout — fails the whole verify/check
+    // closed; only the opt-in prelude cache may downgrade a step error.
+    let output = lean
+        .run_lake(build_dir, phase, arguments)
+        .map_err(|error| error.to_string())?;
     Ok(LakeOut {
         status: output.status,
         combined: format!(

--- a/aver-cert/tests/phase_timeout.rs
+++ b/aver-cert/tests/phase_timeout.rs
@@ -82,12 +82,56 @@ fn verifier_command(artifact: &Path, cert_dir: &Path) -> Command {
     command
 }
 
+/// Probe for the pinned toolchain under a watchdog of its own: `elan` here is
+/// whatever the ambient environment provides, and a probe that hangs or
+/// starts a long download must skip the gate, not stall the suite.
 fn pinned_toolchain_available() -> bool {
     let toolchain = aver_cert::wall::LEAN_TOOLCHAIN.trim();
-    let available = Command::new("elan")
+    let probe = Command::new("elan")
         .args(["run", "--install", toolchain, "lake", "--version"])
-        .output();
-    matches!(available, Ok(output) if output.status.success())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    let Ok(mut probe) = probe else {
+        return false;
+    };
+    let started = Instant::now();
+    loop {
+        match probe.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) if started.elapsed() < Duration::from_secs(120) => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            _ => {
+                let _ = probe.kill();
+                let _ = probe.wait();
+                return false;
+            }
+        }
+    }
+}
+
+/// Wait for the verifier under a watchdog: if the hang guard under test is
+/// broken, stop the verifier so the test fails promptly instead of hanging
+/// the suite.
+fn wait_with_watchdog(child: std::process::Child) -> std::process::Output {
+    let verifier_pid = child.id();
+    let (done_sender, done_receiver) = std::sync::mpsc::channel::<()>();
+    let watchdog = std::thread::spawn(move || {
+        if done_receiver
+            .recv_timeout(Duration::from_secs(180))
+            .is_err()
+        {
+            let _ = Command::new("kill")
+                .args(["-KILL", &verifier_pid.to_string()])
+                .status();
+        }
+    });
+    let output = child.wait_with_output().expect("verifier finishes");
+    let _ = done_sender.send(());
+    watchdog.join().expect("watchdog thread");
+    output
 }
 
 #[test]
@@ -110,24 +154,8 @@ fn check_fails_closed_when_a_lean_step_exceeds_the_time_limit() {
         .spawn()
         .expect("verifier starts");
     let verifier_pid = child.id();
-
-    // Watchdog: if the hang guard under test is broken, stop the verifier so
-    // this test fails promptly instead of hanging the suite.
-    let (done_sender, done_receiver) = std::sync::mpsc::channel::<()>();
-    let watchdog = std::thread::spawn(move || {
-        if done_receiver
-            .recv_timeout(Duration::from_secs(180))
-            .is_err()
-        {
-            let _ = Command::new("kill")
-                .args(["-KILL", &verifier_pid.to_string()])
-                .status();
-        }
-    });
-    let output = child.wait_with_output().expect("verifier finishes");
+    let output = wait_with_watchdog(child);
     let elapsed = started.elapsed();
-    let _ = done_sender.send(());
-    watchdog.join().expect("watchdog thread");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -178,6 +206,68 @@ fn check_fails_closed_when_a_lean_step_exceeds_the_time_limit() {
         leftovers.is_empty(),
         "checker build dirs survived the timeout: {leftovers:?}"
     );
+}
+
+/// A cache build that exceeds the per-step limit must degrade LOUDLY to a
+/// cache miss: the warning names the step and the fallback, and the mandatory
+/// proof build still runs afterwards (and here fails closed under its own
+/// limit). No pinned toolchain is needed: `ELAN_HOME` points at a stub `elan`
+/// that only sleeps, so both Lean steps deterministically exceed the tiny
+/// limit.
+#[test]
+fn timed_out_cache_build_warns_and_the_mandatory_build_still_decides() {
+    let fixture = minimal_fixture();
+    let elan_home = fixture.root.join("stub-elan");
+    std::fs::create_dir_all(elan_home.join("bin")).expect("stub elan home");
+    let elan = elan_home.join("bin").join("elan");
+    std::fs::write(&elan, "#!/bin/sh\nexec sleep 600\n").expect("stub elan");
+    let mut permissions = std::fs::metadata(&elan)
+        .expect("stub elan metadata")
+        .permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut permissions, 0o755);
+    std::fs::set_permissions(&elan, permissions).expect("stub elan mode");
+
+    let cache = fixture.root.join("prelude-cache");
+    std::fs::create_dir(&cache).expect("cache store");
+
+    let started = Instant::now();
+    let child = verifier_command(&fixture.artifact, &fixture.cert_dir)
+        .env("AVER_CERT_PRELUDE_CACHE", &cache)
+        .env("ELAN_HOME", &elan_home)
+        .env("AVER_CERT_PHASE_TIMEOUT_SECS", "2")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("verifier starts");
+    let output = wait_with_watchdog(child);
+    let elapsed = started.elapsed();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        elapsed < Duration::from_secs(170),
+        "the verifier did not stop its timed-out steps promptly ({elapsed:?})"
+    );
+    assert!(
+        stderr.contains(
+            "warning: the proof library cache build exceeded its 2-second limit; \
+             continuing without the cache"
+        ),
+        "the cache-build timeout must be loud:\n{stderr}"
+    );
+    // The warning did not become the verdict: the mandatory proof build ran
+    // after the cache fallback and failed closed under its own limit.
+    assert!(
+        !output.status.success(),
+        "a timed-out mandatory step must exit nonzero:\n{stdout}\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("CHECKED"),
+        "green verdict on timeout:\n{stdout}"
+    );
+    assert!(stderr.contains("CHECK FAILED"), "{stderr}");
+    assert!(stderr.contains("certificate proof build"), "{stderr}");
+    assert!(stderr.contains("time limit"), "{stderr}");
 }
 
 #[test]

--- a/aver-cert/tests/phase_timeout.rs
+++ b/aver-cert/tests/phase_timeout.rs
@@ -1,0 +1,197 @@
+//! The verifier must never hang. Every Lean toolchain step on the
+//! verify/check path runs under a wall-clock limit; when a step exceeds it,
+//! the step's process tree is stopped and the certificate fails closed with
+//! a nonzero exit. `AVER_CERT_PHASE_TIMEOUT_SECS` overrides the limit and is
+//! itself validated fail-closed.
+
+#![cfg(all(unix, feature = "verify"))]
+
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+struct Fixture {
+    root: PathBuf,
+    artifact: PathBuf,
+    cert_dir: PathBuf,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+/// A tiny valid wasm artifact plus a certificate manifest that passes every
+/// Rust-side gate, so the check reaches the first Lean toolchain step. Any
+/// real `lake build` of the embedded wall takes far longer than the tiny
+/// timeout the tests set, so no hostile certificate is needed.
+fn minimal_fixture() -> Fixture {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let root =
+        std::env::temp_dir().join(format!("aver-cert-timeout-{}-{nanos}", std::process::id()));
+    std::fs::create_dir(&root).expect("fixture root");
+
+    let artifact = root.join("app.wasm");
+    let bytes = wat::parse_str("(module)").expect("fixture wasm");
+    std::fs::write(&artifact, &bytes).expect("fixture artifact");
+    let hash = format!("{:x}", Sha256::digest(&bytes));
+
+    let cert_dir = root.join("cert");
+    std::fs::create_dir(&cert_dir).expect("fixture cert dir");
+    let manifest = format!(
+        r#"{{
+  "schema_version": {schema},
+  "wasm_sha256": "{hash}",
+  "format": {{ "version": {version}, "wall_id": "{wall}" }},
+  "artifact_certificate_root": "{root_name}",
+  "profile": "wasm-gc",
+  "abi": "wasm-gc",
+  "certified": [],
+  "runtime_contracts": [],
+  "declaredUncertified": [],
+  "capabilities": [],
+  "start": {{ "present": false, "function_index": null }},
+  "hostRoleTable": {{ "box": null, "add": null, "mul": null, "sub": null }},
+  "stringHostRoles": []
+}}
+"#,
+        schema = aver_cert::format::CERT_SCHEMA_VERSION,
+        version = aver_cert::format::FORMAT_VERSION,
+        wall = aver_cert::format::CURRENT_WALL_ID,
+        root_name = aver_cert::format::ARTIFACT_CERTIFICATE_ROOT,
+    );
+    std::fs::write(cert_dir.join("cert-manifest.json"), manifest).expect("fixture manifest");
+
+    Fixture {
+        root,
+        artifact,
+        cert_dir,
+    }
+}
+
+fn verifier_command(artifact: &Path, cert_dir: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver-cert"));
+    command.arg("check").arg(artifact).arg(cert_dir);
+    command.env_remove("AVER_CERT_PRELUDE_CACHE");
+    command.env_remove("AVER_CERT_DATA_CACHE");
+    command
+}
+
+fn pinned_toolchain_available() -> bool {
+    let toolchain = aver_cert::wall::LEAN_TOOLCHAIN.trim();
+    let available = Command::new("elan")
+        .args(["run", "--install", toolchain, "lake", "--version"])
+        .output();
+    matches!(available, Ok(output) if output.status.success())
+}
+
+#[test]
+fn check_fails_closed_when_a_lean_step_exceeds_the_time_limit() {
+    if !pinned_toolchain_available() {
+        assert!(
+            std::env::var_os("AVER_CERT_REQUIRE_PINNED_LEAN").is_none(),
+            "pinned Elan toolchain is required for this timeout gate"
+        );
+        eprintln!("skipping phase timeout test: pinned Elan toolchain unavailable");
+        return;
+    }
+
+    let fixture = minimal_fixture();
+    let started = Instant::now();
+    let child = verifier_command(&fixture.artifact, &fixture.cert_dir)
+        .env("AVER_CERT_PHASE_TIMEOUT_SECS", "2")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("verifier starts");
+    let verifier_pid = child.id();
+
+    // Watchdog: if the hang guard under test is broken, stop the verifier so
+    // this test fails promptly instead of hanging the suite.
+    let (done_sender, done_receiver) = std::sync::mpsc::channel::<()>();
+    let watchdog = std::thread::spawn(move || {
+        if done_receiver
+            .recv_timeout(Duration::from_secs(180))
+            .is_err()
+        {
+            let _ = Command::new("kill")
+                .args(["-KILL", &verifier_pid.to_string()])
+                .status();
+        }
+    });
+    let output = child.wait_with_output().expect("verifier finishes");
+    let elapsed = started.elapsed();
+    let _ = done_sender.send(());
+    watchdog.join().expect("watchdog thread");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        elapsed < Duration::from_secs(170),
+        "the verifier did not stop the timed-out step promptly ({elapsed:?})"
+    );
+    assert!(
+        !output.status.success(),
+        "a timed-out step must exit nonzero:\n{stdout}\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("CHECKED"),
+        "green verdict on timeout:\n{stdout}"
+    );
+    assert!(stderr.contains("CHECK FAILED"), "{stderr}");
+    assert!(stderr.contains("certificate proof build"), "{stderr}");
+    assert!(stderr.contains("time limit"), "{stderr}");
+    assert!(stderr.contains("AVER_CERT_PHASE_TIMEOUT_SECS"), "{stderr}");
+
+    // No process may keep referencing this run's unique checker build dir
+    // (lake spawns lean workers with absolute paths under it), and the build
+    // dir itself must have been cleaned up.
+    let marker = format!("aver-cert-check-{verifier_pid}-");
+    let mut survivors = String::new();
+    for _ in 0..100 {
+        let listed = Command::new("pgrep")
+            .args(["-fl", &marker])
+            .output()
+            .expect("pgrep runs");
+        survivors = String::from_utf8_lossy(&listed.stdout).into_owned();
+        if survivors.trim().is_empty() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        survivors.trim().is_empty(),
+        "lean/lake processes survived the timeout kill:\n{survivors}"
+    );
+    let leftovers = std::fs::read_dir("/tmp")
+        .expect("temp root")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with(&marker))
+        .collect::<Vec<_>>();
+    assert!(
+        leftovers.is_empty(),
+        "checker build dirs survived the timeout: {leftovers:?}"
+    );
+}
+
+#[test]
+fn malformed_timeout_override_is_rejected_before_any_lean_step() {
+    let fixture = minimal_fixture();
+    let output = verifier_command(&fixture.artifact, &fixture.cert_dir)
+        .env("AVER_CERT_PHASE_TIMEOUT_SECS", "never")
+        .output()
+        .expect("verifier finishes");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains("AVER_CERT_PHASE_TIMEOUT_SECS must be a positive whole number"),
+        "{stderr}"
+    );
+}

--- a/docs/certification.md
+++ b/docs/certification.md
@@ -73,6 +73,14 @@ output. Those directories become trusted local state and must not be writable
 by an attacker. Strict `verify` still authors a fresh checker witness and runs
 the final whole-closure replay.
 
+Every Lean toolchain step (the certificate proof build, the artifact witness
+check, and the final kernel replay) runs under a wall-clock limit of 15
+minutes, so a degenerate or hostile certificate cannot hang `verify` or
+`check` forever: when a step exceeds the limit, its entire process tree is
+stopped and the certificate is declined. `AVER_CERT_PHASE_TIMEOUT_SECS=N`
+replaces the per-step limit, for slower machines or a first run that still
+installs the pinned toolchain.
+
 ## What a successful certification means
 
 The public proof root is:


### PR DESCRIPTION
## Problem

Every Lean/Lake subprocess on the `aver cert verify`/`aver cert check` path ran without a time limit. A degenerate or hostile certificate (or a wedged toolchain) could hang the verifier forever; CI masked this with its 60-minute job timeout, but local users got an eternal hang.

## Fix

- Every `lake` invocation (certificate proof build, artifact witness check, final kernel replay, and the optional proof-library cache build) now runs under a per-step wall-clock limit: 15 minutes by default, overridable with `AVER_CERT_PHASE_TIMEOUT_SECS`. A malformed override is rejected fail-closed instead of ignored.
- On expiry the step's entire process tree is killed. Each subprocess starts in its own process group on Unix (`taskkill /T` on Windows), so the lean workers lake spawns die with it.
- Expiry returns a readable error naming the step and the override knob, and the verdict is a nonzero-exit decline. A timed-out step can never contribute to a green verdict.
- The deadline also covers output draining, so a runaway descendant holding the output pipes open cannot stall the verifier after the direct child exits.
- Documented in `docs/certification.md`, `aver-cert/README.md`, and `aver-cert --help`.

## How tested

- New unit test proves an expired step kills the whole process group (a recorded grandchild pid must be gone afterwards) and that the override is validated.
- New integration test runs the real `aver-cert check` binary on a minimal valid fixture certificate with a 2-second limit: it asserts the clean step-named timeout error, nonzero exit, prompt completion, no surviving lake/lean processes, and no leftover checker build directories.
- Manual run: `AVER_CERT_PHASE_TIMEOUT_SECS=2 aver-cert check app.wasm cert/` fails closed in 2.1 s with `CHECK FAILED the certificate proof build step exceeded its 2-second time limit...`, exit 1, no processes left behind.
- `cargo build --features wasm`, `cargo test -p aver-cert` (24 tests), `cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings`, `cargo clippy --features wasm,wasip2`, and `cargo fmt --check` are all green.