### PR TITLE
Reject non-primitive string interpolation at the typechecker

### DIFF
--- a/.claude/commands/aver.md
+++ b/.claude/commands/aver.md
@@ -222,7 +222,7 @@ Rules:
 - Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`
 - Error propagation: `expr?` (unwraps `Result.Ok`, propagates `Result.Err`). **Result-only** — does not work on `Option`. For `Option`, use `Option.withDefault(opt, fallback)` or pattern-match.
 - Independence: `(a, b)!` (parallel), `(a, b)?!` (parallel + Result unwrap)
-- String interpolation: `"Hello, {name}!"`
+- String interpolation: `"Hello, {name}!"` — **primitives only** (`Int`, `Float`, `Bool`, `String`). Embedding a list, record, tuple, `Map`, `Option`/`Result`, `Vector` or any named type is a type error; write a function returning `String` and interpolate its result.
 
 **These operators do NOT exist** — do not use them:
 
@@ -257,7 +257,7 @@ Key `String` API:
 - `String.join`, `String.split`, `String.chars` — concat is the `+` operator
 - `Int.fromString : String -> Result<Int, String>`, `String.fromInt : Int -> String`
 - `Float.fromString`, `String.fromFloat`, `String.fromBool` — convention: `<targetTyp>.from<source>`
-- string interpolation: `"Hello, {name}!"` is the idiomatic way to render values into text; reserve `String.fromInt` etc. for explicit data conversion (e.g. building keys: `"user:" + String.fromInt(id)`)
+- string interpolation: `"Hello, {name}!"` is the idiomatic way to render PRIMITIVES into text; reserve `String.fromInt` etc. for explicit data conversion (e.g. building keys: `"user:" + String.fromInt(id)`). Compound values have no built-in rendering — write your own `fn show(x: T) -> String`.
 
 Key `List` API (small, recursion-first):
 - `List.len`, `List.prepend`, `List.concat`, `List.reverse`, `List.contains`, `List.zip`, `List.take`, `List.drop`, `List.fromVector`

--- a/docs/language.md
+++ b/docs/language.md
@@ -66,6 +66,8 @@ greeting = "Hello, {name}! You are {age} years old."
 
 Interpolation renders primitives only: an embedded expression must be an `Int`, a `Float`, a `Bool` or a `String`. Embedding anything else — a list, a record, a tuple, a `Map`, an `Option`/`Result`, a `Vector`, a refinement or other named type — is a type error, because an interpolation site is a display site and Aver requires every conversion to `String` to be named in the source. There is no built-in renderer for compound values and none is planned: write a function that returns `String` and interpolate its result (`"cart: {cartLine(item)}"`), or convert at the call site with an explicit conversion such as `String.fromInt(n)`. The rule is the same one that makes `Console.print(list)` a type error; the interpolated form is only sugar over the same display.
 
+An embed whose type inference never pinned is rejected too, with a diagnostic saying the type could not be determined. This happens when the value flows from a still-open generic — matching on a bare `Option.None` or a bare `[]` binds the arm's variable to a type nothing in the program fixes. Give the subject a concrete type (`match someOption` where `someOption: Option<Int>`) and the embed becomes an ordinary primitive or an ordinary compound, with the ordinary answer in each case.
+
 ## Constructors
 
 UpperCamel callee = constructor, lowerCamel = function call. Records use named args (`User(name = "A", age = 1)`), variants use positional args (`Shape.Circle(3.14)`), zero-arg constructors are bare singletons (`Option.None`, `Shape.Point`).

--- a/docs/language.md
+++ b/docs/language.md
@@ -64,6 +64,8 @@ Expressions inside `{}` are evaluated at runtime:
 greeting = "Hello, {name}! You are {age} years old."
 ```
 
+Interpolation renders primitives only: an embedded expression must be an `Int`, a `Float`, a `Bool` or a `String`. Embedding anything else — a list, a record, a tuple, a `Map`, an `Option`/`Result`, a `Vector`, a refinement or other named type — is a type error, because an interpolation site is a display site and Aver requires every conversion to `String` to be named in the source. There is no built-in renderer for compound values and none is planned: write a function that returns `String` and interpolate its result (`"cart: {cartLine(item)}"`), or convert at the call site with an explicit conversion such as `String.fromInt(n)`. The rule is the same one that makes `Console.print(list)` a type error; the interpolated form is only sugar over the same display.
+
 ## Constructors
 
 UpperCamel callee = constructor, lowerCamel = function call. Records use named args (`User(name = "A", age = 1)`), variants use positional args (`Shape.Circle(3.14)`), zero-arg constructors are bare singletons (`Option.None`, `Shape.Point`).
@@ -87,7 +89,7 @@ match value
     _ -> "anything"                        // wildcard
     x -> "bound to {x}"                    // identifier binding
     [] -> "empty list"                     // empty list
-    [h, ..t] -> "head {h}, tail {t}"       // list cons
+    [h, ..t] -> "head {h}, {List.len(t)} more"  // list cons
     Result.Ok(v) -> "success: {v}"         // constructor
     Result.Err(e) -> "error: {e}"
     Shape.Circle(r) -> "circle r={r}"

--- a/self_hosted/domain/eval/core.av
+++ b/self_hosted/domain/eval/core.av
@@ -81,7 +81,53 @@ fn evalExprCalls(expr: Expr, env: Map<String, Val>, fns: FnStore) -> Result<Val,
         Expr.ExprMatch(scrutinee, arms) -> evalMatchExpr(scrutinee, arms, env, fns)
         Expr.ExprPropagate(inner) -> evalPropagate(inner, env, fns)
         Expr.ExprIndependentProduct(exprs, unwrap) -> evalIndependentProduct(exprs, unwrap, env, fns)
-        _ -> Result.Err("unsupported named-env expression: {expr}")
+        _ -> Result.Err("unsupported named-env expression: {exprLabel(expr)}")
+
+fn exprLabel(expr: Expr) -> String
+    ? "Name the AST node kind for diagnostics; interpolation renders primitives only, so an Expr needs a named conversion."
+    match expr
+        Expr.ExprInt(_) -> "ExprInt"
+        Expr.ExprFloat(_) -> "ExprFloat"
+        Expr.ExprStr(_) -> "ExprStr"
+        Expr.ExprBool(_) -> "ExprBool"
+        Expr.ExprBoolBranch(_, _, _) -> "ExprBoolBranch"
+        Expr.ExprVar(_) -> "ExprVar"
+        Expr.ExprSlot(_) -> "ExprSlot"
+        Expr.ExprBinopSlotInt(_, _, _) -> "ExprBinopSlotInt"
+        Expr.ExprBinopSlots(_, _, _) -> "ExprBinopSlots"
+        Expr.ExprCmpSlotInt(_, _, _) -> "ExprCmpSlotInt"
+        Expr.ExprCmpSlots(_, _, _) -> "ExprCmpSlots"
+        Expr.ExprVectorGetOrInt(_, _, _) -> "ExprVectorGetOrInt"
+        Expr.ExprIntModOrInt(_, _, _) -> "ExprIntModOrInt"
+        Expr.ExprAdd(_, _) -> "ExprAdd"
+        Expr.ExprSub(_, _) -> "ExprSub"
+        Expr.ExprMul(_, _) -> "ExprMul"
+        Expr.ExprDiv(_, _) -> "ExprDiv"
+        Expr.ExprNeg(_) -> "ExprNeg"
+        Expr.ExprEq(_, _) -> "ExprEq"
+        Expr.ExprNeq(_, _) -> "ExprNeq"
+        _ -> exprLabelAggregate(expr)
+
+fn exprLabelAggregate(expr: Expr) -> String
+    ? "Continue naming AST node kinds for the comparison, aggregate, and call forms."
+    match expr
+        Expr.ExprLt(_, _) -> "ExprLt"
+        Expr.ExprGt(_, _) -> "ExprGt"
+        Expr.ExprLte(_, _) -> "ExprLte"
+        Expr.ExprGte(_, _) -> "ExprGte"
+        Expr.ExprConcat(_) -> "ExprConcat"
+        Expr.ExprTuple(_) -> "ExprTuple"
+        Expr.ExprList(_) -> "ExprList"
+        Expr.ExprRecord(_, _) -> "ExprRecord"
+        Expr.ExprFieldAccess(_, _) -> "ExprFieldAccess"
+        Expr.ExprCall(_, _) -> "ExprCall"
+        Expr.ExprCallDirect(_, _) -> "ExprCallDirect"
+        Expr.ExprCallBuiltin(_, _) -> "ExprCallBuiltin"
+        Expr.ExprCallBuiltinId(_, _) -> "ExprCallBuiltinId"
+        Expr.ExprMatch(_, _) -> "ExprMatch"
+        Expr.ExprPropagate(_) -> "ExprPropagate"
+        Expr.ExprIndependentProduct(_, _) -> "ExprIndependentProduct"
+        _ -> "Expr"
 
 fn evalVar(name: String, env: Map<String, Val>, fns: FnStore) -> Result<Val, String>
     ? "Look up variable, Option.None, a named function reference, or a nullary variant constructor."
@@ -829,7 +875,7 @@ fn evalExprSlotCalls(expr: Expr, env: Vector<Val>, slotMap: Map<String, Int>, fn
         Expr.ExprMatch(scrutinee, arms) -> evalMatchExprSlot(scrutinee, arms, env, slotMap, fns)
         Expr.ExprPropagate(inner) -> evalPropagateSlot(inner, env, slotMap, fns)
         Expr.ExprIndependentProduct(exprs, unwrap) -> evalIndependentProductSlot(exprs, unwrap, env, slotMap, fns)
-        _ -> Result.Err("unsupported slot expression: {expr}")
+        _ -> Result.Err("unsupported slot expression: {exprLabel(expr)}")
 
 fn evalVarSlot(name: String, fns: FnStore) -> Result<Val, String>
     ? "Resolve unresolved var in slot path: builtins, named function refs, and constructors."

--- a/src/codegen/wasm_gc/body/from_mir/strings.rs
+++ b/src/codegen/wasm_gc/body/from_mir/strings.rs
@@ -1,24 +1,29 @@
 //! String lowering: `MirExpr::InterpolatedStr` and the `String`
-//! branches of `BinOp` (`+` / `==` / `<` / …). Mirrors
-//! `emit_interpolated_str` and `emit_expr`'s String BinOp branches.
+//! branches of `BinOp` (`+` / `==` / `<` / …). Mirrors `emit_expr`'s
+//! String BinOp branches.
 
 use super::*;
 
-/// Mirror of `emit_interpolated_str` (builtins.rs): build a
-/// `Vector<String>` of the parts and concat it with `__wasmgc_concat_n`.
+/// Interpolation lowering: build a `Vector<String>` of the parts and
+/// concat it with `__wasmgc_concat_n`.
 /// Each `Literal` part becomes an `array.new_data` over its segment;
 /// each `Expr` part is emitted then stringified by the same
-/// `String.from{Int,Float,Bool}` dispatch (a `String` is identity), plus
-/// `__wasmgc_string_from_list_int` for a `List<Int>`. The result is always
-/// a `String`, so `produces` is `true` (empty interpolation allocates a
-/// zero-length array directly, same as the oracle).
+/// `String.from{Int,Float,Bool}` dispatch (a `String` is identity).
+/// The result is always a `String`, so `produces` is `true` (empty
+/// interpolation allocates a zero-length array directly, same as the
+/// oracle).
 ///
-/// A part whose type has NO stringifier here still returns `None`. There
-/// is no resolved-HIR emitter left to catch that: a `None` makes the whole
-/// enclosing fn an `unreachable` trap stub, so such a program compiles and
-/// then traps at runtime with no diagnostic. `List<Int>` was in that state
-/// until the helper above landed; records, tuples, `Option`/`Result`, maps
-/// and `List<T>` for other `T` still are.
+/// An embed of any OTHER type is a hard `WasmGcError`, not an
+/// `Ok(None)` bail. `Ok(None)` here means "the MIR walker does not
+/// cover this fn", and the caller answers that by giving the whole fn
+/// an `unreachable` trap stub (`module.rs`, `emit_trap_stub_body`) —
+/// the program would compile clean and then trap at runtime with no
+/// diagnostic. Typechecked source cannot reach this arm at all: the
+/// checker's interpolation rule (`src/types/checker/infer/expr.rs`)
+/// rejects every non-`Int`/`Float`/`Bool`/`String` embed. It stays
+/// reachable from internal pipelines that drive codegen without a
+/// typecheck, and from any future checker gap — both want the loud
+/// error naming the fn and the embed type.
 pub(crate) fn emit_mir_interpolated_str(
     func: &mut Function,
     parts: &[MirStrPart],
@@ -106,30 +111,17 @@ pub(crate) fn emit_mir_interpolated_str(
                             )?;
                         func.instruction(&Instruction::Call(to_string_idx));
                     }
-                    // `List<Int>` renders via the dedicated helper, which
-                    // walks the cons chain and joins `[`, the per-element
-                    // decimals, and `]`. The value on the stack is already
-                    // the boxed cons list — a PACKED refinement field read
-                    // (`o.values`) went through `MirExpr::Project`, which
-                    // inserts the packed→list unpack bridge before we get
-                    // here, so the packed and boxed paths feed the helper
-                    // the identical representation.
-                    "List<Int>" => {
-                        let from_list_idx = ctx
-                            .fn_map
-                            .builtins
-                            .get("__wasmgc_string_from_list_int")
-                            .copied()
-                            .ok_or(WasmGcError::Validation(
-                                "interpolation of List<Int> requires \
-                                 __wasmgc_string_from_list_int builtin"
-                                    .into(),
-                            ))?;
-                        func.instruction(&Instruction::Call(from_list_idx));
+                    // No stringifier for this embed. Loud, not silent —
+                    // see the fn doc comment.
+                    other => {
+                        return Err(WasmGcError::Validation(format!(
+                            "fn `{}`: string interpolation has no stringifier for an \
+                             embed of type `{other}` — interpolation renders primitives \
+                             only (Int, Float, Bool, String). Convert the value with a \
+                             named function returning String and interpolate that.",
+                            ctx.self_fn_name
+                        )));
                     }
-                    // Compound type: `emit_interpolated_str` errors here.
-                    // Fall back so the resolved-HIR path raises it instead.
-                    _ => return Ok(None),
                 }
             }
         }

--- a/src/codegen/wasm_gc/body/from_mir/strings.rs
+++ b/src/codegen/wasm_gc/body/from_mir/strings.rs
@@ -18,12 +18,37 @@ use super::*;
 /// cover this fn", and the caller answers that by giving the whole fn
 /// an `unreachable` trap stub (`module.rs`, `emit_trap_stub_body`) —
 /// the program would compile clean and then trap at runtime with no
-/// diagnostic. Typechecked source cannot reach this arm at all: the
-/// checker's interpolation rule (`src/types/checker/infer/expr.rs`)
-/// rejects every non-`Int`/`Float`/`Bool`/`String` embed. It stays
-/// reachable from internal pipelines that drive codegen without a
-/// typecheck, and from any future checker gap — both want the loud
-/// error naming the fn and the embed type.
+/// diagnostic.
+///
+/// WHY TYPECHECKED SOURCE CANNOT REACH THE ERROR ARM. The dispatch below
+/// keys on `aver_type_str_of(inner)`, i.e. the type the CHECKER stamped on
+/// that very node (`Spanned::set_ty`, a `OnceLock` written during
+/// inference and never rewritten), so the emitter and the checker classify
+/// the same value by the same `Type`. The checker's interpolation rule
+/// (`classify_interpolation_embed` in
+/// `src/types/checker/infer/expr.rs`) partitions that `Type` with no
+/// remainder:
+///   * `Int` / `Float` / `Bool` / `Str` — accepted, and they are exactly
+///     the four cases the dispatch handles;
+///   * bare `Type::Var` — an embed inference never pinned. REJECTED, and
+///     deliberately not folded into the checker's `Invalid` acceptance: an
+///     unresolved variable is not evidence of an earlier diagnostic
+///     (`match Option.None` with an arm `Option.Some(x) -> "{x}"` is
+///     otherwise a clean program), so admitting it was a fail-open path
+///     from a CLEAN typecheck straight into this arm;
+///   * `Type::Invalid` — accepted without a second diagnostic, but only
+///     ever stamped after the checker already reported an error, so the
+///     compile is gated before codegen runs;
+///   * everything else — rejected by name.
+///
+/// Widening the dispatch below and widening that partition must happen in
+/// the same change, or this argument stops holding.
+///
+/// The arm stays reachable from internal pipelines that drive codegen
+/// without gating on the checker's errors (see
+/// `compound_interpolation_embed_is_a_loud_codegen_error_not_a_trap_stub`
+/// in `tests/wasm_gc_codegen_regression.rs`), and from any future checker
+/// gap — both want the loud error naming the fn and the embed type.
 pub(crate) fn emit_mir_interpolated_str(
     func: &mut Function,
     parts: &[MirStrPart],

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -109,16 +109,6 @@ pub(super) enum BuiltinName {
     /// over its parts and calls this) and the future `String.join`
     /// shape (interleave separator, then call this).
     StringConcatN,
-    /// `__wasmgc_string_from_list_int(xs: List<Int>) -> String` — the
-    /// `aver_repr` rendering of a list of Ints (`[1, 2, 3]`, `[]` when
-    /// empty), used by string interpolation of a `List<Int>` embed.
-    /// Without it such an embed had no stringifier, the MIR emitter bailed,
-    /// and the WHOLE enclosing fn silently became an `unreachable` trap
-    /// stub. Builds the `["[", "", e0, ", ", e1, …, "]"]` parts array and
-    /// defers to `__wasmgc_concat_n`, so the join is one O(total_len) copy.
-    /// Internal — not addressable from Aver source (no `from_dotted`
-    /// mapping); registered by interpolation discovery.
-    StringFromListInt,
     StringStartsWith,
     StringContains,
     StringSlice,
@@ -274,7 +264,6 @@ impl BuiltinName {
             Self::StringLength => "String.len",
             Self::StringByteLength => "String.byteLength",
             Self::StringConcatN => "__wasmgc_concat_n",
-            Self::StringFromListInt => "__wasmgc_string_from_list_int",
             Self::StringStartsWith => "String.startsWith",
             Self::StringContains => "String.contains",
             Self::StringSlice => "String.slice",
@@ -330,7 +319,6 @@ impl BuiltinName {
             Self::StringFromIntI64 => Ok(vec![ValType::I64]),
             Self::StringLength | Self::StringByteLength => Ok(vec![string_ref_ty(registry)?]),
             Self::StringConcatN => Ok(vec![string_array_ref_ty(registry)?]),
-            Self::StringFromListInt => Ok(vec![list_ref_ty(registry, "List<Int>")?]),
             Self::StringStartsWith | Self::StringContains => {
                 Ok(vec![string_ref_ty(registry)?, string_ref_ty(registry)?])
             }
@@ -392,7 +380,7 @@ impl BuiltinName {
         match self {
             Self::StringFromInt | Self::StringFromIntI64 => Ok(vec![string_ref_ty(registry)?]),
             Self::StringLength | Self::StringByteLength => Ok(vec![ValType::I64]),
-            Self::StringConcatN | Self::StringFromListInt => Ok(vec![string_ref_ty(registry)?]),
+            Self::StringConcatN => Ok(vec![string_ref_ty(registry)?]),
             Self::StringStartsWith | Self::StringContains => Ok(vec![ValType::I32]),
             Self::StringSlice
             | Self::StringToUpper
@@ -448,7 +436,6 @@ impl BuiltinName {
             Self::StringLength => emit_string_length(registry),
             Self::StringByteLength => emit_string_byte_length(registry),
             Self::StringConcatN => emit_string_concat_n(registry),
-            Self::StringFromListInt => emit_string_from_list_int(registry),
             Self::StringStartsWith => emit_string_starts_with(registry),
             Self::StringContains => emit_string_contains(registry),
             Self::StringSlice => emit_string_slice(registry),
@@ -931,200 +918,6 @@ fn emit_string_concat_n(registry: &TypeRegistry) -> Result<Function, WasmGcError
     "#
     );
     wat_helper::compile_wat_helper(&wat)
-}
-
-/// `__wasmgc_string_from_list_int(xs) -> String` — `aver_repr` of a
-/// `List<Int>`: `[]`, `[7]`, `[0, 1, 255]`.
-///
-/// Two passes over the cons chain. The first counts the elements; the
-/// second fills a `Vector<String>` of `2n + 2` parts laid out as
-/// `"["`, then per element `i` a separator (`""` for `i == 0`, `", "`
-/// otherwise) followed by its decimal rendering, then `"]"`. The
-/// variadic `__wasmgc_concat_n` joins them in a single O(total_len)
-/// copy, and the empty-list case falls out of the same layout (two
-/// parts, `"["` and `"]"`).
-///
-/// The element formatter is the module's active `String.fromInt` — the
-/// `$AverInt` one under bignum, the scalar-i64 one otherwise — which is
-/// exactly the representation a `List<Int>` cons cell stores, so no
-/// bridge is needed at the call. Digits therefore match a bare `{n}`
-/// interpolation of the same element byte for byte.
-///
-/// Raw `wasm_encoder` rather than WAT: the body needs the recursive
-/// `List<Int>` struct type, and re-declaring that (plus enough padding
-/// to align three separate user-module type slots) in a standalone WAT
-/// module is more fragile than emitting the four type indices directly.
-fn emit_string_from_list_int(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
-    use wasm_encoder::{BlockType, HeapType, RefType};
-
-    let string_idx = registry
-        .string_array_type_idx
-        .ok_or(WasmGcError::Validation(
-            "List<Int> stringify helper requires String slot".into(),
-        ))?;
-    let vec_idx = registry
-        .vector_type_idx("Vector<String>")
-        .ok_or(WasmGcError::Validation(
-            "List<Int> stringify helper requires Vector<String> slot".into(),
-        ))?;
-    let list_idx = registry
-        .list_type_idx("List<Int>")
-        .ok_or(WasmGcError::Validation(
-            "List<Int> stringify helper requires List<Int> slot".into(),
-        ))?;
-    let from_int = registry
-        .string_from_int_fn_idx
-        .ok_or(WasmGcError::Validation(
-            "List<Int> stringify helper requires String.fromInt".into(),
-        ))?;
-    let concat_n = registry
-        .string_concat_n_fn_idx
-        .ok_or(WasmGcError::Validation(
-            "List<Int> stringify helper requires __wasmgc_concat_n".into(),
-        ))?;
-
-    let list_ref = ValType::Ref(RefType {
-        nullable: true,
-        heap_type: HeapType::Concrete(list_idx),
-    });
-    let vec_ref = ValType::Ref(RefType {
-        nullable: true,
-        heap_type: HeapType::Concrete(vec_idx),
-    });
-    let string_ref = ValType::Ref(RefType {
-        nullable: true,
-        heap_type: HeapType::Concrete(string_idx),
-    });
-
-    // params: 0=xs. locals: 1=cur, 2=n, 3=parts, 4=i.
-    let mut f = Function::new([
-        (1, list_ref),
-        (1, ValType::I32),
-        (1, vec_ref),
-        (1, ValType::I32),
-    ]);
-
-    // Pass 1: n = length(xs).
-    f.instruction(&Instruction::I32Const(0));
-    f.instruction(&Instruction::LocalSet(2));
-    f.instruction(&Instruction::LocalGet(0));
-    f.instruction(&Instruction::LocalSet(1));
-    f.instruction(&Instruction::Block(BlockType::Empty));
-    f.instruction(&Instruction::Loop(BlockType::Empty));
-    f.instruction(&Instruction::LocalGet(1));
-    f.instruction(&Instruction::RefIsNull);
-    f.instruction(&Instruction::BrIf(1));
-    f.instruction(&Instruction::LocalGet(2));
-    f.instruction(&Instruction::I32Const(1));
-    f.instruction(&Instruction::I32Add);
-    f.instruction(&Instruction::LocalSet(2));
-    f.instruction(&Instruction::LocalGet(1));
-    f.instruction(&Instruction::StructGet {
-        struct_type_index: list_idx,
-        field_index: 1,
-    });
-    f.instruction(&Instruction::LocalSet(1));
-    f.instruction(&Instruction::Br(0));
-    f.instruction(&Instruction::End);
-    f.instruction(&Instruction::End);
-
-    // parts = array.new_default $vec (2n + 2)
-    f.instruction(&Instruction::LocalGet(2));
-    f.instruction(&Instruction::I32Const(2));
-    f.instruction(&Instruction::I32Mul);
-    f.instruction(&Instruction::I32Const(2));
-    f.instruction(&Instruction::I32Add);
-    f.instruction(&Instruction::ArrayNewDefault(vec_idx));
-    f.instruction(&Instruction::LocalSet(3));
-
-    // parts[0] = "["
-    f.instruction(&Instruction::LocalGet(3));
-    f.instruction(&Instruction::I32Const(0));
-    f.instruction(&Instruction::I32Const(b'[' as i32));
-    f.instruction(&Instruction::ArrayNewFixed {
-        array_type_index: string_idx,
-        array_size: 1,
-    });
-    f.instruction(&Instruction::ArraySet(vec_idx));
-
-    // Pass 2: per element, write its separator then its digits.
-    f.instruction(&Instruction::LocalGet(0));
-    f.instruction(&Instruction::LocalSet(1));
-    f.instruction(&Instruction::I32Const(0));
-    f.instruction(&Instruction::LocalSet(4));
-    f.instruction(&Instruction::Block(BlockType::Empty));
-    f.instruction(&Instruction::Loop(BlockType::Empty));
-    f.instruction(&Instruction::LocalGet(1));
-    f.instruction(&Instruction::RefIsNull);
-    f.instruction(&Instruction::BrIf(1));
-    // parts[2i + 1] = i == 0 ? "" : ", "
-    f.instruction(&Instruction::LocalGet(3));
-    f.instruction(&Instruction::LocalGet(4));
-    f.instruction(&Instruction::I32Const(2));
-    f.instruction(&Instruction::I32Mul);
-    f.instruction(&Instruction::I32Const(1));
-    f.instruction(&Instruction::I32Add);
-    f.instruction(&Instruction::LocalGet(4));
-    f.instruction(&Instruction::I32Eqz);
-    f.instruction(&Instruction::If(BlockType::Result(string_ref)));
-    f.instruction(&Instruction::I32Const(0));
-    f.instruction(&Instruction::ArrayNewDefault(string_idx));
-    f.instruction(&Instruction::Else);
-    f.instruction(&Instruction::I32Const(b',' as i32));
-    f.instruction(&Instruction::I32Const(b' ' as i32));
-    f.instruction(&Instruction::ArrayNewFixed {
-        array_type_index: string_idx,
-        array_size: 2,
-    });
-    f.instruction(&Instruction::End);
-    f.instruction(&Instruction::ArraySet(vec_idx));
-    // parts[2i + 2] = String.fromInt(cur.head)
-    f.instruction(&Instruction::LocalGet(3));
-    f.instruction(&Instruction::LocalGet(4));
-    f.instruction(&Instruction::I32Const(2));
-    f.instruction(&Instruction::I32Mul);
-    f.instruction(&Instruction::I32Const(2));
-    f.instruction(&Instruction::I32Add);
-    f.instruction(&Instruction::LocalGet(1));
-    f.instruction(&Instruction::StructGet {
-        struct_type_index: list_idx,
-        field_index: 0,
-    });
-    f.instruction(&Instruction::Call(from_int));
-    f.instruction(&Instruction::ArraySet(vec_idx));
-    // i += 1; cur = cur.tail
-    f.instruction(&Instruction::LocalGet(4));
-    f.instruction(&Instruction::I32Const(1));
-    f.instruction(&Instruction::I32Add);
-    f.instruction(&Instruction::LocalSet(4));
-    f.instruction(&Instruction::LocalGet(1));
-    f.instruction(&Instruction::StructGet {
-        struct_type_index: list_idx,
-        field_index: 1,
-    });
-    f.instruction(&Instruction::LocalSet(1));
-    f.instruction(&Instruction::Br(0));
-    f.instruction(&Instruction::End);
-    f.instruction(&Instruction::End);
-
-    // parts[2n + 1] = "]"
-    f.instruction(&Instruction::LocalGet(3));
-    f.instruction(&Instruction::LocalGet(2));
-    f.instruction(&Instruction::I32Const(2));
-    f.instruction(&Instruction::I32Mul);
-    f.instruction(&Instruction::I32Const(1));
-    f.instruction(&Instruction::I32Add);
-    f.instruction(&Instruction::I32Const(b']' as i32));
-    f.instruction(&Instruction::ArrayNewFixed {
-        array_type_index: string_idx,
-        array_size: 1,
-    });
-    f.instruction(&Instruction::ArraySet(vec_idx));
-
-    f.instruction(&Instruction::LocalGet(3));
-    f.instruction(&Instruction::Call(concat_n));
-    f.instruction(&Instruction::End);
-    Ok(f)
 }
 
 /// `String.len(s) -> Int` — Unicode scalar value count, matching the

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -123,6 +123,15 @@ use crate::ast::{FnDef, TopLevel, TypeDef};
 /// than a `Fn` param. `unreachable` is a polymorphic stack-type
 /// instruction, so it validates for ANY fn signature with zero extra
 /// locals.
+///
+/// A stub is SILENT — the module compiles clean and traps at runtime
+/// with no diagnostic — so any emit gap that a user can hit by writing
+/// ordinary code does not belong here. String interpolation of a
+/// non-primitive embed used to arrive here and now raises a
+/// `WasmGcError` at the emitter instead (see
+/// `body::from_mir::strings::emit_mir_interpolated_str`); the residual
+/// `Ok(None)` bails across the MIR emitter still route here, and
+/// `AVER_WASMGC_REQUIRE_MIR=1` lists them.
 fn emit_trap_stub_body(func: &mut Function) {
     func.instruction(&Instruction::Unreachable);
     func.instruction(&Instruction::End);
@@ -1223,15 +1232,6 @@ pub(super) fn emit_module_with(
     // through them without threading two extra `Option<u32>` params through
     // a dozen helper functions across maps.rs / lists.rs / eq_helpers.rs /
     // hash_helpers.rs. `Some` iff `bignum`.
-    // `__wasmgc_string_from_list_int` renders each element with the active
-    // `String.fromInt` and joins the parts with `__wasmgc_concat_n`; record
-    // both indices for the same reason (its `emit_helper_body` only receives
-    // `&registry`). `None` when the program has no interpolation at all, in
-    // which case the list-stringify helper is not registered either.
-    registry.string_from_int_fn_idx =
-        builtin_registry.lookup_wasm_fn_idx(BuiltinName::StringFromInt);
-    registry.string_concat_n_fn_idx =
-        builtin_registry.lookup_wasm_fn_idx(BuiltinName::StringConcatN);
     if registry.bignum {
         registry.aint_eq_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintEq);
         registry.aint_hash_fn_idx = builtin_registry.lookup_wasm_fn_idx(BuiltinName::AintHash);
@@ -6118,17 +6118,6 @@ fn discover_builtins_in_expr(
             builtins.register(BuiltinName::StringFromInt);
             builtins.register(BuiltinName::StringFromFloat);
             builtins.register(BuiltinName::StringFromBool);
-            // A `List<Int>` embed needs its own renderer. NOT registered
-            // conservatively like the scalar ones: its signature mentions
-            // `List<Int>`, so registering it for a program that has no such
-            // list would fail slot allocation. Keyed on the part's stamped
-            // type, which is what the emitter dispatches on too.
-            if parts.iter().any(|p| {
-                matches!(p, ResolvedStrPart::Parsed(inner)
-                    if inner.ty().is_some_and(|t| t.display().trim() == "List<Int>"))
-            }) {
-                builtins.register(BuiltinName::StringFromListInt);
-            }
             for p in parts {
                 if let ResolvedStrPart::Parsed(inner) = p {
                     discover_builtins_in_expr(

--- a/src/codegen/wasm_gc/types.rs
+++ b/src/codegen/wasm_gc/types.rs
@@ -268,15 +268,6 @@ pub(super) struct TypeRegistry {
     pub(super) aint_normalize_fn_idx: Option<u32>,
     pub(super) aint_strip_fn_idx: Option<u32>,
     pub(super) aint_umag_cmp_fn_idx: Option<u32>,
-    /// wasm fn idx of the active `String.fromInt` decimal formatter (the
-    /// `$AverInt` one under bignum, the scalar-i64 one otherwise) and of
-    /// `__wasmgc_concat_n`. Recorded by `module.rs` once
-    /// `BuiltinRegistry::assign_slots` has run, so the `List<Int>`
-    /// stringify helper can `call` both without threading two extra
-    /// indices through `emit_helper_body`. `Some` iff the corresponding
-    /// builtin was registered.
-    pub(super) string_from_int_fn_idx: Option<u32>,
-    pub(super) string_concat_n_fn_idx: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -1156,8 +1147,6 @@ impl TypeRegistry {
             aint_normalize_fn_idx: None,
             aint_strip_fn_idx: None,
             aint_umag_cmp_fn_idx: None,
-            string_from_int_fn_idx: None,
-            string_concat_n_fn_idx: None,
         }
     }
 
@@ -2686,19 +2675,6 @@ fn collect_lists_from_expr(
         ResolvedExpr::InterpolatedStr(parts) => {
             for part in parts {
                 if let ResolvedStrPart::Parsed(inner) = part {
-                    // A `List<Int>` embed lowers through the
-                    // `__wasmgc_string_from_list_int` helper, whose signature
-                    // mentions `List<Int>`. Register the canonical from the
-                    // part's own stamp: a PROJECTION of a packed field
-                    // (`o.values`) is a `List<Int>` value whose canonical
-                    // otherwise only reaches the registry via the record's
-                    // declared field list.
-                    if inner
-                        .ty()
-                        .is_some_and(|t| t.display().trim() == "List<Int>")
-                    {
-                        collect_lists_from_str("List<Int>", out, order, next_idx);
-                    }
                     collect_lists_from_expr(inner, out, order, next_idx);
                 }
             }

--- a/src/ir/interp_lower.rs
+++ b/src/ir/interp_lower.rs
@@ -25,9 +25,20 @@
 //! non-string parts.
 //!
 //! The pass runs *after* the type checker (the checker still sees
-//! `InterpolatedStr` and approves it as `String`) and *before* the
+//! `InterpolatedStr` and types it as `String`) and *before* the
 //! resolver (the desugared form contains bare `Expr::Ident` callees
 //! the resolver later annotates).
+//!
+//! `__to_str` is the whole reason the checker restricts an interpolated
+//! part to `Int` / `Float` / `Bool` / `String` (decision:
+//! ExplicitStringify — conversion to String is named in source). Those
+//! four are what every backend's `__to_str` renders; the VM's lowering
+//! (a CONCAT against `""`, which calls `NanValue::repr`) happens to
+//! render compounds too, but that is dead weight reachable only from
+//! internal pipelines that skip the typecheck. Do not extend it, and do
+//! not widen the checker's set without widening the wasm-gc dispatch in
+//! `codegen/wasm_gc/body/from_mir/strings.rs` in the same change — the
+//! rule and this lowering must agree exactly.
 
 use crate::ast::{Expr, Literal, Spanned, Stmt, StrPart, TopLevel, Type};
 

--- a/src/self_host/aver_generated/domain/eval/core/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/core/mod.rs
@@ -648,7 +648,9 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> Result<Val, AverStr> 
                                 __b.push_str(&AverStr::from("unsupported named-env expression: "));
                                 __b
                             };
-                            __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(expr))));
+                            __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(
+                                &(crate::aver_generated::domain::eval::core::exprLabel(&expr)),
+                            )));
                             __b
                         }));
                     }
@@ -1665,7 +1667,7 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> Result<Val, AverStr> 
             return crate::aver_generated::domain::eval::core::evalIndependentProductSlot(&exprs, unwrap, &env, &slotMap, &fns)
         },
         _ => {
-            return Err(aver_rt::AverStr::from({ let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((aver_rt::AverInt::from_i64(45)).to_usize().unwrap_or(0)); __b.push_str(&AverStr::from("unsupported slot expression: ")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(expr)))); __b }))
+            return Err(aver_rt::AverStr::from({ let mut __b = { let mut __b = aver_rt::Buffer::with_capacity((aver_rt::AverInt::from_i64(45)).to_usize().unwrap_or(0)); __b.push_str(&AverStr::from("unsupported slot expression: ")); __b }; __b.push_str(&aver_rt::AverStr::from(aver_rt::aver_display(&(crate::aver_generated::domain::eval::core::exprLabel(&expr))))); __b }))
         }
     }
             }
@@ -3043,6 +3045,84 @@ pub fn evalImmediateNamedExpr(expr: &Expr) -> Option<Val> {
             Some(crate::aver_generated::domain::value::Val::ValBool(b))
         }
         _ => None,
+    }
+}
+
+/// Name the AST node kind for diagnostics; interpolation renders primitives only, so an Expr needs a named conversion.
+pub fn exprLabel(expr: &Expr) -> AverStr {
+    crate::cancel_checkpoint();
+    match expr {
+        crate::aver_generated::domain::ast::Expr::ExprInt(_) => AverStr::from("ExprInt"),
+        crate::aver_generated::domain::ast::Expr::ExprFloat(_) => AverStr::from("ExprFloat"),
+        crate::aver_generated::domain::ast::Expr::ExprStr(_) => AverStr::from("ExprStr"),
+        crate::aver_generated::domain::ast::Expr::ExprBool(_) => AverStr::from("ExprBool"),
+        crate::aver_generated::domain::ast::Expr::ExprBoolBranch(_, _, _) => {
+            AverStr::from("ExprBoolBranch")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprVar(_) => AverStr::from("ExprVar"),
+        crate::aver_generated::domain::ast::Expr::ExprSlot(_) => AverStr::from("ExprSlot"),
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlotInt(_, _, _) => {
+            AverStr::from("ExprBinopSlotInt")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprBinopSlots(_, _, _) => {
+            AverStr::from("ExprBinopSlots")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(_, _, _) => {
+            AverStr::from("ExprCmpSlotInt")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCmpSlots(_, _, _) => {
+            AverStr::from("ExprCmpSlots")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(_, _, _) => {
+            AverStr::from("ExprVectorGetOrInt")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprIntModOrInt(_, _, _) => {
+            AverStr::from("ExprIntModOrInt")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprAdd(_, _) => AverStr::from("ExprAdd"),
+        crate::aver_generated::domain::ast::Expr::ExprSub(_, _) => AverStr::from("ExprSub"),
+        crate::aver_generated::domain::ast::Expr::ExprMul(_, _) => AverStr::from("ExprMul"),
+        crate::aver_generated::domain::ast::Expr::ExprDiv(_, _) => AverStr::from("ExprDiv"),
+        crate::aver_generated::domain::ast::Expr::ExprNeg(_) => AverStr::from("ExprNeg"),
+        crate::aver_generated::domain::ast::Expr::ExprEq(_, _) => AverStr::from("ExprEq"),
+        crate::aver_generated::domain::ast::Expr::ExprNeq(_, _) => AverStr::from("ExprNeq"),
+        _ => crate::aver_generated::domain::eval::core::exprLabelAggregate(expr),
+    }
+}
+
+/// Continue naming AST node kinds for the comparison, aggregate, and call forms.
+pub fn exprLabelAggregate(expr: &Expr) -> AverStr {
+    crate::cancel_checkpoint();
+    match expr {
+        crate::aver_generated::domain::ast::Expr::ExprLt(_, _) => AverStr::from("ExprLt"),
+        crate::aver_generated::domain::ast::Expr::ExprGt(_, _) => AverStr::from("ExprGt"),
+        crate::aver_generated::domain::ast::Expr::ExprLte(_, _) => AverStr::from("ExprLte"),
+        crate::aver_generated::domain::ast::Expr::ExprGte(_, _) => AverStr::from("ExprGte"),
+        crate::aver_generated::domain::ast::Expr::ExprConcat(_) => AverStr::from("ExprConcat"),
+        crate::aver_generated::domain::ast::Expr::ExprTuple(_) => AverStr::from("ExprTuple"),
+        crate::aver_generated::domain::ast::Expr::ExprList(_) => AverStr::from("ExprList"),
+        crate::aver_generated::domain::ast::Expr::ExprRecord(_, _) => AverStr::from("ExprRecord"),
+        crate::aver_generated::domain::ast::Expr::ExprFieldAccess(_, _) => {
+            AverStr::from("ExprFieldAccess")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCall(_, _) => AverStr::from("ExprCall"),
+        crate::aver_generated::domain::ast::Expr::ExprCallDirect(_, _) => {
+            AverStr::from("ExprCallDirect")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(_, _) => {
+            AverStr::from("ExprCallBuiltin")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(_, _) => {
+            AverStr::from("ExprCallBuiltinId")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprMatch(_, _) => AverStr::from("ExprMatch"),
+        crate::aver_generated::domain::ast::Expr::ExprPropagate(_) => {
+            AverStr::from("ExprPropagate")
+        }
+        crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(_, _) => {
+            AverStr::from("ExprIndependentProduct")
+        }
+        _ => AverStr::from("Expr"),
     }
 }
 

--- a/src/types/checker/infer/expr.rs
+++ b/src/types/checker/infer/expr.rs
@@ -162,16 +162,61 @@ pub(in crate::types::checker) fn type_is_fully_concrete(ty: &Type) -> bool {
 /// either side. Every other type is a compound display and must be
 /// converted by a function the user writes.
 ///
-/// `Type::Invalid` (checker recovery after an earlier error) and
-/// `Type::Var` (a signature type variable inference never pinned) are
-/// accepted here so this rule does not pile a second diagnostic onto an
-/// expression that already produced one, matching how the neighbouring
-/// argument / element rules treat `Invalid`.
+/// `Type::Invalid` (checker recovery after an earlier error) is accepted
+/// so this rule does not pile a second diagnostic onto an expression that
+/// already produced one, matching how the neighbouring argument / element
+/// rules treat `Invalid`.
+///
+/// A bare `Type::Var` is NOT accepted — see
+/// [`InterpolationEmbed::Unresolved`].
 fn interpolation_renders_directly(ty: &Type) -> bool {
     matches!(
         ty,
-        Type::Int | Type::Float | Type::Bool | Type::Str | Type::Invalid | Type::Var(_)
+        Type::Int | Type::Float | Type::Bool | Type::Str | Type::Invalid
     )
+}
+
+/// Verdict for one `{...}` embed in a string interpolation.
+enum InterpolationEmbed<'a> {
+    /// `Int | Float | Bool | String`, or `Invalid` recovery — nothing to say.
+    Accepted,
+    /// A bare `Type::Var`: inference never pinned this embed to any type.
+    ///
+    /// This is the fail-CLOSED arm, and it is deliberately not folded into
+    /// the `Invalid` no-double-report acceptance. An unresolved variable
+    /// does NOT imply an earlier diagnostic: `match Option.None` with an
+    /// arm `Option.Some(x) -> "{x}"` binds `x` to the `T` of the bare
+    /// `Option<T>` subject, and nothing in that program is an error until
+    /// this rule speaks. Admitting it let a CLEAN typecheck hand the
+    /// backends an embed with no renderable type.
+    ///
+    /// There is no later chance to pin it, which is why the verdict is
+    /// safe to reach here rather than in a post-inference sweep:
+    ///   * `TypeChecker` carries no ambient substitution — every `subst`
+    ///     map is created inside a single `compatible` / `match_with` call
+    ///     and dropped when it returns, so there is nothing to canonicalise
+    ///     a stamped type through afterwards;
+    ///   * `Spanned::set_ty` writes a `OnceLock`, and `infer_type` stamps
+    ///     every node it visits, so the type read here is already the final
+    ///     stamp every downstream pass and backend will see;
+    ///   * the one top-down channel, `infer_type_with_expected`, fires only
+    ///     for the fixed recogniser list in `try_infer_with_expected`
+    ///     (generic constructors, list / tuple / map literals) and runs
+    ///     *instead of* bottom-up inference. Interpolation parts are never
+    ///     on that path: the expected type of an `InterpolatedStr` is
+    ///     `String`, which says nothing about a part, and no recogniser
+    ///     descends into `StrPart::Parsed`.
+    Unresolved(&'a str),
+    /// A known type outside the sanctioned set — a compound display.
+    Rejected(&'a Type),
+}
+
+fn classify_interpolation_embed(ty: &Type) -> InterpolationEmbed<'_> {
+    match ty {
+        _ if interpolation_renders_directly(ty) => InterpolationEmbed::Accepted,
+        Type::Var(name) => InterpolationEmbed::Unresolved(name),
+        other => InterpolationEmbed::Rejected(other),
+    }
 }
 
 /// Recogniser for a bare `Option.None` expression — the one constructor
@@ -571,13 +616,34 @@ impl TypeChecker {
                 // else — lists, records, tuples, `Option`/`Result`, maps,
                 // vectors, refinement/named types, `Unit`, function
                 // values — is a compound display and must go through a
-                // user-written function returning String.
+                // user-written function returning String, and an embed
+                // whose type inference never pinned is rejected too
+                // (`InterpolationEmbed::Unresolved`) rather than waved
+                // through on the assumption that something else already
+                // complained.
                 for part in parts {
                     if let crate::ast::StrPart::Parsed(inner) = part {
                         let ty = self.infer_type(inner);
-                        if interpolation_renders_directly(&ty) {
-                            continue;
-                        }
+                        let msg = match classify_interpolation_embed(&ty) {
+                            InterpolationEmbed::Accepted => continue,
+                            InterpolationEmbed::Rejected(ty) => format!(
+                                "String interpolation renders primitives only \
+                                 (Int, Float, Bool, String); this embed is {}. \
+                                 Write the conversion as a named function \
+                                 returning String and interpolate its result.",
+                                ty.display()
+                            ),
+                            InterpolationEmbed::Unresolved(name) => format!(
+                                "String interpolation renders primitives only \
+                                 (Int, Float, Bool, String); the type of this \
+                                 embed could not be determined — inference left \
+                                 it open as `{name}`. Pin the type (annotate the \
+                                 binding, or give the match subject a concrete \
+                                 type), then write the conversion as a named \
+                                 function returning String and interpolate its \
+                                 result."
+                            ),
+                        };
                         // The embed's own `line` is 1-based inside the
                         // `{...}` fragment (a sub-parser parses it in
                         // isolation), so the interpolation node's line
@@ -587,16 +653,7 @@ impl TypeChecker {
                         } else {
                             self.current_fn_line.unwrap_or(1)
                         };
-                        self.error_at_line(
-                            line,
-                            format!(
-                                "String interpolation renders primitives only \
-                                 (Int, Float, Bool, String); this embed is {}. \
-                                 Write the conversion as a named function \
-                                 returning String and interpolate its result.",
-                                ty.display()
-                            ),
-                        );
+                        self.error_at_line(line, msg);
                     }
                 }
                 Type::Str

--- a/src/types/checker/infer/expr.rs
+++ b/src/types/checker/infer/expr.rs
@@ -150,6 +150,30 @@ pub(in crate::types::checker) fn type_is_fully_concrete(ty: &Type) -> bool {
     }
 }
 
+/// True iff a value of `ty` may be embedded directly in a string
+/// interpolation.
+///
+/// THE SANCTIONED SET IS `Int | Float | Bool | String`, and it is exactly
+/// what the `__to_str` lowering (`src/ir/interp_lower.rs`) can render on
+/// every backend: the wasm-gc interpolation emitter dispatches on
+/// `String` (identity), `Int`, `Float` and `Bool` and has no other
+/// stringifier. There is no `Char` type in Aver (`Char.toCode` /
+/// `Char.fromCode` work on codepoint `Int`s), so no `Char` arm exists on
+/// either side. Every other type is a compound display and must be
+/// converted by a function the user writes.
+///
+/// `Type::Invalid` (checker recovery after an earlier error) and
+/// `Type::Var` (a signature type variable inference never pinned) are
+/// accepted here so this rule does not pile a second diagnostic onto an
+/// expression that already produced one, matching how the neighbouring
+/// argument / element rules treat `Invalid`.
+fn interpolation_renders_directly(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Int | Type::Float | Type::Bool | Type::Str | Type::Invalid | Type::Var(_)
+    )
+}
+
 /// Recogniser for a bare `Option.None` expression — the one constructor
 /// with no payload to fix its `T`. Plain inference stamps it
 /// `Option<Var("T")>`, which backends keyed on the stamp (the wasm-gc
@@ -538,9 +562,41 @@ impl TypeChecker {
             },
 
             Expr::InterpolatedStr(parts) => {
+                // Conversion to String is NAMED in source (decision:
+                // ExplicitStringify). An interpolation site is a display
+                // site, so it may only auto-render the PRIMITIVES the
+                // `__to_str` lowering actually implements on every
+                // backend: Int, Float, Bool, String (there is no `Char`
+                // type — `Char.*` operates on codepoint Ints). Everything
+                // else — lists, records, tuples, `Option`/`Result`, maps,
+                // vectors, refinement/named types, `Unit`, function
+                // values — is a compound display and must go through a
+                // user-written function returning String.
                 for part in parts {
-                    if let crate::ast::StrPart::Parsed(expr) = part {
-                        self.infer_type(expr);
+                    if let crate::ast::StrPart::Parsed(inner) = part {
+                        let ty = self.infer_type(inner);
+                        if interpolation_renders_directly(&ty) {
+                            continue;
+                        }
+                        // The embed's own `line` is 1-based inside the
+                        // `{...}` fragment (a sub-parser parses it in
+                        // isolation), so the interpolation node's line
+                        // is the only source-accurate one.
+                        let line = if expr.line > 0 {
+                            expr.line
+                        } else {
+                            self.current_fn_line.unwrap_or(1)
+                        };
+                        self.error_at_line(
+                            line,
+                            format!(
+                                "String interpolation renders primitives only \
+                                 (Int, Float, Bool, String); this embed is {}. \
+                                 Write the conversion as a named function \
+                                 returning String and interpolate its result.",
+                                ty.display()
+                            ),
+                        );
                     }
                 }
                 Type::Str

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -4022,3 +4022,151 @@ fn plain_tuple_literal_accepts_expected_tuple_elements() {
     let src = "fn pair(n: Int) -> Tuple<Int, Int>\n    ? \"Pairs.\"\n    (1, n)\n";
     assert_no_errors(src);
 }
+
+// ---------------------------------------------------------------------------
+// String interpolation — primitives only, conversions are named in source
+// ---------------------------------------------------------------------------
+
+/// The sanctioned set, one embed per primitive. This is exactly what the
+/// `__to_str` lowering renders on every backend; if a primitive is added
+/// or dropped there, this test and the rule must move together.
+#[test]
+fn interpolation_accepts_every_primitive() {
+    assert_no_errors("fn show(n: Int) -> String\n    \"n={n}\"\n");
+    assert_no_errors("fn show(x: Float) -> String\n    \"x={x}\"\n");
+    assert_no_errors("fn show(b: Bool) -> String\n    \"b={b}\"\n");
+    assert_no_errors("fn show(s: String) -> String\n    \"s={s}\"\n");
+}
+
+#[test]
+fn interpolation_rejects_a_list_embed() {
+    assert_error_containing(
+        "fn show(xs: List<Int>) -> String\n    \"xs={xs}\"\n",
+        "String interpolation renders primitives only (Int, Float, Bool, String); \
+         this embed is List<Int>.",
+    );
+}
+
+#[test]
+fn interpolation_rejects_a_record_embed() {
+    let src = "record User\n    name: String\n    age: Int\n\n\
+               fn show(u: User) -> String\n    \"u={u}\"\n";
+    assert_error_containing(
+        src,
+        "String interpolation renders primitives only (Int, Float, Bool, String); \
+         this embed is User.",
+    );
+}
+
+#[test]
+fn interpolation_rejects_an_option_embed() {
+    assert_error_containing(
+        "fn show(o: Option<Int>) -> String\n    \"o={o}\"\n",
+        "this embed is Option<Int>.",
+    );
+}
+
+#[test]
+fn interpolation_rejects_a_result_embed() {
+    assert_error_containing(
+        "fn show(r: Result<Int, String>) -> String\n    \"r={r}\"\n",
+        "this embed is Result<Int, String>.",
+    );
+}
+
+#[test]
+fn interpolation_rejects_a_map_embed() {
+    assert_error_containing(
+        "fn show(m: Map<String, Int>) -> String\n    \"m={m}\"\n",
+        "this embed is Map<String, Int>.",
+    );
+}
+
+#[test]
+fn interpolation_rejects_a_tuple_embed() {
+    assert_error_containing(
+        "fn show(t: Tuple<Int, Int>) -> String\n    \"t={t}\"\n",
+        "this embed is Tuple<Int, Int>.",
+    );
+}
+
+#[test]
+fn interpolation_rejects_a_vector_embed() {
+    assert_error_containing(
+        "fn show(v: Vector<Int>) -> String\n    \"v={v}\"\n",
+        "this embed is Vector<Int>.",
+    );
+}
+
+/// The diagnostic must point at the fix the language actually offers —
+/// a user-written conversion — and must NOT advertise a stdlib helper,
+/// because none exists and none is planned.
+#[test]
+fn interpolation_rejection_asks_for_a_named_conversion() {
+    let errs = errors("fn show(xs: List<Int>) -> String\n    \"xs={xs}\"\n");
+    let msg = errs
+        .iter()
+        .find(|m| m.contains("String interpolation renders primitives only"))
+        .expect("expected the interpolation diagnostic");
+    assert!(
+        msg.contains("named function returning String"),
+        "diagnostic must ask for a named conversion: {msg}"
+    );
+    assert!(
+        !msg.contains("String.from") && !msg.contains("List.toString"),
+        "diagnostic must not suggest a stdlib helper: {msg}"
+    );
+}
+
+/// Wrapping the value in a user-written display fn is the sanctioned
+/// spelling and must type-check clean — the positive control for the
+/// rejections above.
+#[test]
+fn interpolation_accepts_a_named_conversion_result() {
+    let src = r#"fn joinInts(xs: List<Int>) -> String
+    match xs
+        [] -> ""
+        [head, ..tail] -> match tail
+            [] -> "{head}"
+            _ -> "{head}, {joinInts(tail)}"
+
+fn show(xs: List<Int>) -> String
+    "xs=[{joinInts(xs)}]"
+"#;
+    assert_no_errors(src);
+}
+
+/// An embed whose type the checker could not resolve already produced a
+/// diagnostic of its own; the interpolation rule must not pile a second
+/// one on top (same `Type::Invalid` discipline the neighbouring argument
+/// and element rules follow).
+#[test]
+fn interpolation_does_not_double_report_an_invalid_embed() {
+    let errs = errors("fn show() -> String\n    \"v={nope}\"\n");
+    assert_eq!(
+        errs.iter()
+            .filter(|m| m.contains("Unknown identifier 'nope'"))
+            .count(),
+        1,
+        "expected exactly one unknown-identifier error, got: {errs:?}"
+    );
+    assert_eq!(
+        errs.iter()
+            .filter(|m| m.contains("String interpolation renders primitives only"))
+            .count(),
+        0,
+        "an already-errored embed must not draw a second diagnostic, got: {errs:?}"
+    );
+}
+
+#[test]
+fn interpolation_does_not_double_report_a_bad_call_embed() {
+    let errs = errors("fn show() -> String\n    \"v={missingFn(1)}\"\n");
+    assert_eq!(
+        errs.iter()
+            .filter(|m| m.contains("String interpolation renders primitives only"))
+            .count(),
+        0,
+        "an already-errored embed must not draw a second diagnostic, got: {errs:?}"
+    );
+}

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -4170,3 +4170,124 @@ fn interpolation_does_not_double_report_a_bad_call_embed() {
         "an already-errored embed must not draw a second diagnostic, got: {errs:?}"
     );
 }
+
+// --- Embeds whose type inference never pinned ------------------------------
+//
+// An unresolved `Type::Var` is NOT evidence of an earlier diagnostic, so it
+// must not ride the `Type::Invalid` no-double-report acceptance. Each source
+// below type-checks clean apart from the interpolation itself; admitting the
+// embed would hand a clean-typechecked program to the backends with no
+// renderable type for it.
+
+/// The exact fail-open witness: `match Option.None` binds the arm's `x` to
+/// the `T` of a bare `Option<T>` subject. Nothing else in this program is an
+/// error.
+#[test]
+fn interpolation_rejects_an_unresolved_embed_from_a_bare_none_match() {
+    let src = "fn render() -> String\n\
+               \x20   match Option.None\n\
+               \x20       Option.Some(x) -> \"{x}\"\n\
+               \x20       Option.None -> \"none\"\n";
+    let errs = errors(src);
+    assert_eq!(
+        errs.len(),
+        1,
+        "the unresolved embed must be the ONLY error — an unresolved variable \
+         is not evidence of a prior diagnostic, got: {errs:?}"
+    );
+    assert!(
+        errs[0].contains("the type of this embed could not be determined"),
+        "expected the unresolved-embed diagnostic, got: {errs:?}"
+    );
+    assert!(
+        errs[0].contains("named function returning String"),
+        "the unresolved diagnostic must still ask for a named conversion: {errs:?}"
+    );
+}
+
+/// Same hole reached through a local binding rather than an inline subject.
+#[test]
+fn interpolation_rejects_an_unresolved_embed_bound_through_a_local() {
+    let src = "fn render() -> String\n\
+               \x20   o = Option.None\n\
+               \x20   match o\n\
+               \x20       Option.Some(x) -> \"{x}\"\n\
+               \x20       Option.None -> \"none\"\n";
+    assert_error_containing(src, "the type of this embed could not be determined");
+}
+
+/// And through a bare empty-list subject, whose element type is equally open.
+#[test]
+fn interpolation_rejects_an_unresolved_embed_from_a_bare_empty_list_match() {
+    let src = "fn render() -> String\n\
+               \x20   match []\n\
+               \x20       [] -> \"empty\"\n\
+               \x20       [head, ..tail] -> \"{head}\"\n";
+    assert_error_containing(src, "the type of this embed could not be determined");
+}
+
+/// Pinning the subject's type removes the diagnostic — the positive control
+/// proving the rule rejects genuinely-unresolved embeds, not merely
+/// pattern-bound ones.
+#[test]
+fn interpolation_accepts_a_match_binding_off_a_concrete_subject() {
+    assert_no_errors(
+        "fn render(o: Option<Int>) -> String\n\
+         \x20   match o\n\
+         \x20       Option.Some(x) -> \"{x}\"\n\
+         \x20       Option.None -> \"none\"\n",
+    );
+    assert_no_errors(
+        "fn render(xs: List<Int>) -> String\n\
+         \x20   match xs\n\
+         \x20       [] -> \"empty\"\n\
+         \x20       [head, ..tail] -> \"{head}\"\n",
+    );
+    // Plain bottom-up local binding: the shape a naive "reject Var" would
+    // break if inference deferred pinning to a later pass.
+    assert_no_errors("fn render() -> String\n    x = 5\n    \"{x}\"\n");
+}
+
+/// The parts of an interpolation are parsed by a sub-parser that sees only
+/// the `{...}` fragment, so an embed's own `line` is 1-based inside that
+/// fragment. The diagnostic must be anchored to the OUTER interpolation node
+/// instead. Both interpolation diagnostics are pinned, on a line > 1, so a
+/// refactor cannot silently regress either to line 1.
+#[test]
+fn interpolation_errors_report_the_outer_source_line() {
+    let items = parse(
+        "fn pad() -> Int\n\
+         \x20   1\n\
+         \n\
+         fn show(xs: List<Int>) -> String\n\
+         \x20   \"xs={xs}\"\n",
+    );
+    let errs = aver::types::checker::run_type_check(&items);
+    let err = errs
+        .iter()
+        .find(|e| e.message.contains("this embed is List<Int>"))
+        .unwrap_or_else(|| panic!("expected the known-type interpolation error, got: {errs:?}"));
+    assert_eq!(
+        err.line, 5,
+        "known-type interpolation error must report the outer line, got: {err:?}"
+    );
+
+    let items = parse(
+        "fn pad() -> Int\n\
+         \x20   1\n\
+         \n\
+         fn render() -> String\n\
+         \x20   match Option.None\n\
+         \x20       Option.Some(x) -> \"{x}\"\n\
+         \x20       Option.None -> \"none\"\n",
+    );
+    let errs = aver::types::checker::run_type_check(&items);
+    let err = errs
+        .iter()
+        .find(|e| e.message.contains("could not be determined"))
+        .unwrap_or_else(|| panic!("expected the unresolved interpolation error, got: {errs:?}"));
+    assert_eq!(
+        err.line, 6,
+        "unresolved interpolation error must report the outer line, got: {err:?}"
+    );
+}

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -352,18 +352,26 @@ fn relay(conn: Tcp.Connection) -> Result<Unit, String>
     );
 }
 
+/// A bare `List<Int>` literal in argument position. The literal used to
+/// sit directly inside an interpolation (`"{[1, 2, 3]}"`); interpolation
+/// renders primitives only now, so it reaches the same lowering through
+/// the named conversion a user writes instead.
 #[test]
-fn bare_list_literal_inside_interpolation_compiles() {
+fn bare_list_literal_through_a_named_conversion_compiles() {
     assert_compiles_and_validates(
         r#"module Probe
     intent = "Minimal List<Int> literal for wasm-gc compilation."
     exposes [main]
     effects [Console.print]
 
+fn describe(xs: List<Int>) -> String
+    ? "Name the conversion to String."
+    "len={List.len(xs)}"
+
 fn main() -> Unit
     ? "Print a list literal."
     ! [Console.print]
-    Console.print("{[1, 2, 3]}")
+    Console.print(describe([1, 2, 3]))
 "#,
     );
 }
@@ -542,4 +550,101 @@ fn json_sum_uses_nominal_root_in_variants_tuple_and_dispatch() {
         dispatch_targets.iter().all(|idx| *idx != 0),
         "specific pattern tests/casts must target concrete variants, not the sum root"
     );
+}
+
+// ─── Compound string interpolation is a LOUD codegen error ──────────────
+//
+// The typechecker rejects a non-primitive interpolation embed outright,
+// so `aver run` / `aver compile` never reach the wasm-gc emitter with
+// one. Internal pipelines that drive codegen WITHOUT gating on the
+// checker's errors still can, and so would any future checker gap. The
+// emitter must answer with an error naming the fn and the embed type —
+// not by bailing to `Ok(None)`, which hands the whole fn an
+// `unreachable` trap stub and ships a program that compiles clean and
+// then traps at runtime with no diagnostic.
+
+/// Frontend pipeline that IGNORES typecheck errors — the shape an
+/// eval-style internal harness has. `pipeline::run` skips every later
+/// stage once the checker reports an error, so the typecheck is driven
+/// separately (it stamps types into the AST as it walks, errors or not)
+/// and the pipeline then runs unguarded. Codegen therefore sees the same
+/// stamped `List<Int>` embed a checker gap would let through.
+fn parse_pipeline_ignoring_type_errors(source: &str) -> Vec<TopLevel> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().expect("lex");
+    let mut parser = Parser::new(tokens);
+    let mut items = parser.parse().expect("parse");
+    let tc = ir::pipeline::typecheck(&items, &ir::TypecheckMode::Full { base_dir: None });
+    assert!(
+        !tc.errors.is_empty(),
+        "this harness exists to model an UNGATED pipeline — the program is \
+         expected to be rejected by the checker"
+    );
+    ir::pipeline::run(
+        &mut items,
+        ir::PipelineConfig {
+            typecheck: None,
+            run_interp_lower: false,
+            run_buffer_build: false,
+            ..Default::default()
+        },
+    );
+    items
+}
+
+#[test]
+fn compound_interpolation_embed_is_a_loud_codegen_error_not_a_trap_stub() {
+    let source = r#"module M
+    intent = "reach the interpolation emitter with a compound embed"
+    effects [Console]
+
+fn describe(xs: List<Int>) -> String
+    "xs={xs}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(describe([1, 2, 3]))
+"#;
+    let items = parse_pipeline_ignoring_type_errors(source);
+    let err = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, None)
+        .expect_err("a compound interpolation embed must fail the wasm-gc compile");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("describe"),
+        "the codegen error must name the offending fn: {msg}"
+    );
+    assert!(
+        msg.contains("List<Int>"),
+        "the codegen error must name the embed type: {msg}"
+    );
+    assert!(
+        msg.contains("no stringifier"),
+        "the codegen error must say what is missing: {msg}"
+    );
+}
+
+/// Positive control: the same program with the conversion NAMED compiles
+/// and validates, so the test above is pinning the compound embed and
+/// not some unrelated breakage in the shape.
+#[test]
+fn named_conversion_interpolation_still_compiles_and_validates() {
+    let source = r#"module M
+    intent = "render a list through a named conversion"
+    effects [Console]
+
+fn joinInts(xs: List<Int>) -> String
+    match xs
+        [] -> ""
+        [head, ..tail] -> match tail
+            [] -> "{head}"
+            _ -> "{head}, {joinInts(tail)}"
+
+fn describe(xs: List<Int>) -> String
+    "xs=[{joinInts(xs)}]"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(describe([1, 2, 3]))
+"#;
+    assert_compiles_and_validates(source);
 }

--- a/tests/wasm_gc_packed_sequence.rs
+++ b/tests/wasm_gc_packed_sequence.rs
@@ -70,6 +70,35 @@ fn verify(source: &str, wasm_gc: bool, packed: bool) -> (bool, String) {
     )
 }
 
+/// `aver check` over a single file — for red-checks where the program
+/// must be REJECTED by the frontend before any backend runs.
+fn check(source: &str) -> (bool, String) {
+    let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "aver-packed-sequence-check-{}-{id}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("main.av");
+    std::fs::write(&path, source).expect("source");
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .arg("check")
+        .arg(&path)
+        .output()
+        .expect("check aver");
+    let _ = std::fs::remove_dir_all(dir);
+    (
+        output.status.success(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .trim()
+        .to_string(),
+    )
+}
+
 /// Multi-module variant of `run`: writes `main.av` plus one dep module
 /// file, then drives `aver run main.av --module-root <dir>` so the CLI's
 /// multi-module flatten + wasm-gc path is exercised end to end.
@@ -626,18 +655,19 @@ fn out_of_interval_literal_declines_the_discharge_on_every_backend() {
 // ─── Interpolating the carrier ──────────────────────────────────────────
 //
 // `"{o.values}"` embeds the PROJECTED `List<Int>` carrier in a string.
-// The projection itself already inserts the packed→list unpack bridge, so
-// what the interpolation receives is a plain cons list on both the packed
-// and the boxed path — but wasm-gc had no stringifier for a `List<Int>`
-// embed at all. The MIR interpolation emitter bailed on the compound type,
-// and a bail makes the WHOLE enclosing fn an `unreachable` trap stub, so
-// the program compiled and then trapped at runtime with no diagnostic.
-// The VM (and generated Rust) print `[0, 1, 127, 255]`.
+// That is a display site for a compound value, and conversion to String
+// must be NAMED in source, so the typechecker rejects it outright — see
+// the interpolation rule in `src/types/checker/infer/expr.rs`. wasm-gc
+// used to compile such a fn to an `unreachable` trap stub (silently, at
+// runtime); the rule removes the shape from typechecked programs, and
+// the emitter now raises a loud codegen error if one ever reaches it.
 //
-// The program below pins every leg of the rendering against the VM:
-// empty / single / multi carriers, a NEGATIVE and a beyond-i64 element on
-// a plain (unrefined) list so the bignum formatter is exercised too, and
-// two embeds in one literal so the parts array indexing is covered.
+// Two tests keep the coverage the original trap bug was about:
+//   * the red-check below pins the rejection and its message;
+//   * `packed_field_rendered_by_a_named_fn_matches_vm_and_boxed_wasm`
+//     keeps the three-way differential over packed-field projection +
+//     string building, now routed through an explicit local
+//     `showInts` — which is what a user writes instead.
 const INTERPOLATED_OCTETS: &str = r#"module M
     intent = "interpolate the projected carrier of a packed refinement"
     effects [Console]
@@ -667,24 +697,95 @@ fn render(xs: List<Int>) -> String
 
 fn main() -> Unit
     ! [Console.print]
+    Console.print(render(List.concat([0, 1], [127, 255])))
+"#;
+
+#[test]
+fn interpolating_a_packed_field_is_a_type_error() {
+    let (ok, out) = check(INTERPOLATED_OCTETS);
+    assert!(
+        !ok,
+        "interpolating a List<Int> carrier must be rejected, got: {out}"
+    );
+    assert!(
+        out.contains(
+            "String interpolation renders primitives only (Int, Float, Bool, String); \
+             this embed is List<Int>."
+        ),
+        "the diagnostic must name the offending type: {out}"
+    );
+    assert!(
+        out.contains("named function returning String"),
+        "the diagnostic must ask for a named conversion: {out}"
+    );
+}
+
+// Same program shape, with the display written out. `showInts` is the
+// named conversion the rule demands; it renders exactly what the VM's
+// repr does (`[]`, `[7]`, `[0, 1, 127, 255]`), so the three backends
+// stay comparable byte for byte.
+//
+// The coverage this preserves is the packed-field projection: `o.values`
+// reads the carrier of a PACKED refinement, which inserts the packed→list
+// unpack bridge before the value reaches the string builder, so the
+// packed and boxed lanes must agree. Empty / single / multi carriers, a
+// NEGATIVE and a beyond-i64 element on a plain (unrefined) list so the
+// bignum formatter is exercised too, and two embeds in one literal so the
+// parts-array indexing is covered.
+const NAMED_SHOW_OCTETS: &str = r#"module M
+    intent = "render the projected carrier of a packed refinement via a named fn"
+    effects [Console]
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+
+fn joinInts(xs: List<Int>) -> String
+    match xs
+        [] -> ""
+        [head, ..tail] -> match tail
+            [] -> "{head}"
+            _ -> "{head}, {joinInts(tail)}"
+
+fn showInts(xs: List<Int>) -> String
+    "[{joinInts(xs)}]"
+
+fn show(o: Octets) -> String
+    showInts(o.values)
+
+fn render(xs: List<Int>) -> String
+    match fromList(xs)
+        Result.Ok(o) -> show(o)
+        Result.Err(error) -> error
+
+fn main() -> Unit
+    ! [Console.print]
     empty: List<Int> = []
     Console.print(render(empty))
     Console.print(render(List.concat([7], empty)))
     Console.print(render(List.concat([0, 1], [127, 255])))
     plain = List.concat([0 - 5, 0], [10000000000000000000])
-    Console.print("plain={plain} twice={plain}")
+    Console.print("plain={showInts(plain)} twice={showInts(plain)}")
 "#;
 
 #[test]
-fn interpolated_packed_field_matches_vm_and_boxed_wasm() {
-    let (vm_ok, vm) = run(INTERPOLATED_OCTETS, false, true);
-    let (packed_ok, packed) = run(INTERPOLATED_OCTETS, true, true);
-    let (boxed_ok, boxed) = run(INTERPOLATED_OCTETS, true, false);
+fn packed_field_rendered_by_a_named_fn_matches_vm_and_boxed_wasm() {
+    let (vm_ok, vm) = run(NAMED_SHOW_OCTETS, false, true);
+    let (packed_ok, packed) = run(NAMED_SHOW_OCTETS, true, true);
+    let (boxed_ok, boxed) = run(NAMED_SHOW_OCTETS, true, false);
     assert!(vm_ok, "VM failed: {vm}");
-    assert!(
-        packed_ok,
-        "packed wasm failed (interpolating the carrier trapped): {packed}"
-    );
+    assert!(packed_ok, "packed wasm failed: {packed}");
     assert!(boxed_ok, "boxed wasm failed: {boxed}");
     assert_eq!(
         vm,
@@ -695,11 +796,11 @@ fn interpolated_packed_field_matches_vm_and_boxed_wasm() {
     assert_eq!(boxed, vm, "boxed wasm-gc diverged from the VM");
 }
 
-// Same gap, second surface: `aver verify --wasm-gc` runs cases through
-// its own wasm-gc execution path, so the trap-stub body reached it too —
-// the case bodies below returned nothing and every case failed.
-const INTERPOLATED_OCTETS_VERIFY: &str = r#"module M
-    intent = "verify an interpolated packed carrier on the wasm-gc runner"
+// Second surface: `aver verify` runs cases through its own wasm-gc
+// execution path, so a codegen gap can be red there while `aver run` is
+// green. Same named-conversion shape, driven from verify cases.
+const NAMED_SHOW_OCTETS_VERIFY: &str = r#"module M
+    intent = "verify a named-conversion render of a packed carrier on the wasm-gc runner"
     effects []
 
 record Octets
@@ -717,9 +818,19 @@ fn fromList(xs: List<Int>) -> Result<Octets, String>
         true -> Result.Ok(Octets(values = xs))
         false -> Result.Err("oob")
 
+fn joinInts(xs: List<Int>) -> String
+    match xs
+        [] -> ""
+        [head, ..tail] -> match tail
+            [] -> "{head}"
+            _ -> "{head}, {joinInts(tail)}"
+
+fn showInts(xs: List<Int>) -> String
+    "[{joinInts(xs)}]"
+
 fn render(xs: List<Int>) -> String
     match fromList(xs)
-        Result.Ok(o) -> "{o.values}"
+        Result.Ok(o) -> showInts(o.values)
         Result.Err(error) -> error
 
 verify render
@@ -729,10 +840,10 @@ verify render
 "#;
 
 #[test]
-fn interpolated_packed_field_verifies_on_the_wasm_gc_runner() {
-    let (vm_ok, vm) = verify(INTERPOLATED_OCTETS_VERIFY, false, true);
-    let (packed_ok, packed) = verify(INTERPOLATED_OCTETS_VERIFY, true, true);
-    let (boxed_ok, boxed) = verify(INTERPOLATED_OCTETS_VERIFY, true, false);
+fn named_conversion_render_verifies_on_the_wasm_gc_runner() {
+    let (vm_ok, vm) = verify(NAMED_SHOW_OCTETS_VERIFY, false, true);
+    let (packed_ok, packed) = verify(NAMED_SHOW_OCTETS_VERIFY, true, true);
+    let (boxed_ok, boxed) = verify(NAMED_SHOW_OCTETS_VERIFY, true, false);
     assert!(vm_ok, "VM verify failed: {vm}");
     assert!(packed_ok, "packed wasm-gc verify failed: {packed}");
     assert!(boxed_ok, "boxed wasm-gc verify failed: {boxed}");

--- a/tools/website/llms.txt
+++ b/tools/website/llms.txt
@@ -279,7 +279,7 @@ Rules:
 - Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`
 - Error propagation: `expr?` (unwraps `Result.Ok`, propagates `Result.Err`). **Result-only** — does not work on `Option`. For `Option`, use `Option.withDefault(opt, fallback)` or pattern-match.
 - Independence: `(a, b)!` (parallel), `(a, b)?!` (parallel + Result unwrap)
-- String interpolation: `"Hello, {name}!"`
+- String interpolation: `"Hello, {name}!"` — **primitives only** (`Int`, `Float`, `Bool`, `String`). Embedding a list, record, tuple, `Map`, `Option`/`Result`, `Vector` or any named type is a type error; write a function returning `String` and interpolate its result.
 
 **These operators do NOT exist** — do not use them:
 
@@ -319,7 +319,7 @@ Key `String` API:
 - `String.join`, `String.split`, `String.chars` — concat is the `+` operator
 - `Int.fromString : String -> Result<Int, String>`, `String.fromInt : Int -> String`
 - `Float.fromString`, `String.fromFloat`, `String.fromBool` — convention: `<targetTyp>.from<source>`
-- string interpolation: `"Hello, {name}!"` is the idiomatic way to render values into text; reserve `String.fromInt` etc. for explicit data conversion (e.g. building keys: `"user:" + String.fromInt(id)`)
+- string interpolation: `"Hello, {name}!"` is the idiomatic way to render PRIMITIVES into text; reserve `String.fromInt` etc. for explicit data conversion (e.g. building keys: `"user:" + String.fromInt(id)`). Compound values have no built-in rendering — write your own `fn show(x: T) -> String`.
 
 Key `List` API (small, recursion-first):
 - `List.len`, `List.prepend`, `List.concat`, `List.reverse`, `List.contains`, `List.zip`, `List.take`, `List.drop`, `List.fromVector`


### PR DESCRIPTION
Interpolation renders primitives only — `Int`, `Float`, `Bool`, `String`, exactly the set the `__to_str` lowering implements on every backend. Any other embed is a type error naming the offending type and asking for a named function returning `String`; no standard-library renderer is added.

- Reverts the wasm-gc `List<Int>` interpolation stringifier: no typechecked program can reach the compound arm any more.
- That arm now raises a wasm-gc codegen error naming the function and the embed type instead of bailing to a silent `unreachable` trap stub, so pipelines that skip the typecheck get a diagnostic. The other unsupported-shape bails in the MIR emitter still trap-stub; `AVER_WASMGC_REQUIRE_MIR=1` lists them.
- Migrates the self-hosted evaluator's two `Expr` diagnostics to a named `exprLabel` function (self-host regenerated). The rest of the tree already used named render functions.
- Tests: checker rules for each primitive and each compound shape, no double report on an already-errored embed, a rewritten packed-field red-check plus a three-way differential that keeps the packed-projection coverage through an explicit local render function, and a codegen test that an ungated pipeline gets the loud error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
