### PR TITLE
Document literal patterns in `match`

### DIFF
--- a/.claude/commands/aver.md
+++ b/.claude/commands/aver.md
@@ -91,6 +91,8 @@ Rules:
 - list patterns: `[]` and `[head, ..tail]` (the `..` rest must be named)
 - tuple patterns: `(a, b)`
 - constructor patterns always qualified: `Result.Ok`, `Option.None`, `Shape.Circle`
+- literal patterns: `253 -> …` (`Int`), `"verack" -> …` (`String`), `1.5 -> …` (`Float`), `true` / `false` (`Bool`). An `Int` / `String` / `Float` match still needs a trailing `_ ->` or identifier arm; `-1 ->` is a parse error (no negative literal patterns) and so is an integer beyond 64 bits
+- prefer one literal-pattern `match` over a chain of `match x == "lit"` with `true ->` / `false ->` helper functions — same behaviour, far less code
 - boolean branching: `match x > 0` with `true ->` / `false ->`
 - nested match in match arms is supported
 
@@ -333,6 +335,7 @@ match Map.get(ages, "alice")
 19. `()` as a Unit value literal — there is no `()` literal. Write `Unit`. Diagnostics render the value as `()`, but in source the only spelling is `Unit` (matches `Map<T, Unit>` set semantics, `Unit` field annotations, etc.). `Console.print(...)` returning Unit is implicit — you almost never write the literal directly
 20. `expr?` on an `Option<T>` — `?` is Result-only. For `Option`, use `Option.withDefault(opt, fallback)`, or `match opt { Option.Some(v) -> … ; Option.None -> … }`. `Vector.get` and `Map.get` return `Option`, so neither composes with `?` directly — wrap the value first
 21. `(A, B)` as a tuple type — type position uses `Tuple<A, B>` exclusively. Tuple **value** literals stay paren: `(1, 2)`, `[(1, 2), (3, 4)]`, `Result.Ok((a, b))`. Tuple **patterns** stay paren: `match p { (a, b) -> … }`. The type and the value spelling are deliberately different so grep-for-type and grep-for-value don't collide
+22. Dispatching on a `String` or an `Int` through a chain of `match x == "lit"` with `true ->` / `false ->` helper functions — literal patterns exist: `match cmd { "verack" -> 1 ; "tx" -> 4 ; _ -> 0 }`. Only the trailing `_` arm is mandatory
 
 ### Style
 

--- a/.claude/commands/aver.md
+++ b/.claude/commands/aver.md
@@ -251,7 +251,12 @@ fn sum(xs: List<Int>) -> Int
 Use namespaced builtins only.
 
 Common pure namespaces:
-- `Int`, `Float`, `String`, `List`, `Vector`, `Map`, `Bool`, `Char`, `Byte`, `Result`, `Option`
+- `Int`, `Float`, `String`, `List`, `Vector`, `Map`, `Bool`, `Char`, `Crypto`, `Result`, `Option`
+
+`Bytes` and `Crypto.Digest32` are embedded Aver modules. With
+`depends [Bytes, Crypto.Digest32]`, `Crypto.sha256 : Bytes -> Digest32` is total
+and pure: the input already guarantees octets and the result guarantees exactly
+32 bytes.
 
 Key `String` API:
 - `String.len`, `String.contains`, `String.startsWith`, `String.endsWith`
@@ -278,7 +283,7 @@ Effectful namespaces:
 - `Console`: print, error, warn, readLine — **`print`/`error`/`warn` take `String`**, not arbitrary values. Stringify at the call site: interpolation `"{x}"` for primitives, a per-type render fn (`fn show(r: Result<T, E>) -> String`) for compound shapes.
 - `Http`: get, post, put, patch, delete, head
 - `Disk`: readText, writeText, appendText, exists, delete, deleteDir, listDir, makeDir
-- `Tcp`: connect, writeLine, readLine, close, send, ping
+- `Tcp`: connect, writeLine, writeBytes, readLine, readBytes, close, send, sendBytes, ping — `send`/`readLine` are text-only (UTF-8); binary payloads use nominal `Bytes` through `sendBytes`, `writeBytes`, and `readBytes`
 - `Terminal`: enableRawMode, readKey, setCursor, print, clear, size — `Terminal.print` and `Terminal.setColor` also take `String`.
 - `Time`: now, unixMs, sleep
 - `Env`: get, set

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ No `if`/`else`. No loops. No exceptions. No nulls. No implicit side effects.
 
 Aver is intentionally opinionated. These omissions are part of the design, not missing features:
 
-- no `if`/`else` — branching goes through `match`
+- no `if`/`else` — branching goes through `match`, which dispatches directly on literals (`"verack" ->`, `253 ->`), constructors, lists and tuples, not only on booleans
 - no `for`/`while` — iteration is recursion or explicit list operations
 - no exceptions — failure is `Result`
 - no `null` — absence is `Option`

--- a/docs/language.md
+++ b/docs/language.md
@@ -87,7 +87,8 @@ Option.None
 
 ```aver
 match value
-    42 -> "exact"                          // literal
+    42 -> "exact"                          // Int literal
+    "verack" -> "known command"            // String literal
     _ -> "anything"                        // wildcard
     x -> "bound to {x}"                    // identifier binding
     [] -> "empty list"                     // empty list
@@ -103,6 +104,39 @@ match value
 Constructor patterns are always qualified (`Result.Ok`, `Option.None`, `Shape.Circle`). Records do not support positional destructuring in patterns; bind the whole record and use field access (`user.name`, `user.age`).
 
 Nested match in match arms is supported. Arm body must follow `->` on the same line — extract complex expressions into a named function.
+
+### Literal patterns
+
+An arm may be a literal instead of a binding; it fires when the subject equals it. This is how you dispatch on a command name or a tag byte — there is no `else if` to reach for, and no reason to spread the decision over a chain of single-purpose helper functions:
+
+```aver
+fn handle(command: String) -> Int
+    ? "Dispatch on the wire command name."
+    match command
+        "verack" -> 1
+        "version" -> 2
+        "inv" -> 3
+        "tx" -> 4
+        _ -> 0
+
+fn varIntWidth(head: Int) -> Int
+    ? "253 introduces two more bytes, 254 four, 255 eight."
+    match head
+        253 -> 2
+        254 -> 4
+        255 -> 8
+        _ -> 1
+```
+
+`Int`, `String`, `Float` and `Bool` literals are all valid patterns. `Bool` is the only one a match can exhaust by listing (`true` and `false`), so it is the only one that needs no catch-all; an `Int`, `String` or `Float` match must end in a wildcard `_` or an identifier arm, or the checker rejects it with `Non-exhaustive match: missing catch-all (_) pattern`. Repeating a literal is rejected too — the later arm can never fire, and the error names the line that already covers it.
+
+Three things that look like literal patterns are parse errors:
+
+- a negative number — `-1 -> …` does not parse, because the `-` is a separate token and a pattern is not an expression. Branch on a comparison instead (`match n < 0` with `true ->` / `false ->`), or normalize the subject before the match.
+- an integer beyond 64 bits, even though `Int` itself is arbitrary-precision. The error points at the replacement: `match n == 1267650600228229401496703205376`.
+- an interpolated string — `"{x}" -> …` is rejected, because a pattern is a constant. Compare with `==` when the expected value is computed.
+
+`Float` literal patterns compare exactly, so `0.1 + 0.2` does not match a `0.3` arm. Use them only for sentinels you produced yourself; otherwise branch on a comparison.
 
 ## Record update
 

--- a/tests/eval_spec.rs
+++ b/tests/eval_spec.rs
@@ -1059,6 +1059,23 @@ fn match_literal_wildcard() {
 }
 
 #[test]
+fn match_string_literal_dispatch() {
+    let src = "fn handle(cmd: String) -> Int\n    match cmd\n        \"verack\" -> 1\n        \"tx\" -> 4\n        _ -> 0\n";
+    assert_eq!(
+        call_fn(src, "handle", vec![Value::Str("verack".to_string())]),
+        Value::int(1)
+    );
+    assert_eq!(
+        call_fn(src, "handle", vec![Value::Str("tx".to_string())]),
+        Value::int(4)
+    );
+    assert_eq!(
+        call_fn(src, "handle", vec![Value::Str("nope".to_string())]),
+        Value::int(0)
+    );
+}
+
+#[test]
 fn match_ok_constructor() {
     let src = "fn unwrap(r: Result<Int, String>) -> Int\n    match r\n        Result.Ok(v) -> v\n        Result.Err(_) -> 0\n";
     assert_eq!(

--- a/tests/parser_spec.rs
+++ b/tests/parser_spec.rs
@@ -654,6 +654,35 @@ fn match_with_wildcard() {
 }
 
 #[test]
+fn match_string_literal_pattern() {
+    let src = "fn f(cmd: String) -> Int\n    match cmd\n        \"verack\" -> 1\n        _ -> 0\n";
+    let items = parse(src);
+    if let TopLevel::FnDef(fd) = &items[0] {
+        if let Expr::Match { arms, .. } = single_expr_body(fd) {
+            assert_eq!(arms.len(), 2);
+            assert!(matches!(&arms[0].pattern, Pattern::Literal(Literal::Str(s)) if s == "verack"));
+            assert!(matches!(arms[1].pattern, Pattern::Wildcard));
+        } else {
+            panic!("expected match body");
+        }
+    } else {
+        panic!("expected FnDef");
+    }
+}
+
+#[test]
+fn negative_int_literal_pattern_is_rejected() {
+    let src =
+        "fn f(n: Int) -> String\n    match n\n        -1 -> \"neg\"\n        _ -> \"other\"\n";
+    let err = parse_error(src);
+    assert!(
+        err.contains("Expected match pattern"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
 fn match_subject_colon_is_not_type_ascription() {
     let items = parse("match xs\n    [] -> 0\n    _ -> 1\n");
     assert!(matches!(

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2383,6 +2383,17 @@ fn error_non_exhaustive_int_without_catch_all() {
 }
 
 #[test]
+fn error_non_exhaustive_string_without_catch_all() {
+    let src = concat!(
+        "fn f(s: String) -> Int\n",
+        "  match s\n",
+        "    \"a\" -> 1\n",
+        "    \"b\" -> 2\n",
+    );
+    assert_error_containing(src, "catch-all");
+}
+
+#[test]
 fn exhaustive_int_with_wildcard() {
     let src = concat!(
         "fn f(n: Int) -> Int\n",

--- a/tools/website/llms.txt
+++ b/tools/website/llms.txt
@@ -148,6 +148,8 @@ Rules:
 - list patterns: `[]` and `[head, ..tail]` (the `..` rest must be named)
 - tuple patterns: `(a, b)`
 - constructor patterns always qualified: `Result.Ok`, `Option.None`, `Shape.Circle`
+- literal patterns: `253 -> …` (`Int`), `"verack" -> …` (`String`), `1.5 -> …` (`Float`), `true` / `false` (`Bool`). An `Int` / `String` / `Float` match still needs a trailing `_ ->` or identifier arm; `-1 ->` is a parse error (no negative literal patterns) and so is an integer beyond 64 bits
+- prefer one literal-pattern `match` over a chain of `match x == "lit"` with `true ->` / `false ->` helper functions — same behaviour, far less code
 - boolean branching: `match x > 0` with `true ->` / `false ->`
 - nested match in match arms is supported
 
@@ -395,6 +397,7 @@ match Map.get(ages, "alice")
 19. `()` as a Unit value literal — there is no `()` literal. Write `Unit`. Diagnostics render the value as `()`, but in source the only spelling is `Unit` (matches `Map<T, Unit>` set semantics, `Unit` field annotations, etc.). `Console.print(...)` returning Unit is implicit — you almost never write the literal directly
 20. `expr?` on an `Option<T>` — `?` is Result-only. For `Option`, use `Option.withDefault(opt, fallback)`, or `match opt { Option.Some(v) -> … ; Option.None -> … }`. `Vector.get` and `Map.get` return `Option`, so neither composes with `?` directly — wrap the value first
 21. `(A, B)` as a tuple type — type position uses `Tuple<A, B>` exclusively. Tuple **value** literals stay paren: `(1, 2)`, `[(1, 2), (3, 4)]`, `Result.Ok((a, b))`. Tuple **patterns** stay paren: `match p { (a, b) -> … }`. The type and the value spelling are deliberately different so grep-for-type and grep-for-value don't collide
+22. Dispatching on a `String` or an `Int` through a chain of `match x == "lit"` with `true ->` / `false ->` helper functions — literal patterns exist: `match cmd { "verack" -> 1 ; "tx" -> 4 ; _ -> 0 }`. Only the trailing `_` arm is mandatory
 
 ### Style
 


### PR DESCRIPTION
Closes #824. Closes #831.

`match` has accepted literal patterns on `Int`, `String`, `Float` and `Bool` for a long time, but `docs/language.md` never said so — the pattern list showed constructor, wildcard, binding and list forms only. A reader who has been through the reference does not know the feature exists, and invents the alternative: `match x == "lit"` with `true ->` / `false ->`, one helper function per additional case.

The first substantial third-party Aver project contains zero literal patterns in about 2000 lines, 48 boolean-comparison arms, and a chain of three functions whose only job is to dispatch on four command names.

## What is documented

A `### Literal patterns` section in `docs/language.md` with a `String` dispatch and an `Int` width table, both taken from shapes that actually occur, plus the exhaustiveness rule: `Bool` is the only literal type a match can exhaust by listing, so every other literal match needs a trailing `_` or identifier arm.

Also documented: the three things that look like literal patterns and are not. A negative number does not parse, because `-` is a separate token and a pattern is not an expression. An integer beyond 64 bits does not parse, even though `Int` itself is arbitrary-precision. An interpolated string does not parse, because a pattern is a constant. Each was confirmed against the binary rather than assumed, and the section names the replacement for each.

The same addition reaches the language skill and README.

## Tests

`tests/parser_spec.rs`, `tests/typechecker_spec.rs` and `tests/eval_spec.rs` gain coverage for the accepted forms, the exhaustiveness requirement, the duplicate-arm rejection, and the three parse errors — so the documentation cannot quietly become false.

No new example file. Both forms already appear across `examples/`, and `examples/data/json.av` exercises the `String` form in the run-parity corpus.

## Second commit: the generator

`tools/website/llms.txt` is generated from the language skill, but two sections had been written into the artifact and never into the source — the byte-level TCP surface and `Crypto.sha256`, both 0.28.0 content. Running `build_llms.sh` would have reverted the public language reference to its pre-0.28.0 wording, so in practice the script could not be run at all, and every documentation change faced the same choice: hand-edit the artifact and widen the gap, or regenerate and lose content.

Both sections are now in the source. The regenerated artifact is byte-identical to the committed one, so the script is safe to run again.

Worth a follow-up: a CI step that runs the build script and asserts the working tree is unchanged would turn this class from "discovered later" into "caught in the pull request that caused it".
