### PR TITLE
Give the shared arithmetic helpers low function indices

### DIFF
--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -1897,6 +1897,14 @@ fn render_artifact(
          -- The whole-module big-Nat closure fold is kernel reduction. This\n\
          -- explicit depth budget affects kernel reduction limits only, not soundness or axioms.\n\
          set_option maxRecDepth 200000\n\
+         -- Companion budget for the elaborator, matching the one Certificate.lean\n\
+         -- already carries. Precautionary rather than a fix for an observed\n\
+         -- failure: this proof is one fixed shape repeated per claim, so its\n\
+         -- elaboration cost grows with the size of the artifact, and the stock\n\
+         -- allowance is the only thing here that was never stated explicitly.\n\
+         -- Like the depth budget above it moves a resource limit only: no axiom,\n\
+         -- no trusted hypothesis, no change to what the kernel must accept.\n\
+         set_option maxHeartbeats 1600000\n\
          set_option linter.unusedSimpArgs false\n\n\
          namespace AverCert.Artifact\n\n\
          def symFragmentClaims : List AverCert.AcceptedArtifact.SymFragmentClaim := {sym_claims_list}\n\n\

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -488,8 +488,14 @@ impl BuiltinName {
 /// Per-module registry of used builtins.
 #[derive(Default)]
 pub(super) struct BuiltinRegistry {
-    /// Insertion order — wasm fn indices and type indices follow it.
+    /// Insertion order — TYPE indices follow it, and so do wasm fn indices
+    /// for every builtin outside `hoisted`.
     order: Vec<BuiltinName>,
+    /// Builtins pulled to the FRONT of the function/code sections by
+    /// `assign_hoisted_fn_slots`, in the order they were pulled. Their wasm
+    /// fn indices sit immediately after `_start`, ahead of the user
+    /// functions; their type indices still follow registration order.
+    hoisted: Vec<BuiltinName>,
     wasm_fn_idx: HashMap<BuiltinName, u32>,
     wasm_type_idx: HashMap<BuiltinName, u32>,
 }
@@ -509,12 +515,61 @@ impl BuiltinRegistry {
         self.order.iter().copied()
     }
 
+    /// The hoisted builtins, in function-index order.
+    pub(super) fn iter_hoisted(&self) -> impl Iterator<Item = BuiltinName> + '_ {
+        self.hoisted.iter().copied()
+    }
+
+    /// Every registered builtin that was NOT hoisted, in registration order.
+    pub(super) fn iter_unhoisted(&self) -> impl Iterator<Item = BuiltinName> + '_ {
+        self.order
+            .iter()
+            .copied()
+            .filter(|n| !self.hoisted.contains(n))
+    }
+
+    /// Give `names` the lowest available wasm fn indices, ahead of everything
+    /// the caller slots afterwards. Registration order still drives type
+    /// indices and the un-hoisted fn indices; only these few functions move to
+    /// the front of the function and code sections.
+    ///
+    /// Callers use this to keep a builtin's fn index inside the single-byte
+    /// unsigned-LEB range no matter how many user functions the module has, so
+    /// a `call <idx>` naming it stays one byte wide in the callers' bodies.
+    /// Names that were never registered are skipped.
+    pub(super) fn assign_hoisted_fn_slots(
+        &mut self,
+        names: &[BuiltinName],
+        next_wasm_fn_idx: &mut u32,
+    ) {
+        for name in names.iter().copied() {
+            if !self.order.contains(&name) || self.hoisted.contains(&name) {
+                continue;
+            }
+            self.hoisted.push(name);
+            self.wasm_fn_idx.insert(name, *next_wasm_fn_idx);
+            *next_wasm_fn_idx += 1;
+        }
+    }
+
+    /// Number of builtins already hoisted — the size of the low block the
+    /// caller must leave between `_start` and the first user function.
+    pub(super) fn hoisted_len(&self) -> u32 {
+        self.hoisted.len() as u32
+    }
+
     pub(super) fn assign_slots(&mut self, next_wasm_fn_idx: &mut u32, next_type_idx: &mut u32) {
         for name in self.order.iter().copied() {
-            self.wasm_fn_idx.insert(name, *next_wasm_fn_idx);
+            // Type indices follow registration order for every builtin,
+            // hoisted or not, so the type section keeps one emission loop.
             self.wasm_type_idx.insert(name, *next_type_idx);
-            *next_wasm_fn_idx += 1;
             *next_type_idx += 1;
+            // A hoisted builtin already holds a low fn index; don't move it.
+            if self.wasm_fn_idx.contains_key(&name) {
+                continue;
+            }
+            self.wasm_fn_idx.insert(name, *next_wasm_fn_idx);
+            *next_wasm_fn_idx += 1;
         }
     }
 
@@ -526,12 +581,26 @@ impl BuiltinRegistry {
         self.wasm_type_idx.get(&name).copied()
     }
 
+    /// Bodies of the hoisted builtins — emitted right after `_start`, before
+    /// the user functions, matching their function-section entries.
+    pub(super) fn emit_hoisted_bodies(
+        &self,
+        codes: &mut CodeSection,
+        registry: &TypeRegistry,
+    ) -> Result<(), WasmGcError> {
+        for name in self.iter_hoisted() {
+            let func = name.emit_helper_body(registry)?;
+            codes.function(&func);
+        }
+        Ok(())
+    }
+
     pub(super) fn emit_helper_bodies(
         &self,
         codes: &mut CodeSection,
         registry: &TypeRegistry,
     ) -> Result<(), WasmGcError> {
-        for name in self.iter() {
+        for name in self.iter_unhoisted() {
             let func = name.emit_helper_body(registry)?;
             codes.function(&func);
         }

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -1082,6 +1082,33 @@ pub(super) fn emit_module_with(
         super::TargetMode::Wasip2 => wasip2_imports.import_count(),
     };
 
+    // ── Low block: the shared bignum sub-routines ──────────────────
+    //
+    // The four factored sub-routines are the only builtins the
+    // arithmetic helper bodies `call` by index, and those bodies are
+    // fixed-shape templates: a `call` whose target needs a second
+    // unsigned-LEB byte changes the body's length and no longer matches
+    // the template a reader synthesises from the declared index. Keeping
+    // them below 128 is therefore a property of the emitted bytes, not a
+    // convenience, so they get the lowest function indices in the module
+    // — right after `_start` and ahead of every user function — instead
+    // of trailing a user function count we don't control.
+    //
+    // `_start` stays at `import_count`; the i-th user fn now lives at
+    // `user_fn_base + i`. Registration order still drives type indices
+    // and every other builtin's fn index.
+    let mut next_low_fn_idx = import_count + 1;
+    builtin_registry.assign_hoisted_fn_slots(
+        &[
+            BuiltinName::AintDecompose,
+            BuiltinName::AintNormalize,
+            BuiltinName::AintStrip,
+            BuiltinName::AintUmagCmp,
+        ],
+        &mut next_low_fn_idx,
+    );
+    let user_fn_base = import_count + 1 + builtin_registry.hoisted_len();
+
     // ── Funcref table for first-class `Fn` values ──────────────────
     //
     // Every address-taken fn (referenced via `MirExpr::FnValue`) that
@@ -1091,18 +1118,18 @@ pub(super) fn emit_module_with(
     // table (table 0). Names that don't match a user fn (builtins /
     // variants) are excluded — those `FnValue` sites fall back to the
     // trap stub. The i-th user fn lives at wasm fn idx
-    // `import_count + 1 + i` (`_start` is at `import_count`).
+    // `user_fn_base + i`.
     let mut funcref_table: HashMap<String, u32> = HashMap::new();
     let mut funcref_wasm_idxs: Vec<u32> = Vec::new();
     for name in collect_address_taken(&mir_program) {
         if let Some(i) = fn_defs.iter().position(|fd| fd.name == name) {
             let table_idx = funcref_wasm_idxs.len() as u32;
             funcref_table.insert(name, table_idx);
-            funcref_wasm_idxs.push(import_count + 1 + (i as u32));
+            funcref_wasm_idxs.push(user_fn_base + (i as u32));
         }
     }
 
-    let mut next_builtin_fn_idx = import_count + 1 + (fn_defs.len() as u32);
+    let mut next_builtin_fn_idx = user_fn_base + (fn_defs.len() as u32);
     builtin_registry.assign_slots(&mut next_builtin_fn_idx, &mut next_type_idx);
     for name in builtin_registry.iter() {
         let p = name.params(&registry)?;
@@ -2064,10 +2091,18 @@ pub(super) fn emit_module_with(
     // ── Function section ───────────────────────────────────────────
     let mut funcs = FunctionSection::new();
     funcs.function(start_type_idx); // _start at wasm fn idx K
+    // Hoisted builtins occupy the block between `_start` and the user
+    // functions, so their entries come first (see `user_fn_base`).
+    for name in builtin_registry.iter_hoisted() {
+        let type_idx = builtin_registry
+            .lookup_wasm_type_idx(name)
+            .expect("just-assigned builtin type idx");
+        funcs.function(type_idx);
+    }
     for type_idx in &fn_type_indices {
         funcs.function(*type_idx);
     }
-    for name in builtin_registry.iter() {
+    for name in builtin_registry.iter_unhoisted() {
         let type_idx = builtin_registry
             .lookup_wasm_type_idx(name)
             .expect("just-assigned builtin type idx");
@@ -2489,11 +2524,14 @@ pub(super) fn emit_module_with(
     // wired in the post-emit phase further down. Globals + their
     // start-fn init are gone.)
 
-    // Build the FnId → wasm-fn-idx map. With K imports:
+    // Build the FnId → wasm-fn-idx map. With K imports and H hoisted
+    // builtins (the shared bignum sub-routines, `user_fn_base = K+1+H`):
     //   imports at idx 0..K
     //   _start at K
-    //   user fn i at K+1+i
-    //   builtin at K+1+N+m (assigned by builtin_registry already)
+    //   hoisted builtin h at K+1+h
+    //   user fn i at user_fn_base+i
+    //   every other builtin at user_fn_base+N+m (assigned by
+    //   builtin_registry already)
     //
     // `resolved_fn_defs` is position-aligned with `fn_defs`
     // (`WasmGcLinkedView::build` errors if the resolver drops any
@@ -2508,7 +2546,7 @@ pub(super) fn emit_module_with(
         by_id.insert(
             rfd.fn_id,
             FnEntry {
-                wasm_idx: import_count + 1 + (i as u32),
+                wasm_idx: user_fn_base + (i as u32),
                 return_type: fd.return_type.clone(),
             },
         );
@@ -2624,7 +2662,7 @@ pub(super) fn emit_module_with(
     };
     exports.export(start_export_name, ExportKind::Func, start_wasm_idx);
     for (i, fd) in fn_defs.iter().enumerate() {
-        let wasm_idx = import_count + 1 + (i as u32);
+        let wasm_idx = user_fn_base + (i as u32);
         exports.export(&fd.name, ExportKind::Func, wasm_idx);
     }
     if let Some(b) = &bridge {
@@ -2799,7 +2837,7 @@ pub(super) fn emit_module_with(
             mir_dispatch[i] = true;
             continue;
         }
-        let self_wasm_idx = import_count + 1 + (i as u32);
+        let self_wasm_idx = user_fn_base + (i as u32);
         let mut probe = Function::new([]);
         let used_mir = match mir_fn_for[i] {
             Some(mir_fn) => emit_fn_body_via_mir(
@@ -2878,7 +2916,7 @@ pub(super) fn emit_module_with(
                     handler_name.unwrap_or("?")
                 ))
             })?;
-        let user_handler_wasm_idx = import_count + 1 + (user_handler_idx as u32);
+        let user_handler_wasm_idx = user_fn_base + (user_handler_idx as u32);
 
         let string_idx = registry
             .string_array_type_idx
@@ -3036,7 +3074,7 @@ pub(super) fn emit_module_with(
     } else {
         let mut start = Function::new([]);
         if let Some(idx) = main_idx {
-            let main_idx_wasm = import_count + 1 + (idx as u32);
+            let main_idx_wasm = user_fn_base + (idx as u32);
             let main_returns_value = !fn_defs[idx].return_type.trim().eq("Unit");
             start.instruction(&Instruction::Call(main_idx_wasm));
             if main_returns_value {
@@ -3049,6 +3087,11 @@ pub(super) fn emit_module_with(
         start.instruction(&Instruction::End);
         codes.function(&start);
     }
+
+    // Hoisted builtin bodies — the shared bignum sub-routines, whose fn
+    // indices sit between `_start` and the first user function so the
+    // arithmetic helpers can name them in a single LEB byte.
+    builtin_registry.emit_hoisted_bodies(&mut codes, &registry)?;
 
     // Host-bound plan nodes (Int literals box; `intAdd` calls the carrier
     // add helper) encode against the module's own helper indices, which the
@@ -3066,7 +3109,7 @@ pub(super) fn emit_module_with(
         ..Default::default()
     };
     for (i, _fd) in fn_defs.iter().enumerate() {
-        let self_wasm_idx = import_count + 1 + (i as u32);
+        let self_wasm_idx = user_fn_base + (i as u32);
         if let (Some(plan), Some(carrier)) =
             (fragment_plan_for[i].as_ref(), registry.aint_struct_idx)
         {
@@ -3170,8 +3213,8 @@ pub(super) fn emit_module_with(
     }
 
     // Builtin helper bodies — emitted after user fns so their own
-    // wasm fn indices come last. Bodies are stubs today (Unreachable);
-    // real impls land in `builtins/` per phase 3c roadmap.
+    // wasm fn indices come last. The hoisted sub-routines already went
+    // out above; this covers the rest.
     builtin_registry.emit_helper_bodies(&mut codes, &registry)?;
 
     // Map helper bodies (hash, eq, empty, set, get, len per
@@ -3294,7 +3337,7 @@ pub(super) fn emit_module_with(
     )?;
 
     if let Some(hw) = &handler_wrapper {
-        let user_handler_wasm_idx = import_count + 1 + (hw.user_handler_idx as u32);
+        let user_handler_wasm_idx = user_fn_base + (hw.user_handler_idx as u32);
         // Reserve a caller_fn idx for the synthesised wrapper itself.
         // `emit_handler_wrapper` pushes this constant before every
         // host-effect `Call` to satisfy the ABI's trailing

--- a/tests/cert_whole_module_guard_iso.rs
+++ b/tests/cert_whole_module_guard_iso.rs
@@ -1391,3 +1391,174 @@ example : PlanCheck.encodeSymRawPlanToExprFragmentRawPlan
     );
     let _ = std::fs::remove_dir_all(out_dir);
 }
+
+/// Byte offset of the immediate of the first `call <callee>` inside the body of
+/// function `func`, plus the byte value sitting there. The `call` opcode is one
+/// byte and every index this test uses is below 128, so the immediate is the
+/// single byte right after it.
+fn call_immediate_offset(bytes: &[u8], func: u32, callee: u32) -> usize {
+    let mut imported_funcs = 0u32;
+    let mut code_ordinal = 0u32;
+    let mut found = None;
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        match payload.expect("compiler-produced wasm must parse") {
+            wasmparser::Payload::ImportSection(reader) => {
+                for group in reader {
+                    for import in group.expect("import group must parse") {
+                        let (_, import) = import.expect("import must parse");
+                        if matches!(import.ty, wasmparser::TypeRef::Func(_)) {
+                            imported_funcs += 1;
+                        }
+                    }
+                }
+            }
+            wasmparser::Payload::CodeSectionEntry(body) => {
+                if imported_funcs + code_ordinal == func {
+                    let mut operators = body.get_operators_reader().unwrap();
+                    while !operators.eof() {
+                        let opcode_offset = operators.original_position();
+                        if let wasmparser::Operator::Call { function_index } =
+                            operators.read().expect("operator must parse")
+                            && function_index == callee
+                            && found.is_none()
+                        {
+                            found = Some(opcode_offset + 1);
+                        }
+                    }
+                }
+                code_ordinal += 1;
+            }
+            _ => {}
+        }
+    }
+    let offset = found.expect("the named function must call the named callee");
+    assert_eq!(
+        u32::from(bytes[offset]),
+        callee,
+        "the call immediate must be a single byte"
+    );
+    offset
+}
+
+/// The arithmetic helper template pins the sub-routine CALL TARGETS, not just
+/// the surrounding skeleton.
+///
+/// The wall rebuilds each arith helper body from the manifest's declared
+/// `decompose`/`normalize`/`strip`/`umagCmp` indices and compares it to the real
+/// code bytes. Repointing one `call` inside the add helper — one byte, still a
+/// defined function, module still parses — must break that equality, otherwise
+/// the declaration would fix only the shape of the helper and leave the callee
+/// free. The isolation half is the honest artifact, which the certificate
+/// already proves passes the same check.
+///
+/// This also anchors the producer-side property the low-index block exists for:
+/// the declared sub-routine indices stay single-byte, so the rebuilt template
+/// and the emitted body agree byte for byte in the first place.
+#[test]
+fn arith_template_pins_the_subroutine_call_targets() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping arith call-target GuardIso test: `lake` not available");
+        return;
+    }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("cert-arith-call-target-guard-iso");
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("examples/data/json.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("compile json fixture for arith call-target GuardIso");
+    assert!(
+        compile.status.success(),
+        "json compile failed for arith call-target GuardIso:\n{}{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let wasm = std::fs::read(out_dir.join("json.wasm")).unwrap();
+    let (_, add_idx, _, _, _) =
+        aver::codegen::cert::byte_derived_frag_host_role_indices(&wasm).unwrap();
+    let add_idx = add_idx.expect("json add role");
+    // The declared sub-routine indices live in `Manifest.lean` — the literal the
+    // wall reads when it rebuilds the helper bodies.
+    let manifest_lean = std::fs::read_to_string(out_dir.join("cert/Manifest.lean")).unwrap();
+    let decompose: u32 = manifest_lean
+        .split("decompose := ")
+        .nth(1)
+        .expect("json manifest declares the decompose sub-routine index")
+        .split(|c: char| !c.is_ascii_digit())
+        .next()
+        .expect("the declared index is a number")
+        .parse()
+        .expect("the declared index parses");
+    assert!(
+        decompose < 128,
+        "the declared sub-routine index must fit one LEB byte, got {decompose}"
+    );
+    let call_offset = call_immediate_offset(&wasm, add_idx, decompose);
+
+    let cert = out_dir.join("cert");
+    materialize_wall(&cert);
+    let build = Command::new("lake")
+        .current_dir(&cert)
+        .arg("build")
+        .output()
+        .expect("build json certificate before arith call-target GuardIso");
+    assert!(
+        build.status.success(),
+        "json certificate failed before arith call-target GuardIso:\n{}{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let lean = format!(
+        r#"import Artifact
+
+open CertPrelude AverCert AverCert.Schema
+set_option maxRecDepth 300000
+
+-- Honest control: the declared table and params match the real bytes.
+example : AcceptedArtifact.arithTableCheck ArtifactBytes.modBytes ArtifactBytes.modLen
+    Artifact.data.manifest.subject.hostRoleTable
+    Artifact.data.manifest.subject.arithParams = true := by decide +kernel
+
+-- Repoint one `call` inside the add helper to the next function index. Nothing
+-- else moves: same length, same declaration, same claims.
+def repointedCallBytes : Nat := ArtifactBytes.modBytes +
+  (1 <<< (8 * {call_offset}))
+
+example : AcceptedArtifact.arithTableCheck repointedCallBytes ArtifactBytes.modLen
+    Artifact.data.manifest.subject.hostRoleTable
+    Artifact.data.manifest.subject.arithParams = false := by decide +kernel
+
+def repointedCallArtifact : AcceptedArtifact.ArtifactData :=
+  {{ Artifact.data with modBytes := repointedCallBytes }}
+example : ¬ AcceptedArtifact.decodedHostRoleTable repointedCallArtifact := by
+  intro h
+  have bad : AcceptedArtifact.arithTableCheck repointedCallBytes ArtifactBytes.modLen
+      Artifact.data.manifest.subject.hostRoleTable
+      Artifact.data.manifest.subject.arithParams = true := h
+  exact absurd bad (by decide +kernel)
+"#
+    );
+    std::fs::write(cert.join("ArithCallTargetGuardIso.lean"), lean).unwrap();
+    let check = Command::new("lake")
+        .current_dir(&cert)
+        .arg("env")
+        .arg("lean")
+        .arg("ArithCallTargetGuardIso.lean")
+        .output()
+        .expect("run arith call-target GuardIso");
+    assert!(
+        check.status.success(),
+        "arith call-target GuardIso failed:\n{}{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+    let _ = std::fs::remove_dir_all(out_dir);
+}

--- a/tests/cert_whole_module_guard_iso.rs
+++ b/tests/cert_whole_module_guard_iso.rs
@@ -53,6 +53,23 @@ fn assert_manifest_decode_declines(wasm: &std::path::Path, cert: &std::path::Pat
     );
 }
 
+/// Function index the export section binds `name` to.
+fn export_func_idx(bytes: &[u8], name: &str) -> u32 {
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let wasmparser::Payload::ExportSection(reader) =
+            payload.expect("compiler-produced wasm must parse")
+        {
+            for export in reader {
+                let export = export.expect("export must parse");
+                if export.kind == wasmparser::ExternalKind::Func && export.name == name {
+                    return export.index;
+                }
+            }
+        }
+    }
+    panic!("module exports no function named `{name}`")
+}
+
 fn section_offset_after_export(bytes: &[u8]) -> usize {
     fn read_uleb(bytes: &[u8], cursor: &mut usize) -> usize {
         let mut value = 0usize;
@@ -995,6 +1012,12 @@ fn inkernel_code_table_guard_is_isolated_and_weaken_confirmed() {
         String::from_utf8_lossy(&compile.stdout),
         String::from_utf8_lossy(&compile.stderr)
     );
+    // The SCC's two function indices, read out of the export section rather
+    // than assumed, so the probe follows the emitter's layout.
+    let wasm = std::fs::read(out_dir.join("mutual.wasm")).unwrap();
+    let even_idx = export_func_idx(&wasm, "isEven");
+    let odd_idx = export_func_idx(&wasm, "isOdd");
+
     let cert = out_dir.join("cert");
     materialize_wall(&cert);
     let build = Command::new("lake")
@@ -1009,19 +1032,20 @@ fn inkernel_code_table_guard_is_isolated_and_weaken_confirmed() {
         String::from_utf8_lossy(&build.stderr)
     );
 
-    let lean = r#"import Artifact
+    let lean = format!(
+        r#"import Artifact
 
 open CertPrelude AverCert AverCert.Schema
 set_option maxRecDepth 200000
 
 -- Same module bytes; only the manifest obligation's code table is hostile.
 def hostileEvenCode : CodeTbl := fun fn =>
-  if fn = 2 then none else AverCert.isEvenOb.code fn
+  if fn = {odd_idx} then none else AverCert.isEvenOb.code fn
 def hostileEvenOb : Obligation :=
-  { AverCert.isEvenOb with code := hostileEvenCode }
+  {{ AverCert.isEvenOb with code := hostileEvenCode }}
 def hostileManifest : Manifest :=
-  { AverCert.manifest with
-    obligations := hostileEvenOb :: AverCert.manifest.obligations.tail }
+  {{ AverCert.manifest with
+    obligations := hostileEvenOb :: AverCert.manifest.obligations.tail }}
 
 def evenObligation (m : Manifest) : Option Obligation :=
   m.obligations.find? (fun o => o.export_ = "isEven")
@@ -1032,16 +1056,17 @@ def mutualDecodeWitness (m : Manifest) : Prop :=
   | some obligation =>
       AverCert.AcceptedArtifact.decodedObligationFacts
         AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen
-        obligation [1, 2]
+        obligation [{even_idx}, {odd_idx}]
   | none => False
 
--- Deliberately weakened copy: the cross-member equality at index 2 is absent.
+-- Deliberately weakened copy: the cross-member equality at the other member's
+-- index is absent.
 def mutualDecodeWitnessWithoutCrossCode (m : Manifest) : Prop :=
   match evenObligation m with
   | some obligation =>
       AverCert.AcceptedArtifact.decodedObligationFacts
         AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen
-        obligation [1]
+        obligation [{even_idx}]
   | none => False
 
 example : mutualDecodeWitness AverCert.manifest := by
@@ -1056,17 +1081,18 @@ example : ¬ mutualDecodeWitness hostileManifest := by
   intro h
   change AverCert.AcceptedArtifact.decodedObligationFacts
     AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen
-    hostileEvenOb [1, 2] at h
+    hostileEvenOb [{even_idx}, {odd_idx}] at h
   have bad := h.2.2.1
   change CertDecode.decodeCode AverCert.ArtifactBytes.modBytes
-    AverCert.ArtifactBytes.modLen 2 = hostileEvenOb.code 2 at bad
-  have honestAtTwo :
+    AverCert.ArtifactBytes.modLen {odd_idx} = hostileEvenOb.code {odd_idx} at bad
+  have honestAtOther :
       CertDecode.decodeCode AverCert.ArtifactBytes.modBytes
-        AverCert.ArtifactBytes.modLen 2 = AverCert.isEvenOb.code 2 := rfl
-  have hostileAtTwo : hostileEvenOb.code 2 = none := rfl
-  rw [honestAtTwo, hostileAtTwo] at bad
+        AverCert.ArtifactBytes.modLen {odd_idx} = AverCert.isEvenOb.code {odd_idx} := rfl
+  have hostileAtOther : hostileEvenOb.code {odd_idx} = none := rfl
+  rw [honestAtOther, hostileAtOther] at bad
   cases bad
-"#;
+"#
+    );
     std::fs::write(cert.join("DecodeGuardIso.lean"), lean).unwrap();
     let check = Command::new("lake")
         .current_dir(&cert)

--- a/tests/snapshots/cert_certify_spec__add_one_certificate_package.snap
+++ b/tests/snapshots/cert_certify_spec__add_one_certificate_package.snap
@@ -7,7 +7,7 @@ expression: golden
   "schema_version": 3,
   "format": {"version": 1, "wall_id": "sha256:4e281312588930482d53cfe76e15fbcf530d11d20512015eefba1c008631fd9a"},
   "wasm": "add_one.wasm",
-  "wasm_sha256": "bdda9a1cdd38c016c35df53eae9c38060cfd1fdf9b0564f97610b91e1e9c4d16",
+  "wasm_sha256": "953714206598f8e60d9379741be9812878bf04be1beb9566428bbf191d236af4",
   "level": "L1",
   "profile": "AverUserProfile/v1",
   "abi": "aver-wasm-gc/0",
@@ -62,7 +62,7 @@ open AverCert.Schema CertPrelude
 
 abbrev addOneOb : Schema.Obligation :=
   { export_ := "addOne", policy := .simulatesModel, carrier := 2,
-    code := CertModule.addOneCode, host := fun add _ _ _ _ _ => CertModule.addOneHost add, self := 1,
+    code := CertModule.addOneCode, host := fun add _ _ _ _ _ => CertModule.addOneHost add, self := 5,
     Dom := List Int, Cod := Int,
     domRepr := fun S ns vs => ReprAll S.Repr ns vs ∧ ns.length = 1,
     codRepr := fun S n w => intRepr S n w,
@@ -70,7 +70,7 @@ abbrev addOneOb : Schema.Obligation :=
 
 def manifest : Schema.Manifest :=
   { subject :=
-      { artifactHash := "bdda9a1cdd38c016c35df53eae9c38060cfd1fdf9b0564f97610b91e1e9c4d16",
+      { artifactHash := "953714206598f8e60d9379741be9812878bf04be1beb9566428bbf191d236af4",
         profile := "AverUserProfile/v1",
         abi := "aver-wasm-gc/0",
         artifactRoot := "AverCert.Artifact.certificate",
@@ -79,7 +79,7 @@ def manifest : Schema.Manifest :=
         capabilities := [],
         start := none,
         hostRoleTable := some ({ box := some 6, add := some 7, mul := some 9, sub := some 8, toIndex := some 18 } : CertDecode.AddSub.Roles),
-        arithParams := some ({ carrier := 2, limb := 1, decompose := 2, normalize := 3, strip := 4, umagCmp := 5 } : ArithTemplateDerisk.ArithHostParams),
+        arithParams := some ({ carrier := 2, limb := 1, decompose := 1, normalize := 2, strip := 3, umagCmp := 4 } : ArithTemplateDerisk.ArithHostParams),
         stringHostRoles := [],
         contracts := ["__rt_aint_from_i64 (box i64 -> carrier)", "Int.add (carrier add = exact integer addition on represented values)"] },
     symFragmentPlans := [("addOne", Plans.addOneSymPlan)],
@@ -139,7 +139,7 @@ example : AverCert.PlanCheck.checkExprFragmentRawPlan addOnePlan = true := rfl
 
 /-- The audited Lean-side canonical lowerer maps `addOne`'s raw plan
 to the same instruction body emitted in `Module.lean`. -/
-example : (CertModule.addOneCode 1).map (fun c => c.body) =
+example : (CertModule.addOneCode 5).map (fun c => c.body) =
   AverCert.PlanLower.lowerExprFragmentBody 2 addOnePlan := rfl
 
 /-- The audited Lean-side byte lowerer maps `addOne`'s raw plan
@@ -150,7 +150,7 @@ example : AverCert.PlanBytes.lowerExprFragmentCodeEntry 2 addOnePlan =
 /-- The audited Lean-side Wasm slicer binds `addOne` to its function
 index, type index and exact expected code-entry bytes. -/
 example : AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen [97, 100, 100, 79, 110, 101] [13, 1, 1, 99, 2, 32, 0, 66, 1, 16, 6, 16, 7, 11] =
-  some ({ funcIdx := 1, typeIdx := 4, codeEntry := [13, 1, 1, 99, 2, 32, 0, 66, 1, 16, 6, 16, 7, 11] } : AverCert.WasmSlice.FuncBinding) := rfl
+  some ({ funcIdx := 5, typeIdx := 4, codeEntry := [13, 1, 1, 99, 2, 32, 0, 66, 1, 16, 6, 16, 7, 11] } : AverCert.WasmSlice.FuncBinding) := rfl
 
 /-- The audited Lean-side expr-fragment acceptance predicate aggregates
 plan checking, semantic lowering, byte lowering and byte-origin binding. -/
@@ -158,6 +158,6 @@ example : AverCert.ExprFragmentAccepted.accepted AverCert.ArtifactBytes.modBytes
   [97, 100, 100, 79, 110, 101] 2 addOnePlan
   [.localGet 0, .i64Const (1), .call 6, .call 7]
   [13, 1, 1, 99, 2, 32, 0, 66, 1, 16, 6, 16, 7, 11]
-  ({ funcIdx := 1, typeIdx := 4, codeEntry := [13, 1, 1, 99, 2, 32, 0, 66, 1, 16, 6, 16, 7, 11] } : AverCert.WasmSlice.FuncBinding) := by dsimp [AverCert.ExprFragmentAccepted.accepted]; exact ⟨rfl, rfl, rfl, rfl⟩
+  ({ funcIdx := 5, typeIdx := 4, codeEntry := [13, 1, 1, 99, 2, 32, 0, 66, 1, 16, 6, 16, 7, 11] } : AverCert.WasmSlice.FuncBinding) := by dsimp [AverCert.ExprFragmentAccepted.accepted]; exact ⟨rfl, rfl, rfl, rfl⟩
 
 end AverCert.Plans

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -253,3 +253,157 @@ fn json_sum_uses_nominal_root_in_variants_tuple_and_dispatch() {
         "specific pattern tests/casts must target concrete variants, not the sum root"
     );
 }
+
+/// The four shared bignum sub-routines keep single-byte function indices no
+/// matter how many functions the program declares.
+///
+/// The arithmetic helper bodies are fixed-shape templates whose `call`
+/// immediates name these four functions. A reader that rebuilds the same
+/// template from the declared indices splices each index as one raw byte, so
+/// an index of 128 or more — which wasm encodes as two LEB bytes — makes the
+/// rebuilt body shorter than the emitted one and the comparison fails.
+/// Slotting the sub-routines immediately after `_start`, ahead of the user
+/// functions, makes the bound a property of the emitter instead of a bet on
+/// how small the program happens to be.
+#[test]
+fn shared_bignum_subroutines_keep_single_byte_function_indices() {
+    use wasmparser::{CompositeInnerType, Operator, Parser as WasmParser, Payload};
+
+    // 150 user functions, all of them doing Int arithmetic — enough that a
+    // layout trailing the user functions would push the sub-routines past 128.
+    const USER_FNS: usize = 150;
+    let mut source = String::new();
+    source.push_str("module ManyArithmeticFns\n    exposes []\n    effects []\n\n");
+    for i in 0..USER_FNS {
+        source.push_str(&format!(
+            "fn step{i}(x: Int) -> Int\n    x + {i} * 2 - 1\n\n"
+        ));
+    }
+    source.push_str("fn main() -> Int\n    step0(1)\n");
+
+    let items = parse_pipeline(&source).expect("synthetic arithmetic program typechecks");
+    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None)
+        .expect("synthetic arithmetic program compiles to wasm-gc");
+    wasmparser::Validator::new()
+        .validate_all(&bytes)
+        .expect("synthetic arithmetic program validates");
+
+    let mut imported_funcs = 0u32;
+    // (param count, result count) per type index.
+    let mut type_sigs: Vec<(usize, usize)> = Vec::new();
+    let mut func_type_idx: Vec<u32> = Vec::new();
+    let mut exports: Vec<(String, u32)> = Vec::new();
+    let mut callees_per_body: Vec<Vec<u32>> = Vec::new();
+    for payload in WasmParser::new(0).parse_all(&bytes) {
+        match payload.expect("emitted module parses") {
+            Payload::TypeSection(reader) => {
+                for group in reader {
+                    for sub in group.expect("type group parses").into_types() {
+                        match &sub.composite_type.inner {
+                            CompositeInnerType::Func(ft) => {
+                                type_sigs.push((ft.params().len(), ft.results().len()))
+                            }
+                            _ => type_sigs.push((usize::MAX, usize::MAX)),
+                        }
+                    }
+                }
+            }
+            Payload::ImportSection(reader) => {
+                for group in reader {
+                    for import in group.expect("import group parses") {
+                        let (_, import) = import.expect("import parses");
+                        if matches!(import.ty, wasmparser::TypeRef::Func(_)) {
+                            imported_funcs += 1;
+                        }
+                    }
+                }
+            }
+            Payload::FunctionSection(reader) => {
+                for ty in reader {
+                    func_type_idx.push(ty.expect("function entry parses"));
+                }
+            }
+            Payload::ExportSection(reader) => {
+                for export in reader {
+                    let export = export.expect("export parses");
+                    if export.kind == wasmparser::ExternalKind::Func {
+                        exports.push((export.name.to_string(), export.index));
+                    }
+                }
+            }
+            Payload::CodeSectionEntry(body) => {
+                let mut calls = Vec::new();
+                let mut ops = body.get_operators_reader().expect("body reads");
+                while !ops.eof() {
+                    if let Operator::Call { function_index } = ops.read().expect("operator reads") {
+                        calls.push(function_index);
+                    }
+                }
+                callees_per_body.push(calls);
+            }
+            _ => {}
+        }
+    }
+
+    let sig_of = |wasm_idx: u32| -> (usize, usize) {
+        let def_idx = wasm_idx
+            .checked_sub(imported_funcs)
+            .expect("index names a defined function, not an import");
+        type_sigs[func_type_idx[def_idx as usize] as usize]
+    };
+
+    // The block sits immediately after `_start`, which itself sits at
+    // `imported_funcs` — so the four indices are consecutive from
+    // `imported_funcs + 1`.
+    let block: Vec<u32> = (1..=4).map(|k| imported_funcs + k).collect();
+    for idx in &block {
+        assert!(
+            *idx < 128,
+            "shared bignum sub-routine at fn index {idx} needs a two-byte LEB call immediate"
+        );
+    }
+
+    // Identify the block by signature: decompose is 1 -> 2, normalize 2 -> 1,
+    // strip 1 -> 1, umagCmp 4 -> 1. That multiset is unique to these four.
+    let mut sigs: Vec<(usize, usize)> = block.iter().copied().map(sig_of).collect();
+    sigs.sort();
+    let mut expected = vec![(1usize, 2usize), (2, 1), (1, 1), (4, 1)];
+    expected.sort();
+    assert_eq!(
+        sigs, expected,
+        "the four functions after `_start` are not the bignum sub-routines"
+    );
+
+    // Identity, not just shape: one emitted body (an arithmetic helper) calls
+    // all four of them.
+    assert!(
+        callees_per_body
+            .iter()
+            .any(|calls| block.iter().all(|idx| calls.contains(idx))),
+        "no emitted body calls all four sub-routines — the block is not what it claims"
+    );
+
+    // Every user function lands above the block, and there are enough of them
+    // that a trailing layout would have overflowed the single-byte range.
+    let user_fn_base = imported_funcs + 5;
+    let mut user_indices: Vec<u32> = exports
+        .iter()
+        .filter(|(name, _)| name.starts_with("step") || name == "main")
+        .map(|(_, idx)| *idx)
+        .collect();
+    user_indices.sort();
+    assert_eq!(
+        user_indices.len(),
+        USER_FNS + 1,
+        "every synthetic function is exported"
+    );
+    assert_eq!(
+        user_indices.first().copied(),
+        Some(user_fn_base),
+        "user functions start right above the sub-routine block"
+    );
+    assert!(
+        user_fn_base + (USER_FNS as u32) > 128,
+        "the fixture must be big enough that a trailing layout would exceed 128"
+    );
+}


### PR DESCRIPTION
The notepad example now reaches CERTIFIED with twelve exports — the same twelve its Data.Json dependency certifies when compiled on its own.

The compiler assigned every builtin a function index after every user function, so in a program with 155 user functions the four shared bignum sub-routines landed at 166-169. The trusted wall compares the emitted helper bodies against byte templates that splice a call target as a single raw byte, which is only valid below 128 — above it wasm encodes the index as multi-byte LEB128, the synthesized body is a byte short, and the comparison correctly fails. The four sub-routines now get a low block immediately after the entry function, so they sit at 1-4 regardless of program size. Nothing forced the previous order: wasm function order is free, the verifier derives helper roles from the bytes and the export section, and certification conflicts with the optimizer so the emitted layout is what gets certified.

Measured both ways on a synthetic 151-function module: with the old layout the artifact proof reports that the arithmetic table check is false; with the new one it certifies. A new producer test pins the four indices below 128 and consecutive from the first user slot, identifying the block by its call-signature multiset rather than by position. A new isolation test in the guard suite repoints one call target inside the add helper and shows the table check flips to false while the honest control stays true.

Also included: the artifact proof header now sets an elaboration budget matching the one the certificate proof already had. This is precautionary, not a measured fix — no artifact in the corpus was observed to exhaust the stock allowance, and nothing in this branch stopped failing because of it; the comment and commit message say so.

The mutual code-table isolation probe previously hard-coded the two member indices; it now reads them from the export section of the module it just compiled. The four assertions, their projections and their kernel discharges are unchanged. That test failed loudly on stale literals rather than passing weakly, which is evidence its content survives the change; the numbering itself is pinned explicitly by the new producer test and the package snapshot.

Snapshot delta (five lines) is entirely implied by the reorder: the single user function moves from index 1 to 5 and the arithmetic parameters shift from 2-5 to 1-4. Every code entry byte, including both call immediates, and the whole host role table are unchanged. Wall assets untouched; no wall identity bump.