### PR TITLE
Pack bounded sequence refinements on wasm-gc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
             wasm_gc_games_differential_mir \
             wasm_gc_handler_carrier \
             wasm_gc_optimize_trunc_sat \
+            wasm_gc_packed_sequence \
             wasm_gc_perslot_int_unboxing_differential \
             wasm_gc_record_replay_spec \
             wasm_gc_spec \

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -1259,6 +1259,75 @@ fn literal_in_interval(value: &Spanned<Expr>, iv: crate::ir::interval::Interval)
     iv.contains_point(k)
 }
 
+/// Representation-independent safety scan for refinement carriers. A direct
+/// constructor or update outside the recognized smart constructor can bypass
+/// the invariant, so any such carrier must keep its ordinary representation.
+pub fn carrier_ungated_construction_demotions(
+    inputs: &ProofLowerInputs,
+    candidates: &HashSet<String>,
+    intervals: &HashMap<String, (crate::ir::interval::Interval, bool)>,
+) -> HashSet<String> {
+    let mut demoted = HashSet::new();
+    if candidates.is_empty() {
+        return demoted;
+    }
+
+    let mut ctor_fn_of: HashMap<String, String> = HashMap::new();
+    for name in candidates {
+        if let Some(info) = crate::codegen::common::refinement_info_for_in_scope(name, inputs, None)
+        {
+            ctor_fn_of.insert(name.clone(), info.constructor_fn.to_string());
+        } else {
+            for m in inputs.dep_modules {
+                if let Some(info) = crate::codegen::common::refinement_info_for_in_scope(
+                    name,
+                    inputs,
+                    Some(m.prefix.as_str()),
+                ) {
+                    ctor_fn_of.insert(name.clone(), info.constructor_fn.to_string());
+                    break;
+                }
+            }
+        }
+    }
+
+    let all_fn_defs = inputs
+        .entry_items
+        .iter()
+        .filter_map(|it| match it {
+            TopLevel::FnDef(fd) => Some(fd),
+            _ => None,
+        })
+        .chain(inputs.dep_modules.iter().flat_map(|m| m.fn_defs.iter()));
+    for fd in all_fn_defs {
+        for stmt in fd.body.stmts() {
+            let expr = match stmt {
+                crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => e,
+            };
+            carrier_walk_expr(expr, &mut |e| {
+                let (type_name, fields): (&String, &[(String, Spanned<Expr>)]) = match e {
+                    Expr::RecordCreate { type_name, fields } => (type_name, fields),
+                    Expr::RecordUpdate {
+                        type_name, updates, ..
+                    } => (type_name, updates),
+                    _ => return,
+                };
+                if !candidates.contains(type_name) || ctor_fn_of.get(type_name) == Some(&fd.name) {
+                    return;
+                }
+                let safe_literal = matches!(
+                    intervals.get(type_name),
+                    Some((iv, true)) if construct_arg_is_in_interval(fields, *iv)
+                );
+                if !safe_literal {
+                    demoted.insert(type_name.clone());
+                }
+            });
+        }
+    }
+    demoted
+}
+
 /// ETAP-2 carrier-`i64` SLICE 2b FOLLOW-UP: the fail-closed eligibility
 /// tightening. The bare carrier interval ([`carrier_interval_table`]) proves
 /// only that the smart-constructor's invariant `fits_i64`; it does NOT prove
@@ -1318,89 +1387,9 @@ pub fn carrier_eligibility_demotions(
     intervals: &HashMap<String, (crate::ir::interval::Interval, bool)>,
     resolved_map_keys: &[crate::ast::Type],
 ) -> HashSet<String> {
-    let mut demoted: HashSet<String> = HashSet::new();
+    let mut demoted = carrier_ungated_construction_demotions(inputs, candidates, intervals);
     if candidates.is_empty() {
         return demoted;
-    }
-
-    // Map each candidate carrier to its recognized smart-constructor fn name.
-    // `refinement_info_for_in_scope` is THE source of truth for "the
-    // smart-ctor function" — the exact fn the interval recognizer keyed off.
-    // For the wasm-gc path `dep_modules` is empty (the program is flattened
-    // into `entry_items`), so the entry scope (`None`) resolves every
-    // carrier; we still consult dep scopes for generality.
-    let mut ctor_fn_of: HashMap<String, String> = HashMap::new();
-    for name in candidates {
-        if let Some(info) = crate::codegen::common::refinement_info_for_in_scope(name, inputs, None)
-        {
-            ctor_fn_of.insert(name.clone(), info.constructor_fn.to_string());
-        } else {
-            for m in inputs.dep_modules {
-                if let Some(info) = crate::codegen::common::refinement_info_for_in_scope(
-                    name,
-                    inputs,
-                    Some(m.prefix.as_str()),
-                ) {
-                    ctor_fn_of.insert(name.clone(), info.constructor_fn.to_string());
-                    break;
-                }
-            }
-        }
-    }
-
-    // ---- Scan 1: ungated construction --------------------------------------
-    // Walk every fn body in the program. A `RecordCreate { type_name }` whose
-    // `type_name` is a candidate carrier and which sits in a fn OTHER than
-    // that carrier's smart-constructor is an ungated construct ⇒ demote,
-    // UNLESS its carrier-field argument is a constant literal provably inside
-    // the carrier's proven interval (an in-bounds literal can't smuggle an
-    // out-of-bound value past the gate — fail-closed but not over-eager). If
-    // we can't cleanly identify the smart-ctor (no entry in `ctor_fn_of`),
-    // every non-literal-safe construct demotes — fail-closed.
-    let all_fn_defs = inputs
-        .entry_items
-        .iter()
-        .filter_map(|it| match it {
-            TopLevel::FnDef(fd) => Some(fd),
-            _ => None,
-        })
-        .chain(inputs.dep_modules.iter().flat_map(|m| m.fn_defs.iter()));
-    for fd in all_fn_defs {
-        for stmt in fd.body.stmts() {
-            let expr = match stmt {
-                crate::ast::Stmt::Binding(_, _, e) | crate::ast::Stmt::Expr(e) => e,
-            };
-            carrier_walk_expr(expr, &mut |e| {
-                // Both a fresh construct (`RecordCreate`) and a record-update
-                // (`RecordUpdate`, which sets the carrier's only field to an
-                // arbitrary value) can smuggle a value past the smart-ctor
-                // gate; treat both the same.
-                let (type_name, fields): (&String, &[(String, Spanned<Expr>)]) = match e {
-                    Expr::RecordCreate { type_name, fields } => (type_name, fields),
-                    Expr::RecordUpdate {
-                        type_name, updates, ..
-                    } => (type_name, updates),
-                    _ => return,
-                };
-                if !candidates.contains(type_name) {
-                    return;
-                }
-                // The construct inside the carrier's own smart-ctor is the
-                // gated one — never demotes.
-                if ctor_fn_of.get(type_name) == Some(&fd.name) {
-                    return;
-                }
-                // Outside the smart-ctor: safe iff the (single) carrier field
-                // is a constant literal inside the proven interval.
-                let safe_literal = matches!(
-                    intervals.get(type_name),
-                    Some((iv, true)) if construct_arg_is_in_interval(fields, *iv)
-                );
-                if !safe_literal {
-                    demoted.insert(type_name.clone());
-                }
-            });
-        }
     }
 
     // ---- Scan 2: Map-key usage (direct + transitive) -----------------------
@@ -2732,12 +2721,15 @@ mod induction;
 mod inequality;
 mod int_decimal_roundtrip;
 mod map_laws;
+mod packed_sequence;
 mod refinement;
 mod ring;
 mod simp;
 mod spec_equivalence;
 mod string_escape_roundtrip;
 mod wrapper_laws;
+
+pub use packed_sequence::{PackedIntElement, PackedSequenceLayout, packed_sequence_layout_table};
 
 pub(crate) use induction::LawProofCone;
 

--- a/src/codegen/proof_lower/packed_sequence.rs
+++ b/src/codegen/proof_lower/packed_sequence.rs
@@ -1,0 +1,359 @@
+//! Proof-derived packed layouts for structural refinement carriers.
+//!
+//! Scalar refinement carriers already feed their proven interval into the
+//! carrier-`i64` representation pass. This module extends the same idea to a
+//! canonical structural invariant:
+//!
+//! ```text
+//! record Octets { values: List<Int> }
+//! fn allOctets(xs: List<Int>) -> Bool
+//!     match xs
+//!         [] -> true
+//!         [head, ..tail] -> match 0 <= head <= 255
+//!             true -> allOctets(tail)
+//!             false -> false
+//! fn fromList(xs: List<Int>) -> Result<Octets, String>
+//!     match allOctets(xs)
+//!         true -> Result.Ok(Octets(values = xs))
+//!         false -> Result.Err(...)
+//! ```
+//!
+//! The recognizer proves an interval for *every element* of the carrier and
+//! chooses the smallest lossless integer storage. It is deliberately keyed by
+//! the refinement shape, never by a standard-library type name: `Bytes` is the
+//! first consumer, not a compiler special case.
+
+use super::*;
+use crate::ast::{Pattern, Type};
+use crate::ir::interval::{Bound, Interval};
+
+/// Smallest integer storage that can represent every inhabitant of a proven
+/// element interval. Signedness controls the load extension; wasm packed
+/// storage itself is just `i8` / `i16`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackedIntElement {
+    U8,
+    I8,
+    U16,
+    I16,
+    U32,
+    I32,
+    I64,
+}
+
+impl PackedIntElement {
+    /// Pick the narrowest lossless storage. Open or wider-than-i64 intervals
+    /// decline so codegen keeps the ordinary structural carrier.
+    pub fn for_interval(interval: Interval) -> Option<Self> {
+        let (Bound::Finite(lo), Bound::Finite(hi)) = (interval.lo, interval.hi) else {
+            return None;
+        };
+        if lo >= 0 && hi <= u8::MAX as i128 {
+            Some(Self::U8)
+        } else if lo >= i8::MIN as i128 && hi <= i8::MAX as i128 {
+            Some(Self::I8)
+        } else if lo >= 0 && hi <= u16::MAX as i128 {
+            Some(Self::U16)
+        } else if lo >= i16::MIN as i128 && hi <= i16::MAX as i128 {
+            Some(Self::I16)
+        } else if lo >= 0 && hi <= u32::MAX as i128 {
+            Some(Self::U32)
+        } else if lo >= i32::MIN as i128 && hi <= i32::MAX as i128 {
+            Some(Self::I32)
+        } else if lo >= i64::MIN as i128 && hi <= i64::MAX as i128 {
+            Some(Self::I64)
+        } else {
+            None
+        }
+    }
+}
+
+/// Backend-neutral representation fact for one opaque `List<Int>` carrier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PackedSequenceLayout {
+    pub element_interval: Interval,
+    pub element: PackedIntElement,
+}
+
+/// Derive packed layouts for every canonical opaque `List<Int>` refinement in
+/// scope. Unknown predicate shapes are omitted (fail-closed).
+pub fn packed_sequence_layout_table(
+    inputs: &ProofLowerInputs<'_>,
+) -> HashMap<String, PackedSequenceLayout> {
+    let mut table = HashMap::new();
+    let mut ambiguous_names = HashSet::new();
+
+    let entry_typedefs = inputs.entry_items.iter().filter_map(|item| match item {
+        TopLevel::TypeDef(td) => Some((None::<&str>, td)),
+        _ => None,
+    });
+    let module_typedefs = inputs.dep_modules.iter().flat_map(|module| {
+        module
+            .type_defs
+            .iter()
+            .map(move |td| (Some(module.prefix.as_str()), td))
+    });
+
+    for (scope, td) in entry_typedefs.chain(module_typedefs) {
+        let TypeDef::Product { name, fields, .. } = td else {
+            continue;
+        };
+        if ambiguous_names.contains(name) {
+            continue;
+        }
+        if fields.len() != 1 {
+            continue;
+        }
+        let Some(info) = crate::codegen::common::refinement_info_for_in_scope(name, inputs, scope)
+        else {
+            continue;
+        };
+        if !matches!(
+            crate::types::parse_type_str(info.carrier_type),
+            Type::List(inner) if *inner == Type::Int
+        ) {
+            continue;
+        }
+        let Some(element_interval) = element_interval_from_refinement(info, inputs, scope) else {
+            continue;
+        };
+        let Some(element) = PackedIntElement::for_interval(element_interval) else {
+            continue;
+        };
+        let layout = PackedSequenceLayout {
+            element_interval,
+            element,
+        };
+        // The existing scalar table is bare-name keyed too. A collision must
+        // never widen a fact: retain a layout only when both scopes derive the
+        // exact same interval/storage; otherwise decline the ambiguous name.
+        match table.get(name) {
+            None => {
+                table.insert(name.clone(), layout);
+            }
+            Some(existing) if *existing == layout => {}
+            Some(_) => {
+                table.remove(name);
+                ambiguous_names.insert(name.clone());
+            }
+        }
+    }
+
+    table
+}
+
+fn element_interval_from_refinement(
+    info: crate::codegen::common::RefinementInfo<'_>,
+    inputs: &ProofLowerInputs<'_>,
+    scope: Option<&str>,
+) -> Option<Interval> {
+    let (predicate_fn, predicate_args) = call_target_and_args(&info.predicate.node)?;
+    if predicate_args.len() != 1 || !expr_is_ident(&predicate_args[0], info.param_name) {
+        return None;
+    }
+    let helper = inputs
+        .pure_fns_in_scope(scope)
+        .into_iter()
+        .find(|fd| same_callee_name(&fd.name, &predicate_fn))?;
+    recursive_list_element_predicate(helper).and_then(|(element_name, element_predicate)| {
+        let predicate = Predicate {
+            free_vars: vec![(element_name, QuantifierType::Plain("Int".to_string()))],
+            expr: inputs.resolve_expr(element_predicate, scope),
+        };
+        let (interval, known) = crate::ir::interval::interval_of_invariant(&predicate);
+        known.then_some(interval)
+    })
+}
+
+/// Recognize a total recursive `all` over `List<Int>` and return the cons-head
+/// binder plus its per-element predicate.
+fn recursive_list_element_predicate(fd: &FnDef) -> Option<(String, &Spanned<Expr>)> {
+    if fd.params.len() != 1 || fd.params[0].1.replace(' ', "") != "List<Int>" {
+        return None;
+    }
+    let param = fd.params[0].0.as_str();
+    let [crate::ast::Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return None;
+    };
+    if !expr_is_ident(subject, param) || arms.len() != 2 {
+        return None;
+    }
+
+    let empty_ok = arms
+        .iter()
+        .any(|arm| matches!(arm.pattern, Pattern::EmptyList) && expr_is_bool(&arm.body, true));
+    if !empty_ok {
+        return None;
+    }
+    let cons = arms.iter().find_map(|arm| match &arm.pattern {
+        Pattern::Cons(head, tail) => Some((head.as_str(), tail.as_str(), arm.body.as_ref())),
+        _ => None,
+    })?;
+    let (head, tail, cons_body) = cons;
+
+    // Direct form: Bool.and(P(head), all(tail)).
+    if let Some((callee, args)) = call_target_and_args(&cons_body.node)
+        && callee == "Bool.and"
+        && args.len() == 2
+    {
+        if is_recursive_call(&args[1].node, &fd.name, tail) {
+            return Some((head.to_string(), &args[0]));
+        }
+        if is_recursive_call(&args[0].node, &fd.name, tail) {
+            return Some((head.to_string(), &args[1]));
+        }
+    }
+
+    // Short-circuit form used by stdlib/bytes.av:
+    // match P(head) { true -> all(tail), false -> false }.
+    let Expr::Match {
+        subject: element_predicate,
+        arms: predicate_arms,
+    } = &cons_body.node
+    else {
+        return None;
+    };
+    if predicate_arms.len() != 2 {
+        return None;
+    }
+    let true_recurses = predicate_arms.iter().any(|arm| {
+        matches!(arm.pattern, Pattern::Literal(Literal::Bool(true)))
+            && is_recursive_call(&arm.body.node, &fd.name, tail)
+    });
+    let false_rejects = predicate_arms.iter().any(|arm| {
+        matches!(arm.pattern, Pattern::Literal(Literal::Bool(false)))
+            && expr_is_bool(&arm.body, false)
+    });
+    (true_recurses && false_rejects).then(|| (head.to_string(), element_predicate.as_ref()))
+}
+
+fn call_target_and_args(expr: &Expr) -> Option<(String, &[Spanned<Expr>])> {
+    match expr {
+        Expr::FnCall(callee, args) => crate::codegen::common::expr_to_dotted_name(&callee.node)
+            .map(|name| (name, args.as_slice())),
+        Expr::TailCall(call) => Some((call.target.clone(), call.args.as_slice())),
+        _ => None,
+    }
+}
+
+fn is_recursive_call(expr: &Expr, fn_name: &str, arg_name: &str) -> bool {
+    let Some((callee, args)) = call_target_and_args(expr) else {
+        return false;
+    };
+    same_callee_name(fn_name, &callee) && args.len() == 1 && expr_is_ident(&args[0], arg_name)
+}
+
+fn same_callee_name(declared: &str, called: &str) -> bool {
+    declared == called || declared.rsplit('.').next() == called.rsplit('.').next()
+}
+
+fn expr_is_ident(expr: &Spanned<Expr>, name: &str) -> bool {
+    matches!(
+        &expr.node,
+        Expr::Ident(found) | Expr::Resolved { name: found, .. } if found == name
+    )
+}
+
+fn expr_is_bool(expr: &Spanned<Expr>, value: bool) -> bool {
+    matches!(&expr.node, Expr::Literal(Literal::Bool(found)) if *found == value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::parse_source;
+
+    fn layouts_for(src: &str) -> HashMap<String, PackedSequenceLayout> {
+        let mut items = parse_source(src).expect("parse");
+        let result = crate::ir::pipeline::run(
+            &mut items,
+            crate::ir::pipeline::PipelineConfig {
+                typecheck: Some(crate::ir::pipeline::TypecheckMode::Full { base_dir: None }),
+                ..Default::default()
+            },
+        );
+        let tc = result.typecheck.expect("typecheck requested");
+        assert!(tc.errors.is_empty(), "typecheck errors: {:?}", tc.errors);
+        let prefixes = HashSet::new();
+        let recursive = HashSet::new();
+        let inputs = ProofLowerInputs {
+            entry_items: &items,
+            dep_modules: &[],
+            module_prefixes: &prefixes,
+            recursive_fns: &recursive,
+            symbol_table: &result.symbol_table,
+            program_shape: None,
+        };
+        packed_sequence_layout_table(&inputs)
+    }
+
+    const OCTETS: &str = r#"
+module Octets
+    intent = "generic structural refinement"
+    effects []
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+"#;
+
+    #[test]
+    fn derives_u8_without_a_bytes_name_special_case() {
+        let layouts = layouts_for(OCTETS);
+        assert_eq!(
+            layouts.get("Octets"),
+            Some(&PackedSequenceLayout {
+                element_interval: Interval::between(0, 255),
+                element: PackedIntElement::U8,
+            })
+        );
+        assert!(!OCTETS.contains("record Bytes"));
+    }
+
+    #[test]
+    fn derives_u8_for_the_real_standard_library_bytes_module() {
+        let layouts = layouts_for(include_str!("../../../stdlib/bytes.av"));
+        assert_eq!(
+            layouts.get("Bytes"),
+            Some(&PackedSequenceLayout {
+                element_interval: Interval::between(0, 255),
+                element: PackedIntElement::U8,
+            })
+        );
+    }
+
+    #[test]
+    fn derives_signed_i8_for_negative_elements() {
+        let src = OCTETS
+            .replace("record Octets", "record Samples")
+            .replace("Result<Octets", "Result<Samples")
+            .replace("Octets(values", "Samples(values")
+            .replace("head >= 0", "head >= -128")
+            .replace("head <= 255", "head <= 127");
+        let layouts = layouts_for(&src);
+        assert_eq!(
+            layouts.get("Samples").map(|layout| layout.element),
+            Some(PackedIntElement::I8)
+        );
+    }
+
+    #[test]
+    fn declines_a_non_recursive_list_predicate() {
+        let src = OCTETS.replace("true -> allInRange(tail)", "true -> true");
+        assert!(layouts_for(&src).is_empty());
+    }
+}

--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -71,6 +71,10 @@ pub(super) struct FnMap {
     /// Per-`List<T>` helpers (len / reverse). Key = canonical Aver
     /// string `List<T>`.
     pub(super) list_ops: std::collections::HashMap<String, super::lists::ListOps>,
+    /// Proof-packed structural-refinement construct/project bridges, keyed by
+    /// nominal type name.
+    pub(super) packed_sequence_ops:
+        std::collections::HashMap<String, super::packed_sequences::PackedSequenceOps>,
     /// Per-`List<T>` `Vector.fromList` helper (paired with the
     /// matching `Vector<T>` registered in the type registry).
     pub(super) vfl_ops: std::collections::HashMap<String, super::lists::VectorFromListOps>,
@@ -143,6 +147,20 @@ impl FnMap {
         } else {
             None
         }
+    }
+
+    pub(super) fn packed_sequence_ops_lookup(
+        &self,
+        type_name: &str,
+    ) -> Option<super::packed_sequences::PackedSequenceOps> {
+        self.packed_sequence_ops
+            .get(type_name)
+            .copied()
+            .or_else(|| {
+                type_name
+                    .rsplit_once('.')
+                    .and_then(|(_, bare)| self.packed_sequence_ops.get(bare).copied())
+            })
     }
 
     pub(super) fn map_helpers_lookup(&self, canonical: &str) -> Option<&super::maps::MapKVHelpers> {

--- a/src/codegen/wasm_gc/body/eq_helpers.rs
+++ b/src/codegen/wasm_gc/body/eq_helpers.rs
@@ -46,6 +46,7 @@ use super::super::types::TypeRegistry;
 pub(crate) enum EqKind {
     Record,
     Sum,
+    PackedSequence,
     OptionEq,
     ResultEq,
     TupleEq,
@@ -99,6 +100,11 @@ impl EqHelperRegistry {
         if registry.is_eligible_carrier(type_name) {
             return;
         }
+        let kind = if registry.packed_sequence(type_name).is_some() {
+            EqKind::PackedSequence
+        } else {
+            kind
+        };
         // Skip nominal types whose fields contain unhandled shapes
         // (List/Map/Vector/Set inside fields — the inline eq emitter
         // covers Option/Result/Tuple via per-instantiation helpers
@@ -114,6 +120,7 @@ impl EqHelperRegistry {
             EqKind::Sum => {
                 super::super::lists::sum_fields_resolvable(type_name, registry, &mut seen)
             }
+            EqKind::PackedSequence => true,
             // Carrier kinds — Option<X>/Result/Tuple have one
             // shape regardless of inner; resolvability is checked at
             // the record/sum level via `field_type_resolvable`.
@@ -146,6 +153,7 @@ impl EqHelperRegistry {
                     }
                 }
             }
+            EqKind::PackedSequence => {}
             // Carrier kinds — recurse into inner types so a direct
             // top-level register (e.g. discovery seed walker hitting
             // `Option<PieceKind>` from a `List<Option<PieceKind>>`)
@@ -192,6 +200,10 @@ impl EqHelperRegistry {
         // would emit a body that `struct.get`s a value that is actually an
         // `i64` (the func-33 validation failure this guards).
         if registry.is_eligible_carrier(field_ty) {
+            return;
+        }
+        if registry.packed_sequence(field_ty).is_some() {
+            self.register_transitive(field_ty, EqKind::PackedSequence, registry);
             return;
         }
         if registry.record_fields.contains_key(field_ty) {
@@ -399,6 +411,9 @@ impl EqHelperRegistry {
                     )?;
                     f.instruction(&Instruction::End);
                     codes.function(&f);
+                }
+                EqKind::PackedSequence => {
+                    codes.function(&emit_packed_sequence_eq_body(name, registry)?);
                 }
                 EqKind::OptionEq => {
                     let f = emit_option_eq_body(name, registry, string_eq_fn_idx, &helper_idx_map)?;
@@ -813,6 +828,7 @@ fn type_has_string_field(
             .flat_map(|vs| vs.iter())
             .filter(|v| v.parent == name)
             .any(|v| v.fields.iter().any(|t| t.trim() == "String")),
+        EqKind::PackedSequence => false,
         // Option<X>/Result<X,Y>/Tuple<…> — check whether any inner
         // type is `String`. Cheap string match on the canonical
         // (e.g. `"Option<String>"` contains `"String"`); accurate
@@ -820,4 +836,81 @@ fn type_has_string_field(
         // `__wasmgc_string_eq` when it might be called.
         EqKind::OptionEq | EqKind::ResultEq | EqKind::TupleEq => name.contains("String"),
     }
+}
+
+fn emit_packed_sequence_eq_body(
+    name: &str,
+    registry: &TypeRegistry,
+) -> Result<Function, WasmGcError> {
+    let packed = registry.packed_sequence(name).ok_or_else(|| {
+        WasmGcError::Validation(format!("eq helper for packed `{name}`: type missing"))
+    })?;
+    let packed_ref = wasm_encoder::ValType::Ref(wasm_encoder::RefType {
+        nullable: true,
+        heap_type: wasm_encoder::HeapType::Concrete(packed.type_idx),
+    });
+    let mut f = Function::new(vec![(2, packed_ref), (2, wasm_encoder::ValType::I32)]);
+    let heap = wasm_encoder::HeapType::Concrete(packed.type_idx);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::RefCastNonNull(heap));
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::RefCastNonNull(heap));
+    f.instruction(&Instruction::LocalSet(3));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::ArrayLen);
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::ArrayLen);
+    f.instruction(&Instruction::I32Ne);
+    f.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::Return);
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalSet(5));
+    f.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+    f.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(5));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32GeU);
+    f.instruction(&Instruction::BrIf(1));
+    for local in [2, 3] {
+        f.instruction(&Instruction::LocalGet(local));
+        f.instruction(&Instruction::LocalGet(5));
+        match packed.layout.element {
+            crate::codegen::proof_lower::PackedIntElement::U8
+            | crate::codegen::proof_lower::PackedIntElement::I8
+            | crate::codegen::proof_lower::PackedIntElement::U16
+            | crate::codegen::proof_lower::PackedIntElement::I16 => {
+                f.instruction(&Instruction::ArrayGetU(packed.type_idx));
+            }
+            _ => {
+                f.instruction(&Instruction::ArrayGet(packed.type_idx));
+            }
+        }
+    }
+    if matches!(
+        packed.layout.element,
+        crate::codegen::proof_lower::PackedIntElement::I64
+    ) {
+        f.instruction(&Instruction::I64Ne);
+    } else {
+        f.instruction(&Instruction::I32Ne);
+    }
+    f.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::Return);
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::LocalGet(5));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(5));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::End);
+    Ok(f)
 }

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -1192,6 +1192,21 @@ pub(crate) fn emit_mir_expr(
             // emitter produces `emit_attr_get`'s diagnostic.
             let proj = &spanned_proj.node;
             let record_name = aver_type_str_of(&proj.base);
+            if ctx.registry.packed_sequence(&record_name).is_some() {
+                let produced = emit_mir_expr(func, &proj.base, slots, ctx)?;
+                if produced.is_some() {
+                    let ops = ctx
+                        .fn_map
+                        .packed_sequence_ops_lookup(&record_name)
+                        .ok_or_else(|| {
+                            WasmGcError::Validation(format!(
+                                "packed record `{record_name}` has no projection bridge"
+                            ))
+                        })?;
+                    func.instruction(&Instruction::Call(ops.unpack));
+                }
+                return Ok(produced);
+            }
             if ctx.registry.newtype_underlying(&record_name).is_some() {
                 // ETAP-2 carrier-`i64`: an eligible carrier's field read is
                 // still identity (emit the base, which is a native `i64`).

--- a/src/codegen/wasm_gc/body/from_mir/records.rs
+++ b/src/codegen/wasm_gc/body/from_mir/records.rs
@@ -50,6 +50,24 @@ pub(crate) fn emit_mir_record_create(
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<Option<()>, WasmGcError> {
+    if ctx.registry.packed_sequence(type_name).is_some() {
+        let field = fields.first().ok_or(WasmGcError::Validation(format!(
+            "packed record `{type_name}` requires one List<Int> field"
+        )))?;
+        let produced = emit_mir_record_field_value(func, &field.value, "List<Int>", slots, ctx)?;
+        if produced.is_some() {
+            let ops = ctx
+                .fn_map
+                .packed_sequence_ops_lookup(type_name)
+                .ok_or_else(|| {
+                    WasmGcError::Validation(format!(
+                        "packed record `{type_name}` has no construct bridge"
+                    ))
+                })?;
+            func.instruction(&Instruction::Call(ops.pack));
+        }
+        return Ok(produced);
+    }
     if ctx.registry.newtype_underlying(type_name).is_some() {
         let field = fields.first().ok_or(WasmGcError::Validation(format!(
             "newtype record `{type_name}` requires one field"
@@ -115,6 +133,25 @@ pub(crate) fn emit_mir_record_update(
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<Option<()>, WasmGcError> {
+    if ctx.registry.packed_sequence(type_name).is_some() {
+        let produced = if let Some(override_field) = updates.first() {
+            emit_mir_record_field_value(func, &override_field.value, "List<Int>", slots, ctx)?
+        } else {
+            emit_mir_expr(func, base, slots, ctx)?.map(|_| ())
+        };
+        if produced.is_some() && !updates.is_empty() {
+            let ops = ctx
+                .fn_map
+                .packed_sequence_ops_lookup(type_name)
+                .ok_or_else(|| {
+                    WasmGcError::Validation(format!(
+                        "packed record `{type_name}` has no update bridge"
+                    ))
+                })?;
+            func.instruction(&Instruction::Call(ops.pack));
+        }
+        return Ok(produced);
+    }
     // Mirror `emit_mir_record_create`'s newtype short-circuit: a record with
     // a single primitive field is newtype-erased to the bare underlying value
     // (Int->i64, Float->f64, Bool->i32), so an UPDATE must also emit the bare

--- a/src/codegen/wasm_gc/body/hash_helpers.rs
+++ b/src/codegen/wasm_gc/body/hash_helpers.rs
@@ -35,6 +35,7 @@ use super::super::types::TypeRegistry;
 pub(crate) enum HashKind {
     Record,
     Sum,
+    PackedSequence,
     OptionHash,
     ResultHash,
     TupleHash,
@@ -87,6 +88,11 @@ impl HashHelperRegistry {
         if registry.is_eligible_carrier(type_name) {
             return;
         }
+        let kind = if registry.packed_sequence(type_name).is_some() {
+            HashKind::PackedSequence
+        } else {
+            kind
+        };
         let mut seen = std::collections::HashSet::new();
         let resolvable = match kind {
             HashKind::Record => {
@@ -95,6 +101,7 @@ impl HashHelperRegistry {
             HashKind::Sum => {
                 super::super::lists::sum_fields_resolvable(type_name, registry, &mut seen)
             }
+            HashKind::PackedSequence => true,
             HashKind::OptionHash | HashKind::ResultHash | HashKind::TupleHash => true,
         };
         if !resolvable {
@@ -123,6 +130,7 @@ impl HashHelperRegistry {
                     }
                 }
             }
+            HashKind::PackedSequence => {}
             // Mirror eq_helpers — recurse so direct top-level
             // registration of a carrier (seed walker etc.) still
             // discovers inner types.
@@ -161,6 +169,10 @@ impl HashHelperRegistry {
         // struct, no per-type `__hash_<Carrier>` helper; its hash is the raw
         // `i32.wrap_i64` inlined at the use site. Treat like a primitive.
         if registry.is_eligible_carrier(field_ty) {
+            return;
+        }
+        if registry.packed_sequence(field_ty).is_some() {
+            self.register_transitive(field_ty, HashKind::PackedSequence, registry);
             return;
         }
         if registry.record_fields.contains_key(field_ty) {
@@ -303,6 +315,9 @@ impl HashHelperRegistry {
                     let f = emit_sum_hash_body(name, registry, &helper_idx_map, self_fn_idx)?;
                     codes.function(&f);
                 }
+                HashKind::PackedSequence => {
+                    codes.function(&emit_packed_sequence_hash_body(name, registry)?);
+                }
                 HashKind::OptionHash => {
                     let f = emit_option_hash_body(name, registry, &helper_idx_map)?;
                     codes.function(&f);
@@ -319,6 +334,72 @@ impl HashHelperRegistry {
         }
         Ok(())
     }
+}
+
+fn emit_packed_sequence_hash_body(
+    name: &str,
+    registry: &TypeRegistry,
+) -> Result<Function, WasmGcError> {
+    let packed = registry.packed_sequence(name).ok_or_else(|| {
+        WasmGcError::Validation(format!("hash helper for packed `{name}`: type missing"))
+    })?;
+    let packed_ref = wasm_encoder::ValType::Ref(wasm_encoder::RefType {
+        nullable: true,
+        heap_type: wasm_encoder::HeapType::Concrete(packed.type_idx),
+    });
+    // 1 = typed array, 2 = len, 3 = index, 4 = accumulator.
+    let mut f = Function::new(vec![(1, packed_ref), (3, wasm_encoder::ValType::I32)]);
+    let heap = wasm_encoder::HeapType::Concrete(packed.type_idx);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::RefCastNonNull(heap));
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::ArrayLen);
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalSet(3));
+    f.instruction(&Instruction::I32Const(5381));
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+    f.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32GeU);
+    f.instruction(&Instruction::BrIf(1));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Const(5));
+    f.instruction(&Instruction::I32Shl);
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::LocalGet(3));
+    match packed.layout.element {
+        crate::codegen::proof_lower::PackedIntElement::U8
+        | crate::codegen::proof_lower::PackedIntElement::I8
+        | crate::codegen::proof_lower::PackedIntElement::U16
+        | crate::codegen::proof_lower::PackedIntElement::I16 => {
+            f.instruction(&Instruction::ArrayGetU(packed.type_idx));
+        }
+        crate::codegen::proof_lower::PackedIntElement::I64 => {
+            f.instruction(&Instruction::ArrayGet(packed.type_idx));
+            f.instruction(&Instruction::I32WrapI64);
+        }
+        _ => {
+            f.instruction(&Instruction::ArrayGet(packed.type_idx));
+        }
+    }
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(3));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::End);
+    Ok(f)
 }
 
 /// `(eqref) -> i32` body for a record. Cast → typed, DJB2 fold over

--- a/src/codegen/wasm_gc/builtins/crypto.rs
+++ b/src/codegen/wasm_gc/builtins/crypto.rs
@@ -16,10 +16,10 @@ const SHA256_K: [u32; 64] = [
     0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
 ];
 
-/// Emit SHA-256 directly into the GC module. The helper consumes the nominal
-/// `Bytes` record, hashes its `List<Int>` payload with wrapping i32 operations,
-/// then constructs `Digest32(Bytes(...))`. No host import is involved, so this
-/// one body serves both browser wasm-gc and the wasip2 component wrapper.
+/// Emit SHA-256 directly into the GC module. When the proof-derived structural
+/// refinement pass packed `Bytes`, the helper reads and writes its `(array i8)`
+/// directly. The boxed `record Bytes { List<Int> }` path remains as the exact
+/// differential fallback selected by `AVER_NO_PACKED_SEQUENCES`.
 pub(super) fn emit_sha256(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let byte_array_idx = registry.crypto_byte_array_type_idx.ok_or_else(|| {
         WasmGcError::Validation("Crypto.sha256 requires byte scratch type".into())
@@ -27,24 +27,50 @@ pub(super) fn emit_sha256(registry: &TypeRegistry) -> Result<Function, WasmGcErr
     let word_array_idx = registry.crypto_word_array_type_idx.ok_or_else(|| {
         WasmGcError::Validation("Crypto.sha256 requires word scratch type".into())
     })?;
-    let bytes_idx = registry
-        .record_type_idx("Bytes")
-        .ok_or_else(|| WasmGcError::Validation("Crypto.sha256 requires Bytes record".into()))?;
+    let packed_bytes = registry.packed_sequence("Bytes");
+    if let Some(packed) = packed_bytes
+        && !matches!(
+            packed.layout.element,
+            crate::codegen::proof_lower::PackedIntElement::U8
+        )
+    {
+        return Err(WasmGcError::Validation(
+            "Crypto.sha256 requires an unsigned-octet Bytes layout".into(),
+        ));
+    }
+    let bytes_idx = packed_bytes
+        .map(|p| p.type_idx)
+        .or_else(|| registry.record_type_idx("Bytes"))
+        .ok_or_else(|| WasmGcError::Validation("Crypto.sha256 requires Bytes".into()))?;
     let digest_idx = registry
         .record_type_idx("Digest32")
         .ok_or_else(|| WasmGcError::Validation("Crypto.sha256 requires Digest32 record".into()))?;
-    let list_idx = registry.list_type_idx("List<Int>").ok_or_else(|| {
-        WasmGcError::Validation("Crypto.sha256 requires List<Int> representation".into())
-    })?;
-    let aint_idx = registry.aint_struct_idx.ok_or_else(|| {
-        WasmGcError::Validation("Crypto.sha256 requires unbounded Int representation".into())
-    })?;
-    let from_i64_idx = registry
-        .aint_from_i64_fn_idx
-        .ok_or_else(|| WasmGcError::Validation("Crypto.sha256 requires __aint_from_i64".into()))?;
-    let to_i64_idx = registry.aint_to_i64_checked_fn_idx.ok_or_else(|| {
-        WasmGcError::Validation("Crypto.sha256 requires __aint_to_i64_checked".into())
-    })?;
+    let list_idx = packed_bytes
+        .is_none()
+        .then(|| registry.list_type_idx("List<Int>"))
+        .flatten();
+    let aint_idx = packed_bytes
+        .is_none()
+        .then_some(registry.aint_struct_idx)
+        .flatten();
+    let from_i64_idx = packed_bytes
+        .is_none()
+        .then_some(registry.aint_from_i64_fn_idx)
+        .flatten();
+    let to_i64_idx = packed_bytes
+        .is_none()
+        .then_some(registry.aint_to_i64_checked_fn_idx)
+        .flatten();
+    if packed_bytes.is_none()
+        && (list_idx.is_none()
+            || aint_idx.is_none()
+            || from_i64_idx.is_none()
+            || to_i64_idx.is_none())
+    {
+        return Err(WasmGcError::Validation(
+            "Crypto.sha256 boxed Bytes path requires List<Int> and Int bridges".into(),
+        ));
+    }
 
     let types = crypto_types(
         byte_array_idx,
@@ -53,17 +79,161 @@ pub(super) fn emit_sha256(registry: &TypeRegistry) -> Result<Function, WasmGcErr
         digest_idx,
         list_idx,
         aint_idx,
+        packed_bytes.is_some(),
     )?;
-    let callees = wat_helper::func_placeholders(&[
-        wat_helper::CalleeStub {
-            abs_idx: from_i64_idx,
-            sig: "(param i64) (result (ref null $aint))",
-        },
-        wat_helper::CalleeStub {
-            abs_idx: to_i64_idx,
-            sig: "(param (ref null $aint)) (result i64)",
-        },
-    ]);
+    let callees = if let (Some(from_i64_idx), Some(to_i64_idx)) = (from_i64_idx, to_i64_idx) {
+        wat_helper::func_placeholders(&[
+            wat_helper::CalleeStub {
+                abs_idx: from_i64_idx,
+                sig: "(param i64) (result (ref null $aint))",
+            },
+            wat_helper::CalleeStub {
+                abs_idx: to_i64_idx,
+                sig: "(param (ref null $aint)) (result i64)",
+            },
+        ])
+    } else {
+        String::new()
+    };
+    let carrier_locals = if packed_bytes.is_some() {
+        "(local $digest_bytes (ref null $bytes))"
+    } else {
+        "(local $node (ref null $list_int))\n  (local $out (ref null $list_int))"
+    };
+    let (input_length, input_copy) = if packed_bytes.is_some() {
+        (
+            r#"local.get $input
+  array.len
+  local.set $input_len"#
+                .to_string(),
+            r#"i32.const 0
+  local.set $i
+  (block $copy_done
+    (loop $copy
+      local.get $i
+      local.get $input_len
+      i32.ge_u
+      br_if $copy_done
+      local.get $message
+      local.get $i
+      local.get $input
+      local.get $i
+      array.get_u $bytes
+      array.set $byte_array
+      local.get $i
+      i32.const 1
+      i32.add
+      local.set $i
+      br $copy))"#
+                .to_string(),
+        )
+    } else {
+        let to_i64_idx = to_i64_idx.expect("boxed path checked above");
+        (
+            r#"local.get $input
+  ref.as_non_null
+  struct.get $bytes 0
+  local.set $node
+  (block $count_done
+    (loop $count
+      local.get $node
+      ref.is_null
+      br_if $count_done
+      local.get $input_len
+      i32.const 1
+      i32.add
+      local.set $input_len
+      local.get $node
+      ref.as_non_null
+      struct.get $list_int 1
+      local.set $node
+      br $count))"#
+                .to_string(),
+            format!(
+                r#"local.get $input
+  ref.as_non_null
+  struct.get $bytes 0
+  local.set $node
+  i32.const 0
+  local.set $i
+  (block $copy_done
+    (loop $copy
+      local.get $node
+      ref.is_null
+      br_if $copy_done
+      local.get $message
+      local.get $i
+      local.get $node
+      ref.as_non_null
+      struct.get $list_int 0
+      call {to_i64_idx}
+      i32.wrap_i64
+      array.set $byte_array
+      local.get $i
+      i32.const 1
+      i32.add
+      local.set $i
+      local.get $node
+      ref.as_non_null
+      struct.get $list_int 1
+      local.set $node
+      br $copy))"#
+            ),
+        )
+    };
+    let output_build = if packed_bytes.is_some() {
+        r#"i32.const 32
+  array.new_default $bytes
+  local.set $digest_bytes
+  i32.const 0 local.set $i
+  (block $output_done
+    (loop $output
+      local.get $i i32.const 32 i32.ge_u br_if $output_done
+      local.get $digest_bytes
+      local.get $i
+      local.get $words
+      local.get $i i32.const 2 i32.shr_u
+      array.get $word_array
+      i32.const 3
+      local.get $i i32.const 3 i32.and
+      i32.sub
+      i32.const 3 i32.shl
+      i32.shr_u
+      i32.const 255 i32.and
+      array.set $bytes
+      local.get $i i32.const 1 i32.add local.set $i
+      br $output))
+  local.get $digest_bytes
+  struct.new $digest"#
+            .to_string()
+    } else {
+        let from_i64_idx = from_i64_idx.expect("boxed path checked above");
+        format!(
+            r#"i32.const 31 local.set $i
+  (block $output_done
+    (loop $output
+      local.get $words
+      local.get $i i32.const 2 i32.shr_u
+      array.get $word_array
+      i32.const 3
+      local.get $i i32.const 3 i32.and
+      i32.sub
+      i32.const 3 i32.shl
+      i32.shr_u
+      i32.const 255 i32.and
+      i64.extend_i32_u
+      call {from_i64_idx}
+      local.get $out
+      struct.new $list_int
+      local.set $out
+      local.get $i i32.eqz br_if $output_done
+      local.get $i i32.const 1 i32.sub local.set $i
+      br $output))
+  local.get $out
+  struct.new $bytes
+  struct.new $digest"#
+        )
+    };
     let constants = SHA256_K
         .iter()
         .enumerate()
@@ -80,8 +250,7 @@ pub(super) fn emit_sha256(registry: &TypeRegistry) -> Result<Function, WasmGcErr
 {types}
 {callees}
 (func (export "helper") (param $input (ref null $bytes)) (result (ref null $digest))
-  (local $node (ref null $list_int))
-  (local $out (ref null $list_int))
+  {carrier_locals}
   (local $message (ref null $byte_array))
   (local $words (ref null $word_array))
   (local $input_len i32)
@@ -113,25 +282,8 @@ pub(super) fn emit_sha256(registry: &TypeRegistry) -> Result<Function, WasmGcErr
   (local $h7 i32)
   (local $bit_len i64)
 
-  ;; Count the refined byte list.
-  local.get $input
-  ref.as_non_null
-  struct.get $bytes 0
-  local.set $node
-  (block $count_done
-    (loop $count
-      local.get $node
-      ref.is_null
-      br_if $count_done
-      local.get $input_len
-      i32.const 1
-      i32.add
-      local.set $input_len
-      local.get $node
-      ref.as_non_null
-      struct.get $list_int 1
-      local.set $node
-      br $count))
+  ;; Read the source length and copy octets into the SHA scratch array.
+  {input_length}
 
   ;; padded_len = round_up(input_len + 9, 64)
   local.get $input_len
@@ -143,35 +295,7 @@ pub(super) fn emit_sha256(registry: &TypeRegistry) -> Result<Function, WasmGcErr
   array.new_default $byte_array
   local.set $message
 
-  ;; Copy source octets, checking the Int carrier at the nominal boundary.
-  local.get $input
-  ref.as_non_null
-  struct.get $bytes 0
-  local.set $node
-  i32.const 0
-  local.set $i
-  (block $copy_done
-    (loop $copy
-      local.get $node
-      ref.is_null
-      br_if $copy_done
-      local.get $message
-      local.get $i
-      local.get $node
-      ref.as_non_null
-      struct.get $list_int 0
-      call {to_i64_idx}
-      i32.wrap_i64
-      array.set $byte_array
-      local.get $i
-      i32.const 1
-      i32.add
-      local.set $i
-      local.get $node
-      ref.as_non_null
-      struct.get $list_int 1
-      local.set $node
-      br $copy))
+  {input_copy}
 
   local.get $message
   local.get $input_len
@@ -386,31 +510,8 @@ pub(super) fn emit_sha256(registry: &TypeRegistry) -> Result<Function, WasmGcErr
   local.get $words i32.const 6 local.get $h6 array.set $word_array
   local.get $words i32.const 7 local.get $h7 array.set $word_array
 
-  ;; Build the output list backwards so its final order is digest byte 0..31.
-  i32.const 31 local.set $i
-  (block $output_done
-    (loop $output
-      local.get $words
-      local.get $i i32.const 2 i32.shr_u
-      array.get $word_array
-      i32.const 3
-      local.get $i i32.const 3 i32.and
-      i32.sub
-      i32.const 3 i32.shl
-      i32.shr_u
-      i32.const 255 i32.and
-      i64.extend_i32_u
-      call {from_i64_idx}
-      local.get $out
-      struct.new $list_int
-      local.set $out
-      local.get $i i32.eqz br_if $output_done
-      local.get $i i32.const 1 i32.sub local.set $i
-      br $output))
-
-  local.get $out
-  struct.new $bytes
-  struct.new $digest)
+  ;; Materialise the 32 digest octets in the selected Bytes representation.
+  {output_build})
 )"#
     );
 
@@ -422,18 +523,14 @@ fn crypto_types(
     word_array_idx: u32,
     bytes_idx: u32,
     digest_idx: u32,
-    list_idx: u32,
-    aint_idx: u32,
+    list_idx: Option<u32>,
+    aint_idx: Option<u32>,
+    packed_bytes: bool,
 ) -> Result<String, WasmGcError> {
-    let named = [
-        byte_array_idx,
-        word_array_idx,
-        bytes_idx,
-        digest_idx,
-        list_idx,
-        aint_idx,
-    ];
-    let mut unique = named.to_vec();
+    let mut named = vec![byte_array_idx, word_array_idx, bytes_idx, digest_idx];
+    named.extend(list_idx);
+    named.extend(aint_idx);
+    let mut unique = named.clone();
     unique.sort_unstable();
     unique.dedup();
     if unique.len() != named.len() {
@@ -448,13 +545,15 @@ fn crypto_types(
             "(type $byte_array (array (mut i32)))"
         } else if idx == word_array_idx {
             "(type $word_array (array (mut i32)))"
+        } else if idx == bytes_idx && packed_bytes {
+            "(type $bytes (array (mut i8)))"
         } else if idx == bytes_idx {
             "(type $bytes (struct (field (ref null $list_int))))"
         } else if idx == digest_idx {
             "(type $digest (struct (field (ref null $bytes))))"
-        } else if idx == list_idx {
+        } else if Some(idx) == list_idx {
             "(type $list_int (struct (field (ref null $aint)) (field (ref null $list_int))))"
-        } else if idx == aint_idx {
+        } else if Some(idx) == aint_idx {
             // Only the reference identity is needed in this standalone WAT;
             // actual construction/conversion is delegated to the real helpers.
             "(type $aint (struct))"

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -342,7 +342,11 @@ impl BuiltinName {
                 string_ref_ty(registry)?,
                 string_ref_ty(registry)?,
             ]),
-            Self::CryptoSha256 => Ok(vec![record_ref_ty(registry, "Bytes")?]),
+            Self::CryptoSha256 => Ok(vec![
+                super::types::aver_to_wasm("Bytes", Some(registry))?.ok_or_else(|| {
+                    WasmGcError::Validation("Crypto.sha256 requires Bytes".into())
+                })?,
+            ]),
             Self::IntModEuclid | Self::IntDivEuclid => Ok(vec![ValType::I64, ValType::I64]),
             Self::AintFromI64 => Ok(vec![ValType::I64]),
             Self::AintAdd | Self::AintSub | Self::AintMul | Self::AintCmp | Self::AintEq => {

--- a/src/codegen/wasm_gc/lists.rs
+++ b/src/codegen/wasm_gc/lists.rs
@@ -876,6 +876,14 @@ fn list_eq_kind(elem: &str, registry: &TypeRegistry) -> Option<ListEqKind> {
         "Bool" => Some(ListEqKind::I32),
         "String" => Some(ListEqKind::StringEq),
         other => {
+            // A proof-packed nominal still has a record declaration in the
+            // source registry, but its runtime representation is the packed
+            // array. Route through the nominal eq/hash helpers before the
+            // ordinary-record branch below tries to allocate record-typed
+            // scratch locals. This covers both List<X> and Vector<X> helpers.
+            if registry.packed_sequence(other).is_some() {
+                return Some(ListEqKind::CarrierEq(other.to_string()));
+            }
             // Record / sum element gets a contains/eq/hash slot
             // whenever its fields are themselves resolvable: primitives
             // or nominal types we've already accepted. Recursive refs
@@ -956,6 +964,9 @@ pub(super) fn field_type_resolvable(
     seen: &mut std::collections::HashSet<String>,
 ) -> bool {
     if matches!(field, "Int" | "Float" | "Bool" | "String") {
+        return true;
+    }
+    if registry.packed_sequence(field).is_some() {
         return true;
     }
     if registry.record_type_idx(field).is_some() {

--- a/src/codegen/wasm_gc/maps.rs
+++ b/src/codegen/wasm_gc/maps.rs
@@ -805,6 +805,18 @@ fn emit_hash_for(
     if let Some(under) = registry.newtype_underlying(k_aver) {
         return emit_hash_for(under, registry, string_key_helpers, all_key_helpers);
     }
+    if registry.packed_sequence(k_aver).is_some() {
+        let helpers = all_key_helpers.get(k_aver).ok_or_else(|| {
+            WasmGcError::Validation(format!(
+                "hash_for: packed `{k_aver}` has no registered hash helper"
+            ))
+        })?;
+        let mut f = Function::new([]);
+        f.instruction(&Instruction::LocalGet(0));
+        f.instruction(&Instruction::Call(helpers.hash));
+        f.instruction(&Instruction::End);
+        return Ok(f);
+    }
     if registry.record_type_idx(k_aver).is_some() {
         return emit_hash_record(k_aver, registry, string_key_helpers, all_key_helpers);
     }
@@ -865,6 +877,19 @@ fn emit_eq_for(
     // records.
     if let Some(under) = registry.newtype_underlying(k_aver) {
         return emit_eq_for(under, registry, string_key_helpers, all_key_helpers);
+    }
+    if registry.packed_sequence(k_aver).is_some() {
+        let helpers = all_key_helpers.get(k_aver).ok_or_else(|| {
+            WasmGcError::Validation(format!(
+                "eq_for: packed `{k_aver}` has no registered eq helper"
+            ))
+        })?;
+        let mut f = Function::new([]);
+        f.instruction(&Instruction::LocalGet(0));
+        f.instruction(&Instruction::LocalGet(1));
+        f.instruction(&Instruction::Call(helpers.eq));
+        f.instruction(&Instruction::End);
+        return Ok(f);
     }
     if registry.record_type_idx(k_aver).is_some() {
         return emit_eq_record(k_aver, registry, string_key_helpers, all_key_helpers);
@@ -1025,6 +1050,9 @@ fn key_storage_null_heap(k_aver: &str, registry: &TypeRegistry) -> HeapType {
         && let Some(s) = registry.string_array_type_idx
     {
         return HeapType::Concrete(s);
+    }
+    if let Some(packed) = registry.packed_sequence(k_aver) {
+        return HeapType::Concrete(packed.type_idx);
     }
     if let Some(r) = registry.record_type_idx(k_aver) {
         return HeapType::Concrete(r);

--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -62,6 +62,7 @@ mod flatten;
 mod lists;
 mod maps;
 mod module;
+mod packed_sequences;
 #[cfg(test)]
 mod tests;
 mod types;

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -330,6 +330,52 @@ pub(super) fn emit_module_with(
             .collect();
     registry.set_eligible_carrier_fields(eligible_carrier_fields);
 
+    // Structural sibling of carrier-i64: derive a per-element interval for
+    // canonical opaque `List<Int>` refinements and erase each eligible nominal
+    // wrapper to the smallest lossless wasm array element. This deliberately
+    // reuses the scalar pass's gate-bypass scan rather than trusting the type
+    // name or merely spotting a one-field record. Unlike scalar i64 erasure,
+    // packed refs are supported by Map's key/value storage and eq/hash paths,
+    // so Map-key use does not require a representation demotion.
+    let packed_sequence_layouts = if std::env::var("AVER_NO_PACKED_SEQUENCES").is_ok() {
+        std::collections::HashMap::new()
+    } else {
+        let inputs = crate::codegen::proof_lower::ProofLowerInputs {
+            entry_items: items,
+            dep_modules: &[],
+            module_prefixes: &std::collections::HashSet::new(),
+            recursive_fns: &std::collections::HashSet::new(),
+            symbol_table: &symbol_table,
+            program_shape: None,
+        };
+        let layouts = crate::codegen::proof_lower::packed_sequence_layout_table(&inputs);
+        let candidates: std::collections::HashSet<String> = layouts.keys().cloned().collect();
+        let intervals: std::collections::HashMap<_, _> = layouts
+            .iter()
+            .map(|(name, layout)| (name.clone(), (layout.element_interval, true)))
+            .collect();
+        let demoted = crate::codegen::proof_lower::carrier_ungated_construction_demotions(
+            &inputs,
+            &candidates,
+            &intervals,
+        );
+        layouts
+            .into_iter()
+            .filter(|(name, _)| !demoted.contains(name))
+            .collect()
+    };
+    // The proof scan can see an otherwise-unused dependency even when MIR
+    // instantiation discovery quite correctly omitted `List<Int>`. Packing
+    // such a dead nominal would force bridge helpers to reference a type that
+    // does not exist in this module. Keep the optimization fail-closed: a
+    // live structural carrier necessarily registers its declared list type.
+    let packed_sequence_layouts = if registry.list_type_idx("List<Int>").is_some() {
+        packed_sequence_layouts
+    } else {
+        std::collections::HashMap::new()
+    };
+    registry.install_packed_sequences(packed_sequence_layouts);
+
     let mir_program: crate::ir::mir::MirProgram = {
         // Reuse the `optimized` MIR built above for carrier-eligibility
         // Map-key discovery — the box/unbox boundary rewrite is the only
@@ -477,8 +523,13 @@ pub(super) fn emit_module_with(
         }
     }
     for canonical in &registry.map_order {
-        if let Some((k, _v)) = super::types::parse_map_kv(canonical) {
+        if let Some((k, v)) = super::types::parse_map_kv(canonical) {
             nominal_seed.push(k.trim().to_string());
+            // Map's own helper registry treats non-primitive values as
+            // pseudo-keys for structural eq/hash. Seed the shared nominal
+            // registries too so representation-specialized values (notably a
+            // proof-packed sequence) can override that record-shaped fallback.
+            nominal_seed.push(v.trim().to_string());
         }
     }
     for name in &nominal_seed {
@@ -530,6 +581,7 @@ pub(super) fn emit_module_with(
         let hk = match kind {
             EqKind::Record => HashKind::Record,
             EqKind::Sum => HashKind::Sum,
+            EqKind::PackedSequence => HashKind::PackedSequence,
             EqKind::OptionEq => HashKind::OptionHash,
             EqKind::ResultEq => HashKind::ResultHash,
             EqKind::TupleEq => HashKind::TupleHash,
@@ -1167,6 +1219,13 @@ pub(super) fn emit_module_with(
         &mut next_type_idx,
     )?;
     list_helpers.emit_helper_types(&mut types, &registry)?;
+
+    // Structural refinement list↔packed-array bridges. Their slots follow the
+    // list helpers because their signatures name `List<Int>` directly.
+    let mut packed_sequence_helpers =
+        super::packed_sequences::PackedSequenceHelperRegistry::default();
+    packed_sequence_helpers.assign_slots(&registry, &mut next_builtin_fn_idx, &mut next_type_idx);
+    packed_sequence_helpers.emit_helper_types(&mut types, &registry)?;
 
     // Per-(record/sum) `__eq_<TypeName>` helpers — slot allocation +
     // type emit. Bodies emitted after list helpers (they may call
@@ -1999,6 +2058,7 @@ pub(super) fn emit_module_with(
         &mut next_builtin_fn_idx,
         &registry,
         &effect_registry,
+        packed_sequence_helpers.ops_for("Bytes").map(|ops| ops.pack),
     )?;
 
     // 10) Caller-fn name table exports. `__caller_fn_count() -> i32`
@@ -2083,6 +2143,7 @@ pub(super) fn emit_module_with(
     }
     map_helpers.emit_function_section(&mut funcs);
     list_helpers.emit_function_section(&mut funcs);
+    packed_sequence_helpers.emit_function_section(&mut funcs);
     // Eq helpers — one fn entry per registered `__eq_<TypeName>` slot.
     for (name, _kind) in eq_helpers_registry.iter() {
         let t_idx = eq_helpers_registry
@@ -2574,6 +2635,10 @@ pub(super) fn emit_module_with(
         }
     }
     let string_split_ops = list_helpers.string_split_ops();
+    let packed_sequence_ops = packed_sequence_helpers
+        .iter()
+        .map(|(name, ops)| (name.to_string(), ops))
+        .collect();
     let mut eq_helpers_lookup: HashMap<String, u32> = HashMap::new();
     for (name, _kind) in eq_helpers_registry.iter() {
         if let Some(fn_idx) = eq_helpers_registry.lookup_fn_idx(name) {
@@ -2609,6 +2674,7 @@ pub(super) fn emit_module_with(
         vfl_ops: vfl_ops_lookup,
         zip_ops: zip_ops_lookup,
         string_split_ops,
+        packed_sequence_ops,
         eq_helpers: eq_helpers_lookup,
         funcref_table,
         call_indirect_types,
@@ -3308,15 +3374,17 @@ pub(super) fn emit_module_with(
             compound_eq_hash_lookup.insert(canonical.clone(), (h.eq, h.hash));
         }
     }
-    // Carrier eq+hash lookup — Option/Result/Tuple instantiations
-    // get their helpers from eq_helpers / hash_helpers; map keys
-    // proxy through these. Build the pair map by zipping the two
-    // registries' fn idxs by canonical.
+    // Carrier eq+hash lookup — Option/Result/Tuple and proof-packed nominal
+    // instantiations get their helpers from eq_helpers / hash_helpers; map
+    // keys and values proxy through these. Build the pair map by zipping the
+    // two registries' fn idxs by canonical.
     let mut carrier_eq_hash_lookup: HashMap<String, (u32, u32)> = HashMap::new();
     for (name, kind) in eq_helpers_registry.iter() {
         use super::body::eq_helpers::EqKind as EK;
-        if matches!(kind, EK::OptionEq | EK::ResultEq | EK::TupleEq)
-            && let Some(eq_fn) = eq_helpers_registry.lookup_fn_idx(name)
+        if matches!(
+            kind,
+            EK::PackedSequence | EK::OptionEq | EK::ResultEq | EK::TupleEq
+        ) && let Some(eq_fn) = eq_helpers_registry.lookup_fn_idx(name)
             && let Some(hash_fn) = hash_helpers_registry.lookup_fn_idx(name)
         {
             carrier_eq_hash_lookup.insert(name.to_string(), (eq_fn, hash_fn));
@@ -3363,6 +3431,7 @@ pub(super) fn emit_module_with(
         &hash_helper_fn_idx_map,
         aint_eq_fn_idx,
     )?;
+    packed_sequence_helpers.emit_helper_bodies(&mut codes, &registry)?;
 
     // Per-(record/sum) `__eq_<TypeName>` helper bodies — emit after
     // list helpers so any String fields can call `__wasmgc_string_eq`
@@ -4298,6 +4367,9 @@ pub(super) fn emit_module_with(
                 .as_ref()
                 .map(|g| g.bump_alloc_ptr)
                 .expect("tcp.write_bytes emit requires bump_alloc_ptr global"),
+            bytes_unpack_fn: packed_sequence_helpers
+                .ops_for("Bytes")
+                .map(|ops| ops.unpack),
         };
         codes.function(&super::wasip2_tcp::emit_tcp_write_bytes(tw, &helpers));
     }
@@ -4737,6 +4809,10 @@ pub(super) fn emit_module_with(
             string_from_lm_fn,
             aint_from_i64_fn,
             aint_to_string_fn,
+            bytes_pack_fn: packed_sequence_helpers.ops_for("Bytes").map(|ops| ops.pack),
+            bytes_unpack_fn: packed_sequence_helpers
+                .ops_for("Bytes")
+                .map(|ops| ops.unpack),
         };
         codes.function(&super::wasip2_tcp::emit_tcp_send_bytes(ts, &helpers));
     }
@@ -5130,6 +5206,32 @@ fn emit_user_types(
             idx,
             mk_array(wasm_encoder::FieldType {
                 element_type: wasm_encoder::StorageType::I8,
+                mutable: true,
+            }),
+        ));
+    }
+
+    // Proof-derived structural refinement carriers. `i8` / `i16` are wasm
+    // packed storage; wider intervals use ordinary i32/i64 array elements.
+    // Signedness affects loads in the generated bridge helpers, not the array
+    // declaration itself.
+    for name in &registry.packed_sequence_order {
+        let packed = registry
+            .packed_sequence(name)
+            .expect("packed sequence order entry missing layout");
+        use crate::codegen::proof_lower::PackedIntElement;
+        let element_type = match packed.layout.element {
+            PackedIntElement::U8 | PackedIntElement::I8 => wasm_encoder::StorageType::I8,
+            PackedIntElement::U16 | PackedIntElement::I16 => wasm_encoder::StorageType::I16,
+            PackedIntElement::U32 | PackedIntElement::I32 => {
+                wasm_encoder::StorageType::Val(wasm_encoder::ValType::I32)
+            }
+            PackedIntElement::I64 => wasm_encoder::StorageType::Val(wasm_encoder::ValType::I64),
+        };
+        entries.push((
+            packed.type_idx,
+            mk_array(wasm_encoder::FieldType {
+                element_type,
                 mutable: true,
             }),
         ));
@@ -6411,6 +6513,10 @@ struct FactoryExports {
     result_bytes_string_err: Option<FactorySlot>,
     list_int_cons: Option<FactorySlot>,
     list_int_nil: Option<FactorySlot>,
+    /// When Bytes is proof-packed, the host-facing Ok factory still accepts
+    /// the private `List<Int>` it historically received and calls this bridge
+    /// before storing the Result payload.
+    bytes_pack_fn: Option<u32>,
     /// `__rt_record_tcp_connection_make(id, host, port)` — emitted
     /// when any `Tcp.*` effect is registered. The host hands the
     /// resulting record back as a Connection handle; subsequent
@@ -6450,8 +6556,12 @@ fn allocate_factory_exports(
     next_fn_idx: &mut u32,
     registry: &TypeRegistry,
     effect_registry: &EffectRegistry,
+    bytes_pack_fn: Option<u32>,
 ) -> Result<FactoryExports, WasmGcError> {
-    let mut fx = FactoryExports::default();
+    let mut fx = FactoryExports {
+        bytes_pack_fn,
+        ..FactoryExports::default()
+    };
 
     // Option<String> factories — driven by `Terminal.readKey`.
     if effect_registry
@@ -6842,9 +6952,11 @@ fn allocate_factory_exports(
                     "byte-clean TCP factory requires Result<Bytes,String> slot".into(),
                 ))?;
         let _bytes_idx = registry
-            .record_type_idx("Bytes")
+            .packed_sequence("Bytes")
+            .map(|packed| packed.type_idx)
+            .or_else(|| registry.record_type_idx("Bytes"))
             .ok_or(WasmGcError::Validation(
-                "byte-clean TCP factory requires Bytes record slot".into(),
+                "byte-clean TCP factory requires Bytes slot".into(),
             ))?;
         let list_idx = registry
             .list_type_idx("List<Int>")
@@ -7081,7 +7193,10 @@ impl FactoryExports {
             codes.function(&emit_factory_map_string_list_string_empty(registry)?);
         }
         if self.result_bytes_string_ok.is_some() {
-            codes.function(&emit_factory_result_bytes_string_ok(registry)?);
+            codes.function(&emit_factory_result_bytes_string_ok(
+                registry,
+                self.bytes_pack_fn,
+            )?);
         }
         if self.result_bytes_string_err.is_some() {
             codes.function(&emit_factory_result_bytes_string_err(registry)?);
@@ -7345,12 +7460,10 @@ fn emit_factory_list_string_nil(
 
 fn emit_factory_result_bytes_string_ok(
     registry: &TypeRegistry,
+    bytes_pack_fn: Option<u32>,
 ) -> Result<wasm_encoder::Function, WasmGcError> {
     let res_idx = registry
         .result_type_idx("Result<Bytes,String>")
-        .expect("checked at allocation");
-    let bytes_idx = registry
-        .record_type_idx("Bytes")
         .expect("checked at allocation");
     let s_idx = registry
         .string_array_type_idx
@@ -7358,7 +7471,14 @@ fn emit_factory_result_bytes_string_ok(
     let mut f = Function::new([]);
     f.instruction(&Instruction::I32Const(1));
     f.instruction(&Instruction::LocalGet(0));
-    f.instruction(&Instruction::StructNew(bytes_idx));
+    if let Some(pack_fn) = bytes_pack_fn {
+        f.instruction(&Instruction::Call(pack_fn));
+    } else {
+        let bytes_idx = registry
+            .record_type_idx("Bytes")
+            .expect("checked at allocation");
+        f.instruction(&Instruction::StructNew(bytes_idx));
+    }
     f.instruction(&Instruction::RefNull(wasm_encoder::HeapType::Concrete(
         s_idx,
     )));
@@ -7374,7 +7494,9 @@ fn emit_factory_result_bytes_string_err(
         .result_type_idx("Result<Bytes,String>")
         .expect("checked at allocation");
     let bytes_idx = registry
-        .record_type_idx("Bytes")
+        .packed_sequence("Bytes")
+        .map(|packed| packed.type_idx)
+        .or_else(|| registry.record_type_idx("Bytes"))
         .expect("checked at allocation");
     let mut f = Function::new([]);
     f.instruction(&Instruction::I32Const(0));

--- a/src/codegen/wasm_gc/packed_sequences.rs
+++ b/src/codegen/wasm_gc/packed_sequences.rs
@@ -1,0 +1,275 @@
+//! Construct/project bridges for proof-packed structural refinements.
+//!
+//! A packed nominal value is an array in wasm, while Aver code inside the
+//! defining module still constructs and projects its declared `List<Int>`
+//! carrier. Two small per-type helpers make that boundary explicit. They are
+//! generic over the proof-selected integer width and never key on `Bytes`.
+
+use std::collections::HashMap;
+
+use wasm_encoder::{
+    BlockType, CodeSection, Function, FunctionSection, HeapType, Instruction, RefType, TypeSection,
+    ValType,
+};
+
+use super::WasmGcError;
+use super::types::TypeRegistry;
+use crate::codegen::proof_lower::PackedIntElement;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PackedSequenceOps {
+    pub(super) pack: u32,
+    pub(super) unpack: u32,
+}
+
+#[derive(Default)]
+pub(super) struct PackedSequenceHelperRegistry {
+    ops: HashMap<String, PackedSequenceOps>,
+    type_indices: HashMap<String, (u32, u32)>,
+    order: Vec<String>,
+}
+
+impl PackedSequenceHelperRegistry {
+    pub(super) fn assign_slots(
+        &mut self,
+        registry: &TypeRegistry,
+        next_fn_idx: &mut u32,
+        next_type_idx: &mut u32,
+    ) {
+        for name in &registry.packed_sequence_order {
+            let pack_type = *next_type_idx;
+            *next_type_idx += 1;
+            let unpack_type = *next_type_idx;
+            *next_type_idx += 1;
+            let pack = *next_fn_idx;
+            *next_fn_idx += 1;
+            let unpack = *next_fn_idx;
+            *next_fn_idx += 1;
+            self.ops
+                .insert(name.clone(), PackedSequenceOps { pack, unpack });
+            self.type_indices
+                .insert(name.clone(), (pack_type, unpack_type));
+            self.order.push(name.clone());
+        }
+    }
+
+    pub(super) fn ops_for(&self, type_name: &str) -> Option<PackedSequenceOps> {
+        self.ops.get(type_name).copied().or_else(|| {
+            type_name
+                .rsplit_once('.')
+                .and_then(|(_, bare)| self.ops.get(bare).copied())
+        })
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = (&str, PackedSequenceOps)> + '_ {
+        self.order
+            .iter()
+            .map(|name| (name.as_str(), self.ops[name]))
+    }
+
+    pub(super) fn emit_helper_types(
+        &self,
+        types: &mut TypeSection,
+        registry: &TypeRegistry,
+    ) -> Result<(), WasmGcError> {
+        if self.order.is_empty() {
+            return Ok(());
+        }
+        let list_idx = registry
+            .list_type_idx("List<Int>")
+            .ok_or_else(|| WasmGcError::Validation("packed carrier requires List<Int>".into()))?;
+        let list_ref = ref_ty(list_idx);
+        for name in &self.order {
+            let packed = registry
+                .packed_sequence(name)
+                .expect("packed helper without packed type");
+            let packed_ref = ref_ty(packed.type_idx);
+            types.ty().function([list_ref], [packed_ref]);
+            types.ty().function([packed_ref], [list_ref]);
+        }
+        Ok(())
+    }
+
+    pub(super) fn emit_function_section(&self, funcs: &mut FunctionSection) {
+        for name in &self.order {
+            let (pack, unpack) = self.type_indices[name];
+            funcs.function(pack);
+            funcs.function(unpack);
+        }
+    }
+
+    pub(super) fn emit_helper_bodies(
+        &self,
+        codes: &mut CodeSection,
+        registry: &TypeRegistry,
+    ) -> Result<(), WasmGcError> {
+        for name in &self.order {
+            codes.function(&emit_pack(name, registry)?);
+            codes.function(&emit_unpack(name, registry)?);
+        }
+        Ok(())
+    }
+}
+
+fn ref_ty(type_idx: u32) -> ValType {
+    ValType::Ref(RefType {
+        nullable: true,
+        heap_type: HeapType::Concrete(type_idx),
+    })
+}
+
+fn emit_pack(name: &str, registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let packed = registry
+        .packed_sequence(name)
+        .ok_or_else(|| WasmGcError::Validation(format!("packed type `{name}` missing")))?;
+    let list_idx = registry
+        .list_type_idx("List<Int>")
+        .ok_or_else(|| WasmGcError::Validation("packed carrier requires List<Int>".into()))?;
+    let list_ref = ref_ty(list_idx);
+    let packed_ref = ref_ty(packed.type_idx);
+    let mut f = Function::new([
+        (1, list_ref),     // 1: cursor
+        (1, ValType::I32), // 2: len
+        (1, packed_ref),   // 3: output
+        (1, ValType::I32), // 4: index
+    ]);
+
+    // Pass 1: count the linked list.
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::Block(BlockType::Empty));
+    f.instruction(&Instruction::Loop(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::RefIsNull);
+    f.instruction(&Instruction::BrIf(1));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::StructGet {
+        struct_type_index: list_idx,
+        field_index: 1,
+    });
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::ArrayNewDefault(packed.type_idx));
+    f.instruction(&Instruction::LocalSet(3));
+
+    // Pass 2: checked-unbox each Int and let the proven interval justify the
+    // width narrowing performed by array.set.
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::Block(BlockType::Empty));
+    f.instruction(&Instruction::Loop(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::RefIsNull);
+    f.instruction(&Instruction::BrIf(1));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::StructGet {
+        struct_type_index: list_idx,
+        field_index: 0,
+    });
+    if registry.bignum {
+        let to_i64 = registry.aint_to_i64_checked_fn_idx.ok_or_else(|| {
+            WasmGcError::Validation("packed carrier requires __aint_to_i64_checked".into())
+        })?;
+        f.instruction(&Instruction::Call(to_i64));
+    }
+    if !matches!(packed.layout.element, PackedIntElement::I64) {
+        f.instruction(&Instruction::I32WrapI64);
+    }
+    f.instruction(&Instruction::ArraySet(packed.type_idx));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::StructGet {
+        struct_type_index: list_idx,
+        field_index: 1,
+    });
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::End);
+    Ok(f)
+}
+
+fn emit_unpack(name: &str, registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let packed = registry
+        .packed_sequence(name)
+        .ok_or_else(|| WasmGcError::Validation(format!("packed type `{name}` missing")))?;
+    let list_idx = registry
+        .list_type_idx("List<Int>")
+        .ok_or_else(|| WasmGcError::Validation("packed carrier requires List<Int>".into()))?;
+    let list_ref = ref_ty(list_idx);
+    let mut f = Function::new([
+        (1, list_ref),     // 1: accumulator
+        (1, ValType::I32), // 2: reverse index
+    ]);
+    f.instruction(&Instruction::RefNull(HeapType::Concrete(list_idx)));
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::ArrayLen);
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::Block(BlockType::Empty));
+    f.instruction(&Instruction::Loop(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Eqz);
+    f.instruction(&Instruction::BrIf(1));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::LocalGet(2));
+    match packed.layout.element {
+        PackedIntElement::U8 | PackedIntElement::U16 => {
+            f.instruction(&Instruction::ArrayGetU(packed.type_idx));
+            f.instruction(&Instruction::I64ExtendI32U);
+        }
+        PackedIntElement::I8 | PackedIntElement::I16 => {
+            f.instruction(&Instruction::ArrayGetS(packed.type_idx));
+            f.instruction(&Instruction::I64ExtendI32S);
+        }
+        PackedIntElement::U32 => {
+            f.instruction(&Instruction::ArrayGet(packed.type_idx));
+            f.instruction(&Instruction::I64ExtendI32U);
+        }
+        PackedIntElement::I32 => {
+            f.instruction(&Instruction::ArrayGet(packed.type_idx));
+            f.instruction(&Instruction::I64ExtendI32S);
+        }
+        PackedIntElement::I64 => {
+            f.instruction(&Instruction::ArrayGet(packed.type_idx));
+        }
+    }
+    if registry.bignum {
+        let from_i64 = registry.aint_from_i64_fn_idx.ok_or_else(|| {
+            WasmGcError::Validation("packed carrier requires __aint_from_i64".into())
+        })?;
+        f.instruction(&Instruction::Call(from_i64));
+    }
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::StructNew(list_idx));
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::End);
+    Ok(f)
+}

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -42,6 +42,16 @@ use super::types_discovery::{
 
 use crate::ast::{TopLevel, Type, TypeDef};
 
+/// Wasm storage selected for an opaque structural refinement whose carrier is
+/// `List<Int>`. The nominal Aver type is represented directly by this array;
+/// its source-level list is materialised only at the smart-constructor and
+/// field-projection boundaries.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PackedSequenceType {
+    pub(super) type_idx: u32,
+    pub(super) layout: crate::codegen::proof_lower::PackedSequenceLayout,
+}
+
 /// User-type lookup tables built once before any fn body emit.
 pub(super) struct TypeRegistry {
     /// `record_name → type_idx` for product (record) types.
@@ -117,6 +127,12 @@ pub(super) struct TypeRegistry {
     /// pass raw `K_val` and box on insert / unbox on read.
     pub(super) primitive_key_box: HashMap<String, u32>,
     pub(super) primitive_key_box_order: Vec<String>,
+    /// Proof-derived packed representations for opaque `List<Int>`
+    /// refinements. Keyed by bare nominal type name. Unlike ordinary record
+    /// newtyping this changes the carrier shape, so construct/project sites
+    /// bridge between `List<Int>` and the packed array explicitly.
+    pub(super) packed_sequences: HashMap<String, PackedSequenceType>,
+    pub(super) packed_sequence_order: Vec<String>,
     /// Total number of user-type slots reserved in the type section.
     /// Function types start AFTER these.
     pub(super) user_type_count: u32,
@@ -1072,6 +1088,8 @@ impl TypeRegistry {
             tuple_order,
             primitive_key_box,
             primitive_key_box_order,
+            packed_sequences: HashMap::new(),
+            packed_sequence_order: Vec::new(),
             user_type_count: next_idx,
             string_array_type_idx,
             crypto_byte_array_type_idx,
@@ -1393,6 +1411,35 @@ impl TypeRegistry {
     /// Keyed by bare Aver name (`"IntRange"`).
     pub(super) fn set_eligible_carriers(&mut self, names: std::collections::HashSet<String>) {
         self.eligible_carriers = names;
+    }
+
+    /// Install proof-derived packed sequence layouts after the ordinary type
+    /// discovery pass. Slots are appended deterministically to the user-type
+    /// rec group so every later signature and body sees one stable nominal
+    /// array type per eligible refinement.
+    pub(super) fn install_packed_sequences(
+        &mut self,
+        layouts: HashMap<String, crate::codegen::proof_lower::PackedSequenceLayout>,
+    ) {
+        let mut names: Vec<String> = layouts.keys().cloned().collect();
+        names.sort();
+        for name in names {
+            let layout = layouts[&name];
+            let type_idx = self.user_type_count;
+            self.user_type_count += 1;
+            self.packed_sequences
+                .insert(name.clone(), PackedSequenceType { type_idx, layout });
+            self.packed_sequence_order.push(name);
+        }
+    }
+
+    pub(super) fn packed_sequence(&self, type_name: &str) -> Option<PackedSequenceType> {
+        let trimmed = type_name.trim();
+        self.packed_sequences.get(trimmed).copied().or_else(|| {
+            trimmed
+                .rsplit_once('.')
+                .and_then(|(_, bare)| self.packed_sequences.get(bare).copied())
+        })
     }
 
     /// ETAP-2 carrier-`i64`: is `type_name` (bare or `Module.`-qualified) a
@@ -1919,6 +1966,16 @@ pub(super) fn aver_to_wasm(
         return Ok(None);
     }
     if let Some(reg) = registry {
+        // Structural refinement erasure — an eligible nominal
+        // `record X { values: List<Int> }` is represented by its proven packed
+        // array everywhere. Construction/projection bridge the source-level
+        // list at the opaque module boundary.
+        if let Some(packed) = reg.packed_sequence(trimmed) {
+            return Ok(Some(ValType::Ref(RefType {
+                nullable: true,
+                heap_type: HeapType::Concrete(packed.type_idx),
+            })));
+        }
         // Newtype optimization — a single-field record / single-variant
         // sum of a primitive lowers to the underlying primitive
         // everywhere. Saves an allocation per wrap and a struct.get

--- a/src/codegen/wasm_gc/wasip2_tcp/io.rs
+++ b/src/codegen/wasm_gc/wasip2_tcp/io.rs
@@ -369,6 +369,7 @@ pub(in crate::codegen::wasm_gc) struct TcpWriteBytesHelperFns {
     pub result_err_fn: u32,
     pub tcp_pool_global: u32,
     pub bump_alloc_ptr_global: u32,
+    pub bytes_unpack_fn: Option<u32>,
 }
 
 pub(in crate::codegen::wasm_gc) fn emit_tcp_write_bytes(
@@ -481,10 +482,14 @@ pub(in crate::codegen::wasm_gc) fn emit_tcp_write_bytes(
 
     // First pass validates the private carrier and computes its byte length.
     f.instruction(&Instruction::LocalGet(1));
-    f.instruction(&Instruction::StructGet {
-        struct_type_index: indices.bytes_type_idx,
-        field_index: 0,
-    });
+    if let Some(unpack_fn) = helpers.bytes_unpack_fn {
+        f.instruction(&Instruction::Call(unpack_fn));
+    } else {
+        f.instruction(&Instruction::StructGet {
+            struct_type_index: indices.bytes_type_idx,
+            field_index: 0,
+        });
+    }
     f.instruction(&Instruction::LocalSet(l_list));
     f.instruction(&Instruction::I32Const(0));
     f.instruction(&Instruction::LocalSet(l_len));
@@ -546,10 +551,14 @@ pub(in crate::codegen::wasm_gc) fn emit_tcp_write_bytes(
     f.instruction(&Instruction::Call(helpers.cabi_realloc_fn));
     f.instruction(&Instruction::Drop);
     f.instruction(&Instruction::LocalGet(1));
-    f.instruction(&Instruction::StructGet {
-        struct_type_index: indices.bytes_type_idx,
-        field_index: 0,
-    });
+    if let Some(unpack_fn) = helpers.bytes_unpack_fn {
+        f.instruction(&Instruction::Call(unpack_fn));
+    } else {
+        f.instruction(&Instruction::StructGet {
+            struct_type_index: indices.bytes_type_idx,
+            field_index: 0,
+        });
+    }
     f.instruction(&Instruction::LocalSet(l_list));
     f.instruction(&Instruction::I32Const(0));
     f.instruction(&Instruction::LocalSet(l_off));

--- a/src/codegen/wasm_gc/wasip2_tcp/lifecycle.rs
+++ b/src/codegen/wasm_gc/wasip2_tcp/lifecycle.rs
@@ -212,6 +212,8 @@ pub(in crate::codegen::wasm_gc) struct TcpSendBytesHelperFns {
     pub string_from_lm_fn: u32,
     pub aint_from_i64_fn: Option<u32>,
     pub aint_to_string_fn: Option<u32>,
+    pub bytes_pack_fn: Option<u32>,
+    pub bytes_unpack_fn: Option<u32>,
 }
 
 #[derive(Clone, Copy)]
@@ -274,6 +276,8 @@ enum TcpSendFlavor {
         string_from_lm_fn: u32,
         aint_from_i64_fn: Option<u32>,
         aint_to_string_fn: Option<u32>,
+        bytes_pack_fn: Option<u32>,
+        bytes_unpack_fn: Option<u32>,
     },
 }
 
@@ -589,6 +593,8 @@ pub(in crate::codegen::wasm_gc) fn emit_tcp_send_bytes(
             string_from_lm_fn: helpers.string_from_lm_fn,
             aint_from_i64_fn: helpers.aint_from_i64_fn,
             aint_to_string_fn: helpers.aint_to_string_fn,
+            bytes_pack_fn: helpers.bytes_pack_fn,
+            bytes_unpack_fn: helpers.bytes_unpack_fn,
         },
     )
 }
@@ -817,6 +823,7 @@ fn emit_tcp_send_impl(
         aint_struct_type_idx,
         string_from_lm_fn,
         aint_to_string_fn,
+        bytes_unpack_fn,
         ..
     } = flavor
     {
@@ -824,10 +831,14 @@ fn emit_tcp_send_impl(
         let l_list_cursor = l_list_cursor.expect("bytes flavor has list cursor local");
 
         f.instruction(&Instruction::LocalGet(2));
-        f.instruction(&Instruction::StructGet {
-            struct_type_index: bytes_type_idx,
-            field_index: 0,
-        });
+        if let Some(unpack_fn) = bytes_unpack_fn {
+            f.instruction(&Instruction::Call(unpack_fn));
+        } else {
+            f.instruction(&Instruction::StructGet {
+                struct_type_index: bytes_type_idx,
+                field_index: 0,
+            });
+        }
         f.instruction(&Instruction::LocalSet(l_list_cursor));
         f.instruction(&Instruction::I32Const(0));
         f.instruction(&Instruction::LocalSet(l_data_len));
@@ -1143,6 +1154,7 @@ fn emit_tcp_send_impl(
             bytes_type_idx,
             list_int_type_idx,
             aint_struct_type_idx,
+            bytes_unpack_fn,
             ..
         } => {
             let l_list_cursor = l_list_cursor.expect("bytes flavor has list cursor local");
@@ -1153,10 +1165,14 @@ fn emit_tcp_send_impl(
             f.instruction(&Instruction::Call(helpers.cabi_realloc_fn));
             f.instruction(&Instruction::Drop);
             f.instruction(&Instruction::LocalGet(2));
-            f.instruction(&Instruction::StructGet {
-                struct_type_index: bytes_type_idx,
-                field_index: 0,
-            });
+            if let Some(unpack_fn) = bytes_unpack_fn {
+                f.instruction(&Instruction::Call(unpack_fn));
+            } else {
+                f.instruction(&Instruction::StructGet {
+                    struct_type_index: bytes_type_idx,
+                    field_index: 0,
+                });
+            }
             f.instruction(&Instruction::LocalSet(l_list_cursor));
             f.instruction(&Instruction::I32Const(0));
             f.instruction(&Instruction::LocalSet(l_off));
@@ -1446,6 +1462,7 @@ fn emit_tcp_send_impl(
             result_type_idx,
             aint_struct_type_idx,
             aint_from_i64_fn,
+            bytes_pack_fn,
             ..
         } => {
             let l_list_cursor = l_list_cursor.expect("bytes flavor has list cursor local");
@@ -1481,7 +1498,11 @@ fn emit_tcp_send_impl(
 
             f.instruction(&Instruction::I32Const(1));
             f.instruction(&Instruction::LocalGet(l_list_cursor));
-            f.instruction(&Instruction::StructNew(bytes_type_idx));
+            if let Some(pack_fn) = bytes_pack_fn {
+                f.instruction(&Instruction::Call(pack_fn));
+            } else {
+                f.instruction(&Instruction::StructNew(bytes_type_idx));
+            }
             f.instruction(&Instruction::RefNull(HeapType::Concrete(
                 indices.string_type_idx,
             )));

--- a/src/codegen/wasm_gc/wasip2_tcp/wireup.rs
+++ b/src/codegen/wasm_gc/wasip2_tcp/wireup.rs
@@ -396,7 +396,10 @@ fn allocate_write_bytes(
     next_builtin_fn_idx: &mut u32,
 ) -> Option<TcpWriteBytesIndices> {
     let string_idx = registry.string_array_type_idx?;
-    let bytes_idx = registry.record_type_idx("Bytes")?;
+    let bytes_idx = registry
+        .packed_sequence("Bytes")
+        .map(|packed| packed.type_idx)
+        .or_else(|| registry.record_type_idx("Bytes"))?;
     let list_idx = registry.list_type_idx("List<Int>")?;
     let aint_idx = registry.aint_struct_idx?;
     let conn_idx = registry.record_type_idx("Tcp.Connection")?;
@@ -688,7 +691,10 @@ fn allocate_send_bytes(
     next_builtin_fn_idx: &mut u32,
 ) -> Option<TcpSendBytesIndices> {
     let string_idx = registry.string_array_type_idx?;
-    let bytes_idx = registry.record_type_idx("Bytes")?;
+    let bytes_idx = registry
+        .packed_sequence("Bytes")
+        .map(|packed| packed.type_idx)
+        .or_else(|| registry.record_type_idx("Bytes"))?;
     let list_int_idx = registry.list_type_idx("List<Int>")?;
     let result_idx = registry.result_type_idx("Result<Bytes,String>")?;
     let dns_err_seg = registry.string_literal_segment(b"tcp: dns resolve failed")?;

--- a/src/runtime/wasm_gc/imports/tcp.rs
+++ b/src/runtime/wasm_gc/imports/tcp.rs
@@ -388,6 +388,34 @@ fn decode_byte_payload(
             )));
         }
     };
+    // Proof-packed Bytes crosses the host ABI as `(array i8)`. Keep the old
+    // record/List<Int> decoder below as the differential fallback when
+    // `AVER_NO_PACKED_SEQUENCES` is set.
+    if let Some(array) = bytes_ref.as_array(&*caller)? {
+        let len = array.len(&*caller)?;
+        let mut bytes = Vec::with_capacity(len as usize);
+        for idx in 0..len {
+            match array.get(&mut *caller, idx)? {
+                Val::I32(value) => bytes.push(value as u8),
+                _ => {
+                    return Err(wasmtime::Error::msg(format!(
+                        "{effect}: malformed packed Bytes carrier"
+                    )));
+                }
+            }
+        }
+        let values_json = aver::replay::JsonValue::Array(
+            bytes
+                .iter()
+                .copied()
+                .map(|value| aver::replay::JsonValue::Int(i64::from(value)))
+                .collect(),
+        );
+        return Ok((
+            Ok(bytes),
+            json_record("Bytes", vec![("values", values_json)]),
+        ));
+    }
     let bytes = bytes_ref
         .as_struct(&*caller)?
         .ok_or_else(|| wasmtime::Error::msg(format!("{effect}: payload must be Bytes")))?;

--- a/tests/wasm_gc_packed_sequence.rs
+++ b/tests/wasm_gc_packed_sequence.rs
@@ -1,0 +1,193 @@
+//! Differential coverage for proof-packed `List<Int>` refinements.
+
+#![cfg(feature = "wasm")]
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+
+fn run(source: &str, wasm_gc: bool, packed: bool) -> (bool, String) {
+    let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+    let dir =
+        std::env::temp_dir().join(format!("aver-packed-sequence-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("main.av");
+    std::fs::write(&path, source).expect("source");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver"));
+    command.arg("run").arg(&path);
+    if wasm_gc {
+        command.arg("--wasm-gc");
+    }
+    if !packed {
+        command.env("AVER_NO_PACKED_SEQUENCES", "1");
+    }
+    let output = command.output().expect("run aver");
+    let _ = std::fs::remove_dir_all(dir);
+    (
+        output.status.success(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .trim()
+        .to_string(),
+    )
+}
+
+fn compile(source: &str, packed: bool) -> Vec<u8> {
+    let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "aver-packed-sequence-compile-{}-{id}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("main.av");
+    let out_dir = dir.join("out");
+    std::fs::write(&path, source).expect("source");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver"));
+    command
+        .arg("compile")
+        .arg(&path)
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("-o")
+        .arg(&out_dir);
+    if !packed {
+        command.env("AVER_NO_PACKED_SEQUENCES", "1");
+    }
+    let output = command.output().expect("compile aver");
+    assert!(
+        output.status.success(),
+        "compile failed: {}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let wasm = std::fs::read(out_dir.join("main.wasm")).expect("compiled wasm");
+    let _ = std::fs::remove_dir_all(dir);
+    wasm
+}
+
+fn i8_array_count(wasm: &[u8]) -> usize {
+    use wasmparser::{CompositeInnerType, Parser, Payload, StorageType};
+
+    Parser::new(0)
+        .parse_all(wasm)
+        .filter_map(Result::ok)
+        .filter_map(|payload| match payload {
+            Payload::TypeSection(reader) => Some(reader),
+            _ => None,
+        })
+        .flat_map(|reader| reader.into_iter().filter_map(Result::ok))
+        .flat_map(|group| group.into_types())
+        .filter(|sub| {
+            matches!(
+                &sub.composite_type.inner,
+                CompositeInnerType::Array(array)
+                    if matches!(array.0.element_type, StorageType::I8)
+            )
+        })
+        .count()
+}
+
+const OCTETS: &str = r#"module M
+    intent = "generic packed sequence"
+    effects [Console]
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+
+fn toList(value: Octets) -> List<Int>
+    value.values
+
+fn same(left: Octets, right: Octets) -> Bool
+    left == right
+
+fn main() -> Unit
+    ! [Console.print]
+    match fromList([0, 1, 127, 128, 255])
+        Result.Ok(value) -> match Vector.get(Vector.fromList([value]), 0)
+            Option.Some(first) -> match Map.get(Map.set({}, "value", first), "value")
+                Option.Some(stored) -> match Map.get(Map.set({}, stored, "present"), value)
+                    Option.Some(_) -> match same(stored, value)
+                        true -> Console.print("{List.len(toList(stored))}")
+                        false -> Console.print("bad equality")
+                    Option.None -> Console.print("missing map key")
+                Option.None -> Console.print("missing map value")
+            Option.None -> Console.print("missing value")
+        Result.Err(error) -> Console.print(error)
+"#;
+
+const BYPASSED_OCTETS: &str = r#"module M
+    intent = "an ungated constructor must demote the packed representation"
+    effects [Console]
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+
+fn bypass(xs: List<Int>) -> Octets
+    Octets(values = xs)
+
+fn main() -> Unit
+    ! [Console.print]
+    value = bypass([256])
+    match value.values
+        [head, .._] -> Console.print("{head}")
+        [] -> Console.print("empty")
+"#;
+
+#[test]
+fn generic_u8_refinement_matches_vm_and_boxed_wasm() {
+    let (vm_ok, vm) = run(OCTETS, false, true);
+    let (packed_ok, packed) = run(OCTETS, true, true);
+    let (boxed_ok, boxed) = run(OCTETS, true, false);
+    assert!(vm_ok, "VM failed: {vm}");
+    assert!(packed_ok, "packed wasm failed: {packed}");
+    assert!(boxed_ok, "boxed wasm failed: {boxed}");
+    assert_eq!(packed, vm);
+    assert_eq!(boxed, vm);
+    assert_eq!(vm, "5");
+
+    let packed_wasm = compile(OCTETS, true);
+    let boxed_wasm = compile(OCTETS, false);
+    assert_eq!(
+        i8_array_count(&packed_wasm),
+        i8_array_count(&boxed_wasm) + 1,
+        "the proof-derived layout must add one packed i8 array"
+    );
+}
+
+#[test]
+fn ungated_constructor_demotes_instead_of_truncating() {
+    let (vm_ok, vm) = run(BYPASSED_OCTETS, false, true);
+    let (wasm_ok, wasm) = run(BYPASSED_OCTETS, true, true);
+    assert!(vm_ok, "VM failed: {vm}");
+    assert!(wasm_ok, "wasm failed: {wasm}");
+    assert_eq!(wasm, vm);
+    assert_eq!(vm, "256");
+}


### PR DESCRIPTION
Follow-up to #786.

## Summary
- derive a packed integer layout from the existing refinement-via-opaque proof shape for canonical `List<Int>` carriers; `Bytes` becomes an `(array (mut i8))` without a name-based compiler special case
- preserve the packed nominal representation through `Result`, `List`, `Vector`, and both Map keys and values, including structural equality and hashing
- bridge the packed representation through pure SHA-256, hosted wasm-gc TCP, and WASI 0.2 TCP while retaining the boxed differential fallback
- fail closed to the ordinary record/List representation when construction bypasses the recognized smart constructor
- add a CI differential that compares VM, packed wasm-gc, and boxed wasm-gc and asserts the extra packed i8 array exists in the emitted type section

## Validation
- `cargo clippy -p aver-lang --lib --bin aver --features wasm,wasip2 -- -D warnings`
- `cargo test -p aver-lang --lib --features wasm,wasip2` (1011 passed)
- `cargo test -p aver-lang --features wasm --test wasm_gc_packed_sequence`
- `cargo test -p aver-lang --features wasm --test wasm_gc_spec` (37 passed)
- `cargo test -p aver-lang --features wasm --test wasm_gc_codegen_regression`
- `PROPTEST_CASES=64 cargo test -p aver-lang --features wasm --test cross_backend_proptest`
- `cargo test -p aver-lang --features wasm --test cross_backend_stress`
- `cargo test -p aver-lang --features wasm --test wasm_gc_effect_arg_overflow_regression`
- `cargo test -p aver-lang --features wasm embedded_crypto_sha256_matches_fips_vectors_on_wasm_gc --test stdlib_spec` (13/13 verify cases)
- `cargo test -p aver-lang --features wasm,wasip2 --test wasip2_codegen_regression`
- `cargo test -p aver-lang --features wasm,wasip2 --test wasip2_tcp`