### PR TITLE
Restore qualified annotations over uniquely-declared packed dep types

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -130,6 +130,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aver-cert"
+version = "0.1.1"
+dependencies = [
+ "sha2",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
 name = "aver-fuzz"
 version = "0.0.0"
 dependencies = [
@@ -140,13 +155,17 @@ dependencies = [
 
 [[package]]
 name = "aver-lang"
-version = "0.22.1"
+version = "0.27.1"
 dependencies = [
+ "aver-cert",
  "aver-memory",
  "aver-rt",
  "clap",
+ "num-bigint",
+ "num-traits",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "toml",
@@ -164,19 +183,24 @@ dependencies = [
 
 [[package]]
 name = "aver-memory"
-version = "0.2.8"
+version = "0.2.12"
 dependencies = [
  "aver-rt",
+ "num-bigint",
 ]
 
 [[package]]
 name = "aver-rt"
-version = "0.4.7"
+version = "0.4.9"
 dependencies = [
  "crossterm",
  "getrandom 0.3.4",
  "js-sys",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "rand 0.9.4",
+ "sha2",
  "ureq",
 ]
 
@@ -225,7 +249,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -254,7 +278,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -653,7 +677,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -707,7 +731,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1118,7 +1142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1273,6 +1297,34 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1820,7 +1872,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -2901,7 +2953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/fuzz/fuzz_targets/codegen_wasip2.rs
+++ b/fuzz/fuzz_targets/codegen_wasip2.rs
@@ -81,9 +81,11 @@ fn main() {
             },
         );
 
+        let mut type_aliases = std::collections::HashMap::new();
         if let Some(root) = base_dir {
             if let Ok(dep_modules) = aver::source::load_compile_deps(&items, root) {
-                aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+                type_aliases =
+                    aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
             }
         }
 
@@ -92,8 +94,17 @@ fn main() {
         // namespace refs trips here too. `catch_unwind` so the
         // target keeps going.
         use std::panic::AssertUnwindSafe;
+        // Thread the flatten-derived alias map so the fuzz target compiles
+        // through the same production path the CLI's multi-module flow uses.
         let core_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-            aver::codegen::wasm_gc::compile_to_wasm_gc_for_wasip2(&items, None)
+            aver::codegen::wasm_gc::compile_to_wasm_gc_flattened(
+                &items,
+                None,
+                None,
+                aver::codegen::wasm_gc::TargetMode::Wasip2,
+                &type_aliases,
+            )
+            .map(|out| out.bytes)
         }));
         let Ok(Ok(core_bytes)) = core_result else {
             return;

--- a/fuzz/fuzz_targets/codegen_wasm_gc.rs
+++ b/fuzz/fuzz_targets/codegen_wasm_gc.rs
@@ -100,9 +100,11 @@ fn main() {
         // Multi-module: flatten dep modules into `items` so
         // `compile_to_wasm_gc` (which expects a single flat AST per
         // its doc comment in src/runtime/wasm_gc.rs) sees them.
+        let mut type_aliases = std::collections::HashMap::new();
         if let Some(root) = base_dir {
             if let Ok(dep_modules) = aver::source::load_compile_deps(&items, root) {
-                aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+                type_aliases =
+                    aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
             }
         }
 
@@ -123,8 +125,17 @@ fn main() {
         //     don't let it abort every nightly run in the
         //     meantime.
         use std::panic::AssertUnwindSafe;
+        // Thread the flatten-derived alias map so the fuzz target compiles
+        // through the same production path the CLI's multi-module flow uses.
         let compile_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-            aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None)
+            aver::codegen::wasm_gc::compile_to_wasm_gc_flattened(
+                &items,
+                None,
+                None,
+                aver::codegen::wasm_gc::TargetMode::AverBridge,
+                &type_aliases,
+            )
+            .map(|out| out.bytes)
         }));
         let Ok(Ok(bytes)) = compile_result else {
             return;

--- a/fuzz/fuzz_targets/parity_vm_vs_wasm_gc.rs
+++ b/fuzz/fuzz_targets/parity_vm_vs_wasm_gc.rs
@@ -244,9 +244,11 @@ fn run_wasm_gc(
         // expects a single flat ast — multi-module split happens
         // upstream of run_in_process per its doc comment).
         let mut items_flat = items.to_vec();
+        let mut type_aliases = std::collections::HashMap::new();
         if let Some(root) = module_root {
             if let Ok(dep_modules) = aver::source::load_compile_deps(items, root) {
-                aver::codegen::wasm_gc::flatten_multimodule(&mut items_flat, &dep_modules);
+                type_aliases =
+                    aver::codegen::wasm_gc::flatten_multimodule(&mut items_flat, &dep_modules);
             }
         }
         let (run_res, stdout, _stderr) = aver::services::console::capture_output(|| {
@@ -257,6 +259,7 @@ fn run_wasm_gc(
                     program_args: Vec::new(),
                     entry_info: None,
                     mode: aver::runtime::wasm_gc::EffectMode::Normal,
+                    type_aliases: type_aliases.clone(),
                 },
             )
         });

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -969,6 +969,7 @@ fn rebuild_bool_and(
 pub fn field_carrier_eligible_intervals(
     inputs: &ProofLowerInputs,
     instantiations: &crate::ir::mir::InstantiationRegistry,
+    type_aliases: &HashMap<String, String>,
 ) -> HashMap<(String, String), (crate::ir::interval::Interval, bool)> {
     let table = field_carrier_interval_table(inputs);
     if table.is_empty() {
@@ -991,8 +992,13 @@ pub fn field_carrier_eligible_intervals(
             })
             .collect();
     }
-    let demoted_records =
-        multi_field_record_demotions(inputs, &record_candidates, &table, instantiations);
+    let demoted_records = multi_field_record_demotions(
+        inputs,
+        &record_candidates,
+        &table,
+        instantiations,
+        type_aliases,
+    );
     table
         .into_iter()
         .filter(|((rec, _), (iv, known))| {
@@ -1038,6 +1044,7 @@ fn multi_field_record_demotions(
     candidates: &HashSet<String>,
     field_intervals: &HashMap<(String, String), (crate::ir::interval::Interval, bool)>,
     instantiations: &crate::ir::mir::InstantiationRegistry,
+    type_aliases: &HashMap<String, String>,
 ) -> HashSet<String> {
     let mut demoted: HashSet<String> = HashSet::new();
     if candidates.is_empty() {
@@ -1087,11 +1094,16 @@ fn multi_field_record_demotions(
                     } => (type_name, updates),
                     _ => return,
                 };
+                // Canonicalize the construct-site spelling FIRST — same
+                // reason as the single-field scan: a qualified spelling
+                // resolves the same per-field erasure at emit time, so it
+                // must trip the same demotion key.
+                let type_name = canonical_spelling(type_name, type_aliases);
                 if !candidates.contains(type_name) {
                     return;
                 }
                 // The construct inside the record's own smart-ctor is gated.
-                if ctor_fn_of.get(type_name) == Some(&fd.name) {
+                if ctor_fn_of.get(type_name).map(String::as_str) == Some(fd.name.as_str()) {
                     return;
                 }
                 // Outside the smart-ctor: safe iff EVERY provided field value is
@@ -1100,7 +1112,7 @@ fn multi_field_record_demotions(
                 // the gate). A `RecordUpdate` that omits a bounded field copies
                 // it from the (already-gated) base, which is safe too.
                 let all_safe = create_fields.iter().all(|(fname, value)| {
-                    match field_intervals.get(&(type_name.clone(), fname.clone())) {
+                    match field_intervals.get(&(type_name.to_string(), fname.clone())) {
                         // A non-bounded field (no eligible interval) is stored
                         // boxed regardless, so it can't smuggle an i64-overflow.
                         None => true,
@@ -1109,7 +1121,7 @@ fn multi_field_record_demotions(
                     }
                 });
                 if !all_safe {
-                    demoted.insert(type_name.clone());
+                    demoted.insert(type_name.to_string());
                 }
             });
         }
@@ -1122,13 +1134,14 @@ fn multi_field_record_demotions(
             key,
             candidates,
             &record_fields,
+            type_aliases,
             &mut HashSet::new(),
             &mut demoted,
         );
     }
     for ty_str in all_type_annotations(inputs) {
         let ty = crate::types::parse_type_str(&ty_str);
-        collect_map_key_carriers(&ty, candidates, &record_fields, &mut demoted);
+        collect_map_key_carriers(&ty, candidates, &record_fields, type_aliases, &mut demoted);
     }
 
     // ---- Scan 3: Map-VALUE usage (direct + transitive, list/vec/tuple-stopped)
@@ -1156,6 +1169,7 @@ fn multi_field_record_demotions(
             value,
             candidates,
             &record_fields,
+            type_aliases,
             &mut map_value_seen,
             &mut demoted,
         );
@@ -1178,6 +1192,7 @@ fn carriers_reachable_as_map_value(
     value: &crate::ast::Type,
     candidates: &HashSet<String>,
     record_fields: &HashMap<String, Vec<String>>,
+    type_aliases: &HashMap<String, String>,
     seen: &mut HashSet<String>,
     demoted: &mut HashSet<String>,
 ) {
@@ -1188,16 +1203,44 @@ fn carriers_reachable_as_map_value(
             // Map values array, so a carrier behind them is still a direct
             // value — descend.
             Type::Option(a) => {
-                carriers_reachable_as_map_value(a, candidates, record_fields, seen, demoted);
+                carriers_reachable_as_map_value(
+                    a,
+                    candidates,
+                    record_fields,
+                    type_aliases,
+                    seen,
+                    demoted,
+                );
             }
             Type::Result(a, b) => {
-                carriers_reachable_as_map_value(a, candidates, record_fields, seen, demoted);
-                carriers_reachable_as_map_value(b, candidates, record_fields, seen, demoted);
+                carriers_reachable_as_map_value(
+                    a,
+                    candidates,
+                    record_fields,
+                    type_aliases,
+                    seen,
+                    demoted,
+                );
+                carriers_reachable_as_map_value(
+                    b,
+                    candidates,
+                    record_fields,
+                    type_aliases,
+                    seen,
+                    demoted,
+                );
             }
             // A nested `Map` value is itself a Map values array — descend into
             // its value (its key is a separate Scan-2 concern, handled there).
             Type::Map(_k, v) => {
-                carriers_reachable_as_map_value(v, candidates, record_fields, seen, demoted);
+                carriers_reachable_as_map_value(
+                    v,
+                    candidates,
+                    record_fields,
+                    type_aliases,
+                    seen,
+                    demoted,
+                );
             }
             // `List` / `Vector` / `Tuple` make the carrier a native container
             // ELEMENT (now eligible) — STOP, do not demote anything inside.
@@ -1206,6 +1249,10 @@ fn carriers_reachable_as_map_value(
         }
         return;
     };
+    // Resolved type stamps can spell a sole-declarer dep type qualified
+    // (`Dep.IntRange`) — canonicalize so the bare-keyed candidate and
+    // record-field tables see the same key the registry lookups resolve.
+    let name = canonical_spelling(name, type_aliases);
     if !seen.insert(name.to_string()) {
         return;
     }
@@ -1215,7 +1262,14 @@ fn carriers_reachable_as_map_value(
     if let Some(fields) = record_fields.get(name) {
         for field_ty in fields {
             let parsed = crate::types::parse_type_str(field_ty);
-            carriers_reachable_as_map_value(&parsed, candidates, record_fields, seen, demoted);
+            carriers_reachable_as_map_value(
+                &parsed,
+                candidates,
+                record_fields,
+                type_aliases,
+                seen,
+                demoted,
+            );
         }
     }
 }
@@ -1259,13 +1313,37 @@ fn literal_in_interval(value: &Spanned<Expr>, iv: crate::ir::interval::Interval)
     iv.contains_point(k)
 }
 
+/// Resolve one type-name spelling through the flatten-derived identity-
+/// preserving alias map (qualified spelling → canonical post-flatten
+/// `TypeDef` name); a spelling with no alias entry is returned unchanged.
+///
+/// INVARIANT: every spelling that can RESOLVE a packed/carrier layout at a
+/// construct site must also be VISIBLE to the demotion scans under the same
+/// key. The wasm-gc registry resolves entry-side qualified spellings
+/// (`Dep.Octets`) to the canonical layout facts through this exact map
+/// (`TypeRegistry::canonical_type_name` consumes the same
+/// `flatten_multimodule` return value), so the fail-closed scans must
+/// canonicalize construct-site and resolved-type spellings through the SAME
+/// map before comparing against the bare-name-keyed candidate sets —
+/// otherwise a qualified ungated constructor would escape demotion while
+/// still resolving the packed layout, silently truncating out-of-range
+/// values. The map is empty for single-module compiles (identity).
+fn canonical_spelling<'a>(name: &'a str, type_aliases: &'a HashMap<String, String>) -> &'a str {
+    type_aliases.get(name).map(String::as_str).unwrap_or(name)
+}
+
 /// Representation-independent safety scan for refinement carriers. A direct
 /// constructor or update outside the recognized smart constructor can bypass
 /// the invariant, so any such carrier must keep its ordinary representation.
+/// Construct-site spellings are canonicalized through `type_aliases` (see
+/// [`canonical_spelling`]) so an entry-side qualified constructor over a
+/// sole-declarer dep type is matched against the same bare candidate key the
+/// layout tables use.
 pub fn carrier_ungated_construction_demotions(
     inputs: &ProofLowerInputs,
     candidates: &HashSet<String>,
     intervals: &HashMap<String, (crate::ir::interval::Interval, bool)>,
+    type_aliases: &HashMap<String, String>,
 ) -> HashSet<String> {
     let mut demoted = HashSet::new();
     if candidates.is_empty() {
@@ -1312,7 +1390,14 @@ pub fn carrier_ungated_construction_demotions(
                     } => (type_name, updates),
                     _ => return,
                 };
-                if !candidates.contains(type_name) || ctor_fn_of.get(type_name) == Some(&fd.name) {
+                // Canonicalize the construct-site spelling FIRST: a
+                // qualified `Dep.Octets(values = ...)` resolves the same
+                // layout as `Octets` at emit time, so it must trip the
+                // same demotion key here.
+                let type_name = canonical_spelling(type_name, type_aliases);
+                if !candidates.contains(type_name)
+                    || ctor_fn_of.get(type_name).map(String::as_str) == Some(fd.name.as_str())
+                {
                     return;
                 }
                 let safe_literal = matches!(
@@ -1320,7 +1405,7 @@ pub fn carrier_ungated_construction_demotions(
                     Some((iv, true)) if construct_arg_is_in_interval(fields, *iv)
                 );
                 if !safe_literal {
-                    demoted.insert(type_name.clone());
+                    demoted.insert(type_name.to_string());
                 }
             });
         }
@@ -1386,8 +1471,10 @@ pub fn carrier_eligibility_demotions(
     candidates: &HashSet<String>,
     intervals: &HashMap<String, (crate::ir::interval::Interval, bool)>,
     resolved_map_keys: &[crate::ast::Type],
+    type_aliases: &HashMap<String, String>,
 ) -> HashSet<String> {
-    let mut demoted = carrier_ungated_construction_demotions(inputs, candidates, intervals);
+    let mut demoted =
+        carrier_ungated_construction_demotions(inputs, candidates, intervals, type_aliases);
     if candidates.is_empty() {
         return demoted;
     }
@@ -1413,6 +1500,7 @@ pub fn carrier_eligibility_demotions(
             key,
             candidates,
             &record_fields,
+            type_aliases,
             &mut HashSet::new(),
             &mut demoted,
         );
@@ -1426,7 +1514,7 @@ pub fn carrier_eligibility_demotions(
     // only ever ADD to `demoted` (fail-closed).
     for ty_str in all_type_annotations(inputs) {
         let ty = crate::types::parse_type_str(&ty_str);
-        collect_map_key_carriers(&ty, candidates, &record_fields, &mut demoted);
+        collect_map_key_carriers(&ty, candidates, &record_fields, type_aliases, &mut demoted);
     }
 
     demoted
@@ -1585,34 +1673,42 @@ fn collect_map_key_carriers(
     ty: &crate::ast::Type,
     candidates: &HashSet<String>,
     record_fields: &HashMap<String, Vec<String>>,
+    type_aliases: &HashMap<String, String>,
     demoted: &mut HashSet<String>,
 ) {
     use crate::ast::Type;
     match ty {
         Type::Map(key, value) => {
-            carriers_reachable_from(key, candidates, record_fields, &mut HashSet::new(), demoted);
+            carriers_reachable_from(
+                key,
+                candidates,
+                record_fields,
+                type_aliases,
+                &mut HashSet::new(),
+                demoted,
+            );
             // The KEY is the hazard; recurse into both so a nested Map in
             // either position is still inspected.
-            collect_map_key_carriers(key, candidates, record_fields, demoted);
-            collect_map_key_carriers(value, candidates, record_fields, demoted);
+            collect_map_key_carriers(key, candidates, record_fields, type_aliases, demoted);
+            collect_map_key_carriers(value, candidates, record_fields, type_aliases, demoted);
         }
         Type::Result(a, b) => {
-            collect_map_key_carriers(a, candidates, record_fields, demoted);
-            collect_map_key_carriers(b, candidates, record_fields, demoted);
+            collect_map_key_carriers(a, candidates, record_fields, type_aliases, demoted);
+            collect_map_key_carriers(b, candidates, record_fields, type_aliases, demoted);
         }
         Type::Option(a) | Type::List(a) | Type::Vector(a) => {
-            collect_map_key_carriers(a, candidates, record_fields, demoted);
+            collect_map_key_carriers(a, candidates, record_fields, type_aliases, demoted);
         }
         Type::Tuple(items) => {
             for t in items {
-                collect_map_key_carriers(t, candidates, record_fields, demoted);
+                collect_map_key_carriers(t, candidates, record_fields, type_aliases, demoted);
             }
         }
         Type::Fn(params, ret, _) => {
             for p in params {
-                collect_map_key_carriers(p, candidates, record_fields, demoted);
+                collect_map_key_carriers(p, candidates, record_fields, type_aliases, demoted);
             }
-            collect_map_key_carriers(ret, candidates, record_fields, demoted);
+            collect_map_key_carriers(ret, candidates, record_fields, type_aliases, demoted);
         }
         _ => {}
     }
@@ -1626,6 +1722,7 @@ fn carriers_reachable_from(
     key: &crate::ast::Type,
     candidates: &HashSet<String>,
     record_fields: &HashMap<String, Vec<String>>,
+    type_aliases: &HashMap<String, String>,
     seen: &mut HashSet<String>,
     demoted: &mut HashSet<String>,
 ) {
@@ -1635,25 +1732,37 @@ fn carriers_reachable_from(
         // chase the inner element types too.
         match key {
             Type::Option(a) | Type::List(a) | Type::Vector(a) => {
-                carriers_reachable_from(a, candidates, record_fields, seen, demoted);
+                carriers_reachable_from(a, candidates, record_fields, type_aliases, seen, demoted);
             }
             Type::Tuple(items) => {
                 for t in items {
-                    carriers_reachable_from(t, candidates, record_fields, seen, demoted);
+                    carriers_reachable_from(
+                        t,
+                        candidates,
+                        record_fields,
+                        type_aliases,
+                        seen,
+                        demoted,
+                    );
                 }
             }
             Type::Map(k, v) => {
-                carriers_reachable_from(k, candidates, record_fields, seen, demoted);
-                carriers_reachable_from(v, candidates, record_fields, seen, demoted);
+                carriers_reachable_from(k, candidates, record_fields, type_aliases, seen, demoted);
+                carriers_reachable_from(v, candidates, record_fields, type_aliases, seen, demoted);
             }
             Type::Result(a, b) => {
-                carriers_reachable_from(a, candidates, record_fields, seen, demoted);
-                carriers_reachable_from(b, candidates, record_fields, seen, demoted);
+                carriers_reachable_from(a, candidates, record_fields, type_aliases, seen, demoted);
+                carriers_reachable_from(b, candidates, record_fields, type_aliases, seen, demoted);
             }
             _ => {}
         }
         return;
     };
+    // A resolved Map-key type can spell a sole-declarer dep carrier
+    // qualified (`Map<Dep.IntRange, V>` from a local-binding annotation's
+    // type stamp) — canonicalize so it demotes the same bare key the
+    // registry's eligibility lookups resolve through the alias map.
+    let name = canonical_spelling(name, type_aliases);
     if !seen.insert(name.to_string()) {
         return;
     }
@@ -1663,7 +1772,14 @@ fn carriers_reachable_from(
     if let Some(fields) = record_fields.get(name) {
         for field_ty in fields {
             let parsed = crate::types::parse_type_str(field_ty);
-            carriers_reachable_from(&parsed, candidates, record_fields, seen, demoted);
+            carriers_reachable_from(
+                &parsed,
+                candidates,
+                record_fields,
+                type_aliases,
+                seen,
+                demoted,
+            );
         }
     }
 }

--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -149,9 +149,11 @@ impl FnMap {
         }
     }
 
-    /// Exact-name lookup only — no qualified→bare fallback, mirroring
+    /// Exact-name lookup — no qualified→bare suffix fallback, mirroring
     /// `TypeRegistry::packed_sequence`. A bare-name fallback would route
     /// a collision-renamed dep type through an unrelated packed helper.
+    /// The only extra keys are the flatten-derived identity-preserving
+    /// aliases registered when the map is built in `module.rs`.
     pub(super) fn packed_sequence_ops_lookup(
         &self,
         type_name: &str,

--- a/src/codegen/wasm_gc/body/from_mir/records.rs
+++ b/src/codegen/wasm_gc/body/from_mir/records.rs
@@ -50,6 +50,14 @@ pub(crate) fn emit_mir_record_create(
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<Option<()>, WasmGcError> {
+    // Resolve an identity-preserving qualified alias spelling
+    // (`Dep.Octets`) to its canonical post-flatten name ONCE, so every
+    // lookup below (packed, newtype/carrier, plain struct + its
+    // bare-keyed `record_fields` list) keys consistently. The demotion
+    // scans canonicalize construct sites through the SAME map, so a
+    // spelling that resolves a packed/carrier layout here was already
+    // visible to them under this key.
+    let type_name = ctx.registry.canonical_type_name(type_name);
     if ctx.registry.packed_sequence(type_name).is_some() {
         let field = fields.first().ok_or(WasmGcError::Validation(format!(
             "packed record `{type_name}` requires one List<Int> field"
@@ -133,6 +141,8 @@ pub(crate) fn emit_mir_record_update(
     slots: &SlotTable,
     ctx: &EmitCtx<'_>,
 ) -> Result<Option<()>, WasmGcError> {
+    // Same one-shot alias canonicalization as `emit_mir_record_create`.
+    let type_name = ctx.registry.canonical_type_name(type_name);
     if ctx.registry.packed_sequence(type_name).is_some() {
         let produced = if let Some(override_field) = updates.first() {
             emit_mir_record_field_value(func, &override_field.value, "List<Int>", slots, ctx)?

--- a/src/codegen/wasm_gc/flatten.rs
+++ b/src/codegen/wasm_gc/flatten.rs
@@ -41,11 +41,28 @@ use crate::codegen::common::type_def_name;
 /// appends the dep's renamed `TypeDef`s + prefixed `FnDef`s onto the entry
 /// items.
 ///
+/// Returns the identity-preserving qualified type-name aliases: for every
+/// dep type whose post-flatten `TypeDef` name stays BARE (sole declarer
+/// among the deps, and no entry type shares the bare name), the qualified
+/// spelling the entry module may have used (`"Dep.Octets"`) maps to that
+/// bare post-flatten name (`"Octets"`). Entry-side local-binding
+/// annotations keep their qualified spelling through the pre-flatten
+/// typechecker's type stamps, which survive into codegen — the wasm-gc
+/// registry registers these aliases so a stamped `Dep.Octets` resolves the
+/// SAME proof-derived layout facts as `Octets`. Fail-closed: a bare name
+/// declared by two+ deps is collision-renamed (its canonical `TypeDef`
+/// name is already the qualified form — exact lookups work, no alias), and
+/// a bare name also declared by the entry module gets NO alias because the
+/// qualified spelling would be ambiguous against the entry type.
+///
 /// Component Model is a future separate mode; this single-binary path is the
 /// bench-friendly and playground-friendly default.
-pub fn flatten_multimodule(items: &mut Vec<TopLevel>, dep_modules: &[ModuleInfo]) {
+pub fn flatten_multimodule(
+    items: &mut Vec<TopLevel>,
+    dep_modules: &[ModuleInfo],
+) -> HashMap<String, String> {
     if dep_modules.is_empty() {
-        return;
+        return HashMap::new();
     }
 
     let prefixes: HashSet<String> = dep_modules.iter().map(|m| m.prefix.clone()).collect();
@@ -68,6 +85,24 @@ pub fn flatten_multimodule(items: &mut Vec<TopLevel>, dep_modules: &[ModuleInfo]
         .filter(|(_, owners)| owners.len() > 1)
         .map(|(bare, _)| bare.clone())
         .collect();
+
+    // Entry-declared bare type names, collected BEFORE dep typedefs are
+    // appended: a dep bare name shadowed by an entry type must not get a
+    // qualified alias (two post-flatten `TypeDef`s would share the bare
+    // key, so the alias target would be ambiguous).
+    let entry_bare_names: HashSet<&str> = items
+        .iter()
+        .filter_map(|item| match item {
+            TopLevel::TypeDef(td) => Some(type_def_name(td)),
+            _ => None,
+        })
+        .collect();
+    let mut type_aliases: HashMap<String, String> = HashMap::new();
+    for (bare, owners) in &bare_owners {
+        if owners.len() == 1 && !entry_bare_names.contains(bare.as_str()) {
+            type_aliases.insert(format!("{}.{}", owners[0], bare), bare.clone());
+        }
+    }
 
     let qualified_type_names: HashSet<String> = dep_modules
         .iter()
@@ -148,6 +183,8 @@ pub fn flatten_multimodule(items: &mut Vec<TopLevel>, dep_modules: &[ModuleInfo]
             items.push(TopLevel::FnDef(new_fd));
         }
     }
+
+    type_aliases
 }
 
 fn prefixed(prefix: &str, name: &str) -> String {

--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -52,6 +52,8 @@
 //! (`order_total.wasm` md5 `61e45b325279e17e1b0d8dce3fde43f9`, the
 //! game suite, the wasip2 stress fixtures) held across each PR.
 
+use std::collections::HashMap;
+
 use crate::ast::TopLevel;
 use crate::ir::AnalysisResult;
 
@@ -162,7 +164,33 @@ pub fn compile_to_wasm_gc(
     items: &[TopLevel],
     _analysis: Option<&AnalysisResult>,
 ) -> Result<Vec<u8>, WasmGcError> {
-    module::emit_module_with(items, None, TargetMode::AverBridge).map(|(bytes, _, _)| bytes)
+    module::emit_module_with(items, None, TargetMode::AverBridge, &HashMap::new())
+        .map(|(bytes, _, _)| bytes)
+}
+
+/// Compile a FLATTENED multi-module program, threading the identity-
+/// preserving qualified type-name aliases that [`flatten_multimodule`]
+/// returned. Entry-side local-binding annotations may spell a dep type
+/// qualified (`o: Dep.Octets`); the pre-flatten typechecker's stamps keep
+/// that spelling into codegen, and the wasm-gc registry resolves it to the
+/// sole-declarer dep type's proof-derived layout facts through these
+/// aliases. Callers that did not flatten (single-module programs) should
+/// keep using the plain `compile_to_wasm_gc*` entries — those compile with
+/// an empty alias map.
+pub fn compile_to_wasm_gc_flattened(
+    items: &[TopLevel],
+    _analysis: Option<&AnalysisResult>,
+    handler: Option<&str>,
+    target: TargetMode,
+    type_aliases: &HashMap<String, String>,
+) -> Result<WasmGcCompileOutput, WasmGcError> {
+    module::emit_module_with(items, handler, target, type_aliases).map(
+        |(bytes, mir_count, fragment_plans)| WasmGcCompileOutput {
+            bytes,
+            mir_count,
+            fragment_plans,
+        },
+    )
 }
 
 /// `compile_to_wasm_gc` returning the MIR-coverage count alongside the
@@ -178,7 +206,7 @@ pub fn compile_to_wasm_gc_with_mir_count(
     items: &[TopLevel],
     _analysis: Option<&AnalysisResult>,
 ) -> Result<(Vec<u8>, usize), WasmGcError> {
-    module::emit_module_with(items, None, TargetMode::AverBridge)
+    module::emit_module_with(items, None, TargetMode::AverBridge, &HashMap::new())
         .map(|(bytes, mir_count, _)| (bytes, mir_count))
 }
 
@@ -192,7 +220,8 @@ pub fn compile_to_wasm_gc_with_handler(
     _analysis: Option<&AnalysisResult>,
     handler: Option<&str>,
 ) -> Result<Vec<u8>, WasmGcError> {
-    module::emit_module_with(items, handler, TargetMode::AverBridge).map(|(bytes, _, _)| bytes)
+    module::emit_module_with(items, handler, TargetMode::AverBridge, &HashMap::new())
+        .map(|(bytes, _, _)| bytes)
 }
 
 /// Same bytes as [`compile_to_wasm_gc_with_handler`], plus the expression
@@ -202,7 +231,7 @@ pub fn compile_to_wasm_gc_with_handler_and_cert_plans(
     _analysis: Option<&AnalysisResult>,
     handler: Option<&str>,
 ) -> Result<WasmGcCompileOutput, WasmGcError> {
-    module::emit_module_with(items, handler, TargetMode::AverBridge).map(
+    module::emit_module_with(items, handler, TargetMode::AverBridge, &HashMap::new()).map(
         |(bytes, mir_count, fragment_plans)| WasmGcCompileOutput {
             bytes,
             mir_count,
@@ -227,7 +256,8 @@ pub fn compile_to_wasm_gc_for_wasip2(
     items: &[TopLevel],
     _analysis: Option<&AnalysisResult>,
 ) -> Result<Vec<u8>, WasmGcError> {
-    module::emit_module_with(items, None, TargetMode::Wasip2).map(|(bytes, _, _)| bytes)
+    module::emit_module_with(items, None, TargetMode::Wasip2, &HashMap::new())
+        .map(|(bytes, _, _)| bytes)
 }
 
 /// `--target wasip2 --world wasi:http/proxy` entry — Phase 3 / 0.19.
@@ -251,5 +281,6 @@ pub fn compile_to_wasm_gc_for_wasip2_with_handler(
     _analysis: Option<&AnalysisResult>,
     handler: &str,
 ) -> Result<Vec<u8>, WasmGcError> {
-    module::emit_module_with(items, Some(handler), TargetMode::Wasip2).map(|(bytes, _, _)| bytes)
+    module::emit_module_with(items, Some(handler), TargetMode::Wasip2, &HashMap::new())
+        .map(|(bytes, _, _)| bytes)
 }

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -275,11 +275,17 @@ pub(super) fn emit_module_with(
                         .into_iter()
                         .map(|(k, _v)| k)
                         .collect();
+                // The scans canonicalize construct-site and resolved-type
+                // spellings through the SAME flatten-derived alias map the
+                // registry lookups consult: every spelling that can RESOLVE
+                // a carrier layout must be VISIBLE to the demotion scan
+                // under the same key.
                 let demoted = crate::codegen::proof_lower::carrier_eligibility_demotions(
                     &inputs,
                     &proven,
                     &carrier_intervals,
                     &resolved_map_keys,
+                    type_aliases,
                 );
                 proven.difference(&demoted).cloned().collect()
             }
@@ -337,7 +343,11 @@ pub(super) fn emit_module_with(
             // boxed (its container-element/value codegen stores the boxed
             // `$AverInt` record, so an i64-erased field fails wasm validation).
             let instantiations = crate::ir::mir::discover_instantiations(&optimized_mir);
-            crate::codegen::proof_lower::field_carrier_eligible_intervals(&inputs, &instantiations)
+            crate::codegen::proof_lower::field_carrier_eligible_intervals(
+                &inputs,
+                &instantiations,
+                type_aliases,
+            )
         };
     let eligible_carrier_fields: std::collections::HashSet<(String, String)> =
         field_carrier_intervals
@@ -387,10 +397,15 @@ pub(super) fn emit_module_with(
             .iter()
             .map(|(name, layout)| (name.clone(), (layout.element_interval, true)))
             .collect();
+        // Alias-aware for the same reason as the scalar-carrier scan: a
+        // qualified construct site (`Dep.Octets(values = ...)`) resolves
+        // the packed layout through the alias map, so the demotion scan
+        // must see it under the same canonical key.
         let demoted = crate::codegen::proof_lower::carrier_ungated_construction_demotions(
             &inputs,
             &candidates,
             &intervals,
+            type_aliases,
         );
         layouts
             .into_iter()

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -132,6 +132,7 @@ pub(super) fn emit_module_with(
     items: &[TopLevel],
     handler_name: Option<&str>,
     target: super::TargetMode,
+    type_aliases: &HashMap<String, String>,
 ) -> Result<
     (
         Vec<u8>,
@@ -154,6 +155,12 @@ pub(super) fn emit_module_with(
 
     let mut registry =
         TypeRegistry::build_with_handler(items, &resolved_fn_defs, handler_name.is_some());
+    // Identity-preserving qualified spellings for sole-declarer dep types,
+    // derived by `flatten_multimodule` from its collision info. Entry-side
+    // qualified annotation stamps (`o: Dep.Octets`) survive into codegen,
+    // so the name-keyed representation lookups resolve them through this
+    // map. Empty for single-module programs.
+    registry.set_type_name_aliases(type_aliases.clone());
 
     // Lower the post-link resolved fns to MIR and run the shared
     // `optimize` pipeline — the SAME six passes the VM consumes
@@ -286,11 +293,21 @@ pub(super) fn emit_module_with(
     // kept as `$AverInt` storage — reading an i64 from an `$AverInt` slot,
     // a wasm validation error. So restrict the carrier table to the eligible
     // names before threading it into the rewrite.
-    let bare_carrier_intervals: crate::ir::mir::bare_i64::CarrierIntervals = carrier_intervals
+    let mut bare_carrier_intervals: crate::ir::mir::bare_i64::CarrierIntervals = carrier_intervals
         .iter()
         .filter(|(name, _)| eligible_carriers.contains(name.as_str()))
         .map(|(name, iv)| (name.clone(), *iv))
         .collect();
+    // Register the flatten-derived qualified aliases as extra keys so the
+    // MIR bare-i64 facts agree with the registry's alias-aware storage
+    // decision when an entry-side annotation stamp spells the carrier
+    // qualified. Aliases only mirror canonical entries that SURVIVED the
+    // demotion tightening above, so the fail-closed set is unchanged.
+    for (alias, canonical) in type_aliases {
+        if let Some(iv) = bare_carrier_intervals.get(canonical).copied() {
+            bare_carrier_intervals.entry(alias.clone()).or_insert(iv);
+        }
+    }
     registry.set_eligible_carriers(eligible_carriers);
 
     // ETAP-2 multi-field carrier-`i64`: the per-`(record, field)` eligible
@@ -301,7 +318,7 @@ pub(super) fn emit_module_with(
     // eligible-field set) AND the body-emit bridges (construct / direct-read)
     // key off ONE table. Empty under `AVER_NO_CARRIER_I64=1` (the differential
     // baseline) and on any program with no bounded multi-field record.
-    let field_carrier_intervals: crate::ir::mir::bare_i64::FieldCarrierIntervals =
+    let mut field_carrier_intervals: crate::ir::mir::bare_i64::FieldCarrierIntervals =
         if std::env::var("AVER_NO_CARRIER_I64").is_ok() {
             crate::ir::mir::bare_i64::FieldCarrierIntervals::new()
         } else {
@@ -329,6 +346,22 @@ pub(super) fn emit_module_with(
             .map(|((rec, field), _)| (rec.clone(), field.clone()))
             .collect();
     registry.set_eligible_carrier_fields(eligible_carrier_fields);
+    // Same alias mirroring as `bare_carrier_intervals` above, done AFTER
+    // the registry's eligible set is derived so that set stays keyed by
+    // canonical post-flatten names only.
+    for (alias, canonical) in type_aliases {
+        let mirrored: Vec<(String, (crate::ir::interval::Interval, bool))> =
+            field_carrier_intervals
+                .iter()
+                .filter(|((rec, _), _)| rec == canonical)
+                .map(|((_, field), fact)| (field.clone(), *fact))
+                .collect();
+        for (field, fact) in mirrored {
+            field_carrier_intervals
+                .entry((alias.clone(), field))
+                .or_insert(fact);
+        }
+    }
 
     // Structural sibling of carrier-i64: derive a per-element interval for
     // canonical opaque `List<Int>` refinements and erase each eligible nominal
@@ -2635,10 +2668,20 @@ pub(super) fn emit_module_with(
         }
     }
     let string_split_ops = list_helpers.string_split_ops();
-    let packed_sequence_ops = packed_sequence_helpers
-        .iter()
-        .map(|(name, ops)| (name.to_string(), ops))
-        .collect();
+    let mut packed_sequence_ops: HashMap<String, super::packed_sequences::PackedSequenceOps> =
+        packed_sequence_helpers
+            .iter()
+            .map(|(name, ops)| (name.to_string(), ops))
+            .collect();
+    // Mirror the flatten-derived qualified aliases onto the canonical
+    // pack/unpack pairs (extra lookup keys only — helper emission walks
+    // the canonical order). Keeps `FnMap::packed_sequence_ops_lookup` in
+    // agreement with the registry's alias-aware `packed_sequence`.
+    for (alias, canonical) in &registry.type_name_aliases {
+        if let Some(ops) = packed_sequence_ops.get(canonical).copied() {
+            packed_sequence_ops.entry(alias.clone()).or_insert(ops);
+        }
+    }
     let mut eq_helpers_lookup: HashMap<String, u32> = HashMap::new();
     for (name, _kind) in eq_helpers_registry.iter() {
         if let Some(fn_idx) = eq_helpers_registry.lookup_fn_idx(name) {

--- a/src/codegen/wasm_gc/packed_sequences.rs
+++ b/src/codegen/wasm_gc/packed_sequences.rs
@@ -51,11 +51,24 @@ impl PackedSequenceHelperRegistry {
                 .insert(name.clone(), (pack_type, unpack_type));
             self.order.push(name.clone());
         }
+        // Register the flatten-derived qualified aliases as extra lookup
+        // KEYS onto the canonical ops — never extra helpers (`order` and
+        // `type_indices` stay canonical-only, so slot assignment and
+        // helper emission are untouched). An alias provably denotes the
+        // same `TypeDef` (sole declarer), so sharing the pack/unpack pair
+        // is identity-correct.
+        for (alias, canonical) in &registry.type_name_aliases {
+            if let Some(ops) = self.ops.get(canonical).copied() {
+                self.ops.entry(alias.clone()).or_insert(ops);
+            }
+        }
     }
 
-    /// Exact-name lookup only — no qualified→bare fallback, mirroring
+    /// Exact-name lookup — no qualified→bare suffix fallback, mirroring
     /// `TypeRegistry::packed_sequence`. A bare-name fallback would route
     /// a collision-renamed dep type through an unrelated pack/unpack pair.
+    /// The only extra keys are the flatten-derived identity-preserving
+    /// aliases registered by `assign_slots`.
     pub(super) fn ops_for(&self, type_name: &str) -> Option<PackedSequenceOps> {
         self.ops.get(type_name).copied()
     }

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -133,6 +133,19 @@ pub(super) struct TypeRegistry {
     /// bridge between `List<Int>` and the packed array explicitly.
     pub(super) packed_sequences: HashMap<String, PackedSequenceType>,
     pub(super) packed_sequence_order: Vec<String>,
+    /// Identity-preserving qualified→bare type-name aliases derived by
+    /// `flatten_multimodule` from its collision info: `"Dep.Octets"` →
+    /// `"Octets"` ONLY when `Dep` is the sole declarer of the bare name
+    /// (no dep-dep collision, no entry-declared type of the same bare
+    /// name), so the alias provably denotes the same `TypeDef`. Consulted
+    /// by the name-keyed representation lookups (`packed_sequence`,
+    /// `is_eligible_carrier`, `is_eligible_carrier_field`,
+    /// `newtype_underlying`) because entry-side qualified annotation
+    /// stamps survive into codegen. A collision-renamed dep type never
+    /// lands here — its canonical `TypeDef` name IS the qualified form, so
+    /// exact lookups keep working and the #792 exact-name soundness rule
+    /// (no suffix guessing) is preserved.
+    pub(super) type_name_aliases: HashMap<String, String>,
     /// Total number of user-type slots reserved in the type section.
     /// Function types start AFTER these.
     pub(super) user_type_count: u32,
@@ -1090,6 +1103,10 @@ impl TypeRegistry {
             primitive_key_box_order,
             packed_sequences: HashMap::new(),
             packed_sequence_order: Vec::new(),
+            // Populated post-build by `module.rs` from the aliases
+            // `flatten_multimodule` derived; empty for single-module
+            // programs and for callers that did not flatten.
+            type_name_aliases: HashMap::new(),
             user_type_count: next_idx,
             string_array_type_idx,
             crypto_byte_array_type_idx,
@@ -1434,32 +1451,60 @@ impl TypeRegistry {
         }
     }
 
-    /// Exact-name lookup only — NO qualified→bare fallback. The layout
+    /// Resolve an identity-preserving qualified alias (installed via
+    /// `set_type_name_aliases`) to its canonical post-flatten `TypeDef`
+    /// name; a name with no alias entry is returned trimmed, unchanged.
+    /// This is NOT a suffix fallback: only spellings `flatten_multimodule`
+    /// proved unambiguous (sole declarer, no collision rename, no entry
+    /// shadow) are in the map, so a collision-renamed dep type keeps
+    /// resolving by its exact canonical name.
+    pub(super) fn canonical_type_name<'a>(&'a self, type_name: &'a str) -> &'a str {
+        let trimmed = type_name.trim();
+        match self.type_name_aliases.get(trimmed) {
+            Some(canonical) => canonical.as_str(),
+            None => trimmed,
+        }
+    }
+
+    /// Install the flatten-derived qualified type-name aliases. See
+    /// `type_name_aliases` for the identity contract.
+    pub(super) fn set_type_name_aliases(&mut self, aliases: HashMap<String, String>) {
+        self.type_name_aliases = aliases;
+    }
+
+    /// Exact-name lookup — NO qualified→bare suffix fallback. The layout
     /// table keys are post-flatten `TypeDef` names (bare for entry and
     /// non-colliding dep types, canonical `Prefix.Name` for collision-
     /// renamed dep types), and both the collision guard and the ungated-
     /// construction demotion scan match those names exactly. A bare-name
     /// fallback here would hand a collision-renamed dep type (`Left.Octets`)
     /// the packed layout of an unrelated bare-named gated type (`Octets`),
-    /// letting an ungated record silently truncate through `pack`.
+    /// letting an ungated record silently truncate through `pack`. The only
+    /// indirection is `canonical_type_name`, whose alias entries provably
+    /// denote the same `TypeDef` (entry-side qualified annotation stamps
+    /// over a sole-declarer dep type).
     pub(super) fn packed_sequence(&self, type_name: &str) -> Option<PackedSequenceType> {
-        self.packed_sequences.get(type_name.trim()).copied()
+        self.packed_sequences
+            .get(self.canonical_type_name(type_name))
+            .copied()
     }
 
     /// ETAP-2 carrier-`i64`: is `type_name` a carrier whose erasure should be
     /// a native `i64`? A carrier in the eligible set is ALSO a newtype
     /// (single-field opaque record of `Int`), so `newtype_underlying` already
     /// returns `Some("Int")` for it — this just decides whether that erasure
-    /// becomes `i64` or stays `$AverInt`. Exact-name lookup only, matching the
+    /// becomes `i64` or stays `$AverInt`. Exact-name lookup (modulo the
+    /// identity-preserving `canonical_type_name` aliases), matching the
     /// post-flatten `TypeDef` name the interval table and the demotion scans
-    /// key on — a qualified→bare fallback would let a collision-renamed dep
-    /// type (`Left.IntRange`) inherit an unrelated carrier's i64 erasure and
-    /// trap on values only the bignum representation can hold.
+    /// key on — a qualified→bare suffix fallback would let a collision-renamed
+    /// dep type (`Left.IntRange`) inherit an unrelated carrier's i64 erasure
+    /// and trap on values only the bignum representation can hold.
     pub(super) fn is_eligible_carrier(&self, type_name: &str) -> bool {
         if self.eligible_carriers.is_empty() {
             return false;
         }
-        self.eligible_carriers.contains(type_name.trim())
+        self.eligible_carriers
+            .contains(self.canonical_type_name(type_name))
     }
 
     /// ETAP-2 multi-field carrier-`i64`: install the eligible `(record, field)`
@@ -1476,16 +1521,24 @@ impl TypeRegistry {
 
     /// ETAP-2 multi-field carrier-`i64`: is `(record_name, field)` a bounded
     /// record field whose storage should be a native `i64`? Exact-name lookup
-    /// only, for the same reason as `is_eligible_carrier`.
+    /// (modulo `canonical_type_name` aliases), for the same reason as
+    /// `is_eligible_carrier`.
     pub(super) fn is_eligible_carrier_field(&self, record_name: &str, field: &str) -> bool {
         if self.eligible_carrier_fields.is_empty() {
             return false;
         }
-        self.eligible_carrier_fields
-            .contains(&(record_name.trim().to_string(), field.to_string()))
+        self.eligible_carrier_fields.contains(&(
+            self.canonical_type_name(record_name).to_string(),
+            field.to_string(),
+        ))
     }
 
     pub(super) fn newtype_underlying(&self, type_name: &str) -> Option<&str> {
+        // Qualified annotation stamps over a sole-declarer dep type must
+        // see the SAME newtype/carrier decision as the canonical name —
+        // otherwise an entry-side `r: Dep.IntRange` slot stays a struct
+        // ref while the carrier value it holds erased to `i64`.
+        let type_name = self.canonical_type_name(type_name);
         // Suppress newtype optimisation when the type is used as a
         // `Map<K, *>` key. Map's open-addressing layout uses
         // `keys[i] == null` as the empty marker, which only works

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -1470,6 +1470,61 @@ impl TypeRegistry {
     /// `type_name_aliases` for the identity contract.
     pub(super) fn set_type_name_aliases(&mut self, aliases: HashMap<String, String>) {
         self.type_name_aliases = aliases;
+        // Mirror the alias spellings onto the record identity tables —
+        // `records` (name → struct type idx) and `record_fields` (name →
+        // declared field list) — as extra lookup KEYS on the canonical
+        // entries. Emit paths that key off a STAMPED spelling (map
+        // key/value helpers, hash_record / eq_record field walks, the
+        // demoted plain construct path) then resolve the same slot and
+        // field list for either spelling. The alias provably denotes the
+        // same `TypeDef` (sole declarer, no collision rename, no entry
+        // shadow), so sharing the rows is identity-correct; a spelling
+        // with NO alias keeps declining fail-closed. Point lookups only:
+        // the sole `record_fields.keys()` walk (struct-type emission)
+        // runs at build time, BEFORE this installer, so mirrored keys
+        // never double-emit a struct.
+        let mirrored: Vec<(String, String)> = self
+            .type_name_aliases
+            .iter()
+            .map(|(alias, canonical)| (alias.clone(), canonical.clone()))
+            .collect();
+        for (alias, canonical) in mirrored {
+            if let Some(idx) = self.records.get(&canonical).copied() {
+                self.records.entry(alias.clone()).or_insert(idx);
+            }
+            if let Some(fields) = self.record_fields.get(&canonical).cloned() {
+                self.record_fields.entry(alias).or_insert(fields);
+            }
+        }
+        // Re-run the Map-key newtype suppression with alias-aware key
+        // spellings. The build-time scan populated `non_newtypable_keys`
+        // BEFORE the aliases were installed, and its record/variant
+        // tables are bare-keyed — so a Map whose key is spelled ONLY
+        // qualified (`Map<Dep.IntRange, Int>` from an entry-side
+        // annotation stamp) escaped the suppression and its key record
+        // would be newtype-erased while the key array stores struct
+        // refs. Mark the CANONICAL name; `newtype_underlying`
+        // canonicalizes its argument first, so one canonical entry
+        // suppresses both spellings.
+        let mut extra: Vec<String> = Vec::new();
+        for canonical_map in &self.map_order {
+            let Some((k, _)) = parse_map_kv(canonical_map) else {
+                continue;
+            };
+            let Some(k_canon) = self.type_name_aliases.get(k.trim()) else {
+                continue;
+            };
+            if self.record_fields.contains_key(k_canon)
+                || self
+                    .variants
+                    .values()
+                    .flat_map(|v| v.iter())
+                    .any(|v| v.parent == *k_canon)
+            {
+                extra.push(k_canon.clone());
+            }
+        }
+        self.non_newtypable_keys.extend(extra);
     }
 
     /// Exact-name lookup — NO qualified→bare suffix fallback. The layout

--- a/src/diagnostics/wasm_gc_verify.rs
+++ b/src/diagnostics/wasm_gc_verify.rs
@@ -170,13 +170,21 @@ pub fn run_verify_for_items_wasm_gc_with_mode(
     } else {
         Vec::new()
     };
+    let mut type_aliases = std::collections::HashMap::new();
     if !dep_modules.is_empty() {
-        crate::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+        type_aliases = crate::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
         crate::ir::pipeline::resolve(&mut items);
     }
 
-    let bytes = crate::codegen::wasm_gc::compile_to_wasm_gc(&items, result.analysis.as_ref())
-        .map_err(|e| format!("wasm-gc compile error: {}", e))?;
+    let bytes = crate::codegen::wasm_gc::compile_to_wasm_gc_flattened(
+        &items,
+        result.analysis.as_ref(),
+        None,
+        crate::codegen::wasm_gc::TargetMode::AverBridge,
+        &type_aliases,
+    )
+    .map(|out| out.bytes)
+    .map_err(|e| format!("wasm-gc compile error: {}", e))?;
 
     run_verify_cases_in_wasmtime(&bytes, &plans)
 }

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4481,16 +4481,18 @@ fn cmd_compile_wasm_gc(
         false, /* run_buffer_build */
         false, /* self_host_mode — wasm-gc compile path doesn't use self-host */
     );
-    flatten_multimodule(&mut items, &dep_modules);
+    let type_aliases = flatten_multimodule(&mut items, &dep_modules);
     // Re-run resolver after flatten so dep fns get a FnResolution
     // (slot_types). Entry items already had one from `pipeline::run`
     // above; this picks up the newly appended dep FnDefs.
     aver::ir::pipeline::resolve(&mut items);
 
-    let wasm_gc_output = match wasm_gc::compile_to_wasm_gc_with_handler_and_cert_plans(
+    let wasm_gc_output = match wasm_gc::compile_to_wasm_gc_flattened(
         &items,
         result.analysis.as_ref(),
         handler,
+        wasm_gc::TargetMode::AverBridge,
+        &type_aliases,
     ) {
         Ok(output) => output,
         Err(e) => {
@@ -4729,7 +4731,7 @@ fn cmd_compile_wasip2(
         // the `wasm` feature) and call the wasm-gc library function
         // directly — `wasip2` enables `wasm-compile` (which exposes
         // it) but does not pull `wasm`.
-        aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+        let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
         aver::ir::pipeline::resolve(&mut items);
 
         // Phase 1.6 — static effect-set check. Catches every Aver
@@ -4785,12 +4787,14 @@ fn cmd_compile_wasip2(
                 );
                 process::exit(1);
             });
-            match wasm_gc::compile_to_wasm_gc_for_wasip2_with_handler(
+            match wasm_gc::compile_to_wasm_gc_flattened(
                 &items,
                 result.analysis.as_ref(),
-                handler_name,
+                Some(handler_name),
+                wasm_gc::TargetMode::Wasip2,
+                &type_aliases,
             ) {
-                Ok(b) => b,
+                Ok(out) => out.bytes,
                 Err(e) => {
                     eprintln!("{}", format!("{e}").red());
                     process::exit(1);
@@ -4808,8 +4812,14 @@ fn cmd_compile_wasip2(
                 );
                 process::exit(1);
             }
-            match wasm_gc::compile_to_wasm_gc_for_wasip2(&items, result.analysis.as_ref()) {
-                Ok(b) => b,
+            match wasm_gc::compile_to_wasm_gc_flattened(
+                &items,
+                result.analysis.as_ref(),
+                None,
+                wasm_gc::TargetMode::Wasip2,
+                &type_aliases,
+            ) {
+                Ok(out) => out.bytes,
                 Err(e) => {
                     eprintln!("{}", format!("{e}").red());
                     process::exit(1);
@@ -9062,9 +9072,14 @@ fn cmd_proof_dafny(file: &str, output_dir: &str, ctx: &codegen::CodegenContext) 
 }
 
 /// CLI shim around the library-level wasm-gc multi-module flattener.
+/// Returns the identity-preserving qualified type-name aliases the
+/// flattener derived; thread them into the flattened compile entry.
 #[cfg(feature = "wasm")]
-pub(super) fn flatten_multimodule(items: &mut Vec<TopLevel>, dep_modules: &[ModuleInfo]) {
-    aver::codegen::wasm_gc::flatten_multimodule(items, dep_modules);
+pub(super) fn flatten_multimodule(
+    items: &mut Vec<TopLevel>,
+    dep_modules: &[ModuleInfo],
+) -> std::collections::HashMap<String, String> {
+    aver::codegen::wasm_gc::flatten_multimodule(items, dep_modules)
 }
 
 /// Load dependent modules for codegen (recursive, with circular import detection).

--- a/src/main/run_wasip2.rs
+++ b/src/main/run_wasip2.rs
@@ -107,7 +107,7 @@ fn build_component_bytes(
     }
 
     let dep_modules = super::commands::load_compile_deps(&items, &module_root, false, false, false);
-    aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
     aver::ir::pipeline::resolve(&mut items);
 
     if let Err(unsupported) = wasip2_codegen::check_supported_effects(&items) {
@@ -124,8 +124,15 @@ fn build_component_bytes(
         return Err(out);
     }
 
-    let core_bytes = wasm_gc::compile_to_wasm_gc_for_wasip2(&items, result.analysis.as_ref())
-        .map_err(|e| format!("wasm-gc lowering: {e}"))?;
+    let core_bytes = wasm_gc::compile_to_wasm_gc_flattened(
+        &items,
+        result.analysis.as_ref(),
+        None,
+        wasm_gc::TargetMode::Wasip2,
+        &type_aliases,
+    )
+    .map(|out| out.bytes)
+    .map_err(|e| format!("wasm-gc lowering: {e}"))?;
     let (component_bytes, _wit) =
         wasip2_codegen::compile_to_component(&core_bytes, wasip2_codegen::Wasip2World::CliCommand)
             .map_err(|e| format!("component wrap: {e}"))?;

--- a/src/main/run_wasm_gc.rs
+++ b/src/main/run_wasm_gc.rs
@@ -157,7 +157,7 @@ pub(super) fn try_run_wasm_gc(
         return Err(shared::format_type_errors(&tc.errors));
     }
     let dep_modules = load_compile_deps(&items, &module_root, false, false, false);
-    flatten_multimodule(&mut items, &dep_modules);
+    let type_aliases = flatten_multimodule(&mut items, &dep_modules);
     // Re-run resolver after multi-module flatten so the freshly
     // appended dep fns get a `FnResolution` (slot map + slot_types).
     // The first `pipeline::run` only saw entry items; without this
@@ -173,6 +173,7 @@ pub(super) fn try_run_wasm_gc(
             program_args,
             entry_info: entry_info.clone(),
             mode,
+            type_aliases,
         },
     )?;
 

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -89,10 +89,17 @@ pub fn compile_project_to_wasm(
         .map(|m| loaded_to_module_info(m, false))
         .collect();
 
-    codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
+    let type_aliases = codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
     crate::ir::pipeline::resolve(&mut entry_items);
-    codegen::wasm_gc::compile_to_wasm_gc(&entry_items, pipeline_result.analysis.as_ref())
-        .map_err(|e| format!("{e}"))
+    codegen::wasm_gc::compile_to_wasm_gc_flattened(
+        &entry_items,
+        pipeline_result.analysis.as_ref(),
+        None,
+        codegen::wasm_gc::TargetMode::AverBridge,
+        &type_aliases,
+    )
+    .map(|out| out.bytes)
+    .map_err(|e| format!("{e}"))
 }
 
 /// Multi-file project compile that targets a synthetic `__entry__`
@@ -144,11 +151,17 @@ pub fn compile_project_to_wasm_with_entry(
         .into_iter()
         .map(|m| loaded_to_module_info(m, false))
         .collect();
-    codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
+    let type_aliases = codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
     crate::ir::pipeline::resolve(&mut entry_items);
-    let bytes =
-        codegen::wasm_gc::compile_to_wasm_gc(&entry_items, pipeline_result.analysis.as_ref())
-            .map_err(|e| format!("{e}"))?;
+    let bytes = codegen::wasm_gc::compile_to_wasm_gc_flattened(
+        &entry_items,
+        pipeline_result.analysis.as_ref(),
+        None,
+        codegen::wasm_gc::TargetMode::AverBridge,
+        &type_aliases,
+    )
+    .map(|out| out.bytes)
+    .map_err(|e| format!("{e}"))?;
     Ok((bytes, target_fn))
 }
 

--- a/src/runtime/wasm_gc.rs
+++ b/src/runtime/wasm_gc.rs
@@ -37,8 +37,10 @@ use aver::value::Value;
 /// through the run pipeline without inflating every `Normal` /
 /// `Record` call to recording size — clippy's `large_enum_variant`
 /// would otherwise flag the size mismatch.
+#[derive(Default)]
 pub enum EffectMode {
     /// Production path — real effects run, no recording, no replay.
+    #[default]
     Normal,
     /// `aver run --wasm-gc --record <dir>` — real effects run, every
     /// call appended to the trace, returned through
@@ -55,6 +57,14 @@ pub enum EffectMode {
 }
 
 /// Caller-supplied configuration for one `run_in_process` call.
+///
+/// `Default` is the single-file embedding shape: no argv, whole-program
+/// entry, real effects, empty alias map. A caller that flattened a
+/// multi-module program MUST override `type_aliases` with the map
+/// `flatten_multimodule` returned — leaving it empty makes qualified
+/// dep-type spellings decline fail-closed instead of resolving their
+/// canonical layouts.
+#[derive(Default)]
 pub struct RunConfig {
     /// Argv visible to the program through `Args.get` / `Args.all`.
     pub program_args: Vec<String>,

--- a/src/runtime/wasm_gc.rs
+++ b/src/runtime/wasm_gc.rs
@@ -64,6 +64,10 @@ pub struct RunConfig {
     pub entry_info: Option<(String, Vec<Value>)>,
     /// Recorder / replayer state machine. See [`EffectMode`].
     pub mode: EffectMode,
+    /// Identity-preserving qualified type-name aliases returned by
+    /// `flatten_multimodule` when the caller flattened a multi-module
+    /// program. Empty for single-file programs (the fuzz harness path).
+    pub type_aliases: std::collections::HashMap<String, String>,
 }
 
 /// What one `run_in_process` invocation actually produced. Carries
@@ -120,8 +124,15 @@ pub fn run_in_process(
     analysis: Option<&AnalysisResult>,
     config: RunConfig,
 ) -> Result<RunOutcome, String> {
-    let bytes =
-        aver::codegen::wasm_gc::compile_to_wasm_gc(items, analysis).map_err(|e| format!("{e}"))?;
+    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc_flattened(
+        items,
+        analysis,
+        None,
+        aver::codegen::wasm_gc::TargetMode::AverBridge,
+        &config.type_aliases,
+    )
+    .map(|out| out.bytes)
+    .map_err(|e| format!("{e}"))?;
 
     let entry_fn_name: &str = config
         .entry_info

--- a/tests/wasip2_codegen_regression.rs
+++ b/tests/wasip2_codegen_regression.rs
@@ -86,13 +86,17 @@ fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn parse_pipeline(source: &str) -> Result<Vec<TopLevel>, String> {
-    parse_pipeline_with_module_root(source, None)
+    parse_pipeline_with_module_root(source, None).map(|(items, _)| items)
 }
 
+/// Returns the flattened items PLUS the identity-preserving qualified
+/// type-name aliases `flatten_multimodule` derived — harnesses that
+/// flatten multi-module input must thread the real alias map into the
+/// compile so they exercise the same path `aver compile` takes.
 fn parse_pipeline_with_module_root(
     source: &str,
     module_root: Option<&str>,
-) -> Result<Vec<TopLevel>, String> {
+) -> Result<(Vec<TopLevel>, std::collections::HashMap<String, String>), String> {
     let mut lexer = Lexer::new(source);
     let tokens = lexer.tokenize().map_err(|e| format!("lex: {:?}", e))?;
     let mut parser = Parser::new(tokens);
@@ -122,12 +126,30 @@ fn parse_pipeline_with_module_root(
             tc.errors.first()
         ));
     }
+    let mut type_aliases = std::collections::HashMap::new();
     if let Some(root) = module_root {
         let dep_modules = aver::source::load_compile_deps(&items, root)?;
-        aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+        type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
         aver::ir::pipeline::resolve(&mut items);
     }
-    Ok(items)
+    Ok((items, type_aliases))
+}
+
+/// Compile the wasip2 core module through the flattened entry with the
+/// real alias map, mirroring the CLI's multi-module `--target wasip2`
+/// path.
+fn compile_core_flattened(
+    items: &[TopLevel],
+    type_aliases: &std::collections::HashMap<String, String>,
+) -> Result<Vec<u8>, aver::codegen::wasm_gc::WasmGcError> {
+    aver::codegen::wasm_gc::compile_to_wasm_gc_flattened(
+        items,
+        None,
+        None,
+        aver::codegen::wasm_gc::TargetMode::Wasip2,
+        type_aliases,
+    )
+    .map(|out| out.bytes)
 }
 
 #[test]
@@ -144,9 +166,10 @@ fn main() -> Result<Bytes, String>
     payload = Bytes.fromList([249, 190, 180, 217])?
     Tcp.sendBytes("127.0.0.1", 9, payload)
 "#;
-    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
-        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
-    let core_bytes = aver::codegen::wasm_gc::compile_to_wasm_gc_for_wasip2(&items, None)
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let core_bytes = compile_core_flattened(&items, &type_aliases)
         .unwrap_or_else(|e| panic!("wasip2 core compile: {e}\n--- source ---\n{source}"));
     let (component_bytes, _) = aver::codegen::wasip2::compile_to_component(
         &core_bytes,
@@ -171,9 +194,10 @@ fn read(conn: Tcp.Connection, count: Int) -> Result<Bytes, String>
     ! [Tcp.readBytes]
     Tcp.readBytes(conn, count)
 "#;
-    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
-        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
-    let core_bytes = aver::codegen::wasm_gc::compile_to_wasm_gc_for_wasip2(&items, None)
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let core_bytes = compile_core_flattened(&items, &type_aliases)
         .unwrap_or_else(|e| panic!("wasip2 core compile: {e}\n--- source ---\n{source}"));
     let (component_bytes, _) = aver::codegen::wasip2::compile_to_component(
         &core_bytes,
@@ -198,9 +222,10 @@ fn write(conn: Tcp.Connection, payload: Bytes) -> Result<Unit, String>
     ! [Tcp.writeBytes]
     Tcp.writeBytes(conn, payload)
 "#;
-    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
-        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
-    let core_bytes = aver::codegen::wasm_gc::compile_to_wasm_gc_for_wasip2(&items, None)
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let core_bytes = compile_core_flattened(&items, &type_aliases)
         .unwrap_or_else(|e| panic!("wasip2 core compile: {e}\n--- source ---\n{source}"));
     let (component_bytes, _) = aver::codegen::wasip2::compile_to_component(
         &core_bytes,

--- a/tests/wasm_gc_capture_output.rs
+++ b/tests/wasm_gc_capture_output.rs
@@ -52,11 +52,9 @@ fn wasm_gc_console_print_writes_to_capture_buffer() {
         aver::runtime::wasm_gc::run_in_process(
             &items,
             None,
-            aver::runtime::wasm_gc::RunConfig {
-                program_args: Vec::new(),
-                entry_info: None,
-                mode: aver::runtime::wasm_gc::EffectMode::Normal,
-            },
+            // Single-file program: the default config (no argv, real
+            // effects, empty alias map) is exactly the embedding shape.
+            aver::runtime::wasm_gc::RunConfig::default(),
         )
     });
 
@@ -131,11 +129,9 @@ fn wasm_gc_boxed_int_div_mod_err_messages_match_vm() {
         aver::runtime::wasm_gc::run_in_process(
             &items,
             result.analysis.as_ref(),
-            aver::runtime::wasm_gc::RunConfig {
-                program_args: Vec::new(),
-                entry_info: None,
-                mode: aver::runtime::wasm_gc::EffectMode::Normal,
-            },
+            // Single-file program: the default config (no argv, real
+            // effects, empty alias map) is exactly the embedding shape.
+            aver::runtime::wasm_gc::RunConfig::default(),
         )
     });
 

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -77,13 +77,17 @@ fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn parse_pipeline(source: &str) -> Result<Vec<TopLevel>, String> {
-    parse_pipeline_with_module_root(source, None)
+    parse_pipeline_with_module_root(source, None).map(|(items, _)| items)
 }
 
+/// Returns the flattened items PLUS the identity-preserving qualified
+/// type-name aliases `flatten_multimodule` derived — harnesses that
+/// flatten multi-module input must thread the real alias map into the
+/// compile so they exercise the same path `aver compile` takes.
 fn parse_pipeline_with_module_root(
     source: &str,
     module_root: Option<&str>,
-) -> Result<Vec<TopLevel>, String> {
+) -> Result<(Vec<TopLevel>, std::collections::HashMap<String, String>), String> {
     let mut lexer = Lexer::new(source);
     let tokens = lexer.tokenize().map_err(|e| format!("lex: {:?}", e))?;
     let mut parser = Parser::new(tokens);
@@ -113,12 +117,29 @@ fn parse_pipeline_with_module_root(
             tc.errors.first()
         ));
     }
+    let mut type_aliases = std::collections::HashMap::new();
     if let Some(root) = module_root {
         let dep_modules = aver::source::load_compile_deps(&items, root)?;
-        aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+        type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
         aver::ir::pipeline::resolve(&mut items);
     }
-    Ok(items)
+    Ok((items, type_aliases))
+}
+
+/// Compile through the flattened entry with the real alias map, mirroring
+/// the CLI's multi-module `--target wasm-gc` path.
+fn compile_flattened(
+    items: &[TopLevel],
+    type_aliases: &std::collections::HashMap<String, String>,
+) -> Result<Vec<u8>, aver::codegen::wasm_gc::WasmGcError> {
+    aver::codegen::wasm_gc::compile_to_wasm_gc_flattened(
+        items,
+        None,
+        None,
+        aver::codegen::wasm_gc::TargetMode::AverBridge,
+        type_aliases,
+    )
+    .map(|out| out.bytes)
 }
 
 fn assert_compiles_and_validates(source: &str) {
@@ -146,9 +167,10 @@ fn main() -> Result<Bytes, String>
     payload = Bytes.fromList([249, 190, 180, 217])?
     Tcp.sendBytes("127.0.0.1", 9, payload)
 "#;
-    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
-        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
-    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None)
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let bytes = compile_flattened(&items, &type_aliases)
         .unwrap_or_else(|e| panic!("wasm-gc compile: {e}\n--- source ---\n{source}"));
     wasmparser::Validator::new()
         .validate_all(&bytes)
@@ -185,9 +207,10 @@ fn read(conn: Tcp.Connection, count: Int) -> Result<Bytes, String>
     ! [Tcp.readBytes]
     Tcp.readBytes(conn, count)
 "#;
-    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
-        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
-    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None)
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let bytes = compile_flattened(&items, &type_aliases)
         .unwrap_or_else(|e| panic!("wasm-gc compile: {e}\n--- source ---\n{source}"));
     wasmparser::Validator::new()
         .validate_all(&bytes)
@@ -224,9 +247,10 @@ fn write(conn: Tcp.Connection, payload: Bytes) -> Result<Unit, String>
     ! [Tcp.writeBytes]
     Tcp.writeBytes(conn, payload)
 "#;
-    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
-        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
-    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None)
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let bytes = compile_flattened(&items, &type_aliases)
         .unwrap_or_else(|e| panic!("wasm-gc compile: {e}\n--- source ---\n{source}"));
     wasmparser::Validator::new()
         .validate_all(&bytes)
@@ -270,9 +294,10 @@ fn main() -> Result<String, String>
     Console.print("hashed")
     Result.Ok("hashed")
 "#;
-    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
-        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
-    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None)
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let bytes = compile_flattened(&items, &type_aliases)
         .unwrap_or_else(|e| panic!("wasm-gc compile: {e}\n--- source ---\n{source}"));
     wasmparser::Validator::new()
         .validate_all(&bytes)
@@ -300,9 +325,10 @@ fn relay(conn: Tcp.Connection) -> Result<Unit, String>
     frame = Tcp.readBytes(conn, 4)?
     Tcp.writeBytes(conn, frame)
 "#;
-    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
-        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
-    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None)
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let bytes = compile_flattened(&items, &type_aliases)
         .unwrap_or_else(|e| panic!("wasm-gc compile: {e}\n--- source ---\n{source}"));
     wasmparser::Validator::new()
         .validate_all(&bytes)
@@ -436,8 +462,9 @@ fn json_sum_uses_nominal_root_in_variants_tuple_and_dispatch() {
 
     let source = fs::read_to_string(examples_dir().join("data/json.av")).unwrap();
     let module_root = env!("CARGO_MANIFEST_DIR");
-    let items = parse_pipeline_with_module_root(&source, Some(module_root)).unwrap();
-    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None).unwrap();
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(&source, Some(module_root)).unwrap();
+    let bytes = compile_flattened(&items, &type_aliases).unwrap();
     wasmparser::Validator::new().validate_all(&bytes).unwrap();
 
     let mut types = Vec::new();

--- a/tests/wasm_gc_effect_arg_overflow_regression.rs
+++ b/tests/wasm_gc_effect_arg_overflow_regression.rs
@@ -74,7 +74,10 @@ fn run_wasm_gc_with_mode(
              harness must not run it either:\n{rendered}"
         );
     }
-    aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+    // This harness flattens multi-module input, so it must thread the
+    // REAL alias map the flattener derived — the same production path
+    // `src/main/run_wasm_gc.rs` takes.
+    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
     aver::ir::pipeline::resolve(&mut items);
 
     let (run_res, stdout, _stderr) = aver::services::console::capture_output(|| {
@@ -82,9 +85,9 @@ fn run_wasm_gc_with_mode(
             &items,
             result.analysis.as_ref(),
             aver::runtime::wasm_gc::RunConfig {
-                program_args: Vec::new(),
-                entry_info: None,
                 mode,
+                type_aliases: type_aliases.clone(),
+                ..Default::default()
             },
         )
     });

--- a/tests/wasm_gc_packed_sequence.rs
+++ b/tests/wasm_gc_packed_sequence.rs
@@ -36,6 +36,47 @@ fn run(source: &str, wasm_gc: bool, packed: bool) -> (bool, String) {
     )
 }
 
+/// Multi-module variant of `run`: writes `main.av` plus one dep module
+/// file, then drives `aver run main.av --module-root <dir>` so the CLI's
+/// multi-module flatten + wasm-gc path is exercised end to end.
+fn run_multi(
+    entry_src: &str,
+    dep_file: &str,
+    dep_src: &str,
+    wasm_gc: bool,
+    packed: bool,
+) -> (bool, String) {
+    let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "aver-packed-sequence-multi-{}-{id}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("main.av");
+    std::fs::write(&path, entry_src).expect("entry source");
+    std::fs::write(dir.join(dep_file), dep_src).expect("dep source");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver"));
+    command.arg("run").arg(&path).arg("--module-root").arg(&dir);
+    if wasm_gc {
+        command.arg("--wasm-gc");
+    }
+    if !packed {
+        command.env("AVER_NO_PACKED_SEQUENCES", "1");
+    }
+    let output = command.output().expect("run aver");
+    let _ = std::fs::remove_dir_all(dir);
+    (
+        output.status.success(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .trim()
+        .to_string(),
+    )
+}
+
 fn compile(source: &str, packed: bool) -> Vec<u8> {
     let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
     let dir = std::env::temp_dir().join(format!(
@@ -180,6 +221,67 @@ fn generic_u8_refinement_matches_vm_and_boxed_wasm() {
         i8_array_count(&boxed_wasm) + 1,
         "the proof-derived layout must add one packed i8 array"
     );
+}
+
+// Entry-side qualified annotation over a SOLE-declarer packed dep type
+// (`o: Dep.Octets = ...`). The dep's gated refinement earns the packed
+// layout under its bare post-flatten name while the entry annotation's
+// qualified spelling survives in the type stamps; the flatten-derived
+// alias must resolve both spellings to the same layout, on the packed
+// path AND under the boxed differential baseline.
+const QUALIFIED_ENTRY: &str = r#"module Main
+    intent = "entry qualified annotation over sole-declarer packed dep type"
+    depends [Dep]
+    effects [Console]
+
+fn firstValue(o: Dep.Octets) -> Int
+    match o.values
+        [head, .._] -> head
+        [] -> 0 - 1
+
+fn run() -> Result<Int, String>
+    o: Dep.Octets = Dep.fromList([200])?
+    Result.Ok(firstValue(o))
+
+fn main() -> Unit
+    ! [Console.print]
+    match run()
+        Result.Ok(n) -> Console.print("{n}")
+        Result.Err(error) -> Console.print(error)
+"#;
+
+const QUALIFIED_DEP: &str = r#"module Dep
+    intent = "sole-declarer gated Octets refinement"
+    exposes [Octets, fromList]
+    depends []
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+"#;
+
+#[test]
+fn qualified_annotation_over_sole_declarer_dep_matches_vm_and_boxed_wasm() {
+    let (vm_ok, vm) = run_multi(QUALIFIED_ENTRY, "dep.av", QUALIFIED_DEP, false, true);
+    let (packed_ok, packed) = run_multi(QUALIFIED_ENTRY, "dep.av", QUALIFIED_DEP, true, true);
+    let (boxed_ok, boxed) = run_multi(QUALIFIED_ENTRY, "dep.av", QUALIFIED_DEP, true, false);
+    assert!(vm_ok, "VM failed: {vm}");
+    assert!(packed_ok, "packed wasm failed: {packed}");
+    assert!(boxed_ok, "boxed wasm failed: {boxed}");
+    assert_eq!(packed, vm);
+    assert_eq!(boxed, vm);
+    assert_eq!(vm, "200");
 }
 
 #[test]

--- a/tests/wasm_gc_packed_sequence.rs
+++ b/tests/wasm_gc_packed_sequence.rs
@@ -284,6 +284,46 @@ fn qualified_annotation_over_sole_declarer_dep_matches_vm_and_boxed_wasm() {
     assert_eq!(vm, "200");
 }
 
+// SOUNDNESS counterpart of the alias availability test above: an
+// entry-side QUALIFIED ungated constructor (`Dep.Octets(values = xs)`)
+// resolves the packed layout through the flatten-derived alias, so the
+// demotion scan must see that construct site under the SAME key — every
+// spelling that can resolve a packed layout at a construct site must be
+// visible to the scan. Before the alias-aware scan, the qualified
+// spelling never matched the bare `Octets` candidate, the type kept its
+// packed u8 storage, and the out-of-range 1000 silently truncated to
+// 232 on the packed path (the exact bug class the exact-name rule
+// killed for collision-renamed types).
+const QUALIFIED_BYPASS_ENTRY: &str = r#"module Main
+    intent = "entry-side qualified ungated constructor must demote the packed layout"
+    depends [Dep]
+    effects [Console]
+
+fn bypass(xs: List<Int>) -> Dep.Octets
+    Dep.Octets(values = xs)
+
+fn main() -> Unit
+    ! [Console.print]
+    value = bypass([1000])
+    match value.values
+        [head, .._] -> Console.print("{head}")
+        [] -> Console.print("empty")
+"#;
+
+#[test]
+fn qualified_ungated_constructor_demotes_instead_of_truncating() {
+    let (vm_ok, vm) = run_multi(QUALIFIED_BYPASS_ENTRY, "dep.av", QUALIFIED_DEP, false, true);
+    let (packed_ok, packed) =
+        run_multi(QUALIFIED_BYPASS_ENTRY, "dep.av", QUALIFIED_DEP, true, true);
+    let (boxed_ok, boxed) = run_multi(QUALIFIED_BYPASS_ENTRY, "dep.av", QUALIFIED_DEP, true, false);
+    assert!(vm_ok, "VM failed: {vm}");
+    assert!(packed_ok, "packed wasm failed: {packed}");
+    assert!(boxed_ok, "boxed wasm failed: {boxed}");
+    assert_eq!(packed, vm, "packed wasm must not truncate the ungated 1000");
+    assert_eq!(boxed, vm);
+    assert_eq!(vm, "1000");
+}
+
 #[test]
 fn ungated_constructor_demotes_instead_of_truncating() {
     let (vm_ok, vm) = run(BYPASSED_OCTETS, false, true);

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -559,6 +559,60 @@ fn fromList(xs: List<Int>) -> Result<Octets, String>
     );
 }
 
+// Fail-closed exclusion branch of the alias derivation: when the ENTRY
+// module declares the same bare type name a dep declares, the qualified
+// dep spelling gets NO alias — post-flatten two `TypeDef`s would share
+// the bare key, so aliasing `Dep.Octets` → `Octets` could hand the entry
+// type's layout facts to the dep spelling (or vice versa). The dep type
+// is still the sole declarer AMONG DEPS, which is exactly why the
+// entry-shadow check must be its own condition; an unshadowed sibling
+// dep type keeps its alias (positive control).
+#[test]
+fn entry_shadowed_bare_name_derives_no_alias() {
+    let entry_src = r#"
+module Entry
+    intent = "entry-shadowed bare name must not get a qualified alias"
+    depends [Dep]
+
+record Octets
+    values: List<Int>
+
+fn main() -> Int
+    7
+"#;
+    let dep_src = r#"
+module Dep
+    intent = "dep declaring a shadowed and an unshadowed type"
+    exposes [Octets, Other]
+    depends []
+
+record Octets
+    values: List<Int>
+
+record Other
+    value: Int
+"#;
+    let mut entry_items = parse_source(entry_src).expect("entry parse");
+    let loaded = aver::source::LoadedModule {
+        dep_name: "Dep".to_string(),
+        items: parse_source(dep_src).expect("dep parse"),
+        path: std::path::PathBuf::from("Dep.av"),
+    };
+    let modules = vec![aver::codegen::ModuleInfo::from_loaded(&loaded)];
+    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
+    assert!(
+        !type_aliases.contains_key("Dep.Octets"),
+        "entry declares its own `Octets`, so the qualified dep spelling \
+         must decline fail-closed (no alias registered): {type_aliases:?}"
+    );
+    assert_eq!(
+        type_aliases.get("Dep.Other").map(String::as_str),
+        Some("Other"),
+        "the unshadowed sibling dep type keeps its identity-preserving \
+         alias: {type_aliases:?}"
+    );
+}
+
 // ────────────────────────────────────────────────────────────────────
 // List<T>
 // ────────────────────────────────────────────────────────────────────
@@ -1427,5 +1481,105 @@ fn fromInt(n: Int) -> Result<IntRange, String>
         result, 70,
         "expected the qualified `r: Dep.IntRange` binding to agree with the \
          unique carrier's representation and return 70"
+    );
+}
+
+// A carrier used as a `Map` KEY must stay boxed (the Map-key codegen
+// expects the struct-ref key layout), and that demotion must fire even
+// when the ONLY spelling naming the carrier in Map-key position is the
+// entry-side QUALIFIED one (`m: Map<Dep.IntRange, Int>` — the resolved
+// key type keeps the qualified stamp). The alias-aware Scan 2 must
+// canonicalize the resolved key spelling to the same bare key the
+// eligibility set uses; missing it leaves the carrier i64-erased and
+// the module fails wasm validation.
+#[test]
+fn qualified_map_key_spelling_over_sole_declarer_carrier_demotes() {
+    let entry_src = r#"
+module Entry
+    intent = "qualified Map-key spelling over a sole-declarer carrier dep type"
+    depends [Dep]
+
+fn lookup(r: Dep.IntRange) -> Int
+    m: Map<Dep.IntRange, Int> = Map.set({}, r, 41)
+    match Map.get(m, r)
+        Option.Some(v) -> v
+        Option.None -> 0 - 1
+
+fn run() -> Result<Int, String>
+    r: Dep.IntRange = Dep.fromInt(70)?
+    Result.Ok(lookup(r))
+
+fn main() -> Int
+    match run()
+        Result.Ok(n) -> n
+        Result.Err(_) -> 0 - 2
+"#;
+    let dep_src = r#"
+module Dep
+    intent = "sole-declarer gated IntRange carrier"
+    exposes [IntRange, fromInt]
+    depends []
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+"#;
+    let result = run_int_multi(entry_src, &[("Dep", dep_src)]);
+    assert_eq!(
+        result, 41,
+        "expected the qualified Map-key spelling to demote the carrier to \
+         its boxed struct-ref key layout and read back 41"
+    );
+}
+
+// Availability counterpart for the MULTI-FIELD carrier path: an
+// entry-side qualified local-binding annotation over a sole-declarer
+// gated multi-field dep record (`c: Dep.Coord = ...`) must resolve the
+// same per-`(record, field)` i64-erasure facts as the bare post-flatten
+// name — this exercises the mirrored `field_carrier_intervals` alias
+// entries. Only collision-renamed spellings keep declining.
+#[test]
+fn entry_qualified_annotation_over_sole_declarer_multi_field_carrier_dep_type() {
+    let entry_src = r#"
+module Entry
+    intent = "qualified local annotation over a sole-declarer multi-field carrier dep type"
+    depends [Dep]
+
+fn total(c: Dep.Coord) -> Int
+    c.x + c.y
+
+fn run() -> Result<Int, String>
+    c: Dep.Coord = Dep.coord(3, 4)?
+    Result.Ok(total(c))
+
+fn main() -> Int
+    match run()
+        Result.Ok(n) -> n
+        Result.Err(_) -> 0 - 1
+"#;
+    let dep_src = r#"
+module Dep
+    intent = "sole-declarer gated multi-field Coord record"
+    exposes [Coord, coord]
+    depends []
+
+record Coord
+    x: Int
+    y: Int
+
+fn coord(x: Int, y: Int) -> Result<Coord, String>
+    match Bool.and(Bool.and(x >= 0, x <= 100), Bool.and(y >= 0, y <= 100))
+        true -> Result.Ok(Coord(x = x, y = y))
+        false -> Result.Err("oob")
+"#;
+    let result = run_int_multi(entry_src, &[("Dep", dep_src)]);
+    assert_eq!(
+        result, 7,
+        "expected the qualified `c: Dep.Coord` binding to agree with the \
+         unique multi-field carrier's field representation and return 7"
     );
 }

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -201,11 +201,19 @@ fn compile_multi_module_bytes(entry_src: &str, dep_sources: &[(&str, &str)]) -> 
         .into_iter()
         .map(|m| aver::codegen::ModuleInfo::from_loaded(&m))
         .collect();
-    aver::codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
+    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
     aver::ir::pipeline::resolve(&mut entry_items);
-    compile_to_wasm_gc(&entry_items, result.analysis.as_ref()).unwrap_or_else(|e| {
+    aver::codegen::wasm_gc::compile_to_wasm_gc_flattened(
+        &entry_items,
+        result.analysis.as_ref(),
+        None,
+        aver::codegen::wasm_gc::TargetMode::AverBridge,
+        &type_aliases,
+    )
+    .unwrap_or_else(|e| {
         panic!("wasm-gc multi-module compile failed: {e:?}");
     })
+    .bytes
 }
 
 fn run_int_multi(entry_src: &str, dep_sources: &[(&str, &str)]) -> i64 {
@@ -489,6 +497,65 @@ record Octets
         "expected the ungated Left.Octets record to stay boxed and return \
          1000; 232 means it inherited the entry refinement's packed u8 \
          layout through a qualified→bare name fallback and truncated"
+    );
+}
+
+// Availability counterpart of the exact-name test above: an ENTRY-side
+// local-binding annotation may spell a dep type qualified
+// (`o: Dep.Octets = ...`) even though flatten keeps the sole-declarer
+// dep `TypeDef` bare. The pre-flatten typechecker stamps the binding
+// slot with the qualified name, and that stamp survives into codegen,
+// so the packed lookups must accept `Dep.Octets` as an alias for the
+// unique `Octets` layout. The alias is identity-correct ONLY because
+// `Dep` is the sole declarer — a collision-renamed spelling must keep
+// declining (previous test).
+#[test]
+fn entry_qualified_annotation_over_sole_declarer_packed_dep_type() {
+    let entry_src = r#"
+module Entry
+    intent = "qualified local annotation over a sole-declarer packed dep type"
+    depends [Dep]
+
+fn firstValue(o: Dep.Octets) -> Int
+    match o.values
+        [head, .._] -> head
+        [] -> 0 - 1
+
+fn run() -> Result<Int, String>
+    o: Dep.Octets = Dep.fromList([200])?
+    Result.Ok(firstValue(o))
+
+fn main() -> Int
+    match run()
+        Result.Ok(n) -> n
+        Result.Err(_) -> 0 - 2
+"#;
+    let dep_src = r#"
+module Dep
+    intent = "sole-declarer gated Octets refinement"
+    exposes [Octets, fromList]
+    depends []
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+"#;
+    let result = run_int_multi(entry_src, &[("Dep", dep_src)]);
+    assert_eq!(
+        result, 200,
+        "expected the qualified `o: Dep.Octets` binding to resolve the \
+         unique packed dep layout and return 200"
     );
 }
 
@@ -1314,5 +1381,51 @@ record IntRange
         "expected the plain Left.IntRange record to stay boxed and hold a \
          beyond-i64 Int; a trap or 0 means it inherited the entry carrier's \
          i64 erasure through a qualified→bare name fallback"
+    );
+}
+
+// Availability counterpart for the scalar carrier path: an entry-side
+// qualified local-binding annotation over a SOLE-declarer gated dep
+// carrier (`r: Dep.IntRange = ...`) must resolve the same carrier-i64
+// eligibility fact as the bare post-flatten name, because `Dep` is the
+// unique declarer. Only collision-renamed spellings keep declining.
+#[test]
+fn entry_qualified_annotation_over_sole_declarer_carrier_dep_type() {
+    let entry_src = r#"
+module Entry
+    intent = "qualified local annotation over a sole-declarer carrier dep type"
+    depends [Dep]
+
+fn value(r: Dep.IntRange) -> Int
+    r.value
+
+fn run() -> Result<Int, String>
+    r: Dep.IntRange = Dep.fromInt(70)?
+    Result.Ok(value(r))
+
+fn main() -> Int
+    match run()
+        Result.Ok(n) -> n
+        Result.Err(_) -> 0 - 1
+"#;
+    let dep_src = r#"
+module Dep
+    intent = "sole-declarer gated IntRange carrier"
+    exposes [IntRange, fromInt]
+    depends []
+
+record IntRange
+    value: Int
+
+fn fromInt(n: Int) -> Result<IntRange, String>
+    match Bool.and(n >= 0, n <= 100)
+        true -> Result.Ok(IntRange(value = n))
+        false -> Result.Err("oob")
+"#;
+    let result = run_int_multi(entry_src, &[("Dep", dep_src)]);
+    assert_eq!(
+        result, 70,
+        "expected the qualified `r: Dep.IntRange` binding to agree with the \
+         unique carrier's representation and return 70"
     );
 }


### PR DESCRIPTION
## Problem

#792 made the wasm-gc packed-sequence and carrier-i64 lookups exact-name only (correctly, to stop collision-renamed types from inheriting another type's proof-derived layout). Its audit then found one legitimate shape the removed fallback had been carrying: an entry-side local-binding annotation that spells a dep type qualified over a dep that is the sole declarer of the bare name.

```
module Entry
    depends [Dep]

fn run() -> Result<Int, String>
    o: Dep.Octets = Dep.fromList([200])?
    ...
```

with `Dep` declaring the gated `Octets` refinement (`record Octets { values: List<Int> }` + recursive range predicate + smart constructor). The pre-flatten typechecker stamps the binding with the qualified spelling, and the stamps survive into codegen. The layout table keys the sole-declarer type under the bare post-flatten name `Octets`, so the exact-name lookups miss and the module fails wasm validation (`type mismatch: expected (ref null $type), found (ref null $type)`). The parent of #792 (b4593694) compiled this shape and returned the correct value. The analogous scalar carrier shape (`r: Dep.IntRange = ...`) failed validation even before #792 because `newtype_underlying` was already exact-name.

## Fix

Identity-preserving aliases, never suffix guessing. `flatten_multimodule` already computes the collision info, so it now returns the qualified spellings that provably denote the same `TypeDef`: `"Dep.Octets" -> "Octets"` only when the bare name has exactly one dep declarer, no collision rename, and no entry-declared type of the same bare name. The wasm-gc registry registers those as extra lookup keys onto the canonical entries of the packed-sequence table, the pack/unpack helper maps, the carrier-i64 eligibility sets, the newtype-underlying resolution, and the MIR bare-i64 fact tables. Ambiguous or collision-renamed spellings get no alias and keep declining fail-closed.

The multi-module compile/run/wasip2/verify/playground paths thread the aliases through a new `compile_to_wasm_gc_flattened` entry. The single-module entries compile with an empty alias map (byte-identical output; the snapshot regression suite is green).

## Tests

- `entry_qualified_annotation_over_sole_declarer_packed_dep_type` and `entry_qualified_annotation_over_sole_declarer_carrier_dep_type` in `tests/wasm_gc_spec.rs` — both failed wasm validation on main before this change, both return the correct untruncated value now.
- `qualified_annotation_over_sole_declarer_dep_matches_vm_and_boxed_wasm` in `tests/wasm_gc_packed_sequence.rs` — CLI-driven differential: VM == packed wasm == boxed wasm (`AVER_NO_PACKED_SEQUENCES=1`) == `200`.
- #792 soundness tests stay green: `cross_module_same_bare_name_record_does_not_inherit_packed_layout` and `cross_module_same_bare_name_record_does_not_inherit_carrier_i64_erasure`.
- Full `wasm_gc_spec` (41), `wasm_gc_packed_sequence` (3), `wasm_gc_carrier_i64_differential` (82), `wasm_gc_codegen_regression` (10) all pass; clippy clean on touched code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
