### PR TITLE
Speed up strict verify: replay the import-free capstone

### DIFF
--- a/aver-cert/src/verifier.rs
+++ b/aver-cert/src/verifier.rs
@@ -19,7 +19,7 @@ const AXIOM_WHITELIST: [&str; 3] = ["propext", "Classical.choice", "Quot.sound"]
 const CHECKED_ROOT: &str = "AverCertChecker.checked";
 const MAX_CANDIDATE_LEN: usize = 200;
 const TOOLCHAIN_ROOTS: [&str; 4] = ["Init", "Lake", "Lean", "Std"];
-const FRESH_REPLAY_ARGS: [&str; 4] = ["env", "leanchecker", "--fresh", "CheckerWitness"];
+const FRESH_REPLAY_ARGS: [&str; 4] = ["env", "leanchecker", "--fresh", "ArtifactCertificate"];
 /// User-facing name of the `lake build` step in timeout and failure messages.
 const PROOF_BUILD_PHASE: &str = "certificate proof build";
 


### PR DESCRIPTION
The strict `aver cert verify` spends ~87% of its wall-clock in the `leanchecker --fresh` whole-closure kernel replay. That replay targeted `CheckerWitness`, the only replay root that `import`s Lean (solely to run the elaboration-time axiom-whitelist check), which forces the kernel to additionally replay all of Lean's library — a measured ~56s.

This points the replay at the import-free capstone `ArtifactCertificate` (the same `accepted data` proof over the deployed bytes and the wall acceptance predicate). The kernel still re-checks the entire wall+cert+bytes closure trusting nothing; only Lean's own library — which the certificate provably does not depend on — leaves the replay. The axiom-whitelist enforcement is untouched (it lives in the witness-elaborate step) and still fires: three poisoned certificates (injected non-whitelisted axiom / sorry) are all rejected.

Measured: cold add_one verify 140s -> 102s.

One-line change to the replay root; the full cert suites gate that forgeries are still declined.