### PR TITLE
Document the certificate trust inventory and the versioning and freeze policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ For repository self-documentation via decision exports, see `decisions/architect
 | [docs/dafny.md](docs/dafny.md) | Dafny backend: Z3-powered automated law verification |
 | [docs/certification.md](docs/certification.md) | Artifact behavioral certificates: commands, guarantees, admitted families, and limits |
 | [docs/certification-architecture.md](docs/certification-architecture.md) | Certificate data flow, checker ownership, and trust boundary |
+| [docs/certification-tcb.md](docs/certification-tcb.md) | Certificate trust inventory (the complete TCB) and the versioning, lifetime, and freeze policy |
 | [docs/independence.md](docs/independence.md) | Independent products: the semantic model behind `?!` and `!` |
 | [docs/research.md](docs/research.md) | Narrow related work for effects, Oracle, independent products, and proof targets |
 | [docs/pushback.md](docs/pushback.md) | Common pushback: questions, objections, and honest answers |

--- a/docs/certification-architecture.md
+++ b/docs/certification-architecture.md
@@ -180,6 +180,12 @@ from the prior elaboration environment. It is still a component of the same
 Lean 4.32 distribution, not an independent checker implementation. The
 current architecture should not be described as having two diverse kernels.
 
+The component-by-component inventory of this trust — including which
+assumptions are held by differential testing rather than kernel proof — and
+the policy for how the package version, statement schema, and wall identity
+evolve are documented in
+[Certification Trust Inventory and Versioning Policy](certification-tcb.md).
+
 ## Read declarations and scope
 
 For known non-ADT families, `StandardFace` fixes the semantic face available

--- a/docs/certification-tcb.md
+++ b/docs/certification-tcb.md
@@ -1,0 +1,83 @@
+# Certification Trust Inventory and Versioning Policy
+
+This document is the honest, complete inventory of what a party relying on an `aver-cert` verdict trusts, and the policy for how the identities a certificate is issued under evolve over time. It complements [certification.md](certification.md) (the user guide) and [certification-architecture.md](certification-architecture.md) (the data flow and acceptance pipeline). "The verifier" below means the verify path in `aver-cert/src/verifier.rs` (`verify()` → `trusted_check()`) together with the files it stages and the processes it runs.
+
+## What a verifying party trusts
+
+A green `CERTIFIED` verdict is exactly as strong as the components below. Each one is load-bearing: a defect in any of them could admit a wrong certificate. They are listed individually rather than rounded down to "the Lean kernel", because several of them sit on the adversarial input path and are not themselves kernel-checked.
+
+### 1. The Lean kernel and the axiom whitelist
+
+The final authority for every accepted claim is Lean 4's kernel checking the proof of the named root `AverCert.Artifact.certificate` (re-exposed as `AverCertChecker.checked`). The proof may use no axioms outside the whitelist `propext`, `Classical.choice`, `Quot.sound` (`AXIOM_WHITELIST` in `verifier.rs`). The whitelist is enforced by a checker-authored elaboration guard in `CheckerWitness.lean` that collects the transitive axiom closure of the checked root and fails the build on any other name, including `sorryAx`. Two placement facts matter for trust: the witness is authored after any cache restore and is never cached, so the guard runs on every `verify` and `check` invocation; and the final `leanchecker --fresh` replay re-checks every term in the import closure from an empty environment but does not itself enforce any axiom policy, so the guard's location in the always-fresh witness is load-bearing, not redundant.
+
+### 2. The embedded soundness wall, pinned by wall id
+
+The statement schema and every acceptance predicate live in the 33 checker-owned Lean sources embedded in the verifier binary (`aver-cert/src/wall.rs`, materialized from `aver-cert/assets/wall/current/`). Their identity is the wall id: a SHA-256 over a domain-separated, filename-sorted, length-framed encoding of every wall source plus the Lean toolchain pin as a synthetic file. The id is computed, not assigned; the verifier recomputes it over its own embedded sources on first use and aborts on disagreement with the compiled-in `CURRENT_WALL_ID`, so a binary cannot silently ship a wall that does not match its advertised identity. A certificate's `format.wall_id` resolves only against embedded walls — there is no filesystem, environment, or network fallback. Trusting the wall includes trusting the schema of claims itself: a certificate is only as meaningful as `Obligation.holds`/`holdsTotal` and the acceptance conjuncts, and auditing those definitions is exactly what the wall id makes stable.
+
+### 3. The pinned Lean toolchain and the local Elan installation
+
+Elaboration, `lake`, and the final `leanchecker --fresh` replay all come from the one pinned Lean distribution (`leanprover/lean4:v4.32.0`, `aver-cert/assets/wall/current/lean-toolchain`). `leanchecker` is a fresh-environment replay from the same distribution, not an independently implemented second kernel; the architecture must not be described as having two diverse kernels. The toolchain is resolved through the canonical local Elan installation (`ELAN_HOME`, or `~/.elan`), whose `bin/elan` is canonicalized once and invoked by absolute path as `elan run --install <pin> lake ...` (`aver-cert/src/lean_process.rs`). The verifier pins the toolchain name, not the toolchain binaries' hashes: on first use Elan downloads and installs the pinned toolchain, so the Elan installation and its acquisition channel are a bootstrap trust anchor of the whole scheme.
+
+### 4. The Rust transport harness
+
+Rust owns transport, and a verifying party trusts it to do exactly these jobs correctly (`verifier.rs`, `wall.rs`, `lean_process.rs`, `format.rs`, `main.rs`): read the artifact bytes and compute their SHA-256; parse `cert-manifest.json` strictly (exact-object field checks, policy/termination coupling, and the candidate gate holding every witness-interpolated string to at most 200 bytes of printable ASCII with no `"` or `\`); stage package data through the gates — module-name sanitation against `^[A-Za-z][A-Za-z0-9_]*\.lean$`, case-insensitive shadow rejection against toolchain roots and every checker-owned name, and the twenty-token elaboration-code scan (`#eval`, `run_cmd`, `macro`, `unsafe`, `deriving`, `attribute`, `«`, `open Lean`, ...) that keeps package Lean files data-only; author the checker-owned `ArtifactBytes.lean`, lakefile, toolchain pin, and witness; run each Lean step as a hermetic subprocess (cleared environment, implicit Lake caches disabled, `TMPDIR` redirected into checker-owned directories) under a wall-clock timeout so a degenerate or hostile certificate cannot hang verification; and map results to the verdict and exit code. The harness performs no parallel verdict reconstruction — the facts come from the kernel — but a bug in any of these transport duties is a bug inside the TCB.
+
+### 5. `wasmparser::validate_all`, a required pre-gate on the adversarial path
+
+Before anything else, the verifier runs the standard Rust WebAssembly validator over the artifact bytes. This gate is required, and it is part of the adversarial TCB: the input is attacker-chosen, and the Lean wall does not subsume the check. Quoting the rationale in `verifier.rs`: "Artifact acceptance reasons about a valid WebAssembly module. The Lean wall decodes every trust-bearing section and instruction, but it is not yet a complete Wasm validation algorithm (stack/control typing included)." Every accepted certificate is therefore a statement about a validator-accepted module, with `wasmparser` as the authority for full validity.
+
+### 6. The wall's Wasm model and canonical byte lowering, held by differential testing
+
+The wall models WebAssembly: `CertPrelude.lean` defines the instruction semantics the proofs evaluate, `CertDecode.lean`/`WasmSlice.lean` decode the relevant bytes, and `PlanLower.lean`/`PlanBytes.lean` define the canonical lowering from checked plans to instruction bodies and code-entry bytes. The kernel proves these definitions coherent with each other and binds them to the exact artifact bytes, but it cannot prove that the model is faithful to what real WebAssembly engines execute — that faithfulness is an assumption of the scheme, held empirically by differential testing rather than by proof. The suites that hold it today: `tests/cert_decode_spec.rs` (the in-kernel decoder agrees term-for-term with an independent Python byte oracle, `tools/certkit/decode_ref.py`, and with the Rust rederivation across the certkit fixtures, plus a byte-mutation suite and an opcode-coverage matrix); `tests/cert_verify_spec.rs` (end-to-end acceptance plus fail-closed declines for each tampering class); and the cross-backend execution differentials `tests/cross_backend_proptest.rs`, `tests/cross_backend_stress.rs`, `tests/wasm_gc_carrier_i64_differential.rs`, `tests/bigint_literals_differential.rs`, and `tests/wasm_gc_perslot_int_unboxing_differential.rs`, which run the same emitter output under a real engine and require exact agreement with the VM reference semantics. Those execution suites currently exercise one production engine — the Wasmtime runtime embedded in the compiler's `--wasm-gc` run path; agreement with other engines is not yet pinned by a named suite.
+
+### 7. SHA-256 collision resistance
+
+Both bindings that make the scheme non-transferable are hashes: the artifact identity (`wasm_sha256` against the recomputed digest of the supplied bytes) and the wall identity of item 2. An adversary who can produce SHA-256 collisions can transplant a certificate onto different bytes or a different wall.
+
+### 8. Named runtime contracts and explicit read declarations
+
+The certified theorems are conditional. L1 theorems assume the named runtime contracts (the disclosed laws of the host helpers), and L3 theorems additionally assume the disclosed totality of the selected helpers; proving the shipped runtime satisfies them is a per-release obligation outside any certificate. Separately, source meaning that WebAssembly erases — user-ADT domain meaning, representation interpretation, and non-reconstructible models — enters as explicit read declarations: the wall enforces the byte-derived structure and the standard portions of the face, and the theorem is conditional on the declared meaning of the rest.
+
+### 9. Explicitly configured build caches
+
+Caches are disabled by default. If `AVER_CERT_DATA_CACHE` or `AVER_CERT_PRELUDE_CACHE` is set, that directory becomes trusted local state: its integrity manifests detect accidental corruption, not an active writer able to replace `.olean` outputs and Lake traces together. Even with caches configured, the checker witness is authored and elaborated fresh on every invocation and strict `verify` always runs the whole-closure replay, so caches accelerate the build but never substitute for either enforcement point.
+
+## What a verifying party does not trust
+
+- **The Aver compiler and the certificate producer.** The classifier, disassembler, obligation rederiver, and Lean renderer behind `aver compile --certify` are emission diagnostics; none of them is linked into or re-run on the verifier's acceptance path. A wrong producer yields a declined certificate, not a wrong verdict.
+- **Manifest display strings.** The `certified[].dom`/`cod` prose, `level`, `theorem`, `wasm`, `source_level_only`, and every human-readable reason are declared-only transport data. They can lie without affecting the verdict; the CERTIFIED/CHECKED report prints only kernel-pinned facts, and `explain` labels declared values explicitly.
+- **Rust-side classifications and report candidates.** The JSON's certified list is a set of candidates; every trust-bearing field is pinned by the checker witness against the Lean manifest and the byte-derived facts before it can appear on the trusted report. The order or truth of candidates before Lean pinning carries no authority.
+- **Caches as evidence.** Package-supplied caches and build products are ignored entirely; opt-in local caches are performance hints that cannot skip the witness elaboration or the fresh replay (see item 9 for the trust they do carry as local state).
+- **Package-supplied build infrastructure.** Wall sources, lakefile, toolchain pin, artifact-bytes module, and witness are checker-owned; packaged files with those names are ignored or rejected during staging.
+- **Diagnostics.** A diagnostic can explain a decline; it cannot upgrade one.
+
+## Version identities and what bumps them
+
+Three identities in `aver-cert/src/format.rs` govern acceptance, and the verifier requires an exact match on all three — there is no version negotiation, no downgrade path, and no fallback wall resolution:
+
+| Identity | Constant | Current value | What it versions |
+|---|---|---|---|
+| Package layout version | `FORMAT_VERSION` | `1` | The on-disk `cert/` package shape and the transport envelope as a container (`cert-manifest.json` `format.version`) |
+| Statement schema version | `CERT_SCHEMA_VERSION` | `2` | The certificate statement schema: manifest fields and their meaning, obligation shapes, plan grammars (`cert-manifest.json` `schema_version`) |
+| Wall identity | `CURRENT_WALL_ID` | `sha256:0d667eb0...` (full value in `format.rs`) | The exact bytes of the 33 embedded wall sources plus the Lean toolchain pin |
+
+What changes bump which:
+
+- **Package layout changes** — adding, removing, or restructuring package files or the envelope container — bump `FORMAT_VERSION`.
+- **Statement schema changes** — any change to what a certificate can state or how it states it — bump `CERT_SCHEMA_VERSION`. The `1 → 2` bump is the worked example: schema 2 made the subject's `hostRoleTable` optional, with `null` pinned against a byte-derived proof of the Int box helper's absence.
+- **Any wall source change** changes the wall id automatically, because the id is computed from the bytes. A proof-only hardening of a wall predicate changes the wall id without touching either version number. The converse coupling is one-way: a statement-schema change also changes the wall id, since the schema types are themselves wall sources (`Schema.lean`, `SchemaCore.lean`), but most wall-id changes are not schema bumps.
+- The `aver-cert` crate's own `0.1.x` release version is a package-manager label, not an acceptance identity; none of the three checks reads it.
+
+## Certificate lifetime and re-certification
+
+A certificate does not expire by time. It stays verifiable exactly as long as the verifier binary in use embeds the wall it names, and each `aver-cert` release currently embeds exactly one wall. The lifecycle at a wall change is:
+
+1. A new verifier release ships a changed wall (new `CURRENT_WALL_ID`).
+2. That verifier declines every previously issued package at the envelope gate with `unsupported certificate wall ...; no embedded wall matches` — fail-closed, before any Lean step runs.
+3. The holder re-certifies: re-run `aver compile --certify` with the compiler release paired to the new verifier. Because `--certify` binds the emitter's exact bytes, re-certification generally re-emits the module, and the new certificate is a statement about the new bytes. Verifying the re-issued package still requires no trust in the compiler.
+
+Older verifier binaries keep verifying older packages indefinitely — a binary's embedded wall never changes — so archival verification of a historical artifact/package pair means archiving the matching verifier release alongside it. Whether a released verifier may embed several walls (a grace window for recent predecessors) and what the deprecation policy for retired walls should be are open maintainer decisions.
+
+## Freeze policy
+
+> **OPEN DECISION — wall and schema freeze criterion.** Neither `FORMAT_VERSION = 1` nor `CERT_SCHEMA_VERSION = 2` is declared frozen, and the wall currently changes at the tempo of ordinary software development: predicate hardenings recompute the wall id, and each such change ends the forward-verifiable life of previously issued certificates (previous section). "Audit the wall once" only becomes real once the wall has the tempo of a standard, so a freeze needs an explicit criterion. The proposal on the table — a maintainer decision, deliberately not adopted in this document — is to declare a freeze candidate only after all three hold: (a) module framing and validation move into the kernel-checked wall, so `wasmparser` leaves the adversarial input path (item 5 above); (b) the wall build gains a mechanical pin-completeness check, so that every subject-visible fact must be pinned as an equality against the byte-derived decoder for the wall to build at all; and (c) N consecutive months pass with no soundness-motivated change to any wall source or to the statement schema, with N fixed when the criterion is adopted. Until a freeze is declared, relying parties should expect the wall id to move between releases and plan for the re-certification path above.

--- a/docs/certification.md
+++ b/docs/certification.md
@@ -201,4 +201,7 @@ conditional on their stated meaning, while the wall still enforces the
 standard byte-level face and non-vacuity checks available for that family.
 
 See [Certification Architecture](certification-architecture.md) for the exact
-data flow and trust boundary.
+data flow and trust boundary, and
+[Certification Trust Inventory and Versioning Policy](certification-tcb.md)
+for the complete trusted-component inventory, the version identities and what
+bumps them, and the certificate lifetime and freeze policy.


### PR DESCRIPTION
## Summary

- New **docs/certification-tcb.md** with two parts:
  1. **Trust inventory** — the honest, complete list of what a verifying party trusts for a `CERTIFIED` verdict: the Lean kernel plus the axiom whitelist (`propext`, `Classical.choice`, `Quot.sound`, enforced by the always-fresh checker witness), the 33 embedded wall sources pinned by the computed wall id (recomputed and asserted at runtime), the pinned Lean 4.32 toolchain (`lake`, `leanchecker`) resolved through the local Elan installation as bootstrap trust anchor, the Rust transport harness (byte reading, SHA-256, strict manifest parsing, staging gates: name sanitation, shadow rejection, the twenty-token elaboration-code scan, hermetic subprocesses), the required `wasmparser::validate_all` pre-gate (quoting the `verifier.rs` rationale that the wall is not yet a complete Wasm validation algorithm), the wall's Wasm model and canonical byte lowering whose engine faithfulness is held by named differential test suites rather than kernel proof, SHA-256 collision resistance, the named runtime contracts and explicit read declarations, and opt-in cache directories — followed by the explicit not-trusted list (compiler/producer, declared-only manifest strings such as `dom`/`cod`, Rust-side classifications, caches as evidence, package-supplied build infrastructure, diagnostics).
  2. **Versioning and freeze policy** — the three version identities from `aver-cert/src/format.rs` (package layout version `1`, statement schema version `2`, computed wall id), what kind of change bumps each, exact-match acceptance with no negotiation, certificate lifetime and the re-certification path after a wall change (unknown-wall rejection, re-run `--certify` against the paired release), and a clearly marked **open maintainer decision** box for the wall/schema freeze criterion (proposal recorded, deliberately not decided).
- Linked the new document from `docs/certification.md`, the trust-boundary section of `docs/certification-architecture.md`, and the README documentation table.

Every claim is traced to the current sources (`aver-cert/src/{verifier,wall,format,lean_process}.rs`, the wall assets, and the named test suites) and the document is written to stay consistent with the certificate format specification in #738 without depending on its merge. One note for reviewers: the trust-inventory line about wall-clock timeouts on Lean subprocesses describes the hardening in #739; if #739 changes shape, that clause should be adjusted to match.

## Testing

- Docs-only change; verified mechanically that the quoted `verifier.rs` comment matches the source verbatim, every cited repository path exists, the relative links resolve, and the stated constants (`FORMAT_VERSION = 1`, `CERT_SCHEMA_VERSION = 2`, wall id prefix, toolchain pin, 3-entry axiom whitelist, 20-token scan list, 33 wall sources, unknown-wall error text) match the code.