### PR TITLE
Inline single-use lets, render any source arity, and guard bare-slot functions in the certificate plan producer

### DIFF
--- a/aver-cert/src/engine/render_expr_fragment_bridge.rs
+++ b/aver-cert/src/engine/render_expr_fragment_bridge.rs
@@ -27,8 +27,16 @@ fn expr_fragment_source_model(c: &Cert) -> String {
     debug_assert!(expr_fragment_uses_audited_generic(c));
     match c.arity() {
         1 => c.name().to_string(),
-        2 => format!("fun p => {} p.1 p.2", c.name()),
-        arity => panic!("unsupported generic expr-fragment source arity {arity}"),
+        // The obligation domain is the right-nested product
+        // `FragParams.denote` builds, so the model uncurries the source
+        // function over the same `p.1, p.2.1, …, p.2…2` accessors the
+        // obligation emitter uses (`expr_fragment_dom_accessor`).
+        arity => {
+            let args = (0..arity)
+                .map(|index| format!(" {}", expr_fragment_dom_accessor("p", index, arity)))
+                .collect::<String>();
+            format!("fun p => {}{args}", c.name())
+        }
     }
 }
 
@@ -339,9 +347,20 @@ fn render_expr_fragment_int_bool_semantic_bridge(
     locals.push(".null".to_string());
     let locals = format!("[{}]", locals.join(", "));
     let (dom_name, unpack) = match plan.params.len() {
-        1 => ("a0", String::new()),
-        2 => ("p", "  rcases p with ⟨a0, a1⟩\n".to_string()),
-        arity => panic!("unsupported generic expr-fragment arity {arity}"),
+        1 => ("a0".to_string(), String::new()),
+        // Right-nested product domain: the flat anonymous-constructor
+        // pattern `⟨a0, a1, …⟩` destructures `A × (B × (…))` exactly, so
+        // one `rcases` unpacks any arity.
+        arity => (
+            "p".to_string(),
+            format!(
+                "  rcases p with ⟨{}⟩\n",
+                (0..arity)
+                    .map(|index| format!("a{index}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        ),
     };
     let evalset = format!(
         "AverCert.Plans.{name}Plan, AverCert.PlanLower.maxFuel, \

--- a/src/codegen/cert/expr_fragment_from_mir.rs
+++ b/src/codegen/cert/expr_fragment_from_mir.rs
@@ -803,6 +803,22 @@ impl<'a, 'e> MirSymPlanBuilder<'a, 'e> {
     }
 
     fn finish(self, result: SymValueId) -> Option<SymBlock> {
+        // Kernel block-shape invariants (PlanCheck.checkSymBlock): every
+        // node's id equals its position, and the result is the LAST node
+        // (`result + 1 = nodes.length`). The builder satisfies both by
+        // construction today; checking them here makes a future producer bug
+        // degrade to an unplanned fn instead of a late kernel reject.
+        if self
+            .nodes
+            .iter()
+            .enumerate()
+            .any(|(position, node)| node.id.0 != position)
+        {
+            return None;
+        }
+        if result.0 + 1 != self.nodes.len() {
+            return None;
+        }
         let block = SymBlock {
             nodes: self.nodes,
             result,
@@ -1807,6 +1823,43 @@ mod tests {
         assert!(
             fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).is_none(),
             "an unplannable initializer must keep the fn unplanned"
+        );
+    }
+
+    /// The kernel requires every node id to equal its position and the block
+    /// result to be the LAST node (PlanCheck.checkSymBlock). The builder
+    /// produces exactly that shape; `finish` now refuses anything else so a
+    /// future producer bug fails at the producer, not in the kernel.
+    #[test]
+    fn finish_enforces_kernel_block_shape_invariants() {
+        let params = std::collections::HashMap::new();
+        let record_fields = |_: &str, _: &str| -> Option<(u32, String)> { None };
+        let make_builder = |nodes: Vec<SymNode>| MirSymPlanBuilder {
+            params_by_slot: &params,
+            record_fields: &record_fields,
+            builtins: &[],
+            aliases: std::collections::HashMap::new(),
+            alias_hops: 0,
+            nodes,
+        };
+        let node = |id: usize| SymNode {
+            id: SymValueId(id),
+            ty: SymTy::Bool,
+            kind: SymNodeKind::ConstBool(true),
+        };
+        assert!(
+            make_builder(vec![node(0), node(1)])
+                .finish(SymValueId(0))
+                .is_none(),
+            "a non-last result must not finish"
+        );
+        assert!(
+            make_builder(vec![node(1)]).finish(SymValueId(0)).is_none(),
+            "a discontiguous node id must not finish"
+        );
+        assert!(
+            make_builder(vec![node(0)]).finish(SymValueId(0)).is_some(),
+            "the canonical block shape must still finish"
         );
     }
 

--- a/src/codegen/cert/expr_fragment_from_mir.rs
+++ b/src/codegen/cert/expr_fragment_from_mir.rs
@@ -114,6 +114,8 @@ pub(crate) fn sym_plan_from_mir_fn(
         params_by_slot: &params_by_slot,
         record_fields,
         builtins,
+        aliases: std::collections::HashMap::new(),
+        alias_hops: 0,
         nodes: Vec::new(),
     };
     let (root, root_ty) = builder.lower_expr(&mir_fn.body)?;
@@ -250,17 +252,111 @@ fn expr_fragment_ty_from_mir_name(ty: &str) -> Option<FragTy> {
     }
 }
 
-struct MirSymPlanBuilder<'a> {
+/// Depth guard for let-alias resolution: a chain deeper than this refuses to
+/// plan instead of recursing further. Well-formed MIR let chains are acyclic,
+/// so any real program resolves in a handful of hops; the cap only exists so
+/// pathological nesting degrades to an unplanned fn.
+const MAX_ALIAS_RESOLUTION_DEPTH: usize = 32;
+
+/// Number of reads of `slot` inside `expr`: `Local` reads plus first-class
+/// fn-value calls through the slot (`MirCallee::LocalSlot`). `Let` bindings
+/// and pattern bindings are definitions, not reads; MIR mints locals fresh
+/// per binding, so no shadowing can hide a read from this count.
+fn count_slot_reads(expr: &crate::ast::Spanned<crate::ir::mir::MirExpr>, slot: u32) -> usize {
+    use crate::ir::mir::MirExpr;
+    let sum_all =
+        |items: &[crate::ast::Spanned<MirExpr>]| -> usize {
+            items.iter().map(|item| count_slot_reads(item, slot)).sum()
+        };
+    match &expr.node {
+        MirExpr::Literal(_) | MirExpr::FnValue(_) => 0,
+        MirExpr::Local(local) => usize::from(local.node.slot.0 == slot),
+        MirExpr::Let(l) => {
+            count_slot_reads(&l.node.value, slot) + count_slot_reads(&l.node.body, slot)
+        }
+        MirExpr::Call(call) => {
+            let callee_reads = match &call.node.callee {
+                crate::ir::mir::MirCallee::LocalSlot {
+                    slot: callee_slot, ..
+                } => usize::from(u32::from(*callee_slot) == slot),
+                _ => 0,
+            };
+            callee_reads + sum_all(&call.node.args)
+        }
+        MirExpr::TailCall(tail_call) => sum_all(&tail_call.node.args),
+        MirExpr::BinOp(binop) => {
+            count_slot_reads(&binop.node.lhs, slot) + count_slot_reads(&binop.node.rhs, slot)
+        }
+        MirExpr::Neg(inner)
+        | MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => count_slot_reads(inner, slot),
+        MirExpr::Match(m) => {
+            count_slot_reads(&m.node.subject, slot)
+                + m.node
+                    .arms
+                    .iter()
+                    .map(|arm| count_slot_reads(&arm.body, slot))
+                    .sum::<usize>()
+        }
+        MirExpr::Construct(construct) => sum_all(&construct.node.args),
+        MirExpr::RecordCreate(create) => create
+            .node
+            .fields
+            .iter()
+            .map(|field| count_slot_reads(&field.value, slot))
+            .sum(),
+        MirExpr::RecordUpdate(update) => {
+            count_slot_reads(&update.node.base, slot)
+                + update
+                    .node
+                    .updates
+                    .iter()
+                    .map(|field| count_slot_reads(&field.value, slot))
+                    .sum::<usize>()
+        }
+        MirExpr::Project(project) => count_slot_reads(&project.node.base, slot),
+        MirExpr::IfThenElse(ite) => {
+            count_slot_reads(&ite.node.cond, slot)
+                + count_slot_reads(&ite.node.then_branch, slot)
+                + count_slot_reads(&ite.node.else_branch, slot)
+        }
+        MirExpr::List(items) | MirExpr::Tuple(items) => sum_all(items),
+        MirExpr::MapLiteral(pairs) => pairs
+            .iter()
+            .map(|(key, value)| count_slot_reads(key, slot) + count_slot_reads(value, slot))
+            .sum(),
+        MirExpr::InterpolatedStr(parts) => parts
+            .iter()
+            .map(|part| match part {
+                crate::ir::mir::MirStrPart::Literal(_) => 0,
+                crate::ir::mir::MirStrPart::Expr(inner) => count_slot_reads(inner, slot),
+            })
+            .sum(),
+        MirExpr::IndependentProduct(product) => sum_all(&product.node.items),
+    }
+}
+
+struct MirSymPlanBuilder<'a, 'e> {
     params_by_slot: &'a std::collections::HashMap<u32, (u32, SymTy)>,
     record_fields: RecordFieldLookup<'a>,
     builtins: &'a [String],
+    /// Single-use `let` bindings in scope: slot -> initializer. A `Local`
+    /// read of an aliased slot re-lowers the initializer at the use site
+    /// (sound because every plannable MirExpr is pure, and exact because the
+    /// binding is proven single-use before it is recorded).
+    aliases: std::collections::HashMap<u32, &'e crate::ast::Spanned<crate::ir::mir::MirExpr>>,
+    /// Alias hops currently on the resolution stack (see
+    /// [`MAX_ALIAS_RESOLUTION_DEPTH`]).
+    alias_hops: usize,
     nodes: Vec<SymNode>,
 }
 
-impl MirSymPlanBuilder<'_> {
+impl<'a, 'e> MirSymPlanBuilder<'a, 'e> {
     fn lower_expr(
         &mut self,
-        expr: &crate::ast::Spanned<crate::ir::mir::MirExpr>,
+        expr: &'e crate::ast::Spanned<crate::ir::mir::MirExpr>,
     ) -> Option<(SymValueId, SymTy)> {
         match &expr.node {
             crate::ir::mir::MirExpr::Literal(lit) => match &lit.node {
@@ -276,9 +372,22 @@ impl MirSymPlanBuilder<'_> {
                 _ => None,
             },
             crate::ir::mir::MirExpr::Local(local) => {
-                let (index, ty) = self.params_by_slot.get(&local.node.slot.0)?.clone();
-                self.push_node(ty, SymNodeKind::Param { index })
+                if let Some((index, ty)) = self.params_by_slot.get(&local.node.slot.0).cloned() {
+                    return self.push_node(ty, SymNodeKind::Param { index });
+                }
+                // The one read of a single-use `let` binding: lower the
+                // recorded initializer here, preserving stack discipline
+                // (nodes append in evaluation order at the use site).
+                let init = *self.aliases.get(&local.node.slot.0)?;
+                if self.alias_hops >= MAX_ALIAS_RESOLUTION_DEPTH {
+                    return None;
+                }
+                self.alias_hops += 1;
+                let lowered = self.lower_expr(init);
+                self.alias_hops -= 1;
+                lowered
             }
+            crate::ir::mir::MirExpr::Let(spanned_let) => self.lower_let(&spanned_let.node),
             crate::ir::mir::MirExpr::BinOp(binop) => self.lower_binop(&binop.node),
             crate::ir::mir::MirExpr::Project(spanned_proj) => {
                 // Record field access `base.field`: only a named-record base
@@ -307,6 +416,45 @@ impl MirSymPlanBuilder<'_> {
             crate::ir::mir::MirExpr::Call(call) => self.lower_fused_vector_get(&call.node),
             _ => None,
         }
+    }
+
+    /// Single-use `let` inlining: `x = init; body` lowers as `body` with the
+    /// single read of `x` replaced by lowering `init` at the use site. All
+    /// constraints are mandatory and fail closed to "unplanned":
+    ///
+    /// - the binding must be read EXACTLY once across the whole remaining
+    ///   body, including nested if/match sub-blocks and later `let`
+    ///   initializers (a multi-use binding inlined per-use would duplicate
+    ///   evaluation relative to the MIR-emitted bytes' sharing);
+    /// - the initializer must itself be plannable — checked where it is
+    ///   lowered at the use site; purity comes for free because every
+    ///   plannable MirExpr shape is pure (the fn-level effect gate in
+    ///   `sym_plan_from_mir_fn` is unchanged);
+    /// - malformed shapes (a binding shadowing a param slot, a
+    ///   self-referential initializer) refuse outright.
+    fn lower_let(
+        &mut self,
+        spanned_let: &'e crate::ir::mir::MirLet,
+    ) -> Option<(SymValueId, SymTy)> {
+        if self.params_by_slot.contains_key(&spanned_let.binding.0) {
+            return None;
+        }
+        if count_slot_reads(&spanned_let.body, spanned_let.binding.0) != 1 {
+            return None;
+        }
+        if count_slot_reads(&spanned_let.value, spanned_let.binding.0) != 0 {
+            return None;
+        }
+        let displaced = self
+            .aliases
+            .insert(spanned_let.binding.0, &spanned_let.value);
+        let lowered = self.lower_expr(&spanned_let.body);
+        // Restore the exact scope: the binding ends with its body.
+        match displaced {
+            Some(previous) => self.aliases.insert(spanned_let.binding.0, previous),
+            None => self.aliases.remove(&spanned_let.binding.0),
+        };
+        lowered
     }
 
     /// The fused `Option.withDefault(Vector.get(p0, p1), <int literal>)`
@@ -360,7 +508,7 @@ impl MirSymPlanBuilder<'_> {
         )
     }
 
-    fn lower_binop(&mut self, binop: &crate::ir::mir::MirBinOp) -> Option<(SymValueId, SymTy)> {
+    fn lower_binop(&mut self, binop: &'e crate::ir::mir::MirBinOp) -> Option<(SymValueId, SymTy)> {
         // Narrow straight-line integer face: exactly `param + k` over the
         // single Int parameter (const on the right, matching the emitted byte
         // shape). Anything broader stays unplanned so the emitted bytes are
@@ -428,10 +576,10 @@ impl MirSymPlanBuilder<'_> {
         )
     }
 
-    fn int_const_cmp_shape<'a>(
+    fn int_const_cmp_shape(
         &self,
-        binop: &'a crate::ir::mir::MirBinOp,
-    ) -> Option<(&'a crate::ast::Spanned<crate::ir::mir::MirExpr>, crate::ast::BinOp, i64, bool)>
+        binop: &'e crate::ir::mir::MirBinOp,
+    ) -> Option<(&'e crate::ast::Spanned<crate::ir::mir::MirExpr>, crate::ast::BinOp, i64, bool)>
     {
         if let Some(k) = mir_int_literal(&binop.rhs)
             && self.expr_is_int_param(&binop.lhs)
@@ -446,19 +594,39 @@ impl MirSymPlanBuilder<'_> {
         None
     }
 
-    fn expr_is_int_param(&self, expr: &crate::ast::Spanned<crate::ir::mir::MirExpr>) -> bool {
-        match &expr.node {
-            crate::ir::mir::MirExpr::Local(local) => self
-                .params_by_slot
-                .get(&local.node.slot.0)
-                .is_some_and(|(_, ty)| ty == &SymTy::Int),
-            _ => false,
+    /// Resolve a `Local` read through the single-use let-alias chain to the
+    /// param it terminates at. Only chains made of `Local` reads qualify: a
+    /// COMPUTED alias (any non-`Local` initializer) returns `None`. The two
+    /// callers require exactly that: the `intConstCmp` operand must be a
+    /// param read (PlanCheck's `isSymParam` — kernel-side, not adapter
+    /// courtesy), and the tag-match scrutinee is pinned by the wall face to
+    /// the param-0 local read.
+    fn resolve_local_chain_param(
+        &self,
+        expr: &crate::ast::Spanned<crate::ir::mir::MirExpr>,
+        hops: usize,
+    ) -> Option<(u32, SymTy)> {
+        if hops > MAX_ALIAS_RESOLUTION_DEPTH {
+            return None;
         }
+        let crate::ir::mir::MirExpr::Local(local) = &expr.node else {
+            return None;
+        };
+        if let Some(entry) = self.params_by_slot.get(&local.node.slot.0) {
+            return Some(entry.clone());
+        }
+        let init = self.aliases.get(&local.node.slot.0)?;
+        self.resolve_local_chain_param(init, hops + 1)
+    }
+
+    fn expr_is_int_param(&self, expr: &crate::ast::Spanned<crate::ir::mir::MirExpr>) -> bool {
+        self.resolve_local_chain_param(expr, 0)
+            .is_some_and(|(_, ty)| ty == SymTy::Int)
     }
 
     fn lower_int_const_cmp(
         &mut self,
-        operand: &crate::ast::Spanned<crate::ir::mir::MirExpr>,
+        operand: &'e crate::ast::Spanned<crate::ir::mir::MirExpr>,
         op: crate::ast::BinOp,
         k: i64,
         const_on_left: bool,
@@ -479,7 +647,7 @@ impl MirSymPlanBuilder<'_> {
         )
     }
 
-    fn lower_if(&mut self, ite: &crate::ir::mir::MirIfThenElse) -> Option<(SymValueId, SymTy)> {
+    fn lower_if(&mut self, ite: &'e crate::ir::mir::MirIfThenElse) -> Option<(SymValueId, SymTy)> {
         let (cond, cond_ty) = self.lower_expr(&ite.cond)?;
         if cond_ty != SymTy::Bool {
             return None;
@@ -489,6 +657,8 @@ impl MirSymPlanBuilder<'_> {
             params_by_slot: self.params_by_slot,
             record_fields: self.record_fields,
             builtins: self.builtins,
+            aliases: self.aliases.clone(),
+            alias_hops: self.alias_hops,
             nodes: Vec::new(),
         };
         let (then_root, then_ty) = then_builder.lower_expr(&ite.then_branch)?;
@@ -498,6 +668,8 @@ impl MirSymPlanBuilder<'_> {
             params_by_slot: self.params_by_slot,
             record_fields: self.record_fields,
             builtins: self.builtins,
+            aliases: self.aliases.clone(),
+            alias_hops: self.alias_hops,
             nodes: Vec::new(),
         };
         let (else_root, else_ty) = else_builder.lower_expr(&ite.else_branch)?;
@@ -519,16 +691,17 @@ impl MirSymPlanBuilder<'_> {
 
     fn lower_tag_match(
         &mut self,
-        m: &crate::ir::mir::MirMatch,
+        m: &'e crate::ir::mir::MirMatch,
     ) -> Option<(SymValueId, SymTy)> {
         if self.params_by_slot.len() != 1 || m.arms.len() != 2 {
             return None;
         }
-        let crate::ir::mir::MirExpr::Local(subject_local) = &m.subject.node else {
-            return None;
-        };
-        let (_, subject_ty) = self.params_by_slot.get(&subject_local.node.slot.0)?;
-        let (type_name, hit_ctor, miss_ctor, tag) = match subject_ty {
+        // The subject must resolve to THE single param — directly or through
+        // a single-use let-alias chain of `Local` reads (the wall face pins
+        // the encoded scrutinee to the param-0 local read, which is exactly
+        // what the aliased subject lowers back to in `push_tag_match`).
+        let (_, subject_ty) = self.resolve_local_chain_param(&m.subject, 0)?;
+        let (type_name, hit_ctor, miss_ctor, tag) = match &subject_ty {
             SymTy::App(name, args) if name == "Option" && args.len() == 1 => (
                 "Option",
                 crate::ir::hir::BuiltinCtor::OptionSome,
@@ -592,7 +765,7 @@ impl MirSymPlanBuilder<'_> {
 
     fn push_tag_match(
         &mut self,
-        subject: &crate::ast::Spanned<crate::ir::mir::MirExpr>,
+        subject: &'e crate::ast::Spanned<crate::ir::mir::MirExpr>,
         type_name: &str,
         tag: i32,
         hit: i64,
@@ -969,8 +1142,8 @@ mod tests {
     use crate::ir::hir::BuiltinCtor;
     use crate::ir::FnId;
     use crate::ir::mir::{
-        LocalId, MirBinOp, MirCtor, MirExpr, MirFn, MirFnRepr, MirLocal, MirMatch, MirMatchArm,
-        MirParam, MirPattern,
+        LocalId, MirBinOp, MirCtor, MirExpr, MirFn, MirFnRepr, MirIfThenElse, MirLet, MirLocal,
+        MirMatch, MirMatchArm, MirParam, MirPattern,
     };
 
     fn span<T>(node: T) -> Spanned<T> {
@@ -987,6 +1160,58 @@ mod tests {
 
     fn int_lit(value: i64) -> Spanned<MirExpr> {
         span(MirExpr::Literal(span(Literal::Int(value))))
+    }
+
+    fn bool_lit(value: bool) -> Spanned<MirExpr> {
+        span(MirExpr::Literal(span(Literal::Bool(value))))
+    }
+
+    fn binop(op: BinOp, lhs: Spanned<MirExpr>, rhs: Spanned<MirExpr>) -> Spanned<MirExpr> {
+        span(MirExpr::BinOp(span(MirBinOp {
+            op,
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
+        })))
+    }
+
+    fn let_expr(slot: u32, value: Spanned<MirExpr>, body: Spanned<MirExpr>) -> Spanned<MirExpr> {
+        span(MirExpr::Let(span(MirLet {
+            binding: LocalId(slot),
+            binding_name: "y".to_string(),
+            value: Box::new(value),
+            body: Box::new(body),
+        })))
+    }
+
+    fn if_expr(
+        cond: Spanned<MirExpr>,
+        then_branch: Spanned<MirExpr>,
+        else_branch: Spanned<MirExpr>,
+    ) -> Spanned<MirExpr> {
+        span(MirExpr::IfThenElse(span(MirIfThenElse {
+            cond: Box::new(cond),
+            then_branch: Box::new(then_branch),
+            else_branch: Box::new(else_branch),
+        })))
+    }
+
+    /// `fn f(x: Int) -> <return_type>` with an arbitrary body.
+    fn int_param_fn(return_type: &str, body: Spanned<MirExpr>, local_count: u32) -> MirFn {
+        MirFn {
+            fn_id: FnId(0),
+            name: "f".to_string(),
+            params: vec![MirParam {
+                local: LocalId(0),
+                name: "x".to_string(),
+                ty: "Int".to_string(),
+            }],
+            return_type: return_type.to_string(),
+            effects: vec![],
+            body,
+            local_count,
+            aliased_slots: std::sync::Arc::new(Vec::new()),
+            repr: MirFnRepr::default(),
+        }
     }
 
     fn float_local(slot: u32) -> Spanned<MirExpr> {
@@ -1408,6 +1633,181 @@ mod tests {
         // Control: the identical body with the default (all-boxed) repr plans.
         let boxed = int_predicate_fn(BinOp::Lt, int_local(0), int_lit(0));
         assert!(fragment_plan_from_mir_fn(&boxed, &|_, _| None, &[]).is_some());
+    }
+
+    /// `named(egg) = y = egg; match y { None -> 0; Some(_) -> 1 }`: the
+    /// let-renamed subject resolves through the alias chain back to the
+    /// single param, so the encoded scrutinee is still the param-0 read the
+    /// wall face pins.
+    fn let_renamed_option_match_fn() -> MirFn {
+        let m = span(MirExpr::Match(span(MirMatch {
+            subject: Box::new(int_local(2)),
+            arms: vec![
+                MirMatchArm {
+                    pattern: MirPattern::Ctor {
+                        ctor: MirCtor::Builtin(BuiltinCtor::OptionNone),
+                        bindings: vec![],
+                        binding_names: vec![],
+                    },
+                    body: int_lit(0),
+                },
+                MirMatchArm {
+                    pattern: MirPattern::Ctor {
+                        ctor: MirCtor::Builtin(BuiltinCtor::OptionSome),
+                        bindings: vec![LocalId(1)],
+                        binding_names: vec!["value".to_string()],
+                    },
+                    body: int_lit(1),
+                },
+            ],
+        })));
+        let mut mir_fn = option_slot_count_fn(int_lit(1));
+        mir_fn.body = let_expr(2, int_local(0), m);
+        mir_fn.local_count = 3;
+        mir_fn
+    }
+
+    #[test]
+    fn let_renamed_option_match_lowers_to_tag_dispatch() {
+        let mir_fn = let_renamed_option_match_fn();
+        let plan = fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).expect("tag plan");
+        let FragmentPlan::Sym(sym) = &plan else {
+            panic!("let-renamed Option tag match must remain a source symbolic plan")
+        };
+        assert!(matches!(sym.body.nodes[0].kind, SymNodeKind::Param { index: 0 }));
+        assert!(matches!(
+            &sym.body.nodes[1].kind,
+            SymNodeKind::TagMatch {
+                scrutinee: SymValueId(0),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn chained_let_renames_resolve_recursively() {
+        // `y = egg; z = y; match z { ... }` — two hops back to the param.
+        let mut mir_fn = let_renamed_option_match_fn();
+        let MirExpr::Let(spanned_let) = mir_fn.body.node else {
+            panic!("fixture body is a let")
+        };
+        let mut inner_match = *spanned_let.node.body;
+        let MirExpr::Match(m) = &mut inner_match.node else {
+            panic!("fixture let body is a match")
+        };
+        m.node.subject = Box::new(int_local(3));
+        mir_fn.body = let_expr(2, int_local(0), let_expr(3, int_local(2), inner_match));
+        mir_fn.local_count = 4;
+        let plan = fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).expect("tag plan");
+        let FragmentPlan::Sym(sym) = &plan else {
+            panic!("chained let renames must remain a source symbolic plan")
+        };
+        assert!(matches!(sym.body.nodes[0].kind, SymNodeKind::Param { index: 0 }));
+    }
+
+    #[test]
+    fn let_over_int_add_lowers_through_the_int_add_face() {
+        // `m = x + 2; m` — the single read of `m` re-lowers the initializer,
+        // producing exactly the straight-line integer face node order.
+        let body = let_expr(1, binop(BinOp::Add, int_local(0), int_lit(2)), int_local(1));
+        let mir_fn = int_param_fn("Int", body, 2);
+        let plan = fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).expect("plan");
+        let FragmentPlan::Sym(sym) = &plan else {
+            panic!("let over int add should use SymPlan")
+        };
+        assert!(matches!(sym.body.nodes[0].kind, SymNodeKind::Param { index: 0 }));
+        assert!(matches!(sym.body.nodes[1].kind, SymNodeKind::ConstInt(2)));
+        assert!(matches!(
+            sym.body.nodes[2].kind,
+            SymNodeKind::Prim {
+                op: SymPrim::IntAdd,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn let_bound_comparison_feeds_the_if_condition() {
+        // `isLow = x >= 48; if isLow { x <= 57 } else { false }` — the
+        // `inRangeNamed` shape after `bool_match_to_if`.
+        let body = let_expr(
+            1,
+            binop(BinOp::Gte, int_local(0), int_lit(48)),
+            if_expr(
+                int_local(1),
+                binop(BinOp::Lte, int_local(0), int_lit(57)),
+                bool_lit(false),
+            ),
+        );
+        let mir_fn = int_param_fn("Bool", body, 2);
+        let plan = fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).expect("plan");
+        let FragmentPlan::Sym(sym) = &plan else {
+            panic!("let-bound comparison should use SymPlan")
+        };
+        assert!(matches!(
+            sym.body.nodes[1].kind,
+            SymNodeKind::IntConstCmp {
+                op: SymIntCmp::Ge,
+                value: SymValueId(0),
+                constant: 48,
+            }
+        ));
+        assert!(matches!(sym.body.nodes[2].kind, SymNodeKind::If { cond: SymValueId(1), .. }));
+    }
+
+    #[test]
+    fn multi_use_let_binding_stays_unplanned() {
+        // `y = x; if y > 0 { y <= 5 } else { false }` — TWO reads of `y`
+        // (condition + then branch). Inlining would be semantically fine for
+        // a pure alias, but the single-use gate is the contract: refuse.
+        let body = let_expr(
+            1,
+            int_local(0),
+            if_expr(
+                binop(BinOp::Gt, int_local(1), int_lit(0)),
+                binop(BinOp::Lte, int_local(1), int_lit(5)),
+                bool_lit(false),
+            ),
+        );
+        let mir_fn = int_param_fn("Bool", body, 2);
+        assert!(
+            fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).is_none(),
+            "a let binding read more than once must stay unplanned"
+        );
+    }
+
+    #[test]
+    fn computed_alias_is_not_an_int_const_cmp_operand() {
+        // `y = x + 2; y > 0` — the alias chain terminates in a COMPUTED
+        // expression, not a param read. PlanCheck's `isSymParam` requires the
+        // comparison operand to be a param read, so the producer must refuse
+        // rather than emit a plan the kernel rejects.
+        let body = let_expr(
+            1,
+            binop(BinOp::Add, int_local(0), int_lit(2)),
+            binop(BinOp::Gt, int_local(1), int_lit(0)),
+        );
+        let mir_fn = int_param_fn("Bool", body, 2);
+        assert!(
+            fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).is_none(),
+            "a computed let alias must not become an intConstCmp operand"
+        );
+    }
+
+    #[test]
+    fn let_with_unplannable_initializer_stays_unplanned() {
+        // `y = -x; y > 0` — `Neg` has no plan lowering, so the use-site
+        // lowering of the initializer fails and the fn stays unplanned.
+        let body = let_expr(
+            1,
+            span(MirExpr::Neg(Box::new(int_local(0)))),
+            binop(BinOp::Gt, int_local(1), int_lit(0)),
+        );
+        let mir_fn = int_param_fn("Bool", body, 2);
+        assert!(
+            fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).is_none(),
+            "an unplannable initializer must keep the fn unplanned"
+        );
     }
 
     #[test]

--- a/src/codegen/cert/expr_fragment_from_mir.rs
+++ b/src/codegen/cert/expr_fragment_from_mir.rs
@@ -72,12 +72,29 @@ pub(crate) fn expr_fragment_plan_from_mir_fn(
     plan.to_expr_fragment_plan(&FragHostTable::placeholder(), &struct_table)
 }
 
+/// Fail-closed representation guard. The plan lowerer emits the ALL-BOXED
+/// representation: every Int value is a `$AverInt` carrier ref and every Int
+/// param read becomes a carrier `struct.get`. The wasm signature, however, is
+/// derived from `MirFnRepr` (`param_types_with_repr` / `return_results_with_repr`
+/// with `ENABLE_BARE_SLOTS` on), so a fn whose repr marks any bare param /
+/// return / let slot (or an ETAP-2 bare-carrier slot) carries scalar `i64`
+/// slots — a plan-emitted body over those slots would `struct.get` an `i64`,
+/// invalid wasm. Such functions must never plan; their MIR-emitted bodies
+/// already handle the bare representation.
+fn mir_fn_repr_is_all_boxed(mir_fn: &crate::ir::mir::MirFn) -> bool {
+    let repr = &mir_fn.repr;
+    !repr.bare_return
+        && repr.bare_slots.is_empty()
+        && repr.carrier_slots.is_empty()
+        && repr.bare_params.iter().all(|bare| !bare)
+}
+
 pub(crate) fn sym_plan_from_mir_fn(
     mir_fn: &crate::ir::mir::MirFn,
     record_fields: RecordFieldLookup,
     builtins: &[String],
 ) -> Option<SymPlan> {
-    if !mir_fn.effects.is_empty() {
+    if !mir_fn.effects.is_empty() || !mir_fn_repr_is_all_boxed(mir_fn) {
         return None;
     }
 
@@ -113,7 +130,7 @@ pub(crate) fn sym_plan_from_mir_fn(
 fn repr_expr_fragment_plan_from_mir_fn(
     mir_fn: &crate::ir::mir::MirFn,
 ) -> Option<ExprFragmentPlan> {
-    if !mir_fn.effects.is_empty() {
+    if !mir_fn.effects.is_empty() || !mir_fn_repr_is_all_boxed(mir_fn) {
         return None;
     }
 
@@ -1327,6 +1344,70 @@ mod tests {
             fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).is_none(),
             "projection over an unknown record layout must stay unplanned"
         );
+    }
+
+    /// Belt-and-braces representation guard: a fn whose `MirFnRepr` marks any
+    /// bare param / return / slot (or bare-carrier slot) must never plan —
+    /// with `ENABLE_BARE_SLOTS` its wasm signature carries scalar `i64` slots
+    /// where the plan lowerer would emit carrier `struct.get` reads (invalid
+    /// wasm).
+    ///
+    /// No end-to-end reproduction is constructible for exported plan-shaped
+    /// functions today, which is why this stays a unit test: the wasm-gc bare
+    /// analysis only marks a PARAM bare when `compute_bare_param_intervals`
+    /// derived a bound for it, and its final mapping yields `Some(interval)`
+    /// exclusively for params carrying a recognized equality-decrement
+    /// RECURRENCE (a non-top `guard_floor`, i.e. a self-tail-call counter —
+    /// see the "Phase A withholds it" comment in
+    /// `src/ir/mir/optimize/bare_i64.rs`). A body containing that self call
+    /// dies on the plan builder's `Call`/`TailCall` catch-all, so a
+    /// plan-shaped body and a bare param are mutually exclusive. `bare_return`
+    /// similarly requires the body's tail value to be bare-eligible
+    /// (recurrence arithmetic or a literal), and literal-Int bodies do not
+    /// plan. Verified empirically: exported `p > 0`-shaped fns keep boxed
+    /// `(ref $AverInt)` signatures with and without internal literal callers.
+    /// The guard exists so a future widening of the bare analysis degrades to
+    /// an unplanned fn instead of emitting invalid wasm.
+    #[test]
+    fn bare_repr_functions_never_plan() {
+        let bare_param = {
+            let mut mir_fn = int_predicate_fn(BinOp::Lt, int_local(0), int_lit(0));
+            mir_fn.repr.bare_params = vec![true];
+            mir_fn
+        };
+        let bare_return = {
+            let mut mir_fn = int_predicate_fn(BinOp::Lt, int_local(0), int_lit(0));
+            mir_fn.repr.bare_return = true;
+            mir_fn
+        };
+        let bare_slot = {
+            let mut mir_fn = int_predicate_fn(BinOp::Lt, int_local(0), int_lit(0));
+            mir_fn.repr.bare_slots.insert(LocalId(1));
+            mir_fn
+        };
+        let carrier_slot = {
+            let mut mir_fn = int_predicate_fn(BinOp::Lt, int_local(0), int_lit(0));
+            mir_fn.repr.carrier_slots.insert(LocalId(0));
+            mir_fn
+        };
+        for (case, mir_fn) in [
+            ("bare param", bare_param),
+            ("bare return", bare_return),
+            ("bare let slot", bare_slot),
+            ("bare carrier slot", carrier_slot),
+        ] {
+            assert!(
+                sym_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).is_none(),
+                "{case}: source plan must refuse a non-all-boxed repr"
+            );
+            assert!(
+                fragment_plan_from_mir_fn(&mir_fn, &|_, _| None, &[]).is_none(),
+                "{case}: representation plan must refuse a non-all-boxed repr"
+            );
+        }
+        // Control: the identical body with the default (all-boxed) repr plans.
+        let boxed = int_predicate_fn(BinOp::Lt, int_local(0), int_lit(0));
+        assert!(fragment_plan_from_mir_fn(&boxed, &|_, _| None, &[]).is_some());
     }
 
     #[test]

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -3210,6 +3210,69 @@ fn certify_let_named_shapes_certify_and_lake_build() {
     let _ = std::fs::remove_dir_all(&out_dir);
 }
 
+/// Arity-3 integer/Bool expression fragment through the audited generic
+/// bridge: three Int params, a branch on the first and a constant comparison
+/// of the second or third (three comparisons total — each adds a `by_cases`,
+/// so goal count stays at 2^3). The Lean wall is n-ary throughout
+/// (`FragParams.denote` right-nested products); this pins the renderer's
+/// generalized source model (`fun p => f p.1 p.2.1 p.2.2`) and product
+/// unpacking, and the package must close under lake.
+#[test]
+fn certify_arity_three_fragment_certifies_and_lake_builds() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("certify-arity3");
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/arity3.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("expected `aver compile --certify` to run");
+    assert!(
+        compile.status.success(),
+        "compile --certify arity3 failed:\n{}{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out_dir.join("cert").join("cert-manifest.json"))
+            .expect("cert-manifest.json exists"),
+    )
+    .expect("manifest is valid JSON");
+    let triple = manifest["certified"]
+        .as_array()
+        .expect("certified report is an array")
+        .iter()
+        .find(|entry| entry["name"] == "tripleCheck")
+        .unwrap_or_else(|| panic!("tripleCheck must certify: {manifest:#}"));
+    assert_eq!(triple["class"], "expr-fragment-v1");
+    let manifest_lean = std::fs::read_to_string(out_dir.join("cert").join("Manifest.lean"))
+        .expect("Manifest.lean exists");
+    assert!(
+        manifest_lean.contains("model := fun p => tripleCheck p.1 p.2.1 p.2.2"),
+        "arity-3 obligation must uncurry over the right-nested product:\n{manifest_lean}"
+    );
+    let certificate = std::fs::read_to_string(out_dir.join("cert").join("Certificate.lean"))
+        .expect("Certificate.lean exists");
+    assert!(
+        certificate.contains("rcases p with ⟨a0, a1, a2⟩"),
+        "arity-3 bridge must unpack the right-nested product domain:\n{certificate}"
+    );
+
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping arity3 lake build: `lake` not available");
+        let _ = std::fs::remove_dir_all(&out_dir);
+        return;
+    }
+    assert_certificate_target_builds(&out_dir.join("cert"), "arity-3 fragment");
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
 /// The s33 heap-type boundary: 16 nominal sum roots plus 46 user variant
 /// structs push the Int carrier to wasm type index 64, the first index whose
 /// signed s33 encoding (`c0 00`)

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -3142,6 +3142,74 @@ fn certify_adt_witness_shards_all_have_test_functions() {
     }
 }
 
+/// Single-use let-renamed certificate shapes: a let-renamed Option match
+/// (`named`), a let-named integer increment (`addTwoNamed`), and a let-named
+/// comparison feeding the branch (`inRangeNamed`). The MIR optimizer performs
+/// no copy propagation, so each keeps its `Let` node; the plan producer
+/// inlines the proven single-use binding at its use site. All three must
+/// certify as expression fragments and the emitted package must close under
+/// lake.
+#[test]
+fn certify_let_named_shapes_certify_and_lake_build() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("certify-letnamed");
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("tools/certkit/fixtures/letnamed.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("expected `aver compile --certify` to run");
+    assert!(
+        compile.status.success(),
+        "compile --certify letnamed failed:\n{}{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out_dir.join("cert").join("cert-manifest.json"))
+            .expect("cert-manifest.json exists"),
+    )
+    .expect("manifest is valid JSON");
+    let classes: BTreeMap<String, String> = manifest["certified"]
+        .as_array()
+        .expect("certified report is an array")
+        .iter()
+        .map(|entry| {
+            (
+                entry["name"].as_str().unwrap().to_string(),
+                entry["class"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    for name in ["named", "addTwoNamed", "inRangeNamed"] {
+        assert_eq!(
+            classes.get(name).map(String::as_str),
+            Some("expr-fragment-v1"),
+            "{name} must certify through the plan path; manifest classes: {classes:?}"
+        );
+    }
+    assert!(
+        manifest["source_level_only"]
+            .as_array()
+            .is_none_or(|declined| declined.is_empty()),
+        "no let-named shape may decline to source-level-only: {manifest:#}"
+    );
+
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping letnamed lake build: `lake` not available");
+        let _ = std::fs::remove_dir_all(&out_dir);
+        return;
+    }
+    assert_certificate_target_builds(&out_dir.join("cert"), "let-named shapes");
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
 /// The s33 heap-type boundary: 16 nominal sum roots plus 46 user variant
 /// structs push the Int carrier to wasm type index 64, the first index whose
 /// signed s33 encoding (`c0 00`)

--- a/tests/cert_decode_spec.rs
+++ b/tests/cert_decode_spec.rs
@@ -46,6 +46,7 @@ const FIXTURES: &[&str] = &[
 /// Full S1 transition corpus. Keep this explicit so adding a certkit fixture
 /// requires consciously extending the Rust-splice ↔ kernel-decode regression.
 const S1_FIXTURES: &[&str] = &[
+    "arity3",
     "cell_at",
     "cert_goals",
     "certempty",
@@ -56,6 +57,7 @@ const S1_FIXTURES: &[&str] = &[
     "compose",
     "f64verbatim",
     "intdispatchgen",
+    "letnamed",
     "manytypes",
     "meter",
     "mutual",

--- a/tests/wasm_gc_plan_mir_equivalence.rs
+++ b/tests/wasm_gc_plan_mir_equivalence.rs
@@ -54,13 +54,18 @@ fn letBoolGoal(a: Bool, b: Bool) -> Bool
         true -> b
         false -> false
 
+fn floatPickGoal(a: Float, b: Float, c: Float) -> Bool
+    match a <= b
+        true -> b <= c
+        false -> c <= a
+
 fn report() -> String
-    "le={floatLeGoal(1.0, 2.0)}/{floatLeGoal(3.0, 2.0)} and={boolAndGoal(true, true)}/{boolAndGoal(true, false)} let={letBoolGoal(true, true)}/{letBoolGoal(false, true)}"
+    "le={floatLeGoal(1.0, 2.0)}/{floatLeGoal(3.0, 2.0)} and={boolAndGoal(true, true)}/{boolAndGoal(true, false)} let={letBoolGoal(true, true)}/{letBoolGoal(false, true)} pick={floatPickGoal(1.0, 2.0, 3.0)}/{floatPickGoal(3.0, 2.0, 4.0)}"
 "#;
 
 /// The report line both variants print. Bool-valued throughout, so the text is
 /// format-stable (no float-rendering ambiguity to reason about).
-const EXPECTED_REPORT: &str = "le=true/false and=true/false let=true/false";
+const EXPECTED_REPORT: &str = "le=true/false and=true/false let=true/false pick=true/false";
 
 /// Variant (A): the shared float/bool functions in a module that ALSO declares
 /// Int (via `unrelatedInt`), which flips the `$AverInt` carrier on and routes
@@ -71,7 +76,7 @@ fn variant_a_source() -> String {
     format!(
         r#"module PlanCarrierOn
     intent = "plan-emitted float/bool functions in a module that also declares Int"
-    exposes [floatLeGoal, boolAndGoal, letBoolGoal]
+    exposes [floatLeGoal, boolAndGoal, letBoolGoal, floatPickGoal]
     effects [Console]
 {SHARED_BODY}
 fn unrelatedInt(x: Int) -> Int
@@ -221,7 +226,7 @@ fn plan_and_mir_emitters_agree_on_float_bool_functions() {
 #[test]
 fn variant_a_functions_take_the_plan_path() {
     let manifest = certify_manifest("plan-carrier-certify", &variant_a_source());
-    for name in ["floatLeGoal", "boolAndGoal", "letBoolGoal"] {
+    for name in ["floatLeGoal", "boolAndGoal", "letBoolGoal", "floatPickGoal"] {
         assert_eq!(
             certified_class(&manifest, name),
             Some("expr-fragment-v1"),

--- a/tests/wasm_gc_plan_mir_equivalence.rs
+++ b/tests/wasm_gc_plan_mir_equivalence.rs
@@ -48,13 +48,19 @@ fn boolAndGoal(a: Bool, b: Bool) -> Bool
         true -> b
         false -> false
 
+fn letBoolGoal(a: Bool, b: Bool) -> Bool
+    c = a
+    match c
+        true -> b
+        false -> false
+
 fn report() -> String
-    "le={floatLeGoal(1.0, 2.0)}/{floatLeGoal(3.0, 2.0)} and={boolAndGoal(true, true)}/{boolAndGoal(true, false)}"
+    "le={floatLeGoal(1.0, 2.0)}/{floatLeGoal(3.0, 2.0)} and={boolAndGoal(true, true)}/{boolAndGoal(true, false)} let={letBoolGoal(true, true)}/{letBoolGoal(false, true)}"
 "#;
 
 /// The report line both variants print. Bool-valued throughout, so the text is
 /// format-stable (no float-rendering ambiguity to reason about).
-const EXPECTED_REPORT: &str = "le=true/false and=true/false";
+const EXPECTED_REPORT: &str = "le=true/false and=true/false let=true/false";
 
 /// Variant (A): the shared float/bool functions in a module that ALSO declares
 /// Int (via `unrelatedInt`), which flips the `$AverInt` carrier on and routes
@@ -65,7 +71,7 @@ fn variant_a_source() -> String {
     format!(
         r#"module PlanCarrierOn
     intent = "plan-emitted float/bool functions in a module that also declares Int"
-    exposes [floatLeGoal, boolAndGoal]
+    exposes [floatLeGoal, boolAndGoal, letBoolGoal]
     effects [Console]
 {SHARED_BODY}
 fn unrelatedInt(x: Int) -> Int
@@ -215,7 +221,7 @@ fn plan_and_mir_emitters_agree_on_float_bool_functions() {
 #[test]
 fn variant_a_functions_take_the_plan_path() {
     let manifest = certify_manifest("plan-carrier-certify", &variant_a_source());
-    for name in ["floatLeGoal", "boolAndGoal"] {
+    for name in ["floatLeGoal", "boolAndGoal", "letBoolGoal"] {
         assert_eq!(
             certified_class(&manifest, name),
             Some("expr-fragment-v1"),

--- a/tools/certkit/fixtures/arity3.av
+++ b/tools/certkit/fixtures/arity3.av
@@ -1,0 +1,15 @@
+module Arity3Probe
+    intent =
+        "Probe: three-parameter Bool fragment for the generic bridge."
+    exposes [tripleCheck]
+
+fn tripleCheck(a: Int, b: Int, c: Int) -> Bool
+  ? "Branch on a, compare b or c against constants."
+  match a > 0
+    true -> b > 1
+    false -> c > 2
+
+verify tripleCheck
+    tripleCheck(1, 2, 0) => true
+    tripleCheck(0, 0, 3) => true
+    tripleCheck(0, 0, 0) => false

--- a/tools/certkit/fixtures/letnamed.av
+++ b/tools/certkit/fixtures/letnamed.av
@@ -1,0 +1,38 @@
+module LetNamed
+    intent =
+        "Single-use let-renamed certificate shapes: a renamed Option match,"
+        "a named integer increment, and a named range comparison."
+    exposes [named, addTwoNamed, inRangeNamed]
+
+fn named(o: Option<Int>) -> Int
+  ? "Let-renamed Option match with literal arms."
+  y = o
+  match y
+    Option.Some(v) -> 1
+    Option.None -> 0
+
+fn addTwoNamed(n: Int) -> Int
+  ? "Let-named integer increment by two."
+  m = n + 2
+  m
+
+fn inRangeNamed(c: Int) -> Bool
+  ? "Let-named lower-bound comparison feeding the branch."
+  isLow = c >= 48
+  match isLow
+    true -> c <= 57
+    false -> false
+
+verify named
+    named(Option.Some(9)) => 1
+    named(Option.None) => 0
+
+verify addTwoNamed
+    addTwoNamed(1) => 3
+    addTwoNamed(-2) => 0
+
+verify inRangeNamed
+    inRangeNamed(48) => true
+    inRangeNamed(57) => true
+    inRangeNamed(58) => false
+    inRangeNamed(47) => false


### PR DESCRIPTION
Four producer-side changes; the Lean wall is untouched (zero files under aver-cert/assets/wall/).

- Refuse fragment plans for functions whose parameters, return value, or locals use the bare i64 representation. The plan lowerer assumes carrier structs; on a bare signature it would emit invalid wasm. Not reachable end-to-end today (bare promotion requires a self-recursive shape that plan bodies cannot have), so this is a fail-closed guard with a unit test documenting why.
- Inline single-use let bindings when building fragment plans. `y = o; match y { ... }` now produces the same plan as `match o { ... }`. Strictly limited: exactly one use counting nested blocks, initializer must itself be planable, comparison operands must still resolve to a parameter read, multi-use bindings stay unplanned.
- Render the generic fragment bridge for any source arity. Previously two `panic!`s fired at arity 3+; `aver compile --certify` crashed on an exported three-parameter Int/Bool function. The Lean side was already arity-generic.
- Enforce the kernel's plan-block shape invariants (contiguous node ids, root last) in the producer's `finish`, so future producer bugs degrade to uncertified instead of failing late in the kernel.

Verification: both new fixture packages fully replay in the kernel (`aver cert verify`: letnamed 3 certified exports, arity3 1 certified export); plan-vs-MIR equivalence suite extended with the new shapes; 9 new producer unit tests incl. negatives (multi-use let, computed comparison operand, payload binder, bare-slot guard); goal matrix and MIR floors unchanged; spot-checked example packages byte-identical; fmt and clippy clean on the CI feature matrix.