### PR TITLE
Fix the wasip2 regression test build after the alias-map merge

### DIFF
--- a/tests/wasip2_codegen_regression.rs
+++ b/tests/wasip2_codegen_regression.rs
@@ -456,8 +456,9 @@ fn read(conn: Tcp.Connection, count: Int) -> Result<Bytes, String>
     ! [Tcp.readBytes]
     Tcp.readBytes(conn, count)
 "#;
-    let items = parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
-        .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let (items, _aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
     let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc_for_wasip2(&items, None)
         .unwrap_or_else(|e| panic!("wasip2 core compile: {e}\n--- source ---\n{source}"));
 


### PR DESCRIPTION
Two independently green branches merged into a semantic conflict: the readBytes count-classification test bound the old single-value return of parse_pipeline_with_module_root, while the qualified-alias work changed that helper to return the flatten alias map as well, so main stopped compiling the wasip2 regression test target. Destructures the tuple like every sibling call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)