### PR TITLE
Add Tcp.sendBytes — a byte-clean one-shot TCP call

### DIFF
--- a/aver-rt/src/tcp.rs
+++ b/aver-rt/src/tcp.rs
@@ -130,6 +130,35 @@ pub fn send(host: &str, port: i64, message: &str) -> Result<String, String> {
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
+/// Byte-clean sibling of [`send`].
+///
+/// Identical socket behaviour — open, write, `shutdown(Write)`, read to EOF —
+/// but the payload and the response stay `Vec<u8>` end to end. `send` converts
+/// the response with `String::from_utf8_lossy`, which replaces every non-UTF-8
+/// sequence with U+FFFD and cannot be undone; that makes it unusable for binary
+/// protocols whose framing bytes are not valid UTF-8. This function performs no
+/// encoding or decoding, so the caller sees exactly what the peer sent.
+pub fn send_bytes(host: &str, port: i64, payload: &[u8]) -> Result<Vec<u8>, String> {
+    validate_port(port)?;
+    let socket_addr = resolve(&format!("{}:{}", host, port))?;
+    let mut stream =
+        TcpStream::connect_timeout(&socket_addr, CONNECT_TIMEOUT).map_err(|e| e.to_string())?;
+    stream.set_read_timeout(Some(IO_TIMEOUT)).ok();
+    stream.set_write_timeout(Some(IO_TIMEOUT)).ok();
+    stream.write_all(payload).map_err(|e| e.to_string())?;
+    stream.shutdown(std::net::Shutdown::Write).ok();
+
+    let mut buf = Vec::new();
+    Read::by_ref(&mut stream)
+        .take(BODY_LIMIT as u64 + 1)
+        .read_to_end(&mut buf)
+        .map_err(|e| e.to_string())?;
+    if buf.len() > BODY_LIMIT {
+        return Err("Tcp.sendBytes: response exceeds 10 MB limit".to_string());
+    }
+    Ok(buf)
+}
+
 pub fn ping(host: &str, port: i64) -> Result<(), String> {
     validate_port(port)?;
     let socket_addr = resolve(&format!("{}:{}", host, port))?;

--- a/docs/services.md
+++ b/docs/services.md
@@ -257,6 +257,7 @@ Source: `src/services/tcp.rs`
 | Function | Signature |
 |---|---|
 | `Tcp.send` | `(String, Int, String) -> Result<String, String>` |
+| `Tcp.sendBytes` | `(String, Int, List<Int>) -> Result<List<Int>, String>` |
 | `Tcp.ping` | `(String, Int) -> Result<Unit, String>` |
 
 **Persistent connections:**
@@ -271,6 +272,15 @@ Source: `src/services/tcp.rs`
 `Tcp.Connection` is **opaque** from the surface: construction is reserved to `Tcp.connect` and field reads / pattern matches are rejected by the type checker. The handle is purely an identity token — the caller has nothing to inspect inside it. The underlying socket lives in a thread-local `HashMap` (VM / self-host / wasm-gc-bridge, keyed by `AtomicU64` "tcp-N") or a 256-slot wasm-gc array (`--target wasip2`, slot allocated via first-free scan + monotonic counter generation). Either way, manually forging an id is impossible: the type checker rejects the constructor.
 
 `Tcp.send` is stateless and ephemeral — it opens a fresh socket, writes the request bytes raw (no `\r\n` append), `shutdown(Write)` to signal end-of-request, then reads the peer's response until EOF, capped at 10 MiB. It does **not** touch the persistent-connection pool, so a program holding 256 live `Tcp.connect` handles can still issue `Tcp.send` to another peer. Stream errors (`stream-error.last-operation-failed`) surface as `Result.Err("tcp: stream error")`; a clean half-close (`stream-error.closed`) returns whatever the peer flushed.
+
+`Tcp.sendBytes` is the byte-clean form of `Tcp.send`: same socket behaviour, but
+the payload and response stay `List<Int>` and no UTF-8 encoding or decoding
+happens in either direction. Prefer it for any binary protocol. `Tcp.send`
+decodes the response with `String::from_utf8_lossy`, which replaces every
+non-UTF-8 sequence with U+FFFD — silently, irreversibly, and starting at the
+first offending byte — so it is only safe for protocols whose responses are
+valid UTF-8 text. Payload values outside `0..=255` return
+`Result.Err` naming the offending value and its index.
 
 ### `Random` namespace — use granular effects (`! [Random.int]`, `! [Random.float]`)
 

--- a/src/services/tcp.rs
+++ b/src/services/tcp.rs
@@ -282,9 +282,18 @@ fn bytes_arg(val: &Value, method: &str) -> Result<Result<Vec<u8>, String>, Runti
     let mut out = Vec::with_capacity(items.len());
     for (idx, item) in items.iter().enumerate() {
         let n = match item {
-            Value::Int(n) => n.to_i64().ok_or_else(|| {
-                RuntimeError::Error(format!("{}: payload must be a List<Int>", method))
-            })?,
+            Value::Int(n) => match n.to_i64() {
+                Some(n) => n,
+                // An `Int` outside `i64` is still an `Int` — a fortiori out
+                // of byte range, so it takes the catchable value-error path,
+                // not the type-error one.
+                None => {
+                    return Ok(Err(format!(
+                        "{}: byte {} at index {} is out of range (0\u{2013}255)",
+                        method, n, idx
+                    )));
+                }
+            },
             _ => {
                 return Err(RuntimeError::Error(format!(
                     "{}: payload must be a List<Int>",

--- a/src/services/tcp.rs
+++ b/src/services/tcp.rs
@@ -2,6 +2,10 @@
 ///
 /// One-shot methods:
 ///   `Tcp.send(host, port, message)` — connect, write message, read response, close.
+///   `Tcp.sendBytes(host, port, payload)` — same, but byte-clean: `List<Int>` in,
+///       `List<Int>` out, no UTF-8 encoding or decoding on either side. `send`
+///       decodes the response with `String::from_utf8_lossy`, which destroys any
+///       non-UTF-8 byte irrecoverably; binary protocols need this variant.
 ///   `Tcp.ping(host, port)`          — check whether the port accepts connections.
 ///
 /// Persistent-connection methods:
@@ -14,14 +18,22 @@
 use std::collections::HashMap;
 use std::sync::Arc as Rc;
 
-use aver_rt::TcpConnection;
+use aver_rt::{AverList, TcpConnection};
 
 use crate::nan_value::{Arena, NanValue, NanValueConvert};
 use crate::value::{RuntimeError, Value};
 
 pub fn register(global: &mut HashMap<String, Value>) {
     let mut members = HashMap::new();
-    for method in &["send", "ping", "connect", "writeLine", "readLine", "close"] {
+    for method in &[
+        "send",
+        "sendBytes",
+        "ping",
+        "connect",
+        "writeLine",
+        "readLine",
+        "close",
+    ] {
         members.insert(
             method.to_string(),
             Value::Builtin(format!("Tcp.{}", method)),
@@ -38,6 +50,7 @@ pub fn register(global: &mut HashMap<String, Value>) {
 
 pub const DECLARED_EFFECTS: &[&str] = &[
     "Tcp.send",
+    "Tcp.sendBytes",
     "Tcp.ping",
     "Tcp.connect",
     "Tcp.writeLine",
@@ -48,6 +61,7 @@ pub const DECLARED_EFFECTS: &[&str] = &[
 pub fn effects(name: &str) -> &'static [&'static str] {
     match name {
         "Tcp.send" => &["Tcp.send"],
+        "Tcp.sendBytes" => &["Tcp.sendBytes"],
         "Tcp.ping" => &["Tcp.ping"],
         "Tcp.connect" => &["Tcp.connect"],
         "Tcp.writeLine" => &["Tcp.writeLine"],
@@ -61,6 +75,7 @@ pub fn effects(name: &str) -> &'static [&'static str] {
 pub fn call(name: &str, args: &[Value]) -> Option<Result<Value, RuntimeError>> {
     match name {
         "Tcp.send" => Some(tcp_send(args)),
+        "Tcp.sendBytes" => Some(tcp_send_bytes(args)),
         "Tcp.ping" => Some(tcp_ping(args)),
         "Tcp.connect" => Some(tcp_connect(args)),
         "Tcp.writeLine" => Some(tcp_write_line(args)),
@@ -83,6 +98,29 @@ fn tcp_send(args: &[Value]) -> Result<Value, RuntimeError> {
 
     match aver_rt::tcp::send(&host, port, &message) {
         Ok(response) => Ok(Value::Ok(Box::new(Value::Str(response)))),
+        Err(e) => Ok(Value::Err(Box::new(Value::Str(e)))),
+    }
+}
+
+fn tcp_send_bytes(args: &[Value]) -> Result<Value, RuntimeError> {
+    if args.len() != 3 {
+        return Err(RuntimeError::Error(format!(
+            "Tcp.sendBytes() takes 3 arguments (host, port, payload), got {}",
+            args.len()
+        )));
+    }
+    let host = str_arg(&args[0], "Tcp.sendBytes: host must be a String")?;
+    let port = int_arg(&args[1], "Tcp.sendBytes: port must be an Int")?;
+    let payload = match bytes_arg(&args[2], "Tcp.sendBytes")? {
+        Ok(bytes) => bytes,
+        // Out-of-range byte values are a value error, not a type error, so they
+        // surface as a catchable `Result.Err` — same treatment the port range
+        // gets in `aver-rt::tcp` rather than a VM-only trap.
+        Err(msg) => return Ok(Value::Err(Box::new(Value::Str(msg)))),
+    };
+
+    match aver_rt::tcp::send_bytes(&host, port, &payload) {
+        Ok(response) => Ok(Value::Ok(Box::new(bytes_to_value(&response)))),
         Err(e) => Ok(Value::Err(Box::new(Value::Str(e)))),
     }
 }
@@ -225,6 +263,53 @@ fn str_arg(val: &Value, msg: &str) -> Result<String, RuntimeError> {
     }
 }
 
+/// Convert a `List<Int>` argument into raw bytes.
+///
+/// The outer `Result` is the type check (wrong shape is a `RuntimeError`); the
+/// inner one is the value check (an Int outside `0..=255` is a catchable Aver
+/// `Result.Err`, reported with its index so a long payload is debuggable).
+#[allow(clippy::type_complexity)]
+fn bytes_arg(val: &Value, method: &str) -> Result<Result<Vec<u8>, String>, RuntimeError> {
+    let items = match val {
+        Value::List(items) => items,
+        _ => {
+            return Err(RuntimeError::Error(format!(
+                "{}: payload must be a List<Int>",
+                method
+            )));
+        }
+    };
+    let mut out = Vec::with_capacity(items.len());
+    for (idx, item) in items.iter().enumerate() {
+        let n = match item {
+            Value::Int(n) => n.to_i64().ok_or_else(|| {
+                RuntimeError::Error(format!("{}: payload must be a List<Int>", method))
+            })?,
+            _ => {
+                return Err(RuntimeError::Error(format!(
+                    "{}: payload must be a List<Int>",
+                    method
+                )));
+            }
+        };
+        match u8::try_from(n) {
+            Ok(b) => out.push(b),
+            Err(_) => {
+                return Ok(Err(format!(
+                    "{}: byte {} at index {} is out of range (0\u{2013}255)",
+                    method, n, idx
+                )));
+            }
+        }
+    }
+    Ok(Ok(out))
+}
+
+fn bytes_to_value(bytes: &[u8]) -> Value {
+    let items: Vec<Value> = bytes.iter().map(|b| Value::int(*b as i64)).collect();
+    Value::List(AverList::from_vec(items))
+}
+
 fn int_arg(val: &Value, msg: &str) -> Result<i64, RuntimeError> {
     // Phase 4.7+ fix #13 — type check only; the port-range check
     // moved into `aver-rt::tcp::{connect, send, ping}` so every
@@ -242,7 +327,15 @@ fn int_arg(val: &Value, msg: &str) -> Result<i64, RuntimeError> {
 // ─── NanValue-native API ─────────────────────────────────────────────────────
 
 pub fn register_nv(global: &mut HashMap<String, NanValue>, arena: &mut Arena) {
-    let methods = &["send", "ping", "connect", "writeLine", "readLine", "close"];
+    let methods = &[
+        "send",
+        "sendBytes",
+        "ping",
+        "connect",
+        "writeLine",
+        "readLine",
+        "close",
+    ];
     let mut members: Vec<(Rc<str>, NanValue)> = Vec::with_capacity(methods.len());
     for method in methods {
         let idx = arena.push_builtin(&format!("Tcp.{}", method));
@@ -263,7 +356,13 @@ pub fn call_nv(
 ) -> Option<Result<NanValue, RuntimeError>> {
     if !matches!(
         name,
-        "Tcp.send" | "Tcp.ping" | "Tcp.connect" | "Tcp.writeLine" | "Tcp.readLine" | "Tcp.close"
+        "Tcp.send"
+            | "Tcp.sendBytes"
+            | "Tcp.ping"
+            | "Tcp.connect"
+            | "Tcp.writeLine"
+            | "Tcp.readLine"
+            | "Tcp.close"
     ) {
         return None;
     }

--- a/src/types/checker/builtins.rs
+++ b/src/types/checker/builtins.rs
@@ -128,6 +128,7 @@ impl TypeChecker {
                 "Env.set".to_string(),
                 "Tcp.connect".to_string(),
                 "Tcp.send".to_string(),
+                "Tcp.sendBytes".to_string(),
                 "Tcp.ping".to_string(),
                 "Tcp.writeLine".to_string(),
                 "Tcp.readLine".to_string(),
@@ -286,6 +287,15 @@ impl TypeChecker {
                 &[Type::Str, Type::Int, Type::Str],
                 Type::Result(Box::new(Type::Str), Box::new(Type::Str)),
                 &["Tcp.send"],
+            ),
+            (
+                "Tcp.sendBytes",
+                &[Type::Str, Type::Int, Type::List(Box::new(Type::Int))],
+                Type::Result(
+                    Box::new(Type::List(Box::new(Type::Int))),
+                    Box::new(Type::Str),
+                ),
+                &["Tcp.sendBytes"],
             ),
             (
                 "Tcp.ping",

--- a/src/types/checker/effect_classification.rs
+++ b/src/types/checker/effect_classification.rs
@@ -80,6 +80,10 @@ pub enum RuntimeType {
     TcpConnection,
     /// `Result<Tcp.Connection, Str>` — return of `Tcp.connect`.
     ResultTcpConnectionStr,
+    /// `List<Int>` — the byte payload argument on `Tcp.sendBytes`.
+    ListInt,
+    /// `Result<List<Int>, Str>` — return of `Tcp.sendBytes`.
+    ResultListIntStr,
 }
 
 impl RuntimeType {
@@ -111,6 +115,11 @@ impl RuntimeType {
             RuntimeType::ResultTcpConnectionStr => {
                 Type::Result(Box::new(Type::named("Tcp.Connection")), Box::new(Type::Str))
             }
+            RuntimeType::ListInt => Type::List(Box::new(Type::Int)),
+            RuntimeType::ResultListIntStr => Type::Result(
+                Box::new(Type::List(Box::new(Type::Int))),
+                Box::new(Type::Str),
+            ),
         }
     }
 }
@@ -283,6 +292,12 @@ const CLASSIFICATIONS: &[EffectClassification] = &[
         dimension: EffectDimension::GenerativeOutput,
         runtime_params: &[RuntimeType::Str, RuntimeType::Int, RuntimeType::Str],
         runtime_return: RuntimeType::ResultStrStr,
+    },
+    EffectClassification {
+        method: "Tcp.sendBytes",
+        dimension: EffectDimension::GenerativeOutput,
+        runtime_params: &[RuntimeType::Str, RuntimeType::Int, RuntimeType::ListInt],
+        runtime_return: RuntimeType::ResultListIntStr,
     },
     EffectClassification {
         method: "Tcp.ping",

--- a/src/vm/builtin.rs
+++ b/src/vm/builtin.rs
@@ -67,6 +67,7 @@ vm_builtins! {
     RandomFloat => "Random.float",
 
     TcpSend => "Tcp.send",
+    TcpSendBytes => "Tcp.sendBytes",
     TcpPing => "Tcp.ping",
     TcpConnect => "Tcp.connect",
     TcpWriteLine => "Tcp.writeLine",
@@ -274,6 +275,7 @@ impl VmBuiltin {
             Self::RandomInt | Self::RandomFloat => random::effects(self.name()),
 
             Self::TcpSend
+            | Self::TcpSendBytes
             | Self::TcpPing
             | Self::TcpConnect
             | Self::TcpWriteLine
@@ -358,6 +360,7 @@ impl VmBuiltin {
             Self::RandomInt | Self::RandomFloat => random::call_nv(self.name(), args, arena),
 
             Self::TcpSend
+            | Self::TcpSendBytes
             | Self::TcpPing
             | Self::TcpConnect
             | Self::TcpWriteLine

--- a/tests/eval_spec.rs
+++ b/tests/eval_spec.rs
@@ -2367,6 +2367,30 @@ mod tcp_tests {
             other => panic!("expected Err, got {:?}", other),
         }
     }
+
+    /// An `Int` outside `i64` is still an `Int` — a fortiori out of byte
+    /// range, so it must take the same catchable value-error path as `256`,
+    /// not trap as a bogus type error.
+    #[test]
+    fn tcp_send_bytes_rejects_bignum_byte() {
+        let src = concat!(
+            "fn talk() -> Result<List<Int>, String>\n",
+            "    ! [Tcp.sendBytes]\n",
+            "    Tcp.sendBytes(\"127.0.0.1\", 1, [65, 1208925819614629174706176])\n",
+        );
+        match run_tcp_fn(src, "talk") {
+            Value::Err(inner) => match *inner {
+                Value::Str(msg) => {
+                    assert!(
+                        msg.contains("1208925819614629174706176") && msg.contains("index 1"),
+                        "error should name the offending byte and its index, got: {msg}"
+                    );
+                }
+                other => panic!("expected Str error, got {:?}", other),
+            },
+            other => panic!("expected Err, got {:?}", other),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/eval_spec.rs
+++ b/tests/eval_spec.rs
@@ -2298,6 +2298,75 @@ mod tcp_tests {
             other => panic!("expected Ok(\"echo me\"), got {:?}", other),
         }
     }
+
+    /// Regression: `Tcp.send` decodes the response with
+    /// `String::from_utf8_lossy`, so every non-UTF-8 byte comes back as U+FFFD
+    /// and the original is unrecoverable. `Tcp.sendBytes` must round-trip the
+    /// bytes untouched. The payload here is the Bitcoin mainnet magic
+    /// (`F9 BE B4 D9`) — four bytes that are each invalid UTF-8 for a different
+    /// reason, so a regression on any decode path shows up here.
+    #[test]
+    #[ignore = "integration: starts a local TCP server; run with --include-ignored --test-threads=1"]
+    fn tcp_send_bytes_round_trips_non_utf8() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = Vec::new();
+                stream.read_to_end(&mut buf).ok();
+                stream.write_all(&buf).ok();
+            }
+        });
+
+        let src = format!(
+            "fn talk() -> Result<List<Int>, String>\n    ! [Tcp.sendBytes]\n    Tcp.sendBytes(\"127.0.0.1\", {}, [249, 190, 180, 217])\n",
+            port
+        );
+        match run_tcp_fn(&src, "talk") {
+            Value::Ok(inner) => match *inner {
+                Value::List(items) => {
+                    let got: Vec<i64> = items
+                        .iter()
+                        .map(|v| match v {
+                            Value::Int(n) => n.to_i64().unwrap(),
+                            other => panic!("expected Int element, got {:?}", other),
+                        })
+                        .collect();
+                    assert_eq!(got, vec![249, 190, 180, 217]);
+                }
+                other => panic!("expected List, got {:?}", other),
+            },
+            other => panic!("expected Ok(List<Int>), got {:?}", other),
+        }
+    }
+
+    /// Byte values outside `0..=255` are a value error, not a type error, so
+    /// they surface as a catchable `Result.Err` rather than a VM trap — the
+    /// same treatment the port range gets.
+    #[test]
+    fn tcp_send_bytes_rejects_out_of_range_byte() {
+        let src = concat!(
+            "fn talk() -> Result<List<Int>, String>\n",
+            "    ! [Tcp.sendBytes]\n",
+            "    Tcp.sendBytes(\"127.0.0.1\", 1, [65, 256])\n",
+        );
+        match run_tcp_fn(src, "talk") {
+            Value::Err(inner) => match *inner {
+                Value::Str(msg) => {
+                    assert!(
+                        msg.contains("256") && msg.contains("index 1"),
+                        "error should name the offending byte and its index, got: {msg}"
+                    );
+                }
+                other => panic!("expected Str error, got {:?}", other),
+            },
+            other => panic!("expected Err, got {:?}", other),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/website/llms.txt
+++ b/tools/website/llms.txt
@@ -333,7 +333,7 @@ Effectful namespaces:
 - `Console`: print, error, warn, readLine — **`print`/`error`/`warn` take `String`**, not arbitrary values. Stringify at the call site: interpolation `"{x}"` for primitives, a per-type render fn (`fn show(r: Result<T, E>) -> String`) for compound shapes.
 - `Http`: get, post, put, patch, delete, head
 - `Disk`: readText, writeText, appendText, exists, delete, deleteDir, listDir, makeDir
-- `Tcp`: connect, writeLine, readLine, close, send, ping
+- `Tcp`: connect, writeLine, readLine, close, send, sendBytes, ping — `send`/`readLine` are text-only (UTF-8); use `sendBytes` (`List<Int>` in and out) for binary protocols
 - `Terminal`: enableRawMode, readKey, setCursor, print, clear, size — `Terminal.print` and `Terminal.setColor` also take `String`.
 - `Time`: now, unixMs, sleep
 - `Env`: get, set


### PR DESCRIPTION
# Add `Tcp.sendBytes` — a byte-clean one-shot TCP call

Fixes #763. Broader context, including the other three binary-protocol
blockers this does *not* address: #753.

## The problem

`aver-rt/src/tcp.rs` ends `send` with:

```rust
Ok(String::from_utf8_lossy(&buf).into_owned())
```

Every non-UTF-8 sequence in the response becomes U+FFFD. The substitution is
many-to-one — 128 of the 256 possible single bytes collapse to the same
replacement character — so it cannot be undone. It is also silent: the call
returns `Result.Ok` with mangled data, and `String.len` reports the same length
an uncorrupted read would, so neither the return shape nor a length check
reveals it.

That makes every binary protocol unreachable from Aver. Demonstrated against a
server that always replies with the four bytes `F9 BE B4 D9` (the Bitcoin
mainnet magic — chosen because each byte is invalid UTF-8 for a different
reason):

```
Tcp.send      -> Result.Ok("����")
Tcp.sendBytes -> Result.Ok([249, 190, 180, 217])
```

## The change

Adds `Tcp.sendBytes : (String, Int, List<Int>) -> Result<List<Int>, String>`.

Identical socket behaviour to `Tcp.send` — open, write, `shutdown(Write)`, read
to EOF, same 10 MB cap, same timeouts, same port validation — but the payload
and the response stay bytes end to end, with no encoding or decoding in either
direction.

### Design decisions

**Additive, not a fix in place.** Changing `Tcp.send`'s return type would break
every existing caller, and making it error on invalid UTF-8 would regress
callers who currently tolerate lossy text. A sibling method leaves existing code
untouched and lets the docs steer new code to the right one.

**`List<Int>` as the byte carrier.** Follows the existing `Byte` namespace
convention, which already operates on `Int` rather than introducing a byte
primitive. Worth a maintainer opinion: `Vector<Int>` would give O(1) indexed
access, which matters more when parsing a length-prefixed header than when
sending one. I went with `List<Int>` for consistency with `Args.get` and
`Disk.listDir`, and because `Vector.fromList` makes the conversion cheap at the
one place it matters.

**Out-of-range bytes are catchable, not fatal.** A value outside `0..=255`
returns `Result.Err("Tcp.sendBytes: byte 256 at index 1 is out of range
(0–255)")` rather than trapping — the same treatment the port range gets after
Phase 4.7+ fix #13. The index is included so a long payload is debuggable. A
non-`List<Int>` argument is still a type error, caught statically.

## What's wired

- `aver-rt::tcp::send_bytes` — the runtime call
- VM path: service dispatch, `register`/`register_nv`, `DECLARED_EFFECTS`,
  `effects`, and the `VmBuiltin` enum
- Type checker: signature and effect registration
- Effect classification: `GenerativeOutput`, with two new `RuntimeType`
  variants (`ListInt`, `ResultListIntStr`). Oracle `verify <fn> trace` works
  with a `given tcp: Tcp.sendBytes = [stub]` binding — confirmed against
  `.result`, `.trace.length()` and `.trace.contains()`

## What's not wired — deliberately, and I'd like direction

**Codegen backends.** `Tcp.sendBytes` is VM-only. I stopped there rather than
guess at three backends in a first PR:

- **Rust codegen** currently reports `Compiled ... [Rust]`, then the generated
  project fails at `cargo build` with "MIR walker could not render the `main` fn
  body". Not a silent miscompile, but the error arrives one stage too late. The
  binding itself looks like a short arm next to the existing `Tcp.send` one; the
  `Vec<u8>` ↔ `AverList` conversion is the only real work.
- **wasm-gc** rejects it — but so does any program with a `List<Int>` literal,
  with or without this change (`List literal: cannot resolve list instantiation
  (got List<Int>)`). I verified that against the released 0.27.1 binary too, so
  it's pre-existing and orthogonal.
- **wasip2** already rejects all `Tcp.*` as host territory, so nothing to do.

Happy to extend to any of these if you'd point me at the shape you'd want.

**CHANGELOG.** Left alone on purpose — `AGENTS.md` is explicit that
`tools/release.py` owns version headers, and adding an entry means guessing the
next version number.

`cargo fmt --all -- --check` passes clean (rustfmt 1.9.0) with no diff.

## Tests

Two added to `tests/eval_spec.rs`, alongside the existing `tcp_tests`:

- `tcp_send_bytes_round_trips_non_utf8` — echo server, asserts
  `[249, 190, 180, 217]` survives intact. Marked `#[ignore]` like its
  `tcp_send_echo_server` neighbour since it binds a socket.
- `tcp_send_bytes_rejects_out_of_range_byte` — asserts the error names both the
  offending value and its index.

Manually verified: empty payload → `Result.Ok([])`; connection refused,
out-of-range port, and a `String` passed where `List<Int>` is expected all
produce the right diagnostics.
