### PR TITLE
Cite model definitions by their qualified Lean name

### DIFF
--- a/aver-cert/src/engine/analysis.rs
+++ b/aver-cert/src/engine/analysis.rs
@@ -231,6 +231,21 @@ pub fn analyze_with_fragment_plans(
     }
     let certs = gated_certs;
 
+    // Qualified-model-name gate: every class whose generated Lean cites the
+    // source model by name must resolve that name to the identifier that
+    // actually exists in the emitted model module — the export name itself at
+    // entry level, the dotted namespace form for a dependency-module function.
+    // An export whose citation cannot be derived declines here (fail-closed)
+    // instead of rendering a name Lean would reject.
+    let mut named_certs = Vec::new();
+    for c in certs {
+        match model_citation_gate(&c, &model_info) {
+            Ok(()) => named_certs.push(c),
+            Err(reason) => declined.push((c.name().to_string(), reason)),
+        }
+    }
+    let certs = named_certs;
+
     // Named runtime contracts actually consumed by the certified functions.
     let contracts = runtime_contracts_for_certs(&certs);
     let certified = certs
@@ -249,6 +264,50 @@ pub fn analyze_with_fragment_plans(
         string_host_roles,
         declared_envelopes,
     })
+}
+
+/// Every export name this certificate's renderers cite as a MODEL identifier
+/// in generated Lean. Classes that cite no model function (verbatim packs,
+/// field projections, string leaves, envelope-modeled dispatch/constructors,
+/// plan-modeled fragments) require nothing here; their per-class lookups
+/// already skip or decline on a miss.
+fn model_citation_names(c: &Cert) -> Vec<String> {
+    match c.inner() {
+        Cert::Recursive { name, .. } | Cert::AccumulatorRecursive { name, .. } => {
+            vec![name.clone()]
+        }
+        // The bridge's simultaneous fuel induction cites EVERY member's model.
+        Cert::MutualRecursion { scc, .. } => {
+            scc.iter().map(|member| member.name.clone()).collect()
+        }
+        // The composition model and its simp set cite the root and every
+        // closure member.
+        Cert::Composition { name, closure, .. } => std::iter::once(name.clone())
+            .chain(closure.iter().map(|entry| entry.name.clone()))
+            .collect(),
+        // Audited integer/Bool fragments (including the straight-line add
+        // face) state `model := <source fn>`; plan-modeled (float) fragments
+        // cite no model name.
+        Cert::ExprFragment { name, .. }
+            if expr_fragment_uses_audited_generic(c) || c.int_add_face().is_some() =>
+        {
+            vec![name.clone()]
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Fail-closed: decline any cert whose model citation cannot be derived.
+fn model_citation_gate(c: &Cert, model_info: &ModelInfo) -> Result<(), String> {
+    for name in model_citation_names(c) {
+        if model_info.model_lean_name(&name).is_none() {
+            return Err(format!(
+                "model identifier for `{name}` cannot be resolved to a definition \
+                 in the emitted Lean model; declined"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn has_complete_artifact_plan(

--- a/aver-cert/src/engine/cert_methods.rs
+++ b/aver-cert/src/engine/cert_methods.rs
@@ -193,9 +193,13 @@ impl Cert {
         }
     }
     /// The qualified Lean identifier of this export's source model function.
-    /// Only valid for certs that passed the analysis qualified-name gate;
-    /// citing a name the gate did not resolve would be a guess, so this
-    /// panics (producer bug) instead of emitting one.
+    ///
+    /// Only valid for a cert that passed `model_citation_gate` against THIS
+    /// `model_info` — `analyze` applies that gate to every cert it keeps, and
+    /// `write_project` re-checks it before rendering anything, so a resolution
+    /// failure here is a producer bug rather than a certificate that should
+    /// decline. Citing an unresolved name would be a guess, so this panics
+    /// instead of emitting one.
     fn model_lean_name(&self, model_info: &ModelInfo) -> String {
         model_info
             .model_lean_name(self.name())

--- a/aver-cert/src/engine/cert_methods.rs
+++ b/aver-cert/src/engine/cert_methods.rs
@@ -192,19 +192,31 @@ impl Cert {
             Cert::NonRecursive { .. } => unreachable!(),
         }
     }
+    /// The qualified Lean identifier of this export's source model function.
+    /// Only valid for certs that passed the analysis qualified-name gate;
+    /// citing a name the gate did not resolve would be a guess, so this
+    /// panics (producer bug) instead of emitting one.
+    fn model_lean_name(&self, model_info: &ModelInfo) -> String {
+        model_info
+            .model_lean_name(self.name())
+            .expect("model-citing certificate passed the qualified-name gate")
+    }
     /// The Lean expression for the model this export simulates.
-    fn model_expr(&self) -> String {
+    fn model_expr(&self, model_info: &ModelInfo) -> String {
         if let Some(face) = self.int_add_face() {
             return format!("fun ns => ns.headD 0 + ({})", face.k);
         }
         match self.inner() {
-            Cert::Recursive { name, .. }
-            | Cert::Composition { name, .. }
-            | Cert::MutualRecursion { name, .. } => {
-                format!("fun ns => {name} (ns.headD 0)")
+            Cert::Recursive { .. }
+            | Cert::Composition { .. }
+            | Cert::MutualRecursion { .. } => {
+                format!("fun ns => {} (ns.headD 0)", self.model_lean_name(model_info))
             }
-            Cert::AccumulatorRecursive { name, .. } => {
-                format!("fun ns => {name} (ns.headD 0) ((ns.drop 1).headD 0)")
+            Cert::AccumulatorRecursive { .. } => {
+                format!(
+                    "fun ns => {} (ns.headD 0) ((ns.drop 1).headD 0)",
+                    self.model_lean_name(model_info)
+                )
             }
             Cert::AdtConstructor { .. }
             | Cert::FieldProjection { .. }
@@ -316,11 +328,20 @@ impl Cert {
             | Cert::StringConcatVerbatimMatch { .. } => ("WVal".to_string(), "WVal".to_string()),
             Cert::ExprFragment { plan, .. } => (plan.source_dom(), plan.source_cod()),
             Cert::VariantDispatch { name, .. } | Cert::WidenedIntMatch { name, .. } => {
+                // Display the qualified inductive name when the written type
+                // resolves (identity for entry-level models).
                 let dom = model_info
                     .fns
                     .get(name)
-                    .and_then(|s| s.params.first())
-                    .map(|s| ascii(s))
+                    .and_then(|s| {
+                        s.params.first().map(|written| {
+                            model_info
+                                .resolve_inductive(&s.prefix, written)
+                                .map(|(qualified, _)| qualified)
+                                .unwrap_or_else(|| written.clone())
+                        })
+                    })
+                    .map(|s| ascii(&s))
                     .unwrap_or_else(|| "Op".to_string());
                 (dom, "Int".to_string())
             }
@@ -329,7 +350,13 @@ impl Cert {
                     let cod = model_info
                         .fns
                         .get(self.name())
-                        .map(|s| ascii(&s.ret))
+                        .map(|s| {
+                            model_info
+                                .resolve_inductive(&s.prefix, &s.ret)
+                                .map(|(qualified, _)| qualified)
+                                .unwrap_or_else(|| s.ret.clone())
+                        })
+                        .map(|s| ascii(&s))
                         .unwrap_or_else(|| "Unit".to_string());
                     ("Int".to_string(), cod)
                 } else {

--- a/aver-cert/src/engine/classify_model.rs
+++ b/aver-cert/src/engine/classify_model.rs
@@ -85,9 +85,18 @@ fn parse_body_step(
 /// uses `-`, so it never
 /// confuses the scan; the recognised body shapes carry no other arithmetic.
 fn model_step_ops(model_files: &[(String, String)]) -> std::collections::HashMap<String, char> {
-    let mut ops = std::collections::HashMap::new();
+    // Flat key -> (qualified name that claimed it, combinator operator).
+    let mut ops: std::collections::HashMap<String, (String, char)> =
+        std::collections::HashMap::new();
+    // Flat keys claimed by two different definitions. This parser must agree
+    // with `ModelInfo::parse_lean`: a collision makes the combinator a guess,
+    // so the key is dropped and the recursion classifier declines rather than
+    // reading the operator off whichever definition happened to parse last.
+    let mut ambiguous = std::collections::HashSet::new();
     for (path, content) in model_files {
-        if !path.ends_with(".lean") {
+        // Same user-only file predicate as `ModelInfo::from_files`: the
+        // prelude defines no user model and must not claim flat keys.
+        if !is_user_model_file(path) {
             continue;
         }
         let lines: Vec<&str> = content.lines().collect();
@@ -116,12 +125,19 @@ fn model_step_ops(model_files: &[(String, String)]) -> std::collections::HashMap
             let Some(fuel_pos) = rest.find("__fuel ") else {
                 continue;
             };
-            let flat_prefix = ns_stack.join(".").replace('.', "_");
-            let name = if flat_prefix.is_empty() {
-                rest[..fuel_pos].to_string()
+            let prefix = ns_stack.join(".");
+            let bare = &rest[..fuel_pos];
+            // The qualified Lean name identifies the definition; the flat name
+            // is the wasm-export-space key the classifier looks up.
+            let qualified = if prefix.is_empty() {
+                bare.to_string()
             } else {
-                format!("{flat_prefix}_{}", &rest[..fuel_pos])
+                format!("{prefix}.{bare}")
             };
+            let name = qualified.replace('.', "_");
+            if ambiguous.contains(&name) {
+                continue;
+            }
             for l in lines.iter().skip(i).take(8) {
                 if let Some(p) = l.find("else ") {
                     let els = &l[p + 5..];
@@ -133,12 +149,24 @@ fn model_step_ops(model_files: &[(String, String)]) -> std::collections::HashMap
                         None
                     };
                     if let Some(op) = op {
-                        ops.insert(name.clone(), op);
+                        match ops.get(&name) {
+                            // Two DISTINCT definitions flattening onto one key:
+                            // drop it so no combinator is guessed.
+                            Some((existing, _)) if *existing != qualified => {
+                                ops.remove(&name);
+                                ambiguous.insert(name.clone());
+                            }
+                            _ => {
+                                ops.insert(name.clone(), (qualified.clone(), op));
+                            }
+                        }
                     }
                     break;
                 }
             }
         }
     }
-    ops
+    ops.into_iter()
+        .map(|(name, (_, op))| (name, op))
+        .collect()
 }

--- a/aver-cert/src/engine/classify_model.rs
+++ b/aver-cert/src/engine/classify_model.rs
@@ -91,14 +91,37 @@ fn model_step_ops(model_files: &[(String, String)]) -> std::collections::HashMap
             continue;
         }
         let lines: Vec<&str> = content.lines().collect();
+        // Track the namespace stack exactly like `ModelInfo::parse_lean`, so
+        // a dependency module's `X__fuel` is keyed by its FLAT export-space
+        // name (`Prefix_X`) and the classifier's export-name lookup hits it.
+        let mut ns_stack: Vec<String> = Vec::new();
         for i in 0..lines.len() {
-            let Some(rest) = lines[i].trim().strip_prefix("def ") else {
+            let line = lines[i].trim();
+            if let Some(rest) = line.strip_prefix("namespace ")
+                && let Some(ns) = rest.split_whitespace().next()
+                && rest.trim() == ns
+            {
+                ns_stack.push(ns.to_string());
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix("end ")
+                && ns_stack.last().map(String::as_str) == Some(rest.trim())
+            {
+                ns_stack.pop();
+                continue;
+            }
+            let Some(rest) = line.strip_prefix("def ") else {
                 continue;
             };
             let Some(fuel_pos) = rest.find("__fuel ") else {
                 continue;
             };
-            let name = rest[..fuel_pos].to_string();
+            let flat_prefix = ns_stack.join(".").replace('.', "_");
+            let name = if flat_prefix.is_empty() {
+                rest[..fuel_pos].to_string()
+            } else {
+                format!("{flat_prefix}_{}", &rest[..fuel_pos])
+            };
             for l in lines.iter().skip(i).take(8) {
                 if let Some(p) = l.find("else ") {
                     let els = &l[p + 5..];

--- a/aver-cert/src/engine/model_eval.rs
+++ b/aver-cert/src/engine/model_eval.rs
@@ -40,11 +40,30 @@ fn eval_accumulator(n: i64, acc: i64) -> i64 {
 
 #[derive(Default)]
 struct ModelInfo {
+    /// Keyed by the FLAT (wasm-export-space) name: for a def inside
+    /// `namespace P` the key is `P` with dots replaced by underscores,
+    /// joined to the bare name with `_` — exactly the compiler's dependency
+    /// flattening. Entry-level defs are keyed by their bare name unchanged.
     fns: std::collections::HashMap<String, FnSig>,
+    /// Keyed by the QUALIFIED Lean name (`P.Ty` inside `namespace P`, the
+    /// bare name at entry level).
     inductives: std::collections::HashMap<String, InductiveInfo>,
+    /// Flat forms (dots replaced by underscores) of every namespace the model
+    /// files open. An export name shaped like `<prefix>_<rest>` for one of
+    /// these prefixes MAY be a dependency-module function, so its Lean
+    /// identifier can never be assumed to be the export name itself.
+    module_prefix_flats: Vec<String>,
+    /// Flat keys claimed by two DIFFERENT qualified names. A lookup on such a
+    /// key must fail (fail-closed): citing either candidate would be a guess.
+    ambiguous: std::collections::HashSet<String>,
 }
 
 struct FnSig {
+    /// Fully qualified Lean identifier of this def (equals the bare name at
+    /// entry level, `P.name` inside `namespace P`).
+    lean_name: String,
+    /// Dotted namespace prefix the def was parsed under (empty at entry level).
+    prefix: String,
     params: Vec<String>,
     ret: String,
 }
@@ -70,15 +89,89 @@ impl ModelInfo {
         info
     }
 
+    /// The Lean identifier the generated certificate must cite for the model
+    /// of export `name`, or `None` when it cannot be derived (then the export
+    /// must decline rather than cite a guess).
+    ///
+    /// - A parsed model def with this flat key resolves to its qualified name
+    ///   (identity for entry-level defs).
+    /// - Two distinct defs flattening to the same key are ambiguous: `None`.
+    /// - With no parsed def, the export name itself is citable only when no
+    ///   model namespace flattens to a prefix of it — otherwise the export may
+    ///   be a dependency-module function whose bare-underscore name does not
+    ///   exist in Lean, so `None`.
+    fn model_lean_name(&self, name: &str) -> Option<String> {
+        if self.ambiguous.contains(name) {
+            return None;
+        }
+        if let Some(sig) = self.fns.get(name) {
+            return Some(sig.lean_name.clone());
+        }
+        let may_be_dep_fn = self.module_prefix_flats.iter().any(|prefix| {
+            name.len() > prefix.len() + 1
+                && name.starts_with(prefix.as_str())
+                && name.as_bytes()[prefix.len()] == b'_'
+        });
+        if may_be_dep_fn {
+            None
+        } else {
+            Some(name.to_string())
+        }
+    }
+
+    /// Resolve a type name AS WRITTEN in a model def signature (relative to
+    /// that def's namespace) to the qualified inductive it denotes: first in
+    /// the def's own namespace, then as a fully qualified / entry-level name.
+    fn resolve_inductive<'a>(
+        &'a self,
+        prefix: &str,
+        written: &str,
+    ) -> Option<(String, &'a InductiveInfo)> {
+        if !prefix.is_empty() {
+            let qualified = format!("{prefix}.{written}");
+            if let Some(ind) = self.inductives.get(&qualified) {
+                return Some((qualified, ind));
+            }
+        }
+        self.inductives
+            .get(written)
+            .map(|ind| (written.to_string(), ind))
+    }
+
     fn parse_lean(&mut self, content: &str) {
         let lines: Vec<&str> = content.lines().collect();
+        // Namespace stack: `namespace X` pushes (X may be dotted), a matching
+        // `end X` pops. A bare `end` (a `mutual` block) never pops.
+        let mut ns_stack: Vec<String> = Vec::new();
         let mut i = 0usize;
         while i < lines.len() {
             let line = lines[i].trim();
+            if let Some(rest) = line.strip_prefix("namespace ")
+                && let Some(name) = rest.split_whitespace().next()
+                && rest.trim() == name
+            {
+                ns_stack.push(name.to_string());
+                let prefix = ns_stack.join(".");
+                let flat = prefix.replace('.', "_");
+                if !self.module_prefix_flats.contains(&flat) {
+                    self.module_prefix_flats.push(flat);
+                }
+                i += 1;
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix("end ")
+                && ns_stack.last().map(String::as_str) == Some(rest.trim())
+            {
+                ns_stack.pop();
+                i += 1;
+                continue;
+            }
+            let prefix = ns_stack.join(".");
             if let Some(name) = line
                 .strip_prefix("inductive ")
                 .and_then(|s| s.split_whitespace().next())
             {
+                let qualified = qualify(&prefix, name);
                 i += 1;
                 let mut ctors = Vec::new();
                 while i < lines.len() {
@@ -105,22 +198,49 @@ impl ModelInfo {
                     });
                     i += 1;
                 }
-                self.inductives
-                    .insert(name.to_string(), InductiveInfo { ctors });
+                self.inductives.insert(qualified, InductiveInfo { ctors });
                 continue;
             }
             if line.starts_with("def ")
                 && line.contains(" : ")
                 && line.ends_with(":=")
-                && let Some((name, sig)) = parse_def_sig(line)
+                && let Some((name, mut sig)) = parse_def_sig(line)
             {
-                self.fns.insert(name, sig);
+                let qualified = qualify(&prefix, &name);
+                let flat = qualified.replace('.', "_");
+                sig.lean_name = qualified;
+                sig.prefix = prefix.clone();
+                if self.ambiguous.contains(&flat) {
+                    i += 1;
+                    continue;
+                }
+                match self.fns.get(&flat) {
+                    Some(existing) if existing.lean_name != sig.lean_name => {
+                        // Two distinct qualified names collide on one flat
+                        // key: neither may ever resolve (fail-closed).
+                        self.fns.remove(&flat);
+                        self.ambiguous.insert(flat);
+                    }
+                    _ => {
+                        self.fns.insert(flat, sig);
+                    }
+                }
             }
             i += 1;
         }
     }
 }
 
+fn qualify(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_string()
+    } else {
+        format!("{prefix}.{name}")
+    }
+}
+
+/// Parse one single-line def signature. `lean_name`/`prefix` are filled by the
+/// caller, which knows the namespace the line was parsed under.
 fn parse_def_sig(line: &str) -> Option<(String, FnSig)> {
     let rest = line.strip_prefix("def ")?;
     let name = rest.split_whitespace().next()?.to_string();
@@ -155,5 +275,13 @@ fn parse_def_sig(line: &str) -> Option<(String, FnSig)> {
         }
         tail = &after[end + 1..];
     }
-    Some((name, FnSig { params, ret }))
+    Some((
+        name.clone(),
+        FnSig {
+            lean_name: name,
+            prefix: String::new(),
+            params,
+            ret,
+        },
+    ))
 }

--- a/aver-cert/src/engine/model_eval.rs
+++ b/aver-cert/src/engine/model_eval.rs
@@ -77,11 +77,28 @@ struct CtorInfo {
     fields: Vec<String>,
 }
 
+/// The compiler prelude, emitted into every model tree alongside the user's
+/// own modules (`AverCommon.lean` plus the build files). It carries its own
+/// namespaces (`AverString`, `AverMap`, `AverFloat`, …) and dotted top-level
+/// defs (`String.charAtAv`, `Float.fromInt`, …), none of which is ever a user
+/// export's model.
+///
+/// Reading it into the name space would be actively wrong, not just noisy:
+/// its namespaces would populate `module_prefix_flats` even for a program with
+/// no dependency modules at all, and a user export whose name happens to
+/// collide with a prelude def's flattened key (`AverList_get`) would be marked
+/// ambiguous and DECLINE. The certificate cites only user models, so only user
+/// model files may define the name space.
+fn is_user_model_file(path: &str) -> bool {
+    path.ends_with(".lean") && path != "AverCommon.lean" && path != "lakefile.lean"
+}
+
 impl ModelInfo {
+    /// Parse the USER model modules only — see `is_user_model_file`.
     fn from_files(model_files: &[(String, String)]) -> Self {
         let mut info = Self::default();
         for (path, content) in model_files {
-            if !path.ends_with(".lean") {
+            if !is_user_model_file(path) {
                 continue;
             }
             info.parse_lean(content);
@@ -284,4 +301,94 @@ fn parse_def_sig(line: &str) -> Option<(String, FnSig)> {
             ret,
         },
     ))
+}
+
+#[cfg(test)]
+mod model_name_space_tests {
+    /// A single-file (no dependency module) program's model tree still ships
+    /// the compiler prelude, which carries its own namespaces and dotted
+    /// top-level defs. None of it may enter the name space: a flat program has
+    /// no module prefixes at all, so every export resolves to itself.
+    #[test]
+    fn prelude_namespaces_stay_out_of_the_flat_key_space() {
+        // Abridged from a real `AverCommon.lean`: a namespace block and the
+        // dotted top-level defs the prelude actually emits.
+        let prelude = "\
+def String.charAtAv (s : String) (i : Int) : Option String :=\n\
+  none\n\
+namespace AverList\n\
+def get (xs : List Int) (i : Int) : Int :=\n\
+  0\n\
+end AverList\n\
+namespace AverMap\n\
+def get (m : Int) (k : Int) : Int :=\n\
+  0\n\
+end AverMap\n";
+        let entry = "\
+def addTwo (n : Int) : Int :=\n\
+  n + 2\n";
+        let info = super::ModelInfo::from_files(&[
+            ("AverCommon.lean".to_string(), prelude.to_string()),
+            ("lakefile.lean".to_string(), "import Lake\n".to_string()),
+            ("Program.lean".to_string(), entry.to_string()),
+        ]);
+
+        assert!(
+            info.module_prefix_flats.is_empty(),
+            "a program with no dependency modules must have no module prefixes, got {:?}",
+            info.module_prefix_flats
+        );
+        assert!(
+            info.ambiguous.is_empty(),
+            "the prelude must not make any key ambiguous, got {:?}",
+            info.ambiguous
+        );
+        for prelude_key in ["AverList_get", "AverMap_get", "String_charAtAv"] {
+            assert!(
+                !info.fns.contains_key(prelude_key),
+                "prelude def leaked into the flat key space as `{prelude_key}`"
+            );
+        }
+        assert_eq!(
+            info.model_lean_name("addTwo").as_deref(),
+            Some("addTwo"),
+            "an entry-level export resolves to itself"
+        );
+        // The regression this guards: an export colliding with a prelude def's
+        // flattened key must still resolve, not decline as ambiguous.
+        assert_eq!(
+            info.model_lean_name("AverList_get").as_deref(),
+            Some("AverList_get"),
+            "a flat export must not be shadowed by a prelude namespace"
+        );
+    }
+
+    /// A real dependency module DOES define the name space: its namespace is a
+    /// module prefix, and its functions resolve to their qualified names.
+    #[test]
+    fn dependency_module_namespaces_define_the_flat_key_space() {
+        let dep = "\
+namespace Nested.Deep.Util\n\
+def bump (n : Int) : Int :=\n\
+  n + 2\n\
+end Nested.Deep.Util\n";
+        let info = super::ModelInfo::from_files(&[
+            ("AverCommon.lean".to_string(), "def unrelated : Int := 0\n".to_string()),
+            ("Nested/Deep/Util.lean".to_string(), dep.to_string()),
+        ]);
+
+        assert_eq!(info.module_prefix_flats, vec!["Nested_Deep_Util".to_string()]);
+        assert_eq!(
+            info.model_lean_name("Nested_Deep_Util_bump").as_deref(),
+            Some("Nested.Deep.Util.bump"),
+            "a dependency-module export resolves to its qualified name"
+        );
+        // Fail-closed: an export shaped like this module's prefix but with no
+        // parsed definition must NOT fall back to citing itself.
+        assert_eq!(
+            info.model_lean_name("Nested_Deep_Util_missing"),
+            None,
+            "an unresolvable dependency-shaped export must decline"
+        );
+    }
 }

--- a/aver-cert/src/engine/render_certificate.rs
+++ b/aver-cert/src/engine/render_certificate.rs
@@ -1,7 +1,7 @@
 fn render_certificate(
     analysis: &Analysis,
     model_roots: &[String],
-    _model_info: &ModelInfo,
+    model_info: &ModelInfo,
 ) -> String {
     let mut s = String::new();
     s.push_str(
@@ -32,10 +32,10 @@ fn render_certificate(
             Cert::Recursive { .. } | Cert::AccumulatorRecursive { .. }
                 if recursion_uses_audited_generic(c) =>
             {
-                s.push_str(&render_recursion_semantic_bridge(c))
+                s.push_str(&render_recursion_semantic_bridge(c, model_info))
             }
             Cert::Recursive { .. } | Cert::AccumulatorRecursive { .. } => {
-                s.push_str(&render_fueled_recursion_cert(c))
+                s.push_str(&render_fueled_recursion_cert(c, model_info))
             }
             // Constructor packs (verbatim and named-ADT) are discharged in
             // `Final.cert`: verbatim packs by the canonical option-(c) leaf,
@@ -55,6 +55,7 @@ fn render_certificate(
                     c,
                     analysis.frag_host_table,
                     &struct_table_lean,
+                    model_info,
                 ))
             }
             Cert::ExprFragment { .. } => s.push_str(&render_expr_fragment_cert(c)),
@@ -65,9 +66,11 @@ fn render_certificate(
             | Cert::StringEqVerbatimMatch { .. }
             | Cert::StringConcatVerbatimMatch { .. } => {}
             Cert::Composition { .. } => {
-                s.push_str(&render_composition_semantic_bridge(c, analysis))
+                s.push_str(&render_composition_semantic_bridge(c, analysis, model_info))
             }
-            Cert::MutualRecursion { .. } => s.push_str(&render_mutual_semantic_bridge(c)),
+            Cert::MutualRecursion { .. } => {
+                s.push_str(&render_mutual_semantic_bridge(c, model_info))
+            }
             Cert::NonRecursive { .. } => unreachable!(),
         }
         s.push('\n');

--- a/aver-cert/src/engine/render_composition.rs
+++ b/aver-cert/src/engine/render_composition.rs
@@ -116,7 +116,11 @@ fn composition_claim_acceptance_proof(
 /// Option-(b) composition bridge. Root glue is discharged by the audited
 /// generic; generated lemmas remain only for the non-root member semantics
 /// that the generic deliberately consumes through `MemberFact`.
-fn render_composition_semantic_bridge(c: &Cert, analysis: &Analysis) -> String {
+fn render_composition_semantic_bridge(
+    c: &Cert,
+    analysis: &Analysis,
+    model_info: &ModelInfo,
+) -> String {
     let Cert::Composition {
         name,
         self_idx,
@@ -127,6 +131,14 @@ fn render_composition_semantic_bridge(c: &Cert, analysis: &Analysis) -> String {
     else {
         unreachable!()
     };
+    // Qualified model identifiers: the root and every closure member (the
+    // gate guarantees each one resolves for a certified composition).
+    let member_model = |entry: &ClosureEntry| -> String {
+        model_info
+            .model_lean_name(&entry.name)
+            .expect("model-citing certificate passed the qualified-name gate")
+    };
+    let root_model = c.model_lean_name(model_info);
     let add_idx = analysis
         .frag_host_table
         .add_idx
@@ -164,7 +176,7 @@ fn render_composition_semantic_bridge(c: &Cert, analysis: &Analysis) -> String {
             .map(|entry| format!(
                 "if member = {} then {} x else",
                 lean_str(&entry.name),
-                entry.name
+                member_model(entry)
             ))
             .chain(std::iter::once("x".to_string()))
             .collect::<Vec<_>>()
@@ -172,7 +184,7 @@ fn render_composition_semantic_bridge(c: &Cert, analysis: &Analysis) -> String {
     ));
     let model_simp = closure
         .iter()
-        .map(|entry| entry.name.as_str())
+        .map(&member_model)
         .collect::<Vec<_>>()
         .join(", ");
 
@@ -343,7 +355,7 @@ fn render_composition_semantic_bridge(c: &Cert, analysis: &Analysis) -> String {
          cases htail with\n      \
          | cons _ _ => simp at hLen\n      \
          | nil =>\n          \
-         refine ⟨n, v, {model_name}, {name}, rfl, hv, ?_, ?_, ?_⟩\n          \
+         refine ⟨n, v, {model_name}, {root_model}, rfl, hv, ?_, ?_, ?_⟩\n          \
          · intro input\n            \
          simp [{model_name}, CompositionSoundness.evalCompositionCalls, {model_simp}]\n          \
          · intro w hw\n            \

--- a/aver-cert/src/engine/render_composition.rs
+++ b/aver-cert/src/engine/render_composition.rs
@@ -131,8 +131,9 @@ fn render_composition_semantic_bridge(
     else {
         unreachable!()
     };
-    // Qualified model identifiers: the root and every closure member (the
-    // gate guarantees each one resolves for a certified composition).
+    // Qualified model identifiers: the root and every closure member.
+    // `model_citation_gate` covers a composition's root AND its whole closure,
+    // and both `analyze` and `write_project` enforce it, so each resolves.
     let member_model = |entry: &ClosureEntry| -> String {
         model_info
             .model_lean_name(&entry.name)

--- a/aver-cert/src/engine/render_expr_fragment_bridge.rs
+++ b/aver-cert/src/engine/render_expr_fragment_bridge.rs
@@ -23,10 +23,11 @@ fn expr_fragment_uses_audited_generic(c: &Cert) -> bool {
         && matches!(plan.result, FragTy::IntCarrier | FragTy::BoolI32)
 }
 
-fn expr_fragment_source_model(c: &Cert) -> String {
+fn expr_fragment_source_model(c: &Cert, model_info: &ModelInfo) -> String {
     debug_assert!(expr_fragment_uses_audited_generic(c));
+    let model_name = c.model_lean_name(model_info);
     match c.arity() {
-        1 => c.name().to_string(),
+        1 => model_name,
         // The obligation domain is the right-nested product
         // `FragParams.denote` builds, so the model uncurries the source
         // function over the same `p.1, p.2.1, …, p.2…2` accessors the
@@ -35,7 +36,7 @@ fn expr_fragment_source_model(c: &Cert) -> String {
             let args = (0..arity)
                 .map(|index| format!(" {}", expr_fragment_dom_accessor("p", index, arity)))
                 .collect::<String>();
-            format!("fun p => {}{args}", c.name())
+            format!("fun p => {model_name}{args}")
         }
     }
 }
@@ -91,6 +92,7 @@ fn render_expr_fragment_semantic_bridge(
     c: &Cert,
     host_table: FragHostTable,
     struct_table_lean: &str,
+    model_info: &ModelInfo,
 ) -> String {
     if let Some(face) = c.tag_dispatch_face() {
         return render_expr_fragment_tag_dispatch_semantic_bridge(
@@ -107,9 +109,10 @@ fn render_expr_fragment_semantic_bridge(
             face,
             host_table,
             struct_table_lean,
+            model_info,
         );
     }
-    render_expr_fragment_int_bool_semantic_bridge(c, host_table, struct_table_lean)
+    render_expr_fragment_int_bool_semantic_bridge(c, host_table, struct_table_lean, model_info)
 }
 
 fn render_expr_fragment_tag_dispatch_semantic_bridge(
@@ -182,8 +185,10 @@ fn render_expr_fragment_int_add_semantic_bridge(
     face: FragIntAddFace,
     host_table: FragHostTable,
     struct_table_lean: &str,
+    model_info: &ModelInfo,
 ) -> String {
     let name = c.name();
+    let model_name = c.model_lean_name(model_info);
     let carrier = c.carrier();
     let k = lean_int_lit(face.k);
     let claim = expr_fragment_claim_lean_value(c, host_table, struct_table_lean);
@@ -252,7 +257,7 @@ theorem {name}_exprFragmentSemanticBridge :
                   AverCert.AcceptedArtifact.exprFragmentNLocals,
                   CertModule.{name}Code, CertModule.{name}Host, boxRef,
                   popArgs, initLocals, hc, carrierSmall, b32]
-              · simpa [AverCert.Schema.intRepr, {name}] using
+              · simpa [AverCert.Schema.intRepr, {model_name}] using
                   hAdd n ({k}) v (carrierSmall {carrier} ({k})) result hv
                     (S.smallIntro ({k})) hc
 
@@ -318,6 +323,7 @@ fn render_expr_fragment_int_bool_semantic_bridge(
     c: &Cert,
     host_table: FragHostTable,
     struct_table_lean: &str,
+    model_info: &ModelInfo,
 ) -> String {
     let Cert::ExprFragment {
         name,
@@ -328,6 +334,7 @@ fn render_expr_fragment_int_bool_semantic_bridge(
     else {
         unreachable!()
     };
+    let model_name = c.model_lean_name(model_info);
     debug_assert_eq!(plan.result, FragTy::BoolI32);
     let claim = expr_fragment_claim_lean_value(c, host_table, struct_table_lean);
     let acceptance = expr_fragment_claim_acceptance_proof(c);
@@ -368,7 +375,7 @@ fn render_expr_fragment_int_bool_semantic_bridge(
          ExprFragmentSemantics.runNodesFuel, ExprFragmentSemantics.finishWith, \
          AverCert.AcceptedArtifact.exprFragmentNLocals, \
          CertModule.{name}Code, CertModule.{name}Host, wFuncN, wRunF, f, b32, \
-         popArgs, initLocals, {name}"
+         popArgs, initLocals, {model_name}"
     );
     let host_table_lean = host_table.lean_value();
     let eval_tactic = expr_fragment_bridge_eval_tactic(
@@ -401,7 +408,7 @@ theorem {name}_exprFragmentSemanticBridge :
       AverCert.Plans.{name}Plan, CertModule.{name}Code, CertModule.{name}Host]
   ·
 {eval_tactic}
-  · simp [{name}, AverCert.Schema.boolRepr, b32]
+  · simp [{model_name}, AverCert.Schema.boolRepr, b32]
 
 #print axioms {name}_exprFragmentSemanticBridge
 "#

--- a/aver-cert/src/engine/render_integer_accumulator.rs
+++ b/aver-cert/src/engine/render_integer_accumulator.rs
@@ -1,4 +1,5 @@
-fn accumulator_fuel_pieces(c: &Cert) -> FuelPieces {
+fn accumulator_fuel_pieces(c: &Cert, model_info: &ModelInfo) -> FuelPieces {
+    let q = c.model_lean_name(model_info);
     let Cert::AccumulatorRecursive {
         name,
         self_idx,
@@ -19,7 +20,7 @@ fn accumulator_fuel_pieces(c: &Cert) -> FuelPieces {
             r#"-- model-side fuel bridge (fuel induction; the IH is quantified over both args).
 theorem {name}_fuel_irrel :
     ∀ (t k1 k2 : Nat) (n acc : Int), n.natAbs < t → n.natAbs < k1 → n.natAbs < k2 →
-      {name}__fuel k1 n acc = {name}__fuel k2 n acc := by
+      {q}__fuel k1 n acc = {q}__fuel k2 n acc := by
   intro t
   induction t with
   | zero => intro k1 k2 n acc ht _ _; omega
@@ -32,25 +33,25 @@ theorem {name}_fuel_irrel :
       | zero => omega
       | succ m2 =>
       by_cases hn : n ≤ 0
-      · simp [{name}__fuel, hn]
+      · simp [{q}__fuel, hn]
       · have hrec := ih m1 m2 (n - 1) (acc + n) (by omega) (by omega) (by omega)
-        simp only [{name}__fuel]
+        simp only [{q}__fuel]
         rw [if_neg hn, if_neg hn, hrec]
 
 theorem {name}_fuel_stable (k : Nat) (n acc : Int) (h : n.natAbs < k) :
-    {name}__fuel k n acc = {name} n acc :=
+    {q}__fuel k n acc = {q} n acc :=
   {name}_fuel_irrel (n.natAbs + k + 1) k (n.natAbs + 1) n acc (by omega) h (by omega)
 
 theorem {name}_step (n acc : Int) (hn : ¬ n ≤ 0) :
-    {name} n acc = {name} (n - 1) (acc + n) := by
-  have h0 : {name} n acc = {name}__fuel (n.natAbs + 1) n acc := rfl
+    {q} n acc = {q} (n - 1) (acc + n) := by
+  have h0 : {q} n acc = {q}__fuel (n.natAbs + 1) n acc := rfl
   rw [h0]
-  simp only [{name}__fuel]
+  simp only [{q}__fuel]
   rw [if_neg hn, {name}_fuel_stable n.natAbs (n - 1) (acc + n) (by omega)]
 
-theorem {name}_base (n acc : Int) (hn : n ≤ 0) : {name} n acc = acc := by
-  have h0 : {name} n acc = {name}__fuel (n.natAbs + 1) n acc := rfl
-  rw [h0]; simp [{name}__fuel, hn]"#
+theorem {name}_base (n acc : Int) (hn : n ≤ 0) : {q} n acc = acc := by
+  have h0 : {q} n acc = {q}__fuel (n.natAbs + 1) n acc := rfl
+  rw [h0]; simp [{q}__fuel, hn]"#
         ),
         comb_hyps: r#"    (add sub : List WVal → Option WVal)
     (hAdd : ∀ a b va vb w, Repr a va → Repr b vb → add [va, vb] = some w → Repr (a + b) w)
@@ -59,7 +60,7 @@ theorem {name}_base (n acc : Int) (hn : n ≤ 0) : {name} n acc = acc := by
         concl: format!(
             r#"    ∀ (fuel : Nat) (n acc : Int) (vn vacc w : WVal), Repr n vn → Repr acc vacc →
       wFuncN {name}Code ({name}Host add sub) fuel {self_idx} [vn, vacc] = some w →
-      Repr ({name} n acc) w := by"#
+      Repr ({q} n acc) w := by"#
         ),
         zero_body: "      intro n acc vn vacc w hvn hvacc hrun\n      simp [wFuncN] at hrun"
             .to_string(),
@@ -123,11 +124,11 @@ theorem {name}_base (n acc : Int) (hn : n ≤ 0) : {name} n acc = acc := by
         faithful_concl: format!(
             r#"    ∀ (fuel : Nat) (n acc : Int) (vn vacc w : WVal), Repr n vn → Repr acc vacc →
       wFuncN {name}Code ({name}Host add sub) fuel {self_idx} [vn, vacc] = some w →
-      ∃ m : Int, Repr m w ∧ m = {name} n acc :="#
+      ∃ m : Int, Repr m w ∧ m = {q} n acc :="#
         ),
         faithful_body: format!(
             r#"  fun fuel n acc vn vacc w hvn hvacc hrun =>
-    ⟨{name} n acc,
+    ⟨{q} n acc,
      {name}_wasm_certified Repr hcar hsmall_intro hsmall_elim hbig add sub hAdd hSub fuel n acc vn
        vacc w hvn hvacc hrun,
      rfl⟩"#

--- a/aver-cert/src/engine/render_integer_fuel.rs
+++ b/aver-cert/src/engine/render_integer_fuel.rs
@@ -49,13 +49,13 @@ struct FuelPieces {
 /// the shared `Repr` hypotheses, the two `#print axioms` lines, the anti-vacuity
 /// and obligation structure) into which the recognised shape — single-argument
 /// combinator recursion or two-argument tail accumulator — splices its pieces.
-fn render_fueled_recursion_cert(c: &Cert) -> String {
+fn render_fueled_recursion_cert(c: &Cert, model_info: &ModelInfo) -> String {
     let name = c.name();
     let carrier = c.carrier();
     let hyps = recursion_repr_hyps(carrier);
     let p = match c.inner() {
-        Cert::Recursive { .. } => recursive_fuel_pieces(c),
-        Cert::AccumulatorRecursive { .. } => accumulator_fuel_pieces(c),
+        Cert::Recursive { .. } => recursive_fuel_pieces(c, model_info),
+        Cert::AccumulatorRecursive { .. } => accumulator_fuel_pieces(c, model_info),
         _ => unreachable!(),
     };
     let FuelPieces {

--- a/aver-cert/src/engine/render_integer_recursive.rs
+++ b/aver-cert/src/engine/render_integer_recursive.rs
@@ -1,4 +1,5 @@
-fn recursive_fuel_pieces(c: &Cert) -> FuelPieces {
+fn recursive_fuel_pieces(c: &Cert, model_info: &ModelInfo) -> FuelPieces {
+    let q = c.model_lean_name(model_info);
     let Cert::Recursive {
         name,
         self_idx,
@@ -44,7 +45,7 @@ fn recursive_fuel_pieces(c: &Cert) -> FuelPieces {
         BodyOperand::Const(k) => lean_int_lit(k),
     };
     let step_rhs = {
-        let rec_expr = format!("{name} (n - 1)");
+        let rec_expr = format!("{q} (n - 1)");
         if rec_first {
             format!("{rec_expr} {op} {}", other_expr("n"))
         } else {
@@ -63,7 +64,7 @@ fn recursive_fuel_pieces(c: &Cert) -> FuelPieces {
             BodyOperand::Input => "hv".to_string(),
             BodyOperand::Const(k) => format!("(hsmall_intro {})", lean_int_lit(k)),
         };
-        let rec_int = format!("({name} ({input} - 1))");
+        let rec_int = format!("({q} ({input} - 1))");
         if rec_first {
             (
                 format!("[vr, {other_wval}]"),
@@ -100,7 +101,7 @@ theorem {name}_wasm_total_aux
     (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
     ∀ (fuel : Nat) (n : Int) (v : WVal), Repr n v → n.natAbs < fuel →
       ∃ w, wFuncN {name}Code ({name}Host add sub) fuel {self_idx} [v] = some w ∧
-        Repr ({name} n) w := by
+        Repr ({q} n) w := by
   intro fuel
   induction fuel with
   | zero => intro n v hv hlt; omega
@@ -154,7 +155,7 @@ theorem {name}_wasm_total
     (hSubTot : ∀ a b va vb, Repr a va → Repr b vb → ∃ w, sub [va, vb] = some w) :
     ∀ (n : Int) (v : WVal), Repr n v →
       ∃ w, wFuncN {name}Code ({name}Host add sub) (n.natAbs + 1) {self_idx} [v] = some w ∧
-        Repr ({name} n) w :=
+        Repr ({q} n) w :=
   fun n v hv =>
     {name}_wasm_total_aux Repr hcar hsmall_intro hsmall_elim hbig add sub hAdd hSub
       hAddTot hSubTot (n.natAbs + 1) n v hv (by omega)
@@ -190,7 +191,7 @@ theorem {name}_simulates_total : AverCert.Schema.Obligation.holdsTotal {name}Ob 
             r#"-- model-side fuel bridge (the cap-induction pattern at R = 1).
 theorem {name}_fuel_irrel :
     ∀ (t k1 k2 : Nat) (n : Int), n.natAbs < t → n.natAbs < k1 → n.natAbs < k2 →
-      {name}__fuel k1 n = {name}__fuel k2 n := by
+      {q}__fuel k1 n = {q}__fuel k2 n := by
   intro t
   induction t with
   | zero => intro k1 k2 n ht _ _; omega
@@ -203,24 +204,24 @@ theorem {name}_fuel_irrel :
       | zero => omega
       | succ m2 =>
       by_cases hn : n ≤ 0
-      · simp [{name}__fuel, hn]
+      · simp [{q}__fuel, hn]
       · have hrec := ih m1 m2 (n - 1) (by omega) (by omega) (by omega)
-        simp only [{name}__fuel]
+        simp only [{q}__fuel]
         rw [if_neg hn, if_neg hn, hrec]
 
 theorem {name}_fuel_stable (k : Nat) (n : Int) (h : n.natAbs < k) :
-    {name}__fuel k n = {name} n :=
+    {q}__fuel k n = {q} n :=
   {name}_fuel_irrel (n.natAbs + k + 1) k (n.natAbs + 1) n (by omega) h (by omega)
 
-theorem {name}_step (n : Int) (hn : ¬ n ≤ 0) : {name} n = {step_rhs} := by
-  have h0 : {name} n = {name}__fuel (n.natAbs + 1) n := rfl
+theorem {name}_step (n : Int) (hn : ¬ n ≤ 0) : {q} n = {step_rhs} := by
+  have h0 : {q} n = {q}__fuel (n.natAbs + 1) n := rfl
   rw [h0]
-  simp only [{name}__fuel]
+  simp only [{q}__fuel]
   rw [if_neg hn, {name}_fuel_stable n.natAbs (n - 1) (by omega)]
 
-theorem {name}_base (n : Int) (hn : n ≤ 0) : {name} n = {base} := by
-  have h0 : {name} n = {name}__fuel (n.natAbs + 1) n := rfl
-  rw [h0]; simp [{name}__fuel, hn]"#
+theorem {name}_base (n : Int) (hn : n ≤ 0) : {q} n = {base} := by
+  have h0 : {q} n = {q}__fuel (n.natAbs + 1) n := rfl
+  rw [h0]; simp [{q}__fuel, hn]"#
         ),
         comb_hyps: format!(
             r#"    ({cparam} sub : List WVal → Option WVal)
@@ -230,7 +231,7 @@ theorem {name}_base (n : Int) (hn : n ≤ 0) : {name} n = {base} := by
         concl: format!(
             r#"    ∀ (fuel : Nat) (n : Int) (v w : WVal), Repr n v →
       wFuncN {name}Code ({name}Host {cparam} sub) fuel {self_idx} [v] = some w →
-      Repr ({name} n) w := by"#
+      Repr ({q} n) w := by"#
         ),
         zero_body: "      intro n v w hv hrun\n      simp [wFuncN] at hrun".to_string(),
         succ_body: format!(
@@ -253,7 +254,7 @@ theorem {name}_base (n : Int) (hn : n ≤ 0) : {name} n = {base} := by
             rcases hrec : wFuncN {name}Code ({name}Host {cparam} sub) fuel {self_idx} [vd] with _ | vr
             · simp [hrec] at hrun
             · simp only [hrec] at hrun
-              have hrr : Repr ({name} (s - 1)) vr := ih (s - 1) vd vr hrd hrec
+              have hrr : Repr ({q} (s - 1)) vr := ih (s - 1) vd vr hrd hrec
               rcases hadd : {cparam} {add_small} with _ | wa
               · simp [hadd] at hrun
               · simp only [hadd, Option.some.injEq] at hrun
@@ -280,7 +281,7 @@ theorem {name}_base (n : Int) (hn : n ≤ 0) : {name} n = {base} := by
             rcases hrec : wFuncN {name}Code ({name}Host {cparam} sub) fuel {self_idx} [vd] with _ | vr
             · simp [hrec] at hrun
             · simp only [hrec] at hrun
-              have hrr : Repr ({name} (n - 1)) vr := ih (n - 1) vd vr hrd hrec
+              have hrr : Repr ({q} (n - 1)) vr := ih (n - 1) vd vr hrd hrec
               rcases hadd : {cparam} {add_big} with _ | wa
               · simp [hadd] at hrun
               · simp only [hadd, Option.some.injEq] at hrun
@@ -291,11 +292,11 @@ theorem {name}_base (n : Int) (hn : n ≤ 0) : {name} n = {base} := by
         faithful_concl: format!(
             r#"    ∀ (fuel : Nat) (n : Int) (v w : WVal), Repr n v →
       wFuncN {name}Code ({name}Host {cparam} sub) fuel {self_idx} [v] = some w →
-      ∃ m : Int, Repr m w ∧ m = {name} n :="#
+      ∃ m : Int, Repr m w ∧ m = {q} n :="#
         ),
         faithful_body: format!(
             r#"  fun fuel n v w hv hrun =>
-    ⟨{name} n,
+    ⟨{q} n,
      {name}_wasm_certified Repr hcar hsmall_intro hsmall_elim hbig {cparam} sub {chyp} hSub fuel n v w hv hrun,
      rfl⟩"#
         ),

--- a/aver-cert/src/engine/render_manifest.rs
+++ b/aver-cert/src/engine/render_manifest.rs
@@ -12,10 +12,11 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
              Dom := List Int, Cod := Int,\n    \
              domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = {arity},\n    \
              codRepr := fun S n w => intRepr S n w,\n    \
-             model := fun ns => {name} (ns.headD 0) }}\n\n",
+             model := fun ns => {model_name} (ns.headD 0) }}\n\n",
             carrier = c.carrier(),
             self_idx = c.self_idx(),
             arity = c.arity(),
+            model_name = c.model_lean_name(model_info),
         );
     }
     if let Some(face) = c.tag_dispatch_face() {
@@ -167,7 +168,7 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
                     expr_fragment_dom_accessor("p", idx as usize, plan.params.len())
                 });
             let model = if expr_fragment_uses_audited_generic(c) {
-                expr_fragment_source_model(c)
+                expr_fragment_source_model(c, model_info)
             } else {
                 format!("fun p => {plan_model}")
             };
@@ -208,7 +209,7 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
              Dom := List Int, Cod := Int,\n    \
              domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = 1,\n    \
              codRepr := fun S n w => intRepr S n w,\n    \
-             model := fun ns => {name} (ns.headD 0) }}\n\n",
+             model := fun ns => {model_name} (ns.headD 0) }}\n\n",
             primary = scc[0].name,
             carrier = c.carrier(),
             host = c.host_expr(),
@@ -217,6 +218,7 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
             termination = c
                 .termination_witness()
                 .map_or_else(|| "none".to_string(), |w| format!("some {}", w.lean_value())),
+            model_name = c.model_lean_name(model_info),
         ),
         _ => format!(
             "abbrev {name}Ob : Schema.Obligation :=\n  \
@@ -229,7 +231,7 @@ fn render_obligation_def(c: &Cert, model_info: &ModelInfo) -> String {
             carrier = c.carrier(),
             host = c.host_expr(),
             self_idx = c.self_idx(),
-            model = c.model_expr(),
+            model = c.model_expr(model_info),
             arity = c.arity(),
             policy = c.policy().lean_value(),
             termination = c

--- a/aver-cert/src/engine/render_model_support.rs
+++ b/aver-cert/src/engine/render_model_support.rs
@@ -11,8 +11,13 @@ fn render_user_repr_defs(analysis: &Analysis, model_info: &ModelInfo) -> String 
         let Some(ind) = model_info.inductives.get(&ty) else {
             continue;
         };
+        // `ty` is the qualified inductive name (identity for entry-level
+        // models). The def NAME flattens its dots so it stays one atomic
+        // identifier inside the AverCert namespace; the type POSITION cites
+        // the qualified name the imported model module actually declares.
+        let ty_def = ty.replace('.', "_");
         out.push_str(&format!(
-            "def {ty}Repr (S : CarrierSpec {}) : {ty} → WVal → Prop\n",
+            "def {ty_def}Repr (S : CarrierSpec {}) : {ty} → WVal → Prop\n",
             c.carrier()
         ));
         for (i, ctor) in ind.ctors.iter().enumerate() {
@@ -144,11 +149,11 @@ fn render_user_repr_defs(analysis: &Analysis, model_info: &ModelInfo) -> String 
     out
 }
 
-/// For a widened Int match: the model inductive name, its constructor list, and
-/// the name of the single integer-payload constructor the body projects (the
-/// unique `fields == ["Int"]` constructor). `None` — so the class declines by a
-/// failed render — if the model type is unknown or the projected constructor is
-/// not unique.
+/// For a widened Int match: the model inductive's QUALIFIED name, its
+/// constructor list, and the name of the single integer-payload constructor
+/// the body projects (the unique `fields == ["Int"]` constructor). `None` — so
+/// the class declines by a failed render — if the model type is unknown or the
+/// projected constructor is not unique.
 fn widened_match_info<'a>(
     c: &Cert,
     model_info: &'a ModelInfo,
@@ -157,8 +162,9 @@ fn widened_match_info<'a>(
     let Cert::WidenedIntMatch { name, .. } = c else {
         return None;
     };
-    let ty = model_info.fns.get(name)?.params.first()?.clone();
-    let ind = model_info.inductives.get(&ty)?;
+    let sig = model_info.fns.get(name)?;
+    let written = sig.params.first()?;
+    let (ty, ind) = model_info.resolve_inductive(&sig.prefix, written)?;
     let mut int_ctors = ind.ctors.iter().filter(|ct| ct.fields == ["Int"]);
     let hit = int_ctors.next()?.name.clone();
     if int_ctors.next().is_some() {
@@ -193,7 +199,7 @@ fn adt_constructor_uses_model(c: &Cert, model_info: &ModelInfo) -> bool {
         && model_info
             .fns
             .get(name)
-            .map(|s| model_info.inductives.contains_key(&s.ret))
+            .map(|s| model_info.resolve_inductive(&s.prefix, &s.ret).is_some())
             .unwrap_or(false)
 }
 
@@ -222,11 +228,14 @@ fn verbatim_ctor_shape(
     }
 }
 
+/// The QUALIFIED model inductive name and per-constructor struct indices for a
+/// user-ADT cert (identity qualification for entry-level models).
 fn adt_repr_indices(c: &Cert, model_info: &ModelInfo) -> Option<(String, Vec<u32>)> {
     match c.inner() {
         Cert::VariantDispatch { name, arms, .. } => {
-            let ty = model_info.fns.get(name)?.params.first()?.clone();
-            let ind = model_info.inductives.get(&ty)?;
+            let sig = model_info.fns.get(name)?;
+            let written = sig.params.first()?;
+            let (ty, ind) = model_info.resolve_inductive(&sig.prefix, written)?;
             // Struct tags are assigned per constructor in declaration order;
             // anchor the base on the smallest dispatched tag. A mis-anchored
             // base renders an unprovable `Repr` and fails the lake build —
@@ -237,8 +246,8 @@ fn adt_repr_indices(c: &Cert, model_info: &ModelInfo) -> Option<(String, Vec<u32
         Cert::AdtConstructor {
             name, struct_idx, ..
         } => {
-            let ty = model_info.fns.get(name)?.ret.clone();
-            let ind = model_info.inductives.get(&ty)?;
+            let sig = model_info.fns.get(name)?;
+            let (ty, ind) = model_info.resolve_inductive(&sig.prefix, &sig.ret)?;
             let base = *struct_idx;
             let mut indices = Vec::new();
             for i in 0..ind.ctors.len() {

--- a/aver-cert/src/engine/render_model_support.rs
+++ b/aver-cert/src/engine/render_model_support.rs
@@ -5,9 +5,6 @@ fn render_user_repr_defs(analysis: &Analysis, model_info: &ModelInfo) -> String 
         let Some((ty, indices)) = adt_repr_indices(c, model_info) else {
             continue;
         };
-        if !emitted.insert(ty.clone()) {
-            continue;
-        }
         let Some(ind) = model_info.inductives.get(&ty) else {
             continue;
         };
@@ -15,7 +12,15 @@ fn render_user_repr_defs(analysis: &Analysis, model_info: &ModelInfo) -> String 
         // models). The def NAME flattens its dots so it stays one atomic
         // identifier inside the AverCert namespace; the type POSITION cites
         // the qualified name the imported model module actually declares.
+        //
+        // Dedupe on the EMITTED identifier, not on `ty`: two distinct
+        // qualified types can flatten onto one def name (`A.B` + type `C` and
+        // `A` + type `B_C` both yield `A_B_CRepr`), and emitting both would be
+        // a duplicate declaration that fails the package build.
         let ty_def = ty.replace('.', "_");
+        if !emitted.insert(ty_def.clone()) {
+            continue;
+        }
         out.push_str(&format!(
             "def {ty_def}Repr (S : CarrierSpec {}) : {ty} → WVal → Prop\n",
             c.carrier()

--- a/aver-cert/src/engine/render_mutual.rs
+++ b/aver-cert/src/engine/render_mutual.rs
@@ -253,8 +253,9 @@ fn render_mutual_semantic_bridge(c: &Cert, model_info: &ModelInfo) -> String {
         unreachable!()
     };
     let model_name = c.model_lean_name(model_info);
-    // Every member's model function, by its qualified Lean identifier (the
-    // gate guarantees each member of a certified SCC resolves).
+    // Every member's model function, by its qualified Lean identifier.
+    // `model_citation_gate` covers every member of the SCC, and both `analyze`
+    // and `write_project` enforce it, so each resolves.
     let member_model = |member: &MutualMember| -> String {
         model_info
             .model_lean_name(&member.name)

--- a/aver-cert/src/engine/render_mutual.rs
+++ b/aver-cert/src/engine/render_mutual.rs
@@ -240,7 +240,7 @@ theorem {primary}_mutualFragmentsAccepted :
 /// relates every source member to the plan-derived k-generic evaluator; the
 /// selected member then supplies the represented-domain relation required by
 /// `mutualSemanticBridge`.  Wasm execution and totality stay in the audited wall.
-fn render_mutual_semantic_bridge(c: &Cert) -> String {
+fn render_mutual_semantic_bridge(c: &Cert, model_info: &ModelInfo) -> String {
     let Cert::MutualRecursion {
         name,
         position,
@@ -252,6 +252,14 @@ fn render_mutual_semantic_bridge(c: &Cert) -> String {
     else {
         unreachable!()
     };
+    let model_name = c.model_lean_name(model_info);
+    // Every member's model function, by its qualified Lean identifier (the
+    // gate guarantees each member of a certified SCC resolves).
+    let member_model = |member: &MutualMember| -> String {
+        model_info
+            .model_lean_name(&member.name)
+            .expect("model-citing certificate passed the qualified-name gate")
+    };
     let primary = &scc[0].name;
     let k = scc.len();
     let model_fuel = scc
@@ -261,14 +269,14 @@ fn render_mutual_semantic_bridge(c: &Cert) -> String {
             format!(
                 "MutualRecursionSoundness.evalMutualUFuel {primary}_mutualMembers fuel \
                  ⟨{member_pos}, by omega⟩ n = {}__fuel fuel n",
-                member.name,
+                member_model(member),
             )
         })
         .collect::<Vec<_>>()
         .join(" ∧\n      ");
     let source_fuels = scc
         .iter()
-        .map(|member| format!("{}__fuel", member.name))
+        .map(|member| format!("{}__fuel", member_model(member)))
         .collect::<Vec<_>>()
         .join(", ");
     let zero = mutual_rfl_conjunction(k);
@@ -291,9 +299,9 @@ theorem {name}_mutualSemanticBridge :
         split <;> simp_all [{primary}_mutualMembers]
   have hModel : ∀ n,
       MutualRecursionSoundness.evalMutualU {primary}_mutualMembers
-        ⟨{position}, by omega⟩ n = {name} n := by
+        ⟨{position}, by omega⟩ n = {model_name} n := by
     intro n
-    simpa [MutualRecursionSoundness.evalMutualU, {name}] using
+    simpa [MutualRecursionSoundness.evalMutualU, {model_name}] using
       (hModelFuel (n.natAbs + 1) n){projection}
   refine ⟨{k}, {box_idx}, {sub_idx}, {primary}_mutualScc,
     ⟨{position}, by omega⟩, rfl, rfl, rfl, rfl, ?_, ?_, ?_⟩

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -5,6 +5,14 @@
 /// checker-owned wall and build configuration are resolved from `wall_id`.
 /// Any existing `cert/` directory is removed first so a reused output path
 /// cannot retain files from an older package format.
+///
+/// PRECONDITION: `model_files` must be the SAME emission `analysis` was
+/// derived from. The renderers cite each certified export's model by the
+/// qualified Lean name resolved from these files, and `analyze` already
+/// declined every export whose name it could not resolve — so a mismatched
+/// pair would leave a renderer with a citation the gate never approved. This
+/// is checked here rather than assumed: a mismatch returns an error and no
+/// package is written.
 pub fn write_project(
     out_dir: &Path,
     wasm_name: &str,
@@ -12,6 +20,17 @@ pub fn write_project(
     analysis: &Analysis,
     model_files: &[(String, String)],
 ) -> Result<(), String> {
+    // Enforce the model-file precondition BEFORE touching the output
+    // directory, so a mismatched call leaves any existing package intact.
+    let model_info = ModelInfo::from_files(model_files);
+    for c in &analysis.certs {
+        model_citation_gate(c, &model_info).map_err(|reason| {
+            format!(
+                "model files passed to write_project do not match the analysis: {reason}"
+            )
+        })?;
+    }
+
     let cert_dir = out_dir.join("cert");
     match std::fs::remove_dir_all(&cert_dir) {
         Ok(()) => {}
@@ -31,7 +50,6 @@ pub fn write_project(
             model_roots.push(model_root_from_stem(stem)?);
         }
     }
-    let model_info = ModelInfo::from_files(model_files);
 
     let sha = {
         let mut h = Sha256::new();

--- a/aver-cert/src/engine/render_recursion_bridge.rs
+++ b/aver-cert/src/engine/render_recursion_bridge.rs
@@ -101,7 +101,7 @@ fn recursion_claim_acceptance_proof(c: &Cert) -> String {
 /// generated source model to the independent `RecursionSoundness.evalRecU` evaluator in
 /// the represented obligation domain. Fuel induction and Wasm execution stay in the
 /// sha-pinned `RecursionSoundness` / `DischargeRecursion` wall.
-fn render_unary_recursion_semantic_bridge(c: &Cert) -> String {
+fn render_unary_recursion_semantic_bridge(c: &Cert, model_info: &ModelInfo) -> String {
     let Cert::Recursive {
         name,
         box_idx,
@@ -113,6 +113,7 @@ fn render_unary_recursion_semantic_bridge(c: &Cert) -> String {
         unreachable!()
     };
     debug_assert!(recursion_uses_audited_generic(c));
+    let model_name = c.model_lean_name(model_info);
     let shape = recursion_shape_lean_value(c);
     let combine = recursion_combine_lean_value(c);
     let claim = recursion_claim_lean_value(c);
@@ -133,17 +134,17 @@ theorem {name}_recursionSemanticBridge :
     AcceptanceSoundness.recursionSemanticBridge {claim}
       AverCert.Plans.{name}RecursionPlan := by
   have hModelFuel : ∀ fuel n,
-      RecursionSoundness.evalRecUFuel {combine} {shape} fuel n = {name}__fuel fuel n := by
+      RecursionSoundness.evalRecUFuel {combine} {shape} fuel n = {model_name}__fuel fuel n := by
     intro fuel
     induction fuel with
     | zero => intro n; rfl
     | succ fuel ih =>
         intro n
-        simp only [RecursionSoundness.evalRecUFuel, {name}__fuel]
+        simp only [RecursionSoundness.evalRecUFuel, {model_name}__fuel]
         split <;> simp_all [RecursionSoundness.stepEval, RecursionSoundness.combineEval]
-  have hModel : ∀ n, RecursionSoundness.evalRecU {combine} {shape} n = {name} n := by
+  have hModel : ∀ n, RecursionSoundness.evalRecU {combine} {shape} n = {model_name} n := by
     intro n
-    simpa [RecursionSoundness.evalRecU, {name}] using hModelFuel (n.natAbs + 1) n
+    simpa [RecursionSoundness.evalRecU, {model_name}] using hModelFuel (n.natAbs + 1) n
   refine Or.inl ?_
   refine ⟨{combine}, {box_idx}, {add_idx}, {sub_idx}, {shape},
     rfl, rfl, ?_, ?_⟩
@@ -168,7 +169,7 @@ theorem {name}_recursionSemanticBridge :
     )
 }
 
-fn render_accumulator_recursion_semantic_bridge(c: &Cert) -> String {
+fn render_accumulator_recursion_semantic_bridge(c: &Cert, model_info: &ModelInfo) -> String {
     let Cert::AccumulatorRecursive {
         name,
         box_idx,
@@ -179,6 +180,7 @@ fn render_accumulator_recursion_semantic_bridge(c: &Cert) -> String {
     else {
         unreachable!()
     };
+    let model_name = c.model_lean_name(model_info);
     let claim = recursion_claim_lean_value(c);
     let acceptance = recursion_claim_acceptance_proof(c);
     format!(
@@ -197,17 +199,17 @@ theorem {name}_recursionSemanticBridge :
     AcceptanceSoundness.recursionSemanticBridge {claim}
       AverCert.Plans.{name}RecursionPlan := by
   have hModelFuel : ∀ fuel n acc,
-      RecursionSoundness.evalRecAFuel fuel n acc = {name}__fuel fuel n acc := by
+      RecursionSoundness.evalRecAFuel fuel n acc = {model_name}__fuel fuel n acc := by
     intro fuel
     induction fuel with
     | zero => intro n acc; rfl
     | succ fuel ih =>
         intro n acc
-        simp only [RecursionSoundness.evalRecAFuel, {name}__fuel]
+        simp only [RecursionSoundness.evalRecAFuel, {model_name}__fuel]
         split <;> simp_all
-  have hModel : ∀ n acc, RecursionSoundness.evalRecA n acc = {name} n acc := by
+  have hModel : ∀ n acc, RecursionSoundness.evalRecA n acc = {model_name} n acc := by
     intro n acc
-    simpa [RecursionSoundness.evalRecA, {name}] using hModelFuel (n.natAbs + 1) n acc
+    simpa [RecursionSoundness.evalRecA, {model_name}] using hModelFuel (n.natAbs + 1) n acc
   refine Or.inr ?_
   refine ⟨{box_idx}, {add_idx}, {sub_idx}, .accumulator,
     rfl, rfl, ?_, ?_⟩
@@ -234,11 +236,11 @@ theorem {name}_recursionSemanticBridge :
     )
 }
 
-fn render_recursion_semantic_bridge(c: &Cert) -> String {
+fn render_recursion_semantic_bridge(c: &Cert, model_info: &ModelInfo) -> String {
     match c.inner() {
-        Cert::Recursive { .. } => render_unary_recursion_semantic_bridge(c),
+        Cert::Recursive { .. } => render_unary_recursion_semantic_bridge(c, model_info),
         Cert::AccumulatorRecursive { .. } => {
-            render_accumulator_recursion_semantic_bridge(c)
+            render_accumulator_recursion_semantic_bridge(c, model_info)
         }
         _ => unreachable!(),
     }

--- a/aver-cert/src/engine/sym_plan_defs.rs
+++ b/aver-cert/src/engine/sym_plan_defs.rs
@@ -289,7 +289,7 @@ fn adt_constructor_sym_plan_from_cert(c: &Cert, model_info: &ModelInfo) -> Optio
     let result = sym_ty_from_source_type_name(&sig.ret)?;
     let (type_name, ctor_name, source_args) = match &result {
         SymTy::Named(type_name) if adt_constructor_uses_model(c, model_info) => {
-            let ind = model_info.inductives.get(&sig.ret)?;
+            let (_, ind) = model_info.resolve_inductive(&sig.prefix, &sig.ret)?;
             let ctor = ind.ctors.first()?;
             if ctor.fields != sig.params || !sym_plan_simple_token(&ctor.name) {
                 return None;
@@ -1037,6 +1037,8 @@ mod sym_plan_defs_tests {
         model_info.fns.insert(
             "mkOp".to_string(),
             FnSig {
+                lean_name: "mkOp".to_string(),
+                prefix: String::new(),
                 params: vec!["Int".to_string()],
                 ret: "Op".to_string(),
             },
@@ -1088,6 +1090,8 @@ mod sym_plan_defs_tests {
         model_info.fns.insert(
             "singletonEntry".to_string(),
             FnSig {
+                lean_name: "singletonEntry".to_string(),
+                prefix: String::new(),
                 params: vec!["(String × Json)".to_string()],
                 ret: "List (String × Json)".to_string(),
             },

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -3743,8 +3743,12 @@ fn certify_nested_module_models_close_end_to_end() {
         "nestedmods --certify failed:\n{report}"
     );
     assert!(
-        report.contains("1 certified"),
-        "nestedmods must certify its entry-module export:\n{report}"
+        report.contains("3 certified"),
+        "nestedmods must certify the entry export and both nested-module exports:\n{report}"
+    );
+    assert!(
+        report.contains("Nested_Deep_Util_bump") && report.contains("Nested_Deep_Util_tally"),
+        "nestedmods must certify the exports whose models live in the nested module:\n{report}"
     );
 
     let cert_dir = out_dir.join("cert");
@@ -3768,6 +3772,35 @@ fn certify_nested_module_models_close_end_to_end() {
             "{file} must not emit a path-shaped import line:\n{contents}"
         );
     }
+    // The nested-module export's obligation must cite its model by the
+    // QUALIFIED name the model file declares (inside `namespace
+    // Nested.Deep.Util`), never by the flattened wasm export name — the
+    // flattened form is not a Lean identifier in the model and fails the
+    // package build.
+    let manifest_lean =
+        std::fs::read_to_string(cert_dir.join("Manifest.lean")).expect("Manifest.lean exists");
+    assert!(
+        manifest_lean.contains("model := fun ns => Nested.Deep.Util.bump (ns.headD 0)")
+            && manifest_lean.contains("model := fun ns => Nested.Deep.Util.tally (ns.headD 0)"),
+        "each nested export's obligation must cite the qualified model name:\n{manifest_lean}"
+    );
+    assert!(
+        !manifest_lean.contains("model := fun ns => Nested_Deep_Util_bump")
+            && !manifest_lean.contains("model := fun ns => Nested_Deep_Util_tally"),
+        "the obligation must never cite the flattened export name as the model:\n{manifest_lean}"
+    );
+    // The nested recursion bridge must also cite the model's qualified fuel
+    // form (`Nested.Deep.Util.tally__fuel`), never a flattened one.
+    let certificate_lean = std::fs::read_to_string(cert_dir.join("Certificate.lean"))
+        .expect("Certificate.lean exists");
+    assert!(
+        certificate_lean.contains("Nested.Deep.Util.tally__fuel"),
+        "the recursion bridge must cite the qualified fuel model:\n{certificate_lean}"
+    );
+    assert!(
+        !certificate_lean.contains("Nested_Deep_Util_tally__fuel"),
+        "the recursion bridge must never cite a flattened fuel model:\n{certificate_lean}"
+    );
 
     assert_certificate_target_builds(&cert_dir, "nested module models");
 

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -545,8 +545,12 @@ fn cert_verify_accepts_nested_module_certificate() {
     );
     assert!(report.contains("CERTIFIED"), "missing CERTIFIED:\n{report}");
     assert!(
-        report.contains("1 certified export"),
-        "expected exactly one certified export:\n{report}"
+        report.contains("3 certified exports"),
+        "expected the entry export and both nested-module exports:\n{report}"
+    );
+    assert!(
+        report.contains("Nested_Deep_Util_bump") && report.contains("Nested_Deep_Util_tally"),
+        "the exports whose models live in the nested module must certify:\n{report}"
     );
 
     let _ = std::fs::remove_dir_all(&out_dir);

--- a/tools/certkit/fixtures/nestedmods/app.av
+++ b/tools/certkit/fixtures/nestedmods/app.av
@@ -14,8 +14,15 @@ fn viaDep(n: Int) -> Int
     ? "Delegates to the nested dependency module."
     Nested.Deep.Util.combine(n, 0)
 
+fn viaBump(n: Int) -> Int
+    ? "Keeps the nested certifiable function live from the entry module."
+    Nested.Deep.Util.bump(n)
+
 verify addTwo
     addTwo(1) => 3
 
 verify viaDep
     viaDep(1) => 3
+
+verify viaBump
+    viaBump(1) => 3

--- a/tools/certkit/fixtures/nestedmods/nested/deep/util.av
+++ b/tools/certkit/fixtures/nestedmods/nested/deep/util.av
@@ -1,17 +1,35 @@
 module Util
-    exposes [combine]
+    exposes [combine, bump, tally]
     intent =
-        "Nested dependency for the certificate staging fixture. The exposed"
-        "function takes two arguments on purpose: it stays outside the"
-        "single-argument certified templates, so the fixture's certified"
-        "export lives in the entry module while this module's Lean model"
-        "(Nested/Deep/Util.lean) is still emitted, imported by the"
-        "certificate, and must stage for the package to build."
+        "Nested dependency for the certificate staging fixture. `combine`"
+        "takes two arguments on purpose: it stays outside the certified"
+        "templates, so the package always carries a declined dependency"
+        "function. `bump` is deliberately CERTIFIABLE (straight-line n + 2):"
+        "its wasm export is the flattened `Nested_Deep_Util_bump`, while its"
+        "Lean model lives inside `namespace Nested.Deep.Util` in the nested"
+        "model file (Nested/Deep/Util.lean) — so the generated certificate"
+        "must cite the model by its qualified name for the package to build."
     effects []
 
 fn combine(a: Int, b: Int) -> Int
     ? "Adds two integers and two."
     a + b + 2
 
+fn bump(n: Int) -> Int
+    ? "Adds two to an integer."
+    n + 2
+
+fn tally(n: Int) -> Int
+    ? "Single-argument self recursion; its certificate must cite the qualified model and its fuel form."
+    match n <= 0
+        true -> 0
+        false -> n + tally(n - 1)
+
 verify combine
     combine(1, 0) => 3
+
+verify bump
+    bump(1) => 3
+
+verify tally
+    tally(3) => 6


### PR DESCRIPTION
Certificates for programs with dependencies in nested namespaces staged and built after the previous change, but still declined: obligations cited the model by the flattened wasm export name (Data_Json_isHighSurrogate) while the emitted model defines that function inside a namespace, so the Lean identifier is Data.Json.isHighSurrogate. Flat single-module programs were unaffected, which is why this stayed masked until nested staging worked.

The model parser now tracks the namespace stack while reading the emitted model files and keys each definition by its forward-mangled flat name alongside the real qualified name, so every renderer resolves the name that actually exists. No string surgery on the mangled name — user identifiers contain underscores, so splitting on them is ambiguous. Where a citation cannot be resolved (or two namespaces flatten to the same key), the export declines to source-level-only instead of emitting a name that might not exist; a new pass enforces that for every class that cites a model.

Updated citing sites cover each certificate class: obligation models, expression-fragment bridges, recursion and mutual fuel bridges, composition member models and witness, integer recursion/accumulator/fuel renderers, and the representation helpers that name inductives and constructors.

Verification: the nested fixture now certifies three exports (a plain expression fragment, a fragment in the nested module, and a self-recursive function in the nested module, the last through a qualified fuel bridge) and the kernel replay accepts it. A flat program's certificate directory and wasm are byte-identical before and after, and the package snapshot is unchanged. The notepad example now builds every emitted module and claims twelve certified exports (exactly mirroring the flat json set); it still declines at two limits that predate this change — the trusted wall pins arithmetic helper indices below 128 and that module places them at 166-169, and the artifact proof exceeds the elaboration heartbeat budget for a 44 KB module. Both were reproduced on the previous commit by hand-patching only the two model lines, so they are separate work.

Wall assets unchanged; no wall identity bump.