### PR TITLE
Migrate the edge fractal demo off literal-divisor Result handling

### DIFF
--- a/tools/edge/fractal.av
+++ b/tools/edge/fractal.av
@@ -250,8 +250,8 @@ verify escapeIter
 
 fn ditherThreshold(col: Int, row: Int) -> Float
     ? "4x4 ordered Bayer dither threshold for pixel (col, row). Standard recursive 4x4 Bayer matrix divided by 16 (centred so frac=0 never upgrades and frac=1 always upgrades). 16 distinct thresholds across a 4x4 block give 16-level fractional palette interpolation — fine enough that the dither pattern is barely visible at normal viewing distance while still smoothly bridging adjacent palette entries."
-    cm = Result.withDefault(Int.mod(col, 4), 0)
-    rm = Result.withDefault(Int.mod(row, 4), 0)
+    cm = Int.mod(col, 4)
+    rm = Int.mod(row, 4)
     match rm * 4 + cm
         0  -> 0.03125
         1  -> 0.53125
@@ -282,8 +282,8 @@ fn paletteIdx(nu: Float, col: Int, row: Int, maxIter: Int) -> Int
     match nu >= Float.fromInt(maxIter)
         true  -> 0
         false -> match (nu - Float.fromInt(Float.floor(nu))) > ditherThreshold(col, row)
-            true  -> Result.withDefault(Int.mod(Float.floor(nu) + 1, 30), 0) + 1
-            false -> Result.withDefault(Int.mod(Float.floor(nu), 30), 0) + 1
+            true  -> Int.mod(Float.floor(nu) + 1, 30) + 1
+            false -> Int.mod(Float.floor(nu), 30) + 1
 
 verify paletteIdx
     paletteIdx(Float.fromInt(50), 0, 0, 50) => 0


### PR DESCRIPTION
The release bench gate compiles tools/edge/fractal.av as a dependency of the fractal_seahorse scenario; its four Result.withDefault(Int.mod(..., literal)) sites became type errors under the literal-divisor discharge and no CI lane compiles this directory. Verified locally: aver check shows no type errors and the full bench scenario suite passes with the release binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)