### PR TITLE
Break the two remaining serial gates in certificate CI

### DIFF
--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -15,18 +15,25 @@ env:
 
 jobs:
   cert-kernel:
-    # The two sequential verify monster tests get dedicated runners. The
-    # complement is slice-partitioned, so each verify test is selected exactly
-    # once.
+    # Every lane is a name filter plus a slice partition. Each filter and its
+    # suite-specific complement are disjoint and exhaustive, so each test in a
+    # suite is selected exactly once: no overlap (which would double the kernel
+    # work) and no gap (which would silently stop running a soundness gate).
     #
-    # The certify suite's hostile-model soundness gates all share the
-    # `cert_hostile_model_` name prefix; they are selected by that prefix and
-    # slice-partitioned across dedicated runners, and the `rest` lane excludes
-    # exactly the same prefix. Prefix in, prefix out: no overlap (which would
-    # double the kernel work) and no gap (which would silently stop running a
-    # gate). A hostile model added to the lists inside the suite lands in an
-    # existing shard test, so these lanes never need editing for coverage —
+    # Three families are prefix-selected onto dedicated runners because their
+    # members are long kernel runs:
+    #   * `cert_hostile_model_` (certify) — the hostile obligation-model gates;
+    #   * `cert_adt_witness_`   (certify) — one `lake build` of an emitted
+    #     certificate per non-recursive ADT fixture, ten of them;
+    #   * `cert_plans_authority_` (verify) — the Plans.lean-authority gates,
+    #     one full certificate verification each.
+    # The `rest` lane of each suite excludes exactly those prefixes. Prefix in,
+    # prefix out. A model or fixture added to the lists inside a suite lands in
+    # an existing shard test, so these lanes never need editing for coverage —
     # only to add throughput.
+    #
+    # The remaining verify monster test, `cert_verify_accepts_and_tripwires_
+    # fail_closed`, still gets a dedicated runner by exact name.
     name: Cert Kernel (${{ matrix.suite }}${{ matrix.lane && format(' {0}', matrix.lane) || '' }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -60,9 +67,29 @@ jobs:
             filter: 'test(/^cert_hostile_model_/)'
             partition: 5/5
           - suite: cert_certify_spec
+            lane: adt-witnesses-1/4
+            mode: nextest
+            filter: 'test(/^cert_adt_witness_/)'
+            partition: 1/4
+          - suite: cert_certify_spec
+            lane: adt-witnesses-2/4
+            mode: nextest
+            filter: 'test(/^cert_adt_witness_/)'
+            partition: 2/4
+          - suite: cert_certify_spec
+            lane: adt-witnesses-3/4
+            mode: nextest
+            filter: 'test(/^cert_adt_witness_/)'
+            partition: 3/4
+          - suite: cert_certify_spec
+            lane: adt-witnesses-4/4
+            mode: nextest
+            filter: 'test(/^cert_adt_witness_/)'
+            partition: 4/4
+          - suite: cert_certify_spec
             lane: rest
             mode: nextest
-            filter: 'not test(/^cert_hostile_model_/)'
+            filter: 'not (test(/^cert_hostile_model_/) or test(/^cert_adt_witness_/))'
             partition: 1/1
           - suite: cert_decode_spec
             lane: ''
@@ -79,30 +106,60 @@ jobs:
             filter: 'test(=cert_verify_accepts_and_tripwires_fail_closed)'
             partition: 1/1
           - suite: cert_verify_spec
-            lane: plans-authority
+            lane: plans-authority-1/3
             mode: nextest
-            filter: 'test(=cert_verify_uses_plans_lean_as_the_only_plan_data)'
-            partition: 1/1
+            filter: 'test(/^cert_plans_authority_/)'
+            partition: 1/3
           - suite: cert_verify_spec
-            lane: rest-1/4
+            lane: plans-authority-2/3
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(=cert_verify_uses_plans_lean_as_the_only_plan_data))'
-            partition: 1/4
+            filter: 'test(/^cert_plans_authority_/)'
+            partition: 2/3
           - suite: cert_verify_spec
-            lane: rest-2/4
+            lane: plans-authority-3/3
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(=cert_verify_uses_plans_lean_as_the_only_plan_data))'
-            partition: 2/4
+            filter: 'test(/^cert_plans_authority_/)'
+            partition: 3/3
           - suite: cert_verify_spec
-            lane: rest-3/4
+            lane: rest-1/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(=cert_verify_uses_plans_lean_as_the_only_plan_data))'
-            partition: 3/4
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            partition: 1/8
           - suite: cert_verify_spec
-            lane: rest-4/4
+            lane: rest-2/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(=cert_verify_uses_plans_lean_as_the_only_plan_data))'
-            partition: 4/4
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            partition: 2/8
+          - suite: cert_verify_spec
+            lane: rest-3/8
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            partition: 3/8
+          - suite: cert_verify_spec
+            lane: rest-4/8
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            partition: 4/8
+          - suite: cert_verify_spec
+            lane: rest-5/8
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            partition: 5/8
+          - suite: cert_verify_spec
+            lane: rest-6/8
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            partition: 6/8
+          - suite: cert_verify_spec
+            lane: rest-7/8
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            partition: 7/8
+          - suite: cert_verify_spec
+            lane: rest-8/8
+            mode: nextest
+            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            partition: 8/8
     env:
       CARGO_BUILD_JOBS: '2'
       CARGO_INCREMENTAL: '0'
@@ -183,8 +240,9 @@ jobs:
 
       - name: Run certification suite lane
         # Filtering happens before slice partitioning. Each monster-test filter
-        # (exact name, or the `cert_hostile_model_` prefix) and its
-        # suite-specific complement are disjoint and exhaustive.
+        # (exact name, or one of the `cert_hostile_model_`, `cert_adt_witness_`
+        # and `cert_plans_authority_` prefixes) and its suite-specific
+        # complement are disjoint and exhaustive.
         if: matrix.mode == 'nextest'
         run: >-
           cargo nextest run -p aver-lang --features wasm --test ${{ matrix.suite }}

--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -20,20 +20,24 @@ jobs:
     # suite is selected exactly once: no overlap (which would double the kernel
     # work) and no gap (which would silently stop running a soundness gate).
     #
-    # Three families are prefix-selected onto dedicated runners because their
+    # Four families are prefix-selected onto dedicated runners because their
     # members are long kernel runs:
     #   * `cert_hostile_model_` (certify) — the hostile obligation-model gates;
     #   * `cert_adt_witness_`   (certify) — one `lake build` of an emitted
     #     certificate per non-recursive ADT fixture, ten of them;
     #   * `cert_plans_authority_` (verify) — the Plans.lean-authority gates,
-    #     one full certificate verification each.
+    #     one full certificate verification each;
+    #   * `cert_tripwire_` (verify) — the tampering classes of `aver cert
+    #     verify`, one gate per test. Twenty-three of them pay a full artifact
+    #     DATA build (a tamper of Lean source inside the certificate, or a gate
+    #     that must be ACCEPTED); the other nine are decided by the Rust
+    #     verifier before any Lean process starts and cost milliseconds. Slice
+    #     partitioning is round-robin over the sorted names, which spreads the
+    #     expensive ones four or five to a lane.
     # The `rest` lane of each suite excludes exactly those prefixes. Prefix in,
     # prefix out. A model or fixture added to the lists inside a suite lands in
     # an existing shard test, so these lanes never need editing for coverage —
     # only to add throughput.
-    #
-    # The remaining verify monster test, `cert_verify_accepts_and_tripwires_
-    # fail_closed`, still gets a dedicated runner by exact name.
     name: Cert Kernel (${{ matrix.suite }}${{ matrix.lane && format(' {0}', matrix.lane) || '' }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -101,10 +105,30 @@ jobs:
             lane: ''
             mode: cargo
           - suite: cert_verify_spec
-            lane: tripwires
+            lane: tripwires-1/5
             mode: nextest
-            filter: 'test(=cert_verify_accepts_and_tripwires_fail_closed)'
-            partition: 1/1
+            filter: 'test(/^cert_tripwire_/)'
+            partition: 1/5
+          - suite: cert_verify_spec
+            lane: tripwires-2/5
+            mode: nextest
+            filter: 'test(/^cert_tripwire_/)'
+            partition: 2/5
+          - suite: cert_verify_spec
+            lane: tripwires-3/5
+            mode: nextest
+            filter: 'test(/^cert_tripwire_/)'
+            partition: 3/5
+          - suite: cert_verify_spec
+            lane: tripwires-4/5
+            mode: nextest
+            filter: 'test(/^cert_tripwire_/)'
+            partition: 4/5
+          - suite: cert_verify_spec
+            lane: tripwires-5/5
+            mode: nextest
+            filter: 'test(/^cert_tripwire_/)'
+            partition: 5/5
           - suite: cert_verify_spec
             lane: plans-authority-1/3
             mode: nextest
@@ -123,42 +147,42 @@ jobs:
           - suite: cert_verify_spec
             lane: rest-1/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
             partition: 1/8
           - suite: cert_verify_spec
             lane: rest-2/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
             partition: 2/8
           - suite: cert_verify_spec
             lane: rest-3/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
             partition: 3/8
           - suite: cert_verify_spec
             lane: rest-4/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
             partition: 4/8
           - suite: cert_verify_spec
             lane: rest-5/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
             partition: 5/8
           - suite: cert_verify_spec
             lane: rest-6/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
             partition: 6/8
           - suite: cert_verify_spec
             lane: rest-7/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
             partition: 7/8
           - suite: cert_verify_spec
             lane: rest-8/8
             mode: nextest
-            filter: 'not (test(=cert_verify_accepts_and_tripwires_fail_closed) or test(/^cert_plans_authority_/))'
+            filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
             partition: 8/8
     env:
       CARGO_BUILD_JOBS: '2'
@@ -239,8 +263,8 @@ jobs:
         run: cargo test -p aver-lang --features wasm --test ${{ matrix.suite }}
 
       - name: Run certification suite lane
-        # Filtering happens before slice partitioning. Each monster-test filter
-        # (exact name, or one of the `cert_hostile_model_`, `cert_adt_witness_`
+        # Filtering happens before slice partitioning. Each family filter (one
+        # of the `cert_hostile_model_`, `cert_adt_witness_`, `cert_tripwire_`
         # and `cert_plans_authority_` prefixes) and its suite-specific
         # complement are disjoint and exhaustive.
         if: matrix.mode == 'nextest'

--- a/aver-cert/src/wall.rs
+++ b/aver-cert/src/wall.rs
@@ -357,8 +357,149 @@ pub fn render_artifact_bytes(bytes: &[u8]) -> String {
 }
 
 #[cfg(test)]
+mod byte_binding_lint;
+
+#[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The wall as the lint consumes it: `(filename, source text)`.
+    fn wall_sources() -> Vec<(&'static str, &'static str)> {
+        SOURCES
+            .iter()
+            .map(|source| (source.name, source.contents))
+            .collect()
+    }
+
+    const FORMAT_DOC: &str = include_str!("../../docs/certificate-format.md");
+
+    /// Every value the producer declares must be constrained against the module
+    /// bytes by some conjunct of `AverCert.AcceptedArtifact.accepted`, or carry
+    /// an explicit, reasoned exception.
+    ///
+    /// This is the mechanised form of a failure that has recurred six times: a
+    /// declared value consumed by a proof while nothing pinned it to the bytes.
+    /// The most recent was `hostRoleTable.toIndex`, where the byte-derived
+    /// binding existed, its comment described exactly the attack it prevented,
+    /// and its only consumer had silently left the acceptance path. Reviewers
+    /// reading documentation saw a pin that was not there; this test reads the
+    /// wall instead.
+    #[test]
+    fn producer_declared_values_are_bound_to_the_module_bytes() {
+        match byte_binding_lint::check(&wall_sources(), FORMAT_DOC) {
+            Ok(report) => println!("{report}"),
+            Err(failure) => panic!("{failure}"),
+        }
+    }
+
+    /// The lint must still be able to SEE the historical gap.
+    ///
+    /// Deleting the one conjunct that commit fd455ade added — the equality
+    /// pinning `roles.toIndex` to `CertDecode.AddSub.toIndexIdx` — reproduces
+    /// the pre-fix acceptance predicate for that field, and the lint must flag
+    /// it. `box` is the control: a sibling field of the SAME structure,
+    /// projected in the SAME function on an ADJACENT line, which must stay
+    /// bound. Without that control the test would pass for a lint that had
+    /// stopped discriminating and simply flags everything.
+    ///
+    /// This test is the guard on every future precision refinement. Two
+    /// plausible generalisations (transitive byte taint, and unrestricted
+    /// whole-value propagation through call arguments) each looked like clean
+    /// wins and each silently re-bound `toIndex`; this is what caught them.
+    #[test]
+    fn lint_still_flags_the_historical_index_helper_gap() {
+        const PIN: &str = "(roles.toIndex == CertDecode.AddSub.toIndexIdx n len) &&";
+        let core = CERT_ACCEPTED_ARTIFACT_CORE;
+        assert!(
+            core.contains(PIN),
+            "the `toIndex` pin has moved; this regression test must be re-aimed \
+             rather than deleted"
+        );
+        let without_pin = core.replace(PIN, "");
+
+        let sources: Vec<(&str, &str)> = wall_sources()
+            .into_iter()
+            .map(|(name, text)| {
+                if name == "AcceptedArtifactCore.lean" {
+                    (name, without_pin.as_str())
+                } else {
+                    (name, text)
+                }
+            })
+            .collect();
+
+        let report = byte_binding_lint::analyse(&sources);
+        assert!(
+            report.is_flagged("AddSub.Roles", "toIndex"),
+            "the lint no longer detects the historical index-helper gap: with the \
+             `toIndex` pin removed, `Roles.toIndex` was still considered bound. A \
+             precision refinement has blunted the lint past the point of usefulness."
+        );
+        assert!(
+            report.is_bound("AddSub.Roles", "box"),
+            "control failed: sibling field `Roles.box` is pinned by its own export \
+             name on an adjacent line and must remain bound. The lint is flagging \
+             indiscriminately rather than discriminating."
+        );
+
+        // and with the pin present, the field is bound
+        let clean = byte_binding_lint::analyse(&wall_sources());
+        assert!(
+            clean.is_bound("AddSub.Roles", "toIndex"),
+            "`Roles.toIndex` is not bound on the current wall"
+        );
+    }
+
+    /// Point the lint at an external directory of `.lean` sources, for auditing a
+    /// historical or candidate wall. Ignored by default because it needs a tree
+    /// that is not in the repository:
+    ///
+    /// ```text
+    /// git archive fd455ade^ aver-cert/assets/wall/current | tar -x -C /tmp/prefix
+    /// AVER_WALL_LINT_DIR=/tmp/prefix/aver-cert/assets/wall/current \
+    ///   cargo test -p aver-cert --lib external_wall_directory -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "requires AVER_WALL_LINT_DIR pointing at a directory of wall sources"]
+    fn external_wall_directory() {
+        let dir = std::env::var("AVER_WALL_LINT_DIR")
+            .expect("set AVER_WALL_LINT_DIR to a directory of .lean wall sources");
+        let mut texts: Vec<(String, String)> = Vec::new();
+        for entry in std::fs::read_dir(&dir).expect("readable wall directory") {
+            let path = entry.expect("readable entry").path();
+            if path.extension().and_then(|e| e.to_str()) == Some("lean") {
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .expect("utf-8 filename")
+                    .to_string();
+                texts.push((
+                    name,
+                    std::fs::read_to_string(&path).expect("readable source"),
+                ));
+            }
+        }
+        let sources: Vec<(&str, &str)> = texts
+            .iter()
+            .map(|(n, t)| (n.as_str(), t.as_str()))
+            .collect();
+        let report = byte_binding_lint::analyse(&sources);
+        println!(
+            "{dir}: {} slots, {} bound, {} flagged",
+            report.slots.len(),
+            report.bound.len(),
+            report.flagged.len()
+        );
+        for (s, f) in &report.flagged {
+            println!("  FLAG {s}.{f}");
+        }
+        // Run the real gate too, so this answers "would CI go red on that wall?"
+        // rather than merely listing flags.
+        match byte_binding_lint::check(&sources, FORMAT_DOC) {
+            Ok(_) => println!("\nGATE: PASS (every flagged field has an Allowance)"),
+            Err(failure) => println!("\nGATE: FAIL\n{failure}"),
+        }
+    }
 
     #[test]
     fn wall_sources_have_unique_plain_filenames() {

--- a/aver-cert/src/wall/byte_binding_lint.rs
+++ b/aver-cert/src/wall/byte_binding_lint.rs
@@ -1,0 +1,1714 @@
+//! Byte-binding lint: every producer-declared value must be constrained by the
+//! module bytes somewhere inside the acceptance predicate.
+//!
+//! # Why this exists
+//!
+//! A certificate manifest carries values DECLARED by the producer, who is
+//! untrusted. A declared value is only trustworthy if some conjunct of
+//! `AverCert.AcceptedArtifact.accepted` constrains it against the artifact
+//! bytes. Six times a declared value has been consumed by a proof while nothing
+//! constrained it; the most recent was `hostRoleTable.toIndex`, where the
+//! byte-derived binding (`CertDecode.AddSub.toIndexIdx`) existed and its own
+//! comment claimed to prevent exactly that attack, but its only consumer had
+//! left the acceptance path in an earlier refactor. The spec, the comment and
+//! the function name all agreed, and all three were wrong.
+//!
+//! # What the lint checks, and why it is not "is the field projected"
+//!
+//! The obvious property — "every field is projected somewhere inside the
+//! definitional cone of `accepted`" — does NOT catch that bug. At the pre-fix
+//! commit the chain
+//!
+//! ```text
+//! accepted -> StandardFace.checkedFaces -> symFragmentMatches
+//!          -> hostTableBound -> decodedRoleIdx -> roles.toIndex
+//! ```
+//!
+//! puts `roles.toIndex` squarely inside the cone. The bug was not "never
+//! projected"; it was "projected, and even compared, but only against another
+//! producer-declared value" — `hostTableBound` compares the claim's `hostTable`
+//! against the subject's declared roles, and nothing in that chain touches
+//! `modBytes`. So reachability is necessary (it is what notices a binding that
+//! has LEFT the acceptance path, the literal failure mode here) but nowhere near
+//! sufficient. The discriminating condition is ANCHORING: the field has to meet
+//! something the producer does not control.
+//!
+//! A field slot has binding evidence when a definition reachable from `accepted`
+//! contains a top-level conjunct satisfying one of:
+//!
+//! * **A — byte co-occurrence.** The conjunct projects the field and applies a
+//!   byte anchor. Anchors are auto-derived, never hand-listed: a wall `def` is an
+//!   anchor when its binders carry the module byte stream (`(n len : Nat)`,
+//!   `(modBytes modLen : Nat)`) or `(artifact : ArtifactData)`. This is why
+//!   `CertDecode.AddSub.toIndexIdx` is an anchor and `decodedRoleIdx` is not —
+//!   exactly the distinction the bug turned on.
+//! * **A1 — one-hop argument.** A producer value passed whole into a reachable
+//!   definition from an anchored conjunct, where the callee projects the field.
+//!   Depth one only; deeper propagation reinstates the historical false negative.
+//! * **B — pinned to a wall term.** The conjunct equates the field to a term
+//!   mentioning no producer-supplied value at all (a wall literal, a wall
+//!   constant, a byte decode). The producer then has no freedom in that field.
+//! * **C — whole-value equality against bytes.** One side of the conjunct is
+//!   producer-free AND byte-derived, the other mentions a producer value whole;
+//!   every leaf field of that value is then determined. This is how the lowered
+//!   plan payloads are constrained (`lowerX plan = <real code bytes>`).
+//!
+//! Rules A1 and C are deliberately narrow. Blanket versions of both were tried
+//! and both silently re-bound `roles.toIndex` in the pre-fix tree, i.e. they
+//! reproduced the very blindness the lint exists to prevent. The regression test
+//! `lint_still_flags_the_historical_index_helper_gap` is what holds that line.
+//!
+//! # What this lint cannot see
+//!
+//! It finds MISSING conjuncts, never WEAK ones. Two limits are worth stating
+//! because both were measured, not guessed:
+//!
+//! * **Co-occurrence is not comparison.** Rule A asks whether a projection and
+//!   a byte anchor appear in the same conjunct, not whether they are the two
+//!   sides of one equality. Deleting the exact byte equality
+//!   `actual == declared.map capabilityBytes` from `importsWithinCapabilities`
+//!   does NOT flag `Subject.capabilities`, because a sibling conjunct in the
+//!   same (byte-anchored) function still projects the field for the weaker
+//!   registry-membership test. Deleting the only conjunct that mentions a field
+//!   IS caught — that is the historical class, and mutation runs confirm it for
+//!   `Roles.toIndex`, `Roles.box` and `Subject.start`.
+//! * **Binding strength is invisible.** `arithRoleCheck` returns `true` for an
+//!   unbound (`none`) role — vacuous by design — and the lint still scores
+//!   `Roles.add` as bound. Guard-isolation tests (delete one conjunct, watch a
+//!   hostile package get accepted) remain the only thing that measures whether a
+//!   conjunct is load-bearing.
+//!
+//! It also sees only the wall: values pinned by the Rust checker or the
+//! generated `CheckerWitness.lean` are outside `accepted`'s cone and get
+//! flagged, which is what [`Category::PinnedOutsideTheWall`] is for — and that
+//! category is itself an unaudited trust surface.
+//!
+//! # Exceptions
+//!
+//! There is deliberately no "ignore" or "skip" switch. The only way to make a
+//! field green without a byte binding is an [`Allowance`] stating WHY, and every
+//! allowance is printed on every run, pass or fail, so the declared-only surface
+//! is visible rather than discoverable. Allowances are also checked for rot:
+//! an allowance for a field that has since acquired a real binding fails, an
+//! allowance naming a field that no longer exists fails, and a
+//! [`Category::KnownGap`] allowance must resolve to a `Known gap` marker in the
+//! format specification.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+// ---------------------------------------------------------------------------
+// Lexical helpers (hand-rolled: this crate ships a deliberately minimal
+// dependency tree and the lint must not add to it)
+// ---------------------------------------------------------------------------
+
+fn is_ident_start(c: char) -> bool {
+    c.is_ascii_alphabetic() || c == '_'
+}
+
+fn is_ident_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '\'' || ('\u{2080}'..='\u{2089}').contains(&c)
+}
+
+/// Identifier characters plus the dot/bang/question marks Lean allows in a
+/// qualified name, used when scanning for referenced definitions.
+fn is_token_char(c: char) -> bool {
+    is_ident_char(c) || c == '.' || c == '!' || c == '?'
+}
+
+/// Replace block and line comments with layout-preserving whitespace, so byte
+/// offsets and line numbers stay meaningful.
+fn strip_comments(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0usize;
+    let mut depth = 0usize;
+    while i < chars.len() {
+        let two = |i: usize| -> Option<(char, char)> {
+            if i + 1 < chars.len() {
+                Some((chars[i], chars[i + 1]))
+            } else {
+                None
+            }
+        };
+        if two(i) == Some(('/', '-')) {
+            depth += 1;
+            out.push(' ');
+            out.push(' ');
+            i += 2;
+            continue;
+        }
+        if two(i) == Some(('-', '/')) && depth > 0 {
+            depth -= 1;
+            out.push(' ');
+            out.push(' ');
+            i += 2;
+            continue;
+        }
+        if depth > 0 {
+            out.push(if chars[i] == '\n' { '\n' } else { ' ' });
+            i += 1;
+            continue;
+        }
+        if two(i) == Some(('-', '-')) {
+            while i < chars.len() && chars[i] != '\n' {
+                out.push(' ');
+                i += 1;
+            }
+            continue;
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+/// Blank out string literals so their contents are never mistaken for code.
+fn blank_string_literals(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_str = false;
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if in_str {
+            if c == '\\' {
+                chars.next();
+                continue;
+            }
+            if c == '"' {
+                in_str = false;
+                out.push('"');
+            }
+            continue;
+        }
+        if c == '"' {
+            in_str = true;
+            out.push('"');
+            continue;
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// All identifier-or-qualified-name tokens in `s`.
+fn tokens(s: &str) -> Vec<String> {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < chars.len() {
+        if is_ident_start(chars[i]) && (i == 0 || !is_token_char(chars[i - 1])) {
+            let start = i;
+            while i < chars.len() && is_token_char(chars[i]) {
+                i += 1;
+            }
+            out.push(chars[start..i].iter().collect::<String>());
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Plain identifiers (no dots), used for local-name scanning.
+fn idents(s: &str) -> Vec<String> {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < chars.len() {
+        if is_ident_start(chars[i]) && (i == 0 || !is_token_char(chars[i - 1])) {
+            let start = i;
+            while i < chars.len() && is_ident_char(chars[i]) {
+                i += 1;
+            }
+            if i < chars.len() && chars[i] == '.' {
+                while i < chars.len() && is_token_char(chars[i]) {
+                    i += 1;
+                }
+                continue;
+            }
+            out.push(chars[start..i].iter().collect::<String>());
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// A projection chain `base.f1.f2...` found in source text.
+#[derive(Debug, Clone)]
+struct Chain {
+    base: String,
+    fields: Vec<String>,
+    /// byte offset just past the chain, used to tell `x.f` from `x.f.g`
+    end: usize,
+    start: usize,
+}
+
+/// Scan every `base.f1.f2...` chain. A dot preceded by whitespace or an opening
+/// bracket is Lean's anonymous-constructor dot, not a projection, and is skipped
+/// because the scan requires an identifier immediately before the dot.
+fn chains(s: &str) -> Vec<Chain> {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < chars.len() {
+        if is_ident_start(chars[i]) && (i == 0 || !is_token_char(chars[i - 1])) {
+            let start = i;
+            while i < chars.len() && is_ident_char(chars[i]) {
+                i += 1;
+            }
+            let base: String = chars[start..i].iter().collect();
+            let mut fields = Vec::new();
+            while i + 1 < chars.len() && chars[i] == '.' && is_ident_start(chars[i + 1]) {
+                i += 1;
+                let fs = i;
+                while i < chars.len() && is_ident_char(chars[i]) {
+                    i += 1;
+                }
+                fields.push(chars[fs..i].iter().collect::<String>());
+            }
+            if !fields.is_empty() {
+                out.push(Chain {
+                    base,
+                    fields,
+                    end: i,
+                    start,
+                });
+            }
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Split `s` on top-level (bracket depth zero) occurrences of any separator.
+fn split_top(s: &str, seps: &[&str]) -> Vec<String> {
+    let chars: Vec<char> = s.chars().collect();
+    let mut parts = Vec::new();
+    let mut cur = String::new();
+    let mut depth = 0i32;
+    let mut i = 0usize;
+    'outer: while i < chars.len() {
+        let c = chars[i];
+        if c == '(' || c == '[' || c == '{' {
+            depth += 1;
+        } else if c == ')' || c == ']' || c == '}' {
+            depth -= 1;
+        }
+        if depth <= 0 {
+            for sep in seps {
+                let sc: Vec<char> = sep.chars().collect();
+                if i + sc.len() <= chars.len() && chars[i..i + sc.len()] == sc[..] {
+                    parts.push(std::mem::take(&mut cur));
+                    i += sc.len();
+                    continue 'outer;
+                }
+            }
+        }
+        cur.push(c);
+        i += 1;
+    }
+    parts.push(cur);
+    parts
+}
+
+/// A balanced binder group `( names : type )` / `{ .. }` / `[ .. ]`.
+#[derive(Debug, Clone)]
+struct Binder {
+    names: Vec<String>,
+    ty: String,
+}
+
+fn binders(sig: &str) -> Vec<Binder> {
+    let chars: Vec<char> = sig.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < chars.len() {
+        let open = chars[i];
+        let close = match open {
+            '(' => ')',
+            '{' => '}',
+            '[' => ']',
+            _ => {
+                i += 1;
+                continue;
+            }
+        };
+        let mut depth = 0i32;
+        let mut j = i;
+        while j < chars.len() {
+            if chars[j] == open {
+                depth += 1;
+            } else if chars[j] == close {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            j += 1;
+        }
+        if j >= chars.len() {
+            i += 1;
+            continue;
+        }
+        let inner: String = chars[i + 1..j].iter().collect();
+        if let Some(b) = parse_binder(&inner) {
+            out.push(b);
+        }
+        i += 1;
+    }
+    out
+}
+
+fn parse_binder(inner: &str) -> Option<Binder> {
+    // first top-level `:` that is not `:=`
+    let chars: Vec<char> = inner.chars().collect();
+    let mut depth = 0i32;
+    let mut cut = None;
+    for i in 0..chars.len() {
+        let c = chars[i];
+        if c == '(' || c == '[' || c == '{' {
+            depth += 1;
+        } else if c == ')' || c == ']' || c == '}' {
+            depth -= 1;
+        } else if c == ':' && depth == 0 && chars.get(i + 1) != Some(&'=') {
+            cut = Some(i);
+            break;
+        }
+    }
+    let cut = cut?;
+    let lhs: String = chars[..cut].iter().collect();
+    let rhs: String = chars[cut + 1..].iter().collect();
+    let names: Vec<String> = lhs.split_whitespace().map(|s| s.to_string()).collect();
+    if names.is_empty()
+        || !names
+            .iter()
+            .all(|n| n.chars().next().is_some_and(is_ident_start))
+    {
+        return None;
+    }
+    Some(Binder {
+        names,
+        ty: rhs.trim().to_string(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Wall model
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Def,
+    Structure,
+    Other,
+}
+
+#[derive(Debug, Clone)]
+struct Decl {
+    kind: Kind,
+    short: String,
+    full: String,
+    ns: Vec<String>,
+    opens: Vec<String>,
+    sig: String,
+    body: String,
+    file: String,
+    line: usize,
+    /// structure fields, as (name, type expression)
+    fields: Vec<(String, String)>,
+}
+
+const DECL_KEYWORDS: [&str; 7] = [
+    "def",
+    "abbrev",
+    "theorem",
+    "lemma",
+    "instance",
+    "structure",
+    "inductive",
+];
+
+const MODIFIERS: [&str; 5] = ["private", "protected", "partial", "noncomputable", "unsafe"];
+
+/// Recognise a declaration header, returning (indent, kind, name).
+fn decl_header(line: &str) -> Option<(usize, Kind, String)> {
+    let indent = line.len() - line.trim_start().len();
+    let mut rest = line.trim_start();
+    if rest.starts_with("@[") {
+        let close = rest.find(']')?;
+        rest = rest[close + 1..].trim_start();
+    }
+    loop {
+        let mut advanced = false;
+        for m in MODIFIERS {
+            if let Some(r) = rest.strip_prefix(m)
+                && r.starts_with(char::is_whitespace)
+            {
+                rest = r.trim_start();
+                advanced = true;
+            }
+        }
+        if !advanced {
+            break;
+        }
+    }
+    for kw in DECL_KEYWORDS {
+        if let Some(r) = rest.strip_prefix(kw) {
+            if !r.starts_with(char::is_whitespace) {
+                continue;
+            }
+            let name: String = r
+                .trim_start()
+                .chars()
+                .take_while(|c| is_token_char(*c))
+                .collect();
+            if name.is_empty() || !name.chars().next().is_some_and(is_ident_start) {
+                continue;
+            }
+            let kind = match kw {
+                "def" | "abbrev" => Kind::Def,
+                "structure" => Kind::Structure,
+                _ => Kind::Other,
+            };
+            return Some((indent, kind, name));
+        }
+    }
+    None
+}
+
+fn parse_file(name: &str, text: &str) -> Vec<Decl> {
+    let stripped = strip_comments(text);
+    let lines: Vec<&str> = stripped.split('\n').collect();
+
+    // namespace / open context per line
+    let mut stack: Vec<Option<String>> = Vec::new();
+    let mut opens: Vec<String> = Vec::new();
+    let mut ns_at: Vec<Vec<String>> = Vec::with_capacity(lines.len());
+    let mut op_at: Vec<Vec<String>> = Vec::with_capacity(lines.len());
+    for line in &lines {
+        let t = line.trim_start();
+        if let Some(r) = t.strip_prefix("namespace ") {
+            stack.push(Some(r.trim().to_string()));
+        } else if t.starts_with("section") || t.starts_with("mutual") {
+            stack.push(None);
+        } else if t == "end" || t.starts_with("end ") {
+            stack.pop();
+        } else if let Some(r) = t.strip_prefix("open ")
+            && !r.contains(" in ")
+        {
+            for tok in r.split_whitespace() {
+                if tok.chars().next().is_some_and(is_ident_start) {
+                    opens.push(tok.to_string());
+                }
+            }
+        }
+        ns_at.push(stack.iter().flatten().cloned().collect());
+        op_at.push(opens.clone());
+    }
+
+    let mut starts: Vec<(usize, usize, Kind, String)> = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        if let Some((indent, kind, nm)) = decl_header(line) {
+            starts.push((i, indent, kind, nm));
+        }
+    }
+
+    let mut out = Vec::new();
+    for (k, (i, indent, kind, short)) in starts.iter().enumerate() {
+        let end = starts.get(k + 1).map(|s| s.0).unwrap_or(lines.len());
+        let body = lines[*i..end].join("\n");
+        let sig = match body.find(":=") {
+            Some(c) => body[..c].to_string(),
+            None => body.clone(),
+        };
+        let short_tail = short.rsplit('.').next().unwrap_or(short).to_string();
+        let mut full = ns_at[*i].clone();
+        full.push(short.clone());
+        let fields = if *kind == Kind::Structure {
+            parse_fields(&lines[*i..end], *indent)
+        } else {
+            Vec::new()
+        };
+        out.push(Decl {
+            kind: *kind,
+            short: short_tail,
+            full: full.join("."),
+            ns: ns_at[*i].clone(),
+            opens: op_at[*i].clone(),
+            sig,
+            body,
+            file: name.to_string(),
+            line: i + 1,
+            fields,
+        });
+    }
+    out
+}
+
+fn parse_fields(chunk: &[&str], base_indent: usize) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in chunk.iter().skip(1) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let ind = line.len() - line.trim_start().len();
+        if ind <= base_indent {
+            break;
+        }
+        let t = line.trim();
+        if t.starts_with("deriving") {
+            break;
+        }
+        // `names : type`, rejecting `:=` (default values are still fields, but
+        // the header form `name : Ty := default` splits on the first `:`)
+        let chars: Vec<char> = line.chars().collect();
+        let mut depth = 0i32;
+        let mut cut = None;
+        for i in 0..chars.len() {
+            let c = chars[i];
+            if c == '(' || c == '[' || c == '{' {
+                depth += 1;
+            } else if c == ')' || c == ']' || c == '}' {
+                depth -= 1;
+            } else if c == ':' && depth == 0 && chars.get(i + 1) != Some(&'=') {
+                cut = Some(i);
+                break;
+            }
+        }
+        let Some(cut) = cut else { continue };
+        let lhs: String = chars[..cut].iter().collect();
+        let ty: String = chars[cut + 1..].iter().collect();
+        let names: Vec<String> = lhs.split_whitespace().map(|s| s.to_string()).collect();
+        if names.is_empty()
+            || !names.iter().all(|n| {
+                n.chars().all(is_ident_char) && n.chars().next().is_some_and(is_ident_start)
+            })
+        {
+            continue;
+        }
+        for n in names {
+            out.push((n, ty.trim().to_string()));
+        }
+    }
+    out
+}
+
+struct Wall {
+    decls: Vec<Decl>,
+    by_full: BTreeMap<String, usize>,
+    structs: BTreeMap<String, usize>,
+    struct_by_short: BTreeMap<String, Vec<String>>,
+}
+
+const BUILTIN_TYPES: [&str; 12] = [
+    "Option", "List", "Prod", "Nat", "String", "Int", "Bool", "Type", "Array", "Char", "UInt64",
+    "Prop",
+];
+
+impl Wall {
+    fn new(decls: Vec<Decl>) -> Self {
+        let mut by_full = BTreeMap::new();
+        let mut structs = BTreeMap::new();
+        let mut struct_by_short: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for (i, d) in decls.iter().enumerate() {
+            by_full.entry(d.full.clone()).or_insert(i);
+            if d.kind == Kind::Structure {
+                structs.entry(d.full.clone()).or_insert(i);
+                struct_by_short
+                    .entry(d.short.clone())
+                    .or_default()
+                    .push(d.full.clone());
+            }
+        }
+        Wall {
+            decls,
+            by_full,
+            structs,
+            struct_by_short,
+        }
+    }
+
+    fn get(&self, full: &str) -> Option<&Decl> {
+        self.by_full.get(full).map(|i| &self.decls[*i])
+    }
+
+    fn structure(&self, full: &str) -> Option<&Decl> {
+        self.structs.get(full).map(|i| &self.decls[*i])
+    }
+
+    /// Namespace-aware resolution of a referenced name. Short-name keying alone
+    /// is not enough: it once pulled the DEAD `CertDecode.AddSub.roleTable` into
+    /// the reachable set on the live `StringHost.roleTable`'s name.
+    fn resolve(&self, tok: &str, ns: &[String], opens: &[String]) -> Option<String> {
+        for k in (0..=ns.len()).rev() {
+            let mut cand = ns[..k].to_vec();
+            cand.push(tok.to_string());
+            let c = cand.join(".");
+            if self.by_full.contains_key(&c) {
+                return Some(c);
+            }
+        }
+        for o in opens {
+            let c = format!("{o}.{tok}");
+            if self.by_full.contains_key(&c) {
+                return Some(c);
+            }
+        }
+        if self.by_full.contains_key(tok) {
+            return Some(tok.to_string());
+        }
+        None
+    }
+
+    /// Type expression -> producer structure, peeling `Option`/`List`/`Prod`.
+    fn resolve_struct(&self, ty: &str, ns: &[String], opens: &[String]) -> Option<String> {
+        for t in tokens(ty) {
+            if BUILTIN_TYPES.contains(&t.as_str()) {
+                continue;
+            }
+            if let Some(r) = self.resolve(&t, ns, opens)
+                && self.structs.contains_key(&r)
+            {
+                return Some(r);
+            }
+            if self.structs.contains_key(&t) {
+                return Some(t);
+            }
+            let short = t.rsplit('.').next().unwrap_or(&t);
+            if let Some(v) = self.struct_by_short.get(short)
+                && v.len() == 1
+            {
+                return Some(v[0].clone());
+            }
+        }
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Producer surface and reachability
+// ---------------------------------------------------------------------------
+
+/// A producer-declared value slot: one leaf field of a producer structure.
+pub type FieldRef = (String, String);
+
+fn is_arrow(ty: &str) -> bool {
+    ty.contains('→') || ty.contains("->")
+}
+
+/// Structures reachable from `ArtifactData` through plain-data field types.
+/// Arrow types are not followed: `Obligation.domRepr : CarrierSpec c -> ...`
+/// must not drag `CarrierSpec` in, because a `CarrierSpec` is universally
+/// quantified inside `Obligation.holds` and is wall-side, not producer-supplied.
+fn producer_closure(w: &Wall) -> BTreeSet<String> {
+    let mut start = None;
+    for d in &w.decls {
+        if d.kind == Kind::Structure && d.short == "ArtifactData" {
+            start = Some(d.full.clone());
+        }
+    }
+    let mut seen = BTreeSet::new();
+    let mut stack: Vec<String> = start.into_iter().collect();
+    while let Some(s) = stack.pop() {
+        if !seen.insert(s.clone()) {
+            continue;
+        }
+        let Some(d) = w.structure(&s) else { continue };
+        for (_f, ty) in &d.fields {
+            if is_arrow(ty) {
+                continue;
+            }
+            if let Some(t) = w.resolve_struct(ty, &d.ns, &d.opens)
+                && !seen.contains(&t)
+            {
+                stack.push(t);
+            }
+        }
+    }
+    seen
+}
+
+fn reachable_from(w: &Wall, root: &str) -> BTreeSet<String> {
+    let mut seen = BTreeSet::new();
+    let mut stack = vec![root.to_string()];
+    while let Some(s) = stack.pop() {
+        if !seen.insert(s.clone()) {
+            continue;
+        }
+        let Some(d) = w.get(&s) else { continue };
+        for tok in tokens(&d.body) {
+            if let Some(r) = w.resolve(&tok, &d.ns, &d.opens)
+                && !seen.contains(&r)
+            {
+                stack.push(r);
+            }
+            if tok.contains('.') {
+                let parts: Vec<&str> = tok.split('.').collect();
+                for j in (1..parts.len()).rev() {
+                    let cand = parts[..j].join(".");
+                    if let Some(r) = w.resolve(&cand, &d.ns, &d.opens)
+                        && !seen.contains(&r)
+                    {
+                        stack.push(r);
+                    }
+                }
+            }
+        }
+    }
+    seen
+}
+
+/// A definition is a byte anchor when its binders carry the module byte stream
+/// or the whole artifact. Auto-derived on purpose: a hand-maintained anchor list
+/// is exactly the sort of table that rots into a lie.
+fn is_byte_anchor(d: &Decl) -> bool {
+    for b in binders(&d.sig) {
+        let ty = b.ty.trim();
+        if ty == "Nat" {
+            for pair in [("n", "len"), ("modBytes", "modLen")] {
+                for i in 0..b.names.len().saturating_sub(1) {
+                    if b.names[i] == pair.0 && b.names[i + 1] == pair.1 {
+                        return true;
+                    }
+                }
+            }
+        }
+        if ty == "ArtifactData" && b.names.len() == 1 && b.names[0] == "artifact" {
+            return true;
+        }
+    }
+    false
+}
+
+fn binds_raw_bytes(d: &Decl) -> bool {
+    for b in binders(&d.sig) {
+        if b.ty.trim() == "Nat" {
+            for pair in [("n", "len"), ("modBytes", "modLen")] {
+                for i in 0..b.names.len().saturating_sub(1) {
+                    if b.names[i] == pair.0 && b.names[i + 1] == pair.1 {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Local typing
+// ---------------------------------------------------------------------------
+
+type Env = BTreeMap<String, String>;
+
+fn let_bindings(body: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in body.split('\n') {
+        let mut rest = line;
+        while let Some(p) = rest.find("let ") {
+            let after = &rest[p + 4..];
+            let name: String = after.chars().take_while(|c| is_ident_char(*c)).collect();
+            let tail = &after[name.len()..];
+            if !name.is_empty()
+                && let Some(t) = tail.trim_start().strip_prefix(":=")
+            {
+                out.push((name, t.trim().to_string()));
+            }
+            rest = &rest[p + 4..];
+        }
+    }
+    out
+}
+
+/// `match E1, E2 with` scrutinee texts.
+fn match_scrutinees(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = body;
+    while let Some(p) = rest.find("match ") {
+        let after = &rest[p + 6..];
+        if let Some(w) = after.find(" with") {
+            out.push(after[..w].to_string());
+        }
+        rest = &rest[p + 6..];
+    }
+    out
+}
+
+/// Identifiers bound by a `∃ a b c,` prefix.
+fn exists_names(body: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut rest = body;
+    while let Some(p) = rest.find('∃') {
+        let after = &rest[p + '∃'.len_utf8()..];
+        if let Some(c) = after.find(',') {
+            for id in idents(&after[..c]) {
+                if id != "_" {
+                    out.insert(id);
+                }
+            }
+        }
+        rest = after;
+    }
+    out
+}
+
+fn pattern_binds(pat: &str) -> Vec<String> {
+    let p = pat.trim();
+    for head in ["some ", ".some "] {
+        if let Some(r) = p.strip_prefix(head) {
+            return idents(r).into_iter().filter(|x| x != "_").collect();
+        }
+    }
+    if let Some(i) = p.find("::") {
+        return idents(&p[..i]).into_iter().filter(|x| x != "_").collect();
+    }
+    Vec::new()
+}
+
+fn local_env(w: &Wall, d: &Decl) -> Env {
+    let mut env: Env = BTreeMap::new();
+    for b in binders(&d.sig) {
+        if let Some(t) = w.resolve_struct(&b.ty, &d.ns, &d.opens) {
+            for n in b.names {
+                env.entry(n).or_insert_with(|| t.clone());
+            }
+        }
+    }
+    for (name, rhs) in let_bindings(&d.body) {
+        if let Some(t) = expr_struct(w, &env, &rhs) {
+            env.entry(name).or_insert(t);
+        }
+    }
+    // match-scrutinee propagation, to a fixpoint bounded at three rounds
+    for _ in 0..3 {
+        let mut grew = false;
+        for scrut in match_scrutinees(&d.body) {
+            let parts = split_top(&scrut, &[","]);
+            let types: Vec<Option<String>> = parts
+                .iter()
+                .map(|p| expr_struct(w, &env, p.trim()))
+                .collect();
+            let Some(pos) = d.body.find(&scrut) else {
+                continue;
+            };
+            let tail = &d.body[pos..];
+            let window = &tail[..tail.len().min(6000)];
+            for arm in window.split('|').skip(1) {
+                let Some(ar) = arm.find("=>") else { continue };
+                let pats = split_top(&arm[..ar], &[","]);
+                if pats.len() != types.len() {
+                    continue;
+                }
+                for (pat, ty) in pats.iter().zip(types.iter()) {
+                    let Some(ty) = ty else { continue };
+                    for nm in pattern_binds(pat) {
+                        if let std::collections::btree_map::Entry::Vacant(e) = env.entry(nm) {
+                            e.insert(ty.clone());
+                            grew = true;
+                        }
+                    }
+                }
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
+    env
+}
+
+/// Type of an expression, when it is exactly an identifier or projection chain.
+fn expr_struct(w: &Wall, env: &Env, expr: &str) -> Option<String> {
+    let e = expr.trim();
+    if e.chars().all(is_ident_char) && !e.is_empty() {
+        return env.get(e).cloned();
+    }
+    let cs = chains(e);
+    if cs.len() != 1 || cs[0].start != 0 || cs[0].end != e.chars().count() {
+        return None;
+    }
+    let c = &cs[0];
+    let mut cur = env.get(&c.base)?.clone();
+    for f in &c.fields {
+        let sd = w.structure(&cur)?;
+        let (_n, ty) = sd.fields.iter().find(|(n, _)| n == f)?;
+        if is_arrow(ty) {
+            return None;
+        }
+        cur = w.resolve_struct(ty, &sd.ns, &sd.opens)?;
+    }
+    Some(cur)
+}
+
+/// Resolve the longest prefix of `base.f1.f2...` that ends at a real field.
+/// The prefix walk matters: `manifest.subject.declaredUncertified.map` must
+/// attribute to `Subject.declaredUncertified`, not fail on the trailing `.map`.
+fn chain_field(w: &Wall, env: &Env, c: &Chain) -> Option<FieldRef> {
+    for k in (1..=c.fields.len()).rev() {
+        if let Some(r) = chain_field_exact(w, env, &c.base, &c.fields[..k]) {
+            return Some(r);
+        }
+    }
+    None
+}
+
+fn chain_field_exact(w: &Wall, env: &Env, base: &str, fields: &[String]) -> Option<FieldRef> {
+    let mut cur = env.get(base)?.clone();
+    for (i, f) in fields.iter().enumerate() {
+        let sd = w.structure(&cur)?;
+        let (_n, ty) = sd.fields.iter().find(|(n, _)| n == f)?;
+        if i + 1 == fields.len() {
+            return Some((cur, f.clone()));
+        }
+        if is_arrow(ty) {
+            return None;
+        }
+        cur = w.resolve_struct(ty, &sd.ns, &sd.opens)?;
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Conjunct analysis
+// ---------------------------------------------------------------------------
+
+fn conjuncts(body: &str) -> Vec<String> {
+    let tail = match body.find(":=") {
+        Some(c) => &body[c + 2..],
+        None => body,
+    };
+    let mut out = Vec::new();
+    for arm in split_top(tail, &["\n  | ", "\n      | "]) {
+        out.extend(split_top(&arm, &["&&", "∧"]));
+    }
+    out
+}
+
+fn expand_lets(c: &str, lets: &BTreeMap<String, String>) -> String {
+    let mut cur = c.to_string();
+    for _ in 0..3 {
+        let mut out = String::with_capacity(cur.len());
+        let chars: Vec<char> = cur.chars().collect();
+        let mut i = 0usize;
+        let mut changed = false;
+        while i < chars.len() {
+            if is_ident_start(chars[i]) && (i == 0 || !is_token_char(chars[i - 1])) {
+                let start = i;
+                while i < chars.len() && is_ident_char(chars[i]) {
+                    i += 1;
+                }
+                let word: String = chars[start..i].iter().collect();
+                match lets.get(&word) {
+                    Some(rhs) => {
+                        out.push('(');
+                        out.push_str(rhs);
+                        out.push(')');
+                        changed = true;
+                    }
+                    None => out.push_str(&word),
+                }
+            } else {
+                out.push(chars[i]);
+                i += 1;
+            }
+        }
+        cur = out;
+        if !changed {
+            break;
+        }
+    }
+    cur
+}
+
+/// Split a conjunct at its top-level equality, if it has one.
+fn eq_sides(c: &str) -> Option<(String, String)> {
+    let chars: Vec<char> = c.chars().collect();
+    let mut depth = 0i32;
+    let mut i = 0usize;
+    while i < chars.len() {
+        let ch = chars[i];
+        if ch == '(' || ch == '[' || ch == '{' {
+            depth += 1;
+        } else if ch == ')' || ch == ']' || ch == '}' {
+            depth -= 1;
+        }
+        if depth <= 0 {
+            if chars.get(i) == Some(&'=') && chars.get(i + 1) == Some(&'=') {
+                return Some((chars[..i].iter().collect(), chars[i + 2..].iter().collect()));
+            }
+            if (chars.get(i) == Some(&':') || chars.get(i) == Some(&'!'))
+                && chars.get(i + 1) == Some(&'=')
+            {
+                i += 2;
+                continue;
+            }
+            if ch == '=' && chars.get(i + 1) != Some(&'>') {
+                return Some((chars[..i].iter().collect(), chars[i + 1..].iter().collect()));
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn strip_wrappers(side: &str) -> String {
+    let mut s = side.trim();
+    for w in ["some ", ".some ", "Option.some "] {
+        if let Some(r) = s.strip_prefix(w) {
+            s = r.trim();
+        }
+    }
+    s.to_string()
+}
+
+/// A side that mentions no producer-supplied value at all.
+fn producer_free(w: &Wall, env: &Env, side: &str) -> bool {
+    let s = blank_string_literals(side);
+    if s.trim().is_empty() {
+        return false;
+    }
+    for c in chains(&s) {
+        if env.contains_key(&c.base) {
+            return false;
+        }
+        if chain_field(w, env, &c).is_some() {
+            return false;
+        }
+    }
+    for t in idents(&s) {
+        if env.contains_key(&t) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Every producer value appearing WHOLE (not projected) on a side.
+fn whole_producer_values(w: &Wall, env: &Env, side: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let cs = chains(side);
+    for id in idents(side) {
+        if let Some(t) = env.get(&id) {
+            out.push(t.clone());
+        }
+    }
+    for c in cs {
+        let text: String = side.chars().skip(c.start).take(c.end - c.start).collect();
+        if side.chars().nth(c.end) == Some('.') {
+            continue;
+        }
+        if let Some(t) = expr_struct(w, env, &text) {
+            out.push(t);
+        }
+    }
+    out
+}
+
+/// Leaf slots of a structure, transitively through nested producer structures.
+fn leaves_of(
+    w: &Wall,
+    root: &str,
+    slots: &BTreeSet<FieldRef>,
+    seen: &mut BTreeSet<String>,
+    out: &mut Vec<FieldRef>,
+) {
+    if !seen.insert(root.to_string()) {
+        return;
+    }
+    let Some(sd) = w.structure(root) else { return };
+    for (f, ty) in &sd.fields {
+        let key = (root.to_string(), f.clone());
+        if slots.contains(&key) {
+            out.push(key);
+        }
+        if !is_arrow(ty)
+            && let Some(sub) = w.resolve_struct(ty, &sd.ns, &sd.opens)
+        {
+            leaves_of(w, &sub, slots, seen, out);
+        }
+    }
+}
+
+/// Parameter names of a definition, in order.
+fn sig_params(d: &Decl) -> Vec<String> {
+    let head = match d.sig.find(":=") {
+        Some(c) => &d.sig[..c],
+        None => &d.sig[..],
+    };
+    binders(head).into_iter().flat_map(|b| b.names).collect()
+}
+
+/// Applications `f a1 a2 ...` in a conjunct, with textual arguments.
+fn call_sites(c: &str) -> Vec<(String, Vec<String>)> {
+    let mut out = Vec::new();
+    let chars: Vec<char> = c.chars().collect();
+    let mut i = 0usize;
+    while i < chars.len() {
+        if is_ident_start(chars[i]) && (i == 0 || !is_token_char(chars[i - 1])) {
+            let start = i;
+            while i < chars.len() && is_token_char(chars[i]) {
+                i += 1;
+            }
+            let name: String = chars[start..i].iter().collect();
+            let mut args = Vec::new();
+            loop {
+                let mut j = i;
+                while j < chars.len() && (chars[j] == ' ' || chars[j] == '\n') {
+                    j += 1;
+                }
+                if j >= chars.len() || j == i {
+                    break;
+                }
+                if chars[j] == '(' {
+                    let mut depth = 0i32;
+                    let mut k = j;
+                    while k < chars.len() {
+                        if chars[k] == '(' {
+                            depth += 1;
+                        } else if chars[k] == ')' {
+                            depth -= 1;
+                            if depth == 0 {
+                                break;
+                            }
+                        }
+                        k += 1;
+                    }
+                    if k >= chars.len() {
+                        break;
+                    }
+                    args.push(chars[j + 1..k].iter().collect::<String>());
+                    i = k + 1;
+                } else if chars[j] == ')' || chars[j] == ']' || chars[j] == '}' || chars[j] == ',' {
+                    break;
+                } else {
+                    let mut k = j;
+                    while k < chars.len()
+                        && !chars[k].is_whitespace()
+                        && chars[k] != '('
+                        && chars[k] != ')'
+                    {
+                        k += 1;
+                    }
+                    args.push(chars[j..k].iter().collect::<String>());
+                    i = k;
+                }
+            }
+            if !args.is_empty() {
+                out.push((name, args));
+            }
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct Evidence {
+    pub rule: &'static str,
+    pub decl: String,
+    pub file: String,
+    pub line: usize,
+    pub conjunct: String,
+}
+
+#[derive(Debug)]
+pub struct Report {
+    /// every producer-declared leaf value slot
+    pub slots: BTreeSet<FieldRef>,
+    /// slots with binding evidence, and where it was found
+    pub bound: BTreeMap<FieldRef, Evidence>,
+    /// slots with no binding evidence at all
+    pub flagged: Vec<FieldRef>,
+    pub reachable: usize,
+    pub anchors: usize,
+}
+
+impl Report {
+    pub fn is_bound(&self, structure: &str, field: &str) -> bool {
+        self.bound
+            .keys()
+            .any(|(s, f)| s.ends_with(structure) && f == field)
+    }
+
+    pub fn is_flagged(&self, structure: &str, field: &str) -> bool {
+        self.flagged
+            .iter()
+            .any(|(s, f)| s.ends_with(structure) && f == field)
+    }
+}
+
+/// Run the byte-binding analysis over a set of Lean wall sources.
+pub fn analyse(sources: &[(&str, &str)]) -> Report {
+    let mut decls = Vec::new();
+    let mut names: Vec<&(&str, &str)> = sources.iter().collect();
+    names.sort_by_key(|(n, _)| *n);
+    for (name, text) in names {
+        decls.extend(parse_file(name, text));
+    }
+    let w = Wall::new(decls);
+
+    let root = w
+        .decls
+        .iter()
+        .find(|d| d.short == "accepted" && d.full.ends_with("AcceptedArtifact.accepted"))
+        .map(|d| d.full.clone())
+        .unwrap_or_default();
+    let reach = reachable_from(&w, &root);
+
+    let mut anchors: BTreeSet<String> = BTreeSet::new();
+    let mut anchor_short: BTreeSet<String> = BTreeSet::new();
+    for d in &w.decls {
+        if d.kind == Kind::Def && is_byte_anchor(d) {
+            anchors.insert(d.full.clone());
+            anchor_short.insert(d.short.clone());
+        }
+    }
+
+    let prod = producer_closure(&w);
+    let mut slots: BTreeSet<FieldRef> = BTreeSet::new();
+    for s in &prod {
+        let Some(sd) = w.structure(s) else { continue };
+        for (f, ty) in &sd.fields {
+            let sub = if is_arrow(ty) {
+                None
+            } else {
+                w.resolve_struct(ty, &sd.ns, &sd.opens)
+            };
+            // A field whose type is itself a producer structure is scaffolding,
+            // not a value: its leaves carry the producer's freedom.
+            match sub {
+                Some(t) if prod.contains(&t) => {}
+                _ => {
+                    slots.insert((s.clone(), f.clone()));
+                }
+            }
+        }
+    }
+
+    // unique-name fallback for chains whose base type cannot be resolved
+    let mut field_owner: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (s, f) in &slots {
+        field_owner.entry(f.clone()).or_default().insert(s.clone());
+    }
+    let unique_owner = |f: &str| -> Option<FieldRef> {
+        field_owner.get(f).and_then(|o| {
+            if o.len() == 1 {
+                Some((o.iter().next().unwrap().clone(), f.to_string()))
+            } else {
+                None
+            }
+        })
+    };
+
+    // per-declaration caches for the one-hop rule
+    let mut env_cache: BTreeMap<String, Env> = BTreeMap::new();
+    let mut bound: BTreeMap<FieldRef, Evidence> = BTreeMap::new();
+
+    let mark = |bound: &mut BTreeMap<FieldRef, Evidence>,
+                key: FieldRef,
+                rule: &'static str,
+                d: &Decl,
+                c: &str| {
+        bound.entry(key).or_insert_with(|| Evidence {
+            rule,
+            decl: d.full.clone(),
+            file: d.file.clone(),
+            line: d.line,
+            conjunct: c.split_whitespace().collect::<Vec<_>>().join(" "),
+        });
+    };
+
+    for d in &w.decls {
+        if d.kind != Kind::Def || !reach.contains(&d.full) {
+            continue;
+        }
+        let env = local_env(&w, d);
+        let raw_bytes = binds_raw_bytes(d);
+        let lets: BTreeMap<String, String> = let_bindings(&d.body).into_iter().collect();
+
+        // A byte-derived `match` scrutinee guards every arm of the definition.
+        let mut scrut_toks: BTreeSet<String> = BTreeSet::new();
+        for s in match_scrutinees(&d.body) {
+            for t in tokens(&expand_lets(&s, &lets)) {
+                scrut_toks.insert(t.rsplit('.').next().unwrap_or(&t).to_string());
+                scrut_toks.insert(t);
+            }
+        }
+
+        let cjs = conjuncts(&d.body);
+
+        // ONE-STEP existential chaining. A `∃`-bound name that itself appears in
+        // a conjunct naming the raw byte stream is byte-determined, which is how
+        // `lowerX plan = some codeEntry` reaches the module bytes through the
+        // neighbouring `exactFuncBindingForExport modBytes modLen ... codeEntry`.
+        // Strictly one step, no fixpoint: a transitive version was tried and it
+        // re-bound `roles.toIndex` in the pre-fix tree, destroying the lint.
+        let ex = exists_names(&d.body);
+        let mut byte_locals: BTreeSet<String> = BTreeSet::new();
+        for c in &cjs {
+            let tk: BTreeSet<String> = tokens(c).into_iter().collect();
+            let has_bytes = tk.contains("modBytes")
+                || tk.contains("modLen")
+                || (raw_bytes && tk.contains("n") && tk.contains("len"));
+            if has_bytes {
+                for id in idents(c) {
+                    if ex.contains(&id) {
+                        byte_locals.insert(id);
+                    }
+                }
+            }
+        }
+
+        for c in &cjs {
+            let cx = expand_lets(c, &lets);
+            let mut toks: BTreeSet<String> = scrut_toks.clone();
+            for t in tokens(&cx) {
+                if let Some(r) = w.resolve(&t, &d.ns, &d.opens) {
+                    toks.insert(r);
+                }
+                toks.insert(t.rsplit('.').next().unwrap_or(&t).to_string());
+                toks.insert(t);
+            }
+            let anchored = toks.contains("modBytes")
+                || toks.contains("modLen")
+                || (raw_bytes && toks.contains("n") && toks.contains("len"))
+                || toks.iter().any(|t| anchors.contains(t))
+                || toks.iter().any(|t| anchor_short.contains(t));
+
+            if anchored {
+                // Rule A: projection and byte anchor in the same conjunct.
+                for ch in chains(c) {
+                    let r = chain_field(&w, &env, &ch)
+                        .or_else(|| unique_owner(ch.fields.last().unwrap()));
+                    if let Some(r) = r
+                        && slots.contains(&r)
+                    {
+                        mark(&mut bound, r, "A/byte-cooccurrence", d, c);
+                    }
+                }
+                // Rule A1: one hop into a callee that projects the field.
+                for (name, args) in call_sites(&cx) {
+                    let Some(full) = w.resolve(&name, &d.ns, &d.opens) else {
+                        continue;
+                    };
+                    let Some(g) = w.get(&full) else { continue };
+                    if g.kind != Kind::Def {
+                        continue;
+                    }
+                    let genv = env_cache
+                        .entry(full.clone())
+                        .or_insert_with(|| local_env(&w, g))
+                        .clone();
+                    let params = sig_params(g);
+                    for (i, a) in args.iter().enumerate() {
+                        let Some(pname) = params.get(i) else { break };
+                        let Some(st) = expr_struct(&w, &env, a) else {
+                            continue;
+                        };
+                        let mut genv2 = genv.clone();
+                        genv2.insert(pname.clone(), st);
+                        for gc in chains(&g.body) {
+                            if &gc.base != pname {
+                                continue;
+                            }
+                            if let Some(r) = chain_field(&w, &genv2, &gc)
+                                && slots.contains(&r)
+                            {
+                                mark(&mut bound, r, "A1/one-hop-argument", d, c);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Rules B and C: equality with a producer-free counterpart.
+            if let Some((l, r)) = eq_sides(c) {
+                for (a, b) in [(l.clone(), r.clone()), (r, l)] {
+                    if !producer_free(&w, &env, &b) {
+                        continue;
+                    }
+                    let stripped = strip_wrappers(&a);
+                    let cs = chains(&stripped);
+                    if cs.len() == 1 && cs[0].start == 0 && cs[0].end == stripped.chars().count() {
+                        let hit = chain_field(&w, &env, &cs[0])
+                            .or_else(|| unique_owner(cs[0].fields.last().unwrap()));
+                        if let Some(hit) = hit
+                            && slots.contains(&hit)
+                        {
+                            mark(&mut bound, hit, "B/pinned-to-wall-term", d, c);
+                        }
+                    }
+                    // C needs the counterpart to be byte-derived, not merely
+                    // producer-free: `arithTableCheck ... = true` must NOT bind
+                    // the roles it is handed, or the historical bug walks free.
+                    let btoks: BTreeSet<String> = tokens(&b)
+                        .into_iter()
+                        .flat_map(|t| [t.rsplit('.').next().unwrap_or(&t).to_string(), t.clone()])
+                        .collect();
+                    let b_bytes = btoks.contains("modBytes")
+                        || btoks.contains("modLen")
+                        || (raw_bytes && btoks.contains("n") && btoks.contains("len"))
+                        || btoks.iter().any(|t| anchors.contains(t))
+                        || btoks.iter().any(|t| anchor_short.contains(t))
+                        || idents(&b).iter().any(|t| byte_locals.contains(t));
+                    if !b_bytes {
+                        continue;
+                    }
+                    for st in whole_producer_values(&w, &env, &a) {
+                        let mut seen = BTreeSet::new();
+                        let mut leaves = Vec::new();
+                        leaves_of(&w, &st, &slots, &mut seen, &mut leaves);
+                        for leaf in leaves {
+                            mark(&mut bound, leaf, "C/whole-value-vs-bytes", d, c);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let flagged: Vec<FieldRef> = slots
+        .iter()
+        .filter(|k| !bound.contains_key(*k))
+        .cloned()
+        .collect();
+
+    Report {
+        slots,
+        bound,
+        flagged,
+        reachable: reach.len(),
+        anchors: anchors.len(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exceptions
+// ---------------------------------------------------------------------------
+
+/// Why a producer-declared value is allowed to carry no byte binding. The set is
+/// closed on purpose: a free-text category would become a synonym for "ignore".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    /// Transported for display, deliberately outside the verified claim. No
+    /// current member: the documented example (`certified[].dom` / `cod`) lives
+    /// in the JSON manifest, not in a Lean producer structure, so it is not a
+    /// slot this lint ranges over. The category stays because the policy has
+    /// four kinds and a reviewer needs the vocabulary to classify the next one.
+    #[allow(dead_code)]
+    DeclaredOnlyByDesign,
+    /// The value SHOULD be constrained and is not. Must be documented as such.
+    KnownGap,
+    /// Enforced by the Rust checker or the generated witness, not by `accepted`.
+    PinnedOutsideTheWall,
+    /// Pinned to a value the wall itself computes, so the producer cannot
+    /// influence it, rather than to the artifact bytes.
+    WallOwnedConstraint,
+}
+
+impl Category {
+    fn label(self) -> &'static str {
+        match self {
+            Category::DeclaredOnlyByDesign => "declared-only by design",
+            Category::KnownGap => "KNOWN GAP",
+            Category::PinnedOutsideTheWall => "pinned outside the wall",
+            Category::WallOwnedConstraint => "wall-owned constraint",
+        }
+    }
+}
+
+/// One reviewable exception. There is no wildcard and no per-structure form:
+/// granularity is one field, one reason.
+#[derive(Debug, Clone, Copy)]
+pub struct Allowance {
+    /// Structure short name, e.g. `"Subject"`.
+    pub structure: &'static str,
+    /// Field name, e.g. `"profile"`.
+    pub field: &'static str,
+    pub category: Category,
+    /// Why this value is not bound to the bytes. Must not be empty.
+    pub reason: &'static str,
+    /// Exact text that must appear in `docs/certificate-format.md`, so the
+    /// specification and the lint cannot drift apart silently. This is the rule
+    /// aimed at the actual failure mode: the format spec went on describing a
+    /// pin that had been deleted, and nothing went red.
+    pub doc_anchor: &'static str,
+}
+
+/// The exceptions in force for the embedded wall.
+///
+/// Every entry is printed on every run. Read them as a list of things the
+/// certificate does NOT prove about values it transports.
+pub const ALLOWED: &[Allowance] = &[
+    Allowance {
+        structure: "Subject",
+        field: "profile",
+        category: Category::KnownGap,
+        reason: "The witness pins the JSON string to `subject.profile` by `rfl`, but no \
+                 acceptance conjunct compares it against any fixed identifier: any string \
+                 passing the candidate gate is accepted. The `PROFILE_ID` constant lives \
+                 only on the producer side (engine/mod.rs).",
+        doc_anchor: "the identifier constant exists only on the producer side (`PROFILE_ID` in `engine/mod.rs`)",
+    },
+    Allowance {
+        structure: "Subject",
+        field: "abi",
+        category: Category::KnownGap,
+        reason: "Same status as `profile`: pinned to `subject.abi` by `rfl`, not validated \
+                 against any fixed identifier. The `RUNTIME_ABI` constant lives only on the \
+                 producer side (engine/mod.rs).",
+        doc_anchor: "the constant exists only on the producer side (`RUNTIME_ABI` in `engine/mod.rs`)",
+    },
+    Allowance {
+        structure: "Subject",
+        field: "exports",
+        category: Category::PinnedOutsideTheWall,
+        reason: "The wall never reads this field — its only occurrence in the whole wall is \
+                 its own declaration in SchemaCore.lean, and `exportsAccounted` does the \
+                 byte-level export accounting from `manifest.obligations` and \
+                 `subject.declaredUncertified` instead. It is constrained by the \
+                 checker-authored witness rather than by `accepted`: verifier.rs emits \
+                 `subject.exports = {names} := rfl` against the SAME `{names}` list it pins \
+                 `obligations.map (fun o => o.export_)` to, so the two cannot disagree \
+                 without the witness failing to elaborate, and the obligation export names \
+                 are byte-bound through `exportsAccounted`. Transported duplicate, not an \
+                 independent value. Note this is the one category the lint cannot audit: it \
+                 sees only the wall, so `PinnedOutsideTheWall` is trusted by assertion and \
+                 defended only by review of verifier.rs.",
+        doc_anchor: "",
+    },
+    Allowance {
+        structure: "SymBlock",
+        field: "result",
+        category: Category::WallOwnedConstraint,
+        reason: "Pinned by a wall-computed equality rather than by bytes directly: \
+                 `PlanCheck.checkSymBlockFuel` requires `block.result + 1 = block.nodes.length` \
+                 (PlanCheck.lean:323) and that the node at that index exists with a matching \
+                 id, so once `nodes` is byte-bound through the plan lowering the result index \
+                 carries no independent producer freedom. Reached from acceptance via \
+                 `PlanCheck.checkSymRawPlan`.",
+        doc_anchor: "",
+    },
+];
+
+fn short_of(qualified: &str) -> &str {
+    qualified.rsplit('.').next().unwrap_or(qualified)
+}
+
+/// Run the lint and enforce the exception policy. `format_doc` is the text of
+/// `docs/certificate-format.md`, used to keep `KnownGap` entries honest.
+///
+/// Returns the human-readable report on success, or the failure text.
+pub fn check(sources: &[(&str, &str)], format_doc: &str) -> Result<String, String> {
+    let report = analyse(sources);
+    let mut out = String::new();
+
+    out.push_str(&format!(
+        "byte-binding lint: {} producer-declared value slots, {} bound, {} flagged \
+         ({} definitions reachable from `accepted`, {} auto-derived byte anchors)\n",
+        report.slots.len(),
+        report.bound.len(),
+        report.flagged.len(),
+        report.reachable,
+        report.anchors,
+    ));
+
+    out.push_str("\ndeclared values NOT bound to the module bytes (standing exceptions):\n");
+    for a in ALLOWED {
+        out.push_str(&format!(
+            "  [{}] {}.{}\n      {}\n",
+            a.category.label(),
+            a.structure,
+            a.field,
+            a.reason,
+        ));
+    }
+
+    let mut errors: Vec<String> = Vec::new();
+
+    // 1. Every flagged field must have an allowance.
+    for (s, f) in &report.flagged {
+        let covered = ALLOWED
+            .iter()
+            .any(|a| a.structure == short_of(s) && a.field == f);
+        if !covered {
+            errors.push(format!(
+                "UNBOUND producer-declared value `{}.{}`: no conjunct reachable from \
+                 `accepted` constrains it against the module bytes.\n    Bind it, or add an \
+                 Allowance stating why it is safe to leave declared-only.",
+                short_of(s),
+                f
+            ));
+        }
+    }
+
+    // 2. No stale allowances: an exception must not outlive the gap it describes.
+    for a in ALLOWED {
+        if report.is_bound(a.structure, a.field) {
+            let ev = report
+                .bound
+                .iter()
+                .find(|((s, f), _)| short_of(s) == a.structure && f == a.field)
+                .map(|(_, e)| {
+                    format!(
+                        "{}:{} in `{}` [{}]\n      {}",
+                        e.file, e.line, e.decl, e.rule, e.conjunct
+                    )
+                })
+                .unwrap_or_default();
+            errors.push(format!(
+                "STALE Allowance for `{}.{}`: the field now has binding evidence at {ev}. \
+                 Delete the exception — an exception must not outlive the gap it describes.",
+                a.structure, a.field
+            ));
+        }
+    }
+
+    // 3. No phantom fields: a renamed field must not carry its exemption along.
+    for a in ALLOWED {
+        let exists = report
+            .slots
+            .iter()
+            .any(|(s, f)| short_of(s) == a.structure && f == a.field);
+        if !exists {
+            errors.push(format!(
+                "PHANTOM Allowance for `{}.{}`: no such producer-declared field exists. \
+                 It was renamed or removed; update the exception.",
+                a.structure, a.field
+            ));
+        }
+        if a.reason.trim().is_empty() {
+            errors.push(format!(
+                "EMPTY reason on the Allowance for `{}.{}`.",
+                a.structure, a.field
+            ));
+        }
+    }
+
+    // 4. Known gaps must be documented as such in the format specification.
+    for a in ALLOWED {
+        if a.category != Category::KnownGap {
+            continue;
+        }
+        if a.doc_anchor.trim().is_empty() || !format_doc.contains(a.doc_anchor) {
+            errors.push(format!(
+                "UNDOCUMENTED KnownGap for `{}.{}`: docs/certificate-format.md does not \
+                 contain the declared anchor text\n      {:?}\n    A known gap that is not \
+                 in the specification is how the last one hid.",
+                a.structure, a.field, a.doc_anchor
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(out)
+    } else {
+        Err(format!("{out}\n{}\n", errors.join("\n\n")))
+    }
+}

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -2714,8 +2714,80 @@ fn certify_composition_fixture_lake_builds_kernel_clean() {
     let _ = std::fs::remove_dir_all(&out_dir);
 }
 
-#[test]
-fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
+/// Non-recursive ADT witness fixtures, as `(source, prefix, expected exports)`.
+///
+/// Each entry compiles its own certificate package and `lake build`s it, so the
+/// list used to be ten full Lean builds run back to back inside a single test —
+/// the longest serial chain in the certify suite and the reason its `rest` lane
+/// was the slowest one left after the hostile-model split.
+///
+/// This list is the single source of truth for which fixtures the gate covers,
+/// and it deliberately stays a list. The shard tests below select entries by
+/// `idx % NONRECURSIVE_ADT_WITNESS_SHARDS`, never by name, so a fixture
+/// appended here is automatically exercised by exactly one existing shard: no
+/// new test function to write, no CI filter to update, nothing to forget.
+const NONRECURSIVE_ADT_WITNESS_CASES: &[(&str, &str, &[&str])] = &[
+    (
+        "tools/certkit/fixtures/opteval.av",
+        "opteval",
+        &["mk", "eval"],
+    ),
+    ("examples/core/user_record.av", "user-record", &["greet"]),
+    (
+        "tools/certkit/fixtures/tupleproj.av",
+        "tuple-proj",
+        &["pairFst", "pairSnd"],
+    ),
+    (
+        "tools/certkit/fixtures/widenedmatch.av",
+        "widened-match",
+        &["boxInt"],
+    ),
+    (
+        "tools/certkit/fixtures/rangepred.av",
+        "range-pred",
+        &["inAsciiDigit"],
+    ),
+    (
+        "tools/certkit/fixtures/verbatimwiden.av",
+        "verbatim-widen",
+        &["wrapItems"],
+    ),
+    (
+        "tools/certkit/fixtures/f64verbatim.av",
+        "f64-verbatim",
+        &["floatOrZero"],
+    ),
+    // Out-of-template variant dispatch: four constructors, mixed arm
+    // semantics (negation, offset addition, identity, non-zero default) —
+    // provable only through the structural walker, not a shape template.
+    (
+        "tools/certkit/fixtures/signalgauge.av",
+        "signal-gauge",
+        &["gauge"],
+    ),
+    (
+        "tools/certkit/fixtures/intdispatchgen.av",
+        "int-dispatch-gen",
+        &["boxInt", "gauge"],
+    ),
+    // Payload-first subtraction, constant-first addition, and payload
+    // variants elided into the wildcard default.
+    ("tools/certkit/fixtures/meter.av", "meter", &["readout"]),
+];
+
+/// How many parallel shards `NONRECURSIVE_ADT_WITNESS_CASES` is spread over:
+/// one test function per shard. Keep it at most the list length so no shard
+/// runs empty (an empty shard would pass vacuously); the runner asserts that.
+const NONRECURSIVE_ADT_WITNESS_SHARDS: usize = 4;
+
+/// Runs the `NONRECURSIVE_ADT_WITNESS_CASES` entries that belong to `shard`.
+fn assert_nonrecursive_adt_witness_shard_lake_builds_kernel_clean(shard: usize) {
+    assert!(
+        shard < NONRECURSIVE_ADT_WITNESS_SHARDS
+            && NONRECURSIVE_ADT_WITNESS_SHARDS <= NONRECURSIVE_ADT_WITNESS_CASES.len(),
+        "shard {shard} of {NONRECURSIVE_ADT_WITNESS_SHARDS} covers no ADT witness fixture: keep the shard count at most the list length, one test function per shard"
+    );
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping certify ADT test: `lake` not available");
         return;
@@ -2723,57 +2795,13 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    let cases = [
-        (
-            "tools/certkit/fixtures/opteval.av",
-            "opteval",
-            vec!["mk", "eval"],
-        ),
-        ("examples/core/user_record.av", "user-record", vec!["greet"]),
-        (
-            "tools/certkit/fixtures/tupleproj.av",
-            "tuple-proj",
-            vec!["pairFst", "pairSnd"],
-        ),
-        (
-            "tools/certkit/fixtures/widenedmatch.av",
-            "widened-match",
-            vec!["boxInt"],
-        ),
-        (
-            "tools/certkit/fixtures/rangepred.av",
-            "range-pred",
-            vec!["inAsciiDigit"],
-        ),
-        (
-            "tools/certkit/fixtures/verbatimwiden.av",
-            "verbatim-widen",
-            vec!["wrapItems"],
-        ),
-        (
-            "tools/certkit/fixtures/f64verbatim.av",
-            "f64-verbatim",
-            vec!["floatOrZero"],
-        ),
-        // Out-of-template variant dispatch: four constructors, mixed arm
-        // semantics (negation, offset addition, identity, non-zero default) —
-        // provable only through the structural walker, not a shape template.
-        (
-            "tools/certkit/fixtures/signalgauge.av",
-            "signal-gauge",
-            vec!["gauge"],
-        ),
-        (
-            "tools/certkit/fixtures/intdispatchgen.av",
-            "int-dispatch-gen",
-            vec!["boxInt", "gauge"],
-        ),
-        // Payload-first subtraction, constant-first addition, and payload
-        // variants elided into the wildcard default.
-        ("tools/certkit/fixtures/meter.av", "meter", vec!["readout"]),
-    ];
+    // Index-sharded rather than name-selected: every entry of the list lands in
+    // exactly one shard by construction, including entries added later.
+    for (idx, &(input, prefix, expected)) in NONRECURSIVE_ADT_WITNESS_CASES.iter().enumerate() {
+        if idx % NONRECURSIVE_ADT_WITNESS_SHARDS != shard {
+            continue;
+        }
 
-    for (input, prefix, expected) in cases {
         let out_dir = temp_dir(prefix);
         let compile = aver_command()
             .current_dir(&repo_root)
@@ -2804,7 +2832,7 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
             .iter()
             .map(|c| c["name"].as_str().unwrap())
             .collect();
-        for &name in &expected {
+        for &name in expected {
             assert!(
                 certified.contains(&name),
                 "expected {name} certified for {input}, got {certified:?}"
@@ -2943,6 +2971,62 @@ fn certify_nonrecursive_adt_witnesses_lake_build_kernel_clean() {
         }
 
         let _ = std::fs::remove_dir_all(&out_dir);
+    }
+}
+
+/// Non-recursive ADT witnesses, shard 0: `NONRECURSIVE_ADT_WITNESS_CASES`
+/// entries 0, 4, 8, ... — today `opteval`, `range-pred` and `int-dispatch-gen`.
+#[test]
+fn cert_adt_witness_shard_0_of_4_lake_builds_kernel_clean() {
+    assert_nonrecursive_adt_witness_shard_lake_builds_kernel_clean(0);
+}
+
+/// Non-recursive ADT witnesses, shard 1: `NONRECURSIVE_ADT_WITNESS_CASES`
+/// entries 1, 5, 9, ... — today `user-record`, `verbatim-widen` and `meter`.
+#[test]
+fn cert_adt_witness_shard_1_of_4_lake_builds_kernel_clean() {
+    assert_nonrecursive_adt_witness_shard_lake_builds_kernel_clean(1);
+}
+
+/// Non-recursive ADT witnesses, shard 2: `NONRECURSIVE_ADT_WITNESS_CASES`
+/// entries 2, 6, 10, ... — today `tuple-proj` and `f64-verbatim`.
+#[test]
+fn cert_adt_witness_shard_2_of_4_lake_builds_kernel_clean() {
+    assert_nonrecursive_adt_witness_shard_lake_builds_kernel_clean(2);
+}
+
+/// Non-recursive ADT witnesses, shard 3: `NONRECURSIVE_ADT_WITNESS_CASES`
+/// entries 3, 7, 11, ... — today `widened-match` and `signal-gauge`.
+#[test]
+fn cert_adt_witness_shard_3_of_4_lake_builds_kernel_clean() {
+    assert_nonrecursive_adt_witness_shard_lake_builds_kernel_clean(3);
+}
+
+/// Guard the ADT witness shard count against drifting away from its test
+/// functions.
+///
+/// The shard runner already fails when the list shrinks below its shard count.
+/// The opposite direction is the silent one: RAISING
+/// `NONRECURSIVE_ADT_WITNESS_SHARDS` without adding the matching
+/// `shard_N_of_M` test means every fixture whose index has that remainder is
+/// simply never built, and every remaining test still passes. Nothing in the
+/// type system ties a constant to the number of `#[test]` functions, so this
+/// reads the source of this file and counts them.
+///
+/// Deliberately outside the `cert_adt_witness_` prefix: it needs no `lake` and
+/// belongs on the fast lane, not on a kernel-heavy one.
+#[test]
+fn certify_adt_witness_shards_all_have_test_functions() {
+    let source = include_str!("cert_certify_spec.rs");
+    let shards = NONRECURSIVE_ADT_WITNESS_SHARDS;
+    for shard in 0..shards {
+        let expected =
+            format!("fn cert_adt_witness_shard_{shard}_of_{shards}_lake_builds_kernel_clean");
+        assert!(
+            source.contains(&expected),
+            "ADT witness shard {shard} of {shards} has no test function, so fixtures with \
+             idx % {shards} == {shard} are never built; add `{expected}`"
+        );
     }
 }
 

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -1,7 +1,8 @@
 //! Integration tests for `aver cert verify` — the tripwires ARE the product.
 //!
 //! Compiles a fixture with `--certify`, confirms `aver cert verify` accepts it
-//! end to end, then confirms it fails closed on each tampering class:
+//! end to end, then confirms it fails closed on each tampering class. Each class
+//! is one `cert_tripwire_` test carrying the letter tag used below:
 //!   (a) one flipped wasm byte           → artifact hash mismatch
 //!   (b) a corrupted `Module.lean` body  → lake build failure
 //!   (c) a trivialized final theorem     → kernel witness rejects the type
@@ -376,15 +377,60 @@ const WEAK_FINAL: &str = "import Certificate\nimport Manifest\nimport Schema\n\n
 theorem AverCert.Final.cert : AverCert.Schema.Holds manifest := trivial\n\n\
 #print axioms AverCert.Final.cert\n";
 
-#[test]
-fn cert_verify_accepts_and_tripwires_fail_closed() {
+// Tripwire soundness gates.
+//
+// These tests share one baseline artifact — the `certprobe2` fixture emitted
+// with `--certify` — and differ only in which single tamper they apply before
+// demanding a verdict. They used to be one test that ran every check
+// sequentially, which made it the critical path of certificate CI.
+//
+// The cost here is NOT uniform, and the split is arranged around that. A tamper
+// the Rust verifier rejects up front (an unsupported schema/format/wall, a
+// rebound JSON field, a flipped artifact byte, a candidate outside the charset,
+// a cert file the staging gates refuse) costs milliseconds: no Lean process is
+// ever started. A tamper of Lean SOURCE inside the cert directory, and every
+// gate that must be ACCEPTED, pays a full artifact DATA build plus the checker
+// witness — minutes on CI. One test per tamper puts each of those builds on its
+// own row so the lanes can run them in parallel, the same way
+// `cert_certify_spec.rs` runs its `cert_hostile_model_` family. Prefix in,
+// prefix out: the dedicated lanes select `cert_tripwire_` and the `rest` lanes
+// exclude exactly it, so a gate added here is run exactly once and needs no
+// workflow edit.
+//
+// The clean certificate is verified end to end ONCE, by
+// `cert_tripwire_accepts_clean_certificate_end_to_end`, and not again per gate:
+// that keeps the number of full verifications the same as before the split.
+// Every gate below pins the REASON it was declined (or, for the two gates that
+// must be accepted, the verdict it was granted), so a fixture that stopped
+// verifying for an unrelated reason surfaces as a wrong-reason failure rather
+// than as a vacuous pass; if the honest certificate itself stops verifying, the
+// clean-certificate test is the one that says so.
+
+/// `true` when `lake` is on PATH. Prints the skip note otherwise, exactly as
+/// the single tripwire test did before the split.
+fn tripwire_lake_available() -> bool {
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping cert verify test: `lake` not available");
-        return;
+        return false;
+    }
+    true
+}
+
+/// Emits the shared `certprobe2` tripwire baseline.
+///
+/// Every gate below runs this itself rather than depending on a baseline built
+/// by another test (and therefore another CI lane), so each one fails on its
+/// own terms. The compile is a fraction of a second, so duplicating the setup
+/// per gate is nearly free — unlike the verification each gate then performs.
+///
+/// Returns `None` when `lake` is unavailable; the caller then skips, as before.
+fn tripwire_baseline(prefix: &str) -> Option<PathBuf> {
+    if !tripwire_lake_available() {
+        return None;
     }
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let out_dir = temp_dir("certverify");
+    let out_dir = temp_dir(prefix);
 
     // Emit the recursive fixture's certificate.
     let compile = aver_command()
@@ -403,6 +449,23 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         "compile --certify failed:\n{}",
         String::from_utf8_lossy(&compile.stderr)
     );
+
+    Some(out_dir)
+}
+
+/// The freshly emitted certificate verifies end to end through the
+/// production clean-cache path: the green report, its export count, and the
+/// boundary line it names are all pinned here.
+///
+/// This is the ONE full clean verification of the family, and the reason no
+/// gate below re-verifies a clean certificate: every gate pins the reason it
+/// was declined instead, and this test is what fails if the honest artifact
+/// stops verifying at all.
+#[test]
+fn cert_tripwire_accepts_clean_certificate_end_to_end() {
+    let Some(out_dir) = tripwire_baseline("certverify-clean") else {
+        return;
+    };
 
     let wasm = out_dir.join("certprobe2.wasm");
     let cert = out_dir.join("cert");
@@ -423,105 +486,166 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
         "missing artifact-check line on the happy path:\n{report}"
     );
 
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// A cert-data shape this checker does not know is rejected, never
+/// reinterpreted under the current schema. Rejected before any Lean process.
+#[test]
+fn cert_tripwire_declines_unsupported_schema_version() {
+    let Some(out_dir) = tripwire_baseline("certverify-schema-version") else {
+        return;
+    };
+
     // The cert schema version is a breaking cert-data shape. The checker rejects
     // unsupported manifests instead of trying to reinterpret them under the
     // current schema.
-    {
-        let dir = temp_dir("neg-schema-v99");
-        copy_dir(&out_dir, &dir);
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let mut m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
-        m["schema_version"] = serde_json::json!(99);
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "schema v99 cert must be rejected:\n{out}");
-        assert!(
-            out.contains("unsupported certificate schema_version 99"),
-            "wrong reason for schema v99 rejection:\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-schema-v99");
+    copy_dir(&out_dir, &dir);
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let mut m: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    m["schema_version"] = serde_json::json!(99);
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "schema v99 cert must be rejected:\n{out}");
+    assert!(
+        out.contains("unsupported certificate schema_version 99"),
+        "wrong reason for schema v99 rejection:\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (y) Package-format drift: the package format is versioned independently
+/// of the Lean statement schema, and an unknown version is refused up front.
+#[test]
+fn cert_tripwire_declines_unsupported_format_version() {
+    let Some(out_dir) = tripwire_baseline("certverify-format-version") else {
+        return;
+    };
 
     // The package format is independently versioned from the Lean statement
     // schema. Unknown versions are never reinterpreted as the current shape.
-    {
-        let dir = temp_dir("neg-format-version");
-        copy_dir(&out_dir, &dir);
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let mut m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
-        m["format"]["version"] = serde_json::json!(2);
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "format version drift must be rejected:\n{out}");
-        assert!(
-            out.contains("unsupported certificate format version 2"),
-            "wrong reason for format version drift:\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-format-version");
+    copy_dir(&out_dir, &dir);
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let mut m: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    m["format"]["version"] = serde_json::json!(2);
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "format version drift must be rejected:\n{out}");
+    assert!(
+        out.contains("unsupported certificate format version 2"),
+        "wrong reason for format version drift:\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (z) Wall drift: an unknown aggregate `wall_id` is rejected before any Lean
+/// build, with no filesystem, environment, or network fallback.
+#[test]
+fn cert_tripwire_declines_unknown_wall_id() {
+    let Some(out_dir) = tripwire_baseline("certverify-wall-id") else {
+        return;
+    };
 
     // One aggregate identifier commits to every checker-owned Lean source and
     // the exact toolchain. Resolution is embedded-only: no path, URL, or
     // ambient installation is consulted for an unknown wall.
-    {
-        let dir = temp_dir("neg-wall-id");
-        copy_dir(&out_dir, &dir);
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let mut m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
-        m["format"]["wall_id"] = serde_json::json!("sha256:deadbeef");
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "unknown wall id must be rejected:\n{out}");
-        assert!(
-            out.contains("unsupported certificate wall `sha256:deadbeef`"),
-            "wrong reason for unknown wall rejection:\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-wall-id");
+    copy_dir(&out_dir, &dir);
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let mut m: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    m["format"]["wall_id"] = serde_json::json!("sha256:deadbeef");
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "unknown wall id must be rejected:\n{out}");
+    assert!(
+        out.contains("unsupported certificate wall `sha256:deadbeef`"),
+        "wrong reason for unknown wall rejection:\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// The JSON must pin the artifact-level certificate root the checker expects.
+/// A consumer should not have to guess which theorem is the self-check root.
+#[test]
+fn cert_tripwire_declines_json_artifact_root_drift() {
+    let Some(out_dir) = tripwire_baseline("certverify-artifact-root-pin") else {
+        return;
+    };
 
     // The artifact-level certificate root is pinned as routing metadata. A
     // consumer should not have to guess which theorem is the self-check root.
-    {
-        let dir = temp_dir("neg-artifact-root-pin");
-        copy_dir(&out_dir, &dir);
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let mut m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
-        m["artifact_certificate_root"] = serde_json::json!("AverCert.Final.cert");
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(
-            !ok,
-            "wrong artifact certificate root must be rejected:\n{out}"
-        );
-        assert!(
-            out.contains("artifact certificate root mismatch"),
-            "wrong reason for artifact root drift:\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-artifact-root-pin");
+    copy_dir(&out_dir, &dir);
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let mut m: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    m["artifact_certificate_root"] = serde_json::json!("AverCert.Final.cert");
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(
+        !ok,
+        "wrong artifact certificate root must be rejected:\n{out}"
+    );
+    assert!(
+        out.contains("artifact certificate root mismatch"),
+        "wrong reason for artifact root drift:\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// The LEAN manifest must name the artifact-level certificate root too: JSON
+/// consistency alone is not enough, so this one reaches the kernel witness.
+#[test]
+fn cert_tripwire_declines_lean_artifact_root_drift() {
+    let Some(out_dir) = tripwire_baseline("certverify-lean-artifact-root-pin") else {
+        return;
+    };
 
     // The Lean manifest must also name the artifact-level certificate root.
     // JSON consistency alone is not enough; the checker witness pins the
     // proven manifest literal and the artifact predicate checks the same root.
-    {
-        let dir = temp_dir("neg-lean-artifact-root-pin");
-        copy_dir(&out_dir, &dir);
-        let manifest = dir.join("cert").join("Manifest.lean");
-        let src = std::fs::read_to_string(&manifest).unwrap();
-        let poisoned = src.replacen(
-            "artifactRoot := \"AverCert.Artifact.certificate\"",
-            "artifactRoot := \"AverCert.Final.cert\"",
-            1,
-        );
-        assert_ne!(src, poisoned, "Manifest.lean artifactRoot shape changed");
-        std::fs::write(&manifest, poisoned).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "wrong Lean artifact root must be rejected:\n{out}");
-        assert!(
-            out.contains("manifest.subject.artifactRoot"),
-            "wrong reason for Lean artifact root drift:\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-lean-artifact-root-pin");
+    copy_dir(&out_dir, &dir);
+    let manifest = dir.join("cert").join("Manifest.lean");
+    let src = std::fs::read_to_string(&manifest).unwrap();
+    let poisoned = src.replacen(
+        "artifactRoot := \"AverCert.Artifact.certificate\"",
+        "artifactRoot := \"AverCert.Final.cert\"",
+        1,
+    );
+    assert_ne!(src, poisoned, "Manifest.lean artifactRoot shape changed");
+    std::fs::write(&manifest, poisoned).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "wrong Lean artifact root must be rejected:\n{out}");
+    assert!(
+        out.contains("manifest.subject.artifactRoot"),
+        "wrong reason for Lean artifact root drift:\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (ab) Artifact-data decoy: a cert-supplied `Artifact.data` that points at
+/// zero module bytes must bind its byte/manifest fields — it cannot.
+#[test]
+fn cert_tripwire_declines_tampered_artifact_data() {
+    let Some(out_dir) = tripwire_baseline("certverify-artifact-data-pin") else {
+        return;
+    };
 
     // The artifact-carried data root is useful metadata, not authority. Since
     // the recursion exports carry byte-origin plan claims, an `Artifact.lean`
@@ -529,117 +653,178 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     // claims (`exactFuncBindingForExport 0 modLen name code = some …` has no `rfl`), so the tamper
     // dies at the cert's own build — before the checker witness pins
     // `AverCert.Artifact.data` to the actual bytes and manifest.
-    {
-        let dir = temp_dir("neg-artifact-data-pin");
-        copy_dir(&out_dir, &dir);
-        let artifact = dir.join("cert").join("Artifact.lean");
-        let src = std::fs::read_to_string(&artifact).unwrap();
-        let corrupted = src.replacen(
-            "modBytes := AverCert.ArtifactBytes.modBytes",
-            "modBytes := 0",
-            1,
-        );
-        assert_ne!(src, corrupted, "Artifact.lean data shape changed");
-        std::fs::write(&artifact, corrupted).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "tampered Artifact.lean data must fail:\n{out}");
-        assert!(
-            out.contains("did not build")
-                || out.contains("AverCert.Artifact.data")
-                || out.contains("does not bind"),
-            "wrong reason for artifact data tamper:\n{out}"
-        );
-        assert!(
-            !out.contains("CERTIFIED"),
-            "tampered artifact data credited:\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-artifact-data-pin");
+    copy_dir(&out_dir, &dir);
+    let artifact = dir.join("cert").join("Artifact.lean");
+    let src = std::fs::read_to_string(&artifact).unwrap();
+    let corrupted = src.replacen(
+        "modBytes := AverCert.ArtifactBytes.modBytes",
+        "modBytes := 0",
+        1,
+    );
+    assert_ne!(src, corrupted, "Artifact.lean data shape changed");
+    std::fs::write(&artifact, corrupted).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "tampered Artifact.lean data must fail:\n{out}");
+    assert!(
+        out.contains("did not build")
+            || out.contains("AverCert.Artifact.data")
+            || out.contains("does not bind"),
+        "wrong reason for artifact data tamper:\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED"),
+        "tampered artifact data credited:\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (a) One flipped wasm byte is an artifact hash mismatch, caught before any
+/// Lean build.
+#[test]
+fn cert_tripwire_declines_flipped_wasm_byte() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-a") else {
+        return;
+    };
 
     // (a) One flipped wasm byte → hash mismatch, before any build.
-    {
-        let dir = temp_dir("neg-a");
-        copy_dir(&out_dir, &dir);
-        let w = dir.join("certprobe2.wasm");
-        let mut bytes = std::fs::read(&w).unwrap();
-        let mid = bytes.len() / 2;
-        bytes[mid] ^= 0x01;
-        std::fs::write(&w, &bytes).unwrap();
-        let (ok, out) = aver_check(&w, &dir.join("cert"));
-        assert!(!ok, "flipped wasm byte must fail:\n{out}");
-        assert!(out.contains("hash mismatch"), "wrong reason (a):\n{out}");
-    }
+    let dir = temp_dir("neg-a");
+    copy_dir(&out_dir, &dir);
+    let w = dir.join("certprobe2.wasm");
+    let mut bytes = std::fs::read(&w).unwrap();
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0x01;
+    std::fs::write(&w, &bytes).unwrap();
+    let (ok, out) = aver_check(&w, &dir.join("cert"));
+    assert!(!ok, "flipped wasm byte must fail:\n{out}");
+    assert!(out.contains("hash mismatch"), "wrong reason (a):\n{out}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (a2) A byte flipped inside the certified `countDown` body is the same hard
+/// decline, and is deliberately caught by the hash before any Lean build.
+#[test]
+fn cert_tripwire_declines_flipped_countdown_body_byte() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-a2") else {
+        return;
+    };
 
     // (a2) A byte flipped inside the newly certified `countDown` body is still a
     //      hard decline. This is intentionally caught by the artifact hash
     //      before the checker spends time building Lean.
-    {
-        let dir = temp_dir("neg-a2-countdown-body");
-        copy_dir(&out_dir, &dir);
-        let w = dir.join("certprobe2.wasm");
-        let mut bytes = std::fs::read(&w).unwrap();
-        let count_down_prefix = [
-            0x20, 0x01, 0x05, 0x20, 0x00, 0x42, 0x01, 0x10, 0x07, 0x10, 0x09, 0x20, 0x01, 0x20,
-            0x00, 0x10, 0x08, 0x12, 0x02,
-        ];
-        let off = bytes
-            .windows(count_down_prefix.len())
-            .position(|win| win == count_down_prefix)
-            .expect("countDown body prefix should be present in wasm");
-        bytes[off + 1] ^= 0x01;
-        std::fs::write(&w, &bytes).unwrap();
-        let (ok, out) = aver_check(&w, &dir.join("cert"));
-        assert!(!ok, "countDown body-byte flip must fail:\n{out}");
-        assert!(
-            out.contains("hash mismatch"),
-            "wrong reason for countDown body-byte flip:\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-a2-countdown-body");
+    copy_dir(&out_dir, &dir);
+    let w = dir.join("certprobe2.wasm");
+    let mut bytes = std::fs::read(&w).unwrap();
+    let count_down_prefix = [
+        0x20, 0x01, 0x05, 0x20, 0x00, 0x42, 0x01, 0x10, 0x07, 0x10, 0x09, 0x20, 0x01, 0x20, 0x00,
+        0x10, 0x08, 0x12, 0x02,
+    ];
+    let off = bytes
+        .windows(count_down_prefix.len())
+        .position(|win| win == count_down_prefix)
+        .expect("countDown body prefix should be present in wasm");
+    bytes[off + 1] ^= 0x01;
+    std::fs::write(&w, &bytes).unwrap();
+    let (ok, out) = aver_check(&w, &dir.join("cert"));
+    assert!(!ok, "countDown body-byte flip must fail:\n{out}");
+    assert!(
+        out.contains("hash mismatch"),
+        "wrong reason for countDown body-byte flip:\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (b) A corrupted `Module.lean` instruction fails the certificate's own lake
+/// build.
+#[test]
+fn cert_tripwire_declines_corrupted_module_body() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-b") else {
+        return;
+    };
 
     // (b) A corrupted Module.lean instruction → lake build failure.
-    {
-        let dir = temp_dir("neg-b");
-        copy_dir(&out_dir, &dir);
-        let m = dir.join("cert").join("Module.lean");
-        let src = std::fs::read_to_string(&m).unwrap();
-        let corrupted = src.replacen(".i64Const 0, .i64LeS", ".i64Const 999, .i64LeS", 1);
-        assert_ne!(src, corrupted, "fixture body shape changed");
-        std::fs::write(&m, corrupted).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "corrupted Module.lean must fail:\n{out}");
-        assert!(out.contains("did not build"), "wrong reason (b):\n{out}");
-    }
+    let dir = temp_dir("neg-b");
+    copy_dir(&out_dir, &dir);
+    let m = dir.join("cert").join("Module.lean");
+    let src = std::fs::read_to_string(&m).unwrap();
+    let corrupted = src.replacen(".i64Const 0, .i64LeS", ".i64Const 999, .i64LeS", 1);
+    assert_ne!(src, corrupted, "fixture body shape changed");
+    std::fs::write(&m, corrupted).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "corrupted Module.lean must fail:\n{out}");
+    assert!(out.contains("did not build"), "wrong reason (b):\n{out}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (c) A trivialized final theorem — same name, `: True := trivial` — fails
+/// the build, because the artifact-carried self-check root imports it.
+#[test]
+fn cert_tripwire_declines_trivialized_final_theorem() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-c") else {
+        return;
+    };
 
     // (c) A trivialized final theorem (same name, `: True := trivial`) → the
     //     artifact-carried self-check root imports `Final.cert`, so the cert
     //     build fails before the checker witness can ascribe `Final.cert` to
     //     `Holds manifest`.
-    {
-        let dir = temp_dir("neg-c");
-        copy_dir(&out_dir, &dir);
-        let f = dir.join("cert").join("Final.lean");
-        let trivial = "import Certificate\nimport Manifest\nimport Schema\n\n\
-             theorem AverCert.Final.cert : True := trivial\n\n\
-             #print axioms AverCert.Final.cert\n";
-        std::fs::write(&f, trivial).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "trivialized final theorem must fail:\n{out}");
-        assert!(out.contains("did not build"), "wrong reason (c):\n{out}");
-    }
+    let dir = temp_dir("neg-c");
+    copy_dir(&out_dir, &dir);
+    let f = dir.join("cert").join("Final.lean");
+    let trivial = "import Certificate\nimport Manifest\nimport Schema\n\n\
+         theorem AverCert.Final.cert : True := trivial\n\n\
+         #print axioms AverCert.Final.cert\n";
+    std::fs::write(&f, trivial).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "trivialized final theorem must fail:\n{out}");
+    assert!(out.contains("did not build"), "wrong reason (c):\n{out}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (d) A cert-supplied `Schema.lean` is IGNORED — the checker builds against
+/// its own embedded audited schema — so the genuine certificate still passes.
+#[test]
+fn cert_tripwire_ignores_cert_supplied_schema() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-d") else {
+        return;
+    };
 
     // (d) A swapped Schema.lean is IGNORED: the checker builds against its own
     //     embedded audited schema, never the cert's. Even a weakened schema in
     //     the cert dir has no effect, so the genuine cert still verifies.
-    {
-        let dir = temp_dir("neg-d");
-        copy_dir(&out_dir, &dir);
-        std::fs::write(dir.join("cert").join("Schema.lean"), WEAK_SCHEMA).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(ok, "cert-supplied Schema.lean must be ignored:\n{out}");
-        assert!(
-            out.contains("CHECKED") && !out.contains("CERTIFIED"),
-            "genuine cert should pass trusted-olean preflight (d):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-d");
+    copy_dir(&out_dir, &dir);
+    std::fs::write(dir.join("cert").join("Schema.lean"), WEAK_SCHEMA).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(ok, "cert-supplied Schema.lean must be ignored:\n{out}");
+    assert!(
+        out.contains("CHECKED") && !out.contains("CERTIFIED"),
+        "genuine cert should pass trusted-olean preflight (d):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (e) A1 hash rebind: a different but genuine module, with `wasm_sha256`
+/// edited to match it, must not buy acceptance.
+#[test]
+fn cert_tripwire_declines_hash_rebind_to_foreign_module() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-e") else {
+        return;
+    };
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
     // (e) A1 hash rebind: replace the artifact with a DIFFERENT but genuine cert
     //     module (certprobe's wasm) and edit ONLY `wasm_sha256` in the JSON to
@@ -648,42 +833,57 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     //     bind the checker-staged `ArtifactBytes` (the actual, swapped bytes), so
     //     the cert's own build now fails before the checker witness even runs —
     //     an even earlier fail-closed decline than the witness hash face.
-    {
-        let dir = temp_dir("neg-e");
-        copy_dir(&out_dir, &dir);
-        let foreign_out = temp_dir("neg-e-foreign");
-        let fc = aver_command()
-            .current_dir(&repo_root)
-            .arg("compile")
-            .arg("tools/certkit/fixtures/certprobe.av")
-            .arg("--target")
-            .arg("wasm-gc")
-            .arg("--certify")
-            .arg("-o")
-            .arg(&foreign_out)
-            .output()
-            .expect("aver compile --certify runs");
-        assert!(fc.status.success(), "foreign fixture compile failed");
-        let foreign = std::fs::read(foreign_out.join("certprobe.wasm")).unwrap();
-        std::fs::write(dir.join("certprobe2.wasm"), &foreign).unwrap();
-        let sha = aver::codegen::cert::sha256_hex(&foreign);
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let json = std::fs::read_to_string(&mf).unwrap();
-        let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
-        m["wasm_sha256"] = serde_json::Value::String(sha);
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        let _ = std::fs::remove_dir_all(&foreign_out);
-        assert!(!ok, "A1 hash rebind must fail:\n{out}");
-        assert!(
-            out.contains("did not build") || out.contains("does not bind"),
-            "wrong reason (e):\n{out}"
-        );
-        assert!(
-            !out.contains("CERTIFIED"),
-            "hash rebind credited (e):\n{out}"
-        );
+    let dir = temp_dir("neg-e");
+    copy_dir(&out_dir, &dir);
+    let foreign_out = temp_dir("neg-e-foreign");
+    let fc = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/certprobe.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&foreign_out)
+        .output()
+        .expect("aver compile --certify runs");
+    assert!(fc.status.success(), "foreign fixture compile failed");
+    let foreign = std::fs::read(foreign_out.join("certprobe.wasm")).unwrap();
+    std::fs::write(dir.join("certprobe2.wasm"), &foreign).unwrap();
+    let sha = aver::codegen::cert::sha256_hex(&foreign);
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let json = std::fs::read_to_string(&mf).unwrap();
+    let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
+    m["wasm_sha256"] = serde_json::Value::String(sha);
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    let _ = std::fs::remove_dir_all(&foreign_out);
+    assert!(!ok, "A1 hash rebind must fail:\n{out}");
+    assert!(
+        out.contains("did not build") || out.contains("does not bind"),
+        "wrong reason (e):\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED"),
+        "hash rebind credited (e):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (e2) A1 hash rebind against a CLAIM-FREE certificate, whose Lean data
+/// builds green over any staged bytes: only the kernel witness's hash faces
+/// can catch this swap, so this gate keeps them exercised.
+///
+/// Compiles its own `certempty` fixture and never touches the shared
+/// `certprobe2` baseline, so it takes the lake check alone.
+#[test]
+fn cert_tripwire_declines_hash_rebind_on_claim_free_cert() {
+    if !tripwire_lake_available() {
+        return;
     }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
     // (e2) A1 hash rebind against a CLAIM-FREE cert: `certempty` proves zero
     //      obligations and ships no plan claims, so its Lean data builds green
@@ -693,292 +893,413 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     //      catch the swap: the theorems (and the manifest artifact-hash face) talk about
     //      the ORIGINAL hash, not the checker-computed one. This keeps the
     //      witness hash face exercised now that claim-covered certs die earlier.
-    {
-        let empty_out = temp_dir("neg-e2-empty");
-        let ec = aver_command()
-            .current_dir(&repo_root)
-            .arg("compile")
-            .arg("tools/certkit/fixtures/certempty.av")
-            .arg("--target")
-            .arg("wasm-gc")
-            .arg("--certify")
-            .arg("-o")
-            .arg(&empty_out)
-            .output()
-            .expect("aver compile --certify runs");
-        assert!(ec.status.success(), "certempty fixture compile failed");
-        let w = empty_out.join("certempty.wasm");
-        let mut foreign = std::fs::read(&w).unwrap();
-        // Inert trailing custom section (id 0, size 2, name "x", empty payload).
-        foreign.extend_from_slice(&[0x00, 0x02, 0x01, 0x78]);
-        std::fs::write(&w, &foreign).unwrap();
-        let sha = aver::codegen::cert::sha256_hex(&foreign);
-        let mf = empty_out.join("cert").join("cert-manifest.json");
-        let json = std::fs::read_to_string(&mf).unwrap();
-        let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
-        m["wasm_sha256"] = serde_json::Value::String(sha);
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&w, &empty_out.join("cert"));
-        let _ = std::fs::remove_dir_all(&empty_out);
-        assert!(!ok, "A1 hash rebind on claim-free cert must fail:\n{out}");
-        assert!(out.contains("does not bind"), "wrong reason (e2):\n{out}");
-        // The witness names the exact face the kernel rejected.
-        assert!(
-            out.contains("AverCert.manifest.subject.artifactHash"),
-            "witness not exercised (e2):\n{out}"
-        );
-    }
+    let empty_out = temp_dir("neg-e2-empty");
+    let ec = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/certempty.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&empty_out)
+        .output()
+        .expect("aver compile --certify runs");
+    assert!(ec.status.success(), "certempty fixture compile failed");
+    let w = empty_out.join("certempty.wasm");
+    let mut foreign = std::fs::read(&w).unwrap();
+    // Inert trailing custom section (id 0, size 2, name "x", empty payload).
+    foreign.extend_from_slice(&[0x00, 0x02, 0x01, 0x78]);
+    std::fs::write(&w, &foreign).unwrap();
+    let sha = aver::codegen::cert::sha256_hex(&foreign);
+    let mf = empty_out.join("cert").join("cert-manifest.json");
+    let json = std::fs::read_to_string(&mf).unwrap();
+    let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
+    m["wasm_sha256"] = serde_json::Value::String(sha);
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&w, &empty_out.join("cert"));
+    let _ = std::fs::remove_dir_all(&empty_out);
+    assert!(!ok, "A1 hash rebind on claim-free cert must fail:\n{out}");
+    assert!(out.contains("does not bind"), "wrong reason (e2):\n{out}");
+    // The witness names the exact face the kernel rejected.
+    assert!(
+        out.contains("AverCert.manifest.subject.artifactHash"),
+        "witness not exercised (e2):\n{out}"
+    );
+}
+
+/// (f) A2 comment smuggle: the approved statement present only in a COMMENT,
+/// plus a trivial theorem of the same name.
+#[test]
+fn cert_tripwire_declines_comment_smuggled_final_theorem() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-f") else {
+        return;
+    };
 
     // (f) A2 comment smuggle: the approved statement line present only in a
     //     COMMENT, plus a `theorem AverCert.Final.cert : True := trivial`. The
     //     artifact-carried self-check root imports `Final.cert`, so this now
     //     fails at cert build time before the checker witness.
-    {
-        let dir = temp_dir("neg-f");
-        copy_dir(&out_dir, &dir);
-        let f = dir.join("cert").join("Final.lean");
-        let smuggled = "import Certificate\nimport Manifest\nimport Schema\n\n\
-             -- theorem AverCert.Final.cert : AverCert.Schema.Holds manifest := by trivial\n\
-             theorem AverCert.Final.cert : True := trivial\n\n\
-             #print axioms AverCert.Final.cert\n";
-        std::fs::write(&f, smuggled).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "A2 comment smuggle must fail:\n{out}");
-        assert!(out.contains("did not build"), "wrong reason (f):\n{out}");
-    }
+    let dir = temp_dir("neg-f");
+    copy_dir(&out_dir, &dir);
+    let f = dir.join("cert").join("Final.lean");
+    let smuggled = "import Certificate\nimport Manifest\nimport Schema\n\n\
+         -- theorem AverCert.Final.cert : AverCert.Schema.Holds manifest := by trivial\n\
+         theorem AverCert.Final.cert : True := trivial\n\n\
+         #print axioms AverCert.Final.cert\n";
+    std::fs::write(&f, smuggled).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "A2 comment smuggle must fail:\n{out}");
+    assert!(out.contains("did not build"), "wrong reason (f):\n{out}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (g) A3 build-tree subversion: a decoy tree behind a redirected `srcDir`
+/// plus a weak final proof. The checker ignores the cert's lakefile.
+#[test]
+fn cert_tripwire_declines_srcdir_build_tree_subversion() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-g") else {
+        return;
+    };
 
     // (g) A3 build-tree subversion: point the cert's lakefile `srcDir` at a
     //     hidden decoy tree whose `Holds := True`, and weaken the final proof to
     //     `trivial`. Under the OLD (cert-controlled) build this passed. The
     //     checker now ignores the cert's lakefile/srcDir and builds `Final.lean`
     //     against its OWN embedded schema, so `trivial` fails closed.
-    {
-        let dir = temp_dir("neg-g");
-        copy_dir(&out_dir, &dir);
-        let cert = dir.join("cert");
-        // Decoy build tree with a weakened schema, reached via srcDir redirect.
-        let hidden = cert.join("hidden");
-        copy_dir(&out_dir.join("cert"), &hidden);
-        std::fs::write(hidden.join("Schema.lean"), WEAK_SCHEMA).unwrap();
-        // The (visible) final proof only holds against the trivial `Holds`.
-        std::fs::write(cert.join("Final.lean"), WEAK_FINAL).unwrap();
-        // Redirect the cert's own lakefile at the decoy tree.
-        let lf = cert.join("lakefile.lean");
-        let redirected = "import Lake\nopen Lake DSL\n\npackage «hostile»\n\n\
-             @[default_target]\nlean_lib «Hostile» where\n  srcDir := \"hidden\"\n  roots := #[`Final]\n";
-        std::fs::write(&lf, redirected).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &cert);
-        assert!(!ok, "A3 srcDir subversion must fail:\n{out}");
-        assert!(out.contains("did not build"), "wrong reason (g):\n{out}");
-    }
+    let dir = temp_dir("neg-g");
+    copy_dir(&out_dir, &dir);
+    let cert = dir.join("cert");
+    // Decoy build tree with a weakened schema, reached via srcDir redirect.
+    let hidden = cert.join("hidden");
+    copy_dir(&out_dir.join("cert"), &hidden);
+    std::fs::write(hidden.join("Schema.lean"), WEAK_SCHEMA).unwrap();
+    // The (visible) final proof only holds against the trivial `Holds`.
+    std::fs::write(cert.join("Final.lean"), WEAK_FINAL).unwrap();
+    // Redirect the cert's own lakefile at the decoy tree.
+    let lf = cert.join("lakefile.lean");
+    let redirected = "import Lake\nopen Lake DSL\n\npackage «hostile»\n\n\
+         @[default_target]\nlean_lib «Hostile» where\n  srcDir := \"hidden\"\n  roots := #[`Final]\n";
+    std::fs::write(&lf, redirected).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &cert);
+    assert!(!ok, "A3 srcDir subversion must fail:\n{out}");
+    assert!(out.contains("did not build"), "wrong reason (g):\n{out}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (h) A3 olean cache: a poisoned `.lake` cache shipped in the certificate is
+/// never consumed — the checker builds in a fresh dir — so the genuine
+/// certificate still passes.
+#[test]
+fn cert_tripwire_ignores_shipped_olean_cache() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-h") else {
+        return;
+    };
 
     // (h) A3 olean cache: ship a poisoned `.lake` cache in the cert. The checker
     //     builds in a fresh dir and never consumes it, so a genuine cert still
     //     verifies (a checker that reused the cache would choke on the garbage).
-    {
-        let dir = temp_dir("neg-h");
-        copy_dir(&out_dir, &dir);
-        let lib = dir.join("cert").join(".lake").join("build").join("lib");
-        std::fs::create_dir_all(&lib).unwrap();
-        std::fs::write(lib.join("Schema.olean"), b"GARBAGE-NOT-AN-OLEAN").unwrap();
-        std::fs::write(lib.join("Final.olean"), b"GARBAGE").unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(ok, "shipped .lake cache must be ignored:\n{out}");
-        assert!(
-            out.contains("CHECKED") && !out.contains("CERTIFIED"),
-            "genuine cert should pass trusted-olean preflight (h):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-h");
+    copy_dir(&out_dir, &dir);
+    let lib = dir.join("cert").join(".lake").join("build").join("lib");
+    std::fs::create_dir_all(&lib).unwrap();
+    std::fs::write(lib.join("Schema.olean"), b"GARBAGE-NOT-AN-OLEAN").unwrap();
+    std::fs::write(lib.join("Final.olean"), b"GARBAGE").unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(ok, "shipped .lake cache must be ignored:\n{out}");
+    assert!(
+        out.contains("CHECKED") && !out.contains("CERTIFIED"),
+        "genuine cert should pass trusted-olean preflight (h):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (i) A4 report forgery: a fabricated certified export and contract appended
+/// to ONLY the JSON. The report candidates are kernel-bound to the proven
+/// manifest, so the forged names are never credited.
+#[test]
+fn cert_tripwire_declines_forged_report_json() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-i") else {
+        return;
+    };
 
     // (i) A4 report forgery: append a fabricated certified export + contract to
     //     ONLY the JSON. The report names/count/contracts are now candidates the
     //     kernel witness binds to the proven Lean manifest with `rfl`, so a JSON
     //     that claims an export or contract the manifest does not have makes a
     //     binding fail: the cert is DECLINED and the forged names never appear.
-    {
-        let dir = temp_dir("neg-i");
-        copy_dir(&out_dir, &dir);
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let json = std::fs::read_to_string(&mf).unwrap();
-        let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
-        m["certified"]
-            .as_array_mut()
-            .unwrap()
-            .push(serde_json::json!({
-                "name": "withdrawAll",
-                "class": "straight-line",
-                "policy": "simulatesModel",
-                "level": "L1",
-                "theorem": "CertProofs.withdrawAll_wasm_certified",
-                "dom": "List Int",
-                "cod": "Int"
-            }));
-        m["runtime_contracts"]
-            .as_array_mut()
-            .unwrap()
-            .push(serde_json::Value::String("FAKE contract injected".into()));
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        // Every .lean and hash is byte-identical; only the JSON changed.
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "padded JSON must be DECLINED, not credited:\n{out}");
-        assert!(out.contains("does not bind"), "wrong reason (i):\n{out}");
-        // The declined diagnostic echoes the rejected candidate; what matters is
-        // that the forged export is never CERTIFIED (credited).
-        assert!(
-            !out.contains("CERTIFIED"),
-            "forged export credited (i):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-i");
+    copy_dir(&out_dir, &dir);
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let json = std::fs::read_to_string(&mf).unwrap();
+    let mut m: serde_json::Value = serde_json::from_str(&json).unwrap();
+    m["certified"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "name": "withdrawAll",
+            "class": "straight-line",
+            "policy": "simulatesModel",
+            "level": "L1",
+            "theorem": "CertProofs.withdrawAll_wasm_certified",
+            "dom": "List Int",
+            "cod": "Int"
+        }));
+    m["runtime_contracts"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::Value::String("FAKE contract injected".into()));
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    // Every .lean and hash is byte-identical; only the JSON changed.
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "padded JSON must be DECLINED, not credited:\n{out}");
+    assert!(out.contains("does not bind"), "wrong reason (i):\n{out}");
+    // The declined diagnostic echoes the rejected candidate; what matters is
+    // that the forged export is never CERTIFIED (credited).
+    assert!(
+        !out.contains("CERTIFIED"),
+        "forged export credited (i):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// Class labels are paired with exports by Lean, not compared as two bags, so
+/// swapping two distinct labels while preserving names and order is declined.
+#[test]
+fn cert_tripwire_declines_swapped_report_class_pairs() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-i-pair-swap") else {
+        return;
+    };
 
     // Class labels are paired with exports by Lean, not compared as two bags.
     // Swapping the two distinct recursion labels while preserving names and
     // order must therefore fail the atomic `reportEntries` binding.
-    {
-        let dir = temp_dir("neg-i-report-pair-swap");
-        copy_dir(&out_dir, &dir);
-        let mf = dir.join("cert/cert-manifest.json");
-        let mut m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
-        let certified = m["certified"].as_array_mut().unwrap();
-        assert!(certified.len() >= 2);
-        let first = certified[0]["class"].as_str().unwrap().to_string();
-        let second = certified[1]["class"].as_str().unwrap().to_string();
-        assert_ne!(first, second, "fixture needs two distinct report classes");
-        certified[0]["class"] = serde_json::Value::String(second);
-        certified[1]["class"] = serde_json::Value::String(first);
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let dir = temp_dir("neg-i-report-pair-swap");
+    copy_dir(&out_dir, &dir);
+    let mf = dir.join("cert/cert-manifest.json");
+    let mut m: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    let certified = m["certified"].as_array_mut().unwrap();
+    assert!(certified.len() >= 2);
+    let first = certified[0]["class"].as_str().unwrap().to_string();
+    let second = certified[1]["class"].as_str().unwrap().to_string();
+    assert_ne!(first, second, "fixture needs two distinct report classes");
+    certified[0]["class"] = serde_json::Value::String(second);
+    certified[1]["class"] = serde_json::Value::String(first);
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
 
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "swapped export/class pairs must be DECLINED:\n{out}");
-        assert!(
-            out.contains("does not bind"),
-            "wrong report-pair decline:\n{out}"
-        );
-        assert!(
-            !out.contains("CERTIFIED"),
-            "swapped classes were credited:\n{out}"
-        );
-    }
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "swapped export/class pairs must be DECLINED:\n{out}");
+    assert!(
+        out.contains("does not bind"),
+        "wrong report-pair decline:\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED"),
+        "swapped classes were credited:\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (j) Drift, JSON claims MORE than the manifest: a charset-clean certified
+/// entry that no obligation backs.
+#[test]
+fn cert_tripwire_declines_json_claiming_an_extra_export() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-j") else {
+        return;
+    };
 
     // (j) Drift, JSON claims MORE than the manifest: a second certified entry
     //     whose name is charset-clean but absent from the obligations. The
     //     `obligations.length = N` / export-name bindings fail closed.
-    {
-        let dir = temp_dir("neg-j");
-        copy_dir(&out_dir, &dir);
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let mut m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
-        m["certified"]
-            .as_array_mut()
-            .unwrap()
-            .push(serde_json::json!({
-                "name": "phantom",
-                "class": "straight-line",
-                "policy": "simulatesModel",
-                "level": "L1",
-                "dom": "List Int",
-                "cod": "Int"
-            }));
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "JSON claiming an extra export must fail (j):\n{out}");
-        assert!(out.contains("does not bind"), "wrong reason (j):\n{out}");
-        assert!(
-            !out.contains("CERTIFIED"),
-            "phantom export credited (j):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-j");
+    copy_dir(&out_dir, &dir);
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let mut m: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    m["certified"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "name": "phantom",
+            "class": "straight-line",
+            "policy": "simulatesModel",
+            "level": "L1",
+            "dom": "List Int",
+            "cod": "Int"
+        }));
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "JSON claiming an extra export must fail (j):\n{out}");
+    assert!(out.contains("does not bind"), "wrong reason (j):\n{out}");
+    assert!(
+        !out.contains("CERTIFIED"),
+        "phantom export credited (j):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (k) Drift, JSON claims FEWER than the manifest: an empty `certified` while
+/// the manifest still proves an obligation.
+#[test]
+fn cert_tripwire_declines_json_dropping_a_real_export() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-k") else {
+        return;
+    };
 
     // (k) Drift, JSON claims FEWER than the manifest: an empty `certified` while
     //     the manifest still proves one obligation. `length = 0 := rfl` fails.
-    {
-        let dir = temp_dir("neg-k");
-        copy_dir(&out_dir, &dir);
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let mut m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
-        m["certified"] = serde_json::Value::Array(vec![]);
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "JSON dropping a real export must fail (k):\n{out}");
-        assert!(out.contains("does not bind"), "wrong reason (k):\n{out}");
-    }
+    let dir = temp_dir("neg-k");
+    copy_dir(&out_dir, &dir);
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let mut m: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    m["certified"] = serde_json::Value::Array(vec![]);
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "JSON dropping a real export must fail (k):\n{out}");
+    assert!(out.contains("does not bind"), "wrong reason (k):\n{out}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (l) Charset gate: a certified name carrying a control character is rejected
+/// before any splice, so it can never reach the Lean witness.
+#[test]
+fn cert_tripwire_declines_control_char_in_candidate_name() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-l") else {
+        return;
+    };
 
     // (l) Charset gate: a certified name carrying a control character (decoded
     //     from the JSON) is rejected before any splice, so it can never reach
     //     the Lean witness.
-    {
-        let dir = temp_dir("neg-l");
-        copy_dir(&out_dir, &dir);
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let mut m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
-        m["certified"][0]["name"] = serde_json::Value::String("sumTo\nevil := by rfl".into());
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "control char in a candidate must fail (l):\n{out}");
-        assert!(out.contains("printable ASCII"), "wrong reason (l):\n{out}");
-    }
+    let dir = temp_dir("neg-l");
+    copy_dir(&out_dir, &dir);
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let mut m: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    m["certified"][0]["name"] = serde_json::Value::String("sumTo\nevil := by rfl".into());
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "control char in a candidate must fail (l):\n{out}");
+    assert!(out.contains("printable ASCII"), "wrong reason (l):\n{out}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (m) Evil axiom: `Final.cert` proved from a smuggled `axiom`. The build
+/// succeeds — an axiom is valid Lean — and the witness axiom collector throws.
+#[test]
+fn cert_tripwire_declines_axiom_backed_final_theorem() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-m") else {
+        return;
+    };
 
     // (m) Evil axiom: prove `Final.cert` from a smuggled `axiom evil`. The build
     //     succeeds (an axiom is valid Lean), but the witness runs the kernel's
     //     axiom collector over the ascribed constant and throws on `evil`.
-    {
-        let dir = temp_dir("neg-m");
-        copy_dir(&out_dir, &dir);
-        let f = dir.join("cert").join("Final.lean");
-        let evil = "import Certificate\nimport Manifest\nimport Schema\n\n\
-             open AverCert AverCert.Schema\n\n\
-             axiom evil : AverCert.Schema.Holds AverCert.manifest\n\
-             theorem AverCert.Final.cert : AverCert.Schema.Holds manifest := evil\n";
-        std::fs::write(&f, evil).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "axiom-backed final theorem must fail (m):\n{out}");
-        assert!(
-            out.contains("non-whitelisted axiom"),
-            "witness axiom collector not exercised (m):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-m");
+    copy_dir(&out_dir, &dir);
+    let f = dir.join("cert").join("Final.lean");
+    let evil = "import Certificate\nimport Manifest\nimport Schema\n\n\
+         open AverCert AverCert.Schema\n\n\
+         axiom evil : AverCert.Schema.Holds AverCert.manifest\n\
+         theorem AverCert.Final.cert : AverCert.Schema.Holds manifest := evil\n";
+    std::fs::write(&f, evil).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "axiom-backed final theorem must fail (m):\n{out}");
+    assert!(
+        out.contains("non-whitelisted axiom"),
+        "witness axiom collector not exercised (m):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (n) A7 filename gate: a cert data file whose name is not a plain Lean
+/// module identifier is rejected before staging, so it cannot inject tokens
+/// into the checker-authored lakefile roots.
+#[test]
+fn cert_tripwire_declines_hostile_cert_file_name() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-n") else {
+        return;
+    };
 
     // (n) A7 filename gate: a cert data file whose name is not a plain Lean
     //     module identifier (a space here) is rejected before staging, so it
     //     cannot inject tokens into the checker-authored lakefile roots.
-    {
-        let dir = temp_dir("neg-n");
-        copy_dir(&out_dir, &dir);
-        std::fs::write(
-            dir.join("cert").join("bad name.lean"),
-            "-- inert\ndef x : Nat := 0\n",
-        )
-        .unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "hostile cert file name must fail (n):\n{out}");
-        assert!(
-            out.contains("bad name.lean") && out.contains("^[A-Za-z][A-Za-z0-9_]*\\.lean$"),
-            "wrong reason (n):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-n");
+    copy_dir(&out_dir, &dir);
+    std::fs::write(
+        dir.join("cert").join("bad name.lean"),
+        "-- inert\ndef x : Nat := 0\n",
+    )
+    .unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "hostile cert file name must fail (n):\n{out}");
+    assert!(
+        out.contains("bad name.lean") && out.contains("^[A-Za-z][A-Za-z0-9_]*\\.lean$"),
+        "wrong reason (n):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (o) A8 token scan: a cert data file carrying an elaboration-executes-code
+/// token is rejected before it is staged (deliberately brittle wall).
+#[test]
+fn cert_tripwire_declines_code_executing_token_in_cert_data() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-o") else {
+        return;
+    };
 
     // (o) A8 token scan: a cert data file carrying an elaboration-executes-code
     //     token is rejected before it is staged (deliberately brittle wall).
-    {
-        let dir = temp_dir("neg-o");
-        copy_dir(&out_dir, &dir);
-        let c = dir.join("cert").join("Contracts.lean");
-        let mut src = std::fs::read_to_string(&c).unwrap();
-        src.push_str("\n#eval IO.println \"pwned\"\n");
-        std::fs::write(&c, src).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(
-            !ok,
-            "code-executing token in a data file must fail (o):\n{out}"
-        );
-        assert!(
-            out.contains("elaboration-executing") && out.contains("#eval"),
-            "wrong reason (o):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-o");
+    copy_dir(&out_dir, &dir);
+    let c = dir.join("cert").join("Contracts.lean");
+    let mut src = std::fs::read_to_string(&c).unwrap();
+    src.push_str("\n#eval IO.println \"pwned\"\n");
+    std::fs::write(&c, src).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(
+        !ok,
+        "code-executing token in a data file must fail (o):\n{out}"
+    );
+    assert!(
+        out.contains("elaboration-executing") && out.contains("#eval"),
+        "wrong reason (o):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (p) Bytes-vs-data divergence: a `Module.lean` body that still builds green
+/// and still passes the report bindings, but does not decode from the real
+/// bytes. The wasm is untouched, so the mismatch is purely in the Lean data.
+#[test]
+fn cert_tripwire_declines_diverging_module_body() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-p") else {
+        return;
+    };
 
     // (p) bytes-vs-data divergence: a Module.lean whose `sumToCode` body does NOT
     //     decode from the real bytes. The locals count in the CodeTbl entry is
@@ -990,157 +1311,209 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     //     (locals 1), so the kernel witness fails: DECLINED, never CERTIFIED. The
     //     wasm bytes are untouched, so the hash stays consistent — the mismatch is
     //     purely in the attacker-editable Lean data.
-    {
-        let dir = temp_dir("neg-p");
-        copy_dir(&out_dir, &dir);
-        let m = dir.join("cert").join("Module.lean");
-        let src = std::fs::read_to_string(&m).unwrap();
-        let corrupted = src.replacen("some ⟨1, 1,", "some ⟨1, 2,", 1);
-        assert_ne!(src, corrupted, "fixture recursive body shape changed");
-        std::fs::write(&m, corrupted).unwrap();
-        // wasm bytes are untouched: the hash still matches the pinned value.
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(
-            !ok,
-            "a body that does not bind to the artifact bytes must be DECLINED:\n{out}"
-        );
-        // The acceptance predicate now pins the locals count exactly, so this
-        // mutation can trip either the shipped artifact's own acceptance `rfl`
-        // during the lake build ("did not build") or the later checker-witness
-        // code binding ("does not bind"). Both are the same fail-closed
-        // decline; the earlier stage is the stronger constraint.
-        assert!(
-            out.contains("does not bind") || out.contains("did not build"),
-            "wrong reason (p):\n{out}"
-        );
-        assert!(
-            !out.contains("CERTIFIED"),
-            "a diverging body must never be credited (p):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-p");
+    copy_dir(&out_dir, &dir);
+    let m = dir.join("cert").join("Module.lean");
+    let src = std::fs::read_to_string(&m).unwrap();
+    let corrupted = src.replacen("some ⟨1, 1,", "some ⟨1, 2,", 1);
+    assert_ne!(src, corrupted, "fixture recursive body shape changed");
+    std::fs::write(&m, corrupted).unwrap();
+    // wasm bytes are untouched: the hash still matches the pinned value.
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(
+        !ok,
+        "a body that does not bind to the artifact bytes must be DECLINED:\n{out}"
+    );
+    // The acceptance predicate now pins the locals count exactly, so this
+    // mutation can trip either the shipped artifact's own acceptance `rfl`
+    // during the lake build ("did not build") or the later checker-witness
+    // code binding ("does not bind"). Both are the same fail-closed
+    // decline; the earlier stage is the stronger constraint.
+    assert!(
+        out.contains("does not bind") || out.contains("did not build"),
+        "wrong reason (p):\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED"),
+        "a diverging body must never be credited (p):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (q) Shadow decoy — the reproduced bypass: the ACTIVE body mutated plus a
+/// byte-honest copy re-planted in a `namespace Shadow`. The decoy text does
+/// not change `o.code`.
+#[test]
+fn cert_tripwire_declines_shadow_namespace_decoy() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-q") else {
+        return;
+    };
 
     // (q) Shadow decoy (the reproduced bypass): mutate the ACTIVE `sumToCode`
     //     (locals 1→2) and re-plant a byte-identical honest body in a
     //     `namespace Shadow`. The old substring check matched the honest text in
     //     `Shadow` and passed; the code `rfl` pins `o.code` — which is the active,
     //     mutated `CertModule.sumToCode`, not the shadow — so it fails: DECLINED.
-    {
-        let dir = temp_dir("neg-q");
-        copy_dir(&out_dir, &dir);
-        let m = dir.join("cert").join("Module.lean");
-        let src = std::fs::read_to_string(&m).unwrap();
-        let mutated = src.replacen("some ⟨1, 1,", "some ⟨1, 2,", 1);
-        assert_ne!(src, mutated, "fixture recursive body shape changed");
-        let shadow = format!("namespace Shadow\n{HONEST_SUMTO_CODE}\nend Shadow\n\nend CertModule");
-        let planted = mutated.replacen("end CertModule", &shadow, 1);
-        assert_ne!(mutated, planted, "shadow decoy not planted");
-        std::fs::write(&m, planted).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "shadow decoy must be DECLINED:\n{out}");
-        // The locals-count mutation can trip the shipped artifact's own
-        // acceptance `rfl` at lake build ("did not build") or the later
-        // checker-witness code binding ("does not bind") — the shadow decoy
-        // fools neither stage.
-        assert!(
-            out.contains("does not bind") || out.contains("did not build"),
-            "wrong reason (q):\n{out}"
-        );
-        assert!(
-            !out.contains("CERTIFIED"),
-            "shadow decoy credited (q):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-q");
+    copy_dir(&out_dir, &dir);
+    let m = dir.join("cert").join("Module.lean");
+    let src = std::fs::read_to_string(&m).unwrap();
+    let mutated = src.replacen("some ⟨1, 1,", "some ⟨1, 2,", 1);
+    assert_ne!(src, mutated, "fixture recursive body shape changed");
+    let shadow = format!("namespace Shadow\n{HONEST_SUMTO_CODE}\nend Shadow\n\nend CertModule");
+    let planted = mutated.replacen("end CertModule", &shadow, 1);
+    assert_ne!(mutated, planted, "shadow decoy not planted");
+    std::fs::write(&m, planted).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "shadow decoy must be DECLINED:\n{out}");
+    // The locals-count mutation can trip the shipped artifact's own
+    // acceptance `rfl` at lake build ("did not build") or the later
+    // checker-witness code binding ("does not bind") — the shadow decoy
+    // fools neither stage.
+    assert!(
+        out.contains("does not bind") || out.contains("did not build"),
+        "wrong reason (q):\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED"),
+        "shadow decoy credited (q):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (r) Comment decoy: the active body mutated plus a byte-honest copy inside a
+/// block comment. Dead text.
+#[test]
+fn cert_tripwire_declines_block_comment_decoy() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-r") else {
+        return;
+    };
 
     // (r) Comment decoy: mutate the active `sumToCode` and re-plant a byte-honest
     //     body inside a `/- … -/` block comment. Dead text; `o.code` is still the
     //     mutated active def, so the code `rfl` fails: DECLINED.
-    {
-        let dir = temp_dir("neg-r");
-        copy_dir(&out_dir, &dir);
-        let m = dir.join("cert").join("Module.lean");
-        let src = std::fs::read_to_string(&m).unwrap();
-        let mutated = src.replacen("some ⟨1, 1,", "some ⟨1, 2,", 1);
-        assert_ne!(src, mutated, "fixture recursive body shape changed");
-        let comment = format!("/- honest decoy:\n{HONEST_SUMTO_CODE}\n-/\n\nend CertModule");
-        let planted = mutated.replacen("end CertModule", &comment, 1);
-        std::fs::write(&m, planted).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "comment decoy must be DECLINED:\n{out}");
-        // Same stage-agnostic decline as (q): the locals-count pin can trip at
-        // the artifact's own lake build or at the checker witness.
-        assert!(
-            out.contains("does not bind") || out.contains("did not build"),
-            "wrong reason (r):\n{out}"
-        );
-        assert!(
-            !out.contains("CERTIFIED"),
-            "comment decoy credited (r):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-r");
+    copy_dir(&out_dir, &dir);
+    let m = dir.join("cert").join("Module.lean");
+    let src = std::fs::read_to_string(&m).unwrap();
+    let mutated = src.replacen("some ⟨1, 1,", "some ⟨1, 2,", 1);
+    assert_ne!(src, mutated, "fixture recursive body shape changed");
+    let comment = format!("/- honest decoy:\n{HONEST_SUMTO_CODE}\n-/\n\nend CertModule");
+    let planted = mutated.replacen("end CertModule", &comment, 1);
+    std::fs::write(&m, planted).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "comment decoy must be DECLINED:\n{out}");
+    // Same stage-agnostic decline as (q): the locals-count pin can trip at
+    // the artifact's own lake build or at the checker witness.
+    assert!(
+        out.contains("does not bind") || out.contains("did not build"),
+        "wrong reason (r):\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED"),
+        "comment decoy credited (r):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (s) Migrated-recursion code decouple: `sumTo`'s obligation points at a decoy
+/// code table. The generic recursion claim must bind the obligation's code to
+/// the byte-derived plan with no bespoke simulation proof to swap.
+#[test]
+fn cert_tripwire_declines_recursion_code_decouple() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-s") else {
+        return;
+    };
 
     // (s) Migrated-recursion code decouple: point `sumTo`'s obligation at a
     //     decoy `wrongCode`, leaving the byte-honest `sumToCode` dead. `sumTo`
     //     deliberately has no bespoke `sumTo_simulates` proof now: the generic
     //     recursion bridge's `recursionClaimAccepted` must bind the obligation's
     //     code directly to the byte-derived plan and fail closed.
-    {
-        let dir = temp_dir("neg-s");
-        copy_dir(&out_dir, &dir);
-        let cert = dir.join("cert");
-        let m = cert.join("Module.lean");
-        let src = std::fs::read_to_string(&m).unwrap();
-        let with_decoy = src.replacen(
-            "end CertModule",
-            "/-- decoy: always traps, so `holds` is vacuous. -/\n\
-             def wrongCode : CodeTbl := fun _ => none\nend CertModule",
-            1,
-        );
-        std::fs::write(&m, with_decoy).unwrap();
-        let man = cert.join("Manifest.lean");
-        let msrc = std::fs::read_to_string(&man).unwrap();
-        let decoupled = msrc.replacen(
-            "code := CertModule.sumToCode",
-            "code := CertModule.wrongCode",
-            1,
-        );
-        assert_ne!(msrc, decoupled, "manifest code field shape changed");
-        std::fs::write(&man, decoupled).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &cert);
-        assert!(!ok, "code decouple must be DECLINED:\n{out}");
-        assert!(
-            out.contains("did not build") || out.contains("does not bind"),
-            "wrong reason (s):\n{out}"
-        );
-        assert!(
-            !out.contains("CERTIFIED"),
-            "code decouple credited (s):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-s");
+    copy_dir(&out_dir, &dir);
+    let cert = dir.join("cert");
+    let m = cert.join("Module.lean");
+    let src = std::fs::read_to_string(&m).unwrap();
+    let with_decoy = src.replacen(
+        "end CertModule",
+        "/-- decoy: always traps, so `holds` is vacuous. -/\n\
+         def wrongCode : CodeTbl := fun _ => none\nend CertModule",
+        1,
+    );
+    std::fs::write(&m, with_decoy).unwrap();
+    let man = cert.join("Manifest.lean");
+    let msrc = std::fs::read_to_string(&man).unwrap();
+    let decoupled = msrc.replacen(
+        "code := CertModule.sumToCode",
+        "code := CertModule.wrongCode",
+        1,
+    );
+    assert_ne!(msrc, decoupled, "manifest code field shape changed");
+    std::fs::write(&man, decoupled).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &cert);
+    assert!(!ok, "code decouple must be DECLINED:\n{out}");
+    assert!(
+        out.contains("did not build") || out.contains("does not bind"),
+        "wrong reason (s):\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED"),
+        "code decouple credited (s):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (t) Migrated-recursion self decouple: `sumTo`'s obligation uses a wrong
+/// function index; the generic claim binds it to the byte-derived index.
+#[test]
+fn cert_tripwire_declines_recursion_self_decouple() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-t") else {
+        return;
+    };
 
     // (t) Migrated-recursion self decouple: set `sumTo`'s obligation `self` to a
     //     wrong index. The generic recursion bridge's `recursionClaimAccepted`
     //     binds `obligation.self` to the byte-derived function index, so this
     //     must fail closed without any bespoke simulation-proof replacement.
-    {
-        let dir = temp_dir("neg-t");
-        copy_dir(&out_dir, &dir);
-        let cert = dir.join("cert");
-        let man = cert.join("Manifest.lean");
-        let msrc = std::fs::read_to_string(&man).unwrap();
-        let decoupled = msrc.replacen("self := 1,", "self := 999,", 1);
-        assert_ne!(msrc, decoupled, "manifest self field shape changed");
-        std::fs::write(&man, decoupled).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &cert);
-        assert!(!ok, "self decouple must be DECLINED:\n{out}");
-        assert!(
-            out.contains("did not build") || out.contains("does not bind"),
-            "wrong reason (t):\n{out}"
-        );
-        assert!(
-            !out.contains("CERTIFIED"),
-            "self decouple credited (t):\n{out}"
-        );
-    }
+    let dir = temp_dir("neg-t");
+    copy_dir(&out_dir, &dir);
+    let cert = dir.join("cert");
+    let man = cert.join("Manifest.lean");
+    let msrc = std::fs::read_to_string(&man).unwrap();
+    let decoupled = msrc.replacen("self := 1,", "self := 999,", 1);
+    assert_ne!(msrc, decoupled, "manifest self field shape changed");
+    std::fs::write(&man, decoupled).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &cert);
+    assert!(!ok, "self decouple must be DECLINED:\n{out}");
+    assert!(
+        out.contains("did not build") || out.contains("does not bind"),
+        "wrong reason (t):\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED"),
+        "self decouple credited (t):\n{out}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (u) Export-name relabel: an honest body relabelled to a duplicate export
+/// name in both the Lean manifest and the JSON.
+#[test]
+fn cert_tripwire_declines_export_name_relabel() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-u") else {
+        return;
+    };
 
     // (u) Export-name relabel: keep the byte-bound honest body/self/carrier, but
     //     relabel the first obligation (and the JSON) to a duplicate export name
@@ -1148,74 +1521,83 @@ fn cert_verify_accepts_and_tripwires_fail_closed() {
     //     `obligation.export_` to the claimed export name, so the relabel now
     //     fails the cert's OWN build; the checker witness's manifest export
     //     list `rfl` remains the backstop for claim-free certs → DECLINED.
-    {
-        let dir = temp_dir("neg-u");
-        copy_dir(&out_dir, &dir);
-        let man = dir.join("cert").join("Manifest.lean");
-        let mt = std::fs::read_to_string(&man)
-            .unwrap()
-            .replace("export_ := \"sumTo\"", "export_ := \"countDown\"")
-            .replace("exports := [\"sumTo\"]", "exports := [\"countDown\"]");
-        std::fs::write(&man, mt).unwrap();
-        let mf = dir.join("cert").join("cert-manifest.json");
-        let mut m: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
-        for c in m["certified"].as_array_mut().unwrap() {
-            if c["name"] == serde_json::json!("sumTo") {
-                c["name"] = serde_json::json!("countDown");
-            }
+    let dir = temp_dir("neg-u");
+    copy_dir(&out_dir, &dir);
+    let man = dir.join("cert").join("Manifest.lean");
+    let mt = std::fs::read_to_string(&man)
+        .unwrap()
+        .replace("export_ := \"sumTo\"", "export_ := \"countDown\"")
+        .replace("exports := [\"sumTo\"]", "exports := [\"countDown\"]");
+    std::fs::write(&man, mt).unwrap();
+    let mf = dir.join("cert").join("cert-manifest.json");
+    let mut m: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mf).unwrap()).unwrap();
+    for c in m["certified"].as_array_mut().unwrap() {
+        if c["name"] == serde_json::json!("sumTo") {
+            c["name"] = serde_json::json!("countDown");
         }
-        std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
-        assert!(!ok, "export-name relabel must be DECLINED (u):\n{out}");
-        assert!(
-            out.contains("did not build") || out.contains("does not bind"),
-            "wrong reason (u):\n{out}"
-        );
-        assert!(!out.contains("CERTIFIED"), "relabel credited (u):\n{out}");
     }
+    std::fs::write(&mf, serde_json::to_string_pretty(&m).unwrap()).unwrap();
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &dir.join("cert"));
+    assert!(!ok, "export-name relabel must be DECLINED (u):\n{out}");
+    assert!(
+        out.contains("did not build") || out.contains("does not bind"),
+        "wrong reason (u):\n{out}"
+    );
+    assert!(!out.contains("CERTIFIED"), "relabel credited (u):\n{out}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// (v) Migrated accumulator-recursion code decouple: `countDown` pointed at an
+/// always-trapping code table, with no bespoke simulation theorem to swap.
+#[test]
+fn cert_tripwire_declines_accumulator_code_decouple() {
+    let Some(out_dir) = tripwire_baseline("certverify-neg-v") else {
+        return;
+    };
 
     // (v) Migrated accumulator-recursion code decouple: point `countDown` at an
     //     always-trapping code table. There is no bespoke simulation theorem to
     //     swap after the migration; the audited generic claim/bridge must bind
     //     the arity-two obligation directly to the byte-derived plan.
-    {
-        let dir = temp_dir("neg-v-countdown-code");
-        copy_dir(&out_dir, &dir);
-        let cert = dir.join("cert");
-        let module = cert.join("Module.lean");
-        let src = std::fs::read_to_string(&module).unwrap();
-        let with_decoy = src.replacen(
-            "end CertModule",
-            "/-- decoy: always traps, so `holds` is vacuous. -/\n\
-             def wrongCode : CodeTbl := fun _ => none\nend CertModule",
-            1,
-        );
-        assert_ne!(src, with_decoy, "module end marker shape changed");
-        std::fs::write(&module, with_decoy).unwrap();
+    let dir = temp_dir("neg-v-countdown-code");
+    copy_dir(&out_dir, &dir);
+    let cert = dir.join("cert");
+    let module = cert.join("Module.lean");
+    let src = std::fs::read_to_string(&module).unwrap();
+    let with_decoy = src.replacen(
+        "end CertModule",
+        "/-- decoy: always traps, so `holds` is vacuous. -/\n\
+         def wrongCode : CodeTbl := fun _ => none\nend CertModule",
+        1,
+    );
+    assert_ne!(src, with_decoy, "module end marker shape changed");
+    std::fs::write(&module, with_decoy).unwrap();
 
-        let manifest = cert.join("Manifest.lean");
-        let msrc = std::fs::read_to_string(&manifest).unwrap();
-        let decoupled = msrc.replacen(
-            "code := CertModule.countDownCode",
-            "code := CertModule.wrongCode",
-            1,
-        );
-        assert_ne!(msrc, decoupled, "countDown code field shape changed");
-        std::fs::write(&manifest, decoupled).unwrap();
+    let manifest = cert.join("Manifest.lean");
+    let msrc = std::fs::read_to_string(&manifest).unwrap();
+    let decoupled = msrc.replacen(
+        "code := CertModule.countDownCode",
+        "code := CertModule.wrongCode",
+        1,
+    );
+    assert_ne!(msrc, decoupled, "countDown code field shape changed");
+    std::fs::write(&manifest, decoupled).unwrap();
 
-        let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &cert);
-        assert!(!ok, "countDown code decouple must be DECLINED (v):\n{out}");
-        assert!(
-            out.contains("did not build") || out.contains("does not bind"),
-            "wrong reason (v):\n{out}"
-        );
-        assert!(
-            !out.contains("CERTIFIED"),
-            "countDown code decouple credited (v):\n{out}"
-        );
-    }
+    let (ok, out) = aver_check(&dir.join("certprobe2.wasm"), &cert);
+    assert!(!ok, "countDown code decouple must be DECLINED (v):\n{out}");
+    assert!(
+        out.contains("did not build") || out.contains("does not bind"),
+        "wrong reason (v):\n{out}"
+    );
+    assert!(
+        !out.contains("CERTIFIED"),
+        "countDown code decouple credited (v):\n{out}"
+    );
 
+    let _ = std::fs::remove_dir_all(&dir);
     let _ = std::fs::remove_dir_all(&out_dir);
 }
 

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -1557,15 +1557,44 @@ fn cert_verify_declines_tampered_array_new_data_operands() {
     );
 }
 
-#[test]
-fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
+// Plans.lean-authority soundness gates.
+//
+// These tests share one baseline artifact and differ only in which single
+// tamper they apply to the emitted certificate package before demanding a
+// DECLINE. They used to be one test that ran every verification sequentially.
+// Each of these tampers edits Lean sources, so the decline only surfaces after
+// a full certificate verification (minutes on CI), while the shared
+// `aver compile --certify` baseline costs a fraction of a second. Splitting the
+// tamper vectors into separate tests behind the `cert_plans_authority_` prefix
+// — each redoing the cheap setup — lets CI run the expensive verifications in
+// parallel lanes, the same way `cert_certify_spec.rs` runs its
+// `cert_hostile_model_` family. Prefix in, prefix out: the dedicated lanes
+// select this prefix and the `rest` lanes exclude exactly it, so a gate added
+// here is run exactly once and needs no workflow edit.
+
+/// Compiles the shared Plans.lean-authority baseline package.
+///
+/// Every gate below runs this itself rather than depending on a baseline built
+/// by another test (and therefore another CI lane), so each one fails on its
+/// own terms. The compile is a fraction of a second, so duplicating the setup
+/// per gate is nearly free — unlike the verification each gate then performs.
+///
+/// The honest package's own verdict is asserted once, by
+/// `cert_plans_authority_accepts_clean_certificate_and_pins_public_plan_data`,
+/// rather than per gate: that keeps the number of full verifications the same
+/// as before the split. Every tamper gate additionally pins the REASON its
+/// tamper is declined, so a fixture that stopped verifying for an unrelated
+/// reason surfaces as a wrong-reason failure rather than as a vacuous pass.
+///
+/// Returns `None` when `lake` is unavailable; the caller then skips, as before.
+fn plans_authority_baseline(prefix: &str) -> Option<PathBuf> {
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping Plans.lean authority test: `lake` not available");
-        return;
+        return None;
     }
 
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let out_dir = temp_dir("cert-plans-authority");
+    let out_dir = temp_dir(prefix);
 
     let compile = aver_command()
         .current_dir(&repo_root)
@@ -1584,6 +1613,18 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
         String::from_utf8_lossy(&compile.stdout),
         String::from_utf8_lossy(&compile.stderr)
     );
+
+    Some(out_dir)
+}
+
+/// The honest goals package verifies, and `Plans.lean` is its only public plan
+/// DATA: no checker-generated `ArtifactBytes.lean`, no fragment sidecars, and
+/// no plan metadata leaking into the public manifest.
+#[test]
+fn cert_plans_authority_accepts_clean_certificate_and_pins_public_plan_data() {
+    let Some(out_dir) = plans_authority_baseline("cert-plans-authority") else {
+        return;
+    };
 
     let wasm = out_dir.join("cert_goals.wasm");
     let cert = out_dir.join("cert");
@@ -1610,6 +1651,19 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
         assert!(entry.get("plan_sha256").is_none());
     }
 
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// A cert-supplied `ArtifactBytes.lean` is a checker-owned filename, so a
+/// package that ships a decoy under that name must still be ACCEPTED with the
+/// decoy ignored — the verifier regenerates it from the artifact bytes it read.
+#[test]
+fn cert_plans_authority_ignores_cert_supplied_artifact_bytes_decoy() {
+    let Some(out_dir) = plans_authority_baseline("cert-plans-authority-artifact-bytes-decoy")
+    else {
+        return;
+    };
+
     // The honest package does not carry ArtifactBytes, but an adversarial
     // package may add a decoy. The verifier must still generate the module from
     // the artifact bytes it read and ignore this checker-owned filename.
@@ -1629,6 +1683,19 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
         "cert-supplied ArtifactBytes.lean must be ignored and regenerated:\n{out}"
     );
 
+    let _ = std::fs::remove_dir_all(&artifact_bytes_decoy_dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// The expr-fragment acceptance path pins the carrier scratch local declared by
+/// the canonical byte lowering, so a code table claiming zero locals is
+/// DECLINED even with honest bytes and an honest plan.
+#[test]
+fn cert_plans_authority_declines_zero_locals_expr_fragment_code() {
+    let Some(out_dir) = plans_authority_baseline("cert-plans-authority-zero-locals") else {
+        return;
+    };
+
     // Honest bytes and plan, but the standalone obligation code table claims
     // zero locals. The expr-fragment acceptance path must pin the one carrier
     // scratch local declared by the canonical byte lowering.
@@ -1641,8 +1708,30 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
             !ok,
             "expr-fragment zero-locals code must be DECLINED:\n{report}"
         );
+        // Pin WHY it declined, like every sibling gate here. On its own lane a
+        // bare `!ok` would also be satisfied by a fixture that stopped building
+        // for an unrelated reason, which would retire this gate silently while
+        // the test still passed. In the monolith the shared clean check ahead
+        // of this block ruled that out; standing alone, it has to say so itself.
+        assert!(
+            !report.contains("CERTIFIED"),
+            "zero-locals tamper must not report any certified export:\n{report}"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// An expr-fragment claim whose obligation is not carried by the manifest must
+/// be DECLINED: emptying the manifest obligation list and re-proving the
+/// weakened `Final.cert` must not buy acceptance.
+#[test]
+fn cert_plans_authority_declines_claim_without_manifest_obligation() {
+    let Some(out_dir) = plans_authority_baseline("cert-plans-authority-claim-without-obligation")
+    else {
+        return;
+    };
 
     let claim_without_manifest_ob_dir = temp_dir("cert-expr-claim-without-obligation");
     copy_dir(&out_dir, &claim_without_manifest_ob_dir);
@@ -1707,6 +1796,19 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
         "expr-fragment claim without manifest obligation credited:\n{out}"
     );
 
+    let _ = std::fs::remove_dir_all(&claim_without_manifest_ob_dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// A claim obligation that is no longer structurally the manifest's obligation
+/// — same name, host table wrapped so it differs — must be DECLINED.
+#[test]
+fn cert_plans_authority_declines_artifact_claim_obligation_tamper() {
+    let Some(out_dir) = plans_authority_baseline("cert-plans-authority-artifact-obligation-tamper")
+    else {
+        return;
+    };
+
     let artifact_obligation_tamper_dir = temp_dir("cert-expr-artifact-obligation-tamper");
     copy_dir(&out_dir, &artifact_obligation_tamper_dir);
     let artifact_obligation_tamper_wasm = artifact_obligation_tamper_dir.join("cert_goals.wasm");
@@ -1756,6 +1858,19 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
         "artifact claim obligation tamper credited:\n{out}"
     );
 
+    let _ = std::fs::remove_dir_all(&artifact_obligation_tamper_dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// A package that bridges its acceptance with a carried `axiom` must be
+/// DECLINED by the axiom whitelist, naming the offending axiom.
+#[test]
+fn cert_plans_authority_declines_artifact_carried_axiom_bridge() {
+    let Some(out_dir) = plans_authority_baseline("cert-plans-authority-artifact-axiom-tamper")
+    else {
+        return;
+    };
+
     let artifact_axiom_tamper_dir = temp_dir("cert-expr-artifact-axiom-tamper");
     copy_dir(&out_dir, &artifact_axiom_tamper_dir);
     let artifact_axiom_tamper_wasm = artifact_axiom_tamper_dir.join("cert_goals.wasm");
@@ -1796,6 +1911,18 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
         "artifact-carried axiom bridge credited:\n{out}"
     );
 
+    let _ = std::fs::remove_dir_all(&artifact_axiom_tamper_dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// `Plans.lean` is the authoritative plan DATA, so reordering a raw plan's
+/// operands there must be DECLINED against the module bytes.
+#[test]
+fn cert_plans_authority_declines_tampered_lean_raw_plan() {
+    let Some(out_dir) = plans_authority_baseline("cert-plans-authority-lean-plan-tamper") else {
+        return;
+    };
+
     let lean_plan_tamper_dir = temp_dir("cert-expr-lean-plan-tamper");
     copy_dir(&out_dir, &lean_plan_tamper_dir);
     let lean_plan_tamper_wasm = lean_plan_tamper_dir.join("cert_goals.wasm");
@@ -1823,6 +1950,18 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
         !out.contains("CERTIFIED"),
         "tampered Lean RawPlan data credited:\n{out}"
     );
+
+    let _ = std::fs::remove_dir_all(&lean_plan_tamper_dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// The code-entry byte pin in `Plans.lean` is checked against the module, so a
+/// single flipped opcode byte in that pin must be DECLINED.
+#[test]
+fn cert_plans_authority_declines_tampered_code_entry_byte_pin() {
+    let Some(out_dir) = plans_authority_baseline("cert-plans-authority-lean-bytes-tamper") else {
+        return;
+    };
 
     let lean_bytes_tamper_dir = temp_dir("cert-expr-lean-bytes-tamper");
     copy_dir(&out_dir, &lean_bytes_tamper_dir);
@@ -1857,6 +1996,19 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
         !out.contains("CERTIFIED"),
         "tampered Lean code-entry byte pin credited:\n{out}"
     );
+
+    let _ = std::fs::remove_dir_all(&lean_bytes_tamper_dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// The `WasmSlice` byte-origin pin ties the plan's bytes to their position in
+/// the module, so flipping a byte in that exact-slice argument must be
+/// DECLINED.
+#[test]
+fn cert_plans_authority_declines_tampered_wasm_slice_byte_origin_pin() {
+    let Some(out_dir) = plans_authority_baseline("cert-plans-authority-lean-slice-tamper") else {
+        return;
+    };
 
     let lean_slice_tamper_dir = temp_dir("cert-expr-lean-slice-tamper");
     copy_dir(&out_dir, &lean_slice_tamper_dir);
@@ -1894,14 +2046,8 @@ fn cert_verify_uses_plans_lean_as_the_only_plan_data() {
         "tampered Lean WasmSlice byte-origin pin credited:\n{out}"
     );
 
-    let _ = std::fs::remove_dir_all(&out_dir);
-    let _ = std::fs::remove_dir_all(&artifact_bytes_decoy_dir);
-    let _ = std::fs::remove_dir_all(&claim_without_manifest_ob_dir);
-    let _ = std::fs::remove_dir_all(&artifact_obligation_tamper_dir);
-    let _ = std::fs::remove_dir_all(&artifact_axiom_tamper_dir);
-    let _ = std::fs::remove_dir_all(&lean_plan_tamper_dir);
-    let _ = std::fs::remove_dir_all(&lean_bytes_tamper_dir);
     let _ = std::fs::remove_dir_all(&lean_slice_tamper_dir);
+    let _ = std::fs::remove_dir_all(&out_dir);
 }
 
 /// Byte-derived host-role indices for the goals module, read from the emitted


### PR DESCRIPTION
Follow-up to the hostile-model split. That change took the critical path from 50 minutes to 25; this one goes after what was left holding it there.

Measured on the last run:

| lane | before |
|---|---|
| `cert_verify_spec plans-authority` | 25 min |
| `cert_certify_spec rest` | 22 min |
| `cert_verify_spec rest-*` (quarters) | 19-22 min |
| `cert_certify_spec hostile-models-*` | 10-11 min |

Both 20+ minute lanes turned out to be one test each, running many full certificate verifications in sequence — the same shape as before, not a spread. Widening partitions alone would not have helped, since a lane cannot finish faster than its longest single test.

## What changed

**`cert_verify_uses_plans_lean_as_the_only_plan_data`** performed nine full verifications. Now nine `cert_plans_authority_*` tests over three lanes.

This one deliberately departs from the previous split's shape. There, every shard re-verified a clean certificate first; doing that here would have turned nine verifications into eighteen and spent the entire saving. Instead the clean verdict is asserted once by its own test, and what keeps the rest honest is that each tamper gate pins the *reason* for the decline — so a fixture that stopped verifying for an unrelated reason fails as a wrong-reason failure rather than passing quietly. Review caught one gate asserting only that the verdict was negative; safe while it sat behind the shared clean check, not safe standing alone, so it now pins its reason like its siblings.

**`certify_nonrecursive_adt_witnesses_lake_build_kernel_clean`** built ten emitted certificate packages back to back, accounting for essentially its whole lane. Its case list becomes the sharded source of truth across four lanes, with both drift guards, exactly as for the hostile models.

**Verify complement lanes** widen from quarters to eighths.

## Partitioning

Lane count goes 15 to 25. Each `rest` filter is the literal negation of the prefixes its suite's dedicated lanes select, so a gate added under a prefix lands in an existing lane needing no workflow edit. Partitioning was proved per lane with `cargo nextest list`, not by reading: every test in each suite is selected exactly once, no gap and no overlap.

The certify `rest` lane was left unpartitioned on purpose. With the ADT family moved out its serial floor is another test at roughly 11 minutes, so splitting it would buy about two minutes. If a real run shows otherwise it is a one-line matrix change.

## Honest caveat on the expected result

The estimate is a critical path in the low teens, but per-lane fixed cost — checkout, cache restore, building the verifier binary, compiling the suite, toolchain restore — is not negligible: a lane running just two tests still measured 11 minutes. The next measured run is the real answer, and the untouched `tripwires` lane may well become the new pace-setter.