### PR TITLE
Fix the inverted Disk allowlist root-pattern semantics

### DIFF
--- a/.claude/commands/aver-tooling.md
+++ b/.claude/commands/aver-tooling.md
@@ -326,3 +326,14 @@ reason = "Tree-walking interpreter — CPS would destroy correspondence."
 ```
 
 Effect-host / path / key allowlists narrow which hosts, files, and env keys the runtime will admit. `[[check.suppress]]` lets a project waive specific lint slugs in specific paths with a reason.
+
+Disk path patterns have deliberately small, explicit semantics:
+
+| Pattern | Meaning |
+|---|---|
+| `path` or `path/**` | That path and its entire subtree |
+| `.`, `./`, or `./**` | The project-relative subtree |
+| `/` or `/**` | Every absolute path from the filesystem root |
+| `**` | Invalid; use `./**` or `/**` to state the intended boundary |
+
+An empty pattern, unsupported `*` placement, or a `..`-rooted pattern is also a config-load error. An absent `paths` key or `paths = []` keeps the existing allow-all behavior. Matching is string-only: Aver normalizes `.` and `..` in the caller-supplied path without resolving it against the working directory or touching the filesystem. A project-relative pattern therefore does not admit an absolute spelling of the same in-project file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
+- **Disk allowlists now honor explicit project and filesystem roots.** `paths = ["./**"]` now allows relative paths inside the project and denies absolute paths outside it, while `/` and `/**` allow absolute paths from the filesystem root. Bare `**`, empty entries, unsupported glob spellings, and `..`-rooted paths are rejected when `aver.toml` loads, as are non-matching `*`/`**` host entries and `**` environment-key entries.
 - **Lean proof exports preserve `?` error propagation inside nested expressions.** Proofs can now rely on calls, operators, interpolation, bindings, and match arms returning the original `Result.Err` instead of continuing with a default value.
 
 ## 0.28.0 "Oktet" — 2026-08-10

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ paths = ["./data/**"]
 keys = ["APP_*", "PUBLIC_*"]
 ```
 
+Disk paths accept concrete subtrees, `./**` for the project-relative subtree, and `/**` for the filesystem root. Bare `**`, empty entries, unsupported glob spellings, and `..`-rooted entries are rejected when `aver.toml` loads; see [the CLI reference](docs/cli.md#avertoml) for the full grammar and string-only matching limitation.
+
 Think of this as two separate controls:
 
 - code answers: what kind of I/O is allowed?

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -331,3 +331,14 @@ reason = "Tree-walking interpreter — CPS would destroy correspondence."
 ```
 
 Effect-host / path / key allowlists narrow which hosts, files, and env keys the runtime will admit. `[[check.suppress]]` lets a project waive specific lint slugs in specific paths with a reason.
+
+Disk path patterns have deliberately small, explicit semantics:
+
+| Pattern | Meaning |
+|---|---|
+| `path` or `path/**` | That path and its entire subtree |
+| `.`, `./`, or `./**` | The project-relative subtree |
+| `/` or `/**` | Every absolute path from the filesystem root |
+| `**` | Invalid; use `./**` or `/**` to state the intended boundary |
+
+An empty pattern, unsupported `*` placement, or a `..`-rooted pattern is also a config-load error. An absent `paths` key or `paths = []` keeps the existing allow-all behavior. Matching is string-only: Aver normalizes `.` and `..` in the caller-supplied path without resolving it against the working directory or touching the filesystem. A project-relative pattern therefore does not admit an absolute spelling of the same in-project file.

--- a/src/codegen/rust/policy.rs
+++ b/src/codegen/rust/policy.rs
@@ -178,17 +178,36 @@ const POLICY_TEMPLATE: &str = r#"pub mod aver_policy {
     }
 
     fn path_matches(normalized: &str, pattern: &str) -> bool {
-        let clean_pattern = normalize_path(pattern.strip_suffix("/**").unwrap_or(pattern));
-        if normalized == clean_pattern {
-            return true;
+        if pattern.is_empty() || pattern == "**" {
+            return false;
         }
-        if normalized.starts_with(&clean_pattern) {
-            let rest = &normalized[clean_pattern.len()..];
-            if rest.starts_with('/') {
-                return true;
-            }
+
+        let body = match pattern.strip_suffix("/**") {
+            Some("") => "/",
+            Some(base) => base,
+            None => pattern,
+        };
+        if body.contains('*') {
+            return false;
         }
-        false
+
+        let base = normalize_path(body);
+        if base.is_empty() {
+            return !normalized.starts_with('/')
+                && normalized != ".."
+                && !normalized.starts_with("../");
+        }
+        if base == "/" {
+            return normalized.starts_with('/');
+        }
+        if base == ".." || base.starts_with("../") {
+            return false;
+        }
+
+        normalized == base
+            || (normalized.len() > base.len()
+                && normalized.starts_with(&base)
+                && normalized.as_bytes()[base.len()] == b'/')
     }
 
     fn env_key_matches(key: &str, pattern: &str) -> bool {
@@ -203,3 +222,14 @@ const POLICY_TEMPLATE: &str = r#"pub mod aver_policy {
     }
 }
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::POLICY_TEMPLATE;
+
+    #[test]
+    fn policy_template_mirrors_project_root_semantics() {
+        assert!(POLICY_TEMPLATE.contains("if pattern.is_empty() || pattern == \"**\""));
+        assert!(POLICY_TEMPLATE.contains("Some(\"\") => \"/\""));
+    }
+}

--- a/src/codegen/rust/replay.rs
+++ b/src/codegen/rust/replay.rs
@@ -440,12 +440,24 @@ const RUNTIME_POLICY_CHECK_SNIPPET: &str = r#"    #[derive(Clone, Debug, Default
                     let section = value
                         .as_table()
                         .ok_or_else(|| format!("aver.toml: [effects.{}] must be a table", name))?;
+                    let hosts = parse_policy_list(section, "hosts", name)?;
+                    for (index, host) in hosts.iter().enumerate() {
+                        validate_host_pattern(name, index, host)?;
+                    }
+                    let paths = parse_policy_list(section, "paths", name)?;
+                    for (index, path) in paths.iter().enumerate() {
+                        validate_path_pattern(name, index, path)?;
+                    }
+                    let keys = parse_policy_list(section, "keys", name)?;
+                    for (index, key) in keys.iter().enumerate() {
+                        validate_env_key_pattern(name, index, key)?;
+                    }
                     effect_policies.insert(
                         name.clone(),
                         RuntimeEffectPolicy {
-                            hosts: parse_policy_list(section, "hosts", name)?,
-                            paths: parse_policy_list(section, "paths", name)?,
-                            keys: parse_policy_list(section, "keys", name)?,
+                            hosts,
+                            paths,
+                            keys,
                         },
                     );
                 }
@@ -572,6 +584,58 @@ const RUNTIME_POLICY_CHECK_SNIPPET: &str = r#"    #[derive(Clone, Debug, Default
             .collect()
     }
 
+    fn validate_path_pattern(effect: &str, index: usize, raw: &str) -> Result<(), String> {
+        let prefix = format!("aver.toml: [effects.{effect}].paths[{index}]");
+        if raw.is_empty() {
+            return Err(format!(
+                "{prefix} is empty; use \".\" for the project directory or \"/\" for the filesystem root"
+            ));
+        }
+        if raw == "**" {
+            return Err(format!(
+                "{prefix} is ambiguous: '**'; use \"./**\" for the project subtree or \"/**\" for the filesystem root"
+            ));
+        }
+
+        let body = match raw.strip_suffix("/**") {
+            Some("") => "/",
+            Some(base) => base,
+            None => raw,
+        };
+        if body.contains('*') {
+            return Err(format!(
+                "{prefix} contains an unsupported glob '{raw}'; only a trailing \"/**\" is supported (for example, \"./data/**\")"
+            ));
+        }
+
+        let base = normalize_path(body);
+        if base == ".." || base.starts_with("../") {
+            return Err(format!(
+                "{prefix} escapes the project directory: '{raw}'; use an absolute pattern (for example, \"/srv/data/**\") to allow files outside the project"
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_host_pattern(effect: &str, index: usize, raw: &str) -> Result<(), String> {
+        if raw == "*" || raw == "**" {
+            return Err(format!(
+                "aver.toml: [effects.{effect}].hosts[{index}] contains an unsupported wildcard '{raw}'; use an exact host or a subdomain wildcard such as \"*.example.com\""
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_env_key_pattern(effect: &str, index: usize, raw: &str) -> Result<(), String> {
+        if raw == "**" {
+            return Err(format!(
+                "aver.toml: [effects.{effect}].keys[{index}] contains an unsupported wildcard '**'; use \"*\" for every key or a prefix wildcard such as \"APP_*\""
+            ));
+        }
+        Ok(())
+    }
+
     fn check_policy(effect_type: &str, args: &[ReplayJson]) {
         let policy = SCOPE_STATE.with(|cell| match &*cell.borrow() {
             ScopeState::Inactive => None,
@@ -657,17 +721,36 @@ const RUNTIME_POLICY_CHECK_SNIPPET: &str = r#"    #[derive(Clone, Debug, Default
     }
 
     fn path_matches(normalized: &str, pattern: &str) -> bool {
-        let clean_pattern = normalize_path(pattern.strip_suffix("/**").unwrap_or(pattern));
-        if normalized == clean_pattern {
-            return true;
+        if pattern.is_empty() || pattern == "**" {
+            return false;
         }
-        if normalized.starts_with(&clean_pattern) {
-            let rest = &normalized[clean_pattern.len()..];
-            if rest.starts_with('/') {
-                return true;
-            }
+
+        let body = match pattern.strip_suffix("/**") {
+            Some("") => "/",
+            Some(base) => base,
+            None => pattern,
+        };
+        if body.contains('*') {
+            return false;
         }
-        false
+
+        let base = normalize_path(body);
+        if base.is_empty() {
+            return !normalized.starts_with('/')
+                && normalized != ".."
+                && !normalized.starts_with("../");
+        }
+        if base == "/" {
+            return normalized.starts_with('/');
+        }
+        if base == ".." || base.starts_with("../") {
+            return false;
+        }
+
+        normalized == base
+            || (normalized.len() > base.len()
+                && normalized.starts_with(&base)
+                && normalized.as_bytes()[base.len()] == b'/')
     }
 
     fn env_key_matches(key: &str, pattern: &str) -> bool {
@@ -680,6 +763,24 @@ const RUNTIME_POLICY_CHECK_SNIPPET: &str = r#"    #[derive(Clone, Debug, Default
             false
         }
     }"#;
+
+#[cfg(test)]
+mod policy_tests {
+    use super::RUNTIME_POLICY_CHECK_SNIPPET;
+
+    #[test]
+    fn runtime_policy_snippet_mirrors_project_root_semantics() {
+        assert!(
+            RUNTIME_POLICY_CHECK_SNIPPET.contains("if pattern.is_empty() || pattern == \"**\"")
+        );
+        assert!(RUNTIME_POLICY_CHECK_SNIPPET.contains("Some(\"\") => \"/\""));
+        assert!(RUNTIME_POLICY_CHECK_SNIPPET.contains("validate_path_pattern(name, index, path)"));
+        assert!(RUNTIME_POLICY_CHECK_SNIPPET.contains("validate_host_pattern(name, index, host)"));
+        assert!(
+            RUNTIME_POLICY_CHECK_SNIPPET.contains("validate_env_key_pattern(name, index, key)")
+        );
+    }
+}
 
 const REPLAY_RUNTIME_TEMPLATE: &str = r#"pub mod aver_replay {
     use std::cell::RefCell;

--- a/src/config.rs
+++ b/src/config.rs
@@ -745,6 +745,47 @@ fn glob_match_recursive(path: &[u8], pattern: &[u8]) -> bool {
 mod tests {
     use super::*;
 
+    /// The path matcher is duplicated into every artifact that enforces a
+    /// policy without linking this crate: the two generated-Rust templates and
+    /// the self-hosted replay support. A fix applied only here would still ship
+    /// a compiler that emits the old behaviour into user projects, which is how
+    /// the inverted `./**` semantics survived. Each copy is checked for the
+    /// three decisions that define the semantics rather than for byte equality,
+    /// so the copies may differ in formatting but not in meaning.
+    #[test]
+    fn path_matcher_copies_agree_on_root_pattern_semantics() {
+        const MARKERS: [(&str, &str); 3] = [
+            (r#"pattern == "**""#, "bare `**` is refused, never allow-all"),
+            (r#"Some("") => "/""#, "a bare trailing `/**` means the filesystem root"),
+            (r#"base == "/""#, "the root base admits absolute paths only"),
+        ];
+        let copies: [(&str, &str); 4] = [
+            ("src/config.rs", include_str!("config.rs")),
+            (
+                "src/codegen/rust/policy.rs",
+                include_str!("codegen/rust/policy.rs"),
+            ),
+            (
+                "src/codegen/rust/replay.rs",
+                include_str!("codegen/rust/replay.rs"),
+            ),
+            (
+                "src/self_host/replay_support.rs",
+                include_str!("self_host/replay_support.rs"),
+            ),
+        ];
+        for (name, body) in copies {
+            for (marker, meaning) in MARKERS {
+                assert!(
+                    body.contains(marker),
+                    "{name} is missing `{marker}` — {meaning}. \
+                     Every copy of path_matches must carry the same decisions; \
+                     update all of them together."
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_parse_empty_toml() {
         let config = ProjectConfig::parse("").unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,9 @@ use std::path::Path;
 pub struct EffectPolicy {
     /// Allowed HTTP hosts (exact or wildcard `*.domain`).
     pub hosts: Vec<String>,
-    /// Allowed filesystem paths (exact or recursive `/**`).
+    /// Allowed filesystem paths. Concrete paths and `<path>/**` include the
+    /// same subtree; `.`, `./`, and `./**` mean the project-relative subtree,
+    /// while `/` and `/**` mean the filesystem root.
     pub paths: Vec<String>,
     /// Allowed environment variable keys (exact or wildcard `PREFIX_*`).
     pub keys: Vec<String>,
@@ -144,6 +146,9 @@ impl ProjectConfig {
                 } else {
                     Vec::new()
                 };
+                for (index, host) in hosts.iter().enumerate() {
+                    validate_host_pattern(name, index, host)?;
+                }
 
                 let paths = if let Some(val) = section.get("paths") {
                     let arr = val.as_array().ok_or_else(|| {
@@ -163,6 +168,9 @@ impl ProjectConfig {
                 } else {
                     Vec::new()
                 };
+                for (index, path) in paths.iter().enumerate() {
+                    validate_path_pattern(name, index, path)?;
+                }
 
                 let keys = if let Some(val) = section.get("keys") {
                     let arr = val.as_array().ok_or_else(|| {
@@ -182,6 +190,9 @@ impl ProjectConfig {
                 } else {
                     Vec::new()
                 };
+                for (index, key) in keys.iter().enumerate() {
+                    validate_env_key_pattern(name, index, key)?;
+                }
 
                 effect_policies.insert(name.clone(), EffectPolicy { hosts, paths, keys });
             }
@@ -383,30 +394,93 @@ fn normalize_path(path: &str) -> String {
 }
 
 /// Check if a normalized path matches an allowed pattern.
-/// Supports:
-///   - Exact prefix match: "./data" matches "./data" and "./data/file.txt"
-///   - Recursive glob: "./data/**" matches everything under ./data/
+/// Concrete paths and `<path>/**` include the same subtree. `.`, `./`, and
+/// `./**` match the project-relative subtree; `/` and `/**` match absolute
+/// paths from the filesystem root. Other `*` forms and `..`-rooted patterns
+/// never match.
 fn path_matches(normalized: &str, pattern: &str) -> bool {
-    let clean_pattern = if let Some(base) = pattern.strip_suffix("/**") {
-        normalize_path(base)
-    } else {
-        normalize_path(pattern)
+    if pattern.is_empty() || pattern == "**" {
+        return false;
+    }
+
+    let body = match pattern.strip_suffix("/**") {
+        Some("") => "/",
+        Some(base) => base,
+        None => pattern,
     };
-
-    // The path must start with the allowed base
-    if normalized == clean_pattern {
-        return true;
+    if body.contains('*') {
+        return false;
     }
 
-    // Check if it's under the allowed directory
-    if normalized.starts_with(&clean_pattern) {
-        let rest = &normalized[clean_pattern.len()..];
-        if rest.starts_with('/') {
-            return true;
-        }
+    let base = normalize_path(body);
+    if base.is_empty() {
+        return !normalized.starts_with('/')
+            && normalized != ".."
+            && !normalized.starts_with("../");
+    }
+    if base == "/" {
+        return normalized.starts_with('/');
+    }
+    if base == ".." || base.starts_with("../") {
+        return false;
     }
 
-    false
+    normalized == base
+        || (normalized.len() > base.len()
+            && normalized.starts_with(&base)
+            && normalized.as_bytes()[base.len()] == b'/')
+}
+
+fn validate_path_pattern(effect: &str, index: usize, raw: &str) -> Result<(), String> {
+    let prefix = format!("aver.toml: [effects.{effect}].paths[{index}]");
+    if raw.is_empty() {
+        return Err(format!(
+            "{prefix} is empty; use \".\" for the project directory or \"/\" for the filesystem root"
+        ));
+    }
+    if raw == "**" {
+        return Err(format!(
+            "{prefix} is ambiguous: '**'; use \"./**\" for the project subtree or \"/**\" for the filesystem root"
+        ));
+    }
+
+    let body = match raw.strip_suffix("/**") {
+        Some("") => "/",
+        Some(base) => base,
+        None => raw,
+    };
+    if body.contains('*') {
+        return Err(format!(
+            "{prefix} contains an unsupported glob '{raw}'; only a trailing \"/**\" is supported (for example, \"./data/**\")"
+        ));
+    }
+
+    let base = normalize_path(body);
+    if base == ".." || base.starts_with("../") {
+        return Err(format!(
+            "{prefix} escapes the project directory: '{raw}'; use an absolute pattern (for example, \"/srv/data/**\") to allow files outside the project"
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_host_pattern(effect: &str, index: usize, raw: &str) -> Result<(), String> {
+    if raw == "*" || raw == "**" {
+        return Err(format!(
+            "aver.toml: [effects.{effect}].hosts[{index}] contains an unsupported wildcard '{raw}'; use an exact host or a subdomain wildcard such as \"*.example.com\""
+        ));
+    }
+    Ok(())
+}
+
+fn validate_env_key_pattern(effect: &str, index: usize, raw: &str) -> Result<(), String> {
+    if raw == "**" {
+        return Err(format!(
+            "aver.toml: [effects.{effect}].keys[{index}] contains an unsupported wildcard '**'; use \"*\" for every key or a prefix wildcard such as \"APP_*\""
+        ));
+    }
+    Ok(())
 }
 
 /// Check if an env key matches an allowed pattern.
@@ -758,33 +832,103 @@ hosts = ["*.internal.corp"]
     }
 
     #[test]
-    fn test_check_disk_path_allowed() {
-        let toml = r#"
-[effects.Disk]
-paths = ["./data/**"]
-"#;
-        let config = ProjectConfig::parse(toml).unwrap();
+    fn disk_path_pattern_matrix() {
+        let cases = [
+            // pattern, loads, relative, absolute, escaping relative
+            ("", false, false, false, false),
+            (".", true, true, false, false),
+            ("./", true, true, false, false),
+            ("./**", true, true, false, false),
+            ("**", false, false, false, false),
+            ("/", true, false, true, false),
+            ("/**", true, false, true, false),
+            ("./data/**", true, true, false, false),
+            ("../**", false, false, false, false),
+        ];
+
+        for (pattern, loads, allows_relative, allows_absolute, allows_escape) in cases {
+            let probes = [
+                ("data/ok.txt", allows_relative),
+                ("/etc/passwd", allows_absolute),
+                ("../outside.txt", allows_escape),
+            ];
+            for (probe, expected) in probes {
+                assert_eq!(
+                    path_matches(&normalize_path(probe), pattern),
+                    expected,
+                    "matcher verdict for pattern {pattern:?} and path {probe:?}"
+                );
+            }
+
+            let parsed = ProjectConfig::parse(&format!("[effects.Disk]\npaths = [{pattern:?}]\n"));
+            assert_eq!(
+                parsed.is_ok(),
+                loads,
+                "config-load verdict for pattern {pattern:?}: {parsed:?}"
+            );
+            if let Ok(config) = parsed {
+                for (probe, expected) in probes {
+                    assert_eq!(
+                        config.check_disk_path("Disk.readText", probe).is_ok(),
+                        expected,
+                        "policy verdict for pattern {pattern:?} and path {probe:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn disk_path_degenerate_patterns_are_config_errors() {
+        let cases = [
+            ("", "is empty"),
+            ("**", "use \"./**\" for the project subtree or \"/**\""),
+            ("*", "unsupported glob"),
+            ("./*", "unsupported glob"),
+            ("*.txt", "unsupported glob"),
+            ("data/**/logs", "unsupported glob"),
+            ("..", "escapes the project directory"),
+            ("../**", "escapes the project directory"),
+            ("./data/../..", "escapes the project directory"),
+        ];
+
+        for (pattern, phrase) in cases {
+            let error = ProjectConfig::parse(&format!("[effects.Disk]\npaths = [{pattern:?}]\n"))
+                .expect_err("degenerate path pattern must be rejected");
+            assert!(
+                error.contains("[effects.Disk].paths[0]") && error.contains(phrase),
+                "unexpected error for pattern {pattern:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn disk_path_project_root_pattern_denies_absolute() {
+        let config = ProjectConfig::parse("[effects.Disk]\npaths = [\"./**\"]\n").unwrap();
         assert!(
             config
-                .check_disk_path("Disk.readText", "data/file.txt")
+                .check_disk_path("Disk.readText", "data/ok.txt")
                 .is_ok()
         );
         assert!(
             config
-                .check_disk_path("Disk.readText", "data/sub/deep.txt")
-                .is_ok()
+                .check_disk_path("Disk.readText", "/etc/passwd")
+                .is_err()
         );
     }
 
     #[test]
-    fn test_check_disk_path_denied() {
-        let toml = r#"
-[effects.Disk]
-paths = ["./data/**"]
-"#;
-        let config = ProjectConfig::parse(toml).unwrap();
-        let result = config.check_disk_path("Disk.readText", "/etc/passwd");
-        assert!(result.is_err());
+    fn disk_path_plain_and_recursive_forms_agree() {
+        let plain = ProjectConfig::parse("[effects.Disk]\npaths = [\"./data\"]\n").unwrap();
+        let recursive = ProjectConfig::parse("[effects.Disk]\npaths = [\"./data/**\"]\n").unwrap();
+
+        for probe in ["data", "data/sub/x", "datax/y", "/data/x"] {
+            assert_eq!(
+                plain.check_disk_path("Disk.readText", probe).is_ok(),
+                recursive.check_disk_path("Disk.readText", probe).is_ok(),
+                "plain and recursive forms differ for {probe:?}"
+            );
+        }
     }
 
     #[test]
@@ -934,6 +1078,30 @@ keys = ["PUBLIC_*"]
     }
 
     #[test]
+    fn host_degenerate_patterns_are_config_errors() {
+        for pattern in ["*", "**"] {
+            let error = ProjectConfig::parse(&format!("[effects.Http]\nhosts = [{pattern:?}]\n"))
+                .expect_err("degenerate host pattern must be rejected");
+            assert!(
+                error.contains("[effects.Http].hosts[0]") && error.contains("unsupported wildcard"),
+                "unexpected error for pattern {pattern:?}: {error}"
+            );
+        }
+
+        let config = ProjectConfig::parse("[effects.Http]\nhosts = [\"*.example.com\"]\n").unwrap();
+        assert!(
+            config
+                .check_http_host("Http.get", "https://sub.example.com/")
+                .is_ok()
+        );
+        assert!(
+            config
+                .check_http_host("Http.get", "https://example.com/")
+                .is_err()
+        );
+    }
+
+    #[test]
     fn env_key_matches_exact() {
         assert!(env_key_matches("TOKEN", "TOKEN"));
         assert!(!env_key_matches("TOKEN", "TOK"));
@@ -944,6 +1112,82 @@ keys = ["PUBLIC_*"]
         assert!(env_key_matches("APP_PORT", "APP_*"));
         assert!(env_key_matches("APP_", "APP_*"));
         assert!(!env_key_matches("PORT", "APP_*"));
+    }
+
+    #[test]
+    fn env_key_degenerate_pattern_is_config_error() {
+        let error = ProjectConfig::parse("[effects.Env]\nkeys = [\"**\"]\n")
+            .expect_err("degenerate key pattern must be rejected");
+        assert!(error.contains("[effects.Env].keys[0]"));
+        assert!(error.contains("unsupported wildcard"));
+
+        let config = ProjectConfig::parse("[effects.Env]\nkeys = [\"*\"]\n").unwrap();
+        assert!(config.check_env_key("Env.get", "HOME").is_ok());
+    }
+
+    fn extract_path_matcher(source: &str) -> &str {
+        let signature = "fn path_matches(normalized: &str, pattern: &str) -> bool {";
+        let start = source
+            .find(signature)
+            .unwrap_or_else(|| panic!("missing path matcher in source"));
+        let function = &source[start..];
+        let mut depth = 0usize;
+        for (offset, byte) in function.bytes().enumerate() {
+            match byte {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &function[..=offset];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("unterminated path matcher")
+    }
+
+    fn without_whitespace(source: &str) -> String {
+        source.split_whitespace().collect()
+    }
+
+    #[test]
+    fn path_matcher_copies_do_not_drift() {
+        let canonical = without_whitespace(extract_path_matcher(include_str!("config.rs")));
+        let copies = [
+            (
+                "embedded policy template",
+                include_str!("codegen/rust/policy.rs"),
+            ),
+            (
+                "runtime policy snippet",
+                include_str!("codegen/rust/replay.rs"),
+            ),
+            (
+                "self-host runtime",
+                include_str!("self_host/replay_support.rs"),
+            ),
+        ];
+
+        for (name, source) in copies {
+            assert_eq!(
+                without_whitespace(extract_path_matcher(source)),
+                canonical,
+                "{name} path matcher drifted from src/config.rs"
+            );
+        }
+
+        let raw_self_host =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("self_hosted/out/src/replay_support.rs");
+        match std::fs::read_to_string(&raw_self_host) {
+            Ok(source) => assert_eq!(
+                without_whitespace(extract_path_matcher(&source)),
+                canonical,
+                "raw self-host output path matcher drifted from src/config.rs"
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => panic!("could not read {}: {error}", raw_self_host.display()),
+        }
     }
 
     // --- check.suppress tests ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -755,8 +755,14 @@ mod tests {
     #[test]
     fn path_matcher_copies_agree_on_root_pattern_semantics() {
         const MARKERS: [(&str, &str); 3] = [
-            (r#"pattern == "**""#, "bare `**` is refused, never allow-all"),
-            (r#"Some("") => "/""#, "a bare trailing `/**` means the filesystem root"),
+            (
+                r#"pattern == "**""#,
+                "bare `**` is refused, never allow-all",
+            ),
+            (
+                r#"Some("") => "/""#,
+                "a bare trailing `/**` means the filesystem root",
+            ),
             (r#"base == "/""#, "the root base admits absolute paths only"),
         ];
         let copies: [(&str, &str); 4] = [

--- a/src/self_host/replay_support.rs
+++ b/src/self_host/replay_support.rs
@@ -899,17 +899,36 @@ pub mod aver_replay {
     }
 
     fn path_matches(normalized: &str, pattern: &str) -> bool {
-        let clean_pattern = normalize_path(pattern.strip_suffix("/**").unwrap_or(pattern));
-        if normalized == clean_pattern {
-            return true;
+        if pattern.is_empty() || pattern == "**" {
+            return false;
         }
-        if normalized.starts_with(&clean_pattern) {
-            let rest = &normalized[clean_pattern.len()..];
-            if rest.starts_with('/') {
-                return true;
-            }
+
+        let body = match pattern.strip_suffix("/**") {
+            Some("") => "/",
+            Some(base) => base,
+            None => pattern,
+        };
+        if body.contains('*') {
+            return false;
         }
-        false
+
+        let base = normalize_path(body);
+        if base.is_empty() {
+            return !normalized.starts_with('/')
+                && normalized != ".."
+                && !normalized.starts_with("../");
+        }
+        if base == "/" {
+            return normalized.starts_with('/');
+        }
+        if base == ".." || base.starts_with("../") {
+            return false;
+        }
+
+        normalized == base
+            || (normalized.len() > base.len()
+                && normalized.starts_with(&base)
+                && normalized.as_bytes()[base.len()] == b'/')
     }
 
     fn env_key_matches(key: &str, pattern: &str) -> bool {

--- a/tests/vm_spec.rs
+++ b/tests/vm_spec.rs
@@ -1730,6 +1730,55 @@ fn vm_respects_aver_toml_runtime_policy() {
 }
 
 #[test]
+fn vm_project_root_policy_denies_absolute_path() {
+    let module_root = temp_module_root("project_root_policy");
+    std::fs::write(
+        module_root.join("aver.toml"),
+        "[effects.Disk]\npaths = [\"./**\"]\n",
+    )
+    .expect("write aver.toml");
+    let config = ProjectConfig::load_from_dir(&module_root)
+        .expect("load aver.toml")
+        .expect("aver.toml should exist");
+
+    let run = |src: &str| {
+        let mut items = parse(src);
+        tco::transform_program(&mut items);
+        resolver::resolve_program(&mut items);
+
+        let mut arena = Arena::new();
+        let (resolved, symbols) = resolve_for_vm(&items);
+        let (code, globals) = vm::compile_program_with_modules(
+            &resolved,
+            &symbols,
+            &mut arena,
+            Some(
+                module_root
+                    .to_str()
+                    .expect("module root must be valid UTF-8"),
+            ),
+            "",
+            None,
+        )
+        .expect("compile failed");
+        let mut machine = vm::VM::new(code, globals, arena);
+        machine.set_runtime_policy(config.clone());
+        machine.run()
+    };
+
+    let absolute = "fn main() -> Bool\n    ! [Disk.exists]\n    Disk.exists(\"/etc/passwd\")\n";
+    let error = run(absolute).expect_err("project-root policy must deny absolute paths");
+    assert!(
+        error.to_string().contains("denied by aver.toml policy"),
+        "error should mention aver.toml policy, got: {error}"
+    );
+
+    let relative = "fn main() -> Bool\n    ! [Disk.exists]\n    Disk.exists(\"data/ok.txt\")\n";
+    let result = run(relative).expect("project-root policy must allow relative paths");
+    assert!(result.is_bool());
+}
+
+#[test]
 fn vm_cancel_mode_stops_independent_product_sibling_early() {
     let marker_path = std::env::temp_dir().join(format!(
         "aver_vm_independence_{}_{}.txt",

--- a/tools/website/llms-full.txt
+++ b/tools/website/llms-full.txt
@@ -362,3 +362,14 @@ reason = "Tree-walking interpreter — CPS would destroy correspondence."
 ```
 
 Effect-host / path / key allowlists narrow which hosts, files, and env keys the runtime will admit. `[[check.suppress]]` lets a project waive specific lint slugs in specific paths with a reason.
+
+Disk path patterns have deliberately small, explicit semantics:
+
+| Pattern | Meaning |
+|---|---|
+| `path` or `path/**` | That path and its entire subtree |
+| `.`, `./`, or `./**` | The project-relative subtree |
+| `/` or `/**` | Every absolute path from the filesystem root |
+| `**` | Invalid; use `./**` or `/**` to state the intended boundary |
+
+An empty pattern, unsupported `*` placement, or a `..`-rooted pattern is also a config-load error. An absent `paths` key or `paths = []` keeps the existing allow-all behavior. Matching is string-only: Aver normalizes `.` and `..` in the caller-supplied path without resolving it against the working directory or touching the filesystem. A project-relative pattern therefore does not admit an absolute spelling of the same in-project file.


### PR DESCRIPTION
Closes #821.

`[effects.Disk] paths = ["./**"]` did the opposite of what it says: it denied relative in-project paths and admitted every absolute path on the machine. `paths = ["**"]`, the natural spelling for "allow everything", silently denied everything.

`path_matches` stripped a trailing `/**` and normalised the remainder, so `"./**"` became the empty string. `starts_with("")` is always true, and any absolute path's remainder begins with `/`, so the function returned true — while relative paths took the same branch, failed the `/` test, and were denied.

## Semantics now

Patterns are validated when `aver.toml` is loaded rather than reinterpreted at match time.

| pattern | absolute path outside the project | relative path in the project |
|---|---|---|
| `./**`, `.`, `./` | denied | allowed |
| `/`, `/**` | allowed | denied |
| `./data/**` | denied | allowed under `data/` |
| `**` | rejected at load: ambiguous, name `./**` or `/**` |
| `""` | rejected at load: empty, name `.` or `/` |
| `../**` | rejected at load: escapes the project |
| any other `*` | rejected at load: only a trailing `/**` is supported |

Bare `**` is an error rather than allow-all. The sibling matcher for lint globs treats it as "everything", but the failure modes are not comparable: a wrong lint glob costs noise, a wrong path glob costs filesystem access. Ambiguity at a capability boundary is resolved by the author, not by a default, so the message names both unambiguous spellings.

The same load-time strictness now covers the neighbouring silent-deny cases: `hosts = ["*"]`, `hosts = ["**"]` and `keys = ["**"]` matched nothing and are now rejected with a message naming the working form. Neither change can widen a policy.

## The four copies

The matcher is duplicated into every artifact that enforces a policy without linking this crate — both generated-Rust templates and the self-hosted replay support. A fix landing only in `src/config.rs` would ship a compiler that still emits the inversion into user projects. All four are updated, and a test asserts each copy carries the three decisions that define the semantics. It was checked to fail, naming the offending file, when one copy is edited alone.

## Verification

End to end through the VM, with `paths = ["./**"]`: reading `/etc/passwd` is denied and reading `data/ok.txt` succeeds. Before this change those two outcomes were reversed.

`aver run` was also exercised against every pattern form in the table above, including the three that now fail at load time.

## Compatibility

No working allowlist narrows. The spellings that become permissive (`.`, `./`, `./**` admitting relative paths) admitted nothing usable before; the spellings that become restrictive (`./**`, `/**`, `""` admitting arbitrary absolute paths) are the defect. A project using `paths = ["*"]` or `paths = [""]` now fails at startup instead of silently denying — no aver.toml in this repository declares `paths`.
