### PR TITLE
Size certification lanes from measured runtime

### DIFF
--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -38,6 +38,16 @@ jobs:
     # prefix out. A model or fixture added to the lists inside a suite lands in
     # an existing shard test, so these lanes never need editing for coverage —
     # only to add throughput.
+    #
+    # Lane counts are sized from measured wall-clock, not from test counts:
+    # slice partitioning splits by name, so equal slices are not equal work.
+    # The budget that matters is the runner pool, which caps concurrency at 20
+    # for the whole repository — CI and Proof draw from the same pool, so lanes
+    # past that cap do not shorten the run, they only push the other workflows
+    # further back in the queue. Splitting a family finer than its share of the
+    # pool costs more than it saves. Re-measure before changing a count: the
+    # useful figure is each lane's duration, and the target is that no lane is
+    # much longer than the total kernel time divided by the lane count.
     name: Cert Kernel (${{ matrix.suite }}${{ matrix.lane && format(' {0}', matrix.lane) || '' }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -71,25 +81,10 @@ jobs:
             filter: 'test(/^cert_hostile_model_/)'
             partition: 5/5
           - suite: cert_certify_spec
-            lane: adt-witnesses-1/4
+            lane: adt-witnesses
             mode: nextest
             filter: 'test(/^cert_adt_witness_/)'
-            partition: 1/4
-          - suite: cert_certify_spec
-            lane: adt-witnesses-2/4
-            mode: nextest
-            filter: 'test(/^cert_adt_witness_/)'
-            partition: 2/4
-          - suite: cert_certify_spec
-            lane: adt-witnesses-3/4
-            mode: nextest
-            filter: 'test(/^cert_adt_witness_/)'
-            partition: 3/4
-          - suite: cert_certify_spec
-            lane: adt-witnesses-4/4
-            mode: nextest
-            filter: 'test(/^cert_adt_witness_/)'
-            partition: 4/4
+            partition: 1/1
           - suite: cert_certify_spec
             lane: rest
             mode: nextest
@@ -105,33 +100,25 @@ jobs:
             lane: ''
             mode: cargo
           - suite: cert_whole_module_guard_iso
-            lane: ''
-            mode: cargo
+            lane: 1/2
+            mode: nextest
+            filter: 'all()'
+            partition: 1/2
+          - suite: cert_whole_module_guard_iso
+            lane: 2/2
+            mode: nextest
+            filter: 'all()'
+            partition: 2/2
           - suite: cert_verify_spec
-            lane: tripwires-1/5
+            lane: tripwires-1/2
             mode: nextest
             filter: 'test(/^cert_tripwire_/)'
-            partition: 1/5
+            partition: 1/2
           - suite: cert_verify_spec
-            lane: tripwires-2/5
+            lane: tripwires-2/2
             mode: nextest
             filter: 'test(/^cert_tripwire_/)'
-            partition: 2/5
-          - suite: cert_verify_spec
-            lane: tripwires-3/5
-            mode: nextest
-            filter: 'test(/^cert_tripwire_/)'
-            partition: 3/5
-          - suite: cert_verify_spec
-            lane: tripwires-4/5
-            mode: nextest
-            filter: 'test(/^cert_tripwire_/)'
-            partition: 4/5
-          - suite: cert_verify_spec
-            lane: tripwires-5/5
-            mode: nextest
-            filter: 'test(/^cert_tripwire_/)'
-            partition: 5/5
+            partition: 2/2
           - suite: cert_verify_spec
             lane: plans-authority-1/3
             mode: nextest
@@ -148,45 +135,50 @@ jobs:
             filter: 'test(/^cert_plans_authority_/)'
             partition: 3/3
           - suite: cert_verify_spec
-            lane: rest-1/8
+            lane: rest-1/9
             mode: nextest
             filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
-            partition: 1/8
+            partition: 1/9
           - suite: cert_verify_spec
-            lane: rest-2/8
+            lane: rest-2/9
             mode: nextest
             filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
-            partition: 2/8
+            partition: 2/9
           - suite: cert_verify_spec
-            lane: rest-3/8
+            lane: rest-3/9
             mode: nextest
             filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
-            partition: 3/8
+            partition: 3/9
           - suite: cert_verify_spec
-            lane: rest-4/8
+            lane: rest-4/9
             mode: nextest
             filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
-            partition: 4/8
+            partition: 4/9
           - suite: cert_verify_spec
-            lane: rest-5/8
+            lane: rest-5/9
             mode: nextest
             filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
-            partition: 5/8
+            partition: 5/9
           - suite: cert_verify_spec
-            lane: rest-6/8
+            lane: rest-6/9
             mode: nextest
             filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
-            partition: 6/8
+            partition: 6/9
           - suite: cert_verify_spec
-            lane: rest-7/8
+            lane: rest-7/9
             mode: nextest
             filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
-            partition: 7/8
+            partition: 7/9
           - suite: cert_verify_spec
-            lane: rest-8/8
+            lane: rest-8/9
             mode: nextest
             filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
-            partition: 8/8
+            partition: 8/9
+          - suite: cert_verify_spec
+            lane: rest-9/9
+            mode: nextest
+            filter: 'not (test(/^cert_tripwire_/) or test(/^cert_plans_authority_/))'
+            partition: 9/9
     env:
       CARGO_BUILD_JOBS: '2'
       CARGO_INCREMENTAL: '0'


### PR DESCRIPTION
Certification took ~25 minutes of wall clock. Almost all of it was one lane.

## Measurement

From the last full run on `main` (30 lanes, 330 CPU-minutes total):

| lane family | lanes | total | slowest lane |
|---|---|---|---|
| `cert_verify_spec rest` | 8 | 135.0m | **24.8m** |
| `cert_certify_spec hostile-models` | 5 | 76.4m | 20.2m |
| `cert_verify_spec plans-authority` | 3 | 36.1m | 13.6m |
| `cert_verify_spec tripwires` | 5 | 23.5m | 6.5m |
| `cert_whole_module_guard_iso` | 1 | 21.0m | **21.0m** |
| `cert_certify_spec rest` | 1 | 15.9m | 15.9m |
| `cert_certify_spec adt-witnesses` | 4 | 14.8m | 4.5m |
| `cert_decode_spec` | 1 | 5.5m | 5.5m |
| `cert_intcmp_differential` | 1 | 1.2m | 1.2m |
| `cert_toindex_differential` | 1 | 1.0m | 1.0m |

Slice partitioning splits by test name, so equal slices are not equal work. The mean lane was 11.0 minutes and the slowest was 24.8, and that one lane set the run's wall clock. At the other end, two lanes finished in about a minute.

## Change

Each family is now sized from its measured total rather than from a round number. The two dominant families gain lanes; four cheap ones give lanes back. `cert_whole_module_guard_iso` moves from an unsharded `cargo test` to two nextest slices — at 21 minutes it was a lane nothing could overlap with.

| family | lanes | per lane after |
|---|---|---|
| `cert_verify_spec rest` | 8 → 9 | ~15.0m |
| `cert_certify_spec hostile-models` | 5 → 5 | ~15.3m |
| `cert_verify_spec plans-authority` | 3 → 3 | ~12.0m |
| `cert_verify_spec tripwires` | 5 → 2 | ~11.8m |
| `cert_whole_module_guard_iso` | 1 → 2 | ~10.5m |
| `cert_certify_spec adt-witnesses` | 4 → 1 | ~14.8m |
| others | unchanged | |

Lane count 30 → 26, longest lane 24.8m → ~16m.

## Coverage is unchanged

No test is dropped, skipped or moved out of the pull-request gate. Every filter and its complement remain disjoint and exhaustive. For the one suite that changed harness, this was checked directly:

```
partition 1/2: 8 tests
partition 2/2: 8 tests
unpartitioned: 16 tests
```

## Why not split finer

The runner pool caps concurrency at 20 for the whole repository, and it was saturated for the first 13 minutes of the measured run. CI and Proof draw from the same pool — CI's four jobs did 6.4 minutes of work but waited 9 minutes for a slot. Lanes past the cap do not shorten this workflow, they push the others further back. The floor for the current suite against a 20-runner pool is about 18 minutes of wall clock; going below that needs less kernel work or more runners, not more lanes.

The only behavioural risk here is the `cargo test` → nextest move for `cert_whole_module_guard_iso`, which runs each test in its own process rather than a thread. That is strictly more isolation than before, and the suite already ran its tests concurrently. If it turns out flaky, revert that family alone.
