### PR TITLE
Render Tcp.sendBytes through the Rust codegen backend

### DIFF
--- a/src/codegen/rust/builtins.rs
+++ b/src/codegen/rust/builtins.rs
@@ -53,6 +53,7 @@ pub(super) fn builtin_needs_str_conversion(name: &str) -> bool {
             | "Http.put"
             | "Http.patch"
             | "Tcp.send"
+            | "Tcp.sendBytes"
             | "Tcp.ping"
             | "Tcp.connect"
             | "Tcp.writeLine"
@@ -69,6 +70,13 @@ fn builtin_effect_name(name: &str) -> &str {
         "SelfHostRuntime.httpServerListenWith" => "HttpServer.listenWith",
         _ => name,
     }
+}
+
+fn compose_tcp_send_bytes_call(args: &[String]) -> String {
+    format!(
+        "{{ let __host = &{}; let __port = crate::to_host_i64(&{}, \"Tcp.sendBytes: port must be an Int\"); let __payload = &{}; match crate::tcp_send_bytes_payload_to_host(__payload) {{ Ok(__bytes) => aver_rt::tcp::send_bytes(__host, __port, &__bytes).map(crate::tcp_send_bytes_response_from_host), Err(__error) => Err(__error) }} }}",
+        args[0], args[1], args[2]
+    )
 }
 
 pub(super) fn builtin_is_effectful(name: &str) -> bool {
@@ -157,6 +165,7 @@ fn emit_effectful_builtin_call_with_temps(name: &str, args: &[String]) -> Option
             "aver_rt::tcp::send(&{}, crate::to_host_i64(&{}, \"Tcp.send: port must be an Int\"), &{})",
             args[0], args[1], args[2]
         )),
+        "Tcp.sendBytes" => Some(compose_tcp_send_bytes_call(args)),
         "Tcp.ping" => Some(format!(
             "aver_rt::tcp::ping(&{}, crate::to_host_i64(&{}, \"Tcp.ping: port must be an Int\"))",
             args[0], args[1]
@@ -384,6 +393,7 @@ pub(super) fn compose_effectful_builtin_raw(name: &str, args: &[String]) -> Opti
             a(1),
             a(2)
         )),
+        "Tcp.sendBytes" => Some(compose_tcp_send_bytes_call(args)),
         "Tcp.ping" => Some(format!(
             "aver_rt::tcp::ping(&{}, crate::to_host_i64(&{}, \"Tcp.ping: port must be an Int\"))",
             a(0),

--- a/src/codegen/rust/runtime.rs
+++ b/src/codegen/rust/runtime.rs
@@ -248,7 +248,41 @@ where
 /// (`Tcp.connect`, see `convert_tcp_connection`). Keeping the surface type
 /// distinct is what lets `conn.port.add(&…)` typecheck.
 pub fn generate_tcp_types() -> String {
-    r#"#[derive(Clone, Debug, PartialEq)]
+    r#"pub fn tcp_send_bytes_payload_to_host(
+    payload: &aver_rt::AverList<aver_rt::AverInt>,
+) -> Result<Vec<u8>, String> {
+    let mut bytes = Vec::with_capacity(payload.len());
+    for (idx, n) in payload.iter().enumerate() {
+        let Some(byte) = n.to_i64().and_then(|n| u8::try_from(n).ok()) else {
+            return Err(format!(
+                "Tcp.sendBytes: byte {} at index {} is out of range (0–255)",
+                n, idx
+            ));
+        };
+        bytes.push(byte);
+    }
+    Ok(bytes)
+}
+
+pub fn tcp_send_bytes_response_from_host(
+    bytes: Vec<u8>,
+) -> aver_rt::AverList<aver_rt::AverInt> {
+    aver_rt::AverList::from_vec(
+        bytes
+            .into_iter()
+            .map(|byte| aver_rt::AverInt::from_i64(i64::from(byte)))
+            .collect(),
+    )
+}
+
+impl IntoAverStr for Result<aver_rt::AverList<aver_rt::AverInt>, String> {
+    type Output = Result<aver_rt::AverList<aver_rt::AverInt>, AverStr>;
+    fn into_aver(self) -> Self::Output {
+        self.map_err(AverStr::from)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct Tcp_Connection {
     pub id: aver_rt::AverStr,
     pub host: aver_rt::AverStr,

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -363,6 +363,45 @@ fn run_vm_inline(name: &str, source: &str) -> Result<String, String> {
     out
 }
 
+/// `aver compile` can succeed while leaving a MIR-walker `compile_error!` in
+/// the emitted project, so this regression must drive `Tcp.sendBytes` through
+/// a real `cargo build`. Invalid payloads fail before any socket connection,
+/// which also pins the VM's catchable value-error contract for both small and
+/// arbitrary-precision `Int` values.
+#[test]
+fn rust_tcp_send_bytes_builds_and_returns_catchable_range_errors() {
+    let src = r#"module TcpSendBytesRange
+    intent = "Rust codegen must render Tcp.sendBytes and preserve payload errors"
+    depends []
+    effects [Console, Tcp]
+
+fn report(payload: List<Int>) -> Unit
+    ? "Print the result of validating one binary payload."
+    ! [Console.print, Tcp.sendBytes]
+    match Tcp.sendBytes("127.0.0.1", 1, payload)
+        Result.Ok(_) -> Console.print("unexpected-ok")
+        Result.Err(e) -> Console.print(e)
+
+fn main() -> Unit
+    ! [Console.print, Tcp.sendBytes]
+    report([65, 256])
+    report([65, 1208925819614629174706176])
+"#;
+    let expected = concat!(
+        "Tcp.sendBytes: byte 256 at index 1 is out of range (0–255)\n",
+        "Tcp.sendBytes: byte 1208925819614629174706176 at index 1 is out of range (0–255)",
+    );
+
+    let vm = run_vm_inline("tcp_send_bytes_range", src).expect("vm run");
+    let rust = build_run_rust_inline("tcp_send_bytes_range", src)
+        .expect("rust compile + cargo build + run");
+    assert_eq!(vm, expected, "VM payload-range contract changed");
+    assert_eq!(
+        rust, expected,
+        "Rust payload-range contract diverged from VM"
+    );
+}
+
 /// The #383 corruption class on the RUST backend: a Vector PARAM captured
 /// into a record field AND own-mutated, both in the SAME fn on the SAME
 /// param. `own_param`'s capture guard must keep the slot flagged so the
@@ -2224,6 +2263,117 @@ fn spawn_pong_server(
         }
     });
     (port, handle)
+}
+
+#[test]
+#[ignore = "full tier: cargo build wall-time; set AVER_RUST_DIFF_FULL=1 and run with --ignored"]
+fn rust_tcp_send_bytes_round_trips_non_utf8() {
+    if std::env::var("AVER_RUST_DIFF_FULL").is_err() {
+        eprintln!("skipping Rust Tcp.sendBytes probe — set AVER_RUST_DIFF_FULL=1");
+        return;
+    }
+
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let port = listener.local_addr().expect("listener addr").port();
+    listener
+        .set_nonblocking(true)
+        .expect("set listener nonblocking");
+
+    let ws = temp_dir("tcp-send-bytes");
+    let src = ws.join("tcp_send_bytes.av");
+    fs::write(
+        &src,
+        format!(
+            r#"module TcpSendBytesProbe
+    intent = "Round-trip non-UTF-8 bytes through the Rust backend"
+    depends []
+    effects [Console, Tcp]
+
+fn exchange() -> Result<List<Int>, String>
+    ? "Send one binary payload to a loopback echo server."
+    ! [Tcp.sendBytes]
+    Tcp.sendBytes("127.0.0.1", {port}, [249, 190, 180, 217])
+
+fn main() -> Unit
+    ! [Console.print, Tcp.sendBytes]
+    match exchange()
+        Result.Ok(response) -> Console.print("{{response}}")
+        Result.Err(e) -> Console.print("err:{{e}}")
+"#
+        ),
+    )
+    .expect("write probe source");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let name = "tcp_send_bytes_probe";
+
+    let result = (|| -> Result<(), String> {
+        compile_rust(&src, &project, name, None, &[])?;
+        let bin = cargo_build_in(&project, name, &isolated_target_dir(&ws))?;
+
+        let server = std::thread::spawn(move || -> Result<Vec<u8>, String> {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            loop {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .map_err(|e| format!("set stream blocking: {e}"))?;
+                        stream
+                            .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                            .map_err(|e| format!("set read timeout: {e}"))?;
+                        let mut payload = Vec::new();
+                        stream
+                            .read_to_end(&mut payload)
+                            .map_err(|e| format!("read payload: {e}"))?;
+                        stream
+                            .write_all(&payload)
+                            .map_err(|e| format!("echo payload: {e}"))?;
+                        return Ok(payload);
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        if std::time::Instant::now() >= deadline {
+                            return Err(
+                                "timed out waiting for Tcp.sendBytes connection".to_string()
+                            );
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                    }
+                    Err(e) => return Err(format!("accept connection: {e}")),
+                }
+            }
+        });
+
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("run generated binary: {e}"))?;
+        let received = server
+            .join()
+            .map_err(|_| "loopback server panicked".to_string())??;
+        if !out.status.success() {
+            return Err(format!("generated binary failed:\n{}", format_output(&out)));
+        }
+        if received != [249, 190, 180, 217] {
+            return Err(format!(
+                "loopback server received wrong payload: {received:?}"
+            ));
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if stdout != "[249, 190, 180, 217]" {
+            return Err(format!(
+                "generated binary returned wrong payload:\n{}",
+                format_output(&out)
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
 }
 
 #[test]


### PR DESCRIPTION
First of two backend follow-ups to #764 (the other will cover wasm-gc/wasip2). A `Tcp.sendBytes` program previously reported `Compiled ... [Rust]` and then the generated project failed at `cargo build` with "MIR walker could not render the `main` fn body" — the builtin was missing from the backend entirely. Surfaced by @n1bor in #764.

The arm maps onto the existing target-independent `aver_rt::tcp::send_bytes`, with two prelude helpers in the generated project: payload conversion `AverList<AverInt>` → `Vec<u8>` and response conversion back. The payload conversion carries the VM's exact error contract — any element outside `0..=255`, including arbitrary-precision `Int`s beyond `i64`, produces the same catchable `Result.Err` naming the value and its index, byte-for-byte identical to the VM message.

Two regressions in `rust_codegen_differential`:

- a differential test driving the same out-of-range program through the VM and a real `cargo build` + run of the generated project, asserting both produce identical error output for `256` and for a 2^80-scale payload element;
- a full-tier loopback round-trip (`AVER_RUST_DIFF_FULL=1`): the generated binary sends `F9 BE B4 D9` to a local echo server and prints the intact bytes back.

`rust_codegen_differential` green including both new tests, `eval_spec` `tcp_send_bytes` green, `cargo fmt --check` clean, clippy clean.
