### PR TITLE
Render List<Int> in wasm-gc string interpolation

### DIFF
--- a/src/codegen/wasm_gc/body/from_mir/strings.rs
+++ b/src/codegen/wasm_gc/body/from_mir/strings.rs
@@ -8,12 +8,17 @@ use super::*;
 /// `Vector<String>` of the parts and concat it with `__wasmgc_concat_n`.
 /// Each `Literal` part becomes an `array.new_data` over its segment;
 /// each `Expr` part is emitted then stringified by the same
-/// `String.from{Int,Float,Bool}` dispatch (a `String` is identity).
-/// An interpolation of a compound type — which `emit_interpolated_str`
-/// rejects outright — returns `None` so the whole fn falls back to the
-/// resolved-HIR emitter, which raises the identical error. The result
-/// is always a `String`, so `produces` is `true` (empty interpolation
-/// allocates a zero-length array directly, same as the oracle).
+/// `String.from{Int,Float,Bool}` dispatch (a `String` is identity), plus
+/// `__wasmgc_string_from_list_int` for a `List<Int>`. The result is always
+/// a `String`, so `produces` is `true` (empty interpolation allocates a
+/// zero-length array directly, same as the oracle).
+///
+/// A part whose type has NO stringifier here still returns `None`. There
+/// is no resolved-HIR emitter left to catch that: a `None` makes the whole
+/// enclosing fn an `unreachable` trap stub, so such a program compiles and
+/// then traps at runtime with no diagnostic. `List<Int>` was in that state
+/// until the helper above landed; records, tuples, `Option`/`Result`, maps
+/// and `List<T>` for other `T` still are.
 pub(crate) fn emit_mir_interpolated_str(
     func: &mut Function,
     parts: &[MirStrPart],
@@ -100,6 +105,27 @@ pub(crate) fn emit_mir_interpolated_str(
                                 ),
                             )?;
                         func.instruction(&Instruction::Call(to_string_idx));
+                    }
+                    // `List<Int>` renders via the dedicated helper, which
+                    // walks the cons chain and joins `[`, the per-element
+                    // decimals, and `]`. The value on the stack is already
+                    // the boxed cons list — a PACKED refinement field read
+                    // (`o.values`) went through `MirExpr::Project`, which
+                    // inserts the packed→list unpack bridge before we get
+                    // here, so the packed and boxed paths feed the helper
+                    // the identical representation.
+                    "List<Int>" => {
+                        let from_list_idx = ctx
+                            .fn_map
+                            .builtins
+                            .get("__wasmgc_string_from_list_int")
+                            .copied()
+                            .ok_or(WasmGcError::Validation(
+                                "interpolation of List<Int> requires \
+                                 __wasmgc_string_from_list_int builtin"
+                                    .into(),
+                            ))?;
+                        func.instruction(&Instruction::Call(from_list_idx));
                     }
                     // Compound type: `emit_interpolated_str` errors here.
                     // Fall back so the resolved-HIR path raises it instead.

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -109,6 +109,16 @@ pub(super) enum BuiltinName {
     /// over its parts and calls this) and the future `String.join`
     /// shape (interleave separator, then call this).
     StringConcatN,
+    /// `__wasmgc_string_from_list_int(xs: List<Int>) -> String` — the
+    /// `aver_repr` rendering of a list of Ints (`[1, 2, 3]`, `[]` when
+    /// empty), used by string interpolation of a `List<Int>` embed.
+    /// Without it such an embed had no stringifier, the MIR emitter bailed,
+    /// and the WHOLE enclosing fn silently became an `unreachable` trap
+    /// stub. Builds the `["[", "", e0, ", ", e1, …, "]"]` parts array and
+    /// defers to `__wasmgc_concat_n`, so the join is one O(total_len) copy.
+    /// Internal — not addressable from Aver source (no `from_dotted`
+    /// mapping); registered by interpolation discovery.
+    StringFromListInt,
     StringStartsWith,
     StringContains,
     StringSlice,
@@ -264,6 +274,7 @@ impl BuiltinName {
             Self::StringLength => "String.len",
             Self::StringByteLength => "String.byteLength",
             Self::StringConcatN => "__wasmgc_concat_n",
+            Self::StringFromListInt => "__wasmgc_string_from_list_int",
             Self::StringStartsWith => "String.startsWith",
             Self::StringContains => "String.contains",
             Self::StringSlice => "String.slice",
@@ -319,6 +330,7 @@ impl BuiltinName {
             Self::StringFromIntI64 => Ok(vec![ValType::I64]),
             Self::StringLength | Self::StringByteLength => Ok(vec![string_ref_ty(registry)?]),
             Self::StringConcatN => Ok(vec![string_array_ref_ty(registry)?]),
+            Self::StringFromListInt => Ok(vec![list_ref_ty(registry, "List<Int>")?]),
             Self::StringStartsWith | Self::StringContains => {
                 Ok(vec![string_ref_ty(registry)?, string_ref_ty(registry)?])
             }
@@ -380,7 +392,7 @@ impl BuiltinName {
         match self {
             Self::StringFromInt | Self::StringFromIntI64 => Ok(vec![string_ref_ty(registry)?]),
             Self::StringLength | Self::StringByteLength => Ok(vec![ValType::I64]),
-            Self::StringConcatN => Ok(vec![string_ref_ty(registry)?]),
+            Self::StringConcatN | Self::StringFromListInt => Ok(vec![string_ref_ty(registry)?]),
             Self::StringStartsWith | Self::StringContains => Ok(vec![ValType::I32]),
             Self::StringSlice
             | Self::StringToUpper
@@ -436,6 +448,7 @@ impl BuiltinName {
             Self::StringLength => emit_string_length(registry),
             Self::StringByteLength => emit_string_byte_length(registry),
             Self::StringConcatN => emit_string_concat_n(registry),
+            Self::StringFromListInt => emit_string_from_list_int(registry),
             Self::StringStartsWith => emit_string_starts_with(registry),
             Self::StringContains => emit_string_contains(registry),
             Self::StringSlice => emit_string_slice(registry),
@@ -918,6 +931,200 @@ fn emit_string_concat_n(registry: &TypeRegistry) -> Result<Function, WasmGcError
     "#
     );
     wat_helper::compile_wat_helper(&wat)
+}
+
+/// `__wasmgc_string_from_list_int(xs) -> String` — `aver_repr` of a
+/// `List<Int>`: `[]`, `[7]`, `[0, 1, 255]`.
+///
+/// Two passes over the cons chain. The first counts the elements; the
+/// second fills a `Vector<String>` of `2n + 2` parts laid out as
+/// `"["`, then per element `i` a separator (`""` for `i == 0`, `", "`
+/// otherwise) followed by its decimal rendering, then `"]"`. The
+/// variadic `__wasmgc_concat_n` joins them in a single O(total_len)
+/// copy, and the empty-list case falls out of the same layout (two
+/// parts, `"["` and `"]"`).
+///
+/// The element formatter is the module's active `String.fromInt` — the
+/// `$AverInt` one under bignum, the scalar-i64 one otherwise — which is
+/// exactly the representation a `List<Int>` cons cell stores, so no
+/// bridge is needed at the call. Digits therefore match a bare `{n}`
+/// interpolation of the same element byte for byte.
+///
+/// Raw `wasm_encoder` rather than WAT: the body needs the recursive
+/// `List<Int>` struct type, and re-declaring that (plus enough padding
+/// to align three separate user-module type slots) in a standalone WAT
+/// module is more fragile than emitting the four type indices directly.
+fn emit_string_from_list_int(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    use wasm_encoder::{BlockType, HeapType, RefType};
+
+    let string_idx = registry
+        .string_array_type_idx
+        .ok_or(WasmGcError::Validation(
+            "List<Int> stringify helper requires String slot".into(),
+        ))?;
+    let vec_idx = registry
+        .vector_type_idx("Vector<String>")
+        .ok_or(WasmGcError::Validation(
+            "List<Int> stringify helper requires Vector<String> slot".into(),
+        ))?;
+    let list_idx = registry
+        .list_type_idx("List<Int>")
+        .ok_or(WasmGcError::Validation(
+            "List<Int> stringify helper requires List<Int> slot".into(),
+        ))?;
+    let from_int = registry
+        .string_from_int_fn_idx
+        .ok_or(WasmGcError::Validation(
+            "List<Int> stringify helper requires String.fromInt".into(),
+        ))?;
+    let concat_n = registry
+        .string_concat_n_fn_idx
+        .ok_or(WasmGcError::Validation(
+            "List<Int> stringify helper requires __wasmgc_concat_n".into(),
+        ))?;
+
+    let list_ref = ValType::Ref(RefType {
+        nullable: true,
+        heap_type: HeapType::Concrete(list_idx),
+    });
+    let vec_ref = ValType::Ref(RefType {
+        nullable: true,
+        heap_type: HeapType::Concrete(vec_idx),
+    });
+    let string_ref = ValType::Ref(RefType {
+        nullable: true,
+        heap_type: HeapType::Concrete(string_idx),
+    });
+
+    // params: 0=xs. locals: 1=cur, 2=n, 3=parts, 4=i.
+    let mut f = Function::new([
+        (1, list_ref),
+        (1, ValType::I32),
+        (1, vec_ref),
+        (1, ValType::I32),
+    ]);
+
+    // Pass 1: n = length(xs).
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::Block(BlockType::Empty));
+    f.instruction(&Instruction::Loop(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::RefIsNull);
+    f.instruction(&Instruction::BrIf(1));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::StructGet {
+        struct_type_index: list_idx,
+        field_index: 1,
+    });
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+
+    // parts = array.new_default $vec (2n + 2)
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Const(2));
+    f.instruction(&Instruction::I32Mul);
+    f.instruction(&Instruction::I32Const(2));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::ArrayNewDefault(vec_idx));
+    f.instruction(&Instruction::LocalSet(3));
+
+    // parts[0] = "["
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::I32Const(b'[' as i32));
+    f.instruction(&Instruction::ArrayNewFixed {
+        array_type_index: string_idx,
+        array_size: 1,
+    });
+    f.instruction(&Instruction::ArraySet(vec_idx));
+
+    // Pass 2: per element, write its separator then its digits.
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::Block(BlockType::Empty));
+    f.instruction(&Instruction::Loop(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::RefIsNull);
+    f.instruction(&Instruction::BrIf(1));
+    // parts[2i + 1] = i == 0 ? "" : ", "
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Const(2));
+    f.instruction(&Instruction::I32Mul);
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Eqz);
+    f.instruction(&Instruction::If(BlockType::Result(string_ref)));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::ArrayNewDefault(string_idx));
+    f.instruction(&Instruction::Else);
+    f.instruction(&Instruction::I32Const(b',' as i32));
+    f.instruction(&Instruction::I32Const(b' ' as i32));
+    f.instruction(&Instruction::ArrayNewFixed {
+        array_type_index: string_idx,
+        array_size: 2,
+    });
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::ArraySet(vec_idx));
+    // parts[2i + 2] = String.fromInt(cur.head)
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Const(2));
+    f.instruction(&Instruction::I32Mul);
+    f.instruction(&Instruction::I32Const(2));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::StructGet {
+        struct_type_index: list_idx,
+        field_index: 0,
+    });
+    f.instruction(&Instruction::Call(from_int));
+    f.instruction(&Instruction::ArraySet(vec_idx));
+    // i += 1; cur = cur.tail
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::StructGet {
+        struct_type_index: list_idx,
+        field_index: 1,
+    });
+    f.instruction(&Instruction::LocalSet(1));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+
+    // parts[2n + 1] = "]"
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Const(2));
+    f.instruction(&Instruction::I32Mul);
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::I32Const(b']' as i32));
+    f.instruction(&Instruction::ArrayNewFixed {
+        array_type_index: string_idx,
+        array_size: 1,
+    });
+    f.instruction(&Instruction::ArraySet(vec_idx));
+
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::Call(concat_n));
+    f.instruction(&Instruction::End);
+    Ok(f)
 }
 
 /// `String.len(s) -> Int` — Unicode scalar value count, matching the

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -1223,6 +1223,15 @@ pub(super) fn emit_module_with(
     // through them without threading two extra `Option<u32>` params through
     // a dozen helper functions across maps.rs / lists.rs / eq_helpers.rs /
     // hash_helpers.rs. `Some` iff `bignum`.
+    // `__wasmgc_string_from_list_int` renders each element with the active
+    // `String.fromInt` and joins the parts with `__wasmgc_concat_n`; record
+    // both indices for the same reason (its `emit_helper_body` only receives
+    // `&registry`). `None` when the program has no interpolation at all, in
+    // which case the list-stringify helper is not registered either.
+    registry.string_from_int_fn_idx =
+        builtin_registry.lookup_wasm_fn_idx(BuiltinName::StringFromInt);
+    registry.string_concat_n_fn_idx =
+        builtin_registry.lookup_wasm_fn_idx(BuiltinName::StringConcatN);
     if registry.bignum {
         registry.aint_eq_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintEq);
         registry.aint_hash_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintHash);
@@ -6109,6 +6118,17 @@ fn discover_builtins_in_expr(
             builtins.register(BuiltinName::StringFromInt);
             builtins.register(BuiltinName::StringFromFloat);
             builtins.register(BuiltinName::StringFromBool);
+            // A `List<Int>` embed needs its own renderer. NOT registered
+            // conservatively like the scalar ones: its signature mentions
+            // `List<Int>`, so registering it for a program that has no such
+            // list would fail slot allocation. Keyed on the part's stamped
+            // type, which is what the emitter dispatches on too.
+            if parts.iter().any(|p| {
+                matches!(p, ResolvedStrPart::Parsed(inner)
+                    if inner.ty().is_some_and(|t| t.display().trim() == "List<Int>"))
+            }) {
+                builtins.register(BuiltinName::StringFromListInt);
+            }
             for p in parts {
                 if let ResolvedStrPart::Parsed(inner) = p {
                     discover_builtins_in_expr(

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -268,6 +268,15 @@ pub(super) struct TypeRegistry {
     pub(super) aint_normalize_fn_idx: Option<u32>,
     pub(super) aint_strip_fn_idx: Option<u32>,
     pub(super) aint_umag_cmp_fn_idx: Option<u32>,
+    /// wasm fn idx of the active `String.fromInt` decimal formatter (the
+    /// `$AverInt` one under bignum, the scalar-i64 one otherwise) and of
+    /// `__wasmgc_concat_n`. Recorded by `module.rs` once
+    /// `BuiltinRegistry::assign_slots` has run, so the `List<Int>`
+    /// stringify helper can `call` both without threading two extra
+    /// indices through `emit_helper_body`. `Some` iff the corresponding
+    /// builtin was registered.
+    pub(super) string_from_int_fn_idx: Option<u32>,
+    pub(super) string_concat_n_fn_idx: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -1147,6 +1156,8 @@ impl TypeRegistry {
             aint_normalize_fn_idx: None,
             aint_strip_fn_idx: None,
             aint_umag_cmp_fn_idx: None,
+            string_from_int_fn_idx: None,
+            string_concat_n_fn_idx: None,
         }
     }
 
@@ -2675,6 +2686,19 @@ fn collect_lists_from_expr(
         ResolvedExpr::InterpolatedStr(parts) => {
             for part in parts {
                 if let ResolvedStrPart::Parsed(inner) = part {
+                    // A `List<Int>` embed lowers through the
+                    // `__wasmgc_string_from_list_int` helper, whose signature
+                    // mentions `List<Int>`. Register the canonical from the
+                    // part's own stamp: a PROJECTION of a packed field
+                    // (`o.values`) is a `List<Int>` value whose canonical
+                    // otherwise only reaches the registry via the record's
+                    // declared field list.
+                    if inner
+                        .ty()
+                        .is_some_and(|t| t.display().trim() == "List<Int>")
+                    {
+                        collect_lists_from_str("List<Int>", out, order, next_idx);
+                    }
                     collect_lists_from_expr(inner, out, order, next_idx);
                 }
             }

--- a/tests/wasm_gc_packed_sequence.rs
+++ b/tests/wasm_gc_packed_sequence.rs
@@ -36,6 +36,40 @@ fn run(source: &str, wasm_gc: bool, packed: bool) -> (bool, String) {
     )
 }
 
+/// `aver verify` twin of `run` — the verify runner has its own wasm-gc
+/// execution path (`aver verify --wasm-gc`), so a codegen gap can be red
+/// there while `aver run` is green (and vice versa).
+fn verify(source: &str, wasm_gc: bool, packed: bool) -> (bool, String) {
+    let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "aver-packed-sequence-verify-{}-{id}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("main.av");
+    std::fs::write(&path, source).expect("source");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver"));
+    command.arg("verify").arg(&path);
+    if wasm_gc {
+        command.arg("--wasm-gc");
+    }
+    if !packed {
+        command.env("AVER_NO_PACKED_SEQUENCES", "1");
+    }
+    let output = command.output().expect("verify aver");
+    let _ = std::fs::remove_dir_all(dir);
+    (
+        output.status.success(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .trim()
+        .to_string(),
+    )
+}
+
 /// Multi-module variant of `run`: writes `main.av` plus one dep module
 /// file, then drives `aver run main.av --module-root <dir>` so the CLI's
 /// multi-module flatten + wasm-gc path is exercised end to end.
@@ -587,4 +621,125 @@ fn out_of_interval_literal_declines_the_discharge_on_every_backend() {
     assert_eq!(vm, "oob");
     assert_eq!(packed, vm, "packed wasm-gc must not silently truncate 256");
     assert_eq!(boxed, vm);
+}
+
+// ─── Interpolating the carrier ──────────────────────────────────────────
+//
+// `"{o.values}"` embeds the PROJECTED `List<Int>` carrier in a string.
+// The projection itself already inserts the packed→list unpack bridge, so
+// what the interpolation receives is a plain cons list on both the packed
+// and the boxed path — but wasm-gc had no stringifier for a `List<Int>`
+// embed at all. The MIR interpolation emitter bailed on the compound type,
+// and a bail makes the WHOLE enclosing fn an `unreachable` trap stub, so
+// the program compiled and then trapped at runtime with no diagnostic.
+// The VM (and generated Rust) print `[0, 1, 127, 255]`.
+//
+// The program below pins every leg of the rendering against the VM:
+// empty / single / multi carriers, a NEGATIVE and a beyond-i64 element on
+// a plain (unrefined) list so the bignum formatter is exercised too, and
+// two embeds in one literal so the parts array indexing is covered.
+const INTERPOLATED_OCTETS: &str = r#"module M
+    intent = "interpolate the projected carrier of a packed refinement"
+    effects [Console]
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+
+fn show(o: Octets) -> String
+    "{o.values}"
+
+fn render(xs: List<Int>) -> String
+    match fromList(xs)
+        Result.Ok(o) -> show(o)
+        Result.Err(error) -> error
+
+fn main() -> Unit
+    ! [Console.print]
+    empty: List<Int> = []
+    Console.print(render(empty))
+    Console.print(render(List.concat([7], empty)))
+    Console.print(render(List.concat([0, 1], [127, 255])))
+    plain = List.concat([0 - 5, 0], [10000000000000000000])
+    Console.print("plain={plain} twice={plain}")
+"#;
+
+#[test]
+fn interpolated_packed_field_matches_vm_and_boxed_wasm() {
+    let (vm_ok, vm) = run(INTERPOLATED_OCTETS, false, true);
+    let (packed_ok, packed) = run(INTERPOLATED_OCTETS, true, true);
+    let (boxed_ok, boxed) = run(INTERPOLATED_OCTETS, true, false);
+    assert!(vm_ok, "VM failed: {vm}");
+    assert!(
+        packed_ok,
+        "packed wasm failed (interpolating the carrier trapped): {packed}"
+    );
+    assert!(boxed_ok, "boxed wasm failed: {boxed}");
+    assert_eq!(
+        vm,
+        "[]\n[7]\n[0, 1, 127, 255]\nplain=[-5, 0, 10000000000000000000] \
+         twice=[-5, 0, 10000000000000000000]"
+    );
+    assert_eq!(packed, vm, "packed wasm-gc diverged from the VM");
+    assert_eq!(boxed, vm, "boxed wasm-gc diverged from the VM");
+}
+
+// Same gap, second surface: `aver verify --wasm-gc` runs cases through
+// its own wasm-gc execution path, so the trap-stub body reached it too —
+// the case bodies below returned nothing and every case failed.
+const INTERPOLATED_OCTETS_VERIFY: &str = r#"module M
+    intent = "verify an interpolated packed carrier on the wasm-gc runner"
+    effects []
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+
+fn render(xs: List<Int>) -> String
+    match fromList(xs)
+        Result.Ok(o) -> "{o.values}"
+        Result.Err(error) -> error
+
+verify render
+    render([]) => "[]"
+    render([0, 1, 127, 255]) => "[0, 1, 127, 255]"
+    render([256]) => "oob"
+"#;
+
+#[test]
+fn interpolated_packed_field_verifies_on_the_wasm_gc_runner() {
+    let (vm_ok, vm) = verify(INTERPOLATED_OCTETS_VERIFY, false, true);
+    let (packed_ok, packed) = verify(INTERPOLATED_OCTETS_VERIFY, true, true);
+    let (boxed_ok, boxed) = verify(INTERPOLATED_OCTETS_VERIFY, true, false);
+    assert!(vm_ok, "VM verify failed: {vm}");
+    assert!(packed_ok, "packed wasm-gc verify failed: {packed}");
+    assert!(boxed_ok, "boxed wasm-gc verify failed: {boxed}");
+    for (label, out) in [("packed", &packed), ("boxed", &boxed)] {
+        assert!(
+            out.contains("3/3 cases passed"),
+            "{label} wasm-gc verify did not pass every case: {out}"
+        );
+    }
 }


### PR DESCRIPTION
Embedding a list of integers in a string (`"{o.values}"`, `"{xs}"`) had no stringifier in the wasm-gc backend. The MIR interpolation emitter bailed on the compound type, and a bail turns the whole enclosing function into an `unreachable` trap stub — so the program compiled cleanly and then trapped at runtime with no diagnostic. The VM and generated Rust both print `[0, 1, 127, 255]`.

This was reported against packed sequence refinements, where the embedded value is the projected `List<Int>` carrier. The projection was already correct — `MirExpr::Project` inserts the packed→list unpack bridge — so the packed and boxed paths hand the interpolation the identical cons list. The gap was the missing renderer, and it hit `AVER_NO_PACKED_SEQUENCES=1` and plain unrefined lists exactly the same way.

## Change

`__wasmgc_string_from_list_int`: two passes over the cons chain, the first counting elements and the second filling a `Vector<String>` laid out as `"["`, then per element a separator (`""` for the first, `", "` otherwise) followed by its decimal rendering, then `"]"`. The existing variadic `__wasmgc_concat_n` joins the parts in one O(total_len) copy; the empty list falls out of the same layout. Elements render through the module's active `String.fromInt` (arbitrary-precision when Int arithmetic is reachable, scalar otherwise), which is exactly what a `List<Int>` cons cell stores — so digits match a bare `{n}` embed byte for byte. Registered only when an interpolation part is stamped `List<Int>`.

## Tests

Three-way differential (VM / packed wasm-gc / `AVER_NO_PACKED_SEQUENCES=1`) over the projected carrier of a packed refinement — empty, single and multi-element carriers plus a negative and a beyond-i64 element on an unrefined list — and the same program on the `aver verify --wasm-gc` runner, which traps through the same emitter. Both tests are red on `main` (trap / every case aborted on both wasm legs) and green here.

Also checked by hand across VM, packed wasm-gc, boxed wasm-gc and wasip2: stdlib `Bytes`, `String.join` and `List.len` over the projected list, two embeds in one literal, `wasm-tools validate` on the emitted module, and the `--optimize size` pipeline.

## Not fixed here

Records, tuples, `Option`/`Result`, maps and `List<T>` for other `T` have no interpolation stringifier on wasm-gc either, and still become trap stubs for the same root cause — e.g. `Console.print("{o}")` on the record itself traps on both the packed and boxed legs while the VM prints `Octets(values: [1, 2, 3])`. That residual class is unchanged here and now documented at the emitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
