### PR TITLE
Discover list instantiations from bare literals in wasm-gc codegen

### DIFF
--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -40,7 +40,7 @@ use super::types_discovery::{
     collect_vectors_from_fn_body, collect_vectors_from_str, is_primitive,
 };
 
-use crate::ast::{TopLevel, TypeDef};
+use crate::ast::{TopLevel, Type, TypeDef};
 
 /// User-type lookup tables built once before any fn body emit.
 pub(super) struct TypeRegistry {
@@ -2339,7 +2339,8 @@ fn effect_implies_builtin_record(effect: &str, record_name: &str) -> bool {
 /// ever appears in the binding annotation. Mirrors `collect_options
 /// _from_fn_body` and `collect_vectors_from_fn_body`. Also walks
 /// expressions to catch builtin calls like `String.chars` whose
-/// return type (`List<String>`) only appears as a stdlib signature.
+/// return type (`List<String>`) only appears as a stdlib signature,
+/// plus unannotated list literals whose type only exists as a stamp.
 fn collect_lists_from_fn_body(
     fd: &crate::ir::hir::ResolvedFnDef,
     out: &mut HashMap<String, u32>,
@@ -2357,20 +2358,40 @@ fn collect_lists_from_fn_body(
             collect_lists_from_str(&annot.display(), out, order, next_idx);
         }
         let expr = match stmt {
-            ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => &e.node,
+            ResolvedStmt::Binding { value: e, .. } | ResolvedStmt::Expr(e) => e,
         };
         collect_lists_from_expr(expr, out, order, next_idx);
     }
 }
 
+fn type_is_concrete_for_discovery(ty: &Type) -> bool {
+    match ty {
+        Type::Var(_) | Type::Invalid => false,
+        Type::Int | Type::Float | Type::Str | Type::Bool | Type::Unit | Type::Named { .. } => true,
+        Type::Option(inner) | Type::List(inner) | Type::Vector(inner) => {
+            type_is_concrete_for_discovery(inner)
+        }
+        Type::Result(ok, err) => {
+            type_is_concrete_for_discovery(ok) && type_is_concrete_for_discovery(err)
+        }
+        Type::Map(key, value) => {
+            type_is_concrete_for_discovery(key) && type_is_concrete_for_discovery(value)
+        }
+        Type::Tuple(items) => items.iter().all(type_is_concrete_for_discovery),
+        Type::Fn(params, ret, _) => {
+            params.iter().all(type_is_concrete_for_discovery) && type_is_concrete_for_discovery(ret)
+        }
+    }
+}
+
 fn collect_lists_from_expr(
-    expr: &crate::ir::hir::ResolvedExpr,
+    expr: &crate::ast::Spanned<crate::ir::hir::ResolvedExpr>,
     out: &mut HashMap<String, u32>,
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ir::hir::{ResolvedCallee, ResolvedExpr};
-    match expr {
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr, ResolvedStrPart};
+    match &expr.node {
         ResolvedExpr::Call(callee, args) => {
             // `String.chars(s)` returns `List<String>` — register it
             // eagerly here since the canonical never appears in fn
@@ -2385,57 +2406,86 @@ fn collect_lists_from_expr(
                     *next_idx += 1;
                 }
             }
+            if let ResolvedCallee::Unresolved { callee } = callee {
+                collect_lists_from_expr(callee, out, order, next_idx);
+            }
             for a in args {
-                collect_lists_from_expr(&a.node, out, order, next_idx);
+                collect_lists_from_expr(a, out, order, next_idx);
             }
         }
         ResolvedExpr::BinOp(_, l, r) => {
-            collect_lists_from_expr(&l.node, out, order, next_idx);
-            collect_lists_from_expr(&r.node, out, order, next_idx);
+            collect_lists_from_expr(l, out, order, next_idx);
+            collect_lists_from_expr(r, out, order, next_idx);
         }
-        ResolvedExpr::Neg(inner) => collect_lists_from_expr(&inner.node, out, order, next_idx),
+        ResolvedExpr::Neg(inner) => collect_lists_from_expr(inner, out, order, next_idx),
         ResolvedExpr::Match { subject, arms } => {
-            collect_lists_from_expr(&subject.node, out, order, next_idx);
+            collect_lists_from_expr(subject, out, order, next_idx);
             for arm in arms {
-                collect_lists_from_expr(&arm.body.node, out, order, next_idx);
+                collect_lists_from_expr(&arm.body, out, order, next_idx);
             }
         }
         ResolvedExpr::TailCall { args, .. } => {
             for a in args {
-                collect_lists_from_expr(&a.node, out, order, next_idx);
+                collect_lists_from_expr(a, out, order, next_idx);
             }
         }
-        ResolvedExpr::Attr(obj, _) => collect_lists_from_expr(&obj.node, out, order, next_idx),
+        ResolvedExpr::Attr(obj, _) => collect_lists_from_expr(obj, out, order, next_idx),
         ResolvedExpr::RecordCreate { fields, .. } => {
             for (_, e) in fields {
-                collect_lists_from_expr(&e.node, out, order, next_idx);
+                collect_lists_from_expr(e, out, order, next_idx);
             }
         }
         ResolvedExpr::RecordUpdate { base, updates, .. } => {
-            collect_lists_from_expr(&base.node, out, order, next_idx);
+            collect_lists_from_expr(base, out, order, next_idx);
             for (_, e) in updates {
-                collect_lists_from_expr(&e.node, out, order, next_idx);
+                collect_lists_from_expr(e, out, order, next_idx);
             }
         }
         ResolvedExpr::Ctor(_, args) => {
             for a in args {
-                collect_lists_from_expr(&a.node, out, order, next_idx);
+                collect_lists_from_expr(a, out, order, next_idx);
             }
         }
         ResolvedExpr::Tuple(items) | ResolvedExpr::IndependentProduct(items, _) => {
             for it in items {
-                collect_lists_from_expr(&it.node, out, order, next_idx);
+                collect_lists_from_expr(it, out, order, next_idx);
             }
         }
-        ResolvedExpr::ErrorProp(inner) => {
-            collect_lists_from_expr(&inner.node, out, order, next_idx)
+        ResolvedExpr::ErrorProp(inner) => collect_lists_from_expr(inner, out, order, next_idx),
+        ResolvedExpr::InterpolatedStr(parts) => {
+            for part in parts {
+                if let ResolvedStrPart::Parsed(inner) = part {
+                    collect_lists_from_expr(inner, out, order, next_idx);
+                }
+            }
         }
         ResolvedExpr::List(items) => {
+            if let Some(ty) = expr.ty()
+                && matches!(ty, Type::List(_))
+                && type_is_concrete_for_discovery(ty)
+            {
+                collect_lists_from_str(&ty.display(), out, order, next_idx);
+            } else if let Some(elem_ty) = items.first().and_then(|item| item.ty())
+                && type_is_concrete_for_discovery(elem_ty)
+            {
+                collect_lists_from_str(
+                    &format!("List<{}>", elem_ty.display()),
+                    out,
+                    order,
+                    next_idx,
+                );
+            }
             for x in items {
-                collect_lists_from_expr(&x.node, out, order, next_idx);
+                collect_lists_from_expr(x, out, order, next_idx);
             }
         }
-        _ => {}
+        ResolvedExpr::MapLiteral(entries) => {
+            for (key, value) in entries {
+                collect_lists_from_expr(key, out, order, next_idx);
+                collect_lists_from_expr(value, out, order, next_idx);
+            }
+        }
+        ResolvedExpr::Literal(_) | ResolvedExpr::Ident(_) | ResolvedExpr::Resolved { .. } => {}
     }
 }
 

--- a/src/codegen/wasm_gc/types_discovery.rs
+++ b/src/codegen/wasm_gc/types_discovery.rs
@@ -624,7 +624,7 @@ pub(super) fn collect_options_from_expr(
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ir::hir::{ResolvedCallee, ResolvedExpr};
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr, ResolvedStrPart};
     match expr {
         ResolvedExpr::Call(callee, args) => {
             // `String.charAt(s, i)` and `Char.fromCode(code)` both
@@ -643,6 +643,9 @@ pub(super) fn collect_options_from_expr(
                     order.push(canonical);
                     *next_idx += 1;
                 }
+            }
+            if let ResolvedCallee::Unresolved { callee } = callee {
+                collect_options_from_expr(&callee.node, out, order, next_idx);
             }
             for a in args {
                 collect_options_from_expr(&a.node, out, order, next_idx);
@@ -681,7 +684,9 @@ pub(super) fn collect_options_from_expr(
                 collect_options_from_expr(&a.node, out, order, next_idx);
             }
         }
-        ResolvedExpr::Tuple(items) | ResolvedExpr::IndependentProduct(items, _) => {
+        ResolvedExpr::List(items)
+        | ResolvedExpr::Tuple(items)
+        | ResolvedExpr::IndependentProduct(items, _) => {
             for it in items {
                 collect_options_from_expr(&it.node, out, order, next_idx);
             }
@@ -689,7 +694,20 @@ pub(super) fn collect_options_from_expr(
         ResolvedExpr::ErrorProp(inner) => {
             collect_options_from_expr(&inner.node, out, order, next_idx)
         }
-        _ => {}
+        ResolvedExpr::InterpolatedStr(parts) => {
+            for part in parts {
+                if let ResolvedStrPart::Parsed(inner) = part {
+                    collect_options_from_expr(&inner.node, out, order, next_idx);
+                }
+            }
+        }
+        ResolvedExpr::MapLiteral(entries) => {
+            for (key, value) in entries {
+                collect_options_from_expr(&key.node, out, order, next_idx);
+                collect_options_from_expr(&value.node, out, order, next_idx);
+            }
+        }
+        ResolvedExpr::Literal(_) | ResolvedExpr::Ident(_) | ResolvedExpr::Resolved { .. } => {}
     }
 }
 
@@ -728,7 +746,7 @@ pub(super) fn collect_vectors_from_expr(
     order: &mut Vec<String>,
     next_idx: &mut u32,
 ) {
-    use crate::ir::hir::{ResolvedExpr, ResolvedStrPart};
+    use crate::ir::hir::{ResolvedCallee, ResolvedExpr, ResolvedStrPart};
     match expr {
         ResolvedExpr::Call(callee, args) => {
             // `Vector.new(n, fill)` instantiates `Vector<T>` where `T` is
@@ -747,6 +765,9 @@ pub(super) fn collect_vectors_from_expr(
             {
                 let canonical = format!("Vector<{}>", fill_ty.display());
                 collect_vectors_from_str(&canonical, out, order, next_idx);
+            }
+            if let ResolvedCallee::Unresolved { callee } = callee {
+                collect_vectors_from_expr(&callee.node, out, order, next_idx);
             }
             for a in args {
                 collect_vectors_from_expr(&a.node, out, order, next_idx);
@@ -794,7 +815,9 @@ pub(super) fn collect_vectors_from_expr(
                 collect_vectors_from_expr(&a.node, out, order, next_idx);
             }
         }
-        ResolvedExpr::Tuple(items) | ResolvedExpr::IndependentProduct(items, _) => {
+        ResolvedExpr::List(items)
+        | ResolvedExpr::Tuple(items)
+        | ResolvedExpr::IndependentProduct(items, _) => {
             for it in items {
                 collect_vectors_from_expr(&it.node, out, order, next_idx);
             }
@@ -815,7 +838,13 @@ pub(super) fn collect_vectors_from_expr(
                 }
             }
         }
-        _ => {}
+        ResolvedExpr::MapLiteral(entries) => {
+            for (key, value) in entries {
+                collect_vectors_from_expr(&key.node, out, order, next_idx);
+                collect_vectors_from_expr(&value.node, out, order, next_idx);
+            }
+        }
+        ResolvedExpr::Literal(_) | ResolvedExpr::Ident(_) | ResolvedExpr::Resolved { .. } => {}
     }
 }
 

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -108,6 +108,59 @@ fn parse_pipeline(source: &str) -> Result<Vec<TopLevel>, String> {
     Ok(items)
 }
 
+fn assert_compiles_and_validates(source: &str) {
+    let items = parse_pipeline(source).unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None)
+        .unwrap_or_else(|e| panic!("wasm-gc compile: {e}\n--- source ---\n{source}"));
+    wasmparser::Validator::new()
+        .validate_all(&bytes)
+        .unwrap_or_else(|e| panic!("wasmparser validate: {e}\n--- source ---\n{source}"));
+}
+
+#[test]
+fn bare_list_literal_inside_interpolation_compiles() {
+    assert_compiles_and_validates(
+        r#"module Probe
+    intent = "Minimal List<Int> literal for wasm-gc compilation."
+    exposes [main]
+    effects [Console.print]
+
+fn main() -> Unit
+    ? "Print a list literal."
+    ! [Console.print]
+    Console.print("{[1, 2, 3]}")
+"#,
+    );
+}
+
+#[test]
+fn unannotated_list_binding_compiles() {
+    assert_compiles_and_validates(
+        r#"module Probe
+    intent = "Compile an unannotated list binding."
+    exposes [main]
+
+fn main() -> Int
+    xs = [1, 2, 3]
+    List.len(xs)
+"#,
+    );
+}
+
+#[test]
+fn nested_unannotated_list_literal_compiles() {
+    assert_compiles_and_validates(
+        r#"module Probe
+    intent = "Compile a nested unannotated list literal."
+    exposes [main]
+
+fn main() -> Int
+    xss = [[1], [2, 3]]
+    List.len(xss)
+"#,
+    );
+}
+
 #[test]
 fn wasm_gc_codegen_emits_valid_module_for_every_single_file_example() {
     let files = single_file_examples();


### PR DESCRIPTION
The wasm-gc backend rejected any program whose only `List<T>` instantiation appears as a bare list literal — `Console.print("{[1, 2, 3]}")` in a `Unit` fn failed with ``List literal: cannot resolve list instantiation (got `List<Int>`)``. Surfaced by @n1bor while testing #764.

Two independent gaps in type discovery:

- a list literal's own instantiation was never registered — discovery walked fn signatures, `let` annotations, and record fields, so the emitter's canonical resolution succeeded but the registry lookup missed;
- the expression walkers never traversed string interpolations (or map literals), so nothing inside `"{...}"` was visible to discovery at all.

The body walk now carries `Spanned` nodes so the checker's type stamps are readable; list literals register their stamped type, behind a structural concreteness guard, with a first-element fallback mirroring the emitter's hint chain. All three collectors (lists, options, vectors) got the missing traversal arms, and the expression matches are now exhaustive, so a future HIR variant fails the build instead of silently skipping discovery.

Three regressions in `wasm_gc_codegen_regression`: interpolated bare literal, unannotated binding, nested literal — each compiled and validated with `wasmparser`.

`wasm_gc_codegen_regression` 5/5, `wasm_gc_spec` 37/37, `cargo fmt --check` clean, clippy clean with wasm features.
