### PR TITLE
Resolve packed sequence layouts by exact type name

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -149,18 +149,14 @@ impl FnMap {
         }
     }
 
+    /// Exact-name lookup only — no qualified→bare fallback, mirroring
+    /// `TypeRegistry::packed_sequence`. A bare-name fallback would route
+    /// a collision-renamed dep type through an unrelated packed helper.
     pub(super) fn packed_sequence_ops_lookup(
         &self,
         type_name: &str,
     ) -> Option<super::packed_sequences::PackedSequenceOps> {
-        self.packed_sequence_ops
-            .get(type_name)
-            .copied()
-            .or_else(|| {
-                type_name
-                    .rsplit_once('.')
-                    .and_then(|(_, bare)| self.packed_sequence_ops.get(bare).copied())
-            })
+        self.packed_sequence_ops.get(type_name).copied()
     }
 
     pub(super) fn map_helpers_lookup(&self, canonical: &str) -> Option<&super::maps::MapKVHelpers> {

--- a/src/codegen/wasm_gc/packed_sequences.rs
+++ b/src/codegen/wasm_gc/packed_sequences.rs
@@ -53,12 +53,11 @@ impl PackedSequenceHelperRegistry {
         }
     }
 
+    /// Exact-name lookup only — no qualified→bare fallback, mirroring
+    /// `TypeRegistry::packed_sequence`. A bare-name fallback would route
+    /// a collision-renamed dep type through an unrelated pack/unpack pair.
     pub(super) fn ops_for(&self, type_name: &str) -> Option<PackedSequenceOps> {
-        self.ops.get(type_name).copied().or_else(|| {
-            type_name
-                .rsplit_once('.')
-                .and_then(|(_, bare)| self.ops.get(bare).copied())
-        })
+        self.ops.get(type_name).copied()
     }
 
     pub(super) fn iter(&self) -> impl Iterator<Item = (&str, PackedSequenceOps)> + '_ {

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -1408,7 +1408,8 @@ impl TypeRegistry {
     /// ETAP-2 carrier-`i64`: install the set of refinement-via-opaque
     /// carrier type names whose proven bound `fits_i64`. Called once by the
     /// wasm-gc codegen entry after it derives the carrier interval table.
-    /// Keyed by bare Aver name (`"IntRange"`).
+    /// Keyed by post-flatten `TypeDef` name (`"IntRange"`, or the canonical
+    /// `"Left.IntRange"` for a collision-renamed dep type).
     pub(super) fn set_eligible_carriers(&mut self, names: std::collections::HashSet<String>) {
         self.eligible_carriers = names;
     }
@@ -1433,32 +1434,39 @@ impl TypeRegistry {
         }
     }
 
+    /// Exact-name lookup only — NO qualified→bare fallback. The layout
+    /// table keys are post-flatten `TypeDef` names (bare for entry and
+    /// non-colliding dep types, canonical `Prefix.Name` for collision-
+    /// renamed dep types), and both the collision guard and the ungated-
+    /// construction demotion scan match those names exactly. A bare-name
+    /// fallback here would hand a collision-renamed dep type (`Left.Octets`)
+    /// the packed layout of an unrelated bare-named gated type (`Octets`),
+    /// letting an ungated record silently truncate through `pack`.
     pub(super) fn packed_sequence(&self, type_name: &str) -> Option<PackedSequenceType> {
-        let trimmed = type_name.trim();
-        self.packed_sequences.get(trimmed).copied().or_else(|| {
-            trimmed
-                .rsplit_once('.')
-                .and_then(|(_, bare)| self.packed_sequences.get(bare).copied())
-        })
+        self.packed_sequences.get(type_name.trim()).copied()
     }
 
-    /// ETAP-2 carrier-`i64`: is `type_name` (bare or `Module.`-qualified) a
-    /// carrier whose erasure should be a native `i64`? A carrier in the
-    /// eligible set is ALSO a newtype (single-field opaque record of `Int`),
-    /// so `newtype_underlying` already returns `Some("Int")` for it — this
-    /// just decides whether that erasure becomes `i64` or stays `$AverInt`.
+    /// ETAP-2 carrier-`i64`: is `type_name` a carrier whose erasure should be
+    /// a native `i64`? A carrier in the eligible set is ALSO a newtype
+    /// (single-field opaque record of `Int`), so `newtype_underlying` already
+    /// returns `Some("Int")` for it — this just decides whether that erasure
+    /// becomes `i64` or stays `$AverInt`. Exact-name lookup only, matching the
+    /// post-flatten `TypeDef` name the interval table and the demotion scans
+    /// key on — a qualified→bare fallback would let a collision-renamed dep
+    /// type (`Left.IntRange`) inherit an unrelated carrier's i64 erasure and
+    /// trap on values only the bignum representation can hold.
     pub(super) fn is_eligible_carrier(&self, type_name: &str) -> bool {
         if self.eligible_carriers.is_empty() {
             return false;
         }
-        let bare = type_name.rsplit_once('.').map_or(type_name, |(_, b)| b);
-        self.eligible_carriers.contains(bare.trim())
+        self.eligible_carriers.contains(type_name.trim())
     }
 
     /// ETAP-2 multi-field carrier-`i64`: install the eligible `(record, field)`
     /// pairs whose proven bound `fits_i64`. Called once by the wasm-gc codegen
     /// entry after it derives + demotion-tightens the multi-field carrier table.
-    /// Keyed by bare record name + field name (`("Coord", "x")`).
+    /// Keyed by post-flatten record `TypeDef` name + field name
+    /// (`("Coord", "x")`).
     pub(super) fn set_eligible_carrier_fields(
         &mut self,
         fields: std::collections::HashSet<(String, String)>,
@@ -1467,18 +1475,14 @@ impl TypeRegistry {
     }
 
     /// ETAP-2 multi-field carrier-`i64`: is `(record_name, field)` a bounded
-    /// record field whose storage should be a native `i64`? `record_name` may
-    /// be bare or `Module.`-qualified; the field name is exact.
+    /// record field whose storage should be a native `i64`? Exact-name lookup
+    /// only, for the same reason as `is_eligible_carrier`.
     pub(super) fn is_eligible_carrier_field(&self, record_name: &str, field: &str) -> bool {
         if self.eligible_carrier_fields.is_empty() {
             return false;
         }
-        let bare = record_name
-            .rsplit_once('.')
-            .map_or(record_name, |(_, b)| b)
-            .trim();
         self.eligible_carrier_fields
-            .contains(&(bare.to_string(), field.to_string()))
+            .contains(&(record_name.trim().to_string(), field.to_string()))
     }
 
     pub(super) fn newtype_underlying(&self, type_name: &str) -> Option<&str> {

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -294,11 +294,13 @@ impl FnBareFacts {
         base: &Spanned<MirExpr>,
         field: &str,
     ) -> Option<Interval> {
+        // Exact-name lookup only — the table is keyed by post-flatten
+        // `TypeDef` names, and a qualified→bare fallback would hand a
+        // collision-renamed dep record an unrelated type's bounded-field fact.
         let name = base.ty().and_then(Type::named_name)?;
-        let bare = name.rsplit_once('.').map_or(name, |(_, b)| b);
         let (iv, known) = self
             .field_carrier_intervals
-            .get(&(bare.to_string(), field.to_string()))
+            .get(&(name.to_string(), field.to_string()))
             .copied()?;
         (known && iv.fits_i64()).then_some(iv)
     }
@@ -316,9 +318,10 @@ impl FnBareFacts {
         if !matches!(base.node, MirExpr::Project(_)) {
             return None;
         }
+        // Exact-name lookup only — same rationale as
+        // `field_carrier_field_interval`.
         let name = base.ty().and_then(Type::named_name)?;
-        let bare = name.rsplit_once('.').map_or(name, |(_, b)| b);
-        let (iv, known) = self.carrier_types.get(bare).copied()?;
+        let (iv, known) = self.carrier_types.get(name).copied()?;
         (known && iv.fits_i64()).then_some(iv)
     }
 

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -428,6 +428,70 @@ record Box
     );
 }
 
+// Packed-sequence layouts must resolve by EXACT type name. The entry
+// module's gated `Octets` refinement earns a packed u8 layout; two dep
+// modules declare plain ungated `record Octets { values: List<Int> }`
+// records whose bare name collides, so flatten renames them to
+// `Left.Octets` / `Right.Octets`. Those renamed records are unrelated
+// to the refinement and must keep the ordinary boxed representation.
+// A qualified→bare fallback in the packed lookups would hand
+// `Left.Octets` the entry refinement's u8 layout, and the ungated
+// construct below would silently truncate 1000 to 1000 mod 256 = 232.
+#[test]
+fn cross_module_same_bare_name_record_does_not_inherit_packed_layout() {
+    let entry_src = r#"
+module Entry
+    intent = "packed layout must not leak to same-bare-name dep types"
+    depends [Left, Right]
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+
+fn main() -> Int
+    plain = Left.Octets(values = [1000])
+    match plain.values
+        [head, .._] -> head
+        [] -> 0
+"#;
+    let left_src = r#"
+module Left
+    intent = "plain record sharing the refinement's bare name"
+    exposes [Octets]
+    depends []
+
+record Octets
+    values: List<Int>
+"#;
+    let right_src = r#"
+module Right
+    intent = "second declarer forcing the bare-name collision rename"
+    exposes [Octets]
+    depends []
+
+record Octets
+    values: List<Int>
+"#;
+    let result = run_int_multi(entry_src, &[("Left", left_src), ("Right", right_src)]);
+    assert_eq!(
+        result, 1000,
+        "expected the ungated Left.Octets record to stay boxed and return \
+         1000; 232 means it inherited the entry refinement's packed u8 \
+         layout through a qualified→bare name fallback and truncated"
+    );
+}
+
 // ────────────────────────────────────────────────────────────────────
 // List<T>
 // ────────────────────────────────────────────────────────────────────
@@ -1195,5 +1259,60 @@ fn main() -> Int
 "#
         ),
         -1
+    );
+}
+// Scalar sibling of the packed-sequence exact-name test above: the
+// carrier-i64 eligibility lookups must also resolve by EXACT type name.
+// The entry module's gated `IntRange` carrier earns i64 erasure; the
+// collision-renamed `Left.IntRange` / `Right.IntRange` dep records are
+// unrelated plain records and must stay boxed (`$AverInt`). A
+// qualified→bare fallback would erase `Left.IntRange` to i64 and the
+// beyond-i64 construct below would trap in `__aint_to_i64_checked`
+// instead of round-tripping through the bignum representation.
+#[test]
+fn cross_module_same_bare_name_record_does_not_inherit_carrier_i64_erasure() {
+    let entry_src = r#"
+module Entry
+    intent = "carrier i64 erasure must not leak to same-bare-name dep types"
+    depends [Left, Right]
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+
+fn main() -> Int
+    plain = Left.IntRange(value = 10000000000000000000)
+    match plain.value == 10000000000000000000
+        true -> 1
+        false -> 0
+"#;
+    let left_src = r#"
+module Left
+    intent = "plain record sharing the carrier's bare name"
+    exposes [IntRange]
+    depends []
+
+record IntRange
+    value: Int
+"#;
+    let right_src = r#"
+module Right
+    intent = "second declarer forcing the bare-name collision rename"
+    exposes [IntRange]
+    depends []
+
+record IntRange
+    value: Int
+"#;
+    let result = run_int_multi(entry_src, &[("Left", left_src), ("Right", right_src)]);
+    assert_eq!(
+        result, 1,
+        "expected the plain Left.IntRange record to stay boxed and hold a \
+         beyond-i64 Int; a trap or 0 means it inherited the entry carrier's \
+         i64 erasure through a qualified→bare name fallback"
     );
 }


### PR DESCRIPTION
## Problem

The wasm-gc packed sequence lookups (`TypeRegistry::packed_sequence` in `src/codegen/wasm_gc/types.rs`, `packed_sequence_ops_lookup` in `src/codegen/wasm_gc/body.rs`, `PackedSequenceHelperRegistry::ops_for` in `src/codegen/wasm_gc/packed_sequences.rs`, introduced in #790) fell back to the bare last name segment when the exact key missed. The packed layout table (`packed_sequence_layout_table`) guards bare-name collisions via `ambiguous_names`, and the ungated-construction demotion scan matches names exactly — but the qualified-to-bare fallback sidestepped both guards.

Concrete failing example: the entry module declares a gated packed refinement candidate `Octets` (single `values: List<Int>` field, smart constructor gated by an all-in-`[0, 255]` predicate); dep modules `Left` and `Right` each declare a plain ungated `record Octets { values: List<Int> }`. The bare-name collision makes the multi-module flatten rename the dep records to `Left.Octets` / `Right.Octets`. The fallback then resolved `Left.Octets` to the entry refinement's packed u8 layout, so

```
plain = Left.Octets(values = [1000])
```

went through the pack helper and the packed run returned `232` (1000 mod 256) while `AVER_NO_PACKED_SEQUENCES=1` returned `1000` — silent truncation, no trap.

The scalar carrier-i64 path had the same hole: `is_eligible_carrier` / `is_eligible_carrier_field` (`src/codegen/wasm_gc/types.rs`) and the two projection-interval lookups in `src/ir/mir/optimize/bare_i64.rs` stripped qualified names to the bare segment. A collision-renamed plain record (`Left.IntRange`) inherited an unrelated gated carrier's i64 erasure and `Left.IntRange(value = 10000000000000000000)` trapped in `__aint_to_i64_checked` on the wasm path instead of round-tripping through the bignum representation (verified with the same two-dep repro shape).

## Fix

Exact-name matching only: remove the qualified-to-bare fallback from all of the lookup sites above. The layout / eligibility tables are keyed by post-flatten `TypeDef` names (bare for entry and non-colliding dep types, canonical `Prefix.Name` for collision-renamed dep types), and the collision guard plus the demotion scans match those names exactly, so lookups must too. A miss now keeps the ordinary boxed representation — the fail-closed direction. No alias registration turned out to be needed: every legitimate resolution site already sees the exact post-flatten name (the full wasm-gc, packed-sequence, carrier-i64 differential, stdlib Bytes, and Rust codegen differential suites pass unchanged).

## Tests

- New regression tests in `tests/wasm_gc_spec.rs` (multi-module harness): `cross_module_same_bare_name_record_does_not_inherit_packed_layout` (asserts `1000`, was `232`) and `cross_module_same_bare_name_record_does_not_inherit_carrier_i64_erasure` (asserts the beyond-i64 value survives, was a trap). Both reproduced the bug before the fix.
- `cargo test --features wasm --test wasm_gc_spec` — 39 passed
- `cargo test --features wasm --test wasm_gc_packed_sequence --test wasm_gc_codegen_regression --test stdlib_spec` — 12 passed
- `cargo test --features wasm --test wasm_gc_carrier_i64_differential` — 82 passed
- `cargo test --features wasm --lib bare_i64` — 43 passed; `--lib packed_sequence` — 4 passed
- `cargo test --test rust_codegen_differential` — 15 passed, 9 ignored
- `cargo fmt`, `cargo clippy --features wasm,wasip2` — no findings in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)