### PR TITLE
Warn when a project module is shadowed by the embedded stdlib

### DIFF
--- a/docs/diagnostics-slugs.md
+++ b/docs/diagnostics-slugs.md
@@ -61,6 +61,7 @@ Source of truth: `src/diagnostics/classify.rs` (classifier) and `src/checker/*.r
 |---|---|---|---|
 | `unknown-impact` | warning | A `decision`'s impact symbol doesn't resolve in scope. | Check spelling; remove if intentional. |
 | `unused-expose` | warning | Module `exposes` a name nobody imports. | Drop from `exposes` or start using it. |
+| `stdlib-shadow` | warning | A `depends` entry names an embedded standard module while a same-named project file exists; the project file is silently ignored because the standard library wins resolution. | Rename the project module and its `depends [...]` entries to use the project file. |
 
 ## Naming conventions
 

--- a/src/diagnostics/analyze.rs
+++ b/src/diagnostics/analyze.rs
@@ -30,6 +30,13 @@ pub struct AnalyzeOptions {
     /// `module_base_dir` — the type checker integrates these directly
     /// instead of loading from disk.
     pub loaded_modules: Option<Vec<LoadedModule>>,
+    /// `(module_name, ignored_file)` pairs for `depends` entries that
+    /// resolve to an embedded standard module while a same-named project
+    /// file exists (which module resolution silently ignores). Precomputed
+    /// by callers — `crate::source::collect_stdlib_shadowed` (disk) or
+    /// `collect_stdlib_shadowed_in_map` (playground) — because detection
+    /// needs the caller's file universe; each entry becomes a warning.
+    pub stdlib_shadowed: Vec<(String, String)>,
     pub include_intent_warnings: bool,
     pub include_coverage_warnings: bool,
     pub include_law_dependency_warnings: bool,
@@ -75,6 +82,7 @@ impl Default for AnalyzeOptions {
             file_label: "<input>".to_string(),
             module_base_dir: None,
             loaded_modules: None,
+            stdlib_shadowed: Vec::new(),
             include_intent_warnings: true,
             include_coverage_warnings: true,
             include_law_dependency_warnings: true,
@@ -195,6 +203,33 @@ pub fn analyze_source(source: &str, options: &AnalyzeOptions) -> AnalysisReport 
             diagnostics.push(from_check_finding(
                 Severity::Warning,
                 &w,
+                source,
+                &options.file_label,
+            ));
+        }
+    }
+
+    // Stdlib-shadowing: a `depends` entry resolved to an embedded standard
+    // module while a same-named project file exists — that file is silently
+    // ignored, so the program runs with stdlib semantics regardless of what
+    // the project file says. Anchored on the module declaration line (the
+    // `depends [...]` list lives in its indented block).
+    if !options.stdlib_shadowed.is_empty() {
+        let (module_name, module_line) = crate::visibility::module_decl(&items)
+            .map(|m| (Some(m.name.clone()), m.line))
+            .unwrap_or((None, 1));
+        for (dep_name, shadowed_path) in &options.stdlib_shadowed {
+            let finding = CheckFinding {
+                line: module_line,
+                module: module_name.clone(),
+                file: None,
+                fn_name: None,
+                message: crate::source::stdlib_shadow_message(dep_name, shadowed_path),
+                extra_spans: vec![],
+            };
+            diagnostics.push(from_check_finding(
+                Severity::Warning,
+                &finding,
                 source,
                 &options.file_label,
             ));

--- a/src/diagnostics/classify.rs
+++ b/src/diagnostics/classify.rs
@@ -349,6 +349,8 @@ pub(crate) fn classify_finding(msg: &str) -> (&'static str, Option<String>) {
             "bad-field-name",
             Some("Rename the field to camelCase".to_string()),
         )
+    } else if msg.contains("reserved by the Aver standard library") {
+        ("stdlib-shadow", split_repair(msg))
     } else if msg.contains("verify examples") || msg.contains("verify case") {
         ("verify-coverage", None)
     } else {

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -1428,6 +1428,7 @@ fn run_check_for_file(
         let opts = diagnostic::AnalyzeOptions {
             file_label: shown_path.clone(),
             module_base_dir: Some(module_root.to_string()),
+            stdlib_shadowed: aver::source::collect_stdlib_shadowed(items, module_root),
             ..Default::default()
         };
         let report = diagnostic::analyze_source(source, &opts);

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -551,6 +551,10 @@ fn analyze_project(
     // analyze_source with proper diagnostic formatting.
     if let Ok(items) = parse_source(&entry_source) {
         let depends = load_roots(&items);
+        // The map loader silently prefers embedded standard modules over
+        // same-named virtual files and has no warning channel of its own,
+        // so shadowing surfaces here as a check diagnostic.
+        opts.stdlib_shadowed = crate::source::collect_stdlib_shadowed_in_map(&items, files);
         if let Ok(loaded) = crate::source::load_module_tree_from_map(&depends, files) {
             opts = opts.with_loaded_modules(loaded);
         }
@@ -1253,6 +1257,43 @@ fn main() -> Int
             "playground project compile should use wasm-gc, got:\n{}",
             wat
         );
+    }
+
+    #[test]
+    fn check_project_reports_stdlib_shadowing() {
+        let entry = "module Main\n    intent = \"use Bytes\"\n    depends [Bytes]\n    effects []\n\nfn byteCount(values: List<Int>) -> Result<Int, String>\n    ? \"Count validated bytes.\"\n    bytes = Bytes.fromList(values)?\n    Result.Ok(List.len(Bytes.toList(bytes)))\n\nverify byteCount\n    byteCount([1, 2]) => Result.Ok(2)\n";
+        let mut files = HashMap::new();
+        files.insert("main.av".to_string(), entry.to_string());
+        files.insert(
+            "bytes.av".to_string(),
+            "module Bytes\n    intent = \"project-local Bytes\"\n".to_string(),
+        );
+        let report: serde_json::Value =
+            serde_json::from_str(&check_project(&files, "main.av")).unwrap();
+        let slugs: Vec<String> = report["diagnostics"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|d| d["slug"].as_str().map(str::to_string))
+            .collect();
+        assert!(
+            slugs.iter().any(|s| s == "stdlib-shadow"),
+            "expected stdlib-shadow diagnostic, got: {:?}",
+            slugs
+        );
+
+        // Negative: no virtual file for the reserved name — no finding.
+        files.remove("bytes.av");
+        let report: serde_json::Value =
+            serde_json::from_str(&check_project(&files, "main.av")).unwrap();
+        let has_shadow = report["diagnostics"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .iter()
+            .any(|d| d["slug"] == "stdlib-shadow");
+        assert!(!has_shadow, "unexpected stdlib-shadow diagnostic");
     }
 
     #[test]

--- a/src/source.rs
+++ b/src/source.rs
@@ -99,6 +99,83 @@ pub fn resolve_standard_module_source(name: &str) -> Option<ModuleSource> {
     })
 }
 
+/// Project file that [`find_module_file`] would resolve for `name`, present
+/// even though the embedded standard library reserves the name. `Some` means
+/// module resolution silently ignores the on-disk file.
+pub fn stdlib_shadowed_project_file(name: &str, module_root: &str) -> Option<PathBuf> {
+    crate::stdlib::find(name)?;
+    find_module_file(name, module_root)
+}
+
+/// Shared wording for the stdlib-shadowing warning, used by both the
+/// load-time stderr warning and the `aver check` finding so the two
+/// channels never drift apart.
+pub fn stdlib_shadow_message(name: &str, shadowed_path: &str) -> String {
+    format!(
+        "module '{}' is reserved by the Aver standard library; project file \
+         '{}' is NOT loaded — rename the module and its `depends [...]` \
+         entries to use the project file",
+        name, shadowed_path
+    )
+}
+
+/// Emit the stdlib-shadowing warning once per process per module name.
+/// Resolution runs several times per command (typecheck tree walk, dep
+/// compile walk, check units), and repeating the identical warning would
+/// drown the signal.
+fn warn_stdlib_shadow_once(name: &str, shadowed_path: &Path) {
+    use std::sync::{Mutex, OnceLock};
+    static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    let mut warned = WARNED
+        .get_or_init(Default::default)
+        .lock()
+        .expect("stdlib shadow warning set poisoned");
+    if warned.insert(name.to_string()) {
+        eprintln!(
+            "warning: {}",
+            stdlib_shadow_message(name, &shadowed_path.display().to_string())
+        );
+    }
+}
+
+/// `(module_name, ignored_project_file)` pairs for every `depends` entry of
+/// `items` where the embedded standard library wins over a same-named
+/// project file in `module_root`. Feed the result to
+/// `AnalyzeOptions::stdlib_shadowed` so `aver check` surfaces the shadowing.
+pub fn collect_stdlib_shadowed(items: &[TopLevel], module_root: &str) -> Vec<(String, String)> {
+    let Some(module) = visibility::module_decl(items) else {
+        return Vec::new();
+    };
+    module
+        .depends
+        .iter()
+        .filter_map(|dep| {
+            stdlib_shadowed_project_file(dep, module_root)
+                .map(|path| (dep.clone(), path.display().to_string()))
+        })
+        .collect()
+}
+
+/// Virtual-fs sibling of [`collect_stdlib_shadowed`] for the playground:
+/// flags `depends` entries whose name the standard library reserves while
+/// the in-memory file map also carries a file for that module.
+pub fn collect_stdlib_shadowed_in_map(
+    items: &[TopLevel],
+    files: &HashMap<String, String>,
+) -> Vec<(String, String)> {
+    let Some(module) = visibility::module_decl(items) else {
+        return Vec::new();
+    };
+    module
+        .depends
+        .iter()
+        .filter_map(|dep| {
+            crate::stdlib::find(dep)?;
+            find_file_key_in_map(dep, files).map(|key| (dep.clone(), key))
+        })
+        .collect()
+}
+
 /// Resolve and read a project or standard-library module.
 ///
 /// The standard library is checked first so its module names cannot be
@@ -109,6 +186,12 @@ pub fn resolve_module_source(
     module_root: &str,
 ) -> Result<Option<ModuleSource>, String> {
     if let Some(module) = resolve_standard_module_source(name) {
+        // The embedded module wins, but a same-named project file on disk
+        // means the user probably expects their own code to load — say so
+        // instead of silently changing program meaning.
+        if let Some(shadowed) = find_module_file(name, module_root) {
+            warn_stdlib_shadow_once(name, &shadowed);
+        }
         return Ok(Some(module));
     }
 
@@ -165,6 +248,12 @@ fn load_recursive_from_map(
     loading: &mut Vec<String>,
     result: &mut Vec<LoadedModule>,
 ) -> Result<(), String> {
+    // The embedded standard library wins over a same-named virtual file,
+    // exactly like the filesystem loaders. No warning is emitted here: this
+    // loader's only output channel is `Result<_, String>` (hard errors) and
+    // browser builds drop stderr, so the playground surfaces shadowing as an
+    // `aver check` diagnostic instead (`collect_stdlib_shadowed_in_map`,
+    // wired in `playground::analyze_project`).
     let (key, source) = if let Some(module) = crate::stdlib::find(dep_name) {
         (module.virtual_path.to_string(), module.source.to_string())
     } else {
@@ -548,8 +637,9 @@ fn load_module_recursive_for_compile(
 #[cfg(test)]
 mod tests {
     use super::{
-        load_module_tree, load_module_tree_from_map, parse_source, require_module_declaration,
-        resolve_module_source,
+        collect_stdlib_shadowed, collect_stdlib_shadowed_in_map, load_module_tree,
+        load_module_tree_from_map, parse_source, require_module_declaration, resolve_module_source,
+        stdlib_shadowed_project_file,
     };
 
     #[test]
@@ -585,6 +675,61 @@ mod tests {
         let resolved =
             resolve_module_source("DefinitelyNotARealModule", ".").expect("resolve unknown module");
         assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn stdlib_shadowed_project_file_flags_reserved_names_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("bytes.av"), "module Bytes\n").expect("write bytes.av");
+        std::fs::write(dir.path().join("helpers.av"), "module Helpers\n")
+            .expect("write helpers.av");
+        let root = dir.path().to_str().expect("utf8 root");
+
+        // Reserved name + same-named project file = shadowed.
+        let shadowed = stdlib_shadowed_project_file("Bytes", root).expect("bytes.av is shadowed");
+        assert!(shadowed.ends_with("bytes.av"));
+        // The embedded module still wins resolution.
+        let resolved = resolve_module_source("Bytes", root)
+            .expect("resolve")
+            .expect("Bytes is shipped with Aver");
+        assert_eq!(resolved.path.to_string_lossy(), "<aver-stdlib>/bytes.av");
+        // Non-reserved names and reserved names without a project file
+        // are not shadowed.
+        assert!(stdlib_shadowed_project_file("Helpers", root).is_none());
+        assert!(stdlib_shadowed_project_file("Crypto.Digest32", root).is_none());
+    }
+
+    #[test]
+    fn collect_stdlib_shadowed_reports_depends_entries_with_project_files() {
+        let items = parse_source("module Main\n    intent = \"t\"\n    depends [Bytes]\n")
+            .expect("parse entry");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("bytes.av"), "module Bytes\n").expect("write bytes.av");
+        let pairs = collect_stdlib_shadowed(&items, dir.path().to_str().expect("utf8 root"));
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, "Bytes");
+        assert!(pairs[0].1.ends_with("bytes.av"));
+
+        // Negative: no project file for the reserved name — no finding.
+        let empty = tempfile::tempdir().expect("empty tempdir");
+        assert!(collect_stdlib_shadowed(&items, empty.path().to_str().expect("utf8")).is_empty());
+    }
+
+    #[test]
+    fn collect_stdlib_shadowed_in_map_flags_virtual_files() {
+        let items = parse_source("module Main\n    intent = \"t\"\n    depends [Bytes]\n")
+            .expect("parse entry");
+
+        let mut files = std::collections::HashMap::new();
+        files.insert("bytes.av".to_string(), "module Bytes\n".to_string());
+        assert_eq!(
+            collect_stdlib_shadowed_in_map(&items, &files),
+            vec![("Bytes".to_string(), "bytes.av".to_string())]
+        );
+
+        // Negative: the virtual fs has no file for the reserved name.
+        assert!(collect_stdlib_shadowed_in_map(&items, &Default::default()).is_empty());
     }
 
     #[test]

--- a/tests/stdlib_spec.rs
+++ b/tests/stdlib_spec.rs
@@ -30,6 +30,61 @@ fn temp_output_dir(prefix: &str) -> PathBuf {
 }
 
 #[test]
+fn check_warns_when_project_module_is_shadowed_by_the_stdlib() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("bytes.av"),
+        "module Bytes\n    intent = \"project-local Bytes\"\n    exposes [fromList]\n    effects []\n\nrecord Bytes\n    values: List<Int>\n\nfn fromList(xs: List<Int>) -> Result<Bytes, String>\n    ? \"Accept anything.\"\n    Result.Ok(Bytes(values = xs))\n",
+    )
+    .expect("write bytes.av");
+    let entry = dir.path().join("main.av");
+    std::fs::write(
+        &entry,
+        "module Main\n    intent = \"use Bytes\"\n    depends [Bytes]\n    effects []\n\nfn byteCount(values: List<Int>) -> Result<Int, String>\n    ? \"Validate bytes and count them.\"\n    bytes = Bytes.fromList(values)?\n    Result.Ok(List.len(Bytes.toList(bytes)))\n\nverify byteCount\n    byteCount([1, 2]) => Result.Ok(2)\n    byteCount([300]) => Result.Err(\"byte value outside 0..=255\")\n",
+    )
+    .expect("write main.av");
+    let root = dir.path().to_string_lossy().into_owned();
+    let entry_path = entry.to_string_lossy().into_owned();
+
+    let check = run_aver(&["check", &entry_path, "--module-root", &root, "--json"]);
+    // Shadowing is a warning, not an error — check must still pass.
+    assert_success("aver check (shadowed)", &check);
+    let stdout = String::from_utf8_lossy(&check.stdout);
+    assert!(stdout.contains("\"slug\":\"stdlib-shadow\""), "{stdout}");
+    assert!(
+        stdout.contains("reserved by the Aver standard library"),
+        "{stdout}"
+    );
+    // The module loader also warns on stderr at load time.
+    let stderr = String::from_utf8_lossy(&check.stderr);
+    assert!(stderr.contains("is NOT loaded"), "{stderr}");
+    assert!(stderr.contains("bytes.av"), "{stderr}");
+}
+
+#[test]
+fn check_stays_silent_when_no_project_file_shadows_the_stdlib() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.av");
+    std::fs::write(
+        &entry,
+        "module Main\n    intent = \"use Bytes\"\n    depends [Bytes]\n    effects []\n\nfn byteCount(values: List<Int>) -> Result<Int, String>\n    ? \"Validate bytes and count them.\"\n    bytes = Bytes.fromList(values)?\n    Result.Ok(List.len(Bytes.toList(bytes)))\n\nverify byteCount\n    byteCount([1, 2]) => Result.Ok(2)\n    byteCount([300]) => Result.Err(\"byte value outside 0..=255\")\n",
+    )
+    .expect("write main.av");
+    let root = dir.path().to_string_lossy().into_owned();
+    let entry_path = entry.to_string_lossy().into_owned();
+
+    let check = run_aver(&["check", &entry_path, "--module-root", &root, "--json"]);
+    assert_success("aver check (no shadow)", &check);
+    let stdout = String::from_utf8_lossy(&check.stdout);
+    assert!(!stdout.contains("stdlib-shadow"), "{stdout}");
+    let stderr = String::from_utf8_lossy(&check.stderr);
+    assert!(
+        !stderr.contains("reserved by the Aver standard library"),
+        "{stderr}"
+    );
+}
+
+#[test]
 fn embedded_bytes_module_works_outside_the_project_module_root() {
     let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/stdlib_bytes_app.av")


### PR DESCRIPTION
## Problem

Module resolution checks the embedded standard library before the filesystem, so a project file whose module name the stdlib reserves is silently ignored. Concrete example: a project `bytes.av` declaring `module Bytes` with its own `fromList` next to a `main.av` with `depends [Bytes]` — `aver run` uses the embedded semantics (`Bytes.fromList([300])` is rejected instead of accepted) with zero indication anywhere, and `aver check` has no finding for it. A stdlib upgrade that reserves a new name can therefore change program meaning silently.

## Fix

When a dependency resolves to an embedded standard module and `find_module_file` would have found a project file for the same name:

- `resolve_module_source` prints a load-time stderr warning (once per process per module name, since resolution runs in several phases per command), in the style of the existing "non-law verify block(s) ... are NOT checked" warning.
- `aver check` emits a `stdlib-shadow` warning finding (also in `--json`), anchored on the module declaration, with a repair suggestion. Detection is precomputed by callers (`collect_stdlib_shadowed` on disk, `collect_stdlib_shadowed_in_map` for the virtual fs) so `analyze_source` stays IO-free.
- The playground's `check_project` surfaces the same diagnostic for shadowed virtual files. The map loader itself stays silent — its only output channel is hard errors and browser builds drop stderr — documented with a comment at the resolution site.

`docs/diagnostics-slugs.md` documents the new slug.

## Tests

- `tests/stdlib_spec.rs`: end-to-end `aver check --json` on a shadowed `bytes.av` fixture asserts the `stdlib-shadow` finding, the stderr load warning, and that the exit code stays 0; a negative run without the project file asserts silence on both channels.
- `src/source.rs`: unit tests for `stdlib_shadowed_project_file` / `collect_stdlib_shadowed` / `collect_stdlib_shadowed_in_map`, including that the embedded module still wins resolution.
- `src/playground.rs`: `check_project` reports the diagnostic for a shadowed virtual file and stays silent without one (wasm feature lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
