### PR TITLE
Split the per-claim acceptance proof so large certificates verify under memory

### DIFF
--- a/aver-cert/src/engine/render_composition.rs
+++ b/aver-cert/src/engine/render_composition.rs
@@ -74,12 +74,21 @@ fn composition_claim_lean_value(c: &Cert, add_idx: u32) -> String {
     )
 }
 
-fn composition_claim_acceptance_proof(
-    c: &Cert,
-    strict: FragHostTable,
-) -> String {
+/// Render the companion `{name}_compositionClaimAccepted` acceptance as a SPLIT
+/// proof, mirroring `render_composition_claim_bundles` in `render_project.rs`.
+///
+/// Returns `(declarations, aggregate_proof)`: the per-member witness `def`s and
+/// leaf theorems to emit before the aggregate theorem, and the aggregate proof
+/// term the theorem's `exact` uses. This bridge module re-proves acceptance in a
+/// standalone file, so it carried the same monolithic member tuple the artifact
+/// root did; naming each member's body/code-entry/binding and hoisting the
+/// member `modBytes` walks into leaves keeps the module's per-claim peak bounded.
+fn composition_bridge_claim_accepted(c: &Cert, strict: FragHostTable) -> (String, String) {
     let Cert::Composition {
-        carrier, closure, ..
+        name,
+        carrier,
+        closure,
+        ..
     } = c.inner()
     else {
         unreachable!()
@@ -89,9 +98,19 @@ fn composition_claim_acceptance_proof(
     let add_idx = strict
         .add_idx
         .expect("plan-backed composition has strict add host");
+    let host_table = composition_host_table_lean_value(add_idx);
     let funcs = composition_func_table(closure);
+    let host_types = format!("{name}CompositionHostTypes");
+    // Shared host-table type pin; one leaf serves the claim and every member.
+    let mut declarations = format!(
+        "-- Claim-level host-table declared-function-type pin, shared by the claim\n\
+         -- and every member (a `modBytes` type-section walk).\n\
+         theorem {host_types} :\n  \
+           AverCert.WasmSlice.hostTableFuncTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table} = true := by\n  \
+           rfl\n\n"
+    );
     let mut named_proof = "trivial".to_string();
-    for (entry, plan) in plans.iter().rev() {
+    for (member_index, (entry, plan)) in plans.iter().enumerate().rev() {
         let body = render_ops_value(
             &lower_composition_plan(plan, add_idx, &funcs)
                 .expect("composition member lowers against closure table"),
@@ -100,17 +119,36 @@ fn composition_claim_acceptance_proof(
             &composition_code_entry_bytes(plan, *carrier, add_idx, &funcs)
                 .expect("composition member byte-lowers against closure table"),
         );
-        let binding = format!(
-            "({{ funcIdx := {}, typeIdx := {}, codeEntry := {} }} : \
-             AverCert.WasmSlice.FuncBinding)",
-            entry.self_idx, entry.type_idx, code_entry
+        let export_name_bytes = render_byte_list(entry.name.as_bytes());
+        let body_def = format!("{name}CompositionMember{member_index}Body");
+        let code_def = format!("{name}CompositionMember{member_index}CodeEntry");
+        let binding_def = format!("{name}CompositionMember{member_index}Binding");
+        let func_binding = format!("{name}CompositionMember{member_index}FuncBinding");
+        let func_type = format!("{name}CompositionMember{member_index}FuncType");
+        declarations = format!(
+            "-- Member `{member_index}` witness data as named constants.\n\
+             def {body_def} : List CertPrelude.WInstr := {body}\n\n\
+             def {code_def} : AverCert.WasmSlice.ByteSeq := {code_entry}\n\n\
+             def {binding_def} : AverCert.WasmSlice.FuncBinding :=\n  \
+               {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_def} }}\n\n\
+             theorem {func_binding} :\n  \
+               AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_def} = some {binding_def} := by\n  \
+               rfl\n\n\
+             theorem {func_type} :\n  \
+               AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding_def}.typeIdx 1 {carrier} = true := by\n  \
+               rfl\n\n{declarations}",
+            self_idx = entry.self_idx,
+            type_idx = entry.type_idx,
         );
         let member_proof = format!(
-            "⟨rfl, ⟨({body}), ({code_entry}), {binding}, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩"
+            "⟨rfl, ⟨{body_def}, {code_def}, {binding_def}, rfl, rfl, {func_binding}, {func_type}, {host_types}, rfl⟩⟩"
         );
         named_proof = format!("⟨{member_proof}, {named_proof}⟩");
     }
-    format!("⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, {named_proof}⟩⟩⟩⟩⟩⟩⟩")
+    let aggregate_proof = format!(
+        "⟨rfl, ⟨rfl, ⟨rfl, ⟨{host_types}, ⟨rfl, ⟨rfl, ⟨rfl, {named_proof}⟩⟩⟩⟩⟩⟩⟩"
+    );
+    (declarations, aggregate_proof)
 }
 
 /// Option-(b) composition bridge. Root glue is discharged by the audited
@@ -275,12 +313,14 @@ fn render_composition_semantic_bridge(
             .join(", ")
     );
     let claim = composition_claim_lean_value(c, add_idx);
-    let acceptance = composition_claim_acceptance_proof(c, analysis.frag_host_table);
+    let (claim_decls, acceptance) =
+        composition_bridge_claim_accepted(c, analysis.frag_host_table);
     s.push_str(&format!(
         "def {name}CompositionMembers : List AverCert.AcceptedArtifact.CompositionMemberClaim :=\n  \
          {members}\n\n\
          def {name}CompositionClaim : AverCert.AcceptedArtifact.CompositionClaim :=\n  \
          {claim}\n\n\
+         {claim_decls}\
          theorem {name}_compositionClaimAccepted :\n    \
          AverCert.AcceptedArtifact.compositionClaimAccepted\n      \
          AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen\n      \

--- a/aver-cert/src/engine/render_expr_fragment_bridge.rs
+++ b/aver-cert/src/engine/render_expr_fragment_bridge.rs
@@ -60,8 +60,27 @@ fn expr_fragment_claim_lean_value(
     )
 }
 
-/// Reconstruct the same byte/plan witness emitted as DATA in `Artifact.lean`.
-fn expr_fragment_claim_acceptance_proof(c: &Cert) -> String {
+/// Render the `{name}_exprFragmentClaimAccepted` theorem as a SPLIT proof:
+/// witness data (the lowered `WInstr` body, code-entry bytes, function binding)
+/// as named `def`s and each acceptance conjunct as its OWN leaf theorem, then an
+/// aggregate that combines the already-checked constants. This mirrors
+/// `render_sym_claim_bundles` in `render_project.rs` and exists for the SAME
+/// reason: emitting one monolithic `exact ⟨…giant nested tuple…⟩` submits the
+/// whole witness to the kernel in a single `addDecl` and holds it live, which
+/// peaked `Certificate.lean` at ~6.5 GB — co-equal with, and independent of, the
+/// artifact root's own peak. Splitting each piece into its own declaration drops
+/// the peak to the largest single leaf (a `modBytes` decode / type-section walk,
+/// each ≤ ~1.2 GB). The leaf conjuncts are stated over `AverCert.Plans.{name}Plan`
+/// (the encoded plan), definitionally the value the aggregate reduces to, so the
+/// aggregate re-runs no heavy reduction.
+///
+/// `claim_target` is what `symFragmentClaimAccepted` is applied to — the `claim`
+/// value inline, or a `{name}TagDispatchClaim` def the caller already emitted.
+fn render_expr_fragment_claim_accepted_split(
+    c: &Cert,
+    claim_target: &str,
+    host_table_lean: &str,
+) -> String {
     let Cert::ExprFragment {
         carrier,
         self_idx,
@@ -72,25 +91,67 @@ fn expr_fragment_claim_acceptance_proof(c: &Cert) -> String {
     else {
         unreachable!()
     };
-    let code_entry_bytes = lower_expr_fragment_plan_code_entry_bytes(plan, *carrier)
+    let name = c.name();
+    let carrier = *carrier;
+    let code_entry_bytes = lower_expr_fragment_plan_code_entry_bytes(plan, carrier)
         .expect("generic expr-fragment plan lowers to code-entry bytes");
     let code_entry_bytes = render_byte_list(&code_entry_bytes);
-    let lowered_body = lower_expr_fragment_plan(plan, *carrier)
+    let lowered_body = lower_expr_fragment_plan(plan, carrier)
         .map(|ops| render_ops_value(&ops))
         .expect("generic expr-fragment plan lowers to WInstr body");
-    let binding = format!(
-        "({{ funcIdx := {self_idx}, typeIdx := {type_idx}, \
-         codeEntry := {code_entry_bytes} }} : AverCert.WasmSlice.FuncBinding)"
-    );
-    // The first component discharges the byte-derived carrier binding
-    // (`symFragmentCarrierBound`) and the second the host-table
-    // declared-function-type pin (`hostTableFuncTypesMatch`), both stated
-    // ahead of the export/carrier binds. Both are Boolean checks the kernel
-    // runs, so neither is keyed on anything this emitter has to recompute:
-    // when the binding does not apply the check answers `true` by itself.
+    let export_name_bytes = render_byte_list(name.as_bytes());
+    let plan_ref = format!("AverCert.Plans.{name}Plan");
+    let body = format!("{name}ClaimBody");
+    let code_entry = format!("{name}ClaimCodeEntry");
+    let binding = format!("{name}ClaimBinding");
+    let carrier_bound = format!("{name}ClaimCarrierBound");
+    let host_types = format!("{name}ClaimHostTableFuncTypes");
+    let check_plan = format!("{name}ClaimCheckPlan");
+    let lower_body = format!("{name}ClaimLowerBody");
+    let lower_code = format!("{name}ClaimLowerCodeEntry");
+    let func_binding = format!("{name}ClaimFuncBinding");
+    let func_type = format!("{name}ClaimFuncTypeMatches");
+    let nominal = format!("{name}ClaimNominalTypes");
+    let accepted = format!("{name}_exprFragmentClaimAccepted");
     format!(
-        "⟨rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {binding}, \
-         ⟨⟨rfl, rfl, rfl, rfl⟩, rfl, rfl, rfl, rfl⟩⟩⟩"
+        "-- Witness data as named constants so no large literal is baked into the\n\
+         -- aggregate acceptance term (the source of this file's memory peak).\n\
+         def {body} : List CertPrelude.WInstr := {lowered_body}\n\n\
+         def {code_entry} : AverCert.WasmSlice.ByteSeq := {code_entry_bytes}\n\n\
+         def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+           {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry} }}\n\n\
+         -- One leaf theorem per acceptance conjunct, each checked and freed in its\n\
+         -- own `addDecl`.\n\
+         theorem {carrier_bound} :\n  \
+           AverCert.AcceptedArtifact.symFragmentCarrierBound AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table_lean} {plan_ref} = true := by\n  \
+           rfl\n\n\
+         theorem {host_types} :\n  \
+           AverCert.WasmSlice.hostTableFuncTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table_lean} = true := by\n  \
+           rfl\n\n\
+         theorem {check_plan} :\n  \
+           AverCert.PlanCheck.checkExprFragmentRawPlan {plan_ref} = true := by\n  \
+           rfl\n\n\
+         theorem {lower_body} :\n  \
+           AverCert.PlanLower.lowerExprFragmentBody {carrier} {plan_ref} = some {body} := by\n  \
+           rfl\n\n\
+         theorem {lower_code} :\n  \
+           AverCert.PlanBytes.lowerExprFragmentCodeEntry {carrier} {plan_ref} = some {code_entry} := by\n  \
+           rfl\n\n\
+         theorem {func_binding} :\n  \
+           AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+           rfl\n\n\
+         theorem {func_type} :\n  \
+           AverCert.WasmSlice.exprFragmentFuncTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx {carrier} {plan_ref}.params {plan_ref}.result = true := by\n  \
+           rfl\n\n\
+         theorem {nominal} :\n  \
+           AverCert.WasmSlice.exprFragmentNominalTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx {carrier} {plan_ref} = true := by\n  \
+           rfl\n\n\
+         -- Aggregate: combine the already-checked leaf constants.\n\
+         theorem {accepted} :\n  \
+           AverCert.AcceptedArtifact.symFragmentClaimAccepted\n    \
+             AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {claim_target} := by\n  \
+           unfold AverCert.AcceptedArtifact.symFragmentClaimAccepted\n  \
+           exact ⟨{carrier_bound}, {host_types}, rfl, rfl, ⟨{body}, {code_entry}, {binding}, ⟨⟨{check_plan}, {lower_body}, {lower_code}, {func_binding}⟩, {func_type}, {nominal}, rfl, rfl⟩⟩⟩\n"
     )
 }
 
@@ -131,8 +192,8 @@ fn render_expr_fragment_tag_dispatch_semantic_bridge(
     let carrier = c.carrier();
     let claim_name = format!("{name}TagDispatchClaim");
     let claim = expr_fragment_claim_lean_value(c, host_table, struct_table_lean);
-    let acceptance = expr_fragment_claim_acceptance_proof(c);
     let host_table_lean = host_table.lean_value();
+    let claim_accepted = render_expr_fragment_claim_accepted_split(c, &claim_name, &host_table_lean);
     let tag = lean_int_lit(face.tag);
     let then_c = lean_int_lit(face.then_c);
     let else_c = lean_int_lit(face.else_c);
@@ -165,12 +226,7 @@ fn render_expr_fragment_tag_dispatch_semantic_bridge(
 
 def {claim_name} : AverCert.AcceptedArtifact.SymFragmentClaim := {claim}
 
-theorem {name}_exprFragmentClaimAccepted :
-    AverCert.AcceptedArtifact.symFragmentClaimAccepted
-      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {claim_name} := by
-  unfold AverCert.AcceptedArtifact.symFragmentClaimAccepted
-  exact {acceptance}
-
+{claim_accepted}
 theorem {name}_exprFragmentSemanticBridge :
     AcceptanceSoundness.exprFragmentSemanticBridge {claim_name}
       AverCert.Plans.{name}Plan := by
@@ -198,17 +254,12 @@ fn render_expr_fragment_int_add_semantic_bridge(
     let carrier = c.carrier();
     let k = lean_int_lit(face.k);
     let claim = expr_fragment_claim_lean_value(c, host_table, struct_table_lean);
-    let acceptance = expr_fragment_claim_acceptance_proof(c);
     let host_table_lean = host_table.lean_value();
+    let claim_accepted = render_expr_fragment_claim_accepted_split(c, &claim, &host_table_lean);
     format!(
         r#"/-! ### {name} — option-(b) integer expr-fragment semantic bridge -/
 
-theorem {name}_exprFragmentClaimAccepted :
-    AverCert.AcceptedArtifact.symFragmentClaimAccepted
-      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {claim} := by
-  unfold AverCert.AcceptedArtifact.symFragmentClaimAccepted
-  exact {acceptance}
-
+{claim_accepted}
 theorem {name}_exprFragmentSemanticBridge :
     AcceptanceSoundness.exprFragmentSemanticBridge {claim}
       AverCert.Plans.{name}Plan := by
@@ -424,7 +475,6 @@ fn render_expr_fragment_int_bool_semantic_bridge(
     let model_name = c.model_lean_name(model_info);
     debug_assert_eq!(plan.result, FragTy::BoolI32);
     let claim = expr_fragment_claim_lean_value(c, host_table, struct_table_lean);
-    let acceptance = expr_fragment_claim_acceptance_proof(c);
     let result = expr_fragment_wval_expr(plan, &|idx, _ty| format!("a{idx}"));
     let input_values = plan
         .params
@@ -465,6 +515,7 @@ fn render_expr_fragment_int_bool_semantic_bridge(
          popArgs, initLocals, {model_name}"
     );
     let host_table_lean = host_table.lean_value();
+    let claim_accepted = render_expr_fragment_claim_accepted_split(c, &claim, &host_table_lean);
     let eval_tactic = expr_fragment_bridge_eval_tactic(
         plan,
         name,
@@ -475,12 +526,7 @@ fn render_expr_fragment_int_bool_semantic_bridge(
     format!(
         r#"/-! ### {name} — option-(b) integer/Bool expr-fragment semantic bridge -/
 
-theorem {name}_exprFragmentClaimAccepted :
-    AverCert.AcceptedArtifact.symFragmentClaimAccepted
-      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {claim} := by
-  unfold AverCert.AcceptedArtifact.symFragmentClaimAccepted
-  exact {acceptance}
-
+{claim_accepted}
 theorem {name}_exprFragmentSemanticBridge :
     AcceptanceSoundness.exprFragmentSemanticBridge {claim}
       AverCert.Plans.{name}Plan := by

--- a/aver-cert/src/engine/render_mutual.rs
+++ b/aver-cert/src/engine/render_mutual.rs
@@ -24,11 +24,21 @@ fn mutual_claim_lean_value(c: &Cert) -> String {
     )
 }
 
-/// Concrete byte/plan acceptance for one member of the shared SCC.  This is
-/// data reconstruction only; source-model semantics lives in the bridge below.
-fn mutual_claim_acceptance_proof(c: &Cert) -> String {
+/// Render one SCC member's `{name}_mutualClaimAccepted` companion theorem as a
+/// SPLIT proof, mirroring `render_mutual_claim_bundles` in `render_project.rs`.
+///
+/// This shared bridge module re-proves acceptance for every SCC member in a
+/// standalone file, so it carried the same monolithic witness tuple the artifact
+/// root did. Emitting the lowered body, code-entry bytes and function binding as
+/// named `def`s and each byte-walking conjunct as its own leaf theorem keeps the
+/// per-member kernel peak at the largest single leaf. The leaves are stated over
+/// `AverCert.Plans.{name}MutualPlan`, so the aggregate re-runs no decode work.
+fn render_mutual_bridge_claim_accepted(c: &Cert) -> String {
     let Cert::MutualRecursion {
+        name,
         carrier,
+        box_idx,
+        sub_idx,
         position,
         scc,
         ..
@@ -37,21 +47,67 @@ fn mutual_claim_acceptance_proof(c: &Cert) -> String {
         unreachable!("audited mutual acceptance has a mutual-recursion shape")
     };
     let member = &scc[*position];
-    let plan = mutual_plan_from_cert(c).expect("audited mutual member has a canonical plan");
-    let body = lower_expr_fragment_plan(&plan, *carrier)
+    let plan_cert = mutual_plan_from_cert(c).expect("audited mutual member has a canonical plan");
+    let lowered_body = lower_expr_fragment_plan(&plan_cert, *carrier)
         .map(|ops| render_ops_value(&ops))
         .expect("audited mutual plan lowers to WInstr");
-    let bytes = lower_expr_fragment_plan_code_entry_bytes(&plan, *carrier)
+    let code_entry_bytes = lower_expr_fragment_plan_code_entry_bytes(&plan_cert, *carrier)
         .expect("audited mutual plan lowers to exact code-entry bytes");
-    let bytes = render_byte_list(&bytes);
-    let binding = format!(
-        "({{ funcIdx := {}, typeIdx := {}, codeEntry := {bytes} }} : \
-         AverCert.WasmSlice.FuncBinding)",
-        member.self_idx, member.type_idx,
-    );
+    let code_entry_bytes = render_byte_list(&code_entry_bytes);
+    let export_name_bytes = render_byte_list(name.as_bytes());
+    let host_table = mutual_host_table_lean_value(*box_idx, *sub_idx);
+    let member_set = mutual_member_set_lean_value(scc);
+
+    let body = format!("{name}MutualClaimBody");
+    let code_entry = format!("{name}MutualClaimCodeEntry");
+    let binding = format!("{name}MutualClaimBinding");
+    let check_plan = format!("{name}MutualClaimCheckPlan");
+    let lower_body = format!("{name}MutualClaimLowerBody");
+    let lower_code = format!("{name}MutualClaimLowerCode");
+    let func_binding = format!("{name}MutualClaimFuncBinding");
+    let check_shape = format!("{name}MutualClaimCheckShape");
+    let func_type = format!("{name}MutualClaimFuncType");
+    let host_types = format!("{name}MutualClaimHostTypes");
+    let plan = format!("AverCert.Plans.{name}MutualPlan");
     format!(
-        "⟨rfl, rfl, rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
-         ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
+        "-- Witness data for `{name}` as named constants so no large literal is\n\
+         -- duplicated across the leaf statements or baked into the aggregate term.\n\
+         def {body} : List CertPrelude.WInstr := {lowered_body}\n\n\
+         def {code_entry} : AverCert.WasmSlice.ByteSeq := {code_entry_bytes}\n\n\
+         def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+           {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry} }}\n\n\
+         theorem {check_plan} :\n  \
+           AverCert.PlanCheck.checkMutualRawPlan {plan} = true := by\n  \
+           rfl\n\n\
+         theorem {lower_body} :\n  \
+           AverCert.PlanLower.lowerMutualBody {carrier} {plan} = some {body} := by\n  \
+           rfl\n\n\
+         theorem {lower_code} :\n  \
+           AverCert.PlanBytes.lowerMutualCodeEntry {carrier} {plan} = some {code_entry} := by\n  \
+           rfl\n\n\
+         theorem {func_binding} :\n  \
+           AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+           rfl\n\n\
+         theorem {check_shape} :\n  \
+           AverCert.PlanCheck.checkMutualPlanShape {member_set} {host_table} {plan} = true := by\n  \
+           rfl\n\n\
+         theorem {func_type} :\n  \
+           AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx {plan}.params.length {carrier} = true := by\n  \
+           rfl\n\n\
+         theorem {host_types} :\n  \
+           AverCert.WasmSlice.hostTableFuncTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table} = true := by\n  \
+           rfl\n\n\
+         theorem {name}_mutualClaimAccepted :\n    \
+           AverCert.AcceptedArtifact.mutualRecursionClaimAccepted\n      \
+             AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest\n      \
+             {name}_mutualClaim := by\n  \
+           dsimp [{name}_mutualClaim,\n    \
+             AverCert.AcceptedArtifact.mutualRecursionClaimAccepted,\n    \
+             AverCert.AcceptedArtifact.mutualPlanForExport,\n    \
+             AverCert.AcceptedArtifact.mutualPlanAccepted]\n  \
+           exact ⟨rfl, rfl, rfl, {check_plan}, rfl, ⟨{body}, {code_entry}, {binding}, ⟨{lower_body}, {lower_code}, {func_binding}, rfl, {check_shape}, {func_type}, {host_types}, rfl⟩⟩⟩\n",
+        self_idx = member.self_idx,
+        type_idx = member.type_idx,
     )
 }
 
@@ -179,21 +235,12 @@ def {primary}_mutualScc : MutualRecursionSoundness.AdmittedScc {k} {carrier} {bo
             inner: Box::new(member_cert),
         };
         let claim = mutual_claim_lean_value(&wrapped);
-        let acceptance = mutual_claim_acceptance_proof(&wrapped);
+        let claim_accepted = render_mutual_bridge_claim_accepted(&wrapped);
         out.push_str(&format!(
             r#"def {name}_mutualClaim : AverCert.AcceptedArtifact.MutualRecursionClaim :=
   {claim}
 
-theorem {name}_mutualClaimAccepted :
-    AverCert.AcceptedArtifact.mutualRecursionClaimAccepted
-      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest
-      {name}_mutualClaim := by
-  dsimp [{name}_mutualClaim,
-    AverCert.AcceptedArtifact.mutualRecursionClaimAccepted,
-    AverCert.AcceptedArtifact.mutualPlanForExport,
-    AverCert.AcceptedArtifact.mutualPlanAccepted]
-  exact {acceptance}
-
+{claim_accepted}
 "#,
             name = member.name,
         ));

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -937,9 +937,10 @@ fn render_face_bundles(
 /// the already-numbered witness `def`s and per-conjunct leaf theorems as one
 /// text block plus the aggregate proof term that combines those constants. The
 /// aggregate `{family}Claim{index}Accepted` theorem is stated exactly like the
-/// opaque one `render_per_claim_bundles` emits — it indexes the same family
-/// list and `dsimp`s the same predicate — but its `exact` references the leaf
-/// constants instead of inlining one monolithic witness tuple.
+/// opaque tuple it replaces — it indexes the same family
+/// list and `dsimp`s the same predicate — but
+/// its `exact` references the leaf constants instead of inlining one monolithic
+/// witness tuple.
 ///
 /// This is the mechanism the expr-fragment beachhead established generalized to
 /// the other data-carrying families: emitting the heavy `WInstr` body, the
@@ -1012,8 +1013,8 @@ struct SymClaimParts {
 /// aggregate's `dsimp` computes, so unifying them is a structural plan compare,
 /// not a byte-carrier walk.
 ///
-/// Only the expr-fragment family is split this way; the other nine still emit
-/// one opaque theorem via `render_per_claim_bundles`.
+/// Every data-carrying claim family is split this way; this sym builder and the
+/// generic `render_split_bundles` below share the same leaf-plus-aggregate shape.
 fn render_sym_claim_bundles(parts: &[SymClaimParts], host_table_lean: &str) -> (String, String) {
     let mut theorems = String::new();
     let mut names = Vec::with_capacity(parts.len());

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -1291,6 +1291,177 @@ fn render_mutual_claim_bundles(parts: &[MutualParts]) -> (String, String) {
     )
 }
 
+/// Structured inputs for one String.concat claim's split acceptance proof.
+struct StringConcatParts {
+    name: String,
+    lowered_body: String,
+    code_entry_bytes: String,
+    export_name_bytes: String,
+    carrier_state: String,
+    result_ty: u32,
+    container_ty: u32,
+    concat_func_idx: u32,
+    self_idx: u32,
+    type_idx: u32,
+}
+
+/// Split the String.concat family. Beyond the shared body/code-entry/binding
+/// data, the heavy conjuncts are the carrier-state decode and the function
+/// binding decode, both `modBytes` walks; the plan/sym checks and the two
+/// lowerings are leaves stated over `Plans.{name}StringConcat{Sym}Plan`.
+fn render_string_concat_claim_bundles(parts: &[StringConcatParts]) -> (String, String) {
+    render_split_bundles(
+        "stringConcat",
+        "AverCert.AcceptedArtifact.stringConcatClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
+        "stringConcatClaims",
+        "AverCert.AcceptedArtifact.stringConcatClaimAccepted, AverCert.AcceptedArtifact.stringConcatPlanForExport, AverCert.AcceptedArtifact.stringConcatPlanAccepted, AverCert.AcceptedArtifact.stringConcatCanonicalHost",
+        parts.len(),
+        |index| {
+            let StringConcatParts {
+                name,
+                lowered_body,
+                code_entry_bytes,
+                export_name_bytes,
+                carrier_state,
+                result_ty,
+                container_ty,
+                concat_func_idx,
+                self_idx,
+                type_idx,
+            } = &parts[index];
+            let body = format!("stringConcatClaim{index}Body");
+            let code_entry = format!("stringConcatClaim{index}CodeEntry");
+            let binding = format!("stringConcatClaim{index}Binding");
+            let carrier_dec = format!("stringConcatClaim{index}CarrierState");
+            let check_sym = format!("stringConcatClaim{index}CheckSym");
+            let match_sym = format!("stringConcatClaim{index}MatchSym");
+            let check_plan = format!("stringConcatClaim{index}CheckPlan");
+            let lower_body = format!("stringConcatClaim{index}LowerBody");
+            let lower_code = format!("stringConcatClaim{index}LowerCode");
+            let func_binding = format!("stringConcatClaim{index}FuncBinding");
+            let sym_plan = format!("AverCert.Plans.{name}StringConcatSymPlan");
+            let plan = format!("AverCert.Plans.{name}StringConcatPlan");
+            let declarations = format!(
+                "-- Witness data for `{name}` as named constants so no large literal is\n\
+                 -- duplicated across the leaf statements or baked into the aggregate term.\n\
+                 def {body} : List CertPrelude.WInstr := {lowered_body}\n\n\
+                 def {code_entry} : AverCert.WasmSlice.ByteSeq := {code_entry_bytes}\n\n\
+                 def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+                   {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry} }}\n\n\
+                 -- One leaf theorem per acceptance conjunct; the heavy ones are the\n\
+                 -- `modBytes` carrier-state decode and the binding decode.\n\
+                 theorem {carrier_dec} :\n  \
+                   CertDecode.carrierState AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen = some {carrier_state} := by\n  \
+                   rfl\n\n\
+                 theorem {check_sym} :\n  \
+                   AverCert.PlanCheck.checkSymRawPlan {sym_plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {match_sym} :\n  \
+                   AverCert.PlanCheck.stringConcatPlanMatchesSymRawPlan {sym_plan} {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {check_plan} :\n  \
+                   AverCert.PlanCheck.checkStringConcatRawPlan {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {lower_body} :\n  \
+                   AverCert.PlanLower.lowerStringConcatBody {result_ty} {container_ty} {concat_func_idx} {plan} = some {body} := by\n  \
+                   rfl\n\n\
+                 theorem {lower_code} :\n  \
+                   AverCert.PlanBytes.lowerStringConcatCodeEntry {carrier_state} {result_ty} {container_ty} {concat_func_idx} {plan} = some {code_entry} := by\n  \
+                   rfl\n\n\
+                 theorem {func_binding} :\n  \
+                   AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+                   rfl\n\n"
+            );
+            let aggregate_proof = format!(
+                "⟨rfl, {carrier_dec}, rfl, rfl, rfl, ⟨{body}, {code_entry}, {binding}, ⟨{check_sym}, {match_sym}, {check_plan}, {lower_body}, {lower_code}, {func_binding}, rfl, rfl⟩⟩⟩"
+            );
+            (declarations, aggregate_proof)
+        },
+    )
+}
+
+/// Structured inputs for one String.eq claim's split acceptance proof.
+struct StringEqParts {
+    name: String,
+    lowered_body: String,
+    code_entry_bytes: String,
+    export_name_bytes: String,
+    string_ty: u32,
+    string_eq_idx: u32,
+    self_idx: u32,
+    type_idx: u32,
+    carrier: u32,
+}
+
+/// Split the String.eq family. The only `modBytes` walk is the function binding
+/// decode; the sym/plan checks and the two lowerings are leaves stated over
+/// `Plans.{name}StringEq{Sym}Plan`.
+fn render_string_eq_claim_bundles(parts: &[StringEqParts]) -> (String, String) {
+    render_split_bundles(
+        "stringEq",
+        "AverCert.AcceptedArtifact.stringEqClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
+        "stringEqClaims",
+        "AverCert.AcceptedArtifact.stringEqClaimAccepted, AverCert.AcceptedArtifact.stringEqPlanForExport, AverCert.AcceptedArtifact.stringEqPlanAccepted, AverCert.AcceptedArtifact.stringEqCanonicalHost",
+        parts.len(),
+        |index| {
+            let StringEqParts {
+                name,
+                lowered_body,
+                code_entry_bytes,
+                export_name_bytes,
+                string_ty,
+                string_eq_idx,
+                self_idx,
+                type_idx,
+                carrier,
+            } = &parts[index];
+            let body = format!("stringEqClaim{index}Body");
+            let code_entry = format!("stringEqClaim{index}CodeEntry");
+            let binding = format!("stringEqClaim{index}Binding");
+            let check_sym = format!("stringEqClaim{index}CheckSym");
+            let match_sym = format!("stringEqClaim{index}MatchSym");
+            let check_plan = format!("stringEqClaim{index}CheckPlan");
+            let lower_body = format!("stringEqClaim{index}LowerBody");
+            let lower_code = format!("stringEqClaim{index}LowerCode");
+            let func_binding = format!("stringEqClaim{index}FuncBinding");
+            let sym_plan = format!("AverCert.Plans.{name}StringEqSymPlan");
+            let plan = format!("AverCert.Plans.{name}StringEqPlan");
+            let declarations = format!(
+                "-- Witness data for `{name}` as named constants so no large literal is\n\
+                 -- duplicated across the leaf statements or baked into the aggregate term.\n\
+                 def {body} : List CertPrelude.WInstr := {lowered_body}\n\n\
+                 def {code_entry} : AverCert.WasmSlice.ByteSeq := {code_entry_bytes}\n\n\
+                 def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+                   {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry} }}\n\n\
+                 -- One leaf theorem per acceptance conjunct; the heavy one is the\n\
+                 -- `modBytes` binding decode.\n\
+                 theorem {check_sym} :\n  \
+                   AverCert.PlanCheck.checkSymRawPlan {sym_plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {match_sym} :\n  \
+                   AverCert.PlanCheck.stringEqPlanMatchesSymRawPlan {sym_plan} {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {check_plan} :\n  \
+                   AverCert.PlanCheck.checkStringEqRawPlan {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {lower_body} :\n  \
+                   AverCert.PlanLower.lowerStringEqBody {string_ty} {string_eq_idx} {plan} = some {body} := by\n  \
+                   rfl\n\n\
+                 theorem {lower_code} :\n  \
+                   AverCert.PlanBytes.lowerStringEqCodeEntry {carrier} {string_ty} {string_eq_idx} {plan} = some {code_entry} := by\n  \
+                   rfl\n\n\
+                 theorem {func_binding} :\n  \
+                   AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+                   rfl\n\n"
+            );
+            let aggregate_proof = format!(
+                "⟨rfl, rfl, rfl, rfl, {check_sym}, {match_sym}, {check_plan}, ⟨{body}, {code_entry}, {binding}, ⟨{lower_body}, {lower_code}, {func_binding}, rfl, rfl⟩⟩⟩"
+            );
+            (declarations, aggregate_proof)
+        },
+    )
+}
+
 fn render_artifact_expr_fragment_claims(
     analysis: &Analysis,
     model_info: &ModelInfo,
@@ -1308,8 +1479,8 @@ fn render_artifact_expr_fragment_claims(
     let mut field_projection_claims = Vec::new();
     let mut composition_claims = Vec::new();
     let mut sym_parts: Vec<SymClaimParts> = Vec::new();
-    let mut string_eq_proofs = Vec::new();
-    let mut string_proofs = Vec::new();
+    let mut string_eq_parts: Vec<StringEqParts> = Vec::new();
+    let mut string_parts: Vec<StringConcatParts> = Vec::new();
     let mut construct_proofs = Vec::new();
     let mut recursion_parts: Vec<RecursionParts> = Vec::new();
     let mut mutual_parts: Vec<MutualParts> = Vec::new();
@@ -1389,9 +1560,6 @@ fn render_artifact_expr_fragment_claims(
                 .map(|ops| render_ops_value(&ops))
                 .expect("certified String.concat plan lowers to WInstr body");
                 let export_name_bytes = render_byte_list(name.as_bytes());
-                let func_binding = format!(
-                    "({{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry_bytes} }} : AverCert.WasmSlice.FuncBinding)"
-                );
                 let carrier_state = render_carrier_state(*carrier);
                 // The obligation declares what `decodedCarrierIndex` forces:
                 // the real carrier index, or the reserved `0` in a module that
@@ -1401,13 +1569,19 @@ fn render_artifact_expr_fragment_claims(
                     "({{ exportNameBytes := {export_name_bytes}, exportName := {export_name}, carrier := {carrier_state}, resultTy := {result_ty}, containerTy := {container_ty}, concatFuncIdx := {string_concat_idx}, symPlan := AverCert.Plans.{name}StringConcatSymPlan, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.StringConcatClaim)",
                     export_name = lean_str(name),
                 ));
-                // Five leading `rfl`s: export name, the carrier-state decode,
-                // the obligation's carrier index, the concat host role, and the
-                // canonical host wiring.
-                string_proofs.push(format!(
-                    "⟨rfl, rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
-                ));
+                // Split acceptance proof; see `render_string_concat_claim_bundles`.
+                string_parts.push(StringConcatParts {
+                    name: name.clone(),
+                    lowered_body,
+                    code_entry_bytes,
+                    export_name_bytes,
+                    carrier_state,
+                    result_ty: *result_ty,
+                    container_ty: *container_ty,
+                    concat_func_idx: *string_concat_idx,
+                    self_idx: *self_idx,
+                    type_idx: *type_idx,
+                });
                 string_concat_faces.push(Some((
                     format!("AverCert.Plans.{name}StringConcatPlan"),
                     format!(
@@ -1437,17 +1611,22 @@ fn render_artifact_expr_fragment_claims(
                     .map(|ops| render_ops_value(&ops))
                     .expect("certified String.eq plan lowers to WInstr body");
                 let export_name_bytes = render_byte_list(name.as_bytes());
-                let func_binding = format!(
-                    "({{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry_bytes} }} : AverCert.WasmSlice.FuncBinding)"
-                );
                 string_eq_claims.push(format!(
                     "({{ exportNameBytes := {export_name_bytes}, exportName := {export_name}, carrier := {carrier}, stringTy := {string_ty}, stringEqFuncIdx := {string_eq_idx}, symPlan := AverCert.Plans.{name}StringEqSymPlan, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.StringEqClaim)",
                     export_name = lean_str(name),
                 ));
-                string_eq_proofs.push(format!(
-                    "⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
-                ));
+                // Split acceptance proof; see `render_string_eq_claim_bundles`.
+                string_eq_parts.push(StringEqParts {
+                    name: name.clone(),
+                    lowered_body,
+                    code_entry_bytes,
+                    export_name_bytes,
+                    string_ty,
+                    string_eq_idx: *string_eq_idx,
+                    self_idx: *self_idx,
+                    type_idx: *type_idx,
+                    carrier: *carrier,
+                });
             }
             Cert::AdtConstructor {
                 name,
@@ -1812,8 +1991,8 @@ fn render_artifact_expr_fragment_claims(
         format!("[\n  {}\n]", composition_claims.join(",\n  "))
     };
     let obligation_proof_count = sym_parts.len()
-        + string_eq_proofs.len()
-        + string_proofs.len()
+        + string_eq_parts.len()
+        + string_parts.len()
         + construct_proofs.len()
         + recursion_parts.len()
         + mutual_parts.len()
@@ -1830,20 +2009,8 @@ fn render_artifact_expr_fragment_claims(
     // per-claim kernel peak at the largest single leaf instead of the whole
     // witness tuple. The other nine families still emit one opaque theorem.
     let (sym_bundles, sym_proof) = render_sym_claim_bundles(&sym_parts, host_table_lean);
-    let (string_bundles, string_proof) = render_per_claim_bundles(
-        "stringConcat",
-        "AverCert.AcceptedArtifact.stringConcatClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
-        "stringConcatClaims",
-        "AverCert.AcceptedArtifact.stringConcatClaimAccepted, AverCert.AcceptedArtifact.stringConcatPlanForExport, AverCert.AcceptedArtifact.stringConcatPlanAccepted, AverCert.AcceptedArtifact.stringConcatCanonicalHost",
-        &string_proofs,
-    );
-    let (string_eq_bundles, string_eq_proof) = render_per_claim_bundles(
-        "stringEq",
-        "AverCert.AcceptedArtifact.stringEqClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
-        "stringEqClaims",
-        "AverCert.AcceptedArtifact.stringEqClaimAccepted, AverCert.AcceptedArtifact.stringEqPlanForExport, AverCert.AcceptedArtifact.stringEqPlanAccepted, AverCert.AcceptedArtifact.stringEqCanonicalHost",
-        &string_eq_proofs,
-    );
+    let (string_bundles, string_proof) = render_string_concat_claim_bundles(&string_parts);
+    let (string_eq_bundles, string_eq_proof) = render_string_eq_claim_bundles(&string_eq_parts);
     let construct_claim_count = construct_proofs.len();
     let (construct_bundles, construct_claims_proof) = render_per_claim_bundles(
         "construct",

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -1721,6 +1721,73 @@ fn render_field_projection_claim_bundles(parts: &[FieldProjectionParts]) -> (Str
     )
 }
 
+/// Structured inputs for one verbatim `ref.test`-dispatch claim's split proof.
+struct VerbatimParts {
+    name: String,
+    export_name_bytes: String,
+    carrier: u32,
+}
+
+/// Split the verbatim family. Its `Cert` carries no code/type index (the binding
+/// is recovered from the module by name), so rather than rendering literals the
+/// witnesses are named `def`s whose VALUE is the wall lowerer / byte decoder
+/// applied to the encoded plan. The stored definition body is small, so the
+/// theorems that reference it hold no large literal; each byte walk is
+/// materialized transiently inside its own leaf `addDecl` and freed.
+fn render_verbatim_claim_bundles(parts: &[VerbatimParts]) -> (String, String) {
+    render_split_bundles(
+        "verbatim",
+        "AverCert.AcceptedArtifact.verbatimClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
+        "verbatimClaims",
+        "AverCert.AcceptedArtifact.verbatimClaimAccepted, AverCert.AcceptedArtifact.verbatimPlanForExport, AverCert.AcceptedArtifact.verbatimPlanAccepted",
+        parts.len(),
+        |index| {
+            let VerbatimParts {
+                name,
+                export_name_bytes,
+                carrier,
+            } = &parts[index];
+            let code_entry = format!("verbatimClaim{index}CodeEntry");
+            let binding = format!("verbatimClaim{index}Binding");
+            let check_plan = format!("verbatimClaim{index}CheckPlan");
+            let lower_code = format!("verbatimClaim{index}LowerCode");
+            let func_binding = format!("verbatimClaim{index}FuncBinding");
+            let func_type = format!("verbatimClaim{index}FuncType");
+            let payloads = format!("verbatimClaim{index}Payloads");
+            let plan = format!("AverCert.Plans.{name}VerbatimPlan");
+            let declarations = format!(
+                "-- Witness data for `{name}` as named `def`s computed by the wall\n\
+                 -- lowerer / decoder, so no large literal is baked into the aggregate.\n\
+                 def {code_entry} : AverCert.WasmSlice.ByteSeq :=\n  \
+                   (AverCert.PlanBytes.lowerVerbatimCodeEntry {carrier} {plan}).getD []\n\n\
+                 def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+                   (AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes}).getD ⟨0, 0, []⟩\n\n\
+                 -- One leaf theorem per acceptance conjunct; the heavy ones are the\n\
+                 -- `modBytes` binding decode and type-section walk.\n\
+                 theorem {check_plan} :\n  \
+                   AverCert.PlanCheck.checkVerbatimPlan (AverCert.AcceptedArtifact.verbatimNLocals {plan}) {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {lower_code} :\n  \
+                   AverCert.PlanBytes.lowerVerbatimCodeEntry {carrier} {plan} = some {code_entry} := by\n  \
+                   rfl\n\n\
+                 theorem {func_binding} :\n  \
+                   AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+                   rfl\n\n\
+                 theorem {func_type} :\n  \
+                   AverCert.WasmSlice.verbatimFuncTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx {plan}.resultSig = true := by\n  \
+                   rfl\n\n\
+                 theorem {payloads} :\n  \
+                   AverCert.AcceptedArtifact.verbatimPayloadsBound AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {plan}.body = true := by\n  \
+                   rfl\n\n"
+            );
+            let aggregate_proof = format!(
+                "⟨rfl, rfl, {check_plan}, ⟨{code_entry}, {binding}, {lower_code}, {func_binding}, rfl, {func_type}, {payloads}, rfl⟩⟩"
+            );
+            (declarations, aggregate_proof)
+        },
+    )
+}
+
 fn render_artifact_expr_fragment_claims(
     analysis: &Analysis,
     model_info: &ModelInfo,
@@ -1743,7 +1810,7 @@ fn render_artifact_expr_fragment_claims(
     let mut construct_parts: Vec<ConstructParts> = Vec::new();
     let mut recursion_parts: Vec<RecursionParts> = Vec::new();
     let mut mutual_parts: Vec<MutualParts> = Vec::new();
-    let mut verbatim_proofs = Vec::new();
+    let mut verbatim_parts: Vec<VerbatimParts> = Vec::new();
     let mut int_dispatch_proofs = Vec::new();
     let mut field_projection_parts: Vec<FieldProjectionParts> = Vec::new();
     let mut composition_parts: Vec<CompositionParts> = Vec::new();
@@ -2058,15 +2125,12 @@ fn render_artifact_expr_fragment_claims(
                     "({{ exportNameBytes := {export_name_bytes}, exportName := {export_name}, carrier := {carrier}, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.VerbatimClaim)",
                     export_name = lean_str(name),
                 ));
-                // The code entry, signature and payload conjuncts are the binding
-                // (no host/self calls), so the witness is anonymous for the code
-                // entry and binding; the final `rfl` pins the canonical locals
-                // count (the two preceding `rfl`s discharge the byte-derived
-                // signature and payload binds).
-                verbatim_proofs.push(
-                    "⟨rfl, rfl, rfl, ⟨_, _, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩"
-                        .to_string(),
-                );
+                // Split acceptance proof; see `render_verbatim_claim_bundles`.
+                verbatim_parts.push(VerbatimParts {
+                    name: name.clone(),
+                    export_name_bytes,
+                    carrier: *carrier,
+                });
             }
             Cert::VariantDispatch { name, carrier, .. }
             | Cert::WidenedIntMatch { name, carrier, .. } => {
@@ -2281,7 +2345,7 @@ fn render_artifact_expr_fragment_claims(
         + construct_parts.len()
         + recursion_parts.len()
         + mutual_parts.len()
-        + verbatim_proofs.len()
+        + verbatim_parts.len()
         + int_dispatch_proofs.len()
         + field_projection_parts.len()
         + composition_parts.len();
@@ -2309,13 +2373,7 @@ fn render_artifact_expr_fragment_claims(
     let construct_proof = format!("⟨{construct_claims_proof}, {construct_nodup_proof}⟩");
     let (recursion_bundles, recursion_proof) = render_recursion_claim_bundles(&recursion_parts);
     let (mutual_bundles, mutual_proof) = render_mutual_claim_bundles(&mutual_parts);
-    let (verbatim_bundles, verbatim_proof) = render_per_claim_bundles(
-        "verbatim",
-        "AverCert.AcceptedArtifact.verbatimClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
-        "verbatimClaims",
-        "AverCert.AcceptedArtifact.verbatimClaimAccepted, AverCert.AcceptedArtifact.verbatimPlanForExport, AverCert.AcceptedArtifact.verbatimPlanAccepted",
-        &verbatim_proofs,
-    );
+    let (verbatim_bundles, verbatim_proof) = render_verbatim_claim_bundles(&verbatim_parts);
     let (int_dispatch_bundles, int_dispatch_proof) = render_per_claim_bundles(
         "intDispatch",
         "AverCert.AcceptedArtifact.intDispatchClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -1462,6 +1462,92 @@ fn render_string_eq_claim_bundles(parts: &[StringEqParts]) -> (String, String) {
     )
 }
 
+/// Structured inputs for one ADT-constructor claim's split acceptance proof.
+struct ConstructParts {
+    name: String,
+    lowered_body: String,
+    code_entry_bytes: String,
+    export_name_bytes: String,
+    struct_type_proof: String,
+    func_type_proof: String,
+    struct_idx: u32,
+    self_idx: u32,
+    type_idx: u32,
+    carrier: u32,
+}
+
+/// Split the ADT-constructor family. The sym/plan checks and the two lowerings
+/// are leaves over `Plans.{name}Construct{Sym}Plan`, and the function binding
+/// decode is the `modBytes` walk. The list-constructor struct/func-type
+/// conjuncts already reference the hoisted `Plans.{name}Construct…Matches`
+/// lemmas, so they stay as-is (constants, not re-run literals).
+fn render_construct_claim_bundles(parts: &[ConstructParts]) -> (String, String) {
+    render_split_bundles(
+        "construct",
+        "AverCert.AcceptedArtifact.constructClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
+        "constructClaims",
+        "AverCert.AcceptedArtifact.constructClaimAccepted, AverCert.AcceptedArtifact.constructPlanForExport, AverCert.AcceptedArtifact.constructPlanAccepted",
+        parts.len(),
+        |index| {
+            let ConstructParts {
+                name,
+                lowered_body,
+                code_entry_bytes,
+                export_name_bytes,
+                struct_type_proof,
+                func_type_proof,
+                struct_idx,
+                self_idx,
+                type_idx,
+                carrier,
+            } = &parts[index];
+            let body = format!("constructClaim{index}Body");
+            let code_entry = format!("constructClaim{index}CodeEntry");
+            let binding = format!("constructClaim{index}Binding");
+            let check_sym = format!("constructClaim{index}CheckSym");
+            let match_sym = format!("constructClaim{index}MatchSym");
+            let check_plan = format!("constructClaim{index}CheckPlan");
+            let lower_body = format!("constructClaim{index}LowerBody");
+            let lower_code = format!("constructClaim{index}LowerCode");
+            let func_binding = format!("constructClaim{index}FuncBinding");
+            let sym_plan = format!("AverCert.Plans.{name}ConstructSymPlan");
+            let plan = format!("AverCert.Plans.{name}ConstructPlan");
+            let declarations = format!(
+                "-- Witness data for `{name}` as named constants so no large literal is\n\
+                 -- duplicated across the leaf statements or baked into the aggregate term.\n\
+                 def {body} : List CertPrelude.WInstr := {lowered_body}\n\n\
+                 def {code_entry} : AverCert.WasmSlice.ByteSeq := {code_entry_bytes}\n\n\
+                 def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+                   {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry} }}\n\n\
+                 -- One leaf theorem per acceptance conjunct; the heavy one is the\n\
+                 -- `modBytes` binding decode.\n\
+                 theorem {check_sym} :\n  \
+                   AverCert.PlanCheck.checkSymRawPlan {sym_plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {match_sym} :\n  \
+                   AverCert.PlanCheck.constructPlanMatchesSymRawPlan {sym_plan} {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {check_plan} :\n  \
+                   AverCert.PlanCheck.checkConstructRawPlan {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {lower_body} :\n  \
+                   AverCert.PlanLower.lowerConstructBody {struct_idx} {plan} = some {body} := by\n  \
+                   rfl\n\n\
+                 theorem {lower_code} :\n  \
+                   AverCert.PlanBytes.lowerConstructCodeEntry {carrier} {struct_idx} {plan} = some {code_entry} := by\n  \
+                   rfl\n\n\
+                 theorem {func_binding} :\n  \
+                   AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+                   rfl\n\n"
+            );
+            let aggregate_proof = format!(
+                "⟨rfl, rfl, {check_sym}, {match_sym}, {check_plan}, rfl, ⟨{body}, {code_entry}, {binding}, ⟨{lower_body}, {lower_code}, {func_binding}, rfl, {struct_type_proof}, {func_type_proof}, rfl⟩⟩⟩"
+            );
+            (declarations, aggregate_proof)
+        },
+    )
+}
+
 fn render_artifact_expr_fragment_claims(
     analysis: &Analysis,
     model_info: &ModelInfo,
@@ -1481,7 +1567,7 @@ fn render_artifact_expr_fragment_claims(
     let mut sym_parts: Vec<SymClaimParts> = Vec::new();
     let mut string_eq_parts: Vec<StringEqParts> = Vec::new();
     let mut string_parts: Vec<StringConcatParts> = Vec::new();
-    let mut construct_proofs = Vec::new();
+    let mut construct_parts: Vec<ConstructParts> = Vec::new();
     let mut recursion_parts: Vec<RecursionParts> = Vec::new();
     let mut mutual_parts: Vec<MutualParts> = Vec::new();
     let mut verbatim_proofs = Vec::new();
@@ -1654,9 +1740,6 @@ fn render_artifact_expr_fragment_claims(
                 let export_name_bytes = render_byte_list(name.as_bytes());
                 let elem_ty = construct_val_type_lean_value(*elem_ty)
                     .expect("certified constructor has a supported byte-level element type");
-                let func_binding = format!(
-                    "({{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry_bytes} }} : AverCert.WasmSlice.FuncBinding)"
-                );
                 let (struct_type_proof, func_type_proof) =
                     if sym_plan_is_list_construct(&sym_plan) {
                         (
@@ -1670,11 +1753,19 @@ fn render_artifact_expr_fragment_claims(
                     "({{ exportNameBytes := {export_name_bytes}, exportName := {export_name}, carrier := {carrier}, structIdx := {struct_idx}, fieldCount := {field_count}, elemTy := {elem_ty}, symPlan := AverCert.Plans.{name}ConstructSymPlan, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.ConstructClaim)",
                     export_name = lean_str(name),
                 ));
-                construct_proofs.push(format!(
-                    "⟨rfl, rfl, rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨rfl, rfl, rfl, rfl, {struct_type_proof}, \
-                     {func_type_proof}, rfl⟩⟩⟩"
-                ));
+                // Split acceptance proof; see `render_construct_claim_bundles`.
+                construct_parts.push(ConstructParts {
+                    name: name.clone(),
+                    lowered_body,
+                    code_entry_bytes,
+                    export_name_bytes,
+                    struct_type_proof,
+                    func_type_proof,
+                    struct_idx: *struct_idx,
+                    self_idx: *self_idx,
+                    type_idx: *type_idx,
+                    carrier: *carrier,
+                });
                 if adt_constructor_uses_model(c, model_info) {
                     construct_faces.push(Some((
                         format!("AverCert.Plans.{name}ConstructPlan"),
@@ -1993,7 +2084,7 @@ fn render_artifact_expr_fragment_claims(
     let obligation_proof_count = sym_parts.len()
         + string_eq_parts.len()
         + string_parts.len()
-        + construct_proofs.len()
+        + construct_parts.len()
         + recursion_parts.len()
         + mutual_parts.len()
         + verbatim_proofs.len()
@@ -2011,14 +2102,8 @@ fn render_artifact_expr_fragment_claims(
     let (sym_bundles, sym_proof) = render_sym_claim_bundles(&sym_parts, host_table_lean);
     let (string_bundles, string_proof) = render_string_concat_claim_bundles(&string_parts);
     let (string_eq_bundles, string_eq_proof) = render_string_eq_claim_bundles(&string_eq_parts);
-    let construct_claim_count = construct_proofs.len();
-    let (construct_bundles, construct_claims_proof) = render_per_claim_bundles(
-        "construct",
-        "AverCert.AcceptedArtifact.constructClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
-        "constructClaims",
-        "AverCert.AcceptedArtifact.constructClaimAccepted, AverCert.AcceptedArtifact.constructPlanForExport, AverCert.AcceptedArtifact.constructPlanAccepted, AverCert.AcceptedArtifact.exprFragmentPlanAccepted, AverCert.ExprFragmentAccepted.accepted",
-        &construct_proofs,
-    );
+    let construct_claim_count = construct_parts.len();
+    let (construct_bundles, construct_claims_proof) = render_construct_claim_bundles(&construct_parts);
     // `acceptedConstructFragments` conjoins per-claim acceptance with unique
     // export-name coverage. Build the `Nodup` proof one list cell at a time so
     // Lean never runs a whole-list decision procedure inside the already deep

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -933,36 +933,6 @@ fn render_face_bundles(
     (theorems, aggregate)
 }
 
-/// Render one opaque theorem per concrete claim plus the small constructor
-/// spine used by the corresponding per-family theorem.  Indexing the already
-/// defined family list avoids repeating the large claim literals in theorem
-/// statements; reduction proves that each indexed claim is definitionally the
-/// same value consumed by the aggregate predicate.
-fn render_per_claim_bundles(
-    family: &str,
-    predicate: &str,
-    claims_def: &str,
-    unfolds: &str,
-    proofs: &[String],
-) -> (String, String) {
-    let mut theorems = String::new();
-    let mut names = Vec::with_capacity(proofs.len());
-    for (index, proof) in proofs.iter().enumerate() {
-        let theorem = format!("{family}Claim{index}Accepted");
-        theorems.push_str(&format!(
-            "theorem {theorem} :\n  {predicate} ({claims_def}.get ⟨{index}, by decide⟩) := by\n  dsimp [{claims_def}, {unfolds}]\n  exact {proof}\n\n"
-        ));
-        names.push(theorem);
-    }
-    let aggregate = names
-        .into_iter()
-        .rev()
-        .fold("trivial".to_string(), |rest, theorem| {
-            format!("⟨{theorem}, {rest}⟩")
-        });
-    (theorems, aggregate)
-}
-
 /// Render, per claim, the SPLIT acceptance proof: `per_claim(index)` supplies
 /// the already-numbered witness `def`s and per-conjunct leaf theorems as one
 /// text block plus the aggregate proof term that combines those constants. The
@@ -1788,6 +1758,80 @@ fn render_verbatim_claim_bundles(parts: &[VerbatimParts]) -> (String, String) {
     )
 }
 
+/// Structured inputs for one Int-face `ref.test`-dispatch claim's split proof.
+struct IntDispatchParts {
+    name: String,
+    export_name_bytes: String,
+    host_table: String,
+    carrier: u32,
+}
+
+/// Split the Int-face dispatch family the same way as the verbatim family: the
+/// body, code entry and binding — formerly inferred `_` witnesses solved into
+/// large literals — become named `def`s computed by the wall lowerers and byte
+/// decoder, and each byte-walking conjunct becomes its own leaf theorem.
+fn render_int_dispatch_claim_bundles(parts: &[IntDispatchParts]) -> (String, String) {
+    render_split_bundles(
+        "intDispatch",
+        "AverCert.AcceptedArtifact.intDispatchClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
+        "intDispatchClaims",
+        "AverCert.AcceptedArtifact.intDispatchClaimAccepted, AverCert.AcceptedArtifact.intDispatchPlanForExport, AverCert.AcceptedArtifact.intDispatchPlanAccepted",
+        parts.len(),
+        |index| {
+            let IntDispatchParts {
+                name,
+                export_name_bytes,
+                host_table,
+                carrier,
+            } = &parts[index];
+            let body = format!("intDispatchClaim{index}Body");
+            let code_entry = format!("intDispatchClaim{index}CodeEntry");
+            let binding = format!("intDispatchClaim{index}Binding");
+            let check_plan = format!("intDispatchClaim{index}CheckPlan");
+            let host_types = format!("intDispatchClaim{index}HostTypes");
+            let lower_body = format!("intDispatchClaim{index}LowerBody");
+            let lower_code = format!("intDispatchClaim{index}LowerCode");
+            let func_binding = format!("intDispatchClaim{index}FuncBinding");
+            let func_type = format!("intDispatchClaim{index}FuncType");
+            let plan = format!("AverCert.Plans.{name}IntDispatchPlan");
+            let declarations = format!(
+                "-- Witness data for `{name}` as named `def`s computed by the wall\n\
+                 -- lowerers / decoder, so no large literal is baked into the aggregate.\n\
+                 def {body} : List CertPrelude.WInstr :=\n  \
+                   (AverCert.PlanLower.lowerIntDispatchBody {host_table} {plan}).getD []\n\n\
+                 def {code_entry} : AverCert.WasmSlice.ByteSeq :=\n  \
+                   (AverCert.PlanBytes.lowerIntDispatchCodeEntry {carrier} {host_table} {plan}).getD []\n\n\
+                 def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+                   (AverCert.WasmSlice.funcBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes}).getD ⟨0, 0, []⟩\n\n\
+                 -- One leaf theorem per acceptance conjunct; the heavy ones are the\n\
+                 -- `modBytes` binding decode and type-section walks.\n\
+                 theorem {check_plan} :\n  \
+                   AverCert.PlanCheck.checkIntDispatchRawPlan {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {host_types} :\n  \
+                   AverCert.WasmSlice.hostTableFuncTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table} = true := by\n  \
+                   rfl\n\n\
+                 theorem {lower_body} :\n  \
+                   AverCert.PlanLower.lowerIntDispatchBody {host_table} {plan} = some {body} := by\n  \
+                   rfl\n\n\
+                 theorem {lower_code} :\n  \
+                   AverCert.PlanBytes.lowerIntDispatchCodeEntry {carrier} {host_table} {plan} = some {code_entry} := by\n  \
+                   rfl\n\n\
+                 theorem {func_binding} :\n  \
+                   AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+                   rfl\n\n\
+                 theorem {func_type} :\n  \
+                   AverCert.WasmSlice.verbatimFuncTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx (.refNull {carrier}) = true := by\n  \
+                   rfl\n\n"
+            );
+            let aggregate_proof = format!(
+                "⟨rfl, rfl, {check_plan}, rfl, {host_types}, rfl, ⟨{body}, {code_entry}, {binding}, {lower_body}, {lower_code}, {func_binding}, rfl, {func_type}, rfl⟩⟩"
+            );
+            (declarations, aggregate_proof)
+        },
+    )
+}
+
 fn render_artifact_expr_fragment_claims(
     analysis: &Analysis,
     model_info: &ModelInfo,
@@ -1811,7 +1855,7 @@ fn render_artifact_expr_fragment_claims(
     let mut recursion_parts: Vec<RecursionParts> = Vec::new();
     let mut mutual_parts: Vec<MutualParts> = Vec::new();
     let mut verbatim_parts: Vec<VerbatimParts> = Vec::new();
-    let mut int_dispatch_proofs = Vec::new();
+    let mut int_dispatch_parts: Vec<IntDispatchParts> = Vec::new();
     let mut field_projection_parts: Vec<FieldProjectionParts> = Vec::new();
     let mut composition_parts: Vec<CompositionParts> = Vec::new();
     let mut string_concat_faces: Vec<Option<(String, String)>> = Vec::new();
@@ -2148,17 +2192,13 @@ fn render_artifact_expr_fragment_claims(
                     "({{ exportNameBytes := {export_name_bytes}, exportName := {export_name}, carrier := {carrier}, hostTable := {host_table}, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.IntDispatchClaim)",
                     export_name = lean_str(name),
                 ));
-                // The code-entry and signature conjuncts plus the role-table
-                // parameterization are the binding, so the witness is anonymous
-                // for the body, code entry and binding — each pinned by `rfl`
-                // (the three extra leading `rfl`s discharge the host-table
-                // distinctness, the host-table declared-function-type pin, and
-                // the obligation-wiring bind; the final `rfl` pins the code
-                // table with the CANONICAL locals count, no existential).
-                int_dispatch_proofs.push(
-                    "⟨rfl, rfl, rfl, rfl, rfl, rfl, ⟨_, _, _, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩"
-                        .to_string(),
-                );
+                // Split acceptance proof; see `render_int_dispatch_claim_bundles`.
+                int_dispatch_parts.push(IntDispatchParts {
+                    name: name.clone(),
+                    export_name_bytes,
+                    host_table,
+                    carrier: *carrier,
+                });
                 int_dispatch_faces.push(Some((
                     format!("AverCert.Plans.{name}IntDispatchPlan"),
                     "⟨rfl, rfl, AverCert.Plans.{name}TypePrefix, AverCert.Plans.{name}DeclaredEnvelope, \
@@ -2346,7 +2386,7 @@ fn render_artifact_expr_fragment_claims(
         + recursion_parts.len()
         + mutual_parts.len()
         + verbatim_parts.len()
-        + int_dispatch_proofs.len()
+        + int_dispatch_parts.len()
         + field_projection_parts.len()
         + composition_parts.len();
     let obligation_proof = (0..obligation_proof_count).fold("trivial".to_string(), |acc, _| {
@@ -2374,13 +2414,8 @@ fn render_artifact_expr_fragment_claims(
     let (recursion_bundles, recursion_proof) = render_recursion_claim_bundles(&recursion_parts);
     let (mutual_bundles, mutual_proof) = render_mutual_claim_bundles(&mutual_parts);
     let (verbatim_bundles, verbatim_proof) = render_verbatim_claim_bundles(&verbatim_parts);
-    let (int_dispatch_bundles, int_dispatch_proof) = render_per_claim_bundles(
-        "intDispatch",
-        "AverCert.AcceptedArtifact.intDispatchClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
-        "intDispatchClaims",
-        "AverCert.AcceptedArtifact.intDispatchClaimAccepted, AverCert.AcceptedArtifact.intDispatchPlanForExport, AverCert.AcceptedArtifact.intDispatchPlanAccepted, AverCert.AcceptedArtifact.intDispatchCanonicalHost, AverCert.AcceptedArtifact.intDispatchCanonicalSlots",
-        &int_dispatch_proofs,
-    );
+    let (int_dispatch_bundles, int_dispatch_proof) =
+        render_int_dispatch_claim_bundles(&int_dispatch_parts);
     let (field_projection_bundles, field_projection_proof) =
         render_field_projection_claim_bundles(&field_projection_parts);
     let (composition_bundles, composition_claims_proof) =

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -963,6 +963,52 @@ fn render_per_claim_bundles(
     (theorems, aggregate)
 }
 
+/// Render, per claim, the SPLIT acceptance proof: `per_claim(index)` supplies
+/// the already-numbered witness `def`s and per-conjunct leaf theorems as one
+/// text block plus the aggregate proof term that combines those constants. The
+/// aggregate `{family}Claim{index}Accepted` theorem is stated exactly like the
+/// opaque one `render_per_claim_bundles` emits — it indexes the same family
+/// list and `dsimp`s the same predicate — but its `exact` references the leaf
+/// constants instead of inlining one monolithic witness tuple.
+///
+/// This is the mechanism the expr-fragment beachhead established generalized to
+/// the other data-carrying families: emitting the heavy `WInstr` body, the
+/// code-entry bytes, and the function binding as their OWN top-level `def`s (so
+/// no large literal is duplicated into the aggregate term) and each acceptance
+/// conjunct that walks the module bytes as its OWN leaf theorem means every
+/// `addDecl` completes and frees before the next is elaborated. The per-claim
+/// kernel peak becomes the largest single leaf (a `modBytes` type-section walk)
+/// rather than the whole witness tuple held live at once. The leaf conjuncts are
+/// stated over the encoded plan `def` the aggregate reduces to, so the
+/// aggregate re-runs no byte-decode or lowering work.
+fn render_split_bundles(
+    family: &str,
+    predicate: &str,
+    claims_def: &str,
+    unfolds: &str,
+    count: usize,
+    per_claim: impl Fn(usize) -> (String, String),
+) -> (String, String) {
+    let mut theorems = String::new();
+    let mut names = Vec::with_capacity(count);
+    for index in 0..count {
+        let (declarations, aggregate_proof) = per_claim(index);
+        let accepted = format!("{family}Claim{index}Accepted");
+        theorems.push_str(&declarations);
+        theorems.push_str(&format!(
+            "theorem {accepted} :\n  {predicate} ({claims_def}.get ⟨{index}, by decide⟩) := by\n  dsimp [{claims_def}, {unfolds}]\n  exact {aggregate_proof}\n\n"
+        ));
+        names.push(accepted);
+    }
+    let aggregate = names
+        .into_iter()
+        .rev()
+        .fold("trivial".to_string(), |rest, theorem| {
+            format!("⟨{theorem}, {rest}⟩")
+        });
+    (theorems, aggregate)
+}
+
 /// Structured inputs for one expr-fragment (`sym`) claim's split acceptance
 /// proof. The heavy witness data (lowered body, code-entry bytes, function
 /// binding) and each acceptance conjunct are emitted as their OWN top-level
@@ -1076,6 +1122,92 @@ fn render_sym_claim_bundles(parts: &[SymClaimParts], host_table_lean: &str) -> (
     (theorems, aggregate)
 }
 
+/// Structured inputs for one fuel-recursion claim's split acceptance proof.
+struct RecursionParts {
+    name: String,
+    lowered_body: String,
+    code_entry_bytes: String,
+    export_name_bytes: String,
+    host_table: String,
+    self_idx: u32,
+    type_idx: u32,
+    carrier: u32,
+}
+
+/// Split the fuel-recursion family exactly as `render_sym_claim_bundles` splits
+/// the expr-fragment family: the lowered body, code-entry bytes and function
+/// binding become named `def`s, each byte-walking conjunct of
+/// `recursionPlanAccepted` becomes its own leaf theorem over
+/// `AverCert.Plans.{name}RecursionPlan`, and the aggregate combines them.
+fn render_recursion_claim_bundles(parts: &[RecursionParts]) -> (String, String) {
+    render_split_bundles(
+        "recursion",
+        "AverCert.AcceptedArtifact.recursionClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
+        "recursionClaims",
+        "AverCert.AcceptedArtifact.recursionClaimAccepted, AverCert.AcceptedArtifact.recursionPlanForExport, AverCert.AcceptedArtifact.recursionPlanAccepted",
+        parts.len(),
+        |index| {
+            let RecursionParts {
+                name,
+                lowered_body,
+                code_entry_bytes,
+                export_name_bytes,
+                host_table,
+                self_idx,
+                type_idx,
+                carrier,
+            } = &parts[index];
+            let body = format!("recursionClaim{index}Body");
+            let code_entry = format!("recursionClaim{index}CodeEntry");
+            let binding = format!("recursionClaim{index}Binding");
+            let check_plan = format!("recursionClaim{index}CheckPlan");
+            let lower_body = format!("recursionClaim{index}LowerBody");
+            let lower_code = format!("recursionClaim{index}LowerCode");
+            let func_binding = format!("recursionClaim{index}FuncBinding");
+            let check_shape = format!("recursionClaim{index}CheckShape");
+            let func_type = format!("recursionClaim{index}FuncType");
+            let host_types = format!("recursionClaim{index}HostTypes");
+            let plan = format!("AverCert.Plans.{name}RecursionPlan");
+            let obligation = format!("AverCert.{name}Ob");
+            let declarations = format!(
+                "-- Witness data for `{name}` as named constants so no large literal is\n\
+                 -- duplicated across the leaf statements or baked into the aggregate term.\n\
+                 def {body} : List CertPrelude.WInstr := {lowered_body}\n\n\
+                 def {code_entry} : AverCert.WasmSlice.ByteSeq := {code_entry_bytes}\n\n\
+                 def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+                   {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry} }}\n\n\
+                 -- One leaf theorem per acceptance conjunct; the heavy ones are the\n\
+                 -- `modBytes` binding decode and type-section walks.\n\
+                 theorem {check_plan} :\n  \
+                   AverCert.PlanCheck.checkRecursionRawPlan {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {lower_body} :\n  \
+                   AverCert.PlanLower.lowerRecursionBody {carrier} {plan} = some {body} := by\n  \
+                   rfl\n\n\
+                 theorem {lower_code} :\n  \
+                   AverCert.PlanBytes.lowerRecursionCodeEntry {carrier} {plan} = some {code_entry} := by\n  \
+                   rfl\n\n\
+                 theorem {func_binding} :\n  \
+                   AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+                   rfl\n\n\
+                 theorem {check_shape} :\n  \
+                   AverCert.PlanCheck.checkRecursionPlanShape {binding}.funcIdx {host_table} {obligation}.totalityRole {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {func_type} :\n  \
+                   AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx {plan}.params.length {carrier} = true := by\n  \
+                   rfl\n\n\
+                 theorem {host_types} :\n  \
+                   AverCert.WasmSlice.hostTableFuncTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table} = true := by\n  \
+                   rfl\n\n"
+            );
+            let aggregate_proof = format!(
+                "⟨rfl, rfl, {check_plan}, rfl, ⟨{body}, {code_entry}, {binding}, ⟨{lower_body}, {lower_code}, {func_binding}, rfl, {check_shape}, {func_type}, {host_types}, rfl⟩⟩⟩"
+            );
+            (declarations, aggregate_proof)
+        },
+    )
+}
+
 fn render_artifact_expr_fragment_claims(
     analysis: &Analysis,
     model_info: &ModelInfo,
@@ -1096,7 +1228,7 @@ fn render_artifact_expr_fragment_claims(
     let mut string_eq_proofs = Vec::new();
     let mut string_proofs = Vec::new();
     let mut construct_proofs = Vec::new();
-    let mut recursion_proofs = Vec::new();
+    let mut recursion_parts: Vec<RecursionParts> = Vec::new();
     let mut mutual_proofs = Vec::new();
     let mut verbatim_proofs = Vec::new();
     let mut int_dispatch_proofs = Vec::new();
@@ -1322,17 +1454,24 @@ fn render_artifact_expr_fragment_claims(
                     .expect("certified recursion plan lowers to WInstr body");
                 let export_name_bytes = render_byte_list(name.as_bytes());
                 let host_table = recursion_host_table_lean_value(c);
-                let func_binding = format!(
-                    "({{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry_bytes} }} : AverCert.WasmSlice.FuncBinding)"
-                );
                 recursion_claims.push(format!(
                     "({{ exportNameBytes := {export_name_bytes}, exportName := {export_name}, carrier := {carrier}, hostTable := {host_table}, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.RecursionClaim)",
                     export_name = lean_str(name),
                 ));
-                recursion_proofs.push(format!(
-                    "⟨rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
-                ));
+                // Split acceptance proof: the witness data and every byte-walking
+                // conjunct become their own top-level declarations (see
+                // `render_recursion_claim_bundles`) so the kernel checks and frees
+                // each separately instead of holding one monolithic witness tuple.
+                recursion_parts.push(RecursionParts {
+                    name: name.clone(),
+                    lowered_body,
+                    code_entry_bytes,
+                    export_name_bytes,
+                    host_table,
+                    self_idx: *self_idx,
+                    type_idx: *type_idx,
+                    carrier: *carrier,
+                });
             }
             Cert::MutualRecursion {
                 name,
@@ -1589,7 +1728,7 @@ fn render_artifact_expr_fragment_claims(
         + string_eq_proofs.len()
         + string_proofs.len()
         + construct_proofs.len()
-        + recursion_proofs.len()
+        + recursion_parts.len()
         + mutual_proofs.len()
         + verbatim_proofs.len()
         + int_dispatch_proofs.len()
@@ -1635,13 +1774,7 @@ fn render_artifact_expr_fragment_claims(
         |acc, _| format!("List.nodup_cons.mpr ⟨by decide, {acc}⟩"),
     );
     let construct_proof = format!("⟨{construct_claims_proof}, {construct_nodup_proof}⟩");
-    let (recursion_bundles, recursion_proof) = render_per_claim_bundles(
-        "recursion",
-        "AverCert.AcceptedArtifact.recursionClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
-        "recursionClaims",
-        "AverCert.AcceptedArtifact.recursionClaimAccepted, AverCert.AcceptedArtifact.recursionPlanForExport, AverCert.AcceptedArtifact.recursionPlanAccepted",
-        &recursion_proofs,
-    );
+    let (recursion_bundles, recursion_proof) = render_recursion_claim_bundles(&recursion_parts);
     let (mutual_bundles, mutual_proof) = render_per_claim_bundles(
         "mutual",
         "AverCert.AcceptedArtifact.mutualRecursionClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -963,6 +963,119 @@ fn render_per_claim_bundles(
     (theorems, aggregate)
 }
 
+/// Structured inputs for one expr-fragment (`sym`) claim's split acceptance
+/// proof. The heavy witness data (lowered body, code-entry bytes, function
+/// binding) and each acceptance conjunct are emitted as their OWN top-level
+/// declarations by `render_sym_claim_bundles`.
+struct SymClaimParts {
+    name: String,
+    lowered_body: String,
+    code_entry_bytes: String,
+    export_name_bytes: String,
+    self_idx: u32,
+    type_idx: u32,
+    carrier: u32,
+}
+
+/// Render, per `sym` claim, named data `def`s + per-conjunct leaf theorems +
+/// the aggregate `symFragmentClaim{i}Accepted` theorem that combines the
+/// already-checked constants.
+///
+/// The former shape emitted ONE theorem per claim whose proof was
+/// `dsimp [...]; exact ⟨…giant nested tuple…⟩`. A `theorem` submits its entire
+/// proof term to the kernel in a single `addDecl`, so the whole witness tuple
+/// (the large `WInstr` body list, the code-entry bytes, the binding record, and
+/// every conjunct's `isDefEq`) was held live at once — the affine verify peaked
+/// at ~6.7 GB there. Splitting the data into `def`s and each conjunct into its
+/// own `theorem` means every `addDecl` completes and frees before the next is
+/// elaborated, so the per-claim peak becomes the largest single leaf (the
+/// `modBytes` decode / type-section walks, each measured ≤ ~1.24 GB) rather
+/// than the whole tuple. The aggregate then only references the constants, so
+/// its own `exact` re-runs no heavy reduction: the encoded plan the conjuncts
+/// are stated over is `AverCert.Plans.{name}Plan`, definitionally the value the
+/// aggregate's `dsimp` computes, so unifying them is a structural plan compare,
+/// not a byte-carrier walk.
+///
+/// Only the expr-fragment family is split this way; the other nine still emit
+/// one opaque theorem via `render_per_claim_bundles`.
+fn render_sym_claim_bundles(parts: &[SymClaimParts], host_table_lean: &str) -> (String, String) {
+    let mut theorems = String::new();
+    let mut names = Vec::with_capacity(parts.len());
+    for (index, part) in parts.iter().enumerate() {
+        let SymClaimParts {
+            name,
+            lowered_body,
+            code_entry_bytes,
+            export_name_bytes,
+            self_idx,
+            type_idx,
+            carrier,
+        } = part;
+        let body = format!("symFragmentClaim{index}Body");
+        let code_entry = format!("symFragmentClaim{index}CodeEntry");
+        let binding = format!("symFragmentClaim{index}Binding");
+        let carrier_bound = format!("symFragmentClaim{index}CarrierBound");
+        let host_types = format!("symFragmentClaim{index}HostTableFuncTypes");
+        let check_plan = format!("symFragmentClaim{index}CheckPlan");
+        let lower_body = format!("symFragmentClaim{index}LowerBody");
+        let lower_code = format!("symFragmentClaim{index}LowerCodeEntry");
+        let func_binding = format!("symFragmentClaim{index}FuncBinding");
+        let func_type = format!("symFragmentClaim{index}FuncTypeMatches");
+        let nominal = format!("symFragmentClaim{index}NominalTypes");
+        let accepted = format!("symFragmentClaim{index}Accepted");
+        let plan = format!("AverCert.Plans.{name}Plan");
+        theorems.push_str(&format!(
+            "-- Witness data for `{name}` as named constants so no large literal is\n\
+             -- duplicated across the leaf statements or baked into the aggregate term.\n\
+             def {body} : List CertPrelude.WInstr := {lowered_body}\n\n\
+             def {code_entry} : AverCert.WasmSlice.ByteSeq := {code_entry_bytes}\n\n\
+             def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+               {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry} }}\n\n\
+             -- One leaf theorem per acceptance conjunct. Each is checked and freed in\n\
+             -- its own `addDecl`; the heavy ones are the `modBytes` type-section walks\n\
+             -- and the function-binding decode.\n\
+             theorem {carrier_bound} :\n  \
+               AverCert.AcceptedArtifact.symFragmentCarrierBound AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table_lean} {plan} = true := by\n  \
+               rfl\n\n\
+             theorem {host_types} :\n  \
+               AverCert.WasmSlice.hostTableFuncTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table_lean} = true := by\n  \
+               rfl\n\n\
+             theorem {check_plan} :\n  \
+               AverCert.PlanCheck.checkExprFragmentRawPlan {plan} = true := by\n  \
+               rfl\n\n\
+             theorem {lower_body} :\n  \
+               AverCert.PlanLower.lowerExprFragmentBody {carrier} {plan} = some {body} := by\n  \
+               rfl\n\n\
+             theorem {lower_code} :\n  \
+               AverCert.PlanBytes.lowerExprFragmentCodeEntry {carrier} {plan} = some {code_entry} := by\n  \
+               rfl\n\n\
+             theorem {func_binding} :\n  \
+               AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+               rfl\n\n\
+             theorem {func_type} :\n  \
+               AverCert.WasmSlice.exprFragmentFuncTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx {carrier} {plan}.params {plan}.result = true := by\n  \
+               rfl\n\n\
+             theorem {nominal} :\n  \
+               AverCert.WasmSlice.exprFragmentNominalTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx {carrier} {plan} = true := by\n  \
+               rfl\n\n\
+             -- Aggregate: combine the already-checked leaf constants. `dsimp` only\n\
+             -- prepares the goal shape; the `exact` holds no heavy reduction.\n\
+             theorem {accepted} :\n  \
+               AverCert.AcceptedArtifact.symFragmentClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen (symFragmentClaims.get ⟨{index}, by decide⟩) := by\n  \
+               dsimp [symFragmentClaims, AverCert.AcceptedArtifact.symFragmentClaimAccepted, AverCert.AcceptedArtifact.symFragmentPlanAccepted, AverCert.AcceptedArtifact.exprFragmentPlanAccepted, AverCert.ExprFragmentAccepted.accepted]\n  \
+               exact ⟨{carrier_bound}, {host_types}, rfl, rfl, ⟨{body}, {code_entry}, {binding}, ⟨⟨{check_plan}, {lower_body}, {lower_code}, {func_binding}⟩, {func_type}, {nominal}, rfl, rfl⟩⟩⟩\n\n"
+        ));
+        names.push(accepted);
+    }
+    let aggregate = names
+        .into_iter()
+        .rev()
+        .fold("trivial".to_string(), |rest, theorem| {
+            format!("⟨{theorem}, {rest}⟩")
+        });
+    (theorems, aggregate)
+}
+
 fn render_artifact_expr_fragment_claims(
     analysis: &Analysis,
     model_info: &ModelInfo,
@@ -979,7 +1092,7 @@ fn render_artifact_expr_fragment_claims(
     let mut int_dispatch_claims = Vec::new();
     let mut field_projection_claims = Vec::new();
     let mut composition_claims = Vec::new();
-    let mut sym_proofs = Vec::new();
+    let mut sym_parts: Vec<SymClaimParts> = Vec::new();
     let mut string_eq_proofs = Vec::new();
     let mut string_proofs = Vec::new();
     let mut construct_proofs = Vec::new();
@@ -1010,25 +1123,25 @@ fn render_artifact_expr_fragment_claims(
                     .map(|ops| render_ops_value(&ops))
                     .expect("certified expr-fragment plan lowers to WInstr body");
                 let export_name_bytes = render_byte_list(name.as_bytes());
-                let func_binding = format!(
-                    "({{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry_bytes} }} : AverCert.WasmSlice.FuncBinding)"
-                );
-                // The first component discharges the byte-derived carrier
-                // binding (`symFragmentCarrierBound`) and the second the
-                // host-table declared-function-type pin
-                // (`hostTableFuncTypesMatch`). Both are stated ahead of the
-                // export/carrier binds, and both are Boolean checks the
-                // kernel runs, so neither is keyed on claim data here.
-                let proof = format!(
-                    "⟨rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨⟨rfl, rfl, rfl, rfl⟩, rfl, rfl, rfl, rfl⟩⟩⟩"
-                );
                 if expr_fragment_source_plan(source_plan, plan).is_some() {
                     sym_claims.push(format!(
                         "({{ exportNameBytes := {export_name_bytes}, exportName := {export_name}, carrier := {carrier}, hostTable := {host_table_lean}, structTable := {struct_table_lean}, plan := AverCert.Plans.{name}SymPlan, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.SymFragmentClaim)",
                         export_name = lean_str(name),
                     ));
-                    sym_proofs.push(proof);
+                    // Structured inputs for this claim's SPLIT acceptance proof:
+                    // the witness data and every conjunct become their own
+                    // top-level declarations (see `render_sym_claim_bundles`), so
+                    // the kernel checks and frees each in a separate `addDecl`
+                    // instead of holding one monolithic witness tuple live.
+                    sym_parts.push(SymClaimParts {
+                        name: name.clone(),
+                        lowered_body,
+                        code_entry_bytes,
+                        export_name_bytes,
+                        self_idx: *self_idx,
+                        type_idx: *type_idx,
+                        carrier: *carrier,
+                    });
                 }
             }
             Cert::StringConcatVerbatimMatch {
@@ -1472,7 +1585,7 @@ fn render_artifact_expr_fragment_claims(
     } else {
         format!("[\n  {}\n]", composition_claims.join(",\n  "))
     };
-    let obligation_proof_count = sym_proofs.len()
+    let obligation_proof_count = sym_parts.len()
         + string_eq_proofs.len()
         + string_proofs.len()
         + construct_proofs.len()
@@ -1485,13 +1598,12 @@ fn render_artifact_expr_fragment_claims(
     let obligation_proof = (0..obligation_proof_count).fold("trivial".to_string(), |acc, _| {
         format!("⟨rfl, {acc}⟩")
     });
-    let (sym_bundles, sym_proof) = render_per_claim_bundles(
-        "symFragment",
-        "AverCert.AcceptedArtifact.symFragmentClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen",
-        "symFragmentClaims",
-        "AverCert.AcceptedArtifact.symFragmentClaimAccepted, AverCert.AcceptedArtifact.symFragmentPlanAccepted, AverCert.AcceptedArtifact.exprFragmentPlanAccepted, AverCert.ExprFragmentAccepted.accepted",
-        &sym_proofs,
-    );
+    // The expr-fragment (`sym`) family emits a SPLIT proof: witness data as
+    // named `def`s and each acceptance conjunct as its own leaf theorem, with
+    // the aggregate combining the already-checked constants. This keeps the
+    // per-claim kernel peak at the largest single leaf instead of the whole
+    // witness tuple. The other nine families still emit one opaque theorem.
+    let (sym_bundles, sym_proof) = render_sym_claim_bundles(&sym_parts, host_table_lean);
     let (string_bundles, string_proof) = render_per_claim_bundles(
         "stringConcat",
         "AverCert.AcceptedArtifact.stringConcatClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -1548,6 +1548,93 @@ fn render_construct_claim_bundles(parts: &[ConstructParts]) -> (String, String) 
     )
 }
 
+/// One composition member's witness data for the split proof.
+struct CompositionMemberData {
+    export_name_bytes: String,
+    body: String,
+    code_entry: String,
+    self_idx: u32,
+    type_idx: u32,
+}
+
+/// Structured inputs for one composition-root claim's split acceptance proof.
+struct CompositionParts {
+    carrier: u32,
+    host_table: String,
+    members: Vec<CompositionMemberData>,
+}
+
+/// Split the cross-function composition family. Each member's lowered body and
+/// code-entry bytes become named `def`s, and the member `modBytes` walks (the
+/// binding decode and the declared-function-type pin) plus the claim-level
+/// host-table type pin become their own leaf theorems. The member lowerings and
+/// the closure/root conjuncts stay inline: they read the byte-derived
+/// `funcTable`, which the aggregate must reduce to enter the `some` branch in
+/// any case, so isolating them would not remove that one walk.
+fn render_composition_claim_bundles(parts: &[CompositionParts]) -> (String, String) {
+    render_split_bundles(
+        "composition",
+        "AverCert.AcceptedArtifact.compositionClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen compositionMembers",
+        "compositionClaims",
+        "AverCert.AcceptedArtifact.compositionClaimAccepted, AverCert.AcceptedArtifact.compositionFuncTable, AverCert.AcceptedArtifact.compositionMemberBinding, AverCert.AcceptedArtifact.compositionNamedMembersAccepted, AverCert.AcceptedArtifact.compositionMemberPlanAccepted, AverCert.AcceptedArtifact.compositionMemberForName, AverCert.AcceptedArtifact.compositionClosureBound, AverCert.AcceptedArtifact.compositionEdges, AverCert.AcceptedArtifact.compositionPlanCallees, AverCert.AcceptedArtifact.compositionEdgesDescend, AverCert.AcceptedArtifact.compositionReachClosure, AverCert.AcceptedArtifact.compositionReachStep, AverCert.AcceptedArtifact.stringListNodup, AverCert.AcceptedArtifact.stringListSetEq",
+        parts.len(),
+        |index| {
+            let CompositionParts {
+                carrier,
+                host_table,
+                members,
+            } = &parts[index];
+            let host_types = format!("compositionClaim{index}HostTypes");
+            // Shared host-table type pin: the same statement is the claim-level
+            // conjunct and every member's host-type conjunct, so one leaf serves
+            // both and no member re-runs the walk.
+            let mut declarations = format!(
+                "-- Claim-level host-table declared-function-type pin (a `modBytes`\n\
+                 -- type-section walk), shared by the claim and every member.\n\
+                 theorem {host_types} :\n  \
+                   AverCert.WasmSlice.hostTableFuncTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table} = true := by\n  \
+                   rfl\n\n"
+            );
+            let mut named_proof = "trivial".to_string();
+            for (member_index, member) in members.iter().enumerate().rev() {
+                let CompositionMemberData {
+                    export_name_bytes,
+                    body,
+                    code_entry,
+                    self_idx,
+                    type_idx,
+                } = member;
+                let body_def = format!("compositionClaim{index}Member{member_index}Body");
+                let code_def = format!("compositionClaim{index}Member{member_index}CodeEntry");
+                let binding_def = format!("compositionClaim{index}Member{member_index}Binding");
+                let func_binding = format!("compositionClaim{index}Member{member_index}FuncBinding");
+                let func_type = format!("compositionClaim{index}Member{member_index}FuncType");
+                declarations = format!(
+                    "-- Member `{member_index}` witness data as named constants.\n\
+                     def {body_def} : List CertPrelude.WInstr := {body}\n\n\
+                     def {code_def} : AverCert.WasmSlice.ByteSeq := {code_entry}\n\n\
+                     def {binding_def} : AverCert.WasmSlice.FuncBinding :=\n  \
+                       {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_def} }}\n\n\
+                     theorem {func_binding} :\n  \
+                       AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_def} = some {binding_def} := by\n  \
+                       rfl\n\n\
+                     theorem {func_type} :\n  \
+                       AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding_def}.typeIdx 1 {carrier} = true := by\n  \
+                       rfl\n\n{declarations}"
+                );
+                let member_proof = format!(
+                    "⟨rfl, ⟨{body_def}, {code_def}, {binding_def}, rfl, rfl, {func_binding}, {func_type}, {host_types}, rfl⟩⟩"
+                );
+                named_proof = format!("⟨{member_proof}, {named_proof}⟩");
+            }
+            let aggregate_proof = format!(
+                "⟨rfl, ⟨rfl, ⟨rfl, ⟨{host_types}, ⟨rfl, ⟨rfl, ⟨rfl, {named_proof}⟩⟩⟩⟩⟩⟩⟩"
+            );
+            (declarations, aggregate_proof)
+        },
+    )
+}
+
 fn render_artifact_expr_fragment_claims(
     analysis: &Analysis,
     model_info: &ModelInfo,
@@ -1573,7 +1660,7 @@ fn render_artifact_expr_fragment_claims(
     let mut verbatim_proofs = Vec::new();
     let mut int_dispatch_proofs = Vec::new();
     let mut field_projection_proofs = Vec::new();
-    let mut composition_proofs = Vec::new();
+    let mut composition_parts: Vec<CompositionParts> = Vec::new();
     let mut string_concat_faces: Vec<Option<(String, String)>> = Vec::new();
     let mut construct_faces: Vec<Option<(String, String)>> = Vec::new();
     let mut int_dispatch_faces: Vec<Option<(String, String)>> = Vec::new();
@@ -2002,29 +2089,34 @@ fn render_artifact_expr_fragment_claims(
             "({{ exportName := {export_name}, carrier := {carrier}, hostTable := {host_table}, memberNames := {member_names}, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.CompositionClaim)",
             export_name = lean_str(name),
         ));
-        let mut named_proof = "trivial".to_string();
-        for (entry, plan) in plans.iter().rev() {
-            let body = render_ops_value(
-                &lower_composition_plan(plan, add_idx, &global_func_table)
-                    .expect("composition member lowers against global byte table"),
-            );
-            let code_entry = render_byte_list(
-                &composition_code_entry_bytes(plan, *carrier, add_idx, &global_func_table)
-                    .expect("composition member byte-lowers against global byte table"),
-            );
-            let binding = format!(
-                "({{ funcIdx := {}, typeIdx := {}, codeEntry := {} }} : AverCert.WasmSlice.FuncBinding)",
-                entry.self_idx, entry.type_idx, code_entry
-            );
-            let member_proof = format!(
-                "⟨rfl, ⟨({body}), ({code_entry}), {binding}, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩"
-            );
-            named_proof = format!("⟨{member_proof}, {named_proof}⟩");
-        }
+        // Collect each member's witness data for the split acceptance proof;
+        // see `render_composition_claim_bundles`.
+        let members = plans
+            .iter()
+            .map(|(entry, plan)| {
+                let body = render_ops_value(
+                    &lower_composition_plan(plan, add_idx, &global_func_table)
+                        .expect("composition member lowers against global byte table"),
+                );
+                let code_entry = render_byte_list(
+                    &composition_code_entry_bytes(plan, *carrier, add_idx, &global_func_table)
+                        .expect("composition member byte-lowers against global byte table"),
+                );
+                CompositionMemberData {
+                    export_name_bytes: render_byte_list(entry.name.as_bytes()),
+                    body,
+                    code_entry,
+                    self_idx: entry.self_idx,
+                    type_idx: entry.type_idx,
+                }
+            })
+            .collect::<Vec<_>>();
         let _ = self_idx;
-        composition_proofs.push(format!(
-            "⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, ⟨rfl, {named_proof}⟩⟩⟩⟩⟩⟩⟩"
-        ));
+        composition_parts.push(CompositionParts {
+            carrier: *carrier,
+            host_table,
+            members,
+        });
     }
     let sym_claims = if sym_claims.is_empty() {
         "[]".to_string()
@@ -2090,7 +2182,7 @@ fn render_artifact_expr_fragment_claims(
         + verbatim_proofs.len()
         + int_dispatch_proofs.len()
         + field_projection_proofs.len()
-        + composition_proofs.len();
+        + composition_parts.len();
     let obligation_proof = (0..obligation_proof_count).fold("trivial".to_string(), |acc, _| {
         format!("⟨rfl, {acc}⟩")
     });
@@ -2136,13 +2228,8 @@ fn render_artifact_expr_fragment_claims(
         "AverCert.AcceptedArtifact.fieldProjectionClaimAccepted, AverCert.AcceptedArtifact.fieldProjectionPlanForExport, AverCert.AcceptedArtifact.fieldProjectionPlanAccepted",
         &field_projection_proofs,
     );
-    let (composition_bundles, composition_claims_proof) = render_per_claim_bundles(
-        "composition",
-        "AverCert.AcceptedArtifact.compositionClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen compositionMembers",
-        "compositionClaims",
-        "AverCert.AcceptedArtifact.compositionClaimAccepted, AverCert.AcceptedArtifact.compositionFuncTable, AverCert.AcceptedArtifact.compositionMemberBinding, AverCert.AcceptedArtifact.compositionNamedMembersAccepted, AverCert.AcceptedArtifact.compositionMemberPlanAccepted, AverCert.AcceptedArtifact.compositionMemberForName, AverCert.AcceptedArtifact.compositionClosureBound, AverCert.AcceptedArtifact.compositionEdges, AverCert.AcceptedArtifact.compositionPlanCallees, AverCert.AcceptedArtifact.compositionEdgesDescend, AverCert.AcceptedArtifact.compositionReachClosure, AverCert.AcceptedArtifact.compositionReachStep, AverCert.AcceptedArtifact.stringListNodup, AverCert.AcceptedArtifact.stringListSetEq",
-        &composition_proofs,
-    );
+    let (composition_bundles, composition_claims_proof) =
+        render_composition_claim_bundles(&composition_parts);
     // `acceptedCompositionFragments` conjoins the per-claim acceptance with the
     // artifact-wide member coverage, manifest-obligation coverage, and unique
     // obligation-export bounds. Each is a decidable `Bool = true` over concrete

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -1208,6 +1208,89 @@ fn render_recursion_claim_bundles(parts: &[RecursionParts]) -> (String, String) 
     )
 }
 
+/// Structured inputs for one mutual-recursion member claim's split proof.
+struct MutualParts {
+    name: String,
+    lowered_body: String,
+    code_entry_bytes: String,
+    export_name_bytes: String,
+    host_table: String,
+    member_set: String,
+    self_idx: u32,
+    type_idx: u32,
+    carrier: u32,
+}
+
+/// Split the mutual-recursion family the same way as the fuel-recursion family.
+fn render_mutual_claim_bundles(parts: &[MutualParts]) -> (String, String) {
+    render_split_bundles(
+        "mutual",
+        "AverCert.AcceptedArtifact.mutualRecursionClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
+        "mutualRecursionClaims",
+        "AverCert.AcceptedArtifact.mutualRecursionClaimAccepted, AverCert.AcceptedArtifact.mutualPlanForExport, AverCert.AcceptedArtifact.mutualPlanAccepted",
+        parts.len(),
+        |index| {
+            let MutualParts {
+                name,
+                lowered_body,
+                code_entry_bytes,
+                export_name_bytes,
+                host_table,
+                member_set,
+                self_idx,
+                type_idx,
+                carrier,
+            } = &parts[index];
+            let body = format!("mutualClaim{index}Body");
+            let code_entry = format!("mutualClaim{index}CodeEntry");
+            let binding = format!("mutualClaim{index}Binding");
+            let check_plan = format!("mutualClaim{index}CheckPlan");
+            let lower_body = format!("mutualClaim{index}LowerBody");
+            let lower_code = format!("mutualClaim{index}LowerCode");
+            let func_binding = format!("mutualClaim{index}FuncBinding");
+            let check_shape = format!("mutualClaim{index}CheckShape");
+            let func_type = format!("mutualClaim{index}FuncType");
+            let host_types = format!("mutualClaim{index}HostTypes");
+            let plan = format!("AverCert.Plans.{name}MutualPlan");
+            let declarations = format!(
+                "-- Witness data for `{name}` as named constants so no large literal is\n\
+                 -- duplicated across the leaf statements or baked into the aggregate term.\n\
+                 def {body} : List CertPrelude.WInstr := {lowered_body}\n\n\
+                 def {code_entry} : AverCert.WasmSlice.ByteSeq := {code_entry_bytes}\n\n\
+                 def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+                   {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry} }}\n\n\
+                 -- One leaf theorem per acceptance conjunct; the heavy ones are the\n\
+                 -- `modBytes` binding decode and type-section walks.\n\
+                 theorem {check_plan} :\n  \
+                   AverCert.PlanCheck.checkMutualRawPlan {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {lower_body} :\n  \
+                   AverCert.PlanLower.lowerMutualBody {carrier} {plan} = some {body} := by\n  \
+                   rfl\n\n\
+                 theorem {lower_code} :\n  \
+                   AverCert.PlanBytes.lowerMutualCodeEntry {carrier} {plan} = some {code_entry} := by\n  \
+                   rfl\n\n\
+                 theorem {func_binding} :\n  \
+                   AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+                   rfl\n\n\
+                 theorem {check_shape} :\n  \
+                   AverCert.PlanCheck.checkMutualPlanShape {member_set} {host_table} {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {func_type} :\n  \
+                   AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx {plan}.params.length {carrier} = true := by\n  \
+                   rfl\n\n\
+                 theorem {host_types} :\n  \
+                   AverCert.WasmSlice.hostTableFuncTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table} = true := by\n  \
+                   rfl\n\n"
+            );
+            let aggregate_proof = format!(
+                "⟨rfl, rfl, rfl, {check_plan}, rfl, ⟨{body}, {code_entry}, {binding}, ⟨{lower_body}, {lower_code}, {func_binding}, rfl, {check_shape}, {func_type}, {host_types}, rfl⟩⟩⟩"
+            );
+            (declarations, aggregate_proof)
+        },
+    )
+}
+
 fn render_artifact_expr_fragment_claims(
     analysis: &Analysis,
     model_info: &ModelInfo,
@@ -1229,7 +1312,7 @@ fn render_artifact_expr_fragment_claims(
     let mut string_proofs = Vec::new();
     let mut construct_proofs = Vec::new();
     let mut recursion_parts: Vec<RecursionParts> = Vec::new();
-    let mut mutual_proofs = Vec::new();
+    let mut mutual_parts: Vec<MutualParts> = Vec::new();
     let mut verbatim_proofs = Vec::new();
     let mut int_dispatch_proofs = Vec::new();
     let mut field_projection_proofs = Vec::new();
@@ -1498,18 +1581,22 @@ fn render_artifact_expr_fragment_claims(
                 let export_name_bytes = render_byte_list(name.as_bytes());
                 let host_table = mutual_host_table_lean_value(*box_idx, *sub_idx);
                 let member_set = mutual_member_set_lean_value(scc);
-                let func_binding = format!(
-                    "({{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry_bytes} }} : AverCert.WasmSlice.FuncBinding)",
-                    type_idx = member.type_idx,
-                );
                 mutual_claims.push(format!(
                     "({{ exportNameBytes := {export_name_bytes}, exportName := {export_name}, carrier := {carrier}, memberSet := {member_set}, hostTable := {host_table}, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.MutualRecursionClaim)",
                     export_name = lean_str(name),
                 ));
-                mutual_proofs.push(format!(
-                    "⟨rfl, rfl, rfl, rfl, rfl, ⟨({lowered_body}), ({code_entry_bytes}), {func_binding}, \
-                     ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
-                ));
+                // Split acceptance proof; see `render_mutual_claim_bundles`.
+                mutual_parts.push(MutualParts {
+                    name: name.clone(),
+                    lowered_body,
+                    code_entry_bytes,
+                    export_name_bytes,
+                    host_table,
+                    member_set,
+                    self_idx: *self_idx,
+                    type_idx: member.type_idx,
+                    carrier: *carrier,
+                });
             }
             Cert::VerbatimWidenedMatch {
                 name, carrier, ..
@@ -1729,7 +1816,7 @@ fn render_artifact_expr_fragment_claims(
         + string_proofs.len()
         + construct_proofs.len()
         + recursion_parts.len()
-        + mutual_proofs.len()
+        + mutual_parts.len()
         + verbatim_proofs.len()
         + int_dispatch_proofs.len()
         + field_projection_proofs.len()
@@ -1775,13 +1862,7 @@ fn render_artifact_expr_fragment_claims(
     );
     let construct_proof = format!("⟨{construct_claims_proof}, {construct_nodup_proof}⟩");
     let (recursion_bundles, recursion_proof) = render_recursion_claim_bundles(&recursion_parts);
-    let (mutual_bundles, mutual_proof) = render_per_claim_bundles(
-        "mutual",
-        "AverCert.AcceptedArtifact.mutualRecursionClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
-        "mutualRecursionClaims",
-        "AverCert.AcceptedArtifact.mutualRecursionClaimAccepted, AverCert.AcceptedArtifact.mutualPlanForExport, AverCert.AcceptedArtifact.mutualPlanAccepted",
-        &mutual_proofs,
-    );
+    let (mutual_bundles, mutual_proof) = render_mutual_claim_bundles(&mutual_parts);
     let (verbatim_bundles, verbatim_proof) = render_per_claim_bundles(
         "verbatim",
         "AverCert.AcceptedArtifact.verbatimClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",

--- a/aver-cert/src/engine/render_project.rs
+++ b/aver-cert/src/engine/render_project.rs
@@ -1635,6 +1635,92 @@ fn render_composition_claim_bundles(parts: &[CompositionParts]) -> (String, Stri
     )
 }
 
+/// Structured inputs for one field-projection claim's split acceptance proof.
+struct FieldProjectionParts {
+    name: String,
+    body: String,
+    code_entry: String,
+    export_name_bytes: String,
+    result_ty: String,
+    struct_idx: u32,
+    field_count: u32,
+    self_idx: u32,
+    type_idx: u32,
+    carrier: u32,
+}
+
+/// Split the field-projection family. The former proof left the body,
+/// code-entry and binding as `_`; elaboration solves them to the same large
+/// literals the byte lowerers produce, so they still bloated the single proof
+/// term. Emit them as named `def`s (the `Cert` already carries the exact bytes
+/// and ops the wall lowerers reproduce) and each byte-walking conjunct as its
+/// own leaf theorem over `Plans.{name}FieldProjectionPlan`.
+fn render_field_projection_claim_bundles(parts: &[FieldProjectionParts]) -> (String, String) {
+    render_split_bundles(
+        "fieldProjection",
+        "AverCert.AcceptedArtifact.fieldProjectionClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
+        "fieldProjectionClaims",
+        "AverCert.AcceptedArtifact.fieldProjectionClaimAccepted, AverCert.AcceptedArtifact.fieldProjectionPlanForExport, AverCert.AcceptedArtifact.fieldProjectionPlanAccepted",
+        parts.len(),
+        |index| {
+            let FieldProjectionParts {
+                name,
+                body,
+                code_entry,
+                export_name_bytes,
+                result_ty,
+                struct_idx,
+                field_count,
+                self_idx,
+                type_idx,
+                carrier,
+            } = &parts[index];
+            let body_def = format!("fieldProjectionClaim{index}Body");
+            let code_def = format!("fieldProjectionClaim{index}CodeEntry");
+            let binding_def = format!("fieldProjectionClaim{index}Binding");
+            let check_plan = format!("fieldProjectionClaim{index}CheckPlan");
+            let lower_body = format!("fieldProjectionClaim{index}LowerBody");
+            let lower_code = format!("fieldProjectionClaim{index}LowerCode");
+            let func_binding = format!("fieldProjectionClaim{index}FuncBinding");
+            let struct_type = format!("fieldProjectionClaim{index}StructType");
+            let func_type = format!("fieldProjectionClaim{index}FuncType");
+            let plan = format!("AverCert.Plans.{name}FieldProjectionPlan");
+            let declarations = format!(
+                "-- Witness data for `{name}` as named constants so the byte lowerings\n\
+                 -- are not solved into large literals inside one proof term.\n\
+                 def {body_def} : List CertPrelude.WInstr := {body}\n\n\
+                 def {code_def} : AverCert.WasmSlice.ByteSeq := {code_entry}\n\n\
+                 def {binding_def} : AverCert.WasmSlice.FuncBinding :=\n  \
+                   {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_def} }}\n\n\
+                 -- One leaf theorem per acceptance conjunct; the heavy ones are the\n\
+                 -- `modBytes` binding decode and type-section walks.\n\
+                 theorem {check_plan} :\n  \
+                   AverCert.PlanCheck.checkFieldProjectionRawPlan {field_count} {plan} = true := by\n  \
+                   rfl\n\n\
+                 theorem {lower_body} :\n  \
+                   AverCert.PlanLower.lowerFieldProjectionBody {struct_idx} {field_count} {plan} = some {body_def} := by\n  \
+                   rfl\n\n\
+                 theorem {lower_code} :\n  \
+                   AverCert.PlanBytes.lowerFieldProjectionCodeEntry {carrier} {struct_idx} {field_count} {result_ty} {plan} = some {code_def} := by\n  \
+                   rfl\n\n\
+                 theorem {func_binding} :\n  \
+                   AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_def} = some {binding_def} := by\n  \
+                   rfl\n\n\
+                 theorem {struct_type} :\n  \
+                   AverCert.WasmSlice.projectionStructTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {struct_idx} {field_count} {plan}.fieldIdx {result_ty} = true := by\n  \
+                   rfl\n\n\
+                 theorem {func_type} :\n  \
+                   AverCert.WasmSlice.projectionFuncTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding_def}.typeIdx {struct_idx} {result_ty} = true := by\n  \
+                   rfl\n\n"
+            );
+            let aggregate_proof = format!(
+                "⟨rfl, rfl, {check_plan}, ⟨{body_def}, {code_def}, {binding_def}, {lower_body}, {lower_code}, {func_binding}, {struct_type}, {func_type}, rfl, rfl⟩⟩"
+            );
+            (declarations, aggregate_proof)
+        },
+    )
+}
+
 fn render_artifact_expr_fragment_claims(
     analysis: &Analysis,
     model_info: &ModelInfo,
@@ -1659,7 +1745,7 @@ fn render_artifact_expr_fragment_claims(
     let mut mutual_parts: Vec<MutualParts> = Vec::new();
     let mut verbatim_proofs = Vec::new();
     let mut int_dispatch_proofs = Vec::new();
-    let mut field_projection_proofs = Vec::new();
+    let mut field_projection_parts: Vec<FieldProjectionParts> = Vec::new();
     let mut composition_parts: Vec<CompositionParts> = Vec::new();
     let mut string_concat_faces: Vec<Option<(String, String)>> = Vec::new();
     let mut construct_faces: Vec<Option<(String, String)>> = Vec::new();
@@ -2020,24 +2106,40 @@ fn render_artifact_expr_fragment_claims(
             }
             Cert::FieldProjection {
                 name,
+                self_idx,
+                type_idx,
                 carrier,
                 struct_idx,
                 field_count,
+                code_entry_bytes,
+                ops,
                 ..
             } => {
                 let Some((_plan, result_ty)) = field_projection_plan_from_cert(c) else {
                     continue;
                 };
+                let result_ty = field_projection_result_ty_lean_value(result_ty);
                 field_projection_claims.push(format!(
                     "({{ exportNameBytes := {bytes}, exportName := {export_name}, carrier := {carrier}, structIdx := {struct_idx}, fieldCount := {field_count}, resultTy := {result_ty}, obligation := AverCert.{name}Ob }} : AverCert.AcceptedArtifact.FieldProjectionClaim)",
                     bytes = render_byte_list(name.as_bytes()),
                     export_name = lean_str(name),
-                    result_ty = field_projection_result_ty_lean_value(result_ty),
                 ));
-                field_projection_proofs.push(
-                    "⟨rfl, rfl, rfl, ⟨_, _, _, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩"
-                        .to_string(),
-                );
+                // Split acceptance proof; the `Cert` already carries the exact
+                // ops and code-entry bytes the wall lowerers reproduce, so no `_`
+                // witness is solved into a large literal. See
+                // `render_field_projection_claim_bundles`.
+                field_projection_parts.push(FieldProjectionParts {
+                    name: name.clone(),
+                    body: render_ops_value(ops),
+                    code_entry: render_byte_list(code_entry_bytes),
+                    export_name_bytes: render_byte_list(name.as_bytes()),
+                    result_ty,
+                    struct_idx: *struct_idx,
+                    field_count: *field_count,
+                    self_idx: *self_idx,
+                    type_idx: *type_idx,
+                    carrier: *carrier,
+                });
             }
             _ => {}
         }
@@ -2181,7 +2283,7 @@ fn render_artifact_expr_fragment_claims(
         + mutual_parts.len()
         + verbatim_proofs.len()
         + int_dispatch_proofs.len()
-        + field_projection_proofs.len()
+        + field_projection_parts.len()
         + composition_parts.len();
     let obligation_proof = (0..obligation_proof_count).fold("trivial".to_string(), |acc, _| {
         format!("⟨rfl, {acc}⟩")
@@ -2221,13 +2323,8 @@ fn render_artifact_expr_fragment_claims(
         "AverCert.AcceptedArtifact.intDispatchClaimAccepted, AverCert.AcceptedArtifact.intDispatchPlanForExport, AverCert.AcceptedArtifact.intDispatchPlanAccepted, AverCert.AcceptedArtifact.intDispatchCanonicalHost, AverCert.AcceptedArtifact.intDispatchCanonicalSlots",
         &int_dispatch_proofs,
     );
-    let (field_projection_bundles, field_projection_proof) = render_per_claim_bundles(
-        "fieldProjection",
-        "AverCert.AcceptedArtifact.fieldProjectionClaimAccepted AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen AverCert.manifest",
-        "fieldProjectionClaims",
-        "AverCert.AcceptedArtifact.fieldProjectionClaimAccepted, AverCert.AcceptedArtifact.fieldProjectionPlanForExport, AverCert.AcceptedArtifact.fieldProjectionPlanAccepted",
-        &field_projection_proofs,
-    );
+    let (field_projection_bundles, field_projection_proof) =
+        render_field_projection_claim_bundles(&field_projection_parts);
     let (composition_bundles, composition_claims_proof) =
         render_composition_claim_bundles(&composition_parts);
     // `acceptedCompositionFragments` conjoins the per-claim acceptance with the

--- a/aver-cert/src/engine/render_recursion_bridge.rs
+++ b/aver-cert/src/engine/render_recursion_bridge.rs
@@ -60,39 +60,95 @@ fn recursion_claim_lean_value(c: &Cert) -> String {
     )
 }
 
-/// Concrete byte/plan acceptance needed to instantiate the artifact-shaped
-/// audited discharge from `Final.lean`. This is data reconstruction only: the
-/// source-model residual lives exclusively in the semantic bridge below.
-fn recursion_claim_acceptance_proof(c: &Cert) -> String {
-    let (self_idx, type_idx, carrier) = match c.inner() {
+/// Render the companion `{name}_recursionClaimAccepted` theorem as a SPLIT
+/// proof, mirroring `render_recursion_claim_bundles` in `render_project.rs`.
+///
+/// This bridge module re-proves acceptance for its export in a STANDALONE file,
+/// so the same monolithic witness tuple that inflated the artifact root also
+/// inflated this module. Emitting the lowered body, code-entry bytes and
+/// function binding as named `def`s and each byte-walking conjunct as its own
+/// leaf theorem keeps this module's per-claim peak at the largest single leaf.
+/// The leaves are stated over `AverCert.Plans.{name}RecursionPlan`, so the
+/// aggregate re-runs no byte-decode work.
+fn render_recursion_bridge_claim_accepted(c: &Cert) -> String {
+    let (name, self_idx, type_idx, carrier) = match c.inner() {
         Cert::Recursive {
+            name,
             self_idx,
             type_idx,
             carrier,
             ..
         }
         | Cert::AccumulatorRecursive {
+            name,
             self_idx,
             type_idx,
             carrier,
             ..
-        } => (self_idx, type_idx, carrier),
+        } => (name, self_idx, type_idx, carrier),
         _ => unreachable!("audited recursion acceptance has a recursion shape"),
     };
-    let plan = recursion_plan_from_cert(c).expect("audited recursion has a canonical plan");
-    let body = lower_expr_fragment_plan(&plan, *carrier)
+    let plan_cert = recursion_plan_from_cert(c).expect("audited recursion has a canonical plan");
+    let lowered_body = lower_expr_fragment_plan(&plan_cert, *carrier)
         .map(|ops| render_ops_value(&ops))
         .expect("audited recursion plan lowers to WInstr");
-    let bytes = lower_expr_fragment_plan_code_entry_bytes(&plan, *carrier)
+    let code_entry_bytes = lower_expr_fragment_plan_code_entry_bytes(&plan_cert, *carrier)
         .expect("audited recursion plan lowers to exact code-entry bytes");
-    let bytes = render_byte_list(&bytes);
-    let binding = format!(
-        "({{ funcIdx := {self_idx}, typeIdx := {type_idx}, \
-         codeEntry := {bytes} }} : AverCert.WasmSlice.FuncBinding)"
-    );
+    let code_entry_bytes = render_byte_list(&code_entry_bytes);
+    let export_name_bytes = render_byte_list(name.as_bytes());
+    let host_table = recursion_host_table_lean_value(c);
+    let claim = recursion_claim_lean_value(c);
+
+    let body = format!("{name}RecursionClaimBody");
+    let code_entry = format!("{name}RecursionClaimCodeEntry");
+    let binding = format!("{name}RecursionClaimBinding");
+    let check_plan = format!("{name}RecursionClaimCheckPlan");
+    let lower_body = format!("{name}RecursionClaimLowerBody");
+    let lower_code = format!("{name}RecursionClaimLowerCode");
+    let func_binding = format!("{name}RecursionClaimFuncBinding");
+    let check_shape = format!("{name}RecursionClaimCheckShape");
+    let func_type = format!("{name}RecursionClaimFuncType");
+    let host_types = format!("{name}RecursionClaimHostTypes");
+    let plan = format!("AverCert.Plans.{name}RecursionPlan");
+    let obligation = format!("AverCert.{name}Ob");
     format!(
-        "⟨rfl, rfl, rfl, rfl, ⟨({body}), ({bytes}), {binding}, \
-         ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩⟩⟩"
+        "-- Witness data for `{name}` as named constants so no large literal is\n\
+         -- duplicated across the leaf statements or baked into the aggregate term.\n\
+         def {body} : List CertPrelude.WInstr := {lowered_body}\n\n\
+         def {code_entry} : AverCert.WasmSlice.ByteSeq := {code_entry_bytes}\n\n\
+         def {binding} : AverCert.WasmSlice.FuncBinding :=\n  \
+           {{ funcIdx := {self_idx}, typeIdx := {type_idx}, codeEntry := {code_entry} }}\n\n\
+         -- One leaf theorem per acceptance conjunct; the heavy ones are the\n\
+         -- `modBytes` binding decode and type-section walks.\n\
+         theorem {check_plan} :\n  \
+           AverCert.PlanCheck.checkRecursionRawPlan {plan} = true := by\n  \
+           rfl\n\n\
+         theorem {lower_body} :\n  \
+           AverCert.PlanLower.lowerRecursionBody {carrier} {plan} = some {body} := by\n  \
+           rfl\n\n\
+         theorem {lower_code} :\n  \
+           AverCert.PlanBytes.lowerRecursionCodeEntry {carrier} {plan} = some {code_entry} := by\n  \
+           rfl\n\n\
+         theorem {func_binding} :\n  \
+           AverCert.WasmSlice.exactFuncBindingForExport AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {export_name_bytes} {code_entry} = some {binding} := by\n  \
+           rfl\n\n\
+         theorem {check_shape} :\n  \
+           AverCert.PlanCheck.checkRecursionPlanShape {binding}.funcIdx {host_table} {obligation}.totalityRole {plan} = true := by\n  \
+           rfl\n\n\
+         theorem {func_type} :\n  \
+           AverCert.WasmSlice.funcTypeMatches AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {binding}.typeIdx {plan}.params.length {carrier} = true := by\n  \
+           rfl\n\n\
+         theorem {host_types} :\n  \
+           AverCert.WasmSlice.hostTableFuncTypesMatch AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen {carrier} {host_table} = true := by\n  \
+           rfl\n\n\
+         theorem {name}_recursionClaimAccepted :\n    \
+           AverCert.AcceptedArtifact.recursionClaimAccepted\n      \
+             AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen\n      \
+             AverCert.manifest {claim} := by\n  \
+           dsimp [AverCert.AcceptedArtifact.recursionClaimAccepted,\n    \
+             AverCert.AcceptedArtifact.recursionPlanForExport,\n    \
+             AverCert.AcceptedArtifact.recursionPlanAccepted]\n  \
+           exact ⟨rfl, rfl, {check_plan}, rfl, ⟨{body}, {code_entry}, {binding}, ⟨{lower_body}, {lower_code}, {func_binding}, rfl, {check_shape}, {func_type}, {host_types}, rfl⟩⟩⟩\n"
     )
 }
 
@@ -117,19 +173,11 @@ fn render_unary_recursion_semantic_bridge(c: &Cert, model_info: &ModelInfo) -> S
     let shape = recursion_shape_lean_value(c);
     let combine = recursion_combine_lean_value(c);
     let claim = recursion_claim_lean_value(c);
-    let acceptance = recursion_claim_acceptance_proof(c);
+    let claim_accepted = render_recursion_bridge_claim_accepted(c);
     format!(
         r#"/-! ### {name} — option-(b) recursion semantic bridge -/
 
-theorem {name}_recursionClaimAccepted :
-    AverCert.AcceptedArtifact.recursionClaimAccepted
-      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen
-      AverCert.manifest {claim} := by
-  dsimp [AverCert.AcceptedArtifact.recursionClaimAccepted,
-    AverCert.AcceptedArtifact.recursionPlanForExport,
-    AverCert.AcceptedArtifact.recursionPlanAccepted]
-  exact {acceptance}
-
+{claim_accepted}
 theorem {name}_recursionSemanticBridge :
     AcceptanceSoundness.recursionSemanticBridge {claim}
       AverCert.Plans.{name}RecursionPlan := by
@@ -182,19 +230,11 @@ fn render_accumulator_recursion_semantic_bridge(c: &Cert, model_info: &ModelInfo
     };
     let model_name = c.model_lean_name(model_info);
     let claim = recursion_claim_lean_value(c);
-    let acceptance = recursion_claim_acceptance_proof(c);
+    let claim_accepted = render_recursion_bridge_claim_accepted(c);
     format!(
         r#"/-! ### {name} — option-(b) accumulator recursion semantic bridge -/
 
-theorem {name}_recursionClaimAccepted :
-    AverCert.AcceptedArtifact.recursionClaimAccepted
-      AverCert.ArtifactBytes.modBytes AverCert.ArtifactBytes.modLen
-      AverCert.manifest {claim} := by
-  dsimp [AverCert.AcceptedArtifact.recursionClaimAccepted,
-    AverCert.AcceptedArtifact.recursionPlanForExport,
-    AverCert.AcceptedArtifact.recursionPlanAccepted]
-  exact {acceptance}
-
+{claim_accepted}
 theorem {name}_recursionSemanticBridge :
     AcceptanceSoundness.recursionSemanticBridge {claim}
       AverCert.Plans.{name}RecursionPlan := by


### PR DESCRIPTION
Certificates for larger modules could not be verified: a single-export example already drove the kernel to ~6.7 GB, and the checkers board and the notepad app could not finish at all — the host swapped. This makes them verifiable again.

## What the cost actually was

The blowup is not the byte decoder (a separate measurement confirmed the kernel decodes a 44 kB module in under 5 seconds regardless of how the bytes are represented — it GMP-accelerates the shift and mask, and the module bytes are shared and reduced once). It is the shape of the emitted proof: each claim's acceptance was discharged by one monolithic anonymous-constructor term, `dsimp; exact ⟨…⟩`, that the elaborator and kernel held entirely live. Removing that one term from the single-claim example dropped it from 6.65 GB to 1.34 GB; every conjunct proved on its own was under 1.24 GB.

## The change

Producer-side only. The generated per-claim proof now emits the heavy witness data (the lowered body, the code-entry bytes, the function binding) as named top-level `def`s, and each byte-walking acceptance conjunct as its own leaf `theorem`, with a thin aggregate that references those constants. Because each is a separate top-level declaration with an explicit type, each is submitted to the kernel in its own step and freed before the next, so the peak is the largest single conjunct rather than the whole tuple. The serial verify peak is the maximum over all emitted modules, so the companion re-proof modules each family also emits are split the same way. Applied to all ten claim families and their bridge modules.

This does not touch the trusted acceptance predicate. The wall sources are unchanged and `CURRENT_WALL_ID` does not move; the diff is five files under `aver-cert/src/engine/`. A wrong split fails the kernel — the acceptance predicate the proof discharges is identical, only its assembly changed.

## Measured

| module | claims | peak, before | peak, after | verdict |
|---|--:|--:|--:|---|
| affine | 1 | 6.68 GB | 1.45 GB | CERTIFIED |
| checkers board | 1 | 15.9 GB (swapping) | 2.43 GB | CERTIFIED |
| checkers ai | 4 | did not finish | 4.95 GB | CERTIFIED |
| notepad app | 12 | did not finish | 6.62 GB | CERTIFIED |

Per-claim cost is additive over a shared decode floor, not multiplicative. Every `cert verify` on the critical path is ~4.6x lighter.

## Gates

`cert_certify_spec` 34/34 (goal matrix exercises every family and bridge kernel-clean; the add_one golden snapshot does not drift), `cert_whole_module_guard_iso` 12/12, `cert_decode_spec` 7/7. Regenerated certificate axioms `[propext, Classical.choice, Quot.sound]`. `cargo fmt --check` clean; clippy clean in all CI shapes.
