### PR TITLE
Create parent directories when writing a certificate model

### DIFF
--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -2018,8 +2018,20 @@ fn render_byte_nat(bytes: &[u8]) -> String {
     numeral
 }
 
+/// Write one file of the certificate project.
+///
+/// `name` may be a nested path: a module declared as `Data.Fibonacci` transpiles
+/// to `Data/Fibonacci.lean`. The certificate directory is cleared and recreated
+/// at the start of rendering, so intermediate directories never survive from a
+/// previous run and have to be made here — without this, every project with a
+/// dotted module dependency failed to emit a certificate at all.
 fn write(dir: &Path, name: &str, content: &str) -> Result<(), String> {
-    std::fs::write(dir.join(name), content).map_err(|e| format!("write {name}: {e}"))
+    let path = dir.join(name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create directory for {name}: {e}"))?;
+    }
+    std::fs::write(path, content).map_err(|e| format!("write {name}: {e}"))
 }
 
 fn sanitize_model_for_cert(content: &str) -> String {


### PR DESCRIPTION
A module declared as `Data.Fibonacci` transpiles to a model at `Data/Fibonacci.lean`, but the writer called `fs::write` on that path without creating the directory above it. Rendering clears and recreates the certificate directory first, so no intermediate directory ever survived from an earlier run to make it work by accident.

The effect was larger than a missing file: **no project with a dotted module dependency could emit a certificate at all**. Five programs in the corpus failed this way.

What makes it worth stating plainly is how it hid. A program that cannot produce a certificate never appears as an uncertified function either — it drops out of the denominator instead of counting against coverage. It surfaced only because a corpus-wide measurement tried to compile every entry point and noticed nine that produced nothing, of which five failed with `write Services/Redis.lean: No such file or directory` rather than with a source error.

After the fix, `examples/services/weather.av` emits a certificate with two certified exports and the nested model lands where it belongs. That project still does not pass full verification, for a different reason further down the pipeline; this removes the wall in front of it, not everything behind it.