### PR TITLE
Name the offending byte and index in Bytes.fromList errors

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -26,7 +26,7 @@ proof export.
 
 | Function | Signature | Notes |
 |---|---|---|
-| `Bytes.fromList` | `List<Int> -> Result<Bytes, String>` | Validates every octet |
+| `Bytes.fromList` | `List<Int> -> Result<Bytes, String>` | Validates every octet; `Result.Err` names the offending value and its index |
 | `Bytes.toList` | `Bytes -> List<Int>` | Exposes validated values |
 | `Bytes.fromHex` | `String -> Result<Bytes, String>` | Even length, case-insensitive, no `0x` prefix |
 | `Bytes.toHex` | `Bytes -> String` | Total, lowercase output |

--- a/stdlib/bytes.av
+++ b/stdlib/bytes.av
@@ -16,11 +16,27 @@ fn allInRange(xs: List<Int>) -> Bool
             true -> allInRange(tail)
             false -> false
 
+fn firstOutOfRange(xs: List<Int>) -> Int
+    ? "Return the first non-octet value; -1 when every value is an octet."
+    match xs
+        [] -> -1
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> firstOutOfRange(tail)
+            false -> head
+
+fn firstOutOfRangeIndex(xs: List<Int>) -> Int
+    ? "Return the index of the first non-octet value; the length when every value is an octet."
+    match xs
+        [] -> 0
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> 1 + firstOutOfRangeIndex(tail)
+            false -> 0
+
 fn fromList(xs: List<Int>) -> Result<Bytes, String>
     ? "Validate raw integers and construct a byte sequence."
     match allInRange(xs)
         true -> Result.Ok(Bytes(values = xs))
-        false -> Result.Err("byte value outside 0..=255")
+        false -> Result.Err("byte {firstOutOfRange(xs)} at index {firstOutOfRangeIndex(xs)} is outside 0..=255")
 
 fn toList(bytes: Bytes) -> List<Int>
     ? "Expose the validated octets for ordinary List operations."
@@ -143,9 +159,20 @@ verify allInRange
     allInRange([-1]) => false
     allInRange([256]) => false
 
+verify firstOutOfRange
+    firstOutOfRange([]) => -1
+    firstOutOfRange([0, 256, 300]) => 256
+    firstOutOfRange([255, -7]) => -7
+
+verify firstOutOfRangeIndex
+    firstOutOfRangeIndex([]) => 0
+    firstOutOfRangeIndex([0, 256, 300]) => 1
+    firstOutOfRangeIndex([255, -7]) => 1
+
 verify fromList
     fromList([0, 127, 255]) => Result.Ok(Bytes(values = [0, 127, 255]))
-    fromList([256]) => Result.Err("byte value outside 0..=255")
+    fromList([256]) => Result.Err("byte 256 at index 0 is outside 0..=255")
+    fromList([0, 256]) => Result.Err("byte 256 at index 1 is outside 0..=255")
 
 verify parseHexChars
     parseHexChars([], []) => Result.Ok([])

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -2071,7 +2071,7 @@ fn cert_verify_declines_tampered_array_new_data_operands() {
 {compile_report}"
     );
     assert!(
-        compile_report.contains("(12 certified, 88 source-level-only)"),
+        compile_report.contains("(12 certified, 90 source-level-only)"),
         "json certificate KPI denominator changed:
 {compile_report}"
     );

--- a/tests/fixtures/stdlib_bytes_app.av
+++ b/tests/fixtures/stdlib_bytes_app.av
@@ -45,7 +45,7 @@ fn doubleShaHex(values: List<Int>) -> Result<String, String>
 
 verify roundTrip
     roundTrip([0, 127, 255]) => Result.Ok([0, 127, 255])
-    roundTrip([0, 256]) => Result.Err("byte value outside 0..=255")
+    roundTrip([0, 256]) => Result.Err("byte 256 at index 1 is outside 0..=255")
 
 verify hexRoundTrip
     hexRoundTrip("00aF") => Result.Ok("00af")
@@ -63,7 +63,7 @@ verify shaHex
     shaHex([]) => Result.Ok("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
     shaHex([97, 98, 99]) => Result.Ok("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
     shaHex([97, 98, 99, 100, 98, 99, 100, 101, 99, 100, 101, 102, 100, 101, 102, 103, 101, 102, 103, 104, 102, 103, 104, 105, 103, 104, 105, 106, 104, 105, 106, 107, 105, 106, 107, 108, 106, 107, 108, 109, 107, 108, 109, 110, 108, 109, 110, 111, 109, 110, 111, 112, 110, 111, 112, 113]) => Result.Ok("248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1")
-    shaHex([256]) => Result.Err("byte value outside 0..=255")
+    shaHex([256]) => Result.Err("byte 256 at index 0 is outside 0..=255")
 
 verify doubleShaHex
     doubleShaHex([97, 98, 99]) => Result.Ok("4f8b42c22dd3729b519ba6f68d2da7cc5b2d606d05daed5ad5128cc03e6c6358")

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -411,7 +411,8 @@ fn main() -> Unit
     report([65, 256])
     report([65, 1208925819614629174706176])
 "#;
-    let expected = "byte value outside 0..=255\nbyte value outside 0..=255";
+    let expected = "byte 256 at index 1 is outside 0..=255\n\
+                    byte 1208925819614629174706176 at index 1 is outside 0..=255";
 
     let vm = run_vm_inline("tcp_send_bytes_range", src).expect("vm run");
     let rust = build_run_rust_inline("tcp_send_bytes_range", src)

--- a/tests/wasip2_tcp.rs
+++ b/tests/wasip2_tcp.rs
@@ -667,7 +667,7 @@ fn main() -> Unit
         out.status.code(),
         String::from_utf8_lossy(&out.stderr)
     );
-    assert_eq!(s, "byte value outside 0..=255\n");
+    assert_eq!(s, "byte 256 at index 1 is outside 0..=255\n");
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/tests/wasm_gc_effect_arg_overflow_regression.rs
+++ b/tests/wasm_gc_effect_arg_overflow_regression.rs
@@ -183,7 +183,7 @@ fn main() -> Unit
         Result.Err(e) -> Console.print(e)
 "#;
     let out = run_wasm_gc(src).expect("Bytes range failure must be a catchable Result.Err");
-    assert_eq!(out, "byte value outside 0..=255\n");
+    assert_eq!(out, "byte 256 at index 1 is outside 0..=255\n");
 }
 
 #[test]
@@ -201,7 +201,10 @@ fn main() -> Unit
         Result.Err(e) -> Console.print(e)
 "#;
     let out = run_wasm_gc(src).expect("big Bytes range failure must be a catchable Result.Err");
-    assert_eq!(out, "byte value outside 0..=255\n");
+    assert_eq!(
+        out,
+        "byte 1208925819614629174706176 at index 1 is outside 0..=255\n"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Since the move of byte validation to the `Bytes` refinement boundary, `Bytes.fromList` rejects invalid input with a bare message:

```
Bytes.fromList([65, 256])  =>  Result.Err("byte value outside 0..=255")
```

The previous host-side `Tcp.sendBytes` validation named the offending value and its index, and `docs/services.md` advertised that. For a long binary payload the bare message means bisecting the list by hand to find the bad element.

## Fix

`stdlib/bytes.av` gains two error-path helpers (`firstOutOfRange`, `firstOutOfRangeIndex`) and interpolates them into the `Result.Err` message:

```
Bytes.fromList([65, 256])  =>  Result.Err("byte 256 at index 1 is outside 0..=255")
```

- The `allInRange` predicate and the smart-constructor gate shape are untouched, so the wasm-gc packed-sequence recognizer still derives the packed `(array i8)` layout from `stdlib/bytes.av` (`cargo test --lib packed_sequence` passes, including the test that runs the recognizer on the real stdlib source).
- The helpers build the index on the way out of the recursion instead of threading an accumulator parameter: a `(shrinking list, incrementing Int)` signature makes the Dafny backend infer `decreases |xs| - index`, which is not bounded below and fails `dafny verify`. The accumulator-free shape infers `decreases |xs|`.
- `docs/services.md` again documents that the error names the offending value and its index.

## Tests

- `cargo test --lib packed_sequence` (recognizer unit tests incl. real stdlib source)
- `cargo test --features wasm,wasip2 --test wasm_gc_packed_sequence` (packed differential suite)
- `cargo test --features wasm,wasip2 --test stdlib_spec` (VM verify + wasm-gc verify + wasip2 component)
- `cargo test --features wasm,wasip2 --test wasm_gc_effect_arg_overflow_regression bytes` (incl. bigint octet message)
- `cargo test --features wasm,wasip2 --test wasip2_tcp bytes_from_list`
- `cargo test --test rust_codegen_differential rust_tcp_send_bytes` (real cargo build, VM/Rust diff)
- `cargo test --test rust_codegen_regression rust_codegen_builds_embedded_bytes_crypto_fixture`
- `cargo test --test proof_spec embedded_bytes_and_crypto_digest_preserve_refinements_in_both_proof_backends` (lake + dafny checks ran locally)
- `cargo test --test proof_spec proof_lean_crypto_sha256_model_axiom_closure_is_core_only`
- `cargo test --test proof_spec lean_proves_string_escape_roundtrip_law_when_lake_is_available` (law proof that unfolds `Bytes.fromList` in its simp set)
- `cargo fmt`, `cargo clippy --tests --features wasm,wasip2` clean on touched code

🤖 Generated with [Claude Code](https://claude.com/claude-code)