### PR TITLE
Preserve error propagation for a nested `?` in the Lean proof export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
+## Unreleased
+
+### Fixed
+
+- **Lean proof exports preserve `?` error propagation inside nested expressions.** Proofs can now rely on calls, operators, interpolation, bindings, and match arms returning the original `Result.Err` instead of continuing with a default value.
+
 ## 0.28.0 "Oktet" — 2026-08-10
 
 Named for the humble byte: this release gives Aver a real binary story — validated bytes as a type, exact TCP reads and writes, SHA-256 — with the proofs to match, and it starts deleting `Result` ceremony wherever the compiler can see the answer.

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -3293,6 +3293,7 @@ mod tests {
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            lean_do_block: std::cell::Cell::new(false),
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -242,6 +242,7 @@ mod tests {
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            lean_do_block: std::cell::Cell::new(false),
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -122,9 +122,15 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
         ResolvedExpr::Match { subject, arms } => emit_match(subject, arms, expr.line, ctx),
         ResolvedExpr::Ctor(ctor, args) => emit_constructor(ctor, args, ctx),
         ResolvedExpr::ErrorProp(inner) => {
-            // ? operator — unwrap Except using withDefault
             let inner_str = emit_expr(inner, ctx);
-            format!("(({}).withDefault default)", inner_str)
+            if ctx.lean_do_block.get() {
+                format!("(<- {})", inner_str)
+            } else {
+                // Verify cases and law statements are not emitted inside `do`,
+                // so they retain the legacy fallback until their propagation
+                // semantics can be modeled separately.
+                format!("(({}).withDefault default)", inner_str)
+            }
         }
         ResolvedExpr::InterpolatedStr(parts) => emit_interpolated_str(parts, ctx),
         ResolvedExpr::List(elements) => {
@@ -520,9 +526,16 @@ fn emit_match(
 ) -> String {
     // Bool match → if/then/else (avoids Lean dependent elimination issues)
     if let Some((true_body, false_body)) = extract_bool_arms(arms) {
+        let monadify_arms = ctx.lean_do_block.get()
+            && (resolved_expr_contains_error_prop(true_body)
+                || resolved_expr_contains_error_prop(false_body));
         let cond = emit_expr(subject, ctx);
-        let t = emit_expr(true_body, ctx);
-        let f = emit_expr(false_body, ctx);
+        let mut t = emit_expr(true_body, ctx);
+        let mut f = emit_expr(false_body, ctx);
+        if monadify_arms {
+            t = format!("(do pure ({t}))");
+            f = format!("(do pure ({f}))");
+        }
         // Dependent `if h : cond then T else F` ONLY when the true
         // branch contains a refinement-Subtype constructor — those
         // need the predicate as a hypothesis in scope to discharge
@@ -538,15 +551,30 @@ fn emit_match(
         // transparent to Lean's elaborator and tactics (same `ite`).
         if true_body_uses_refinement_subtype(true_body, ctx) {
             let hyp = format!("h_{line}");
+            if monadify_arms {
+                // Lean's `do` notation is layout-sensitive: `if` and `else`
+                // must align and remain strictly inside the nested action.
+                return format!("(<- (do\n     if {hyp} : {cond} then {t}\n     else {f}))");
+            }
             return format!("(if {hyp} : {cond} then {t}\n  else {f})");
+        }
+        if monadify_arms {
+            return format!("(<- (do\n     if {cond} then {t}\n     else {f}))");
         }
         return format!("(if {cond} then {t}\n  else {f})");
     }
+    let monadify_arms = ctx.lean_do_block.get()
+        && arms
+            .iter()
+            .any(|arm| resolved_expr_contains_error_prop(&arm.body));
     let subj = emit_expr(subject, ctx);
     let mut arm_strs = Vec::new();
     for arm in arms {
         let pat = emit_pattern(&arm.pattern, ctx);
-        let body = emit_expr(&arm.body, ctx);
+        let mut body = emit_expr(&arm.body, ctx);
+        if monadify_arms {
+            body = format!("(do pure ({body}))");
+        }
         if body.contains('\n') {
             let body_lines: Vec<&str> = body.lines().collect();
             let mut rendered = vec![format!("  | {} => {}", pat, body_lines[0])];
@@ -583,11 +611,69 @@ fn emit_match(
         &subject.node,
         ResolvedExpr::Ident(_) | ResolvedExpr::Resolved { .. } | ResolvedExpr::Attr(_, _)
     );
-    if needs_eq_binder {
+    let emitted_match = if needs_eq_binder {
         let eq_name = format!("h_{}", line);
         format!("match {} : {} with\n{}", eq_name, subj, arm_strs.join("\n"))
     } else {
         format!("match {} with\n{}", subj, arm_strs.join("\n"))
+    };
+    if monadify_arms {
+        let nested_match = emitted_match
+            .lines()
+            .map(|line| format!("     {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("(<- (do\n{nested_match}))")
+    } else {
+        emitted_match
+    }
+}
+
+fn resolved_expr_contains_error_prop(expr: &Spanned<ResolvedExpr>) -> bool {
+    match &expr.node {
+        ResolvedExpr::ErrorProp(_) => true,
+        ResolvedExpr::Attr(obj, _) => resolved_expr_contains_error_prop(obj),
+        ResolvedExpr::Call(callee, args) => {
+            let callee_contains = match callee {
+                ResolvedCallee::Unresolved { callee } => resolved_expr_contains_error_prop(callee),
+                _ => false,
+            };
+            callee_contains || args.iter().any(resolved_expr_contains_error_prop)
+        }
+        ResolvedExpr::BinOp(_, left, right) => {
+            resolved_expr_contains_error_prop(left) || resolved_expr_contains_error_prop(right)
+        }
+        ResolvedExpr::Neg(inner) => resolved_expr_contains_error_prop(inner),
+        ResolvedExpr::Match { subject, arms } => {
+            resolved_expr_contains_error_prop(subject)
+                || arms
+                    .iter()
+                    .any(|arm| resolved_expr_contains_error_prop(&arm.body))
+        }
+        ResolvedExpr::Ctor(_, args) => args.iter().any(resolved_expr_contains_error_prop),
+        ResolvedExpr::InterpolatedStr(parts) => parts.iter().any(|part| match part {
+            ResolvedStrPart::Parsed(expr) => resolved_expr_contains_error_prop(expr),
+            ResolvedStrPart::Literal(_) => false,
+        }),
+        ResolvedExpr::List(items)
+        | ResolvedExpr::Tuple(items)
+        | ResolvedExpr::IndependentProduct(items, _) => {
+            items.iter().any(resolved_expr_contains_error_prop)
+        }
+        ResolvedExpr::MapLiteral(entries) => entries.iter().any(|(key, value)| {
+            resolved_expr_contains_error_prop(key) || resolved_expr_contains_error_prop(value)
+        }),
+        ResolvedExpr::RecordCreate { fields, .. } => fields
+            .iter()
+            .any(|(_, value)| resolved_expr_contains_error_prop(value)),
+        ResolvedExpr::RecordUpdate { base, updates, .. } => {
+            resolved_expr_contains_error_prop(base)
+                || updates
+                    .iter()
+                    .any(|(_, value)| resolved_expr_contains_error_prop(value))
+        }
+        ResolvedExpr::TailCall { args, .. } => args.iter().any(resolved_expr_contains_error_prop),
+        ResolvedExpr::Literal(_) | ResolvedExpr::Ident(_) | ResolvedExpr::Resolved { .. } => false,
     }
 }
 

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -59,6 +59,7 @@ fn empty_ctx() -> CodegenContext {
         resolved_fn_defs: Vec::new(),
         resolved_module_fn_defs: Vec::new(),
         current_module_scope: std::cell::RefCell::new(None),
+        lean_do_block: std::cell::Cell::new(false),
         resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
         program_shape: None,
         mir_program: None,
@@ -144,6 +145,106 @@ fn generated_lean_file(out: &crate::codegen::ProjectOutput) -> String {
         })
         .collect::<Vec<&str>>()
         .join("\n")
+}
+
+#[test]
+fn nested_error_prop_lowers_to_monadic_bind_not_with_default() {
+    let mut ctx = ctx_from_source(
+        r#"
+module Nested
+    effects []
+
+fn addOne(x: Int) -> Int
+    x + 1
+
+fn boundForm(n: Int, d: Int) -> Result<Int, String>
+    ? "Propagate division errors before adding one."
+    q = Int.div(n, d)?
+    Result.Ok(addOne(q))
+
+fn nestedArg(n: Int, d: Int) -> Result<Int, String>
+    ? "Propagate division errors from a nested argument."
+    Result.Ok(addOne(Int.div(n, d)?))
+"#,
+        "Nested",
+    );
+    let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
+    let lean = generated_lean_file(&out);
+    let nested_arg = lean
+        .split_once("def nestedArg")
+        .map(|(_, body)| body)
+        .expect("nestedArg definition should be emitted");
+
+    assert!(
+        nested_arg.contains("(<- "),
+        "nested `?` must lower to a monadic bind:\n{lean}"
+    );
+    assert!(
+        !lean.contains("withDefault default"),
+        "function-body `?` must not swallow errors:\n{lean}"
+    );
+    assert!(
+        lean.contains("| .ok q =>")
+            && lean.contains("| .error __qm_err_0 => Except.error __qm_err_0"),
+        "statement-level `?` lowering must retain its short-circuiting match:\n{lean}"
+    );
+}
+
+#[test]
+fn nested_error_prop_in_match_arm_monadifies_the_branch() {
+    let mut ctx = ctx_from_source(
+        r#"
+module NestedMatch
+    effects []
+
+fn divL(n: Int, d: Int) -> Result<Int, String>
+    ? "Return a labeled error for a zero divisor."
+    match d == 0
+        true -> Result.Err("left")
+        false -> Result.Ok(Int.div(n, d)?)
+"#,
+        "NestedMatch",
+    );
+    let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
+    let lean = generated_lean_file(&out);
+
+    assert!(
+        lean.contains("(<- (do"),
+        "a `?` inside a match arm needs a nested monadic action:\n{lean}"
+    );
+    assert!(
+        !lean.contains("withDefault default"),
+        "match-arm `?` must not swallow errors:\n{lean}"
+    );
+}
+
+#[test]
+fn error_prop_in_verify_case_keeps_with_default_lowering() {
+    let mut ctx = ctx_from_source(
+        r#"
+module VerifyFallback
+    effects []
+
+fn addOne(x: Int) -> Int
+    x + 1
+
+fn quotient(n: Int, d: Int) -> Result<Int, String>
+    ? "Divide two integers."
+    Int.div(n, d)
+
+verify quotient
+    addOne(quotient(10, 2)?) => 6
+"#,
+        "VerifyFallback",
+    );
+    let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
+    let lean = generated_lean_file(&out);
+
+    assert!(
+        lean.lines()
+            .any(|line| line.starts_with("example :") && line.contains(".withDefault default")),
+        "verify-case emission must retain its non-`do` fallback:\n{lean}"
+    );
 }
 
 fn empty_ctx_with_verify_case() -> CodegenContext {

--- a/src/codegen/lean/toplevel/fn_def.rs
+++ b/src/codegen/lean/toplevel/fn_def.rs
@@ -548,9 +548,11 @@ fn emit_fn_body(body: &FnBody, ctx: &CodegenContext) -> String {
 fn emit_fn_body_result_do(body: &FnBody, ctx: &CodegenContext) -> String {
     let stmts = body.stmts();
     let mut lines = vec!["  do".to_string()];
-    for (i, stmt) in stmts.iter().enumerate() {
-        lines.push(emit_do_stmt(stmt, ctx, i == stmts.len() - 1));
-    }
+    ctx.with_lean_do_block(true, || {
+        for (i, stmt) in stmts.iter().enumerate() {
+            lines.push(emit_do_stmt(stmt, ctx, i == stmts.len() - 1));
+        }
+    });
     lines.join("\n")
 }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -291,6 +291,11 @@ pub struct CodegenContext {
     /// Empty by default. Set with [`Self::with_module_scope`] in a
     /// scoped manner.
     pub current_module_scope: std::cell::RefCell<Option<String>>,
+    /// Whether the Lean emitter is currently rendering a function body inside
+    /// a `do` block. This scopes `?` emission: nested error propagation uses a
+    /// monadic bind only where Lean has a surrounding action to lift it into,
+    /// while verify cases and law statements keep their non-`do` fallback.
+    pub lean_do_block: std::cell::Cell<bool>,
     /// Per-dep resolved fn defs, parallel to `modules`.
     ///
     /// **Compatibility projection of `resolved_program.modules[i].fn_defs`**
@@ -687,6 +692,7 @@ pub fn build_context(
         resolved_fn_defs,
         resolved_module_fn_defs,
         current_module_scope: std::cell::RefCell::new(None),
+        lean_do_block: std::cell::Cell::new(false),
         program_shape,
         resolved_program,
         mir_program,
@@ -717,6 +723,14 @@ impl CodegenContext {
             .replace(scope.map(|s| s.to_string()));
         let out = f();
         *self.current_module_scope.borrow_mut() = prev;
+        out
+    }
+
+    /// Set the Lean `do`-block emission mode for the duration of `f`.
+    pub fn with_lean_do_block<R>(&self, on: bool, f: impl FnOnce() -> R) -> R {
+        let prev = self.lean_do_block.replace(on);
+        let out = f();
+        self.lean_do_block.set(prev);
         out
     }
 

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -1486,6 +1486,7 @@ mod tests {
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            lean_do_block: std::cell::Cell::new(false),
             resolved_program: crate::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -10308,6 +10308,7 @@ Dafny program verifier finished with 158 verified, 2 errors, 12 time outs";
             resolved_fn_defs: Vec::new(),
             resolved_module_fn_defs: Vec::new(),
             current_module_scope: std::cell::RefCell::new(None),
+            lean_do_block: std::cell::Cell::new(false),
             resolved_program: aver::codegen::program_view::ResolvedProgramView::default(),
             program_shape: None,
             mir_program: None,

--- a/tests/proof_spec/lean_kernel.rs
+++ b/tests/proof_spec/lean_kernel.rs
@@ -1,6 +1,137 @@
 use super::*;
 
 #[test]
+fn proof_lean_nested_question_mark_agrees_with_bound_form_on_error_path() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping nested question-mark test: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-nested-question-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("m.av"),
+        r#"module NestedQuestion
+    intent = "Exercise error propagation in every nested expression position."
+    effects []
+
+fn addOne(x: Int) -> Int
+    x + 1
+
+fn divL(n: Int, d: Int) -> Result<Int, String>
+    ? "Divide or return the left-side error."
+    match d == 0
+        true -> Result.Err("left")
+        false -> Result.Ok(Int.div(n, d)?)
+
+fn divR(n: Int, d: Int) -> Result<Int, String>
+    ? "Divide or return the right-side error."
+    match d == 0
+        true -> Result.Err("right")
+        false -> Result.Ok(Int.div(n, d)?)
+
+fn boundForm(n: Int, d: Int) -> Result<Int, String>
+    ? "Propagate a division error from a binding."
+    q = Int.div(n, d)?
+    Result.Ok(addOne(q))
+
+fn nestedArg(n: Int, d: Int) -> Result<Int, String>
+    ? "Propagate a division error from a call argument."
+    Result.Ok(addOne(Int.div(n, d)?))
+
+fn twoNested(n: Int, d: Int, e: Int) -> Result<Int, String>
+    ? "Propagate the first error from two operands."
+    Result.Ok(divL(n, d)? + divR(n, e)?)
+
+fn inInterp(n: Int, d: Int) -> Result<String, String>
+    ? "Propagate an error from string interpolation."
+    Result.Ok("q={divL(n, d)?}")
+
+fn inBinding(n: Int, d: Int) -> Result<Int, String>
+    ? "Propagate an error nested in a binding expression."
+    q = divL(n, d)? + 1
+    Result.Ok(q)
+
+fn scalarArm(n: Int, d: Int, b: Bool) -> Result<Int, String>
+    ? "Propagate an error from an integer-valued match arm."
+    x = match b
+        true -> divL(n, d)?
+        false -> 0
+    Result.Ok(x + 1)
+
+verify boundForm
+    boundForm(10, 2) => Result.Ok(6)
+    boundForm(10, 0) => Result.Err("division by zero")
+
+verify nestedArg
+    nestedArg(10, 2) => Result.Ok(6)
+    nestedArg(10, 0) => Result.Err("division by zero")
+
+verify twoNested
+    twoNested(10, 2, 5) => Result.Ok(7)
+    twoNested(10, 0, 0) => Result.Err("left")
+    twoNested(10, 5, 0) => Result.Err("right")
+
+verify inInterp
+    inInterp(10, 2) => Result.Ok("q=5")
+    inInterp(10, 0) => Result.Err("left")
+
+verify inBinding
+    inBinding(10, 2) => Result.Ok(6)
+    inBinding(10, 0) => Result.Err("left")
+
+verify scalarArm
+    scalarArm(10, 2, true) => Result.Ok(6)
+    scalarArm(10, 0, true) => Result.Err("left")
+    scalarArm(10, 0, false) => Result.Ok(1)
+"#,
+    )
+    .expect("write m.av");
+    let out = temp_output_dir("aver-nested-question-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected `aver proof --check --check-json` to run");
+    let lean =
+        std::fs::read_to_string(out.join("NestedQuestion.lean")).expect("read NestedQuestion.lean");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|line| {
+            std::str::from_utf8(line)
+                .ok()
+                .filter(|text| text.starts_with('{'))
+        })
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).unwrap_or_else(|e| panic!("bad JSON ({e}):\n{json_line}"));
+
+    assert_eq!(
+        (
+            summary["passed"].as_bool(),
+            summary["build_errors"].as_u64(),
+        ),
+        (Some(true), Some(0)),
+        "nested `?` error paths must agree with the bound form in Lean:\n{}",
+        format_output(&run)
+    );
+    assert!(
+        !lean.contains("withDefault default"),
+        "function-body `?` must use short-circuiting binds:\n{lean}"
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
 fn proof_lean_peano_lift_nat_arith_kernel_clean() {
     // Proof-only Peano representation lift: a canonical `type Nat { Z; S(Nat) }`
     // is emitted as Lean's builtin `Nat` (no `inductive`, `Z`→`0`, `S(x)`→`x+1`,


### PR DESCRIPTION
Closes #819.

The Lean proof export lowered `?` two different ways depending on syntactic position. In binding position (`q = Int.div(n, d)?`) it emitted a short-circuiting `match`. Nested inside an expression (`addOne(Int.div(n, d)?)`) it emitted `((...).withDefault default)`, which discards the error, substitutes `Inhabited.default` and continues — so the exported model was a different function from the source on every error path, and the kernel would prove statements about it.

## What changed

`ErrorProp` now lowers to a monadic bind `(<- inner)` while a scoped emit-mode flag says we are inside a Result `do` block. Because Lean cannot lift a nested action over a binder or into a term-position `if`, any `match` or `if` whose arm bodies contain a `?` is monadified — each arm becomes `(do pure ...)` and the construct is wrapped in `(<- (do ...))`. That is one rule, needs no type information, and handles the case where an arm's type is `Int` rather than `Result`.

Outside a `do` block — verify cases and law statements — the previous lowering is retained deliberately. Those are not `do` contexts, and a bind emitted there is a hard elaboration error. This keeps the two green proof projects green, and the smaller hole it leaves is filed separately as #827.

## Evidence

Before, with both spellings carrying the same two verify cases, Lean rejected the export:

```
error: Tactic `decide` proved that the proposition
  nestedArg 10 0 = Except.error "division by zero"
is false
```

After, the same file exports `Except.ok (addOne (<- (...)))` and builds clean, with the error-path case passing.

Measured against a 2000-line external project that uses the shape heavily: 63 function-body sites before, 0 after. The 53 remaining `withDefault default` occurrences in that corpus are all inside `example :` verify-case lines, which is the deliberate boundary above.

The in-repo corpus was never affected — exporting all 114 files under `examples/` and `stdlib/` yields four `withDefault default` occurrences, all verify cases. That is why no existing test covered this.

## Tests

Three emitter unit tests (bind emitted in a `do` body; a match arm monadified; a verify case keeping the old lowering — the guard against the fix leaking out of scope) and one kernel-gated regression covering the binding form, a nested call argument, two `?` in one expression with left-to-right first-error ordering, interpolation, a non-tail binding, a `?` inside a match arm, and an arm whose type is not a `Result`. The kernel test fails on `main` and passes here.

Full suite: 3158 passed, 25 skipped. Lake-gated tests ran rather than skipped.

Dafny has the same class but fails loud rather than silent, so it is out of scope here and filed as #825.
