### PR TITLE
Report the blocker that actually applies when a function cannot be certified

### DIFF
--- a/aver-cert/src/engine/classify_entry.rs
+++ b/aver-cert/src/engine/classify_entry.rs
@@ -57,14 +57,84 @@ fn classify_without_expr_fragment(
         });
     }
 
-    // ---- decline with an honest reason -----------------------------------
-    // Arity 2 is a supported signature (the accumulator-recursion template),
-    // so a 2-argument function that did not match falls through to the
-    // shape-based reasons below instead of a contradictory signature message.
-    if f.arity != 1 && f.arity != 2 {
+    // ---- decline with the blocker that actually applies --------------------
+    //
+    // Every template above has already had its shot, so this section only
+    // reports. It reports the blocker that survives fixing the others, in this
+    // order:
+    //
+    //   1. effects. A body that calls a host capability is not a pure function
+    //      of its arguments, so no signature and no rewrite of the rest of the
+    //      body could make it a simulation of the source model.
+    //   2. a module with no Int carrier, where every remaining template is out
+    //      of reach whatever this one export looks like.
+    //   3. what the export DECLARES — parameter shapes, then result shapes.
+    //      No rewrite of a body removes a String parameter or a record result.
+    //   4. what the body USES: control flow, then instructions outside the
+    //      opcode vocabulary.
+    //   5. what the body CALLS, which the composition and mutual-recursion
+    //      routes above do cover in specific shapes.
+    //   6. the arity-shaped template misses, LAST. A parameter count is only
+    //      ever the blocker once nothing else is, and reporting it first said
+    //      "unsupported signature" to hundreds of exports whose signature was
+    //      not the problem at all.
+    //
+    // Composition keeps the first word because it is still a certifying route:
+    // its chain callers are unary Int-carrier functions that call other user
+    // functions, so any check below would otherwise pre-empt a certificate.
+    match try_composition(f, box_idx, carrier, user_idx_set, fns) {
+        CompositionOutcome::Certified(c) => return Ok(*c),
+        CompositionOutcome::Declined(reason) => return Err(reason),
+        CompositionOutcome::NotApplicable => {}
+    }
+    if let Some(capability) = f.host_capability_calls.first() {
         return Err(format!(
-            "unsupported signature ({} params); Stage-B templates cover one-argument Int functions and two-argument accumulator recursion",
-            f.arity
+            "calls the host capability `{capability}`; certified templates simulate pure bodies, never effects"
+        ));
+    }
+    // A module can legitimately carry no Int runtime at all. Say so before any
+    // per-function shape complaint: every integer-family template cites the box
+    // helper, and the carrier-free templates above already had their shot, so
+    // in such a module nothing this export could be rewritten into would bind.
+    // Blaming its parameters here would point at a fix that cannot work.
+    if box_idx.is_none() {
+        return Err(
+            "body does not match a carrier-free certified template, and the module has no Int carrier host helpers (`__rt_aint_from_i64`); integer-family certification requires the Int carrier"
+                .to_string(),
+        );
+    }
+    if let Some((position, shape)) = f
+        .param_shapes
+        .iter()
+        .enumerate()
+        .find(|(_, shape)| shape.outside_scalar_fragment())
+    {
+        return Err(format!(
+            "parameter {} is {}; a value of that shape is certified only by the projection, variant-dispatch and String templates, and this body matches none of them",
+            position + 1,
+            shape.describe()
+        ));
+    }
+    if f.results.is_empty() {
+        return Err(
+            "returns nothing; every certified template simulates a function that returns one value"
+                .to_string(),
+        );
+    }
+    if f.results.len() > 1 {
+        return Err(format!(
+            "returns {} values; every certified template simulates a function that returns one",
+            f.results.len()
+        ));
+    }
+    if let Some(shape) = f
+        .result_shapes
+        .first()
+        .filter(|shape| shape.outside_scalar_fragment())
+    {
+        return Err(format!(
+            "returns {}; a value of that shape is built only by the constructor, projection, variant-dispatch and String templates, and this body matches none of them",
+            shape.describe()
         ));
     }
     if f.has_loop_or_branch {
@@ -73,13 +143,13 @@ fn classify_without_expr_fragment(
                 .to_string(),
         );
     }
-    // Cross-function composition: a unary chain caller whose entire call closure
-    // is itself certified by the straight-line integer shapes. A chain caller
-    // whose closure leaves the classes declines with a specific reason.
-    match try_composition(f, box_idx, carrier, user_idx_set, fns) {
-        CompositionOutcome::Certified(c) => return Ok(*c),
-        CompositionOutcome::Declined(reason) => return Err(reason),
-        CompositionOutcome::NotApplicable => {}
+    if f.ops.iter().any(|o| matches!(o, Op::Other)) {
+        return Err(match &f.first_unsupported_op {
+            Some(instruction) => format!(
+                "body uses the wasm instruction `{instruction}`, which is outside the certified fragment"
+            ),
+            None => "body uses wasm instructions outside the certified fragment".to_string(),
+        });
     }
     let calls_other_user = f
         .calls
@@ -87,25 +157,26 @@ fn classify_without_expr_fragment(
         .any(|c| *c != f.wasm_idx && user_idx_set.contains(c));
     if calls_other_user {
         return Err(
-            "calls other user functions (cross-function / mutual recursion), outside Stage-B scope"
+            "calls other user functions; only the composition and mutual-recursion templates cross function boundaries, and this body fits neither"
                 .to_string(),
         );
     }
-    if f.ops.iter().any(|o| matches!(o, Op::Other)) {
+    // Only now can a parameter count be the honest answer: the signature is
+    // scalar, the body is pure straight-line code that calls nobody, and still
+    // nothing matched. Name the family templates the arity ruled out rather
+    // than implying the signature is unsupported in general — the arity-free
+    // templates (field projection above all) accept any parameter count.
+    if f.arity == 0 {
         return Err(
-            "body uses opcodes outside the certified fragment (strings / ADTs / effects / tail calls)"
+            "takes no parameters; every certified template simulates a function of at least one argument"
                 .to_string(),
         );
     }
-    // A module can legitimately carry no Int runtime at all. Say so instead
-    // of the generic template list: every integer-family template cites the
-    // box helper, so it can never match here, and the carrier-free templates
-    // above already had their shot.
-    if box_idx.is_none() {
-        return Err(
-            "body does not match a carrier-free certified template, and the module has no Int carrier host helpers (`__rt_aint_from_i64`); integer-family certification requires the Int carrier"
-                .to_string(),
-        );
+    if f.arity > 2 {
+        return Err(format!(
+            "takes {} parameters; the arity-free templates did not match this body, and the recursion, ADT-construction, variant-dispatch, String and composition templates take one or two arguments",
+            f.arity
+        ));
     }
     Err("body does not match a certified template (straight-line add-constant, single-argument self-recursion, two-argument accumulator recursion, or non-recursive ADT constructor/projection/match)".to_string())
 }

--- a/aver-cert/src/engine/core_wasm.rs
+++ b/aver-cert/src/engine/core_wasm.rs
@@ -22,7 +22,61 @@ struct UserFn {
     ops: Vec<Op>,
     /// call targets in body order, for reason reporting.
     calls: Vec<u32>,
+    /// `module.name` of every host capability (function import) this body calls,
+    /// in body order. Diagnostic only: no certified template admits a call into
+    /// the import surface, so a non-empty list names the blocker outright.
+    host_capability_calls: Vec<String>,
+    /// The declared parameter kinds resolved against the module's own type
+    /// section, so a decline can say "a String" instead of "a reference to type
+    /// 20". Diagnostic only; every admission gate reads `params`.
+    param_shapes: Vec<ValShape>,
+    /// The declared result kinds, resolved the same way.
+    result_shapes: Vec<ValShape>,
+    /// The first instruction in the body that the opcode vocabulary does not
+    /// model, named as the disassembler saw it. Diagnostic only; `None` when
+    /// the body is fully in vocabulary or the instruction carried an operand
+    /// the disassembler could not resolve.
+    first_unsupported_op: Option<String>,
     has_loop_or_branch: bool,
+}
+
+/// What a declared parameter or result actually is, once its wasm type is
+/// resolved against the module's own type section. Purely for decline reasons:
+/// nothing is admitted or refused on a `ValShape`, so a misreading here can
+/// only make a message vaguer, never certify anything.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ValShape {
+    /// A reference to the Int carrier struct: a boxed `Int`.
+    Int,
+    /// A reference to a string byte-array type: a `String`.
+    Str,
+    /// Any other reference: a user record, variant or list value.
+    UserRef,
+    /// A bare machine scalar (`i64`, `i32`, `f64`) — `Int` in unboxed form,
+    /// `Bool`, or `Float`.
+    Scalar,
+    /// A wasm type outside the certificate's type vocabulary altogether.
+    Raw,
+}
+
+impl ValShape {
+    /// Whether the certified fragment treats this shape as an opaque value
+    /// rather than a number it can compute with. Scalars and boxed `Int`s are
+    /// the fragment's native vocabulary; everything else is only ever read or
+    /// built by one of the specific ADT/String templates.
+    fn outside_scalar_fragment(self) -> bool {
+        matches!(self, ValShape::Str | ValShape::UserRef | ValShape::Raw)
+    }
+
+    fn describe(self) -> &'static str {
+        match self {
+            ValShape::Int => "an Int",
+            ValShape::Str => "a String",
+            ValShape::UserRef => "a user record, variant or list value",
+            ValShape::Scalar => "a machine scalar",
+            ValShape::Raw => "a wasm type the certified fragment does not model",
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -32,6 +86,9 @@ struct CodeEntry {
     ops: Vec<Op>,
     calls: Vec<u32>,
     has_loop_or_branch: bool,
+    /// Name of the first instruction the opcode vocabulary does not model, as
+    /// the disassembler read it. Diagnostic only.
+    first_unsupported_op: Option<String>,
     host_role: Option<HostRole>,
     /// The first `i64` arithmetic operator seen in the body — the strict
     /// discriminator the plan-first host-role table uses to tell the

--- a/aver-cert/src/engine/disasm_hosts.rs
+++ b/aver-cert/src/engine/disasm_hosts.rs
@@ -252,6 +252,19 @@ fn resolve_data_ops(ops: Vec<Op>, data_segments: &[Option<Vec<u8>>]) -> Vec<Op> 
         .collect()
 }
 
+/// The name of an instruction the opcode vocabulary does not model, for the
+/// decline reason. `wasmparser`'s `Debug` prints the instruction first and its
+/// operands after (`I32Sub`, `LocalTee { local_index: 3 }`), so the leading
+/// identifier is exactly the instruction and nothing else. Diagnostic only: no
+/// admission decision ever reads this string.
+fn operator_name(op: &wasmparser::Operator<'_>) -> String {
+    format!("{op:?}")
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .next()
+        .unwrap_or_default()
+        .to_string()
+}
+
 fn heap_type_index(hty: wasmparser::HeapType) -> Option<u32> {
     match hty {
         wasmparser::HeapType::Concrete(idx) => idx.as_module_index(),

--- a/aver-cert/src/engine/disasm_module.rs
+++ b/aver-cert/src/engine/disasm_module.rs
@@ -168,6 +168,10 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
         .map_err(|e| format!("wasm module failed validation: {e}"))?;
 
     let mut num_imported_funcs: u32 = 0;
+    // `module.name` of every FUNCTION import, in index order. Purely diagnostic:
+    // a call into one of these is a call into the host capability surface, which
+    // no certified template admits, and the decline reason names it.
+    let mut imported_func_names: Vec<String> = Vec::new();
     // defined-function index -> declared type index
     let mut func_type_idx: Vec<u32> = Vec::new();
     // type index -> byte-level signature (param kinds, FULL result-kind vector)
@@ -283,6 +287,7 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
                         let (_, imp) = imp.map_err(|e| format!("import read: {e}"))?;
                         if let wasmparser::TypeRef::Func(_) = imp.ty {
                             num_imported_funcs += 1;
+                            imported_func_names.push(format!("{}.{}", imp.module, imp.name));
                         } else {
                             has_non_function_import = true;
                         }
@@ -339,6 +344,7 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
         let mut saw_i64_sub = false;
                 let mut first_i64_arith = None;
                 let mut first_arith_strict = None;
+                let mut first_unsupported_op: Option<String> = None;
                 let mut host_ops = Vec::new();
                 let mut opr = body
                     .get_operators_reader()
@@ -460,7 +466,16 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
                             array_type_index,
                             array_size,
                         } => Op::ArrayNewFixed(array_type_index, array_size),
-                        _ => Op::Other,
+                        _ => {
+                            // Record what the body actually used, so the
+                            // decline reason names the instruction instead of
+                            // guessing at a family. Reading `op` here is free:
+                            // no arm above moves anything out of it.
+                            if first_unsupported_op.is_none() {
+                                first_unsupported_op = Some(operator_name(&op));
+                            }
+                            Op::Other
+                        }
                     };
                     ops.push(mapped);
                 }
@@ -476,6 +491,7 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
                     ops,
                     calls,
                     has_loop_or_branch,
+                    first_unsupported_op,
                     host_role,
                     first_arith_strict,
                     kernel_arith_scan,
@@ -695,6 +711,16 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
         }
     };
 
+    // Resolve one declared wasm type against this module's own type section so
+    // a decline reason can name the source-level shape. Diagnostic only.
+    let value_shape = |ty: &TyKind| match ty {
+        TyKind::Ref { idx, .. } if Some(*idx) == carrier => ValShape::Int,
+        TyKind::Ref { idx, .. } if string_byte_array_types.contains(idx) => ValShape::Str,
+        TyKind::Ref { .. } | TyKind::Eqref => ValShape::UserRef,
+        TyKind::I64 | TyKind::I32 | TyKind::F64 => ValShape::Scalar,
+        TyKind::Other => ValShape::Raw,
+    };
+
     let mut user_fns = Vec::new();
     for (name, wasm_idx) in user_exports {
         let Some(def_idx) = wasm_idx.checked_sub(num_imported_funcs) else {
@@ -712,6 +738,8 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
             .cloned()
             .unwrap_or((Vec::new(), Vec::new()));
         let result = results.first().copied();
+        let param_shapes = params.iter().map(&value_shape).collect();
+        let result_shapes = results.iter().map(&value_shape).collect();
         user_fns.push(UserFn {
             name,
             wasm_idx,
@@ -723,6 +751,14 @@ fn disassemble(wasm_bytes: &[u8]) -> Result<DisasmResult, String> {
             nlocals: entry.nlocals,
             code_entry_bytes: entry.code_entry_bytes,
             ops,
+            host_capability_calls: entry
+                .calls
+                .iter()
+                .filter_map(|c| imported_func_names.get(*c as usize).cloned())
+                .collect(),
+            param_shapes,
+            result_shapes,
+            first_unsupported_op: entry.first_unsupported_op,
             calls: entry.calls,
             has_loop_or_branch: entry.has_loop_or_branch,
         });

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -3498,14 +3498,117 @@ fn certify_emits_declared_uncertified_package_for_module_without_int_helper() {
         !certified.contains("main"),
         "`main` is an effectful zero-argument export and must not certify"
     );
+    // `main` prints. That is what stops it being a pure simulation of the
+    // source model, and it is what the report must say: the parameter count it
+    // used to blame was never the blocker, since a zero-argument export with no
+    // effects declines for its arity only when nothing else applies.
     assert_eq!(
         declared.get("main").map(String::as_str),
         Some(
-            "unsupported signature (0 params); Stage-B templates cover \
-             one-argument Int functions and two-argument accumulator recursion"
+            "calls the host capability `aver.console_print`; \
+             certified templates simulate pure bodies, never effects"
         ),
-        "`main` must decline for its signature, not for the missing Int helper"
+        "`main` must decline for the effect it performs, not for its parameter \
+         count and not for the missing Int helper"
     );
+
+    let _ = std::fs::remove_dir_all(&out_dir);
+}
+
+/// Each declined export must be told what is actually stopping it. The Fibonacci
+/// example carries one export per blocker the classifier can distinguish, so it
+/// pins the whole vocabulary at once — and in particular pins that a parameter
+/// count is reported for `fibTR`, whose body really is a pure three-argument
+/// recursion, and for nothing else here.
+#[test]
+fn certify_declines_name_the_blocker_that_actually_applies() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let out_dir = temp_dir("certify-decline-blockers");
+
+    let compile = aver_command()
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("examples/data/fibonacci.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&out_dir)
+        .output()
+        .expect("expected `aver compile --certify` to run");
+    assert!(
+        compile.status.success(),
+        "fibonacci --certify failed:\n{}{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out_dir.join("cert").join("cert-manifest.json"))
+            .expect("cert-manifest.json exists"),
+    )
+    .expect("manifest is valid JSON");
+    let declared: BTreeMap<String, String> = manifest["declaredUncertified"]
+        .as_array()
+        .expect("declaredUncertified report is an array")
+        .iter()
+        .map(|entry| {
+            (
+                entry["name"]
+                    .as_str()
+                    .expect("entry has a name")
+                    .to_string(),
+                entry["reason"]
+                    .as_str()
+                    .expect("entry has a reason")
+                    .to_string(),
+            )
+        })
+        .collect();
+
+    for (export, reason) in [
+        // A pure three-argument tail recursion: nothing but the accumulator
+        // template's two-argument limit stands in its way, so the report says
+        // which family it missed instead of calling the signature unsupported.
+        (
+            "fibTR",
+            "takes 3 parameters; the arity-free templates did not match this body, \
+             and the recursion, ADT-construction, variant-dispatch, String and \
+             composition templates take one or two arguments",
+        ),
+        (
+            "main",
+            "calls the host capability `aver.console_print`; \
+             certified templates simulate pure bodies, never effects",
+        ),
+        (
+            "absF",
+            "body uses the wasm instruction `F64Sub`, which is outside the certified fragment",
+        ),
+        (
+            "finalizeFibStats",
+            "parameter 1 is a user record, variant or list value; a value of that shape \
+             is certified only by the projection, variant-dispatch and String templates, \
+             and this body matches none of them",
+        ),
+        (
+            "buildFibStats",
+            "returns a user record, variant or list value; a value of that shape is built \
+             only by the constructor, projection, variant-dispatch and String templates, \
+             and this body matches none of them",
+        ),
+        (
+            "fib",
+            "calls other user functions; only the composition and mutual-recursion \
+             templates cross function boundaries, and this body fits neither",
+        ),
+    ] {
+        assert_eq!(
+            declared.get(export).map(String::as_str),
+            Some(reason),
+            "`{export}` must decline with the blocker that actually applies to it"
+        );
+    }
 
     let _ = std::fs::remove_dir_all(&out_dir);
 }


### PR DESCRIPTION
Half of all decline reasons were wrong. The arity check sat near the top of the classifier chain, so any function with no parameters or three or more got told its signature was unsupported, whatever its real problem was. The check was inert as a gate — every path past it already ended in a decline, and moving it certifies nothing — but it shadowed the truth for 992 distinct exports.

The chain now reports the blocker that survives fixing the others: effects first, since a body that calls a host capability is not a pure function of its arguments whatever else it looks like; then the module-level carrier requirement; then what the signature declares, because no rewrite of a body removes a String parameter; then what the body uses; then what it calls; and only then arity, which now names the family templates it missed rather than implying the signature is unsupported in general.

The messages name causes a reader can act on: which host capability is called, which parameter has which shape and which templates accept that shape, which wasm instruction falls outside the vocabulary. Behind them are diagnostic-only fields carrying import names, resolved value shapes and the first unsupported instruction; no admission gate reads any of them.

The certified set is unchanged and proved so: a full corpus sweep on this branch and on main produces identical certified rows (219, matching on name, class, policy, level, domain, codomain and theorem) and an identical set of declined exports. Only the reason strings differ.

What the corrected attribution shows is worth recording: 77 percent of declines are signature-shaped, dominated by parameters and results that are user records, variants, lists or strings; effects are the next 11 percent. The instruction bucket is now readable and points straight at grammar gaps rather than at a guess-list.

One existing assertion changed — a zero-argument effectful export in the hello example whose pinned reason was the mislabel, and whose own test comment already described it as effectful. A new test pins six exports of one file to six distinct blockers, guarding both the vocabulary and the ordering.