### PR TITLE
Escape Lean reserved tokens in type and module names

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -75,6 +75,14 @@ jobs:
           echo "::error::lake unreachable after 6 attempts (toolchain download)"
           exit 1
 
+      - name: Check reserved-token snapshot against pinned Lean
+        # The guard test in src/codegen/lean/syntax.rs asks the pinned Lean
+        # toolchain for its token table and fails when the LEAN_RESERVED
+        # snapshot is missing entries. It silently skips when `lean` is not
+        # on PATH, and no other lane runs the lib tests with Lean installed —
+        # this job is the only place the tripwire can actually fire.
+        run: cargo test -p aver-lang --lib -- reserved_snapshot_covers_pinned_lean_token_table
+
       - name: Install Dafny
         # Manual download of the self-contained (62 MB — bundles its own
         # .NET runtime and Z3) Dafny release zip, replacing

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -1,7 +1,6 @@
 /// Aver expressions → Lean 4 expression strings.
 use super::builtins;
 use super::pattern::emit_pattern;
-use super::shared::to_lower_first;
 pub(crate) use super::syntax::{aver_name_to_lean, lean_name_to_aver};
 use crate::ast::{BinOp, Literal, Spanned};
 use crate::codegen::CodegenContext;
@@ -64,7 +63,11 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
                 }
                 // User-defined type variant access: Shape.Point
                 if is_user_type(type_name, ctx) {
-                    return format!("{}.{}", type_name, to_lower_first(field));
+                    return format!(
+                        "{}.{}",
+                        aver_name_to_lean(type_name),
+                        super::syntax::lean_ctor_name(field)
+                    );
                 }
             }
             // Check module-qualified reference
@@ -75,12 +78,16 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
                     let type_name = &bare[..dot_pos];
                     let variant = &bare[dot_pos + 1..];
                     if is_user_type(type_name, ctx) {
-                        return format!("{}.{}", type_name, to_lower_first(variant));
+                        return format!(
+                            "{}.{}",
+                            aver_name_to_lean(type_name),
+                            super::syntax::lean_ctor_name(variant)
+                        );
                     }
                 }
                 let bare_lean = aver_name_to_lean(bare);
                 if !ctx.modules.is_empty() {
-                    return format!("{}.{}", prefix, bare_lean);
+                    return format!("{}.{}", super::syntax::aver_path_to_lean(prefix), bare_lean);
                 }
                 return bare_lean;
             }
@@ -350,7 +357,11 @@ fn emit_fn_call(
             let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
             let func = match module_prefix {
                 Some(prefix) if !ctx.modules.is_empty() => {
-                    format!("{}.{}", prefix, aver_name_to_lean(bare))
+                    format!(
+                        "{}.{}",
+                        super::syntax::aver_path_to_lean(prefix),
+                        aver_name_to_lean(bare)
+                    )
                 }
                 _ => aver_name_to_lean(bare),
             };
@@ -417,8 +428,10 @@ fn emit_constructor(
                 };
             }
             // User ctor: `Type.variant` in Lean. Lean convention is
-            // lowercase variant names; type stays as written.
-            let variant = to_lower_first(name);
+            // lowercase variant names; both segments pass through the
+            // reserved-token guard (`Type` / `Match` are legal Aver names).
+            let type_name = super::syntax::aver_path_to_lean(&type_name);
+            let variant = super::syntax::lean_ctor_name(name);
             let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
             if arg_strs.is_empty() {
                 format!("{}.{}", type_name, variant)

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -11,7 +11,7 @@
 use std::collections::BTreeSet;
 
 use super::super::expr::aver_name_to_lean;
-use super::super::shared::to_lower_first;
+use super::super::syntax::lean_ctor_name;
 use super::super::tactic_ir::{InductionArm, Tactic};
 use super::AutoProof;
 use super::shared::law_simp_defs;
@@ -4731,7 +4731,7 @@ fn emit_simple_induction(
         let lean_variant = match &peano {
             Some(p) if variant.name == p.base_ctor => "zero".to_string(),
             Some(p) if variant.name == p.succ_ctor => "succ".to_string(),
-            _ => to_lower_first(&variant.name),
+            _ => lean_ctor_name(&variant.name),
         };
         let field_binders: Vec<String> = (0..variant.fields.len())
             .map(|index| format!("f{}", index))

--- a/src/codegen/lean/law_auto/suffix_roundtrip.rs
+++ b/src/codegen/lean/law_auto/suffix_roundtrip.rs
@@ -73,13 +73,18 @@ fn lean_str(s: &str) -> String {
 }
 
 /// Source ctor name (`ParseResult.Ok`) → Lean ctor name
-/// (`ParseResult.ok`) — Lean convention lowercases the variant leaf.
+/// (`ParseResult.ok`) — Lean convention lowercases the variant leaf;
+/// both segments pass through the reserved-token guard.
 fn lean_ctor(name: &str) -> String {
     match name.rsplit_once('.') {
         Some((ty, variant)) => {
-            format!("{}.{}", ty, crate::codegen::common::to_lower_first(variant))
+            format!(
+                "{}.{}",
+                crate::codegen::lean::syntax::aver_path_to_lean(ty),
+                crate::codegen::lean::syntax::lean_ctor_name(variant)
+            )
         }
-        None => crate::codegen::common::to_lower_first(name),
+        None => crate::codegen::lean::syntax::lean_ctor_name(name),
     }
 }
 

--- a/src/codegen/lean/law_auto/transparent_chain.rs
+++ b/src/codegen/lean/law_auto/transparent_chain.rs
@@ -399,7 +399,9 @@ fn resolve_fn_for_call<'a>(
         return Some(ResolvedFn {
             fd,
             scope: Some(prefix.to_string()),
-            lean_name: aver_name_to_lean(&format!("{prefix}.{short}")),
+            lean_name: crate::codegen::lean::syntax::aver_path_to_lean(&format!(
+                "{prefix}.{short}"
+            )),
         });
     }
 
@@ -412,7 +414,10 @@ fn resolve_fn_for_call<'a>(
         return Some(ResolvedFn {
             fd,
             scope: Some(scope.to_string()),
-            lean_name: aver_name_to_lean(&format!("{scope}.{}", fd.name)),
+            lean_name: crate::codegen::lean::syntax::aver_path_to_lean(&format!(
+                "{scope}.{}",
+                fd.name
+            )),
         });
     }
 

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -13,7 +13,6 @@ mod pattern;
 mod prelude;
 pub(crate) mod recurrence;
 mod sample_literal;
-mod shared;
 mod syntax;
 pub mod tactic_ir;
 #[cfg(test)]

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -193,7 +193,11 @@ fn verify_counter_key(vb: &crate::ast::VerifyBlock) -> String {
 }
 
 fn lean_project_name(ctx: &CodegenContext) -> String {
-    crate::codegen::common::entry_basename(ctx)
+    // The entry module name is a Lean surface like any other: an entry named
+    // `Type` must emit `Type'.lean` with a matching lakefile root, or every
+    // Lean-source reference to the root (the `--check` audit probes' `import`
+    // lines, cert model imports) hits `unexpected token 'Type'`.
+    syntax::aver_path_to_lean(&crate::codegen::common::entry_basename(ctx))
 }
 
 pub(super) fn bound_expr_to_lean(expr: &Spanned<crate::ir::hir::ResolvedExpr>) -> String {

--- a/src/codegen/lean/pattern.rs
+++ b/src/codegen/lean/pattern.rs
@@ -1,5 +1,4 @@
 /// Aver patterns → Lean 4 pattern strings.
-use super::shared::to_lower_first;
 use crate::ast::Literal;
 use crate::codegen::CodegenContext;
 use crate::codegen::proof_recognize::{PeanoCtor, peano_ctor_role};
@@ -87,13 +86,14 @@ fn emit_ctor_pattern(ctor: &ResolvedCtor, bindings: &[String], ctx: &CodegenCont
         }
         ResolvedCtor::Builtin(BuiltinCtor::OptionNone) => ".none".to_string(),
         ResolvedCtor::User { name, .. } => {
-            // Lean convention: lowercase constructor names. The
-            // `name` field of `ResolvedCtor::User` is the bare
-            // variant name (e.g. `"Point"` for `Shape.Point`); the
-            // owning type's emit context already namespaces the
-            // ctor at the call site, so no qualified-name handling
-            // is needed here.
-            let lean_variant = to_lower_first(name);
+            // Lean convention: lowercase constructor names (with the
+            // reserved-token guard — a variant `Match` lowers to the
+            // reserved `match`). The `name` field of
+            // `ResolvedCtor::User` is the bare variant name (e.g.
+            // `"Point"` for `Shape.Point`); the owning type's emit
+            // context already namespaces the ctor at the call site,
+            // so no qualified-name handling is needed here.
+            let lean_variant = super::syntax::lean_ctor_name(name);
             if bindings.is_empty() {
                 format!(".{}", lean_variant)
             } else {

--- a/src/codegen/lean/shared.rs
+++ b/src/codegen/lean/shared.rs
@@ -1,4 +1,0 @@
-/// Convert first character to lowercase.
-pub(super) fn to_lower_first(s: &str) -> String {
-    crate::codegen::common::to_lower_first(s)
-}

--- a/src/codegen/lean/syntax.rs
+++ b/src/codegen/lean/syntax.rs
@@ -3,8 +3,9 @@
 //! Lean distinguishes identifier-shaped syntax tokens from ordinary
 //! identifiers. Emitting an Aver function named `at`, `using`, or `exists`
 //! verbatim therefore produces a parse error. The test below asks the pinned
-//! Lean executable for its own token table, so a toolchain upgrade fails loudly
-//! when this snapshot needs to grow.
+//! Lean toolchain (resolved via a `lean-toolchain` file matching the one
+//! emitted proof projects carry) for its own token table, so a toolchain
+//! upgrade fails loudly when this snapshot needs to grow.
 
 /// Identifier-shaped syntax tokens registered by `import Lean` in Lean 4.32,
 /// plus global declarations whose bare names are ambiguous in generated code.
@@ -233,6 +234,25 @@ pub(crate) fn aver_name_to_lean(name: &str) -> String {
     crate::codegen::common::escape_reserved_word(name, LEAN_RESERVED, "'")
 }
 
+/// Escape every `.`-segment of a qualified module/type path — the
+/// reserved list carries identifier-shaped PascalCase tokens (`Type`,
+/// `Prop`, `Sort`) that Aver accepts as type and module names, so a
+/// dotted path like `Models.Type` must escape per segment
+/// (`Models.Type'`). Identity for paths without reserved segments.
+pub(crate) fn aver_path_to_lean(path: &str) -> String {
+    path.split('.')
+        .map(aver_name_to_lean)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+/// Lean constructor spelling for an Aver variant name: the usual
+/// lowercase-first convention plus the reserved-token guard — an Aver
+/// variant `Match` lowers to `match`, which Lean reserves.
+pub(crate) fn lean_ctor_name(variant: &str) -> String {
+    aver_name_to_lean(&crate::codegen::common::to_lower_first(variant))
+}
+
 /// Strip the trailing keyword guard for the `--explain` un-translator.
 pub(crate) fn lean_name_to_aver(name: &str) -> String {
     if let Some(base) = name.strip_suffix('\'')
@@ -274,11 +294,21 @@ mod tests {
 
     #[test]
     fn reserved_snapshot_covers_pinned_lean_token_table() {
-        let mut probe = tempfile::Builder::new()
+        // Probe dir carries the same `lean-toolchain` pin as emitted proof
+        // projects, so elan resolves the PINNED toolchain rather than the
+        // ambient default — the snapshot is checked against the Lean version
+        // the generated code actually builds with.
+        let probe_dir = tempfile::Builder::new()
             .prefix("aver-lean-reserved-")
-            .suffix(".lean")
-            .tempfile()
-            .expect("create Lean token probe");
+            .tempdir()
+            .expect("create Lean token probe dir");
+        std::fs::write(
+            probe_dir.path().join("lean-toolchain"),
+            super::super::prelude::generate_toolchain(),
+        )
+        .expect("write probe lean-toolchain");
+        let probe_path = probe_dir.path().join("probe.lean");
+        let mut probe = std::fs::File::create(&probe_path).expect("create Lean token probe");
         probe
             .write_all(
                 br##"import Lean
@@ -296,8 +326,13 @@ elab "#aver_reserved_tokens" : command => do
 "##,
             )
             .expect("write Lean token probe");
+        drop(probe);
 
-        let output = match Command::new("lean").arg(probe.path()).output() {
+        let output = match Command::new("lean")
+            .arg(&probe_path)
+            .current_dir(probe_dir.path())
+            .output()
+        {
             Ok(output) => output,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
             Err(error) => panic!("run Lean token probe: {error}"),

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -2373,6 +2373,52 @@ fn proof_mode_when_equivalent_to_refinement_invariant_drops_cleanly() {
 }
 
 #[test]
+fn proof_mode_refinement_lift_escapes_reserved_type_binder() {
+    // The refinement-lift quantifier binder interpolated the IR's canonical
+    // refined-type key as raw Lean type text. A refined record named `Type`
+    // (legal Aver — the lexer reserves only lowercase keywords) then emitted
+    // `∀ (a : Type), …` against a declaration escaped to `Type'`, so the
+    // theorem referenced Lean's `Type` sort instead of the record. The
+    // binder must route through the same spelling helper as every other
+    // type reference.
+    let src = "module Lift\n\
+             \x20   intent = \"t\"\n\
+             \n\
+             record Type\n\
+             \x20   value: Int\n\
+             \n\
+             fn fromInt(n: Int) -> Result<Type, String>\n\
+             \x20   match n >= 0\n\
+             \x20       true  -> Result.Ok(Type(value = n))\n\
+             \x20       false -> Result.Err(\"must be >= 0\")\n\
+             \n\
+             fn identity(a: Type) -> Type\n\
+             \x20   a\n\
+             \n\
+             verify identity law selfEq\n\
+             \x20   given a: Int = [0, 1, 2]\n\
+             \x20   when a >= 0\n\
+             \x20   identity(Type(value = a)) => identity(Type(value = a))\n";
+    let mut ctx = ctx_from_source(src, "lift");
+    let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
+    let lean = generated_lean_file(&out);
+    let universal_theorem = lean
+        .lines()
+        .find(|l| l.contains("theorem identity_law_selfEq"))
+        .unwrap_or_else(|| panic!("expected universal theorem line, got:\n{}", lean));
+    assert!(
+        universal_theorem.contains("∀ (a : Type')"),
+        "refinement-lifted binder must escape the reserved type name, got:\n{}",
+        universal_theorem
+    );
+    assert!(
+        !universal_theorem.contains("(a : Type)"),
+        "the raw reserved-token binder must not survive, got:\n{}",
+        universal_theorem
+    );
+}
+
+#[test]
 fn proof_mode_non_zero_base_literal_falls_back_to_fuel() {
     // Conservative guard: native IntCountdownGuarded emit assumes
     // the aux's default `(h_dom : p ≥ 0)` precondition, under

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -374,6 +374,75 @@ verify addOne
 }
 
 #[test]
+fn reserved_lean_tokens_as_type_names_are_escaped() {
+    // `Type` / `Prop` are legal Aver type names (the lexer reserves only
+    // lowercase keywords) but Lean syntax tokens — declarations AND every
+    // reference (signatures, match subjects, ctor spellings) must carry the
+    // trailing-quote guard. A variant named `Match` lowers to Lean's
+    // reserved `match` and needs the same guard.
+    let mut ctx = ctx_from_source(
+        r#"
+module Reserved
+    intent = "Reserved Lean tokens as user type names."
+
+type Type
+    Scalar
+    Match
+    Vector(Int)
+
+record Prop
+    value: Int
+
+fn describe(t: Type) -> Int
+    match t
+        Type.Scalar -> 0
+        Type.Match -> 1
+        Type.Vector(n) -> n
+
+fn propValue(p: Prop) -> Int
+    p.value
+
+fn mkMatch() -> Type
+    Type.Match
+"#,
+        "reserved",
+    );
+    let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
+    let lean = generated_lean_file(&out);
+
+    assert!(
+        lean.contains("inductive Type' where"),
+        "sum type named `Type` must escape its declaration:\n{}",
+        lean
+    );
+    assert!(
+        lean.contains("structure Prop' where"),
+        "record named `Prop` must escape its declaration:\n{}",
+        lean
+    );
+    assert!(
+        lean.contains("(t : Type')") && lean.contains("(p : Prop')"),
+        "signature references to reserved type names must escape:\n{}",
+        lean
+    );
+    assert!(
+        lean.contains("| match'"),
+        "variant `Match` lowers to reserved `match` and must escape:\n{}",
+        lean
+    );
+    assert!(
+        lean.contains("Type'.match'"),
+        "constructor references must escape both segments:\n{}",
+        lean
+    );
+    assert!(
+        !lean.contains("inductive Type where") && !lean.contains("structure Prop where"),
+        "raw reserved declarations must not survive:\n{}",
+        lean
+    );
+}
+
+#[test]
 fn transpile_emits_native_decide_for_verify_by_default() {
     let mut ctx = empty_ctx_with_verify_case();
     let out = transpile(&mut ctx);

--- a/src/codegen/lean/toplevel/mod.rs
+++ b/src/codegen/lean/toplevel/mod.rs
@@ -22,8 +22,8 @@ pub use verify::{emit_decision, emit_verify_block};
 // paths keep resolving exactly as they did when this was a single file.
 pub(super) use super::{
     LAW_CLASS_BOUNDED_DOMAIN, LAW_CLASS_MARKER_PREFIX, LAW_CLASS_UNIVERSAL, VerifyEmitMode,
-    bound_expr_to_lean, expr, law_auto, recurrence, sample_literal, shared,
-    sizeof_measure_param_indices, types,
+    bound_expr_to_lean, expr, law_auto, recurrence, sample_literal, sizeof_measure_param_indices,
+    syntax, types,
 };
 
 /// Check if a sum type is self-referencing (any variant field mentions the type name).

--- a/src/codegen/lean/toplevel/type_def.rs
+++ b/src/codegen/lean/toplevel/type_def.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use super::expr::aver_name_to_lean;
-use super::shared::to_lower_first;
+use super::syntax::lean_ctor_name;
 use super::types::type_annotation_to_lean;
 use super::{is_recursive_product, is_recursive_type};
 use crate::ast::*;
@@ -49,15 +49,16 @@ pub fn emit_inhabited_instance(td: &TypeDef, ctx: &CodegenContext, scope: Option
             let Some(first) = variants.first() else {
                 return String::new();
             };
+            let lean_name = aver_name_to_lean(name);
             let nullary = variants.iter().find(|v| v.fields.is_empty());
             let witness = match nullary {
-                Some(v) => format!("{}.{}", name, to_lower_first(&v.name)),
+                Some(v) => format!("{}.{}", lean_name, lean_ctor_name(&v.name)),
                 None => {
                     let args = " default".repeat(first.fields.len());
-                    format!("{}.{}{}", name, to_lower_first(&first.name), args)
+                    format!("{}.{}{}", lean_name, lean_ctor_name(&first.name), args)
                 }
             };
-            format!("instance : Inhabited {name} := ⟨{witness}⟩")
+            format!("instance : Inhabited {lean_name} := ⟨{witness}⟩")
         }
         TypeDef::Product { name, fields, .. } => {
             // Every decl admitted to ProofIR emits as a Subtype rather than a
@@ -68,7 +69,10 @@ pub fn emit_inhabited_instance(td: &TypeDef, ctx: &CodegenContext, scope: Option
             let args = std::iter::repeat_n("default", fields.len())
                 .collect::<Vec<_>>()
                 .join(", ");
-            format!("instance : Inhabited {name} := ⟨{args}⟩")
+            format!(
+                "instance : Inhabited {} := ⟨{args}⟩",
+                aver_name_to_lean(name)
+            )
         }
     }
 }
@@ -77,9 +81,9 @@ fn emit_sum_type(name: &str, variants: &[TypeVariant]) -> String {
     let mut lines = Vec::new();
     let is_recursive = is_recursive_type(name, variants);
 
-    lines.push(format!("inductive {} where", name));
+    lines.push(format!("inductive {} where", aver_name_to_lean(name)));
     for v in variants {
-        let lean_name = to_lower_first(&v.name);
+        let lean_name = lean_ctor_name(&v.name);
         if v.fields.is_empty() {
             lines.push(format!("  | {}", lean_name));
         } else {
@@ -121,13 +125,16 @@ fn emit_product_type(
         let carrier_ty = type_annotation_to_lean(&decl.carrier_type);
         let param = aver_name_to_lean(&decl.predicate_param);
         let predicate = super::expr::emit_expr(&decl.invariant.expr, ctx);
-        return format!("abbrev {name} := {{ {param} : {carrier_ty} // {predicate} }}");
+        return format!(
+            "abbrev {} := {{ {param} : {carrier_ty} // {predicate} }}",
+            aver_name_to_lean(name)
+        );
     }
 
     let mut lines = Vec::new();
     let is_recursive = is_recursive_product(name, fields);
 
-    lines.push(format!("structure {} where", name));
+    lines.push(format!("structure {} where", aver_name_to_lean(name)));
     for (field_name, field_type) in fields {
         lines.push(format!(
             "  {} : {}",
@@ -413,11 +420,11 @@ fn emit_recursive_sum_measure(
     lines.push(format!(
         "  def {} (value : {}) : Nat :=",
         measure_fn_name(name),
-        name
+        aver_name_to_lean(name)
     ));
     lines.push("    match value with".to_string());
     for variant in variants {
-        let ctor = to_lower_first(&variant.name);
+        let ctor = lean_ctor_name(&variant.name);
         if variant.fields.is_empty() {
             lines.push(format!("    | .{} => 1", ctor));
             continue;
@@ -448,7 +455,7 @@ fn emit_recursive_sum_measure(
     lines.push(format!(
         "  def {} (items : List {}) : Nat :=",
         measure_list_fn_name(name),
-        name
+        aver_name_to_lean(name)
     ));
     lines.push("    match items with".to_string());
     lines.push("    | [] => 1".to_string());
@@ -470,8 +477,8 @@ fn emit_recursive_sum_measure(
         lines.push(format!(
             "  def {} (items : List ({} × {})) : Nat :=",
             measure_entries_fn_name(name, &key_type),
-            key_type,
-            name
+            type_annotation_to_lean(&key_type),
+            aver_name_to_lean(name)
         ));
         lines.push("    match items with".to_string());
         lines.push("    | [] => 1".to_string());
@@ -512,13 +519,13 @@ fn emit_recursive_product_measure(
         format!(
             "  def {} (value : {}) : Nat :=",
             measure_fn_name(name),
-            name
+            aver_name_to_lean(name)
         ),
         format!("    {}", body),
         format!(
             "  def {} (items : List {}) : Nat :=",
             measure_list_fn_name(name),
-            name
+            aver_name_to_lean(name)
         ),
         "    match items with".to_string(),
         "    | [] => 1".to_string(),
@@ -537,8 +544,8 @@ fn emit_recursive_product_measure(
         lines.push(format!(
             "  def {} (items : List ({} × {})) : Nat :=",
             measure_entries_fn_name(name, &key_type),
-            key_type,
-            name
+            type_annotation_to_lean(&key_type),
+            aver_name_to_lean(name)
         ));
         lines.push("    match items with".to_string());
         lines.push("    | [] => 1".to_string());
@@ -576,6 +583,7 @@ pub fn emit_recursive_measure(
 /// fabricated proof matches. (Float's `==` is IEEE, so its shim reflects
 /// IEEE semantics instead; same mechanism, both deliberate.)
 pub fn emit_recursive_decidable_eq(name: &str) -> String {
+    let name = aver_name_to_lean(name);
     let mut lines = Vec::new();
     lines.push(format!(
         "private unsafe def {}.unsafeDecEq (a b : {}) : Decidable (a = b) :=",

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -418,7 +418,10 @@ fn emit_verify_law_block(
             // …) when the law body used `Natural(value = a)` etc.
             // See `refinement_lift_for_given` for the detection.
             let type_text = if let Some(refined) = lifted_vars.get(&given.name) {
-                refined.clone()
+                // `lifted_vars` values are the IR's canonical Aver keys
+                // (`Natural`, `M.Type`) — spell them as Lean type text so a
+                // reserved-token segment carries the trailing-quote guard.
+                crate::codegen::lean::types::lean_named_type_name(refined)
             } else if let Some(subtype) = bounded_oracle_subtype_for(&given.type_name) {
                 subtype.to_string()
             } else {

--- a/src/codegen/lean/transpile.rs
+++ b/src/codegen/lean/transpile.rs
@@ -540,12 +540,17 @@ pub(super) fn transpile_unified(
         union_body.push_str(&body);
         union_body.push('\n');
 
+        // Reserved-token guard on every module-name surface: `namespace` /
+        // `end`, `import` / `open` lines, and the `.lean` file path itself
+        // (a Lean module named `Type` is unimportable, so the file is named
+        // after the escaped spelling and the lakefile root matches).
+        let lean_prefix = super::syntax::aver_path_to_lean(&module.prefix);
         let mut imports = vec!["import AverCommon".to_string()];
         if body.contains("Crypto.sha256") {
             imports.push("import Crypto".to_string());
         }
         for d in &module.depends {
-            imports.push(format!("import {}", d));
+            imports.push(format!("import {}", super::syntax::aver_path_to_lean(d)));
         }
         // AverCommon has no surrounding namespace (top-level helpers / instances),
         // so `import` already brings them into scope. We `open` only the
@@ -553,7 +558,7 @@ pub(super) fn transpile_unified(
         let opens: Vec<String> = module
             .depends
             .iter()
-            .map(|d| format!("open {}", d))
+            .map(|d| format!("open {}", super::syntax::aver_path_to_lean(d)))
             .collect();
 
         let opens_str = if opens.is_empty() {
@@ -565,11 +570,11 @@ pub(super) fn transpile_unified(
             "{}\n\nset_option linter.unusedVariables false\nset_option maxRecDepth 1000000\n{}\nnamespace {}\n\n{}\nend {}\n",
             imports.join("\n"),
             opens_str,
-            module.prefix,
+            lean_prefix,
             body,
-            module.prefix
+            lean_prefix
         );
-        let path = module.prefix.replace('.', "/");
+        let path = lean_prefix.replace('.', "/");
         module_files.push((format!("{}.lean", path), content));
     }
 
@@ -616,12 +621,15 @@ pub(super) fn transpile_unified(
         entry_imports.push("import Crypto".to_string());
     }
     for m in &ctx.modules {
-        entry_imports.push(format!("import {}", m.prefix));
+        entry_imports.push(format!(
+            "import {}",
+            super::syntax::aver_path_to_lean(&m.prefix)
+        ));
     }
     let entry_opens: Vec<String> = ctx
         .modules
         .iter()
-        .map(|m| format!("open {}", m.prefix))
+        .map(|m| format!("open {}", super::syntax::aver_path_to_lean(&m.prefix)))
         .collect();
     let mut entry_parts = vec![entry_imports.join("\n")];
     if !entry_opens.is_empty() {
@@ -678,7 +686,7 @@ pub(super) fn transpile_unified(
         extra_roots.push("Crypto".to_string());
     }
     for m in &ctx.modules {
-        extra_roots.push(m.prefix.clone());
+        extra_roots.push(super::syntax::aver_path_to_lean(&m.prefix));
     }
     let lakefile = generate_lakefile_with_roots(&project_name, &extra_roots);
     let toolchain = generate_toolchain();

--- a/src/codegen/lean/types.rs
+++ b/src/codegen/lean/types.rs
@@ -105,13 +105,14 @@ pub fn type_to_lean(ty: &Type) -> String {
 /// must mangle the same way. A USER record is emitted inside its
 /// owning module's `namespace M`, so its Lean name is the dotted
 /// namespaced path (`Domain.Rational.Fraction`) — the dots must be
-/// preserved or the type ascription fails to resolve. Bare names (no
-/// dot) are unaffected either way.
+/// preserved or the type ascription fails to resolve, with each
+/// segment routed through the reserved-token guard (an Aver type or
+/// module named `Type`/`Prop` is legal but collides with Lean syntax).
 pub(crate) fn lean_named_type_name(name: &str) -> String {
     if crate::codegen::builtin_records::find(name).is_some() {
         name.replace('.', "_")
     } else {
-        name.to_string()
+        super::syntax::aver_path_to_lean(name)
     }
 }
 

--- a/src/codegen/lean/untranslate.rs
+++ b/src/codegen/lean/untranslate.rs
@@ -558,12 +558,13 @@ fn const_to_expr(name: &str) -> Expr {
 }
 
 /// Un-escape a (possibly dotted) Lean name back to its Aver spelling: strip the
-/// trailing-`'` reserved-word guard from the final segment.
+/// trailing-`'` reserved-word guard from every segment (module and type
+/// segments carry the guard too — `Models.Type'` is Aver's `Models.Type`).
 fn lean_dotted_to_aver(name: &str) -> String {
-    match name.rsplit_once('.') {
-        Some((prefix, last)) => format!("{prefix}.{}", super::expr::lean_name_to_aver(last)),
-        None => super::expr::lean_name_to_aver(name),
-    }
+    name.split('.')
+        .map(super::expr::lean_name_to_aver)
+        .collect::<Vec<_>>()
+        .join(".")
 }
 
 /// The Aver type name for a data `∀`-binder type node (`const Int`,

--- a/tests/proof_spec/cross_file.rs
+++ b/tests/proof_spec/cross_file.rs
@@ -750,3 +750,98 @@ fn cross_file_forward_citation_is_refused_end_to_end() {
          in the emitted proof\nDomain/Frac.lean:\n{fwd_frac}"
     );
 }
+
+/// A dependency module named `Type` — a reserved Lean token that Aver's
+/// lexer accepts as a module name. Every module-name surface must carry
+/// the trailing-quote guard: the emitted file (`Type'.lean`), its
+/// `namespace`/`end` pair, the consumer's `import`/`open` lines and
+/// qualified call sites, and the lakefile root. Guarded by the standard
+/// `lake` skip; asserts the emitted sources, then that the project
+/// builds clean under the pinned toolchain.
+#[test]
+fn cross_file_reserved_module_name_escapes_and_builds() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping reserved-module-name test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-reserved-module-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("Type.av"),
+        "module Type\n\
+        \x20   intent =\n\
+        \x20       \"Dependency module named after a reserved Lean token.\"\n\
+        \x20   exposes [double]\n\n\
+        fn double(n: Int) -> Int\n\
+        \x20   n * 2\n",
+    )
+    .expect("write Type.av");
+    std::fs::write(
+        src.join("Consumer.av"),
+        "module Consumer\n\
+        \x20   depends [Type]\n\
+        \x20   intent =\n\
+        \x20       \"Entry depending on a module named Type.\"\n\n\
+        fn quadruple(n: Int) -> Int\n\
+        \x20   Type.double(Type.double(n))\n\n\
+        verify quadruple\n\
+        \x20   quadruple(3) => 12\n",
+    )
+    .expect("write Consumer.av");
+    let out = temp_output_dir("aver-reserved-module-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("Consumer.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("--module-root")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+
+    let dep_lean = std::fs::read_to_string(out.join("Type'.lean"))
+        .expect("dep module named `Type` must emit as Type'.lean");
+    assert!(
+        dep_lean.contains("namespace Type'") && dep_lean.contains("end Type'"),
+        "the dep namespace must carry the reserved-token guard\nType'.lean:\n{dep_lean}"
+    );
+    let consumer_lean =
+        std::fs::read_to_string(out.join("Consumer.lean")).expect("Consumer.lean must exist");
+    assert!(
+        consumer_lean.contains("import Type'") && consumer_lean.contains("open Type'"),
+        "the consumer's import/open lines must escape the module name\n\
+         Consumer.lean:\n{consumer_lean}"
+    );
+    assert!(
+        consumer_lean.contains("Type'.double"),
+        "qualified call sites must escape the module segment\nConsumer.lean:\n{consumer_lean}"
+    );
+    let lakefile =
+        std::fs::read_to_string(out.join("lakefile.lean")).expect("lakefile.lean must exist");
+    assert!(
+        lakefile.contains("`Type'"),
+        "the lakefile root must match the escaped module name\nlakefile.lean:\n{lakefile}"
+    );
+
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with('{')))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "the reserved-module-name project must build clean\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}

--- a/tests/proof_spec/cross_file.rs
+++ b/tests/proof_spec/cross_file.rs
@@ -845,3 +845,93 @@ fn cross_file_reserved_module_name_escapes_and_builds() {
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+/// The ENTRY module named `Type` — the same reserved-token shape as the
+/// dep-module test above, but on the entry surface (`lean_project_name`):
+/// the emitted entry file and the lakefile root/lib names. `lake build`
+/// itself tolerates a raw `Type` root, so the observable failure is
+/// subtler than a red build: the `--check` law audit writes probe files
+/// that `import` every lakefile root, and `import Type` dies with
+/// `unexpected token 'Type'` — silently downgrading a kernel-proven
+/// universal law to `universal: false`. Asserts the escaped surfaces,
+/// then that the law KEEPS its universal credit end-to-end.
+#[test]
+fn entry_reserved_module_name_escapes_and_builds() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping reserved-entry-name test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-reserved-entry-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("Type.av"),
+        "module Type\n\
+        \x20   intent =\n\
+        \x20       \"Entry module named after a reserved Lean token.\"\n\n\
+        fn add(a: Int, b: Int) -> Int\n\
+        \x20   a + b\n\n\
+        verify add law commutative\n\
+        \x20   given a: Int = [1, 2, 3]\n\
+        \x20   given b: Int = [4, 5, 6]\n\
+        \x20   add(a, b) => add(b, a)\n",
+    )
+    .expect("write Type.av");
+    let out = temp_output_dir("aver-reserved-entry-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("Type.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("--module-root")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+
+    let entry_lean = std::fs::read_to_string(out.join("Type'.lean"))
+        .expect("entry module named `Type` must emit as Type'.lean");
+    assert!(
+        entry_lean.contains("theorem add_law_commutative"),
+        "the escaped entry file must carry the law theorem\nType'.lean:\n{entry_lean}"
+    );
+    assert!(
+        !out.join("Type.lean").exists(),
+        "no raw Type.lean may be emitted alongside the escaped entry file"
+    );
+    let lakefile =
+        std::fs::read_to_string(out.join("lakefile.lean")).expect("lakefile.lean must exist");
+    assert!(
+        lakefile.contains("`Type'"),
+        "the lakefile root must match the escaped entry name\nlakefile.lean:\n{lakefile}"
+    );
+    assert!(
+        !lakefile.contains("#[`Type,"),
+        "the raw entry name must not survive as a lakefile root\nlakefile.lean:\n{lakefile}"
+    );
+
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with('{')))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["universal"].as_bool(),
+            summary["universal_laws"].as_u64(),
+        ),
+        (Some(true), Some(true), Some(1)),
+        "the reserved-entry-name project must build clean AND keep its \
+         universal-law credit (the audit probes import the escaped root)\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
## Problem

The Lean reserved-identifier escaping (#787) covers value-level names only. The reserved list contains PascalCase tokens (`Type`, `Prop`, `Sort`, `StateRefT`) that Aver's lexer happily accepts as user type and module names (only lowercase keywords are reserved), but type declarations, type references, constructor spellings, namespace headers, and import/open lines all emit raw names.

Concrete failing example (`aver proof typenames.av`):

```
type Type
    Scalar
    Vector(Int)

record Prop
    value: Int
```

emitted

```lean
inductive Type where
  ...
structure Prop where
  ...
def describe (t : Type) : Int := ...
```

which is unparseable Lean — `lake build` fails on every project containing such a type. A dependency module named `Type` was equally broken: `namespace Type`, `import Type`, `open Type`, and a `Type.lean` root all fail to parse. Fail-loud (proof export breaks), availability not soundness.

Separately, the advertised tripwire test `reserved_snapshot_covers_pinned_lean_token_table` never ran in CI: it silently returns when `lean` is absent, `ci.yml` runs lib tests without Lean, and `proof.yml` installs elan but runs only `--test proof_spec`. It also probed whatever toolchain elan resolved ambiently, not the pinned one.

## Fix

- New `aver_path_to_lean` (per-`.`-segment escape) and `lean_ctor_name` (lowercase-first + escape, since a variant `Match` lowers to the reserved `match`) in `src/codegen/lean/syntax.rs`.
- Type declarations escape their names: `inductive`/`structure`/`abbrev` (refined records), `Inhabited` instances, recursive measure defs, and the recursive `DecidableEq` shim.
- Type references escape via the single choke point `lean_named_type_name` (covers signatures, fields, ctor argument types through `type_annotation_to_lean`) plus the ctor/attr/record emission sites in `expr.rs` and `pattern.rs`.
- Module names escape on every surface: `namespace`/`end`, `import`/`open` lines (per-module and entry), qualified call sites, the emitted `.lean` file path, and lakefile roots — a module named `Type` now emits `Type'.lean` with `namespace Type'` and root `` `Type' ``.
- The `--explain` un-translator strips the guard from every path segment, keeping it inverse-consistent.
- Guard test now writes a `lean-toolchain` file (from the same generator as emitted proof projects) into the probe dir so elan resolves the pinned toolchain, and `proof.yml` gains a cheap step running exactly that test in the job that already has elan installed.
- `src/codegen/lean/shared.rs` (a one-fn `to_lower_first` re-export) became dead once ctor spelling moved to `lean_ctor_name`; removed.

Known residual: a few law-strategy citation builders (cross-module law pool in `law_auto`) still interpolate raw module prefixes into theorem citations; for a reserved-token module name with cross-module laws the admission gate now declines the citation (build stays green, law degrades) rather than emitting broken Lean. Escaping is identity for all non-reserved names, so existing output is byte-identical.

## Tests

- `cargo test -p aver-lang --lib` — 954 passed (includes new `reserved_lean_tokens_as_type_names_are_escaped` and the reworked pinned-toolchain probe, exercised locally with Lean 4.32.0 on PATH).
- `cargo test -p aver-lang --test proof_spec cross_file` — 9 passed with `lake` available, including new `cross_file_reserved_module_name_escapes_and_builds` (module named `Type`, full `lake build` green).
- `cargo test -p aver-lang --test proof_spec export_structure` — 13 passed.
- Manual repros: sum + record named `Type`/`Prop`, a recursive ADT named `Type` (measure + DecidableEq shim paths), and a dep module named `Type` — all now `lake build` clean under the pinned toolchain.
- `cargo fmt`, `cargo clippy -p aver-lang --all-targets` and `--features wasm,wasip2` — no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)