### PR TITLE
Make the Lean SHA-256 model axiom-free and kernel-reducible

### DIFF
--- a/src/codegen/lean/crypto_model.lean
+++ b/src/codegen/lean/crypto_model.lean
@@ -1,9 +1,6 @@
 import Bytes
 import Crypto.Digest32
 
-set_option maxRecDepth 1000000
-set_option maxHeartbeats 0
-
 namespace AverCrypto
 
 def rotr (x : UInt32) (n : Nat) : UInt32 :=
@@ -44,8 +41,9 @@ def padded (input : List Int) : Array UInt8 := Id.run do
   let mut out := input.foldl (fun acc byte => acc.push (UInt8.ofNat byte.toNat)) #[]
   let bitLength := UInt64.ofNat (out.size * 8)
   out := out.push 0x80
-  while out.size % 64 != 56 do
-    out := out.push 0
+  -- Zero-pad to 56 mod 64 with a computed count instead of a `while`-loop:
+  -- `while` bottoms out in a non-total combinator the kernel cannot unfold.
+  out := out ++ Array.replicate ((56 + 64 - out.size % 64) % 64) 0
   for shift in #[56, 48, 40, 32, 24, 16, 8, 0] do
     out := out.push ((bitLength >>> UInt64.ofNat shift).toUInt8)
   return out
@@ -91,14 +89,12 @@ def compress (state : Array UInt32) (message : Array UInt8) (offset : Nat) : Arr
     state[4]! + e, state[5]! + f, state[6]! + g, state[7]! + h
   ]
 
-def digestWords (input : List Int) : Array UInt32 := Id.run do
+def digestWords (input : List Int) : Array UInt32 :=
   let message := padded input
-  let mut state := initial
-  let mut offset := 0
-  while offset < message.size do
-    state := compress state message offset
-    offset := offset + 64
-  return state
+  -- `padded` always returns a multiple of 64 bytes, so folding over the
+  -- exact block count replaces the kernel-opaque `while`-loop over offsets.
+  (List.range (message.size / 64)).foldl
+    (fun state i => compress state message (i * 64)) initial
 
 def sha256Bytes (input : List Int) : List Int := Id.run do
   let mut out : Array Int := #[]
@@ -113,11 +109,20 @@ end AverCrypto
 
 namespace Crypto
 
+/-- Zero bytes are octets. Proven by induction because the exported
+`Bytes.allInRange` is compiled by well-founded recursion, which `decide`
+cannot evaluate through the elaborator. -/
+private theorem allInRange_replicate_zero (n : Nat) :
+    Bytes.allInRange (List.replicate n 0) = true := by
+  induction n with
+  | zero => simp [Bytes.allInRange]
+  | succ n ih => simpa [Bytes.allInRange, List.replicate] using ih
+
 private def fallbackBytes : Bytes.Bytes :=
-  ⟨List.replicate 32 0, by native_decide⟩
+  ⟨List.replicate 32 0, allInRange_replicate_zero 32⟩
 
 private def fallbackDigest : Crypto.Digest32.Digest32 :=
-  ⟨fallbackBytes, by native_decide⟩
+  ⟨fallbackBytes, by decide⟩
 
 def sha256 (bytes : Bytes.Bytes) : Crypto.Digest32.Digest32 :=
   match Bytes.fromList (AverCrypto.sha256Bytes bytes.val) with

--- a/tests/proof_spec/export_structure.rs
+++ b/tests/proof_spec/export_structure.rs
@@ -632,8 +632,12 @@ fn embedded_bytes_and_crypto_digest_preserve_refinements_in_both_proof_backends(
         crypto_lean.contains("def sha256 (bytes : Bytes.Bytes)")
             && crypto_lean.contains("def compress")
             && !crypto_lean.contains("axiom ")
-            && !crypto_lean.contains("sorry"),
-        "Lean Crypto.sha256 must be an executable, axiom-free model:\n{crypto_lean}"
+            && !crypto_lean.contains("sorry")
+            && !crypto_lean.contains("native_decide")
+            && !crypto_lean.contains("while ")
+            && !crypto_lean.contains("partial "),
+        "Lean Crypto.sha256 must be an executable, axiom-free, kernel-reducible model \
+         (no native_decide, no `while` loops bottoming out in partial combinators):\n{crypto_lean}"
     );
 
     let dafny_out = root.join("dafny");

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -1683,3 +1683,90 @@ fn proof_lean_mixed_advance_skipper_stays_fueled_stability_lemma_kernel_clean() 
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn proof_lean_crypto_sha256_model_axiom_closure_is_core_only() {
+    // Scrub-proof gate for the exported SHA-256 model: `#print axioms
+    // Crypto.sha256` inside a generated project must report a SUBSET of
+    // Lean's core three ({propext, Classical.choice, Quot.sound}). The
+    // model once carried `native_decide` proofs on its private fallback
+    // witnesses, which added per-def `_native.native_decide.ax_1` axioms
+    // to the closure of EVERY theorem touching sha256 and defeated the
+    // axiom-whitelist gate. A static text check cannot catch every
+    // reintroduction path (e.g. a tactic that expands to native
+    // evaluation), so this probes the real axiom closure via the kernel.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping crypto sha256 axiom probe: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture = repo_root.join("tests/fixtures/stdlib_bytes_app.av");
+    let root = temp_output_dir("aver-proof-crypto-sha256-axioms");
+    let missing_module_root = root.join("no-project-modules");
+    let out = root.join("lean");
+    let export = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg(&fixture)
+        .arg("--module-root")
+        .arg(&missing_module_root)
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("aver proof export for the sha256 axiom probe");
+    assert!(
+        export.status.success(),
+        "proof export failed:\n{}",
+        format_output(&export)
+    );
+    // `lake env lean` resolves imports from built oleans, so build first.
+    let build = Command::new("lake")
+        .current_dir(&out)
+        .arg("build")
+        .output()
+        .expect("lake build for the sha256 axiom probe");
+    assert!(
+        build.status.success(),
+        "lake build failed:\n{}",
+        format_output(&build)
+    );
+    std::fs::write(
+        out.join("AxiomProbe.lean"),
+        "import Crypto\n\n#print axioms Crypto.sha256\n",
+    )
+    .expect("write AxiomProbe.lean");
+    let probe = Command::new("lake")
+        .current_dir(&out)
+        .arg("env")
+        .arg("lean")
+        .arg("AxiomProbe.lean")
+        .output()
+        .expect("lake env lean AxiomProbe.lean");
+    assert!(
+        probe.status.success(),
+        "axiom probe failed to elaborate:\n{}",
+        format_output(&probe)
+    );
+    let stdout = String::from_utf8_lossy(&probe.stdout);
+    // Two possible shapes:
+    //   'Crypto.sha256' does not depend on any axioms
+    //   'Crypto.sha256' depends on axioms: [propext, Quot.sound]
+    if !stdout.contains("does not depend on any axioms") {
+        let listed = stdout
+            .split_once('[')
+            .and_then(|(_, rest)| rest.rsplit_once(']'))
+            .map(|(inner, _)| inner)
+            .unwrap_or_else(|| panic!("unexpected `#print axioms` output:\n{stdout}"));
+        for axiom in listed.split(',').map(str::trim).filter(|a| !a.is_empty()) {
+            assert!(
+                matches!(axiom, "propext" | "Classical.choice" | "Quot.sound"),
+                "Crypto.sha256 depends on non-core axiom `{axiom}` — a \
+                 `native_decide`/`sorry` crept back into the exported model:\n{stdout}"
+            );
+        }
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
The exported Lean SHA-256 model (`src/codegen/lean/crypto_model.lean`, emitted as `Crypto.lean` into every proof project that uses `Crypto.sha256`) was neither axiom-free nor kernel-transparent:

1. The private fallback witnesses (`fallbackBytes`, `fallbackDigest`) were proved by `native_decide`, and `fallbackDigest` sits in the body of `Crypto.sha256` — so every theorem whose closure touches sha256 inherited native-evaluation trust and failed the core-axiom whitelist.
2. `padded` and `digestWords` used `while` loops in `Id.run do`; `while` bottoms out in a non-total combinator, so the kernel could not reduce any concrete sha256 application.

## Changes

- `padded`: the zero-padding `while` loop is replaced by a computed count — after pushing `0x80` append exactly `(56 + 64 - size % 64) % 64` zeros via `Array.replicate` (the formula gives 0 in the case where the old loop body never ran).
- `digestWords`: the block-iteration `while` loop is replaced by `(List.range (message.size / 64)).foldl` — `padded` always returns a multiple of 64 bytes, so this folds over the exact block count.
- Fallback witnesses: `fallbackBytes` is proved by a small induction lemma (`allInRange_replicate_zero`) because the exported `Bytes.allInRange` is compiled by well-founded recursion, which `decide` cannot evaluate; `fallbackDigest` closes by plain `decide`. Both are kernel-checked with zero extra axioms.
- Dropped the file-wide `set_option maxHeartbeats 0` and `set_option maxRecDepth 1000000`; the model elaborates and proves with default limits (verified standalone and in a full generated project).
- Regression test `proof_lean_crypto_sha256_model_axiom_closure_is_core_only` (toolchain-conditional, skips without `lake`): exports the `stdlib_bytes_app.av` fixture, builds it, runs a `#print axioms Crypto.sha256` probe via `lake env lean`, and fails if the closure leaves `{propext, Classical.choice, Quot.sound}` — a future `native_decide` reintroduction fails CI in the proof lane.
- The existing static check on the emitted `Crypto.lean` additionally rejects `native_decide`, `while ` and `partial `.

## `#print axioms Crypto.sha256`

Before:

```
'Crypto.sha256' depends on axioms: [propext,
 Classical.choice,
 Quot.sound,
 Crypto.fallbackBytes._native.native_decide.ax_1,
 Crypto.fallbackDigest._native.native_decide.ax_1]
```

After:

```
'Crypto.sha256' depends on axioms: [propext, Quot.sound]
```

## Kernel `decide` measurement (Lean 4.32.0, M-series, generated project for `tests/fixtures/stdlib_bytes_app.av`)

Plain `decide` still gets stuck (the elaborator's whnf pre-check stalls on the model), but `decide +kernel` closes concrete FIPS 180-4 facts:

| Fact | wall clock (`lake env lean`) |
| --- | --- |
| baseline (imports only) | 0.6 s |
| `AverCrypto.sha256Bytes [97, 98, 99] = <abc digest>` (1 block) | 1.75 s |
| empty-message + 56-byte two-block vectors (3 blocks total) | 4.1 s |
| full `shaHex [97, 98, 99] = Except.ok "ba78…"` verify-case shape | 1.9 s |

Net cost is roughly 1.1 s per compression block, so kernel-checking sha256 samples is practical. Verify-case emission is left on `native_decide`: the emit mode is a single global `VerifyEmitMode` shared by all sampled cases, including Float cases that have no kernel-decidable semantics, so routing crypto cases through `decide +kernel` would need a per-case kernel-decidability classifier — not a contained change.

## Evidence

- `aver proof tests/fixtures/stdlib_bytes_app.av --backend lean --check`: lake build green, 0 sorries — the fixture's `native_decide` FIPS examples (empty, abc, 2-block, error paths, double-SHA) all still pass, confirming the model's output is unchanged.
- `aver verify tests/fixtures/stdlib_bytes_app.av` (VM): 13/13 cases passed.
- `cargo test --test proof_spec proof_lean_crypto_sha256_model_axiom_closure_is_core_only`: passed.
- `cargo test --test proof_spec embedded_bytes_and_crypto_digest_preserve_refinements_in_both_proof_backends`: passed.
- `cargo test --test stdlib_spec`: passed. (The `--features wasm` FIPS lane was not run locally due to disk exhaustion; the change touches only the Lean asset, and CI covers that lane.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
