### PR TITLE
Support top-level bindings in the self-host pipeline

### DIFF
--- a/self_hosted/README.md
+++ b/self_hosted/README.md
@@ -10,6 +10,7 @@ This directory is the source for `aver run --self-host`. End users who install A
 - Recursive descent parser (expressions, match, fn defs, modules)
 - Compile-time variable resolver (ExprVar → ExprSlot)
 - Tree-walking evaluator with Map-based env and slot-based locals
+- Top-level bindings evaluated in source order before `main()` and visible to every function, matching the host VM
 - Guest independent products executed through the evaluator's own `?!`, so VM / compiled self-host can overlap guest branches
 - Float literals and arithmetic with Int↔Float promotion
 - Pattern matching: literals, wildcards, cons, constructors, tuples

--- a/self_hosted/domain/eval/common.av
+++ b/self_hosted/domain/eval/common.av
@@ -7,16 +7,27 @@ module Common
     effects []
 
 fn evalVarFallback(name: String, fns: FnStore) -> Result<Val, String>
-    ? "If variable not in env, try as a named function reference before falling back to a nullary variant."
+    ? "If variable not in env, try a top-level binding, then a named function reference, then a nullary variant."
+    match Domain.Eval.Store.lookupGlobal(fns, name)
+        Option.Some(v) -> Result.Ok(v)
+        Option.None -> evalVarFallbackNamed(name, fns)
+
+verify evalVarFallback
+    evalVarFallback("Token.TkPlus", Domain.Eval.Store.emptyFnStore()) => Result.Ok(Val.ValVariant(Domain.Ast.ctorNameToTag("Token.TkPlus"), "Token.TkPlus", []))
+    evalVarFallback("xyz", Domain.Eval.Store.emptyFnStore()) => Result.Err("undefined variable: xyz")
+    evalVarFallback("g", Domain.Eval.Store.withGlobals(Domain.Eval.Store.emptyFnStore(), Map.set({}, "g", Val.ValInt(7)))) => Result.Ok(Val.ValInt(7))
+
+fn evalVarFallbackNamed(name: String, fns: FnStore) -> Result<Val, String>
+    ? "Resolve a name that is neither a local nor a top-level binding: function reference, then nullary variant."
     match Domain.Eval.Store.lookupFnOption(fns, name)
         Option.Some(fd) -> Result.Ok(Val.ValFnRef(fd.name))
         Option.None -> match Domain.Builtins.splitDotted(name)
             Option.Some(_) -> Result.Ok(Val.ValVariant(Domain.Ast.ctorNameToTag(name), name, []))
             Option.None -> Result.Err("undefined variable: {name}")
 
-verify evalVarFallback
-    evalVarFallback("Token.TkPlus", Domain.Eval.Store.emptyFnStore()) => Result.Ok(Val.ValVariant(Domain.Ast.ctorNameToTag("Token.TkPlus"), "Token.TkPlus", []))
-    evalVarFallback("xyz", Domain.Eval.Store.emptyFnStore()) => Result.Err("undefined variable: xyz")
+verify evalVarFallbackNamed
+    evalVarFallbackNamed("Token.TkPlus", Domain.Eval.Store.emptyFnStore()) => Result.Ok(Val.ValVariant(Domain.Ast.ctorNameToTag("Token.TkPlus"), "Token.TkPlus", []))
+    evalVarFallbackNamed("xyz", Domain.Eval.Store.emptyFnStore()) => Result.Err("undefined variable: xyz")
 
 fn propagationPrefix() -> String
     ? "Internal prefix used to distinguish ? propagation from evaluator runtime errors."

--- a/self_hosted/domain/eval/core.av
+++ b/self_hosted/domain/eval/core.av
@@ -724,19 +724,31 @@ fn evalStmts(stmts: List<Stmt>, env: Map<String, Val>, fns: FnStore) -> Result<V
                     [] -> Result.Ok(v)
                     _ -> evalStmts(rest, newEnv, fns)
 
+fn evalTopLevelStmts(stmts: List<Stmt>, env: Map<String, Val>, last: Val, fns: FnStore) -> Result<Tuple<Val, Map<String, Val>>, String>
+    ? "Evaluate top-level statements in source order and keep the resulting env, so top-level bindings stay visible to functions. Each statement sees the bindings before it, both directly and through any function it calls."
+    ! [Args, Console, Disk, Env, Http, HttpServer, Random, Tcp, Terminal, Time]
+    match stmts
+        [] -> Result.Ok((last, env))
+        [s, ..rest] -> match evalStmt(s, env, Domain.Eval.Store.withGlobals(fns, env))
+            Result.Err(e) -> Result.Err(e)
+            Result.Ok(pair) -> match pair
+                (v, newEnv) -> evalTopLevelStmts(rest, newEnv, v, fns)
+
 fn evalProgram(prog: Program) -> Result<Val, String>
     ? "Evaluate a complete program: run top-level stmts, then call main() if it exists."
     ! [Args, Console, Disk, Env, Http, HttpServer, Random, Tcp, Terminal, Time]
     fnsStore = Domain.Eval.Store.fnsToStore(prog.fns)
-    v = evalStmts(prog.stmts, {}, fnsStore)?
-    maybeCallMain(fnsStore, v)
+    top = evalTopLevelStmts(prog.stmts, {}, Val.ValUnit, fnsStore)?
+    match top
+        (v, globals) -> maybeCallMain(Domain.Eval.Store.withGlobals(fnsStore, globals), v)
 
 fn evalProgramWithFns(prog: Program, extraFns: List<FnDef>) -> Result<Val, String>
     ? "Evaluate a program with additional functions from loaded modules."
     ! [Args, Console, Disk, Env, Http, HttpServer, Random, Tcp, Terminal, Time]
     allFns = Domain.Eval.Store.fnsToStore(List.concat(extraFns, prog.fns))
-    v = evalStmts(prog.stmts, {}, allFns)?
-    maybeCallMain(allFns, v)
+    top = evalTopLevelStmts(prog.stmts, {}, Val.ValUnit, allFns)?
+    match top
+        (v, globals) -> maybeCallMain(Domain.Eval.Store.withGlobals(allFns, globals), v)
 
 fn maybeCallMain(fns: FnStore, fallback: Val) -> Result<Val, String>
     ? "If a main() function exists, call it. Otherwise return fallback value."

--- a/self_hosted/domain/eval/store.av
+++ b/self_hosted/domain/eval/store.av
@@ -3,12 +3,13 @@ module Store
     intent =
         "Function-store and environment helpers for the self-hosted evaluator."
         "Keeps name-to-id lookup separate from the main eval loop."
-    exposes [FnStore, lookupVar, emptyFnStore, lookupFnId, lookupFnById, lookupFnOption, lookupFn, zipArgs, mergeBindings, fnsToStore]
+    exposes [FnStore, lookupVar, emptyFnStore, lookupFnId, lookupFnById, lookupFnOption, lookupFn, zipArgs, mergeBindings, fnsToStore, withGlobals, lookupGlobal]
     effects []
 
 record FnStore
     nameToId: Map<String, Int>
     byId: Vector<FnDef>
+    globals: Map<String, Val>
 
 fn lookupVar(env: Map<String, Val>, name: String) -> Result<Val, String>
     ? "Look up a variable in the environment."
@@ -22,10 +23,26 @@ verify lookupVar
 
 fn emptyFnStore() -> FnStore
     ? "Create an empty function store."
-    FnStore(nameToId = {}, byId = Vector.fromList([]))
+    FnStore(nameToId = {}, byId = Vector.fromList([]), globals = {})
 
 verify emptyFnStore
     emptyFnStore().nameToId => {}
+    emptyFnStore().globals => {}
+
+fn withGlobals(fns: FnStore, globals: Map<String, Val>) -> FnStore
+    ? "Attach evaluated top-level bindings so function bodies can read them."
+    FnStore(nameToId = fns.nameToId, byId = fns.byId, globals = globals)
+
+verify withGlobals
+    withGlobals(emptyFnStore(), Map.set({}, "x", Val.ValInt(1))).globals => Map.set({}, "x", Val.ValInt(1))
+
+fn lookupGlobal(fns: FnStore, name: String) -> Option<Val>
+    ? "Look up a top-level binding value by name."
+    Map.get(fns.globals, name)
+
+verify lookupGlobal
+    lookupGlobal(withGlobals(emptyFnStore(), Map.set({}, "x", Val.ValInt(1))), "x") => Option.Some(Val.ValInt(1))
+    lookupGlobal(emptyFnStore(), "x") => Option.None
 
 fn lookupFnId(fns: FnStore, name: String) -> Result<Int, String>
     ? "Look up a function id by name."
@@ -93,7 +110,7 @@ verify mergeBindings
 fn fnsToStore(fns: List<FnDef>) -> FnStore
     ? "Build a function store with a name->id index and id->FnDef table."
     nameToId = fnsToIdMap(fns, {}, 0)
-    FnStore(nameToId = nameToId, byId = Vector.fromList(fns))
+    FnStore(nameToId = nameToId, byId = Vector.fromList(fns), globals = {})
 
 verify fnsToStore
     fnsToStore([]).nameToId => {}

--- a/src/self_host/aver_generated/domain/eval/common/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/common/mod.rs
@@ -9,9 +9,19 @@ use crate::aver_generated::domain::value::*;
 #[allow(unused_imports)]
 use crate::*;
 
-/// If variable not in env, try as a named function reference before falling back to a nullary variant.
+/// If variable not in env, try a top-level binding, then a named function reference, then a nullary variant.
 #[inline(always)]
 pub fn evalVarFallback(name: AverStr, fns: &FnStore) -> Result<Val, AverStr> {
+    crate::cancel_checkpoint();
+    match crate::aver_generated::domain::eval::store::lookupGlobal(fns, name.clone()) {
+        Some(v) => Ok(v),
+        None => crate::aver_generated::domain::eval::common::evalVarFallbackNamed(name, fns),
+    }
+}
+
+/// Resolve a name that is neither a local nor a top-level binding: function reference, then nullary variant.
+#[inline(always)]
+pub fn evalVarFallbackNamed(name: AverStr, fns: &FnStore) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::store::lookupFnOption(fns, name.clone()) {
         Some(fd) => Ok(crate::aver_generated::domain::value::Val::ValFnRef(

--- a/src/self_host/aver_generated/domain/eval/core/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/core/mod.rs
@@ -4265,16 +4265,44 @@ pub fn evalStmts(
     }
 }
 
+/// Evaluate top-level statements in source order and keep the resulting env, so top-level bindings stay visible to functions. Each statement sees the bindings before it, both directly and through any function it calls.
+pub fn evalTopLevelStmts(
+    mut stmts: aver_rt::AverList<Stmt>,
+    mut env: aver_rt::AverMap<AverStr, Val>,
+    mut last: Val,
+    mut fns: FnStore,
+) -> Result<(Val, aver_rt::AverMap<AverStr, Val>), AverStr> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(stmts, [] => { return Ok((last, env)); }, [s, rest] => { match crate::aver_generated::domain::eval::core::evalStmt(&s, &env, &crate::aver_generated::domain::eval::store::withGlobals(&fns, &env)) { Err(e) => { return Err(e); }, Ok(pair) => { { let (v, newEnv) = pair; {
+            let __tco0 = rest;
+            let __tco1 = newEnv;
+            let __tco2 = v;
+            stmts = __tco0;
+            env = __tco1;
+            last = __tco2;
+            continue;
+        } } } } })
+    }
+}
+
 /// Evaluate a complete program: run top-level stmts, then call main() if it exists.
 pub fn evalProgram(prog: &Program) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let fnsStore = crate::aver_generated::domain::eval::store::fnsToStore(&prog.fns);
-    let v = crate::aver_generated::domain::eval::core::evalStmts(
+    let top = crate::aver_generated::domain::eval::core::evalTopLevelStmts(
         prog.stmts.clone(),
         HashMap::new(),
+        crate::aver_generated::domain::value::Val::ValUnit,
         fnsStore.clone(),
     )?;
-    crate::aver_generated::domain::eval::core::maybeCallMain(&fnsStore, &v)
+    {
+        let (v, globals) = top;
+        crate::aver_generated::domain::eval::core::maybeCallMain(
+            &crate::aver_generated::domain::eval::store::withGlobals(&fnsStore, &globals),
+            &v,
+        )
+    }
 }
 
 /// Evaluate a program with additional functions from loaded modules.
@@ -4286,12 +4314,19 @@ pub fn evalProgramWithFns(
     let allFns = crate::aver_generated::domain::eval::store::fnsToStore(
         &aver_rt::AverList::concat(&extraFns.clone(), &prog.fns.clone()),
     );
-    let v = crate::aver_generated::domain::eval::core::evalStmts(
+    let top = crate::aver_generated::domain::eval::core::evalTopLevelStmts(
         prog.stmts.clone(),
         HashMap::new(),
+        crate::aver_generated::domain::value::Val::ValUnit,
         allFns.clone(),
     )?;
-    crate::aver_generated::domain::eval::core::maybeCallMain(&allFns, &v)
+    {
+        let (v, globals) = top;
+        crate::aver_generated::domain::eval::core::maybeCallMain(
+            &crate::aver_generated::domain::eval::store::withGlobals(&allFns, &globals),
+            &v,
+        )
+    }
 }
 
 /// If a main() function exists, call it. Otherwise return fallback value.

--- a/src/self_host/aver_generated/domain/eval/store/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/store/mod.rs
@@ -9,6 +9,7 @@ use crate::*;
 pub struct FnStore {
     pub nameToId: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     pub byId: aver_rt::AverVector<FnDef>,
+    pub globals: aver_rt::AverMap<AverStr, Val>,
 }
 
 impl aver_rt::AverDisplay for FnStore {
@@ -17,7 +18,8 @@ impl aver_rt::AverDisplay for FnStore {
             "FnStore({})",
             vec![
                 format!("nameToId: {}", self.nameToId.aver_display_inner()),
-                format!("byId: {}", self.byId.aver_display_inner())
+                format!("byId: {}", self.byId.aver_display_inner()),
+                format!("globals: {}", self.globals.aver_display_inner())
             ]
             .join(", ")
         )
@@ -35,6 +37,10 @@ impl aver_replay::ReplayValue for FnStore {
             ReplayValue::to_replay_json(&self.nameToId),
         );
         fields.insert("byId".to_string(), ReplayValue::to_replay_json(&self.byId));
+        fields.insert(
+            "globals".to_string(),
+            ReplayValue::to_replay_json(&self.globals),
+        );
         let mut payload = serde_json::Map::new();
         payload.insert(
             "type".to_string(),
@@ -75,6 +81,11 @@ impl aver_replay::ReplayValue for FnStore {
                     .get("byId")
                     .ok_or_else(|| "$record FnStore missing field 'byId'".to_string())?,
             )?,
+            globals: <aver_rt::AverMap<AverStr, Val> as ReplayValue>::from_replay_json(
+                fields
+                    .get("globals")
+                    .ok_or_else(|| "$record FnStore missing field 'globals'".to_string())?,
+            )?,
         })
     }
 }
@@ -95,7 +106,25 @@ pub fn emptyFnStore() -> FnStore {
     crate::aver_generated::domain::eval::store::FnStore {
         nameToId: HashMap::new(),
         byId: aver_rt::AverVector::from_vec(aver_rt::AverList::empty().to_vec()),
+        globals: HashMap::new(),
     }
+}
+
+/// Attach evaluated top-level bindings so function bodies can read them.
+pub fn withGlobals(fns: &FnStore, globals: &aver_rt::AverMap<AverStr, Val>) -> FnStore {
+    crate::cancel_checkpoint();
+    crate::aver_generated::domain::eval::store::FnStore {
+        nameToId: fns.nameToId.clone(),
+        byId: fns.byId.clone(),
+        globals: globals.clone(),
+    }
+}
+
+/// Look up a top-level binding value by name.
+#[inline(always)]
+pub fn lookupGlobal(fns: &FnStore, name: AverStr) -> Option<Val> {
+    crate::cancel_checkpoint();
+    fns.globals.get(&name).cloned()
 }
 
 /// Look up a function id by name.
@@ -200,6 +229,7 @@ pub fn fnsToStore(fns: &aver_rt::AverList<FnDef>) -> FnStore {
     crate::aver_generated::domain::eval::store::FnStore {
         nameToId: nameToId,
         byId: aver_rt::AverVector::from_vec(fns.to_vec()),
+        globals: HashMap::new(),
     }
 }
 

--- a/tests/cross_backend_stress.rs
+++ b/tests/cross_backend_stress.rs
@@ -917,3 +917,119 @@ fn cross_vector_aliasing_pin_self_host() {
         VECTOR_ALIASING_OUT,
     );
 }
+
+// ─── Top-level bindings ────────────────────────────────────────────────
+//
+// A binding outside any `fn` is a module-level value: the host VM
+// evaluates every top-level statement in source order before `main`,
+// then exposes the results to every function regardless of where the
+// function is written. The self-hosted interpreter used to evaluate the
+// same statements into a throwaway environment and then call `main` with
+// an empty one, so any program with a top-level binding died on
+// `undefined variable` — no division, no refinement, nothing else
+// involved. This source pins the whole set of rules that made the two
+// pipelines agree again:
+//
+//   * `header` reads `title`, which is bound BELOW it — visibility does
+//     not depend on source position.
+//   * `doubled` / `kept` / `summary` read earlier top-level bindings.
+//   * `next = bump()` calls a function that reads `limit`, so bindings
+//     must already be visible to functions WHILE the top level runs, not
+//     only once `main` starts.
+//   * `scaled` shadows `limit` with a parameter and `pick` shadows it
+//     with a match-arm binding; the local must win, and the last line
+//     proves the global survived both.
+//
+// (A fn-local `x = ...` shadowing a top-level `x` is not covered here:
+// the host typechecker rejects that program on both paths before either
+// backend runs.)
+const TOP_LEVEL_BINDING_SRC: &str = r#"module Tmp
+
+fn header() -> String
+    "[" + title + "]"
+
+title = "cfg"
+limit = 3
+doubled = limit * 2
+items = [1, 2, 4, 8]
+kept = List.take(items, limit)
+summary = "{title}:{doubled}"
+
+fn bump() -> Int
+    limit + 1
+
+next = bump()
+
+fn scaled(limit: Int) -> Int
+    limit * 100
+
+fn pick(xs: List<Int>) -> Int
+    match xs
+        [limit, .._] -> limit
+        [] -> 0 - 1
+
+fn main()
+    ! [Console.print]
+    Console.print(header())
+    Console.print(summary)
+    Console.print(String.fromInt(List.len(kept)))
+    Console.print(String.fromInt(next))
+    Console.print(String.fromInt(scaled(2)))
+    Console.print(String.fromInt(pick(items)))
+    Console.print(String.fromInt(limit))
+"#;
+// header | summary | len(take(items, 3)) | bump() | scaled(2) | pick(items) | limit
+const TOP_LEVEL_BINDING_OUT: &str = "[cfg]\ncfg:6\n3\n4\n200\n1\n3";
+
+#[test]
+fn cross_top_level_bindings_vm() {
+    assert_eq_with_label(
+        "VM",
+        &run_vm("aver-cross-toplevel-vm", TOP_LEVEL_BINDING_SRC),
+        TOP_LEVEL_BINDING_OUT,
+    );
+}
+
+#[test]
+fn cross_top_level_bindings_self_host() {
+    assert_eq_with_label(
+        "self-host",
+        &run_self_host("aver-cross-toplevel-sh", TOP_LEVEL_BINDING_SRC),
+        TOP_LEVEL_BINDING_OUT,
+    );
+}
+
+/// A top-level binding may carry the same name as a function. The host
+/// VM stores both under one global slot and the binding wins when the
+/// name is read as a value, so the self-hosted evaluator must consult
+/// top-level bindings BEFORE falling back to a function reference.
+const TOP_LEVEL_SHADOWS_FN_SRC: &str = r#"module Tmp
+
+fn tally() -> Int
+    1
+
+tally = 7
+
+fn main()
+    ! [Console.print]
+    Console.print(String.fromInt(tally))
+"#;
+const TOP_LEVEL_SHADOWS_FN_OUT: &str = "7";
+
+#[test]
+fn cross_top_level_binding_shadows_fn_name_vm() {
+    assert_eq_with_label(
+        "VM",
+        &run_vm("aver-cross-toplevelfn-vm", TOP_LEVEL_SHADOWS_FN_SRC),
+        TOP_LEVEL_SHADOWS_FN_OUT,
+    );
+}
+
+#[test]
+fn cross_top_level_binding_shadows_fn_name_self_host() {
+    assert_eq_with_label(
+        "self-host",
+        &run_self_host("aver-cross-toplevelfn-sh", TOP_LEVEL_SHADOWS_FN_SRC),
+        TOP_LEVEL_SHADOWS_FN_OUT,
+    );
+}


### PR DESCRIPTION
A binding written outside any `fn` is a module-level value. The host VM evaluates every top-level statement in source order before calling `main` and exposes the results to all functions. The self-hosted interpreter evaluated those statements into a throwaway environment and then called `main` with an empty one, so this program worked on the VM and failed under `aver run --self-host` with `undefined variable: greeting`:

```
greeting = "hello"

fn main() -> Unit
    ! [Console.print]
    Console.print(greeting)
```

## What changed

- `FnStore` carries a `globals` map next to the function table, with `withGlobals` / `lookupGlobal` accessors.
- `evalTopLevelStmts` threads the environment through the top-level statement list and returns it, re-attaching it to the store for each statement, so a binding whose value comes from a function call can read the bindings above it.
- The unresolved-name fallback consults top-level bindings before function references, matching the host, where a binding sharing a function's name wins when the name is read as a value.

Semantics were derived from the host VM with probe programs first: source order, visible to functions defined before the binding, forward references and function-local rebinding rejected by the typechecker on both paths, parameters and match-arm bindings shadow normally.

`src/self_host` was regenerated through the release regeneration sequence; the diff is confined to the three evaluator modules. The regeneration gate passes (`AVER_SELF_HOST_REGEN=1 cargo test --features runtime --test rust_self_host_regen -- --ignored`, corpus parity 3/3). No unrelated drift showed up in the regenerated tree.

## Tests

`tests/cross_backend_stress.rs` gains VM/self-host parity pairs covering a binding used in `main`, a binding reading another binding, a binding produced by a function call, shadowing by a parameter and by a match-arm binding, and a binding sharing a function's name.

## Known gaps, unchanged

- The wasm-gc backend traps on any program with a top-level binding. Pre-existing and untouched here, so no wasm-gc test is added.
- The self-host `HttpServer` callback bridge builds its own function store without globals, so a handler reading a top-level binding still fails. Previously the whole program failed, so this is strictly narrower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
