### PR TITLE
Gate wasip2 TCP helpers on declared effects and align readBytes error classification

### DIFF
--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -1017,6 +1017,12 @@ impl TypeRegistry {
                 b"Tcp.writeBytes: malformed Bytes carrier".as_ref(),
                 b"Tcp.readBytes: count is negative".as_ref(),
                 b"Tcp.readBytes: count exceeds the 10485760 byte limit".as_ref(),
+                // Out-of-i64 counts get their own message, mirroring
+                // the VM's `count_arg` classification: i64-fit is
+                // checked before sign, so an out-of-i64 count of
+                // either sign reports "exceeds the read limit",
+                // never "is negative" or the 10485760 text.
+                b"Tcp.readBytes: count exceeds the read limit".as_ref(),
                 b"failed to fill whole buffer".as_ref(),
                 // Phase 4.7+ — port validation. VM message verbatim
                 // (`Tcp: port N is out of range (0\u{2013}65535)`)

--- a/src/codegen/wasm_gc/wasip2_tcp/io.rs
+++ b/src/codegen/wasm_gc/wasip2_tcp/io.rs
@@ -1116,6 +1116,12 @@ pub(in crate::codegen::wasm_gc) struct TcpReadBytesIndices {
     pub negative_len: u32,
     pub limit_segment_idx: u32,
     pub limit_len: u32,
+    /// Out-of-i64 counts (either sign) — `"Tcp.readBytes: count
+    /// exceeds the read limit"`, mirroring the VM's `count_arg`
+    /// classification where the i64-fit check fires before the sign
+    /// and 10485760-limit checks.
+    pub read_limit_segment_idx: u32,
+    pub read_limit_len: u32,
     pub short_read_segment_idx: u32,
     pub short_read_len: u32,
     pub unknown_segment_idx: u32,
@@ -1207,6 +1213,11 @@ pub(in crate::codegen::wasm_gc) fn emit_tcp_read_bytes(
 
     // Big values cannot fit the bounded read request. Small values retain
     // their exact i64 representation for the ordinary range checks below.
+    // Branch classification mirrors the VM (`count_arg` +
+    // `aver_rt::tcp::read_bytes`): out-of-i64 counts of either sign
+    // report "exceeds the read limit" before the sign check ever runs,
+    // in-i64 negatives report "is negative", and in-i64 over-limit
+    // counts report the 10485760 byte limit.
     f.instruction(&Instruction::LocalGet(1));
     f.instruction(&Instruction::StructGet {
         struct_type_index: indices.aint_struct_type_idx,
@@ -1215,7 +1226,11 @@ pub(in crate::codegen::wasm_gc) fn emit_tcp_read_bytes(
     f.instruction(&Instruction::RefIsNull);
     f.instruction(&Instruction::I32Eqz);
     f.instruction(&Instruction::If(BlockType::Empty));
-    emit_err(&mut f, indices.limit_segment_idx, indices.limit_len);
+    emit_err(
+        &mut f,
+        indices.read_limit_segment_idx,
+        indices.read_limit_len,
+    );
     f.instruction(&Instruction::End);
     f.instruction(&Instruction::LocalGet(1));
     f.instruction(&Instruction::StructGet {
@@ -1460,6 +1475,8 @@ mod tests {
             negative_len: 1,
             limit_segment_idx: 8,
             limit_len: 1,
+            read_limit_segment_idx: 11,
+            read_limit_len: 1,
             short_read_segment_idx: 9,
             short_read_len: 1,
             unknown_segment_idx: 10,

--- a/src/codegen/wasm_gc/wasip2_tcp/wireup.rs
+++ b/src/codegen/wasm_gc/wasip2_tcp/wireup.rs
@@ -71,13 +71,25 @@ pub(in crate::codegen::wasm_gc) fn allocate(
     next_type_idx: &mut u32,
     next_builtin_fn_idx: &mut u32,
 ) -> TcpHelpers {
-    let connect = allocate_connect(
-        registry,
-        wasip2_imports,
-        types,
-        next_type_idx,
-        next_builtin_fn_idx,
-    );
+    // Every helper allocation is gated on its declared effect, not
+    // just registry / wasi-import availability. Without the effect
+    // gate, one Tcp.* effect registers enough shared slots (the
+    // needs_tcp literals, the pool types, the wasi:io stream pair)
+    // that unrelated helpers allocate coincidentally and ship as
+    // dead module bytes — e.g. `Tcp.writeLine` + `Console.readLine`
+    // used to emit the whole `__rt_tcp_read_line` body.
+    let declares = |name: EffectName| effects.iter().any(|effect| effect == name);
+    let connect = declares(EffectName::TcpConnect)
+        .then(|| {
+            allocate_connect(
+                registry,
+                wasip2_imports,
+                types,
+                next_type_idx,
+                next_builtin_fn_idx,
+            )
+        })
+        .flatten();
     let format_id = allocate_format_id(
         registry,
         &connect,
@@ -85,18 +97,36 @@ pub(in crate::codegen::wasm_gc) fn allocate(
         next_type_idx,
         next_builtin_fn_idx,
     );
-    let parse_id = allocate_parse_id(registry, types, next_type_idx, next_builtin_fn_idx);
-    let write_line = allocate_write_line(
-        registry,
-        wasip2_imports,
-        parse_id,
-        types,
-        next_type_idx,
-        next_builtin_fn_idx,
-    );
-    let write_bytes = effects
+    // parse_id is shared by every pool-consuming helper (write_line /
+    // write_bytes / read_line / read_bytes / close), so it gates on
+    // the union of their effects.
+    let parse_id = effects
         .iter()
-        .any(|effect| effect == EffectName::TcpWriteBytes)
+        .any(|effect| {
+            matches!(
+                effect,
+                EffectName::TcpWriteLine
+                    | EffectName::TcpWriteBytes
+                    | EffectName::TcpReadLine
+                    | EffectName::TcpReadBytes
+                    | EffectName::TcpClose
+            )
+        })
+        .then(|| allocate_parse_id(registry, types, next_type_idx, next_builtin_fn_idx))
+        .flatten();
+    let write_line = declares(EffectName::TcpWriteLine)
+        .then(|| {
+            allocate_write_line(
+                registry,
+                wasip2_imports,
+                parse_id,
+                types,
+                next_type_idx,
+                next_builtin_fn_idx,
+            )
+        })
+        .flatten();
+    let write_bytes = declares(EffectName::TcpWriteBytes)
         .then(|| {
             allocate_write_bytes(
                 registry,
@@ -108,17 +138,19 @@ pub(in crate::codegen::wasm_gc) fn allocate(
             )
         })
         .flatten();
-    let read_line = allocate_read_line(
-        registry,
-        wasip2_imports,
-        parse_id,
-        types,
-        next_type_idx,
-        next_builtin_fn_idx,
-    );
-    let read_bytes = effects
-        .iter()
-        .any(|effect| effect == EffectName::TcpReadBytes)
+    let read_line = declares(EffectName::TcpReadLine)
+        .then(|| {
+            allocate_read_line(
+                registry,
+                wasip2_imports,
+                parse_id,
+                types,
+                next_type_idx,
+                next_builtin_fn_idx,
+            )
+        })
+        .flatten();
+    let read_bytes = declares(EffectName::TcpReadBytes)
         .then(|| {
             allocate_read_bytes(
                 registry,
@@ -130,35 +162,51 @@ pub(in crate::codegen::wasm_gc) fn allocate(
             )
         })
         .flatten();
-    let close = allocate_close(
-        registry,
-        wasip2_imports,
-        parse_id,
-        types,
-        next_type_idx,
-        next_builtin_fn_idx,
-    );
-    let send = allocate_send(
-        registry,
-        wasip2_imports,
-        types,
-        next_type_idx,
-        next_builtin_fn_idx,
-    );
-    let send_bytes = allocate_send_bytes(
-        registry,
-        wasip2_imports,
-        types,
-        next_type_idx,
-        next_builtin_fn_idx,
-    );
-    let ping = allocate_ping(
-        registry,
-        wasip2_imports,
-        types,
-        next_type_idx,
-        next_builtin_fn_idx,
-    );
+    let close = declares(EffectName::TcpClose)
+        .then(|| {
+            allocate_close(
+                registry,
+                wasip2_imports,
+                parse_id,
+                types,
+                next_type_idx,
+                next_builtin_fn_idx,
+            )
+        })
+        .flatten();
+    let send = declares(EffectName::TcpSend)
+        .then(|| {
+            allocate_send(
+                registry,
+                wasip2_imports,
+                types,
+                next_type_idx,
+                next_builtin_fn_idx,
+            )
+        })
+        .flatten();
+    let send_bytes = declares(EffectName::TcpSendBytes)
+        .then(|| {
+            allocate_send_bytes(
+                registry,
+                wasip2_imports,
+                types,
+                next_type_idx,
+                next_builtin_fn_idx,
+            )
+        })
+        .flatten();
+    let ping = declares(EffectName::TcpPing)
+        .then(|| {
+            allocate_ping(
+                registry,
+                wasip2_imports,
+                types,
+                next_type_idx,
+                next_builtin_fn_idx,
+            )
+        })
+        .flatten();
     TcpHelpers {
         connect,
         format_id,
@@ -317,13 +365,14 @@ fn allocate_parse_id(
     next_type_idx: &mut u32,
     next_builtin_fn_idx: &mut u32,
 ) -> Option<(u32, u32)> {
-    // Gate on `needs_tcp` (via the slot type idx) rather than the
-    // connect helper specifically. close / write_line / read_line
-    // each need parse_id; a program that only consumes a
+    // The caller gates on the union of the pool-consuming effects
+    // rather than the connect helper specifically. close / write_line
+    // / read_line each need parse_id; a program that only consumes a
     // `Tcp.Connection` parameter (e.g. `fn handle(c: Tcp.Connection)
     // ! [Tcp.close]`) graduates close in `effect_check` without ever
     // declaring `Tcp.connect`, and would otherwise hit an `expect`
-    // at emit time.
+    // at emit time. The slot type idx check stays as the registry
+    // availability gate.
     registry.tcp_slot_type_idx?;
     let s_idx = registry.string_array_type_idx?;
     let s_ref = ValType::Ref(wasm_encoder::RefType {
@@ -515,6 +564,8 @@ fn allocate_read_bytes(
     let negative_seg = registry.string_literal_segment(b"Tcp.readBytes: count is negative")?;
     let limit_seg =
         registry.string_literal_segment(b"Tcp.readBytes: count exceeds the 10485760 byte limit")?;
+    let read_limit_seg =
+        registry.string_literal_segment(b"Tcp.readBytes: count exceeds the read limit")?;
     let short_read_seg = registry.string_literal_segment(b"failed to fill whole buffer")?;
     let unknown_seg = registry.string_literal_segment(b"tcp: unknown connection")?;
     wasip2_imports.lookup_wasm_fn_idx(Wasip2ImportSlot::InputStreamBlockingRead)?;
@@ -550,6 +601,8 @@ fn allocate_read_bytes(
         negative_len: b"Tcp.readBytes: count is negative".len() as u32,
         limit_segment_idx: limit_seg,
         limit_len: b"Tcp.readBytes: count exceeds the 10485760 byte limit".len() as u32,
+        read_limit_segment_idx: read_limit_seg,
+        read_limit_len: b"Tcp.readBytes: count exceeds the read limit".len() as u32,
         short_read_segment_idx: short_read_seg,
         short_read_len: b"failed to fill whole buffer".len() as u32,
         unknown_segment_idx: unknown_seg,

--- a/tests/wasip2_codegen_regression.rs
+++ b/tests/wasip2_codegen_regression.rs
@@ -290,3 +290,172 @@ fn wasip2_codegen_emits_valid_component_for_every_single_file_example() {
         compiled
     );
 }
+
+/// Map every passive data segment in a core module to its index, and
+/// collect the `array.new_data` data-segment references of every code
+/// body (one Vec per body, in code-section order). Helper for the
+/// TCP helper-gating and readBytes-classification regressions below.
+fn segments_and_body_data_refs(bytes: &[u8]) -> (Vec<Vec<u8>>, Vec<Vec<u32>>) {
+    use wasmparser::{Operator, Parser as WasmParser, Payload};
+
+    let mut segments: Vec<Vec<u8>> = Vec::new();
+    let mut body_refs: Vec<Vec<u32>> = Vec::new();
+    for payload in WasmParser::new(0).parse_all(bytes) {
+        match payload.expect("generated module must parse") {
+            Payload::DataSection(reader) => {
+                for data in reader {
+                    segments.push(data.expect("data segment").data.to_vec());
+                }
+            }
+            Payload::CodeSectionEntry(body) => {
+                let mut refs = Vec::new();
+                let mut ops = body.get_operators_reader().expect("operators");
+                while !ops.eof() {
+                    if let Operator::ArrayNewData {
+                        array_data_index, ..
+                    } = ops.read().expect("operator")
+                    {
+                        refs.push(array_data_index);
+                    }
+                }
+                body_refs.push(refs);
+            }
+            _ => {}
+        }
+    }
+    (segments, body_refs)
+}
+
+fn segment_idx(segments: &[Vec<u8>], text: &[u8]) -> u32 {
+    segments
+        .iter()
+        .position(|seg| seg == text)
+        .unwrap_or_else(|| {
+            panic!(
+                "data segment {:?} must be present",
+                String::from_utf8_lossy(text)
+            )
+        }) as u32
+}
+
+/// TCP helper allocation is gated on declared effects, not on
+/// coincidental registry / wasi-import availability. This program
+/// declares `Tcp.writeLine` (plus connect/close and the Console pair
+/// whose imports made the leak possible): `Console.readLine` registers
+/// the `input-stream.blocking-read` import and interns
+/// `Result<String,String>`, which used to be enough for the unused
+/// `__rt_tcp_read_line` and `__rt_tcp_send` helper bodies to ride
+/// along as dead module bytes.
+#[test]
+fn wasip2_tcp_helpers_absent_without_their_declared_effects() {
+    let source = r#"module Probe
+    intent = "Persistent line-oriented TCP client."
+    exposes [main]
+    effects [Tcp.connect, Tcp.writeLine, Tcp.close, Console.readLine, Console.print]
+
+fn chat(conn: Tcp.Connection, line: String) -> Result<Unit, String>
+    ? "Write one line, then close the connection."
+    ! [Tcp.writeLine, Tcp.close]
+    _w = Tcp.writeLine(conn, line)?
+    Tcp.close(conn)
+
+fn main() -> Unit
+    ! [Tcp.connect, Tcp.writeLine, Tcp.close, Console.readLine, Console.print]
+    match Console.readLine()
+        Result.Ok(line) -> match Tcp.connect("127.0.0.1", 4242)
+            Result.Ok(conn) -> match chat(conn, line)
+                Result.Ok(_) -> Console.print("sent")
+                Result.Err(e) -> Console.print("tcp error: {e}")
+            Result.Err(e) -> Console.print("connect error: {e}")
+        Result.Err(e) -> Console.print("stdin error: {e}")
+"#;
+    let items = parse_pipeline(source).unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc_for_wasip2(&items, None)
+        .unwrap_or_else(|e| panic!("wasip2 core compile: {e}\n--- source ---\n{source}"));
+
+    let (segments, body_refs) = segments_and_body_data_refs(&bytes);
+    let referenced = |seg: u32| -> bool { body_refs.iter().any(|refs| refs.contains(&seg)) };
+
+    // Present: the declared effects' own helpers keep their bodies.
+    let write_failed = segment_idx(&segments, b"tcp: write failed");
+    let connect_limit = segment_idx(&segments, b"tcp: connection limit reached (256 max)");
+    assert!(
+        referenced(write_failed),
+        "Tcp.writeLine is declared — its helper body must reference \"tcp: write failed\""
+    );
+    assert!(
+        referenced(connect_limit),
+        "Tcp.connect is declared — its helper body must reference the pool-limit segment"
+    );
+
+    // Absent: no declared effect needs these helpers, so no body may
+    // reference their distinctive segments. "tcp: eof" is only used
+    // by `__rt_tcp_read_line`; the 10 MiB response cap is only used
+    // by `__rt_tcp_send` / `__rt_tcp_send_bytes`.
+    let eof = segment_idx(&segments, b"tcp: eof");
+    assert!(
+        !referenced(eof),
+        "Tcp.readLine is not declared — the read_line helper must not be emitted"
+    );
+    let response_cap = segment_idx(&segments, b"tcp: response exceeds 10 MiB limit");
+    assert!(
+        !referenced(response_cap),
+        "Tcp.send / Tcp.sendBytes are not declared — their helpers must not be emitted"
+    );
+}
+
+/// `Tcp.readBytes` count-error classification on native wasip2 must
+/// match the VM (`src/services/tcp.rs` `count_arg` +
+/// `aver_rt::tcp::read_bytes`), branch by branch:
+///
+/// 1. count outside i64 (either sign) → "exceeds the read limit"
+/// 2. in-i64 count < 0 → "is negative"
+/// 3. in-i64 count > 10485760 → "exceeds the 10485760 byte limit"
+///
+/// Residual difference: the VM interpolates the offending count
+/// (`"Tcp.readBytes: count -1 is negative"`), while the wasip2 helper
+/// builds its Err strings from static data segments and cannot splice
+/// the number in — so the wasip2 texts are the VM texts minus the
+/// `count N` value. The error class (catchable Result.Err) is
+/// identical everywhere.
+#[test]
+fn wasip2_tcp_read_bytes_count_error_classification_matches_vm() {
+    let source = r#"module Probe
+    intent = "Compile exact-length binary reads."
+    depends [Bytes]
+    exposes [read]
+    effects [Tcp.readBytes]
+
+fn read(conn: Tcp.Connection, count: Int) -> Result<Bytes, String>
+    ? "Read one length-delimited binary frame."
+    ! [Tcp.readBytes]
+    Tcp.readBytes(conn, count)
+"#;
+    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc_for_wasip2(&items, None)
+        .unwrap_or_else(|e| panic!("wasip2 core compile: {e}\n--- source ---\n{source}"));
+
+    let (segments, body_refs) = segments_and_body_data_refs(&bytes);
+    let read_limit = segment_idx(&segments, b"Tcp.readBytes: count exceeds the read limit");
+    let negative = segment_idx(&segments, b"Tcp.readBytes: count is negative");
+    let byte_limit = segment_idx(
+        &segments,
+        b"Tcp.readBytes: count exceeds the 10485760 byte limit",
+    );
+
+    // The read_bytes helper is the only body referencing the
+    // "is negative" segment. Its first three Err materializations
+    // appear in check order, pinning the branch classification:
+    // out-of-i64 first (read limit), then sign, then the byte limit.
+    let helper_refs = body_refs
+        .iter()
+        .find(|refs| refs.contains(&negative))
+        .expect("a body referencing the readBytes negative-count segment must exist");
+    assert_eq!(
+        &helper_refs[..3],
+        &[read_limit, negative, byte_limit],
+        "readBytes count checks must classify: out-of-i64 -> read limit, \
+         in-i64 negative -> is negative, in-i64 over-limit -> 10485760 byte limit"
+    );
+}


### PR DESCRIPTION
## Problem

Two wasip2 TCP parity gaps from the #777/#779 reviews:

1. In `src/codegen/wasm_gc/wasip2_tcp/wireup.rs` only `write_bytes` and `read_bytes` were gated on declared effects. The other helpers (`connect`, `write_line`, `read_line`, `close`, `send`, `send_bytes`, `ping`, and the shared `parse_id`) allocated on coincidental registry/wasi-import availability. Concretely: a program declaring only `Tcp.writeLine` + `Console.readLine` got the full `__rt_tcp_read_line` and `__rt_tcp_send` bodies emitted as dead module bytes, because `Console.readLine` registers `input-stream.blocking-read` and interns `Result<String,String>`.

2. In `emit_tcp_read_bytes`, the out-of-i64 count branch reused the `"count exceeds the 10485760 byte limit"` data segment, while the VM (`src/services/tcp.rs` `count_arg`) reports `"exceeds the read limit"` for out-of-i64 counts of either sign — the classification pinned by the hostile-profile fidelity tests in #791.

## Fix

- Every TCP helper allocation now gates on its own declared effect; `parse_id` (shared by write_line/write_bytes/read_line/read_bytes/close) gates on the union of those five effects; `format_id` keeps inheriting the connect gate.
- The out-of-i64 branch gets its own static segment `"Tcp.readBytes: count exceeds the read limit"`. Branch order (i64-fit before sign before limit) and the catchable `Result.Err` class are unchanged and now match the VM branch for branch.

## Tests

- `wasip2_tcp_helpers_absent_without_their_declared_effects` — compiles a `Tcp.writeLine`-only (plus connect/close/Console) core module and asserts no code body references the read_line/send-distinctive data segments while the declared helpers' segments stay referenced. Fails before the fix.
- `wasip2_tcp_read_bytes_count_error_classification_matches_vm` — pins the read_bytes count-check order and segment texts against the VM classification. Fails before the fix.
- Suites run locally: `wasip2_codegen_regression` (full example corpus), `wasip2_tcp` (loopback servers), `wasip2_tcp_stress`, `wasm_gc_codegen_regression`, `hostile_readbytes_stub_fidelity`, wasm-gc lib unit tests. All green; `cargo fmt` + clippy clean on touched code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)