### PR TITLE
Canonicalize oracle signatures for source-typed builtins

### DIFF
--- a/src/types/checker/flow.rs
+++ b/src/types/checker/flow.rs
@@ -1,6 +1,19 @@
 use super::*;
 
 impl TypeChecker {
+    /// Oracle signature for `method`, re-stamped into the active `TypeId`
+    /// space. The static classification table builds types from bare
+    /// source names (`Type::Named { id: None, .. }`), while builtin
+    /// signatures crossing stdlib-owned nominals are canonicalized after
+    /// the embedded modules load (`canonicalize_source_typed_builtin_sigs`).
+    /// Oracle signatures derived from the same table must go through the
+    /// same canonicalization, or a user stub typed against the resolved
+    /// nominal `Bytes` fails to match the raw-named oracle type.
+    fn canonical_oracle_signature(&self, method: &str) -> Option<Type> {
+        super::effect_classification::oracle_signature(method)
+            .map(|sig| self.canonicalize_named(sig))
+    }
+
     fn with_verify_law_givens<T>(
         &mut self,
         givens: &[crate::ast::VerifyGiven],
@@ -14,7 +27,7 @@ impl TypeChecker {
             // capability reader for snapshot). Output effects have no oracle
             // and are rejected with a clear message.
             if let Some(c) = super::effect_classification::classify(&given.type_name) {
-                match super::effect_classification::oracle_signature(&given.type_name) {
+                match self.canonical_oracle_signature(&given.type_name) {
                     Some(sig) => {
                         self.locals.insert(given.name.clone(), sig);
                     }
@@ -31,6 +44,7 @@ impl TypeChecker {
             }
             match parse_type_str_strict(&given.type_name) {
                 Ok(ty) => {
+                    let ty = self.canonicalize_named(ty);
                     self.locals.insert(given.name.clone(), ty);
                 }
                 Err(unknown) => {
@@ -435,8 +449,7 @@ impl TypeChecker {
                             crate::ast::VerifyKind::Cases => Box::new(vb.cases_givens.iter()),
                         };
                     for given in givens_iter {
-                        let Some(expected) =
-                            super::effect_classification::oracle_signature(&given.type_name)
+                        let Some(expected) = self.canonical_oracle_signature(&given.type_name)
                         else {
                             continue;
                         };

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -1367,6 +1367,66 @@ fn valid_tcp_read_bytes_returns_nominal_bytes() {
 }
 
 #[test]
+fn valid_verify_trace_given_stub_for_tcp_read_bytes() {
+    // Regression: the oracle signature for the byte-carrying TCP methods
+    // is built from bare source names (`Type::Named { id: None, name:
+    // "Bytes" }`), while a user-written stub fn gets its signature
+    // canonicalized against the loaded stdlib `Bytes` module (`id:
+    // Some(..)`). Pre-fix the stub-type check rejected the given with an
+    // error printing two identical-looking signatures.
+    let src = concat!(
+        "module Prog\n",
+        "    intent = \"User stub for Tcp.readBytes must typecheck.\"\n",
+        "    depends [Bytes]\n",
+        "    effects [Tcp]\n",
+        "\n",
+        "fn readStub(path: BranchPath, n: Int, conn: Tcp.Connection, count: Int) -> Result<Bytes, String>\n",
+        "    ? \"Honest stub returning a fixed frame.\"\n",
+        "    Bytes.fromList([1, 2, 3, 4])\n",
+        "\n",
+        "fn readFrame(conn: Tcp.Connection) -> Result<Bytes, String>\n",
+        "    ? \"Read one 4-byte frame.\"\n",
+        "    ! [Tcp.readBytes]\n",
+        "    Tcp.readBytes(conn, 4)\n",
+        "\n",
+        "verify readFrame trace\n",
+        "    given conn: Tcp.Connection = [Tcp.Connection(id = \"fake\", host = \"h\", port = 1)]\n",
+        "    given reader: Tcp.readBytes = [readStub]\n",
+        "    readFrame(conn) => Bytes.fromList([1, 2, 3, 4])\n",
+    );
+    let errs = errors_with_base(src, env!("CARGO_MANIFEST_DIR"));
+    assert!(errs.is_empty(), "expected no errors, got: {errs:?}");
+}
+
+#[test]
+fn valid_verify_trace_given_stub_for_tcp_write_bytes() {
+    // Same regression as above, exercising nominal `Bytes` in stub
+    // parameter position (`Tcp.writeBytes` consumes the payload).
+    let src = concat!(
+        "module Prog\n",
+        "    intent = \"User stub for Tcp.writeBytes must typecheck.\"\n",
+        "    depends [Bytes]\n",
+        "    effects [Tcp]\n",
+        "\n",
+        "fn writeStub(path: BranchPath, n: Int, conn: Tcp.Connection, payload: Bytes) -> Result<Unit, String>\n",
+        "    ? \"Honest stub accepting any frame.\"\n",
+        "    Result.Ok(Unit)\n",
+        "\n",
+        "fn sendFrame(conn: Tcp.Connection, payload: Bytes) -> Result<Unit, String>\n",
+        "    ? \"Write one frame.\"\n",
+        "    ! [Tcp.writeBytes]\n",
+        "    Tcp.writeBytes(conn, payload)\n",
+        "\n",
+        "verify sendFrame trace\n",
+        "    given conn: Tcp.Connection = [Tcp.Connection(id = \"fake\", host = \"h\", port = 1)]\n",
+        "    given writer: Tcp.writeBytes = [writeStub]\n",
+        "    sendFrame(conn, Bytes.fromList([1, 2])?) => Result.Ok(Unit)\n",
+    );
+    let errs = errors_with_base(src, env!("CARGO_MANIFEST_DIR"));
+    assert!(errs.is_empty(), "expected no errors, got: {errs:?}");
+}
+
+#[test]
 fn valid_tcp_close_with_connection() {
     let src = concat!(
         "fn done(conn: Tcp.Connection) -> Result<Unit, String>\n",

--- a/tests/verify_tcp_bytes_given_stub.rs
+++ b/tests/verify_tcp_bytes_given_stub.rs
@@ -1,0 +1,56 @@
+//! Regression — a user-written `given` stub for the byte-carrying TCP
+//! methods must typecheck and actually run on the VM.
+//!
+//! Pre-fix, `effect_classification::oracle_signature` returned types
+//! built from bare source names (`Type::Named { id: None, name: "Bytes" }`)
+//! while the user's stub fn had its signature canonicalized against the
+//! loaded stdlib `Bytes` module (`id: Some(..)`). The typed-identity
+//! matcher rejects mixed `(Some, None)` comparisons, so the verify
+//! block's stub-type check failed with an error printing two
+//! identical-looking signatures, and the block never reached the VM.
+//!
+//! The passing run below is only possible with the user stub installed:
+//! the `given` connection is fabricated, so an unstubbed dispatch of the
+//! real `Tcp.readBytes` builtin can only return `Result.Err`.
+
+use aver::diagnostics::vm_verify::run_verify_for_items_vm;
+use aver::source::parse_source;
+
+#[test]
+fn user_given_stub_for_tcp_read_bytes_typechecks_and_runs_on_vm() {
+    let src = r#"module Prog
+    intent = "User stub for Tcp.readBytes runs under verify."
+    depends [Bytes]
+    effects [Tcp]
+
+fn readStub(path: BranchPath, n: Int, conn: Tcp.Connection, count: Int) -> Result<Bytes, String>
+    ? "Honest stub returning a fixed frame."
+    Bytes.fromList([1, 2, 3, 4])
+
+fn readFrame(conn: Tcp.Connection) -> Result<Bytes, String>
+    ? "Read one 4-byte frame."
+    ! [Tcp.readBytes]
+    Tcp.readBytes(conn, 4)
+
+verify readFrame trace
+    given conn: Tcp.Connection = [Tcp.Connection(id = "fake", host = "127.0.0.1", port = 1)]
+    given reader: Tcp.readBytes = [readStub]
+    readFrame(conn) => Bytes.fromList([1, 2, 3, 4])
+"#;
+    let items = parse_source(src).unwrap_or_else(|e| panic!("parse failed: {e:?}"));
+    let results = run_verify_for_items_vm(
+        items,
+        None,
+        Some(env!("CARGO_MANIFEST_DIR")),
+        "verify_tcp_bytes_given_stub.av",
+    )
+    .expect("verify run must typecheck clean — a raw-named oracle signature rejects the stub");
+    assert_eq!(results.len(), 1);
+    let result = &results[0];
+    assert_eq!(
+        (result.passed, result.failed, result.skipped),
+        (1, 0, 0),
+        "the stubbed read must return the fixed frame; failures: {:?}",
+        result.failures
+    );
+}


### PR DESCRIPTION
A verify block with a user-written given stub for the byte-carrying TCP methods failed typecheck: `given reader: Tcp.readBytes = [readStub]` was rejected with an error printing two identical-looking signatures, because the oracle signature carries a bare-named `Bytes` (`id: None`) while the stub fn's signature is canonicalized against the loaded stdlib `Bytes` (`id: Some`), and the typed-identity matcher rejects mixed comparisons. Oracle signatures now go through the same `canonicalize_named` re-stamping as builtin signatures at both checker use sites, and plain-type law givens canonicalize their annotation the same way. Tests: two typecheck-level regressions (readBytes and writeBytes given stubs) plus a VM execution test where the stubbed verify run can only pass with the stub installed; all three red before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)